### PR TITLE
OSDOCS-18449: updates bash to terminal in source blocks

### DIFF
--- a/deployment/deployment.adoc
+++ b/deployment/deployment.adoc
@@ -21,7 +21,7 @@ include::modules/proc-set-up-tls-issuer.adoc[leveloffset=+1]
 
 include::modules/proc-create-gateway.adoc[leveloffset=+1]
 
-include::modules/proc-platform-eng-flow.adoc[leveloffset=+1]
+include::modules/proc-platform-eng-workflow.adoc[leveloffset=+1]
 
 include::modules/con-about-token-based-rate-limiting.adoc[leveloffset=+1]
 

--- a/modules/con-coredns-troubleshooting.adoc
+++ b/modules/con-coredns-troubleshooting.adoc
@@ -10,19 +10,19 @@
 You can troubleshoot your CoreDNS deployment by restarting CoreDNS and by checking the logs. Use the following commands as needed to investigate your specific errors:
 
 Restart CoreDNS by using the following command:
-[source,bash]
+[source,terminal]
 ----
 $ oc -n kuadrant-coredns rollout restart deployment kuadrant-coredns
 ----
 
 You can view CoreDNS logs by running the following command:
-[source, bash]
+[source,terminal]
 ----
 $ oc logs -f deployments/kuadrant-coredns -n kuadrant-coredns
 ----
 
 You can get recent logs by running the following command:
-[source, bash]
+[source,terminal]
 ----
 $ oc logs --tail=100 deployments/kuadrant-coredns -n kuadrant-coredns
 ----

