### PR TITLE
Revert "[enterprise-4.19] CNV-69069: Adding links to new runbook aler…

### DIFF
--- a/virt/monitoring/virt-runbooks.adoc
+++ b/virt/monitoring/virt-runbooks.adoc
@@ -64,45 +64,10 @@ Runbooks for the {VirtProductName} Operator are maintained in the link:https://g
 
 * link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/CnaoNmstateMigration.md[View the runbook] for the `CnaoNMstateMigration` alert.
 
-[id="virt-runbook-deprecatedmachinetype_{context}"]
-== DeprecatedMachineType
-
-* link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/DeprecatedMachineType.md[View the runbook] for the `DeprecatedMachineType` alert.
-
-[id="virt-runbook-duplicatewaspagentdsdetected_{context}"]
-== DuplicateWaspAgentDSDetected
-
-* The `DuplicateWaspAgentDSDetected` alert is link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/DuplicateWaspAgentDSDetected.md[deprecated].
-
-[id="virt-runbook-guestfilesystemalmostoutofspace_{context}"]
-== GuestFilesystemAlmostOutOfSpace
-
-* link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/GuestFilesystemAlmostOutOfSpace.md[View the runbook] for the `GuestFilesystemAlmostOutOfSpace` alert.
-
-[id="virt-runbook-guestvcpuqueuehighcritical_{context}"]
-== GuestVCPUQueueHighCritical
-
-* link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/GuestVCPUQueueHighCritical.md[View the runbook] for the `GuestVCPUQueueHighCritical` alert.
-
-[id="virt-runbook-guestvcpuqueuehighwarning_{context}"]
-== GuestVCPUQueueHighWarning
-
-* link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/GuestVCPUQueueHighWarning.md[View the runbook] for the `GuestVCPUQueueHighWarning` alert.
-
 [id="virt-runbook-hacontrolplanedown_{context}"]
 == HAControlPlaneDown
 
 * link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/HAControlPlaneDown.md[View the runbook] for the `HAControlPlaneDown` alert.
-
-[id="virt-runbook-hcogoldenimagewithnoarchitectureannotation_{context}"]
-== HCOGoldenImageWithNoArchitectureAnnotation
-
-* link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/HCOGoldenImageWithNoArchitectureAnnotation.md[View the runbook] for the `HCOGoldenImageWithNoArchitectureAnnotation` alert.
-
-[id="virt-runbook-hcogoldenimagewithnosupportedarchitecture_{context}"]
-== HCOGoldenImageWithNoSupportedArchitecture
-
-* link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/HCOGoldenImageWithNoSupportedArchitecture.md[View the runbook] for the `HCOGoldenImageWithNoSupportedArchitecture` alert.
 
 [id="virt-runbook-hcoinstallationincomplete_{context}"]
 == HCOInstallationIncomplete
@@ -113,21 +78,6 @@ Runbooks for the {VirtProductName} Operator are maintained in the link:https://g
 == HCOMisconfiguredDescheduler
 
 * link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/HCOMisconfiguredDescheduler.md[View the runbook] for the `HCOMisconfiguredDescheduler` alert.
-
-[id="virt-runbook-hcomultiarchgoldenimagesdisabled_{context}"]
-== HCOMultiArchGoldenImagesDisabled
-
-* link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/HCOMultiArchGoldenImagesDisabled.md[View the runbook] for the `HCOMultiArchGoldenImagesDisabled` alert.
-
-[id="virt-runbook-hcooperatorconditionsunhealthy_{context}"]
-== HCOOperatorConditionsUnhealthy
-
-* link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/HCOOperatorConditionsUnhealthy.md[View the runbook] for the `HCOOperatorConditionsUnhealthy` alert.
-
-[id="virt-runbook-highnodecpufrequency_{context}"]
-== HighNodeCPUFrequency
-
-* link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/HighNodeCPUFrequency.md[View the runbook] for the `HighNodeCPUFrequency` alert.
 
 [id="virt-runbook-hppnotready_{context}"]
 == HPPNotReady
