### PR TITLE
OSDOCS:16989_1_4.16#AWS_IPI_CQA_Remediation

### DIFF
--- a/installing/installing_aws/installing-aws-account.adoc
+++ b/installing/installing_aws/installing-aws-account.adoc
@@ -26,6 +26,10 @@ include::modules/installation-aws-permissions-iam-roles.adoc[leveloffset=+2]
 
 include::modules/installation-aws-add-iam-roles.adoc[leveloffset=+2]
 
+[role="_additional-resources"]
+.Additional resources
+* xref:../../installing/installing_aws/ipi/installing-aws-customizations.adoc#installation-launching-installer_installing-aws-customizations[Deploying the cluster]
+
 include::modules/installation-aws-access-analyzer.adoc[leveloffset=+2]
 
 include::modules/installation-aws-marketplace.adoc[leveloffset=+1]


### PR DESCRIPTION
Version:
4.16

Issue:
https://issues.redhat.com/browse/OSDOCS-16989

Link to docs preview:
[Specifying an existing IAM role](https://108712--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-aws-account.html#specify-an-existing-iam-role_installing-aws-account)

QE review:
No content changes, so QE approval is not required.

Additional information:
Remediation PR for https://github.com/openshift/openshift-docs/pull/106457. (This is the [PR ](https://github.com/openshift/openshift-docs/pull/103169)that required a manual CP.) The link to 'Deploying the cluster' was inadvertently removed; this PR restores it.
