### PR TITLE
[enterprise-4.15] OSDOCS#18710: Docs for KDO 5.0.4

### DIFF
--- a/modules/nodes-descheduler-rn-5.0.4.adoc
+++ b/modules/nodes-descheduler-rn-5.0.4.adoc
@@ -1,0 +1,23 @@
+// Module included in the following assemblies:
+//
+// * nodes/scheduling/descheduler/nodes-descheduler-release-notes.adoc
+
+// This release notes module is allowed to contain xrefs. It must only ever be included from one assembly.
+
+:_mod-docs-content-type: REFERENCE
+[id="descheduler-operator-release-notes-5.0.4_{context}"]
+= Release notes for {descheduler-operator} 5.0.4
+
+[role="_abstract"]
+Review the release notes for {descheduler-operator} 5.0.4 to learn what is new and updated with this release.
+
+Issued: 18 March 2026
+
+The following advisory is available for the {descheduler-operator} 5.0.4:
+
+* link:https://access.redhat.com/errata/RHBA-2026:4912[RHBA-2026:4912]
+
+[id="descheduler-operator-5.0.4-bug-fixes_{context}"]
+== Bug fixes
+
+* This release of the {descheduler-operator} addresses Common Vulnerabilities and Exposures (CVE).

--- a/nodes/scheduling/descheduler/nodes-descheduler-release-notes.adoc
+++ b/nodes/scheduling/descheduler/nodes-descheduler-release-notes.adoc
@@ -12,6 +12,9 @@ These release notes track the development of the {descheduler-operator}.
 
 For more information, see xref:../../../nodes/scheduling/descheduler/index.adoc#nodes-descheduler-about_nodes-descheduler-about[About the descheduler].
 
+// Release notes for Kube Descheduler Operator 5.0.4
+include::modules/nodes-descheduler-rn-5.0.4.adoc[leveloffset=+1]
+
 [id="descheduler-operator-release-notes-5.0.3"]
 == Release notes for {descheduler-operator} 5.0.3
 


### PR DESCRIPTION
Manual CP of #108187 to 4.15

The conflict is because we performed CQA work only back to 4.16. Need to make sure this adds seamlessly (mixing a module with the older versions contained directly in the assembly)