### PR TITLE
WIP: Test - OpenShift on OpenShift Virtualization possible changes

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -171,6 +171,9 @@ Topics:
   - Name: Installation overview
     File: index
     Distros: openshift-origin,openshift-enterprise
+  - Name: Choosing an installation approach based on your needs
+    File: choosing-installation-approach
+    Distros: openshift-origin,openshift-enterprise
   - Name: Selecting an installation method and preparing a cluster
     File: installing-preparing
     Distros: openshift-origin,openshift-enterprise
@@ -600,6 +603,12 @@ Topics:
     File: uninstalling-openstack-user
   - Name: Installation configuration parameters for OpenStack
     File: installation-config-parameters-openstack
+- Name: Installing on OpenShift Virtualization
+  Dir: installing_virt
+  Distros: openshift-enterprise
+  Topics:
+  - Name: Installing on OpenShift Virtualization overview
+    File: index
 - Name: Installing on Oracle Distributed Cloud
   Dir: installing_oci
   Distros: openshift-origin,openshift-enterprise

--- a/installing/installing_virt/index.adoc
+++ b/installing/installing_virt/index.adoc
@@ -13,7 +13,7 @@ You can deploy {product-title} clusters as virtual machines on an existing {prod
 
 This installation method is appropriate when you:
 
-* Want to use existing {product-title} infrastructure without provisioning new bare metal
+* Want to deploy virtual clusters to existing bare metal {VirtProductName} infrastructure
 * Need to operate multiple clusters efficiently
 * Are migrating from VMware vSphere and want to leverage similar virtualization-based workflows
 * Need rapid cluster provisioning for test, development, or production workloads
@@ -42,10 +42,12 @@ Starting with {product-title} 4.14, Red Hat recommends using Hosted Control Plan
 **Why HCP is recommended:**
 
 * **Resource efficiency:** Control planes run as pods on shared infrastructure instead of dedicated VMs
-* **Faster provisioning:** No VM bootstrapping process (10-15 minutes vs. 45+ minutes)
+* **Faster provisioning:** No VM bootstrapping for control plane (10-15 minutes vs. 45+ minutes)
 * **Simplified operations:** Manage hosted cluster control planes like application workloads
-* **Cost reduction:** 60-70% reduction in per-cluster resource overhead
+* **Cost reduction:** Significant reduction in per-cluster control plane resource overhead
 * **Strong isolation:** Clusters remain isolated despite shared control plane infrastructure
+* **Integrated storage:** KubeVirt CSI enables storage from the hosting cluster to be available as PVCs in hosted clusters
+* **Autoscaling support:** Only HCP provides autoscaling capabilities for hosted clusters
 
 **Getting started:**
 

--- a/installing/installing_virt/index.adoc
+++ b/installing/installing_virt/index.adoc
@@ -1,0 +1,73 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="installing-virt-overview"]
+= Installing {product-title} on {VirtProductName}
+include::_attributes/common-attributes.adoc[]
+:context: installing-virt-overview
+
+toc::[]
+
+[role="_abstract"]
+You can deploy {product-title} clusters as virtual machines on an existing {product-title} cluster with {VirtProductName}.
+
+== When to use this installation method
+
+This installation method is appropriate when you:
+
+* Want to use existing {product-title} infrastructure without provisioning new bare metal
+* Need to operate multiple clusters efficiently
+* Are migrating from VMware vSphere and want to leverage similar virtualization-based workflows
+* Need rapid cluster provisioning for test, development, or production workloads
+* Want strong cluster isolation without dedicated physical hardware
+
+[IMPORTANT]
+====
+This method requires an existing {product-title} cluster with {VirtProductName} already installed and configured. If you are installing your first {product-title} cluster, see xref:../../installing/overview/index.adoc[Installation overview] for guidance.
+====
+
+include::modules/hcp-virt-support-statement.adoc[leveloffset=+1]
+
+include::modules/hcp-virt-comparison.adoc[leveloffset=+1]
+
+== Installation methods
+
+You must use one of the following installation methods to deploy {product-title} on {VirtProductName}:
+
+include::modules/hcp-virt-method-comparison.adoc[leveloffset=+2]
+
+[id="installing-virt-hcp-recommended"]
+== Installing with Hosted Control Planes (Recommended)
+
+Starting with {product-title} 4.14, Red Hat recommends using Hosted Control Planes (HCP) to deploy clusters on {VirtProductName}.
+
+**Why HCP is recommended:**
+
+* **Resource efficiency:** Control planes run as pods on shared infrastructure instead of dedicated VMs
+* **Faster provisioning:** No VM bootstrapping process (10-15 minutes vs. 45+ minutes)
+* **Simplified operations:** Manage hosted cluster control planes like application workloads
+* **Cost reduction:** 60-70% reduction in per-cluster resource overhead
+* **Strong isolation:** Clusters remain isolated despite shared control plane infrastructure
+
+**Getting started:**
+
+* xref:../../hosted_control_planes/hcp-deploy/hcp-deploy-virt.adoc[Deploying Hosted Control Planes on OpenShift Virtualization] - Complete deployment documentation
+
+[id="installing-virt-alternative-methods"]
+== Alternative installation methods
+
+If you cannot use Hosted Control Planes, you can deploy {product-title} on {VirtProductName} using:
+
+* xref:../../installing/installing_with_agent_based_installer/installing-with-agent-basic.adoc[Agent-based Installer] with `platform: none`
+* link:https://access.redhat.com/documentation/en-us/assisted_installer_for_openshift_container_platform[Assisted Installer] with `platform: none`
+
+[NOTE]
+====
+These methods create traditional clusters with dedicated control plane VMs. They require more resources per cluster and longer provisioning times compared to HCP.
+====
+
+[role="_additional-resources"]
+.Additional resources
+
+* link:https://access.redhat.com/articles/6975424[OpenShift on OpenShift Virtualization Support Statement]
+* xref:../../virt/about_virt/about-virt.adoc[About OpenShift Virtualization]
+* xref:../../hosted_control_planes/index.adoc[Hosted Control Planes overview]
+* xref:../../installing/overview/choosing-installation-approach.adoc[Choosing an installation approach based on your needs]

