### PR TITLE
CNV-74970: Fix callout formatting

### DIFF
--- a/modules/nw-sriov-configuring-device.adoc
+++ b/modules/nw-sriov-configuring-device.adoc
@@ -69,14 +69,14 @@ spec:
   deviceType: vfio-pci
   isRdma: false
 ----
-** `metadata.name` specifies a name for the `SriovNetworkNodePolicy` object.
-** `metadata.namespace` specifies the namespace where the SR-IOV Network Operator is installed.
-** `spec.resourceName` specifies the resource name of the SR-IOV device plugin. You can create multiple `SriovNetworkNodePolicy` objects for a resource name.
-** `spec.nodeSelector.feature.node.kubernetes.io/network-sriov.capable` specifies the node selector to select which nodes are configured. Only SR-IOV network devices on selected nodes are configured. The SR-IOV Container Network Interface (CNI) plugin and device plugin are deployed only on selected nodes.
-** `spec.priority` is an optional field that specifies an integer value between `0` and `99`. A smaller number gets higher priority, so a priority of `10` is higher than a priority of `99`. The default value is `99`.
-** `spec.mtu` is an optional field that specifies a value for the maximum transmission unit (MTU) of the virtual function. The maximum MTU value can vary for different NIC models.
-** `spec.numVfs` specifies the number of the virtual functions (VF) to create for the SR-IOV physical network device. For an Intel network interface controller (NIC), the number of VFs cannot be larger than the total VFs supported by the device. For a Mellanox NIC, the number of VFs cannot be larger than `127`.
-** `spec.nicSelector` selects the Ethernet device for the Operator to configure. You do not need to specify values for all the parameters.
+** `metadata.name` defines a name for the `SriovNetworkNodePolicy` object.
+** `metadata.namespace` defines the namespace where the SR-IOV Network Operator is installed.
+** `spec.resourceName` defines the resource name of the SR-IOV device plugin. You can create multiple `SriovNetworkNodePolicy` objects for a resource name.
+** `spec.nodeSelector.feature.node.kubernetes.io/network-sriov.capable` defines the node selector to select which nodes are configured. Only SR-IOV network devices on selected nodes are configured. The SR-IOV Container Network Interface (CNI) plugin and device plugin are deployed only on selected nodes.
+** `spec.priority` is an optional field that defines an integer value between `0` and `99`. A smaller number gets higher priority, so a priority of `10` is higher than a priority of `99`. The default value is `99`.
+** `spec.mtu` is an optional field that defines a value for the maximum transmission unit (MTU) of the virtual function. The maximum MTU value can vary for different NIC models.
+** `spec.numVfs` defines the number of the virtual functions (VF) to create for the SR-IOV physical network device. For an Intel network interface controller (NIC), the number of VFs cannot be larger than the total VFs supported by the device. For a Mellanox NIC, the number of VFs cannot be larger than `127`.
+** `spec.nicSelector` defines the Ethernet device for the Operator to configure. You do not need to specify values for all the parameters.
 +
 [NOTE]
 ====
@@ -85,12 +85,12 @@ If you specify `rootDevices`, you must also specify a value for `vendor`, `devic
 ====
 +
 If you specify both `pfNames` and `rootDevices` at the same time, ensure that they point to an identical device.
-** `spec.nicSelector.vendor` is an optional field that specifies the vendor hex code of the SR-IOV network device. The only allowed values are either `8086` or `15b3`.
-** `spec.nicSelector.deviceID` is an optional field that specifies the device hex code of SR-IOV network device. The only allowed values are `158b`, `1015`, `1017`.
-** `spec.nicSelector.pfNames` is an optional field that specifies an array of one or more physical function (PF) names for the Ethernet device.
-** `spec.nicSelector.rootDevices` is an optional field that specifies an array of one or more PCI bus addresses for the physical function of the Ethernet device. Provide the address in the following format: `0000:02:00.1`.
-** `spec.deviceType` specifies the driver type. The `vfio-pci` driver type is required for virtual functions in {VirtProductName}.
-** `spec.isRdma` is an optional field that specifies whether to enable remote direct memory access (RDMA) mode. For a Mellanox card, set `isRdma` to `false`. The default value is `false`.
+** `spec.nicSelector.vendor` is an optional field that defines the vendor hex code of the SR-IOV network device. The only allowed values are either `8086` or `15b3`.
+** `spec.nicSelector.deviceID` is an optional field that defines the device hex code of SR-IOV network device. The only allowed values are `158b`, `1015`, `1017`.
+** `spec.nicSelector.pfNames` is an optional field that defines an array of one or more physical function (PF) names for the Ethernet device.
+** `spec.nicSelector.rootDevices` is an optional field that defines an array of one or more PCI bus addresses for the physical function of the Ethernet device. Provide the address in the following format: `0000:02:00.1`.
+** `spec.deviceType` defines the driver type. The `vfio-pci` driver type is required for virtual functions in {VirtProductName}.
+** `spec.isRdma` is an optional field that defines whether to enable remote direct memory access (RDMA) mode. For a Mellanox card, set `isRdma` to `false`. The default value is `false`.
 +
 [NOTE]
 ====

--- a/modules/virt-configuring-cdiuploadproxy-routes.adoc
+++ b/modules/virt-configuring-cdiuploadproxy-routes.adoc
@@ -27,9 +27,9 @@ $ oc create route reencrypt <route_name> -n openshift-cnv \
 ----
 +
 where:
-
-<route_name>:: Specifies the name to assign to this custom route.
-<host_name_or_address>:: Specifies the fully qualified domain name or IP address of the external host providing image upload access.
++
+`<route_name>`:: Specifies the name to assign to this custom route.
+`<host_name_or_address>`:: Specifies the fully qualified domain name or IP address of the external host providing image upload access.
 
 . Run the following command to annotate the route. This ensures that the correct Containerized Data Importer (CDI) CA certificate is injected when certificates are rotated:
 +
@@ -40,5 +40,5 @@ $ oc annotate route <route_name> -n openshift-cnv \
 ----
 +
 where:
-
-<route_name>:: The name of the route you created.
++
+`<route_name>`:: Specifies the name of the route you created.

--- a/modules/virt-configuring-secondary-network-vm-live-migration.adoc
+++ b/modules/virt-configuring-secondary-network-vm-live-migration.adoc
@@ -41,10 +41,10 @@ spec:
     }
   }'
 ----
-** `metadata.name` specifies the name of the `NetworkAttachmentDefinition` object.
-** `config.master` specifies the name of the NIC to be used for live migration.
-** `config.type` specifies the name of the CNI plugin that provides the network for the NAD.
-** `config.range` specifies an IP address range for the secondary network. This range must not overlap the IP addresses of the main network.
+** `metadata.name` defines the name of the `NetworkAttachmentDefinition` object.
+** `config.master` defines the name of the NIC to be used for live migration.
+** `config.type` defines the name of the CNI plugin that provides the network for the NAD.
+** `config.range` defines an IP address range for the secondary network. This range must not overlap the IP addresses of the main network.
 
 . Open the `HyperConverged` CR in your default editor by running the following command:
 +
@@ -73,7 +73,7 @@ spec:
     progressTimeout: 150
 # ...
 ----
-** `spec.liveMigrationConfig.network` specifies the name of the Multus `NetworkAttachmentDefinition` object to be used for live migrations.
+** `spec.liveMigrationConfig.network` defines the name of the Multus `NetworkAttachmentDefinition` object to be used for live migrations.
 
 . Save your changes and exit the editor. The `virt-handler` pods restart and connect to the secondary network.
 

--- a/modules/virt-creating-storage-class-csi-driver.adoc
+++ b/modules/virt-creating-storage-class-csi-driver.adoc
@@ -43,9 +43,9 @@ parameters:
   storagePool: my-storage-pool <3>
 ----
 +
-* `reclaimPolicy` specifies whether the underlying storage is deleted or retained when a user deletes a PVC. The two possible `reclaimPolicy` values are `Delete` and `Retain`. If you do not specify a value, the default value is `Delete`.
-* `volumeBindingMode` specifies the timing of PV creation. The `WaitForFirstConsumer` configuration in this example means that PV creation is delayed until a pod is scheduled to a specific node.
-* `parameters.storagePool` specifies the name of the storage pool defined in the HPP custom resource (CR).
+* `reclaimPolicy` defines whether the underlying storage is deleted or retained when a user deletes a PVC. The two possible `reclaimPolicy` values are `Delete` and `Retain`. If you do not specify a value, the default value is `Delete`.
+* `volumeBindingMode` defines the timing of PV creation. The `WaitForFirstConsumer` configuration in this example means that PV creation is delayed until a pod is scheduled to a specific node.
+* `parameters.storagePool` defines the name of the storage pool defined in the HPP custom resource (CR).
 
 . Save the file and exit.
 

--- a/modules/virt-install-ibm-cloud-cluster-network-access.adoc
+++ b/modules/virt-install-ibm-cloud-cluster-network-access.adoc
@@ -2,7 +2,7 @@
 //
 // * virt/install/virt-install-ibm-cloud-bm-nodes.adoc
 
-:_mod-docs-content-type: PROCEDURE 
+:_mod-docs-content-type: PROCEDURE
 [id="virt-install-ibm-cloud-cluster-network-access_{context}"]
 = Configuring cluster networking and access
 
@@ -10,6 +10,7 @@
 Configure networking and access to allow for remote management of the cluster.
 
 .Procedure
+
 . Edit `/etc/samba/smb.conf` to use the following configuration:
 +
 [source,text]
@@ -78,12 +79,12 @@ $ sudo MotionPro --host $<vpn_endpoint> --user $<vpn_username> --passwd $<vpn_pa
 ----
 +
 where:
-
-<vpn_endpoint>:: The appropriate SSL VPN endpoint.
-<vpn_username>:: The SSL VPN user name you configured.
-<vpn_password>:: The SSL VPN password you configured.
++
+`<vpn_endpoint>`:: Specifies the appropriate SSL VPN endpoint.
+`<vpn_username>`:: Specifies the SSL VPN user name you configured.
+`<vpn_password>`:: Specifies the SSL VPN password you configured.
 +
 [NOTE]
 ====
-Connecting to the {ibm-cloud-title} SSL VPN will disconnect you from any open VPN connections.
+Connecting to the {ibm-cloud-title} SSL VPN disconnects you from any open VPN connections.
 ====

--- a/modules/virt-install-ibm-cloud-complete-cluster-config.adoc
+++ b/modules/virt-install-ibm-cloud-complete-cluster-config.adoc
@@ -2,7 +2,7 @@
 //
 // * virt/install/virt-install-ibm-cloud-bm-nodes.adoc
 
-:_mod-docs-content-type: PROCEDURE 
+:_mod-docs-content-type: PROCEDURE
 [id="virt-install-ibm-cloud-complete-cluster-config_{context}"]
 = Completing the cluster configuration
 
@@ -10,6 +10,7 @@
 Complete the cluster configuration by installing software on the control plane and compute nodes and configuring DNS for external access.
 
 .Procedure
+
 . For each bare-metal server, perform the following tasks:
 .. Access the server using the IPMI console.
 +
@@ -34,7 +35,7 @@ The IP address and credentials for IPMI console access is available in the *Remo
 
 . Select the *Install {VirtProductName}* and *Install {rh-storage}* checkboxes in the *Assisted Installer* options.
 
-. Select a role for each host. 
+. Select a role for each host.
 +
 [NOTE]
 ====
@@ -69,7 +70,7 @@ The IP address and credentials for IPMI console access is available in the *Remo
 .. Download the `kubeconfig` file.
 .. Save the `kubeadmin` password.
 
-. Install `haproxy` on the Bastion virtual server instance. 
+. Install `haproxy` on the Bastion virtual server instance.
 
 . Configure `haproxy` for your environment. The following is an example configuration:
 +
@@ -179,15 +180,15 @@ backend insecure
 ----
 +
 where:
-
-<api_ip_address>:<api_port>:: The front end IP address and port used by the Kubernetes API server.
-<apiinternal_ip_address>:<apiinternal_port>:: The front end IP address and port used for internal cluster management.
-<frontend_secure_ip_address>:<frontend_secure_port>:: The front end IP address and port used for HTTPS traffic for hosted applications.
-<frontend_insecure_ip_address>:<frontend_insecure_port>:: The front end IP address and port used for HTTP traffic for hosted applications.
-<controlplaneapi_ip_address>:<controlplaneapi_port>:: The back end IP address and port used by the Kubernetes API server.
-<controlplaneapiinternal_ip_address>:<controlplaneapiinternal_port>:: The back end IP address and port used for internal cluster management.
-<backend_secure_ip_address>:<backend_secure_port>:: The back end IP address and port used for HTTPS traffic for hosted applications.
-<backend_insecure_ip_address>:<backend_insecure_port>:: The back end IP address and port used for HTTP traffic for hosted applications.
++
+`<api_ip_address>:<api_port>`:: Specifies the front end IP address and port used by the Kubernetes API server.
+`<apiinternal_ip_address>:<apiinternal_port>`:: Specifies the front end IP address and port used for internal cluster management.
+`<frontend_secure_ip_address>:<frontend_secure_port>`:: Specifies the front end IP address and port used for HTTPS traffic for hosted applications.
+`<frontend_insecure_ip_address>:<frontend_insecure_port>`:: Specifies the front end IP address and port used for HTTP traffic for hosted applications.
+`<controlplaneapi_ip_address>:<controlplaneapi_port>`:: Specifies the back end IP address and port used by the Kubernetes API server.
+`<controlplaneapiinternal_ip_address>:<controlplaneapiinternal_port>`:: Specifies the back end IP address and port used for internal cluster management.
+`<backend_secure_ip_address>:<backend_secure_port>`:: Specifies the back end IP address and port used for HTTPS traffic for hosted applications.
+`<backend_insecure_ip_address>:<backend_insecure_port>`:: Specifies the back end IP address and port used for HTTP traffic for hosted applications.
 +
 [NOTE]
 ====
@@ -205,10 +206,10 @@ Replace the example values with values applicable to your network configuration.
 ----
 +
 where:
-
-<bastion_public_ip_address>:: The externally available IP address of the Bastion virtual server instance.
-<cluster_name>:: The name assigned to the cluster.
-<cluster_domain>:: The domain assigned to the cluster.
++
+`<bastion_public_ip_address>`:: Specifies the externally available IP address of the Bastion virtual server instance.
+`<cluster_name>`:: Specifies the name assigned to the cluster.
+`<cluster_domain>`:: Specifies the domain assigned to the cluster.
 
 .Verification
 
@@ -221,8 +222,9 @@ $ export KUBECONFIG=<kubeconfig_file_path>
 ----
 +
 where:
++
+`<kubeconfig_file_path>`:: Specifies the path to the downloaded `kubeconfig` file.
 
-<kubeconfig_file_path>:: The path to the downloaded `kubeconfig` file.
 .. Check cluster node status:
 +
 [source,terminal]

--- a/modules/virt-install-ibm-cloud-config-new-cluster.adoc
+++ b/modules/virt-install-ibm-cloud-config-new-cluster.adoc
@@ -2,7 +2,7 @@
 //
 // * virt/install/virt-install-ibm-cloud-bm-nodes.adoc
 
-:_mod-docs-content-type: PROCEDURE 
+:_mod-docs-content-type: PROCEDURE
 [id="virt-install-ibm-cloud-config-new-cluster_{context}"]
 = Configuring {ibm-cloud-title} for the new cluster
 
@@ -10,7 +10,8 @@
 Configure and provision the {ibm-cloud-title} environment to establish the operational framework and nodes for your {VirtProductName} cluster.
 
 .Procedure
-. Create a new virtual server instance in {ibm-cloud-title} at link:https://cloud.ibm.com/gen1/infrastructure/provision/vs[Virtual Server for Classic] to be the Bastion server. This instance is used to run the installation and provide environment services. 
+
+. Create a new virtual server instance in {ibm-cloud-title} at link:https://cloud.ibm.com/gen1/infrastructure/provision/vs[Virtual Server for Classic] to be the Bastion server. This instance is used to run the installation and provide environment services.
 
 . Change the default properties of the new virtual server instance to the following values. Use the provided defaults for all other values.
 +
@@ -66,15 +67,15 @@ subnet <subnet_ip_address> netmask <subnet_mask> {
 ----
 +
 where:
-
-<dns_domain_name>:: The default domain name for DNS clients.
-<dns_ip_addresses>:: A comma-seperated list of DNS server IP addresses.
-<default_lease_value>:: The default number of seconds a client keeps an assigned address.
-<max_lease_value>:: The maximum number of seconds a client keeps an assigned address.
-<subnet_ip_address>:: The start of the subnet IP address range.
-<subnet_mask>:: The subnet mask of the subnet IP address range.
-<broad_ip_address>:: The broadcast IP address to use when to use sending a message to every device on the subnet.
-<default_gateway_ip_address>:: The default gateway of the subnet.
++
+`<dns_domain_name>`:: Specifies the default domain name for DNS clients.
+`<dns_ip_addresses>`:: Specifies a comma-separated list of DNS server IP addresses.
+`<default_lease_value>`:: Specifies the default number of seconds a client keeps an assigned address.
+`<max_lease_value>`:: Specifies the maximum number of seconds a client keeps an assigned address.
+`<subnet_ip_address>`:: Specifies the start of the subnet IP address range.
+`<subnet_mask>`:: Specifies the subnet mask of the subnet IP address range.
+`<broad_ip_address>`:: Specifies the broadcast IP address to use when to use sending a message to every device on the subnet.
+`<default_gateway_ip_address>`:: Specifies the default gateway of the subnet.
 
 . Restart DHCP on the Bastion virtual server instance:
 +
@@ -124,7 +125,6 @@ $ systemctl enable firewalld
 ----
 $ systemctl start firewalld
 ----
-
 
 . Add network address translation (NAT) rules to the `firewalld` service:
 +


### PR DESCRIPTION
Version(s):
Cherrypick back to as many supported versions as possible.

Issue:
https://issues.redhat.com/browse/CNV-74970

Link to docs preview:
- https://108099--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/install/virt-install-ibm-cloud-bm-nodes.html
- https://108099--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/post_installation_configuration/virt-post-install-network-config.html
- https://108099--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/post_installation_configuration/virt-post-install-storage-config.html
- 

QE review:
N/A, formatting updates only

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
