### PR TITLE
OSDOCS 18571 [Docs] Explain admin-ack remediation in 4.21 bootimage update docs

### DIFF
--- a/modules/mco-update-boot-images-configuring.adoc
+++ b/modules/mco-update-boot-images-configuring.adoc
@@ -26,7 +26,12 @@ Enabling the feature updates the boot image to the {op-system-first} boot image 
 
 .Prerequisites
 
-* If you are enabling boot image management for control plane machine sets, you enabled the required Technology Preview features for your cluster by editing the `FeatureGate` CR named `cluster`.
+* If you are enabling boot image management for control plane machine sets, you enabled the required Technology Preview features for your cluster by adding the `TechPreviewNoUpgrade` feature set to the `FeatureGate` CR named `cluster`. For information about enabling Feature Gates, see _Enabling features using feature gates_.
++
+[WARNING]
+====
+Enabling the `TechPreviewNoUpgrade` feature set on your cluster cannot be undone and prevents minor version updates. This feature set allows you to enable these Technology Preview features on test clusters, where you can fully test them. Do not enable this feature set on production clusters.
+====
 
 .Procedure
 
@@ -64,14 +69,14 @@ spec:
 --
 where:
 
-`spec.managedBootImages`:: Configures the boot image management feature.
+`spec.managedBootImages`:: Specifies the parameters for the boot image management feature.
 
 `spec.managedBootImages.machineManagers.apiGroup`:: Specifies the API group. This must be `machine.openshift.io`. 
 
 `spec.managedBootImages.machineManagers.resource`:: Specifies the resource within the specified API group to apply the change. Use one or both of the following parameters. You must add the full stanza, as shown, if you want to enable the feature for control plane and worker machine sets.
 
-* `controlplanemachinesets`: Enables boot image management for control plane machine sets.
-* `machinesets`: Enables boot image management for worker machine sets.
+* `controlplanemachinesets`: Specifies that the `selection.mode` parameter applies to control plane nodes.
+* `machinesets`: Specifies that the `selection.mode` parameter applies to compute nodes.
 
 `spec.managedBootImages.machineManagers.selection.mode`:: Specifies that the feature is enabled for all machine sets in the cluster. 
 --
@@ -101,7 +106,7 @@ spec:
 --
 where:
 
-`spec.managedBootImages`:: Configures the boot image management feature.
+`spec.managedBootImages`:: Specifies the parameters for the boot image management feature.
 
 `spec.managedBootImages.machineManagers.apiGroup`:: Specifies the API group. This must be `machine.openshift.io`. 
 

--- a/modules/mco-update-boot-images-disable.adoc
+++ b/modules/mco-update-boot-images-disable.adoc
@@ -10,6 +10,22 @@
 [role="_abstract"]
 You can disable the boot image management feature so that the Machine Config Operator (MCO) no longer manages or updates the boot image in the affected machine sets. For example, you could disable this feature for the worker nodes in order to use a custom boot image that you do not want changed.
 
+[NOTE]
+====
+If you are updating an {azure-first} or {vmw-first} cluster from {product-title} 4.21 to 4.22, and you have not configured the `managedBootImages` parameter, the update is blocked with a _This cluster is Azure or vSphere but lacks a boot image configuration._ message. The update is blocked intentionally on {azure-short} or {vmw-short} clusters in order to alert you that the default updated boot image behavior is changing between version 4.21 and 4.22 to enable updated boot images by default on those platforms.
+
+To allow the update, perform one of the following tasks:
+
+* If you want to allow the feature to be enabled, acknowledge that you are aware of the change in the default behavior by patching the `admin-acks` config map by running the following command:
++
+[source,terminal]
+----
+$ oc -n openshift-config patch cm admin-acks --patch '{"data":{"ack-4.21-boot-image-opt-out-in-4.22":"true"}}' --type=merge
+----
+
+* If you do not want the updated boot image feature enabled, explicitly disable the feature for compute nodes by using the following procedure.
+====
+
 You disable the boot image management feature for the control plane or worker machine sets in your cluster by editing the `MachineConfiguration` object.
 
 [NOTE]
@@ -17,9 +33,21 @@ You disable the boot image management feature for the control plane or worker ma
 include::snippets/mco-update-boot-images-intro.adoc[]
 ====
 
