### PR TITLE
OSDOCS-16842-18-cqa:  CQA for NOP-1 AWS Load Balancer Operator

### DIFF
--- a/modules/aws-installing-an-aws-load-balancer-operator.adoc
+++ b/modules/aws-installing-an-aws-load-balancer-operator.adoc
@@ -5,12 +5,13 @@
 :_mod-docs-content-type: PROCEDURE
 [id="aws-installing-an-aws-load-balancer-operator_{context}"]
 = Installing an AWS Load Balancer Operator
-You can install an AWS Load Balancer Operator and an AWS Load Balancer Controller if you meet certain requirements.
+
+[role="_abstract"]
+To install the AWS Load Balancer Operator and the AWS Load Balancer Controller, ensure that your environment meets the necessary requirements. Meeting these prerequisites is essential for the successful deployment of the Operator and controller.
 
 .Prerequisites
 
 * You have an existing {product-title} (ROSA) cluster with bring-your-own-VPC (BYO-VPC) configuration across multiple Availability Zones (AZs) installed in Hosted Control Plane (HCP) mode.
-
 * You have access to the cluster as a user with the `dedicated-admin` role.
 * You have access to modify the VPC and subnets of the created ROSA cluster.
 * You have installed the ROSA CLI (`rosa`).
@@ -44,9 +45,12 @@ $ oc get infrastructure cluster -o json | jq -r '.status.infrastructureName'
 +
 [source,terminal,subs="quotes,verbatim"]
 ----
-$ rosa describe cluster --cluster=<cluster_name> | grep -i OIDC <1>
+$ rosa describe cluster --cluster=<cluster_name> | grep -i OIDC
 ----
-<1> An OIDC DNS example is `oidc.op1.openshiftapps.com/28q7fsn54m2jjts3kd556aij4mu9omah`.
++
+where:
++
+`<cluster_name>`:: Specifies an OIDC DNS example is `oidc.op1.openshiftapps.com/28q7fsn54m2jjts3kd556aij4mu9omah`.
 +
 or
 +
@@ -77,9 +81,12 @@ $ IDP='{Cluster_OIDC_Endpoint}'
 +
 [source,terminal,subs="quotes,verbatim"]
 ----
-$ IDP_ARN="arn:aws:iam::{AWS_AccountNo}:oidc-provider/${IDP}" <1>
+$ IDP_ARN="arn:aws:iam::{AWS_AccountNo}:oidc-provider/${IDP}"
 ----
-<1> Replace `{AWS_AccountNo}` with your AWS account number and `{Cluster_OIDC_Endpoint}` with the OIDC DNS identified earlier in this procedure.
++
+where:
++
+`AWS_AccountNo`:: Replace `{AWS_AccountNo}` with your AWS account number and `{Cluster_OIDC_Endpoint}` with the OIDC DNS identified earlier in this procedure.
 +
 .. Verify that the trsut policy was assigned to the AWS IAM role.
 +
@@ -144,7 +151,7 @@ PRINCIPAL arn:aws:iam:<aws_account_number>:oidc-provider/<oidc_provider_id>
 Where `arn` of the AWS IAM role was created for the AWS Load Balancer Operator, such as `arn:aws:iam::777777777777:role/albo-operator`.
 ====
 +
-.. Attach the operator's permission policy to the role:
+.. Attach the Operator's permission policy to the role:
 +
 [source,terminal]
 ----
@@ -272,10 +279,13 @@ spec:
   config:
     env:
     - name: ROLEARN
-      value: "<operator_role_arn>" <1>
+      value: "<operator_role_arn>"
 EOF
 ----
-<1> Specifies the ARN role for the {aws-short} Load Balancer Operator. The `CredentialsRequest` object uses this ARN role to provision the {aws-short} credentials. An example of `<operator_role_arn>` is `arn:aws:iam::<aws_account_number>:role/albo-operator`.
++
+where:
++
+`<operator_role_arn>`:: Specifies the ARN role for the {aws-short} Load Balancer Operator. The `CredentialsRequest` object uses this ARN role to provision the {aws-short} credentials. An example of `<operator_role_arn>` is `arn:aws:iam::<aws_account_number>:role/albo-operator`.
 
 . Create the AWS Load Balancer Controller:
 +

--- a/modules/aws-uninstalling-an-aws-load-balancer-operator.adoc
+++ b/modules/aws-uninstalling-an-aws-load-balancer-operator.adoc
@@ -5,9 +5,12 @@
 :_mod-docs-content-type: PROCEDURE
 [id="aws-uninstalling-an-aws-load-balancer-operator_{context}"]
 = Uninstalling an AWS Load Balancer Operator
-To uninstall an AWS Load Balancer Operator and perform an overall cleanup of the associated resources, perform the following procedure.
+
+[role="_abstract"]
+To remove the AWS Load Balancer Operator and clean up associated resources, uninstall the operator from the cluster. This ensures a complete cleanup of the environment and prevents unused resources from persisting.
 
 .Procedure
+
 . Clean up the sample application by deleting the Load Balancers created and managed by the ALBO. For more information about deleting Load Balancers, see link:https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-delete.html[Delete an Application Load Balancer].
 
 . Clean up the AWS VPC tags by removing the VPC tags that were added to the subnets for discovering subnets and for creating Application Load Balancers (ALBs). For more information, see link:https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Tags.html#tag-basics[Tag basics].


### PR DESCRIPTION
modules/aws-installing-an-aws-load-balancer-operator.adoc and modules/aws-uninstalling-an-aws-load-balancer-operator.adoc already existed (pre-CQA) but are not included in any assembly. I've CQA'd it anyway to align with other versions.

Version(s):
4.18

Issue:
[OSDOCS-18673](https://redhat.atlassian.net/browse/OSDOCS-18673)

Link to docs preview:


