### PR TITLE
<gitops-docs-1.19> RHDEVDOCS-7071: CQA 2.0 fixes for Preparing to install OpenShift GitOps

### DIFF
--- a/installing_gitops/preparing-gitops-install.adoc
+++ b/installing_gitops/preparing-gitops-install.adoc
@@ -6,7 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-Read the following information about sizing requirements and prerequisites before you install {gitops-title} on {OCP}. Sizing requirements also provides the sizing details for the default ArgoCD instance that is instantiated by the {gitops-title} Operator.
+[role="_abstract"]
+Read the following sizing requirements before you install {gitops-title} on {OCP}. This information includes the sizing details for the default Argo CD instance that is instantiated by the {gitops-title} Operator.
 
 // Sizing requirements for GitOps
 include::modules/sizing-requirements-for-gitops.adoc[leveloffset=+1]

--- a/modules/sizing-requirements-for-gitops.adoc
+++ b/modules/sizing-requirements-for-gitops.adoc
@@ -8,7 +8,9 @@
 
 {gitops-title} is a declarative way to implement continuous deployment for cloud-native applications. Through GitOps, you can define and configure the CPU and memory requirements of your application.
 
-Every time you install the {gitops-title} Operator, the resources on the namespace are installed within the defined limits. If the default installation does not set any limits or requests, the Operator fails within the namespace with quotas. Without enough resources, the cluster cannot schedule ArgoCD related pods. The following table details the resource requests and limits for the default workloads:
+When you install the {gitops-title} Operator, the resources are deployed to the namespace within the defined limits. If the namespace has resource quotas configured and the installation does not set limits or requests, the Operator installation may fail. Additionally, without sufficient resources, the cluster cannot schedule Argo CD related pods. 
+
+The following table details the resource requests and limits for the default workloads.
 
 [cols="2,2,2,2,2",options="header"]
 |===
@@ -24,26 +26,26 @@ Every time you install the {gitops-title} Operator, the resources on the namespa
 
 Optionally, you can also use the ArgoCD custom resource with the `oc` command to see the specifics and modify them:
 
-[source,terminal]
+[source,terminal,subs="+quotes"]
 ----
 oc edit argocd <name of argo cd> -n namespace
 ----
 
 [id="sizing-requirements-for-argocd-redis_{context}"]
-== Sizing requirements for argocd-redis
+== Sizing requirements for Argo CD redis
 
 During the capacity planning stage for your application in the {gitops-title} Operator, you must ensure that an adequate amount of resources, such as memory, CPU, and storage, are allocated for the `argocd-redis` pod.
 
 The default memory limit for the Redis pod might not be enough to manage a large number of resources. In these instances, you must increase the memory limit, monitor the memory metrics, and change the memory configuration while the application deployment scales up.
 
 The following command shows the example of the memory configuration for a Redis pod in the `openshift-gitops` namespace:
-[source,terminal]
+[source,terminal,subs="+quotes"]
 ----
 $ oc get argocd -n openshift-gitops openshift-gitops -o json | jq '.spec.redis.resources'
 ----
 
-*Example Output:*
-[source,terminal]
+Example Output:
+[source,terminal,subs="+quotes"]
 ----
 {
     "limits": {
@@ -64,16 +66,16 @@ where:
 `requests`:: Specifies the lowest resource limit threshold allocated to the pod.
 --
 
-The following example command changes the memory configuration for a Redis pod. The highest resource limit threshold is set to 8 GiB and the lowest is set to 256 MiB.
-[source,terminal]
+The following example command changes the memory configuration for a Redis pod. The highest resource limit threshold is set to 8 Gi and the lowest is set to 256 Mi.
+[source,terminal,subs="+quotes"]
 ----
 $ oc patch argocd -n openshift-gitops openshift-gitops --type json -p '[{"op": "replace", "path":  \
   "/spec/redis/resources/limits/memory", "value": "8Gi"}, {"op": "replace", "path": \
   "/spec/redis/resources/requests/memory", "value": "256Mi"}]'
 ----
 
-*Example Output:*
-[source,terminal]
+Example Output:
+[source,terminal,subs="+quotes"]
 ----
 argocd.argoproj.io/openshift-gitops patched
 ----


### PR DESCRIPTION
This PR is an automated cherry-pick of https://github.com/openshift/openshift-docs/pull/108552.