### PR TITLE
[OSDOCS-18734]: Removing fs-backup as default for OADP backup

### DIFF
--- a/modules/hcp-dr-oadp-backup-cp-workload-auto.adoc
+++ b/modules/hcp-dr-oadp-backup-cp-workload-auto.adoc
@@ -64,7 +64,7 @@ spec:
   ttl: 2h0m0s
   snapshotMoveData: true <6>
   datamover: "velero" <6>
-  defaultVolumesToFsBackup: true <7>
+  defaultVolumesToFsBackup: false <7>
 ----
 ====
 <1> Replace `backup_resource_name` with a name for your `Backup` resource.
@@ -73,7 +73,7 @@ spec:
 <4> Replace `<hosted_control_plane_namespace>` with the name of the hosted control plane namespace, for example, `clusters-hosted`.
 <5> You must create the `infraenv` resource in a separate namespace. Do not delete the `infraenv` resource during the backup process.
 <6> Enables the CSI volume snapshots and uploads the control plane workload automatically to the cloud storage.
-<7> Sets the `fs-backup` backing up method for persistent volumes (PVs) as default. This setting is useful when you use a combination of Container Storage Interface (CSI) volume snapshots and the `fs-backup` method.
+<7> Specifies that the `fs-backup` backing up method for persistent volumes (PVs) is not used.
 +
 [NOTE]
 ====


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.20+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OSDOCS-18734
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://108323--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp_high_availability/hcp-disaster-recovery-oadp-auto.html#hcp-dr-oadp-backup-cp-workload-auto_hcp-disaster-recovery-oadp-auto
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

NOTE FOR MERGE REVIEW: The purpose of this PR is to resolve a high-priority docs bug. I addressed the bug, but did not apply the changes we've been making for DITA migration (replacing callouts, adding a shortdesc, etc.). 
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
