### PR TITLE
OCPBUGS-77312 removing outdated snippet

### DIFF
--- a/nodes/pods/run_once_duration_override/index.adoc
+++ b/nodes/pods/run_once_duration_override/index.adoc
@@ -9,8 +9,5 @@ toc::[]
 [role="_abstract"]
 You can use the {run-once-operator} to specify a maximum time limit that run-once pods can be active for.
 
-:operator-name: The {run-once-operator}
-include::snippets/operator-not-available.adoc[]
-
 // About the {run-once-operator}
 include::modules/rodoo-about.adoc[leveloffset=+1]

--- a/nodes/pods/run_once_duration_override/run-once-duration-override-install.adoc
+++ b/nodes/pods/run_once_duration_override/run-once-duration-override-install.adoc
@@ -9,9 +9,6 @@ toc::[]
 [role="_abstract"]
 You can use the {run-once-operator} to specify a maximum time limit that run-once pods can be active for. By enabling the run-once duration override on a namespace, all future run-once pods created or updated in that namespace have their `activeDeadlineSeconds` field set to the value specified by the {run-once-operator}.
 
-:operator-name: The {run-once-operator}
-include::snippets/operator-not-available.adoc[]
-
 [NOTE]
 ====
 If both the run-once pod and the {run-once-operator} have their `activeDeadlineSeconds` value set, the lower of the two values is used.

--- a/nodes/pods/run_once_duration_override/run-once-duration-override-uninstall.adoc
+++ b/nodes/pods/run_once_duration_override/run-once-duration-override-uninstall.adoc
@@ -8,9 +8,6 @@ toc::[]
 
 You can remove the {run-once-operator} from {product-title} by uninstalling the Operator and removing its related resources.
 
-:operator-name: The {run-once-operator}
-include::snippets/operator-not-available.adoc[]
-
 // Uninstalling the {run-once-operator}
 include::modules/rodoo-uninstall-operator.adoc[leveloffset=+1]
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.21+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [OCPBUGS-77312](https://issues.redhat.com/browse/OCPBUGS-77312)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://107327--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/pods/run_once_duration_override/index.html
https://107327--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/pods/run_once_duration_override/run-once-duration-override-install.html
https://107327--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/pods/run_once_duration_override/run-once-duration-override-uninstall.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review: NA
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
