### PR TITLE
OSDOCS-18572:Update Installation docs for 4.22 compatibility with RHEL 9.8

### DIFF
--- a/_attributes/attributes-microshift.adoc
+++ b/_attributes/attributes-microshift.adoc
@@ -6,7 +6,7 @@
 :experimental:
 :imagesdir: images
 :OCP: OpenShift Container Platform
-:ocp-version: 4.21
+:ocp-version: 4.22
 :oc-first: pass:quotes[OpenShift CLI (`oc`)]
 :ai-first: artificial intelligence (AI)
 //OpenShift Kubernetes Engine
@@ -18,7 +18,7 @@
 :gitops-title: Red{nbsp}Hat OpenShift GitOps
 :gitops: GitOps
 :product-registry: OpenShift image registry
-:product-version: 4.21
+:product-version: 4.22
 :rhel-major: rhel-9
 :rhoai-full: Red{nbsp}Hat OpenShift AI
 :rhoai: RHOAI
@@ -29,11 +29,11 @@
 :op-system-rt-kernel: Red{nbsp}Hat Enterprise Linux for Real Time (real-time kernel)
 :op-system-rtk: real-time kernel
 :op-system-image: image mode for RHEL
-:op-system-version: 9.6
+:op-system-version: 9.8
 :op-system-version-major: 9
 :op-system-bundle: Red{nbsp}Hat Device Edge
 :ovms: OpenVINO Model Server
 :ov: OVMS
-:rpm-repo-version: rhocp-4.21
+:rpm-repo-version: rhocp-4.22
 :rhde-version: 4
 :VirtProductName: OpenShift Virtualization

--- a/modules/microshift-greenboot-prerollback-log.adoc
+++ b/modules/microshift-greenboot-prerollback-log.adoc
@@ -31,10 +31,10 @@ boot_indeterminate=0
 boot_counter=0
 The ostree status:
 * rhel c0baa75d9b585f3dd989a9cf05f647eb7ca27ee0dbd4b94fe8c93ed3a4b9e4a5.0
-    Version: 9.6
+    Version: 9.8
     origin: <unknown origin type>
   rhel 6869c1347b0e0ba1bbf0be750cdf32da5138a1fcbc5a4c6325ab9eb647b64663.0 (rollback)
-    Version: 9.6
+    Version: 9.8
     origin refspec: edge:rhel/9/x86_64/edge
 System rollback imminent - preparing MicroShift for a clean start
 Stopping MicroShift services

--- a/modules/microshift-rhde-compatibility-table.adoc
+++ b/modules/microshift-rhde-compatibility-table.adoc
@@ -24,17 +24,29 @@ Be sure to check the support status of a release on the product lifecycle page.
 ^|*{microshift-short} Version*
 ^|*Supported {microshift-short} Version{nbsp}&#8594;{nbsp}Version Updates*
 
-^|10.0
+^|10.2
+^|4.22
+^|4.22.0{nbsp}&#8594;{nbsp}4.22.z (Technology Preview)
+
+^|9.8
+^|4.22
+^|4.22.0{nbsp}&#8594;{nbsp}4.22.z
+
+^|9.8
 ^|4.21
-^|4.21.0{nbsp}&#8594;{nbsp}4.21.z (Technology Preview)
+^|4.21.0{nbsp}&#8594;{nbsp}4.21.z, 4.21{nbsp}&#8594;{nbsp}4.22
+
+^|9.8
+^|4.20
+^|4.20.0{nbsp}&#8594;{nbsp}4.20.z, 4.20{nbsp}&#8594;{nbsp}4.21
 
 ^|9.6
 ^|4.21
-^|4.21.0{nbsp}&#8594;{nbsp}4.21.z
+^|4.21.0{nbsp}&#8594;{nbsp}4.21.z, 4.21{nbsp}&#8594;{nbsp}4.22 on {op-system-base} 9.8
 
 ^|9.6
 ^|4.20
-^|4.20.0{nbsp}&#8594;{nbsp}4.20.z, 4.20{nbsp}&#8594;{nbsp}4.21
+^|4.20.0{nbsp}&#8594;{nbsp}4.20.z, 4.20{nbsp}&#8594;{nbsp}4.21, 4.20{nbsp}&#8594;{nbsp}4.22 on {op-system-base} 9.8
 
 ^|9.6
 ^|4.19


### PR DESCRIPTION
Version(s):
4.22

Issue:
https://redhat.atlassian.net/browse/OSDOCS-18572

Link to docs preview:
https://108730--ocpdocs-pr.netlify.app/microshift/latest/microshift_install_get_ready/microshift-install-get-ready#microshift-rhde-compatibility-table_microshift-install-get-ready
https://108730--ocpdocs-pr.netlify.app/microshift/latest/microshift_install_bootc/microshift-install-bootc-image

SME review:
- [x] SME has approved this change.

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
