### PR TITLE
OSDOCS-16873-2: CQA CQA 2.0 for SCALE-3 Low-Latency/CNF Provisioning

### DIFF
--- a/modules/apply-performance-profile-hosted-cluster.adoc
+++ b/modules/apply-performance-profile-hosted-cluster.adoc
@@ -6,7 +6,10 @@
 [id="apply-performance-profile-hosted-cluster_{context}"]
 = Configuring low-latency tuning in a hosted cluster
 
-To set low latency with the performance profile on the nodes in your hosted cluster, you can use the Node Tuning Operator. In {hcp}, you can configure low-latency tuning by creating config maps that contain `Tuned` objects and referencing those config maps in your node pools. The tuned object in this case is a `PerformanceProfile` object that defines the performance profile you want to apply to the nodes in a node pool.
+[role="_abstract"]
+To set low latency with the performance profile on the nodes in your hosted cluster, you can use the Node Tuning Operator. In {hcp}, you can configure low-latency tuning by creating config maps that contain `Tuned` objects and referencing those config maps in your node pools. 
+
+The tuned object in this case is a `PerformanceProfile` object that defines the performance profile you want to apply to the nodes in a node pool.
 
 .Procedure
 

--- a/modules/cnf-about-irq-affinity-setting.adoc
+++ b/modules/cnf-about-irq-affinity-setting.adoc
@@ -7,7 +7,8 @@
 [id="about_irq_affinity_setting_{context}"]
 = Finding the effective IRQ affinity setting for a node
 
-Some IRQ controllers lack support for IRQ affinity setting and will always expose all online CPUs as the IRQ mask. These IRQ controllers effectively run on CPU 0.
+[role="_abstract"]
+To verify actual interrupt handling, determine the effective IRQ affinity setting for a node. Some IRQ controllers do not support affinity settings and effectively run on CPU 0, even when the IRQ mask exposes all online CPUs.
 
 The following are examples of drivers and hardware that Red Hat are aware lack support for IRQ affinity setting. The list is, by no means, exhaustive:
 
@@ -61,4 +62,4 @@ $ find /proc/irq -name effective_affinity -printf "%p: " -exec cat {} \;
 /proc/irq/34/effective_affinity: 2
 ----
 
-Some drivers use `managed_irqs`, whose affinity is managed internally by the kernel and userspace cannot change the affinity. In some cases, these IRQs might be assigned to isolated CPUs. For more information about `managed_irqs`, see link:https://access.redhat.com/solutions/4819541[Affinity of managed interrupts cannot be changed even if they target isolated CPU].
+Some drivers use `managed_irqs`, whose affinity is managed internally by the kernel and userspace cannot change the affinity. In some cases, these IRQs might be assigned to isolated CPUs. For more information about `managed_irqs`, see "Affinity of managed interrupts cannot be changed even if they target isolated CPU".

--- a/modules/cnf-about-the-profile-creator-tool.adoc
+++ b/modules/cnf-about-the-profile-creator-tool.adoc
@@ -6,7 +6,8 @@
 [id="cnf-about-the-profile-creator-tool_{context}"]
 = About the Performance Profile Creator
 
-The Performance Profile Creator (PPC) is a command-line tool, delivered with the Node Tuning Operator, that can help you to create a performance profile for your cluster.
+[role="_abstract"]
+The Performance Profile Creator (PPC) is a command-line tool and is delivered with the Node Tuning Operator. You can use the PPC CLI to create a performance profile for your cluster.
 
 Initially, you can use the PPC tool to process the `must-gather` data to display key performance configurations for your cluster, including the following information:
 
@@ -15,7 +16,6 @@ Initially, you can use the PPC tool to process the `must-gather` data to display
 
 You can use this information to help you configure the performance profile.
 
-.Running the PPC
 Specify performance configuration arguments to the PPC tool to generate a proposed performance profile that is appropriate for your hardware, topology, and use-case.
 
 You can run the PPC by using one of the following methods:

--- a/modules/cnf-adjusting-nic-queues-with-the-performance-profile.adoc
+++ b/modules/cnf-adjusting-nic-queues-with-the-performance-profile.adoc
@@ -6,7 +6,10 @@
 [id="adjusting-nic-queues-with-the-performance-profile_{context}"]
 = Adjusting the NIC queues with the performance profile
 
-The performance profile lets you adjust the queue count for each network device.
+[role="_abstract"]
+To optimize network traffic handling, adjust the queue count for each network device by using the performance profile. By using this configuration, you can tune your network settings to meet specific workload requirements.
+
+You can use a performance profile to adjust the queue count for each network device.
 
 Supported network devices:
 
@@ -25,7 +28,7 @@ Unsupported network devices:
 .Prerequisites
 
 * Access to the cluster as a user with the `cluster-admin` role.
-* Install the OpenShift CLI (`oc`).
+* Install the {oc-first}.
 
 .Procedure
 
@@ -73,6 +76,7 @@ spec:
     userLevelNetworking: true
   nodeSelector:
     node-role.kubernetes.io/worker-cnf: ""
+# ...
 ----
 
 . Set the queue count to the reserved CPU count for all devices matching any of the defined device identifiers by using this example performance profile:
@@ -96,6 +100,7 @@ spec:
       deviceID: "0x1000"
   nodeSelector:
     node-role.kubernetes.io/worker-cnf: ""
+# ...
 ----
 
 . Set the queue count to the reserved CPU count for all devices starting with the interface name `eth` by using this example performance profile:
@@ -116,6 +121,7 @@ spec:
     - interfaceName: "eth*"
   nodeSelector:
     node-role.kubernetes.io/worker-cnf: ""
+# ...
 ----
 
 . Set the queue count to the reserved CPU count for all devices with an interface named anything other than `eno1` by using this example performance profile:
@@ -136,6 +142,7 @@ spec:
     - interfaceName: "!eno1"
   nodeSelector:
     node-role.kubernetes.io/worker-cnf: ""
+# ...
 ----
 
 . Set the queue count to the reserved CPU count for all devices that have an interface name `eth0`, `vendorID` of `0x1af4`, and `deviceID` of `0x1000` by using this example performance profile:
@@ -158,6 +165,7 @@ spec:
       deviceID: "0x1000"
   nodeSelector:
     node-role.kubernetes.io/worker-cnf: ""
+# ...
 ----
 
 . Apply the updated performance profile:

--- a/modules/cnf-allocating-multiple-huge-page-sizes.adoc
+++ b/modules/cnf-allocating-multiple-huge-page-sizes.adoc
@@ -3,15 +3,26 @@
 // * scalability_and_performance/cnf-low-latency-tuning.adoc
 // * scalability_and_performance/low_latency_tuning/cnf-tuning-low-latency-nodes-with-perf-profile.adoc
 
+:_mod-docs-content-type: PROCEDURE
 [id="cnf-allocating-multiple-huge-page-sizes_{context}"]
 = Allocating multiple huge page sizes
 
-You can request huge pages with different sizes under the same container. This allows you to define more complicated pods consisting of containers with different huge page size needs.
+[role="_abstract"]
+You can request huge pages with different sizes under the same container. By doing this task, you can define more complicated pods consisting of containers with different huge page size needs.
 
-For example, you can define sizes `1G` and `2M` and the Node Tuning Operator will configure both sizes on the node, as shown here:
+The following example, shows you how to define sizes `1G` and `2M`. The Node Tuning Operator configures both sizes on the node.
 
+.Procedure
+
+* Edit the `PerformanceProfile` object to define `1G` and `2M` sizes for the huge pages. The Node Tuning Operator configues both sizes on the node.
++
 [source,yaml]
 ----
+apiVersion: performance.openshift.io/v2
+kind: PerformanceProfile
+metadata:
+    name: example-performance-profile
+#...
 spec:
   hugepages:
     defaultHugepagesSize: 1G
@@ -22,4 +33,5 @@ spec:
     - count: 4
       node: 1
       size: 1G
+# ...
 ----

--- a/modules/cnf-configure_for_irq_dynamic_load_balancing.adoc
+++ b/modules/cnf-configure_for_irq_dynamic_load_balancing.adoc
@@ -6,7 +6,8 @@
 [id="configuring_for_irq_dynamic_load_balancing_{context}"]
 = Configuring node interrupt affinity
 
-Configure a cluster node for IRQ dynamic load balancing to control which cores can receive device interrupt requests (IRQ).
+[role="_abstract"]
+To control which cores receive device interrupt requests (IRQ), configure IRQ dynamic load balancing on a cluster node. With this configuration, you can isolate interrupt handling to specific CPUs, ensuring consistent performance for latency-sensitive workloads.
 
 .Prerequisites
 
@@ -15,8 +16,11 @@ Configure a cluster node for IRQ dynamic load balancing to control which cores c
 .Procedure
 
 . Log in to the {product-title} cluster as a user with cluster-admin privileges.
+
 . Set the performance profile `apiVersion` to use `performance.openshift.io/v2`.
+
 . Remove the `globallyDisableIrqLoadBalancing` field or set it to `false`.
+
 . Set the appropriate isolated and reserved CPUs. The following snippet illustrates a profile that reserves 2 CPUs. IRQ load-balancing is enabled for pods running on the `isolated` CPU set:
 +
 [source,yaml]

--- a/modules/cnf-configuring-huge-pages.adoc
+++ b/modules/cnf-configuring-huge-pages.adoc
@@ -3,15 +3,20 @@
 // * scalability_and_performance/cnf-low-latency-tuning.adoc
 // * scalability_and_performance/low_latency_tuning/cnf-tuning-low-latency-nodes-with-perf-profile.adoc
 
+:_mod-docs-content-type: PROCEDURE
 [id="cnf-configuring-huge-pages_{context}"]
 = Configuring huge pages
 
