### PR TITLE
OSDOCS-16874-3: Updated mod doc tags on some older files

### DIFF
--- a/modules/cnf-checking-numa-aware-scheduler-logs.adoc
+++ b/modules/cnf-checking-numa-aware-scheduler-logs.adoc
@@ -2,11 +2,14 @@
 //
 // *scalability_and_performance/cnf-numa-aware-scheduling.adoc
 
-:_module-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="cnf-checking-numa-aware-scheduler-logs_{context}"]
 = Checking the NUMA-aware scheduler logs
 
-Troubleshoot problems with the NUMA-aware scheduler by reviewing the logs. If required, you can increase the scheduler log level by modifying the `spec.logLevel` field of the `NUMAResourcesScheduler` resource. Acceptable values are `Normal`, `Debug`, and `Trace`, with `Trace` being the most verbose option.
+[role="_abstract"]
+To troubleshoot problems with the NUMA-aware scheduler, review the scheduler logs. If necessary, increase the log level in the `NUMAResourcesScheduler` custom resource (CR) to capture more detailed diagnostic data.
+
+Acceptable values are `Normal`, `Debug`, and `Trace`, with `Trace` being the most verbose option.
 
 [NOTE]
 ====
@@ -15,13 +18,13 @@ To change the log level of the secondary scheduler, delete the running scheduler
 
 .Prerequisites
 
-* Install the OpenShift CLI (`oc`).
-* Log in as a user with `cluster-admin` privileges.
+* Installed the {oc-first}.
+* You are logged in as a user with `cluster-admin` privileges.
 
 .Procedure
 
 . Delete the currently running `NUMAResourcesScheduler` resource:
-
++
 .. Get the active `NUMAResourcesScheduler` by running the following command:
 +
 [source,terminal]
@@ -35,7 +38,7 @@ $ oc get NUMAResourcesScheduler
 NAME                     AGE
 numaresourcesscheduler   90m
 ----
-
++
 .. Delete the secondary scheduler resource by running the following command:
 +
 [source,terminal]
@@ -60,6 +63,7 @@ metadata:
 spec:
   imageSpec: "registry.redhat.io/openshift4/noderesourcetopology-scheduler-container-rhel8:v{product-version}"
   logLevel: Debug
+# ...
 ----
 
 . Create the updated `Debug` logging `NUMAResourcesScheduler` resource by running the following command:
@@ -75,10 +79,10 @@ $ oc create -f nro-scheduler-debug.yaml
 numaresourcesscheduler.nodetopology.openshift.io/numaresourcesscheduler created
 ----
 
-.Verification steps
+.Verification
 
 . Check that the NUMA-aware scheduler was successfully deployed:
-
++
 .. Run the following command to check that the CRD is created successfully:
 +
 [source,terminal]
@@ -92,7 +96,7 @@ $ oc get crd | grep numaresourcesschedulers
 NAME                                                              CREATED AT
 numaresourcesschedulers.nodetopology.openshift.io                 2022-02-25T11:57:03Z
 ----
-
++
 .. Check that the new custom scheduler is available by running the following command:
 +
 [source,terminal]
@@ -108,7 +112,7 @@ numaresourcesscheduler   3h26m
 ----
 
 . Check that the logs for the scheduler shows the increased log level:
-
++
 .. Get the list of pods running in the `openshift-numaresources` namespace by running the following command:
 +
 [source,terminal]
@@ -125,7 +129,7 @@ numaresourcesoperator-worker-5wm2k                 2/2     Running   0          
 numaresourcesoperator-worker-pb75c                 2/2     Running   0          45h
 secondary-scheduler-7976c4d466-qm4sc               1/1     Running   0          21m
 ----
-
++
 .. Get the logs for the secondary scheduler pod by running the following command:
 +
 [source,terminal]

--- a/modules/cnf-configuring-nrop-on-schedlable-control-planes.adoc
+++ b/modules/cnf-configuring-nrop-on-schedlable-control-planes.adoc
@@ -8,7 +8,7 @@
 = Configuring NUMA Resources Operator on schedulable control plane nodes
 
 [role="_abstract"]
-This procedure describes how to configure the NUMA Resources Operator (NROP) to manage control plane nodes that a user configures to be schedulable. This is particularly useful in compact clusters where control plane nodes also serve as worker nodes, or in multi-node OpenShift (MNO) clusters where control plane nodes are configured as schedulable to run workloads.
+To run workloads on control plane nodes, configure the NUMA Resources Operator (NROP) to manage them as schedulable. This configuration is ideal for compact clusters and multi-node OpenShift (MNO) environments where control plane nodes also function as compute nodes.
 
 .Prerequisites
 
