### PR TITLE
remove level offset attribute and add comment at end of module to fix ToC

### DIFF
--- a/backup_and_restore/application_backup_and_restore/installing/installing-oadp-gcp.adoc
+++ b/backup_and_restore/application_backup_and_restore/installing/installing-oadp-gcp.adoc
@@ -31,7 +31,6 @@ include::modules/oadp-setting-resource-limits-and-requests.adoc[leveloffset=+2]
 
 include::snippets/oadp-nodeselector-snippet.adoc[]
 
-:leveloffset: 0
 include::modules/oadp-self-signed-certificate.adoc[leveloffset=+2]
 
 include::modules/oadp-using-ca-certificates-with-velero-command.adoc[leveloffset=+2]

--- a/backup_and_restore/application_backup_and_restore/installing/installing-oadp-kubevirt.adoc
+++ b/backup_and_restore/application_backup_and_restore/installing/installing-oadp-kubevirt.adoc
@@ -49,7 +49,6 @@ include::modules/oadp-backup-single-vm.adoc[leveloffset=+1]
 
 include::modules/oadp-restore-single-vm.adoc[leveloffset=+1]
 
-:leveloffset: 0
 include::modules/oadp-restore-single-vm-from-multiple-vm-backup.adoc[leveloffset=+1]
 
 include::modules/oadp-configuring-client-burst-qps.adoc[leveloffset=+1]
@@ -68,7 +67,6 @@ include::modules/oadp-configuring-repository-maintenance.adoc[leveloffset=+1]
 
 include::modules/oadp-configuring-velero-load-affinity.adoc[leveloffset=+1]
 
-:leveloffset: 0
 include::modules/oadp-configuring-imagepullpolicy.adoc[leveloffset=+1]
 
 include::modules/oadp-incremental-backup-support.adoc[leveloffset=+1]

--- a/backup_and_restore/application_backup_and_restore/installing/installing-oadp-ocs.adoc
+++ b/backup_and_restore/application_backup_and_restore/installing/installing-oadp-ocs.adoc
@@ -31,7 +31,6 @@ include::modules/oadp-setting-resource-limits-and-requests.adoc[leveloffset=+2]
 
 include::snippets/oadp-nodeselector-snippet.adoc[]
 
-:leveloffset: 0
 include::modules/oadp-odf-cpu-memory-requirements.adoc[leveloffset=+3]
 
 include::modules/oadp-self-signed-certificate.adoc[leveloffset=+2]

--- a/modules/oadp-backup-single-vm.adoc
+++ b/modules/oadp-backup-single-vm.adoc
@@ -57,3 +57,4 @@ $ oc apply -f <backup_cr_file_name>
 where:
 +
 `backup_cr_file_name`:: Specifies the name of the `Backup` CR file.
+// end of module. Need to add this comment because the level offset attribute does not get unset at the end of this module due to the continuation plus symbol. Causing the level offset from this module to stack on to the next module. This causes build failures or deeply nested modules.

--- a/modules/oadp-configuring-client-burst-qps.adoc
+++ b/modules/oadp-configuring-client-burst-qps.adoc
@@ -65,3 +65,5 @@ where:
 +
 `client-burst`:: Specifies the `client-burst` value. In this example, the `client-burst` field is set to 500.
 `client-qps`:: Specifies the `client-qps` value. In this example, the `client-qps` field is set to 300.
+
+// end of module. Need to add this comment because the level offset attribute does not get unset at the end of this module due to the continuation plus symbol. Causing the level offset from this module to stack on to the next module. This causes build failures or deeply nested modules.

--- a/modules/oadp-configuring-imagepullpolicy.adoc
+++ b/modules/oadp-configuring-imagepullpolicy.adoc
@@ -68,3 +68,5 @@ spec:
 where:
 +
 `imagePullPolicy`:: Specifies the value for `imagePullPolicy`. In this example, the `imagePullPolicy` field is set to `Never`.
+
+// end of module. Need to add this comment because the level offset attribute does not get unset at the end of this module due to the continuation plus symbol. Causing the level offset from this module to stack on to the next module. This causes build failures or deeply nested modules.

