### PR TITLE
OSDOCS 18401 WMCO 10.21.1 Release Notes

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -3127,8 +3127,8 @@ Topics:
   Topics:
   - Name: Red Hat OpenShift support for Windows Containers release notes
     File: windows-containers-release-notes
-#  - Name: Past releases
-#    File: windows-containers-release-notes-past
+  - Name: Past releases
+    File: windows-containers-release-notes-past
   - Name: Windows Machine Config Operator prerequisites
     File: windows-containers-release-notes-prereqs
   - Name: Windows Machine Config Operator known limitations

--- a/modules/windows-containers-release-notes-10-21-0.adoc
+++ b/modules/windows-containers-release-notes-10-21-0.adoc
@@ -8,23 +8,18 @@
 
 Issued: 03 February 2026
 
+[role="_abstract"]
 The components of the Red Hat Windows Machine Config Operator (WMCO) 10.21.0 were released in https://access.redhat.com/errata/RHBA-2026:1767[RHBA-2026:1767].
 
 [id="wmco-10-21-0-new-features"]
 == New features and improvements
 
-[id="wmco-10-21-0-new-features-kubernetes"]
-=== Kubernetes upgrade
+Kubernetes upgrade:: The WMCO now uses Kubernetes version 1.34.
 
-The WMCO now uses Kubernetes version 1.34.
-
-[id="wmco-10-21-0-new-features-wicd"]
-=== WICD can access only the node its running on
-
-The Windows Instance Config Daemon (WICD) on each Windows node now has permission to access only the node that it is installed on. The WICD having write access to only one node increases cluster security. 
+WICD can access only the node its running on:: The Windows Instance Config Daemon (WICD) on each Windows node now has permission to access only the node that it is installed on. The WICD having write access to only one node increases cluster security. 
 
 [id="wmco-10-21-0-deprecated-removed"]
-=== Deprecated and removed features
+== Deprecated and removed features
 
 Windows Server 2019 support::
 Because Microsoft support for Windows Server 2019 is ending, WMCO 10.21 will be the last version that supports Windows Server 2019.  Support for Windows Server 2025 will be added in a future release. You should upgrade your Windows Server 2019 nodes to Windows Server 2022 prior to the release of WMCO 10.22. Support for Windows Server 2022 remains unchanged.
