### PR TITLE
PR for SRVLOGIC-781: Add a section for upgrading the OpenShift Serverless Logic Operator from 1.37.0 to 1.37.1

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -420,6 +420,8 @@ Topics:
     File: serverless-logic-upgrading-operator-from-1-35-to-1-36
   - Name: Upgrading Serverless Logic Operator from 1.36.0 to 1.37.0
     File: serverless-logic-upgrading-operator-from-1-36-to-1-37
+  - Name: Upgrading Serverless Logic Operator from 1.37.0 to 1.37.1
+    File: serverless-logic-upgrading-operator-from-1-37-0-to-1-37-1
 
 ---
 # Knative kn CLI

--- a/modules/serverless-logic-1-37-1-finalizing-the-upgrade.adoc
+++ b/modules/serverless-logic-1-37-1-finalizing-the-upgrade.adoc
@@ -1,0 +1,17 @@
+// Module included in the following assemblies:
+// * serverless-logic/serverless-logic-upgrading-operator-from-1-37-0-to-1-37-1
+
+:_mod-docs-content-type: REFERENCE
+[id="serverless-logic-1-37-1-finalizing-the-upgrade_{context}"]
+= Finalizing the upgrade
+
+[role="_abstract"]
+After upgrading the {ServerlessLogicOperatorName} to version 1.37.1, you must finalize the upgrade process by redeploying the workflows.
+
+Follow the appropriate steps based on the profile of your workflows and services.
+
+.Prerequisites
+* You have access to the cluster with `cluster-admin` privileges.
+* You have {ServerlessLogicOperatorName} installed on your cluster.
+* You have access to a {ServerlessLogicProductName} project with the appropriate roles and permissions to create applications and other workloads in {ocp-product-title}.
+* You have installed the OpenShift CLI (`oc`).

--- a/modules/serverless-logic-1-37-1-increasing-jobs-service-retry-interval.adoc
+++ b/modules/serverless-logic-1-37-1-increasing-jobs-service-retry-interval.adoc
@@ -1,0 +1,45 @@
+// Module included in the following assemblies:
+// * serverless-logic/serverless-logic-upgrading-operator-from-1-37-0-to-1-37-1
+
+:_mod-docs-content-type: PROCEDURE
+[id="serverless-logic-1-37-1-increasing-jobs-service-retry-interval_{context}"]
+= Increasing the Jobs Service retry interval
+
+[role="_abstract"]
+During system upgrades or migrations, job executions might fail temporarily because the system enters transitional states. For example, workflows might not be fully available while migration is in progress.
+
+If the retry interval is too short, the system might discard failed jobs before the upgrade completes. Increase the Jobs Service retry interval before you start the upgrade. This change ensures that the system retains failed jobs during the upgrade and retries them after the system stabilizes.
+
+.Procedure
+
+. Edit your `SonataFlowPlatform` custom resource (CR) and add the `KOGITO_JOBS_SERVICE_MAXINTERVALLIMITTORETRYMILLIS` environment variable to `jobService.podTemplate.container`:
++
+[source,yaml]
+----
+apiVersion: sonataflow.org/v1alpha08
+kind: SonataFlowPlatform
+metadata:
+  name: sonataflow-platform-example
+  namespace: example-namespace
+spec:
+  # Preserve all existing fields in your SonataFlowPlatform
+  services:
+    jobService:
+      podTemplate:
+        container:
+          env:
+            - name: KOGITO_JOBS_SERVICE_MAXINTERVALLIMITTORETRYMILLIS
+              # Example: retry interval of 4 hours
+              value: "14400000"
+----
+
+. Keep all existing fields in your `SonataFlowPlatform` CR unchanged.
+
+. Reapply the `SonataFlowPlatform` CR by running the following command:
++
+[source,terminal]
+----
+oc apply -f <sonataflowplatform.yaml>
+----
+
+. Verify that the Jobs Service deployment updates successfully.

