### PR TITLE
OSDOCS-17771 updated customizing ESO

### DIFF
--- a/modules/external-secrets-operator-adding-custom-annotations.adoc
+++ b/modules/external-secrets-operator-adding-custom-annotations.adoc
@@ -1,0 +1,82 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-log-levels.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="external-secrets-enable-operator-adding-custom-annotations_{context}"]
+= Adding custom annotations to external-secrets resources
+
+[role="_abstract"]
+To customize your resources, you can define up to 20 custom annotations in the custom resource (CR). The Operator merges the annotations with the defaults, prioritizes them, and safely preserves annotations set by external systems.
+
+When an annotation is removed from the CR, the Operator automatically removes it from all managed resources during the next reconciliation. Annotations set by external sources, such as Kubernetes system annotations or annotations added by other controllers, are preserved and are not affected by the Operator.
+
+Annotation keys containing the following reserved domain prefixes are not allowed and are rejected by validation if applied:
+
+* `kubernetes.io/` (including subdomains such as `*.kubernetes.io/`)
+
+* `k8s.io/` (including subdomains such as `*.k8s.io/`)
+
+* `openshift.io/` (including subdomains such as `*.openshift.io/`)
+
+* `cert-manager.io/`
+
+.Prerequisites
+
+* You have access to the cluster with `cluster-admin` privileges.
+
+* You have created the `ExternalSecretsConfig` custom resource.
+
+.Procedure
+
+. Edit the `ExternalSecretsConfig` CR by running the following command:
++
+[source,terminal]
+----
+$ oc edit externalsecretsconfigs.operator.openshift.io cluster
+----
+
+. Add the `annotations` field under `spec.controllerConfig` as follows:
++
+[source,yaml]
+----
+apiVersion: operator.openshift.io/v1alpha1
+kind: ExternalSecretsConfig
+metadata:
+  name: cluster
+spec:
+  controllerConfig:
+    annotations:
+      prometheus.io/scrape: "true"
+      example.com/environment: "production"
+----
+
+.Verification
+
+. Verify that annotations are applied to the external-secrets deployment by running the following command:
++
+[source,terminal]
+----
+$ oc get deployment external-secrets -n external-secrets -o jsonpath='{.metadata.annotations}' | jq .
+----
++
+The output should include the custom annotations you specified.
+
+. Verify that annotations are applied to the pod template by running the following command:
++
+[source,terminal]
+----
+$ oc get deployment external-secrets -n external-secrets -o jsonpath='{.spec.template.metadata.annotations}' | jq .
+----
++
+The output should include the custom annotations you specified.
+
+. Verify that annotations are applied to other managed resources such as Services by running the following command:
++
+[source,terminal]
+----
+$ oc get service external-secrets-webhook -n external-secrets -o jsonpath='{.metadata.annotations}' | jq .
+----
++
+The output should include the custom annotations you specified.
+

--- a/modules/external-secrets-operator-configure-history-limit.adoc
+++ b/modules/external-secrets-operator-configure-history-limit.adoc
@@ -1,0 +1,81 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-log-levels.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="external-secrets-enable-operator-configure-history-limit_{context}"]
+= Configuring the revisionHistoryLimit for external-secrets components
+
+[role="_abstract"]
+Configure the number of old `ReplicaSet` objects retained for rollback by setting the `revisionHistoryLimit` parameter for `external-secrets` components.
+
+The following components can be configured:
+
+[cols="1,1",options="header"]
+|===
+| Component name
+| Description
+
+| `ExternalSecretsCoreController`
+| The main `external-secrets` controller.
+
+| `Webhook`
+| The `external-secrets` webhook server.
+
+| `CertController`
+| The certificate controller for webhook TLS.
+
+| `BitwardenSDKServer`
+| The Bitwarden SDK server plugin.
+|===
+
+Each component can only have one configuration entry. A maximum of 4 component configuration entries are allowed, one per component.
+
+.Prerequisites
+
+* You have access to the cluster with `cluster-admin` privileges.
+
+* You have created the `ExternalSecretsConfig` custom resource.
+
+.Procedure
+
+. Edit the `ExternalSecretsConfig` CR by running the following command:
++
+[source,terminal]
+----
+$ oc edit externalsecretsconfigs.operator.openshift.io cluster
+----
+
+. Add the `componentConfigs` field under `spec.controllerConfig` as follows:
++
+[source,yaml]
+----
+apiVersion: operator.openshift.io/v1alpha1
+kind: ExternalSecretsConfig
+metadata:
+  name: cluster
+spec:
+  controllerConfig:
+    componentConfigs:
+      - componentName: ExternalSecretsCoreController
+        deploymentConfigs:
+          revisionHistoryLimit: 5
+      - componentName: Webhook
+        deploymentConfigs:
+          revisionHistoryLimit: 3
+----
++
+where
+
+`spec.controllerConfig.componentConfigs.componentName.deploymentConfigs.revisionHistoryLimit`:: Specifies the number of old `ReplicaSet` objects to retain for rollback. The value must be at least 1 to ensure rollback capability. The maximum value is 50. If not specified, the default is 10.
+
+.Verification
+
+* Verify that the `revisionHistoryLimit` parameter is applied to the deployment by running the following command:
++
+[source,terminal]
+----
+$ oc get deployment external-secrets -n external-secrets -o jsonpath='{.spec.revisionHistoryLimit}'
+----
++
+The output should display the value you configured.

