### PR TITLE
OSDOCS WMCO 10.17/4.17 RN Prep

### DIFF
--- a/modules/windows-containers-release-notes-10-17-0.adoc
+++ b/modules/windows-containers-release-notes-10-17-0.adoc
@@ -7,23 +7,25 @@
 [id="windows-containers-release-notes-10-17-0_{context}"]
 = Release notes for Red Hat Windows Machine Config Operator 10.17.0
 
-This release of the WMCO provides bug fixes for running Windows compute nodes in an {product-title} cluster. The components of the WMCO 10.17.0 were released in link:https://access.redhat.com/errata/RHSA-2024:7436[RHSA-2024:7436].
+[role="_abstract"]
+You can review the following release notes to learn about the bug fixes provided in this release of the Windows Machine Config Operator (WMCO). 
 
-[id="wmco-10-17-0-new-features"]
+The components of the WMCO 10.17.0 were released in link:https://access.redhat.com/errata/RHSA-2024:7436[RHSA-2024:7436].
+
+[id="wmco-10-17-0-new-features_{context}"]
 == New features and improvements
 
-[id="wmco-10-17-0-new-features-kubernetes"]
-=== Kubernetes upgrade
+Kubernetes upgrade::
 
 The WMCO now uses Kubernetes 1.30.
 
-[id="wmco-10-17-0-bug-fixes"]
+[id="wmco-10-17-0-bug-fixes_{context}"]
 == Bug fixes
 
