### PR TITLE
[CQA] PR for SRVCOM-4231: Fix missing "_mod-docs-content-type" attribute in Assemblies & Modules

### DIFF
--- a/about/about-knative-eventing.adoc
+++ b/about/about-knative-eventing.adoc
@@ -1,4 +1,4 @@
-:_content-type: ASSEMBLY
+:_mod-docs-content-type: ASSEMBLY
 [id="about-knative-eventing"]
 = Knative Eventing
 :context: about-knative-eventing

--- a/about/about-knative-serving.adoc
+++ b/about/about-knative-serving.adoc
@@ -1,4 +1,4 @@
-:_content-type: ASSEMBLY
+:_mod-docs-content-type: ASSEMBLY
 [id="about-knative-serving"]
 = Knative Serving
 :context: about-knative-serving

--- a/modules/serverless-kafka-developer.adoc
+++ b/modules/serverless-kafka-developer.adoc
@@ -2,7 +2,7 @@
 //
 // serverless/about/about-knative-eventing.adoc
 
-:_content-type: CONCEPT
+:_mod-docs-content-type: CONCEPT
 [id="serverless-kafka-developer_{context}"]
 = Using the Knative broker for Apache Kafka
 


### PR DESCRIPTION
**Note for the peer & merge reviewer:** 
- This PR contains only `_mod-docs-content-type` updates. 
- No other CQA changes, error types, or content refinements are included. 
- Other CQA error types will be addressed in separate PRs to maintain clear scope and reviewability.

**Changes:** 
- This PR resolves CQA errors related to missing `_mod-docs-content-type` attributes across affected assemblies & modules in the Serverless repository. 
- Changes are metadata-only and do not impact user-facing content.

**Tracking JIRA:** https://issues.redhat.com/browse/SRVLOGIC-815

**You can cherry-pick for the following branches:** 
- `serverless-docs-1.37`
- `serverless-docs-1.38`

**I will create the Manual CPs for the following release branches:** 
- `serverless-docs-1.36`
- `serverless-docs-1.35`
- `serverless-docs-1.34`

**Reviews:**
- [ ] Peer has approved this change