### PR TITLE
OSDOCS-17077: Canary update CQA

### DIFF
--- a/modules/update-canary-about.adoc
+++ b/modules/update-canary-about.adoc
@@ -1,0 +1,52 @@
+:_mod-docs-content-type: CONCEPT
+[id="update-using-custom-machine-config-pools-about-mcp_{context}"]
+= About the canary rollout update process and MCPs
+
+[role="_abstract"]
+In {product-title}, nodes are not considered individually. Instead, they are grouped into machine config pools (MCPs).
+By default, nodes in an {product-title} cluster are grouped into two MCPs: one for the control plane nodes and one for the worker nodes.
+
+An {product-title} update affects all MCPs concurrently.
+
+During the update, the Machine Config Operator (MCO) drains and cordons all nodes within an MCP up to the specified `maxUnavailable` number of nodes, if a max number is specified.
+By default, `maxUnavailable` is set to `1`.
+Draining and cordoning a node deschedules all pods on the node and marks the node as unschedulable.
+
+After the node is drained, the Machine Config Daemon applies a new machine configuration, which can include updating the operating system (OS). Updating the OS requires the host to reboot.
+
+
+[id="using-custom-mcps_{context}"]
+== Using custom machine config pools
+
+To prevent specific nodes from being updated, you can create custom MCPs.
+Because the MCO does not update nodes within paused MCPs, you can pause the MCPs containing nodes that you do not want to update before initiating a cluster update.
+
+Using one or more custom MCPs can give you more control over the sequence in which you update your worker nodes.
+For example, after you update the nodes in the first MCP, you can verify the application compatibility and then update the rest of the nodes gradually to the new version.
+
+[WARNING]
+====
+The default setting for `maxUnavailable` is `1` for all the machine config pools in {product-title}. It is recommended to not change this value and update one control plane node at a time. Do not change this value to `3` for the control plane pool.
+====
+
+[NOTE]
+====
+To ensure the stability of the control plane, creating a custom MCP from the control plane nodes is not supported. The Machine Config Operator (MCO) ignores any custom MCP created for the control plane nodes.
+====
+
+
+[id="custom-mcp-considerations_{context}"]
+== Considerations when using custom machine config pools
+
+Give careful consideration to the number of MCPs that you create and the number of nodes in each MCP, based on your workload deployment topology.
+For example, if you must fit updates into specific maintenance windows, you must know how many nodes {product-title} can update within a given window.
+This number is dependent on your unique cluster and workload characteristics.
+
+You must also consider how much extra capacity is available in your cluster to determine the number of custom MCPs and the amount of nodes within each MCP.
+In a case where your applications fail to work as expected on newly updated nodes, you can cordon and drain those nodes in the pool, which moves the application pods to other nodes.
+However, you must determine whether the available nodes in the remaining MCPs can provide sufficient quality-of-service (QoS) for your applications.
+
+[NOTE]
+====
+You can use this update process with all documented {product-title} update processes. However, the process does not work with {op-system-base-full} machines, which are updated using Ansible playbooks.
+====