--- a/installing/overview/choosing-installation-approach.adoc
+++ b/installing/overview/choosing-installation-approach.adoc
@@ -1,0 +1,22 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="choosing-installation-approach"]
+= Choosing an installation approach based on your needs
+include::_attributes/common-attributes.adoc[]
+:context: choosing-installation-approach
+
+toc::[]
+
+[role="_abstract"]
+Different organizations have different needs when deploying {product-title}. This guide helps you select the right installation method based on what you're trying to accomplish, not just what infrastructure you have.
+
+== Common installation scenarios
+
+include::modules/installation-using-virtualization.adoc[leveloffset=+2]
+
+include::modules/installation-multi-cluster.adoc[leveloffset=+2]
+
+include::modules/installation-test-dev.adoc[leveloffset=+2]
+
+== Decision tree
+
+include::modules/installation-decision-tree.adoc[leveloffset=+2]

--- a/installing/overview/index.adoc
+++ b/installing/overview/index.adoc
@@ -6,6 +6,14 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
+Before selecting an installation method, consider what you're trying to accomplish. Different installation approaches are optimized for different jobs.
+
+[TIP]
+====
+New to {product-title} installation? See xref:../../installing/overview/choosing-installation-approach.adoc[Choosing an installation approach based on your needs] for scenario-based guidance.
+====
+
 include::modules/installation-overview.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
@@ -57,6 +65,8 @@ include::modules/supported-platforms-for-openshift-clusters.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources
+
+* See xref:../../installing/overview/choosing-installation-approach.adoc[Choosing an installation approach based on your needs] for scenario-based guidance on selecting the right installation method.
 
 * See xref:../../installing/overview/installing-preparing.adoc#supported-installation-methods-for-different-platforms[Supported installation methods for different platforms] for more information about the types of installations that are available for each supported platform.
 

