### PR TITLE
DITA rewrite: Azure default IPI installation

### DIFF
--- a/installing/installing_azure/ipi/installing-azure-default.adoc
+++ b/installing/installing_azure/ipi/installing-azure-default.adoc
@@ -6,6 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 You can install a cluster on {azure-first} that uses the default configuration options.
 
 include::modules/installation-launching-installer.adoc[leveloffset=+1]
@@ -15,10 +16,6 @@ include::modules/cli-logging-in-kubeadmin.adoc[leveloffset=+1]
 [role="_additional-resources"]
 .Additional resources
 
-* For more information about accessing and understanding the {product-title} web console, see xref:../../../web_console/web-console.adoc#web-console[Accessing the web console].
-
-== Next steps
-
-* xref:../../../post_installation_configuration/cluster-tasks.adoc#available_cluster_customizations[Customize your cluster].
-* If necessary, you can
-xref:../../../support/remote_health_monitoring/remote-health-reporting.adoc#remote-health-reporting[Remote health reporting].
+* xref:../../../web_console/web-console.adoc#web-console[Accessing the web console]
+* xref:../../../post_installation_configuration/cluster-tasks.adoc#available_cluster_customizations[Customize your cluster]
+* xref:../../../support/remote_health_monitoring/remote-health-reporting.adoc#remote-health-reporting[Remote health reporting]


### PR DESCRIPTION
## Summary

Fixed Vale AsciiDocDITA rule violations for the Azure default IPI installation assembly.

## Changes Applied

- **TaskStep**: Fixed list continuations in procedure steps
- Removed blank lines breaking list structure
- Converted plain text to proper step format within conditional blocks

## Files Modified

Assembly:
- installing/installing_azure/ipi/installing-azure-default.adoc

Modified Modules:
- modules/installation-launching-installer.adoc

## Vale Validation Results

All actionable AsciiDocDITA issues resolved.

## Test Plan

- [x] Vale AsciiDocDITA linting passes with 0 errors
- [ ] Verify AsciiDoc renders correctly
- [ ] Content meaning preserved

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)