### PR TITLE
OSDOCS-18814: CQA updates for ROSA Security (HCP and Classic)

### DIFF
--- a/modules/rosa-attaching-the-policy.adoc
+++ b/modules/rosa-attaching-the-policy.adoc
@@ -6,12 +6,12 @@
 = Attaching the identity-based IAM policy
 
 [role="_abstract"]
-Once you have created an identity-based IAM policy, attach it to the relevant IAM users, groups, or roles in your AWS account to prevent IP-based role assumption for those entities.
+After you create an Identity and Access Management (IAM) policy, attach it to the relevant IAM users, groups, or roles in your AWS account. The policy prevents IP-based role assumption for these entities.
 
 .Procedure
 
 . Navigate to the IAM console in the AWS Management Console.
-. Select the default IAM `ManagedOpenShift-Support-Role` role to which you want to attach the policy.
+. Select the default IAM `ManagedOpenShift-Support-Role` role to attach the policy.
 +
 [NOTE]
 ====
@@ -26,6 +26,6 @@ You can change the default IAM `ManagedOpenShift-Support-Role` role. For more in
 +
 [IMPORTANT]
 ====
-To ensure effective IP-based role assumption prevention, you must keep the allowlisted IPs up to date. Failure to do so may result in Red{nbsp}Hat site reliability engineering (SRE) being unable to access your account and affect your SLA. If you have further questions or require assistance, please reach out to our support team.
+To prevent IP-based role assumption, keep the allowlisted IPs up-to-date. Outdated IPs can block Red{nbsp}Hat site reliability engineering (SRE) from accessing your account and affect your Service Level Agreement (SLA).
 ====
 

--- a/modules/rosa-create-an-iam-role-policy.adoc
+++ b/modules/rosa-create-an-iam-role-policy.adoc
@@ -6,16 +6,21 @@
 = Creating an IAM role and policy
 
 [role="_abstract"]
-When you forward your logs to an Amazon CloudWatch group or S3 bucket, those locations exist outside your control plane. You must create an IAM role and policy so that your log forwarder has the right permissions and capabilities to send these logs to your chosen destination, CloudWatch or S3.
+When you forward your logs to an Amazon CloudWatch group or S3 bucket, those locations exist outside your control plane. You must create an Identity and Access Management (IAM) role and policy so that your log forwarder has the right permissions and capabilities to send these logs to your chosen destination, CloudWatch or S3.
 
 [NOTE]
 ====
 To use a CloudWatch group, you must create an IAM role and policy. To use an S3 bucket, you do not need an IAM role and policy. However, if you do not have an IAM role and policy created for the S3 bucket to use, then the encryption for the S3 bucket is limited to Amazon S3 managed keys, `SSE-S3`.
 ====
 
+.Prerequisites
+
+* You have installed and configured the latest {rosa-cli-first} on your installation host.
+* You have installed and configured the latest {aws-first} command-line interface (CLI) on your installation host.
+
 .Procedure
 
-. To enable the log forwarder delivery capability, prepare the IAM policy by creating an `assume-role-policy.json` file. Apply the following IAM policy sample: 
+. To enable the log forwarder delivery capability, prepare the IAM policy by creating an `assume-role-policy.json` file. Apply the following IAM policy sample:
 +
 [source,json]
 ----
@@ -33,9 +38,9 @@ To use a CloudWatch group, you must create an IAM role and policy. To use an S3 
 }
 ----
 +
-. To enable the log forwarder distribution capability, create an IAM role that must include the `CustomerLogDistribution` name by running the following command: 
+. To enable the log forwarder distribution capability, create an IAM role that must include the `CustomerLogDistribution` name by running the following command:
 +
-[source,terminal] 
+[source,terminal]
 ----
 $ aws iam create-role \
     --role-name CustomerLogDistribution-RH \
@@ -44,7 +49,7 @@ $ aws iam create-role \
 
 .Next steps
 
-After you create an IAM role and policy, you must decide to send your control plane logs to either a CloudWatch log group, an S3 bucket, or both. See the following summary about CloudWatch and S3 to help you decide what you want to do: 
+After you create an IAM role and policy, you must decide to send your control plane logs to either a CloudWatch log group, an S3 bucket, or both. See the following summary about CloudWatch and S3 to help you decide what you want to do:
 
