### PR TITLE
OSDOCS-16835-main: CP review for MNW-4: Secondary Network Advanced Co…

### DIFF
--- a/modules/nw-multi-network-policy-ipv6-suppport.adoc
+++ b/modules/nw-multi-network-policy-ipv6-suppport.adoc
@@ -24,11 +24,11 @@ data:
 
   custom-v6-rules.txt: |
     # accept NDP
-    -p icmpv6 --icmpv6-type neighbor-solicitation -j ACCEPT <1>
-    -p icmpv6 --icmpv6-type neighbor-advertisement -j ACCEPT <2>
+    -p icmpv6 --icmpv6-type neighbor-solicitation -j ACCEPT
+    -p icmpv6 --icmpv6-type neighbor-advertisement -j ACCEPT
     # accept RA/RS
-    -p icmpv6 --icmpv6-type router-solicitation -j ACCEPT <3>
-    -p icmpv6 --icmpv6-type router-advertisement -j ACCEPT <4>
+    -p icmpv6 --icmpv6-type router-solicitation -j ACCEPT
+    -p icmpv6 --icmpv6-type router-advertisement -j ACCEPT
 ----
 
 where:

--- a/modules/nw-networkpolicy-allow-application-all-namespaces.adoc
+++ b/modules/nw-networkpolicy-allow-application-all-namespaces.adoc
@@ -43,12 +43,36 @@ endif::microshift[]
 ifndef::multi[]
 [source,yaml]
 ----
-kind: NetworkPolicy
 apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: web-allow-all-namespaces
+  namespace: default
 spec:
   podSelector:
     matchLabels:
       app: web
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector: {}
+----
+endif::multi[]
+ifdef::multi[]
+[source,yaml]
+----
+apiVersion: k8s.cni.cncf.io/v1beta1
+kind: MultiNetworkPolicy
+metadata:
+  name: web-allow-all-namespaces
+  namespace: default
+  annotations:
+    k8s.v1.cni.cncf.io/policy-for:<namespace_name>/<network_name>
+spec:
+  podSelector:
+    matchLabels:
+     app: web
   policyTypes:
   - Ingress
   ingress:


### PR DESCRIPTION
Version(s):
4.16+

Issue:
[OSDOCS-18667](https://redhat.atlassian.net/browse/OSDOCS-18667)

Link to docs preview:

* [Creating a multi-network policy allowing traffic to an application from all namespaces](https://108832--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/multiple_networks/secondary_networks/configuring-multi-network-policy.html)
