### PR TITLE
CNV-80551: Add info about removing unused resources and Operators from CNV

### DIFF
--- a/modules/virt-update-removing-unused.adoc
+++ b/modules/virt-update-removing-unused.adoc
@@ -1,0 +1,12 @@
+// Module included in the following assemblies:
+//
+// * virt/updating/upgrading-virt.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="virt-update-removing-unused_{context}"]
+= Remove unused Operators and resources
+
+[role="_abstract"]
+As a cluster administrator who is updating {VirtProductName} from a previous version to version {VirtVersion}, you can remove certain Operators and resources that are no longer required. This can help you to reclaim space and resources on your cluster.
+
+As of {VirtProductName} version 4.21, the {mtc-first} is no longer required to support live storage migration.

--- a/virt/updating/upgrading-virt.adoc
+++ b/virt/updating/upgrading-virt.adoc
@@ -17,6 +17,12 @@ include::modules/virt-manual-approval-strategy.adoc[leveloffset=+2]
 
 include::modules/olm-approving-pending-upgrade.adoc[leveloffset=+2]
 
+// cleaning up unused Operators and resources
+
+include::modules/virt-update-removing-unused.adoc[leveloffset=+1]
+
+include::modules/migration-uninstalling-mtc-clean-up.adoc[leveloffset=+2]
+
 include::modules/virt-rhel-9.adoc[leveloffset=+1]
 
 include::modules/virt-monitoring-upgrade-status.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s):
4.21+

Issue:
https://issues.redhat.com/browse/CNV-80551

Link to docs preview:
https://107494--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/updating/upgrading-virt.html#virt-update-removing-unused_upgrading-virt

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
