### PR TITLE
RHDEVDOCS-7088: CQA 2.0 fixes for Customizing permissions by creating aggregated cluster roles

### DIFF
--- a/declarative_clusterconfig/customizing-permissions-by-creating-aggregated-cluster-roles.adoc
+++ b/declarative_clusterconfig/customizing-permissions-by-creating-aggregated-cluster-roles.adoc
@@ -45,6 +45,7 @@ include::modules/gitops-creating-aggregated-cluster-roles.adoc[leveloffset=+1]
 
 // Enabling the creation of aggregated cluster roles
 include::modules/gitops-enabling-the-creation-of-aggregated-cluster-roles.adoc[leveloffset=+1]
+
 [role="_additional-resources"]
 .Additional resources
 * xref:../argocd_instance/setting-up-argocd-instance.adoc#setting-up-argocd-instance[Installing a user-defined Argo CD instance]

--- a/modules/gitops-creating-user-defined-cluster-roles-and-configuring-user-defined-permissions-for-application-controller.adoc
+++ b/modules/gitops-creating-user-defined-cluster-roles-and-configuring-user-defined-permissions-for-application-controller.adoc
@@ -70,7 +70,7 @@ rules:
 where:
 
 `metadata.name`:: Specifies the name of the user-defined cluster role.
-`metadata.labels.argocd/aggregate-to-admin`:: Specifies that the cluster role is aggregated into the Argo CD application controller admin cluster role, allowing the permissions defined in this role to be included automatically.
+`metadata.labels.argocd/aggregate-to-admin`:: Specifies that the cluster role is aggregated into the Argo CD Application Controller admin cluster role, allowing the permissions defined in this role to be included automatically.
 `rules`:: Specifies the list of permissions granted by the cluster role, including allowed API groups, resources, and verbs.
 --
 +

--- a/modules/gitops-enabling-the-creation-of-aggregated-cluster-roles.adoc
+++ b/modules/gitops-enabling-the-creation-of-aggregated-cluster-roles.adoc
@@ -33,7 +33,7 @@ spec:
 where:
 
 `metadata.name`:: Specifies the name of the cluster-scoped instance.
-`metadata.namespace`:: Specifies the namespace where you want to run the cluster-scoped instance.
+`metadata.namespace`:: Specifies the namespace where Argo CD is installed.
 `spec.aggregatedClusterRoles`:: Specifies the value of the cluster roles to enable the creation of aggregated cluster roles. If you do not want to enable the creation of aggregated cluster roles, either do not include this line or set the value to `false`.
 --
 +
@@ -138,7 +138,7 @@ The cluster role bindings for the `view` and `admin` cluster roles are not creat
 Alternatively, you can use the {OCP} web console to verify from the *Administrator* perspective. You can go to *User Management* -> *Roles* and *User Management* -> *RoleBindings*, respectively. You can search for the cluster roles and cluster role bindings that have the `app.kubernetes.io/part-of:argocd` label.
 ====
 
-. Verify that the aggregated cluster role is created by checking the permissions of outputs of the roles created by running the following command:
+. Verify that the aggregated cluster role is created by running the following command to check the role permissions:
 +
 --
 [source,terminal]
@@ -170,7 +170,7 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: spring-petclinic
     app.kubernetes.io/name: example
-    app.kubernetes.io/part-of: argocd 
+    app.kubernetes.io/part-of: argocd
   name: example-spring-petclinic-argocd-application-controller
   resourceVersion: "78640"
   uid: aeeb2ef5-b531-4fe3-a61a-b5ad8dd8ca6e
@@ -187,7 +187,7 @@ rules: []
 where:
 
 `metadata.name`:: Specifies the name of the aggregated cluster role.
-`aggregationRule.clusterRoleSelectors`:: Specifies the predefined list of labels indicates that the aggregated cluster role can inherit permissions from the other user-defined cluster roles.
+`aggregationRule.clusterRoleSelectors`:: Specifies the predefined list of labels. This indicates that the aggregated cluster role can inherit permissions from the other user-defined cluster roles.
 `rules`:: Specifies the predefined permissions. However, when the Operator immediately creates a `<argocd_name>-<argocd_namespace>-argocd-application-controller-view` cluster role, the corresponding predefined `view` permissions are added into the aggregated cluster role.
 --
 +
@@ -273,7 +273,7 @@ where:
 
 `metadata.labels`:: Specifies the labels to match the predefined list of an existing aggregated cluster role.
 `metadata.name`:: Specifies the name of the `admin` cluster role.
-`aggregationRule.clusterRoleSelectors`:: Specifies the predefined list of labels indicates that the existing `<argocd_name>-<argocd_namespace>-argocd-application-controller-admin` cluster role can inherit permissions from the other user-defined cluster roles.
+`aggregationRule.clusterRoleSelectors`:: Specifies the predefined list of labels. This indicates that the existing `<argocd_name>-<argocd_namespace>-argocd-application-controller-admin` cluster role can inherit permissions from the other user-defined cluster roles.
 `rules`:: Specifies that no permissions are defined yet in one or more user-defined cluster roles.
 --
 +


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

gitops-docs-1.19, gitops-docs-1.20

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

https://redhat.atlassian.net/browse/RHDEVDOCS-7088

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

[Customizing permissions by creating aggregated cluster roles](https://108936--ocpdocs-pr.netlify.app/openshift-gitops/latest/declarative_clusterconfig/customizing-permissions-by-creating-aggregated-cluster-roles.html)

Peer review:
- [x] Peer has approved this change.
<!--- Peer approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Peer reviewer:

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
