### PR TITLE
fix short desc, callouts, dita errors

### DIFF
--- a/backup_and_restore/application_backup_and_restore/troubleshooting/pods-crash-or-restart-due-to-lack-of-memory-or-cpu.adoc
+++ b/backup_and_restore/application_backup_and_restore/troubleshooting/pods-crash-or-restart-due-to-lack-of-memory-or-cpu.adoc
@@ -14,7 +14,9 @@ include::_attributes/attributes-openshift-dedicated.adoc[]
 
 
 [role="_abstract"]
-If a Velero or Restic pod crashes due to a lack of memory or CPU, you can set specific resource requests for either of those resources. The values for the resource request fields must follow the same format as Kubernetes resource requirements.
+Resolve Velero or Restic pod crashes caused by insufficient memory or CPU by configuring resource requests in the `DataProtectionApplication` custom resource (CR). This helps you allocate adequate CPU and memory resources to prevent pod restarts and ensure stable backup and restore operations.
+
+Ensure that the values for the resource request fields follow the same format as Kubernetes resource requirements.
 
 If you do not specify `configuration.velero.podConfig.resourceAllocations` or `configuration.restic.podConfig.resourceAllocations`, see the following default `resources` specification configuration for a Velero or Restic pod:
 
@@ -30,5 +32,7 @@ requests:
 * xref:../../../backup_and_restore/application_backup_and_restore/installing/about-installing-oadp.adoc#oadp-velero-cpu-memory-requirements_about-installing-oadp[Velero CPU and memory requirements based on collected data]
 
 include::modules/oadp-pod-crash-set-resource-request-velero.adoc[leveloffset=+1]
+
 include::modules/oadp-pod-crash-set-resource-request-restic.adoc[leveloffset=+1]
+
 include::modules/setting-resource-requests-for-a-nodeagent-pod.adoc[leveloffset=+1]

--- a/backup_and_restore/application_backup_and_restore/troubleshooting/restic-issues.adoc
+++ b/backup_and_restore/application_backup_and_restore/troubleshooting/restic-issues.adoc
@@ -12,11 +12,7 @@ include::_attributes/attributes-openshift-dedicated.adoc[]
 
 
 [role="_abstract"]
-You might encounter the following issues when you back up applications with Restic:
-
-* Restic permission error for NFS data volumes with the `root_squash` resource/parameter enabled
-* Restic `Backup` CR cannot be recreated after bucket is emptied
-* Restic restore partially failing on {product-title} 4.14 due to changed pod security admission (PSA) policy
+Troubleshoot common Restic issues during application backups and restores to maintain reliable data protection. Common Restic issues include NFS permission errors, backup custom resource re-creation failures, and restore failures caused by pod security admission policy changes.
 
 include::modules/restic-permission-error-for-nfs-data-volumes-with-root-squash-enabled.adoc[leveloffset=+1]
 

--- a/modules/oadp-pod-crash-set-resource-request-restic.adoc
+++ b/modules/oadp-pod-crash-set-resource-request-restic.adoc
@@ -7,16 +7,14 @@
 = Setting resource requests for a Restic pod
 
 [role="_abstract"]
-You can use the `configuration.restic.podConfig.resourceAllocations` specification field to set specific resource requests for a `Restic` pod.
+Use the `configuration.restic.podConfig.resourceAllocations` specification field to set specific resource requests for a `Restic` pod.
 
 include::snippets/about-restic-deprecation.adoc[leveloffset=+1]
 
 .Procedure
 
-* Set the `cpu` and `memory` resource requests in the YAML file:
+* Set the `cpu` and `memory` resource requests as shown in the following example:
 +
-.Example Restic file
-
 [source,yaml]
 ----
 apiVersion: oadp.openshift.io/v1alpha1
@@ -25,9 +23,10 @@ kind: DataProtectionApplication
 configuration:
   restic:
     podConfig:
-      resourceAllocations: <1>
+      resourceAllocations:
         requests:
           cpu: 1000m
           memory: 16Gi
 ----
-<1> The `resourceAllocations` listed are for average usage.
++
+The `resourceAllocations` listed are for average usage.

--- a/modules/oadp-pod-crash-set-resource-request-velero.adoc
+++ b/modules/oadp-pod-crash-set-resource-request-velero.adoc
@@ -7,14 +7,12 @@
 = Setting resource requests for a Velero pod
 
 [role="_abstract"]
-You can use the `configuration.velero.podConfig.resourceAllocations` specification field in the `oadp_v1alpha1_dpa.yaml` file to set specific resource requests for a `Velero` pod.
+Use the `configuration.velero.podConfig.resourceAllocations` specification field in the `oadp_v1alpha1_dpa.yaml` file to set specific resource requests for a `Velero` pod.
 
 .Procedure
 
-* Set the `cpu` and `memory` resource requests in the YAML file:
+* Set the `cpu` and `memory` resource requests as shown in the following example:
 +
-.Example Velero file
-
 [source,yaml]
 ----
 apiVersion: oadp.openshift.io/v1alpha1
@@ -23,9 +21,10 @@ kind: DataProtectionApplication
 configuration:
   velero:
     podConfig:
-      resourceAllocations: <1>
+      resourceAllocations:
         requests:
           cpu: 200m
           memory: 256Mi
 ----
-<1> The `resourceAllocations` listed are for average usage.
++
+The `resourceAllocations` listed are for average usage.

--- a/modules/oadp-restic-restore-failing-psa-policy.adoc
+++ b/modules/oadp-restic-restore-failing-psa-policy.adoc
@@ -4,16 +4,15 @@
 //
 :_mod-docs-content-type: PROCEDURE
 [id="oadp-restic-restore-failing-psa-policy_{context}"]
-= Troubleshooting restic restore partially failed issue on {ocp} 4.14 due to changed PSA policy
+= Troubleshooting restic restore partially failed issue on {ocp} 4.14 onward due to changed PSA policy
 
 [role="_abstract"]
-{ocp} 4.14 enforces a Pod Security Admission (PSA) policy that can hinder the readiness of pods during a Restic restore process.
+Resolve a partial failure of Restic restore on {ocp} 4.14 onward caused by Pod Security Admission (PSA) policy enforcement by adjusting the `restore-resource-priorities` field in your `DataProtectionApplication` (DPA) custom resource (CR). By doing so, you ensure that `SecurityContextConstraints` (SCC) resources are restored before pods. This helps you to complete restore operations successfully when PSA policies deny pod admission due to Velero resource restore order.
 
-If a `SecurityContextConstraints` (SCC) resource is not found when a pod is created, and the PSA policy on the pod is not set up to meet the required standards, pod admission is denied.
+From 4.14 onward, {ocp} enforces a PSA policy that can hinder the readiness of pods during a Restic restore process. If an SCC resource is not found when a pod is created, and the PSA policy on the pod is not set up to meet the required standards, pod admission is denied. 
 
-This issue arises due to the resource restore order of Velero.
+Review the following example error:
 
-.Sample error
 [source,text]
 ----
 \"level=error\" in line#2273: time=\"2023-06-12T06:50:04Z\"
@@ -49,7 +48,6 @@ restore=openshift-adp/todolist-backup-0780518c-08ed-11ee-805c-0a580a80e92c\n]",
 $ oc get dpa -o yaml
 ----
 +
-.Example DPA CR
 [source,yaml]
 ----
 # ...
@@ -58,18 +56,23 @@ configuration:
     enable: true
   velero:
     args:
-      restore-resource-priorities: 'securitycontextconstraints,customresourcedefinitions,namespaces,storageclasses,volumesnapshotclass.snapshot.storage.k8s.io,volumesnapshotcontents.snapshot.storage.k8s.io,volumesnapshots.snapshot.storage.k8s.io,datauploads.velero.io,persistentvolumes,persistentvolumeclaims,serviceaccounts,secrets,configmaps,limitranges,pods,replicasets.apps,clusterclasses.cluster.x-k8s.io,endpoints,services,-,clusterbootstraps.run.tanzu.vmware.com,clusters.cluster.x-k8s.io,clusterresourcesets.addons.cluster.x-k8s.io' <1>
+      restore-resource-priorities: 'securitycontextconstraints,customresourcedefinitions,namespaces,storageclasses,volumesnapshotclass.snapshot.storage.k8s.io,volumesnapshotcontents.snapshot.storage.k8s.io,volumesnapshots.snapshot.storage.k8s.io,datauploads.velero.io,persistentvolumes,persistentvolumeclaims,serviceaccounts,secrets,configmaps,limitranges,pods,replicasets.apps,clusterclasses.cluster.x-k8s.io,endpoints,services,-,clusterbootstraps.run.tanzu.vmware.com,clusters.cluster.x-k8s.io,clusterresourcesets.addons.cluster.x-k8s.io'
     defaultPlugins:
     - gcp
     - openshift
 ----
-<1> If you have an existing restore resource priority list, ensure you combine that existing list with the complete list.
++
+where:
++
+`restore-resource-priorities`:: If you have an existing restore resource priority list, ensure you combine that existing list with the complete list.
 
 . Ensure that the security standards for the application pods are aligned, as provided in link:https://access.redhat.com/solutions/7002730[Fixing PodSecurity Admission warnings for deployments], to prevent deployment warnings. If the application is not aligned with security standards, an error can occur regardless of the SCC. 
 
++
+
 [NOTE]
 ====
-This solution is temporary, and ongoing discussions are in progress to address it. 
+This solution is temporary, and ongoing discussions are in progress to address it.
 ====
 
 

--- a/modules/restic-backup-cr-cannot-be-recreated-after-bucket-is-emptied.adoc
+++ b/modules/restic-backup-cr-cannot-be-recreated-after-bucket-is-emptied.adoc
@@ -8,11 +8,12 @@
 = Troubleshooting Restic Backup CR issue that cannot be re-created after bucket is emptied
 
 [role="_abstract"]
