### PR TITLE
TELCODOCS-2647: Fix AsciiDocDITA rule violations in PTP modules (4.17)

### DIFF
--- a/modules/cnf-about-collecting-ptp-data.adoc
+++ b/modules/cnf-about-collecting-ptp-data.adoc
@@ -6,7 +6,13 @@
 [id="cnf-about-collecting-nro-data_{context}"]
 = Collecting PTP Operator data
 
-You can use the `oc adm must-gather` command to collect information about your cluster, including features and objects associated with PTP Operator.
+[role="_abstract"]
+You can use the `oc adm must-gather` command to collect information about your cluster, including features and objects associated with Precision Time Protocol (PTP) Operator.
+
+[NOTE]
+====
+When you deploy the PTP Operator in a disconnected environment by using {ztp-first}, {ztp} mirrors the PTP `must-gather` image together with the PTP Operator images. You do not need to configure image mirroring for the PTP `must-gather` image to collect `must-gather` data.
+====
 
 .Prerequisites
 

--- a/modules/cnf-configuring-fifo-priority-scheduling-for-ptp.adoc
+++ b/modules/cnf-configuring-fifo-priority-scheduling-for-ptp.adoc
@@ -6,6 +6,7 @@
 [id="cnf-configuring-fifo-priority-scheduling-for-ptp_{context}"]
 = Configuring FIFO priority scheduling for PTP hardware
 
+[role="_abstract"]
 In telco or other deployment types that require low latency performance, PTP daemon threads run in a constrained CPU footprint alongside the rest of the infrastructure components. By default, PTP threads run with the `SCHED_OTHER` policy. Under high load, these threads might not get the scheduling latency they require for error-free operation.
 
 To mitigate against potential scheduling latency errors, you can configure the PTP Operator `linuxptp` services to allow threads to run with a `SCHED_FIFO` policy. If `SCHED_FIFO` is set for a `PtpConfig` CR, then `ptp4l` and `phc2sys` will run in the parent container under `chrt` with a priority set by the `ptpSchedulingPriority` field of the `PtpConfig` CR.
@@ -38,11 +39,13 @@ spec:
   profile:
   - name: "profile1"
 ...
-    ptpSchedulingPolicy: SCHED_FIFO <1>
-    ptpSchedulingPriority: 10 <2>
+    ptpSchedulingPolicy: SCHED_FIFO
+    ptpSchedulingPriority: 10
 ----
-<1> Scheduling policy for `ptp4l` and `phc2sys` processes. Use `SCHED_FIFO` on systems that support FIFO scheduling.
-<2> Required. Sets the integer value 1-65 used to configure FIFO priority for `ptp4l` and `phc2sys` processes.
+
+- `spec.profile.ptpSchedulingPolicy` scheduling policy for `ptp4l` and `phc2sys` processes. Use `SCHED_FIFO` on systems that support FIFO scheduling.
+- `spec.profile.ptpSchedulingPriority` required. Sets the integer value 1-65 used to configure FIFO priority for `ptp4l` and `phc2sys` processes.
+
 
 . Save and exit to apply the changes to the `PtpConfig` CR.
 

--- a/modules/cnf-configuring-log-filtering-for-linuxptp.adoc
+++ b/modules/cnf-configuring-log-filtering-for-linuxptp.adoc
@@ -4,13 +4,13 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="cnf-configuring-log-filtering-for-linuxptp_{context}"]
-= Configuring log filtering for linuxptp services
+= Configuring log filtering for PTP
 
-The `linuxptp` daemon generates logs that you can use for debugging purposes. In telco or other deployment types that feature a limited storage capacity, these logs can add to the storage demand.
-
-To reduce the number log messages, you can configure the `PtpConfig` custom resource (CR) to exclude log messages that report the `master offset` value. The `master offset` log message reports the difference between the current node's clock and the master clock in nanoseconds.
+[role="_abstract"]
+Modify the `PtpConfig` custom resource (CR) to configure basic log filtering and exclude log messages that report the master offset value.
 
 .Prerequisites
+
 * Install the OpenShift CLI (`oc`).
 
 * Log in as a user with `cluster-admin` privileges.
@@ -73,8 +73,8 @@ ptp-operator-3r4dcvf7f4-zndk7   1/1     Running   0          1d7h    10.129.0.61
 +
 [source,terminal]
 ----
-$ oc -n openshift-ptp logs <linux_daemon_container> -c linuxptp-daemon-container | grep "master offset" <1>
+$ oc -n openshift-ptp logs <linux_daemon_container> -c linuxptp-daemon-container | grep "master offset"
 ----
