### PR TITLE
MIG-1870: Add MTC 1.8.13 RNs

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -92,7 +92,7 @@ endif::[]
 :mtc-short: MTC
 :mtc-full: Migration Toolkit for Containers
 :mtc-version: 1.8
-:mtc-version-z: 1.8.11
+:mtc-version-z: 1.8.13
 :mtc-legacy-image: 1.7
 :mtv-first: Migration Toolkit for Virtualization (MTV)
 :mtv-short: MTV

--- a/migration_toolkit_for_containers/release_notes/mtc-release-notes.adoc
+++ b/migration_toolkit_for_containers/release_notes/mtc-release-notes.adoc
@@ -15,6 +15,8 @@ The {mtc-short} enables you to migrate application workloads between {product-ti
 
 For information on the support policy for {mtc-short}, see link:https://access.redhat.com/support/policy/updates/openshift#app_migration[OpenShift Application and Cluster Migration Solutions], part of the _Red Hat {product-title} Life Cycle Policy_.
 
+include::modules/migration-mtc-release-notes-1-8-13.adoc[leveloffset=+1]
+
 include::modules/migration-mtc-release-notes-1-8-12.adoc[leveloffset=+1]
 
 include::modules/migration-mtc-release-notes-1-8-11.adoc[leveloffset=+1]

--- a/modules/migration-mtc-release-notes-1-8-13.adoc
+++ b/modules/migration-mtc-release-notes-1-8-13.adoc
@@ -1,0 +1,11 @@
+// Module included in the following assemblies:
+//
+//
+// * migration_toolkit_for_containers/mtc-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="migration-mtc-release-notes-1-8-13_{context}"]
+= {mtc-full} 1.8.13 release notes
+
+[role="_abstract"]
+{mtc-first} 1.8.13 is a Container Grade Only (CGO) release, which is released to refresh the health grades of the containers. No code was changed in the product itself compared to that of {mtc-short} 1.8.12.


### PR DESCRIPTION
Version(s):
OCP 4.14+

Issue:
[MIG-1870](https://issues.redhat.com/browse/MIG-1870)

Link to docs preview:

- [Migration Toolkit for Containers 1.8.13 release notes](https://107175--ocpdocs-pr.netlify.app/openshift-enterprise/latest/migration_toolkit_for_containers/release_notes/mtc-release-notes.html#migration-mtc-release-notes-1-8-13_mtc-release-notes)

QE review:
- [x] QE has approved this change.

Changes:

- Add MTC 1.8.13 Release Notes and update attributes.
