### PR TITLE
OSDOCS-18093: update our docs to use v1beta2 for kueue objects

### DIFF
--- a/modules/kueue-clusterqueue-configuring-cohorts-reference.adoc
+++ b/modules/kueue-clusterqueue-configuring-cohorts-reference.adoc
@@ -6,20 +6,20 @@
 [id="clusterqueue-configuring-cohorts-reference_{context}"]
 = Configuring cohorts within a cluster queue spec
 
-You can add a cluster queue to a cohort by specifying the name of the cohort in the `.spec.cohort` field of the `ClusterQueue` object, as shown in the following example:
+You can add a cluster queue to a cohort by specifying the name of the cohort in the `.spec.cohortName` field of the `ClusterQueue` object, as shown in the following example:
 
 [source,yaml]
 ----
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: ClusterQueue
 metadata:
   name: cluster-queue
 spec:
 # ...
-  cohort: example-cohort
+  cohortName: example-cohort
 # ...
 ----
 
-All cluster queues that have a matching `spec.cohort` are part of the same cohort.
+All cluster queues that have a matching `spec.cohortName` are part of the same cohort.
 
-If the `spec.cohort` field is omitted, the cluster queue does not belong to any cohort and cannot access borrowable resources.
+If the `spec.cohortName` field is omitted, the cluster queue does not belong to any cohort and cannot access borrowable resources.

--- a/modules/kueue-clusterqueue-share-value.adoc
+++ b/modules/kueue-clusterqueue-share-value.adoc
@@ -15,7 +15,7 @@ The `weight` value, or share value, defines a comparative advantage for the clus
 .Example cluster queue with a fair sharing weight configured
 [source,yaml]
 ----
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: ClusterQueue
 metadata:
   name: cluster-queue
@@ -28,7 +28,7 @@ spec:
       resources:
       - name: cpu
         nominalQuota: 9
-  cohort: example-cohort
+  cohortName: example-cohort
   fairSharing:
     weight: 2
 ----

--- a/modules/kueue-configuring-clusterqueues.adoc
+++ b/modules/kueue-configuring-clusterqueues.adoc
@@ -25,7 +25,7 @@ include::snippets/prereqs-snippet-yaml.adoc[]
 .Example of a basic `ClusterQueue` object using a single resource flavor
 [source,yaml]
 ----
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: ClusterQueue
 metadata:
   name: cluster-queue

--- a/modules/kueue-configuring-localqueue-defaults.adoc
+++ b/modules/kueue-configuring-localqueue-defaults.adoc
@@ -28,7 +28,7 @@ include::snippets/prereqs-snippet-yaml-1.1.adoc[]
 .Example of a default `LocalQueue` object
 [source,yaml]
 ----
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: LocalQueue
 metadata:
   namespace: team-namespace

--- a/modules/kueue-configuring-localqueues.adoc
+++ b/modules/kueue-configuring-localqueues.adoc
@@ -23,7 +23,7 @@ include::snippets/prereqs-snippet-yaml.adoc[]
 .Example of a basic `LocalQueue` object
 [source,yaml]
 ----
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: LocalQueue
 metadata:
   namespace: team-namespace

--- a/modules/kueue-configuring-resourceflavors.adoc
+++ b/modules/kueue-configuring-resourceflavors.adoc
@@ -23,7 +23,7 @@ include::snippets/prereqs-snippet-yaml.adoc[]
 .Example of an empty `ResourceFlavor` object
 [source,yaml]
 ----
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: ResourceFlavor
 metadata:
   name: default-flavor
@@ -32,7 +32,7 @@ metadata:
 .Example of a custom `ResourceFlavor` object
 [source,yaml]
 ----
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: ResourceFlavor
 metadata:
   name: "x86"

--- a/modules/kueue-monitoring-pending-workloads-on-demand.adoc
+++ b/modules/kueue-monitoring-pending-workloads-on-demand.adoc
@@ -26,12 +26,12 @@ The following procedure tells you how to install and test workload monitoring.
 ----
 cat <<EOF| oc create -f -
 ---
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: ResourceFlavor
 metadata:
   name: "default-flavor"
 ---
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: ClusterQueue
 metadata:
   name: "cluster-queue"
