### PR TITLE
OSDOCS-18665-18: CP review for CORE-1

### DIFF
--- a/networking/networking_overview/cidr-range-definitions.adoc
+++ b/networking/networking_overview/cidr-range-definitions.adoc
@@ -17,7 +17,7 @@ To ensure stable and accurate network routing in {product-title} clusters that u
 For {product-title} 4.17 and later versions, clusters use `169.254.0.0/17` for IPv4 and `fd69::/112` for IPv6 as the default masquerade subnet. You must avoid these ranges. For upgraded clusters, there is no change to the default masquerade subnet.
 ====
 
-The following subnet types and are mandatory for a cluster that uses OVN-Kubernetes:
+The following subnet types are mandatory for a cluster that uses OVN-Kubernetes:
 
 * Join: Uses a join switch to connect gateway routers to distributed routers. A join switch reduces the number of IP addresses for a distributed router. For a cluster that uses the OVN-Kubernetes plugin, an IP address from a dedicated subnet is assigned to any logical port that attaches to the join switch.
 * Masquerade: Prevents collisions for identical source and destination IP addresses that are sent from a node as hairpin traffic to the same node after a load balancer makes a routing decision.


### PR DESCRIPTION
Very minor typo that was spotted during the remediation review. No reference PR needed.

Version(s):
4.18

Issue:
[OSDOCS-18665](https://redhat.atlassian.net/browse/OSDOCS-18665)

Link to docs preview:
https://108795--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/networking_overview/cidr-range-definitions.html

