### PR TITLE
OLS-2744: Update OLS 1.0.10 rel notes to mention KCS

### DIFF
--- a/modules/ols-1-0-10-release-notes.adoc
+++ b/modules/ols-1-0-10-release-notes.adoc
@@ -19,6 +19,6 @@ The following enhancements have been made with {ols-official} 1.0.10:
 * With this update, {ols-long} introduces token management for tool calls, which prevents {ols-long} from exceeding the message context window size. This enhancement aims to avoid errors due to `context_window` limit during tool calls, ensuring a better user experience. It also reserves tokens for tool output, managing the amount of data displayed in a single tool output and helping to retain a smooth conversation flow without the need to end and restart sessions.
 
 * With this update, MCP headers and MCP definitions have changed. Previously {ols-long} supported three methods for the MCP client to send messages back and forth with the MCP server: Server-Sent Events (SSE), Standard Input/Output (stdio), and Streamable Hypertext Transfer Protocol (HTTP). Now, {ols-long}
-supports only Streamable HTTP.
+supports only Streamable HTTP. See link:https://access.redhat.com/solutions/7139435[OLSConfig CR requires manual update of MCP server configuration before upgrading OpenShift Lightspeed Operator to 1.0.10] for more information. 
 
 * With this update, you can enable tool filtering to control the list of tools provided to the LLM model. To enable this feature, specify the `toolFilteringConfig` field in the `OLSConfig` custom resource (CR) file.


### PR DESCRIPTION
Affects:
[lightspeed-main](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-main)
[lightspeed-docs-1.0](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-1.0)

PR must be CP'd back to the lightspeed-docs-1.0 branch.

Issue:
https://issues.redhat.com/browse/OLS-2744

Link to docs preview:
https://108238--ocpdocs-pr.netlify.app/openshift-lightspeed/latest/release_notes/ols-release-notes.html#ols-1-0-10-enhancements_ols-release-notes

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
