### PR TITLE
[power-monitoring-docs-0.4] CCSINTL-3095 [POWERMON] Module short descriptions

### DIFF
--- a/modules/power-monitoring-accessing-dashboards-admin.adoc
+++ b/modules/power-monitoring-accessing-dashboards-admin.adoc
@@ -6,7 +6,8 @@
 [id="power-monitoring-accessing-dashboards-admin_{context}"]
 = Accessing {PM-shortname} dashboards as a cluster administrator
 
-You can access {PM-shortname} dashboards of the {ocp} web console.
+[role="_abstract"]
+Access power monitoring dashboards from the {ocp} web console using cluster administrator credentials and permissions.
 
 .Prerequisites
 

--- a/modules/power-monitoring-accessing-dashboards-developer.adoc
+++ b/modules/power-monitoring-accessing-dashboards-developer.adoc
@@ -6,6 +6,9 @@
 [id="power-monitoring-accessing-dashboards-developer_{context}"]
 = Accessing {PM-shortname} dashboards as a developer
 
+[role="_abstract"]
+Access {PM-shortname} dashboards from the {ocp} web console using developer credentials and view permissions for monitoring.
+
 You can access {PM-shortname} dashboards from {ocp} web console.
 
 .Prerequisites

--- a/modules/power-monitoring-dashboards-overview.adoc
+++ b/modules/power-monitoring-dashboards-overview.adoc
@@ -6,7 +6,8 @@
 [id="power-monitoring-dashboards-overview_{context}"]
 = {PM-shortname-c} dashboards overview
 
-There are two types of {PM-shortname} dashboards. Both provide different levels of details around power consumption metrics for a single cluster:
+[role="_abstract"]
+{PM-shortname} provides two dashboards for visualizing cluster power consumption at node, namespace, and pod levels.
 
 [id="power-monitoring-overview-dashboard_{context}"]
 == Power Monitoring / Overview dashboard

--- a/modules/power-monitoring-deleting-kepler.adoc
+++ b/modules/power-monitoring-deleting-kepler.adoc
@@ -6,7 +6,13 @@
 [id="power-monitoring-deleting-kepler_{context}"]
 = Deleting {PM-kepler}
 
-You can delete {PM-kepler} by removing the {PM-kepler} instance of the `{PM-kepler}` custom resource definition (CRD) from the {ocp} web console.
+[role="_abstract"]
+Remove {PM-kepler} by deleting the {PM-kepler} custom resource instance from the {ocp} web console.
+
+[IMPORTANT]
+====
+Starting with {PM-title} 0.5 (Technology Preview), use the `PowerMonitor` custom resource definition (CRD), and remove all instances of the `Kepler` CRD.
+====
 
 .Prerequisites
 * You have access to the {ocp} web console.

--- a/modules/power-monitoring-fips-support.adoc
+++ b/modules/power-monitoring-fips-support.adoc
@@ -6,7 +6,10 @@
 [id="power-monitoring-fips-support_{context}"]
 = About FIPS compliance for {PM-operator}
 
-Starting with version 0.4, {PM-operator} for Red{nbsp}Hat OpenShift is FIPS compliant. When deployed on an {ocp} cluster in FIPS mode, it uses {op-system-base-full} cryptographic libraries validated by National Institute of Standards and Technology (NIST).
+[role="_abstract"]
+The {PM-operator} version 0.4 and later is FIPS compliant when deployed on {ocp} clusters in FIPS mode.
+
+When deployed on an {ocp} cluster in FIPS mode, it uses {op-system-base-full} cryptographic libraries validated by National Institute of Standards and Technology (NIST).
 
 For details on the NIST validation program, see link:https://csrc.nist.gov/Projects/cryptographic-module-validation-program/validated-modules[Cryptographic module validation program]. For the latest NIST status of {op-system-base} cryptographic libraries, see link:https://access.redhat.com/en/compliance[Compliance activities and government standards].
 

--- a/modules/power-monitoring-installing-pmo.adoc
+++ b/modules/power-monitoring-installing-pmo.adoc
@@ -6,7 +6,8 @@
 [id="power-monitoring-installing-pmo_{context}"]
 = Installing the {PM-operator}
 
-As a cluster administrator, you can install the {PM-operator} from the software catalog by using the {ocp} web console.
+[role="_abstract"]
+Install the {PM-operator} from the software catalog using the {ocp} web console.
 
 [WARNING]
 ====

--- a/modules/power-monitoring-kepler-architecture.adoc
+++ b/modules/power-monitoring-kepler-architecture.adoc
@@ -6,6 +6,9 @@
 [id="power-monitoring-kepler-architecture_{context}"]
 = {PM-shortname-c} architecture
 