-<1> <linux_daemon_container> is the name of the `linuxptp-daemon` pod, for example `linuxptp-daemon-gmv2n`.
+* `<linux_daemon_container>` is the name of the `linuxptp-daemon` pod, for example `linuxptp-daemon-gmv2n`.
 +
 When you configure the `logReduce` specification, this command does not report any instances of `master offset` in the logs of the `linuxptp` daemon.

--- a/modules/cnf-getting-the-dpll-firmware-version-for-intel-800-series-nics.adoc
+++ b/modules/cnf-getting-the-dpll-firmware-version-for-intel-800-series-nics.adoc
@@ -6,6 +6,7 @@
 [id="cnf-getting-the-dpll-firmware-version-for-intel-800-series-nics_{context}"]
 = Getting the DPLL firmware version for the CGU in an Intel 800 series NIC
 
+[role="_abstract"]
 You can get the digital phase-locked loop (DPLL) firmware version for the Clock Generation Unit (CGU) in an Intel 800 series NIC by opening a debug shell to the cluster node and querying the NIC hardware.
 
 .Prerequisites
@@ -51,16 +52,21 @@ where:
 .Example output
 [source,terminal]
 ----
-cgu.id 36 <1>
-fw.cgu 8032.16973825.6021 <2>
+cgu.id 36
+fw.cgu 8032.16973825.6021
 ----
-<1> CGU hardware revision number
-<2> The DPLL firmware version running in the CGU, where the DPLL firmware version is `6201`, and the DPLL model is `8032`.
-The string `16973825` is a shorthand representation of the binary version of the DPLL firmware version (`1.3.0.1`).
++
+where:
++
+--
+`cgu.id 36`:: CGU hardware revision number.
 
+`fw.cgu 8032.16973825.6021`:: DPLL firmware version running in the CGU, where the DPLL firmware version is `6201`, and the DPLL model is `8032`.
+The string `16973825` is a shorthand representation of the binary version of the DPLL firmware version (`1.3.0.1`).
+--
 +
 [NOTE]
-====
+--
 The firmware version has a leading nibble and 3 octets for each part of the version number.
 The number `16973825` in binary is `0001 0000 0011 0000 0000 0000 0001`.
 Use the binary value to decode the firmware version.
@@ -84,4 +90,4 @@ For example:
 |`0000 0001`
 |1
 |====
-====
+--

--- a/modules/cnf-troubleshooting-common-ptp-operator-issues.adoc
+++ b/modules/cnf-troubleshooting-common-ptp-operator-issues.adoc
@@ -6,6 +6,7 @@
 [id="cnf-troubleshooting-common-ptp-operator-issues_{context}"]
 = Troubleshooting common PTP Operator issues
 
+[role="_abstract"]
 Troubleshoot common problems with the PTP Operator by performing the following steps.
 
 .Prerequisites
@@ -154,7 +155,7 @@ $ oc rsh -n openshift-ptp -c linuxptp-daemon-container linuxptp-daemon-74m2g eth
 ----
 driver: ice
 version: 5.14.0-356.bz2232515.el9.x86_64
-firmware-version: 4.20 0x8001778b 1.3346.0
+firmware-version: 4.21 0x8001778b 1.3346.0
 ----
 
 . For GNSS-sourced grandmaster clocks, verify that the `linuxptp-daemon` container is receiving signal from the GNSS antenna.

--- a/modules/nw-columbiaville-ptp-config-refererence.adoc
+++ b/modules/nw-columbiaville-ptp-config-refererence.adoc
@@ -6,6 +6,7 @@
 [id="nw-columbiaville-ptp-config-refererence_{context}"]
 = Intel Columbiaville E800 series NIC as PTP ordinary clock reference
 
+[role="_abstract"]
 The following table describes the changes that you must make to the reference PTP configuration to use Intel Columbiaville E800 series NICs as ordinary clocks. Make the changes in a `PtpConfig` custom resource (CR) that you apply to the cluster.
 
 .Recommended PTP settings for Intel Columbiaville NIC

--- a/modules/nw-ptp-configuring-linuxptp-services-as-boundary-clock.adoc
+++ b/modules/nw-ptp-configuring-linuxptp-services-as-boundary-clock.adoc
@@ -6,6 +6,7 @@
 [id="configuring-linuxptp-services-as-boundary-clock_{context}"]
 = Configuring linuxptp services as a boundary clock
 
