### PR TITLE
MIG-1873: Add MTC 1.8.14 RNs

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -90,7 +90,7 @@ endif::[]
 :mtc-short: MTC
 :mtc-full: Migration Toolkit for Containers
 :mtc-version: 1.8
-:mtc-version-z: 1.8.13
+:mtc-version-z: 1.8.14
 :mtc-legacy-image: 1.7
 :mtv-first: Migration Toolkit for Virtualization (MTV)
 :mtv-short: MTV

--- a/migration_toolkit_for_containers/release_notes/mtc-release-notes.adoc
+++ b/migration_toolkit_for_containers/release_notes/mtc-release-notes.adoc
@@ -15,6 +15,8 @@ The {mtc-short} enables you to migrate application workloads between {product-ti
 
 For information on the support policy for {mtc-short}, see link:https://access.redhat.com/support/policy/updates/openshift#app_migration[OpenShift Application and Cluster Migration Solutions], part of the _Red Hat {product-title} Life Cycle Policy_.
 
+include::modules/migration-mtc-release-notes-1-8-14.adoc[leveloffset=+1]
+
 include::modules/migration-mtc-release-notes-1-8-13.adoc[leveloffset=+1]
 
 include::modules/migration-mtc-release-notes-1-8-12.adoc[leveloffset=+1]

--- a/modules/migration-mtc-release-notes-1-8-14.adoc
+++ b/modules/migration-mtc-release-notes-1-8-14.adoc
@@ -1,0 +1,30 @@
+// Module included in the following assemblies:
+//
+//
+// * migration_toolkit_for_containers/mtc-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="migration-mtc-release-notes-1-8-14_{context}"]
+= {mtc-full} 1.8.14 release notes
+
+[role="_abstract"]
+{mtc-first} 1.8.14 release notes list resolved issues.
+
+{mtc-short} 1.8.14 restores full support for {ocp} versions 4.12 and 4.13. This release realigns the {mtc-short} upgrade path across all supported OpenShift versions, ensuring a stable foundation for future updates.
+
+
+[id="resolved-issues-1-8-14_{context}"]
+== Resolved issues
+
+Fixed incompatible Operator versions due to an incorrect {ocp} 4.18 catalog update::
+Before this update, the {ocp} 4.18 Operators catalog was accidentally pushed to 4.12 and later versions. As a consequence, clusters on {ocp} versions 4.12-4.17 installed incompatible Operator versions. With this release, {mtc-short} 1.8 support is extended to {ocp} 4.12 and 4.13. As a result, the bug fix updates the {mtc-short} Operator to the correct version in {ocp} catalogs to provide updates for impacted customers.
++
+If you are on {ocp} 4.12 and 4.13, upgrade to {mtc-short} 1.8.14 as soon as possible to ensure continued support and access to future security patches.
++
+link:https://issues.redhat.com/browse/MIG-1874[MIG-1874]
+
+
+{mtc-short} Operator includes latest `rsync` version::
+Before this update, the {mtc-short} Operator mistakenly included an older version of the `rsync` package. This release updates the {mtc-short} Operator to include the latest `rsync` package.
++
+link:https://issues.redhat.com/browse/MIG-1876[MIG-1876]


### PR DESCRIPTION
Version(s):
OCP 4.14-4.21

Issue:
[MIG-1873](https://issues.redhat.com/browse/MIG-1873)

Link to docs preview:
- [Migration Toolkit for Containers 1.8.14 release notes](https://108259--ocpdocs-pr.netlify.app/openshift-enterprise/latest/migration_toolkit_for_containers/release_notes/mtc-release-notes.html#migration-mtc-release-notes-1-8-14_mtc-release-notes)

QE review:
- [x] QE has approved this change.

Changes:
Add MTC 1.8.14 Release Notes and update attributes.
