### PR TITLE
[OSDOCS#18461]: Removed tech preview note for TNF

### DIFF
--- a/installing/installing_two_node_cluster/installing_tnf/installing-two-node-fencing.adoc
+++ b/installing/installing_two_node_cluster/installing_tnf/installing-two-node-fencing.adoc
@@ -6,9 +6,6 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-:FeatureName: Two-node OpenShift cluster with fencing
-include::snippets/technology-preview.adoc[leveloffset=+1]
-
 A two-node OpenShift cluster with fencing provides high availability (HA) with a reduced hardware footprint. This configuration is designed for distributed or edge environments where deploying a full three-node control plane cluster is not practical.
 
 A two-node cluster does not include compute nodes. The two control plane machines run user workloads in addition to managing the cluster.

--- a/modules/rn-ocp-release-notes-technology-preview.adoc
+++ b/modules/rn-ocp-release-notes-technology-preview.adoc
@@ -42,7 +42,7 @@ In the following tables, features are marked with the following statuses:
 .Edge computing Technology Preview tracker
 [cols="4,1,1,1",options="header"]
 |====
-|Feature |4.19 |4.20 |4.21
+|Feature |4.20 |4.21 |4.22
 
 |Accelerated provisioning of {ztp}
 |Technology Preview
@@ -55,14 +55,14 @@ In the following tables, features are marked with the following statuses:
 |Technology Preview
 
 |Configuring a local arbiter node
-|Technology Preview
+|General Availability
 |General Availability
 |General Availability
 
 |Configuring a two-node {product-title} cluster with fencing
-|Not Available
 |Technology Preview
 |Technology Preview
+|General Availability
 |====
 
 


### PR DESCRIPTION
Version(s):
4.22

Issue:
https://issues.redhat.com/browse/OSDOCS-18461

Link to docs preview:
https://108177--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_two_node_cluster/installing_tnf/installing-two-node-fencing.html

For release Notes: 
https://108177--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-21-release-notes#ocp-release-notesedge-computing-tp-features_release-notes

QE review:
- [ ] QE has approved this change.