+[role="_abstract"]
 You can configure the `linuxptp` services (`ptp4l`, `phc2sys`) as boundary clock by creating a `PtpConfig` custom resource (CR) object.
 
 [NOTE]

--- a/modules/nw-ptp-configuring-linuxptp-services-as-grandmaster-clock-dual-nic.adoc
+++ b/modules/nw-ptp-configuring-linuxptp-services-as-grandmaster-clock-dual-nic.adoc
@@ -4,8 +4,9 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="configuring-linuxptp-services-as-grandmaster-clock-dual-nic_{context}"]
-= Configuring linuxptp services as a grandmaster clock for dual E810 Westport Channel NICs
+= Configuring linuxptp services as a grandmaster clock for 2 E810 NICs
 
+[role="_abstract"]
 You can configure the `linuxptp` services (`ptp4l`, `phc2sys`, `ts2phc`) as a grandmaster clock (T-GM) for 2 E810 NICs by creating a `PtpConfig` custom resource (CR) that configures the NICs.
 
 You can configure the `linuxptp` services as a T-GM for the following E810 NICs:
@@ -23,13 +24,13 @@ The `ptp4l` and `ts2phc` programs are each configured to operate on two PTP hard
 The host system clock is synchronized from the NIC that is connected to the GNSS time source.
 
 [NOTE]
-====
+--
 Use the following example `PtpConfig` CR as the basis to configure `linuxptp` services as T-GM for dual Intel E810 network interfaces.
 
 To configure PTP fast events, set appropriate values for `ptp4lOpts`, `ptp4lConf`, and `ptpClockThreshold`.
 `ptpClockThreshold` is used only when events are enabled.
 See "Configuring the PTP fast event notifications publisher" for more information.
-====
+--
 
 .Prerequisites
 
@@ -47,19 +48,15 @@ See "Configuring the PTP fast event notifications publisher" for more informatio
 
 .. Save the following YAML in the `grandmaster-clock-ptp-config-dual-nics.yaml` file:
 +
-.PTP grandmaster clock configuration for dual E810 NICs
-[%collapsible]
-====
 [source,yaml]
 ----
 include::snippets/ptp_PtpConfigDualCardGmWpc.yaml[]
 ----
-====
 +
 [NOTE]
-====
+--
 Set the value for `ts2phc.nmea_serialport` to `/dev/gnss0`.
-====
+--
 
 .. Create the CR by running the following command:
 +

--- a/modules/nw-ptp-configuring-linuxptp-services-as-grandmaster-clock-three-nic.adoc
+++ b/modules/nw-ptp-configuring-linuxptp-services-as-grandmaster-clock-three-nic.adoc
@@ -6,6 +6,7 @@
 [id="configuring-linuxptp-services-as-grandmaster-clock-three-nic_{context}"]
 = Configuring linuxptp services as a grandmaster clock for 3 E810 NICs
 
+[role="_abstract"]
 You can configure the `linuxptp` services (`ptp4l`, `phc2sys`, `ts2phc`) as a grandmaster clock (T-GM) for 3 E810 NICs by creating a `PtpConfig` custom resource (CR) that configures the NICs.
 
 You can configure the `linuxptp` services as a T-GM with 3 NICs for the following E810 NICs:
@@ -36,19 +37,15 @@ Use the following example `PtpConfig` CRs as the basis to configure `linuxptp` s
 
 .. Save the following YAML in the `three-nic-grandmaster-clock-ptp-config.yaml` file:
 +
-.PTP grandmaster clock configuration for 3 E810 NICs
-[%collapsible]
-====
 [source,yaml]
 ----
 include::snippets/ptp_PtpConfigThreeCardGmWpc.yaml[]
 ----
-====
 +
 [NOTE]
-====
+--
 Set the value for `ts2phc.nmea_serialport` to `/dev/gnss0`.
-====
+--
 
 .. Create the CR by running the following command:
 +
@@ -86,21 +83,48 @@ $ oc logs linuxptp-daemon-74m3q -n openshift-ptp -c linuxptp-daemon-container
 .Example output
 [source,terminal]
 ----