--- a/installing/overview/installing-preparing.adoc
+++ b/installing/overview/installing-preparing.adoc
@@ -70,6 +70,21 @@ If you want to reuse extensive cloud infrastructure, you can complete a _user-pr
 
 You can also complete a user-provisioned infrastructure installation on your existing hardware. If you use xref:../../installing/installing_openstack/installing-openstack-user.adoc#installing-openstack-user[{rh-openstack}], xref:../../installing/installing_ibm_z/upi/installing-ibm-z.adoc#installing-ibm-z[{ibm-z-name} or {ibm-linuxone-name}], xref:../../installing/installing_ibm_z/upi/installing-ibm-z-kvm.adoc#installing-ibm-z-kvm[{ibm-z-name} and {ibm-linuxone-name} with {op-system-base} KVM], xref:../../installing/installing_ibm_z/upi/installing-ibm-z-lpar.adoc#installing-ibm-z-lpar[{ibm-z-name} and {ibm-linuxone-name} in an LPAR], xref:../../installing/installing_ibm_power/installing-ibm-power.adoc#installing-ibm-power[{ibm-power-title}], or xref:../../installing/installing_vsphere/upi/installing-vsphere.adoc#installing-vsphere[vSphere], use the specific installation instructions to deploy your cluster. If you use other supported hardware, follow the xref:../../installing/installing_bare_metal/upi/installing-bare-metal.adoc#installing-bare-metal[bare metal installation] procedure. For some of these platforms, such as xref:../../installing/installing_vsphere/upi/installing-vsphere.adoc#installing-vsphere[vSphere] and xref:../../installing/installing_bare_metal/upi/installing-bare-metal-network-customizations.adoc#installing-bare-metal-network-customizations[bare metal], you can also customize additional network parameters during installation.
 
+[id="installing-preparing-openshift-virtualization"]
+=== Do you want to run OpenShift on OpenShift Virtualization?
+
+If you have an existing {product-title} cluster with {VirtProductName}, you can deploy additional {product-title} clusters as virtual machines. Red Hat recommends using xref:../../hosted_control_planes/hcp-deploy/hcp-deploy-virt.adoc[Hosted Control Planes (HCP)] for this deployment scenario.
+
+Hosted Control Planes provides several benefits when deploying on {VirtProductName}:
+
+* Reduced resource consumption per cluster (60-70% reduction in control plane overhead)
+* Faster cluster provisioning (10-15 minutes vs. 45+ minutes for traditional clusters)
+* Simplified multi-cluster operations with centralized control plane management
+* Strong cluster isolation despite shared infrastructure
+
+Alternatively, you can use the xref:../../installing/installing_with_agent_based_installer/installing-with-agent-basic.adoc[Agent-based installer] or link:https://access.redhat.com/documentation/en-us/assisted_installer_for_openshift_container_platform[Assisted Installer] with platform set to `none`.
+
+For more information, see xref:../../installing/installing_virt/index.adoc[Installing on OpenShift Virtualization] and link:https://access.redhat.com/articles/6975424[OpenShift on OpenShift Virtualization Support Statement].
 
 [id="installing-preparing-security"]
 === Do you need extra security for your cluster?

--- a/modules/hcp-virt-comparison.adoc
+++ b/modules/hcp-virt-comparison.adoc
@@ -51,4 +51,4 @@ For 10 clusters:
 
 * **Traditional:** 30 control plane nodes minimum (120 vCPU, 480 GB RAM)
 * **HCP:** Shared control plane infrastructure (~40 vCPU, 180 GB RAM)
-* **Savings:** ~67% reduction in control plane resources
+* **Savings:** Significant reduction in control plane resources (actual savings vary based on configuration)

