### PR TITLE
OSDOCS-17084: Backport MS CQA updates to enterprise-4.21

### DIFF
--- a/modules/microshift-nw-ipv6-concept.adoc
+++ b/modules/microshift-nw-ipv6-concept.adoc
@@ -6,11 +6,17 @@
 [id="microshift-intro-ipv6_{context}"]
 = IPv6 networking with {microshift-short}
 
-The {microshift-short} service defaults to IPv4 address families node-wide. However, IPv6 single-stack and IPv4/IPv6 dual-stack networking is available on supported platforms.
+[role="_abstract"]
+The {product-title} service defaults to IPv4. IPv6 single-stack and IPv4/IPv6 dual-stack networking is available on supported platforms. You configure IPv6 or dual-stack networking in the configuration file.
+
+Consider the following when configuring IPv6 or dual-stack networking with {microshift-short}:
 
 * When you set the values for IPv6 in the {microshift-short} configuration file and restart the service, settings managed by the OVN-Kubernetes network plugin are updated automatically.
+
 * After migrating to dual-stack networking, both new and existing pods have dual-stack networking enabled.
+
 * If you require node-wide IPv6 access, such as for the control plane and other services, use the following configuration examples. The {microshift-short} Multus Container Network Interface (CNI) plugin can enable IPv6 for pods.
+
 * For dual-stack networking, each {microshift-short} node network and service network supports up to two values in the node and service network configuration parameters.
 
 [IMPORTANT]

--- a/modules/microshift-nw-ipv6-dual-stack-config.adoc
+++ b/modules/microshift-nw-ipv6-dual-stack-config.adoc
@@ -6,7 +6,8 @@
 [id="microshift-configuring-ipv6-dual-stack-config_{context}"]
 = Configuring IPv6 dual-stack networking before {microshift-short} starts
 
-You can configure your {microshift-short} node to run on dual-stack networking that supports IPv4 and IPv6 address families by using the configuration file before starting the service.
+[role="_abstract"]
+To run your {microshift-short} node with IPv4 and IPv6 dual-stack networking, you can configure the network section in the configuration file before starting the service.
 
 * The first IP family in the configuration is the primary IP stack in the node.
 * After the node is running with dual-stack networking, enable application pods and add-on services for dual-stack by restarting them.
@@ -54,19 +55,24 @@ apiServer:
 network:
   clusterNetwork:
   - 10.42.0.0/16
-  - fd01::/48 <1>
+  - fd01::/48
   serviceNetwork:
   - 10.43.0.0/16
-  - fd02::/112 <2>
+  - fd02::/112
 node:
-  nodeIP: 192.168.113.117 <3>
-  nodeIPv6: 2001:db9:ca7:ff::1db8 <4>
+  nodeIP: 192.168.113.117
+  nodeIPv6: 2001:db9:ca7:ff::1db8
 # ...
 ----
-<1> Specify an IPv6 `clusterNetwork` with a CIDR value that is less than `64`.
-<2> Specify an IPv6 CIDR with a prefix of `112`. Kubernetes uses only the lowest 16 bits. For a prefix of `112`, IP addresses are assigned from `112` to `128` bits.
-<3> Example node IP address. Must be an IPv4 address family.
-<4> Example node IP address for dual-stack configuration. Must be an IPv6 address family. Configurable only with dual-stack networking.
++
+where:
++
+--
+`network.clusterNetwork`:: Specifies an IPv6 `clusterNetwork` with a CIDR value that is less than `64`.
+`network.serviceNetwork`:: Specifies an IPv6 CIDR with a prefix of `112`. Kubernetes uses only the lowest 16 bits. For a prefix of `112`, IP addresses are assigned from `112` to `128` bits.
+`node.nodeIP`:: Specifies an IPv4 address family.
+`node.nodeIPv6`:: Specifies an IPv6 address family. Configurable only with dual-stack networking.
+--
 
 . Complete any other {microshift-short} configurations you require, then start {microshift-short} by running the following command:
 +

--- a/modules/microshift-nw-ipv6-dual-stack-migrating-config.adoc
+++ b/modules/microshift-nw-ipv6-dual-stack-migrating-config.adoc
@@ -6,7 +6,8 @@
 [id="microshift-nw-ipv6-dual-stack-migrating-config_{context}"]
 = Migrating a {microshift-short} node to IPv6 dual-stack networking
 
