### PR TITLE
OSDOCS-18565: removes OCP DNS link coreDNS docs RHCL

### DIFF
--- a/deployment/coredns.adoc
+++ b/deployment/coredns.adoc
@@ -31,6 +31,5 @@ include::modules/con-coredns-removal-migration.adoc[leveloffset=+1]
 [role="_additional-resources"]
 == Additional resources
 
-* link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.21/html/networking_operators/dns-operator[DNS Operator in {ocp}]
 * link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.21/html/network_security/logging-network-security#logging-network-security[Audit logging for network security]
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
rhcl-docs-1.3
rhcl-docs-1.4

Issue:
[OSDOCS-18565](https://issues.redhat.com/browse/OSDOCS-18565)

Link to docs preview:
[minus link](https://108045--ocpdocs-pr.netlify.app/rhcl/latest/deployment/coredns.html#additional-resources_rhcl-using-on-prem-dns-coredns)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->


<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
