### PR TITLE
[OCPBUGS#77836]: Remove references to Elasticsearch from OKE docs

### DIFF
--- a/welcome/oke_about.adoc
+++ b/welcome/oke_about.adoc
@@ -194,7 +194,7 @@ the kubevirt.io open source project.
 === Advanced cluster management
 {oke} is compatible with your additional purchase of {rh-rhacm-first} for
 Kubernetes. An {oke} subscription does not offer a cluster-wide log aggregation
-solution or support Elasticsearch, Fluentd, or Kibana-based logging solutions.
+solution or support Fluentd, or Kibana-based logging solutions.
 {SMProductName} capabilities derived from the open-source istio.io and kiali.io
 projects that offer OpenTracing observability for containerized services on
 {product-title} are not supported in {oke}.
@@ -293,7 +293,6 @@ s| Feature s| {oke} s| {product-title} s| Operator name
 | User Workload Monitoring | Not Included | Included | N/A
 | Cost Management SaaS Service | Included | Included | Cost Management Metrics Operator
 | Platform Logging | Not Included | Included | Red Hat OpenShift Logging Operator
-| OpenShift Elasticsearch Operator provided by Red Hat | Not Included | Cannot be run standalone | N/A
 | Developer Web Console | Not Included | Included | N/A
 | Developer Application Catalog | Not Included | Included | N/A
 | Source to Image and Builder Automation (Tekton) | Not Included | Included | N/A

--- a/welcome/oke_about.adoc
+++ b/welcome/oke_about.adoc
@@ -194,7 +194,7 @@ the kubevirt.io open source project.
 === Advanced cluster management
 {oke} is compatible with your additional purchase of {rh-rhacm-first} for
 Kubernetes. An {oke} subscription does not offer a cluster-wide log aggregation
-solution or support Fluentd, or Kibana-based logging solutions.
+solution.
 {SMProductName} capabilities derived from the open-source istio.io and kiali.io
 projects that offer OpenTracing observability for containerized services on
 {product-title} are not supported in {oke}.


### PR DESCRIPTION
Version(s):
4.18

Issue:
https://issues.redhat.com/browse/OCPBUGS-77836

Link to docs preview:
https://108111--ocpdocs-pr.netlify.app/openshift-enterprise/latest/welcome/oke_about.html

QE review: 
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
