### PR TITLE
OSDOCS-18463 [NETOBSERV] CQA Vale rule fixes that are not Callouts

### DIFF
--- a/modules/network-observability-RTT.adoc
+++ b/modules/network-observability-RTT.adoc
@@ -36,16 +36,13 @@ spec:
 <1> You can start tracing RTT network flows by listing the `FlowRTT` parameter in the `spec.agent.ebpf.features` specification list.
 
 .Verification
-When you refresh the *Network Traffic* page, the *Overview*, *Traffic Flow*, and *Topology* views display new information about RTT:
+After the *Network Traffic* page is refreshed, the *Overview*, *Traffic flows*, and *Topology* views display RTT information.
 
-.. In the *Overview*, select new choices in *Manage panels* to choose which graphical visualizations of RTT to display.
-.. In the *Traffic flows* table, the *Flow RTT* column can be seen, and you can manage display in *Manage columns*.
-.. In the *Traffic Flows* view, you can also expand the side panel to view more information about RTT.
-+
-.Example filtering
-... Click the *Common* filters -> *Protocol*.
-... Filter the network flow data based on *TCP*, *Ingress* direction, and look for *FlowRTT* values greater than 10,000,000 nanoseconds (10ms).
-... Remove the *Protocol* filter.
-... Filter for *Flow RTT* values greater than 0 in the *Common* filters.
-
-.. In the *Topology* view, click the Display option dropdown. Then click *RTT* in the *edge labels* drop-down list.
+. In the *Overview* view, click *Manage panels* to select the RTT graphical visualizations to display.
+. In the *Traffic flows* table, verify that the *Flow RTT* column is visible by default. To manage columns, click *Manage columns*.
+. In the *Traffic flows* view, expand the side panel to view RTT metadata:
+.. Filter the flow data for the *TCP* protocol by entering `protocol=TCP` in the filter search bar.
+.. Verify that all TCP filtered flows have *FlowRTT* values greater than `0`.
+.. Filter for *FlowRTT* values greater than `10,000,000` nanoseconds (10 ms) by entering `time_flow_rtt>=10000000` in the filter search bar.
+.. Remove the filters.
+. In the *Topology* view, click the *Display* option drop-down menu. In the *Edge labels* list, select *RTT*.

--- a/modules/network-observability-configuring-custom-metrics-examples.adoc
+++ b/modules/network-observability-configuring-custom-metrics-examples.adoc
@@ -1,0 +1,69 @@
+// Module included in the following assemblies:
+// * network_observability/metrics-alerts-dashboards.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="network-observability-configuring-custom-metrics-examples_{context}"]
+= Custom metrics configuration examples
+
+[role="_abstract"]
+To monitor specific network behaviors not covered by default metrics, such as external traffic volume or latency spikes, use the `FlowMetric` custom resource (CR). These examples provide the configuration needed to generate targeted Prometheus metrics from network flows.
+
+[id="tracking-ingress-bytes-from-cluster-external-sources_{context}"]
+== Tracking ingress bytes from cluster external sources
+
+To measure the volume of data entering the cluster from external networks, use the following `FlowMetric` configuration. This metric helps identify potential bandwidth issues or unexpected external data transfer costs.
+
+[source,yaml]
+----
+apiVersion: flows.netobserv.io/v1alpha1
+kind: FlowMetric
+metadata:
+  name: flowmetric-cluster-external-ingress-traffic
+  namespace: netobserv                              <1>
+spec:
+  metricName: cluster_external_ingress_bytes_total  <2>
+  type: Counter                                     <3>
+  valueField: Bytes
+  direction: Ingress                                <4>
+  labels: [DstK8S_HostName,DstK8S_Namespace,DstK8S_OwnerName,DstK8S_OwnerType] <5>
+  filters:                                          <6>
+  - field: SrcSubnetLabel
+    matchType: Absence
+----
+<1> The `FlowMetric` resources need to be created in the namespace defined in the `FlowCollector` `spec.namespace`, which is `netobserv` by default.
+<2> The name of the Prometheus metric, which in the web console appears with the prefix `netobserv-<metricName>`.
+<3> The `type` specifies the type of metric. The `Counter` `type` is useful for counting bytes or packets.
+<4> The direction of traffic to capture. If not specified, both ingress and egress are captured, which can lead to duplicated counts.
+<5> Labels define what the metrics look like and the relationship between the different entities and also define the metrics cardinality. For example, `SrcK8S_Name` is a high cardinality metric.
+<6> Refines results based on the listed criteria. In this example,  selecting only the cluster external traffic is done by matching only flows where `SrcSubnetLabel` is absent. This assumes the subnet labels feature is enabled (via `spec.processor.subnetLabels`), which is done by default.
+
+[id="monitoring-rtt-latency-for-cluster-external-ingress-traffic_{context}"]
+== Monitoring RTT latency for cluster external ingress traffic
+
+To analyze the performance of external connections and identify high-latency paths, use the following `FlowMetric` configuration. This metric converts nanoseconds to seconds to align with standard Prometheus latency dashboards.
+
+[source,yaml]
+----
+apiVersion: flows.netobserv.io/v1alpha1
+kind: FlowMetric
+metadata:
+  name: flowmetric-cluster-external-ingress-rtt
+  namespace: netobserv    <1>
+spec:
+  metricName: cluster_external_ingress_rtt_seconds
+  type: Histogram                 <2>
+  valueField: TimeFlowRttNs
+  direction: Ingress
+  labels: [DstK8S_HostName,DstK8S_Namespace,DstK8S_OwnerName,DstK8S_OwnerType]
+  filters:
+  - field: SrcSubnetLabel
+    matchType: Absence
+  - field: TimeFlowRttNs
+    matchType: Presence
+  divider: "1000000000"      <3>
+  buckets: [".001", ".005", ".01", ".02", ".03", ".04", ".05", ".075", ".1", ".25", "1"]  <4>
+----
+<1> The `FlowMetric` resources need to be created in the namespace defined in the `FlowCollector` `spec.namespace`, which is `netobserv` by default.
+<2> The `type` specifies the type of metric. The `Histogram` `type` is useful for a latency value (`TimeFlowRttNs`).
+<3> Since the Round-trip time (RTT) is provided as nanos in flows, use a divider of 1 billion to convert into seconds, which is standard in Prometheus guidelines.
+<4> The custom buckets specify precision on RTT, with optimal precision ranging between 5ms and 250ms.

--- a/modules/network-observability-configuring-custom-metrics.adoc
+++ b/modules/network-observability-configuring-custom-metrics.adoc
@@ -15,69 +15,8 @@ Configure the `FlowMetric` API to create custom Prometheus metrics by mapping fl
 . In the *Provided APIs* heading for the *NetObserv Operator*, select *FlowMetric*.
 . In the *Project:*  dropdown list, select the project of the Network Observability Operator instance.
 . Click *Create FlowMetric*.
-. Configure the `FlowMetric` resource, similar to the following sample configurations:
-+
-.Generate a metric that tracks ingress bytes received from cluster external sources
-
-[source,yaml]
-----
-apiVersion: flows.netobserv.io/v1alpha1
-kind: FlowMetric
-metadata:
-  name: flowmetric-cluster-external-ingress-traffic
-  namespace: netobserv                              <1>
-spec:
-  metricName: cluster_external_ingress_bytes_total  <2>
-  type: Counter                                     <3>
-  valueField: Bytes
-  direction: Ingress                                <4>
-  labels: [DstK8S_HostName,DstK8S_Namespace,DstK8S_OwnerName,DstK8S_OwnerType] <5>
-  filters:                                          <6>
-  - field: SrcSubnetLabel
-    matchType: Absence
-----
-<1> The `FlowMetric` resources need to be created in the namespace defined in the `FlowCollector` `spec.namespace`, which is `netobserv` by default.
-<2> The name of the Prometheus metric, which in the web console appears with the prefix `netobserv-<metricName>`.
-<3> The `type` specifies the type of metric. The `Counter` `type` is useful for counting bytes or packets.
-<4> The direction of traffic to capture. If not specified, both ingress and egress are captured, which can lead to duplicated counts.
-<5> Labels define what the metrics look like and the relationship between the different entities and also define the metrics cardinality. For example, `SrcK8S_Name` is a high cardinality metric.
-<6> Refines results based on the listed criteria. In this example,  selecting only the cluster external traffic is done by matching only flows where `SrcSubnetLabel` is absent. This assumes the subnet labels feature is enabled (via `spec.processor.subnetLabels`), which is done by default.
+. Configure the `FlowMetric` resource. See "Custom metrics configuration examples".
 
 .Verification
 . Once the pods refresh, navigate to *Observe* -> *Metrics*.
 . In the *Expression* field, type the metric name to view the corresponding result. You can also enter an expression, such as `topk(5, sum(rate(netobserv_cluster_external_ingress_bytes_total{DstK8S_Namespace="my-namespace"}[2m])) by (DstK8S_HostName, DstK8S_OwnerName, DstK8S_OwnerType))`
