### PR TITLE
CNV-56896: Virt and hosted control plane confusion

### DIFF
--- a/modules/virt-aws-bm.adoc
+++ b/modules/virt-aws-bm.adoc
@@ -7,11 +7,11 @@ ifndef::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
 = {VirtProductName} on AWS bare metal
 
 [role="_abstract"]
-You can run {VirtProductName} on an Amazon Web Services (AWS) bare metal {product-title} cluster.
+You can run {VirtProductName} on an {aws-first} bare metal {product-title} cluster.
 
 [NOTE]
 ====
-{VirtProductName} is also supported on {product-rosa} (ROSA) Classic clusters, which have the same configuration requirements as AWS bare-metal clusters.
+{VirtProductName} is also supported on {product-rosa} (ROSA) Classic clusters, which have the same configuration requirements as {aws-short} bare-metal clusters.
 ====
 endif::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
 
@@ -50,7 +50,7 @@ endif::openshift-dedicated[]
 ifndef::openshift-dedicated,openshift-rosa-hcp,openshift-rosa[]
 You specify bare-metal instance types by editing the `install-config.yaml` file.
 
-For more information, see the {product-title} documentation about installing on AWS.
+For more information, see the {product-title} documentation about installing on {aws-short}.
 
 endif::openshift-dedicated,openshift-rosa-hcp,openshift-rosa[]
 Accessing virtual machines (VMs)::
@@ -62,7 +62,7 @@ Accessing virtual machines (VMs)::
 ====
 The load balancer approach is preferable because {product-title} automatically creates the load balancer in
 ifndef::openshift-dedicated[]
-AWS
+{aws-short}
 endif::openshift-dedicated[]
 ifdef::openshift-dedicated[]
 Google Cloud
@@ -98,7 +98,7 @@ endif::openshift-dedicated[]
 ifdef::openshift-rosa,openshift-rosa-hcp[]
 [IMPORTANT]
 ====
-AWS bare metal, Red Hat OpenShift Service on AWS, and Red Hat OpenShift Service on AWS classic architecture clusters might have different supported storage solutions. Ensure that you confirm support with your storage vendor.
+{aws-short} bare metal, {product-rosa}, and {product-rosa} classic architecture clusters might have different supported storage solutions. Ensure that you confirm support with your storage vendor.
 ====
 endif::openshift-rosa,openshift-rosa-hcp[]
 ifdef::openshift-rosa,openshift-rosa-hcp[]
@@ -143,8 +143,9 @@ Consider using CSI storage, which supports ReadWriteMany (RWX), cloning, and sna
 endif::openshift-rosa,openshift-rosa-hcp[]
 ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 Hosted control planes (HCPs)::
-
-* HCPs for {VirtProductName} are not currently supported on AWS infrastructure.
+--
+* You can run {VirtProductName} on HCP clusters that use {aws-short} bare-metal nodes. However, using {VirtProductName} VMs as HCP nodes is not currently supported on {aws-short}.
+--
 endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 
 endif::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]


### PR DESCRIPTION
Resolves: https://issues.redhat.com/browse/CNV-56896

CNV 4.17+
OCP 4.17+

Preview: https://108122--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/install/preparing-cluster-for-virt.html#virt-aws-bm_preparing-cluster-for-virt