### PR TITLE
OSDOCS-18711: Expanded port range details in configuring-node-port-se…

### DIFF
--- a/modules/nodes-safe-sysctls-list.adoc
+++ b/modules/nodes-safe-sysctls-list.adoc
@@ -40,7 +40,12 @@ You cannot manually enable interface-specific unsafe sysctls.
 a|When set to `1`, all shared memory objects in current IPC namespace are automatically forced to use IPC_RMID. For more information, see link:https://docs.kernel.org/admin-guide/sysctl/kernel.html?highlight=shm_rmid_forced#shm-rmid-forced[shm_rmid_forced].
 
 | `net.ipv4.ip_local_port_range`
-a| Defines the local port range that is used by TCP and UDP to choose the local port. The first number is the first port number, and the second number is the last local port number. If possible, it is better if these numbers have different parity (one even and one odd value). They must be greater than or equal to `ip_unprivileged_port_start`. The default values are `32768` and `60999` respectively. For more information, see link:https://docs.kernel.org/networking/ip-sysctl.html?highlight=ip_local_port_range#ip-variables[ip_local_port_range (Kernel.org documentation)].
+a| Defines the local port range that is used by TCP and UDP to choose the local port. The first number is the first port number, and the second number is the last local port number. If possible, ensure these numbers have different parity, such as one even and one odd value. The numbers must be greater than or equal to `ip_unprivileged_port_start`. The default values are `32768` and `60999` respectively. For more information, see link:https://docs.kernel.org/networking/ip-sysctl.html?highlight=ip_local_port_range#ip-variables[ip_local_port_range (Kernel.org documentation)].
+
+[IMPORTANT]
+====
+When specifying a range for the `net.ipv4.ip_local_port_range` sysctl parameter, ensure the range does not overlap with the range you set for the `serviceNodePortRange` parameter. For more information, see "Configuring the node port service range" in the _Additional resources_ section.
+====
 
 | `net.ipv4.tcp_syncookies`
 |When `net.ipv4.tcp_syncookies` is set, the kernel handles TCP SYN packets normally until the

--- a/modules/nw-nodeport-service-range-edit.adoc
+++ b/modules/nw-nodeport-service-range-edit.adoc
@@ -14,6 +14,15 @@ To expand the node port range for your {product-title} cluster after installatio
 Red{nbsp}Hat has not performed testing outside the default port range of `30000-32768`. For ranges outside the default port range, ensure that you test to verify that expanding your node port range does not impact your cluster. If you expanded the range and a port allocation issue occurs, create a new cluster and set the required range for it.
 ====
 
+[IMPORTANT]
+====
+When expanding the `serviceNodePortRange` parameter, ensure the value you set for the parameter does not overlap with the ephemeral port range, `net.ipv4.ip_local_port_range`, of the kernel.
+
+OVN-Kubernetes uses this ephemeral range for source network address translation (SNAT) source port selection on outbound pod traffic. When a SNAT source port coincides with a node port number, return traffic can be misrouted, causing intermittent outbound TCP connection timeouts.
+
+For more information, see "Safe and unsafe sysctls" in the _Additional resources_ section.
+====
+
 .Prerequisites
 
 * Installed the {oc-first}.

--- a/networking/configuring_network_settings/configuring-node-port-service-range.adoc
+++ b/networking/configuring_network_settings/configuring-node-port-service-range.adoc
@@ -29,5 +29,9 @@ include::modules/nw-nodeport-service-range-edit.adoc[leveloffset=+1]
 == Additional resources
 
 * xref:../../networking/ingress_load_balancing/configuring_ingress_cluster_traffic/configuring-ingress-cluster-traffic-nodeport.adoc#configuring-ingress-cluster-traffic-nodeport[Configuring ingress cluster traffic using a NodePort]
-* xref:../../rest_api/config_apis/network-config-openshift-io-v1.adoc#network-config-openshift-io-v1[Network [config.openshift.io/v1\]]
-* xref:../../rest_api/network_apis/service-v1.adoc#service-v1[Service [core/v1\]]
+
+* xref:../../rest_api/config_apis/network-config-openshift-io-v1.adoc#network-config-openshift-io-v1[Network: config.openshift.io v1]
+
+* xref:../../rest_api/network_apis/service-v1.adoc#service-v1[Service: core v1]
+
+* xref:../../nodes/containers/nodes-containers-sysctls.adoc#safe_and_unsafe_sysctls_nodes-containers-sysctls[Safe and unsafe sysctls]

--- a/nodes/containers/nodes-containers-sysctls.adoc
+++ b/nodes/containers/nodes-containers-sysctls.adoc
@@ -16,9 +16,17 @@ Network sysctls are a special category of sysctl. Network sysctls include:
 * System-wide sysctls, for example `net.ipv4.ip_local_port_range`, that are valid for all networking. You can set these independently for each pod on a node.
 * Interface-specific sysctls, for example `net.ipv4.conf.IFNAME.accept_local`, that only apply to a specific additional network interface for a given pod. You can set these independently for each additional network configuration. You set these by using a configuration in the `tuning-cni` after the network interfaces are created.
 
-Only those sysctls considered _safe_ are enabled by default. A cluster administrator
-can manually enable _unsafe_ sysctls on the node to be available to the
-user.
+[IMPORTANT]
+====
+If the `net.ipv4.ip_local_port_range` safe sysctl parameter value and the default node port service range overlap, the OVN Kubernetes plugin might experience connection failures. For more information about this parameter, see the _System-wide safe sysctls_ table in the "Safe and unsafe sysctls" section.
+====
+
+Only those sysctls considered _safe_ are enabled by default. A cluster administrator can manually enable _unsafe_ sysctls on the node to be available to the user.
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../networking/configuring_network_settings/configuring-node-port-service-range.adoc#configuring-node-port-service-range[Configuring the node port service range]
 
 // The following include statements pull in the module files that comprise
 // the assembly. Include any combination of concept, procedure, or reference
@@ -30,6 +38,11 @@ include::modules/nodes-containers-sysctls-about.adoc[leveloffset=+1]
 include::modules/nodes-namespaced-nodelevel-sysctls.adoc[leveloffset=+1]
 
 include::modules/nodes-safe-sysctls-list.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+== Additional resources
+
+* xref:../../networking/ingress_load_balancing/configuring_ingress_cluster_traffic/configuring-ingress-cluster-traffic-nodeport.adoc#configuring-ingress-cluster-traffic-nodeport[Configuring ingress cluster traffic using a NodePort]
 
 include::modules/update-network-sysctl-allowlist.adoc[leveloffset=+1]
 


### PR DESCRIPTION
Version(s):
4.16+

Issue:
[OSDOCS-18711](https://issues.redhat.com/browse/OSDOCS-18711)

Link to docs preview:

* https://108244--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/configuring_network_settings/configuring-node-port-service-range.html
* https://108244--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/containers/nodes-containers-sysctls.html

- [x] SME has approved this change (Matteo. D).
- [x] QE has approved this change (Anurag S.).

Asked for reviews in the [forum-ocp-node channel](https://redhat-internal.slack.com/archives/CK1AE4ZCK/p1774615545423869). 
