### PR TITLE
[gitops-docs-1.19] RHDEVDOCS-7073: CQA 2.0 fixes for Uninstalling GitOps

### DIFF
--- a/modules/go-deleting-argocd-instance.adoc
+++ b/modules/go-deleting-argocd-instance.adoc
@@ -8,25 +8,32 @@
 
 Delete the Argo CD instances added to the namespace of the GitOps Operator.
 
-[discrete]
 .Procedure
-* In the *Terminal* type the following command:*
 
+. In the terminal, run the following command:
++
+--
 [source,terminal]
 ----
 $ oc delete gitopsservice cluster -n openshift-gitops
 ----
-
+--
++
+--
 [NOTE]
 ====
-You cannot delete an Argo CD cluster from the web console UI.
+You cannot delete an Argo CD instance from the web console UI.
 ====
-
-After the command runs successfully all the Argo CD instances will be deleted from the `openshift-gitops` namespace.
-
-Delete any other Argo CD instances from other namespaces using the same command:
-
+--
++
+--
+After the command runs successfully, the Argo CD instances will be deleted from the `openshift-gitops` namespace.
+--
+. Delete any other Argo CD instances from other namespaces using the same command:
++
+--
 [source,terminal]
 ----
 $ oc delete gitopsservice cluster -n <namespace>
 ----
+--

--- a/modules/go-uninstalling-gitops-operator.adoc
+++ b/modules/go-uninstalling-gitops-operator.adoc
@@ -6,10 +6,11 @@
 [id='go-uninstalling-gitops-operator_{context}']
 = Uninstalling the {gitops-shortname} Operator
 
-You can uninstall {gitops-title} Operator from the OperatorHub by using the web console.
+[role="_abstract"]
+You can uninstall the {gitops-title} Operator from the OperatorHub by using the web console.
 
-[discrete]
 .Procedure
+
 . From the *Operators* -> *OperatorHub* page, use the *Filter by keyword* box to search for `{gitops-title}` tile.
 
 . Click the *{gitops-title}* tile. The Operator tile indicates it is installed.

--- a/removing_gitops/uninstalling-openshift-gitops.adoc
+++ b/removing_gitops/uninstalling-openshift-gitops.adoc
@@ -8,7 +8,7 @@ toc::[]
 
 Uninstalling the {gitops-title} Operator is a two-step process:
 
-. Delete the Argo CD instances that were added under the default namespace of the {gitops-title} Operator.
+. Delete the Argo CD instances from the `openshift-gitops` namespace and any other namespaces where they were created.
 . Uninstall the {gitops-title} Operator.
 
 Uninstalling only the Operator will not remove the Argo CD instances created.


### PR DESCRIPTION
This PR is a cherry-pick of https://github.com/openshift/openshift-docs/pull/107714.