### PR TITLE
TELCODOCS-2813: Fix DITA warnings in routing-optimization

### DIFF
--- a/modules/ingress-liveness-readiness-startup-probes.adoc
+++ b/modules/ingress-liveness-readiness-startup-probes.adoc
@@ -39,7 +39,8 @@ The following example demonstrates how you can directly patch the default router
 $ oc -n openshift-ingress patch deploy/router-default --type=strategic --patch='{"spec":{"template":{"spec":{"containers":[{"name":"router","livenessProbe":{"timeoutSeconds":5},"readinessProbe":{"timeoutSeconds":5}}]}}}}'
 ----
 
-.Verification
+To verify that the timeout values are set correctly, run the following command:
+
 [source,terminal]
 ----
 $ oc -n openshift-ingress describe deploy/router-default | grep -e Liveness: -e Readiness:

--- a/scalability_and_performance/optimization/routing-optimization.adoc
+++ b/scalability_and_performance/optimization/routing-optimization.adoc
@@ -1,6 +1,7 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="routing-optimization"]
 = Optimizing routing
+
 include::_attributes/common-attributes.adoc[]
 :context: routing-optimization
 


### PR DESCRIPTION
## Summary

- Add blank line after document title in `routing-optimization.adoc` to prevent AsciiDoc author line interpretation (AuthorLine warning)
- Replace `.Verification` block title with inline text in `ingress-liveness-readiness-startup-probes.adoc` since block titles are not supported in REFERENCE modules for DITA conversion (BlockTitle warning)

## Test plan

- [ ] Verify Vale AsciiDocDITA rules pass with 0 errors and 0 warnings on affected files
- [ ] Verify AsciiDoc renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)