### PR TITLE
[rhacs] Add Vale template for automated PR review comments

### DIFF
--- a/.vale/templates/bot-comment-output.tmpl
+++ b/.vale/templates/bot-comment-output.tmpl
@@ -1,0 +1,54 @@
+{{- /* Modify Vale's output https://docs.errata.ai/vale/cli#--output */ -}}
+
+{{- /* Keep track of our various counts */ -}}
+
+{{- $e := 0 -}}
+{{- $w := 0 -}}
+{{- $s := 0 -}}
+
+{{- /* Range over the linted files */ -}}
+[
+{{- range $jdx, $file := .Files -}}
+    {{- $path := .Path -}}
+    {{- /* Range over the file's alerts */ -}}
+    {{- if $jdx -}},{{- end -}}
+    {{- range $idx, $a := .Alerts -}}
+
+        {{- $error := "" -}}
+        {{- if eq .Severity "error" -}}
+            {{- $error = "error" -}}
+            {{- $e = add1 $e  -}}
+        {{- else if eq .Severity "warning" -}}
+            {{- $error = "warning" -}}
+            {{- $w = add1 $w -}}
+        {{- else -}}
+            {{- $error = "suggestion" -}}
+            {{- $s = add1 $s -}}
+        {{- end}}
+
+        {{- /* Variables setup */ -}}
+        {{- $loc := printf "%d" .Line -}}
+        {{- $check := printf "%s" .Check -}}
+        {{- /* Escape special characters for valid JSON */ -}}
+        {{- $message := replace "\\" "\\\\" (printf "%s" .Message) -}}
+        {{- $message = replace "\"" "\\\"" $message -}}
+        {{- $message = replace "\n" "\\n" $message -}}
+        {{- $message = replace "\r" "\\r" $message -}}
+        {{- $message = replace "\t" "\\t" $message -}}
+        {{- /* Only add a link for RedHat rule errors */ -}}
+        {{- $link := "" -}}
+        {{- if contains "RedHat." .Check -}}
+            {{- $link = printf "For more information, see [%s](https://redhat-documentation.github.io/vale-at-red-hat/docs/main/reference-guide/%s)." .Check (lower (trimPrefix "RedHat." .Check)) -}}
+        {{- end -}}
+        {{- if $idx -}},{{- end -}}
+
+        {{- /* Output */ -}}
+        {
+            "body": "🤖 **[{{ $error }}] {{$check}}**: {{ $message }} {{ $link }}",
+            "path": "{{ $path }}",
+            "line": {{ $loc }}
+        }
+    {{end -}}
+{{end -}}
+]
+


### PR DESCRIPTION
Version(s): main, no cherry picks
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://redhat.atlassian.net/browse/ROX-33629
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: **N/A**
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review: **N/A**
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:

This template is required by the prow-vale-review.sh script to format Vale errors as JSON for posting review comments on PRs. Without this template, Vale fails with 'open : no such file or directory' error and cannot post review comments even when errors are detected.

The template was missing from rhacs-docs-main branch, causing the vale-review step to fail silently during PR validation. This prevented automated DITA validation feedback on PRs.

Copied from main branch to enable Vale review functionality on rhacs-docs-main branch.

co-authored by claude code

<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
