### PR TITLE
OSDOCS-17077: Updates CQA pt 4

### DIFF
--- a/modules/scheduling-virtual-hardware-update-on-vsphere.adoc
+++ b/modules/scheduling-virtual-hardware-update-on-vsphere.adoc
@@ -4,8 +4,9 @@
 
 :_mod-docs-content-type: CONCEPT
 [id="scheduling-virtual-hardware-update-on-vsphere_{context}"]
-= Scheduling an update for virtual hardware on vSphere
+= Scheduled updates for virtual hardware on vSphere
 
-Virtual hardware updates can be scheduled to occur when a virtual machine is powered on or rebooted. You can schedule your virtual hardware updates exclusively in vCenter by following link:https://docs.vmware.com/en/VMware-vSphere/7.0/com.vmware.vsphere.vm_admin.doc/GUID-96C06236-C271-4CFE-857E-22D1FDEECC95.html[Schedule a Compatibility Upgrade for a Virtual Machine] in the VMware documentation.
+[role="_abstract"]
+Virtual hardware updates can be scheduled to occur when a virtual machine is powered on or rebooted. You can schedule your virtual hardware updates exclusively in vCenter by following link:https://docs.vmware.com/en/VMware-vSphere/7.0/com.vmware.vsphere.vm_admin.doc/GUID-96C06236-C271-4CFE-857E-22D1FDEECC95.html[Schedule a Compatibility Upgrade for a Virtual Machine] (VMware vSphere documentation).
 
 When scheduling an update prior to performing an update of {product-title}, the virtual hardware update occurs when the nodes are rebooted during the course of the {product-title} update.

--- a/modules/update-vsphere-virtual-hardware-on-compute-nodes.adoc
+++ b/modules/update-vsphere-virtual-hardware-on-compute-nodes.adoc
@@ -6,6 +6,9 @@
 [id="update-vsphere-virtual-hardware-on-compute-nodes_{context}"]
 = Updating the virtual hardware for compute nodes on vSphere
 
+[role="_abstract"]
+You can update the virtual hardware for compute nodes on vSphere.
+
 To reduce the risk of downtime, it is recommended that compute nodes be updated serially.
 
 [NOTE]
@@ -20,7 +23,7 @@ Multiple compute nodes can be updated in parallel given workloads are tolerant o
 
 .Procedure
 
-. List the compute nodes in your cluster.
+. List the compute nodes in your cluster by running the following command:
 +
 [source,terminal]
 ----
@@ -38,36 +41,36 @@ compute-node-2    Ready    worker   30m   v1.34.2
 +
 Note the names of your compute nodes.
 
-. Mark the compute node as unschedulable:
+. Mark the compute node as unschedulable by running the following command:
 +
 [source,terminal]
 ----
 $ oc adm cordon <compute_node>
 ----
 
-. Evacuate the pods from the compute node. There are several ways to do this. For example, you can evacuate all or selected pods on a node:
+. Evacuate the pods from the compute node. There are several ways to do this. For example, you can evacuate all or selected pods on a node by running the following command:
 +
 [source,terminal]
 ----
 $ oc adm drain <compute_node> [--pod-selector=<pod_selector>]
 ----
 +
-See the "Evacuating pods on nodes" section for other options to evacuate pods from a node.
+See "Evacuating pods on nodes" for other options to evacuate pods from a node.
 
 . Shut down the virtual machine (VM) associated with the compute node. Do this in the vSphere client by right-clicking the VM and selecting *Power* -> *Shut Down Guest OS*. Do not shut down the VM using *Power Off* because it might not shut down safely.
 
-. Update the VM in the vSphere client. Follow link:https://docs.vmware.com/en/VMware-vSphere/7.0/com.vmware.vsphere.vm_admin.doc/GUID-60768C2F-72E1-42E0-8A17-CA76849F2950.html[Upgrade the Compatibility of a Virtual Machine Manually] in the VMware documentation for more information.
+. Update the VM in the vSphere client. Follow link:https://docs.vmware.com/en/VMware-vSphere/7.0/com.vmware.vsphere.vm_admin.doc/GUID-60768C2F-72E1-42E0-8A17-CA76849F2950.html[Upgrade the Compatibility of a Virtual Machine Manually] (VMware vSphere documentation).
 
 . Power on the VM associated with the compute node. Do this in the vSphere client by right-clicking the VM and selecting *Power On*.
 
