### PR TITLE
[RHDEVDOCS-7380] Update version-dependent navigation behavior for 1.21

### DIFF
--- a/modules/op-release-notes-1-21-0.adoc
+++ b/modules/op-release-notes-1-21-0.adoc
@@ -584,9 +584,19 @@ With this update, messages added by any member of a group when approving or reje
 
 .User interface
 
-Pipelines console navigation requires explicit plugin enablement::
-With this update, the legacy static console plugin is fully deprecated. After installing the {pipelines-title} Operator, you must explicitly enable the console plugin to access the *Pipelines* section in the {OCP} console. The previous fallback behavior, which displayed a limited *Pipelines* entry when the plugin was disabled, is removed, and the *Pipelines* navigation menu is only visible when the console plugin is active.
-//+
+Pipelines console navigation menu requires explicit plugin enablement::
+With this update, the legacy static console plugin is fully deprecated. The behavior of the *Pipelines* navigation menu in the {OCP} console depends on your {OCP} version.
++
+On {OCP} 4.21 and later versions, the *Pipelines* tab appears in the navigation menu only when the console plugin is enabled. If you disable the console plugin, the *Pipelines* tab is removed from the navigation menu. The previous fallback behavior, which displayed a limited *Pipelines* entry when the plugin was disabled, no longer applies.
++
+On {OCP} versions prior to 4.21, the previous behavior is retained. The *Pipelines* tab with three sub-menus remains visible in the navigation menu even if you disable the console plugin. For optimal experience with {pipelines-shortname} 1.20.2, 1.20.3, and 1.21, use one of the following {OCP} versions:
++
+* {OCP} 4.16.55 or later
+* {OCP} 4.17.47 or later
+* {OCP} 4.18.31 or later
+* {OCP} 4.19.22 or later
+* {OCP} 4.20.10 or later
+
 //link:https://issues.redhat.com/browse/SRVKP-9456[SRVKP-9456]
 
 .{pac}


### PR DESCRIPTION
Version(s):
- _none for cherry-picking_

Issue:
- https://redhat.atlassian.net/browse/RHDEVDOCS-7380

Link to docs preview:
- [Breaking changes](https://108831--ocpdocs-pr.netlify.app/openshift-pipelines/latest/release_notes/op-release-notes-1-21.html#pipelines-breaking-changes-1-21-0)

QE review:
- [x] QE has approved this change.

