### PR TITLE
Adds missing source,terminal,subs=+quotes syntax to MS commands

### DIFF
--- a/modules/microshift-backing-up-manually.adoc
+++ b/modules/microshift-backing-up-manually.adoc
@@ -20,7 +20,7 @@ You can back up {microshift-short} data manually at any time. Back up your data 
 
 . Manually create a backup by using the parent directory and specifying a name, such as `/var/lib/microshift-backups/<my_manual_backup>`, by running the following command:
 +
-[source,terminal]
+[source,terminal,subs="+quotes"]
 ----
 $ sudo microshift backup /var/lib/microshift-backups/_<manual_backup>_
 ----
@@ -39,9 +39,9 @@ $ sudo microshift backup /var/lib/microshift-backups/_<manual_backup>_
 
 . Optional: Manually create a backup in a specific parent directory with a custom name by running the following command:
 +
-[source,terminal]
+[source,terminal,subs="+quotes"]
 ----
-$ sudo microshift backup /mnt/<other_backups_location>/<another_manual_backup>
+$ sudo microshift backup /mnt/_<other_backups_location>_/_<another_manual_backup>_
 ----
 +
 ** For `_<other_backups_location>_`, specify the directory that you want to use.

--- a/modules/microshift-restoring-data-backups.adoc
+++ b/modules/microshift-restoring-data-backups.adoc
@@ -24,7 +24,7 @@ On an `rpm-ostree` system, {microshift-short} backs up and restores data automat
 
 . Manually restore {microshift-short} data by using the full file path of the backup you want to restore by running the following command:
 +
-[source,terminal]
+[source,terminal,subs="+quotes"]
 ----
 $ sudo microshift restore /var/lib/microshift-backups/_<manual_backup>_
 ----
@@ -45,7 +45,7 @@ $ sudo microshift restore /var/lib/microshift-backups/_<manual_backup>_
 
 . Optional. Manually restore data from a customized directory by using the full file path of the backup. Run the following command:
 +
-[source,terminal]
+[source,terminal,subs="+quotes"]
 ----
 $ sudo microshift restore /mnt/_<other_backups_location>_/_<another_manual_backup>_
 ----


### PR DESCRIPTION
Follow up to https://github.com/openshift/openshift-docs/pull/106398. Adds missing subs=+quotes syntax. 

Version(s):
4.18 

Issue:
https://issues.redhat.com/browse/OSDOCS-17104

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