-Nodes must pre-allocate huge pages used in an {product-title} cluster. Use the Node Tuning Operator to allocate huge pages on a specific node.
+[role="_abstract"]
+To pre-allocate huge pages on a specific node, use the Node Tuning Operator. This configuration ensures that your {product-title} cluster reserves the necessary memory resources for workloads that require them.
 
 {product-title} provides a method for creating and allocating huge pages. Node Tuning Operator provides an easier method for doing  this using the performance profile.
 
-For example, in the `hugepages` `pages` section of the performance profile, you can specify multiple blocks of `size`, `count`, and, optionally, `node`:
+.Procedure
 
+* In the `hugepages.pages` section of the performance profile, specify multiple blocks of `size`, `count`, and, optionally, `node`:
++
+.Example configuration
 [source,yaml]
 ----
 hugepages:
@@ -19,18 +24,20 @@ hugepages:
    pages:
    - size:  "1G"
      count:  4
-     node:  0 <1>
+     node:  0
+# ...
 ----
-
-<1> `node` is the NUMA node in which the huge pages are allocated. If you omit `node`, the pages are evenly spread across all NUMA nodes.
-
++
+where:
++
+`hugepages.pages.node`:: Specifies the `node` that is the NUMA node in which the huge pages are allocated. If you omit `node`, the pages are evenly spread across all NUMA nodes.
++
 [NOTE]
 ====
 Wait for the relevant machine config pool status that indicates the update is finished.
 ====
-
++
 These are the only configuration steps you need to do to allocate huge pages.
-
 
 .Verification
 

--- a/modules/cnf-configuring-hyperthreading-for-a-cluster.adoc
+++ b/modules/cnf-configuring-hyperthreading-for-a-cluster.adoc
@@ -6,6 +6,7 @@
 [id="cnf-configuring-hyperthreading-for-a-cluster_{context}"]
 = Configuring Hyper-Threading for a cluster
 
+[role="_abstract"]
 To configure Hyper-Threading for an {product-title} cluster, set the CPU threads in the performance profile to the same cores that are configured for the reserved or isolated CPU pools.
 
 [NOTE]
@@ -21,7 +22,7 @@ Disabling a previously enabled host Hyper-Threading configuration can cause the 
 .Prerequisites
 
 * Access to the cluster as a user with the `cluster-admin` role.
-* Install the OpenShift CLI (oc).
+* Install the {oc-first}.
 
 .Procedure
 
@@ -35,7 +36,6 @@ $ lscpu --all --extended
 ----
 +
 .Example output
-+
 [source,terminal]
 ----
 CPU NODE SOCKET CORE L1d:L1i:L2:L3 ONLINE MAXMHZ    MINMHZ
@@ -49,9 +49,7 @@ CPU NODE SOCKET CORE L1d:L1i:L2:L3 ONLINE MAXMHZ    MINMHZ
 7   0    0      3    3:3:3:0       yes    4800.0000 400.0000
 ----
 +
-In this example, there are eight logical CPU cores running on four physical CPU cores. CPU0 and CPU4 are running on physical Core0, CPU1 and CPU5 are running on physical Core 1, and so on.
-+
-Alternatively, to view the threads that are set for a particular physical CPU core (`cpu0` in the example below), open a shell prompt and run the following:
+In this example, there are eight logical CPU cores running on four physical CPU cores. CPU0 and CPU4 are running on physical Core0, CPU1 and CPU5 are running on physical Core 1, and so on. Alternatively, to view the threads that are set for a particular physical CPU core (`cpu0` in the example below), open a shell prompt and run the following:
 +
 [source,terminal]
 ----
@@ -59,7 +57,6 @@ $ cat /sys/devices/system/cpu/cpu0/topology/thread_siblings_list
 ----
 +
 .Example output
-+
 [source,terminal]
 ----
 0-4
@@ -80,54 +77,11 @@ $ cat /sys/devices/system/cpu/cpu0/topology/thread_siblings_list
 ====
 The reserved and isolated CPU pools must not overlap and together must span all available cores in the worker node.
 ====
-
++
 [IMPORTANT]
 ====
 Hyper-Threading is enabled by default on most Intel processors. If you enable Hyper-Threading, all threads processed by a particular core must be isolated or processed on the same core.
 
 When Hyper-Threading is enabled, all guaranteed pods must use multiples of the simultaneous multi-threading (SMT) level to avoid a "noisy neighbor" situation that can cause the pod to fail.
 See link:https://kubernetes.io/docs/tasks/administer-cluster/cpu-management-policies/#static-policy-options[Static policy options] for more information.
-====
-
-[id="disabling_hyperthreading_for_low_latency_applications_{context}"]
-== Disabling Hyper-Threading for low latency applications
-
-When configuring clusters for low latency processing, consider whether you want to disable Hyper-Threading before you deploy the cluster. To disable Hyper-Threading, perform the following steps:
-
-. Create a performance profile that is appropriate for your hardware and topology.
-. Set `nosmt` as an additional kernel argument. The following example performance profile illustrates this setting:
-+
-[source,yaml]
-----
-apiVersion: performance.openshift.io/v2
-kind: PerformanceProfile
-metadata:
-  name: example-performanceprofile
-spec:
-  additionalKernelArgs:
-    - nmi_watchdog=0
-    - audit=0
-    - mce=off
-    - processor.max_cstate=1
-    - idle=poll
-    - intel_idle.max_cstate=0
-    - nosmt
-  cpu:
-    isolated: 2-3
-    reserved: 0-1
-  hugepages:
-    defaultHugepagesSize: 1G
-    pages:
-      - count: 2
-        node: 0
-        size: 1G
-  nodeSelector:
-    node-role.kubernetes.io/performance: ''
-  realTimeKernel:
-    enabled: true
-----
-+
-[NOTE]
-====
-When you configure reserved and isolated CPUs, the infra containers in pods use the reserved CPUs and the application containers use the isolated CPUs.
 ====

--- a/modules/cnf-configuring-power-saving-for-nodes.adoc
+++ b/modules/cnf-configuring-power-saving-for-nodes.adoc
@@ -6,6 +6,7 @@
 [id="cnf-configuring-power-saving-for-nodes_{context}"]
 = Configuring power saving for nodes that run colocated high and low priority workloads
 
+[role="_abstract"]
 You can enable power savings for a node that has low priority workloads that are colocated with high priority workloads without impacting the latency or throughput of the high priority workloads. Power saving is possible without modifications to the workloads themselves.
 
 [IMPORTANT]
@@ -27,14 +28,13 @@ $ podman run --entrypoint performance-profile-creator -v \
 /must-gather:/must-gather:z registry.redhat.io/openshift4/ose-cluster-node-tuning-rhel9-operator:v{product-version} \
 --mcp-name=worker-cnf --reserved-cpu-count=20 --rt-kernel=true \
 --split-reserved-cpus-across-numa=false --topology-manager-policy=single-numa-node \
---must-gather-dir-path /must-gather --power-consumption-mode=low-latency \ <1>
+--must-gather-dir-path /must-gather --power-consumption-mode=low-latency \
 --per-pod-power-management=true > my-performance-profile.yaml
 ----
-<1> The `power-consumption-mode` argument must be `default` or `low-latency` when the `per-pod-power-management` argument is set to `true`.
-
++
+The `power-consumption-mode` argument must be `default` or `low-latency` when the `per-pod-power-management` argument is set to `true`.
 +
 .Example `PerformanceProfile` with `perPodPowerManagement`
-
 [source,yaml]
 ----
 apiVersion: performance.openshift.io/v2
@@ -47,6 +47,7 @@ spec:
         realTime: true
         highPowerConsumption: false
         perPodPowerManagement: true
+# ...
 ----
 
 . Set the default `cpufreq` governor as an additional kernel argument in the `PerformanceProfile` custom resource (CR):
@@ -60,9 +61,13 @@ metadata:
 spec:
     ...
     additionalKernelArgs:
-    - cpufreq.default_governor=schedutil <1>
+    - cpufreq.default_governor=schedutil
+# ...
 ----
-<1> Using the `schedutil` governor is recommended, however, you can use other governors such as the `ondemand` or `powersave` governors.
++
+where:
++
+`cpufreq.default_governor=schedutil`:: Specifies using the `schedutil` governor. You can use other governors, such as the `ondemand` or `powersave` governors.
 
 . Set the maximum CPU frequency in the `TunedPerformancePatch` CR:
 +
@@ -72,6 +77,9 @@ spec:
   profile:
   - data: |
       [sysfs]
-      /sys/devices/system/cpu/intel_pstate/max_perf_pct = <x> <1>
+      /sys/devices/system/cpu/intel_pstate/max_perf_pct = <x>
 ----
-<1> The `max_perf_pct` controls the maximum frequency that the `cpufreq` driver is allowed to set as a percentage of the maximum supported cpu frequency. This value applies to all CPUs. You can check the maximum supported frequency in `/sys/devices/system/cpu/cpu0/cpufreq/cpuinfo_max_freq`. As a starting point, you can use a percentage that caps all CPUs at the `All Cores Turbo` frequency. The `All Cores Turbo` frequency is the frequency that all cores will run at when the cores are all fully occupied.
++
+where:
++
+`/sys/devices/system/cpu/intel_pstate/max_perf_pct`:: Specifies the `max_perf_pct` that controls the maximum frequency that the `cpufreq` driver is allowed to set as a percentage of the maximum supported cpu frequency. This value applies to all CPUs. You can check the maximum supported frequency in `/sys/devices/system/cpu/cpu0/cpufreq/cpuinfo_max_freq`. As a starting point, you can use a percentage that caps all CPUs at the `All Cores Turbo` frequency. The `All Cores Turbo` frequency is the frequency that all cores will run at when the cores are all fully occupied.

