### PR TITLE
CNV-78916: Add RN about removing latency check

### DIFF
--- a/virt/release_notes/virt-4-22-release-notes.adoc
+++ b/virt/release_notes/virt-4-22-release-notes.adoc
@@ -91,8 +91,10 @@ link:https://issues.redhat.com/browse/CNV-73301[CNV-73301]
 [role="_abstract"]
 Removed features are no longer supported in {VirtProductName}.
 
-
-
+Predefined latency checkup feature removed::
+In previous versions, cluster and project administrators could use a predefined latency checkup to verify network connectivity and measure latency between two virtual machines (VMs) that are attached to a secondary network interface. With this release, the predefined latency checkup feature is removed.
++
+link:https://issues.redhat.com/browse/CNV-77646[CNV-77646]
 
 [id="virt-4-22-technology-preview_{context}"]
 == Technology Preview features


### PR DESCRIPTION
Version(s):
4.22

Issue:
https://issues.redhat.com/browse/CNV-78916

Link to docs preview:
https://107720--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/release_notes/virt-4-22-release-notes.html#virt-4-22-removed_virt-4-22-release-notes

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
