### PR TITLE
DOCPLAN-86: Update for DITA vale

### DIFF
--- a/modules/nw-sriov-additional-network.adoc
+++ b/modules/nw-sriov-additional-network.adoc
@@ -1,0 +1,106 @@
+// Module included in the following assemblies:
+//
+// * virt/vm_networking/virt-connecting-vm-to-sriov.adoc
+
+ifeval::["{context}" == "virt-connecting-vm-to-sriov"]
+:rs: SriovNetwork
+:virt-sriov-net:
+:object: pods or virtual machines
+endif::[]
+
+:_mod-docs-content-type: PROCEDURE
+[id="nw-sriov-additional-network_{context}"]
+= Configuring SR-IOV additional network
+
+[role="_abstract"]
+You can configure an additional network that uses SR-IOV hardware by creating an `{rs}` object.
+When you create an `{rs}` object, the SR-IOV Network Operator automatically creates a `NetworkAttachmentDefinition` object.
+
+[NOTE]
+=====
+Do not modify or delete an `{rs}` object if it is attached to {object} in a `running` state.
+=====
+
+.Prerequisites
+
+* Install the {oc-first}.
+* Log in as a user with `cluster-admin` privileges.
+
+.Procedure
+
+. Create the following `SriovNetwork` object, and then save the YAML in the `<name>-sriov-network.yaml` file. Replace `<name>` with a name for this additional network.
++
+[source,yaml]
+----
+apiVersion: sriovnetwork.openshift.io/v1
+kind: SriovNetwork
+metadata:
+  name: <name>
+  namespace: openshift-sriov-network-operator
+spec:
+  resourceName: <sriov_resource_name>
+  networkNamespace: <target_namespace>
+  vlan: <vlan>
+  spoofChk: "<spoof_check>"
+  linkState: <link_state>
+  maxTxRate: <max_tx_rate>
+  minTxRate: <min_rx_rate>
+  vlanQoS: <vlan_qos>
+  trust: "<trust_vf>"
+  capabilities: <capabilities>
+ifdef::ocp-sriov-net[]
+  ipam: {}
+  linkState: <link_state>
+  maxTxRate: <max_tx_rate>
+  minTxRate: <min_tx_rate>
+  vlanQoS: <vlan_qos>
+  trust: "<trust_vf>"
+  capabilities: <capabilities>
+endif::ocp-sriov-net[]
+----
+** `metadata.name` defines a name for the `SriovNetwork` object. The SR-IOV Network Operator creates a `NetworkAttachmentDefinition` object with same name.
+** `metadata.namespace` defines the namespace where the SR-IOV Network Operator is installed.
+** `spec.resourceName` defines the value of the `.spec.resourceName` parameter in the `SriovNetworkNodePolicy` object that defines the SR-IOV hardware for this additional network.
+** `spec.networkNamespace` defines the target namespace for the `SriovNetwork` object. Only {object} in the target namespace can attach to the `SriovNetwork` object.
+** `spec.vlan` an optional field that defines a Virtual LAN (VLAN) ID for the additional network. The integer value must be from `0` to `4095`. The default value is `0`.
+** `spec.spoofChk` an optional field that defines the spoof check mode of the VF. The allowed values are the strings `"on"` and `"off"`.
++
+[IMPORTANT]
+====
+You must enclose the value you specify in quotes or the CR is rejected by the SR-IOV Network Operator.
+====
+** `spec.linkState` an optional field that defines the link state of virtual function (VF). Allowed values are `enable`, `disable` and `auto`.
+** `spec.maxTxRate` an optional field that defines the maximum transmission rate, in Mbps, for the VF.
+** `spec.minTxRate` an optional field that defines the minimum transmission rate, in Mbps, for the VF. This value should always be less than or equal to the maximum transmission rate.
++
+[NOTE]
+====
+Intel NICs do not support the `minTxRate` parameter. For more information, see link:https://bugzilla.redhat.com/show_bug.cgi?id=1772847[BZ#1772847].
+====
+** `spec.vlanQoS` an optional field that defines the IEEE 802.1p priority level for the VF. The default value is `0`.
+** `spec.trust` an optional field that defines the trust mode of the VF. The allowed values are the strings `"on"` and `"off"`.
++
+[IMPORTANT]
+====
+You must enclose the value you specify in quotes or the CR is rejected by the SR-IOV Network Operator.
+====
+** `spec.capabilities` an optional field that defines the capabilities to configure for this network.
+ifdef::ocp-sriov-net[]
+You can specify `"{ "ips": true }"` to enable IP address support or `"{ "mac": true }"` to enable MAC address support.
+** `spec.capabilities` defines a configuration object for the IPAM CNI plugin as a YAML block scalar. The plugin manages IP address assignment for the attachment definition.
+endif::ocp-sriov-net[]
+
+[start=2]
+. To create the object, enter the following command. Replace `<name>` with a name for this additional network.
++
+[source,terminal]
+----
+$ oc create -f <name>-sriov-network.yaml
+----
+
+. Optional: To confirm that the `NetworkAttachmentDefinition` object associated with the `SriovNetwork` object that you created in the previous step exists, enter the following command. Replace `<namespace>` with the namespace you specified in the `SriovNetwork` object.
++
+[source,terminal]
+----
+$ oc get net-attach-def -n <namespace>
+----