-ts2phc[2527.586]: [ts2phc.0.config:7] adding tstamp 1742826342.000000000 to clock /dev/ptp11 <1>
-ts2phc[2527.586]: [ts2phc.0.config:7] adding tstamp 1742826342.000000000 to clock /dev/ptp7 <1>
-ts2phc[2527.586]: [ts2phc.0.config:7] adding tstamp 1742826342.000000000 to clock /dev/ptp14 <1>
+ts2phc[2527.586]: [ts2phc.0.config:7] adding tstamp 1742826342.000000000 to clock /dev/ptp11
+ts2phc[2527.586]: [ts2phc.0.config:7] adding tstamp 1742826342.000000000 to clock /dev/ptp7
+ts2phc[2527.586]: [ts2phc.0.config:7] adding tstamp 1742826342.000000000 to clock /dev/ptp14
 ts2phc[2527.586]: [ts2phc.0.config:7] nmea delay: 56308811 ns
-ts2phc[2527.586]: [ts2phc.0.config:6] /dev/ptp14 offset          0 s2 freq      +0 <2>
-ts2phc[2527.587]: [ts2phc.0.config:6] /dev/ptp7 offset          0 s2 freq      +0 <2>
-ts2phc[2527.587]: [ts2phc.0.config:6] /dev/ptp11 offset          0 s2 freq      -0 <2>
+ts2phc[2527.586]: [ts2phc.0.config:6] /dev/ptp14 offset          0 s2 freq      +0
+ts2phc[2527.587]: [ts2phc.0.config:6] /dev/ptp7 offset          0 s2 freq      +0
+ts2phc[2527.587]: [ts2phc.0.config:6] /dev/ptp11 offset          0 s2 freq      -0
 I0324 14:25:05.000439  106907 stats.go:61] state updated for ts2phc =s2
 I0324 14:25:05.000504  106907 event.go:419] dpll State s2, gnss State s2, tsphc state s2, gm state s2,
 I0324 14:25:05.000906  106907 stats.go:61] state updated for ts2phc =s2
 I0324 14:25:05.001059  106907 stats.go:61] state updated for ts2phc =s2
 ts2phc[1742826305]:[ts2phc.0.config] ens4f0 nmea_status 1 offset 0 s2
-GM[1742826305]:[ts2phc.0.config] ens4f0 T-GM-STATUS s2 <3>
+GM[1742826305]:[ts2phc.0.config] ens4f0 T-GM-STATUS s2
 ----
-<1> `ts2phc` is updating the PTP hardware clock.
-<2> Estimated PTP device offset between PTP device and the reference clock is 0 nanoseconds.
-The PTP device is in sync with the leader clock.
-<3> T-GM is in a locked state (s2).
++
+where:
++
+[cols="1,2,2", options="header"]
+|===
+| Log entry | Sample output | Description
+
+| **Clock Update**
+a|
+[source,text]
+----
+ts2phc[2527.586]: adding tstamp 1742826342.000000000 to clock /dev/ptp14
+----
+| Indicates `ts2phc` is actively synchronizing the PTP hardware clock (PHC) by applying a specific timestamp.
+
+| **Offset & Sync**
+a|
+[source,text]
+----
+/dev/ptp14 offset 0 s2 freq +0
+----
+| Shows the estimated offset between the PTP device and the reference. An offset of **0** and state **s2** indicates the clock is fully synchronized.
+
+| **Grandmaster Status**
+a|
+[source,text]
+----
+GM[1742826305]: ens4f0 T-GM-STATUS s2
+----
+| Confirms the Telecom Grandmaster (T-GM) is in a **locked state (s2)**, providing a stable time reference for the network.
+|===

--- a/modules/nw-ptp-configuring-linuxptp-services-as-grandmaster-clock.adoc
+++ b/modules/nw-ptp-configuring-linuxptp-services-as-grandmaster-clock.adoc
@@ -6,18 +6,19 @@
 [id="configuring-linuxptp-services-as-grandmaster-clock_{context}"]
 = Configuring linuxptp services as a grandmaster clock
 
+[role="_abstract"]
 You can configure the `linuxptp` services (`ptp4l`, `phc2sys`, `ts2phc`) as grandmaster clock (T-GM) by creating a `PtpConfig` custom resource (CR) that configures the host NIC.
 
 The `ts2phc` utility allows you to synchronize the system clock with the PTP grandmaster clock so that the node can stream precision clock signal to downstream PTP ordinary clocks and boundary clocks.
 
 [NOTE]
-====
+--
 Use the following example `PtpConfig` CR as the basis to configure `linuxptp` services as T-GM for an Intel Westport Channel E810-XXVDA4T network interface.
 
 To configure PTP fast events, set appropriate values for `ptp4lOpts`, `ptp4lConf`, and `ptpClockThreshold`.
 `ptpClockThreshold` is used only when events are enabled.
 See "Configuring the PTP fast event notifications publisher" for more information.
