### PR TITLE
OCPBUGS-63453_FOR_4_22#Add user namespaces support for storage

### DIFF
--- a/modules/persistent-storage-csi-drivers-supported.adoc
+++ b/modules/persistent-storage-csi-drivers-supported.adoc
@@ -45,29 +45,29 @@ In addition to the drivers listed in the following table, {product-title} functi
 endif::openshift-rosa,openshift-rosa-hcp,openshift-aro[]
 
 .Supported CSI drivers and features in {product-title}
-[cols=",^v,^v,^v,^v,^v,^v width="100%",options="header"]
+[cols=",^v,^v,^v,^v,^v,^v,^v width="100%",options="header"]
 |===
-|CSI driver |CSI volume snapshots  |CSI volume group snapshots ^[1]^ |CSI cloning  |CSI resize |Inline ephemeral volumes
-|AWS EBS | ✅ |  |  | ✅|
-|AWS EFS |  |  |  |  |
+|CSI driver |CSI volume snapshots  |CSI volume group snapshots ^[1]^ |CSI cloning  |CSI resize |Inline ephemeral volumes |User namespaces
+|AWS EBS | ✅ |  |  | ✅| |✅
+|AWS EFS |  |  |  |  | |
 ifndef::openshift-rosa,openshift-rosa-hcp[]
-|Google Compute Platform (GCP) persistent disk (PD)|  ✅|  |✅^[2]^ | ✅|
-|GCP Filestore | ✅ |  | | ✅|
+|Google Compute Platform (GCP) persistent disk (PD)|  ✅|  |✅^[2]^ | ✅| |✅
+|GCP Filestore | ✅ |  | | ✅| |
 endif::openshift-rosa,openshift-rosa-hcp[]
 ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
-|{ibm-power-server-name} Block |   |  |   | ✅ |
-|{ibm-cloud-name} Block | ✅^[3]^ |  |   | ✅^[3]^|
+|{ibm-power-server-name} Block |   |  |   | ✅ | |✅
+|{ibm-cloud-name} Block | ✅^[3]^ |  |   | ✅^[3]^| |✅
 endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
-|LVM Storage | ✅ |  | ✅ | ✅ |
+|{lvms} | ✅ |  | ✅ | ✅ | |✅
 ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
-|Microsoft Azure Disk | ✅ |  | ✅ | ✅|
-|Microsoft Azure Stack Hub | ✅ |  | ✅ | ✅|
-|Microsoft Azure File | ✅  |  | ✅ | ✅| ✅
-|OpenStack Cinder | ✅ |  | ✅ | ✅|
-|OpenShift Data Foundation | ✅ | ✅ | ✅ | ✅|
-|OpenStack Manila | ✅ |  |   | ✅  |
-|CIFS/SMB |   |  | ✅  |   |
-|VMware vSphere | ✅^[4]^ |  |   | ✅^[5]^|
+|Microsoft Azure Disk | ✅ |  | ✅ | ✅| |✅
+|Microsoft Azure Stack Hub | ✅ |  | ✅ | ✅| |✅
+|Microsoft Azure File | ✅  |  | ✅ | ✅| ✅ |
+|OpenStack Cinder | ✅ |  | ✅ | ✅| |✅
+|{rh-storage} | ✅ | ✅ | ✅ | ✅| |✅ ^[4]^
+|OpenStack Manila | ✅ |  |   | ✅  | |
+|CIFS/SMB |   |  | ✅  |   | |
+|VMware vSphere | ✅^[5]^ |  |   | ✅^[6]^| |✅^[7]^
 endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 |===
 ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
@@ -87,12 +87,20 @@ include::snippets/technology-preview.adoc[leveloffset=+1]
 
 4.
 
+* RBD supports user namespaces; CephFS does not.
+
+5.
+
 * Requires VMware vSphere version 8.0 Update 1 or later, or VMware vSphere Foundation (VVF) 9, or VMware Cloud Foundation (VCF) 9, for both vCenter Server and ESXi.
 
 * Does not support fileshare volumes.
 
-5.
+6.
 
 * Online expansion is supported from VMware vSphere version 8.0 Update 1 and later, or VVF 9, or VCF 9.
+
+7.
+
+* File persistent volumes (PVs), such as vSAN file service, do not support user namespaces.
 --
 endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]

--- a/nodes/pods/nodes-pods-user-namespaces.adoc
+++ b/nodes/pods/nodes-pods-user-namespaces.adoc
@@ -19,6 +19,8 @@ When running a pod in an isolated user namespace, the UID/GID inside a pod conta
 Not all file systems currently support ID-mapped mounts, such as Network File Systems (NFS) and other network/distributed file systems. Any pod that is using an NFS-backed persistent volume from a vendor that does not support ID-mapped mounts might experience access or permission issues when running in a user namespace. This behavior is not specific to {product-title}. It applies to all Kubernetes distributions from Kubernetes v1.33 onward.
 ====
 
+To check user namespaces support for storage options, see xref:../../storage/container_storage_interface/persistent-storage-csi.adoc#csi-drivers-supported_persistent-storage-csi[CSI drivers supported by {product-title}].
+
 // The following include statements pull in the module files that comprise
 // the assembly. Include any combination of concept, procedure, or reference
 // modules required to cover the user story. You can also include other

--- a/storage/persistent_storage/persistent-storage-nfs.adoc
+++ b/storage/persistent_storage/persistent-storage-nfs.adoc
@@ -13,6 +13,11 @@ NFS-specific information contained in a PV definition could also be defined
 directly in a `Pod` definition, doing so does not create the volume as a
 distinct cluster resource, making the volume more susceptible to conflicts.
 
+[NOTE]
+====
+The in-tree NFS provisioner does not support user namespaces.
+====
+
 [role="_additional-resources"]
 .Additional resources
 


### PR DESCRIPTION
This is a replacement for https://github.com/openshift/openshift-docs/pull/101913, which has been closed. 

This PR covers changes for 4.22 only. For 4.20 changes, see https://github.com/openshift/openshift-docs/pull/105764. For 4.21 changes, see https://github.com/openshift/openshift-docs/pull/105779.

Version(s): 4.22 only

Issue: https://issues.redhat.com/browse/OCPBUGS-63453

Link to docs preview:

**CSI driver support table:**  https://108206--ocpdocs-pr.netlify.app/openshift-enterprise/latest/storage/container_storage_interface/persistent-storage-csi.html#persistent-storage-csi-drivers-supported_persistent-storage-csi

**Nodes xref:**  https://108206--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/pods/nodes-pods-user-namespaces

**Note in NFS in-tree content**:  https://108206--ocpdocs-pr.netlify.app/openshift-enterprise/latest/storage/persistent_storage/persistent-storage-nfs.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

 QE has approved this change.
Additional information:

PTAL: @gcharot @jsafrane @wsun1 @duanwei33 @tamireran @DanielFroehlich @CFields651 @mwerner2113 @kalexand-rh
