### PR TITLE
TELCODOCS-2807: Fix AsciiDocDITA Vale warnings for MetalLB upgrade docs

### DIFF
--- a/modules/nw-metalLB-basic-upgrade-operator.adoc
+++ b/modules/nw-metalLB-basic-upgrade-operator.adoc
@@ -57,7 +57,8 @@ $ oc -n metallb-system get csv
 $ oc -n metallb-system get installplan
 ----
 +
-.Example output that shows install-tsz2g as a manual install plan
+The following example output shows `install-tsz2g` as a manual install plan:
++
 [source,terminal,subs="attributes+"]
 ----
 NAME            CSV                                     APPROVAL    APPROVED

--- a/networking/networking_operators/metallb-operator/metallb-upgrading-operator.adoc
+++ b/networking/networking_operators/metallb-operator/metallb-upgrading-operator.adoc
@@ -1,6 +1,7 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="metallb-upgrading-operator"]
 = Upgrading the MetalLB Operator
+
 include::_attributes/common-attributes.adoc[]
 :context: metallb-upgrading-operator
 


### PR DESCRIPTION
## Summary
- Add blank line after document title in `metallb-upgrading-operator.adoc` to prevent author line interpretation during DITA conversion
- Convert unsupported block title to normal text in `nw-metalLB-basic-upgrade-operator.adoc` for DITA compatibility

## Test plan
- [x] Verified 0 errors, 0 warnings from Vale AsciiDocDITA rules after changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)