### PR TITLE
OBSDOCS-3239-vale-issue: Added the asciidocDITA file

### DIFF
--- a/.vale/styles/AsciiDocDITA/AdmonitionTitle.yml
+++ b/.vale/styles/AsciiDocDITA/AdmonitionTitle.yml
@@ -1,0 +1,70 @@
+# Report that admonition titles are not supported.
+---
+extends: script
+message: "Admonition titles are not supported in DITA."
+level: warning
+link: https://github.com/jhradilek/asciidoctor-dita-vale/blob/main/README.md#warnings
+scope: raw
+script: |
+  text               := import("text")
+  matches            := []
+
+  r_comment_line     := text.re_compile("^(//|//[^/].*)$")
+  r_comment_block    := text.re_compile("^/{4,}\\s*$")
+  r_block_title      := text.re_compile("^\\.{1,2}[^ \\t.].*$")
+  r_admonition_para  := text.re_compile("^(?:NOTE|TIP|IMPORTANT|WARNING|CAUTION):[ \\t]")
+  r_admonition_block := text.re_compile("^\\[(?:NOTE|TIP|IMPORTANT|WARNING|CAUTION)\\][ \\t]*$")
+  r_empty_line       := text.re_compile("^[ \\t]*$")
+
+  document           := text.split(text.trim_suffix(scope, "\n"), "\n")
+
+  in_comment_block   := false
+  expect_title       := false
+  expect_admonition  := false
+  start              := 0
+  end                := 0
+
+  for line in document {
+    start += end
+    end    = len(line) + 1
+
+    if r_comment_block.match(line) {
+      delimiter := text.trim_space(line)
+      if ! in_comment_block {
+        in_comment_block = delimiter
+      } else if in_comment_block == delimiter {
+        in_comment_block = false
+      }
+      continue
+    }
+    if in_comment_block { continue }
+    if r_comment_line.match(line) { continue }
+    if r_empty_line.match(line) { continue }
+
+    if r_block_title.match(line) {
+      if expect_title {
+        matches = append(matches, {begin: start, end: start + end - 1})
+        expect_title = false
+        expect_admonition = false
+      } else {
+        expect_admonition = {begin: start, end: start + end - 1}
+      }
+    } else if r_admonition_block.match(line) {
+      if expect_admonition {
+        matches = append(matches, expect_admonition)
+        expect_admonition = false
+        expect_title = false
+      } else {
+        expect_title = true
+      }
+    } else if r_admonition_para.match(line) {
+      if expect_admonition {
+        matches = append(matches, expect_admonition)
+        expect_admonition = false
+      }
+      expect_title = false
+    } else {
+      expect_title = false
+      expect_admonition = false
+    }
+  }

--- a/.vale/styles/AsciiDocDITA/AssemblyContents.yml
+++ b/.vale/styles/AsciiDocDITA/AssemblyContents.yml
@@ -1,0 +1,90 @@
+# Report unexpected contents in assemblies.
+---
+extends: script
+message: "Content other than additional resources cannot follow include directives."
+level: warning
+link: https://github.com/jhradilek/asciidoctor-dita-vale/blob/main/README.md#warnings
+scope: raw
+script: |
+  text              := import("text")
+  matches           := []
+
+  r_add_resources   := text.re_compile("^(?:={2,}[ \\t]+|\\.{1,2})Additional resources[ \\t]*$")
+  r_any_title       := text.re_compile("^(?:={2,}[ \\t]+|\\.{1,2})[^ \\t.].*$")
+  r_attribute       := text.re_compile("^:!?\\S[^:]*:")
+  r_comment_block   := text.re_compile("^/{4,}\\s*$")
+  r_comment_line    := text.re_compile("^(//|//[^/].*)$")
+  r_conditional     := text.re_compile("^(?:ifn?def|ifeval|endif)::\\S*\\[.*\\][ \\t]*$")
+  r_content_type    := text.re_compile("^:_(?:mod-docs-content|content|module)-type:[ \\t]+(?i:assembly)[ \\t]*$")
+  r_empty_line      := text.re_compile("^[ \\t]*$")
+  r_id_attribute    := text.re_compile("^\\[(?:id=['\\x22]|#|\\[)[A-Za-z_:{}][A-Za-z0-9_.:{}-]*(?:['\\x22],?[^\\]]*|,[^\\]]*\\]?|\\]?)\\][ \\t]*$")
+  r_include         := text.re_compile("^include::(?:[^ \\t\\[]|[^[]*[^ \\t\\[])\\[.*\\][ \\t]*$")
+  r_role_attribute  := text.re_compile("^\\[(?:role=['\\x22]|\\.).*['\\x22]?\\][ \\t]*$")
+
+  // Teams are inconsistent in how they name attribute definition files and
+  // snippet files. As it is impossible to reliably identify these files without
+  // reading their contents, the following is a workaround specifically for
+  // openshift-docs:
+  r_attribute_file  := text.re_compile("^include::(?:\\.\\./)?_?(?:attributes|common|artifacts)/(?:attributes-[^/]+|[^/]*-?attributes[^/]*)\\.adoc\\[.*\\][ \\t]*$")
+  r_snippet_file    := text.re_compile("^include::_?snippets/[^/]+\\.adoc\\[.*\\][ \\t]*$")
+
+  document          := text.split(text.trim_suffix(scope, "\n"), "\n")
+
+  in_comment_block  := false
+  is_assembly       := false
+  has_includes      := false
+  in_add_resources  := false
+  start             := 0
+  end               := 0
+
+  for line in document {
+    start += end
+    end    = len(line) + 1
+
+    if r_comment_block.match(line) {
+      delimiter := text.trim_space(line)
+      if ! in_comment_block {
+        in_comment_block = delimiter
+      } else if in_comment_block == delimiter {
+        in_comment_block = false
+      }
+      continue
+    }
+    if in_comment_block { continue }
+    if r_comment_line.match(line) { continue }
+
+    if r_content_type.match(line) {
+      is_assembly = true
+      continue
+    }
+
+    if r_include.match(line) {
+      if ! r_attribute_file.match(line) && ! r_snippet_file.match(line) {
+        has_includes = true
+        in_add_resources = false
+      }
+      continue
+    }
+
+    if r_add_resources.match(line) {
+      in_add_resources = true
+      continue
+    }
+
+    if ! has_includes { continue }
+
+    if r_empty_line.match(line) { continue }
+    if r_attribute.match(line) { continue }
+    if r_conditional.match(line) { continue }
+    if r_id_attribute.match(line) { continue }
+    if r_role_attribute.match(line) { continue }
+
+    if ! in_add_resources || r_any_title.match(line) {
+      matches = append(matches, {begin: start, end: start + end - 1})
+      break
+    }
+  }
+
+  if ! is_assembly {
+    matches = []
+  }

--- a/.vale/styles/AsciiDocDITA/AttributeReference.yml
+++ b/.vale/styles/AsciiDocDITA/AttributeReference.yml
@@ -1,0 +1,41 @@
+# Report custom attribute references.
+---
+extends: existence
+message: "%s"
+level: suggestion
+link: https://github.com/jhradilek/asciidoctor-dita-vale/blob/main/README.md#suggestions
+scope: raw
+nonword: true
+tokens:
+  - '(?<!\$)\{([0-9A-Za-z_][0-9A-Za-z_-]*|set:.+?|counter2?:.+?)\}'
+exceptions:
+  - blank
+  - empty
+  - sp
+  - nbsp
+  - zwsp
+  - wj
+  - apos
+  - quot
+  - lsquo
+  - rsquo
+  - ldquo
+  - rdquo
+  - deg
+  - plus
+  - brvbar
+  - vbar
+  - amp
+  - lt
+  - gt
+  - startsb
+  - endsb
+  - caret
+  - asterisk
+  - tilde
+  - backslash
+  - backtick
+  - two-colons
+  - two-semicolons
+  - cpp
+  - pp

