### PR TITLE
OSDOCS-17109-4:CQA-2-MSH-INST-3-bootc (attachment#4)

### DIFF
--- a/microshift_install_bootc/microshift-install-running-bootc-image-vm.adoc
+++ b/microshift_install_bootc/microshift-install-running-bootc-image-vm.adoc
@@ -1,11 +1,12 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="microshift-install-running-bootc-image-in-vm"]
-include::_attributes/attributes-microshift.adoc[]
 = Running the bootc image in a virtual machine
+include::_attributes/attributes-microshift.adoc[]
 :context: microshift-install-running-bootc-image-in-vm
 
 toc::[]
 
+[role="_abstract"]
 Use the bootable container image as an installation source to set up a {op-system-base-full} virtual machine.
 
 include::modules/microshift-install-bootc-prepare-kickstart.adoc[leveloffset=+1]

--- a/modules/microshift-install-bootc-creating-vm.adoc
+++ b/modules/microshift-install-bootc-creating-vm.adoc
@@ -6,6 +6,7 @@
 [id="microshift-install-bootc-creating-vm_{context}"]
 = Creating a virtual machine
 
+[role="_abstract"]
 You can create a virtual machine by using the {op-system-base-full} boot ISO image.
 
 .Prerequisites

--- a/modules/microshift-install-bootc-prepare-kickstart.adoc
+++ b/modules/microshift-install-bootc-prepare-kickstart.adoc
@@ -6,6 +6,7 @@
 [id="microshift-install-bootc-prepare-kickstart_{context}"]
 = Creating the Kickstart file
 
+[role="_abstract"]
 You must create the Kickstart file to use during installation.
 
 .Prerequisites
@@ -33,9 +34,10 @@ $ PULL_SECRET=~/.pull-secret.json
 +
 [source,terminal,subs="attributes+,quotes"]
 ----
-$ IMAGE_REF="quay.io/_<myorg>/<mypath>_/microshift-{product-version}-bootc" <1>
+$ IMAGE_REF="quay.io/_<myorg>/<mypath>_/microshift-{product-version}-bootc"
 ----
-<1> Replace _<myorg/<mypath>_ with your remote registry organization name and path.
++
+Replace _<myorg/<mypath>_ with your remote registry organization name and path.
 
 . Create the `kickstart.ks` file to use during installation by running the following script:
 +


### PR DESCRIPTION
Version(s):
4.20+

Issue:
https://issues.redhat.com/browse/OSDOCS-17109

Link to docs preview:
https://107915--ocpdocs-pr.netlify.app/microshift/latest/microshift_install_bootc/microshift-install-running-bootc-image-vm.html