### PR TITLE
OBSDOCS-3191: 4.21 doc has outdated Logging doc content

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -3208,46 +3208,46 @@ Topics:
 #      File: logging-5-8-release-notes
 #    - Name: Logging 5.7
 #      File: logging-5-7-release-notes
-  - Name: Logging 6.2
-    Dir: logging-6.2
-    Topics:
-    - Name: Support
-      File: log62-cluster-logging-support
-    - Name: Release notes
-      File: log6x-release-notes-6.2
-    - Name: About logging 6.2
-      File: log6x-about-6.2
-    - Name: Configuring log forwarding
-      File: log6x-clf-6.2
-    - Name: Configuring the logging collector
-      File: 6x-cluster-logging-collector-6.2
-    - Name: Configuring LokiStack storage
-      File: log6x-loki-6.2
-    - Name: Configuring LokiStack for OTLP
-      File: log6x-configuring-lokistack-otlp-6.2
-    - Name: Visualization for logging
-      File: log6x-visual-6.2
-  - Name: Logging 6.1
-    Dir: logging-6.1
-    Topics:
-    - Name: Support
-      File: log61-cluster-logging-support
-    - Name: Release notes
-      File: log6x-release-notes-6.1
-    - Name: About logging 6.1
-      File: log6x-about-6.1
-    - Name: Configuring log forwarding
-      File: log6x-clf-6.1
-    - Name: Configuring the logging collector
-      File: 6x-cluster-logging-collector-6.1
-    - Name: Configuring LokiStack storage
-      File: log6x-loki-6.1
-    - Name: Configuring LokiStack for OTLP
-      File: log6x-configuring-lokistack-otlp-6.1
-    - Name: OpenTelemetry data model
-      File: log6x-opentelemetry-data-model-6.1
-    - Name: Visualization for logging
-      File: log6x-visual-6.1
+#  - Name: Logging 6.2
+#    Dir: logging-6.2
+#    Topics:
+#    - Name: Support
+#      File: log62-cluster-logging-support
+#    - Name: Release notes
+#      File: log6x-release-notes-6.2
+#    - Name: About logging 6.2
+#      File: log6x-about-6.2
+#    - Name: Configuring log forwarding
+#      File: log6x-clf-6.2
+#    - Name: Configuring the logging collector
+#      File: 6x-cluster-logging-collector-6.2
+#    - Name: Configuring LokiStack storage
+#      File: log6x-loki-6.2
+#    - Name: Configuring LokiStack for OTLP
+#      File: log6x-configuring-lokistack-otlp-6.2
+#    - Name: Visualization for logging
+#      File: log6x-visual-6.2
+#  - Name: Logging 6.1
+#    Dir: logging-6.1
+#    Topics:
+#    - Name: Support
+#      File: log61-cluster-logging-support
+#    - Name: Release notes
+#      File: log6x-release-notes-6.1
+#    - Name: About logging 6.1
+#      File: log6x-about-6.1
+#    - Name: Configuring log forwarding
+#      File: log6x-clf-6.1
+#    - Name: Configuring the logging collector
+#      File: 6x-cluster-logging-collector-6.1
+#    - Name: Configuring LokiStack storage
+#      File: log6x-loki-6.1
+#    - Name: Configuring LokiStack for OTLP
+#      File: log6x-configuring-lokistack-otlp-6.1
+#    - Name: OpenTelemetry data model
+#      File: log6x-opentelemetry-data-model-6.1
+#    - Name: Visualization for logging
+#      File: log6x-visual-6.1
 #  - Name: Support
 #    File: cluster-logging-support
 #  - Name: Troubleshooting logging
@@ -3260,8 +3260,8 @@ Topics:
 #    - Name: Troubleshooting logging alerts
 #      File: troubleshooting-logging-alerts
 #      File: cluster-logging-log-store-status
-#  - Name: About Logging
-#    File: cluster-logging
+  - Name: About Logging
+    File: about-logging
 #  - Name: Installing Logging
 #    File: cluster-logging-deploying
 #  - Name: Updating Logging


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.21
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OBSDOCS-3191
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://107882--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/logging/about-logging.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review: Not required as there are no technical changes.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
