### PR TITLE
OSDOCS-17109-2:CQA-2-MSH-INST-3-bootc (attachment#2)

### DIFF
--- a/microshift_install_bootc/microshift-install-bootc-image.adoc
+++ b/microshift_install_bootc/microshift-install-bootc-image.adoc
@@ -1,22 +1,18 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="microshift-install-bootc-image"]
-include::_attributes/attributes-microshift.adoc[]
 = Installing and publishing a bootc image to a registry
+include::_attributes/attributes-microshift.adoc[]
 :context: microshift-install-bootc-image
 
 toc::[]
 
-{microshift-short} is built and published as image mode containers. When installing a {op-system-base-full} bootable container image with {microshift-short}, use either a prebuilt bootable container image or build your own custom bootable container image.
+[role="_abstract"]
+{microshift-short} is built and published as image mode containers. When installing a {op-system-base-full} bootable container image with {microshift-short}, use either a prebuilt bootable container image or build your own custom bootable container image so that you can publish the image to a remote registry for use.
 
 include::modules/microshift-install-bootc-workflow.adoc[leveloffset=+1]
 
-[id="microshift-get-build-bootc-image_{context}"]
-== Get or build your bootc image
+include::modules/microshift-install-bootc-get-published-image.adoc[leveloffset=+1]
 
-Either get an existing bootc image or create one, then you can publish that image to a remote registry for use.
-
-include::modules/microshift-install-bootc-get-published-image.adoc[leveloffset=+2]
-
-include::modules/microshift-install-bootc-build-image.adoc[leveloffset=+2]
+include::modules/microshift-install-bootc-build-image.adoc[leveloffset=+1]
 
 include::modules/microshift-install-bootc-publish-image.adoc[leveloffset=+1]

--- a/microshift_install_bootc/microshift-install-bootc-image.adoc
+++ b/microshift_install_bootc/microshift-install-bootc-image.adoc
@@ -1,22 +1,18 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="microshift-install-bootc-image"]
-include::_attributes/attributes-microshift.adoc[]
 = Installing and publishing a bootc image to a registry
+include::_attributes/attributes-microshift.adoc[]
 :context: microshift-install-bootc-image
 
 toc::[]
 
-{microshift-short} is built and published as image mode containers. When installing a {op-system-base-full} bootable container image with {microshift-short}, use either a prebuilt bootable container image or build your own custom bootable container image.
+[role="_abstract"]
+{microshift-short} is built and published as image mode containers. When installing a {op-system-base-full} bootable container image with {microshift-short}, use either a prebuilt bootable container image or build your own custom bootable container image so that you can publish the image to a remote registry for use.
 
 include::modules/microshift-install-bootc-workflow.adoc[leveloffset=+1]
-
-[id="microshift-get-build-bootc-image_{context}"]
-== Get or build your bootc image
-
-Either get an existing bootc image or create one, then you can publish that image to a remote registry for use.
 
 include::modules/microshift-install-bootc-get-published-image.adoc[leveloffset=+2]
 
 include::modules/microshift-install-bootc-build-image.adoc[leveloffset=+2]
 
-include::modules/microshift-install-bootc-publish-image.adoc[leveloffset=+1]
+include::modules/microshift-install-bootc-publish-image.adoc[leveloffset=+2]

--- a/microshift_install_bootc/microshift-install-bootc-physically-bound.adoc
+++ b/microshift_install_bootc/microshift-install-bootc-physically-bound.adoc
@@ -16,8 +16,3 @@ Edge-computing scenarios involving embedded systems on specialized devices, high
 include::modules/microshift-install-bootc-physically-bound-con.adoc[leveloffset=+1]
 
 include::modules/microshift-embed-cont-images-bootc-image.adoc[leveloffset=+1]
-
-[id="_additional-resources_microshift-install-bootc-physically-bound_{context}"]
-== Additional resources
-
-* xref:../microshift_install_bootc/microshift-install-bootc-image.adoc#microshift-install-bootc-build-image_microshift-install-bootc-image[Building the bootc image]

--- a/modules/microshift-install-bootc-build-image.adoc
+++ b/modules/microshift-install-bootc-build-image.adoc
@@ -6,7 +6,8 @@
 [id="microshift-install-bootc-build-image_{context}"]
 = Building the bootc image
 
-Build your {op-system-base-full} that contains {microshift-short} as a bootable container image by using a Containerfile.
+[role="_abstract"]
+Build your {op-system-base-full} that contains {microshift-short} as a bootable container image by using a Containerfile. 
 
 .Prerequisites
 
