### PR TITLE
OADP-6455: Add OADP 1.3.9 RNs

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -42,7 +42,7 @@ endif::[]
 :oadp-full: OpenShift API for Data Protection
 :oadp-short: OADP
 :oadp-version: 1.4.8
-:oadp-version-1-3: 1.3.8
+:oadp-version-1-3: 1.3.9
 :oadp-version-1-4: 1.4.8
 :oadp-bsl-api: backupstoragelocations.velero.io
 :velero-overview: link:https://{velero-domain}/docs/v{velero-version}/locations/[Overview of backup and snapshot locations in the Velero documentation]

--- a/backup_and_restore/application_backup_and_restore/release-notes/oadp-release-notes-1-3.adoc
+++ b/backup_and_restore/application_backup_and_restore/release-notes/oadp-release-notes-1-3.adoc
@@ -9,6 +9,8 @@ toc::[]
 
 The release notes for {oadp-first} 1.3 describe new features and enhancements, deprecated features, product recommendations, known issues, and resolved issues.
 
+include::modules/oadp-release-notes-1-3-9.adoc[leveloffset=+1]
+
 include::modules/oadp-release-notes-1-3-8.adoc[leveloffset=+1]
 include::modules/oadp-release-notes-1-3-7.adoc[leveloffset=+1]
 include::modules/oadp-release-notes-1-3-6.adoc[leveloffset=+1]

--- a/modules/oadp-release-notes-1-3-9.adoc
+++ b/modules/oadp-release-notes-1-3-9.adoc
@@ -1,0 +1,23 @@
+// Module included in the following assemblies:
+//
+// * backup_and_restore/application_backup_and_restore/release-notes/oadp-release-notes-1-3.adoc
+
+:_mod-docs-content-type: REFERENCE
+
+[id="oadp-1-3-9-release-notes_{context}"]
+= {oadp-short} 1.3.9 release notes
+
+[role="_abstract"]
+{oadp-first} 1.3.9 is a Container Grade Only (CGO) release, which is released to refresh the health grades of the containers. No code was changed in the product itself compared to that of {oadp-short} 1.3.8. {oadp-short} 1.3.9 fixes several Common Vulnerabilities and Exposures (CVEs).
+
+
+[id="resolved-issues-1-3-9_{context}"]
+== Resolved issues
+
+{oadp-short} 1.3.9 fixes the following CVEs::
+
+* link:https://access.redhat.com/security/cve/cve-2025-66418[CVE-2025-66418]
+
+* link:https://access.redhat.com/security/cve/cve-2025-66471[CVE-2025-66471]
+
+* link:https://access.redhat.com/security/cve/cve-2026-21441[CVE-2026-21441]


### PR DESCRIPTION
Version(s):
OCP 4.12-4.15

Issue:
[OADP-6455](https://issues.redhat.com/browse/OADP-6455)

Link to docs preview:

- [OADP 1.3.9 release notes](https://107041--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/release-notes/oadp-release-notes-1-3.html#oadp-1-3-9-release-notes_oadp-release-notes)

QE review:
- [x] QE has approved this change.

Changes:

- Add OADP 1.3.9. Release Notes and change attributes.