### PR TITLE
OSDOCS-18429: replace kubectl with oc RHCL docs

### DIFF
--- a/modules/con-secure-protect-connect.adoc
+++ b/modules/con-secure-protect-connect.adoc
@@ -32,9 +32,3 @@ You can use {prodname} capabilities in single or multiple {ocp} clusters. The fo
 +
 Platform engineers can use {prodname} in clusters in different geographic regions to bring specific traffic to geo-located gateways. This approach reduces latency, distributes load, and protects and secures with global rate limiting and auth policies.
 * *Application developer*: This guide shows how application developers can override the Gateway-level global auth and rate limiting policies to configure application-level auth and rate limiting requirements for specific users.
-
-[id="rhcl-deployment-management_{context}"]
-== Deployment management
-
-The examples in this guide use `kubectl` commands for simplicity. However, working with multiple clusters is complex, and it is best to use a tool such as {ocp} GitOps, based on Argo CD, to manage the deployment of resources to multiple clusters.
-//TODO: then we should show gitops or link to it; what is used in production?

--- a/modules/proc-app-dev-override-rlp.adoc
+++ b/modules/proc-app-dev-override-rlp.adoc
@@ -25,7 +25,7 @@ Any new HTTPRoutes are affected by the existing Gateway-level policy. Because yo
 +
 [source,terminal]
 ----
-$ kubectl apply -f - <<EOF
+$ oc apply -f - <<EOF
 apiVersion: kuadrant.io/v1
 kind: RateLimitPolicy
 metadata:
@@ -61,14 +61,14 @@ It might take a few minutes for the `RateLimitPolicy` to be applied, depending o
 +
 [source,terminal]
 ----
-$ kubectl get ratelimitpolicy -n ${KUADRANT_DEVELOPER_NS} toystore-rlp -o=jsonpath='{.status.conditions[?(@.type=="Accepted")].message}{"\n"}{.status.conditions[?(@.type=="Enforced")].message}'
+$ oc get ratelimitpolicy -n ${KUADRANT_DEVELOPER_NS} toystore-rlp -o=jsonpath='{.status.conditions[?(@.type=="Accepted")].message}{"\n"}{.status.conditions[?(@.type=="Enforced")].message}'
 ----
 
 . Check that the status of the `HTTPRoute` is now affected by the `RateLimitPolicy` in the same namespace:
 +
 [source,terminal]
 ----
-$ kubectl get httproute toystore -n ${KUADRANT_DEVELOPER_NS} -o=jsonpath='{.status.parents[0].conditions[?(@.type=="kuadrant.io/RateLimitPolicyAffected")].message}'
+$ oc get httproute toystore -n ${KUADRANT_DEVELOPER_NS} -o=jsonpath='{.status.parents[0].conditions[?(@.type=="kuadrant.io/RateLimitPolicyAffected")].message}'
 ----
 
 .Verification

--- a/modules/proc-configure-obs-monitoring.adoc
+++ b/modules/proc-configure-obs-monitoring.adoc
@@ -29,7 +29,7 @@ The following procedure is an example only and is not intended for production us
 +
 [source,terminal]
 ----
-$ kubectl get configmap cluster-monitoring-config -n openshift-monitoring -o jsonpath='{.data.config\.yaml}'|grep enableUserWorkload
+$ oc get configmap cluster-monitoring-config -n openshift-monitoring -o jsonpath='{.data.config\.yaml}'|grep enableUserWorkload
 ----
 +
 The expected output is `enableUserWorkload: true`.
@@ -38,7 +38,7 @@ The expected output is `enableUserWorkload: true`.
 +
 [source,terminal]
 ----
-$ kubectl apply -k https://github.com/Kuadrant/kuadrant-operator/config/install/configure/observability?ref=v1.2.0
+$ oc apply -k https://github.com/Kuadrant/kuadrant-operator/config/install/configure/observability?ref=v1.2.0
 ----
 
 . From the root directory of your Kuadrant Operator repository, configure the {ocp} `thanos-query` instance as a data source in Grafana as follows:
@@ -46,15 +46,15 @@ $ kubectl apply -k https://github.com/Kuadrant/kuadrant-operator/config/install/
 [source,terminal]
 ----
 TOKEN="Bearer $(oc whoami -t)"
-HOST="$(kubectl -n openshift-monitoring get route thanos-querier -o jsonpath='https://{.status.ingress[].host}')"
+HOST="$(oc -n openshift-monitoring get route thanos-querier -o jsonpath='https://{.status.ingress[].host}')"
 echo "TOKEN=$TOKEN" > config/observability/openshift/grafana/datasource.env
 echo "HOST=$HOST" >> config/observability/openshift/grafana/datasource.env
-kubectl apply -k config/observability/openshift/grafana
+oc apply -k config/observability/openshift/grafana
 ----
 
 . Configure the example Grafana dashboards as follows:
 +
 [source,terminal,subs="attributes+"]
 ----
-$ kubectl apply -k https://github.com/Kuadrant/kuadrant-operator/examples/dashboards?ref=v{operator-version}
+$ oc apply -k https://github.com/Kuadrant/kuadrant-operator/examples/dashboards?ref=v{operator-version}
 ----

--- a/modules/proc-configure-redis.adoc
+++ b/modules/proc-configure-redis.adoc
@@ -37,7 +37,7 @@ Include the appropriate URI scheme for your environment:
 +
 [source,terminal]
 ----
-$ kubectl -n kuadrant-system create secret generic redis-config \
+$ oc -n kuadrant-system create secret generic redis-config \
   --from-literal=URL=$REDIS_URL
 ----
 
@@ -45,7 +45,7 @@ $ kubectl -n kuadrant-system create secret generic redis-config \
 +
 [source,terminal]
 ----
-$ kubectl patch limitador limitador --type=merge -n kuadrant-system -p '
+$ oc patch limitador limitador --type=merge -n kuadrant-system -p '
 spec:
   storage:
     redis:

--- a/modules/proc-create-gateway.adoc
+++ b/modules/proc-create-gateway.adoc
@@ -25,7 +25,7 @@ In a multicluster environment, for {prodname} to balance traffic by using DNS ac
 +
 [source,terminal]
 ----
-$ kubectl apply -f - <<EOF
+$ oc apply -f - <<EOF
 apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
@@ -56,7 +56,7 @@ EOF
 +
 [source,terminal]
 ----
-$ kubectl get gateway ${KUADRANT_GATEWAY_NAME} -n ${KUADRANT_GATEWAY_NS} -o=jsonpath='{.status.conditions[?(@.type=="Accepted")].message}{"\n"}{.status.conditions[?(@.type=="Programmed")].message}'
+$ oc get gateway ${KUADRANT_GATEWAY_NAME} -n ${KUADRANT_GATEWAY_NS} -o=jsonpath='{.status.conditions[?(@.type=="Accepted")].message}{"\n"}{.status.conditions[?(@.type=="Programmed")].message}'
 ----
 +
 Your Gateway should be `Accepted` and `Programmed`, which means that it is valid and assigned an external address.
@@ -65,7 +65,7 @@ Your Gateway should be `Accepted` and `Programmed`, which means that it is valid
 +
 [source,terminal]
 ----
-$ kubectl get gateway ${KUADRANT_GATEWAY_NAME} -n ${KUADRANT_GATEWAY_NS} -o=jsonpath='{.status.listeners[0].conditions[?(@.type=="Programmed")].message}'
+$ oc get gateway ${KUADRANT_GATEWAY_NAME} -n ${KUADRANT_GATEWAY_NS} -o=jsonpath='{.status.listeners[0].conditions[?(@.type=="Programmed")].message}'
 ----
 +
 You will see that the HTTPS listener is not yet programmed or ready to accept traffic due to bad TLS configuration. {prodname} can help with this by using a TLSPolicy, which is described in the next step.

