### PR TITLE
TELCODOCS-2616: Adding cluster-compare docs to hub RDS

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -177,6 +177,10 @@ ifdef::telco-core[]
 :rds: telco core
 :rds-caps: Telco core
 endif::[]
+ifdef::telco-hub[]
+:rds: telco hub
+:rds-caps: Telco hub
+endif::[]
 //lightspeed
 :ols-official: Red{nbsp}Hat OpenShift Lightspeed
 :ols: OpenShift Lightspeed

--- a/modules/using-cluster-compare-telco-hub.adoc
+++ b/modules/using-cluster-compare-telco-hub.adoc
@@ -1,0 +1,131 @@
+// Module included in the following assemblies:
+//
+// * scalability_and_performance/telco-hub-rds.adoc
+
+:_mod-docs-content-type: PROCEDURE
+
+[id="using-cluster-compare-telco_hub_{context}"]
+= Comparing a cluster with the {rds} reference configuration
+
+After you deploy a {rds} cluster, you can use the `cluster-compare` plugin to assess the cluster's compliance with the {rds} reference design specifications (RDS). The `cluster-compare` plugin is an OpenShift CLI (`oc`) plugin. The plugin uses a {rds} reference configuration to validate the cluster with the {rds} custom resources (CRs).
+
+The plugin-specific reference configuration for {rds} is packaged in a container image with the {rds} CRs.
+
+For further information about the `cluster-compare` plugin, see "Understanding the cluster-compare plugin".
+
+The following example shows how to compare the configuration of a cluster to the {rds} reference configuration by using `must-gather` data.
+
+[NOTE]
+====
+When comparing a cluster to the {rds} reference configuration by using `must-gather` data, you must use the `--all-images` flag when generating the `must-gather` data. You must also collect cluster-scoped resource information, as well as Operator and registry configurations. Without this data, the plugin might report false positives.
+====
+
+.Prerequisites
+
+* You have access to the cluster as a user with the `cluster-admin` role.
+
+* You have credentials to access the `registry.redhat.io` container image registry.
+
+* You installed the `cluster-compare` plugin.
+
+* You extracted the {rds} reference configuration from the `openshift-telco-hub-rds-rhel9` container image.
+
+.Procedure
+
+. Collect data about your cluster by running the `must-gather` command with the `--all-images` flag:
++
+[source,terminal]
+----
+$ oc adm must-gather --all-images
+----
++
+* The `--all-images` flag ensures that the `must-gather` command collects all the data required by the {rds} reference configuration.
+
+. Collect cluster-scoped resource information by running the following command:
++
+[source,terminal]
+----
+$ oc adm inspect clusterroles,clusterrolebindings,namespaces,nodes --dest-dir=./cluster-scoped
+----
+
+. Collect Operator and registry configurations by running the following command:
++
+[source,terminal]
+----
+$ oc adm inspect imagedigestmirrorset,imagetagmirrorset,catalogsource,clusterserviceversion,customresourcedefinition,operatorhub --dest-dir=./cluster-config
+----
+
+. Compare the collected data to a reference configuration by running the following command:
++
+[source,terminal]
+----
+$ oc cluster-compare -r <path_to_reference_config>/metadata.yaml -f "must-gather*/*/cluster-scoped-resources","must-gather*/*/namespaces","cluster-scoped","cluster-config" -R
+----
++
+** `-r` specifies a path to the `metadata.yaml` file of the reference configuration. You can specify a local directory or a URI.
+** `-f` specifies the path to the `must-gather` data directory. You can specify a local directory or a URI. This example restricts the comparison to the relevant cluster configuration directories in the `must-gather` data, and also the `cluster-config` and `cluster-scoped` directories you created.
+** `-R` searches the target directories recursively.
++
+.Example output
+[source,terminal]
+----
+W0309 13:08:01.564387   29400 compare.go:476] Reference Contains Templates With Types (kind) Not Supported By Cluster: AgentServiceConfig, AppProject, Application, Certificate, ClusterIssuer, ClusterLogForwarder, LocalVolume, ManagedClusterSetBinding, MultiClusterEngine, MultiClusterHub, MultiClusterObservability, ObjectBucketClaim, Placement, PlacementBinding, Policy, StorageCluster
+...
+
+**********************************
+
+Cluster CR: operator.openshift.io/v1_IngressController_openshift-ingress-operator_default
+Reference File: optional/cert-manager/ingressControllerConfig.yaml
+Diff Output: diff -u -N /tmp/MERGED-3542158379/operator-openshift-io-v1_ingresscontroller_openshift-ingress-operator_default /tmp/LIVE-285048405/operator-openshift-io-v1_ingresscontroller_openshift-ingress-operator_default
+--- /tmp/MERGED-3542158379/operator-openshift-io-v1_ingresscontroller_openshift-ingress-operator_default	2026-03-09 13:09:32.985703558 +0000
++++ /tmp/LIVE-285048405/operator-openshift-io-v1_ingresscontroller_openshift-ingress-operator_default	2026-03-09 13:09:32.985703558 +0000
+@@ -4,5 +4,17 @@
+   name: default
+   namespace: openshift-ingress-operator
+ spec:
+-  defaultCertificate:
+-    name: ingress-wildcard-cert
++  clientTLS:
++    clientCA:
++      name: ""
++    clientCertificatePolicy: ""
++  closedClientConnectionPolicy: Continue
++  httpCompression: {}
++  httpEmptyRequestsPolicy: Respond
++  httpErrorCodePages:
++    name: ""
++  idleConnectionTerminationPolicy: Immediate
++  replicas: 2
++  tuningOptions:
++    reloadInterval: 0s
++  unsupportedConfigOverrides: null
+
+**********************************
+
+Summary
+CRs with diffs: 5/5
+CRs in reference missing from the cluster: 43
+optional-cert-manager:
+  cert-manager-apiserver:
+    Missing CRs:
+    - optional/cert-manager/apiServerCertificate.yaml
+  cert-manager-ingress:
+    Missing CRs:
+    - optional/cert-manager/ingressCertificate.yaml
+
+...
+
+No CRs are unmatched to reference CRs
+Metadata Hash: 6297bc738df2373467cc6f5acc3a6aa23f3c3d0b0ce2ac23887d7914a6241d92
+No patched CRs
+
+----
++
+* `Cluster CR` shows the CR with a difference from the corresponding template.
+* `Reference File` shows the template file that the tool uses in its comparison with the cluster CR. The output in Linux diff format shows the difference between the template and the cluster CR.
+* `CRs with diffs` shows the number of CRs in the comparison with differences from the corresponding templates.
+* `CRs in reference missing from the cluster` shows the number of CRs represented in the reference configuration, but missing from the live cluster.
+* `Missing CRs` shows the list of CRs represented in the reference configuration, but missing from the live cluster.
+* `No CRs are unmatched to reference CRs` indicates that all CRs in the cluster matched to a corresponding template in the reference configuration.
+* `Metadata Hash` shows the metadata hash that identifies the reference configuration.
+* `No patched CRs` indicates that there are no patched CRs in the cluster.

--- a/scalability_and_performance/telco-hub-rds.adoc
+++ b/scalability_and_performance/telco-hub-rds.adoc
@@ -218,6 +218,8 @@ include::modules/telco-hub-oadp-operator.adoc[leveloffset=+2]
 
 include::modules/telco-hub-rds-container.adoc[leveloffset=+1]
 
+include::modules/using-cluster-compare-telco-hub.adoc[leveloffset=+1]
+
 include::modules/hub-cluster-ref-config-crs.adoc[leveloffset=+1]
 
 include::modules/telco-hub-crs-advanced-cluster-management.adoc[leveloffset=+1]


### PR DESCRIPTION
[TELCODOCS-2616](https://issues.redhat.com/browse/TELCODOCS-2616): Adding cluster-compare docs to hub RDS

Version(s):
4.21+

Issue:
https://issues.redhat.com/browse/TELCODOCS-2616

Link to docs preview:
https://108082--ocpdocs-pr.netlify.app/openshift-enterprise/latest/scalability_and_performance/telco-hub-rds#using-cluster-compare-telco_hub_telco-hub 

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
