### PR TITLE
OSDOCS-16874-6: CQA for SCALE-4 Low-Latency/CNF Debugging and Related

### DIFF
--- a/modules/advanced-node-tuning-hosted-cluster.adoc
+++ b/modules/advanced-node-tuning-hosted-cluster.adoc
@@ -7,7 +7,8 @@
 [id="advanced-node-tuning-hosted-cluster_{context}"]
 = Advanced node tuning for hosted clusters by setting kernel boot parameters
 
-For more advanced tuning in {hcp}, which requires setting kernel boot parameters, you can also use the Node Tuning Operator. The following example shows how you can create a node pool with huge pages reserved.
+[role="_abstract"]
+To configure advanced kernel boot parameters in {hcp}, use the Node Tuning Operator. By applying these settings to a custom node pool, you can allocate huge pages and optimize memory management for your high-performance workloads.
 
 .Procedure
 
@@ -39,6 +40,7 @@ For more advanced tuning in {hcp}, which requires setting kernel boot parameters
           recommend:
           - priority: 20
             profile: openshift-node-hugepages
+# ...
 ----
 +
 [NOTE]
@@ -46,34 +48,42 @@ For more advanced tuning in {hcp}, which requires setting kernel boot parameters
 The `.spec.recommend.match` field is intentionally left blank. In this case, this `Tuned` object is applied to all nodes in the node pool where this `ConfigMap` object is referenced. Group nodes with the same hardware configuration into the same node pool. Otherwise, TuneD operands can calculate conflicting kernel parameters for two or more nodes that share the same node pool.
 ====
 
-. Create the `ConfigMap` object in the management cluster:
+. Create the `ConfigMap` object in the management cluster by entering the following command:
 +
 [source,terminal]
 ----
-$ oc --kubeconfig="<management_cluster_kubeconfig>" create -f tuned-hugepages.yaml <1>
+$ oc --kubeconfig="<management_cluster_kubeconfig>" create -f tuned-hugepages.yaml
 ----
-<1> Replace `<management_cluster_kubeconfig>` with the name of your management cluster `kubeconfig` file.
+** `<management_cluster_kubeconfig>`: Specifies the name of your management cluster `kubeconfig` file.
 
-. Create a `NodePool` manifest YAML file, customize the upgrade type of the `NodePool`, and reference the `ConfigMap` object that you created in the `spec.tuningConfig` section. Create the `NodePool` manifest and save it in a file named `hugepages-nodepool.yaml` by using the `hcp` CLI:
+. Create a `NodePool` manifest YAML file, customize the upgrade type of the `NodePool`, and reference the `ConfigMap` object that you created in the `spec.tuningConfig` section. Ensure that you save file named `hugepages-nodepool.yaml` by using the `hcp` CLI:
 +
 [source,terminal]
 ----
 $ hcp create nodepool aws \
-  --cluster-name <hosted_cluster_name> \// <1>
-  --name <nodepool_name> \// <2>
-  --node-count <nodepool_replicas> \// <3>
-  --instance-type <instance_type> \// <4>
+  --cluster-name <hosted_cluster_name> \
+  --name <nodepool_name> \
+  --node-count <nodepool_replicas> \
+  --instance-type <instance_type> \
   --render > hugepages-nodepool.yaml
 ----
-<1> Replace `<hosted_cluster_name>` with the name of your hosted cluster.
-<2> Replace `<nodepool_name>` with the name of your node pool.
-<3> Replace `<nodepool_replicas>` with the number of your node pool replicas, for example, `2`.
-<4> Replace `<instance_type>` with the instance type, for example, `m5.2xlarge`.
++
+where:
++
+--
+`<hosted_cluster_name>`:: Specifies the name of your hosted cluster.
+
+`<nodepool_name>`:: Specifies the name of your node pool.
+
+`<nodepool_replicas>`:: Specifies the number of your node pool replicas, for example, `2`.
+
+`<instance_type>`:: Specifies the instance type, for example, `m5.2xlarge`.
 +
 [NOTE]
 ====
 The `--render` flag in the `hcp create` command does not render the secrets. To render the secrets, you must use both the `--render` and the `--render-sensitive` flags in the `hcp create` command.
 ====
+--
 
 . In the `hugepages-nodepool.yaml` file, set `.spec.management.upgradeType` to `InPlace`, and set `.spec.tuningConfig` to reference the `tuned-hugepages` `ConfigMap` object that you created.
 +
@@ -92,6 +102,7 @@ The `--render` flag in the `hcp create` command does not render the secrets. To 
       ...
       tuningConfig:
       - name: tuned-hugepages
+# ...
 ----
 +
 [NOTE]
@@ -108,9 +119,9 @@ $ oc --kubeconfig="<management_cluster_kubeconfig>" create -f hugepages-nodepool
 
 .Verification
 
-After the nodes are available, the containerized TuneD daemon calculates the required kernel boot parameters based on the applied TuneD profile. After the nodes are ready and reboot once to apply the generated `MachineConfig` object, you can verify that the TuneD profile is applied and that the kernel boot parameters are set.
-
-. List the `Tuned` objects in the hosted cluster:
+. After the nodes are available, the containerized TuneD daemon calculates the required kernel boot parameters based on the applied TuneD profile. After the nodes are ready and reboot once to apply the generated `MachineConfig` object, you can verify that the TuneD profile is applied and that the kernel boot parameters are set.
++
+.. List the `Tuned` objects in the hosted cluster by entering the following command:
 +
 [source,terminal]
 ----
@@ -126,8 +137,8 @@ default              123m
 hugepages-8dfb1fed   1m23s
 rendered             123m
 ----
-
-. List the `Profile` objects in the hosted cluster:
++
+.. List the `Profile` objects in the hosted cluster by entering the following command:
 +
 [source,terminal]
 ----
@@ -145,9 +156,9 @@ hugepages-nodepool-worker-1    openshift-node-hugepages   True      False      4
 hugepages-nodepool-worker-2    openshift-node-hugepages   True      False      3m57s
 ----
 +
-Both of the worker nodes in the new `NodePool` have the `openshift-node-hugepages` profile applied.
-
-. To confirm that the tuning was applied correctly, start a debug shell on a node and check `/proc/cmdline`.
+Both of the compute nodes in the new `NodePool` have the `openshift-node-hugepages` profile applied.
++
+.. To confirm that the tuning was applied correctly, start a debug shell on a node and check `/proc/cmdline`. You can complete these tasks by entering the following command:
 +
 [source,terminal]
 ----

--- a/modules/custom-tuning-example.adoc
+++ b/modules/custom-tuning-example.adoc
@@ -2,15 +2,16 @@
 //
 // * scalability_and_performance/using-node-tuning-operator.adoc
 
-:_mod-docs-content-type: CONCEPT
+:_mod-docs-content-type: REFERENCE
 [id="custom-tuning-example_{context}"]
 = Custom tuning examples
 
-*Using TuneD profiles from the default CR*
+[role="_abstract"]
+To apply custom configurations to specific {product-title} nodes, review the custom tuning examples. By analyzing these custom resource (CR) templates, you can properly use labels to target and tune your workloads.
 
-The following CR applies custom node-level tuning for
-{product-title} nodes with label
-`tuned.openshift.io/ingress-node-label` set to any value.
+Using TuneD profiles from the default CR::
+
+The following CR applies custom node-level tuning for {product-title} nodes with label `tuned.openshift.io/ingress-node-label` set to any value:
 
 .Example: custom tuning using the openshift-control-plane TuneD profile
 [source,yaml]
@@ -35,20 +36,17 @@ spec:
     - label: tuned.openshift.io/ingress-node-label
     priority: 10
     profile: openshift-ingress
+# ...
 ----
 
 [IMPORTANT]
 ====
-Custom profile writers are strongly encouraged to include the default TuneD
-daemon profiles shipped within the default Tuned CR. The example above uses the
-default `openshift-control-plane` profile to accomplish this.
+Custom profile writers are strongly encouraged to include the default TuneD daemon profiles shipped within the default Tuned CR. The example above uses the default `openshift-control-plane` profile to accomplish this.
 ====
 
-*Using built-in TuneD profiles*
+Using built-in TuneD profiles::
 
-Given the successful rollout of the NTO-managed daemon set, the TuneD operands
-all manage the same version of the TuneD daemon. To list the built-in TuneD
-profiles supported by the daemon, query any TuneD pod in the following way:
+Given the successful rollout of the NTO-managed daemon set, the TuneD operands all manage the same version of the TuneD daemon. To list the built-in TuneD profiles supported by the daemon, query any TuneD pod in the following way:
 
 [source,terminal]
 ----
@@ -78,15 +76,12 @@ spec:
     - label: tuned.openshift.io/openshift-node-hpc-compute
     priority: 20
     profile: openshift-node-hpc-compute
+# ...
 ----
 
-In addition to the built-in `hpc-compute` profile, the example above includes
-the `openshift-node` TuneD daemon profile shipped within the default
-Tuned CR to use OpenShift-specific tuning for compute nodes.
+In addition to the built-in `hpc-compute` profile, the example above includes the `openshift-node` TuneD daemon profile shipped within the default Tuned CR to use OpenShift-specific tuning for compute nodes.
 
-// Note the issues with including profiles sharing the same ancestor: see link:https://bugzilla.redhat.com/show_bug.cgi?id=1825882[BZ#1825882]
-
-*Overriding host-level sysctls*
+*Overriding host-level sysctls::
 
 Various kernel parameters can be changed at runtime by using `/run/sysctl.d/`, `/etc/sysctl.d/`, and `/etc/sysctl.conf` host configuration files. {product-title} adds several host configuration files which set kernel parameters at runtime; for example, `net.ipv[4-6].`, `fs.inotify.`, and `vm.max_map_count`. These runtime parameters provide basic functional tuning for the system prior to the kubelet and the Operator start.
 
@@ -117,4 +112,5 @@ spec:
     operand:
       tunedConfig:
         reapply_sysctl: false
+# ...
 ----

--- a/modules/defer-application-tuning-proc.adoc
+++ b/modules/defer-application-tuning-proc.adoc
@@ -6,12 +6,14 @@
 [id="defer-application-of-tuning-changes-example_{context}"]
 = Deferring application of tuning changes: An example
 
-The following worked example describes how to defer the application of tuning changes by using the Node Tuning Operator.
+[role="_abstract"]
+To safely stage updates without immediately disrupting your workloads, review the example for deferring application of tuning changes. By analyzing this Node Tuning Operator configuration, you can understand how to correctly format your custom resources to delay configuration updates.
 
 .Prerequisites
+
 * You have `cluster-admin` role access.
 * You have applied a performance profile to your cluster.
-* A `MachineConfigPool` resource, for example, `worker-cnf` is configured to ensure that the profile is only applied to the designated nodes.
+* You configured a `MachineConfigPool` resource, such as `worker-cnf`, to ensure that the profile is only applied to the designated nodes.
 
 .Procedure
 
@@ -59,9 +61,9 @@ $ oc describe performanceprofile performance | grep Tuned
 Tuned:                   openshift-cluster-node-tuning-operator/openshift-node-performance-performance
 ----
 
-. Verify the existing value of the `kernel.shmmni` sysctl parameter:
-
-.. Run the following command to display the node names:
+. Verify the existing value of the `kernel.shmmni` sysctl parameter by completing the following steps:
++
+.. To display the node names, enter the following command:
 +
 [source,shell]
 ----
@@ -79,8 +81,8 @@ ip-10-0-6-97.ec2.internal     Ready    control-plane,master   121m   v1.30.6
 ip-10-0-86-145.ec2.internal   Ready    worker                 117m   v1.30.6
 ip-10-0-92-228.ec2.internal   Ready    control-plane,master   123m   v1.30.6
 ----