-+
-.Show RTT latency for cluster external ingress traffic
-
-[source,yaml]
-----
-apiVersion: flows.netobserv.io/v1alpha1
-kind: FlowMetric
-metadata:
-  name: flowmetric-cluster-external-ingress-rtt
-  namespace: netobserv    <1>
-spec:
-  metricName: cluster_external_ingress_rtt_seconds
-  type: Histogram                 <2>
-  valueField: TimeFlowRttNs
-  direction: Ingress
-  labels: [DstK8S_HostName,DstK8S_Namespace,DstK8S_OwnerName,DstK8S_OwnerType]
-  filters:
-  - field: SrcSubnetLabel
-    matchType: Absence
-  - field: TimeFlowRttNs
-    matchType: Presence
-  divider: "1000000000"      <3>
-  buckets: [".001", ".005", ".01", ".02", ".03", ".04", ".05", ".075", ".1", ".25", "1"]  <4>
-----
-<1> The `FlowMetric` resources need to be created in the namespace defined in the `FlowCollector` `spec.namespace`, which is `netobserv` by default.
-<2> The `type` specifies the type of metric. The `Histogram` `type` is useful for a latency value (`TimeFlowRttNs`).
-<3> Since the Round-trip time (RTT) is provided as nanos in flows, use a divider of 1 billion to convert into seconds, which is standard in Prometheus guidelines.
-<4> The custom buckets specify precision on RTT, with optimal precision ranging between 5ms and 250ms.
-
-.Verification
-. Once the pods refresh, navigate to *Observe* -> *Metrics*.
-. In the *Expression* field, you can type the metric name to view the corresponding result.
-
-
-

--- a/modules/network-observability-configuring-options-trafficflow.adoc
+++ b/modules/network-observability-configuring-options-trafficflow.adoc
@@ -2,26 +2,20 @@
 //
 // network_observability/observing-network-traffic.adoc
 
-:_mod-docs-content-type: PROCEDURE
+:_mod-docs-content-type: REFERENCE
 [id="network-observability-configuring-options-trafficflow_{context}"]
-= Configuring advanced options for the Traffic flows view
+= Traffic flow display settings
 
 [role="_abstract"]
-Customize the *Traffic flows* view by adjusting row density, selecting specific data columns, and exporting filtered flow data for external analysis.
+The **Traffic flows** view contains settings to customize the display density, data columns, and data export options.
 
-You can customize and export the view by using *Show advanced options*.
-You can set the row size by using the *Display options* drop-down menu. The default value is *Normal*.
+[id="display-options_{context}"]
+== Display options
+The following elements are available in the *Traffic flows* view:
 
-[id="network-observability-cao-managing-columns-trafficflow_{context}"]
-== Managing columns
-You can select the required columns to be displayed, and reorder them. To manage columns, click *Manage columns*.
+*Show advanced options*:: Specifies a menu to customize and export the current view.
+*Display options* drop-down:: Specifies the row size for the data table. The default value is *Normal*.
+*Manage columns*:: Specifies a dialog to select and reorder the columns displayed in the *Traffic flows* table.
 
-[id="network-observability-cao-export-trafficflow_{context}"]
-== Exporting the traffic flow data
-You can export data from the *Traffic flows* view.
 
-.Procedure
-
-. Click *Export data*.
-. In the pop-up window, you can select the *Export all data* checkbox to export all the data, and clear the checkbox to select the required fields to be exported.
-. Click *Export*.
+//02/25/2026 note for JTBD: content reads more like REFERENCE than PROCEDURE. Only header updated at this time. May need further review for JTBD.

--- a/modules/network-observability-exporting-traffic-flow-data.adoc
+++ b/modules/network-observability-exporting-traffic-flow-data.adoc
@@ -1,0 +1,17 @@
+
+// Module included in the following assemblies:
+//
+// network_observability/observing-network-traffic.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="network-observability-exporting-traffic-flow-data_{context}"]
+= Exporting traffic flow data
+
+[role="_abstract"]
+Export network flow data from the *Traffic flows* view to a CSV file for external analysis or reporting.
+
+.Procedure
+
+. Click *Export data*.
+. In the window, select the *Export all data* checkbox to export all the data, and clear the checkbox to select the required fields to be exported.
+. Click *Export*.

--- a/modules/network-observability-filter-network-flows-at-ingestion.adoc
+++ b/modules/network-observability-filter-network-flows-at-ingestion.adoc
@@ -45,15 +45,21 @@ The query language uses the following syntax:
 | `and`, `or`
 
 | Comparison operators
-| `=` (equals), +
-`!=` (not equals), +
-`=~` (matches regexp), +
-`!~` (not matches regexp), +
-`<` / `\<=` (less than or equal to), +
+| `=` (equals),
+
+`!=` (not equals),
+
+`=~` (matches regexp),
+
+`!~` (not matches regexp),
+
+`<` / `\<=` (less than or equal to),
+
 `>` / `>=` (greater than or equal to)
 
 | Unary operations
-| `with(field)` (field is present), +
+| `with(field)` (field is present),
+
 `without(field)` (field is absent)
 
 | Parenthesis-based priority

--- a/modules/network-observability-flowmetrics-charts-examples.adoc
+++ b/modules/network-observability-flowmetrics-charts-examples.adoc
@@ -1,0 +1,94 @@
+// Module included in the following assemblies:
+// * network_observability/metrics-alerts-dashboards.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="network-observability-flowmetrics-charts-examples_{context}"]
+= Flowmetric chart configuration examples
+
+[role="_abstract"]
+These `FlowMetric` custom resource examples demonstrate how to define charts in the {product-title} web console for tracking external ingress traffic and round-trip time (RTT) latency.
+
+[id="chart-tracking-ingress-bytes-cluster-external-sources_{context}"]
+== Ingress bytes chart for cluster external sources
+
+Use the following configuration to track the rate of ingress traffic from cluster external sources. These charts help identify bandwidth usage per workload.
+
+[source,yaml]
+----
+apiVersion: flows.netobserv.io/v1alpha1
+kind: FlowMetric
+metadata:
+  name: flowmetric-cluster-external-ingress-traffic
+  namespace: netobserv   <1>
+# ...
+  charts:
+  - dashboardName: Main  <2>
+    title: External ingress traffic
+    unit: Bps
+    type: SingleStat
+    queries:
+    - promQL: "sum(rate($METRIC[2m]))"
+      legend: ""
+  - dashboardName: Main  <2>
+    sectionName: External
+    title: Top external ingress traffic per workload
+    unit: Bps
+    type: StackArea
+    queries:
+    - promQL: "sum(rate($METRIC{DstK8S_Namespace!=\"\"}[2m])) by (DstK8S_Namespace, DstK8S_OwnerName)"
+      legend: "{{DstK8S_Namespace}} / {{DstK8S_OwnerName}}"
+# ...
+----
+<1> The `FlowMetric` resources need to be created in the namespace defined in the `FlowCollector` `spec.namespace`, which is `netobserv` by default.
+
+[id="chart-rtt-latency-cluster-external-ingress-traffic_{context}"]
+== RTT latency chart for cluster external ingress traffic
+
+Use the following configuration to monitor round-trip time (RTT) for cluster external ingress traffic. These examples use the `histogram_quantile` function to display the 50th and 99th percentiles (p50 and p99).
+
+[source,yaml]
+----
+apiVersion: flows.netobserv.io/v1alpha1
+kind: FlowMetric
+metadata:
+  name: flowmetric-cluster-external-ingress-traffic
+  namespace: netobserv   <1>
+# ...
+  charts:
+  - dashboardName: Main  <2>
+    title: External ingress TCP latency
+    unit: seconds
+    type: SingleStat
+    queries:
+    - promQL: "histogram_quantile(0.99, sum(rate($METRIC_bucket[2m])) by (le)) > 0"
+      legend: "p99"
+  - dashboardName: Main  <2>
+    sectionName: External
+    title: "Top external ingress sRTT per workload, p50 (ms)"
+    unit: seconds
+    type: Line
+    queries:
+    - promQL: "histogram_quantile(0.5, sum(rate($METRIC_bucket{DstK8S_Namespace!=\"\"}[2m])) by (le,DstK8S_Namespace,DstK8S_OwnerName))*1000 > 0"
+      legend: "{{DstK8S_Namespace}} / {{DstK8S_OwnerName}}"
+  - dashboardName: Main  <2>
+    sectionName: External
+    title: "Top external ingress sRTT per workload, p99 (ms)"
+    unit: seconds
+    type: Line
+    queries:
+    - promQL: "histogram_quantile(0.99, sum(rate($METRIC_bucket{DstK8S_Namespace!=\"\"}[2m])) by (le,DstK8S_Namespace,DstK8S_OwnerName))*1000 > 0"
+      legend: "{{DstK8S_Namespace}} / {{DstK8S_OwnerName}}"
+# ...
+----
+<1> The `FlowMetric` resources need to be created in the namespace defined in the `FlowCollector` `spec.namespace`, which is `netobserv` by default.
+<2> Using a different `dashboardName` creates a new dashboard that is prefixed with `Netobserv`. For example, *Netobserv / <dashboard_name>*.
+
+[id="calculate-histogram-averages_{context}"]
+== Calculate histogram averages
+
+You can show averages of histograms by dividing the metric, `$METRIC_sum`, by the metric, `$METRIC_count`, which are automatically generated when you create a histogram. With the preceding example, the Prometheus query to do this is as follows:
+
+[source,yaml]
+----
+promQL: "(sum(rate($METRIC_sum{DstK8S_Namespace!=\"\"}[2m])) by (DstK8S_Namespace,DstK8S_OwnerName) / sum(rate($METRIC_count{DstK8S_Namespace!=\"\"}[2m])) by (DstK8S_Namespace,DstK8S_OwnerName))*1000"
+----

--- a/modules/network-observability-flowmetrics-charts.adoc
+++ b/modules/network-observability-flowmetrics-charts.adoc
@@ -16,36 +16,7 @@ You can view custom charts as an administrator in the *Dashboard* menu.
 . In the *Provided APIs* heading for the *NetObserv Operator*, select *FlowMetric*.
 . In the *Project:*  dropdown list, select the project of the Network Observability Operator instance.
 . Click *Create FlowMetric*.
-. Configure the `FlowMetric` resource, similar to the following sample configurations:
-+
-.Chart for tracking ingress bytes received from cluster external sources
-[source,yaml]
-----
-apiVersion: flows.netobserv.io/v1alpha1
-kind: FlowMetric
-metadata:
-  name: flowmetric-cluster-external-ingress-traffic
-  namespace: netobserv   <1>
-# ...
-  charts:
-  - dashboardName: Main  <2>
-    title: External ingress traffic
-    unit: Bps
-    type: SingleStat
-    queries:
-    - promQL: "sum(rate($METRIC[2m]))"
-      legend: ""
-  - dashboardName: Main  <2>
-    sectionName: External
-    title: Top external ingress traffic per workload
-    unit: Bps
-    type: StackArea
-    queries:
-    - promQL: "sum(rate($METRIC{DstK8S_Namespace!=\"\"}[2m])) by (DstK8S_Namespace, DstK8S_OwnerName)"
-      legend: "{{DstK8S_Namespace}} / {{DstK8S_OwnerName}}"
-# ...
-----
-<1> The `FlowMetric` resources need to be created in the namespace defined in the `FlowCollector` `spec.namespace`, which is `netobserv` by default.
+. Configure the `FlowMetric` resource. See "Flowmetric chart configuration examples".
 
 .Verification
 . Once the pods refresh, navigate to *Observe* -> *Dashboards*.
