### PR TITLE
OSDOCS-18775:Update the z-stream RNs for 4.14.63

### DIFF
--- a/modules/zstream-4-14-63.adoc
+++ b/modules/zstream-4-14-63.adoc
@@ -1,0 +1,38 @@
+// Module included in the following assembly:
+//
+// * release_notes/ocp-4-14-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-14-63-bug-fixes_{context}"]
+= RHSA-2026:5107 - {product-title} {product-version}.63 image release, fixed issues, and security update
+
+Issued: 26 March 2026
+
+[role="_abstract"]
+{product-title} release {product-version}.63 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2026:5107[RHSA-2026:5107] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2026:5086[RHSA-2026:5086] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.14.63 --pullspecs
+----
+
+= Enhancements
+
+* Before this update, the self-signed loopback certificate for the Kubernetes API Server expired after one year. With this release, the expiration date of the certificate is extended to three years. (link:https://redhat.atlassian.net/browse/OCPBUGS-59473[OCPBUGS-59473])
+
+= Fixed issues
+
+* Before this update, when you configured a Windows VM on which the default PowerShell execution policy that was set to `Restricted`, the Windows Machine Config Operator (WMCO) could not execute the necessary commands. As a consequence, the Windows node was not properly configured. With this release, the WMCO bypasses the execution policy when running PowerShell commands on a Windows VM. (link:https://redhat.atlassian.net/browse/OCPBUGS-37611[OCPBUGS-37611])
+
+* Before this update, aggregated API servers on {product-title} used in-memory loopback certificates that were valid for only one year. With this release, these servers now use in-memory loopback certificates that are valid for three years. (link:https://redhat.atlassian.net/browse/OCPBUGS-74922[OCPBUGS-74922])
+
+* Before this update, service account creation with the `openshift/local/google` provider in earlier {product-title} versions caused inconsistent results during service account creation. As a consequence, errors occurred during the apply process, which affected cluster provisioning in {gcp-first}. With this release, the issue is resolved by upgrading Terraform and the provider. As a result, service account creation issues are resolved, which reduces inconsistencies during cluster installation in {gcp-short}. (link:https://issues.redhat.com/browse/OCPBUGS-76930[OCPBUGS-76930])
+
+[id="zstream-4-14-63-updating_{context}"]
+== Updating
+
+To update an {product-title} 4.14 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].

--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -3407,10 +3407,13 @@ The impact is on East/West traffic in local gateway mode with `routingViaHost` s
 
 * There is a known issue with HAProxy in {product-title} {product-version} involving applications that send invalid `Transfer-Encoding` headers. This issue results in losing external access to pods when they expose a route that sends these invalid headers. For more details, see the information in this link:https://access.redhat.com/solutions/7055002[Red Hat Knowledgebase article]. (link:https://issues.redhat.com/browse/OCPBUGS-43095[OCPBUGS-43095])
 
-// 4.14.62 about async
+// 4.14 about async
 include::modules/rn-async-errata.adoc[leveloffset=+1]
 
-// 4.18.34 Rns and updating
+// 4.14.63 Rns and updating
+include::modules/zstream-4-14-63.adoc[leveloffset=+2]
+
+// 4.14.62 Rns and updating
 include::modules/zstream-4-14-62.adoc[leveloffset=+2]
 
 //4.14.61 about


### PR DESCRIPTION
Version(s):
4.14

Issue:
https://redhat.atlassian.net/browse/OSDOCS-18775

Link to docs preview:
https://108724--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes.html#zstream-4-14-63-bug-fixes_release-notes

Additional information:
4.14.63 MR: https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/424
ART Dashboard: https://art-dash.engineering.redhat.com/dashboard/release/openshift-4.14