### PR TITLE
RHDEVDOCS-7307: Fixing block titles

### DIFF
--- a/argocd_applications/managing-apps-in-non-control-plane-namespaces.adoc
+++ b/argocd_applications/managing-apps-in-non-control-plane-namespaces.adoc
@@ -11,16 +11,17 @@ As a cluster administrator, you can create and manage the `Application` resource
 [NOTE]
 ====
 As a developer, if you are creating Argo CD applications in non-control plane namespaces other than the `openshift-gitops` control plane namespace, ensure that your cluster administrator grants the necessary permissions to them.
+====
 
 Otherwise, after the Argo CD reconciliation, you will see an error message similar to the following example:
 
-.Example error message
-
+--
+*Example error message:*
 [source,terminal]
 ----
 error while validating and normalizing app: error getting application's project: application 'app' in namespace 'dev' is not allowed to use project 'default'
 ----
-====
+--
 
 To use this functionality, you must explicitly enable and configure the target namespaces in the following objects:
 

--- a/declarative_clusterconfig/customizing-permissions-by-creating-user-defined-cluster-roles-for-cluster-scoped-instances.adoc
+++ b/declarative_clusterconfig/customizing-permissions-by-creating-user-defined-cluster-roles-for-cluster-scoped-instances.adoc
@@ -18,16 +18,17 @@ This guide provides instructions with examples to help you create a user-defined
 [NOTE]
 ====
 As a developer, if you are creating an Argo CD application and deploying cluster-wide resources, ensure that your cluster administrator grants the necessary permissions to them.
+====
 
 Otherwise, after the Argo CD reconciliation, you will see an authentication error message in the application's `Status` field similar to the following example:
 
-.Example authentication error message
-
+--
+*Example authentication error message:*
 [source,terminal]
 ----
 persistentvolumes is forbidden: User "system:serviceaccount:gitops-demo:argocd-argocd-application-controller" cannot create resource "persistentvolumes" in API group "" at the cluster scope.
 ----
-====
+--
 
 [id="prerequisites_{context}"]
 == Prerequisites

--- a/gitops_workloads_infranodes/running-gitops-control-plane-workloads-on-infrastructure-nodes.adoc
+++ b/gitops_workloads_infranodes/running-gitops-control-plane-workloads-on-infrastructure-nodes.adoc
@@ -17,7 +17,6 @@ With {gitops-shortname} control plane workloads, you can securely and declarativ
 include::modules/go-add-infra-nodes.adoc[leveloffset=+1]
 include::modules/moving-the-gitops-operator-pod-to-infrastructure-nodes.adoc[leveloffset=+1]
 
-
 [role="_additional-resources"]
 [id="additional-resources_{context}"]
 == Additional resources

--- a/modules/about-must-gather.adoc
+++ b/modules/about-must-gather.adoc
@@ -23,7 +23,7 @@ Alternatively, you can collect specific information by running the command with 
 
 * To collect data related to one or more specific features, use the `--image` argument with an image, as listed in a following section.
 +
-.Example command
+*Example command:*
 [source,terminal,subs="attributes+"]
 ----
 $ oc adm must-gather --image=registry.redhat.io/openshift-gitops-1/must-gather-rhel8:v1.16.0
@@ -31,11 +31,13 @@ $ oc adm must-gather --image=registry.redhat.io/openshift-gitops-1/must-gather-r
 
 * To collect the audit logs, use the `-- /usr/bin/gather_audit_logs` argument, as described in a following section.
 +
-.Example command
+--
+*Example command:*
 [source,terminal]
 ----
 $ oc adm must-gather -- /usr/bin/gather_audit_logs
 ----
+--
 +
 [NOTE]
 ====
@@ -44,7 +46,7 @@ Audit logs are not collected as part of the default set of information to reduce
 
 When you run `oc adm must-gather`, a new pod with a random name is created in a new project on the cluster. The data is collected on that pod and saved in a new directory that starts with `must-gather.local`. This directory is created in the current working directory.
 
-.Example pod
+*Example pod:*
 [source,terminal]
 ----
 NAMESPACE                      NAME                 READY   STATUS      RESTARTS      AGE
@@ -56,7 +58,7 @@ openshift-must-gather-5drcj    must-gather-s8sdh    2/2     Running     0       
 // todo: table or ref module listing available images?
 Optionally, you can run the `oc adm must-gather` command in a specific namespace by using the `--run-namespace` option.
 
-.Example command
+*Example command:*
 [source,terminal,subs="attributes+"]
 ----
 $ oc adm must-gather --image=registry.redhat.io/openshift-gitops-1/must-gather-rhel8:v1.10.0

--- a/modules/collecting-gitops-debugging-data.adoc
+++ b/modules/collecting-gitops-debugging-data.adoc
@@ -36,7 +36,7 @@ where:
 `<image_version_tag>`:: Specifies the must-gather image version tag for {gitops-shortname}.
 --
 +
-.Example command
+*Example command:*
 [source,terminal]
 ----
 $ oc adm must-gather --image=registry.redhat.io/openshift-gitops-1/must-gather-rhel8:v1.10.0

--- a/modules/con-enabling-config-management-plugins-argo-cd-cr.adoc
+++ b/modules/con-enabling-config-management-plugins-argo-cd-cr.adoc
@@ -14,7 +14,7 @@ In the {gitops-title} Operator, you can configure the Config Management plugin a
 
 To configure a sidecar container in the {gitops-title} Operator, add the `.spec.repo.sidecarContainers` key in the Argo CD CR. 
 
-.Example Config Management Plugin configuration
+*Example Config Management Plugin configuration:*
 [source,yaml]
 ----
 apiVersion: argoproj.io/v1alpha1

--- a/modules/con_notifications-configuration.adoc
+++ b/modules/con_notifications-configuration.adoc
@@ -43,7 +43,7 @@ Any modification to the Argo CD `argocd-notifications-cm` config map is overridd
 
 The following examples define how to add templates, triggers, services, and subscription resources to the Argo CD `argocd-notification-cm` config map by using the `default-notifications-configuration` custom resource.
 
-.Example for `templates`
+*Example for `templates`:*
 [source,yaml]
 ----
 apiVersion: argoproj.io/v1alpha1
@@ -62,7 +62,7 @@ where:
 `metadata.name`:: Specifies the default name of the `NotificationsConfiguration` CR in a cluster.
 `spec.template.my-custom-template`:: Specifies an example custom template configuration for the `NotificationsConfiguration` CR.
 
-.Example for `triggers`
+*Example for `triggers`:*
 [source,yaml]
 ----
 apiVersion: argoproj.io/v1alpha1
@@ -81,7 +81,7 @@ where:
 `metadata.name`:: Specifies the default name of the `NotificationsConfiguration` CR in a cluster.
 `spec.trigger.on-sync-status-unknown`:: Specifies an example custom trigger configuration for the `NotificationsConfiguration` CR.
 
-.Example for `services`
+*Example for `services`:*
 [source,yaml]
 ----
 apiVersion: argoproj.io/v1alpha1
@@ -101,7 +101,7 @@ where:
 `metadata.name`:: Specifies the default name of the `NotificationsConfiguration` CR in a cluster.
 `spec.service.slack`:: Specifies an example custom service configuration for the `NotificationsConfiguration` CR.
 
-.Example for `subscriptions`
+*Example for `subscriptions`:*
 [source,yaml]
 ----
 apiVersion: argoproj.io/v1alpha1

--- a/modules/configuring-permissions.adoc
+++ b/modules/configuring-permissions.adoc
@@ -20,7 +20,6 @@ When using the default instance for cluster configuration, provide the `cluster-
 * You have your login credentials to access the {OCP} cluster with `cluster-admin` privileges.
 * You have installed the link:https://docs.redhat.com/en/documentation/openshift_container_platform/latest/html/cli_tools/openshift-cli-oc[`oc` CLI].
 
-
 .Procedure
 
 * Run the following command:
@@ -29,13 +28,12 @@ When using the default instance for cluster configuration, provide the `cluster-
 ----
 $ oc adm policy add-cluster-role-to-user --rolebinding-name="openshift-gitops-cluster-admin" cluster-admin -z openshift-gitops-argocd-application-controller -n openshift-gitops
 ----
-.Example output
+*Example output:*
 +
 [source,terminal]
 ----
 clusterrole.rbac.authorization.k8s.io/cluster-admin added: "openshift-gitops-argocd-application-controller"
 ----
-
 
 .Verification
 
@@ -45,7 +43,7 @@ clusterrole.rbac.authorization.k8s.io/cluster-admin added: "openshift-gitops-arg
 ----
 $ oc get clusterrolebinding openshift-gitops-cluster-admin -o yaml
 ----
-.Example output
+*Example output:*
 +
 [source,yaml]
 ----

--- a/modules/configuring-rbac.adoc
+++ b/modules/configuring-rbac.adoc
@@ -35,7 +35,7 @@ Ensure that you always use either an empty string or a deny-all type of role for
 ----
 $ oc get argocd openshift-gitops -n openshift-gitops -o=jsonpath='{.spec.rbac}'
 ----
-.Output
+*Example Output:*
 +
 [source,json]
 ----
@@ -62,7 +62,7 @@ where:
 
 <user>:: Denotes the user that you want to add to the group.
 +
-.Example output
+*Example Output:*
 +
 [source,terminal]
 ----
@@ -80,7 +80,7 @@ where:
 
 <user>:: Denotes the user that you want to add to the group.
 +
-.Example output
+*Example Output:*
 +
 [source,terminal]
 ----
@@ -98,8 +98,7 @@ $ oc get groups cluster-admins
 ----
 +
 The output shows the `cluster-admins` group with your user assigned to it.
-
-
++
 [IMPORTANT]
 ====
 After creating or editing the `cluster-admins` group, ensure you log out of the Argo CD web console and then log back in again so that the group becomes associated with your user. Check the **User Info** page to validate that your user is part of the `cluster-admins` group within Argo CD.

--- a/modules/gitops-about-argo-rollout-manager-custom-resources-and-spec.adoc
+++ b/modules/gitops-about-argo-rollout-manager-custom-resources-and-spec.adoc
@@ -17,7 +17,7 @@ To use Argo Rollouts, you must install {gitops-title} Operator on the cluster, a
 
 You can specify the command arguments, environment variables, a custom image name, and so on for the Argo Rollouts controller resource in the spec of the `RolloutsManager` CR. The `RolloutManager` CR spec defines the desired state of Argo Rollouts.
 
-.Example: `RolloutManager` CR
+*Example: `RolloutManager` CR:*
 [source,yaml]
 ----
 apiVersion: argoproj.io/v1alpha1

--- a/modules/gitops-accessing-the-gitops-operator-metrics.adoc
+++ b/modules/gitops-accessing-the-gitops-operator-metrics.adoc
@@ -29,11 +29,13 @@ You can access the Operator metrics from the *Administrator* perspective of the 
 
 . (Optional): Filter the metric by its properties. For example, filter the `active_argocd_instances_by_phase` metric by the `Available` phase:
 +
-.Example
+--
+*Example:*
 [source, terminal]
 ----
 active_argocd_instances_by_phase{phase="Available"}
 ----
+--
 
 . (Optional): Click *Add query* to enter multiple queries.
 

--- a/modules/gitops-allowing-scm-providers.adoc
+++ b/modules/gitops-allowing-scm-providers.adoc
@@ -17,7 +17,8 @@ Allowing `ApplicationSet` resources in non-control plane namespaces can result i
 
 * To use the SCM Provider and PR generators, explicitly define a list of allowed SCM Providers:
 +
-.Example Argo CD custom resource
+--
+*Example Argo CD custom resource:*
 [source,yaml]
 ----
 apiVersion: argoproj.io/v1beta1
@@ -32,6 +33,7 @@ spec:
       - https://git.mydomain.com/
       - https://gitlab.mydomain.com/
 ----
+--
 +
 --
 where:

--- a/modules/gitops-argo-cd-dynamic-scaling-by-using-cli.adoc
+++ b/modules/gitops-argo-cd-dynamic-scaling-by-using-cli.adoc
@@ -26,19 +26,25 @@ You can enable dynamic scaling of shards by using the {oc-first}.
 $ oc patch argocd <argocd_instance> -n <namespace> --type=merge --patch='{"spec":{"controller":{"sharding":{"dynamicScalingEnabled":true,"minShards":<value>,"maxShards":<value>,"clustersPerShard":<value>}}}}'
 ----
 +
-.Example command
+--
+*Example command:*
 [source,terminal]
 ----
 $ oc patch argocd openshift-gitops -n openshift-gitops --type=merge --patch='{"spec":{"controller":{"sharding":{"dynamicScalingEnabled":true,"minShards":1,"maxShards":3,"clustersPerShard":1}}}}'
 ----
+--
 +
+--
 The example command enables dynamic scaling for the `openshift-gitops` Argo CD instance in the `openshift-gitops` namespace, and sets the minimum number of shards to `1`, the maximum number of shards to `3`, and the number of clusters per shard to `1`. The values of `minShard` and `clustersPerShard` must be set to `1` or greater. The value of `maxShard` must be equal to or greater than the value of `minShard`.
+--
 +
-.Example output
+--
+*Example output:*
 [source,terminal]
 ----
 argocd.argoproj.io/openshift-gitops patched
 ----
+--
 
 .Verification
 
@@ -49,17 +55,21 @@ argocd.argoproj.io/openshift-gitops patched
 $ oc get argocd <argocd_instance> -n <namespace> -o jsonpath='{.spec.controller.sharding}'
 ----
 +
-.Example command 
+--
+*Example command:*
 [source,terminal]
 ----
 $ oc get argocd openshift-gitops -n openshift-gitops -o jsonpath='{.spec.controller.sharding}'
 ----
+--
 +
-.Example output when dynamic scaling of shards is enabled
+--
+*Example output when dynamic scaling of shards is enabled:*
 [source,terminal]
 ----
 {"dynamicScalingEnabled":true,"minShards":1,"maxShards":3,"clustersPerShard":1}
 ----
+--
 
 . Optional: Verify that dynamic scaling is enabled by checking the configured `spec.controller.sharding` properties in the configuration `YAML` file of the Argo CD instance in the {OCP} web console.
 
@@ -70,17 +80,23 @@ $ oc get argocd openshift-gitops -n openshift-gitops -o jsonpath='{.spec.control
 $ oc get pods -n <namespace> -l app.kubernetes.io/name=<argocd_instance>-application-controller
 ----
 +
-.Example command
+--
+*Example command:*
 [source,terminal]
 ----
 $ oc get pods -n openshift-gitops -l app.kubernetes.io/name=openshift-gitops-application-controller
 ----
+--
 +
-.Example output
+--
+*Example output:*
 [source,terminal]
 ----
 NAME                                           READY   STATUS    RESTARTS   AGE
 openshift-gitops-application-controller-0      1/1     Running   0          2m
 ----
+--
 +
+--
 The number of Argo CD Application Controller pods must be greater than or equal to the value of `minShard`.
+--

--- a/modules/gitops-argo-cd-dynamic-scaling-in-web-console.adoc
+++ b/modules/gitops-argo-cd-dynamic-scaling-in-web-console.adoc
@@ -24,7 +24,8 @@ You can enable dynamic scaling of shards by using the {OCP} web console.
 
 . Click the *YAML* tab, and then edit and configure the `spec.controller.sharding` properties as follows:
 +
-.Example Argo CD YAML file with dynamic scaling enabled
+--
+*Example Argo CD YAML file with dynamic scaling enabled:*
 [source,yaml]
 ----
 apiVersion: argoproj.io/v1beta1
@@ -40,6 +41,7 @@ spec:
       maxShards: 3
       clustersPerShard: 1
 ----
+--
 +
 --
 where:

--- a/modules/gitops-argo-cd-installation.adoc
+++ b/modules/gitops-argo-cd-installation.adoc
@@ -33,7 +33,7 @@ To manage cluster configurations or deploy applications, you can install and dep
 ====
 You can alternatively configure YAML to create an external OS Route as shown in the following example:
 
-.Example Argo CD with external OS route created
+*Example Argo CD with external OS route created:*
 
 [source,yaml]
 ----

--- a/modules/gitops-argo-cd-notification.adoc
+++ b/modules/gitops-argo-cd-notification.adoc
@@ -21,7 +21,8 @@ To enable notifications for an Argo CD instance using the {OCP} web console, com
 . Select the Argo CD instance name you want to enable notifications. For example, `openshift-gitops`.
 . Click on the *YAML* tab, and then edit and set the `spec.notifications.enabled` parameter to `true`:
 +
-.Example
+--
+*Example:*
 [source,yaml]
 ----
 apiVersion: argoproj.io/v1beta1
@@ -33,6 +34,7 @@ spec:
     enabled: true
 #....  
 ----
+--
 
 . Click *Save*.
 

--- a/modules/gitops-argocd-cli-basic-syntax.adoc
+++ b/modules/gitops-argocd-cli-basic-syntax.adoc
@@ -35,50 +35,59 @@ If multiple Argo CD instances are in use, set the default namespace of the curre
 +
 `argocd --core [command or options] [arguments…​]`
 +
-.Example 1: Display a list of applications
+--
+*Example 1: Display a list of applications:*
 [source,terminal]
 -----
 $ argocd --core app list --repo-server-name openshift-gitops-repo-server
 -----
+--
 +
-.Example 2: Display a list of applications
+--
+*Example 2: Display a list of applications:*
 [source,terminal]
 -----
 $ ARGOCD_REPO_SERVER_NAME=openshift-gitops-repo-server argocd --core app list
 -----
-
+--
 * Default `kubeconfig` file with a custom context:
 +
 `argocd --core --kube-context [context]  [command or options] [arguments…​]`
 +
-.Example 1: Display a list of applications
+--
+*Example 1: Display a list of applications:*
 [source,terminal]
 -----
 $ argocd --core --kube-context kubeadmin-local app list --repo-server-name openshift-gitops-repo-server
 -----
+--
 +
-.Example 2: Display a list of applications
+--
+*Example 2: Display a list of applications:*
 [source,terminal]
 -----
 $ ARGOCD_REPO_SERVER_NAME=openshift-gitops-repo-server argocd --core --kube-context kubeadmin-local app list
 -----
-
+--
 * A custom `kubeconfig` file with the default context:
 +
 `KUBECONFIG=~/.kube/custom_config argocd --core [command or options] [arguments…​]`
 +
-.Example: Display a list of applications
+--
+*Example: Display a list of applications:*
 [source,terminal]
 -----
 $ KUBECONFIG=~/.kube/custom_config argocd --core app list --repo-server-name openshift-gitops-repo-server
 -----
-
+--
 * A custom `kubeconfig` file with a custom context:
 +
 `KUBECONFIG=~/.kube/custom_config argocd --core --kube-context [context] [command or options] [arguments…​]`
 +
-.Example: Display a list of applications
+--
+*Example: Display a list of applications:*
 [source,terminal]
 -----
 $ KUBECONFIG=~/.kube/custom_config argocd --kube-context kubeadmin-local --core app list --repo-server-name openshift-gitops-repo-server
 -----
+--

--- a/modules/gitops-argocd-cli-creating-an-application-in-core-mode.adoc
+++ b/modules/gitops-argocd-cli-creating-an-application-in-core-mode.adoc
@@ -35,11 +35,13 @@ endif::cluster[]
 $ oc login -u <username> -p <password> <server_url>
 ----
 +
-.Example
+--
+*Example:*
 [source,terminal]
 ----
 $ oc login -u kubeadmin -p '<password>' https://api.crc.testing:6443
 ----
+--
 
 . Check whether the context is set correctly in the `kubeconfig` file:
 +
@@ -71,11 +73,13 @@ $ argocd app list --core
 +
 If the configuration is correct, then existing applications will be listed with the following header:
 +
-.Sample output
+--
+*Sample output:*
 [source,terminal]
 ----
 NAME CLUSTER NAMESPACE  PROJECT  STATUS  HEALTH   SYNCPOLICY  CONDITIONS  REPO PATH TARGET
 ----
+--
 
 ifdef::cluster[]
 . Create an application in `core` mode:

--- a/modules/gitops-argocd-cli-creating-an-application-in-default-mode.adoc
+++ b/modules/gitops-argocd-cli-creating-an-application-in-default-mode.adoc
@@ -55,11 +55,13 @@ Enclosing the password in single quotes ensures that special characters, such as
 $ argocd login --username admin --password ${ADMIN_PASSWD} ${SERVER_URL}
 ----
 +
-.Example
+--
+*Example:*
 [source,terminal]
 ----
 $ argocd login --username admin --password '<password>' openshift-gitops.openshift-gitops.apps-crc.testing
 ----
+--
 
 . Verify that you are able to run `argocd` commands in the default mode by listing all applications:
 +
@@ -70,11 +72,13 @@ $ argocd app list
 +
 If the configuration is correct, then existing applications will be listed with the following header:
 +
-.Sample output
+--
+*Sample output:*
 [source,terminal]
 ----
 NAME CLUSTER NAMESPACE  PROJECT  STATUS  HEALTH   SYNCPOLICY  CONDITIONS  REPO PATH TARGET
 ----
+--
 
 ifdef::cluster[]
 . Create an application in the default mode:

--- a/modules/gitops-argocd-cli-logging-in-to-argocd-server.adoc
+++ b/modules/gitops-argocd-cli-logging-in-to-argocd-server.adoc
@@ -47,17 +47,21 @@ Enclosing the password in single quotes ensures that special characters, such as
 $ argocd login --username admin --password ${ADMIN_PASSWD} ${SERVER_URL}
 ----
 +
-.Example
+--
+*Example:*
 [source,terminal]
 ----
 $ argocd login --username admin --password '<password>' openshift-gitops.openshift-gitops.apps-crc.testing
 ----
+--
 +
 After a successful login, the session context will be displayed as follows:
 +
-.Example output
+--
+*Example output:*
 [source,terminal]
 ----
 'admin:login' logged in successfully
 Context '<server_url>' updated
 ----
+--

--- a/modules/gitops-argocd-cli-synchronizing-an-application-in-core-mode.adoc
+++ b/modules/gitops-argocd-cli-synchronizing-an-application-in-core-mode.adoc
@@ -26,11 +26,13 @@ This sample workflow walks you through the process of configuring Argo CD to rec
 $ oc login -u <username> -p <password> <server_url>
 ----
 +
-.Example
+--
+*Example:*
 [source,terminal]
 ----
 $ oc login -u kubeadmin -p '<password>' https://api.crc.testing:6443
 ----
+--
 
 . Check whether the context is set correctly in the `kubeconfig` file:
 +

--- a/modules/gitops-argocd-cli-synchronizing-an-application-in-default-mode.adoc
+++ b/modules/gitops-argocd-cli-synchronizing-an-application-in-default-mode.adoc
@@ -46,11 +46,13 @@ Enclosing the password in single quotes ensures that special characters, such as
 $ argocd login --username admin --password ${ADMIN_PASSWD} ${SERVER_URL}
 ----
 +
-.Example
+--
+*Example:*
 [source,terminal]
 ----
 $ argocd login --username admin --password '<password>' openshift-gitops.openshift-gitops.apps-crc.testing
 ----
+--
 
 . Because the application is configured with the `none` sync policy, you must manually trigger the sync operation:
 +

--- a/modules/gitops-argocd-cli-utility-commands.adoc
+++ b/modules/gitops-argocd-cli-utility-commands.adoc
@@ -9,7 +9,7 @@
 == argocd
 Parent command for {gitops-shortname} `argocd` CLI.
 
-.Example: Display all options
+*Example: Display all options:*
 [source,terminal]
 ----
 $ argocd
@@ -21,31 +21,31 @@ Print version information of the CLI.
 .Command syntax
 `argocd version [flags]`
 
-.Example: Print the full version of client and server to stdout
+*Example: Print the full version of client and server to stdout:*
 [source,terminal]
 ----
 $ argocd version
 ----
 
-.Example: Print only full version of the client, no connection to server will be made
+*Example: Print only full version of the client, no connection to server will be made:*
 [source,terminal]
 ----
 $ argocd version --client
 ----
 
-.Example: Print only full version of the server
+*Example: Print only full version of the server:*
 [source,terminal]
 ----
 $ argocd version --server <server_url>
 ----
 
-.Example: Print the full version of client and server in JSON format
+*Example: Print the full version of client and server in JSON format:*
 [source,terminal]
 ----
 $ argocd version -o json
 ----
 
-.Example: Print only client and server core version strings in YAML format
+*Example: Print only client and server core version strings in YAML format:*
 [source,terminal]
 ----
 $ argocd version --short -o yaml
@@ -57,13 +57,13 @@ Print the help message about any command in the application.
 .Command syntax
 `argocd help [command] [flags]`
 
-.Example: Get the help text for all the available commands
+*Example: Get the help text for all the available commands:*
 [source,terminal]
 ----
 $ argocd help
 ----
 
-.Example: Get the help text for `admin` subcommand
+*Example: Get the help text for `admin` subcommand:*
 [source,terminal]
 ----
 $ argocd help admin
@@ -77,7 +77,7 @@ Write `bash` or `zsh` shell completion code to standard output.
 
 For `bash`, ensure you have Bash completions installed and enabled. Alternatively, write it to a file and source it in your `.bash_profile`.
 
-.Example: Access completion in your current shell
+*Example: Access completion in your current shell:*
 [source,terminal]
 ----
 # source <(argocd completion bash)
@@ -85,7 +85,7 @@ For `bash`, ensure you have Bash completions installed and enabled. Alternativel
 
 For `zsh`, ensure you have Bash completions installed and enabled.
 
-.Example: Add to your `~/.zshrc` file and access completion in your current shell
+*Example: Add to your `~/.zshrc` file and access completion in your current shell:*
 [source,terminal]
 ----
 source <(argocd completion zsh)

--- a/modules/gitops-configure-aws-secret-manager-on-openshift-with-gitops.adoc
+++ b/modules/gitops-configure-aws-secret-manager-on-openshift-with-gitops.adoc
@@ -9,8 +9,8 @@
 This guide provides instructions with examples to help you use {gitops-shortname} workflows with the Secrets Store Container Storage Interface (SSCSI) Driver Operator to mount secrets from AWS Secrets Manager to a CSI volume in {OCP}.
 
 As an example, consider that you are using AWS Secrets Manager as your secrets store provider with the SSCSI Driver Operator. The following example shows the directory structure in {gitops-shortname} repository that is ready to use the secrets from AWS Secrets Manager:
-
-.Example directory structure in {gitops-shortname} repository
+--
+*Example directory structure in {gitops-shortname} repository:*
 ----
 ├── config
 │   ├── argocd
@@ -39,3 +39,4 @@ where:
 `dev`:: Specifies the directory that stores the deployment pod and credential requests.
 `app-taxi`:: Specifies the directory that stores the `SecretProviderClass` resources to define your secrets store provider.
 `credentialsrequest-dir-aws`:: Specifies the folder that stores the `credentialsrequest.yaml` file. This file contains the configuration for the credentials request to mount a secret to the deployment pod.
+--

--- a/modules/gitops-configure-hashicorp-vault-as-a-secrets-provider-on-openshift-with-gitops.adoc
+++ b/modules/gitops-configure-hashicorp-vault-as-a-secrets-provider-on-openshift-with-gitops.adoc
@@ -12,7 +12,8 @@ Structure the {gitops-shortname} repository and configure the Vault CSI provider
 
 The following sample {gitops-shortname} repository layout is used for integrating Vault with your application.
 
-.Example directory structure in {gitops-shortname} repository
+--
+*Example directory structure in {gitops-shortname} repository:*
 ----
 ├── config
 │   ├── argocd
@@ -35,3 +36,4 @@ where:
 `config/argocd/`:: Specifies the directory that stores Argo CD Application definitions for cluster-wide tools like the Vault CSI provider.
 `environments/<env>/apps/<app-name>/manifest/`:: Specifies the directory that contains Kubernetes manifests specific to an application in a particular environment.
 `environments/<env>/apps/<app-name>/argocd/`:: Specifies the directory that contains the Argo CD Application definition that deploys the application and its resources.
+--

--- a/modules/gitops-configure-rollout-route-traffic-using-openshift-routes.adoc
+++ b/modules/gitops-configure-rollout-route-traffic-using-openshift-routes.adoc
@@ -24,7 +24,10 @@ The following example procedure creates a route, a rollout, and two services. It
 .. In the *Administrator* perspective of the web console, click *Networking* -> *Routes*.
 .. Click *Create Route*.
 .. On the *Create Route* page, click *YAML view* and add the following snippet:
++
+--
 The following example creates a route called `rollouts-demo-route`:
+--
 +
 [source,yaml]
 ----
@@ -65,7 +68,10 @@ where:
 .. In the *Administrator* perspective of the web console, click *Networking* -> *Services*.
 .. Click *Create Service*.
 .. On the *Create Service* page, click *YAML view* and add the following snippet:
++
+--
 The following example creates a canary service called `argo-rollouts-canary-service`. Canary traffic is directed to this service.
+--
 +
 [source,yaml]
 ----
@@ -99,7 +105,10 @@ Ensure that the name of the canary service specified in the `Route` object match
 +
 Rollouts automatically update the created service with pod template hash of the canary `ReplicaSet`. For example, `rollouts-pod-template-hash: 7bf84f9696`.
 .. Repeat these steps to create the stable service:
++
+--
 The following example creates a stable service called `argo-rollouts-stable-service`. Stable traffic is directed to this service.
+--
 +
 [source,yaml]
 ----
@@ -204,7 +213,8 @@ When the first instance of the `Rollout` resource is created, the rollout regula
 .. Go to *Networking* -> *Routes* and look for the `Route` resource you want to verify. 
 .. Select the *YAML* tab and view the following snippet:
 +
-.Example: `Route`
+--
+*Example: `Route`:*
 [source,yaml]
 ----
 kind: Route
@@ -221,6 +231,7 @@ spec:
     name: argo-rollouts-stable-service
     weight: 100
 ----
+--
 +
 --
 where:
@@ -240,7 +251,8 @@ As a result, the container image deployed in the rollout is modified and the rol
 As per the `setWeight` property defined in the `.spec.strategy.canary.steps` field of the `Rollout` resource, initially 30% of traffic to the route reaches the canary version and 70% of traffic is directed towards the stable version. The rollout is paused after 30% of traffic is directed to the canary version.
 ====
 +
-.Example route with 30% of traffic directed to the canary version and 70% directed to the stable version.
+--
+*Example route with 30% of traffic directed to the canary version and 70% directed to the stable version.:*
 [source,yaml]
 ----
 spec:
@@ -254,6 +266,7 @@ spec:
     name: argo-rollouts-stable-service
     weight: 70
 ----
+--
 
 . Simulate another new canary version of the application by running the following command in the Argo Rollouts CLI:
 +
@@ -270,7 +283,8 @@ where:
 +
 This increases the traffic weight to 60% in the canary version and 40% in the stable version. 
 +
-.Example route with 60% of traffic directed to the canary version and 40% directed to the stable version.
+--
+*Example route with 60% of traffic directed to the canary version and 40% directed to the stable version.:*
 [source,yaml]
 ----
 spec:
@@ -284,6 +298,7 @@ spec:
     name: argo-rollouts-stable-service
     weight: 40
 ----
+--
 
 . Increase the traffic weight in the canary version to 100% and discard the traffic in the old stable version of the application by running the following command:
 +
@@ -298,7 +313,8 @@ where:
 `<namespace>`:: Specifies the namespace where the `Rollout` resource is defined.
 -- 
 +
-.Example route with 0% of traffic directed to the canary version and 100% directed to the stable version.
+--
+*Example route with 0% of traffic directed to the canary version and 100% directed to the stable version.:*
 [source,yaml]
 ----
 spec:
@@ -308,3 +324,4 @@ spec:
     name: argo-rollouts-stable-service
     weight: 100
 ----
+--

--- a/modules/gitops-configure-rollout-route-traffic-using-openshift-service-mesh.adoc
+++ b/modules/gitops-configure-rollout-route-traffic-using-openshift-service-mesh.adoc
@@ -28,8 +28,8 @@ In the following example procedure, the rollout routes 20% of traffic to a canar
 
 .. Create a YAML file with the following snippet content.
 +
-.Example gateway called `rollouts-demo-gateway`
-+
+--
+*Example gateway called `rollouts-demo-gateway`*
 [source,yaml]
 ----
 apiVersion: networking.istio.io/v1alpha3
@@ -47,6 +47,7 @@ spec:
     hosts:
     - "*"
 ----
+--
 +
 --
 where:
@@ -266,7 +267,8 @@ where:
 +
 `<namespace>`:: Specifies the namespace where the `Rollout` resource is defined.
 +
-.Example output
+--
+*Example output:*
 [source,terminal]
 ----
 Name:            rollouts-demo
@@ -294,6 +296,7 @@ NAME                                       KIND        STATUS     AGE    INFO
       ├──□ rollouts-demo-687d76d795-rsgtv  Pod         ✔ Running  4m49s  ready:1/1
       └──□ rollouts-demo-687d76d795-xrmrj  Pod         ✔ Running  4m49s  ready:1/1
 ----
+--
 +
 [NOTE]
 ====
@@ -309,6 +312,7 @@ $ oc describe virtualservice/rollouts-demo-vsvc -n <namespace>
 
 .. View the following output displayed in the terminal:
 +
+--
 [source,yaml]
 ----
 route
@@ -319,6 +323,7 @@ route
     host: rollouts-demo-canary
   weight: 0
 ----
+--
 +
 --
 where:
@@ -350,15 +355,20 @@ As per the `setWeight` property defined in the `.spec.strategy.canary.steps` fie
 ----
 $ oc argo rollouts get rollout rollouts-demo --watch -n <namespace>
 ----
-
+--
++
+--
 where:
 
 `<namespace>`:: Specifies the namespace where the `Rollout` resource is defined.
 --
 +
+--
 In the following example, 80% of traffic is routed to the stable service and 20% of traffic is routed to the canary service. The deployment is then paused indefinitely until you manually promote it to the next level.
+--
 +
-.Example output
+--
+*Example output:*
 [source,terminal]
 ----
 Name:            rollouts-demo
@@ -390,8 +400,10 @@ NAME                                       KIND        STATUS     AGE    INFO
       ├──□ rollouts-demo-687d76d795-rsgtv  Pod         ✔ Running  9m50s  ready:1/1
       └──□ rollouts-demo-687d76d795-xrmrj  Pod         ✔ Running  9m50s  ready:1/1
 ----
+--
 +
-.Example with 80% directed to the stable version and 20% of traffic directed to the canary version.
+--
+*Example with 80% directed to the stable version and 20% of traffic directed to the canary version.:*
 [source,yaml]
 ----
 route
@@ -402,6 +414,7 @@ route
     host: rollouts-demo-canary
   weight: 20
 ----
+--
 +
 --
 where:
@@ -437,7 +450,8 @@ where:
 +
 In the following example, 60% of traffic is routed to the stable service and 40% of traffic is routed to the canary service. The deployment is then paused indefinitely until you manually promote it to the next level.
 +
-.Example output
+--
+*Example output:*
 [source,terminal]
 ----
 Name:            rollouts-demo
@@ -469,8 +483,10 @@ NAME                                       KIND        STATUS     AGE    INFO
       ├──□ rollouts-demo-687d76d795-rsgtv  Pod         ✔ Running  9m50s  ready:1/1
       └──□ rollouts-demo-687d76d795-xrmrj  Pod         ✔ Running  9m50s  ready:1/1
 ----
+--
 +
-.Example of 60% traffic directed to the stable version and 40% directed to the canary version.
+--
+*Example of 60% traffic directed to the stable version and 40% directed to the canary version.:*
 [source,yaml]
 ----
 route
@@ -481,6 +497,7 @@ route
     host: rollouts-demo-canary
   weight: 40
 ----
+--
 +
 --
 where:

--- a/modules/gitops-configuring-a-cluster-scoped-argo-rollouts-instance-to-manage-rollouts-resources.adoc
+++ b/modules/gitops-configuring-a-cluster-scoped-argo-rollouts-instance-to-manage-rollouts-resources.adoc
@@ -21,7 +21,8 @@ You can only create a cluster-scoped Argo Rollouts instance if the `NAMESPACE_SC
 
 . On the *openshift-gitops-operator* Subscription details page, under the *YAML* tab, edit the `Subscription` YAML file by adding the namespace of the Argo CD instance to the `CLUSTER_SCOPED_ARGO_ROLLOUTS_NAMESPACES` environment variable in the `spec` section:
 +
-.Example configuring the `CLUSTER_SCOPED_ARGO_ROLLOUTS_NAMESPACES` environment variable
+--
+*Example configuring the `CLUSTER_SCOPED_ARGO_ROLLOUTS_NAMESPACES` environment variable:*
 [source,yaml]
 ----
 apiVersion: operators.coreos.com/v1alpha1
@@ -37,6 +38,7 @@ spec:
       value: <list_of_namespaces_in_the_cluster-scoped_Argo_CD_instances>
  ...
 ----
+--
 +
 --
 where:

--- a/modules/gitops-configuring-argo-cd-cr-of-your-user-defined-cluster-scoped-instance-with-target-namespaces.adoc
+++ b/modules/gitops-configuring-argo-cd-cr-of-your-user-defined-cluster-scoped-instance-with-target-namespaces.adoc
@@ -27,7 +27,8 @@ As a cluster administrator, you can define a certain set of non-control plane na
 .. Click the *YAML* tab and edit the YAML file of the `ArgoCD` CR.
 .. In the `ArgoCD` CR, set the value of the `sourceNamespaces` parameter to include the non-control plane namespaces:
 +
-.Example `ArgoCD` CR 
+--
+*Example `ArgoCD` CR:*
 [source,yaml]
 ----
 apiVersion: argoproj.io/v1beta1
@@ -40,6 +41,7 @@ spec:
     - dev
     - app-team-*
 ----
+--
 +
 --
 where:
@@ -55,7 +57,8 @@ where:
 When a target namespace is specified under the `sourceNamespaces` field, the Operator adds the `argocd.argoproj.io/managed-by-cluster-argocd` label to the specified namespace.
 ====
 +
-.Example `dev` target namespace
+--
+*Example `dev` target namespace:*
 [source,yaml]
 ----
 apiVersion: v1
@@ -66,6 +69,7 @@ metadata:
     argocd.argoproj.io/managed-by-cluster-argocd: spring-petclinic
     kubernetes.io/metadata.name: dev
 ----
+--
 +
 --
 where:

--- a/modules/gitops-configuring-common-cluster-roles-by-specifying-user-defined-cluster-roles-for-namespace-scoped-instances.adoc
+++ b/modules/gitops-configuring-common-cluster-roles-by-specifying-user-defined-cluster-roles-for-namespace-scoped-instances.adoc
@@ -30,7 +30,8 @@ To configure common cluster roles for all managed namespaces, you can specify us
 . Select the *YAML* tab and make your customization:
 ** Specify the user-defined cluster roles for the `CONTROLLER_CLUSTER_ROLE` and `SERVER_CLUSTER_ROLE` environment variables:
 +
-.Example Subscription
+--
+*Example Subscription:*
 [source,yaml]
 ----
 apiVersion: operators.coreos.com/v1alpha1
@@ -46,6 +47,7 @@ spec:
     - name: SERVER_CLUSTER_ROLE
       value: gitops-server-role
 ----
+--
 +
 --
 where:

--- a/modules/gitops-configuring-gitops-managed-resources-to-use-mounted-secrets.adoc
+++ b/modules/gitops-configuring-gitops-managed-resources-to-use-mounted-secrets.adoc
@@ -19,7 +19,8 @@ You must configure the {gitops-shortname} managed resources by adding volume mou
 
 .. Add the volume mounting to the deployment YAML file and configure the container pod to use the secret provider class resources and mounted secret:
 +
-.Example YAML file
+--
+*Example YAML file:*
 [source,yaml]
 ----
 apiVersion: apps/v1
@@ -55,6 +56,7 @@ spec:
     status: {}
 # ...
 ----
+--
 +
 --
 where:
@@ -81,17 +83,21 @@ where:
 $ oc exec <deployment_name>-<hash> -n <namespace> -- ls /mnt/secrets-store/
 ----
 +
-.Example command
+--
+*Example command:*
 [source,terminal]
 ----
 $ oc exec taxi-5959644f9-t847m -n dev -- ls /mnt/secrets-store/
 ----
+--
 +
-.Example output
+--
+*Example output:*
 [source,terminal]
 ----
 <secret_name>
 ----
+--
 
 .. View a secret in the pod mount:
 +
@@ -100,14 +106,18 @@ $ oc exec taxi-5959644f9-t847m -n dev -- ls /mnt/secrets-store/
 $ oc exec <deployment_name>-<hash> -n <namespace> -- cat /mnt/secrets-store/<secret_name>
 ----
 +
-.Example command
+--
+*Example command:*
 [source,terminal]
 ----
 $ oc exec taxi-5959644f9-t847m -n dev -- cat /mnt/secrets-store/testSecret
 ----
+--
 +
-.Example output
+--
+*Example output:*
 [source,terminal]
 ----
 <secret_value>
 ----
+--

--- a/modules/gitops-configuring-gitops-managed-resources-to-use-vault-mounted-secrets.adoc
+++ b/modules/gitops-configuring-gitops-managed-resources-to-use-vault-mounted-secrets.adoc
@@ -14,7 +14,8 @@ Securely inject secrets from HashiCorp Vault into GitOps-managed Kubernetes work
 
 .. Create a `SecretProviderClass` resource in the application's manifest directory for example, `environments/dev/apps/demo-app/manifest/secretProviderClass.yaml`. This resource defines how the Secrets Store CSI driver retrieves secrets from Vault.
 +
-.Example `vault-secret-provider-app.yaml` file
+--
+*Example `vault-secret-provider-app.yaml` file:*
 [source,yaml]
 ----
 apiVersion: secrets-store.csi.x-k8s.io/v1
@@ -35,6 +36,7 @@ apiVersion: secrets-store.csi.x-k8s.io/v1
             secretPath: "secret/demo/config"
              secretKey: "password"
 ----
+--
 +
 --
 where:
@@ -49,7 +51,8 @@ where:
 
 .. Create a Kubernetes `ServiceAccount` for the application workload. The `ServiceAccount` name must match the `bound_service_account_names` value defined in the Vault Kubernetes authentication role. Store the manifest in the GitOps repository, for example, `environments/dev/apps/demo-app/manifest/serviceAccount.yaml`.
 +
-.Example `ServiceAccount.yaml` file
+--
+*Example `ServiceAccount.yaml` file:*
 [source,yaml]
 ----
 apiVersion: v1
@@ -58,12 +61,14 @@ metadata:
   name: demo-app-sa
   namespace: demo-app
 ----
+--
 
 . Create the Application deployment:
 
 .. Modify the application's deployment to use the designated `ServiceAccount` and mount secrets using the CSI volume. Store the updated manifest in the GitOps repository, for example, `environments/dev/apps/demo-app/manifest/deployment.yaml`:
 +
-.Example `deployment.yaml` file
+--
+*Example `deployment.yaml` file:*
 [source,yaml]
 ----
 apiVersion: apps/v1
@@ -99,6 +104,7 @@ spec:
             volumeAttributes:
               secretProviderClass: demo-app-creds
 ----
+--
 +
 --
 where:
@@ -112,7 +118,8 @@ where:
 
 .. Define an Argo CD application resource to deploy application components such as `ServiceAccount`, `SecretProviderClass`, and `Deployment` from the GitOps repository. Store the Argo CD manifest in a directory location, such as, `environments/dev/apps/demo-app/argocd/demo-app.yaml`.
 +
-.Example `demo-app.yaml` file
+--
+*Example `demo-app.yaml` file:*
 [source,yaml]
 ----
 apiVersion: argoproj.io/v1alpha1
@@ -136,3 +143,4 @@ spec:
     syncOptions:
       - CreateNamespace=true
 ----
+--

--- a/modules/gitops-configuring-high-availability-for-argo-rollouts.adoc
+++ b/modules/gitops-configuring-high-availability-for-argo-rollouts.adoc
@@ -22,7 +22,8 @@ To enable high availability, configure the `ha` specification in the `RolloutMan
 
 . On the *Create RolloutManager* page, select the *YAML view* and edit the YAML.
 +
-.Example enabling the `ha` field in the `RolloutManager` CR
+--
+*Example enabling the `ha` field in the `RolloutManager` CR:*
 [source,yaml]
 ----
 apiVersion: argoproj.io/v1alpha1
@@ -34,6 +35,7 @@ spec:
   ha:
     enabled: true
 ----
+--
 +
 --
 where:
@@ -52,7 +54,8 @@ where:
 .. Click the *Details* tab and confirm that the number of replicas in the Rollouts deployment is now set to 2. 
 .. Click the *YAML* tab and confirm that the following configuration is displayed:
 +
-.Example Argo Rollouts deployment configuration file
+--
+*Example Argo Rollouts deployment configuration file:*
 [source,yaml]
 ----
 kind: Deployment
@@ -75,6 +78,7 @@ spec:
             - '--leader-elect'
             - 'true'
 ----
+--
 +
 --
 where:

--- a/modules/gitops-configuring-namespace-scoped-argo-rollouts-installation.adoc
+++ b/modules/gitops-configuring-namespace-scoped-argo-rollouts-installation.adoc
@@ -21,8 +21,8 @@ To configure a namespace-scoped instance of Argo Rollouts installation, complete
 . Click the *YAML* tab and edit the YAML file. 
 .. Specify the `NAMESPACE_SCOPED_ARGO_ROLLOUTS` environment variable, with the value set to `true` in the `.spec.config.env` property.
 +
-.Example of configuring the namespace-scoped Argo Rollouts installation
-+
+--
+*Example of configuring the namespace-scoped Argo Rollouts installation:*
 [source,yaml]
 ----
 apiVersion: operators.coreos.com/v1alpha1
@@ -36,6 +36,7 @@ spec:
       - name: NAMESPACE_SCOPED_ARGO_ROLLOUTS
         value: 'true'
 ----
+--
 +
 --
 where:
@@ -57,7 +58,8 @@ The {gitops-title} Operator facilitates the reconciliation of the Argo Rollouts 
 .. Click *Create RolloutManager*.
 .. Select *YAML view* and enter the following snippet:
 +
-.Example `RolloutManager` CR for a namespace-scoped Argo Rollouts installation
+--
+*Example `RolloutManager` CR for a namespace-scoped Argo Rollouts installation:*
 [source,yaml]
 ----
 apiVersion: argoproj.io/v1alpha1
@@ -68,6 +70,7 @@ metadata:
 spec:
   namespaceScoped: true
 ----
+--
 +
 --
 where:
@@ -83,7 +86,8 @@ After the `RolloutManager` CR is created, {gitops-title} begins to install the n
 .. In the *RolloutManager* tab, under the *RolloutManagers* section, ensure that the *Status* field of the `RolloutManager` instance is `Phase: Available`.
 .. Examine the following output in the *YAML* tab under the *RolloutManagers* section to ensure that the installation is successful:
 +
-.Example of namespace-scoped Argo Rollouts installation YAML file
+--
+*Example of namespace-scoped Argo Rollouts installation YAML file:*
 [source,yaml]
 ----
 spec:
@@ -98,6 +102,7 @@ status:
   phase: Available
   rolloutController: Available
 ----
+--
 +
 --
 where:
@@ -107,7 +112,8 @@ where:
 +
 If you try to install a namespace-specific Argo Rollouts instance while a cluster-scoped installation already exists on the cluster, an error message is displayed:
 +
-.Example of an incorrect installation with an error message
+--
+*Example of an incorrect installation with an error message:*
 [source,yaml]
 ----
 spec:
@@ -122,6 +128,7 @@ status:
   phase: Failure
   rolloutController: Failure
 ----
+--
 +
 --
 where:

--- a/modules/gitops-configuring-respect-rbac-using-gitops.adoc
+++ b/modules/gitops-configuring-respect-rbac-using-gitops.adoc
@@ -25,7 +25,8 @@ You can configure the `respectRBAC` feature by using the CLI.
 
 . Create a YAML object file, for example, `argo-cd-resource.yaml`, to configure the `respectRBAC` feature: 
 +
-.Example `ArgoCD` YAML to create `respectRBAC` 
+--
+*Example `ArgoCD` YAML to create `respectRBAC`:*
 [source,yaml]
 ----
 apiVersion: argoproj.io/v1beta1
@@ -36,6 +37,7 @@ spec:
   controller:
     respectRBAC: strict
 ----
+--
 +
 --
 where:
@@ -52,7 +54,7 @@ $ oc apply -f argocd-resource.yaml -n argo-cd-instance
 ----
 +
 Specify the name of the YAML file that includes the `ArgoCD` resource and the namespace that hosts `ArgoCD`.
-+
+
 . Verify that the status of the `.status.phase` field is `Available` by running the following command:
 +
 [source,terminal]

--- a/modules/gitops-configuring-sscsi-driver-to-mount-secrets-from-aws-secrets-manager.adoc
+++ b/modules/gitops-configuring-sscsi-driver-to-mount-secrets-from-aws-secrets-manager.adoc
@@ -21,11 +21,13 @@ To store and manage your secrets securely, use {gitops-shortname} workflows and 
 $ oc adm policy add-scc-to-user privileged -z csi-secrets-store-provider-aws -n openshift-cluster-csi-drivers
 ----
 +
-.Example output
+--
+*Example output:*
 [source,terminal]
 ----
 clusterrole.rbac.authorization.k8s.io/system:openshift:scc:privileged added: "csi-secrets-store-provider-aws"
 ----
+--
 
 . Grant permission to allow the service account to read the AWS secret object:
 
@@ -38,7 +40,8 @@ $ mkdir credentialsrequest-dir-aws
 
 .. Create a YAML file with the following configuration for the credentials request in the `/environments/dev/credentialsrequest-dir-aws/` path to mount a secret to the deployment pod in the `dev` namespace:
 +
-.Example `credentialsrequest.yaml` file
+--
+*Example `credentialsrequest.yaml` file:*
 [source,yaml]
 ----
 apiVersion: cloudcredential.openshift.io/v1
@@ -62,6 +65,7 @@ secretRef:
 serviceAccountNames:
   - default
 ----
+--
 +
 --
 where:
@@ -79,7 +83,7 @@ To find your cluster region, run the command:
 $ oc get infrastructure cluster -o jsonpath='{.status.platformStatus.aws.region}'
 ----
 
-.Example output
+*Example output:*
 [source,terminal]
 ----
 us-west-2
@@ -93,11 +97,13 @@ us-west-2
 $ oc get --raw=/.well-known/openid-configuration | jq -r '.issuer'
 ----
 +
-.Example output
+--
+*Example output:*
 [source,terminal]
 ----
 https://<oidc_provider_name>
 ----
+--
 Copy the OIDC provider name `<oidc_provider_name>` from the output to use in the next step.
 
 .. Use the `ccoctl` tool to process the credentials request by running the following command:
@@ -110,19 +116,22 @@ $ ccoctl aws create-iam-roles \
 `    --identity-provider-arn arn:aws:iam`::<aws_account>:oidc-provider/<oidc_provider_name> --output-dir=credrequests-ccoctl-output
 ----
 +
-.Example output
+--
+*Example output:*
 [source,terminal]
 ----
 `2023/05/15 18:10:34 Role arn:aws:iam`::<aws_account_id>:role/my-role-my-namespace-aws-creds created
 2023/05/15 18:10:34 Saved credentials configuration to: credrequests-ccoctl-output/manifests/my-namespace-aws-creds-credentials.yaml
 2023/05/15 18:10:35 Updated Role policy for Role my-role-my-namespace-aws-creds
 ----
+--
 +
 `Copy the `<aws_role_arn>` from the output to use in the next step. For example, `arn:aws:iam`::<aws_account_id>:role/my-role-my-namespace-aws-creds`.
 
 .. Check the role policy on AWS to confirm the `<aws_region>` of `"Resource"` in the role policy matches the cluster region:
 +
-.Example role policy
+--
+*Example role policy:*
 [source,json]
 ----
 {
@@ -139,6 +148,7 @@ $ ccoctl aws create-iam-roles \
 	]
 }
 ----
+--
 
 .. Bind the service account with the role ARN by running the following command:
 +
@@ -147,23 +157,27 @@ $ ccoctl aws create-iam-roles \
 $ oc annotate -n <namespace> sa/<app_service_account> eks.amazonaws.com/role-arn="<aws_role_arn>"
 ----
 +
-.Example command
+--
+*Example command:*
 [source,terminal]
 ----
 $ oc annotate -n dev sa/default eks.amazonaws.com/role-arn="<aws_role_arn>"
 ----
+--
 +
-.Example output
+--
+*Example output:*
 [source,terminal]
 ----
 serviceaccount/default annotated
 ----
-
+--
 . Create a namespace-scoped `SecretProviderClass` resource to define your secrets store provider. For example, you create a `SecretProviderClass` resource in `/environments/dev/apps/app-taxi/services/taxi/base/config` directory of your {gitops-shortname} repository.
 
 .. Create a `secret-provider-class-aws.yaml` file in the same directory where the target deployment is located in your {gitops-shortname} repository: 
 +
-.Example `secret-provider-class-aws.yaml`
+--
+*Example `secret-provider-class-aws.yaml`:*
 [source,yaml]
 ----
 apiVersion: secrets-store.csi.x-k8s.io/v1
@@ -178,6 +192,7 @@ spec:
       - objectName: "testSecret"
         objectType: "secretsmanager"
 ----
+--
 +
 --
 where:

--- a/modules/gitops-configuring-tls-for-redis-with-autotls-disabled.adoc
+++ b/modules/gitops-configuring-tls-for-redis-with-autotls-disabled.adoc
@@ -22,7 +22,8 @@ You can manually configure TLS encryption for Redis by creating the `argocd-oper
 
 .. Edit or replace the YAML similar to the following example:
 +
-.Example ArgoCD CR with autotls disabled
+--
+*Example ArgoCD CR with autotls disabled:*
 [source,yaml]
 ----
 apiVersion: argoproj.io/v1beta1
@@ -34,6 +35,7 @@ spec:
   ha:
     enabled: true
 ----
+--
 +
 --
 where:
@@ -58,7 +60,8 @@ where:
 `<namespace>`:: Specifies a namespace where the Argo CD instance is running, for example `openshift-gitops`.
 --
 +
-.Example output with HA disabled
+--
+*Example output with HA disabled:*
 [source,terminal]
 ----
 NAME                                  READY   STATUS    RESTARTS   AGE
@@ -67,13 +70,15 @@ argocd-redis-84b77d4f58-vp6zm         1/1     Running   0          37s
 argocd-repo-server-5b959b57f4-znxjq   1/1     Running   0          37s
 argocd-server-6b8787d686-wv9zh        1/1     Running   0          37s
 ----
+--
 +
 [NOTE]
 ====
 The HA-enabled TLS configuration requires a cluster with at least three worker nodes. It can take a few minutes for the output to appear if you have enabled the Argo CD instances with HA configuration.
 ====
 +
-.Example output with HA enabled
+--
+*Example output with HA enabled:*
 [source,terminal]
 ----
 NAME                                       READY   STATUS    RESTARTS   AGE
@@ -85,6 +90,7 @@ argocd-redis-ha-server-2                   2/2     Running   0          53s
 argocd-repo-server-576499d46d-8hgbh        1/1     Running   0          10m
 argocd-server-9486f88b7-dk2ks              1/1     Running   0          10m
 ----
+--
 
 . Create a self-signed certificate for the Redis server by using one of the following options depending on your HA configuration:
 
@@ -110,7 +116,8 @@ where:
 `<namespace>`:: Specifies a namespace where the Argo CD instance is running, for example `openshift-gitops`.
 --
 +
-.Example output
+--
+*Example output:*
 [source,terminal]
 ----
 Generating a RSA private key
@@ -118,6 +125,7 @@ Generating a RSA private key
 ............................++++
 writing new private key to '/tmp/redis.key'
 ----
+--
 
 * For the Argo CD instance with HA enabled, run the following command:
 +
@@ -141,7 +149,8 @@ where:
 `<namespace>`:: Specifies a namespace where the Argo CD instance is running, for example `openshift-gitops`.
 --
 +
-.Example output
+--
+*Example output:*
 [source,terminal]
 ----
 Generating a RSA private key
@@ -149,6 +158,7 @@ Generating a RSA private key
 ............................++++
 writing new private key to '/tmp/redis-ha.key'
 ----
+--
 
 . Verify that the generated certificate and key are available in the `/tmp` directory by running the following commands:
 +
@@ -162,7 +172,8 @@ $ cd /tmp
 $ ls
 ----
 +
-.Example output with HA disabled
+--
+*Example output with HA disabled:*
 [source,terminal]
 ----
 ...
@@ -170,8 +181,10 @@ redis.crt
 redis.key
 ...
 ----
+--
 +
-.Example output with HA enabled
+--
+*Example output with HA enabled:*
 [source,terminal]
 ----
 ...
@@ -179,6 +192,7 @@ redis-ha.crt
 redis-ha.key
 ...
 ----
+--
 
 . Create the `argocd-operator-redis-tls` secret by using one of the following options depending on your HA configuration:
 
@@ -196,12 +210,13 @@ $ oc create secret tls argocd-operator-redis-tls --key=/tmp/redis.key --cert=/tm
 $ oc create secret tls argocd-operator-redis-tls --key=/tmp/redis-ha.key --cert=/tmp/redis-ha.crt
 ----
 +
-.Example output
+--
+*Example output:*
 [source,terminal]
 ----
 secret/argocd-operator-redis-tls created
 ----
-
+--
 . Annotate the secret to indicate that it belongs to the Argo CD CR:
 +
 [source,terminal]
@@ -215,11 +230,13 @@ where:
 `<instance-name>`:: Specifies a name of the Argo CD instance, for example `argocd`.
 --
 +
-.Example output
+--
+*Example output:*
 [source,terminal]
 ----
 secret/argocd-operator-redis-tls annotated
 ----
+--
 
 . Verify that the Argo CD pods are ready and running:
 +
@@ -234,7 +251,8 @@ where:
 `<namespace>`:: Specifies a namespace where the Argo CD instance is running, for example `openshift-gitops`.
 --
 +
-.Example output with HA disabled
+--
+*Example output with HA disabled:*
 [source,terminal]
 ----
 NAME                                  READY   STATUS    RESTARTS   AGE
@@ -243,13 +261,15 @@ argocd-redis-84b77d4f58-vp6zm         1/1     Running   0          37s
 argocd-repo-server-5b959b57f4-znxjq   1/1     Running   0          37s
 argocd-server-6b8787d686-wv9zh        1/1     Running   0          37s
 ----
+--
 +
 [NOTE]
 ====
 It can take a few minutes for the output to appear if you have enabled the Argo CD instances with HA configuration.
 ====
 +
-.Example output with HA enabled
+--
+*Example output with HA enabled:*
 [source,terminal]
 ----
 NAME                                       READY   STATUS    RESTARTS   AGE
@@ -261,3 +281,4 @@ argocd-redis-ha-server-2                   2/2     Running   0          53s
 argocd-repo-server-576499d46d-8hgbh        1/1     Running   0          10m
 argocd-server-9486f88b7-dk2ks              1/1     Running   0          10m
 ----
+--

--- a/modules/gitops-configuring-tls-for-redis-with-autotls-enabled.adoc
+++ b/modules/gitops-configuring-tls-for-redis-with-autotls-enabled.adoc
@@ -27,7 +27,8 @@ By default, the `autotls` setting is disabled.
 
 .. Edit or replace the YAML similar to the following example:
 +
-.Example Argo CD CR with autotls enabled
+--
+*Example Argo CD CR with autotls enabled:*
 [source,yaml]
 ----
 apiVersion: argoproj.io/v1beta1
@@ -41,6 +42,7 @@ spec:
   ha:
     enabled: true
 ----
+--
 +
 --
 where:
@@ -76,7 +78,8 @@ where:
 `<namespace>`:: Specifies a namespace where the Argo CD instance is running, for example `openshift-gitops`.
 --
 +
-.Example output with HA disabled
+--
+*Example output with HA disabled:*
 [source,terminal]
 ----
 NAME                                  READY   STATUS    RESTARTS   AGE
@@ -85,13 +88,15 @@ argocd-redis-84b77d4f58-vp6zm         1/1     Running   0          37s
 argocd-repo-server-5b959b57f4-znxjq   1/1     Running   0          37s
 argocd-server-6b8787d686-wv9zh        1/1     Running   0          37s
 ----
+--
 +
 [NOTE]
 ====
 The HA-enabled TLS configuration requires a cluster with at least three worker nodes. It can take a few minutes for the output to appear if you have enabled the Argo CD instances with HA configuration.
 ====
 +
-.Example output with HA enabled
+--
+*Example output with HA enabled:*
 [source,terminal]
 ----
 NAME                                       READY   STATUS    RESTARTS   AGE
@@ -103,6 +108,7 @@ argocd-redis-ha-server-2                   2/2     Running   0          53s
 argocd-repo-server-576499d46d-8hgbh        1/1     Running   0          10m
 argocd-server-9486f88b7-dk2ks              1/1     Running   0          10m
 ----
+--
 
 . Verify that the `argocd-operator-redis-tls` secret is created:
 +
@@ -117,11 +123,13 @@ where:
 `<namespace>`:: Specifies a namespace where the Argo CD instance is running, for example `openshift-gitops`.
 --
 +
-.Example output 
+--
+*Example output:*
 [source,terminal]
 ----
 NAME                        TYPE                DATA   AGE
 argocd-operator-redis-tls   kubernetes.io/tls   2      30s
 ----
+--
 +
 The secret must be of the `kubernetes.io/tls` type and a size of `2`.

--- a/modules/gitops-configuring-user-level-access.adoc
+++ b/modules/gitops-configuring-user-level-access.adoc
@@ -16,7 +16,7 @@ To manage and modify the user level access, configure the role-based access cont
 ----
 $ oc edit argocd [argocd-instance-name] -n [namespace]
 ----
-.Output
+*Output:*
 +
 [source,yaml]
 ----

--- a/modules/gitops-creating-a-new-client-using-keycloak.adoc
+++ b/modules/gitops-creating-a-new-client-using-keycloak.adoc
@@ -78,7 +78,7 @@ spec:
 +
 ** Add a `host` parameter in the `ArgoCD` CR by using the following example YAML:
 +
-.Example `ArgoCD` CR
+*Example `ArgoCD` CR:*
 [source,yaml]
 ----
 apiVersion: argoproj.io/v1alpha1

--- a/modules/gitops-creating-and-configuring-the-app-cr-to-reference-the-target-namespace-and-user-defined-appproject-instance.adoc
+++ b/modules/gitops-creating-and-configuring-the-app-cr-to-reference-the-target-namespace-and-user-defined-appproject-instance.adoc
@@ -19,7 +19,8 @@ As a cluster administrator, you can define a certain set of non-control plane na
 .. In the *Administrator* perspective of the web console, click *Operators* -> *Installed Operators* -> *{gitops-title}* and go to the *Application* tab.
 .. Click *Create Application* and enter the following configuration in the YAML view:
 +
-.Example user-defined `AppProject` instance
+--
+*Example user-defined `AppProject` instance:*
 [source,yaml]
 ----
 kind: Application
@@ -40,6 +41,7 @@ where:
 `spec.project` (AppProject):: the name of the user-defined `AppProject` instance.
 --
 .. Click *Create*.
+--
 +
 The *Applications* page displays the created application. 
 +

--- a/modules/gitops-creating-and-configuring-user-defined-appproject-instance-with-target-namespaces.adoc
+++ b/modules/gitops-creating-and-configuring-user-defined-appproject-instance-with-target-namespaces.adoc
@@ -24,7 +24,7 @@ Applications in the {gitops-shortname} control plane namespace (`openshift-gitop
 .. In the *Administrator* perspective of the web console, click *Operators* -> *Installed Operators* -> *{gitops-title}* and go to the *AppProject* tab.
 .. Click *Create AppProject* and enter the following configuration in the YAML view:
 +