-Velero does not re-create or update the Restic repository from the `ResticRepository` manifest if the Restic directories are deleted from object storage. For more information, see link:https://github.com/vmware-tanzu/velero/issues/4421[Velero issue 4421].
+Resolve the `Backup` custom resource (CR) re-creation failure that occurs after you empty the object storage bucket. This failure occurs because Velero does not automatically re-create the Restic repository from the `ResticRepository` manifest. 
 
-If you create a Restic `Backup` CR for a namespace, empty the object storage bucket, and then re-create the `Backup` CR for the same namespace, the re-created `Backup` CR fails. In this case, the `velero` pod log displays the following error message:
-+
-.Sample error
+For more information, see link:https://github.com/vmware-tanzu/velero/issues/4421[Velero issue 4421].
+
+The `velero` pod log displays the following error message:
+
 [source,text]
 ----
 stderr=Fatal: unable to open config file: Stat: The specified key does not exist.\nIs there a repository at the following location?
@@ -27,7 +28,7 @@ stderr=Fatal: unable to open config file: Stat: The specified key does not exist
 $ oc delete resticrepository openshift-adp <name_of_the_restic_repository>
 ----
 +
-In the following error log, `mysql-persistent` is the problematic Restic repository. The name of the repository appears in italics for clarity.
+In the following error log, `mysql-persistent` is the problematic Restic repository. The name of the repository is displayed in italics for clarity.
 +
 [source,text,options="nowrap",subs="+quotes,verbatim"]
 ----

--- a/modules/restic-permission-error-for-nfs-data-volumes-with-root-squash-enabled.adoc
+++ b/modules/restic-permission-error-for-nfs-data-volumes-with-root-squash-enabled.adoc
@@ -8,14 +8,14 @@
 = Troubleshooting Restic permission errors for NFS data volumes
 
 [role="_abstract"]
-If your NFS data volumes have the `root_squash` parameter enabled, `Restic` maps set to the `nfsnobody` value, and do not have permission to create backups, the Restic` pod log displays the following error message:
+Create a supplemental group and add its group ID to the `DataProtectionApplication` customer resource CR to resolve `Restic` permission errors on NFS data volumes with `root_squash` enabled. This helps you to restore backup functionality for NFS volumes without disabling root squash.
 
-.Sample error
+If your NFS data volumes have the `root_squash` parameter enabled, `Restic` maps set to the `nfsnobody` value, and do not have permission to create backups, the `Restic` pod log displays the following error message:
+
 [source,text]
 ----
 controller=pod-volume-backup error="fork/exec/usr/bin/restic: permission denied".
 ----
-You can resolve this issue by creating a supplemental group for `Restic` and adding the group ID to the `DataProtectionApplication` manifest.
 
 .Procedure
 
@@ -36,9 +36,12 @@ spec:
       enable: true
       uploaderType: restic
       supplementalGroups:
-      - <group_id> <1>
+      - <group_id>
 # ...
 ----
-<1> Specify the supplemental group ID.
++
+where:
++
+`<group_id>`:: Specifies the supplemental group ID.
 
 . Wait for the `Restic` pods to restart so that the changes are applied.

--- a/modules/setting-resource-requests-for-a-nodeagent-pod.adoc
+++ b/modules/setting-resource-requests-for-a-nodeagent-pod.adoc
@@ -8,7 +8,7 @@
 = Setting resource requests for a nodeAgent pod
 
 [role="_abstract"]
-You can use the `configuration.nodeAgent.podConfig.resourceAllocations` specification field to set specific resource requests for a `nodeAgent` pod.
+Use the `configuration.nodeAgent.podConfig.resourceAllocations` specification field to set specific resource requests for a `nodeAgent` pod.
 
 include::snippets/about-restic-deprecation.adoc[leveloffset=+1]
 
@@ -17,7 +17,6 @@ include::snippets/about-restic-deprecation.adoc[leveloffset=+1]
 
 . Set the `cpu` and `memory` resource requests in the YAML file:
 +
-.Example `nodeAgent.yaml` file
 [source,yaml]
 ----
 apiVersion: oadp.openshift.io/v1alpha1
@@ -45,13 +44,16 @@ spec:
       enable: true
       uploaderType: kopia
       podConfig:
-        resourceAllocations: <1>
+        resourceAllocations:
           requests:
             cpu: 1000m
-            memory: 16Gi <2>
+            memory: 16Gi
 ----
-<1> The resource allocation examples shown are for average usage.
-<2> You can modify this parameter depending on your infrastructure and usage.
++
+where:
++
+`resourceAllocations`:: The resource allocation examples shown are for average usage.
+`memory`:: You can modify this parameter depending on your infrastructure and usage.
 
 . Create the DPA CR by running the following command:
 +


### PR DESCRIPTION
## Jira

[OADP-7339](https://issues.redhat.com/browse/OADP-7339)

This PR contains fixes for `pods-crash-or-restart-due-to-lack-of-memory-or-cpu` and `restic-issues` assemblies for callouts, short desc, block titles, and other CQA work.

## Version

OCP 4.14 → OCP 4.22

## Preview

[Pod crash](https://107596--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/troubleshooting/pods-crash-or-restart-due-to-lack-of-memory-or-cpu.html)

[Restic Issues](https://107596--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/troubleshooting/restic-issues.html)

