### PR TITLE
DOCPLAN-98: Split out assembly into separate modules, fix links and xrefs

### DIFF
--- a/modules/virt-collecting-data-about-vms.adoc
+++ b/modules/virt-collecting-data-about-vms.adoc
@@ -1,0 +1,29 @@
+// Module included in the following assemblies:
+//
+// * virt/support/virt-collecting-virt-data.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="virt-collecting-data-about-vms_{context}"]
+= Collecting data about virtual machines
+
+[role="_abstract"]
+Collecting data about malfunctioning virtual machines (VMs) minimizes the time required to analyze and determine the root cause.
+
+.Prerequisites
+
+* For Linux VMs, you have installed the latest QEMU guest agent.
+* For Windows VMs, you have:
+** Recorded the Windows patch update details.
+** link:https://access.redhat.com/solutions/6957701[Installed the latest VirtIO drivers].
+** Installed the latest QEMU guest agent.
+** If Remote Desktop Protocol (RDP) is enabled, you have connected by using the desktop viewer to determine whether there is a problem with the connection software.
+
+.Procedure
+
+// must-gather not supported for ROSA/OSD, per Dustin Row
+ifndef::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
+. Collect must-gather data for the VMs using the `/usr/bin/gather` script.
+endif::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
+. Collect screenshots of VMs that have crashed before you restart them.
+. Collect memory dumps from VMs before remediation attempts.
+. Record factors that the malfunctioning VMs have in common. For example, the VMs have the same host or network.

--- a/modules/virt-collecting-data-about-your-environment.adoc
+++ b/modules/virt-collecting-data-about-your-environment.adoc
@@ -1,0 +1,36 @@
+// Module included in the following assemblies:
+//
+// * virt/support/virt-collecting-virt-data.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="virt-collecting-data-about-your-environment_{context}"]
+= Collecting data about your environment
+
+[role="_abstract"]
+Collecting data about your environment minimizes the time required to analyze and determine the root cause.
+
+.Prerequisites
+//link needs to be added for HCP when available
+ifdef::openshift-dedicated,openshift-rosa[]
+* You have link:https://docs.redhat.com/en/documentation/monitoring_stack_for_red_hat_openshift/4.21/html/configuring_user_workload_monitoring/storing-and-recording-data-uwm#modifying-retention-time-and-size-for-prometheus-metrics-data_storing-and-recording-data-uwm[set the retention time for Prometheus metrics data] to a minimum of seven days.
+* You have link:https://docs.redhat.com/en/documentation/monitoring_stack_for_red_hat_openshift/4.21/html/configuring_user_workload_monitoring/storing-and-recording-data-uwm#modifying-retention-time-and-size-for-prometheus-metrics-data_storing-and-recording-data-uwm[configured the Alertmanager to capture relevant alerts and to send alert notifications to a dedicated mailbox] so that they can be viewed and persisted outside the cluster.
+endif::openshift-dedicated,openshift-rosa[]
+
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
+* You have link:https://docs.redhat.com/en/documentation/monitoring_stack_for_red_hat_openshift/4.21/html/configuring_core_platform_monitoring/storing-and-recording-data#modifying-retention-time-and-size-for-prometheus-metrics-data_storing-and-recording-data[set the retention time for Prometheus metrics data] to a minimum of seven days.
+* You have link:https://docs.redhat.com/en/documentation/monitoring_stack_for_red_hat_openshift/4.21/html/configuring_core_platform_monitoring/configuring-alerts-and-notifications[configured the Alertmanager to capture relevant alerts and to send alert notifications to a dedicated mailbox] so that they can be viewed and persisted outside the cluster.
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
+* You have recorded the exact number of affected nodes and virtual machines.
+
+.Procedure
+
+// must-gather not supported for ROSA/OSD, per Dustin Row
+ifndef::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
+. Collect must-gather data for the cluster.
+. link:https://access.redhat.com/documentation/en-us/red_hat_openshift_data_foundation/latest/html-single/troubleshooting_openshift_data_foundation/index#downloading-log-files-and-diagnostic-information_rhodf[Collect must-gather data for {rh-storage-first}], if necessary.
+. Collect must-gather data for {VirtProductName}.
+endif::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
+ifndef::openshift-rosa-hcp[]
+. link:https://docs.redhat.com/en/documentation/monitoring_stack_for_red_hat_openshift/4.21/html/accessing_metrics/accessing-metrics-as-an-administrator#querying-metrics-for-all-projects-with-mon-dashboard_accessing-metrics-as-an-administrator[Collect Prometheus metrics for the cluster].
+endif::openshift-rosa-hcp[]
+//link needs to be added for HCP when available

--- a/virt/support/virt-collecting-virt-data.adoc
+++ b/virt/support/virt-collecting-virt-data.adoc
@@ -21,68 +21,10 @@ Prometheus is a time-series database and a rule evaluation engine for metrics. P
 Alertmanager::
 The Alertmanager service handles alerts received from Prometheus. The Alertmanager is also responsible for sending the alerts to external notification systems.
 //link needs to be added for HCP when available
-ifndef::openshift-dedicated,openshift-rosa-hcp,openshift-rosa[]
-For information about the {product-title} monitoring stack, see link:https://docs.redhat.com/en/documentation/monitoring_stack_for_red_hat_openshift/4.21/html/about_monitoring/about-ocp-monitoring[About {product-title} monitoring].
-endif::openshift-dedicated,openshift-rosa-hcp,openshift-rosa[]
-ifdef::openshift-dedicated,openshift-rosa[]
-For information about the {product-title} monitoring stack, see xref:../../observability/monitoring/about-ocp-monitoring/about-ocp-monitoring.adoc#about-ocp-monitoring[About {product-title} monitoring].
-endif::openshift-dedicated,openshift-rosa[]
 
-// This procedure is in the assembly so that we can add xrefs instead of a long list of additional resources.
-[id="virt-collecting-data-about-your-environment_{context}"]
-== Collecting data about your environment
+include::modules/virt-collecting-data-about-your-environment.adoc[leveloffset=+1]
 
-Collecting data about your environment minimizes the time required to analyze and determine the root cause.
-
-.Prerequisites
-//link needs to be added for HCP when available
-ifdef::openshift-dedicated,openshift-rosa[]
-* link:https://docs.redhat.com/en/documentation/monitoring_stack_for_red_hat_openshift/4.21/html/configuring_user_workload_monitoring/storing-and-recording-data-uwm#modifying-retention-time-and-size-for-prometheus-metrics-data_storing-and-recording-data-uwm[Set the retention time for Prometheus metrics data] to a minimum of seven days.
-* link:https://docs.redhat.com/en/documentation/monitoring_stack_for_red_hat_openshift/4.21/html/configuring_user_workload_monitoring/storing-and-recording-data-uwm#modifying-retention-time-and-size-for-prometheus-metrics-data_storing-and-recording-data-uwm[Configure the Alertmanager to capture relevant alerts and to send alert notifications to a dedicated mailbox] so that they can be viewed and persisted outside the cluster.
-endif::openshift-dedicated,openshift-rosa[]
-
-ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
-* link:https://docs.redhat.com/en/documentation/monitoring_stack_for_red_hat_openshift/4.21/html/configuring_core_platform_monitoring/storing-and-recording-data#modifying-retention-time-and-size-for-prometheus-metrics-data_storing-and-recording-data[Set the retention time for Prometheus metrics data] to a minimum of seven days.
-* link:https://docs.redhat.com/en/documentation/monitoring_stack_for_red_hat_openshift/4.21/html/configuring_core_platform_monitoring/configuring-alerts-and-notifications[Configure the Alertmanager to capture relevant alerts and to send alert notifications to a dedicated mailbox] so that they can be viewed and persisted outside the cluster.
-endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
-* Record the exact number of affected nodes and virtual machines.
-
-.Procedure
-
-// must-gather not supported for ROSA/OSD, per Dustin Row
-ifndef::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
-. xref:../../support/gathering-cluster-data.adoc#support_gathering_data_gathering-cluster-data[Collect must-gather data for the cluster].
-. link:https://access.redhat.com/documentation/en-us/red_hat_openshift_data_foundation/latest/html-single/troubleshooting_openshift_data_foundation/index#downloading-log-files-and-diagnostic-information_rhodf[Collect must-gather data for {rh-storage-first}], if necessary.
-. xref:../../virt/support/virt-collecting-virt-data.adoc#virt-using-virt-must-gather_virt-collecting-virt-data[Collect must-gather data for {VirtProductName}].
-endif::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
-ifndef::openshift-rosa-hcp[]
-. link:https://docs.redhat.com/en/documentation/monitoring_stack_for_red_hat_openshift/4.21/html/accessing_metrics/accessing-metrics-as-an-administrator#querying-metrics-for-all-projects-with-mon-dashboard_accessing-metrics-as-an-administrator[Collect Prometheus metrics for the cluster].
-endif::openshift-rosa-hcp[]
-//link needs to be added for HCP when available
-
-[id="virt-collecting-data-about-vms_{context}"]
-== Collecting data about virtual machines
-
-Collecting data about malfunctioning virtual machines (VMs) minimizes the time required to analyze and determine the root cause.
-
-.Prerequisites
-
-* Linux VMs: xref:../../virt/managing_vms/virt-installing-qemu-guest-agent.adoc#virt-installing-qemu-guest-agent-on-linux-vm_virt-installing-qemu-guest-agent[Install the latest QEMU guest agent].
-* Windows VMs:
-** Record the Windows patch update details.
-** link:https://access.redhat.com/solutions/6957701[Install the latest VirtIO drivers].
-** xref:../../virt/managing_vms/virt-installing-qemu-guest-agent.adoc#virt-installing-virtio-drivers-existing-windows_virt-installing-qemu-guest-agent[Install the latest QEMU guest agent].
-** If Remote Desktop Protocol (RDP) is enabled, connect by using the xref:../../virt/managing_vms/virt-accessing-vm-consoles.adoc#desktop-viewer_virt-accessing-vm-consoles[desktop viewer] to determine whether there is a problem with the connection software.
-
-.Procedure
-
-// must-gather not supported for ROSA/OSD, per Dustin Row
-ifndef::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
-. xref:../../virt/support/virt-collecting-virt-data.adoc#virt-must-gather-options_virt-collecting-virt-data[Collect must-gather data for the VMs] using the `/usr/bin/gather` script.
-endif::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
-. Collect screenshots of VMs that have crashed _before_ you restart them.
-. xref:../../virt/support/virt-collecting-virt-data.adoc#virt-generating-a-vm-memory-dump_virt-collecting-virt-data[Collect memory dumps from VMs] _before_ remediation attempts.
-. Record factors that the malfunctioning VMs have in common. For example, the VMs have the same host or network.
+include::modules/virt-collecting-data-about-vms.adoc[leveloffset=+1]
 
 // must-gather not supported for ROSA/OSD, per Dustin Row
 ifndef::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
@@ -99,3 +41,13 @@ include::modules/virt-generating-a-vm-memory-dump.adoc[leveloffset=+1]
 == Additional resources
 * xref:../../virt/support/virt-support-overview.adoc#virt-support-overview[VM support overview]
 * link:https://access.redhat.com/solutions/2112[How to provide log files to Red Hat Support (Red Hat Knowledgebase)]
+ifndef::openshift-dedicated,openshift-rosa-hcp,openshift-rosa[]
+* link:https://docs.redhat.com/en/documentation/monitoring_stack_for_red_hat_openshift/4.21/html/about_monitoring/about-ocp-monitoring[About {product-title} monitoring]
+endif::openshift-dedicated,openshift-rosa-hcp,openshift-rosa[]
+ifdef::openshift-dedicated,openshift-rosa[]
+* xref:../../observability/monitoring/about-ocp-monitoring/about-ocp-monitoring.adoc#about-ocp-monitoring[About {product-title} monitoring]
+endif::openshift-dedicated,openshift-rosa[]
+* xref:../../virt/managing_vms/virt-installing-qemu-guest-agent.adoc#virt-installing-qemu-guest-agent-on-linux-vm_virt-installing-qemu-guest-agent[Installing the QEMU guest agent on a Linux VM]
+* xref:../../virt/managing_vms/virt-installing-qemu-guest-agent.adoc#virt-installing-virtio-drivers-existing-windows_virt-installing-qemu-guest-agent[Installing VirtIO drivers from a SATA CD drive on an existing Windows VM]
+* xref:../../virt/managing_vms/virt-accessing-vm-consoles.adoc#desktop-viewer_virt-accessing-vm-consoles[Connecting to the desktop viewer]
+* xref:../../virt/support/virt-collecting-virt-data.adoc#virt-generating-a-vm-memory-dump_virt-collecting-virt-data[Collect memory dumps from VMs]


### PR DESCRIPTION
Version(s):
Cherrypick back to as many supported versions as possible (CQA work).

Issue:
https://issues.redhat.com/browse/DOCPLAN-98

Link to docs preview:
https://108212--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/support/virt-collecting-virt-data.html

QE review:
No QE required - just reformatting docs for CQA/DITA.

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
