### PR TITLE
OSDOCS 18490 Enable boot image updates by default for vsphere and Azure

### DIFF
--- a/snippets/mco-update-boot-images-intro.adoc
+++ b/snippets/mco-update-boot-images-intro.adoc
@@ -19,11 +19,11 @@ The following table lists the platforms on which boot image management is availa
 |Disabled by default
 
 |{azure-first}
-|Disabled by default
+|Enabled by default 
 |Disabled by default
 
 |{vmw-first}
-|Disabled by default 
+|Enabled by default
 |Not supported
 
 |===


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-18490

Link to docs preview:
Boot image management -- Updated table. [Current docs](https://docs.redhat.com/en/documentation/openshift_container_platform/4.21/html/machine_configuration/mco-update-boot-images).

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->