### PR TITLE
[OSDOCS-18736]: Add note to HCP OADP docs about restic deprecation

### DIFF
--- a/modules/hcp-dr-oadp-dpa.adoc
+++ b/modules/hcp-dr-oadp-dpa.adoc
@@ -57,7 +57,7 @@ spec:
   configuration:
     nodeAgent:
       enable: true
-      uploaderType: kopia
+      uploaderType: kopia #<6>
     velero:
       defaultPlugins:
         - openshift
@@ -72,6 +72,7 @@ spec:
 <3> Specify the bucket prefix; for example, `hcp`.
 <4> The bucket region in this example is `minio`, which is a storage provider that is compatilble with the S3 API.
 <5> Specify the URL of the S3 endpoint.
+<6> Specify `kopia` as the uploader type. The `restic` uploader type is deprecated for {oadp-short} 1.5 and later.
 
 . Create the DPA object by running the following command:
 +
@@ -123,7 +124,7 @@ spec:
   configuration:
     nodeAgent:
       enable: true
-      uploaderType: kopia
+      uploaderType: kopia # <4>
     velero:
       defaultPlugins:
         - openshift
@@ -136,6 +137,7 @@ spec:
 <1> Specify the bucket name; for example, `oadp-backup`.
 <2> Specify the bucket prefix; for example, `hcp`.
 <3> The bucket region in this example is `minio`, which is a storage provider that is compatilble with the S3 API.
+<4> Specify `kopia` as the uploader type. The `restic` uploader type is deprecated for {oadp-short} 1.5 and later.
 
 . Create the DPA resource by running the following command:
 +


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.20+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OSDOCS-18736
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://108332--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp_high_availability/hcp-disaster-recovery-oadp-auto.html#hcp-dr-oadp-dpa_hcp-disaster-recovery-oadp-auto
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

NOTE FOR MERGE REVIEW: The purpose of this PR is to resolve a high-priority docs bug. I addressed the bug, but did not apply the changes we've been making for DITA migration (replacing callouts, adding a shortdesc, etc.).

<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