--- a/modules/nw-sriov-network-attachment.adoc
+++ b/modules/nw-sriov-network-attachment.adoc
@@ -1,7 +1,6 @@
 // Module included in the following assemblies:
 //
 // * networking/hardware_networks/configuring-sriov-net-attach.adoc
-// * virt/vm_networking/virt-connecting-vm-to-sriov.adoc
 // * virt/post_installation_configuration/virt-post-install-network-config.adoc
 
 // Note: IB does not support ipam with `type=dhcp`.
@@ -16,12 +15,6 @@ ifeval::["{context}" == "configuring-sriov-ib-attach"]
 :rs: SriovIBNetwork
 :ocp-sriov-net:
 :object: pods
-endif::[]
-
-ifeval::["{context}" == "virt-connecting-vm-to-sriov"]
-:rs: SriovNetwork
-:virt-sriov-net:
-:object: pods or virtual machines
 endif::[]
 
 :_mod-docs-content-type: PROCEDURE
@@ -74,7 +67,9 @@ spec:
 $ oc create -f <name>.yaml
 ----
 +
-where `<name>` specifies the name of the additional network.
+where:
++
+`<name>`:: Specifies the name of the additional network.
 
 . Optional: To confirm that the `NetworkAttachmentDefinition` object that is associated with the `{rs}` object that you created in the previous step exists, enter the following command. Replace `<namespace>` with the `networkNamespace` value you specified in the `{rs}` object.
 +
@@ -84,117 +79,12 @@ $ oc get net-attach-def -n <namespace>
 ----
 endif::ocp-sriov-net[]
 
-// LEGACY
-ifdef::virt-sriov-net[]
-[id="nw-sriov-network-attachment_{context}"]
-= Configuring SR-IOV additional network
-
-You can configure an additional network that uses SR-IOV hardware by creating an `{rs}` object.
-
-When you create an `{rs}` object, the SR-IOV Network Operator automatically creates a `NetworkAttachmentDefinition` object.
-
-[NOTE]
-=====
-Do not modify or delete an `{rs}` object if it is attached to {object} in a `running` state.
-=====
-
-.Prerequisites
-
-* Install the {oc-first}.
-* Log in as a user with `cluster-admin` privileges.
-
-.Procedure
-
-. Create the following `SriovNetwork` object, and then save the YAML in the `<name>-sriov-network.yaml` file. Replace `<name>` with a name for this additional network.
-+
-[source,yaml]
-----
-apiVersion: sriovnetwork.openshift.io/v1
-kind: SriovNetwork
-metadata:
-  name: <name>
-  namespace: openshift-sriov-network-operator
-spec:
-  resourceName: <sriov_resource_name>
-  networkNamespace: <target_namespace>
-  vlan: <vlan>
-  spoofChk: "<spoof_check>"
-  linkState: <link_state>
-  maxTxRate: <max_tx_rate>
-  minTxRate: <min_rx_rate>
-  vlanQoS: <vlan_qos>
-  trust: "<trust_vf>"
-  capabilities: <capabilities>
-ifdef::ocp-sriov-net[]
-  ipam: {}
-  linkState: <link_state>
-  maxTxRate: <max_tx_rate>
-  minTxRate: <min_tx_rate>
-  vlanQoS: <vlan_qos>
-  trust: "<trust_vf>"
-  capabilities: <capabilities>
-endif::ocp-sriov-net[]
-----
-+
-`metadata.name`:: Specify a name for the `SriovNetwork` object. The SR-IOV Network Operator creates a `NetworkAttachmentDefinition` object with same name.
-`metadata.namespace`:: Specify the namespace where the SR-IOV Network Operator is installed.
-`spec.resourceName`:: Specify the value of the `.spec.resourceName` parameter in the `SriovNetworkNodePolicy` object that defines the SR-IOV hardware for this additional network.
-`spec.networkNamespace`:: Specify the target namespace for the `SriovNetwork` object. Only {object} in the target namespace can attach to the `SriovNetwork` object.
-`spec.vlan`:: Optional: Specify a Virtual LAN (VLAN) ID for the additional network. The integer value must be from `0` to `4095`. The default value is `0`.
-`spec.spoofChk`:: Optional: Specify the spoof check mode of the VF. The allowed values are the strings `"on"` and `"off"`.
-+
-[IMPORTANT]
-====
-You must enclose the value you specify in quotes or the CR is rejected by the SR-IOV Network Operator.
-====
-`spec.linkState`:: Optional: Specify the link state of virtual function (VF). Allowed values are `enable`, `disable` and `auto`.
-`spec.maxTxRate`:: Optional: Specify the maximum transmission rate, in Mbps, for the VF.
-`spec.minTxRate`:: Optional: Specify the minimum transmission rate, in Mbps, for the VF. This value should always be less than or equal to the maximum transmission rate.
-+
-[NOTE]
-====
-Intel NICs do not support the `minTxRate` parameter. For more information, see link:https://bugzilla.redhat.com/show_bug.cgi?id=1772847[BZ#1772847].
-====
-`spec.vlanQoS`:: Optional: Specify the IEEE 802.1p priority level for the VF. The default value is `0`.
-`spec.trust`:: Optional: Specify the trust mode of the VF. The allowed values are the strings `"on"` and `"off"`.
-+
-[IMPORTANT]
-====
-You must enclose the value you specify in quotes or the CR is rejected by the SR-IOV Network Operator.
-====
-`spec.capabilities`:: Optional: Specify the capabilities to configure for this network.
-ifdef::ocp-sriov-net[]
-You can specify `"{ "ips": true }"` to enable IP address support or `"{ "mac": true }"` to enable MAC address support.
-`spec.capabilities`:: Specify a configuration object for the IPAM CNI plugin as a YAML block scalar. The plugin manages IP address assignment for the attachment definition.
-endif::ocp-sriov-net[]
-
-[start=2]
-. To create the object, enter the following command. Replace `<name>` with a name for this additional network.
-+
-[source,terminal]
-----
-$ oc create -f <name>-sriov-network.yaml
-----
-
-. Optional: To confirm that the `NetworkAttachmentDefinition` object associated with the `SriovNetwork` object that you created in the previous step exists, enter the following command. Replace `<namespace>` with the namespace you specified in the `SriovNetwork` object.
-+
-[source,terminal]
-----
-$ oc get net-attach-def -n <namespace>
-----
-// LEGACY
-endif::virt-sriov-net[]
-
 ifdef::object[]
 :!object:
 endif::[]
 
 ifdef::rs[]
 :!rs:
-endif::[]
-
-ifeval::["{context}" == "virt-connecting-vm-to-sriov"]
-:!virt-sriov-net:
 endif::[]
 
 ifeval::["{context}" == "configuring-sriov-net-attach"]

--- a/virt/managing_vms/virt-accessing-vm-ssh.adoc
+++ b/virt/managing_vms/virt-accessing-vm-ssh.adoc
@@ -146,7 +146,7 @@ See the link:https://access.redhat.com/articles/6994974#networking-multus[Multus
 
 ifndef::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
 * You configured a secondary network such as xref:../../virt/vm_networking/virt-connecting-vm-to-linux-bridge.adoc#virt-connecting-vm-to-linux-bridge[Linux bridge] or xref:../../virt/vm_networking/virt-connecting-vm-to-sriov.adoc#virt-connecting-vm-to-sriov[SR-IOV].
