### PR TITLE
Fix DITA conversion issues in cluster-compare advanced customization …

### DIFF
--- a/modules/cluster-compare-manual-match.adoc
+++ b/modules/cluster-compare-manual-match.adoc
@@ -7,6 +7,7 @@
 [id="cluster-compare-manual-match_{context}"]
 = Configuring manual matching between CRs and templates
 
+[role="_abstract"]
 In some cases, the `cluster-compare` plugin's default matching might not work as expected. You can manually define how a custom resource (CR) maps to a template by using a user configuration file.
 
 By default, the plugin maps a CR to a template based on the `apiversion`, `kind`, `name`, and `namespace` fields. However, multiple templates might match a single CR. For example, this can occur in the following scenarios:
@@ -19,26 +20,33 @@ When a CR matches multiple templates, the plugin uses a tie-breaking mechanism t
 
 .Procedure
 
-. Create a user configuration file to define the manual matching criteria:
+. Create a user configuration file to define the manual matching criteria. The following example shows a `user-config.yaml` file:
 +
-.Example `user-config.yaml` file
 [source,yaml]
 ----
-correlationSettings: <1>
-   manualCorrelation: <2>
-      correlationPairs: <3>
-        ptp.openshift.io/v1_PtpConfig_openshift-ptp_grandmaster: optional/ptp-config/PtpOperatorConfig.yaml <4>
-        ptp.openshift.io/v1_PtpOperatorConfig_openshift-ptp_default: optional/ptp-config/PtpOperatorConfig.yaml
+correlationSettings:
+   manualCorrelation:
+      correlationPairs:
+        <cr_specification>: <template_path>
 ----
-<1> The `correlationSettings` section contains the manual correlation settings.
-<2> The `manualCorrelation` section specifies that manual correlation is enabled.
-<3> The `correlationPairs` section lists the CR and template pairs to manually match.
-<4> Specifies the CR and template pair to match. The CR specification uses the following format: `<apiversion>_<kind>_<namespace>_<name>`. For cluster-scoped CRs that do not have a namespace, use the following format: `<apiversion>_<kind>_<name>`. The path to the template must be relative to the `metadata.yaml` file.
++
+where:
++
+--
+`correlationSettings`:: The section that has the manual correlation settings.
+`manualCorrelation`:: Specifies that manual correlation is enabled.
+`correlationPairs`:: Lists the CR and template pairs to manually match.
+`<cr_specification>`:: Specifies the CR to match. Use the following format: `<apiversion>_<kind>_<namespace>_<name>`. For cluster-scoped CRs that do not have a namespace, use the following format: `<apiversion>_<kind>_<name>`.
+`<template_path>`:: Specifies the path to the template. The path must be relative to the `metadata.yaml` file.
+--
 
 . Reference the user configuration file in a `cluster-compare` command by running the following command:
 +
 [source,terminal]
 ----
-$ oc cluster-compare -r <path_to_reference_config>/metadata.yaml -c <path_to_user_config>/user-config.yaml <1>
+$ oc cluster-compare -r <path_to_reference_config>/metadata.yaml -c <path_to_user_config>/user-config.yaml
 ----
-<1> Specify the `user-config.yaml` file by using the `-c` option.
++
+where:
++
+`-c <path_to_user_config>/user-config.yaml`:: Specifies the path to the `user-config.yaml` file.

