### PR TITLE
OSDOCS-18424 updated zero-trust modules

### DIFF
--- a/modules/zero-trust-manager-automatic-management.adoc
+++ b/modules/zero-trust-manager-automatic-management.adoc
@@ -49,19 +49,19 @@ spec:
     managedRoute: "true"
 ----
 
-* The `trustDomain` field sets a unique trust domain for each cluster (for example, `cluster1.example.com`, `cluster2.example.com`).
+* The `spec.trustDomain` field sets a unique trust domain for each cluster (for example, `cluster1.example.com`, `cluster2.example.com`).
 
-* The `profile` field uses the `https_web` profile for ACME-based certificate management.
+* The `spec.federation.bundleEndpoint.profile` field uses the `https_web` profile for ACME-based certificate management.
 
-* The `directoryUrl` field contains the Let's Encrypt production directory URL. For testing, use: `https://acme-staging-v02.api.letsencrypt.org/directory`.
+* The `spec.federation.bundleEndpoint.httpsWeb.acme.directoryUrl` field contains the Let's Encrypt production directory URL. For testing, use: `https://acme-staging-v02.api.letsencrypt.org/directory`.
 
-* The `domainName` field is the domain name where your federation endpoint is accessible. This automatically sets to `federation.<cluster-apps-domain>` if `managedRoute` is set to "true".
+* The `spec.federation.bundleEndpoint.httpsWeb.acme.domainName` field is the domain name where your federation endpoint is accessible. This automatically sets to `federation.<cluster-apps-domain>` if `managedRoute` is set to "true".
 
-* The `email` field is your email address for ACME account registration and certificate expiration notifications.
+* The `spec.federation.bundleEndpoint.httpsWeb.acme.email` field is your email address for ACME account registration and certificate expiration notifications.
 
-* The `tosAccepted` field accepts the Let's Encrypt Terms of Service.
+* The `spec.federation.bundleEndpoint.httpsWeb.acme.tosAccepted` field accepts the Let's Encrypt Terms of Service.
 
-* The `managedRoute` field enables an automatic route creation by the operator for the federation bundle endpoint.
+* The `spec.federation.managedRoute` field enables an automatic route creation by the operator for the federation bundle endpoint.
 
 . Apply the configuration to each cluster by running the following command:
 +
@@ -140,6 +140,7 @@ spec:
   bundleEndpointURL: https://federation.apps.cluster2.example.com
   bundleEndpointProfile:
     type: https_web
+  className: zero-trust-workload-identity-manager-spire
   trustDomainBundle: |
     {
       "keys": [...],
@@ -155,6 +156,7 @@ spec:
   bundleEndpointURL: https://federation.apps.cluster3.example.com
   bundleEndpointProfile:
     type: https_web
+   className: zero-trust-workload-identity-manager-spire
   trustDomainBundle: |
     {
       "keys": [...],
@@ -162,7 +164,9 @@ spec:
     }
 ----
 
-* The `trustDomainBundle` field contains the complete trust bundle JSON that you fetched using `curl` in step 5.
+* The `spec.trustDomainBundle` field contains the complete trust bundle JSON that you fetched using `curl` in step 5.
+
+* The `spec.className` field contains the name of a class to watch CRs for. Spire-controller-manager watches the resource only if `spec.className` is set to `zero-trust-workload-identity-manager-spire`.
 
 . Apply the `ClusterFederatedTrustDomain` resources by running the following command:
 +
@@ -196,7 +200,7 @@ spec:
     managedRoute: "true"
 ----
 
-* The `federatesWith` field lists all remote trust domains this cluster should federate with.
+* The `spec.federation.federatesWith` field lists all remote trust domains this cluster should federate with.
 
 . Apply the updated configuration by running the following command:
 +

--- a/modules/zero-trust-manager-federation-configuration.adoc
+++ b/modules/zero-trust-manager-federation-configuration.adoc
@@ -22,7 +22,7 @@ The {zero-trust-full} includes SPIRE Federation support, allowing multiple indep
 
 .Procedure
 
-. Configure the `SpireServer` custom resource on each cluster to enable federation with the `https_spiffe` profile. The `https_spiffe` profile uses SPIFFE-based TLS authentication, where SPIRE servers authenticate to each other using their own SVIDs (SPIFFE Verifiable Identity Documents).
+. Configure the `SpireServer` custom resource on each cluster to enable federation with the `https_spiffe` profile. The `https_spiffe` profile uses SPIFFE-based TLS authentication, where SPIRE servers authenticate to each other using their own SPIFFE Verifiable Identity Documents (SVIDs).
 +
 [source,yaml]
 ----
@@ -39,13 +39,13 @@ spec:
     managedRoute: "true"
 ----
 
-* The `trustDomain` field sets a unique trust domain for each cluster.
+* The `spec.trustDomain` field sets a unique trust domain for each cluster.
 
-* The `profile` field uses the `https_spiffe` profile for SPIFFE-based TLS authentication.
+* The `spec.federation.bundleEnpoint.profile` field uses the `https_spiffe` profile for SPIFFE-based TLS authentication.
 
-* The `refreshHint` field suggests intervals (in seconds) for remote servers to refresh the trust bundle. Range: 60-3600 seconds.
+* The `spec.federation.bundleEndpoint.refreshHint` field suggests intervals (in seconds) for remote servers to refresh the trust bundle. Range: 60-3600 seconds.
 
-* The `managedRoute` field enables automatic route creation by the Operator.
+* The `spec.federation.managedRoute` field enables automatic route creation by the Operator.
 
 . Apply the configuration changes by running the following command:
 +
@@ -60,6 +60,7 @@ $ oc apply -f spire-server.yaml
 ----
 $ oc get spireserver cluster -w
 ----
+
 . Verify that the federation route has been created:
 +
 [source,terminal]
@@ -83,7 +84,7 @@ $  curl -k https://federation.apps.cluster2.example.com > cluster2-bundle.json
 +
 [NOTE]
 ====
-For `https_spiffe` profile, you might need to use `-k` flag if the certificate is not trusted by your system's CA bundle:
+For `https_spiffe` profile, you might need to use the `-k` flag if the certificate is not trusted by your system's CA bundle:
 ====
 +
 The response contains the trust bundle in JSON Web Key Set (JWKS) format:
@@ -115,13 +116,14 @@ The response contains the trust bundle in JSON Web Key Set (JWKS) format:
 apiVersion: spire.spiffe.io/v1alpha1
 kind: ClusterFederatedTrustDomain
 metadata:
-  name: cluster2-federation
+  name: federation-to-cluster2
 spec:
-  trustDomain: cluster2.example.com
-  bundleEndpointURL: https://federation.apps.cluster2.example.com
+  trustDomain: <CLUSTER2_APPS_DOMAIN>
+  bundleEndpointURL: https://federation.<CLUSTER2_APPS_DOMAIN>
   bundleEndpointProfile:
     type: https_spiffe
-    endpointSPIFFEID: spiffe://cluster2.example.com/spire/server
+    endpointSPIFFEID: spiffe://<CLUSTER2_APPS_DOMAIN>/spire/server
+  className: zero-trust-workload-identity-manager-spire
   trustDomainBundle: |
     {
       "keys": [
@@ -136,10 +138,16 @@ spec:
       "spiffe_sequence": 1
     }
 ----
++
+where
 
-* The `endpointSPIFFEID` field contains the SPIFFE ID of the remote SPIRE server. Required for `https_spiffe` profile to validate the remote server's identity.
+`<CLUSTER2_APPS_DOMAIN>`:: Specifies the trust domain of the external cluster you are federating with.
 
-* The `trustDomainBundle` contains the complete trust bundle JSON that you fetched in the previous step.
+`spec.bundleEndpointProfile.endpointSPIFFEID`:: Specifies the SPIFFE ID of the remote SPIRE server. Required for `https_spiffe` profile to validate the remote server's identity.
+
+`spec.trustDomainBundle`:: Specifies the complete trust bundle JSON that you fetched in the previous step.
+
+`spec.className`:: Specifies the name of a class to watch CRs for. Spire-controller-manager watches the resource only if `spec.className` is set to `zero-trust-workload-identity-manager-spire`.
 
 . Apply the `ClusterFederatedTrustDomain` resource by running the following command:
 +
@@ -176,7 +184,7 @@ spec:
     managedRoute: "true"
 ----
 
-* The `federatesWith` field lists all remote trust domains this cluster should federate with.
+* The `spec.federation.federatesWith` field lists all remote trust domains this cluster should federate with.
 
 . Apply the updated configuration by running the following command:
 +

--- a/modules/zero-trust-manager-manual-management.adoc
+++ b/modules/zero-trust-manager-manual-management.adoc
@@ -336,6 +336,7 @@ spec:
   bundleEndpointURL: https://federation.apps.cluster1.example.com
   bundleEndpointProfile:
     type: https_web
+  className: zero-trust-workload-identity-manager-spire
   trustDomainBundle: |
     {
       "keys": [
@@ -359,6 +360,7 @@ spec:
   bundleEndpointURL: https://federation.apps.cluster2.example.com
   bundleEndpointProfile:
     type: https_web
+  className: zero-trust-workload-identity-manager-spire
   trustDomainBundle: |
     {
       "keys": [...],
@@ -367,6 +369,8 @@ spec:
 ----
 
 * The `trustDomainBundle` field contains the complete trust bundle JSON that you fetched in the previous step.
+
+* The `spec.className` field contains the name of a class to watch CRs for. Spire-controller-manager watches the resource only if `spec.className` is set to `zero-trust-workload-identity-manager-spire`.
 
 . Apply the `ClusterFederatedTrustDomain` resources by running the following command:
 +


### PR DESCRIPTION
Version(s):
4.19+

Issue:
https://issues.redhat.com/browse/OSDOCS-18424

Link to docs preview:
https://107167--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/zero_trust_workload_identity_manager/zero-trust-manager-spire-federation.html

QE review:
- [ ] QE has approved this change.


Additional information:

