### PR TITLE
[CQA] [Part 2] PR for SRVCOM-4230: Fix missing "_mod-docs-content-type" attribute in Modules

### DIFF
--- a/modules/about-must-gather.adoc
+++ b/modules/about-must-gather.adoc
@@ -8,7 +8,7 @@
 // * service_mesh/v1x/servicemesh-release-notes.adoc
 // * serverless/serverless-support.adoc
 
-:_content-type: CONCEPT
+:_mod-docs-content-type: CONCEPT
 [id="about-must-gather_{context}"]
 = About the must-gather tool
 

--- a/modules/accessing-the-current-envoy-bootstrap-configuration.adoc
+++ b/modules/accessing-the-current-envoy-bootstrap-configuration.adoc
@@ -1,7 +1,7 @@
 // Module included in the following assemblies:
 //
 // * config-applications/configuring-kourier.adoc
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="accessing-the-current-envoy-bootstrap-configuration_{context}"]
 = Accessing the current Envoy bootstrap configuration
 

--- a/modules/apiserversource-kn.adoc
+++ b/modules/apiserversource-kn.adoc
@@ -3,7 +3,7 @@
 // * serverless/eventing/event-sources/serverless-apiserversource.adoc
 // * serverless/reference/kn-eventing-ref.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="apiserversource-kn_{context}"]
 = Creating an API server source by using the Knative CLI
 

--- a/modules/apiserversource-yaml.adoc
+++ b/modules/apiserversource-yaml.adoc
@@ -6,7 +6,7 @@
 //
 // * serverless/eventing/event-sources/serverless-apiserversource.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="apiserversource-yaml_context"]
 = Creating an API server source by using YAML files
 

--- a/modules/configuring-containersource-with-ossm.adoc
+++ b/modules/configuring-containersource-with-ossm.adoc
@@ -1,4 +1,4 @@
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="configuring-containersource-with-ossm_{context}"]
 = Configuring ContainerSource with {SMProductShortName}
 

--- a/modules/configuring-queue-proxy.adoc
+++ b/modules/configuring-queue-proxy.adoc
@@ -1,4 +1,4 @@
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-configuring-queue-proxy_{context}"]
 = Configuring Queue Proxy Resources for a Knative Service
 

--- a/modules/configuring-sinkbinding-with-ossm.adoc
+++ b/modules/configuring-sinkbinding-with-ossm.adoc
@@ -1,4 +1,4 @@
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="configuring-sinkbinding-with-ossm_{context}"]
 = Configuring a sink binding with {SMProductShortName}
 

--- a/modules/creating-serverless-apps-admin-console.adoc
+++ b/modules/creating-serverless-apps-admin-console.adoc
@@ -2,7 +2,7 @@
 //
 // serverless/admin_guide/serverless-cluster-admin-serving.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="creating-serverless-apps-admin-console_{context}"]
 = Creating serverless applications using the Administrator perspective
 

--- a/modules/creating-serverless-apps-kn.adoc
+++ b/modules/creating-serverless-apps-kn.adoc
@@ -3,7 +3,7 @@
 // * serverless/develop/serverless-applications.adoc
 // * serverless/reference/kn-serving-ref.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="creating-serverless-apps-kn_{context}"]
 = Creating serverless applications by using the Knative CLI
 

--- a/modules/creating-serverless-apps-yaml.adoc
+++ b/modules/creating-serverless-apps-yaml.adoc
@@ -2,7 +2,7 @@
 //
 // * serverless/develop/serverless-applications.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="creating-serverless-apps-yaml_{context}"]
 = Creating serverless applications using YAML
 

--- a/modules/customizing-kourier-bootstrap-for-kourier-getaways.adoc
+++ b/modules/customizing-kourier-bootstrap-for-kourier-getaways.adoc
@@ -1,7 +1,7 @@
 // Module included in the following assemblies:
 //
 // * config-applications/configuring-kourier.adoc
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="customizing-kourier-bootstrap-for-kourier-getaways_{context}"]
 = Customizing kourier-bootstrap for Kourier getaways
 

--- a/modules/delete-kn-trigger.adoc
+++ b/modules/delete-kn-trigger.adoc
@@ -2,7 +2,7 @@
 //
 // * /serverless/eventing/triggers/delete-triggers-cli.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="delete-kn-trigger_{context}"]
 = Deleting a trigger by using the Knative CLI
 

--- a/modules/describe-function-kn.adoc
+++ b/modules/describe-function-kn.adoc
@@ -1,4 +1,4 @@
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="describe-function-kn_{context}"]
 = Describing a function
 

--- a/modules/distr-tracing-product-overview.adoc
+++ b/modules/distr-tracing-product-overview.adoc
@@ -6,7 +6,7 @@ This module included in the following assemblies:
 -serverless/serverless-tracing.adoc
 ////
 
-:_content-type: CONCEPT
+:_mod-docs-content-type: CONCEPT
 [id="distr-tracing-product-overview_{context}"]
 = Distributed tracing overview
 

--- a/modules/enabling-administrator-interface-access.adoc
+++ b/modules/enabling-administrator-interface-access.adoc
@@ -1,7 +1,7 @@
 // Module included in the following assemblies:
 //
 // * config-applications/configuring-kourier.adoc
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="enabling-administrator-interface-access_{context}"]
 = Enabling administrator interface access
 

--- a/modules/functions-list-kn.adoc
+++ b/modules/functions-list-kn.adoc
@@ -2,7 +2,7 @@
 
 // * /serverless/cli_tools/kn-func-ref.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="functions-list-kn_{context}"]
 = Listing existing functions
 

--- a/modules/interacting-serverless-apps-http2-gRPC.adoc
+++ b/modules/interacting-serverless-apps-http2-gRPC.adoc
@@ -2,7 +2,7 @@
 //
 // serverless/knative-serving/external-ingress-routing/using-http2-gRPC.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="interacting-serverless-apps-http2-grpc_{context}"]
 = Interacting with a serverless application using HTTP2 and gRPC
 

--- a/modules/kn-service-apply.adoc
+++ b/modules/kn-service-apply.adoc
@@ -2,7 +2,7 @@
 //
 // * serverless/reference/kn-serving-ref.adoc
 
-:_content-type: REFERENCE
+:_mod-docs-content-type: REFERENCE
 [id="kn-service-apply_{context}"]
 = Applying service declarations
 

--- a/modules/kn-service-describe.adoc
+++ b/modules/kn-service-describe.adoc
@@ -2,7 +2,7 @@
 //
 // * serverless/reference/kn-serving-ref.adoc
 
-:_content-type: REFERENCE
+:_mod-docs-content-type: REFERENCE
 [id="kn-service-describe_{context}"]
 = Describing serverless applications by using the Knative CLI
 

--- a/modules/kn-service-offline-about.adoc
+++ b/modules/kn-service-offline-about.adoc
@@ -2,7 +2,7 @@
 //
 // * serverless/reference/kn-serving-ref.adoc
 
-:_content-type: CONCEPT
+:_mod-docs-content-type: CONCEPT
 [id="kn-service-offline-about_{context}"]
 = About the Knative CLI offline mode
 

--- a/modules/kn-service-offline-create.adoc
+++ b/modules/kn-service-offline-create.adoc
@@ -3,7 +3,7 @@
 // * serverless/reference/kn-serving-ref.adoc
 // * serverless/develop/serverless-applications.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="creating-an-offline-service_{context}"]
 = Creating a service using offline mode
 

--- a/modules/kn-service-update.adoc
+++ b/modules/kn-service-update.adoc
@@ -2,7 +2,7 @@
 //
 // * serverless/reference/kn-serving-ref.adoc
 
-:_content-type: REFERENCE
+:_mod-docs-content-type: REFERENCE
 [id="kn-service-update_{context}"]
 = Updating serverless applications by using the Knative CLI
 

--- a/modules/kn-trigger-describe.adoc
+++ b/modules/kn-trigger-describe.adoc
@@ -2,7 +2,7 @@
 //
 // * /serverless/eventing/triggers/describe-triggers-cli.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="kn-trigger-describe_{context}"]
 = Describing a trigger by using the Knative CLI
 

--- a/modules/kn-trigger-filtering.adoc
+++ b/modules/kn-trigger-filtering.adoc
@@ -2,7 +2,7 @@
 //
 // * /serverless/eventing/triggers/filter-triggers-cli.adoc
 
-:_content-type: REFERENCE
+:_mod-docs-content-type: REFERENCE
 [id="kn-trigger-filtering_{context}"]
 = Filtering events with triggers by using the Knative CLI
 // should be a procedure module but out of scope for this PR

--- a/modules/kn-trigger-list.adoc
+++ b/modules/kn-trigger-list.adoc
@@ -2,7 +2,7 @@
 //
 // * /serverless/eventing/triggers/list-triggers-cli.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="kn-trigger-list_{context}"]
 = Listing triggers by using the Knative CLI
 

--- a/modules/kn-trigger-update.adoc
+++ b/modules/kn-trigger-update.adoc
@@ -2,7 +2,7 @@
 //
 // * /serverless/develop/serverless-triggers.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="kn-trigger-update_{context}"]
 = Updating a trigger by using the Knative CLI
 

--- a/modules/knative-eventing-CR-system-deployments.adoc
+++ b/modules/knative-eventing-CR-system-deployments.adoc
@@ -2,7 +2,7 @@
 //
 // * serverless/eventing/tuning/overriding-config-eventing.adoc
 
-:_content-type: REFERENCE
+:_mod-docs-content-type: REFERENCE
 [id="knative-eventing-CR-system-deployments_{context}"]
 = Overriding deployment configurations
 

--- a/modules/knative-eventing-modifying-consumer-group-ids-and-topic-names.adoc
+++ b/modules/knative-eventing-modifying-consumer-group-ids-and-topic-names.adoc
@@ -2,7 +2,7 @@
 //
 // * serverless/eventing/tuning/overriding-config-eventing.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="knative-eventing-modifying-consumer-group-ids-and-topic-names_{context}"]
 = Modifying consumer group IDs and topic names
 

--- a/modules/knative-service-cluster-local.adoc
+++ b/modules/knative-service-cluster-local.adoc
@@ -2,7 +2,7 @@
 //
 // * serverless/knative-serving/external-ingress-routing/routing-overview.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="knative-service-cluster-local_{context}"]
 = Setting cluster availability to cluster local
 

--- a/modules/knative-serving-CR-system-deployments.adoc
+++ b/modules/knative-serving-CR-system-deployments.adoc
@@ -2,7 +2,7 @@
 //
 // * serverless/admin_guide/serverless-configuration.adoc
 
-:_content-type: REFERENCE
+:_mod-docs-content-type: REFERENCE
 [id="knative-serving-CR-system-deployments_{context}"]
 = Overriding system deployment configurations
 

--- a/modules/knative-serving-controller-custom-certs-secrets.adoc
+++ b/modules/knative-serving-controller-custom-certs-secrets.adoc
@@ -2,7 +2,7 @@
 //
 // * serverless/admin_guide/serverless-configuration.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="knative-serving-controller-custom-certs-secrets_{context}"]
 = Configuring tag-to-digest resolution by using a secret
 

--- a/modules/odc-creating-apiserversource.adoc
+++ b/modules/odc-creating-apiserversource.adoc
@@ -2,7 +2,7 @@
 //
 // * serverless/eventing/event-sources/serverless-apiserversource.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="odc-creating-apiserversource_{context}"]
 = Creating an API server source by using the web console
 

--- a/modules/odc-creating-functions.adoc
+++ b/modules/odc-creating-functions.adoc
@@ -2,7 +2,7 @@
 //
 // * serverless/functions/serverless-functions-getting-started.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="odc-creating-functions_{context}"]
 = Creating a function in the web console
 

--- a/modules/odc-splitting-traffic-between-revisions-using-developer-perspective.adoc
+++ b/modules/odc-splitting-traffic-between-revisions-using-developer-perspective.adoc
@@ -2,7 +2,7 @@
 //
 // * serverless/develop/serverless-traffic-management.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="odc-splitting-traffic-between-revisions-using-developer-perspective_{context}"]
 = Managing traffic between revisions by using the {ocp-product-title} web console
 

--- a/modules/release-notes-template.adoc
+++ b/modules/release-notes-template.adoc
@@ -2,7 +2,7 @@
 //
 // * about/serverless-release-notes.adoc
 
-:_content-type: REFERENCE
+:_mod-docs-content-type: REFERENCE
 [id="serverless-rn-X-YY-Z_{context}"]
 = Red Hat {ServerlessProductName} X.YY[.Z]
 // Substitute X-YY-Z with full version (e.g. 1-29-0)

--- a/modules/serverless-about-collecting-data.adoc
+++ b/modules/serverless-about-collecting-data.adoc
@@ -2,7 +2,7 @@
 //
 // * serverless/serverless-support.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-about-collecting-data_{context}"]
 = About collecting {ServerlessProductName} data
 

--- a/modules/serverless-activator-metrics.adoc
+++ b/modules/serverless-activator-metrics.adoc
@@ -2,7 +2,7 @@
 //
 // * serverless/observability/admin-metrics/serverless-admin-metrics.adoc
 
-:_content-type: REFERENCE
+:_mod-docs-content-type: REFERENCE
 [id="serverless-activator-metrics_{context}"]
 = Activator metrics
 

--- a/modules/serverless-admin-init-containers.adoc
+++ b/modules/serverless-admin-init-containers.adoc
@@ -2,7 +2,7 @@
 //
 // * /serverless/admin_guide/serverless-configuration.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-admin-init-containers_{context}"]
 = Enabling init containers
 

--- a/modules/serverless-api-versions.adoc
+++ b/modules/serverless-api-versions.adoc
@@ -2,7 +2,7 @@
 //
 // * serverless/serverless-release-notes.adoc
 
-:_content-type: CONCEPT
+:_mod-docs-content-type: CONCEPT
 [id="serverless-api-versions_{context}"]
 = About API versions
 

--- a/modules/serverless-applications-checking-ingress-istio-routing.adoc
+++ b/modules/serverless-applications-checking-ingress-istio-routing.adoc
@@ -2,7 +2,7 @@
 //
 // * knative-serving/debugging-serverless-applications.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-applications-checking-ingress-istio-routing_{context}"]
 = Checking Ingress and Istio routing
 

--- a/modules/serverless-applications-checking-ingress-status.adoc
+++ b/modules/serverless-applications-checking-ingress-status.adoc
@@ -2,7 +2,7 @@
 //
 // * knative-serving/debugging-serverless-applications.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-applications-checking-ingress-status_{context}"]
 = Checking Ingress status
 

