### PR TITLE
RHDEVDOCS-7300: Content creation for Overriding step resources using pipelinerun

### DIFF
--- a/modules/op-override-step-resources-pipelinerun.adoc
+++ b/modules/op-override-step-resources-pipelinerun.adoc
@@ -1,0 +1,29 @@
+:_mod-docs-content-type: CONCEPT
+// This module is included in the following assemblies:
+// * resource/reducing-pipelines-resource-consumption.adoc
+
+[id='op-override-step-resources-pipelinerun_{context}']
+= Override step level compute resources in a PipelineRun
+
+In {product-title}, tasks consume compute resources based on the definitions in the `Task` specification or cluster defaults. In some cases, a specific step within a task requires more CPU, memory, or ephemeral storage than the configured defaults.
+
+When using referenced tasks, such as tasks from Tekton bundles or shared pipelines, modifying the original `Task` or `Pipeline` definition might not be possible or desirable. In this scenario, you can override step-level compute resources directly in a `PipelineRun`.
+
+You can override step level resources by using the `spec.taskRunSpecs[*].stepSpecs` field in the `PipelineRun` definition.
+
+This approach enables you to:
+
+* Increase CPU or memory for a specific step
+* Prevent failures caused by insufficient resources
+* Avoid modifying shared or upstream pipeline definitions
+* Customize execution behavior when using {PaC}
+
+[IMPORTANT]
+====
+Step-level overrides differ from task-level compute resource settings.
+
+* *Step-level override* — A step-level override allocates resources to a specific step.
+* *Task-level compute resources* — Task-level compute resources distribute resources evenly across all steps in a task.
+
+If only one step requires additional resources, step-level overrides provide more precise and efficient allocation.
+====

--- a/modules/op-setting-compute-resources-for-a-task-step.adoc
+++ b/modules/op-setting-compute-resources-for-a-task-step.adoc
@@ -1,0 +1,75 @@
+:_mod-docs-content-type: PROCEDURE
+// This module is included in the following assemblies:
+// * resource/reducing-pipelines-resource-consumption.adoc
+
+[id="op-setting-compute-resources-for-a-task-step_{context}"]
+= Setting compute resources for a task step
+
+You can set compute resources for a specific task step by modifying the `PipelineRun` definition in your `.tekton` directory.
+
+.Prerequisites
+
+* You installed the {pipelines-title} Operator in your cluster.
+* You have permission to modify `PipelineRun` definitions.
+* You identified a task step that fails due to insufficient resources.
+
+.Procedure
+
+. Identify the task step that requires additional resources.
++
+Inspect the `TaskRun` logs in the OpenShift web console or by using the CLI. Determine:
+
+* The pipeline task name.
+* The step name within the task.
+* The resource constraint, such as memory or CPU limits.
+
+. Edit the corresponding `PipelineRun` file in the `.tekton` directory.
+
+. Add a `taskRunSpecs` entry for the task and step.
++
+[source,yaml]
+----
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  name: example-run
+spec:
+  taskRunSpecs:
+    - pipelineTaskName: ecosystem-cert-preflight-checks
+      stepSpecs:
+        - name: app-check
+          computeResources:
+            requests:
+              memory: 4Gi
+            limits:
+              memory: 4Gi
+----
++
+--
+where:
+
+`pipelineTaskName`:: Specifies the task name that the Pipeline defines.
+`stepSpecs[].name`:: Specifies the step within the task.
+`computeResources`:: Defines the CPU and memory allocation for the step.
+--
+
+. Optional: Configure CPU in addition to memory.
++
+[source,yaml]
+----
+computeResources:
+  requests:
+    memory: 4Gi
+    cpu: 100m
+  limits:
+    memory: 4Gi
+    cpu: 2000m
+----
+
+To guarantee allocation, set identical values for `requests` and `limits`.
+
+. Commit and push the changes.
+
+When using {pac}, the system applies the updated PipelineRun during the next execution.
+
+. Verify that the step completes successfully.

--- a/resource/reducing-pipelines-resource-consumption.adoc
+++ b/resource/reducing-pipelines-resource-consumption.adoc
@@ -19,6 +19,10 @@ include::modules/op-understanding-pipelines-resource-consumption.adoc[leveloffse
 
 include::modules/op-mitigating-extra-pipeline-resource-consumption.adoc[leveloffset=+1]
 
+include::modules/op-override-step-resources-pipelinerun.adoc[leveloffset=+1]
+
+include::modules/op-setting-compute-resources-for-a-task-step.adoc[leveloffset=+2]
+
 [role="_additional-resources"]
 [id="additional-resources_reducing-pipelines-resource-consumption"]
 == Additional resources


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

pipelines-docs-1.22

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

https://issues.redhat.com/browse/RHDEVDOCS-7300

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

[Override step level compute resources in a PipelineRun](https://107893--ocpdocs-pr.netlify.app/openshift-pipelines/latest/resource/reducing-pipelines-resource-consumption.html#op-override-step-resources-pipelinerun_reducing-pipelines-resource-consumption)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

SME review: @khrm 
Peer review: bdooley@redhat.com
QE review: @srivickynesh

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