@@ -66,6 +66,7 @@ metadata:
 spec:
   nodeGroups:
     - poolName: master
+# ...
 ----
 +
 [NOTE]
@@ -73,7 +74,7 @@ spec:
 Configuring a compact cluster with a worker pool in addition to the `master` pool should be avoided. While this setup does not break the cluster or affect operator functionality, it can lead to redundant or duplicate pods and create unnecessary noise in the system. The worker pool is essentially a pointless, empty MCP in this context and serves no purpose.
 ====
 
-.. For an MNO cluster where both control plane and worker nodes are schedulable, you have the option to configure the NUMA Resources Operator to manage multiple `nodeGroups`. You can specify which nodes to include by adding their corresponding MCPs to the `nodeGroups` list in the `NUMAResourcesOperator` CR. The configuration depends entirely on your specific requirements. For example, to manage both the `master` and `worker-cnf` pools, create the following `nodeGroups` configuration in the NUMAResourcesOperator CR:
+.. For an MNO cluster where both control plane and compute nodes are schedulable, you have the option to configure the NUMA Resources Operator to manage multiple `nodeGroups`. You can specify which nodes to include by adding their corresponding MCPs to the `nodeGroups` list in the `NUMAResourcesOperator` CR. The configuration depends entirely on your specific requirements. For example, to manage both the `master` and `worker-cnf` pools, create the following `nodeGroups` configuration in the NUMAResourcesOperator CR:
 +
 [source,yaml]
 ----
@@ -84,7 +85,8 @@ metadata:
 spec:
   nodeGroups:
     - poolName: master
-    - poolName: worker-cnf 
+    - poolName: worker-cnf
+# ...
 ----
 +
 [NOTE]
@@ -165,7 +167,6 @@ master-2      21m
 +
 The presence of a `NodeResourceTopology` resource for a node confirms that the NUMA Resources Operator was able to schedule a pod on it to collect the data, enabling topology-aware scheduling.
 
-
 . Inspect a single Node Resource Topology by running the following command:
 +
 [source,terminal]
@@ -211,6 +212,7 @@ zones:
     capacity: "1576189952"
     name: memory
   type: Node
+# ...
 ----
 +
 The presence of this resource for a node with a master role proves that the NUMA Resources Operator was able to deploy its discovery pods onto that node. These pods are what gather the NUMA topology data, and they can only be scheduled on nodes that are considered schedulable.

--- a/modules/cnf-creating-nrop-cr-with-manual-performance-settings.adoc
+++ b/modules/cnf-creating-nrop-cr-with-manual-performance-settings.adoc
@@ -2,7 +2,7 @@
 //
 // *scalability_and_performance/cnf-numa-aware-scheduling.adoc
 
-:_module-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="cnf-creating-nrop-cr-with-manual-performance-settings_{context}"]
 = Creating the NUMAResourcesOperator custom resource with manual performance settings
 

--- a/modules/cnf-deploying-the-numa-aware-scheduler-with-manual-performance-settings.adoc
+++ b/modules/cnf-deploying-the-numa-aware-scheduler-with-manual-performance-settings.adoc
@@ -2,7 +2,7 @@
 //
 // *scalability_and_performance/cnf-numa-aware-scheduling.adoc
 
-:_module-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="cnf-deploying-the-numa-aware-scheduler-with-manual-performance-settings_{context}"]
 = Deploying the NUMA-aware secondary pod scheduler with manual performance settings
 

--- a/modules/cnf-deploying-the-numa-aware-scheduler.adoc
+++ b/modules/cnf-deploying-the-numa-aware-scheduler.adoc
@@ -2,15 +2,17 @@
 //
 // *scalability_and_performance/cnf-numa-aware-scheduling.adoc
 
-:_module-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="cnf-deploying-the-numa-aware-scheduler_{context}"]
 = Deploying the NUMA-aware secondary pod scheduler
 
-After you install the NUMA Resources Operator, follow this procedure to deploy the NUMA-aware secondary pod scheduler. 
+[role="_abstract"]
+To optimize the placement of high-performance workloads, deploy the NUMA-aware secondary pod scheduler. This component aligns pods with specific NUMA zones to ensure efficient resource utilization in your cluster.
 
 .Procedure
-. Create the `NUMAResourcesScheduler` custom resource that deploys the NUMA-aware custom pod scheduler:
 
+. Create the `NUMAResourcesScheduler` custom resource that deploys the NUMA-aware custom pod scheduler:
++
 .. Save the following minimal required YAML in the `nro-scheduler.yaml` file:
 +
 [source,yaml,subs="attributes+"]
@@ -20,15 +22,16 @@ kind: NUMAResourcesScheduler
 metadata:
   name: numaresourcesscheduler
 spec:
-  imageSpec: "registry.redhat.io/openshift4/noderesourcetopology-scheduler-rhel9:v{product-version}" <1>
+  imageSpec: "registry.redhat.io/openshift4/noderesourcetopology-scheduler-rhel9:v{product-version}"
+# ...
 ----
 +
-<1> In a disconnected environment, make sure to configure the resolution of this image by either:
-
-* Creating an `ImageTagMirrorSet` custom resource (CR). For more information, see "Configuring image registry repository mirroring" in the "Additional resources" section.
-
-* Setting the URL to the disconnected registry.
-
+** `spec.imageSpec`: In a disconnected environment, make sure to configure the resolution of this image by either:
++
+.. Create an `ImageTagMirrorSet` custom resource (CR). For more information, see "Configuring image registry repository mirroring" in the "Additional resources" section.
++
+.. Set the URL to the disconnected registry.
++
 .. Create the `NUMAResourcesScheduler` CR by running the following command:
 +
 [source,terminal]

--- a/modules/cnf-nrop-support-schedulable-resources.adoc
+++ b/modules/cnf-nrop-support-schedulable-resources.adoc
@@ -3,10 +3,12 @@
 // *scalability_and_performance/cnf-numa-aware-scheduling.adoc
 :_mod-docs-content-type: CONCEPT
 [id="cnf-numa-resource-operator-support-scheduling-cp_{context}"]
-=  NUMA Resources Operator support for schedulable control-plane nodes
+= NUMA Resources Operator support for schedulable control-plane nodes
 
 [role="_abstract"]
-You can enable schedulable control plane nodes to run user-defined pods, effectively turning the nodes into hybrid Control Plane and Worker nodes. This configuration is especially beneficial in resource-constrained environments, such as compact clusters. When enabled, the NUMA Resources Operator can apply its topology-aware scheduling to the nodes for guaranteed workloads, ensuring Pods are placed according to the best NUMA affinity.
+You can enable schedulable control plane nodes to run user-defined pods, effectively turning the nodes into hybrid control plane and compute nodes. This configuration is especially beneficial in resource-constrained environments, such as compact clusters. 
+
+When enabled, the NUMA Resources Operator can apply its topology-aware scheduling to the nodes for guaranteed workloads, ensuring pods are placed according to the best NUMA affinity.
 
 Traditionally, control plane nodes in {product-title} are dedicated to running critical cluster services. Enabling schedulable control plane nodes allows user-defined Pods to be scheduled on the nodes.
 
@@ -17,13 +19,13 @@ You can make control plane nodes schedulable by setting the `mastersSchedulable`
 When you enable schedulable control plane nodes, enabling workload partitioning is strongly recommended to safeguard critical infrastructure pods from resource starvation. This process restricts infrastructure components, like the `ovnkube-node` process, to dedicated, reserved CPUs. However, the OVS dynamic pinning feature relies on `ovnkube-node` having access to the CPUs designated for bustable/best-effort pods to correctly identify and use non-pinned CPUs. When workload partitioning configures the `ovnkube-node` process with CPU affinity for reserved CPUs, this dynamic pinning mechanism breaks.
 ====
 
-The NUMA Resources Operator provides topology-aware scheduling for workloads that need a specific NUMA affinity. When control plane nodes are made schedulable, the operator's management capabilities can be applied to them, just as they are to worker nodes. This ensures that NUMA-aware pods are placed on a node with the best NUMA topology, whether it's a control plane or worker node.
+The NUMA Resources Operator provides topology-aware scheduling for workloads that need a specific NUMA affinity. When control plane nodes are made schedulable, the management capabilities of the Operator can be applied to them, just as they are to compute nodes. This ensures that NUMA-aware pods are placed on a node with the best NUMA topology, whether it is a control plane or compute node.
 
 When configuring the NUMA Resources Operator, its management scope is determined by the `nodeGroups` field in its custom resource (CR). This principle applies to both compact and multi-node clusters.
 
 Compact clusters:: In a compact cluster, all nodes are configured as schedulable control plane nodes. The NUMA Resources Operator can be configured to manage all nodes in the cluster. Follow the deployment instructions for more details on the process.
 
-Multi-Node OpenShift (MNO) clusters:: In a Multi-Node {product-title} cluster, control plane nodes are made schedulable in addition to existing worker nodes. To manage these nodes, you can configure the NUMA Resources Operator by defining separate `nodeGroups` in the `NUMAResourcesOperator` CR for the control plane and worker nodes. This ensures that the NUMA Resources Operator correctly schedules pods on both sets of nodes based on resource availability and NUMA topology.
+Multi-Node OpenShift (MNO) clusters:: In a Multi-Node {product-title} cluster, control plane nodes are made schedulable in addition to existing compute nodes. To manage these nodes, you can configure the NUMA Resources Operator by defining separate `nodeGroups` in the `NUMAResourcesOperator` CR for the control plane and compute nodes. This ensures that the NUMA Resources Operator correctly schedules pods on both sets of nodes based on resource availability and NUMA topology.
 
 [NOTE]
 ====

