### PR TITLE
OSDOCS:16989_2_4.19#AWS_IPI_CQA_Remediation

### DIFF
--- a/installing/installing_aws/installing-aws-account.adoc
+++ b/installing/installing_aws/installing-aws-account.adoc
@@ -27,6 +27,7 @@ include::modules/installation-aws-add-iam-roles.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
 .Additional resources
+* xref:../../installing/installing_aws/ipi/installing-aws-customizations.adoc#installation-launching-installer_installing-aws-customizations[Deploying the cluster]
 * xref:../../installing/installing_aws/ipi/installing-aws-default.adoc#installing-aws-default[Quickly install a cluster]
 * xref:../../installing/installing_aws/ipi/installing-aws-customizations.adoc#installing-aws-customizations[Install a cluster with cloud customizations on installer-provisioned infrastructure]
 * xref:../../installing/installing_aws/upi/installing-aws-user-infra.adoc#installing-aws-user-infra[Installing a cluster on user-provisioned infrastructure in AWS by using CloudFormation templates]


### PR DESCRIPTION
Version:
4.19

Issue:
https://issues.redhat.com/browse/OSDOCS-16989

Link to docs preview:
[Specifying an existing IAM role]()

QE review:
No content changes, so QE approval is not required.

Additional information:
Remediation PR for https://github.com/openshift/openshift-docs/pull/104069. (This https://github.com/openshift/openshift-docs/pull/103257 required a manual CP to 4.19.) The link to 'Deploying the cluster' was inadvertently removed; this PR restores