--- a/modules/update-canary-example.adoc
+++ b/modules/update-canary-example.adoc
@@ -1,0 +1,56 @@
+:_mod-docs-content-type: CONCEPT
+[id="example_{context}"]
+= Example Canary update strategy
+
+[role="_abstract"]
+To better understand how the canary rollout strategy works, it is useful to consider an example of an update using the strategy.
+
+The following example describes a canary update strategy where you have a cluster with 100 nodes with 10% excess capacity, you have maintenance windows that must not exceed 4 hours, and you know that it takes no longer than 8 minutes to drain and reboot a worker node.
+
+[NOTE]
+====
+The previous values are an example only.
+The time it takes to drain a node might vary depending on factors such as workloads.
+====
+
+[id="defining-custom-mcps_{context}"]
+== Definition of custom machine config pools
+
+In order to organize the worker node updates into separate stages, you can begin by defining the following machine config pools:
+
+* *workerpool-canary* with 10 nodes
+* *workerpool-A* with 30 nodes
+* *workerpool-B* with 30 nodes
+* *workerpool-C* with 30 nodes
+
+[id="updating-canary-worker-pool_{context}"]
+== Update of the canary worker pool
+
+During your first maintenance window, you pause the machine config pools (MCPs) for *workerpool-A*, *workerpool-B*, and *workerpool-C*, and then initiate the cluster update.
+This updates components that run on top of {product-title} and the 10 nodes that are part of the unpaused *workerpool-canary* MCP.
+The other three MCPs are not updated because they were paused.
+
+[id="determining-remaining-worker-pools_{context}"]
+== Whether or not to proceed with the remaining worker pool updates
+
+If for some reason you determine that your cluster or workload health was negatively affected by the *workerpool-canary* update, you then cordon and drain all nodes in that pool while still maintaining sufficient capacity until you have diagnosed and resolved the problem.
+When everything is working as expected, you evaluate the cluster and workload health before deciding to unpause, and thus update, *workerpool-A*, *workerpool-B*, and *workerpool-C* in succession during each additional maintenance window.
+
+Managing worker node updates using custom machine config pools (MCPs) provides flexibility, however it can be a time-consuming process that requires you execute multiple commands. This complexity can result in errors that might affect the entire cluster. It is recommended that you carefully consider your organizational needs and carefully plan the implementation of the process before you start.
+
+//The following wording comes from https://github.com/openshift/openshift-docs/pull/34704, not yet finalized
+
+[IMPORTANT]
+====
+Pausing a machine config pool prevents the Machine Config Operator from applying any configuration changes on the associated nodes. Pausing an MCP also prevents any automatically rotated certificates from being pushed to the associated nodes, including the automatic CA rotation of the `kube-apiserver-to-kubelet-signer` CA certificate.
+
+If the MCP is paused when the `kube-apiserver-to-kubelet-signer` CA certificate expires and the MCO attempts to automatically renew the certificate, the MCO cannot push the newly rotated certificates to those nodes. This causes failure in multiple `oc` commands, including `oc debug`, `oc logs`, `oc exec`, and `oc attach`. You receive alerts in the Alerting UI of the {product-title} web console if an MCP is paused when the certificates are rotated.
+
+Pausing an MCP should be done with careful consideration about the `kube-apiserver-to-kubelet-signer` CA certificate expiration and for short periods of time only.
+====
+
+[NOTE]
+====
+It is not recommended to update the MCPs to different {product-title} versions. For example, do not update one MCP from 4.y.10 to 4.y.11 and another to 4.y.12.
+This scenario has not been tested and might result in an undefined cluster state.
+====

--- a/modules/update-canary-performing.adoc
+++ b/modules/update-canary-performing.adoc
@@ -1,0 +1,12 @@
+
+:_mod-docs-content-type: PROCEDURE
+[id="update-using-custom-machine-config-pools-update_{context}"]
+= Performing the cluster update
+
+[role="_abstract"]
+After the machine config pools (MCP) enter a ready state, you can perform the cluster update.
+
+.Procedure
+* See one of the following update methods, as appropriate for your cluster:
+** "Updating a cluster using the web console"
+** "Updating a cluster using the CLI"

--- a/modules/update-using-custom-machine-config-pools-about.adoc
+++ b/modules/update-using-custom-machine-config-pools-about.adoc
@@ -6,7 +6,10 @@
 [id="update-using-custom-machine-config-pools-about_{context}"]
 = About performing a canary rollout update
 
-The following steps outline the high-level workflow of the canary rollout update process:
+[role="_abstract"]
+The process of a canary update can be understood as several high-level steps.
+
+The following steps outline the high-level workflow of the process:
 
 . Create custom machine config pools (MCP) based on the worker pool.
 +

--- a/modules/update-using-custom-machine-config-pools-inheritance.adoc
+++ b/modules/update-using-custom-machine-config-pools-inheritance.adoc
@@ -6,8 +6,8 @@
 [id="update-using-custom-machine-config-pools-mcp-inheritance_{context}"]
 = Managing machine configuration inheritance for a worker pool canary
 
-
-You can configure a machine config pool (MCP) canary to inherit any `MachineConfig` assigned to an existing MCP. 
+[role="_abstract"]
+You can configure a machine config pool (MCP) canary to inherit any `MachineConfig` assigned to an existing MCP.
 This configuration is useful when you want to use an MCP canary to test as you update nodes one at a time for an existing MCP.
 
 .Prerequisites
@@ -107,14 +107,14 @@ $ oc create -f new-machineconfig.yaml
 
 . Create the new canary MCP and add machines from the MCP you created in the previous steps. The following example creates an MCP called `worker-perf-canary`, and adds machines from the `worker-perf` MCP that you previosuly created.
 +
-.. Label the canary worker node `worker-a` by running the following command: 
+.. Label the canary worker node `worker-a` by running the following command:
 +
 [source,terminal]
 ----
 $ oc label node worker-a node-role.kubernetes.io/worker-perf-canary=''
 ----
 +
-.. Remove the canary worker node `worker-a` from the original MCP by running the following command: 
+.. Remove the canary worker node `worker-a` from the original MCP by running the following command:
 +
 [source,terminal]
 ----
@@ -136,13 +136,16 @@ spec:
       - {
          key: machineconfiguration.openshift.io/role,
          operator: In,
-         values: [worker,worker-perf,worker-perf-canary] <1>
+         values: [worker,worker-perf,worker-perf-canary]
         }
   nodeSelector:
     matchLabels:
       node-role.kubernetes.io/worker-perf-canary: ""
 ----
-<1> Optional value. This example includes `worker-perf-canary` as an additional value. You can use a value in this way to configure members of an additional `MachineConfig`.
++
+where:
++
+`spec.machineConfigSelector.matchExpressions.values`:: Specifies a value you can use to configure members of an additional `MachineConfig`. This example includes `worker-perf-canary` as an additional value. This is an optional value.
 +
 .. Create the new `worker-perf-canary` by running the following command:
 +
@@ -157,7 +160,7 @@ $ oc create -f machineConfigPool-Canary.yaml
 machineconfigpool.machineconfiguration.openshift.io/worker-perf-canary created
 ----
 
-. Check if the `MachineConfig` is inherited in `worker-perf-canary`. 
+. Check if the `MachineConfig` is inherited in `worker-perf-canary`.
 +
 .. Verify that no MCP is degraded by running the following command:
 +
@@ -227,7 +230,7 @@ The output should include the updated `crashekernel` value, for example:
 crashkernel=512M
 ----
 
-. Optional: If you are satisfied with the upgrade, you can return `worker-a` to `worker-perf`. 
+. Optional: If you are satisfied with the upgrade, you can return `worker-a` to `worker-perf`.
 +
 .. Return `worker-a` to `worker-perf` by running the following command:
 +
@@ -236,7 +239,7 @@ crashkernel=512M
 $ oc label node worker-a node-role.kubernetes.io/worker-perf=''
 ----
 +
-.. Remove `worker-a` from the canary MCP by running the following command: 
+.. Remove `worker-a` from the canary MCP by running the following command:
 +
 [source,terminal]
 ----

--- a/modules/update-using-custom-machine-config-pools-mcp-remove.adoc
+++ b/modules/update-using-custom-machine-config-pools-mcp-remove.adoc
@@ -6,6 +6,7 @@
 [id="update-using-custom-machine-config-pools-mcp-remove_{context}"]
 = Moving a node to the original machine config pool
 
+[role="_abstract"]
 After you update and verify applications on nodes in a custom machine config pool (MCP), move the nodes back to their original MCP by removing the custom label that you added to the nodes.
 
 [IMPORTANT]

--- a/modules/update-using-custom-machine-config-pools-mcp.adoc
+++ b/modules/update-using-custom-machine-config-pools-mcp.adoc
@@ -6,6 +6,7 @@
 [id="update-using-custom-machine-config-pools-mcp_{context}"]
 = Creating machine config pools to perform a canary rollout update
 
+[role="_abstract"]
 To perform a canary rollout update, you must first create one or more custom machine config pools (MCP).
 
 .Procedure
@@ -56,22 +57,25 @@ node/ci-ln-gtrwm8t-f76d1-spbl7-worker-a-xk76k labeled
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfigPool
 metadata:
-  name: workerpool-canary <1>
+  name: workerpool-canary
 spec:
   machineConfigSelector:
     matchExpressions:
       - {
          key: machineconfiguration.openshift.io/role,
          operator: In,
-         values: [worker,workerpool-canary] <2>
+         values: [worker,workerpool-canary]
         }
   nodeSelector:
     matchLabels:
-      node-role.kubernetes.io/workerpool-canary: "" <3>
+      node-role.kubernetes.io/workerpool-canary: ""
 ----
-<1> Specify a name for the MCP.
-<2> Specify the `worker` and custom MCP name.
-<3> Specify the custom label you added to the nodes that you want in this pool.
++
+where:
++
+`metadata.name`:: Specifies a name for the MCP.
+`spec.machineConfigSelector.matchExpressions.values`:: Specifies the `worker` and custom MCP name.
+`spec.nodeSelectormatchLabels.node-role.kubernetes.io/workerpool-canary`:: Specifies the custom label you added to the nodes that you want in this pool.
 
 .. Create the `MachineConfigPool` object by running the following command:
 +

--- a/modules/update-using-custom-machine-config-pools-pause.adoc
+++ b/modules/update-using-custom-machine-config-pools-pause.adoc
@@ -6,11 +6,12 @@
 [id="update-using-custom-machine-config-pools-pause_{context}"]
 = Pausing the machine config pools
 
+[role="_abstract"]
 After you create your custom machine config pools (MCPs), you then pause those MCPs. Pausing an MCP prevents the Machine Config Operator (MCO) from updating the nodes associated with that MCP.
 
 .Procedure
 
-. Patch the MCP that you want paused by running the following command:
+* Patch the MCP that you want paused by running the following command:
 +
 [source,terminal]
 ----

--- a/modules/update-using-custom-machine-config-pools-unpause.adoc
+++ b/modules/update-using-custom-machine-config-pools-unpause.adoc
@@ -6,6 +6,7 @@
 [id="update-using-custom-machine-config-pools-unpause_{context}"]
 = Unpausing the machine config pools
 
+[role="_abstract"]
 After the {product-title} update is complete, unpause your custom machine config pools (MCP) one at a time. Unpausing an MCP allows the Machine Config Operator (MCO) to update the nodes associated with that MCP.
 
 .Procedure
@@ -45,7 +46,7 @@ $ oc get machineconfigpools
 . Test your applications on the updated nodes to ensure that they are working as expected.
 
 . Repeat this process for any other paused MCPs, one at a time.
-
++
 [NOTE]
 ====
 In case of a failure, such as your applications not working on the updated nodes, you can cordon and drain the nodes in the pool, which moves the application pods to other nodes to help maintain the quality-of-service for the applications. This first MCP should be no larger than the excess capacity.

--- a/updating/updating_a_cluster/update-using-custom-machine-config-pools.adoc
+++ b/updating/updating_a_cluster/update-using-custom-machine-config-pools.adoc
@@ -6,128 +6,22 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-////
-WARNING: This assembly has been moved into a subdirectory for 4.14+. Changes to this assembly for earlier versions should be done in separate PRs based off of their respective version branches. Otherwise, your cherry picks may fail.
+[role="_abstract"]
+For a more controlled rollout of worker node updates, you can use a _canary update_.
+A canary update is an update strategy where worker node updates are performed in discrete, sequential stages instead of updating all worker nodes at the same time.
 
-To do: Remove this comment once 4.13 docs are EOL.
-////
-
-A _canary update_ is an update strategy where worker node updates are performed in discrete, sequential stages instead of updating all worker nodes at the same time.
 This strategy can be useful in the following scenarios:
 
-* You want a more controlled rollout of worker node updates to ensure that mission-critical applications stay available during the whole update, even if the update process causes your applications to fail.
+* You want a more controlled rollout of worker node updates to ensure that mission-critical applications stay available during the entire update, even if the update process causes your applications to fail.
 * You want to update a small subset of worker nodes, evaluate cluster and workload health over a period of time, and then update the remaining nodes.
 * You want to fit worker node updates, which often require a host reboot, into smaller defined maintenance windows when it is not possible to take a large maintenance window to update the entire cluster at one time.
 
 In these scenarios, you can create multiple custom machine config pools (MCPs) to prevent certain worker nodes from updating when you update the cluster.
 After the rest of the cluster is updated, you can update those worker nodes in batches at appropriate times.
 
