### PR TITLE
OSDOCS 16930-19 Remediation for NODES-2

### DIFF
--- a/modules/mco-update-boot-images-configuring.adoc
+++ b/modules/mco-update-boot-images-configuring.adoc
@@ -12,8 +12,6 @@ include::snippets/mco-update-boot-images-abstract.adoc[]
 
 If you disabled the boot image management feature, so that the boot images are not updated, you can re-enable the feature by editing the `MachineConfiguration` object.  
 
-Currently, the ability to update the boot image is available for only Google Cloud Platform (GCP) and Amazon Web Services (AWS) clusters. It is not supported for clusters managed by the {cluster-capi-operator}.
-
 .Procedure
 
 . Edit the `MachineConfiguration` object, named `cluster`, to enable the updating of boot images by running the following command:
@@ -82,73 +80,4 @@ $ oc label machineset.machine ci-ln-hmy310k-72292-5f87z-worker-a update-boot-ima
 
 .Verification
 
-. View the current state of the boot image updates by viewing the machine configuration object:
-+
-[source,terminal]
-----
-$ oc get machineconfiguration cluster -n openshift-machine-api -o yaml
-----
-+
-.Example machine set with the boot image reference
-+
-[source,yaml]
-----
-kind: MachineConfiguration
-metadata:
-  name: cluster
-# ...
-status:
-  conditions:
-  - lastTransitionTime: "2024-09-09T13:51:37Z"
-    message: Reconciled 1 of 2 MAPI MachineSets | Reconciled 0 of 0 CAPI MachineSets
-      | Reconciled 0 of 0 CAPI MachineDeployments
-    reason: BootImageUpdateConfigurationAdded
-    status: "True"
-    type: BootImageUpdateProgressing
-  - lastTransitionTime: "2024-09-09T13:51:37Z"
-    message: 0 Degraded MAPI MachineSets | 0 Degraded CAPI MachineSets | 0 CAPI MachineDeployments
-    reason: BootImageUpdateConfigurationAdded
-    status: "False"
-    type: BootImageUpdateDegraded
-----
-+
-The `status.conditions.lastTransitionTime.type:BootImageUpdateProgressing` stanza specifies the status of the boot image update. {cluster-capi-operator} machine sets and machine deployments are not currently supported for boot image updates.
-+
-The `status.conditions.lastTransitionTime.type:BootImageUpdateConfigurationAdded` stanza specifies if any boot image updates failed. If any of the updates fail, the Machine Config Operator is degraded. In this case, manual intervention might be required.        
-
-. Get the boot image version by running the following command:
-+
-[source,terminal]
-----
-$ oc get machinesets <machineset_name> -n openshift-machine-api -o yaml
-----
-+
-.Example machine set with the boot image reference
-+
-[source,yaml]
-----
-apiVersion: machine.openshift.io/v1beta1
-kind: MachineSet
-metadata:
-  labels:
-    machine.openshift.io/cluster-api-cluster: ci-ln-77hmkpt-72292-d4pxp
-    update-boot-image: "true"
-  name: ci-ln-77hmkpt-72292-d4pxp-worker-a
-  namespace: openshift-machine-api
-spec:
-# ...
-  template:
-# ...
-    spec:
-# ...
-      providerSpec:
-# ...
-        value:
-          disks:
-          - autoDelete: true
-            boot: true
-            image: projects/rhcos-cloud/global/images/<boot_image>
-# ...
-----
-+
-This boot image is the same as the current {product-title} version. The location and format of the boot image within the machine set differs, based on the platform. However, the boot image is always listed in the `spec.template.spec.providerSpec.` parameter. 
+include::snippets/mco-update-boot-images-verification.adoc[]


### PR DESCRIPTION
Remediation work for https://github.com/openshift/openshift-docs/pull/106219 and https://issues.redhat.com/browse/OSDOCS-16930

Link to docs preview:
[Enabling boot image management](https://108421--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_configuration/mco-update-boot-images.html#mco-update-boot-images-configuring_machine-configs-configure) -- Replaced verification snippet