-====
+--
 
 .Prerequisites
 
@@ -36,19 +37,15 @@ See "Configuring the PTP fast event notifications publisher" for more informatio
 .. Depending on your requirements, use one of the following T-GM configurations for your deployment.
 Save the YAML in the `grandmaster-clock-ptp-config.yaml` file:
 +
-.PTP grandmaster clock configuration for E810 NIC
-[%collapsible]
-====
 [source,yaml]
 ----
 include::snippets/ptp_PtpConfigGmWpc.yaml[]
 ----
-====
 +
 [NOTE]
-====
+--
 For E810 Westport Channel NICs, set the value for `ts2phc.nmea_serialport` to `/dev/gnss0`.
-====
+--
 
 .. Create the CR by running the following command:
 +

--- a/modules/nw-ptp-configuring-linuxptp-services-as-ordinary-clock.adoc
+++ b/modules/nw-ptp-configuring-linuxptp-services-as-ordinary-clock.adoc
@@ -6,6 +6,7 @@
 [id="configuring-linuxptp-services-as-ordinary-clock_{context}"]
 = Configuring linuxptp services as an ordinary clock
 
+[role="_abstract"]
 You can configure `linuxptp` services (`ptp4l`, `phc2sys`) as ordinary clock by creating a `PtpConfig` custom resource (CR) object.
 
 [NOTE]

--- a/modules/nw-ptp-device-discovery.adoc
+++ b/modules/nw-ptp-device-discovery.adoc
@@ -6,10 +6,11 @@
 [id="discover-ptp-devices_{context}"]
 = Discovering PTP-capable network devices in your cluster
 
+[role="_abstract"]
 Identify PTP-capable network devices that exist in your cluster so that you can configure them 
 
 
-.Prerequisties
+.Prerequisites
 
 * You installed the PTP Operator.
 
@@ -32,13 +33,13 @@ items:
   metadata:
     creationTimestamp: "2022-01-27T15:16:28Z"
     generation: 1
-    name: dev-worker-0 <1>
+    name: dev-worker-0
     namespace: openshift-ptp
     resourceVersion: "6538103"
     uid: d42fc9ad-bcbf-4590-b6d8-b676c642781a
   spec: {}
   status:
-    devices: <2>
+    devices:
     - name: eno1
     - name: eno2
     - name: eno3
@@ -47,5 +48,12 @@ items:
     - name: enp5s0f1
 ...
 ----
-<1> The value for the `name` parameter is the same as the name of the parent node.
-<2> The `devices` collection includes a list of the PTP capable devices that the PTP Operator discovers for the node.
++
+where:
++
+--
+`-worker-0`:: The value for the `name` parameter is the same as the name of the parent node.
+
+`devices`:: The `devices` collection includes a list of the PTP capable devices that the PTP Operator discovers for the node.
+--
+

--- a/modules/nw-ptp-dual-wpc-hardware-config-reference.adoc
+++ b/modules/nw-ptp-dual-wpc-hardware-config-reference.adoc
@@ -6,6 +6,7 @@
 [id="nw-ptp-dual-e810-hardware-config-reference_{context}"]
 = Dual E810 NIC configuration reference
 
+[role="_abstract"]
 Use this information to understand how to use the link:https://github.com/openshift/linuxptp-daemon/blob/release-4.14/addons/intel/e810.go[Intel E810 hardware plugin] to configure a pair of E810 network interfaces as PTP grandmaster clock (T-GM).
 
 Before you configure the dual-NIC cluster host, you must connect the two NICs with an SMA1 cable using the 1PPS faceplace connections.

--- a/modules/nw-ptp-e810-hardware-configuration-reference.adoc
+++ b/modules/nw-ptp-e810-hardware-configuration-reference.adoc
@@ -6,7 +6,9 @@
 [id="nw-ptp-e810-hardware-pins-reference_{context}"]
 = Intel E810 NIC hardware configuration reference
 
+[role="_abstract"]
 Use this information to understand how to use the link:https://github.com/openshift/linuxptp-daemon/blob/release-4.16/addons/intel/e810.go[Intel E810 hardware plugin] to configure the E810 network interface as PTP grandmaster clock.
+
 Hardware pin configuration determines how the network interface interacts with other components and devices in the system.
 The Intel E810 NIC has four connectors for external 1PPS signals: `SMA1`, `SMA2`, `U.FL1`, and `U.FL2`.
 
