### PR TITLE
TELCODOCS-2816: Fix AsciiDocDITA rule violations in optimizing-storage assembly

### DIFF
--- a/modules/available-persistent-storage-options.adoc
+++ b/modules/available-persistent-storage-options.adoc
@@ -15,7 +15,7 @@ To optimize your {product-title} environment, review the available persistent st
 | Storage type | Description | Examples
 
 |Block
-a|* Presented to the operating system (OS) as a block device
+a|* Presented to the operating system as a block device
 * Suitable for applications that need full control of storage and operate at a low level on files bypassing the file system.
 * Also referred to as a Storage Area Network (SAN).
 * Non-shareable, which means that only one client at a time can mount an endpoint of this type.
@@ -23,7 +23,7 @@ a|* Presented to the operating system (OS) as a block device
 // Ceph RBD, OpenStack Cinder, Azure Disk, GCE persistent disk
 
 |File
-a| * Presented to the OS as a file system export to be mounted
+a| * Presented to the operating system as a file system export to be mounted
 * Also referred to as Network Attached Storage (NAS).
 * Concurrency, latency, file locking mechanisms, and other capabilities vary widely between protocols, implementations, vendors, and scales.
 |RHEL NFS, NetApp NFS, and Vendor NFS.
@@ -32,7 +32,7 @@ a| * Presented to the OS as a file system export to be mounted
 | Object
 a| * Accessible through a REST API endpoint.
 * Configurable for use in the {product-registry}
-* Applications must build their drivers into the application and/or container.
+* Applications must build their drivers into the application, the container, or both.
 | AWS S3.
 // Aliyun OSS, Ceph Object Storage (RADOS Gateway)
 // Google Cloud Storage, Azure Blob Storage, OpenStack Swift

--- a/modules/data-storage-management.adoc
+++ b/modules/data-storage-management.adoc
@@ -33,7 +33,7 @@ Additional 20-25 GB for every additional 8 GB of memory.
 |Growth is limited by capacity for running containers.
 
 |*_/var/lib/kubelet_*
-|Ephemeral volume storage for pods. This includes anything external that is mounted into a container at runtime. Includes environment variables, kube secrets, and data volumes not backed by persistent volumes.
+|Ephemeral volume storage for pods. This includes anything external that is mounted into a container at runtime. Includes environment variables, Kubernetes secrets, and data volumes not backed by persistent volumes.
 |Varies
 |Minimal if pods requiring storage are using persistent volumes. If using ephemeral storage, this can grow quickly.
 

--- a/modules/recommended-configurable-storage-technology.adoc
+++ b/modules/recommended-configurable-storage-technology.adoc
@@ -71,7 +71,7 @@ where:
 
 `Elasticsearch Logging.Configurable`:: For logging, review the recommended storage solution in Configuring persistent storage for the log store section. Using NFS storage as a persistent volume or through NAS, such as Gluster, can corrupt the data. Therefore, NFS is not supported for Elasticsearch storage and LokiStack log store in {product-title} Logging. You must use one persistent volume type per log store.
 
-`Apps.Not configurable`:: Specifies that object storage is not consumed through PVs or PVCs of {product-title}. Apps must integrate with the object storage REST API.
+`Apps.Not configurable`:: Specifies that object storage is not consumed through persistent volumes (PVs) or persistent volume claims (PVCs) of {product-title}. Apps must integrate with the object storage REST API.
 
 [NOTE]
 ====

--- a/modules/specific-application-storage-recommendations.adoc
+++ b/modules/specific-application-storage-recommendations.adoc
@@ -12,14 +12,14 @@ To select the optimal storage solution for your {product-title} cluster applicat
 
 [IMPORTANT]
 ====
-Testing shows issues with using the NFS server on {op-system-base-full} as a storage backend for core services. This includes the OpenShift Container Registry and Quay, Prometheus for monitoring storage, and Elasticsearch for logging storage. Therefore, using {op-system-base} NFS to back PVs used by core services is not recommended.
+Testing shows issues with using the NFS server on {op-system-base-full} as a storage backend for core services. This includes the OpenShift Container Registry and Quay, Prometheus for monitoring storage, and Elasticsearch for logging storage. Therefore, using {op-system-base} NFS to back persistent volumes (PVs) used by core services is not recommended.
 
 Other NFS implementations in the marketplace might not have these issues. Contact the individual NFS implementation vendor for more information on any testing that was possibly completed against these {product-title} core components.
 ====
 
 Registry::
 
-In a non-scaled/high-availability (HA) {product-registry} cluster deployment:
+In a non-scaled, non-high-availability (HA) {product-registry} cluster deployment:
 
 * The storage technology does not have to support RWX access mode.
 * The storage technology must ensure read-after-write consistency.
@@ -28,7 +28,7 @@ In a non-scaled/high-availability (HA) {product-registry} cluster deployment:
 
 Scaled registry::
 
-In a scaled/HA {product-registry} cluster deployment:
+In a scaled or HA {product-registry} cluster deployment:
 
 * The storage technology must support RWX access mode.
 * The storage technology must ensure read-after-write consistency.
@@ -83,5 +83,5 @@ Red{nbsp}Hat does not recommend using RAID configurations on `Write` intensive w
 ====
 
 * {rh-openstack-first} Cinder: {rh-openstack} Cinder tends to be adept at ROX access mode use cases.
-* Databases: Databases (RDBMSs, NoSQL DBs, etc.) tend to perform best with dedicated block storage.
+* Databases: Databases, such as relational database management systems (RDBMS) and NoSQL databases, tend to perform best with dedicated block storage.
 * The etcd database must have enough storage and adequate performance capacity to enable a large cluster. Information about monitoring and benchmarking tools to establish ample storage and a high-performance environment is described in _Recommended etcd practices_.

--- a/scalability_and_performance/optimization/optimizing-storage.adoc
+++ b/scalability_and_performance/optimization/optimizing-storage.adoc
@@ -2,6 +2,7 @@
 [id="optimizing-storage"]
 = Optimizing storage
 include::_attributes/common-attributes.adoc[]
+
 :gluster: GlusterFS
 :gluster-native: Containerized GlusterFS
 :gluster-external: External GlusterFS
@@ -21,9 +22,7 @@ endif::[]
 toc::[]
 
 [role="_abstract"]
-Optimizing storage helps to minimize storage use across all resources. By
-optimizing storage, administrators help ensure that existing storage resources
-are working in an efficient manner.
+Optimizing storage helps to minimize storage use across all resources. By optimizing storage, administrators help ensure that existing storage resources are working in an efficient manner.
 
 include::modules/available-persistent-storage-options.adoc[leveloffset=+1]
 


### PR DESCRIPTION
[TELCODOCS-2816]: Fix AsciiDocDITA rule violations in optimizing-storage assembly

Version(s): 4.20+

Issue: https://issues.redhat.com/browse/TELCODOCS-2816

Link to docs preview: https://108645--ocpdocs-pr.netlify.app/openshift-enterprise/latest/scalability_and_performance/optimization/optimizing-storage.html

QE review:
- [ ] QE has approved this change.

Additional information: Resolve all AsciiDocDITA errors across 5 files in the optimizing-storage assembly to prepare for DITA conversion.

Note: These are editorial/DITA-prep changes only - no technical content changes.