### PR TITLE
OSDOCS Add TP note for control plane boot image update

### DIFF
--- a/nodes/nodes/nodes-update-boot-images.adoc
+++ b/nodes/nodes/nodes-update-boot-images.adoc
@@ -12,6 +12,9 @@ include::snippets/mco-update-boot-images-abstract.adoc[]
 
 include::snippets/mco-update-boot-images-intro.adoc[]
 
+:FeatureName: Boot image management for control plane nodes
+include::snippets/technology-preview.adoc[]
+
 include::modules/mco-update-boot-images-about.adoc[leveloffset=+1]
 
 include::modules/mco-update-boot-images-disable.adoc[leveloffset=+1]


### PR DESCRIPTION
Neglected to add Tech Preview note to this module to match https://github.com/openshift/openshift-docs/pull/102966/changes#diff-ee54250c7b9a288ae12815c25cb6372b4f47bca1da8852233c5b453010a2bb41R13

Node -> Nodes -> [Boot image management](https://108169--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/nodes/nodes-update-boot-images.html) -- Added TP note to match Machine Config -> [Boot image management](https://108169--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_configuration/mco-update-boot-images)