### PR TITLE
[enterprise-4.16] Updates ADV errors for MS

### DIFF
--- a/microshift_configuring/microshift-node-access-kubeconfig.adoc
+++ b/microshift_configuring/microshift-node-access-kubeconfig.adoc
@@ -6,7 +6,8 @@ include::_attributes/attributes-microshift.adoc[]
 
 toc::[]
 
-Learn about how `kubeconfig` files are used with {microshift-short} deployments. CLI tools use `kubeconfig` files to communicate with the API server of a node. These files provide node details, IP addresses, and other information needed for authentication.
+[role="_abstract"]
+`Kubeconfig` files supply the node details and authentication that CLI tools need to communicate with the API server in {product-title}. You can use them for local and remote node access and to generate additional configuration files.
 
 include::modules/microshift-kubeconfig-overview.adoc[leveloffset=+1]
 

--- a/modules/microshift-kubeconfig-generating-additional-files.adoc
+++ b/modules/microshift-kubeconfig-generating-additional-files.adoc
@@ -6,16 +6,12 @@
 [id="microshift-kubeconfig-generating-additional-files_{context}"]
 = Generating additional kubeconfig files for remote access
 
-You can generate additional `kubeconfig` files to use if you need more host names or IP addresses than the default remote access file provides.
-
-[IMPORTANT]
-====
-You must restart {microshift-short} for configuration changes to be implemented.
-====
+[role="_abstract"]
+To use more host names or IP addresses than the default remote access file provides in {microshift-short}, you can generate additional `kubeconfig` files. Add entries to `apiServer.subjectAltNames` in the `config.yaml` file and restart the service so that the `kubeconfig` files are generated.
 
 .Prerequisites
 
-* You have created a `config.yaml` for {microshift-short}.
+* You have created a `config.yaml` file for {microshift-short}.
 
 .Procedure
 
@@ -46,16 +42,20 @@ Additional remote access `kubeconfig` files must include one of the server names
 dns:
   baseDomain: example.com
 node:
-  hostnameOverride: "microshift-rhel9" <1>
+  hostnameOverride: "microshift-rhel9"
   nodeIP: 10.0.0.1
 apiServer:
   subjectAltNames:
-  - alt-name-1 <2>
-  - 1.2.3.4 <3>
+  - alt-name-1
+  - 1.2.3.4
 ----
-<1> Hostname
-<2> DNS name
-<3> IP address or range
++
+where:
++
+--
+`node.hostnameOverride`:: Specifies the hostname of the node.
+`apiServer.subjectAltNames`:: Specifies the additional DNS names or IP address ranges to be used for authentication.
+--
 
 . Restart {microshift-short} to apply configuration changes and auto-generate the `kubeconfig` files you need by running the following command:
 +
@@ -71,7 +71,7 @@ $ sudo systemctl restart microshift
 $ cat /var/lib/microshift/resources/kubeadmin/alt-name-1/kubeconfig
 ----
 
-. Choose the `kubeconfig` file to use that contains the SAN or IP address you want to use to connect your node. In this example, the `kubeconfig` containing`alt-name-1` in the `cluster.server` field is the correct file.
+. Choose the `kubeconfig` file to use that contains the SAN or IP address you want to use to connect your node. In this example, the `kubeconfig` containing `alt-name-1` in the `cluster.server` field is the correct file.
 +
 .Example contents of an additional `kubeconfig` file
 [source,yaml]
@@ -79,9 +79,10 @@ $ cat /var/lib/microshift/resources/kubeadmin/alt-name-1/kubeconfig
 clusters:
 - cluster:
     certificate-authority-data: <base64 CA>
-    server: https://alt-name-1:6443 <1>
+    server: https://alt-name-1:6443
 ----
-<1> The `/var/lib/microshift/resources/kubeadmin/alt-name-1/kubeconfig` file values are from the `apiServer.subjectAltNames` configuration values.
++
+** The `/var/lib/microshift/resources/kubeadmin/alt-name-1/kubeconfig` file values are from the `apiServer.subjectAltNames` configuration values.
 +
 [NOTE]
 ====

--- a/modules/microshift-kubeconfig-local-access.adoc
+++ b/modules/microshift-kubeconfig-local-access.adoc
@@ -6,7 +6,8 @@
 [id="microshift-kubeconfig-local-access_{context}"]
 = Local access kubeconfig file
 
-The local access `kubeconfig` file is written to `/var/lib/microshift/resources/kubeadmin/kubeconfig`. This `kubeconfig` file provides access to the API server by using `localhost`. Choose this file when you are connecting the node locally.
+[role="_abstract"]
+The local access `kubeconfig` file in {product-title} is written to `/var/lib/microshift/resources/kubeadmin/kubeconfig`. This `kubeconfig` file provides access to the API server by using `localhost`. Choose this file when you are connecting the node locally.
 
 .Example contents of `kubeconfig` for local access
 [source,yaml]


### PR DESCRIPTION
Cherry picked from: 581575da0f0ff3db15ff5802d0d459a7d33801b9
xref: https://github.com/openshift/openshift-docs/pull/108208

Minor discrepancy in line count because THIS version already included the `+` on line 86 in modules/microshift-kubeconfig-generating-additional-files.adoc. In versions 4.17+ I had to add this line. 