### PR TITLE
OSDOCS-18685: Fixing missed callout removal from cherry pick 

### DIFF
--- a/modules/microshift-get-rpm-release-info.adoc
+++ b/modules/microshift-get-rpm-release-info.adoc
@@ -55,7 +55,7 @@ Replace `_<release_version>_` with the numerical value of the release you are de
 [subs="+quotes"]
 [source,terminal]
 ----
-microshift-release-info-4.17.1.-202311101230.p0.g7dc6a00.assembly.4.17.1.el9.noarch.rpm # <1>
+microshift-release-info-4.17.1.-202311101230.p0.g7dc6a00.assembly.4.17.1.el9.noarch.rpm
 ----
 +
 Your output should contain the date and commit ID.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.16-4.18

Issue:
https://issues.redhat.com/browse/OSDOCS-17138
https://redhat.atlassian.net/browse/OSDOCS-18685

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
N/A

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->

Missed this line during a manual CP of #107081 (and to the 4.16 and 4.17 ones)

CPs:
- #107084
- #107083
- #107081