@@ -76,10 +78,11 @@ ublxCmds:
       - "-z"
       - "CFG-HW-ANT_CFG_VOLTCTRL,1"
       - "-z"
-      - "CFG-TP-ANT_CABLEDELAY,<antenna_delay_offset>"<1>
+      - "CFG-TP-ANT_CABLEDELAY,<antenna_delay_offset>"
     reportOutput: false
 ----
-<1> Measured T-GM antenna delay offset in nanoseconds.
+
+Measured T-GM antenna delay offset in nanoseconds.
 To get the required delay offset value, you must measure the cable delay using external test equipment.
 
 The following table describes the equivalent `ubxtool` commands:

--- a/modules/nw-ptp-grandmaster-clock-class-reference.adoc
+++ b/modules/nw-ptp-grandmaster-clock-class-reference.adoc
@@ -6,7 +6,9 @@
 [id="nw-ptp-grandmaster-clock-class-reference_{context}"]
 = Grandmaster clock class sync state reference
 
+[role="_abstract"]
 The following table describes the PTP grandmaster clock (T-GM) `gm.ClockClass` states.
+
 Clock class states categorize T-GM clocks based on their accuracy and stability with regard to the Primary Reference Time Clock (PRTC) or other timing source.
 
 Holdover specification is the amount of time a PTP clock can maintain synchronization without receiving updates from the primary time source.

--- a/modules/nw-ptp-grandmaster-clock-configuration-reference.adoc
+++ b/modules/nw-ptp-grandmaster-clock-configuration-reference.adoc
@@ -6,6 +6,7 @@
 [id="nw-ptp-grandmaster-clock-configuration-reference_{context}"]
 = Grandmaster clock PtpConfig configuration reference
 
+[role="_abstract"]
 The following reference information describes the configuration options for the `PtpConfig` custom resource (CR) that configures the `linuxptp` services (`ptp4l`, `phc2sys`, `ts2phc`) as a grandmaster clock.
 
 .PtpConfig configuration options for PTP Grandmaster clock

--- a/modules/nw-ptp-installing-operator-cli.adoc
+++ b/modules/nw-ptp-installing-operator-cli.adoc
@@ -6,6 +6,7 @@
 [id="install-ptp-operator-cli_{context}"]
 = Installing the PTP Operator using the CLI
 
+[role="_abstract"]
 As a cluster administrator, you can install the Operator by using the CLI.
 
 .Prerequisites

--- a/modules/nw-ptp-installing-operator-web-console.adoc
+++ b/modules/nw-ptp-installing-operator-web-console.adoc
@@ -6,6 +6,7 @@
 [id="install-ptp-operator-web-console_{context}"]
 = Installing the PTP Operator by using the web console
 
+[role="_abstract"]
 As a cluster administrator, you can install the PTP Operator by using the web console.
 
 [NOTE]
@@ -18,7 +19,7 @@ in the previous section.
 
 . Install the PTP Operator using the {product-title} web console:
 
-.. In the {product-title} web console, click *Operators* -> *OperatorHub*.
+.. In the {product-title} web console, click *Ecosystem* -> *Software Catalog*.
 
 .. Choose  *PTP Operator* from the list of available Operators, and then click *Install*.
 
@@ -26,7 +27,7 @@ in the previous section.
 
 . Optional: Verify that the PTP Operator installed successfully:
 
-.. Switch to the *Operators* -> *Installed Operators* page.
+.. Switch to the *Ecosystem* -> *Installed Operators* page.
 
 .. Ensure that *PTP Operator* is listed in the *openshift-ptp* project with a *Status* of *InstallSucceeded*.
 +
@@ -40,5 +41,5 @@ If the installation later succeeds with an *InstallSucceeded* message, you can i
 If the Operator does not appear as installed, to troubleshoot further:
 
 +
-* Go to the *Operators* -> *Installed Operators* page and inspect the *Operator Subscriptions* and *Install Plans* tabs for any failure or errors under *Status*.
+* Go to the *Ecosystem* -> *Installed Operators* page and inspect the *Operator Subscriptions* and *Install Plans* tabs for any failure or errors under *Status*.
 * Go to the *Workloads* -> *Pods* page and check the logs for pods in the `openshift-ptp` project.

--- a/modules/nw-ptp-three-nic-hardware-config-reference.adoc
+++ b/modules/nw-ptp-three-nic-hardware-config-reference.adoc
@@ -6,6 +6,7 @@
 [id="nw-ptp-three-nic-hardware-config-reference_{context}"]
 = 3-card E810 NIC configuration reference
 
