### PR TITLE
OLS-2630: Vale checks for modules in configuring assembly - part 1

### DIFF
--- a/configure/ols-configuring-openshift-lightspeed.adoc
+++ b/configure/ols-configuring-openshift-lightspeed.adoc
@@ -69,6 +69,10 @@ include::modules/ols-activating-token-quota-limits.adoc[leveloffset=+2]
 
 include::modules/ols-about-postgresql-persistence.adoc[leveloffset=+1]
 
+include::modules/ols-enabling-postgresql-persistence.adoc[leveloffset=+2]
+
+include::modules/ols-overriding-default-persistent-volume-claim-specifications.adoc[leveloffset=+2]
+
 include::modules/ols-about-query-based-tool-filtering.adoc[leveloffset=+1]
 
 include::modules/ols-enabling-query-based-tool-filtering.adoc[leveloffset=+2]

--- a/modules/ols-about-cluster-interaction.adoc
+++ b/modules/ols-about-cluster-interaction.adoc
@@ -7,11 +7,11 @@
 
 [role="_abstract"]
 
-Enable the cluster interaction feature to provide the large language model (LLM) with additional context about your {ocp-product-title} cluster.
+Enable the cluster interaction feature to supply the large language model (LLM) with additional context about your {ocp-product-title} cluster.
 
-The {ols-long} Service uses a large language model (LLM) to generate responses to questions. Providing information about the Kubernetes objects that the cluster contains enables the LLM to generate highly specific responses for your environment.
+{ols-long} uses a large language model (LLM) to answer your questions. When you share details about your cluster objects, the LLM can give specific answers for your environment.
 
-The Model Context Protocol (MCP) is an open protocol that standardizes how applications provide context to an LLM. Using the protocol, an MCP server offers a standardized way for an LLM to increase context by requesting and receiving real-time information from external resources.
+The Model Context Protocol (MCP) is an open protocol. It creates a standard way for applications to give context to an LLM. Using the protocol, an MCP server offers a standardized way for an LLM to increase context by requesting and receiving real-time information from external resources.
 
 [NOTE]
 ====
@@ -25,9 +25,9 @@ When you enable cluster interaction, the {ols-long} Operator installs an MCP ser
 The ability of {ols-long} to choose and use a tool effectively is very sensitive to the large language (LLM) model. In general, a larger model with more parameters performs better, and the best performance comes from an extremely large frontier model that represents the latest AI capabilities. When using a small model, you might notice poor performance in tool selection or other aspects of cluster interaction.
 ====
 
-To activate the cluster interaction feature in the {ols-long} Service, tool calling must be enabled in the LLM provider.
+You must enable tool calling in the LLM provider to activate the cluster interaction feature in the {ols-long} Service.
 
 [NOTE]
 ====
-Enabling tool calling can dramatically increase token usage. When you use public model providers, increased token usage can increase billing costs.
+Enabling tool calling can dramatically increase token usage. When you use  a public model provider, an increase in token usage usually increases billing costs.
 ====

--- a/modules/ols-about-postgresql-persistence.adoc
+++ b/modules/ols-about-postgresql-persistence.adoc
@@ -9,7 +9,6 @@
 
 PostgreSQL persistence ensures that {ols-long} conversation history and quota usage data remain available across pod restarts and rescheduling events.
 
-:FeatureName: PostgreSQL persistence
-include::snippets/technology-preview.adoc[]
+By default, the Service disables PostgreSQL persistence.
 
-PostgreSQL persistence is disabled by default. To enable the functionality, add the  `spec.ols.storage` specification to the `OLSConfig` custom resource (CR).
+To enable the functionality, add the `spec.ols.storage` specification to the `OLSConfig` custom resource (CR).

--- a/modules/ols-activating-token-quota-limits.adoc
+++ b/modules/ols-activating-token-quota-limits.adoc
@@ -5,15 +5,19 @@
 [id="ols-activating-token-quota-limits_{context}"]
 = Activating token quota limits
 
