### PR TITLE
DITA rework and rewrite for ztp-talm-updating-managed-policies-pg

### DIFF
--- a/edge_computing/policygenerator_for_ztp/ztp-talm-updating-managed-policies-pg.adoc
+++ b/edge_computing/policygenerator_for_ztp/ztp-talm-updating-managed-policies-pg.adoc
@@ -18,29 +18,29 @@ include::modules/cnf-topology-aware-lifecycle-manager-preparing-for-updates.adoc
 [role="_additional-resources"]
 .Additional resources
 
-* For more information about how to update {ztp-first}, see xref:../../edge_computing/ztp-updating-gitops.adoc#ztp-updating-gitops[Upgrading {ztp}].
+* xref:../../edge_computing/ztp-updating-gitops.adoc#ztp-updating-gitops[Upgrading {ztp}]
 
-* For more information about how to mirror an {product-title} image repository, see xref:../../disconnected/installing-mirroring-installation-images.adoc#installation-mirror-repository_installing-mirroring-installation-images[Mirroring the {product-title} image repository].
+* xref:../../disconnected/installing-mirroring-installation-images.adoc#installation-mirror-repository_installing-mirroring-installation-images[Mirroring the {product-title} image repository]
 
-* For more information about how to mirror Operator catalogs for disconnected clusters, see xref:../../disconnected/installing-mirroring-installation-images.adoc#olm-mirror-catalog_installing-mirroring-installation-images[Mirroring Operator catalogs for use with disconnected clusters].
+* xref:../../disconnected/installing-mirroring-installation-images.adoc#olm-mirror-catalog_installing-mirroring-installation-images[Mirroring Operator catalogs for use with disconnected clusters]
 
-* For more information about how to prepare the disconnected environment and mirroring the desired image repository, see xref:../../edge_computing/ztp-preparing-the-hub-cluster.adoc#ztp-preparing-the-hub-cluster[Preparing the disconnected environment].
+* xref:../../edge_computing/ztp-preparing-the-hub-cluster.adoc#ztp-preparing-the-hub-cluster[Preparing the disconnected environment]
 
-* For more information about update channels and releases, see xref:../../updating/understanding_updates/understanding-update-channels-release.adoc#understanding-update-channels-releases[Understanding update channels and releases].
+* xref:../../updating/understanding_updates/understanding-update-channels-release.adoc#understanding-update-channels-releases[Understanding update channels and releases]
 
 include::modules/cnf-topology-aware-lifecycle-manager-platform-update.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources
 
-* For more information about mirroring the images in a disconnected environment, see xref:../../edge_computing/ztp-preparing-the-hub-cluster.adoc#ztp-acm-adding-images-to-mirror-registry_ztp-preparing-the-hub-cluster[Preparing the disconnected environment].
+* xref:../../edge_computing/ztp-preparing-the-hub-cluster.adoc#ztp-acm-adding-images-to-mirror-registry_ztp-preparing-the-hub-cluster[Preparing the disconnected environment]
 
 include::modules/cnf-topology-aware-lifecycle-manager-operator-update.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources
 
-* For more information about updating {ztp}, see xref:../../edge_computing/ztp-updating-gitops.adoc#ztp-updating-gitops[Upgrading {ztp}].
+* xref:../../edge_computing/ztp-updating-gitops.adoc#ztp-updating-gitops[Upgrading {ztp}]
 
 include::modules/cnf-topology-aware-lifecycle-manager-operator-troubleshooting.adoc[leveloffset=+1]
 
@@ -55,7 +55,7 @@ include::modules/cnf-topology-aware-lifecycle-manager-creating-custom-resources.
 [role="_additional-resources"]
 .Additional resources
 
-* For more information about the {cgu-operator} precaching workflow, see xref:../../edge_computing/cnf-talm-for-cluster-upgrades.adoc#talo-precache-feature-concept_cnf-topology-aware-lifecycle-manager[Using the container image precache feature].
+* xref:../../edge_computing/cnf-talm-for-cluster-upgrades.adoc#talo-precache-feature-concept_cnf-topology-aware-lifecycle-manager[Using the container image precache feature]
 
 include::modules/cnf-topology-aware-lifecycle-manager-autocreate-cgu-cr-ztp.adoc[leveloffset=+1]
 

--- a/modules/cnf-topology-aware-lifecycle-manager-autocreate-cgu-cr-ztp.adoc
+++ b/modules/cnf-topology-aware-lifecycle-manager-autocreate-cgu-cr-ztp.adoc
@@ -2,17 +2,17 @@
 //
 // * scalability_and_performance/ztp_far_edge/ztp-talm-updating-managed-policies.adoc
 
-:_mod-docs-content-type: PROCEDURE
+:_mod-docs-content-type: CONCEPT
 [id="talo-precache-autocreated-cgu-for-ztp_{context}"]
 = About the auto-created ClusterGroupUpgrade CR for {ztp}
 
