### PR TITLE
MIG-1872: Add an Enhancement MTC 1.8.13

### DIFF
--- a/modules/migration-mtc-release-notes-1-8-13.adoc
+++ b/modules/migration-mtc-release-notes-1-8-13.adoc
@@ -9,3 +9,12 @@
 
 [role="_abstract"]
 {mtc-first} 1.8.13 is a Container Grade Only (CGO) release, which is released to refresh the health grades of the containers. No code was changed in the product itself compared to that of {mtc-short} 1.8.12.
+
+
+[id="enhancements-1-8-13_{context}"]
+== Enhancements
+
+{mtc-short} 1.8.13 restricts cluster upgrades beyond {product-title} 4.20::
+With this update, {mtc-short} prevents {product-title} clusters from upgrading to version 4.21 and later to maintain compatibility and stability. To upgrade your cluster beyond version 4.20, uninstall {mtc-short} first. For instructions on how to uninstall {mtc-short}, see xref:../migration_toolkit_for_containers/installing-mtc#migration-uninstalling-mtc-clean-up_installing-mtc[Uninstalling {mtc-short} and deleting resources].
++
+link:https://redhat.atlassian.net/browse/MIG-1872[(MIG-1872)]


### PR DESCRIPTION
Version(s):
OCP 4.14-4.20

Issue:
[MIG-1872](https://redhat.atlassian.net/browse/MIG-1872)

Link to docs preview:
- [Migration Toolkit for Containers 1.8.13 release notes](https://108924--ocpdocs-pr.netlify.app/openshift-enterprise/latest/migration_toolkit_for_containers/release_notes/mtc-release-notes.html#migration-mtc-release-notes-1-8-13_mtc-release-notes)

QE review:
- [x] QE has approved this change.

Changes:
- Update the MTC 1.8.13 Release Notes to mention that the cluster upgrade path to OCP 4.21+ is restricted by OLM.