### PR TITLE
CNV-69069-16: backporting deprecated alerts to 4.14, 4.15, 4.16

### DIFF
--- a/virt/monitoring/virt-runbooks.adoc
+++ b/virt/monitoring/virt-runbooks.adoc
@@ -99,7 +99,7 @@ follow the procedures in the runbooks.
 [id="virt-runbook-KubeMacPoolDuplicateMacsFound"]
 == KubeMacPoolDuplicateMacsFound
 
-* link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/KubeMacPoolDuplicateMacsFound.md[View the runbook] for the `KubeMacPoolDuplicateMacsFound` alert.
+* The `KubeMacPoolDuplicateMacsFound` alert is link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/KubeMacPoolDuplicateMacsFound.md[deprecated].
 
 [id="virt-runbook-KubeVirtComponentExceedsRequestedCPU"]
 == KubeVirtComponentExceedsRequestedCPU
@@ -129,7 +129,7 @@ follow the procedures in the runbooks.
 [id="virt-runbook-KubevirtVmHighMemoryUsage"]
 == KubevirtVmHighMemoryUsage
 
-* link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/KubevirtVmHighMemoryUsage.md[View the runbook] for the `KubevirtVmHighMemoryUsage` alert.
+* The `KubevirtVmHighMemoryUsage` alert is link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/KubevirtVmHighMemoryUsage.md[deprecated].
 
 [id="virt-runbook-KubeVirtVMIExcessiveMigrations"]
 == KubeVirtVMIExcessiveMigrations
@@ -199,7 +199,7 @@ follow the procedures in the runbooks.
 [id="virt-runbook-SingleStackIPv6Unsupported"]
 == SingleStackIPv6Unsupported
 
-* link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/SingleStackIPv6Unsupported.md[View the runbook] for the `SingleStackIPv6Unsupported` alert.
+* The `SingleStackIPv6Unsupported` alert is link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/SingleStackIPv6Unsupported.md[deprecated].
 
 [id="virt-runbook-SSPCommonTemplatesModificationReverted"]
 == SSPCommonTemplatesModificationReverted
@@ -244,7 +244,7 @@ follow the procedures in the runbooks.
 [id="virt-runbook-VirtApiRESTErrorsHigh"]
 == VirtApiRESTErrorsHigh
 
-* link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/VirtApiRESTErrorsHigh.md[View the runbook] for the `VirtApiRESTErrorsHigh` alert.
+* The `VirtApiRESTErrorsHigh` alert is link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/VirtApiRESTErrorsHigh.md[deprecated].
 
 [id="virt-runbook-VirtControllerDown"]
 == VirtControllerDown
@@ -259,7 +259,7 @@ follow the procedures in the runbooks.
 [id="virt-runbook-VirtControllerRESTErrorsHigh"]
 == VirtControllerRESTErrorsHigh
 
-* link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/VirtControllerRESTErrorsHigh.md[View the runbook] for the `VirtControllerRESTErrorsHigh` alert.
+* The `VirtControllerRESTErrorsHigh` alert is link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/VirtControllerRESTErrorsHigh.md[deprecated].
 
 [id="virt-runbook-VirtHandlerDaemonSetRolloutFailing"]
 == VirtHandlerDaemonSetRolloutFailing
@@ -274,7 +274,7 @@ follow the procedures in the runbooks.
 [id="virt-runbook-VirtHandlerRESTErrorsHigh"]
 == VirtHandlerRESTErrorsHigh
 
-* link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/VirtHandlerRESTErrorsHigh.md[View the runbook] for the `VirtHandlerRESTErrorsHigh` alert.
+* The `VirtHandlerRESTErrorsHigh` alert is link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/VirtHandlerRESTErrorsHigh.md[deprecated].
 
 [id="virt-runbook-VirtOperatorDown"]
 == VirtOperatorDown
@@ -289,12 +289,12 @@ follow the procedures in the runbooks.
 [id="virt-runbook-VirtOperatorRESTErrorsHigh"]
 == VirtOperatorRESTErrorsHigh
 
-* link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/VirtOperatorRESTErrorsHigh.md[View the runbook] for the `VirtOperatorRESTErrorsHigh` alert.
+* The `VirtOperatorRESTErrorsHigh` alert is link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/VirtOperatorRESTErrorsHigh.md[deprecated].
 
 [id="virt-runbook-VirtualMachineCRCErrors"]
 == VirtualMachineCRCErrors
 
-* The runbook for the `VirtualMachineCRCErrors` alert is deprecated because the alert was renamed to `VMStorageClassWarning`. 
+* The runbook for the `VirtualMachineCRCErrors` alert is deprecated because the alert was renamed to `VMStorageClassWarning`.
 ** link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/VMStorageClassWarning.md[View the runbook] for the `VMStorageClassWarning` alert.
 
 [id="virt-runbook-VMCannotBeEvicted"]


### PR DESCRIPTION
Backporting only the deprecated alerts from : https://github.com/openshift/openshift-docs/pull/105845

These have all been QE approved and peer reviewed.