@@ -53,59 +24,6 @@ metadata:
 
 * A textual single statistic showing the global external ingress rate summed across all dimensions
 * A timeseries graph showing the same metric per destination workload
-
-For more information about the query language, refer to the link:https://prometheus.io/docs/prometheus/latest/querying/basics/[Prometheus documentation].
-
-.Chart for RTT latency for cluster external ingress traffic
-[source,yaml]
-----
-apiVersion: flows.netobserv.io/v1alpha1
-kind: FlowMetric
-metadata:
-  name: flowmetric-cluster-external-ingress-traffic
-  namespace: netobserv   <1>
-# ...
-  charts:
-  - dashboardName: Main  <2>
-    title: External ingress TCP latency
-    unit: seconds
-    type: SingleStat
-    queries:
-    - promQL: "histogram_quantile(0.99, sum(rate($METRIC_bucket[2m])) by (le)) > 0"
-      legend: "p99"
-  - dashboardName: Main  <2>
-    sectionName: External
-    title: "Top external ingress sRTT per workload, p50 (ms)"
-    unit: seconds
-    type: Line
-    queries:
-    - promQL: "histogram_quantile(0.5, sum(rate($METRIC_bucket{DstK8S_Namespace!=\"\"}[2m])) by (le,DstK8S_Namespace,DstK8S_OwnerName))*1000 > 0"
-      legend: "{{DstK8S_Namespace}} / {{DstK8S_OwnerName}}"
-  - dashboardName: Main  <2>
-    sectionName: External
-    title: "Top external ingress sRTT per workload, p99 (ms)"
-    unit: seconds
-    type: Line
-    queries:
-    - promQL: "histogram_quantile(0.99, sum(rate($METRIC_bucket{DstK8S_Namespace!=\"\"}[2m])) by (le,DstK8S_Namespace,DstK8S_OwnerName))*1000 > 0"
-      legend: "{{DstK8S_Namespace}} / {{DstK8S_OwnerName}}"
-# ...
-----
-<1> The `FlowMetric` resources need to be created in the namespace defined in the `FlowCollector` `spec.namespace`, which is `netobserv` by default.
-<2> Using a different `dashboardName` creates a new dashboard that is prefixed with `Netobserv`. For example, *Netobserv / <dashboard_name>*.
-
-This example uses the `histogram_quantile` function to show `p50` and `p99`.
-
-You can show averages of histograms by dividing the metric, `$METRIC_sum`, by the metric, `$METRIC_count`, which are automatically generated when you create a histogram. With the preceding example, the Prometheus query to do this is as follows:
-
-[source,yaml]
-----
-promQL: "(sum(rate($METRIC_sum{DstK8S_Namespace!=\"\"}[2m])) by (DstK8S_Namespace,DstK8S_OwnerName) / sum(rate($METRIC_count{DstK8S_Namespace!=\"\"}[2m])) by (DstK8S_Namespace,DstK8S_OwnerName))*1000"
-----
-
-.Verification
-. Once the pods refresh, navigate to *Observe* -> *Dashboards*.
-. Search for the *NetObserv / Main* dashboard. View the new panel under the *NetObserv / Main* dashboard, or optionally a dashboard name that you create.
 
 For more information about the query language, refer to the link:https://prometheus.io/docs/prometheus/latest/querying/basics/[Prometheus documentation].
 

--- a/modules/network-observability-viewing-network-events.adoc
+++ b/modules/network-observability-viewing-network-events.adoc
@@ -54,9 +54,9 @@ spec:
 .Verification
 . Navigate to the *Network Traffic* view and select the *Traffic flows* table.
 . You should see the new column, *Network Events*, where you can view information about impacts of one of the following network APIs you have enabled: `NetworkPolicy`, `AdminNetworkPolicy`, `BaselineNetworkPolicy`, `UserDefinedNetwork` isolation, multicast, or egress firewalls.
-
++
 An example of the kind of events you could see in this column is as follows:
-
++
 .Example of Network Events output
 [source,text]
 ----