@@ -47,7 +47,7 @@ spec:
       - name: "memory"
         nominalQuota: 36Gi
 ---
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: LocalQueue
 metadata:
   namespace: "default"

--- a/modules/kueue-viewing-pending-workloads-clusterqueue.adoc
+++ b/modules/kueue-viewing-pending-workloads-clusterqueue.adoc
@@ -15,7 +15,7 @@ To view all pending workloads at the cluster level, administrators can use the `
 +
 [source,terminal]
 ----
-$ oc get --raw "/apis/visibility.kueue.x-k8s.io/v1beta1/clusterqueues/cluster-queue/pendingworkloads"
+$ oc get --raw "/apis/visibility.kueue.x-k8s.io/v1beta2/clusterqueues/cluster-queue/pendingworkloads"
 ----
 +
 .Example output
@@ -23,7 +23,7 @@ $ oc get --raw "/apis/visibility.kueue.x-k8s.io/v1beta1/clusterqueues/cluster-qu
 ----
 {
   "kind": "PendingWorkloadsSummary",
-  "apiVersion": "visibility.kueue.x-k8s.io/v1beta1",
+  "apiVersion": "visibility.kueue.x-k8s.io/v1beta2",
   "metadata": {
     "creationTimestamp": null
   },
@@ -99,5 +99,5 @@ You can pass the following optional query parameters:
 +
 [source,terminal]
 ----
-$ oc get --raw "/apis/visibility.kueue.x-k8s.io/v1beta1/clusterqueues/cluster-queue/pendingworkloads?limit=1&offset=0"
+$ oc get --raw "/apis/visibility.kueue.x-k8s.io/v1beta2/clusterqueues/cluster-queue/pendingworkloads?limit=1&offset=0"
 ----

--- a/modules/kueue-viewing-pending-workloads-localqueue.adoc
+++ b/modules/kueue-viewing-pending-workloads-localqueue.adoc
@@ -15,7 +15,7 @@ To view the pending workloads submitted by a specific tenant within their namesp
 +
 [source,terminal]
 ----
-$ oc get --raw /apis/visibility.kueue.x-k8s.io/v1beta1/namespaces/default/localqueues/user-queue/pendingworkloads
+$ oc get --raw /apis/visibility.kueue.x-k8s.io/v1beta2/namespaces/default/localqueues/user-queue/pendingworkloads
 ----
 +
 .Example output
@@ -23,7 +23,7 @@ $ oc get --raw /apis/visibility.kueue.x-k8s.io/v1beta1/namespaces/default/localq
 ----
 {
   "kind": "PendingWorkloadsSummary",
-  "apiVersion": "visibility.kueue.x-k8s.io/v1beta1",
+  "apiVersion": "visibility.kueue.x-k8s.io/v1beta2",
   "metadata": {
     "creationTimestamp": null
   },
@@ -99,5 +99,5 @@ You can pass the following optional query parameters:
 +
 [source,terminal]
 ----
-$ oc get --raw "/apis/visibility.kueue.x-k8s.io/v1beta1/namespaces/default/localqueues/user-queue/pendingworkloads?limit=1&offset=0"
+$ oc get --raw "/apis/visibility.kueue.x-k8s.io/v1beta2/namespaces/default/localqueues/user-queue/pendingworkloads?limit=1&offset=0"
 ----


### PR DESCRIPTION
Version(s):
4.18, 4.19, 4.20, 4.21, 4.22

Issue:
https://issues.redhat.com/browse/OSDOCS-18093

Link to docs preview:
https://107617--ocpdocs-pr.netlify.app/openshift-enterprise/latest/ai_workloads/kueue/configuring-fairsharing.html
https://107617--ocpdocs-pr.netlify.app/openshift-enterprise/latest/ai_workloads/kueue/configuring-quotas.html
https://107617--ocpdocs-pr.netlify.app/openshift-enterprise/latest/ai_workloads/kueue/monitoring-pending-workloads.html
https://107617--ocpdocs-pr.netlify.app/openshift-enterprise/latest/ai_workloads/kueue/using-cohorts.html

Dev: @kannon92 

QE review: @anahas-redhat

    QE has approved this change.

Additional information:

