### PR TITLE
OSDOCS#18618: Update the z-stream RNs for 4.20.15 

### DIFF
--- a/modules/zstream-4-20-15.adoc
+++ b/modules/zstream-4-20-15.adoc
@@ -1,0 +1,51 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-20-release-notes.adoc
+
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-20-15_{context}"]
+= RHBA-2026:2987 - {product-title} {product-version}.15 fixed issues advisory
+
+Issued: 25 February 2026
+
+[role="_abstract"]
+{product-title} release {product-version}.15 is now available. The list of fixed issues that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2026:2987[RHSA-2026-2987] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2026:2980[RHBA-2026:2980] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.20.15 --pullspecs
+----
+
+[id="zstream-4-20-15-enhancements_{context}"]
+== Enhancements
+
+The following enhancements are fixed for this release:
+
+* With this update, the system ensures that the `HostedControlPlane` and `HostedCluster` become available only after all control plane parts have successfully rolled out. This is accomplished by using the `ControlPlaneComponent` resource to track the rollout status of each control plane part. This enhancement improves the reliability and accuracy of the system's availability reporting, providing a more secure user experience. By accurately tracking the rollout status, the system reduces the risk of unexpected issues during the initial provisioning of a `HostedCluster`. (link:https://issues.redhat.com/browse/OCPBUGS-74775[OCPBUGS-74775])
+
+[id="zstream-4-20-15-fixed-issues_{context}"]
+== Fixed issues
+
+The following issues are fixed for this release:
+
+* Before this update, a problem with signal handling in the `keepalived` container caused an unnecessary delaty in failover when the nodes were restarted. As a consequence, access to the API and ingress services was disrupted. With this release, the signal handling is fixed so failover occurs immediately. As a result, disruption to the API and ingress services is minimized. (link:https://issues.redhat.com/browse/OCPBUGS-69706[OCPBUGS-69706])
+
+* Before this update, during the cluster deletion got stuck during the inspection phase due to a power off stage transition. As a consequence, the cluster was not deleted. With this release, the BareMetal host (BMH) is prevented from getting stuck during deletion in a ZTP environment. As a result, the cluster removal is prevented from getting stuck during the inspection phase, which improves the efficiency of the ZTP environment. (link:https://issues.redhat.com/browse/OCPBUGS-74987[OCPBUGS-74987])
+
+* Before this update, a duplicate channel in catalog.json caused a mirroring failure. As a consequence, mirroring operation failed for some Operators due to a duplicate channel error. With this release, the mirroring issue is fixed. As a result, mirroring to enclaves succeeds without duplicate channel errors. (link:https://issues.redhat.com/browse/OCPBUGS-75007[OCPBUGS-75007])
+
+* Before this update, the overflow menu on the **Subscription details** page was empty, which affected user navigation. With this update, the issue is resolved and the menu is populated correctly with relevant actions.(link:https://issues.redhat.com/browse/OCPBUGS-75880[OCPBUGS-75880])
+
+* Before this update, the Security Context Constraints(SCC) additionally set `readOnlyRootFilesystem: true`. As a consequence, read-only file system errors occurred. With this release, by default, SSC sets the `readOnlyRootFilesystem` value to false. As a result, read-only file system errors do not occur. (link:https://issues.redhat.com/browse/OCPBUGS-75933[OCPBUGS-75933])
+
+* Before this update, the `collect-profiles` job was affected by maintenance difficulties, causing confusion for customers and support engineers during troubleshooting. With this release, the `collect-profiles` job is removed, improving user experience and reducing maintenance effort. (link:https://issues.redhat.com/browse/OCPBUGS-76335[OCPBUGS-76335])
+
+[id="zstream-4-20-15-updating_{context}"]
+== Updating
+
+To update an {product-title} 4.20 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].

--- a/release_notes/ocp-4-20-release-notes.adoc
+++ b/release_notes/ocp-4-20-release-notes.adoc
@@ -3015,9 +3015,11 @@ In both cases, the installation program generates a user-assigned identity. (lin
 
 // [id="ocp-storage-core-release-known-issues_{context}"]
 
-
 // 4.20.14 about async
 include::modules/rn-async-errata.adoc[leveloffset=+1]
+
+// 4-20-15 release notes enhancements
+include::modules/zstream-4-20-15.adoc[leveloffset=+2]
 
 // 4.20.14 RNs
 include::modules/zstream-4-20-14.adoc[leveloffset=+2]


### PR DESCRIPTION
Version(s):
4.20

Issue:
[OSDOCS-18618](https://issues.redhat.com/browse/OSDOCS-18618)

Link to docs preview:
[4.20.15](https://108155--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-20-release-notes.html#zstream-4-20-15_release-notes)

QE review:
- [ ] QE has approved this change.
N/A for z-streams RNs.

Additional information:
** This is an update to PR #[18387](https://github.com/openshift/openshift-docs/pull/108110/changes) to add the 4.20.15 RNs.