--- a/observability/network_observability/metrics-alerts-dashboards.adoc
+++ b/observability/network_observability/metrics-alerts-dashboards.adoc
@@ -21,6 +21,8 @@ include::modules/network-observability-custom-metrics.adoc[leveloffset=+1]
 
 include::modules/network-observability-configuring-custom-metrics.adoc[leveloffset=+1]
 
+include::modules/network-observability-configuring-custom-metrics-examples.adoc[leveloffset=+2]
+
 include::modules/network-observability-creating-metrics-network-events.adoc[leveloffset=+1]
 
 [IMPORTANT]
@@ -28,6 +30,8 @@ include::modules/network-observability-creating-metrics-network-events.adoc[leve
 High cardinality can affect the memory usage of Prometheus. You can check whether specific labels have high cardinality in the xref:../../observability/network_observability/json-flows-format-reference.adoc#network-observability-flows-format_json_reference[Network Flows format reference].
 ====
 include::modules/network-observability-flowmetrics-charts.adoc[leveloffset=+1]
+
+include::modules/network-observability-flowmetrics-charts-examples.adoc[leveloffset=+2]
 
 include::modules/network-observability-tcp-flag-syn-flood.adoc[leveloffset=+1]
 

--- a/observability/network_observability/observing-network-traffic.adoc
+++ b/observability/network_observability/observing-network-traffic.adoc
@@ -70,6 +70,8 @@ include::modules/network-observability-working-with-trafficflow.adoc[leveloffset
 
 include::modules/network-observability-configuring-options-trafficflow.adoc[leveloffset=+2]
 
+include::modules/network-observability-exporting-traffic-flow-data.adoc[leveloffset=+2]
+
 include::modules/network-observability-configuring-ipsec-with-flow-collector-resource.adoc[leveloffset=+2]
 
 [role="_additional-resources"]


### PR DESCRIPTION
[OSDOCS-18463](https://issues.redhat.com/browse/OSDOCS-18463) [NETOBSERV] CQA Vale rule fixes that are not Callouts

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.16+ since CQA related

Issue:
https://issues.redhat.com/browse/OSDOCS-18463

Link to docs preview:
* Configuring custom metrics:https://107356--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/metrics-alerts-dashboards#network-observability-configuring-custom-metrics_metrics-dashboards-alerts
* Custom metrics examples: https://107356--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/metrics-alerts-dashboards#network-observability-configuring-custom-metrics-examples_metrics-dashboards-alerts
* Configuring custom charts: https://107356--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/metrics-alerts-dashboards#network-observability-custom-charts-flowmetrics_metrics-dashboards-alerts
* Flowmetric chart configuration examples: https://107356--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/metrics-alerts-dashboards#network-observability-flowmetrics-charts-examples_metrics-dashboards-alerts
* Traffic flow display settings: https://107356--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/observing-network-traffic#network-observability-configuring-options-trafficflow_nw-observe-network-traffic
* Exporting traffic flow data: https://107356--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/observing-network-traffic#network-observability-exporting-traffic-flow-data_nw-observe-network-traffic 
* Flowlogs pipeline filters > Table 1. Query language syntax: https://107356--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/configuring-operator#flowlogs-pipeline-filters_network_observability
* Working with RTT: https://107356--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/observing-network-traffic#network-observability-RTT_nw-observe-network-traffic
* Viewing network events: https://107356--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/observing-network-traffic#network-observability-viewing-network-events_nw-observe-network-traffic

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
* :warning: :warning:  Callouts are being addressed by [OSDOCS-14480](https://issues.redhat.com/browse/OSDOCS-14480) :warning: :warning: 
* In some instances, Callouts were already updated.
* This PR is a consolidation of a number of other PRs and Jira issues that were opened/created in Aug/Sept 2025. The majority of the files in those initial PRs and Jira issues all pass Vale checks.
* This PR ONLY addresses Vale rule violations for the remaining files. Rather than a bunch of XS PRs that contain 1 or 2 files, I consolidated the remaining violations into 1 Jira, and they are being addressed in this PR.
* Where necessary, such as for examples that were included in PROCEDURES, the content was copy/pasted as is into a new file. 
* In other instances, some rewording was done to pass Vale and style checks, such as in ‎`modules/network-observability-RTT.adoc`
* Other issues will be addressed in separate PRs.
* JTBD will be addressed separately. 

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
