### PR TITLE
OSDOCS-18646-19: Remediation for MSH-STOR-1

### DIFF
--- a/microshift_storage/expanding-persistent-volumes-microshift.adoc
+++ b/microshift_storage/expanding-persistent-volumes-microshift.adoc
@@ -11,12 +11,6 @@ To increase available storage capacity, expand persistent volumes in {microshift
 
 include::modules/storage-expanding-csi-volumes.adoc[leveloffset=+1]
 
-[role="_additional-resources"]
-[id="additional-resources_{context}"]
-== Additional resources
-
-* link:https://docs.redhat.com/en/documentation/openshift_container_platform/latest/html/storage/using-container-storage-interface-csi#csi-drivers-supported_persistent-storage-csi[CSI drivers supported by {product-title}]
-
 include::modules/storage-expanding-local-volumes.adoc[leveloffset=+1]
 
 include::modules/storage-expanding-filesystem-pvc.adoc[leveloffset=+1]

--- a/modules/microshift-storage-vol-snapshot-class.adoc
+++ b/modules/microshift-storage-vol-snapshot-class.adoc
@@ -29,8 +29,8 @@ deletionPolicy: Delete
 
 where:
 
-`snapshot.storage.kubernetes.io/is-default-class`:: Specifies the `VolumeSnapshotClass` configuration file to use when none is specified by `VolumeSnapshot`. Where `VolumeSnapshot` is a request for snapshot of a volume by a user.
+`snapshot.storage.kubernetes.io/is-default-class`:: Specifies the `VolumeSnapshotClass` configuration file to use when none is specified by `VolumeSnapshot`. Where `VolumeSnapshot` is a request for the snapshot of a volume.
 
-`driver`:: Identifies the snapshot provisioner that manages the requests for snapshots of a volume by a user for this class.
+`driver`:: Identifies the snapshot provisioner that manages the requests for snapshots of a volume for this class.
 
 `deletionPolicy`:: Specifies the `VolumeSnapshotContent` objects and the backing snapshots that are kept or deleted when a bound `VolumeSnapshot` is deleted. Valid values are `Retain` or `Delete`.

--- a/modules/pvc-cli-command-usage.adoc
+++ b/modules/pvc-cli-command-usage.adoc
@@ -18,14 +18,14 @@ To view PVC usage statistics, you must have the necessary privileges.
 
 * If you do not have admin privileges, complete the following steps:
 +
-** Create cluster roles for the user by running the following command:
+** Create cluster roles by running the following command:
 +
 [source,terminal]
 ----
 $ oc create clusterrole routes-view --verb=get,list --resource=routes
 ----
 +
-** Add the `routes-view` cluster role for the user by running the following command:
+** Add the `routes-view` cluster role by running the following command:
 +
 [source,terminal]
 ----
@@ -33,7 +33,7 @@ $ oc admin policy add-cluster-role-to-user routes-view _<user_name>_
 ----
 ** Replace `_<user_name>_` with the user name.
 +
-** Add the `cluster-monitoring-view` cluster role for the user by running the following command:
+** Add the `cluster-monitoring-view` cluster role by running the following command:
 +
 [source,terminal]
 ----

--- a/modules/storage-persistent-storage-fsGroup.adoc
+++ b/modules/storage-persistent-storage-fsGroup.adoc
@@ -10,8 +10,6 @@
 [role="_abstract"]
 To reduce pod timeouts when using a storage volume with many files, configure the `fsGroup` field. By specifying this field, you can manage how file ownership and permissions are applied, preventing delays caused by the default recursive permission changes on large volumes.
 
-If a storage volume contains many files (~1,000,000 or greater), you may experience pod timeouts.
-
 This can occur because, by default, {product-title} recursively changes ownership and permissions for the contents of each volume to match the `fsGroup` specified in a pod's `securityContext` when that volume is mounted. For large volumes, checking and changing ownership and permissions can be time consuming, slowing pod startup. You can use the `fsGroupChangePolicy` field inside a `securityContext` to control the way that {product-title} checks and manages ownership and permissions for a volume.
 
 `fsGroupChangePolicy` defines behavior for changing ownership and permission of the volume before being exposed inside a pod. This field only applies to volume types that support `fsGroup`-controlled ownership and permissions. This field has two possible values:


### PR DESCRIPTION
Addresses remediation work on [Link to spreadsheet](https://docs.google.com/spreadsheets/d/1vPbOwh7iqQ-mrRKJ-MCXafsprg3Kxxt23dXmjhfyiTM/edit?gid=967267424#gid=967267424)

Version(s):
4.19

Issue:
[OSDOCS-18646](https://issues.redhat.com/browse/OSDOCS-18646)

Link to docs preview:

https://108290--ocpdocs-pr.netlify.app/microshift/latest/microshift_storage/expanding-persistent-volumes-microshift.html

https://108290--ocpdocs-pr.netlify.app/microshift/latest/microshift_storage/using-persistent-storage-microshift.html

https://108290--ocpdocs-pr.netlify.app/microshift/latest/microshift_storage/volume-snapshots-microshift.html

https://108290--ocpdocs-pr.netlify.app/openshift-enterprise/latest/storage/understanding-persistent-storage.html

