### PR TITLE
OSDOCS-18602 added new APIs and updated existing ones

### DIFF
--- a/modules/eso-component-config.adoc
+++ b/modules/eso-component-config.adoc
@@ -1,0 +1,43 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-operator-api.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="eso-comoponent-config_{context}"]
+= componentConfig
+
+[role="_abstract"]
+The `componentConfig` field defines configuration overrides for a specific `external-secrets` component.
+
+[cols="1,1,1,1,1",options="header"]
+|===
+| Field
+| Type
+| Description
+| Default
+| Validation
+
+| `componentName`
+| _string_
+| `componentName` identifies which `external-secrets` component this configuration applies to. Valid values are `ExternalSecretsCoreController`, `Webhook`, `CertController`, and `BitwardenSDKServer`.
+|
+a| Enum: [`ExternalSecretsCoreController`, `Webhook`, `CertController`, `BitwardenSDKServer`]
+
+Required
+
+| `deploymentConfigs`
+| _object_
+| `deploymentConfigs` specifies overrides for the Kubernetes Deployment resource of this component.
+|
+|Optional
+
+| `overrideEnv`
+a| *EnvVar*
+
+_array_
+| `overrideEnv` specifies custom environment variables for this component's container. These are merged with operator-managed environment variables, with user-defined values taking precedence. Environment variable names starting with `HOSTNAME`, `KUBERNETES_` or `EXTERNAL_SECRETS_` are reserved and are not allowed.
+|
+a| The maximum number of items is 50.
+
+Optional
+|===

--- a/modules/eso-controller-config.adoc
+++ b/modules/eso-controller-config.adoc
@@ -33,4 +33,23 @@ The minimum number of properties is 0.
 
 Optional
 
+| `annotations`
+| _object (keys:string, values:string)_
+| `annotations` add custom annotations to all the resources created for the `external-secrets` deployment. The annotations are merged with any default annotations set by the Operator. User-specified annotations take precedence over defaults in case of conflicts. Annotation keys containing the reserved domains `kubernetes.io/`, `openshift.io/`, `k8s.io/`, or `cert-manager.io/` (including subdomains like `*.kubernetes.io/`) are not allowed.
+|
+a| The maximum number of properties is 20.
+
+The minimum number of properties is 0.
+
+Optional
+
+| `componentConfigs`
+| _ComponentConfig array_
+| `componentConfigs` allows specifying deployment-level configuration overrides for individual `external-secrets` components. Each component can have only one configuration entry.
+a| The maximum number of items is 4.
+
+The minimum number of items is 0.
+
+Optional
+
 |===

--- a/modules/eso-deployment-config.adoc
+++ b/modules/eso-deployment-config.adoc
@@ -1,0 +1,29 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-operator-api.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="eso-deployment-config_{context}"]
+= deploymentConfig
+
+[role="_abstract"]
+The `deploymentConfig` field defines configuration overrides for a Kubernetes Deployment resource.
+
+[cols="1,1,1,1,1",options="header"]
+|===
+| Field
+| Type
+| Description
+| Default
+| Validation
+
+| `revisionHistoryLimit`
+| _integer_
+| `revisionHistoryLimit` specifies the number of old `ReplicaSets` to retain for rollback purposes. This allows rolling back to previous deployment versions using the command `oc rollout undo`. Must be at least 1 to ensure rollback capability.
+| 10
+a| The minimum value is 1.
+
+The maximum value is 50.
+
+Optional
+|===

--- a/security/external_secrets_operator/external-secrets-operator-api.adoc
+++ b/security/external_secrets_operator/external-secrets-operator-api.adoc
@@ -105,3 +105,10 @@ include::modules/eso-plugins-config.adoc[leveloffset=+1]
 
 //ProxyConfig
 include::modules/eso-proxy-config.adoc[leveloffset=+1]
+
+//componentConfig
+include::modules/eso-component-config.adoc[leveloffset=+1]
+
+//deploymentConfig
+include::modules/eso-deployment-config.adoc[leveloffset=+1]
+


### PR DESCRIPTION
Version(s):
4.18+

Issue:
https://issues.redhat.com/browse/OSDOCS-18602

Link to docs preview:
https://108080--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/external_secrets_operator/external-secrets-operator-api.html#eso-controller-config_external-secrets-operator-api

https://108080--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/external_secrets_operator/external-secrets-operator-api.html#eso-comoponent-config_external-secrets-operator-api

https://108080--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/external_secrets_operator/external-secrets-operator-api.html#eso-deployment-config_external-secrets-operator-api


QE review:
- [x] QE has approved this change.


Additional information:

