### PR TITLE
OSDOCS-18706: DITA updates for 1 assembly in ROSA Prepare

### DIFF
--- a/rosa_planning/rosa-sts-aws-prereqs.adoc
+++ b/rosa_planning/rosa-sts-aws-prereqs.adoc
@@ -41,22 +41,17 @@ endif::openshift-rosa-hcp[]
 
 include::modules/rosa-sts-aws-requirements-account.adoc[leveloffset=+1]
 
-//Adding conditions around these in case the Additional resources don't get ported to HCP or have different file names / locations; keeping all included for now
-ifdef::openshift-rosa[]
 [role="_additional-resources"]
-[id="additional-resources_aws-account-requirements_{context}"]
 .Additional resources
 // Removed as part of OSDOCS-13310, until figures are verified.
 //* xref:../rosa_planning/rosa-limits-scalability.adoc#rosa-limits-scalability[Limits and scalability]
 * xref:../support/troubleshooting/rosa-troubleshooting-deployments.adoc#rosa-troubleshooting-elb-service-role_rosa-troubleshooting-cluster-deployments[Creating the Elastic Load Balancing (ELB) service-linked role]
-endif::openshift-rosa[]
 
 include::modules/rosa-sts-aws-requirements-support-req.adoc[leveloffset=+2]
+
 include::modules/rosa-sts-aws-requirements-security-req.adoc[leveloffset=+2]
 
-//Adding conditions around these in case the Additional resources don't get ported to HCP or have different file names / locations; keeping all included for now
 [role="_additional-resources"]
-[id="additional-resources_aws-security-requirements_{context}"]
 .Additional resources
 ifdef::openshift-dedicated[]
 * xref:../rosa_planning/rosa-sts-aws-prereqs.adoc#osd-aws-privatelink-firewall-prerequisites_rosa-sts-aws-prereqs[AWS firewall prerequisites]
@@ -69,24 +64,25 @@ ifdef::openshift-rosa-hcp[]
 endif::openshift-rosa-hcp[]
 
 include::modules/rosa-sts-aws-requirements-association-concept.adoc[leveloffset=+2]
+
 include::modules/rosa-sts-aws-requirements-creating-association.adoc[leveloffset=+2]
 
 ifdef::openshift-rosa,openshift-rosa-hcp[]
 [role="_additional-resources"]
-[id="additional-resources_creating-association_{context}"]
-== Additional resources
+.Additional resources
 * xref:../rosa_architecture/rosa-sts-about-iam-resources.adoc#rosa-sts-account-wide-roles-and-policies_rosa-sts-about-iam-resources[Account-wide IAM role and policy reference]
 endif::openshift-rosa,openshift-rosa-hcp[]
 
 include::modules/rosa-sts-aws-requirements-creating-multi-association.adoc[leveloffset=+2]
+
 include::modules/rosa-requirements-deploying-in-opt-in-regions.adoc[leveloffset=+1]
+
 include::modules/rosa-setting-the-aws-security-token-version.adoc[leveloffset=+2]
 
 include::modules/rosa-sts-policy-iam.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
-[id="additional-resources_policy-iam_{context}"]
-== Additional resources
+.Additional resources
 ifdef::openshift-rosa[]
 * xref:../rosa_planning/rosa-sts-ocm-role.adoc#rosa-sts-ocm-role[OpenShift Cluster Manager IAM role resources]
 endif::openshift-rosa[]
@@ -97,7 +93,9 @@ endif::openshift-rosa-hcp[]
 * xref:../rosa_architecture/rosa-sts-about-iam-resources.adoc#rosa-sts-operator-roles_rosa-sts-about-iam-resources[Cluster-specific Operator IAM role reference]
 
 include::modules/rosa-aws-provisioned.adoc[leveloffset=+1]
+
 include::modules/rosa-security-groups-custom.adoc[leveloffset=+2]
+
 include::modules/mos-network-prereqs-min-bandwidth.adoc[leveloffset=+1]
 
 [id="osd-aws-privatelink-firewall-prerequisites"]
@@ -114,23 +112,16 @@ include::modules/rosa-hcp-vpc-subnet-tagging.adoc[leveloffset=+2]
 endif::openshift-rosa-hcp[]
 
 [role="_additional-resources"]
-== Additional resources
-* xref:../support/remote_health_monitoring/about-remote-health-monitoring.adoc#about-remote-health-monitoring[About remote health monitoring]
-
-== Next steps
-* xref:../rosa_planning/rosa-sts-required-aws-service-quotas.adoc#rosa-required-aws-service-quotas_rosa-sts-required-aws-service-quotas[Review the required AWS service quotas]
-
-[role="_additional-resources"]
 [id="additional-resources_aws-prerequisites_{context}"]
 == Additional resources
 ifdef::openshift-rosa[]
 * xref:../rosa_architecture/rosa_policy_service_definition/rosa-policy-process-security.adoc#rosa-policy-sre-access_rosa-policy-process-security[SRE access to all {product-title} clusters]
-* xref:../applications/deployments/rosa-config-custom-domains-applications.adoc#rosa-applications-config-custom-domains[Configuring custom domains for applications]
 * xref:../rosa_architecture/rosa_policy_service_definition/rosa-service-definition.adoc#rosa-sdpolicy-instance-types_rosa-service-definition[Instance types]
 endif::openshift-rosa[]
 ifdef::openshift-rosa-hcp[]
 * xref:../rosa_architecture/rosa_policy_service_definition/rosa-sre-access.adoc#rosa-sre-access[SRE and service account access]
-//Omitted until Applications has been ported for HCP
-//* xref ../applications/deployments/rosa-config-custom-domains-applications.adoc#rosa-applications-config-custom-domains[Configuring custom domains for applications]
 * xref:../rosa_architecture/rosa_policy_service_definition/rosa-hcp-instance-types.adoc#rosa-hcp-instance-types[Instance types]
 endif::openshift-rosa-hcp[]
+* xref:../applications/deployments/rosa-config-custom-domains-applications.adoc#rosa-applications-config-custom-domains_rosa-config-custom-domains-applications[Configuring custom domains for applications]
+* xref:../support/remote_health_monitoring/about-remote-health-monitoring.adoc#about-remote-health-monitoring[About remote health monitoring]
+* xref:../rosa_planning/rosa-sts-required-aws-service-quotas.adoc#rosa-required-aws-service-quotas_rosa-sts-required-aws-service-quotas[Required AWS service quotas]


### PR DESCRIPTION


<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.21+

Issue:
https://redhat.atlassian.net/browse/OSDOCS-18706

Link to docs preview:
HCP: [Detailed requirements for deploying Red Hat OpenShift Service on AWS](https://108341--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/rosa_planning/rosa-sts-aws-prereqs.html)
Classic: [Detailed requirements for deploying Red Hat OpenShift Service on AWS (classic architecture) using STS](https://108341--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_planning/rosa-sts-aws-prereqs.html)

QE review:
- N/A

Additional information:
The PR:

- Reformats multiple == Additional resources into .Additional resources. This also fixes a rendering bug from [OSDOCS-18706](https://redhat.atlassian.net/browse/OSDOCS-18706). 
- Removes == Next steps (1 link) since only additional resources are allowed in an assembly after includes. The link is now part of == Additional resources.
- Moves the final .Additional resources (1 link) to == Additional resources to eliminate confusion.
- Adds blank lines between includes.
- Returns a couple of xrefs into the HCP doc. These xrefs were commented out because of the HCP/Classic split, the docs are live now.

This assembly also needs to be modularized but this work is out of scope of this Jira ticket.