### PR TITLE
[enterprise-4.21] CNV-73283: Add release note about kubevirt actions menu

### DIFF
--- a/virt/release_notes/virt-4-21-release-notes.adoc
+++ b/virt/release_notes/virt-4-21-release-notes.adoc
@@ -142,6 +142,11 @@ With this update, cluster administrators can integrate third-party solutions int
 +
 link:https://issues.redhat.com/browse/CNV-73256[CNV-73256]
 
+Customizable action menu added for Kubevirt plugin::
+With this update, the Kubevirt plugin introduces a customizable action menu, which allows you to load custom actions from dynamic plugins. This enhancement also offers dynamic loading of local actions, and de-duplication of action lists, resulting in a more flexible user interface.
++
+link:https://issues.redhat.com/browse/CNV-70667[CNV-70667]
+
 // Monitoring
 
 New metric to list VM labels as Prometheus labels::


### PR DESCRIPTION
Version(s):
4.21

Issue:
https://issues.redhat.com/browse/CNV-73283

Link to docs preview:
https://107904--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/release_notes/virt-4-21-release-notes.html#virt-4-21-new_virt-4-21-release-notes

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
