### PR TITLE
OBSDOCS-3038: Document Tempo Operator configuration via OLM Subscription environment

### DIFF
--- a/modules/distr-tracing-tempo-config-operator.adoc
+++ b/modules/distr-tracing-tempo-config-operator.adoc
@@ -1,0 +1,155 @@
+// Module included in the following assemblies:
+//
+// * observability/distr_tracing/distr-tracing-tempo-configuring.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="distr-tracing-tempo-config-operator_{context}"]
+= Configuring the {TempoOperator}
+
+[role="_abstract"]
+You can configure the {TempoOperator} by using the Operator Lifecycle Manager (OLM) Subscription custom resource (CR) to override default settings. This configuration method uses environment variables that take precedence over any ConfigMap-based configuration.
+
+.Example Subscription CR with Operator configuration
+[source,yaml]
+----
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: tempo-product
+  namespace: openshift-tempo-operator
+spec:
+  channel: stable
+  name: tempo-product
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+  config:
+    env:
+    - name: FEATURE_GATES
+      value: "openshift.route,openshift.servingCertsService"
+    - name: TLS_PROFILE
+      value: "Modern"
+----
+where:
+
+`FEATURE_GATES`:: Specifies a comma-separated list of feature gates to enable or disable. Prefix a gate with `-` to disable it.
+`TLS_PROFILE`:: Specifies the TLS security profile for the Operator.
+
+[TIP]
+====
+You can also configure these values from the {product-title} web console by editing the Subscription object under *Operators* > *Installed Operators* > *{TempoOperator}* > *Subscription*.
+====
+
+You can configure the {TempoOperator} by using the environment variables from the following tables.
+
+.Feature gates
+[options="header"]
+[cols="a, a"]
+|===
+|Feature gate |Description
+
+|`openshift.route`
+|Enables {product-title} route creation for Tempo components.
+
+|`openshift.servingCertsService`
+|Enables {product-title} service serving certificates.
+
+|`openshift.oauthProxy`
+|Enables {product-title} OAuth proxy integration.
+
+|`httpEncryption`
+|Enables HTTP encryption for Tempo components.
+
+|`grpcEncryption`
+|Enables gRPC encryption for Tempo components.
+
+|`prometheusOperator`
+|Enables Prometheus Operator integration for metrics.
+
+|`grafanaOperator`
+|Enables Grafana Operator integration.
+
+|`builtInCertManagement`
+|Enables built-in certificate management.
+
+|`observability.metrics.createServiceMonitors`
+|Enables creation of `ServiceMonitor` resources for Prometheus.
+
+|`observability.metrics.createPrometheusRules`
+|Enables creation of `PrometheusRule` resources for alerts.
+
+|`networkPolicies`
+|Enables creation of `NetworkPolicy` resources.
+
+|===
+
+.General configuration environment variables
+[options="header"]
+[cols="a, a, a"]
+|===
+|Environment variable |Description |Example value
+
+|`FEATURE_GATES`
+|Lists comma-separated feature gates to enable or disable. Prefix a gate with `-` to disable it.
+|`openshift.route,openshift.servingCertsService,-networkPolicies`
+
+|`TLS_PROFILE`
+|Sets TLS security profile type.
+|`Old`, `Intermediate`, or `Modern`
+
+|`OPENSHIFT_BASE_DOMAIN`
+|Sets the {product-title} base domain for route generation.
+|`apps.example.com`
+
+|`DEFAULT_POD_SECURITY_CONTEXT`
+|Sets the default `PodSecurityContext` object as JSON.
+|`{"runAsNonRoot": true}`
+
+|===
+
+.Built-in certificate management environment variables
+[options="header"]
+[cols="a, a, a"]
+|===
+|Environment variable |Description |Example value
+
+|`BUILT_IN_CERT_MANAGEMENT_CA_VALIDITY`
+|CA certificate validity duration.
+|`8760h`
+
+|`BUILT_IN_CERT_MANAGEMENT_CA_REFRESH`
+|CA certificate refresh interval.
+|`7008h`
+
+|`BUILT_IN_CERT_MANAGEMENT_CERT_VALIDITY`
+|Certificate validity duration.
+|`2160h`
+
+|`BUILT_IN_CERT_MANAGEMENT_CERT_REFRESH`
+|Certificate refresh interval.
+|`1728h`
+
+|===
+
+.Controller manager environment variables
+[options="header"]
+[cols="a, a, a"]
+|===
+|Environment variable |Description |Example value
+
+|`METRICS_BIND_ADDRESS`
+|Metrics server bind address.
+|`:8080`
+
+|`METRICS_SECURE`
+|Enables secure metrics serving.
+|`true`
+
+|`HEALTH_PROBE_BIND_ADDRESS`
+|Health probe bind address.
+|`:8081`
+
+|`WEBHOOK_PORT`
+|Webhook server port.
+|`9443`
+
+|===

--- a/observability/distr_tracing/distr-tracing-tempo-configuring.adoc
+++ b/observability/distr_tracing/distr-tracing-tempo-configuring.adoc
@@ -8,6 +8,8 @@ toc::[]
 
 The {TempoOperator} uses a custom resource definition (CRD) file that defines the architecture and configuration settings for creating and deploying the {TempoShortName} resources. You can install the default configuration or modify the file.
 
+include::modules/distr-tracing-tempo-config-operator.adoc[leveloffset=+1]
+
 ifdef::openshift-enterprise,openshift-dedicated[]
 [id="configuring-storages_{context}"]
 == Configuring back-end storage


### PR DESCRIPTION
Signed-off-by: Ruben Vargas <ruben.vp8510@gmail.com>

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): OCP 4.12-4.21
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OBSDOCS-3038
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://107817--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/distr_tracing/distr-tracing-tempo-configuring.html#distr-tracing-tempo-config-operator_distr-tracing-tempo-configuring
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: Based on https://github.com/openshift/openshift-docs/pull/105528
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
