### PR TITLE
[RHDEVDOCS-7336] Update links to binaries for 1.21 release

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -16,6 +16,7 @@
 :pipelines-shortname: OpenShift Pipelines
 :pipelines-ver: pipelines-1.21
 :pipelines-version-number: 1.21
+:osp-version-patch: 0
 :tekton-cache: Tekton Cache
 :tekton-chains: Tekton Chains
 :tekton-results: Tekton Results

--- a/modules/op-installing-pipelines-as-code-cli.adoc
+++ b/modules/op-installing-pipelines-as-code-cli.adoc
@@ -8,14 +8,14 @@
 [role="_abstract"]
 Cluster administrators can use the `tkn pac` and `opc` CLI tools on local machines or as containers for testing. The `tkn pac` and `opc` CLI tools are installed automatically when you install the `tkn` CLI for {pipelines-title}.
 
-You can install the `tkn pac` and `opc` version `{pipelines-version-number}.0` binaries for the supported platforms:
+You can install the `tkn pac` and `opc` version `{pipelines-version-number}.{osp-version-patch}` binaries for the supported platforms:
 
-* link:https://mirror.openshift.com/pub/openshift-v4/clients/pipelines/{pipelines-version-number}.0/tkn-linux-amd64.tar.gz[Linux (x86_64, amd64)]
-* link:https://mirror.openshift.com/pub/openshift-v4/clients/pipelines/{pipelines-version-number}.0/tkn-linux-s390x.tar.gz[Linux on {ibmzProductName} and {linuxoneProductName} (s390x)]
-* link:https://mirror.openshift.com/pub/openshift-v4/clients/pipelines/{pipelines-version-number}.0/tkn-linux-ppc64le.tar.gz[Linux on {ibmpowerProductName} (ppc64le)]
-* link:https://mirror.openshift.com/pub/openshift-v4/clients/pipelines/{pipelines-version-number}.0/tkn-linux-arm64.tar.gz[Linux on ARM (aarch64, arm64)]
-* link:https://mirror.openshift.com/pub/openshift-v4/clients/pipelines/{pipelines-version-number}.0/tkn-macos-amd64.tar.gz[macOS]
-* link:https://mirror.openshift.com/pub/openshift-v4/clients/pipelines/{pipelines-version-number}.0/tkn-windows-amd64.zip[Windows]
+* link:https://mirror.openshift.com/pub/cgw/pipelines/{pipelines-version-number}.{osp-version-patch}/tkn-linux-amd64.tar.gz[Linux (x86_64, amd64)]
+* link:https://mirror.openshift.com/pub/cgw/pipelines/{pipelines-version-number}.{osp-version-patch}/tkn-linux-s390x.tar.gz[Linux on {ibmzProductName} and {linuxoneProductName} (s390x)]
+* link:https://mirror.openshift.com/pub/cgw/pipelines/{pipelines-version-number}.{osp-version-patch}/tkn-linux-ppc64le.tar.gz[Linux on {ibmpowerProductName} (ppc64le)]
+* link:https://mirror.openshift.com/pub/cgw/pipelines/{pipelines-version-number}.{osp-version-patch}/tkn-linux-arm64.tar.gz[Linux on ARM (aarch64, arm64)]
+* link:https://mirror.openshift.com/pub/cgw/pipelines/{pipelines-version-number}.{osp-version-patch}/tkn-macos-amd64.tar.gz[macOS]
+* link:https://mirror.openshift.com/pub/cgw/pipelines/{pipelines-version-number}.{osp-version-patch}/tkn-windows-amd64.zip[Windows]
 
 // In addition, you can install `tkn pac` using the following methods:
 

--- a/modules/op-installing-tkn-on-linux.adoc
+++ b/modules/op-installing-tkn-on-linux.adoc
@@ -13,13 +13,13 @@ For Linux distributions, you can download the CLI as a `tar.gz` archive.
 
 . Download the relevant CLI tool.
 
