### PR TITLE
[OSDOCS#16811]:Update assembly for Creating a cluster workshop

### DIFF
--- a/rosa_learning/creating_cluster_workshop/learning-getting-started-hcp-for-hcp.adoc
+++ b/rosa_learning/creating_cluster_workshop/learning-getting-started-hcp-for-hcp.adoc
@@ -8,7 +8,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 [role="_abstract"]
-Follow this workshop to deploy a sample {product-title} cluster. You can then use your cluster in the next workshops.
+Follow this workshop to deploy a sample {product-title} cluster, where you can set up the prerequisites such as {rosa-cli-first}, and create an admin user. You can then use your cluster in the next workshops.
 
 include::modules/learning-getting-started-objects-prereqs.adoc[leveloffset=+1]
 include::modules/learning-getting-started-create-vpc.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s):
4.20+

Issue:
https://issues.redhat.com/browse/OSDOCS-16811

Link to docs preview:
[Creating a cluster workshop](https://107973--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/rosa_learning/creating_cluster_workshop/learning-getting-started-hcp-for-hcp.html)

Peer review:
- [x] Peer reviewer has approved this change.

QE review:
- QE approval is not required for this PR as no procedural changes.

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
