### PR TITLE
OSDOCS#18570: Update the z-stream RNs for 4.13.64

### DIFF
--- a/modules/zstream-4-13-62-about.adoc
+++ b/modules/zstream-4-13-62-about.adoc
@@ -2,11 +2,9 @@
 [id="zstream-4-13-62-about_{context}"]
 = RHSA-2025:22284 - {product-title} 4.13.62 bug fix and security update
 
-
-[role="_abstract"]
 Issued: 04 December 2025
 
-
+[role="_abstract"]
 {product-title} release 4.13.62, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2025:22284[RHSA-2025:22284] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2025:22274[RHBA-2025:22274] advisory.
 
 

--- a/modules/zstream-4-13-62-bug-fixes.adoc
+++ b/modules/zstream-4-13-62-bug-fixes.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: REFERENCE
 [id="zstream-4-13-62-bug-fixes_{context}"]
-= Bug fixes
+= Fixed issues
 
 [role=”_abstract”]
-There are no notable bug fixes in this release.
+There are no notable fixed issues in this release.

--- a/modules/zstream-4-13-63-about.adoc
+++ b/modules/zstream-4-13-63-about.adoc
@@ -2,9 +2,9 @@
 [id="zstream-4-13-63-about_{context}"]
 = RHBA-2026:0678 - {product-title} 4.13.63 bug fix and security updates
 
-[role="_abstract"]
 Issued: 22 January 2026
 
+[role="_abstract"]
 {product-title} release 4.13.63, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2026:0678[RHBA-2026:0678] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2026:0676[RHSA-2026:0676] advisory.
 
 You can view the container images in this release by running the following command:

--- a/modules/zstream-4-13-63-updating.adoc
+++ b/modules/zstream-4-13-63-updating.adoc
@@ -1,0 +1,6 @@
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-13-63-updating_{context}"]
+= Updating
+
+[role="_abstract"]
+To update an existing {product-title} 4.13 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].

--- a/modules/zstream-4-13-64-about.adoc
+++ b/modules/zstream-4-13-64-about.adoc
@@ -1,0 +1,15 @@
+:_mod-docs-content-type: CONCEPT
+[id="zstream-4-13-64-about_{context}"]
+= RHSA-2026:3422 - {product-title} 4.13.64 bug fix and security updates
+
+Issued: 05 March 2026
+
+[role="_abstract"]
+{product-title} release 4.13.64, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2026:3422[RHSA-2026:3422] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2026:3414[RHBA-2026:3414] advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.13.64 --pullspecs
+----

--- a/modules/zstream-4-13-64-bug-fixes.adoc
+++ b/modules/zstream-4-13-64-bug-fixes.adoc
@@ -1,5 +1,5 @@
 :_mod-docs-content-type: REFERENCE
-[id="zstream-4-13-63-bug-fixes_{context}"]
+[id="zstream-4-13-64-bug-fixes_{context}"]
 = Fixed issues
 
 [role=”_abstract”]

--- a/modules/zstream-4-13-64-updating.adoc
+++ b/modules/zstream-4-13-64-updating.adoc
@@ -1,0 +1,6 @@
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-13-64-updating_{context}"]
+= Updating
+
+[role="_abstract"]
+To update an existing {product-title} 4.13 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].

--- a/release_notes/ocp-4-13-release-notes.adoc
+++ b/release_notes/ocp-4-13-release-notes.adoc
@@ -4655,4 +4655,11 @@ include::modules/zstream-4-13-63-about.adoc[leveloffset=+2]
 
 include::modules/zstream-4-13-63-bug-fixes.adoc[leveloffset=+2]
 
-include::modules/zstream-updating.adoc[leveloffset=+2]
+include::modules/zstream-4-13-63-updating.adoc[leveloffset=+2]
+
+//4.13.64
+include::modules/zstream-4-13-64-about.adoc[leveloffset=+2]
+
+include::modules/zstream-4-13-64-bug-fixes.adoc[leveloffset=+2]
+
+include::modules/zstream-4-13-64-updating.adoc[leveloffset=+2]


### PR DESCRIPTION
Version(s):
4.13

Issue:
[OSDOCS-18570](https://issues.redhat.com/browse/OSDOCS-18570)

Link to docs preview:
[4.13.64](https://107997--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-13-release-notes.html#zstream-4-13-64-about_release-notes)

QE review:
- [ ] QE has approved this change.
N/A for z-stream RNs.

Additional information:
Shipment [MR](https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/388)
ART [Dashboard](https://art-dash.engineering.redhat.com/dashboard/release/openshift-4.13)

**Mergers:  For 4.13.62 and 4.13.63, I changed the position of `[role=_abstract"]` from above the date to above the intro sentence/paragraph. I also changed `Bug fixes` to `Fixed issues`  for consistency with the latest standard.