--- a/modules/cnf-configuring-workload-hints.adoc
+++ b/modules/cnf-configuring-workload-hints.adoc
@@ -3,13 +3,14 @@
 // * scalability_and_performance/cnf-low-latency-tuning.adoc
 // * scalability_and_performance/low_latency_tuning/cnf-tuning-low-latency-nodes-with-perf-profile.adoc
 
-:_mod-docs-content-type: CONCEPT
+:_mod-docs-content-type: REFERENCE
 [id="configuring-workload-hints_{context}"]
-= Configuring node power consumption and realtime processing with workload hints
+= Node power consumption and realtime processing with workload hints
 
-.Procedure
+[role="_abstract"]
+You can create a performance profile appropriate for the hardware and topology of an environment by using the Performance Profile Creator (PPC) tool. 
 
-* Create a `PerformanceProfile` appropriate for the environment's hardware and topology by using the Performance Profile Creator (PPC) tool. The following table describes the possible values set for the `power-consumption-mode` flag associated with the PPC tool and the workload hint that is applied. 
+The following table describes the possible values set for the `power-consumption-mode` flag associated with the PPC tool and the workload hint that is applied. 
 
 .Impact of combinations of power consumption and real-time settings on latency
 [cols="1,1,1,1",options="header"]
@@ -58,9 +59,7 @@ perPodPowerManagement: true
 |Allows for power management per pod.
 |===
 
-.Example
-
-The following configuration is commonly used in a telco RAN DU deployment. 
+The following configuration is commonly used in a telco RAN DU deployment:
 
 [source,yaml]
 ----
@@ -73,13 +72,13 @@ The following configuration is commonly used in a telco RAN DU deployment.
       workloadHints:
         realTime: true
         highPowerConsumption: false
-        perPodPowerManagement: false <1>
+        perPodPowerManagement: false
 ----
-<1> Disables some debugging and monitoring features that can affect system latency.
+`perPodPowerManagement`:: Specifies to disable some debugging and monitoring features that can affect system latency.
 
 [NOTE]
 ====
 When the `realTime` workload hint flag is set to `true` in a performance profile, add the `cpu-quota.crio.io: disable` annotation to every guaranteed pod with pinned CPUs. This annotation is necessary to prevent the degradation of the process performance within the pod. If the `realTime` workload hint is not explicitly set, it defaults to `true`.
 ====
 
-For more information how combinations of power consumption and real-time settings impact latency, see link:https://access.redhat.com/articles/7081587[Understanding workload hints].
+For more information how combinations of power consumption and real-time settings impact latency, see "Understanding workload hints".

--- a/modules/cnf-cpu-infra-container.adoc
+++ b/modules/cnf-cpu-infra-container.adoc
@@ -5,9 +5,12 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="cnf-cpu-infra-container_{context}"]
-= Restricting CPUs for infra and application containers
+= CPUs for infra and application containers
 
-Generic housekeeping and workload tasks use CPUs in a way that may impact latency-sensitive processes. By default, the container runtime uses all online CPUs to run all containers together, which can result in context switches and spikes in latency. Partitioning the CPUs prevents noisy processes from interfering with latency-sensitive processes by separating them from each other. The following table describes how processes run on a CPU after you have tuned the node using the Node Tuning Operator:
+[role="_abstract"]
+Generic housekeeping and workload tasks use CPUs in a way that might impact latency-sensitive processes. By default, the container runtime uses all online CPUs to run all containers together, which can result in context switches and spikes in latency. 
+
+Partitioning the CPUs prevents noisy processes from interfering with latency-sensitive processes by separating them from each other. The following table describes how processes run on a CPU after you have tuned the node using the Node Tuning Operator:
 
 .Process' CPU assignments
 [%header,cols=2*]
@@ -36,12 +39,13 @@ Generic housekeeping and workload tasks use CPUs in a way that may impact latenc
 
 The allocatable capacity of cores on a node for pods of all QoS process types, `Burstable`,  `BestEffort`, or `Guaranteed`, is equal to the capacity of the isolated pool. The capacity of the reserved pool is removed from the node's total core capacity for use by the cluster and operating system housekeeping duties.
 
-.Example 1
+Example 1:: 
+
 A node features a capacity of 100 cores. Using a performance profile, the cluster administrator allocates 50 cores to the isolated pool and 50 cores to the reserved pool. The cluster administrator assigns 25 cores to QoS `Guaranteed` pods and 25 cores for `BestEffort` or `Burstable` pods. This matches the capacity of the isolated pool.
 
-.Example 2
-A node features a capacity of 100 cores. Using a performance profile, the cluster administrator allocates 50 cores to the isolated pool and 50 cores to the reserved pool. The cluster administrator assigns 50 cores to QoS `Guaranteed` pods and one core for `BestEffort` or `Burstable` pods. This exceeds the capacity of the isolated pool by one core. Pod scheduling fails because of insufficient CPU capacity.
+Example 2:: 
 
+A node features a capacity of 100 cores. Using a performance profile, the cluster administrator allocates 50 cores to the isolated pool and 50 cores to the reserved pool. The cluster administrator assigns 50 cores to QoS `Guaranteed` pods and one core for `BestEffort` or `Burstable` pods. This exceeds the capacity of the isolated pool by one core. Pod scheduling fails because of insufficient CPU capacity.
 
 The exact partitioning pattern to use depends on many factors like hardware, workload characteristics and the expected system load. Some sample use cases are as follows:
 
@@ -61,26 +65,3 @@ To ensure that housekeeping tasks and workloads do not interfere with each other
 * `isolated` - Specifies the CPUs for the application container workloads. These CPUs have the lowest latency. Processes in this group have no interruptions and can, for example, reach much higher DPDK zero packet loss bandwidth.
 
 * `reserved` - Specifies the CPUs for the cluster and operating system housekeeping duties. Threads in the `reserved` group are often busy. Do not run latency-sensitive applications in the `reserved` group. Latency-sensitive applications run in the `isolated` group.
-
-.Procedure
-
-. Create a performance profile appropriate for the environment's hardware and topology.
-
-. Add the `reserved` and `isolated` parameters with the CPUs you want reserved and isolated for the infra and application containers:
-+
-[source,yaml]
-----
-﻿apiVersion: performance.openshift.io/v2
-kind: PerformanceProfile
-metadata:
-  name: infra-cpus
-spec:
-  cpu:
-    reserved: "0-4,9" <1>
-    isolated: "5-8" <2>
-  nodeSelector: <3>
-    node-role.kubernetes.io/worker: ""
-----
-<1> Specify which CPUs are for infra containers to perform cluster and operating system housekeeping duties.
-<2> Specify which CPUs are for application containers to run workloads.
-<3> Optional: Specify a node selector to apply the performance profile to specific nodes.

--- a/modules/cnf-create-performance-profiles-hosted-cp.adoc
+++ b/modules/cnf-create-performance-profiles-hosted-cp.adoc
@@ -1,0 +1,16 @@
+// Module included in the following assemblies:
+//
+// * scalability_and_performance/low_latency_tuning/cnf-tuning-low-latency-nodes-with-perf-profile.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="cnf-create-performance-profiles-hosted-cp_{context}"]
+= Creating a performance profile for hosted control planes
+
+[role="_abstract"]
+You can create a cluster performance profile by using the Performance Profile Creator (PPC) tool. The PPC is a function of the Node Tuning Operator. 
+
+The PPC combines information about your cluster with user-supplied configurations to generate a performance profile that is appropriate to your hardware, topology, and use-case. The following high-level workflow creates and applys a performance profile in your cluster:
+
+. Gather information about your cluster by using the `must-gather` command.
+. Use the PPC tool to create a performance profile.
+. Apply the performance profile to your cluster.

--- a/modules/cnf-create-performance-profiles.adoc
+++ b/modules/cnf-create-performance-profiles.adoc
@@ -1,0 +1,31 @@
+// Module included in the following assemblies:
+//
+// * scalability_and_performance/low_latency_tuning/cnf-tuning-low-latency-nodes-with-perf-profile.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="cnf-create-performance-profiles_{context}"]
+= Creating a performance profile
+
+[role="_abstract"]
+You can create a cluster performance profile by using the Performance Profile Creator (PPC) tool. The PPC is a function of the Node Tuning Operator. 
+
+The PPC combines information about your cluster with user-supplied configurations to generate a performance profile that is appropriate to your hardware, topology and use-case.
+
+[NOTE]
+====
+Performance profiles are applicable only to bare-metal environments where the cluster has direct access to the underlying hardware resources. You can configure performances profiles for both {sno} and multi-node clusters.
+====
+
+The following is a high-level workflow for creating and applying a performance profile in your cluster:
+
+* Create a machine config pool (MCP) for nodes that you want to target with performance configurations. In {sno} clusters, you must use the `master` MCP because there is only one node in the cluster.
+
+* Gather information about your cluster using the `must-gather` command.
+
+* Use the PPC tool to create a performance profile by using either of the following methods:
+
+** Run the PPC tool by using Podman as described in _Running the Performance Profile Creator using Podman_. . 
+
+** Run the PPC tool by using a wrapper script as described in _Running the Performance Profile Creator wrapper script_..
+
+* Configure the performance profile for your use case and apply the performance profile to your cluster.

--- a/modules/cnf-creating-mcp-for-ppc.adoc
+++ b/modules/cnf-creating-mcp-for-ppc.adoc
@@ -6,6 +6,7 @@
 [id="creating-mcp-for-ppc_{context}"]
 = Creating a machine config pool to target nodes for performance tuning
 
+[role="_abstract"]
 For multi-node clusters, you can define a machine config pool (MCP) to identify the target nodes that you want to configure with a performance profile. 
 
 In {sno} clusters, you must use the `master` MCP because there is only one node in the cluster. You do not need to create a separate MCP for {sno} clusters.
@@ -13,7 +14,7 @@ In {sno} clusters, you must use the `master` MCP because there is only one node 
 .Prerequisites
 
 * You have `cluster-admin` role access.