-
-.. Run the following command to display the current value of the `kernel.shmmni` sysctl parameters on the node `ip-10-0-32-74.ec2.internal`:
++
+.. To display the current value of the `kernel.shmmni` sysctl parameter on the node `ip-10-0-32-74.ec2.internal`, enter the following command:
 +
 [source,shell]
 ----
@@ -110,19 +112,26 @@ spec:
       data: |
         [main]
         summary=Configuration changes profile inherited from performance created tuned
-        include=openshift-node-performance-performance <1>
+        include=openshift-node-performance-performance
         [sysctl]
-        kernel.shmmni=8192 <2> 
+        kernel.shmmni=8192
   recommend:
     - machineConfigLabels:
-        machineconfiguration.openshift.io/role: worker-cnf <3>
+        machineconfiguration.openshift.io/role: worker-cnf
       priority: 19
       profile: performance-patch
+# ...
 ----
 +
-<1> The `include` directive is used to inherit the `openshift-node-performance-performance` profile. This is a best practice to ensure that the profile is not missing any required settings.
-<2> The `kernel.shmmni` sysctl parameter is being changed to `8192`.
-<3> The `machineConfigLabels` field is used to target the `worker-cnf` role.
+where:
++
+--
+`spec.profile.data:[main]`:: The `include` directive is used to inherit the `openshift-node-performance-performance` profile. This is a best practice to ensure that the profile is not missing any required settings.
+
+`spec.profile.data:[sysctl]`:: Specifies a value for the `kernel.shmmni` sysctl parameter. The example sets `8192` as the value for the parameter.
+
+`spec.recommend.machineConfigLabels`:: Specifies the target the `worker-cnf` role.
+--
 
 . Apply the profile patch by running the following command:
 +
@@ -131,7 +140,7 @@ spec:
 $ oc apply -f perf-patch.yaml
 ----
 
-. Run the following command to verify that the profile patch is waiting for the next node restart:
+. To verify that the profile patch is waiting for the next node restart, enter the following command:
 +
 [source,shell]
 ----
@@ -150,8 +159,8 @@ ip-10-0-86-145.ec2.internal   openshift-node            True      False      Tun
 ip-10-0-92-228.ec2.internal   openshift-control-plane   True      False      TuneD profile applied.                                                             130m
 ----
 
-. Confirm the value of the `kernel.shmmni` sysctl parameter remain unchanged before a restart:
-
+. Confirm the value of the `kernel.shmmni` sysctl parameter remain unchanged before a restart by completing the following steps:
++
 .. Run the following command to confirm that the application of the `performance-patch` change to the `kernel.shmmni` sysctl parameter on the node `ip-10-0-26-151.ec2.internal` is not applied:
 +
 [source,shell]
@@ -172,7 +181,7 @@ kernel.shmmni = 4096
 $ oc debug node/ip-10-0-26-151.ec2.internal  -q -- chroot host reboot&
 ----
 
-. In another terminal window, run the following command to verify that the node has restarted:
+. In another terminal window, enter the following command to verify that the node has restarted:
 +
 [source,shell]
 ----
@@ -200,9 +209,9 @@ ip-10-0-84-72.ec2.internal    openshift-control-plane   True      False      Tun
 ip-10-0-93-89.ec2.internal    openshift-node            True      False      TuneD profile applied.                                                             179m
 ----
 
-. Check that the value of the `kernel.shmmni` sysctl parameter have changed after the restart:
-
-.. Run the following command to verify that the `kernel.shmmni` sysctl parameter change has been applied on the node `ip-10-0-32-74.ec2.internal`:
+. Check that the value of the `kernel.shmmni` sysctl parameter has changed after the restart by entering the following command:
++
+.. To verify that the `kernel.shmmni` sysctl parameter change has been applied on the node `ip-10-0-32-74.ec2.internal`, enter the following command:
 +
 [source,shell]
 ----
@@ -214,7 +223,7 @@ $ oc debug node/ip-10-0-32-74.ec2.internal  -q -- chroot host sysctl kernel.shmm
 ----
 kernel.shmmni = 8192
 ----
-
++
 [NOTE]
 ====
 An additional restart results in the restoration of the original value of the `kernel.shmmni` sysctl parameter.

--- a/modules/defer-applicaton-tuning-example.adoc
+++ b/modules/defer-applicaton-tuning-example.adoc
@@ -6,16 +6,19 @@
 [id="defer-application-of-tuning-changes_{context}"]
 = Deferring application of tuning changes
 
-As an administrator, use the Node Tuning Operator (NTO) to update custom resources (CRs) on a running system and make tuning changes. For example, they can update or add a sysctl parameter to the [sysctl] section of the tuned object. When administrators apply a tuning change, the NTO prompts TuneD to reprocess all configurations, causing the tuned process to roll back all tuning and then reapply it.
+[role="_abstract"]
+To control exactly when node-level configurations take effect, defer the application of your tuning changes. By using the Node Tuning Operator (NTO) to update custom resources (CRs) on a running system, you can safely stage updates without immediately disrupting your workloads.
 
-Latency-sensitive applications may not tolerate the removal and reapplication of the tuned profile, as it can briefly disrupt performance. This is particularly critical for configurations that partition CPUs and manage process or interrupt affinity using the performance profile. To avoid this issue, {product-title} introduced new methods for applying tuning changes. Before {product-title} 4.17, the only available method, immediate, applied changes instantly, often triggering a tuned restart.
+For example, they can update or add a sysctl parameter to the `[sysctl]` section of the tuned object. When administrators apply a tuning change, the NTO prompts TuneD to reprocess all configurations, causing the tuned process to roll back all tuning and then reapply it.
+
+Latency-sensitive applications might not tolerate the removal and reapplication of the tuned profile, as the profile can briefly disrupt performance. This is particularly critical for configurations that partition CPUs and manage process or interrupt affinity by using the performance profile. To avoid this issue, {product-title} introduced new methods for applying tuning changes. Before {product-title} 4.17, the only available method, immediate, applied changes instantly, often triggering a tuned restart.
 
 The following additional methods are supported:
  
- * `always`: Every change is applied at the next node restart.
- * `update`: When a tuning change modifies a tuned profile, it is applied immediately by default and takes effect as soon as possible. When a tuning change does not cause a tuned profile to change and its values are modified in place, it is treated as always.
+* `always`: Every change is applied at the next node restart.
+* `update`: When a tuning change modifies a tuned profile, the profile is applied immediately by default and takes effect as soon as possible. When a tuning change does not cause a tuned profile to change and its values are modified in place, it is treated as always.
 
-Enable this feature by adding the annotation `tuned.openshift.io/deferred`. The following table summarizes the possible values for the annotation:
+You can enable this feature by adding the annotation `tuned.openshift.io/deferred`. The following table summarizes the possible values for the annotation:
 
 [cols="3,3",options="header"]
 |===
@@ -25,9 +28,8 @@ Enable this feature by adding the annotation `tuned.openshift.io/deferred`. The 
 |update           | The change is applied immediately if it causes a profile change, otherwise at the next node restart. 
 |===
 
-The following example demonstrates how to apply a change to the `kernel.shmmni` sysctl parameter by using the `always` method:
+The following example configuration demonstrates how to apply a change to the `kernel.shmmni` sysctl parameter by using the `always` method:
 
-.Example
 [source,yaml]
 ----
 apiVersion: tuned.openshift.io/v1
@@ -43,19 +45,24 @@ spec:
       data: |
         [main]
         summary=Configuration changes profile inherited from performance created tuned
-        include=openshift-node-performance-performance <1>
+        include=openshift-node-performance-performance
         [sysctl]
-        kernel.shmmni=8192 <2>
+        kernel.shmmni=8192
   recommend:
     - machineConfigLabels:
-        machineconfiguration.openshift.io/role: worker-cnf <3>
+        machineconfiguration.openshift.io/role: worker-cnf
       priority: 19
       profile: performance-patch
+# ...
 ----
 
-<1> The `include` directive is used to inherit the `openshift-node-performance-performance` profile. This is a best practice to ensure that the profile is not missing any required settings.
-<2> The `kernel.shmmni` sysctl parameter is being changed to `8192`.
-<3> The `machineConfigLabels` field is used to target the `worker-cnf` role. Configure a `MachineConfigPool` resource to ensure the profile is applied only to the correct nodes.
+where:
+
+`spec.profile.name.data: [main]`:: The `include` directive is used to inherit the `openshift-node-performance-performance` profile. This is a best practice to ensure that the profile is not missing any required settings.
+
+`spec.profile.name.data: [sysctl]`:: The `kernel.shmmni` sysctl parameter is being changed to `8192`.
+
+`spec.recommend.machineConfigLabels`:: The `machineConfigLabels` field is used to target the `worker-cnf` role. Configure a `MachineConfigPool` resource to ensure the profile is applied only to the correct nodes.
 
 [NOTE]
 ====

--- a/modules/node-tuning-hosted-cluster.adoc
+++ b/modules/node-tuning-hosted-cluster.adoc
@@ -7,7 +7,8 @@
 [id="node-tuning-hosted-cluster_{context}"]
 = Configuring node tuning in a hosted cluster
 
-To set node-level tuning on the nodes in your hosted cluster, you can use the Node Tuning Operator. In {hcp}, you can configure node tuning by creating config maps that contain `Tuned` objects and referencing those config maps in your node pools.
+[role="_abstract"]
+To apply custom node-level tuning in a hosted cluster, configure the Node Tuning Operator. Creating config maps containing Tuned objects and referencing them in your node pools ensures your {hcp} nodes are optimally configured for your workloads.
 
 .Procedure
 
@@ -39,6 +40,7 @@ To set node-level tuning on the nodes in your hosted cluster, you can use the No
           recommend:
           - priority: 20
             profile: tuned-1-profile
+# ...
 ----
 +
 [NOTE]
@@ -46,7 +48,7 @@ To set node-level tuning on the nodes in your hosted cluster, you can use the No
 If you do not add any labels to an entry in the `spec.recommend` section of the Tuned spec, node-pool-based matching is assumed, so the highest priority profile in the `spec.recommend` section is applied to nodes in the pool. Although you can achieve more fine-grained node-label-based matching by setting a label value in the Tuned `.spec.recommend.match` section, node labels will not persist during an upgrade unless you set the `.spec.management.upgradeType` value of the node pool to `InPlace`.
 ====
 
-. Create the `ConfigMap` object in the management cluster:
+. Create the `ConfigMap` object in the management cluster by entering the following command:
 +
 [source,terminal]
 ----
@@ -70,6 +72,7 @@ $ oc --kubeconfig="$MGMT_KUBECONFIG" create -f tuned-1.yaml
       - name: tuned-1
     status:
     ...
+# ...
 ----
 +
 [NOTE]
@@ -79,9 +82,9 @@ You can reference the same config map in multiple node pools. In {hcp}, the Node
 
 .Verification
 
-Now that you have created the `ConfigMap` object that contains a `Tuned` manifest and referenced it in a `NodePool`, the Node Tuning Operator syncs the `Tuned` objects into the hosted cluster. You can verify which `Tuned` objects are defined and which TuneD profiles are applied to each node.
-
-. List the `Tuned` objects in the hosted cluster:
+. Now that you have created the `ConfigMap` object that contains a `Tuned` manifest and referenced the object in a `NodePool`, the Node Tuning Operator syncs the `Tuned` objects into the hosted cluster. You can verify which `Tuned` objects are defined and which TuneD profiles are applied to each node by completing the following steps:
++
+.. List the `Tuned` objects in the hosted cluster by entering the following command:
 +
 [source,terminal]
 ----
@@ -97,8 +100,8 @@ default    7m36s
 rendered   7m36s
 tuned-1    65s
 ----
-
-. List the `Profile` objects in the hosted cluster:
++
+.. List the `Profile` objects in the hosted cluster by entering the following command:
 +
 [source,terminal]
 ----
