### PR TITLE
ROX-33587: Add runtime enforcement information to docs

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -228,6 +228,8 @@ Topics:
     File: about-security-policies
   - Name: Using admission controller enforcement
     File: use-admission-controller-enforcement
+  - Name: Understanding and implementing runtime policy enforcement
+    File: runtime-policy-enforcement
   - Name: Creating and modifying security policies
     File: custom-security-policies
   - Name: Configuring file activity monitoring

--- a/modules/enabling-runtime-policy-enforcement.adoc
+++ b/modules/enabling-runtime-policy-enforcement.adoc
@@ -1,0 +1,65 @@
+// Module included in the following assemblies:
+//
+// * operating/manage_security_policies/runtime-policy-enforcement.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="enabling-runtime-policy-enforcement_{context}"]
+= Enabling runtime policy enforcement
+
+[role="_abstract"]
+Enable runtime policy enforcement to have {product-title-short} automatically respond to security violations in running workloads. Before enabling enforcement, test policies in Inform mode to understand their impact and ensure predictable enforcement behavior.
+
+.Procedure
+
+. In the {product-title-short} portal, navigate to *Platform Configuration* -> *Policy Management*.
+
+. Locate the runtime policy for which you want to enable enforcement. Verify that the policy is enabled, and if it is not, enable it.
++
+[TIP]
+====
+Use the filter options to display only runtime policies by selecting *Runtime* in the *Lifecycle stage* filter.
+====
+
+. Click the policy name and select *Edit policy* from the *Actions* menu.
+. In the *Policy Behavior* section, in the *Enforcement* section, select *Inform and enforce*.
+
+. In the *Configure enforcement behavior* section, enable *Runtime*.
++
+[WARNING]
+====
+Enabling runtime enforcement activates two enforcement mechanisms:
+
+* Hard enforcement through the admission controller blocks user-initiated container commands that violate the policy.
+* Pod termination by Sensor terminates pods that violate the policy during runtime monitoring.
+
+Ensure that your deployments can handle pod terminations and that you have reviewed the policy violations in inform mode before enabling enforcement.
+====
+
+. Save the policy.
+
+.Verification
+
+. Identify the enforcement path for the policy by reviewing its event source in the policy details.
+
+. Create a test scenario that intentionally violates the policy:
++
+* For Kubernetes API event-based policies (for example, exec-blocking policies), attempt the blocked operation using `kubectl`.
+* For process execution-based policies, deploy a test workload that executes the prohibited process.
+
+. Verify the expected enforcement behavior:
++
+* For Kubernetes API event-based policies: The operation should be blocked at the API server with an error message. The pod continues running.
+* For process execution-based policies: The pod should be terminated after the violation is detected. Kubernetes or {ocp} creates a replacement pod.
+* For audit log-based policies: A violation alert is generated with no enforcement action.
+
+. Check the violations list to confirm that a violation alert was generated with the correct enforcement action details.
+
+For policies that block Kubernetes API events (such as `kubectl exec`), verify that the admission controller is configured to listen on the appropriate resources:
+
+. In the {product-title-short} portal, navigate to *Platform Configuration* -> *Clusters*.
+. Select the target cluster.
+. In the *Dynamic configuration* section, verify that *Admission controller enforcement behavior* is set to *Enforce policies*.
+. Confirm that the admission controller webhook configuration includes the resources required by your policies. For example, to block `kubectl exec` operations, the webhook must be configured to listen on `pods/exec`.
+//claude code suggested this but not sure this last item is required
+
+If the admission controller is not configured to enable enforcement on the cluster, Kubernetes API event-based enforcement will not work, even if the policy is configured.

--- a/modules/policy-enforcement-runtime.adoc
+++ b/modules/policy-enforcement-runtime.adoc
@@ -4,19 +4,21 @@
 
 :_mod-docs-content-type: CONCEPT
 [id="policy-enforcement-runtime_{context}"]
-= Runtime enforcement 
+= Runtime enforcement
 
 [role="_abstract"]
-You can configure policies that are enforced during runtime to terminate a pod that violates the policy or, in the case of audit log inspection, notify you of events that violate the policy but have already occurred and have been logged.
+Runtime policies monitor running workloads and detect security violations during execution. When you enable enforcement for runtime policies, the enforcement behavior depends on the policy's event source. {product-title-short} uses three distinct enforcement paths for runtime policies.
 
-When enforced, a policy violation results in one or more of the following actions:
+When you enable enforcement for a runtime policy, the enforcement action depends on the policy's event source:
 
-* Shutting down an offending pod, which results in creation of another healthy pod in its place
-* {product-title-short} intercepting and preventing certain Kubernetes API calls 
+Kubernetes API event-based enforcement:: For policies that detect Kubernetes API events, for example, "Kubernetes action: Pod exec", the {product-title-short} admission controller blocks the API request before it executes. The pod continues running. For the admission controller to successfully intercept and block these specific actions, you must enable enforcement in the static configuration section for the cluster.
+
+Process execution-based enforcement:: For policies that detect process execution, network activity, or file system events (for example, "nmap Execution" or "Ubuntu Package Manager Execution"), {product-title-short} Sensor terminates the pod after detecting the violation. Kubernetes or {ocp} then creates a replacement pod.
+
+Audit log-based enforcement:: For policies that detect events from audit logs, {product-title-short} generates violation alerts but does not take automated enforcement actions.
 
 [IMPORTANT]
 ====
-When a violation is triggered by an image or workload rule, a violation alert is generated, but the pod is _not_ disrupted.
+The same *Inform and enforce* toggle results in different enforcement behaviors depending on the policy's event source. Review the policy details to understand which enforcement path applies before enabling enforcement.
 ====
-//is the above true? I thought the pod was terminated if enforcement is configured.
 

--- a/modules/runtime-policy-enforcement-behaviors-reference.adoc
+++ b/modules/runtime-policy-enforcement-behaviors-reference.adoc
@@ -1,0 +1,83 @@
+// Module included in the following assemblies:
+//
+// * operating/manage_security_policies/runtime-policy-enforcement.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="runtime-policy-enforcement-behaviors-reference_{context}"]
+= Runtime policy enforcement behavior reference
+
+[role="_abstract"]
+This reference provides detailed information about how specific runtime policies behave when enforcement is enabled. Use this information to understand the enforcement actions that {product-title-short} will take for each policy and to plan your enforcement strategy.
+
+The following table shows the enforcement path for common event sources:
+
+[cols="3,2,3",options="header"]
+|===
+|Event source
+|Enforcement path
+|Enforcement behavior
+
+|Kubernetes Event (Kubernetes actions: Exec, Port forward)
+|Kubernetes API event-based
+|Admission controller blocks the API request
+
+|Process Activity (Process name, command-line, UID)
+|Process execution-based
+|Sensor terminates the pod after detecting the process
+
+|Network Activity (Network flow, egress/ingress)
+|Process execution-based
+|Sensor terminates the pod after detecting the network activity
+
+|File Activity (File path, file type)
+|Process execution-based
+|Sensor terminates the pod after detecting the file modification
+
+|Audit Log Event
+|Audit log-based
+|Alert only, no enforcement action
+
+|Image and Deployment Configuration
+|Alert only
+|Alert only, enforcement occurs at build/deploy stages
+|===
+
+== Common runtime policies and their enforcement behavior
+
+The following table lists common default runtime policies and their behavior when enforcement is enabled:
+
+[cols="3,2,3",options="header"]
+|===
+|Policy name
+|Enforcement path
+|What happens when enforced
+
+|Kubernetes Actions: Exec into Pod
+|Kubernetes API event-based
+|`kubectl exec` commands are blocked by admission controller
+
+|nmap Execution
+|Process execution-based
+|Pod is terminated after `nmap` process is detected
+
+|Ubuntu Package Manager Execution
+|Process execution-based
+|Pod is terminated after package manager process is detected
+
+|Shell spawned by Java application
+|Process execution-based
+|Pod is terminated after shell process is detected
+
+|Unauthorized Network Flow
+|Process execution-based
+|Pod is terminated after unauthorized network connection is detected
+
+|Linux Group Add Execution
+|Process execution-based
+|Pod is terminated after group add process is detected
+|===
+
+[IMPORTANT]
+====
+The same *Inform and enforce* toggle in the policy configuration results in completely different enforcement behaviors depending on the policy's event source. Review the policy's event source to understand the expected enforcement behavior before enabling enforce mode.
+====

