### PR TITLE
HCP fix bullet indentation in Creating a private hosted cluster on AWS

### DIFF
--- a/modules/hcp-create-private-hc-aws.adoc
+++ b/modules/hcp-create-private-hc-aws.adoc
@@ -46,6 +46,8 @@ $ hcp create cluster aws \
 <8> Specify the Amazon Resource Name (ARN), for example, `arn:aws:iam::820196288204:role/myrole`. For more information about ARN roles, see "Identity and Access Management (IAM) permissions".
 +
 The following API endpoints for the hosted cluster are accessible through a private DNS zone:
-
++
+--
 * `api.<hosted_cluster_name>.hypershift.local`
 * `*.apps.<hosted_cluster_name>.hypershift.local`
+--


### PR DESCRIPTION
Fixing an issue with misplaced bullets. 

<img width="804" height="176" alt="image" src="https://github.com/user-attachments/assets/df3ff0fc-ff8f-4b42-bf6c-3d844e7185e3" />