--- a/modules/cnf-reporting-more-exact-reource-availability.adoc
+++ b/modules/cnf-reporting-more-exact-reource-availability.adoc
@@ -2,21 +2,24 @@
 //
 // *scalability_and_performance/cnf-numa-aware-scheduling.adoc
 
-:_module-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="cnf-reporting-more-exact-resource-availability_{context}"]
 = Reporting more exact resource availability
 
-Enable the `cacheResyncPeriod` specification to help the NUMA Resources Operator report more exact resource availability by monitoring pending resources on nodes and synchronizing this information in the scheduler cache at a defined interval. This also helps to minimize Topology Affinity Error errors because of sub-optimal scheduling decisions. The lower the interval, the greater the network load. The `cacheResyncPeriod` specification is disabled by default.
+[role="_abstract"]
+To report more exact resource availability and minimize Topology Affinity Errors, enable the `cacheResyncPeriod` specification for the NUMA Resources Operator. This configuration monitors pending resources on nodes and synchronizes them in the scheduler cache, though lower intervals increase network load.
+
+The lower the interval, the greater the network load. The `cacheResyncPeriod` specification is disabled by default.
 
 .Prerequisites
 
-* Install the OpenShift CLI (`oc`).
-* Log in as a user with `cluster-admin` privileges.
+* Installed the {oc-first}.
+* You are logged in as a user with `cluster-admin` privileges.
 
 .Procedure
 
 . Delete the currently running `NUMAResourcesScheduler` resource:
-
++
 .. Get the active `NUMAResourcesScheduler` by running the following command:
 +
 [source,terminal]
@@ -30,7 +33,7 @@ $ oc get NUMAResourcesScheduler
 NAME                     AGE
 numaresourcesscheduler   92m
 ----
-
++
 .. Delete the secondary scheduler resource by running the following command:
 +
 [source,terminal]
@@ -54,10 +57,10 @@ metadata:
   name: numaresourcesscheduler
 spec:
   imageSpec: "registry.redhat.io/openshift4/noderesourcetopology-scheduler-container-rhel8:v{product-version}"
-  cacheResyncPeriod: "5s" <1>
+  cacheResyncPeriod: "5s"
 ----
 +
-<1> Enter an interval value in seconds for synchronization of the scheduler cache. A value of `5s` is typical for most implementations.
+** `spec.cacheResyncPeriod`: Enter an interval value in seconds for synchronization of the scheduler cache. A value of `5s` is typical for most implementations.
 
 . Create the updated `NUMAResourcesScheduler` resource by running the following command:
 +
@@ -72,10 +75,10 @@ $ oc create -f nro-scheduler-cacheresync.yaml
 numaresourcesscheduler.nodetopology.openshift.io/numaresourcesscheduler created
 ----
 
-.Verification steps
+.Verification
 
 . Check that the NUMA-aware scheduler was successfully deployed:
-
++
 .. Run the following command to check that the CRD is created successfully:
 +
 [source,terminal]
@@ -89,7 +92,7 @@ $ oc get crd | grep numaresourcesschedulers
 NAME                                                              CREATED AT
 numaresourcesschedulers.nodetopology.openshift.io                 2022-02-25T11:57:03Z
 ----
-
++
 .. Check that the new custom scheduler is available by running the following command:
 +
 [source,terminal]
@@ -105,7 +108,7 @@ numaresourcesscheduler   3h26m
 ----
 
 . Check that the logs for the scheduler show the increased log level:
-
++
 .. Get the list of pods running in the `openshift-numaresources` namespace by running the following command:
 +
 [source,terminal]
@@ -122,7 +125,7 @@ numaresourcesoperator-worker-5wm2k                 2/2     Running   0          
 numaresourcesoperator-worker-pb75c                 2/2     Running   0          45h
 secondary-scheduler-7976c4d466-qm4sc               1/1     Running   0          21m
 ----
-
++
 .. Get the logs for the secondary scheduler pod by running the following command:
 +
 [source,terminal]

--- a/modules/cnf-troubleshooting-missing-rte-config-maps.adoc
+++ b/modules/cnf-troubleshooting-missing-rte-config-maps.adoc
@@ -2,7 +2,7 @@
 //
 // *scalability_and_performance/cnf-numa-aware-scheduling.adoc
 
-:_module-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="cnf-troubleshooting-missing-rte-config-maps_{context}"]
 = Correcting a missing resource topology exporter config map
 

