### PR TITLE
CNV-74970: Update callouts and other formatting for DITA migration

### DIFF
--- a/modules/virt-performing-actions-on-multiple-virtual-machines.adoc
+++ b/modules/virt-performing-actions-on-multiple-virtual-machines.adoc
@@ -1,0 +1,18 @@
+// Module included in the following assemblies:
+//
+// * virt/managing_vms/virt-edit-vms.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="virt-performing-actions-on-multiple-virtual-machines_{context}"]
+= Performing bulk actions on virtual machines
+
+[role="_abstract"]
+You can perform bulk actions on multiple virtual machines (VMs) simultaneously by using the *VirtualMachines* list view in the web console. This allows you to efficiently manage a group of VMs with minimal manual effort.
+
+Available bulk actions:
+
+* *Label VMs* - Add, edit, or remove labels that are applied across selected VMs.
+* *Delete VMs* - Select multiple VMs to delete. The confirmation dialog displays the number of VMs selected for deletion.
+* *Move VMs to folder* - Move selected VMs to a folder. All VMs must belong to the same namespace.
+* *LiveMigration* - Perform live migration of multiple selected VMs. The confirmation dialog displays the number of VMs selected for migration. The target node is chosen automatically; there is no option of specifying it.
+* *Take snapshot* - Take snapshots of multiple VMs. The *Take snapshots* dialog allows you to enter a suffix for the names of the resulting snapshots.

--- a/modules/virt-updating-multiple-vms.adoc
+++ b/modules/virt-updating-multiple-vms.adoc
@@ -11,7 +11,7 @@ You can use the command line interface (CLI) to update multiple virtual machines
 
 .Prerequisites
 
-* You installed the `oc` CLI.
+* You installed the {oc-first}.
 * You have access to the {product-title} cluster, and you have `cluster-admin` permissions.
 
 .Procedure
@@ -54,16 +54,16 @@ spec:
   spec:
    containers:
    - name: kubevirt-api-lifecycle-automation
-     image: quay.io/openshift-virtualization/kubevirt-api-lifecycle-automation:v4.21 <1>
+     image: quay.io/openshift-virtualization/kubevirt-api-lifecycle-automation:v4.21
      imagePullPolicy: Always
      env:
-     - name: MACHINE_TYPE_GLOB <2>
+     - name: MACHINE_TYPE_GLOB
        value: smth-glob9.10.0
-     - name: RESTART_REQUIRED <3>
+     - name: RESTART_REQUIRED
        value: "true"
-     - name: NAMESPACE <4>
+     - name: NAMESPACE
        value: "default"
-     - name: LABEL_SELECTOR <5>
+     - name: LABEL_SELECTOR
        value: my-vm
      securityContext:
       allowPrivilegeEscalation: false
@@ -77,22 +77,11 @@ spec:
    restartPolicy: Never
    serviceAccountName: kubevirt-api-lifecycle-automation
 ----
-
-<1> Replace the image value with your pull URL for the image.
-<2> Replace the `MACHINE_TYPE_GLOB` value with your own pattern. This pattern is used to detect deprecated machine types that need to be upgraded.
-<3> If the `RESTART_REQUIRED` emvironment variable is set to `true`, VMs are restarted after the machine type is updated. If you do not want VMs to be restarted, set the value to `false`.
-<4> The `namespace` environment value indicates the namespace to look for VMs in. Leave the parameter empty for the job to go over all namespaces in the cluster.
-<5> You can use the `LABEL_SELECTOR` environment variable to select VMs that receive the job action. If you want the job to go over all VMs in the cluster, do not assign a value to the parameter.
-
-
-[id="virt-performing-actions-on-multiple-virtual-machines_{context}"]
-== Performing bulk actions on virtual machines
-
-You can perform bulk actions on multiple virtual machines (VMs) simultaneously by using the *VirtualMachines* list view in the web console. This allows you to efficiently manage a group of VMs with minimal manual effort.
-
-.Available bulk actions
-* *Label VMs* - Add, edit, or remove labels that are applied across selected VMs.
-* *Delete VMs* - Select multiple VMs to delete. The confirmation dialog displays the number of VMs selected for deletion.
-* *Move VMs to folder* - Move selected VMs to a folder. All VMs must belong to the same namespace.
-* *LiveMigration* - Perform live migration of multiple selected VMs. The confirmation dialog displays the number of VMs selected for migration. The target node is chosen automatically; there is no option of specifying it.
-* *Take snapshot* - Take snapshots of multiple VMs. The *Take snapshots* dialog allows you to enter a suffix for the names of the resulting snapshots.
++
+where:
++
+`quay.io/openshift-virtualization/kubevirt-api-lifecycle-automation:v4.21`:: Specifies the pull URL for your image. Replace the image value in this example with your pull URL for the image.
+`MACHINE_TYPE_GLOB`:: Specifies the pattern that is used to detect deprecated machine types that need to be upgraded. Replace the `MACHINE_TYPE_GLOB` value with your own pattern.
+`RESTART_REQUIRED`:: Specifies whether VMs should be restarted after the machine type is updated. If the `RESTART_REQUIRED` environment variable is set to `true`, VMs are restarted after the machine type is updated. If you do not want VMs to be restarted, set this value to `false`.
+`NAMESPACE`:: Specifies the namespace to look for VMs in. Leave the parameter empty for the job to go over all namespaces in the cluster.
+`LABEL_SELECTOR`:: Specifies which VMs receive the job action. If you want the job to go over all VMs in the cluster, do not assign a value to the parameter.

--- a/virt/managing_vms/virt-edit-vms.adoc
+++ b/virt/managing_vms/virt-edit-vms.adoc
@@ -6,6 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 You can update a virtual machine (VM) configuration by using the {product-title} web console. You can update the YAML file or the *VirtualMachine details* page.
 
 You can also edit a VM by using the command line.
@@ -32,13 +33,13 @@ include::modules/virt-adding-secret-configmap-service-account-to-vm.adoc[levelof
 
 include::modules/virt-updating-multiple-vms.adoc[leveloffset=+1]
 
+include::modules/virt-performing-actions-on-multiple-virtual-machines.adoc[leveloffset=+2]
+
 include::modules/virt-configure-multiple-iothreads.adoc[leveloffset=+1]
 
-[discrete]
-[id="additional-resources-configmaps"]
 [role="_additional-resources"]
-=== Additional resources for config maps, secrets, and service accounts
+[id="additional-resources_{context}"]
+== Additional resources
 * xref:../../nodes/pods/nodes-pods-configmaps.adoc#nodes-pods-configmap-overview_builds-configmaps[Understanding config maps]
 * xref:../../nodes/pods/nodes-pods-secrets.adoc#nodes-pods-secrets-about[Providing sensitive data to pods]
 * xref:../../authentication/understanding-and-creating-service-accounts.adoc#service-accounts-overview[Understanding and creating service accounts]
-


### PR DESCRIPTION
Version(s):
4.12, 4.14, 4.16+

Issue:
https://issues.redhat.com/browse/CNV-74970

Link to docs preview:
- https://107560--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/managing_vms/virt-edit-vms.html#virt-updating-multiple-vms_virt-edit-vms
- https://107560--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/managing_vms/virt-edit-vms.html#additional-resources_virt-edit-vms

QE review:
N/A, formatting changes for DITA

Additional information:
* Removed callouts
* Updated addtl resources section and IDs, removed `===`
* Moved content from `==` in procedure which is not supported to a new concept module