+[role="_abstract"]
 {cgu-operator} has a controller called `ManagedClusterForCGU` that monitors the `Ready` state of the `ManagedCluster` CRs on the hub cluster and creates the `ClusterGroupUpgrade` CRs for {ztp-first}.
 
 For any managed cluster in the `Ready` state without a `ztp-done` label applied, the `ManagedClusterForCGU` controller automatically creates a `ClusterGroupUpgrade` CR in the `ztp-install` namespace with its associated {rh-rhacm} policies that are created during the {ztp} process. {cgu-operator} then remediates the set of configuration policies that are listed in the auto-created `ClusterGroupUpgrade` CR to push the configuration CRs to the managed cluster.
 
 If there are no policies for the managed cluster at the time when the cluster becomes `Ready`, a `ClusterGroupUpgrade` CR with no policies is created. Upon completion of the `ClusterGroupUpgrade` the managed cluster is labeled as `ztp-done`. If there are policies that you want to apply for that managed cluster, manually create a `ClusterGroupUpgrade` as a day-2 operation.
 
-.Example of an auto-created `ClusterGroupUpgrade` CR for {ztp}
 
 [source,yaml]
 ----
@@ -35,13 +35,13 @@ spec:
   actions:
     afterCompletion:
       addClusterLabels:
-        ztp-done: "" <1>
+        ztp-done: ""
       deleteClusterLabels:
         ztp-running: ""
       deleteObjects: true
     beforeEnable:
       addClusterLabels:
-        ztp-running: "" <2>
+        ztp-running: ""
   clusters:
   - spoke1
   enable: true
@@ -56,5 +56,7 @@ spec:
     maxConcurrency: 1
     timeout: 240
 ----
-<1> Applied to the managed cluster when {cgu-operator} completes the cluster configuration.
-<2> Applied to the managed cluster when {cgu-operator} starts deploying the configuration policies.
+
+- `spec.actions.afterCompletion.addClusterLabels.ztp-done` applied to the managed cluster when {cgu-operator} completes the cluster configuration.
+- `spec.actions.beforeEnable.addClusterLabels.ztp-running` applied to the managed cluster when {cgu-operator} starts deploying the configuration policies.
+

--- a/modules/cnf-topology-aware-lifecycle-manager-creating-custom-resources.adoc
+++ b/modules/cnf-topology-aware-lifecycle-manager-creating-custom-resources.adoc
@@ -6,7 +6,10 @@
 [id="talm-prechache-user-specified-images-preparing-crs_{context}"]
 = Creating the custom resources for pre-caching
 
+[role="_abstract"]
 You must create the `PreCachingConfig` CR before or concurrently with the `ClusterGroupUpgrade` CR.
+
+.Procedure
 
 . Create the `PreCachingConfig` CR with the list of additional images you want to pre-cache.
 +
@@ -16,17 +19,19 @@ apiVersion: ran.openshift.io/v1alpha1
 kind: PreCachingConfig
 metadata:
   name: exampleconfig
-  namespace: default <1>
+  namespace: default
 spec:
 [...]
-  spaceRequired: 30Gi <2>
+  spaceRequired: 30Gi
   additionalImages:
     - quay.io/exampleconfig/application1@sha256:3d5800990dee7cd4727d3fe238a97e2d2976d3808fc925ada29c559a47e2e1ef
     - quay.io/exampleconfig/application2@sha256:3d5800123dee7cd4727d3fe238a97e2d2976d3808fc925ada29c559a47adfaef
     - quay.io/exampleconfig/applicationN@sha256:4fe1334adfafadsf987123adfffdaf1243340adfafdedga0991234afdadfsa09
 ----
-<1> The `namespace` must be accessible to the hub cluster.
-<2> It is recommended to set the minimum disk space required field to ensure that there is sufficient storage space for the pre-cached images.
+
+- `metadata.namespace` the `namespace` must be accessible to the hub cluster.
+- `spec.spaceRequired` it is recommended to set the minimum disk space required field to ensure that there is sufficient storage space for the pre-cached images.
+
 
 . Create a `ClusterGroupUpgrade` CR with the `preCaching` field set to `true` and specify the `PreCachingConfig` CR created in the previous step:
 +
@@ -66,10 +71,13 @@ Once you install the images on the cluster, you cannot change or delete them.
 ----
 $ oc apply -f cgu.yaml
 ----
++
 
 {cgu-operator} verifies the `ClusterGroupUpgrade` CR.
++
 
 From this point, you can continue with the {cgu-operator} pre-caching workflow.
++
 
 [NOTE]
 ====
@@ -86,7 +94,7 @@ $ oc get cgu <cgu_name> -n <cgu_namespace> -oyaml
 ----
 
 +
-.Example output
+Example output:
 [source,yaml]
 ----
   precaching:
@@ -116,7 +124,7 @@ The pre-caching configurations are validated by checking if the managed policies
 Valid configurations of the `ClusterGroupUpgrade` and the `PreCachingConfig` CRs result in the following statuses:
 
 +
-.Example output of valid CRs
+Example output of valid CRs:
 [source,yaml]
 ----
 - lastTransitionTime: "2023-01-01T00:00:01Z"
@@ -142,7 +150,7 @@ Valid configurations of the `ClusterGroupUpgrade` and the `PreCachingConfig` CRs
 ----
 
 +
-.Example of an invalid PreCachingConfig CR
+Example of an invalid PreCachingConfig CR:
 [source,yaml]
 ----
 Type:    "PrecacheSpecValid"
@@ -159,7 +167,7 @@ $ oc get jobs -n openshift-talo-pre-cache
 ----
 
 +
