### PR TITLE
OBSDOCS-3132 Add docinfo.xml to 7 DT titles

### DIFF
--- a/about/docinfo.xml
+++ b/about/docinfo.xml
@@ -1,0 +1,11 @@
+<title>About the distributed tracing platform</title>
+<productname>{product-title}</productname>
+<productnumber>{product-version}</productnumber>
+<subtitle>Key features and architecture</subtitle>
+<abstract>
+    <para>Learn about the key capabilities, architecture, and concepts of the distributed tracing platform.</para>
+</abstract>
+<authorgroup>
+    <orgname>Red Hat OpenShift Documentation Team</orgname>
+</authorgroup>
+<xi:include href="Common_Content/Legal_Notice.xml" xmlns:xi="http://www.w3.org/2001/XInclude" />

--- a/configuring/docinfo.xml
+++ b/configuring/docinfo.xml
@@ -1,0 +1,11 @@
+<title>Configuring</title>
+<productname>{product-title}</productname>
+<productnumber>{product-version}</productnumber>
+<subtitle>Customizing TempoStack and TempoMonolithic configuration</subtitle>
+<abstract>
+    <para>Learn how to configure the distributed tracing platform, including query options, TLS settings, span metrics, and monitoring.</para>
+</abstract>
+<authorgroup>
+    <orgname>Red Hat OpenShift Documentation Team</orgname>
+</authorgroup>
+<xi:include href="Common_Content/Legal_Notice.xml" xmlns:xi="http://www.w3.org/2001/XInclude" />

--- a/installing/docinfo.xml
+++ b/installing/docinfo.xml
@@ -1,0 +1,11 @@
+<title>Installing</title>
+<productname>{product-title}</productname>
+<productnumber>{product-version}</productnumber>
+<subtitle>Deploying the Tempo Operator and creating instances</subtitle>
+<abstract>
+    <para>Learn how to deploy the Tempo Operator and create TempoStack or TempoMonolithic instances from the OpenShift web console or CLI.</para>
+</abstract>
+<authorgroup>
+    <orgname>Red Hat OpenShift Documentation Team</orgname>
+</authorgroup>
+<xi:include href="Common_Content/Legal_Notice.xml" xmlns:xi="http://www.w3.org/2001/XInclude" />

--- a/release-notes/docinfo.xml
+++ b/release-notes/docinfo.xml
@@ -1,0 +1,11 @@
+<title>Release notes</title>
+<productname>{product-title}</productname>
+<productnumber>{product-version}</productnumber>
+<subtitle>What is new and what has changed with this release</subtitle>
+<abstract>
+    <para>Learn about the general availability and Technology Preview updates in terms of features and bugs.</para>
+</abstract>
+<authorgroup>
+    <orgname>Red Hat OpenShift Documentation Team</orgname>
+</authorgroup>
+<xi:include href="Common_Content/Legal_Notice.xml" xmlns:xi="http://www.w3.org/2001/XInclude" />

--- a/removing/docinfo.xml
+++ b/removing/docinfo.xml
@@ -1,0 +1,11 @@
+<title>Removing</title>
+<productname>{product-title}</productname>
+<productnumber>{product-version}</productnumber>
+<subtitle>Uninstalling the Tempo Operator and instances</subtitle>
+<abstract>
+    <para>Learn how to correctly and successfully remove the distributed tracing platform from an OpenShift cluster.</para>
+</abstract>
+<authorgroup>
+    <orgname>Red Hat OpenShift Documentation Team</orgname>
+</authorgroup>
+<xi:include href="Common_Content/Legal_Notice.xml" xmlns:xi="http://www.w3.org/2001/XInclude" />

--- a/troubleshooting/docinfo.xml
+++ b/troubleshooting/docinfo.xml
@@ -1,0 +1,11 @@
+<title>Troubleshooting</title>
+<productname>{product-title}</productname>
+<productnumber>{product-version}</productnumber>
+<subtitle>Diagnosing distributed tracing platform issues</subtitle>
+<abstract>
+    <para>Learn how to troubleshoot the distributed tracing platform by collecting diagnostic data from the command line.</para>
+</abstract>
+<authorgroup>
+    <orgname>Red Hat OpenShift Documentation Team</orgname>
+</authorgroup>
+<xi:include href="Common_Content/Legal_Notice.xml" xmlns:xi="http://www.w3.org/2001/XInclude" />

--- a/updating/docinfo.xml
+++ b/updating/docinfo.xml
@@ -1,0 +1,11 @@
+<title>Upgrading</title>
+<productname>{product-title}</productname>
+<productnumber>{product-version}</productnumber>
+<subtitle>Managing Tempo Operator version upgrades</subtitle>
+<abstract>
+    <para>Learn about the automatic upgrades of the Tempo Operator.</para>
+</abstract>
+<authorgroup>
+    <orgname>Red Hat OpenShift Documentation Team</orgname>
+</authorgroup>
+<xi:include href="Common_Content/Legal_Notice.xml" xmlns:xi="http://www.w3.org/2001/XInclude" />


### PR DESCRIPTION
## Summary
- Adds `docinfo.xml` metadata files to all 7 content directories (`about`, `release-notes`, `installing`, `configuring`, `troubleshooting`, `updating`, `removing`)
- Each file follows the OTel standalone pattern with title, subtitle, abstract, author group, and legal notice include