--- a/modules/cluster-compare-patching-generate.adoc
+++ b/modules/cluster-compare-patching-generate.adoc
@@ -1,0 +1,86 @@
+// Module included in the following assemblies:
+//
+// * scalability_and_performance/cluster-compare/advanced-ref-config-customization.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="cluster-compare-patching-generate_{context}"]
+= Using the cluster-compare plugin to generate a patch
+
+[role="_abstract"]
+You can use the `cluster-compare` plugin to generate a patch for specific template files. The plugin adjusts the template to ensure it matches with the cluster custom resource (CR). Any previously valid differences in the patched template are not reported. The plugin highlights the patched files in the output.
+
+.Procedure
+
+. Generate patches for templates by running the following command:
++
+[source,terminal]
+----
+$ oc cluster-compare -r <path_to_reference_config>/metadata.yaml -o 'generate-patches' --override-reason "<reason>" --generate-override-for "<template_path>" > <path_to_patches_file>
+----
++
+where:
++
+`-r <path_to_reference_config>/metadata.yaml`:: Specifies the path to the `metadata.yaml` file of the reference configuration.
+`-o 'generate-patches'`:: Specifies the output format. To generate a patch output, you must use the `generate-patches` value.
+`--override-reason "<reason>"`:: Describes the reason for the patch.
+`--generate-override-for "<template_path>"`:: Specifies a path to the template that requires a patch.
+`<path_to_patches_file>`:: Specifies the filename and path for your patch.
++
+[NOTE]
+====
+You must use a file path for the target template that is relative to the `metadata.yaml` file. For example, if the file path for the `metadata.yaml` file is `./compare/metadata.yaml`, a relative file path for the template might be `optional/my-template.yaml`.
+====
+
+. Optional: Review the patch file before applying to the reference configuration. The following example shows a `patch-config` file:
++
+[source,yaml]
+----
+- apiVersion: storage.k8s.io/v1
+  kind: StorageClass
+  name: crc-csi-hostpath-provisioner
+  patch: '{"provisioner":"kubevirt.io.hostpath-provisioner"}'
+  reason: A valid reason for the override
+  templatePath: optional/local-storage-operator/StorageClass.yaml
+  type: mergepatch
+----
++
+where:
++
+`patch`:: The plugin patches the fields in the template to match the CR.
+`templatePath`:: The path to the template.
+`type: mergepatch`:: The `mergepatch` option merges the JSON into the target template. Unspecified fields remain unchanged.
+
+. Apply the patch to the reference configuration by running the following command:
++
+[source,terminal]
+----
+$ oc cluster-compare -r <path_to_reference_config>/metadata.yaml -p <path_to_patches_file>
+----
++
+where:
++
+`-r`:: Specifies the path to the `metadata.yaml` file of the reference configuration.
+`-p`:: Specifies the path to the patch file.
+
+.Verification
+
+* Review the output to verify that the patch was applied. The following example shows a successful patch:
++
+[source,terminal]
+----
+...
+
+Cluster CR: storage.k8s.io/v1_StorageClass_crc-csi-hostpath-provisioner
+Reference File: optional/local-storage-operator/StorageClass.yaml
+Description: Component description
+Diff Output: None
+Patched with patch
+Patch Reasons:
+- A valid reason for the override
+
+...
+
+No CRs are unmatched to reference CRs
+Metadata Hash: bb2165004c496b32e0c8509428fb99c653c3cf4fba41196ea6821bd05c3083ab
+Cluster CRs with patches applied: 1
+----