-. Wait for the node to report as `Ready`:
+. Run the following command and wait for the node to report as `Ready`:
 +
 [source,terminal]
 ----
 $ oc wait --for=condition=Ready node/<compute_node>
 ----
 
-. Mark the compute node as schedulable again:
+. Mark the compute node as schedulable again by running the following command:
 +
 [source,terminal]
 ----

--- a/modules/update-vsphere-virtual-hardware-on-control-plane-nodes.adoc
+++ b/modules/update-vsphere-virtual-hardware-on-control-plane-nodes.adoc
@@ -6,6 +6,9 @@
 [id="update-vsphere-virtual-hardware-on-control-plane-nodes_{context}"]
 = Updating the virtual hardware for control plane nodes on vSphere
 
+[role="_abstract"]
+You can update the virtual hardware for control plane nodes on vSphere.
+
 To reduce the risk of downtime, it is recommended that control plane nodes be updated serially. This ensures that the Kubernetes API remains available and etcd retains quorum.
 
 .Prerequisites
@@ -15,7 +18,7 @@ To reduce the risk of downtime, it is recommended that control plane nodes be up
 
 .Procedure
 
-. List the control plane nodes in your cluster.
+. List the control plane nodes in your cluster by running the following command:
 +
 [source,terminal]
 ----
@@ -33,7 +36,7 @@ control-plane-node-2    Ready    master   75m   v1.34.2
 +
 Note the names of your control plane nodes.
 
-. Mark the control plane node as unschedulable.
+. Mark the control plane node as unschedulable by running the following command:
 +
 [source,terminal]
 ----
@@ -42,18 +45,18 @@ $ oc adm cordon <control_plane_node>
 
 . Shut down the virtual machine (VM) associated with the control plane node. Do this in the vSphere client by right-clicking the VM and selecting *Power* -> *Shut Down Guest OS*. Do not shut down the VM using *Power Off* because it might not shut down safely.
 
-. Update the VM in the vSphere client. Follow link:https://docs.vmware.com/en/VMware-vSphere/7.0/com.vmware.vsphere.vm_admin.doc/GUID-60768C2F-72E1-42E0-8A17-CA76849F2950.html[Upgrade the Compatibility of a Virtual Machine Manually] in the VMware documentation for more information.
+. Update the VM in the vSphere client. Follow link:https://docs.vmware.com/en/VMware-vSphere/7.0/com.vmware.vsphere.vm_admin.doc/GUID-60768C2F-72E1-42E0-8A17-CA76849F2950.html[Upgrade the Compatibility of a Virtual Machine Manually] (VMware vSphere documentation).
 
 . Power on the VM associated with the control plane node. Do this in the vSphere client by right-clicking the VM and selecting *Power On*.
 
-. Wait for the node to report as `Ready`:
+. Run the following command and wait for the node to report as `Ready`:
 +
 [source,terminal]
 ----
 $ oc wait --for=condition=Ready node/<control_plane_node>
 ----
 
-. Mark the control plane node as schedulable again:
+. Mark the control plane node as schedulable again by running the following command:
 +
 [source,terminal]
 ----

--- a/modules/update-vsphere-virtual-hardware-on-template.adoc
+++ b/modules/update-vsphere-virtual-hardware-on-template.adoc
@@ -6,6 +6,9 @@
 [id="update-vsphere-virtual-hardware-on-template_{context}"]
 = Updating the virtual hardware for template on vSphere
 
+[role="_abstract"]
+You can update the virtual hardware for templates on vSphere.
+
 .Prerequisites
 
 * You have cluster administrator permissions to execute the required permissions in the vCenter instance hosting your {product-title} cluster.
@@ -13,8 +16,7 @@
 
 .Procedure
 