@@ -118,8 +121,8 @@ nodepool-1-worker-2            tuned-1-profile  True      False      7m14s
 ====
 If no custom profiles are created, the `openshift-node` profile is applied by default.
 ====
-
-. To confirm that the tuning was applied correctly, start a debug shell on a node and check the sysctl values:
++
+.. To confirm that the tuning was applied correctly, start a debug shell on a node and check the sysctl values by entering the following command:
 +
 [source,terminal]
 ----

--- a/modules/node-tuning-operator-supported-tuned-daemon-plug-ins.adoc
+++ b/modules/node-tuning-operator-supported-tuned-daemon-plug-ins.adoc
@@ -8,8 +8,10 @@
 [id="supported-tuned-daemon-plug-ins_{context}"]
 = Supported TuneD daemon plugins
 
-Excluding the `[main]` section, the following TuneD plugins are supported when
-using custom profiles defined in the `profile:` section of the Tuned CR:
+[role="_abstract"]
+To properly define node-level optimizations, review the supported TuneD daemon plugins. Understanding which plugins are permitted in your custom resource (CR) helps you successfully configure and apply your custom tuning profiles.
+
+Excluding the `[main]` section, the following TuneD plugins are supported when using custom profiles defined in the `profile:` section of the Tuned CR:
 
 * audio
 * cpu
@@ -28,8 +30,7 @@ using custom profiles defined in the `profile:` section of the Tuned CR:
 * vm
 * bootloader
 
-There is some dynamic tuning functionality provided by some of these plugins
-that is not supported. The following TuneD plugins are currently not supported:
+There is some dynamic tuning functionality provided by some of these plugins that is not supported. The following TuneD plugins are currently not supported:
 
 * script
 * systemd
@@ -40,8 +41,4 @@ that is not supported. The following TuneD plugins are currently not supported:
 The TuneD bootloader plugin only supports {op-system-first} worker nodes.
 ====
 
-.Additional resources
 
-* link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/monitoring_and_managing_system_status_and_performance/customizing-tuned-profiles_monitoring-and-managing-system-status-and-performance#available-tuned-plug-ins_customizing-tuned-profiles[Available TuneD Plugins]
-
-* link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/monitoring_and_managing_system_status_and_performance/getting-started-with-tuned_monitoring-and-managing-system-status-and-performance[Getting Started with TuneD]

--- a/scalability_and_performance/using-node-tuning-operator.adoc
+++ b/scalability_and_performance/using-node-tuning-operator.adoc
@@ -31,6 +31,13 @@ include::modules/defer-application-tuning-proc.adoc[leveloffset=+2]
 
 include::modules/node-tuning-operator-supported-tuned-daemon-plug-ins.adoc[leveloffset=+1]
 
+[role="_additional-resources"]
+.Additional resources
+
+* link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/monitoring_and_managing_system_status_and_performance/customizing-tuned-profiles_monitoring-and-managing-system-status-and-performance#available-tuned-plug-ins_customizing-tuned-profiles[Available TuneD Plugins]
+
+* link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/monitoring_and_managing_system_status_and_performance/getting-started-with-tuned_monitoring-and-managing-system-status-and-performance[Getting Started with TuneD]
+
 include::modules/node-tuning-hosted-cluster.adoc[leveloffset=+1]
 
 include::modules/advanced-node-tuning-hosted-cluster.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s):
4.16+

Issue:
[OSDOCS-16874](https://issues.redhat.com/browse/OSDOCS-16874)

Preview links:

* https://107995--ocpdocs-pr.netlify.app/openshift-dedicated/latest/nodes/nodes/nodes-node-tuning-operator.html
* https://107995--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-machine-config.html
* https://107995--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/nodes/nodes-node-tuning-operator.html
* https://107995--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/node-tasks.html
* https://107995--ocpdocs-pr.netlify.app/openshift-enterprise/latest/scalability_and_performance/using-node-tuning-operator.html
* https://107995--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/nodes/nodes/nodes-node-tuning-operator.html
* https://107995--ocpdocs-pr.netlify.app/openshift-rosa/latest/nodes/nodes/nodes-node-tuning-operator.html