### PR TITLE
OCPBUGS#74682: Added an extra manifest

### DIFF
--- a/modules/cnf-image-based-upgrade-seed-image-config.adoc
+++ b/modules/cnf-image-based-upgrade-seed-image-config.adoc
@@ -9,7 +9,7 @@ ifeval::["{context}" == "generate-seed"]
 :ibu:
 endif::[]
 
-:_mod-docs-content-type: PROCEDURE
+:_mod-docs-content-type: CONCEPT
 [id="cnf-image-based-upgrade-seed-image-config_{context}"]
 = Seed image configuration
 
@@ -109,6 +109,10 @@ The following table lists the components, resources, and configurations that you
 
 |`StorageLVMCluster.yaml`
 |No
+
+|`SriovVrbClusterConfig.yaml`
+|Yes
+
 |====
 
 ifdef::ibu[]

--- a/modules/ibi-extra-manifests-standalone.adoc
+++ b/modules/ibi-extra-manifests-standalone.adoc
@@ -41,9 +41,12 @@ $ mkdir extra-manifests
 
 . Create the `SriovNetworkNodePolicy` and `SriovNetwork` resources in the `extra-manifests` folder:
 
-.. Create a YAML file that defines the resources:
+.. Create a YAML file that defines the resources, as shown in the following example:
 +
-.Example `sriov-extra-manifest.yaml` file
+[NOTE]
+====
+If the cluster nodes include Intel vRAN Boost (VRB1 or VRB2) hardware, you can include a `SriovVrbClusterConfig` resource in the extra manifests to configure the hardware.
+====
 +
 [source,yaml]
 ----
@@ -78,6 +81,52 @@ spec:
   resourceName: example-sriov-node-policy
   spoofChk: "on"
   trust: "off"
+---
+apiVersion: sriovvrb.intel.com/v1
+kind: SriovVrbClusterConfig
+metadata:
+  name: config
+  namespace: vran-acceleration-operators
+spec:
+  priority: 1
+  nodeSelector:
+    kubernetes.io/hostname: worker-node
+  acceleratorSelector:
+    pciAddress: 0000:07:00.0
+  drainSkip: true
+  physicalFunction:
+    pfDriver: vfio-pci
+    vfDriver: vfio-pci
+    vfAmount: 2
+    bbDevConfig:
+      vrb2:
+        pfMode: false
+        numVfBundles: 2
+        maxQueueSize: 1024
+        downlink4G:
+          aqDepthLog2: 4
+          numAqsPerGroups: 16
+          numQueueGroups: 0
+        uplink4G:
+          aqDepthLog2: 4
+          numAqsPerGroups: 16
+          numQueueGroups: 0
+        downlink5G:
+          aqDepthLog2: 4
+          numAqsPerGroups: 16
+          numQueueGroups: 4
+        uplink5G:
+          aqDepthLog2: 4
+          numAqsPerGroups: 16
+          numQueueGroups: 4
+        qfft:
+          aqDepthLog2: 4
+          numAqsPerGroups: 16
+          numQueueGroups: 4
+        qmld:
+          aqDepthLog2: 4
+          numAqsPerGroups: 64
+          numQueueGroups: 4
 ----
 
 .Verification


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.19+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
[OCPBUGS-74682](https://issues.redhat.com/browse/OCPBUGS-74682)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
[Configuring resources for extra manifests](https://108106--ocpdocs-pr.netlify.app/openshift-enterprise/latest/edge_computing/image_base_install/ibi_deploying_sno_clusters/ibi-edge-image-based-install-standalone.html#creating-a-resource-in-the-extra-manifests-folder)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->