--- a/modules/cluster-compare-patching-manual.adoc
+++ b/modules/cluster-compare-patching-manual.adoc
@@ -1,0 +1,122 @@
+// Module included in the following assemblies:
+//
+// * scalability_and_performance/cluster-compare/advanced-ref-config-customization.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="cluster-compare-patching-manual_{context}"]
+= Creating a patch file manually
+
+[role="_abstract"]
+You can write a patch file to handle expected deviations in a cluster configuration.
+
+Patches have three possible values for the `type` field:
+
+* `mergepatch` - Merges the JSON into the target template. Unspecified fields remain unchanged.
+* `rfc6902` - Merges the JSON in the target template by using `add`, `remove`, `replace`, `move`, and `copy` operations. Each operation targets a specific path.
+* `go-template` - Defines a Golang template. The plugin renders the template by using the cluster custom resource (CR) as input and generates either a `mergepatch` or `rfc6902` patch for the target template.
+
+The following example shows the same patch by using all three different formats.
+
+.Procedure
+
+. Create a patch file to match your use case. The following example shows the `patch-config` structure:
++
+[source,yaml]
+----
+- apiVersion: v1
+  kind: Namespace
+  name: openshift-storage
+  reason: known deviation
+  templatePath: namespace.yaml
+  type: mergepatch
+  patch: '{"metadata":{"annotations":{"openshift.io/sa.scc.mcs":"s0:c29,c14","openshift.io/sa.scc.supplemental-groups":"1000840000/10000","openshift.io/sa.scc.uid-range":"1000840000/10000","reclaimspace.csiaddons.openshift.io/schedule":"@weekly","workload.openshift.io/allowed":null},"labels":{"kubernetes.io/metadata.name":"openshift-storage","olm.operatorgroup.uid/ffcf3f2d-3e37-4772-97bc-983cdfce128b":"","openshift.io/cluster-monitoring":"false","pod-security.kubernetes.io/audit":"privileged","pod-security.kubernetes.io/audit-version":"v1.24","pod-security.kubernetes.io/warn":"privileged","pod-security.kubernetes.io/warn-version":"v1.24","security.openshift.io/scc.podSecurityLabelSync":"true"}},"spec":{"finalizers":["kubernetes"]}}'
+- name: openshift-storage
+  apiVersion: v1
+  kind: Namespace
+  templatePath: namespace.yaml
+  type: rfc6902
+  reason: known deviation
+  patch: '[
+    {"op": "add", "path": "/metadata/annotations/openshift.io~1sa.scc.mcs", "value": "s0:c29,c14"},
+    {"op": "add", "path": "/metadata/annotations/openshift.io~1sa.scc.supplemental-groups", "value": "1000840000/10000"},
+    {"op": "add", "path": "/metadata/annotations/openshift.io~1sa.scc.uid-range", "value": "1000840000/10000"},
+    {"op": "add", "path": "/metadata/annotations/reclaimspace.csiaddons.openshift.io~1schedule", "value": "@weekly"},
+    {"op": "remove", "path": "/metadata/annotations/workload.openshift.io~1allowed"},
+    {"op": "add", "path": "/metadata/labels/kubernetes.io~1metadata.name", "value": "openshift-storage"},
+    {"op": "add", "path": "/metadata/labels/olm.operatorgroup.uid~1ffcf3f2d-3e37-4772-97bc-983cdfce128b", "value": ""},
+    {"op": "add", "path": "/metadata/labels/openshift.io~1cluster-monitoring", "value": "false"},
+    {"op": "add", "path": "/metadata/labels/pod-security.kubernetes.io~1audit", "value": "privileged"},
+    {"op": "add", "path": "/metadata/labels/pod-security.kubernetes.io~1audit-version", "value": "v1.24"},
+    {"op": "add", "path": "/metadata/labels/pod-security.kubernetes.io~1warn", "value": "privileged"},
+    {"op": "add", "path": "/metadata/labels/pod-security.kubernetes.io~1warn-version", "value": "v1.24"},
+    {"op": "add", "path": "/metadata/labels/security.openshift.io~1scc.podSecurityLabelSync", "value": "true"},
+    {"op": "add", "path": "/spec", "value": {"finalizers": ["kubernetes"]}}
+    ]'
+- apiVersion: v1
+  kind: Namespace
+  name: openshift-storage
+  reason: "known deviation"
+  templatePath: namespace.yaml
+  type: go-template
+  patch: |
+    {
+        "type": "rfc6902",
+        "patch": '[
+            {"op": "add", "path": "/metadata/annotations/openshift.io~1sa.scc.mcs", "value": "s0:c29,c14"},
+            {"op": "add", "path": "/metadata/annotations/openshift.io~1sa.scc.supplemental-groups", "value": "1000840000/10000"},
+            {"op": "add", "path": "/metadata/annotations/openshift.io~1sa.scc.uid-range", "value": "1000840000/10000"},
+            {"op": "add", "path": "/metadata/annotations/reclaimspace.csiaddons.openshift.io~1schedule", "value": "@weekly"},
+            {"op": "remove", "path": "/metadata/annotations/workload.openshift.io~1allowed"},
+            {"op": "add", "path": "/metadata/labels/kubernetes.io~1metadata.name", "value": "openshift-storage"},
+            {"op": "add", "path": "/metadata/labels/olm.operatorgroup.uid~1ffcf3f2d-3e37-4772-97bc-983cdfce128b", "value": ""},
+            {"op": "add", "path": "/metadata/labels/openshift.io~1cluster-monitoring", "value": "false"},
+            {"op": "add", "path": "/metadata/labels/pod-security.kubernetes.io~1audit", "value": "privileged"},
+            {"op": "add", "path": "/metadata/labels/pod-security.kubernetes.io~1audit-version", "value": "v1.24"},
+            {"op": "add", "path": "/metadata/labels/pod-security.kubernetes.io~1warn", "value": "privileged"},
+            {"op": "add", "path": "/metadata/labels/pod-security.kubernetes.io~1warn-version", "value": "v1.24"},
+            {"op": "add", "path": "/metadata/labels/security.openshift.io~1scc.podSecurityLabelSync", "value": "true"},
+            {"op": "add", "path": "/spec", "value": {"finalizers": {{ .spec.finalizers | toJson }} }}
+        ]'
+    }
+----
++
+where:
++
+`kind`, `apiVersion`, `name`, `namespace`:: The patch uses these fields to match the patch with the correct cluster CR.
+
+. Apply the patch to the reference configuration by running the following command:
++
+[source,terminal]
+----
+$ oc cluster-compare -r <path_to_reference_config>/metadata.yaml -p <path_to_patches_file>
+----
++
+where:
++
+`-r`:: Specifies the path to the `metadata.yaml` file of the reference configuration.
+`-p`:: Specifies the path to the patch file.
+
+.Verification
+
+* Review the output to verify that the patch was applied. The following example shows a successful patch:
++
+[source,terminal]
+----
+...
+
+Cluster CR: storage.k8s.io/v1_StorageClass_crc-csi-hostpath-provisioner
+Reference File: namespace.yaml
+Description: Component description
+Diff Output: None
+Patched with patch
+Patch Reasons:
+- known deviation
+- known deviation
+- known deviation
+
+...
+
+No CRs are unmatched to reference CRs
+Metadata Hash: bb2165004c496b32e0c8509428fb99c653c3cf4fba41196ea6821bd05c3083ab
+Cluster CRs with patches applied: 1
+----

--- a/modules/cluster-compare-patching.adoc
+++ b/modules/cluster-compare-patching.adoc
@@ -1,202 +1,22 @@
 // Module included in the following assemblies:
+//
+// * scalability_and_performance/cluster-compare/advanced-ref-config-customization.adoc
 
-// *scalability_and_performance/cluster-compare/advanced-ref-config-customization.adoc
-
-:_mod-docs-content-type: PROCEDURE
+:_mod-docs-content-type: ASSEMBLY
 [id="cluster-compare-patching_{context}"]
 = Patching a reference configuration
 
+[role="_abstract"]
 In certain scenarios, you might need to patch the reference configuration to handle expected deviations in a cluster configuration. The plugin applies the patch during the comparison process, modifying the specified resource fields as defined in the patch file.
 
 For example, you might need to temporarily patch a template because a cluster uses a deprecated field that is out-of-date with the latest reference configuration. Patched files are reported in the comparison output summary.
 
 You can create a patch file in two ways:
 
-* Use the `cluster-compare` plugin to generate a patch YAML file. 
+* Use the `cluster-compare` plugin to generate a patch YAML file.
 
 * Create your own patch file.
 
-== Using the cluster-compare plugin to generate a patch
+include::cluster-compare-patching-generate.adoc[leveloffset=+1]
 