+[role="_abstract"]
 Use this information to understand how to configure 3 E810 NICs as PTP grandmaster clock (T-GM).
 
 Before you configure the 3-card cluster host, you must connect the 3 NICs by using the 1PPS faceplate connections.

--- a/modules/ptp-configuring-dynamic-leap-seconds-handling-for-tgm.adoc
+++ b/modules/ptp-configuring-dynamic-leap-seconds-handling-for-tgm.adoc
@@ -6,7 +6,9 @@
 [id="ptp-configuring-dynamic-leap-seconds-handling-for-tgm_{context}"]
 = Configuring dynamic leap seconds handling for PTP grandmaster clocks
 
+[role="_abstract"]
 The PTP Operator container image includes the latest `leap-seconds.list` file  that is available at the time of release.
+
 You can configure the PTP Operator to automatically update the leap second file by using Global Positioning System (GPS) announcements.
 
 Leap second information is stored in an automatically generated `ConfigMap` resource named `leap-configmap` in the `openshift-ptp` namespace.
@@ -36,7 +38,7 @@ Set the following options:
 +
 [source,yaml]
 ----
-phc2sysOpts: -r -u 0 -m -N 8 -R 16 -S 2 -s ens2f0 -n 24 <1>
+phc2sysOpts: -r -u 0 -m -N 8 -R 16 -S 2 -s ens2f0 -n 24
 ----
 +
 [NOTE]
@@ -101,12 +103,12 @@ Run the following command:
 +
 [source,terminal]
 ----
-$ oc -n openshift-ptp get configmap leap-configmap -o jsonpath='{.data.<node_name>}' <1>
+$ oc -n openshift-ptp get configmap leap-configmap -o jsonpath='{.data.<node_name>}'
 ----
-<1> Replace `<node_name>` with the node where you have installed and configured the PTP T-GM clock with automatic leap second management.
++
+Replace `<node_name>` with the node where you have installed and configured the PTP T-GM clock with automatic leap second management.
 Escape special characters in the node name.
 For example, `node-1\.example\.com`.
-
 +
 .Example output
 [source,terminal]

--- a/modules/ptp-configuring-linuxptp-services-as-boundary-clock-dual-nic.adoc
+++ b/modules/ptp-configuring-linuxptp-services-as-boundary-clock-dual-nic.adoc
@@ -6,6 +6,7 @@
 [id="ptp-configuring-linuxptp-services-as-bc-for-dual-nic_{context}"]
 = Configuring linuxptp services as boundary clocks for dual-NIC hardware
 
+[role="_abstract"]
 You can configure the `linuxptp` services (`ptp4l`, `phc2sys`) as boundary clocks for dual-NIC hardware by creating a `PtpConfig` custom resource (CR) object for each NIC.
 
 Dual NIC hardware allows you to connect each NIC to the same upstream leader clock with separate `ptp4l` instances for each NIC feeding the downstream clocks.
@@ -35,16 +36,18 @@ spec:
   profile:
   - name: "profile1"
     ptp4lOpts: "-2 --summary_interval -4"
-    ptp4lConf: | <1>
+    ptp4lConf: |
       [ens5f1]
       masterOnly 1
       [ens5f0]
       masterOnly 0
     ...
-    phc2sysOpts: "-a -r -m -n 24 -N 8 -R 16" <2>
+    phc2sysOpts: "-a -r -m -n 24 -N 8 -R 16"
 ----
-<1> Specify the required interfaces to start `ptp4l` as a boundary clock. For example, `ens5f0` synchronizes from a grandmaster clock and `ens5f1` synchronizes connected devices.
-<2> Required `phc2sysOpts` values. `-m` prints messages to `stdout`. The `linuxptp-daemon` `DaemonSet` parses the logs and generates Prometheus metrics.
+
+- `spec.profile.ptp4lConf` specify the required interfaces to start `ptp4l` as a boundary clock. For example, `ens5f0` synchronizes from a grandmaster clock and `ens5f1` synchronizes connected devices.
+- `spec.profile.phc2sysOpts` required `phc2sysOpts` values. `-m` prints messages to `stdout`. The `linuxptp-daemon` `DaemonSet` parses the logs and generates Prometheus metrics.
+
 
 .. Create `boundary-clock-ptp-config-nic2.yaml`, removing the `phc2sysOpts` field altogether to disable the `phc2sys` service for the second NIC:
 +
@@ -59,19 +62,20 @@ spec:
   profile:
   - name: "profile2"
     ptp4lOpts: "-2 --summary_interval -4"