+[role="_abstract"]
+{PM-shortname-c} consists of the {PM-operator} for management and {PM-kepler} for collecting power metrics.
+
 {PM-shortname-c} is made up of the following major components:
 
 The {PM-operator}:: For administrators, the {PM-operator} streamlines the monitoring of power usage for workloads by simplifying the deployment and management of {PM-kepler} in an {ocp} cluster. The setup and configuration for the {PM-operator} are simplified by adding a {PM-kepler} custom resource definition (CRD). The Operator also manages operations, such as upgrading, removing, configuring, and redeploying {PM-kepler}. 

--- a/modules/power-monitoring-kepler-configuration.adoc
+++ b/modules/power-monitoring-kepler-configuration.adoc
@@ -6,7 +6,9 @@
 [id="power-monitoring-kepler-configuration_{context}"]
 = The {PM-kepler} configuration
 
-You can configure {PM-kepler} with the `spec` field of the `{PM-kepler}` resource.
+[role="_abstract"]
+Configuration options available for customizing Kepler deployment, security, logging, and metric collection through `PowerMonitor` resources.
+
 
 [IMPORTANT]
 ====
@@ -18,7 +20,7 @@ The following is the list of configuration options:
 .{PM-kepler} configuration options
 [options="header"]
 |===
-|Name |Spec |Description |Default 
+|Name |Spec |Description |Default
 |`port` |`exporter.deployment` |The port on the node where the Prometheus metrics are exposed. |`9103`
 |`nodeSelector` |`exporter.deployment` |The nodes on which {PM-kepler} exporter pods are scheduled. |`kubernetes.io/os: linux`
 |`tolerations` |`exporter.deployment` |The tolerations for {PM-kepler} exporter that allow the pods to be scheduled on nodes with specific characteristics. |`- operator: "Exists"`
@@ -35,11 +37,11 @@ spec:
   exporter:
     deployment:
       port: 9103 # <1>
-      nodeSelector: 
+      nodeSelector:
         kubernetes.io/os: linux # <2>
       Tolerations: # <3>
       - key: ""
-        operator: "Exists" 
+        operator: "Exists"
         value: ""
         effect: ""
 ----

--- a/modules/power-monitoring-monitoring-kepler-status.adoc
+++ b/modules/power-monitoring-monitoring-kepler-status.adoc
@@ -6,7 +6,8 @@
 [id="power-monitoring-monitoring-kepler-status_{context}"]
 = Monitoring the {PM-kepler} status
 
-You can monitor the state of the {PM-kepler} exporter with the `status` field of the `{PM-kepler}` resource. 
+[role="_abstract"]
+The `PowerMonitor` resource status field provides real-time information about Kepler pod deployment state and health across nodes.
 
 The `status.exporter` field includes information, such as the following:
 
@@ -14,7 +15,7 @@ The `status.exporter` field includes information, such as the following:
 * The number of nodes that should be running the {PM-kepler} pods
 * Conditions representing the health of the {PM-kepler} resource
 
-This provides you with valuable insights into the changes made through the `spec` field. 
+This provides you with valuable insights into the changes made through the `spec` field.
 
 .Example state of the `{PM-kepler}` resource
 [source,yaml]

--- a/modules/power-monitoring-overview.adoc
+++ b/modules/power-monitoring-overview.adoc
@@ -6,7 +6,10 @@
 [id="power-monitoring-overview_{context}"]
 = {PM-shortname-c} overview
 
-You can use {PM-title} to monitor the power usage and identify power-consuming containers running in an {ocp} cluster. {PM-shortname-c} collects and exports energy-related system statistics from various components, such as CPU and DRAM. It provides granular power consumption data for Kubernetes pods, namespaces, and nodes.
+[role="_abstract"]
+{PM-title} tracks energy consumption across {ocp}cluster infrastructure and provides granular metrics for pods and namespaces.
+
+You can use {PM-title} to monitor the power usage and identify power-consuming containers running in an {ocp} cluster. {PM-shortname-c} collects and exports energy-related system statistics from various components, such as CPU and DRAM. It provides estimates and granular power consumption data for Kubernetes pods and namespaces, and reads the power consumption of nodes.
 
 [WARNING]
 ====

--- a/modules/power-monitoring-uninstalling-pmo.adoc
+++ b/modules/power-monitoring-uninstalling-pmo.adoc
@@ -6,7 +6,8 @@
 [id="power-monitoring-uninstalling-pmo_{context}"]
 = Uninstalling the {PM-operator}
 
-If you installed the {PM-operator} by using the software catalog, you can uninstall it from the {ocp} web console.
+[role="_abstract"]
+Uninstall the {PM-operator} from the {ocp} web console after deleting Kepler.
 
 .Prerequisites
 * You have access to the {ocp} web console.


### PR DESCRIPTION
Cherry pick: https://github.com/openshift/openshift-docs/commit/7976eadb9e3e359935b38964c4a250aa498f37f7

Original PR: https://github.com/openshift/openshift-docs/pull/107858

Version(s):
power-monitoring-docs-0.4

QE review:
QE is not required for this PR.

Additional information:

* Fewer files as not all content for `power-monitoring-main` and `power-monitoring-0.5` is applicable to `power-monitoring-0.4`