### PR TITLE
[OSDOCS-17084] Updates MS node configuration docs to resolve ADV errors

### DIFF
--- a/microshift_configuring/microshift-node-access-kubeconfig.adoc
+++ b/microshift_configuring/microshift-node-access-kubeconfig.adoc
@@ -7,7 +7,7 @@ include::_attributes/attributes-microshift.adoc[]
 toc::[]
 
 [role="_abstract"]
-`Kubeconfig` files supply the node details and authentication that CLI tools need to communicate with the API server in {product-title}. You can use them for local and remote node access and to generate additional configuration files.
+`Kubeconfig` files supply node details, IP addresses, and authentication so that CLI tools can communicate with the API server of a node. You can use them for local access, remote access, generating additional files, and opening firewall access when needed.
 
 include::modules/microshift-kubeconfig-overview.adoc[leveloffset=+1]
 

--- a/modules/microshift-kubeconfig-generating-additional-files.adoc
+++ b/modules/microshift-kubeconfig-generating-additional-files.adoc
@@ -7,7 +7,12 @@
 = Generating additional kubeconfig files for remote access
 
 [role="_abstract"]
-To use more host names or IP addresses than the default remote access file provides in {microshift-short}, you can generate additional `kubeconfig` files. Add entries to `apiServer.subjectAltNames` in the `config.yaml` file and restart the service so that the `kubeconfig` files are generated.
+To support more host names or IP addresses for remote access than the default file provides, you can generate additional `kubeconfig` files in {microshift-short}. Add the entries to `apiServer.subjectAltNames` in `config.yaml` and restart the service to create the files.
+
+[IMPORTANT]
+====
+You must restart {microshift-short} for configuration changes to be implemented.
+====
 
 .Prerequisites
 
@@ -51,11 +56,10 @@ apiServer:
 ----
 +
 where:
-+
---
-`node.hostnameOverride`:: Specifies the hostname of the node.
-`apiServer.subjectAltNames`:: Specifies the additional DNS names or IP address ranges to be used for authentication.
---
+
+`microshift-rhel9`:: Specifies the hostname of the node.
+`alt-name-1`:: Specifies the DNS name.
+`1.2.3.4`:: Specifies the IP address or range.
 
 . Restart {microshift-short} to apply configuration changes and auto-generate the `kubeconfig` files you need by running the following command:
 +
@@ -71,7 +75,7 @@ $ sudo systemctl restart microshift
 $ cat /var/lib/microshift/resources/kubeadmin/alt-name-1/kubeconfig
 ----
 
-. Choose the `kubeconfig` file to use that contains the SAN or IP address you want to use to connect your node. In this example, the `kubeconfig` containing `alt-name-1` in the `cluster.server` field is the correct file.
+. Choose the `kubeconfig` file to use that contains the SAN or IP address you want to use to connect your node. In this example, the `kubeconfig` containing `alt-name-1` in the `clusters.cluster.server` field is the correct file.
 +
 .Example contents of an additional `kubeconfig` file
 [source,yaml]
@@ -86,5 +90,5 @@ clusters:
 +
 [NOTE]
 ====
-All of these parameters are included as common names (CN) and subject alternative names (SAN) in the external serving certificates for the API server.
+All parameters are included as common names (CN) and subject alternative names (SAN) in the external serving certificates for the API server.
 ====

--- a/modules/microshift-kubeconfig-local-access.adoc
+++ b/modules/microshift-kubeconfig-local-access.adoc
@@ -7,14 +7,14 @@
 = Local access kubeconfig file
 
 [role="_abstract"]
-The local access `kubeconfig` file in {product-title} is written to `/var/lib/microshift/resources/kubeadmin/kubeconfig`. This `kubeconfig` file provides access to the API server by using `localhost`. Choose this file when you are connecting the node locally.
+The local access `kubeconfig` file in {product-title} is written to `/var/lib/microshift/resources/kubeadmin/kubeconfig`. This `kubeconfig` file provides access to the API server by using `localhost`. Use this file when you connect to the node locally.
 
 .Example contents of `kubeconfig` for local access
 [source,yaml]
 ----
 clusters:
 - cluster:
-    certificate-authority-data: <base64 CA>
+    certificate-authority-data: <base64_encoded_CA>
     server: https://localhost:6443
 ----
 

--- a/modules/microshift-kubeconfig-overview.adoc
+++ b/modules/microshift-kubeconfig-overview.adoc
@@ -6,7 +6,8 @@
 [id="kubeconfig-files-overview_{context}"]
 = Kubeconfig files for configuring node access
 