-.Example user-defined `AppProject` instance
+*Example user-defined `AppProject` instance:*
 [source,yaml]
 ----
 kind: AppProject

--- a/modules/gitops-creating-rolloutmanager-custom-resource.adoc
+++ b/modules/gitops-creating-rolloutmanager-custom-resource.adoc
@@ -26,7 +26,8 @@ To manage progressive delivery of deployments by using Argo Rollouts in {gitops-
 
 . On the *Create RolloutManager* page, select the *YAML view* and use the default YAML or edit it according to your requirements:
 +
-.Example: `RolloutManager` CR
+--
+*Example: `RolloutManager` CR:*
 [source,yaml]
 ----
 apiVersion: argoproj.io/v1alpha1
@@ -36,6 +37,7 @@ metadata:
   namespace: openshift-gitops
 spec: {}
 ----
+--
 
 . Click *Create*.
 

--- a/modules/gitops-creating-user-defined-cluster-roles-and-configuring-user-defined-permissions-for-application-controller.adoc
+++ b/modules/gitops-creating-user-defined-cluster-roles-and-configuring-user-defined-permissions-for-application-controller.adoc
@@ -33,7 +33,8 @@ where:
 `<cluster_role_name>`:: Specifies the name of your defined cluster role YAML file.
 --
 +
-.Example user-defined cluster role YAML
+--
+*Example user-defined cluster role YAML:*
 [source,yaml]
 ----
 apiVersion: rbac.authorization.k8s.io/v1
@@ -62,6 +63,7 @@ rules:
     resources:
       - scansettingbindings
 ----
+--
 +
 --
 where:
@@ -76,11 +78,13 @@ where:
 Alternatively, you can use the web console to create a user-defined cluster role from the *Administrator* perspective. You can go to *User Management* -> *Roles* -> *Create Role*, use the preceding YAML template to add permissions, and click *Create*.
 ====
 +
-.Example output
+--
+*Example output:*
 [source,terminal]
 ----
 clusterrole.rbac.authorization.k8s.io/user-application-controller created
 ----
+--
 +
 A user-defined cluster role is created. 
 
@@ -98,7 +102,8 @@ where:
 `<argocd_namespace>`:: Specifies the namespace where Argo CD is installed.
 --
 +
-.Example output
+--
+*Example output:*
 [source,terminal]
 ----
 aggregationRule:
@@ -140,6 +145,7 @@ rules:
   verbs:
   - '*'
 ----
+--
 +
 [TIP]
 ====
@@ -160,7 +166,8 @@ where:
 `<argocd_namespace>`:: Specifies the namespace where Argo CD is installed.
 --
 +
-.Example output of the aggregated cluster role
+--
+*Example output of the aggregated cluster role:*
 [source,terminal]
 ----
 aggregationRule:
@@ -215,6 +222,7 @@ rules:
   - get
   - list
 ----
+--
 +
 [TIP]
 ====

--- a/modules/gitops-customizing-permissions-for-cluster-scoped-instances.adoc
+++ b/modules/gitops-customizing-permissions-for-cluster-scoped-instances.adoc
@@ -16,8 +16,8 @@ For example purposes, the following instructions focus only on user-defined clus
 
 . Use the following `ClusterRole` YAML template to add rules to specify the additional permissions.
 +
-.Example cluster role YAML template
-
+--
+*Example cluster role YAML template:*
 [source,yaml]
 ----
 apiVersion: rbac.authorization.k8s.io/v1
@@ -41,6 +41,7 @@ rules:
       - namespaces 
       - persistentvolumes 
 ----
+--
 +
 --
 where:
@@ -80,8 +81,8 @@ For *Subject name*, ensure that the value you configure is the same as the value
 +
 You have created the required permissions for the control plane component's service account and namespace. The YAML file for the `ClusterRoleBinding` object looks similar to the following example:
 +
-.Example YAML file for a cluster role binding
-
+--
+*Example YAML file for a cluster role binding:*
 [source,yaml]
 ----
 kind: ClusterRoleBinding
@@ -97,3 +98,4 @@ roleRef:
   kind: ClusterRole
   name: example-spring-petclinic-argocd-application-controller
 ----
+--

--- a/modules/gitops-deploying-a-rollout.adoc
+++ b/modules/gitops-deploying-a-rollout.adoc
@@ -90,12 +90,14 @@ where:
 `<namespace>`:: Specifies the namespace where the `Rollout` resource is defined.
 --
 +
-.Example output
+--
+*Example output:*
 [source,terminal]
 ----
 NAME           STRATEGY   STATUS        STEP  SET-WEIGHT  READY  DESIRED  UP-TO-DATE  AVAILABLE
 rollouts-demo  Canary     Healthy       8/8   100         5/5    5        5           5        
 ----
+--
 
 . Create the Kubernetes services that targets the `rollouts-demo` rollout.
 .. In the *Administrator* perspective of the web console, click *Networking* -> *Services*.
@@ -141,7 +143,8 @@ where:
 `<namespace>`:: Specifies the namespace where the `Rollout` resource is defined.
 --
 +
-.Example output
+--
+*Example output:*
 [source,terminal]
 ----
 Name:            rollouts-demo
@@ -169,6 +172,7 @@ NAME                                       KIND        STATUS     AGE    INFO
       ├──□ rollouts-demo-687d76d795-rsgtv  Pod         ✔ Running  4m49s  ready:1/1
       └──□ rollouts-demo-687d76d795-xrmrj  Pod         ✔ Running  4m49s  ready:1/1
 ----
+--
 +
 After the rollout has been created, you can verify that the *Status* field of the rollout shows *Phase: Healthy*.
 
@@ -185,7 +189,7 @@ $ oc argo rollouts status rollouts-demo -n <namespace>
 +
 Specify the namespace where the `Rollout` resource is defined.
 
-.Example output
+*Example output:*
 [source,terminal]
 ----
 Healthy

--- a/modules/gitops-disabling-automatic-scraping-of-metrics-for-argo-cd-instances.adoc
+++ b/modules/gitops-disabling-automatic-scraping-of-metrics-for-argo-cd-instances.adoc
@@ -34,7 +34,8 @@ As a cluster administrator, by disabling metric scraping for individual instance
 .. Click the *YAML* tab and edit the YAML file of the `ArgoCD` CR.
 .. In the `ArgoCD` CR, set the `spec.monitoring.disableMetrics` field value to `true`:
 +
-.Example `ArgoCD` CR
+--
+*Example `ArgoCD` CR:*
 [source,YAML]
 ----
 apiVersion: argoproj.io/v1beta1
@@ -46,6 +47,7 @@ spec:
  monitoring:
    disableMetrics: true
 ----
+--
 +
 --
 where:
@@ -57,19 +59,23 @@ where:
 [TIP]
 ====
 Alternatively, use the following command to disable the automatic scraping of metrics in the {gitops-title} `argocd` CLI:
-
-.Example command
+====
++
+--
+*Example command:*
 [source,terminal]
 ----
 $ oc patch argocd example -n spring-petclinic --type='json' -p='[{"op": "replace", "path": "/spec/monitoring/disableMetrics", "value": true}]'
 ----
-
-.Example output
+--
++
+--
+*Example output:*
 [source,terminal]
 ----
 argocd.argoproj.io/example patched
 ----
-====
+--
 
 . Verify that the Operator adds the `openshift.io/cluster-monitoring=false` label to your defined namespace:
 .. Go to *Administration* -> *Namespaces*.

--- a/modules/gitops-disabling-monitoring-for-argo-cd-custom-resource-workloads.adoc
+++ b/modules/gitops-disabling-monitoring-for-argo-cd-custom-resource-workloads.adoc
@@ -12,8 +12,8 @@ You can disable workload monitoring for specific Argo CD instances. Disabling wo
 
 * Set the `.spec.monitoring.enabled` field value to `false` on a given Argo CD instance:
 +
-.Example Argo CD custom resource
-
+--
+*Example Argo CD custom resource:*
 [source,yaml]
 ----
 apiVersion: argoproj.io/v1beta1
@@ -28,3 +28,4 @@ spec:
     enabled: false
  # ...
 ----
+--

--- a/modules/gitops-disabling-the-creation-of-the-default-cluster-roles-for-the-cluster-scoped-instance.adoc
+++ b/modules/gitops-disabling-the-creation-of-the-default-cluster-roles-for-the-cluster-scoped-instance.adoc
@@ -12,8 +12,8 @@ To add or remove permissions to cluster-wide resources, as needed, you must disa
 
 . In the Argo CD CR, set the value of the `.spec.defaultClusterScopedRoleDisabled` field to `true`:
 +
-.Example Argo CD CR
-
+--
+*Example Argo CD CR:*
 [source,yaml]
 ----
 apiVersion: argoproj.io/v1beta1
@@ -26,6 +26,7 @@ spec:
   defaultClusterScopedRoleDisabled: true
 # ...
 ----
+--
 +
 --
 where:
@@ -35,11 +36,13 @@ where:
 `spec.defaultClusterScopedRoleDisabled`:: Specifies the flag value that disables the creation of the default cluster roles for the cluster-scoped instance. If you want the Operator to recreate the default cluster roles and cluster role bindings for the cluster-scoped instance, set the field value to `false`.
 --
 +
-.Sample output
+--
+*Sample output:*
 [source,terminal]
 ----
 argocd.argoproj.io/example configured
 ----
+--
 
 . Verify that the {gitops-title} Operator has deleted the default cluster roles and cluster role bindings for the {gitops-shortname} control plane components by running the following commands:
 +
@@ -53,10 +56,12 @@ $ oc get ClusterRoles/<argocd_name>-<argocd_namespace>-<control_plane_component>
 $ oc get ClusterRoleBindings/<argocd_name>-<argocd_namespace>-<control_plane_component>
 ----
 +
-.Sample output
+--
+*Sample output:*
 [source,terminal]
 ----
 No resources found
 ----
+--
 +
 The default cluster roles and cluster role bindings for the cluster-scoped instance are not created. As a cluster administrator, you can now create and customize permissions for cluster-scoped instances by creating new cluster roles and cluster role bindings for the {gitops-shortname} control plane components.

--- a/modules/gitops-enable-replicas-for-argo-cd-server.adoc
+++ b/modules/gitops-enable-replicas-for-argo-cd-server.adoc
@@ -12,8 +12,8 @@ Argo CD-server and Argo CD-repo-server workloads are stateless. To better distri
 
 * Set the `replicas` parameters for the `repo` and `server` spec to the number of replicas you want to run:
 +
-.Example Argo CD custom resource
-
+--
+*Example Argo CD custom resource:*
 [source,yaml]
 ----
 apiVersion: argoproj.io/v1beta1
@@ -35,3 +35,4 @@ spec:
         termination: passthrough
       wildcardPolicy: None
 ----
+--

--- a/modules/gitops-enable-traffic-management-and-metric-plugins-in-argo-rollouts.adoc
+++ b/modules/gitops-enable-traffic-management-and-metric-plugins-in-argo-rollouts.adoc
@@ -22,7 +22,8 @@ To enable traffic management and metric plugins in Argo Rollouts, complete the f
 
 . On the *Create RolloutManager* page, select the *YAML view* and edit the YAML.
 +
-.Example adding the traffic management and metric plugins configuration in the `RolloutManager` CR
+--
+*Example adding the traffic management and metric plugins configuration in the `RolloutManager` CR:*
 [source,yaml]
 ----
 apiVersion: argoproj.io/v1alpha1
@@ -39,6 +40,7 @@ spec:
         location: https://github.com/sample-trafficrouter-plugin
         sha256: dac10cbf57633c9832a17f8c27d2ca34aa97dd3d
 ----
+--
 +
 --
 where:
@@ -60,7 +62,8 @@ where:
 +
 As a result, the plugins defined in the `RolloutManager` CR are updated in the *argo-rollouts-config* config map.
 +
-.Example updated traffic management and metric plugins in the argo-rollouts-config config map
+--
+*Example updated traffic management and metric plugins in the *argo-rollouts-config* `ConfigMap`:*
 [source,yaml]
 ----
 kind: ConfigMap
@@ -86,6 +89,7 @@ data:
       sha256: ""
 
 ----
+--
 +
 --
 where:

--- a/modules/gitops-enabling-argo-rollouts-ui-on-an-argo-cd-instance.adoc
+++ b/modules/gitops-enabling-argo-rollouts-ui-on-an-argo-cd-instance.adoc
@@ -28,7 +28,8 @@ To enable Argo Rollouts UI on an Argo CD instance, complete the following steps.
 
 . Click *YAML* and add the following configuration to configure the Argo Rollouts UI:
 +
-.Example enabling Argo Rollouts UI in the Argo CD CR
+--
+*Example enabling Argo Rollouts UI in the Argo CD CR:*
 [source,yaml]
 ----
 apiVersion: argoproj.io/v1beta1
@@ -39,6 +40,7 @@ spec:
   server:    
     enableRolloutsUI: true
 ----
+--
 +
 --
 where:

--- a/modules/gitops-enabling-monitoring-for-argo-cd-custom-resource-workloads.adoc
+++ b/modules/gitops-enabling-monitoring-for-argo-cd-custom-resource-workloads.adoc
@@ -14,8 +14,8 @@ With {gitops-title}, you can enable workload monitoring for specific Argo CD ins
 
 . Set the `.spec.monitoring.enabled` field value to `true` on a given Argo CD instance:
 +
-.Example Argo CD custom resource
-
+--
+*Example Argo CD custom resource:*
 [source,yaml]
 ----
 apiVersion: argoproj.io/v1beta1
@@ -30,11 +30,12 @@ spec:
     enabled: true
  # ...
 ----
+--
 
 . Verify whether an alert rule is included in the PrometheusRule created by the Operator:
 +
-.Example alert rule
-
+--
+*Example alert rule:*
 [source,yaml]
 ----
 apiVersion: monitoring.coreos.com/v1
@@ -61,6 +62,7 @@ spec:
           labels:
             severity: critical
 ----
+--
 +
 --
 where:

--- a/modules/gitops-enabling-the-application-set-resources-in-non-control-plane-namespaces.adoc
+++ b/modules/gitops-enabling-the-application-set-resources-in-non-control-plane-namespaces.adoc
@@ -12,7 +12,8 @@ As a cluster administrator, you can define a certain set of non-control plane na
 
 . Set the `sourceNamespaces` parameter for the `applicationSet` spec to include the non-control plane namespaces:
 +
-.Example Argo CD custom resource
+--
+*Example Argo CD custom resource:*
 [source,yaml]
 ----
 apiVersion: argoproj.io/v1beta1
@@ -25,6 +26,7 @@ spec:
     sourceNamespaces:
       - dev
 ----
+--
 +
 --
 where:

--- a/modules/gitops-enabling-the-creation-of-aggregated-cluster-roles.adoc
+++ b/modules/gitops-enabling-the-creation-of-aggregated-cluster-roles.adoc
@@ -12,7 +12,8 @@ To enable the creation of aggregated cluster roles for the Argo CD Application C
 
 . In the Argo CD CR, set the value of the `.spec.aggregatedClusterRoles` field to `true`:
 +
-.Example Argo CD CR
+--
+*Example Argo CD CR:*
 [source,yaml]
 ----
 apiVersion: argoproj.io/v1beta1
@@ -25,6 +26,7 @@ spec:
   aggregatedClusterRoles: true
 # ...
 ----
+--
 +
 --
 where:
@@ -34,11 +36,13 @@ where:
 `spec.aggregatedClusterRoles`:: Specifies the value of the cluster roles to enable the creation of aggregated cluster roles. If you do not want to enable the creation of aggregated cluster roles, either do not include this line or set the value to `false`.
 --
 +
-.Example output
+--
+*Example output:*
 [source,terminal]
 ----
 argocd.argoproj.io/example configured
 ----
+--
 
 . Verify that the `Status` field of the cluster-scoped Argo CD instance shows as `Phase: Available` by running the following command:
 +
@@ -47,7 +51,8 @@ argocd.argoproj.io/example configured
 $ oc describe argocd.argoproj.io/example -n spring-petclinic
 ----
 +
-.Example output
+--
+*Example output:*
 [source,terminal]
 ----
 Name:         example
@@ -76,8 +81,11 @@ Status:
   Sso:                         Unknown
 Events:                        <none>
 ----
+--
 +
+--
 The `Available` status indicates that the cluster-scoped Argo CD instance is healthy and available.
+--
 +
 [NOTE]
 ====
@@ -95,7 +103,8 @@ The {gitops-title} Operator creates the following default cluster roles and mana
 $ oc get ClusterRoles -l app.kubernetes.io/part-of=argocd
 ----
 +
-.Example output
+--
+*Example output:*
 [source,terminal]
 ----
 NAME                                                           CREATED AT
@@ -104,19 +113,22 @@ example-spring-petclinic-argocd-application-controller-admin   2024-08-14T09:08:
 example-spring-petclinic-argocd-application-controller-view    2024-08-14T09:08:38Z
 example-spring-petclinic-argocd-server                         2024-08-14T08:20:59Z
 ----
+--
 +
 [source,terminal]
 ----
 $ oc get ClusterRoleBindings -l app.kubernetes.io/part-of=argocd
 ----
 +
-.Example output
+--
+*Example output:*
 [source,terminal]
 ----
 NAME                                                     ROLE                                                                 AGE
 example-spring-petclinic-argocd-application-controller   ClusterRole/example-spring-petclinic-argocd-application-controller   54m
 example-spring-petclinic-argocd-server                   ClusterRole/example-spring-petclinic-argocd-server                   54m
 ----
+--
 +
 The cluster role bindings for the `view` and `admin` cluster roles are not created. This is because the `view` and `admin` cluster roles only add permissions to the aggregated cluster role and do not directly configure permissions to the Argo CD Application Controller.
 +
@@ -127,10 +139,12 @@ Alternatively, you can use the {OCP} web console to verify from the *Administrat
 
 . Verify that the aggregated cluster role is created by checking the permissions of outputs of the roles created by running the following command:
 +
+--
 [source,terminal]
 ----
 $ oc get ClusterRole/<cluster_role_name> -o yaml
 ----
+--
 +
 --
 where:
@@ -138,8 +152,8 @@ where:
 `<cluster_role_name>`:: Specifies the name of the role created.
 --
 +
-.Example output of the aggregated cluster role
-+
+--
+*Example output of the aggregated cluster role:*
 [source,terminal]
 ----
 apiVersion: rbac.authorization.k8s.io/v1
@@ -166,6 +180,7 @@ aggregationRule:
       argocd/aggregate-to-controller: "true"
 rules: []
 ----
+--
 +
 --
 where:
@@ -175,8 +190,8 @@ where:
 `rules`:: Specifies the predefined permissions. However, when the Operator immediately creates a `<argocd_name>-<argocd_namespace>-argocd-application-controller-view` cluster role, the corresponding predefined `view` permissions are added into the aggregated cluster role.
 --
 +
-.Example output of the `view` cluster role
-+
+--
+*Example output of the `view` cluster role:*
 [source,terminal]
 ----
 apiVersion: rbac.authorization.k8s.io/v1
@@ -211,6 +226,7 @@ rules:
   - get
   - list
 ----
+--
 +
 --
 where:
@@ -220,7 +236,8 @@ where:
 `rules`:: Specifies the predefined `view` permissions. These permissions are added into the existing aggregated cluster role.
 --
 +
-.Example output of the `admin` cluster role
+--
+*Example output of the `admin` cluster role:*
 [source,terminal]
 ----
 apiVersion: rbac.authorization.k8s.io/v1
@@ -248,6 +265,7 @@ aggregationRule:
       argocd/aggregate-to-admin: "true"
 rules: null
 ----
+--
 +
 --
 where:

--- a/modules/gitops-enabling-the-gitopsservice-custom-resource.adoc
+++ b/modules/gitops-enabling-the-gitopsservice-custom-resource.adoc
@@ -32,7 +32,8 @@ $ oc edit gitopsservice cluster -n openshift-gitops
 
 . In the `.spec.consolePlugin` section, add the `.backend.resources` and `.gitopsPlugin.resources` fields. These sections define requests and limits for CPU and memory.
 +
-.Example configuration
+--
+*Example configuration:*
 [source,yaml]
 ----
 apiVersion: pipelines.openshift.io/v1alpha1
@@ -58,6 +59,7 @@ spec:
           cpu: 100m
           memory: 1Gi
 ----
+--
 
 After you update the `GitOpsService` CR, the `GitOpsService` controller applies the specified resource requests and limits to the backend and the {gitops-shortname} plugin components.
 

--- a/modules/gitops-enabling-the-round-robin-sharding-algorithm-in-web-console.adoc
+++ b/modules/gitops-enabling-the-round-robin-sharding-algorithm-in-web-console.adoc
@@ -23,7 +23,8 @@ You can enable the `round-robin` sharding algorithm by using the {OCP} web conso
 
 . Click the *YAML* tab and edit the YAML file as shown in the following example:
 +
-.Example Argo CD instance with round-robin sharding algorithm enabled
+--
+*Example Argo CD instance with round-robin sharding algorithm enabled:*
 [source,yaml]
 ----
 apiVersion: argoproj.io/v1beta1
@@ -41,6 +42,7 @@ spec:
         value: round-robin
     logLevel: debug
 ----
+--
 +
 --
 where:
@@ -73,7 +75,8 @@ If you edit the default `openshift-gitops` instance, the *Managed resource* dial
 
 .. Click on the controller pod you want to examine and go to the *Logs* tab to view the pod logs.
 +
-.Example controller pod logs snippet
+--
+*Example controller pod logs snippet:*
 [source,terminal]
 ----
 time="2023-12-13T09:05:34Z" level=info msg="ArgoCD Application Controller is starting" built="2023-12-01T19:21:49Z" commit=a3vd5c3df52943a6fff6c0rg181fth3248976299 namespace=openshift-gitops version=v2.9.2+c5ea5c4
@@ -82,8 +85,11 @@ time="2023-12-13T09:05:34Z" level=info msg="Using filter function:  round-robin"
 time="2023-12-13T09:05:34Z" level=info msg="Using filter function:  round-robin"
 time="2023-12-13T09:05:34Z" level=info msg="appResyncPeriod=3m0s, appHardResyncPeriod=0s"
 ----
+--
 +
+--
 Look for the `"Using filter function:  round-robin"` message.
+--
 
 .. In the log *Search* field, search for `processed by shard` to verify that the cluster distribution across shards is even, as shown in the following example.
 +
@@ -92,7 +98,8 @@ Look for the `"Using filter function:  round-robin"` message.
 Ensure that you set the log level to `debug` to observe these logs.
 ====
 +
-.Example controller pod logs snippet
+--
+*Example controller pod logs snippet:*
 [source,terminal]
 ----
 time="2023-12-13T09:05:34Z" level=debug msg="ClustersList has 3 items"
@@ -103,8 +110,11 @@ time="2023-12-13T09:05:34Z" level=debug msg="Cluster with id= will be processed 
 time="2023-12-13T09:05:34Z" level=debug msg="Cluster with id=068d8b26-6rhi-4w23-jrf6-wjjfyw833n23 will be processed by shard 1"
 time="2023-12-13T09:05:34Z" level=debug msg="Cluster with id=836d8b53-96k4-f68r-8wq0-sh72j22kl90w will be processed by shard 2"
 ----
+--
 +
+--
 In this example, 3 clusters are attached consecutively to shard 0, shard 1, and shard 2.
+--
 +
 [NOTE]
 ====

--- a/modules/gitops-enabling-the-round-robin-sharding-algorithm-using-cli.adoc
+++ b/modules/gitops-enabling-the-round-robin-sharding-algorithm-using-cli.adoc
@@ -21,11 +21,13 @@ You can enable the `round-robin` sharding algorithm by using the command-line in
 $ oc patch argocd <argocd_instance> -n <namespace> --patch='{"spec":{"controller":{"sharding":{"enabled":true,"replicas":<value>}}}}' --type=merge
 ----
 +
-.Example output
+--
+*Example output:*
 [source,terminal]
 ----
 argocd.argoproj.io/<argocd_instance> patched
 ----
+--
 
 . Configure the sharding algorithm to `round-robin` by running the following command:
 +
@@ -34,11 +36,13 @@ argocd.argoproj.io/<argocd_instance> patched
 $ oc patch argocd <argocd_instance> -n <namespace> --patch='{"spec":{"controller":{"env":[{"name":"ARGOCD_CONTROLLER_SHARDING_ALGORITHM","value":"round-robin"}]}}}' --type=merge
 ----
 +
-.Example output
+--
+*Example output:*
 [source,terminal]
 ----
 argocd.argoproj.io/<argocd_instance> patched
 ----
+--
 
 . Verify that the number of Argo CD Application Controller pods corresponds with the number of set replicas by running the following command:
 +
@@ -47,7 +51,8 @@ argocd.argoproj.io/<argocd_instance> patched
 $ oc get pods -l app.kubernetes.io/name=<argocd_instance>-application-controller -n <namespace>
 ----
 +
-.Example output
+--
+*Example output:*
 [source,terminal]
 ----
 NAME                                        READY   STATUS    RESTARTS   AGE
@@ -55,15 +60,19 @@ NAME                                        READY   STATUS    RESTARTS   AGE
 <argocd_instance>-application-controller-1   1/1     Running   0          32s
 <argocd_instance>-application-controller-2   1/1     Running   0          22s
 ----
+--
 
 . Verify that the sharding is enabled with `round-robin` as the sharding algorithm by running the following command:
 +
+--
 [source,terminal]
 ----
 $ oc logs <argocd_application_controller_pod> -n <namespace>
 ----
+--
 +
-.Example output snippet
+--
+*Example output snippet:*
 [source,terminal]
 ----
 time="2023-12-13T09:05:34Z" level=info msg="ArgoCD Application Controller is starting" built="2023-12-01T19:21:49Z" commit=a3vd5c3df52943a6fff6c0rg181fth3248976299 namespace=<namespace> version=v2.9.2+c5ea5c4
@@ -72,6 +81,7 @@ time="2023-12-13T09:05:34Z" level=info msg="Using filter function:  round-robin"
 time="2023-12-13T09:05:34Z" level=info msg="Using filter function:  round-robin"
 time="2023-12-13T09:05:34Z" level=info msg="appResyncPeriod=3m0s, appHardResyncPeriod=0s"
 ----
+--
 +
 --
 Verify that the `"Using filter function:  round-robin"` message appears in the output. This message confirms that the Argo CD Application Controller is using the `round-robin` sharding algorithm.
@@ -86,11 +96,13 @@ Verify that the `"Using filter function:  round-robin"` message appears in the o
 $ oc patch argocd <argocd_instance> -n <namespace> --patch='{"spec":{"controller":{"logLevel":"debug"}}}' --type=merge
 ----
 +
-.Example output
+--
+*Example output:*
 [source,terminal]
 ----
 argocd.argoproj.io/<argocd_instance> patched
 ----
+--
 
 .. View the logs and search for `processed by shard` to observe to which shard each cluster is attached by running the following command:
 +
@@ -99,15 +111,19 @@ argocd.argoproj.io/<argocd_instance> patched
 $ oc logs <argocd_application_controller_pod> -n <namespace> | grep "processed by shard"
 ----
 +
-.Example output snippet
+--
+*Example output snippet:*
 [source,terminal]
 ----
 time="2023-12-13T09:05:34Z" level=debug msg="Cluster with id= will be processed by shard 0"
 time="2023-12-13T09:05:34Z" level=debug msg="Cluster with id=068d8b26-6rhi-4w23-jrf6-wjjfyw833n23 will be processed by shard 1"
 time="2023-12-13T09:05:34Z" level=debug msg="Cluster with id=836d8b53-96k4-f68r-8wq0-sh72j22kl90w will be processed by shard 2"
 ----
+--
 +
+--
 In this example, 3 clusters are attached consecutively to shard 0, shard 1, and shard 2.
+--
 +
 [NOTE]
 ====

--- a/modules/gitops-installing-argo-rollouts-cli-on-linux.adoc
+++ b/modules/gitops-installing-argo-rollouts-cli-on-linux.adoc
@@ -47,7 +47,8 @@ Ensure that you have superuser privileges to run this command.
 $ oc argo rollouts version
 ----
 +
-.Example output
+--
+*Example output:*
 [source,terminal]
 ----
 kubectl-argo-rollouts: v1.6.6+737ca89
@@ -58,6 +59,7 @@ kubectl-argo-rollouts: v1.6.6+737ca89
   Compiler: gc
   Platform: linux/amd64
 ----
+--
 +
 --
 where:

--- a/modules/gitops-installing-argocd-agent-in-managed-mode-by-using-helm-chart.adoc
+++ b/modules/gitops-installing-argocd-agent-in-managed-mode-by-using-helm-chart.adoc
@@ -48,11 +48,12 @@ where:
 $ oc apply -f network-policy.yaml -n "<agent_namespace>" --context "<agent_context>"
 ----
 +
+--
 where:
 
 `agent_namespace`:: Specifies the namespace where the network policy is created.
 `agent_context`:: Ensures that the command runs against the Agent cluster and not on the hub cluster.
-
+--
 . Add the {OCP} Helm chart repository by running the following command:
 +
 [source,terminal]

--- a/modules/gitops-installing-argocd-cli-on-linux-using-rpm.adoc
+++ b/modules/gitops-installing-argocd-cli-on-linux-using-rpm.adoc
@@ -52,11 +52,13 @@ For {op-system-base-full} version 8 or later, you can install the {gitops-shortn
 # subscription-manager repos --enable="gitops-<gitops_version>-for-rhel-<rhel_version>-x86_64-rpms"
 ----
 +
-.Example command
+--
+*Example command:*
 [source,terminal,subs="attributes+"]
 ----
 # subscription-manager repos --enable="gitops-{gitops-ver}-for-rhel-8-x86_64-rpms"
 ----
+--
 // Update the gitops version attribute value for every release
 +
 * Linux on {ibmzProductName} and {linuxoneProductName} (s390x)
@@ -66,11 +68,13 @@ For {op-system-base-full} version 8 or later, you can install the {gitops-shortn
 # subscription-manager repos --enable="gitops-<gitops_version>-for-rhel-<rhel_version>-s390x-rpms"
 ----
 +
-.Example command
+--
+*Example command:*
 [source,terminal,subs="attributes+"]
 ----
 # subscription-manager repos --enable="gitops-{gitops-ver}-for-rhel-8-s390x-rpms"
 ----
+--
 // Update the gitops version attribute value for every release
 +
 * Linux on {ibmpowerProductName} (ppc64le)
@@ -80,11 +84,13 @@ For {op-system-base-full} version 8 or later, you can install the {gitops-shortn
 # subscription-manager repos --enable="gitops-<gitops_version>-for-rhel-<rhel_version>-ppc64le-rpms"
 ----
 +
-.Example command
+--
+*Example command:*
 [source,terminal,subs="attributes+"]
 ----
 # subscription-manager repos --enable="gitops-{gitops-ver}-for-rhel-8-ppc64le-rpms"
 ----
+--
 // Update the gitops version attribute value for every release
 +
 * Linux on ARM (aarch64, arm64)
@@ -94,11 +100,13 @@ For {op-system-base-full} version 8 or later, you can install the {gitops-shortn
 # subscription-manager repos --enable="gitops-<gitops_version>-for-rhel-<rhel_version>-aarch64-rpms"
 ----
 +
-.Example command
+--
+*Example command:*
 [source,terminal,subs="attributes+"]
 ----
 # subscription-manager repos --enable="gitops-{gitops-ver}-for-rhel-8-aarch64-rpms"
 ----
+--
 // Update the gitops version attribute value for every release
 
 . Install the `openshift-gitops-argocd-cli` package by running the following command:
@@ -115,7 +123,8 @@ For {op-system-base-full} version 8 or later, you can install the {gitops-shortn
 $ argocd version --client
 ----
 +
-.Example output
+--
+*Example output:*
 [source,terminal]
 ----
 argocd: v2.9.5+f943664
@@ -127,10 +136,10 @@ argocd: v2.9.5+f943664
   Platform: linux/amd64
   ExtraBuildInfo: openshift-gitops-version: 1.12.0, release: 0015022024
 ----
+--
 +
 --
 where:
 
 `ExtraBuildInfo: openshift-gitops-version`:: Specifies the build information of {gitops-title} built by Red Hat.
 --
-

--- a/modules/gitops-installing-argocd-cli-on-linux.adoc
+++ b/modules/gitops-installing-argocd-cli-on-linux.adoc
@@ -55,7 +55,8 @@ $ sudo chmod +x /usr/local/bin/argocd
 $ argocd version --client
 ----
 +
-.Example output
+--
+*Example output:*
 [source,terminal]
 ----
 argocd: v2.9.5+f943664
@@ -67,6 +68,7 @@ argocd: v2.9.5+f943664
   Platform: linux/amd64
   ExtraBuildInfo: openshift-gitops-version: 1.12.0, release: 0015022024
 ----
+--
 +
 --
 where:

--- a/modules/gitops-installing-argocd-cli-on-macos.adoc
+++ b/modules/gitops-installing-argocd-cli-on-macos.adoc
@@ -53,7 +53,8 @@ $ sudo chmod +x /usr/local/bin/argocd
 $ argocd version --client
 ----
 +
-.Example output
+--
+*Example output:*
 [source,terminal]
 ----
 argocd: v2.9.5+f943664
@@ -65,6 +66,7 @@ argocd: v2.9.5+f943664
   Platform: linux/amd64
   ExtraBuildInfo: openshift-gitops-version: 1.12.0, release: 0015022024
 ----
+--
 +
 --
 where:

--- a/modules/gitops-installing-argocd-cli-on-windows.adoc
+++ b/modules/gitops-installing-argocd-cli-on-windows.adoc
@@ -40,7 +40,8 @@ C:\> move argocd.exe <directory>
 $ argocd version --client
 ----
 +
-.Example output
+--
+*Example output:*
 [source,terminal]
 ----
 argocd: v2.9.5+f943664
@@ -52,6 +53,7 @@ argocd: v2.9.5+f943664
   Platform: linux/amd64
   ExtraBuildInfo: openshift-gitops-version: 1.12.0, release: 0015022024
 ----
+--
 +
 --
 where:

--- a/modules/gitops-installing-olm-operators-using-gitops.adoc
+++ b/modules/gitops-installing-olm-operators-using-gitops.adoc
@@ -19,7 +19,7 @@ Operator Lifecycle Manager (OLM) uses a default `global-operators` Operator grou
 
 To install cluster-scoped Operators, create and place the `Subscription` resource of the required Operator in your Git repository.
 
-.Example: Grafana Operator subscription
+*Example: Grafana Operator subscription:*
 
 [source,yaml]
 ----
@@ -40,7 +40,7 @@ spec:
 
 To install namespace-scoped Operators, create and place the `Subscription` and `OperatorGroup` resources of the required Operator in your Git repository.
 
-.Example: Ansible Automation Platform Resource Operator
+*Example: Ansible Automation Platform Resource Operator:*
 
 [source,yaml]
 ----

--- a/modules/gitops-installing-the-vault-csi-provider-using-gitops.adoc
+++ b/modules/gitops-installing-the-vault-csi-provider-using-gitops.adoc
@@ -22,7 +22,8 @@ Install the Vault CSI provider by deploying an Argo CD Application that uses Has
 
 .. Create an Argo CD Application resource to deploy the Vault CSI provider. Add this resource to your {gitops-shortname} repository, for example, `config/argocd/vault-secret-provider-app.yaml`:
 +
-.Example `vault-secret-provider-app.yaml` file
+--
+*Example `vault-secret-provider-app.yaml` file:*
 [source,yaml]
 ----
 apiVersion: argoproj.io/v1alpha1
@@ -63,6 +64,7 @@ spec:
       - /spec/template/spec/containers/0/securityContext/privileged
 
 ----
+--
 +
 [NOTE]
 ====

--- a/modules/gitops-manually-aborting-the-rollout.adoc
+++ b/modules/gitops-manually-aborting-the-rollout.adoc
@@ -29,11 +29,13 @@ where:
 `<namespace>`:: Specifies the namespace where the `Rollout` custom resource (CR) is defined.
 --
 +
-.Example output
+--
+*Example output:*
 [source,terminal]
 ----
 rollout "rollouts-demo" image updated
 ----
+--
 +
 The container image deployed in the rollout is modified and the rollout initiates a new canary deployment.
 
@@ -52,7 +54,8 @@ where:
 `<namespace>`:: Specifies the namespace where the `Rollout` CR is defined.
 --
 +
-.Example output
+--
+*Example output:*
 [source,terminal]
 ----
 Name:            rollouts-demo
@@ -86,7 +89,7 @@ NAME                                       KIND        STATUS        AGE    INFO
 └──# revision:1                                                             
    └──⧉ rollouts-demo-687d76d795           ReplicaSet  • ScaledDown  17m   
 ----
-
+--
 . Abort the update of the rollout by running the following command:
 +
 [source,terminal]
@@ -100,11 +103,13 @@ where:
 `<namespace>`:: Specifies the namespace where the `Rollout` CR is defined.
 --
 +
-.Example output
+--
+*Example output:*
 [source,terminal]
 ----
 rollout 'rollouts-demo' aborted
 ----
+--
 +
 The Argo Rollouts controller deletes the canary resources of the application, and rolls back to the stable version. 
 
@@ -121,7 +126,8 @@ where:
 `<namespace>`:: Specifies the namespace where the `Rollout` CR is defined.
 --
 +
-.Example output
+--
+*Example output:*
 [source,terminal]
 ----
 Name:            rollouts-demo
@@ -154,6 +160,7 @@ NAME                                       KIND        STATUS        AGE    INFO
 └──# revision:1                                                             
    └──⧉ rollouts-demo-687d76d795           ReplicaSet  • ScaledDown  24m 
 ----
+--
 +
 The rollout status is marked as `Degraded` indicating that even though the application has rolled back to the previous stable version, `yellow`, the rollout is not currently at the wanted version, `red`, that was set within the `.spec.template.spec.containers.image` field. 
 +
@@ -175,11 +182,13 @@ where:
 `<namespace>`:: Specifies the namespace where the `Rollout` CR is defined.
 --
 +
-.Example output
+--
+*Example output:*
 [source,terminal]
 ----
 rollout "rollouts-demo" image updated
 ----
+--
 +
 The rollout skips the analysis and promotion steps, rolls back to the previous stable version, `yellow`, and fast-tracks the deployment of the stable `ReplicaSet`.
 
@@ -196,7 +205,8 @@ where:
 `<namespace>`:: Specifies the namespace where the `Rollout` CR is defined.
 --
 +
-.Example output
+--
+*Example output:*
 [source,terminal]
 ----
 Name:            rollouts-demo
@@ -228,3 +238,4 @@ NAME                                       KIND        STATUS        AGE  INFO
 └──# revision:1                                                           
    └──⧉ rollouts-demo-687d76d795           ReplicaSet  • ScaledDown  63m 
 ----
+--

--- a/modules/gitops-monitoring-argo-cd-health-using-prometheus-metrics.adoc
+++ b/modules/gitops-monitoring-argo-cd-health-using-prometheus-metrics.adoc
@@ -14,7 +14,7 @@ You can monitor the health status of an Argo CD application by running Prometheu
 . From the *Select query* drop-down list, select *Custom query*.
 . To check the health status of your Argo CD application, enter the Prometheus Query Language (PromQL) query similar to the following example in the *Expression* field:
 +
-.Example
+*Example:*
 [source, terminal]
 ----
 sum(argocd_app_info{dest_namespace=~"<your_defined_namespace>",health_status!=""}) by (health_status)

--- a/modules/gitops-promoting-the-rollout.adoc
+++ b/modules/gitops-promoting-the-rollout.adoc
@@ -23,11 +23,14 @@ where:
 `<namespace>`:: Specifies the namespace where the `Rollout` resource is defined.
 --
 +
-.Example output
+--
+*Example output:*
 [source,terminal]
 ----
 rollout 'rollouts-demo' promoted
 ----
+--
++
 This increases the traffic weight to 40% in the canary version.
 
 . Verify that the rollout progresses through the rest of the steps, by running the following command: 
@@ -47,7 +50,8 @@ Because the rest of the steps as defined in the `Rollout` CR have set durations,
 +
 After all steps are completed successfully, the new `ReplicaSet` object is marked as the stable replica set.
 +
-.Example output
+--
+*Example output:*
 [source,terminal]
 ----
 Name:            rollouts-demo
@@ -77,3 +81,4 @@ NAME                                       KIND        STATUS        AGE   INFO
 └──# revision:1                                                            
    └──⧉ rollouts-demo-687d76d795           ReplicaSet  • ScaledDown  14m    
 ----
+--

--- a/modules/gitops-storing-aws-secret-manager-resources-in-gitops-repository.adoc
+++ b/modules/gitops-storing-aws-secret-manager-resources-in-gitops-repository.adoc
@@ -39,7 +39,8 @@ The AWS Secrets Manager provider for the SSCSI driver is an upstream provider.
 This configuration is modified from the configuration provided in the upstream link:https://github.com/aws/secrets-store-csi-driver-provider-aws#installing-the-aws-provider[AWS documentation] so that it works properly with {OCP}. Changes to this configuration might impact functionality.
 ====
 +
-.Example `aws-provider.yaml` file
+--
+*Example `aws-provider.yaml` file:*
 [source,yaml]
 ----
 apiVersion: v1
@@ -133,10 +134,12 @@ spec:
       nodeSelector:
         kubernetes.io/os: linux
 ----
+--
 
 .. Add a `secret-provider-app.yaml` file in your {gitops-shortname} repository to create an application and deploy resources for AWS Secrets Manager:
 +
-.Example `secret-provider-app.yaml` file
+--
+*Example `secret-provider-app.yaml` file:*
 [source,yaml]
 ----
 apiVersion: argoproj.io/v1alpha1
@@ -157,6 +160,7 @@ spec:
     prune: true
     selfHeal: true
 ----
+--
 +
 --
 where:
@@ -175,12 +179,13 @@ $ oc label namespace openshift-cluster-csi-drivers argocd.argoproj.io/managed-by
 
 .. Apply the resources in your {gitops-shortname} repository to your cluster, including the `aws-provider.yaml` file you just pushed:
 +
-.Example output
+--
+*Example output:*
 [source,terminal]
 ----
 application.argoproj.io/argo-app created
 application.argoproj.io/secret-provider-app created
 ...
 ----
-
+--
 In the Argo CD UI, you can observe that the `csi-secrets-store-provider-aws` daemonset continues to synchronize resources. To resolve this issue, you must configure the SSCSI driver to mount secrets from the AWS Secrets Manager.

--- a/modules/gitops-updating-the-rollout.adoc
+++ b/modules/gitops-updating-the-rollout.adoc
@@ -22,7 +22,8 @@ The container image deployed in the rollout is modified and the rollout initiate
 As per the `setWeight` property defined in the `.spec.strategy.canary.steps` field of the `Rollout` CR, initially 20% of traffic to the route reaches the canary version and the rollout is paused indefinitely until a request for promotion is received.
 ====
 +
-.Example route with 20% of traffic directed to the canary version and rollout is paused indefinitely until a request for promotion is specified in the subsequent step
+--
+*Example route with 20% of traffic directed to the canary version and rollout is paused indefinitely until a request for promotion is specified in the subsequent step:*
 [source,yaml]
 ----
 spec:
@@ -34,6 +35,7 @@ spec:
       - pause: {}
   # (...)
 ----
+--
 +
 --
 where:
@@ -57,7 +59,8 @@ where:
 `<namespace>`:: Specifies the namespace where the `Rollout` CR is defined.
 --
 +
-.Example output
+--
+*Example output:*
 [source,terminal]
 ----
 Name:            rollouts-demo
@@ -89,6 +92,7 @@ NAME                                       KIND        STATUS     AGE    INFO
       ├──□ rollouts-demo-687d76d795-rsgtv  Pod         ✔ Running  9m50s  ready:1/1
       └──□ rollouts-demo-687d76d795-xrmrj  Pod         ✔ Running  9m50s  ready:1/1
 ----
+--
 +
 The rollout is now in a paused status, because there is no pause duration specified in the rollout's update strategy configuration.
 

--- a/modules/go-deleting-argocd-instance.adoc
+++ b/modules/go-deleting-argocd-instance.adoc
@@ -10,7 +10,7 @@ Delete the Argo CD instances added to the namespace of the GitOps Operator.
 
 [discrete]
 .Procedure
-. In the *Terminal* type the following command:
+* In the *Terminal* type the following command:*
 
 [source,terminal]
 ----

--- a/modules/go-run-argo-cd-instance-on-infrastructure-nodes.adoc
+++ b/modules/go-run-argo-cd-instance-on-infrastructure-nodes.adoc
@@ -8,7 +8,6 @@
 
 The default Argo CD instance and the accompanying controllers, installed by the {gitops-title} Operator, can now run on the infrastructure nodes of the cluster by setting a simple configuration toggle.
 
-[discrete]
 .Procedure
 . Label the existing nodes:
 +
@@ -37,7 +36,8 @@ spec:
 ----
 . Optional: If taints have been added to the nodes, then add `tolerations` to the `GitOpsService` custom resource.
 +
-.Example
+--
+*Example:*
 [source,yaml]
 ----
 apiVersion: pipelines.openshift.io/v1alpha1
@@ -54,6 +54,8 @@ metadata:
       key: infra
       value: reserved
 ----
+--
+
 . Verify that the workloads in the `openshift-gitops` namespace are now scheduled on the infrastructure nodes by viewing *Pods* -> *Pod details* for any pod in the console UI.
 
 [NOTE]

--- a/modules/go-settings-for-environment-labels-and-annotations.adoc
+++ b/modules/go-settings-for-environment-labels-and-annotations.adoc
@@ -13,7 +13,7 @@ This section provides reference settings for environment labels and annotations 
 
 The environment application manifest must contain `labels.openshift.gitops/environment` and `destination.namespace` fields. You must set identical values for the `<environment_name>` variable and the name of the environment application manifest.
 
-.Specification of the environment application manifest
+*Specification of the environment application manifest:*
 [source,yaml]
 ----
 spec:
@@ -24,7 +24,7 @@ spec:
 # ...
 ----  
 
-.Example of an environment application manifest
+*Example of an environment application manifest:*
 [source,yaml]
 ----
 apiVersion: argoproj.io/v1beta1
@@ -50,7 +50,7 @@ where:
 == Environment annotations
 The environment namespace manifest must contain the `annotations.app.openshift.io/vcs-uri` and `annotations.app.openshift.io/vcs-ref` fields to specify the version controller code source of the application. You must set identical values for the `<environment_name>` variable and the name of the environment namespace manifest.
 
-.Specification of the environment namespace manifest
+*Specification of the environment namespace manifest:*
 [source,yaml]
 ----
 apiVersion: v1
@@ -69,7 +69,7 @@ where:
 `<metadata.name>`:: Specifies the name of the environment namespace manifest. The value set is the same as the value of the `<environment_name>` variable.
 --
 
-.Example of an environment namespace manifest
+*Example of an environment namespace manifest:*
 [source,yaml]
 ----
 apiVersion: v1

--- a/modules/installing-gitops-operator-in-web-console.adoc
+++ b/modules/installing-gitops-operator-in-web-console.adoc
@@ -38,7 +38,7 @@ You can enable cluster monitoring on any namespace by applying the `openshift.io
 $ oc label namespace <namespace> openshift.io/cluster-monitoring=true
 ----
 
-.Example output
+*Example output:*
 [source,terminal]
 ----
 namespace/<namespace> labeled

--- a/modules/installing-gitops-operator-using-cli.adoc
+++ b/modules/installing-gitops-operator-using-cli.adoc
@@ -28,31 +28,34 @@ For the {gitops-shortname} version 1.10 and later, the default namespace changed
 $ oc create ns openshift-gitops-operator
 ----
 +
-.Example output
+--
+*Example output:*
 [source,terminal]
 ----
 namespace/openshift-gitops-operator created
 ----
+--
 +
+--
 [NOTE]
 ====
 You can enable cluster monitoring on `openshift-gitops-operator`, or any namespace, by applying the `openshift.io/cluster-monitoring=true` label:
-
+====
 [source,terminal]
 ----
 $ oc label namespace <namespace> openshift.io/cluster-monitoring=true
 ----
-
-.Example output
+*Example output:*
 [source,terminal]
 ----
 namespace/<namespace> labeled
 ----
-====
+--
 
 . Create a `OperatorGroup` object YAML file, for example, `gitops-operator-group.yaml`:
 +
-.Example OperatorGroup
+--
+*Example OperatorGroup:*
 [source,yaml]
 ----
 apiVersion: operators.coreos.com/v1
@@ -63,6 +66,7 @@ metadata:
 spec:
   upgradeStrategy: Default
 ----
+--
 
 . Apply the `OperatorGroup` to the cluster:
 +
@@ -71,15 +75,17 @@ spec:
 $ oc apply -f gitops-operator-group.yaml
 ----
 +
-.Example output
+--
+*Example output:*
 [source,terminal]
 ----
 operatorgroup.operators.coreos.com/openshift-gitops-operator created
 ----
-
+--
 . Create a `Subscription` object YAML file to subscribe a namespace to the {gitops-title} Operator, for example, `openshift-gitops-sub.yaml`:
 +
-.Example Subscription
+--
+*Example Subscription:*
 [source,yaml]
 ----
 apiVersion: operators.coreos.com/v1alpha1
@@ -94,6 +100,7 @@ spec:
   source: redhat-operators
   sourceNamespace: openshift-marketplace
 ----
+--
 +
 --
 where:
@@ -111,11 +118,13 @@ where:
 $ oc apply -f openshift-gitops-sub.yaml
 ----
 +
-.Example output
+--
+*Example output:*
 [source,terminal]
 ----
 subscription.operators.coreos.com/openshift-gitops-operator created
 ----
+--
 
 . After the installation is complete, verify that all the pods in the `openshift-gitops` namespace are running:
 +
@@ -124,7 +133,8 @@ subscription.operators.coreos.com/openshift-gitops-operator created
 $ oc get pods -n openshift-gitops
 ----
 +
-.Example output
+--
+*Example output:*
 [source,terminal]
 ----
 NAME                                                      	  READY   STATUS    RESTARTS   AGE
@@ -137,6 +147,7 @@ openshift-gitops-redis-6d65c94d4b-k9l8k                       1/1     Running   
 openshift-gitops-repo-server-79db854c58-279jr                 1/1     Running   0          75s
 openshift-gitops-server-f488b848-xntbc                        1/1     Running   0          75s
 ----
+--
 
 . Verify that the pods in the `openshift-gitops-operator` namespace are running:
 +
@@ -145,10 +156,11 @@ openshift-gitops-server-f488b848-xntbc                        1/1     Running   
 $ oc get pods -n openshift-gitops-operator
 ----
 +
-.Example output
+--
+*Example output:*
 [source,terminal]
 ----
 NAME                                                            READY   STATUS    RESTARTS   AGE
 openshift-gitops-operator-controller-manager-6fdc5cd9dc-jr9mn   2/2     Running   0          41s
 ----
-
+--

--- a/modules/moving-the-gitops-operator-pod-to-infrastructure-nodes.adoc
+++ b/modules/moving-the-gitops-operator-pod-to-infrastructure-nodes.adoc
@@ -27,12 +27,13 @@ where:
 `<node_name>`:: Specifies the name of the node you want to label as infrastructure node.
 --
 +
-.Example output
+--
+*Example output:*
 [source,terminal]
 ----
 node/<node_name> labeled
 ----
-
+--
 . Edit the {gitops-title} `Subscription` resource by running the following command:
 +
 [source,terminal]
@@ -42,7 +43,8 @@ $ oc -n openshift-gitops-operator edit subscription openshift-gitops-operator
 
 . Add `nodeSelector` and `tolerations` to the `spec.config` field in the `Subscription` resource:
 +
-.Example Subscription
+--
+*Example Subscription:*
 [source,yaml]
 ----
 apiVersion: operators.coreos.com/v1alpha1
@@ -59,6 +61,7 @@ spec:
       operator: Exists
       effect: NoSchedule
 ----
+--
 +
 --
 where:
@@ -67,11 +70,13 @@ where:
 `<metadata.namespace>`:: Defines the namespace of the pod to be accepted by the infrastructure node.
 --
 +
-.Example output
+--
+*Example output:*
 [source,terminal]
 ----
 subscription.operators.coreos.com/openshift-gitops-operator edited
 ----
+--
 
 . Verify that the {gitops-shortname} Operator pod is running on the infrastructure node by running the following command:
 +
@@ -80,11 +85,15 @@ subscription.operators.coreos.com/openshift-gitops-operator edited
 $ oc -n openshift-gitops-operator get po -owide
 ----
 +
-.Example output
+--
+*Example output:*
 [source,terminal]
 ----
 NAME                                                            READY   STATUS    RESTARTS   AGE   IP              NODE            NOMINATED NODE   READINESS GATES
 openshift-gitops-operator-controller-manager-abcd               2/2     Running   0          11m   94.142.44.126   <node_name>     <none>           <none>
 ----
+--
 +
+--
 Ensure that the listed `<node_name>` is the node with the `node-role.kubernetes.io/infra` label.
+--

--- a/modules/proc_configuring-annotation-based-tracking-in-multiple-argo-cd-instances.adoc
+++ b/modules/proc_configuring-annotation-based-tracking-in-multiple-argo-cd-instances.adoc
@@ -35,7 +35,8 @@ When you follow these steps, replace the example values with the actual values.
 
 . To create two Argo CD instances, click *Create ArgoCD* and create two YAML files similar to the following examples:
 +
-.Example first Argo CD instance with an annotation label
+--
+*Example first Argo CD instance with an annotation label:*
 [source,yaml]
 ----
 apiVersion: argoproj.io/v1beta1
@@ -47,6 +48,7 @@ spec:
   installationID: "instance-demo-1"
   resourceTrackingMethod: "annotation+label"
 ----
+--
 +
 --
 where:
@@ -56,7 +58,8 @@ where:
 `spec.installationID`:: Specifies the name of the `installationID` object for the first Argo CD instance.
 --
 +
-.Example second Argo CD instance with an annotation label
+--
+*Example second Argo CD instance with an annotation label:*
 [source,yaml]
 ----
 apiVersion: argoproj.io/v1beta1
@@ -68,6 +71,7 @@ spec:
   installationID: "instance-demo-2"
   resourceTrackingMethod: "annotation+label"
 ----
+--
 +
 --
 where:
@@ -83,26 +87,31 @@ where:
 .. Associate each namespace with their respective Argo CD instance:
 ... Associate the `app-ns-1` namespace with the `argocd-test-demo-1` Argo CD instance by running the following command: 
 +
-.Example command
+--
+*Example command:*
 [source,terminal]
 ----
 $ oc label namespace app-ns-1 argocd.argoproj.io/managed-by=argocd-test-demo-1
 ----
+--
 ... Associate the `app-ns-2` namespace with the `argocd-test-demo-2` Argo CD instance by running the following command: 
 +
-.Example command
+--
+*Example command:*
 [source,terminal]
 ----
 $ oc label namespace app-ns-2 argocd.argoproj.io/managed-by=argocd-test-demo-2
 ----
-+
+--
+
 . Create two applications in Argo CD.
 .. In the {OCP} web console, go to *Operators* -> *Installed Operators* -> *OpenShift GitOps Operator*.
 .. Select *Argo CD* and navigate to the *Applications* tab.
 .. Click *Create Application*.
 .. Enter the following YAML snippet to create two applications in Argo CD.
 +
-.Example first application using Argo CD
+--
+*Example first application using Argo CD:*
 [source,yaml]
 ----
 apiVersion: argoproj.io/v1alpha1
@@ -122,6 +131,7 @@ spec:
   syncPolicy:
     automated: {}
 ----
+--
 +
 --
 where:
@@ -130,7 +140,8 @@ where:
 `metadata.namespace`:: Specifies the namespace used for the first application.
 --
 +
-.Example second application using Argo CD
+--
+*Example second application using Argo CD:*
 [source,yaml]
 ----
 apiVersion: argoproj.io/v1alpha1
@@ -150,6 +161,7 @@ spec:
   syncPolicy:
     automated: {}
 ----
+--
 +
 --
 where:
@@ -159,6 +171,7 @@ where:
 --
 
 .Verification
+
 . Navigate to *Workloads* -> *Pods* in the {OCP} web console.
 . Ensure that the pods for Argo CD instances `argocd-instance-demo-1` and `argocd-instance-demo-2` are running.
 . Check the application synchronization status in the *Argo CD Applications* YAML tab.

--- a/modules/proc_configuring-by-using-the-ocp-web-console.adoc
+++ b/modules/proc_configuring-by-using-the-ocp-web-console.adoc
@@ -21,13 +21,15 @@ You can configure the `NotificationsConfiguration` custom resource (CR) by using
 . On the *NotificationsConfigurations* page, click `default-notifications-configuration`. 
 . On the *default-notifications-configuration* page, click *YAML* and add the configuration for any supported resources such as `templates`, `triggers`, `services`, and `subscriptions`. For example, under `templates` in the code, add the following sample configuration:
 +
-.Example template configuration
+--
+*Example template configuration:*
 [source,yaml]
 ----
   template.my-custom-template: |
     message: |
     Application details: {{.context.argocdUrl}}/applications/{{.app.metadata.name}}.
 ----
+--
 
 . Click *Save*.
 

--- a/modules/proc_configuring-notificationsconfiguration-crd-by-using-the-ocp-cli.adoc
+++ b/modules/proc_configuring-notificationsconfiguration-crd-by-using-the-ocp-cli.adoc
@@ -30,13 +30,15 @@ where:
 
 . Under the `templates` section of the CR, add a configuration similar to the following example:
 +
-.Example template configuration
+--
+*Example template configuration:*
 [source,yaml]
 ----
   template.my-custom-template: |
     message: |
     Application details: {{.context.argocdUrl}}/applications/{{.app.metadata.name}}.
 ----
+--
 
 . Verify the contents of the `argocd-notifications-cm` config map by running the following command:
 +

--- a/modules/sizing-requirements-for-gitops.adoc
+++ b/modules/sizing-requirements-for-gitops.adoc
@@ -42,7 +42,7 @@ The following command shows the example of the memory configuration for a Redis 
 $ oc get argocd -n openshift-gitops openshift-gitops -o json | jq '.spec.redis.resources'
 ----
 
-.Example Output
+*Example Output:*
 [source,terminal]
 ----
 {
@@ -72,7 +72,7 @@ $ oc patch argocd -n openshift-gitops openshift-gitops --type json -p '[{"op": "
   "/spec/redis/resources/requests/memory", "value": "256Mi"}]'
 ----
 
-.Example Output
+*Example Output:*
 [source,terminal]
 ----
 argocd.argoproj.io/openshift-gitops patched


### PR DESCRIPTION
This PR is not a feature request. It is a part of Phase 0 Dita migration tasks. It is related to fixing block titles in accordance with the DITA migration standards. Based on an analysis run by Claude, the affected files with incorrect block titles are fixed in this PR. As there are too many files fixed, I have only added a small number of preview links 
for reference.

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

gitops-docs-1.20, gitops-docs-1.19

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

https://issues.redhat.com/browse/RHDEVDOCS-7307#

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

[Configuring annotation-based tracking in multiple Argo CD instances](https://107452--ocpdocs-pr.netlify.app/openshift-gitops/latest/argocd_instance/argo-cd-cr-component-properties#configuring-annotation-based-tracking-in-multiple-argo-cd-instances_argo-cd-cr-component-properties)

[Creating a RolloutManager custom resource](https://107452--ocpdocs-pr.netlify.app/openshift-gitops/latest/argo_rollouts/using-argo-rollouts-for-progressive-deployment-delivery#gitops-creating-rolloutmanager-custom-resource_using-argo-rollouts-for-progressive-deployment-delivery)

[Configuring TLS for Redis with autotls disabled](https://107452--ocpdocs-pr.netlify.app/openshift-gitops/latest/securing_openshift_gitops/configuring-secure-communication-with-redis#gitops-configuring-tls-for-redis-with-autotls-disabled_configuring-secure-communication-with-redis)

Peer review:
- [ ] Peer has approved this change.
<!--- Peer approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
