### PR TITLE
OCPBUGS#74606: Note node filesystem change from XFS to ComposeFS

### DIFF
--- a/release_notes/ocp-4-19-release-notes.adoc
+++ b/release_notes/ocp-4-19-release-notes.adoc
@@ -2056,6 +2056,8 @@ Warning ErrorAllocatingPod 4s (x7 over 79s)  ovnk-controlplane  failed to update
 
 * Previously, CPUs for the last guaranteed pod admitted to a node remained allocated after the pod was deleted. This behavior caused scheduling domain inconsistencies. With this release, CPUs that are allocated to guaranteed pods return to the pool of available CPU resources as expected, ensuring correct CPU scheduling for subsequent pods. (link:https://issues.redhat.com/browse/OCPBUGS-17792[OCPBUGS-17792])
 
+* Previously, nodes were formatted with an XFS filesystem in read-write mode. With this release, nodes use a read-only ComposeFS filesystem using XFS as a backing store which reports full disk usage, making the filesystem immutable. (link:https://issues.redhat.com/browse/OCPNODE-2445[OCPNODE-2445])
+
 
 [id="ocp-release-note-node-tuning-operator-bug-fixes_{context}"]
 === Node Tuning Operator (NTO)


### PR DESCRIPTION
Version(s):
4.19

Issue:
[OCPBUGS-74606](https://issues.redhat.com/browse/OCPBUGS-74606)

Link to docs preview:
[OpenShift Container Platform 4.19 release notes](https://108249--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-19-release-notes.html#ocp-release-note-node-bug-fixes_release-notes)

QE review:
- [ ] QE has approved this change.

Additional information:

I wasn't sure if this release note should go under the **Node** section or the **Storage** section. Both feel appropriate to me. I defaulted to the **Node** section.