### PR TITLE
OSDOCS-18599: Correct defaulft namespace for LVMS operator to openshift-lvm-storage

### DIFF
--- a/modules/lvms-installing-logical-volume-manager-operator-using-cli.adoc
+++ b/modules/lvms-installing-logical-volume-manager-operator-using-cli.adoc
@@ -55,7 +55,7 @@ metadata:
   namespace: openshift-lvm-storage
 spec:
   targetNamespaces:
-  - openshift-storage
+  - openshift-lvm-storage
 ----
 
 . Create the `OperatorGroup` CR by running the following command:


### PR DESCRIPTION
- As of v4.20+, the default namespace for LVMS operator has been changed to "openshift-lvm-storage" instead of "openshift-storage".

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
- v4.20+

Issue:
- https://issues.redhat.com/browse/OSDOCS-18599
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
