### PR TITLE
OSDOCS-18174 updated removed and deprecated tables

### DIFF
--- a/modules/rn-ocp-release-notes-deprecated-removed-tables.adoc
+++ b/modules/rn-ocp-release-notes-deprecated-removed-tables.adoc
@@ -8,12 +8,12 @@
 .Images deprecated and removed tracker
 [cols="4,1,1,1",options="header"]
 |====
-|Feature |4.19 |4.20 |4.21
+|Feature |4.20 |4.21 |4.22
 
 |Cluster Samples Operator
 |Deprecated
 |Deprecated
-|Deprecated
+|
 |====
 
 
@@ -23,57 +23,52 @@
 .Installation deprecated and removed tracker
 [cols="4,1,1,1",options="header"]
 |====
-|Feature |4.19 |4.20 |4.21
+|Feature |4.20 |4.21 |4.22
 
 |`--cloud` parameter for `oc adm release extract`
 |Deprecated
 |Deprecated
-|Deprecated
+|
 
 |CoreDNS wildcard queries for the `cluster.local` domain
 |Deprecated
 |Deprecated
-|Deprecated
+|
 
 |`compute.platform.openstack.rootVolume.type` for {rh-openstack}
 |Deprecated
 |Deprecated
-|Deprecated
+|
 
 |`controlPlane.platform.openstack.rootVolume.type` for {rh-openstack}
 |Deprecated
 |Deprecated
-|Deprecated
+|
 
 |`ingressVIP` and `apiVIP` settings in the `install-config.yaml` file for installer-provisioned infrastructure clusters
 |Deprecated
 |Deprecated
-|Deprecated
-
-|Package-based {op-system-base} compute machines
-|Removed
-|Removed
-|Removed
+|
 
 |`platform.aws.preserveBootstrapIgnition` parameter for {aws-first}
 |Deprecated
 |Deprecated
-|Deprecated
+|
 
 |Installing a cluster on {aws-short} with compute nodes in {aws-short} Outposts
 |Deprecated
 |Deprecated
-|Deprecated
+|
 
 |Deploying managed clusters using `SiteConfig` and the {ztp} workflow
 |Deprecated
-|Deprecated
 |Removed
+|
 
 |Installing a cluster using Fujitsu iRMC drivers on bare-metal machines
 |General Availability
-|General Availability
 |Deprecated
+|
 |====
 
 [id="ocp-release-note-machine-manage-dep-rem_{context}"]
@@ -82,17 +77,17 @@
 .Machine management deprecated and removed tracker
 [cols="4,1,1,1",options="header"]
 |====
-|Feature |4.19 |4.20 |4.21
+|Feature |4.20 |4.21 |4.22
 
 |Confidential Computing with AMD Secure Encrypted Virtualization for {gcp-first}
-|General Availability
 |Deprecated
 |Deprecated
+|
 
 |Managing bare-metal machines using Fujitsu iRMC drivers
 |General Availability
-|General Availability
 |Deprecated
+|
 |====
 
 [id="ocp-release-note-networking-dep-rem_{context}"]
@@ -101,12 +96,12 @@
 .Networking deprecated and removed tracker
 [cols="4,1,1,1",options="header"]
 |====
-|Feature |4.19 |4.20 |4.21
+|Feature |4.20 |4.21 |4.22
 
 |iptables
 |Deprecated
 |Deprecated
-|Deprecated
+|
 |====
 
 
@@ -116,27 +111,22 @@
 .Node deprecated and removed tracker
 [cols="4,1,1,1",options="header"]
 |====
-|Feature |4.19 |4.20 |4.21
+|Feature |4.20 |4.21 |4.22
 
 |`ImageContentSourcePolicy` (ICSP) objects
 |Deprecated
 |Deprecated
-|Deprecated
+|
 
 |Kubernetes topology label `failure-domain.beta.kubernetes.io/zone`
 |Deprecated
 |Deprecated
