### PR TITLE
OSDOCS-17271.1:Updated text regarding marketplace roles

### DIFF
--- a/modules/ccs-gcp-customer-procedure.adoc
+++ b/modules/ccs-gcp-customer-procedure.adoc
@@ -111,7 +111,7 @@ For more information about configuring {gcp-short} organization policy constrain
 
 |link:https://docs.cloud.google.com/marketplace/docs/reference/consumerprocurement/rest[Cloud Commerce Consumer Procurement API]
 |`cloudcommerceconsumerprocurement.googleapis.com`
-|Enables users to procure products from the {gcp-short}  Marketplace. Specifically, this permission is required to validate through this API that customers have accepted the  Marketplace terms and conditions for {product-title}.
+|Enables users to procure products from the {gcp-short}  Marketplace. Specifically, it is required to validate that customers have accepted the Marketplace terms and conditions for {product-title}.
 
 This API is required when transacting through the {gcp-short} Marketplace.
 

--- a/modules/ccs-gcp-permissions-marketplace-billing.adoc
+++ b/modules/ccs-gcp-permissions-marketplace-billing.adoc
@@ -9,7 +9,7 @@
 [role="_abstract"]
 To deploy an {product-title} cluster using {GCP} Marketplace-based billing, your {GCP} account must first be prepared. This involves accepting the {GCP} Marketplace terms and agreements for the OpenShift Dedicated product listing. Contact your {GCP} administrator who has the `Consumer Procurement Entitlement Manager` role to enable {product-title} cluster deployments in your {GCP} project.
 
-To automate the checking and acceptance of these terms and agreements during OpenShift Dedicated cluster creation, you must grant the `Consumer Procurement Entitlement Viewer` role to the {GCP} identity (user or service account) that is creating the cluster. The `Consumer Procurement Entitlement Viewer` role includes the necessary permissions to check for existing consent to the {GCP} terms and agreements and grants consent if that has not yet been given.
+To automate the checking and acceptance of these terms and agreements during OpenShift Dedicated cluster creation, you must grant the `Consumer Procurement Entitlement Viewer` role to the {GCP} identity (user or service account) that is creating the cluster. The `Consumer Procurement Entitlement Viewer` role includes the necessary permissions to check for existing consent to the {GCP} terms and agreements.
 
 The following table lists the permissions that are included in the `Consumer Procurement Entitlement Viewer` role.
 


### PR DESCRIPTION
Version(s):
4.21+

Issue:
[OSDOCS-17271](https://redhat.atlassian.net/browse/OSDOCS-17271)

Link to docs preview:

- [Required customer procedure](https://108695--ocpdocs-pr.netlify.app/openshift-dedicated/latest/osd_planning/gcp-ccs.html#ccs-gcp-customer-procedure_gcp-ccs)
- [Roles required for Google Cloud Marketplace billing](https://108695--ocpdocs-pr.netlify.app/openshift-dedicated/latest/osd_planning/gcp-ccs.html#ccs-gcp-permissions-marketplace-billing_gcp-ccs)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
