### PR TITLE
PR for SRVCOM-4305: CQA + DITA readiness for assemblies and modules under "Installing OpenShift Serverless" & "Removing OpenShift Serverless" sections.

### DIFF
--- a/install/configuring-serverless-functions.adoc
+++ b/install/configuring-serverless-functions.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: ASSEMBLY
-include::_attributes/common-attributes.adoc[]
 [id="configuring-serverless-functions"]
 = Configuring {FunctionsProductName}
+include::_attributes/common-attributes.adoc[]
 :context: configuring-serverless-functions
 
 toc::[]
@@ -9,37 +9,25 @@ toc::[]
 [role="_abstract"]
 To improve the process of deployment of your application code, you can use {ServerlessProductName} to deploy stateless, event-driven functions as a Knative service on {ocp-product-title}. If you want to develop functions, you must complete the set up steps.
 
-[id="prerequisites_configuring-serverless-functions"]
-== Prerequisites
-
-To enable the use of {FunctionsProductName} on your cluster, you must complete the following steps:
-
-* The {ServerlessOperatorName} and Knative Serving are installed on your cluster.
-+
-[NOTE]
-====
-Functions are deployed as a Knative service. If you want to use event-driven architecture with your functions, you must also install Knative Eventing.
-====
-
-* You have the link:https://docs.redhat.com/en/documentation/openshift_container_platform/latest/html/cli_tools/openshift-cli-oc#cli-getting-started[`oc` CLI] installed.
-
-* You have the xref:../install/installing-kn.adoc#installing-kn[Knative (`kn`) CLI] installed. Installing the Knative CLI enables the use of `kn func` commands which you can use to create and manage functions.
-
-* You have installed Docker Container Engine or Podman version 3.4.7 or higher.
-
-* You have access to an available image registry, such as the OpenShift Container Registry.
-
-* If you are using link:https://quay.io/[Quay.io] as the image registry, you must ensure that either the repository is not private, or that you have followed the {ocp-product-title} documentation on link:https://docs.redhat.com/en/documentation/openshift_container_platform/latest/html/images/managing-images#images-allow-pods-to-reference-images-from-secure-registries_using-image-pull-secrets[Allowing pods to reference images from other secured registries].
-
-
-* If you are using the OpenShift Container Registry, a cluster administrator must link:https://docs.redhat.com/en/documentation/openshift_container_platform/latest/html/registry/securing-exposing-registry[expose the registry].
+include::modules/prerequisites-configuring-serverless-functions.adoc[leveloffset=+1]
 
 include::modules/serverless-functions-podman.adoc[leveloffset=+1]
+
 include::modules/serverless-functions-podman-macos.adoc[leveloffset=+1]
 
-[id="next-steps_configuring-serverless-functions"]
-== Next steps
+[role="_additional-resources"]
+== Additional resources
 
-* For more information about Docker Container Engine or Podman, see link:https://docs.openshift.com/container-platform/latest/architecture/understanding-development.html#container-build-tool-options[Container build tool options].
+* link:https://docs.redhat.com/en/documentation/openshift_container_platform/latest/html/cli_tools/openshift-cli-oc#cli-getting-started[`oc` CLI]
+
+* xref:../install/installing-kn.adoc#installing-kn[Knative (`kn`) CLI]
+
+* link:https://quay.io/[Quay.io]
+
+* link:https://docs.redhat.com/en/documentation/openshift_container_platform/latest/html/images/managing-images#images-allow-pods-to-reference-images-from-secure-registries_using-image-pull-secrets[Allowing pods to reference images from other secured registries]
+
+* link:https://docs.redhat.com/en/documentation/openshift_container_platform/latest/html/registry/securing-exposing-registry[expose the registry]
+
+* link:https://docs.openshift.com/container-platform/latest/architecture/understanding-development.html#container-build-tool-options[Container build tool options].
 
 * See xref:../functions/serverless-functions-getting-started.adoc#serverless-functions-getting-started[Getting started with functions].

--- a/install/install-serverless-logic-operator.adoc
+++ b/install/install-serverless-logic-operator.adoc
@@ -1,22 +1,25 @@
 :_mod-docs-content-type: ASSEMBLY
-include::_attributes/common-attributes.adoc[]
 [id="install-serverless-logic-operator"]
 = Installing the {ServerlessLogicOperatorName}
+include::_attributes/common-attributes.adoc[]
 :context: install-serverless-logic-operator
 
 toc::[]
 
 [role="_abstract"]
-Installing the {ServerlessLogicOperatorName} enables you to install and use link:https://serverlessworkflow.io[Serverless Workflow] on a {ocp-product-title} cluster. The {ServerlessLogicOperatorName} manages Kubernetes custom resource definitions (CRDs) to configure and deploy the workflows.
+You can install the {ServerlessLogicOperatorName} to run Serverless Workflow on an {ocp-product-title} cluster. The {ServerlessLogicOperatorName} manages Kubernetes custom resource definitions (CRDs) that configure and deploy workflows.
 
-//install doc
 include::modules/serverless-logic-install-web-console.adoc[leveloffset=+1]
 
-[id="additional-resources_install-serverless-logic-operator"]
 [role="_additional-resources"]
 == Additional resources
+
+* link:https://serverlessworkflow.io[Serverless Workflow]
+
 * link:https://docs.openshift.com/container-platform/latest/operators/understanding/crds/crd-managing-resources-from-crds.html[Managing resources from custom resource definitions]
+
 * link:https://docs.openshift.com/container-platform/latest/storage/understanding-persistent-storage.html#understanding-persistent-storage[Understanding persistent storage]
+
 * link:https://docs.openshift.com/container-platform/latest/networking/configuring-a-custom-pki.html[Configuring a custom PKI]
 
 

--- a/install/install-serverless-operator.adoc
+++ b/install/install-serverless-operator.adoc
@@ -1,51 +1,33 @@
 :_mod-docs-content-type: ASSEMBLY
-include::_attributes/common-attributes.adoc[]
 [id="install-serverless-operator"]
 = Installing the {ServerlessOperatorName}
+include::_attributes/common-attributes.adoc[]
 :context: install-serverless-operator
 
 toc::[]
 
 [role="_abstract"]
-Installing the {ServerlessOperatorName} enables you to install and use Knative Serving, Knative Eventing, and the Knative broker for Apache Kafka on a {ocp-product-title} cluster. The {ServerlessOperatorName} manages Knative custom resource definitions (CRDs) for your cluster and enables you to configure them without directly modifying individual config maps for each component.
+You can install the {ServerlessOperatorName} to run Knative Serving, Knative Eventing, and the Knative broker for Apache Kafka on a {ocp-product-title} cluster. The {ServerlessOperatorName} manages Knative custom resource definitions (CRDs) for the cluster. Configure these resources without modifying individual ConfigMaps for each component.
 
-
-// operator resource requirements doc
 include::modules/serverless-operator-installation-resource-requirements.adoc[leveloffset=+1]
 
-// universal install doc
 include::modules/serverless-install-web-console.adoc[leveloffset=+1]
-
-[IMPORTANT]
-====
-If you want to xref:../observability/tracing/serverless-tracing.adoc#serverless-tracing[use {DTProductName} with {ServerlessProductName}], you must install and configure {DTProductName} before you install Knative Serving or Knative Eventing.
-====
 
 include::modules/serverless-install-cli.adoc[leveloffset=+1]
 
-[IMPORTANT]
-====
-If you want to xref:../observability/tracing/serverless-tracing.adoc#serverless-tracing[use {DTProductName} with {ServerlessProductName}], you must install and configure {DTProductName} before you install Knative Serving or Knative Eventing.
-====
+include::modules/serverless-operator-global-configuration.adoc[leveloffset=+1]
 
-
-[id="serverless-configuration"]
-== Global configuration
-
-The {ServerlessOperatorName} manages the global configuration of a Knative installation, including propagating values from the `KnativeServing` and `KnativeEventing` custom resources to system link:https://kubernetes.io/docs/concepts/configuration/configmap/[config maps]. Any updates to config maps which are applied manually are overwritten by the Operator. However, modifying the Knative custom resources allows you to set values for these config maps.
-
-Knative has multiple config maps that are named with the prefix `config-`. All Knative config maps are created in the same namespace as the custom resource that they apply to. For example, if the `KnativeServing` custom resource is created in the `knative-serving` namespace, all Knative Serving config maps are also created in this namespace.
-
-The `spec.config` in the Knative custom resources have one `<name>` entry for each config map, named `config-<name>`, with a value which is be used for the config map `data`.
-
-[id="additional-resources_knative-serving-CR-config"]
 [role="_additional-resources"]
-== Additional resources for {ocp-product-title}
+== Additional resources
+
 * link:https://docs.openshift.com/container-platform/latest/operators/understanding/crds/crd-managing-resources-from-crds.html[Managing resources from custom resource definitions]
+
+* link:https://kubernetes.io/docs/concepts/configuration/configmap/[config maps]
+
 * link:https://docs.openshift.com/container-platform/latest/storage/understanding-persistent-storage.html#understanding-persistent-storage[Understanding persistent storage]
+
 * link:https://docs.openshift.com/container-platform/latest/networking/configuring-a-custom-pki.html[Configuring a custom PKI]
 
-[id="next-steps_install-serverless-operator"]
-== Next steps
+* xref:../install/installing-knative-serving.adoc#installing-knative-serving[install Knative Serving]
 
-* After the {ServerlessOperatorName} is installed, you can xref:../install/installing-knative-serving.adoc#installing-knative-serving[install Knative Serving] or xref:../install/installing-knative-eventing.adoc#installing-knative-eventing[install Knative Eventing].
+* xref:../install/installing-knative-eventing.adoc#installing-knative-eventing[install Knative Eventing]

