### PR TITLE
[enterprise-4.18] OSDOCS-17043_10:updating CQAs

### DIFF
--- a/machine_management/creating_machinesets/creating-machineset-vsphere.adoc
+++ b/machine_management/creating_machinesets/creating-machineset-vsphere.adoc
@@ -6,7 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-You can create a different compute machine set to serve a specific purpose in your {product-title} cluster on VMware vSphere. For example, you might create infrastructure machine sets and related machines so that you can move supporting workloads to the new machines.
+[role="_abstract"]
+You can define and create a {product-title} compute machine set on VMware vSphere to enable the Machine API to automatically scale and manage compute nodes in vSphere. You can create a different compute machine set to serve a specific purpose in your {product-title} cluster on vSphere. For example, you might create infrastructure machine sets and related machines so that you can move supporting workloads to the new machines.
 
 include::snippets/machine-user-provisioned-limitations.adoc[leveloffset=+1]
 

--- a/modules/compute-machineset-upi-reqs.adoc
+++ b/modules/compute-machineset-upi-reqs.adoc
@@ -12,7 +12,8 @@ endif::[]
 [id="compute-machineset-upi-reqs_{context}"]
 = Requirements for clusters with user-provisioned infrastructure to use compute machine sets
 
-To use compute machine sets on clusters that have user-provisioned infrastructure, you must ensure that you cluster configuration supports using the Machine API.
+[role="_abstract"]
+To enable the Machine API to manage and scale compute nodes on user-provisioned infrastructure, you can configure a `MachineSet` YAML file with specific vSphere parameters, for example data center and disk image. To use compute machine sets on clusters that have user-provisioned infrastructure, you must ensure that you cluster configuration supports using the Machine API.
 
 ifeval::["{context}" == "creating-machineset-vsphere"]
 :!vsphere:

--- a/modules/machine-api-vmw-add-tags.adoc
+++ b/modules/machine-api-vmw-add-tags.adoc
@@ -7,8 +7,8 @@
 [id="machine-api-vmw-add-tags_{context}"]
 = Adding tags to machines by using machine sets
 
-{product-title} adds a cluster-specific tag to each virtual machine (VM) that it creates.
-The installation program uses these tags to select the VMs to delete when uninstalling a cluster.
+[role="_abstract"]
+To ensure that your cluster remains scalable and resilient, you can use a `MachineSet` object and machine health checks to automate the provisioning and repair of nodes. {product-title} adds a cluster-specific tag to each virtual machine (VM) that it creates. The installation program uses these tags to select the VMs to delete when uninstalling a cluster.
 
 In addition to the cluster-specific tags assigned to VMs, you can configure a machine set to add up to 10 additional {vmw-short} tags to the VMs it provisions.
 
@@ -63,10 +63,13 @@ spec:
     spec:
       providerSpec:
         value:
-          tagIDs: # <1>
-          - <tag_id_value> # <2>
+          tagIDs:
+          - <tag_id_value>
 # ...
 ----
-<1> Specify a list of up to 10 tags to add to the machines that this machine set provisions.
-<2> Specify the value of the tag that you want to add to your machines.
-For example, `urn:vmomi:InventoryServiceTag:208e713c-cae3-4b7f-918e-4051ca7d1f97:GLOBAL`.
++
+where:
++
+--
+`spec.template.spec.providerSpec.value.tagIDs`:: Specifies a list of up to 10 tags to add to the machines that this machine set provisions. Replace `<tag_id_value>` with the tag that you want to add to your machines. For example, `urn:vmomi:InventoryServiceTag:208e713c-cae3-4b7f-918e-4051ca7d1f97:GLOBAL`.
+--

--- a/modules/machineset-upi-reqs-ignition-config.adoc
+++ b/modules/machineset-upi-reqs-ignition-config.adoc
@@ -12,7 +12,8 @@ endif::[]
 [id="machineset-upi-reqs-ignition-config_{context}"]
 = Satisfying Ignition configuration requirements
 
-Provisioning virtual machines (VMs) requires a valid Ignition configuration. The Ignition configuration contains the `machine-config-server` address and a system trust bundle for obtaining further Ignition configurations from the Machine Config Operator.
+[role="_abstract"]
+For the Machine API to provision virtual machines (VMs) with the correct initial configuration using Ignition, a valid Ignition configuration is required. The Ignition configuration contains the `machine-config-server` address and a system trust bundle for obtaining further Ignition configurations from the Machine Config Operator.
 
 By default, this configuration is stored in the `worker-user-data` secret in the `machine-api-operator` namespace. Compute machine sets reference the secret during the machine creation process.
 
