### PR TITLE
OSDOCS-18368 [NETOBSERV] Health rules and other fixes from 1.11

### DIFF
--- a/modules/network-observability-disable-predefined-rules.adoc
+++ b/modules/network-observability-disable-predefined-rules.adoc
@@ -7,6 +7,6 @@
 = Disable predefined rules
 
 [role="_abstract"]
-Rule templates can be disabled in the `spec.processor.metrics.disableAlerts` field of the `FlowCollector` custom resource (CR). This setting accepts a list of rule template names. For a list of alert template names, see: "List of default rules".
+Rule templates can be disabled in the `spec.processor.metrics.disableAlerts` field of the `FlowCollector` custom resource (CR). This setting accepts a list of rule template names. For a list of alert template names, see "List of default rules".
 
 If a template is disabled and overridden in the `spec.processor.metrics.healthRules` field, the disable setting takes precedence and the alert rule is not created.

--- a/modules/network-observability-health-rule-structure-customization.adoc
+++ b/modules/network-observability-health-rule-structure-customization.adoc
@@ -9,9 +9,9 @@
 [role="_abstract"]
 Health rules in the Network Observability Operator are defined using rule templates and variants in the `spec.processor.metrics.healthRules` object of the `FlowCollector` custom resource (CR). You can customize the default templates and variants for flexible, fine-grained alerting.
 
-For each template, you can define a list of variants, each with their own thresholds and grouping configurations. For more information, see the "List of default alert templates".
+For each template, you can define a list of variants, each with their own thresholds and grouping configurations. For more information, see "List of default alert templates".
 
-Here is an example:
+The following example shows an alert:
 
 [source,yaml]
 ----

--- a/modules/network-observability-health-rules-promql-expressions-metadata.adoc
+++ b/modules/network-observability-health-rules-promql-expressions-metadata.adoc
@@ -128,11 +128,11 @@ The `netobserv_io_network_health` annotation is a JSON string consisting of the 
 | List of strings
 | One or more labels that hold node names. When provided, the alert appears under the *Nodes* tab.
 
-|`workloadLabels`:
+|`workloadLabels`
 | List of strings
 | One or more labels that hold owner/workload names. When provided alongside with `kindLabels`, the alert will show up under the "Owners" tab.
 
-|`kindLabels`:
+|`kindLabels`
 | List of strings
 | One or more labels that hold owner/workload kinds. When provided alongside with `workloadLabels`, the alert will show up under the "Owners" tab.
 
@@ -157,6 +157,8 @@ The `netobserv_io_network_health` annotation is a JSON string consisting of the 
 | Information related to the link to the *Network Traffic* page, for URL building. Some filters will be set automatically, such as the `node` or `namespace` filter.
 |===
 
+The `namespaceLabels` and `nodeLabels` are mutually exclusive. If neither is provided, the alert appears under the *Global* tab.
+
 .`trafficLink` fields
 [cols="1,3",options="header"]
 |===
@@ -172,5 +174,3 @@ The `netobserv_io_network_health` annotation is a JSON string consisting of the 
 | `filterDestination`
 | Whether the filter should target the destination of the traffic instead of the source (`true` or `false`).
 |===
-
-The `namespaceLabels` and `nodeLabels` are mutually exclusive. If neither is provided, the alert appears under the *Global* tab.

--- a/observability/network_observability/network-observability-health-rules.adoc
+++ b/observability/network_observability/network-observability-health-rules.adoc
@@ -32,7 +32,7 @@ include::modules/network-observability-disable-predefined-rules.adoc[leveloffset
 
 
 [role="_additional-resources"]
-.Additional resources
+== Additional resources
 * xref:../../observability/network_observability/network-observability-health-rules.adoc#network-observability-default-rules_network-observability-health-rules[List of default rules]
 * xref:../../observability/network_observability/metrics-alerts-dashboards.adoc#network-observability-viewing-dashboards_metrics-dashboards-alerts[Viewing network observability metrics dashboards]
 * xref:../../observability/network_observability/metrics-alerts-dashboards.adoc#network-observability-netobserv-dashboard-high-traffic-alert_metrics-dashboards-alerts[Creating alerts]

--- a/observability/network_observability/network-observability-per-tenant-model.adoc
+++ b/observability/network_observability/network-observability-per-tenant-model.adoc
@@ -26,17 +26,3 @@ include::modules/network-observability-per-tenant-flowcollector-slice-api-refere
 == Additional resources
 
 * xref:../../observability/network_observability/flowcollector-api.adoc#network-observability-flowcollector-api-specifications_network_observability[FlowCollector API reference]
-
-////
-* drafty draft to get words on the page and an overall sense of new feature.
-* may not stay own assembly; may need to be slotted somewhere. but it also might make sense to keep it as its own assembly so as not to make the observing-network-traffic.adoc assembly even larger.
-* worth considering collecting FlowCollector info and putting it all together, except for the API since that is auto-generated.
-* should enable, configure, disable be leveloffset=+2?
-* fix titles and URLs once content is structured/organized
-////
-
-
-
-
-
-


### PR DESCRIPTION
[OSDOCS-18368](https://issues.redhat.com/browse/OSDOCS-18368) [NETOBSERV] Health rules and other fixes from 1.11

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.12, 4.14+

Issue:
https://issues.redhat.com/browse/OSDOCS-18368

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
QE is not required for this PR.

Additional information:
* Addresses Doc Merge Review comments from previously merged PRs for the Network Observability Operator 1.11 release.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