-. If the RHCOS template is configured as a vSphere template follow link:https://docs.vmware.com/en/VMware-vSphere/7.0/com.vmware.vsphere.vm_admin.doc/GUID-D632CAC5-BA5E-4A1E-959B-382D9ACB1DD0_copy.html[Convert a Template to a Virtual Machine]
-in the VMware documentation prior to the next step.
+. If the RHCOS template is configured as a vSphere template, follow link:https://docs.vmware.com/en/VMware-vSphere/7.0/com.vmware.vsphere.vm_admin.doc/GUID-D632CAC5-BA5E-4A1E-959B-382D9ACB1DD0_copy.html[Convert a Template to a Virtual Machine] (VMware vSphere documentation).
 +
 [NOTE]
 ====
@@ -27,7 +29,7 @@ Once converted from a template, do not power on the virtual machine.
 ====
 If you modified the VM settings, those changes might reset after moving to a newer virtual hardware. Please review that all your configured settings are still in place after your upgrade before proceeding to the next step.
 ====
-. Convert the VM in the {vmw-short} client to a template by right-clicking on the VM and then selecting **Template -> Convert to Template**.  
+. Convert the VM in the {vmw-short} client to a template by right-clicking on the VM and then selecting **Template -> Convert to Template**.
 +
 [IMPORTANT]
 ====

--- a/modules/updating-control-plane-only-layered-products.adoc
+++ b/modules/updating-control-plane-only-layered-products.adoc
@@ -2,33 +2,28 @@
 //
 // * updating/updating_a_cluster/control-plane-only-update.adoc
 
-:_mod-docs-content-type: PROCEDURE
+:_mod-docs-content-type: CONCEPT
 [id="updating-control-plane-only-olm-operators_{context}"]
 = Control Plane Only updates for layered products and Operators installed through Operator Lifecycle Manager
 
-In addition to the Control Plane Only update steps mentioned for the web console and CLI, there are additional steps to consider when performing Control Plane Only updates for clusters with the following:
-
-* Layered products
-* Operators installed through Operator Lifecycle Manager (OLM)
-
-.What is a layered product?
+[role="_abstract"]
+There are additional steps to consider when performing Control Plane Only updates for clusters with either layered products or Operators installed through Operator Lifecycle Manager (OLM).
 
 Layered products refer to products that are made of multiple underlying products that are intended to be used together and cannot be broken into individual subscriptions. For examples of layered {product-title} products, see link:https://access.redhat.com/support/policy/updates/openshift/#layered[Layered Offering On OpenShift].
 
-As you perform a Control Plane Only update for the clusters of layered products and those of Operators that have been installed through OLM, you must complete the following:
+As you perform a Control Plane Only update for the clusters of layered products and those of Operators that have been installed through OLM, you must complete the following actions:
 
-. You have updated all Operators previously installed through Operator Lifecycle Manager (OLM) to a version that is compatible with your target release. Updating the Operators ensures they have a valid update path when the default software catalogs switch from the current minor version to the next during a cluster update. See "Updating installed Operators" in the "Additional resources" section for more information on how to check compatibility and, if necessary, update the installed Operators.
+. You have updated all Operators previously installed through Operator Lifecycle Manager (OLM) to a version that is compatible with your target release. Updating the Operators ensures they have a valid update path when the default software catalogs switch from the current minor version to the next during a cluster update. See "Updating installed Operators" for more information on how to check compatibility and, if necessary, update the installed Operators.
 
 . Confirm the cluster version compatibility between the current and intended Operator versions. You can verify which versions your OLM Operators are compatible with by using the link:https://access.redhat.com/labs/ocpouic/?operator=logging&&ocp_versions=4.10,4.11,4.12[Red{nbsp}Hat {product-title} Operator Update Information Checker].
 
-As an example, here are the steps to perform a Control Plane Only update from <4.y> to <4.y+2> for '{rh-storage}'. This can be done through the CLI or web console. For information about how to update clusters through your desired interface, see _Control Plane Only update using the web console_ and "Control Plane Only update using the CLI" in "Additional resources".
+For example, the following high level steps describe how to perform a Control Plane Only update from <4.y> to <4.y+2> for {rh-storage} (ODF). This can be done through the CLI or web console. For information about how to update clusters through your desired interface, see "Control Plane Only update using the web console" and "Control Plane Only update using the CLI".
 
