### PR TITLE
OKD fix version picker and prune version

### DIFF
--- a/_templates/_page_openshift.html.erb
+++ b/_templates/_page_openshift.html.erb
@@ -374,25 +374,10 @@
             </a>
             <select id="version-selector" onchange="versionSelector(this);">
               <option value="latest">latest</option>
+              <option value="4.21">4.21</option>
+              <option value="4.20">4.20</option>
               <option value="4.19">4.19</option>
               <option value="4.18">4.18</option>
-              <option value="4.17">4.17</option>
-              <option value="4.16">4.16</option>
-              <option value="4.15">4.15</option>
-              <option value="4.14">4.14</option>
-              <option value="4.13">4.13</option>
-              <option value="4.12">4.12</option>
-              <option value="4.11">4.11</option>
-              <option value="4.10">4.10</option>
-              <option value="4.9">4.9</option>
-              <option value="4.8">4.8</option>
-              <option value="4.7">4.7</option>
-              <option value="4.6">4.6</option>
-              <option value="3.11">3.11</option>
-              <option value="3.10">3.10</option>
-              <option value="3.9">3.9</option>
-              <option value="3.7">3.7</option>
-              <option value="3.6">3.6</option>
             </select>
         <% else %>
           <%= breadcrumb_root %>

--- a/contributing_to_docs/doc_guidelines.adoc
+++ b/contributing_to_docs/doc_guidelines.adoc
@@ -543,8 +543,7 @@ possible values for `{product-title}` and `{product-version}`, depending on the 
 
 |`openshift-origin`
 |OKD
-a|* 3.6, 3.7, 3.9, 3.10, 3.11
-* 4.8, 4.9, 4.10, 4.11, 4.12, 4.13, 4.14, 4.15, 4.16, 4.17, 4.18, 4.19, 4.20, 4.21
+a|* 4.18, 4.19, 4.20, 4.21
 * 4 for the `latest/` build from the `main` branch
 
 |`openshift-enterprise`

--- a/index-community.html
+++ b/index-community.html
@@ -55,23 +55,6 @@
                <li><a href="4.20/"><i class="fa fa-arrow-circle-o-right"></i> OKD 4.20</a></li>
                <li><a href="4.19/"><i class="fa fa-arrow-circle-o-right"></i> OKD 4.19</a></li>
                <li><a href="4.18/"><i class="fa fa-arrow-circle-o-right"></i> OKD 4.18</a></li>
-               <li><a href="4.17/"><i class="fa fa-arrow-circle-o-right"></i> OKD 4.17</a></li>
-               <li><a href="4.16/"><i class="fa fa-arrow-circle-o-right"></i> OKD 4.16</a></li>
-               <li><a href="4.15/"><i class="fa fa-arrow-circle-o-right"></i> OKD 4.15</a></li>
-               <li><a href="4.14/"><i class="fa fa-arrow-circle-o-right"></i> OKD 4.14</a></li>
-               <li><a href="4.13/"><i class="fa fa-arrow-circle-o-right"></i> OKD 4.13</a></li>
-               <li><a href="4.12/"><i class="fa fa-arrow-circle-o-right"></i> OKD 4.12</a></li>
-               <li><a href="4.11/"><i class="fa fa-arrow-circle-o-right"></i> OKD 4.11</a></li>
-               <li><a href="4.10/"><i class="fa fa-arrow-circle-o-right"></i> OKD 4.10</a></li>
-               <li><a href="4.9/"><i class="fa fa-arrow-circle-o-right"></i> OKD 4.9</a></li>
-               <li><a href="4.8/"><i class="fa fa-arrow-circle-o-right"></i> OKD 4.8</a></li>
-               <li><a href="4.7/"><i class="fa fa-arrow-circle-o-right"></i> OKD 4.7</a></li>
-               <li><a href="4.6/"><i class="fa fa-arrow-circle-o-right"></i> OKD 4.6</a></li>
-               <li><a href="3.11/"><i class="fa fa-arrow-circle-o-right"></i> OKD 3.11</a></li>
-               <li><a href="3.10/"><i class="fa fa-arrow-circle-o-right"></i> OKD 3.10</a></li>
-               <li><a href="3.9/"><i class="fa fa-arrow-circle-o-right"></i> OKD 3.9</a></li>
-               <li><a href="3.7/"><i class="fa fa-arrow-circle-o-right"></i> OKD 3.7</a></li>
-               <li><a href="3.6/"><i class="fa fa-arrow-circle-o-right"></i> OKD 3.6</a></li>
              </ul>
            </div>
          </div>


### PR DESCRIPTION
The OKD version picker doesn't list options for 4.20 and 4.21 despite the docs existing. This PR attempts to fix this. Also, pruning versions earlier than 4.18, per @ausil [in Slack](https://redhat-internal.slack.com/archives/CLKF3H5RS/p1771957725871289).

Merge to main only, similar to https://github.com/openshift/openshift-docs/pull/95277