-The two categories of `kubeconfig` files used in {microshift-short} are local access and remote access. Every time {microshift-short} starts, a set of `kubeconfig` files for local and remote access to the API server are generated. These files are generated in the `/var/lib/microshift/resources/kubeadmin/` directory by using preexisting configuration information.
+[role="_abstract"]
+The two categories of `kubeconfig` files used in {microshift-short} are local access and remote access. Each time {microshift-short} starts, it generates a set of `kubeconfig` files for accessing the API server. These files are created in the `/var/lib/microshift/resources/kubeadmin/` directory by using existing configuration information.
 
 Each access type requires a different authentication certificate signed by different Certificate Authorities (CAs). The generation of multiple `kubeconfig` files accommodates this need.
 
@@ -21,15 +22,18 @@ A `kubeconfig` file must exist for the cluster to be accessible. The values are 
 [source,terminal]
 ----
 /var/lib/microshift/resources/kubeadmin/
-├── kubeconfig <1>
-├── alt-name-1 <2>
+├── kubeconfig
+├── alt-name-1
 │   └── kubeconfig
-├── 1.2.3.4 <3>
+├── 1.2.3.4
 │   └── kubeconfig
-└── microshift-rhel9 <4>
+└── microshift-rhel9
     └── kubeconfig
 ----
-<1> Local hostname. The main IP address of the host is always the default.
-<2> Subject Alternative Names for API server certificates.
-<3> DNS name.
-<4> {microshift-short} hostname.
+
+where:
+
+`kubeconfig`:: Specifies the local hostname. The main IP address of the host is always the default.
+`alt-name-1`:: Specifies the subject alternative name for the API server certificate.
+`1.2.3.4`:: Specifies the DNS name.
+`microshift-rhel9`:: Specifies the {microshift-short} hostname.

--- a/modules/microshift-kubeconfig-remote-con.adoc
+++ b/modules/microshift-kubeconfig-remote-con.adoc
@@ -6,9 +6,12 @@
 [id="remote-access-con_{context}"]
 = Remote access kubeconfig files
 
-When a {microshift-short} node connects to the API server from an external source, a certificate with all of the alternative names in the SAN field is used for validation. {microshift-short} generates a default `kubeconfig` for external access by using the `hostname` value. The defaults are set in the `<node.hostnameOverride>`, `<node.nodeIP>` and `api.<dns.baseDomain>` parameter values of the default `kubeconfig` file.
+[role="_abstract"]
+{microshift-short} generates a default `kubeconfig` file that enables external clients to connect securely to the API server. The configuration uses the node hostname and certificate validation based on Subject Alternative Name (SAN) entries.
 
-The `/var/lib/microshift/resources/kubeadmin/<hostname>/kubeconfig` file uses the `hostname` of the machine, or `node.hostnameOverride` if that option is set, to reach the API server. The CA of the `kubeconfig` file is able to validate certificates when accessed externally.
+When a {microshift-short} node connects to the API server from an external source, a certificate with all alternative names listed in the SAN field is used for validation. {microshift-short} generates a default `kubeconfig` for external access by using the hostname value. The defaults are set in the `<node.hostnameOverride>`, `<node.nodeIP>`, and `api.<dns.baseDomain>` parameter values of the default `kubeconfig` file.
+
+The `/var/lib/microshift/resources/kubeadmin/<hostname>/kubeconfig` file uses the hostname of the machine, or `node.hostnameOverride` if that option is set, to reach the API server. The CA in the `kubeconfig` file can validate certificates when the API server is accessed externally.
 
 .Example contents of a default `kubeconfig` file for remote access
 [source,yaml]
@@ -22,4 +25,5 @@ clusters:
 //line space was not showing on PV1 preview, so added extra blank line
 [id="remote-access-customization_{context}"]
 == Remote access customization
+
 Multiple remote access `kubeconfig` file values can be generated for accessing the node with different IP addresses or host names. An additional `kubeconfig` file generates for each entry in the `apiServer.subjectAltNames` parameter. You can copy remote access `kubeconfig` files from the host during times of IP connectivity and then use them to access the API server from other workstations.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.16+

Issue:
https://108012--ocpdocs-pr.netlify.app/microshift/latest/microshift_configuring/microshift-node-access-kubeconfig.html

Link to docs preview:
https://108012--ocpdocs-pr.netlify.app/microshift/latest/microshift_configuring/microshift-node-access-kubeconfig.html

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
