### PR TITLE
OSDOCS-18427: Added duplicate NAD name issue to Configuration for a l…

### DIFF
--- a/modules/configuring-localnet-switched-topology.adoc
+++ b/modules/configuring-localnet-switched-topology.adoc
@@ -9,6 +9,11 @@
 [role="_abstract"]
 The switched `localnet` topology interconnects the workloads created as Network Attachment Definitions (NADs) through a cluster-wide logical switch to a physical network.
 
+[IMPORTANT]
+====
+When creating multiple NADs, ensure that each NAD references a unique VLAN ID number. If two NADs reference the same VLAN ID, the OVN-Kubernetes network plugin experiences networking issues.
+====
+
 You must map a secondary network to the OVS bridge to use it as an OVN-Kubernetes secondary network. Bridge mappings allow network traffic to reach the physical network. A bridge mapping associates a physical network name, also known as an interface label, to a bridge created with Open vSwitch (OVS).
 
 You can create an `NodeNetworkConfigurationPolicy` (NNCP) object, part of the `nmstate.io/v1` API group, to declaratively create the mapping. This API is provided by the NMState Operator. By using this API you can apply the bridge mapping to nodes that match your specified `nodeSelector` expression, such as `node-role.kubernetes.io/worker: ''`. With this declarative approach, the NMState Operator applies secondary network configuration to all nodes specified by the node selector automatically and transparently.


### PR DESCRIPTION
Version(s):
4.17+

Issue:
[OSDOCS-18427](https://issues.redhat.com/browse/OSDOCS-18427)

Link to docs preview:
* [Configuration for a localnet switched topology](https://108070--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/multiple_networks/secondary_networks/creating-secondary-nwt-ovnk.html#configuration-localnet-switched-topology_configuring-additional-network-ovnk)

- [x] SME has approved this change (Harshit Mongia).
- [x] QE has approved this change (Weibin Liang).