-.Example workflow
 . Pause the worker machine pools.
-. Update OpenShift <4.y> -> OpenShift <4.y+1>.
-. Update ODF <4.y> -> ODF <4.y+1>.
-. Update OpenShift <4.y+1> -> OpenShift <4.y+2>.
-. Update to ODF <4.y+2>.
+. Update {product-title} from <4.y> to <4.y+1>.
+. Update ODF from <4.y> to <4.y+1>.
+. Update {product-title} from <4.y+1> to <4.y+2>.
+. Update ODF to <4.y+2>.
 . Unpause the worker machine pools.
 
 [NOTE]

--- a/modules/updating-control-plane-only-update-cli.adoc
+++ b/modules/updating-control-plane-only-update-cli.adoc
@@ -6,15 +6,18 @@
 [id="updating-control-plane-only-update-cli_{context}"]
 = Control Plane Only update using the CLI
 
+[role="_abstract"]
+You can perform a Control Plane Only update by using the {oc-first}.
+
 .Prerequisites
 
-* Verify that machine config pools are unpaused.
-* Have access to the {product-title} web console as a user with `cluster-admin` privileges.
-* Update the OpenShift CLI (`oc`) to the target version before each update.
-
+* You verified that machine config pools are unpaused.
+* You have access to the {product-title} web console as a user with `cluster-admin` privileges.
+* You updated the {oc-first} to the target version before each update.
++
 [IMPORTANT]
 ====
-It is highly discouraged to skip this prerequisite. If the OpenShift CLI (`oc`) is not updated to the target version before your update, unexpected issues may occur.
+It is highly discouraged to skip this prerequisite. If the {oc-first} is not updated to the target version before your update, unexpected issues may occur.
 ====
 
 .Procedure

--- a/modules/updating-control-plane-only-update-console.adoc
+++ b/modules/updating-control-plane-only-update-console.adoc
@@ -6,14 +6,17 @@
 [id="updating-control-plane-only-update-console_{context}"]
 = Control Plane Only update using the web console
 
+[role="_abstract"]
+You can perform a Control Plane Only update by using the web console.
+
 .Prerequisites
 
-* Verify that machine config pools are unpaused.
-* Have access to the web console as a user with `cluster-admin` privileges.
+* You verified that machine config pools are unpaused.
+* You have access to the web console as a user with `cluster-admin` privileges.
 
 .Procedure
 
-. Using the web console, update any Operator Lifecycle Manager (OLM) Operators to the versions that are compatible with your intended updated version. You can find more information on how to perform this action in "Updating installed Operators"; see "Additional resources".
+. Using the web console, update any Operator Lifecycle Manager (OLM) Operators to the versions that are compatible with your intended updated version. For more information, see "Updating installed Operators".
 
 . Verify that all machine config pools display a status of `Up to date` and that no machine config pool displays a status of `UPDATING`.
 +
@@ -21,7 +24,7 @@ To view the status of all machine config pools, click *Compute* -> *MachineConfi
 +
 [NOTE]
 ====
-If your machine config pools have an `Updating` status, please wait for this status to change to `Up to date`. This process could take several minutes.
+If your machine config pools have an `Updating` status, wait for this status to change to `Up to date`. This process could take several minutes.
 ====
 
 . Set your channel to `eus-<4.y+2>`.
@@ -30,13 +33,13 @@ To set your channel, click *Administration* -> *Cluster Settings* -> *Channel*. 
 
 . Pause all worker machine pools except for the master pool. You can perform this action on the *MachineConfigPools* tab under the *Compute* page. Select the vertical ellipses next to the machine config pool you'd like to pause and click *Pause updates*.
 
