### PR TITLE
OSDOCS#18765: Update the z-stream release notes for 4.15.62

### DIFF
--- a/modules/zstream-4-15-62-about.adoc
+++ b/modules/zstream-4-15-62-about.adoc
@@ -1,0 +1,22 @@
+
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-15-release-notes.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="zstream-4-15-62-about_{context}"]
+= RHSA-2026:1549 - {product-title} {product-version}.62 bug fix advisory
+
+[role="_abstract"]
+Issued: 19 March 2026
+
+{product-title} release {product-version}.62 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2026:4423[RHSA-2026:4423] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2026:4418[RHSA-2026:4418] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.15.62--pullspecs
+----

--- a/modules/zstream-4-15-62-bug-fixes.adoc
+++ b/modules/zstream-4-15-62-bug-fixes.adoc
@@ -1,0 +1,18 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-15-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-15-62-bug-fixes_{context}"]
+= Fixed issues
+
+[role="_abstract"]
+* Before this update, when using the `SiteConfig` custom resources (CR) to delete a cluster or a node, the `BareMetalHost` CR was stuck in the `Deprovisioning` state. With this release, the bug is fixed to ensure that the order deletion is correct. The fix requires {gitops-title} 1.13 or later version. (link:https://redhat.atlassian.net/browse/OCPBUGS-47798[OCPBUGS-47798])
+
+* Before this update, the `Bad Gateway` error occurred when importing an image from Quay.io. As a consequence, end users encountered failed image imports with this error. With this release, the {quay} API request issue for image import is fixed, resolving the `Bad Gateway` error. As a result, successful image imports are possible for users. (link:https://redhat.atlassian.net/browse/OCPBUGS-74670[OCPBUGS-74670])
+
+* Before this update, an {azure-first} OAuth issue occurred during the upgrade from {product-title} 4.18.14 to {product-title} 4.18.22 in {hcp} clusters. As a consequence, {azure-short} OAuth authentication failed, causing user authentication issues. With this release ({product-title} 4.15.0-0.nightly-2026-02-24-133955), the {azure-short} OAuth authentication issue is fixed. As a result, {azure-short} OAuth authentication issues are resolved, enabling successful login for hosted clusters. (link:https://issues.redhat.com/browse/OCPBUGS-74671[OCPBUGS-74671])
+
+* Before this update, aggregated API servers on {product-title} used in-memory loopback certificates that were valid for one year. With this release, these servers use in-memory loopback certificates that are valid for three years. (link:https://redhat.atlassian.net/browse/OCPBUGS-74921[OCPBUGS-74921])
+
+* Before this update, service account creation with the `openshift/local/google` provider in earlier {product-title} versions resulted in inconsistent results during service account creation. As a consequence, this issue caused errors during the apply process, impacting cluster provisioning in {gcp-first}. With this release, the issue is resolved by upgrading Terraform and the provider that are included in {product-title} 4.15.0-0.nightly-2026-03-07-214126. As a result, service account creation issues are resolved, reducing inconsistencies during cluster installation in {gcp-first}. (link:https://issues.redhat.com/browse/OCPBUGS-76929[OCPBUGS-76929])

--- a/modules/zstream-4-15-62-updating.adoc
+++ b/modules/zstream-4-15-62-updating.adoc
@@ -1,0 +1,10 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-15-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-15-62-updating_{context}"]
+= Updating
+
+[role="_abstract"]
+To update an {product-title} 4.15 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].

--- a/release_notes/ocp-4-15-release-notes.adoc
+++ b/release_notes/ocp-4-15-release-notes.adoc
@@ -2812,13 +2812,22 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+//  4.15.62 about
+include::modules/zstream-4-15-62-about.adoc[leveloffset=+2]
+
+//4.15.62 bug fixes
+include::modules/zstream-4-15-62-bug-fixes.adoc[leveloffset=+3]
+
+//4.15.62 updating
+include::modules/zstream-4-15-62-updating.adoc[leveloffset=+3]
+
 //  4.15.61 about
 include::modules/zstream-4-15-61-about.adoc[leveloffset=+2]
 
 //4.15.61 bug fixes
 include::modules/zstream-4-15-61-bug-fixes.adoc[leveloffset=+3]
 
-//4.15.61 bug fixes
+//4.15.61 updating
 include::modules/zstream-4-15-61-updating.adoc[leveloffset=+3]
 
 //  4.15.60 about


### PR DESCRIPTION
Version(s):
4.15

Issue:
https://redhat.atlassian.net/browse/OSDOCS-18765

Link to docs preview:
[4.15.62](https://108635--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-15-release-notes.html#zstream-4-15-62-about_release-notes)

QE review:
- [ ] QE has approved this change.
N/A

Additional information:
Shipment [MR](https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/405/diffs#32f8e2910bb341fee3950bb56047d49952300c33)

ART [Dashboard](https://art-dash.engineering.redhat.com/dashboard/release/openshift-4.15)
