### PR TITLE
Telcodocs 2125 redo 422: RAN Hardening for High Security Issues

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -3537,6 +3537,8 @@ Topics:
   File: ztp-sno-additional-worker-node
 - Name: Pre-caching images for single-node OpenShift deployments
   File: ztp-precaching-tool
+- Name: Security hardening
+  File: ztp-security-hardening
 - Name: Image-based upgrade for single-node OpenShift clusters
   Dir: image_based_upgrade
   Distros: openshift-origin,openshift-enterprise

--- a/edge_computing/ztp-security-hardening.adoc
+++ b/edge_computing/ztp-security-hardening.adoc
@@ -12,7 +12,7 @@ include::snippets/technology-preview.adoc[leveloffset=+2]
 [role="_abstract"]
 [role="_abstract"]
 When you deploy a RAN cluster using the RAN reference design specification (RDS), high-severity security fixes are applied automatically.
-These fixes address compliance issues identified by the Compliance Operator running the essential eight (E8) security profile.
+These fixes address compliance issues identified by the Compliance Operator running the Essential 8 (E8) security and Center for Internet Security (CIS) profile.
 
 The following section describe the hardening configurations that the RDS applies.
 

--- a/edge_computing/ztp-security-hardening.adoc
+++ b/edge_computing/ztp-security-hardening.adoc
@@ -12,8 +12,7 @@ include::snippets/technology-preview.adoc[leveloffset=+2]
 [role="_abstract"]
 When you deploy a RAN cluster using the RAN reference design specification (RDS), high-severity security fixes are applied automatically.
 These fixes address compliance issues identified by the Compliance Operator running the Essential 8 (E8) security and Center for Internet Security (CIS) profile.
-
-The following section describe the hardening configurations that the RDS applies.
+The following sections describe the hardening configurations that the RDS applies.
 
 include::modules/ztp-high-security-issues-addressed.adoc[leveloffset=+1]
 

--- a/edge_computing/ztp-security-hardening.adoc
+++ b/edge_computing/ztp-security-hardening.adoc
@@ -1,0 +1,25 @@
+_mod-docs-content-type: ASSEMBLY
+[id="ztp-security-hardening"]
+= Security hardening for edge deployments (Technology preview)
+include::_attributes/common-attributes.adoc[]
+:context: security-hardening
+
+toc::[]
+
+:FeatureName: RAN hardening for high security issues
+include::snippets/technology-preview.adoc[leveloffset=+2]
+
+Security hardening is important for protecting edge deployments. NIST SP 800-53 and CIS Kubernetes benchmarks provide the foundation for securing containerized workloads, enforcing zero trust, and ensuring regulatory compliance. To mitigate risks, safeguard critical telecommunications infrastructure, and enhance resilience at the edge, it is vital to align with these security frameworks.
+
+The Compliance Operator on {product-title}, running a custom telecommunications security profile based on NIST SP 800-53 and CIS Kubernetes benchmark v1.5.0, identified areas for security hardening and validated adherence to best practices. Using ZTP manifests, enhancements in {product-version} provide these critical security controls. The following sections detail the high-severity security hardening measures being implemented.
+
+include::modules/ztp-high-security-issues-addressed.adoc[leveloffset=+1]
+
+
+[role="_additional-resources"]
+.Additional resources
+
+* link:https://csrc.nist.gov/publications/detail/sp/800-53/rev-5/final[NIST SP 800-53]
+* link:https://www.cisecurity.org/benchmark/kubernetes/[CIS Kubernetes benchmarks]
+* xref:../security/compliance_operator/co-concepts/compliance-operator-understanding.adoc#compliance-operator-understanding[Understanding the Compliance Operator]
+* xref:../edge_computing/ztp-reference-cluster-configuration-for-vdu.adoc#ztp-du-configuring-host-firmware-requirements_sno-configure-for-vdu[Configuring host firmware for low latency and high performance]

--- a/edge_computing/ztp-security-hardening.adoc
+++ b/edge_computing/ztp-security-hardening.adoc
@@ -10,7 +10,6 @@ toc::[]
 include::snippets/technology-preview.adoc[leveloffset=+2]
 
 [role="_abstract"]
-[role="_abstract"]
 When you deploy a RAN cluster using the RAN reference design specification (RDS), high-severity security fixes are applied automatically.
 These fixes address compliance issues identified by the Compliance Operator running the Essential 8 (E8) security and Center for Internet Security (CIS) profile.
 

--- a/edge_computing/ztp-security-hardening.adoc
+++ b/edge_computing/ztp-security-hardening.adoc
@@ -1,4 +1,4 @@
-_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: ASSEMBLY
 [id="ztp-security-hardening"]
 = Security hardening for edge deployments (Technology preview)
 include::_attributes/common-attributes.adoc[]

--- a/edge_computing/ztp-security-hardening.adoc
+++ b/edge_computing/ztp-security-hardening.adoc
@@ -6,9 +6,6 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-:FeatureName: RAN hardening for high security issues
-include::snippets/technology-preview.adoc[leveloffset=+2]
-
 Security hardening is important for protecting edge deployments. NIST SP 800-53 and CIS Kubernetes benchmarks provide the foundation for securing containerized workloads, enforcing zero trust, and ensuring regulatory compliance. To mitigate risks, safeguard critical telecommunications infrastructure, and enhance resilience at the edge, it is vital to align with these security frameworks.
 
 The Compliance Operator on {product-title}, running a custom telecommunications security profile based on NIST SP 800-53 and CIS Kubernetes benchmark v1.5.0, identified areas for security hardening and validated adherence to best practices. Using ZTP manifests, enhancements in {product-version} provide these critical security controls. The following sections detail the high-severity security hardening measures being implemented.

--- a/edge_computing/ztp-security-hardening.adoc
+++ b/edge_computing/ztp-security-hardening.adoc
@@ -10,21 +10,16 @@ toc::[]
 include::snippets/technology-preview.adoc[leveloffset=+2]
 
 [role="_abstract"]
-{product-title} {product-version} introduces automatic security hardening for Radio Access Network (RAN) deployments.
-The Compliance Operator, running the Essential Eight (E8) security profile, identifies compliance flags that require remediation.
-These remediations are grouped into high-severity priority groups (H1, H2, H3) and are applied automatically when you deploy the recommended reference design specification (RDS).
+[role="_abstract"]
+When you deploy a RAN cluster using the RAN reference design specification (RDS), high-severity security fixes are applied automatically.
+These fixes address compliance issues identified by the Compliance Operator running the essential eight (E8) security profile.
 
-You do not need to manually apply these security controls.
-When you deploy a cluster by using the RAN RDS, the hardening `MachineConfig` objects are included automatically.
-The following sections describe the high-severity compliance remediations that the RDS applies.
+The following section describe the hardening configurations that the RDS applies.
 
 include::modules/ztp-high-security-issues-addressed.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources
 
-* link:https://sebrandon1.github.io/compliance-scripts/versions/4.21/groups/H1.html[H1: Crypto policy remediation details]
-* link:https://sebrandon1.github.io/compliance-scripts/versions/4.21/groups/H2.html[H2: PAM empty passwords remediation details]
-* link:https://sebrandon1.github.io/compliance-scripts/versions/4.21/groups/H3.html[H3: SSHD empty passwords remediation details]
 * xref:../security/compliance_operator/co-concepts/compliance-operator-understanding.adoc#compliance-operator-understanding[Understanding the Compliance Operator]
 * xref:../edge_computing/ztp-reference-cluster-configuration-for-vdu.adoc#sno-configure-for-vdu[Recommended single-node OpenShift cluster configuration for vDU application workloads]

--- a/edge_computing/ztp-security-hardening.adoc
+++ b/edge_computing/ztp-security-hardening.adoc
@@ -1,29 +1,30 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="ztp-security-hardening"]
-= Security hardening for edge deployments (Technology Preview)
+= Security hardening for RAN deployments (Technology Preview)
 include::_attributes/common-attributes.adoc[]
 :context: security-hardening
 
 toc::[]
 
-:FeatureName: RAN hardening for high security issues
+:FeatureName: RAN security hardening for high-severity compliance issues
 include::snippets/technology-preview.adoc[leveloffset=+2]
 
 [role="_abstract"]
-Security hardening is important for protecting edge deployments.
-National Institute of Standards and Technology (NIST) SP 800-53 and Center for Internet Security (CIS) Kubernetes benchmarks provide the foundation for securing containerized workloads, enforcing zero trust, and ensuring regulatory compliance.
-To mitigate risks, safeguard critical telecommunications infrastructure, and enhance resilience at the edge, it is vital to align with these security frameworks.
+{product-title} {product-version} introduces automatic security hardening for Radio Access Network (RAN) deployments.
+The Compliance Operator, running the Essential Eight (E8) security profile, identifies compliance flags that require remediation.
+These remediations are grouped into high-severity priority groups (H1, H2, H3) and are applied automatically when you deploy the recommended reference design specification (RDS).
 
-The Compliance Operator on {product-title}, running a custom telecommunications security profile based on NIST SP 800-53 and CIS Kubernetes benchmark v1.5.0, identifies areas for security hardening and validates adherence to best practices.
-Using ZTP manifests, enhancements in {product-version} deliver these critical security controls.
-The following sections detail the high-severity security hardening measures that are implemented.
+You do not need to manually apply these security controls.
+When you deploy a cluster by using the RAN RDS, the hardening `MachineConfig` objects are included automatically.
+The following sections describe the high-severity compliance remediations that the RDS applies.
 
 include::modules/ztp-high-security-issues-addressed.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources
 
-* link:https://csrc.nist.gov/publications/detail/sp/800-53/rev-5/final[NIST SP 800-53]
-* link:https://www.cisecurity.org/benchmark/kubernetes/[CIS Kubernetes benchmarks]
+* link:https://sebrandon1.github.io/compliance-scripts/versions/4.21/groups/H1.html[H1: Crypto policy remediation details]
+* link:https://sebrandon1.github.io/compliance-scripts/versions/4.21/groups/H2.html[H2: PAM empty passwords remediation details]
+* link:https://sebrandon1.github.io/compliance-scripts/versions/4.21/groups/H3.html[H3: SSHD empty passwords remediation details]
 * xref:../security/compliance_operator/co-concepts/compliance-operator-understanding.adoc#compliance-operator-understanding[Understanding the Compliance Operator]
-* xref:../edge_computing/ztp-reference-cluster-configuration-for-vdu.adoc#ztp-du-configuring-host-firmware-requirements_sno-configure-for-vdu[Configuring host firmware for low latency and high performance]
+* xref:../edge_computing/ztp-reference-cluster-configuration-for-vdu.adoc#sno-configure-for-vdu[Recommended single-node OpenShift cluster configuration for vDU application workloads]

--- a/edge_computing/ztp-security-hardening.adoc
+++ b/edge_computing/ztp-security-hardening.adoc
@@ -1,17 +1,24 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="ztp-security-hardening"]
-= Security hardening for edge deployments (Technology preview)
+= Security hardening for edge deployments (Technology Preview)
 include::_attributes/common-attributes.adoc[]
 :context: security-hardening
 
 toc::[]
 
-Security hardening is important for protecting edge deployments. NIST SP 800-53 and CIS Kubernetes benchmarks provide the foundation for securing containerized workloads, enforcing zero trust, and ensuring regulatory compliance. To mitigate risks, safeguard critical telecommunications infrastructure, and enhance resilience at the edge, it is vital to align with these security frameworks.
+:FeatureName: RAN hardening for high security issues
+include::snippets/technology-preview.adoc[leveloffset=+2]
 
-The Compliance Operator on {product-title}, running a custom telecommunications security profile based on NIST SP 800-53 and CIS Kubernetes benchmark v1.5.0, identified areas for security hardening and validated adherence to best practices. Using ZTP manifests, enhancements in {product-version} provide these critical security controls. The following sections detail the high-severity security hardening measures being implemented.
+[role="_abstract"]
+Security hardening is important for protecting edge deployments.
+National Institute of Standards and Technology (NIST) SP 800-53 and Center for Internet Security (CIS) Kubernetes benchmarks provide the foundation for securing containerized workloads, enforcing zero trust, and ensuring regulatory compliance.
+To mitigate risks, safeguard critical telecommunications infrastructure, and enhance resilience at the edge, it is vital to align with these security frameworks.
+
+The Compliance Operator on {product-title}, running a custom telecommunications security profile based on NIST SP 800-53 and CIS Kubernetes benchmark v1.5.0, identifies areas for security hardening and validates adherence to best practices.
+Using ZTP manifests, enhancements in {product-version} deliver these critical security controls.
+The following sections detail the high-severity security hardening measures that are implemented.
 
 include::modules/ztp-high-security-issues-addressed.adoc[leveloffset=+1]
-
 
 [role="_additional-resources"]
 .Additional resources

--- a/modules/ztp-du-host-firmware-requirements.adoc
+++ b/modules/ztp-du-host-firmware-requirements.adoc
@@ -6,13 +6,14 @@
 [id="ztp-du-configuring-host-firmware-requirements_{context}"]
 = Configuring host firmware for low latency and high performance
 
-Bare-metal hosts require the firmware to be configured before the host can be provisioned. The firmware configuration is dependent on the specific hardware and the particular requirements of your installation.
+[role="_abstract"]
+Before you provision bare-metal hosts, you must configure the firmware. The firmware configuration depends on the specific hardware and the particular requirements of your installation.
 
 .Procedure
 
 . Set the *UEFI/BIOS Boot Mode* to `UEFI`.
 . In the host boot sequence order, set *Hard drive first*.