-Activate token quota limits for the {ols-long} service by defining key-value pairs in the `ConfigMap` resource. The {ols-long} pod mounts the `ConfigMap` resource as a volume, enabling access to the file stored within it. The `OLSConfig` custom resource (CR) references the `ConfigMap` resource to obtain the quota limit information.
+[role="_abstract"]
+
+Activate token quota limits for {ols-long} by creating a `ConfigMap` resource and referencing it in the `OLSConfig` custom resource.
+
+The {ols-long} pod mounts the `ConfigMap` resource as a volume, enabling access to the file stored within it. The `OLSConfig` custom resource (CR) references the `ConfigMap` resource to obtain the quota limit information.
 
 .Prerequisites
 
-* You have installed the the {ols-long} Operator.
+* You have installed the {ols-long} Operator.
 
 * You have configured a large language model provider.
 
-* A PostgreSQL database is configured and the {ols-long} service can access the database.
+* The {ols-long} Service has access to a PostgreSQL database.
 
 .Procedure
 
@@ -24,9 +28,8 @@ Activate token quota limits for the {ols-long} service by defining key-value pai
 $ oc edit olsconfig cluster
 ----
 
-. Modify the `spec.ols.quotaHandlersConfig` specification to include token quota limit information.
+. Update the `spec.ols.quotaHandlersConfig` specification to include token quota limit information.
 +
-.Example {ols-long} `OLSConfig` CR
 [source,yaml]
 ----
 apiVersion: ols.openshift.io/v1alpha1
@@ -37,24 +40,37 @@ spec:
   ols:
     quotaHandlersConfig:
       limitersConfig:
-      - name: user_limits # <1>
+      - name: user_limits
         type: user_limiter
-        initialQuota: 100000 # <2>
-        quotaIncrease: 1000 # <3>
+        initialQuota: 100000
+        quotaIncrease: 1000
         period: 30 days
-      - name: cluster_limits # <4>
+      - name: cluster_limits 
         type: cluster_limiter 
-        initialQuota: 1000000 # <5>
-        quotaIncrease: 100000 # <6>
-        period: 30 days # <7>
+        initialQuota: 1000000
+        quotaIncrease: 100000
+        period: 30 days
 ----
-<1> Specifies the token limit for user account. 
-<2> Specifies a token quota limit of 100,000 for each user over the time period specified in the `period` field.
-<3> Increases the token quota limit for the user by 1,000 at the end of the time period specified in the `period` field.
-<4> Specifies the token limit for a cluster.
-<5> Specifies a token quota limit of 1,000,000 for each cluster over the time period specified in the `period` field.
-<6> Increases the token quota limit for the cluster by 100,000 at the end of the time period specified in the `period` field.
-<7> Defines the amount of time that the scheduler waits before the period resets or the quota limit increases.
+
+* User quota configuration fields
+
+** `spec.ols.quotaHandlersConfig.limitersConfig.name` specifies the token limit for the user account. 
+
+** `spec.ols.quotaHandlersConfig.limitersConfig.initialQuota` specifies a token quota limit of `100,000` for each user over the time period specified in the `period` field.
+
+** `spec.ols.quotaHandlersConfig.limitersConfig.quotaIncrease` increases the token quota limit for the user by `1,000` at the end of the time period specified in the `period` field.
+
+* Cluster quota configuration fields
+
+** `spec.ols.quotaHandlersConfig.limitersConfig.name` specifies the token limit for a cluster.
+
+** `spec.ols.quotaHandlersConfig.limitersConfig.initialQuota` specifies a token quota limit of `1,000,000` for each cluster over the time period specified in the `period` field.
+
+** `spec.ols.quotaHandlersConfig.limitersConfig.quotaIncrease` increases the token quota limit for the cluster by 100,000 at the end of the time period specified in the `period` field.
+
+* Shared configuration field
+
+** `spec.ols.quotaHandlersConfig.limitersConfig.period` defines the amount of time that the scheduler waits before the period resets or the quota limit increases.
 
 . Click *Save*. 
 +