-* CloudWatch can help you when you have logs requiring immediate action or organization.  
-* S3 can help you when you have logs needing long-term storage or large-scale data analysis. 
+* Use CloudWatch for logs requiring immediate action or organization.
+* Use S3 for logs requiring long-term storage or large-scale data analysis.

--- a/modules/rosa-create-an-identity-based-policy.adoc
+++ b/modules/rosa-create-an-identity-based-policy.adoc
@@ -3,14 +3,14 @@
 // * rosa-adding-additional-constraints-for-ip-based-aws-role-assumption/rosa-create-an-identity-based-policy.adoc
 :_mod-docs-content-type: PROCEDURE
 [id="rosa-create-an-identity-based-policy_{context}"]
-= Create an identity-based IAM policy
+= Creating an identity-based IAM policy
 
 [role="_abstract"]
-You can create an identity-based Identity and Access Management (IAM) policy that denies access to all AWS actions when the request originates from an IP address other than Red{nbsp}Hat provided IPs.
+Create an Identity and Access Management (IAM) policy that denies access to all AWS actions if the request is made from an IP address not provided by Red{nbsp}Hat.
 
 .Prerequisites
 
-* You have access to the see link:https://aws.amazon.com/console/[AWS Management Console] with the permissions required to create and modify IAM policies.
+* You have access to the link:https://aws.amazon.com/console/[AWS Management Console] with the permissions required to create and modify IAM policies.
 
 .Procedure
 
@@ -19,7 +19,7 @@ You can create an identity-based Identity and Access Management (IAM) policy tha
 . In the IAM console, select *Policies* from the left navigation menu.
 . Click *Create policy*.
 . Select the *JSON* tab to define the policy using JSON format.
-. To get the IP addresses that you need to enter into the JSON policy document, run the following command:
+. To get the IP addresses required for the JSON policy document, run the following command:
 +
 [source,terminal]
 ----
@@ -28,7 +28,7 @@ $ ocm get /api/clusters_mgmt/v1/trusted_ip_addresses
 +
 [NOTE]
 ====
-These IP addresses are not permanent and are subject to change. You must continuously review the API output and make the necessary updates in the JSON policy document.
+These IP addresses are not permanent and can change. Regularly review the API output and update the JSON policy document.
 ====
 +
 . Copy and paste the following `policy_document.json` file into the editor:
@@ -62,5 +62,5 @@ These IP addresses are not permanent and are subject to change. You must continu
 +
 [NOTE]
 ====
-The condition key `aws:ViaAWSService` must be set to false to enable subsequent calls to succeed based on the initial call. For example, if you make an initial call to `aws ec2 describe-instances`, all subsequent calls made within the AWS API server to retrieve information about the EBS volumes attached to the ec2 instance will fail if the condition key `aws:ViaAWSService` is not set to false. The subsequent calls would fail because they would originate from AWS IP addresses, which are not included in the AllowList.
+Set the `aws:ViaAWSService` condition key to false to ensure that subsequent calls succeed after your initial call. For example, if you do not set `aws:ViaAWSService` to false and run `aws ec2 describe-instances`, some follow-up calls can fail. It applies to subsequent calls that you make within the AWS API server to retrieve information about the Elastic Block Store (EBS) volumes attached to the EC2 instance. The subsequent calls fail because they originate from AWS IP addresses that are not included in the AllowList.
 ====

--- a/modules/rosa-determine-log-groups.adoc
+++ b/modules/rosa-determine-log-groups.adoc
@@ -3,7 +3,7 @@
 // * security/rosa-configuring-the-log-forwarder.adoc
 :_mod-docs-content-type: REFERENCE
 [id="rosa-determine-log-groups_{context}"]
-= Determining what log groups to use 
+= Determining what log groups to use
 
 [role="_abstract"]
 When you forward control plane logs to Amazon CloudWatch or S3, you must decide on what log groups you want to use. Because of the existing AWS pricing for the respective services, you can expect additional costs associated with forwarding and storing your logs in S3 and CloudWatch. When you determine what log group to use, consider these additional costs along with other factors, such as your log retention requirements.
@@ -12,31 +12,33 @@ For each log group, you have access to different applications, and these applica
 
 When you forward log groups, you must specify a group or application. When you specify a group, the log forwarder collects all the applications in that group. Instead of selecting a group, you can select individual applications. When you set up your log forwarder, you must specify at least one group or application, but you do not need to specify both.
 