--- a/modules/cnf-troubleshooting-numa-aware-workloads.adoc
+++ b/modules/cnf-troubleshooting-numa-aware-workloads.adoc
@@ -6,15 +6,14 @@
 [id="cnf-troubleshooting-numa-aware-workloads_{context}"]
 = Troubleshooting NUMA-aware scheduling
 
-To troubleshoot common problems with NUMA-aware pod scheduling, perform the following steps.
+[role="_abstract"]
+To resolve common problems with NUMA-aware pod scheduling, troubleshoot your cluster configuration. Identifying and fixing these issues ensures that your pods are optimally aligned with underlying hardware for high-performance workloads.
 
 .Prerequisites
 
-* Install the {product-title} CLI (`oc`).
-
-* Log in as a user with cluster-admin privileges.
-
-* Install the NUMA Resources Operator and deploy the NUMA-aware secondary scheduler.
+* Installed the {oc-first}.
+* Logged in as a user with cluster-admin privileges.
+* Installed the NUMA Resources Operator and deploy the NUMA-aware secondary scheduler.
 
 .Procedure
 
@@ -150,14 +149,14 @@ items:
     uid: e8659390-6f8d-4e67-9a51-1ea34bba1cc3
   topologyPolicies:
   - SingleNUMANodeContainerLevel
-  zones: <1>
+  zones:
   - costs:
     - name: node-0
       value: 10
     - name: node-1
       value: 21
     name: node-0
-    resources: <2>
+    resources:
     - allocatable: "38"
       available: "38"
       capacity: "40"
@@ -203,6 +202,8 @@ kind: List
 metadata:
   resourceVersion: ""
   selfLink: ""
+# ...
 ----
-<1> Each stanza under `zones` describes the resources for a single NUMA zone.
-<2> `resources` describes the current state of the NUMA zone resources. Check that resources listed under `items.zones.resources.available` correspond to the exclusive NUMA zone resources allocated to each guaranteed pod.
++
+** `zones`: Each stanza under `zones` describes the resources for a single NUMA zone.
+** `costs.resources`: Specifies the current state of the NUMA zone resources. Check that resources listed under `items.zones.resources.available` correspond to the exclusive NUMA zone resources allocated to each guaranteed pod.

--- a/modules/cnf-troubleshooting-resource-topo-exporter.adoc
+++ b/modules/cnf-troubleshooting-resource-topo-exporter.adoc
@@ -2,20 +2,21 @@
 //
 // *scalability_and_performance/cnf-numa-aware-scheduling.adoc
 
-:_module-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="cnf-troubleshooting-resource-topo-exporter_{context}"]
 = Troubleshooting the resource topology exporter
 
-Troubleshoot `noderesourcetopologies` objects where unexpected results are occurring by inspecting the corresponding `resource-topology-exporter` logs.
+[role="_abstract"]
+To resolve unexpected results in `noderesourcetopologies` objects, inspect the `resource-topology-exporter` logs. Reviewing this diagnostic data helps you identify and fix configuration issues within your cluster.
 
 [NOTE]
 ====
-It is recommended that NUMA resource topology exporter instances in the cluster are named for nodes they refer to. For example, a worker node with the name `worker` should have a corresponding `noderesourcetopologies` object called `worker`.
+Ensure that the NUMA resource topology exporter instances in the cluster are named for nodes they refer to. For example, a compute node with the name `worker` should have a corresponding `noderesourcetopologies` object called `worker`.
 ====
 
 .Prerequisites
 
-* Install the OpenShift CLI (`oc`).
+* Install the {oc-first}.
 * Log in as a user with `cluster-admin` privileges.
 
 .Procedure

--- a/modules/creating-custom-live-rhcos-iso.adoc
+++ b/modules/creating-custom-live-rhcos-iso.adoc
@@ -2,7 +2,6 @@
 //
 // * installing/installing_sno/install-sno-installing-sno.adoc
 
-:_module-type: PROCEDURE
 :_mod-docs-content-type: PROCEDURE
 [id="create-custom-live-rhcos-iso_{context}"]
 = Creating a custom live {op-system} ISO for remote server access

--- a/modules/ipi-verifying-nodes-after-installation.adoc
+++ b/modules/ipi-verifying-nodes-after-installation.adoc
@@ -2,7 +2,7 @@
 //
 // * installing/overview/index.adoc
 
-:_module-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="ipi-verifying-nodes-after-installation_{context}"]
 = Verifying node state after installation
 

--- a/modules/ref_cluster-logging-elasticsearch-cluster-status.adoc
+++ b/modules/ref_cluster-logging-elasticsearch-cluster-status.adoc
@@ -1,5 +1,4 @@
-:_module-type: REFERENCE
-
+:_mod-docs-content-type: REFERENCE
 [id="ref_cluster-logging-elasticsearch-cluster-status_{context}"]
 = Elasticsearch cluster status
 

--- a/modules/ztp-add-local-reg-for-sno-duprofile.adoc
+++ b/modules/ztp-add-local-reg-for-sno-duprofile.adoc
@@ -3,7 +3,7 @@
 // * edge_computing/policygenerator_for_ztp/ztp-advanced-policygenerator-config.adoc
 // * edge_computing/policygentemplate_for_ztp/ztp-advanced-policy-config.adoc
 
-:_module-type: CONCEPT
+:_mod-docs-content-type: CONCEPT
 [id="ztp-add-local-reg-for-sno-duprofile_{context}"]
 = Configuring the Image Registry Operator for local caching of images
 

--- a/modules/ztp-checking-du-cluster-config.adoc
+++ b/modules/ztp-checking-du-cluster-config.adoc
@@ -2,7 +2,7 @@
 //
 // * scalability_and_performance/ztp_far_edge/ztp-vdu-validating-cluster-tuning.adoc
 
-:_module-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="ztp-checking-du-cluster-config_{context}"]
 = Checking that the recommended cluster configurations are applied
 

--- a/modules/ztp-checking-kernel-rt-in-cluster.adoc
+++ b/modules/ztp-checking-kernel-rt-in-cluster.adoc
@@ -2,7 +2,7 @@
 //
 // * scalability_and_performance/ztp_far_edge/ztp-vdu-validating-cluster-tuning.adoc
 
-:_module-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="ztp-checking-kernel-rt-in-cluster_{context}"]
 = Checking the realtime kernel version
 

--- a/modules/ztp-configuring-disk-partitioning.adoc
+++ b/modules/ztp-configuring-disk-partitioning.adoc
@@ -3,7 +3,7 @@
 // * edge_computing/policygenerator_for_ztp/ztp-advanced-policygenerator-config.adoc
 // * edge_computing/policygentemplate_for_ztp/ztp-advanced-policy-config.adoc
 
-:_module-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="ztp-configuring-disk-partitioning_{context}"]
 = Configuring disk partitioning with ClusterInstance
 

--- a/modules/ztp-configuring-ipsec-using-ztp-and-siteconfig.adoc
+++ b/modules/ztp-configuring-ipsec-using-ztp-and-siteconfig.adoc
@@ -2,7 +2,7 @@
 //
 // * scalability_and_performance/ztp_far_edge/ztp-advanced-install-ztp.adoc
 
-:_module-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="ztp-configuring-ipsec-using-ztp-and-siteconfig_{context}"]
 = Configuring IPsec encryption for {sno} clusters using {ztp} and ClusterInstance resources
 

--- a/modules/ztp-configuring-pgt-image-registry.adoc
+++ b/modules/ztp-configuring-pgt-image-registry.adoc
@@ -3,7 +3,7 @@
 // * edge_computing/policygenerator_for_ztp/ztp-advanced-policygenerator-config.adoc
 // * edge_computing/policygentemplate_for_ztp/ztp-advanced-policy-config.adoc
 
-:_module-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="ztp-configuring-pgt-image-registry_{context}"]
 = Configuring the image registry using {policy-gen-cr} CRs
 

--- a/modules/ztp-customizing-the-install-extra-manifests.adoc
+++ b/modules/ztp-customizing-the-install-extra-manifests.adoc
@@ -2,7 +2,7 @@
 //
 // * scalability_and_performance/ztp_far_edge/ztp-advanced-install-ztp.adoc
 
-:_module-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="ztp-customizing-the-install-extra-manifests_{context}"]
 = Customizing extra installation manifests in the {ztp} pipeline
 

--- a/modules/ztp-deploying-additional-changes-to-clusters.adoc
+++ b/modules/ztp-deploying-additional-changes-to-clusters.adoc
@@ -3,7 +3,7 @@
 // * edge_computing/policygenerator_for_ztp/ztp-advanced-policygenerator-config.adoc
 // * edge_computing/policygentemplate_for_ztp/ztp-advanced-policy-config.adoc
 
-:_module-type: CONCEPT
+:_mod-docs-content-type: CONCEPT
 [id="ztp-deploying-additional-changes-to-clusters_{context}"]
 = Deploying additional changes to clusters
 

--- a/modules/ztp-pgt-config-best-practices.adoc
+++ b/modules/ztp-pgt-config-best-practices.adoc
@@ -2,7 +2,7 @@
 //
 // * scalability_and_performance/ztp_far_edge/ztp-configuring-managed-clusters-policies.adoc
 
