### PR TITLE
OSSM-12945 DOCS Known issues update to 3.3

### DIFF
--- a/modules/ossm-release-notes-3-3-fixed-issues.adoc
+++ b/modules/ossm-release-notes-3-3-fixed-issues.adoc
@@ -8,7 +8,7 @@
 
 [role="_abstract"]
 
-This release addresses enhancements, fixed issues, and Common Vulnerabilities and Exposures (CVEs).
+This release addresses the following fixed issues:
 
 Halting unnecessary {ossmc-full} pod redeployments::
 
@@ -18,4 +18,6 @@ link:https://issues.redhat.com/browse/OSSM-12420[OSSM-12420]
 
 Removed false warnings for unmanaged namespaces in Kiali logs::
 
-Before this update, Kiali logged warnings for namespaces without the required sidecar label. As a consequence, users experienced excessive warnings in Kiali logs for namespaces not managed by {istio} control plane due to incorrect `GetRootNamespace` determination. With this release, the false warnings in Kiali logs for namespaces not managed by {istio} control plane are removed. As a result, user experience is improved by reducing unnecessary log messages.
+Before this update, Kiali logged warnings for namespaces without the required sidecar label. As a consequence, users experienced excessive warnings in Kiali logs for namespaces not managed by the {istio} control plane due to incorrect `GetRootNamespace` determination. With this release, the false warnings in Kiali logs for namespaces not managed by the {istio} control plane are removed. As a result, user experience is improved by reducing unnecessary log messages.
++
+link:https://issues.redhat.com/browse/OSSM-12581[OSSM-12581]

--- a/modules/ossm-release-notes-3-3-known-issues.adoc
+++ b/modules/ossm-release-notes-3-3-known-issues.adoc
@@ -1,0 +1,27 @@
+// Module included in the following assemblies:
+//
+// * service-mesh-docs-main/ossm-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="ossm-release-3-3-known-issues_{context}"]
+= {SMProductName} 3.3 known issues
+
+[role="_abstract"]
+
+This release has the following known issues:
+
+Performance issues when applying configuration changes in large FIPS clusters::
+
+There is currently a known issue where applying configuration changes takes longer than expected in environments with a large number of services and pods when FIPS mode is enabled. This delay occurs because Envoy performs additional certificate checks to maintain FIPS compliance.
++
+There is currently no workaround for this issue. Wait for the configuration changes to complete; the process eventually succeeds.
++
+link:https://issues.redhat.com/browse/OSSM-12930[OSSM-12930]
+
+Increased Envoy validation time impacts OSSM proxy readiness::
+
+In the {SMProductName} 3.3 FIPS release, a known issue arises due to extended validation time for `ISTIO_MUTUAL` TLS keys within Envoy, leading to a delay. The issue particularly affects the readiness time of Envoy proxies in {SMProductName} 3.3 FIPS clusters, potentially increasing performance impact on the affected cluster. 
++
+There is currently no workaround for this issue.
++
+link:https://issues.redhat.com/browse/OSSM-12929[OSSM-12929]

--- a/ossm-release-notes/ossm-release-notes.adoc
+++ b/ossm-release-notes/ossm-release-notes.adoc
@@ -16,6 +16,8 @@ include::modules/ossm-release-notes-3-3-technology-preview-features.adoc[levelof
 
 include::modules/ossm-release-notes-3-3-fixed-issues.adoc[leveloffset=+1]
 
+include::modules/ossm-release-notes-3-3-known-issues.adoc[leveloffset=+1]
+
 [role="_additional-resources"]
 [id="additional-resources-release-notes_{context}"]
 == Additional resources


### PR DESCRIPTION
Change type: Doc update; Known issues update to 3.3

Doc JIRA: https://issues.redhat.com/browse/OSSM-12945

Fix Version: [service-mesh-docs-3.3](https://github.com/openshift/openshift-docs/tree/service-mesh-docs-3.3)

Doc Preview:
https://108764--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/ossm-release-notes/ossm-release-notes.html#ossm-release-3-3-known-issues_ossm-release-notes

SME Review/QE Review: @mkralik3 
Peer Review: @kaldesai 