### PR TITLE
[RHDEVDOCS-7371] Release notes for Pipelines 1.21.1

### DIFF
--- a/modules/op-release-notes-1-21-1.adoc
+++ b/modules/op-release-notes-1-21-1.adoc
@@ -1,0 +1,21 @@
+// This module is included in the following assemblies:
+// * release_notes/op-release-notes-1-21.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="op-release-notes-1-21-1_{context}"]
+= Release notes for {pipelines-title} 1.21.1
+
+With this update, {pipelines-title} General Availability (GA) 1.21.1 is available on {OCP} 4.14 and later supported versions.
+
+[id="pipelines-fixed-issues-1-21-1_{context}"]
+== Fixed issues
+
+Operator webhook no longer panics for matrixed v1beta1 Pipelines with invalid variable substitutions::
+Before this update, creating a `v1beta1` Pipeline with a matrix that referenced invalid or malformed variables caused the Operator webhook to panic due to an index out of range error. With this update, webhook validation for `v1beta1` Pipelines gracefully rejects invalid matrix references without crashing, consistent with `v1` Pipeline behavior.
++
+link:https://issues.redhat.com/browse/SRVKP-9204[SRVKP-9204]
+
+Custom Hub catalog type is correctly set based on the provided URL::
+Before this update, the custom Hub catalog type was always set to Artifact Hub, regardless of the provided custom catalog URL. As a consequence, catalogs pointing to Tekton Hub were incorrectly identified as Artifact Hub catalogs. With this update, the custom Hub catalog URL is properly validated, and the correct catalog type is automatically determined and set based on the provided URL.
++
+link:https://issues.redhat.com/browse/SRVKP-9976[SRVKP-9976]

--- a/release_notes/op-release-notes-1-21.adoc
+++ b/release_notes/op-release-notes-1-21.adoc
@@ -28,6 +28,9 @@ For an overview of {pipelines-title}, see xref:../about/understanding-openshift-
 // Compatibility and support matrix 1.21
 include::modules/op-tkn-pipelines-compatibility-support-matrix.adoc[leveloffset=+1]
 
+// Release notes for Red Hat Openshift Pipelines 1.21.1
+include::modules/op-release-notes-1-21-1.adoc[leveloffset=+1]
+
 // Release notes for Red Hat OpenShift Pipelines 1.21.0
 include::modules/op-release-notes-1-21-0.adoc[leveloffset=+1]
 


### PR DESCRIPTION
Version(s):
- _none for cherry-picking_

Issue:
- https://redhat.atlassian.net/browse/RHDEVDOCS-7371

Link to docs preview:
- [Release notes for Red Hat OpenShift Pipelines 1.21.1](https://108350--ocpdocs-pr.netlify.app/openshift-pipelines/latest/release_notes/op-release-notes-1-21.html#op-release-notes-1-21-1_op-release-notes-1-21)

QE review:
- [x] QE has approved this change.