@@ -157,7 +107,7 @@ Runbooks for the {VirtProductName} Operator are maintained in the link:https://g
 [id="virt-runbook-KubeMacPoolDuplicateMacsfound_{context}"]
 == KubeMacPoolDuplicateMacsFound
 
-*The `KubeMacPoolDuplicateMacsFound` alert is link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/KubeMacPoolDuplicateMacsFound.md[deprecated].
+* link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/KubeMacPoolDuplicateMacsFound.md[View the runbook] for the `KubeMacPoolDuplicateMacsFound` alert.
 
 [id="virt-runbook-kubevirtcomponentexceedsrequestedcpu_{context}"]
 == KubeVirtComponentExceedsRequestedCPU
@@ -179,17 +129,6 @@ Runbooks for the {VirtProductName} Operator are maintained in the link:https://g
 
 * link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/KubeVirtDeprecatedAPIRequested.md[View the runbook] for the `KubeVirtDeprecatedAPIRequested` alert.
 
-[id="virt-runbook-kubevirtguestmemoryavailablelow_{context}"]
-== KubeVirtVMGuestMemoryAvailableLow
-
-* link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/KubeVirtVMGuestMemoryAvailableLow.md[View the runbook] for the `KubeVirtVMGuestMemoryAvailableLow` alert.
-
-[id="virt-runbook-kubevirtguestmemorypressure_{context}"]
-== KubeVirtVMGuestMemoryPressure
-
-* link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/KubeVirtVMGuestMemoryPressure.md[View the runbook] for the `KubeVirtVMGuestMemoryPressure` alert.
-
-
 [id="virt-runbook-kubevirtnoavailablenodestorunvms_{context}"]
 == KubeVirtNoAvailableNodesToRunVMs
 
@@ -198,7 +137,7 @@ Runbooks for the {VirtProductName} Operator are maintained in the link:https://g
 [id="virt-runbook-kubevirtvmhighmemoryusage_{context}"]
 == KubevirtVmHighMemoryUsage
 
-* The `KubevirtVmHighMemoryUsage` alert is link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/KubevirtVmHighMemoryUsage.md[deprecated].
+* link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/KubevirtVmHighMemoryUsage.md[View the runbook] for the `KubevirtVmHighMemoryUsage` alert.
 
 [id="virt-runbook-kubevirtvmiexcessivemigrations_{context}"]
 == KubeVirtVMIExcessiveMigrations
@@ -275,15 +214,10 @@ Runbooks for the {VirtProductName} Operator are maintained in the link:https://g
 
 * link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/OutdatedVirtualMachineInstanceWorkloads.md[View the runbook] for the `OutdatedVirtualMachineInstanceWorkloads` alert.
 
-[id="virt-runbook-persistentvolumefillingup_{context}"]
-== PersistentVolumeFillingUp
-
-* link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/PersistentVolumeFillingUp.md[View the runbook] for the `PersistentVolumeFillingUp` alert.
-
 [id="virt-runbook-singlestackipv6unsupported_{context}"]
 == SingleStackIPv6Unsupported
 
-* The `SingleStackIPv6Unsupported` alert is link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/SingleStackIPv6Unsupported.md[deprecated].
+* link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/SingleStackIPv6Unsupported.md[View the runbook] for the `SingleStackIPv6Unsupported` alert.
 
 [id="virt-runbook-sspcommontemplatesmodificationreverted_{context}"]
 == SSPCommonTemplatesModificationReverted
@@ -308,7 +242,7 @@ Runbooks for the {VirtProductName} Operator are maintained in the link:https://g
 [id="virt-runbook-sspoperatordown_{context}"]
 == SSPOperatorDown
 
-* The `SSPOperatorDown` alert is link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/SSPOperatorDown.md[deprecated].
+* link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/SSPOperatorDown.md[View the runbook] for the `SSPOperatorDown` alert.
 
 [id="virt-runbook-ssptemplatevalidatordown_{context}"]
 == SSPTemplateValidatorDown
@@ -333,7 +267,7 @@ Runbooks for the {VirtProductName} Operator are maintained in the link:https://g
 [id="virt-runbook-virtapiresterrorshigh_{context}"]
 == VirtApiRESTErrorsHigh
 
