### PR TITLE
OSDOCS-16866:fixes mistake in callouts

### DIFF
--- a/modules/installation-registry-storage-block-recreate-rollout-bare-metal.adoc
+++ b/modules/installation-registry-storage-block-recreate-rollout-bare-metal.adoc
@@ -46,12 +46,15 @@ spec:
     requests:
       storage: 100Gi
 ----
++
 where:
-
-`name`:: Specifies a unique name that represents the `PersistentVolumeClaim` object.
-`namespace`:: Specifies the `namespace` for the `PersistentVolumeClaim` object, which is `openshift-image-registry`.
-`accessModes`:: Specifies the access mode of the persistent volume claim. With `ReadWriteOnce`, the volume can be mounted with read and write permissions by a single node.
-`storage`:: The size of the persistent volume claim.
++
+--
+`metadata.name`:: Specifies a unique name that represents the `PersistentVolumeClaim` object.
+`metadata.namespace`:: Specifies the `namespace` for the `PersistentVolumeClaim` object, which is `openshift-image-registry`.
+`spec.accessModes`:: Specifies the access mode of the persistent volume claim. With `ReadWriteOnce`, the volume can be mounted with read and write permissions by a single node.
+`spec.resources.requests.storage`:: The size of the persistent volume claim.
+--
 
 .. Enter the following command to create the `PersistentVolumeClaim` object from the file:
 +


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.16+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
https://redhat.atlassian.net/browse/OSDOCS-16866
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
https://108663--ocpdocs-pr.netlify.app/openshift-enterprise/latest/registry/configuring_registry_storage/configuring-registry-storage-baremetal.html#installation-registry-storage-block-recreate-rollout-bare-metal_configuring-registry-storage-baremetal:~:text=storage%3A%20100Gi-,where,-%3A
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