--- a/.vale/styles/AsciiDocDITA/AuthorLine.yml
+++ b/.vale/styles/AsciiDocDITA/AuthorLine.yml
@@ -1,0 +1,60 @@
+# Report accidental author lines.
+---
+extends: script
+message: "Author lines are not supported for topics."
+level: warning
+link: https://github.com/jhradilek/asciidoctor-dita-vale/blob/main/README.md#warnings
+scope: raw
+script: |
+  text              := import("text")
+  matches           := []
+
+  r_comment_line    := text.re_compile("^(//|//[^/].*)$")
+  r_comment_block   := text.re_compile("^/{4,}\\s*$")
+  r_document_title  := text.re_compile("^=[ \\t]+\\S.*$")
+  r_attribute       := text.re_compile("^:!?\\S[^:]*:")
+
+  // Teams are inconsistent in how they name attribute definition files.
+  // As it is impossible to reliably identify which files only define attributes
+  // without reading their contents, the following is a workaround specifically
+  // for openshift-docs:
+  r_attribute_file  := text.re_compile("^include::_attributes/(?:attributes-[^/]+|[^/]*-?attributes)\\.adoc\\[.*\\][ \\t]*$")
+
+  document          := text.split(text.trim_suffix(scope, "\n"), "\n")
+
+  in_comment_block  := false
+  need_empty_line   := false
+  start             := 0
+  end               := 0
+
+  for line in document {
+    start += end
+    end    = len(line) + 1
+
+    if r_comment_block.match(line) {
+      delimiter := text.trim_space(line)
+      if ! in_comment_block {
+        in_comment_block = delimiter
+      } else if in_comment_block == delimiter {
+        in_comment_block = false
+      }
+      continue
+    }
+    if in_comment_block { continue }
+    if r_comment_line.match(line) { continue }
+
+    if r_document_title.match(line) {
+      if need_empty_line {
+        matches = append(matches, {begin: start, end: start + end - 1})
+        break
+      }
+      need_empty_line = true
+    } else if need_empty_line {
+      if r_attribute.match(line) || r_attribute_file.match(line) {
+        continue
+      } else if text.trim_space(line) != "" {
+        matches = append(matches, {begin: start, end: start + end - 1})
+      }
+      break
+    }
+  }

--- a/.vale/styles/AsciiDocDITA/BlockTitle.yml
+++ b/.vale/styles/AsciiDocDITA/BlockTitle.yml
@@ -1,0 +1,99 @@
+# Report unsupported block titles.
+---
+extends: script
+message: "Block titles can only be assigned to examples, figures, and tables in DITA."
+level: warning
+link: https://github.com/jhradilek/asciidoctor-dita-vale/blob/main/README.md#warnings
+scope: raw
+script: |
+  text              := import("text")
+  matches           := []
+
+  r_add_resources   := text.re_compile("^\\.{1,2}Additional resources[ \\t]*$")
+  r_attribute_list  := text.re_compile("^\\[(?:|[\\w.#%{,\"'].*)\\][ \\t]*$")
+  r_attribute       := text.re_compile("^:!?\\S[^:]*:")
+  r_block_title     := text.re_compile("^\\.{1,2}[^ \\t.].*$")
+  r_code_block      := text.re_compile("^(?:\\.{4,}|-{4,})[ \\t]*$")
+  r_comment_block   := text.re_compile("^/{4,}\\s*$")
+  r_comment_line    := text.re_compile("^(//|//[^/].*)$")
+  r_conditional     := text.re_compile("^(?:ifn?def|ifeval|endif)::\\S*\\[.*\\][ \\t]*$")
+  r_content_type    := text.re_compile("^:_(?:mod-docs-content|content|module)-type:[ \\t]+(?i:procedure)")
+  r_empty_line      := text.re_compile("^[ \\t]*$")
+  r_example_block   := text.re_compile("^\\[example\\][ \\t]*$")
+  r_example_delim   := text.re_compile("^={4,}[ \\t]*$")
+  r_image           := text.re_compile("^image::(?:\\S|\\S.*\\S)\\[.*\\][ \\t]*$")
+  r_supported_title := text.re_compile("^\\.{1,2}(?:Prerequisites?|Procedure|Verification|Results?|Troubleshooting|Troubleshooting steps?|Next steps?)[ \\t]*$")
+  r_table_cell      := text.re_compile("^\\.[^ \\t|]+\\|")
+  r_table           := text.re_compile("^\\|={3,}[ \\t]*$")
+
+  document          := text.split(text.trim_suffix(scope, "\n"), "\n")
+
+  in_code_block     := false
+  in_comment_block  := false
+  is_procedure      := false
+  expect_block      := false
+  start             := 0
+  end               := 0
+
+  for line in document {
+    start += end
+    end    = len(line) + 1
+
+    if r_comment_block.match(line) {
+      delimiter := text.trim_space(line)
+      if ! in_comment_block {
+        in_comment_block = delimiter
+      } else if in_comment_block == delimiter {
+        in_comment_block = false
+      }
+      continue
+    }
+    if in_comment_block { continue }
+    if r_comment_line.match(line) { continue }
+
+    if r_code_block.match(line) {
+      delimiter := text.trim_space(line)
+      if ! in_code_block {
+        in_code_block = delimiter
+      } else if in_code_block == delimiter {
+        in_code_block = false
+      }
+      expect_block = false
+      continue
+    }
+    if in_code_block { continue }
+
+    if r_content_type.match(line) {
+      is_procedure = true
+      continue
+    }
+
+    if r_attribute_list.match(line) && ! r_example_block.match(line) { continue }
+    if r_attribute.match(line) { continue }
+    if r_conditional.match(line) { continue }
+    if r_empty_line.match(line) { continue }
+
+    if r_block_title.match(line) {
+      if is_procedure && r_supported_title.match(line) { continue }
+      if r_add_resources.match(line) { continue }
+      if r_table_cell.match(line) { continue }
+
+      expect_block = {begin: start, end: start + end -1}
+      continue
+    }
+
+    if r_table.match(line) || r_image.match(line) ||
+       r_example_block.match(line) || r_example_delim.match(line) {
+      expect_block = false
+      continue
+    }
+
+    if expect_block {
+      matches = append(matches, expect_block)
+      expect_block = false
+    }
+  }
+
+  if expect_block {
+    matches = append(matches, expect_block)
+  }

--- a/.vale/styles/AsciiDocDITA/CalloutList.yml
+++ b/.vale/styles/AsciiDocDITA/CalloutList.yml
@@ -1,0 +1,9 @@
+# Report unsupported callout lists.
+---
+extends: existence
+message: "Callouts are not supported in DITA."
+level: warning
+scope: raw
+nonword: true
+tokens:
+  - '^<(?:1|\.)>[ \t]+.*$'

--- a/.vale/styles/AsciiDocDITA/ConceptLink.yml
+++ b/.vale/styles/AsciiDocDITA/ConceptLink.yml
@@ -1,0 +1,79 @@
+# Report links and cross references outside of Additional resources in concept modules.
+---
+extends: script
+message: "Move all links and cross references to Additional resources."
+level: warning
+link: https://github.com/jhradilek/asciidoctor-dita-vale/blob/main/README.md#warnings
+scope: raw
+script: |
+  text              := import("text")
+  matches           := []
+
+  r_add_resources   := text.re_compile("^(?:={2,}[ \\t]+|\\.{1,2})Additional resources[ \\t]*$")
+  r_any_title       := text.re_compile("^(?:={2,}[ \\t]+|\\.{1,2})[^ \\t.].*$")
+  r_comment_block   := text.re_compile("^/{4,}\\s*$")
+  r_comment_line    := text.re_compile("^(//|//[^/].*)$")
+  r_content_type    := text.re_compile("^:_(?:mod-docs-content|content|module)-type:[ \\t]+(?i:assembly|concept)")
+  r_inline_link     := text.re_compile("(?:|link:|<)(?:|\\+\\+)(?:https?|file|ftp|irc)://[^ \\t\\[\\]]+(?:|\\+\\+)(?:|\\[.*?\\])>?")
+  r_inline_xref     := text.re_compile("<<[A-Za-z0-9/.:{].*?>>")
+  r_link_macro      := text.re_compile("(?:link|mailto):(?:|[^: \\t\\[][^: \\t\\[]*)\\[.*?\\]")
+  r_xref_macro      := text.re_compile("xref:[A-Za-z0-9/.:{].*?\\[.*?\\]")
+
+  document          := text.split(text.trim_suffix(scope, "\n"), "\n")
+
+  is_relevant       := false
+  in_comment_block  := false
+  in_add_resources  := false
+  start             := 0
+  end               := 0
+
+  for line in document {
+    start += end
+    end    = len(line) + 1
+
+    if r_comment_block.match(line) {
+      delimiter := text.trim_space(line)
+      if ! in_comment_block {
+        in_comment_block = delimiter
+      } else if in_comment_block == delimiter {
+        in_comment_block = false
+      }
+      continue
+    }
+    if in_comment_block { continue }
+    if r_comment_line.match(line) { continue }
+
+    if r_content_type.match(line) {
+      is_relevant = true
+      continue
+    }
+
+    if r_add_resources.match(line) {
+      in_add_resources = true
+      continue
+    }
+
+    if r_any_title.match(line) {
+      in_add_resources = false
+      continue
+    }
+
+    if in_add_resources { continue }
+
+    for i, entry in r_link_macro.find(line, -1) {
+      matches = append(matches, {begin: start + entry[0].begin, end: start + entry[0].end - 1})
+    }
+    for i, entry in r_inline_link.find(line, -1) {
+      matches = append(matches, {begin: start + entry[0].begin, end: start + entry[0].end - 1})
+    }
+    for i, entry in r_xref_macro.find(line, -1) {
+      matches = append(matches, {begin: start + entry[0].begin, end: start + entry[0].end - 1})
+    }
+    for i, entry in r_inline_xref.find(line, -1) {
+      matches = append(matches, {begin: start + entry[0].begin, end: start + entry[0].end - 1})
+    }
+  }
+
+  if ! is_relevant {
+    matches = []
+  }

