### PR TITLE
CCSINTL-3105 [POWERMON] Remaining Vale fixes for power-monitoring-0.4

### DIFF
--- a/about/about-power-monitoring.adoc
+++ b/about/about-power-monitoring.adoc
@@ -1,12 +1,13 @@
 :_mod-docs-content-type: ASSEMBLY
-include::_attributes/common-attributes.adoc[]
-
 [id="about-power-monitoring"]
 = About {PM-shortname}
-
+include::_attributes/common-attributes.adoc[]
 :context: about-power-monitoring
 
 toc::[]
+
+[role="_abstract"]
+{PM-shortname-c} uses the {PM-kepler} architecture to provide energy consumption metrics, enabling you to track and optimize the power usage of your cluster workloads.
 
 :FeatureName: Power monitoring
 include::snippets/technology-preview.adoc[leveloffset=+2]

--- a/configuring/configuring-power-monitoring.adoc
+++ b/configuring/configuring-power-monitoring.adoc
@@ -1,12 +1,13 @@
 :_mod-docs-content-type: ASSEMBLY
-include::_attributes/common-attributes.adoc[]
-
 [id="configuring-power-monitoring"]
 = Configuring {PM-shortname}
-
+include::_attributes/common-attributes.adoc[]
 :context: configuring-power-monitoring
 
 toc::[]
+
+[role="_abstract"]
+Configure the {PM-kepler} custom resource to manage how the Kepler exporter collects and reports power consumption metrics from your cluster nodes.
 
 :FeatureName: Power monitoring
 include::snippets/technology-preview.adoc[leveloffset=+2]

--- a/installing/installing-power-monitoring.adoc
+++ b/installing/installing-power-monitoring.adoc
@@ -1,9 +1,7 @@
 :_mod-docs-content-type: ASSEMBLY
-include::_attributes/common-attributes.adoc[]
-
 [id="installing-power-monitoring"]
 = Installing {PM-title}
-
+include::_attributes/common-attributes.adoc[]
 :context: installing-power-monitoring
 
 toc::[]
@@ -11,7 +9,8 @@ toc::[]
 :FeatureName: Power monitoring
 include::snippets/technology-preview.adoc[leveloffset=+2]
 
-You can install {PM-title} by deploying the {PM-operator} in the {ocp} web console.
+[role="_abstract"]
+Install the {PM-operator} and deploy {PM-kepler} to monitor power consumption across your {ocp} cluster infrastructure.
 
 //Installing power monitoring operator
 include::modules/power-monitoring-installing-pmo.adoc[leveloffset=+1]

--- a/modules/power-monitoring-configuring-kepler-redfish.adoc
+++ b/modules/power-monitoring-configuring-kepler-redfish.adoc
@@ -6,7 +6,8 @@
 [id="power-monitoring-configuring-kepler-redfish_{context}"]
 = Configuring {PM-kepler} to use Redfish
 
-You can configure {PM-kepler} to use Redfish as the source for running or hosting containers. {PM-kepler} can then monitor the power usage of these containers.
+[role="_abstract"]
+Configure {PM-kepler} to monitor power consumption of containers using Redfish as the data source for your nodes.
 
 .Prerequisites
 * You have access to the {ocp} web console.
@@ -33,16 +34,19 @@ metadata:
 spec:
   exporter:
     deployment:
-# ... 
+# ...
     redfish:
-      secretRef: <secret_name> required <1>
-      probeInterval: 60s <2>
-      skipSSLVerify: false <3>
+      secretRef: <secret_name> required
+      probeInterval: 60s
+      skipSSLVerify: false
 # ...
 ----
-<1> Required: Specifies the name of the secret that contains the credentials for accessing the Redfish server.
-<2> Optional: Controls the frequency at which the power information is queried from Redfish. The default value is `60s`.
-<3> Optional: Controls if {PM-kepler} skips verifying the Redfish server certificate. The default value is `false`.
++
+where:
+
+`spec.exporter.redfish.secretRef`:: Required. Specifies the name of the secret that contains the credentials for accessing the Redfish server.
+`spec.exporter.redfish.probeInterval`:: Optional. Specifies the frequency at which the power information is queried from Redfish. The default value is `60s`.
+`spec.exporter.redfish.skipSSLVerify`:: Optional. Specifies if {PM-kepler} skips verifying the Redfish server certificate. The default value is `false`.
 +
 [NOTE]
 ====

