### PR TITLE
TELCODOCS-2812 Fix Vale errors and warnings in optimizing-cpu-usage assembly

### DIFF
--- a/modules/enabling-encapsulation.adoc
+++ b/modules/enabling-encapsulation.adoc
@@ -7,7 +7,7 @@
 = Configuring mount namespace encapsulation
 
 [role="_abstract"]
-To run your cluster with less resource overhead, configure mount namespace encapsulation. This setting optimizes performance by moving mount namespaces to an alternative location, preventing the host operating system from constantly scanning them.
+To run your cluster with fewer resource requirements, configure mount namespace encapsulation. This setting optimizes performance by moving mount namespaces to an alternative location, preventing the host operating system from constantly scanning them.
 
 [NOTE]
 ====

--- a/modules/optimizing-by-encapsulation.adoc
+++ b/modules/optimizing-by-encapsulation.adoc
@@ -9,7 +9,7 @@
 [role="_abstract"]
 To prevent the host operating system from constantly scanning mount points, review the process of encapsulation. This mechanism moves Kubernetes mount namespaces to an alternative location, ensuring that processes in different namespaces remain isolated and cannot view each other's files.
 
-The host operating system uses systemd to constantly scan all mount namespaces: both the standard Linux mounts and the numerous mounts that Kubernetes uses to operate. The current implementation of kubelet and CRI-O both use the top-level namespace for all container runtime and kubelet mount points. However, encapsulating these container-specific mount points in a private namespace reduces systemd overhead with no difference in functionality. Using a separate mount namespace for both CRI-O and kubelet can encapsulate container-specific mounts from any systemd or other host operating system interaction.
+The host operating system uses systemd to constantly scan all mount namespaces: both the standard Linux mounts and the numerous mounts that Kubernetes uses to operate. The current implementation of kubelet and CRI-O both use the top-level namespace for all container runtime and kubelet mount points. However, encapsulating these container-specific mount points in a private namespace reduces the systemd resource usage with no difference in functionality. Using a separate mount namespace for both CRI-O and kubelet can encapsulate container-specific mounts from any systemd or other host operating system interaction.
 
 This ability to potentially achieve major CPU optimization is now available to all {product-title} administrators. Encapsulation can also improve security by storing Kubernetes-specific mount points in a location safe from inspection by unprivileged users.
 
@@ -37,6 +37,6 @@ image::after-k8s-mount-propagation.png[After encapsulation]
 
 * Using a separate mount namespace for both CRI-O and kubelet completely separates all container-specific mounts away from any systemd or other host operating system interaction whatsoever.
 
-* The behavior of Container 1 is unchanged, except a mount it creates such as `/run/a` is no longer visible to systemd or host operating system processes. It is still visible to kubelet, CRI-O, and other containers with host-to-container or bidirectional mount propagation configured (like Container 2).
+* The behavior of Container 1 is unchanged, except a mount it creates such as `/run/a` is no longer visible to systemd or host operating system processes. It is still visible to kubelet, CRI-O, and other containers with host-to-container or bidirectional mount propagation configured (such as Container 2).
 
 * The behavior of Container 2 and Container 3 is unchanged.

--- a/modules/running-services-with-encapsulation.adoc
+++ b/modules/running-services-with-encapsulation.adoc
@@ -6,7 +6,7 @@
 = Running additional services in the encapsulated namespace
 
 [role="_abstract"]
-To enable monitoring tools to view mount points created by kubelet, CRI-O, or containers, use the `kubensenter` script provided with {product-title}. By using this tool, you can execute commands inside the Kubernetes mount point, ensuring existing tools can run within the encapsulated namespace.
+To enable monitoring tools to view mount points created by kubelet, CRI-O, or containers, use the `kubensenter` script provided with {product-title}. By using this tool, you can run commands inside the Kubernetes mount point, ensuring existing tools can run within the encapsulated namespace.
 
 The `kubensenter` script is aware of the state of the mount encapsulation feature status, and is safe to run even if encapsulation is not enabled. In that case the script executes the provided command in the default mount namespace.
 

--- a/scalability_and_performance/optimization/optimizing-cpu-usage.adoc
+++ b/scalability_and_performance/optimization/optimizing-cpu-usage.adoc
@@ -26,6 +26,6 @@ include::modules/running-services-with-encapsulation.adoc[leveloffset=+1]
 
 * link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/monitoring_and_managing_system_status_and_performance/setting-limits-for-applications_monitoring-and-managing-system-status-and-performance#what-namespaces-are_setting-limits-for-applications[What are namespaces]
 
-* link:https://www.redhat.com/sysadmin/container-namespaces-nsenter[Manage containers in namespaces by using nsenter]
+* link:https://www.redhat.com/sysadmin/container-namespaces-nsenter[Manage containers in namespaces by using `nsenter`]
 
-* xref:../../rest_api/machine_apis/machineconfig-machineconfiguration-openshift-io-v1.adoc[MachineConfig]
+* xref:../../rest_api/machine_apis/machineconfig-machineconfiguration-openshift-io-v1.adoc#machineconfig-machineconfiguration-openshift-io-v1[MachineConfig]


### PR DESCRIPTION
## Summary
- Add missing anchor ID to `MachineConfig` xref to fix `OpenShiftAsciiDoc.XrefContainsAnchorID` error
- Wrap `nsenter` in backticks in link text to resolve spelling warning
- Replace "overhead" with specific terminology per `RedHat.DoNotUseTerms`
- Replace "like" with "such as" per `RedHat.TermsWarnings`
- Replace "execute" with "run" per `RedHat.TermsWarnings`

## Test plan
- [x] Vale linting passes with zero errors and warnings
- [ ] Verify rendered output in preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)