--- a/modules/troubleshooting-runtime-policy-enforcement.adoc
+++ b/modules/troubleshooting-runtime-policy-enforcement.adoc
@@ -1,0 +1,197 @@
+// Module included in the following assemblies:
+//
+// * operating/manage_security_policies/runtime-policy-enforcement.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="troubleshooting-runtime-policy-enforcement_{context}"]
+= Troubleshooting runtime policy enforcement
+
+[role="_abstract"]
+Consult the following troubleshooting guidance for common issues related to runtime policy enforcement in {product-title-short}.
+
+== Unpredictable or inconsistent enforcement behavior
+
+Symptom:: After enabling enforce mode for runtime policies, the enforcement behavior is inconsistent or unpredictable. Sometimes operations are blocked, sometimes pods are killed, and sometimes no enforcement occurs.
+
+Cause:: Runtime policies use different enforcement paths depending on their event source. The same *Inform and enforce* toggle results in different enforcement behaviors for different policy types:
+
+* Kubernetes API event-based policies block operations through the admission controller.
+* Process execution-based policies terminate pods after detecting violations.
+* Audit log-based policies generate alerts only.
+
+Without understanding the enforcement path that a policy uses, the enforcement behavior appears unpredictable.
+
+Solution::
+
+. Identify the enforcement path for each policy by reviewing its event source in the policy details. 
+. For Kubernetes API event-based policies, verify that "enforce policies" is configured for the admission controller enforcement behavior in the static configuration for the cluster.
+. For process execution-based policies, understand that the pod is terminated after the violation is detected, not before the process starts.
+. Test each policy individually in inform mode to understand its specific enforcement behavior before enabling enforce mode across multiple policies.
+
+== Enforcement not taking effect
+
+Symptom:: Runtime policy enforcement is enabled, but pods that violate the policy are not being terminated or user-initiated commands are not being blocked.
+
+Possible causes and solutions::
+
+* *Policy is disabled*
++
+Solution: Navigate to *Platform Configuration* -> *System Policies*, locate the policy, and verify that it is enabled. If the policy is disabled, edit the policy and enable it.
+
+* *Enforce mode is not enabled*
++
+Solution: Edit the policy and verify that *Response method* is set to *Inform and enforce* and that *Enforce on Runtime* is enabled.
+
+* *Policy scope does not include the target workloads*
++
+Solution: Review the policy scope configuration to ensure it includes the namespaces, clusters, or labels where the target workloads are running. Edit the policy scope if needed.
+
+* *Policy criteria do not match the violations*
++
+Solution: Review the policy criteria and compare them to the expected violations. Adjust the criteria to ensure they match the violations you want to detect.
+
+* *Admission controller is not enabled for Kubernetes API event-based enforcement*
++
+Solution: For Kubernetes API event-based enforcement, verify that the admission controller is enabled in the target cluster. In *Platform Configuration* -> *Clusters*, select the cluster, and check the *Admission controller enforcement behavior* setting.
+
+* *Sensor is not running for pod termination enforcement*
++
+Solution: For pod termination enforcement, verify that Sensor is running in the target cluster. Check the Sensor pod status in the namespace where {product-title-short} is installed.
+
+== Pods being repeatedly terminated
+
+Symptom:: {product-title-short} repeatedly terminates pods, creating an enforcement loop where new pods are terminated as soon as they start.
+
+Temporary workaround:: Set the policy to *Inform* mode while investigating and resolving the underlying issue. This stops the enforcement loop so that you can continue monitoring violations.
+
+Possible causes and solutions::
+
+* *Violation is caused by container image*
++
+Solution: The violation is likely caused by processes, files, or configurations in the container image. Update the container image to remove the source of the violation, or adjust the policy criteria to exclude expected behavior.
+
+* *Violation is caused by deployment configuration*
++
+Solution: Review the deployment configuration, including the pod spec, security context, and environment variables, to identify the source of the violation. Update the deployment configuration to comply with the policy.
+
+* *Process baseline is incomplete*
++
+Solution: If the policy uses a process baseline, ensure that the baseline includes all expected processes. Update the baseline to include authorized processes that are being flagged as violations.
+
+* *Policy criteria are too strict*
++
+Solution: Review the policy criteria to determine if they are overly restrictive. Consider relaxing the criteria or using exclusions for specific workloads.
+
+== Unexpected pod terminations
+
+Symptom:: Pods are being terminated unexpectedly, causing service disruptions or availability issues.
+
+Possible causes and solutions::
+
+* *Policy was enabled without testing*
++
+Solution: Before enabling enforcement for any runtime policy, test it in inform mode to understand the violations that will occur. Review the violations and assess the impact of enforcement before enabling it.
+
+* *Policy scope is broader than intended*
++
+Solution: Review the policy scope configuration to ensure it only includes the intended workloads. Use namespace, cluster, or label selectors to narrow the scope.
+
+* *False positives in policy criteria*
++
+Solution: Review recent violations in the violations list to identify false positives. Adjust the policy criteria to reduce false positives, or add exclusions for specific workloads.
+
+* *Shared workloads affected*
++
+Solution: If enforcement is affecting shared services or critical workloads, consider excluding them from enforcement using policy scope or namespace exclusions. Document the rationale for exclusions.
+
+== No alerts being generated
+
+Symptom:: Runtime policy violations are occurring, but alerts are not being generated or delivered.
+
+Possible causes and solutions::
+
+* *Notification integrations not configured*
++
+Solution: Configure notification integrations to receive alerts for policy violations. In *Platform Configuration* -> *Integrations*, add the appropriate notification methods, for example, email, Slack, or PagerDuty.
+
+* *Policy does not have notifiers assigned*
++
+Solution: Edit the policy and verify that notifiers are configured in the *Policy Notifiers* section. Assign the appropriate notifiers to the policy.
+
+* *Notifier configuration is incorrect*
++
+Solution: Test the notifier configuration to verify that it is working correctly. Check the integration settings and credentials.
+
+* *Violations are not being generated*
++
+Solution: Verify that the policy criteria are correctly configured and that the target workloads are included in the policy scope. Review the violations list in the {product-title-short} portal to confirm that violations are being detected.
+
+== Enforcement action details not clear
+
+Symptom:: Violation alerts are generated, but the enforcement action details are unclear or missing.
+
+Possible causes and solutions::
+
+* *Review violation details*
++
+Solution: In the violations list, click a violation to view detailed information about the enforcement action, including the specific criteria that triggered the violation and the action that was taken.
+
+* *Check policy configuration*
++
+Solution: Review the policy configuration to understand the expected enforcement action for the policy type. Compare the expected action to the actual action recorded in the violation details.
+
+* *Review logs*
++
+Solution: For detailed troubleshooting, review the Sensor and Collector logs in the target cluster. The logs provide additional context about enforcement actions and any errors that occurred.
+
+//These seem like they might be too much/unrelated for this section, should I leave in?
+== Performance impact from enforcement
+
+Symptom:: Enabling runtime enforcement causes performance degradation in the cluster or {product-title-short} components.
+
+Possible causes and solutions::
+
+* *High volume of violations*
++
+Solution: If a policy is generating a large number of violations, it can impact performance. Review the policy criteria to reduce false positives, or adjust the policy scope to limit the number of workloads being monitored.
+
+* *Resource constraints on Sensor or Collector*
++
+Solution: Verify that the Sensor and Collector pods have sufficient CPU and memory resources. If needed, adjust resource requests and limits in the deployment configuration.
+
+* *Too many policies enabled*
++
+Solution: Review the enabled policies and disable any that are not providing value. Focus on enforcing policies that address the most significant security risks.
+
+== Violation data not showing in portal
+
+Symptom:: Runtime violations are occurring, but violation data is not appearing in the {product-title-short} portal.
+
+Possible causes and solutions::
+
+//This seems incorrect because would violations even be occurring if there wasn't a connection between sensor and central?
+* *Connectivity issues between Sensor and Central*
++
+Solution: Verify that the Sensor can communicate with Central. Check network connectivity, firewall rules, and proxy settings.
+
+* *Central database issues*
++
+Solution: Verify that the Central database is running and accessible. Check the Central pod logs for database connection errors.
+
+//I have no idea where this came from but is this a common issue?!
+* *Time synchronization issues*
++
+Solution: Ensure that the system clocks on the Central and Sensor nodes are synchronized. Time differences can cause violations to be displayed incorrectly or not at all.
+
+//Really??
+* *Browser cache issues*
++
+Solution: Clear your browser cache and refresh the {product-title-short} portal. Try accessing the portal from a different browser or incognito window.
+
+== Getting additional help
+
+If you continue to experience issues with runtime policy enforcement after trying the troubleshooting steps in this section:
+
+* Review the {product-title-short} logs for error messages and additional context.
+* Check the Red Hat Customer Portal for known issues and workarounds.
+* Contact Red Hat Support for assistance. Provide detailed information about the issue, including policy configuration, violation details, and relevant log entries.

