### PR TITLE
OCPBUGS-77797: OCI UK Gov Cloud GA

### DIFF
--- a/modules/installing-oci-distributed-infra-support.adoc
+++ b/modules/installing-oci-distributed-infra-support.adoc
@@ -24,7 +24,7 @@ The following table describes the support status of each {oci-distributed} infra
 |Technology Preview
 
 |UK Government Cloud
-|Technology Preview
+|General Availability
 
 |EU Sovereign Cloud
 |Technology Preview


### PR DESCRIPTION
[OCPBUGS-77797](https://issues.redhat.com/browse/OCPBUGS-77797)

Version(s): 4.20+

This PR retroactively updates a table to state that Oracle UK Government Cloud is a GA infrastructure to install on. This will require change management.

Change Management Acks:

- [x] PM (@makentenza)
- [x] Product Experience (Chris Fields)
- [x] Engineering Team Lead (Andrea Fasano)
- [x] Engineering Manager (Pedro Amoedo)
- [x] DPM (Kathryn Alexander)
- [x] Content Strategist (Avani Bhatt)

QE review:
- [x] QE has approved this change.

Preview: [Supported Oracle Distributed Cloud infrastructures](https://107907--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_oci/installing-oci-agent-based-installer.html#installing-oci-distributed-infra-support_installing-oci-agent-based-installer)