### PR TITLE
[OBSDOCS-3179] Release notes for Logging 6.5.0

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -16,7 +16,7 @@ Name: Release notes
 Dir: release_notes
 Distros: openshift-logging
 Topics:
-- Name: Logging 6.3 release notes
+- Name: Logging 6.5 release notes
   File: logging-release-notes
 ---
 Name: Installing logging

--- a/modules/logging-release-notes-6-5-0.adoc
+++ b/modules/logging-release-notes-6-5-0.adoc
@@ -1,0 +1,148 @@
+// Module included in the following assemblies:
+//
+// * about/logging-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="logging-release-notes-6-5-0_{context}"]
+= Logging 6.5.0 release notes
+
+[role="_abstract"]
+This release of {LoggingProductName} is supported on {ocp-product-title} 4.19 and later.
+
+This release includes link:https://access.redhat.com/errata/RHBA-2026:6393[RHBA-2026:6393].
+
+[id="openshift-logging-release-notes-6-5-0-enhancements_{context}"]
+== New features and enhancements
+
+Automatic trace context enrichment for OTLP log forwarding::
+With this release, log entries forwarded to OpenTelemetry Protocol (OTLP) or LokiStack outputs with `dataModel: Otel` are automatically enriched with trace context attributes, including trace ID, span ID, and trace flags. This enables you to correlate logs with distributed traces in your observability platform, making it easier to troubleshoot issues across services. Trace context is automatically extracted from log messages without requiring any additional configuration.
++
+link:https://redhat.atlassian.net/browse/LOG-5843[LOG-5843]
+
+Dynamic Pod Disruption Budget for LokiStack ingesters::
+With this release, the Pod Disruption Budget for LokiStack ingester pods dynamically adjusts based on the configured replication factor and number of ingester replicas, rather than using a hard-coded value determined by the LokiStack size. This helps ensure high availability is maintained when you customize the replication factor beyond the default value for your selected LokiStack size.
++
+link:https://redhat.atlassian.net/browse/LOG-6715[LOG-6715]
+
+OpenTelemetry log forwarding is now generally available::
+With this release, {LoggingProductName} support for OpenTelemetry (OTel) is promoted to General Availability (GA). You can now forward logs over OTLP outputs using OTel semantic conventions as specified in the link:https://github.com/rhobs/observability-data-model/blob/main/cluster-logging.md[Red Hat Observability Model]. This includes configuring log forwarding to a LokiStack deployment using the OTel data model for log storage and retrieving logs using the log observability UI plugin distributed by the Cluster Observability Operator.
++
+link:https://redhat.atlassian.net/browse/LOG-7623[LOG-7623]
++
+[IMPORTANT]
+====
+This release reduces the default set of stream labels for OTLP log forwarding to LokiStack to help improve LokiStack performance. The new default configuration uses only the following labels as stream labels:
+
+* `k8s.namespace.name`
+* `kubernetes.namespace_name`
+* `log_source`
+* `log_type`
+* `openshift.cluster.uid`
+* `openshift.log.source`
+* `openshift.log.type`
+
+If you have existing queries that used other labels in label matchers (inside `{}`), you must rewrite them to use those labels as filters (after `|`) instead. Alternatively, you can configure your LokiStack to use the previous set of stream labels.
+
+link:https://redhat.atlassian.net/browse/LOG-8319[LOG-8319]
+====
+
+NDJSON support for HTTP output::
+With this release, you can configure an HTTP output to forward logs as new line delimited JSON (NDJSON) instead of as a JSON array by setting the `format` field to `ndjson`. This format reduces memory footprint for some receivers.
++
+[source,yaml]
+----
+# ...
+spec:
+  outputs:
+  - http:
+      format: ndjson
+      method: POST
+      url: http://echo-service.test.svc:8080
+    name: http-echo
+    type: http
+# ...
+----
++
+link:https://redhat.atlassian.net/browse/LOG-7892[LOG-7892]
+
+
+Port validation for Kafka and Syslog outputs::
+With this release, the `ClusterLogForwarder` API requires port numbers in destination URLs for Kafka and Syslog outputs. URLs without port numbers are rejected at admission time, which provides immediate feedback to administrators. This validation enhances security when evaluating NetworkPolicy configurations for socket-level transports.
++
+link:https://redhat.atlassian.net/browse/LOG-8241[LOG-8241]
+
+
+
+HTTP proxy configuration for Loki output::
+With this release, you can configure a proxy URL when forwarding logs to a Loki output in the `ClusterLogForwarder` custom resource by setting the `proxyURL` field. This follows the same syntax and semantics as the HTTP output proxy configuration.
++
+[source,yaml]
+----
+# ...
+spec:
+  outputs:
+  - loki:
+      proxyURL: http://proxy.example.com:8080
+      url: https://loki-endpoint.example.com:3100
+    name: loki-output
+    type: loki
+# ...
+----
++
+link:https://redhat.atlassian.net/browse/LOG-8645[LOG-8645]
+
+
+Ability to disable the LokiStack Gateway Route::
+With this release, you can disable the Gateway Route created automatically by the Loki Operator by setting the `disableIngress` field to `true` in the `LokiStack` custom resource. This provides more control over external access to your LokiStack deployment.
++
+[source,yaml]
+----
+# ...
+spec:
+  tenants:
+    disableIngress: true
+    mode: openshift-logging
+# ...
+----
++
+link:https://redhat.atlassian.net/browse/LOG-7810[LOG-7810]
+
+Improved leader election resilience for Loki Operator::
+With this release, the Loki Operator uses recommended leader election parameters to better tolerate API server disruptions. The lease duration, renew deadline, and retry period values are configured according to OpenShift best practices, which helps improve operator resilience during cluster maintenance or temporary API server unavailability.
++
+link:https://redhat.atlassian.net/browse/LOG-8080[LOG-8080]
+
+Fine-grained authorization for the openshift-network tenant::
+With this release, the LokiStack `openshift-network` tenant correctly enforces fine-grained authorization. The gateway selector extractor is configured to extract selectors from queries, which allows Open Policy Agent (OPA) to enforce fine-grained authorization. As a result, network observability data access is properly restricted based on authorization policies.
++
+link:https://redhat.atlassian.net/browse/LOG-8131[LOG-8131]
+
+
+[id="logging-release-notes-6-5-0-fixed-issues_{context}"]
+== Fixed issues
+
+LokiStack components alert fires when pods are in Pending state::
+Before this update, the `LokistackComponentsNotReadyWarning` alert did not fire when LokiStack components were in `Pending` state during initial deployment, such as when provisioned with an incorrect storage class. As a consequence, administrators were not alerted to configuration issues that prevented components from becoming ready. With this update, the alert rule is triggered when a LokiStack is deployed with components that are not ready, even during first-time deployment. As a result, the alert now properly fires when components fail to reach a ready state.
++
+link:https://redhat.atlassian.net/browse/LOG-7874[LOG-7874]
+
+NetworkPolicy uses correct port for ODF NooBaa S3 backend egress::
+Before this update, the NetworkPolicy generated by the Loki Operator used the Service port instead of the Pod port for the egress port configuration. As a consequence, when a Kubernetes service was configured for the object storage endpoint with OpenShift Data Foundation (ODF), ingestion and flush failures occurred with timeout errors. With this update, the Loki Operator fetches the Service and EndpointSlices and correctly uses the Pod port rather than the Service port in the NetworkPolicy. As a result, the LokiStack can successfully forward logs to the NooBaa S3 backend.
++
+link:https://redhat.atlassian.net/browse/LOG-8075[LOG-8075]
+
+NetworkPolicy uses correct ports for OpenStack Swift backend egress::
+Before this update, the NetworkPolicy generated by the Loki Operator exposed only the OpenStack authentication port for egress. As a consequence, when using OpenStack Swift as a storage backend, ingestion and flush failures occurred with timeout errors, and compactor and ingester pods entered a crash loop. With this update, the Loki Operator exposes either the default SSL port 443 for services or, for OpenShift installations, Red Hat's OpenStack default SSL port 13808. As a result, the LokiStack can successfully forward logs to the OpenStack Swift storage backend.
++
+link:https://redhat.atlassian.net/browse/LOG-8083[LOG-8083]
+
+NetworkPolicy uses correct ports for cluster-wide proxy egress::
+Before this update, the NetworkPolicy generated by the Loki Operator exposed the incorrect port when NetworkPolicies and cluster-wide proxy were enabled. As a consequence, egress to storage backends timed out with proxy connection errors. With this update, the Loki Operator exposes the proxy port to allow communication between the ingester and object storage through the proxy. As a result, the LokiStack can successfully forward logs through the cluster-wide proxy.
++
+link:https://redhat.atlassian.net/browse/LOG-8084[LOG-8084]
+
+
+Deprecated replicationFactor field is handled correctly::
+Before this update, the handling of the deprecated `replicationFactor` field was in the wrong part of the code. As a consequence, the field was ignored by the Loki Operator and not applied to `replication.factor` in the generated Loki configuration. With this update, the handling is moved to the correct location where it is visible by the operator. As a result, the deprecated `replicationFactor` field is correctly processed and applied.
++
+link:https://redhat.atlassian.net/browse/LOG-8795[LOG-8795]

--- a/release_notes/logging-release-notes.adoc
+++ b/release_notes/logging-release-notes.adoc
@@ -1,10 +1,10 @@
 :_mod-docs-content-type: ASSEMBLY
 include::_attributes/common-attributes.adoc[]
 [id="logging-release-notes"]
-= Logging 6.3 release notes
+= Logging 6.5 release notes
 
 :context: logging-release-notes
 
 toc::[]
 
-include::modules/logging-release-notes-6-3-0.adoc[leveloffset=+1]
+include::modules/logging-release-notes-6-5-0.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s):
- _none for cherry-picking_

Issue:
- https://redhat.atlassian.net/browse/OBSDOCS-3179

Link to docs preview:
- [Logging 6.5.0 release notes](https://108830--ocpdocs-pr.netlify.app/openshift-logging/latest/release_notes/logging-release-notes.html#logging-release-notes-6-5-0_logging-release-notes)

QE review:
- [x] QE has approved this change.
