### PR TITLE
OSDOCS#18544: Update the MicroShift z-stream RNs for 4.19.25

### DIFF
--- a/microshift_release_notes/microshift-4-19-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-19-release-notes.adoc
@@ -31,3 +31,5 @@ include::modules/microshift-4-19-asynchronous-errata-updates.adoc[leveloffset=+1
 include::modules/microshift-4-19-0-dp.adoc[leveloffset=+2]
 
 include::modules/microshift-4-19-7-dp.adoc[leveloffset=+2]
+
+include::modules/microshift-4-19-25-dp.adoc[leveloffset=+2]

--- a/modules/microshift-4-19-25-dp.adoc
+++ b/modules/microshift-4-19-25-dp.adoc
@@ -1,0 +1,22 @@
+// Module included in the following assemblies:
+//
+//microshift_release_notes/microshift-4-19-release-notes.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="microshift-4-19-25-dp_{context}"]
+= RHBA-2026:3508 - {microshift-short} 4.19.25 bug fix and update advisory
+
+Issued: 04 March 2026
+
+[role="_abstract"]
+{product-title} release 4.19.25 is now available. Bug fixes and enhancements are listed in the link:https://access.redhat.com/errata/RHBA-2026:3508[RHBA-2026:3508] advisory. Release notes for bug fixes and enhancements are provided in this documentation. The images that are included in the update are provided by the {OCP} link:https://access.redhat.com/errata/RHBA-2026:3394[RHBA-2026:3394] advisory.
+
+See the latest images included with {microshift-short} by using the following instructions:
+
+* xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[Listing the contents of the {microshift-short} RPM release package]
+* xref:../microshift_install_bootc/microshift-install-bootc-image.adoc#microshift-install-bootc-get-published-image_microshift-install-publish-bootc-image[Getting the published bootc image for MicroShift]
+
+[id="microshift-4-19-25-dp-bug-fixes_{context}"]
+== Fixed issues
+
+There are no notable fixed issues for this release.


### PR DESCRIPTION
Version(s):
4.19

Issue:
[OSDOCS-18544](https://issues.redhat.com/browse/OSDOCS-18544)

Link to docs preview:
[4.19.25](https://107859--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-19-release-notes.html#microshift-4-19-25-dp_release-notes)

QE review:
- [ ] QE has approved this change.
N/A for z-streams RNs.

Additional information:
Shipment [MR](https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/389) 
ART [Dashboard](https://art-dash.engineering.redhat.com/dashboard/release/openshift-4.19)

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
