### PR TITLE
CCSINTL-3102 [POWERMON] Remaining Vale fixes for power-monitoring-0.3

### DIFF
--- a/about/about-power-monitoring.adoc
+++ b/about/about-power-monitoring.adoc
@@ -1,12 +1,13 @@
 :_mod-docs-content-type: ASSEMBLY
-include::_attributes/common-attributes.adoc[]
-
 [id="about-power-monitoring"]
 = About {PM-shortname}
-
+include::_attributes/common-attributes.adoc[]
 :context: about-power-monitoring
 
 toc::[]
+
+[role="_abstract"]
+{PM-shortname-c} uses the {PM-kepler} architecture to provide energy consumption metrics, enabling you to track and optimize the power usage of your cluster workloads.
 
 :FeatureName: Power monitoring
 include::snippets/technology-preview.adoc[leveloffset=+2]

--- a/configuring/configuring-power-monitoring.adoc
+++ b/configuring/configuring-power-monitoring.adoc
@@ -1,17 +1,17 @@
 :_mod-docs-content-type: ASSEMBLY
-include::_attributes/common-attributes.adoc[]
-
 [id="configuring-power-monitoring"]
 = Configuring {PM-shortname}
-
+include::_attributes/common-attributes.adoc[]
 :context: configuring-power-monitoring
 
 toc::[]
 
+[role="_abstract"]
+You can configure the {PM-kepler} custom resource to manage how the Kepler exporter collects and reports power consumption metrics from your cluster nodes.
+
 :FeatureName: Power monitoring
 include::snippets/technology-preview.adoc[leveloffset=+2]
 
-The `{PM-kepler}` resource is a Kubernetes custom resource definition (CRD) that enables you to configure the deployment and monitor the status of the {PM-kepler} resource.
 
 include::modules/power-monitoring-kepler-configuration.adoc[leveloffset=+1]
 

--- a/installing/installing-power-monitoring.adoc
+++ b/installing/installing-power-monitoring.adoc
@@ -1,12 +1,13 @@
 :_mod-docs-content-type: ASSEMBLY
-include::_attributes/common-attributes.adoc[]
-
 [id="installing-power-monitoring"]
 = Installing {PM-title}
-
+include::_attributes/common-attributes.adoc[]
 :context: installing-power-monitoring
 
 toc::[]
+
+[role="_abstract"]
+You can install the {PM-operator} and deploy {PM-kepler} to monitor power consumption across your {ocp} cluster infrastructure.
 
 :FeatureName: Power monitoring
 include::snippets/technology-preview.adoc[leveloffset=+2]

--- a/modules/power-monitoring-accessing-dashboards-admin.adoc
+++ b/modules/power-monitoring-accessing-dashboards-admin.adoc
@@ -7,7 +7,7 @@
 = Accessing {PM-shortname} dashboards as a cluster administrator
 
 [role="_abstract"]
-Access power monitoring dashboards from the {ocp} web console using cluster administrator credentials and permissions.
+Access power monitoring dashboards from the {ocp} web console using cluster administrator privileges to view comprehensive power consumption metrics across your entire cluster.
 
 .Prerequisites
 
@@ -21,6 +21,6 @@ Access power monitoring dashboards from the {ocp} web console using cluster admi
 
 . In the web console, go to *Observe* -> *Dashboards*.
 
-. From the *Dashboard* drop-down list, select the {PM-shortname} dashboard you want to see: 
+. From the *Dashboard* drop-down list, select the {PM-shortname} dashboard you want to see:
 ** *Power Monitoring / Overview*
 ** *Power Monitoring / Namespace*

--- a/modules/power-monitoring-accessing-dashboards-developer.adoc
+++ b/modules/power-monitoring-accessing-dashboards-developer.adoc
@@ -7,7 +7,7 @@
 = Accessing {PM-shortname} dashboards as a developer
 
 [role="_abstract"]
-Access {PM-shortname} dashboards from the {ocp} web console using developer credentials and view permissions for monitoring.
+Access {PM-shortname} dashboards from the {ocp} web console using developer credentials to view power consumption metrics for namespaces where you have view permissions.
 
 You can access {PM-shortname} dashboards from {ocp} web console.
 

