### PR TITLE
CQA 2.1 (Feb 26) - CNV Nodes

### DIFF
--- a/virt/nodes/virt-activating-ksm.adoc
+++ b/virt/nodes/virt-activating-ksm.adoc
@@ -6,7 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-{VirtProductName} can activate kernel samepage merging (KSM) when nodes are overloaded. KSM deduplicates identical data found in the memory pages of virtual machines (VMs). If you have very similar VMs, KSM can make it possible to schedule more VMs on a single node.
+[role="_abstract"]
+{VirtProductName} can activate kernel samepage merging (KSM) when nodes are overloaded. KSM deduplicates same data found in the memory pages of virtual machines (VMs). If you have very similar VMs, KSM can make it possible to schedule more VMs on a single node.
 
 [IMPORTANT]
 ====
@@ -24,9 +25,9 @@ include::modules/virt-configure-ksm-web.adoc[leveloffset=+1]
 
 include::modules/virt-configure-ksm-cli.adoc[leveloffset=+1]
 
-[role="_additional-resources"]
 [id="additional-resources_{context}"]
+[role="_additional-resources"]
 == Additional resources
 * xref:../../virt/managing_vms/advanced_vm_management/virt-specifying-nodes-for-vms.adoc#virt-specifying-nodes-for-vms[Specifying nodes for virtual machines]
 * xref:../../nodes/scheduling/nodes-scheduler-node-selectors.adoc#nodes-scheduler-node-selectors[Placing pods on specific nodes using node selectors]
-* link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html-single/configuring_and_managing_virtualization/index#proc_managing-ksm_optimizing-virtual-machine-cpu-performance[Managing kernel samepage merging] in the {op-system-base-full} documentation
+* link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html-single/configuring_and_managing_virtualization/index#proc_managing-ksm_optimizing-virtual-machine-cpu-performance[Managing kernel samepage merging in the {op-system-base-full} documentation]

--- a/virt/nodes/virt-managing-node-labeling-obsolete-cpu-models.adoc
+++ b/virt/nodes/virt-managing-node-labeling-obsolete-cpu-models.adoc
@@ -6,7 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-You can schedule a virtual machine (VM) on a node as long as the VM CPU model and policy are supported by the node.
+[role="_abstract"]
+You can schedule a virtual machine (VM) on a node if the VM CPU model and policy are supported by the node.
 
 include::modules/virt-about-node-labeling-obsolete-cpu-models.adoc[leveloffset=+1]
 

--- a/virt/nodes/virt-node-maintenance.adoc
+++ b/virt/nodes/virt-node-maintenance.adoc
@@ -6,6 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 Nodes can be placed into maintenance mode by using the `oc adm` utility or `NodeMaintenance` custom resources (CRs).
 
 [NOTE]
@@ -72,6 +73,11 @@ You can configure an eviction strategy for the cluster to prioritize workload co
 --
 endif::openshift-rosa,openshift-dedicated[]
 
+[id="run-strategies"]
+== Run strategies
+
+The `spec.runStrategy` key determines how a VM behaves under certain conditions.
+
 include::modules/virt-configuring-vm-eviction-strategy-cli.adoc[leveloffset=+2]
 
 // Hiding in ROSA/OSD as Tech Preview features are not suppotred
@@ -79,18 +85,13 @@ ifndef::openshift-rosa,openshift-dedicated[]
 include::modules/virt-configuring-cluster-eviction-strategy-cli.adoc[leveloffset=+2]
 endif::openshift-rosa,openshift-dedicated[]
 
-[id="run-strategies"]
-== Run strategies
-
-The `spec.runStrategy` key determines how a VM behaves under certain conditions.
-
 include::modules/virt-runstrategies-vms.adoc[leveloffset=+2]
 
 include::modules/virt-configuring-runstrategy-vm.adoc[leveloffset=+2]
 
 include::modules/virt-maintaining-bare-metal-nodes.adoc[leveloffset=+1]
 
-[role="_additional-resources"]
 [id="additional-resources_virt-node-maintenance"]
+[role="_additional-resources"]
 == Additional resources
 * xref:../../virt/live_migration/virt-about-live-migration.adoc#virt-about-live-migration[About live migration]

--- a/virt/nodes/virt-preventing-node-reconciliation.adoc
+++ b/virt/nodes/virt-preventing-node-reconciliation.adoc
@@ -6,6 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 Use `skip-node` annotation to prevent the `node-labeller` from reconciling a node.
 
 include::modules/virt-using-skip-node.adoc[leveloffset=+1]

--- a/virt/nodes/virt-triggering-vm-failover-resolving-failed-node.adoc
+++ b/virt/nodes/virt-triggering-vm-failover-resolving-failed-node.adoc
@@ -6,6 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 If a node fails and link:https://access.redhat.com/articles/7057929[node health checks] are not deployed on your cluster, virtual machines (VMs) with `runStrategy: Always` configured are not automatically relocated to healthy nodes.
 
 [id="prerequisites_{context}"]
@@ -15,11 +16,11 @@ If a node fails and link:https://access.redhat.com/articles/7057929[node health 
 * The virtual machine that was running on the failed node has `runStrategy` set to `Always`.
 * You have installed the OpenShift CLI (`oc`).
 