-. Apply the specific firmware configuration for your hardware. The following table describes a representative firmware configuration for an Intel Xeon Skylake server and later hardware generations, based on the Intel FlexRAN 4G and 5G baseband PHY reference design.
+. Apply the specific firmware configuration for your hardware. The following table describes a representative firmware configuration for an Intel Xeon Skylake server and later hardware generations, based on the Intel FlexRAN 4G and 5G baseband physical layer (PHY) reference design.
 +
 [IMPORTANT]
 ====
@@ -37,19 +38,19 @@ The exact firmware configuration depends on your specific hardware and network r
 |Enhanced Intel SpeedStep (R) Tech
 |Enabled
 
-|Intel Configurable TDP
+|Intel Configurable TDP (Thermal Design Power)
 |Enabled
 
-|Configurable TDP Level
+|Configurable TDP (Thermal Design Power) Level
 |Level 2
 
-|Intel(R) Turbo Boost Technology
+|Intel Turbo Boost Technology
 |Enabled
 
 |Energy Efficient Turbo
 |Disabled
 
-|Hardware P-States
+|Hardware P-states
 |Disabled
 
 |Package C-State
@@ -60,8 +61,17 @@ The exact firmware configuration depends on your specific hardware and network r
 
 |Processor C6
 |Disabled
-|====
 
+|USB Boot
+|Disabled
+
+|Wireless LAN
+|Disabled
+
+|Bluetooth
+|Disabled
+|====
++
 [NOTE]
 ====
 Enable global SR-IOV and VT-d settings in the firmware for the host. These settings are relevant to bare-metal environments.

--- a/modules/ztp-du-host-firmware-requirements.adoc
+++ b/modules/ztp-du-host-firmware-requirements.adoc
@@ -6,14 +6,13 @@
 [id="ztp-du-configuring-host-firmware-requirements_{context}"]
 = Configuring host firmware for low latency and high performance
 
-[role="_abstract"]
-Before you provision bare-metal hosts, you must configure the firmware. The firmware configuration depends on the specific hardware and the particular requirements of your installation.
+Bare-metal hosts require the firmware to be configured before the host can be provisioned. The firmware configuration is dependent on the specific hardware and the particular requirements of your installation.
 
 .Procedure
 
 . Set the *UEFI/BIOS Boot Mode* to `UEFI`.
 . In the host boot sequence order, set *Hard drive first*.
-. Apply the specific firmware configuration for your hardware. The following table describes a representative firmware configuration for an Intel Xeon Skylake server and later hardware generations, based on the Intel FlexRAN 4G and 5G baseband physical layer (PHY) reference design.
+. Apply the specific firmware configuration for your hardware. The following table describes a representative firmware configuration for an Intel Xeon Skylake server and later hardware generations, based on the Intel FlexRAN 4G and 5G baseband PHY reference design.
 +
 [IMPORTANT]
 ====
@@ -38,19 +37,19 @@ The exact firmware configuration depends on your specific hardware and network r
 |Enhanced Intel SpeedStep (R) Tech
 |Enabled
 
-|Intel Configurable TDP (Thermal Design Power)
+|Intel Configurable TDP
 |Enabled
 
-|Configurable TDP (Thermal Design Power) Level
+|Configurable TDP Level
 |Level 2
 
-|Intel Turbo Boost Technology
+|Intel(R) Turbo Boost Technology
 |Enabled
 
 |Energy Efficient Turbo
 |Disabled
 
-|Hardware P-states
+|Hardware P-States
 |Disabled
 
 |Package C-State
@@ -61,17 +60,8 @@ The exact firmware configuration depends on your specific hardware and network r
 
 |Processor C6
 |Disabled
-
-|USB Boot
-|Disabled
-
-|Wireless LAN
-|Disabled
-
-|Bluetooth
-|Disabled
 |====
-+
+
 [NOTE]
 ====
 Enable global SR-IOV and VT-d settings in the firmware for the host. These settings are relevant to bare-metal environments.

--- a/modules/ztp-high-security-issues-addressed.adoc
+++ b/modules/ztp-high-security-issues-addressed.adoc
@@ -1,0 +1,37 @@
+// Module included in the following assemblies:
+//
+// * scalability_and_performance/ztp_far_edge/ztp-security-hardening.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="ztp-addressed-security-issues_{context}"]
+= Security hardening measures implemented
+
+== Disabling USB boot, wireless and bluetooth access
+
+To prevent unauthorized modifications to the operating system and to reduce the risk of physical attack vectors, USB boot, wireless, and Bluetooth are disabled in the BIOS settings. These settings are not controlled by using ZTP configuration. Disabling USB boot prevents attackers from booting from a USB drive and gaining unauthorized access to the system. The recommended firmware configuration is described in "Configuring host firmware for low latency and high performance".
+
+== Preventing unauthorized reboots
+
+Disabling `CtrlAltDelBurstAction` and `Ctrl+Alt+Del` actions prevents unauthorized reboots.
+
+== Restricting direct SSH access
+
+Direct SSH access to {product-title} is limited by disabling the `root` login.
+
+== Disabling passwordless logins
+
+This feature enforces strict authentication policies by disabling logins for accounts without passwords to ensure compliance with security best practices and reduce unauthorized access risks.
+
+== Ensure that the RBAC setup follows the principle of least privilege
+
+To minimize the risk of unauthorized access, the RBAC setup follows the principle of least privilege, as described in "Using RBAC to define and apply permissions", granting users the minimum required permissions.
+
+{product-title} provides the tools for creating minimal permissions. However, you must assess the needs of users and services within your environment and apply the principle of least privilege accordingly.
+
+For example, consider creating a role that:
+
+* Provides permissions to control user access, such as granting users the ability to view resources without modifying them.
+* Enables developers to manage only deployments and services within a specific namespace, without granting access to sensitive resources.
+* Allows users to view configuration resources, such as `ConfigMaps` and `Secrets`, but not change them.
+
+Regularly review and update permissions to ensure that users have only the permissions necessary to perform their tasks.

--- a/modules/ztp-high-security-issues-addressed.adoc
+++ b/modules/ztp-high-security-issues-addressed.adoc
@@ -1,37 +1,261 @@
 // Module included in the following assemblies:
 //
-// * scalability_and_performance/ztp_far_edge/ztp-security-hardening.adoc
+// * edge_computing/ztp-security-hardening.adoc
 
 :_mod-docs-content-type: CONCEPT
 [id="ztp-addressed-security-issues_{context}"]
 = Security hardening measures implemented
 
-Disabling USB boot, wireless and bluetooth access
+[role="_abstract"]
+These high-severity security hardening measures address compliance requirements from National Institute of Standards and Technology (NIST) SP 800-53 and Center for Internet Security (CIS) Kubernetes benchmark v1.5.0.
+The measures are delivered through firmware configuration changes (outside ZTP) and ZTP-managed `MachineConfig` objects that enforce system-wide security controls.
 
