### PR TITLE
[enterprise-4.16] 17084 manual CPs

### DIFF
--- a/modules/nw-ovn-kuberentes-limitations.adoc
+++ b/modules/nw-ovn-kuberentes-limitations.adoc
@@ -6,7 +6,8 @@
 [id="nw-ovn-kubernetes-limitations_{context}"]
 = OVN-Kubernetes IPv6 and dual-stack limitations
 
-The OVN-Kubernetes network plugin has the following limitations:
+[role="abstract"]
+IPv6 and dual-stack networking for the OVN-Kubernetes network plugin in {microshift-short} have specific limitations that affect gateway configuration, routing, and cluster stability.
 
 // The foll limitation is also recorded in the installation section.
 * For clusters configured for dual-stack networking, both IPv4 and IPv6 traffic must use the same network interface as the default gateway.


### PR DESCRIPTION
Cherry picked from: 459b90d2ea3d30f939ffc3e76212c469082f6735
xref: https://github.com/openshift/openshift-docs/pull/108440

The original PR touched 6 files. This one only touches 1. 5/6 of the files do not exist in this branch. Confirmed via https://github.com/openshift/openshift-docs/pull/79226 / blame that the content was only introduced in MS version 4.17. 