### PR TITLE
[enterprise-4.12] Remove kube-reserved 'Understanding how to allocate resources for nodes'

### DIFF
--- a/modules/nodes-nodes-resources-configuring-about.adoc
+++ b/modules/nodes-nodes-resources-configuring-about.adoc
@@ -6,26 +6,14 @@
 [id="nodes-nodes-resources-configuring-about_{context}"]
 = Understanding how to allocate resources for nodes
 
-CPU and memory resources reserved for node components in {product-title} are based on two node settings:
+[role="_abstract"]
+You can manually reserve optimal CPU and memory resources for the node and system components on your nodes. Ensuring proper resources for these services can help ensure that your cluster is operating efficiently.
 
-[options="header",cols="1,2"]
-|===
-|Setting |Description
-
-|`kube-reserved`
-| This setting is not used with {product-title}. Add the CPU and memory resources that you planned to reserve to the `system-reserved` setting.
-
-|`system-reserved`
-| This setting identifies the resources to reserve for the node components and system components, such as CRI-O and Kubelet. The default settings depend on the {product-title} and Machine Config Operator versions. Confirm the default `systemReserved` parameter on the `machine-config-operator` repository.
-|===
-
-If a flag is not set, the defaults are used. If none of the flags are set, the
-allocated resource is set to the node's capacity as it was before the
-introduction of allocatable resources.
+The `system-reserved` setting in the `KubeletConfig` custom resource (CR) identifies the resources to reserve for the node components and system components, such as CRI-O and Kubelet. The default settings depend on the {product-title} and Machine Config Operator versions. Confirm the default `systemReserved` parameter on the `machine-config-operator` repository.
 
 [NOTE]
 ====
-Any CPUs specifically reserved using the `reservedSystemCPUs` parameter are not available for allocation using `kube-reserved` or `system-reserved`.
+The Kubernetes `kubeReserved` parameter is not supported in {product-title}.
 ====
 
 [id="computing-allocated-resources_{context}"]


### PR DESCRIPTION
Manual cherrypick of https://github.com/openshift/openshift-docs/pull/105623. Need to remove references to automatic script that was added in 4.21+