### PR TITLE
Removes in-line xref to match 4.17+ versions

### DIFF
--- a/networking/configuring-cluster-network-range.adoc
+++ b/networking/configuring-cluster-network-range.adoc
@@ -11,8 +11,6 @@ To expand the cluster network range in {product-title} to support more nodes and
 
 For example, if you deployed a cluster and specified `10.128.0.0/19` as the cluster network range and a host prefix of `23`, you are limited to 16 nodes. You can expand that to 510 nodes by changing the CIDR mask on a cluster to `/14`.
 
-When expanding the cluster network address range, your cluster must use the xref:../networking/ovn_kubernetes_network_provider/about-ovn-kubernetes.adoc#about-ovn-kubernetes[OVN-Kubernetes network plugin]. Other network plugins are not supported.
-
 The following limitations apply when modifying the cluster network IP address range:
 
 - The CIDR mask size specified must always be smaller than the currently configured CIDR mask size, because you can only increase IP space by adding more nodes to an installed cluster


### PR DESCRIPTION
I did not remove this line in version 4.16, but removed it in 4.17+. This is part of a cherry-pick remediation for Networking docs. The xref was moved to an Additional Resources section below and the introduction/short abstract calls out the required information now. 

Version(s):
4.16

Issue:
https://redhat.atlassian.net/browse/OSDOCS-18639

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Original cherry pick: https://github.com/openshift/openshift-docs/pull/105372