--- a/modules/ols-configuring-custom-tls-certificates.adoc
+++ b/modules/ols-configuring-custom-tls-certificates.adoc
@@ -11,7 +11,7 @@ Use the {ocp-product-title} web console to configure custom TLS certificates for
 
 .Prerequisites
 
-* You are logged in to the {ocp-product-title} web console as a user with the `cluster-admin` role. Alternatively, you are logged in to a user account that has permission to create or edit the `OLSConfig` custom resource (CR).
+* You have logged in to the {ocp-product-title} web console as a user with the `cluster-admin` role. As another option, you have logged in to a user account that has permission to create or edit the `OLSConfig` custom resource (CR).
 
 * You have a large language model (LLM) provider.
 
@@ -31,10 +31,9 @@ Use the {ocp-product-title} web console to configure custom TLS certificates for
 
 . Click the *YAML* tab.
 
-. Modify the `OLSconfig` CR to contain the file that contains the TLS secret.
+. Update the `OLSconfig` CR to contain the file that has the TLS secret.
 +
-.Example credentials secret and the `OLSconfig` CR file
-[source,yaml,subs="attributes,verbatim"]
+[source,yaml]
 ----
 apiVersion: ols.openshift.io/v1alpha1
 kind: OLSConfig
@@ -44,37 +43,29 @@ spec:
   ols: 
     tlsConfig: 
       keyCertSecretRef: 
-        name: <lightspeed_tls> <1>
+        name: <lightspeed_tls>
 ---
 apiVersion: v1
 data: 
-  tls.crt: LS0tLS1CRUd... <2>
+  tls.crt: LS0tLS1CRUd... 
   tls.key: LS0tLS1CRUd...
 kind: Secret
 metadata: 
   name: <lightspeed_tls>
   namespace: <openshift_lightspeed>
 ----
-<1> Refers to the secret that contains the `tls.crt` and `tls.key` file.
-<2> The name of the certificate must be `tls.crt` and the name of the key must be `tls.key`.
+
+* `spec.ols.tlsConfig.keyCertSecretRef.name` specifies the secret that has the `tls.crt` and `tls.key` file.
+
+* `apiVersion.data.tls` specifies that the name of the certificate must be `tls.crt` and the name of the key must be `tls.key`.
 
 . Click *Save*.
 
 .Verification
 
-. Verify that a new pod was created in the `lightspeed-app-server` deployment by running the following command:
+. Verify that a new pod exists in the `lightspeed-app-server` deployment by running the following command:
 +
 [source,terminal]
 ----
 $ oc get pod -n openshift-lightspeed
-----
-+
-.Example output
-[source,terminal]
-----
-NAME                                                     READY   STATUS    RESTARTS   AGE
-lightspeed-app-server-5b45d6dd99-5599w                   2/2     Running   2          8h
-lightspeed-console-plugin-88d878686-tjt5p                1/1     Running   1          8d
-lightspeed-operator-controller-manager-7d7cc4588-p7442   1/1     Running   9          8d
-lightspeed-postgres-server-5484fcfdfc-kcpjh              1/1     Running   2          8d
 ----

--- a/modules/ols-enabling-cluster-interaction.adoc
+++ b/modules/ols-enabling-cluster-interaction.adoc
@@ -7,14 +7,15 @@
 
 [role="_abstract"]
 
-Enable the cluster interaction feature by modifying the `OLSConfig` custom resource (CR) to provide {ols-long} with cluster-specific context.
+Enable the cluster interaction feature by modifying the `OLSConfig` custom resource (CR) to give {ols-long} cluster-specific context.
 
 :FeatureName: The cluster interaction feature
 include::snippets/technology-preview.adoc[]
+:FeatureName!:
 
 .Prerequisites
 
-* You are logged in to the {ocp-product-title} web console as a user with the `cluster-admin` role. Alternatively, you are logged in to a user account that has permission to create a cluster-scoped CR.
+* You have logged in to the {ocp-product-title} web console as a user with the `cluster-admin` role. As another option, you have logged in to a user account that has permission to create a cluster-scoped custom resource.
 
 * You have configured the large language model (LLM) provider.
 