--- a/modules/proc-app-dev-flow.adoc
+++ b/modules/proc-app-dev-flow.adoc
@@ -34,7 +34,7 @@ $ export KUADRANT_SYSTEM_NS=$(kubectl get kuadrant -A -o jsonpath="{.items[0].me
 +
 [source,bash]
 ----
-kubectl apply -f - <<EOF
+$ kubectl apply -f - <<EOF
 apiVersion: v1
 kind: Secret
 metadata:
@@ -69,7 +69,7 @@ EOF
 +
 [source,bash]
 ----
-kubectl apply -f - <<EOF
+$ kubectl apply -f - <<EOF
 apiVersion: kuadrant.io/v1
 kind: AuthPolicy
 metadata:

--- a/modules/proc-app-dev-override-rlp.adoc
+++ b/modules/proc-app-dev-override-rlp.adoc
@@ -23,9 +23,9 @@ Any new HTTPRoutes are affected by the existing Gateway-level policy. Because yo
 
 . Create a new `RateLimitPolicy` in a different namespace to override the default `low-limit` policy created previously and set rate limits for specific users as follows:
 +
-[source,bash]
+[source,terminal]
 ----
-kubectl apply -f - <<EOF
+$ kubectl apply -f - <<EOF
 apiVersion: kuadrant.io/v1
 kind: RateLimitPolicy
 metadata:
@@ -59,14 +59,14 @@ It might take a few minutes for the `RateLimitPolicy` to be applied, depending o
 +
 . Check that the `RateLimitPolicy` has a status of `Accepted` and `Enforced` as follows:
 +
-[source,bash]
+[source,terminal]
 ----
 $ kubectl get ratelimitpolicy -n ${KUADRANT_DEVELOPER_NS} toystore-rlp -o=jsonpath='{.status.conditions[?(@.type=="Accepted")].message}{"\n"}{.status.conditions[?(@.type=="Enforced")].message}'
 ----
 
 . Check that the status of the `HTTPRoute` is now affected by the `RateLimitPolicy` in the same namespace:
 +
-[source,bash]
+[source,terminal]
 ----
 $ kubectl get httproute toystore -n ${KUADRANT_DEVELOPER_NS} -o=jsonpath='{.status.parents[0].conditions[?(@.type=="kuadrant.io/RateLimitPolicyAffected")].message}'
 ----
@@ -75,7 +75,7 @@ $ kubectl get httproute toystore -n ${KUADRANT_DEVELOPER_NS} -o=jsonpath='{.stat
 
 . Send requests as user *alice* as follows:
 +
-[source,bash]
+[source,terminal]
 ----
 $ while :; do curl -k --write-out '%{http_code}\n' --silent --output /dev/null -H 'Authorization: APIKEY IAMALICE' "https://api.$KUADRANT_ZONE_ROOT_DOMAIN/cars" | grep -E --color "\b(429)\b|$"; sleep 1; done
 ----
@@ -84,7 +84,7 @@ You should see HTTP status `200` every second for 5 seconds, followed by HTTP st
 
 . Send requests as user *bob* as follows:
 +
-[source,bash]
+[source,terminal]
 ----
 $ while :; do curl -k --write-out '%{http_code}\n' --silent --output /dev/null -H 'Authorization: APIKEY IAMBOB' "https://api.$KUADRANT_ZONE_ROOT_DOMAIN/cars" | grep -E --color "\b(429)\b|$"; sleep 1; done
 ----

--- a/modules/proc-configure-dns-provider-aws.adoc
+++ b/modules/proc-configure-dns-provider-aws.adoc
@@ -55,7 +55,7 @@ $ export AWS_REGION=your-aws-region
 
 . Create a `Secret` resource for your credentials as follows:
 +
-[source,bash]
+[source,terminal]
 ----
 $ kubectl create secret generic aws-credentials \
   --namespace=api-gateway \

--- a/modules/proc-configure-dns-provider-azure.adoc
+++ b/modules/proc-configure-dns-provider-azure.adoc
@@ -32,7 +32,7 @@ If you already know your environment variable values, you can set up the require
 
 . Create a new Azure service principal for managing DNS as follows:
 +
-[source,bash]
+[source,terminal]
 ----
 DNS_NEW_SP_NAME=kuadrantDnsPrincipal
 DNS_SP=$(az ad sp create-for-rbac --name $DNS_NEW_SP_NAME)
@@ -46,7 +46,7 @@ For more details on service principals, see the https://learn.microsoft.com/en-u
 
 .. Fetch the DNS ID used to grant access to the service principal as follows:
 +
-[source,bash]
+[source,terminal]
 ----
 $ DNS_ID=$(az network dns zone show --name example.com \
  --resource-group ExampleDNSResourceGroup --query "id" --output tsv)
@@ -57,21 +57,21 @@ $ RESOURCE_GROUP_ID=az group show --resource-group ExampleDNSResourceGroup | jq 
 
 .. Provide reader access to the resource group as follows:
 +
-[source,bash]
+[source,terminal]
 ----
 $ az role assignment create --role "Reader" --assignee $DNS_SP_APP_ID --scope $DNS_ID
 ----
 
 .. Provide contributor access to the DNS zone as follows:
 +
-[source,bash]
+[source,terminal]
 ----
 $ az role assignment create --role "Contributor" --assignee $DNS_SP_APP_ID --scope $DNS_ID
 ----
 
 . Because you are setting up advanced traffic rules for geographic and weighted responses, you must also grant traffic manager and DNS zone access as follows:
 +
-[source,bash]
+[source,terminal]
 ----
 $ az role assignment create --role "Traffic Manager Contributor" --assignee $DNS_SP_APP_ID --scope $RESOURCE_GROUP_ID
 
@@ -90,7 +90,7 @@ EOF
 
 . Create a `Secret` resource for your credentials as follows:
 +
-[source,bash]
+[source,terminal]
 ----
 $ kubectl create secret generic test-azure-credentials \
   --namespace=api-gateway \

--- a/modules/proc-configure-dns-provider-google.adoc
+++ b/modules/proc-configure-dns-provider-google.adoc
@@ -30,7 +30,7 @@ If you already know your environment variable values, you can set up the require
 
 . Optional: Specify your environment variables as follows:
 +
-[source,bash]
+[source,terminal]
 ----
 $ export GOOGLE=xxxxxxx
 $ export PROJECT_ID=xxxxxxx
@@ -51,7 +51,7 @@ For example, `$HOME/.config/gcloud/application_default_credentials.json`, which 
 
 . Create a `Secret` resource for your credentials as follows:
 +
-[source,bash]
+[source,terminal]
 ----
 $ kubectl create secret generic test-gcp-credentials \
   --namespace=api-gateway \

--- a/modules/proc-configure-obs-data-plane-tracing.adoc
+++ b/modules/proc-configure-obs-data-plane-tracing.adoc
@@ -20,7 +20,7 @@ Enable data plane tracing in {service-mesh} with the `kuadrant` CR. You must per
 . Enable tracing in {service-mesh} by configuring your `Telemetry` custom resource (CR) as follows:
 +
 .Example {service-mesh} Telemetry CR with tracing
-[source,bash]
+[source,yaml]
 ----
 apiVersion: telemetry.istio.io/v1alpha1
 kind: Telemetry
@@ -39,13 +39,13 @@ spec:
 +
 [source,terminal]
 ----
-$ kubectl apply -f mesh-default.yaml
+$ oc apply -f mesh-default.yaml
 ----
 
 . Configure a tracing extension provider for {service-mesh} in your `Istio` CR by adding a list value to the `spec.values.meshConfig.extensionProviders` parameter. Ensure that you also add the `otel` port and service information:
 +
 .Example Istio CR with tracing extension provider
-[source,terminal]
+[source,yaml]
 ----
 apiVersion: operator.istio.io/v1alpha1
 kind: Istio
@@ -91,7 +91,7 @@ spec:
 +
 [source,terminal]
 ----
-$ kubectl apply -f istio.yaml
+$ oc apply -f istio.yaml
 ----
 
 . Optional. If you want to collect `Authorino` and `Limitador` traces in a different location than your `Kaudrant` traces, complete the following steps:
@@ -99,7 +99,7 @@ $ kubectl apply -f istio.yaml
 .. Enable request tracing in your `Authorino` custom resource (CR) and send authentication and authorization traces to the central collector as follows:
 +
 .Example Authorino CR with request tracing
-[source,bash]
+[source,yaml]
 ----
 apiVersion: operator.authorino.kuadrant.io/v1beta1
 kind: Authorino
@@ -118,13 +118,13 @@ Set `insecure` to `true` to skip TLS certificate verification in development env
 +
 [source,terminal]
 ----
-$ kubectl apply -f authorino.yaml
+$ oc apply -f authorino.yaml
 ----
 
 .. Enable request tracing in your `Limitador` CR and send rate limit traces to the central collector as follows:
 +
 .Example Limitador CR with request tracing
-[source,bash]
+[source,yaml]
 ----
 apiVersion: limitador.kuadrant.io/v1alpha1
 kind: Limitador
@@ -143,7 +143,7 @@ Set `insecure` to `true` to skip TLS certificate verification in development env
 +
 [source,terminal]
 ----
-$ kubectl apply -f limitador.yaml
+$ oc apply -f limitador.yaml
 ----
 +
 [IMPORTANT]
@@ -174,10 +174,10 @@ spec:
 +
 where:
 +
-* `spec.observability.tracing.defaultEndpoint`: The URL of the tracing collector backend. That is, the OpenTelemetry endpoint. The following are supported protocols:
+* `spec.observability.tracing.defaultEndpoint`:: The URL of the tracing collector backend. That is, the OpenTelemetry endpoint. The following are supported protocols:
 ** `rpc://` for gRPC OTLP, port 4317
 ** `http://` for HTTP OTLP, port 4318
-* ``spec.observability.tracing.insecure`: Set to `true` to skip TLS certificate verification in development environments. Set to `false` for production environments.
+* ``spec.observability.tracing.insecure`:: Set to `true` to skip TLS certificate verification in development environments. Set to `false` for production environments.
 +
 [IMPORTANT]
 ====
@@ -186,16 +186,16 @@ Point to the collector service, such as the {TempoShortName}, not the query serv
 
 . Apply the configuration by running the following command:
 +
-[source,bash]
+[source,terminal]
 ----
-$ kubectl apply -f kuadrant.yaml
+$ oc apply -f kuadrant.yaml
 ----
 
 .Verification
 
 * Verify that the CR applied successfully by listing the objects of that `Kind` by running the following command:
 +
-[source,bash]
+[source,terminal]
 ----
-$ kubectl get kuadrant
+$ oc get kuadrant
 ----

--- a/modules/proc-configure-obs-monitoring.adoc
+++ b/modules/proc-configure-obs-monitoring.adoc
@@ -27,7 +27,7 @@ The following procedure is an example only and is not intended for production us
 
 . Verify that the user workload monitoring is configured correctly in your {ocp} cluster as follows:
 +
-[source,bash]
+[source,terminal]
 ----
 $ kubectl get configmap cluster-monitoring-config -n openshift-monitoring -o jsonpath='{.data.config\.yaml}'|grep enableUserWorkload
 ----
@@ -36,14 +36,14 @@ The expected output is `enableUserWorkload: true`.
 
 . Install the {prodname}, Gateway, and Grafana component metrics and configuration as follows:
 +
-[source,bash]
+[source,terminal]
 ----
 $ kubectl apply -k https://github.com/Kuadrant/kuadrant-operator/config/install/configure/observability?ref=v1.2.0
 ----
 
 . From the root directory of your Kuadrant Operator repository, configure the {ocp} `thanos-query` instance as a data source in Grafana as follows:
 +
-[source,bash]
+[source,terminal]
 ----
 TOKEN="Bearer $(oc whoami -t)"
 HOST="$(kubectl -n openshift-monitoring get route thanos-querier -o jsonpath='https://{.status.ingress[].host}')"

--- a/modules/proc-configure-redis.adoc
+++ b/modules/proc-configure-redis.adoc
@@ -23,7 +23,7 @@ You must configure connection details for your shared Redis-based datastore on e
 
 . Set the following environment variable to your shared Redis-based instance URL:
 +
-[source,bash]
+[source,terminal]
 ----
 $ export REDIS_URL=rediss://user:xxxxxx@some-redis.com:10340
 ----
@@ -35,7 +35,7 @@ Include the appropriate URI scheme for your environment:
 
 . Create a `Secret` resource for your Redis URL as follows:
 +
-[source,bash]
+[source,terminal]
 ----
 $ kubectl -n kuadrant-system create secret generic redis-config \
   --from-literal=URL=$REDIS_URL
@@ -43,7 +43,7 @@ $ kubectl -n kuadrant-system create secret generic redis-config \
 
 . Update your Limitador custom resource to use the secret that you created as follows:
 +
-[source,bash]
+[source,terminal]
 ----
 $ kubectl patch limitador limitador --type=merge -n kuadrant-system -p '
 spec:

--- a/modules/proc-configure-token-based-rate-limiting.adoc
+++ b/modules/proc-configure-token-based-rate-limiting.adoc
@@ -97,21 +97,21 @@ spec:
 
 . Apply the policy:
 +
-[source,bash]
+[source,terminal]
 ----
 $ oc apply -f your-tokenratelimitpolicy.yaml -n my-api-namespace
 ----
 
 . Check the status of the policy to ensure it has been accepted and enforced on the target `HTTPRoute`. Look for conditions with `type: Accepted` and `type: Enforced` with `status: "True"`.
 +
-[source,bash]
+[source,terminal]
 ----
 $ oc get tokenratelimitpolicy llm-protection -n my-api-namespace -o jsonpath='{.status.conditions}'
 ----
 
 . Send requests to your API endpoint, including the required authentication details.
 +
-[source,bash]
+[source,terminal]
 ----
 $ curl -H "Authorization: <auth-details>" \
      -d '{"model": "gpt-4", "messages": [{"role": "user", "content": "Hello"}]}' \

--- a/modules/proc-create-gateway.adoc
+++ b/modules/proc-create-gateway.adoc
@@ -4,7 +4,7 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="create-gateway_{context}"]
-= Create your Gateway instance
+= Create your gateway instance
 
 [role="_abstract"]
 This section shows how you can deploy a Gateway in your {ocp} cluster. This task is typically performed by platform engineers when setting up the infrastructure to be used by application developers.
