### PR TITLE
[enterprise-4.20] OCPBUGS#52324: Added note for bootMode

### DIFF
--- a/modules/ipi-install-additional-install-config-parameters.adoc
+++ b/modules/ipi-install-additional-install-config-parameters.adoc
@@ -21,9 +21,13 @@ See the following tables for the required parameters, the `hosts` parameter, and
 
 | `bootMode`
 | `UEFI`
-| The boot mode for a node. Options are `legacy`, `UEFI`, and `UEFISecureBoot`. If `bootMode` is not set, Ironic sets it while inspecting the node.
+a| The boot mode for a node. Options are `legacy`, `UEFI`, and `UEFISecureBoot`. If `bootMode` is not set, Ironic sets it while inspecting the node.
 
-a| 
+[NOTE]
+====
+For hardware that implements `BootMode` read-only, such as HP or Cisco, do not leave this parameter blank. You must manually set the system to UEFI mode before installation and explicitly set this parameter to UEFI.
+====
+a|
 ----
 platform:
   baremetal: 


### PR DESCRIPTION
Manual cherrypick of https://github.com/openshift/openshift-docs/pull/107591