--- a/install/installing-kn.adoc
+++ b/install/installing-kn.adoc
@@ -7,25 +7,27 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 [role="_abstract"]
-The Knative (`kn`) CLI does not have its own login mechanism. To log in to the cluster, you must install the OpenShift CLI (`oc`) and use the `oc login` command. Installation options for the CLIs may vary depending on your operating system.
+The Knative (`kn`) CLI does not have its own login mechanism. To log in to the cluster, you must install the OpenShift CLI (`oc`) and use the `oc login` command. Installation options for the command-line interface (CLI) can vary depending on your operating system.
 
-For more information on installing the OpenShift CLI (`oc`) for your operating system and logging in with `oc`, see the link:https://docs.openshift.com/container-platform/latest/cli_reference/openshift_cli/getting-started-cli.html#cli-getting-started[OpenShift CLI getting started] documentation.
-
-{ServerlessProductName} cannot be installed using the Knative (`kn`) CLI. A cluster administrator must install the {ServerlessOperatorName} and set up the Knative components, as described in the xref:../install/install-serverless-operator.adoc#install-serverless-operator[Installing the {ServerlessOperatorName}] documentation.
-
-[IMPORTANT]
-====
-If you try to use an older version of the Knative (`kn`) CLI with a newer {ServerlessProductName} release, the API is not found and an error occurs.
-
-For example, if you use the 1.23.0 release of the Knative (`kn`) CLI, which uses version 1.2, with the 1.24.0 {ServerlessProductName} release, which uses the 1.3 versions of the Knative Serving and Knative Eventing APIs, the CLI does not work because it continues to look for the outdated 1.2 API versions.
-
-Ensure that you are using the latest Knative (`kn`) CLI version for your {ServerlessProductName} release to avoid issues.
-====
+You cannot install {ServerlessProductName} by using the Knative (kn) CLI. A cluster administrator must install the {ServerlessOperatorName} and set up the Knative components, as described in the {ServerlessOperatorName} documentation.
 
 include::modules/serverless-installing-cli-web-console.adoc[leveloffset=+1]
+
 include::modules/serverless-installing-cli-linux-rpm-package-manager.adoc[leveloffset=+1]
+
 include::modules/serverless-locking-version-for-cli-installed-with-rpm-package-manager.adoc[leveloffset=+1]
+
 include::modules/serverless-upgrading-cli-with-locked-version.adoc[leveloffset=+1]
+
 include::modules/serverless-installing-cli-linux.adoc[leveloffset=+1]
+
 include::modules/serverless-installing-cli-macos.adoc[leveloffset=+1]
+
 include::modules/serverless-installing-cli-windows.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+== Additional resources
+
+* link:https://docs.openshift.com/container-platform/latest/cli_reference/openshift_cli/getting-started-cli.html#cli-getting-started[OpenShift CLI getting started]
+
+* xref:../install/install-serverless-operator.adoc#install-serverless-operator[Installing the {ServerlessOperatorName}]

--- a/install/installing-knative-eventing.adoc
+++ b/install/installing-knative-eventing.adoc
@@ -9,23 +9,23 @@ toc::[]
 [role="_abstract"]
 To use event-driven architecture on your cluster, install Knative Eventing. You can create Knative components such as event sources, brokers, and channels and then use them to send events to applications or external systems.
 
-After you install the {ServerlessOperatorName}, you can install Knative Eventing by using the default settings, or configure more advanced settings in the `KnativeEventing` custom resource (CR). For more information about configuration options for the `KnativeEventing` CR, see xref:../install/install-serverless-operator.adoc#serverless-configuration[Global configuration].
-
-[IMPORTANT]
-====
-If you want to xref:../observability/tracing/serverless-tracing.adoc#serverless-tracing[use {DTProductName} with {ServerlessProductName}], you must install and configure {DTProductName} before you install Knative Eventing.
-====
+After you install the {ServerlessOperatorName}, you can install Knative Eventing by using the default settings, or configure more advanced settings in the `KnativeEventing` custom resource (CR). If you want to use {DTProductName} with {ServerlessProductName}, you must install and configure {DTProductName} before you install Knative Eventing.
 
 include::modules/serverless-install-eventing-web-console.adoc[leveloffset=+1]
+
 include::modules/serverless-install-eventing-yaml.adoc[leveloffset=+1]
 
 include::modules/serverless-install-kafka-odc.adoc[leveloffset=+1]
 
-[id="next-steps_installing-knative-eventing"]
-== Next steps
+[role="_additional-resources"]
+== Additional resources
 
-* Learn more about how to use Knative event-driven architecture in xref:../eventing/knative-eventing.adoc#knative-eventing-overview[Knative Eventing].
+* xref:../eventing/knative-eventing.adoc#knative-eventing-overview[Knative Eventing]
 
-* If you want to use Knative Eventing with Apache Kafka, see xref:../install/serverless-kafka-admin.adoc#serverless-kafka-admin[Configuring Knative broker for Apache Kafka].
+* xref:../install/serverless-kafka-admin.adoc#serverless-kafka-admin[Configuring Knative broker for Apache Kafka]
 
-* If you want to use Knative services, see xref:../install/installing-knative-serving.adoc#installing-knative-serving[Installing Knative Serving] and then start xref:../knative-serving/getting-started/serverless-applications.adoc#serverless-applications[Creating serverless applications].
+* xref:../install/installing-knative-serving.adoc#installing-knative-serving[Installing Knative Serving] 
+
+* xref:../knative-serving/getting-started/serverless-applications.adoc#serverless-applications[Creating serverless applications]
+
+* xref:../observability/tracing/serverless-tracing.adoc#serverless-tracing[{DTProductName} with {ServerlessProductName}]

--- a/install/installing-knative-serving.adoc
+++ b/install/installing-knative-serving.adoc
@@ -7,27 +7,21 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 [role="_abstract"]
-Installing Knative Serving allows you to create Knative services and functions on your cluster. It also allows you to use additional functionality such as autoscaling and networking options for your applications.
+You can install Knative Serving to create Knative services and functions on your cluster. You can also use additional features such as autoscaling and networking options for your applications.
 
-After you install the {ServerlessOperatorName}, you can install Knative Serving by using the default settings, or configure more advanced settings in the `KnativeServing` custom resource (CR). For more information about configuration options for the `KnativeServing` CR, see xref:../install/install-serverless-operator.adoc#serverless-configuration[Global configuration].
-
-[IMPORTANT]
-====
-If you want to xref:../observability/tracing/serverless-tracing.adoc#serverless-tracing[use {DTProductName} with {ServerlessProductName}], you must install and configure {DTProductName} before you install Knative Serving.
-====
+After you install the {ServerlessOperatorName}, you can install Knative Serving by using the default settings, or configure more advanced settings in the `KnativeServing` custom resource (CR).
 
 include::modules/serverless-install-serving-web-console.adoc[leveloffset=+1]
+
 include::modules/serverless-install-serving-yaml.adoc[leveloffset=+1]
 
-[id="additional-resources_installing-knative-serving"]
 [role="_additional-resources"]
 == Additional resources
 
 * xref:../knative-serving/kourier-and-istio-ingresses.adoc#kourier-and-istio-ingresses[Kourier and Istio ingresses]
 
-[id="next-steps_installing-knative-serving"]
-== Next steps
+* xref:../knative-serving/getting-started/serverless-applications.adoc#serverless-applications[creating serverless applications]
 
-* After installing Knative Serving, you can start xref:../knative-serving/getting-started/serverless-applications.adoc#serverless-applications[creating serverless applications].
+* xref:../install/installing-knative-eventing.adoc#installing-knative-eventing[Installing Knative Eventing]
 
-* If you want to use Knative event-driven architecture, see xref:../install/installing-knative-eventing.adoc#installing-knative-eventing[Installing Knative Eventing].
+* xref:../observability/tracing/serverless-tracing.adoc#serverless-tracing[{DTProductName} with {ServerlessProductName}]

--- a/install/kube-rbac-proxy-kafka.adoc
+++ b/install/kube-rbac-proxy-kafka.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: ASSEMBLY
-include::_attributes/common-attributes.adoc[]
 [id="kube-rbac-proxy-kafka"]
 = Configuring kube-rbac-proxy for Knative for Apache Kafka
+include::_attributes/common-attributes.adoc[]
 :context: kube-rbac-proxy-kafka
 
 toc::[]

--- a/install/preparing-serverless-install.adoc
+++ b/install/preparing-serverless-install.adoc
@@ -1,77 +1,35 @@
 :_mod-docs-content-type: ASSEMBLY
-include::_attributes/common-attributes.adoc[]
 [id="preparing-serverless-install"]
 = Preparing to install {ServerlessProductName}
+include::_attributes/common-attributes.adoc[]
 :context: preparing-serverless-install
 
 toc::[]
 
 [role="_abstract"]
-Read the following information about supported configurations and prerequisites before you install {ServerlessProductName}.
+Read the following information about supported configurations and prerequisites before you install {ServerlessProductName}. The set of supported features, configurations, and integrations for {ServerlessProductName}, current and past versions, are available at the *Supported Configurations* page.
 
-// OCP specific docs
-For {ocp-product-title}:
+For {ocp-product-title}, you can install {ServerlessProductName} in a restricted or disconnected network environment except for {FunctionsProductName}, but you cannot use it in a multitenant configuration on a single cluster.
 