-[id="example_{context}"]
-== Example Canary update strategy
+include::modules/update-canary-example.adoc[leveloffset=+1]
 
-The following example describes a canary update strategy where you have a cluster with 100 nodes with 10% excess capacity, you have maintenance windows that must not exceed 4 hours, and you know that it takes no longer than 8 minutes to drain and reboot a worker node.
-
-[NOTE]
-====
-The previous values are an example only.
-The time it takes to drain a node might vary depending on factors such as workloads.
-====
-
-
-[id="defining-custom-mcps_{context}"]
-=== Defining custom machine config pools
-
-In order to organize the worker node updates into separate stages, you can begin by defining the following MCPs:
-
-* *workerpool-canary* with 10 nodes
-* *workerpool-A* with 30 nodes
-* *workerpool-B* with 30 nodes
-* *workerpool-C* with 30 nodes
-
-
-
-[id="updating-canary-worker-pool_{context}"]
-=== Updating the canary worker pool
-
-During your first maintenance window, you pause the MCPs for *workerpool-A*, *workerpool-B*, and *workerpool-C*, and then initiate the cluster update.
-This updates components that run on top of {product-title} and the 10 nodes that are part of the unpaused *workerpool-canary* MCP.
-The other three MCPs are not updated because they were paused.
-
-
-[id="determining-remaining-worker-pools_{context}"]
-=== Determining whether to proceed with the remaining worker pool updates
-
-If for some reason you determine that your cluster or workload health was negatively affected by the *workerpool-canary* update, you then cordon and drain all nodes in that pool while still maintaining sufficient capacity until you have diagnosed and resolved the problem.
-When everything is working as expected, you evaluate the cluster and workload health before deciding to unpause, and thus update, *workerpool-A*, *workerpool-B*, and *workerpool-C* in succession during each additional maintenance window.
-
-Managing worker node updates using custom MCPs provides flexibility, however it can be a time-consuming process that requires you execute multiple commands. This complexity can result in errors that might affect the entire cluster. It is recommended that you carefully consider your organizational needs and carefully plan the implementation of the process before you start.
-
-//The following wording comes from https://github.com/openshift/openshift-docs/pull/34704, not yet finalized
-
-[IMPORTANT]
-====
-Pausing a machine config pool prevents the Machine Config Operator from applying any configuration changes on the associated nodes. Pausing an MCP also prevents any automatically rotated certificates from being pushed to the associated nodes, including the automatic CA rotation of the `kube-apiserver-to-kubelet-signer` CA certificate.
-
-If the MCP is paused when the `kube-apiserver-to-kubelet-signer` CA certificate expires and the MCO attempts to automatically renew the certificate, the MCO cannot push the newly rotated certificates to those nodes. This causes failure in multiple `oc` commands, including `oc debug`, `oc logs`, `oc exec`, and `oc attach`. You receive alerts in the Alerting UI of the {product-title} web console if an MCP is paused when the certificates are rotated.
-
-Pausing an MCP should be done with careful consideration about the `kube-apiserver-to-kubelet-signer` CA certificate expiration and for short periods of time only.
-====
-
-[NOTE]
-====
-It is not recommended to update the MCPs to different {product-title} versions. For example, do not update one MCP from 4.y.10 to 4.y.11 and another to 4.y.12.
-This scenario has not been tested and might result in an undefined cluster state.
-====
-
-[id="update-using-custom-machine-config-pools-about-mcp_{context}"]
-== About the canary rollout update process and MCPs
-
-In {product-title}, nodes are not considered individually. Instead, they are grouped into machine config pools (MCPs).
-By default, nodes in an {product-title} cluster are grouped into two MCPs: one for the control plane nodes and one for the worker nodes.
-An {product-title} update affects all MCPs concurrently.
-
-During the update, the Machine Config Operator (MCO) drains and cordons all nodes within an MCP up to the specified `maxUnavailable` number of nodes, if a max number is specified.
-By default, `maxUnavailable` is set to `1`.
-Draining and cordoning a node deschedules all pods on the node and marks the node as unschedulable.
-
-After the node is drained, the Machine Config Daemon applies a new machine configuration, which can include updating the operating system (OS). Updating the OS requires the host to reboot.
-
-
-[id="using-custom-mcps_{context}"]
-=== Using custom machine config pools
-
-To prevent specific nodes from being updated, you can create custom MCPs.
-Because the MCO does not update nodes within paused MCPs, you can pause the MCPs containing nodes that you do not want to update before initiating a cluster update.
-
-Using one or more custom MCPs can give you more control over the sequence in which you update your worker nodes.
-For example, after you update the nodes in the first MCP, you can verify the application compatibility and then update the rest of the nodes gradually to the new version.
-
-[WARNING]
-====
-The default setting for `maxUnavailable` is `1` for all the machine config pools in {product-title}. It is recommended to not change this value and update one control plane node at a time. Do not change this value to `3` for the control plane pool.
-====
-
-[NOTE]
-====
-To ensure the stability of the control plane, creating a custom MCP from the control plane nodes is not supported. The Machine Config Operator (MCO) ignores any custom MCP created for the control plane nodes.
-====
-
-
-[id="custom-mcp-considerations_{context}"]
-=== Considerations when using custom machine config pools
-
-Give careful consideration to the number of MCPs that you create and the number of nodes in each MCP, based on your workload deployment topology.
-For example, if you must fit updates into specific maintenance windows, you must know how many nodes {product-title} can update within a given window.
-This number is dependent on your unique cluster and workload characteristics.
-
-You must also consider how much extra capacity is available in your cluster to determine the number of custom MCPs and the amount of nodes within each MCP.
-In a case where your applications fail to work as expected on newly updated nodes, you can cordon and drain those nodes in the pool, which moves the application pods to other nodes.
-However, you must determine whether the available nodes in the remaining MCPs can provide sufficient quality-of-service (QoS) for your applications.
-
-[NOTE]
-====
-You can use this update process with all documented {product-title} update processes. However, the process does not work with {op-system-base-full} machines, which are updated using Ansible playbooks.
-====
+include::modules/update-canary-about.adoc[leveloffset=+1]
 
 // About performing a canary rollout update
 include::modules/update-using-custom-machine-config-pools-about.adoc[leveloffset=+1]
