### PR TITLE
[enterprise-4.14] CNV-80551: Vale compliance cleanup before adding new upgrade content

### DIFF
--- a/modules/virt-about-upgrading-virt.adoc
+++ b/modules/virt-about-upgrading-virt.adoc
@@ -6,15 +6,18 @@
 [id="virt-about-upgrading-virt_{context}"]
 = About updating {VirtProductName}
 
-When you install {VirtProductName}, you select an update channel and an approval strategy. The update channel determines the versions that {VirtProductName} will be updated to. The approval strategy setting determines whether updates occur automatically or require manual approval. Both settings can impact supportability.
+[role="_abstract"]
+When you install {VirtProductName}, you select an update channel and an approval strategy. The update channel determines the version that {VirtProductName} is updated to. The approval strategy setting determines whether updates occur automatically or require manual approval. Both settings can impact supportability.
 
 [id="recommended-settings_{context}"]
 == Recommended settings
 
 To maintain a supportable environment, use the following settings:
 
-* Update channel: *stable* 
-* Approval strategy: *Automatic* 
+* Update channel: *stable*
+* Approval strategy: *Automatic*
+
+The *stable* release channel and the *Automatic* approval strategy are recommended for most {VirtProductName} installations. Use other settings only if you understand the risks.
 
 With these settings, the update process automatically starts when a new version of the Operator is available in the *stable* channel. This ensures that your {VirtProductName} and {product-title} versions remain compatible, and that your version of {VirtProductName} is suitable for production environments.
 