@@ -62,6 +63,7 @@ WantedBy=multi-user.target
 EOF
 RUN systemctl enable microshift-make-rshared.service
 ----
++
 [IMPORTANT]
 ====
 Podman uses the host subscription information and repositories inside the container when building the container image. If the `rhocp` and `fast-datapath` repositories are not available on the host, the build fails.
@@ -78,9 +80,10 @@ $ PULL_SECRET=~/.pull-secret.json
 +
 [source,terminal,subs="+quotes"]
 ----
-$ USER_PASSWD=_<redhat_user_password>_ <1>
+$ USER_PASSWD=_<redhat_user_password>_
 ----
-<1> Replace _<redhat_user_password>_ with your password.
++
+Replace `_<redhat_user_password>_` with your password.
 
 . Configure the `IMAGE_NAME` environment variable:
 +

--- a/modules/microshift-install-bootc-build-image.adoc
+++ b/modules/microshift-install-bootc-build-image.adoc
@@ -6,7 +6,8 @@
 [id="microshift-install-bootc-build-image_{context}"]
 = Building the bootc image
 
-Build your {op-system-base-full} that contains {microshift-short} as a bootable container image by using a Containerfile.
+[role="_abstract"]
+Build your {op-system-base-full} that contains {microshift-short} as a bootable container image by using a Containerfile. 
 
 .Prerequisites
 
@@ -62,11 +63,12 @@ WantedBy=multi-user.target
 EOF
 RUN systemctl enable microshift-make-rshared.service
 ----
++
 [IMPORTANT]
 ====
 Podman uses the host subscription information and repositories inside the container when building the container image. If the `rhocp` and `fast-datapath` repositories are not available on the host, the build fails.
 ====
-
++
 . Set the `PULL_SECRET` environment variable:
 +
 [source,terminal]
@@ -78,9 +80,10 @@ $ PULL_SECRET=~/.pull-secret.json
 +
 [source,terminal,subs="+quotes"]
 ----
-$ USER_PASSWD=_<redhat_user_password>_ <1>
+$ USER_PASSWD=_<redhat_user_password>_
 ----
-<1> Replace _<redhat_user_password>_ with your password.
++
+Replace _<redhat_user_password>_ with your password.
 
 . Configure the `IMAGE_NAME` environment variable:
 +

--- a/modules/microshift-install-bootc-get-published-image.adoc
+++ b/modules/microshift-install-bootc-get-published-image.adoc
@@ -6,6 +6,7 @@
 [id="microshift-install-bootc-get-published-image_{context}"]
 = Getting the published bootc image for {microshift-short}
 
+[role="_abstract"]
 You can use the {microshift-short} container images to install {op-system-image}.
 
 .Prerequisites

--- a/modules/microshift-install-bootc-publish-image.adoc
+++ b/modules/microshift-install-bootc-publish-image.adoc
@@ -6,6 +6,7 @@
 [id="microshift-bootc-publish-image_{context}"]
 = Publishing the bootc image to the remote registry
 
+[role="_abstract"]
 Publish your bootc image to the remote registry so that the image can be used for running the container on another host, or for when you want to install a new operating system with the bootc image layer.
 
 .Prerequisites
@@ -20,9 +21,10 @@ Publish your bootc image to the remote registry so that the image can be used fo
 +
 [source,terminal,subs="+quotes"]
 ----
-$ REGISTRY_URL=_<quay.io>_ # <1>
+$ REGISTRY_URL=_<quay.io>_
 ----
-<1> Replace _<quay.io>_ with the URL for your image registry.
++
+Replace `_<quay.io>_` with the URL for your image registry.
 
 . Log in to your remote registry by running the following command:
 +
@@ -35,17 +37,19 @@ $ sudo podman login "${REGISTRY_URL}"
 +
 [source,terminal,subs="attributes+,quotes"]
 ----
-$ IMAGE_NAME=_<microshift-{product-version}-bootc>_ # <1>
+$ IMAGE_NAME=_<microshift-{product-version}-bootc>_
 ----
-<1> Replace _<microshift-{product-version}-bootc>_ with the name of the image you want to publish.
++
+Replace _<microshift-{product-version}-bootc>_ with the name of the image you want to publish.
 
 . Set the `REGISTRY_IMG` variable for the image by running the following command:
 +
 [source,terminal,subs="+quotes"]
 ----
-$ REGISTRY_IMG=_<myorg/mypath>_/"${IMAGE_NAME}" # <1>
+$ REGISTRY_IMG=_<myorg/mypath>_/"${IMAGE_NAME}"
 ----
