### PR TITLE
TELCODOCS-2814: Fix Vale warnings in optimizing-networking docs

### DIFF
--- a/modules/ipsec-impact-networking.adoc
+++ b/modules/ipsec-impact-networking.adoc
@@ -7,6 +7,6 @@
 = Impact of IPsec
 
 [role="_abstract"]
-To account for performance overhead, review the impact of enabling IPsec. Encrypting and decrypting traffic on node hosts consumes CPU power, which affects both throughput and CPU usage regardless of the specific IP security system.
+To account for performance impact, review the effect of enabling IPsec. Encrypting and decrypting traffic on node hosts consumes CPU power, which affects both throughput and CPU usage regardless of the specific IP security system.
 
-IPSec encrypts traffic at the IP payload level, before it hits the NIC, protecting fields that would otherwise be used for NIC offloading. This means that some NIC acceleration features might not be usable when IPSec is enabled. This situation leads to decreased throughput and increased CPU usage.
+IPsec encrypts traffic at the IP payload level, before it hits the NIC, protecting fields that would otherwise be used for NIC offloading. This means that some NIC acceleration features might not be usable when IPsec is enabled. This situation leads to decreased throughput and increased CPU usage.

--- a/scalability_and_performance/optimization/optimizing-networking.adoc
+++ b/scalability_and_performance/optimization/optimizing-networking.adoc
@@ -11,9 +11,9 @@ To tunnel traffic between nodes, use Generic Network Virtualization Encapsulatio
 
 Geneve provides benefits over VLANs, such as an increase in networks from 4096 to over 16 million, and layer 2 connectivity across physical networks. This allows for all pods behind a service to communicate with each other, even if they are running on different systems.
 
-Cloud, virtual, and bare-metal environments running {product-title} can use a high percentage of the capabilities of a network interface card (NIC) with minimal tuning. Production clusters using OVN-Kubernetes with Geneve tunneling can handle high-throughput traffic effectively and scale up (for example, utilizing 100 Gbps NICs) and scale out (for example, adding more NICs) without requiring special configuration.
+Cloud, virtual, and bare-metal environments running {product-title} can use a high percentage of the capabilities of a network interface controller (NIC) with minimal tuning. Production clusters that use OVN-Kubernetes with Geneve tunneling can handle high-throughput traffic effectively and scale up (for example, using 100 Gbps NICs) and scale out (for example, adding more NICs) without requiring special configuration.
 
-In some high-performance scenarios where maximum efficiency is critical, targeted performance tuning can help optimize CPU usage, reduce overhead, and ensure that you are making full use of the NIC's capabilities.
+In some high-performance scenarios where maximum efficiency is critical, targeted performance tuning can help optimize CPU usage, reduce processing demands, and ensure that you are making full use of the NIC's capabilities.
 
 For environments where maximum throughput and CPU efficiency are critical, you can further optimize performance with the following strategies:
 
@@ -21,7 +21,7 @@ For environments where maximum throughput and CPU efficiency are critical, you c
 
 * Evaluate OVN-Kubernetes User Defined Networking (UDN) routing techniques, such as border gateway protocol (BGP).
 
-* Use Geneve-offload capable network adapters. Geneve-offload moves the packet checksum calculation and associated CPU overhead off of the system CPU and onto dedicated hardware on the network adapter. This frees up CPU cycles for use by pods and applications, so that users can use the full bandwidth of their network infrastructure.
+* Use Geneve-offload capable network adapters. Geneve-offload moves the packet checksum calculation and associated CPU processing off of the system CPU and onto dedicated hardware on the network adapter. This frees up CPU cycles for use by pods and applications, so that users can use the full bandwidth of their network infrastructure.
 
 [role="_additional-resources"]
 [id="additional-resources_{context}"]


### PR DESCRIPTION
## Summary
- Fix Vale warnings in the optimizing-networking assembly and its included modules
- Replace "network interface card" with "network interface controller (NIC)" per Red Hat terminology
- Fix "IPSec" capitalization to "IPsec" (2 occurrences)
- Replace "overhead" (do-not-use term) with specific alternatives: "processing demands", "CPU processing", "performance impact"
- Fix grammar: "clusters using" → "clusters that use", "utilizing" → "using"

## Preview
https://108564--ocpdocs-pr.netlify.app/openshift-enterprise/latest/scalability_and_performance/optimization/optimizing-networking.html

## Test plan
- [x] Ran Vale linting — all actionable warnings resolved
- [ ] Verify AsciiDoc renders correctly with `asciibinder build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)