### PR TITLE
OSDOCS:16989_2_4.18#AWS_IPI_CQA_Remediation

### DIFF
--- a/installing/installing_aws/installing-aws-account.adoc
+++ b/installing/installing_aws/installing-aws-account.adoc
@@ -1,7 +1,8 @@
 :_mod-docs-content-type: ASSEMBLY
+include::_attributes/common-attributes.adoc[]
 [id="installing-aws-account"]
 = Configuring an {aws-short} account
-include::_attributes/common-attributes.adoc[]
+
 :context: installing-aws-account
 
 toc::[]
@@ -24,6 +25,10 @@ include::modules/installation-aws-iam-policies-about.adoc[leveloffset=+1]
 include::modules/installation-aws-permissions-iam-roles.adoc[leveloffset=+2]
 
 include::modules/installation-aws-add-iam-roles.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources
+* xref:../../installing/installing_aws/ipi/installing-aws-customizations.adoc#installation-launching-installer_installing-aws-customizations[Deploying the cluster]
 
 include::modules/installation-aws-access-analyzer.adoc[leveloffset=+2]
 

--- a/modules/nw-endpoint-route53.adoc
+++ b/modules/nw-endpoint-route53.adoc
@@ -36,9 +36,8 @@ platform:
     - name: tagging
       url: https://tagging.us-gov-west-1.amazonaws.com
 ----
-++
+
 where:
-++
 
 `https://route53.us-gov.amazonaws.com`:: Defaults to `https://route53.us-gov.amazonaws.com` for both {aws-short} GovCloud (US) regions.
 `https://tagging.us-gov-west-1.amazonaws.com`:: Only the US-West region has endpoints for tagging. Omit this parameter if your cluster is in another region.


### PR DESCRIPTION
Version:
4.18

Issue:
https://issues.redhat.com/browse/OSDOCS-16989

Link to docs preview:

- [Specifying an existing IAM role](https://108719--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-aws-account.html#specify-an-existing-iam-role_installing-aws-account) (Restoring the link to 'Deploying the cluster')
- [Ingress Operator endpoint configuration for AWS Route 53](https://108719--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-aws-account.html#specify-an-existing-iam-role_installing-aws-account) (Adjusting the position of the 'where')

QE review:
No content changes, so QE approval is not required.

Additional information:
Remediation PR for https://github.com/openshift/openshift-docs/pull/104141. (This https://github.com/openshift/openshift-docs/pull/103257 required the manual CP to 4.18.)