### PR TITLE
OSDOCS 16930-16 Remediation for NODES-2

### DIFF
--- a/modules/mco-update-boot-images-configuring.adoc
+++ b/modules/mco-update-boot-images-configuring.adoc
@@ -1,7 +1,6 @@
 // Module included in the following assemblies:
 //
 // * machine-configuration/mco-update-boot-images.adoc
-// * nodes/nodes-nodes-managing.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="mco-update-boot-images-configuring_{context}"]
@@ -10,13 +9,15 @@
 [role="_abstract"]
 include::snippets/mco-update-boot-images-abstract.adoc[]
 
+You can configure your cluster to update the boot image whenever you update your cluster by modifying the `MachineConfiguration` object. 
+
 Enabling the feature updates the boot image to the {op-system-first} boot image version appropriate for your cluster. If the cluster is again updated to a new {product-title} version in the future, the boot image is updated again. New nodes created after enabling the feature use the updated boot image. This feature has no effect on existing nodes.
 
-To enable the boot image management feature for control plane machine sets or to re-enable the boot image management feature for worker machine sets where it was disabled, edit the `MachineConfiguration` object. You can enable the feature for all of the machine sets in the cluster or specific machine sets.
+You can enable the feature for all of the machine sets in the cluster or specific machine sets.
 
 .Prerequisites
 
-* If you are enabling boot image management for control plane machine sets, you enabled the required Technology Preview features for your cluster by editing the `FeatureGate` CR named `cluster`.
+* You have enabled the `TechPreviewNoUpgrade` feature set by using the feature gates. For more information, see "Enabling features using feature gates" in the _Additional resources_  section.
 
 .Procedure
 

--- a/modules/mco-update-boot-images-disable.adoc
+++ b/modules/mco-update-boot-images-disable.adoc
@@ -32,7 +32,8 @@ metadata:
   namespace: openshift-machine-config-operator
 spec:
 # ...
-  managedBootImages: <1>
+  managedBootImages:
     machineManagers: []
 ----
-<1> Remove the parameters listed under `machineManagers` and add the `[]` characters to disable boot image updates.
++
+Remove the parameters listed under `machineManagers` and add the `[]` characters to disable boot image updates.

--- a/modules/nodes-nodes-viewing-listing.adoc
+++ b/modules/nodes-nodes-viewing-listing.adoc
@@ -218,12 +218,12 @@ where:
 `Events`:: Specifies the events reported by the node.
 --
 +
-ifndef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
+ifndef::openshift-rosa,openshift-dedicated[]
 [NOTE]
 ====
 The control plane label is not automatically added to newly created or updated master nodes. If you want to use the control plane label for your nodes, you can manually configure the label. For more information, see _Understanding how to update labels on nodes_ in the _Additional resources_ section.
 ====
-endif::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
+endif::openshift-rosa,openshift-dedicated[]
 
 Among the information shown for nodes, the following node conditions appear in the output of the commands shown in this section:
 


### PR DESCRIPTION
Remediation work for https://github.com/openshift/openshift-docs/pull/106219 and https://issues.redhat.com/browse/OSDOCS-16930

mco-update-boot-images-configuring -- remove inappropriate version information
mco-update-boot-images-disable -- removed missed call-out 
nodes-nodes-viewing-listing.adoc -- replaced [ifdef to original](https://github.com/openshift/openshift-docs/blame/8e462f2f79ad511a5952a6564ea7552e70e39e15/modules/nodes-nodes-viewing-listing.adoc#L216)

Previews