-See the following table to help you decide what log groups you need before you begin to forward your control plane logs: 
+The following table lists available log groups:
 
+.Log groups
+[cols="1,2,2",options="header"]
 |====
-| Log group name| Benefit of that log group| Example applications available for that log group  
+| Log group name| Benefit of that log group| Example applications available for that log group
 
-| api 
-| Records every request made to the cluster. Helps security by detecting unauthorized access attempts.
-a| 
+| api
+| Records every request made to the cluster. Supports security by detecting unauthorized access attempts.
+a|
 * `audit-webhook`
 * `kube-apiserver`
 * `oauth-openshift`
 * `openshift-apiserver`
 * `openshift-oauth-apiserver`
 * `packageserver`
-* `validation-webhook`  
+* `validation-webhook`
 
-| authentication  
-| Tracks login attempts and requests for tokens. Helps security by recording authenticated user information.
-a| 
+| authentication
+| Tracks login attempts and requests for tokens. Supports security by recording authenticated user information.
+a|
 * `ignition-server`
 * `konnectivity-agent`
 
-| controller manager  
-| Monitors the controllers that manages the state of your clusters. Helps explain the difference among the different cluster states, for example, the `Current`, `Desired`, `Health`, and `Feature` state.
-a| 
+| controller manager
+| Monitors the controllers that manages the state of your clusters. Clarifies differences among the different cluster states, for example, the `Current`, `Desired`, `Health`, and `Feature` state.
+a|
 * `aws-ebs-csi-driver-controller`
 * `capi-provider-controller-manager`
 * `catalog-operator`
@@ -61,21 +63,21 @@ a|
 * `olm-operator`
 * `openshift-controller-manager`
 * `openshift-route-controller-manager`
-* `ovnkube-control-plane`   
+* `ovnkube-control-plane`
 
-| scheduler    
-| Records the placement of each pod on every node. Helps you understand why pods are in a `Running` or `Pending` state.
-a| 
+| scheduler
+| Records the placement of each pod on every node. Shows why pods are in a `Running` or `Pending` state.
+a|
 * `kube-scheduler`
 
-| not applicable   
-| These applications do not belong to a defined log group. To forward their logs, set these applications in the `applications` array.  
-a| 
+| not applicable
+| These applications do not belong to a defined log group. To forward their logs, set these applications in the `applications` array.
+a|
 * `certified-operators-catalog`
 * `cluster-api`
 * `community-operators-catalog`
 * `etcd`
 * `private-router`
 * `redhat-marketplace-catalog`
-* `redhat-operators-catalog`    
+* `redhat-operators-catalog`
 |====

--- a/modules/rosa-manage-control-plane-log-forwarding.adoc
+++ b/modules/rosa-manage-control-plane-log-forwarding.adoc
@@ -3,13 +3,15 @@
 // * security/rosa-configuring-the-log-forwarder.adoc
 :_mod-docs-content-type: REFERENCE
 [id="rosa-manage-control-plane-log-forwarding_{context}"]
-= Managing control plane log forwarding 
+= Managing control plane log forwarding
 
 [role="_abstract"]
 After you configure the {product-title} clusters to use your selected log forwarder for control plane logs, see the following commands to run based on your specific needs. For all of these commands, you must provide the `clusterid` or cluster name in the `--cluster` flag:
 
-`rosa create log-forwarder -c <cluster_name|cluster_id>`:: Configures your {product-title} cluster to use the log forwarder. 
+`rosa create log-forwarder -c <cluster_name|cluster_id>`:: Configures your {product-title} cluster to use the log forwarder.
 `rosa list log-forwarder -c <cluster_name|cluster_id>`:: Displays all of the log forwarder configurations for a {product-title} cluster.