--- a/modules/serverless-logic-1-37-1-preparing-for-the-upgrade.adoc
+++ b/modules/serverless-logic-1-37-1-preparing-for-the-upgrade.adoc
@@ -1,0 +1,23 @@
+// Module included in the following assemblies:
+// * serverless-logic/serverless-logic-upgrading-operator-from-1-37-0-to-1-37-1
+
+:_mod-docs-content-type: REFERENCE
+[id="serverless-logic-1-37-1-preparing-for-the-upgrade_{context}"]
+= Preparing for the 1.37.0 to 1.37.1 upgrade
+
+[role="_abstract"]
+Before starting the upgrade process, prepare your {ServerlessLogicProductName} environment to upgrade from version 1.37.0 to 1.37.1.
+
+The preparation process is as follows:
+
+* Deleting workflows based on their profiles.
+* Backing up all necessary databases and resources.
+* Ensuring you have a record of all custom configurations.
+
+.Prerequisites
+* You have access to the cluster with `cluster-admin` privileges.
+* You have {ServerlessLogicOperatorName} installed on your cluster.
+* You have access to a {ServerlessLogicProductName} project with the appropriate roles and permissions to create applications and other workloads in {ocp-product-title}.
+* You have backups for all workflow, Data Index, and Job Service databases where persistence is enabled.
+* You have access to all namespaces where `SonataFlow`, Data Index, and Job Service are deployed.
+* You have installed the OpenShift CLI (`oc`).

--- a/modules/serverless-logic-1-37-1-restoring-jobs-service-retry-interval.adoc
+++ b/modules/serverless-logic-1-37-1-restoring-jobs-service-retry-interval.adoc
@@ -1,0 +1,27 @@
+// Module included in the following assemblies:
+// * serverless-logic/serverless-logic-upgrading-operator-from-1-37-0-to-1-37-1
+
+:_mod-docs-content-type: PROCEDURE
+[id="serverless-logic-1-37-1-restoring-jobs-service-retry-interval_{context}"]
+= Restoring the Jobs Service retry interval
+
+[role="_abstract"]
+After you redeploy all workflows, restore the Jobs Service retry interval to its original configuration.
+
+.Procedure
+
+. Edit your `SonataFlowPlatform` custom resource (CR) and update the `KOGITO_JOBS_SERVICE_MAXINTERVALLIMITTORETRYMILLIS` environment variable by one of the following steps:
++
+* Remove the environment variable if you added it only for the upgrade.
+* Restore the environment variable to its earlier value if you had overridden the default configuration.
+
+. Keep all existing fields in your `SonataFlowPlatform` CR unchanged.
+
+. Reapply the `SonataFlowPlatform` CR:
++
+[source,terminal]
+----
+oc apply -f <sonataflowplatform.yaml>
+----
+
+. Verify that the Jobs Service deployment updates successfully.

