### PR TITLE
OSDOCS-18636-17:SCALE-1 Core Scalability Planning and Resource Manage

### DIFF
--- a/modules/consuming-huge-pages-resource-using-the-downward-api.adoc
+++ b/modules/consuming-huge-pages-resource-using-the-downward-api.adoc
@@ -60,7 +60,7 @@ spec:
   - name: podinfo
     downwardAPI:
       items:
-        - path: "hugepages_1G_request" <.>
+        - path: "hugepages_1G_request"
           resourceFieldRef:
             containerName: example
             resource: requests.hugepages-1Gi


### PR DESCRIPTION
Version(s):
4.17

Issue:
[OSDOCS-18636](https://issues.redhat.com/browse/OSDOCS-18636)

Link to docs preview:
* [Consuming huge pages resources using the Downward API](https://108365--ocpdocs-pr.netlify.app/openshift-enterprise/latest/scalability_and_performance/what-huge-pages-do-and-how-they-are-consumed-by-apps.html#consuming-huge-pages-resource-using-the-downward-api_huge-pages)
