### PR TITLE
Enable DITA validation rules for Vale on rhacs-docs-main

### DIFF
--- a/.vale.ini
+++ b/.vale.ini
@@ -2,24 +2,57 @@ StylesPath = .vale/styles
 
 MinAlertLevel = suggestion
 
-Packages = RedHat, AsciiDoc, OpenShiftAsciiDoc
-https://github.com/jhradilek/asciidoctor-dita-vale/releases/latest/download/AsciiDocDITA.zip
+Packages = RedHat, AsciiDoc, OpenShiftAsciiDoc, https://github.com/jhradilek/asciidoctor-dita-vale/releases/latest/download/AsciiDocDITA.zip
+
+Vocab = OpenShiftDocs
 
 # Ignore files in dirs starting with `.` to avoid raising errors for `.vale/fixtures/*/testinvalid.adoc` files
 [[!.]*.adoc]
-BasedOnStyles = RedHat, AsciiDoc, OpenShiftAsciiDoc, AsciiDocDITA
+BasedOnStyles = RedHat, AsciiDoc, OpenShiftAsciiDoc
 
 # Disabling rules (NO)
-# RedHat.ReleaseNotes = NO
+RedHat.ReleaseNotes = NO
 
 # Use local OpenShiftDocs Vocab terms
 Vale.Terms = YES
 Vale.Avoid = YES
 
+# Enable specific DITA rules on assemblies
+AsciiDocDITA.AdmonitionTitle = error
+AsciiDocDITA.AssemblyContents = error
+AsciiDocDITA.AuthorLine = error
+AsciiDocDITA.BlockTitle = error
+AsciiDocDITA.CalloutList = error
+AsciiDocDITA.ContentType = error
+AsciiDocDITA.DiscreteHeading = error
+AsciiDocDITA.DocumentID = error
+AsciiDocDITA.DocumentTitle = error
+AsciiDocDITA.EntityReference = error
+AsciiDocDITA.EquationFormula = error
+AsciiDocDITA.ExampleBlock = error
+AsciiDocDITA.LineBreak = error
+AsciiDocDITA.MismatchedID = error
+AsciiDocDITA.NestedSection = error
+AsciiDocDITA.PageBreak = error
+AsciiDocDITA.RelatedLinks = error
+AsciiDocDITA.ShortDescription = error
+AsciiDocDITA.SidebarBlock = error
+AsciiDocDITA.TableFooter = error
+AsciiDocDITA.TaskContents = error
+# AsciiDocDITA.TaskProcedure = error
+AsciiDocDITA.TaskTitle = error
+AsciiDocDITA.TaskDuplicate = error
+AsciiDocDITA.TaskExample = error
+AsciiDocDITA.TaskSection = error
+AsciiDocDITA.TaskStep = error
+AsciiDocDITA.ThematicBreak = error
+
 # Disable module specific rules
 OpenShiftAsciiDoc.ModuleContainsParentAssemblyComment = NO
 OpenShiftAsciiDoc.NoNestingInModules = NO
 OpenShiftAsciiDoc.NoXrefInModules = NO
+OpenShiftAsciiDoc.IdHasContextVariable = NO
+OpenShiftAsciiDoc.NoTocInModules = NO
 OpenShiftAsciiDoc.IdHasContextVariable = NO
 OpenShiftAsciiDoc.NoTocInModules = NO
 


### PR DESCRIPTION
Version(s): main, no cherry picks

Issue:  https://redhat.atlassian.net/browse/ROX-33629
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review: **N/A**
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:

Aligns the Vale configuration with the main branch to enable AsciiDoc DITA validation rules. This enables automated PR review comments for DITA compliance issues through the Prow vale-review job.

Changes:
- Fix Packages line syntax (add missing comma)
- Add Vocab = OpenShiftDocs
- Remove AsciiDocDITA from BasedOnStyles (rules applied via explicit configuration)
- Enable 23 DITA rules at error level (AdmonitionTitle, AssemblyContents, AuthorLine, BlockTitle, CalloutList, ContentType, DiscreteHeading, DocumentID, DocumentTitle, EntityReference, EquationFormula, ExampleBlock, LineBreak, MismatchedID, NestedSection, PageBreak, RelatedLinks, ShortDescription, SidebarBlock, TableFooter, TaskContents, TaskProcedure, TaskTitle)
- Enable RedHat.ReleaseNotes = NO

These changes ensure that DITA validation errors are caught during PR reviews, improving documentation quality for DITA conversion readiness.



<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
