### PR TITLE
[OBSDOCS-2542_6.2] Add link to loki obj storage in Loki install

### DIFF
--- a/modules/installing-loki-operator-cli.adoc
+++ b/modules/installing-loki-operator-cli.adoc
@@ -125,7 +125,7 @@ stringData: # <2>
   region: eu-central-1
 ----
 <1> Use the name `logging-loki-s3` to match the name used in LokiStack.
-<2> For the contents of the secret see the Loki object storage section.
+<2> For the contents of the secret see the link:https://docs.redhat.com/en/documentation/red_hat_openshift_logging/{logging-major-version}/html/configuring_logging/configuring-lokistack-storage#logging-loki-storage_configuring-the-log-store[Loki object storage section].
 +
 --
 include::snippets/logging-retention-period-snip.adoc[leveloffset=+1]

--- a/modules/installing-loki-operator-web-console.adoc
+++ b/modules/installing-loki-operator-web-console.adoc
@@ -42,7 +42,7 @@ An Operator might display a `Failed` status before the installation completes. I
 
 . While the Operator installs, create the namespace to which the log store will be deployed.
 
-.. Click *+* in the top right of the screen to access the *Import YAML* page. 
+.. Click *+* in the top right of the screen to access the *Import YAML* page.
 
 .. Add the YAML definition for the `openshift-logging` namespace:
 +
@@ -63,7 +63,7 @@ metadata:
 
 . Create a secret with the credentials to access the object storage.
 
-.. Click *+* in the top right of the screen to access the *Import YAML* page. 
+.. Click *+* in the top right of the screen to access the *Import YAML* page.
 
 .. Add the YAML definition for the secret. For example, create a secret to access Amazon Web Services (AWS) s3:
 +
@@ -84,7 +84,7 @@ stringData: <3>
 ----
 <1> Note down the name used for the secret `logging-loki-s3` to use it later when creating the `LokiStack` resource.
 <2> Set the namespace to `openshift-logging` as that will be the namespace used to deploy `LokiStack`.
-<3> For the contents of the secret see the Loki object storage section.
+<3> For the contents of the secret see the link:https://docs.redhat.com/en/documentation/red_hat_openshift_logging/{logging-major-version}/html/configuring_logging/configuring-lokistack-storage#logging-loki-storage_configuring-the-log-store[Loki object storage section].
 +
 --
 include::snippets/logging-retention-period-snip.adoc[leveloffset=+1]


### PR DESCRIPTION
https://github.com/openshift/openshift-docs/pull/104857 cherry-pick into `standalone-loggin-6.2`