### PR TITLE
OSDOCS-17466: Added FIPS encryption documentation

### DIFF
--- a/_topic_maps/_topic_map_rosa_hcp.yml
+++ b/_topic_maps/_topic_map_rosa_hcp.yml
@@ -194,6 +194,8 @@ Topics:
     File: rosa-hcp-creating-a-cluster-quickly-terraform
 - Name: Creating ROSA clusters using a custom AWS KMS encryption key
   File: rosa-hcp-creating-cluster-with-aws-kms-key
+- Name: Deploying Red Hat OpenShift Service on AWS clusters using FIPS encryption
+  File: rosa-hcp-creating-cluster-with-fips-encryption
 - Name: Configuring a shared virtual private cloud for ROSA clusters
   File: rosa-hcp-shared-vpc-config
 - Name: Creating a private cluster on ROSA

--- a/modules/aws-encryption-key.adoc
+++ b/modules/aws-encryption-key.adoc
@@ -1,0 +1,140 @@
+// Module included in the following assemblies:
+//
+// * observability/monitoring/enabling-monitoring-for-user-defined-projects.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="aws-encryption-key_{context}"]
+= Create an AWS KMS encryption key
+
+[role="_abstract"]
+Using your AWS account and the `aws` CLI tool, you can create an AWS KMS encryption key to encypt your resources.
+
+.Procedure
+
+. Set the AWS region where you installed your VPC by running the following command:
++
+[NOTE]
+====
+You should use the same region where you installed your VPC.
+====
++
+[source,terminal]
+----
+$ AWS_REGION=<aws_region>
+----
+
+. Create a custom AWS customer-managed KMS key by running the following command:
++
+[source,terminal]
+----
+$ KMS_ARN=$(aws kms create-key --region $AWS_REGION --description 'Custom ROSA Encryption Key' --tags TagKey=red-hat,TagValue=true --query KeyMetadata.Arn --output text)
+----
++
+This command saves the Amazon Resource Name (ARN) output of this custom key for further steps.
++
+[NOTE]
+====
+Customers must provide the `--tags TagKey=red-hat,TagValue=true` argument that is required for a customer KMS key.
+====
+
+. Verify the KMS key has been created by running the following command:
++
+[source,terminal]
+----
+$ echo $KMS_ARN
+----
+
+. Set your AWS account ID to an environment variable by running the following command:
++
+[source,terminal]
+----
+$ AWS_ACCOUNT=$(aws sts get-caller-identity --query Account --output text)
+----
+
+. Create your AWS key policy by running the following command.
++
+[NOTE]
+====
+If you use the default prefix, you need to modify the following code sample where you see `{PREFIX}-` to `ManagedOpenShift-`.
+====
++
+[source,terminal]
+----
+cat << EOF > rosa-key-policy.json
+{
+    "Version": "2012-10-17",
+    "Id": "key-rosa-policy-1",
+    "Statement": [
+        {
+            "Sid": "Enable IAM User Permissions",
+            "Effect": "Allow",
+            "Principal": {
+                "AWS": "arn:aws:iam::${AWS_ACCOUNT}:root"
+            },
+            "Action": "kms:*",
+            "Resource": "*"
+        },
+        {
+            "Sid": "Allow ROSA use of the key",
+            "Effect": "Allow",
+            "Principal": {
+                "AWS": [
+                    "arn:aws:iam::${AWS_ACCOUNT}:role/${PREFIX}-HCP-ROSA-Support-Role",
+                    "arn:aws:iam::${AWS_ACCOUNT}:role/${PREFIX}-HCP-ROSA-Installer-Role",
+                    "arn:aws:iam::${AWS_ACCOUNT}:role/${PREFIX}-HCP-ROSA-Worker-Role",
+                    "arn:aws:iam::${AWS_ACCOUNT}:role/${PREFIX}-openshift-cluster-csi-drivers-ebs-cloud-credentials",
+                    "arn:aws:iam::${AWS_ACCOUNT}:role/${PREFIX}-kube-system-kms-provider"
+                ]
+            },
+            "Action": [
+                "kms:Encrypt",
+                "kms:Decrypt",
+                "kms:ReEncrypt*",
+                "kms:GenerateDataKey*",
+                "kms:DescribeKey"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Sid": "Allow attachment of persistent resources",
+            "Effect": "Allow",
+            "Principal": {
+                "AWS": [
+                    "arn:aws:iam::${AWS_ACCOUNT}:role/${PREFIX}-HCP-ROSA-Support-Role",
+                    "arn:aws:iam::${AWS_ACCOUNT}:role/${PREFIX}-HCP-ROSA-Installer-Role",
+                    "arn:aws:iam::${AWS_ACCOUNT}:role/${PREFIX}-HCP-ROSA-Worker-Role",
+                    "arn:aws:iam::${AWS_ACCOUNT}:role/${PREFIX}-openshift-cluster-csi-drivers-ebs-cloud-credentials"
+                ]
+            },
+            "Action": [
+                "kms:CreateGrant",
+                "kms:ListGrants",
+                "kms:RevokeGrant"
+            ],
+            "Resource": "*",
+            "Condition": {
+                "Bool": {
+                    "kms:GrantIsForAWSResource": "true"
+                }
+            }
+        }
+    ]
+}
+EOF
+----
+
+. Confirm the details of the policy file created by running the following command:
++
+[source,terminal]
+----
+$ cat rosa-key-policy.json
+----
+
+. Apply the newly generated key policy to the custom KMS key by running the following command:
++
+[source,terminal]
+----
+aws kms put-key-policy --key-id $KMS_ARN --policy file://rosa-key-policy.json --policy-name default
+----
++
+You can now create your cluster using this AWS KMS encryption key.

--- a/modules/creating-cluster-with-fips-encryption.adoc
+++ b/modules/creating-cluster-with-fips-encryption.adoc
@@ -1,0 +1,106 @@
+// Module included in the following assemblies:
+//
+// * observability/monitoring/enabling-monitoring-for-user-defined-projects.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="creating-cluster-with-fips-encryption_{context}"]
+= Creating a {product-title} cluster using a custom AWS KMS key
+
+[role="_abstract"]
+You can create a {product-title} cluster with Federal Information Processing Standards (FIPS) encryption that uses a customer-provided KMS key to encrypt either node root volumes, the etcd database, or both. A different KMS key ARN can be provided for each option.
+
+[NOTE]
+====
+{product-title} does not automatically configure the `default` storage class to encrypt persistent volumes with the customer-provided KMS key. This is something that can be configured in-cluster after installation.
+====
+
+.Procedure
+
+. Verify the KMS key has been created by running the following command:
++
+[source,terminal]
+----
+$ echo $KMS_ARN
+----
+
+. Confirm the details of the policy file created by running the following command:
++
+[source,terminal]
+----
+$ cat rosa-key-policy.json
+----
+
+. Create the cluster by running the following command:
++
+--
+include::snippets/rosa-long-cluster-name.adoc[]
+--
++
+[source,terminal]
+----
+$ rosa create cluster \
+--cluster-name ${PREFIX}-test \
+--hosted-cp \
+--machine-cidr 10.0.0.0/16 \
+--oidc-config-id $OIDC_CONFIG \
+--mode auto \
+--region $AWS_REGION \
+--replicas 2 \
+--operator-roles-prefix $PREFIX \
+--installer-role-arn "arn:aws:iam::${AWS_ACCOUNT}:role/${PREFIX}-HCP-ROSA-Installer-Role" \
+--support-role-arn "arn:aws:iam::${AWS_ACCOUNT}:role/${PREFIX}-HCP-ROSA-Support-Role" \
+--worker-iam-role-arn "arn:aws:iam::${AWS_ACCOUNT}:role/${PREFIX}-HCP-ROSA-Worker-Role" \
+--subnet-ids <subnet-ids> \
+--etcd-encryption \
+--etcd-encryption-kms-arn $KMS_ARN \
+--fips
+----
++
+--
+where:
+
+`--subnet-ids`:: These subnet IDs should be at least one private subnet ID and public subnet ID.
+`--kms-key-arn`:: This KMS key ARN is used to encrypt all worker node root volumes. It is not required if only etcd database encryption is needed.
+`--etcd-encryption-kms-arn`:: This KMS key ARN is used to encrypt the etcd database. The etcd database is always encrypted by default with an AES cipher block, but can be encrypted instead with a KMS key. It is not required if only node root volume encryption is needed.
+--
+
+.Verification
+
+. Log in to your cluster as an admin user.
+. Set the node name as a variable by running the following command:
++
+[source,terminal]
+----
+$ NODE=$(oc get nodes --no-headers | awk '$2=="Ready"{print $1; exit}')
+----
+
+. Check your cluster's FIPS status by running the following command:
++
+[source,terminal]
+----
+$ oc debug node/${NODE} --to-namespace=default -- chroot /host bash -c 'set -x; \
+fips-mode-setup --check; \
+update-crypto-policies --show; \
+cat /etc/system-fips; \
+cat /proc/sys/crypto/fips_enabled; \
+sysctl crypto.fips_enabled'
+----
++
+.Example output
+[source,terminal]
+----
+Starting pod/ip-10-0-1-162us-east-2computeinternal-debug-86cnb ...
+To use host binaries, run `chroot /host`
++ fips-mode-setup --check
+FIPS mode is enabled.
++ update-crypto-policies --show
+FIPS
++ cat /etc/system-fips
+# FIPS module installation complete
++ cat /proc/sys/crypto/fips_enabled
+1
++ sysctl crypto.fips_enabled
+crypto.fips_enabled = 1
+
+Removing debug pod ...
+----

--- a/modules/rosa-hcp-creating-account-wide-sts-roles-and-policies.adoc
+++ b/modules/rosa-hcp-creating-account-wide-sts-roles-and-policies.adoc
@@ -9,6 +9,9 @@
 ifeval::["{context}" == "rosa-hcp-egress-zero-install"]
 :egress-lockdown:
 endif::[]
+ifeval::["{context}" == "rosa-hcp-creating-cluster-with-fips-encryption"]
+:fips:
+endif::[]
 
 :_mod-docs-content-type: PROCEDURE
 [id="rosa-sts-creating-account-wide-sts-roles-and-policies_{context}"]
@@ -19,7 +22,7 @@ Account-wide roles, like,  `account-roles` in the {rosa-cli-first} are required 
 
 [NOTE]
 ====
-Specific AWS-managed policies for {product-title} must be attached to each role. Customer-managed policies must not be used with these required account roles. For more information regarding AWS-managed policies for {product-title} clusters, see link:https://docs.aws.amazon.com/ROSA/latest/userguide/security-iam-awsmanpol-account-policies.html[AWS managed policies for ROSA].
+Specific AWS-managed policies for {product-title} must be attached to each role. Customer-managed policies must not be used with these required account roles. For more information regarding AWS-managed policies for {product-title} clusters, see link:https://docs.aws.amazon.com/ROSA/latest/userguide/security-iam-awsmanpol-account-policies.html[AWS managed policies for {product-title}].
 ====
 
 .Prerequisites
@@ -27,17 +30,27 @@ Specific AWS-managed policies for {product-title} must be attached to each role.
 * You have completed the AWS prerequisites for {product-title}.
 * You have available AWS service quotas.
 * You have enabled the {product-title} in the AWS Console.
-* You have installed and configured the latest ROSA CLI (`rosa`) on your installation host.
-* You have logged in to your Red{nbsp}Hat account by using the ROSA CLI.
+* You have installed and configured the latest {rosa-cli-first} on your installation host.
+* You have logged in to your Red{nbsp}Hat account by using the {rosa-cli}.
 
 .Procedure
 
 . If they do not exist in your AWS account, create the required account-wide STS roles and attach the policies by running the following command:
 +
+ifndef::fips[]
 [source,terminal]
 ----
 $ rosa create account-roles --hosted-cp
 ----
+endif::fips[]
+ifdef::fips[]
+[source,terminal]
+----
+$ export PREFIX=<custom_prefix>; rosa create account-roles --hosted-cp --prefix $PREFIX
+----
++
+When using FIPS encryption, you need to set a custom prefix instead of using the default `ManagedOpenShift` prefix.
+endif::fips[]
 
 ifdef::egress-lockdown[]
 . Ensure that the your worker role has the correct AWS policy by running the following command:
@@ -54,6 +67,7 @@ $ aws iam attach-role-policy \
 --
 endif::egress-lockdown[]
 
+ifndef::fips[]
 . Optional: Set your prefix as an environmental variable by running the following command:
 +
 [source,terminal]
@@ -74,9 +88,16 @@ For example:
 ----
 ManagedOpenShift
 ----
-+
-For more information regarding AWS managed IAM policies for {product-title}, see link:https://docs.aws.amazon.com/ROSA/latest/userguide/security-iam-awsmanpol.html[AWS managed IAM policies for ROSA].
+endif::fips[]
 
+[role="_additional-resources"]
+.Additional resources
+
+* link:https://docs.aws.amazon.com/ROSA/latest/userguide/security-iam-awsmanpol.html[AWS managed IAM policies for {product-title}]
+
+ifeval::["{context}" == "rosa-hcp-creating-cluster-with-fips-encryption"]
+:!fips:
+endif::[]
 ifeval::["{context}" == "rosa-hcp-egress-zero-install"]
 :!egress-lockdown:
 endif::[]

--- a/modules/rosa-hcp-creating-vpc.adoc
+++ b/modules/rosa-hcp-creating-vpc.adoc
@@ -11,7 +11,6 @@
 You must have an AWS Virtual Private Cloud (VPC) to create a {product-title} cluster. You can use the following methods to create a VPC:
 
 * Create a VPC using the {rosa-cli}
-* Create a VPC by using a Terraform template
 * Manually create the VPC resources in the AWS console
 
 [NOTE]

--- a/modules/rosa-operator-config.adoc
+++ b/modules/rosa-operator-config.adoc
@@ -7,6 +7,10 @@
 // * rosa_hcp/rosa-hcp-egress-zero-install.adoc
 // * rosa_planning/rosa-hcp-prepare-iam-roles-resources.adoc
 
+ifeval::["{context}" == "rosa-hcp-creating-cluster-with-fips-encryption"]
+:fips:
+endif::[]
+
 :_mod-docs-content-type: PROCEDURE
 [id="rosa-operator-config_{context}"]
 = Creating Operator roles and policies
@@ -21,8 +25,18 @@ When you deploy a {product-title} cluster, you must create the Operator IAM role
 * You created the account-wide AWS roles.
 
 .Procedure
-
-* To create your Operator roles, run the following command:
+ifdef::fips[]
+. To create your Operator roles, run the following command:
++
+[source,terminal]
+----
+$ rosa create operator-roles --hosted-cp --prefix=$PREFIX --oidc-config-id=$OIDC_ID 
+----
++
+The Operator roles are now created and ready to use for creating your {product-title} cluster.
+endif::fips[]
+ifndef::fips[]
+. To create your Operator roles, run the following command:
 +
 [source,terminal]
 ----
@@ -82,6 +96,7 @@ where:
 --
 +
 The Operator roles are now created and ready to use for creating your {product-title} cluster.
+endif::fips[]
 
 .Verification
 
@@ -113,3 +128,7 @@ ROLE NAME                                                         ROLE ARN      
 ----
 +
 After the command runs, it displays all the prefixes associated with your AWS account and notes how many roles are associated with this prefix. If you need to see all of these roles and their details, enter "Yes" on the detail prompt to have these roles listed out with specifics.
+
+ifeval::["{context}" == "rosa-hcp-creating-cluster-with-fips-encryption"]
+:!fips:
+endif::[]

--- a/modules/rosa-policy-security-regulation-compliance.adoc
+++ b/modules/rosa-policy-security-regulation-compliance.adoc
@@ -63,6 +63,8 @@ ifdef::openshift-rosa-hcp[]
 |===
 | Compliance | {hcp-title-first}
 
+| FIPS | Yes
+
 | HIPAA Qualified^[1]^ | Yes
 
 | ISO 27001 | Yes

--- a/modules/rosa-release-notes-Q2-2026.adoc
+++ b/modules/rosa-release-notes-Q2-2026.adoc
@@ -1,0 +1,11 @@
+// Module included in the following assemblies:
+// * rosa-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="rosa-q2-2026_{context}"]
+= Q2 2026
+
+[role="_abstract"]
+The following items were added during the second quarter of 2026.
+
+* **Users can create FIPS-encrypted Red Hat OpenShift Service on AWS clusters**. With this update, you can create Red Hat OpenShift Service on AWS clusters with Federal Information Processing Standards (FIPS) encryption that adhere to the highest data security levels.

--- a/rosa_hcp/rosa-hcp-creating-cluster-with-fips-encryption.adoc
+++ b/rosa_hcp/rosa-hcp-creating-cluster-with-fips-encryption.adoc
@@ -1,52 +1,32 @@
 :_mod-docs-content-type: ASSEMBLY
-[id="rosa-hcp-creating-cluster-with-aws-kms-key"]
-= Creating {product-title} clusters using a custom AWS KMS encryption key
+[id="rosa-hcp-creating-cluster-with-fips-encryption"]
+= Deploying {product-title} clusters using FIPS encryption
 include::_attributes/attributes-openshift-dedicated.adoc[]
-:context: rosa-hcp-creating-cluster-with-aws-kms-key
+:context: rosa-hcp-creating-cluster-with-fips-encryption
 
 toc::[]
 
 [role="_abstract"]
-Create a {product-title} cluster using a custom AWS Key Management Service (KMS) key.
+Deploying a {product-title} cluster using Federal Information Processing Standards (FIPS) encryption ensures that sensitive data is protected using validated cryptographic modules. 
 
-//include::modules/rosa-sts-creating-a-cluster-quickly-ocm.adoc[leveloffset=+1]
-//include::modules/rosa-sts-associating-your-aws-account.adoc[leveloffset=+2]
+include::modules/rosa-hcp-creating-account-wide-sts-roles-and-policies.adoc[leveloffset=+1]
 
-[id="rosa-hcp-creating-cluster-with-aws-kms-key-prereqs"]
-== {product-title} Prerequisites
+include::modules/rosa-hcp-create-network.adoc[leveloffset=+1]
 
-To create a {product-title} cluster, you must have the following items:
+include::modules/rosa-sts-byo-oidc.adoc[leveloffset=+1]
 
-* A configured virtual private cloud (VPC)
-* Account-wide roles
-* An OIDC configuration
-* Operator roles
+include::modules/rosa-operator-config.adoc[leveloffset=+1]
 
-include::modules/rosa-hcp-creating-vpc.adoc[leveloffset=+1]
+include::modules/aws-encryption-key.adoc[leveloffset=+1]
 
-include::modules/rosa-hcp-create-network.adoc[leveloffset=+2]
-
-include::modules/rosa-hcp-vpc-manual.adoc[leveloffset=+2]
-
-include::modules/vpc-troubleshooting.adoc[leveloffset=+2]
-
-include::modules/rosa-hcp-vpc-subnet-tagging.adoc[leveloffset=+3]
-
-include::modules/rosa-hcp-creating-account-wide-sts-roles-and-policies.adoc[leveloffset=+2]
-
-include::modules/rosa-sts-byo-oidc.adoc[leveloffset=+2]
-
-include::modules/rosa-operator-config.adoc[leveloffset=+2]
-
-include::modules/creating-cluster-with-aws-kms-key.adoc[leveloffset=+2]
+include::modules/creating-cluster-with-fips-encryption.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
-[id="additional-resources_rosa-hcp-creating-cluster-with-aws-kms-key"]
+[id="additional-resources_rosa-hcp-creating-cluster-with-fips-encryption"]
 == Additional resources
 
 * link:https://aws.amazon.com/cloudformation/[AWS CloudFormation]
 * link:https://github.com/openshift/rosa/blob/master/cmd/create/network/templates/rosa-quickstart-default-vpc/cloudformation.yaml[Default VPC AWS CloudFormation template]
-* link:https://github.com/openshift-cs/terraform-vpc-example[Terraform VPC repository]
 * xref:../support/troubleshooting/rosa-troubleshooting-installations-hcp.adoc#rosa-troubleshooting-installations-hcp[Troubleshooting {product-title} cluster installations]
 * xref:../support/getting-support.adoc#getting-support[Getting support for Red{nbsp}Hat OpenShift Service on AWS]
 * link:https://docs.aws.amazon.com/vpc/latest/userguide/vpc-getting-started.html[Get Started with Amazon VPC]

--- a/rosa_release_notes/rosa-release-notes.adoc
+++ b/rosa_release_notes/rosa-release-notes.adoc
@@ -12,6 +12,7 @@ toc::[]
 Find new additions, recent changes, and relevant updates for {product-title} listed below in quarterly increments.
 
 // //remove the conditional if Classic notes are added to the module
+include::modules/rosa-release-notes-Q2-2026.adoc[leveloffset=+1]
 
 include::modules/rosa-release-notes-Q1-2026.adoc[leveloffset=+1]
 


### PR DESCRIPTION
Version(s):
`enterprise-4.21+`

Issue:
[OSDOCS-17466](https://issues.redhat.com/browse/OSDOCS-17466)

Link to docs preview:
* [Red Hat OpenShift Service on AWS Introduction to ROSA](https://108102--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/rosa_architecture/rosa_policy_service_definition/rosa-policy-process-security.html#rosa-policy-compliance_rosa-policy-process-security) - Added compliance information 
    <img width="895" height="561" alt="image" src="https://github.com/user-attachments/assets/d3737a38-465d-433a-8f89-f6c892d61279" />
* [What’s New](https://108102--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/rosa_release_notes/rosa-release-notes#rosa-q1-2026_rosa-whats-new)
* [Installing a cluster with FIPS encryption](https://108102--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/rosa_hcp/rosa-hcp-creating-cluster-with-fips-encryption.html)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
This PR adds a new cluster creation guide that covers FIPS encryption on a new cluster.