-.Example of pre-caching job in progress
+Example of pre-caching job in progress:
 [source,terminal]
 ----
 NAME        COMPLETIONS       DURATION      AGE
@@ -174,7 +182,7 @@ $ oc describe pod pre-cache -n openshift-talo-pre-cache
 ----
 
 +
-.Example of pre-caching job in progress
+Example of pre-caching job in progress:
 [source,terminal]
 ----
 Type        Reason              Age    From              Message
@@ -196,7 +204,7 @@ $ oc describe pod pre-cache -n openshift-talo-pre-cache
 ----
 
 +
-.Example of completed pre-cache job
+Example of completed pre-cache job:
 [source,terminal]
 ----
 Type        Reason              Age    From              Message

--- a/modules/cnf-topology-aware-lifecycle-manager-operator-and-platform-update.adoc
+++ b/modules/cnf-topology-aware-lifecycle-manager-operator-and-platform-update.adoc
@@ -6,6 +6,7 @@
 [id="talo-operator-and-platform-update_{context}"]
 = Performing a platform and an Operator update together
 
+[role="_abstract"]
 You can perform a platform and an Operator update at the same time.
 
 .Prerequisites
@@ -68,9 +69,9 @@ metadata:
   namespace: default
 spec:
   managedPolicies:
-  - du-upgrade-platform-upgrade <1>
-  - du-upgrade-operator-catsrc-policy <2>
-  - common-subscriptions-policy <3>
+  - du-upgrade-platform-upgrade
+  - du-upgrade-operator-catsrc-policy
+  - common-subscriptions-policy
   preCaching: true
   clusterSelector:
   - group-du-sno
@@ -78,9 +79,11 @@ spec:
     maxConcurrency: 1
   enable: false
 ----
-<1> This is the platform update policy.
-<2> This is the policy containing the catalog source information for the Operators to be updated. It is needed for the pre-caching feature to determine which Operator images to download to the managed cluster.
-<3> This is the policy to update the Operators.
+
+- `spec` this is the platform update policy.
+- `spec` this is the policy containing the catalog source information for the Operators to be updated. It is needed for the pre-caching feature to determine which Operator images to download to the managed cluster.
+- `spec` this is the policy to update the Operators.
+
 
 .. Apply the `cgu-platform-operator-upgrade.yml` file to the hub cluster by running the following command:
 +

--- a/modules/cnf-topology-aware-lifecycle-manager-operator-troubleshooting.adoc
+++ b/modules/cnf-topology-aware-lifecycle-manager-operator-troubleshooting.adoc
@@ -6,6 +6,7 @@
 [id="cnf-topology-aware-lifecycle-manager-operator-troubleshooting-{policy-gen-cr}_{context}"]
 = Troubleshooting missed Operator updates with {policy-gen-cr} CRs
 
+[role="_abstract"]
 In some scenarios, {cgu-operator-first} might miss Operator updates due to an out-of-date policy compliance state.
 
 After a catalog source update, it takes time for the Operator Lifecycle Manager (OLM) to update the subscription status. The status of the subscription policy might continue to show as compliant while {cgu-operator} decides whether remediation is needed. As a result, the Operator specified in the subscription policy does not get upgraded.
@@ -34,7 +35,9 @@ metadata:
   namespace: operator-namspace
 # ...
 spec:
-  source: redhat-operators-disconnected-v2 <1>
+  source: redhat-operators-disconnected-v2
 # ...
 ----
-<1> Enter the name of the additional catalog source configuration that you defined in the `{policy-gen-cr}` resource.
++
+
+Enter the name of the additional catalog source configuration that you defined in the `{policy-gen-cr}` resource.

--- a/modules/cnf-topology-aware-lifecycle-manager-operator-update.adoc
+++ b/modules/cnf-topology-aware-lifecycle-manager-operator-update.adoc
@@ -6,6 +6,7 @@
 [id="talo-operator-update-{policy-gen-cr}_{context}"]
 = Performing an Operator update with {policy-gen-cr} CRs
 
+[role="_abstract"]
 You can perform an Operator update with the {cgu-operator}.
 
 .Prerequisites
@@ -113,8 +114,8 @@ metadata:
   namespace: default
 spec:
   managedPolicies:
-  - du-upgrade-operator-catsrc-policy <1>
-  - common-subscriptions-policy <2>
+  - du-upgrade-operator-catsrc-policy
+  - common-subscriptions-policy
   preCaching: false
   clusters:
   - spoke1
@@ -122,8 +123,10 @@ spec:
     maxConcurrency: 1
   enable: false
 ----
-<1> The policy is needed by the image pre-caching feature to retrieve the operator images from the catalog source.
-<2> The policy contains Operator subscriptions. If you have followed the structure and content of the reference `PolicyGenTemplates`, all Operator subscriptions are grouped into the `common-subscriptions-policy` policy.
+
+- `spec` the policy is needed by the image pre-caching feature to retrieve the operator images from the catalog source.
+- `spec` the policy contains Operator subscriptions. If you have followed the structure and content of the reference `PolicyGenTemplates`, all Operator subscriptions are grouped into the `common-subscriptions-policy` policy.
+
 +
 [NOTE]
 ====
@@ -146,7 +149,7 @@ $ oc apply -f cgu-operator-upgrade.yml
 $ oc get policy common-subscriptions-policy -n <policy_namespace>
 ----
 +
