### PR TITLE
OADP-7420: Update OADP 1.5 channels

### DIFF
--- a/modules/about-oadp-update-channels.adoc
+++ b/modules/about-oadp-update-channels.adoc
@@ -7,27 +7,22 @@
 [id="about-oadp-update-channels_{context}"]
 = About {oadp-short} update channels
 
-When you install an {oadp-short} Operator, you choose an _update channel_. This channel determines which upgrades to the {oadp-short} Operator and to Velero you receive. You can switch channels at any time.
+[role="_abstract"]
+When you install an {oadp-short} Operator, you choose an update channel. This channel determines which upgrades to the {oadp-short} Operator and to Velero you receive.
 
 The following update channels are available:
-
-* The *stable* channel is now deprecated. The *stable* channel contains the patches (z-stream updates) of OADP `ClusterServiceVersion` for `{oadp-short}.v1.1.z` and older versions from `{oadp-short}.v1.0.z`.
-
-* The *stable-1.0* channel is deprecated and is not supported.
-
-* The *stable-1.1* channel is deprecated and is not supported.
-
-* The *stable-1.2* channel  is deprecated and is not supported.
 
 * The *stable-1.3* channel contains `{oadp-short}.v1.3.z`, the most recent {oadp-short} 1.3 `ClusterServiceVersion`.
 
 * The *stable-1.4* channel contains `{oadp-short}.v1.4.z`, the most recent {oadp-short} 1.4 `ClusterServiceVersion`.
 
+* Starting with {oadp-short} 1.5 on {product-title} v4.19, {oadp-short} reintroduces the *stable* channel which contains a single supported {oadp-short} version for a particular {product-title} version.
+
 For more information, see link:https://access.redhat.com/support/policy/updates/openshift_operators[OpenShift Operator Life Cycles].
 
 *Which update channel is right for you?*
 
-* The *stable* channel is now deprecated. If you are already using the stable channel, you will continue to get updates from `{oadp-short}.v1.1.z`.
+* If you are already using the *stable* channel, you will continue to get updates from `{oadp-short}.v1.5.z`.
 
 * Choose the *stable-1.y* update channel to install {oadp-short} 1.y and to continue receiving patches for it. If you choose this channel, you will receive all z-stream patches for version 1.y.z.
 


### PR DESCRIPTION
Version(s):
OCP 4.19+

Issue:
[OADP-7420](https://issues.redhat.com/browse/OADP-7420)

Link to docs preview:

- [About OADP update channels](https://107048--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/installing/about-installing-oadp.html#about-oadp-update-channels_about-installing-oadp)

QE review:
- [x] QE has approved this change.

Changes: Update channels for OADP 1.5.
