### PR TITLE
OSDOCS-16875-1: CQA for SCALE-5 Cluster Compare Tool and Reference Conf…

### DIFF
--- a/modules/cluster-compare-overview.adoc
+++ b/modules/cluster-compare-overview.adoc
@@ -3,11 +3,11 @@
 // *scalability_and_performance/cluster-compare/understanding-the-cluster-compare-plugin.adoc
 
 :_mod-docs-content-type: CONCEPT
-
 [id="cluster-compare-overview_{context}"]
 = Overview of the cluster-compare plugin
 
-Clusters deployed at scale typically use a validated set of baseline custom resources (CRs) to configure clusters to meet use-case requirements and ensure consistency when deploying across different environments. 
+[role="_abstract"]
+To ensure consistency across different environments, configure your clusters with a validated set of baseline custom resources (CRs). By understanding how the `cluster-compare` plugin evaluates these settings, you can reliably meet your specific use-case requirements at scale.
 
 In live clusters, some variation from the validated set of CRs is expected. For example, configurations might differ because of variable substitution, optional components, or hardware-specific fields. This variation makes it difficult to accurately assess if a cluster is compliant with the baseline configuration.
 

--- a/modules/installing-cluster-compare.adoc
+++ b/modules/installing-cluster-compare.adoc
@@ -2,20 +2,18 @@
 
 // *scalability_and_performance/cluster-compare/installing-cluster-compare-plugin.adoc
 
-:_mod-docs-content-type: CONCEPT
-
+:_mod-docs-content-type: PROCEDURE
 [id="installing-cluster-compare_{context}"]
 = Installing the cluster-compare plugin
 
-Install the `cluster-compare` plugin to compare a reference configuration with a cluster configuration from a live cluster or `must-gather` data.
+[role="_abstract"]
+To compare a reference configuration with settings from a live cluster or `must-gather` data, install the `cluster-compare` plugin. By deploying this tool, you can effectively validate your current environment against a known baseline and identify any configuration deviations.
 
 .Prerequisites
 
-. You have installed the OpenShift CLI (`oc`).
-
-. You installed `podman`.
-
-. You have access to the Red Hat container catalog.
+* You have installed the {oc-first}.
+* You installed `podman`.
+* You have access to the Red Hat container catalog.
 
 .Procedure
 