-To prevent unauthorized modifications to the operating system and to reduce the risk of physical attack vectors, USB boot, wireless, and Bluetooth are disabled in the BIOS settings. These settings are not controlled by using ZTP configuration. Disabling USB boot prevents attackers from booting from a USB drive and gaining unauthorized access to the system. The recommended firmware configuration is described in "Configuring host firmware for low latency and high performance".
+.Applicability matrix: Day 0 versus Day 2 operations
+[cols="3,2,2,2,3", width="100%", options="header"]
+|====
+|Control
+|Day 0 only
+|Day 2 safe
+|Requires reboot
+|Notes
 
-Preventing unauthorized reboots
+|USB boot, wireless, Bluetooth disable
+|
+|✓
+|
+|Firmware configuration; no workload impact
+
+|Ctrl+Alt+Del protection
+|
+|✓
+|
+|`MachineConfig`; no reboot required
+
+|SSH root login restriction
+|
+|✓
+|✓
+|`MachineConfig`; verify no automated scripts use root SSH before applying
+
+|Cryptographic policy enforcement
+|
+|✓
+|✓
+|`MachineConfig`; mandatory reboot; might affect services using deprecated ciphers
+
+|Passwordless login disable
+|
+|✓
+|✓
+|`MachineConfig`; mandatory reboot; verify no accounts rely on passwordless access
+
+|RBAC least privilege
+|✓
+|✓
+|
+|Apply at Day 0; refine continuously; no reboot required
+|====
+
+== Disabling USB boot, wireless, and Bluetooth access
+
+To prevent unauthorized modifications to the operating system and reduce physical attack vectors, you disable USB boot, wireless, and Bluetooth in firmware settings.
+ZTP configuration does not control these settings.
+
+Disabling USB boot prevents attackers from booting from a USB drive and gaining unauthorized access to the system.
+Disabling wireless and Bluetooth eliminates additional physical attack vectors that attackers could exploit to compromise the host.
+
+The recommended firmware configuration is in xref:../edge_computing/ztp-reference-cluster-configuration-for-vdu.adoc#ztp-du-configuring-host-firmware-requirements_sno-configure-for-vdu[Configuring host firmware for low latency and high performance].
+Specifically, see the *USB Boot*, *Wireless LAN*, and *Bluetooth* rows in the firmware configuration table, which should all be set to *Disabled*.
+
+== Preventing unauthorized reboots
 
 Disabling `CtrlAltDelBurstAction` and `Ctrl+Alt+Del` actions prevents unauthorized reboots.
+This mitigates the risk that an attacker with physical access could trigger a denial of service by forcing unexpected system restarts.
 
-Restricting direct SSH access
+In RHEL systems, `CtrlAltDelBurstAction` is a systemd-logind configuration parameter that allows rapid Ctrl+Alt+Del key sequences to trigger an emergency reboot without authentication.
+When you disable this feature through `MachineConfig`, the emergency reboot path is blocked, requiring proper authentication and authorization for any system reboot.
+This is critical for telecommunications deployments that must keep availability up and prevent physical attackers from forcing denial-of-service reboots.
 
-Direct SSH access to {product-title} is limited by disabling the `root` login.
+After you apply this control, pressing Ctrl+Alt+Del has no effect on the system; only properly authorized administrators can start reboots through standard administrative channels.
 
-Disabling passwordless logins
+Ctrl+Alt+Del reboot protection is enforced through a `MachineConfig` object delivered through ZTP manifests.
 
-This feature enforces strict authentication policies by disabling logins for accounts without passwords to ensure compliance with security best practices and reduce unauthorized access risks.
+A sample `MachineConfig` object for disabling Ctrl+Alt+Del burst action (applied to all nodes) looks like the following:
 
-Ensure that the RBAC setup follows the principle of least privilege
+----
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  name: disable-ctrl-alt-del
+spec:
+  config:
+    ignition:
+      version: 3.2.0
+    storage:
+      files:
+      - path: /etc/systemd/logind.conf.d/99-disable-ctrl-alt-del-burst
+        mode: 0644
+        contents:
+          source: data:,%5BLogind%5D%0ACtrlAltDelBurstAction%3Dnone
+nodeSelector: {}
+----
 
-To minimize the risk of unauthorized access, the RBAC setup follows the principle of least privilege, as described in "Using RBAC to define and apply permissions", granting users the minimum required permissions.
+You can verify that this control is active by checking that `CtrlAltDelBurstAction` is set to `none` on each node:
 
-{product-title} provides the tools for creating minimal permissions. However, you must assess the needs of users and services within your environment and apply the principle of least privilege accordingly.
+----
+oc debug node/<node-name> -- chroot /host cat /etc/systemd/logind.conf.d/99-disable-ctrl-alt-del-burst | grep CtrlAltDelBurstAction
+----
 
-For example, consider creating a role that:
+== Restricting direct SSH access
 
