### PR TITLE
[OBSDOCS-3178] Release notes for Logging 6.4.3

### DIFF
--- a/modules/logging-release-notes-6-4-3.adoc
+++ b/modules/logging-release-notes-6-4-3.adoc
@@ -1,0 +1,29 @@
+// Module included in the following assemblies:
+//
+// * release_notes/logging-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="logging-release-notes-6-4-3_{context}"]
+= Logging 6.4.3 release notes
+
+This release includes link:https://access.redhat.com/errata/RHSA-2026:4498[RHSA-2026:4498].
+
+[id="logging-release-notes-6-4-3-bug-fixes_{context}"]
+== Bug fixes
+
+* Before this update, the `k8s_audit_level` field could become null when you referenced it in the `.notIn` section of a prune filter for audit logs. This happened because `k8s_audit_level` depends on `.structured.level`. If you pruned `.structured.level`, the audit level was lost. As a result, audit logs reached the output destination without their associated audit level metadata, complicating log analysis. With this update, the pruning logic ensures the `k8s_audit_level` field retains its value. As a result, audit metadata remains intact even when you use custom prune filters.
+(link:https://issues.redhat.com/browse/LOG-8289[LOG-8289])
+
+* Before this update, prune filters for audit logs did not preserve the `.auditID` field unless you referenced it as `.structured.auditID` in the `.notIn` section. Referencing `.auditID` caused the field to be removed from the output. With this update, the pruning logic correctly preserves the `auditID` field when you reference it as `.auditID`. As a result, you do not need to use `.structured.auditID`.
+(link:https://issues.redhat.com/browse/LOG-8291[LOG-8291])
+
+* Before this update, prune filters did not work as expected for audit logs when you referenced fields such as `.requestURI` or `.stage`. The logging pipeline stored audit log fields under `.structured` during processing. It applied the prune filter earlier in the pipeline, before restoring those fields to the top-level log structure. As a result, the prune filter did not remove the specified fields. With this update, the system applies the prune filter at the correct stage of the pipeline. As a result, audit log fields are pruned according to the configured rules.
+(link:https://issues.redhat.com/browse/LOG-8597[LOG-8597])
+
+
+[id="logging-release-notes-6-4-3-cves_{context}"]
+== CVEs
+
+* link:https://access.redhat.com/security/cve/CVE-2025-61726[CVE-2025-61726]
+* link:https://access.redhat.com/security/cve/CVE-2025-61729[CVE-2025-61729]
+* link:https://access.redhat.com/security/cve/CVE-2025-68121[CVE-2025-68121]

--- a/release_notes/logging-release-notes.adoc
+++ b/release_notes/logging-release-notes.adoc
@@ -7,6 +7,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+include::modules/logging-release-notes-6-4-3.adoc[leveloffset=+1]
+
 include::modules/logging-release-notes-6-4-2.adoc[leveloffset=+1]
 
 include::modules/logging-release-notes-6-4-1.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s):
- _none for cherry-picking_

Issue:
- https://issues.redhat.com/browse/OBSDOCS-3178

Link to docs preview:
- [6.4.3 Release notes](https://108081--ocpdocs-pr.netlify.app/openshift-logging/latest/release_notes/logging-release-notes.html#logging-release-notes-6-4-3_logging-release-notes)

QE review:
- [x] QE has approved this change.
