### PR TITLE
OSDOCS-17084 ADV MicroShift error resolution

### DIFF
--- a/microshift_configuring/microshift-config-snippets.adoc
+++ b/microshift_configuring/microshift-config-snippets.adoc
@@ -6,7 +6,8 @@ include::_attributes/attributes-microshift.adoc[]
 
 toc::[]
 
-If you want to configure one or two settings, use the `/etc/microshift/config.d/` configuration directory to drop in configuration snippet YAML files.
+[role="_abstract"]
+To configure one or two settings in {product-title}, use the `/etc/microshift/config.d/` configuration directory to drop in configuration snippet YAML files. Restart {microshift-short} for new or changed snippets to apply.
 
 include::modules/microshift-how-config-snippets-work.adoc[leveloffset=+1]
 

--- a/modules/microshift-example-config-snippets-list.adoc
+++ b/modules/microshift-example-config-snippets-list.adoc
@@ -6,15 +6,15 @@
 [id="microshift-ex-config-snippets-lists_{context}"]
 = Examples of configuration snippet lists or arrays
 
-Lists, or arrays, are not merged, they are overwritten. For example, you can replace a SAN or list of SANs by creating an additional snippet for the same field that is read after the first:
+[role="_abstract"]
+Lists and arrays in {product-title} configuration snippets are overwritten, not merged.
 
-.{microshift-short} configuration directory contents
-* `/etc/microshift/config.yaml.default` or `/etc/microshift/config.yaml`
+For example, you can replace a SAN or list of SANs by creating an additional snippet for the same field that is read after the first:
 
-.Example {microshift-short} configuration snippet directory contents
-* `/etc/microshift/config.d/10-san.yaml`
-* `/etc/microshift/config.d/20-san.yaml`
-+
+{microshift-short} configuration directory contents:: `/etc/microshift/config.yaml.default` or `/etc/microshift/config.yaml`
+
+Example {microshift-short} configuration snippet directory contents:: `/etc/microshift/config.d/10-san.yaml` and `/etc/microshift/config.d/20-san.yaml`
+
 .Example `10-san.yaml` snippet
 [source,yaml]
 ----
@@ -23,7 +23,7 @@ apiServer:
     - host1
     - host2
 ----
-+
+
 .Example `20-san.yaml` snippet
 [source,yaml]
 ----
@@ -31,7 +31,7 @@ apiServer:
   subjectAltNames:
     - hostZ
 ----
-+
+
 .Example configuration result
 [source,yaml]
 ----

--- a/modules/microshift-example-config-snippets-objects.adoc
+++ b/modules/microshift-example-config-snippets-objects.adoc
@@ -6,7 +6,8 @@
 [id="microshift-example-config-snippets-objects_{context}"]
 = Example configuration snippets that are objects
 
-Objects are merged together when you use a configuration snippet.
+[role="_abstract"]
+Object fields in {product-title} are merged together when you use a configuration snippet.
 
 .Example `10-advertiseAddress.yaml` snippet
 [source,yaml]

--- a/modules/microshift-example-mixed-config-snippets.adoc
+++ b/modules/microshift-example-mixed-config-snippets.adoc
@@ -6,7 +6,10 @@
 [id="microshift-example-mixed-config-snippets_{context}"]
 = Examples of mixed configuration snippets
 
-In this example, the values of both `advertiseAddress` and `auditLog.maxFileAge` fields merge into the configuration, but only the `c.com` and `d.com` `subjectAltNames` values are retained. This happens because the numbering in the filename indicates that the `c.com` and `d.com` values are higher priority.
+[role="_abstract"]
+When you use mixed configuration snippets in {product-title}, object fields merge and the last-read snippet replaces list values. File order controls which list entries apply.
+
+In the following example, the values of both `advertiseAddress` and `auditLog.maxFileAge` fields merge into the configuration, but only the `c.com` and `d.com` `subjectAltNames` values are retained. This happens because the numbering in the filename indicates that the `c.com` and `d.com` values are higher priority.
 
 .Example `10-advertiseAddress.yaml` snippet
 [source,yaml]

--- a/modules/microshift-how-config-snippets-work.adoc
+++ b/modules/microshift-how-config-snippets-work.adoc
@@ -6,7 +6,10 @@
 [id="microshift-how-config-snippets-work_{context}"]
 = How configuration snippets work
 
-If you want to configure one or two settings, such as adding subject alternative names (SANs), you can use the `/etc/microshift/config.d/` configuration directory to drop in configuration snippet YAML files. You must restart {microshift-short} for new configurations to apply.
+[role="_abstract"]
+Configuration snippets in {product-title} are YAML files in `/etc/microshift/config.d/` that merge with the existing configuration at runtime. You can use them to change one or two settings without editing the main config file.
+
+You must restart {microshift-short} for new configurations to apply.
 
 To return to previous values, you can delete a configuration snippet and restart {microshift-short}.
 


### PR DESCRIPTION
Oddly the modules exist in 4.16-4.17, but the assembly file does not. I'm not going to CP these changes back to those branches since they're not actually used in the 4.16-4.17 branches. 

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.18+

Issue:
https://107168--ocpdocs-pr.netlify.app/microshift/latest/microshift_configuring/microshift-config-snippets.html

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
