### PR TITLE
OSDOCS#18593: Update OPP compatibility table and some pre-migration work to build

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -15,6 +15,8 @@
 :rh-storage-essentials-first: Red Hat OpenShift Data Foundation Essentials
 :rh-storage-data-foundation: Red Hat OpenShift Data Foundation
 :op-system-first: Red Hat Enterprise Linux CoreOS (RHCOS)
+:openshift-dev-spaces-productname: Red Hat OpenShift Dev Spaces
+:openshift-local-productname: Red Hat OpenShift Local
 :op-system: RHCOS
 :op-system-base: RHEL
 :op-system-base-full: Red Hat Enterprise Linux (RHEL)
@@ -38,32 +40,32 @@
 :olm-first: Operator Lifecycle Manager (OLM)
 :olm: OLM
 // These variable are the current product release versions for the OPP products
-:ocp-supported-version: 4.19
-:rhacs-version: 4.8
-:quay-version: 3.15
-:rhacm-version: 2.14
-:odf-version: 4.19
+:ocp-supported-version: 4.20
+:rhacs-version: 4.9
+:quay-version: 3.16
+:rhacm-version: 2.15
+:odf-version: 4.20
 // These variables are for the immediate past 4 OPP product versions that are in the compatibility table
-:ocp-supported-version-1: 4.18
-:rhacs-version-1: 4.7
-:quay-version-1: 3.14
-:rhacm-version-1: 2.13
-:odf-version-1: 4.18
-:ocp-supported-version-2: 4.17
-:rhacs-version-2: 4.6
-:quay-version-2: 3.13
-:rhacm-version-2: 2.12
-:odf-version-2: 4.17
-:ocp-supported-version-3: 4.16
-:rhacs-version-3: 4.5
-:quay-version-3: 3.12
-:rhacm-version-3: 2.11
-:odf-version-3: 4.16
-:ocp-supported-version-4: 4.15
-:rhacs-version-4: 4.4
-:quay-version-4: 3.11
-:rhacm-version-4: 2.10
-:odf-version-4: 4.15
+:ocp-supported-version-1: 4.19
+:rhacs-version-1: 4.8
+:quay-version-1: 3.15
+:rhacm-version-1: 2.14
+:odf-version-1: 4.19
+:ocp-supported-version-2: 4.18
+:rhacs-version-2: 4.7
+:quay-version-2: 3.14
+:rhacm-version-2: 2.13
+:odf-version-2: 4.18
+:ocp-supported-version-3: 4.17
+:rhacs-version-3: 4.6
+:quay-version-3: 3.13
+:rhacm-version-3: 2.12
+:odf-version-3: 4.17
+:ocp-supported-version-4: 4.16
+:rhacs-version-4: 4.5
+:quay-version-4: 3.12
+:rhacm-version-4: 2.11
+:odf-version-4: 4.16
 // Following variables are required for publishing using PV2
 :product-title: OpenShift Platform Plus
 :product-version: .1

--- a/architecture/opp-architecture.adoc
+++ b/architecture/opp-architecture.adoc
@@ -1,3 +1,4 @@
+:_mod-docs-content-type: ASSEMBLY
 [id="opp-architecture"]
 = {product-title} overview
 include::_attributes/common-attributes.adoc[]
@@ -5,7 +6,10 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-{product-title} is a single hybrid-cloud platform for enterprises. Use it to build, deploy, run, and manage intelligent applications securely for multiple infrastructures. It is based on {op-system-base-full}, Kubernetes, and Red Hat {ocp} and includes the following products:
+[role="_abstract"]
+{product-title} provides a hybrid-cloud platform to build, deploy, and manage applications consistently across multiple infrastructures. By integrating {op-system-base-full}, Kubernetes, and {ocp}, the platform enables you to streamline application lifecycles while maintaining security and scalability.
+
+The platform includes the following products:
 
 * {rh-rhacm} for Kubernetes - Controls clusters and applications from a single console.
 * {acs} for Kubernetes - Provides information about cluster security, visibility management, and security compliance.
@@ -14,13 +18,16 @@ toc::[]
 
 
 include::modules/opp-architecture-architecture.adoc[leveloffset=+1]
+
 include::modules/opp-architecture-installation.adoc[leveloffset=+1]
-[role="_additional-resources"]
-.Additional resources
-* link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.15/html/installing/installing-preparing#supported-installation-methods-for-different-platforms[Supported installation methods for different platforms]
-* link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.10/html/install/installing[Installing {rh-rhacm}]
 
 include::modules/opp-architecture-installing-policyset.adoc[leveloffset=+2]
+[role="_additional-resources"]
+.Additional resources
+* link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.8/html/governance/governance#deploying-policies-using-gitops[Deploying policies using gitops]
+
 include::modules/opp-architecture-relnotes.adoc[leveloffset=+1]
+
 include::modules/opp-architecture-compatibility-matrix.adoc[leveloffset=+1]
