### PR TITLE
[OBSDOCS-3177] Release notes for Logging 6.3.4

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -391,4 +391,4 @@ endif::openshift-origin[]
 :logging-title-uc: Logging for Red Hat OpenShift
 
 :logging-major-version: 6.3
-:logging-minor-version: 2
+:logging-minor-version: 4

--- a/modules/logging-release-notes-6-3-4.adoc
+++ b/modules/logging-release-notes-6-3-4.adoc
@@ -1,0 +1,16 @@
+// Module included in the following assemblies:
+//
+// * release_notes/logging-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="logging-release-notes-6-3-4_{context}"]
+= Logging 6.3.4 release notes
+
+This release includes link:https://access.redhat.com/errata/RHSA-2026:4939[RHSA-2026:4939].
+
+[id="logging-release-notes-6-3-4-CVEs_{context}"]
+== CVEs
+
+* link:https://access.redhat.com/security/cve/CVE-2025-61726[CVE-2025-61726]
+* link:https://access.redhat.com/security/cve/CVE-2025-61729[CVE-2025-61729]
+* link:https://access.redhat.com/security/cve/CVE-2025-68121[CVE-2025-68121]

--- a/release_notes/logging-release-notes.adoc
+++ b/release_notes/logging-release-notes.adoc
@@ -7,6 +7,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+include::modules/logging-release-notes-6-3-4.adoc[leveloffset=+1]
+
 include::modules/logging-release-notes-6-3-3.adoc[leveloffset=+1]
 
 include::modules/logging-release-notes-6-3-2.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s):
- _none for cherry-picking_

Issue:
- https://redhat.atlassian.net/browse/OBSDOCS-3177

Link to docs preview:
- [Logging 6.2.4 release notes](https://108393--ocpdocs-pr.netlify.app/openshift-logging/latest/release_notes/logging-release-notes.html#logging-release-notes-6-3-4_logging-release-notes)

QE review:
- [x] SE approved. QE apporval not needed as this only adds CVE links.
