### PR TITLE
DOCPLAN-78: Monitoring docs abstract fixes

### DIFF
--- a/modules/monitoring-querying-metrics-for-all-projects-with-mon-dashboard.adoc
+++ b/modules/monitoring-querying-metrics-for-all-projects-with-mon-dashboard.adoc
@@ -8,8 +8,9 @@
 = Querying metrics for all projects with the {product-title} web console
 
 // The following section will be included in the administrator section, hence there is no need to include "administrator" in the title
+[role="_abstract"]
 
-You can use the {product-title} metrics query browser to run Prometheus Query Language (PromQL) queries to examine metrics visualized on a plot. This functionality provides information about the state of a cluster and any user-defined workloads that you are monitoring.
+Monitor the state of a cluster and any user-defined workloads by using the {product-title} metrics query browser. The query browser uses Prometheus Query Language (PromQL) queries to examine metrics visualized on a plot.
 
 As a
 ifndef::openshift-dedicated,openshift-rosa[]
@@ -26,8 +27,6 @@ ifdef::openshift-dedicated,openshift-rosa[]
 Only dedicated administrators have access to the third-party UIs provided with {product-title} monitoring.
 ====
 endif::openshift-dedicated,openshift-rosa[]
-
-The Metrics UI includes predefined queries, for example, CPU, memory, bandwidth, or network packet for all projects. You can also run custom Prometheus Query Language (PromQL) queries.
 
 .Prerequisites
 

--- a/modules/monitoring-querying-metrics-for-user-defined-projects-with-mon-dashboard.adoc
+++ b/modules/monitoring-querying-metrics-for-user-defined-projects-with-mon-dashboard.adoc
@@ -7,11 +7,10 @@
 [id="querying-metrics-for-user-defined-projects-with-mon-dashboard_{context}"]
 = Querying metrics for user-defined projects with the {product-title} web console
 
-You can use the {product-title} metrics query browser to run Prometheus Query Language (PromQL) queries to examine metrics visualized on a plot. This functionality provides information about any user-defined workloads that you are monitoring.
+[role="_abstract"]
+Monitor user-defined workloads by using the {product-title} metrics query browser. The query browser uses Prometheus Query Language (PromQL) queries to examine metrics visualized on a plot.
 
 As a developer, you must specify a project name when querying metrics. You must have the required privileges to view metrics for the selected project.
-
-The Metrics UI includes predefined queries, for example, CPU, memory, bandwidth, or network packet. These queries are restricted to the selected project. You can also run custom Prometheus Query Language (PromQL) queries for the project.
 
 ifdef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 [NOTE]

--- a/modules/virt-defining-watchdogs.adoc
+++ b/modules/virt-defining-watchdogs.adoc
@@ -1,0 +1,28 @@
+// Module included in the following assemblies:
+//
+// * virt/monitoring/virt-monitoring-vm-health.adoc
+
+:_mod-docs-content-type: CONCEPT
+
+[id="virt-defining-watchdogs_{context}"]
+= About watchdogs
+
+[role="_abstract"]
+A watchdog device monitors the agent and performs one of the following actions if the guest operating system is unresponsive:
+
+* `poweroff`: The virtual machine (VM) powers down immediately. If `spec.runStrategy` is not set to `manual`, the VM reboots.
+* `reset`: The VM reboots in place and the guest operating system cannot react.
++
+[NOTE]
+====
+The reboot time might cause liveness probes to time out. If cluster-level protections detect a failed liveness probe, the VM might be forcibly rescheduled, increasing the reboot time.
+====
+
+* `shutdown`: The VM gracefully powers down by stopping all services.
+
+[NOTE]
+====
+Watchdog functionality is not available for Windows VMs.
+====
+
+You can create a watchdog device by configuring the device for a VM and installing the watchdog agent on the guest.

--- a/virt/monitoring/virt-exposing-custom-metrics-for-vms.adoc
+++ b/virt/monitoring/virt-exposing-custom-metrics-for-vms.adoc
@@ -7,9 +7,8 @@ include::_attributes/attributes-openshift-dedicated.adoc[]
 
 toc::[]
 
-{product-title} includes a preconfigured, preinstalled, and self-updating monitoring stack that provides monitoring for core platform components. This monitoring stack is based on the Prometheus monitoring system. Prometheus is a time-series database and a rule evaluation engine for metrics.
-
-In addition to using the {product-title} monitoring stack, you can enable monitoring for user-defined projects by using the CLI and query custom metrics that are exposed for virtual machines through the `node-exporter` service.
+[role="_abstract"]
+Monitor core platform components using the {product-title} monitoring stack based on the Prometheus monitoring system. Additionally, enable monitoring for user-defined projects by using the CLI and query custom metrics that are exposed for virtual machines through the `node-exporter` service.
 
 include::modules/virt-configuring-node-exporter-service.adoc[leveloffset=+1]
 include::modules/virt-configuring-vm-with-node-exporter-service.adoc[leveloffset=+1]

