### PR TITLE
OSDOCS-18823:Update the MicroShift z-stream RNs for 4.18.36

### DIFF
--- a/microshift_release_notes/microshift-4-18-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-18-release-notes.adoc
@@ -33,3 +33,5 @@ include::modules/microshift-4-18-2-dp.adoc[leveloffset=+2]
 include::modules/microshift-4-18-11-dp.adoc[leveloffset=+2]
 
 include::modules/microshift-4-18-26-dp.adoc[leveloffset=+2]
+
+include::modules/microshift-4-18-36-dp.adoc[leveloffset=+2]

--- a/modules/microshift-4-18-36-dp.adoc
+++ b/modules/microshift-4-18-36-dp.adoc
@@ -1,0 +1,23 @@
+
+// Module included in the following assemblies:
+//
+//microshift_release_notes/microshift-4-18-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="microshift-4-18-36-dp_{context}"]
+= RHBA-2026:5750 - {microshift-short} 4.18.36 bug fix and enhancement advisory
+
+Issued: 25 March 2026
+
+[role="_abstract"]
+{product-title} release 4.18.36 is now available. Bug fixes and enhancements are listed in the link:https://access.redhat.com/errata/RHBA-2026:5750[RHBA-2026:5750] advisory. Release notes for bug fixes and enhancements are provided in this documentation. The images that are included in the update are provided by the {OCP} link:https://access.redhat.com/errata/RHSA-2026:5133[RHSA-2026:5133] advisory.
+
+See the latest images included with {microshift-short} by using the following instructions:
+
+* xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[Listing the contents of the {microshift-short} RPM release package]
+* xref:../microshift_install_bootc/microshift-install-bootc-image.adoc#microshift-install-bootc-get-published-image_microshift-install-publish-bootc-image[Getting the published bootc image for MicroShift]
+
+[id="microshift-4-18-36-bugs_{context}"]
+== Fixed issues
+
+There are no notable fixed issues in this release.


### PR DESCRIPTION
Version(s):
4.18

Issue:
https://redhat.atlassian.net/browse/OSDOCS-18823

Link to docs preview:
https://108888--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-18-release-notes.html#microshift-4-18-36-dp_release-notes

Additional information:
MS 4.18.36 MR: https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/428
ART Dashboard: https://art-dash.engineering.redhat.com/dashboard/release/openshift-4.18