-You can convert a single-stack node to dual-stack node networking that supports IPv4 and IPv6 address families by setting two entries in the service and node network parameters in the {microshift-short} configuration file.
+[role="_abstract"]
+To convert a single-stack node to dual-stack node networking that supports IPv4 and IPv6 address families, set two entries in the service and node network parameters in the {microshift-short} configuration file and restart the service.
 
 * The first IP family in the configuration is the primary IP stack in the node.
 * {microshift-short} system pods and services are automatically updated upon {microshift-short} restart.
@@ -53,32 +54,36 @@ You must keep the same first entry across restarts and migrations. This is true 
 .. Add network assignments to the `network` section of the {microshift-short} `config.yaml` to enable dual stack with IPv6 as secondary network.
 +
 .Example dual-stack IPv6 configuration with network assignments
-+
-[source,terminal]
+[source,yaml]
 ----
 # ...
 apiServer:
   subjectAltNames:
   - 192.168.113.117
-  - 2001:db9:ca7:ff::1db8 <1>
+  - 2001:db9:ca7:ff::1db8
 network:
   clusterNetwork:
-  - 10.42.0.0/16 <2>
-  - fd01::/48 <3>
+  - 10.42.0.0/16
+  - fd01::/48
   serviceNetwork:
   - 10.43.0.0/16
-  - fd02::/112 <4>
+  - fd02::/112
 node:
-  nodeIP: 192.168.113.117 <5>
-  nodeIPv6: 2001:db9:ca7:ff::1db8 <6>
+  nodeIP: 192.168.113.117
+  nodeIPv6: 2001:db9:ca7:ff::1db8
 # ...
 ----
-<1> The IPv6 node address.
-<2> IPv4 network. Specify a `clusterNetwork` with a CIDR value that is less than `24`.
-<3> IPv6 network. Specify a `clusterNetwork` with a CIDR value that is less than `64`.
-<4> Specify an IPv6 CIDR with a prefix of `112`. Kubernetes uses only the lowest 16 bits. For a prefix of `112`, IP addresses are assigned from `112` to `128` bits.
-<5> Example node IP address. Maintain the previous IPv4 IP address.
-<6> Example node IP address. Must be an IPv6 address family.
++
+where:
++
+--
+`2001:db9:ca7:ff::1db8`:: Specifies an IPv6 node address.
+`10.42.0.0/16`:: Specifies an IPv4 `clusterNetwork` address with a CIDR value that is less than `24`.
+`fd01::/48`:: Specifies an IPv6 `clusterNetwork` address with a CIDR value that is less than `64`.
+`fd02::/112`:: Specifies an IPv6 CIDR with a prefix of `112`. Kubernetes uses only the lowest 16 bits. For a prefix of `112`, IP addresses are assigned from `112` to `128` bits.
+`192.168.113.117`:: Specifies an IPv4 node IP address. Maintain the previous IPv4 IP address.
+`2001:db9:ca7:ff::1db8`:: Specifies an IPv6 node IP address. Must be an IPv6 address family.
+--
 
 . Complete any other configurations you require, then restart {microshift-short} by running the following command:
 +
@@ -101,7 +106,6 @@ $ oc get pod -A -o wide
 ----
 +
 .Example output
-+
 [source,text]
 ----
 NAMESPACE                  NAME                                      READY   STATUS    RESTARTS        AGE     IP                NODE           NOMINATED NODE   READINESS GATES

--- a/modules/microshift-nw-ipv6-dual-stack-reset-ipfam.adoc
+++ b/modules/microshift-nw-ipv6-dual-stack-reset-ipfam.adoc
@@ -6,7 +6,9 @@
 [id="microshift-nw-ipv6-dual-stack-reset-ipfam_{context}"]
 = Resetting the IP family policy for application pods and services
 
-The default `ipFamilyPolicy` configuration value, `PreferSingleStack`, does not automatically update in all services after you update your {microshift-short} configuration to dual-stack networking. To enable dual-stack networking in services and application pods, you must update the `ipFamilyPolicy` value.
+[role="_abstract"]
+The default `PreferSingleStack` value does not change when you migrate the {microshift-short} node to dual-stack.
+To enable dual-stack networking in application pods and services on a node that uses dual-stack, set the `ipFamilyPolicy` field to `PreferDualStack` or `RequireDualStack` and restart the pods. 
 
 .Prerequisites
 
@@ -26,13 +28,16 @@ metadata:
   labels: app: microshift-application
 spec:
   type: NodePort
-  ipFamilyPolicy: `PreferDualStack` # <1>
+  ipFamilyPolicy: PreferDualStack
 # ...
 ----
-<1> Required. Valid values for dual-stack networking are `PreferDualStack` and `RequireDualStack`. The value you set depends on the requirements of your application. `PreferSingleStack` is the default value for the `ipFamilyPolicy` field.
++
+where:
+
+`spec.ipFamilyPolicy`:: Required. Specifies the IP family policy for the service. Valid values are `PreferDualStack` and `RequireDualStack`. The value you set depends on the requirements of your application. `PreferSingleStack` is the default value for the `ipFamilyPolicy` field.
 
 . Restart any application pods that do not have a `hostNetwork` defined. Pods that do have a `hostNetwork` defined do not need to be restarted to update the `ipFamilyPolicy` value.
-
++
 [NOTE]
 ====
 {microshift-short} system services and pods are automatically updated when the `ipFamilyPolicy` value is updated.

--- a/modules/microshift-nw-ipv6-single-stack-config.adoc
+++ b/modules/microshift-nw-ipv6-single-stack-config.adoc
@@ -6,7 +6,8 @@
 [id="microshift-configuring-ipv6-single-stack-config_{context}"]
 = Configuring IPv6 single-stack networking
 
-You can use the IPv6 network protocol by updating the {microshift-short} service configuration file.
+[role="_abstract"]
+To run {microshift-short} with IPv6-only networking, you can update the service configuration file and set the network section with your cluster and service CIDRs. You can verify the configuration by checking that pods and services use IPv6 addresses.
 
 .Prerequisites
 
@@ -35,16 +36,21 @@ apiServer:
 # ...
 network:
   clusterNetwork:
-  - fd01::/48 <1>
+  - fd01::/48
   serviceNetwork:
-  - fd02::/112 <2>
+  - fd02::/112
 node:
-  nodeIP: 2600:1f14:1c48:ee00:2d76:3190:5bc2:5aef <3>
+  nodeIP: 2600:1f14:1c48:ee00:2d76:3190:5bc2:5aef
 # ...
 ----
-<1> Specify a `clusterNetwork` with a CIDR value that is less than `64`.
-<2> Specify an IPv6 CIDR with a prefix of `112`. Kubernetes uses only the lowest 16 bits. For a prefix of `112`, IP addresses are assigned from `112` to `128` bits.
-<3> Example node IP address. Valid values are IP addresses in the IPv6 address family. You must only specify an IPv6 address when an IPv4 network is also present. If an IPv4 network is not present, the {microshift-short} service automatically fills in this value upon restart.
++
+where:
++
+--
+`networking.clusterNetwork`:: Specifies a `clusterNetwork` address with a CIDR value that is less than `64`. For example, `fd01::/48`.
+`network.serviceNetwork`:: Specifies an IPv6 CIDR with a prefix of `112`, for example, `fd02::/112`. Kubernetes uses only the lowest 16 bits. For a prefix of `112`, IP addresses are assigned from `112` to `128` bits.
+`node.nodeIP`:: Specifies a node IP address. Valid values are IP addresses in the IPv6 address family. You must only specify an IPv6 address when an IPv4 network is also present. If an IPv4 network is not present, the {microshift-short} service automatically fills in this value upon restart.
+--
 
 . Complete any other configurations you require, then start {microshift-short} by running the following command:
 +
@@ -76,7 +82,6 @@ $ oc get pod -A -o wide
 ----
 +
 .Example output
-+
 [source,text]
 ----
 NAMESPACE                  NAME                                      READY   STATUS    RESTARTS   AGE   IP                      NODE           NOMINATED NODE   READINESS GATES

--- a/modules/nw-ovn-kubernetes-limitations.adoc
+++ b/modules/nw-ovn-kubernetes-limitations.adoc
@@ -7,7 +7,8 @@
 [id="nw-ovn-kubernetes-limitations_{context}"]
 = OVN-Kubernetes IPv6 and dual-stack limitations
 
-The OVN-Kubernetes network plugin has the following limitations:
+[role="abstract"]
+IPv6 and dual-stack networking for the OVN-Kubernetes network plugin in {microshift-short} have specific limitations that affect gateway configuration, routing, and cluster stability.
 
 // The foll limitation is also recorded in the installation section.
 ifndef::microshift[]


### PR DESCRIPTION
Backport of https://github.com/openshift/openshift-docs/pull/108440 to enterprise-4.21.

6 files included, 0 files excluded.

All files from the source PR are present on enterprise-4.21.

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
