### PR TITLE
[OSDOCS#16816]:Updated Accessing your cluster_CQA assembly jobs

### DIFF
--- a/rosa_learning/creating_cluster_workshop/learning-getting-started-accessing.adoc
+++ b/rosa_learning/creating_cluster_workshop/learning-getting-started-accessing.adoc
@@ -7,7 +7,7 @@ include::_attributes/attributes-openshift-dedicated.adoc[]
 
 toc::[]
 [role="_abstract"]
-You can connect to your cluster using the {rosa-cli-first} or the {hybrid-console} user interface (UI).
+You can connect to your cluster using the {rosa-cli-first} or the {hybrid-console} user interface (UI). You can use the {rosa-cli} to authenticate with your service account credentials, and the {hybrid-console} to connect by using a user ID and password that you retrieve through the console.
 
 include::modules/learning-getting-started-accessing-cli.adoc[leveloffset=+1]
 include::modules/learning-getting-started-accessing-hcm.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s):
4.20+

Issue:
https://redhat.atlassian.net/browse/OSDOCS-16816

Link to docs preview:
[Accessing your cluster](https://108869--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/rosa_learning/creating_cluster_workshop/learning-getting-started-accessing.html)

Peer review:
- [ ] Peer reviewer has approved this change.

QE review:
- QE approval is not required for this PR as no procedural changes involved.

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
