### PR TITLE
[enterprise-4.17] DOCPLAN108_417CP

### DIFF
--- a/modules/virt-configuring-a-live-migration-policy.adoc
+++ b/modules/virt-configuring-a-live-migration-policy.adoc
@@ -65,15 +65,19 @@ metadata:
   name: <migration_policy>
 spec:
   selectors:
-    namespaceSelector: <1>
+    namespaceSelector:
       hpc-workloads: "True"
       xyz-workloads-type: ""
-    virtualMachineInstanceSelector: <2>
+    virtualMachineInstanceSelector:
       kubevirt.io/environment: "production"
 ----
-<1> Specify project labels.
-<2> Specify VM labels.
-
++
+where:
++
+`namespaceSelector`:: Specifies the project labels.
++
+`virtualMachineInstanceSelector`:: Specifies the VM labels.
++
 . Create the migration policy by running the following command:
 +
 [source,terminal]

--- a/modules/virt-configuring-live-migration-heavy.adoc
+++ b/modules/virt-configuring-live-migration-heavy.adoc
@@ -24,7 +24,7 @@ Configure live migration for heavy workloads by updating the `HyperConverged` cu
 $ oc edit hyperconverged kubevirt-hyperconverged -n {CNVNamespace}
 ----
 +
-.Example configuration file
+.Example
 [source,yaml,subs="attributes+"]
 ----
 apiVersion: hco.kubevirt.io/v1beta1
@@ -34,20 +34,28 @@ metadata:
   namespace: {CNVNamespace}
 spec:
   liveMigrationConfig:
-    bandwidthPerMigration: 0Mi <1>
-    completionTimeoutPerGiB: 150 <2>
-    parallelMigrationsPerCluster: 5 <3>
-    parallelOutboundMigrationsPerNode: 1 <4>
-    progressTimeout: 150 <5>
-    allowPostCopy: true <6>
+    bandwidthPerMigration: 0Mi
+    completionTimeoutPerGiB: 150
+    parallelMigrationsPerCluster: 5
+    parallelOutboundMigrationsPerNode: 1
+    progressTimeout: 150
+    allowPostCopy: true
 ----
-<1> Bandwidth limit of each migration, where the value is the quantity of bytes per second. The default is `0`, which is unlimited. 
-<2> The migration is canceled if it is not completed in this time, and triggers post copy mode, when post copy is enabled. This value is measured in seconds per GiB of memory. You can lower `completionTimeoutPerGiB` to trigger post copy mode earlier in the migration process, or raise the  `completionTimeoutPerGiB` to trigger post copy mode later in the migration process.
-<3> Number of migrations running in parallel in the cluster. The default is `5`. Keeping the `parallelMigrationsPerCluster` setting low is better when migrating heavy workloads.
-<4> Maximum number of outbound migrations per node. Configure a single VM per node for heavy workloads.
-<5> The migration is canceled if memory copy fails to make progress in this time. This value is measured in seconds. Increase this parameter for large memory sizes running heavy workloads.
-<6> Use post copy mode when memory dirty rates are high to ensure the migration converges. Set `allowPostCopy` to `true` to enable post copy mode.
-
++
+where:
++
+`bandwidthPerMigration`:: Specifies the bandwidth of each migration in bytes per second. The default is `0`, which is unlimited.
++
+`completionTimeoutPerGiB`:: Specifies the length of time, in seconds per GiB of memory, at which the migration is canceled if it has not completed and post copy mode is triggered, if enabled. You can lower `completionTimeoutPerGiB` to trigger post copy mode earlier in the migration process, or raise the  `completionTimeoutPerGiB` to trigger post copy mode later in the migration process.
++
+`parallelMigrationsPerCluster`:: Specifies the number of migrations running in parallel in the cluster. The default is `5`. Keeping the `parallelMigrationsPerCluster` setting low is better when migrating heavy workloads.
++
+`parallelOutboundMigrationsPerNode`:: Specifies the maximum number of outbound migrations per node. Configure a single VM per node for heavy workloads.
++
+`progressTimeout`:: Specifies the length of time, in seconds, at which the migration is canceled if memory copy fails to make progress. Increase this parameter for large memory sizes running heavy workloads.
++
+`allowPostCopy`:: Specifies whether the post copy mode is enabled. You can enable post copy mode to allow the migration of one node to another to converge, even if a VM is running a heavy workload and the memory dirty rate is too high. Set allowPostCopy to true to enable post copy mode.
++
 . Optional: If your main network is too busy for the migration, configure a secondary, dedicated migration network.
 
 [NOTE]

--- a/modules/virt-configuring-live-migration-limits.adoc
+++ b/modules/virt-configuring-live-migration-limits.adoc
@@ -7,8 +7,8 @@
 [id="virt-configuring-live-migration-limits_{context}"]
 = Configuring live migration limits and timeouts
 
-Configure live migration limits and timeouts for the cluster by updating the `HyperConverged` custom resource (CR), which is located in the
-`{CNVNamespace}` namespace.
+[role="_abstract"]
+Configure live migration limits and timeouts for the cluster by updating the `HyperConverged` custom resource (CR), which is located in the `{CNVNamespace}` namespace.
 
 .Procedure
 
@@ -19,7 +19,7 @@ Configure live migration limits and timeouts for the cluster by updating the `Hy
 $ oc edit hyperconverged kubevirt-hyperconverged -n {CNVNamespace}
 ----
 +
-.Example configuration file
+.Example
 [source,yaml,subs="attributes+"]
 ----
 apiVersion: hco.kubevirt.io/v1beta1
@@ -29,19 +29,28 @@ metadata:
   namespace: {CNVNamespace}
 spec:
   liveMigrationConfig:
-    bandwidthPerMigration: 64Mi <1>
-    completionTimeoutPerGiB: 800 <2>
-    parallelMigrationsPerCluster: 5 <3>
-    parallelOutboundMigrationsPerNode: 2 <4>
-    progressTimeout: 150 <5>
-    allowPostCopy: false <6>
+    bandwidthPerMigration: 64Mi
+    completionTimeoutPerGiB: 800
+    parallelMigrationsPerCluster: 5
+    parallelOutboundMigrationsPerNode: 2
+    progressTimeout: 150
+    allowPostCopy: false
 ----
-<1> Bandwidth limit of each migration, where the value is the quantity of bytes per second. For example, a value of `2048Mi` means 2048 MiB/s. Default: `0`, which is unlimited.
-<2> The migration is canceled if it has not completed in this time, in seconds per GiB of memory. For example, a VM with 6GiB memory times out if it has not completed migration in 4800 seconds. If the `Migration Method` is `BlockMigration`, the size of the migrating disks is included in the calculation.
-<3> Number of migrations running in parallel in the cluster. Default: `5`.
-<4> Maximum number of outbound migrations per node. Default: `2`.
-<5> The migration is canceled if memory copy fails to make progress in this time, in seconds. Default: `150`.
-<6> If a VM is running a heavy workload and the memory dirty rate is too high, this can prevent the migration from one node to another from converging. To prevent this, you can enable post copy mode. By default, `allowPostCopy` is set to `false`. 
++
+where:
++
+`bandwidthPerMigration`:: Specifies the bandwidth of each migration in bytes per second. For example, a value of 2048Mi means 2048 MiB/s. Default: 0, which is unlimited.
++
+`completionTimeoutPerGiB`:: Specifies the length of time, in seconds per GiB of memory, at which the migration is canceled if it has not completed. For example, a VM with 6GiB memory times out if it has not completed migration in 4800 seconds. If the `Migration Method` is `BlockMigration`, the size of the migrating disks is included in the calculation.
++
+`parallelMigrationsPerCluster`:: Specifies the number of migrations running in parallel in the cluster. Default: `5`.
++
+`parallelOutboundMigrationsPerNode`:: Specifies the maximum number of outbound migrations per node. Default: `2`.
++
+`progressTimeout`:: Specifies the length of time, in seconds, at which the migration is canceled if memory copy fails to make progress. Default: `150`.
++
+`allowPostCopy`:: Specifies whether the post copy mode is enabled. You can enable post copy mode to allow the migration of one node to another to converge, even if a VM is running a heavy workload and the memory dirty rate is too high. By default, `allowPostCopy` is set to `false`.
++
 
 [NOTE]
 ====

--- a/modules/virt-live-migration-policies.adoc
+++ b/modules/virt-live-migration-policies.adoc
@@ -1,0 +1,15 @@
+// Module included in the following assemblies:
+//
+// * virt/live_migration/virt-configuring-live-migration.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="virt-live-migration-policies_{context}"]
+= Live migration policies
+
+[role="_abstract"]
+You can create live migration policies to apply different migration configurations to groups of VMs that are defined by VM or project labels.
+
+[TIP]
+====
+You can create live migration policies by using the {product-title} web console.
+====

--- a/virt/live_migration/virt-configuring-live-migration.adoc
+++ b/virt/live_migration/virt-configuring-live-migration.adoc
@@ -14,24 +14,12 @@ include::modules/virt-configuring-live-migration-limits.adoc[leveloffset=+1]
 
 include::modules/virt-configuring-live-migration-heavy.adoc[leveloffset=+1]
 
+include::modules/virt-live-migration-policies.adoc[leveloffset=+1]
+
+include::modules/virt-configuring-a-live-migration-policy.adoc[leveloffset=+1]
+
 [role="_additional-resources"]
 [id="additional-resources_virt-configuring-live-migration-heavy"]
 == Additional resources
 * xref:../../virt/vm_networking/virt-dedicated-network-live-migration.adoc#virt-configuring-secondary-network-vm-live-migration_virt-dedicated-network-live-migration[Configuring a dedicated network for live migration]
 
-[id="live-migration-policies"]
-== Live migration policies
-
-You can create live migration policies to apply different migration configurations to groups of VMs that are defined by VM or project labels.
-
-[TIP]
-====
-You can create live migration policies by using the {product-title} web console.
-====
-
-include::modules/virt-configuring-a-live-migration-policy.adoc[leveloffset=+2]
-
-[role="_additional-resources"]
-[id="additional-resources_virt-configuring-live-migration"]
-== Additional resources
-* xref:../../virt/vm_networking/virt-dedicated-network-live-migration.adoc#virt-dedicated-network-live-migration[Configuring a dedicated Multus network for live migration]


### PR DESCRIPTION
Cherry picked from 91797d569021359fb7e2e343510ef2217e1be743 for [PR](https://github.com/openshift/openshift-docs/pull/108213)

Version(s): 4.17

Issue: [DOCPLAN108](https://redhat.atlassian.net/browse/DOCPLAN-108)

Link to docs preview: https://108659--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/live_migration/virt-configuring-live-migration.html

QE review: N/A (for DITA compliance only)