--- a/modules/proc-obs-configure-access-logs.adoc
+++ b/modules/proc-obs-configure-access-logs.adoc
@@ -83,7 +83,7 @@ The `expression` field uses Common Expression Language (CEL). You can use CEL-ba
 +
 [source,terminal]
 ----
-$ kubectl get istio -A
+$ oc get istio -A
 ----
 +
 The expected output is a list of your mesh deployments, such as `default`, `prod-mesh` and their current status.

--- a/modules/proc-platform-eng-workflow.adoc
+++ b/modules/proc-platform-eng-workflow.adoc
@@ -31,7 +31,7 @@ In multicluster environments, you must perform the following steps in each clust
 +
 [source,terminal]
 ----
-$ kubectl apply -f - <<EOF
+$ oc apply -f - <<EOF
 apiVersion: kuadrant.io/v1
 kind: TLSPolicy
 metadata:
@@ -53,7 +53,7 @@ EOF
 +
 [source,terminal]
 ----
-$ kubectl get tlspolicy ${KUADRANT_GATEWAY_NAME}-tls -n ${KUADRANT_GATEWAY_NS} -o=jsonpath='{.status.conditions[?(@.type=="Accepted")].message}{"\n"}{.status.conditions[?(@.type=="Enforced")].message}'
+$ oc get tlspolicy ${KUADRANT_GATEWAY_NAME}-tls -n ${KUADRANT_GATEWAY_NS} -o=jsonpath='{.status.conditions[?(@.type=="Accepted")].message}{"\n"}{.status.conditions[?(@.type=="Enforced")].message}'
 ----
 +
 This may take a few minutes depending on the TLS provider, for example, Let's Encrypt.
@@ -67,7 +67,7 @@ This may take a few minutes depending on the TLS provider, for example, Let's En
 +
 [source,terminal]
 ----
-$ kubectl apply -f - <<EOF
+$ oc apply -f - <<EOF
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
@@ -107,7 +107,7 @@ EOF
 +
 [source,terminal]
 ----
-$ kubectl apply -f - <<EOF
+$ oc apply -f - <<EOF
 apiVersion: kuadrant.io/v1
 kind: AuthPolicy
 metadata:
@@ -144,7 +144,7 @@ EOF
 +
 [source,terminal]
 ----
-$ kubectl get authpolicy ${KUADRANT_GATEWAY_NAME}-auth -n ${KUADRANT_GATEWAY_NS} -o=jsonpath='{.status.conditions[?(@.type=="Accepted")].message}{"\n"}{.status.conditions[?(@.type=="Enforced")].message}'
+$ oc get authpolicy ${KUADRANT_GATEWAY_NAME}-auth -n ${KUADRANT_GATEWAY_NS} -o=jsonpath='{.status.conditions[?(@.type=="Accepted")].message}{"\n"}{.status.conditions[?(@.type=="Enforced")].message}'
 ----
 
 //TODO new module
@@ -156,7 +156,7 @@ $ kubectl get authpolicy ${KUADRANT_GATEWAY_NAME}-auth -n ${KUADRANT_GATEWAY_NS}
 +
 [source,terminal]
 ----
-$ kubectl apply -f  - <<EOF
+$ oc apply -f  - <<EOF
 apiVersion: kuadrant.io/v1
 kind: RateLimitPolicy
 metadata:
@@ -182,7 +182,7 @@ It might take a few minutes for the `RateLimitPolicy` to be applied depending on
 +
 [source,terminal]
 ----
-$ kubectl get ratelimitpolicy ${KUADRANT_GATEWAY_NAME}-rlp -n ${KUADRANT_GATEWAY_NS} -o=jsonpath='{.status.conditions[?(@.type=="Accepted")].message}{"\n"}{.status.conditions[?(@.type=="Enforced")].message}'
+$ oc get ratelimitpolicy ${KUADRANT_GATEWAY_NAME}-rlp -n ${KUADRANT_GATEWAY_NS} -o=jsonpath='{.status.conditions[?(@.type=="Accepted")].message}{"\n"}{.status.conditions[?(@.type=="Enforced")].message}'
 ----
 
 //TODO new module
