### PR TITLE
OCPBUGS-60529 Getting error while configuring the NAD

### DIFF
--- a/modules/nw-multus-bond-cni-object.adoc
+++ b/modules/nw-multus-bond-cni-object.adoc
@@ -22,7 +22,7 @@ The following table describes the configuration parameters for the Bond CNI plug
 
 |`cniVersion`
 |`string`
-|The CNI specification version.
+|The CNI specification version. A minimum version of `0.3.1` is required.
 
 |`type`
 |`string`

--- a/modules/nw-multus-bridge-object.adoc
+++ b/modules/nw-multus-bridge-object.adoc
@@ -7,7 +7,7 @@
 [id="nw-multus-bridge-object_{context}"]
 = Configuration for a bridge secondary network
 
-[role="_abstract"] 
+[role="_abstract"]
 The bridge CNI plugin JSON configuration object describes the configuration parameters for the Bridge CNI plugin. The following table details these parameters:
 
 [cols=".^2,.^2,.^6",options="header"]
@@ -17,7 +17,7 @@ The bridge CNI plugin JSON configuration object describes the configuration para
 ifndef::microshift[]
 |`cniVersion`
 |`string`
-|The CNI specification version. The `0.3.1` value is required.
+|The CNI specification version. A minimum version of `0.3.1` is required.
 
 |`name`
 |`string`

--- a/modules/nw-multus-dummy-device-object.adoc
+++ b/modules/nw-multus-dummy-device-object.adoc
@@ -6,7 +6,7 @@
 [id="nw-multus-dummy-device-object_{context}"]
 = Configuration for a dummy device additional network
 
-[role="_abstract"] 
+[role="_abstract"]
 The dummy CNI plugin functions like a loopback device. The plugin is a virtual interface, and you can use the plugin to route the packets to a designated IP address. Unlike a loopback device, the IP address is arbitrary and is not restricted to the `127.0.0.0/8` address range.
 
 The dummy device CNI plugin JSON configuration object describes the configuration parameters for the dummy CNI plugin. The following table details these parameters:
@@ -17,7 +17,7 @@ The dummy device CNI plugin JSON configuration object describes the configuratio
 
 |`cniVersion`
 |`string`
-|The CNI specification version. The required value is `0.3.1`.
+|The CNI specification version. A minimum version of `0.3.1` is required.
 
 |`name`
 |`string`

--- a/modules/nw-multus-host-device-object.adoc
+++ b/modules/nw-multus-host-device-object.adoc
@@ -6,7 +6,7 @@
 [id="nw-multus-host-device-object_{context}"]
 = Configuration for a host device secondary network
 
-[role="_abstract"] 
+[role="_abstract"]
 The host device CNI plugin JSON configuration object describes the configuration parameters for the host-device CNI plugin.
 
 [NOTE]
@@ -22,7 +22,7 @@ The following table details the configuration parameters:
 
 |`cniVersion`
 |`string`
-|The CNI specification version. The `0.3.1` value is required.
+|The CNI specification version. A minimum version of `0.3.1` is required.
 
 |`name`
 |`string`

--- a/modules/nw-multus-ipvlan-object.adoc
+++ b/modules/nw-multus-ipvlan-object.adoc
@@ -10,7 +10,7 @@
 [id="nw-multus-ipvlan-object_{context}"]
 = Configuration for an IPVLAN secondary network
 
-[role="_abstract"] 
+[role="_abstract"]
 The IPVLAN CNI plugin JSON configuration object describes the configuration parameters for the IPVLAN, `ipvlan`, CNI plugin. The following table details these parameters:
 
 [cols=".^2,.^2,.^6",options="header"]
@@ -19,8 +19,7 @@ The IPVLAN CNI plugin JSON configuration object describes the configuration para
 
 |`cniVersion`
 |`string`
