### PR TITLE
OSDOCS Document how to perform boot image updates on marketplace clusters GCP

### DIFF
--- a/machine_configuration/mco-update-boot-images-manual.adoc
+++ b/machine_configuration/mco-update-boot-images-manual.adoc
@@ -16,6 +16,8 @@ Red{nbsp}Hat does not support manually updating the boot image in control plane 
 
 include::modules/mco-update-boot-images-azure.adoc[leveloffset=+1]
 
+include::modules/mco-update-boot-images-gcp.adoc[leveloffset=+1]
+
 include::modules/mco-update-boot-images-ibm-cloud.adoc[leveloffset=+1]
 
 include::modules/mco-update-boot-images-nutanix.adoc[leveloffset=+1]
@@ -28,5 +30,6 @@ include::modules/mco-update-boot-images-openstack.adoc[leveloffset=+1]
 * xref:../machine_configuration/mco-update-boot-images.adoc#mco-update-boot-images[Boot image management]
 * xref:../installing/installing_aws/ipi/ipi-aws-preparing-to-install.adoc#installation-obtaining-installer_ipi-aws-preparing-to-install[Obtaining the installation program]
 * xref:../machine_management/user_infra/adding-bare-metal-compute-user-infra.adoc#adding-bare-metal-compute-user-infra[Adding compute machines to bare metal]
-
+* xref:../installing/installing_aws/installing-aws-account.adoc#installing-aws-account[Configuring an AWS account]
+* xref:../installing/installing_gcp/installing-restricted-networks-gcp.adoc#installation-creating-gcp-worker_installing-restricted-networks-gcp[Creating additional worker machines in {gcp-short}]
 

--- a/modules/mco-update-boot-images-gcp.adoc
+++ b/modules/mco-update-boot-images-gcp.adoc
@@ -1,0 +1,396 @@
+// Module included in the following assemblies:
+//
+// * machine_configuration/mco-update-boot-images-manual.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="mco-update-boot-images-gcp_{context}"]
+= Manually updating the boot image on an {gcp-short} cluster
+
+[role="_abstract"]
+You can manually update the boot image for your {gcp-first} cluster by configuring your machine sets to use the latest {product-title} image as the boot image to ensure that new nodes can scale up properly.
+
+Use the following procedure to create environment variables that facilitate running the required commands, identify the correct boot image to use as the new boot image, and modify your machine sets to use that image.
+
+ifndef::openshift-dedicated[]
+The process differs for clusters that use a default {op-system-first} image, clusters that use a custom {op-system-first} image from the {gcp-short} Marketplace, and user-provisioned infrastructure clusters. The following procedure helps determine which type of cluster you have.
+
+For user-provisioned infrastructure {gcp-short} clusters, which typically have no Machine API compute machine sets, you can provision new nodes based on the new boot image by updating the underlying {gcp-short} infrastructure with the new boot image, such as instance templates, Deployment Manager templates, or Terraform configuration. For more information, see "Creating additional worker machines in {gcp-short}".
+endif::openshift-dedicated[]
+
+[NOTE]
+====
+For clusters that use a default {op-system-first} image, you can configure the cluster to automatically update the boot image each time the cluster is updated. If you are using the following procedure, ensure that automatic boot image updates are disabled and skew enforcement is in manual mode. For more information, see "Boot image management" and "Boot image skew enforcement".
+====
+
+.Prerequisites
+
+* You have completed the general boot image prerequisites as described in the "Prerequisites" section of the link:https://access.redhat.com/articles/7053165#prerequisites-2[{product-title} Boot Image Updates knowledgebase article].
+
+* You have installed the {oc-first}.
+
+* You have set boot image skew enforcement to the manual or none mode. For more information, see "Configuring boot image skew enforcement".  
+
+* You have disabled boot image management for the cluster. For more information, see "Disabling boot image management".
+
+ifndef::openshift-dedicated[]
+* For a cluster that uses a default {op-system} image, ensure that your cluster meets the following additional prerequisites: 
+
+** You have downloaded the latest version of the {product-title} installation program, openshift-install, from the {cluster-manager-url}. For more information, see "Obtaining the installation program."
+
+** You have installed the link:https://jqlang.github.io/jq/[`jq`] program.
+
+* For a user-provisioned infrastructure cluster, ensure that your cluster meets the following additional prerequisites: 
+
+** You have downloaded the latest version of the {product-title} installation program from the {cluster-manager-url}. For more information, see "Obtaining the installation program."
+
+** You have installed the link:https://cloud.google.com/sdk/docs/install[{gcp-short} CLI].
+
+** You have created a {gcp-short} service account.
+endif::openshift-dedicated[]
+
+.Procedure 
+
+. Determine which image in the machine set is the boot image and set the value in an environment variable:
+
+.. Set the boot image value in an environment variable by running the following command:
++
+[source,terminal]
+----
+$ export BOOT_DISK_INDEX=$(oc get machineset -n openshift-machine-api -o json | \
+  jq '.items[0].spec.template.spec.providerSpec.value.disks | map(.boot == true) | index(true)')
+----
+
+.. Display the contents of the `BOOT_DISK_INDEX` environment variable by running the following command:
++
+[source,terminal]
+----
+$ echo $BOOT_DISK_INDEX
+----
++
+.Example output
+[source,terminal]
+----
+0
+----
++
+If the output for the `BOOT_DISK_INDEX` environment variable is `null`, none of the disks in the machine set has the `boot` field explicitly set. In this case, the boot disk is typically the first disk. 
++
+.Example null output
+[source,terminal]
+----
+null
+----
+
+.. If the  `BOOT_DISK_INDEX` output is `null`, set the boot image to the first image by running the following command:
++
+[source,terminal]
+----
+$ export BOOT_DISK_INDEX=0
+----
+
+ifndef::openshift-dedicated[]
+. Determine if your cluster uses a default {op-system} image or a GCP Marketplace {op-system} image from the {gcp-short} Marketplace, or is a user-provisioned infrastructure cluster:
+
+.. Obtain the name of the current boot image and set the name as an environment variable by running the following command:
++
+[source,terminal]
+----
+$ export CURRENT_IMAGE=$(oc get machineset -n openshift-machine-api -o json | \
+  jq -r ".items[0].spec.template.spec.providerSpec.value.disks[${BOOT_DISK_INDEX}].image")
+----
++
+`BOOT_DISK_INDEX` is the environment variable you created in a previous step.
+
+.. View the name of the image by running the following command:
++
+[source,terminal]
+----
+$ echo $CURRENT_IMAGE
+----
++
+.Example output
+[source,terminal]
+----
+projects/rhcos-cloud/global/images/rhcos-416-94-202510081640-0-gcp-x86-64
+----
+
+.. Compare the prefix of the image name to the entries in the following table:
++
+[cols="1,1",options="header"]
+|===
+| Current image prefix | Variant
+| `projects/rhcos-cloud/global/images/` | Default
+| `projects/redhat-marketplace-public/global/images/` | GCP Marketplace {op-system} image
+| No machine set present/custom prefix | User-provisioned infrastructure
+|===
++
+Default {op-system} clusters use images from the `rhcos-cloud` project in the `rhcos-<version>-<platform>-<arch>` format.
++
+GCP Marketplace {op-system} clusters use images from the `redhat-marketplace-public` project in the `redhat-coreos-<offering>-<version>-<arch>-<date>` format.
++
+[NOTE]
+====
+The following images are the latest {gcp-short} Marketplace images for the {product-title}:
+
+{product-title}:: `redhat-coreos-ocp-413-x86-64-202305021736`
+{opp}:: `redhat-coreos-opp-413-x86-64-202305021736`
+{oke}:: `redhat-coreos-oke-413-x86-64-202305021736`
+
+Red Hat has not published Marketplace images for {product-title} later than these {product-title} 4.13 images. If the current boot image in your cluster matches one of the listed images, no further action is necessary.
+====
+endif::openshift-dedicated[]
+ifndef::openshift-dedicated[]
+. Obtain the name of the new boot image by using one of the following steps, depending upon your cluster:
+
+* For a cluster that uses a default {op-system} image, perform the following steps:
++
+.. Set an environment variable with your cluster architecture by running the following command:
++
+[source,terminal]
+----
+$ export ARCH=<architecture_type>
+----
++
+Replace `<architecture_type>` with one of the following values: 
++
+--
+* Specify `aarch64` for the AArch64 or ARM64 architecture.
+* Specify `ppc64le` for the {ibm-power-name} (ppc64le) architecture.
+* Specify `s390x` for the {ibm-z-name} and {ibm-linuxone-name} (s390x) architecture.
+* Specify `x86_64` for the x86_64 or AMD64 architecture.
+--
++
+You can find the architecture as a label in any `MachineSet` object.
++
+.Example machine set with an architecture label
+[source,terminal]
+----
+apiVersion: machine.openshift.io/v1beta1
+kind: MachineSet
+metadata:
+  annotations:
+    capacity.cluster-autoscaler.kubernetes.io/labels: kubernetes.io/arch=amd64
+# ...
+----
+
+.. Set an environment variable with the name of the new boot image by running the following command:
++
+[source,terminal]
+----
+$ export GCP_IMAGE=$(openshift-install coreos print-stream-json | jq -r ".architectures.\"${ARCH}\".images.gcp.name")
+----
++
+`ARCH` is the environment variable you created in a previous step.
+
+.. Set an environment variable with the {gcp-short} project of the new boot image by running the following command:
++
+[source,terminal]
+----
+$ export GCP_PROJECT=$(openshift-install coreos print-stream-json | jq -r ".architectures.\"${ARCH}\".images.gcp.project")
+----
++
+`ARCH` is the environment variable you created in a previous step.
+
+.. View the {op-system-first} version of the new boot image by running the following command:
++
+[source,terminal]
+----
+$ openshift-install coreos print-stream-json | jq -r ".architectures.\"${ARCH}\".images.gcp.release"
+----
++
+.Example output
+[source,terminal]
+----
+9.6.20251212-1
+----
++
+Make note of the {op-system} version for later use.
+
+* For a cluster that uses a GCP Marketplace {op-system} image that is earlier than the 4.13 images listed above, perform the following steps:
+
+.. Set an environment variable with the name of the new boot image by running the following command:
++
+[source,terminal]
+----
+$ export GCP_IMAGE=<image_name>
+----
++
+Replace `<image_name>` with one of the following values: 
++
+--
+* Specify `redhat-coreos-ocp-413-x86-64-202305021736` for an {product-title} cluster. 
+* Specify `redhat-coreos-opp-413-x86-64-202305021736` for an {opp} cluster. 
+* Specify `redhat-coreos-oke-413-x86-64-202305021736` for an {oke} cluster. 
+--
+
+.. Set an environment variable with the {gcp-short} project of the new boot image by running the following command:
++
+[source,terminal]
+----
+$ export GCP_PROJECT=redhat-marketplace-public
+----
+
+* For a user-provisioned infrastructure cluster, perform the following steps:
+
+.. Set an environment variable with your cluster architecture by running the following command:
++
+[source,terminal]
+----
+$ export ARCH=<architecture_type>
+----
++
+Replace `<architecture_type>` with one of the following values: 
++
+--
+* Specify `aarch64` for the AArch64 or ARM64 architecture.
+* Specify `ppc64le` for the {ibm-power-name} (ppc64le) architecture.
+* Specify `s390x` for the {ibm-z-name} and {ibm-linuxone-name} (s390x) architecture.
+* Specify `x86_64` for the x86_64 or AMD64 architecture.
+--
+
+.. Set an environment variable with the name of the new boot image by running the following command:
++
+[source,terminal]
+----
+$ export GCP_IMAGE=$(openshift-install coreos print-stream-json | jq -r ".architectures.\"${ARCH}\".images.gcp.name")
+----
++
+`ARCH` is the environment variable you created in a previous step.
+
+.. Set an environment variable with the {gcp-short} project of the new boot image in your cluster by running the following command:
++
+[source,terminal]
+----
+$ export GCP_PROJECT=$(openshift-install coreos print-stream-json | jq -r ".architectures.\"${ARCH}\".images.gcp.project")
+----
++
+`ARCH` is the environment variable you created in a previous step.
++
+If the default {op-system} image is not accessible in your environment, for example in a restricted or disconnected environment, you could download the new boot image tar file and upload the file as a custom image to your own {gcp-short} project before updating your {gcp-short} instance templates.
++
+Update your {gcp-short} instance template(s) to reference the new image, then create new instances from the updated template. The exact steps depend on how your infrastructure was provisioned. For more information, see "Creating additional worker machines in {gcp-short}".
++
+After creating the new instances, you can proceed to the verification steps, unless your user-provisioned infrastructure cluster has any Machine API machine sets, such as for Day-2 scaling. You can update those machine sets as described in the following steps.
+endif::openshift-dedicated[]
+ifdef::openshift-dedicated[]
+. Set an environment variable with the name of the new boot image by running the following command:
++
+[source,terminal]
+----
+$ export GCP_IMAGE=<osd_image_name>
+----
++
+Replace `osd_image_name` with the name of the new boot image. 
++
+[NOTE]
+====
+The `redhat-marketplace-public` project does not grant image list permissions to external users. You must obtain the {product-dedicated} image name Red Hat from support or release documentation.
+====
+
+. Set an environment variable with the project of the new boot image by running the following command:
++
+[source,terminal]
+----
+$ export GCP_PROJECT=redhat-marketplace-public
+----
+endif::openshift-dedicated[]
+
+. Update each of your compute machine sets to include the new boot image:
+
+.. Obtain the name of your machine sets for use in the following step by running the following command:
++
+[source,terminal]
+----
+$ oc get machineset -n openshift-machine-api
+----
++
+.Example output
+[source,terminal]
+----
+NAME                                 DESIRED   CURRENT   READY   AVAILABLE   AGE
+ci-ln-xw7zmyt-72292-x7nqv-worker-a   1         1         1       1           53m
+ci-ln-xw7zmyt-72292-x7nqv-worker-b   1         1         1       1           53m
+ci-ln-xw7zmyt-72292-x7nqv-worker-c   1         1         1       1           53m
+----
+
+.. Edit a machine set to update the `image` field in the `providerSpec` stanza to add your boot image by running the following command:
++
+[source,terminal]
+----
+$ oc patch machineset <machineset-name> -n openshift-machine-api --type json \
+  -p '[{"op": "replace", "path": "/spec/template/spec/providerSpec/value/disks/'${BOOT_DISK_INDEX}'/image", "value": "projects/'${GCP_PROJECT}'/global/images/'${GCP_IMAGE}'"}]'
+----
++
+Replace `<machineset_name>` with the name of your machine set.
++
+`BOOT_DISK_INDEX`, `GCP_PROJECT`, and `GCP_IMAGE` are environment variables you created in previous steps.
+
+. If boot image skew enforcement in your cluster is set to the manual mode, update the version of the new boot image in the `MachineConfiguration` object as described in "Updating the boot image skew enforcement version".
+
+.Verification
+
+. Scale up a machine set to check that the new node is using the new boot image:
+
+.. Increase the machine set replicas by one to trigger a new machine by running the following command:
++
+[source,terminal]
+----
+$ oc scale --replicas=<count> machineset <machineset_name> -n openshift-machine-api
+----
+where:
+
+`<count>`:: Specifies the total number of replicas, including any existing replicas, that you want for this machine set.
+`<machineset_name>`:: Specifies the name of the machine set to scale.
+
+.. Optional: View the status of the machine set as it provisions by running the following command:
++
+[source,terminal]
+----
+$ oc get machines.machine.openshift.io -n openshift-machine-api -w
+----
++
+It can take several minutes for the machine set to achieve the `Running` state.
+
+.. Verify that the new node has been created and is in the `Ready` state by running the following command:
++
+[source,terminal]
+----
+$ oc get nodes
+----
+
+. Verify that the new node is using the new boot image by running the following command:
++
+[source,terminal]
+----
+$ oc debug node/<new_node> -- chroot /host cat /sysroot/.coreos-aleph-version.json
+----
++
+Replace `<new_node>` with the name of your new node.
++
+.Example output
+[source,terminal]
+----
+{
+# ...
+    "ref": "docker://ostree-image-signed:oci-archive:/rhcos-9.6.20251212-1-ostree.x86_64.ociarchive",
+    "version": "9.6.20251212-1"
+}
+----
+where:
+
+`version`:: Specifies the boot image version.
+
+. Verify that the boot image is the same the {op-system} version as the image you noted in a previous step by running the following command:
++
+[source,terminal]
+----
+$ echo $GCP_IMAGE
+----
++
+`RHCOS_URL` is the environment variable you created in a previous step.
++
+.Example output
+[source,terminal]
+----
+https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.6/builds/9.6.20251212-1/x86_64/rhcos-9.6.20251212-1-nutanix.x86_64.qcow2
+----


### PR DESCRIPTION
Incorporate https://gist.github.com/djoshy/5f2c6fe469d9ce5a9e4645e78ec57694#osd-clusters-only-for-sres

https://redhat.atlassian.net/browse/OSDOCS-18794

Link to docs preview:
OCP: [Manually updating the boot image on an Google Cloud cluster](https://108868--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_configuration/mco-update-boot-images-manual#mco-update-boot-images-gcp_mco-update-boot-images-manual) -- New module.

**Reviewer:** The "Updating the boot image skew enforcement version" module is not available yet. Will add link later.

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