-* You created a network attachment definition for a xref:../../virt/vm_networking/virt-connecting-vm-to-linux-bridge.adoc#virt-creating-linux-bridge-nad-web_virt-connecting-vm-to-linux-bridge[Linux bridge network] or the SR-IOV Network Operator created a xref:../../virt/vm_networking/virt-connecting-vm-to-sriov.adoc#nw-sriov-network-attachment_virt-connecting-vm-to-sriov[network attachment definition] when you created an `SriovNetwork` object.
+* You created a network attachment definition for a xref:../../virt/vm_networking/virt-connecting-vm-to-linux-bridge.adoc#virt-creating-linux-bridge-nad-web_virt-connecting-vm-to-linux-bridge[Linux bridge network] or the SR-IOV Network Operator created a xref:../../virt/vm_networking/virt-connecting-vm-to-sriov.adoc#nw-sriov-additional-network_virt-connecting-vm-to-sriov[network attachment definition] when you created an `SriovNetwork` object.
 endif::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
 ifdef::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
 * You configured a xref:../../virt/vm_networking/virt-connecting-vm-to-ovn-secondary-network.adoc#virt-connecting-vm-to-ovn-secondary-network[secondary network].

--- a/virt/vm_networking/virt-connecting-vm-to-sriov.adoc
+++ b/virt/vm_networking/virt-connecting-vm-to-sriov.adoc
@@ -6,15 +6,16 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 You can connect a virtual machine (VM) to a Single Root I/O Virtualization (SR-IOV) network by performing the following steps:
 
 * xref:../../virt/vm_networking/virt-connecting-vm-to-sriov.adoc#nw-sriov-configuring-device_virt-connecting-vm-to-sriov[Configuring an SR-IOV network device]
-* xref:../../virt/vm_networking/virt-connecting-vm-to-sriov.adoc#nw-sriov-network-attachment_virt-connecting-vm-to-sriov[Configuring an SR-IOV network]
+* xref:../../virt/vm_networking/virt-connecting-vm-to-sriov.adoc#nw-sriov-additional-network_virt-connecting-vm-to-sriov[Configuring an SR-IOV network]
 * xref:../../virt/vm_networking/virt-connecting-vm-to-sriov.adoc#virt-attaching-vm-to-sriov-network_virt-connecting-vm-to-sriov[Connecting the VM to the SR-IOV network]
 
 include::modules/nw-sriov-configuring-device.adoc[leveloffset=+1]
 
-include::modules/nw-sriov-network-attachment.adoc[leveloffset=+1]
+include::modules/nw-sriov-additional-network.adoc[leveloffset=+1]
 
 include::modules/virt-attaching-vm-to-sriov-network.adoc[leveloffset=+1]
 

--- a/virt/vm_networking/virt-hot-plugging-network-interfaces.adoc
+++ b/virt/vm_networking/virt-hot-plugging-network-interfaces.adoc
@@ -44,6 +44,6 @@ include::modules/virt-hot-unplugging-bridge-network-interface-cli.adoc[leveloffs
 ifndef::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
 * xref:../../virt/vm_networking/virt-connecting-vm-to-linux-bridge.adoc#creating-linux-bridge-nad[Creating a Linux bridge network attachment definition]
 * xref:../../virt/vm_networking/virt-connecting-vm-to-linux-bridge.adoc#configuring-vm-network-interface[Connecting a virtual machine to a Linux bridge network]
-* xref:../../virt/vm_networking/virt-connecting-vm-to-sriov.adoc#nw-sriov-network-attachment_virt-connecting-vm-to-sriov[Creating an SR-IOV network attachment definition]
+* xref:../../virt/vm_networking/virt-connecting-vm-to-sriov.adoc#nw-sriov-additional-network_virt-connecting-vm-to-sriov[Creating an SR-IOV network attachment definition]
 * xref:../../virt/vm_networking/virt-connecting-vm-to-sriov.adoc#virt-attaching-vm-to-sriov-network_virt-connecting-vm-to-sriov[Connecting a virtual machine to an SR-IOV network]
 endif::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]

