### PR TITLE
OSDOCS-18460 created zstream RNs for 4-17-50

### DIFF
--- a/modules/zstream-4-17-50.adoc
+++ b/modules/zstream-4-17-50.adoc
@@ -1,0 +1,31 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-17-release-notes.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="zstream-4-17-50-about_{context}"]
+= RHSA-2026:3418 - {product-title} {product-version}.50 fixed issues and security update
+
+Issued: 4 March 2026
+
+[role="_abstract"]
+{product-title} release {product-version}.50 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2026:3418[RHSA-2026:3418] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2026:3416[RHSA-2026:3416] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.17.50--pullspecs
+----
+
+[id="zstream-4-17-50-fixed-issues_{context}"]
+== Fixed issues
+
+* Before this update, the `collect-profiles` job in {olm0-first} periodically used CPU and disk space. With this release, the `collect-profiles` job is removed from {olmv0}, which reduces the periodic CPU and disk use caused by the job process. (link:https://issues.redhat.com/browse/OCPBUGS-76953[OCPBUGS-76953])
+
+[id="zstream-4-17-50-updating_{context}"]
+== Updating
+
+To update an {product-title} 4.17 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].

--- a/release_notes/ocp-4-17-release-notes.adoc
+++ b/release_notes/ocp-4-17-release-notes.adoc
@@ -2947,6 +2947,9 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+//  4.17.50
+include::modules/zstream-4-17-50.adoc[leveloffset=+2]
+
 //  4.17.49
 include::modules/zstream-4-17-49.adoc[leveloffset=+2]
 


### PR DESCRIPTION
Version(s):
4.17

Issue:
https://issues.redhat.com/browse/OSDOCS-18460

Link to docs preview:
https://107701--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-17-release-notes.html#zstream-4-17-50-about_release-notes


QE review:
- [ ] QE has approved this change.


Additional information:
To find the **Image** and **RPM IDs**, select the following links:

For the **Image ID**:[https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/387/diffs#ef2d1f07a477820b4d6b4a5240b1aaf310f394f1]( https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/387/diffs#ef2d1f07a477820b4d6b4a5240b1aaf310f394f1)

For the **RPM ID**:[https://errata.devel.redhat.com/advisory/159607(https://errata.devel.redhat.com/advisory/159607](https://errata.devel.redhat.com/advisory/159607)

**Must be on VPN** to view these links.

