### PR TITLE
DITA rework: installing/installing_sno/install-sno-installing-sno.adoc

### DIFF
--- a/installing/installing_sno/install-sno-installing-sno.adoc
+++ b/installing/installing_sno/install-sno-installing-sno.adoc
@@ -80,9 +80,9 @@ include::modules/install-sno-generating-the-install-iso-manually.adoc[leveloffse
 [role="_additional-resources"]
 .Additional resources
 
-* See xref:../../installing/installing_sno/install-sno-preparing-to-install-sno.adoc#preparing-to-install-sno[Requirements for installing OpenShift on a single node] for more information about installing {product-title} on a single node.
-* See xref:../../installing/overview/cluster-capabilities.adoc#cluster-capabilities[Cluster capabilities] for more information about enabling cluster capabilities that were disabled before installation.
-* See xref:../../installing/overview/cluster-capabilities.adoc#explanation_of_capabilities_cluster-capabilities[Optional cluster capabilities in {product-title} {product-version}] for more information about the features provided by each capability.
+* xref:../../installing/installing_sno/install-sno-preparing-to-install-sno.adoc#preparing-to-install-sno[Requirements for installing OpenShift on a single node]
+* xref:../../installing/overview/cluster-capabilities.adoc#cluster-capabilities[Cluster capabilities]
+* xref:../../installing/overview/cluster-capabilities.adoc#explanation_of_capabilities_cluster-capabilities[Optional cluster capabilities in {product-title} {product-version}]
 
 // Monitoring the cluster installation using openshift-install
 include::modules/install-sno-monitoring-the-installation-manually.adoc[leveloffset=+2]

--- a/installing/installing_sno/install-sno-installing-sno.adoc
+++ b/installing/installing_sno/install-sno-installing-sno.adoc
@@ -7,6 +7,7 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 ifndef::openshift-origin[]
+[role="_abstract"]
 You can install {sno} by using either the web-based Assisted Installer or the `coreos-installer` tool to generate a discovery ISO image. The discovery ISO image writes the {op-system-first} system configuration to the target installation disk, so that you can run a single-cluster node to meet your needs.
 
 Consider using {sno} when you want to run a cluster in a low-resource or an isolated environment for testing, troubleshooting, training, or small-scale project purposes.
@@ -31,15 +32,7 @@ include::modules/install-sno-installing-with-the-assisted-installer.adoc[levelof
 endif::openshift-origin[]
 
 ifdef::openshift-origin[]
-[id="installing-sno-assisted-installer"]
-== Installing {sno-okd} using the Assisted Service
-
-[role="_additional-resources"]
-.Additional resources
-
-* link:https://github.com/openshift/assisted-service/tree/master/deploy/podman#okd-configuration[Install OKD using Assisted Service]
-* xref:../../installing/installing_sno/install-sno-installing-sno.adoc#installing-with-usb-media_install-sno-installing-sno-with-the-assisted-installer[Creating a bootable ISO image on a USB drive]
-* xref:../../nodes/nodes/nodes-sno-worker-nodes.adoc#nodes-sno-worker-nodes[Adding worker nodes to {sno-okd} clusters]
+include::modules/con_install-sno-okd-assisted-service.adoc[leveloffset=+1]
 endif::openshift-origin[]
 
 ifndef::openshift-origin[]
@@ -51,25 +44,7 @@ ifndef::openshift-origin[]
 * xref:../../nodes/nodes/nodes-sno-worker-nodes.adoc#nodes-sno-worker-nodes[Adding worker nodes to {sno} clusters]
 endif::openshift-origin[]
 
-ifndef::openshift-origin[]
-[id="install-sno-installing-sno-manually"]
-== Installing {sno} manually
-endif::openshift-origin[]
-ifdef::openshift-origin[]
-[id="install-sno-installing-sno-manually"]
-== Installing {sno-okd} manually
-endif::openshift-origin[]
-
-To install {product-title} on a single node, first generate the installation ISO, and then boot the server from the ISO. You can monitor the installation using the `openshift-install` installation program.
-
-[role="_additional-resources"]
-.Additional resources
-
-* xref:../../installing/installing_bare_metal/upi/installing-bare-metal-network-customizations.adoc#installation-network-user-infra_installing-bare-metal-network-customizations[Networking requirements for user-provisioned infrastructure]
-
-* xref:../../installing/installing_bare_metal/upi/installing-bare-metal-network-customizations.adoc#installation-dns-user-infra_installing-bare-metal-network-customizations[User-provisioned DNS requirements]
-
-* xref:../../installing/installing_bare_metal/upi/installing-bare-metal-network-customizations.adoc#configuring-dhcp-or-static-ip-addresses_installing-bare-metal-network-customizations[Configuring DHCP or static IP addresses]
+include::modules/con_install-sno-installing-manually.adoc[leveloffset=+1]
 
 include::modules/install-sno-generating-the-install-iso-manually.adoc[leveloffset=+2]
 
@@ -89,20 +64,13 @@ include::modules/install-sno-monitoring-the-installation-manually.adoc[leveloffs
 * xref:../../installing/installing_sno/install-sno-installing-sno.adoc#installing-with-usb-media_install-sno-installing-sno-with-the-assisted-installer[Creating a bootable ISO image on a USB drive]
 ifndef::openshift-origin[]
 * xref:../../installing/installing_sno/install-sno-installing-sno.adoc#install-booting-from-an-iso-over-http-redfish_install-sno-installing-sno-with-the-assisted-installer[Booting from an HTTP-hosted ISO image using the Redfish API]
-endif::openshift-origin[]
-ifndef::openshift-origin[]
 * xref:../../nodes/nodes/nodes-sno-worker-nodes.adoc#nodes-sno-worker-nodes[Adding worker nodes to {sno} clusters]
-
-[id="install-sno-installing-sno-on-cloud-providers"]
-== Installing {sno} on cloud providers
 endif::openshift-origin[]
-
 ifdef::openshift-origin[]
 * xref:../../nodes/nodes/nodes-sno-worker-nodes.adoc#nodes-sno-worker-nodes[Adding worker nodes to {sno-okd} clusters]
-
-[id="install-sno-installing-sno-on-cloud-providers"]
-== Installing {sno-okd} on cloud providers
 endif::openshift-origin[]
+
+include::modules/con_install-sno-on-cloud-providers.adoc[leveloffset=+1]
 
 include::modules/install-sno-additional-requirements-for-installing-sno-on-a-cloud-provider.adoc[leveloffset=+2]
 
@@ -137,25 +105,9 @@ include::modules/install-booting-from-an-iso-over-http-redfish.adoc[leveloffset=
 
 include::modules/creating-custom-live-rhcos-iso.adoc[leveloffset=+1]
 
-[id="install-sno-with-ibm-z"]
-== Installing {sno} with {ibm-z-title} and {ibm-linuxone-title}
+include::modules/con_install-sno-with-ibm-z.adoc[leveloffset=+1]
 
-Installing a single-node cluster on {ibm-z-name} and {ibm-linuxone-name} requires user-provisioned installation using one of the available procedures: z/VM, {op-system-base} KVM, or LPAR installation.
-
-[NOTE]
-====
-Installing a single-node cluster on {ibm-z-name} simplifies installation for development and test environments and requires less resource requirements at entry level.
-====
-
-=== Hardware requirements
-
-* The equivalent of two Integrated Facilities for Linux (IFL), which are SMT2 enabled, for each cluster.
-* At least one network connection to both connect to the `LoadBalancer` service and to serve data for traffic outside the cluster.
-
-[NOTE]
-====
-You can use dedicated or shared IFLs to assign sufficient compute resources. Resource sharing is one of the key strengths of {ibm-z-name}. However, you must adjust capacity correctly on each hypervisor layer and ensure sufficient resources for every {product-title} cluster.
-====
+include::modules/ref_install-sno-ibm-z-hardware-requirements.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
 .Additional resources
@@ -170,26 +122,9 @@ include::modules/install-sno-ibm-z-kvm.adoc[leveloffset=+2]
 
 include::modules/install-sno-ibm-z-lpar.adoc[leveloffset=+2]
 
-[id="installing-sno-with-ibmpower"]
-== Installing {sno} with {ibm-power-title}
+include::modules/con_install-sno-with-ibm-power.adoc[leveloffset=+1]
 
-Installing a single-node cluster on {ibm-power-name} requires user-provisioned installation using the "Installing a cluster with {ibm-power-name}" procedure.
-
-[NOTE]
-====
-Installing a single-node cluster on {ibm-power-name} simplifies installation for development and test environments and requires less resource requirements at entry level.
-====
-
-
-=== Hardware requirements
-
-* The equivalent of two Integrated Facilities for Linux (IFL), which are SMT2 enabled, for each cluster.
-* At least one network connection to connect to the `LoadBalancer` service and to serve data for traffic outside of the cluster.
-
-[NOTE]
-====
-You can use dedicated or shared IFLs to assign sufficient compute resources. Resource sharing is one of the key strengths of {ibm-power-name}. However, you must adjust capacity correctly on each hypervisor layer and ensure sufficient resources for every {product-title} cluster.
-====
+include::modules/ref_install-sno-ibm-power-hardware-requirements.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
 .Additional resources

--- a/installing/installing_sno/install-sno-installing-sno.adoc
+++ b/installing/installing_sno/install-sno-installing-sno.adoc
@@ -16,13 +16,12 @@ Consider using {sno} when you want to run a cluster in a low-resource or an isol
 
 To install {product-title} on a single node, use the web-based Assisted Installer wizard to guide you through the process and manage the installation.
 
-See the link:https://access.redhat.com/documentation/en-us/assisted_installer_for_openshift_container_platform/[Assisted Installer for {product-title}] documentation for details and configuration options.
-
 include::modules/install-sno-generating-the-discovery-iso-with-the-assisted-installer.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
 .Additional resources
 
+* link:https://access.redhat.com/documentation/en-us/assisted_installer_for_openshift_container_platform/[Assisted Installer for {product-title}]
 * xref:../../storage/persistent_storage_local/persistent-storage-using-lvms.adoc#persistent-storage-using-lvms_logical-volume-manager-storage[Persistent storage using logical volume manager storage]
 * xref:../../virt/about_virt/about-virt.adoc#virt-what-you-can-do-with-virt_about-virt[What you can do with OpenShift Virtualization]
 
@@ -37,22 +36,23 @@ You can install {sno-okd} using the Assisted Service or you can generate an inst
 [id="installing-sno-assisted-installer"]
 == Installing {sno-okd} using the Assisted Service
 
-To install {sno-okd} with the Assisted Service, please refer to the following documentation:
-* link:https://github.com/openshift/assisted-service/tree/master/deploy/podman#okd-configuration[Install OKD using Assisted Service]
-endif::openshift-origin[]
+To install {sno-okd} with the Assisted Service, refer to the OKD documentation.
 
 [role="_additional-resources"]
 .Additional resources
 
+* link:https://github.com/openshift/assisted-service/tree/master/deploy/podman#okd-configuration[Install OKD using Assisted Service]
 * xref:../../installing/installing_sno/install-sno-installing-sno.adoc#installing-with-usb-media_install-sno-installing-sno-with-the-assisted-installer[Creating a bootable ISO image on a USB drive]
-
-ifndef::openshift-origin[]
-* xref:../../installing/installing_sno/install-sno-installing-sno.adoc#install-booting-from-an-iso-over-http-redfish_install-sno-installing-sno-with-the-assisted-installer[Booting from an HTTP-hosted ISO image using the Redfish API]
-* xref:../../nodes/nodes/nodes-sno-worker-nodes.adoc#nodes-sno-worker-nodes[Adding worker nodes to {sno} clusters]
+* xref:../../nodes/nodes/nodes-sno-worker-nodes.adoc#nodes-sno-worker-nodes[Adding worker nodes to {sno-okd} clusters]
 endif::openshift-origin[]
 
-ifdef::openshift-origin[]
-* xref:../../nodes/nodes/nodes-sno-worker-nodes.adoc#nodes-sno-worker-nodes[Adding worker nodes to {sno-okd} clusters]
+ifndef::openshift-origin[]
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../installing/installing_sno/install-sno-installing-sno.adoc#installing-with-usb-media_install-sno-installing-sno-with-the-assisted-installer[Creating a bootable ISO image on a USB drive]
+* xref:../../installing/installing_sno/install-sno-installing-sno.adoc#install-booting-from-an-iso-over-http-redfish_install-sno-installing-sno-with-the-assisted-installer[Booting from an HTTP-hosted ISO image using the Redfish API]
+* xref:../../nodes/nodes/nodes-sno-worker-nodes.adoc#nodes-sno-worker-nodes[Adding worker nodes to {sno} clusters]
 endif::openshift-origin[]
 
 ifndef::openshift-origin[]
@@ -144,17 +144,12 @@ include::modules/creating-custom-live-rhcos-iso.adoc[leveloffset=+1]
 [id="install-sno-with-ibm-z"]
 == Installing {sno} with {ibm-z-title} and {ibm-linuxone-title}
 
-Installing a single-node cluster on {ibm-z-name} and {ibm-linuxone-name} requires user-provisioned installation using one of the following procedures:
-
-* xref:../../installing/installing_ibm_z/upi/installing-ibm-z.adoc#installing-ibm-z[Installing a cluster with z/VM on {ibm-z-name} and {ibm-linuxone-name}]
-* xref:../../installing/installing_ibm_z/upi/installing-ibm-z-kvm.adoc#installing-ibm-z-kvm[Installing a cluster with {op-system-base} KVM on {ibm-z-name} and {ibm-linuxone-name}]
-* xref:../../installing/installing_ibm_z/upi/installing-ibm-z-lpar.adoc#installing-ibm-z-lpar[Installing a cluster in an LPAR on {ibm-z-name} and {ibm-linuxone-name}]
+Installing a single-node cluster on {ibm-z-name} and {ibm-linuxone-name} requires user-provisioned installation using one of the available procedures: z/VM, {op-system-base} KVM, or LPAR installation.
 
 [NOTE]
 ====
 Installing a single-node cluster on {ibm-z-name} simplifies installation for development and test environments and requires less resource requirements at entry level.
 ====
-
 
 === Hardware requirements
 
@@ -165,6 +160,13 @@ Installing a single-node cluster on {ibm-z-name} simplifies installation for dev
 ====
 You can use dedicated or shared IFLs to assign sufficient compute resources. Resource sharing is one of the key strengths of {ibm-z-name}. However, you must adjust capacity correctly on each hypervisor layer and ensure sufficient resources for every {product-title} cluster.
 ====
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../installing/installing_ibm_z/upi/installing-ibm-z.adoc#installing-ibm-z[Installing a cluster with z/VM on {ibm-z-name} and {ibm-linuxone-name}]
+* xref:../../installing/installing_ibm_z/upi/installing-ibm-z-kvm.adoc#installing-ibm-z-kvm[Installing a cluster with {op-system-base} KVM on {ibm-z-name} and {ibm-linuxone-name}]
+* xref:../../installing/installing_ibm_z/upi/installing-ibm-z-lpar.adoc#installing-ibm-z-lpar[Installing a cluster in an LPAR on {ibm-z-name} and {ibm-linuxone-name}]
 
 include::modules/install-sno-ibm-z.adoc[leveloffset=+2]
 

--- a/installing/installing_sno/install-sno-installing-sno.adoc
+++ b/installing/installing_sno/install-sno-installing-sno.adoc
@@ -31,12 +31,8 @@ include::modules/install-sno-installing-with-the-assisted-installer.adoc[levelof
 endif::openshift-origin[]
 
 ifdef::openshift-origin[]
-You can install {sno-okd} using the Assisted Service or you can generate an installation ISO using `openshift-installer`.
-
 [id="installing-sno-assisted-installer"]
 == Installing {sno-okd} using the Assisted Service
-
-To install {sno-okd} with the Assisted Service, refer to the OKD documentation.
 
 [role="_additional-resources"]
 .Additional resources

--- a/modules/con_install-sno-installing-manually.adoc
+++ b/modules/con_install-sno-installing-manually.adoc
@@ -1,0 +1,17 @@
+// Module included in the following assemblies:
+//
+// * installing/installing_sno/install-sno-installing-sno.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="install-sno-installing-sno-manually_{context}"]
+= Installing single-node OpenShift manually
+
+[role="_abstract"]
+To install {product-title} on a single node, first generate the installation ISO, and then boot the server from the ISO. You can monitor the installation using the `openshift-install` installation program.
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../installing/installing_bare_metal/upi/installing-bare-metal-network-customizations.adoc#installation-network-user-infra_installing-bare-metal-network-customizations[Networking requirements for user-provisioned infrastructure]
+* xref:../../installing/installing_bare_metal/upi/installing-bare-metal-network-customizations.adoc#installation-dns-user-infra_installing-bare-metal-network-customizations[User-provisioned DNS requirements]
+* xref:../../installing/installing_bare_metal/upi/installing-bare-metal-network-customizations.adoc#configuring-dhcp-or-static-ip-addresses_installing-bare-metal-network-customizations[Configuring DHCP or static IP addresses]

--- a/modules/con_install-sno-okd-assisted-service.adoc
+++ b/modules/con_install-sno-okd-assisted-service.adoc
@@ -1,0 +1,17 @@
+// Module included in the following assemblies:
+//
+// * installing/installing_sno/install-sno-installing-sno.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="install-sno-okd-assisted-service_{context}"]
+= Installing {sno-okd} using the Assisted Service
+
+[role="_abstract"]
+You can install {sno-okd} using the Assisted Service deployed locally with Podman.
+
+[role="_additional-resources"]
+.Additional resources
+
+* link:https://github.com/openshift/assisted-service/tree/master/deploy/podman#okd-configuration[Install OKD using Assisted Service]
+* xref:../../installing/installing_sno/install-sno-installing-sno.adoc#installing-with-usb-media_install-sno-installing-sno-with-the-assisted-installer[Creating a bootable ISO image on a USB drive]
+* xref:../../nodes/nodes/nodes-sno-worker-nodes.adoc#nodes-sno-worker-nodes[Adding worker nodes to {sno-okd} clusters]

--- a/modules/con_install-sno-on-cloud-providers.adoc
+++ b/modules/con_install-sno-on-cloud-providers.adoc
@@ -1,0 +1,10 @@
+// Module included in the following assemblies:
+//
+// * installing/installing_sno/install-sno-installing-sno.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="install-sno-installing-sno-on-cloud-providers_{context}"]
+= Installing single-node OpenShift on cloud providers
+
+[role="_abstract"]
+You can install single-node OpenShift on supported cloud providers. Review the requirements and provider-specific instructions for your target cloud environment.

--- a/modules/con_install-sno-with-ibm-power.adoc
+++ b/modules/con_install-sno-with-ibm-power.adoc
@@ -1,0 +1,15 @@
+// Module included in the following assemblies:
+//
+// * installing/installing_sno/install-sno-installing-sno.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="installing-sno-with-ibmpower_{context}"]
+= Installing {sno} with {ibm-power-title}
+
+[role="_abstract"]
+Installing a single-node cluster on {ibm-power-name} requires user-provisioned installation using the "Installing a cluster with {ibm-power-name}" procedure.
+
+[NOTE]
+====
+Installing a single-node cluster on {ibm-power-name} simplifies installation for development and test environments and requires less resource requirements at entry level.
+====

--- a/modules/con_install-sno-with-ibm-z.adoc
+++ b/modules/con_install-sno-with-ibm-z.adoc
@@ -1,0 +1,15 @@
+// Module included in the following assemblies:
+//
+// * installing/installing_sno/install-sno-installing-sno.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="install-sno-with-ibm-z_{context}"]
+= Installing {sno} with {ibm-z-title} and {ibm-linuxone-title}
+
+[role="_abstract"]
+Installing a single-node cluster on {ibm-z-name} and {ibm-linuxone-name} requires user-provisioned installation using one of the available procedures: z/VM, {op-system-base} KVM, or LPAR installation.
+
+[NOTE]
+====
+Installing a single-node cluster on {ibm-z-name} simplifies installation for development and test environments and requires less resource requirements at entry level.
+====

--- a/modules/creating-custom-live-rhcos-iso.adoc
+++ b/modules/creating-custom-live-rhcos-iso.adoc
@@ -6,6 +6,7 @@
 [id="create-custom-live-rhcos-iso_{context}"]
 = Creating a custom live {op-system} ISO for remote server access
 
+[role="_abstract"]
 In some cases, you cannot attach an external disk drive to a server, however, you need to access the server remotely to provision a node.
 It is recommended to enable SSH access to the server.
 You can create a live {op-system} ISO with SSHd enabled and with predefined credentials so that you can access the server after it boots.
@@ -32,11 +33,14 @@ metadata:
     machineconfiguration.openshift.io/role: worker
 passwd:
   users:
-    - name: core <1>
+    - name: <username>
       ssh_authorized_keys:
         - '<ssh_key>'
 ----
-<1> The `core` user has sudo privileges.
++
+where:
++
+`<username>`:: Specifies the username. The `core` user has sudo privileges.
 
 . Run the `butane` utility to create the Ignition file using the following command:
 +

--- a/modules/install-booting-from-an-iso-over-http-redfish.adoc
+++ b/modules/install-booting-from-an-iso-over-http-redfish.adoc
@@ -6,6 +6,7 @@
 [id="install-booting-from-an-iso-over-http-redfish_{context}"]
 = Booting from an HTTP-hosted ISO image using the Redfish API
 
+[role="_abstract"]
 You can provision hosts in your network using ISOs that you install using the Redfish Baseboard Management Controller (BMC) API.
 
 [NOTE]

--- a/modules/install-sno-additional-requirements-for-installing-sno-on-a-cloud-provider.adoc
+++ b/modules/install-sno-additional-requirements-for-installing-sno-on-a-cloud-provider.adoc
@@ -7,6 +7,7 @@
 ifndef::openshift-origin[]
 = Additional requirements for installing {sno} on a cloud provider
 
+[role="_abstract"]
 The documentation for installer-provisioned installation on cloud providers is based on a high availability cluster consisting of three control plane nodes. When referring to the documentation, consider the differences between the requirements for a {sno} cluster and a high availability cluster.
 
 * A high availability cluster requires a temporary bootstrap machine, three control plane machines, and at least two compute machines. For a {sno} cluster, you need only a temporary bootstrap machine and one cloud instance for the control plane node and no compute nodes.

--- a/modules/install-sno-generating-the-discovery-iso-with-the-assisted-installer.adoc
+++ b/modules/install-sno-generating-the-discovery-iso-with-the-assisted-installer.adoc
@@ -6,6 +6,7 @@
 [id="install-sno-generating-the-discovery-iso-with-the-assisted-installer_{context}"]
 = Generating the discovery ISO with the Assisted Installer
 
+[role="_abstract"]
 Installing {product-title} on a single node requires a discovery ISO, which the Assisted Installer can generate.
 
 .Procedure

--- a/modules/install-sno-generating-the-install-iso-manually.adoc
+++ b/modules/install-sno-generating-the-install-iso-manually.adoc
@@ -21,40 +21,28 @@ See "Requirements for installing OpenShift on a single node" for networking requ
 .Procedure
 
 ifndef::openshift-origin[]
-. Set the {product-title} version:
+. Set the {product-title} version by running the following command, replacing `<ocp_version>` with the current version, for example, `latest-{product-version}`:
 +
 [source,terminal]
 ----
 $ export OCP_VERSION=<ocp_version>
 ----
-+
-where:
-+
-`<ocp_version>`:: Specifies the current version, for example, `latest-{product-version}`.
 endif::openshift-origin[]
 ifdef::openshift-origin[]
-. Set the {product-title} version:
+. Set the {product-title} version by running the following command, replacing `<okd_version>` with the current version, for example, `4.14.0-0.okd-2024-01-26-175629`:
 +
 [source,terminal]
 ----
 $ OKD_VERSION=<okd_version>
 ----
-+
-where:
-+
-`<okd_version>`:: Specifies the current version, for example, `4.14.0-0.okd-2024-01-26-175629`.
 endif::openshift-origin[]
 
-. Set the host architecture:
+. Set the host architecture by running the following command, replacing `<architecture>` with the target host architecture, for example, `aarch64` or `x86_64`:
 +
 [source,terminal]
 ----
 $ export ARCH=<architecture>
 ----
-+
-where:
-+
-`<architecture>`:: Specifies the target host architecture, for example, `aarch64` or `x86_64`.
 
 ifndef::openshift-origin[]
 . Download the {product-title} client (`oc`) and make it available for use by entering the following commands:

--- a/modules/install-sno-generating-the-install-iso-manually.adoc
+++ b/modules/install-sno-generating-the-install-iso-manually.adoc
@@ -163,7 +163,7 @@ pullSecret: '<pull_secret>'
 sshKey: |
   <ssh_key>
 ----
-
++
 where:
 
 `<domain>`:: Specifies the cluster domain name.

--- a/modules/install-sno-generating-the-install-iso-manually.adoc
+++ b/modules/install-sno-generating-the-install-iso-manually.adoc
@@ -6,6 +6,7 @@
 [id="generating-the-install-iso-manually_{context}"]
 = Generating the installation ISO with coreos-installer
 
+[role="_abstract"]
 Installing {product-title} on a single node requires an installation ISO, which you can generate with the following procedure.
 
 .Prerequisites
@@ -24,29 +25,36 @@ ifndef::openshift-origin[]
 +
 [source,terminal]
 ----
-$ export OCP_VERSION=<ocp_version> <1>
+$ export OCP_VERSION=<ocp_version>
 ----
 +
-<1> Replace `<ocp_version>` with the current version, for example, `latest-{product-version}`
+where:
++
+`<ocp_version>`:: Specifies the current version, for example, `latest-{product-version}`.
 endif::openshift-origin[]
 ifdef::openshift-origin[]
 . Set the {product-title} version:
 +
 [source,terminal]
 ----
-$ OKD_VERSION=<okd_version> <1>
+$ OKD_VERSION=<okd_version>
 ----
 +
-<1> Replace `<okd_version>` with the current version, for example, `4.14.0-0.okd-2024-01-26-175629`
+where:
++
+`<okd_version>`:: Specifies the current version, for example, `4.14.0-0.okd-2024-01-26-175629`.
 endif::openshift-origin[]
 
 . Set the host architecture:
 +
 [source,terminal]
 ----
-$ export ARCH=<architecture> <1>
+$ export ARCH=<architecture>
 ----
-<1> Replace `<architecture>` with the target host architecture, for example, `aarch64` or `x86_64`.
++
+where:
++
+`<architecture>`:: Specifies the target host architecture, for example, `aarch64` or `x86_64`.
 
 ifndef::openshift-origin[]
 . Download the {product-title} client (`oc`) and make it available for use by entering the following commands:
@@ -141,46 +149,48 @@ endif::openshift-origin[]
 [source,yaml]
 ----
 apiVersion: v1
-baseDomain: <domain> <1>
+baseDomain: <domain>
 compute:
 - name: worker
-  replicas: 0 <2>
+  replicas: 0
 controlPlane:
   name: master
-  replicas: 1 <3>
+  replicas: 1
 metadata:
-  name: <name> <4>
-networking: <5>
+  name: <name>
+networking:
   clusterNetwork:
   - cidr: 10.128.0.0/14
     hostPrefix: 23
   machineNetwork:
-  - cidr: 10.0.0.0/16 <6>
+  - cidr: 10.0.0.0/16
   networkType: OVNKubernetes
   serviceNetwork:
   - 172.30.0.0/16
 platform:
   none: {}
 bootstrapInPlace:
-  installationDisk: /dev/disk/by-id/<disk_id> <7>
-pullSecret: '<pull_secret>' <8>
+  installationDisk: /dev/disk/by-id/<disk_id>
+pullSecret: '<pull_secret>'
 sshKey: |
-  <ssh_key> <9>
+  <ssh_key>
 ----
-<1> Add the cluster domain name.
-<2> Set the `compute` replicas to `0`. This makes the control plane node schedulable.
-<3> Set the `controlPlane` replicas to `1`. In conjunction with the previous `compute` setting, this setting ensures the cluster runs on a single node.
-<4> Set the `metadata` name to the cluster name.
-<5> Set the `networking` details. OVN-Kubernetes is the only allowed network plugin type for single-node clusters.
+
+where:
+
+`<domain>`:: Specifies the cluster domain name.
+`replicas: 0` (compute):: Sets the compute replicas to `0`. This makes the control plane node schedulable.
+`replicas: 1` (controlPlane):: Sets the controlPlane replicas to `1`. In conjunction with the previous compute setting, this setting ensures the cluster runs on a single node.
+`<name>`:: Specifies the cluster name in the metadata.
 ifndef::openshift-origin[]
-<6> Set the `cidr` value to match the subnet of the {sno} cluster.
+`cidr: 10.0.0.0/16`:: Sets the `cidr` value to match the subnet of the {sno} cluster. OVN-Kubernetes is the only allowed network plugin type for single-node clusters.
 endif::openshift-origin[]
 ifdef::openshift-origin[]
-<6> Set the `cidr` value to match the subnet of the {sno-okd} cluster.
+`cidr: 10.0.0.0/16`:: Sets the `cidr` value to match the subnet of the {sno-okd} cluster. OVN-Kubernetes is the only allowed network plugin type for single-node clusters.
 endif::openshift-origin[]
-<7> Set the path to the installation disk drive, for example, `/dev/disk/by-id/wwn-0x64cd98f04fde100024684cf3034da5c2`.
-<8> Copy the {cluster-manager-url-pull} and add the contents to this configuration setting.
-<9> Add the public SSH key from the administration host so that you can log in to the cluster after installation.
+`<disk_id>`:: Specifies the path to the installation disk drive, for example, `/dev/disk/by-id/wwn-0x64cd98f04fde100024684cf3034da5c2`.
+`<pull_secret>`:: Specifies your pull secret. Copy the {cluster-manager-url-pull} and add the contents to this configuration setting.
+`<ssh_key>`:: Specifies the public SSH key from the administration host so that you can log in to the cluster after installation.
 
 ifndef::openshift-origin[]
 . Generate {product-title} assets by running the following commands:

--- a/modules/install-sno-ibm-power.adoc
+++ b/modules/install-sno-ibm-power.adoc
@@ -6,13 +6,14 @@
 [id="installing-sno-on-ibm-power_{context}"]
 = Installing {sno} with {ibm-power-title}
 
+[role="_abstract"]
+Installing a {sno} cluster on {ibm-power-name} requires two steps: first the {sno} logical partition (LPAR) needs to boot up with PXE, then you monitor the installation progress.
+
 .Prerequisites
 
 * You have set up bastion.
 
 .Procedure
-
-There are two steps for the {sno} cluster installation. First the {sno} logical partition (LPAR) needs to boot up with PXE, then you need to monitor the installation progress.
 
 . Use the following command to boot powerVM with netboot:
 +

--- a/modules/install-sno-ibm-z-kvm.adoc
+++ b/modules/install-sno-ibm-z-kvm.adoc
@@ -15,27 +15,19 @@ You can install a single-node cluster on {ibm-z-name} and {ibm-linuxone-name} us
 
 .Procedure
 
-. Set the {product-title} version by running the following command:
+. Set the {product-title} version by running the following command, replacing `<ocp_version>` with the current version, for example, `latest-{product-version}`:
 +
 [source,terminal]
 ----
 $ OCP_VERSION=<ocp_version>
 ----
-+
-where:
-+
-`<ocp_version>`:: Specifies the current version, for example, `latest-{product-version}`.
 
-. Set the host architecture by running the following command:
+. Set the host architecture by running the following command, replacing `<architecture>` with the target host architecture `s390x`:
 +
 [source,terminal]
 ----
 $ ARCH=<architecture>
 ----
-+
-where:
-+
-`<architecture>`:: Specifies the target host architecture `s390x`.
 
 . Download the {product-title} client (`oc`) and make it available for use by entering the following commands:
 +

--- a/modules/install-sno-ibm-z-kvm.adoc
+++ b/modules/install-sno-ibm-z-kvm.adoc
@@ -94,7 +94,7 @@ pullSecret: '<pull_secret>'
 sshKey: |
   <ssh_key>
 ----
-
++
 where:
 
 `<domain>`:: Specifies the cluster domain name.
@@ -147,7 +147,7 @@ The file names contain the {product-title} version number. They resemble the fol
 ** Ignition files
 ** The new disk image
 ** Adjusted parm line arguments
-
++
 [source,terminal]
 ----
 $ virt-install \
@@ -169,7 +169,7 @@ $ virt-install \
    --extra-args "console=ttysclp0" \
    --wait
 ----
-
++
 where:
 
 `--location`:: Specifies the location of the kernel/initrd on the HTTP or HTTPS server.

--- a/modules/install-sno-ibm-z-kvm.adoc
+++ b/modules/install-sno-ibm-z-kvm.adoc
@@ -6,9 +6,12 @@
 [id="installing-sno-on-ibm-z-kvm_{context}"]
 = Installing {sno} with {op-system-base} KVM on {ibm-z-title} and {ibm-linuxone-title}
 
+[role="_abstract"]
+You can install a single-node cluster on {ibm-z-name} and {ibm-linuxone-name} using {op-system-base} KVM.
+
 .Prerequisites
 
-* You  have installed `podman`.
+* You have installed `podman`.
 
 .Procedure
 
@@ -16,18 +19,23 @@
 +
 [source,terminal]
 ----
-$ OCP_VERSION=<ocp_version> <1>
+$ OCP_VERSION=<ocp_version>
 ----
 +
-<1> Replace `<ocp_version>` with the current version. For example, `latest-{product-version}`.
+where:
++
+`<ocp_version>`:: Specifies the current version, for example, `latest-{product-version}`.
 
 . Set the host architecture by running the following command:
 +
 [source,terminal]
 ----
-$ ARCH=<architecture> <1>
+$ ARCH=<architecture>
 ----
-<1> Replace `<architecture>` with the target host architecture `s390x`.
++
+where:
++
+`<architecture>`:: Specifies the target host architecture `s390x`.
 
 . Download the {product-title} client (`oc`) and make it available for use by entering the following commands:
 +
@@ -68,41 +76,43 @@ $ chmod +x openshift-install
 [source,yaml]
 ----
 apiVersion: v1
-baseDomain: <domain> <1>
+baseDomain: <domain>
 compute:
 - name: worker
-  replicas: 0 <2>
+  replicas: 0
 controlPlane:
   name: master
-  replicas: 1 <3>
+  replicas: 1
 metadata:
-  name: <name> <4>
-networking: <5>
+  name: <name>
+networking:
   clusterNetwork:
   - cidr: 10.128.0.0/14
     hostPrefix: 23
   machineNetwork:
-  - cidr: 10.0.0.0/16 <6>
+  - cidr: 10.0.0.0/16
   networkType: OVNKubernetes
   serviceNetwork:
   - 172.30.0.0/16
 platform:
   none: {}
 bootstrapInPlace:
-  installationDisk: /dev/disk/by-id/<disk_id> <7>
-pullSecret: '<pull_secret>' <8>
+  installationDisk: /dev/disk/by-id/<disk_id>
+pullSecret: '<pull_secret>'
 sshKey: |
-  <ssh_key> <9>
+  <ssh_key>
 ----
-<1> Add the cluster domain name.
-<2> Set the `compute` replicas to `0`. This makes the control plane node schedulable.
-<3> Set the `controlPlane` replicas to `1`. In conjunction with the previous `compute` setting, this setting ensures the cluster runs on a single node.
-<4> Set the `metadata` name to the cluster name.
-<5> Set the `networking` details. OVN-Kubernetes is the only allowed network plugin type for single-node clusters.
-<6> Set the `cidr` value to match the subnet of the {sno} cluster.
-<7> Set the path to the installation disk drive, for example, `/dev/disk/by-id/wwn-0x64cd98f04fde100024684cf3034da5c2`.
-<8> Copy the {cluster-manager-url-pull} and add the contents to this configuration setting.
-<9> Add the public SSH key from the administration host so that you can log in to the cluster after installation.
+
+where:
+
+`<domain>`:: Specifies the cluster domain name.
+`replicas: 0` (compute):: Sets the compute replicas to `0`. This makes the control plane node schedulable.
+`replicas: 1` (controlPlane):: Sets the controlPlane replicas to `1`. In conjunction with the previous compute setting, this setting ensures the cluster runs on a single node.
+`<name>`:: Specifies the cluster name in the metadata.
+`cidr: 10.0.0.0/16`:: Sets the `cidr` value to match the subnet of the {sno} cluster. OVN-Kubernetes is the only allowed network plugin type for single-node clusters.
+`<disk_id>`:: Specifies the path to the installation disk drive, for example, `/dev/disk/by-id/wwn-0x64cd98f04fde100024684cf3034da5c2`.
+`<pull_secret>`:: Specifies your pull secret. Copy the {cluster-manager-url-pull} and add the contents to this configuration setting.
+`<ssh_key>`:: Specifies the public SSH key from the administration host so that you can log in to the cluster after installation.
 
 . Generate {product-title} assets by running the following commands:
 +
@@ -154,20 +164,23 @@ $ virt-install \
    --memory=<memory_mb> \
    --cpu host \
    --vcpus <vcpus> \
-   --location <media_location>,kernel=<rhcos_kernel>,initrd=<rhcos_initrd> \// <1>
+   --location <media_location>,kernel=<rhcos_kernel>,initrd=<rhcos_initrd> \
    --disk size=100 \
    --network network=<virt_network_parm> \
    --graphics none \
    --noautoconsole \
    --extra-args "rd.neednet=1 ignition.platform.id=metal ignition.firstboot" \
-   --extra-args "ignition.config.url=http://<http_server>/bootstrap.ign" \// <2>
-   --extra-args "coreos.live.rootfs_url=http://<http_server>/rhcos-<version>-live-rootfs.<architecture>.img" \// <3>
-   --extra-args "ip=<ip>::<gateway>:<mask>:<hostname>::none" \ <4>
+   --extra-args "ignition.config.url=http://<http_server>/bootstrap.ign" \
+   --extra-args "coreos.live.rootfs_url=http://<http_server>/rhcos-<version>-live-rootfs.<architecture>.img" \
+   --extra-args "ip=<ip>::<gateway>:<mask>:<hostname>::none" \
    --extra-args "nameserver=<dns>" \
    --extra-args "console=ttysclp0" \
    --wait
 ----
-<1> For the `--location` parameter, specify the location of the kernel/initrd on the HTTP or HTTPS server.
-<2> Specify the location of the `bootstrap.ign` config file. Only HTTP and HTTPS protocols are supported.
-<3> For the `coreos.live.rootfs_url=` artifact, specify the matching `rootfs` artifact for the `kernel` and `initramfs` you are booting. Only HTTP and HTTPS protocols are supported.
-<4> For the `ip=` parameter, assign the IP address manually as described in "Installing a cluster with {op-system-base} KVM on {ibm-z-name} and {ibm-linuxone-name}".
+
+where:
+
+`--location`:: Specifies the location of the kernel/initrd on the HTTP or HTTPS server.
+`ignition.config.url`:: Specifies the location of the `bootstrap.ign` config file. Only HTTP and HTTPS protocols are supported.
+`coreos.live.rootfs_url`:: Specifies the matching `rootfs` artifact for the `kernel` and `initramfs` you are booting. Only HTTP and HTTPS protocols are supported.
+`ip`:: Specifies the IP address. Assign the IP address manually as described in "Installing a cluster with {op-system-base} KVM on {ibm-z-name} and {ibm-linuxone-name}".

--- a/modules/install-sno-ibm-z-lpar.adoc
+++ b/modules/install-sno-ibm-z-lpar.adoc
@@ -92,7 +92,7 @@ pullSecret: '<pull_secret>'
 sshKey: |
   <ssh_key>
 ----
-
++
 where:
 
 `<domain>`:: Specifies the cluster domain name.

--- a/modules/install-sno-ibm-z-lpar.adoc
+++ b/modules/install-sno-ibm-z-lpar.adoc
@@ -6,6 +6,9 @@
 [id="installing-sno-on-ibm-z-lpar_{context}"]
 = Installing {sno} in an LPAR on {ibm-z-title} and {ibm-linuxone-title}
 
+[role="_abstract"]
+You can install a single-node cluster in an LPAR on {ibm-z-name} and {ibm-linuxone-name}.
+
 .Prerequisites
 
 * If you are deploying a single-node cluster there are zero compute nodes, the Ingress Controller pods run on the control plane nodes. In single-node cluster deployments, you must configure your application ingress load balancer to route HTTP and HTTPS traffic to the control plane nodes. See the _Load balancing requirements for user-provisioned infrastructure_ section for more information.
@@ -16,18 +19,23 @@
 +
 [source,terminal]
 ----
-$ OCP_VERSION=<ocp_version> <1>
+$ OCP_VERSION=<ocp_version>
 ----
 +
-<1> Replace `<ocp_version>` with the current version. For example, `latest-{product-version}`.
+where:
++
+`<ocp_version>`:: Specifies the current version, for example, `latest-{product-version}`.
 
 . Set the host architecture by running the following command:
 +
 [source,terminal]
 ----
-$ ARCH=<architecture> <1>
+$ ARCH=<architecture>
 ----
-<1> Replace `<architecture>` with the target host architecture `s390x`.
++
+where:
++
+`<architecture>`:: Specifies the target host architecture `s390x`.
 
 . Download the {product-title} client (`oc`) and make it available for use by entering the following commands:
 +
@@ -68,38 +76,40 @@ $ chmod +x openshift-install
 [source,yaml]
 ----
 apiVersion: v1
-baseDomain: <domain> <1>
+baseDomain: <domain>
 compute:
 - name: worker
-  replicas: 0 <2>
+  replicas: 0
 controlPlane:
   name: master
-  replicas: 1 <3>
+  replicas: 1
 metadata:
-  name: <name> <4>
-networking: <5>
+  name: <name>
+networking:
   clusterNetwork:
   - cidr: 10.128.0.0/14
     hostPrefix: 23
   machineNetwork:
-  - cidr: 10.0.0.0/16 <6>
+  - cidr: 10.0.0.0/16
   networkType: OVNKubernetes
   serviceNetwork:
   - 172.30.0.0/16
 platform:
   none: {}
-pullSecret: '<pull_secret>' <7>
+pullSecret: '<pull_secret>'
 sshKey: |
-  <ssh_key> <8>
+  <ssh_key>
 ----
-<1> Add the cluster domain name.
-<2> Set the `compute` replicas to `0`. This makes the control plane node schedulable.
-<3> Set the `controlPlane` replicas to `1`. In conjunction with the previous `compute` setting, this setting ensures the cluster runs on a single node.
-<4> Set the `metadata` name to the cluster name.
-<5> Set the `networking` details. OVN-Kubernetes is the only allowed network plugin type for single-node clusters.
-<6> Set the `cidr` value to match the subnet of the {sno} cluster.
-<7> Copy the {cluster-manager-url-pull} and add the contents to this configuration setting.
-<8> Add the public SSH key from the administration host so that you can log in to the cluster after installation.
+
+where:
+
+`<domain>`:: Specifies the cluster domain name.
+`replicas: 0` (compute):: Sets the compute replicas to `0`. This makes the control plane node schedulable.
+`replicas: 1` (controlPlane):: Sets the controlPlane replicas to `1`. In conjunction with the previous compute setting, this setting ensures the cluster runs on a single node.
+`<name>`:: Specifies the cluster name in the metadata.
+`cidr: 10.0.0.0/16`:: Sets the `cidr` value to match the subnet of the {sno} cluster. OVN-Kubernetes is the only allowed network plugin type for single-node clusters.
+`<pull_secret>`:: Specifies your pull secret. Copy the {cluster-manager-url-pull} and add the contents to this configuration setting.
+`<ssh_key>`:: Specifies the public SSH key from the administration host so that you can log in to the cluster after installation.
 
 . Generate {product-title} assets by running the following commands:
 +
@@ -117,10 +127,12 @@ $ cp install-config.yaml ocp
 +
 [source,terminal]
 ----
-$ ./openshift-install create manifests --dir <installation_directory> <1>
+$ ./openshift-install create manifests --dir <installation_directory>
 ----
 +
-<1> For `<installation_directory>`, specify the installation directory that contains the `install-config.yaml` file you created.
+where:
++
+`<installation_directory>`:: Specifies the installation directory that contains the `install-config.yaml` file you created.
 
 . Check that the `mastersSchedulable` parameter in the `<installation_directory>/manifests/cluster-scheduler-02-config.yml` Kubernetes manifest file is set to `true`.
 +
@@ -141,9 +153,12 @@ status: {}
 +
 [source,terminal]
 ----
-$ ./openshift-install create ignition-configs --dir <installation_directory> <1>
+$ ./openshift-install create ignition-configs --dir <installation_directory>
 ----
-<1> For `<installation_directory>`, specify the same installation directory.
++
+where:
++
+`<installation_directory>`:: Specifies the same installation directory.
 
 . Obtain the {op-system-base} `kernel`, `initramfs`, and `rootfs`  artifacts from the link:https://access.redhat.com/downloads/content/290[Product Downloads] page on the Red Hat Customer Portal or from the link:https://mirror.openshift.com/pub/openshift-v4/s390x/dependencies/rhcos/latest/[{op-system} image mirror] page.
 +
@@ -168,42 +183,14 @@ The `rootfs` image is the same for FCP and DASD.
 ** Downloaded {op-system-base} live `kernel`, `initramfs`, and `rootfs` artifacts
 ** Ignition files
 
-. Create a parameter file for the bootstrap in an LPAR:
-+
-.Example parameter file for the bootstrap machine
-+
-[source,terminal]
-----
-cio_ignore=all,!condev rd.neednet=1 \
-console=ttysclp0 \
-coreos.inst.install_dev=/dev/<block_device> \// <1>
-coreos.inst.ignition_url=http://<http_server>/bootstrap.ign \// <2>
-coreos.live.rootfs_url=http://<http_server>/rhcos-<version>-live-rootfs.<architecture>.img \// <3>
-ip=<ip>::<gateway>:<netmask>:<hostname>::none nameserver=<dns> \// <4>
-rd.znet=qeth,0.0.1140,0.0.1141,0.0.1142,layer2=1,portno=0 \
-rd.dasd=0.0.4411 \// <5>
-rd.zfcp=0.0.8001,0x50050763040051e3,0x4000406300000000 \// <6>
-zfcp.allow_lun_scan=0
-----
-<1> Specify the block device on the system to install to. For installations on DASD-type disk use `dasda`, for installations on FCP-type disks use `sda`.
-<2> Specify the location of the `bootstrap.ign` config file. Only HTTP and HTTPS protocols are supported.
-<3> For the `coreos.live.rootfs_url=` artifact, specify the matching `rootfs` artifact for the `kernel`and `initramfs` you are booting. Only HTTP and HTTPS protocols are supported.
-<4> For the `ip=` parameter, assign the IP address manually as described in "Installing a cluster in an LPAR on {ibm-z-name} and {ibm-linuxone-name}".
-<5> For installations on DASD-type disks, use `rd.dasd=` to specify the DASD where {op-system} is to be installed. Omit this entry for FCP-type disks.
-<6> For installations on FCP-type disks, use `rd.zfcp=<adapter>,<wwpn>,<lun>` to specify the FCP disk where {op-system} is to be installed. Omit this entry for DASD-type disks.
-+
-You can adjust further parameters if required.
-
-. Create a parameter file for the control plane in an LPAR:
-+
-.Example parameter file for the control plane machine
+. Create a parameter file for the bootstrap in an LPAR. The following example shows a parameter file for the bootstrap machine:
 +
 [source,terminal]
 ----
 cio_ignore=all,!condev rd.neednet=1 \
 console=ttysclp0 \
 coreos.inst.install_dev=/dev/<block_device> \
-coreos.inst.ignition_url=http://<http_server>/master.ign \// <1>
+coreos.inst.ignition_url=http://<http_server>/bootstrap.ign \
 coreos.live.rootfs_url=http://<http_server>/rhcos-<version>-live-rootfs.<architecture>.img \
 ip=<ip>::<gateway>:<netmask>:<hostname>::none nameserver=<dns> \
 rd.znet=qeth,0.0.1140,0.0.1141,0.0.1142,layer2=1,portno=0 \
@@ -211,7 +198,37 @@ rd.dasd=0.0.4411 \
 rd.zfcp=0.0.8001,0x50050763040051e3,0x4000406300000000 \
 zfcp.allow_lun_scan=0
 ----
-<1> Specify the location of the `master.ign` config file. Only HTTP and HTTPS protocols are supported.
++
+where:
++
+`coreos.inst.install_dev`:: Specifies the block device on the system to install to. For installations on DASD-type disk use `dasda`, for installations on FCP-type disks use `sda`.
+`coreos.inst.ignition_url`:: Specifies the location of the `bootstrap.ign` config file. Only HTTP and HTTPS protocols are supported.
+`coreos.live.rootfs_url`:: Specifies the matching `rootfs` artifact for the `kernel` and `initramfs` you are booting. Only HTTP and HTTPS protocols are supported.
+`ip`:: Specifies the IP address. Assign the IP address manually as described in "Installing a cluster in an LPAR on {ibm-z-name} and {ibm-linuxone-name}".
+`rd.dasd`:: Specifies the DASD where {op-system} is to be installed. Use this parameter for installations on DASD-type disks. Omit this entry for FCP-type disks.
+`rd.zfcp`:: Specifies the FCP disk where {op-system} is to be installed using the format `<adapter>,<wwpn>,<lun>`. Use this parameter for installations on FCP-type disks. Omit this entry for DASD-type disks.
++
+You can adjust further parameters if required.
+
+. Create a parameter file for the control plane in an LPAR. The following example shows a parameter file for the control plane machine:
++
+[source,terminal]
+----
+cio_ignore=all,!condev rd.neednet=1 \
+console=ttysclp0 \
+coreos.inst.install_dev=/dev/<block_device> \
+coreos.inst.ignition_url=http://<http_server>/master.ign \
+coreos.live.rootfs_url=http://<http_server>/rhcos-<version>-live-rootfs.<architecture>.img \
+ip=<ip>::<gateway>:<netmask>:<hostname>::none nameserver=<dns> \
+rd.znet=qeth,0.0.1140,0.0.1141,0.0.1142,layer2=1,portno=0 \
+rd.dasd=0.0.4411 \
+rd.zfcp=0.0.8001,0x50050763040051e3,0x4000406300000000 \
+zfcp.allow_lun_scan=0
+----
++
+where:
++
+`coreos.inst.ignition_url`:: Specifies the location of the `master.ign` config file. Only HTTP and HTTPS protocols are supported.
 
 . Transfer the following artifacts, files, and images to the LPAR. For example by using FTP:
 

--- a/modules/install-sno-ibm-z-lpar.adoc
+++ b/modules/install-sno-ibm-z-lpar.adoc
@@ -15,27 +15,19 @@ You can install a single-node cluster in an LPAR on {ibm-z-name} and {ibm-linuxo
 
 .Procedure
 
-. Set the {product-title} version by running the following command:
+. Set the {product-title} version by running the following command, replacing `<ocp_version>` with the current version, for example, `latest-{product-version}`:
 +
 [source,terminal]
 ----
 $ OCP_VERSION=<ocp_version>
 ----
-+
-where:
-+
-`<ocp_version>`:: Specifies the current version, for example, `latest-{product-version}`.
 
-. Set the host architecture by running the following command:
+. Set the host architecture by running the following command, replacing `<architecture>` with the target host architecture `s390x`:
 +
 [source,terminal]
 ----
 $ ARCH=<architecture>
 ----
-+
-where:
-+
-`<architecture>`:: Specifies the target host architecture `s390x`.
 
 . Download the {product-title} client (`oc`) and make it available for use by entering the following commands:
 +

--- a/modules/install-sno-ibm-z.adoc
+++ b/modules/install-sno-ibm-z.adoc
@@ -15,27 +15,19 @@ You can install a single-node cluster on {ibm-z-name} and {ibm-linuxone-name} us
 
 .Procedure
 
-. Set the {product-title} version by running the following command:
+. Set the {product-title} version by running the following command, replacing `<ocp_version>` with the current version, for example, `latest-{product-version}`:
 +
 [source,terminal]
 ----
 $ OCP_VERSION=<ocp_version>
 ----
-+
-where:
-+
-`<ocp_version>`:: Specifies the current version, for example, `latest-{product-version}`.
 
-. Set the host architecture by running the following command:
+. Set the host architecture by running the following command, replacing `<architecture>` with the target host architecture `s390x`:
 +
 [source,terminal]
 ----
 $ ARCH=<architecture>
 ----
-+
-where:
-+
-`<architecture>`:: Specifies the target host architecture `s390x`.
 
 . Download the {product-title} client (`oc`) and make it available for use by entering the following commands:
 +

--- a/modules/install-sno-ibm-z.adoc
+++ b/modules/install-sno-ibm-z.adoc
@@ -94,7 +94,7 @@ pullSecret: '<pull_secret>'
 sshKey: |
   <ssh_key>
 ----
-
++
 where:
 
 `<domain>`:: Specifies the cluster domain name.

--- a/modules/install-sno-ibm-z.adoc
+++ b/modules/install-sno-ibm-z.adoc
@@ -6,6 +6,9 @@
 [id="installing-sno-on-ibm-z_{context}"]
 = Installing {sno} with z/VM on {ibm-z-title} and {ibm-linuxone-title}
 
+[role="_abstract"]
+You can install a single-node cluster on {ibm-z-name} and {ibm-linuxone-name} using z/VM.
+
 .Prerequisites
 
 * You have installed `podman`.
@@ -16,18 +19,23 @@
 +
 [source,terminal]
 ----
-$ OCP_VERSION=<ocp_version> <1>
+$ OCP_VERSION=<ocp_version>
 ----
 +
-<1> Replace `<ocp_version>` with the current version. For example, `latest-{product-version}`.
+where:
++
+`<ocp_version>`:: Specifies the current version, for example, `latest-{product-version}`.
 
 . Set the host architecture by running the following command:
 +
 [source,terminal]
 ----
-$ ARCH=<architecture> <1>
+$ ARCH=<architecture>
 ----
-<1> Replace `<architecture>` with the target host architecture `s390x`.
++
+where:
++
+`<architecture>`:: Specifies the target host architecture `s390x`.
 
 . Download the {product-title} client (`oc`) and make it available for use by entering the following commands:
 +
@@ -68,41 +76,43 @@ $ chmod +x openshift-install
 [source,yaml]
 ----
 apiVersion: v1
-baseDomain: <domain> <1>
+baseDomain: <domain>
 compute:
 - name: worker
-  replicas: 0 <2>
+  replicas: 0
 controlPlane:
   name: master
-  replicas: 1 <3>
+  replicas: 1
 metadata:
-  name: <name> <4>
-networking: <5>
+  name: <name>
+networking:
   clusterNetwork:
   - cidr: 10.128.0.0/14
     hostPrefix: 23
   machineNetwork:
-  - cidr: 10.0.0.0/16 <6>
+  - cidr: 10.0.0.0/16
   networkType: OVNKubernetes
   serviceNetwork:
   - 172.30.0.0/16
 platform:
   none: {}
 bootstrapInPlace:
-  installationDisk: /dev/disk/by-id/<disk_id> <7>
-pullSecret: '<pull_secret>' <8>
+  installationDisk: /dev/disk/by-id/<disk_id>
+pullSecret: '<pull_secret>'
 sshKey: |
-  <ssh_key> <9>
+  <ssh_key>
 ----
-<1> Add the cluster domain name.
-<2> Set the `compute` replicas to `0`. This makes the control plane node schedulable.
-<3> Set the `controlPlane` replicas to `1`. In conjunction with the previous `compute` setting, this setting ensures the cluster runs on a single node.
-<4> Set the `metadata` name to the cluster name.
-<5> Set the `networking` details. OVN-Kubernetes is the only allowed network plugin type for single-node clusters.
-<6> Set the `cidr` value to match the subnet of the {sno} cluster.
-<7> Set the path to the installation disk drive, for example, `/dev/disk/by-id/wwn-0x64cd98f04fde100024684cf3034da5c2`.
-<8> Copy the {cluster-manager-url-pull} and add the contents to this configuration setting.
-<9> Add the public SSH key from the administration host so that you can log in to the cluster after installation.
+
+where:
+
+`<domain>`:: Specifies the cluster domain name.
+`replicas: 0` (compute):: Sets the compute replicas to `0`. This makes the control plane node schedulable.
+`replicas: 1` (controlPlane):: Sets the controlPlane replicas to `1`. In conjunction with the previous compute setting, this setting ensures the cluster runs on a single node.
+`<name>`:: Specifies the cluster name in the metadata.
+`cidr: 10.0.0.0/16`:: Sets the `cidr` value to match the subnet of the {sno} cluster. OVN-Kubernetes is the only allowed network plugin type for single-node clusters.
+`<disk_id>`:: Specifies the path to the installation disk drive, for example, `/dev/disk/by-id/wwn-0x64cd98f04fde100024684cf3034da5c2`.
+`<pull_secret>`:: Specifies your pull secret. Copy the {cluster-manager-url-pull} and add the contents to this configuration setting.
+`<ssh_key>`:: Specifies the public SSH key from the administration host so that you can log in to the cluster after installation.
 
 . Generate {product-title} assets by running the following commands:
 +
@@ -144,28 +154,29 @@ The `rootfs` image is the same for FCP and DASD.
 ** Downloaded {op-system-base} live `kernel`, `initramfs`, and `rootfs` artifacts
 ** Ignition files
 
-. Create parameter files for a particular virtual machine:
-+
-.Example parameter file
+. Create parameter files for a particular virtual machine. The following example shows a parameter file:
 +
 [source,terminal]
 ----
 cio_ignore=all,!condev rd.neednet=1 \
 console=ttysclp0 \
 ignition.firstboot ignition.platform.id=metal \
-ignition.config.url=http://<http_server>:8080/ignition/bootstrap-in-place-for-live-iso.ign \// <1>
-coreos.live.rootfs_url=http://<http_server>/rhcos-<version>-live-rootfs.<architecture>.img \// <2>
-ip=<ip>::<gateway>:<mask>:<hostname>::none nameserver=<dns> \// <3>
+ignition.config.url=http://<http_server>:8080/ignition/bootstrap-in-place-for-live-iso.ign \
+coreos.live.rootfs_url=http://<http_server>/rhcos-<version>-live-rootfs.<architecture>.img \
+ip=<ip>::<gateway>:<mask>:<hostname>::none nameserver=<dns> \
 rd.znet=qeth,0.0.bdd0,0.0.bdd1,0.0.bdd2,layer2=1 \
-rd.dasd=0.0.4411 \// <4>
-rd.zfcp=0.0.8001,0x50050763040051e3,0x4000406300000000 \// <5>
+rd.dasd=0.0.4411 \
+rd.zfcp=0.0.8001,0x50050763040051e3,0x4000406300000000 \
 zfcp.allow_lun_scan=0
 ----
-<1> For the `ignition.config.url=` parameter, specify the Ignition file for the machine role. Only HTTP and HTTPS protocols are supported.
-<2> For the `coreos.live.rootfs_url=` artifact, specify the matching `rootfs` artifact for the `kernel`and `initramfs` you are booting. Only HTTP and HTTPS protocols are supported.
-<3> For the `ip=` parameter, assign the IP address automatically using DHCP or manually as described in "Installing a cluster with z/VM on {ibm-z-name} and {ibm-linuxone-name}".
-<4> For installations on DASD-type disks, use `rd.dasd=` to specify the DASD where {op-system} is to be installed. Omit this entry for FCP-type disks.
-<5> For installations on FCP-type disks, use `rd.zfcp=<adapter>,<wwpn>,<lun>` to specify the FCP disk where {op-system} is to be installed. Omit this entry for DASD-type disks.
++
+where:
++
+`ignition.config.url`:: Specifies the Ignition file for the machine role. Only HTTP and HTTPS protocols are supported.
+`coreos.live.rootfs_url`:: Specifies the matching `rootfs` artifact for the `kernel` and `initramfs` you are booting. Only HTTP and HTTPS protocols are supported.
+`ip`:: Specifies the IP address. Assign the IP address automatically using DHCP or manually as described in "Installing a cluster with z/VM on {ibm-z-name} and {ibm-linuxone-name}".
+`rd.dasd`:: Specifies the DASD where {op-system} is to be installed. Use this parameter for installations on DASD-type disks. Omit this entry for FCP-type disks.
+`rd.zfcp`:: Specifies the FCP disk where {op-system} is to be installed using the format `<adapter>,<wwpn>,<lun>`. Use this parameter for installations on FCP-type disks. Omit this entry for DASD-type disks.
 +
 Leave all other parameters unchanged.
 
@@ -241,14 +252,15 @@ where:
 `<kernel_parameters>`:: Specifies a set of kernel parameters to be stored as system control program data (SCPDATA). When booting Linux, these kernel parameters are concatenated to the end of the existing kernel parameters that are used by your boot configuration. The combined parameter string must not exceed 896 characters.
 
 `<APPEND|NEW>`:: Optional: Specify `APPEND` to append kernel parameters to existing SCPDATA. This is the default. Specify `NEW` to replace existing SCPDATA.
-
-.Example
++
+The following example shows the command:
++
 [source,terminal]
 ----
 $ cp set loaddev scpdata 'rd.zfcp=0.0.8001,0x500507630a0350a4,0x4000409D00000000
 ip=encbdd0:dhcp::02:00:00:02:34:02 rd.neednet=1'
 ----
-
++
 To start the IPL and boot process, run the following command:
 
 [source,terminal]

--- a/modules/install-sno-installing-sno-on-azure.adoc
+++ b/modules/install-sno-installing-sno-on-azure.adoc
@@ -13,4 +13,5 @@ ifdef::openshift-origin[]
 
 endif::openshift-origin[]
 
+[role="_abstract"]
 Installing a single node cluster on Azure requires installer-provisioned installation using the "Installing a cluster on Azure with customizations" procedure.

--- a/modules/install-sno-installing-sno-on-gcp.adoc
+++ b/modules/install-sno-installing-sno-on-gcp.adoc
@@ -13,4 +13,5 @@ ifdef::openshift-origin[]
 
 endif::openshift-origin[]
 
+[role="_abstract"]
 Installing a single node cluster on {gcp-short} requires installer-provisioned installation using the "Installing a cluster on {gcp-short} with customizations" procedure.

--- a/modules/install-sno-installing-with-the-assisted-installer.adoc
+++ b/modules/install-sno-installing-with-the-assisted-installer.adoc
@@ -6,6 +6,7 @@
 [id="install-sno-installing-with-the-assisted-installer_{context}"]
 = Installing {sno} with the Assisted Installer
 
+[role="_abstract"]
 Use the Assisted Installer to install the single-node cluster.
 
 .Prerequisites

--- a/modules/install-sno-installing-with-usb-media.adoc
+++ b/modules/install-sno-installing-with-usb-media.adoc
@@ -6,6 +6,7 @@
 [id="installing-with-usb-media_{context}"]
 = Creating a bootable ISO image on a USB drive
 
+[role="_abstract"]
 You can install software using a bootable USB drive that contains an ISO image. Booting the server with the USB drive prepares the server for the software installation.
 
 .Procedure

--- a/modules/install-sno-monitoring-the-installation-manually.adoc
+++ b/modules/install-sno-monitoring-the-installation-manually.adoc
@@ -6,6 +6,7 @@
 [id="install-sno-monitoring-the-installation-manually_{context}"]
 = Monitoring the cluster installation using openshift-install
 
+[role="_abstract"]
 Use `openshift-install` to monitor the progress of the single-node cluster installation.
 
 .Prerequisites

--- a/modules/install-sno-supported-cloud-providers-for-single-node-openshift.adoc
+++ b/modules/install-sno-supported-cloud-providers-for-single-node-openshift.adoc
@@ -13,6 +13,7 @@ ifdef::openshift-origin[]
 
 endif::openshift-origin[]
 
+[role="_abstract"]
 The following table contains a list of supported cloud providers and CPU architectures.
 
 .Supported cloud providers

--- a/modules/installation-aws_con_installing-sno-on-aws.adoc
+++ b/modules/installation-aws_con_installing-sno-on-aws.adoc
@@ -6,4 +6,5 @@
 [id="installing-sno-on-aws_{context}"]
 = Installing {sno} on AWS
 
+[role="_abstract"]
 Installing a single-node cluster on AWS requires installer-provisioned installation using the "Installing a cluster on AWS with customizations" procedure.

--- a/modules/ref_install-sno-ibm-power-hardware-requirements.adoc
+++ b/modules/ref_install-sno-ibm-power-hardware-requirements.adoc
@@ -1,0 +1,18 @@
+// Module included in the following assemblies:
+//
+// * installing/installing_sno/install-sno-installing-sno.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="install-sno-ibm-power-hardware-requirements_{context}"]
+= Hardware requirements for {sno} on {ibm-power-title}
+
+[role="_abstract"]
+Review the hardware requirements for installing {sno} on {ibm-power-name}.
+
+* The equivalent of two Integrated Facilities for Linux (IFL), which are SMT2 enabled, for each cluster.
+* At least one network connection to connect to the `LoadBalancer` service and to serve data for traffic outside of the cluster.
+
+[NOTE]
+====
+You can use dedicated or shared IFLs to assign sufficient compute resources. Resource sharing is one of the key strengths of {ibm-power-name}. However, you must adjust capacity correctly on each hypervisor layer and ensure sufficient resources for every {product-title} cluster.
+====

--- a/modules/ref_install-sno-ibm-z-hardware-requirements.adoc
+++ b/modules/ref_install-sno-ibm-z-hardware-requirements.adoc
@@ -1,0 +1,18 @@
+// Module included in the following assemblies:
+//
+// * installing/installing_sno/install-sno-installing-sno.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="install-sno-ibm-z-hardware-requirements_{context}"]
+= Hardware requirements for {sno} on {ibm-z-title}
+
+[role="_abstract"]
+Review the hardware requirements for installing {sno} on {ibm-z-name} and {ibm-linuxone-name}.
+
+* The equivalent of two Integrated Facilities for Linux (IFL), which are SMT2 enabled, for each cluster.
+* At least one network connection to both connect to the `LoadBalancer` service and to serve data for traffic outside the cluster.
+
+[NOTE]
+====
+You can use dedicated or shared IFLs to assign sufficient compute resources. Resource sharing is one of the key strengths of {ibm-z-name}. However, you must adjust capacity correctly on each hypervisor layer and ensure sufficient resources for every {product-title} cluster.
+====

--- a/modules/setting-up-bastion-for-sno.adoc
+++ b/modules/setting-up-bastion-for-sno.adoc
@@ -6,6 +6,7 @@
 [id="setting-up-bastion-for-sno_{context}"]
 = Setting up bastion for {sno} with {ibm-power-title}
 
+[role="_abstract"]
 Prior to installing {sno} on {ibm-power-name}, you must set up bastion. Setting up a bastion server for {sno} on {ibm-power-name} requires the configuration of the following services:
 
 * PXE is used for the {sno} cluster installation. PXE requires the following services to be configured and run:
@@ -107,41 +108,43 @@ $ cd ~/sno-work
 [source,yaml]
 ----
 apiVersion: v1
-baseDomain: <domain> <1>
+baseDomain: <domain>
 compute:
 - name: worker
-  replicas: 0 <2>
+  replicas: 0
 controlPlane:
   name: master
-  replicas: 1 <3>
+  replicas: 1
 metadata:
-  name: <name> <4>
-networking: <5>
+  name: <name>
+networking:
   clusterNetwork:
   - cidr: 10.128.0.0/14
     hostPrefix: 23
   machineNetwork:
-  - cidr: 10.0.0.0/16 <6>
+  - cidr: 10.0.0.0/16
   networkType: OVNKubernetes
   serviceNetwork:
   - 172.30.0.0/16
 platform:
   none: {}
 bootstrapInPlace:
-  installationDisk: /dev/disk/by-id/<disk_id> <7>
-pullSecret: '<pull_secret>' <8>
+  installationDisk: /dev/disk/by-id/<disk_id>
+pullSecret: '<pull_secret>'
 sshKey: |
-  <ssh_key> <9>
+  <ssh_key>
 ----
-<1> Add the cluster domain name.
-<2> Set the `compute` replicas to `0`. This makes the control plane node schedulable.
-<3> Set the `controlPlane` replicas to `1`. In conjunction with the previous `compute` setting, this setting ensures that the cluster runs on a single node.
-<4> Set the `metadata` name to the cluster name.
-<5> Set the `networking` details. OVN-Kubernetes is the only allowed network plugin type for single-node clusters.
-<6> Set the `cidr` value to match the subnet of the {sno} cluster.
-<7> Set the path to the installation disk drive, for example, `/dev/disk/by-id/wwn-0x64cd98f04fde100024684cf3034da5c2`.
-<8> Copy the {cluster-manager-url-pull} and add the contents to this configuration setting.
-<9> Add the public SSH key from the administration host so that you can log in to the cluster after installation.
++
+where:
++
+`<domain>`:: Specifies the cluster domain name.
+`replicas: 0` (compute):: Sets the compute replicas to `0`. This makes the control plane node schedulable.
+`replicas: 1` (controlPlane):: Sets the controlPlane replicas to `1`. In conjunction with the previous compute setting, this setting ensures the cluster runs on a single node.
+`<name>`:: Specifies the cluster name in the metadata.
+`cidr: 10.0.0.0/16`:: Sets the `cidr` value to match the subnet of the {sno} cluster. OVN-Kubernetes is the only allowed network plugin type for single-node clusters.
+`<disk_id>`:: Specifies the path to the installation disk drive, for example, `/dev/disk/by-id/wwn-0x64cd98f04fde100024684cf3034da5c2`.
+`<pull_secret>`:: Specifies your pull secret. Copy the {cluster-manager-url-pull} and add the contents to this configuration setting.
+`<ssh_key>`:: Specifies the public SSH key from the administration host so that you can log in to the cluster after installation.
 
 . Download the `openshift-install` image to create the ignition file and copy it to the `http` directory.
 


### PR DESCRIPTION
## Summary

```cmd
/ralph-loop:ralph-loop "Use the dita-tools:dita-rework skill on installing/installing_sno/install-sno-installing-sno.adoc with --rewrite to fix all Vale AsciiDocDITA rule Error and Warning violations" --completion-promise "0 errors, 0 warnings" --max-iterations 10
```

Claude Code tokens: $14.44

Refactored AsciiDoc files in `installing/installing_sno/install-sno-installing-sno.adoc` for DITA conversion compatibility using LLM-guided rewriting.

## Changes Applied

The following DITA issues were fixed through LLM-guided refactoring:

- **ShortDescription**: Added `[role="_abstract"]` paragraphs to assembly and all new modules
- **AssemblyContents**: Extracted inline section content to separate concept modules:
  - `con_install-sno-okd-assisted-service.adoc` - OKD Assisted Service installation
  - `con_install-sno-installing-manually.adoc` - Manual installation introduction
  - `con_install-sno-on-cloud-providers.adoc` - Cloud providers overview
  - `con_install-sno-with-ibm-z.adoc` - IBM Z introduction
  - `con_install-sno-with-ibm-power.adoc` - IBM Power introduction
- **NestedSection**: Extracted hardware requirements to reference modules:
  - `ref_install-sno-ibm-z-hardware-requirements.adoc`
  - `ref_install-sno-ibm-power-hardware-requirements.adoc`
- **ConceptLink**: Restructured OKD conditional blocks to include modules instead of inline content
- **RelatedLinks**: Separated Additional resources sections from section headings in conditionals
- **TaskStep**: Added list continuation markers (`+`) for "where:" description lists that explain install-config.yaml fields
- **CalloutList**: Already converted to description lists with "where:" introductions (from previous iteration)
- **BlockTitle**: Already converted to inline text using "The following example shows..." pattern (from previous iteration)

## Files Processed

12 files were modified or created:

| File | Action | Changes |
|------|--------|---------|
| installing/installing_sno/install-sno-installing-sno.adoc | Modified | Added abstract, restructured sections, included new modules |
| modules/install-sno-generating-the-install-iso-manually.adoc | Modified | Added `+` continuation for description list |
| modules/install-sno-ibm-z.adoc | Modified | Added `+` continuation for description list |
| modules/install-sno-ibm-z-kvm.adoc | Modified | Added `+` continuation markers for description lists |
| modules/install-sno-ibm-z-lpar.adoc | Modified | Added `+` continuation for description list |
| modules/con_install-sno-okd-assisted-service.adoc | Created | OKD Assisted Service concept module |
| modules/con_install-sno-installing-manually.adoc | Created | Manual installation concept module |
| modules/con_install-sno-on-cloud-providers.adoc | Created | Cloud providers concept module |
| modules/con_install-sno-with-ibm-z.adoc | Created | IBM Z concept module |
| modules/con_install-sno-with-ibm-power.adoc | Created | IBM Power concept module |
| modules/ref_install-sno-ibm-z-hardware-requirements.adoc | Created | IBM Z hardware requirements reference |
| modules/ref_install-sno-ibm-power-hardware-requirements.adoc | Created | IBM Power hardware requirements reference |

## Vale Validation Results (Actionable Issues Only)

| Metric | Count |
|--------|-------|
| Issues before | 57 |
| Issues after | 0 |
| **Fixed** | **57** |
| Improvement | 100% |

### Remaining Actionable Issues

None. All AsciiDocDITA errors and warnings have been resolved.

## Test Plan

- [x] Verify the AsciiDoc renders correctly
- [ ] Run DITA conversion on the modified files
- [x] Content meaning preserved
- [ ] Links and cross-references work

---
Generated with [Claude Code](https://claude.com/claude-code)