### PR TITLE
[RHDEVDOCS-6532] Add new Results watcher metrics

### DIFF
--- a/modules/op-results-metrics.adoc
+++ b/modules/op-results-metrics.adoc
@@ -1,0 +1,98 @@
+// This module is included in the following assembly:
+//
+// * records/using-tekton-results-for-openshift-pipelines-observability.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="results-observability-metrics_{context}"]
+= Observability metrics for {tekton-results}
+
+[role="_abstract"]
+You can monitor the health and performance of {tekton-results} storage and deletion operations by using the metrics exposed by the `tekton-results-watcher` component. These metrics provide insights into storage latency, deletion timing, and help identify runs deleted before successful storage.
+
+The `tekton-results-watcher` service exposes the metrics on port `9090` at the `/metrics` endpoint. If you have configured `ServiceMonitor` resources for {tekton-results}, Prometheus Operator automatically discovers these metrics.
+
+The following are the metric categories:
+
+* Storage performance
+* Storage failures
+* Deletion duration
+* Deletion count
+
+Most {tekton-results} metrics use labels to provide additional context, which you can use in PromQL{nbsp}queries or dashboards to filter and group the metrics.
+
+[cols="1,3",options="header"]
+|===
+| Label | Description
+
+| `kind`
+| The Tekton resource type: `pipelinerun` or `taskrun`.
+
+| `namespace`
+| The Kubernetes namespace of the run.
+
+| `pipeline`
+| The name of the pipeline. This label is optional.
+
+| `status`
+| The completion status of the run.
+
+| `task`
+| The name of the task. This label is optional and applies only to TaskRuns.
+
+| `taskrun`
+| The name of the TaskRun. This label is optional and applies only to TaskRuns.
+|===
+
+Storage performance metrics::
+{tekton-results} exposes the following storage performance metrics:
++
+[cols="3,1,3,2,2",options="header"]
+|===
+| Name | Type | Description | Labels | Buckets
+
+| `watcher_run_storage_latency_seconds` | Histogram | The duration between run completion and successful storage | kind, namespace | 0.1, 0.5, 1, 2, 5, 10, 30, 60, 120, 300, 600, and 1800 seconds
+|===
++
+[NOTE]
+====
+This metric tracks latency only when the watcher stores a run after completion. When you set `DisableStoringIncompleteRuns` to `false`, the watcher stores runs before completion but only records storage latency when the run completes and the watcher stores it again.
+====
+
+Storage failure metrics::
+{tekton-results} exposes the following storage failure metrics:
++
+[cols="3,1,3,2",options="header"]
+|===
+| Name | Type | Description | Labels
+
+| `runs_not_stored_count` | Counter | Total number of runs the system deletes without successful storage | kind, namespace
+|===
++
+[NOTE]
+====
+This metric might show inflated values in rare cases because the system can increment it multiple times during reconciliation when the controller attempts to store the run again or when the system does not complete deletion immediately.
+====
+
+Deletion duration metrics::
+{tekton-results} exposes the following deletion duration metrics:
++
+[cols="3,1,3,2",options="header"]
+|===
+| Name | Type | Description | Labels
+
+| `watcher_pipelinerun_delete_duration_seconds` | Histogram | The duration that the watcher takes to delete the PipelineRun since completion | pipeline, status, namespace
+
+| `watcher_taskrun_delete_duration_seconds` | Histogram | The duration that the watcher takes to delete the TaskRun since completion | pipeline, status, task, taskrun, namespace
+|===
+
+Deletion count metrics::
+{tekton-results} exposes the following deletion count metrics:
++
+[cols="3,1,3,2",options="header"]
+|===
+| Name | Type | Description | Labels
+
+| `watcher_pipelinerun_delete_count` | Counter | The total count of deleted PipelineRuns | status, namespace
+
+| `watcher_taskrun_delete_count` | Counter | The total count of deleted TaskRuns | status, namespace
+|===

--- a/records/using-tekton-results-for-openshift-pipelines-observability.adoc
+++ b/records/using-tekton-results-for-openshift-pipelines-observability.adoc
@@ -14,8 +14,12 @@ include::modules/op-results-concepts.adoc[leveloffset=+1]
 include::modules/op-configuring-results.adoc[leveloffset=+1]
 
 include::modules/op-results-log-forward.adoc[leveloffset=+2]
+
 include::modules/op-results-db.adoc[leveloffset=+2]
+
 include::modules/op-configuring-retention-policy-results.adoc[leveloffset=+2]
+
+include::modules/op-results-metrics.adoc[leveloffset=+2]
 
 [id="querying-using-opc_using-tekton-results-for-openshift-pipelines-observability"]
 == Querying {tekton-results} for results and records


### PR DESCRIPTION
Version(s):
- `pipelines-docs-1.21`
- `pipelines-docs-1.22`

Issue:
- https://issues.redhat.com/browse/RHDEVDOCS-6532

Link to docs preview:
- [Observability mertrics for Tekton Results](https://107957--ocpdocs-pr.netlify.app/openshift-pipelines/latest/records/using-tekton-results-for-openshift-pipelines-observability.html#results-observability-metrics_using-tekton-results-for-openshift-pipelines-observability)

QE review:
- [x] QE has approved this change.