-|Deprecated
+|
 
 |Kubernetes topology label `failure-domain.beta.kubernetes.io/region`
 |Deprecated
 |Deprecated
-|Deprecated
-
-|cgroup v1
-|Removed
-|Removed
-|Removed
+|
 |====
 
 
@@ -146,18 +136,18 @@
 .OpenShift CLI (oc) deprecated and removed tracker
 [cols="4,1,1,1",options="header"]
 |====
-|Feature |4.19 |4.20 |4.21
+|Feature |4.20 |4.21 |4.22
 
 |oc-mirror plugin v1
 |Deprecated
 |Deprecated
-|Deprecated
+|
 
 
 |Docker v2 registries
-|General Availability
 |Deprecated
 |Deprecated
+|
 |====
 
 
@@ -169,43 +159,13 @@
 .Operator lifecycle and development deprecated and removed tracker
 [cols="4,1,1,1",options="header"]
 |====
-|Feature |4.19 |4.20 |4.21
-
-|Operator SDK
-|Removed
-|Removed
-|Removed
-
-|Scaffolding tools for Ansible-based Operator projects
-|Removed
-|Removed
-|Removed
-
-|Scaffolding tools for Helm-based Operator projects
-|Removed
-|Removed
-|Removed
-
-|Scaffolding tools for Go-based Operator projects
-|Removed
-|Removed
-|Removed
-
-|Scaffolding tools for Hybrid Helm-based Operator projects
-|Removed
-|Removed
-|Removed
-
-|Scaffolding tools for Java-based Operator projects
-|Removed
-|Removed
-|Removed
+|Feature |4.20 |4.21 |4.22
 
 // Do not remove the SQLite database... entry until otherwise directed by the Operator Framework PM
 |SQLite database format for Operator catalogs
 |Deprecated
 |Deprecated
-|Deprecated
+|
 |====
 
 
@@ -219,19 +179,13 @@
 //|====
 
 
-== Storage deprecated and removed features
+//== Storage deprecated and removed features
 
-.Storage deprecated and removed tracker
-[cols="4,1,1,1",options="header"]
-|====
-|Feature |4.19 |4.20 |4.21
-
-|Shared Resources CSI Driver Operator
-|Removed
-|Removed
-|Removed
-|====
-
+//.Storage deprecated and removed tracker
+//[cols="4,1,1,1",options="header"]
+//|====
+//|Feature |4.19 |4.20 |4.21
+//|====
 
 //[id="ocp-clusters-dep-rem_{context}"]
 //== Updating clusters deprecated and removed features
@@ -249,17 +203,12 @@
 .Web console deprecated and removed tracker
 [cols="4,1,1,1",options="header"]
 |====
-|Feature |4.19 |4.20 |4.21
+|Feature |4.20 |4.21 |4.22
 
 |`useModal` hook for dynamic plugin SDK
 |Deprecated
 |Deprecated
-|Deprecated
-
-|Patternfly 4
-|Removed
-|Removed
-|Removed
+|
 |====
 
 
@@ -269,10 +218,10 @@
 .Workloads deprecated and removed tracker
 [cols="4,1,1,1",options="header"]
 |====
-|Feature |4.19 |4.20 |4.21
+|Feature |4.20 |4.21 |4.22
 
 |`DeploymentConfig` objects
 |Deprecated
 |Deprecated
-|Deprecated
+|
 |====

--- a/modules/rn-ocp-release-notes-technology-preview.adoc
+++ b/modules/rn-ocp-release-notes-technology-preview.adoc
@@ -22,17 +22,17 @@ In the following tables, features are marked with the following statuses:
 .Authentication and authorization Technology Preview tracker
 [cols="4,1,1,1",options="header"]
 |====
-|Feature |4.19 |4.20 |4.21
+|Feature |4.20 |4.21 |4.22
 
 |Pod security admission restricted enforcement
 |Technology Preview
 |Technology Preview
-|Technology Preview
+|
 
 |Direct authentication with an external OIDC identity provider
-|Technology Preview
 |General Availability
 |General Availability
+|
 |====
 
 
@@ -74,37 +74,32 @@ In the following tables, features are marked with the following statuses:
 .Extensions Technology Preview tracker
 [cols="4,1,1,1",options="header"]
 |====
-|Feature |4.19 |4.20 |4.21
-
-|{olmv1-first}
-|General Availability
-|General Availability
-|General Availablity
+|Feature |4.20 |4.21 |4.22
 
 |{olmv1} runtime validation of container images using sigstore signatures
 |Technology Preview
 |Technology Preview
-|Technology Preview
+|
 
 |{olmv1} permissions preflight check for cluster extensions
 |Technology Preview
 |Technology Preview
-|Technology Preview
+|
 
 |{olmv1} deploying a cluster extension in a specified namespace
 |Technology Preview
 |Technology Preview
-|Technology Preview
+|
 
 |{olmv1} deploying a cluster extension that uses webhooks
-|Not Available
 |Technology Preview
 |General Availability
+|
 
 |{olmv1} software catalog
 |Not Available
-|Not Available
 |Technology Preview
+|
 |====
 
 
@@ -114,98 +109,78 @@ In the following tables, features are marked with the following statuses:
 .Installation Technology Preview tracker
 [cols="4,1,1,1",options="header"]
 |====
-|Feature |4.19 |4.20 |4.21
+|Feature |4.20 |4.21 |4.22
 
 // All GA in 4.17 notes for oci-first
 |Adding kernel modules to nodes with kvc
 |Technology Preview
 |Technology Preview
-|Technology Preview
-
-|Enabling NIC partitioning for SR-IOV devices
-|General Availability
-|General Availability
-|General Availability
-
-|User-defined labels and tags for {gcp-first}
-|General Availability
-|General Availability
-|General Availability
+|
 
 |Installing a cluster on Alibaba Cloud by using Assisted Installer
 |Technology Preview
 |Technology Preview
-|Technology Preview
-
-|Installing a cluster on {azure-first} with confidential VMs
-|General Availability
-|General Availability
-|General Availability
+|
 
 |Dedicated disk for etcd on {azure-full}
-|Not Available
 |Technology Preview
 |Technology Preview
+|
 
 |Mount shared entitlements in BuildConfigs in RHEL
 |Technology Preview
 |Technology Preview
-|Technology Preview
+|
 
 |OpenShift zones support for vSphere host groups
 |Technology Preview
 |Technology Preview
-|Technology Preview
+|
 
 |Selectable Cluster Inventory
 |Technology Preview
 |Technology Preview
-|Technology Preview
-
-|Installing a cluster on {gcp-short} using the Cluster API implementation
-|General Availability
-|General Availability
-|General Availability
+|
 
 |Enabling a user-provisioned DNS on {gcp-short}
 |Technology Preview
-|Technology Preview
 |General Availability
+|
 
 |Enabling a user-provisioned DNS on {azure-full}
 |Not Available
-|Not Available
 |Technology Preview
+|
 
 |Enabling a user-provisioned DNS on {aws-first}
 |Not Available
-|Not Available
 |Technology Preview
+|
 
 |Installing a cluster using {gcp-first} private and restricted API endpoints
 |Not Available
-|Not Available
 |General Availability
+|
 
 |Installing a cluster on {vmw-full} with multiple network interface controllers
-|Technology Preview
 |General Availability
 |General Availability
+|
 
 |Using bare metal as a service
 |Technology Preview
 |Technology Preview
-|Technology Preview
+|
 
 |Running firmware upgrades for hosts in deployed bare metal clusters
 |Technology Preview
-|Technology Preview
 |General Availability
+|
 
 |Changing the CVO log level
