### PR TITLE
[RHDEVDOCS-7184_fix] Pipelines 1.15.4 Release Notes

### DIFF
--- a/modules/op-release-notes-1-15.adoc
+++ b/modules/op-release-notes-1-15.adoc
@@ -564,3 +564,19 @@ With this update, {pipelines-title} General Availability (GA) 1.15.3 is availabl
 * Before this update, if you used the `buildah` task, which was shipped in the `openshift-pipelines` namespace and specified an entitlement secret, {pipelines-shortname} logged a `permission denied` error. By default, the task expected `ReadWrite` permissions on all directories; however, the task used the entitlement secret as a volume and this secret was mounted with `ReadOnly` permissions. With this update, the expected permissions are corrected and you can use the `buildah` task successfully without a permission error.
 
 * Before this update, automatic updates were enabled for the Chains component during an upgrade of the {pipelines-title} version, even if you had previously disabled the automatic updates. With this update, the automatic updates setting for the Chains component does not change during a version upgrade.
+
+[id="release-notes-1-15-4_{context}"]
+== Release notes for {pipelines-title} General Availability 1.15.4
+
+With this update, {pipelines-title} General Availability (GA) 1.15.4 is available on {OCP} 4.12, 4.14, and later versions.
+
+[id="fixed-issues-1-15-4_{context}"]
+=== Fixed issues
+
+* Before this update, the {pipelines-shortname} console plugin did not include a dedicated navigation section. With this update, a *Pipelines* section is added to the console navigation, improving the discoverability and organization of {pipelines-shortname} resources in the web console.
+
+* Before this update, the resource icons for custom resource definitions (CRDs) in the {pipelines-shortname} console plugin were not displayed with consistent colors. With this update, all CRD icons use consistent coloring.
+
+* Before this update, the {pipelines-title} Operator logged excessive messages during normal operation. With this update, the Operator logging levels are corrected to reduce extraneous log output.
+
+* Before this update, the {pipelines-shortname} Operator logged high-frequency internal operations at the `INFO` level, generating more than 2,000 log entries per second during normal operation. With this update, these operations are logged at the `DEBUG` level, significantly reducing log volume and improving log signal-to-noise ratio.


### PR DESCRIPTION
Version(s):

- None for CP

Issue:

https://issues.redhat.com/browse/RHDEVDOCS-7184

Link to docs preview:
- [Release notes for Red Hat OpenShift Pipelines General Availability 1.15.4](https://107790--ocpdocs-pr.netlify.app/openshift-pipelines/latest/about/op-release-notes.html#release-notes-1-15-4_op-release-notes)

QE review:

- [x] QE has approved this change.

SME review: @waveywaves
QE review: @jayesh-garg


Additional information:
Fix PR for https://github.com/openshift/openshift-docs/pull/105815.
