### PR TITLE
OSDOCS -16577 [ROSA] Vale Errors: Cluster Admin

### DIFF
--- a/modules/rosa-cluster-autoscaler-about.adoc
+++ b/modules/rosa-cluster-autoscaler-about.adoc
@@ -1,0 +1,14 @@
+// Module included in the following assemblies:
+//
+// * rosa_cluster_admin/rosa-cluster-autoscaling-hcp.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="rosa-cluster-autoscaler-about_{context}"]
+= About the cluster autoscaler
+
+[role="_abstract"]
+The cluster autoscaler adjusts the size of a {product-title} cluster to meet its current deployment needs. It uses declarative, Kubernetes-style arguments to provide infrastructure management that does not rely on objects of a specific cloud provider. The cluster autoscaler has a cluster scope, and is not associated with a particular namespace. In {product-title}, the Cluster Autoscaler is fully managed, which means it is hosted along with the control plane.
+
+The cluster autoscaler increases the size of the cluster when there are pods that fail to schedule on any of the current worker nodes due to insufficient resources or when another node is necessary to meet deployment needs. The cluster autoscaler does not increase the cluster resources beyond the limits that you specify.
+
+The cluster autoscaler computes the total memory, CPU, and GPU only on the nodes that belong to autoscaling machine pools. All of the machine pool nodes that are not autoscaling are excluded from this aggregation. For example, if you set the `maxNodesTotal` to `50` on a {product-title} cluster with three machine pools in which a single machine pool is not autoscaling, the cluster autoscaler restricts the total nodes to `50` in only those two machine pools that are autoscaling. The single manually scaling machine pool can have additional nodes, making the overall cluster nodes total more than `50`.

