### PR TITLE
OLS-2666: Update MCP procedure for creating credential secret

### DIFF
--- a/modules/.vale.ini
+++ b/modules/.vale.ini
@@ -2,8 +2,39 @@ StylesPath = ../.vale/styles
 
 MinAlertLevel = suggestion
 
+Vocab = OpenShiftDocs
+
 [[!.]*.adoc]
 BasedOnStyles = OpenShiftAsciiDoc, AsciiDoc, RedHat
+
+# Changing severity of a rule both enables and sets it (i.e; = YES)
+AsciiDocDITA.AdmonitionTitle = error
+AsciiDocDITA.AssemblyContents = error
+AsciiDocDITA.AuthorLine = error
+AsciiDocDITA.BlockTitle = error
+AsciiDocDITA.CalloutList = error
+AsciiDocDITA.ContentType = error
+AsciiDocDITA.DiscreteHeading = error
+AsciiDocDITA.DocumentID = error
+AsciiDocDITA.DocumentTitle = error
+AsciiDocDITA.EntityReference = error
+AsciiDocDITA.EquationFormula = error
+AsciiDocDITA.ExampleBlock = error
+AsciiDocDITA.LineBreak = error
+AsciiDocDITA.MismatchedID = error
+AsciiDocDITA.NestedSection = error
+AsciiDocDITA.PageBreak = error
+AsciiDocDITA.RelatedLinks = error
+AsciiDocDITA.ShortDescription = error
+AsciiDocDITA.SidebarBlock = error
+AsciiDocDITA.TableFooter = error
+AsciiDocDITA.TaskContents = error
+AsciiDocDITA.TaskDuplicate = error
+AsciiDocDITA.TaskExample = error
+AsciiDocDITA.TaskSection = error
+AsciiDocDITA.TaskStep = error
+AsciiDocDITA.TaskTitle = error
+AsciiDocDITA.ThematicBreak = error
 
 # Use local OpenShiftDocs Vocab terms
 Vale.Terms = YES

--- a/modules/ols-enabling-custom-mcp-server.adoc
+++ b/modules/ols-enabling-custom-mcp-server.adoc
@@ -9,7 +9,7 @@
 
 Add an additional Model Context Protocol (MCP) server that interfaces with a tool in your environment so that the large language model (LLM) uses the tool to generate answers to your questions.
 
-:FeatureName: The cluster interaction feature
+:FeatureName: The MCP server feature
 include::snippets/technology-preview.adoc[]
 
 .Prerequisites
@@ -48,26 +48,27 @@ spec:
         sseReadTimeout: 10
         headers:
           - Authorization: kubernetes <4>        
-          - Authorization1: <name_of_the_secret_containing_the_header_content>
+          - Example-Authorization: <name_of_the_secret_containing_the_header_content> <5>
         enableSSE: true
     - name: mcp-server-2
       streamableHTTP:
         url: http://localhost:8080/mcp
-        timeout: 30 <5>
-        sseReadTimeout: 10 <6>
+        timeout: 30 <6>
+        sseReadTimeout: 10 <7>
         headers:
-          - <key1>: <value1> <7>
+          - <key1>: <value1> <8>
           - <key2>: <value2>
-        enableSSE: true <8>
+        enableSSE: true <9>
 ----
 <1> Specifies the MCP server functionality.
 <2> Specifies the name of the MCP server.
 <3> Specifies the URL path that the MCP server uses to communicate.
-<4> If you want to pass the kubernetes token in the header, specify a string `kubernetes` instead of the secret name.
-<5> Specifies the time that the MCP server has to respond to a query. If the client does not receive a query within the time specified, the MCP server times out. In this example, the timeout is 30 seconds.
-<6> Specifies the amount of time a client waits for new data from a Server-Sent Events (SSE) connection. If the client does not receive data within that time, the client closes the connection.
-<7> Specifies the additional header that the HTTP request sends to the MCP server. 
-<8> When you set `enableSSE` to `true`, the MCP server establishes a one-way channel that the MCP server uses to push updates to the client whenever the server has new information. The default setting is `false`. 
+<4> Specifies that the that MCP server receives a header named `Authorization` that contains the bearer token. To pass a Kubernetes token in the header the string must be `kubernetes`. 
+<5> Specifies that that MCP server receives a header named `Example-Authorization` that contains the header content from the secret. The secret must contain a key-value pair with the key named `header` and the value must be the header content. 
+<6> Specifies the time that the MCP server has to respond to a query. If the client does not receive a query within the specified time, the MCP server times out. In this example, the timeout is 30 seconds.
+<7> Specifies the amount of time a client waits for new data from a Server-Sent Events (SSE) connection. If the client does not receive data within that time, the client closes the connection.
+<8> Specifies the additional header that the HTTP request sends to the MCP server. 
+<9> When you set `enableSSE` to `true`, the MCP server establishes a one-way channel that the MCP server uses to push updates to the client whenever the server has new information. The default setting is `false`. 
 
 . Click *Save*. 
 +


### PR DESCRIPTION
Affects:
[lightspeed-main](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-main)
[lightspeed-docs-1.0](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-1.0)

PR must be CP'd back to the lightspeed-docs-1.0 branch.

Issue:
https://issues.redhat.com/browse/OLS-2666

Link to docs preview:
https://107024--ocpdocs-pr.netlify.app/openshift-lightspeed/latest/configure/ols-configuring-openshift-lightspeed.html#ols-enabling-mcp-server_ols-configuring-openshift-lightspeed

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
