### PR TITLE
ROX-32677-vuln-in-console: adding new content for vulnerability info …

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -198,6 +198,8 @@ Topics:
   File: managing-preview-features
 - Name: Configuring and integrating the RHACS plugin with Red Hat Developer Hub
   File: configuring-and-integrating-the-rhacs-plugin-with-red-hat-developer-hub
+- Name: Accessing vulnerability information in the OpenShift Container Platform web console
+  File: accessing-vulnerability-information-in-web-console
 ---
 Name: Operating
 Dir: operating

--- a/configuration/accessing-vulnerability-information-in-web-console.adoc
+++ b/configuration/accessing-vulnerability-information-in-web-console.adoc
@@ -1,0 +1,24 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="accessing-vulnerability-information-in-web-console"]
+= Accessing vulnerability information in the OpenShift Container Platform web console
+include::modules/common-attributes.adoc[]
+:context: accessing-vulnerability-information-in-web-console
+
+toc::[]
+
+// GUI LABELING ISSUES
+// SEE MEETING RHACS SPRINT DEMO RECORDING 01/29/2026 ~28 MINUTES
+// IN THE INTERFACE, THIS APPEARS AS "console plugin" IN THE OPERATOR INSTALLATION, BUT FROM THE INSTALLED OPERATORS PAGE FOR RHACS OPERATOR IT APPEARS IN THE SIDEBAR INFO AS A NAMED "advanced-cluster-security" PLUGIN UNDER A GENERIC "Console plugin" HEADER. UNSURE WHY THIS APPEARS WITH DIFFERENT NAMES IN DIFFERENT LOCATIONS IN THE GUI.
+// ALSO UNCLEAR IF THIS FUNCTION/CODE IS THE SAME AS THE "RHACS PLUGIN" THAT YOU INSTALL WITH RHDH OR DIFFERENT FUNCTION/CODE.
+
+Beginning with the 4.10 release, {rh-rhacs-first} includes a dynamic plugin as a part of the {product-title-short} Operator. This plugin provides access to vulnerability management information for your secured cluster workloads directly from the {ocp} web console. 
+
+With this {rh-rhacs-console-plugin} dynamic plugin, data gathered by {product-title-short} is displayed in the {ocp} interface, providing information about CVEs, image and workload vulnerabilities, and verified image signature status. Authorized security administrators, platform engineers, and application developers gain a unified view of security status that is embedded in their day-to-day {ocp} workflows. 
+
+:FeatureName: RHACS Vulnerability Management in OpenShift Container Platform plugin
+include::snippets/technology-preview.adoc[]
+
+include::modules/enabling-the-plugin.adoc[leveloffset=+1]
+
+include::modules/viewing-vulnerability-information-in-web-console.adoc[leveloffset=+1]
+

--- a/modules/common-attributes.adoc
+++ b/modules/common-attributes.adoc
@@ -38,6 +38,7 @@ endif::[]
 :rh-rhtas-first: Red{nbsp}Hat Trusted Artifact Signer (RHTAS)
 :rh-rhacs-first: Red{nbsp}Hat Advanced Cluster Security for Kubernetes (RHACS)
 :rh-rhacscs-first: Red{nbsp}Hat Advanced Cluster Security Cloud Service (RHACS Cloud Service)
+:rh-rhacs-console-plugin: console
 :rh-rhacm: RHACM
 :rh-rhdh-first: Red{nbsp}Hat Developer Hub (RHDH)
 :rh-rhdh: RHDH

--- a/modules/enabling-the-plugin.adoc
+++ b/modules/enabling-the-plugin.adoc
@@ -1,0 +1,34 @@
+// Module included in the following assemblies:
+//
+// * accessing-vulnerability-information-in-web-console.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="enabling-the-plugin_{context}"]
+= Enabling the plugin
+
+To view vulnerability information for a secured cluster, make sure that the {rh-rhacs-console-plugin} dynamic plugin is enabled. 
+
+For a fresh installation of {rh-rhacs-first} 4.10, the {rh-rhacs-console-plugin} dynamic plugin is enabled by default when you install the {product-title-short} Operator on a cluster. You can choose to disable the plugin if you do not want to use it. For an upgrade to {product-title-short} 4.10, the dynamic plugin is disabled by default, and you must enable the plugin during or after the installation of the {product-title-short} Operator.
+
+To review enablement status during Operator installation, or to enable the {rh-rhacs-console-plugin} plugin after Operator installation, use the following steps.
+
+.Prerequisites
+* You are running {ocp} version 4.19 or later.
+* You are running the {product-title-short} version 4.10 code base for both secured cluster services and Central services.
+* You have access to an {ocp} cluster using an account with Operator installation permissions.
+* As part of the installation process for the {product-title-short} Operator, you will install secured cluster services on the cluster. 
+
+.Procedure 
+
+* During the installation of the {product-title-short} Operator on the cluster, on the Install Operator page, ensure that the *Console plugin* option is set to *Enable*.
++
+[NOTE]
+====
+You can also review and change the enablement status of the {rh-rhacs-console-plugin} dynamic plugin after the installation of the {product-title-short} Operator by viewing the installed operator details and checking whether the *Console plugin* section shows the {rh-rhacs-console-plugin} plugin with an *Enabled* or *Disabled* status.
+====
+
+.Verification
+
+* In the web console, verify that a new *Security* option, with a *Vulnerabilities* secondary option, displays in the navigation menu. If you are an authorized user with access to all of the deployment-like resources within the selected project or namespace for a secured cluster, use these options to view vulnerability information. 
+
+* In addition, verify that a new *Security* tab displays on certain pages in the web console, such as the details views for individual projects, namespaces, deployments, and daemonsets.

--- a/modules/viewing-vulnerability-information-in-web-console.adoc
+++ b/modules/viewing-vulnerability-information-in-web-console.adoc
@@ -1,0 +1,27 @@
+// Module included in the following assemblies:
+//
+// * accessing-vulnerability-information-in-web-console.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="viewing-vulnerability-information-in-web-console_{context}"]
+= Viewing vulnerability information in the web console
+
+Use the *Security* navigation option in the {ocp} web console to view vulnerability information that is scoped to the namespace of a secured cluster.  
+
+.Prerequisites
+* The {rh-rhacs-console-plugin} plugin is enabled on the secured cluster.
+
+.Procedure 
+
+. In the web console, ensure that the relevant project for the secured cluster is selected. 
+
+. In the {ocp} web console navigation, click *Security > Vulnerabilities*.
+
+. From the Workload vulnerabilities page, click the *CVEs*, *Images*, or *Deployments* option to determine the context in which you want to view vulnerabilities.
+
+. In the displayed results, click a specific result to view detailed information about the vulnerability.
++
+[NOTE]
+====
+You can also view vulnerability information on other pages in the {ocp} web console by clicking the *Security* tab. For example, you can view vulnerability information in the details views for individual projects, namespaces, deployments, and daemonsets.
+====


### PR DESCRIPTION
Visibility of vulnerability information in web console


Version(s):
4.10

Issue:
https://issues.redhat.com/browse/ROX-32677

Link to docs preview:
https://106918--ocpdocs-pr.netlify.app/openshift-acs/latest/configuration/accessing-vulnerability-information-in-web-console

QE review:
ACS has no formal QE team to review

Additional information:
@kcarmichael08 reviewed initial commit with comments, but there were some substantial changes to content after ENG clarification of the enablement status of the plugin for fresh vs. upgrade installs.