### PR TITLE
DOCPLAN-78: Monitoring docs callout fixes

### DIFF
--- a/modules/virt-checking-storage-configuration.adoc
+++ b/modules/virt-checking-storage-configuration.adoc
@@ -27,9 +27,12 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: storage-checkup-sa
-  namespace: <target_namespace> # <1>
+  namespace: <target_namespace> 
 ----
-<1> The namespace where the checkup is to be run.
++
+where:
+
+`<target_namespace>`:: Specifies the namespace where the checkup is to be run.
 
 .Procedure
 
@@ -165,20 +168,20 @@ metadata:
     kiagnose/checkup-type: kubevirt-storage
 data:
   spec.timeout: 10m
-  status.succeeded: "true" # <1>
-  status.failureReason: "" # <2>
-  status.startTimestamp: "2023-07-31T13:14:38Z" # <3>
-  status.completionTimestamp: "2023-07-31T13:19:41Z" # <4>
-  status.result.cnvVersion: 4.21.2 # <5>
-  status.result.defaultStorageClass: trident-nfs <6>
-  status.result.goldenImagesNoDataSource: <data_import_cron_list> # <7>
-  status.result.goldenImagesNotUpToDate: <data_import_cron_list> # <8>
-  status.result.ocpVersion: 4.21.0 # <9>
-  status.result.pvcBound: "true" # <10>
-  status.result.storageProfileMissingVolumeSnapshotClass: <storage_class_list> # <11>
-  status.result.storageProfilesWithEmptyClaimPropertySets: <storage_profile_list> # <12>
-  status.result.storageProfilesWithSmartClone: <storage_profile_list> # <13>
-  status.result.storageProfilesWithSpecClaimPropertySets: <storage_profile_list> # <14>
+  status.succeeded: "true" 
+  status.failureReason: "" 
+  status.startTimestamp: "2023-07-31T13:14:38Z" 
+  status.completionTimestamp: "2023-07-31T13:19:41Z" 
+  status.result.cnvVersion: 4.21.2 
+  status.result.defaultStorageClass: trident-nfs
+  status.result.goldenImagesNoDataSource: <data_import_cron_list> 
+  status.result.goldenImagesNotUpToDate: <data_import_cron_list> 
+  status.result.ocpVersion: 4.21.0
+  status.result.pvcBound: "true"
+  status.result.storageProfileMissingVolumeSnapshotClass: <storage_class_list> 
+  status.result.storageProfilesWithEmptyClaimPropertySets: <storage_profile_list> 
+  status.result.storageProfilesWithSmartClone: <storage_profile_list>
+  status.result.storageProfilesWithSpecClaimPropertySets: <storage_profile_list>
   status.result.storageProfilesWithRWX: |-
     ocs-storagecluster-ceph-rbd
     ocs-storagecluster-ceph-rbd-virtualization
@@ -193,25 +196,26 @@ data:
     VMI "vmi-under-test-dhkb8" hotplug volume removed
   status.result.vmLiveMigration: VMI "vmi-under-test-dhkb8" migration completed
   status.result.vmVolumeClone: 'DV cloneType: "csi-clone"'
-  status.result.vmsWithNonVirtRbdStorageClass: <vm_list> # <15>
-  status.result.vmsWithUnsetEfsStorageClass: <vm_list> # <16>
+  status.result.vmsWithNonVirtRbdStorageClass: <vm_list>
+  status.result.vmsWithUnsetEfsStorageClass: <vm_list>
 ----