-`rosa describe log-forwarder -c <cluster_name|cluster_id> <log-fwd-id>`::  Provides more than the basic details for that specific log forwarder. 
-`rosa edit log-forwarder -c <cluster_name|cluster_id> <log-fwd-id>`:: Enables you to make changes to the log forwarder. With the edit functionality, you can make changes to the following log forwarder fields: groups, applications, and S3 and CloudWatch configurations, depending on type of configuration.  
-`rosa delete log-forwarder -c <cluster_name|cluster_id> <log-fwd-id>`:: Deletes the log forwarder configuration which stops your logs from being forwarded to your chosen destinations. Your logs are not automatically deleted. If you no longer want to store your logs in the S3 bucket or CloudWatch group, you can delete those specific logs. To make changes to the following log forwarder fields, use the delete functionality, then recreate these log forwarder fields, implementing your changes: ID, cluster ID, and the type for S3 and CloudWatch.  
+`rosa describe log-forwarder -c <cluster_name|cluster_id> <log_fwd_id>`:: Provides additional details for a specific log forwarder.
+`rosa edit log-forwarder -c <cluster_name|cluster_id> <log_fwd_id>`:: Changes the following log forwarder fields: groups, applications, and S3 and CloudWatch configurations.
+`rosa delete log-forwarder -c <cluster_name|cluster_id> <log_fwd_id>`:: Deletes the log forwarder configuration. Logs are no longer forwarded to your chosen destinations but are not automatically deleted. If you no longer want to store your logs in the S3 bucket or CloudWatch group, delete those logs.
++
+Additionally, use this command to change the following log forwarder fields: ID, cluster ID, and the type for S3 and CloudWatch. Delete a log forwarder and re-create it with the updated values.

--- a/modules/rosa-set-up-cloudwatch-log-group.adoc
+++ b/modules/rosa-set-up-cloudwatch-log-group.adoc
@@ -6,22 +6,22 @@
 = Setting up the CloudWatch log group
 
 [role="_abstract"]
-If you have logs requiring immediate action or organization, set up an Amazon CloudWatch log group.   
+If you have logs that require immediate action or organization, set up an Amazon CloudWatch log group.
 
 .Prerequisites
 
-* You have created an IAM role and policy. 
+* You have created an IAM role and policy.
 
 .Procedure
 
-. Create the CloudWatch log group by running the following command: 
+. Create the CloudWatch log group by running the following command:
 +
 [source,terminal]
 ----
 $ aws logs create-log-group –log-group-name <your_log_group_name>
 ----
 +
-. In your {product-title} cluster, configure the log forwarder to use the CloudWatch log group by applying the following JSON sample:  
+. In your {product-title} cluster, configure the log forwarder to use the CloudWatch log group by applying the following JSON sample:
 +
 [source,json]
 ----
@@ -50,7 +50,7 @@ $ aws logs create-log-group –log-group-name <your_log_group_name>
 }
 ----
 +
-. Attach the policy to the CloudWatch role by running the following command: 
+. Attach the policy to the CloudWatch role by running the following command:
 +
 [source,terminal]
 ----
@@ -60,43 +60,47 @@ $ aws iam put-role-policy \
     --policy-document file://cloudwatch-policy.json
 ----
 +
-. Configure your {product-title} cluster to forward logs to the CloudWatch log group by applying the following sample YAML list. Specify an application, or group, or both:  
+. Configure your {product-title} cluster to forward logs to the CloudWatch log group by applying the following sample YAML list. Specify an application, or group, or both:
 +
 [source,yaml]
 ----
 cloudwatch:
   cloudwatch_log_role_arn: "arn:aws:iam::123456789012:role/RosaCloudWatch"
   cloudwatch_log_group_name: "rosa-logs"
-  applications: 
+  applications:
     - "<example_app1>"
-  groups: 
+  groups:
     - "<example_group1>"
 ----
++
+where:
+
 <example_app1>:: Add one or more applications. For a list of applications, see the table in "Determining what log groups to use".
-<example_group1>:: Add one or more of the following groups: `api`, `authentication`, `controller manager`, `scheduler`. 
-. Enable the log forwarder to send logs to your {product-title} cluster. 
-.. To enable control plane log forwarding on a new cluster, include the log forwarding configuration by running the following command:  
+<example_group1>:: Add one or more of the following groups: `api`, `authentication`, `controller manager`, `scheduler`.
+
+. Enable the log forwarder to send logs to your {product-title} cluster.
+.. To enable control plane log forwarding on a new cluster, include the log forwarding configuration by running the following command:
 +
 [source,terminal]
 ----
 $ rosa create cluster --log-fwd-config="<path_to_file>.yaml"
 ----
 +
-.. To enable control plane log forwarding on an existing cluster, include the log forwarding configuration by running the following command:    
+.. To enable control plane log forwarding on an existing cluster, include the log forwarding configuration by running the following command:
 +
 [source,terminal]
 ----
 $ rosa create log-forwarder -c <cluster> --log-fwd-config="<path_to_file>.yaml" -o yaml
 ----
-. *Optional:* For an example for forwarding logs to the CloudWatch log group, apply the following sample YAML:  
+. Optional: For an example for forwarding logs to the CloudWatch log group, apply the following sample YAML:
 +
 [source,yaml]
 ----
 cloudwatch:
   cloudwatch_log_role_arn: "cloudwatch-log-role-arn"
   cloudwatch_log_group_name: "cloudwatch-group-name"
-  applications: 
+  applications:
     - "<example_app1>"
-  groups: 
+  groups:
     - "<example_group1>"
 ----

--- a/modules/rosa-set-up-s3-bucket.adoc
+++ b/modules/rosa-set-up-s3-bucket.adoc
@@ -10,11 +10,11 @@ If you have logs that need long-term storage or large-scale data analysis, set u
 
 .Prerequisites
 
-* If you want to prevent limitations for the managed keys for your S3 bucket, you must have created an IAM role and policy. 
+* If you want to prevent limitations for the managed keys for your S3 bucket, you must have created an IAM role and policy.
 
 .Procedure
 
-. Create the S3 bucket by running the following command: 
+. Create the S3 bucket by running the following command:
 +
 [source,terminal]
 ----
@@ -24,7 +24,7 @@ $ aws s3api create-bucket \
     --create-bucket-configuration LocationConstraint=<cluster_aws_region>
 ----
 +
-. Configure the policy for the S3 bucket by applying the following S3 bucket policy sample:  
+. Configure the policy for the S3 bucket by applying the following S3 bucket policy sample:
 +
 [source,json]
 ----
@@ -48,7 +48,7 @@ $ aws s3api create-bucket \
 }
 ----
 +
-. Attach the policy to the S3 role by running the following command: 
+. Attach the policy to the S3 role by running the following command:
 +
 [source,terminal]
 ----
@@ -57,42 +57,42 @@ $ aws s3api put-bucket-policy \
     --policy file://s3-bucket-policy.json
 ----
 +
-. Configure your {product-title} cluster to forward logs to the S3 bucket by applying the following sample YAML list. Specify an application, or group, or both:    
+. Configure your {product-title} cluster to forward logs to the S3 bucket by applying the following sample YAML list. Specify an application, or group, or both:
 +
 [source,yaml]
 ----
 s3:
   s3_config_bucket_name: "my-log-bucket"
   s3_config_bucket_prefix: "my-bucket-prefix"
-  applications: 
+  applications:
     - "<example_app1>"
-  groups: 
+  groups:
     - "<example_group1>"
 ----
 <example_app1>:: Add one or more applications. For a list of applications, see the table in "Determining what log groups to use".
-<example_group1>:: Add one or more of the following groups: `api`, `authentication`, `controller manager`, `scheduler`. 
-. Enable the log forwarder to send logs to your {product-title} cluster. 
-.. To enable control plane log forwarding on a new cluster, include the log forwarding configuration by running the following command:   
+<example_group1>:: Add one or more of the following groups: `api`, `authentication`, `controller manager`, `scheduler`.
+. Enable the log forwarder to send logs to your {product-title} cluster.
+.. To enable control plane log forwarding on a new cluster, include the log forwarding configuration by running the following command:
 +
 [source,terminal]
 ----
 $ rosa create cluster --log-fwd-config="<path_to_file>.yaml"
 ----
 +
-.. To enable control plane log forwarding on an existing cluster, include the log forwarding configuration by running the following command:    
+.. To enable control plane log forwarding on an existing cluster, include the log forwarding configuration by running the following command:
 +
 [source,terminal]
 ----
 $ rosa create log-forwarder -c <cluster> --log-fwd-config="<path_to_file>.yaml" -o yaml
 ----
 +
-. *Optional:* For an example for forwarding logs to the S3 bucket, apply the following sample YAML:  
+. Optional: For an example for forwarding logs to the S3 bucket, apply the following sample YAML:
 +
 [source,yaml]
 ----
 s3:
   s3_config_bucket_name: "s3-bucket-name"
   s3_config_bucket_prefix: "s3-bucket-prefix"