-* {ServerlessProductName} is supported for installation in a restricted network environment.
-
-* {ServerlessProductName} is supported for disconnected installation, except for {FunctionsProductName}.
-
-* {ServerlessProductName} currently cannot be used in a multi-tenant configuration on a single cluster.
-
-
-[id="about-serverless-supported-configs"]
-== Supported configurations
-
-The set of supported features, configurations, and integrations for {ServerlessProductName}, current and past versions, are available at the link:https://access.redhat.com/articles/4912821[Supported Configurations page].
-
-
-[id="about-serverless-scalability-performance"]
-== Scalability and performance on {ocp-product-title}
-
-With a configuration of 3 main nodes and 3 worker nodes, each of which has 64 CPUs, 457 GB of memory, and 394 GB of storage each, the following time values have been determined during testing for a simple Quarkus application: 
-
-* The average scale-from-zero response time was approximately 3.4 seconds.
-* The maximum response time was 8 seconds.
-* The 99.9th percentile of response times was 4.5 seconds.
-
-These times might vary depending on the application and the runtime of the application.
-
-The maximum number of Knative services that can be created is 3,000. This corresponds to the link:https://docs.openshift.com/container-platform/latest/scalability_and_performance/planning-your-environment-according-to-object-maximums.html#cluster-maximums-major-releases_object-limits[{ocp-product-title} Kubernetes services limit of 10,000], since 1 Knative service creates 3 Kubernetes services.
-
-Learn more about scaling and performance of {ServerlessProductName} Serving in xref:../knative-serving/scalability-and-performance-serving.adoc#scalability-and-performance-serving[Scalability and performance of {ServerlessProductName} Serving].
-
-// OCP specific docs
-
-[id="install-serverless-operator-before-you-begin"]
-
-// OSD and ROSA docs
-[NOTE]
-====
-The following section on defining cluster size requirements applies to these distributions:
-
-* {ocp-product-title}
-* {dedicated-product-title}
-* {rosa-product-title}
-====
+include::modules/about-serverless-scalability-performance.adoc[leveloffset=+1]
 
 include::modules/serverless-cluster-sizing-req.adoc[leveloffset=+1]
 
-
-[id="install-serverless-operator-scaling-with-machinesets"]
-== Scaling your cluster using compute machine sets on {ocp-product-title}
-
-You can use the {ocp-product-title} `MachineSet` API to manually scale your cluster up to the desired size. The minimum requirements usually mean that you must scale up one of the default compute machine sets by two additional machines. See link:https://docs.openshift.com/container-platform/latest/machine_management/manually-scaling-machineset.html#manually-scaling-machineset[Manually scaling a compute machine set].
-
 include::modules/serverless-cluster-sizing-req-additional.adoc[leveloffset=+2]
 
-// TODO: Add OSD specific docs for auto scaling compute machine sets? These docs aren't available for OSD so we need to look into what's required to doc here.
-// QE thread related: https://coreos.slack.com/archives/CD87JDUB0/p1643986092796179
-
-
-[id="additional-resources_preparing-serverless-install"]
 [role="_additional-resources"]
-== Additional resources in {ocp-product-title} documentation
+== Additional resources
 
 * link:https://docs.openshift.com/container-platform/latest/operators/admin/olm-restricted-networks.html#olm-restricted-networks[Using Operator Lifecycle Manager on restricted networks]
+
 * link:https://docs.openshift.com/container-platform/latest/operators/understanding/olm-understanding-operatorhub.html#olm-operatorhub-overview[Understanding OperatorHub]
+
 * link:https://docs.openshift.com/container-platform/latest/installing/overview/cluster-capabilities.html[Cluster capabilities]
+
+* link:https://access.redhat.com/articles/4912821[Supported Configurations page]
+
+* link:https://docs.openshift.com/container-platform/latest/machine_management/manually-scaling-machineset.html#manually-scaling-machineset[Manually scaling a compute machine set]
+
+* xref:../knative-serving/scalability-and-performance-serving.adoc#scalability-and-performance-serving[Scalability and performance of {ServerlessProductName} Serving]
+
+* link:https://docs.openshift.com/container-platform/latest/scalability_and_performance/planning-your-environment-according-to-object-maximums.html#cluster-maximums-major-releases_object-limits[{ocp-product-title} Kubernetes services limit of 10,000]

--- a/install/serverless-kafka-admin.adoc
+++ b/install/serverless-kafka-admin.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: ASSEMBLY
-include::_attributes/common-attributes.adoc[]
 [id="serverless-kafka-admin"]
 = Configuring Knative broker for Apache Kafka
+include::_attributes/common-attributes.adoc[]
 :context: serverless-kafka-admin
 
 toc::[]
@@ -9,24 +9,17 @@ toc::[]
 [role="_abstract"]
 The Knative broker implementation for Apache Kafka provides integration options for you to use supported versions of the Apache Kafka message streaming platform with {ServerlessProductName}. Kafka provides options for event source, channel, broker, and event sink capabilities.
 
-In addition to the Knative Eventing components that are provided as part of a core {ServerlessProductName} installation, the `KnativeKafka` custom resource (CR) can be installed by:
-
-* Cluster administrators, for {ocp-product-title}
-* Cluster or dedicated administrators, for {rosa-product-title} or for {dedicated-product-title}.
-
-The `KnativeKafka` CR provides users with additional options, such as:
-
-* Kafka source
-* Kafka channel
-* Kafka broker
-* Kafka sink
+include::modules/serverless-kafka-components.adoc[leveloffset=+1]
 
 include::modules/serverless-install-kafka-odc.adoc[leveloffset=+1]
 
-[id="additional-resources_serverless-kafka-admin"]
 [role="_additional-resources"]
-== Additional resources for Apache Kafka in Knative Eventing
+== Additional resources
+
 * xref:../eventing/event-sources/serverless-kafka-developer-source.adoc#serverless-kafka-developer-source[Source for apache Kafka]
+
 * xref:../eventing/event-sinks/serverless-kafka-developer-sink.adoc#serverless-kafka-developer-sink[Sink for Apache Kafka]
+
 * xref:../eventing/brokers/kafka-broker.adoc#kafka-broker[Knative broker implementation for Apache Kafka]
+
 * xref:../eventing/kube-rbac-proxy-eventing.adoc#kube-rbac-proxy-eventing-kafka[Configuring kube-rbac-proxy for Knative for Apache Kafka]

--- a/install/serverless-logic-install-kn-workflow-plugin-cli.adoc
+++ b/install/serverless-logic-install-kn-workflow-plugin-cli.adoc
@@ -7,10 +7,17 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 [role="_abstract"]
-OpenShift Serverless Logic provides a plugin named `kn-workflow` for the Knative CLI, enabling you to set up a local workflow project using the command line.
+OpenShift Serverless Logic provides a plugin named `kn-workflow` for the Knative CLI, enabling you to set up a local workflow project by using the command line.
 
-//install doc
 include::modules/serverless-logic-install-kn-workflow-binary-file-linux.adoc[leveloffset=+1]
+
 include::modules/serverless-logic-install-kn-workflow-binary-file-macos.adoc[leveloffset=+1]
+
 include::modules/serverless-logic-install-kn-workflow-binary-file-windows.adoc[leveloffset=+1]
+
 include::modules/serverless-logic-install-kn-workflow-artifact-images.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+== Additional resources
+
+* xref:../install/installing-kn.adoc#installing-kn[Installing the Knative CLI]

--- a/install/serverless-upgrades.adoc
+++ b/install/serverless-upgrades.adoc
@@ -1,20 +1,23 @@
 :_mod-docs-content-type: ASSEMBLY
-include::_attributes/common-attributes.adoc[]
 [id="serverless-upgrades"]
 = Serverless upgrades
+include::_attributes/common-attributes.adoc[]
 :context: serverless-upgrades
 
 toc::[]
 
 [role="_abstract"]
-{ServerlessProductName} should be upgraded without skipping release versions. This section shows how to resolve problems with upgrading.
+You can upgrade {ServerlessProductName} without skipping release versions and resolve common upgrade-related issues to support stability and performance.
 
 include::modules/serverless-hotfix-patch.adoc[leveloffset=+1]
+
 include::modules/serverless-resolving-operator-upgrade-failure.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
-.Additional resources
+== Additional resources
 
 * xref:../about/serverless-release-notes.adoc#serverless-tech-preview-features_serverless-release-notes[{ServerlessProductName} Release Notes]
+
 * xref:../removing/removing-serverless-operator.adoc#olm-deleting-operators-from-a-cluster-using-web-console_removing-serverless-operator[Deleting Operators from a cluster using the web console]
-* xref:../install/install-serverless-operator.adoc#serverless-install-web-console_install-serverless-operator[Installing the OpenShift Serverless Operator from the web console]
+
+* xref:../install/install-serverless-operator.adoc#serverless-install-web-console_install-serverless-operator[Installing the {ServerlessOperatorName} from the web console]

--- a/modules/about-serverless-scalability-performance.adoc
+++ b/modules/about-serverless-scalability-performance.adoc
@@ -1,0 +1,20 @@
+// Module included in the following assemblies:
+//
+// * /serverless/install/preparing-serverless-install.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="about-serverless-scalability-performance_{context}"]
+= Scalability and performance on {ocp-product-title}
+
+[role="_abstract"]
+The cluster includes 3 main nodes and 3 worker nodes. Each node has 64 CPUs, 457 GB of memory, and 394 GB of storage. Testing showed the following time values for a simple Quarkus application:
+
+* The average scale-from-zero response time was about 3.4 seconds.
+* The maximum response time was 8 seconds.
+* The 99.9th percentile of response times was 4.5 seconds.
+
+These times might vary depending on the application and the runtime of the application.
+
+The maximum number of Knative services that can be created is 3,000. This corresponds to the{ocp-product-title} Kubernetes services limit of 10,000, since 1 Knative service creates 3 Kubernetes services.
+
+You can use the {ocp-product-title} `MachineSet` API to manually scale your cluster up to the required size. The minimum requirements usually mean that you must scale up one of the default compute machine sets by two additional machines.