--- a/modules/power-monitoring-configuring-kepler-redfish.adoc
+++ b/modules/power-monitoring-configuring-kepler-redfish.adoc
@@ -6,7 +6,8 @@
 [id="power-monitoring-configuring-kepler-redfish_{context}"]
 = Configuring {PM-kepler} to use Redfish
 
-You can configure {PM-kepler} to use Redfish as the source for running or hosting containers. {PM-kepler} can then monitor the power usage of these containers.
+[role="_abstract"]
+Configure {PM-kepler} to monitor power consumption of containers using Redfish as the data source for your nodes.
 
 .Prerequisites
 * You have access to the {ocp} web console.
@@ -33,21 +34,25 @@ metadata:
 spec:
   exporter:
     deployment:
-# ... 
+# ...
     redfish:
-      secretRef: <secret_name> required <1>
-      probeInterval: 60s <2>
-      skipSSLVerify: false <3>
+      secretRef: <secret_name> required
+      probeInterval: 60s
+      skipSSLVerify: false
 # ...
 ----
-<1> Required: Specifies the name of the secret that contains the credentials for accessing the Redfish server.
-<2> Optional: Controls the frequency at which the power information is queried from Redfish. The default value is `60s`.
-<3> Optional: Controls if {PM-kepler} skips verifying the Redfish server certificate. The default value is `false`.
++
+where:
+
+`spec.exporter.redfish.secretRef`:: Required: Specifies the name of the secret that contains the credentials for accessing the Redfish server.
+`spec.exporter.redfish.probeInterval`:: Optional: Specifies how frequently the power information is queried from Redfish. The default value is `60s`.
+`spec.exporter.redfish.skipSSLVerify`:: Optional: Specifies if {PM-kepler} skips verifying the Redfish server certificate. The default value is `false`.
 +
 [NOTE]
 ====
 After {PM-kepler} is deployed, the `openshift-power-monitoring` namespace is created.
 ====
+
 . Create the `redfish.csv` file with the following data format:
 +
 [source,csv]

--- a/modules/power-monitoring-dashboards-overview.adoc
+++ b/modules/power-monitoring-dashboards-overview.adoc
@@ -7,7 +7,7 @@
 = {PM-shortname-c} dashboards overview
 
 [role="_abstract"]
-{PM-shortname} provides two dashboards for visualizing cluster power consumption at node, namespace, and pod levels.
+{PM-shortname-c} provides two dashboards for visualizing cluster power consumption at node, namespace, and pod levels.
 
 [id="power-monitoring-overview-dashboard_{context}"]
 == Power Monitoring / Overview dashboard

--- a/modules/power-monitoring-deleting-kepler.adoc
+++ b/modules/power-monitoring-deleting-kepler.adoc
@@ -7,7 +7,7 @@
 = Deleting {PM-kepler}
 
 [role="_abstract"]
-Remove {PM-kepler} by deleting the {PM-kepler} custom resource instance from the {ocp} web console.
+Remove {PM-kepler} from your {ocp} cluster by deleting the {PM-kepler} custom resource instance from the {ocp} web console.
 
 .Prerequisites
 * You have access to the {ocp} web console.
@@ -24,4 +24,3 @@ Remove {PM-kepler} by deleting the {PM-kepler} custom resource instance from the
 . Click {kebab} for this entry and select *Delete {PM-kepler}*.
 
 . In the *Delete {PM-kepler}?* dialog, click *Delete* to delete the {PM-kepler} instance.
-

--- a/modules/power-monitoring-deploying-kepler.adoc
+++ b/modules/power-monitoring-deploying-kepler.adoc
@@ -6,7 +6,8 @@
 [id="power-monitoring-deploying-kepler_{context}"]
 = Deploying {PM-kepler}
 
-You can deploy {PM-kepler} by creating an instance of the `{PM-kepler}` custom resource definition (CRD) by using the {PM-operator}. 
+[role="_abstract"]
+You can deploy {PM-kepler} by creating a `{PM-kepler}` custom resource instance using the {PM-operator}.
 
 .Prerequisites
 * You have access to the {ocp} web console.

--- a/modules/power-monitoring-hardware-virtualization-support.adoc
+++ b/modules/power-monitoring-hardware-virtualization-support.adoc
@@ -6,14 +6,16 @@
 [id="power-monitoring-hardware-virtualization-support_{context}"]
 = {PM-kepler} hardware and virtualization support
 
-{PM-kepler} is the key component of {PM-shortname} that collects real-time power consumption data from a node through one of the following methods:
+[role="_abstract"]
+{PM-kepler} is the key component of {PM-shortname} that collects real-time power consumption data using either hardware-based power subsystems or machine learning estimation models.
 
-Kernel Power Management Subsystem (preferred)::
-* `rapl-sysfs`: This requires access to the `/sys/class/powercap/intel-rapl` host file.
-* `rapl-msr`: This requires access to the `/dev/cpu/*/msr` host file.
+Kernel Power Management Subsystem (preferred):: Kernel Power Management Subsystem (preferred):: Uses the `rapl-sysfs` or `rapl-msr` host files to access the CPU power monitoring hardware.
++
+* `rapl-sysfs` Requires access to the `/sys/class/powercap/intel-rapl` host file.
+* `rapl-msr` Requires access to the `/dev/cpu/*/msr` host file.
 
 The `estimator` power source::
-Without access to the kernel's power cap subsystem, {PM-kepler} uses a machine learning model to estimate the power usage of the CPU on the node.
+Uses a machine learning model to estimate CPU power usage when the kernel power management subsystem is unavailable.
 +
 [WARNING]
 ====

--- a/modules/power-monitoring-installing-pmo.adoc
+++ b/modules/power-monitoring-installing-pmo.adoc
@@ -7,7 +7,9 @@
 = Installing the {PM-operator}
 
 [role="_abstract"]
-Install the {PM-operator} from the software catalog using the {ocp} web console.
+Install the {PM-operator} from the software catalog using the {ocp} web console to enable power consumption monitoring capabilities on your cluster.
+
+The {PM-operator} manages the deployment and configuration of {pm-Kepler}, which collects real-time power metrics from cluster nodes.
 
 [WARNING]
 ====

--- a/modules/power-monitoring-kepler-architecture.adoc
+++ b/modules/power-monitoring-kepler-architecture.adoc
@@ -7,10 +7,10 @@
 = {PM-shortname-c} architecture
 
 [role="_abstract"]
-{PM-shortname-c} consists of the {PM-operator} for management and {PM-kepler} for collecting power metrics.
+{PM-shortname-c} consists of the {PM-operator} to manage the lifecycle and configuration of Kepler, and {PM-kepler} collects power metrics.
 
 {PM-shortname-c} is made up of the following major components:
 
-The {PM-operator}:: For administrators, the {PM-operator} streamlines the monitoring of power usage for workloads by simplifying the deployment and management of {PM-kepler} in an {ocp} cluster. The setup and configuration for the {PM-operator} are simplified by adding a {PM-kepler} custom resource definition (CRD). The Operator also manages operations, such as upgrading, removing, configuring, and redeploying {PM-kepler}. 
+The {PM-operator}:: For administrators, the {PM-operator} streamlines the monitoring of power usage for workloads by simplifying the deployment and management of {PM-kepler} in an {ocp} cluster. The setup and configuration for the {PM-operator} are simplified by adding a {PM-kepler} custom resource definition (CRD). The Operator also manages operations, such as upgrading, removing, configuring, and redeploying {PM-kepler}.
 
 {PM-kepler}:: {PM-kepler} is a key component of {PM-shortname}. It is responsible for monitoring the power usage of containers running in {ocp}. It generates metrics related to the power usage of both nodes and containers.

--- a/modules/power-monitoring-kepler-configuration.adoc
+++ b/modules/power-monitoring-kepler-configuration.adoc
@@ -6,13 +6,8 @@
 [id="power-monitoring-kepler-configuration_{context}"]
 = The {PM-kepler} configuration
 
-<<<<<<< HEAD
-You can configure {PM-kepler} with the `spec` field of the `{PM-kepler}` resource.
-=======
 [role="_abstract"]