@@ -141,15 +35,13 @@ include::modules/update-using-custom-machine-config-pools-inheritance.adoc[level
 // Pausing the machine config pools
 include::modules/update-using-custom-machine-config-pools-pause.adoc[leveloffset=+1]
 
-[id="update-using-custom-machine-config-pools-update_{context}"]
-== Performing the cluster update
+include::modules/update-canary-performing.adoc[leveloffset=+1]
 
-After the machine config pools (MCP) enter a ready state, you can perform the cluster update. See one of the following update methods, as appropriate for your cluster:
+[role="_additional-resources"]
+.Additional resources
 
 * xref:../../updating/updating_a_cluster/updating-cluster-web-console.adoc#update-upgrading-web_updating-cluster-web-console[Updating a cluster using the web console]
 * xref:../../updating/updating_a_cluster/updating-cluster-cli.adoc#update-upgrading-cli_updating-cluster-cli[Updating a cluster using the CLI]
-
-After the cluster update is complete, you can begin to unpause the MCPs one at a time.
 
 // Unpausing the machine config pools
 include::modules/update-using-custom-machine-config-pools-unpause.adoc[leveloffset=+1]


### PR DESCRIPTION
[OSDOCS-17077](https://issues.redhat.com/browse/OSDOCS-17077)

Version(s): 4.16+

This PR is one of several to perform a CQA of the updating procedures in the OTA docs.

No new content added as part of this PR

QE review: I did not change any technical statements, however let me know if you think anything needs QE.

Preview: [Performing a canary rollout update](https://108812--ocpdocs-pr.netlify.app/openshift-enterprise/latest/updating/updating_a_cluster/update-using-custom-machine-config-pools)