-. Update to version <4.y+1> and complete up to the *Save* step. You can find more information on how to perform these actions in "Updating a cluster by using the web console"; see "Additional resources".
+. Update to version <4.y+1> and complete up to the *Save* step. For more information, see "Updating a cluster by using the web console".
 
 . Ensure that the <4.y+1> updates are complete by viewing the *Last completed version* of your cluster. You can find this information on the *Cluster Settings* page under the *Details* tab.
 
-. If necessary, update your OLM Operators by using the Administrator perspective on the web console. You can find more information on how to perform these actions in "Updating installed Operators"; see "Additional resources".
+. If necessary, update your OLM Operators by using the Administrator perspective on the web console. For more information, see "Updating installed Operators".
 
-. Update to version <4.y+2> and complete up to the *Save* step. You can find more information on how to perform these actions in "Updating a cluster by using the web console"; see "Additional resources".
+. Update to version <4.y+2> and complete up to the *Save* step. For more information, see "Updating a cluster by using the web console".
 
 . Ensure that the <4.y+2> update is complete by viewing the *Last completed version* of your cluster. You can find this information on the *Cluster Settings* page under the *Details* tab.
 
@@ -53,7 +56,7 @@ You can verify that your pools have updated on the *MachineConfigPools* tab unde
 +
 [IMPORTANT]
 ====
-When you update a cluster that contains {op-system-base-full} compute machines, those machines temporarily become unavailable during the update process. You must run the upgrade playbook against each {op-system-base} machine as it enters the `NotReady` state for the cluster to finish updating. For more information, see "Updating a cluster that includes RHEL compute machines" in the additional resources section.
+When you update a cluster that contains {op-system-base-full} compute machines, those machines temporarily become unavailable during the update process. You must run the upgrade playbook against each {op-system-base} machine as it enters the `NotReady` state for the cluster to finish updating. For more information, see "Updating a cluster that includes RHEL compute machines".
 ====
 +
 You can verify that your cluster has completed the update by viewing the *Last completed version* of your cluster. You can find this information on the *Cluster Settings* page under the *Details* tab.

--- a/modules/updating-control-plane-only-update.adoc
+++ b/modules/updating-control-plane-only-update.adoc
@@ -6,15 +6,17 @@
 [id="updating-control-plane-only-update_{context}"]
 = Performing a Control Plane Only update
 
-The following procedure pauses all non-`master` machine config pools and performs updates from {product-title} <4.y> to <4.y+1> to <4.y+2>, then unpauses the machine config pools.
+[role="_abstract"]
+You can perform a Control Plane Only update by pausing all non-`master` machine config pools, performing updates from {product-title} <4.y> to <4.y+1> to <4.y+2>, then unpausing the machine config pools.
+
 Following this procedure reduces the total update duration and the number of times worker nodes are restarted.
 
 .Prerequisites
 
-* Review the release notes for {product-title} <4.y+1> and <4.y+2>.
-* Review the release notes and product lifecycles for any layered products and Operator Lifecycle Manager (OLM) Operators. Some products and OLM Operators might require updates either before or during a Control Plane Only update.
-* Ensure that you are familiar with version-specific prerequisites, such as the removal of deprecated APIs, that are required before updating from {product-title} <4.y+1> to <4.y+2>.
-* If your cluster uses in-tree vSphere volumes, update vSphere to version 7.0u3L+ or 8.0u2+.
+* You reviewed the release notes for {product-title} <4.y+1> and <4.y+2>.
+* You reviewed the release notes and product lifecycles for any layered products and Operator Lifecycle Manager (OLM) Operators. Some products and OLM Operators might require updates either before or during a Control Plane Only update.
+* You are familiar with version-specific prerequisites, such as the removal of deprecated APIs, that are required before updating from {product-title} <4.y+1> to <4.y+2>.
+* If your cluster uses in-tree vSphere volumes, you updated vSphere to version 7.0u3L+ or 8.0u2+.
 +
 [IMPORTANT]
 ====

--- a/updating/updating_a_cluster/control-plane-only-update.adoc
+++ b/updating/updating_a_cluster/control-plane-only-update.adoc
@@ -12,6 +12,9 @@ WARNING: This assembly has been moved into a subdirectory for 4.14+. Changes to 
 To do: Remove this comment once 4.13 docs are EOL.
 ////
 