--- a/modules/hcp-virt-comparison.adoc
+++ b/modules/hcp-virt-comparison.adoc
@@ -1,0 +1,54 @@
+// Module included in the following assemblies:
+//
+// * installing/installing_virt/index.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="hcp-virt-comparison_{context}"]
+= Comparing Hosted Control Planes with traditional clusters
+
+Understanding the differences between HCP and traditional clusters helps you make the right choice.
+
+[cols="2,3,3", options="header"]
+|===
+|Aspect |Traditional cluster |Hosted Control Planes
+
+|Control plane location
+|Dedicated VMs/nodes in the cluster
+|Pods on management cluster
+
+|Resource overhead per cluster
+|Minimum 3 nodes: 12 vCPU, 48 GB RAM
+|Control plane: ~4 vCPU, 18 GB RAM
+
+|Provisioning time
+|45-60 minutes
+|10-15 minutes
+
+|Management model
+|Each cluster self-managed
+|Centralized management of control planes
+
+|Upgrade process
+|Per-cluster operators
+|Simplified central upgrades
+
+|Isolation level
+|Full physical/VM isolation
+|Pod-level isolation (still strong)
+
+|Multi-cluster efficiency
+|Linear resource scaling
+|Shared infrastructure, better density
+
+|Best for
+|Single production cluster, maximum isolation
+|Multiple clusters, resource efficiency, rapid provisioning
+|===
+
+**Resource calculation example:**
+
+For 10 clusters:
+
+* **Traditional:** 30 control plane nodes minimum (120 vCPU, 480 GB RAM)
+* **HCP:** Shared control plane infrastructure (~40 vCPU, 180 GB RAM)
+* **Savings:** ~67% reduction in control plane resources

--- a/modules/hcp-virt-method-comparison.adoc
+++ b/modules/hcp-virt-method-comparison.adoc
@@ -1,0 +1,27 @@
+// Module included in the following assemblies:
+//
+// * installing/installing_virt/index.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="hcp-virt-method-comparison_{context}"]
+= Installation method comparison
+
+[cols="2,2,3,3", options="header"]
+|===
+|Method |Provisioning time |Resource efficiency |When to use
+
+|xref:../../hosted_control_planes/hcp-deploy/hcp-deploy-virt.adoc[Hosted Control Planes]
+|10-15 minutes
+|High - shared control plane infrastructure
+|Recommended for most use cases. Best for multi-cluster operations, resource efficiency, rapid provisioning.
+
+|xref:../../installing/installing_with_agent_based_installer/installing-with-agent-basic.adoc[Agent-based Installer]
+|45-60 minutes
+|Standard - dedicated control plane VMs
+|When HCP is not available or not suitable. Provides traditional cluster architecture.
+
+|link:https://access.redhat.com/documentation/en-us/assisted_installer_for_openshift_container_platform[Assisted Installer]
+|30-45 minutes
+|Standard - dedicated control plane VMs
+|Guided installation experience with UI-based configuration.
+|===

--- a/modules/hcp-virt-support-statement.adoc
+++ b/modules/hcp-virt-support-statement.adoc
@@ -1,0 +1,23 @@
+// Module included in the following assemblies:
+//
+// * installing/installing_virt/index.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="hcp-virt-support-statement_{context}"]
+= Support for {product-title} on {VirtProductName}
+
+Red Hat supports running {product-title} as virtual machines on {VirtProductName}.
+
+Starting with {product-title} 4.14 and {VirtProductName} 4.14, Red Hat recommends using Hosted Control Planes rather than traditional nested cluster deployments.
+
+**Key support requirements:**
+
+* The management cluster (providing {VirtProductName}) must run on bare metal
+* The hosted cluster must use one of these installation methods:
+  ** Hosted Control Planes (recommended)
+  ** Agent-based Installer with `platform: none`
+  ** Assisted Installer with `platform: none`
+* The hosted cluster is not integrated with the management cluster
+* Compute, storage, and network resources must adequately support hosted workloads
+
+For complete support details, see link:https://access.redhat.com/articles/6975424[OpenShift on OpenShift Virtualization Support Statement].