-  groups: 
+  groups:
     - "<example_group1>"
 ----

--- a/security/rosa-adding-additional-constraints-for-ip-based-aws-role-assumption.adoc
+++ b/security/rosa-adding-additional-constraints-for-ip-based-aws-role-assumption.adoc
@@ -9,12 +9,14 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 [role="_abstract"]
-You can implement an additional layer of security in your AWS account to prevent role assumption from non-allowlisted IP addresses.
+Create an identity-based policy that denies requests from non-allowlisted IP addresses. Restricting role access can improve your AWS account security.
 
 include::modules/rosa-create-an-identity-based-policy.adoc[leveloffset=+1]
+
 include::modules/rosa-attaching-the-policy.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
+[id="additional-resources_{context}"]
 == Additional resources
 
 * link:https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_examples_aws_deny-ip.html[AWS: Denies access to AWS based on the source IP]

--- a/security/rosa-forwarding-control-plane-logs.adoc
+++ b/security/rosa-forwarding-control-plane-logs.adoc
@@ -9,15 +9,9 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 [role="_abstract"]
-With {product-title} you have a control plane log forwarder that is a separate system outside your cluster. You can use the control plane log forwarder to send your logs to either an Amazon CloudWatch group or Amazon S3 bucket, depending on your preference. 
+{product-title} provides a control plane log forwarder that is a separate system outside your cluster. You can use the control plane log forwarder to send your logs to either an Amazon CloudWatch group or Amazon S3 bucket.
 
-Since the {product-title} control plane log forwarder is a managed system, it does not contend for resources against your workloads on your worker nodes. 
-
-[id="prerequisites_{context}"]
-== Prerequisites
-
-* You have installed and configured the latest {rosa-cli} on your installation host.
-* You have installed and configured the latest {aws-first} command-line interface (CLI) on your installation host. 
+The {product-title} control plane log forwarder is a managed system and it does not use resources reserved for workloads on your worker nodes.
 
 include::modules/rosa-determine-log-groups.adoc[leveloffset=+1]
 
@@ -28,4 +22,3 @@ include::modules/rosa-set-up-cloudwatch-log-group.adoc[leveloffset=+1]
 include::modules/rosa-set-up-s3-bucket.adoc[leveloffset=+1]
 
 include::modules/rosa-manage-control-plane-log-forwarding.adoc[leveloffset=+1]
-


### PR DESCRIPTION
Version(s):
4.21+

Issue:
**[OSDOCS-16410](https://redhat.atlassian.net/browse/OSDOCS-16410) - CQA issue and parent to the following:**

- [OSDOCS-18814](https://redhat.atlassian.net/browse/OSDOCS-18814) - DITA updates for assemblies
- [OSDOCS-18893](https://redhat.atlassian.net/browse/OSDOCS-18893) - Expand acronyms
- [OSDOCS-18894](https://redhat.atlassian.net/browse/OSDOCS-18894) - Short descriptions
- [OSDOCS-18895](https://redhat.atlassian.net/browse/OSDOCS-18895) - "Easy to read" section: complex words, readability, minimalism
- [OSDOCS-18896](https://redhat.atlassian.net/browse/OSDOCS-18896) - Fix formatting in optional steps and user-replaced values
- [OSDOCS-18897](https://redhat.atlassian.net/browse/OSDOCS-18897) - Style guide requirements
- [OSDOCS-18898](https://redhat.atlassian.net/browse/OSDOCS-18898) - Fix a table 

Link to docs preview:

**ROSA HCP Security and compliance:**
Assembly 1: [Adding additional constraints for IP-based AWS role assumption](https://108826--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/security/rosa-adding-additional-constraints-for-ip-based-aws-role-assumption.html)
Assembly 2: [Forwarding control plane logs](https://108826--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/security/rosa-forwarding-control-plane-logs.html)

**ROSA Classic Security and compliance:**
Assembly 1 is shared with OCP. Not part of this PR.
Assembly 2: [Adding additional constraints for IP-based AWS role assumption](https://108826--ocpdocs-pr.netlify.app/openshift-rosa/latest/security/rosa-adding-additional-constraints-for-ip-based-aws-role-assumption.html)

QE review:
N/A

Additional information:
