### PR TITLE
OSDOCS-18705: Enabling ROSA HCP xrefs in Operators

### DIFF
--- a/operators/admin/olm-managing-custom-catalogs.adoc
+++ b/operators/admin/olm-managing-custom-catalogs.adoc
@@ -27,10 +27,7 @@ Kubernetes periodically deprecates certain APIs that are removed in subsequent r
 [id="olm-managing-custom-catalogs-bundle-format-prereqs"]
 == Prerequisites
 
-// TODO-HCP remove conditions for HCP after cli_tools book is migrated
-ifndef::openshift-rosa-hcp[]
 * You have installed the xref:../../cli_reference/opm/cli-opm-install.adoc#cli-opm-install[`opm` CLI].
-endif::openshift-rosa-hcp[]
 
 [id="olm-managing-custom-catalogs-fb"]
 == File-based catalogs
@@ -57,10 +54,7 @@ include::modules/olm-creating-fb-catalog-image.adoc[leveloffset=+2]
 [role="_additional-resources"]
 .Additional resources
 
-// TODO-HCP remove conditions for HCP after cli_tools book is migrated
-ifndef::openshift-rosa-hcp[]
 * xref:../../cli_reference/opm/cli-opm-ref.adoc#cli-opm-ref[`opm` CLI reference]
-endif::openshift-rosa-hcp[]
 
 include::modules/olm-filtering-fbc.adoc[leveloffset=+2]
 


### PR DESCRIPTION
Version(s):
4.21+

Issue:
https://issues.redhat.com/browse/OSDOCS-18705

Link to docs preview:
ROSA HCP:  [Updating or filtering a file-based catalog image chapter](https://108166--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/operators/admin/olm-managing-custom-catalogs.html#olm-filtering-fbc_olm-managing-custom-catalogs). The PR uncomments 2 xrefs for ROSA HCP, and that also fixes formatting for the linked chapter.

The assembly is reused in other docs sets. Confirming that the change hasn't broken anything in them:

- [ROSA Classic](https://108166--ocpdocs-pr.netlify.app/openshift-rosa/latest/operators/admin/olm-managing-custom-catalogs.html#olm-filtering-fbc_olm-managing-custom-catalogs)
- [OSD](https://108166--ocpdocs-pr.netlify.app/openshift-dedicated/latest/operators/admin/olm-managing-custom-catalogs.html#olm-filtering-fbc_olm-managing-custom-catalogs)
- [OCP](https://108166--ocpdocs-pr.netlify.app/openshift-enterprise/latest/operators/admin/olm-managing-custom-catalogs.html#olm-filtering-fbc_olm-managing-custom-catalogs)

QE review:
N/A

Additional information:

