### PR TITLE
OSDOCS 18594 WMCO 10.20.1 Release Notes

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -2983,8 +2983,8 @@ Topics:
   Topics:
   - Name: Red Hat OpenShift support for Windows Containers release notes
     File: windows-containers-release-notes
-#  - Name: Past releases
-#    File: windows-containers-release-notes-past
+  - Name: Past releases
+    File: windows-containers-release-notes-past
   - Name: Windows Machine Config Operator prerequisites
     File: windows-containers-release-notes-prereqs
   - Name: Windows Machine Config Operator known limitations

--- a/modules/windows-containers-release-notes-10-20-0.adoc
+++ b/modules/windows-containers-release-notes-10-20-0.adoc
@@ -8,15 +8,15 @@
 
 Issued: 21 October 2025
 
+[role="_abstract"]
+You can review the following release notes to learn about the bug fixes provided in this release of the Windows Machine Config Operator (WMCO). 
+
 The components of the Red Hat Windows Machine Config Operator (WMCO) 10.20.0 were released in link:https://access.redhat.com/errata/RHBA-2025:18930[RHBA-2025:18930].
 
 [id="wmco-10-20-0-new-features"]
 == New features and improvements
 
-[id="wmco-10-20-0-new-features-kubernetes"]
-=== Kubernetes upgrade
-
-The WMCO now uses Kubernetes version 1.33.
+Kubernetes upgrade:: The WMCO now uses Kubernetes version 1.33.
 
 [id="wmco-10-20-0-bug-fixes"]
 == Bug fixes

--- a/modules/windows-containers-release-notes-10-20-1.adoc
+++ b/modules/windows-containers-release-notes-10-20-1.adoc
@@ -1,0 +1,19 @@
+// Module included in the following assemblies:
+//
+// * windows_containers/wmco_rn/windows-containers-release-notes.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="windows-containers-release-notes-10-20-1_{context}"]
+= Release notes for Red Hat Windows Machine Config Operator 10.20.1
+
+Issued: 12 March 2026
+
+[role="_abstract"]
+You can review the following release notes to learn about the bug fixes provided in this release of the Windows Machine Config Operator (WMCO). 
+
+The components of the Red Hat Windows Machine Config Operator (WMCO) 10.20.1 were released in link:https://access.redhat.com/errata/RHBA-2026:4527[RHBA-2026:4527].
+
+[id="wmco-10-20-1-bug-fixes_{context}"]
+== Bug fixes
+
+* Before this update, the `hybridOverlay` service was not using the trusted CA bundle when connecting to Kubernetes, because the `--k8s-cacert` option was missing from the service command. Because of this, users could encounter trust issues or failures when the `hybridOverlay` service attempted to communicate securely with Kubernetes clusters using custom or internal CAs. With this release, the `hybridOverlay` service command now includes the `--k8s-cacert flag` pointing to the trusted CA bundle. As a result, the `hybridOverlay` service uses the trusted CA bundle for secure communication, preventing trust issues and ensuring compatibility with the cluster. (link:https://issues.redhat.com/browse/OCPBUGS-65856[OCPBUGS-65856])

--- a/windows_containers/wmco_rn/windows-containers-release-notes-past.adoc
+++ b/windows_containers/wmco_rn/windows-containers-release-notes-past.adoc
@@ -6,20 +6,9 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-// Release notes for past versions; cut and paste current version to top of this file for next release
-The following release notes are for previous versions of the Windows Machine Config Operator (WMCO).
+[role="_abstract"]
+You can review the following release notes to learn about changes in previous versions of the Custom Metrics Autoscaler Operator.
 
 For the current version, see xref:../../windows_containers/wmco_rn/windows-containers-release-notes.adoc#windows-containers-release-notes[{productwinc} release notes].
 
-[id="wmco-10-x-x-past-release-notes"]
-== Release notes for Red Hat Windows Machine Config Operator 10.x.0
-
-This release of the WMCO provides bug fixes for running Windows compute nodes in an {product-title} cluster. The components of the WMCO 10.x.0 were released in
-
-[id="wmco-10-x-x-past-new-features"]
-=== New features and improvements
-
-[id="wmco-10-x-x-past-bug-fixes"]
-=== Bug fixes
-
-
+include::modules/windows-containers-release-notes-10-20-0.adoc[leveloffset=+1]

--- a/windows_containers/wmco_rn/windows-containers-release-notes.adoc
+++ b/windows_containers/wmco_rn/windows-containers-release-notes.adoc
@@ -6,6 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-This release of the Windows Machine Config Operator (WMCO) provides bug fixes for running Windows compute nodes in an {product-title} cluster. 
+[role="_abstract"]
+You can review the following release notes to learn about changes in the Windows Machine Config Operator (WMCO) version 10.20.1.
 
-include::modules/windows-containers-release-notes-10-20-0.adoc[leveloffset=+1]
+include::modules/windows-containers-release-notes-10-20-1.adoc[leveloffset=+1]


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-18594

[Release notes for Red Hat Windows Machine Config Operator 10.20.1](https://108017--ocpdocs-pr.netlify.app/openshift-enterprise/latest/windows_containers/wmco_rn/windows-containers-release-notes.html#windows-containers-release-notes-10-20-1_windows-containers-release-notes) -- New module. NEED TO ADD RELEASE DATE AND ERRATA LINK when available.
[Release notes for past releases of the Windows Machine Config Operator](https://108017--ocpdocs-pr.netlify.app/openshift-enterprise/latest/windows_containers/wmco_rn/windows-containers-release-notes-past) -- Unhid assembly. Made Vale changes.
[Release notes for Red Hat Windows Machine Config Operator 10.20.0](https://108017--ocpdocs-pr.netlify.app/openshift-enterprise/latest/windows_containers/wmco_rn/windows-containers-release-notes-past#windows-containers-release-notes-10-20-0_windows-containers-release-notes-past) -- Moved to Past Releases assembly. Made Vale changes (bumped some headings to description list). NO CHANGES TO TEXT.