--- a/modules/serverless-applications-checking-pod-status.adoc
+++ b/modules/serverless-applications-checking-pod-status.adoc
@@ -2,7 +2,7 @@
 //
 // * knative-serving/debugging-serverless-applications.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-applications-checking-pod-status_{context}"]
 = Checking pod status
 

--- a/modules/serverless-applications-checking-revision-status.adoc
+++ b/modules/serverless-applications-checking-revision-status.adoc
@@ -2,7 +2,7 @@
 //
 // * knative-serving/debugging-serverless-applications.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-applications-checking-revision-status_{context}"]
 = Checking revision status
 

--- a/modules/serverless-applications-checking-route-status.adoc
+++ b/modules/serverless-applications-checking-route-status.adoc
@@ -2,7 +2,7 @@
 //
 // * knative-serving/debugging-serverless-applications.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-applications-checking-route-status_{context}"]
 = Checking route status
 

--- a/modules/serverless-applications-checking-terminal-output.adoc
+++ b/modules/serverless-applications-checking-terminal-output.adoc
@@ -2,7 +2,7 @@
 //
 // * knative-serving/debugging-serverless-applications.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-applications-checking-terminal-output_{context}"]
 = Checking terminal output
 

--- a/modules/serverless-autoscaler-metrics.adoc
+++ b/modules/serverless-autoscaler-metrics.adoc
@@ -2,7 +2,7 @@
 //
 // * serverless/observability/admin-metrics/serverless-admin-metrics.adoc
 
-:_content-type: REFERENCE
+:_mod-docs-content-type: REFERENCE
 [id="serverless-autoscaler-metrics_{context}"]
 = Autoscaler metrics
 

--- a/modules/serverless-autoscaling-developer-maxscale.adoc
+++ b/modules/serverless-autoscaling-developer-maxscale.adoc
@@ -2,7 +2,7 @@
 //
 // * serverless/knative-serving/autoscaling/serverless-autoscaling-developer.adoc
 
-:_content-type: REFERENCE
+:_mod-docs-content-type: REFERENCE
 [id="serverless-autoscaling-developer-maxscale_{context}"]
 = Maximum scale bounds
 

--- a/modules/serverless-autoscaling-developer-minscale.adoc
+++ b/modules/serverless-autoscaling-developer-minscale.adoc
@@ -2,7 +2,7 @@
 //
 // * serverless/knative-serving/autoscaling/serverless-autoscaling-developer.adoc
 
-:_content-type: REFERENCE
+:_mod-docs-content-type: REFERENCE
 [id="serverless-autoscaling-developer-minscale_{context}"]
 = Minimum scale bounds
 

--- a/modules/serverless-autoscaling-maxscale-kn.adoc
+++ b/modules/serverless-autoscaling-maxscale-kn.adoc
@@ -2,7 +2,7 @@
 //
 // * serverless/knative-serving/autoscaling/serverless-autoscaling-developer.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-autoscaling-maxscale-kn_{context}"]
 = Setting the max-scale annotation by using the Knative CLI
 

--- a/modules/serverless-autoscaling-minscale-kn.adoc
+++ b/modules/serverless-autoscaling-minscale-kn.adoc
@@ -2,7 +2,7 @@
 //
 // * serverless/knative-serving/autoscaling/serverless-autoscaling-developer.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-autoscaling-minscale-kn_{context}"]
 = Setting the min-scale annotation by using the Knative CLI
 

--- a/modules/serverless-blue-green-deploy.adoc
+++ b/modules/serverless-blue-green-deploy.adoc
@@ -2,7 +2,7 @@
 //
 // * serverless/develop/serverless-traffic-management.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-blue-green-deploy_{context}"]
 = Routing and managing traffic by using a blue-green deployment strategy
 

--- a/modules/serverless-broker-filter-metrics.adoc
+++ b/modules/serverless-broker-filter-metrics.adoc
@@ -2,7 +2,7 @@
 //
 // * serverless/observability/admin-metrics/serverless-admin-metrics.adoc
 
-:_content-type: REFERENCE
+:_mod-docs-content-type: REFERENCE
 [id="serverless-broker-filter-metrics_{context}"]
 = Broker filter metrics
 

--- a/modules/serverless-broker-ingress-metrics.adoc
+++ b/modules/serverless-broker-ingress-metrics.adoc
@@ -2,7 +2,7 @@
 //
 // * serverless/observability/admin-metrics/serverless-admin-metrics.adoc
 
-:_content-type: REFERENCE
+:_mod-docs-content-type: REFERENCE
 [id="serverless-broker-ingress-metrics_{context}"]
 = Broker ingress metrics
 

--- a/modules/serverless-build-events-kn.adoc
+++ b/modules/serverless-build-events-kn.adoc
@@ -1,4 +1,4 @@
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-build-events-kn_{context}"]
 = Building events by using the kn-event plugin
 

--- a/modules/serverless-build-func-kn.adoc
+++ b/modules/serverless-build-func-kn.adoc
@@ -2,7 +2,7 @@
 //
 // * serverless/functions/serverless-functions-getting-started.adoc
 
-:_content-type: REFERENCE
+:_mod-docs-content-type: REFERENCE
 [id="serverless-build-func-kn_{context}"]
 = Building a function
 

--- a/modules/serverless-channel-default.adoc
+++ b/modules/serverless-channel-default.adoc
@@ -2,7 +2,7 @@
 //
 //  * serverless/eventing/channels/serverless-channel-default.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-channel-default_{context}"]
 = Configuring the default channel implementation
 

--- a/modules/serverless-cluster-sizing-req-additional.adoc
+++ b/modules/serverless-cluster-sizing-req-additional.adoc
@@ -2,7 +2,7 @@
 //
 // * /serverless/install/install-serverless-operator.adoc
 
-:_content-type: REFERENCE
+:_mod-docs-content-type: REFERENCE
 [id="serverless-cluster-sizing-req-additional_{context}"]
 = Additional requirements for advanced use-cases
 

--- a/modules/serverless-cluster-sizing-req.adoc
+++ b/modules/serverless-cluster-sizing-req.adoc
@@ -2,7 +2,7 @@
 //
 // * /serverless/install/preparing-serverless-install.adoc
 
-:_content-type: REFERENCE
+:_mod-docs-content-type: REFERENCE
 [id="serverless-cluster-sizing-req_{context}"]
 = Defining cluster size requirements
 

--- a/modules/serverless-concurrency-limits-configure-hard.adoc
+++ b/modules/serverless-concurrency-limits-configure-hard.adoc
@@ -2,7 +2,7 @@
 //
 // * serverless/knative-serving/autoscaling/serverless-autoscaling-developer.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-concurrency-limits-configure-hard_{context}"]
 = Configuring a hard concurrency limit
 

--- a/modules/serverless-concurrency-limits-configure-soft.adoc
+++ b/modules/serverless-concurrency-limits-configure-soft.adoc
@@ -2,7 +2,7 @@
 //
 // * serverless/knative-serving/autoscaling/serverless-autoscaling-developer.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-concurrency-limits-configure-soft_{context}"]
 = Configuring a soft concurrency target
 

--- a/modules/serverless-config-emptydir.adoc
+++ b/modules/serverless-config-emptydir.adoc
@@ -2,7 +2,7 @@
 //
 // * serverless/knative-serving/config-applications/serverless-configuration.adoc
 
-:_content-type: REFERENCE
+:_mod-docs-content-type: REFERENCE
 [id="serverless-config-emptydir_{context}"]
 = Configuring the EmptyDir extension
 // should probably be a procedure doc, but this is out of scope for the abstracts PR

--- a/modules/serverless-config-replicas-eventing.adoc
+++ b/modules/serverless-config-replicas-eventing.adoc
@@ -2,7 +2,7 @@
 //
 // * /serverless/eventing/tuning/serverless-ha.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-config-replicas-eventing_{context}"]
 = Configuring high availability replicas for Knative Eventing
 

--- a/modules/serverless-config-replicas-kafka.adoc
+++ b/modules/serverless-config-replicas-kafka.adoc
@@ -2,7 +2,7 @@
 //
 // * /serverless/eventing/tuning/serverless-ha.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-config-replicas-kafka_{context}"]
 = Configuring high availability replicas for the Knative broker implementation for Apache Kafka
 

--- a/modules/serverless-config-replicas-serving.adoc
+++ b/modules/serverless-config-replicas-serving.adoc
@@ -3,7 +3,7 @@
 // * /serverless/knative-serving/config-ha-services/ha-replicas-serving.adoc
 // * /serverless/eventing/tuning/serverless-ha.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-config-replicas-serving_{context}"]
 = Configuring high availability replicas for Knative Serving
 

--- a/modules/serverless-configuring-burst-qps-for-net-kourier.adoc
+++ b/modules/serverless-configuring-burst-qps-for-net-kourier.adoc
@@ -2,7 +2,7 @@
 //
 // * knative-serving/kube-burst-qps-net-kourier.adoc
 
-:_content-type: REFERENCE
+:_mod-docs-content-type: REFERENCE
 [id="serverless-configuring-burst-qps-for-net-kourier_{context}"]
 = Configuring burst and QPS values for net-kourier
 

--- a/modules/serverless-configuring-event-delivery-examples.adoc
+++ b/modules/serverless-configuring-event-delivery-examples.adoc
@@ -2,7 +2,7 @@
 //
 // * /serverless/eventing/serverless-event-delivery.adoc
 
-:_content-type: REFERENCE
+:_mod-docs-content-type: REFERENCE
 [id="serverless-configuring-event-delivery-examples_{context}"]
 = Examples of configuring event delivery parameters
 

--- a/modules/serverless-configuring-kube-rbac-proxy-resources-for-eventing.adoc
+++ b/modules/serverless-configuring-kube-rbac-proxy-resources-for-eventing.adoc
@@ -2,7 +2,7 @@
 //
 // * eventing/kube-rbac-proxy-eventing.adoc
 
-:_content-type: REFERENCE
+:_mod-docs-content-type: REFERENCE
 [id="serverless-configuring-kube-rbac-proxy-resources-for-eventing_{context}"]
 = Configuring kube-rbac-proxy resources for Eventing
 

--- a/modules/serverless-configuring-kube-rbac-proxy-resources-for-kafka.adoc
+++ b/modules/serverless-configuring-kube-rbac-proxy-resources-for-kafka.adoc
@@ -2,7 +2,7 @@
 //
 // * install/kube-rbac-proxy-kafka.adoc
 
-:_content-type: REFERENCE
+:_mod-docs-content-type: REFERENCE
 [id="serverless-configuring-kube-rbac-proxy-resources-for-kafka_{context}"]
 = Configuring kube-rbac-proxy resources for Knative for Apache Kafka
 

--- a/modules/serverless-configuring-kube-rbac-proxy-resources-for-serving.adoc
+++ b/modules/serverless-configuring-kube-rbac-proxy-resources-for-serving.adoc
@@ -2,7 +2,7 @@
 //
 // * knative-serving/kube-rbac-proxy-serving.adoc
 
-:_content-type: REFERENCE
+:_mod-docs-content-type: REFERENCE
 [id="serverless-configuring-kube-rbac-proxy-resources-for-serving_{context}"]
 = Configuring kube-rbac-proxy resources for Serving
 

--- a/modules/serverless-configuring-multi-container-service.adoc
+++ b/modules/serverless-configuring-multi-container-service.adoc
@@ -2,7 +2,7 @@
 //
 // * serverless/knative-serving/config-applications/multi-container-support-for-serving.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-configuring-multi-container-service_{context}"]
 = Configuring a multi-container service
 

--- a/modules/serverless-configuring-progress-deadline-serving.adoc
+++ b/modules/serverless-configuring-progress-deadline-serving.adoc
@@ -2,7 +2,7 @@
 //
 // * serverless/knative-serving/config-applications/startup-probes-for-serving.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-configuring-progress-deadline-serving_{context}"]
 = Configuring the progress deadline
 

--- a/modules/serverless-configuring-runtimeclass-name.adoc
+++ b/modules/serverless-configuring-runtimeclass-name.adoc
@@ -2,7 +2,7 @@
 //
 // * knative-serving/config-applications/deployment-resources.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-configuring-runtimeclass-name_{context}"]
 = Configuring selectable RuntimeClassName 
 

--- a/modules/serverless-configuring-startup-probing-serving.adoc
+++ b/modules/serverless-configuring-startup-probing-serving.adoc
@@ -2,7 +2,7 @@
 //
 // * serverless/knative-serving/config-applications/startup-probes-for-serving.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-configuring-startup-probing-serving_{context}"]
 = Configuring startup probing
 

--- a/modules/serverless-connect-func-source-odc.adoc
+++ b/modules/serverless-connect-func-source-odc.adoc
@@ -2,7 +2,7 @@
 //
 // * serverless/functions/serverless-functions-eventing.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-connect-func-source-odc_{context}"]
 = Connect an event source to a function
 

--- a/modules/serverless-connect-sink-broker-odc.adoc
+++ b/modules/serverless-connect-sink-broker-odc.adoc
@@ -2,7 +2,7 @@
 //
 // * serverless/eventing/brokers/serverless-using-brokers-managing-brokers.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-connect-sink-broker-odc_{context}"]
 = Connect a broker to a sink
 

--- a/modules/serverless-connect-sink-source-odc.adoc
+++ b/modules/serverless-connect-sink-source-odc.adoc
@@ -2,7 +2,7 @@
 //
 // * serverless/eventing/event-sources/serverless-sink-source-odc.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-connect-sink-source-odc_{context}"]
 = Connect an event source to an event sink
 

--- a/modules/serverless-containersource-guidelines.adoc
+++ b/modules/serverless-containersource-guidelines.adoc
@@ -2,7 +2,7 @@
 //
 // * /serverless/eventing/event-sources/serverless-custom-event-sources.adoc
 
-:_content-type: REFERENCE
+:_mod-docs-content-type: REFERENCE
 [id="serverless-containersource-guidelines_{context}"]
 = Guidelines for creating a container image
 

--- a/modules/serverless-containersource-ossm.adoc
+++ b/modules/serverless-containersource-ossm.adoc
@@ -2,7 +2,7 @@
 //
 // * /serverless/eventing/event-sources/serverless-custom-event-sources.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-containersource-ossm_{context}"]
 = Integrating {SMProductShortName} with ContainerSource
 

--- a/modules/serverless-containersource-reference.adoc
+++ b/modules/serverless-containersource-reference.adoc
@@ -2,7 +2,7 @@
 //
 // * /serverless/eventing/event-sources/serverless-custom-event-sources.adoc
 
-:_content-type: REFERENCE
+:_mod-docs-content-type: REFERENCE
 [id="serverless-containersource-reference_{context}"]
 = Container source reference
 

--- a/modules/serverless-cost-management-labels.adoc
+++ b/modules/serverless-cost-management-labels.adoc
@@ -2,7 +2,7 @@
 //
 // * /serverless/integrations/serverless-cost-management-integration.adoc
 
-:_content-type: REFERENCE
+:_mod-docs-content-type: REFERENCE
 [id="serverless-cost-management-labels_{context}"]
 = Labels for cost management queries
 

--- a/modules/serverless-create-broker-kn.adoc
+++ b/modules/serverless-create-broker-kn.adoc
@@ -2,7 +2,7 @@
 //
 // * /serverless/eventing/brokers/serverless-using-brokers.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-create-broker-kn_{context}"]
 = Creating a broker by using the Knative CLI
 

--- a/modules/serverless-create-channel-kn.adoc
+++ b/modules/serverless-create-channel-kn.adoc
@@ -2,7 +2,7 @@
 //
 //  * /serverless/develop/serverless-creating-channels.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-create-channel-kn_{context}"]
 = Creating a channel by using the Knative CLI
 

--- a/modules/serverless-create-channel-odc.adoc
+++ b/modules/serverless-create-channel-odc.adoc
@@ -2,7 +2,7 @@
 //
 //  * /serverless/develop/serverless-creating-channels.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-create-channel-odc_{context}"]
 = Creating a channel
 

--- a/modules/serverless-create-default-channel-yaml.adoc
+++ b/modules/serverless-create-default-channel-yaml.adoc
@@ -2,7 +2,7 @@
 //
 //  * /serverless/develop/serverless-creating-channels.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-create-default-channel-yaml_{context}"]
 = Creating a default implementation channel by using YAML
 

--- a/modules/serverless-create-domain-mapping-kn.adoc
+++ b/modules/serverless-create-domain-mapping-kn.adoc
@@ -3,7 +3,7 @@
 // * serverless/security/serverless-custom-domains.adoc
 // * serverless/reference/kn-serving-ref.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-create-domain-mapping-kn_{context}"]
 = Creating a custom domain mapping by using the Knative CLI
 

--- a/modules/serverless-create-domain-mapping.adoc
+++ b/modules/serverless-create-domain-mapping.adoc
@@ -2,7 +2,7 @@
 //
 // * serverless/knative-serving/config-custom-domains/create-domain-mapping.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-create-domain-mapping_{context}"]
 = Creating a custom domain mapping
 

--- a/modules/serverless-create-func-kn.adoc
+++ b/modules/serverless-create-func-kn.adoc
@@ -3,7 +3,7 @@
 // * serverless/functions/serverless-functions-getting-started.adoc
 // * serverless/reference/kn-func-ref.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-create-func-kn_{context}"]
 = Creating a function by using the Knative CLI
 

--- a/modules/serverless-create-kafka-channel-yaml.adoc
+++ b/modules/serverless-create-kafka-channel-yaml.adoc
@@ -3,7 +3,7 @@
 //  * serverless/develop/serverless-creating-channels.adoc
 //  * serverless/develop/serverless-kafka-developer.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-create-kafka-channel-yaml_{context}"]
 = Creating a channel for Apache Kafka by using YAML
 

--- a/modules/serverless-create-kafka-namespaced-broker.adoc
+++ b/modules/serverless-create-kafka-namespaced-broker.adoc
@@ -2,7 +2,7 @@
 //
 // * serverless/eventing/brokers/kafka-broker.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-create-kafka-namespaced-broker-{context}"]
 = Creating a Knative broker for Apache Kafka that uses an isolated data plane
 

--- a/modules/serverless-create-kn-trigger.adoc
+++ b/modules/serverless-create-kn-trigger.adoc
@@ -2,7 +2,7 @@
 //
 // * /serverless/eventing/triggers/create-trigger-cli.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-create-kn-trigger_{context}"]
 = Creating a trigger by using the Knative CLI
 

--- a/modules/serverless-create-traffic-split-kn.adoc
+++ b/modules/serverless-create-traffic-split-kn.adoc
@@ -2,7 +2,7 @@
 //
 // * serverless/develop/serverless-traffic-management.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-create-traffic-split-kn_{context}"]
 = Creating a traffic split by using the Knative CLI
 

--- a/modules/serverless-create-trigger-odc.adoc
+++ b/modules/serverless-create-trigger-odc.adoc
@@ -2,7 +2,7 @@
 //
 // * /serverless/eventing/triggers/create-trigger-odc.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-create-trigger-odc_{context}"]
 = Creating a trigger
 

--- a/modules/serverless-creating-a-broker-odc.adoc
+++ b/modules/serverless-creating-a-broker-odc.adoc
@@ -2,7 +2,7 @@
 //
 // * /serverless/develop/serverless-pingsource.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-creating-a-broker-odc_{context}"]
 = Creating a broker by using the web console
 

--- a/modules/serverless-creating-a-kafka-event-sink.adoc
+++ b/modules/serverless-creating-a-kafka-event-sink.adoc
@@ -2,7 +2,7 @@
 //
 // * serverless/eventing/event-sinks/serverless-kafka-developer-sink.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-creating-a-kafka-event-sink_{context}"]
 = Creating an event sink for Apache Kafka by using the {ocp-product-title} web console
 

--- a/modules/serverless-creating-broker-admin-web-console.adoc
+++ b/modules/serverless-creating-broker-admin-web-console.adoc
@@ -2,7 +2,7 @@
 //
 // * serverless/eventing/brokers/serverless-using-brokers.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-creating-broker-admin-web-console_{context}"]
 = Creating a broker by using the Administrator perspective
 

--- a/modules/serverless-creating-broker-annotation.adoc
+++ b/modules/serverless-creating-broker-annotation.adoc
@@ -2,7 +2,7 @@
 //
 // * /serverless/eventing/brokers/serverless-using-brokers.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-creating-broker-annotation_{context}"]
 = Creating a broker by annotating a trigger
 

--- a/modules/serverless-creating-broker-labeling.adoc
+++ b/modules/serverless-creating-broker-labeling.adoc
@@ -2,7 +2,7 @@
 //
 // * /serverless/eventing/brokers/serverless-using-brokers.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-creating-broker-labeling_{context}"]
 = Creating a broker by labeling a namespace
 

--- a/modules/serverless-creating-channel-admin-web-console.adoc
+++ b/modules/serverless-creating-channel-admin-web-console.adoc
@@ -2,7 +2,7 @@
 //
 // * serverless/admin_guide/serverless-cluster-admin-eventing.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-creating-channel-admin-web-console_{context}"]
 = Creating a channel by using the Administrator perspective
 

--- a/modules/serverless-creating-event-source-admin-web-console.adoc
+++ b/modules/serverless-creating-event-source-admin-web-console.adoc
@@ -2,7 +2,7 @@
 //
 // * serverless/admin_guide/serverless-cluster-admin-eventing.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-creating-event-source-admin-web-console_{context}"]
 = Creating an event source
 

--- a/modules/serverless-creating-subscription-admin-web-console.adoc
+++ b/modules/serverless-creating-subscription-admin-web-console.adoc
@@ -2,7 +2,7 @@
 //
 // * serverless/admin_guide/serverless-cluster-admin-eventing.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-creating-subscription-admin-web-console_{context}"]
 = Creating a subscription with administrator privileges
 

--- a/modules/serverless-creating-subscriptions-kn.adoc
+++ b/modules/serverless-creating-subscriptions-kn.adoc
@@ -2,7 +2,7 @@
 //
 // * /serverless/develop/serverless-subs.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-creating-subscriptions-kn_{context}"]
 = Creating a subscription by using the Knative CLI
 

--- a/modules/serverless-creating-subscriptions-odc.adoc
+++ b/modules/serverless-creating-subscriptions-odc.adoc
@@ -2,7 +2,7 @@
 //
 // * /serverless/develop/serverless-subs.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-creating-subscriptions-odc_{context}"]
 = Creating a subscription
 

--- a/modules/serverless-creating-subscriptions-yaml.adoc
+++ b/modules/serverless-creating-subscriptions-yaml.adoc
@@ -2,7 +2,7 @@
 //
 // * /serverless/develop/serverless-subs.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-creating-subscriptions-yaml_{context}"]
 = Creating a subscription by using YAML
 

--- a/modules/serverless-creating-trigger-admin-web-console.adoc
+++ b/modules/serverless-creating-trigger-admin-web-console.adoc
@@ -3,7 +3,7 @@
 // * serverless/admin_guide/serverless-cluster-admin-eventing.adoc
 // * serverless/eventing/triggers/create-trigger-admin.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-creating-trigger-admin-web-console_{context}"]
 = Creating a trigger by using the Administrator perspective
 

--- a/modules/serverless-custom-revision-urls.adoc
+++ b/modules/serverless-custom-revision-urls.adoc
@@ -2,7 +2,7 @@
 //
 // * serverless/develop/serverless-traffic-management.adoc
 
-:_content-type: REFERENCE
+:_mod-docs-content-type: REFERENCE
 [id="serverless-custom-revision-urls_{context}"]
 = Custom URLs for revisions
 

--- a/modules/serverless-customize-labels-annotations-routes.adoc
+++ b/modules/serverless-customize-labels-annotations-routes.adoc
@@ -2,7 +2,7 @@
 //
 // * serverless/knative-serving/external-ingress-routing/customize-labels-annotations-routes.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-customize-labels-annotations-routes_{context}"]
 = Customizing labels and annotations for {ocp-product-title} routes
 

--- a/modules/serverless-deleting-broker-injection.adoc
+++ b/modules/serverless-deleting-broker-injection.adoc
@@ -2,7 +2,7 @@
 //
 // * /serverless/eventing/brokers/serverless-using-brokers.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-deleting-broker-injection_{context}"]
 = Deleting a broker that was created by injection
 

--- a/modules/serverless-deleting-crds.adoc
+++ b/modules/serverless-deleting-crds.adoc
@@ -2,7 +2,7 @@
 //
 //  * serverless/install/removing-openshift-serverless.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-deleting-crds_{context}"]
 = Removing {ServerlessProductName} Operator and API CRDs
 

--- a/modules/serverless-deploy-func-kn.adoc
+++ b/modules/serverless-deploy-func-kn.adoc
@@ -2,7 +2,7 @@
 //
 // * serverless/functions/serverless-functions-getting-started.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-deploy-func-kn_{context}"]
 = Deploying a function
 

--- a/modules/serverless-deprecated-removed-features.adoc
+++ b/modules/serverless-deprecated-removed-features.adoc
@@ -2,7 +2,7 @@
 //
 // * serverless/serverless-release-notes.adoc
 
-:_content-type: REFERENCE
+:_mod-docs-content-type: REFERENCE
 [id="serverless-deprecated-removed-features_{context}"]
 = Deprecated and removed features
 

--- a/modules/serverless-describe-broker-kn.adoc
+++ b/modules/serverless-describe-broker-kn.adoc
@@ -2,7 +2,7 @@
 //
 // * /serverless/eventing/brokers/serverless-using-brokers.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-describe-broker-kn_{context}"]
 = Describing an existing broker by using the Knative CLI
 

--- a/modules/serverless-describe-subs-kn.adoc
+++ b/modules/serverless-describe-subs-kn.adoc
@@ -2,7 +2,7 @@
 //
 // * /serverless/develop/serverless-subs.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-describe-subs-kn_{context}"]
 = Describing subscriptions by using the Knative CLI
 

--- a/modules/serverless-domain-mapping-custom-tls-cert.adoc
+++ b/modules/serverless-domain-mapping-custom-tls-cert.adoc
@@ -2,7 +2,7 @@
 //
 // * /serverless/knative-serving/config-custom-domains/domain-mapping-custom-tls-cert.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-domain-mapping-custom-tls-cert_{context}"]
 = Securing a service with a custom domain by using a TLS certificate
 

--- a/modules/serverless-domain-mapping-odc-admin.adoc
+++ b/modules/serverless-domain-mapping-odc-admin.adoc
@@ -2,7 +2,7 @@
 //
 // * serverless/knative_serving/serverless-custom-domains.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-domain-mapping-odc-admin_{context}"]
 = Mapping a custom domain to a service by using the Administrator perspective
 

--- a/modules/serverless-domain-mapping-odc-developer.adoc
+++ b/modules/serverless-domain-mapping-odc-developer.adoc
@@ -2,7 +2,7 @@
 //
 // * serverless/knative_serving/serverless-custom-domains.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-domain-mapping-odc-developer_{context}"]
 = Mapping a custom domain to a service
 

--- a/modules/serverless-enable-scale-to-zero.adoc
+++ b/modules/serverless-enable-scale-to-zero.adoc
@@ -2,7 +2,7 @@
 //
 // * /serverless/admin_guide/serverless-configuration.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-enable-scale-to-zero_{context}"]
 = Enabling scale-to-zero
 

--- a/modules/serverless-enabling-pvc-support.adoc
+++ b/modules/serverless-enabling-pvc-support.adoc
@@ -2,7 +2,7 @@
 //
 // * serverless/admin_guide/serverless-configuration.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-enabling-pvc-support_{context}"]
 = Enabling PVC support
 

--- a/modules/serverless-enabling-tls-local-services.adoc
+++ b/modules/serverless-enabling-tls-local-services.adoc
@@ -2,7 +2,7 @@
 //
 // * /serverless/security/serverless-config-tls.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-enabling-tls-local-services_{context}"]
 = Enabling TLS authentication for cluster local services
 

--- a/modules/serverless-event-delivery-parameters.adoc
+++ b/modules/serverless-event-delivery-parameters.adoc
@@ -2,7 +2,7 @@
 //
 // serverless/eventing/serverless-event-delivery.adoc
 
-:_content-type: REFERENCE
+:_mod-docs-content-type: REFERENCE
 [id="serverless-event-delivery-parameters_{context}"]
 = Configurable event delivery parameters
 

--- a/modules/serverless-event-source-metrics.adoc
+++ b/modules/serverless-event-source-metrics.adoc
@@ -2,7 +2,7 @@
 //
 // * serverless/admin_guide/serverless-admin-metrics.adoc
 
-:_content-type: REFERENCE
+:_mod-docs-content-type: REFERENCE
 [id="serverless-event-source-metrics_{context}"]
 = Event source metrics
 

--- a/modules/serverless-functions-adding-annotations.adoc
+++ b/modules/serverless-functions-adding-annotations.adoc
@@ -2,7 +2,7 @@
 //
 // * serverless/functions/serverless-functions-annotations.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-functions-adding-annotations_{context}"]
 = Adding annotations to a function
 

--- a/modules/serverless-functions-all-values-in-configmap-to-env-variables.adoc
+++ b/modules/serverless-functions-all-values-in-configmap-to-env-variables.adoc
@@ -2,6 +2,7 @@
 //
 // * serverless/functions/serverless-functions-accessing-secrets-configmaps.adoc
 
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-functions-all-values-in-configmap-to-env-variables_{context}"]
 = Setting environment variables from all values defined in a config map
 

--- a/modules/serverless-functions-creating-deploying-invoking.adoc
+++ b/modules/serverless-functions-creating-deploying-invoking.adoc
@@ -2,7 +2,7 @@
 //
 // * serverless/functions/serverless-functions-getting-started.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-functions-creating-deploying-invoking_{context}"]
 = Creating, deploying, and invoking a function
 

--- a/modules/serverless-functions-creating-on-cluster-builds.adoc
+++ b/modules/serverless-functions-creating-on-cluster-builds.adoc
@@ -2,7 +2,7 @@
 //
 // * /serverless/functions/serverless-functions-on-cluster-builds.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-functions-creating-on-cluster-builds_{context}"]
 = Building and deploying a function on the cluster
 

--- a/modules/serverless-functions-podman-macos.adoc
+++ b/modules/serverless-functions-podman-macos.adoc
@@ -2,7 +2,7 @@
 //
 // * serverless/functions/serverless-functions-setup.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-functions-podman-macos_{context}"]
 = Setting up Podman on macOS
 

--- a/modules/serverless-functions-podman.adoc
+++ b/modules/serverless-functions-podman.adoc
@@ -2,7 +2,7 @@
 //
 // * serverless/serverless-functions-setup.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-functions-podman_{context}"]
 = Setting up Podman
 

--- a/modules/serverless-functions-quarkus-return-value-types.adoc
+++ b/modules/serverless-functions-quarkus-return-value-types.adoc
@@ -2,7 +2,7 @@
 //
 // * serverless/functions/serverless-developing-quarkus-functions.adoc
 
-:_content-type: REFERENCE
+:_mod-docs-content-type: REFERENCE
 [id="serverless-functions-quarkus-return-value-types_{context}"]
 = Permitted types
 

--- a/modules/serverless-functions-setting-custom-volume-size.adoc
+++ b/modules/serverless-functions-setting-custom-volume-size.adoc
@@ -2,7 +2,7 @@
 //
 // * serverless/functions/serverless-functions-on-cluster-builds.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-functions-setting-custom-volume-size_{context}"]
 = Setting custom volume size
 

--- a/modules/serverless-functions-specifying-function-revision.adoc
+++ b/modules/serverless-functions-specifying-function-revision.adoc
@@ -2,7 +2,7 @@
 //
 // * serverless/functions/serverless-functions-on-cluster-builds.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-functions-specifying-function-revision_{context}"]
 = Specifying function revision
 

--- a/modules/serverless-go-function-return-values.adoc
+++ b/modules/serverless-go-function-return-values.adoc
@@ -2,7 +2,7 @@
 //
 // * serverless/functions/serverless-developing-go-functions.adoc
 
-:_content-type: REFERENCE
+:_mod-docs-content-type: REFERENCE
 [id="serverless-go-function-return-values_{context}"]
 = Go function return values
 

--- a/modules/serverless-go-metrics.adoc
+++ b/modules/serverless-go-metrics.adoc
@@ -2,7 +2,7 @@
 //
 // * serverless/admin_guide/serverless-admin-metrics.adoc
 
-:_content-type: REFERENCE
+:_mod-docs-content-type: REFERENCE
 [id="serverless-go-metrics_{context}"]
 = Go runtime metrics
 

--- a/modules/serverless-go-template.adoc
+++ b/modules/serverless-go-template.adoc
@@ -2,7 +2,7 @@
 //
 // * serverless/functions/serverless-developing-go-functions.adoc
 
-:_content-type: REFERENCE
+:_mod-docs-content-type: REFERENCE
 [id="serverless-go-template_{context}"]
 = Go function template structure
 

--- a/modules/serverless-gpu-resources-kn.adoc
+++ b/modules/serverless-gpu-resources-kn.adoc
@@ -2,7 +2,7 @@
 //
 //  * serverless/integrations/gpu-resources.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-gpu-resources-kn_{context}"]
 = Specifying GPU requirements for a service
 

--- a/modules/serverless-hotfix-patch.adoc
+++ b/modules/serverless-hotfix-patch.adoc
@@ -2,7 +2,7 @@
 //
 // * install/serverless-upgrades.adoc
 
-:_content-type: CONCEPT
+:_mod-docs-content-type: CONCEPT
 [id="serverless-hotfix-patch_{context}"]
 = Serverless Operator maintenance release upgrades
 

--- a/modules/serverless-https-redirect-global.adoc
+++ b/modules/serverless-https-redirect-global.adoc
@@ -2,7 +2,7 @@
 //
 // * serverless/knative-serving/http-configuration/https-redirect-global.adoc
 
-:_content-type: REFERENCE
+:_mod-docs-content-type: REFERENCE
 [id="serverless-https-redirect-global_{context}"]
 = HTTPS redirection global settings
 

--- a/modules/serverless-https-redirect-service.adoc
+++ b/modules/serverless-https-redirect-service.adoc
@@ -2,7 +2,7 @@
 //
 // * serverless/knative-serving/external-ingress-routing/https-redirect-per-service.adoc
 
-:_content-type: REFERENCE
+:_mod-docs-content-type: REFERENCE
 [id="serverless-https-redirect-service_{context}"]
 = Redirecting HTTPS for a service
 

--- a/modules/serverless-init-containers-apps.adoc
+++ b/modules/serverless-init-containers-apps.adoc
@@ -2,7 +2,7 @@
 //
 // * /serverless/develop/serverless-applications.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-init-containers-apps_{context}"]
 = Configuring init containers
 

--- a/modules/serverless-inmemory-dispatch-metrics.adoc
+++ b/modules/serverless-inmemory-dispatch-metrics.adoc
@@ -2,7 +2,7 @@
 //
 // * serverless/admin_guide/serverless-admin-metrics.adoc
 
-:_content-type: REFERENCE
+:_mod-docs-content-type: REFERENCE
 [id="serverless-inmemory-dispatch-metrics_{context}"]
 = InMemoryChannel dispatcher metrics
 

--- a/modules/serverless-install-cli.adoc
+++ b/modules/serverless-install-cli.adoc
@@ -2,7 +2,7 @@
 //
 // * /serverless/install/install-serverless-operator.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-install-cli_{context}"]
 = Installing the {ServerlessOperatorName} from the CLI
 

--- a/modules/serverless-install-eventing-web-console.adoc
+++ b/modules/serverless-install-eventing-web-console.adoc
@@ -2,7 +2,7 @@
 //
 //  * /serverless/install/installing-knative-eventing.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-install-eventing-web-console_{context}"]
 = Installing Knative Eventing by using the web console
 

--- a/modules/serverless-install-eventing-yaml.adoc
+++ b/modules/serverless-install-eventing-yaml.adoc
@@ -2,7 +2,7 @@
 //
 // * /serverless/install/installing-knative-eventing.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-install-eventing-yaml_{context}"]
 = Installing Knative Eventing by using YAML
 

--- a/modules/serverless-install-kafka-odc.adoc
+++ b/modules/serverless-install-kafka-odc.adoc
@@ -2,7 +2,7 @@
 //
 // serverless/install/installing-knative-eventing.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-install-kafka-odc_{context}"]
 = Installing Knative broker for Apache Kafka
 

--- a/modules/serverless-install-serving-web-console.adoc
+++ b/modules/serverless-install-serving-web-console.adoc
@@ -2,7 +2,7 @@
 //
 //  * serverless/install/installing-knative-serving.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-install-serving-web-console_{context}"]
 = Installing Knative Serving by using the web console
 

--- a/modules/serverless-install-serving-yaml.adoc
+++ b/modules/serverless-install-serving-yaml.adoc
@@ -2,7 +2,7 @@
 //
 // * /serverless/install/installing-knative-serving.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-install-serving-yaml_{context}"]
 = Installing Knative Serving by using YAML
 

--- a/modules/serverless-install-web-console.adoc
+++ b/modules/serverless-install-web-console.adoc
@@ -2,7 +2,7 @@
 //
 // * /serverless/install/install-serverless-operator.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-install-web-console_{context}"]
 = Installing the {ServerlessOperatorName} from the web console
 

--- a/modules/serverless-installing-cli-linux-rpm-package-manager.adoc
+++ b/modules/serverless-installing-cli-linux-rpm-package-manager.adoc
@@ -2,7 +2,7 @@
 //
 // * serverless/cli_tools/installing-kn.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-installing-cli-linux-rpm-package-manager_{context}"]
 = Installing the Knative CLI for Linux by using an RPM package manager
 

--- a/modules/serverless-installing-cli-web-console.adoc
+++ b/modules/serverless-installing-cli-web-console.adoc
@@ -2,7 +2,7 @@
 //
 // * serverless/cli_tools/installing-kn.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="installing-cli-web-console_{context}"]
 = Installing the Knative CLI using the {ocp-product-title} web console
 

--- a/modules/serverless-installing-cli-windows.adoc
+++ b/modules/serverless-installing-cli-windows.adoc
@@ -2,7 +2,7 @@
 //
 // * serverless/cli_tools/installing-kn.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="installing-cli-windows_{context}"]
 = Installing the Knative CLI for Windows
 

--- a/modules/serverless-invoking-go-functions-cloudevent.adoc
+++ b/modules/serverless-invoking-go-functions-cloudevent.adoc
@@ -2,7 +2,7 @@
 //
 // * serverless/functions/serverless-developing-go-functions.adoc
 
-:_content-type: REFERENCE
+:_mod-docs-content-type: REFERENCE
 [id="serverless-invoking-go-functions-cloudevent_{context}"]
 = Functions triggered by a cloud event
 

--- a/modules/serverless-invoking-go-functions-http.adoc
+++ b/modules/serverless-invoking-go-functions-http.adoc
@@ -2,7 +2,7 @@
 //
 // * serverless/functions/serverless-developing-go-functions.adoc
 
-:_content-type: REFERENCE
+:_mod-docs-content-type: REFERENCE
 [id="serverless-invoking-go-functions-http_{context}"]
 = Functions triggered by an HTTP request
 

--- a/modules/serverless-invoking-python-functions.adoc
+++ b/modules/serverless-invoking-python-functions.adoc
@@ -2,7 +2,7 @@
 //
 // * serverless/functions/serverless-developing-python-functions.adoc
 
-:_content-type: CONCEPT
+:_mod-docs-content-type: CONCEPT
 [id="serverless-invoking-python-functions_{context}"]
 = About invoking Python functions
 

--- a/modules/serverless-invoking-quarkus-functions.adoc
+++ b/modules/serverless-invoking-quarkus-functions.adoc
@@ -2,7 +2,7 @@
 //
 // * serverless/functions/serverless-developing-quarkus-functions.adoc
 
-:_content-type: CONCEPT
+:_mod-docs-content-type: CONCEPT
 [id="serverless-invoking-quarkus-functions_{context}"]
 = About invoking Quarkus functions
 

--- a/modules/serverless-jaeger-config.adoc
+++ b/modules/serverless-jaeger-config.adoc
@@ -2,7 +2,7 @@
 //
 // * serverless/serverless-tracing.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-jaeger-config_{context}"]
 = Configuring Jaeger to enable distributed tracing
 

--- a/modules/serverless-jobsink-cleaning-up-jobs.adoc
+++ b/modules/serverless-jobsink-cleaning-up-jobs.adoc
@@ -2,7 +2,7 @@
 //
 // * serverless/eventing/event-sinks/serverless-jobsink.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-jobsink-cleaning-up-jobs_{context}"]
 = Cleaning up finished jobs
 

--- a/modules/serverless-jobsink-customizing-event-file-directory.adoc
+++ b/modules/serverless-jobsink-customizing-event-file-directory.adoc
@@ -2,7 +2,7 @@
 //
 // * serverless/eventing/event-sinks/serverless-jobsink.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-jobsink-customizing-event-file-directory_{context}"]
 = Setting custom event file mount path
 

--- a/modules/serverless-jobsink-examples.adoc
+++ b/modules/serverless-jobsink-examples.adoc
@@ -2,7 +2,7 @@
 //
 // * serverless/eventing/event-sinks/serverless-jobsink.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-jobsink-examples_{context}"]
 = Simulating FailJob action
 

--- a/modules/serverless-jobsink-reading-event-file.adoc
+++ b/modules/serverless-jobsink-reading-event-file.adoc
@@ -2,7 +2,7 @@
 //
 // * serverless/eventing/event-sinks/serverless-jobsink.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-jobsink-reading-event-file_{context}"]
 = Reading the Job event file
 

--- a/modules/serverless-kafka-broker-configmap.adoc
+++ b/modules/serverless-kafka-broker-configmap.adoc
@@ -2,7 +2,7 @@
 //
 // * /serverless/eventing/brokers/kafka-broker.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-kafka-broker-configmap_{context}"]
 = Configuring Apache Kafka broker settings
 

--- a/modules/serverless-kafka-broker-sasl-default-config.adoc
+++ b/modules/serverless-kafka-broker-sasl-default-config.adoc
@@ -2,7 +2,7 @@
 //
 // * serverless/admin_guide/serverless-kafka-admin.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-kafka-broker-sasl-default-config_{context}"]
 = Configuring SASL authentication for Apache Kafka brokers
 

--- a/modules/serverless-kafka-broker-tls-default-config.adoc
+++ b/modules/serverless-kafka-broker-tls-default-config.adoc
@@ -3,7 +3,7 @@
 // * serverless/admin_guide/serverless-kafka-admin.adoc
 // * /serverless/security/serverless-config-tls.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-kafka-broker-tls-default-config_{context}"]
 = Configuring TLS authentication for Apache Kafka brokers
 

--- a/modules/serverless-kafka-broker-with-isolated-dataplane.adoc
+++ b/modules/serverless-kafka-broker-with-isolated-dataplane.adoc
@@ -2,7 +2,7 @@
 //
 // * serverless/eventing/brokers/kafka-broker.adoc
 
-:_content-type: CONCEPT
+:_mod-docs-content-type: CONCEPT
 [id="serverless-kafka-broker-with-isolated-dataplane_{context}"]
 = Knative Broker implementation for Apache Kafka with isolated data plane
 

--- a/modules/serverless-kafka-broker-with-kafka-topic.adoc
+++ b/modules/serverless-kafka-broker-with-kafka-topic.adoc
@@ -2,7 +2,7 @@
 //
 // * serverless/eventing/brokers/serverless-using-brokers.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-kafka-broker-with-kafka-topic_{context}"]
 = Creating an Apache Kafka broker that uses an externally managed Kafka topic
 

--- a/modules/serverless-kafka-broker.adoc
+++ b/modules/serverless-kafka-broker.adoc
@@ -2,7 +2,7 @@
 //
 // * serverless/eventing/brokers/serverless-using-brokers.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-kafka-broker_{context}"]
 = Creating an Apache Kafka broker by using YAML
 

--- a/modules/serverless-kafka-developer.adoc
+++ b/modules/serverless-kafka-developer.adoc
@@ -2,7 +2,7 @@
 //
 // serverless/about/about-knative-eventing.adoc
 
-:_content-type: CONCEPT
+:_mod-docs-content-type: CONCEPT
 [id="serverless-kafka-developer_{context}"]
 = Using the Knative broker for Apache Kafka
 

--- a/modules/serverless-kafka-event-delivery.adoc
+++ b/modules/serverless-kafka-event-delivery.adoc
@@ -2,7 +2,7 @@
 //
 // * serverless/develop/serverless-kafka-developer.adoc
 
-:_content-type: CONCEPT
+:_mod-docs-content-type: CONCEPT
 [id="serverless-kafka-delivery-retries_{context}"]
 = Apache Kafka event delivery and retries
 

--- a/modules/serverless-kafka-sasl-channels.adoc
+++ b/modules/serverless-kafka-sasl-channels.adoc
@@ -2,7 +2,7 @@
 //
 // * serverless/admin_guide/serverless-kafka-admin.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-kafka-sasl-channels_{context}"]
 = Configuring SASL authentication for Knative channels for Apache Kafka
 

--- a/modules/serverless-kafka-sasl-source.adoc
+++ b/modules/serverless-kafka-sasl-source.adoc
@@ -2,7 +2,7 @@
 //
 // * serverless/admin_guide/serverless-kafka-admin.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-kafka-sasl-source_{context}"]
 = Configuring SASL authentication for Apache Kafka sources
 

--- a/modules/serverless-kafka-sink-security-config.adoc
+++ b/modules/serverless-kafka-sink-security-config.adoc
@@ -2,7 +2,7 @@
 //
 // * serverless/admin_guide/serverless-kafka-admin.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-kafka-sink-security-config_{context}"]
 = Configuring security for Apache Kafka sinks
 

--- a/modules/serverless-kafka-sink.adoc
+++ b/modules/serverless-kafka-sink.adoc
@@ -2,7 +2,7 @@
 //
 // * serverless/develop/serverless-kafka-developer.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-kafka-sink_{context}"]
 = Creating an Apache Kafka sink by using YAML
 

--- a/modules/serverless-kafka-source-autoscale-keda.adoc
+++ b/modules/serverless-kafka-source-autoscale-keda.adoc
@@ -2,7 +2,7 @@
 //
 // * eventing/event-sources/serverless-kafka-developer-source.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-kafka-source-autoscale-keda_{context}"]
 = Configuring KEDA autoscaling for KafkaSource
 

--- a/modules/serverless-kafka-source-kn.adoc
+++ b/modules/serverless-kafka-source-kn.adoc
@@ -3,7 +3,7 @@
 // * serverless/develop/serverless-kafka-developer.adoc
 // * serverless/reference/kn-eventing-ref.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-kafka-source-kn_{context}"]
 = Creating an Apache Kafka event source by using the Knative CLI
 

--- a/modules/serverless-kafka-source-odc.adoc
+++ b/modules/serverless-kafka-source-odc.adoc
@@ -2,7 +2,7 @@
 //
 // * serverless/develop/serverless-kafka-developer.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-kafka-source-odc_{context}"]
 = Creating an Apache Kafka event source by using the web console
 

--- a/modules/serverless-kafka-source-yaml.adoc
+++ b/modules/serverless-kafka-source-yaml.adoc
@@ -2,7 +2,7 @@
 //
 // * serverless/develop/serverless-kafka-developer.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-kafka-source-yaml_{context}"]
 = Creating an Apache Kafka event source by using YAML
 

--- a/modules/serverless-kafka-tls-channels.adoc
+++ b/modules/serverless-kafka-tls-channels.adoc
@@ -3,7 +3,7 @@
 // * /serverless/admin_guide/serverless-kafka-admin.adoc
 // * /serverless/security/serverless-config-tls.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-kafka-tls-channels_{context}"]
 = Configuring TLS authentication for Knative channels for Apache Kafka
 

--- a/modules/serverless-kn-config.adoc
+++ b/modules/serverless-kn-config.adoc
@@ -2,7 +2,7 @@
 //
 // * serverless/cli_tools/advanced-kn-config.adoc
 
-:_content-type: CONCEPT
+:_mod-docs-content-type: CONCEPT
 [id="serverless-kn-config_{context}"]
 = Customizing the Knative CLI
 

--- a/modules/serverless-kn-container.adoc
+++ b/modules/serverless-kn-container.adoc
@@ -2,7 +2,7 @@
 //
 // * serverless/reference/kn-serving-ref.adoc
 
-:_content-type: REFERENCE
+:_mod-docs-content-type: REFERENCE
 [id="serverless-kn-container_{context}"]
 = Knative client multi-container support
 

--- a/modules/serverless-kn-containersource.adoc
+++ b/modules/serverless-kn-containersource.adoc
@@ -3,7 +3,7 @@
 // * serverless/eventing/event-sources/serverless-custom-event-sources.adoc
 // * serverless/reference/kn-eventing-ref.adoc
 
-:_content-type: REFERENCE
+:_mod-docs-content-type: REFERENCE
 [id="serverless-kn-containersource_{context}"]
 = Creating and managing container sources by using the Knative CLI
 // needs to be revised as separate procedure modules; out of scope for this PR

--- a/modules/serverless-kn-func-delete.adoc
+++ b/modules/serverless-kn-func-delete.adoc
@@ -2,7 +2,7 @@
 
 // * serverless/cli_tools/kn-func-ref.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-kn-func-delete_{context}"]
 = Deleting a function
 

--- a/modules/serverless-kn-func-invoke-reference.adoc
+++ b/modules/serverless-kn-func-invoke-reference.adoc
@@ -2,7 +2,7 @@
 //
 // * serverless/reference/kn-func-ref.adoc
 
-:_content-type: REFERENCE
+:_mod-docs-content-type: REFERENCE
 [id="serverless-kn-func-invoke-reference_{context}"]
 = kn func invoke optional parameters
 

--- a/modules/serverless-kn-func-invoke.adoc
+++ b/modules/serverless-kn-func-invoke.adoc
@@ -3,7 +3,7 @@
 // * serverless/functions/serverless-functions-getting-started.adoc
 // * serverless/cli_tools/kn-func-ref.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-kn-func-invoke_{context}"]
 = Invoking a deployed function with a test event
 

--- a/modules/serverless-kn-func-run.adoc
+++ b/modules/serverless-kn-func-run.adoc
@@ -3,7 +3,7 @@
 // * serverless/cli_tools/kn-func-ref.adoc
 // * serverless/functions/serverless-functions-getting-started.adoc
 
-:_content-type: REFERENCE
+:_mod-docs-content-type: REFERENCE
 [id="serverless-kn-func-run_{context}"]
 = Running a function locally
 

--- a/modules/serverless-kourier-gateway-service-type.adoc
+++ b/modules/serverless-kourier-gateway-service-type.adoc
@@ -2,7 +2,7 @@
 //
 // * serverless/knative-serving/external-ingress-routing/kourier-gateway-service-type.adoc
 
-:_content-type: REFERENCE
+:_mod-docs-content-type: REFERENCE
 [id="serverless-kourier-gateway-service-type_{context}"]
 = Setting the Kourier Gateway service type
 // should probably be a procedure but this is out of scope for the abstracts PR

--- a/modules/serverless-list-broker-kn.adoc
+++ b/modules/serverless-list-broker-kn.adoc
@@ -2,7 +2,7 @@
 //
 // * /serverless/eventing/brokers/serverless-using-brokers.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-list-broker-kn_{context}"]
 = Listing existing brokers by using the Knative CLI
 

--- a/modules/serverless-list-source-cli.adoc
+++ b/modules/serverless-list-source-cli.adoc
@@ -2,7 +2,7 @@
 //
 // * serverless/eventing/discovery/list-event-sources-cli.adoc
 
-:_content-type: REFERENCE
+:_mod-docs-content-type: REFERENCE
 [id="serverless-list-source-cli_{context}"]
 = Listing available event sources by using the Knative CLI
 

--- a/modules/serverless-list-source-types-kn.adoc
+++ b/modules/serverless-list-source-types-kn.adoc
@@ -2,7 +2,7 @@
 //
 // * serverless/develop/serverless-listing-event-sources.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-list-source-types-kn_{context}"]
 = Listing available event source types by using the Knative CLI
 

--- a/modules/serverless-list-source-types-odc.adoc
+++ b/modules/serverless-list-source-types-odc.adoc
@@ -2,7 +2,7 @@
 //
 // * serverless/eventing/discovery/list-event-sources.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-list-source-types-odc_{context}"]
 = Viewing available event source types
 

--- a/modules/serverless-list-subs-kn.adoc
+++ b/modules/serverless-list-subs-kn.adoc
@@ -2,7 +2,7 @@
 //
 // * /serverless/develop/serverless-subs.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-list-subs-kn_{context}"]
 = Listing subscriptions by using the Knative CLI
 

--- a/modules/serverless-locking-version-for-cli-installed-with-rpm-package-manager.adoc
+++ b/modules/serverless-locking-version-for-cli-installed-with-rpm-package-manager.adoc
@@ -2,7 +2,7 @@
 //
 // * /serverless/install/serverless-upgrades.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-locking-version-for-cli-installed-with-rpm-package-manager_{context}"]
 = Locking version for the Knative CLI installed with RPM package manager
 

--- a/modules/serverless-logic-install-kn-workflow-artifact-images.adoc
+++ b/modules/serverless-logic-install-kn-workflow-artifact-images.adoc
@@ -2,7 +2,7 @@
 //
 // * /serverless/install/serverless-logic-install-kn-workflow-plugin-cli.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-logic-install-kn-workflow-artifact-images_{context}"]
 = Installing the OpenShift Serverless Logic Knative Workflow plugin using the artifacts image
 

--- a/modules/serverless-logic-install-kn-workflow-binary-file-linux.adoc
+++ b/modules/serverless-logic-install-kn-workflow-binary-file-linux.adoc
@@ -2,7 +2,7 @@
 //
 // * /serverless/install/serverless-logic-install-kn-workflow-plugin-cli.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-logic-install-kn-workflow-binary-file-linux_{context}"]
 = Installing the {ServerlessLogicProductName} Knative Workflow plugin for Linux
 

--- a/modules/serverless-logic-install-kn-workflow-binary-file-macos.adoc
+++ b/modules/serverless-logic-install-kn-workflow-binary-file-macos.adoc
@@ -2,7 +2,7 @@
 //
 // * /serverless/install/serverless-logic-install-kn-workflow-plugin-cli.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-logic-install-kn-workflow-binary-file-macos_{context}"]
 = Installing the {ServerlessLogicProductName} Knative Workflow plugin for macOS
 

--- a/modules/serverless-logic-install-kn-workflow-binary-file-windows.adoc
+++ b/modules/serverless-logic-install-kn-workflow-binary-file-windows.adoc
@@ -2,7 +2,7 @@
 //
 // * /serverless/install/serverless-logic-install-kn-workflow-plugin-cli.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-logic-install-kn-workflow-binary-file-windows_{context}"]
 = Installing the {ServerlessLogicProductName} Knative Workflow plugin for Windows
 

--- a/modules/serverless-logic-install-web-console.adoc
+++ b/modules/serverless-logic-install-web-console.adoc
@@ -2,7 +2,7 @@
 //
 // * /serverless/install/install-serverless-operator.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-logic-install-web-console_{context}"]
 = Installing the {ServerlessLogicOperatorName} from the web console
 

--- a/modules/serverless-logic-overview-callbacks.adoc
+++ b/modules/serverless-logic-overview-callbacks.adoc
@@ -2,7 +2,7 @@
 // * about/serverless-logic-overview.adoc
 
 
-:_content-type: CONCEPT
+:_mod-docs-content-type: CONCEPT
 [id="serverless-logic-overview-callbacks_{context}"]
 = Callbacks
 

--- a/modules/serverless-logic-overview-custom-functions.adoc
+++ b/modules/serverless-logic-overview-custom-functions.adoc
@@ -2,7 +2,7 @@
 // * about/serverless-logic-overview.adoc
 
 
-:_content-type: CONCEPT
+:_mod-docs-content-type: CONCEPT
 [id="serverless-logic-overview-custom-functions_{context}"]
 = Custom functions
 

--- a/modules/serverless-logic-overview-error-handling.adoc
+++ b/modules/serverless-logic-overview-error-handling.adoc
@@ -2,7 +2,7 @@
 // * about/serverless-logic-overview.adoc
 
 
-:_content-type: CONCEPT
+:_mod-docs-content-type: CONCEPT
 [id="serverless-logic-overview-error-handling_{context}"]
 = Error handling
 

--- a/modules/serverless-logic-overview-events.adoc
+++ b/modules/serverless-logic-overview-events.adoc
@@ -2,7 +2,7 @@
 // * about/serverless-logic-overview.adoc
 
 
-:_content-type: CONCEPT
+:_mod-docs-content-type: CONCEPT
 [id="serverless-logic-overview-events_{context}"]
 = Events
 

--- a/modules/serverless-logic-overview-input-output-schema.adoc
+++ b/modules/serverless-logic-overview-input-output-schema.adoc
@@ -2,7 +2,7 @@
 // * about/serverless-logic-overview.adoc
 
 
-:_content-type: CONCEPT
+:_mod-docs-content-type: CONCEPT
 [id="serverless-logic-overview-input-output-schema_{context}"]
 = Schema definitions
 

--- a/modules/serverless-logic-overview-jq-expressions.adoc
+++ b/modules/serverless-logic-overview-jq-expressions.adoc
@@ -2,7 +2,7 @@
 // * about/serverless-logic-overview.adoc
 
 
-:_content-type: CONCEPT
+:_mod-docs-content-type: CONCEPT
 [id="serverless-logic-overview-jq-expressions_{context}"]
 = JQ expressions
 

--- a/modules/serverless-logic-overview-parallelism.adoc
+++ b/modules/serverless-logic-overview-parallelism.adoc
@@ -2,7 +2,7 @@
 // * about/serverless-logic-overview.adoc
 
 
-:_content-type: CONCEPT
+:_mod-docs-content-type: CONCEPT
 [id="serverless-logic-overview-parallelism_{context}"]
 = Parallelism
 

--- a/modules/serverless-logic-overview-timeouts.adoc
+++ b/modules/serverless-logic-overview-timeouts.adoc
@@ -2,7 +2,7 @@
 // * about/serverless-logic-overview.adoc
 
 
