### PR TITLE
CCSINTL-3101 [POWERMON] Remaining Vale fixes for power-monitoring-docs-main and power-monitoring-docs-0.5

### DIFF
--- a/about/about-power-monitoring.adoc
+++ b/about/about-power-monitoring.adoc
@@ -1,12 +1,13 @@
 :_mod-docs-content-type: ASSEMBLY
-include::_attributes/common-attributes.adoc[]
-
 [id="about-power-monitoring"]
 = About {PM-shortname}
-
+include::_attributes/common-attributes.adoc[]
 :context: about-power-monitoring
 
 toc::[]
+
+[role="_abstract"]
+{PM-shortname-c} uses the {PM-kepler} architecture to provide energy consumption metrics, enabling you to track and optimize the power usage of your cluster workloads.
 
 :FeatureName: Power monitoring
 include::snippets/technology-preview.adoc[leveloffset=+2]

--- a/configuring/configuring-power-monitoring.adoc
+++ b/configuring/configuring-power-monitoring.adoc
@@ -1,12 +1,13 @@
 :_mod-docs-content-type: ASSEMBLY
-include::_attributes/common-attributes.adoc[]
-
 [id="configuring-power-monitoring"]
 = Configuring {PM-shortname}
-
+include::_attributes/common-attributes.adoc[]
 :context: configuring-power-monitoring
 
 toc::[]
+
+[role="_abstract"]
+Configure the {PM-kepler} custom resource to manage how the Kepler exporter collects and reports power consumption metrics from your cluster nodes.
 
 :FeatureName: Power monitoring
 include::snippets/technology-preview.adoc[leveloffset=+2]

--- a/modules/power-monitoring-kepler-power-attribution-guide.adoc
+++ b/modules/power-monitoring-kepler-power-attribution-guide.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: CONCEPT
 [id="power-monitoring-kepler-power-attribution-guide_{context}"]
-== Power monitoring Kepler power attribution guide
+= Power monitoring Kepler power attribution guide
 
 [role="_abstract"]
 Kepler attributes hardware energy consumption proportionally to individual workloads using CPU-time-based distribution for practical power monitoring.

--- a/modules/power-monitoring-monitoring-kepler-status.adoc
+++ b/modules/power-monitoring-monitoring-kepler-status.adoc
@@ -25,7 +25,7 @@ kind: PowerMonitor
 metadata:
   name: power-monitor
 status:
-   conditions: # <1>
+   conditions:
      - lastTransitionTime: '2024-01-11T11:07:39Z'
        message: Reconcile succeeded
        observedGeneration: 1
@@ -40,9 +40,12 @@ status:
        reason: DaemonSetReady
        status: 'True'
        type: Available
-   currentNumberScheduled: 2 # <2>
-   desiredNumberScheduled: 2 # <3>
+   currentNumberScheduled: 2
+   desiredNumberScheduled: 2
 ----
-<1> The health of the `PowerMonitor` resource. In this example, the `PowerMonitor` resource is successfully reconciled and ready.
-<2> The number of nodes currently running the {PM-kepler} pods is 2.
-<3> The wanted number of nodes to run the {PM-kepler} pods is 2.
++
+where:
+
+`status.conditions`:: Specifies the health of the `PowerMonitor` resource. In this example, the `PowerMonitor` resource is successfully reconciled and ready.
+`status.currentNumberScheduled`:: Specifies the number of nodes currently running the {PM-kepler} pods.
+`status.desiredNumberScheduled`:: Specifies the target number of nodes to run the {PM-kepler} pods.

--- a/modules/power-monitoring-release-notes-tp-0-5-overview.adoc
+++ b/modules/power-monitoring-release-notes-tp-0-5-overview.adoc
@@ -6,6 +6,9 @@
 [id="power-monitoring-tp-0-5-overview_{context}"]
 = Power monitoring 0.5 (Technology Preview) release notes overview
 
+[role="_abstract"]
+Review new features, enhancements, deprecated features, and support information for power monitoring 0.5 Technology Preview.
+
 :FeatureName: Power monitoring
 include::snippets/technology-preview.adoc[leveloffset=+2]
 

--- a/reference/power-monitoring-references.adoc
+++ b/reference/power-monitoring-references.adoc
@@ -11,6 +11,6 @@ toc::[]
 :FeatureName: Power monitoring
 include::snippets/technology-preview.adoc[leveloffset=+2]
 
-include::modules/power-monitoring-kepler-power-attribution-guide.adoc[Leveloffset=+1]
+include::modules/power-monitoring-kepler-power-attribution-guide.adoc[leveloffset=+1]
 
 //move API reference here post release. There may need to be additional IA updates for GA to better incorporate reference material.

--- a/uninstalling/uninstalling-power-monitoring.adoc
+++ b/uninstalling/uninstalling-power-monitoring.adoc
@@ -1,9 +1,7 @@
 :_mod-docs-content-type: ASSEMBLY
-include::_attributes/common-attributes.adoc[]
-
 [id="uninstalling-power-monitoring"]
 = Uninstalling {PM-shortname}
-
+include::_attributes/common-attributes.adoc[]
 :context: uninstalling-power-monitoring
 
 toc::[]
@@ -11,6 +9,7 @@ toc::[]
 :FeatureName: Power monitoring
 include::snippets/technology-preview.adoc[leveloffset=+2]
 
+[role="_abstract"]
 You can uninstall {PM-shortname} by deleting the {PM-kepler} instance and then the {PM-operator} in the {ocp} web console.
 
 // Removing kepler


### PR DESCRIPTION
[CCSINTL-3101](https://issues.redhat.com/browse/CCSINTL-3101) [POWERMON] Remaining Vale fixes for power-monitoring-docs-main and power-monitoring-docs-0.5

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
* `power-monitoring-docs-main`
* `power-monitoring-docs-0.5`

Issue:
https://issues.redhat.com/browse/CCSINTL-3101

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
QE is not required for this PR.

Additional information:
* To avoid cherry-pick failures, a separate PR will be created for updates to `power-monitoring-0.3` and `power-monitoring-0.4` since the content is different.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
