### PR TITLE
OCPBUGS-74540: Code fix

### DIFF
--- a/modules/kmm-installing-older-versions.adoc
+++ b/modules/kmm-installing-older-versions.adoc
@@ -106,12 +106,11 @@ metadata:
   name: kernel-module-management
   namespace: openshift-kmm
 spec:
-  channel: release-1.0
+  channel: stable
   installPlanApproval: Automatic
   name: kernel-module-management
   source: redhat-operators
   sourceNamespace: openshift-marketplace
-  startingCSV: kernel-module-management.v1.0.0
 ----
 
 .. Create the subscription object by running the following command:

--- a/modules/kmm-installing-using-cli.adoc
+++ b/modules/kmm-installing-using-cli.adoc
@@ -49,12 +49,11 @@ metadata:
   name: kernel-module-management
   namespace: openshift-kmm
 spec:
-  channel: release-1.0
+  channel: stable
   installPlanApproval: Automatic
   name: kernel-module-management
   source: redhat-operators
   sourceNamespace: openshift-marketplace
-  startingCSV: kernel-module-management.v1.0.0
 ----
 
 .. Create the subscription object by running the following command:


### PR DESCRIPTION
Wrong KMMO subs example in 4.20 docs

Jira: https://redhat.atlassian.net/browse/OCPBUGS-74540

Versions: 4.20+

Preview: https://108952--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hardware_enablement/kmm-kernel-module-management.html

Dev: @ybettan 
QE: @cdvultur 