-* Provides permissions to control user access, such as granting users the ability to view resources without modifying them.
-* Enables developers to manage only deployments and services within a specific namespace, without granting access to sensitive resources.
-* Allows users to view configuration resources, such as `ConfigMaps` and `Secrets`, but not change them.
+You can limit direct SSH access to {product-title} by disabling the `root` login.
+This prevents attackers from gaining administrative access through brute-force attacks or credential compromise targeting the root account.
+
+SSH root login is disabled through a `MachineConfig` object that modifies SSH daemon (SSHD) configuration, delivered through ZTP manifests.
+
+A sample `MachineConfig` object for disabling root SSH access (applied to worker nodes) looks like the following:
+
+----
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  name: disable-root-ssh
+spec:
+  config:
+    ignition:
+      version: 3.2.0
+    storage:
+      files:
+      - path: /etc/ssh/sshd_config.d/99-disable-root-login
+        mode: 0644
+        contents:
+          source: data:,PermitRootLogin%20no
+nodeSelector:
+  node-role.kubernetes.io/worker: ""
+----
+
+After you apply this `MachineConfig` (which triggers a node reboot), you can verify that root SSH login is disabled by running:
+
+----
+oc debug node/<node-name> -- chroot /host grep "PermitRootLogin" /etc/ssh/sshd_config.d/99-disable-root-login
+----
+
+This should return `PermitRootLogin no`, confirming that the SSH restriction is active.
+
+== Enforcing system-wide cryptographic policy
+
+System-wide cryptographic policy enforcement disables weaker cipher suites and ensures that all components use strong cryptographic algorithms.
+The default cryptographic policy is set to `DEFAULT:NO-SHA1`, which removes support for SHA-1 digest algorithms.
+This prevents downgrade attacks and ensures compliance with modern cryptographic standards required by NIST SP 800-53.
+
+Removing SHA-1 support might affect older clients or services that rely on SHA-1 for certificate verification or data integrity.
+Test this control in a non-production environment before applying to production clusters to ensure compatibility with your workloads.
+
+Cryptographic policy changes are enforced through a `MachineConfig` object that updates the system-wide cryptographic policy, delivered through ZTP manifests.
+
+A sample `MachineConfig` object for enforcing the `DEFAULT:NO-SHA1` cryptographic policy (applied to all nodes) looks like the following:
+
+----
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  name: enforce-crypto-policy
+spec:
+  config:
+    ignition:
+      version: 3.2.0
+    systemd:
+      units:
+      - name: update-crypto-policies.service
+        enabled: true
+        contents: |
+          [Unit]
+          Description=Update crypto policies to DEFAULT:NO-SHA1
+          After=network.target
+          [Service]
+          Type=oneshot
+          ExecStart=/usr/bin/update-crypto-policies --set DEFAULT:NO-SHA1
+          RemainAfterExit=yes
+nodeSelector: {}
+----
+
+To verify that the cryptographic policy has been applied correctly after the `MachineConfig` is reconciled, run:
+
+----
+oc debug node/<node-name> -- chroot /host update-crypto-policies --show
+----
+
+This command should display `DEFAULT:NO-SHA1`, confirming that SHA-1 support has been disabled.
+
+[WARNING]
+====
+Applying or updating crypto policy MachineConfig objects triggers mandatory node reboot events.
+Plan your maintenance window accordingly to minimize service disruption.
+====
+
+== Disabling passwordless logins
+
+This feature enforces strict authentication policies by disabling logins for accounts without passwords.
+Removing the `nullok` Pluggable Authentication Modules (PAM) option ensures that all user accounts require a password to authenticate, reducing the risk of unauthorized access.
+
+PAM authentication changes are enforced through a `MachineConfig` object that removes the `nullok` parameter from PAM configuration files, delivered through ZTP manifests.
+
+A sample `MachineConfig` object for disabling password-less logins (applied to worker nodes) looks like the following:
+
+----
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  name: disable-nullok-pam
+spec:
+  config:
+    ignition:
+      version: 3.2.0
+    storage:
+      files:
+      - path: /etc/pam.d/system-auth.d/99-disable-nullok
+        mode: 0644
+        contents:
+          source: data:,auth%20%20required%20%20pam_deny.so%0A
+nodeSelector:
+  node-role.kubernetes.io/worker: ""
+----
+
+After you apply this `MachineConfig`, verify that the `nullok` option has been removed from PAM configuration:
+
+----
+oc debug node/<node-name> -- chroot /host grep -r "nullok" /etc/pam.d/
+----
+
+This command should return no results, confirming that password-less login accounts are disabled.
+
+[WARNING]
+====
+Applying or updating PAM `MachineConfig` objects triggers mandatory node reboot events.
+Plan your maintenance window accordingly to minimize service disruption.
+Before applying this control, verify that no automated scripts or services depend on passwordless account access.
+====
+
+== Ensuring RBAC follows the principle of least privilege
+
+To minimize the risk of unauthorized access, the RBAC setup follows the principle of least privilege, as described in xref:../authentication/using-rbac.adoc#using-rbac[Using RBAC to define and apply permissions].
+
+In the context of security hardening for RAN deployments, RBAC controls are essential to prevent tampering with the security measures described in the preceding sections.
+Specifically, you must restrict who can:
+
+* Create, change, or delete `MachineConfig` objects (which enforce cryptographic policy, SSH restrictions, and PAM settings)
+* View or change SSH daemon (SSHD) configuration files
+* Change system-wide cryptographic policies
+* Change or remove the `SecurityContextConstraints` (SCC) policies that enforce pod security
+
+{product-title} provides the tools for creating minimal permissions.
+However, you must assess the needs of users and services within your environment and apply the principle of least privilege accordingly.
+
+For example, consider creating the following RBAC roles:
+
+* A restricted `machineconfig-admins` `ClusterRole` that grants permission to view and change `MachineConfig` objects only to a small set of cluster administrators who are responsible for security compliance.
+* A developer role that permits only deployment and service management within a specific namespace, without access to cluster-wide security resources such as `MachineConfigs` or `SecurityContextConstraints`.
+* An auditor role that permits viewing (but not changing) security-relevant resources such as `MachineConfigs`, SCC policies, and audit logs.
 
 Regularly review and update permissions to ensure that users have only the permissions necessary to perform their tasks.
+Use the audit logs to monitor who accessed or changed security-relevant resources, and verify that only authorized administrators can change the hardening controls described in the preceding sections.

--- a/modules/ztp-high-security-issues-addressed.adoc
+++ b/modules/ztp-high-security-issues-addressed.adoc
@@ -8,13 +8,14 @@
 
 [role="_abstract"]
 The following security configurations are applied automatically when the RAN RDS is applied to a cluster.
-These `MachineConfig` objects address high-severity compliance issues identified by the essential eight (E8) profile.
+These `MachineConfig` objects address high-severity compliance issues identified by the Essential E8 and Center for Internet Security (CIS) profiles.
 
 == System-wide cryptographic policy enforcement
 
 This security fix enforces the `DEFAULT:NO-SHA1` system-wide cryptographic policy, which removes support for SHA-1 digest algorithms.
 
-To verify that the SHA-1 algorithms have been disabled on a node, run:
+To verify that the SHA-1 algorithms have been disabled on a node, run the following command:
+
 ----
 $ oc debug node/<node-name> -- chroot /host update-crypto-policies --show
 ----
@@ -25,7 +26,7 @@ The expected output is `DEFAULT:NO-SHA1`.
 
 This security fix removes the `nullok` option from pluggable authentication modules (PAM) configuration, preventing authentication for accounts that have empty passwords.
 
-To verify that empty password authentication is disabled on a node, run:
+To verify that empty password authentication is disabled on a node, run the following command:
 
 ----
 $ oc debug node/<node-name> -- chroot /host grep nullok /etc/pam.d/system-auth /etc/pam.d/password-auth
@@ -37,7 +38,7 @@ This command should return no output, confirming that the `nullok` option has be
 
 This security fix configures the SSH daemon to explicitly deny authentication with empty passwords.
 
-To verify that SSHD empty password authentication is disabled on a node, run:
+To verify that SSHD empty password authentication is disabled on a node, run the following command:
 
 ----
 $ oc debug node/<node-name> -- chroot /host grep PermitEmptyPasswords /etc/ssh/sshd_config.d/75-hardening.conf

--- a/modules/ztp-high-security-issues-addressed.adoc
+++ b/modules/ztp-high-security-issues-addressed.adoc
@@ -10,10 +10,9 @@
 The following security configurations are applied automatically when the RAN RDS is applied to a cluster.
 These `MachineConfig` objects address high-severity compliance issues identified by the essential eight (E8) profile.
 
-System-wide cryptographic policy enforcement
+== System-wide cryptographic policy enforcement
 
 This security fix enforces the `DEFAULT:NO-SHA1` system-wide cryptographic policy, which removes support for SHA-1 digest algorithms.
-SHA-1 has known security vulnerabilities and has been deprecated by industry security standards.
 
 To verify that the SHA-1 algorithms have been disabled on a node, run:
 ----
@@ -22,12 +21,7 @@ $ oc debug node/<node-name> -- chroot /host update-crypto-policies --show
 
 The expected output is `DEFAULT:NO-SHA1`.
 
-[WARNING]
-====
-Removing SHA-1 support might affect older clients or services that rely on SHA-1 for certificate verification or data integrity.
-====
-
-Disabling PAM empty password authentication
+== Disabling PAM empty password authentication
 
 This security fix removes the `nullok` option from pluggable authentication modules (PAM) configuration, preventing authentication for accounts that have empty passwords.
 

--- a/modules/ztp-high-security-issues-addressed.adoc
+++ b/modules/ztp-high-security-issues-addressed.adoc
@@ -4,258 +4,76 @@
 
 :_mod-docs-content-type: CONCEPT
 [id="ztp-addressed-security-issues_{context}"]
-= Security hardening measures implemented
+= High-severity compliance remediations
 
 [role="_abstract"]
-These high-severity security hardening measures address compliance requirements from National Institute of Standards and Technology (NIST) SP 800-53 and Center for Internet Security (CIS) Kubernetes benchmark v1.5.0.
-The measures are delivered through firmware configuration changes (outside ZTP) and ZTP-managed `MachineConfig` objects that enforce system-wide security controls.
+The RAN reference design specification (RDS) for {product-title} {product-version} includes `MachineConfig` objects that remediate high-severity compliance flags identified by the Compliance Operator Essential Eight (E8) profile.
+These remediations are organized into three priority groups: H1, H2, and H3.
+The `MachineConfig` objects are applied automatically to both control plane and worker nodes when you deploy a cluster by using the RDS.
 
-.Applicability matrix: Day 0 versus Day 2 operations
-[cols="3,2,2,2,3", width="100%", options="header"]
-|====
-|Control
-|Day 0 only
-|Day 2 safe
-|Requires reboot
-|Notes
+[NOTE]
+====
+You do not need to manually apply these `MachineConfig` objects.
+They are included in the RDS and are deployed automatically through ZTP provisioning.
+If you need to remove a specific remediation, you can delete the corresponding `MachineConfig` object from the cluster.
+====
 
-|USB boot, wireless, Bluetooth disable
-|
-|✓
-|
-|Firmware configuration; no workload impact
+== H1: System-wide cryptographic policy enforcement
 
-|Ctrl+Alt+Del protection
-|
-|✓
-|
-|`MachineConfig`; no reboot required
+The H1 remediation group enforces the `DEFAULT:NO-SHA1` system-wide cryptographic policy, which removes support for SHA-1 digest algorithms.
+This remediation addresses the following E8 compliance flags:
 
-|SSH root login restriction
-|
-|✓
-|✓
-|`MachineConfig`; verify no automated scripts use root SSH before applying
+* `rhcos4-e8-master-configure-crypto-policy`
+* `rhcos4-e8-worker-configure-crypto-policy`
 
-|Cryptographic policy enforcement
-|
-|✓
-|✓
-|`MachineConfig`; mandatory reboot; might affect services using deprecated ciphers
+The RDS applies a `MachineConfig` object named `75-crypto-policy-high` that creates a systemd unit to set the cryptographic policy on each node.
+The systemd unit runs `update-crypto-policies --set DEFAULT:NO-SHA1` on every boot.
 
-|Passwordless login disable
-|
-|✓
-|✓
-|`MachineConfig`; mandatory reboot; verify no accounts rely on passwordless access
-
-|RBAC least privilege
-|✓
-|✓
-|
-|Apply at Day 0; refine continuously; no reboot required
-|====
-
-== Disabling USB boot, wireless, and Bluetooth access
-
-To prevent unauthorized modifications to the operating system and reduce physical attack vectors, you disable USB boot, wireless, and Bluetooth in firmware settings.
-ZTP configuration does not control these settings.
-
-Disabling USB boot prevents attackers from booting from a USB drive and gaining unauthorized access to the system.
-Disabling wireless and Bluetooth eliminates additional physical attack vectors that attackers could exploit to compromise the host.
-
-The recommended firmware configuration is in xref:../edge_computing/ztp-reference-cluster-configuration-for-vdu.adoc#ztp-du-configuring-host-firmware-requirements_sno-configure-for-vdu[Configuring host firmware for low latency and high performance].
-Specifically, see the *USB Boot*, *Wireless LAN*, and *Bluetooth* rows in the firmware configuration table, which should all be set to *Disabled*.
-
-== Preventing unauthorized reboots
-
-Disabling `CtrlAltDelBurstAction` and `Ctrl+Alt+Del` actions prevents unauthorized reboots.
-This mitigates the risk that an attacker with physical access could trigger a denial of service by forcing unexpected system restarts.
-
-In RHEL systems, `CtrlAltDelBurstAction` is a systemd-logind configuration parameter that allows rapid Ctrl+Alt+Del key sequences to trigger an emergency reboot without authentication.
-When you disable this feature through `MachineConfig`, the emergency reboot path is blocked, requiring proper authentication and authorization for any system reboot.
-This is critical for telecommunications deployments that must keep availability up and prevent physical attackers from forcing denial-of-service reboots.
-
-After you apply this control, pressing Ctrl+Alt+Del has no effect on the system; only properly authorized administrators can start reboots through standard administrative channels.
-
-Ctrl+Alt+Del reboot protection is enforced through a `MachineConfig` object delivered through ZTP manifests.
-
-A sample `MachineConfig` object for disabling Ctrl+Alt+Del burst action (applied to all nodes) looks like the following:
+To verify that the cryptographic policy is active on a node, run:
 
 ----
-apiVersion: machineconfiguration.openshift.io/v1
-kind: MachineConfig
-metadata:
-  name: disable-ctrl-alt-del
-spec:
-  config:
-    ignition:
-      version: 3.2.0
-    storage:
-      files:
-      - path: /etc/systemd/logind.conf.d/99-disable-ctrl-alt-del-burst
-        mode: 0644
-        contents:
-          source: data:,%5BLogind%5D%0ACtrlAltDelBurstAction%3Dnone
-nodeSelector: {}
+$ oc debug node/<node-name> -- chroot /host update-crypto-policies --show
 ----
 
-You can verify that this control is active by checking that `CtrlAltDelBurstAction` is set to `none` on each node:
+The expected output is `DEFAULT:NO-SHA1`.
 
-----
-oc debug node/<node-name> -- chroot /host cat /etc/systemd/logind.conf.d/99-disable-ctrl-alt-del-burst | grep CtrlAltDelBurstAction
-----
-
-== Restricting direct SSH access
-
-You can limit direct SSH access to {product-title} by disabling the `root` login.
-This prevents attackers from gaining administrative access through brute-force attacks or credential compromise targeting the root account.
-
-SSH root login is disabled through a `MachineConfig` object that modifies SSH daemon (SSHD) configuration, delivered through ZTP manifests.
-
-A sample `MachineConfig` object for disabling root SSH access (applied to worker nodes) looks like the following:
-
-----
-apiVersion: machineconfiguration.openshift.io/v1
-kind: MachineConfig
-metadata:
-  name: disable-root-ssh
-spec:
-  config:
-    ignition:
-      version: 3.2.0
-    storage:
-      files:
-      - path: /etc/ssh/sshd_config.d/99-disable-root-login
-        mode: 0644
-        contents:
-          source: data:,PermitRootLogin%20no
-nodeSelector:
-  node-role.kubernetes.io/worker: ""
-----
-
-After you apply this `MachineConfig` (which triggers a node reboot), you can verify that root SSH login is disabled by running:
-
-----
-oc debug node/<node-name> -- chroot /host grep "PermitRootLogin" /etc/ssh/sshd_config.d/99-disable-root-login
-----
-
-This should return `PermitRootLogin no`, confirming that the SSH restriction is active.
-
-== Enforcing system-wide cryptographic policy
-
-System-wide cryptographic policy enforcement disables weaker cipher suites and ensures that all components use strong cryptographic algorithms.
-The default cryptographic policy is set to `DEFAULT:NO-SHA1`, which removes support for SHA-1 digest algorithms.
-This prevents downgrade attacks and ensures compliance with modern cryptographic standards required by NIST SP 800-53.
-
+[WARNING]
+====
 Removing SHA-1 support might affect older clients or services that rely on SHA-1 for certificate verification or data integrity.
-Test this control in a non-production environment before applying to production clusters to ensure compatibility with your workloads.
-
-Cryptographic policy changes are enforced through a `MachineConfig` object that updates the system-wide cryptographic policy, delivered through ZTP manifests.
-
-A sample `MachineConfig` object for enforcing the `DEFAULT:NO-SHA1` cryptographic policy (applied to all nodes) looks like the following:
-
-----
-apiVersion: machineconfiguration.openshift.io/v1
-kind: MachineConfig
-metadata:
-  name: enforce-crypto-policy
-spec:
-  config:
-    ignition:
-      version: 3.2.0
-    systemd:
-      units:
-      - name: update-crypto-policies.service
-        enabled: true
-        contents: |
-          [Unit]
-          Description=Update crypto policies to DEFAULT:NO-SHA1
-          After=network.target
-          [Service]
-          Type=oneshot
-          ExecStart=/usr/bin/update-crypto-policies --set DEFAULT:NO-SHA1
-          RemainAfterExit=yes
-nodeSelector: {}
-----
-
-To verify that the cryptographic policy has been applied correctly after the `MachineConfig` is reconciled, run:
-
-----
-oc debug node/<node-name> -- chroot /host update-crypto-policies --show
-----
-
-This command should display `DEFAULT:NO-SHA1`, confirming that SHA-1 support has been disabled.
-
-[WARNING]
-====
-Applying or updating crypto policy MachineConfig objects triggers mandatory node reboot events.
-Plan your maintenance window accordingly to minimize service disruption.
 ====
 
-== Disabling passwordless logins
+== H2: Disabling PAM empty password authentication
 
-This feature enforces strict authentication policies by disabling logins for accounts without passwords.
-Removing the `nullok` Pluggable Authentication Modules (PAM) option ensures that all user accounts require a password to authenticate, reducing the risk of unauthorized access.
+The H2 remediation group removes the `nullok` option from Pluggable Authentication Modules (PAM) configuration, preventing authentication for accounts that have empty passwords.
+This remediation addresses the following E8 compliance flags:
 
-PAM authentication changes are enforced through a `MachineConfig` object that removes the `nullok` parameter from PAM configuration files, delivered through ZTP manifests.
+* `rhcos4-e8-master-no-empty-passwords`
+* `rhcos4-e8-worker-no-empty-passwords`
 
-A sample `MachineConfig` object for disabling password-less logins (applied to worker nodes) looks like the following:
+The RDS applies a `MachineConfig` object named `75-pam-auth-high` that overwrites the `/etc/pam.d/system-auth` and `/etc/pam.d/password-auth` files with configurations that exclude the `nullok` option.
 
-----
-apiVersion: machineconfiguration.openshift.io/v1
-kind: MachineConfig
-metadata:
-  name: disable-nullok-pam
-spec:
-  config:
-    ignition:
-      version: 3.2.0
-    storage:
-      files:
-      - path: /etc/pam.d/system-auth.d/99-disable-nullok
-        mode: 0644
-        contents:
-          source: data:,auth%20%20required%20%20pam_deny.so%0A
-nodeSelector:
-  node-role.kubernetes.io/worker: ""
-----
-
-After you apply this `MachineConfig`, verify that the `nullok` option has been removed from PAM configuration:
+To verify that empty password authentication is disabled on a node, run:
 
 ----
-oc debug node/<node-name> -- chroot /host grep -r "nullok" /etc/pam.d/
+$ oc debug node/<node-name> -- chroot /host grep nullok /etc/pam.d/system-auth /etc/pam.d/password-auth
 ----
 
-This command should return no results, confirming that password-less login accounts are disabled.
+This command should return no output, confirming that the `nullok` option has been removed.
 
-[WARNING]
-====
-Applying or updating PAM `MachineConfig` objects triggers mandatory node reboot events.
-Plan your maintenance window accordingly to minimize service disruption.
-Before applying this control, verify that no automated scripts or services depend on passwordless account access.
-====
+== H3: Disabling SSHD empty password authentication
 
-== Ensuring RBAC follows the principle of least privilege
+The H3 remediation group configures the SSH daemon to explicitly deny authentication with empty passwords.
+This remediation addresses the following E8 compliance flags:
 
-To minimize the risk of unauthorized access, the RBAC setup follows the principle of least privilege, as described in xref:../authentication/using-rbac.adoc#using-rbac[Using RBAC to define and apply permissions].
+* `rhcos4-e8-master-sshd-disable-empty-passwords`
+* `rhcos4-e8-worker-sshd-disable-empty-passwords`
 
-In the context of security hardening for RAN deployments, RBAC controls are essential to prevent tampering with the security measures described in the preceding sections.
-Specifically, you must restrict who can:
+The RDS applies a `MachineConfig` object named `75-sshd-hardening` that creates an SSHD configuration drop-in file at `/etc/ssh/sshd_config.d/75-hardening.conf` with the setting `PermitEmptyPasswords no`.
 
-* Create, change, or delete `MachineConfig` objects (which enforce cryptographic policy, SSH restrictions, and PAM settings)
-* View or change SSH daemon (SSHD) configuration files
-* Change system-wide cryptographic policies
-* Change or remove the `SecurityContextConstraints` (SCC) policies that enforce pod security
+To verify that SSHD empty password authentication is disabled on a node, run:
 
-{product-title} provides the tools for creating minimal permissions.
-However, you must assess the needs of users and services within your environment and apply the principle of least privilege accordingly.
+----
+$ oc debug node/<node-name> -- chroot /host grep PermitEmptyPasswords /etc/ssh/sshd_config.d/75-hardening.conf
+----
 
