### PR TITLE
OSDOCS 18609 WMCO 10.18.2 RN

### DIFF
--- a/modules/windows-containers-release-notes-10-18-0.adoc
+++ b/modules/windows-containers-release-notes-10-18-0.adoc
@@ -8,35 +8,33 @@
 
 Issued: 19 March 2025
 
-This release of the Windows Machine Config Operator (WMCO) provides bug fixes for running Windows compute nodes in an {product-title} cluster. The components of the WMCO 10.18.0 were released in link:https://access.redhat.com/errata/RHBA-2025:3040[RHBA-2025:3040].
+[role="_abstract"]
+You can review the following release notes to learn about the bug fixes provided in this release of the Windows Machine Config Operator (WMCO). 
 
-[id="wmco-10-18-0-new-features"]
+The components of the WMCO 10.18.0 were released in link:https://access.redhat.com/errata/RHBA-2025:3040[RHBA-2025:3040].
+
+[id="wmco-10-18-0-new-features_{context}"]
 == New features and improvements
 
-[id="wmco-10-18-0-new-features-hpa"]
-=== Horizontal Pod autoscaling is available for Windows workloads
+Horizontal Pod autoscaling is available for Windows workloads::
 You can now use a horizontal pod autoscaler (HPA) to scale your Windows pods based on CPU and/or memory resource metrics. For more information on using an HPA, see xref:../../nodes/pods/nodes-pods-autoscaling.adoc#nodes-pods-autoscaling[Automatically scaling pods with the horizontal pod autoscaler].
 
-[id="wmco-10-18-0-new-features-eus"]
-=== Control Plane Only updates are now available for Windows nodes
+Control Plane Only updates are now available for Windows nodes::
 You can now use *Control Plane Only* updates, previously known as *EUS-to-EUS* updates, to update your Windows nodes between {product-title} EUS versions. For more information, see xref:../../windows_containers/windows-node-upgrades.adoc#wmco-upgrades-eus_windows-node-upgrades[Windows Machine Config Operator Control Plane Only upgrade].
 
-[id="wmco-10-18-0-new-features-metrics"]
-=== WMCO metrics endpoint is now HTTPS
+WMCO metrics endpoint is now HTTPS::
 The WMCO metrics endpoint is now exposed over HTTPS. Previously, WMCO pod metrics were available over HTTP. This change improves the security posture of the WMCO metrics endpoint.
 // https://issues.redhat.com/browse/WINC-1269
 // https://issues.redhat.com/browse/WINC-588
 
-[id="wmco-10-18-0-new-features-debuglogging"]
-=== WMCO now defaults to info-level logging
+WMCO now defaults to info-level logging::
 The WMCO is configured to use the `info` log level by default. You can change the log level to `debug` by editing the WMCO subscription object. For more information, see xref:../../windows_containers/enabling-windows-container-workloads.adoc#wmco-configure-debug-logging_enabling-windows-container-workloads[Configuring debug-level logging for the Windows Machine Config Operator].
 
-[id="wmco-10-18-0-new-features-kubernetes"]
-=== Kubernetes upgrade
+Kubernetes upgrade::
 The WMCO now uses Kubernetes 1.31.
 
-[id="wmco-10-18-0-bug-fixes"]
+[id="wmco-10-18-0-bug-fixes_{context}"]
 == Bug fixes
-* Previously, if you installed the WMCO into the the default `openshift-windows-machine-config-operator` namespace and removed the WMCO, subsequently installing the WMCO into a namespace other than the default would fail. This was because the role-based access control (RBAC) for the Windows Instance Config Daemon (WICD) was always associated with the default namespace. With this fix, when installing the WMCO to a non-default namespace, the RBAC for the WICD is configured correctly. (link:https://issues.redhat.com/browse/OCPBUGS-46473[*OCPBUGS-46473*])
+* Before this update, if you installed the WMCO into the the default `openshift-windows-machine-config-operator` namespace and removed the WMCO, subsequently installing the WMCO into a namespace other than the default would fail. This was because the role-based access control (RBAC) for the Windows Instance Config Daemon (WICD) was always associated with the default namespace. With this release, when installing the WMCO to a non-default namespace, the RBAC for the WICD is configured correctly. (link:https://issues.redhat.com/browse/OCPBUGS-46473[OCPBUGS-46473])
 
-* Previously, the {product-title} documentation lacked information about WMCO support for the installer-provisioned infrastructure and the user-provisioned infrastructure installation methods. With this fix, the documentation now reports that the installer-provisioned infrastructure method is the preferred installation method and can be used with all platforms. The user-provisioned infrastructure method is limited to specific use cases. For more information, see xref:../../windows_containers/wmco_rn/windows-containers-release-notes-prereqs.adoc#wmco-prerequisites-supported-install_windows-containers-release-notes-prereqs[WMCO supported installation method]. (link:https://issues.redhat.com/browse/OCPBUGS-18898[*OCPBUGS-18898*])
+* Before this update, the {product-title} documentation lacked information about WMCO support for the installer-provisioned infrastructure and the user-provisioned infrastructure installation methods. With this release, the documentation now reports that the installer-provisioned infrastructure method is the preferred installation method and can be used with all platforms. The user-provisioned infrastructure method is limited to specific use cases. For more information, see xref:../../windows_containers/wmco_rn/windows-containers-release-notes-prereqs.adoc#wmco-prerequisites-supported-install_windows-containers-release-notes-prereqs[WMCO supported installation method]. (link:https://issues.redhat.com/browse/OCPBUGS-18898[OCPBUGS-18898])

--- a/modules/windows-containers-release-notes-10-18-1.adoc
+++ b/modules/windows-containers-release-notes-10-18-1.adoc
@@ -8,11 +8,14 @@
 
 Issued: 27 May 2025
 
-This release of the Windows Machine Config Operator (WMCO) provides bug fixes for running Windows compute nodes in an {product-title} cluster. The components of the WMCO 10.18.1 were released in link:https://access.redhat.com/errata/RHSA-2025:8224[RHSA-2025:8224].
+[role="_abstract"]
+You can review the following release notes to learn about the bug fixes provided in this release of the Windows Machine Config Operator (WMCO). 
 
-[id="wmco-10-18-1-bug-fixes"]
+The components of the WMCO 10.18.1 were released in link:https://access.redhat.com/errata/RHSA-2025:8224[RHSA-2025:8224].
+
+[id="wmco-10-18-1-bug-fixes_{context}"]
 == Bug fixes
 
-* Previously, Windows nodes were unable to pull from image mirror registries if an organization name or namespace was included in the source of the `ImageTagMirrorSet` (ITMS) object. With this fix, you can include an organization name or namespace in the `ITMS` object. With this change, additional guidelines and requirements around using mirror registries have been added to the {product-title} documentation. 
-(link:https://issues.redhat.com/browse/OCPBUGS-55787[*OCPBUGS-55787*])
+* Before this update, Windows nodes were unable to pull from image mirror registries if an organization name or namespace was included in the source of the `ImageTagMirrorSet` (ITMS) object. With this release, you can include an organization name or namespace in the `ITMS` object. With this change, additional guidelines and requirements around using mirror registries have been added to the {product-title} documentation. 
+(link:https://issues.redhat.com/browse/OCPBUGS-55787[OCPBUGS-55787])
 // The "additional guidelines and requirements" are forthcoming in https://github.com/openshift/openshift-docs/pull/92629

--- a/modules/windows-containers-release-notes-10-18-2.adoc
+++ b/modules/windows-containers-release-notes-10-18-2.adoc
@@ -1,0 +1,23 @@
+// Module included in the following assemblies:
+//
+// * windows_containers/wmco_rn/windows-containers-release-notes-10-18-x.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="windows-containers-release-notes-10-18-2_{context}"]
+= Release notes for Red Hat Windows Machine Config Operator 10.18.2
+
+Issued: 11 March 2026
+
+[role="_abstract"]
+You can review the following release notes to learn about the bug fixes provided in this release of the Windows Machine Config Operator (WMCO). 
+
+The components of the WMCO 10.18.2 were released in link:https://access.redhat.com/errata/RHBA-2026:4395[RHBA-2026:4395].
+
+[id="wmco-10-18-2-bug-fixes_{context}"]
+== Bug fixes
+
+* Before this update, the `hybridOverlay` service was not using the trusted CA bundle when connecting to Kubernetes, because the `--k8s-cacert` option was missing from the service command. Because of this, users could encounter trust issues or failures when the `hybridOverlay` service attempted to communicate securely with Kubernetes clusters using custom or internal CAs. With this release, the `hybridOverlay` service command now includes the `--k8s-cacert flag` pointing to the trusted CA bundle. As a result, the `hybridOverlay` service uses the trusted CA bundle for secure communication, preventing trust issues and ensuring compatibility with the cluster. (link:https://issues.redhat.com/browse/OCPBUGS-65856[OCPBUGS-65856])
+
+* Before this update, if you made a configuration change that required the WMCO to delete and re-create an internal config map, such as changing the proxy settings of the cluster, the WMCO pod panicked and entered a crash loop due to a nil pointer dereference panic. With this release, the error handling logic is reworked. As a result, the WMCO pod no longer crashes when an internal config map is recreated. (link:https://issues.redhat.com/browse/OCPBUGS-61743[OCPBUGS-61743])
+
+* Before this update, Windows Server 2019 machines might not have a running SSH server because of network instability. As a result, the WMCO could not access some VMs to complete configuration. With this release, the WMCO makes multiple attempt to SSH into the VM. As such, SSH connectivity to VMs is restored, ensuring smooth configuration and management of nodes. (link:https://issues.redhat.com/browse/OCPBUGS-60774[OCPBUGS-60774])

--- a/windows_containers/wmco_rn/windows-containers-release-notes-past.adoc
+++ b/windows_containers/wmco_rn/windows-containers-release-notes-past.adoc
@@ -6,8 +6,15 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-The following release notes are for previous versions of the Windows Machine Config Operator (WMCO).
+[role="_abstract"]
+You can review the following release notes to learn about changes in previous versions of the Custom Metrics Autoscaler Operator.
 
 For the current version, see xref:../../windows_containers/wmco_rn/windows-containers-release-notes.adoc#windows-containers-release-notes[{productwinc} release notes].
+
+include::modules/windows-containers-release-notes-10-18-1.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+* xref:../../windows_containers/enabling-windows-container-workloads.adoc#images-configuration-registry-mirror-configuring_enabling-windows-container-workloads[Configuring image registry repository mirroring]
 
 include::modules/windows-containers-release-notes-10-18-0.adoc[leveloffset=+1]

--- a/windows_containers/wmco_rn/windows-containers-release-notes.adoc
+++ b/windows_containers/wmco_rn/windows-containers-release-notes.adoc
@@ -6,8 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-include::modules/windows-containers-release-notes-10-18-1.adoc[leveloffset=+1]
+[role="_abstract"]
+You can review the following release notes to learn about changes in the Windows Machine Config Operator (WMCO) version 10.18.2.
 
-[role="_additional-resources"]
-.Additional resources
-* xref:../../windows_containers/enabling-windows-container-workloads.adoc#images-configuration-registry-mirror-configuring_enabling-windows-container-workloads[Configuring image registry repository mirroring]
+include::modules/windows-containers-release-notes-10-18-2.adoc[leveloffset=+1]


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-18609

Link to docs preview:
[Release notes for Red Hat Windows Machine Config Operator 10.18.2](https://108094--ocpdocs-pr.netlify.app/openshift-enterprise/latest/windows_containers/wmco_rn/windows-containers-release-notes.html#windows-containers-release-notes-10-18-2_windows-containers-release-notes) -- New module. NEED TO ADD RELEASE DATE AND ERRATA LINK when available.
[Release notes for past releases of the Windows Machine Config Operator](https://108094--ocpdocs-pr.netlify.app/openshift-enterprise/latest/windows_containers/wmco_rn/windows-containers-release-notes-past) -- Unhid assembly. Made Vale changes.
[Release notes for Red Hat Windows Machine Config Operator 10.18.1](https://108094--ocpdocs-pr.netlify.app/openshift-enterprise/latest/windows_containers/wmco_rn/windows-containers-release-notes-past#windows-containers-release-notes-10-18-1_windows-containers-release-notes-past) -- Moved to Past Releases assembly. Made Vale changes (bumped some headings to description list). 
[Release notes for Red Hat Windows Machine Config Operator 10.18.1](https://108094--ocpdocs-pr.netlify.app/openshift-enterprise/latest/windows_containers/wmco_rn/windows-containers-release-notes-past#windows-containers-release-notes-10-18-0_windows-containers-release-notes-past) -- Made Vale changes (bumped some headings to description list). 