--- a/modules/external-secrets-operator-set-custom-variables.adoc
+++ b/modules/external-secrets-operator-set-custom-variables.adoc
@@ -1,0 +1,70 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-log-levels.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="external-secrets-operator-set-custom-variables_{context}"]
+=  Setting custom environment variables for external-secrets components
+
+[role="_abstract"]
+To configure component behavior at runtime or integrate with external services, set custom environment variables for individual `external-secrets` components.
+
+Custom environment variables are merged with the default environment variables set by the Operator. User-specified variables take precedence in case of conflicts with the Operator defaults. A maximum of 50 custom environment variables can be specified per component.
+
+The environment variable names starting with the following prefixes are reserved:
+
+* `HOSTNAME`
+
+* `KUBERNETES_`
+
+* `EXTERNAL_SECRETS_`
+
+.Prerequisites
+
+* You have access to the cluster with `cluster-admin` privileges.
+
+* You have created the `ExternalSecretsConfig` custom resource.
+
+.Procedure
+
+. Edit the `ExternalSecretsConfig` CR by running the following command:
++
+[source,terminal]
+----
+$ oc edit externalsecretsconfigs.operator.openshift.io cluster
+----
+
+. Add the `overrideEnv` field under the desired component in the `spec.controllerConfig.componentConfigs` stanza as follows:
++
+[source,yaml]
+----
+apiVersion: operator.openshift.io/v1alpha1
+kind: ExternalSecretsConfig
+metadata:
+  name: cluster
+spec:
+  controllerConfig:
+    componentConfigs:
+      - componentName: ExternalSecretsCoreController
+        overrideEnv:
+          - name: Example
+            value: "4"
+----
++
+where
+
+`spec.controllerConfig.componentConfigs.overrideEnv.name`:: Specifies the name of the environment variable. Environment variable names starting with `HOSTNAME`, `KUBERNETES_`, or `EXTERNAL_SECRETS_` are reserved and are not allowed.
+
+`spec.controllerConfig.componentConfigs.overrideEnv.value`:: Specifies the value of the environment variable.
+
+.Verification
+
+* Verify that the environment variable is set on the deployment by running the following command:
++
+[source,terminal]
+----
+$ oc set env deployment/external-secrets -n external-secrets --list
+----
++
+The output should include the custom environment variable you specified.
+

--- a/security/external_secrets_operator/external-secrets-log-levels.adoc
+++ b/security/external_secrets_operator/external-secrets-log-levels.adoc
@@ -7,7 +7,16 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 [role="_abstract"]
-After the {external-secrets-operator} is installed, you can customize its behavior by editing the `ExternalSecretsConfig` custom resource (CR). This lets you modify components like the external-secrets controller, the cert-controller, the webhook, and the `bitwardenSecretManagerProvider` plugin and also lets you set environment variables for the Operator pod.
+You can customize the behavior of the {external-secrets-operator} operand components by configuring custom annotations, deployment lifecycle settings, and environment variables through the `ExternalSecretsConfig` custom resource (CR).
+
+These configurations provide administrators with fine-grained control over the external-secrets deployment.
+
+You can customize the {external-secrets-operator} operand by using the `ExternalSecretsConfig` custom resource (CR). The CR supports a set of deployment and runtime options, such as custom annotations, revision history limits, environment variables, resource limits, tolerations, and proxy settings—so you can control how the operand is deployed and run without editing the operand resources directly.
+
+All supported options are defined in the `ExternalSecretsConfig` CR (for example under the `spec.controllerConfig` for controller-related settings). The Operator reconciles the operand from this CR. Changes made directly to operand resources are overwritten. Use the `ExternalSecretsConfig` CR as the only supported way to customize the operand.
+
+For the complete list of fields and allowed values, see the `ExternalSecretsConfig` API reference in the {external-secrets-operator} documentation.
+
 
 [role="_additional-resources"]
 .Additional resources
@@ -33,3 +42,12 @@ include::modules/external-secrets-cert-manager-config.adoc[leveloffset=+1]
 
 // configuring bitwarden
 include::modules/external-secrets-bit-warden-config.adoc[leveloffset=+1]
+
+// add custom annotations
+include::modules/external-secrets-operator-adding-custom-annotations.adoc[leveloffset=+1]
+
+// configure history limit
+include::modules/external-secrets-operator-configure-history-limit.adoc[leveloffset=+1]
+
+// Set custom environment variables
+include::modules/external-secrets-operator-set-custom-variables.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s):
4.20+

Issue:
https://issues.redhat.com/browse/OSDOCS-17771

Link to docs preview:
https://108044--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/external_secrets_operator/external-secrets-log-levels.html#external-secrets-enable-operator-adding-custom-annotations_external-secrets-log-levels

https://108044--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/external_secrets_operator/external-secrets-log-levels.html#external-secrets-enable-operator-configure-history-limit_external-secrets-log-levels

https://108044--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/external_secrets_operator/external-secrets-log-levels.html#external-secrets-operator-set-custom-variables_external-secrets-log-levels


QE review:
- [ ] QE has approved this change.


Additional information:

