### PR TITLE
OLS-2626: Vale checks for modules in tshooting assembly

### DIFF
--- a/modules/ols-502-bad-gateway-errors.adoc
+++ b/modules/ols-502-bad-gateway-errors.adoc
@@ -1,11 +1,12 @@
-// This module is used in the following assemblies:
-// troubleshoot/ols-troubleshooting-openshift-lightspeed.adoc
+// Module included in the following assemblies:
+// lightspeed-docs-main/troubleshoot/ols-troubleshooting-openshift-lightspeed.adoc
 
 :_mod-docs-content-type: REFERENCE
 [id="ols-502-bad-gateway-errors_{context}"]
-= 502 Bad Gateway Errors in the interface
+= 502 Bad Gateway errors in the interface
 
 [role="_abstract"]
-Avoid 502 Bad Gateway errors by waiting for all internal {ols-long} and {ocp-product-title} system components to stabilize after deployment.
 
-Wait a few minutes and try using {ols-long} again.
+Avoid 502 Bad Gateway errors by waiting for the service pods to finish starting. 
+
+Give {ols-long} and {ocp-product-title} a few minutes to get ready after you deploy them. Then, try using {ols-long} again.

--- a/modules/ols-operator-missing-from-operatorhub-list.adoc
+++ b/modules/ols-operator-missing-from-operatorhub-list.adoc
@@ -1,11 +1,10 @@
-// This module is used in the following assemblies:
-// troubleshoot/ols-troubleshooting-openshift-lightspeed.adoc
+// Module included in the following assemblies:
+// lightspeed-docs-main/troubleshoot/ols-troubleshooting-openshift-lightspeed.adoc
 
 :_mod-docs-content-type: REFERENCE
 [id="ols-operator-missing-from-operatorhub-list_{context}"]
-= Operator Missing from the Operator Hub list
+= Operator missing from the OperatorHub list
 
 [role="_abstract"] 
-The {ols-long} Operator is visible in the Operator Hub only for supported architectures, as filtering prevents it from appearing on non-x86 platforms.
 
-{ols-long} is only supported on x86 architecture.
+The OperatorHub displays the {ols-long} Operator only for supported architectures. Filtering prevents the Operator from appearing on anything other than the `x86_64` architecture. 

--- a/modules/ols-thinking-model-generates-delineator-prompt.adoc
+++ b/modules/ols-thinking-model-generates-delineator-prompt.adoc
@@ -1,14 +1,15 @@
-// This module is used in the following assemblies:
-// troubleshoot/ols-troubleshooting-openshift-lightspeed.adoc
+// Module included in the following assemblies:
+// lightspeed-docs-main/troubleshoot/ols-troubleshooting-openshift-lightspeed.adoc
 
 :_mod-docs-content-type: REFERENCE
 [id="ols-thinking-model-generates-delineator-prompt_{context}"]
 = Thinking model generates delineator prompt
 
 [role="_abstract"]
-Reasoning models use delineators, such as `THOUGHT` or `reasoning`, to distinguish internal thought processes from the final response provided by the {ols-long} Service.
 
-The {ols-long} Service does not configure the delineator behavior or produce the delineators in the output. The delineator feature is a model configuration setting. Typically, you can disable the feature using one of the following methods:
+Reasoning models use tags such as `THOUGHT` or `reasoning` to separate their inner logic from the final answer.
 
-* Append your question prompt with the specific keyword that the model requires to disable the delineator feature, for example, `/nothink`. For more information, see the documentation for the model you are using.
-* Modify the inference server configuration settings to disable the delineator feature. For more information, see the documentation for the inference server or for the model you are using.
+{ols-long} does not control these tags or add them to the output. This feature is part of the model itself. Usually, you can turn off these tags in one of two ways:
+
+* Add a keyword to your prompt if the model supports it. For example, `/nothink`. Check the documentation for your model to obtain the right word to use.
+* Change the inference server configuration settings to disable the delineator feature. For more information, see the documentation for the inference server or for the model you are using.

--- a/troubleshoot/ols-troubleshooting-openshift-lightspeed.adoc
+++ b/troubleshoot/ols-troubleshooting-openshift-lightspeed.adoc
@@ -8,7 +8,8 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 [role="_abstract"]
-Review solutions and workarounds for common installation, configuration, and operational issues encountered with the {ols-long}.
+
+Review solutions and workarounds for common installation, configuration, and operational issues encountered with {ols-long}.
 
 include::modules/ols-502-bad-gateway-errors.adoc[leveloffset=+1]
 


### PR DESCRIPTION
Affects:
[lightspeed-main](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-main)
[lightspeed-docs-1.0](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-1.0)

PR must be CP'd back to the lightspeed-docs-1.0 branch.

Issue:
https://issues.redhat.com/browse/OLS-2626

Link to docs preview:
https://106936--ocpdocs-pr.netlify.app/openshift-lightspeed/latest/troubleshoot/ols-troubleshooting-openshift-lightspeed.html

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
