### PR TITLE
OSDOCS-18636-main: SCALE-1 Core Scalability Planning and Resource Manage

### DIFF
--- a/modules/openshift-cluster-maximums-major-releases.adoc
+++ b/modules/openshift-cluster-maximums-major-releases.adoc
@@ -42,7 +42,7 @@ Red{nbsp}Hat does not provide direct guidance on sizing your {product-title} clu
 
 | Number of pods per namespace
 | 25,000
-| here are several control loops in the system that must iterate over all objects in a given namespace as a reaction to some changes in state. Having a large number of objects of a given type in a single namespace can make those loops expensive and slow down processing given state changes. The limit assumes that the system has enough CPU, memory, and disk to satisfy the application requirements.
+| There are several control loops in the system that must iterate over all objects in a given namespace as a reaction to some changes in state. Having a large number of objects of a given type in a single namespace can make those loops expensive and slow down processing given state changes. The limit assumes that the system has enough CPU, memory, and disk to satisfy the application requirements.
 
 | Number of routes per default 2-router deployment
 | 9,000


### PR DESCRIPTION
Version(s):
4.17+

Issue:
[OSDOCS-18636](https://issues.redhat.com/browse/OSDOCS-18636)

Link to docs preview:
[OpenShift Container Platform tested cluster maximums for major releases](https://108367--ocpdocs-pr.netlify.app/openshift-enterprise/latest/scalability_and_performance/planning-your-environment-according-to-object-maximums.html)