--- a/modules/ols-enabling-custom-mcp-server.adoc
+++ b/modules/ols-enabling-custom-mcp-server.adoc
@@ -11,6 +11,7 @@ Add an additional Model Context Protocol (MCP) server that interfaces with a too
 
 :FeatureName: The cluster interaction feature
 include::snippets/technology-preview.adoc[]
+:FeatureName!:
 
 .Prerequisites
 
@@ -39,15 +40,15 @@ metadata:
   name: cluster
 spec:
   featureGates:
-    - MCPServer <1>
+    - MCPServer 
   mcpServers:
-  - name: mcp-server-1 <2>
-    url: https://mcp.example.com <3> 
-    timeout: 30 <4> 
-    headers: <5> 
-      - name: Authorization <6>
+  - name: mcp-server-1
+    url: https://mcp.example.com 
+    timeout: 30 
+    headers: 
+      - name: Authorization
         valueFrom:
-         type: kubernetes <7>
+         type: kubernetes 
   - name: mcp-server-2
     url: https://mcp.example.com 
     timeout: 30 
@@ -56,16 +57,24 @@ spec:
         valueFrom:
           type: secret 
           secretRef:
-            name: <secret_name> <8>
+            name: <secret_name> 
 ----
-<1> Specifies the MCP server functionality.
-<2> Specifies the name of the MCP server.
-<3> Specifies the URL path that the MCP server uses to communicate.
-<4> Specifies the time that the MCP server has to respond to a query. If the client does not receive a query within the time specified, the MCP server times out. In this example, the timeout is 30 seconds.
-<5> Define MCP headers as an array of structured objects containing the key-value pairs required for server authentication and context.
-<6> Specifies the name of the header that gets sent to the MCP server.
-<7> Specify the string `kubernetes` to specify the user's bearer token. 
-<8> Specifies the name of the secret that contains the header value. Ensure that the secret has the key name `header`.
+
+* `spec.featureGates` specifies the MCP server functionality on the {ols-long} pod.
+
+* `spec.mcpServers.name` specifies the name of the MCP server.
+
+* `spec.mcpServers.url` specifies the URL path that the MCP server uses to communicate
+
+* `spec.mcpServers.timeout` specifies the time that the MCP server has to respond to a query. If the client does not receive a query within the time specified, the MCP server times out. In this example, the timeout is 30 seconds.
+
+* `spec.mcpServers.headers` specifies MCP headers as an array of structured objects containing the key-value pairs required for server authentication and context.
+
+* `spec.mcpServers.headers.name` specifies the name of the header that gets sent to the MCP server.
+
+* `spec.mcpServers.headers.valueFrom.type` specify the string `kubernetes` to provide the user's bearer token
+
+* `spec.mcpServers.headers.valueFrom.secretRef.name` specifies the name of the secret that contains the header value. Ensure that the secret has the key name `header`.
 
 . Click *Save*. 
 +

--- a/modules/ols-enabling-postgresql-persistence.adoc
+++ b/modules/ols-enabling-postgresql-persistence.adoc
@@ -9,9 +9,13 @@
 
 Enable PostgreSQL persistence for {ols-long} by modifying the `OLSConfig` custom resource (CR) file.
 
+:FeatureName: PostgreSQL persistence
+include::snippets/technology-preview.adoc[]
+:FeatureName!:
+
 .Prerequisites
 
-* You are logged in to the {ocp-product-title} web console as a user account with permission to create a cluster-scoped CR file, such as a user with the `cluster-admin` role.
+* You have logged in to the {ocp-product-title} web console as a user account with permission to create a cluster-scoped CR file, such as a user with the `cluster-admin` role.
 
 * You have installed the {ols-long} Operator.
 
@@ -31,8 +35,7 @@ Enable PostgreSQL persistence for {ols-long} by modifying the `OLSConfig` custom
 
 . Insert the `spec.ols.storage` YAML code.
 +