--- a/modules/hcp-virt-support-statement.adoc
+++ b/modules/hcp-virt-support-statement.adoc
@@ -8,7 +8,7 @@
 
 Red Hat supports running {product-title} as virtual machines on {VirtProductName}.
 
-Starting with {product-title} 4.14 and {VirtProductName} 4.14, Red Hat recommends using Hosted Control Planes rather than traditional nested cluster deployments.
+Starting with {product-title} 4.14 and {VirtProductName} 4.14, Red Hat recommends using hosted control planes in most scenarios rather than traditional cluster deployments using dedicated control plane virtual machines.
 
 **Key support requirements:**
 

--- a/modules/installation-decision-tree.adoc
+++ b/modules/installation-decision-tree.adoc
@@ -1,0 +1,42 @@
+// Module included in the following assemblies:
+//
+// * installing/overview/choosing-installation-approach.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="installation-decision-tree_{context}"]
+= Installation decision tree
+
+Follow this decision tree to identify your recommended installation approach:
+
+[start=1]
+. **What infrastructure do you have?**
+   * Existing {product-title} cluster with {VirtProductName} -> Go to step 2
+   * Cloud account (AWS/Azure/GCP) -> Go to step 3
+   * Bare metal hardware -> Go to step 4
+   * VMware vSphere -> Go to step 5
+   * Other virtualization -> Go to step 6
+
+. **You have OpenShift Virtualization**
+   * Need multiple clusters? -> xref:../../hosted_control_planes/hcp-deploy/hcp-deploy-virt.adoc[HCP on OpenShift Virtualization] (Recommended)
+   * Need one additional cluster? -> xref:../../hosted_control_planes/hcp-deploy/hcp-deploy-virt.adoc[HCP on OpenShift Virtualization] or xref:../../installing/installing_with_agent_based_installer/installing-with-agent-basic.adoc[Agent-based installer]
+
+. **You have cloud infrastructure**
+   * Want managed service? -> link:https://www.openshift.com/products[OpenShift managed services]
+   * Want self-managed? -> xref:../../installing/installing_aws/ipi/installing-aws-default.adoc[Cloud IPI installation]
+   * Need many clusters? -> Consider xref:../../hosted_control_planes/hcp-deploy/hcp-deploy-aws.adoc[HCP on cloud]
+
+. **You have bare metal**
+   * Need many clusters? -> xref:../../installing/installing_bare_metal/ipi/ipi-install-overview.adoc[Bare metal IPI] then xref:../../hosted_control_planes/hcp-deploy/hcp-deploy-bm.adoc[HCP on bare metal]
+   * Need one cluster? -> xref:../../installing/installing_bare_metal/ipi/ipi-install-overview.adoc[Bare metal IPI] or xref:../../installing/installing_bare_metal/upi/installing-bare-metal.adoc[Bare metal UPI]
+
+. **You have VMware vSphere**
+   * Have automation/templates? -> xref:../../installing/installing_vsphere/ipi/installing-vsphere-installer-provisioned.adoc[vSphere IPI]
+   * Manual provisioning preferred? -> xref:../../installing/installing_vsphere/upi/installing-vsphere.adoc[vSphere UPI]
+
+. **You have other virtualization**
+   * Use xref:../../installing/installing_platform_agnostic/installing-platform-agnostic.adoc[Platform agnostic installation] with xref:../../installing/installing_with_agent_based_installer/installing-with-agent-basic.adoc[Agent-based installer]
+
+[TIP]
+====
+Not sure which applies? See xref:../../installing/overview/installing-preparing.adoc[Selecting a cluster installation method] for detailed platform comparisons.
+====