+
 include::modules/opp-architecture-support.adoc[leveloffset=+1]

--- a/modules/opp-architecture-architecture.adoc
+++ b/modules/opp-architecture-architecture.adoc
@@ -2,20 +2,21 @@
 //
 // * architecture/opp-architecture.adoc
 
-:_mod-docs-content-type: CONCEPT
+:_mod-docs-content-type: REFERENCE
 [id="opp-architecture-architecture_{context}"]
 = {product-title} description and architecture
 
-{product-title} builds on the capabilities of {ocp} with the following features:
+[role="_abstract"]
+{product-title} provides a consistent management and security framework for applications across hybrid-cloud environments. By using these tools, you can maintain visibility and control over your application lifecycle while ensuring that workloads remain secure and compliant on any infrastructure.
+
+{product-title} adds the following features to {ocp}:
 
 * Multi-cluster security
 * Complete management capabilities
 * Integrated data management
 * A global container registry
 
-{product-title} protects and manages applications for open hybrid cloud environments and application lifecycles.
-
-{product-title} supports these additional capabilities:
+{product-title} includes the following additional capabilities:
 
 * Platform services
 ** Service mesh, serverless
@@ -42,5 +43,5 @@
 * Developer services
 ** Developer CLI/IDE
 ** Plug-ins and extensions
-** Red Hat OpenShift Dev Spaces
-** Red Hat OpenShift Local
+** {openshift-dev-spaces-productname}
+** {openshift-local-productname}

--- a/modules/opp-architecture-compatibility-matrix.adoc
+++ b/modules/opp-architecture-compatibility-matrix.adoc
@@ -2,15 +2,16 @@
 //
 // * architecture/opp-architecture.adoc
 
-:_mod-docs-content-type: CONCEPT
+:_mod-docs-content-type: REFERENCE
 [id="opp-architecture-compatibility-matrix_{context}"]
 = {product-title} product release compatibility matrix
 
-{product-title} product releases are based on the latest verified {ocp} release. The verified release number for each {product-title} product is listed in this section. See link:https://access.redhat.com/support/policy/updates/openshift_operators[OpenShift Operator Life Cycles] for detailed information about additional supported versions. 
+[role="_abstract"]
+Verify that your {product-title} and {ocp} versions are compatible to ensure optimal performance and environment stability. This release mapping identifies supported configurations and helps you plan a successful installation or upgrade.
 
 [NOTE]
 ====
-This table is updated after each product release is tested and verified with the latest {ocp} release. Use the versions in the matrix for the optimal performance.
+This matrix lists the specific {ocp}-based combinations that maintain platform performance and lifecycle support. Use these versions to ensure a supported and stable configuration.
 ====
 
 .Verified product versions

--- a/modules/opp-architecture-installation.adoc
+++ b/modules/opp-architecture-installation.adoc
@@ -2,10 +2,16 @@
 //
 // * architecture/opp-architecture.adoc
 
-:_mod-docs-content-type: CONCEPT
+:_mod-docs-content-type: REFERENCE
 [id="opp-architecture-installation_{context}"]
 = Install {product-title} products
 
-To install {product-title}, you must install {ocp} followed by {rh-rhacm}. Install the additional products by applying the {rh-rhacm} policy sets: {quay}, {rh-storage-essentials-first}, and {acs}. 
+[role="_abstract"]
+To install {product-title}, you must first install {ocp} and then {rh-rhacm}. After these products are installed, you must apply the {rh-rhacm} policy sets to install {quay}, {rh-storage-essentials-first}, and {acs}. 
 
-See the link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.8/html/governance/governance#opp-policy-set[Red Hat OpenShift Platform Plus policy set] for detailed information about installing the products.    
+See the Red{nbsp}Hat {product-title} policy set for detailed information about installing the products. 
+
+* link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.8/html/governance/governance#opp-policy-set[Red{nbsp}Hat {product-title} policy set]
+* link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.21/html-single/installation_overview/index#supported-installation-methods-for-different-platforms[Supported installation methods for different platforms]
+* link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.10/html/install/installing[Installing {rh-rhacm}]
+* link:https://access.redhat.com/support/policy/updates/openshift_operators[OpenShift Operator Life Cycles]

--- a/modules/opp-architecture-installing-policyset.adoc
+++ b/modules/opp-architecture-installing-policyset.adoc
@@ -7,16 +7,13 @@
 
 = Installing {product-title} by using policy sets
 
-The {ocp} installation uses two policy sets to install additional products.
+[role="_abstract"]
+{ocp} uses specific policy sets to automate the installation of additional products and services. These policies ensure that your environment remains compliant and secure while you extend the platform's capabilities across your infrastructure.
 