-.Example output
+Example output:
 +
 [source,terminal]
 ----
@@ -176,7 +179,7 @@ $ oc get cgu cgu-operator-upgrade -o jsonpath='{.status.precaching.status}'
 $ oc get cgu -n default cgu-operator-upgrade -ojsonpath='{.status.conditions}' | jq
 ----
 +
-.Example output
+Example output:
 +
 [source,json]
 ----

--- a/modules/cnf-topology-aware-lifecycle-manager-pao-update.adoc
+++ b/modules/cnf-topology-aware-lifecycle-manager-pao-update.adoc
@@ -6,6 +6,7 @@
 [id="talm-pao-update-{policy-gen-cr}_{context}"]
 = Removing Performance Addon Operator subscriptions from deployed clusters with {policy-gen-cr} CRs
 
+[role="_abstract"]
 In earlier versions of {product-title}, the Performance Addon Operator provided automatic, low latency performance tuning for applications. In {product-title} 4.11 or later, these functions are part of the Node Tuning Operator.
 
 Do not install the Performance Addon Operator on clusters running {product-title} 4.11 or later. If you upgrade to {product-title} 4.11 or later, the Node Tuning Operator automatically removes the Performance Addon Operator.

--- a/modules/cnf-topology-aware-lifecycle-manager-platform-update.adoc
+++ b/modules/cnf-topology-aware-lifecycle-manager-platform-update.adoc
@@ -6,6 +6,7 @@
 [id="talo-platform-update-{policy-gen-cr}_{context}"]
 = Performing a platform update with {policy-gen-cr} CRs
 
+[role="_abstract"]
 You can perform a platform update with the {cgu-operator}.
 
 .Prerequisites
@@ -24,7 +25,6 @@ You can perform a platform update with the {cgu-operator}.
 .. Save the following `{policy-gen-cr}` CR in the `du-upgrade.yaml` file:
 +
 --
-.Example of `{policy-gen-cr}` for platform update
 ifeval::["{policy-gen-cr}" == "PolicyGenTemplate"]
 include::snippets/pgt-cnf-topology-aware-lifecycle-manager-platform-update.adoc[]
 endif::[]

--- a/modules/cnf-topology-aware-lifecycle-manager-precache-user-spec-images.adoc
+++ b/modules/cnf-topology-aware-lifecycle-manager-precache-user-spec-images.adoc
@@ -6,6 +6,7 @@
 [id="talm-prechache-user-specified-images-concept_{context}"]
 = Pre-caching user-specified images with {cgu-operator} on {sno} clusters
 
+[role="_abstract"]
 You can pre-cache application-specific workload images on {sno} clusters before upgrading your applications.
 
 You can specify the configuration options for the pre-caching jobs using the following custom resources (CR):
@@ -18,7 +19,8 @@ You can specify the configuration options for the pre-caching jobs using the fol
 All fields in the `PreCachingConfig` CR are optional.
 ====
 
-.Example PreCachingConfig CR
+Example PreCachingConfig CR:
++
 [source,yaml]
 ----
 apiVersion: ran.openshift.io/v1alpha1
@@ -27,7 +29,7 @@ metadata:
   name: exampleconfig
   namespace: exampleconfig-ns
 spec:
-  overrides: <1>
+  overrides:
     platformImage: quay.io/openshift-release-dev/ocp-release@sha256:3d5800990dee7cd4727d3fe238a97e2d2976d3808fc925ada29c559a47e2e1ef
     operatorsIndexes:
       - registry.example.com:5000/custom-redhat-operators:1.0.0
@@ -35,21 +37,24 @@ spec:
       - local-storage-operator: stable
       - ptp-operator: stable
       - sriov-network-operator: stable
-  spaceRequired: 30 Gi <2>
-  excludePrecachePatterns: <3>
+  spaceRequired: 30 Gi
+  excludePrecachePatterns:
     - aws
     - vsphere
-  additionalImages: <4>
+  additionalImages:
     - quay.io/exampleconfig/application1@sha256:3d5800990dee7cd4727d3fe238a97e2d2976d3808fc925ada29c559a47e2e1ef
     - quay.io/exampleconfig/application2@sha256:3d5800123dee7cd4727d3fe238a97e2d2976d3808fc925ada29c559a47adfaef
     - quay.io/exampleconfig/applicationN@sha256:4fe1334adfafadsf987123adfffdaf1243340adfafdedga0991234afdadfsa09
 ----
-<1>  By default, {cgu-operator} automatically populates the `platformImage`, `operatorsIndexes`, and the `operatorsPackagesAndChannels` fields from the policies of the managed clusters. You can specify values to override the default {cgu-operator}-derived values for these fields.
-<2> Specifies the minimum required disk space on the cluster. If unspecified, {cgu-operator} defines a default value for {product-title} images. The disk space field must include an integer value and the storage unit. For example: `40 GiB`, `200 MB`, `1 TiB`.
-<3> Specifies the images to exclude from pre-caching based on image name matching.
-<4> Specifies the list of additional images to pre-cache.
 