-* You installed the OpenShift CLI (`oc`).
+* You installed the {oc-first}.
 
 .Procedure
 
@@ -21,12 +22,12 @@ In {sno} clusters, you must use the `master` MCP because there is only one node 
 +
 [source,terminal]
 ----
-$ oc label node <node_name> node-role.kubernetes.io/worker-cnf="" <1>
+$ oc label node <node_name> node-role.kubernetes.io/worker-cnf=""
 ----
-<1> Replace `<node_name>` with the name of your node. This example applies the `worker-cnf` label.
+** `<node_name>`: Specifies the name of your node. This example applies the `worker-cnf` label.
 
 . Create a `MachineConfigPool` resource containing the target nodes:
-
++
 .. Create a YAML file that defines the `MachineConfigPool` resource:
 +
 .Example `mcp-worker-cnf.yaml` file
@@ -35,9 +36,9 @@ $ oc label node <node_name> node-role.kubernetes.io/worker-cnf="" <1>
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfigPool
 metadata:
-  name: worker-cnf <1>
+  name: worker-cnf
   labels:
-    machineconfiguration.openshift.io/role: worker-cnf <2>
+    machineconfiguration.openshift.io/role: worker-cnf
 spec:
   machineConfigSelector:
     matchExpressions:
@@ -49,12 +50,19 @@ spec:
   paused: false
   nodeSelector:
     matchLabels:
-      node-role.kubernetes.io/worker-cnf: "" <3>
+      node-role.kubernetes.io/worker-cnf: ""
 ----
-<1> Specify a name for the `MachineConfigPool` resource.
-<2> Specify a unique label for the machine config pool.
-<3> Specify the nodes with the target label that you defined.
++
+--
+where:
 
+`metadata.name`:: Specifies a name for the `MachineConfigPool` resource.
+
+`machineconfiguration.openshift.io/role`:: Specifes a unique label for the machine config pool.
+
+`node-role.kubernetes.io/worker-cnf`:: Specifies the nodes with the target label that you defined.
+--
++
 .. Apply the `MachineConfigPool` resource by running the following command:
 +
 [source,terminal]

--- a/modules/cnf-gathering-data-about-cluster-using-must-gather.adoc
+++ b/modules/cnf-gathering-data-about-cluster-using-must-gather.adoc
@@ -6,12 +6,13 @@
 [id="gathering-data-about-your-cluster-using-must-gather_{context}"]
 = Gathering data about your cluster for the PPC
 
+[role="_abstract"]
 The Performance Profile Creator (PPC) tool requires `must-gather` data. As a cluster administrator, run the `must-gather` command to capture information about your cluster.
 
 .Prerequisites
 
 * Access to the cluster as a user with the `cluster-admin` role.
-* You installed the OpenShift CLI (`oc`).
+* You installed the {oc-first}.
 * You identified a target MCP that you want to configure with a performance profile.
 
 .Procedure
@@ -31,9 +32,9 @@ The command creates a folder with the `must-gather` data in your local directory
 +
 [source,terminal]
 ----
-$ tar cvaf must-gather.tar.gz <must_gather_folder> <1>
+$ tar cvaf must-gather.tar.gz <must_gather_folder>
 ----
-<1> Replace with the name of the `must-gather` data folder.
+** `<must_gather_folder>`: Specifies the name of the `must-gather` data folder.
 +
 [NOTE]
 ====

--- a/modules/cnf-gathering-data-about-hosted-cluster-using-must-gather.adoc
+++ b/modules/cnf-gathering-data-about-hosted-cluster-using-must-gather.adoc
@@ -6,6 +6,7 @@
 [id="gathering-data-about-your-hosted-cluster-using-must-gather_{context}"]
 = Gathering data about your hosted control planes cluster for the PPC
 
+[role="_abstract"]
 The Performance Profile Creator (PPC) tool requires `must-gather` data. As a cluster administrator, run the `must-gather` command to capture information about your cluster.
 
 .Prerequisites
@@ -36,9 +37,9 @@ NAMESPACE   NAME                     CLUSTER       DESIRED NODES   CURRENT NODES
 clusters    democluster-us-east-1a   democluster   1               1               False         False        4.17.0    False             True                          
 ----
 +
-* The output shows the namespace `clusters` in the management cluster where the `NodePool` resource is defined.
-* The name of the `NodePool` resource, for example `democluster-us-east-1a`.
-* The `HostedCluster` this `NodePool` belongs to. For example, `democluster`.
+** The output shows the namespace `clusters` in the management cluster where the `NodePool` resource is defined.
+** The name of the `NodePool` resource, for example `democluster-us-east-1a`.
+** The `HostedCluster` this `NodePool` belongs to. For example, `democluster`.
 
 .  On the management cluster, run the following command to list available secrets:
 +
@@ -74,7 +75,7 @@ $ oc get secret democluster-admin-kubeconfig -n clusters -o jsonpath='{.data.kub
 ----
 
 . To create a `must-gather` bundle for the hosted cluster, open a separate terminal window and run the following commands:
-
++
 .. Export the hosted cluster `kubeconfig` file:
 +
 [source,terminal]
@@ -87,16 +88,16 @@ $ export HC_KUBECONFIG=<path_to_hosted_cluster_kubeconfig>
 ----
 $ export HC_KUBECONFIG=~/hostedcpkube/hosted-cluster-kubeconfig
 ----
-
++
 .. Navigate to the directory where you want to store the `must-gather` data.
-
++
 .. Gather the troubleshooting data for your hosted cluster:
 +
 [source,terminal]
 ----
 $ oc --kubeconfig="$HC_KUBECONFIG" adm must-gather
 ----
-
++
 .. Create a compressed file from the `must-gather` directory that was just created in your working directory. For example, on a computer that uses a Linux operating system, run the following command:
 +
 [source,terminal]

--- a/modules/cnf-logging-associated-with-adjusting-nic-queues.adoc
+++ b/modules/cnf-logging-associated-with-adjusting-nic-queues.adoc
@@ -2,10 +2,14 @@
 //
 // * scalability_and_performance/low_latency_tuning/cnf-tuning-low-latency-nodes-with-perf-profile.adoc
 
+:_mod-docs-content-type: REFERENCE
 [id="logging-associated-with-adjusting-nic-queues_{context}"]
 = Logging associated with adjusting NIC queues
 
-Log messages detailing the assigned devices are recorded in the respective Tuned daemon logs. The following messages might be recorded to the `/var/log/tuned/tuned.log` file:
+[role="_abstract"]
+To verify NIC queue adjustments, review the Tuned daemon logs. These logs record messages detailing the assigned devices so that you can confirm that the system applied your configuration changes correctly.
+
+The following messages might be recorded to the `/var/log/tuned/tuned.log` file:
 
 * An `INFO` message is recorded detailing the successfully assigned devices:
 +
@@ -13,6 +17,7 @@ Log messages detailing the assigned devices are recorded in the respective Tuned
 ----
 INFO tuned.plugins.base: instance net_test (net): assigning devices ens1, ens2, ens3
 ----
+
 * A `WARNING` message is recorded if none of the devices can be assigned:
 +
 [source,terminal]

--- a/modules/cnf-managing-device-interrupt-processing-for-guaranteed-pod-isolated-cpus.adoc
+++ b/modules/cnf-managing-device-interrupt-processing-for-guaranteed-pod-isolated-cpus.adoc
@@ -2,10 +2,12 @@
 //
 // * scalability_and_performance/low_latency_tuning/cnf-tuning-low-latency-nodes-with-perf-profile.adoc
 
+:_mod-docs-content-type: CONCEPT
 [id="managing-device-interrupt-processing-for-guaranteed-pod-isolated-cpus_{context}"]
 = Managing device interrupt processing for guaranteed pod isolated CPUs
 
-The Node Tuning Operator can manage host CPUs by dividing them into reserved CPUs for cluster and operating system housekeeping duties, including pod infra containers, and isolated CPUs for application containers to run the workloads. This allows you to set CPUs for low latency workloads as isolated.
+[role="_abstract"]
+The Node Tuning Operator can manage host CPUs by dividing them into reserved CPUs for cluster and operating system housekeeping duties, including pod infra containers, and isolated CPUs for application containers to run the workloads. By completing these tasks, you can set CPUs for low-latency workloads as isolated workloads.
 
 Device interrupts are load balanced between all isolated and reserved CPUs to avoid CPUs being overloaded, with the exception of CPUs where there is a guaranteed pod running. Guaranteed pod CPUs are prevented from processing device interrupts when the relevant annotations are set for the pod.
 

--- a/modules/cnf-memory-optimization.adoc
+++ b/modules/cnf-memory-optimization.adoc
@@ -6,4 +6,5 @@
 [id="cnf-configuring-kernal-page-size_{context}"]
 = Configuring memory page sizes
 
+[role="_abstract"]
 By configuring memory page sizes, system administrators can implement more efficient memory management on a specific node to suit workload requirements. The Node Tuning Operator provides a method for configuring huge pages and kernel page sizes by using a performance profile.

--- a/modules/cnf-performance-profile-creator-arguments.adoc
+++ b/modules/cnf-performance-profile-creator-arguments.adoc
@@ -2,9 +2,12 @@
 //
 // * scalability_and_performance/low_latency_tuning/cnf-tuning-low-latency-nodes-with-perf-profile.adoc
 
-
+:_mod-docs-content-type: REFERENCE
 [id="performance-profile-creator-arguments_{context}"]
 = Performance Profile Creator arguments
+
+[role="_abstract"]
+To customize the generation of performance profiles, review the arguments for the Performance Profile Creator. By using these command-line options, you can define specific tuning parameters, such as CPU isolation and huge pages, to meet your workload requirements.
 
 .Required Performance Profile Creator arguments
 [cols="30%,70%",options="header"]

