### PR TITLE
OSDOCS-18675-main: Remediation for REG-3

### DIFF
--- a/modules/registry-exposing-default-registry-manually.adoc
+++ b/modules/registry-exposing-default-registry-manually.adoc
@@ -14,7 +14,7 @@ Instead of logging in to the default {product-registry} from within the cluster,
 
 .Procedure
 
-. To expose the registry by using the `defaultRoute` parameter that exists in the `configs.imageregistry.operator.openshift.io` resource, set defaultRoute` to `true` by running the following command:
+. To expose the registry by using the `defaultRoute` parameter that exists in the `configs.imageregistry.operator.openshift.io` resource, set `defaultRoute` to `true` by running the following command:
 +
 [source,terminal]
 ----


### PR DESCRIPTION

Version(s):
4.16+

Issue:
[OSDOCS-18675](https://redhat.atlassian.net/browse/OSDOCS-18675)

Link to docs preview:

* [Exposing a default registry manually](https://108565--ocpdocs-pr.netlify.app/openshift-enterprise/latest/registry/securing-exposing-registry.html#registry-exposing-default-registry-manually_securing-exposing-registry)