-.Example `OLSconfig` CR file
-[source,yaml,subs="attributes,verbatim"]
+[source,yaml]
 ----
 apiVersion: ols.openshift.io/v1alpha1
 kind: OLSConfig
@@ -44,20 +47,9 @@ spec:
     providers:
 ...
   ols:
-    storage: {} <1>
+    storage: {}
 ----
-<1> The class depends on the existing instances of the storage class in the cluster. If you leave the storage class empty, {ols-long} uses default values. The persistent volume allocated for the PostgreSQL database is 1 GB in size and uses the storage class of the default cluster. Specify empty braces for the `storage` parameter to use the default values.
-+
-If you want to change the `size` and `class` parameters, you can independently specify an explicit value for the parameter. 
-+
-[source,yaml,subs="attributes,verbatim"]
-----
-ols:
-  storage:
-    size: 768Mi <1>
-    class: gp2-csi <2>
-----
-<1> Specifies the size of the Requested Volume. If the size is not specified, the default value is 1 GB.
-<2> Specifies the Storage Class of the Requested Volume. If no class is specified, the storage class uses the default storage class setting for the cluster.
+
+* `spec.ols.storage` specifies how the assistant stores persistent data, specifically conversation history. The class depends on the existing instances of the storage class in the cluster. If you leave the storage class empty, the assistant uses default values. The persistent volume allocated for the PostgreSQL database is 1 GB in size and uses the storage class of the default cluster. Specify empty braces for the `storage` parameter to use the default values.
 
 . Click *Save*.

--- a/modules/ols-overriding-default-persistent-volume-claim-specifications.adoc
+++ b/modules/ols-overriding-default-persistent-volume-claim-specifications.adoc
@@ -1,0 +1,63 @@
+// Module included in the following assemblies:
+// * lightspeed-docs-main/configure/ols-configuring-openshift-lightspeed.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="overriding-default-persistent-volume-claim-specifications_{context}"]
+= Overriding default Persistent Volume Claim (PVC) specifications
+
+[role="_abstract"]
+
+Customize the storage capacity and storage class for the {ols-long} database by modifying the `OLSConfig` custom resource (CR).
+
+.Prerequisites
+
+* You have logged in to the {ocp-product-title} web console as a user account with permission to create a cluster-scoped CR, such as a user with the `cluster-admin` role.
+
+* You have installed the {ols-long} Operator.
+
+* You have configured the large language model provider.
+
+* You have access to the {oc-first}. 
+
+.Procedure 
+
+. In the {ocp-product-title} web console, click *Operators* -> *Installed Operators*. 
+
+. Select *All Projects* in the  *Project* dropdown at the top of the screen.
+
+. Click {ols-long} Operator.
+
+. Click *OLSConfig*, then click the `cluster` configuration instance in the list.
+
+. Click the *YAML* tab.
+
+. Update the `OLSconfig` CR to override the default PVC specifications as shown in the following example.
++
+[source,yaml]
+----
+apiVersion: ols.openshift.io/v1alpha1
+kind: OLSConfig
+metadata:
+  name: cluster
+  namespace: openshift-lightspeed
+spec:
+  ols:
+    storage:
+      size: 768Mi
+      class: gp2-csi
+----
+
+* `spec.ols.storage.size` specifies the total storage capacity for the database. If you do not specify this parameter, the Operator uses the default size of 1 GiB.
+
+* `spec.ols.storage.class` specifies the Storage Class for the database volume. If you do not specify this parameter, the Operator uses the default storage class setting of the cluster.
+
+. Click *Save*.
+
+.Verification
+
+. Verify that the cluster has successfully provisioned the storage by checking the status of the Persistent Volume Claim.
++
+[source,terminal]
+----
+$ oc get pvc -n openshift-lightspeed
+----

--- a/modules/ols-support-for-trusted-ca-certificates-and-llm-providers.adoc
+++ b/modules/ols-support-for-trusted-ca-certificates-and-llm-providers.adoc
@@ -1,3 +1,6 @@
+// Module included in the following assemblies:
+// * lightspeed-docs-main/configure/ols-configuring-openshift-lightspeed.adoc
+
 :_mod-docs-content-type: CONCEPT
 [id="support-for-trusted-ca-certificates-and-llm-providers_{context}"]
 = Support for trusted-ca certificates and LLM providers
@@ -16,7 +19,7 @@ The {ols-long} Service supports adding trusted-ca certificates for the following
 
 * {azure-openai}
 
-To add a trusted-ca certificate you must create a `ConfigMap` object that contains the certificates. Then, add the  name of the object to the `OLSConfig` custom resource (CR) file as shown in the following example:
+To add a trusted-ca certificate you must create a `ConfigMap` object that has the certificates. Then, add the  name of the object to the `OLSConfig` custom resource (CR) file as shown in the following example:
 
 [source,yaml]
 ----

--- a/modules/ols-tokens-and-token-quota-limits.adoc
+++ b/modules/ols-tokens-and-token-quota-limits.adoc
@@ -7,10 +7,8 @@
 
 [role="_abstract"]
 
-Tokens measure the text exchanged between {ols-long} and large language models (LLMs), and token quota limits manage costs and ensure equitable resource access for clusters and users.
+Token quotas manage the amount of text that the {ols-long} Service exchanges with a large language model (LLM). These limits control costs and ensure all users get fair access to resources.
 
-Tokens are small chunks of text, which can be as small as one character or as large as one word. Tokens are the units of measurement used to quantify the amount of text that the {ols-long} service sends to, or receives from, a large language model (LLM). Every interaction with the service and the LLM is counted in tokens.
+The Service measures the text it exchanges with the LLM in tokens. A token is a small unit of text, ranging from a single character to a full word. Every chat between the Service and the LLM uses tokens.
 
-Token quota limits define the number of tokens that can be used in a certain timeframe. Implementing token quota limits helps control costs, encourage more efficient use of queries, and regulate system demands. In a multi-user configuration, token quota limits help provide equal access to all users ensuring everyone has an opportunity to submit queries. 
-
-You can define token quota limits for {ocp-short-name} clusters or {ocp-short-name} user accounts. 
+Token quotas limit how many tokens you can use within a specific time frame. You can define token quota limits for {ocp-short-name} clusters or {ocp-short-name} user accounts.

--- a/modules/ols-verifying-openshift-lightspeed-deployment.adoc
+++ b/modules/ols-verifying-openshift-lightspeed-deployment.adoc
@@ -1,16 +1,19 @@
+// Module included in the following assemblies:
+// * lightspeed-docs-main/configure/ols-configuring-openshift-lightspeed.adoc
+
 :_mod-docs-content-type: PROCEDURE
 [id="ols-verifying-openshift-lightspeed-deployment_{context}"]
-= Verifying the OpenShift Lightspeed deployment
+= Verifying the {ols-long} deployment
 
 [role="_abstract"]
 
-Use the {ocp-product-title} web console to verify that the {ols-long} Service is deployed and running successfully.
+Use the {ocp-product-title} web console to verify that the {ols-long} Service is running and deployed.
 
 include::snippets/ols-unified-perspective-web-console.adoc[]
 
 .Prerequisites
 
-* You are logged in to the {ocp-product-title} web console as a user with the `cluster-admin` role.
+* You have logged in to the {ocp-product-title} web console as a user with the `cluster-admin` role.
 
 * You have access to the {oc-first}.
 


### PR DESCRIPTION
Affects:
[lightspeed-main](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-main)
[lightspeed-docs-1.0](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-1.0)

PR must be CP'd back to the lightspeed-docs-1.0 branch.

Issue:
https://issues.redhat.com/browse/OLS-2630

Link to docs preview:
https://107188--ocpdocs-pr.netlify.app/openshift-lightspeed/latest/configure/ols-configuring-openshift-lightspeed.html

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
