### PR TITLE
[RHDEVDOCS-7255] Update snippets to tekton.dev/v1 API version

### DIFF
--- a/modules/op-about-podtemplate.adoc
+++ b/modules/op-about-podtemplate.adoc
@@ -41,7 +41,7 @@ For a task run, you can define a pod template in the `podTemplate` spec, as in t
 .Example `TaskRun` CR with a pod template
 [source,yaml]
 ----
-apiVersion: tekton.dev/v1 # or tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: TaskRun
 metadata:
   name: mytaskrun

--- a/modules/op-about-triggers.adoc
+++ b/modules/op-about-triggers.adoc
@@ -18,7 +18,7 @@ The following example shows a code snippet of the `TriggerBinding` resource, fro
 +
 [source,yaml]
 ----
-apiVersion: triggers.tekton.dev/v1beta1
+apiVersion: triggers.tekton.dev/v1
 kind: TriggerBinding
 metadata:
   name: vote-app
@@ -32,7 +32,7 @@ spec:
     value: $(body.head_commit.id)
 ----
 
-`apiVersion`:: The API version of the `TriggerBinding` resource. In this example, `v1beta1`.
+`apiVersion`:: The API version of the `TriggerBinding` resource. In this example, `v1`.
 
 `kind`:: Specifies the type of Kubernetes object. In this example, `TriggerBinding`.
 
@@ -46,7 +46,7 @@ The following example shows a code snippet of a `TriggerTemplate` resource, whic
 +
 [source,yaml,subs="attributes+"]
 ----
-apiVersion: triggers.tekton.dev/v1beta1
+apiVersion: triggers.tekton.dev/v1
 kind: TriggerTemplate
 metadata:
   name: vote-app
@@ -90,7 +90,7 @@ spec:
               storage: 500Mi
 ----
 
-`apiVersion`:: The API version of the `TriggerTemplate` resource. In this example, `v1beta1`.
+`apiVersion`:: The API version of the `TriggerTemplate` resource. In this example, `v1`.
 
 `kind`:: Specifies the type of Kubernetes object. In this example, `TriggerTemplate`.
 
@@ -109,7 +109,7 @@ The following example shows a code snippet of a `Trigger` resource, named `vote-
 +
 [source,yaml]
 ----
-apiVersion: triggers.tekton.dev/v1beta1
+apiVersion: triggers.tekton.dev/v1
 kind: Trigger
 metadata:
   name: vote-trigger
@@ -140,7 +140,7 @@ stringData:
   secretToken: "1234567"
 ----
 
-`apiVersion`:: The API version of the `Trigger` resource. In this example, `v1beta1`.
+`apiVersion`:: The API version of the `Trigger` resource. In this example, `v1`.
 
 `kind`:: Specifies the type of Kubernetes object. In this example, `Trigger`.
 
@@ -170,7 +170,7 @@ The following example shows an `EventListener` resource, which references the `T
 +
 [source,yaml]
 ----
-apiVersion: triggers.tekton.dev/v1beta1
+apiVersion: triggers.tekton.dev/v1
 kind: EventListener
 metadata:
   name: vote-app
@@ -181,7 +181,7 @@ spec:
     - triggerRef: vote-trigger
 ----
 
-`apiVersion`:: The API version of the `EventListener` resource. In this example, `v1beta1`.
+`apiVersion`:: The API version of the `EventListener` resource. In this example, `v1`.
 
 `kind`:: Specifies the type of Kubernetes object. In this example, `EventListener`.
 

--- a/modules/op-adding-triggers.adoc
+++ b/modules/op-adding-triggers.adoc
@@ -13,7 +13,7 @@ Triggers enable pipelines to respond to external GitHub events, such as push eve
 +
 [source,yaml]
 ----
-apiVersion: triggers.tekton.dev/v1beta1
+apiVersion: triggers.tekton.dev/v1
 kind: TriggerBinding
 metadata:
   name: vote-app
@@ -45,7 +45,7 @@ $ oc create -f https://raw.githubusercontent.com/openshift/pipelines-tutorial/{p
 +
 [source,yaml,subs="attributes+"]
 ----
-apiVersion: triggers.tekton.dev/v1beta1
+apiVersion: triggers.tekton.dev/v1
 kind: TriggerTemplate
 metadata:
   name: vote-app
@@ -109,7 +109,7 @@ $ oc create -f https://raw.githubusercontent.com/openshift/pipelines-tutorial/{p
 +
 [source,yaml]
 ----
