### PR TITLE
MCO fix boot image management table

### DIFF
--- a/snippets/mco-update-boot-images-intro.adoc
+++ b/snippets/mco-update-boot-images-intro.adoc
@@ -19,11 +19,11 @@ The following table lists the platforms on which boot image management is availa
 |Disabled by default
 
 |{azure-first}
-|Enabled by default
+|Disabled by default
 |Disabled by default
 
 |{vmw-first}
-|Enabled by default 
+|Disabled by default 
 |Not supported
 
 |===


### PR DESCRIPTION
Per [Slack updating table of boot image management platform availability](https://redhat-internal.slack.com/archives/C02CZNQHGN8/p1772121338925959).

https://issues.redhat.com/browse/OSDOCS-18488

Machine configuration -> [Boot image management](https://107508--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_configuration/mco-update-boot-images.html)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
