### PR TITLE
OLS-2741: Update MCP page

### DIFF
--- a/modules/ols-enabling-custom-mcp-server.adoc
+++ b/modules/ols-enabling-custom-mcp-server.adoc
@@ -9,7 +9,7 @@
 
 Add an additional Model Context Protocol (MCP) server that interfaces with a tool in your environment so that the large language model (LLM) uses the tool to generate answers to your questions.
 
-:FeatureName: The cluster interaction feature
+:FeatureName: The MCP server feature
 include::snippets/technology-preview.adoc[]
 :FeatureName!:
 


### PR DESCRIPTION
Affects:
[lightspeed-main](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-main)
[lightspeed-docs-1.0](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-1.0)

PR must be CP'd back to the lightspeed-docs-1.0 branch.

Issue:
https://issues.redhat.com/browse/OLS-2741


Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
