### PR TITLE
OBSDOCS-3174: Document Review default set of stream labels for "opens…

### DIFF
--- a/configuring/configuring-lokistack-otlp.adoc
+++ b/configuring/configuring-lokistack-otlp.adoc
@@ -104,34 +104,33 @@ Avoid using regular expressions for stream labels, as this can increase data vol
 
 Attributes that are not explicitly set as stream labels or dropped from the entry are saved as structured metadata by default.
 
-[id="customizing-openshift-defaults_{context}"]
-=== Customizing OpenShift defaults
+[id="required-and-optional-default-labels-for-OpenShift_{context}"]
+=== Required and optional default labels for OpenShift
 
-In the `openshift-logging` mode, certain attributes are required and cannot be removed from the configuration due to their role in OpenShift functions. Other attributes, labeled *recommended*, might be dropped if performance is impacted. For information about the attributes, see xref:../configuring/opentelemetry-data-model.adoc#attributes_opentelemetry-data-model[OpenTelemetry data model attributes].
+In the openshift-logging mode, you must not remove certain required attributes because they are essential to OpenShift functions.
 
-When using the `openshift-logging` mode without custom attributes, you can achieve immediate compatibility with OpenShift tools. If additional attributes are needed as stream labels or some attributes need to be dropped, use custom configuration. Custom configurations can merge with default configurations.
+If you use the {ocp-product-title} web console to query logs, enable the attributes called console labels.
+When you enable console labels, the following attributes are added to stream labels:
 
-[id="removing-recommended-attributes_{context}"]
-=== Removing recommended attributes
+* `k8s.container.name`
+* `k8s.cronjob.name`
+* `k8s.daemonset.name`
+* `k8s.deployment.name`
+* `k8s.job.name`
+* `k8s.node.name`
+* `k8s.pod.name`
+* `k8s.statefulset.name`
+* `kubernetes.container_name`
+* `kubernetes.host`
+* `kubernetes.pod_name`
+* `service.name`
 
-To reduce default attributes in the `openshift-logging` mode, disable recommended attributes:
+For information about enabling console attributes, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_logging/{logging-major-version}/html/configuring_logging/configuring-lokistack-otlp#configuring-lokistack-otlp-data-ingestion_configuring-lokistack-otlp[Configuring LokiStack for OTLP data ingestion].
 
-[source,yaml]
-----
-# ...
-spec:
-  tenants:
-    mode: openshift-logging
-    openshift:
-      otlp:
-        disableRecommendedAttributes: true # <1>
-----
-<1> Set `disableRecommendedAttributes: true` to remove recommended attributes, which limits default attributes to the required attributes or stream labels.
-+
-[NOTE]
-====
-This setting might negatively impact query performance, as it removes default stream labels. You must pair this option with a custom attribute configuration to retain attributes essential for queries.
-====
+You can add custom stream labels or drop information from the structured metadata when you use the openshift-logging mode.
+The custom configuration is merged with the OpenShift defaults.
+
+For information about the attributes, see xref:../configuring/opentelemetry-data-model.adoc#attributes_opentelemetry-data-model[OpenTelemetry data model attributes].
 
 [role="_additional-resources"]
 [id="additional-resources_{context}"]

--- a/modules/configuring-lokistack-otlp-data-ingestion.adoc
+++ b/modules/configuring-lokistack-otlp-data-ingestion.adoc
@@ -36,3 +36,16 @@ spec:
 ----
 +
 Once the `effectiveDate` has passed, the v13 schema takes effect, enabling your `LokiStack` to store structured metadata.
+
+. If you use the {ocp-product-title} web console to query logs, enable console labels:
++
+[source,yaml]
+----
+# ...
+spec:
+  tenants:
+    mode: openshift-logging
+    openshift:
+      otlp:
+        enableConsoleLabels: true
+----


### PR DESCRIPTION
Version(s): 6.5
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OBSDOCS-3174
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
- https://107773--ocpdocs-pr.netlify.app/openshift-logging/latest/configuring/configuring-lokistack-otlp.html#customizing-openshift-defaults_configuring-lokistack-otlp
- https://107773--ocpdocs-pr.netlify.app/openshift-logging/latest/configuring/configuring-lokistack-otlp.html#enabling-console-labels-for-openshift-web-console_configuring-lokistack-otlp

<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
