### PR TITLE
[gitops-docs-1.19] RHDEVDOCS-7069: CQA 2.0 for Managing cluster configuration

### DIFF
--- a/managing_cluster_configuration/managing-openshift-cluster-configuration.adoc
+++ b/managing_cluster_configuration/managing-openshift-cluster-configuration.adoc
@@ -7,7 +7,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-With {gitops-title}, you can manage your {OCP} cluster configuration to have the following benefits:
+[role="_abstract"]
+As an administrator, maintaining the stability and consistency of an {OCP} environment requires a move away from traditionally manual configurations toward automated, declarative management. {gitops-title} enables you to use Git repositories as the foundation for your infrastructure and application definitions. With {gitops-title}, you can manage your {OCP} cluster configuration for the following benefits:
 
 * Version control and auditability: Configuration changes committed to Git provide a complete history of modifications. This facilitates auditing, compliance, and accountability.
 * Single source of truth: Git serves as the definitive source for the desired state of your {OCP} cluster.

--- a/modules/configuring-rbac.adoc
+++ b/modules/configuring-rbac.adoc
@@ -71,22 +71,33 @@ group.user.openshift.io/cluster-admins created
 
 * If the group exists, check if your user is part of it in the output of the previously run `oc get groups` command. If your user is not in the group, add your user to the group: 
 +
+--
 [source,terminal]
 ----
 $ oc adm groups add-users cluster-admins <user>
 ----
+--
 +
+--
 where:
 
 <user>:: Denotes the user that you want to add to the group.
+--
 +
-*Example Output:*
-+
+--
 [source,terminal]
 ----
-group.user.openshift.io/cluster-admins added: "<user>"
+$ oc adm groups add-users cluster-admins jane.doe
 ----
-
+--
++
+--
+.Example output
+[source,terminal]
+----
+group.user.openshift.io/cluster-admins added: "jane.doe"
+----
+--
 
 .Verification
 


### PR DESCRIPTION
This PR is a cherry-pick of https://github.com/openshift/openshift-docs/pull/104552. It is built on the gitops-docs-1.19 branch.