@@ -34,6 +29,6 @@ Because Microsoft support for Windows Server 2019 is ending, WMCO 10.21 will be 
 
 * Before this update, during secret reconciliations, secret change data was being added to the logs on each reconciliation loop. As a result, the secret change data was persisting, causing the logs to grow in size with unrelated data. With this release, only the current secret change data is being logged. As a result, the size and complexity of the logs is reduced. (link:https://issues.redhat.com/browse/OCPBUGS-61122[*OCPBUGS-61122*])
 
-* Before this update, the `hybridOverlay` service was not using the trusted CA bundle when connecting to {product-title}, because the `--k8s-cacert` option was missing from the service command. Because of this, users could encounter trust issues or failures when the `hybridOverlay` service attempted to communicate securely with {product-title} clusters using custom or internal CAs. With this release, the `hybridOverlay` service command now includes the `--k8s-cacert flag` pointing to the trusted CA bundle. As a result, the `hybridOverlay` service uses the trusted CA bundle for secure communication, preventing trust issues and ensuring compatibility with the cluster. (link:https://issues.redhat.com/browse/OCPBUGS-64719[*OCPBUGS-64719*])
+* Before this update, the `hybridOverlay` service was not using the trusted CA bundle when connecting to {product-title}, because the `--k8s-cacert` option was missing from the service command. Because of this, users could encounter trust issues or failures when the `hybridOverlay` service attempted to communicate securely with {product-title} clusters using custom or internal CAs. With this release, the `hybridOverlay` service command now includes the `--k8s-cacert flag` pointing to the trusted CA bundle. As a result, the `hybridOverlay` service uses the trusted CA bundle for secure communication, preventing trust issues and ensuring compatibility with the cluster. (link:https://issues.redhat.com/browse/OCPBUGS-64719[OCPBUGS-64719])
 
-* Before this update, an error message regarding a cache not being started was being printed to the logs at WMCO start up. This error had no impact on functionality. The check causing the error message has been removed, and it will no longer log the error. (link:https://issues.redhat.com/browse/OCPBUGS-62815[*OCPBUGS-62815*])
+* Before this update, an error message regarding a cache not being started was being printed to the logs at WMCO start up. This error had no impact on functionality. The check causing the error message has been removed, and it will no longer log the error. (link:https://issues.redhat.com/browse/OCPBUGS-62815[OCPBUGS-62815])

--- a/modules/windows-containers-release-notes-10-21-1.adoc
+++ b/modules/windows-containers-release-notes-10-21-1.adoc
@@ -1,0 +1,16 @@
+// Module included in the following assemblies:
+//
+// * windows_containers/wmco_rn/windows-containers-release-notes.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="windows-containers-release-notes-10-21-1_{context}"]
+= Release notes for Red Hat Windows Machine Config Operator 10.21.1
+
+Issued: 3 March 2026
+
+The components of the Red Hat Windows Machine Config Operator (WMCO) 10.21.1 were released in https://access.redhat.com/errata/RHBA-2026:3684[RHBA-2026:3684].
+
+[id="wmco-10-21-1-bug-fixes"]
+== Bug fixes
+
+* Before this update, the `hybridOverlay` service was not using the trusted CA bundle when connecting to Kubernetes, because the `--k8s-cacert` option was missing from the service command. Because of this, users could encounter trust issues or failures when the `hybridOverlay` service attempted to communicate securely with Kubernetes clusters using custom or internal CAs. With this release, the `hybridOverlay` service command now includes the `--k8s-cacert flag` pointing to the trusted CA bundle. As a result, the `hybridOverlay` service uses the trusted CA bundle for secure communication, preventing trust issues and ensuring compatibility with the cluster. (link:https://issues.redhat.com/browse/OCPBUGS-64719[OCPBUGS-64719])

--- a/windows_containers/wmco_rn/windows-containers-release-notes-past.adoc
+++ b/windows_containers/wmco_rn/windows-containers-release-notes-past.adoc
@@ -6,20 +6,9 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-// Release notes for past versions; cut and paste current version to top of this file for next release
-The following release notes are for previous versions of the Windows Machine Config Operator (WMCO).
+[role="_abstract"]
+You can review the following release notes to learn about changes in previous versions of the Custom Metrics Autoscaler Operator.
 
 For the current version, see xref:../../windows_containers/wmco_rn/windows-containers-release-notes.adoc#windows-containers-release-notes[{productwinc} release notes].
 
-[id="wmco-10-x-x-past-release-notes"]
-== Release notes for Red Hat Windows Machine Config Operator 10.x.0
-
-This release of the WMCO provides bug fixes for running Windows compute nodes in an {product-title} cluster. The components of the WMCO 10.x.0 were released in
-
-[id="wmco-10-x-x-past-new-features"]
-=== New features and improvements
-
-[id="wmco-10-x-x-past-bug-fixes"]
-=== Bug fixes
-
-
+include::modules/windows-containers-release-notes-10-21-0.adoc[leveloffset=+1]

--- a/windows_containers/wmco_rn/windows-containers-release-notes.adoc
+++ b/windows_containers/wmco_rn/windows-containers-release-notes.adoc
@@ -6,6 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 This release of the Windows Machine Config Operator (WMCO) provides bug fixes for running Windows compute nodes in an {product-title} cluster. 
 
-include::modules/windows-containers-release-notes-10-21-0.adoc[leveloffset=+1]
+include::modules/windows-containers-release-notes-10-21-1.adoc[leveloffset=+1]


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-18401

[Release notes for Red Hat Windows Machine Config Operator 10.21.1](https://107025--ocpdocs-pr.netlify.app/openshift-enterprise/latest/windows_containers/wmco_rn/windows-containers-release-notes.html) -- New module. **NEED TO ADD RELEASE DATE AND ERRATA LINK** when available.
[Release notes for past releases of the Windows Machine Config Operator](https://107025--ocpdocs-pr.netlify.app/openshift-enterprise/latest/windows_containers/wmco_rn/windows-containers-release-notes-past) -- Unhid assembly. Made Vale changes. 
[Release notes for Red Hat Windows Machine Config Operator 10.21.0](https://107025--ocpdocs-pr.netlify.app/openshift-enterprise/latest/windows_containers/wmco_rn/windows-containers-release-notes-past#windows-containers-release-notes-10-21-0_windows-containers-release-notes-past) -- Moved to Past Releases assembly. Made Vale changes (bumped some headings to description list). **NO CHANGES TO TEXT**.