### PR TITLE
[power-monitoring-docs-0.5] CCSINTL-3120 [POWERMON] ConceptLink, missing short description

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -12,6 +12,8 @@ Distros: openshift-power-monitoring
 Topics:
 - Name: Power monitoring 0.5 release notes
   File: power-monitoring-release-notes-tp-0-5
+- Name: Power monitoring release notes
+  File: power-monitoring-release-notes
 ---
 Name: Installing power monitoring
 Dir: installing

--- a/about/about-power-monitoring.adoc
+++ b/about/about-power-monitoring.adoc
@@ -24,3 +24,5 @@ include::modules/power-monitoring-fips-support.adoc[leveloffset=+1]
 == Additional resources
 * xref:../visualizing/visualizing-power-monitoring-metrics.adoc#power-monitoring-dashboards-overview_visualizing-power-monitoring-metrics[{PM-shortname-c} dashboards overview]
 * link:https://docs.redhat.com/en/documentation/openshift_container_platform/latest/html-single/installation_overview/index#installing-preparing-security[Do you need extra security for your cluster?]
+* link:https://csrc.nist.gov/Projects/cryptographic-module-validation-program/validated-modules[Cryptographic module validation program]
+* link:https://access.redhat.com/en/compliance[Compliance activities and government standards]

--- a/installing/installing-power-monitoring.adoc
+++ b/installing/installing-power-monitoring.adoc
@@ -1,9 +1,7 @@
 :_mod-docs-content-type: ASSEMBLY
-include::_attributes/common-attributes.adoc[]
-
 [id="installing-power-monitoring"]
 = Installing {PM-title}
-
+include::_attributes/common-attributes.adoc[]
 :context: installing-power-monitoring
 
 toc::[]
@@ -11,7 +9,8 @@ toc::[]
 :FeatureName: Power monitoring
 include::snippets/technology-preview.adoc[leveloffset=+2]
 
-You can install {PM-title} by deploying the {PM-operator} in the {ocp} web console.
+[role="_abstract"]
+Install {PM-title} by deploying the {PM-operator} in the {ocp} web console.
 
 //Installing power monitoring operator
 include::modules/power-monitoring-installing-pmo.adoc[leveloffset=+1]

--- a/modules/power-monitoring-accessing-dashboards-admin.adoc
+++ b/modules/power-monitoring-accessing-dashboards-admin.adoc
@@ -20,6 +20,6 @@ You can access {PM-shortname} dashboards of the {ocp} web console.
 
 . In the web console, go to *Observe* -> *Dashboards*.
 
-. From the *Dashboard* drop-down list, select the {PM-shortname} dashboard you want to see:
+. From the *Dashboards* drop-down list, select the {PM-shortname} dashboard you want to see:
 ** *Power Monitor / Overview*
 ** *Power Monitor / Namespace (Pods)*

--- a/modules/power-monitoring-accessing-dashboards-developer.adoc
+++ b/modules/power-monitoring-accessing-dashboards-developer.adoc
@@ -6,7 +6,8 @@
 [id="power-monitoring-accessing-dashboards-developer_{context}"]
 = Accessing {PM-shortname} dashboards as a developer
 
-You can access {PM-shortname} dashboards from {ocp} web console.
+[role="_abstract"]
+Access {PM-shortname} dashboards from the {ocp} web console using developer credentials and view permissions for monitoring.
 
 .Prerequisites
 
@@ -19,7 +20,7 @@ You can access {PM-shortname} dashboards from {ocp} web console.
 
 .Procedure
 
-. In the web console, go to *Observe* -> *Dashboard*.
+. In the web console, go to *Observe* -> *Dashboards*.
 
-. From the *Dashboard* drop-down list, select the {PM-shortname} dashboard you want to see:
+. From the *Dashboards* drop-down list, select the {PM-shortname} dashboard you want to see:
 ** *Power Monitor / Overview*

--- a/modules/power-monitoring-fips-support.adoc
+++ b/modules/power-monitoring-fips-support.adoc
@@ -6,8 +6,9 @@
 [id="power-monitoring-fips-support_{context}"]
 = About FIPS compliance for {PM-operator}
 
-Starting with version 0.4, {PM-operator} for Red{nbsp}Hat OpenShift is FIPS compliant. When deployed on an {ocp} cluster in FIPS mode, it uses {op-system-base-full} cryptographic libraries validated by National Institute of Standards and Technology (NIST).
+[role="_abstract"]
+The {PM-operator} version 0.4 and later is FIPS compliant when deployed on {ocp} clusters in FIPS mode.
 
-For details on the NIST validation program, see link:https://csrc.nist.gov/Projects/cryptographic-module-validation-program/validated-modules[Cryptographic module validation program]. For the latest NIST status of {op-system-base} cryptographic libraries, see link:https://access.redhat.com/en/compliance[Compliance activities and government standards].
+When deployed on an {ocp} cluster in FIPS mode, it uses {op-system-base-full} cryptographic libraries validated by National Institute of Standards and Technology (NIST).
 
 To enable FIPS mode, you must install {PM-operator} for Red{nbsp}Hat OpenShift on an {ocp} cluster. For more information, see "Do you need extra security for your cluster?".

--- a/modules/power-monitoring-kepler-power-attribution-guide.adoc
+++ b/modules/power-monitoring-kepler-power-attribution-guide.adoc
@@ -2,6 +2,7 @@
 [id="power-monitoring-kepler-power-attribution-guide_{context}"]
 == Power monitoring Kepler power attribution guide
 
-Kepler's power attribution system provides practical, proportional distribution of hardware energy consumption to individual workloads. While CPU-time-based attribution has inherent limitations due to modern CPU complexity, it offers a good balance between accuracy, simplicity, and performance overhead for most monitoring and optimization use cases.
+[role="_abstract"]
+Kepler attributes hardware energy consumption proportionally to individual workloads using CPU-time-based distribution for practical power monitoring.
 
-For more information about power attribution, see link:http://sustainable-computing.io/kepler/usage/power-attribution[Kepler Power Attribution Guide].
+Although CPU-time-based attribution has inherent limitations due to modern CPU complexity, it offers a good balance between accuracy, simplicity, and performance overhead for most monitoring and optimization use cases.

--- a/modules/power-monitoring-monitoring-kepler-status.adoc
+++ b/modules/power-monitoring-monitoring-kepler-status.adoc
@@ -4,9 +4,10 @@
 
 :_mod-docs-content-type: CONCEPT
 [id="power-monitoring-monitoring-kepler-status_{context}"]
-= Monitoring the {PM-kepler} status
+= {PM-kepler} resource status
 
-You can monitor the state of the {PM-kepler} exporter with the `status` field of the `PowerMonitor` resource.
+[role="_abstract"]
+The `PowerMonitor` resource status field provides real-time information about Kepler pod deployment state and health across nodes.
 
 The `status` field includes information, such as the following:
 

--- a/modules/power-monitoring-overview.adoc
+++ b/modules/power-monitoring-overview.adoc
@@ -6,6 +6,9 @@
 [id="power-monitoring-overview_{context}"]
 = {PM-shortname-c} overview
 
+[role="_abstract"]
+{PM-title} tracks energy consumption across {ocp} cluster infrastructure and provides granular metrics for pods and namespaces.
+
 You can use {PM-title} to monitor the power usage and identify power-consuming containers running in an {ocp} cluster. {PM-shortname-c} collects and exports energy-related system statistics from various components, such as CPU and DRAM. It provides estimates and granular power consumption data for Kubernetes pods and namespaces, and reads the power consumption of nodes.
 
 [WARNING]

--- a/reference/power-monitoring-references.adoc
+++ b/reference/power-monitoring-references.adoc
@@ -1,16 +1,21 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="power-monitoring-references"]
 = Power monitoring references
-
 include::_attributes/common-attributes.adoc[]
-
 :context: power-monitoring-references
 
 toc::[]