-* The `VirtApiRESTErrorsHigh` alert is link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/VirtApiRESTErrorsHigh.md[deprecated].
+* link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/VirtApiRESTErrorsHigh.md[View the runbook] for the `VirtApiRESTErrorsHigh` alert.
 
 [id="virt-runbook-virtcontrollerdown_{context}"]
 == VirtControllerDown
@@ -348,7 +282,7 @@ Runbooks for the {VirtProductName} Operator are maintained in the link:https://g
 [id="virt-runbook-virtcontrollerresterrorshigh_{context}"]
 == VirtControllerRESTErrorsHigh
 
-* The `VirtControllerRESTErrorsHigh` alert is link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/VirtControllerRESTErrorsHigh.md[deprecated].
+* link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/VirtControllerRESTErrorsHigh.md[View the runbook] for the `VirtControllerRESTErrorsHigh` alert.
 
 [id="virt-runbook-virthandlerdaemonsetrolloutfailing_{context}"]
 == VirtHandlerDaemonSetRolloutFailing
@@ -363,12 +297,7 @@ Runbooks for the {VirtProductName} Operator are maintained in the link:https://g
 [id="virt-runbook-virthandlerresterrorshigh_{context}"]
 == VirtHandlerRESTErrorsHigh
 
-* The `VirtHandlerRESTErrorsHigh` alert is link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/VirtHandlerRESTErrorsHigh.md[deprecated].
-
-[id="virt-runbook-virtlauncherpodsstuckfailed_{context}"]
-== VirtLauncherPodsStuckFailed
-
-* link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/VirtLauncherPodsStuckFailed.md[View the runbook] for the `VirtLauncherPodsStuckFailed` alert.
+* link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/VirtHandlerRESTErrorsHigh.md[View the runbook] for the `VirtHandlerRESTErrorsHigh` alert.
 
 [id="virt-runbook-virtoperatordown_{context}"]
 == VirtOperatorDown
@@ -383,7 +312,7 @@ Runbooks for the {VirtProductName} Operator are maintained in the link:https://g
 [id="virt-runbook-virtoperatorresterrorshigh_{context}"]
 == VirtOperatorRESTErrorsHigh
 
-* The `VirtOperatorRESTErrorsHigh` alert is link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/VirtOperatorRESTErrorsHigh.md[deprecated].
+* link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/VirtOperatorRESTErrorsHigh.md[View the runbook] for the `VirtOperatorRESTErrorsHigh` alert.
 
 [id="virt-runbook-virtualmachinecrcerrors_{context}"]
 == VirtualMachineCRCErrors
@@ -391,21 +320,6 @@ Runbooks for the {VirtProductName} Operator are maintained in the link:https://g
 * The `VirtualMachineCRCErrors` alert is link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/VirtualMachineCRCErrors.md[deprecated].
 +
 The alert is now called `VMStorageClassWarning`.
-
-[id="virt-runbook-virtualmachineinstancehasephemeralhotplugvolume_{context}"]
-== VirtualMachineInstanceHasEphemeralHotplugVolume
-
-* link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/VirtualMachineInstanceHasEphemeralHotplugVolume.md[View the runbook] for the `VirtualMachineInstanceHasEphemeralHotplugVolume` alert.
-
-[id="virt-runbook-virtualmachinestuckinunhealthystate_{context}"]
-== VirtualMachineStuckInUnhealthyState
-
-* link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/VirtualMachineStuckInUnhealthyState.md[View the runbook] for the `VirtualMachineStuckInUnhealthyState` alert.
-
-[id="virt-runbook-virtualmachinestuckonnode_{context}"]
-== VirtualMachineStuckOnNode
-
-* link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/VirtualMachineStuckOnNode.md[View the runbook] for the `VirtualMachineStuckOnNode` alert.
 
 [id="virt-runbook-vmcannotbeevicted_{context}"]
 == VMCannotBeEvicted


### PR DESCRIPTION
Only deprecated alerts need to be backported, not all alerts.