+[role="_abstract"]
+To reduce the rebooting of non-control plane hosts during cluster updates, you can perform a Control Plane Only update for your cluster.
+
 Due to fundamental Kubernetes design, all {product-title} updates between minor versions must be serialized.
 You must update from {product-title} <4.y> to <4.y+1>, and then to <4.y+2>. You cannot update from {product-title} <4.y> to <4.y+2> directly.
 However, administrators who want to update between two even-numbered minor versions can do so incurring only a single reboot of non-control plane hosts.

--- a/updating/updating_a_cluster/updating-hardware-on-nodes-running-on-vsphere.adoc
+++ b/updating/updating_a_cluster/updating-hardware-on-nodes-running-on-vsphere.adoc
@@ -12,6 +12,7 @@ WARNING: This assembly has been moved into a subdirectory for 4.14+. Changes to 
 To do: Remove this comment once 4.13 docs are EOL.
 ////
 
+[role="_abstract"]
 You must ensure that your nodes running in vSphere are running on the hardware version supported by {product-title}. Currently, hardware version 15 or later is supported for vSphere virtual machines in a cluster.
 
 You can update your virtual hardware immediately or schedule an update in vCenter.
@@ -23,29 +24,19 @@ You can update your virtual hardware immediately or schedule an update in vCente
 * Before upgrading OpenShift 4.12 to OpenShift 4.13, you must update vSphere to *v8.0 Update 1 or later*; otherwise, the OpenShift 4.12 cluster is marked *un-upgradeable*.
 ====
 
-[id="updating-virtual-hardware-on-vsphere_{context}"]
-== Updating virtual hardware on vSphere
-
-To update the hardware of your virtual machines (VMs) on VMware vSphere, update your virtual machines separately to reduce the risk of downtime for your cluster.
-
-[IMPORTANT]
-====
-As of {product-title} 4.13, VMware virtual hardware version 13 is no longer supported. You need to update to VMware version 15 or later for supporting functionality.
-====
-
 // Updating the virtual hardware for control plane nodes on vSphere
-include::modules/update-vsphere-virtual-hardware-on-control-plane-nodes.adoc[leveloffset=+2]
+include::modules/update-vsphere-virtual-hardware-on-control-plane-nodes.adoc[leveloffset=+1]
 
 // Updating the virtual hardware for compute nodes on vSphere
-include::modules/update-vsphere-virtual-hardware-on-compute-nodes.adoc[leveloffset=+2]
-
-// Updating the virtual hardware for template on vSphere
-include::modules/update-vsphere-virtual-hardware-on-template.adoc[leveloffset=+2]
+include::modules/update-vsphere-virtual-hardware-on-compute-nodes.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources
 
 * xref:../../nodes/nodes/nodes-nodes-working.adoc#nodes-nodes-working-evacuating_nodes-nodes-working[Evacuating pods on nodes]
+
+// Updating the virtual hardware for template on vSphere
+include::modules/update-vsphere-virtual-hardware-on-template.adoc[leveloffset=+1]
 
 // Scheduling an update for virtual hardware on vSphere
 include::modules/scheduling-virtual-hardware-update-on-vsphere.adoc[leveloffset=+1]


### PR DESCRIPTION
[OSDOCS-17077](https://issues.redhat.com/browse/OSDOCS-17077)

Version(s): 4.16+

This PR is one of several to perform a CQA of the updating procedures in the OTA docs.

No new content added.

QE review: No technical accuracy changes and therefore no need for QE, but let me know if you think anything needs a review.

Previews:
- [Performing a Control Plane Only update](https://108960--ocpdocs-pr.netlify.app/openshift-enterprise/latest/updating/updating_a_cluster/control-plane-only-update)
- [Updating hardware on nodes running on vSphere](https://108960--ocpdocs-pr.netlify.app/openshift-enterprise/latest/updating/updating_a_cluster/updating-hardware-on-nodes-running-on-vsphere)