-include::modules/nodes-nodes-working-deleting-bare-metal.adoc[leveloffset=+1]
-
 [id="verifying-vm-failover_{context}"]
 == Verifying virtual machine failover
 
 After all resources are terminated on the unhealthy node, a new virtual machine instance (VMI) is automatically created on a healthy node for each relocated VM. To confirm that the VMI was created, view all VMIs by using the `oc` CLI.
+
+include::modules/nodes-nodes-working-deleting-bare-metal.adoc[leveloffset=+1]
 
 include::modules/virt-listing-vmis-cli.adoc[leveloffset=+2]


### PR DESCRIPTION
# JIRA

* [DOCPLAN-44](https://issues.redhat.com/browse/DOCPLAN-44)


# Report: Vale and CQA Remediation for `virt/nodes`

**Content location:** `virt/nodes`  
**Scope:** Content Quality Assessment (CQA 2.1), Vale DITA validation, and remediation of reported issues.

---

## 1. Activities Performed

### 1.1 CQA 2.1 analysis

A manual assessment was carried out against the CQA 2.1 Pre-Migration and Quality criteria for the five assembly files in `virt/nodes`, using the framework described in *CQA 2.1 — Content Quality Assessment*. The assessment covered short descriptions, assembly structure, modularization, prerequisites, editorial and legal/branding requirements, and quality measures.

### 1.2 Vale DITA validation

Vale was run from within the `virt/nodes` directory using the repository `.vale.ini` (Red Hat, AsciiDoc, OpenShiftAsciiDoc, and AsciiDocDITA packages). An initial run from the repository root had failed with an include-path error (E100); running `vale *.adoc` from `virt/nodes` allowed includes to resolve and produced a full lint report.

The initial Vale run reported **9 errors**, **7 warnings**, and **23 suggestions** across the five assemblies.

### 1.3 Remediation of Vale errors

All nine Vale errors were addressed as follows:

| Rule | Files | Remediation |
|------|--------|-------------|
| **AsciiDocDITA.ShortDescription** | All five assemblies | A short description was introduced by adding `[role="_abstract"]` before the first paragraph in each assembly so that it is used as the DITA `<shortdesc>`. |
| **AsciiDocDITA.RelatedLinks** | `virt-activating-ksm.adoc` | The related link was adjusted so that no text appeared outside the link: the phrase “in the {op-system-base-full} documentation” was moved inside the link text. |
| **AsciiDocDITA.AssemblyContents** | `virt-node-maintenance.adoc` | The “Run strategies” heading and its introductory paragraph were moved above the block of include directives so that no content other than includes and Additional resources follows an include. |
| **AsciiDocDITA.AssemblyContents** | `virt-triggering-vm-failover-resolving-failed-node.adoc` | The “Verifying virtual machine failover” heading and its paragraph were moved above the first include so that the paragraph no longer appeared between two includes. |
| **RedHat.TermsErrors** | `virt-managing-node-labeling-obsolete-cpu-models.adoc` | The phrase “as long as” was replaced with “if” in line with the style rule. |

Additional editorial and structural adjustments were made: the word “identical” was replaced with “same” in the short description of `virt-activating-ksm.adoc` (RedHat.SimpleWords), and the order of the Additional resources block (id, then role, then heading) was aligned across assemblies where applicable.

### 1.4 Remediation of Vale warnings

All seven Vale warnings were **RedHat.Spelling** flags for terms not present in the American English dictionary used by Vale. The following terms were added to the project vocabulary (OpenShiftDocs accept list) at `.vale/styles/config/vocabularies/OpenShiftDocs/accept.txt`:

- **deduplicates**
- **samepage**
- **unschedulable**
- **VMIs**

No changes were made to the prose; the terms were accepted as valid project terminology.

---

## 2. Outcome

After remediation:

- **Vale:** 0 errors, 0 warnings. Eighteen suggestions remain (passive voice and style); these are advisory and are permitted by the style guide where appropriate.
- **CQA Pre-Migration:** The assemblies now satisfy the Vale asciidoctor-dita-vale check (no errors or warnings), use short descriptions with `[role="_abstract"]`, and comply with the assembly-structure rule (no content between include directives other than optional Additional resources).

---

## 3. Files Modified

| Path | Changes |
|------|---------|
| `virt/nodes/virt-activating-ksm.adoc` | Short description role; related link text; “identical” → “same”; Additional resources block order. |
| `virt/nodes/virt-managing-node-labeling-obsolete-cpu-models.adoc` | Short description role; “as long as” → “if”. |
| `virt/nodes/virt-node-maintenance.adoc` | Short description role; “Run strategies” section moved before includes; Additional resources block order. |
| `virt/nodes/virt-preventing-node-reconciliation.adoc` | Short description role. |
| `virt/nodes/virt-triggering-vm-failover-resolving-failed-node.adoc` | Short description role; “Verifying” section and paragraph moved above includes. |
| `.vale/styles/config/vocabularies/OpenShiftDocs/accept.txt` | Four terms added (deduplicates, samepage, unschedulable, VMIs). |

---

## 4. References

- CQA 2.1: *CQA 2.1 — Content Quality Assessment* (Pre-migration, Quality, Onboarding tabs).
- Vale AsciiDocDITA: [AsciiDocDITA.zip](https://github.com/jhradilek/asciidoctor-dita-vale/releases/latest/download/AsciiDocDITA.zip).
- Repository Vale configuration: `.vale.ini`.