--- a/modules/serverless-logic-upgrade-1-37-1-deleting-migrating-workflows-with-gitops-profile.adoc
+++ b/modules/serverless-logic-upgrade-1-37-1-deleting-migrating-workflows-with-gitops-profile.adoc
@@ -1,0 +1,91 @@
+// Module included in the following assemblies:
+// * serverless-logic/serverless-logic-upgrading-operator-from-1-36-to-1-37
+
+:_mod-docs-content-type: PROCEDURE
+[id="serverless-logic-upgrade-1-37-1-deleting-migrating-workflows-with-gitops-profile_{context}"]
+= Deleting workflows with the gitops profile
+
+[role="_abstract"]
+For workflows that use the `gitops` profile, it is strongly recommended to rebuild the workflow image that you generated for version `1.37.0` before upgrading the Operator. Rebuilding the image ensures compatibility with {ServerlessLogicProductName} `1.37.1`.
+
+For each workflow, for example `my-workflow`, complete the following steps.
+
+.Procedure
+
+. Rebuild the workflow image by using the {ServerlessLogicProductName} `1.37.1` workflow builder image:
++
+[source,terminal]
+----
+$ registry.redhat.io/openshift-serverless-1/logic-swf-builder-rhel9:1.37.1
+----
+
+. Reconfigure the workflow image by considering the following behavior:
++
+By default, {ServerlessLogicProductName} generates a workflow `Deployment` with `imagePullPolicy: IfNotPresent`. If you redeploy a workflow with the same image name, the cluster reuses the earlier downloaded image, even if the image was rebuilt.
+
+. Do not change the workflow definition or any related metadata when rebuilding the image.
++ 
+Rebuilding the image creates a new image build, not a new workflow version. The workflow name, version, and description must remain unchanged.
+
+. Ensure that the cluster pulls the rebuilt image by using one of the following approaches:
+
+* Use a new image tag and update the workflow to reference the new tag (recommended).
++
+You get an output similar to the following example:
++
+[source,yaml]
+----
+current image: quay.io/my-images/my-workflow:1.0
+new image: quay.io/my-images/my-workflow:1.0-1
+
+apiVersion: sonataflow.org/v1alpha08
+kind: SonataFlow
+metadata: # don't change
+  name: my-workflow
+  annotations:
+    sonataflow.org/description: My Workflow
+    sonataflow.org/version: '1.0'
+    sonataflow.org/profile: gitops
+spec:
+  podTemplate:
+    container:
+      # only change the image name/tag
+      image: quay.io/my-images/my-workflow:1.0-1
+  flow:
+    # the workflow definition (don't change)
+----
+
+* Preserve the image name and configure the workflow with `imagePullPolicy: Always`.
++
+You get an output similar to the following example:
++
+[source,yaml]
+----
+apiVersion: sonataflow.org/v1alpha08
+kind: SonataFlow
+metadata:
+  name: my-workflow
+  annotations:
+    sonataflow.org/description: My Workflow
+    sonataflow.org/version: '1.0'
+    sonataflow.org/profile: gitops
+spec:
+  podTemplate:
+    container:
+      image: quay.io/my-images/my-workflow:1.0
+      # change only the image pull policy
+      imagePullPolicy: Always
+  flow:
+    # do not change the workflow definition
+----
+
+. If the workflow uses persistence, back up the workflow database. Ensure that the backup includes all database objects, not only table data.
+
+. Ensure that you have a copy of the corresponding `SonataFlow` custom resource (CR) and any related Kubernetes resources created for the workflow. For example, if the workflow uses custom property configurations, keep a copy of the user-provided `ConfigMap` that has the `application.properties` file.
+
+. Delete the workflow by running the following command: 
++
+[source,terminal]
+----
+$ oc delete -f <my-workflow.yaml> -n <target_namespace>
+----

--- a/modules/serverless-logic-upgrade-1-37-1-finalizing-data-index.adoc
+++ b/modules/serverless-logic-upgrade-1-37-1-finalizing-data-index.adoc
@@ -1,0 +1,9 @@
+// Module included in the following assemblies:
+// * serverless-logic/serverless-logic-upgrading-operator-from-1-36-to-1-37
+
+:_mod-docs-content-type: REFERENCE
+[id="serverless-logic-upgrade-1-37-1-finalizing-data-index_{context}"]
+= Finalizing the Data Index upgrade
+
+[role="_abstract"]
+After you upgrade the {ServerlessLogicOperatorName} to version 1.37.1, the Data Index service restarts automatically and runs version 1.37.1.

--- a/modules/serverless-logic-upgrade-1-37-1-finalizing-job-service.adoc
+++ b/modules/serverless-logic-upgrade-1-37-1-finalizing-job-service.adoc
@@ -1,0 +1,9 @@
+// Module included in the following assemblies:
+// * serverless-logic/serverless-logic-upgrading-operator-from-1-36-to-1-37
+
+:_mod-docs-content-type: REFERENCE
+[id="serverless-logic-upgrade-1-37-1-finalizing-job-service_{context}"]
+= Finalizing the Job Service upgrade
+
+[role="_abstract"]
+After you upgrade the {ServerlessLogicOperatorName} to version 1.37.1, the Job Service restarts automatically and runs version 1.37.1.

--- a/modules/serverless-logic-upgrade-1-37-1-redeploying-workflows-with-dev-profile.adoc
+++ b/modules/serverless-logic-upgrade-1-37-1-redeploying-workflows-with-dev-profile.adoc
@@ -1,0 +1,19 @@
+// Module included in the following assemblies:
+// * serverless-logic/serverless-logic-upgrading-operator-from-1-36-to-1-37
+
+:_mod-docs-content-type: PROCEDURE
+[id="serverless-logic-upgrade-1-37-1-redeploying-workflows-with-dev-profile_{context}"]
+= Redeploying workflows with the dev profile
+
+[role="_abstract"]
+After upgrading the {ServerlessLogicOperatorName} to version 1.37.1, you must redeploy workflows that use the `dev` profile to complete the upgrade process.
+
+.Procedure
+. Restore all required Kubernetes resources before redeploying the workflow. These resources include the `ConfigMap` resource with the `application.properties` field.
+
+. Redeploy the workflow by running the following command: 
++
+[source,terminal]
+----
+$ oc apply -f <workflow_yaml> -n <target_namespace>
+----

