### PR TITLE
OBSDOCS-3250: Fix typo in RBAC service account name

### DIFF
--- a/modules/otel-creating-required-RBAC-resources-automatically.adoc
+++ b/modules/otel-creating-required-RBAC-resources-automatically.adoc
@@ -11,7 +11,7 @@ Some Collector components require configuring the RBAC resources.
 
 .Procedure
 
-* Add the following permissions to the `opentelemetry-operator-controller-manage` service account so that the {OTELOperator} can create them automatically:
+* Add the following permissions to the `opentelemetry-operator-controller-manager` service account so that the {OTELOperator} can create them automatically:
 +
 [source,yaml]
 ----


### PR DESCRIPTION
Version(s): `main`, `3.9`, `3.8`
Issue: https://redhat.atlassian.net/browse/OBSDOCS-3250

The service account name `opentelemetry-operator-controller-manage` is missing the trailing "r" — should be `opentelemetry-operator-controller-manager`.