-[NOTE]
-====
-Edit the `policyGenerator.yaml` file to remove any products that you do not want to install. You can delete the product entries or comment out the lines.
-====
+To install the policy sets using gitops, follow the steps in "Deploying policies using gitops". Use the actual path to the policy set instead of the path in the example path `policygenerator/policy-sets/stable/openshift-plus`. Otherwise, use the following procedure to install the policy sets by using CLI.
 
-To install the policy sets using gitops, follow the steps in link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.8/html/governance/governance#deploying-policies-using-gitops[Deploying policies using gitops]. Use the actual path to the policy set instead of the path in the example path `policygenerator/policy-sets/stable/openshift-plus`.
-
-Use the following procedure to install the policy sets by using CLI:
+.Prerequisites
+ * Edit the `policyGenerator.yaml` file to remove any products that you do not want to install. You can delete the product entries or comment out the lines.
 
 .Procedure
 . Install the `PolicyGenerator` plugin by following the instructions in _Installing and using the PolicyGenerator Kustomize plug-in_.

--- a/modules/opp-architecture-relnotes.adoc
+++ b/modules/opp-architecture-relnotes.adoc
@@ -2,14 +2,15 @@
 //
 // * architecture/opp-architecture.adoc
 
-:_mod-docs-content-type: CONCEPT
+:_mod-docs-content-type: REFERENCE
 [id="opp-architecture-relnotes_{context}"]
 = {product-title} product release notes
 
-The release note information for each product is accessible from the following list:
+[role="_abstract"]
+Learn about new features, known issues, and fixed bugs in the latest {product-title} release. This information helps you plan your upgrade and understand how changes to the platform affect your existing environment.
 
-* link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.15/html/release_notes/ocp-4-15-release-notes[{ocp}]
-* link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.10/html/release_notes/release-notes[{rh-rhacm} for Kubernetes]
-* link:https://access.redhat.com/documentation/en-us/red_hat_quay/3.11/html/red_hat_quay_release_notes/release-notes-311[{quay} Release Notes]
-* link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_security_for_kubernetes/4.4/html/release_notes/release-notes-44[{acs} for Kubernetes 4.4]
-* link:https://access.redhat.com/documentation/en-us/red_hat_openshift_data_foundation/4.15/html/4.15_release_notes/index[{rh-storage-data-foundation}]
+* link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.21/html/release_notes/ocp-4-21-release-notes[{ocp}]
+* link:https://https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.15/html/release_notes/acm-release-notes[Release notes for {rh-rhacm}]
+* link:https://https://docs.redhat.com/en/documentation/red_hat_quay/3.16/html/red_hat_quay_release_notes/release-notes-316[{quay} Release Notes]
+* link:https://https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_security_for_kubernetes/4.9/html/release_notes/release-notes-49[{acs} for Kubernetes 4.9]
+* link:https://https://docs.redhat.com/en/documentation/red_hat_openshift_data_foundation/4.20/html/4.20_release_notes/index[{rh-storage-data-foundation}]

--- a/modules/opp-architecture-support.adoc
+++ b/modules/opp-architecture-support.adoc
@@ -2,10 +2,11 @@
 //
 // * architecture/opp-architecture.adoc
 
-:_mod-docs-content-type: CONCEPT
+:_mod-docs-content-type: REFERENCE
 [id="opp-architecture-support_{context}"]
 = Get support for {product-title}
 
-Red Hat offers cluster administrator tools for gathering data, monitoring, and troubleshooting your cluster.
+[role="_abstract"]
+Use Red{nbsp}Hat cluster administrator tools to monitor environment health, collect diagnostic data, and troubleshoot issues. If you cannot resolve an issue independently, you must open a support case through the Red{nbsp}Hat Customer Portal to receive assistance covered by your subscription.
 
-If you need help with your {product-title} solution, log a case in the appropriate product by using its subscription name. See the link:https://access.redhat.com/support/cases/#/case/list?query=%20orderBy%20lastModifiedDate%20desc&p=1&size=10&searchType=basic[Red Hat customer support portal] to open a support case.
+* link:https://access.redhat.com/support/cases/#/case/list?query=%20orderBy%20lastModifiedDate%20desc&p=1&size=10&searchType=basic[Red{nbsp}Hat Customer Portal]


### PR DESCRIPTION
Version(s):
This PR is based on the ‘opp-docs-main’ repo and when merged, it should be in that branch only. The OPP doc is not versioned. Add this PR to the ‘Continuous Release’ milestone.

Issue:
[OSDOCS-18593](https://issues.redhat.com/browse/OSDOCS-18593)

Link to docs preview:
[Architecture](https://108018--ocpdocs-pr.netlify.app/openshift-opp/latest/architecture/opp-architecture)

QE review:
- [ x] QE has approved this change.

Additional information:
The OPP docs set has not yet gone through the official CQA process. However, some changes were made to ensure the build completed. For example:

- Add `[role"=_abstract"]
- Remove links from modules
- Revise short descriptions

All suggestions will be completed in a separate PR so we can get the compatibility matrix updated asap. This is ACKed by the team.