-:_content-type: CONCEPT
+:_mod-docs-content-type: CONCEPT
 [id="serverless-logic-overview-timeouts_{context}"]
 = Timeouts
 

--- a/modules/serverless-manage-domain-mapping-kn.adoc
+++ b/modules/serverless-manage-domain-mapping-kn.adoc
@@ -2,7 +2,7 @@
 //
 // * serverless/reference/kn-serving-ref.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-manage-domain-mapping-kn_{context}"]
 = Managing custom domain mappings by using the Knative CLI
 

--- a/modules/serverless-monitoring-services-examining-metrics-dashboard.adoc
+++ b/modules/serverless-monitoring-services-examining-metrics-dashboard.adoc
@@ -2,7 +2,7 @@
 //
 // * /serverless/monitor/serverless-developer-metrics.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-monitoring-services-examining-metrics-dashboard_{context}"]
 = Examining metrics of a service in the dashboard
 

--- a/modules/serverless-nodejs-context-object-reference.adoc
+++ b/modules/serverless-nodejs-context-object-reference.adoc
@@ -2,7 +2,7 @@
 //
 // * serverless/functions/serverless-functions-reference-guide.adoc
 
-:_content-type: REFERENCE
+:_mod-docs-content-type: REFERENCE
 [id="serverless-nodejs-context-object-reference_{context}"]
 = Node.js context object reference
 

--- a/modules/serverless-nodejs-function-return-values.adoc
+++ b/modules/serverless-nodejs-function-return-values.adoc
@@ -2,7 +2,7 @@
 //
 // * serverless/functions/serverless-developing-nodejs-functions.adoc
 
-:_content-type: REFERENCE
+:_mod-docs-content-type: REFERENCE
 [id="serverless-nodejs-function-return-values_{context}"]
 = Node.js function return values
 

--- a/modules/serverless-nodejs-functions-context-objects.adoc
+++ b/modules/serverless-nodejs-functions-context-objects.adoc
@@ -2,7 +2,7 @@
 //
 // * serverless/functions/serverless-developing-nodejs-functions.adoc
 
-:_content-type: REFERENCE
+:_mod-docs-content-type: REFERENCE
 [id="serverless-nodejs-functions-context-objects_{context}"]
 = Node.js context objects
 

--- a/modules/serverless-nodejs-functions-overriding-liveness-readiness.adoc
+++ b/modules/serverless-nodejs-functions-overriding-liveness-readiness.adoc
@@ -2,7 +2,7 @@
 //
 // * functions/reference/serverless-developing-nodejs-functions.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-nodejs-functions-overriding-liveness-readiness_{context}"]
 = Overriding liveness and readiness probe values
 
@@ -62,15 +62,11 @@ const Function = {
   } <2>
 };
 
-Function.liveness.path = '/alive'; <3>
-Function.readiness.path = '/ready'; <4>
+Function.liveness.path = '/alive';
+Function.readiness.path = '/ready';
 
 module.exports = Function;
 ----
-<1> Custom `liveness` function.
-<2> Custom `readiness` function.
-<3> Custom `liveness` endpoint.
-<4> Custom `readiness` endpoint.
 +
 As an alternative to `Function.liveness.path` and `Function.readiness.path`, you can specify custom endpoints using the `LIVENESS_URL` and `READINESS_URL` environment variables:
 +
@@ -79,12 +75,10 @@ As an alternative to `Function.liveness.path` and `Function.readiness.path`, you
 run:
   envs:
   - name: LIVENESS_URL
-    value: /alive <1>
+    value: /alive
   - name: READINESS_URL
-    value: /ready <2>
+    value: /ready
 ----
-<1> The liveness path, set to `/alive` here.
-<2> The readiness path, set to `/ready` here.
 
 . Add the new endpoints to the `func.yaml` file, so that they are properly bound to the container for the Knative service:
 +

--- a/modules/serverless-nodejs-template.adoc
+++ b/modules/serverless-nodejs-template.adoc
@@ -2,7 +2,7 @@
 //
 // * serverless/functions/serverless-developing-nodejs-functions.adoc
 
-:_content-type: REFERENCE
+:_mod-docs-content-type: REFERENCE
 [id="serverless-nodejs-template_{context}"]
 = Node.js function template structure
 

--- a/modules/serverless-odc-create-containersource.adoc
+++ b/modules/serverless-odc-create-containersource.adoc
@@ -2,7 +2,7 @@
 //
 // * /serverless/eventing/event-sources/serverless-custom-event-sources.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-odc-create-containersource_{context}"]
 = Creating a container source by using the web console
 

--- a/modules/serverless-open-telemetry.adoc
+++ b/modules/serverless-open-telemetry.adoc
@@ -2,7 +2,7 @@
 //
 // * serverless/serverless-tracing.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-open-telemetry_{context}"]
 = Using {DTProductName} to enable distributed tracing
 

--- a/modules/serverless-openshift-routes.adoc
+++ b/modules/serverless-openshift-routes.adoc
@@ -2,7 +2,7 @@
 //
 // * serverless/knative-serving/external-ingress-routing/configuring-service-routes.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-openshift-routes_{context}"]
 = Configuring {ocp-product-title} routes for Knative services
 

--- a/modules/serverless-operator-installation-resource-requirements.adoc
+++ b/modules/serverless-operator-installation-resource-requirements.adoc
@@ -2,7 +2,7 @@
 //
 // * install/install-serverless-operator.adoc
 
-:_content-type: REFERENCE
+:_mod-docs-content-type: REFERENCE
 [id="serverless-operator-resource-requirements_{context}"]
 = {ServerlessOperatorName} resource requirements
 

--- a/modules/serverless-ossm-enabling-serving-metrics.adoc
+++ b/modules/serverless-ossm-enabling-serving-metrics.adoc
@@ -2,7 +2,7 @@
 //
 // * /serverless/integrations/serverless-ossm-setup.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-ossm-enabling-serving-metrics_{context}"]
 = Enabling Knative Serving and Knative Eventing metrics when using Service Mesh with mTLS
 

--- a/modules/serverless-ossm-external-certs.adoc
+++ b/modules/serverless-ossm-external-certs.adoc
@@ -2,7 +2,7 @@
 //
 // * /serverless/integrations/serverless-ossm-setup.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serverlesss-ossm-external-certs_{context}"]
 = Creating a certificate to encrypt incoming external traffic
 

--- a/modules/serverless-ossm-installing-and-configuring-openshift-service-mesh.adoc
+++ b/modules/serverless-ossm-installing-and-configuring-openshift-service-mesh.adoc
@@ -1,4 +1,4 @@
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-ossm-installing-and-configuring-openshift-service-mesh_{context}"]
 = Installing and configuring {SMProductShortName}
 

--- a/modules/serverless-ossm-secret-filtering-net-istio.adoc
+++ b/modules/serverless-ossm-secret-filtering-net-istio.adoc
@@ -2,7 +2,7 @@
 //
 // * /serverless/integrations/serverless-ossm-setup.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-ossm-secret-filtering-net-istio_{context}"]
 = Improving net-istio memory usage by using secret filtering for {SMProductShortName}
 

--- a/modules/serverless-ossm-secret-filtering-net-kourier.adoc
+++ b/modules/serverless-ossm-secret-filtering-net-kourier.adoc
@@ -2,7 +2,7 @@
 //
 // * /serverless/knative-serving/config-custom-domains/domain-mapping-custom-tls-cert.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-ossm-secret-filtering-net-kourier_{context}"]
 = Improving net-kourier memory usage by using secret filtering
 

--- a/modules/serverless-ossm-setup.adoc
+++ b/modules/serverless-ossm-setup.adoc
@@ -2,7 +2,7 @@
 //
 // * /serverless/integrations/serverless-ossm-setup.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-ossm-setup_{context}"]
 = Integrating {SMProductShortName} with {ServerlessProductName}
 

--- a/modules/serverless-ossm-traffic-isolation-architecture.adoc
+++ b/modules/serverless-ossm-traffic-isolation-architecture.adoc
@@ -1,4 +1,4 @@
-:_content-type: CONCEPT
+:_mod-docs-content-type: CONCEPT
 [id="serverless-ossm-traffic-isolation-architecture_context"]
 = High-level architecture
 

--- a/modules/serverless-ossm-traffic-isolation-securing-the-service-mesh.adoc
+++ b/modules/serverless-ossm-traffic-isolation-securing-the-service-mesh.adoc
@@ -1,4 +1,4 @@
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-ossm-traffic-isolation-securing-the-service-mesh_{context}"]
 = Securing the {SMProductShortName}
 

--- a/modules/serverless-ossm-traffic-isolation-verifying-the-configuration.adoc
+++ b/modules/serverless-ossm-traffic-isolation-verifying-the-configuration.adoc
@@ -1,4 +1,4 @@
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-ossm-traffic-isolation-verifying-the-configuration_{context}"]
 = Verifying the configuration
 

--- a/modules/serverless-ossm-v1x-jwt.adoc
+++ b/modules/serverless-ossm-v1x-jwt.adoc
@@ -2,7 +2,7 @@
 //
 // * serverless/knative-serving/config-access/serverless-ossm-with-kourier-jwt.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-ossm-v1x-jwt_{context}"]
 = Configuring JSON Web Token authentication for {SMProductShortName} 1.x and {ServerlessProductName}
 

--- a/modules/serverless-ossm-v2x-jwt.adoc
+++ b/modules/serverless-ossm-v2x-jwt.adoc
@@ -2,7 +2,7 @@
 //
 // * serverless/knative-serving/config-access/serverless-ossm-with-kourier-jwt.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-ossm-v2x-jwt_{context}"]
 = Configuring JSON Web Token authentication for {SMProductShortName} 2.x and {ServerlessProductName}
 

--- a/modules/serverless-overriding-pdbs-eventing.adoc
+++ b/modules/serverless-overriding-pdbs-eventing.adoc
@@ -3,7 +3,7 @@
 // * /eventing/tuning/serverless-ha.adoc
 
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-overriding-poddistruptionbudgets-eventing_{context}"]
 = Overriding disruption budgets
 

--- a/modules/serverless-overriding-pdbs-serving.adoc
+++ b/modules/serverless-overriding-pdbs-serving.adoc
@@ -3,7 +3,7 @@
 // * /knative-serving/config-ha-services/ha-replicas-serving.adoc
 
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-overriding-poddistruptionbudgets-serving_{context}"]
 = Overriding disruption budgets
 

--- a/modules/serverless-pingsource-kn.adoc
+++ b/modules/serverless-pingsource-kn.adoc
@@ -3,7 +3,7 @@
 // * serverless/eventing/event-sources/serverless-pingsource.adoc
 // * serverless/reference/kn-eventing-ref.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-pingsource-kn_{context}"]
 = Creating a ping source by using the Knative CLI
 

--- a/modules/serverless-pingsource-odc.adoc
+++ b/modules/serverless-pingsource-odc.adoc
@@ -2,7 +2,7 @@
 //
 // * /serverless/eventing/event-sources/serverless-pingsource.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-pingsource-odc_{context}"]
 = Creating a ping source by using the web console
 

--- a/modules/serverless-pingsource-yaml.adoc
+++ b/modules/serverless-pingsource-yaml.adoc
@@ -2,7 +2,7 @@
 //
 // * /serverless/eventing/event-sources/serverless-pingsource.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-pingsource-yaml_{context}"]
 = Creating a ping source by using YAML
 

--- a/modules/serverless-probing-multi-container-service.adoc
+++ b/modules/serverless-probing-multi-container-service.adoc
@@ -3,7 +3,7 @@
 // * serverless/knative-serving/config-applications/multi-container-support-for-serving.adoc
 
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-probing-multi-container-service_{context}"]
 = Probing a multi-container service
 

--- a/modules/serverless-progress-deadline-config.adoc
+++ b/modules/serverless-progress-deadline-config.adoc
@@ -2,7 +2,7 @@
 //
 // * knative-serving/config-applications/deployment-resources.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-progress-deadline-config_{context}"]
 = Configuring the progress deadline
 

--- a/modules/serverless-progress-deadline-serving.adoc
+++ b/modules/serverless-progress-deadline-serving.adoc
@@ -2,7 +2,7 @@
 //
 // * serverless/knative-serving/config-applications/startup-probes-for-serving.adoc
 
-:_content-type: CONCEPT
+:_mod-docs-content-type: CONCEPT
 [id="serverless-progress-deadline-serving_{context}"]
 = Progress deadline
 

--- a/modules/serverless-progress-deadline.adoc
+++ b/modules/serverless-progress-deadline.adoc
@@ -2,7 +2,7 @@
 //
 // * knative-serving/config-applications/deployment-resources.adoc
 
-:_content-type: CONCEPT
+:_mod-docs-content-type: CONCEPT
 [id="serverless-progress-deadline_{context}"]
 = Progress deadline
 

--- a/modules/serverless-python-function-return-values.adoc
+++ b/modules/serverless-python-function-return-values.adoc
@@ -2,7 +2,7 @@
 //
 // * serverless/functions/serverless-developing-python-functions.adoc
 
-:_content-type: REFERENCE
+:_mod-docs-content-type: REFERENCE
 [id="serverless-python-function-return-values_{context}"]
 = Python function return values
 

--- a/modules/serverless-python-template.adoc
+++ b/modules/serverless-python-template.adoc
@@ -2,7 +2,7 @@
 //
 // * serverless/functions/serverless-developing-python-functions.adoc
 
-:_content-type: REFERENCE
+:_mod-docs-content-type: REFERENCE
 [id="serverless-python-template_{context}"]
 = Python function template structure
 

--- a/modules/serverless-quarkus-cloudevent-attributes.adoc
+++ b/modules/serverless-quarkus-cloudevent-attributes.adoc
@@ -2,7 +2,7 @@
 //
 // * serverless/functions/serverless-developing-quarkus-functions.adoc
 
-:_content-type: CONCEPT
+:_mod-docs-content-type: CONCEPT
 [id="serverless-quarkus-cloudevent-attributes_{context}"]
 = CloudEvent attributes
 

--- a/modules/serverless-quarkus-function-return-values.adoc
+++ b/modules/serverless-quarkus-function-return-values.adoc
@@ -2,7 +2,7 @@
 //
 // * serverless/functions/serverless-developing-quarkus-functions.adoc
 
-:_content-type: CONCEPT
+:_mod-docs-content-type: CONCEPT
 [id="serverless-quarkus-function-return-values_{context}"]
 = Quarkus function return values
 

