### PR TITLE
OSDOCS:16989_1_4.19#AWS_IPI_CQA_Remediation

### DIFF
--- a/installing/installing_aws/installing-aws-account.adoc
+++ b/installing/installing_aws/installing-aws-account.adoc
@@ -25,6 +25,10 @@ include::modules/installation-aws-permissions-iam-roles.adoc[leveloffset=+2]
 
 include::modules/installation-aws-add-iam-roles.adoc[leveloffset=+2]
 
+[role="_additional-resources"]
+.Additional resources
+* xref:../../installing/installing_aws/ipi/installing-aws-customizations.adoc#installation-launching-installer_installing-aws-customizations[Deploying the cluster]
+
 include::modules/installation-aws-access-analyzer.adoc[leveloffset=+2]
 
 include::modules/installation-aws-marketplace.adoc[leveloffset=+1]


### PR DESCRIPTION
Version:
4.19

Issue:
https://issues.redhat.com/browse/OSDOCS-16989

Link to docs preview:
[Specifying an existing IAM role](https://108698--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-aws-account.html#specify-an-existing-iam-role_installing-aws-account)

QE review:
No content changes, so QE approval is not required.

Additional information:
Remediation PR for https://github.com/openshift/openshift-docs/pull/106453. (This [PR](https://github.com/openshift/openshift-docs/pull/103169) required a manual CP to 4.19.) The link to 'Deploying the cluster' was inadvertently removed; this PR restores it.