### PR TITLE
OSDOCS-17109-3:CQA-2-MSH-INST-3-bootc (attachment#3)

### DIFF
--- a/microshift_install_bootc/microshift-install-bootc-physically-bound.adoc
+++ b/microshift_install_bootc/microshift-install-bootc-physically-bound.adoc
@@ -1,12 +1,17 @@
 :_mod-docs-content-type: ASSEMBLY
+
 [id="microshift-install-bootc-physically-bound"]
-include::_attributes/attributes-microshift.adoc[]
 = Creating a fully self-contained bootc image
 :context: microshift-install-bootc-physically-bound
 
+include::_attributes/attributes-microshift.adoc[]
+
 toc::[]
 
-If you need your bootc image to include everything required to run workloads, use physically-bound container images. Edge-computing scenarios involving embedded systems on specialized devices, high security, or high hardware control scenarios are likely candidates.
+[role="_abstract"]
+You can use physically-bound container images if you need your bootc image to include everything required to run workloads. 
+
+Edge-computing scenarios involving embedded systems on specialized devices, high security, or high hardware control scenarios are likely candidates.
 
 include::modules/microshift-install-bootc-physically-bound-con.adoc[leveloffset=+1]
 

--- a/modules/microshift-embed-cont-images-bootc-image.adoc
+++ b/modules/microshift-embed-cont-images-bootc-image.adoc
@@ -6,7 +6,10 @@
 [id="microshift-embed-cont-images-bootc-image_{context}"]
 = Embedding container images into a bootc image
 
-First, you must add instructions to an existing Containerfile to copy the images you want and list them in a file to keep track of the copied image names. Then, you must copy images locally from the `/usr/lib/containers/storage` directory to the local container storage.
+[role="_abstract"]
+You embed container images by adding instructions to an existing Containerfile to copy the images you want and list them in a file to keep track of the copied image names.
+
+Then, you must copy images locally from the `/usr/lib/containers/storage` directory to the local container storage.
 
 [IMPORTANT]
 ====
@@ -27,9 +30,10 @@ You cannot store images in the default or additional container storage directory
 +
 [source,terminal,subs="+quotes"]
 ----
-$ podman build --secret id=pullsecret,src=/_<path/to/pull/secret>_.json <1>
+$ podman build --secret id=pullsecret,src=/_<path/to/pull/secret>_.json
 ----
-<1> Specify the path to your pull secret in _<path/to/pull/secret>_.
++
+Specify the path to your pull secret in _<path/to/pull/secret>_.
 
 . Add the instructions to physically embed the image at build time by adding the following to your Containerfile:
 +

--- a/modules/microshift-install-bootc-physically-bound-con.adoc
+++ b/modules/microshift-install-bootc-physically-bound-con.adoc
@@ -6,6 +6,7 @@
 [id="microshift-install-bootc-physically-bound_{context}"]
 = About physically bound bootc image building
 
+[role="_abstract"]
 When a bootc image is fully self-contained, everything you need to run workloads is embedded with the bootc image, including {microshift-short} and application container images. The underlying mechanism is to pre-pull physically-bound images during image build and then make them available at runtime.
 
 Because embedded images might change with each system update, you cannot pull the images directly to the default container storage. Additional image stores do not work in this case because of current implementation limits. These limits do not allow bootc image updates for those container images.


### PR DESCRIPTION
Version(s):
4.22

Issue:
https://issues.redhat.com/browse/OSDOCS-17109

Link to docs preview:
https://107562--ocpdocs-pr.netlify.app/microshift/latest/microshift_install_bootc/microshift-install-bootc-physically-bound.html
