### PR TITLE
OSDOCS Remove kube-reserved 'Understanding how to allocate resources for nodes' follow up

### DIFF
--- a/modules/nodes-nodes-resources-configuring-about.adoc
+++ b/modules/nodes-nodes-resources-configuring-about.adoc
@@ -49,7 +49,7 @@ For example, on a 4-core node, 0.5 vCPU is reserved for node and system componen
 Any CPUs specifically reserved using the `reservedSystemCPUs` parameter in a `KubeletConfig` object are not available for allocation using `system-reserved`.
 ====
 
-You can manually manage CPU and memory reservations for the node and system components by configuring the `system-reserved` parameter in a `MachineConfig` object, as described in "Manually allocating resources for nodes".
+You can manually manage CPU and memory reservations for the node and system components by configuring the `system-reserved` parameter in a `KubeletConfig` object, as described in "Manually allocating resources for nodes".
 
 [id="computing-allocated-resources_{context}"]
 == How {product-title} computes allocated resources


### PR DESCRIPTION
Made an error in https://github.com/openshift/openshift-docs/pull/105623. This PR fixes the error. CP to 4.21 and 4.22 only. The error doesn't appear in 4.19 and lower, as those were manual CPs.

Preview:


QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->