--- a/.vale/styles/AsciiDocDITA/ConditionalCode.yml
+++ b/.vale/styles/AsciiDocDITA/ConditionalCode.yml
@@ -1,0 +1,10 @@
+# Report conditional directives.
+---
+extends: existence
+message: "%s"
+level: suggestion
+link: https://github.com/jhradilek/asciidoctor-dita-vale/blob/main/README.md#suggestions
+scope: raw
+nonword: true
+tokens:
+  - '^(?:ifn?def|ifeval)::\S*\[.*\][ \t]*$'

--- a/.vale/styles/AsciiDocDITA/ContentType.yml
+++ b/.vale/styles/AsciiDocDITA/ContentType.yml
@@ -1,0 +1,9 @@
+# Report a missing content type definition.
+---
+extends: occurrence
+message: "The '_mod-docs-content-type' attribute definition is missing."
+level: warning
+link: https://github.com/jhradilek/asciidoctor-dita-vale/blob/main/README.md#warnings
+scope: raw
+min: 1
+token: '(?:^|[\n\r]):_(?:mod-docs-content|content|module)-type:[ \t]+\S'

--- a/.vale/styles/AsciiDocDITA/DiscreteHeading.yml
+++ b/.vale/styles/AsciiDocDITA/DiscreteHeading.yml
@@ -1,0 +1,10 @@
+# Report that discrete headings are not supported.
+---
+extends: existence
+message: "Discrete headings are not supported in DITA."
+level: warning
+link: https://github.com/jhradilek/asciidoctor-dita-vale/blob/main/README.md#warnings
+scope: raw
+nonword: true
+tokens:
+  - '^\[discrete\b[^\n\]]*?\]'

--- a/.vale/styles/AsciiDocDITA/DocumentId.yml
+++ b/.vale/styles/AsciiDocDITA/DocumentId.yml
@@ -1,0 +1,75 @@
+# Report a missing document id.
+---
+extends: script
+message: "The document id assigned to the level 0 heading is missing."
+level: warning
+link: https://github.com/jhradilek/asciidoctor-dita-vale/blob/main/README.md#warnings
+scope: raw
+script: |
+  text              := import("text")
+  matches           := []
+
+  r_attribute_list  := text.re_compile("^\\[(?:|[\\w.#%{,\"'].*)\\][ \\t]*$")
+  r_attribute       := text.re_compile("^:!?\\S[^:]*:")
+  r_code_block      := text.re_compile("^(?:\\.{4,}|-{4,})[ \\t]*$")
+  r_comment_block   := text.re_compile("^/{4,}\\s*$")
+  r_comment_line    := text.re_compile("^(//|//[^/].*)$")
+  r_conditional     := text.re_compile("^(?:ifn?def|ifeval|endif)::\\S*\\[.*\\][ \\t]*$")
+  r_document_title  := text.re_compile("^(?:=[ \\t]+[^ \\t].*|ifn?def::\\S*\\[=[ \\t]+[^ \\t].*\\][ \\t]*)$")
+  r_empty_line      := text.re_compile("^[ \\t]*$")
+  r_id_attribute    := text.re_compile("^\\[(?:id=['\\x22]?|#|\\[)[A-Za-z_:{}][A-Za-z0-9_.:{}-]*(?:['\\x22]?,?[^\\]]*|,[^\\]]*\\]?|\\]?)\\][ \\t]*$")
+
+  document          := text.split(text.trim_suffix(scope, "\n"), "\n")
+
+  in_code_block     := false
+  in_comment_block  := false
+  assigned_id       := false
+  start             := 0
+  end               := 0
+
+  for line in document {
+    start += end
+    end    = len(line) + 1
+
+    if r_comment_block.match(line) {
+      delimiter := text.trim_space(line)
+      if ! in_comment_block {
+        in_comment_block = delimiter
+      } else if in_comment_block == delimiter {
+        in_comment_block = false
+      }
+      continue
+    }
+    if in_comment_block { continue }
+    if r_comment_line.match(line) { continue }
+
+    if r_code_block.match(line) {
+      delimiter := text.trim_space(line)
+      if ! in_code_block {
+        in_code_block = delimiter
+      } else if in_code_block == delimiter {
+        in_code_block = false
+      }
+      continue
+    }
+    if in_code_block { continue }
+
+    if r_id_attribute.match(line) {
+      assigned_id = true
+      continue
+    }
+
+    if r_attribute_list.match(line) { continue }
+    if r_attribute.match(line) { continue }
+    if r_empty_line.match(line) { continue }
+    if r_conditional.match(line) && ! r_document_title.match(line) { continue }
+
+    if r_document_title.match(line) {
+      if ! assigned_id {
+        matches = append(matches, {begin: start, end: start + end - 1})
+      }
+      break
+    }
+
+    assigned_id = false
+  }

--- a/.vale/styles/AsciiDocDITA/DocumentTitle.yml
+++ b/.vale/styles/AsciiDocDITA/DocumentTitle.yml
@@ -1,0 +1,51 @@
+# Report a missing document title.
+---
+extends: script
+message: "The document title (a level 0 heading) is missing."
+level: warning
+link: https://github.com/jhradilek/asciidoctor-dita-vale/blob/main/README.md#warnings
+scope: raw
+script: |
+  text              := import("text")
+  matches           := [{begin: 0, end: 0}]
+
+  r_code_block      := text.re_compile("^(?:\\.{4,}|-{4,})[ \\t]*$")
+  r_comment_block   := text.re_compile("^/{4,}\\s*$")
+  r_comment_line    := text.re_compile("^(//|//[^/].*)$")
+  r_document_title  := text.re_compile("^(?:=[ \\t]+[^ \\t].*|ifn?def::\\S*\\[=[ \\t]+[^ \\t].*\\][ \\t]*)$")
+  r_excluded_type   := text.re_compile("^:_(?:mod-docs-content|content|module)-type:[ \\t]+(?i:snippet|attributes)[ \\t]*$")
+
+  document          := text.split(text.trim_suffix(scope, "\n"), "\n")
+
+  in_code_block     := false
+  in_comment_block  := false
+
+  for line in document {
+    if r_comment_block.match(line) {
+      delimiter := text.trim_space(line)
+      if ! in_comment_block {
+        in_comment_block = delimiter
+      } else if in_comment_block == delimiter {
+        in_comment_block = false
+      }
+      continue
+    }
+    if in_comment_block { continue }
+    if r_comment_line.match(line) { continue }
+
+    if r_code_block.match(line) {
+      delimiter := text.trim_space(line)
+      if ! in_code_block {
+        in_code_block = delimiter
+      } else if in_code_block == delimiter {
+        in_code_block = false
+      }
+      continue
+    }
+    if in_code_block { continue }
+
+    if r_excluded_type.match(line) || r_document_title.match(line) {
+      matches = []
+      break
+    }
+  }

--- a/.vale/styles/AsciiDocDITA/EntityReference.yml
+++ b/.vale/styles/AsciiDocDITA/EntityReference.yml
@@ -1,0 +1,80 @@
+# Report unsupported character entity references.
+---
+extends: script
+message: "HTML character entity references are not supported in DITA."
+level: error
+link: https://github.com/jhradilek/asciidoctor-dita-vale/blob/main/README.md#errors
+scope: raw
+script: |
+  text               := import("text")
+  matches            := []
+
+  r_attribute_list   := text.re_compile("^\\[(?:|[\\w.#%{,\"'].*)\\][ \\t]*$")
+  r_block_title      := text.re_compile("^\\.{1,2}[^ \\t.].*$")
+  r_code_block       := text.re_compile("^(?:\\.{4,}|-{4,})[ \\t]*$")
+  r_comment_line     := text.re_compile("^(//|//[^/].*)$")
+  r_comment_block    := text.re_compile("^/{4,}\\s*$")
+  r_empty_line       := text.re_compile("^[ \\t]*$")
+  r_entity_reference := text.re_compile("&[a-zA-Z][a-zA-Z0-9]*;")
+  r_list_continue    := text.re_compile("^\\+[ \\t]*$")
+  r_sub_disabled     := text.re_compile("-replacements")
+  r_sub_replacements := text.re_compile("subs=['\\x22](?:[^'\\x22]*,[ \\t]*|)\\+?(?:replacements|normal)(?:[ \\t]*,[^'\\x22]*|)['\\x22]")
+  r_supported_entity := text.re_compile("&(?:amp|lt|gt|apos|quot);")
+
+  document           := text.split(text.trim_suffix(scope, "\n"), "\n")
+
+  in_code_block      := false
+  in_comment_block   := false
+  replacements       := false
+  start              := 0
+  end                := 0
+
+  for line in document {
+    start += end
+    end    = len(line) + 1
+
+    if r_comment_block.match(line) {
+      delimiter := text.trim_space(line)
+      if ! in_comment_block {
+        in_comment_block = delimiter
+      } else if in_comment_block == delimiter {
+        in_comment_block = false
+      }
+      continue
+    }
+    if in_comment_block { continue }
+    if r_comment_line.match(line) { continue }
+
+    if r_code_block.match(line) {
+      delimiter := text.trim_space(line)
+      if ! in_code_block {
+        in_code_block = delimiter
+      } else if in_code_block == delimiter {
+        in_code_block = false
+        replacements = false
+      }
+      continue
+    }
+    if in_code_block && ! replacements { continue }
+
+    if r_block_title.match(line) { continue }
+    if r_empty_line.match(line) { continue }
+    if r_list_continue.match(line) { continue }
+
+    if r_attribute_list.match(line) {
+      if r_sub_replacements.match(line) && ! r_sub_disabled.match(line) {
+        replacements = true
+      }
+      continue
+    }
+
+    if replacements && ! in_code_block {
+      replacements = false
+    }
+
+    for i, entry in r_entity_reference.find(line, -1) {
+      if ! r_supported_entity.match(entry[0].text) {
+        matches = append(matches, {begin: start + entry[0].begin, end: start + entry[0].end - 1})
+      }
+    }
+  }

--- a/.vale/styles/AsciiDocDITA/EquationFormula.yml
+++ b/.vale/styles/AsciiDocDITA/EquationFormula.yml
@@ -1,0 +1,12 @@
+# Report that equations and formulas are not implemented.
+---
+extends: existence
+message: "Equations and formulas are not implemented."
+level: warning
+link: https://github.com/jhradilek/asciidoctor-dita-vale/blob/main/README.md#warnings
+scope: raw
+nonword: true
+tokens:
+  - '^:stem:(?:|[ \t]+asciimath|[ \t]latexmath)[ \t]*$'
+  - '^\[(?:stem|asciimath|latexmath)\][ \t]*$'
+  - '\b(?:stem|asciimath|latexmath):(?:[a-z,-]+)?\[.*?[^\\]\]'

--- a/.vale/styles/AsciiDocDITA/ExampleBlock.yml
+++ b/.vale/styles/AsciiDocDITA/ExampleBlock.yml
@@ -1,0 +1,143 @@
+# Report unsupported example blocks.
+---
+extends: script
+message: "Examples can not be inside of other blocks in DITA."
+level: error
+link: https://github.com/jhradilek/asciidoctor-dita-vale/blob/main/README.md#errors
+scope: raw
+script: |
+  text               := import("text")
+  matches            := []
+
+  r_admonition_block := text.re_compile("^\\[(?:NOTE|TIP|IMPORTANT|WARNING|CAUTION)\\][ \\t]*$")
+  r_attribute        := text.re_compile("^:!?\\S[^:]*:")
+  r_block_title      := text.re_compile("^\\.{1,2}[^ \\t.].*$")
+  r_code_block       := text.re_compile("^(?:\\.{4,}|-{4,})[ \\t]*$")
+  r_comment_block    := text.re_compile("^/{4,}\\s*$")
+  r_comment_line     := text.re_compile("^(//|//[^/].*)$")
+  r_conditional      := text.re_compile("^(?:ifn?def|ifeval|endif)::\\S*\\[.*\\][ \\t]*$")
+  r_empty_line       := text.re_compile("^[ \\t]*$")
+  r_example_block    := text.re_compile("^\\[example\\][ \\t]*$")
+  r_example_delim    := text.re_compile("^={4,}[ \\t]*$")
+  r_list_continue    := text.re_compile("^\\+[ \\t]*$")
+  r_list_item        := text.re_compile("^[ \\t]*[\\*-.]+[ \\t]+\\S.*$")
+  r_other_block      := text.re_compile("^(?:\\*{4,}|-{2})[ \\t]*$")
+  r_section          := text.re_compile("^={2,}[ \\t]\\S.*$")
+
+  document           := text.split(text.trim_suffix(scope, "\n"), "\n")
+
+  in_comment_block   := false
+  in_example_block   := false
+  in_code_block      := false
+  in_other_block     := false
+  in_section         := false
+  in_list            := false
+  in_continue        := false
+  expect_admonition  := false
+  start              := 0
+  end                := 0
+
+  for line in document {
+    start += end
+    end    = len(line) + 1
+
+    if r_comment_block.match(line) {
+      delimiter := text.trim_space(line)
+      if ! in_comment_block {
+        in_comment_block = delimiter
+      } else if in_comment_block == delimiter {
+        in_comment_block = false
+      }
+      continue
+    }
+    if in_comment_block { continue }
+    if r_comment_line.match(line) { continue }
+
+    if r_code_block.match(line) {
+      delimiter := text.trim_space(line)
+      if ! in_code_block {
+        in_code_block = delimiter
+      } else if in_code_block == delimiter {
+        in_code_block = false
+      }
+      in_continue = false
+      continue
+    }
+    if in_code_block { continue }
+
+    if r_attribute.match(line) { continue }
+    if r_conditional.match(line) { continue }
+
+    if r_example_delim.match(line) {
+      delimiter := text.trim_space(line)
+      if ! in_example_block {
+        in_example_block = delimiter
+
+        if expect_admonition { continue }
+
+        if in_section || in_other_block || in_list {
+          matches = append(matches, {begin: start, end: start + end - 1})
+        }
+      } else if in_example_block == delimiter {
+        in_example_block = false
+      }
+      in_continue = false
+      continue
+    }
+
+    if r_empty_line.match(line) {
+      if ! in_continue {
+        in_list = false
+      }
+      continue
+    }
+
+    if r_list_continue.match(line) {
+      in_continue = true
+      in_list = true
+      continue
+    } else {
+      in_continue = false
+    }
+
+    if r_block_title.match(line) && expect_admonition {
+      if in_continue {
+        in_continue = false
+      }
+      continue
+    }
+
+    if r_list_item.match(line) {
+      in_list = true
+      continue
+    }
+
+    if r_admonition_block.match(line) {
+      expect_admonition = true
+      continue
+    }
+
+    if r_section.match(line) {
+      in_section = true
+      continue
+    }
+
+    if r_example_block.match(line) {
+      if in_section || in_other_block || in_list {
+        matches = append(matches, {begin: start, end: start + end - 1})
+      }
+      continue
+    }
+
+    if r_other_block.match(line) {
+      delimiter := text.trim_space(line)
+      if ! in_other_block {
+        in_other_block = delimiter
+      } else if in_other_block == delimiter {
+        in_other_block = false
+      }
+      continue
+    }
+
+    expect_admonition = false
+  }

--- a/.vale/styles/AsciiDocDITA/IncludeDirective.yml
+++ b/.vale/styles/AsciiDocDITA/IncludeDirective.yml
@@ -1,0 +1,10 @@
+# Report include directives.
+---
+extends: existence
+message: "%s"
+level: suggestion
+link: https://github.com/jhradilek/asciidoctor-dita-vale/blob/main/README.md#suggestions
+scope: raw
+nonword: true
+tokens:
+  - '^include::(?:[^\s\[]|[^[]*[^\s\[])\[.*\][ \t]*$'

--- a/.vale/styles/AsciiDocDITA/LineBreak.yml
+++ b/.vale/styles/AsciiDocDITA/LineBreak.yml
@@ -1,0 +1,16 @@
+# Report that hard line breaks ara not supported.
+---
+extends: existence
+message: "Hard line breaks are not supported in DITA."
+level: warning
+link: https://github.com/jhradilek/asciidoctor-dita-vale/blob/main/README.md#warnings
+scope: raw
+nonword: true
+tokens:
+  - '^[^/]{2}.* \+[ \t]*$'
+  - '^. \+[ \t]*$'
+  - '^:hardbreaks-option:(?:|.*?)[ \t]*$'
+  - '^\[[^\]]*%hardbreaks[^\n\]]*?\]'
+  - '^\[[^\]]*options=hardbreaks\b[^\n\]]*?\]'
+  - '^\[[^\]]*options="[^"]*hardbreaks\b[^\n\]]*?\]'
+  - "^\\[[^\\]]*options='[^']*hardbreaks\\b[^\\n\\]]*?\\]"

--- a/.vale/styles/AsciiDocDITA/MismatchedId.yml
+++ b/.vale/styles/AsciiDocDITA/MismatchedId.yml
@@ -1,0 +1,13 @@
+# Report mismatched quotes in a custom ID.
+---
+extends: existence
+message: "The quotes in the ID are mismatched."
+level: error
+link: https://github.com/jhradilek/asciidoctor-dita-vale/blob/main/README.md#errors
+scope: raw
+nonword: true
+tokens:
+  - '^\[id=["\x27][^"\x27]+\]'
+  - '^\[id=[^"\x27]+["\x27]\]'
+  - '^\[id="[^"\x27]+\x27\]'
+  - '^\[id=\x27[^"\x27]+"\]'

--- a/.vale/styles/AsciiDocDITA/NestedSection.yml
+++ b/.vale/styles/AsciiDocDITA/NestedSection.yml
@@ -1,0 +1,10 @@
+# Report that level 2, 3, 4, and 5 sections are not supported.
+---
+extends: existence
+message: "Level 2, 3, 4, and 5 sections are not supported in DITA."
+level: error
+link: https://github.com/jhradilek/asciidoctor-dita-vale/blob/main/README.md#errors
+scope: raw
+nonword: true
+tokens:
+  - '^={3,6}[ \t]\S.*$'

--- a/.vale/styles/AsciiDocDITA/PageBreak.yml
+++ b/.vale/styles/AsciiDocDITA/PageBreak.yml
@@ -1,0 +1,10 @@
+# Report that page breaks are not supported.
+---
+extends: existence
+message: "Page breaks are not supported in DITA."
+level: warning
+link: https://github.com/jhradilek/asciidoctor-dita-vale/blob/main/README.md#warnings
+scope: raw
+nonword: true
+tokens:
+  - '^<{3,}[ \t]*$'

--- a/.vale/styles/AsciiDocDITA/RelatedLinks.yml
+++ b/.vale/styles/AsciiDocDITA/RelatedLinks.yml
@@ -1,0 +1,89 @@
+# Report text outside of links in additional resources.
+---
+extends: script
+message: "Content other than links cannot be mapped to DITA related-links."
+level: warning
+link: https://github.com/jhradilek/asciidoctor-dita-vale/blob/main/README.md#warnings
+scope: raw
+script: |
+  text              := import("text")
+  matches           := []
+
+  r_add_resources   := text.re_compile("^(?:={2,}[ \\t]+|\\.{1,2})Additional resources[ \\t]*$")
+  r_any_title       := text.re_compile("^(?:={2,}[ \\t]+|\\.{1,2})[^ \\t.].*$")
+  r_attribute       := text.re_compile("^:!?\\S[^:]*:")
+  r_attribute_ref   := text.re_compile("^[ \\t]*[\\*-][ \\t]+\\{(?:[0-9A-Za-z_][0-9A-Za-z_-]*|set:.+?|counter2?:.+?)\\}(?:|[^\\[\\s]*\\[.*?\\])[ \\t]*$")
+  r_comment_block   := text.re_compile("^/{4,}\\s*$")
+  r_comment_line    := text.re_compile("^(//|//[^/].*)$")
+  r_conditional     := text.re_compile("^(?:ifn?def|ifeval|endif)::\\S*\\[.*\\][ \\t]*$")
+  r_content_type    := text.re_compile("^:_(?:mod-docs-content|content|module)-type:[ \\t]+(?i:assembly)")
+  r_empty_line      := text.re_compile("^[ \\t]*$")
+  r_id_attribute    := text.re_compile("^\\[(?:id=['\\x22]|#|\\[)[A-Za-z_:{}][A-Za-z0-9_.:{}-]*(?:['\\x22],?[^\\]]*|,[^\\]]*\\]?|\\]?)\\][ \\t]*$")
+  r_include         := text.re_compile("^include::(?:[^ \\t\\[]|[^[]*[^ \\t\\[])\\[.*\\][ \\t]*$")
+  r_inline_link     := text.re_compile("^[ \\t]*[\\*-][ \\t]+(?:|link:|<)(?:|\\+\\+)(?:https?|file|ftp|irc)://[^ \\t\\[\\]]+(?:|\\+\\+)(?:|\\[.*?\\])>?[ \\t]*$")
+  r_inline_xref     := text.re_compile("^[ \\t]*[\\*-][ \\t]+<<[A-Za-z0-9/.:{].*?>>[ \\t]*$")
+  r_link_macro      := text.re_compile("^[ \\t]*[\\*-][ \\t]+(?:link|mailto):(?:|[^: \\t\\[][^: \\t\\[]*)\\[.*?\\][ \\t]*$")
+  r_role_attribute  := text.re_compile("^\\[(?:role=['\\x22]|\\.)_additional-resources['\\x22]?\\][ \\t]*$")
+  r_xref_macro      := text.re_compile("^[ \\t]*[\\*-][ \\t]+xref:[A-Za-z0-9/.:{].*?\\[.*?\\][ \\t]*$")
+
+  document          := text.split(text.trim_suffix(scope, "\n"), "\n")
+
+  is_assembly       := false
+  in_comment_block  := false
+  in_add_resources  := false
+  start             := 0
+  end               := 0
+
+  for line in document {
+    start += end
+    end    = len(line) + 1
+
+    if r_comment_block.match(line) {
+      delimiter := text.trim_space(line)
+      if ! in_comment_block {
+        in_comment_block = delimiter
+      } else if in_comment_block == delimiter {
+        in_comment_block = false
+      }
+      continue
+    }
+    if in_comment_block { continue }
+    if r_comment_line.match(line) { continue }
+
+    if r_content_type.match(line) {
+      is_assembly = true
+      continue
+    }
+
+    if r_empty_line.match(line) { continue }
+    if r_attribute.match(line) { continue }
+    if r_conditional.match(line) { continue }
+
+    if r_role_attribute.match(line) || r_id_attribute.match(line) {
+      continue
+    }
+
+    if r_include.match(line) && is_assembly {
+      continue
+    }
+
+    if r_add_resources.match(line) {
+      in_add_resources = true
+      continue
+    }
+
+    if ! in_add_resources { continue }
+
+    if r_any_title.match(line) {
+      in_add_resources = false
+      continue
+    }
+
+    if r_link_macro.match(line) || r_inline_link.match(line) ||
+       r_xref_macro.match(line) || r_inline_xref.match(line) ||
+       r_attribute_ref.match(line) {
+      continue
+    }
+
+    matches = append(matches, {begin: start, end: start + end - 1})
+  }

--- a/.vale/styles/AsciiDocDITA/ShortDescription.yml
+++ b/.vale/styles/AsciiDocDITA/ShortDescription.yml
@@ -1,0 +1,56 @@
+# Suggest assigning the [role="_abstract"] attribute list to a paragraph to
+# be used as short description in DITA.
+---
+extends: script
+message: "Assign [role=\"_abstract\"] to a paragraph to use it as <shortdesc> in DITA."
+level: warning
+link: https://github.com/jhradilek/asciidoctor-dita-vale/blob/main/README.md#warnings
+scope: raw
+script: |
+  text              := import("text")
+  matches           := [{begin: 0, end: 0}]
+
+  r_abstract        := text.re_compile("^\\[role=(?:\"_abstract\"|'_abstract'|_abstract)\\][ \\t]*$")
+  r_comment_block   := text.re_compile("^/{4,}\\s*$")
+  r_comment_line    := text.re_compile("^(//|//[^/].*)$")
+  r_content_type    := text.re_compile("^:_(?:mod-docs-content|content|module)-type:")
+  r_document_title  := text.re_compile("^(?:=[ \\t]+[^ \\t].*|ifn?def::\\S*\\[=[ \\t]+[^ \\t].*\\][ \\t]*)$")
+  r_excluded_type   := text.re_compile("[ \\t]+(?i:snippet|attributes)[ \\t]*$")
+
+  document          := text.split(text.trim_suffix(scope, "\n"), "\n")
+
+  in_comment_block  := false
+  has_title         := false
+  start             := 0
+  end               := 0
+
+  for line in document {
+    start += end
+    end    = len(line) + 1
+
+    if r_comment_block.match(line) {
+      delimiter := text.trim_space(line)
+      if ! in_comment_block {
+        in_comment_block = delimiter
+      } else if in_comment_block == delimiter {
+        in_comment_block = false
+      }
+      continue
+    }
+    if in_comment_block { continue }
+    if r_comment_line.match(line) { continue }
+
+    if r_document_title.match(line) {
+      if ! has_title {
+        matches = [{begin: start, end: start + end - 1}]
+        has_title = true
+      }
+      continue
+    }
+
+    if (r_content_type.match(line) && r_excluded_type.match(line)) ||
+       r_abstract.match(line) {
+      matches = []
+      break
+    }
+  }

--- a/.vale/styles/AsciiDocDITA/SidebarBlock.yml
+++ b/.vale/styles/AsciiDocDITA/SidebarBlock.yml
@@ -1,0 +1,55 @@
+# Report that sidebars are not supported.
+---
+extends: script
+message: "Sidebars are not supported in DITA."
+level: warning
+link: https://github.com/jhradilek/asciidoctor-dita-vale/blob/main/README.md#warnings
+scope: raw
+script: |
+  text              := import("text")
+  matches           := []
+
+  r_code_block      := text.re_compile("^(?:\\.{4,}|-{4,})[ \\t]*$")
+  r_comment_block   := text.re_compile("^/{4,}\\s*$")
+  r_comment_line    := text.re_compile("^(//|//[^/].*)$")
+  r_sidebar_block   := text.re_compile("^\\[sidebar\\b[^\\]]*?\\][ \\t]*$")
+  r_sidebar_delim   := text.re_compile("^\\*{4,}[ \\t]*$")
+
+  document          := text.split(text.trim_suffix(scope, "\n"), "\n")
+
+  in_code_block     := false
+  in_comment_block  := false
+  start             := 0
+  end               := 0
+
+  for line in document {
+    start += end
+    end    = len(line) + 1
+
+    if r_comment_block.match(line) {
+      delimiter := text.trim_space(line)
+      if ! in_comment_block {
+        in_comment_block = delimiter
+      } else if in_comment_block == delimiter {
+        in_comment_block = false
+      }
+      continue
+    }
+    if in_comment_block { continue }
+    if r_comment_line.match(line) { continue }
+
+    if r_code_block.match(line) {
+      delimiter := text.trim_space(line)
+      if ! in_code_block {
+        in_code_block = delimiter
+      } else if in_code_block == delimiter {
+        in_code_block = false
+      }
+      continue
+    }
+    if in_code_block { continue }
+
+    if r_sidebar_block.match(line) || r_sidebar_delim.match(line) {
+      matches = append(matches, {begin: start, end: start + end - 1})
+    }
+  }

--- a/.vale/styles/AsciiDocDITA/TableFooter.yml
+++ b/.vale/styles/AsciiDocDITA/TableFooter.yml
@@ -1,0 +1,13 @@
+# Report that table footers are not supported.
+---
+extends: existence
+message: "Table footers are not supported in DITA."
+level: warning
+link: https://github.com/jhradilek/asciidoctor-dita-vale/blob/main/README.md#warnings
+scope: raw
+nonword: true
+tokens:
+  - '^\[[^\]]*%footer[^\n\]]*?\]'
+  - '^\[[^\]]*options=footer\b[^\n\]]*?\]'
+  - '^\[[^\]]*options="[^"]*footer\b[^\n\]]*?\]'
+  - "^\\[[^\\]]*options='[^']*footer\\b[^\\n\\]]*?\\]"

--- a/.vale/styles/AsciiDocDITA/TagDirective.yml
+++ b/.vale/styles/AsciiDocDITA/TagDirective.yml
@@ -1,0 +1,10 @@
+# Report tag directives.
+---
+extends: existence
+message: "%s"
+level: suggestion
+link: https://github.com/jhradilek/asciidoctor-dita-vale/blob/main/README.md#suggestions
+scope: raw
+nonword: true
+tokens:
+  - '\btag::\S+?\[\][ \t]*$'

--- a/.vale/styles/AsciiDocDITA/TaskContents.yml
+++ b/.vale/styles/AsciiDocDITA/TaskContents.yml
@@ -1,0 +1,58 @@
+# Report a missing procedure title in a procedure module.
+---
+extends: script
+message: "The '.Procedure' block title is missing."
+level: warning
+link: https://github.com/jhradilek/asciidoctor-dita-vale/blob/main/README.md#warnings
+scope: raw
+script: |
+  text              := import("text")
+  matches           := [{begin: 0, end: 0}]
+
+  r_code_block      := text.re_compile("^(?:\\.{4,}|-{4,})[ \\t]*$")
+  r_comment_block   := text.re_compile("^/{4,}\\s*$")
+  r_comment_line    := text.re_compile("^(//|//[^/].*)$")
+  r_content_type    := text.re_compile("^:_(?:mod-docs-content|content|module)-type:[ \\t]+(?i:procedure)[ \\t]*$")
+  r_procedure_title := text.re_compile("^\\.{1,2}Procedure[ \\t]*$")
+
+  document          := text.split(text.trim_suffix(scope, "\n"), "\n")
+
+  in_code_block     := false
+  in_comment_block  := false
+  is_procedure      := false
+
+  for line in document {
+    if r_comment_block.match(line) {
+      delimiter := text.trim_space(line)
+      if ! in_comment_block {
+        in_comment_block = delimiter
+      } else if in_comment_block == delimiter {
+        in_comment_block = false
+      }
+      continue
+    }
+    if in_comment_block { continue }
+    if r_comment_line.match(line) { continue }
+
+    if r_code_block.match(line) {
+      delimiter := text.trim_space(line)
+      if ! in_code_block {
+        in_code_block = delimiter
+      } else if in_code_block == delimiter {
+        in_code_block = false
+      }
+      continue
+    }
+    if in_code_block { continue }
+
+    if r_content_type.match(line) {
+      is_procedure = true
+    } else if r_procedure_title.match(line) {
+      matches = []
+      break
+    }
+  }
+
+  if ! is_procedure {
+    matches = []
+  }

--- a/.vale/styles/AsciiDocDITA/TaskDuplicate.yml
+++ b/.vale/styles/AsciiDocDITA/TaskDuplicate.yml
@@ -1,0 +1,65 @@
+# Report duplicate titles inside of procedure modules.
+---
+extends: script
+message: "Duplicate titles cannot be mapped to DITA tasks."
+level: warning
+link: https://github.com/jhradilek/asciidoctor-dita-vale/blob/main/README.md#warnings
+scope: raw
+script: |
+  text              := import("text")
+  matches           := []
+
+  r_comment_line    := text.re_compile("^(//|//[^/].*)$")
+  r_comment_block   := text.re_compile("^/{4,}\\s*$")
+  r_content_type    := text.re_compile("^:_(?:mod-docs-content|content|module)-type:[ \\t]+(?i:procedure)")
+
+  titles            := {}
+  titles.prereq      = text.re_compile("^\\.{1,2}Prerequisites?[ \\t]*$")
+  titles.steps       = text.re_compile("^\\.{1,2}Procedure[ \\t]*$")
+  titles.result      = text.re_compile("^\\.{1,2}(?:Verification|Results?)[ \\t]*$")
+  titles.trouble     = text.re_compile("^\\.{1,2}(?:Troubleshooting|Troubleshooting steps?)[ \\t]*$")
+  titles.postreq     = text.re_compile("^\\.{1,2}Next steps?[ \\t]*$")
+  titles.links       = text.re_compile("^\\.{1,2}Additional resources[ \\t]*$")
+
+  document          := text.split(text.trim_suffix(scope, "\n"), "\n")
+
+  in_comment_block  := false
+  is_procedure      := false
+  start             := 0
+  end               := 0
+  block_titles      := {}
+
+  for line in document {
+    start += end
+    end    = len(line) + 1
+
+    if r_comment_block.match(line) {
+      delimiter := text.trim_space(line)
+      if ! in_comment_block {
+        in_comment_block = delimiter
+      } else if in_comment_block == delimiter {
+        in_comment_block = false
+      }
+      continue
+    }
+    if in_comment_block { continue }
+    if r_comment_line.match(line) { continue }
+
+    if r_content_type.match(line) {
+      is_procedure = true
+    }
+
+    for title, r in titles {
+      if ! r.match(line) { continue }
+
+      if block_titles[title] {
+        matches = append(matches, {begin: start, end: start + end - 1})
+      } else {
+        block_titles[title] = true
+      }
+    }
+  }
+
+  if ! is_procedure {
+    matches = []
+  }