--- a/modules/installation-multi-cluster.adoc
+++ b/modules/installation-multi-cluster.adoc
@@ -1,0 +1,55 @@
+// Module included in the following assemblies:
+//
+// * installing/overview/choosing-installation-approach.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="installation-multi-cluster_{context}"]
+= Running multiple clusters efficiently
+
+You can minimize resource overhead and operational complexity when running multiple {product-title} clusters.
+
+**Common scenarios:**
+
+* Running edge deployments across many sites
+* Providing cluster-as-a-service to development teams
+* Multi-tenant architectures requiring cluster isolation
+* Testing multiple versions or configurations
+
+**Recommended approach:**
+
+Hosted Control Planes significantly reduce per-cluster overhead:
+
+* **Traditional cluster:** 3 control plane VMs/nodes per cluster (minimum 12 vCPU, 48 GB RAM)
+* **Hosted cluster:** Control planes run as pods on shared infrastructure (3-4 vCPU, 18 GB RAM)
+
+**Deployment options:**
+
+[cols="1,2,3", options="header"]
+|===
+|Platform |Method |When to use
+
+|{VirtProductName}
+|xref:../../hosted_control_planes/hcp-deploy/hcp-deploy-virt.adoc[HCP on OpenShift Virtualization]
+|Best resource efficiency, fastest provisioning, strong isolation
+
+|AWS
+|xref:../../hosted_control_planes/hcp-deploy/hcp-deploy-aws.adoc[HCP on AWS]
+|Cloud-native deployment, leveraging AWS services
+
+|Bare metal
+|xref:../../hosted_control_planes/hcp-deploy/hcp-deploy-bm.adoc[HCP on bare metal]
+|Maximum control, existing bare metal infrastructure
+|===
+
+**Comparison:**
+
+For 10 clusters:
+
+* Traditional: 30 control plane nodes minimum
+* HCP: Shared control plane infrastructure serving all 10 clusters
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../hosted_control_planes/index.adoc[Hosted Control Planes overview]
+* xref:../../hosted_control_planes/hcp-prepare/hcp-sizing-guidance.adoc[Sizing guidance for hosted control planes]

--- a/modules/installation-test-dev.adoc
+++ b/modules/installation-test-dev.adoc
@@ -1,0 +1,48 @@
+// Module included in the following assemblies:
+//
+// * installing/overview/choosing-installation-approach.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="installation-test-dev_{context}"]
+= Deploying temporary or test clusters
+
+You can quickly provision {product-title} clusters for testing, development, or learning.
+
+**Common scenarios:**
+
+* Testing upgrade paths
+* Reproducing customer issues
+* Developer sandbox environments
+* Learning OpenShift before production deployment
+
+**Fast, low-cost options:**
+
+[cols="1,2,2,2", options="header"]
+|===
+|Approach |Provisioning time |Resources required |Best for
+
+|xref:../../installing/installing_sno/install-sno-installing-sno.adoc[Single-node OpenShift]
+|20-30 minutes
+|1 node: 8 vCPU, 16 GB RAM
+|Learning, edge testing, minimal resource usage
+
+|xref:../../hosted_control_planes/hcp-deploy/hcp-deploy-virt.adoc[HCP on OpenShift Virtualization]
+|10-15 minutes
+|Shared infrastructure
+|Rapid spin-up/teardown, multiple concurrent tests
+
+|link:https://developers.redhat.com/products/openshift-local/overview[OpenShift Local]
+|5 minutes
+|Laptop: 4 vCPU, 9 GB RAM
+|Local development, no cluster infrastructure needed
+
+|link:https://console.redhat.com/openshift/create/sandbox[Developer Sandbox]
+|Immediate
+|None (shared environment)
+|Trying OpenShift, learning without installation
+|===
+
+[NOTE]
+====
+For production workloads, see the planning guidance at xref:../../installing/overview/installing-preparing.adoc[Selecting a cluster installation method and preparing it for users].
+====