--- a/modules/virt-about-workload-updates.adoc
+++ b/modules/virt-about-workload-updates.adoc
@@ -10,9 +10,7 @@ When you update {VirtProductName}, virtual machine workloads, including `libvirt
 
 [NOTE]
 ====
-Each virtual machine has a `virt-launcher` pod that runs the virtual machine
-instance (VMI). The `virt-launcher` pod runs an instance of `libvirt`, which is
-used to manage the virtual machine (VM) process.
+Each virtual machine has a `virt-launcher` pod that runs the virtual machine instance (VMI). The `virt-launcher` pod runs an instance of `libvirt`, which is used to manage the virtual machine (VM) process.
 ====
 
 You can configure how workloads are updated by editing the `spec.workloadUpdateStrategy` stanza of the `HyperConverged` custom resource (CR). There are two available workload update methods: `LiveMigrate` and `Evict`.
@@ -49,6 +47,3 @@ When a VMI fails to migrate, the `virt-controller` tries to migrate it again. It
 ====
 Each attempt corresponds to a migration object. Only the five most recent attempts are held in a buffer. This prevents migration objects from accumulating on the system while retaining information for debugging.
 ====
-
-
-

--- a/modules/virt-configuring-workload-update-methods.adoc
+++ b/modules/virt-configuring-workload-update-methods.adoc
@@ -17,6 +17,8 @@ You can configure workload update methods by editing the `HyperConverged` custom
 If a `VirtualMachineInstance` CR contains `evictionStrategy: LiveMigrate` and the virtual machine instance (VMI) does not support live migration, the VMI will not update.
 ====
 
+* You have installed the {oc-first}.
+
 .Procedure
 
 . To open the `HyperConverged` CR in your default editor, run the following command:
@@ -36,19 +38,18 @@ metadata:
   name: kubevirt-hyperconverged
 spec:
   workloadUpdateStrategy:
-    workloadUpdateMethods: <1>
-    - LiveMigrate <2>
-    - Evict <3>
-    batchEvictionSize: 10 <4>
-    batchEvictionInterval: "1m0s" <5>
+    workloadUpdateMethods:
+    - LiveMigrate
+    - Evict
+    batchEvictionSize: 10
+    batchEvictionInterval: "1m0s"
 # ...
 ----
-<1> The methods that can be used to perform automated workload updates. The available values are `LiveMigrate` and `Evict`. If you enable both options as shown in this example, updates use `LiveMigrate` for VMIs that support live migration and `Evict` for any VMIs that do not support live migration. To disable automatic workload updates, you can either remove the `workloadUpdateStrategy` stanza or set `workloadUpdateMethods: []` to leave the array empty.
-//NOTE: in 4.10, removing the stanza will not disable the feature.
-<2> The least disruptive update method. VMIs that support live migration are updated by migrating the virtual machine (VM) guest into a new pod with the updated components enabled. If `LiveMigrate` is the only workload update method listed, VMIs that do not support live migration are not disrupted or updated.
-<3> A disruptive method that shuts down VMI pods during upgrade. `Evict` is the only update method available if live migration is not enabled in the cluster. If a VMI is controlled by a `VirtualMachine` object that has `runStrategy: Always` configured, a new VMI is created in a new pod with updated components.
-<4> The number of VMIs that can be forced to be updated at a time by using the `Evict` method. This does not apply to the `LiveMigrate` method.
-<5> The interval to wait before evicting the next batch of workloads. This does not apply to the `LiveMigrate` method.
+** `spec.workloadUpdateStrategy.workloadUpdateMethods` defines the methods that can be used to perform automated workload updates. The available values are `LiveMigrate` and `Evict`. If you enable both options as shown in this example, updates use `LiveMigrate` for VMIs that support live migration and `Evict` for any VMIs that do not support live migration. To disable automatic workload updates, you can either remove the `workloadUpdateStrategy` stanza or set `workloadUpdateMethods: []` to leave the array empty.
+*** `LiveMigrate` is the least disruptive update method. VMIs that support live migration are updated by migrating the virtual machine (VM) guest into a new pod with the updated components enabled. If `LiveMigrate` is the only workload update method listed, VMIs that do not support live migration are not disrupted or updated.
+*** `Evict` is a disruptive method that shuts down VMI pods during upgrade. `Evict` is the only update method available if live migration is not enabled in the cluster. If a VMI is controlled by a `VirtualMachine` object that has `runStrategy: Always` configured, a new VMI is created in a new pod with updated components.
+** `spec.workloadUpdateStrategy.batchEvictionSize` defines the number of VMIs that can be forced to be updated at a time by using the `Evict` method. This does not apply to the `LiveMigrate` method.
+** `spec.workloadUpdateStrategy.batchEvictionInterval` defines the interval to wait before evicting the next batch of workloads. This does not apply to the `LiveMigrate` method.
 +
 [NOTE]
 ====

--- a/modules/virt-monitoring-upgrade-status.adoc
+++ b/modules/virt-monitoring-upgrade-status.adoc
@@ -10,14 +10,13 @@ To monitor the status of a {VirtProductName} Operator update, watch the cluster 
 
 [NOTE]
 ====
-The `PHASE` and conditions values are approximations that are based on
-available information.
+The `PHASE` and conditions values are approximations that are based on available information.
 ====
 
 .Prerequisites
 
 * Log in to the cluster as a user with the `cluster-admin` role.
-* Install the OpenShift CLI (`oc`).
+* Install the {oc-first}.
 
 .Procedure
 

--- a/virt/updating/upgrading-virt.adoc
+++ b/virt/updating/upgrading-virt.adoc
@@ -1,16 +1,23 @@
 :_mod-docs-content-type: ASSEMBLY
+include::_attributes/common-attributes.adoc[]
 [id="upgrading-virt"]
 = Updating {VirtProductName}
-include::_attributes/common-attributes.adoc[]
 :context: upgrading-virt
 
 toc::[]
 
+[role="_abstract"]
 Learn how to keep {VirtProductName} updated and compatible with {product-title}.
 
 include::modules/virt-about-upgrading-virt.adoc[leveloffset=+1]
 
-include::modules/virt-rhel-9.adoc[leveloffset=+2]
+include::modules/virt-changing-update-settings.adoc[leveloffset=+2]
+
+include::modules/virt-manual-approval-strategy.adoc[leveloffset=+2]
+
+include::modules/olm-approving-pending-upgrade.adoc[leveloffset=+2]
+
+include::modules/virt-rhel-9.adoc[leveloffset=+1]
 
 include::modules/virt-monitoring-upgrade-status.adoc[leveloffset=+1]
 
@@ -22,31 +29,13 @@ include::modules/virt-configuring-workload-update-methods.adoc[leveloffset=+2]
 
 include::modules/virt-viewing-outdated-workloads.adoc[leveloffset=+2]
 
-[NOTE]
-====
-To ensure that VMIs update automatically, configure workload updates.
-====
-
 // control plane updates
 
 ifndef::openshift-rosa,openshift-dedicated,openshift-origin[]
 include::modules/virt-about-control-plane-only-updates.adoc[leveloffset=+1]
 
-Learn more about xref:../../updating/updating_a_cluster/control-plane-only-update.adoc#control-plane-only-update[Performing a Control Plane Only update].
-
 include::modules/virt-preventing-workload-updates-during-control-plane-only-update.adoc[leveloffset=+2]
 endif::openshift-rosa,openshift-dedicated,openshift-origin[]
-
-[id="advanced-options_upgrading-virt"]
-== Advanced options
-
-The *stable* release channel and the *Automatic* approval strategy are recommended for most {VirtProductName} installations. Use other settings only if you understand the risks.
-
-include::modules/virt-changing-update-settings.adoc[leveloffset=+2]
-
-include::modules/virt-manual-approval-strategy.adoc[leveloffset=+2]
-
-include::modules/olm-approving-pending-upgrade.adoc[leveloffset=+2]
 
 [id="additional-resources_upgrading-virt"]
 [role="_additional-resources"]


### PR DESCRIPTION
Manual cherrypick of https://github.com/openshift/openshift-docs/commit/455318bda17e345fb115e0575c1960ff38ab03b3 xref: https://github.com/openshift/openshift-docs/pull/107226