--- a/.vale/styles/AsciiDocDITA/TaskExample.yml
+++ b/.vale/styles/AsciiDocDITA/TaskExample.yml
@@ -1,0 +1,124 @@
+# Report extra examples inside of procedure modules.
+---
+extends: script
+message: "Examples are allowed only once in DITA tasks."
+level: error
+link: https://github.com/jhradilek/asciidoctor-dita-vale/blob/main/README.md#errors
+scope: raw
+script: |
+  text               := import("text")
+  matches            := []
+
+  r_admonition_block := text.re_compile("^\\[(?:NOTE|TIP|IMPORTANT|WARNING|CAUTION)\\][ \\t]*$")
+  r_block_title      := text.re_compile("^\\.{1,2}[^ \\t.].*$")
+  r_comment_block    := text.re_compile("^/{4,}\\s*$")
+  r_comment_line     := text.re_compile("^(//|//[^/].*)$")
+  r_code_block       := text.re_compile("^(?:\\.{4,}|-{4,})[ \\t]*$")
+  r_conditional      := text.re_compile("^(?:ifn?def|ifeval|endif)::\\S*\\[.*\\][ \\t]*$")
+  r_content_type     := text.re_compile("^:_(?:mod-docs-content|content|module)-type:[ \\t]+(?i:procedure)")
+  r_empty_line       := text.re_compile("^[ \\t]*$")
+  r_example_block    := text.re_compile("^\\[example\\][ \\t]*$")
+  r_example_delim    := text.re_compile("^={4,}[ \\t]*$")
+  r_list_continue    := text.re_compile("^\\+[ \\t]*$")
+
+  document           := text.split(text.trim_suffix(scope, "\n"), "\n")
+
+  expect_admonition  := false
+  expect_example     := false
+  in_comment_block   := false
+  in_code_block      := false
+  in_example_block   := false
+  is_procedure       := false
+  count              := 0
+  start              := 0
+  end                := 0
+
+  for line in document {
+    start += end
+    end    = len(line) + 1
+
+    if r_comment_block.match(line) {
+      delimiter := text.trim_space(line)
+      if ! in_comment_block {
+        in_comment_block = delimiter
+      } else if in_comment_block == delimiter {
+        in_comment_block = false
+      }
+      continue
+    }
+    if in_comment_block { continue }
+    if r_comment_line.match(line) { continue }
+
+    if r_code_block.match(line) {
+      delimiter := text.trim_space(line)
+      if ! in_code_block {
+        in_code_block = delimiter
+      } else if in_code_block == delimiter {
+        in_code_block = false
+      }
+      continue
+    }
+    if in_code_block { continue }
+
+    if r_conditional.match(line) { continue }
+    if r_empty_line.match(line) { continue }
+
+    if r_content_type.match(line) {
+      is_procedure = true
+      continue
+    }
+
+    if r_admonition_block.match(line) {
+      expect_admonition = true
+      continue
+    }
+
+    if expect_admonition || expect_example {
+      if r_block_title.match(line) || r_list_continue.match(line) {
+        continue
+      }
+    }
+
+    if r_example_delim.match(line) {
+      delimiter := text.trim_space(line)
+      if ! in_example_block {
+        in_example_block = delimiter
+
+        if expect_admonition {
+          expect_admonition = false
+          continue
+        }
+        if expect_example {
+          expect_example = false
+          continue
+        }
+
+        count++
+
+        if count > 1 {
+          matches = append(matches, {begin: start, end: start + end - 1})
+        }
+      } else if in_example_block == delimiter {
+        in_example_block = false
+      }
+      continue
+    }
+
+    if r_example_block.match(line) {
+      count++
+
+      if count > 1 {
+        matches = append(matches, {begin: start, end: start + end - 1})
+      }
+
+      expect_example = true
+      continue
+    }
+
+    expect_admonition = false
+    expect_example = false
+  }
+
+  if ! is_procedure {
+    matches = []
+  }

--- a/.vale/styles/AsciiDocDITA/TaskInclude.yml
+++ b/.vale/styles/AsciiDocDITA/TaskInclude.yml
@@ -1,0 +1,64 @@
+# Report include directives in procedure steps.
+---
+extends: script
+message: "The included file may introduce content that cannot be mapped to DITA steps."
+level: warning
+link: https://github.com/jhradilek/asciidoctor-dita-vale/blob/main/README.md#warnings
+scope: raw
+script: |
+  text              := import("text")
+  matches           := []
+
+  r_comment_block   := text.re_compile("^/{4,}\\s*$")
+  r_comment_line    := text.re_compile("^(//|//[^/].*)$")
+  r_content_type    := text.re_compile("^:_(?:mod-docs-content|content|module)-type:[ \\t]+(?i:procedure)")
+  r_include         := text.re_compile("^include::(?:[^ \\t\\[]|[^[]*[^ \\t\\[])\\[.*\\][ \\t]*$")
+  r_procedure       := text.re_compile("^(?:={2,}[ \\t]+|\\.{1,2})Procedure[ \\t]*$")
+  r_supported_title := text.re_compile("^\\.{1,2}(?:Prerequisites?|Procedure|Verification|Results?|Troubleshooting|Troubleshooting steps?|Next steps?|Additional resources)[ \\t]*$")
+
+  document          := text.split(text.trim_suffix(scope, "\n"), "\n")
+
+  is_procedure_mod  := false
+  in_comment_block  := false
+  in_procedure      := false
+
+  start             := 0
+  end               := 0
+
+  for line in document {
+    start += end
+    end    = len(line) + 1
+
+    if r_comment_block.match(line) {
+      delimiter := text.trim_space(line)
+      if ! in_comment_block {
+        in_comment_block = delimiter
+      } else if in_comment_block == delimiter {
+        in_comment_block = false
+      }
+      continue
+    }
+    if in_comment_block { continue }
+    if r_comment_line.match(line) { continue }
+
+    if r_content_type.match(line) {
+      is_procedure_mod = true
+      continue
+    }
+
+    if r_procedure.match(line) {
+      in_procedure = true
+      continue
+    }
+
+    if ! in_procedure { continue }
+    if r_supported_title.match(line) { break }
+
+    if r_include.match(line) {
+      matches = append(matches, {begin: start, end: start + end - 1})
+    }
+  }
+
+  if ! is_procedure_mod {
+    matches = []
+  }

--- a/.vale/styles/AsciiDocDITA/TaskSection.yml
+++ b/.vale/styles/AsciiDocDITA/TaskSection.yml
@@ -1,0 +1,62 @@
+# Report sections inside of procedure modules.
+---
+extends: script
+message: "Sections are not allowed in DITA tasks."
+level: error
+link: https://github.com/jhradilek/asciidoctor-dita-vale/blob/main/README.md#errors
+scope: raw
+script: |
+  text              := import("text")
+  matches           := []
+
+  r_code_block      := text.re_compile("^(?:\\.{4,}|-{4,})[ \\t]*$")
+  r_comment_block   := text.re_compile("^/{4,}\\s*$")
+  r_comment_line    := text.re_compile("^(//|//[^/].*)$")
+  r_content_type    := text.re_compile("^:_(?:mod-docs-content|content|module)-type:[ \\t]+(?i:procedure)")
+  r_section         := text.re_compile("^={2,}[ \\t]\\S.*$")
+
+  document          := text.split(text.trim_suffix(scope, "\n"), "\n")
+
+  in_code_block     := false
+  in_comment_block  := false
+  is_procedure      := false
+  start             := 0
+  end               := 0
+
+  for line in document {
+    start += end
+    end    = len(line) + 1
+
+    if r_comment_block.match(line) {
+      delimiter := text.trim_space(line)
+      if ! in_comment_block {
+        in_comment_block = delimiter
+      } else if in_comment_block == delimiter {
+        in_comment_block = false
+      }
+      continue
+    }
+    if in_comment_block { continue }
+    if r_comment_line.match(line) { continue }
+
+    if r_code_block.match(line) {
+      delimiter := text.trim_space(line)
+      if ! in_code_block {
+        in_code_block = delimiter
+      } else if in_code_block == delimiter {
+        in_code_block = false
+      }
+      continue
+    }
+    if in_code_block { continue }
+
+    if r_content_type.match(line) {
+      is_procedure = true
+    } else if r_section.match(line) {
+      matches = append(matches, {begin: start, end: start + end - 1})
+    }
+  }
+
+  if ! is_procedure {
+    matches = []
+  }

