### PR TITLE
OSDOCS-17203 Highlighting machine network parameter for bare metal UPI

### DIFF
--- a/modules/installation-bare-metal-config-yaml.adoc
+++ b/modules/installation-bare-metal-config-yaml.adoc
@@ -98,6 +98,8 @@ networking:
   - cidr: 10.128.0.0/14
     hostPrefix: 23
   networkType: OVNKubernetes
+  machineNetwork:
+  - cidr: 192.168.0.0/16
   serviceNetwork:
   - 172.30.0.0/16
 platform:
@@ -226,16 +228,17 @@ If you are installing a three-node cluster, do not deploy any compute machines w
 
 `controlPlane.replicas`:: Specifies the number of control plane machines that you add to the cluster. Because the cluster uses these values as the number of etcd endpoints in the cluster, the value must match the number of control plane machines that you deploy.
 `metadata.name`:: Specifies the cluster name that you specified in your DNS records.
-`clusterNetwork.cidr`:: Specifies a block of IP addresses from which pod IP addresses are allocated. This block must not overlap with existing physical networks. These IP addresses are used for the pod network. If you need to access the pods from an external network, you must configure load balancers and routers to manage the traffic.
+`networking.clusterNetwork.cidr`:: Specifies a block of IP addresses from which pod IP addresses are allocated. This block must not overlap with existing physical networks. These IP addresses are used for the pod network. If you need to access the pods from an external network, you must configure load balancers and routers to manage the traffic.
 
 [NOTE]
 ====
 Class E CIDR range is reserved for a future use. To use the Class E CIDR range, you must ensure your networking environment accepts the IP addresses within the Class E CIDR range.
 ====
 
-`cidr.hostPrefix`:: Specifies the subnet prefix length to assign to each individual node. For example, if `hostPrefix` is set to `23`, then each node is assigned a `/23` subnet out of the given `cidr`, which allows for 510 (2^(32 - 23) - 2) pod IP addresses. If you are required to provide access to nodes from an external network, configure load balancers and routers to manage the traffic.
-`networkType`:: Specifies the cluster network plugin to install. The default value `OVNKubernetes` is the only supported value.
-`serviceNetwork`:: Specifies the IP address pool to use for service IP addresses. You can enter only one IP address pool. This block must not overlap with existing physical networks. If you need to access the services from an external network, configure load balancers and routers to manage the traffic.
+`networking.clusterNetwork.hostPrefix`:: Specifies the subnet prefix length to assign to each individual node. For example, if `hostPrefix` is set to `23`, then each node is assigned a `/23` subnet out of the given `cidr`, which allows for 510 (2^(32 - 23) - 2) pod IP addresses. If you are required to provide access to nodes from an external network, configure load balancers and routers to manage the traffic.
+`networking.networkType`:: Specifies the cluster network plugin to install. The default value `OVNKubernetes` is the only supported value.
+`networking.machineNetwork`:: Optional. Specifies the IP address pool to use for machines in the cluster. You cannot change this value after installation. If you do not set this value, and you configure a cluster-wide proxy, you must manually add the machine network address pool or pools to the proxy configuration. For more information, see the _Configuring the cluster-wide proxy during installation_ section.
+`networking.serviceNetwork`:: Specifies the IP address pool to use for service IP addresses. You can enter only one IP address pool. This block must not overlap with existing physical networks. If you need to access the services from an external network, configure load balancers and routers to manage the traffic.
 `platform`:: Specifies the platform. You must set the platform to `none`. You cannot provide additional platform configuration variables for
 ifndef::ibm-z,ibm-z-kvm,ibm-power[your platform.]
 ifdef::ibm-z,ibm-z-kvm[{ibm-z-name} infrastructure.]


### PR DESCRIPTION
Version(s):
4.16+

Issue:
https://issues.redhat.com/browse/OSDOCS-17203

Link to docs preview:
[UPI Bare metal](https://107098--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/upi/installing-bare-metal#installation-bare-metal-config-yaml_installing-bare-metal)
[Platform agnostic](https://107098--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_platform_agnostic/installing-platform-agnostic#installation-bare-metal-config-yaml_installing-platform-agnostic)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Also renamed a few parameters to meet the requirement to list the full nested param.