### PR TITLE
OSDOCS-18482:Update the z-stream RNs for 4.21.4

### DIFF
--- a/modules/zstream-4-21-4.adoc
+++ b/modules/zstream-4-21-4.adoc
@@ -1,0 +1,39 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-21-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-21-4_{context}"]
+= RHSA-2026:3402 - {product-title} {product-version}.4 image release, fixed issues, and security update
+
+Issued: 03 March 2026
+
+[role="_abstract"]
+{product-title} release {product-version}.4 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2026:3402[RHSA-2026:3402] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2026:3400[RHBA-2026:3400] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.21.4 --pullspecs
+----
+
+[id="zstream-4-21-4-fixed-issues_{context}"]
+== Fixed issues
+
+The following issues are fixed for this release:
+
+* Before this update, when the PTP Operator monitored the digital phase-locked loop (DPLL) offset, and the DPLL reached a steady state, the offset value could be temporarily below the threshold to be considered locked because of the high variability of the offset. As a consequence, the PTP boundary clock (T-BC) would announce its clock class before the `ptp4l` program and the DPLL reached a locked state. With this release, clock class decisions are started only after a minimum number of samples. As a result, the clock class is announced after the DPLL is stabilized. (link:https://issues.redhat.com/browse/OCPBUGS-73795[OCPBUGS-73795])
+
+* Before this update, the Baseboard Management Controller (BMC) firmware lacked a structured error response for `UserName` and `Password` parameters, which caused the BMC to reject ISO mounting during NVIDIA Deep GPU Xceleration (DGX) B200 node provisioning. As a consequence, automated provisioning failed. With this release, the firmware handling of credentials is updated, which adds handling for missing `UserName` and `Password` parameters in the Redfish `InsertMedia` response. As a result, Bare Metal Operator (BMO) and Ironic mounting failures are resolved and automated provisioning of NVIDIA DGX B200 nodes is enabled. (link:https://issues.redhat.com/browse/OCPBUGS-74404[OCPBUGS-74404])
+
+* Before this update, a race condition which was caused by concurrent map writes on the `vpa.Conditions` parameter within the {product-title} Vertical Pod Autoscaler (VPA) recommender led to the crashing of VPA pods and caused resource scaling instability within the {product-title} cluster. With this release, the VPA recommender ensures thread-safe access to race conditions. As a result, the concurrent map write error in the `vpa-recommender` parameter is resolved and VPA pod crashes are prevented. (link:https://issues.redhat.com/browse/OCPBUGS-76296[OCPBUGS-76296])
+
+* Before this update, the `UnmanagedRoutes` alert incorrectly fired for a correctly managed ingress resource that owned a route, if another unmanaged ingress resource with the same name was on another namespace. This issue occurred even if the second ingress resource did not own a route resource. With this release, the controller correctly identifies those ingress resources with conflicting names. As a result, an alert only fires if an ingress owns a route, and is not managed, even when there are ingress resources with the same name. (link:https://issues.redhat.com/browse/OCPBUGS-76641[OCPBUGS-76641])
+
+[id="zstream-4-21-4-updating_{context}"]
+== Updating
+
+To update an {product-title} 4.21 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].

--- a/release_notes/ocp-4-21-release-notes.adoc
+++ b/release_notes/ocp-4-21-release-notes.adoc
@@ -44,6 +44,9 @@ include::modules/rn-ocp-release-notes-known-issues.adoc[leveloffset=+1]
 // Asynchronous errata updates
 include::modules/rn-async-errata.adoc[leveloffset=+1]
 
+// 4.21.4 RNs and updating
+include::modules/zstream-4-21-4.adoc[leveloffset=+2]
+
 // 4.21.3 RNs
 include::modules/zstream-4-21-3.adoc[leveloffset=+2]
 


### PR DESCRIPTION
Version(s):
4.21

Issue:
https://issues.redhat.com/browse/OSDOCS-18482

Link to docs preview:
https://107559--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-21-release-notes.html#zstream-4-21-4_release-notes

Additional information:
4.21.4 MR: https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/386
ART Dashboard: https://art-dash.engineering.redhat.com/dashboard/release/openshift-4.21