### PR TITLE
[OSDOCS-14787][OCPBUGS-20469]: Clarify oc adm policy who-can SCC limitations

### DIFF
--- a/modules/security-context-constraints-example.adoc
+++ b/modules/security-context-constraints-example.adoc
@@ -74,6 +74,14 @@ allows any capabilities.
 The `users` and `groups` fields on the SCC control which users can access the SCC.
 By default, cluster administrators, nodes, and the build controller are granted access to the privileged SCC. All authenticated users are granted access to the `restricted-v2` SCC.
 
+[NOTE]
+====
+When verifying access to an SCC, be aware of the following command behaviors:
+
+* The `oc adm policy who-can use scc <scc_name>` and `oc auth can-i use scc/<scc_name>` commands evaluate only RBAC policies (`RoleBinding` or `ClusterRoleBinding` resources). Their output does not include users or groups configured directly in the SCC `users` and `groups` fields.
+* The `oc describe scc <scc_name>` command displays only the users and groups configured directly within the SCC object. Its output does not include access granted through RBAC policies.
+====
+
 .Without explicit `runAsUser` setting
 [source,yaml]
 ----


### PR DESCRIPTION
Add a note to the SCC example module explaining that the who-can command only evaluates RBAC and does not reflect direct group assignments within the SCC object.

Summary of Issue:
When groups are configured directly in the SCC (Security Context Constraints) YAML, the SCC is correctly applied to those groups. However, running the `oc adm policy who-can use scc <scc-name>` command does not list those groups as having access.

Root Cause:
The oc adm policy who-can command only checks access granted through RBAC (RoleBinding/ClusterRoleBinding). It does not evaluate direct SCC-to-group assignments specified in the SCC object itself. As a result, access granted through SCC configuration alone is not reflected in the command output.

Documentation Reference:
The issue is related to the documentation here:
https://docs.redhat.com/en/documentation/openshift_container_platform/4.18/html/authentication_and_authorization/managing-pod-security-policies#security-context-constraints-example_configuring-internal-oauth:~:text=The%20groups%20that%20can%20access%20this%20SCC.

Suggested Documentation Update:
Add a note to the above section:

Note: The oc adm policy who-can use scc <scc-name> command only lists access granted through RBAC (RoleBindings or ClusterRoleBindings). It does not reflect access configured directly within the SCC object.

Version(s):
OCP 4.y

Issue:
https://issues.redhat.com/browse/OSDOCS-14787
https://issues.redhat.com/browse/OCPBUGS-20469

Link to docs preview:
https://107125--ocpdocs-pr.netlify.app/openshift-enterprise/latest/authentication/managing-security-context-constraints.html#security-context-constraints-example_configuring-internal-oauth

QE review:
- [ ] QE has approved this change.

Additional information:
Verified the AsciiDoc syntax matches the contributing_to_docs/doc_guidelines.adoc requirements.
Ran a local build using podman run --rm -it -v $(pwd):/docs:Z quay.io/openshift-cs/asciibinder asciibinder build.
Confirmed the note renders correctly within the definition list using +.
Tested _preview/openshift-enterprise/authentication/managing-security-context-constraints.html with preview window.