--- a/modules/understanding-runtime-enforcement-behavior.adoc
+++ b/modules/understanding-runtime-enforcement-behavior.adoc
@@ -1,0 +1,116 @@
+// Module included in the following assemblies:
+//
+// * operating/manage_security_policies/runtime-policy-enforcement.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="understanding-runtime-enforcement-behavior_{context}"]
+= Understanding runtime enforcement behavior
+
+[role="_abstract"]
+Runtime policies in {product-title} ({product-title-short}) detect and respond to security violations in running workloads. When you enable enforce mode for a runtime policy, {product-title-short} takes automated actions to respond to violations, ensuring that your cluster remains secure and compliant with your security standards.
+
+Runtime policies monitor your running workloads and detect violations based on the criteria you define. Unlike build-time or deploy-time policies that prevent noncompliant workloads from entering your environment, runtime policies focus on detecting and responding to violations that occur during the execution of workloads. Runtime policies detect violations in all running pods, including pods that were deployed before the policy was created. 
+
+Runtime policies can detect various security concerns, including the following actions:
+
+* Unauthorized processes running in containers
+* Suspicious network activity
+* Privilege escalations
+* File system modifications
+* Port exposure violations
+* Resource access violations
+
+When you configure a runtime policy, you can choose between two enforcement modes:
+
+Inform mode:: {product-title-short} generates violation alerts when the policy criteria are met but does not take any automated enforcement action. This mode is useful for monitoring and understanding policy violations without impacting running workloads.
+
+Inform and enforce mode:: {product-title-short} generates violation alerts and takes automated enforcement actions when the policy criteria are met. The specific enforcement action depends on the policy type and configuration.
+
+Runtime policy enforcement uses three distinct enforcement paths depending on the policy event source and type. Understanding which enforcement path a policy uses is critical for predicting the enforcement behavior when you enable enforce mode.
+
+Kubernetes API event-based enforcement::
+
+Policies that detect Kubernetes API events use the admission controller to block API requests before they reach the pod. This enforcement path applies to policies with event sources such as:
+
+* Kubernetes actions (for example, `kubectl exec`, `kubectl port-forward`)
+* Kubernetes API server events
+
+When enforce mode is enabled for these policies:
+
+. The {product-title-short} admission controller intercepts the Kubernetes API request.
+. The request is blocked at the API server level.
+. The pod continues running without disruption.
+. The user receives an error message indicating the operation was blocked by a security policy.
+
+[IMPORTANT]
+====
+For Kubernetes API event-based enforcement to work, the admission controller must be configured to listen on the appropriate resources. For example, to block `kubectl exec` operations, the admission controller must be configured to listen on `pods/exec`.
+====
+
+Process execution-based enforcement::
+
+Policies that detect process execution events use Sensor to monitor running containers and terminate pods when violations are detected. This enforcement path applies to policies with event sources such as the following:
+
+* Process execution (for example, detecting execution of `nmap`, package managers, shells)
+* Process activity monitoring
+
+When enforce mode is enabled for these policies:
+
+. Sensor monitors process execution in running containers.
+. When a violation is detected, Sensor terminates the pod.
+. Kubernetes or {ocp} creates a replacement pod.
+. The violation is detected after the process has started.
+
+[NOTE]
+====
+With process execution-based enforcement, the violating process starts before the pod is terminated. For very fast processes, the process might complete before enforcement occurs.
+====
+
+Audit log-based enforcement::
+
+Policies that detect events from audit logs generate alerts but do not take automated enforcement actions. This enforcement path applies to policies with event sources such as the following:
+
+* Audit log events
+* Historical activity detection
+
+[IMPORTANT]
+====
+When a violation is triggered by an image or deployment configuration rule during runtime detection, {product-title-short} generates a violation alert but does not disrupt the running pod. Enforcement for image and deployment configuration violations occurs during the build or deploy lifecycle stages.
+====
+
+== Relationship to hard and soft enforcement
+
+Runtime enforcement relates to the hard and soft enforcement mechanisms used in {product-title-short}:
+
+Hard enforcement:: The {product-title-short} admission controller provides hard enforcement for runtime policies by blocking user-initiated container commands. This is the same hard enforcement mechanism used for deploy-time policies, where the Kubernetes or {ocp} API server blocks noncompliant operations.
+
+Soft enforcement:: Soft enforcement by Sensor applies only to deploy-time policies, not runtime policies. Sensor uses soft enforcement to scale down deployments to 0 replicas when the admission controller is unavailable. Runtime enforcement does not use soft enforcement.
+
+Pod termination:: Pod termination by Sensor for runtime violations is distinct from both hard and soft enforcement. This mechanism actively terminates running pods that violate runtime policies during execution.
+
+If Sensor is down, pod termination enforcement cannot occur because Sensor performs the monitoring and termination actions. However, hard enforcement through the admission controller continues to work independently, blocking user-initiated container commands that violate runtime policies.
+
+Ensure that Sensor is running and healthy in all clusters where you need runtime violation detection and pod termination enforcement.
+
+== Critical and high severity runtime policies
+
+Runtime policies with critical or high severity typically address significant security risks. When you enable enforce mode for these policies, carefully consider the following:
+
+* **Impact on availability**: Pod termination can affect workload availability if the terminated pod is part of a critical service. Ensure that your deployments have sufficient replicas and health checks to handle pod terminations.
+
+* **Replacement pod behavior**: When {product-title-short} terminates a noncompliant pod, Kubernetes or {ocp} creates a replacement pod. If the replacement pod exhibits the same violation behavior, {product-title-short} terminates it again. This cycle continues until the underlying issue is resolved.
+
+* **Alert volume**: High-severity violations can generate a large number of alerts if the underlying issue is widespread. Configure notification integrations to manage alert volume effectively.
+
+== Enforcement behavior predictability
+
+To ensure predictable enforcement behavior:
+
+* **Test in Inform mode first**: Before enabling Enforce mode, run the policy in Inform mode to understand the violations that would occur. Review the violations in the {product-title-short} portal to assess the impact of enforcement.
+
+* **Use policy scope**: Configure policy scope to limit enforcement to specific namespaces, clusters, or labels. You can gradually roll out enforcement across your environment.
+
+* **Monitor enforcement actions**: Review the violations list regularly to understand the enforcement actions that {product-title-short} is taking. Investigate unexpected violations and adjust policy criteria as needed.
+
+* **Document enforcement expectations**: Communicate enforcement behavior to development teams and stakeholders to ensure they understand the automated actions that {product-title-short} will take when violations occur.
+