--- a/modules/installation-using-virtualization.adoc
+++ b/modules/installation-using-virtualization.adoc
@@ -1,0 +1,44 @@
+// Module included in the following assemblies:
+//
+// * installing/overview/choosing-installation-approach.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="installation-using-virtualization_{context}"]
+= Using existing virtualization infrastructure
+
+You can deploy {product-title} on your existing virtualization infrastructure without investing in new bare metal hardware.
+
+**Common scenarios:**
+
+* Migrating from VMware vSphere after licensing changes
+* Evaluating OpenShift before committing to bare metal
+* Need to prove value before capital expenditure approval
+* Have excess capacity on existing virtualization platforms
+
+**Your options:**
+
+[cols="1,2,2,2", options="header"]
+|===
+|Infrastructure type |Installation method |Best for |Trade-offs
+
+|{VirtProductName}
+|xref:../../hosted_control_planes/hcp-deploy/hcp-deploy-virt.adoc[Hosted Control Planes] (Recommended)
+|Multi-cluster operations, resource efficiency, rapid provisioning
+|Requires existing {product-title} cluster with {VirtProductName}
+
+|VMware vSphere
+|xref:../../installing/installing_vsphere/ipi/installing-vsphere-installer-provisioned.adoc[IPI] or xref:../../installing/installing_vsphere/upi/installing-vsphere.adoc[UPI]
+|Existing VMware investment, traditional VM management workflows
+|Higher per-cluster resource overhead, slower provisioning
+
+|KVM, Hyper-V, other hypervisors
+|xref:../../installing/installing_platform_agnostic/installing-platform-agnostic.adoc[Platform agnostic installation]
+|Non-VMware virtualization, full control over infrastructure
+|Manual infrastructure provisioning, no platform integration
+|===
+
+[role="_additional-resources"]
+.Additional resources
+
+* link:https://access.redhat.com/articles/6975424[OpenShift on OpenShift Virtualization Support Statement]
+* xref:../../installing/overview/installing-preparing.adoc#installing-preparing-existing-components[Using existing infrastructure components]

--- a/modules/supported-platforms-for-openshift-clusters.adoc
+++ b/modules/supported-platforms-for-openshift-clusters.adoc
@@ -88,6 +88,12 @@ The following table describes which platforms are supported by the different met
 |
 |X
 
+|{VirtProductName} ^[4]^
+|
+|
+|X
+|X
+
 |{oci-first-no-rt}
 |
 |
@@ -122,5 +128,7 @@ After installation, the following changes are not supported:
 In a disconnected installation, you can download the images that are required to install a cluster, place them in a mirror registry, and use that data to install your cluster. While you require internet access to pull images for platform containers, with a disconnected installation on vSphere or bare-metal infrastructure, your cluster machines do not require direct internet access.
 
 3. For {rh-openstack-first}: The latest {product-title} release supports both the latest {rh-openstack} long-life release and intermediate release. For complete {rh-openstack} release compatibility, see the link:https://access.redhat.com/articles/4679401[{product-title} on {rh-openstack} support matrix].
+
+4. For {VirtProductName}: Requires an existing {product-title} cluster with {VirtProductName}. Hosted Control Planes is the recommended installation method. See xref:../../installing/installing_virt/index.adoc[Installing on OpenShift Virtualization] and link:https://access.redhat.com/articles/6975424[OpenShift on OpenShift Virtualization Support Statement].
 
 The link:https://access.redhat.com/articles/4128421[{product-title} 4.x Tested Integrations] page contains details about integration testing for different platforms.


### PR DESCRIPTION
Changes include:
- New scenario-based installation guide to help users select the right approach based on their needs (virtualization, multi-cluster, test/dev)
- New installing/installing_virt/ directory with overview of installing on OpenShift Virtualization
- Updated supported platforms table to include OpenShift Virtualization
- Updated installation preparation guide to highlight HCP on Virt as recommended approach for existing OpenShift Virtualization environments
- Comparison modules showing benefits of HCP vs traditional clusters

This addresses the documentation gap identified in KB article 6975424 where OpenShift on OpenShift Virtualization is supported but not discoverable from the main installation documentation.
