### PR TITLE
CQA, short desc, callouts for troubleshooting

### DIFF
--- a/backup_and_restore/application_backup_and_restore/troubleshooting/restoring-workarounds-for-velero-backups-that-use-admission-webhooks.adoc
+++ b/backup_and_restore/application_backup_and_restore/troubleshooting/restoring-workarounds-for-velero-backups-that-use-admission-webhooks.adoc
@@ -12,9 +12,9 @@ include::_attributes/attributes-openshift-dedicated.adoc[]
 toc::[]
 
 [role="_abstract"]
-Velero has limited abilities to resolve admission webhook issues during a restore. If you have workloads with admission webhooks, you might need to use an additional Velero plugin or make changes to how you restore the workload.
+Resolve restore failures caused by admission webhooks by applying workarounds for workloads such as Knative and {ibm-title} AppConnect resources. This helps you to successfully restore workloads that have mutating or validating admission webhooks.
 
-Typically, workloads with admission webhooks require you to create a resource of a specific kind first. This is especially true if your workload has child resources because admission webhooks typically block child resources.
+Velero has limited abilities to resolve admission webhook issues during a restore. If you have workloads with admission webhooks, you might need to use an additional Velero plugin or make changes to how you restore the workload. Typically, workloads with admission webhooks require you to create a resource of a specific kind first. This is especially true if your workload has child resources because admission webhooks typically block child resources.
 
 For example, creating or restoring a top-level object such as `service.serving.knative.dev` typically creates child resources automatically. If you do this first, you will not need to use Velero to create and restore these resources. This avoids the problem of child resources being blocked by an admission webhook that Velero might use.
 
@@ -25,13 +25,18 @@ Receiving a `received EOF, stopping recv loop` message in the debug logs indicat
 ====
 
 include::modules/migration-debugging-velero-admission-webhooks-knative.adoc[leveloffset=+1]
+
 include::modules/migration-debugging-velero-admission-webhooks-ibm-appconnect.adoc[leveloffset=+1]
+
 include::modules/avoiding-the-velero-plugin-panic-error.adoc[leveloffset=+1]
+
 include::modules/workaround-for-openshift-adp-controller-segmentation-fault.adoc[leveloffset=+1]
 
 
 [role="_additional-resources"]
 .Additional resources
 * xref:../../../architecture/admission-plug-ins.adoc#admission-plug-ins[Admission plugins]
+
 * xref:../../../architecture/admission-plug-ins.adoc#admission-webhooks-about_admission-plug-ins[Webhook admission plugins]
+
 * xref:../../../architecture/admission-plug-ins.adoc#admission-webhook-types_admission-plug-ins[Types of webhook admission plugins]

--- a/backup_and_restore/application_backup_and_restore/troubleshooting/velero-cli-tool.adoc
+++ b/backup_and_restore/application_backup_and_restore/troubleshooting/velero-cli-tool.adoc
@@ -12,14 +12,14 @@ include::_attributes/attributes-openshift-dedicated.adoc[]
 
 
 [role="_abstract"]
-You can obtain the `velero` CLI tool by using the following options:
-
-* Downloading the `velero` CLI tool
-* Accessing the `velero` binary in the Velero deployment in the cluster
+Download the `velero` CLI tool or access the `velero` binary in your cluster to debug `Backup` and `Restore` custom resources (CRs) and retrieve logs. This helps you to troubleshoot failed backup and restore operations.
 
 include::modules/velero-obtaining-by-downloading.adoc[leveloffset=+1]
+
 include::modules/velero-oadp-version-relationship.adoc[leveloffset=+2]
+
 include::modules/velero-obtaining-by-accessing-binary.adoc[leveloffset=+1]
 
 include::modules/oadp-debugging-oc-cli.adoc[leveloffset=+1]
+
 include::modules/migration-debugging-velero-resources.adoc[leveloffset=+1]

--- a/modules/avoiding-the-velero-plugin-panic-error.adoc
+++ b/modules/avoiding-the-velero-plugin-panic-error.adoc
@@ -9,9 +9,9 @@
 = Avoiding the Velero plugin panic error
 
 [role="_abstract"]
-A missing secret can cause a panic error for the Velero plugin during image stream backups.
+Label a custom Backup Storage Location (BSL) to resolve Velero plugin panic errors during `imagestream` backups. This action prompts the {oadp-short} controller to create the required registry secret when you manage the BSL outside the `DataProtectionApplication` (DPA) custom resource (CR).
 
