### PR TITLE
CNV-69069-19: backporting deprecated alerts to 4.17, 4.18, 4.19

### DIFF
--- a/virt/monitoring/virt-runbooks.adoc
+++ b/virt/monitoring/virt-runbooks.adoc
@@ -16,7 +16,7 @@ xref:../../observability/monitoring/about-ocp-monitoring/key-concepts.adoc#about
 endif::openshift-dedicated,openshift-rosa[]
 follow the procedures in the runbooks for the {VirtProductName} Operator. Triggered {VirtProductName} alerts can be viewed in the main *Observe* -> *Alerts* tab in the web console, and also in the *Virtualization* -> *Overview* tab.
 
-Runbooks for the {VirtProductName} Operator are maintained in the link:https://github.com/openshift/runbooks/tree/master/alerts/openshift-virtualization-operator[openshift/runbooks] Git repository, and you can view them on GitHub. 
+Runbooks for the {VirtProductName} Operator are maintained in the link:https://github.com/openshift/runbooks/tree/master/alerts/openshift-virtualization-operator[openshift/runbooks] Git repository, and you can view them on GitHub.
 
 // IMPORTANT: these IDs are meant to exactly mirror the original module IDs //
 // changing them will break links in the actual alerts //
@@ -99,7 +99,7 @@ Runbooks for the {VirtProductName} Operator are maintained in the link:https://g
 [id="virt-runbook-KubeMacPoolDuplicateMacsfound_{context}"]
 == KubeMacPoolDuplicateMacsFound
 
-* link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/KubeMacPoolDuplicateMacsFound.md[View the runbook] for the `KubeMacPoolDuplicateMacsFound` alert.
+* The `KubeMacPoolDuplicateMacsFound` alert is link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/KubeMacPoolDuplicateMacsFound.md[deprecated].
 
 [id="virt-runbook-kubevirtcomponentexceedsrequestedcpu_{context}"]
 == KubeVirtComponentExceedsRequestedCPU
@@ -129,7 +129,7 @@ Runbooks for the {VirtProductName} Operator are maintained in the link:https://g
 [id="virt-runbook-kubevirtvmhighmemoryusage_{context}"]
 == KubevirtVmHighMemoryUsage
 
-* link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/KubevirtVmHighMemoryUsage.md[View the runbook] for the `KubevirtVmHighMemoryUsage` alert.
+* The `KubevirtVmHighMemoryUsage` alert is link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/KubevirtVmHighMemoryUsage.md[deprecated].
 
 [id="virt-runbook-kubevirtvmiexcessivemigrations_{context}"]
 == KubeVirtVMIExcessiveMigrations
@@ -199,7 +199,7 @@ Runbooks for the {VirtProductName} Operator are maintained in the link:https://g
 [id="virt-runbook-singlestackipv6unsupported_{context}"]
 == SingleStackIPv6Unsupported
 
-* link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/SingleStackIPv6Unsupported.md[View the runbook] for the `SingleStackIPv6Unsupported` alert.
+* The `SingleStackIPv6Unsupported` alert is link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/SingleStackIPv6Unsupported.md[deprecated].
 
 [id="virt-runbook-sspcommontemplatesmodificationreverted_{context}"]
 == SSPCommonTemplatesModificationReverted
@@ -221,15 +221,15 @@ Runbooks for the {VirtProductName} Operator are maintained in the link:https://g
 
 * link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/SSPHighRateRejectedVms.md[View the runbook] for the `SSPHighRateRejectedVms` alert.
 
+[id="virt-runbook-sspoperatordown_{context}"]
+== SSPOperatorDown
+
+* The `SSPOperatorDown` alert is link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/SSPOperatorDown.md[deprecated].
+
 [id="virt-runbook-ssptemplatevalidatordown_{context}"]
 == SSPTemplateValidatorDown
 
 * link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/SSPTemplateValidatorDown.md[View the runbook] for the `SSPTemplateValidatorDown` alert.
-
-[id="virt-runbook-sspoperatordown_{context}"]
-== SSPOperatorDown
-
-* link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/SSPOperatorDown.md[View the runbook] for the `SSPOperatorDown` alert.
 
 [id="virt-runbook-unsupportedhcomodification_{context}"]
 == UnsupportedHCOModification
@@ -249,7 +249,7 @@ Runbooks for the {VirtProductName} Operator are maintained in the link:https://g
 [id="virt-runbook-virtapiresterrorshigh_{context}"]
 == VirtApiRESTErrorsHigh
 
-* link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/VirtApiRESTErrorsHigh.md[View the runbook] for the `VirtApiRESTErrorsHigh` alert.
+* The `VirtApiRESTErrorsHigh` alert is link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/VirtApiRESTErrorsHigh.md[deprecated].
 
 [id="virt-runbook-virtcontrollerdown_{context}"]
 == VirtControllerDown
@@ -264,7 +264,7 @@ Runbooks for the {VirtProductName} Operator are maintained in the link:https://g
 [id="virt-runbook-virtcontrollerresterrorshigh_{context}"]
 == VirtControllerRESTErrorsHigh
 
-* link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/VirtControllerRESTErrorsHigh.md[View the runbook] for the `VirtControllerRESTErrorsHigh` alert.
+* The `VirtControllerRESTErrorsHigh` alert is link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/VirtControllerRESTErrorsHigh.md[deprecated].
 
 [id="virt-runbook-virthandlerdaemonsetrolloutfailing_{context}"]
 == VirtHandlerDaemonSetRolloutFailing
@@ -279,7 +279,7 @@ Runbooks for the {VirtProductName} Operator are maintained in the link:https://g
 [id="virt-runbook-virthandlerresterrorshigh_{context}"]
 == VirtHandlerRESTErrorsHigh
 
-* link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/VirtHandlerRESTErrorsHigh.md[View the runbook] for the `VirtHandlerRESTErrorsHigh` alert.
+* The `VirtHandlerRESTErrorsHigh` alert is link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/VirtHandlerRESTErrorsHigh.md[deprecated].
 
 [id="virt-runbook-virtoperatordown_{context}"]
 == VirtOperatorDown
@@ -294,7 +294,7 @@ Runbooks for the {VirtProductName} Operator are maintained in the link:https://g
 [id="virt-runbook-virtoperatorresterrorshigh_{context}"]
 == VirtOperatorRESTErrorsHigh
 
-* link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/VirtOperatorRESTErrorsHigh.md[View the runbook] for the `VirtOperatorRESTErrorsHigh` alert.
+* The `VirtOperatorRESTErrorsHigh` alert is link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/VirtOperatorRESTErrorsHigh.md[deprecated].
 
 [id="virt-runbook-virtualmachinecrcerrors_{context}"]
 == VirtualMachineCRCErrors


### PR DESCRIPTION
Manual CP from: https://github.com/openshift/openshift-docs/pull/107032