--- a/.vale/styles/AsciiDocDITA/TaskStep.yml
+++ b/.vale/styles/AsciiDocDITA/TaskStep.yml
@@ -1,0 +1,131 @@
+# Report content other than steps in procedures.
+---
+extends: script
+message: "Content other than a single list cannot be mapped to DITA steps."
+level: warning
+link: https://github.com/jhradilek/asciidoctor-dita-vale/blob/main/README.md#warnings
+scope: raw
+script: |
+  text              := import("text")
+  matches           := []
+
+  r_admonition      := text.re_compile("^\\[(?:NOTE|TIP|IMPORTANT|WARNING|CAUTION)\\][ \\t]*$")
+  r_any_title       := text.re_compile("^\\.{1,2}[^ \\t.].*$")
+  r_attribute_list  := text.re_compile("^\\[(?:|[\\w.#%{,\"'].*)\\][ \\t]*$")
+  r_attribute       := text.re_compile("^:!?\\S[^:]*:")
+  r_comment_block   := text.re_compile("^/{4,}\\s*$")
+  r_comment_line    := text.re_compile("^(//|//[^/].*)$")
+  r_conditional     := text.re_compile("^(?:ifn?def|ifeval|endif)::\\S*\\[.*\\][ \\t]*$")
+  r_content_type    := text.re_compile("^:_(?:mod-docs-content|content|module)-type:[ \\t]+(?i:procedure)")
+  r_dlist           := text.re_compile("^[ \\t]*\\S.*?(?::{2,4}|;;)(?:|[ \\t]+.*)$")
+  r_empty_line      := text.re_compile("^[ \\t]*$")
+  r_example_delim   := text.re_compile("^={4,}[ \\t]*$")
+  r_include         := text.re_compile("^include::(?:[^ \\t\\[]|[^[]*[^ \\t\\[])\\[.*\\][ \\t]*$")
+  r_list_continue   := text.re_compile("^\\+[ \\t]*$")
+  r_other_block     := text.re_compile("^(?:\\.{4,}|-{4,}|={4,}|-{2}|\\|={3,})[ \\t]*$")
+  r_procedure       := text.re_compile("^(?:={2,}[ \\t]+|\\.{1,2})Procedure[ \\t]*$")
+  r_step            := text.re_compile("^[ \\t]*[\\*-.]+[ \\t]+\\S.*$")
+  r_supported_title := text.re_compile("^\\.{1,2}(?:Prerequisites?|Procedure|Verification|Results?|Troubleshooting|Troubleshooting steps?|Next steps?|Additional resources)[ \\t]*$")
+
+  document          := text.split(text.trim_suffix(scope, "\n"), "\n")
+
+  is_procedure_mod  := false
+  in_comment_block  := false
+  in_continue       := false
+  in_list           := false
+  in_other_block    := false
+  in_procedure      := false
+  in_step           := false
+  start             := 0
+  end               := 0
+
+  for line in document {
+    start += end
+    end    = len(line) + 1
+
+    if r_comment_block.match(line) {
+      delimiter := text.trim_space(line)
+      if ! in_comment_block {
+        in_comment_block = delimiter
+      } else if in_comment_block == delimiter {
+        in_comment_block = false
+      }
+      continue
+    }
+    if in_comment_block { continue }
+    if r_comment_line.match(line) { continue }
+
+    if r_content_type.match(line) {
+      is_procedure_mod = true
+      continue
+    }
+
+    if r_conditional.match(line) { continue }
+    if r_include.match(line) { continue }
+    if r_attribute.match(line) { continue }
+    if r_attribute_list.match(line) && ! r_admonition.match(line) {
+      continue
+    }
+
+    if r_procedure.match(line) {
+      in_procedure = true
+      continue
+    }
+
+    if ! in_procedure { continue }
+
+    if r_supported_title.match(line) { break }
+    if r_any_title.match(line) { continue }
+
+    if in_step {
+      if r_other_block.match(line) {
+        delimiter := text.trim_space(line)
+        if ! in_other_block {
+          in_other_block = delimiter
+        } else if in_other_block == delimiter {
+          in_other_block = false
+          in_continue = false
+        }
+        continue
+      }
+      if in_other_block { continue }
+    }
+
+    if r_empty_line.match(line) {
+      if ! in_continue {
+        in_step = false
+      }
+      continue
+    }
+
+    if r_list_continue.match(line) {
+      in_continue = true
+      in_step = true
+      continue
+    } else {
+      in_continue = false
+    }
+
+    if r_step.match(line) {
+      in_list = true
+      in_step = true
+      continue
+    }
+
+    if in_list && r_dlist.match(line) {
+      in_step = true
+      continue
+    }
+
+    if in_step { continue }
+
+    if r_example_delim.match(line) { break }
+
+    matches = append(matches, {begin: start, end: start + end - 1})
+
+    if in_list { break }
+  }
+
+  if ! is_procedure_mod {
+    matches = []
+  }

--- a/.vale/styles/AsciiDocDITA/TaskTitle.yml
+++ b/.vale/styles/AsciiDocDITA/TaskTitle.yml
@@ -1,0 +1,102 @@
+# Report unsupported titles inside of procedure modules.
+---
+extends: script
+message: "Unsupported titles cannot be mapped to DITA tasks."
+level: warning
+link: https://github.com/jhradilek/asciidoctor-dita-vale/blob/main/README.md#warnings
+scope: raw
+script: |
+  text              := import("text")
+  matches           := []
+
+  r_attribute_list  := text.re_compile("^\\[(?:|[\\w.#%{,\"'].*)\\][ \\t]*$")
+  r_attribute       := text.re_compile("^:!?\\S[^:]*:")
+  r_block_title     := text.re_compile("^\\.{1,2}[^ \\t.].*$")
+  r_code_block      := text.re_compile("^(?:\\.{4,}|-{4,})[ \\t]*$")
+  r_comment_block   := text.re_compile("^/{4,}\\s*$")
+  r_comment_line    := text.re_compile("^(//|//[^/].*)$")
+  r_conditional     := text.re_compile("^(?:ifn?def|ifeval|endif)::\\S*\\[.*\\][ \\t]*$")
+  r_content_type    := text.re_compile("^:_(?:mod-docs-content|content|module)-type:[ \\t]+(?i:procedure)")
+  r_example_block   := text.re_compile("^\\[example\\][ \\t]*$")
+  r_example_delim   := text.re_compile("^={4,}[ \\t]*$")
+  r_image           := text.re_compile("^image::(?:\\S|\\S.*\\S)\\[.*\\][ \\t]*$")
+  r_list_continue   := text.re_compile("^\\+[ \\t]*$")
+  r_supported_title := text.re_compile("^\\.{1,2}(?:Prerequisites?|Procedure|Verification|Results?|Troubleshooting|Troubleshooting steps?|Next steps?|Additional resources)[ \\t]*$")
+  r_table_cell      := text.re_compile("^\\.[^ \\t|]+\\|")
+  r_table           := text.re_compile("^\\|={3,}[ \\t]*$")
+
+  document          := text.split(text.trim_suffix(scope, "\n"), "\n")
+
+  in_code_block     := false
+  in_comment_block  := false
+  is_procedure      := false
+  is_list_continue  := false
+  expect_block      := false
+  start             := 0
+  end               := 0
+
+  for line in document {
+    start += end
+    end    = len(line) + 1
+
+    if r_comment_block.match(line) {
+      delimiter := text.trim_space(line)
+      if ! in_comment_block {
+        in_comment_block = delimiter
+      } else if in_comment_block == delimiter {
+        in_comment_block = false
+      }
+      continue
+    }
+    if in_comment_block { continue }
+    if r_comment_line.match(line) { continue }
+
+    if r_code_block.match(line) {
+      delimiter := text.trim_space(line)
+      if ! in_code_block {
+        in_code_block = delimiter
+      } else if in_code_block == delimiter {
+        in_code_block = false
+      }
+      continue
+    }
+    if in_code_block { continue }
+
+    if r_content_type.match(line) {
+      is_procedure = true
+      continue
+    }
+
+    if r_attribute_list.match(line) && ! r_example_block.match(line) { continue }
+    if r_attribute.match(line) { continue }
+    if r_conditional.match(line) { continue }
+
+    if r_list_continue.match(line) {
+      is_list_continue = true
+      continue
+    }
+
+    if r_table.match(line) || r_image.match(line) ||
+       r_example_block.match(line) || r_example_delim.match(line) {
+      expect_block = false
+      is_list_continue = false
+      continue
+    }
+
+    if r_block_title.match(line) && ! r_supported_title.match(line) && ! r_table_cell.match(line) {
+      if ! is_list_continue {
+        expect_block = {begin: start, end: start + end - 1}
+      }
+    } else if expect_block {
+      matches = append(matches, expect_block)
+      expect_block = false
+    }
+
+    is_list_continue = false
+  }
+
+  if ! is_procedure {
+    matches = []
+  } else if expect_block {
+    matches = append(matches, expect_block)
+  }

--- a/.vale/styles/AsciiDocDITA/ThematicBreak.yml
+++ b/.vale/styles/AsciiDocDITA/ThematicBreak.yml
@@ -1,0 +1,14 @@
+# Report that thematic breaks are not supported.
+---
+extends: existence
+message: "Thematic breaks are not supported in DITA."
+level: warning
+link: https://github.com/jhradilek/asciidoctor-dita-vale/blob/main/README.md#warnings
+scope: raw
+nonword: true
+tokens:
+  - "^'{3,}[ \\t]*$"
+  - '^[*_]{3}[ \t]*$'
+  - '^\* \* \*[ \t]*$'
+  - '^- - -[ \t]*$'
+  - '^_ _ _[ \t]*$'


### PR DESCRIPTION
Cherry-pick version: 

- 6.5 (latest) 
- 6.4

**Tracking JIRA:** https://redhat.atlassian.net/browse/OBSDOCS-3239

**Note for the merge reviewer:** 
I noticed an untracked _**.vale/styles/AsciiDocDITA/**_ directory in the **_standalone-logging-docs-main_** branch while running Vale. I verified that this directory already exists in the **_serverless-docs-main_** branch. 
After confirming with Ashwin that it’s safe and harmless to include, I created a local branch, added the directory, and raised a PR to keep Vale configuration consistent across branches.

No peer review is needed