### PR TITLE
RHDEVDOCS-7084: CQA 2.0 fixes for Managing the application set resources in non-control plane namespaces

### DIFF
--- a/argocd_application_sets/managing-app-sets-in-non-control-plane-namespaces.adoc
+++ b/argocd_application_sets/managing-app-sets-in-non-control-plane-namespaces.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY   
+:_mod-docs-content-type: ASSEMBLY
 include::_attributes/common-attributes.adoc[]
 [id="managing-app-sets-in-non-control-plane-namespaces"]
 = Managing the application set resources in non-control plane namespaces
@@ -6,13 +6,13 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-[role="_abstract"]
 :FeatureName: Argo CD application sets in non-control plane namespaces
 include::snippets/technology-preview.adoc[]
 
+[role="_abstract"]
 By using application sets, you can automate and manage the deployments of multiple Argo CD applications declaratively from a single mono-repository to many clusters at once with greater flexibility.
 
-With {gitops-title} 1.12 and later, as a cluster administrator, you can create and manage the `ApplicationSet` resources in non-control plane namespaces declaratively, other than the `openshift-gitops` control plane namespace,  by explicitly enabling and configuring the `ArgoCD` and `ApplicationSet` custom resources (CRs) as per your requirements. This functionality is particularly useful in multitenancy environments when you want to manage deployments of Argo CD applications for your isolated teams. This functionality is called the _ApplicationSet in any namespace_ feature in the Argo CD open source project.
+With {gitops-title} 1.12 and later, as a cluster administrator, you can create and manage the `ApplicationSet` resources in non-control plane namespaces declaratively, other than the `openshift-gitops` control plane namespace, by explicitly enabling and configuring the `ArgoCD` and `ApplicationSet` custom resources (CRs) as per your requirements. This functionality is particularly useful in multitenancy environments when you want to manage deployments of Argo CD applications for your isolated teams. This functionality is called the _ApplicationSet in any namespace_ feature in the Argo CD open source project.
 
 [NOTE]
 ====

--- a/modules/gitops-allowing-scm-providers.adoc
+++ b/modules/gitops-allowing-scm-providers.adoc
@@ -6,13 +6,19 @@
 [id="gitops-allowing-scm-providers_{context}"]
 = Allowing Source Code Manager Providers
 
-[role="_abstract"]
 [IMPORTANT]
 ====
-Please read this section carefully. Misconfiguration could lead to potential security issues. 
+Ensure that you read this section carefully. Misconfiguration could lead to potential security issues. 
 ====
 
+[role="_abstract"]
 Allowing `ApplicationSet` resources in non-control plane namespaces can result in the exfiltration of secrets through malicious API endpoints in Source Code Manager (SCM) Provider or Pull Request (PR) generators. To prevent unauthorized access to sensitive information, the Operator disables the SCM Provider and PR generators by default as a precautionary measure.
+
+.Prerequisites
+
+* You have installed the {gitops-title} Operator on your {OCP} cluster.
+* You are logged in to the {OCP} cluster as an administrator.
+* You have a cluster-scoped Argo CD instance configured with `spec.applicationSet.sourceNamespaces`.
 
 .Procedure
 
@@ -39,7 +45,7 @@ spec:
 --
 where:
 
-`spec.applicationSet.scmProviders`:: Specifies the list of URLs of the allowed SCM Providers.
+`spec.applicationSet.scmProviders`:: Specifies the allowlist of SCM Provider URLs that `ApplicationSets` can access. Only SCM Providers from this list are permitted for use with SCM Provider and Pull Request generators.
 --
 +
 [NOTE]

--- a/modules/gitops-enabling-the-application-set-resources-in-non-control-plane-namespaces.adoc
+++ b/modules/gitops-enabling-the-application-set-resources-in-non-control-plane-namespaces.adoc
@@ -9,6 +9,12 @@
 [role="_abstract"]
 As a cluster administrator, you can define a certain set of non-control plane namespaces wherein users can create, update, and reconcile `ApplicationSet` resources. You must explicitly enable and configure the `ArgoCD` and `ApplicationSet` custom resources (CRs) as per your requirements.
 
+.Prerequisites
+
+* You have installed the {gitops-title} Operator on your {OCP} cluster.
+* You are logged in to the {OCP} cluster as an administrator.
+* Ensure that a cluster-scoped Argo CD instance exists in your defined namespace.
+
 .Procedure
 
 . Set the `sourceNamespaces` parameter for the `applicationSet` spec to include the non-control plane namespaces:
@@ -32,7 +38,7 @@ spec:
 --
 where:
 
-`spec.applicationSet`:: Specifies the list of non-control plane namespaces for creating and managing `ApplicationSet` resources.
+`spec.applicationSet.sourceNamespaces`:: Specifies the list of non-control plane namespaces for creating and managing `ApplicationSet` resources.
 --
 +
 [NOTE]
@@ -54,5 +60,5 @@ At the moment, the use of wildcards (`*`) is not supported in the `.spec.applica
 +
 [NOTE]
 ====
-The Operator adds the `argocd.argoproj.io/applicationset-managed-by-cluster-argocd` label to the target namespace.
+In addition to creating RBAC resources, the {gitops-title} Operator also adds a label to target namespaces. The {gitops-shortname} Operator adds the `argocd.argoproj.io/applicationset-managed-by-cluster-argocd` label to the target namespace.
 ====


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

gitops-docs-1.20, gitops-docs-1.19

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

https://redhat.atlassian.net/browse/RHDEVDOCS-7084

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

[Managing the application set resources in non-control plane namespaces](https://108443--ocpdocs-pr.netlify.app/openshift-gitops/latest/argocd_application_sets/managing-app-sets-in-non-control-plane-namespaces.html)

Peer review:
- [x] Peer has approved this change.
<!--- Peer approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Peer review:

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