-apiVersion: triggers.tekton.dev/v1beta1
+apiVersion: triggers.tekton.dev/v1
 kind: Trigger
 metadata:
   name: vote-trigger
@@ -139,7 +139,7 @@ $ oc create -f https://raw.githubusercontent.com/openshift/pipelines-tutorial/{p
 +
 [source,yaml]
 ----
-apiVersion: triggers.tekton.dev/v1beta1
+apiVersion: triggers.tekton.dev/v1
 kind: EventListener
 metadata:
   name: vote-app
@@ -154,7 +154,7 @@ Alternatively, if you have not defined a trigger custom resource, add the bindin
 +
 [source,yaml]
 ----
-apiVersion: triggers.tekton.dev/v1beta1
+apiVersion: triggers.tekton.dev/v1
 kind: EventListener
 metadata:
   name: vote-app

--- a/modules/op-configuring-container-registry-authentication-using-workspaces.adoc
+++ b/modules/op-configuring-container-registry-authentication-using-workspaces.adoc
@@ -26,7 +26,7 @@ $ oc create secret generic my-registry-credentials \ # <1>
 .Example definition of a workspace
 [source, yaml]
 ----
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   name: skopeo-copy
@@ -52,7 +52,7 @@ $ tkn task start <task_name>
 .Example task for copying an image from a container repository using Skopeo
 [source,yaml,subs="attributes+"]
 ----
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   name: skopeo-copy

--- a/modules/op-configuring-eventlisteners-to-serve-multiple-namespaces.adoc
+++ b/modules/op-configuring-eventlisteners-to-serve-multiple-namespaces.adoc
@@ -72,7 +72,7 @@ roleRef:
 .Example `EventListener.yaml`
 [source,yaml]
 ----
-apiVersion: triggers.tekton.dev/v1beta1
+apiVersion: triggers.tekton.dev/v1
 kind: EventListener
 metadata:
   name: namespace-selector-listener
@@ -123,7 +123,7 @@ roleRef:
 .Example `Trigger.yaml`
 [source,yaml]
 ----
-apiVersion: triggers.tekton.dev/v1beta1
+apiVersion: triggers.tekton.dev/v1
 kind: Trigger
 metadata:
   name: trigger

--- a/modules/op-configuring-git-ssh-authentication-using-workspaces.adoc
+++ b/modules/op-configuring-git-ssh-authentication-using-workspaces.adoc
@@ -28,7 +28,7 @@ $ oc create secret generic my-github-ssh-credentials \ # <1>
 .Example definition of a workspace
 [source, yaml]
 ----
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   name: git-clone
@@ -54,7 +54,7 @@ $ tkn task start <task_name>
 .Example task for cloning a Git repository using an SSH key for authentication
 [source,yaml,subs="attributes+"]
 ----
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   name: git-clone

--- a/modules/op-filtering-pull-requests-using-GitHub-interceptor.adoc
+++ b/modules/op-filtering-pull-requests-using-GitHub-interceptor.adoc
@@ -17,7 +17,7 @@ GitHub Interceptor adds a comma delimited list of all files that have been chang
 +
 [source,yaml]
 ----
-apiVersion: triggers.tekton.dev/v1beta1
+apiVersion: triggers.tekton.dev/v1
 kind: EventListener
 metadata:
   name: github-add-changed-files-pr-listener
@@ -51,7 +51,7 @@ spec:
 +
 [source,yaml]
 ----
-apiVersion: triggers.tekton.dev/v1beta1
+apiVersion: triggers.tekton.dev/v1
 kind: EventListener
 metadata:
   name: github-add-changed-files-pr-listener

--- a/modules/op-limiting-secret-workspace-to-step.adoc
+++ b/modules/op-limiting-secret-workspace-to-step.adoc
@@ -15,7 +15,7 @@ To limit a secret to specific steps, define the workspace both in the task speci
 .Example task definition where only one step can access the credentials workspace
 [source,yaml,subs="attributes+"]
 ----
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   name: git-clone-build

--- a/modules/op-release-notes-1-12.adoc
+++ b/modules/op-release-notes-1-12.adoc
@@ -96,7 +96,7 @@ include::snippets/technology-preview.adoc[]
 .Example usage
 [source,yaml]
 ----
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: PipelineRun
 # ...
 spec:

--- a/modules/op-release-notes-1-14.adoc
+++ b/modules/op-release-notes-1-14.adoc
@@ -45,7 +45,7 @@ spec:
 .Example usage for a pipeline
 [source,yaml]
 ----
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
   name: http-demo
@@ -79,7 +79,7 @@ spec:
 .Example usage
 [source,yaml]
 ----
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: TaskRun
 metadata:
   name: git-api-demo-tr

--- a/modules/op-release-notes-1-15.adoc
+++ b/modules/op-release-notes-1-15.adoc
@@ -137,7 +137,7 @@ spec:
 .Example `TriggerTemplate` CR
 [source,yaml]
 ----
-apiVersion: triggers.tekton.dev/v1beta1
+apiVersion: triggers.tekton.dev/v1
 kind: TriggerTemplate
 metadata:
   name: create-configmap-template
@@ -158,7 +158,7 @@ spec:
 .Example `EventListener` CR defining a port number
 [source,yaml]
 ----
-apiVersion: triggers.tekton.dev/v1beta1
+apiVersion: triggers.tekton.dev/v1
 kind: EventListener
 metadata:
   name: simple-eventlistener
@@ -181,7 +181,7 @@ spec:
 .Example specifying a LoadBalancerClass setting
 [source,yaml]
 ----
-apiVersion: triggers.tekton.dev/v1beta1
+apiVersion: triggers.tekton.dev/v1
 kind: EventListener
 metadata:
   name: listener-loadbalancerclass

--- a/modules/op-release-notes-1-16.adoc
+++ b/modules/op-release-notes-1-16.adoc
@@ -88,7 +88,7 @@ spec:
 .Example of using `params` within a pipeline
 [source,yaml]
 ----
-apiVersion: tekton.dev/v1 # or tekton.dev/v1beta1
+apiVersion: tekton.dev/v1 # or tekton.dev/v1
 kind: Pipeline
 metadata:
   name: pipeline-propagated-params

--- a/modules/op-release-notes-1-18.adoc
+++ b/modules/op-release-notes-1-18.adoc
@@ -124,7 +124,7 @@ include::snippets/technology-preview.adoc[]
 .Example of using the `ImagePullSecrets` field
 [source,yaml]
 ----
-apiVersion: triggers.tekton.dev/v1beta1
+apiVersion: triggers.tekton.dev/v1
 kind: EventListener
 metadata:
   name: imagepullsecrets-example
@@ -158,7 +158,7 @@ spec:
 .Example of using the `on-path-change` and `on-path-change-ignore` annotations
 [source,yaml]
 ----
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
   name: "on-path-change"
@@ -178,7 +178,7 @@ You must configure a pipeline run to enable the triggering with the `on-comment`
 .Example of enabling triggering of a pipeline run through pushed commits
 [source,yaml]
 ----
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
   name: "on-comment-pr"
@@ -197,7 +197,7 @@ For example, you can test the following `on-target-branch` annotation to ensure 
 .Example `on-target-branch` annotation
 [source,yaml]
 ----
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
   name: "on-target-branch"
@@ -220,7 +220,7 @@ For example, to match two branches called `main` and `branchWith,comma`, specify
 .Example annotation with commas
 [source,yaml]
 ----
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
   name: "comma-annotation"
@@ -236,7 +236,7 @@ spec:
 .Example `cancel-in-progress` annotation
 [source,yaml]
 ----
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
   name: "cancel-in-progress"
@@ -257,7 +257,7 @@ To enable the feature, set the `pipelinesascode.tekton.dev/cancel-in-progress` a
 .Example of enabling the cancellation of older pipeline runs
 [source,yaml]
 ----
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
   name: "cancel-in-progress"

--- a/modules/op-release-notes-1-19.adoc
+++ b/modules/op-release-notes-1-19.adoc
@@ -20,7 +20,7 @@ In addition to fixes and stability improvements, the following sections highligh
 .Example `securityContext` configuration in the `EventListener` resource
 [source,yaml]
 ----
-apiVersion: triggers.tekton.dev/v1beta1
+apiVersion: triggers.tekton.dev/v1
 kind: EventListener
 metadata:
   name: listener-securitycontext
@@ -108,7 +108,7 @@ data:
 .Example for configuring the `gitToken:` field
 [source,yaml]
 ----
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
   name: git-clone-demo-pr

--- a/modules/op-release-notes-1-8.adoc
+++ b/modules/op-release-notes-1-8.adoc
@@ -57,7 +57,7 @@ To enable this feature, in the `TektonConfig` custom resource definition, in the
 [source,yaml]
 ----
 kind: Task
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 metadata:
   name: write-array
   annotations:
@@ -313,7 +313,7 @@ $ oc get route -n openshift-pipelines pipelines-as-code-controller \
 [id="deprecated-features-1-8_{context}"]
 == Deprecated and removed features
 
-* Starting with {OCP} 4.11, the `preview` and `stable` channels for installing and upgrading the {pipelines-title} Operator are removed. To install and upgrade the Operator, use the appropriate `pipelines-<version>` channel, or the `latest` channel for the most recent stable version. For example, to install the {pipelines-shortname} Operator version `1.8.x`, use the `pipelines-1.8` channel. 
+* Starting with {OCP} 4.11, the `preview` and `stable` channels for installing and upgrading the {pipelines-title} Operator are removed. To install and upgrade the Operator, use the appropriate `pipelines-<version>` channel, or the `latest` channel for the most recent stable version. For example, to install the {pipelines-shortname} Operator version `1.8.x`, use the `pipelines-1.8` channel.
 +
 [NOTE]
 ====
@@ -550,7 +550,7 @@ With this update, {pipelines-title} General Availability (GA) 1.8.1 is available
 [id="known-issues-1-8-1_{context}"]
 === Known issues
 
-* By default, the containers have restricted permissions for enhanced security. The restricted permissions apply to all controller pods in the {pipelines-title} Operator, and to some cluster tasks. Due to restricted permissions, the `git-clone` cluster task fails under certain configurations. 
+* By default, the containers have restricted permissions for enhanced security. The restricted permissions apply to all controller pods in the {pipelines-title} Operator, and to some cluster tasks. Due to restricted permissions, the `git-clone` cluster task fails under certain configurations.
 +
 Workaround: None. You can track the issue link:https://issues.redhat.com/browse/SRVKP-2634[SRVKP-2634].
 
@@ -559,22 +559,22 @@ Workaround: None. You can track the issue link:https://issues.redhat.com/browse/
 .Example: Failed installer sets
 [source,terminal]
 ----
-$ oc get tektoninstallerset 
+$ oc get tektoninstallerset
 NAME                                     READY   REASON
 addon-clustertasks-nx5xz                 False   Error
-addon-communityclustertasks-cfb2p        True    
-addon-consolecli-ftrb8                   True    
-addon-openshift-67dj2                    True    
-addon-pac-cf7pz                          True    
-addon-pipelines-fvllm                    True    
-addon-triggers-b2wtt                     True    
+addon-communityclustertasks-cfb2p        True
+addon-consolecli-ftrb8                   True
+addon-openshift-67dj2                    True
+addon-pac-cf7pz                          True
+addon-pipelines-fvllm                    True
+addon-triggers-b2wtt                     True
 addon-versioned-clustertasks-1-8-hqhnw   False   Error
-pipeline-w75ww                           True    
-postpipeline-lrs22                       True    
-prepipeline-ldlhw                        True    
-rhosp-rbac-4dmgb                         True    
-trigger-hfg64                            True    
-validating-mutating-webhoook-28rf7       True 
+pipeline-w75ww                           True
+postpipeline-lrs22                       True
+prepipeline-ldlhw                        True
+rhosp-rbac-4dmgb                         True
+trigger-hfg64                            True
+validating-mutating-webhoook-28rf7       True
 ----
 +
 .Example: Incorrect `TektonConfig` status
@@ -582,7 +582,7 @@ validating-mutating-webhoook-28rf7       True
 ----
 $ oc get tektonconfig config
 NAME     VERSION   READY   REASON
-config   1.8.1     True 
+config   1.8.1     True
 ----
 
 // https://issues.redhat.com/browse/SRVKP-2556
@@ -621,4 +621,3 @@ With this update, {pipelines-title} General Availability (GA) 1.8.2 is available
 
 * Before this update, the `git-clone` task failed when cloning a repository using SSH keys. With this update, the role of the non-root user in the `git-init` task is removed, and the SSH program looks in the `$HOME/.ssh/` directory for the correct keys.
 // https://issues.redhat.com/browse/SRVKP-2634
-

--- a/modules/op-resolver-git-anon.adoc
+++ b/modules/op-resolver-git-anon.adoc
@@ -58,7 +58,7 @@ The following example pipeline run references a remote pipeline from a Git repos
 
 [source,yaml]
 ----
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
   name: git-pipeline-reference-demo
@@ -108,7 +108,7 @@ The following example task run references a remote task from a Git repository:
 
 [source,yaml]
 ----
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: TaskRun
 metadata:
   name: git-task-reference-demo

--- a/modules/op-resolver-git-override-scm.adoc
+++ b/modules/op-resolver-git-override-scm.adoc
@@ -11,7 +11,7 @@ The following example task run references a remote task from a Git repository th
 
 [source,yaml]
 ----
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: TaskRun
 metadata:
   name: git-task-reference-demo

--- a/modules/op-resolver-http.adoc
+++ b/modules/op-resolver-http.adoc
@@ -37,7 +37,7 @@ The following example pipeline run references a remote pipeline from the same cl
 
 [source,yaml]
 ----
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
   name: http-pipeline-reference-demo
@@ -58,7 +58,7 @@ The following example pipeline defines a task that references a remote task from
 
 [source,yaml]
 ----
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
   name: pipeline-with-http-task-reference-demo
@@ -79,7 +79,7 @@ The following example task run references a remote task from an HTTPS URL:
 
 [source,yaml]
 ----
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: TaskRun
 metadata:
   name: http-task-reference-demo

--- a/modules/op-running-buildah-ns-task.adoc
+++ b/modules/op-running-buildah-ns-task.adoc
@@ -10,7 +10,7 @@ You can run the `buildah-ns` task as part of a `PipelineRun` resource.
 
 [source,yaml]
 ----
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata: {}
 spec:

--- a/modules/op-setting-eventlistener-scc.adoc
+++ b/modules/op-setting-eventlistener-scc.adoc
@@ -14,7 +14,7 @@ You can configure a custom security context directly in your `EventListener` cus
 .Example EventListener custom resource with configured security context
 [source,yaml,subs="attributes+"]
 ----
-apiVersion: triggers.tekton.dev/v1beta1
+apiVersion: triggers.tekton.dev/v1
 kind: EventListener
 metadata:
 #...

--- a/modules/op-specifying-manual-approval-task.adoc
+++ b/modules/op-specifying-manual-approval-task.adoc
@@ -21,7 +21,7 @@ The following example shows how to include an approval task in a typical deploym
 +
 [source,yaml]
 ----
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
   name: deployment-pipeline
@@ -125,7 +125,7 @@ The following is an example for multi user approval.
 
 [source,yaml]
 ----
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
   name: deployment-pipeline
@@ -163,7 +163,7 @@ The following is an example for a group-based user approval.
 
 [source,yaml]
 ----
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
   name: deployment-pipeline
@@ -200,7 +200,7 @@ The following is an example for mixed user and group approvals.
 
 [source,yaml]
 ----
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
   name: deployment-pipeline

--- a/modules/op-triggering-pipelinerun-on-git-tags-using-pipelines-as-code.adoc
+++ b/modules/op-triggering-pipelinerun-on-git-tags-using-pipelines-as-code.adoc
@@ -30,7 +30,7 @@ The following example shows a minimal `PipelineRun` configuration that triggers 
 
 [source,yaml]
 ----
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
   name: pipelinerun-on-tag

--- a/modules/op-validating-pull-requests-using-GitHub-interceptors.adoc
+++ b/modules/op-validating-pull-requests-using-GitHub-interceptors.adoc
@@ -27,7 +27,7 @@ Owners are configured in an `OWNERS` file at the root of the repository.
 +
 [source,yaml]
 ----
-apiVersion: triggers.tekton.dev/v1beta1
+apiVersion: triggers.tekton.dev/v1
 kind: EventListener
 metadata:
   name: github-owners-listener
@@ -57,7 +57,7 @@ spec:
 +
 [source,yaml]
 ----
-apiVersion: triggers.tekton.dev/v1beta1
+apiVersion: triggers.tekton.dev/v1
 kind: EventListener
 metadata:
   name: github-owners-listener


### PR DESCRIPTION
Version(s):
- pipelines-docs-1.15
- pipelines-docs-1.20
- pipelines-docs-1.21
- pipelines-docs-1.22

Issue:
- https://issues.redhat.com/browse/RHDEVDOCS-7255

Link to docs preview:
- for example [YAML snippet in Supported GitOps commands](https://107176--ocpdocs-pr.netlify.app/openshift-pipelines/latest/pac/managing-pipeline-runs-pac.html#supported-gitops-commands)

QE review:
- [x] QE approval not needed.
