### PR TITLE
[OSDOCS#17648]Fix Official Product Names for ROSA Learning_Delete cluster using ROSA CLI.

### DIFF
--- a/modules/learning-getting-started-deleting-cli.adoc
+++ b/modules/learning-getting-started-deleting-cli.adoc
@@ -3,10 +3,10 @@
 // * rosa_learning/creating_cluster_workshop/learning-getting-started-support.adoc
 :_mod-docs-content-type: PROCEDURE
 [id="learning-getting-started-deleting-cli_{context}"]
-= Deleting a {product-title} cluster using the CLI
+= Deleting a {product-title} cluster using the ROSA CLI
 
 [role="_abstract"]
-You can delete your cluster using the {rosa-cli}.
+You can delete your cluster using the {rosa-cli-first}.
 
 .Procedure
 . *Optional:* List your clusters to make sure you are deleting the correct one by running the following command:
@@ -32,10 +32,10 @@ This command is non-recoverable.
 +
 [NOTE]
 ====
-All AWS STS and IAM roles and policies will remain and must be deleted manually once the cluster deletion is complete by following the steps below.
+All AWS Security Token Service (STS) and Identity and Access Managmenet (IAM) roles and policies will remain and must be deleted manually once the cluster deletion is complete by following the steps below.
 ====
 
-. The CLI outputs the commands to delete the OpenID Connect (OIDC) provider and Operator IAM roles resources that were created. Wait until the cluster finishes deleting before deleting these resources. Perform a quick status check by running the following command:
+. The {rosa-cli} outputs the commands to delete the OpenID Connect (OIDC) provider and Operator IAM roles resources that were created. Wait until the cluster finishes deleting before deleting these resources. Perform a quick status check by running the following command:
 +
 [source,terminal]
 ----
@@ -61,7 +61,7 @@ $ rosa delete operator-roles -c <clusterID> --mode auto --yes
 This command requires the cluster ID and not the cluster name.
 ====
 
-. Only remove the remaining account roles if they are no longer needed by other clusters in the same account. If you want to create other ROSA clusters in this account, do not perform this step.
+. Only remove the remaining account roles if they are no longer needed by other clusters in the same account. If you want to create other {product-title} clusters in this account, do not perform this step.
 +
 To delete the account roles, you need to know the prefix used when creating them. The default is "ManagedOpenShift" unless you specified otherwise.
 +


### PR DESCRIPTION
Version(s):
4.20+

Issue:
https://issues.redhat.com/browse/OSDOCS-17648

Link to docs preview:
[Deleting your cluster](https://107706--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/rosa_learning/creating_cluster_workshop/learning-getting-started-deleting.html)

Peer review:
- [ ] Peer reviewer has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

QE review:
- QE approval is not required for this PR as no procedural changes involved.

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
