### PR TITLE
OSDOCS#18611: Update the z-stream RNs for 4.12.86

### DIFF
--- a/modules/zstream-4-12-86-about.adoc
+++ b/modules/zstream-4-12-86-about.adoc
@@ -1,0 +1,24 @@
+// Module included in the following assembly:
+//
+// * release_notes/ocp-4-12-release-notes.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="zstream-4-12-86-about_{context}"]
+= RHSA-2026:3870 - {product-title} {product-version}.86 bug fix and security update
+
+[role="_abstract"]
+Issued: 12 March 2026
+
+{product-title} release {product-version}.86, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2026:3870[RHSA-2026:3870] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2026:3860[RHBA-2026:3860] advisory.
+
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+
+You can view the container images in this release by running the following command:
+
+
+[source,terminal]
+----
+$ oc adm release info 4.12.86 --pullspecs
+----

--- a/modules/zstream-4-12-86-fixed-issues.adoc
+++ b/modules/zstream-4-12-86-fixed-issues.adoc
@@ -1,0 +1,12 @@
+// Module included in the following assembly:
+//
+// * release_notes/ocp-4-12-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-12-86-fixed-issues_{context}"]
+= Fixed issues
+
+[role="_abstract"]
+The following issue is fixed with this release:
+
+* Before this update, a bug occurred in {product-title} 4.12 because of an unsupported user configuration in {product-title} 4.13. As a consequence, the user experience in {product-title} 4.12 was disrupted. With this release, a bug fix in {product-title} 4.12.0-0.nightly-2026-03-04-014443 resolves the issue found only in {product-title} 4.12. As a result, system stability for users in {product-title} 4.12 is improved. (link:https://issues.redhat.com/browse/OCPBUGS-77403[OCPBUGS-77403])

--- a/modules/zstream-4-12-86-updating.adoc
+++ b/modules/zstream-4-12-86-updating.adoc
@@ -1,0 +1,10 @@
+// Module included in the following assembly:
+//
+// * release_notes/ocp-4-12-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-12-86-updating_{context}"]
+= Updating
+
+[role="_abstract"]
+To update an existing {product-title} 4.12 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].

--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -5343,26 +5343,35 @@ include::modules/zstream-4-12-83-about.adoc[leveloffset=+2]
 
 
 // 4.12.83 fixes
-include::modules/zstream-4-12-83-bug-fixes.adoc[leveloffset=+2]
+include::modules/zstream-4-12-83-bug-fixes.adoc[leveloffset=+3]
 
 
 // 4.12.83 updating
-include::modules/zstream-4-12-83-updating.adoc[leveloffset=+2]
+include::modules/zstream-4-12-83-updating.adoc[leveloffset=+3]
 
 // 4.12.84 about
 include::modules/zstream-4-12-84-about.adoc[leveloffset=+2]
 
 // 4.12.84 fixes
-include::modules/zstream-4-12-84-bug-fixes.adoc[leveloffset=+2]
+include::modules/zstream-4-12-84-bug-fixes.adoc[leveloffset=+3]
 
 // 4.12.84 updating
-include::modules/zstream-4-12-84-updating.adoc[leveloffset=+2]
+include::modules/zstream-4-12-84-updating.adoc[leveloffset=+3]
 
 // 4.12.85 about
 include::modules/zstream-4-12-85-about.adoc[leveloffset=+2]
 
 // 4.12.85 fixes
-include::modules/zstream-4-12-85-bug-fixes.adoc[leveloffset=+2]
+include::modules/zstream-4-12-85-bug-fixes.adoc[leveloffset=+3]
 
 // 4.12.85 updating
-include::modules/zstream-4-12-85-updating.adoc[leveloffset=+2]
+include::modules/zstream-4-12-85-updating.adoc[leveloffset=+3]
+
+// 4.12.86 about
+include::modules/zstream-4-12-86-about.adoc[leveloffset=+2]
+
+// 4.12.86 fixes
+include::modules/zstream-4-12-86-fixed-issues.adoc[leveloffset=+3]
+
+// 4.12.86 updating
+include::modules/zstream-4-12-86-updating.adoc[leveloffset=+3]


### PR DESCRIPTION
Version(s):
4.12

Issue:
[OSDOCS-18611](https://issues.redhat.com/browse/OSDOCS-18611)

Link to docs preview:
[4.12.86](https://108236--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-12-release-notes.html#zstream-4-12-86-about_release-notes)

QE review:
- [ ] QE has approved this change.
N/A for z-stream RNs

Additional information:

- Shipment [MR](https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/393#c58c40ade127be561b0e9cffc9887cf5d9ff24f4)
- ART [dashboard](https://art-dash.engineering.redhat.com/dashboard/release/openshift-4.12)