### PR TITLE
RHDEVDOCS-7087: CQA 2.0 fixes for Customizing permissions by creating user-defined cluster roles for cluster-scoped instances

### DIFF
--- a/declarative_clusterconfig/customizing-permissions-by-creating-user-defined-cluster-roles-for-cluster-scoped-instances.adoc
+++ b/declarative_clusterconfig/customizing-permissions-by-creating-user-defined-cluster-roles-for-cluster-scoped-instances.adoc
@@ -7,18 +7,18 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 [role="_abstract"]
-For the default cluster-scoped instance, the {gitops-title} Operator grants additional permissions for managing certain cluster-scoped resources. Consequently, as a cluster administrator, when you deploy an Argo CD as a cluster-scoped instance, the Operator creates additional cluster roles and cluster role bindings for the {gitops-shortname} control plane components. These cluster roles and cluster role bindings provide the additional permissions that Argo CD requires to operate at the cluster level. 
+For the default cluster-scoped instance, the {gitops-title} Operator grants additional permissions for managing certain cluster-scoped resources. Consequently, as a cluster administrator, when you deploy Argo CD as a cluster-scoped instance, the Operator creates additional cluster roles and cluster role bindings for the {gitops-shortname} control plane components. These cluster roles and cluster role bindings provide the additional permissions that Argo CD requires to operate at the cluster level. 
 
 If you do not want the cluster-scoped instance to have all of the Operator-given permissions and choose to add or remove permissions to cluster-wide resources, you must first disable the creation of the default cluster roles for the cluster-scoped instance. Then, you can customize permissions for the following cluster-scoped instances:
 
-* Default ArgoCD instance (default cluster-scoped instance)
+* Default Argo CD instance (default cluster-scoped instance)
 * User-defined cluster-scoped Argo CD instance
 
-This guide provides instructions with examples to help you create a user-defined cluster-scoped Argo CD instance, deploy an Argo CD application in your defined namespace that contains custom configurations for your cluster, disable the creation of the default cluster roles for the cluster-scoped instance, and customize permissions for user-defined cluster-scoped instances by creating new cluster roles and cluster role bindings for the {gitops-shortname} control plane components. 
+This guide provides instructions with examples to help you create a user-defined cluster-scoped Argo CD instance and deploy an Argo CD application in your defined namespace that contains custom configurations for your cluster. You will learn how to disable the creation of the default cluster roles for the cluster-scoped instance and customize permissions for user-defined cluster-scoped instances by creating new cluster roles and cluster role bindings for the {gitops-shortname} control plane components.
 
 [NOTE]
 ====
-As a developer, if you are creating an Argo CD application and deploying cluster-wide resources, ensure that your cluster administrator grants the necessary permissions to them.
+As a developer, if you are creating an Argo CD application and deploying cluster-wide resources, ensure that your cluster administrator grants the necessary permissions.
 ====
 
 Otherwise, after the Argo CD reconciliation, you will see an authentication error message in the application's `Status` field similar to the following example:
@@ -34,10 +34,10 @@ persistentvolumes is forbidden: User "system:serviceaccount:gitops-demo:argocd-a
 [id="prerequisites_{context}"]
 == Prerequisites
 
-* You have installed {gitops-title} 1.13.0  or a later version on your {OCP} cluster.
+* You have installed {gitops-title} 1.13.0 or a later version on your {OCP} cluster.
 * You have installed the OpenShift CLI (`oc`).
 * You have installed the {gitops-title} `argocd` CLI.
-* You have installed a xref:../declarative_clusterconfig/configuring-an-openshift-cluster-by-deploying-an-application-with-cluster-configurations.adoc#using-argo-cd-instance-to-manage-cluster-scoped-resources_configuring-an-openshift-cluster-by-deploying-an-application-with-cluster-configurations[cluster-scoped Argo CD instance] in your defined namespace. For example, `spring-petclinic` namespace. 
+* You have installed a xref:../declarative_clusterconfig/configuring-an-openshift-cluster-by-deploying-an-application-with-cluster-configurations.adoc#using-argo-cd-instance-to-manage-cluster-scoped-resources_configuring-an-openshift-cluster-by-deploying-an-application-with-cluster-configurations[cluster-scoped Argo CD instance] in your defined namespace, for example, the `spring-petclinic` namespace. 
 * You have validated that the user-defined cluster-scoped instance is configured with the cluster roles and cluster role bindings for the following components:
 +
 ** Argo CD Application Controller
@@ -52,9 +52,9 @@ The `cluster-configs` Argo CD application must be managed by a user-defined clus
 
 * The `selfHeal` field value set to `true`
 * The `syncPolicy` field value set to `automated`
-* The  *Label* field set to the `app.kubernetes.io/part-of=argocd` value
-* The  *Label* field set to the `argocd.argoproj.io/managed-by=<user_defined_namespace>` value so that the Argo CD instance in your defined namespace can manage your namespace
-* The  *Label* field set to the `app.kubernetes.io/name=<user_defined_argocd_instance>` value
+* The *Label* field set to the `app.kubernetes.io/part-of=argocd` value
+* The *Label* field set to the `argocd.argoproj.io/managed-by=<user_defined_namespace>` value so that the Argo CD instance in your defined namespace can manage your namespace
+* The *Label* field set to the `app.kubernetes.io/name=<user_defined_argocd_instance>` value
 ====
 
 // Disabling the creation of the default cluster-scoped instance

--- a/modules/gitops-customizing-permissions-for-cluster-scoped-instances.adoc
+++ b/modules/gitops-customizing-permissions-for-cluster-scoped-instances.adoc
@@ -39,8 +39,8 @@ rules:
     apiGroups:
       - ''
     resources:
-      - namespaces 
-      - persistentvolumes 
+      - namespaces
+      - persistentvolumes
 ----
 --
 +
@@ -48,16 +48,16 @@ rules:
 where:
 
 `metadata.name`:: Specifies the name of the cluster role according to the <argocd_name>-<argocd_namespace>-<control_plane_component> naming convention.
-`metadata.rules`:: Specifies the resources to which you want to grant permissions at the cluster level.
+`rules`:: Specifies the resources to which you want to grant permissions at the cluster level.
 --
 . Click *Create* to add the cluster role.
 
-. Find the service account used by the control plane component you are customizing permissions for, by performing the following steps:
+. Find the service account used by the control plane component you are customizing permissions for by performing the following steps:
 +
 .. Go to *Workloads* -> *Pods*.
 .. From the *Project* list, select the project where the user-defined cluster-scoped instance is installed.
 .. Click the pod of the control plane component and go to the *YAML* tab.
-.. Find the `spec.ServiceAccount` field and note the service account.
+.. Find the value of the `spec.ServiceAccountName` field.
 
 . Go to *User Management* -> *RoleBindings* -> *Create binding*.
 
@@ -69,7 +69,7 @@ where:
 
 . Select the newly created cluster role from the drop-down list for *Role name*.
 
-. Select the *Subject* as *ServiceAccount* and the provide the *Subject namespace* and *name*.
+. Select the *Subject* as *ServiceAccount* and then provide the *Subject namespace* and *name*.
 .. *Subject namespace*: `spring-petclinic`
 .. *Subject name*: `example-argocd-application-controller`
 +
@@ -80,7 +80,7 @@ For *Subject name*, ensure that the value you configure is the same as the value
 
 . Click *Create*. 
 +
-You have created the required permissions for the control plane component's service account and namespace. The YAML file for the `ClusterRoleBinding` object looks similar to the following example:
+You have created the required permissions for the control plane component's service account in the specified namespace.. The YAML file for the `ClusterRoleBinding` object looks similar to the following example:
 +
 --
 *Example YAML file for a cluster role binding:*

--- a/modules/gitops-disabling-the-creation-of-the-default-cluster-roles-for-the-cluster-scoped-instance.adoc
+++ b/modules/gitops-disabling-the-creation-of-the-default-cluster-roles-for-the-cluster-scoped-instance.adoc
@@ -65,4 +65,4 @@ No resources found
 ----
 --
 +
-The default cluster roles and cluster role bindings for the cluster-scoped instance are not created. As a cluster administrator, you can now create and customize permissions for cluster-scoped instances by creating new cluster roles and cluster role bindings for the {gitops-shortname} control plane components.
+The default cluster roles and cluster role bindings for the cluster-scoped instance are deleted. As a cluster administrator, you can now create and customize permissions for cluster-scoped instances by creating new cluster roles and cluster role bindings for the {gitops-shortname} control plane components.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

gitops-docs-1.19, gitops-docs-1.20

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

https://redhat.atlassian.net/browse/RHDEVDOCS-7087

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

[Customizing permissions by creating user-defined cluster roles for cluster-scoped instances](https://108935--ocpdocs-pr.netlify.app/openshift-gitops/latest/declarative_clusterconfig/customizing-permissions-by-creating-user-defined-cluster-roles-for-cluster-scoped-instances.html)

Peer review:
- [x] Peer has approved this change.
<!--- Peer approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Peer reviewer:

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