+:FeatureName: Boot image management for control plane nodes
+include::snippets/technology-preview.adoc[]
+
 Disabling this feature does not rollback the nodes or machine sets to the originally-installed boot image. The machine sets retain the boot image version that was present when the feature was disabled and is not updated if the cluster is upgraded to a new {product-title} version in the future. This feature has no effect on existing nodes.
 
 After disabling the feature, you can re-enable the feature at any time. For more information, see "Enabling updated boot images".
+
+.Prerequisites
+
+* If you are disabling boot image management for control plane machine sets, you enabled the required Technology Preview features for your cluster by adding the `TechPreviewNoUpgrade` feature set to the `FeatureGate` CR named `cluster`. For information about enabling Feature Gates, see _Enabling features using feature gates_.
++
+[WARNING]
+====
+Enabling the `TechPreviewNoUpgrade` feature set on your cluster cannot be undone and prevents minor version updates. This feature set allows you to enable these Technology Preview features on test clusters, where you can fully test them. Do not enable this feature set on production clusters.
+====
 
 .Procedure
 
@@ -30,7 +58,9 @@ After disabling the feature, you can re-enable the feature at any time. For more
 $ oc edit MachineConfiguration cluster
 ----
 
-. Disable the feature for some or all of your machine sets:
+. Disable the feature for some or all of your machine sets by making one or both of the following changes:
+
+* Disable the feature for nodes in the worker machine sets by adding the following parameters:
 +
 [source,yaml]
 ----
@@ -46,6 +76,32 @@ spec:
       resource: machinesets
       selection:
         mode: None
+----
++
+--
+where:
+
+`spec.managedBootImages`:: Specifies the parameters for the boot image management feature.
+
+`spec.managedBootImages.machineManagers.apiGroup`:: Specifies the API group. This must be `machine.openshift.io`. 
+
+`spec.managedBootImages.machineManagers.resource.machinesets`:: Specifies that the `selection.mode` parameter applies to compute nodes.
+
+`spec.managedBootImages.machineManagers.selection.mode.None`:: Specifies that the feature is disabled for the specified machine sets. 
+--
+
+* Disable the feature for nodes in the control plane machine sets by adding the following parameters:
++
+[source,yaml]
+----
+apiVersion: operator.openshift.io/v1
+kind: MachineConfiguration
+metadata:
+  name: cluster
+spec:
+# ...
+  managedBootImages:
+    machineManagers:
     - apiGroup: machine.openshift.io
       resource: controlplanemachinesets
       selection:
@@ -55,14 +111,15 @@ spec:
 --
 where:
 
-`spec.managedBootImages`:: Configures the boot image management feature.
+`spec.managedBootImages`:: Specifies the parameters for the boot image management feature.
 
-`spec.managedBootImages.machineManagers.selection.mode.None`:: Specifies that the feature is disabled for all machine sets in the cluster. Set the selection mode to `None` for one or both of the following resources to disable the feature for that resource.
+`spec.managedBootImages.machineManagers.apiGroup`:: Specifies the API group. This must be `machine.openshift.io`. 
 
-* `controlplanemachinesets`: Disable boot image management for control plane machine sets.
+`spec.managedBootImages.machineManagers.resource.controlplanemachinesets`:: Specifies that the `selection.mode` parameter applies to control plane nodes.
 
-* `machinesets`: Disables boot image management for worker machine sets.
+`spec.managedBootImages.machineManagers.selection.mode.None`:: Specifies that the feature is disabled for the specified machine sets. 
 --
+
 
 ////
 Hiding per djoshy https://github.com/openshift/openshift-docs/pull/93065#pullrequestreview-2844549815


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-18571

Link to docs preview:
[Enabling boot image management](https://108279--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_configuration/mco-update-boot-images.html#mco-update-boot-images-configuring_machine-configs-configure) -- Added TP warning block, which I missed when I added the feature in 4.21. Updated callouts to use "Specifies" wording.
[Disabling boot image management](https://108279--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_configuration/mco-update-boot-images.html#mco-update-boot-images-disable_machine-configs-configure) -- Added admin ack note, TP snippet (for users coming from admin ack link in the web console), TP prereq (which I missed when I added the feature in 4.21), split the disable step into control plane and worker node substeps, as admin ack users can/must disable only the worker nodes).

Merge to 4.21, manually cherrypick to main and 4.22 anything that is not related to the admin ack.

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->