--- a/modules/power-monitoring-deploying-kepler.adoc
+++ b/modules/power-monitoring-deploying-kepler.adoc
@@ -6,7 +6,8 @@
 [id="power-monitoring-deploying-kepler_{context}"]
 = Deploying {PM-kepler}
 
-You can deploy {PM-kepler} by creating an instance of the `{PM-kepler}` custom resource definition (CRD) by using the {PM-operator}. 
+[role="_abstract"]
+Deploy {PM-kepler} by creating a `{PM-kepler}` custom resource instance using the {PM-operator}.
 
 .Prerequisites
 * You have access to the {ocp} web console.

--- a/modules/power-monitoring-fips-support.adoc
+++ b/modules/power-monitoring-fips-support.adoc
@@ -11,6 +11,11 @@ The {PM-operator} version 0.4 and later is FIPS compliant when deployed on {ocp}
 
 When deployed on an {ocp} cluster in FIPS mode, it uses {op-system-base-full} cryptographic libraries validated by National Institute of Standards and Technology (NIST).
 
-For details on the NIST validation program, see link:https://csrc.nist.gov/Projects/cryptographic-module-validation-program/validated-modules[Cryptographic module validation program]. For the latest NIST status of {op-system-base} cryptographic libraries, see link:https://access.redhat.com/en/compliance[Compliance activities and government standards].
+For details on the NIST validation program, see ""Cryptographic module validation program". For the latest NIST status of {op-system-base} cryptographic libraries, see "Compliance activities and government standards".
 
 To enable FIPS mode, you must install {PM-operator} for Red{nbsp}Hat OpenShift on an {ocp} cluster. For more information, see "Do you need extra security for your cluster?".
+
+[id="fips-support-additional-resources_{context}"]
+== Additional resources
+* link:https://csrc.nist.gov/Projects/cryptographic-module-validation-program/validated-modules[Cryptographic module validation program]
+* link:https://access.redhat.com/en/compliance[Compliance activities and government standards]

--- a/modules/power-monitoring-hardware-virtualization-support.adoc
+++ b/modules/power-monitoring-hardware-virtualization-support.adoc
@@ -6,14 +6,16 @@
 [id="power-monitoring-hardware-virtualization-support_{context}"]
 = {PM-kepler} hardware and virtualization support
 
-{PM-kepler} is the key component of {PM-shortname} that collects real-time power consumption data from a node through one of the following methods:
+[role="_abstract"]
+{PM-kepler} is the key component of {PM-shortname} that collects real-time power consumption data from a node through one of two methods.
 
-Kernel Power Management Subsystem (preferred)::
-* `rapl-sysfs`: This requires access to the `/sys/class/powercap/intel-rapl` host file.
-* `rapl-msr`: This requires access to the `/dev/cpu/*/msr` host file.
+Kernel Power Management Subsystem (preferred):: Uses the `rapl-sysfs` or `rapl-msr` host files to access the CPU power monitoring hardware.
++
+* `rapl-sysfs` Requires access to the `/sys/class/powercap/intel-rapl` host file.
+* `rapl-msr` Requires access to the `/dev/cpu/*/msr` host file.
 
 The `estimator` power source::
-Without access to the kernel's power cap subsystem, {PM-kepler} uses a machine learning model to estimate the power usage of the CPU on the node.
+Uses a machine learning model to estimate CPU power usage when the kernel power management subsystem is unavailable.
 +
 [WARNING]
 ====

--- a/modules/power-monitoring-kepler-configuration.adoc
+++ b/modules/power-monitoring-kepler-configuration.adoc
@@ -7,8 +7,7 @@
 = The {PM-kepler} configuration
 
 [role="_abstract"]
-Configuration options available for customizing Kepler deployment, security, logging, and metric collection through `PowerMonitor` resources.
-
+You can customize Kepler deployment, security, and metric collection settings by configuring the available options in the PowerMonitor custom resource.
 
 [IMPORTANT]
 ====
@@ -36,15 +35,18 @@ metadata:
 spec:
   exporter:
     deployment:
-      port: 9103 # <1>
+      port: 9103 #
       nodeSelector:
-        kubernetes.io/os: linux # <2>
-      Tolerations: # <3>
+        kubernetes.io/os: linux #
+      Tolerations: #
       - key: ""
         operator: "Exists"
         value: ""
         effect: ""
 ----
-<1> The Prometheus metrics are exposed on port 9103.
-<2> {PM-kepler} pods are scheduled on Linux nodes.
-<3> The default tolerations allow {PM-kepler} to be scheduled on any node.
++
+where:
+
+`spec.exporter.deployment.port`:: Specifies the port where Prometheus metrics are exposed. The default is `9103`.
+`spec.exporter.deployment.nodeSelector`:: Specifies the nodes where pods are scheduled. In this example, pods are scheduled on *Linux* nodes.
+`spec.exporter.deployment.Tolerations`:: Specifies the tolerations that allow {PM-kepler} pods to be scheduled on nodes with specific taints. In this example, the configuration tolerates any taint.

--- a/modules/power-monitoring-metrics-overview.adoc
+++ b/modules/power-monitoring-metrics-overview.adoc
@@ -6,6 +6,9 @@
 [id="power-monitoring-metrics-overview_{context}"]
 = {PM-shortname-c} metrics overview
 
+[role="_abstract"]
+{PM-operator} exposes a variety of {pm-Kepler} metrics that provide detailed energy consumption data for cluster nodes, pods, and containers.
+
 The {PM-operator} exposes the following metrics, which you can view by using the {ocp} web console under the *Observe* -> *Metrics* tab.
 
 [WARNING]

--- a/modules/power-monitoring-monitoring-kepler-status.adoc
+++ b/modules/power-monitoring-monitoring-kepler-status.adoc
@@ -26,7 +26,7 @@ metadata:
   name: kepler
 status:
  exporter:
-   conditions: # <1>
+   conditions: #
      - lastTransitionTime: '2024-01-11T11:07:39Z'
        message: Reconcile succeeded
        observedGeneration: 1
@@ -41,9 +41,12 @@ status:
        reason: DaemonSetReady
        status: 'True'
        type: Available
-   currentNumberScheduled: 2 # <2>
-   desiredNumberScheduled: 2 # <3>
+   currentNumberScheduled: 2 #
+   desiredNumberScheduled: 2 #
 ----
-<1> The health of the {PM-kepler} resource. In this example, {PM-kepler} is successfully reconciled and ready.
-<2> The number of nodes currently running the {PM-kepler} pods is 2.
-<3> The wanted number of nodes to run the {PM-kepler} pods is 2.
++
+where:
+
+`status.exporter.conditions`:: Specifies the health of the {PM-kepler} resource. In this example, {PM-kepler} is successfully reconciled and ready.
+`status.currentNumberScheduled`:: Specifies the number of nodes currently running the {PM-kepler} pods.
+`status.desiredNumberScheduled`:: Specifies the target number of nodes to run the {PM-kepler} pods.

--- a/uninstalling/uninstalling-power-monitoring.adoc
+++ b/uninstalling/uninstalling-power-monitoring.adoc
@@ -1,12 +1,13 @@
 :_mod-docs-content-type: ASSEMBLY
-include::_attributes/common-attributes.adoc[]
-
 [id="uninstalling-power-monitoring"]
 = Uninstalling {PM-shortname}
-
+include::_attributes/common-attributes.adoc[]
 :context: uninstalling-power-monitoring
 
 toc::[]
+
+[role="_abstract"]
+Uninstall {PM-shortname} by deleting the {PM-kepler} instance and removing the {PM-operator} from your {ocp} cluster.
 
 :FeatureName: Power monitoring
 include::snippets/technology-preview.adoc[leveloffset=+2]

--- a/visualizing/visualizing-power-monitoring-metrics.adoc
+++ b/visualizing/visualizing-power-monitoring-metrics.adoc
@@ -1,12 +1,13 @@
 :_mod-docs-content-type: ASSEMBLY
-include::_attributes/common-attributes.adoc[]
-
 [id="visualizing-power-monitoring-metrics"]
 = Visualizing power monitoring metrics
-
+include::_attributes/common-attributes.adoc[]
 :context: visualizing-power-monitoring-metrics
 
 toc::[]
+
+[role="_abstract"]
+You can monitor energy usage across cluster resources by using power consumption dashboards in the {ocp} web console.
 
 :FeatureName: Power monitoring
 include::snippets/technology-preview.adoc[leveloffset=+2]


### PR DESCRIPTION
[CCSINTL-3105](https://issues.redhat.com/browse/CCSINTL-3105) [POWERMON] Remaining Vale fixes for power-monitoring-0.4

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
`power-monitoring-0.4`

Issue:
https://issues.redhat.com/browse/CCSINTL-3105

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
QE is not required for this PR.

Additional information:
* `power-monitoring-0.4` release notes are being addressed by a separate Jira: https://issues.redhat.com/browse/CCSINTL-3100

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
