### PR TITLE
OSDOCS-18620: Add LeaderWorkerSet and JobSet to Kueue 1.3 release notes

### DIFF
--- a/ai_workloads/kueue/integrating-jobset.adoc
+++ b/ai_workloads/kueue/integrating-jobset.adoc
@@ -13,6 +13,7 @@ You can use the {js-operator} to manage and run large-scale, coordinated workloa
 
 The {js-operator} models a distributed batch workload as a group of Kubernetes Jobs. This allows you to easily specify different pod templates for different distinct groups of pods, for example, a leader, workers, parameter servers, and so on. 
 
+
 include::modules/kueue-installing-jobset.adoc[leveloffset=+1]
 [role="_additional-resources"]
 .Additional resources
@@ -21,7 +22,6 @@ include::modules/kueue-installing-jobset.adoc[leveloffset=+1]
 * link:https://kueue.sigs.k8s.io/docs/tasks/run/jobsets/[Run A JobSet (Kubernetes documentation)]
 
 * xref:../../security/cert_manager_operator/cert-manager-operator-install.adoc#installing-the-cert-manager-operator-for-red-hat-openshift[Installing the {cert-manager-operator} by using the web console]
-
 
 include::modules/kueue-running-jobset.adoc[leveloffset=+1]
 [role="_additional-resources"]

--- a/modules/kueue-release-notes-1.3.adoc
+++ b/modules/kueue-release-notes-1.3.adoc
@@ -12,11 +12,11 @@
 [id="release-notes-1.3-new-features_{context}"]
 == New features and enhancements
 
-// {lws-operator}::
-// {kueue-name} version 1.3 provides for the integration of the {lws-operator} with {kueue-name} so you can leverage the {kueue-name} scheduling and resource management functionality when running LeaderWorkerSets. 
+{lws-operator}::
+{kueue-name} version 1.3 provides for the integration of the {lws-operator} with {kueue-name} so you can leverage the {kueue-name} scheduling and resource management functionality when running LeaderWorkerSets. For more information, see xref:../../ai_workloads/kueue/integrating-lws.adoc#integrating-lws[Integrating the Leader Worker Set Operator].
 
-// {js-operator}::
-// {kueue-name} version 1.3 provides for the integration of the {js-operator} so you can use the {js-operator} to manage and run large-scale, coordinated workloads like high-performance computing (HPC) and AI training. 
+{js-operator}::
+{kueue-name} version 1.3 provides for the integration of the {js-operator} so you can use the {js-operator} to manage and run large-scale, coordinated workloads like high-performance computing (HPC) and AI training. For more information, see xref:../../ai_workloads/kueue/integrating-jobset.adoc#integrating-jobset[Integrating the JobSet Operator].
 
 Upstream progression of the {kueue-name} API to `v1beta2`::
 {kueue-name} version 1.3 provides the `v1beta2` version of the {kueue-name} API. This update continues the evolution of the {kueue-name} APIs with the ultimate goal of graduating the API to `v1`. 


### PR DESCRIPTION
Add LeaderWorkerSet and JobSet to KUEUE 1.3 Release Notes
Version(s): 4.21, 4.22

**Note to reviewers:** The RNs for these topics have already been reviewed and approved in PR[108005](https://github.com/openshift/openshift-docs/pull/108005). The topics were commented out  and did not have xrefs. The purpose of this PR is to uncomment the topics and add the xrefs for Publish. **Again - all text has been reviewed and approved in a previous PR.** 

Issue: https://issues.redhat.com/browse/OSDOCS-18620

Link to docs preview: https: 
https://108205--ocpdocs-pr.netlify.app/openshift-enterprise/latest/ai_workloads/kueue/release-notes.html

Dev: @kannon92

QE review: @anahas-redhat