-    ptp4lConf: | <1>
+    ptp4lConf: |
       [ens7f1]
       masterOnly 1
       [ens7f0]
       masterOnly 0
 ...
 ----
-<1> Specify the required interfaces to start `ptp4l` as a boundary clock on the second NIC.
++
+Specify the required interfaces to start `ptp4l` as a boundary clock on the second NIC.
 +
 [NOTE]
-====
+--
 You must completely remove the `phc2sysOpts` field from the second `PtpConfig` CR to disable the `phc2sys` service on the second NIC.
-====
+--
 
 . Create the dual-NIC `PtpConfig` CRs by running the following commands:
 

--- a/modules/ptp-configuring-linuxptp-services-as-ha-bc-for-dual-nic.adoc
+++ b/modules/ptp-configuring-linuxptp-services-as-ha-bc-for-dual-nic.adoc
@@ -6,6 +6,7 @@
 [id="ptp-configuring-linuxptp-services-as-ha-bc-for-dual-nic_{context}"]
 = Configuring linuxptp as a highly available system clock for dual-NIC Intel E810 PTP boundary clocks
 
+[role="_abstract"]
 You can configure the `linuxptp` services `ptp4l` and `phc2sys` as a highly available (HA) system clock for dual PTP boundary clocks (T-BC).
 
 The highly available system clock uses multiple time sources from dual-NIC Intel E810 Salem channel hardware configured as two boundary clocks.
@@ -60,16 +61,18 @@ spec:
   profile:
   - name: "ha-ptp-config-profile1"
     ptp4lOpts: "-2 --summary_interval -4"
-    ptp4lConf: | <1>
+    ptp4lConf: |
       [ens5f1]
       masterOnly 1
       [ens5f0]
       masterOnly 0
     #...
-    phc2sysOpts: "" <2>
+    phc2sysOpts: ""
 ----
-<1> Specify the required interfaces to start `ptp4l` as a boundary clock. For example, `ens5f0` synchronizes from a grandmaster clock and `ens5f1` synchronizes connected devices.
-<2> Set `phc2sysOpts` with an empty string.
+
+- `spec.profile.ptp4lConf` specify the required interfaces to start `ptp4l` as a boundary clock. For example, `ens5f0` synchronizes from a grandmaster clock and `ens5f1` synchronizes connected devices.
+- `spec.profile.phc2sysOpts` set `phc2sysOpts` with an empty string.
++
 These values are populated from the `spec.profile.ptpSettings.haProfiles` field of the `PtpConfig` CR that configures high availability.
 
 .. Apply the `PtpConfig` CR for NIC 1 by running the following command:
@@ -127,7 +130,7 @@ metadata:
 spec:
   profile:
     - name: "boundary-ha"
-      ptp4lOpts: "" # <1>
+      ptp4lOpts: ""
       phc2sysOpts: "-a -r -n 24"
       ptpSchedulingPolicy: SCHED_FIFO
       ptpSchedulingPriority: 10
@@ -140,14 +143,14 @@ spec:
       match:
         - nodeLabel: "node-role.kubernetes.io/$mcp"
 ----
-<1> Set the `ptp4lOpts` field to an empty string.
++
+Set the `ptp4lOpts` field to an empty string.
 If it is not empty, the `p4ptl` process starts with a critical error.
-
 +
 [IMPORTANT]
-====
+--
 Do not apply the high availability `PtpConfig` CR before the `PtpConfig` CRs that configure the individual NICs.
-====
+--
 
 .. Apply the HA `PtpConfig` CR by running the following command:
 +


### PR DESCRIPTION
## Summary

Backport of #106280 to enterprise-4.17.

Fixes AsciiDocDITA rule violations across 22 PTP modules:
- Added missing `[role="_abstract"]` short description attributes
- Transformed source block callouts for DITA compatibility
- Fixed block delimiter formatting
- Other editorial fixes for DITA conversion readiness

5 modules excluded (not present in 4.17):
- `cnf-configuring-enhanced-log-filtering-for-linuxptp` (4.20+)
- `cnf-configuring-log-reduction-for-linuxptp` (4.20+)
- `nw-ptp-t-bc-t-tsc-holdover` (4.20+)
- `nw-ptp-configuring-linuxptp-services-dual-port-oc` (4.18+)
- `nw-ptp-holdover-in-a-grandmaster-clock` (4.18+)

Assembly file excluded (path differs between versions).

Preview: https://107896--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/advanced_networking/ptp/configuring-ptp.html