-|Not Available
 |Technology Preview
 |Technology Preview
+|
 |====
 
 
@@ -215,27 +190,27 @@ In the following tables, features are marked with the following statuses:
 .Machine Config Operator Technology Preview tracker
 [cols="4,1,1,1",options="header"]
 |====
-|Feature |4.19 |4.20 |4.21
+|Feature |4.20 |4.21 |4.22
 
 |Boot image management for {azure-short} and {vmw-short}
-|Not available
 |Technology Preview
 |General Availability
+|
 
 |Boot image management for control plane nodes
 |Not available
-|Not available
 |Technology Preview
+|
 
 |{image-mode-os-lower} status reporting improvements
 |Not available
-|Not available
 |Technology Preview
+|
 
 |Overriding storage or partition setup
 |Not available
-|Not available
 |Technology Preview
+|
 |====
 
 
@@ -245,67 +220,57 @@ In the following tables, features are marked with the following statuses:
 .Machine management Technology Preview tracker
 [cols="4,1,1,1",options="header"]
 |====
-|Feature |4.19 |4.20 |4.21
+|Feature |4.20 |4.21 |4.22
 
 |Managing machines with the Cluster API for {aws-full}
 |Technology Preview
 |Technology Preview
-|Technology Preview
+|
 
 |Managing machines with the Cluster API for {gcp-full}
 |Technology Preview
 |Technology Preview
-|Technology Preview
+|
 
 |Managing machines with the Cluster API for {ibm-power-server-name}
 |Technology Preview
 |Technology Preview
-|Technology Preview
+|
 
 |Managing machines with the Cluster API for {azure-full}
 |Technology Preview
 |Technology Preview
-|Technology Preview
+|
 
 |Managing machines with the Cluster API for {rh-openstack}
 |Technology Preview
 |Technology Preview
-|Technology Preview
+|
 
 |Managing machines with the Cluster API for {vmw-full}
 |Technology Preview
 |Technology Preview
-|Technology Preview
+|
 
 |Managing machines with the Cluster API for bare metal
 |Technology Preview
 |Technology Preview
-|Technology Preview
+|
 
 |Cloud controller manager for {ibm-power-server-name}
 |Technology Preview
 |Technology Preview
-|Technology Preview
+|
 
 |Adding multiple subnets to an existing {vmw-full} cluster by using compute machine sets
 |Technology Preview
 |Technology Preview
-|Technology Preview
-
-|Configuring Trusted Launch for {azure-full} virtual machines by using machine sets
-|General Availability
-|General Availability
-|General Availability
-
-|Configuring {azure-short} confidential virtual machines by using machine sets
-|General Availability
-|General Availability
-|General Availability
+|
 
 |Bare-metal nodes on {vmw-full} clusters
 |Not Available
-|Not Available
 |Technology Preview
+|
 |====
 
 
@@ -315,27 +280,27 @@ In the following tables, features are marked with the following statuses:
 .Multi-Architecture Technology Preview tracker
 [cols="4,1,1,1",options="header"]
 |====
-|Feature |4.19 |4.20 |4.21
+|Feature |4.20 |4.21 |4.22
 
 |`kdump` on `arm64` architecture
-|Technology Preview
 |General Availability
 |General Availability
+|
 
 |`kdump` on `s390x` architecture
-|Technology Preview
 |General Availability
 |General Availability
+|
 
 |`kdump` on `ppc64le` architecture
-|Technology Preview
 |General Availability
 |General Availability
+|
 
 |Support for configuring the image stream import mode behavior
 |Technology Preview
 |Technology Preview
-|Technology Preview
+|
 |====
 
 
@@ -345,138 +310,92 @@ In the following tables, features are marked with the following statuses:
 .Networking Technology Preview tracker
 [cols="4,1,1,1",options="header"]
 |====
