### PR TITLE
[OBSDOCS-3176] Release notes for Logging 6.2.9

### DIFF
--- a/modules/logging-release-notes-6-2-9.adoc
+++ b/modules/logging-release-notes-6-2-9.adoc
@@ -1,0 +1,23 @@
+// Module included in the following assemblies:
+//
+// * release_notes/logging-release-notes-6.2.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="logging-release-notes-6-2-9_{context}"]
+= Logging 6.2.9 Release Notes
+
+This release includes link:https://access.redhat.com/errata/RHSA-2026:4500[RHSA-2026:4500].
+
+[id="logging-release-notes-6-2-9-bug-fixes_{context}"]
+== Bug fixes
+
+* Before this update, syslog output could become corrupted when Eventrouter log messages contained newline characters (`\n`). The syslog sink interpreted newlines as delimiters. It split a single event across multiple malformed records and populated metadata fields such as `hostname` and `syslogtag` with invalid data. With this update, the system escapes newline characters in log payloads. As a result, the syslog sink emits a single, well-formed line with correct metadata.
+(link:https://issues.redhat.com/browse/LOG-8892[LOG-8892])
+
+
+[id="logging-release-notes-6-2-9-cves_{context}"]
+== CVEs
+
+* link:https://access.redhat.com/security/cve/CVE-2025-61726[CVE-2025-61726]
+* link:https://access.redhat.com/security/cve/CVE-2025-61729[CVE-2025-61729]
+* link:https://access.redhat.com/security/cve/CVE-2025-68121[CVE-2025-68121]

--- a/release_notes/logging-release-notes-6.2.adoc
+++ b/release_notes/logging-release-notes-6.2.adoc
@@ -6,6 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+include::modules/logging-release-notes-6-2-9.adoc[leveloffset=+1]
+
 include::modules/logging-release-notes-6-2-8.adoc[leveloffset=+1]
 
 include::modules/logging-release-notes-6-2-7.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s):
- _none for cherry-picking_

Issue:
- https://issues.redhat.com/browse/OBSDOCS-3176

Link to docs preview:
- [6.2.9 Release notes](https://108079--ocpdocs-pr.netlify.app/openshift-logging/latest/release_notes/logging-release-notes-6.2.html#logging-release-notes-6-2-9_loggging-release-notes-6-2)

QE review:
- [x] QE has approved this change.