-* Previously, if a Windows VM had its PowerShell `ExecutionPolicy` set to `Restricted`, the Windows Instance Config Daemon (WICD) could not run the commands on that VM that are necessary for creating Windows nodes. With this fix, the WICD now bypasses the execution policy on the VM when running PowerShell commands. As a result, the WICD can create Windows nodes on the VM as expected. (link:https://issues.redhat.com/browse/OCPBUGS-30995[*OCPBUGS-30995*])
+* Before this update, if a Windows VM had its PowerShell `ExecutionPolicy` set to `Restricted`, the Windows Instance Config Daemon (WICD) could not run the commands on that VM that are necessary for creating Windows nodes. With this release, the WICD now bypasses the execution policy on the VM when running PowerShell commands. As a result, the WICD can create Windows nodes on the VM as expected. (link:https://issues.redhat.com/browse/OCPBUGS-30995[*OCPBUGS-30995*])
 
 // Copied from 4.16 release notes. 
-* Previously, if reverse DNS lookup failed due to an error, such as the reverse DNS lookup services being unavailable, the WMCO would not fall back to using the VM hostname to determine if a certificate signing requests (CSR) should be approved. As a consequence, Bring-Your-Own-Host (BYOH) Windows nodes configured with an IP address would not become available. With this fix, BYOH nodes are properly added if reverse DNS is not available. (link:https://issues.redhat.com/browse/OCPBUGS-36643[*OCPBUGS-36643*])
+* Before this update, if reverse DNS lookup failed due to an error, such as the reverse DNS lookup services being unavailable, the WMCO would not fall back to using the VM hostname to determine if a certificate signing requests (CSR) should be approved. As a consequence, Bring-Your-Own-Host (BYOH) Windows nodes configured with an IP address would not become available. With this release, BYOH nodes are properly added if reverse DNS is not available. (link:https://issues.redhat.com/browse/OCPBUGS-36643[*OCPBUGS-36643*])
 
 // Copied from 4.16 release notes. 
-* Previously, if there were multiple service account token secrets in the WMCO namespace, scaling Windows nodes would fail. With this fix, the WMCO uses only the secret it creates, ignoring any other service account token secrets in the WMCO namespace. As a result, Windows nodes scale properly. (link:https://issues.redhat.com/browse/OCPBUGS-29253[*OCPBUGS-29253*])
+* Before this update, if there were multiple service account token secrets in the WMCO namespace, scaling Windows nodes would fail. With this release, the WMCO uses only the secret it creates, ignoring any other service account token secrets in the WMCO namespace. As a result, Windows nodes scale properly. (link:https://issues.redhat.com/browse/OCPBUGS-29253[*OCPBUGS-29253*])

--- a/modules/windows-containers-release-notes-10-17-1.adoc
+++ b/modules/windows-containers-release-notes-10-17-1.adoc
@@ -8,21 +8,23 @@
 
 Issued: 9 June 2025
 
-This release of the WMCO provides bug fixes for running Windows compute nodes in an {product-title} cluster. The components of the WMCO 10.17.1 were released in link:https://access.redhat.com/errata/RHSA-2025:8704[RHSA-2025:8704].
+[role="_abstract"]
+You can review the following release notes to learn about the bug fixes provided in this release of the Windows Machine Config Operator (WMCO). 
 
-[id="wmco-10-17-1-new-features"]
+The components of the WMCO 10.17.1 were released in link:https://access.redhat.com/errata/RHSA-2025:8704[RHSA-2025:8704].
+
+[id="wmco-10-17-1-new-features_{context}"]
 == New features and improvements
 
-[id="wmco-10-17-1-new-features-debuglogging"]
-=== WMCO now defaults to info-level logging
+WMCO now defaults to info-level logging::
 The WMCO is configured to use the `info` log level by default. You can change the log level to `debug` by editing the WMCO subscription object. 
 // Based on https://issues.redhat.com/browse/WINC-1345
-
++
 For more information, see _Configuring debug-level logging for the Windows Machine Config Operator_.
 
-[id="wmco-10-17-1-bug-fixes"]
+[id="wmco-10-17-1-bug-fixes_{context}"]
 == Bug fixes
 
-* Previously, Windows nodes were unable to pull from image mirror registries if an organization name or namespace was included in the source of the `ImageTagMirrorSet` (ITMS) object. With this fix, you can include an organization name or namespace in the `ITMS` object. With this change, additional guidelines and requirements around using mirror registries have been added to the {product-title} documentation. For more information, see _Using Windows containers with a mirror registry_. (link:https://issues.redhat.com/browse/OCPBUGS-55915[*OCPBUGS-55915*])
+* Before this update, Windows nodes were unable to pull from image mirror registries if an organization name or namespace was included in the source of the `ImageTagMirrorSet` (ITMS) object. With this fix, you can include an organization name or namespace in the `ITMS` object. With this release, additional guidelines and requirements around using mirror registries have been added to the {product-title} documentation. For more information, see _Using Windows containers with a mirror registry_. (link:https://issues.redhat.com/browse/OCPBUGS-55915[*OCPBUGS-55915*])
 
-* Previously, the {product-title} documentation lacked information about WMCO support for the installer-provisioned infrastructure (IPI) and the user-provisioned infrastructure (UPI) installation methods. With this fix, the documentation reports that the IPI method is the preferred installation method and can be used with all platforms. The UPI method is limited to specific use cases. For more information, see _WMCO supported installation method_. (link:https://issues.redhat.com/browse/OCPBUGS-44237[*OCPBUGS-44237*])
+* Before this update, the {product-title} documentation lacked information about WMCO support for the installer-provisioned infrastructure and the user-provisioned infrastructure installation methods. With this release, the documentation reports that the installer-provisioned infrastructure method is the preferred installation method and can be used with all platforms. The user-provisioned infrastructure method is limited to specific use cases. For more information, see _WMCO supported installation method_. (link:https://issues.redhat.com/browse/OCPBUGS-44237[*OCPBUGS-44237*])

--- a/modules/windows-containers-release-notes-10-17-2.adoc
+++ b/modules/windows-containers-release-notes-10-17-2.adoc
@@ -1,0 +1,26 @@
+// Module included in the following assemblies:
+//
+// * windows_containers/wmco_rn/windows-containers-release-notes-10-17-x.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="windows-containers-release-notes-10-17-2_{context}"]
+= Release notes for Red Hat Windows Machine Config Operator 10.17.2
+
+Issued: DD MONTH 2026
+
+[role="_abstract"]
+You can review the following release notes to learn about the bug fixes provided in this release of the Windows Machine Config Operator (WMCO). 
+
+The components of the WMCO 10.17.2 were released in link:https://access.redhat.com/errata/RHSA-2026:TBD[RHSA-2026:TBD].
+
+[id="wmco-10-17-2-new-features_{context}"]
+== New features and improvements
+
+New feature::
+Description
+
+[id="wmco-10-17-2-bug-fixes_{context}"]
+== Bug fixes
+
+* Before this update, With this release, (link:https://issues.redhat.com/browse/OCPBUGS-55915[*OCPBUGS-55915*])
+

--- a/windows_containers/wmco_rn/windows-containers-release-notes-past.adoc
+++ b/windows_containers/wmco_rn/windows-containers-release-notes-past.adoc
@@ -6,8 +6,18 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-The following release notes are for previous versions of the Windows Machine Config Operator (WMCO).
+[role="_abstract"]
+You can review the following release notes to learn about changes in previous versions of the Custom Metrics Autoscaler Operator.
 
 For the current version, see xref:../../windows_containers/wmco_rn/windows-containers-release-notes.adoc#windows-containers-release-notes[{productwinc} release notes].
 
+include::modules/windows-containers-release-notes-10-17-1.adoc[leveloffset=+1]
+
 include::modules/windows-containers-release-notes-10-17-0.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+[id="additional-resources_{context}"]
+== Additional resources
+* xref:../../windows_containers/enabling-windows-container-workloads.adoc#wmco-disconnected-cluster_enabling-windows-container-workloads[Using Windows containers with a mirror registry]
+* xref:../../windows_containers/enabling-windows-container-workloads.adoc#wmco-configure-debug-logging_enabling-windows-container-workloads[Configuring debug-level logging for the Windows Machine Config Operator]
+* xref:../../windows_containers/wmco_rn/windows-containers-release-notes-prereqs.adoc#wmco-prerequisites-supported-install_windows-containers-release-notes-prereqs[WMCO supported installation method]

--- a/windows_containers/wmco_rn/windows-containers-release-notes.adoc
+++ b/windows_containers/wmco_rn/windows-containers-release-notes.adoc
@@ -6,12 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-include::modules/windows-containers-release-notes-10-17-1.adoc[leveloffset=+1]
+[role="_abstract"]
+You can review the following release notes to learn about changes in the Windows Machine Config Operator (WMCO) version 10.17.2.
 
-[role="_additional-resources"]
-.Additional resources
-* xref:../../windows_containers/enabling-windows-container-workloads.adoc#wmco-disconnected-cluster_enabling-windows-container-workloads[Using Windows containers with a mirror registry]
-* xref:../../windows_containers/enabling-windows-container-workloads.adoc#wmco-configure-debug-logging_enabling-windows-container-workloads[Configuring debug-level logging for the Windows Machine Config Operator]
-* xref:../../windows_containers/wmco_rn/windows-containers-release-notes-prereqs.adoc#wmco-prerequisites-supported-install_windows-containers-release-notes-prereqs[WMCO supported installation method]
-
+include::modules/windows-containers-release-notes-10-17-2.adoc[leveloffset=+1]
 


### PR DESCRIPTION
Updates to the current WMCO 10.17/4/17 release notes in preparation for the 10.17.2 release. Mostly a sanity check is all that is required at this point.

[Red Hat OpenShift support for Windows Containers release notes](https://108961--ocpdocs-pr.netlify.app/openshift-enterprise/latest/windows_containers/wmco_rn/windows-containers-release-notes.html) -- Moved the 10.17.1 module to past release notes. Added the 10.17.2 release notes module.
[Release notes for Red Hat Windows Machine Config Operator 10.17.2](https://108961--ocpdocs-pr.netlify.app/openshift-enterprise/latest/windows_containers/wmco_rn/windows-containers-release-notes.html#windows-containers-release-notes-10-17-2_windows-containers-release-notes) -- New module in template format for filling out later.
[Release notes for past releases of the Windows Machine Config Operator](https://108961--ocpdocs-pr.netlify.app/openshift-enterprise/latest/windows_containers/wmco_rn/windows-containers-release-notes-past) -- Added the 10.17.1 module. 
[Release notes for Red Hat Windows Machine Config Operator 10.17.1](https://108961--ocpdocs-pr.netlify.app/openshift-enterprise/latest/windows_containers/wmco_rn/windows-containers-release-notes-past#windows-containers-release-notes-10-17-1_windows-containers-release-notes-past) -- Added abstract, made small editorial, vale, CQA-type changes.
[Release notes for Red Hat Windows Machine Config Operator 10.17.0](https://108961--ocpdocs-pr.netlify.app/openshift-enterprise/latest/windows_containers/wmco_rn/windows-containers-release-notes-past#windows-containers-release-notes-10-17-0_windows-containers-release-notes-past) -- Added abstract, made small editorial, vale, CQA-type changes.