+
+[role="_abstract"]
+Reference documentation for power monitoring, including power attribution methodology and external resources.
 
 :FeatureName: Power monitoring
 include::snippets/technology-preview.adoc[leveloffset=+2]
 
 include::modules/power-monitoring-kepler-power-attribution-guide.adoc[Leveloffset=+1]
+
+[id="additional-resources-power-monitoring-references_{context}"]
+.Additional resources
+* link:https://sustainable-computing.io/kepler/usage/power-attribution[Kepler Power Attribution Guide]
 
 //move API reference here post release. There may need to be additional IA updates for GA to better incorporate reference material.

--- a/release_notes/power-monitoring-release-notes-tp-0-5.adoc
+++ b/release_notes/power-monitoring-release-notes-tp-0-5.adoc
@@ -1,12 +1,13 @@
 :_mod-docs-content-type: ASSEMBLY
-include::_attributes/common-attributes.adoc[]
-
 [id="power-monitoring-assembly-tp-0-5-release-notes"]
 = {product-title} 0.5 (Technology Preview) release notes
-
+include::_attributes/common-attributes.adoc[]
 :context: power-monitoring-release-notes
 
 toc::[]
+
+[role="_abstract"]
+You can review the new features, enhancements, deprecated features, and component updates for the {PM-title} 0.5 (Technology Preview) release.
 
 //:FeatureName: Power monitoring
 //include::snippets/technology-preview.adoc[leveloffset=+2]
@@ -14,8 +15,6 @@ toc::[]
 {product-title} enables you to monitor the power usage of workloads and identify the most power-consuming namespaces running in an {ocp} cluster with key power consumption metrics, such as CPU or DRAM, measured at container level.
 ////
 These release notes track the development of {PM-title} in the {ocp}.
-
-For an overview of the {PM-operator}, see xref:../about/about-power-monitoring.adoc#power-monitoring-overview_about-power-monitoring[{PM-shortname-c} overview].
 
 include::modules/power-monitoring-release-notes-tp-0-5-overview.adoc[leveloffset=+1]
 include::modules/power-monitoring-release-notes-tp-0-5-new-features.adoc[leveloffset=+2]

--- a/release_notes/power-monitoring-release-notes.adoc
+++ b/release_notes/power-monitoring-release-notes.adoc
@@ -1,0 +1,17 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="power-monitoring-release-notes"]
+= {product-title} release notes
+include::_attributes/common-attributes.adoc[]
+:context: power-monitoring-release-notes
+
+toc::[]
+
+[role="_abstract"]
+{product-title} enables you to monitor the power usage of workloads and identify the most power-consuming namespaces running in an {ocp} cluster with key power consumption metrics, such as CPU or DRAM, measured at container level.
+
+:FeatureName: Power monitoring
+include::snippets/technology-preview.adoc[leveloffset=+2]
+
+These release notes track the development of {PM-title} in the {ocp}.
+
+//this file may be able to be removed. Will test after Vale fix PRs are merged.

--- a/visualizing/visualizing-power-monitoring-metrics.adoc
+++ b/visualizing/visualizing-power-monitoring-metrics.adoc
@@ -1,12 +1,13 @@
 :_mod-docs-content-type: ASSEMBLY
-include::_attributes/common-attributes.adoc[]
-
 [id="visualizing-power-monitoring-metrics"]
 = Visualizing power monitoring metrics
-
+include::_attributes/common-attributes.adoc[]
 :context: visualizing-power-monitoring-metrics
 
 toc::[]
+
+[role="_abstract"]
+Visualize {PM-shortname} metrics using dashboards and the Metrics explorer in the {ocp} web console.
 
 :FeatureName: Power monitoring
 include::snippets/technology-preview.adoc[leveloffset=+2]


### PR DESCRIPTION
Manual cherry-pick

Original commit: 64deea66b4ace6cc8e6786bb14586ea0c7cdbaf6

Original PR: https://github.com/openshift/openshift-docs/pull/108628

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
`power-monitoring-docs-0.5`


Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
QE is not required for this PR.

Additional information:
* 1 extra file for `release_notes/power-monitoring-release-notes.adoc` that should not be removed yet.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
