### PR TITLE
RHDEVDOCS-7080: CQA 2.0 for Configure resource requests and limits for GitOps plugin components

### DIFF
--- a/modules/gitops-enabling-the-gitopsservice-custom-resource.adoc
+++ b/modules/gitops-enabling-the-gitopsservice-custom-resource.adoc
@@ -20,7 +20,15 @@ To enable resource configuration for the {gitops-shortname} plugin components, s
 +
 [source,terminal]
 ----
-$ oc get gitopsService -A
+$ oc get gitopsservice -A
+----
++
+Example output:
++
+[source,terminal]
+----
+NAMESPACE          NAME      AGE
+openshift-gitops   cluster   5d
 ----
 
 . Edit the `GitOpsService` CR by running the following command.
@@ -37,7 +45,7 @@ $ oc edit gitopsservice cluster -n openshift-gitops
 [source,yaml]
 ----
 apiVersion: pipelines.openshift.io/v1alpha1
-kind: GitopsService
+kind: GitOpsService
 metadata:
   name: cluster
 spec:
@@ -61,8 +69,19 @@ spec:
 ----
 --
 
+. Save and exit the editor.
+
 After you update the `GitOpsService` CR, the `GitOpsService` controller applies the specified resource requests and limits to the backend and the {gitops-shortname} plugin components.
 
 .Verification
 
-. Ensure that the requests and limits values in the pod specifications match the configuration you have added to the `GitOpsService` CR.
+To verify that the resource requests and limits have been applied:
+
+. Verify the resource configuration:
++
+[source,terminal]
+----
+$ oc describe pod <pod-name> -n openshift-gitops
+----
++
+Look for the `Limits` and `Requests` sections in the output and ensure they match your configuration.

--- a/modules/gitops-plugin-resource-behavior.adoc
+++ b/modules/gitops-plugin-resource-behavior.adoc
@@ -9,10 +9,10 @@
 [role="_abstract"]
 The following information describes how the `GitOpsService` controller applies resource values defined in the `GitOpsService` custom resource (CR).
 
-* *Specified values:*
+* Specified values:
 When you define resource values in the `GitOpsService` CR, the `GitOpsService` controller applies those values only to the components you specify. For example, if you configure resource limits only for the backend, those values apply to the backend deployment and not to the plugin.
 
-* *Default values:*  
+* Default values:
 If you do not define any resource values in the `GitOpsService` custom resource, the `GitOpsService` controller applies default values to all components.
 
 .Default resource values


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

gitops-docs-1.19, gitops-docs-1.20

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

https://redhat.atlassian.net/browse/RHDEVDOCS-7080

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

[Configure resource requests and limits for GitOps plugin components](https://108352--ocpdocs-pr.netlify.app/openshift-gitops/latest/managing_resource/configure-resource-requests-and-limits-for-gitops-plugin-components.html)

Peer review:
- [x] Peer has approved this change.
<!--- Peer approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Peer review: @shivanisathe25 

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