-|Feature |4.19 |4.20 |4.21
+|Feature |4.20 |4.21 |4.22
 
 |eBPF manager Operator
 |Technology Preview
 |Technology Preview
-|Technology Preview
+|
 
 |Advertise using L2 mode the MetalLB service from a subset of nodes, using a specific pool of IP addresses
 |Technology Preview
 |Technology Preview
-|Technology Preview
+|
 
 |Updating the interface-specific safe sysctls list
 |Technology Preview
 |Technology Preview
-|Technology Preview
+|
 
 |Egress service custom resource
 |Technology Preview
 |Technology Preview
-|Technology Preview
+|
 
 |VRF specification in `BGPPeer` custom resource
 |Technology Preview
 |Technology Preview
-|Technology Preview
-
-|VRF specification in `NodeNetworkConfigurationPolicy` custom resource
-|General Availability
-|General Availability
-|General Availability
-
-|Host network settings for SR-IOV VFs
-|General Availability
-|General Availability
-|General Availability
-
-|Integration of MetalLB and FRR-K8s
-|General Availability
-|General Availability
-|General Availability
-
-|Automatic leap seconds handling for PTP grandmaster clocks
-|General Availability
-|General Availability
-|General Availability
-
-|PTP events REST API v2
-|General Availability
-|General Availability
-|General Availability
-
-|OVN-Kubernetes customized `br-ex` bridge on bare metal
-|General Availability
-|General Availability
-|General Availability
+|
 
 |OVN-Kubernetes customized `br-ex` bridge on {vmw-short} and {rh-openstack}
 |Technology Preview
 |Technology Preview
-|Technology Preview
+|
 
 |Live migration to OVN-Kubernetes from {product-title} SDN
 |Not Available
 |Not Available
-|Not Available
-
-|User-defined network segmentation
-|General Availability
-|General Availability
-|General Availability
+|
 
 |Dynamic configuration manager
 |Technology Preview
 |Technology Preview
-|Technology Preview
+|
 
 |SR-IOV Network Operator support for Intel C741 Emmitsburg Chipset
 |Technology Preview
 |Technology Preview
-|Technology Preview
-
-|SR-IOV Network Operator support on ARM architecture
-|General Availability
-|General Availability
-|General Availability
-
-|Gateway API and Istio for Ingress management
-|General Availability
-|General Availability
-|General Availability
+|
 
 |Dual-port NIC for PTP ordinary clock
 |Technology Preview
 |Technology Preview
-|Technology Preview
+|
 
 |DPU Operator
 |Technology Preview
 |Technology Preview
-|Technology Preview
+|
 
 |Fast IPAM for the Whereabouts IPAM CNI plugin
 |Technology Preview
 |Technology Preview
-|Technology Preview
+|
 
 |Unnumbered BGP peering
-|Technology Preview
 |General Availability
 |General Availability
+|
 
 |Load balancing across the aggregated bonded interface with xmitHashPolicy
-|Not Available
 |Technology Preview
 |Technology Preview
+|
 
 |PF Status Relay Operator for high availability with SR-IOV networks
-|Not Available
 |Technology Preview
 |Technology Preview
+|
 
 |Preconfigured user-defined network end points using {mtv-short}
-|Not Available
 |Technology Preview
 |Technology Preview
+|
 
 |Unassisted holdover for PTP devices
-|Not Available
 |Technology Preview
 |General Availability
-
+|
 |====
 
 
@@ -486,85 +405,55 @@ In the following tables, features are marked with the following statuses:
 .Nodes Technology Preview tracker
 [cols="4,1,1,1",options="header"]
 |====
-|Feature |4.19 |4.20 |4.21
+|Feature |4.20 |4.21 |4.22
 
 |`MaxUnavailableStatefulSet` featureset
 |Technology Preview
 |Technology Preview
-|Technology Preview
+|
 
 |sigstore support
-|Technology Preview
 |General Availability
 |General Availability