-:_module-type: CONCEPT
+:_mod-docs-content-type: CONCEPT
 [id="ztp-pgt-config-best-practices_{context}"]
 = Recommendations when customizing {policy-gen-cr} CRs
 

--- a/modules/ztp-policygentemplates-for-ran.adoc
+++ b/modules/ztp-policygentemplates-for-ran.adoc
@@ -2,7 +2,7 @@
 //
 // * scalability_and_performance/ztp_far_edge/ztp-configuring-managed-clusters-policies.adoc
 
-:_module-type: CONCEPT
+:_mod-docs-content-type: CONCEPT
 [id="ztp-policygentemplates-for-ran_{context}"]
 = {policy-gen-cr} CRs for RAN deployments
 

--- a/modules/ztp-precaching-downloading-artifacts.adoc
+++ b/modules/ztp-precaching-downloading-artifacts.adoc
@@ -2,7 +2,7 @@
 //
 // * scalability_and_performance/ztp_far_edge/ztp-precaching-tool.adoc
 
-:_module-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="ztp-downloading-images_{context}"]
 = Downloading the images
 

--- a/modules/ztp-precaching-partitioning.adoc
+++ b/modules/ztp-precaching-partitioning.adoc
@@ -2,7 +2,7 @@
 //
 // * scalability_and_performance/ztp_far_edge/ztp-precaching-tool.adoc
 
-:_module-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="ztp-partitioning_{context}"]
 = Partitioning the disk
 

--- a/modules/ztp-precaching-ztp-config.adoc
+++ b/modules/ztp-precaching-ztp-config.adoc
@@ -2,7 +2,7 @@
 //
 // * scalability_and_performance/ztp_far_edge/ztp-precaching-tool.adoc
 
-:_module-type: CONCEPT
+:_mod-docs-content-type: CONCEPT
 [id="ztp-pre-caching-config-con_{context}"]
 = Pre-caching images in {ztp}
 

--- a/modules/ztp-recommended-cluster-kernel-config.adoc
+++ b/modules/ztp-recommended-cluster-kernel-config.adoc
@@ -2,7 +2,7 @@
 //
 // * scalability_and_performance/ztp_far_edge/ztp-vdu-validating-cluster-tuning.adoc
 
-:_module-type: REFERENCE
+:_mod-docs-content-type: REFERENCE
 [id="ztp-recommended-cluster-kernel-config_{context}"]
 = Recommended cluster kernel configuration
 

--- a/modules/ztp-recommended-cluster-operators.adoc
+++ b/modules/ztp-recommended-cluster-operators.adoc
@@ -2,7 +2,7 @@
 //
 // * scalability_and_performance/ztp_far_edge/ztp-vdu-validating-cluster-tuning.adoc
 
-:_module-type: REFERENCE
+:_mod-docs-content-type: REFERENCE
 [id="ztp-recommended-cluster-operators_{context}"]
 = Recommended cluster Operators
 

--- a/modules/ztp-talo-integration.adoc
+++ b/modules/ztp-talo-integration.adoc
@@ -2,7 +2,7 @@
 //
 // * scalability_and_performance/ztp_far_edge/ztp-deploying-far-edge-sites.adoc
 
-:_module-type: CONCEPT
+:_mod-docs-content-type: CONCEPT
 [id="ztp-talo-integration_{context}"]
 = {ztp} and {cgu-operator-full}
 

--- a/modules/ztp-using-pgt-to-configure-high-performance-mode.adoc
+++ b/modules/ztp-using-pgt-to-configure-high-performance-mode.adoc
@@ -3,7 +3,7 @@
 // * edge_computing/policygenerator_for_ztp/ztp-advanced-policygenerator-config.adoc
 // * edge_computing/policygentemplate_for_ztp/ztp-advanced-policy-config.adoc
 
-:_module-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="ztp-using-pgt-to-configure-high-performance-mode_{context}"]
 = Configuring high-performance mode using {policy-gen-cr} CRs
 

--- a/modules/ztp-using-pgt-to-configure-performance-mode.adoc
+++ b/modules/ztp-using-pgt-to-configure-performance-mode.adoc
@@ -3,7 +3,7 @@
 // * edge_computing/policygenerator_for_ztp/ztp-advanced-policygenerator-config.adoc
 // * edge_computing/policygentemplate_for_ztp/ztp-advanced-policy-config.adoc
 
-:_module-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="ztp-using-pgt-to-configure-performance-mode_{context}"]
 = Configuring performance mode using {policy-gen-cr} CRs
 

