### PR TITLE
OSDOCS-18265: Vale DITA fixes for OSD storage

### DIFF
--- a/modules/sd-persistent-storage-csi-efs-sts.adoc
+++ b/modules/sd-persistent-storage-csi-efs-sts.adoc
@@ -6,6 +6,7 @@
 [id="efs-sts_{context}"]
 = Obtaining a role Amazon Resource Name for Security Token Service
 
+[role="_abstract"]
 This procedure explains how to obtain a role Amazon Resource Name (ARN) to configure the AWS EFS CSI Driver Operator with {product-title} on AWS Security Token Service (STS).
 
 [IMPORTANT]
@@ -66,7 +67,6 @@ Perform this procedure before you install the AWS EFS CSI Driver Operator (see _
 
 . Create an IAM trust JSON file with the following content:
 +
---
 [source,json]
 ----
 {
@@ -75,12 +75,12 @@ Perform this procedure before you install the AWS EFS CSI Driver Operator (see _
     {
       "Effect": "Allow",
       "Principal": {
-        "Federated": "arn:aws:iam::<your_aws_account_ID>:oidc-provider/<openshift_oidc_provider>"  <1>
+        "Federated": "arn:aws:iam::<your_aws_account_ID>:oidc-provider/<openshift_oidc_provider>"
       },
       "Action": "sts:AssumeRoleWithWebIdentity",
       "Condition": {
         "StringEquals": {
-          "<openshift_oidc_provider>:sub": [  <2>
+          "<openshift_oidc_provider>:sub": [
             "system:serviceaccount:openshift-cluster-csi-drivers:aws-efs-csi-driver-operator",
             "system:serviceaccount:openshift-cluster-csi-drivers:aws-efs-csi-driver-controller-sa"
           ]
@@ -90,7 +90,11 @@ Perform this procedure before you install the AWS EFS CSI Driver Operator (see _
   ]
 }
 ----
-<1> Specify your AWS account ID and the OpenShift OIDC provider endpoint. 
++
+--
+where:
+
+`Statement.Principal.Federated`:: Specify your AWS account ID and the OpenShift OIDC provider endpoint. 
 +
 Obtain your AWS account ID by running the following command:
 +
@@ -121,7 +125,7 @@ $ openshift_oidc_provider=`oc get authentication.config.openshift.io cluster \
 ----
 endif::openshift-dedicated[]
 
-<2> Specify the OpenShift OIDC endpoint again.
+`Statement.Condition.StringEquals[0]`:: Specify the OpenShift OIDC endpoint again.
 --
 
 . Create the IAM role:
@@ -169,10 +173,9 @@ stringData:
   credentials: |-
     [default]
     sts_regional_endpoints = regional
-    role_arn = <role_ARN> <1>
+    role_arn = <role_ARN>
     web_identity_token_file = /var/run/secrets/openshift/serviceaccount/token
 ----
-<1> Replace `role_ARN` with the output you saved while creating the role.
 
 . Create the secret:
 +


### PR DESCRIPTION
This PR addresses the Vale DITA fixes for the OSD content in the Storage book. It does not address any Vale issues for non-OSD content.

Version(s):
* 4.21+

Issue:
https://redhat.atlassian.net/browse/OSDOCS-18265

Link to docs preview:
* 

QE review:
- n/a
