### PR TITLE
OLS-2741: Update MCP doc page

### DIFF
--- a/modules/ols-enabling-custom-mcp-server.adoc
+++ b/modules/ols-enabling-custom-mcp-server.adoc
@@ -66,15 +66,15 @@ spec:
 
 * `spec.mcpServers.url` specifies the URL path that the MCP server uses to communicate
 
-* `spec.mcpServers.timeout` specifies the time that the MCP server has to respond to a query. If the client does not receive a query within the time specified, the MCP server times out. In this example, the timeout is 30 seconds.
+* `spec.mcpServers.timeout` specifies the time that the MCP server has to respond to a query. If the Service does not receive a response within the time specified, the connection times out. In this example, the timeout is 30 seconds.
 
-* `spec.mcpServers.headers` specifies MCP headers as an array of structured objects containing the key-value pairs required for server authentication and context.
+* `spec.mcpServers.headers` specifies MCP headers as an array of structured objects, which are required for MCP server authentication.
 
 * `spec.mcpServers.headers.name` specifies the name of the header that gets sent to the MCP server.
 
 * `spec.mcpServers.headers.valueFrom.type` specify the string `kubernetes` to provide the user's bearer token
 
-* `spec.mcpServers.headers.valueFrom.secretRef.name` specifies the name of the secret that contains the header value. Ensure that the secret has the key name `header`.
+* `spec.mcpServers.headers.valueFrom.secretRef.name` specifies the name of the secret that contains the header value. Ensure that the secret has the key name `header`. 
 
 . Click *Save*. 
 +


### PR DESCRIPTION
Affects:
[lightspeed-main](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-main)
[lightspeed-docs-1.0](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-1.0)

PR must be CP'd back to the lightspeed-docs-1.0 branch.

Issue:
https://issues.redhat.com/browse/OLS-2741

Link to docs preview:

web console task: 
https://108234--ocpdocs-pr.netlify.app/openshift-lightspeed/latest/configure/ols-configuring-openshift-lightspeed.html#ols-creating-the-credentials-secret-using-web-console_ols-configuring-openshift-lightspeed

CLI task:
https://108234--ocpdocs-pr.netlify.app/openshift-lightspeed/latest/configure/ols-configuring-openshift-lightspeed.html#ols-creating-the-credentials-secret-using-cli_ols-configuring-openshift-lightspeed

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