--- a/modules/prerequisites-configuring-serverless-functions.adoc
+++ b/modules/prerequisites-configuring-serverless-functions.adoc
@@ -1,0 +1,29 @@
+// Module included in the following assemblies:
+//
+// * serverless/configuring-serverless-functions.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="prerequisites-configuring-serverless-functions_{context}"]
+= Prerequisites for configuring {FunctionsProductName}
+
+[role="_abstract"]
+To enable the use of {FunctionsProductName} on your cluster, you must complete the following steps:
+
+* You have installed {ServerlessOperatorName} and Knative Serving on your cluster.
++
+[NOTE]
+====
+Functions are deployed as a Knative service. If you want to use event-driven architecture with your functions, you must also install Knative Eventing.
+====
+
+* You have the `oc` CLI installed.
+
+* You have the Knative (`kn`) CLI installed. Installing the Knative CLI enables the use of `kn func` commands which you can use to create and manage functions.
+
+* You have installed Docker Container Engine or Podman version 3.4.7 or higher.
+
+* You have access to an available image registry, such as the OpenShift Container Registry.
+
+* If you are using Quay.io as the image registry, you must ensure that either the repository is not private, or that you have followed the {ocp-product-title} documentation on allowing pods to reference images from other secured registries.
+
+* If you are using the OpenShift Container Registry, a cluster administrator must expose the registry.

--- a/modules/serverless-cluster-sizing-req.adoc
+++ b/modules/serverless-cluster-sizing-req.adoc
@@ -14,6 +14,15 @@ You must size the cluster correctly to install and use {ServerlessProductName}.
 The following requirements apply only to the worker node pool in the cluster. The system does not use control plane nodes for general scheduling and therefore excludes them from these requirements.
 ====
 
+[NOTE]
+====
+The following section on defining cluster size requirements applies to these distributions:
+
+* {ocp-product-title}
+* {dedicated-product-title}
+* {rosa-product-title}
+====
+
 The minimum requirement to use {ServerlessProductName} is a cluster with 10 CPUs and 40GB memory. By default, each pod requests about 400m of CPU, so the system calculates the minimum requirements based on this value.
 
 The total size requirements for running {ServerlessProductName} depend on the installed components and deployed applications, and can vary by deployment.

--- a/modules/serverless-configuring-kube-rbac-proxy-resources-for-kafka.adoc
+++ b/modules/serverless-configuring-kube-rbac-proxy-resources-for-kafka.adoc
@@ -16,7 +16,8 @@ You can also override resource allocation for a specific deployment.
 
 The following configuration sets Knative Kafka `kube-rbac-proxy` minimum and maximum CPU and memory allocation:
 
-.`KnativeKafka` CR example
+You get an output similar to the following example:
+
 [source,yaml]
 ----
 apiVersion: operator.serverless.openshift.io/v1alpha1
@@ -27,12 +28,13 @@ metadata:
 spec:
   config:
     deployment:
-      "kube-rbac-proxy-cpu-request": "10m" <1>
-      "kube-rbac-proxy-memory-request": "20Mi" <2>
-      "kube-rbac-proxy-cpu-limit": "100m" <3>
-      "kube-rbac-proxy-memory-limit": "100Mi" <4>
+      "kube-rbac-proxy-cpu-request": "10m"
+      "kube-rbac-proxy-memory-request": "20Mi"
+      "kube-rbac-proxy-cpu-limit": "100m"
+      "kube-rbac-proxy-memory-limit": "100Mi"
 ----
-<1> Sets minimum CPU allocation.
-<2> Sets minimum RAM allocation.
-<3> Sets maximum CPU allocation.
-<4> Sets maximum RAM allocation.
+
+`kube-rbac-proxy-cpu-request`:: Sets minimum CPU allocation.
+`kube-rbac-proxy-memory-request`:: Sets minimum RAM allocation.
+`kube-rbac-proxy-cpu-limit`:: Sets maximum CPU allocation.
+`kube-rbac-proxy-memory-limit`:: Sets maximum RAM allocation.

--- a/modules/serverless-deleting-crds.adoc
+++ b/modules/serverless-deleting-crds.adoc
@@ -9,6 +9,11 @@
 [role="_abstract"]
 Delete the Operator and API Custom Resource Definitions (CRD) by using the following procedure.
 
+[IMPORTANT]
+====
+Removing the Operator and custom resource definitions (CRDs) also removes all resources that you defined by using them, including Knative services.
+====
+
 .Prerequisites
 
 * Install the OpenShift CLI (`oc`).

--- a/modules/serverless-functions-podman-macos.adoc
+++ b/modules/serverless-functions-podman-macos.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * serverless/functions/serverless-functions-setup.adoc
+// * serverless/functions/configuring-serverless-functions.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="serverless-functions-podman-macos_{context}"]

--- a/modules/serverless-functions-podman.adoc
+++ b/modules/serverless-functions-podman.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * serverless/serverless-functions-setup.adoc
+// * serverless/configuring-serverless-functions.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="serverless-functions-podman_{context}"]
@@ -10,10 +10,6 @@
 To use advanced container management features, you might want to use Podman with {FunctionsProductName}. To do so, you need to start the Podman service and configure the Knative (`kn`) CLI to connect to it.
 
 .Procedure
-
-// This step might no longer be needed in the future, when automatic
-// podman startup is reliable.
-// https://github.com/openshift/openshift-docs/pull/46660/files#r907310116
 . Start the Podman service that serves the Docker API on a UNIX socket at `${XDG_RUNTIME_DIR}/podman/podman.sock`:
 +
 [source,terminal]

--- a/modules/serverless-hotfix-patch.adoc
+++ b/modules/serverless-hotfix-patch.adoc
@@ -16,7 +16,7 @@ Beginning with {ServerlessProductName} 1.29, the different product versions are 
 +
 [NOTE]
 ====
-The maintenance release is the release prior to the latest release. For example, if the `stable` channel includes version 1.30, then the maintenance release will be available in the `stable-1.29` channel.
+The maintenance release is the release before the latest release. For example, if the `stable` channel includes version 1.30, then the maintenance release will be available in the `stable-1.29` channel.
 ====
 
 Using a version-based channel allows you to stay within a specific `x.y` stream. Additionally, it prevents an upgrade to the latest version of the product, which might contain breaking changes.
@@ -32,9 +32,9 @@ As with the stable release, the maintenance release is subject to patches and ho
 +
 Hotfixes might not be available to all customers immediately. However, changes introduced by hotfixes often become available to all customers as part of a future release.
 +
-When a hotfix pertaining to your deployment is available, you will be given the hotfix CatalogSource to update your subscription and obtain the hotfix.
+When a hotfix pertaining to your deployment is available, you will be given the hotfix `CatalogSource` to update your subscription and obtain the hotfix.
 +
-After a new operator release is available, deployed operators with hotfixes can also be upgraded. To use the latest GA version, modify the subscription to use the public CatalogSource instead of the hotfix one.
+After a new Operator release is available, deployed Operators with hotfixes can also be upgraded. To use the latest GA version, change the subscription to use the public `CatalogSource` instead of the hotfix one.
 
 The following diagram illustrates how patches and hotfixes work:
 
@@ -72,9 +72,7 @@ If you use a version-based channel, you can always upgrade to the latest version
 
 Additionally, from the head of the channel, you can upgrade to the next `x.y` release. For example, if 1.29.2 is the head in the `stable-1.29` channel, you can upgrade from 1.29.2 to 1.30. Such cross-channel updates are not done automatically, and the administrator needs to switch the channel manually by updating the subscription.
 
-== Upgrade examples
-
-=== Scenario 1
+== Upgrade example scenario 1
 
 In this scenario, the following circumstances are true:
 
@@ -109,7 +107,7 @@ The upgrade path from 1.28.0 on `stable-1.28` to 1.29.0 on `stable` in this scen
 +--------------+            +--------------+
 ----
 
-=== Scenario 2
+== Upgrade example scenario 2
 
 In this scenario, the following circumstances are true:
 
@@ -142,7 +140,7 @@ The upgrade path from 1.29.0 on `stable-1.29` to 1.30.0 on `stable` in this scen
 +--------------+           +--------------+
 ----
 
-=== Scenario 3
+== Upgrade example scenario 3
 
 In this scenario, the following circumstances are true:
 

--- a/modules/serverless-install-cli.adoc
+++ b/modules/serverless-install-cli.adoc
@@ -7,20 +7,17 @@
 = Installing the {ServerlessOperatorName} from the CLI
 
 [role="_abstract"]
-You can install the {ServerlessOperatorName} from the OperatorHub by using the CLI. Installing this Operator enables you to install and use Knative components.
+You can install the {ServerlessOperatorName} from the OperatorHub by using the CLI. After installation, run Knative components on the cluster.
 
 .Prerequisites
 
 * You have cluster administrator permissions on {ocp-product-title}, or you have cluster or dedicated administrator permissions on {rosa-product-title} or {dedicated-product-title}.
 * For {ocp-product-title}, your cluster has the Marketplace capability enabled or the Red Hat Operator catalog source configured manually.
-
-
 * You have logged in to the cluster.
 
 .Procedure
