### PR TITLE
[OSDOCS#18745]: For z-stream release notes 4.16.58. 

### DIFF
--- a/modules/zstream-4-16-52.adoc
+++ b/modules/zstream-4-16-52.adoc
@@ -21,8 +21,6 @@ $ oc adm release info 4.16.52 --pullspecs
 [id="ocp-4-16-52-fixed-issues_{context}"]
 == Fixed issues
 
-
-
 * Before this update, a Machine Config Operator (MCO) incorrectly set an `Upgradeable=False` condition to all new nodes that were added to a cluster. A `PoolUpdating` reason was provided for the `Upgradeable=False` condition. With this release, the MCO now correctly sets an `Upgradeable=True` condition to all new nodes that get added to a cluster, which resolves the issue. (link:https://issues.redhat.com/browse/OCPBUGS-57423[OCPBUGS-57423])
 
 * Before this update, the controller created and deleted a file with a random name when setting up a session to {aws-first}, which caused the controller to continuously allocate more memory to cache the session. With this release, the controller now uses the same file name instead of a random one, allowing the kernel to re-use the `dentry` object instead of requesting a new one for each session. As a result, excessive memory allocation is resolved. (link:https://issues.redhat.com/browse/OCPBUGS-63140[OCPBUGS-63140])

--- a/modules/zstream-4-16-53.adoc
+++ b/modules/zstream-4-16-53.adoc
@@ -21,8 +21,6 @@ $ oc adm release info 4.16.53 --pullspecs
 [id="zstream-4-16-53-fixed-issues_{context}"]
 == Fixed issues
 
-
-
 * Before this update, API and Ingress Virtual IP (VIP) addresses were automatically assigned even when a user-managed load balancer was in use. With this release, the API and Ingress VIPs are no longer automatically assigned. If these values are not explicitly set in the `install-config.yaml`, the installation fails with an error, prompting you to provide them. (link:https://issues.redhat.com/browse/OCPBUGS-53237[OCPBUGS-53237])
 
 * Before this update, installing an {aws-short} cluster in either the Commercial Cloud Services (C2S) region or the Secret Commercial Cloud Services (SC2S) region failed because the installation program added unsupported security groups to the load balancer. With this release, the installation program no longer adds unsupported security groups to the load balancer for a cluster that needs to be installed in either the C2S region or SC2S region. (link:https://issues.redhat.com/browse/OCPBUGS-54165[OCPBUGS-54165])

--- a/modules/zstream-4-16-54.adoc
+++ b/modules/zstream-4-16-54.adoc
@@ -21,8 +21,6 @@ $ oc adm release info 4.16.54 --pullspecs
 [id="zstream-4-16-54-fixed-issues_{context}"]
 == Fixed issues
 
-
-
 * Before this update, a Kube State Metrics (KSM) deny-list had typographical errors as demonstrated in the following example:
 +
 [source,terminal,subs=""verbatim""]

--- a/modules/zstream-4-16-56.adoc
+++ b/modules/zstream-4-16-56.adoc
@@ -21,8 +21,6 @@ $ oc adm release info 4.16.56 --pullspecs
 [id="zstream-4-16-56-fixed-issues_{context}"]
 == Fixed Issues
 
-
-
 * Before this update, HAProxy pods frequently exceeded the `maxConn` limit because idle connections remained open when using the `idle-close-on-response` setting. As a consequence, HAProxy pods entered a CrashLoop state, resulting in performance degradation and persistent reconciliation failures. With this release, the IdleConnectionTerminationPolicy is activated to ensure idle connections are closed correctly. As a result, HAProxy pods in {product-title} 4.18.0 no longer exceed the maxConn limit or experience crashes related to connection buildup.(link:https://issues.redhat.com/browse/OCPBUGS-71202[OCPBUGS-71202])
 
 * Before this update, a validation error occurred during the creation of user accounts with special characters in the email address. As a consequence, user account creation failed. With this release, the validation error is resolved. As a result, user account creation with special characters in the email address is successful. (link:https://issues.redhat.com/browse/OCPBUGS-72541[OCPBUGS-72541])

--- a/modules/zstream-4-16-57.adoc
+++ b/modules/zstream-4-16-57.adoc
@@ -23,8 +23,6 @@ $ oc adm release info 4.16.57 --pullspecs
 [id="zstream-4-16-57-fixed-issues_{context}"]
 == Fixed issues
 
-
-
 * Before this update, a bug in the `oc adm inspect --all-namespaces` command construction prevented the `must-gather` utility from correctly gathering information about leases, `csistoragecapacities` resources, and the `assisted-installer` namespace. With this release, the `must-gather` utility gathers the information correctly. (link:https://issues.redhat.com/browse/OCPBUGS-66106[OCPBUGS-66106])
 
 * Before this update, aggregated API servers on {product-title} used in-memory loopback certificates that were valid for only one year. With this release, these servers now use in-memory loopback certificates that are valid for three years. (link:https://issues.redhat.com/browse/OCPBUGS-74110[OCPBUGS-74110])

--- a/modules/zstream-4-16-58.adoc
+++ b/modules/zstream-4-16-58.adoc
@@ -1,0 +1,45 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-16-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-16-58_{context}"]
+= RHSA-2026:4482 - {product-title} {product-version}.58 fixed issues and security updates
+
+Issued: 19 March 2026
+
+[role="_abstract"]
+{product-title} release {product-version}.58 is now available. The list of fixed issues that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2026:4482[RHSA-2026:4482] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2026:4464[RHSA-2026:4464] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.16.58 --pullspecs
+----
+
+[id="zstream-4-16-58-fixed-issues_{context}"]
+== Fixed issues
+
+* Before this update, the bonded network configuration in the Assisted Installer caused a mismatch between the `bootMACAddress` configuration  and the provisioned host, leading to the Ironic agent failing to find the corresponding bare-metal Host (BMH). As a consequence, end users could not provision hosts in a cluster due to a missing `bootMACAddress` configuration. With this release, the bonded network configuration issue in {product-title} {product-version} is fixed for versions above {product-title} {product-version}. As a result, cluster deployment does not become unresponsive, improving the user's experience in {product-title} {product-version}. (link:https://issues.redhat.com/browse/OCPBUGS-61165[OCPBUGS-61165])
+
+* Before this update, `iptables-alerter` pods experienced high CPU usage in some clusters due to an issue in the upgrade. As a consequence, those `iptables-alerter` pods could experience performance degradation. With this release, `iptables-alerter` CPU usage is reduced by optimizing the code. As a result, high CPU usage for `iptables-alerter` pods is resolved, improving cluster performance. (link:https://issues.redhat.com/browse/OCPBUGS-75890[OCPBUGS-75890])
+
+* Before this update, the service account creation in {product-title} clusters on {gcp-first} resulted in inconsistent provider results. As a consequence, service account creation issues affected service account key creation in {gcp-short}. With this release, the service account creation issue is fixed by upgrading Terraform for {product-title} 4.12+. As a result, service account creation consistency is improved. (link:https://issues.redhat.com/browse/OCPBUGS-76586[OCPBUGS-76586])
+
+* Before this update, confusion and maintenance issues were present with the `collect-profiles` job. As a consequence, end users experienced difficulty with the `collect-profiles` job, making it hard to maintain. With this release, the `collect-profiles` job is removed, reducing user confusion and maintenance effort. As a result, the user experience is simplified. (link:https://issues.redhat.com/browse/OCPBUGS-77169[OCPBUGS-77169])
+
+* Before this update, when service endpoints were deleted and re-created in {product-title} clusters by using OVN-Kubernetes networking and the service port differed from the endpoint port, stale User Datagram Protocol (UDP) connection tracking (conntrack) entries could remain on worker nodes. This occurred because the `conntrack` cleanup logic incorrectly used the endpoint port, which is the target port on the pod, instead of the externally-facing service port that clients connect to when attempting to delete stale entries. With this release, the cleanup process uses the service port when deleting or updating service endpoints. This change ensures that stale conntrack entries are correctly matched and removed. Network connectivity now remains reliable during service endpoint lifecycle changes. (link:https://issues.redhat.com/browse/OCPBUGS-77187[OCPBUGS-77187])
+
+* Before this update, duplicate `PrometheusRule` objects were created due to changes in rules over time and inconsistent updates in the `prometheus-k8s-rulefiles-0` config map. As a consequence, inconsistent monitoring occurred. With this release, duplicate `PrometheusRules` are removed from the config map, ensuring consistent rule versions across clusters. As a result, duplicate `PrometheusRule` objects no longer occur, ensuring consistent rule usage across clusters. (link:https://issues.redhat.com/browse/OCPBUGS-77276[OCPBUGS-77276])
+
+* Before this update, when a bare-metal Host (BMH) was marked as `Provisioned` or `ExternallyProvisioned`, the system would try to de-provision it or power it off first and the `DataImage` attached to the BMH would also prevent deletion. This blocked or slowed down host removal, creating operational inefficiencies. With this release, if the BMH has the `detached annotation` and deletion is requested, the BMH transitions to the deleting state, allowing for direct deletion. (link:https://issues.redhat.com/browse/OCPBUGS-77278[OCPBUGS-77278])
+
+* Before this update, `NodePort UDP traffic` test passed unexpectedly due to service pod cycling on the same node. As a consequence, `NodePort UDP traffic E2E` tests failed due to service pod cycling issue. With this release, `NodePort UDP traffic E2E` tests pass due to fixed service connectivity. As a result, `NodePort UDP traffic E2E` tests now pass, ensuring stable UDP traffic for NodePort services across nodes. (link:https://issues.redhat.com/browse/OCPBUGS-77685[OCPBUGS-77685])
+
+[id="zstream-4-16-58-updating_{context}"]
+== Updating
+
+To update an {product-title} 4.16 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].

--- a/modules/zstream-4-16-6.adoc
+++ b/modules/zstream-4-16-6.adoc
@@ -45,7 +45,7 @@ metadata:
 [id="ocp-4-16-6-fixed-issues_{context}"]
 == Fixed issues
 
-*  Previously, installer-created subnets were being tagged with `kubernetes.io/cluster/<clusterID>: shared`. With this release, subnets are now tagged with `kubernetes.io/cluster/<clusterID>: owned`. (link:https://issues.redhat.com/browse/OCPBUGS-37510[OCPBUGS-37510])
+* Previously, installer-created subnets were being tagged with `kubernetes.io/cluster/<clusterID>: shared`. With this release, subnets are now tagged with `kubernetes.io/cluster/<clusterID>: owned`. (link:https://issues.redhat.com/browse/OCPBUGS-37510[OCPBUGS-37510])
 
 * Previously, the same node was queued multiple times in the draining controller, which caused the the same node to be drained twice. With this release, a node will only be drained once. (link:https://issues.redhat.com/browse/OCPBUGS-37470[OCPBUGS-37470])
 

--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -3385,6 +3385,9 @@ Testing has shown that wake up latencies are under 20μs for over 99.99999% of t
 // 4.16.57 about async
 include::modules/rn-async-errata.adoc[leveloffset=+1]
 
+// 4.16.58 Rns and updating
+include::modules/zstream-4-16-58.adoc[leveloffset=+2]
+
 // 4.16.57 Rns and updating
 include::modules/zstream-4-16-57.adoc[leveloffset=+2]
 


### PR DESCRIPTION

Version(s):
4.16

Issue:
https://redhat.atlassian.net/browse/OSDOCS-18745

Link to docs preview:
https://108422--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html#zstream-4-16-58_release-notes

QE review:
N/A