-.Example ClusterGroupUpgrade CR with PreCachingConfig CR reference
+- `spec.overrides` by default, {cgu-operator} automatically populates the `platformImage`, `operatorsIndexes`, and the `operatorsPackagesAndChannels` fields from the policies of the managed clusters. You can specify values to override the default {cgu-operator}-derived values for these fields.
+- `spec.spaceRequired` specifies the minimum required disk space on the cluster. If unspecified, {cgu-operator} defines a default value for {product-title} images. The disk space field must include an integer value and the storage unit. For example: `40 GiB`, `200 MB`, `1 TiB`.
+- `spec.excludePrecachePatterns` specifies the images to exclude from pre-caching based on image name matching.
+- `spec.additionalImages` specifies the list of additional images to pre-cache.
+
+
+Example ClusterGroupUpgrade CR with PreCachingConfig CR reference:
++
 [source,yaml]
 ----
 apiVersion: ran.openshift.io/v1alpha1
@@ -57,11 +62,13 @@ kind: ClusterGroupUpgrade
 metadata:
   name: cgu
 spec:
-  preCaching: true <1>
+  preCaching: true
   preCachingConfigRef:
-    name: exampleconfig <2>
-    namespace: exampleconfig-ns <3>
+    name: exampleconfig
+    namespace: exampleconfig-ns
 ----
-<1> The `preCaching` field set to `true` enables the pre-caching job.
-<2> The `preCachingConfigRef.name` field specifies the `PreCachingConfig` CR that you want to use.
-<3> The `preCachingConfigRef.namespace` specifies the namespace of the `PreCachingConfig` CR that you want to use.
+
+- `spec.preCaching` the `preCaching` field set to `true` enables the pre-caching job.
+- `spec.preCachingConfigRef.name` the `preCachingConfigRef.name` field specifies the `PreCachingConfig` CR that you want to use.
+- `spec.preCachingConfigRef.namespace` the `preCachingConfigRef.namespace` specifies the namespace of the `PreCachingConfig` CR that you want to use.
+

--- a/modules/cnf-topology-aware-lifecycle-manager-preparing-for-updates.adoc
+++ b/modules/cnf-topology-aware-lifecycle-manager-preparing-for-updates.adoc
@@ -6,15 +6,18 @@
 [id="talo-platform-prepare-for-update-env-setup_{context}"]
 = Setting up the disconnected environment
 
+[role="_abstract"]
 {cgu-operator} can perform both platform and Operator updates.
 
 You must mirror both the platform image and Operator images that you want to update to in your mirror registry before you can use {cgu-operator} to update your disconnected clusters. Complete the following steps to mirror the images:
 
 * For platform updates, you must perform the following steps:
 +
+
+.Procedure
 . Mirror the desired {product-title} image repository. Ensure that the desired platform image is mirrored by following the "Mirroring the {product-title} image repository" procedure linked in the Additional resources. Save the contents of the `imageContentSources` section in the `imageContentSources.yaml` file:
 +
-.Example output
+Example output:
 [source,yaml]
 ----
 imageContentSources:
@@ -39,9 +42,11 @@ $ OCP_RELEASE_NUMBER=<release_version>
 +
 [source,terminal]
 ----
-$ ARCHITECTURE=<cluster_architecture> <1>
+$ ARCHITECTURE=<cluster_architecture>
 ----
-<1> Specify the architecture of the cluster, such as `x86_64`, `aarch64`, `s390x`, or `ppc64le`.
++
+
+Specify the architecture of the cluster, such as `x86_64`, `aarch64`, `s390x`, or `ppc64le`.
 +
 .. Get the release image digest from Quay by running the following command
 +

--- a/snippets/pg-cnf-topology-aware-lifecycle-manager-operator-troubleshooting.adoc
+++ b/snippets/pg-cnf-topology-aware-lifecycle-manager-operator-troubleshooting.adoc
@@ -1,3 +1,4 @@
+:_mod-docs-content-type: SNIPPET
 [source,yaml]
 ----
 manifests:
@@ -17,10 +18,10 @@ manifests:
 - path: source-crs/DefaultCatsrc.yaml
   patches:
     - metadata:
-        name: redhat-operators-disconnected-v2 <1>
+        name: redhat-operators-disconnected-v2
       spec:
-        displayName: Red Hat Operators Catalog v2 <2>
-        image: registry.example.com:5000/olm/redhat-operators-disconnected:<version> <3>
+        displayName: Red Hat Operators Catalog v2
+        image: registry.example.com:5000/olm/redhat-operators-disconnected:<version>
         updateStrategy:
             registryPoll:
                 interval: 1h
@@ -28,6 +29,8 @@ manifests:
         connectionState:
             lastObservedState: READY
 ----
-<1> Update the name for the new configuration.
-<2> Update the display name for the new configuration.
-<3> Update the index image URL. This `policies.manifests.patches.spec.image` field overrides any configuration in the `DefaultCatsrc.yaml` file.
+
+- `manifests.patches.name` update the name for the new configuration.
+- `manifests.patches.spec.displayName` update the display name for the new configuration.
+- `manifests.patches.spec.image` update the index image URL. This `policies.manifests.patches.spec.image` field overrides any configuration in the `DefaultCatsrc.yaml` file.
+

--- a/snippets/pg-cnf-topology-aware-lifecycle-manager-operator-update.adoc
+++ b/snippets/pg-cnf-topology-aware-lifecycle-manager-operator-update.adoc
@@ -35,14 +35,16 @@ policies:
                 name: redhat-operators-disconnected
               spec:
                 displayName: Red Hat Operators Catalog