-* link:https://mirror.openshift.com/pub/openshift-v4/clients/pipelines/{pipelines-version-number}.0/tkn-linux-amd64.tar.gz[Linux (x86_64, amd64)]
+* link:https://mirror.openshift.com/pub/cgw/pipelines/{pipelines-version-number}.{osp-version-patch}/tkn-linux-amd64.tar.gz[Linux (x86_64, amd64)]
 
-* link:https://mirror.openshift.com/pub/openshift-v4/clients/pipelines/{pipelines-version-number}.0/tkn-linux-s390x.tar.gz[Linux on {ibmzProductName} and {linuxoneProductName} (s390x)]
+* link:https://mirror.openshift.com/pub/cgw/pipelines/{pipelines-version-number}.{osp-version-patch}/tkn-linux-s390x.tar.gz[Linux on {ibmzProductName} and {linuxoneProductName} (s390x)]
 
-* link:https://mirror.openshift.com/pub/openshift-v4/clients/pipelines/{pipelines-version-number}.0/tkn-linux-ppc64le.tar.gz[Linux on {ibmpowerProductName} (ppc64le)]
+* link:https://mirror.openshift.com/pub/cgw/pipelines/{pipelines-version-number}.{osp-version-patch}/tkn-linux-ppc64le.tar.gz[Linux on {ibmpowerProductName} (ppc64le)]
 
-* link:https://mirror.openshift.com/pub/openshift-v4/clients/pipelines/{pipelines-version-number}.0/tkn-linux-arm64.tar.gz[Linux on ARM (aarch64, arm64)]
+* link:https://mirror.openshift.com/pub/cgw/pipelines/{pipelines-version-number}.{osp-version-patch}/tkn-linux-arm64.tar.gz[Linux on ARM (aarch64, arm64)]
 
 // Binaries also need to be updated in the following modules:
 // op-installing-pipelines-as-code-cli.adoc

--- a/modules/op-installing-tkn-on-macos.adoc
+++ b/modules/op-installing-tkn-on-macos.adoc
@@ -13,9 +13,9 @@ For macOS, you can download the CLI as a `tar.gz` archive.
 
 . Download the relevant CLI tool.
 
-* link:https://mirror.openshift.com/pub/openshift-v4/clients/pipelines/{pipelines-version-number}.0/tkn-macos-amd64.tar.gz[macOS]
+* link:https://mirror.openshift.com/pub/cgw/pipelines/{pipelines-version-number}.{osp-version-patch}/tkn-macos-amd64.tar.gz[macOS]
 
-* link:https://mirror.openshift.com/pub/openshift-v4/clients/pipelines/{pipelines-version-number}.0/tkn-macos-arm64.tar.gz[macOS on ARM]
+* link:https://mirror.openshift.com/pub/cgw/pipelines/{pipelines-version-number}.{osp-version-patch}/tkn-macos-arm64.tar.gz[macOS on ARM]
 
 . Unpack and extract the archive.
 

--- a/modules/op-installing-tkn-on-windows.adoc
+++ b/modules/op-installing-tkn-on-windows.adoc
@@ -11,7 +11,7 @@ For Windows, you can download the CLI as a `zip` archive.
 
 .Procedure
 
-.  Download the link:https://mirror.openshift.com/pub/openshift-v4/clients/pipelines/{pipelines-version-number}.0/tkn-windows-amd64.zip[CLI tool].
+.  Download the link:https://mirror.openshift.com/pub/cgw/pipelines/{pipelines-version-number}.{osp-version-patch}/tkn-windows-amd64.zip[CLI tool].
 
 . Extract the archive with a ZIP program.
 ifndef::openshift-rosa,openshift-dedicated[]


### PR DESCRIPTION
Version(s):
- _none for cherry-picking_

Issue:
- https://issues.redhat.com/browse/RHDEVDOCS-7336

Link to docs preview:
- for example, links in [Installing tkn on Linux](https://108067--ocpdocs-pr.netlify.app/openshift-pipelines/latest/tkn_cli/installing-tkn.html#installing-tkn-on-linux)

QE review:
- [x] QE approval not needed.
