### PR TITLE
[Enterprise-4.16] OSDOCS-18670 Fixes for MS security, auth, and node access CQA

### DIFF
--- a/microshift_configuring/microshift_auth_security/microshift-audit-logs-config.adoc
+++ b/microshift_configuring/microshift_auth_security/microshift-audit-logs-config.adoc
@@ -11,18 +11,19 @@ You can control {microshift-short} audit log file rotation and retention by usin
 
 include::modules/microshift-audit-logs-config-intro.adoc[leveloffset=+1]
 
+[id="Additional-resources_audit-log-intro"]
+[role="_additional-resources"]
+== Additional resources
+
+* link:https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9/html/security_hardening/auditing-the-system_security-hardening#configuring-auditd-for-a-secure-environment_auditing-the-system[Configuring auditd for a secure environment]
+
+* link:https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9/html/security_hardening/auditing-the-system_security-hardening#understanding-audit-log-files_auditing-the-system[Understanding Audit log files]
+
+* link:https://access.redhat.com/solutions/1294[How to use logrotate utility to rotate log files] (Solutions, dated 7 August 2024)
+
 // About audit log profiles; OCP module, edit with conditionals and care
 include::modules/nodes-nodes-audit-config-about.adoc[leveloffset=+1]
 
 include::modules/microshift-audit-logs-config-proc.adoc[leveloffset=+1]
 
 include::modules/microshift-audit-logs-troubleshoot.adoc[leveloffset=+1]
-
-[id="Additional-resources_audit-log-intro"]
-[role="_additional-resources"]
-== Additional resources
-* link:https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9/html/security_hardening/auditing-the-system_security-hardening#configuring-auditd-for-a-secure-environment_auditing-the-system[Configuring auditd for a secure environment]
-
-* link:https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9/html/security_hardening/auditing-the-system_security-hardening#understanding-audit-log-files_auditing-the-system[Understanding Audit log files]
-
-* link:https://access.redhat.com/solutions/1294[How to use logrotate utility to rotate log files] (Solutions, dated 7 August 2024)

--- a/modules/microshift-audit-logs-config-proc.adoc
+++ b/modules/microshift-audit-logs-config-proc.adoc
@@ -30,10 +30,10 @@ apiServer:
 +
 where:
 
-`apiserver.auditLog.maxFileAge`:: Specifies the maximum time in days that log files are kept. Files older than this limit are deleted. In this example, after a log file is more than 7 days old, it is deleted. The files are deleted regardless of whether or not the live log has reached the maximum file size specified in the `maxFileSize` field. File age is determined by the timestamp written in the name of the rotated log file, for example, `audit-2024-05-16T17-03-59.994.log`. When the value is `0`, the limit is disabled.
-`apiserver.auditLog.maxFileSize`:: The maximum audit log file size in megabytes. In this example, the file is rotated as soon as the live log reaches the 200 MB limit. When the value is set to `0`, the limit is disabled.
-`apiserver.auditLog.maxFiles`:: The maximum number of rotated audit log files retained. After the limit is reached, the log files are deleted in order from oldest to newest. In this example, the value `1` results in only 1 file of size `maxFileSize` being retained in addition to the current active log. When the value is set to `0`, the limit is disabled.
-`apiserver.auditLog.profile`:: Logs only metadata for read and write requests; does not log request bodies except for OAuth access token requests. If you do not specify this field, the `Default` profile is used.
+`apiServer.auditLog.maxFileAge`:: Specifies the maximum time in days that log files are kept. Files older than this limit are deleted. In this example, after a log file is more than 7 days old, it is deleted. The files are deleted regardless of whether or not the live log has reached the maximum file size specified in the `maxFileSize` field. File age is determined by the timestamp written in the name of the rotated log file, for example, `audit-2024-05-16T17-03-59.994.log`. When the value is `0`, the limit is disabled.
+`apiServer.auditLog.maxFileSize`:: The maximum audit log file size in megabytes. In this example, the file is rotated as soon as the live log reaches the 200 MB limit. When the value is set to `0`, the limit is disabled.
+`apiServer.auditLog.maxFiles`:: The maximum number of rotated audit log files retained. After the limit is reached, the log files are deleted in order from oldest to newest. In this example, the value `1` results in only 1 file of size `maxFileSize` being retained in addition to the current active log. When the value is set to `0`, the limit is disabled.
+`apiServer.auditLog.profile`:: Logs only metadata for read and write requests; does not log request bodies except for OAuth access token requests. If you do not specify this field, the `Default` profile is used.
 
 . Optional: To specify a new directory for logs, you can stop {microshift-short}, and then move the `/var/log/kube-apiserver` directory to your desired location:
 

--- a/modules/microshift-custom-ca-proc.adoc
+++ b/modules/microshift-custom-ca-proc.adoc
@@ -43,9 +43,9 @@ apiServer:
 +
 where:
 
-`apiserver.namedCertificates.certPath`:: Add the full path to the certificate.
-`apiserver.namedCertificates.keyPath`:: Add the full path to the certificate key.
-`apiserver.namedCertificates.names`:: Optional. Add a list of explicit DNS names. Leading wildcards are allowed. If no names are listed, the implicit names are extracted from the certificates.
+`apiServer.namedCertificates.certPath`:: Add the full path to the certificate.
+`apiServer.namedCertificates.keyPath`:: Add the full path to the certificate key.
+`apiServer.namedCertificates.names`:: Optional. Add a list of explicit DNS names. Leading wildcards are allowed. If no names are listed, the implicit names are extracted from the certificates.
 
 . Restart the {microshift-short} to apply the certificates by running the following command:
 +


### PR DESCRIPTION

Version(s): 4.16
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [OSDOCS-18670](https://redhat.atlassian.net/browse/OSDOCS-18670)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://108479--ocpdocs-pr.netlify.app/microshift/latest/microshift_configuring/microshift_auth_security/microshift-audit-logs-config.html
https://108479--ocpdocs-pr.netlify.app/microshift/latest/microshift_configuring/microshift_auth_security/microshift-custom-ca.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: Cherry Picked from https://github.com/openshift/openshift-docs/commit/2b69d47c93fb2822be3897f8d36c2ba2e73975f9 xref: https://github.com/openshift/openshift-docs/pull/108456
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