--- a/modules/serverless-quarkus-functions-overriding-liveness-readiness.adoc
+++ b/modules/serverless-quarkus-functions-overriding-liveness-readiness.adoc
@@ -2,7 +2,7 @@
 //
 // * functions/reference/serverless-developing-quarkus-functions.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-quarkus-functions-overriding-liveness-readiness_{context}"]
 = Overriding liveness and readiness probe values
 

--- a/modules/serverless-quarkus-template.adoc
+++ b/modules/serverless-quarkus-template.adoc
@@ -2,7 +2,7 @@
 //
 // * serverless/functions/serverless-developing-quarkus-functions.adoc
 
-:_content-type: REFERENCE
+:_mod-docs-content-type: REFERENCE
 [id="serverless-quarkus-template_{context}"]
 = Quarkus function template structure
 

--- a/modules/serverless-resolving-operator-upgrade-failure.adoc
+++ b/modules/serverless-resolving-operator-upgrade-failure.adoc
@@ -2,7 +2,7 @@
 //
 // * /serverless/install/serverless-upgrades.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-resolving-operator-upgrade-failure_{context}"]
 = Resolving an {ServerlessOperatorName} upgrade failure
 

--- a/modules/serverless-restricting-cipher-suits-odc-admin.adoc
+++ b/modules/serverless-restricting-cipher-suits-odc-admin.adoc
@@ -2,7 +2,7 @@
 //
 // * serverless/knative_serving/serverless-custom-domains.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-restricting-cipher-suits-odc-admin_{context}"]
 = Restricting cipher suites
 

--- a/modules/serverless-rn-1-18-0.adoc
+++ b/modules/serverless-rn-1-18-0.adoc
@@ -2,7 +2,7 @@
 //
 // * /serverless/serverless-release-notes.adoc
 
-:_content-type: REFERENCE
+:_mod-docs-content-type: REFERENCE
 [id="serverless-rn-1-18-0_{context}"]
 = Red Hat {ServerlessProductName} 1.18.0
 

--- a/modules/serverless-rn-1-19-0.adoc
+++ b/modules/serverless-rn-1-19-0.adoc
@@ -2,7 +2,7 @@
 //
 // * /serverless/serverless-release-notes.adoc
 
-:_content-type: REFERENCE
+:_mod-docs-content-type: REFERENCE
 [id="serverless-rn-1-19-0_{context}"]
 = Red Hat {ServerlessProductName} 1.19.0
 

--- a/modules/serverless-rn-1-20-0.adoc
+++ b/modules/serverless-rn-1-20-0.adoc
@@ -2,7 +2,7 @@
 //
 // * /serverless/serverless-release-notes.adoc
 
-:_content-type: REFERENCE
+:_mod-docs-content-type: REFERENCE
 [id="serverless-rn-1-20-0_{context}"]
 = Red Hat {ServerlessProductName} 1.20.0
 

--- a/modules/serverless-rn-1-21-0.adoc
+++ b/modules/serverless-rn-1-21-0.adoc
@@ -2,7 +2,7 @@
 //
 // * /serverless/serverless-release-notes.adoc
 
-:_content-type: REFERENCE
+:_mod-docs-content-type: REFERENCE
 [id="serverless-rn-1-21-0_{context}"]
 = Red Hat {ServerlessProductName} 1.21.0
 

--- a/modules/serverless-rn-1-22-0.adoc
+++ b/modules/serverless-rn-1-22-0.adoc
@@ -2,7 +2,7 @@
 //
 // * /serverless/serverless-release-notes.adoc
 
-:_content-type: REFERENCE
+:_mod-docs-content-type: REFERENCE
 [id="serverless-rn-1-22-0_{context}"]
 = Red Hat {ServerlessProductName} 1.22.0
 

--- a/modules/serverless-rn-1-23-0.adoc
+++ b/modules/serverless-rn-1-23-0.adoc
@@ -2,7 +2,7 @@
 //
 // * /serverless/serverless-release-notes.adoc
 
-:_content-type: REFERENCE
+:_mod-docs-content-type: REFERENCE
 [id="serverless-rn-1-23-0_{context}"]
 = Red Hat {ServerlessProductName} 1.23.0
 

--- a/modules/serverless-rn-1-24-0.adoc
+++ b/modules/serverless-rn-1-24-0.adoc
@@ -2,7 +2,7 @@
 //
 // * /serverless/serverless-release-notes.adoc
 
-:_content-type: REFERENCE
+:_mod-docs-content-type: REFERENCE
 [id="serverless-rn-1-24-0_{context}"]
 = Red Hat {ServerlessProductName} 1.24.0
 

--- a/modules/serverless-rn-1-25-0.adoc
+++ b/modules/serverless-rn-1-25-0.adoc
@@ -2,7 +2,7 @@
 //
 // * serverless/serverless-release-notes.adoc
 
-:_content-type: REFERENCE
+:_mod-docs-content-type: REFERENCE
 [id="serverless-rn-1-25-0_{context}"]
 = Red Hat {ServerlessProductName} 1.25.0
 

--- a/modules/serverless-rn-1-26-0.adoc
+++ b/modules/serverless-rn-1-26-0.adoc
@@ -2,7 +2,7 @@
 //
 // * /serverless/serverless-release-notes.adoc
 
-:_content-type: REFERENCE
+:_mod-docs-content-type: REFERENCE
 [id="serverless-rn-1-26_{context}"]
 = Red Hat {ServerlessProductName} 1.26
 

--- a/modules/serverless-rn-1-27-0.adoc
+++ b/modules/serverless-rn-1-27-0.adoc
@@ -2,7 +2,7 @@
 //
 // * /serverless/serverless-release-notes.adoc
 
-:_content-type: REFERENCE
+:_mod-docs-content-type: REFERENCE
 [id="serverless-rn-1-27_{context}"]
 = Red Hat {ServerlessProductName} 1.27
 

--- a/modules/serverless-rn-1-28-0.adoc
+++ b/modules/serverless-rn-1-28-0.adoc
@@ -2,7 +2,7 @@
 //
 // * /serverless/serverless-release-notes.adoc
 
-:_content-type: REFERENCE
+:_mod-docs-content-type: REFERENCE
 [id="serverless-rn-1-28-0_{context}"]
 = Red Hat {ServerlessProductName} 1.28
 

--- a/modules/serverless-rn-1-29-0.adoc
+++ b/modules/serverless-rn-1-29-0.adoc
@@ -2,7 +2,7 @@
 //
 // * /serverless/serverless-release-notes.adoc
 
-:_content-type: REFERENCE
+:_mod-docs-content-type: REFERENCE
 [id="serverless-rn-1-29-0_{context}"]
 = Red Hat {ServerlessProductName} 1.29
 

--- a/modules/serverless-rn-1-29-1.adoc
+++ b/modules/serverless-rn-1-29-1.adoc
@@ -2,7 +2,7 @@
 //
 // * /serverless/serverless-release-notes.adoc
 
-:_content-type: REFERENCE
+:_mod-docs-content-type: REFERENCE
 [id="serverless-rn-1-29-1_{context}"]
 = Red Hat {ServerlessProductName} 1.29.1
 

--- a/modules/serverless-rn-1-30-0.adoc
+++ b/modules/serverless-rn-1-30-0.adoc
@@ -2,7 +2,7 @@
 //
 // * about/serverless-release-notes.adoc
 
-:_content-type: REFERENCE
+:_mod-docs-content-type: REFERENCE
 [id="serverless-rn-1-30-0_{context}"]
 = Red Hat {ServerlessProductName} 1.30
 

--- a/modules/serverless-rn-1-30-1.adoc
+++ b/modules/serverless-rn-1-30-1.adoc
@@ -2,7 +2,7 @@
 //
 // * /serverless/serverless-release-notes.adoc
 
-:_content-type: REFERENCE
+:_mod-docs-content-type: REFERENCE
 [id="serverless-rn-1-30-1_{context}"]
 = Red Hat {ServerlessProductName} 1.30.1
 

--- a/modules/serverless-rn-1-30-2.adoc
+++ b/modules/serverless-rn-1-30-2.adoc
@@ -2,7 +2,7 @@
 //
 // * /serverless/serverless-release-notes.adoc
 
-:_content-type: REFERENCE
+:_mod-docs-content-type: REFERENCE
 [id="serverless-rn-1-30-2_{context}"]
 = Red Hat {ServerlessProductName} 1.30.2
 

--- a/modules/serverless-rn-1-31-0.adoc
+++ b/modules/serverless-rn-1-31-0.adoc
@@ -2,7 +2,7 @@
 //
 // * about/serverless-release-notes.adoc
 
-:_content-type: REFERENCE
+:_mod-docs-content-type: REFERENCE
 [id="serverless-rn-1-31-0_{context}"]
 = Red Hat {ServerlessProductName} 1.31
 

--- a/modules/serverless-rn-1-32-0.adoc
+++ b/modules/serverless-rn-1-32-0.adoc
@@ -2,7 +2,7 @@
 //
 // * about/serverless-release-notes.adoc
 
-:_content-type: REFERENCE
+:_mod-docs-content-type: REFERENCE
 [id="serverless-rn-1-32-0_{context}"]
 = Red Hat {ServerlessProductName} 1.32
 

--- a/modules/serverless-rn-1-32-2.adoc
+++ b/modules/serverless-rn-1-32-2.adoc
@@ -2,7 +2,7 @@
 //
 // * about/serverless-release-notes.adoc
 
-:_content-type: REFERENCE
+:_mod-docs-content-type: REFERENCE
 [id="serverless-rn-1-32-2_{context}"]
 = Red Hat {ServerlessProductName} 1.32.2
 

--- a/modules/serverless-rn-1-33-0.adoc
+++ b/modules/serverless-rn-1-33-0.adoc
@@ -2,7 +2,7 @@
 //
 // * about/serverless-release-notes.adoc
 
-:_content-type: REFERENCE
+:_mod-docs-content-type: REFERENCE
 [id="serverless-rn-1-33-0_{context}"]
 = Red Hat {ServerlessProductName} 1.33
 

--- a/modules/serverless-rn-1-33-2.adoc
+++ b/modules/serverless-rn-1-33-2.adoc
@@ -2,7 +2,7 @@
 //
 // * about/serverless-release-notes.adoc
 
-:_content-type: REFERENCE
+:_mod-docs-content-type: REFERENCE
 [id="serverless-rn-1-33-2_{context}"]
 = Red Hat {ServerlessProductName} 1.33.2
 

--- a/modules/serverless-rn-1-33-3.adoc
+++ b/modules/serverless-rn-1-33-3.adoc
@@ -2,7 +2,7 @@
 //
 // * about/serverless-release-notes.adoc
 
-:_content-type: REFERENCE
+:_mod-docs-content-type: REFERENCE
 [id="serverless-rn-1-33-3_{context}"]
 = Red Hat {ServerlessProductName} 1.33.3
 

--- a/modules/serverless-rn-1-34-0.adoc
+++ b/modules/serverless-rn-1-34-0.adoc
@@ -2,7 +2,7 @@
 //
 // * about/serverless-release-notes.adoc
 
-:_content-type: REFERENCE
+:_mod-docs-content-type: REFERENCE
 [id="serverless-rn-1-34-0_{context}"]
 = Red Hat {ServerlessProductName} 1.34
 

--- a/modules/serverless-rn-1-34-1.adoc
+++ b/modules/serverless-rn-1-34-1.adoc
@@ -2,7 +2,7 @@
 //
 // * about/serverless-release-notes.adoc
 
-:_content-type: REFERENCE
+:_mod-docs-content-type: REFERENCE
 [id="serverless-rn-1-34-1_{context}"]
 = Red Hat {ServerlessProductName} 1.34.1
 

--- a/modules/serverless-rn-1-35-0.adoc
+++ b/modules/serverless-rn-1-35-0.adoc
@@ -2,7 +2,7 @@
 //
 // * about/serverless-release-notes.adoc
 
-:_content-type: REFERENCE
+:_mod-docs-content-type: REFERENCE
 [id="serverless-rn-1-35-0_{context}"]
 = Red Hat {ServerlessProductName} 1.35
 

--- a/modules/serverless-rn-1-35-1.adoc
+++ b/modules/serverless-rn-1-35-1.adoc
@@ -2,7 +2,7 @@
 //
 // * about/serverless-release-notes.adoc
 
-:_content-type: REFERENCE
+:_mod-docs-content-type: REFERENCE
 [id="serverless-rn-1-35-1_{context}"]
 = Red{nbsp}Hat {ServerlessProductName} 1.35.1
 

--- a/modules/serverless-rn-1-36-0.adoc
+++ b/modules/serverless-rn-1-36-0.adoc
@@ -2,7 +2,7 @@
 //
 // * about/serverless-release-notes.adoc
 
-:_content-type: REFERENCE
+:_mod-docs-content-type: REFERENCE
 [id="serverless-rn-1-36-0_{context}"]
 = Red Hat {ServerlessProductName} 1.36
 

--- a/modules/serverless-scale-to-zero-grace-period.adoc
+++ b/modules/serverless-scale-to-zero-grace-period.adoc
@@ -2,7 +2,7 @@
 //
 // * /serverless/admin_guide/serverless-configuration.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-scale-to-zero-grace-period_{context}"]
 = Configuring the scale-to-zero grace period
 

--- a/modules/serverless-send-events-kn.adoc
+++ b/modules/serverless-send-events-kn.adoc
@@ -1,4 +1,4 @@
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-send-events-kn_{context}"]
 = Sending events by using the kn-event plugin
 

--- a/modules/serverless-services-network-policies-enabling-comms.adoc
+++ b/modules/serverless-services-network-policies-enabling-comms.adoc
@@ -2,7 +2,7 @@
 //
 // * serverless/knative-serving/config-applications/restrictive-cluster-policies.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-services-network-policies-enabling-comms_{context}"]
 = Enabling communication with Knative applications on a cluster with restrictive network policies
 

--- a/modules/serverless-services-network-policies.adoc
+++ b/modules/serverless-services-network-policies.adoc
@@ -2,7 +2,7 @@
 //
 // * serverless/knative-serving/config-applications/restrictive-cluster-policies.adoc
 
-:_content-type: Concept
+:_mod-docs-content-type: Concept
 [id="serverless-services-network-policies_{context}"]
 = Clusters with restrictive network policies
 

--- a/modules/serverless-sinkbinding-intro.adoc
+++ b/modules/serverless-sinkbinding-intro.adoc
@@ -2,7 +2,7 @@
 //
 // * /serverless/eventing/event-sources/serverless-custom-event-sources.adoc
 
-:_content-type: CONCEPT
+:_mod-docs-content-type: CONCEPT
 [id="serverless-sinkbinding-intro_context"]
 = Sink binding
 