--- a/modules/serverless-logic-upgrade-1-37-1-redeploying-workflows-with-gitops-profile.adoc
+++ b/modules/serverless-logic-upgrade-1-37-1-redeploying-workflows-with-gitops-profile.adoc
@@ -1,0 +1,19 @@
+// Module included in the following assemblies:
+// * serverless-logic/serverless-logic-upgrading-operator-from-1-36-to-1-37
+
+:_mod-docs-content-type: PROCEDURE
+[id="serverless-logic-upgrade-1-37-1-redeploying-workflows-with-gitops-profile_{context}"]
+= Redeploying workflows with the gitops profile
+
+[role="_abstract"]
+After upgrading the {ServerlessLogicOperatorName} to version 1.37.1, you must redeploy workflows that use the `gitops` profile to complete the upgrade process.
+
+.Procedure
+. Restore all required Kubernetes resources before redeploying the workflow. These resources include the `ConfigMap` resource with the `application.properties` field.
+
+. Redeploy the workflow by running the following command: 
++
+[source,terminal]
+----
+$ oc apply -f <workflow_yaml> -n <target_namespace>
+----

--- a/modules/serverless-logic-upgrade-1-37-1-redeploying-workflows-with-preview-profile.adoc
+++ b/modules/serverless-logic-upgrade-1-37-1-redeploying-workflows-with-preview-profile.adoc
@@ -1,0 +1,19 @@
+// Module included in the following assemblies:
+// * serverless-logic/serverless-logic-upgrading-operator-from-1-36-to-1-37
+
+:_mod-docs-content-type: PROCEDURE
+[id="serverless-logic-upgrade-1-37-1-redeploying-workflows-with-preview-profile_{context}"]
+= Redeploying workflows with the preview profile
+
+[role="_abstract"]
+After upgrading the {ServerlessLogicOperatorName} to version 1.37.1, you must redeploy workflows that use the `preview` profile to complete the upgrade process.
+
+.Procedure
+. Restore all required Kubernetes resources before redeploying the workflow. These resources include the `ConfigMap` resource with the `application.properties` field.
+
+. Redeploy the workflow by running the following command: 
++
+[source,terminal]
+----
+$ oc apply -f <workflow_yaml> -n <target_namespace>
+----

--- a/modules/serverless-logic-upgrade-1-37-backing-up-data-index-database.adoc
+++ b/modules/serverless-logic-upgrade-1-37-backing-up-data-index-database.adoc
@@ -11,4 +11,4 @@ You must back up the Data Index database before upgrading to prevent data loss.
 .Procedure
 * Take a full backup of the Data Index database, ensuring:
 ** The backup includes all database objects and not just table data.
-** The backup is stored in a secure location.
+** Ensure that you store the backup in a secure location.

--- a/modules/serverless-logic-upgrade-1-37-backing-up-job-service-database.adoc
+++ b/modules/serverless-logic-upgrade-1-37-backing-up-job-service-database.adoc
@@ -11,4 +11,4 @@ You must back up the Jobs Service database before upgrading to maintain the job 
 .Procedure
 * Take a full backup of the Jobs Service database, ensuring:
 ** The backup includes all database objects and not just table data.
-** The backup is stored in a secure location.
+** Ensure that you store the backup in a secure location.

--- a/modules/serverless-logic-upgrade-1-37-deleting-migrating-workflows-with-gitops-profile.adoc
+++ b/modules/serverless-logic-upgrade-1-37-deleting-migrating-workflows-with-gitops-profile.adoc
@@ -6,7 +6,7 @@
 = Deleting workflows with the gitops profile
 
 [role="_abstract"]
