### PR TITLE
OSDOCS:16989_2_4.16#AWS_IPI_CQA_Remediation

### DIFF
--- a/modules/installation-aws-permissions-iam-roles.adoc
+++ b/modules/installation-aws-permissions-iam-roles.adoc
@@ -7,9 +7,7 @@
 = Default permissions for IAM instance profiles
 
 [role="_abstract"]
-To ensure your cluster operates with the correct security permissions in {product-title}, review the default IAM instance profiles created by the installation program.
-
-By default, the installation program creates IAM instance profiles for the bootstrap, control plane, and compute instances with the necessary permissions for the cluster to operate.
+By default, the installation program creates IAM instance profiles for the bootstrap, control plane and worker instances with the necessary permissions for the cluster to operate.
 
 The following lists specify the default permissions for control plane and compute machines:
 

--- a/modules/nw-endpoint-route53.adoc
+++ b/modules/nw-endpoint-route53.adoc
@@ -7,9 +7,7 @@
 = Ingress Operator endpoint configuration for {aws-short} Route 53
 
 [role="_abstract"]
-Configure Ingress Operator endpoints for {product-title} clusters in {aws-first} GovCloud (US) regions. Verifying these settings helps to ensure that your cluster connects to the correct API endpoints.
-
-If you install in either {aws-short} GovCloud (US) US-West or US-East region, the Ingress Operator uses `us-gov-west-1` region for Route53 and tagging API clients.
+If you install in either {aws-first} GovCloud (US) US-West or US-East region, the Ingress Operator uses `us-gov-west-1` region for Route53 and tagging API clients.
 
 The Ingress Operator uses `https://tagging.us-gov-west-1.amazonaws.com` as the tagging API endpoint if a tagging custom endpoint is configured that includes the string `us-gov-east-1`.
 
@@ -36,9 +34,8 @@ platform:
     - name: tagging
       url: https://tagging.us-gov-west-1.amazonaws.com
 ----
-++
+
 where:
-++
 
 `https://route53.us-gov.amazonaws.com`:: Defaults to `https://route53.us-gov.amazonaws.com` for both {aws-short} GovCloud (US) regions.
 `https://tagging.us-gov-west-1.amazonaws.com`:: Only the US-West region has endpoints for tagging. Omit this parameter if your cluster is in another region.


### PR DESCRIPTION
Version:
4.16

Issue:
https://issues.redhat.com/browse/OSDOCS-16989

Link to docs preview:

- [Default permissions for IAM instance profiles](https://108842--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-aws-account.html#installation-aws-permissions-iam-roles_installing-aws-account)
- [Ingress Operator endpoint configuration for AWS Route 53](https://108842--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-aws-account.html#nw-endpoint-route53_installing-aws-account)

QE review:
No content changes, so QE approval is not required.

Additional information:
Remediation PR for https://github.com/openshift/openshift-docs/pull/104548. (This https://github.com/openshift/openshift-docs/pull/103257 required a manual CP to 4.16.) 
