### PR TITLE
[enterprise-4.16] Telcodocs 2645 416 cp fresh

### DIFF
--- a/modules/nw-ptp-introduction.adoc
+++ b/modules/nw-ptp-introduction.adoc
@@ -21,11 +21,3 @@ Grandmaster clock:: The grandmaster clock provides standard time information to 
 Boundary clock:: The boundary clock has ports in two or more communication paths and can be a source and a destination to other destination clocks at the same time. The boundary clock works as a destination clock upstream. The destination clock receives the timing message, adjusts for delay, and then creates a new source time signal to pass down the network. The boundary clock produces a new timing packet that is still correctly synced with the source clock and can reduce the number of connected devices reporting directly to the source clock.
 
 Ordinary clock:: The ordinary clock has a single port connection that can play the role of source or destination clock, depending on its position in the network. The ordinary clock can read and write timestamps.
-
-
-[id="ptp-advantages-over-ntp_{context}"]
-== Advantages of PTP over NTP
-
-One of the main advantages that PTP has over NTP is the hardware support present in various network interface controllers (NIC) and network switches. The specialized hardware allows PTP to account for delays in message transfer and improves the accuracy of time synchronization. To achieve the best possible accuracy, it is recommended that all networking components between PTP clocks are PTP hardware enabled.
-
-Hardware-based PTP provides optimal accuracy, since the NIC can timestamp the PTP packets at the exact moment they are sent and received. Compare this to software-based PTP, which requires additional processing of the PTP packets by the operating system.

--- a/modules/ptp-advantages-over-ntp.adoc
+++ b/modules/ptp-advantages-over-ntp.adoc
@@ -1,0 +1,37 @@
+// Module included in the following assemblies:
+//
+// * networking/ptp/about-ptp.adoc
+
+:_mod-docs-content-type: CONCEPT
+
+[id="ptp-advantages-over-ntp_{context}"]
+== Advantages of PTP over NTP
+
+One of the main advantages that PTP has over NTP is the hardware support present in various network interface controllers (NIC) and network switches. The specialized hardware allows PTP to account for delays in message transfer and improves the accuracy of time synchronization. To achieve the best possible accuracy, it is recommended that all networking components between PTP clocks are PTP hardware enabled.
+
+Hardware-based PTP provides optimal accuracy, since the NIC can timestamp the PTP packets at the exact moment they are sent and received. Compare this to software-based PTP, which requires additional processing of the PTP packets by the operating system.
+
+[IMPORTANT]
+====
+If your `openshift-sdn` cluster with PTP uses the User Datagram Protocol (UDP) for hardware time stamping and you migrate to the OVN-Kubernetes plugin, the hardware time stamping cannot be applied to primary interface devices, such as an Open vSwitch (OVS) bridge. As a result, UDP version 4 configurations cannot work with a `br-ex` interface.
+====
+
+You can configure `linuxptp` services and use PTP-capable hardware in {product-title} cluster nodes.
+
+Use the {product-title} web console or OpenShift CLI (`oc`) to install PTP by deploying the PTP Operator. The PTP Operator creates and manages the `linuxptp` services and provides the following features:
+
+* Discovery of the PTP-capable devices in the cluster.
+
+* Management of the configuration of `linuxptp` services.
+
+* Notification of PTP clock events that negatively affect the performance and reliability of your application with the PTP Operator `cloud-event-proxy` sidecar.
+
+[NOTE]
+====
+The PTP Operator works with PTP-capable devices on clusters provisioned only on bare-metal infrastructure.
+====
+
+[IMPORTANT]
+====
+Before enabling PTP, ensure that NTP is disabled for the required nodes. You can disable the chrony time service (`chronyd`) using a `MachineConfig` custom resource. For more information, see _Disabling chrony time service_.
+====

--- a/networking/ptp/about-ptp.adoc
+++ b/networking/ptp/about-ptp.adoc
@@ -6,36 +6,17 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 Precision Time Protocol (PTP) is used to synchronize clocks in a network. When used in conjunction with hardware support, PTP is capable of sub-microsecond accuracy, and is more accurate than Network Time Protocol (NTP).
-
-[IMPORTANT]
-====
-If your `openshift-sdn` cluster with PTP uses the User Datagram Protocol (UDP) for hardware time stamping and you migrate to the OVN-Kubernetes plugin, the hardware time stamping cannot be applied to primary interface devices, such as an Open vSwitch (OVS) bridge. As a result, UDP version 4 configurations cannot work with a `br-ex` interface.
-====
-
-You can configure `linuxptp` services and use PTP-capable hardware in {product-title} cluster nodes.
-
-Use the {product-title} web console or OpenShift CLI (`oc`) to install PTP by deploying the PTP Operator. The PTP Operator creates and manages the `linuxptp` services and provides the following features:
-
-* Discovery of the PTP-capable devices in the cluster.
-
-* Management of the configuration of `linuxptp` services.
-
-* Notification of PTP clock events that negatively affect the performance and reliability of your application with the PTP Operator `cloud-event-proxy` sidecar.
-
-[NOTE]
-====
-The PTP Operator works with PTP-capable devices on clusters provisioned only on bare-metal infrastructure.
-====
 
 include::modules/nw-ptp-introduction.adoc[leveloffset=+1]
 
-[IMPORTANT]
-====
-Before enabling PTP, ensure that NTP is disabled for the required nodes. You can disable the chrony time service (`chronyd`) using a `MachineConfig` custom resource. For more information, see xref:../../machine_configuration/machine-configs-configure.adoc#cnf-disable-chronyd_machine-configs-configure[Disabling chrony time service].
-====
-
 include::modules/ptp-linuxptp-introduction.adoc[leveloffset=+1]
+
+include::modules/ptp-advantages-over-ntp.adoc[leveloffset=+1]
+
+.Additional resources
+* xref:../../machine_configuration/machine-configs-configure.adoc#cnf-disable-chronyd_machine-configs-configure[Disabling chrony time service]
 
 include::modules/ptp-overview-of-gnss-grandmaster-clock.adoc[leveloffset=+1]
 


### PR DESCRIPTION
[TELCODOCS-2645]: [DITA compatibility fixes for PTP about-ptp assembly]

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.16
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:https://issues.redhat.com/browse/TELCODOCS-2645
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://107299--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/advanced_networking/ptp/about-ptp.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:

A very manual CP of https://github.com/openshift/openshift-docs/pull/106215 as to difficult to resolve otherwise.

- Add [role="_abstract"] to 6 PTP modules for DITA short description support
- Move IMPORTANT admonition about NTP failover from assembly into nw-ptp-introduction module
- Clean up Additional resources section in assembly to contain only links
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.---