-Before upgrading the Operator, you must delete workflows running with the `gitops` profile. When the upgrade is complete, you must rebuild the corresponding workflow image using the new {ServerlessLogicProductName} 1.37.0 serverless workflow builder image and you must redeploy the workflow using the new image.
+Before upgrading the Operator, delete workflows that run with the `gitops` profile. After the upgrade completes, rebuild the corresponding workflow image by using the {ServerlessLogicProductName} 1.37.1 Serverless Workflow builder image. Redeploy the workflow by using the rebuilt image.
 
 .Procedure
 . If you are using persistence, back up the workflow database and ensure the backup includes both database objects and table data.

--- a/modules/serverless-logic-upgrading-1-37-1-osl-operator.adoc
+++ b/modules/serverless-logic-upgrading-1-37-1-osl-operator.adoc
@@ -1,0 +1,90 @@
+// Module included in the following assemblies:
+// * serverless-logic/serverless-logic-upgrading-operator-from-1-36-to-1-37
+
+:_mod-docs-content-type: PROCEDURE
+[id="serverless-logic-upgrading-1-37-1-osl-operator_{context}"]
+= Upgrading the {ServerlessLogicOperatorName} to 1.37.1
+
+[role="_abstract"]
+You can upgrade the {ServerlessLogicOperatorName} from version 1.37.0 to 1.37.1 by performing the following steps.
+
+.Prerequisites
+* You have access to the cluster with `cluster-admin` privileges.
+* You have {ServerlessLogicOperatorName} installed on your cluster.
+* You have access to a {ServerlessLogicProductName} project with the appropriate roles and permissions to create applications and other workloads in {ocp-product-title}.
+* You have installed the OpenShift CLI (`oc`).
+* You have version 1.37.0 of {ServerlessLogicOperatorName} installed.
+
+.Procedure
+. If you configure `dbMigrationStrategy: job` for Data Index or Jobs Service in any namespace that has a `SonataFlowPlatform`, delete the existing database initialization job by running the following command:
++
+[source, terminal]
+----
+$ oc delete job sonataflow-db-migrator-job -n <target_namespace>
+----
+
+. Query the available installation plans for the Operator upgrade by running the following command:
++
+[source, terminal]
+----
+$ oc get installplan -n openshift-serverless-logic
+----
++
+You must get an output similar to the following:
++
+[source, terminal]
+----
+NAME            CSV                      APPROVAL   APPROVED
+install-YYYY    logic-operator.v1.37.1   Manual     false
+install-XXXX    logic-operator.v1.37.0   Manual     true
+----
+
+. Approve the install plan by running the following command:
++
+[source, terminal]
+----
+$ oc patch installplan install-YYYY -n openshift-serverless-logic --type merge -p '{"spec":{"approved":true}}'
+----
+
+. Verify that the Operator upgrade completed successfully by running the following command:
++
+[source, terminal]
+----
+$ oc get csv -n openshift-serverless-logic
+----
++
+You must get an output similar to the following:
++
+[source, terminal]
+----
+NAME                     DISPLAY                               VERSION   REPLACES                 PHASE
+logic-operator.v1.37.1   OpenShift Serverless Logic Operator   1.37.1    logic-operator.v1.37.0   Succeeded
+----
+
+.Verification
+
+. If you configure `dbMigrationStrategy: job` for Data Index or Jobs Service, verify that the database initialization job exists by running the following command:
++
+[source, terminal]
+----
+$ oc get job sonataflow-db-migrator-job -n <target_namespace> 
+----
+
+. Verify that the Data Index database migration completed successfully by checking the job logs by running the following command:
++
+[source, terminal]
+----
+$ oc logs job/sonataflow-db-migrator-job -n <target_namespace>
+----
++
+You will get an output similar to the following example:
++
+[source, terminal]
+----
+2026-02-02 11:45:09,606 INFO  [org.kie.kog.mig.pos.MigrationService] (main) Migrating data-index
+2026-02-02 11:45:09,778 INFO  [org.fly.cor.int.com.DbValidate] (main) Successfully validated 22 migrations (execution time 00:00.043s)
+2026-02-02 11:45:09,810 INFO  [org.fly.cor.int.com.DbMigrate] (main) Current version of schema "sonataflow-platform-data-index-service": 1.45.1.4
+2026-02-02 11:45:09,824 INFO  [org.fly.cor.int.com.DbMigrate] (main) Migrating schema "sonataflow-platform-data-index-service" to version "1.46.0 - add user task id column"
+2026-02-02 11:45:09,861 INFO  [org.fly.cor.int.com.DbMigrate] (main) Migrating schema "sonataflow-platform-data-index-service" to version "1.47.0 - adjust column sizes in tables updated by hibernate"
+2026-02-02 11:45:09,882 INFO  [org.fly.cor.int.com.DbMigrate] (main) Successfully applied 2 migrations to schema "sonataflow-platform-data-index-service", now at version v1.47.0 (execution time 00:00.010s)
+----

