### PR TITLE
OSDOCS 16930-17 Remediation for NODES-2

### DIFF
--- a/nodes/nodes/nodes-nodes-viewing.adoc
+++ b/nodes/nodes/nodes-nodes-viewing.adoc
@@ -19,15 +19,14 @@ The master uses the information from node objects to validate nodes with health 
 
 include::modules/nodes-nodes-viewing-listing.adoc[leveloffset=+1]
 
-ifndef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
-
 include::modules/nodes-nodes-viewing-listing-pods.adoc[leveloffset=+1]
 
 include::modules/nodes-nodes-viewing-memory.adoc[leveloffset=+1]
 
+ifndef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 [role="_additional-resources"]
 [id="additional-resources_{context}"]
-.Additional resources
+== Additional resources
 
 * xref:../../nodes/nodes/nodes-nodes-working.adoc#nodes-nodes-working-updating_nodes-nodes-working[Understanding how to update labels on nodes]
 


### PR DESCRIPTION
Remediation work for https://github.com/openshift/openshift-docs/pull/106219 and https://issues.redhat.com/browse/OSDOCS-16930

[Viewing and listing the nodes in your cluster](https://108403--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/nodes/nodes-nodes-viewing.html) -- Moved includes outside of ifdef. See [history in blame](https://github.com/openshift/openshift-docs/blame/30f493b49dddeb316b5c1a6264913801373e8eaf/nodes/nodes/nodes-nodes-viewing.adoc#L21).

