### PR TITLE
OSDOCS-18567: KUEUE 1.3 Release Notes

### DIFF
--- a/ai_workloads/kueue/release-notes.adoc
+++ b/ai_workloads/kueue/release-notes.adoc
@@ -10,6 +10,8 @@ toc::[]
 
 include::modules/kueue-compatible-environments.adoc[leveloffset=+1]
 
+include::modules/kueue-release-notes-1.3.adoc[leveloffset=+1]
+
 include::modules/kueue-release-notes-1.2.adoc[leveloffset=+1]
 
 include::modules/kueue-release-notes-1.1.adoc[leveloffset=+1]

--- a/modules/kueue-release-notes-1.3.adoc
+++ b/modules/kueue-release-notes-1.3.adoc
@@ -1,0 +1,55 @@
+// Module included in the following assemblies:
+//
+// * ai_workloads/kueue/release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="release-notes-1.3_{context}"]
+= Release notes for {kueue-name} version 1.3
+
+[role="_abstract"]
+{kueue-name} version 1.3 is a generally available release that is supported on {product-title} versions 4.18 and later. {kueue-name} version 1.3 uses link:https://kueue.sigs.k8s.io/docs/overview/[Kueue] version 0.16.
+
+[id="release-notes-1.3-new-features_{context}"]
+== New features and enhancements
+
+// {lws-operator}::
+// {kueue-name} version 1.3 provides for the integration of the {lws-operator} with {kueue-name} so you can leverage the {kueue-name} scheduling and resource management functionality when running LeaderWorkerSets. 
+
+// {js-operator}::
+// {kueue-name} version 1.3 provides for the integration of the {js-operator} so you can use the {js-operator} to manage and run large-scale, coordinated workloads like high-performance computing (HPC) and AI training. 
+
+Upstream progression of the {kueue-name} API to `v1beta2`::
+{kueue-name} version 1.3 provides the `v1beta2` version of the {kueue-name} API. This update continues the evolution of the {kueue-name} APIs with the ultimate goal of graduating the API to `v1`. 
++
+All new Kueue objects created after the upgrade will be stored using the `v1beta2` version. The earlier version of the API, `v1beta1` is deprecated. Objects can still be created using `v1beta1`, if necessary. In these cases, a deprecation message is shown.
++
+However, existing objects are only auto-converted to the new storage version by Kubernetes during a write request. This means that {kueue-name} API objects that rarely receive updates such as Topologies, ResourceFlavors, or long-running Workloads could remain in the older `v1beta1` format indefinitely.
+
+[id="release-notes-1.3-fixed-issues_{context}"]
+== Fixed issues
+
+Reconcile jobs only in opt-in namespaces::
+{product-title} allowed reconciliation of `Job` resources that have the `kueue.x-k8s.io/queue-name` label, even if these resources are in namespaces that are not configured to opt in to being managed by {product-title}. With this release, there is ongoing upstream work that updates this behavior so that Jobs with queue-name labels are also ignored unless their namespace matches the `managedJobsNamespaceSelector`. This change makes {kueue-name} behavior consistent across all integrations.
++
+(link:https://issues.redhat.com/browse/OCPBUGS-58205[OCPBUGS-58205])
+
+`Kueue` CR description reads as "Not available" in the {product-title} web console:: 
+After installing {kueue-name}, in the *Operator details* view, the description for the `Kueue` CR read as "Not available". This issue did not affect or degrade the {kueue-name} Operator functionality. With this release, the "Not available" message no longer displays.
++
+(link:https://issues.redhat.com/browse/OCPBUGS-62185[OCPBUGS-62185])
+
+LeaderWorkerSet and Jobset validation errors::
+Currently, the {lws-operator} and {js-operator} are only validated after the Operand CR is updated and the full Kueue hierarchy (ResourceFlavor, ClusterQueue, and LocalQueue) is established. Any configuration errors appear only when applying a LeaderWorkerSet or JobSet template.
++
+(link:https://issues.redhat.com/browse/OCPBUGS-74210[OCPBUGS-74210])
+
+[id="release-notes-1.3-known-issues_{context}"]
+== Known issues
+
+LeaderWorkerSet pods update sequentially by default::
+If you have integrated {lws-operator} with your {kueue-name} installation and you are using the rollout strategy option for updating LeaderWorkerSet pods, be aware that the `MaxUnavailable` feature gate in {product-title} is disabled by default. 
++
+When any change is made to LeaderWorkerSet pods, a rolling update is triggered. This action gradually replaces the old pods of a deployment with new ones, keeping as many pods alive as possible to avoid downtime. If `MaxUnavailable` is disabled, which is the {product-title} default setting, the pods are updated one at a time.
++
+If you want to run updates in parallel instead of running them sequentially, `MaxUnavailable` feature gate must be enabled. For more information, see xref:../../nodes/clusters/nodes-cluster-enabling-features.adoc#nodes-cluster-enabling-features-install_nodes-cluster-enabling[Enabling feature sets at installation] and link:https://lws.sigs.k8s.io/docs/concepts/rollout-strategy/[Rollout Strategy]. 
+


### PR DESCRIPTION
KUEUE 1.3 Release Notes
Version(s): 4.21, 4.22

Issue: https://issues.redhat.com/browse/OSDOCS-17094

Link to docs preview: https://108005--ocpdocs-pr.netlify.app/openshift-enterprise/latest/ai_workloads/kueue/release-notes.html#release-notes-1.3_release-notes

Dev: @kannon92

QE review: @anahas-redhat