### PR TITLE
TELCODOCS-2806: Fix DITA compatibility issues in DPU Operator docs

### DIFF
--- a/modules/nw-dpu-configuring-operator.adoc
+++ b/modules/nw-dpu-configuring-operator.adoc
@@ -35,7 +35,7 @@ spec:
 ----
 +
 * `metadata.name`: Specifies the name of the Custom Resource, which must be `dpu-operator-config`.
-* `spec.logLevel`: Sets the desired logging verbosity in the operator container logs. The value `0` is the default setting.
+* `spec.logLevel`: Sets the required logging verbosity in the Operator container logs. The value `0` is the default setting.
 
 . Create the resource by running the following command:
 +

--- a/modules/nw-dpu-creating-a-sfc.adoc
+++ b/modules/nw-dpu-creating-a-sfc.adoc
@@ -54,7 +54,7 @@ spec:
 ----
 +
 * `metadata.name.annotations.k8s.v1.cni.cncf.io/networks`: The value `dpunfcni-conf` specifies the name of the `NetworkAttachmentDefinition` resource. The DPU Operator creates this resource during installation to configure the DPU networking.
-* `spec.nodeSelector`: The `nodeSelector` is the primary mechanism for scheduling this workload. The DPU Operator creates and maintains the label: `dpu.config.openshift.io/dpuside: "dpu"`. This label ensures the pod is scheduled directly onto the DPU's processing unit.
+* `spec.nodeSelector`: The `nodeSelector` is the primary mechanism for scheduling this workload. The DPU Operator creates and maintains the label: `dpu.config.openshift.io/dpuside: "dpu"`. This label ensures the pod is scheduled directly onto the DPU processing unit.
 * `spec.containers.name`: The name of the container.
 * `spec.containers.image`: The container image to pull and run.
 

--- a/modules/nw-dpu-intro-installing-operator.adoc
+++ b/modules/nw-dpu-intro-installing-operator.adoc
@@ -2,14 +2,14 @@
 //
 // * networking/networking_operators/installing-dpu-operator.adoc
 
-:_mod-docs-content-type: Concept
+:_mod-docs-content-type: CONCEPT
 [id="overview-installing-dpu-operator_{context}"]
 = Installing the DPU Operator
 
 [role="_abstract"]
-You can install the Data Processing Unit (DPU) Operator on both host and DPU clusters to manage device lifecycle and network attachments using the CLI or web console.
+You can install the Data Processing Unit (DPU) Operator on both host and DPU clusters to manage device lifecycle and network attachments by using the CLI or web console.
 
-Cluster administrators can install the DPU Operator on the host cluster and all DPU clusters using the {product-title} CLI or the web console. The DPU Operator manages the lifecycle, DPU devices, and network attachments for all supported DPUs."
+Cluster administrators can install the DPU Operator on the host cluster and all DPU clusters by using the {product-title} CLI or the web console. The DPU Operator manages the lifecycle, DPU devices, and network attachments for all supported DPUs.
 
 [NOTE]
 ====

--- a/modules/nw-dpu-operator-uninstall.adoc
+++ b/modules/nw-dpu-operator-uninstall.adoc
@@ -18,7 +18,7 @@ To uninstall the DPU Operator, you must first delete any running DPU workloads. 
 
 .Procedure
 
-. Delete the `DpuOperatorConfig` CR that was created by running the following command
+. Delete the `DpuOperatorConfig` CR by running the following command:
 +
 [source,terminal]
 ----
@@ -48,7 +48,7 @@ $ oc delete OperatorGroup dpu-operators -n openshift-dpu-operator
 $ oc get csv -n openshift-dpu-operator
 ----
 +
-.Example output
+The following example shows the output:
 +
 [source,terminal]
 ----

--- a/modules/nw-monitoring-dpu-status.adoc
+++ b/modules/nw-monitoring-dpu-status.adoc
@@ -44,7 +44,7 @@ worker-host-marvell-41         Ready    worker   4d     v1.32.9
 worker-host-ptl-243            Ready    worker   3d23h  v1.32.9
 ----
 +
-This output shows three master nodes, and three worker nodes identified by the worker-host prefix, for example, `worker-host-ipu-219`. Each worker node contains a DPU identified by the ocpcluster-dpu prefix, for example, `ocpcluster-dpu-ipu-219`.
+This output shows three control plane nodes, and three worker nodes identified by the worker-host prefix, for example, `worker-host-ipu-219`. Each worker node has a DPU identified by the ocpcluster-dpu prefix, for example, `ocpcluster-dpu-ipu-219`.
 
 . Run the following command to report on the status of the DPUs:
 +
@@ -65,10 +65,12 @@ intel-ipu-dpu                        Intel IPU E2100                true        
 marvell-dpu-0000-87-00.0-host        Marvell DPU                    false           worker-host-marvell-41  True
 marvell-dpu-ipu                      Marvell DPU                    true            worker-dpu-marvell-41   True
 ----
-* `DPU PRODUCT`:Displays the vendor or type of DPU, for example, Intel or Marvell.
-* `DPU SIDE`:Indicates whether the DPU is operating on the host side (`false`) or the DPU side (`true`). Each physical DPU is represented twice.
-* `MODE NAME`:The name of the node where the DPU is located. This is the host worker node for `false` entries and the DPU node for `true` entries.
-* `STATUS`:Indicates whether the DPU is functioning correctly (`True`) or has issues (`False`).
+where:
+
+`DPU PRODUCT`:: Displays the vendor or type of DPU, for example, Intel or Marvell.
+`DPU SIDE`:: Indicates whether the DPU is operating on the host side (`false`) or the DPU side (`true`). Each physical DPU is represented twice.
+`MODE NAME`:: The name of the node where the DPU is located. This is the host worker node for `false` entries and the DPU node for `true` entries.
+`STATUS`:: Indicates whether the DPU is functioning correctly (`True`) or has issues (`False`).
 +
 [NOTE]
 ====

--- a/networking/networking_operators/dpu-operator/dpu-operator.adoc
+++ b/networking/networking_operators/dpu-operator/dpu-operator.adoc
@@ -6,7 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-As a cluster administrator, you can add the DPU Operator to your cluster to manage DPU devices and network attachments.
+[role="_abstract"]
+As a cluster administrator, you can add the Data Processing Unit (DPU) Operator to your cluster to manage DPU devices and network attachments.
 
 --
 :FeatureName: The DPU Operator


### PR DESCRIPTION
## Summary
- Fix AsciiDocDITA Vale errors: add missing `[role="_abstract"]` to assembly, fix content type case (`Concept` → `CONCEPT`), replace unsupported `.Example output` block title with normal text
- Fix Vale warnings: use "by using" instead of "using", replace "master" with "control plane", replace "desired" with "required"
- Additional fixes: remove incorrect possessive "DPU's", convert malformed unordered list to proper AsciiDoc description list format, fix missing colon and passive voice in procedure step

## Test plan
- [x] Ran Vale with AsciiDocDITA rules — all errors resolved, only suggestions and spelling false positives remain
- [x] Verify AsciiDoc renders correctly with `asciibinder build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)