### PR TITLE
OSSM-12329 Update version support table for 3.3 & Supported Platforms & Configurations

### DIFF
--- a/modules/ossm-release-notes-supported-versions.adoc
+++ b/modules/ossm-release-notes-supported-versions.adoc
@@ -8,193 +8,36 @@
 
 [role="_abstract"]
 
-See the following table for information about {SMProduct} 3.1.2 supported versions.
+See the following table for information about {SMProduct} 3.3.0 supported versions.
 
-== {SMProduct} 3.1.2 supported versions
+== {SMProduct} 3.3.0 supported versions
 
 [cols="1,1"]
 |===
 | Feature | Supported versions
 
 |{SMProduct} 3 Operator
-|3.1.2
+|3.3.0
 
 |{SMProduct} `Istio` control plane resource
-|1.26.4
+|1.28.4
 
 |{ocp-product-title}
-|4.16 and later
+|4.18 and later
 
 | Envoy proxy
-| 1.34.6
+| 1.36.4
 
 | `IstioCNI` resource
-| 1.26.4
+| 1.28.4
+
+| `Ztunnel` resource
+| 1.28.4
 
 |Kiali Operator
-|2.11.3
+|2.22.1
 
-|Kiali control plane resource
-|2.11.3
-
-|===
-
-See the following table for information about {SMProduct} 3.1.1 supported versions.
-
-== {SMProduct} 3.1.1 supported versions
-
-[cols="1,1"]
-|===
-| Feature | Supported versions
-
-|{SMProduct} 3 Operator
-|3.1.1
-
-|{SMProduct} `Istio` control plane resource
-|1.26.3
-
-|{ocp-product-title}
-|4.16 and later
-
-| Envoy proxy
-| 1.34.3
-
-| `IstioCNI` resource
-| 1.26.3
-
-|Kiali Operator
-|2.11.2
+|Kiali server
+|2.22.1
 
 |===
-
-See the following table for information about {SMProduct} 3.1.0 supported versions.
-
-== {SMProduct} 3.1.0 supported versions
-
-[cols="1,1"]
-|===
-| Feature | Supported versions
-
-|{SMProduct} 3 Operator
-|3.1.0
-
-|{SMProduct} `Istio` control plane resource
-|1.26.2
-
-|{ocp-product-title}
-|4.16 and later
-
-| Envoy proxy
-| 1.34.2
-
-| `IstioCNI` resource
-| 1.26.2
-
-|Kiali Operator
-|2.11.1
-
-|===
-
-See the following table for information about {SMProduct} 3.0.3 supported versions.
-
-== {SMProduct} 3.0.3 supported versions
-
-[cols="1,1"]
-|===
-| Feature | Supported versions
-
-|{SMProduct} 3 Operator
-|3.0.3
-
-|{SMProduct} `Istio` control plane resource
-|1.24.6
-
-|{ocp-product-title}
-|4.14 and later
-
-| Envoy proxy
-| 1.32.6
-
-| `IstioCNI` resource
-| 1.24.6 ^[1]^
-
-|Kiali Operator
-|2.4.7
-
-|===
-
-. The `Istio` control plane and `IstioCNI` resources can be upgraded in any order, as long as their version difference is within one minor version.
-
-See the following table for information about {SMProduct} 3.0.2 supported versions.
-
-== {SMProduct} 3.0.2 supported versions
-
-[cols="1,1"]
-|===
-| Feature | Supported versions
-
-|{SMProduct} 3 Operator
-|3.0.2
-
-|{SMProduct} `Istio` control plane resource
-|1.24.5
-
-|{ocp-product-title}
-|4.14 and later
-
-| Envoy proxy
-| 1.32.6
-
-| `IstioCNI` resource
-| 1.24.5 ^[1]^
-|===
-
-See the following table for information about {SMProduct} 3.0.1 supported versions.
-
-== {SMProduct} 3.0.1 supported versions
-
-[cols="1,1"]
-|===
-| Feature | Supported versions
-
-|{SMProduct} 3 Operator
-|3.0.1
-
-|{SMProduct} `Istio` control plane resource
-|1.24.4
-
-|{ocp-product-title}
-|4.14 and later
-
-| Envoy proxy
-| 1.32.4
-
-| `IstioCNI` resource
-| 1.24.4 ^[1]^
-|===
-
-See the following table for information about {SMProduct} 3.0.0 supported versions.
-
-== {SMProduct} 3.0.0 supported versions
-
-[cols="1,1"]
-|===
-| Feature | Supported versions
-
-|{SMProduct} 3 Operator
-|3.0.0
-
-|{SMProduct} `Istio` control plane resource
-|1.24.3
-
-|{ocp-product-title}
-|4.14 and later
-
-| Envoy proxy
-| 1.32.4
-
-| `IstioCNI` resource
-| 1.24.3 ^[1]^
-|===
-
-//note to self for post GA: might be worth having Envoy proxy and IstioCNI attributes.

--- a/modules/ossm-supported-platforms.adoc
+++ b/modules/ossm-supported-platforms.adoc
@@ -11,16 +11,16 @@
 The following platform versions support {SMProductShortName} control plane version {SMProductVersion}:
 
 ifdef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
-* Red Hat OpenShift Container Platform version 4.16 or later
+* Red Hat OpenShift Container Platform version 4.18 or later
 endif::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 ifndef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
-* Red Hat {ocp-product-title} version 4.16 or later
+* Red Hat {ocp-product-title} version 4.18 or later
 endif::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 * {product-dedicated} version 4
 * Azure Red Hat OpenShift (ARO) version 4
 * Red Hat OpenShift Service on AWS (ROSA)
 
-The {SMProductName} Operator supports multiple versions of `Istio`.
+The {SMProductName} Operator supports multiple versions of `{istio}`.
 
 If you are installing {SMProductName} on a link:https://docs.redhat.com/en/documentation/openshift_container_platform/latest/html/installation_overview/installing-preparing#supported-installation-methods-for-different-platforms[restricted network], follow the instructions for your chosen {ocp-product-title} infrastructure.
 


### PR DESCRIPTION
Change type: Doc update; Update version support table for 3.3 & Supported Platforms & Configurations

Doc JIRA: https://issues.redhat.com/browse/OSSM-12329

Fix Version: [service-mesh-docs-3.3](https://github.com/openshift/openshift-docs/tree/service-mesh-docs-3.3)

Doc Previews: 

- Version support table: https://107586--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/ossm-release-notes/ossm-release-notes-version-support-tables.html
- Supported Platforms & Configurations section: https://107586--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/install/ossm-supported-platforms-configurations.html

SME Review/QE Review: @ferhoyos @cam-garrison 
Peer Review: @kaldesai 