--- a/modules/serverless-sinkbinding-kn.adoc
+++ b/modules/serverless-sinkbinding-kn.adoc
@@ -2,7 +2,7 @@
 //
 // * /serverless/eventing/event-sources/serverless-custom-event-sources.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-sinkbinding-kn_{context}"]
 = Creating a sink binding by using the Knative CLI
 

--- a/modules/serverless-sinkbinding-odc.adoc
+++ b/modules/serverless-sinkbinding-odc.adoc
@@ -2,7 +2,7 @@
 //
 // * /serverless/eventing/event-sources/serverless-custom-event-sources.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-sinkbinding-odc_{context}"]
 = Creating a sink binding by using the web console
 

--- a/modules/serverless-sinkbinding-ossm.adoc
+++ b/modules/serverless-sinkbinding-ossm.adoc
@@ -2,7 +2,7 @@
 //
 // * /serverless/eventing/event-sources/serverless-custom-event-sources.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-sinkbinding-ossm_{context}"]
 = Integrating {SMProductShortName} with a sink binding
 

--- a/modules/serverless-sinkbinding-reference.adoc
+++ b/modules/serverless-sinkbinding-reference.adoc
@@ -2,7 +2,7 @@
 //
 // * /serverless/eventing/event-sources/serverless-custom-event-sources.adoc
 
-:_content-type: REFERENCE
+:_mod-docs-content-type: REFERENCE
 [id="serverless-sinkbinding-reference_{context}"]
 = Sink binding reference
 // this section probably needs a rewrite / restructure; feels like multiple modules maybe for a larger ref doc. Out of scope for this PR.

--- a/modules/serverless-sinkbinding-yaml.adoc
+++ b/modules/serverless-sinkbinding-yaml.adoc
@@ -2,7 +2,7 @@
 //
 // * /serverless/eventing/event-sources/serverless-custom-event-sources.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-sinkbinding-yaml_{context}"]
 = Creating a sink binding by using YAML
 

--- a/modules/serverless-skipping-tag-resolution.adoc
+++ b/modules/serverless-skipping-tag-resolution.adoc
@@ -2,7 +2,7 @@
 //
 // * knative-serving/config-applications/deployment-resources.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-skipping-tag-resolution_{context}"]
 = Skipping tag resolution
 

--- a/modules/serverless-subscribing-a-function-to-cloudevents.adoc
+++ b/modules/serverless-subscribing-a-function-to-cloudevents.adoc
@@ -1,4 +1,4 @@
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-subscribing-a-function-to-cloudevents_{context}"]
 = Subscribing a function to CloudEvents
 

--- a/modules/serverless-tag-to-digest-resolution.adoc
+++ b/modules/serverless-tag-to-digest-resolution.adoc
@@ -2,7 +2,7 @@
 //
 // * serverless/admin_guide/serverless-configuration.adoc
 
-:_content-type: CONCEPT
+:_mod-docs-content-type: CONCEPT
 [id="serverless-tag-to-digest-resolution_{context}"]
 = Tag-to-digest resolution
 

--- a/modules/serverless-target-utilization.adoc
+++ b/modules/serverless-target-utilization.adoc
@@ -2,7 +2,7 @@
 //
 // * serverless/knative-serving/autoscaling/serverless-autoscaling-developer.adoc
 
-:_content-type: REFERENCE
+:_mod-docs-content-type: REFERENCE
 [id="serverless-target-utilization_{context}"]
 = Concurrency target utilization
 

--- a/modules/serverless-tech-preview-features.adoc
+++ b/modules/serverless-tech-preview-features.adoc
@@ -2,7 +2,7 @@
 //
 // * about/serverless-release-notes.adoc
 
-:_content-type: REFERENCE
+:_mod-docs-content-type: REFERENCE
 [id="serverless-tech-preview-features_{context}"]
 = Generally Available and Technology Preview features
 

--- a/modules/serverless-testing-go-functions.adoc
+++ b/modules/serverless-testing-go-functions.adoc
@@ -2,7 +2,7 @@
 //
 // * serverless/functions/serverless-developing-typescript-functions.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-testing-go-functions_{context}"]
 = Testing Go functions
 

--- a/modules/serverless-testing-nodejs-functions.adoc
+++ b/modules/serverless-testing-nodejs-functions.adoc
@@ -2,7 +2,7 @@
 //
 // * /serverless/functions/serverless-developing-nodejs-functions.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-testing-nodejs-functions_{context}"]
 = Testing Node.js functions
 

--- a/modules/serverless-testing-python-functions.adoc
+++ b/modules/serverless-testing-python-functions.adoc
@@ -2,7 +2,7 @@
 //
 // * serverless/functions/serverless-developing-python-functions.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-testing-python-functions_{context}"]
 = Testing Python functions
 

--- a/modules/serverless-testing-quarkus-functions.adoc
+++ b/modules/serverless-testing-quarkus-functions.adoc
@@ -2,7 +2,7 @@
 //
 // * serverless/functions/serverless-developing-quarkus-functions.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-testing-quarkus-functions_{context}"]
 = Testing Quarkus functions
 

--- a/modules/serverless-testing-typescript-functions.adoc
+++ b/modules/serverless-testing-typescript-functions.adoc
@@ -2,7 +2,7 @@
 //
 // * serverless/functions/serverless-developing-typescript-functions.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-testing-typescript-functions_{context}"]
 = Testing TypeScript functions
 

--- a/modules/serverless-traffic-splitting-flags-kn.adoc
+++ b/modules/serverless-traffic-splitting-flags-kn.adoc
@@ -2,7 +2,7 @@
 //
 // * serverless/develop/serverless-traffic-management.adoc
 
-:_content-type: REFERENCE
+:_mod-docs-content-type: REFERENCE
 [id="serverless-traffic-splitting-flags-kn_{context}"]
 = Knative CLI traffic splitting flags
 

--- a/modules/serverless-typescript-context-object-reference.adoc
+++ b/modules/serverless-typescript-context-object-reference.adoc
@@ -2,7 +2,7 @@
 //
 // * serverless/functions/serverless-functions-reference-guide.adoc
 
-:_content-type: REFERENCE
+:_mod-docs-content-type: REFERENCE
 [id="serverless-typescript-context-object-reference_{context}"]
 = TypeScript context object reference
 

--- a/modules/serverless-typescript-function-return-values.adoc
+++ b/modules/serverless-typescript-function-return-values.adoc
@@ -2,7 +2,7 @@
 //
 // * serverless/functions/serverless-developing-typescript-functions.adoc
 
-:_content-type: REFERENCE
+:_mod-docs-content-type: REFERENCE
 [id="serverless-typescript-function-return-values_{context}"]
 = TypeScript function return values
 

--- a/modules/serverless-typescript-functions-context-objects.adoc
+++ b/modules/serverless-typescript-functions-context-objects.adoc
@@ -2,7 +2,7 @@
 //
 // * serverless/functions/serverless-developing-typescript-functions.adoc
 
-:_content-type: REFERENCE
+:_mod-docs-content-type: REFERENCE
 [id="serverless-typescript-functions-context-objects_{context}"]
 = TypeScript context objects
 

--- a/modules/serverless-typescript-template.adoc
+++ b/modules/serverless-typescript-template.adoc
@@ -2,7 +2,7 @@
 //
 // * serverless/functions/serverless-developing-typescript-functions.adoc
 
-:_content-type: REFERENCE
+:_mod-docs-content-type: REFERENCE
 [id="serverless-typescript-template_{context}"]
 = TypeScript function template structure
 

--- a/modules/serverless-uninstalling-knative-eventing.adoc
+++ b/modules/serverless-uninstalling-knative-eventing.adoc
@@ -2,7 +2,7 @@
 //
 // * serverless/removing/uninstalling-knative-eventing.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-uninstalling-knative-eventing_{context}"]
 = Uninstalling Knative Eventing
 

--- a/modules/serverless-uninstalling-knative-serving.adoc
+++ b/modules/serverless-uninstalling-knative-serving.adoc
@@ -2,7 +2,7 @@
 //
 // * serverless/install/removing-openshift-serverless.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-uninstalling-knative-serving_{context}"]
 = Uninstalling Knative Serving
 

--- a/modules/serverless-update-subscriptions-kn.adoc
+++ b/modules/serverless-update-subscriptions-kn.adoc
@@ -2,7 +2,7 @@
 //
 // * /serverless/develop/serverless-subs.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-update-subscriptions-kn_{context}"]
 = Updating subscriptions by using the Knative CLI
 

--- a/modules/serverless-upgrading-cli-with-locked-version.adoc
+++ b/modules/serverless-upgrading-cli-with-locked-version.adoc
@@ -2,7 +2,7 @@
 //
 // * /serverless/install/serverless-upgrades.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-upgrading-cli-with-locked-version_{context}"]
 = Upgrading the Knative CLI with locked version
 

--- a/modules/serverless-url-scheme-external-routes.adoc
+++ b/modules/serverless-url-scheme-external-routes.adoc
@@ -2,7 +2,7 @@
 //
 // * serverless/knative-serving/external-ingress-routing/url-scheme-external-routes.adoc
 
-:_content-type: REFERENCE
+:_mod-docs-content-type: REFERENCE
 [id="serverless-url-scheme-external-routes_{context}"]
 = Setting the URL scheme for external routes
 // should probably be a procedure, but this is out of scope for the abstracts PR

--- a/modules/serverless-using-jobsink.adoc
+++ b/modules/serverless-using-jobsink.adoc
@@ -2,7 +2,7 @@
 //
 // * serverless/eventing/event-sinks/serverless-jobsink.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-using-jobsink_{context}"]
 = Using JobSink
 

--- a/modules/serving-transport-encryption-configuring-selfsigned-clusterissuer.adoc
+++ b/modules/serving-transport-encryption-configuring-selfsigned-clusterissuer.adoc
@@ -1,7 +1,7 @@
 // Module included in the following assemblies:
 //
 // * knative-serving/serving-transport-encryption.adoc
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serving-transport-encryption-configuring-selfsigned-clusterissuer_{context}"]
 = Configuring a SelfSigned cluster issuer
 

--- a/modules/serving-transport-encryption-configuring.adoc
+++ b/modules/serving-transport-encryption-configuring.adoc
@@ -1,7 +1,7 @@
 // Module included in the following assemblies:
 //
 // * knative-serving/serving-transport-encryption.adoc
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serving-transport-encryption-configuring_{context}"]
 = Configuring transport encryption
 

--- a/modules/serving-transport-encryption-creating-a-clusterissuer-to-be-used-by-serving.adoc
+++ b/modules/serving-transport-encryption-creating-a-clusterissuer-to-be-used-by-serving.adoc
@@ -1,7 +1,7 @@
 // Module included in the following assemblies:
 //
 // * knative-serving/serving-transport-encryption.adoc
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serving-transport-encryption-creating-a-clusterissuer-to-be-used-by-serving_{context}"]
 = Creating a ClusterIssuer to be used by Serving
 

--- a/modules/serving-transport-encryption-ensuring-seamless-ca-rotation.adoc
+++ b/modules/serving-transport-encryption-ensuring-seamless-ca-rotation.adoc
@@ -1,7 +1,7 @@
 // Module included in the following assemblies:
 //
 // * knative-serving/serving-transport-encryption.adoc
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serving-transport-encryption-ensuring-seamless-ca-rotation_{context}"]
 = Ensuring seamless CA rotation
 

--- a/modules/serving-transport-encryption-verifying.adoc
+++ b/modules/serving-transport-encryption-verifying.adoc
@@ -1,7 +1,7 @@
 // Module included in the following assemblies:
 //
 // * knative-serving/serving-transport-encryption.adoc
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serving-transport-encryption-verifying_{context}"]
 = Verifying transport encryption is enabled
 

--- a/modules/specifying-sink-flag-kn.adoc
+++ b/modules/specifying-sink-flag-kn.adoc
@@ -6,7 +6,7 @@
 // * serverless/develop/serverless-kafka-developer.adoc
 // * serverless/reference/kn-flags-reference.adoc
 
-:_content-type: REFERENCE
+:_mod-docs-content-type: REFERENCE
 [id="specifying-sink-flag-kn_{context}"]
 = Knative CLI sink flag
 

--- a/modules/support-knowledgebase-about.adoc
+++ b/modules/support-knowledgebase-about.adoc
@@ -5,7 +5,7 @@
 // * service_mesh/v2x/ossm-troubleshooting-istio.adoc
 // * osd_architecture/osd-support.adoc
 
-:_content-type: CONCEPT
+:_mod-docs-content-type: CONCEPT
 [id="support-knowledgebase-about_{context}"]
 = About the Red Hat Knowledgebase
 

--- a/modules/support-knowledgebase-search.adoc
+++ b/modules/support-knowledgebase-search.adoc
@@ -5,7 +5,7 @@
 // * service_mesh/v2x/ossm-troubleshooting-istio.adoc
 // * osd_architecture/osd-support.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="support-knowledgebase-search_{context}"]
 = Searching the Red Hat Knowledgebase
 

--- a/modules/support-submitting-a-case.adoc
+++ b/modules/support-submitting-a-case.adoc
@@ -5,7 +5,7 @@
 // * service_mesh/v2x/ossm-troubleshooting-istio.adoc
 // * osd_architecture/osd-support.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="support-submitting-a-case_{context}"]
 = Submitting a support case
 

--- a/modules/trigger-event-delivery-config.adoc
+++ b/modules/trigger-event-delivery-config.adoc
@@ -2,7 +2,7 @@
 //
 // * /serverless/eventing/triggers/serverless-triggers.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="trigger-event-delivery-config_{context}"]
 = Configuring event delivery ordering for triggers
 

--- a/modules/verifying-serverless-app-deployment.adoc
+++ b/modules/verifying-serverless-app-deployment.adoc
@@ -2,7 +2,7 @@
 //
 // serverless/develop/serverless-applications.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="verifying-serverless-app-deployment_{context}"]
 = Verifying your serverless application deployment
 


### PR DESCRIPTION
**Note for the peer & merge reviewer:** 
- This PR contains only `_mod-docs-content-type` updates. 
- No other CQA changes, error types, or content refinements are included. 
- Other CQA error types will be addressed in separate PRs to maintain clear scope and reviewability.

**Changes:** 
- This PR resolves CQA errors related to missing `_mod-docs-content-type` attributes across affected modules in the Serverless repository. 
- Changes are metadata-only and do not impact user-facing content.

**Tracking JIRA:** https://issues.redhat.com/browse/SRVLOGIC-815

**You can cherry-pick for the following branches:** 
- `serverless-docs-1.37`
- `serverless-docs-1.38`

**I will create the Manual CPs for the following release branches:** 
- `serverless-docs-1.36`
- `serverless-docs-1.35`
- `serverless-docs-1.34`

**Reviews:**
- [ ] Peer has approved this change