-<1> Replace _<myorg/mypath>_ with your remote registry organization name and path.
++
+Replace `_<myorg/mypath>_` with your remote registry organization name and path.
 
 . Publish the image by running the following command:
 +

--- a/modules/microshift-install-bootc-publish-image.adoc
+++ b/modules/microshift-install-bootc-publish-image.adoc
@@ -6,6 +6,7 @@
 [id="microshift-bootc-publish-image_{context}"]
 = Publishing the bootc image to the remote registry
 
+[role="_abstract"]
 Publish your bootc image to the remote registry so that the image can be used for running the container on another host, or for when you want to install a new operating system with the bootc image layer.
 
 .Prerequisites
@@ -20,9 +21,10 @@ Publish your bootc image to the remote registry so that the image can be used fo
 +
 [source,terminal,subs="+quotes"]
 ----
-$ REGISTRY_URL=_<quay.io>_ # <1>
+$ REGISTRY_URL=_<quay.io>_
 ----
-<1> Replace _<quay.io>_ with the URL for your image registry.
++
+Replace _<quay.io>_ with the URL for your image registry.
 
 . Log in to your remote registry by running the following command:
 +
@@ -35,17 +37,19 @@ $ sudo podman login "${REGISTRY_URL}"
 +
 [source,terminal,subs="attributes+,quotes"]
 ----
-$ IMAGE_NAME=_<microshift-{product-version}-bootc>_ # <1>
+$ IMAGE_NAME=_<microshift-{product-version}-bootc>_
 ----
-<1> Replace _<microshift-{product-version}-bootc>_ with the name of the image you want to publish.
++
+Replace _<microshift-{product-version}-bootc>_ with the name of the image you want to publish.
 
 . Set the `REGISTRY_IMG` variable for the image by running the following command:
 +
 [source,terminal,subs="+quotes"]
 ----
-$ REGISTRY_IMG=_<myorg/mypath>_/"${IMAGE_NAME}" # <1>
+$ REGISTRY_IMG=_<myorg/mypath>_/"${IMAGE_NAME}"
 ----
-<1> Replace _<myorg/mypath>_ with your remote registry organization name and path.
++
+Replace _<myorg/mypath>_ with your remote registry organization name and path.
 
 . Publish the image by running the following command:
 +

--- a/modules/microshift-install-bootc-workflow.adoc
+++ b/modules/microshift-install-bootc-workflow.adoc
@@ -6,11 +6,20 @@
 [id="microshift-install-rhel-image-mode-conc_{context}"]
 = The image mode for {op-system-base} with {microshift-short} workflow
 
-Before you use {op-system-image}, ensure that the following resources are available:
+[role="_abstract"]
+Before you can use {op-system-image} with {microshift-short}, you must verify the availability of required resources.
+
+[id="microshift-install-rhel-image-mode-resources_{context}"]
+== Required resources
+
+Ensure that the following resources are available:
 
 * A {op-system-base} {op-system-version} host with an active Red{nbsp}Hat subscription for building {microshift-short} bootc images.
 * A remote registry for storing and accessing `rhel-bootc` images.
 * An AArch64 or x86_64 system architecture.
+
+[id="microshift-install-rhel-image-mode-workflow_{context}"]
+== Workflow
 
 The workflow for using {op-system-image} with {microshift-short} includes the following steps:
 

--- a/modules/microshift-install-bootc-workflow.adoc
+++ b/modules/microshift-install-bootc-workflow.adoc
@@ -6,11 +6,16 @@
 [id="microshift-install-rhel-image-mode-conc_{context}"]
 = The image mode for {op-system-base} with {microshift-short} workflow
 
-Before you use {op-system-image}, ensure that the following resources are available:
+[role="_abstract"]
+Before you can use {op-system-image} with {microshift-short}, you must verify the availability of required resources.
+
+== Required resources
 
 * A {op-system-base} {op-system-version} host with an active Red{nbsp}Hat subscription for building {microshift-short} bootc images.
 * A remote registry for storing and accessing `rhel-bootc` images.
 * An AArch64 or x86_64 system architecture.
+
+== Workflow
 
 The workflow for using {op-system-image} with {microshift-short} includes the following steps:
 


### PR DESCRIPTION
Version(s):
5.0, 4.22, 4.21, and 4.20

Issue:
https://issues.redhat.com/browse/OSDOCS-17109

Link to docs preview:
https://107023--ocpdocs-pr.netlify.app/microshift/latest/microshift_install_bootc/microshift-install-bootc-image.html