-                image: registry.example.com:5000/olm/redhat-operators-disconnected:v{product-version} <1>
-                updateStrategy: <2>
+                image: registry.example.com:5000/olm/redhat-operators-disconnected:v{product-version}
+                updateStrategy:
                     registryPoll:
                         interval: 1h
               status:
                 connectionState:
-                    lastObservedState: READY <3>
+                    lastObservedState: READY
 ----
-<1> Contains the required Operator images. If the index images are always pushed to the same image name and tag, this change is not needed.
-<2> Sets how frequently the Operator Lifecycle Manager (OLM) polls the index image for new Operator versions with the `registryPoll.interval` field. This change is not needed if a new index image tag is always pushed for y-stream and z-stream Operator updates. The `registryPoll.interval` field can be set to a shorter interval to expedite the update, however shorter intervals increase computational load. To counteract this, you can restore `registryPoll.interval` to the default value once the update is complete.
-<3> Displays the observed state of the catalog connection. The `READY` value ensures that the `CatalogSource` policy is ready, indicating that the index pod is pulled and is running. This way, {cgu-operator} upgrades the Operators based on up-to-date policy compliance states.
+
+- `policies.manifests.patches.spec.image` contains the required Operator images. If the index images are always pushed to the same image name and tag, this change is not needed.
+- `policies.manifests.patches.spec.updateStrategy` sets how frequently the Operator Lifecycle Manager (OLM) polls the index image for new Operator versions with the `registryPoll.interval` field. This change is not needed if a new index image tag is always pushed for y-stream and z-stream Operator updates. The `registryPoll.interval` field can be set to a shorter interval to expedite the update, however shorter intervals increase computational load. To counteract this, you can restore `registryPoll.interval` to the default value once the update is complete.
+- `policies.manifests.patches.status.connectionState.lastObservedState` displays the observed state of the catalog connection. The `READY` value ensures that the `CatalogSource` policy is ready, indicating that the index pod is pulled and is running. This way, {cgu-operator} upgrades the Operators based on up-to-date policy compliance states.
+

--- a/snippets/pg-cnf-topology-aware-lifecycle-manager-pao-update.yaml
+++ b/snippets/pg-cnf-topology-aware-lifecycle-manager-pao-update.yaml
@@ -1,4 +1,3 @@
-:_mod-docs-content-type: SNIPPET
 - name: group-du-sno-pg-subscriptions-policy
   policyAnnotations:
     ran.openshift.io/ztp-deploy-wave: "2"

--- a/snippets/pg-cnf-topology-aware-lifecycle-manager-pao-update.yaml
+++ b/snippets/pg-cnf-topology-aware-lifecycle-manager-pao-update.yaml
@@ -1,3 +1,4 @@
+:_mod-docs-content-type: SNIPPET
 - name: group-du-sno-pg-subscriptions-policy
   policyAnnotations:
     ran.openshift.io/ztp-deploy-wave: "2"

--- a/snippets/pg-cnf-topology-aware-lifecycle-manager-platform-update.adoc
+++ b/snippets/pg-cnf-topology-aware-lifecycle-manager-platform-update.adoc
@@ -29,7 +29,7 @@ policies:
       policyAnnotations:
         ran.openshift.io/ztp-deploy-wave: "100"
       manifests:
-        - path: source-crs/ClusterVersion.yaml <1>
+        - path: source-crs/ClusterVersion.yaml
           patches:
             - metadata:
                 name: version
@@ -46,13 +46,13 @@ policies:
       policyAnnotations:
         ran.openshift.io/ztp-deploy-wave: "1"
       manifests:
-        - path: source-crs/ImageSignature.yaml <2>
+        - path: source-crs/ImageSignature.yaml
         - path: source-crs/DisconnectedICSP.yaml
           patches:
             - metadata:
                 name: disconnected-internal-icsp-for-ocp
               spec:
-                repositoryDigestMirrors: <3>
+                repositoryDigestMirrors:
                     - mirrors:
                         - quay-intern.example.com/ocp4/openshift-release-dev
                       source: quay.io/openshift-release-dev/ocp-release
@@ -60,7 +60,9 @@ policies:
                         - quay-intern.example.com/ocp4/openshift-release-dev
                       source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
 ----
-<1> Shows the `ClusterVersion` CR to trigger the update. The `channel`, `upstream`, and `desiredVersion` fields are all required for image pre-caching.
-<2> `ImageSignature.yaml` contains the image signature of the required release image. The image signature is used to verify the image before applying the platform update.
-<3> Shows the mirror repository that contains the required {product-title} image. Get the mirrors from the `imageContentSources.yaml` file that you saved when following the procedures in the "Setting up the environment" section.
+
+- `policies.manifests.path` shows the `ClusterVersion` CR to trigger the update. The `channel`, `upstream`, and `desiredVersion` fields are all required for image pre-caching.
+- `policies.manifests.path` `ImageSignature.yaml` contains the image signature of the required release image. The image signature is used to verify the image before applying the platform update.
+- `policies.manifests.patches.spec.repositoryDigestMirrors` shows the mirror repository that contains the required {product-title} image. Get the mirrors from the `imageContentSources.yaml` file that you saved when following the procedures in the "Setting up the environment" section.
+
 

--- a/snippets/pgt-cnf-topology-aware-lifecycle-manager-operator-troubleshooting.adoc
+++ b/snippets/pgt-cnf-topology-aware-lifecycle-manager-operator-troubleshooting.adoc
@@ -19,10 +19,10 @@
       remediationAction: inform
       policyName: "operator-catsrc-policy"
       metadata:
-        name: redhat-operators-disconnected-v2 <1>
+        name: redhat-operators-disconnected-v2
       spec:
-        displayName: Red Hat Operators Catalog v2 <2>
-        image: registry.example.com:5000/olm/redhat-operators-disconnected:<version> <3>
+        displayName: Red Hat Operators Catalog v2
+        image: registry.example.com:5000/olm/redhat-operators-disconnected:<version>
         updateStrategy:
           registryPoll:
             interval: 1h
@@ -30,6 +30,8 @@
         connectionState:
             lastObservedState: READY
 ----
-<1> Update the name for the new configuration.
-<2> Update the display name for the new configuration.
-<3> Update the index image URL. This `fileName.spec.image` field overrides any configuration in the `DefaultCatsrc.yaml` file.
+
+- `metadata.name` update the name for the new configuration.
+- `spec.displayName` update the display name for the new configuration.
+- `spec.image` update the index image URL. This `fileName.spec.image` field overrides any configuration in the `DefaultCatsrc.yaml` file.
+

--- a/snippets/pgt-cnf-topology-aware-lifecycle-manager-operator-update.adoc
+++ b/snippets/pgt-cnf-topology-aware-lifecycle-manager-operator-update.adoc
@@ -19,14 +19,16 @@ spec:
         name: redhat-operators-disconnected
       spec:
         displayName: Red Hat Operators Catalog
-        image: registry.example.com:5000/olm/redhat-operators-disconnected:v{product-version} <1>
-        updateStrategy: <2>
+        image: registry.example.com:5000/olm/redhat-operators-disconnected:v{product-version}
+        updateStrategy:
           registryPoll:
             interval: 1h
       status:
         connectionState:
-            lastObservedState: READY <3>
+            lastObservedState: READY
 ----
-<1> The index image URL contains the desired Operator images. If the index images are always pushed to the same image name and tag, this change is not needed.
-<2> Set how frequently the Operator Lifecycle Manager (OLM) polls the index image for new Operator versions with the `registryPoll.interval` field. This change is not needed if a new index image tag is always pushed for y-stream and z-stream Operator updates. The `registryPoll.interval` field can be set to a shorter interval to expedite the update, however shorter intervals increase computational load. To counteract this behavior, you can restore `registryPoll.interval` to the default value once the update is complete.
-<3> Last observed state of the catalog connection. The `READY` value ensures that the `CatalogSource` policy is ready, indicating that the index pod is pulled and is running. This way, {cgu-operator} upgrades the Operators based on up-to-date policy compliance states.
+
+- `spec.sourceFiles.spec.image` the index image URL contains the desired Operator images. If the index images are always pushed to the same image name and tag, this change is not needed.
+- `spec.sourceFiles.spec.updateStrategy` set how frequently the Operator Lifecycle Manager (OLM) polls the index image for new Operator versions with the `registryPoll.interval` field. This change is not needed if a new index image tag is always pushed for y-stream and z-stream Operator updates. The `registryPoll.interval` field can be set to a shorter interval to expedite the update, however shorter intervals increase computational load. To counteract this behavior, you can restore `registryPoll.interval` to the default value once the update is complete.
+- `spec.sourceFiles.status.connectionState.lastObservedState` last observed state of the catalog connection. The `READY` value ensures that the `CatalogSource` policy is ready, indicating that the index pod is pulled and is running. This way, {cgu-operator} upgrades the Operators based on up-to-date policy compliance states.
+

--- a/snippets/pgt-cnf-topology-aware-lifecycle-manager-pao-update.yaml
+++ b/snippets/pgt-cnf-topology-aware-lifecycle-manager-pao-update.yaml
@@ -1,3 +1,4 @@
+:_mod-docs-content-type: SNIPPET
 - fileName: PaoSubscriptionNS.yaml
   policyName: "subscriptions-policy"
   complianceType: mustnothave

--- a/snippets/pgt-cnf-topology-aware-lifecycle-manager-pao-update.yaml
+++ b/snippets/pgt-cnf-topology-aware-lifecycle-manager-pao-update.yaml
@@ -1,4 +1,3 @@
-:_mod-docs-content-type: SNIPPET
 - fileName: PaoSubscriptionNS.yaml
   policyName: "subscriptions-policy"
   complianceType: mustnothave

--- a/snippets/pgt-cnf-topology-aware-lifecycle-manager-platform-update.adoc
+++ b/snippets/pgt-cnf-topology-aware-lifecycle-manager-platform-update.adoc
@@ -12,23 +12,23 @@ spec:
   mcp: "master"
   remediationAction: inform
   sourceFiles:
-    - fileName: ImageSignature.yaml <1>
+    - fileName: ImageSignature.yaml
       policyName: "platform-upgrade-prep"
       binaryData:
-        ${DIGEST_ALGO}-${DIGEST_ENCODED}: ${SIGNATURE_BASE64} <2>
+        ${DIGEST_ALGO}-${DIGEST_ENCODED}: ${SIGNATURE_BASE64}
     - fileName: DisconnectedICSP.yaml
       policyName: "platform-upgrade-prep"
       metadata:
         name: disconnected-internal-icsp-for-ocp
       spec:
-        repositoryDigestMirrors: <3>
+        repositoryDigestMirrors:
           - mirrors:
             - quay-intern.example.com/ocp4/openshift-release-dev
             source: quay.io/openshift-release-dev/ocp-release
           - mirrors:
             - quay-intern.example.com/ocp4/openshift-release-dev
             source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
-    - fileName: ClusterVersion.yaml <4>
+    - fileName: ClusterVersion.yaml
       policyName: "platform-upgrade"
       metadata:
         name: version
@@ -42,7 +42,9 @@ spec:
           - version: {product-version}.4
             state: "Completed"
 ----
-<1> The `ConfigMap` CR contains the signature of the desired release image to update to.
-<2> Shows the image signature of the desired {product-title} release. Get the signature from the `checksum-${OCP_RELEASE_NUMBER}.yaml` file you saved when following the procedures in the "Setting up the environment" section.
-<3> Shows the mirror repository that contains the desired {product-title} image. Get the mirrors from the `imageContentSources.yaml` file that you saved when following the procedures in the "Setting up the environment" section.
-<4> Shows the `ClusterVersion` CR to trigger the update. The `channel`, `upstream`, and `desiredVersion` fields are all required for image pre-caching.
+
+- `spec.sourceFiles.fileName` the `ConfigMap` CR contains the signature of the desired release image to update to.
+- `spec.sourceFiles.binaryData` shows the image signature of the desired {product-title} release. Get the signature from the `checksum-${OCP_RELEASE_NUMBER}.yaml` file you saved when following the procedures in the "Setting up the environment" section.
+- `spec.sourceFiles.spec.repositoryDigestMirrors` shows the mirror repository that contains the desired {product-title} image. Get the mirrors from the `imageContentSources.yaml` file that you saved when following the procedures in the "Setting up the environment" section.
+- `spec.sourceFiles.fileName` shows the `ClusterVersion` CR to trigger the update. The `channel`, `upstream`, and `desiredVersion` fields are all required for image pre-caching.
+


### PR DESCRIPTION
## Summary                                                                     
                  
 Prepared AsciiDoc files in `edge_computing/policygenerator_for_ztp/ztp-talm-up
 dating-managed-policies-pg.adoc` for DITA conversion by running a two-phase
 DITA fix workflow (mechanical scripts + LLM-guided rewriting).

## Preview: 

- https://108026--ocpdocs-pr.netlify.app/
- https://108026--ocpdocs-pr.netlify.app/openshift-enterprise/latest/edge_computing/policygenerator_for_ztp/ztp-talm-updating-managed-policies-pg.html
- https://108026--ocpdocs-pr.netlify.app/openshift-enterprise/latest/edge_computing/policygentemplate_for_ztp/ztp-talm-updating-managed-policies.html

 ## Changes Applied

 ### Phase 1: Mechanical fixes (dita-rework)

 The following DITA cleanup scripts were applied in sequence:

 1. **dita-content-type**: Added `:_mod-docs-content-type:` attributes (3
 snippet files)
 2. **dita-document-id**: All IDs already present (no changes)
 3. **dita-callouts**: Transformed callouts using auto-detection (13 code
 blocks across 10 files)
 4. **dita-entity-reference**: No entity references found (no changes)
 5. **dita-line-break**: No hard line breaks found (no changes)
 6. **dita-related-links**: No auto-fixable related links issues (no changes)
 7. **dita-short-description**: Added `[role="_abstract"]` attributes (9 module
  files)
 8. **dita-task-contents**: Added `.Procedure` block titles (2 files)
 9. **dita-task-step**: Fixed list continuations in procedure steps (3 files)
 10. **dita-task-title**: Removed unsupported block titles (2 files)
 11. **dita-block-title**: Converted unsupported block titles to inline text (4
  files, 11 titles)

 ### Phase 2: LLM-guided fixes (dita-rewrite)

 - **TaskContents** (1 issue): Changed
 `cnf-topology-aware-lifecycle-manager-autocreate-cgu-cr-ztp.adoc` content type
  from PROCEDURE to CONCEPT (module is conceptual, not procedural)
 - **RelatedLinks** (8 issues): Stripped wrapper text ("For more information
 about...see") from xref links in 3 Additional resources sections in the
 assembly

 ## Files Processed

 18 files were modified from the assembly and its includes.

 ## Vale Validation Results (Actionable Issues Only)

 | Metric | Count |
 |--------|-------|
 | Issues before | 42 |
 | Issues after Phase 1 | 9 |
 | Issues after Phase 2 | 0 |
 | **Total fixed** | **42** |
 | Improvement | 100% |

 ## Test Plan

 - [ ] Verify the AsciiDoc renders correctly
 - [ ] Run DITA conversion on the modified files
 - [ ] Review callout conversions (bulleted lists and simple sentences)
 - [ ] Review block title conversions
 - [ ] Confirm Additional resources sections render correctly

 ---
 🤖 Generated with [Claude Code](https://claude.com/claude-code)
