### PR TITLE
OSDOCS#18780: Update 4.21.7 z stream Release Notes

### DIFF
--- a/modules/zstream-4-21-7.adoc
+++ b/modules/zstream-4-21-7.adoc
@@ -1,0 +1,43 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-21-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-21-7_{context}"]
+= RHSA-2026:5174 - {product-title} {product-version}.7 fixed issues
+
+Issued: 24 March 2026
+
+[role="_abstract"]
+{product-title} release {product-version}.7 is now available. The list of fixed issues that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2026:5174[RHSA-2026:5174] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2026:5147[RHBA-2026:5147] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.21.7 --pullspecs
+----
+
+[id="zstream-4-21-7-fixed-issues_{context}"]
+== Fixed issues
+
+* Before this update, pagination titles in the console UI were not marked for translation when the user interface language was set to non-English. As a consequence, the user interface text remained in English, causing confusion for non-English users. With this release, pagination titles are marked for translation in the `DataView` object. As a result, pagination titles support translation, improving user experience in non-English OCP consoles. (link:https://issues.redhat.com/browse/OCPBUGS-76387[OCPBUGS-76387])
+
+* Before this release, creating a hosted cluster with a node port publishing strategy, specifying a port outside the Kubernetes `ServiceNodePortRange` was silently accepted during cluster creation. As a consequence, the cluster installation was stuck with three pods and in the hosted cluster namespace. With this release, a fix added an early validation for `NodePort.Port` against the cluster's configured `ServiceNodePortRange`, rejecting invalid values with a clear error message indicating the allowed range. As a result, users receive an immediate validation error when specifying a node port outside the acceptable range, preventing stuck cluster installations. (link:https://issues.redhat.com/browse/OCPBUGS-77456[OCPBUGS-77456])
+
+* Before this update, the icon was not displayed in the **Status** column due to missing icon rendering in specific plugin statuses. This affected the user's ability to visually identify plugin status. With this release, the icon is added to the **Status** column for loaded, pending, and failed plugin states. As a result, the icon is now displayed in the **Status** column for all plugins, enhancing the visual experience. (link:https://issues.redhat.com/browse/OCPBUGS-77561[OCPBUGS-77561])
+
+* Before this update, the {hcp} Operator created Agent pods with insufficient memory limits, causing crashes on large clusters. As a consequence, the Agent CAPI-provider pod crashed due to insufficient memory limits on big clusters. With this release, memory limits for the Agent CAPI provider in the {hcp} Operator are increased. As a result, Agent pods do not crash due to memory limits, improving cluster stability. (link:https://issues.redhat.com/browse/OCPBUGS-77647[OCPBUGS-77647])
+
+* Before this update, the etcd Operator randomly removed control plane nodes, causing duplication and potential cluster downtime. As a consequence, user experience was disrupted, leading to a potential loss of control plane nodes in the etcd cluster. With this release, the etcd Operator prioritizes removing members in the same failure domain index, reducing potential duplication and improving cluster stability. As a result, the etcd Operator ensures the control plane remains stable with three nodes, preventing potential service disruptions. (link:https://issues.redhat.com/browse/OCPBUGS-77921[OCPBUGS-77921])
+
+* Before this update, an ordering issue in the hosted cluster controller's reconcile loop caused a deadlock during z-stream updates, stalling cluster provisioning and causing Azure Red{nbsp}Hat OpenShift {hcp} to fail. With this release, the deadlock during initial provisioning is resolved by updating Control Plane Operator (CPO) deployment before secret fetching. As a result, seamless cluster creation is enabled. (link:https://issues.redhat.com/browse/OCPBUGS-78473[OCPBUGS-78473])
+
+* Before this update, the catalog image version cap in `images.go` prevented the use of {product-title} 4.21 images. As a consequence, hosted clusters on {product-title} 4.21 and later were using {product-title} 4.20 catalog images, causing compatibility issues. With this release, the catalog image version cap is updated to {product-title} 4.21 in `support/catalogs/images.go`. As a result, hosted clusters on {product-title} 4.21 and later use {product-title} 4.21 catalog images, improving compatibility and functionality. (link:https://issues.redhat.com/browse/OCPBUGS-78484[OCPBUGS-78484])
+
+[id="zstream-4-21-7-updating_{context}"]
+== Updating
+
+To update an {product-title} 4.21 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].

--- a/release_notes/ocp-4-21-release-notes.adoc
+++ b/release_notes/ocp-4-21-release-notes.adoc
@@ -44,6 +44,9 @@ include::modules/rn-ocp-release-notes-known-issues.adoc[leveloffset=+1]
 // Asynchronous errata updates
 include::modules/rn-async-errata.adoc[leveloffset=+1]
 
+// 4.21.7 RNs and updating
+include::modules/zstream-4-21-7.adoc[leveloffset=+2]
+
 // 4.21.6 RNs and updating
 include::modules/zstream-4-21-6.adoc[leveloffset=+2]
 


### PR DESCRIPTION
Version(s):
4.21

Issue:
[OSDOCS-18780](https://redhat.atlassian.net/browse/OSDOCS-18780)

Link to docs preview:
[4.21.7](https://108966--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-21-release-notes.html#zstream-4-21-7_release-notes)

QE review:
N/A

Additional information:
(https://art-dash.engineering.redhat.com/dashboard/release/openshift-4.21)

https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/427/diffs#174470010592fa719ef10a7c5ee7f415673789de