### PR TITLE
OSSM-12962 CQA on all the modules in "Uninstall" chapter

### DIFF
--- a/modules/ossm-uninstalling-delete-istio-crds.adoc
+++ b/modules/ossm-uninstalling-delete-istio-crds.adoc
@@ -8,12 +8,12 @@
 
 [role="_abstract"]
 
-Deleting Istio custom resource definitions (CRDs) are optional.
+Deleting {istio} custom resource definitions (CRDs) are optional.
 
 .Procedure
 
-. To delete the Istio CRDs, run the following command:
-
+* To delete the {istio} CRDs, run the following command:
++
 [source,terminal]
 ----
 $ oc get crds -oname | grep -e istio.io -e sailoperator.io | xargs kubectl delete

--- a/modules/ossm-uninstalling-service-mesh-operator-control-plane-cli.adoc
+++ b/modules/ossm-uninstalling-service-mesh-operator-control-plane-cli.adoc
@@ -8,23 +8,23 @@
 
 [role="_abstract"]
 
-Uninstalling {SMProductName} Operator 3 and the {Istio} control plane from an existing {ocp-product-title} instance requires removing the following:
+Uninstalling {SMProductName} Operator 3 and the {istio} control plane from an existing {ocp-product-title} instance requires removing the following:
 
-* `Istio` resource
+* `{istio}` resource
 * `IstioCNI` resource
 * {SMProductName} Operator 3
 * `istio-system` project
 * `istio-cni` project
 
-Optionally, you can remove the Istio custom resource definitions (CRDs).
+Optionally, you can remove the {istio} custom resource definitions (CRDs).
 
 You can uninstall the {SMProductName} Operator 3 either by using the {ocp-product-title} command line interface (CLI).
 
 .Procedure
 
-. Delete the `Istio` resource:
+. Delete the `{istio}` resource:
 
-.. Retrieve the `Istio` resource name by running the following command:
+.. Retrieve the `{istio}` resource name by running the following command:
 +
 [source,terminal]
 ----
@@ -79,7 +79,8 @@ $ oc delete ns istio-cni
 $ oc delete subscription servicemeshoperator3 -n openshift-operators
 ----
 +
-.Example output
+You will get an output similar to the following example:
++
 [source,terminal]
 ----
 output: subscription.operators.coreos.com "servicemeshoperator3" deleted
@@ -92,7 +93,8 @@ output: subscription.operators.coreos.com "servicemeshoperator3" deleted
 $ oc get clusterserviceversion -n openshift-operators | grep servicemeshoperator3 | awk '{print $1}'
 ----
 +
-.Example output
+You will get an output similar to the following example:
++
 [source,terminal]
 ----
 output: currentCSV: servicemeshoperator3.v3.0.0
@@ -105,7 +107,7 @@ output: currentCSV: servicemeshoperator3.v3.0.0
 $ oc delete clusterserviceversion servicemeshoperator3.v3.0.0 -n openshift-operators
 ----
 +
-.Example output
+You will get an output similar to the following example:
 +
 [source,terminal]
 ----

--- a/modules/ossm-uninstalling-service-mesh-operator-control-plane-web-console.adoc
+++ b/modules/ossm-uninstalling-service-mesh-operator-control-plane-web-console.adoc
@@ -16,41 +16,64 @@ Uninstalling {SMProductName} Operator 3 and the {Istio} control plane from an ex
 * `istio-system` project
 * `istio-cni` project
 
-Optionally, you can remove the Istio custom resource definitions (CRDs).
+Optionally, you can remove the {istio} custom resource definitions (CRDs).
 
 You can uninstall the {SMProductName} Operator 3 either by using the {ocp-product-title} web console.
 
 .Procedure
 
-. Delete the `Istio` resource:
+. Delete the `{istio}` resource:
+
 .. In the {ocp-short-name} web console, click *Operators* -> *Installed Operators*.
+
 .. Click *Istio* in the *Provided APIs* column.
-.. Click the *Options* menu -> *Delete Istio*.
+
+.. Click the *Options* menu -> *Delete {istio}*.
+
 .. At the prompt to confirm the action, click *Delete*.
 
 . Delete the `IstioCNI` resource:
+
 .. In the {ocp-short-name} web console, click *Operators* -> *Installed Operators*.
+
 .. Click *IstioCNI* in the *Provided APIs* column.
+
 .. Click the *Options* menu -> *Delete IstioCNI*.
+
 .. At the prompt to confirm the action, click *Delete*.
 
 . Uninstall {SMProductName} 3 Operator:
+
 .. In the {ocp-short-name} web console, click *Operators* -> *Installed Operators*.
+
 .. Locate {SMProductName} 3 Operator.
+
 .. Click the *Options* menu -> *Uninstall Operator*.
-.. At the prompt to confirm the action, select the *Delete all operand instances for this operator* checkbox. 
+
+.. At the prompt to confirm the action, select the *Delete all operand instances for this operator* checkbox.
+
 .. Click *Uninstall*.
 
 . Delete the `istio-system` project:
+
 .. In the {ocp-short-name} web console, click  *Home* -> *Projects*.
+
 .. Locate the name of the `istio-system` project.
+
 .. Click the *Options* menu -> *Delete Project*.
+
 .. At the prompt to confirm the action, enter the name of the project.
+
 .. Click *Delete*.
 
 . Delete the `istio-cni` project:
+
 .. In the {ocp-short-name} web console, click  *Home* -> *Projects*.
+
 .. Locate the name of the `istio-cni` project.
+
 .. Click the *Options* menu -> *Delete Project*.
+
 .. At the prompt to confirm the action, enter the name of the project.
+
 .. Click *Delete*.

--- a/uninstalling/ossm-uninstalling-openshift-service-mesh.adoc
+++ b/uninstalling/ossm-uninstalling-openshift-service-mesh.adoc
@@ -1,4 +1,4 @@
-:_content-type: ASSEMBLY
+:_mod-docs_content-type: ASSEMBLY
 [id="ossm-uninstalling-openshift-service-mesh"]
 = Uninstalling OpenShift Service Mesh
 include::_attributes/common-attributes.adoc[]


### PR DESCRIPTION
Change type: Doc update; CQA on all the modules in "Uninstall" chapter

Doc JIRA: https://issues.redhat.com/browse/OSSM-12962

Fix Version: [service-mesh-docs-main](https://github.com/openshift/openshift-docs/tree/service-mesh-docs-main)

NOTE: Can be automatically CP'ed to the following branches:

[service-mesh-docs-3.0](https://github.com/openshift/openshift-docs/tree/service-mesh-docs-3.0)
[service-mesh-docs-3.1](https://github.com/openshift/openshift-docs/tree/service-mesh-docs-3.1)
[service-mesh-docs-3.2](https://github.com/openshift/openshift-docs/tree/service-mesh-docs-3.2)
[service-mesh-docs-3.3](https://github.com/openshift/openshift-docs/tree/service-mesh-docs-3.3)

Doc Preview:

Peer Review: @kaldesai 