-. Create a YAML file containing `Namespace`, `OperatorGroup`, and `Subscription` objects to subscribe a namespace to the {ServerlessOperatorName}. For example, create the file `serverless-subscription.yaml` with the following content:
+. Create a YAML file containing `Namespace`, `OperatorGroup`, and `Subscription` objects to subscribe a namespace to the {ServerlessOperatorName}. For example, create the file `serverless-subscription.yaml` similar to the following example:
 +
-.Example subscription
 [source,yaml]
 ----
 ---
@@ -42,15 +39,16 @@ metadata:
   name: serverless-operator
   namespace: openshift-serverless
 spec:
-  channel: stable <1>
-  name: serverless-operator <2>
-  source: redhat-operators <3>
-  sourceNamespace: openshift-marketplace <4>
+  channel: stable
+  name: serverless-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
 ----
-<1> The channel name of the Operator. The `stable` channel enables installation of the most recent stable version of the {ServerlessOperatorName}. To install another version, specify the corresponding `stable-x.y` channel, for example `stable-1.29`.
-<2> The name of the Operator to subscribe to. For the {ServerlessOperatorName}, this is always `serverless-operator`.
-<3> The name of the CatalogSource that provides the Operator. Use `redhat-operators` for the default OperatorHub catalog sources.
-<4> The namespace of the CatalogSource. Use `openshift-marketplace` for the default OperatorHub catalog sources.
+
+`spec.channel``:: The channel name of the Operator. The `stable` channel enables installation of the most recent stable version of the {ServerlessOperatorName}. To install another version, specify the corresponding `stable-x.y` channel, for example `stable-1.29`.
+`spec.name``:: The name of the Operator to subscribe to. For the {ServerlessOperatorName}, this is always `serverless-operator`.
+`spec.source``:: The name of the `CatalogSource` that provides the Operator. Use `redhat-operators` for the default OperatorHub catalog sources.
+`spec.sourceNamespace``:: The namespace of the `CatalogSource`. Use `openshift-marketplace` for the default OperatorHub catalog sources.
 
 . Create the `Subscription` object:
 +

--- a/modules/serverless-install-eventing-web-console.adoc
+++ b/modules/serverless-install-eventing-web-console.adoc
@@ -12,7 +12,6 @@ After you install the {ServerlessOperatorName}, install Knative Eventing by usin
 .Prerequisites
 
 * You have cluster administrator permissions on {ocp-product-title}, or you have cluster or dedicated administrator permissions on {rosa-product-title} or {dedicated-product-title}.
-
 * You have logged in to the {ocp-product-title} web console.
 * You have installed the {ServerlessOperatorName}.
 
@@ -38,16 +37,16 @@ After you install the {ServerlessOperatorName}, install Knative Eventing by usin
 
 .Verification
 
-. Click on the `knative-eventing` custom resource in the *Knative Eventing* tab. You are automatically directed to the *Knative Eventing Overview* page.
+. Click the `knative-eventing` custom resource in the *Knative Eventing* tab. You are automatically directed to the *Knative Eventing Overview* page.
 
-. Scroll down to look at the list of *Conditions*.
+. Scroll down to check the list of *Conditions*.
 
 . You should see a list of conditions with a status of *True*.
 
 +
 [NOTE]
 ====
-It may take a few seconds for the Knative Eventing resources to be created. You can check their status in the *Resources* tab.
+It can take a few seconds for the Knative Eventing resources to be created. You can check their status in the *Resources* tab.
 ====
 
 . If the conditions have a status of *Unknown* or *False*, wait a few moments and then check again after you have confirmed that the resources have been created.

--- a/modules/serverless-install-eventing-yaml.adoc
+++ b/modules/serverless-install-eventing-yaml.adoc
@@ -12,9 +12,8 @@ After you install the {ServerlessOperatorName}, you can install Knative Eventing
 .Prerequisites
 
 * You have cluster administrator permissions on {ocp-product-title}, or you have cluster or dedicated administrator permissions on {rosa-product-title} or {dedicated-product-title}.
-
 * You have installed the {ServerlessOperatorName}.
-* Install the OpenShift CLI (`oc`).
+* You have installed the OpenShift CLI (`oc`).
 
 .Procedure
 
@@ -48,7 +47,8 @@ $ oc get knativeeventing.operator.knative.dev/knative-eventing \
   --template='{{range .status.conditions}}{{printf "%s=%s\n" .type .status}}{{end}}'
 ----
 +
-.Example output
+You get an output similar to the following example:
++
 [source,terminal]
 ----
 InstallSucceeded=True
@@ -57,7 +57,7 @@ Ready=True
 +
 [NOTE]
 ====
-It may take a few seconds for the Knative Eventing resources to be created.
+It can take a few seconds for the Knative Eventing resources to be created.
 ====
 . If the conditions have a status of `Unknown` or `False`, wait a few moments and then check again after you have confirmed that the resources have been created.
 . Check that the Knative Eventing resources have been created by entering:
@@ -67,7 +67,8 @@ It may take a few seconds for the Knative Eventing resources to be created.
 $ oc get pods -n knative-eventing
 ----
 +
-.Example output
+You get an output similar to the following example:
++
 [source,terminal]
 ----
 NAME                                   READY   STATUS    RESTARTS   AGE

--- a/modules/serverless-install-kafka-odc.adoc
+++ b/modules/serverless-install-kafka-odc.adoc
@@ -15,7 +15,7 @@ The Knative broker implementation for Apache Kafka provides integration options 
 * You have access to a Red Hat AMQ Streams cluster.
 * Install the OpenShift CLI (`oc`) if you want to use the verification steps.
 * You have cluster administrator permissions on {ocp-product-title}, or you have cluster or dedicated administrator permissions on {rosa-product-title} or {dedicated-product-title}.
-* You are logged in to the {ocp-product-title} web console.
+* You have logged in to the {ocp-product-title} web console.
 
 .Procedure
 
@@ -35,7 +35,8 @@ To use the Kafka channel, source, broker, or sink on your cluster, you must togg
 ** Use the form for simpler configurations that do not require full control of *KnativeKafka* object creation.
 ** Edit the YAML for more complex configurations that require full control of *KnativeKafka* object creation. You can access the YAML by clicking the *Edit YAML* link on the *Create Knative Kafka* page.
 +
-.Example `KnativeKafka` custom resource
+You get an output similar to the following example:
++
 [source,yaml]
 ----
 apiVersion: operator.serverless.openshift.io/v1alpha1
@@ -45,30 +46,32 @@ metadata:
     namespace: knative-eventing
 spec:
     channel:
-        enabled: true <1>
-        bootstrapServers: <bootstrap_servers> <2>
+        enabled: true
+        bootstrapServers: <bootstrap_servers>
     source:
-        enabled: true <3>
+        enabled: true
     broker:
-        enabled: true <4>
+        enabled: true
         defaultConfig:
-            bootstrapServers: <bootstrap_servers> <5>
-            numPartitions: <num_partitions> <6>
-            replicationFactor: <replication_factor> <7>
+            bootstrapServers: <bootstrap_servers>
+            numPartitions: <num_partitions>
+            replicationFactor: <replication_factor>
     sink:
-        enabled: true <8>
+        enabled: true
     logging:
-        level: INFO <9>
+        level: INFO
 ----
-<1> Enables developers to use the `KafkaChannel` channel type in the cluster.
-<2> A comma-separated list of bootstrap servers from your AMQ Streams cluster.
-<3> Enables developers to use the `KafkaSource` event source type in the cluster.
-<4> Enables developers to use the Knative broker implementation for Apache Kafka in the cluster.
-<5> A comma-separated list of bootstrap servers from your Red Hat AMQ Streams cluster.
-<6> Defines the number of partitions of the Kafka topics, backed by the `Broker` objects. The default is `10`.
-<7> Defines the replication factor of the Kafka topics, backed by the `Broker` objects. The default is `3`. The `replicationFactor` value must be less than or equal to the number of nodes of your Red Hat AMQ Streams cluster.
-<8> Enables developers to use a Kafka sink in the cluster.
-<9> Defines the log level of the Kafka data plane. Allowed values are `TRACE`, `DEBUG`, `INFO`, `WARN` and `ERROR`. The default value is `INFO`.
+
+`spec.channel.enabled`:: Enables developers to use the `KafkaChannel` channel type in the cluster.
+`spec.channel.bootstrapServers`:: A comma-separated list of bootstrap servers from your AMQ Streams 
+cluster.
+`spec.source.enabled`:: Enables developers to use the `KafkaSource` event source type in the cluster.
+`spec.broker.enabled`:: Enables developers to use the Knative broker implementation for Apache Kafka in the cluster.
+`spec.broker.defaultConfig.bootstrapServers`:: A comma-separated list of bootstrap servers from your Red Hat AMQ Streams cluster.
+`spec.broker.defaultConfig.numPartitions`:: Defines the number of partitions of the Kafka topics, backed by the `Broker` objects. The default is `10`.
+`spec.broker.defaultConfig.replicationFactor`:: Defines the replication factor of the Kafka topics, backed by the `Broker` objects. The default is `3`. The `replicationFactor` value must be less than or equal to the number of nodes of your Red Hat AMQ Streams cluster.
+`sink.enabled`:: Enables developers to use a Kafka sink in the cluster.
+`logging.level`:: Defines the log level of the Kafka data plane. Allowed values are `TRACE`, `DEBUG`, `INFO`, `WARN` and `ERROR`. The default value is `INFO`.
 +
 [WARNING]
 ====
@@ -79,7 +82,7 @@ Do not use `DEBUG` or `TRACE` as the logging level in production environments. T
 
 .Verification
 
-. Click on the *knative-kafka* resource in the *Knative Kafka* tab. You are automatically directed to the *Knative Kafka Overview* page.
+. Click the *knative-kafka* resource in the *Knative Kafka* tab. You are automatically directed to the *Knative Kafka Overview* page.
 
 . View the list of *Conditions* for the resource and confirm that they have a status of *True*.
 +
@@ -94,7 +97,8 @@ If the conditions have a status of *Unknown* or *False*, wait a few moments to r
 $ oc get pods -n knative-eventing
 ----
 +
-.Example output
+You get an output similar to the following example:
++
 [source,terminal]
 ----
 NAME                                        READY   STATUS    RESTARTS   AGE

--- a/modules/serverless-install-serving-web-console.adoc
+++ b/modules/serverless-install-serving-web-console.adoc
@@ -12,7 +12,6 @@ After you install the {ServerlessOperatorName}, install Knative Serving by using
 .Prerequisites
 
 * You have cluster administrator permissions on {ocp-product-title}, or you have cluster or dedicated administrator permissions on {rosa-product-title} or {dedicated-product-title}.
-
 * You have logged in to the {ocp-product-title} web console.
 * You have installed the {ServerlessOperatorName}.
 
@@ -28,7 +27,7 @@ After you install the {ServerlessOperatorName}, install Knative Serving by using
 
 . In the *Create Knative Serving* page, you can install Knative Serving using the default settings by clicking *Create*.
 +
-You can also modify settings for the Knative Serving installation by editing the `KnativeServing` object using either the form provided, or by editing the YAML.
+You can also change settings for the Knative Serving installation by editing the `KnativeServing` object by using either the form provided, or by editing the YAML.
 
 * Using the form is recommended for simpler configurations that do not require full control of `KnativeServing` object creation.
 
@@ -45,15 +44,15 @@ For more information about configuration options for the KnativeServing custom r
 
 .Verification
 
-. Click on `knative-serving` custom resource in the *Knative Serving* tab. You will be automatically directed to the *Knative Serving Overview* page.
+. Click `knative-serving` custom resource in the *Knative Serving* tab. You will be automatically directed to the *Knative Serving Overview* page.
 
-. Scroll down to look at the list of *Conditions*.
+. Scroll down to check the list of *Conditions*.
 
 . You should see a list of conditions with a status of *True*.
 
 [NOTE]
 ====
-It may take a few seconds for the Knative Serving resources to be created. You can check their status in the *Resources* tab.
+It can take a few seconds for the Knative Serving resources to be created. You can check their status in the *Resources* tab.
 ====
 
 . If the conditions have a status of *Unknown* or *False*, wait a few moments and then check again after you have confirmed that the resources have been created.

--- a/modules/serverless-install-serving-yaml.adoc
+++ b/modules/serverless-install-serving-yaml.adoc
@@ -12,9 +12,8 @@ After you install the {ServerlessOperatorName}, you can install Knative Serving 
 .Prerequisites
 
 * You have cluster administrator permissions on {ocp-product-title}, or you have cluster or dedicated administrator permissions on {rosa-product-title} or {dedicated-product-title}.
-
 * You have installed the {ServerlessOperatorName}.
-* Install the OpenShift CLI (`oc`).
+* You have installed the OpenShift CLI (`oc`).
 
 .Procedure
 
@@ -44,7 +43,8 @@ $ oc apply -f serving.yaml
 $ oc get knativeserving.operator.knative.dev/knative-serving -n knative-serving --template='{{range .status.conditions}}{{printf "%s=%s\n" .type .status}}{{end}}'
 ----
 +
-.Example output
+You get an output similar to the following example:
++
 [source,terminal]
 ----
 DependenciesInstalled=True
@@ -55,7 +55,7 @@ Ready=True
 +
 [NOTE]
 ====
-It may take a few seconds for the Knative Serving resources to be created.
+It can take a few seconds for the Knative Serving resources to be created.
 ====
 +
 If the conditions have a status of `Unknown` or `False`, wait a few moments and then check again after you have confirmed that the resources have been created.
@@ -67,7 +67,8 @@ If the conditions have a status of `Unknown` or `False`, wait a few moments and 
 $ oc get pods -n knative-serving
 ----
 +
-.Example output
+You get an output similar to the following example:
++
 [source,terminal]
 ----
 NAME                                                        READY   STATUS      RESTARTS   AGE
@@ -88,14 +89,15 @@ webhook-5fb774f8d8-6bqrt                                    2/2     Running     
 webhook-5fb774f8d8-b8lt5                                    2/2     Running     0          3m57s
 ----
 
-. Check that the necessary networking components have been installed to the automatically created `knative-serving-ingress` namespace:
+. Check that the necessary networking components are installed to the automatically created `knative-serving-ingress` namespace:
 +
 [source,terminal]
 ----
 $ oc get pods -n knative-serving-ingress
 ----
 +
-.Example output
+You get an output similar to the following example:
++
 [source,terminal]
 ----
 NAME                                      READY   STATUS    RESTARTS   AGE

--- a/modules/serverless-install-web-console.adoc
+++ b/modules/serverless-install-web-console.adoc
@@ -7,14 +7,12 @@
 = Installing the {ServerlessOperatorName} from the web console
 
 [role="_abstract"]
-You can install the {ServerlessOperatorName} from the OperatorHub by using the {ocp-product-title} web console. Installing this Operator enables you to install and use Knative components.
+You can install the {ServerlessOperatorName} from the OperatorHub by using the {ocp-product-title} web console. After installation, run Knative components on the cluster.
 
 .Prerequisites
 
 * You have cluster administrator permissions on {ocp-product-title}, or you have cluster or dedicated administrator permissions on {rosa-product-title} or {dedicated-product-title}.
 * For {ocp-product-title}, your cluster has the Marketplace capability enabled or the Red Hat Operator catalog source configured manually.
-
-
 * You have logged in to the  web console.
 
 .Procedure
@@ -27,7 +25,7 @@ You can install the {ServerlessOperatorName} from the OperatorHub by using the {
 
 . On the *Install Operator* page:
 
-.. The *Installation Mode* is *All namespaces on the cluster (default)*. This mode installs the Operator in the default `openshift-serverless` namespace to watch and be made available to all namespaces in the cluster.
+.. The *Installation Mode* is *All namespaces on the cluster (default)*. This mode installs the Operator in the default `openshift-serverless` namespace to watch and made available to all namespaces in the cluster.
 
 .. The *Installed Namespace* is `openshift-serverless`.
 

--- a/modules/serverless-installing-cli-linux-rpm-package-manager.adoc
+++ b/modules/serverless-installing-cli-linux-rpm-package-manager.adoc
@@ -7,7 +7,7 @@
 = Installing the Knative CLI for Linux by using an RPM package manager
 
 [role="_abstract"]
-For {op-system-base-full}, you can install the Knative (`kn`) CLI as an RPM by using a package manager, such as `yum` or `dnf`. This allows the Knative CLI version to be automatically managed by the system. For example, using a command like `dnf upgrade` upgrades all packages, including `kn`, if a new version is available.
+For {op-system-base-full}, you can install the Knative (`kn`) CLI as an RPM by using a package manager, such as `yum` or `dnf`. This allows the Knative CLI version to be automatically managed by the system. For example, using a command such as `dnf upgrade` upgrades all packages, including `kn`, if a new version is available.
 
 .Prerequisites
 
@@ -33,10 +33,10 @@ For {op-system-base-full}, you can install the Knative (`kn`) CLI as an RPM by u
 +
 [source,terminal]
 ----
-# subscription-manager attach --pool=<pool_id> <1>
+# subscription-manager attach --pool=<pool_id>
 ----
 +
-<1> Pool ID for an active {ocp-product-title} subscription
+`<pool_id>`:: Pool ID for an active {ocp-product-title} subscription
 
 . Enable the repositories required by the Knative (`kn`) CLI:
 +
@@ -61,9 +61,8 @@ For {op-system-base-full}, you can install the Knative (`kn`) CLI as an RPM by u
 # subscription-manager repos --enable="openshift-serverless-1-for-rhel-9-ppc64le-rpms"
 ----
 
-. Install the Knative (`kn`) CLI as an RPM by using a package manager:
+. Install the Knative (`kn`) CLI as an RPM by using a package manager similar to the following example:
 +
-.Example `yum` command
 [source,terminal]
 ----
 # yum install openshift-serverless-clients

--- a/modules/serverless-installing-cli-web-console.adoc
+++ b/modules/serverless-installing-cli-web-console.adoc
@@ -7,12 +7,21 @@
 = Installing the Knative CLI using the {ocp-product-title} web console
 
 [role="_abstract"]
-Using the {ocp-product-title} web console provides a streamlined and intuitive user interface to install the Knative (`kn`) CLI. After the {ServerlessOperatorName} is installed, you will see a link to download the Knative (`kn`) CLI for Linux (amd64, s390x, ppc64le), macOS, or Windows from the *Command Line Tools* page in the {ocp-product-title} web console.
+Using the {ocp-product-title} web console provides a streamlined and intuitive user interface to install the Knative (`kn`) CLI. Once you install the {ServerlessOperatorName}, you will see a link to download the Knative (`kn`) CLI for Linux (amd64, s390x, ppc64le), macOS, or Windows from the *Command Line Tools* page in the {ocp-product-title} web console.
+
+[IMPORTANT]
+====
+If you try to use an older version of the Knative (`kn`) CLI with a newer {ServerlessProductName} release, the API is not found and an error occurs.
+
+For example, the 1.23.0 release of the Knative (`kn`) CLI uses version 1.2. The 1.24.0 {ServerlessProductName} release uses version 1.3 of the Knative Serving and Knative Eventing APIs. The CLI fails because it looks for the outdated 1.2 API versions.
+
+Ensure that you are using the latest Knative (`kn`) CLI version for your {ServerlessProductName} release to avoid issues.
+====
 
 .Prerequisites
 
 * You have logged in to the {ocp-product-title} web console.
-* The {ServerlessOperatorName} and Knative Serving are installed on your {ocp-product-title} cluster.
+* You have installed the {ServerlessOperatorName} and Knative Serving on your {ocp-product-title} cluster.
 +
 [IMPORTANT]
 ====
@@ -55,7 +64,8 @@ $ echo $PATH
 $ oc get ConsoleCLIDownload
 ----
 +
-.Example output
+You get an output similar to the following example:
++
 [source,terminal]
 ----
 NAME                  DISPLAY NAME                                             AGE
@@ -68,7 +78,8 @@ oc-cli-downloads      oc - OpenShift Command Line Interface (CLI)              2
 $ oc get route -n openshift-serverless
 ----
 +
-.Example output
+You get an output similar to the following example:
++
 [source,terminal]
 ----
 NAME   HOST/PORT                                  PATH   SERVICES                      PORT       TERMINATION     WILDCARD

--- a/modules/serverless-installing-cli-windows.adoc
+++ b/modules/serverless-installing-cli-windows.adoc
@@ -9,8 +9,6 @@
 [role="_abstract"]
 If you are using Windows, you can install the Knative (`kn`) CLI as a binary file. To do this, you must download and unpack a ZIP archive and add the binary to a directory on your `PATH`.
 
-// no prereqs?
-
 .Procedure
 
 . Download the link:https://mirror.openshift.com/pub/cgw/serverless/latest/kn-windows-amd64.zip[Knative (`kn`) CLI ZIP archive].
@@ -21,7 +19,7 @@ You can also download any version of `kn` by navigating to that version's corres
 
 . Move the `kn` binary to a directory on your `PATH`.
 
-. To check your `PATH`, open the command prompt and run the command:
+. To check your `PATH`, open the Command Prompt and run the command:
 +
 [source,terminal]
 ----

--- a/modules/serverless-kafka-components.adoc
+++ b/modules/serverless-kafka-components.adoc
@@ -1,0 +1,19 @@
+// Module is included in the following assemblies:
+//
+// serverless/install/serverless-kafka-admin.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="serverless-kafka-components_{context}"]
+= Kafka components for Knative Eventing
+
+[role="_abstract"]
+In addition to the Knative Eventing components that come with a core {ServerlessProductName} installation, install the `KnativeKafka` custom resource (CR) to use Kafka-based eventing features.
+
+Cluster administrators can install the `KnativeKafka` CR on {ocp-product-title}. On {rosa-product-title} and {dedicated-product-title}, cluster or dedicated administrators can install the CR.
+
+The `KnativeKafka` CR provides the following components:
+
+* Kafka source
+* Kafka channel
+* Kafka broker
+* Kafka sink

--- a/modules/serverless-locking-version-for-cli-installed-with-rpm-package-manager.adoc
+++ b/modules/serverless-locking-version-for-cli-installed-with-rpm-package-manager.adoc
@@ -7,7 +7,7 @@
 = Locking version for the Knative CLI installed with RPM package manager
 
 [role="_abstract"]
-You might require to use Knative (`kn`) CLI version that is not the most recent, but is in Maintenance Phase. You can achieve that by locking the version of `kn`, which prevents it from being upgraded.
+You can use a Knative (`kn`) CLI version that is in the Maintenance Phase, even if it is not the most recent. Lock the `kn` version to prevent upgrades.
 
 .Procedure
 

--- a/modules/serverless-logic-install-kn-workflow-artifact-images.adoc
+++ b/modules/serverless-logic-install-kn-workflow-artifact-images.adoc
@@ -7,7 +7,7 @@
 = Installing the OpenShift Serverless Logic Knative Workflow plugin using the artifacts image
 
 [role="_abstract"]
-You can install the Knative Workflow plugin for the `kn` CLI by downloading it from the artifacts container image by using Podman. This method provides access to the plugin binary files for multiple platforms including Linux, macOS, and Windows.
+You can install the Knative Workflow plugin for the `kn` CLI by downloading it from the artifacts container image by using Podman. This method provides access to the plugin binary files for many platforms including Linux, macOS, and Windows.
 
 .Prerequisites
 
@@ -125,13 +125,13 @@ $ kn plugin list
 
 . After installing the plugin, you can use `kn-workflow` to run the related subcommands.
 +
-.Aliases to use workflow subcommand
 [source,terminal]
 ----
 kn-workflow
 ----
 +
-.Example output of `kn-workflow help` command
+You get an output similar to the following example:
++
 [source,terminal]
 ----
 Manage OpenShift Serverless Logic Workflow projects

--- a/modules/serverless-logic-install-kn-workflow-binary-file-linux.adoc
+++ b/modules/serverless-logic-install-kn-workflow-binary-file-linux.adoc
@@ -11,8 +11,7 @@ If you are using a Linux distribution that does not have RPM or another package 
 
 .Prerequisites
 
-* You have installed the Knative (`kn`) command-line interface (CLI). For more information, see the xref:../install/installing-kn.adoc#installing-kn[Installing the Knative CLI] documentation.
-
+* You have installed the Knative (`kn`) command-line interface (CLI).
 * If you are not using {op-system-base} or Fedora, ensure that the *libc* library is installed in a directory on your path.
 +
 [IMPORTANT]

--- a/modules/serverless-logic-install-kn-workflow-binary-file-macos.adoc
+++ b/modules/serverless-logic-install-kn-workflow-binary-file-macos.adoc
@@ -16,7 +16,7 @@ On macOS, some systems might block the application from running due to security 
 
 .Prerequisites
 
-* You have installed the Knative (`kn`) command-line interface (CLI). For more information, see the xref:../install/installing-kn.adoc#installing-kn[Installing the Knative CLI] documentation.
+* You have installed the Knative (`kn`) command-line interface (CLI).
 
 .Procedure
 

--- a/modules/serverless-logic-install-kn-workflow-binary-file-windows.adoc
+++ b/modules/serverless-logic-install-kn-workflow-binary-file-windows.adoc
@@ -11,7 +11,7 @@ If you are using Windows, you can install the Knative Workflow plugin as a binar
 
 .Prerequisites
 
-* You have installed the Knative (`kn`) command-line interface (CLI). For more information, see the xref:../install/installing-kn.adoc#installing-kn[Installing the Knative CLI] documentation.
+* You have installed the Knative (`kn`) command-line interface (CLI).
 
 .Procedure
 
@@ -33,7 +33,7 @@ $ Rename-Item -Path <destination>\<filename>.exe -NewName kn-workflow.exe
 
 . Install the `kn-workflow` command as the Knative CLI plugin:
 +
-On Windows, files with a `.exe` extension are treated as executable by default, so you do not need to change permissions.
+On Windows, files with a `.exe` extension are treated as executable files by default, so you do not need to change permissions.
 
 * Copy the `kn-workflow` binary file to a directory in your `PATH` by running the following command:
 +

--- a/modules/serverless-operator-global-configuration.adoc
+++ b/modules/serverless-operator-global-configuration.adoc
@@ -1,0 +1,14 @@
+// Module included in the following assemblies:
+//
+// * install/install-serverless-operator.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="serverless-operator-global-configuration_{context}"]
+= {ServerlessOperatorName} global configuration
+
+[role="_abstract"]
+The {ServerlessOperatorName} manages the global configuration of a Knative installation. It propagates values from the `KnativeServing` and `KnativeEventing` custom resources to system ConfigMaps. If you manually update a ConfigMap, the Operator overwrites those changes. You can change the Knative custom resources to set values for these ConfigMaps.
+
+Knative uses many ConfigMaps with the `config-` prefix. Create all Knative ConfigMaps in the same namespace as the custom resource they apply to. For example, if you create the `KnativeServing` custom resource in the `knative-serving` namespace, create all Knative Serving ConfigMaps in the same namespace.
+
+In Knative custom resources, the `spec.config` field has one `<name>` entry for each ConfigMap, named `config-<name>`. Set the value of each entry to define the `data` field for the corresponding ConfigMap.

--- a/modules/serverless-operator-installation-resource-requirements.adoc
+++ b/modules/serverless-operator-installation-resource-requirements.adoc
@@ -23,7 +23,7 @@ The test suite used in the sample setup has the following parameters:
 
 * 41 stable scenarios, where events are sent throughout the test run slowly but continuously.
 
-* The test setup contains, in total:
+* The test setup has, in total:
 ** 170 Knative Services
 ** 20 In-Memory Channels
 ** 24 Kafka Channels

--- a/modules/serverless-resolving-operator-upgrade-failure.adoc
+++ b/modules/serverless-resolving-operator-upgrade-failure.adoc
@@ -7,7 +7,7 @@
 = Resolving an {ServerlessOperatorName} upgrade failure
 
 [role="_abstract"]
-You might encounter an error when upgrading {ServerlessOperatorName}, for example, when performing manual uninstalls and reinstalls. If you encounter an error, you must manually reinstall {ServerlessOperatorName}.
+You might get an error when upgrading {ServerlessOperatorName}, for example, when performing manual uninstalls and reinstalls. If you get an error, you must manually reinstall {ServerlessOperatorName}.
 
 .Procedure
 
@@ -20,7 +20,7 @@ For example, the error message during attempted upgrade might contain the follow
 The installed KnativeServing version is v1.5.0.
 ----
 +
-In this example, the KnativeServing `MAJOR.MINOR` version is `1.5`, which is covered in the release notes for {ServerlessProductName} 1.26: _OpenShift Serverless now uses Knative Serving 1.5_.
+In this example, the `KnativeServing` `MAJOR.MINOR` version is `1.5`, which is covered in the release notes for {ServerlessProductName} 1.26: _OpenShift Serverless now uses Knative Serving 1.5_.
 
 . Uninstall {ServerlessOperatorName} and all of its install plans.
 

--- a/modules/serverless-uninstalling-knative-eventing.adoc
+++ b/modules/serverless-uninstalling-knative-eventing.adoc
@@ -12,8 +12,7 @@ You can uninstall Knative Eventing from your cluster by deleting the `KnativeEve
 .Prerequisites
 
 * You have cluster administrator permissions on {ocp-product-title}, or you have cluster or dedicated administrator permissions on {dedicated-product-title}.
-
-* Install the OpenShift CLI (`oc`).
+* You have installed the OpenShift CLI (`oc`).
 
 .Procedure
 

--- a/modules/serverless-uninstalling-knative-serving.adoc
+++ b/modules/serverless-uninstalling-knative-serving.adoc
@@ -12,8 +12,7 @@ You can uninstall Knative Serving from your cluster by deleting the `KnativeServ
 .Prerequisites
 
 * You have cluster administrator permissions on {ocp-product-title}, or you have cluster or dedicated administrator permissions on {dedicated-product-title}.
-
-* Install the OpenShift CLI (`oc`).
+* You have installed the OpenShift CLI (`oc`).
 
 .Procedure
 

--- a/modules/serverless-upgrading-cli-with-locked-version.adoc
+++ b/modules/serverless-upgrading-cli-with-locked-version.adoc
@@ -7,10 +7,9 @@
 = Upgrading the Knative CLI with locked version
 
 [role="_abstract"]
-You can manually upgrade the Knative (`kn`) CLI version that has previously been version-locked.
+You can manually upgrade the Knative (`kn`) CLI version after you remove the version lock.
 
 .Procedure
-
 
 . Check whether upgraded packages are available:
 +
@@ -20,12 +19,14 @@ You can manually upgrade the Knative (`kn`) CLI version that has previously been
 ----
 
 . Remove the version lock of `kn`:
++
 [source,terminal]
 ----
 # dnf versionlock delete openshift-serverless-clients
 ----
 
 . Lock `kn` to the new version:
++
 [source,terminal]
 ----
 # dnf versionlock add --raw 'openshift-serverless-clients-1.8.*'

--- a/removing/deleting-serverless-crds.adoc
+++ b/removing/deleting-serverless-crds.adoc
@@ -1,16 +1,10 @@
 :_mod-docs-content-type: ASSEMBLY
-include::_attributes/common-attributes.adoc[]
 [id="deleting-serverless-crds"]
 = Deleting {ServerlessProductName} custom resource definitions
+include::_attributes/common-attributes.adoc[]
 :context: deleting-serverless-crds
 
 [role="_abstract"]
 After uninstalling the {ServerlessProductName}, the Operator and API custom resource definitions (CRDs) remain on the cluster. You can use the following procedure to remove the remaining CRDs.
 
-[IMPORTANT]
-====
-Removing the Operator and API CRDs also removes all resources that were defined by using them, including Knative services.
-====
-
-// deleting serverless CRDs
 include::modules/serverless-deleting-crds.adoc[leveloffset=+1]

--- a/removing/removing-openshift-serverless-logic-operator.adoc
+++ b/removing/removing-openshift-serverless-logic-operator.adoc
@@ -1,13 +1,16 @@
 :_mod-docs-content-type: ASSEMBLY
-include::_attributes/common-attributes.adoc[]
 [id="removing-openshift-serverless-logic-operator"]
 = Removing the OpenShift Serverless Logic Operator
+include::_attributes/common-attributes.adoc[]
 :context: uninstalling-openshift-serverless-logic-operator
 
 [role="_abstract"]
 If you need to remove OpenShift Serverless Logic from your cluster, you can do so by manually removing the {ServerlessLogicOperatorName} and other OpenShift Serverless Logic components.
 
-You can delete the {ServerlessLogicOperatorName} by using the web console. 
+You can delete the {ServerlessLogicOperatorName} by using the web console.
+
+[role="_additional-resources"]
+== Additional resources
 
 * link:https://docs.openshift.com/container-platform/latest/operators/admin/olm-deleting-operators-from-cluster.html#olm-deleting-operators-from-a-cluster-using-web-console_olm-deleting-operators-from-a-cluster[Deleting Operators from a cluster using the web console]
 

--- a/removing/removing-openshift-serverless.adoc
+++ b/removing/removing-openshift-serverless.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: ASSEMBLY
-include::_attributes/common-attributes.adoc[]
 [id="removing-openshift-serverless"]
 = Removing {ServerlessProductName} overview
+include::_attributes/common-attributes.adoc[]
 :context: removing-openshift-serverless
 
 [role="_abstract"]
@@ -9,9 +9,12 @@ If you need to remove {ServerlessProductName} from your cluster, you can do so b
 
 After uninstalling the {ServerlessProductName}, you can remove the Operator and API custom resource definitions (CRDs) that remain on the cluster.
 
-The steps for fully removing {ServerlessProductName} are detailed in the following procedures:
+To fully remove {ServerlessProductName}, complete the following procedures:
 
-* xref:../removing/uninstalling-knative-eventing.adoc#uninstalling-knative-eventing[Uninstalling Knative Eventing].
-* xref:../removing/uninstalling-knative-serving.adoc#uninstalling-knative-serving[Uninstalling Knative Serving].
-* xref:../removing/removing-serverless-operator.adoc#removing-serverless-operator[Removing the {ServerlessOperatorName}].
-* xref:../removing/deleting-serverless-crds.adoc#deleting-serverless-crds[Deleting {ServerlessProductName} custom resource definitions].
+* xref:../removing/uninstalling-knative-eventing.adoc#uninstalling-knative-eventing[Uninstalling Knative Eventing]
+
+* xref:../removing/uninstalling-knative-serving.adoc#uninstalling-knative-serving[Uninstalling Knative Serving]
+
+* xref:../removing/removing-serverless-operator.adoc#removing-serverless-operator[Removing the {ServerlessOperatorName}]
+
+* xref:../removing/deleting-serverless-crds.adoc#deleting-serverless-crds[Deleting {ServerlessProductName} custom resource definitions]

--- a/removing/removing-serverless-operator.adoc
+++ b/removing/removing-serverless-operator.adoc
@@ -1,11 +1,14 @@
 :_mod-docs-content-type: ASSEMBLY
-include::_attributes/common-attributes.adoc[]
 [id="removing-serverless-operator"]
 = Removing the {ServerlessOperatorName}
+include::_attributes/common-attributes.adoc[]
 :context: removing-serverless-operator
 
 [role="_abstract"]
 After you have removed Knative Serving and Knative Eventing, you can remove the {ServerlessOperatorName}. You can do this by using the web console or the `oc` CLI.
+
+[role="_additional-resources"]
+== Additional resources
 
 * link:https://docs.openshift.com/container-platform/latest/operators/admin/olm-deleting-operators-from-cluster.html#olm-deleting-operators-from-a-cluster-using-web-console_olm-deleting-operators-from-a-cluster[Deleting Operators from a cluster using the web console]
 

--- a/removing/uninstalling-knative-eventing.adoc
+++ b/removing/uninstalling-knative-eventing.adoc
@@ -1,12 +1,11 @@
 :_mod-docs-content-type: ASSEMBLY
-include::_attributes/common-attributes.adoc[]
 [id="uninstalling-knative-eventing"]
 = Uninstalling {ServerlessProductName} Knative Eventing
+include::_attributes/common-attributes.adoc[]
 :context: uninstalling-knative-eventing
 
 [role="_abstract"]
 Before you can remove the {ServerlessOperatorName}, you must remove Knative Eventing. To uninstall Knative Eventing, you must remove the `KnativeEventing` custom resource (CR) and delete the `knative-eventing` namespace.
 
-// Uninstalling Knative Eventing
 include::modules/serverless-uninstalling-knative-eventing.adoc[leveloffset=+1]
 

--- a/removing/uninstalling-knative-serving.adoc
+++ b/removing/uninstalling-knative-serving.adoc
@@ -1,11 +1,10 @@
 :_mod-docs-content-type: ASSEMBLY
-include::_attributes/common-attributes.adoc[]
 [id="uninstalling-knative-serving"]
 = Uninstalling {ServerlessProductName} Knative Serving
+include::_attributes/common-attributes.adoc[]
 :context: uninstalling-knative-serving
 
 [role="_abstract"]
 Before you can remove the {ServerlessOperatorName}, you must remove Knative Serving. To uninstall Knative Serving, you must remove the `KnativeServing` custom resource (CR) and delete the `knative-serving` namespace.
 
-// Uninstalling Knative Serving
 include::modules/serverless-uninstalling-knative-serving.adoc[leveloffset=+1]


### PR DESCRIPTION
**You can cherry-pick for the following branches:** 
- `serverless-docs-1.37`
- `serverless-docs-1.38`
- `serverless-docs-1.36`

**Note for the peer & merge reviewer:** 
- This PR updates the only "Installing OpenShift Serverless" & "Removing OpenShift Serverless" sections to prepare them for Phase 0 DITA migration.
- No other CQA changes, error types, or content refinements are included. 

**Changes:** 
This PR prepares the "About OpenShift Serverless" section for Phase 0 DITA migration by applying Vale (AsciiDoc DITA) rules and cleaning up the existing content.

**Tracking JIRA:** https://redhat.atlassian.net/browse/SRVCOM-4305

**Reviews:**
- [ ] Peer has approved this change