### PR TITLE
RHDEVDOCS-6854: Content creation for protecting tekton workload pods from eviction

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -59,6 +59,8 @@ Topics:
   File: reducing-pipelines-resource-consumption
 - Name: Setting compute resource quota for OpenShift Pipelines
   File: setting-compute-resource-quota-for-openshift-pipelines
+- Name: Protecting Tekton workload pods from eviction during node drains
+  File: protecting-tekton-workloads-from-eviction-during-node-drains
 ---
 Name: Creating CI/CD pipelines
 Dir: create

--- a/modules/op-eviction-protection-for-taskrun-pods.adoc
+++ b/modules/op-eviction-protection-for-taskrun-pods.adoc
@@ -1,0 +1,17 @@
+// This module is included in the following assemblies:
+// * resource/protecting-tekton-workloads-from-eviction-during-node-drains.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="op-eviction-protection-for-taskrun-pods_{context}"]
+= Eviction protection for TaskRun pods
+
+Labels defined on a `PipelineRun` resource propagate automatically to the associated `TaskRun` resources and the pods created by those `TaskRun` resources.
+
+You can use this label propagation behavior to identify and protect selected workloads from voluntary disruptions during cluster maintenance operations such as node drains or upgrades.
+
+By applying a label to a `PipelineRun` or standalone `TaskRun`, and configuring a `PodDisruptionBudget` (PDB) that targets pods with the same label, you can prevent eviction of running Tekton workload pods during voluntary disruptions.
+
+This configuration ensures the following behavior:
+
+* While a Tekton pod with a matching label is running, node drains and other voluntary eviction operations are blocked.
+* After the protected pod completes execution, for example when the associated `PipelineRun` succeeds, the PDB no longer blocks cluster disruption operations.

--- a/modules/op-preventing-taskrun-pod-eviction-during-node-maintenance.adoc
+++ b/modules/op-preventing-taskrun-pod-eviction-during-node-maintenance.adoc
@@ -1,0 +1,80 @@
+// This module is included in the following assemblies:
+// * resource/protecting-tekton-workloads-from-eviction-during-node-drains.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="op-preventing-taskrun-pod-eviction-during-node-maintenance_{context}"]
+= Preventing eviction of TaskRun pods during node maintenance
+
+You can prevent eviction of running Tekton `TaskRun` pods during node maintenance operations, such as node drains or cluster upgrades, by labeling the associated `PipelineRun` or `TaskRun` resources and configuring a `PodDisruptionBudget` (PDB) that targets the resulting pods. This configuration prevents voluntary disruption of critical workloads while they are running.
+
+.Prerequisites
+
+* You have access to an {OCP} cluster.
+* The xref:../install_config/installing-pipelines.adoc#installing-pipelines[{pipelines-shortname} Operator] is installed in your cluster.
+* You have identified the tasks or pipelines that require protection from eviction.
+
+.Procedure
+
+. Create a `PodDisruptionBudget` resource in the namespace where you want to protect Tekton workloads:
++
+[source,yaml]
+----
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: tekton-protect
+  namespace: ci
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      pdb: protect
+----
++
+[NOTE]
+====
+This PDB is a one-time configuration for the namespace and can be reused by multiple `PipelineRun` and `TaskRun` resources.
+====
+
+. Apply the `PodDisruptionBudget` resource by running the following command:
++
+[source,terminal]
+----
+$ oc apply -f pdb-tekton-protect.yaml
+----
+
+. Add a label to the `PipelineRun` resource that requires protection from eviction:
++
+[source,yaml]
+----
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  name: infra-change
+  namespace: ci
+  labels:
+    pdb: protect
+spec:
+  pipelineRef:
+    name: infra-change-pipeline
+----
++
+The label propagates automatically to the associated `TaskRun` resources and the pods created by those resources. The `PodDisruptionBudget` protects any workload with the `pdb: protect` label.
+
+.Verification
+
+. Verify that the `PodDisruptionBudget` resource is active by running the following command:
++
+[source,terminal]
+----
+$ oc get pdb tekton-protect -n ci
+----
+
+. Optional: Test the protection by attempting to drain a node running a protected `TaskRun` pod:
++
+[source,terminal]
+----
+$ oc adm drain <node-name> --ignore-daemonsets
+----
++
+If the PDB is configured correctly, the drain operation pauses while the protected pod is running.

--- a/resource/protecting-tekton-workloads-from-eviction-during-node-drains.adoc
+++ b/resource/protecting-tekton-workloads-from-eviction-during-node-drains.adoc
@@ -1,0 +1,17 @@
+:_content-type: ASSEMBLY
+include::_attributes/common-attributes.adoc[]
+[id="protecting-tekton-workloads-from-eviction-during-node-drains"]
+= Protecting Tekton workload pods from eviction during node drains
+:context: managing-pipelines-performance
+
+toc::[]
+
+During cluster maintenance operations such as node drains or upgrades in {OCP}, the system might evict and reschedule running Tekton workload pods to another node.
+
+Eviction during execution can disrupt workloads that are not designed to rerun safely, such as one-time configuration tasks, backups, deletions, or infrastructure changes.
+
+In {pipelines-title}, labels applied to a PipelineRun custom resource (CR) propagate automatically to the associated TaskRun resources and the pods created by those resources. You can use this label propagation behavior together with a `PodDisruptionBudget` (PDB) custom resource to protect selected workloads from voluntary disruptions.
+
+include::modules/op-eviction-protection-for-taskrun-pods.adoc[leveloffset=+1]
+
+include::modules/op-preventing-taskrun-pod-eviction-during-node-maintenance.adoc[leveloffset=+1]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

pipelines-docs-1.22

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

https://issues.redhat.com/browse/RHDEVDOCS-6854

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

[Protecting Tekton workload pods from eviction during node drains](https://107049--ocpdocs-pr.netlify.app/openshift-pipelines/latest/resource/protecting-tekton-workloads-from-eviction-during-node-drains.html)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

SME review: @khrm 
QE review: @manthinasai 
Peer review: bdooley@redhat.com

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
