### PR TITLE
OSSM-12627 2.6.14 (At Stage): [DOC] Release Notes, Known Issues and Bug Fixes

### DIFF
--- a/modules/ossm-release-2-6-13.adoc
+++ b/modules/ossm-release-2-6-13.adoc
@@ -12,8 +12,6 @@ This release of {SMProductName} updates the {SMProductName} Operator version to 
 
 This release addresses Common Vulnerabilities and Exposures (CVEs) and is supported on {product-title} 4.14 and later.
 
-include::snippets/ossm-current-version-support-snippet.adoc[]
-
 You can use the most current version of the {KialiProduct} with all supported versions of {SMProductName}. The version of {SMProductShortName} automatically ensures a compatible version of Kiali.
 
 [id="ossm-release-2-6-13-components_{context}"]

--- a/modules/ossm-release-2-6-14.adoc
+++ b/modules/ossm-release-2-6-14.adoc
@@ -1,0 +1,33 @@
+// Module included in the following assemblies:
+//
+// * service_mesh/v2x/servicemesh-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="ossm-release-2-6-14_{context}"]
+= {SMProductName} version 2.6.14
+
+[role="_abstract"]
+
+This release of {SMProductName} updates the {SMProductName} Operator version to 2.6.14, and includes the `ServiceMeshControlPlane` resource version updates for 2.6.14.
+
+This release addresses Common Vulnerabilities and Exposures (CVEs) and is supported on {product-title} 4.14 and later.
+
+include::snippets/ossm-current-version-support-snippet.adoc[]
+
+You can use the most current version of the {KialiProduct} with all supported versions of {SMProductName}. The version of {SMProductShortName} automatically ensures a compatible version of Kiali.
+
+[id="ossm-release-2-6-14-components_{context}"]
+== Component updates
+
+|===
+|Component |Version
+
+|Istio
+|1.20.8
+
+|Envoy Proxy
+|1.28.8
+
+|Kiali Server
+|1.73
+|===

--- a/service_mesh/v2x/servicemesh-release-notes.adoc
+++ b/service_mesh/v2x/servicemesh-release-notes.adoc
@@ -8,6 +8,8 @@ toc::[]
 
 // The following include statements pull in the module files that comprise 2.x release notes.
 
+include::modules/ossm-release-2-6-14.adoc[leveloffset=+1]
+
 include::modules/ossm-release-2-6-13.adoc[leveloffset=+1]
 
 include::modules/ossm-release-2-6-12.adoc[leveloffset=+1]


### PR DESCRIPTION
Change type: Doc update; OSSM 2.6.14 (At Stage): [DOC] Release Notes, Known Issues and Bug Fixes

Doc JIRA: https://issues.redhat.com/browse/OSSM-12627

Fix Version: 4.14-4.19
Note: This PR is created on enterprise-4.19 and needs CPing to the remaining versions.

Doc Previews: https://107927--ocpdocs-pr.netlify.app/openshift-enterprise/latest/service_mesh/v2x/servicemesh-release-notes.html#ossm-release-2-6-14_ossm-release-notes

QE Review: @mkralik3 
Peer Review: @eromanova97 