### PR TITLE
OADP-7534: Add OADP 1.5.5 RNs

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -49,10 +49,10 @@ endif::[]
 :oadp-first: OpenShift API for Data Protection (OADP)
 :oadp-full: OpenShift API for Data Protection
 :oadp-short: OADP
-:oadp-version: 1.5.4
+:oadp-version: 1.5.5
 :oadp-version-1-3: 1.3.6
 :oadp-version-1-4: 1.4.6
-:oadp-version-1-5: 1.5.4
+:oadp-version-1-5: 1.5.5
 :oadp-bsl-api: backupstoragelocations.velero.io
 :velero-overview: link:https://{velero-domain}/docs/v{velero-version}/locations/[Overview of backup and snapshot locations in the Velero documentation]
 :velero-link: link:https://{velero-domain}/docs/v{velero-version}/[Velero {velero-version}]

--- a/backup_and_restore/application_backup_and_restore/release-notes/oadp-1-5-release-notes.adoc
+++ b/backup_and_restore/application_backup_and_restore/release-notes/oadp-1-5-release-notes.adoc
@@ -16,6 +16,8 @@ The release notes for {oadp-first} 1.5 describe new features and enhancements, d
 For additional information about {oadp-short}, see link:https://access.redhat.com/articles/5456281[{oadp-first} FAQ].
 ====
 
+include::modules/oadp-1-5-5-release-notes.adoc[leveloffset=+1]
+
 include::modules/oadp-1-5-4-release-notes.adoc[leveloffset=+1]
 
 include::modules/oadp-1-5-3-release-notes.adoc[leveloffset=+1]

--- a/modules/oadp-1-5-5-release-notes.adoc
+++ b/modules/oadp-1-5-5-release-notes.adoc
@@ -1,0 +1,29 @@
+// Module included in the following assemblies:
+//
+// * backup_and_restore/application_backup_and_restore/release-notes/oadp-1-5-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+
+[id="oadp-1-5-5-release-notes_{context}"]
+= OADP 1.5.5 release notes
+
+[role="_abstract"]
+{oadp-first} 1.5.5 release notes list resolved issues.
+
+
+[id="resolved-issues-1-5-5_{context}"]
+== Resolved issues
+
+{oadp-short} 1.5.5 fixes the following CVEs::
+
+* link:https://access.redhat.com/security/cve/cve-2025-61726[CVE-2025-61726]
+
+* link:https://access.redhat.com/security/cve/cve-2025-61728[CVE-2025-61728]
+
+* link:https://access.redhat.com/security/cve/cve-2025-68121[CVE-2025-68121]
+
+
+{sno-caps} clusters no longer crash due to premature CRD sync before API initialization::
+Before this update, the controller crashed during image-based upgrade (IBU) due to missing {ocp} custom resource definitions (CRDs) before they were fully initialized. As a consequence, this failure delayed `DataProtectionApplication` (DPA) reconciliation during IBU upgrade by 8 minutes. This release resolves this issue by requiring the controller to wait for {ocp} CRDs to load before starting in the IBU environment on {sno}, while also disabling leader election. This change shortens the DPA reconciliation window and improves the overall upgrade duration for {sno} clusters.
++
+link:https://issues.redhat.com/browse/OADP-7508[OADP-7508]


### PR DESCRIPTION
Version(s):
OCP 4.19+

Issue:
[OADP-7534](https://issues.redhat.com/browse/OADP-7534)

Link to docs preview:
- [OADP 1.5.5 release notes](https://107903--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/release-notes/oadp-1-5-release-notes.html#oadp-1-5-5-release-notes_oadp-1-5-release-notes)

QE review:
- [x] QE has approved this change.

Summary:
Add Release Notes for OADP 1.5.5 and update attributes.