--- a/virt/monitoring/virt-exposing-downward-metrics.adoc
+++ b/virt/monitoring/virt-exposing-downward-metrics.adoc
@@ -6,34 +6,22 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-As an administrator, you can expose a limited set of host and virtual machine (VM) metrics to a guest VM by first enabling a `downwardMetrics` feature gate and then configuring a `downwardMetrics` device.
-
-Users can view the metrics results by using the command line or the `vm-dump-metrics tool`.
+[role="_abstract"]
+As an administrator, you can expose a set of host and virtual machine (VM) metrics to a guest VM by enabling the `downwardMetrics` feature gate and configuring a downward metrics device. You can view these metrics by using the command line or the `vm-dump-metrics` tool.
 
 [NOTE]
 ====
 On Red Hat Enterprise Linux (RHEL) 9, use the command line to view downward metrics. See xref:../../virt/monitoring/virt-exposing-downward-metrics.adoc#virt-viewing-downward-metrics-cli_virt-exposing-downward-metrics[Viewing downward metrics by using the command line].
 
-The vm-dump-metrics tool is not supported on the Red Hat Enterprise Linux (RHEL) 9 platform.
+The `vm-dump-metrics` tool is not supported on the Red Hat Enterprise Linux (RHEL) 9 platform.
 ====
 
-[id="virt-enabling-disabling-feature-gate"]
-== Enabling or disabling the downwardMetrics feature gate
+include::modules/virt-enabling-disabling-downward-metrics-feature-gate-yaml.adoc[leveloffset=+1]
 
-You can enable or disable the `downwardMetrics` feature gate by performing either of the following actions:
-
-* Editing the HyperConverged custom resource (CR) in your default editor
-* Using the command line
-
-include::modules/virt-enabling-disabling-downward-metrics-feature-gate-yaml.adoc[leveloffset=+2]
-
-include::modules/virt-enabling-disabling-downward-metrics-feature-gate-cli.adoc[leveloffset=+2]
+include::modules/virt-enabling-disabling-downward-metrics-feature-gate-cli.adoc[leveloffset=+1]
 
 include::modules/virt-configuring-downward-metrics.adoc[leveloffset=+1]
 
-include::modules/virt-viewing-downward-metrics.adoc[leveloffset=+1]
+include::modules/virt-viewing-downward-metrics-cli.adoc[leveloffset=+1]
 
-include::modules/virt-viewing-downward-metrics-cli.adoc[leveloffset=+2]
-
-include::modules/virt-viewing-downward-metrics-tool.adoc[leveloffset=+2]
-
+include::modules/virt-viewing-downward-metrics-tool.adoc[leveloffset=+1]

--- a/virt/monitoring/virt-monitoring-overview.adoc
+++ b/virt/monitoring/virt-monitoring-overview.adoc
@@ -6,7 +6,10 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-You can monitor the health of your cluster and virtual machines (VMs) with the following tools:
+[role="_abstract"]
+Monitor the health of your cluster and virtual machines (VMs) to have a unified operational view of your environment. This ensures high availability and optimal resource performance.
+
+You can monitor the health of your cluster and VMs with the following tools:
 
 Monitoring {VirtProductName} VM health status::
 View the overall health of your {VirtProductName} environment in the web console by navigating to the *Home* -> *Overview* page in the {product-title} web console. The *Status* card displays the overall health of {VirtProductName} based on the alerts and conditions.

--- a/virt/monitoring/virt-monitoring-vm-health.adoc
+++ b/virt/monitoring/virt-monitoring-vm-health.adoc
@@ -6,7 +6,10 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-You can configure virtual machine (VM) health checks by defining readiness and liveness probes in the `VirtualMachine` resource.
+[role="_abstract"]
+Define probes and watchdogs in the `VirtualMachine` resource to configure virtual machine (VM) health checks. Health checks monitor and report the internal state of a VM.
+
+You can configure VM health checks by defining readiness and liveness probes in the `VirtualMachine` resource.
 
 include::modules/virt-about-readiness-liveness-probes.adoc[leveloffset=+1]
 
@@ -16,30 +19,7 @@ include::modules/virt-define-tcp-readiness-probe.adoc[leveloffset=+2]
 
 include::modules/virt-define-http-liveness-probe.adoc[leveloffset=+2]
 
-[id="watchdog_{context}"]
-== Defining a watchdog
-
-You can define a watchdog to monitor the health of the guest operating system by performing the following steps:
-
-. Configure a watchdog device for the virtual machine (VM).
-. Install the watchdog agent on the guest.
-
-The watchdog device monitors the agent and performs one of the following actions if the guest operating system is unresponsive:
-
-* `poweroff`: The VM powers down immediately. If `spec.runStrategy` is not set to `manual`, the VM reboots.
-* `reset`: The VM reboots in place and the guest operating system cannot react.
-+
-[NOTE]
-====
-The reboot time might cause liveness probes to time out. If cluster-level protections detect a failed liveness probe, the VM might be forcibly rescheduled, increasing the reboot time.
-====
-
-* `shutdown`: The VM gracefully powers down by stopping all services.
-
-[NOTE]
-====
-Watchdog is not available for Windows VMs.
-====
+include::modules/virt-defining-watchdogs.adoc[leveloffset=+1]
 
 include::modules/virt-defining-watchdog-device-vm.adoc[leveloffset=+2]
 

