### PR TITLE
Fix `topologyUpdater` casing in NFD CR examples

### DIFF
--- a/modules/creating-nfd-cr-cli.adoc
+++ b/modules/creating-nfd-cr-cli.adoc
@@ -36,7 +36,7 @@ metadata:
   namespace: openshift-nfd
 spec:
   instance: "" # instance is empty by default
-  topologyupdater: false # False by default
+  topologyUpdater: false # False by default
   operand:
     image: registry.redhat.io/openshift4/ose-node-feature-discovery-rhel9:v{product-version} <1>
     imagePullPolicy: Always


### PR DESCRIPTION
Version(s): 4.14+

Issue:

Link to docs preview: https://108061--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hardware_enablement/psap-node-feature-discovery-operator.html

QE review:
- [ ] QE has approved this change.

Additional information:

Here is an example of the OpenShift 4.20 docs where this typo exists: https://docs.redhat.com/en/documentation/openshift_container_platform/4.20/html/specialized_hardware_and_driver_enablement/psap-node-feature-discovery-operator#creating-nfd-cr-cli_psap-node-feature-discovery-operator

Here are links to the NFD Operator for some recent releases showing that `topologyUpdater` is the correct field name:
- 4.21: https://github.com/openshift/cluster-nfd-operator/blob/release-4.21/api/v1/nodefeaturediscovery_types.go#L35
- 4.20: https://github.com/openshift/cluster-nfd-operator/blob/release-4.20/api/v1/nodefeaturediscovery_types.go#L35
- 4.19: https://github.com/openshift/cluster-nfd-operator/blob/release-4.19/api/v1/nodefeaturediscovery_types.go#L35
- 4.18: https://github.com/openshift/cluster-nfd-operator/blob/release-4.18/api/v1/nodefeaturediscovery_types.go#L35 
- 4.17: https://github.com/openshift/cluster-nfd-operator/blob/release-4.17/api/v1/nodefeaturediscovery_types.go#L35
- 4.16: https://github.com/openshift/cluster-nfd-operator/blob/release-4.16/api/v1/nodefeaturediscovery_types.go#L35
- 4.15: https://github.com/openshift/cluster-nfd-operator/blob/release-4.15/api/v1/nodefeaturediscovery_types.go#L35
- 4.14: https://github.com/openshift/cluster-nfd-operator/blob/release-4.14/api/v1/nodefeaturediscovery_types.go#L35