--- a/serverless-logic/serverless-logic-managing-upgrades/serverless-logic-upgrading-operator-from-1-37-0-to-1-37-1.adoc
+++ b/serverless-logic/serverless-logic-managing-upgrades/serverless-logic-upgrading-operator-from-1-37-0-to-1-37-1.adoc
@@ -1,0 +1,45 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="serverless-logic-upgrading-operator-from-1-37-0-to-1-37-1"]
+= Upgrading OpenShift Serverless Logic Operator from version 1.37.0 to 1.37.1
+include::_attributes/common-attributes.adoc[]
+:context: serverless-logic-upgrading-operator-from-1-37-0-to-1-37-1
+
+toc::[]
+
+[role="_abstract"]
+You can upgrade the {ServerlessLogicOperatorName} from version 1.37.0 to 1.37.1. The upgrade process involves preparing the existing workflows and services, updating the Operator, and restoring the workflows after the upgrade.
+
+[IMPORTANT]
+====
+Different workflow profiles require different upgrade steps. Follow the instructions for each profile carefully.
+====
+
+include::modules/serverless-logic-1-37-1-preparing-for-the-upgrade.adoc[leveloffset=+1]
+
+include::modules/serverless-logic-1-37-1-increasing-jobs-service-retry-interval.adoc[leveloffset=+2]
+
+include::modules/serverless-logic-upgrade-1-37-deleting-workflows-with-dev-profile.adoc[leveloffset=+2]
+
+include::modules/serverless-logic-upgrade-1-37-deleting-migrating-workflows-with-preview-profile.adoc[leveloffset=+2]
+
+include::modules/serverless-logic-upgrade-1-37-1-deleting-migrating-workflows-with-gitops-profile.adoc[leveloffset=+2]
+
+include::modules/serverless-logic-upgrade-1-37-backing-up-data-index-database.adoc[leveloffset=+2]
+
+include::modules/serverless-logic-upgrade-1-37-backing-up-job-service-database.adoc[leveloffset=+2]
+
+include::modules/serverless-logic-upgrading-1-37-1-osl-operator.adoc[leveloffset=+1]
+
+include::modules/serverless-logic-1-37-1-finalizing-the-upgrade.adoc[leveloffset=+1]
+
+include::modules/serverless-logic-upgrade-1-37-1-finalizing-data-index.adoc[leveloffset=+2]
+
+include::modules/serverless-logic-upgrade-1-37-1-finalizing-job-service.adoc[leveloffset=+2]
+
+include::modules/serverless-logic-upgrade-1-37-1-redeploying-workflows-with-gitops-profile.adoc[leveloffset=+2]
+
+include::modules/serverless-logic-upgrade-1-37-1-redeploying-workflows-with-dev-profile.adoc[leveloffset=+2]
+
+include::modules/serverless-logic-upgrade-1-37-1-redeploying-workflows-with-preview-profile.adoc[leveloffset=+2]
+
+include::modules/serverless-logic-1-37-1-restoring-jobs-service-retry-interval.adoc[leveloffset=+2]


### PR DESCRIPTION
**Affected versions:** 
- `serverless-docs-1.37`
- `serverless-docs-1.38`

**Tracking JIRA:** https://issues.redhat.com/browse/SRVLOGIC-781

**Doc preview:**

- [Upgrading OpenShift Serverless Logic Operator from version 1.37.0 to 1.37.1](https://107665--ocpdocs-pr.netlify.app/openshift-serverless/latest/serverless-logic/serverless-logic-managing-upgrades/serverless-logic-upgrading-operator-from-1-37-0-to-1-37-1.html)

**Reviews:**
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
- [x] SME has approved this change.
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
- [x] Peer has approved this change.
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->