--- a/modules/rosa-cluster-autoscaler-cli-describe.adoc
+++ b/modules/rosa-cluster-autoscaler-cli-describe.adoc
@@ -10,7 +10,6 @@ You can view your cluster autoscaler configurations using the `rosa describe aut
 
 //ROSA HCP procedure
 ifdef::openshift-rosa-hcp[]
-.Procedure
 
 * To view cluster autoscaler configurations, run the following command:
 +
@@ -23,7 +22,6 @@ endif::openshift-rosa-hcp[]
 
 //ROSA Classic procedure
 ifdef::openshift-rosa[]
-.Procedure
 
 * To view cluster autoscaler configurations, run the following command:
 +

--- a/modules/rosa-cluster-autoscaler-interaction.adoc
+++ b/modules/rosa-cluster-autoscaler-interaction.adoc
@@ -1,0 +1,18 @@
+// Module included in the following assemblies:
+//
+// * rosa_cluster_admin/rosa-cluster-autoscaling-hcp.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="rosa-cluster-autoscaler-interaction_{context}"]
+=  Interaction with other scheduling features
+
+[role="_abstract"]
+The horizontal pod autoscaler (HPA) and the cluster autoscaler modify cluster resources in different ways. The HPA changes the deployment's or replica set's number of replicas based on the current CPU load. If the load increases, the HPA creates new replicas, regardless of the amount of resources available to the cluster. If there are not enough resources, the cluster autoscaler adds resources so that the HPA-created pods can run. If the load decreases, the HPA stops some replicas. If this action causes some nodes to be underutilized or completely empty, the cluster autoscaler deletes the unnecessary nodes.
+
+The cluster autoscaler takes pod priorities into account. The Pod Priority and Preemption feature enables scheduling pods based on priorities if the cluster does not have enough resources, but the cluster autoscaler ensures that the cluster has resources to run all pods. To honor the intention of both features, the cluster autoscaler includes a priority cutoff function. You can use this cutoff to schedule "best-effort" pods, which do not cause the cluster autoscaler to increase resources but instead run only when spare resources are available.
+
+Pods with priority lower than the cutoff value do not cause the cluster to scale up or prevent the cluster from scaling down. No new nodes are added to run the pods, and nodes running these pods might be deleted to free resources.
+
+include::modules/rosa-cluster-autoscaler-cli-interactive-during.adoc[leveloffset=+1]
+
+include::modules/rosa-cluster-autoscaler-cli-during.adoc[leveloffset=+1]

--- a/modules/rosa-cluster-autoscaler-limitations.adoc
+++ b/modules/rosa-cluster-autoscaler-limitations.adoc
@@ -1,0 +1,24 @@
+// Module included in the following assemblies:
+//
+// * rosa_cluster_admin/rosa-cluster-autoscaling-hcp.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="rosa-cluster-autoscaler-limitations_{context}"]
+=  Limitations
+
+[role="_abstract"]
+If you configure the cluster autoscaler, additional usage restrictions apply. 
+
+See the following restrictions: 
+
+* Do not modify the nodes that are in autoscaled node groups directly. All nodes within the same node group have the same capacity and labels and run the same system pods.
+* Specify requests for your pods.
+* If you have to prevent pods from being deleted too quickly, configure appropriate PDBs.
+* Confirm that your cloud provider quota is large enough to support the maximum node pools that you configure.
+* Do not run additional node group autoscalers, especially the ones offered by your cloud provider.
+
+[NOTE]
+====
+The cluster autoscaler only adds nodes in autoscaled node groups if doing so would result in a schedulable pod.
+If the available node types cannot meet the requirements for a pod request, or if the node groups that could meet these requirements are at their maximum size, the cluster autoscaler cannot scale up.
+====

--- a/modules/rosa-cluster-autoscaler-scale-down.adoc
+++ b/modules/rosa-cluster-autoscaler-scale-down.adoc
@@ -1,0 +1,28 @@
+// Module included in the following assemblies:
+//
+// * rosa_cluster_admin/rosa-cluster-autoscaling-hcp.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="rosa-cluster-autoscaler-scale-down_{context}"]
+=  Automatic node removal
+
+[role="_abstract"]
+Every 10 seconds, the cluster autoscaler checks which nodes are unnecessary in the cluster and removes them.
+
+The cluster autoscaler considers a node for removal if the following conditions apply:
+
+* The node utilization is less than the _node utilization level_ threshold for the cluster. The node utilization level is the sum of the requested resources divided by the allocated resources for the node. If you do not specify a value in the `ClusterAutoscaler` custom resource, the cluster autoscaler uses a default value of `0.5`, which corresponds to 50% utilization.
+* The cluster autoscaler can move all pods running on the node to the other nodes. The Kubernetes scheduler is responsible for scheduling pods on the nodes.
+* The cluster autoscaler does not have scale down disabled annotation.
+
+If the following types of pods are present on a node, the cluster autoscaler will not remove the node:
+
+* Pods with restrictive pod disruption budgets (PDBs).
+* Kube-system pods that do not run on the node by default.
+* Kube-system pods that do not have a PDB or have a PDB that is too restrictive.
+* Pods that are not backed by a controller object such as a deployment, replica set, or stateful set.
+* Pods with local storage.
+* Pods that cannot be moved elsewhere because of a lack of resources, incompatible node selectors or affinity, matching anti-affinity, and so on.
+* Unless they also have a `"cluster-autoscaler.kubernetes.io/safe-to-evict": "true"` annotation, pods that have a `"cluster-autoscaler.kubernetes.io/safe-to-evict": "false"` annotation.
+
+For example, you set the maximum CPU limit to 64 cores and configure the cluster autoscaler to only create machines that have 8 cores each. If your cluster starts with 30 cores, the cluster autoscaler can add up to 4 more nodes with 32 cores, for a total of 62.

--- a/modules/rosa-cluster-cli-autoscale-parameters.adoc
+++ b/modules/rosa-cluster-cli-autoscale-parameters.adoc
@@ -1,0 +1,41 @@
+// Module included in the following assemblies:
+//
+// * rosa_cluster_admin/rosa-cluster-autoscaling-hcp.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="rosa-cluster-cli-autoscale-parameters_{context}"]
+= Cluster autoscaling parameters using the ROSA CLI
+
+[role="_abstract"]
+You can add the following parameters to the cluster creation command to configure autoscaler parameters when using the {rosa-cli-first}.
+
+.Configurable autoscaler parameters available with the ROSA CLI
+
+[cols="4",options="header"]
+|===
+|Setting
+|Description
+|Type or Range
+|Example/Instruction
+
+|`--autoscaler-max-pod-grace-period _int_`
+|Gives pods graceful termination time before scaling down, measured in seconds. Replace _int_ in the command with the number of seconds you want to use.
+|`integer`
+|`--autoscaler-max-pod-grace-period 0`
+
+|`--autoscaler-pod-priority-threshold _int_`
+|The priority that a pod must exceed to cause the cluster autoscaler to deploy additional nodes. Replace _int_ in the command with the number you want to use, can be negative.
+|`integer`
+|`--autoscaler-pod-priority-threshold -10`
+
+|`--autoscaler-max-node-provision-time _string_`
+|Maximum time that the cluster autoscaler waits for a node to be provisioned. Replace _string_ in the command with an integer and time unit (ns,us,µs,ms,s,m,h).
+|`string`
+|`--autoscaler-max-node-provision-time 35m`
+
+|`--autoscaler-max-nodes-total _int_`
+|Maximum amount of nodes in the cluster, including the autoscaled nodes. Replace _int_ in the command with the number you want to use.
+|`integer`
+|`--autoscaler-max-nodes-total 180`
+
+|===

--- a/modules/rosa-cluster-notification-emails.adoc
+++ b/modules/rosa-cluster-notification-emails.adoc
@@ -1,0 +1,14 @@
+// Module included in the following assemblies:
+//
+// * rosa_cluster_admin/rosa-cluster-notifications.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="rosa-cluster-notification-emails_{context}"]
+= Cluster notification emails   
+
+[role="_abstract"]
+By default, when a cluster notification is sent to the cluster, it is also sent as an email to the cluster owner. You can configure additional recipients for notification emails to ensure that all appropriate users remain informed about the state of the cluster.
+
+include::modules/managed-cluster-add-notification-contacts.adoc[leveloffset=+2]
+
+include::modules/managed-cluster-remove-notification-contacts.adoc[leveloffset=+2]

--- a/modules/rosa-edit-cluster-autoscale-cli.adoc
+++ b/modules/rosa-edit-cluster-autoscale-cli.adoc
@@ -1,0 +1,24 @@
+// Module included in the following assemblies:
+//
+// * rosa_cluster_admin/rosa-cluster-autoscaling-hcp.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="rosa-edit-cluster-autoscale-cli_{context}"]
+= Edit autoscaling after cluster creation with the ROSA CLI
+
+[role="_abstract"]
+You can edit any specific parameters of the cluster autoscaler after creating the autoscaler when using the {rosa-cli-first}.
+
+* To edit the cluster autoscaler, run the following command:
++
+[source,terminal]
+----
+$ rosa edit autoscaler --cluster=<mycluster>
+----
++
+** To edit a specific parameter, run the following command:
++
+[source,terminal]
+----
+$ rosa edit autoscaler --cluster=<mycluster> <parameter>
+----

--- a/modules/rosa-expectations.adoc
+++ b/modules/rosa-expectations.adoc
@@ -1,0 +1,18 @@
+// Module included in the following assemblies:
+//
+// * rosa_cluster_admin/rosa-cluster-notifications.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="rosa-expectations_{context}"]
+=  What to expect from cluster notifications
+
+[role="_abstract"]
+As a cluster administrator, you need to be aware of when and why cluster notifications are sent, as well as their types and severity levels, in order to effectively understand the health and administration needs of your cluster.
+
+include::modules/managed-cluster-notification-policy.adoc[leveloffset=+2]
+
+include::modules/managed-cluster-notification-severity-levels.adoc[leveloffset=+2]
+
+include::modules/managed-cluster-notification-types.adoc[leveloffset=+2]
+
+include::modules/managed-cluster-notification-view-in-hcc.adoc[leveloffset=+1]

--- a/modules/rosa-troubleshooting-cluster-notifications.adoc
+++ b/modules/rosa-troubleshooting-cluster-notifications.adoc
@@ -1,0 +1,18 @@
+// Module included in the following assemblies:
+//
+// * rosa_cluster_admin/rosa-cluster-notifications.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="rosa-troubleshooting-cluster-notifications_{context}"]
+= Troubleshooting cluster notifications
+
+[role="_abstract"]
+If you are not receiving cluster notification emails, you can troubleshoot the issue by completing the following steps.
+
+* Ensure that emails sent from `@redhat.com` addresses are not filtered out of your email inbox.
+* Ensure that your correct email address is listed as a notification contact for the cluster.
+* Ask the cluster owner or administrator to add you as a notification contact: xref:#cluster-notification-emails_rosa-cluster-notifications[Cluster notification emails].
+
+If your cluster does not receive notifications:
+
+* Ensure that your cluster can access resources at `api.openshift.com`.

--- a/rosa_cluster_admin/rosa-cluster-autoscaling-hcp.adoc
+++ b/rosa_cluster_admin/rosa-cluster-autoscaling-hcp.adoc
@@ -10,139 +10,17 @@ toc::[]
 [role="_abstract"]
 Applying autoscaling to {product-title} clusters involves configuring one or more machine pools with autoscaling. You can use the Cluster Autoscaler to further configure cluster-wide autoscaling that is applicable to all of the machine pools that are autoscaling.
 
-[id="cluster-autoscaler-about_{context}"]
-== About the cluster autoscaler
+include::modules/rosa-cluster-autoscaler-about.adoc[leveloffset=+1]
 
-The cluster autoscaler adjusts the size of a {product-title} cluster to meet its current deployment needs. It uses declarative, Kubernetes-style arguments to provide infrastructure management that does not rely on objects of a specific cloud provider. The cluster autoscaler has a cluster scope, and is not associated with a particular namespace. In {product-title}, the Cluster Autoscaler is fully managed, which means it is hosted along with the control plane.
+include::modules/rosa-cluster-autoscaler-scale-down.adoc[leveloffset=+1]
 
-The cluster autoscaler increases the size of the cluster when there are pods that fail to schedule on any of the current worker nodes due to insufficient resources or when another node is necessary to meet deployment needs. The cluster autoscaler does not increase the cluster resources beyond the limits that you specify.
+include::modules/rosa-cluster-autoscaler-limitations.adoc[leveloffset=+1]
 
-The cluster autoscaler computes the total memory, CPU, and GPU only on the nodes that belong to autoscaling machine pools. All of the machine pool nodes that are not autoscaling are excluded from this aggregation. For example, if you set the `maxNodesTotal` to `50` on a {product-title} cluster with three machine pools in which a single machine pool is not autoscaling, the cluster autoscaler restricts the total nodes to `50` in only those two machine pools that are autoscaling. The single manually scaling machine pool can have additional nodes, making the overall cluster nodes total more than `50`.
+include::modules/rosa-cluster-autoscaler-interaction.adoc[leveloffset=+1]
 
-[id="cluster-autoscaler-scale-down_{context}"]
-=== Automatic node removal
+include::modules/rosa-cluster-cli-autoscale-parameters.adoc[leveloffset=+1]
 
-Every 10 seconds, the cluster autoscaler checks which nodes are unnecessary in the cluster and removes them. The cluster autoscaler considers a node for removal if the following conditions apply:
+include::modules/rosa-edit-cluster-autoscale-cli.adoc[leveloffset=+1]
 
-* The node utilization is less than the _node utilization level_ threshold for the cluster. The node utilization level is the sum of the requested resources divided by the allocated resources for the node. If you do not specify a value in the `ClusterAutoscaler` custom resource, the cluster autoscaler uses a default value of `0.5`, which corresponds to 50% utilization.
-* The cluster autoscaler can move all pods running on the node to the other nodes. The Kubernetes scheduler is responsible for scheduling pods on the nodes.
-* The cluster autoscaler does not have scale down disabled annotation.
-
-If the following types of pods are present on a node, the cluster autoscaler will not remove the node:
-
-* Pods with restrictive pod disruption budgets (PDBs).
-* Kube-system pods that do not run on the node by default.
-* Kube-system pods that do not have a PDB or have a PDB that is too restrictive.
-* Pods that are not backed by a controller object such as a deployment, replica set, or stateful set.
-* Pods with local storage.
-* Pods that cannot be moved elsewhere because of a lack of resources, incompatible node selectors or affinity, matching anti-affinity, and so on.
-* Unless they also have a `"cluster-autoscaler.kubernetes.io/safe-to-evict": "true"` annotation, pods that have a `"cluster-autoscaler.kubernetes.io/safe-to-evict": "false"` annotation.
-
-For example, you set the maximum CPU limit to 64 cores and configure the cluster autoscaler to only create machines that have 8 cores each. If your cluster starts with 30 cores, the cluster autoscaler can add up to 4 more nodes with 32 cores, for a total of 62.
-
-[id="cluster-autoscaler-limitations_{context}"]
-=== Limitations
-
-If you configure the cluster autoscaler, additional usage restrictions apply:
-
-* Do not modify the nodes that are in autoscaled node groups directly. All nodes within the same node group have the same capacity and labels and run the same system pods.
-* Specify requests for your pods.
-* If you have to prevent pods from being deleted too quickly, configure appropriate PDBs.
-* Confirm that your cloud provider quota is large enough to support the maximum node pools that you configure.
-* Do not run additional node group autoscalers, especially the ones offered by your cloud provider.
-
-[NOTE]
-====
-The cluster autoscaler only adds nodes in autoscaled node groups if doing so would result in a schedulable pod.
-If the available node types cannot meet the requirements for a pod request, or if the node groups that could meet these requirements are at their maximum size, the cluster autoscaler cannot scale up.
-====
-
-[id="cluster-autoscaler-interaction_{context}"]
-=== Interaction with other scheduling features
-
-The horizontal pod autoscaler (HPA) and the cluster autoscaler modify cluster resources in different ways. The HPA changes the deployment's or replica set's number of replicas based on the current CPU load. If the load increases, the HPA creates new replicas, regardless of the amount of resources available to the cluster. If there are not enough resources, the cluster autoscaler adds resources so that the HPA-created pods can run. If the load decreases, the HPA stops some replicas. If this action causes some nodes to be underutilized or completely empty, the cluster autoscaler deletes the unnecessary nodes.
-
-The cluster autoscaler takes pod priorities into account. The Pod Priority and Preemption feature enables scheduling pods based on priorities if the cluster does not have enough resources, but the cluster autoscaler ensures that the cluster has resources to run all pods. To honor the intention of both features, the cluster autoscaler includes a priority cutoff function. You can use this cutoff to schedule "best-effort" pods, which do not cause the cluster autoscaler to increase resources but instead run only when spare resources are available.
-
-Pods with priority lower than the cutoff value do not cause the cluster to scale up or prevent the cluster from scaling down. No new nodes are added to run the pods, and nodes running these pods might be deleted to free resources.
-
-include::modules/rosa-cluster-autoscaler-cli-interactive-during.adoc[leveloffset=+1]
-
-include::modules/rosa-cluster-autoscaler-cli-during.adoc[leveloffset=+1]
-
-[id="rosa-cluster-cli-autoscale-parameters_{context}"]
-== Cluster autoscaling parameters using the ROSA CLI
-
-You can add the following parameters to the cluster creation command to configure autoscaler parameters when using the {rosa-cli-first}.
-
-.Configurable autoscaler parameters available with the ROSA CLI
-
-[cols="4",options="header"]
-|===
-|Setting
-|Description
-|Type or Range
-|Example/Instruction
-
-|`--autoscaler-max-pod-grace-period _int_`
-|Gives pods graceful termination time before scaling down, measured in seconds. Replace _int_ in the command with the number of seconds you want to use.
-|`integer`
-|`--autoscaler-max-pod-grace-period 0`
-
-|`--autoscaler-pod-priority-threshold _int_`
-|The priority that a pod must exceed to cause the cluster autoscaler to deploy additional nodes. Replace _int_ in the command with the number you want to use, can be negative.
-|`integer`
-|`--autoscaler-pod-priority-threshold -10`
-
-|`--autoscaler-max-node-provision-time _string_`
-|Maximum time that the cluster autoscaler waits for a node to be provisioned. Replace _string_ in the command with an integer and time unit (ns,us,µs,ms,s,m,h).
-|`string`
-|`--autoscaler-max-node-provision-time 35m`
-
-|`--autoscaler-max-nodes-total _int_`
-|Maximum amount of nodes in the cluster, including the autoscaled nodes. Replace _int_ in the command with the number you want to use.
-|`integer`
-|`--autoscaler-max-nodes-total 180`
-
-|===
-
-//::modules/rosa-cluster-autoscaler-cli-edit.adoc[leveloffset=+1]
-[id="rosa-edit-cluster-autoscale-cli_{context}"]
-== Edit autoscaling after cluster creation with the ROSA CLI
-
-You can edit any specific parameters of the cluster autoscaler after creating the autoscaler when using the {rosa-cli-first}.
-
-.Procedure
-
-* To edit the cluster autoscaler, run the following command:
-+
-.Example
-[source,terminal]
-----
-$ rosa edit autoscaler --cluster=<mycluster>
-----
-+
-** To edit a specific parameter, run the following command:
-+
-.Example
-[source,terminal]
-----
-$ rosa edit autoscaler --cluster=<mycluster> <parameter>
-----
-
-//::modules/rosa-cluster-autoscaler-cli-describe.adoc[leveloffset=+1]
-[id="rosa-cluster-autoscaler-cli-describe_{context}"]
-== View autoscaler configurations with the ROSA CLI
-
-You can view your cluster autoscaler configurations using the `rosa describe autoscaler` command when using the {rosa-cli-first}.
-
-.Procedure
-
-* To view cluster autoscaler configurations, run the following command:
-+
-.Example
-[source,terminal]
-----
-$ rosa describe autoscaler -h --cluster=<mycluster>
-----
+include::modules/rosa-cluster-autoscaler-cli-describe.adoc[leveloffset=+1]
 

--- a/rosa_cluster_admin/rosa-cluster-notifications.adoc
+++ b/rosa_cluster_admin/rosa-cluster-notifications.adoc
@@ -9,6 +9,9 @@ toc::[]
 
 include::snippets/managed-openshift-about-cluster-notifications.adoc[leveloffset=+0]
 
+[role="_abstract"]
+Use the following resources and information to understand the cluster notifications that you receive for your {product-title} cluster, and to manage the recipients of cluster notification emails.
+
 [role="_additional-resources"]
 == Additional resources
 

--- a/rosa_cluster_admin/rosa-cluster-notifications.adoc
+++ b/rosa_cluster_admin/rosa-cluster-notifications.adoc
@@ -12,46 +12,13 @@ include::snippets/managed-openshift-about-cluster-notifications.adoc[leveloffset
 [role="_abstract"]
 Use the following resources and information to understand the cluster notifications that you receive for your {product-title} cluster, and to manage the recipients of cluster notification emails.
 
+include::modules/rosa-expectations.adoc[leveloffset=+1]
+
+include::modules/rosa-cluster-notification-emails.adoc[leveloffset=+1]
+
+include::modules/rosa-troubleshooting-cluster-notifications.adoc[leveloffset=+1]
+
 [role="_additional-resources"]
-== Additional resources
+.Additional resources
 
 * link:https://docs.openshift.com/rosa/rosa_architecture/rosa_policy_service_definition/rosa-policy-responsibility-matrix.adoc#notifications_rosa-policy-responsibility-matrix[Customer responsibilities: Review and action cluster notifications]
-* xref:../rosa_architecture/rosa_policy_service_definition/rosa-policy-responsibility-matrix.adoc#notifications_rosa-policy-responsibility-matrix[Customer responsibilities: Review and action cluster notifications]
-* xref:#cluster-notification-emails_rosa-cluster-notifications[Cluster notification emails]
-* xref:#troubleshoot_rosa-cluster-notifications[Troubleshooting: Cluster notifications]
-
-
-[id="expectations_{context}"]
-== What to expect from cluster notifications
-
-As a cluster administrator, you need to be aware of when and why cluster notifications are sent, as well as their types and severity levels, in order to effectively understand the health and administration needs of your cluster.
-
-include::modules/managed-cluster-notification-policy.adoc[leveloffset=+2]
-
-include::modules/managed-cluster-notification-severity-levels.adoc[leveloffset=+2]
-
-include::modules/managed-cluster-notification-types.adoc[leveloffset=+2]
-
-include::modules/managed-cluster-notification-view-in-hcc.adoc[leveloffset=+1]
-
-[id="cluster-notification-emails_{context}"]
-== Cluster notification emails
-
-By default, when a cluster notification is sent to the cluster, it is also sent as an email to the cluster owner. You can configure additional recipients for notification emails to ensure that all appropriate users remain informed about the state of the cluster.
-
-include::modules/managed-cluster-add-notification-contacts.adoc[leveloffset=+2]
-
-include::modules/managed-cluster-remove-notification-contacts.adoc[leveloffset=+2]
-
-[id="troubleshoot_{context}"]
-== Troubleshooting
-
-If you are not receiving cluster notification emails:
-
-* Ensure that emails sent from `@redhat.com` addresses are not filtered out of your email inbox.
-* Ensure that your correct email address is listed as a notification contact for the cluster.
-* Ask the cluster owner or administrator to add you as a notification contact: xref:#cluster-notification-emails_rosa-cluster-notifications[Cluster notification emails].
-
-If your cluster does not receive notifications:
-
-* Ensure that your cluster can access resources at `api.openshift.com`.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.20+

Issue:
https://redhat.atlassian.net/browse/OSDOCS-16577

Link to docs preview:
https://108402--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/rosa_cluster_admin/rosa-cluster-notifications.html

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