@@ -23,7 +23,7 @@ In a multicluster environment, for {prodname} to balance traffic by using DNS ac
 
 . Enter the following command to create the Gateway:
 +
-[source,bash]
+[source,terminal]
 ----
 $ kubectl apply -f - <<EOF
 apiVersion: gateway.networking.k8s.io/v1
@@ -54,16 +54,16 @@ EOF
 
 . Check the status of your Gateway as follows:
 +
-[source,bash]
+[source,terminal]
 ----
-kubectl get gateway ${KUADRANT_GATEWAY_NAME} -n ${KUADRANT_GATEWAY_NS} -o=jsonpath='{.status.conditions[?(@.type=="Accepted")].message}{"\n"}{.status.conditions[?(@.type=="Programmed")].message}'
+$ kubectl get gateway ${KUADRANT_GATEWAY_NAME} -n ${KUADRANT_GATEWAY_NS} -o=jsonpath='{.status.conditions[?(@.type=="Accepted")].message}{"\n"}{.status.conditions[?(@.type=="Programmed")].message}'
 ----
 +
 Your Gateway should be `Accepted` and `Programmed`, which means that it is valid and assigned an external address.
 
 . Check the status of your HTTPS listener as follows:
 +
-[source,bash]
+[source,terminal]
 ----
 $ kubectl get gateway ${KUADRANT_GATEWAY_NAME} -n ${KUADRANT_GATEWAY_NS} -o=jsonpath='{.status.listeners[0].conditions[?(@.type=="Programmed")].message}'
 ----

--- a/modules/proc-enable-obs-monitor.adoc
+++ b/modules/proc-enable-obs-monitor.adoc
@@ -34,7 +34,7 @@ To use {prodname} observability dashboards, you must enable observability on eac
 * To enable default observability for {prodname} and any gateways, set `spec.observability.enable` parameter value to `true` in your `Kuadrant` custom resource (CR):
 +
 .Example `Kuadrant` CR
-[source,bash]
+[source,yaml]
 ----
 apiVersion: kuadrant.io/v1beta1
 kind: Kuadrant
@@ -52,8 +52,8 @@ You can also set the `spec.observability.enable` to `false` and create your own 
 
 * Check the created monitors by running the following command:
 +
-[source,bash]
+[source,terminal]
 ----
-$ kubectl get servicemonitor,podmonitor -A -l kuadrant.io/observability=true
+$ oc get servicemonitor,podmonitor -A -l kuadrant.io/observability=true
 ----
 //Q: example output?

--- a/modules/proc-install-on-openshift-cmd.adoc
+++ b/modules/proc-install-on-openshift-cmd.adoc
@@ -20,14 +20,14 @@ NOTE: You must perform these steps on each {ocp} cluster that you want to use {p
 
 . Create the namespace where you want to install the Operator as follows, for example, `kuadrant-system`:
 +
-[source,bash]
+[source,terminal]
 ----
 $ kubectl create ns kuadrant-system
 ----
 
 . To install the {prodname} Operator, enter the following command:
 +
-[source,bash]
+[source,terminal]
 ----
 $ kubectl apply -f - <<EOF
 apiVersion: operators.coreos.com/v1alpha1
@@ -54,7 +54,7 @@ EOF
 +
 Wait for the {prodname} Operators to be installed as follows:
 +
-[source,bash]
+[source,terminal]
 ----
 $ kubectl get installplan -n kuadrant-system -o=jsonpath='{.items[0].status.phase}'
 ----
@@ -63,7 +63,7 @@ After some time, this command will return `Complete` when ready.
 
 . To create your {prodname} deployment, enter the following command:
 +
-[source,bash]
+[source,terminal]
 ----
 $ kubectl apply -f - <<EOF
 apiVersion: kuadrant.io/v1beta1
@@ -77,7 +77,7 @@ EOF
 +
 Wait for Kuadrant to be ready as follows:
 +
-[source,bash]
+[source,terminal]
 ----
 $ kubectl wait kuadrant/kuadrant --for="condition=Ready=true" -n kuadrant-system --timeout=300s
 ----

--- a/modules/proc-obs-configure-access-logs.adoc
+++ b/modules/proc-obs-configure-access-logs.adoc
@@ -81,7 +81,7 @@ The `expression` field uses Common Expression Language (CEL). You can use CEL-ba
 
 .  If you are using the Sail Operator, check which `Istio` Operator is active in your cluster by running the following command:
 +
-[source,bash]
+[source,terminal]
 ----
 $ kubectl get istio -A
 ----

--- a/modules/proc-platform-eng-workflow.adoc
+++ b/modules/proc-platform-eng-workflow.adoc
@@ -29,7 +29,7 @@ In multicluster environments, you must perform the following steps in each clust
 
 . Set the `TLSPolicy` for your Gateway as follows:
 +
-[source,bash]
+[source,terminal]
 ----
 $ kubectl apply -f - <<EOF
 apiVersion: kuadrant.io/v1
@@ -51,7 +51,7 @@ EOF
 
 . Check that your TLS policy has an `Accepted` and `Enforced` status as follows:
 +
-[source,bash]
+[source,terminal]
 ----
 $ kubectl get tlspolicy ${KUADRANT_GATEWAY_NAME}-tls -n ${KUADRANT_GATEWAY_NS} -o=jsonpath='{.status.conditions[?(@.type=="Accepted")].message}{"\n"}{.status.conditions[?(@.type=="Enforced")].message}'
 ----
@@ -65,7 +65,7 @@ This may take a few minutes depending on the TLS provider, for example, Let's En
 
 . Create an `HTTPRoute` for the example Toystore application as follows:
 +
-[source,bash]
+[source,terminal]
 ----
 $ kubectl apply -f - <<EOF
 apiVersion: gateway.networking.k8s.io/v1
@@ -105,9 +105,9 @@ EOF
 
 . Set a default `AuthPolicy` with a `deny-all` setting for your Gateway as follows:
 +
-[source,bash]
+[source,terminal]
 ----
-kubectl apply -f - <<EOF
+$ kubectl apply -f - <<EOF
 apiVersion: kuadrant.io/v1
 kind: AuthPolicy
 metadata:
@@ -142,7 +142,7 @@ EOF
 
 . Check that your `AuthPolicy` has `Accepted` and `Enforced` status as follows:
 +
-[source,bash]
+[source,terminal]
 ----
 $ kubectl get authpolicy ${KUADRANT_GATEWAY_NAME}-auth -n ${KUADRANT_GATEWAY_NS} -o=jsonpath='{.status.conditions[?(@.type=="Accepted")].message}{"\n"}{.status.conditions[?(@.type=="Enforced")].message}'
 ----
@@ -154,9 +154,9 @@ $ kubectl get authpolicy ${KUADRANT_GATEWAY_NAME}-auth -n ${KUADRANT_GATEWAY_NS}
 
 . Set the default `RateLimitPolicy` with a `low-limit` setting for your Gateway as follows:
 +
-[source,bash]
+[source,terminal]
 ----
-kubectl apply -f  - <<EOF
+$ kubectl apply -f  - <<EOF
 apiVersion: kuadrant.io/v1
 kind: RateLimitPolicy
 metadata:
@@ -180,7 +180,7 @@ It might take a few minutes for the `RateLimitPolicy` to be applied depending on
 
 . Check that your `RateLimitPolicy` has `Accepted` and `Enforced` status as follows:
 +
-[source,bash]
+[source,terminal]
 ----
 $ kubectl get ratelimitpolicy ${KUADRANT_GATEWAY_NAME}-rlp -n ${KUADRANT_GATEWAY_NS} -o=jsonpath='{.status.conditions[?(@.type=="Accepted")].message}{"\n"}{.status.conditions[?(@.type=="Enforced")].message}'
 ----
@@ -192,7 +192,7 @@ $ kubectl get ratelimitpolicy ${KUADRANT_GATEWAY_NAME}-rlp -n ${KUADRANT_GATEWAY
 
 . Set the `DNSPolicy` for your Gateway as follows:
 +
-[source,bash]
+[source,terminal]
 ----
 $ kubectl apply -f - <<EOF
 apiVersion: kuadrant.io/v1
@@ -222,7 +222,7 @@ The `DNSPolicy` uses the DNS Provider `Secret` that you defined earlier. The `ge
 
 . Check that your `DNSPolicy` has status of `Accepted` and `Enforced` as follows:
 +
-[source,bash]
+[source,terminal]
 ----
 $ kubectl get dnspolicy ${KUADRANT_GATEWAY_NAME}-dnspolicy -n ${KUADRANT_GATEWAY_NS} -o=jsonpath='{.status.conditions[?(@.type=="Accepted")].message}{"\n"}{.status.conditions[?(@.type=="Enforced")].message}'
 ----
@@ -231,7 +231,7 @@ This might take a few minutes.
 
 . Check the status of the DNS health checks that are enabled on your DNSPolicy as follows:
 +
-[source,bash]
+[source,terminal]
 ----
 $ kubectl get dnspolicy ${KUADRANT_GATEWAY_NAME}-dnspolicy -n ${KUADRANT_GATEWAY_NS} -
 ----
@@ -252,7 +252,7 @@ You can use a `curl` command to test the default `low-limit` and `deny-all` poli
 
 * Enter the following `curl` command:
 +
-[source,bash]
+[source,terminal]
 ----
 $ while :; do curl -k --write-out '%{http_code}\n' --silent --output /dev/null  "https://api.$KUADRANT_ZONE_ROOT_DOMAIN/cars" | grep -E --color "\b(429)\b|$"; sleep 1; done
 ----

--- a/modules/proc-set-up-dns-provider.adoc
+++ b/modules/proc-set-up-dns-provider.adoc
@@ -23,14 +23,14 @@ You must apply the following `Secret` resource to each cluster. If you are addin
 
 . Create the namespace that the Gateway will be deployed in as follows:
 +
-[source,bash]
+[source,terminal]
 ----
-kubectl create ns ${KUADRANT_GATEWAY_NS}
+$ kubectl create ns ${KUADRANT_GATEWAY_NS}
 ----
 
 . Create the secret credentials in the same namespace as the Gateway as follows:
 +
-[source,bash]
+[source,terminal]
 ----
 $ kubectl -n ${KUADRANT_GATEWAY_NS} create secret generic aws-credentials \
   --type=kuadrant.io/aws \
@@ -40,7 +40,7 @@ $ kubectl -n ${KUADRANT_GATEWAY_NS} create secret generic aws-credentials \
 
 . Before adding a TLS certificate issuer, create the secret credentials in the `cert-manager` namespace as follows:
 +
-[source,bash]
+[source,terminal]
 ----
 $ kubectl -n cert-manager create secret generic aws-credentials \
   --type=kuadrant.io/aws \

--- a/modules/proc-set-up-environment.adoc
+++ b/modules/proc-set-up-environment.adoc
@@ -18,20 +18,20 @@ This section shows how you can set up your environment variables and deploy the 
 //TODO FIXME steps, also Q: we need to define these as upstream?
 . Optional: Set the following environment variables:
 +
-[source,bash]
+[source,terminal]
 ----
-export KUADRANT_GATEWAY_NS=api-gateway
-export KUADRANT_GATEWAY_NAME=external
-export KUADRANT_DEVELOPER_NS=toystore
-export KUADRANT_AWS_ACCESS_KEY_ID=xxxx
-export KUADRANT_AWS_SECRET_ACCESS_KEY=xxxx
-export KUADRANT_AWS_DNS_PUBLIC_ZONE_ID=xxxx
-export KUADRANT_ZONE_ROOT_DOMAIN=example.com
-export KUADRANT_CLUSTER_ISSUER_NAME=self-signed
+$ export KUADRANT_GATEWAY_NS=api-gateway \
+  export KUADRANT_GATEWAY_NAME=external \
+  export KUADRANT_DEVELOPER_NS=toystore \
+  export KUADRANT_AWS_ACCESS_KEY_ID=xxxx \
+  export KUADRANT_AWS_SECRET_ACCESS_KEY=xxxx \
+  export KUADRANT_AWS_DNS_PUBLIC_ZONE_ID=xxxx \
+  export KUADRANT_ZONE_ROOT_DOMAIN=example.com
+  export KUADRANT_CLUSTER_ISSUER_NAME=self-signed
 ----
 +
 These environment variables are described as follows:
-
++
 * `KUADRANT_GATEWAY_NS`: Namespace for your example gateway in {ocp}.
 * `KUADRANT_GATEWAY_NAME`: Name of your example gateway in {ocp}.
 * `KUADRANT_DEVELOPER_NS`: Namespace for the example Toystore app in {ocp}.
@@ -49,14 +49,14 @@ If you know your environment variable values, you can set up the required YAML f
 
 . Create the namespace for the Toystore app as follows:
 +
-[source,bash]
+[source,terminal]
 ----
 $ kubectl create ns ${KUADRANT_DEVELOPER_NS}
 ----
 
 . Deploy the Toystore app to the developer namespace:
 +
-[source,bash]
+[source,terminal]
 ----
 $ kubectl apply -f https://raw.githubusercontent.com/Kuadrant/Kuadrant-operator/main/examples/toystore/toystore.yaml -n ${KUADRANT_DEVELOPER_NS}
 ----

--- a/modules/proc-set-up-tls-issuer.adoc
+++ b/modules/proc-set-up-tls-issuer.adoc
@@ -23,7 +23,7 @@ This example uses the Let's Encrypt TLS certificate issuer for simplicity, but y
 
 . Enter the following command to define a TLS certificate issuer:
 +
-[source,bash]
+[source,terminal]
 ----
 $ kubectl apply -f - <<EOF
 apiVersion: cert-manager.io/v1
@@ -37,7 +37,7 @@ EOF
 
 . Wait for the `ClusterIssuer` to become ready as follows:
 +
-[source,bash]
+[source,terminal]
 ----
 $ kubectl wait clusterissuer/${KUADRANT_CLUSTER_ISSUER_NAME} --for=condition=ready=true
 ----

--- a/modules/proc-use-coredns-single-cluster.adoc
+++ b/modules/proc-use-coredns-single-cluster.adoc
@@ -99,14 +99,14 @@ For production or exact GeoIP routing, mount your licensed MaxMind GeoIP databas
 
 . Update the CoreDNS deployment to use the new configuration by running the following command:
 +
-[source,bash]
+[source,terminal]
 ----
 $ oc --context $CTX_PRIMARY -n kuadrant-system patch deployment kuadrant-coredns --patch '{"spec":{"template":{"spec":{"volumes":[{"name":"config-volume","configMap":{"name":"coredns-kuadrant-config","items":[{"key":"Corefile","path":"Corefile"}]}}]}}}}'
 ----
 
 . Set a watch-and-wait command for the deployment rollout to complete:
 +
-[source,bash]
+[source,terminal]
 ----
 $ oc --context $CTX_PRIMARY -n kuadrant-system rollout status deployment/kuadrant-coredns
 ----
@@ -119,7 +119,7 @@ kuadrant-coredns successfully rolled out
 
 . Create the Kubernetes `Secret` that {prodname} uses to interact with CoreDNS. This secret specifies the zones this provider instance is authoritative for.
 +
-[source,bash]
+[source,terminal]
 ----
 $ oc create secret generic coredns-credentials \
   --namespace=kuadrant-system \

--- a/modules/proc-viewing-rate-limit-trace-IDs.adoc
+++ b/modules/proc-viewing-rate-limit-trace-IDs.adoc
@@ -21,7 +21,7 @@ You can enable request logging with trace IDs to get more information about requ
 * Set the verbosity to `3` or higher in your `Limitador` custom resource (CR) as follows:
 +
 .Example Limitador CR
-[source,bash]
+[source,yaml]
 ----
 apiVersion: limitador.kuadrant.io/v1alpha1
 kind: Limitador
@@ -32,7 +32,7 @@ spec:
 ----
 +
 .Example log entry with the `traceparent` field holding the trace ID
-[source,bash]
+[source,terminal]
 ----
 "Request received: Request { metadata: MetadataMap { headers: {"te": "trailers", "grpc-timeout": "5000m", "content-type": "application/grpc", "traceparent": "00-4a2a933a23df267aed612f4694b32141-00f067aa0ba902b7-01", "x-envoy-internal": "true", "x-envoy-expected-rq-timeout-ms": "5000"} }, message: RateLimitRequest { domain: "default/toystore", descriptors: [RateLimitDescriptor { entries: [Entry { key: "limit.general_user__f5646550", value: "1" }, Entry { key: "metadata.filter_metadata.envoy\\.filters\\.http\\.ext_authz.identity.userid", value: "alice" }], limit: None }], hits_addend: 1 }, extensions: Extensions }"
 ----


### PR DESCRIPTION
Version(s):
rhcl-docs-1.4
rhcl-docs-1.3
rhcl-docs-1.2

Issue:
[OSDOCS-18449](https://issues.redhat.com/browse/OSDOCS-18449)

Link to docs preview:
https://107488--ocpdocs-pr.netlify.app/rhcl/latest/deployment/coredns.html#proc-use-coredns-single-cluster_rhcl-using-on-prem-dns-coredns (etc)
https://107488--ocpdocs-pr.netlify.app/rhcl/latest/deployment/deployment.html#set-up-environment_rhcl-config-deploy-gateway-policies (etc)
https://107488--ocpdocs-pr.netlify.app/rhcl/latest/install-guide/install-guide.html#install-on-ocp-cmd_installing-rhcl-on-ocp (etc)
https://107488--ocpdocs-pr.netlify.app/rhcl/latest/observability/observability.html#configure-obs-monitoring_rhcl-observability (etc)

QE review:
- N/A repo work

Additional info:
Internal repo work to replace `[source,bash]` with `[source,terminal]` for highlighting and build purposes. The `rhcl-docs-1.4` branch is not available yet, so please `ack` but do not merge.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
