### PR TITLE
[enterprise-4.19] Manual CP of 37f84d830e68a10aa7f265bf31cb20cf7200e885

### DIFF
--- a/microshift_configuring/microshift-disable-lvms-csi-provider-csi-snapshot.adoc
+++ b/microshift_configuring/microshift-disable-lvms-csi-provider-csi-snapshot.adoc
@@ -6,6 +6,7 @@ include::_attributes/attributes-microshift.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 You can configure {microshift-short} to disable the built-in logical volume manager storage (LVMS) Container Storage Interface (CSI) provider or the CSI snapshot capabilities to reduce the use of runtime resources such as RAM, CPU, and storage.
 
 include::modules/microshift-disabling-lvms-csi-snapshot.adoc[leveloffset=+1]


### PR DESCRIPTION
This is a manual cherry pick of 37f84d830e68a10aa7f265bf31cb20cf7200e885. Xref: https://github.com/openshift/openshift-docs/pull/107490

The original PR has 8 files changed and you'll notice that this one only has 1. This is because the original PR did CQAs for the Generic Device Plugin feature for MicroShift. The Generic Device Plugin feature was not introduced until version 4.20. The feature PR can be found here: https://github.com/openshift/openshift-docs/pull/97090 

This "cherry pick" only adds the [role="_abstract"] to 1 file (microshift_configuring/microshift-disable-lvms-csi-provider-csi-snapshot.adoc) which exists in MicroShift versions 4.17-4.19; it does not exist in MicroShift version 4.16. 

Just explaining the files changed discrepancy. 