--- a/modules/cnf-running-the-performance-creator-profile-hosted.adoc
+++ b/modules/cnf-running-the-performance-creator-profile-hosted.adoc
@@ -6,6 +6,7 @@
 [id="running-the-performance-profile-profile-hosted-cluster-using-podman_{context}"]
 = Running the Performance Profile Creator on a hosted cluster using Podman
 
+[role="_abstract"]
 As a cluster administrator, you can use Podman with the Performance Profile Creator (PPC) tool to create a performance profile.
 
 For more information about PPC arguments, see "Performance Profile Creator arguments".
@@ -49,26 +50,36 @@ Password: <password>
 [source,terminal,subs="attributes+"]
 ----
 $ podman run --entrypoint performance-profile-creator \
-    -v /path/to/must-gather:/must-gather:z \// <1>
+    -v /path/to/must-gather:/must-gather:z \
     registry.redhat.io/openshift4/ose-cluster-node-tuning-rhel9-operator:v{product-version} \
     --must-gather-dir-path /must-gather \
-    --reserved-cpu-count=2 \// <2>
-    --rt-kernel=false \// <3>
-    --split-reserved-cpus-across-numa=false \ <4>
-    --topology-manager-policy=single-numa-node \// <5>
+    --reserved-cpu-count=2 \
+    --rt-kernel=false \
+    --split-reserved-cpus-across-numa=false \
+    --topology-manager-policy=single-numa-node \
     --node-pool-name=democluster-us-east-1a \ 
-    --power-consumption-mode=ultra-low-latency \// <6>
-    --offlined-cpu-count=1 \// <7>
+    --power-consumption-mode=ultra-low-latency \
+    --offlined-cpu-count=1 \
     > my-hosted-cp-performance-profile.yaml
 ----
 +
-<1> Mounts the local directory where the output of an `oc adm must-gather` was created into the container. 
-<2> Specifies two reserved CPUs.
-<3> Disables the real-time kernel.
-<4> Disables reserved CPUs splitting across NUMA nodes.
-<5> Specifies the NUMA topology policy. If installing the NUMA Resources Operator, this must be set to `single-numa-node`.
-<6> Specifies minimal latency at the cost of increased power consumption.
-<7> Specifies one offlined CPU.
+--
+where:
+
+`/path/to/must-gather:/must-gather:z`:: Specifies the local directory to mount where the output of an `oc adm must-gather` was created into the container. 
+
+`reserved-cpu-count=2`:: Specifies two reserved CPUs.
+
+`rt-kernel=false`:: Specifies whether to disable the real-time kernel. A setting of `false` disables the kernel.
+
+`split-reserved-cpus-across-numa=false`:: Specifies whether to split CPUs across NUMA nodes. A setting of `false` disables the CPU-splitting.
+
+`topology-manager-policy=single-numa-node`:: Specifies the NUMA topology policy. If installing the NUMA Resources Operator, this must be set to `single-numa-node`.
+
+`power-consumption-mode=ultra-low-latency`:: Specifies minimal latency at the cost of increased power consumption.
+
+`offlined-cpu-count=1`:: Specifies one offlined CPU.
+--
 +
 .Example output
 [source,terminal]

--- a/modules/cnf-running-the-performance-creator-profile-offline.adoc
+++ b/modules/cnf-running-the-performance-creator-profile-offline.adoc
@@ -6,9 +6,10 @@
 [id="running-the-performance-profile-creator-wrapper-script_{context}"]
 = Running the Performance Profile Creator wrapper script
 
+[role="_abstract"]
 The wrapper script simplifies the process of creating a performance profile with the Performance Profile Creator (PPC) tool. The script handles tasks such as pulling and running the required container image, mounting directories into the container, and providing parameters directly to the container through Podman.
 
-For more information about the Performance Profile Creator arguments, see the section _"Performance Profile Creator arguments"_.
+For more information about the Performance Profile Creator arguments, see the section "Performance Profile Creator arguments".
 
 [IMPORTANT]
 ====
@@ -19,7 +20,7 @@ The PPC uses the `must-gather` data from your cluster to create the performance 
 
 * Access to the cluster as a user with the `cluster-admin` role.
 * A cluster installed on bare-metal hardware.
-* You installed `podman` and the OpenShift CLI (`oc`).
+* You installed `podman` and the {oc-first}.
 * Access to the Node Tuning Operator image.
 * You identified a machine config pool containing target nodes for configuration.
 * Access to the `must-gather` tarball.
@@ -147,8 +148,6 @@ Password: <password>
 $ ./run-perf-profile-creator.sh -h
 ----
 +
-.Example output
-+
 [source,terminal]
 ----
 Wrapper usage:
@@ -192,8 +191,7 @@ You can optionally set a path for the Node Tuning Operator image using the `-p` 
 ----
 $ ./run-perf-profile-creator.sh -t /<path_to_must_gather_dir>/must-gather.tar.gz -- --info=log
 ----
-+
-* `-t /<path_to_must_gather_dir>/must-gather.tar.gz` specifies the path to directory containing the must-gather tarball. This is a required argument for the wrapper script.
+* `-t /<path_to_must_gather_dir>/must-gather.tar.gz`: Specifies the path to directory containing the must-gather tarball. This is a required argument for the wrapper script.
 +
 .Example output
 [source,terminal]
@@ -216,14 +214,12 @@ level=info msg="CPU(s): 4"
 level=info msg=---
 ----
 
-. Create a performance profile by running the following command.
+. Create a performance profile by running the following command. The example command uses sample PPC arguments and values.
 +
 [source,terminal]
 ----
 $ ./run-perf-profile-creator.sh -t /path-to-must-gather/must-gather.tar.gz -- --mcp-name=worker-cnf --reserved-cpu-count=1 --rt-kernel=true --split-reserved-cpus-across-numa=false --power-consumption-mode=ultra-low-latency --offlined-cpu-count=1 > my-performance-profile.yaml
 ----
-+
-This example uses sample PPC arguments and values.
 +
 * `--mcp-name=worker-cnf` specifies the `worker-cnf` machine config pool.
 * `--reserved-cpu-count=1` specifies one reserved CPU.
@@ -236,7 +232,6 @@ This example uses sample PPC arguments and values.
 ====
 The `mcp-name` argument in this example is set to `worker-cnf` based on the output of the command `oc get mcp`. For {sno} use `--mcp-name=master`.
 ====
-// Can't the MCP name be whatever the user wants, regardless of SNO vs multi-mode?
 
 . Review the created YAML file by running the following command:
 +
@@ -244,11 +239,10 @@ The `mcp-name` argument in this example is set to `worker-cnf` based on the outp
 ----
 $ cat my-performance-profile.yaml
 ----
-.Example output
 +
+.Example output
 [source,yaml]
 ----
----
 apiVersion: performance.openshift.io/v2
 kind: PerformanceProfile
 metadata:

--- a/modules/cnf-running-the-performance-creator-profile.adoc
+++ b/modules/cnf-running-the-performance-creator-profile.adoc
@@ -6,9 +6,10 @@
 [id="running-the-performance-profile-profile-cluster-using-podman_{context}"]
 = Running the Performance Profile Creator using Podman
 
+[role="_abstract"]
 As a cluster administrator, you can use Podman with the Performance Profile Creator (PPC) to create a performance profile.
 
-For more information about the PPC arguments, see the section _"Performance Profile Creator arguments"_.
+For more information about the PPC arguments, see the section "Performance Profile Creator arguments".
 
 [IMPORTANT]
 ====
@@ -19,7 +20,7 @@ The PPC uses the `must-gather` data from your cluster to create the performance 
 
 * Access to the cluster as a user with the `cluster-admin` role.
 * A cluster installed on bare-metal hardware.
-* You installed `podman` and the OpenShift CLI (`oc`).
+* You installed `podman` and the {oc-first}.
 * Access to the Node Tuning Operator image.
 * You identified a machine config pool containing target nodes for configuration.
 * You have access to the `must-gather` data for your cluster.
@@ -63,7 +64,6 @@ $ podman run --rm --entrypoint performance-profile-creator registry.redhat.io/op
 ----
 +
 .Example output
-+
 [source,terminal]
 ----
 A tool that automates creation of Performance Profiles
@@ -165,7 +165,6 @@ level=info msg="1 reserved CPUs allocated: 0 "
 level=info msg="2 isolated CPUs allocated: 2-3"
 level=info msg="Additional Kernel Args based on configuration: []"
 ----
-// Can't the MCP name be whatever the user wants, regardless of SNO vs multi-mode?
 
 . Review the created YAML file by running the following command:
 +

--- a/modules/cnf-telco-core-reference-design-performance-profile-template.adoc
+++ b/modules/cnf-telco-core-reference-design-performance-profile-template.adoc
@@ -6,7 +6,8 @@
 [id="cnf-telco-core-reference-design-performance-profile-template_{context}"]
 = Telco core reference design performance profile
 
-The following performance profile configures node-level performance settings for {product-title} clusters on commodity hardware to host telco core workloads.
+[role="_abstract"]
+You can use a pre-configured design performance profile that configures node-level performance settings for {product-title} clusters on commodity hardware to host telco core workloads.
 
 .Telco core reference design performance profile
 [source,yaml]

--- a/modules/cnf-telco-ran-reference-design-performance-profile-template.adoc
+++ b/modules/cnf-telco-ran-reference-design-performance-profile-template.adoc
@@ -6,7 +6,8 @@
 [id="cnf-telco-ran-reference-design-performance-profile-template_{context}"]
 = Telco RAN DU reference design performance profile
 
-The following performance profile configures node-level performance settings for {product-title} clusters on commodity hardware to host telco RAN DU workloads.
+[role="_abstract"]
+You can use a pre-configured design performance profile that configures node-level performance settings for {product-title} clusters on commodity hardware to host telco RAN DU workloads.
 
 .Telco RAN DU reference design performance profile
 [source,yaml]