@@ -31,7 +32,7 @@ $ oc get secret \
 [source,terminal]
 ----
 disableTemplating: false
-userData: <1>
+userData:
   {
     "ignition": {
       ...
@@ -39,7 +40,8 @@ userData: <1>
     ...
   }
 ----
-<1> The full output is omitted here, but should have this format.
++
+The full output is omitted here, but this is the format to use.
 
 . If the secret does not exist, create it by running the following command:
 +
@@ -50,7 +52,7 @@ $ oc create secret generic worker-user-data \
   --from-file=<installation_directory>/worker.ign
 ----
 +
-where `<installation_directory>` is the directory that was used to store your installation assets during cluster installation.
+The variable `<installation_directory>` specifies the directory that was used to store your installation assets during cluster installation.
 
 ifeval::["{context}" == "creating-machineset-vsphere"]
 :!vsphere:

--- a/modules/machineset-upi-reqs-infra-id.adoc
+++ b/modules/machineset-upi-reqs-infra-id.adoc
@@ -12,7 +12,8 @@ endif::[]
 [id="machineset-upi-reqs-infra-id_{context}"]
 = Obtaining the infrastructure ID
 
-To create compute machine sets, you must be able to supply the infrastructure ID for your cluster.
+[role="_abstract"]
+To ensure the Machine API correctly identifies and manages virtual machines (VMs) that belong to a specific cluster, you must add the unique infrastructure ID to the `MachineSet` YAML file to label and link resources. To create compute machine sets, you must be able to supply the infrastructure ID for your cluster.
 
 .Procedure
 

--- a/modules/machineset-upi-reqs-vsphere-creds.adoc
+++ b/modules/machineset-upi-reqs-vsphere-creds.adoc
@@ -6,7 +6,8 @@
 [id="machineset-upi-reqs-vsphere-creds_{context}"]
 = Satisfying vSphere credentials requirements
 
-To use compute machine sets, the Machine API must be able to interact with vCenter. Credentials that authorize the Machine API components to interact with vCenter must exist in a secret in the `openshift-machine-api` namespace.
+[role="_abstract"]
+To use compute machine sets and manage virtual machine (VM) resources, the Machine API must be able to interact with vCenter. Credentials that authorize the Machine API components to interact with vCenter must exist in a secret in the `openshift-machine-api` namespace.
 
 .Procedure
 
@@ -26,8 +27,11 @@ $ oc get secret \
 <vcenter-server>.username=<openshift-user>
 ----
 +
-where `<vcenter-server>` is the IP address or fully qualified domain name (FQDN) of the vCenter server and `<openshift-user>` and `<openshift-user-password>` are the {product-title} administrator credentials to use.
-
+where:
++
+--
+`<vcenter_server>`:: Specifies the IP address or fully qualified domain name (FQDN) of the vCenter server and `<openshift_user_password>` and `<openshift_user>` are the {product-title} administrator credentials to use.
+--
 . If the secret does not exist, create it by running the following command:
 +
 [source,terminal]

--- a/modules/machineset-vsphere-multiple-nics.adoc
+++ b/modules/machineset-vsphere-multiple-nics.adoc
@@ -8,8 +8,8 @@
 [id="machineset-vsphere-multiple-nics_{context}"]
 = Configuring multiple network interface controllers by using machine sets
 
-{product-title} clusters on {vmw-first} support connecting up to 10 network interface controllers (NICs) to a node. 
-By configuring multiple NICs, you can provide dedicated network links in the node virtual machines (VMs) for uses such as storage or databases.
+[role="_abstract"]
+By configuring multiple network interface controllers (NICs), you can provide dedicated network links in the node virtual machines (VMs) for uses such as storage or databases. {product-title} clusters on {vmw-first} support connecting up to 10 network interface controllers (NICs) to a node.
 
 You can use machine sets to manage this configuration.
 
@@ -104,16 +104,16 @@ spec:
       providerSpec:
         value:
           network:
-            devices: # <1>
+            devices:
             - networkName: "<vm_network_name_1>"
             - networkName: "<vm_network_name_2>"
-          template: <vm_template_name> # <2>
+          template: <vm_template_name>
           workspace:
-            datacenter: <vcenter_data_center_name> # <3>
-            datastore: <vcenter_datastore_name> # <4>
-            folder: <vcenter_vm_folder_path> # <5>
-            resourcepool: <vsphere_resource_pool> # <6>
-            server: <vcenter_server_ip> # <7>
+            datacenter: <vcenter_data_center_name>
+            datastore: <vcenter_datastore_name>
+            folder: <vcenter_vm_folder_path>
+            resourcepool: <vsphere_resource_pool>
+            server: <vcenter_server_ip>
 # ...
 end::compute[]
 tag::controlplane[]
@@ -127,24 +127,43 @@ spec:
         providerSpec:
           value:
             network:
-              devices: # <1>
+              devices:
               - networkName: "<vm_network_name_1>"
               - networkName: "<vm_network_name_2>"
-            template: <vm_template_name> # <2>
+            template: <vm_template_name>
             workspace:
-              datacenter: <vcenter_data_center_name> # <3>
-              datastore: <vcenter_datastore_name> # <4>
-              folder: <vcenter_vm_folder_path> # <5>
-              resourcepool: <vsphere_resource_pool> # <6>
-              server: <vcenter_server_ip> # <7>
+              datacenter: <vcenter_data_center_name>
+              datastore: <vcenter_datastore_name>
+              folder: <vcenter_vm_folder_path>
+              resourcepool: <vsphere_resource_pool>
+              server: <vcenter_server_ip>
 
 # ...
 end::controlplane[]
 ----
-<1> Specify a list of up to 10 NICs to use.
-<2> Specify the {vmw-short} VM template to use, such as `user-5ddjd-rhcos`.
-<3> Specify the vCenter data center to deploy the machine set on.
-<4> Specify the vCenter datastore to deploy the machine set on.
-<5> Specify the path to the {vmw-short} VM folder in vCenter, such as `/dc1/vm/user-inst-5ddjd`.
-<6> Specify the {vmw-short} resource pool for your VMs.
-<7> Specify the vCenter server IP or fully qualified domain name (FQDN).
+where:
++
+--
+tag::compute[]
+
+`spec.template.spec.providerSpec.value.network.devices`:: Specifies a list of up to 10 NICs to use.
+`spec.template.spec.providerSpec.value.network.template`:: Specifies the {vmw-short} VM template to use, such as `user-5ddjd-rhcos`.
+`spec.template.spec.providerSpec.value.network.workspace.datacenter`:: Specifies the vCenter data center to deploy the machine set on.
+`spec.template.spec.providerSpec.value.network.workspace.datastore`:: Specifies the vCenter datastore to deploy the machine set on.
+`spec.template.spec.providerSpec.value.network.workspace.folder`:: Specifies the path to the {vmw-short} VM folder in vCenter, such as `/dc1/vm/user-inst-5ddjd`.
+`spec.template.spec.providerSpec.value.network.workspace.resourcepool`:: Specifies the {vmw-short} resource pool for your VMs.
+`spec.template.spec.providerSpec.value.network.workspace.server`:: Specifies the vCenter server IP or fully qualified domain name (FQDN).
+
+end::compute[]
+tag::controlplane[]
+
+`spec.template.machines_v1beta1_machine_openshift_io.spec.providerSpec.value.network.devices`:: Specifies a list of up to 10 NICs to use.
+`spec.template.machines_v1beta1_machine_openshift_io.spec.providerSpec.value.network.template`:: Specifies the {vmw-short} VM template to use, such as `user-5ddjd-rhcos`.
+`spec.template.machines_v1beta1_machine_openshift_io.spec.providerSpec.value.network.workspace.datacenter`:: Specifies the vCenter data center to deploy the machine set on.
+`spec.template.machines_v1beta1_machine_openshift_io.spec.providerSpec.value.network.workspace.datastore`:: Specifies the vCenter datastore to deploy the machine set on.
+`spec.template.machines_v1beta1_machine_openshift_io.spec.providerSpec.value.network.workspace.folder`:: Specifies the path to the {vmw-short} VM folder in vCenter, such as `/dc1/vm/user-inst-5ddjd`.
+`spec.template.machines_v1beta1_machine_openshift_io.spec.providerSpec.value.network.workspace.resourcepool`:: Specifies the {vmw-short} resource pool for your VMs.
+`spec.template.machines_v1beta1_machine_openshift_io.spec.providerSpec.value.network.workspace.server`:: Specifies the vCenter server IP or fully qualified domain name (FQDN).
+
+end::controlplane[]
+--

--- a/modules/machineset-vsphere-required-permissions.adoc
+++ b/modules/machineset-vsphere-required-permissions.adoc
@@ -6,13 +6,12 @@
 [id="machineset-vsphere-requirements-user-provisioned-machine-sets_{context}"]
 = Minimum required vCenter privileges for compute machine set management
 
+[role="_abstract"]
 To manage compute machine sets in an {product-title} cluster on vCenter, you must use an account with privileges to read, create, and delete the required resources. Using an account that has global administrative privileges is the simplest way to access all of the necessary permissions.
 
 If you cannot use an account with global administrative privileges, you must create roles to grant the minimum required privileges. The following table lists the minimum vCenter roles and privileges that are required to create, scale, and delete compute machine sets and to delete machines in your {product-title} cluster.
 
 .Minimum vCenter roles and privileges required for compute machine set management
-[%collapsible]
-====
 [cols="3a,3a,3a",options="header"]
 |===
 |vSphere object for role
@@ -22,7 +21,6 @@ If you cannot use an account with global administrative privileges, you must cre
 |vSphere vCenter
 |Always
 |
-[%hardbreaks]
 `InventoryService.Tagging.AttachTag`
 `InventoryService.Tagging.CreateCategory`
 `InventoryService.Tagging.CreateTag`
@@ -37,13 +35,13 @@ If you cannot use an account with global administrative privileges, you must cre
 |vSphere vCenter Cluster
 |Always
 |
-[%hardbreaks]
+
 `Resource.AssignVMToPool`
 
 |vSphere datastore
 |Always
 |
-[%hardbreaks]
+
 `Datastore.AllocateSpace`
 `Datastore.Browse`
 
@@ -54,7 +52,7 @@ If you cannot use an account with global administrative privileges, you must cre
 |Virtual Machine Folder
 |Always
 |
-[%hardbreaks]
+
 `VirtualMachine.Config.AddRemoveDevice`
 `VirtualMachine.Config.AdvancedConfig`
 `VirtualMachine.Config.Annotation`
@@ -71,20 +69,17 @@ If you cannot use an account with global administrative privileges, you must cre
 |vSphere vCenter data center
 |If the installation program creates the virtual machine folder.
 |
-[%hardbreaks]
+
 `Resource.AssignVMToPool`
 `VirtualMachine.Provisioning.DeployTemplate`
 
 3+a|
 ^1^ The `StorageProfile.Update` and `StorageProfile.View` permissions are required only for storage backends that use the Container Storage Interface (CSI).
 |===
-====
 
 The following table details the permissions and propagation settings that are required for compute machine set management.
 
 .Required permissions and propagation settings
-[%collapsible]
-====
 [cols="3a,3a,3a,3a",options="header"]
 |===
 |vSphere object
@@ -131,6 +126,5 @@ The following table details the permissions and propagation settings that are re
 |Required
 |Listed required privileges
 |===
-====
 
 For more information about creating an account with only the required privileges, see link:https://docs.vmware.com/en/VMware-vSphere/7.0/com.vmware.vsphere.security.doc/GUID-5372F580-5C23-4E9C-8A4E-EF1B4DD9033E.html[vSphere Permissions and User Management Tasks] in the vSphere documentation.

--- a/modules/machineset-yaml-vsphere.adoc
+++ b/modules/machineset-yaml-vsphere.adoc
@@ -3,6 +3,7 @@
 // * machine_management/creating-infrastructure-machinesets.adoc
 // * machine_management/creating_machinesets/creating-machineset-vsphere.adoc
 
+
 ifeval::["{context}" == "creating-infrastructure-machinesets"]
 :infra:
 endif::[]
@@ -11,7 +12,10 @@ endif::[]
 [id="machineset-yaml-vsphere_{context}"]
 = Sample YAML for a compute machine set custom resource on vSphere
 
-This sample YAML defines a compute machine set that runs on VMware vSphere and creates nodes that are labeled with
+[role="_abstract"]
+To enable the Machine API to automate node provisioning on VMware vSphere infrastructure, define a `MachineSet` resource with parameters that are specific to VMware vSphere, for example data center, resource pool, and template.
+
+The sample YAML file defines a compute machine set that runs on VMware vSphere and creates nodes that are labeled with
 ifndef::infra[`node-role.kubernetes.io/<role>: ""`.]
 ifdef::infra[`node-role.kubernetes.io/infra: ""`.]
 
@@ -25,113 +29,121 @@ is the node label to add.
 apiVersion: machine.openshift.io/v1beta1
 kind: MachineSet
 metadata:
-  creationTimestamp: null
-  labels:
-    machine.openshift.io/cluster-api-cluster: <infrastructure_id> <1>
+ creationTimestamp: null
+ labels:
+   machine.openshift.io/cluster-api-cluster: <infrastructure_id>
 ifndef::infra[]
-  name: <infrastructure_id>-<role> <2>
+ name: <infrastructure_id>-<role>
 endif::infra[]
 ifdef::infra[]
-  name: <infrastructure_id>-infra <2>
+ name: <infrastructure_id>-infra
 endif::infra[]
-  namespace: openshift-machine-api
+ namespace: openshift-machine-api
 spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      machine.openshift.io/cluster-api-cluster: <infrastructure_id>
+ replicas: 1
+ selector:
+   matchLabels:
+     machine.openshift.io/cluster-api-cluster: <infrastructure_id>
 ifndef::infra[]
-      machine.openshift.io/cluster-api-machineset: <infrastructure_id>-<role>
+     machine.openshift.io/cluster-api-machineset: <infrastructure_id>-<role>
 endif::infra[]
 ifdef::infra[]
-      machine.openshift.io/cluster-api-machineset: <infrastructure_id>-infra
+     machine.openshift.io/cluster-api-machineset: <infrastructure_id>-infra
 endif::infra[]
-  template:
-    metadata:
-      creationTimestamp: null
-      labels:
-        machine.openshift.io/cluster-api-cluster: <infrastructure_id>
+ template:
+   metadata:
+     creationTimestamp: null
+     labels:
+       machine.openshift.io/cluster-api-cluster: <infrastructure_id>
 ifndef::infra[]
-        machine.openshift.io/cluster-api-machine-role: <role> <3>
-        machine.openshift.io/cluster-api-machine-type: <role>
-        machine.openshift.io/cluster-api-machineset: <infrastructure_id>-<role>
+       machine.openshift.io/cluster-api-machine-role: <role>
+       machine.openshift.io/cluster-api-machine-type: <role>
+       machine.openshift.io/cluster-api-machineset: <infrastructure_id>-<role>
 endif::infra[]
 ifdef::infra[]
-        machine.openshift.io/cluster-api-machine-role: infra <3>
-        machine.openshift.io/cluster-api-machine-type: infra
-        machine.openshift.io/cluster-api-machineset: <infrastructure_id>-infra
+       machine.openshift.io/cluster-api-machine-role: infra
+       machine.openshift.io/cluster-api-machine-type: infra
+       machine.openshift.io/cluster-api-machineset: <infrastructure_id>-infra
 endif::infra[]
-    spec:
-      metadata:
-        creationTimestamp: null
-        labels:
+   spec:
+     metadata:
+       creationTimestamp: null
+       labels:
 ifndef::infra[]
-          node-role.kubernetes.io/<role>: ""
+         node-role.kubernetes.io/<role>: ""
 endif::infra[]
 ifdef::infra[]
-          node-role.kubernetes.io/infra: ""
+         node-role.kubernetes.io/infra: ""
 endif::infra[]
-      providerSpec:
-        value:
-          apiVersion: machine.openshift.io/v1beta1
-          credentialsSecret:
-            name: vsphere-cloud-credentials
-          diskGiB: 120
-          kind: VSphereMachineProviderSpec
-          memoryMiB: 8192
-          metadata:
-            creationTimestamp: null
-          network:
-            devices:
-            - networkName: "<vm_network_name>" <4>
-          numCPUs: 4
-          numCoresPerSocket: 1
-          snapshot: ""
-          template: <vm_template_name> <5>
-          userDataSecret:
-            name: worker-user-data
-          workspace:
-            datacenter: <vcenter_data_center_name> <6>
-            datastore: <vcenter_datastore_name> <7>
-            folder: <vcenter_vm_folder_path> <8>
-            resourcepool: <vsphere_resource_pool> <9>
-            server: <vcenter_server_ip> <10>
+     providerSpec:
+       value:
+         apiVersion: machine.openshift.io/v1beta1
+         credentialsSecret:
+           name: vsphere-cloud-credentials
+         dataDisks:
+         - name: "<disk_name>"
+           provisioningMode: "<mode>"
+           sizeGiB: 20
+         diskGiB: 120
+         kind: VSphereMachineProviderSpec
+         memoryMiB: 8192
+         metadata:
+           creationTimestamp: null
+         network:
+           devices:
+           - networkName: "<vm_network_name>"
+         numCPUs: 4
+         numCoresPerSocket: 1
+         snapshot: ""
+         template: <vm_template_name>
+         userDataSecret:
+           name: worker-user-data
+         workspace:
+           datacenter: <vcenter_data_center_name>
+           datastore: <vcenter_datastore_name>
+           folder: <vcenter_vm_folder_path>
+           resourcepool: <vsphere_resource_pool>
+           server: <vcenter_server_ip>
 ifdef::infra[]
-      taints: <11>
-      - key: node-role.kubernetes.io/infra
-        effect: NoSchedule
+     taints:
+     - key: node-role.kubernetes.io/infra
+       effect: NoSchedule
 endif::infra[]
 ----
-<1> Specify the infrastructure ID that is based on the cluster ID that you set when you provisioned the cluster. If you have the OpenShift CLI (`oc`) installed, you can obtain the infrastructure ID by running the following command:
-+
+
+where:
+
+`<infrastructure_id>`:: Specifies the infrastructure ID that is based on the cluster ID that you set when you provisioned the cluster. If you have the OpenShift CLI (`oc`) installed, you can obtain the infrastructure ID by running the following command:
 [source,terminal]
 ----
 $ oc get -o jsonpath='{.status.infrastructureName}{"\n"}' infrastructure cluster
 ----
 ifndef::infra[]
-<2> Specify the infrastructure ID and node label.
-<3> Specify the node label to add.
+`<infrastructure_id>-<role>`:: Specifies the infrastructure ID and node label.
+`<role>`:: Specifies the node label to add.
 endif::infra[]
 ifdef::infra[]
-<2> Specify the infrastructure ID and `infra` node label.
-<3> Specify the `infra` node label.
+`<infrastructure_id>-infra`:: Specifies the infrastructure ID and `infra` node label.
+`infra`:: Specifies the `infra` node label.
 endif::infra[]
-<4> Specify the vSphere VM network to deploy the compute machine set to. This VM network must be where other compute machines reside in the cluster.
-<5> Specify the vSphere VM template to use, such as `user-5ddjd-rhcos`.
-<6> Specify the vCenter data center to deploy the compute machine set on.
-<7> Specify the vCenter datastore to deploy the compute machine set on.
-<8> Specify the path to the vSphere VM folder in vCenter, such as `/dc1/vm/user-inst-5ddjd`.
-<9> Specify the vSphere resource pool for your VMs.
-<10> Specify the vCenter server IP or fully qualified domain name.
+`<disk_name>`:: Specifies one or more data disk definitions. For more information, see "Configuring data disks by using machine sets".
+`<vm_network_name>`:: Specifies the vSphere VM network to deploy the compute machine set to. This VM network must be where other compute machines reside in the cluster.
+`<vm_template_name>`:: Specifies the vSphere VM template to use, such as `user-5ddjd-rhcos`.
+`<vcenter_data_center_name>`:: Specifies the vCenter datacenter to deploy the compute machine set on.
+`<vcenter_datastore_name>`:: Specifies the vCenter datastore to deploy the compute machine set on.
+`<vcenter_vm_folder_path>`:: Specifies the path to the vSphere VM folder in vCenter, such as `/dc1/vm/user-inst-5ddjd`.
+`<vsphere_resource_pool>`:: Specifies the vSphere resource pool for your VMs.
+`<vcenter_server_ip>`:: Specifies the vCenter server IP or fully qualified domain name.
+
 ifdef::infra[]
-<11> Specify a taint to prevent user workloads from being scheduled on infra nodes.
-+
+`taints`:: Specifies a taint to prevent user workloads from being scheduled on infra nodes.
+
 [NOTE]
 ====
 After adding the `NoSchedule` taint on the infrastructure node, existing DNS pods running on that node are marked as `misscheduled`. You must either delete or link:https://access.redhat.com/solutions/6592171[add toleration on `misscheduled` DNS pods].
 ====
-endif::infra[]
 
+endif::infra[]
 ifeval::["{context}" == "creating-infrastructure-machinesets"]
 :!infra:
 endif::[]


### PR DESCRIPTION
4.18 cherrypick of https://github.com/openshift/openshift-docs/commit/12a2c8a237cd7ea426a8730376cc0254c66aec52
Manual cherry pick of https://github.com/openshift/openshift-docs/pull/103153

This PR does not include modules/machineset-vsphere-data-disks.adoc. This file was in https://github.com/openshift/openshift-docs/pull/103153, but is not in this PR as it is not in the 4.18 repo.