### PR TITLE
CNV#80385: Placeholder file for 4.22 RN

### DIFF
--- a/virt/release_notes/virt-4-22-release-notes.adoc
+++ b/virt/release_notes/virt-4-22-release-notes.adoc
@@ -1,0 +1,15 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="virt-4-22-release-notes"]
+= {VirtProductName} release notes
+include::_attributes/common-attributes.adoc[]
+:context: virt-4-22-release-notes
+
+[role="_abstract"]
+Placeholder assembly used only so the documentation build succeeds. Release notes must be edited in the relevant product branch.
+
+toc::[]
+
+Do not add or edit release notes here. Edit release notes directly in the branch
+that they are relevant for.
+
+This file is here to allow builds to work.


### PR DESCRIPTION
Version(s):
main only

Issue:
https://issues.redhat.com/browse/CNV-80385

Link to docs preview:
https://107849--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/release_notes/virt-release-notes-placeholder

QE review:
NA

Additional information:
In order to fix vale-bot error, had to add an `abstract` role to the file, though it doesn't really matter since it doesn't render.
