### PR TITLE
OSDOCS#14017: HostedCluster and NodePool version compatibility

### DIFF
--- a/hosted_control_planes/hcp-release-notes.adoc
+++ b/hosted_control_planes/hcp-release-notes.adoc
@@ -12,7 +12,7 @@ With this release, {hcp} for {product-title} 4.21 is available. {hcp-capital} fo
 include::modules/hcp-release-notes-new-features.adoc[leveloffset=+1]
 
 // Notable technical changes
-//include::modules/hcp-release-notes-notable-changes.adoc[leveloffset=+1]
+include::modules/hcp-release-notes-notable-changes.adoc[leveloffset=+1]
 
 // Deprecated and removed tables
 //include::modules/hcp-release-notes-deprecated-removed-tables.adoc[leveloffset=+1]

--- a/hosted_control_planes/hcp-updating.adoc
+++ b/hosted_control_planes/hcp-updating.adoc
@@ -6,7 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-Updates for {hcp} involve updating the hosted cluster and the node pools. For a cluster to remain fully operational during an update process, you must meet the requirements of the link:https://kubernetes.io/releases/version-skew-policy/[Kubernetes version skew policy] while completing the control plane and node updates.
+Updates for {hcp} involve updating the hosted cluster and the node pools. For a cluster to remain fully operational during an update process, you must meet the requirements of the xref:../hosted_control_planes/hcp-updating.adoc#hcp-np-version-skew_hcp-updating[hosted cluster and node pool version skew policy] while completing the control plane and node updates.
 
 include::modules/hcp-updating-requirements.adoc[leveloffset=+1]
 
@@ -19,9 +19,17 @@ include::modules/hcp-updating-requirements.adoc[leveloffset=+1]
 * xref:../hosted_control_planes/hcp-updating.adoc#hcp-update-ocp-hc_hcp-updating[Updating a control plane in a hosted cluster]
 * xref:../hosted_control_planes/hcp-updating.adoc#hcp-update-node-pools_hcp-updating[Updating node pools in a hosted cluster]
 
+// Hosted cluster and node pool version skew policy
+include::modules/hcp-np-version-skew.adoc[leveloffset=+1]
+
 include::modules/hcp-get-ocp-channel.adoc[leveloffset=+1]
 
 include::modules/hcp-get-upgrade-versions.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../hosted_control_planes/hcp-updating.adoc#hcp-np-version-skew_hcp-updating[Hosted cluster and node pool version skew policy]
 
 // Updates for the hosted cluster
 include::modules/hcp-updates-hosted-cluster.adoc[leveloffset=+1]

--- a/modules/hcp-get-upgrade-versions.adoc
+++ b/modules/hcp-get-upgrade-versions.adoc
@@ -12,7 +12,7 @@ As a cluster service provider or cluster administrator, you can manage the contr
 
 You can update a control plane by modifying the `HostedCluster` custom resource (CR) and a node by modifying its `NodePool` CR. Both the `HostedCluster` and `NodePool` CRs specify an {product-title} release image in a `.release` field.
 
-To keep your hosted cluster fully operational during an update process, the control plane and the node updates must follow the link:https://kubernetes.io/releases/version-skew-policy/[Kubernetes version skew policy].
+To keep your hosted cluster fully operational during an update process, the control plane and the node versions must be compatible. For more information, see "Hosted cluster and node pool version skew policy".
 
 [id="hcp-mce-hub-cluster_{context}"]
 == The {mce-short} hub management cluster

--- a/modules/hcp-np-version-skew.adoc
+++ b/modules/hcp-np-version-skew.adoc
@@ -1,0 +1,43 @@
+// Module included in the following assemblies
+//
+// * hosted_control_planes/hcp-updating.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="hcp-np-version-skew_{context}"]
+= Hosted cluster and node pool version skew policy
+
+[role="_abstract"]
+In {hcp}, ensure that you use a node pool version that is supported with your hosted cluster version.
+
+* Node pool versions up to 3 minor versions behind the hosted cluster version are supported.
++
+For example, a 4.21 hosted cluster supports node pool versions 4.21, 4.20, 4.19, and 4.18.
+
+* Node pool versions cannot be higher than the hosted cluster version.
++
+This includes patch versions within the same minor version. For example, a 4.20.3 node pool version is _not_ supported on a 4.20.2 hosted cluster.
+
+.Example supported node pool versions for your hosted cluster
+[cols="1,1,1",options="header"]
+|===
+|Hosted cluster version |Supported node pool versions |Example unsupported node pool versions
+
+|4.21.0
+|4.21.0, 4.20.z, 4.19.z, 4.18.z
+|4.21.1+, 4.17.z, 4.16.z
+
+|4.20.2
+|4.20.0, 4.20.1, 4.20.2, 4.19.z, 4.18.z, 4.17.z
+|4.21.z, 4.20.3+, 4.16.z
+
+|===
+
+[id="hcp-np-version-skew-compatibility-reporting_{context}"]
+== Version compatibility reporting
+
+The node pool controller sets the `SupportedVersionSkew` condition to report one of the following version compatibility statuses:
+
+`True`:: Indicates that the node pool version is compatible with the hosted cluster version.
+`False`:: Indicates that the node pool version is incompatible with the hosted cluster version. A detailed error message is provided. You must upgrade or downgrade your node pools to a compatible version.
++
+If incompatibility is detected, the existing node pools continue to operate, but without stability or support. When creating new node pools, the CLI returns an error if you try to create a node pool with an incompatible version.

--- a/modules/hcp-release-notes-notable-changes.adoc
+++ b/modules/hcp-release-notes-notable-changes.adoc
@@ -1,0 +1,21 @@
+// Module included in the following assemblies
+//
+// * hosted_control_planes/hcp-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="hcp-release-notes-notable-technical-changes_{context}"]
+= Notable technical changes
+
+[role="_abstract"]
+Review the following notable technical changes introduced in this release.
+
+Updated hosted cluster and node pool version skew policy::
++
+With this release, the version skew policy for compatibility between hosted cluster and node pools has been updated:
++
+--
+* Node pool versions up to 3 minor versions behind the hosted cluster version are supported.
+* Node pool versions cannot be higher than the hosted cluster version.
+--
++
+For more information, see xref:../hosted_control_planes/hcp-updating.adoc#hcp-np-version-skew_hcp-updating[Hosted cluster and node pool version skew policy].


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.21+

Issue:
https://issues.redhat.com/browse/OSDOCS-14017

Link to docs preview:
- https://107225--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-release-notes.html#hcp-release-notes-notable-technical-changes_hcp-release-notes
- https://107225--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-updating.html#hcp-np-version-skew_hcp-updating


QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->

This is a continuation of #95207

Needed for the HCP release on March 11