### PR TITLE
DOCPLAN-81: Rewrites to virt-creating-storage-class-csi-driver for CQ…

### DIFF
--- a/modules/virt-creating-storage-class-csi-driver.adoc
+++ b/modules/virt-creating-storage-class-csi-driver.adoc
@@ -14,9 +14,9 @@ When you create a storage class, you set parameters that affect the dynamic prov
 
 [NOTE]
 ====
-Virtual machines use data volumes that are based on local PVs. Local PVs are bound to specific nodes. While a disk image is prepared for consumption by the virtual machine, it is possible that the virtual machine cannot be scheduled to the node where the local storage PV was previously pinned.
+Virtual machines use data volumes based on local PVs, which reside on specific nodes. When the system prepares a disk image for the virtual machine, the scheduler might not place the virtual machine on the node where it pinned the local storage PV.
 
-To solve this problem, use the Kubernetes pod scheduler to bind the persistent volume claim (PVC) to a PV on the correct node. By using the `StorageClass` value with `volumeBindingMode` parameter set to `WaitForFirstConsumer`, the binding and provisioning of the PV is delayed until a pod is created using the PVC.
+To solve this problem, use the Kubernetes pod scheduler to bind the persistent volume claim (PVC) to a PV on the correct node. Setting the `volumeBindingMode` parameter of the `StorageClass` to `WaitForFirstConsumer` delays PV binding and provisioning until you create a pod that uses the PVC.
 ====
 
 ifdef::openshift-rosa,openshift-dedicated[]
@@ -43,9 +43,9 @@ parameters:
   storagePool: my-storage-pool <3>
 ----
 +
-* `reclaimPolicy` defines whether the underlying storage is deleted or retained when a user deletes a PVC. The two possible `reclaimPolicy` values are `Delete` and `Retain`. If you do not specify a value, the default value is `Delete`.
-* `volumeBindingMode` defines the timing of PV creation. The `WaitForFirstConsumer` configuration in this example means that PV creation is delayed until a pod is scheduled to a specific node.
-* `parameters.storagePool` defines the name of the storage pool defined in the HPP custom resource (CR).
+* `reclaimPolicy` specifies whether the underlying storage is deleted or retained when a user deletes a PVC. The two possible `reclaimPolicy` values are `Delete` and `Retain`. If you do not specify a value, the default value is `Delete`.
+* `volumeBindingMode` specifies the timing of PV creation. In this example, the `WaitForFirstConsumer` configuration delays PV creation until the scheduler assigns a pod to a specific node.
+* `parameters.storagePool` specifies the name of the storage pool defined in the HPP custom resource (CR).
 
 . Save the file and exit.
 

--- a/modules/virt-creating-storage-class-csi-driver.adoc
+++ b/modules/virt-creating-storage-class-csi-driver.adoc
@@ -12,13 +12,6 @@ To use the hostpath provisioner (HPP) you must create an associated storage clas
 
 When you create a storage class, you set parameters that affect the dynamic provisioning of persistent volumes (PVs) that belong to that storage class. You cannot update a `StorageClass` object's parameters after you create it.
 
-[NOTE]
-====
-Virtual machines use data volumes based on local PVs, which reside on specific nodes. When the system prepares a disk image for the virtual machine, the scheduler might not place the virtual machine on the node where it pinned the local storage PV.
-
-To solve this problem, use the Kubernetes pod scheduler to bind the persistent volume claim (PVC) to a PV on the correct node. Setting the `volumeBindingMode` parameter of the `StorageClass` to `WaitForFirstConsumer` delays PV binding and provisioning until you create a pod that uses the PVC.
-====
-
 ifdef::openshift-rosa,openshift-dedicated[]
 .Prerequisites
 
@@ -45,6 +38,13 @@ parameters:
 +
 * `reclaimPolicy` specifies whether the underlying storage is deleted or retained when a user deletes a PVC. The two possible `reclaimPolicy` values are `Delete` and `Retain`. If you do not specify a value, the default value is `Delete`.
 * `volumeBindingMode` specifies the timing of PV creation. In this example, the `WaitForFirstConsumer` configuration delays PV creation until the scheduler assigns a pod to a specific node.
++
+[NOTE]
+====
+Virtual machines use data volumes based on local PVs, which reside on specific nodes. When the system prepares a disk image for the virtual machine, the scheduler might not place the virtual machine on the node where it pinned the local storage PV.
++
+To solve this problem, use the Kubernetes pod scheduler to bind the persistent volume claim (PVC) to a PV on the correct node. Setting the `volumeBindingMode` parameter of the `StorageClass` to `WaitForFirstConsumer` delays PV binding and provisioning until you create a pod that uses the PVC.
+====
 * `parameters.storagePool` specifies the name of the storage pool defined in the HPP custom resource (CR).
 
 . Save the file and exit.


### PR DESCRIPTION
Version(s):
Main, 4.21, 4.22

Issue:
[DOCPLAN-81](https://issues.redhat.com/browse/DOCPLAN-81)

[Link to docs preview](https://108240--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/post_installation_configuration/virt-post-install-storage-config.html#virt-creating-storage-class-csi-driver_virt-post-install-storage-config)

QE review:
- [x] QE has approved this change.
