### PR TITLE
OSDOCS 18558 Document how to perform boot image updates on the Nutanix platform

### DIFF
--- a/machine_configuration/mco-update-boot-images.adoc
+++ b/machine_configuration/mco-update-boot-images.adoc
@@ -22,6 +22,8 @@ include::modules/mco-update-boot-images-about.adoc[leveloffset=+1]
 
 include::modules/mco-update-boot-images-configuring.adoc[leveloffset=+1]
 
+include::modules/mco-update-boot-images-nutanix.adoc[leveloffset=+2]
+
 include::modules/mco-update-boot-images-openstack.adoc[leveloffset=+2]
 
 [role="_additional-resources"]

--- a/modules/mco-update-boot-images-nutanix.adoc
+++ b/modules/mco-update-boot-images-nutanix.adoc
@@ -1,0 +1,271 @@
+// Module included in the following assemblies:
+//
+// * machine_configuration/mco-update-boot-images.adoc
+// * nodes/nodes/nodes-update-boot-images.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="mco-update-boot-images-nutanix_{context}"]
+= Manually updating the boot image on a Nutanix cluster
+
+[role="_abstract"]
+You can manually update the boot image for your Nutanix cluster by configuring your machine sets to use the latest {product-title} image as the boot image to ensure that new nodes can scale up properly.
+
+[NOTE]
+====
+The standard boot image management feature is not supported for Nutanix clusters.
+====
+
+The following procedure, which includes steps to create environment variables that facilitate running the required commands, shows how to obtain Nutanix authentication credentials, download a boot image, upload that image to the Nutanix Prism Central, and modify your compute machine sets to use the new boot image.
+
+This procedure requires Nutanix authentication credentials, which you need to access Prism Central. If you need to recover your credentials, you can get them from an {product-title} secret, the name of which you can find in the default compute machine set. You can decrypt this secret and export the credentials to create the `clouds.yaml` file, as described in the following procedure.
+
+.Prerequisites
+
+* You have completed the general boot image prerequisites as described in the "Prerequisites" section of the link:https://access.redhat.com/articles/7053165#prerequisites-2[{product-title} Boot Image Updates knowledgebase article].
+
+* You have downloaded the latest version of the {product-title} installation program, openshift-install, from the {cluster-manager-url}. For more information, see "Obtaining the installation program."
+
+* You have installed the {oc-first}.
+
+* You have installed the link:https://stedolan.github.io/jq/[`jq`] program.
+
+.Procedure
+
+. If you need to recover your Nutanix authentication credentials, perform the following steps: 
+
+.. Obtain the name of the secret that contains your credentials by running the following command:
++
+[source,terminal]
+----
+$ oc get machineset -n openshift-machine-api -o yaml | grep credentialsSecret -A 1
+----
++
+.Example output
+[source,terminal]
+----
+    credentialsSecret:
+      name: nutanix-credentials
+----
+
+.. Decrypt the secret by running the following command:
++
+[source,terminal]
+----
+$ oc get secret <secret_name> -n openshift-machine-api -o jsonpath='{.data.credentials}' | base64 -d
+----
++
+Replace `<secret_name>` with the name of the secret, which you obtained in the previous step.
++
+.Example output
+[source,terminal]
+----
+[{"type":"basic_auth","data":{"prismCentral":{"username":"","password":""},"prismElements":null}}]
+----
+
+. Set an environment variable for the Nutanix username by running the following command:
++
+[source,terminal]
+----
+$ export USER="<username>"
+----
+
+. Set an environment variable for the Nutanix password by running the following command:
++
+[source,terminal]
+----
+$ export PASS="<password>"
+----
+
+. If you need to recover your IP address for Prism Central, run the following command:
++
+[source,terminal]
+----
+$ oc get configmap cloud-provider-config -n openshift-config -o jsonpath='{.data.config}' | grep prismCentral -A 8
+----
++
+.Example output
+[source,terminal]
+----
+    "prismCentral": {
+        "address": "",
+        "port": 9440,
+        "credentialRef": {
+            "kind": "Secret",
+            "name": "nutanix-credentials",
+            "namespace": "openshift-cloud-controller-manager"
+        }
+    },
+----
+where:
+
+`prismCentral.address`:: Specifies the Prism Central IP address.
+
+. Set an environment variables for the Prism Central IP address by running the following command:
++
+[source,terminal]
+----
+$ export PC_IP="<prism_central_ip_address>"
+----
+
+. Obtain the boot image and upload the image to Prism Central:
+
+.. Obtain the URL of the {op-system} image you want to use as the boot image and set the location in an environment variable by running the following command:
++
+[source,terminal]
+----
+$ export RHCOS_URL=$(openshift-install coreos print-stream-json | jq -r '.architectures.x86_64.artifacts.nutanix.formats.qcow2.disk.location')
+----
+
+.. Set an environment variable to create a descriptive name for your boot image in Prism Central by running the following command:
++
+[source,terminal]
+----
+$ export IMAGE_NAME="<descriptive_image_name>"
+----
++
+Setting a descriptive name for your boot image in Prism Central, such as using the {op-system-first} version number in the image name, makes it easier to track which version is currently deployed if you update the cluster in the future.
++
+.Example command
+[source,terminal]
+----
+$ export IMAGE_NAME="rhcos-9.6-boot-image"
+----
+
+.. Upload the image to Prism Central by running the following command:
++
+[source,terminal]
+----
+$ curl -k -u "$USER:$PASS" \
+  -X POST "https://$PC_IP:9440/api/nutanix/v3/images" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "spec": {
+      "name": "'"$IMAGE_NAME"'",
+      "resources": {
+        "image_type": "DISK_IMAGE",
+        "source_uri": "'"$RHCOS_URL"'"
+      }
+    },
+    "metadata": {
+      "kind": "image"
+    }
+  }'
+----
++
+`USER`,`PASS`, `IMAGE_NAME`, and `RHCOS_URL` are environment variables you created in previous steps.
+
+.. Optional: Verify that the image is uploaded by running the following command:
++
+[source,terminal]
+----
+$ curl -k -u "$USER:$PASS" \
+  -X POST "https://$PC_IP:9440/api/nutanix/v3/images/list" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "kind": "image",
+    "filter": "name=='"$IMAGE_NAME"'"
+  }'
+----
++
+.Example output
+[source,terminal]
+----
+{
+  "name": "<image-name>",
+  "state": "COMPLETE"
+}
+----
+
+. Update each of your compute machine sets to include the new boot image:
+
+.. Obtain the name of your machine sets for use in the following step by running the following command:
++
+[source,terminal]
+----
+$ oc get machineset -n openshift-machine-api
+----
++
+.Example output
+[source,terminal]
+----
+NAME                                 DESIRED   CURRENT   READY   AVAILABLE   AGE
+rhhdrbk-b5564-4pcm9-worker-0         3         3         3       3           123m
+ci-ln-xj96skb-72292-48nm5-worker-d   1         1         1       1           27m
+----
+
+.. Edit a machine set to update the `image` field in the `providerSpec` stanza to add your boot image by running the following command:
++
+[source,terminal]
+----
+$ oc patch machineset <machineset_name> -n openshift-machine-api --type merge -p '{"spec":{"template":{"spec":{"providerSpec":{"value":{"image":{"type":"name","name":"'${IMAGE_NAME}'"}}}}}}}'  
+----
++
+Replace `<machineset_name>` with the name of your machine set.
+
+.Verification
+
+. Scale up a machine set to check that the new node is using the new boot image:
+
+.. Increase the machine set replicas by one to trigger a new machine by running the following command:
++
+[source,terminal]
+----
+$ oc scale --replicas=<count> machineset <machineset_name> -n openshift-machine-api
+----
+where:
+
+`<count>`:: Specifies the total number of replicas, including any existing replicas, that you want for this machine set.
+`<machineset_name>`:: Specifies the name of the machine set to scale.
+
+.. Optional: View the status of the machine set as it provisions by running the following command:
++
+[source,terminal]
+----
+$ oc get machines.machine.openshift.io -n openshift-machine-api -w
+----
++
+It can take several minutes for the machine set to achieve the `Running` state.
+
+.. Verify that the new node has been created and is in the `Ready` state by running the following command:
++
+[source,terminal]
+----
+$ oc get nodes
+----
+
+. Verify that the new node is using the new boot image by running the following command:
++
+[source,terminal]
+----
+$ oc debug node/<new_node> -- chroot /host cat /sysroot/.coreos-aleph-version.json
+----
++
+Replace `<new_node>` with the name of your new node.
++
+.Example output
+[source,terminal]
+----
+{
+# ...
+    "ref": "docker://ostree-image-signed:oci-archive:/rhcos-9.6.20251212-1-ostree.x86_64.ociarchive",
+    "version": "9.6.20251212-1"
+}
+----
+where:
+
+`version`:: Specifies the boot image version.
+
+. Verify that the boot image is the same version as the image you uploaded in a previous step by running the following command:
++
+[source,terminal]
+----
+$ echo ${RHCOS_URL}
+----
++
+.Example output
+[source,terminal]
+----
+https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20251212-1/x86_64/rhcos-9.6.20251212-1-nutanix.x86_64.qcow2
+----
++
+After you migrate all machine sets to the new boot image, you can remove the old boot image from Prism Central.


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-18558

Incorporate [Nutanix boot image updates](https://hackmd.io/@isabella-janssen/S1PHoijwWg) into the docs.

Link to docs preview:
Machine configuration -> Boot image management -> [Manually updating the boot image on a Nutanix cluster](https://108057--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_configuration/mco-update-boot-images.html#mco-update-boot-images-nutanix_machine-configs-configure) -- New module, in temporary location as of 3/11.

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->