-Configuration options available for customizing Kepler deployment, security, logging, and metric collection through `PowerMonitor` resources.
-
->>>>>>> 7976eadb9e (CCSINTL-3095 [POWERMON] Module short descriptions)
+You can customize {PM-Kepler} deployment, security, logging, and metric collection settings by configuring the available parameters in the `PowerMonitor` custom resource.
 
 [IMPORTANT]
 ====
@@ -24,7 +19,7 @@ The following is the list of configuration options:
 .{PM-kepler} configuration options
 [options="header"]
 |===
-|Name |Spec |Description |Default 
+|Name |Spec |Description |Default
 |`port` |`exporter.deployment` |The port on the node where the Prometheus metrics are exposed. |`9103`
 |`nodeSelector` |`exporter.deployment` |The nodes on which {PM-kepler} exporter pods are scheduled. |`kubernetes.io/os: linux`
 |`tolerations` |`exporter.deployment` |The tolerations for {PM-kepler} exporter that allow the pods to be scheduled on nodes with specific characteristics. |`- operator: "Exists"`
@@ -40,15 +35,18 @@ metadata:
 spec:
   exporter:
     deployment:
-      port: 9103 # <1>
-      nodeSelector: 
-        kubernetes.io/os: linux # <2>
-      Tolerations: # <3>
+      port: 9103
+      nodeSelector:
+        kubernetes.io/os: linux
+      Tolerations:
       - key: ""
-        operator: "Exists" 
+        operator: "Exists"
         value: ""
         effect: ""
 ----
-<1> The Prometheus metrics are exposed on port 9103.
-<2> {PM-kepler} pods are scheduled on Linux nodes.
-<3> The default tolerations allow {PM-kepler} to be scheduled on any node.
++
+where:
+
+`spec.exporter.deployment.port`:: Specifies the port that exposes Prometheus metrics. The default is `9103`.
+`spec.exporter.deployment.nodeSelector`:: Specifies the nodes where pods are scheduled. In this example, pods are scheduled on *Linux* nodes.
+`spec.exporter.deployment.Tolerations`:: Specifies the tolerations that allow {PM-kepler} pods to be scheduled on nodes with specific taints. In this example, the configuration tolerates any taint.

--- a/modules/power-monitoring-metrics-overview.adoc
+++ b/modules/power-monitoring-metrics-overview.adoc
@@ -6,6 +6,9 @@
 [id="power-monitoring-metrics-overview_{context}"]
 = {PM-shortname-c} metrics overview
 
+[role="_abstract"]
+{PM-operator} provides detailed energy consumption metrics for cluster nodes, pods, and containers to help you analyze resource-level power usage.
+
 The {PM-operator} exposes the following metrics, which you can view by using the {ocp} web console under the *Observe* -> *Metrics* tab.
 
 [WARNING]

--- a/modules/power-monitoring-monitoring-kepler-status.adoc
+++ b/modules/power-monitoring-monitoring-kepler-status.adoc
@@ -6,12 +6,8 @@
 [id="power-monitoring-monitoring-kepler-status_{context}"]
 = Monitoring the {PM-kepler} status
 
-<<<<<<< HEAD
-You can monitor the state of the {PM-kepler} exporter with the `status` field of the `{PM-kepler}` resource. 
-=======
 [role="_abstract"]
 The `PowerMonitor` resource status field provides real-time information about Kepler pod deployment state and health across nodes.
->>>>>>> 7976eadb9e (CCSINTL-3095 [POWERMON] Module short descriptions)
 
 The `status.exporter` field includes information, such as the following:
 
@@ -19,7 +15,7 @@ The `status.exporter` field includes information, such as the following:
 * The number of nodes that should be running the {PM-kepler} pods
 * Conditions representing the health of the {PM-kepler} resource
 
-This provides you with valuable insights into the changes made through the `spec` field. 
+This provides you with valuable insights into the changes made through the `spec` field.
 
 .Example state of the `{PM-kepler}` resource
 [source,yaml]
@@ -30,7 +26,7 @@ metadata:
   name: kepler
 status:
  exporter:
-   conditions: # <1>
+   conditions:
      - lastTransitionTime: '2024-01-11T11:07:39Z'
        message: Reconcile succeeded
        observedGeneration: 1
@@ -45,9 +41,12 @@ status:
        reason: DaemonSetReady
        status: 'True'
        type: Available
-   currentNumberScheduled: 2 # <2>
-   desiredNumberScheduled: 2 # <3>
+   currentNumberScheduled: 2
+   desiredNumberScheduled: 2
 ----
-<1> The health of the {PM-kepler} resource. In this example, {PM-kepler} is successfully reconciled and ready.
-<2> The number of nodes currently running the {PM-kepler} pods is 2.
-<3> The wanted number of nodes to run the {PM-kepler} pods is 2.
++
+where:
+
+`status.exporter.conditions`:: Specifies the health of the {PM-kepler} resource. In this example, {PM-kepler} is successfully reconciled and ready.
+`status.currentNumberScheduled`:: Specifies the number of nodes currently running the {PM-kepler} pods.
+`status.desiredNumberScheduled`:: Specifies the target number of nodes to run the {PM-kepler} pods.

--- a/modules/power-monitoring-overview.adoc
+++ b/modules/power-monitoring-overview.adoc
@@ -7,7 +7,7 @@
 = {PM-shortname-c} overview
 
 [role="_abstract"]
-{PM-title} tracks energy consumption across {ocp}cluster infrastructure and provides granular metrics for pods and namespaces.
+{PM-shortname-c} tracks energy consumption across {ocp} cluster infrastructure and provides granular metrics for pods and namespaces.
 
 You can use {PM-title} to monitor the power usage and identify power-consuming containers running in an {ocp} cluster. {PM-shortname-c} collects and exports energy-related system statistics from various components, such as CPU and DRAM. It provides estimates and granular power consumption data for Kubernetes pods and namespaces, and reads the power consumption of nodes.
 

--- a/modules/power-monitoring-uninstalling-pmo.adoc
+++ b/modules/power-monitoring-uninstalling-pmo.adoc
@@ -7,7 +7,7 @@
 = Uninstalling the {PM-operator}
 
 [role="_abstract"]
-Uninstall the {PM-operator} from the {ocp} web console after deleting Kepler.
+Uninstall the {PM-operator} from your {ocp} cluster using the {ocp} web console. You must delete all Kepler instances before uninstalling {PM-operator} to prevent resource conflicts and ensure clean removal of all power monitoring components from your cluster.
 
 .Prerequisites
 * You have access to the {ocp} web console.

--- a/uninstalling/uninstalling-power-monitoring.adoc
+++ b/uninstalling/uninstalling-power-monitoring.adoc
@@ -8,6 +8,9 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
+Uninstall {PM-shortname} by deleting the {PM-kepler} instance and then removing the {PM-operator} from your {ocp} cluster.
+
 :FeatureName: Power monitoring
 include::snippets/technology-preview.adoc[leveloffset=+2]
 

--- a/visualizing/visualizing-power-monitoring-metrics.adoc
+++ b/visualizing/visualizing-power-monitoring-metrics.adoc
@@ -1,12 +1,13 @@
 :_mod-docs-content-type: ASSEMBLY
-include::_attributes/common-attributes.adoc[]
-
 [id="visualizing-power-monitoring-metrics"]
 = Visualizing power monitoring metrics
-
+include::_attributes/common-attributes.adoc[]
 :context: visualizing-power-monitoring-metrics
 
 toc::[]
+
+[role="_abstract"]
+You can monitor energy usage across cluster resources by using power consumption dashboards in the {ocp} web console.
 
 :FeatureName: Power monitoring
 include::snippets/technology-preview.adoc[leveloffset=+2]


### PR DESCRIPTION
[CCSINTL-3102](https://issues.redhat.com/browse/CCSINTL-3102) [POWERMON] Remaining Vale fixes for power-monitoring-0.3

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
`power-monitoring-docs-0.3`

Issue:
https://issues.redhat.com/browse/CCSINTL-3102

* About: https://108055--ocpdocs-pr.netlify.app/openshift-power-monitoring/latest/about/about-power-monitoring
* Power monitoring overview: https://108055--ocpdocs-pr.netlify.app/openshift-power-monitoring/latest/about/about-power-monitoring#power-monitoring-overview_about-power-monitoring
* Power monitoring architecture: https://108055--ocpdocs-pr.netlify.app/openshift-power-monitoring/latest/about/about-power-monitoring#power-monitoring-kepler-architecture_about-power-monitoring
* Kepler hardware and virtualization support: https://108055--ocpdocs-pr.netlify.app/openshift-power-monitoring/latest/about/about-power-monitoring#power-monitoring-hardware-virtualization-support_about-power-monitoring
* Installing: https://108055--ocpdocs-pr.netlify.app/openshift-power-monitoring/latest/installing/installing-power-monitoring
* Installing the Power monitoring Operator: https://108055--ocpdocs-pr.netlify.app/openshift-power-monitoring/latest/installing/installing-power-monitoring#power-monitoring-installing-pmo_installing-power-monitoring
* Deploying Kepler: https://108055--ocpdocs-pr.netlify.app/openshift-power-monitoring/latest/installing/installing-power-monitoring#power-monitoring-deploying-kepler_installing-power-monitoring
* Uninstalling: https://108055--ocpdocs-pr.netlify.app/openshift-power-monitoring/latest/uninstalling/uninstalling-power-monitoring
* Deleting Kepler: https://108055--ocpdocs-pr.netlify.app/openshift-power-monitoring/latest/uninstalling/uninstalling-power-monitoring#power-monitoring-deleting-kepler_uninstalling-power-monitoring
* Uninstalling the Power monitoring Operator: https://108055--ocpdocs-pr.netlify.app/openshift-power-monitoring/latest/uninstalling/uninstalling-power-monitoring#power-monitoring-uninstalling-pmo_uninstalling-power-monitoring
* Configuring: https://108055--ocpdocs-pr.netlify.app/openshift-power-monitoring/latest/configuring/configuring-power-monitoring
* The Kepler configuration: https://108055--ocpdocs-pr.netlify.app/openshift-power-monitoring/latest/configuring/configuring-power-monitoring#power-monitoring-kepler-configuration_configuring-power-monitoring
* Monitoring the Kepler status: https://108055--ocpdocs-pr.netlify.app/openshift-power-monitoring/latest/configuring/configuring-power-monitoring#power-monitoring-monitoring-kepler-status_configuring-power-monitoring
* Configuring Kepler to use Redfish: https://108055--ocpdocs-pr.netlify.app/openshift-power-monitoring/latest/configuring/configuring-power-monitoring#power-monitoring-configuring-kepler-redfish_configuring-power-monitoring
* Visualizing: https://108055--ocpdocs-pr.netlify.app/openshift-power-monitoring/latest/visualizing/visualizing-power-monitoring-metrics
* Power monitoring dashboards overview: https://108055--ocpdocs-pr.netlify.app/openshift-power-monitoring/latest/visualizing/visualizing-power-monitoring-metrics#power-monitoring-dashboards-overview_visualizing-power-monitoring-metrics
* Accessing power monitoring dashboards as a cluster-admin: https://108055--ocpdocs-pr.netlify.app/openshift-power-monitoring/latest/visualizing/visualizing-power-monitoring-metrics#power-monitoring-accessing-dashboards-admin_visualizing-power-monitoring-metrics
* Accessing power monitoring dashboards as a developer: https://108055--ocpdocs-pr.netlify.app/openshift-power-monitoring/latest/visualizing/visualizing-power-monitoring-metrics#power-monitoring-accessing-dashboards-developer_visualizing-power-monitoring-metrics
* Power monitoring metrics overview: https://108055--ocpdocs-pr.netlify.app/openshift-power-monitoring/latest/visualizing/visualizing-power-monitoring-metrics#power-monitoring-metrics-overview_visualizing-power-monitoring-metrics

QE review:
- [N/A] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
* Vale fixes for all files on `power-monitoring-docs-0.3` that are not release notes.
* Release notes are being handled by a separate Jira: https://issues.redhat.com/browse/CCSINTL-3099

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
