### PR TITLE
CNV-78580: Remove outdated prerequisites

### DIFF
--- a/modules/virt-generating-a-vm-memory-dump.adoc
+++ b/modules/virt-generating-a-vm-memory-dump.adoc
@@ -1,7 +1,8 @@
-:_newdoc-version: 2.18.5
-:_template-generated: 2025-08-14
-:_mod-docs-content-type: PROCEDURE
+// Module included in the following assemblies:
+//
+// virt/support/virt-collecting-virt-data.adoc
 
+:_mod-docs-content-type: PROCEDURE
 [id="virt-generating-a-vm-memory-dump_{context}"]
 = Generating a VM memory dump
 
@@ -10,28 +11,17 @@ When a virtual machine (VM) terminates unexpectedly, you can use the `virtctl me
 
 // You can specify an existing PVC or use the `--create-claim` flag to create a new PVC.
 
-.Prerequisites
+.Procedure
 
-* The hot plug feature gate is enabled in the `HyperConverged` custom resource. To do so, run the following command:
-+
-[source,terminal,subs="attributes+"]
-----
-$ oc patch hyperconverged kubevirt-hyperconverged -n {CNVNamespace} \
-  --type json -p '[{"op": "add", "path": "/spec/featureGates", \
-  "value": "HotplugVolumes"}]'
-----
-
-* Optional: You have an existing PVC on which you want to save the memory dump.
+. Optional: You have an existing PVC on which you want to save the memory dump.
 ** The PVC volume mode must be `FileSystem`.
 ** The PVC must be large enough to contain the memory dump.
 +
 The formula for calculating the PVC size is `(VMMemorySize + 100Mi) * FileSystemOverhead`, where `100Mi` is the memory dump overhead, and `FileSystemOverhead` is defined in the `HCO` object.
 
-.Procedure
-
 . Create a memory dump of the required VM:
 
-** If you have an existing PVC selected on which you want to save the memory dump: 
+** If you have an existing PVC selected on which you want to save the memory dump:
 +
 [source,terminal]
 ----
@@ -53,7 +43,7 @@ $ virtctl memory-dump download <vm_name> --output=<output_file>
 ----
 
 . Attach the memory dump to a Red Hat Support case.
-+ 
++
 Alternatively, you can inspect the memory dump, for example by using link:https://github.com/volatilityfoundation/volatility3[the volatility3 tool].
 
 . Optional: Remove the memory dump:


### PR DESCRIPTION
Version(s):
4.20+

Issue:
https://issues.redhat.com/browse/CNV-78580

Link to docs preview:
https://107082--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/support/virt-collecting-virt-data.html#virt-generating-a-vm-memory-dump_virt-collecting-virt-data

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