@@ -194,7 +194,7 @@ $ kubectl get ratelimitpolicy ${KUADRANT_GATEWAY_NAME}-rlp -n ${KUADRANT_GATEWAY
 +
 [source,terminal]
 ----
-$ kubectl apply -f - <<EOF
+$ oc apply -f - <<EOF
 apiVersion: kuadrant.io/v1
 kind: DNSPolicy
 metadata:
@@ -224,7 +224,7 @@ The `DNSPolicy` uses the DNS Provider `Secret` that you defined earlier. The `ge
 +
 [source,terminal]
 ----
-$ kubectl get dnspolicy ${KUADRANT_GATEWAY_NAME}-dnspolicy -n ${KUADRANT_GATEWAY_NS} -o=jsonpath='{.status.conditions[?(@.type=="Accepted")].message}{"\n"}{.status.conditions[?(@.type=="Enforced")].message}'
+$ oc get dnspolicy ${KUADRANT_GATEWAY_NAME}-dnspolicy -n ${KUADRANT_GATEWAY_NS} -o=jsonpath='{.status.conditions[?(@.type=="Accepted")].message}{"\n"}{.status.conditions[?(@.type=="Enforced")].message}'
 ----
 +
 This might take a few minutes.
@@ -233,7 +233,7 @@ This might take a few minutes.
 +
 [source,terminal]
 ----
-$ kubectl get dnspolicy ${KUADRANT_GATEWAY_NAME}-dnspolicy -n ${KUADRANT_GATEWAY_NS} -
+$ oc get dnspolicy ${KUADRANT_GATEWAY_NAME}-dnspolicy -n ${KUADRANT_GATEWAY_NS} -
 ----
 +
 These health checks flag a published endpoint as healthy or unhealthy based on defined configuration. When unhealthy, an endpoint will not be published if it has not already been published to the DNS provider. An endpoint will only be unpublished if it is part of a multi-value A record, and in all cases can be observed in the DNSPolicy status.

--- a/modules/proc-set-up-dns-provider.adoc
+++ b/modules/proc-set-up-dns-provider.adoc
@@ -25,14 +25,14 @@ You must apply the following `Secret` resource to each cluster. If you are addin
 +
 [source,terminal]
 ----
-$ kubectl create ns ${KUADRANT_GATEWAY_NS}
+$ oc create ns ${KUADRANT_GATEWAY_NS}
 ----
 
 . Create the secret credentials in the same namespace as the Gateway as follows:
 +
 [source,terminal]
 ----
-$ kubectl -n ${KUADRANT_GATEWAY_NS} create secret generic aws-credentials \
+$ oc -n ${KUADRANT_GATEWAY_NS} create secret generic aws-credentials \
   --type=kuadrant.io/aws \
   --from-literal=AWS_ACCESS_KEY_ID=$KUADRANT_AWS_ACCESS_KEY_ID \
   --from-literal=AWS_SECRET_ACCESS_KEY=$KUADRANT_AWS_SECRET_ACCESS_KEY
@@ -42,7 +42,7 @@ $ kubectl -n ${KUADRANT_GATEWAY_NS} create secret generic aws-credentials \
 +
 [source,terminal]
 ----
-$ kubectl -n cert-manager create secret generic aws-credentials \
+$ oc -n cert-manager create secret generic aws-credentials \
   --type=kuadrant.io/aws \
   --from-literal=AWS_ACCESS_KEY_ID=$KUADRANT_AWS_ACCESS_KEY_ID \
   --from-literal=AWS_SECRET_ACCESS_KEY=$KUADRANT_AWS_SECRET_ACCESS_KEY

--- a/modules/proc-set-up-environment.adoc
+++ b/modules/proc-set-up-environment.adoc
@@ -51,12 +51,12 @@ If you know your environment variable values, you can set up the required YAML f
 +
 [source,terminal]
 ----
-$ kubectl create ns ${KUADRANT_DEVELOPER_NS}
+$ oc create ns ${KUADRANT_DEVELOPER_NS}
 ----
 
 . Deploy the Toystore app to the developer namespace:
 +
 [source,terminal]
 ----
-$ kubectl apply -f https://raw.githubusercontent.com/Kuadrant/Kuadrant-operator/main/examples/toystore/toystore.yaml -n ${KUADRANT_DEVELOPER_NS}
+$ oc apply -f https://raw.githubusercontent.com/Kuadrant/Kuadrant-operator/main/examples/toystore/toystore.yaml -n ${KUADRANT_DEVELOPER_NS}
 ----

--- a/modules/proc-set-up-tls-issuer.adoc
+++ b/modules/proc-set-up-tls-issuer.adoc
@@ -25,7 +25,7 @@ This example uses the Let's Encrypt TLS certificate issuer for simplicity, but y
 +
 [source,terminal]
 ----
-$ kubectl apply -f - <<EOF
+$ oc apply -f - <<EOF
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
@@ -39,5 +39,5 @@ EOF
 +
 [source,terminal]
 ----
-$ kubectl wait clusterissuer/${KUADRANT_CLUSTER_ISSUER_NAME} --for=condition=ready=true
+$ oc wait clusterissuer/${KUADRANT_CLUSTER_ISSUER_NAME} --for=condition=ready=true
 ----

--- a/modules/proc-use-coredns-multicluster.adoc
+++ b/modules/proc-use-coredns-multicluster.adoc
@@ -178,7 +178,7 @@ Replace `<node-name>` with the node you are testing on.
 [source,terminal]
 ----
 $ oc patch cm kuadrant-coredns -n kuadrant-coredns --type merge \
-   -p "$(kubectl get cm kuadrant-coredns -n kuadrant-coredns -o jsonpath='{.data.Corefile}' | \
+   -p "$(oc get cm kuadrant-coredns -n kuadrant-coredns -o jsonpath='{.data.Corefile}' | \
    sed 's/kuadrant/transfer {\n        to *\n    }\n    kuadrant/' | \
    jq -Rs '{data: {Corefile: .}}')"
 ----
@@ -208,7 +208,7 @@ In this example, `k.example` is the delegated zone and `ns1.k.example` is the pr
 [source,terminal]
 ----
 $ oc patch cm kuadrant-coredns -n kuadrant-coredns --type merge \
-   -p "$(kubectl get cm kuadrant-coredns -n kuadrant-coredns -o jsonpath='{.data.Corefile}' | \
+   -p "$(oc get cm kuadrant-coredns -n kuadrant-coredns -o jsonpath='{.data.Corefile}' | \
    sed '/transfer {/,/}/d' | \
    jq -Rs '{data: {Corefile: .}}')"
 ----

--- a/modules/proc-use-coredns-single-cluster.adoc
+++ b/modules/proc-use-coredns-single-cluster.adoc
@@ -30,7 +30,7 @@ In a single-cluster setup, ensure that the `endpoints` IP address value you use 
 +
 [source,terminal]
 ----
-$ export CTX_PRIMARY=$(kubectl config current-context) \
+$ export CTX_PRIMARY=$(oc config current-context) \
   export KUBECONFIG=~/.kube/config \
   export PRIMARY_CLUSTER_NAME=local-cluster \
   export ONPREM_DOMAIN=<onprem-domain> \


### PR DESCRIPTION
Version(s):
rhcl-docs-1.4
rhcl-docs-1.3
rhcl-docs-1.2

Issue:
[OSDOCS-18429](https://issues.redhat.com/browse/OSDOCS-18429)

Link to docs preview:
https://108004--ocpdocs-pr.netlify.app/rhcl/latest/deployment/coredns.html
https://108004--ocpdocs-pr.netlify.app/rhcl/latest/deployment/deployment.html
https://108004--ocpdocs-pr.netlify.app/rhcl/latest/install-guide/install-guide.html
https://108004--ocpdocs-pr.netlify.app/rhcl/latest/observability/observability.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