--- a/modules/oadp-configuring-node-agent-load-affinity.adoc
+++ b/modules/oadp-configuring-node-agent-load-affinity.adoc
@@ -65,3 +65,5 @@ where:
 +
 `loadAffinity`:: Specifies the `loadAffinity` object by adding the `matchLabels` and `matchExpressions` objects.
 `matchExpressions`:: Specifies the `matchExpressions` object to add restrictions on the node agent pods scheduling.
+
+// end of module. Need to add this comment because the level offset attribute does not get unset at the end of this module due to the continuation plus symbol. Causing the level offset from this module to stack on to the next module. This causes build failures or deeply nested modules.

--- a/modules/oadp-configuring-node-agent-load-concurrency.adoc
+++ b/modules/oadp-configuring-node-agent-load-concurrency.adoc
@@ -52,3 +52,5 @@ where:
 `globalConfig`:: Specifies the global concurrent number. The default value is 1, which means there is no concurrency and only one load is allowed. The `globalConfig` value does not have a limit.
 `label.io/instance-type`:: Specifies the label for per-node concurrency.
 `number`:: Specifies the per-node concurrent number. You can specify many per-node concurrent numbers, for example, based on the instance type and size. The range of per-node concurrent number is the same as the global concurrent number. If the configuration file contains a per-node concurrent number and a global concurrent number, the per-node concurrent number takes precedence.
+
+// end of module. Need to add this comment because the level offset attribute does not get unset at the end of this module due to the continuation plus symbol. Causing the level offset from this module to stack on to the next module. This causes build failures or deeply nested modules.

--- a/modules/oadp-configuring-node-agent-non-root.adoc
+++ b/modules/oadp-configuring-node-agent-non-root.adoc
@@ -126,3 +126,5 @@ where:
 `privileged`:: Specifies that the `privileged` field is false.
 `readOnlyRootFilesystem`:: Specifies that the root file system is read-only.
 `runAsNonRoot`:: Specifies that the node agent is run as a non-root user.
+
+// end of module. Need to add this comment because the level offset attribute does not get unset at the end of this module due to the continuation plus symbol. Causing the level offset from this module to stack on to the next module. This causes build failures or deeply nested modules.

--- a/modules/oadp-configuring-repository-maintenance.adoc
+++ b/modules/oadp-configuring-repository-maintenance.adoc
@@ -73,3 +73,5 @@ spec:
 where:
 +
 `myrepositoryname`:: Specifies the `repositoryMaintenance` object for each repository.
+
+// end of module. Need to add this comment because the level offset attribute does not get unset at the end of this module due to the continuation plus symbol. Causing the level offset from this module to stack on to the next module. This causes build failures or deeply nested modules.

--- a/modules/oadp-configuring-velero-load-affinity.adoc
+++ b/modules/oadp-configuring-velero-load-affinity.adoc
@@ -55,3 +55,5 @@ spec:
                   - US
                   - EU
 ----
+
+// end of module. Need to add this comment because the level offset attribute does not get unset at the end of this module due to the continuation plus symbol. Causing the level offset from this module to stack on to the next module. This causes build failures or deeply nested modules.

--- a/modules/oadp-incremental-backup-support.adoc
+++ b/modules/oadp-incremental-backup-support.adoc
@@ -35,3 +35,5 @@
 ====
 The CSI Data Mover backups use Kopia regardless of `uploaderType`.
 ====
+
+// end of module. Need to add this comment because the level offset attribute does not get unset at the end of this module due to the continuation plus symbol. Causing the level offset from this module to stack on to the next module. This causes build failures or deeply nested modules.

--- a/modules/oadp-restore-single-vm-from-multiple-vm-backup.adoc
+++ b/modules/oadp-restore-single-vm-from-multiple-vm-backup.adoc
@@ -62,3 +62,4 @@ $ oc apply -f <restore_cr_file_name>
 where:
 +
 `restore_cr_file_name`:: Specifies the name of the `Restore` CR file.
+// end of module. Need to add this comment because the level offset attribute does not get unset at the end of this module due to the continuation plus symbol. Causing the level offset from this module to stack on to the next module. This causes build failures or deeply nested modules.

--- a/modules/oadp-restore-single-vm.adoc
+++ b/modules/oadp-restore-single-vm.adoc
@@ -54,3 +54,4 @@ When you restore a backup of VMs, you might notice that the Ceph storage capacit
 
 Use the `rbd sparsify` tool to reclaim space on target volumes. For more details, see link:https://access.redhat.com/documentation/en-us/red_hat_openshift_data_foundation/latest/html-single/managing_and_allocating_storage_resources/index#reclaiming-space-on-target-volumes_rhodf[Reclaiming space on target volumes].
 ====
+// end of module. Need to add this comment because the level offset attribute does not get unset at the end of this module due to the continuation plus symbol. Causing the level offset from this module to stack on to the next module. This causes build failures or deeply nested modules.

--- a/modules/oadp-secrets-for-different-credentials.adoc
+++ b/modules/oadp-secrets-for-different-credentials.adoc
@@ -168,3 +168,5 @@ where:
 +
 `custom_secret`:: Specifies the backup location `Secret` with custom name.
 endif::[]
+
+// end of module. Need to add this comment because the level offset attribute does not get unset at the end of this module due to the continuation plus symbol. Causing the level offset from this module to stack on to the next module. This causes build failures or deeply nested modules.


### PR DESCRIPTION
**OCP versions**

OCP 4.14 -> 4.22

## Issue 1: GCP Assembly Build Failure

**Error:**

    asciidoctor: WARNING: modules/oadp-self-signed-certificate.adoc: line 7:
    section title out of sequence: expected level 3, got level 4

### Root Cause:

 The module `modules/oadp-secrets-for-different-credentials.adoc` ends with a definition list (`` `term`:: description ``) nested inside an ordered list via list continuation (`+`). When AsciiDoctor processes `include::file[leveloffset=+N]`, it appends `:leveloffset!:` after the included content to reset the offset. However, when the file ends in a nested list context, that `:leveloffset!:` directive gets absorbed by the list parser instead of being processed as a document-level attribute reset. This causes the leveloffset to leak into the next included module, pushing its headings one level deeper than expected.

The `:leveloffset: 0` that was previously added reset the `:leveloffset:` attribute to 0, but it did not fix the root cause.

### Fix:

 Added a comment (`// end of module...`) at the end of `oadp-secrets-for-different-credentials.adoc`. The comment acts as a non-whitespace line that forces AsciiDoctor to close the list parsing context before `:leveloffset!:` is appended, allowing it to be processed correctly.

## Issue 2: Kubevirt Assembly ToC Nesting Issues

**Symptoms:**

- `oadp-restore-single-vm-from-multiple-vm-backup.adoc` appeared nested under `oadp-restore-single-vm.adoc` in the ToC
- Modules after `oadp-configuring-client-burst-qps.adoc` were not displayed in the Netlify preview
- ToC did not match production docs at docs.okd.io

### Root Cause:

Same `leveloffset` leak pattern as Issue 1, but affecting **12 modules** in the kubevirt assembly chain. Each unfixed module's leaked `leveloffset` compounded with the next, causing progressively deeper nesting.

### Fix:

Added the `// end of module...` comment to all 12 affected modules and removed the `:leveloffset: 0` workaround on line 70 of `installing-oadp-kubevirt.adoc`.

### Files Modified (12 modules)

| # | File | Ending Pattern |
|---|------|---------------|
| 1 | modules/oadp-secrets-for-different-credentials.adoc | Definition list in ordered list continuation |
| 2 | modules/oadp-backup-single-vm.adoc | Definition list in list continuation |
| 3 | modules/oadp-restore-single-vm.adoc | Example block in list continuation |
| 4 | modules/oadp-restore-single-vm-from-multiple-vm-backup.adoc | Definition list in list continuation |
| 5 | modules/oadp-configuring-client-burst-qps.adoc | Definition list in list continuation |
| 6 | modules/oadp-configuring-velero-load-affinity.adoc | Code block in list continuation |
| 7 | modules/oadp-configuring-node-agent-non-root.adoc | Definition list in list continuation |
| 8 | modules/oadp-configuring-node-agent-load-affinity.adoc | Definition list in list continuation |
| 9 | modules/oadp-configuring-node-agent-load-concurrency.adoc | Definition list in list continuation |
| 10 | modules/oadp-configuring-repository-maintenance.adoc | Definition list in list continuation |
| 11 | modules/oadp-configuring-imagepullpolicy.adoc | Definition list in list continuation |
| 12 | modules/oadp-incremental-backup-support.adoc | NOTE block |
