### PR TITLE
OSDOCS-18667-16: CP review for MNW-4: Secondary Network Advanced Conf…

### DIFF
--- a/modules/cnf-assigning-a-secondary-network-to-a-vrf.adoc
+++ b/modules/cnf-assigning-a-secondary-network-to-a-vrf.adoc
@@ -14,8 +14,6 @@ The Cluster Network Operator (CNO) manages secondary network definitions. When y
 Do not edit the `NetworkAttachmentDefinition` CRs that the Cluster Network Operator manages. Doing so might disrupt network traffic on your additional network.
 ====
 
-To create an additional network attachment with the CNI VRF plugin, perform the following procedure.
-
 .Prerequisites
 
 * Install the {oc-first}.

--- a/modules/nodes-nodes-swap-memory.adoc
+++ b/modules/nodes-nodes-swap-memory.adoc
@@ -78,8 +78,5 @@ where:
 +
 `failSwapOn`:: Set to `false` to enable swap memory use on the associated nodes. Set to `true` to disable swap memory use.
 `swapBehavior`:: Optional: Specify the swap memory behavior for {product-title} pods.
-+
-* `NoSwap`: {product-title} pods cannot use swap. This is the default.
-* `LimitedSwap`: {product-title} pods of Burstable QoS class only are permitted to employ swap.
 
 . Enable swap memory on the machines.


### PR DESCRIPTION
Version(s):
4.16

Issue:
[OSDOCS-18667](https://redhat.atlassian.net/browse/OSDOCS-18667)

Link to docs preview:

* https://108837--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/multiple_networks/assigning-a-secondary-network-to-a-vrf.html
* https://108837--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/nodes/nodes-nodes-managing.html


