### PR TITLE
OCPBUGS#77304 Correcting IBM Power VC attribute

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -313,7 +313,6 @@ endif::[]
 :ibm-power-server-title: IBM Power Virtual Server
 :ibm-power-vc-name: IBM PowerVC
 :ibm-power-vc-title: IBM(R) Power(R) Virtualization Center
-:ibm-power-vc: IBM PowerVC
 // IBM zSystems
 :ibm-z-name: IBM Z(R)
 :ibm-z-title: IBM Z

--- a/installing/installing_ibm_powervc/installation-config-parameters-ibm-powervc.adoc
+++ b/installing/installing_ibm_powervc/installation-config-parameters-ibm-powervc.adoc
@@ -8,6 +8,6 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 [role="_abstract"]
-Before you deploy an {product-title} cluster on {ibm-power-vc-title} ({ibm-power-vc}), you provide parameters to customize your cluster and the platform that hosts it. When you create the `install-config.yaml` file, you provide values for the required parameters through the command line. You can then modify the `install-config.yaml` file to customize your cluster further.
+Before you deploy an {product-title} cluster on {ibm-power-vc-title}, you provide parameters to customize your cluster and the platform that hosts it. When you create the `install-config.yaml` file, you provide values for the required parameters through the command line. You can then modify the `install-config.yaml` file to customize your cluster further.
 
 include::modules/installation-configuration-parameters.adoc[leveloffset=+1]

--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -197,9 +197,9 @@ ifdef::ibm-power-vc[]
 [id="installation-configuration-parameters-additional-powervc_{context}"]
 == Additional {ibm-power-vc-name} configuration parameters
 
-Additional {ibm-power-vc} configuration parameters are described in the following table:
+Additional {ibm-power-vc-name} configuration parameters are described in the following table:
 
-.Additional {ibm-power-vc} parameters
+.Additional {ibm-power-vc-name} parameters
 [cols=".^l,.^a",options="header"]
 |====
 |Parameter|Description
@@ -207,7 +207,7 @@ Additional {ibm-power-vc} configuration parameters are described in the followin
 |platform:
   powervc:
     cloud:
-|The name of the {ibm-power-vc} cloud to use from the list of clouds in the `clouds.yaml` file.
+|The name of the {ibm-power-vc-name} cloud to use from the list of clouds in the `clouds.yaml` file.
 
 In the cloud configuration in the `clouds.yaml` file, if possible, use application credentials rather than a user name and password combination. Using application credentials avoids disruptions from secret propogation that follow user name and password rotation.
 
@@ -216,11 +216,11 @@ In the cloud configuration in the `clouds.yaml` file, if possible, use applicati
 |====
 
 [id="installation-configuration-parameters-optional-ibm-power-vc_{context}"]
-== Optional {ibm-power-vc} configuration parameters
+== Optional {ibm-power-vc-name} configuration parameters
 
-Optional {ibm-power-vc} configuration parameters are described in the following table:
+Optional {ibm-power-vc-name} configuration parameters are described in the following table:
 
-.Optional {ibm-power-vc} parameters
+.Optional {ibm-power-vc-name} parameters
 [%header, cols=".^l,.^a"]
 |====
 |Parameter|Description
@@ -229,7 +229,7 @@ Optional {ibm-power-vc} configuration parameters are described in the following 
   platform:
     powervc:
       zones:
-|{ibm-power-vc} Compute availability zones to install machines on. If this parameter is not set, the installation program relies on the default settings that the {ibm-power-vc} administrator configured.
+|{ibm-power-vc-name} Compute availability zones to install machines on. If this parameter is not set, the installation program relies on the default settings that the {ibm-power-vc-name} administrator configured.
 
 *Value:* A list of strings. For example, `["zone-1", "zone-2"]`.
 
@@ -237,16 +237,16 @@ Optional {ibm-power-vc} configuration parameters are described in the following 
   platform:
     powervc:
       zones:
-|{ibm-power-vc} Compute availability zones to install machines on. If this parameter is not set, the installation program relies on the default settings that the {ibm-power-vc} administrator configured.
+|{ibm-power-vc-name} Compute availability zones to install machines on. If this parameter is not set, the installation program relies on the default settings that the {ibm-power-vc-name} administrator configured.
 
 *Value:* A list of strings. For example, `["zone-1", "zone-2"]`.
 
 |platform:
   powervc:
     clusterOSImage:
-|The name of the existing {ibm-power-vc} image.
+|The name of the existing {ibm-power-vc-name} image.
 
-*Value:* the name of an existing {ibm-power-vc} image, for example `my-rhcos`.
+*Value:* the name of an existing {ibm-power-vc-name} image, for example `my-rhcos`.
 
 |platform:
   powervc:
@@ -263,7 +263,7 @@ Optional {ibm-power-vc} configuration parameters are described in the following 
       network:
 |A network for the machines to use.
 
-*Value:* The UUID or name of an {ibm-power-vc} network to use in cluster installation.
+*Value:* The UUID or name of an {ibm-power-vc-name} network to use in cluster installation.
 
 |platform:
   powervc:


### PR DESCRIPTION
Version(s):
4.21+

Issue:
https://issues.redhat.com/browse/OCPBUGS-77304

Link to docs preview:
[IBM Power VC parameters](https://107301--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_ibm_powervc/installation-config-parameters-ibm-powervc)
[AWS parameters (showing that IBM Power VC is not present)](https://107301--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/installation-config-parameters-aws)

QE review not needed - docs structural change.

Due to the presence of the ibm power vc attribute in the common attributes file, the `ifdef::ibm-power-vc` conditional was always resolving as true.