--- a/operating/manage_security_policies/about-security-policies.adoc
+++ b/operating/manage_security_policies/about-security-policies.adoc
@@ -39,6 +39,11 @@ include::modules/policy-enforcement-soft.adoc[leveloffset=+3]
 
 include::modules/policy-enforcement-runtime.adoc[leveloffset=+2]
 
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../operating/manage_security_policies/runtime-policy-enforcement.adoc#runtime-policy-enforcement[Understanding and implementing runtime policy enforcement]
+
 //RHACS Policy Structure
 
 include::modules/policy-structure.adoc[leveloffset=+1]

--- a/operating/manage_security_policies/runtime-policy-enforcement.adoc
+++ b/operating/manage_security_policies/runtime-policy-enforcement.adoc
@@ -1,0 +1,26 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="runtime-policy-enforcement"]
+= Understanding and implementing runtime policy enforcement
+include::modules/common-attributes.adoc[]
+:context: runtime-policy-enforcement
+
+toc::[]
+
+[role="_abstract"]
+{product-title} ({product-title-short}) runtime policies help you secure running workloads by detecting and enforcing security violations during the runtime phase. When you enable enforce mode for runtime policies, the enforcement behavior depends on the policy's event source. {product-title-short} uses three distinct enforcement paths: Kubernetes API event-based enforcement that blocks operations through the admission controller, process execution-based enforcement that terminates pods after detecting violations, and audit log-based enforcement that generates alerts only. Understanding which enforcement path a policy uses is critical for predicting the enforcement behavior and avoiding unexpected outcomes. 
+
+include::modules/understanding-runtime-enforcement-behavior.adoc[leveloffset=+1]
+
+include::modules/enabling-runtime-policy-enforcement.adoc[leveloffset=+1]
+
+include::modules/troubleshooting-runtime-policy-enforcement.adoc[leveloffset=+1]
+
+include::modules/runtime-policy-enforcement-behaviors-reference.adoc[leveloffset=+1]
+
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../operating/manage_security_policies/about-security-policies.adoc#about-security-policies[About policies in {product-title-short}]
+* xref:../../operating/manage_security_policies/custom-security-policies.adoc#custom-security-policies[Creating and modifying security policies]
+* xref:../../operating/manage_security_policies/security-policy-reference.adoc#security-policy-reference[Security policy reference]


### PR DESCRIPTION
Version(s): 4.8+

[Issue](https://redhat.atlassian.net/issues?filter=-1&selectedIssue=[ROX-33587](https://redhat.atlassian.net/browse/ROX-33587))

Links to docs previews:

https://108629--ocpdocs-pr.netlify.app/openshift-acs/latest/operating/manage_security_policies/about-security-policies.html
https://108629--ocpdocs-pr.netlify.app/openshift-acs/latest/operating/manage_security_policies/runtime-policy-enforcement.html

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Authored with help from claude code

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
