### PR TITLE
Removing .adoc in context as it is breaking the build

### DIFF
--- a/scalability_and_performance/recommended-performance-scale-practices/increasing-aws-flavor-size.adoc
+++ b/scalability_and_performance/recommended-performance-scale-practices/increasing-aws-flavor-size.adoc
@@ -2,7 +2,7 @@
 [id="increasing-aws-flavor-size"]
 = Selecting a larger AWS instance type for control plane machines
 include::_attributes/common-attributes.adoc[]
-:context: increasing-aws-flavor-size.adoc
+:context: increasing-aws-flavor-size
 
 toc::[]
 


### PR DESCRIPTION
I think https://github.com/openshift/openshift-docs/pull/106601 introduced this error and was CP'd to 4.16 so probably we need to CP to 4.16 and later also.

Version(s):
4.16+

Issue:
````
Transforming the AsciiDoc content to DocBook XML...
[31m[1mInvalid ID "additional-resources_increasing-aws-flavor-size.adoc". IDs must not be a filename, or end with file like extensions[0m
[31m[1mInvalid ID "cpms-changing-aws-instance-type_increasing-aws-flavor-size.adoc". IDs must not be a filename, or end with file like extensions[0m
[31m[1mInvalid ID "aws-console-changing-aws-instance-type_increasing-aws-flavor-size.adoc". IDs must not be a filename, or end with file like extensions[0m
````