+|
 
 |Default sigstore `openshift` cluster image policy
 |Technology Preview
-|Technology Preview
 |General Availability
+|
 
 |Linux user namespace support
-|Technology Preview
 |General Availability
 |General Availability
+|
 
 |Attribute-Based GPU Allocation
-|Not Available
 |Technology Preview
 |General Availability
+|
 |====
 
 
-[id="ocp-release-notes-oc-cli-tech-preview_{context}"]
-== OpenShift CLI (oc) Technology Preview features
+//[id="ocp-release-notes-oc-cli-tech-preview_{context}"]
+//== OpenShift CLI (oc) Technology Preview features
 
-.OpenShift CLI (`oc`) Technology Preview tracker
-[cols="4,1,1,1",options="header"]
-|====
-|Feature |4.19 |4.20 |4.21
-
-|oc-mirror plugin v2
-|General Availability
-|General Availability
-|General Availability
-
-|oc-mirror plugin v2 enclave support
-|General Availability
-|General Availability
-|General Availability
-
-|oc-mirror plugin v2 delete functionality
-|General Availability
-|General Availability
-|General Availability
-|====
+//.OpenShift CLI (`oc`) Technology Preview tracker
+//[cols="4,1,1,1",options="header"]
+//|====
+//|Feature |4.20 |4.21 |4.22
+//|====
 
 
-[id="ocp-release-notes-operator-lifecycle-tech-preview_{context}"]
-== Operator lifecycle and development Technology Preview features
+//[id="ocp-release-notes-operator-lifecycle-tech-preview_{context}"]
+//== Operator lifecycle and development Technology Preview features
 
 // "Operator lifecycle" refers to OLMv0 and "development" refers to Operator SDK
 
-.Operator lifecycle and development Technology Preview tracker
-[cols="4,1,1,1",options="header"]
-|====
-|Feature |4.19 |4.20 |4.21
-
-|{olmv1-first}
-|General Availability
-|General Availability
-|General Availability
-
-|Scaffolding tools for Hybrid Helm-based Operator projects
-|Removed
-|Removed
-|Removed
-
-|Scaffolding tools for Java-based Operator projects
-|Removed
-|Removed
-|Removed
-|====
+//.Operator lifecycle and development Technology Preview tracker
+//[cols="4,1,1,1",options="header"]
+//|====
+//|Feature |4.20 |4.21 |4.22
+//|====
 
 
 [id="ocp-release-notes-rhcos-tech-preview_{context}"]
@@ -573,17 +462,17 @@ In the following tables, features are marked with the following statuses:
 .{rh-openstack} Technology Preview tracker
 [cols="4,1,1,1",options="header"]
 |====
-|Feature |4.19 |4.20 |4.21
+|Feature |4.20 |4.21 |4.22
 
 |{rh-openstack} integration into the {cluster-capi-operator}
 |Technology Preview
 |Technology Preview
-|Technology Preview
+|
 
 |Hosted control planes on {rh-openstack} 17.1
 |Technology Preview
 |Technology Preview
-|Technology Preview
+|
 |====
 
 
@@ -593,52 +482,47 @@ In the following tables, features are marked with the following statuses:
 .Scalability and performance Technology Preview tracker
 [cols="4,1,1,1",options="header"]
 |====
-|Feature |4.19 |4.20 |4.21
+|Feature |4.20 |4.21 |4.22
 
 |{factory-prestaging-tool}
 |Technology Preview
 |Technology Preview
-|Technology Preview
+|
 
 |Hyperthreading-aware CPU manager policy
 |Technology Preview
 |Technology Preview
-|Technology Preview
+|
 
 |Mount namespace encapsulation
 |Technology Preview
 |Technology Preview
-|Technology Preview
+|
 
 |Node Observability Operator
 |Technology Preview
 |Technology Preview
-|Technology Preview
+|
 
 |Increasing the etcd database size
 |Technology Preview
 |Technology Preview
-|Technology Preview
+|
 
 |Managing etcd size by setting the `eventTTLMinutes` property
 |Not available
-|Not available
 |Technology Preview
-
-|Using {rh-rhacm} `PolicyGenerator` resources to manage {ztp} cluster policies
-|General Availability
-|General Availability
-|General Availability
+|
 
 |Pinned Image Sets
 |Technology Preview
 |Technology Preview
-|Technology Preview
+|
 
 |Configuring NUMA-aware scheduler replicas and high availability
-|Not available
 |Technology Preview
 |Technology Preview
+|
 |====
 
 
@@ -658,107 +542,67 @@ In the following tables, features are marked with the following statuses:
 .Storage Technology Preview tracker
 [cols="4,1,1,1",options="header"]
 |====
-|Feature |4.19 |4.20 |4.21
+|Feature |4.20 |4.21 |4.22
 
 |AWS EFS One Zone volume
-|Not Available
 |General Availability
 |General Availability
+|
 
 |Automatic device discovery and provisioning with Local Storage Operator
 |Technology Preview
 |Technology Preview
-|Technology Preview
+|
 
 |Azure File CSI cloning support
 |Technology Preview
-|Technology Preview
 |General Availability
+|
 
 |Azure File CSI snapshot support
 |Technology Preview
-|Technology Preview
 |General Availability
-
-|Azure File cross-subscription support
-|General Availability
-|General Availability
-|General Availability
+|
 
 |Azure Disk performance plus
-|Not Available
 |General Availability
 |General Availability
+|
 
 |Configuring fsGroupChangePolicy per namespace
-|Not Available
 |General Availability
 |General Availability
+|
 
 |Shared Resources CSI Driver in OpenShift Builds
 |Technology Preview
 |Technology Preview
-|Technology Preview
-
-|{secrets-store-operator}
-|General Availability
-|General Availability
-|General Availability
-
-|CIFS/SMB CSI Driver Operator
-|General Availability
-|General Availability
-|General Availability
-
-|VMware vSphere multiple vCenter support
-|General Availability
-|General Availability
-|General Availability
-
-|Disabling/enabling storage on vSphere
-|General Availability
-|General Availability
-|General Availability
+|
 
 |Increasing max number of volumes per node for vSphere
 |Technology Preview
 |Technology Preview
-|Technology Preview
+|
 
 |RWX/RWO SELinux mount option
-|Developer Preview
 |Technology Preview
 |Technology Preview
-
-|Migrating CNS Volumes Between Datastores
-|General Availability
-|General Availability
-|General Availability
+|
 
 |CSI volume group snapshots
 |Technology Preview
 |Technology Preview
-|Technology Preview
-
-|GCP PD supports C3/N4 instance types and hyperdisk-balanced disks
-|General Availability
-|General Availability
-|General Availability
-
-|OpenStack Manila support for CSI resize
-|General Availability
-|General Availability
-|General Availability
+|
 
 |Volume Attribute Classes
 |Technology Preview
-|Technology Preview
 |General Availability
+|
 
 |Volume populators
-|Technology Preview
 |General Availability
 |General Availability
+|
 |====
 
 
@@ -768,10 +612,10 @@ In the following tables, features are marked with the following statuses:
 .Web console Technology Preview tracker
 [cols="4,1,1,1",options="header"]
 |====
-|Feature |4.19 |4.20|4.21
+|Feature |4.20 |4.21 |4.22
 
 |{ols-official} in the {product-title} web console
 |Technology Preview
 |Technology Preview
-|Technology Preview
+|
 |====


### PR DESCRIPTION
Version(s):
4.22

Issue:
https://redhat.atlassian.net/browse/OSDOCS-18174

Link to docs preview:


QE review:
- [ ] QE has approved this change.


Additional information:
The information in the **Edge computing Technology Preview features** was already there so I didn't do anything with that table

