### PR TITLE
OCPBUGS-78481: Update Preparing your hardware MTU configuration doc

### DIFF
--- a/modules/nw-cluster-mtu-preparing.adoc
+++ b/modules/nw-cluster-mtu-preparing.adoc
@@ -29,7 +29,7 @@ where:
 +
 ** If your hardware MTU is specified in a NetworkManager connection configuration, complete the following steps. This approach is the default for {product-title} if you do not explicitly specify your network configuration with DHCP, a kernel command line, or some other method. Your cluster nodes must all use the same underlying network configuration for the following procedure to work unmodified.
 
-.. Find the primary network interface by entering the following command:
+. Find the primary network interface by entering the following command:
 +
 [source,terminal]
 ----
@@ -42,7 +42,7 @@ where:
 `<node_name>`:: Specifies the name of a node in your cluster.
 --
 
-.. Create the following `NetworkManager` configuration in the `<interface>-mtu.conf` file:
+. Create the following `NetworkManager` configuration in the `<interface>-mtu.conf` file:
 +
 [source,ini]
 ----
@@ -57,3 +57,5 @@ where:
 `<interface>`:: Specifies the primary network interface name.
 `<mtu>`:: Specifies the new hardware MTU value.
 --
++
+** If you used Kubernetes NMState to configure the `br-ex` bridge, use the Kubernetes NMState Operator to update the MTU for the `br-ex` bridge. Changing the MTU for this bridge in a `.nmconnection` file could lead to persistence issues as the Machine Config Operator (MCO) might overwrite the file.


### PR DESCRIPTION
Version(s):
4.16+

Issue:
[OCPBUGS-78481](https://issues.redhat.com/browse/OCPBUGS-78481)

Link to docs preview:
* [Preparing your hardware MTU configuration](https://108326--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/advanced_networking/changing-cluster-network-mtu.html#nw-cluster-mtu-preparing_changing-cluster-network-mtu)


- [x] SME has approved this change (Ben Nemec).
- [x] QE has approved this change (Ross Brattain).