--- a/modules/troubleshooting-cc-false-positives.adoc
+++ b/modules/troubleshooting-cc-false-positives.adoc
@@ -1,0 +1,18 @@
+// Module included in the following assemblies:
+
+// *scalability_and_performance/cluster-compare/troubleshooting-cluster-comparisons.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="troubleshooting-cc-false-positives_{context}"]
+= Troubleshooting false positives for missing resources
+
+[role="_abstract"]
+To resolve false positives for missing resources, troubleshoot your plugin results. By diagnosing why the tool fails to detect a present cluster custom resource (CR, you can fix unexpected errors and ensure accurate evaluations.
+
+.Procedure
+
+. Check that you are using the latest version of the `cluster-compare` plugin. For more information, see "Installing the cluster-compare plugin".
+
+. Check that you are using the most up-to-date version of the reference configuration.
+
+. Check that the template has the same `apiVersion`, `kind`, `name`, and `namespace` fields as the cluster CR.

--- a/modules/troubleshooting-cc-multiple-matches.adoc
+++ b/modules/troubleshooting-cc-multiple-matches.adoc
@@ -1,0 +1,20 @@
+// Module included in the following assemblies:
+
+// *scalability_and_performance/cluster-compare/troubleshooting-cluster-comparisons.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="troubleshooting-cc-multiple-matches_{context}"]
+= Troubleshooting multiple template matches for the same CR
+
+[role="_abstract"]
+To resolve conflicts when multiple cluster custom resources (CRs) match a single template, troubleshoot your plugin results. By diagnosing how the tool defaults to the resource with the least differences, you can fix unexpected matching errors and ensure accurate evaluations.
+
+You can optionally configure your reference configuration to avoid this situation.
+
+In some cases, more than one cluster CR can match a template because they feature the same `apiVersion`, `namespace`, and `kind`. The plugin's default matching compares the CR that features the least differences.
+
+.Procedure
+
+. Check that the templates feature distinct `apiVersion`, `namespace`, and `kind` values to ensure no duplicate template matching.
+
+. Use a user configuration file to manually match a template to a CR. For more information, see "Configuring manual matching between CRs and templates".

--- a/modules/understanding-a-reference-config.adoc
+++ b/modules/understanding-a-reference-config.adoc
@@ -3,18 +3,17 @@
 // *scalability_and_performance/cluster-compare/understanding-the-cluster-compare-plugin.adoc
 
 :_mod-docs-content-type: CONCEPT
-
 [id="understanding-a-reference-config_{context}"]
 = Understanding a reference configuration
 
-The `cluster-compare` plugin uses a reference configuration to validate a configuration from a live cluster.
-The reference configuration consists of a YAML file called `metadata.yaml`, which references a set of templates that represent the baseline configuration.
+[role="_abstract"]
+To validate a live cluster configuration against a known baseline, use a reference configuration. The `cluster-compare` plugin evaluates your environment against this specific `metadata.yaml` file and its associated templates to accurately identify any configuration deviations.
 
 .Example directory structure for a reference configuration
 [source,text]
 ----
-├── metadata.yaml <1>
-├── optional <2>
+├── metadata.yaml
+├── optional
 │   ├── optionalTemplate1.yaml
 │   └── optionalTemplate2.yaml 
 ├── required
@@ -26,12 +25,11 @@ The reference configuration consists of a YAML file called `metadata.yaml`, whic
     ├── clusterResource3.yaml
     └── clusterResource4.yaml
 ----
-<1> The reference configuration consists of the `metadata.yaml` file and a set of templates.
-<2> This example uses an optional and required directory structure for templates that are referenced by the `metadata.yaml` file.
-<3> The configuration CRs to use as a baseline configuration for clusters.
+** `metadata.yaml`: Specifies the reference configuration consists of the `metadata.yaml` file and a set of templates.
+** `optional`: Specifies an optional and required directory structure for templates that are referenced by the `metadata.yaml` file.
+** `baselineClusterResources`: Specifies the configuration CRs to use as a baseline configuration for clusters.
 
-During a comparison, the plugin matches each template to a configuration resource from the cluster. 
-The plugin evaluates optional or required fields in the template using features such as Golang templating syntax and inline regular expression validation. The `metadata.yaml` file applies additional validation rules to decide whether a template is optional or required and assesses template dependency relationships.
+During a comparison, the plugin matches each template to a configuration resource from the cluster. The plugin evaluates optional or required fields in the template by using features such as Golang templating syntax and inline regular expression validation. The `metadata.yaml` file applies additional validation rules to decide whether a template is optional or required and assesses template dependency relationships.
 
 Using these features, the plugin identifies relevant configuration differences between the cluster and the reference configuration. For example, the plugin can highlight mismatched field values, missing resources, extra resources, field type mismatches, or version discrepancies.
 

--- a/scalability_and_performance/cluster-compare/installing-cluster-compare-plugin.adoc
+++ b/scalability_and_performance/cluster-compare/installing-cluster-compare-plugin.adoc
@@ -6,7 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-You can extract the `cluster-compare` plugin from a container image in the Red Hat container catalog and use it as a plugin to the `oc` command.
+[role="_abstract"]
+To install the `cluster-compare` plugin for the `oc` command, extract it from a container image in the Red Hat container catalog. By obtaining the tool directly from the catalog, you can quickly deploy the plugin and begin evaluating your cluster configurations.
 
 include::modules/installing-cluster-compare.adoc[leveloffset=+1]
 

--- a/scalability_and_performance/cluster-compare/troubleshooting-cluster-comparisons.adoc
+++ b/scalability_and_performance/cluster-compare/troubleshooting-cluster-comparisons.adoc
@@ -6,33 +6,12 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-When using the `cluster-compare` plugin, you might see unexpected results, such as false positives or conflicts when multiple cluster custom resources (CRs) exist. 
+[role="_abstract"]
+To fix false positives or resource conflicts, troubleshoot your `cluster-compare` plugin results. By diagnosing how the tool evaluates multiple cluster custom resources (CRs), you can resolve unexpected errors and ensure accurate environment comparisons.
 
-[id="troubleshooting-cc-false-positives_{context}"]
-== Troubleshooting false positives for missing resources
+include::modules/troubleshooting-cc-false-positives.adoc[leveloffset=+1]
 
-The plugin might report a missing resource even though the cluster custom resource (CR) is present in the cluster.
-
-.Procedure
-
-. Ensure you are using the latest version of the `cluster-compare` plugin. For more information, see "Installing the cluster-compare plugin".
-
-. Ensure you are using the most up-to-date version of the reference configuration.
-
-. Ensure that template has the same `apiVersion`, `kind`, `name`, and `namespace` fields as the cluster CR.
-
-[id="troubleshooting-cc-multiple-matches_{context}"]
-== Troubleshooting multiple template matches for the same CR
-
-In some cases, more than one cluster CR can match a template because they feature the same `apiVersion`, `namespace`, and `kind`. The plugin's default matching compares the CR that features the least differences.
-
-You can optionally configure your reference configuration to avoid this situation.
-
-.Procedure
-
-. Ensure the templates feature distinct `apiVersion`, `namespace`, and `kind` values to ensure no duplicate template matching.
-
-. Use a user configuration file to manually match a template to a CR. For more information, see "Configuring manual matching between CRs and templates".
+include::modules/troubleshooting-cc-multiple-matches.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 == Additional resources

--- a/scalability_and_performance/cluster-compare/understanding-the-cluster-compare-plugin.adoc
+++ b/scalability_and_performance/cluster-compare/understanding-the-cluster-compare-plugin.adoc
@@ -6,7 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-The `cluster-compare` plugin is an OpenShift CLI (`oc`) plugin that compares a cluster configuration with a reference configuration. The plugin reports configuration differences while suppressing expected variations by using configurable validation rules and templates.
+[role="_abstract"]
+To compare a cluster configuration against a known reference configuration, use the `cluster-compare` plugin. This {oc-first} tool reports configuration differences while suppressing expected variations through configurable validation rules and templates.
 
 Use the `cluster-compare` plugin in development, production, and support scenarios to ensure cluster compliance with a reference configuration, and to quickly identify and troubleshoot relevant configuration differences.
 


### PR DESCRIPTION
Version(s):
4.16+

Issue:
[OSDOCS-16875](https://issues.redhat.com/browse/OSDOCS-16875)

Link to docs preview:

* https://108181--ocpdocs-pr.netlify.app/openshift-enterprise/latest/scalability_and_performance/cluster-compare/installing-cluster-compare-plugin.html
* https://108181--ocpdocs-pr.netlify.app/openshift-enterprise/latest/scalability_and_performance/cluster-compare/troubleshooting-cluster-comparisons.html
* https://108181--ocpdocs-pr.netlify.app/openshift-enterprise/latest/scalability_and_performance/cluster-compare/understanding-the-cluster-compare-plugin.html