--- a/virt/monitoring/virt-prometheus-queries.adoc
+++ b/virt/monitoring/virt-prometheus-queries.adoc
@@ -7,23 +7,18 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-ifndef::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
-{VirtProductName} provides metrics that you can use to monitor the consumption of cluster infrastructure resources, including vCPU, network, storage, and guest memory swapping. You can also use metrics to query live migration status.
-endif::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
-ifdef::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
-Use the {product-title} monitoring dashboard to query virtualization metrics.
-{VirtProductName} provides metrics that you can use to monitor the consumption of cluster infrastructure resources, including network, storage, and guest memory swapping. You can also use metrics to query live migration status.
-endif::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
+[role="_abstract"]
+Monitor the consumption of cluster infrastructure resources using the metrics provided by {VirtProductName}. These metrics are also used to query live migration status. 
 
-[id="prerequisites_{context}"]
-== Prerequisites
-
+[NOTE]
+====
 // Hiding in ROSA/OSD as user cannot edit MCO
 ifndef::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
 * To use the vCPU metric, the `schedstats=enable` kernel argument must be applied to the `MachineConfig` object. This kernel argument enables scheduler statistics used for debugging and performance tuning and adds a minor additional load to the scheduler. For more information, see xref:../../machine_configuration/machine-configs-configure.adoc#nodes-nodes-kernel-arguments_machine-configs-configure[Adding kernel arguments to nodes].
 endif::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
 
 * For guest memory swapping queries to return data, memory swapping must be enabled on the virtual guests.
+====
 
 include::modules/monitoring-querying-metrics-for-all-projects-with-mon-dashboard.adoc[leveloffset=+1]
 

--- a/virt/monitoring/virt-runbooks.adoc
+++ b/virt/monitoring/virt-runbooks.adoc
@@ -7,9 +7,13 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 :!virt-runbooks:
-To diagnose and resolve issues that trigger {VirtProductName} link:https://docs.redhat.com/en/documentation/monitoring_stack_for_red_hat_openshift/4.21/html/monitoring_key_concepts/key-concepts#about-managing-alerts_key-concepts[alerts], follow the procedures in the runbooks for the {VirtProductName} Operator. Triggered {VirtProductName} alerts can be viewed in the main *Observe* -> *Alerts* tab in the web console, and also in the *Virtualization* -> *Overview* tab.
+[role="_abstract"]
+To diagnose and resolve {VirtProductName} alerts, you can use the {VirtProductName} Operator runbooks. These guides help ensure you can effectively troubleshoot cluster issues and restore system health.
 
+[NOTE]
+====
 Runbooks for the {VirtProductName} Operator are maintained in the link:https://github.com/openshift/runbooks/tree/master/alerts/openshift-virtualization-operator[openshift/runbooks] Git repository, and you can view them on GitHub. 
+====
 
 // IMPORTANT: these IDs are meant to exactly mirror the original module IDs //
 // changing them will break links in the actual alerts //


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: 

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->
DITA content fixes for Monitoring documentation. This PR fixes the abstract errors that Vale found.

Version(s):
4.16+

Issue:
[DOCPLAN-116](https://issues.redhat.com/browse/DOCPLAN-116)
[DOCPLAN-117](https://issues.redhat.com/browse/DOCPLAN-117)
[DOCPLAN-118](https://issues.redhat.com/browse/DOCPLAN-118)
[DOCPLAN-119](https://issues.redhat.com/browse/DOCPLAN-119)
[DOCPLAN-125](https://issues.redhat.com/browse/DOCPLAN-125)
[DOCPLAN-127](https://issues.redhat.com/browse/DOCPLAN-127)
[DOCPLAN-130](https://issues.redhat.com/browse/DOCPLAN-130)
[DOCPLAN-131](https://issues.redhat.com/browse/DOCPLAN-131)

Link to docs preview:
- https://108092--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/monitoring/virt-prometheus-queries#querying-metrics-for-all-projects-with-mon-dashboard_virt-prometheus-queries
- https://108092--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/monitoring/virt-prometheus-queries#querying-metrics-for-user-defined-projects-with-mon-dashboard_virt-prometheus-queries
- https://108092--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/monitoring/virt-monitoring-vm-health#watchdog_virt-monitoring-vm-health
- https://108092--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/monitoring/virt-exposing-custom-metrics-for-vms
- https://108092--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/monitoring/virt-exposing-downward-metrics
- https://108092--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/monitoring/virt-monitoring-overview
- https://108092--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/monitoring/virt-monitoring-vm-health
- https://108092--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/monitoring/virt-prometheus-queries
- https://108092--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/monitoring/virt-runbooks

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
