### PR TITLE
[RHACS] [Docs] ROX-33642: Fix DITA vale error by editing .vale.ini file

### DIFF
--- a/.vale.ini
+++ b/.vale.ini
@@ -4,18 +4,12 @@ MinAlertLevel = suggestion
 
 Packages = RedHat, AsciiDoc, OpenShiftAsciiDoc, https://github.com/jhradilek/asciidoctor-dita-vale/releases/latest/download/AsciiDocDITA.zip
 
-Vocab = OpenShiftDocs
-
 # Ignore files in dirs starting with `.` to avoid raising errors for `.vale/fixtures/*/testinvalid.adoc` files
 [[!.]*.adoc]
 BasedOnStyles = RedHat, AsciiDoc, OpenShiftAsciiDoc
 
 # Disabling rules (NO)
 RedHat.ReleaseNotes = NO
-
-# Use local OpenShiftDocs Vocab terms
-Vale.Terms = YES
-Vale.Avoid = YES
 
 # Enable specific DITA rules on assemblies
 AsciiDocDITA.AdmonitionTitle = error


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
rhacs-docs-main
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
https://redhat.atlassian.net/browse/ROX-33642
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

Additional information:
No cherrypicking
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