-<1> Specifies if the checkup is successful (`true`) or not (`false`).
-<2> The reason for failure if the checkup fails.
-<3> The time when the checkup started, in RFC 3339 time format.
-<4> The time when the checkup has completed, in RFC 3339 time format.
-<5> The {VirtProductName} version.
-<6> Specifies if there is a default storage class.
-<7> The list of golden images whose data source is not ready.
-<8> The list of golden images whose data import cron is not up-to-date.
-<9> The {product-title} version.
-<10> Specifies if a PVC of 10Mi has been created and bound by the provisioner.
-<11> The list of storage profiles using snapshot-based clone but missing VolumeSnapshotClass.
-<12> The list of storage profiles with unknown provisioners.
-<13> The list of storage profiles with smart clone support (CSI/snapshot).
-<14> The list of storage profiles spec-overriden claimPropertySets.
-<15> The list of virtual machines that use the Ceph RBD storage class when the virtualization storage class exists.
-<16> The list of virtual machines that use an Elastic File Store (EFS) storage class where the GID and UID are not set in the storage class.
++
+* `data.status.succeeded` defines if the checkup is successful (`true`) or not (`false`).
+* `data.status.failureReason` defines the reason for failure if the checkup fails.
+* `data.status.startTimestamp` defines the time when the checkup started, in RFC 3339 time format.
+* `data.status.completionTimestamp` defines the time when the checkup has completed, in RFC 3339 time format.
+* `data.status.result.cnvVersion` defines the {VirtProductName} version.
+* `data.status.result.defaultStorageClass` defines if there is a default storage class.
+* `data.status.result.goldenImagesNoDataSource` defines the list of golden images whose data source is not ready.
+* `data.status.result.goldenImagesNotUpToDate` defines the list of golden images whose data import cron is not up-to-date.
+* `data.status.result.ocpVersion` defines the {product-title} version.
+* `data.status.result.pvcBound` defines if a PVC of 10Mi has been created and bound by the provisioner.
+* `data.status.result.storageProfileMissingVolumeSnapshotClass` defines the list of storage profiles using snapshot-based clone but missing VolumeSnapshotClass.
+* `data.status.result.storageProfilesWithEmptyClaimPropertySets` defines the list of storage profiles with unknown provisioners.
+* `data.status.result.storageProfilesWithSmartClone` defines the list of storage profiles with smart clone support (CSI/snapshot).
+* `data.status.result.storageProfilesWithSpecClaimPropertySets` defines the list of storage profiles spec-overriden claimPropertySets.
+* `data.status.result.vmsWithNonVirtRbdStorageClass` defines the list of virtual machines that use the Ceph RBD storage class when the virtualization storage class exists.
+* `data.status.result.vmsWithUnsetEfsStorageClass` defines the list of virtual machines that use an Elastic File Store (EFS) storage class where the GID and UID are not set in the storage class.
 
 
 . Delete the job and config map that you previously created by running the following commands:

--- a/modules/virt-configuring-downward-metrics.adoc
+++ b/modules/virt-configuring-downward-metrics.adoc
@@ -45,7 +45,7 @@ spec:
     spec:
       domain:
         devices:
-          downwardMetrics: {} <1>
+          downwardMetrics: {}
       subdomain: headless
       volumes:
         - dataVolume:
@@ -56,9 +56,10 @@ spec:
               #cloud-config
               chpasswd:
                 expire: false
-              password: '<password>' <2>
+              password: '<password>'
               user: fedora
           name: cloudinitdisk
 ----
-<1> The `downwardMetrics` device.
-<2> The password for the `fedora` user.
++
+* `spec.domain.devices.downwardMetrics` defines the `downwardMetrics` device.
+* `spec.volumes.cloudInitNoCloud.userdata.password` defines the password for the `fedora` user.

--- a/modules/virt-configuring-node-exporter-service.adoc
+++ b/modules/virt-configuring-node-exporter-service.adoc
@@ -25,27 +25,28 @@ The node-exporter agent is deployed on every virtual machine in the cluster from
 kind: Service
 apiVersion: v1
 metadata:
-  name: node-exporter-service <1>
-  namespace: dynamation <2>
+  name: node-exporter-service
+  namespace: dynamation
   labels:
-    servicetype: metrics <3>
+    servicetype: metrics
 spec:
   ports:
-    - name: exmet <4>
+    - name: exmet
       protocol: TCP
-      port: 9100 <5>
-      targetPort: 9100 <6>
+      port: 9100
+      targetPort: 9100
   type: ClusterIP
   selector:
-    monitor: metrics <7>
+    monitor: metrics
 ----
-<1> The node-exporter service that exposes the metrics from the virtual machines.
-<2> The namespace where the service is created.
-<3> The label for the service. The `ServiceMonitor` uses this label to match this service.
-<4> The name given to the port that exposes metrics on port 9100 for the `ClusterIP` service.
-<5> The target port used by `node-exporter-service` to listen for requests.
-<6> The TCP port number of the virtual machine that is configured with the `monitor` label.
-<7> The label used to match the virtual machine's pods. In this example, any virtual machine's pod with the label `monitor` and a value of `metrics` will be matched.
++
+* `metadata.name` defines the node-exporter service that exposes the metrics from the virtual machines.
+* `metadata.namespace` defines the namespace where the service is created.
+* `metadata.labels.servicetype` defines the label for the service. The `ServiceMonitor` uses this label to match this service.
+* `spec.ports.name` defines the name given to the port that exposes metrics on port 9100 for the `ClusterIP` service.
+* `spec.ports.port` defines the target port used by `node-exporter-service` to listen for requests.
+* `spec.ports.targetPort` defines the TCP port number of the virtual machine that is configured with the `monitor` label.
+* `spec.selector.monitor` defines the label used to match the virtual machine's pods. In this example, any virtual machine's pod with the label `monitor` and a value of `metrics` will be matched.
 
 . Create the node-exporter service:
 +

--- a/modules/virt-creating-servicemonitor-resource-for-node-exporter.adoc
+++ b/modules/virt-creating-servicemonitor-resource-for-node-exporter.adoc
@@ -26,22 +26,23 @@ kind: ServiceMonitor
 metadata:
   labels:
     k8s-app: node-exporter-metrics-monitor
-  name: node-exporter-metrics-monitor <1>
-  namespace: dynamation <2>
+  name: node-exporter-metrics-monitor
+  namespace: dynamation
 spec:
   endpoints:
-  - interval: 30s <3>
-    port: exmet <4>
+  - interval: 30s
+    port: exmet
     scheme: http
   selector:
     matchLabels:
       servicetype: metrics
 
 ----
-<1> The name of the `ServiceMonitor`.
-<2> The namespace where the `ServiceMonitor` is created.
-<3> The interval at which the port will be queried.
-<4> The name of the port that is queried every 30 seconds
++
+* `metadata.name` defines the name of the `ServiceMonitor`.
+* `metadata.namespace` defines the namespace where the `ServiceMonitor` is created.
+* `spec.endpoints.interval` defines the interval at which the port will be queried.
+* `spec.endpoints.port` defines the name of the port that is queried every 30 seconds
 
 . Create the `ServiceMonitor` configuration for the node-exporter service.
 +

--- a/modules/virt-define-guest-agent-ping-probe.adoc
+++ b/modules/virt-define-guest-agent-ping-probe.adoc
@@ -32,20 +32,21 @@ spec:
   template:
     spec:
       readinessProbe:
-        guestAgentPing: {} <1>
-        initialDelaySeconds: 120 <2>
-        periodSeconds: 20 <3>
-        timeoutSeconds: 10 <4>
-        failureThreshold: 3 <5>
-        successThreshold: 3 <6>
+        guestAgentPing: {} 
+        initialDelaySeconds: 120
+        periodSeconds: 20
+        timeoutSeconds: 10 
+        failureThreshold: 3
+        successThreshold: 3
 # ...
 ----
-<1> The guest agent ping probe to connect to the VM.
-<2> Optional: The time, in seconds, after the VM starts before the guest agent probe is initiated.
-<3> Optional: The delay, in seconds, between performing probes. The default delay is 10 seconds. This value must be greater than `timeoutSeconds`.
-<4> Optional: The number of seconds of inactivity after which the probe times out and the VM is assumed to have failed. The default value is 1. This value must be lower than `periodSeconds`.
-<5> Optional: The number of times that the probe is allowed to fail. The default is 3. After the specified number of attempts, the pod is marked `Unready`.
-<6> Optional: The number of times that the probe must report success, after a failure, to be considered successful. The default is 1.
++
+* `spec.template.spec.readinessProbe.guestAgentPing` defines the guest agent ping probe to connect to the VM.
+* `spec.template.spec.readinessProbe.initialDelaySeconds` defines the time, in seconds, after the VM starts before the guest agent probe is initiated. This value is optional.
+* `spec.template.spec.readinessProbe.periodSeconds` defines the delay, in seconds, between performing probes. The default delay is 10 seconds. This value must be greater than `timeoutSeconds`. This value is optional
+* `spec.template.spec.readinessProbe.timeoutSeconds` defines the number of seconds of inactivity after which the probe times out and the VM is assumed to have failed. The default value is 1. This value must be lower than `periodSeconds`. This value is optional.
+* `spec.template.spec.readinessProbe.failureThreshold` defines the number of times that the probe is allowed to fail. The default is 3. After the specified number of attempts, the pod is marked `Unready`. This value is optional.
+* `spec.template.spec.readinessProbe.successThreshold` defines the number of times that the probe must report success, after a failure, to be considered successful. The default is 1. This value is optional.
 
 . Create the VM by running the following command:
 +

--- a/modules/virt-define-http-liveness-probe.adoc
+++ b/modules/virt-define-http-liveness-probe.adoc
@@ -33,23 +33,24 @@ spec:
   template:
     spec:
       livenessProbe:
-        initialDelaySeconds: 120 <1>
-        periodSeconds: 20 <2>
-        httpGet: <3>
-          port: 1500 <4>
-          path: /healthz <5>
+        initialDelaySeconds: 120
+        periodSeconds: 20
+        httpGet:
+          port: 1500 
+          path: /healthz
           httpHeaders:
           - name: Custom-Header
             value: Awesome
-        timeoutSeconds: 10 <6>
+        timeoutSeconds: 10
 # ...
 ----
-<1> The time, in seconds, after the VM starts before the liveness probe is initiated.
-<2> The delay, in seconds, between performing probes. The default delay is 10 seconds. This value must be greater than `timeoutSeconds`.
-<3> The HTTP GET request to perform to connect to the VM.
-<4> The port of the VM that the probe queries. In the above example, the probe queries port 1500. The VM installs and runs a minimal HTTP server on port 1500 via cloud-init.
-<5> The path to access on the HTTP server. In the above example, if the handler for the server's `/healthz` path returns a success code, the VM is considered to be healthy. If the handler returns a failure code, the VM is deleted and a new VM is created.
-<6> The number of seconds of inactivity after which the probe times out and the VM is assumed to have failed. The default value is 1. This value must be lower than `periodSeconds`.
++
+* `spec.tenmplate.spec.livenessProbe.initialDelaySeconds` defines the time, in seconds, after the VM starts before the liveness probe is initiated.
+* `spec.tenmplate.spec.livenessProbe.periodSeconds` defines the delay, in seconds, between performing probes. The default delay is 10 seconds. This value must be greater than `timeoutSeconds`.
+* `spec.tenmplate.spec.livenessProbe.httpGet` defines the HTTP GET request to perform to connect to the VM.
+* `spec.tenmplate.spec.livenessProbe.httpGet.port` defines the port of the VM that the probe queries. In the above example, the probe queries port 1500. The VM installs and runs a minimal HTTP server on port 1500 via cloud-init.
+* `spec.tenmplate.spec.livenessProbe.httpGet.path` defines the path to access on the HTTP server. In the above example, if the handler for the server's `/healthz` path returns a success code, the VM is considered to be healthy. If the handler returns a failure code, the VM is deleted and a new VM is created.
+* `spec.tenmplate.spec.livenessProbe.timeoutSeconds` defines the number of seconds of inactivity after which the probe times out and the VM is assumed to have failed. The default value is 1. This value must be lower than `periodSeconds`.
 
 . Create the VM by running the following command:
 +

--- a/modules/virt-define-http-readiness-probe.adoc
+++ b/modules/virt-define-http-readiness-probe.adoc
@@ -31,27 +31,28 @@ spec:
   template:
     spec:
       readinessProbe:
-        httpGet: <1>
-          port: 1500 <2>
-          path: /healthz <3>
+        httpGet:
+          port: 1500
+          path: /healthz
           httpHeaders:
           - name: Custom-Header
             value: Awesome
-        initialDelaySeconds: 120 <4>
-        periodSeconds: 20 <5>
-        timeoutSeconds: 10 <6>
-        failureThreshold: 3 <7>
-        successThreshold: 3 <8>
+        initialDelaySeconds: 120
+        periodSeconds: 20
+        timeoutSeconds: 10
+        failureThreshold: 3
+        successThreshold: 3
 # ...
 ----
-<1> The HTTP GET request to perform to connect to the VM.
-<2> The port of the VM that the probe queries. In the above example, the probe queries port 1500.
-<3> The path to access on the HTTP server. In the above example, if the handler for the server’s /healthz path returns a success code, the VM is considered to be healthy. If the handler returns a failure code, the VM is removed from the list of available endpoints.
-<4> The time, in seconds, after the VM starts before the readiness probe is initiated.
-<5> The delay, in seconds, between performing probes. The default delay is 10 seconds. This value must be greater than `timeoutSeconds`.
-<6> The number of seconds of inactivity after which the probe times out and the VM is assumed to have failed. The default value is 1. This value must be lower than `periodSeconds`.
-<7> The number of times that the probe is allowed to fail. The default is 3. After the specified number of attempts, the pod is marked `Unready`.
-<8> The number of times that the probe must report success, after a failure, to be considered successful. The default is 1.
++
+* `spec.template.spec.readinessProbe.httpGet` defines the HTTP GET request to perform to connect to the VM.
+* `spec.template.spec.readinessProbe.httpGet.port` defines the port of the VM that the probe queries. In the above example, the probe queries port 1500.
+* `spec.template.spec.readinessProbe.httpGet.path` defines the path to access on the HTTP server. In the above example, if the handler for the server’s /healthz path returns a success code, the VM is considered to be healthy. If the handler returns a failure code, the VM is removed from the list of available endpoints.
+* `spec.template.spec.readinessProbe.initialDelaySeconds` defines the time, in seconds, after the VM starts before the readiness probe is initiated.
+* `spec.template.spec.readinessProbe.periodSeconds` defines the delay, in seconds, between performing probes. The default delay is 10 seconds. This value must be greater than `timeoutSeconds`.
+* `spec.template.spec.readinessProbe.timeoutSeconds` defines the number of seconds of inactivity after which the probe times out and the VM is assumed to have failed. The default value is 1. This value must be lower than `periodSeconds`.
+* `spec.template.spec.readinessProbe.failureThreshold` defines the number of times that the probe is allowed to fail. The default is 3. After the specified number of attempts, the pod is marked `Unready`.
+* `spec.template.spec.readinessProbe.successThreshold` defines the number of times that the probe must report success, after a failure, to be considered successful. The default is 1.
 
 . Create the VM by running the following command:
 +

--- a/modules/virt-define-tcp-readiness-probe.adoc
+++ b/modules/virt-define-tcp-readiness-probe.adoc
@@ -33,18 +33,19 @@ spec:
   template:
     spec:
       readinessProbe:
-        initialDelaySeconds: 120 <1>
-        periodSeconds: 20 <2>
-        tcpSocket: <3>
-          port: 1500 <4>
-        timeoutSeconds: 10 <5>
+        initialDelaySeconds: 120
+        periodSeconds: 20
+        tcpSocket:
+          port: 1500
+        timeoutSeconds: 10
 # ...
 ----
-<1> The time, in seconds, after the VM starts before the readiness probe is initiated.
-<2> The delay, in seconds, between performing probes. The default delay is 10 seconds. This value must be greater than `timeoutSeconds`.
-<3> The TCP action to perform.
-<4> The port of the VM that the probe queries.
-<5> The number of seconds of inactivity after which the probe times out and the VM is assumed to have failed. The default value is 1. This value must be lower than `periodSeconds`.
++
+* `spec.template.spec.readinessProbe.initialDelaySeconds` defines the time, in seconds, after the VM starts before the readiness probe is initiated.
+* `spec.template.spec.readinessProbe.periodSeconds`defines the delay, in seconds, between performing probes. The default delay is 10 seconds. This value must be greater than `timeoutSeconds`.
+* `spec.template.spec.readinessProbe.tcpSocket` defines the TCP action to perform.
+* `spec.template.spec.readinessProbe.tcpSocket.port` defines the port of the VM that the probe queries.
+* `spec.template.spec.readinessProbe.timeoutSeconds` defines the number of seconds of inactivity after which the probe times out and the VM is assumed to have failed. The default value is 1. This value must be lower than `periodSeconds`.
 
 . Create the VM by running the following command:
 +

--- a/modules/virt-defining-watchdog-device-vm.adoc
+++ b/modules/virt-defining-watchdog-device-vm.adoc
@@ -37,12 +37,13 @@ spec:
         devices:
           watchdog:
             name: <watchdog>
-            <watchdog-device-model>: <1>
-              action: "poweroff" <2>
+            <watchdog-device-model>:
+              action: "poweroff"
 # ...
 ----
-<1> The watchdog device model to use. For `x86` specify `i6300esb`. For `s390x` specify `diag288`.
-<2> Specify `poweroff`, `reset`, or `shutdown`. The `shutdown` action requires that the guest virtual machine is responsive to ACPI signals. Therefore, using `shutdown` is not recommended.
++
+* `spec.template.spec.domain.devices.watchdog.name.<watchdog-device-model>` defines the watchdog device model to use. For `x86` specify `i6300esb`. For `s390x` specify `diag288`.
+* `spec.template.spec.domain.devices.watchdog.name.<watchdog-device-model>.action` defines the watchdog device action. Specify `poweroff`, `reset`, or `shutdown`. The `shutdown` action requires that the guest virtual machine is responsive to ACPI signals. Using `shutdown` is not recommended.
 +
 The example above configures the watchdog device on a VM with the `poweroff` action and exposes the device as `/dev/watchdog`.
 +


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->
DITA content fixes for Monitoring documentation. This PR fixes the callout errors that Vale found.

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.16+

Issue:
[DOCPLAN-115](https://issues.redhat.com/browse/DOCPLAN-115)
[DOCPLAN-120](https://issues.redhat.com/browse/DOCPLAN-120)
[DOCPLAN-121](https://issues.redhat.com/browse/DOCPLAN-121)
[DOCPLAN-122](https://issues.redhat.com/browse/DOCPLAN-122)
[DOCPLAN-123](https://issues.redhat.com/browse/DOCPLAN-123)
[DOCPLAN-124](https://issues.redhat.com/browse/DOCPLAN-124)
[DOCPLAN-126](https://issues.redhat.com/browse/DOCPLAN-126)
[DOCPLAN-128](https://issues.redhat.com/browse/DOCPLAN-128)
[DOCPLAN-129](https://issues.redhat.com/browse/DOCPLAN-129)

Link to docs preview:

- https://108042--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/monitoring/virt-exposing-custom-metrics-for-vms.html
- https://108042--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/monitoring/virt-exposing-downward-metrics.html
- https://108042--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/monitoring/virt-monitoring-vm-health.html
- https://108042--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/monitoring/virt-storage-checkups.html
- https://108042--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/virt/monitoring/virt-exposing-custom-metrics-for-vms.html
- https://108042--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/virt/monitoring/virt-monitoring-vm-health.html
- https://108042--ocpdocs-pr.netlify.app/openshift-rosa/latest/virt/monitoring/virt-exposing-custom-metrics-for-vms.html
- https://108042--ocpdocs-pr.netlify.app/openshift-rosa/latest/virt/monitoring/virt-monitoring-vm-health.html

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