--- a/modules/ztp-using-pgt-to-configure-power-saving-mode.adoc
+++ b/modules/ztp-using-pgt-to-configure-power-saving-mode.adoc
@@ -3,7 +3,7 @@
 // * edge_computing/policygenerator_for_ztp/ztp-advanced-policygenerator-config.adoc
 // * edge_computing/policygentemplate_for_ztp/ztp-advanced-policy-config.adoc
 
-:_module-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="ztp-using-pgt-to-configure-power-saving-mode_{context}"]
 = Configuring power saving mode using {policy-gen-cr} CRs
 

--- a/modules/ztp-using-pgt-to-configure-power-states.adoc
+++ b/modules/ztp-using-pgt-to-configure-power-states.adoc
@@ -3,8 +3,7 @@
 // * edge_computing/policygenerator_for_ztp/ztp-advanced-policygenerator-config.adoc
 // * edge_computing/policygentemplate_for_ztp/ztp-advanced-policy-config.adoc
 
-:_module-type: CONCEPT
-
+:_mod-docs-content-type: CONCEPT
 [id="ztp-using-pgt-to-configure-power-saving-states_{context}"]
 = Configuring power states using {policy-gen-cr} CRs
 

--- a/modules/ztp-using-pgt-to-maximize-power-saving-mode.adoc
+++ b/modules/ztp-using-pgt-to-maximize-power-saving-mode.adoc
@@ -3,7 +3,7 @@
 // * edge_computing/policygenerator_for_ztp/ztp-advanced-policygenerator-config.adoc
 // * edge_computing/policygentemplate_for_ztp/ztp-advanced-policy-config.adoc
 
-:_module-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="ztp-using-pgt-to-maximize-power-savings-mode_{context}"]
 = Maximizing power savings
 

--- a/modules/ztp-using-pgt-to-update-source-crs.adoc
+++ b/modules/ztp-using-pgt-to-update-source-crs.adoc
@@ -3,7 +3,7 @@
 // * edge_computing/policygenerator_for_ztp/ztp-advanced-policygenerator-config.adoc
 // * edge_computing/policygentemplate_for_ztp/ztp-advanced-policy-config.adoc
 
-:_module-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="ztp-using-pgt-to-update-source-crs_{context}"]
 = Using {policy-gen-cr} CRs to override source CRs content
 

--- a/scalability_and_performance/cnf-numa-aware-scheduling.adoc
+++ b/scalability_and_performance/cnf-numa-aware-scheduling.adoc
@@ -72,6 +72,11 @@ include::modules/cnf-creating-nrop-cr-hosted-control-plane.adoc[leveloffset=+2]
 
 include::modules/cnf-deploying-the-numa-aware-scheduler.adoc[leveloffset=+2]
 
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../disconnected/updating/disconnected-update.adoc#images-configuration-registry-mirror_updating-disconnected-cluster[Configuring image registry repository mirroring]
+
 include::modules/cnf-scheduling-numa-aware-workloads.adoc[leveloffset=+2]
 
 include::modules/cnf-nrop-support-schedulable-resources.adoc[leveloffset=+1]


### PR DESCRIPTION
Continue next PR from: modules/cnf-troubleshooting-missing-rte-config-maps.adoc

Version(s):
4.16+

Issue:
[OSDOCS-16874](https://issues.redhat.com/browse/OSDOCS-16874)


Link to docs preview:

* https://107677--ocpdocs-pr.netlify.app/openshift-enterprise/latest/edge_computing/policygenerator_for_ztp/ztp-advanced-policygenerator-config.html
* https://107677--ocpdocs-pr.netlify.app/openshift-enterprise/latest/edge_computing/policygenerator_for_ztp/ztp-configuring-managed-clusters-policygenerator.html
* https://107677--ocpdocs-pr.netlify.app/openshift-enterprise/latest/edge_computing/policygentemplate_for_ztp/ztp-advanced-policy-config.html
* https://107677--ocpdocs-pr.netlify.app/openshift-enterprise/latest/edge_computing/policygentemplate_for_ztp/ztp-configuring-managed-clusters-policies.html
* https://107677--ocpdocs-pr.netlify.app/openshift-enterprise/latest/edge_computing/ztp-advanced-install-ztp.html
* https://107677--ocpdocs-pr.netlify.app/openshift-enterprise/latest/edge_computing/ztp-deploying-far-edge-sites.html
* https://107677--ocpdocs-pr.netlify.app/openshift-enterprise/latest/edge_computing/ztp-precaching-tool.html
* https://107677--ocpdocs-pr.netlify.app/openshift-enterprise/latest/edge_computing/ztp-vdu-validating-cluster-tuning.html
* https://107677--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_sno/install-sno-installing-sno.html
* https://107677--ocpdocs-pr.netlify.app/openshift-enterprise/latest/scalability_and_performance/cnf-numa-aware-scheduling.html