-When the backup and the Backup Storage Location (BSL) are managed outside the scope of the Data Protection Application (DPA), the OADP controller does not create the relevant `oadp-<bsl_name>-<bsl_provider>-registry-secret` parameter.
+A missing secret can cause a panic error for the Velero plugin during image stream backups. When the backup and the BSL are managed outside the scope of the DPA, the OADP controller does not create the relevant `oadp-<bsl_name>-<bsl_provider>-registry-secret` parameter.
 
 During the backup operation, the OpenShift Velero plugin panics on the `imagestream` backup, with the following panic error:
 
@@ -22,8 +22,6 @@ backup=openshift-adp/<backup name> error="error executing custom action (groupRe
 namespace=<BSL Name>, name=postgres): rpc error: code = Aborted desc = plugin panicked:
 runtime error: index out of range with length 1, stack trace: goroutine 94…
 ----
-
-Use the following workaround to avoid the Velero plugin panic error.
 
 .Procedure
 

--- a/modules/migration-debugging-velero-admission-webhooks-ibm-appconnect.adoc
+++ b/modules/migration-debugging-velero-admission-webhooks-ibm-appconnect.adoc
@@ -6,7 +6,7 @@
 = Restoring {ibm-title} AppConnect resources
 
 [role="_abstract"]
-If you experience issues when you use Velero to a restore an {ibm-name} AppConnect resource that has an admission webhook, you can run the checks in this procedure.
+Troubleshoot Velero restore failures for {ibm-name} AppConnect resources that use admission webhooks. Verify your webhook rules and check that the installed Operator supports the backup's version to successfully complete the restore.
 
 .Procedure
 

--- a/modules/migration-debugging-velero-admission-webhooks-knative.adoc
+++ b/modules/migration-debugging-velero-admission-webhooks-knative.adoc
@@ -7,17 +7,15 @@
 = Restoring Knative resources
 
 [role="_abstract"]
-You might encounter problems by using Velero to back up Knative resources that use admission webhooks.
-
-You can avoid such problems by restoring the top level `Service` resource whenever you back up and restore Knative resources that use admission webhooks.
+Resolve issues with restoring Knative resources that use admission webhooks by restoring the top-level `service.serving.knative.dev` service resource with Velero. This helps you to ensure that Knative resources are restored successfully without admission webhook errors.
 
 .Procedure
 
-* Restore the top level `service.serving.knavtive.dev Service` resource by using the following command:
+* Restore the top level `service.serving.knative.dev Service` resource by using the following command:
 +
 [source,terminal]
 ----
 $ velero restore <restore_name> \
   --from-backup=<backup_name> --include-resources \
-  service.serving.knavtive.dev
+  service.serving.knative.dev
 ----

--- a/modules/migration-debugging-velero-resources.adoc
+++ b/modules/migration-debugging-velero-resources.adoc
@@ -3,12 +3,13 @@
 // * backup_and_restore/application_backup_and_restore/troubleshooting/velero-cli-tool.adoc
 // * migrating_from_ocp_3_to_4/troubleshooting-3-4.adoc
 // * migration_toolkit_for_containers/troubleshooting-mtc
+
 :_mod-docs-content-type: PROCEDURE
 [id="migration-debugging-velero-resources_{context}"]
 = Debugging Velero resources with the Velero CLI tool
 
 [role="_abstract"]
-You can debug `Backup` and `Restore` custom resources (CRs) and retrieve logs with the Velero CLI tool. The Velero CLI tool provides more detailed information than the OpenShift CLI tool.
+Debug `Backup` and `Restore` custom resources (CRs) and retrieve logs with the Velero CLI tool. The Velero CLI tool provides more detailed information than the OpenShift CLI tool.
 
 .Procedure
 
@@ -79,6 +80,8 @@ One or more errors in one of these categories results in a `Restore` operation r
 +
 
 Consider the following points for these restore errors:
+
+* For resource-specific errors, that is, `Cluster` and `Namespaces` errors, the `restore describe --details` output includes a resource list that includes all resources that Velero restored. For any resource that has such an error, check if the resource is actually in the cluster.
 
 * For resource-specific errors, that is, `Cluster` and `Namespaces` errors, the `restore describe --details` output includes a resource list that includes all resources that Velero restored. For any resource that has such an error, check if the resource is actually in the cluster.
 