-You can use the `cluster-compare` plugin to generate a patch for specific template files. The plugin adjusts the template to ensure it matches with the cluster custom resource (CR). Any previously valid differences in the patched template are not reported. The plugin highlights the patched files in the output.
-
-.Procedure
-
-. Generate patches for templates by running the following command:
-+
-[source,terminal]
-----
-$ oc cluster-compare -r <path_to_reference_config>/metadata.yaml -o 'generate-patches' --override-reason "A valid reason for the override" --generate-override-for "<template1_path>" --generate-override-for "<template2_path>" > <path_to_patches_file>
-----
-+
-* `-r` specifies the path to the metadata.yaml file of the reference configuration. 
-* `-o` specifies the output format. To generate a patch output, you must use the `generate-patches` value.
-* `--override-reason` describes the reason for the patch.
-* `--generate-override-for` specifies a path to the template that requires a patch.
-+
-[NOTE]
-====
-You must use a file path for the target template that is relative to the `metadata.yaml` file. For example, if the file path for the `metadata.yaml` file is `./compare/metadata.yaml`, a relative file path for the template might be `optional/my-template.yaml`.
-====
-+
-* `<path_to_patches_file>` specifies the filename and path for your patch.
-
-. Optional: Review the patch file before applying to the reference configuration:
-+
-.Example `patch-config` file
-[source,yaml]
-----
-- apiVersion: storage.k8s.io/v1
-  kind: StorageClass
-  name: crc-csi-hostpath-provisioner
-  patch: '{"provisioner":"kubevirt.io.hostpath-provisioner"}' <1>
-  reason: A valid reason for the override
-  templatePath: optional/local-storage-operator/StorageClass.yaml <2>
-  type: mergepatch <3>
-----
-<1> The plugin patches the fields in the template to match the CR.
-<2> The path to the template.
-<3> The `mergepath` option merges the JSON into the target template. Unspecified fields remain unchanged.
-
-. Apply the patch to the reference configuration by running the following command:
-+
-[source,terminal]
-----
-$ oc cluster-compare -r <referenceConfigurationDirectory> -p <path_to_patches_file>
-----
-+
-* `-r` specifies the path to the metadata.yaml file of the reference configuration. 
-* `-p` specifies the path to the patch file.
-+
-.Example output
-[source,terminal]
-----
-...
-
-Cluster CR: storage.k8s.io/v1_StorageClass_crc-csi-hostpath-provisioner
-Reference File: optional/local-storage-operator/StorageClass.yaml
-Description: Component description
-Diff Output: None
-Patched with patch
-Patch Reasons:
-- A valid reason for the override
-
-...
-
-No CRs are unmatched to reference CRs
-Metadata Hash: bb2165004c496b32e0c8509428fb99c653c3cf4fba41196ea6821bd05c3083ab
-Cluster CRs with patches applied: 1
-----
-
-
-== Creating a patch file manually
-
-You can write a patch file to handle expected deviations in a cluster configuration. 
-
-[NOTE]
-====
-Patches have three possible values for the `type` field: 
-
-* `mergepatch` - Merges the JSON into the target template. Unspecified fields remain unchanged.
-* `rfc6902` - Merges the JSON in the target template using `add`, `remove`, `replace`, `move`, and `copy` operations. Each operation targets a specific path.
-* `go-template` - Defines a Golang template. The plugin renders the template using the cluster custom resource (CR) as input and generates either a `mergepatch` or `rfc6902` patch for the target template.
-
-The following example shows the same patch using all three different formats.
-====
-
-.Procedure
-
-. Create a patch file to match your use case. Use the following structure as an example:
-+
-.Example `patch-config`
-[source,yaml]
-----
-- apiVersion: v1 <1>
-  kind: Namespace
-  name: openshift-storage
-  reason: known deviation
-  templatePath: namespace.yaml
-  type: mergepatch
-  patch: '{"metadata":{"annotations":{"openshift.io/sa.scc.mcs":"s0:c29,c14","openshift.io/sa.scc.supplemental-groups":"1000840000/10000","openshift.io/sa.scc.uid-range":"1000840000/10000","reclaimspace.csiaddons.openshift.io/schedule":"@weekly","workload.openshift.io/allowed":null},"labels":{"kubernetes.io/metadata.name":"openshift-storage","olm.operatorgroup.uid/ffcf3f2d-3e37-4772-97bc-983cdfce128b":"","openshift.io/cluster-monitoring":"false","pod-security.kubernetes.io/audit":"privileged","pod-security.kubernetes.io/audit-version":"v1.24","pod-security.kubernetes.io/warn":"privileged","pod-security.kubernetes.io/warn-version":"v1.24","security.openshift.io/scc.podSecurityLabelSync":"true"}},"spec":{"finalizers":["kubernetes"]}}'
-- name: openshift-storage
-  apiVersion: v1
-  kind: Namespace
-  templatePath: namespace.yaml
-  type: rfc6902
-  reason: known deviation
-  patch: '[
-    {"op": "add", "path": "/metadata/annotations/openshift.io~1sa.scc.mcs", "value": "s0:c29,c14"}, 
-    {"op": "add", "path": "/metadata/annotations/openshift.io~1sa.scc.supplemental-groups", "value": "1000840000/10000"}, 
-    {"op": "add", "path": "/metadata/annotations/openshift.io~1sa.scc.uid-range", "value": "1000840000/10000"}, 
-    {"op": "add", "path": "/metadata/annotations/reclaimspace.csiaddons.openshift.io~1schedule", "value": "@weekly"}, 
-    {"op": "remove", "path": "/metadata/annotations/workload.openshift.io~1allowed"},
-    {"op": "add", "path": "/metadata/labels/kubernetes.io~1metadata.name", "value": "openshift-storage"}, 
-    {"op": "add", "path": "/metadata/labels/olm.operatorgroup.uid~1ffcf3f2d-3e37-4772-97bc-983cdfce128b", "value": ""}, 
-    {"op": "add", "path": "/metadata/labels/openshift.io~1cluster-monitoring", "value": "false"}, 
-    {"op": "add", "path": "/metadata/labels/pod-security.kubernetes.io~1audit", "value": "privileged"}, 
-    {"op": "add", "path": "/metadata/labels/pod-security.kubernetes.io~1audit-version", "value": "v1.24"}, 
-    {"op": "add", "path": "/metadata/labels/pod-security.kubernetes.io~1warn", "value": "privileged"}, 
-    {"op": "add", "path": "/metadata/labels/pod-security.kubernetes.io~1warn-version", "value": "v1.24"}, 
-    {"op": "add", "path": "/metadata/labels/security.openshift.io~1scc.podSecurityLabelSync", "value": "true"}, 
-    {"op": "add", "path": "/spec", "value": {"finalizers": ["kubernetes"]}}
-    ]'
-- apiVersion: v1
-  kind: Namespace
-  name: openshift-storage
-  reason: "known deviation"
-  templatePath: namespace.yaml
-  type: go-template
-  patch: |
-    {
-        "type": "rfc6902",
-        "patch": '[
-            {"op": "add", "path": "/metadata/annotations/openshift.io~1sa.scc.mcs", "value": "s0:c29,c14"},
-            {"op": "add", "path": "/metadata/annotations/openshift.io~1sa.scc.supplemental-groups", "value": "1000840000/10000"},
-            {"op": "add", "path": "/metadata/annotations/openshift.io~1sa.scc.uid-range", "value": "1000840000/10000"},
-            {"op": "add", "path": "/metadata/annotations/reclaimspace.csiaddons.openshift.io~1schedule", "value": "@weekly"},
-            {"op": "remove", "path": "/metadata/annotations/workload.openshift.io~1allowed"},
-            {"op": "add", "path": "/metadata/labels/kubernetes.io~1metadata.name", "value": "openshift-storage"},
-            {"op": "add", "path": "/metadata/labels/olm.operatorgroup.uid~1ffcf3f2d-3e37-4772-97bc-983cdfce128b", "value": ""},
-            {"op": "add", "path": "/metadata/labels/openshift.io~1cluster-monitoring", "value": "false"},
-            {"op": "add", "path": "/metadata/labels/pod-security.kubernetes.io~1audit", "value": "privileged"},
-            {"op": "add", "path": "/metadata/labels/pod-security.kubernetes.io~1audit-version", "value": "v1.24"},
-            {"op": "add", "path": "/metadata/labels/pod-security.kubernetes.io~1warn", "value": "privileged"},
-            {"op": "add", "path": "/metadata/labels/pod-security.kubernetes.io~1warn-version", "value": "v1.24"},
-            {"op": "add", "path": "/metadata/labels/security.openshift.io~1scc.podSecurityLabelSync", "value": "true"},
-            {"op": "add", "path": "/spec", "value": {"finalizers": {{ .spec.finalizers | toJson }} }}
-        ]'
-    }
-----
-<1> The patches uses the `kind`, `apiVersion`, `name`, and `namespace` fields to match the patch with the correct cluster CR.
-
-. Apply the patch to the reference configuration by running the following command:
-+
-[source,terminal]
-----
-$ oc cluster-compare -r <referenceConfigurationDirectory> -p <path_to_patches_file>
-----
-+
-* `-r` specifies the path to the metadata.yaml file of the reference configuration. 
-* `p` specifies the path to the patch file.
-+
-.Example output
-[source,terminal]
-----
-...
-
-Cluster CR: storage.k8s.io/v1_StorageClass_crc-csi-hostpath-provisioner
-Reference File: namespace.yaml
-Description: Component description
-Diff Output: None
-Patched with patch
-Patch Reasons:
-- known deviation
-- known deviation
-- known deviation
-
-...
-
-No CRs are unmatched to reference CRs
-Metadata Hash: bb2165004c496b32e0c8509428fb99c653c3cf4fba41196ea6821bd05c3083ab
-Cluster CRs with patches applied: 1
-----
+include::cluster-compare-patching-manual.adoc[leveloffset=+1]

--- a/scalability_and_performance/cluster-compare/advanced-ref-config-customization.adoc
+++ b/scalability_and_performance/cluster-compare/advanced-ref-config-customization.adoc
@@ -6,6 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 For scenarios where you want to allow temporary deviations from the reference design, you can apply more advanced customizations. 
 
 [WARNING]


### PR DESCRIPTION
…docs

Add [role="_abstract"] for DITA short descriptions, convert callouts to description lists, and split cluster-compare-patching procedure module into an assembly with two separate procedure modules to resolve TaskSection and TaskDuplicate errors.

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
