### PR TITLE
OSDOCS-18714:Update the z-stream RNs for 4.21.6

### DIFF
--- a/modules/zstream-4-21-6.adoc
+++ b/modules/zstream-4-21-6.adoc
@@ -1,0 +1,52 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-21-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-21-6_{context}"]
+= RHBA-2026:4420 - {product-title} {product-version}.6 fixed issues
+
+Issued: 17 March 2026
+
+[role="_abstract"]
+{product-title} release {product-version}.6 is now available. The list of fixed issues that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2026:4420[RHBA-2026:4420] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2026:4416[RHBA-2026:4416] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.21.6 --pullspecs
+----
+
+[id="zstream-4-21-6-known-issues_{context}"]
+== Known issues
+
+* In some {azure-first} configurations ({azure-short} private, public {azure-short} {product-title}, and private {azure-short} {product-title}), outbound connectivity is achieved through outbound rules that are connected to the backend address pool of the primary IP address of the VM network interface controller (NIC). Before this update, the Egress IP address was added to the public load balancer backend address pool when an `OutBoundRule` parameter was not specified. The Egress IP addresses are no longer added to the public load balancer backend pool for any {product-title} cluster hosted on {azure-short}, regardless of the existence of an `OutBoundRule` parameter. As a result, Egress IP addresses will have no outbound connectivity except for the infrastructure subnet in an {azure-short} {product-title} cluster. (link:https://redhat.atlassian.net/browse/OCPBUGS-77154[OCPBUGS-77154])
+
+[id="zstream-4-21-6-fixed-issues_{context}"]
+== Fixed issues
+
+* Before this update, the minimal collection profile did not include the `kube_pod_labels` metric. As a consequence, the status for the control plane was displayed as `unknown` on the web console. With this release, the `kube_pod_labels` metric is included. As a result, the displayed status for the control plane is correct. (link:https://redhat.atlassian.net/browse/OCPBUGS-74425[OCPBUGS-74425])
+
+* Before this update, the `IngressControllerDynamicConfigurationManager` feature gate was temporarily removed from the `TechPreviewNoUpgrade` feature set while a critical defect was being resolved. As a consequence, the dynamic configuration manager feature of the router was not available even as a `TechPreviewNoUpgrade` feature. With this release, the `IngressControllerDynamicConfigurationManager` feature gate is added back to the `TechPreviewNoUpgrade` feature set. As a result, the {product-title} router includes the dynamic configuration manager option on clusters that enable the `TechPreviewNoUpgrade` feature set. (link:https://redhat.atlassian.net/browse/OCPBUGS-76408[OCPBUGS-76408])
+
+* Before this update, control plane nodes with a root partition larger than 300 GB caused a boot failure of the nodes and stopped the cluster installation. With this release, the boot failure does not occur and the cluster installation is not stopped. (link:https://redhat.atlassian.net/browse/OCPBUGS-77536[OCPBUGS-77536])
+
+* Before this update, the `tmpfs` volume that stored the ostree image on the bootstrap node was too small to contain the entire image for the ppc64le architecture. With this release, the `tmpfs` size is increased to support the ppc64le architecture.  (link:https://redhat.atlassian.net/browse/OCPBUGS-77551[OCPBUGS-77551])
+
+* Before this update, faulty `vCenter` matching logic caused boot image update failures in multi center vSphere clusters. As a consequence, the Machine Config Operator (MCO) degraded when boot image updates were enabled for this scenario. With this update, the matching `vCenter` logic is fixed. As a result, boot image updates work as expected in 4.21 for multi center vSphere clusters. (link:https://redhat.atlassian.net/browse/OCPBUGS-77577[OCPBUGS-77577])
+
+* Before this update, `NetworkPolicy` egress rules hard-coded port 6443 for Kube API Server access. Because {hcp} allows custom API server ports through the `hostedcluster.spec.networking.apiServer.port` parameter, {olm-first} Operators failed to communicate with the Kube API Server in the hosted clusters, which used non-default API ports. As a consequence, the Operator functionality and catalog operations were broken. With this release, the hard-coded port 6443 is replaced with wildcard egress (*egress: [{}]*) for the Kube API Server traffic. Explicit DNS rules (ports 53, 5353) are also added for documentation and future policy refinements. As a result, {olm} supports {hcp} deployments with any configured API server port.  (link:https://redhat.atlassian.net/browse/OCPBUGS-77580[OCPBUGS-77580])
+
+* Before this update, `NetworkPolicy` egress rules in {olmv0-first} hard-coded port 6443 for Kube API Server access across static manifests and generated policies. Because {hcp} allows custom API server ports that differ from 6443, {olmv0} components (`olm-operator`, `catalog-operator`, and `packageserver`) did not communicate with the Kube API Server in hosted clusters that used custom API ports. As a consequence, this issue prevented Operator installation and catalog operations. With this release, `NetworkPolicy` egress rules are updated to use a wildcard (*egress: [{}]*) for Kube API Server traffic in both static manifests and dynamic policy generation code. Explicit DNS rules (ports 53, 5353) are also added for future policy refinements. As a result, {olmv0} supports {hcp} deployments with any configured API server port. (link:https://redhat.atlassian.net/browse/OCPBUGS-77712[OCPBUGS-77712])
+
+* Before this update, the `olm` cluster Operator did not detect version changes during cluster upgrades. As a consequence, the Operator failed to report the `Progressing=True` status during upgrades, which prevented accurate upgrade monitoring. With this release, a new version detection logic compares the release version with the stored Operator version and sets the `Progressing=True` status when an upgrade is detected. As a result, the Operator correctly reports the Progressing status during upgrades, which improves upgrade observability. (link:https://redhat.atlassian.net/browse/OCPBUGS-77826[OCPBUGS-77826])
+
+* Before this update, when you clicked the *Add access* button on the *Project access* tab on the *Project* details page while in the *Developer* perspective, the *Save* button was disabled and a potential error occurred. With this release, the *Project access* tab works as expected. (link:https://redhat.atlassian.net/browse/OCPBUGS-77882[OCPBUGS-77882])
+
+[id="zstream-4-21-6-updating_{context}"]
+== Updating
+
+To update an {product-title} 4.21 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].

--- a/release_notes/ocp-4-21-release-notes.adoc
+++ b/release_notes/ocp-4-21-release-notes.adoc
@@ -44,9 +44,11 @@ include::modules/rn-ocp-release-notes-known-issues.adoc[leveloffset=+1]
 // Asynchronous errata updates
 include::modules/rn-async-errata.adoc[leveloffset=+1]
 
+// 4.21.6 RNs and updating
+include::modules/zstream-4-21-6.adoc[leveloffset=+2]
+
 // 4.21.5 RNs and updating
 include::modules/zstream-4-21-5.adoc[leveloffset=+2]
-
 
 // 4.21.4 RNs and updating
 include::modules/zstream-4-21-4.adoc[leveloffset=+2]


### PR DESCRIPTION
Version(s):
4.21

Issue:
https://issues.redhat.com/browse/OSDOCS-18714

Link to docs preview:
https://108274--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-21-release-notes.html#zstream-4-21-6_release-notes

Additional information:
4.21.6 MR: https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/404
ART Dashboard: https://art-dash.engineering.redhat.com/dashboard/release/openshift-4.21