--- a/modules/cnf-use-device-interrupt-processing-for-isolated-cpus.adoc
+++ b/modules/cnf-use-device-interrupt-processing-for-isolated-cpus.adoc
@@ -3,30 +3,26 @@
 // * scalability_and_performance/low_latency_tuning/cnf-provisioning-low-latency-workloads.adoc
 // * scalability_and_performance/low_latency_tuning/cnf-tuning-low-latency-nodes-with-perf-profile.adoc
 
+:_mod-docs-content-type: REFERENCE
 [id="nto_supported_api_versions_{context}"]
 = Supported performance profile API versions
 
+[role="_abstract"]
 The Node Tuning Operator supports `v2`, `v1`, and `v1alpha1` for the performance profile `apiVersion` field. The v1 and v1alpha1 APIs are identical. The v2 API includes an optional boolean field `globallyDisableIrqLoadBalancing` with a default value of `false`.
 
-[discrete]
-[id="use-device-interrupt-processing-for-isolated-cpus_{context}"]
-== Upgrading the performance profile to use device interrupt processing
+Upgrading the performance profile to use device interrupt processing::
 
 When you upgrade the Node Tuning Operator performance profile custom resource definition (CRD) from v1 or v1alpha1 to v2, `globallyDisableIrqLoadBalancing` is set to `true` on existing profiles.
-
++
 [NOTE]
 ====
 `globallyDisableIrqLoadBalancing` toggles whether IRQ load balancing will be disabled for the Isolated CPU set. When the option is set to `true` it disables IRQ load balancing for the Isolated CPU set. Setting the option to `false` allows the IRQs to be balanced across all CPUs.
 ====
 
-[discrete]
-[id="upgrading_nto_api_from_v1alpha1_to_v1_{context}"]
-=== Upgrading Node Tuning Operator API from v1alpha1 to v1
+Upgrading Node Tuning Operator API from v1alpha1 to v1::
 
 When upgrading Node Tuning Operator API version from v1alpha1 to v1, the v1alpha1 performance profiles are converted on-the-fly using a "None" Conversion strategy and served to the Node Tuning Operator with API version v1.
 
-[discrete]
-[id="upgrading_nto_api_from_v1alpha1_to_v1_or_v2_{context}"]
-=== Upgrading Node Tuning Operator API from v1alpha1 or v1 to v2
+Upgrading Node Tuning Operator API from v1alpha1 or v1 to v2::
 
 When upgrading from an older Node Tuning Operator API version, the existing v1 and v1alpha1 performance profiles are converted using a conversion webhook that injects the `globallyDisableIrqLoadBalancing` field with a value of `true`.

--- a/modules/cnf-verifying-queue-status.adoc
+++ b/modules/cnf-verifying-queue-status.adoc
@@ -2,17 +2,21 @@
 //
 // * scalability_and_performance/low_latency_tuning/cnf-tuning-low-latency-nodes-with-perf-profile.adoc
 
+:_mod-docs-content-type: REFERENCE
 [id="verifying-queue-status_{context}"]
 = Verifying the queue status
 
-In this section, a number of examples illustrate different performance profiles and how to verify the changes are applied.
+[role="_abstract"]
+To ensure that your performance profile changes are active, verify the queue status. Reviewing these examples helps you confirm that specific tuning configurations are successfully applied to your environment.
 
-.Example 1
+In this section, several examples illustrate different performance profiles and how to verify the changes are applied.
 
-In this example, the net queue count is set to the reserved CPU count (2) for _all_ supported devices.
-
+Example 1::
++
+Example 1 demonstrates that the net queue count that is set to the reserved CPU count (2) for _all_ supported devices.
++
 The relevant section from the performance profile is:
-
++
 [source,yaml]
 ----
 apiVersion: performance.openshift.io/v2
@@ -28,8 +32,8 @@ spec:
       userLevelNetworking: true
 # ...
 ----
-
-* Display the status of the queues associated with a device using the following command:
++
+The following command displays the status of the queues associated with a device:
 +
 [NOTE]
 ====
@@ -40,8 +44,8 @@ Run this command on the node where the performance profile was applied.
 ----
 $ ethtool -l <device>
 ----
-
-* Verify the queue status before the profile is applied:
++
+The following command verifies the queue status before the profile is applied:
 +
 [source,terminal]
 ----
@@ -63,8 +67,8 @@ TX:         0
 Other:      0
 Combined:   4
 ----
-
-* Verify the queue status after the profile is applied:
++
+The following command verifies the queue status after the profile is applied:
 +
 [source,terminal]
 ----
@@ -84,17 +88,17 @@ Current hardware settings:
 RX:         0
 TX:         0
 Other:      0
-Combined:   2 <1>
+Combined:   2
 ----
++
+* `Combined`: Specifies the combined channel that shows the total count of reserved CPUs for _all_ supported devices is 2. This matches what is configured in the performance profile.
 
-<1> The combined channel shows that the total count of reserved CPUs for _all_ supported devices is 2. This matches what is configured in the performance profile.
-
-.Example 2
-
-In this example, the net queue count is set to the reserved CPU count (2) for _all_ supported network devices with a specific `vendorID`.
-
+Example 2::
++
+Example 2 demonstrates that the net queue count is set to the reserved CPU count (2) for _all_ supported network devices with a specific `vendorID`.
++
 The relevant section from the performance profile is:
-
++
 [source,yaml]
 ----
 apiVersion: performance.openshift.io/v2
@@ -104,7 +108,7 @@ spec:
   kind: PerformanceProfile
   spec:
     cpu:
-      reserved: 0-1  #total = 2
+      reserved: 0-1
       isolated: 2-8
     net:
       userLevelNetworking: true
@@ -112,8 +116,8 @@ spec:
       - vendorID = 0x1af4
 # ...
 ----
-
-* Display the status of the queues associated with a device using the following command:
++
+The following command displays the status of the queues associated with a device:
 +
 [NOTE]
 ====
@@ -124,8 +128,8 @@ Run this command on the node where the performance profile was applied.
 ----
 $ ethtool -l <device>
 ----
-
-* Verify the queue status after the profile is applied:
++
+The following command verifies the queue status after the profile is applied:
 +
 [source,terminal]
 ----
@@ -145,18 +149,15 @@ Current hardware settings:
 RX:         0
 TX:         0
 Other:      0
-Combined:   2 <1>
+Combined:   2
 ----
++
+* `Combined`: Specifies that the total count of reserved CPUs for all supported devices with `vendorID=0x1af4` is 2. For example, if there is another network device `ens2` with `vendorID=0x1af4` it will also have total net queues of 2. This matches what is configured in the performance profile.
 
-<1> The total count of reserved CPUs for all supported devices with `vendorID=0x1af4` is 2.
-For example, if there is another network device `ens2` with `vendorID=0x1af4` it will also have total net queues of 2. This matches what is configured in the performance profile.
-
-.Example 3
-
-In this example, the net queue count is set to the reserved CPU count (2) for _all_ supported network devices that match any of the defined device identifiers.
-
-The command `udevadm info` provides a detailed report on a device. In this example the devices are:
-
+Example 3:: 
++
+Example 3 shows that the net queue count is set to the reserved CPU count (2) for _all_ supported network devices that match any of the defined device identifiers. The command `udevadm info` provides a detailed report on a device. In this example the devices are:
++
 [source,terminal]
 ----
 # udevadm info -p /sys/class/net/ens4
@@ -166,7 +167,7 @@ E: ID_VENDOR_ID=0x1af4
 E: INTERFACE=ens4
 ...
 ----
-
++
 [source,terminal]
 ----
 # udevadm info -p /sys/class/net/eth0
@@ -176,10 +177,10 @@ E: ID_VENDOR_ID=0x1001
 E: INTERFACE=eth0
 ...
 ----
-
-* Set the net queues to 2 for a device with `interfaceName` equal to `eth0` and any devices that have a `vendorID=0x1af4` with the following performance profile:
 +
-[source,yaml]
+Set the net queues to 2 for a device with `interfaceName` equal to `eth0` and any devices that have a `vendorID=0x1af4` with the following performance profile:
++
+[source,terminal,subs="attributes+"]
 ----
 apiVersion: performance.openshift.io/v2
 metadata:
@@ -195,10 +196,10 @@ spec:
         devices:
         - interfaceName = eth0
         - vendorID = 0x1af4
-...
+# ...
 ----
-
-* Verify the queue status after the profile is applied:
++
+The following command verifies the queue status after the profile is applied:
 +
 [source,terminal]
 ----
@@ -218,8 +219,9 @@ Current hardware settings:
 RX:         0
 TX:         0
 Other:      0
-Combined:   2 <1>
+Combined:   2
 ----
 +
-<1> The total count of reserved CPUs for all supported devices with `vendorID=0x1af4` is set to 2.
+* `Combined`: Specifies that the total count of reserved CPUs for all supported devices with `vendorID=0x1af4` is set to 2.
++
 For example, if there is another network device `ens2` with `vendorID=0x1af4`, it will also have the total net queues set to 2. Similarly, a device with `interfaceName` equal to `eth0` will have total net queues set to 2.

--- a/modules/configuring-kernal-page-size.adoc
+++ b/modules/configuring-kernal-page-size.adoc
@@ -6,6 +6,7 @@
 [id="cnf-page-size-optimization_{context}"]
 = Configuring kernel page sizes
 
+[role="_abstract"]
 Use the `kernelPageSize` specification in a performance profile to configure the kernel page size on a specific node. Specify larger kernel page sizes for memory-intensive, high-performance workloads. 
 
 [NOTE]
@@ -34,15 +35,22 @@ metadata:
     name: example-performance-profile
 #...
 spec:
-    kernelPageSize: "64k" <1>
+    kernelPageSize: "64k"
     realTimeKernel:
-        enabled: false <2>
+        enabled: false
     nodeSelector:
-        node-role.kubernetes.io/worker: "" <3>
+        node-role.kubernetes.io/worker: ""
 ----
-<1> This example specifies a kernel page size of `64k`. You can only specify `64k` for nodes with an AArch64 architecture. The default value is `4k`.
-<2> You must disable the realtime kernel to use the `64k` kernel page size option.
-<3> This example targets nodes with the `worker` role.
++
+--
+where:
+
+`spec.kernelPageSize`:: Specifies a kernel page size of `64k`. You can only specify `64k` for nodes with an AArch64 architecture. The default value is `4k`.
+
+`spec.realTimeKernel.enabled:false`:: Specifies whether to disable the realtime kernel. A setting of `false` disables the kernel. You must disable the realtime kernel to use the `64k` kernel page size option.
+
+`spec.nodeSelector.node-role.kubernetes.io/worker`:: Specifies targets nodes with the `worker` role.
+--
 
 . Apply the performance profile to the cluster:
 +
@@ -62,9 +70,9 @@ performanceprofile.performance.openshift.io/example-performance-profile created
 +
 [source,bash]
 ----
-$ oc debug node/<node_name> <1>
+$ oc debug node/<node_name>
 ----
-<1> Replace `<node_name>` with the name of the node with the performance profile applied.
+** `<node_name>`: Replace `<node_name>` with the name of the node with the performance profile applied.
 
 . Verify that the kernel page size is set to the value you specified in the performance profile by running the following command:
 +

--- a/modules/disabling-hyperthreading-for-low-latency-applications.adoc
+++ b/modules/disabling-hyperthreading-for-low-latency-applications.adoc
@@ -1,0 +1,52 @@
+// Module included in the following assemblies:
+//
+// * scalability_and_performance/low_latency_tuning/cnf-tuning-low-latency-nodes-with-perf-profile.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="disabling-hyperthreading-for-low-latency-applications_{context}"]
+= Disabling Hyper-Threading for low latency applications
+
+[role="_abstract"]
+When configuring clusters for low latency processing, consider whether you want to disable Hyper-Threading before you deploy the cluster. 
+
+To disable Hyper-Threading, perform the following steps:
+
+.Procedure
+
+* Create a performance profile that is appropriate for your hardware and topology. The following example sets `nosmt` as an additional kernel argument: 
++
+.Example performance profile
+[source,yaml]
+----
+apiVersion: performance.openshift.io/v2
+kind: PerformanceProfile
+metadata:
+  name: example-performanceprofile
+spec:
+  additionalKernelArgs:
+    - nmi_watchdog=0
+    - audit=0
+    - mce=off
+    - processor.max_cstate=1
+    - idle=poll
+    - intel_idle.max_cstate=0
+    - nosmt
+  cpu:
+    isolated: 2-3
+    reserved: 0-1
+  hugepages:
+    defaultHugepagesSize: 1G
+    pages:
+      - count: 2
+        node: 0
+        size: 1G
+  nodeSelector:
+    node-role.kubernetes.io/performance: ''
+  realTimeKernel:
+    enabled: true
+----
++
+[NOTE]
+====
+When you configure reserved and isolated CPUs, the infra containers in pods use the reserved CPUs and the application containers use the isolated CPUs.
+====

--- a/modules/installation-openstack-ovs-dpdk-performance-profile.adoc
+++ b/modules/installation-openstack-ovs-dpdk-performance-profile.adoc
@@ -6,6 +6,7 @@
 [id="installation-openstack-ovs-dpdk-performance-profile_{context}"]
 = Performance profile template for clusters that use OVS-DPDK on OpenStack
 
+[role="_abstract"]
 To maximize machine performance in a cluster that uses Open vSwitch with the Data Plane Development Kit (OVS-DPDK) on {rh-openstack-first}, you can use a performance profile.
 
 You can use the following performance profile template to create a profile for your deployment.

--- a/modules/restricting-cnf-cpu-infra-container.adoc
+++ b/modules/restricting-cnf-cpu-infra-container.adoc
@@ -1,0 +1,38 @@
+// Module included in the following assemblies:
+//
+// * scalability_and_performance/cnf-low-latency-tuning.adoc
+// * scalability_and_performance/low_latency_tuning/cnf-tuning-low-latency-nodes-with-perf-profile.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="restricting-cnf-cpu-infra-container_{context}"]
+= Restricting CPUs for infra and application containers
+
+[role="_abstract"]
+To ensure optimal cluster stability and performance, restrict CPUs for infrastructure and application containers. This configuration isolates workloads to specific CPU sets, preventing resource contention between critical system components and user applications.
+
+.Procedure
+
+. Create a performance profile appropriate for the environment's hardware and topology. The following example adds the `reserved` and `isolated` parameters with the CPUs you want reserved and isolated for the infra and application containers:
++
+[source,yaml]
+----
+apiVersion: performance.openshift.io/v2
+kind: PerformanceProfile
+metadata:
+  name: infra-cpus
+spec:
+  cpu:
+    reserved: "0-4,9"
+    isolated: "5-8"
+  nodeSelector:
+    node-role.kubernetes.io/worker: ""
+# ...
+----
++
+where:
+
+`spec.cpu.reserved`:: Specifies which CPUs are for infra containers to perform cluster and operating system housekeeping duties.
+
+`spec.cpu.isolated`:: Specifies which CPUs are for application containers to run workloads.
+
+`spec.nodeSelector`:: Specifies a node selector to apply the performance profile to specific nodes. Optional parameter.

--- a/networking/hardware_networks/using-dpdk-and-rdma.adoc
+++ b/networking/hardware_networks/using-dpdk-and-rdma.adoc
@@ -22,12 +22,12 @@ include::modules/nw-sriov-dpdk-example-mellanox.adoc[leveloffset=+1]
 // Using the TAP CNI to run a rootless DPDK workload with kernel access
 include::modules/nw-running-dpdk-rootless-tap.adoc[leveloffset=+1]
 
+////
 [role="_additional-resources"]
 .Additional resources
 
-// I can't seem to find this in 4.16 or 4.15 * xr3f:../../networking/multiple_networks/configuring-additional-network.adoc#nw-multus-enable-container_use_devices_configuring-additional-network[Enabling the container_use_devices boolean]
-
-* xref:../../scalability_and_performance/cnf-tuning-low-latency-nodes-with-perf-profile.adoc#cnf-create-performance-profiles[Creating a performance profile]
+* ../../scalability_and_performance/cnf-tuning-low-latency-nodes-with-perf-profile.adoc#cnf-create-performance-profiles_cnf-tuning-low-latency-nodes-with-perf-profile[Creating a performance profile]
+////
 
 * xref:../../networking/hardware_networks/configuring-sriov-device.adoc#configuring-sriov-device[Configuring an SR-IOV network device]
 
@@ -64,7 +64,9 @@ include::modules/nw-openstack-ovs-dpdk-testpmd-pod.adoc[leveloffset=+1]
 
 * link:https://catalog.redhat.com/en/hardware[Red Hat certified hardware (Red Hat Ecosystem Catalog)]
 
-* xref:../../scalability_and_performance/cnf-tuning-low-latency-nodes-with-perf-profile.adoc#cnf-create-performance-profiles[Creating a performance profile]
+////
+* ../../scalability_and_performance/cnf-tuning-low-latency-nodes-with-perf-profile.adoc#cnf-create-performance-profiles_cnf-tuning-low-latency-nodes-with-perf-profile[Creating a performance profile]
+////
 
 * xref:../../scalability_and_performance/cnf-tuning-low-latency-nodes-with-perf-profile.adoc#adjusting-nic-queues-with-the-performance-profile_cnf-low-latency-perf-profile[Adjusting the NIC queues with the performance profile]
 

--- a/scalability_and_performance/cnf-numa-aware-scheduling.adoc
+++ b/scalability_and_performance/cnf-numa-aware-scheduling.adoc
@@ -64,10 +64,12 @@ include::modules/cnf-creating-nrop-cr.adoc[leveloffset=+2]
 
 include::modules/cnf-creating-nrop-cr-hosted-control-plane.adoc[leveloffset=+2]
 
+////
 [role="_additional-resources"]
 .Additional resources
 
-* xref:../scalability_and_performance/cnf-tuning-low-latency-hosted-cp-nodes-with-perf-profile.adoc#cnf-create-performance-profiles-hosted-cp[Creating a performance profile for hosted control planes]
+* ../../scalability_and_performance/cnf-tuning-low-latency-nodes-with-perf-profile.adoc#cnf-create-performance-profiles_cnf-tuning-low-latency-nodes-with-perf-profile[Creating a performance profile]
+////
 
 include::modules/cnf-deploying-the-numa-aware-scheduler.adoc[leveloffset=+2]
 

--- a/scalability_and_performance/cnf-provisioning-low-latency-workloads.adoc
+++ b/scalability_and_performance/cnf-provisioning-low-latency-workloads.adoc
@@ -18,10 +18,12 @@ You can update the kernel to kernel-rt, reserve CPUs for cluster and operating s
 When writing your applications, follow the general recommendations described in link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux_for_real_time/9/html-single/understanding_rhel_for_real_time/index#assembly_rhel-for-real-time-processes-and-threads_understanding-RHEL-for-Real-Time-core-concepts[RHEL for Real Time processes and threads].
 ====
 
+////
 [role="_additional-resources"]
 .Additional resources
 
-* xref:../scalability_and_performance/cnf-tuning-low-latency-nodes-with-perf-profile.adoc#cnf-create-performance-profiles[Creating a performance profile]
+* ../../scalability_and_performance/cnf-tuning-low-latency-nodes-with-perf-profile.adoc#cnf-create-performance-profiles_cnf-tuning-low-latency-nodes-with-perf-profile[Creating a performance profile]
+////
 
 include::modules/cnf-scheduling-workload-onto-worker-with-real-time-capabilities.adoc[leveloffset=+1]
 