-|The CNI specification version. The `0.3.1` value is required.
-
+|The CNI specification version. A minimum version of `0.3.1` is required.
 |`name`
 |`string`
 |The mandatory, unique identifier assigned to this CNI network attachment definition. It is used by the container runtime to select the correct network configuration and serves as the key for persistent resource state management, such as IP address allocations.

--- a/modules/nw-multus-macvlan-object.adoc
+++ b/modules/nw-multus-macvlan-object.adoc
@@ -7,7 +7,7 @@
 [id="nw-multus-macvlan-object_{context}"]
 = Configuration for a MACVLAN secondary network
 
-[role="_abstract"] 
+[role="_abstract"]
 The MACVLAN CNI plugin JSON configuration object describes the configuration parameters for the MAC Virtual LAN (MACVLAN) Container Network Interface (CNI) plugin. The following table describes these parameters:
 
 [cols=".^2,.^2,.^6",options="header"]
@@ -16,7 +16,7 @@ The MACVLAN CNI plugin JSON configuration object describes the configuration par
 
 |`cniVersion`
 |`string`
-|The CNI specification version. The `0.3.1` value is required.
+|The CNI specification version. A minimum version of `0.3.1` is required.
 
 |`name`
 |`string`

--- a/modules/nw-multus-tap-object.adoc
+++ b/modules/nw-multus-tap-object.adoc
@@ -6,7 +6,7 @@
 [id="nw-multus-tap-object_{context}"]
 = Configuration for a TAP secondary network
 
-[role="_abstract"] 
+[role="_abstract"]
 The TAP CNI plugin JSON configuration object describes the configuration parameters for the TAP CNI plugin. The following table describes these parameters:
 
 [cols=".^2,.^2,.^6",options="header"]
@@ -15,7 +15,7 @@ The TAP CNI plugin JSON configuration object describes the configuration paramet
 
 |`cniVersion`
 |`string`
-|The CNI specification version. The `0.3.1` value is required.
+|The CNI specification version. A minimum version of `0.3.1` is required.
 
 |`name`
 |`string`

--- a/modules/nw-multus-vlan-object.adoc
+++ b/modules/nw-multus-vlan-object.adoc
@@ -8,7 +8,7 @@
 [id="nw-multus-vlan-object_{context}"]
 = Configuration for a VLAN secondary network
 
-[role="_abstract"]  
+[role="_abstract"]
 The VLAN CNI plugin JSON configuration object describes the configuration parameters for the VLAN, `vlan`, CNI plugin. The following table details these parameters:
 
 [cols=".^2,.^2,.^6",options="header"]
@@ -17,7 +17,7 @@ The VLAN CNI plugin JSON configuration object describes the configuration parame
 
 |`cniVersion`
 |`string`
-|The CNI specification version. The `0.3.1` value is required.
+|The CNI specification version. A minimum version of `0.3.1` is required.
 
 |`name`
 |`string`
@@ -83,4 +83,4 @@ The following example demonstrates a `vlan` configuration with a secondary netwo
 }
 ----
 
-* `ipam.type.host-local`: Allocates IPv4 and IPv6 IP addresses from a specified set of address ranges. IPAM plugin stores the IP addresses locally on the host filesystem so that the addresses remain unique to the host. 
+* `ipam.type.host-local`: Allocates IPv4 and IPv6 IP addresses from a specified set of address ranges. IPAM plugin stores the IP addresses locally on the host filesystem so that the addresses remain unique to the host.


### PR DESCRIPTION
[OCPBUGS-60529 ]: Getting error while configuring the NAD

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.16 and greater
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:https://issues.redhat.com/browse/OCPBUGS-60529
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
https://107014--ocpdocs-pr.netlify.app/microshift/latest/microshift_networking/microshift_multiple_networks/microshift-cni-multus.html
https://107014--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/multiple_networks/secondary_networks/creating-secondary-nwt-other-cni.html
https://107014--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/live_migration/virt-configuring-cross-cluster-live-migration-network.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
