### PR TITLE
Fix formatting issues in GCP STS setup documentation

### DIFF
--- a/modules/distr-tracing-tempo-object-storage-setup-gcp-sts-install.adoc
+++ b/modules/distr-tracing-tempo-object-storage-setup-gcp-sts-install.adoc
@@ -24,10 +24,10 @@ include::snippets/technology-preview.adoc[leveloffset=+1]
 [source,bash]
 ----
 SERVICE_ACCOUNT_EMAIL=$(gcloud iam service-accounts create <iam_service_account_name> \ # <1>
-    --display-name="Tempo Account" \
-    --project <project_id>  \ # <2>
-    --format='value(email)' \ 
-    --quiet)
+--display-name="Tempo Account" \
+--project <project_id>  \ # <2>
+--format='value(email)' \ 
+--quiet)
 ----
 <1> The name of the service account on the {gcp-short}.
 <2> The project ID of the service account on the {gcp-short}.
@@ -37,8 +37,8 @@ SERVICE_ACCOUNT_EMAIL=$(gcloud iam service-accounts create <iam_service_account_
 [source,terminal]
 ----
 $ gcloud projects add-iam-policy-binding <project_id> \
-    --member "serviceAccount:$SERVICE_ACCOUNT_EMAIL" \
-    --role "roles/storage.objectAdmin"
+  --member "serviceAccount:$SERVICE_ACCOUNT_EMAIL" \
+  --role "roles/storage.objectAdmin"
 ----
 
 . Retrieve the `POOL_ID` value of the {gcp-full} Workload Identity Pool that is associated with the cluster. How you can retrieve this value depends on your environment, so the following command is only an example:
@@ -78,11 +78,11 @@ $ gcloud iam service-accounts add-iam-policy-binding "$SERVICE_ACCOUNT_EMAIL" \ 
 [source,terminal]
 ----
 $ gcloud iam workload-identity-pools create-cred-config \
-    "projects/<project_number>/locations/global/workloadIdentityPools/<pool_id>/providers/<provider_id>" \
-    --service-account="$SERVICE_ACCOUNT_EMAIL" \
-    --credential-source-file=/var/run/secrets/storage/serviceaccount/token \ # <1>
-    --credential-source-type=text \
-    --output-file=<output_file_path> # <2>
+  "projects/<project_number>/locations/global/workloadIdentityPools/<pool_id>/providers/<provider_id>" \
+  --service-account="$SERVICE_ACCOUNT_EMAIL" \
+  --credential-source-file=/var/run/secrets/storage/serviceaccount/token \ # <1>
+  --credential-source-type=text \
+  --output-file=<output_file_path> # <2>
 ----
 <1> The `credential-source-file` parameter must always point to the `/var/run/secrets/storage/serviceaccount/token` path because the Operator mounts the token from this path.
 <2> The path for saving the output file.


### PR DESCRIPTION
- Google Cloud storage with the STS wrong command structure
- Here is the documentation link: https://docs.redhat.com/en/documentation/openshift_container_platform/4.21/html/distributed_tracing/distr-tracing-tempo-installing#setting-up-google-cloud-storage-with-security-token-service_distr-tracing-tempo-installing 

Here is the updated look for all these code blocks: 
~~~
SERVICE_ACCOUNT_EMAIL=$(gcloud iam service-accounts create <iam_service_account_name> \  1  
--display-name="Tempo Account" \
--project <project_id>  \  2 
--format='value(email)' \
--quiet) 
~~~
~~~
$ gcloud projects add-iam-policy-binding <project_id> \
  --member "serviceAccount:$SERVICE_ACCOUNT_EMAIL" \
  --role "roles/storage.objectAdmin" 
~~~
~~~
$ gcloud iam workload-identity-pools create-cred-config \
  "projects/<project_number>/locations/global/workloadIdentityPools/<pool_id>/providers/<provider_id>" \
  --service-account="$SERVICE_ACCOUNT_EMAIL" \
  --credential-source-file=/var/run/secrets/storage/serviceaccount/token \1 
  --credential-source-type=text \
  --output-file=<output_file_path>
~~~

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

RHOCP 4.21, RHOCP 4.20, RHOCP 4.19, RHOCP 4.18

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

https://issues.redhat.com/browse/OBSDOCS-3167


Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

https://107640--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/distr_tracing/distr-tracing-tempo-installing.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
