### PR TITLE
[RHDEVDOCS-7240] Add Configurable prefix for GitOps comments

### DIFF
--- a/modules/op-configuring-gitops-command-prefix.adoc
+++ b/modules/op-configuring-gitops-command-prefix.adoc
@@ -1,0 +1,72 @@
+// This module is included in the following assemblies:
+// * pac/using-repository-crd.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="configuring-gitops-command-prefix_{context}"]
+= Configuring GitOps command prefix
+
+[role="_abstract"]
+You can configure a custom prefix for GitOps commands in {pac} to prevent command collisions when using multiple CI systems on the same repository, such as when both Prow and {pac} are configured. By default, {pac} uses standard commands like `/test`, `/retest`, and `/cancel`. When you define a custom prefix, you must include it before the command.
+
+.Procedure
+
+. Configure the `settings.gitops_command_prefix` field in your `Repository` CR:
++
+[source,yaml]
+----
+apiVersion: "pipelinesascode.tekton.dev/v1alpha1"
+kind: Repository
+metadata:
+  name: my-repo
+  namespace: target-namespace
+spec:
+  url: <project_URL>
+  settings:
+    gitops_command_prefix: <custom_prefix>
+  # ...
+----
+* `gitops_command_prefix`: defines the custom prefix for GitOps commands. Set the prefix as a plain word, for example, `pac`.
+
+. Use the prefixed commands in your pull requests or commit comments.
++
+The following table lists the available GitOps commands with the custom prefix:
++
+[cols="2,3",options="header"]
+|===
+| Command | Usage
+
+| `/<custom_prefix> test`
+| Trigger all matching pipeline runs.
+
+| `/<custom_prefix> test <pipelinerun_name>`
+| Trigger a specific pipeline run.
+
+| `/<custom_prefix> retest`
+| Retest failed pipeline runs.
+
+| `/<custom_prefix> retest <pipelinerun_name>`
+| Retest a specific pipeline run.
+
+| `/<custom_prefix> cancel`
+| Cancel all running pipeline runs.
+
+| `/<custom_prefix> cancel <pipelinerun_name>`
+| Cancel a specific pipeline run.
+
+| `/<custom_prefix> ok-to-test`
+| Approve CI for external contributors.
+
+| `/<custom_prefix> ok-to-test <SHA>`
+| Approve CI for external contributors for a specific SHA.
+|===
++
+For example, with the custom prefix set to `pac`, use the following command to test a specific pipeline run:
++
+----
+/pac test <pipelinerun_name>
+----
+
+[NOTE]
+====
+The prefix setting does not affect custom GitOps commands.
+====

--- a/modules/op-configuring-gitops-command-prefix.adoc
+++ b/modules/op-configuring-gitops-command-prefix.adoc
@@ -1,0 +1,72 @@
+// This module is included in the following assemblies:
+// * pac/using-repository-crd.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="configuring-gitops-command-prefix_{context}"]
+= Configuring GitOps command prefix
+
+[role="_abstract"]
+Configure a custom prefix for GitOps commands in {pac} to prevent command collisions when using multiple CI systems. By default, {pac} uses commands such as `/test`, `/retest`, and `/cancel`. Include the prefix before each command.
+
+.Procedure
+
+. Configure the `settings.gitops_command_prefix` field in your `Repository` CR:
++
+[source,yaml]
+----
+apiVersion: "pipelinesascode.tekton.dev/v1alpha1"
+kind: Repository
+metadata:
+  name: my-repo
+  namespace: target-namespace
+spec:
+  url: <project_URL>
+  settings:
+    gitops_command_prefix: <custom_prefix>
+  # ...
+----
+* `gitops_command_prefix`: Defines the custom prefix for GitOps commands. Set the prefix as a plain word, for example, `pac`.
+
+. Use the prefixed commands in pull requests or commit comments.
++
+The following table lists the available GitOps commands with the custom prefix:
++
+[cols="2,3",options="header"]
+|===
+| Command | Usage
+
+| `/<custom_prefix> test`
+| Trigger all matching pipeline runs.
+
+| `/<custom_prefix> test <pipelinerun_name>`
+| Trigger a specific pipeline run.
+
+| `/<custom_prefix> retest`
+| Retest failed pipeline runs.
+
+| `/<custom_prefix> retest <pipelinerun_name>`
+| Retest a specific pipeline run.
+
+| `/<custom_prefix> cancel`
+| Cancel all running pipeline runs.
+
+| `/<custom_prefix> cancel <pipelinerun_name>`
+| Cancel a specific pipeline run.
+
+| `/<custom_prefix> ok-to-test`
+| Approve CI for external contributors.
+
+| `/<custom_prefix> ok-to-test <SHA>`
+| Approve CI for external contributors for a specific SHA.
+|===
++
+For example, if the custom prefix is set to `pac`, use the following command to test a specific pipeline run:
++
+----
+/pac test <pipelinerun_name>
+----
+
+[NOTE]
+====
+The prefix setting does not affect custom GitOps commands.
+====

--- a/pac/using-repository-crd.adoc
+++ b/pac/using-repository-crd.adoc
@@ -19,6 +19,8 @@ include::modules/op-creating-global-repository-cr.adoc[leveloffset=+1]
 
 include::modules/op-setting-concurrency-limits-in-repository-crd.adoc[leveloffset=+1]
 
+include::modules/op-configuring-gitops-command-prefix.adoc[leveloffset=+1]
+
 include::modules/op-changing-source-branch-in-repository-crd.adoc[leveloffset=+1]
 
 include::modules/op-custom-parameter-expansion.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s):
- pipelines-docs-1.23

Issue:
https://issues.redhat.com/browse/RHDEVDOCS-7240

Link to docs preview:
- [Configuring GitOps command prefix](https://107246--ocpdocs-pr.netlify.app/openshift-pipelines/latest/pac/using-repository-crd.html#configuring-gitops-command-prefix_using-repository-crd)

QE review:
- [x] QE has approved this change.