--- a/virt/vm_networking/virt-networking-overview.adoc
+++ b/virt/vm_networking/virt-networking-overview.adoc
@@ -94,10 +94,10 @@ endif::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
 xref:../../virt/vm_networking/virt-connecting-vm-to-ovn-secondary-network.adoc#virt-connecting-vm-to-ovn-secondary-network[Connecting a virtual machine to an OVN-Kubernetes secondary network]::
 
 ifdef::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
-You can connect a VM to an Open Virtual Network (OVN)-Kubernetes secondary network. {VirtProductName} supports the `layer2` topology for OVN-Kubernetes. 
+You can connect a VM to an Open Virtual Network (OVN)-Kubernetes secondary network. {VirtProductName} supports the `layer2` topology for OVN-Kubernetes.
 +
 --
-A `layer2` topology connects workloads by a cluster-wide logical switch. The OVN-Kubernetes CNI plugin uses the Geneve (Generic Network Virtualization Encapsulation) protocol to create an overlay network between nodes. You can use this overlay network to connect VMs on different nodes, without having to configure any additional physical networking infrastructure. 
+A `layer2` topology connects workloads by a cluster-wide logical switch. The OVN-Kubernetes CNI plugin uses the Geneve (Generic Network Virtualization Encapsulation) protocol to create an overlay network between nodes. You can use this overlay network to connect VMs on different nodes, without having to configure any additional physical networking infrastructure.
 --
 endif::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
 
@@ -142,7 +142,7 @@ You must xref:../../networking/networking_operators/sr-iov-operator/installing-s
 You can connect a VM to an SR-IOV network by performing the following steps:
 
 . xref:../../virt/vm_networking/virt-connecting-vm-to-sriov.adoc#nw-sriov-configuring-device_virt-connecting-vm-to-sriov[Configure an SR-IOV network device] by creating a `SriovNetworkNodePolicy` CRD.
-. xref:../../virt/vm_networking/virt-connecting-vm-to-sriov.adoc#nw-sriov-network-attachment_virt-connecting-vm-to-sriov[Configure an SR-IOV network] by creating an `SriovNetwork` object.
+. xref:../../virt/vm_networking/virt-connecting-vm-to-sriov.adoc#nw-sriov-additional-network_virt-connecting-vm-to-sriov[Configure an SR-IOV network] by creating an `SriovNetwork` object.
 . xref:../../virt/vm_networking/virt-connecting-vm-to-sriov.adoc#virt-attaching-vm-to-sriov-network_virt-connecting-vm-to-sriov[Connect the VM to the SR-IOV network] by including the network details in the VM configuration.
 endif::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
 
@@ -239,7 +239,7 @@ The following table provides a comparison of features available when using the L
 endif::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
 
 [id="service-mesh-integration"]
-== Integrating with {SMProductName} 
+== Integrating with {SMProductName}
 xref:../../virt/vm_networking/virt-connecting-vm-to-service-mesh.adoc#virt-connecting-vm-to-service-mesh[Connecting a virtual machine to a service mesh]::
 
 {VirtProductName} is integrated with {SMProductShortName}. You can monitor, visualize, and control traffic between pods and virtual machines.
@@ -273,4 +273,3 @@ You create a service, associate the service with the VM, and connect to the IP a
 * xref:../../virt/managing_vms/virt-accessing-vm-ssh.adoc#using-secondary-networks-ssh_virt-accessing-vm-ssh[Secondary network]
 +
 You configure a secondary network, attach a VM to the secondary network interface, and connect to its allocated IP address.
-


### PR DESCRIPTION
Version(s):
4.16+

Issue:
https://issues.redhat.com/browse/DOCPLAN-86

Link to docs preview:
- https://107068--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/hardware_networks/configuring-sriov-ib-attach.html
- https://107068--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/hardware_networks/configuring-sriov-net-attach.html
- https://107068--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/vm_networking/virt-connecting-vm-to-sriov.html

QE review:
N/A - content doesn't change, just formatting / asciidoc structure for DITA conversion

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
