### PR TITLE
[OSDOCS#18539]: Changed disk size from 120 GB to 50 GB for arbiter node

### DIFF
--- a/modules/ipi-install-config-local-arbiter-node.adoc
+++ b/modules/ipi-install-config-local-arbiter-node.adoc
@@ -24,7 +24,7 @@ The arbiter node must meet the following minimum system requirements:
 
 * 2 threads
 * 8 GB of RAM
-* 120 GB of SSD or equivalent storage
+* 50 GB of SSD or equivalent storage
 
 The arbiter node must be located in a network environment with an end-to-end latency of less than 500 milliseconds, including disk I/O. In high-latency environments, you might need to apply the `etcd` slow profile.
 


### PR DESCRIPTION
Version(s):
4.20+

Issue:
https://redhat.atlassian.net/browse/OSDOCS-18539

Link to docs preview:
https://108726--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/ipi/ipi-install-installation-workflow.html#ipi-install-config-local-arbiter-node_ipi-install-installation-workflow

QE review:
- [x] QE has approved this change.
