### PR TITLE
OSDOCS#18776: Update the MicroShift z-stream RNs for 4.16.58 

### DIFF
--- a/microshift_release_notes/microshift-4-16-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-16-release-notes.adoc
@@ -82,3 +82,5 @@ include::modules/microshift-4-16-32-dp.adoc[leveloffset=+2]
 include::modules/microshift-4-16-40-dp.adoc[leveloffset=+2]
 
 include::modules/microshift-4-16-47-dp.adoc[leveloffset=+2]
+
+include::modules/microshift-4-16-58-dp.adoc[leveloffset=+2]

--- a/modules/microshift-4-16-58-dp.adoc
+++ b/modules/microshift-4-16-58-dp.adoc
@@ -1,0 +1,14 @@
+// Module included in the following assemblies:
+//
+//microshift_release_notes/microshift-4-16-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="microshift-4-16-58-dp_{context}"]
+= RHSA-2026:4580 - {microshift-short} 4.16.58 bug fix advisory
+
+Issued: 19 March 2026
+
+[role="_abstract"]
+{product-title} release 4.16.58 is now available. The list of bug fixes that are included in the update is attached to the link:https://access.redhat.com/errata/RHSA-2026:4580[RHSA-2026:4580] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2026:4482[RHSA-2026:4482] advisory.
+
+See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].


### PR DESCRIPTION
Version(s):
4.16

Issue:
[OSDOCS-18776](https://redhat.atlassian.net/browse/OSDOCS-18776)

Link to docs preview:
[4.16.58](https://108708--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-16-release-notes.html#microshift-4-16-58-dp_release-notes)

QE review:
- [ ] QE has approved this change.
N/A for z-stream RNs.

Additional information:
Shipment [MR](https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/407)
ART [Dashboard](https://art-dash.engineering.redhat.com/dashboard/release/openshift-4.16)