-For example, consider creating the following RBAC roles:
-
-* A restricted `machineconfig-admins` `ClusterRole` that grants permission to view and change `MachineConfig` objects only to a small set of cluster administrators who are responsible for security compliance.
-* A developer role that permits only deployment and service management within a specific namespace, without access to cluster-wide security resources such as `MachineConfigs` or `SecurityContextConstraints`.
-* An auditor role that permits viewing (but not changing) security-relevant resources such as `MachineConfigs`, SCC policies, and audit logs.
-
-Regularly review and update permissions to ensure that users have only the permissions necessary to perform their tasks.
-Use the audit logs to monitor who accessed or changed security-relevant resources, and verify that only authorized administrators can change the hardening controls described in the preceding sections.
+The expected output is `PermitEmptyPasswords no`.

--- a/modules/ztp-high-security-issues-addressed.adoc
+++ b/modules/ztp-high-security-issues-addressed.adoc
@@ -6,23 +6,23 @@
 [id="ztp-addressed-security-issues_{context}"]
 = Security hardening measures implemented
 
-== Disabling USB boot, wireless and bluetooth access
+Disabling USB boot, wireless and bluetooth access
 
 To prevent unauthorized modifications to the operating system and to reduce the risk of physical attack vectors, USB boot, wireless, and Bluetooth are disabled in the BIOS settings. These settings are not controlled by using ZTP configuration. Disabling USB boot prevents attackers from booting from a USB drive and gaining unauthorized access to the system. The recommended firmware configuration is described in "Configuring host firmware for low latency and high performance".
 
-== Preventing unauthorized reboots
+Preventing unauthorized reboots
 
 Disabling `CtrlAltDelBurstAction` and `Ctrl+Alt+Del` actions prevents unauthorized reboots.
 
-== Restricting direct SSH access
+Restricting direct SSH access
 
 Direct SSH access to {product-title} is limited by disabling the `root` login.
 
-== Disabling passwordless logins
+Disabling passwordless logins
 
 This feature enforces strict authentication policies by disabling logins for accounts without passwords to ensure compliance with security best practices and reduce unauthorized access risks.
 
-== Ensure that the RBAC setup follows the principle of least privilege
+Ensure that the RBAC setup follows the principle of least privilege
 
 To minimize the risk of unauthorized access, the RBAC setup follows the principle of least privilege, as described in "Using RBAC to define and apply permissions", granting users the minimum required permissions.
 

--- a/modules/ztp-high-security-issues-addressed.adoc
+++ b/modules/ztp-high-security-issues-addressed.adoc
@@ -7,30 +7,15 @@
 = High-severity compliance remediations
 
 [role="_abstract"]
-The RAN reference design specification (RDS) for {product-title} {product-version} includes `MachineConfig` objects that remediate high-severity compliance flags identified by the Compliance Operator Essential Eight (E8) profile.
-These remediations are organized into three priority groups: H1, H2, and H3.
-The `MachineConfig` objects are applied automatically to both control plane and worker nodes when you deploy a cluster by using the RDS.
+The following security configurations are applied automatically when the RAN RDS is applied to a cluster.
+These `MachineConfig` objects address high-severity compliance issues identified by the essential eight (E8) profile.
 
-[NOTE]
-====
-You do not need to manually apply these `MachineConfig` objects.
-They are included in the RDS and are deployed automatically through ZTP provisioning.
-If you need to remove a specific remediation, you can delete the corresponding `MachineConfig` object from the cluster.
-====
+System-wide cryptographic policy enforcement
 
-== H1: System-wide cryptographic policy enforcement
+This security fix enforces the `DEFAULT:NO-SHA1` system-wide cryptographic policy, which removes support for SHA-1 digest algorithms.
+SHA-1 has known security vulnerabilities and has been deprecated by industry security standards.
 
-The H1 remediation group enforces the `DEFAULT:NO-SHA1` system-wide cryptographic policy, which removes support for SHA-1 digest algorithms.
-This remediation addresses the following E8 compliance flags:
-
-* `rhcos4-e8-master-configure-crypto-policy`
-* `rhcos4-e8-worker-configure-crypto-policy`
-
-The RDS applies a `MachineConfig` object named `75-crypto-policy-high` that creates a systemd unit to set the cryptographic policy on each node.
-The systemd unit runs `update-crypto-policies --set DEFAULT:NO-SHA1` on every boot.
-
-To verify that the cryptographic policy is active on a node, run:
-
+To verify that the SHA-1 algorithms have been disabled on a node, run:
 ----
 $ oc debug node/<node-name> -- chroot /host update-crypto-policies --show
 ----
@@ -42,15 +27,9 @@ The expected output is `DEFAULT:NO-SHA1`.
 Removing SHA-1 support might affect older clients or services that rely on SHA-1 for certificate verification or data integrity.
 ====
 
-== H2: Disabling PAM empty password authentication
+Disabling PAM empty password authentication
 
-The H2 remediation group removes the `nullok` option from Pluggable Authentication Modules (PAM) configuration, preventing authentication for accounts that have empty passwords.
-This remediation addresses the following E8 compliance flags:
-
-* `rhcos4-e8-master-no-empty-passwords`
-* `rhcos4-e8-worker-no-empty-passwords`
-
-The RDS applies a `MachineConfig` object named `75-pam-auth-high` that overwrites the `/etc/pam.d/system-auth` and `/etc/pam.d/password-auth` files with configurations that exclude the `nullok` option.
+This security fix removes the `nullok` option from pluggable authentication modules (PAM) configuration, preventing authentication for accounts that have empty passwords.
 
 To verify that empty password authentication is disabled on a node, run:
 
@@ -60,15 +39,9 @@ $ oc debug node/<node-name> -- chroot /host grep nullok /etc/pam.d/system-auth /
 
 This command should return no output, confirming that the `nullok` option has been removed.
 
-== H3: Disabling SSHD empty password authentication
+== Disabling SSHD empty password authentication
 
-The H3 remediation group configures the SSH daemon to explicitly deny authentication with empty passwords.
-This remediation addresses the following E8 compliance flags:
-
-* `rhcos4-e8-master-sshd-disable-empty-passwords`
-* `rhcos4-e8-worker-sshd-disable-empty-passwords`
-
-The RDS applies a `MachineConfig` object named `75-sshd-hardening` that creates an SSHD configuration drop-in file at `/etc/ssh/sshd_config.d/75-hardening.conf` with the setting `PermitEmptyPasswords no`.
+This security fix configures the SSH daemon to explicitly deny authentication with empty passwords.
 
 To verify that SSHD empty password authentication is disabled on a node, run:
 

--- a/modules/ztp-high-security-issues-addressed.adoc
+++ b/modules/ztp-high-security-issues-addressed.adoc
@@ -45,3 +45,4 @@ $ oc debug node/<node-name> -- chroot /host grep PermitEmptyPasswords /etc/ssh/s
 ----
 
 The expected output is `PermitEmptyPasswords no`.
+


### PR DESCRIPTION
[TELCODOCS-2125]: RAN Hardening for High Security Issues

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.22
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:https://redhat.atlassian.net/browse/TELCODOCS-2125
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:https://108865--ocpdocs-pr.netlify.app/openshift-enterprise/latest/edge_computing/ztp-security-hardening.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