--- a/modules/oadp-debugging-oc-cli.adoc
+++ b/modules/oadp-debugging-oc-cli.adoc
@@ -2,12 +2,12 @@
 //
 //backup_and_restore/application_backup_and_restore/troubleshooting/velero-cli-tool.adoc
 
-:_mod-docs-content-type: REFERENCE
+:_mod-docs-content-type: PROCEDURE
 [id="oadp-debugging-oc-cli_{context}"]
 = Debugging Velero resources with the OpenShift CLI tool
 
 [role="_abstract"]
-You can debug a failed backup or restore by checking Velero custom resources (CRs) and the `Velero` pod log with the OpenShift CLI tool.
+Debug a failed backup or restore by checking Velero custom resources (CRs) and the `Velero` pod log with the OpenShift CLI tool.
 
 .Procedure
 
@@ -32,7 +32,6 @@ $ oc logs pod/<velero>
 This option is available starting from {oadp-short} 1.0.3.
 ====
 +
-.Example Velero log level file
 [source,yaml]
 ----
 apiVersion: oadp.openshift.io/v1alpha1
@@ -46,12 +45,13 @@ spec:
 ----
 +
 The following `logLevel` values are available:
-* `trace`
-* `debug`
-* `info`
-* `warning`
-* `error`
-* `fatal`
-* `panic`
+
+** `trace`
+** `debug`
+** `info`
+** `warning`
+** `error`
+** `fatal`
+** `panic`
 +
 Use the `info` `logLevel` value for most logs.

--- a/modules/velero-obtaining-by-accessing-binary.adoc
+++ b/modules/velero-obtaining-by-accessing-binary.adoc
@@ -7,7 +7,7 @@
 = Accessing the Velero binary in the Velero deployment in the cluster
 
 [role="_abstract"]
-You can use a shell command to access the Velero binary in the Velero deployment in the cluster.
+Use a shell command to access the Velero binary in the Velero deployment in the cluster.
 
 .Prerequisites
 

--- a/modules/velero-obtaining-by-downloading.adoc
+++ b/modules/velero-obtaining-by-downloading.adoc
@@ -7,11 +7,8 @@
 = Downloading the Velero CLI tool
 
 [role="_abstract"]
-You can download and install the Velero CLI tool by following the instructions on the Velero documentation page. The page includes instructions for the following options:
+Download and install the `velero` CLI tool from the Velero documentation page, which provides instructions for macOS by using Homebrew, GitHub, and Windows by using Chocolatey. This helps you to access the `velero` CLI for debugging backup and restore operations.
 
-* macOS by using Homebrew
-* GitHub
-* Windows by using Chocolatey
 
 .Prerequisites
 

--- a/modules/workaround-for-openshift-adp-controller-segmentation-fault.adoc
+++ b/modules/workaround-for-openshift-adp-controller-segmentation-fault.adoc
@@ -9,7 +9,7 @@
 = Workaround for OpenShift ADP Controller segmentation fault
 
 [role="_abstract"]
-If you configure a Data Protection Application (DPA) with both `cloudstorage` and `restic` enabled, the `openshift-adp-controller-manager` pod crashes and restarts indefinitely until the pod fails with a crash loop segmentation fault.
+Define either `velero` or `cloudstorage` in your Data Protection Application (DPA) configuration to prevent indefinite pod crashes. This configuration resolves a segmentation fault in the `openshift-adp-controller-manager` pod that occurs when both components are enabled.
 
 Define either `velero` or `cloudstorage` when you configure a DPA. Otherwise, the `openshift-adp-controller-manager` pod fails with a crash loop segmentation fault due to the following settings:
 


### PR DESCRIPTION
## Jira

[OADP-7339](https://issues.redhat.com/browse/OADP-7339)

This PR contains fixes for `restoring-workarounds-for-velero-backups-that-use-admission-webhooks` and `velero cli` for callouts, short desc, block titles, and other CQA work.

## Version

OCP 4.14 → OCP 4.22

## Preview

[Restoring workarounds](https://107883--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/troubleshooting/restoring-workarounds-for-velero-backups-that-use-admission-webhooks.html)

[velero cli tool](https://107883--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/troubleshooting/velero-cli-tool.html)