--- a/scalability_and_performance/cnf-tuning-low-latency-hosted-cp-nodes-with-perf-profile.adoc
+++ b/scalability_and_performance/cnf-tuning-low-latency-hosted-cp-nodes-with-perf-profile.adoc
@@ -6,22 +6,10 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 Tune hosted control planes for low latency by applying a performance profile. With the performance profile, you can restrict CPUs for infrastructure and application containers and configure huge pages, Hyper-Threading, and CPU partitions for latency-sensitive processes.
 
-[id="cnf-create-performance-profiles-hosted-cp"]
-== Creating a performance profile for hosted control planes
-
-You can create a cluster performance profile by using the Performance Profile Creator (PPC) tool. The PPC is a function of the Node Tuning Operator. 
-
-The PPC combines information about your cluster with user-supplied configurations to generate a performance profile that is appropriate to your hardware, topology, and use-case.
-
-The following is a high-level workflow for creating and applying a performance profile in your cluster:
-
-. Gather information about your cluster using the `must-gather` command.
-
-. Use the PPC tool to create a performance profile.
-
-. Apply the performance profile to your cluster.
+include::modules/cnf-create-performance-profiles-hosted-cp.adoc[leveloffset=+1]
 
 include::modules/cnf-gathering-data-about-hosted-cluster-using-must-gather.adoc[leveloffset=+2]
 
@@ -30,9 +18,12 @@ include::modules/cnf-gathering-data-about-hosted-cluster-using-must-gather.adoc[
 
 * xref:../support/gathering-cluster-data.adoc#nodes-nodes-managing[Gathering data about your cluster] 
 
-* xref:../hosted_control_planes/hcp-troubleshooting.adoc#hcp-must-gather-cli[Gathering data for a hosted cluster by using the CLI].
+* xref:../hosted_control_planes/hcp-troubleshooting.adoc#hcp-must-gather-cli[Gathering data for a hosted cluster by using the CLI]
 
 include::modules/cnf-running-the-performance-creator-profile-hosted.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources
 
 * xref:../scalability_and_performance/cnf-tuning-low-latency-nodes-with-perf-profile.adoc#performance-profile-creator-arguments_cnf-low-latency-perf-profile[Performance Profile Creator arguments]
 

--- a/scalability_and_performance/cnf-tuning-low-latency-nodes-with-perf-profile.adoc
+++ b/scalability_and_performance/cnf-tuning-low-latency-nodes-with-perf-profile.adoc
@@ -6,34 +6,10 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-Tune nodes for low latency by using the cluster performance profile.
-You can restrict CPUs for infra and application containers, configure huge pages, Hyper-Threading, and configure CPU partitions for latency-sensitive processes.
+[role="_abstract"]
+Tune nodes for low latency by using the cluster performance profile. You can restrict CPUs for infra and application containers, configure huge pages, Hyper-Threading, and configure CPU partitions for latency-sensitive processes.
 
-[id="cnf-create-performance-profiles"]
-== Creating a performance profile
-
-You can create a cluster performance profile by using the Performance Profile Creator (PPC) tool. The PPC is a function of the Node Tuning Operator. 
-
-The PPC combines information about your cluster with user-supplied configurations to generate a performance profile that is appropriate to your hardware, topology and use-case.
-
-[NOTE]
-====
-Performance profiles are applicable only to bare-metal environments where the cluster has direct access to the underlying hardware resources. You can configure performances profiles for both {sno} and multi-node clusters.
-====
-
-The following is a high-level workflow for creating and applying a performance profile in your cluster:
-
-* Create a machine config pool (MCP) for nodes that you want to target with performance configurations. In {sno} clusters, you must use the `master` MCP because there is only one node in the cluster.
-
-* Gather information about your cluster using the `must-gather` command.
-
-* Use the PPC tool to create a performance profile by using either of the following methods:
-
-** Run the PPC tool by using Podman. 
-
-** Run the PPC tool by using a wrapper script.
-
-* Configure the performance profile for your use case and apply the performance profile to your cluster.
+include::modules/cnf-create-performance-profiles.adoc[leveloffset=+1]
 
 include::modules/cnf-about-the-profile-creator-tool.adoc[leveloffset=+2]
 
@@ -55,19 +31,24 @@ include::modules/cnf-running-the-performance-creator-profile-offline.adoc[levelo
 include::modules/cnf-performance-profile-creator-arguments.adoc[leveloffset=+2]
 
 [id="cnf-create-performance-profiles-reference"]
-=== Reference performance profiles
+== Reference performance profiles
 
 Use the following reference performance profiles as the basis to develop your own custom profiles.
 
-include::modules/installation-openstack-ovs-dpdk-performance-profile.adoc[leveloffset=+3]
+include::modules/installation-openstack-ovs-dpdk-performance-profile.adoc[leveloffset=+2]
 
-include::modules/cnf-telco-ran-reference-design-performance-profile-template.adoc[leveloffset=+3]
+include::modules/cnf-telco-ran-reference-design-performance-profile-template.adoc[leveloffset=+2]
 
-include::modules/cnf-telco-core-reference-design-performance-profile-template.adoc[leveloffset=+3]
+include::modules/cnf-telco-core-reference-design-performance-profile-template.adoc[leveloffset=+2]
 
 include::modules/cnf-use-device-interrupt-processing-for-isolated-cpus.adoc[leveloffset=+1]
 
 include::modules/cnf-configuring-workload-hints.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* link:https://access.redhat.com/articles/7081587[Understanding workload hints]
 
 include::modules/cnf-configuring-power-saving-for-nodes.adoc[leveloffset=+1]
 
@@ -82,11 +63,20 @@ include::modules/cnf-configuring-power-saving-for-nodes.adoc[leveloffset=+1]
 
 include::modules/cnf-cpu-infra-container.adoc[leveloffset=+1]
 
+include::modules/restricting-cnf-cpu-infra-container.adoc[leveloffset=+1]
+
 include::modules/cnf-configuring-hyperthreading-for-a-cluster.adoc[leveloffset=+1]
+
+include::modules/disabling-hyperthreading-for-low-latency-applications.adoc[leveloffset=+1]
 
 include::modules/cnf-managing-device-interrupt-processing-for-guaranteed-pod-isolated-cpus.adoc[leveloffset=+1]
 
 include::modules/cnf-about-irq-affinity-setting.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources
+
+* link:https://access.redhat.com/solutions/4819541[Affinity of managed interrupts cannot be changed even if they target isolated CPU]
 
 include::modules/cnf-configure_for_irq_dynamic_load_balancing.adoc[leveloffset=+2]
 
@@ -106,10 +96,12 @@ Adjustments are made using the performance profile, allowing customization of qu
 
 include::modules/cnf-adjusting-nic-queues-with-the-performance-profile.adoc[leveloffset=+2]
 
+////
 [role="_additional-resources"]
 .Additional resources
 
-* xref:../scalability_and_performance/cnf-tuning-low-latency-nodes-with-perf-profile.adoc#cnf-create-performance-profiles[Creating a performance profile].
+* ../../scalability_and_performance/cnf-tuning-low-latency-nodes-with-perf-profile.adoc#cnf-create-performance-profiles_cnf-tuning-low-latency-nodes-with-perf-profile[Creating a performance profile]
+////
 
 include::modules/cnf-verifying-queue-status.adoc[leveloffset=+2]
 

--- a/scalability_and_performance/telco-core-rds.adoc
+++ b/scalability_and_performance/telco-core-rds.adoc
@@ -54,7 +54,9 @@ include::modules/telco-core-workloads-on-schedulable-control-planes.adoc[levelof
 [role="_additional-resources"]
 .Additional resources
 
-* xref:../scalability_and_performance/cnf-tuning-low-latency-nodes-with-perf-profile.adoc#cnf-create-performance-profiles[Creating a performance profile]
+////
+* :../scalability_and_performance/cnf-tuning-low-latency-nodes-with-perf-profile.adoc#cnf-create-performance-profiles_cnf-tuning-low-latency-nodes-with-perf-profile[Creating a performance profile]
+////
 
 * xref:../edge_computing/ztp-reference-cluster-configuration-for-vdu.adoc#ztp-du-configuring-host-firmware-requirements_sno-configure-for-vdu[Configuring host firmware for low latency and high performance]
 


### PR DESCRIPTION
PR completes CQA work for 'scalability_and_performance/cnf-tuning-low-latency-hosted-cp-nodes-with-perf-profile.adoc' and 'scalability_and_performance/cnf-tuning-low-latency-nodes-with-perf-profile.adoc'. Other assemblies touched have links that are commented out as a follow-up PR will deal with those.

Need to fix the following links as I could not determine the ID issue on this PR. Follow-on PR will be raised so I could isolate the issue.

<img width="2598" height="490" alt="Screenshot From 2026-02-23 12-55-45" src="https://github.com/user-attachments/assets/083127c6-de9e-4af4-867c-a82af40e93c9" />


Version(s):
4.16+

Issue:
[OSDOCS-16873](https://issues.redhat.com/browse/OSDOCS-16873)

Link to docs preview:

* [cnf-tuning-low-latency-hosted-cp-nodes-with-perf-profile](https://107038--ocpdocs-pr.netlify.app/openshift-enterprise/latest/scalability_and_performance/cnf-tuning-low-latency-hosted-cp-nodes-with-perf-profile.html)
* [cnf-tuning-low-latency-nodes-with-perf-profile.adoc](https://107038--ocpdocs-pr.netlify.app/openshift-enterprise/latest/scalability_and_performance/cnf-tuning-low-latency-nodes-with-perf-profile.html)

- [ ] SME has approved this change.
- [ ] QE has approved this change.

