### PR TITLE
OSDOCS WMCO 10.19/4.19 RN Prep

### DIFF
--- a/modules/windows-containers-release-notes-10-19-0.adoc
+++ b/modules/windows-containers-release-notes-10-19-0.adoc
@@ -11,30 +11,28 @@ The components of the WMCO 10.19.0 were released in link:https://access.redhat.c
 [id="wmco-10-19-0-new-features_{context}"]
 == New features and improvements
 
-[id="wmco-10-19-0-new-features-kubeconfig_{context}"]
-=== WMCO kubelet configuration changes 
-
+WMCO kubelet configuration changes:: 
 With this release, the WMCO now sets the following values in the `KubeletConfig` custom resource (CR):
-
++
+--
 * The `system-reserved` parameter on new Windows nodes is now set to 2GiB of memory for system processes by default, as recommended in the link:https://kubernetes.io/docs/concepts/configuration/windows-resource-management/#resource-reservation[Kubernetes documentation]. (link:https://issues.redhat.com/browse/WINC-1373[WINC-1373])
 * The `enforceNodeAllocatable` on new Windows nodes is now set to `none` by default. Previously, the value was set to `[]` to avoid a known issue. Both settings disable the enforcement of node allocatable resource limits. (link:https://issues.redhat.com/browse/WINC-926[WINC-926]) 
 * The `evictionHard` parameters, `imagefs.available` and `nodefs.available`, are now set to `15%` and `10%` respectively by default, as recommended in the link:https://kubernetes.io/docs/concepts/scheduling-eviction/node-pressure-eviction/#eviction-signals[Kubernetes documentation]. (link:https://issues.redhat.com/browse/WINC-1374[WINC-1374])
-
+--
++
 The `KubeletConfig` object configures the kubelet service, which runs on each node in the cluster to ensure that containers in a pod are running.
 
-[id="wmco-10-19-0-new-features-ec2launch_{context}"]
-=== WMCO kubelet configuration changes 
-
+WMCO kubelet configuration changes::
 For disconnected clusters, the Windows AMI that you are using must have the EC2LaunchV2 agent version 2.0.2107 or later installed. Previously, the minimum required EC2LaunchV2 agent version was 2.0.1643. For more information, see the link:https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2launch-v2-install.html[Install the latest version of EC2Launch v2] in the AWS documentation.
 
 [id="wmco-10-19-0-bug-fixes_{context}"]
 == Bug fixes
 
-* Previously, when using the `optional_namespaces` parameter in an `ImageTagMirrorSet` CR, Windows nodes could fail to pull the specified image, resulting in a image not found error. With this fix, the `optional_namespace` parameter works as expected. (link:https://issues.redhat.com/browse/OCPBUGS-47696[OCPBUGS-47696])
+* Before this update, when using the `optional_namespaces` parameter in an `ImageTagMirrorSet` CR, Windows nodes could fail to pull the specified image, resulting in a image not found error.  With this release, the `optional_namespace` parameter works as expected. (link:https://issues.redhat.com/browse/OCPBUGS-47696[OCPBUGS-47696])
 
-* Previously, Windows Server 2019 nodes did not have a running an SSH server because of network instability. As a result, you were unable to SSH into that node. With this fix, the WMCO installs the SSH server node creation. As a result, you can SSH into the Windows nodes as expected. (link:https://issues.redhat.com/browse/OCPBUGS-56131[OCPBUGS-56131])
+* Before this update, Windows Server 2019 nodes did not have a running an SSH server because of network instability. As a result, you were unable to SSH into that node.  With this release, the WMCO installs the SSH server node creation. As a result, you can SSH into the Windows nodes as expected. (link:https://issues.redhat.com/browse/OCPBUGS-56131[OCPBUGS-56131])
 
-* Previously, because an `Endpoint_IP` variable was not resolving, the Windows Instance Config Daemon (WICD) repeatedly reported an `Endpoint_IP` error. This fix adds retries to ensure that the `Endpoint_IP` is created before continuing. As a result, the error message is no longer reported. (link:https://issues.redhat.com/browse/OCPBUGS-1721[OCPBUGS-1721])
+* Before this update, because an `Endpoint_IP` variable was not resolving, the Windows Instance Config Daemon (WICD) repeatedly reported an `Endpoint_IP` error.  With this release, retries are added to ensure that the `Endpoint_IP` is created before continuing. As a result, the error message is no longer reported. (link:https://issues.redhat.com/browse/OCPBUGS-1721[OCPBUGS-1721])
 
 [id="wmco-10-19-0-known-issues_{context}"]
 == Known issues 

--- a/modules/windows-containers-release-notes-10-19-1.adoc
+++ b/modules/windows-containers-release-notes-10-19-1.adoc
@@ -3,21 +3,22 @@
 // * windows_containers/wmco_rn/windows-containers-release-notes.adoc
 
 :_mod-docs-content-type: CONCEPT
-[id="windows-containers-release-notes-10-19-0_{context}"]
+[id="windows-containers-release-notes-10-19-1_{context}"]
 = Release notes for Red Hat Windows Machine Config Operator 10.19.1
 
 Issued: 11 November 2025
 
-The components of the WMCO 10.19.1 were released in link:https://access.redhat.com/errata/RHBA-2025:21039[RHBA-2025:21039].
+[role="_abstract"]
+You can review the following release notes to learn about the bug fixes provided in this release of the Windows Machine Config Operator (WMCO).
 
 [id="wmco-10-19-1-bug-fixes_{context}"]
 == Bug fixes
 
-* Previously, the `hybridOverlay` service was not using the trusted CA bundle when connecting to Kubernetes because the `hybridOverlay` service command was missing the `--k8s-cacert` option. As a consequence, users could have encountered trust issues or failures when the `hybridOverlay` service attempted to communicate securely with Kubernetes clusters using custom or internal CAs. With this fix, the `hybridOverlay` service command now includes the `--k8s-cacert` flag pointing to the trusted CA bundle. As a result, the `hybridOverlay` service uses the trusted CA bundle for secure communication, preventing trust issues and ensuring compatibility with the cluster. 
+* Before this update, the `hybridOverlay` service was not using the trusted CA bundle when connecting to Kubernetes because the `hybridOverlay` service command was missing the `--k8s-cacert` option. As a consequence, users could have encountered trust issues or failures when the `hybridOverlay` service attempted to communicate securely with Kubernetes clusters using custom or internal CAs. With this release, the `hybridOverlay` service command now includes the `--k8s-cacert` flag pointing to the trusted CA bundle. As a result, the `hybridOverlay` service uses the trusted CA bundle for secure communication, preventing trust issues and ensuring compatibility with the cluster. 
 // (link: issues.redhat.com/browse/OCPBUGS-60701[OCPBUGS-60701])
 
-* Previously, the WMCO neglected to close SSH connections when finishing node reconciliation. As a consequence, after adding a new Windows node to a cluster, the node SSH server would eventually refuse new connections due to being overwhelmed, causing node management issues. With this fix, the WMCO now properly closes SSH connections. As a result, the node SSH servers no longer refuse new connections due to this problem. (link:https://issues.redhat.com/browse/OCPBUGS-60775[OCPBUGS-60775])
+* Before this update, the WMCO neglected to close SSH connections when finishing node reconciliation. As a consequence, after adding a new Windows node to a cluster, the node SSH server would eventually refuse new connections due to being overwhelmed, causing node management issues. With this release, the WMCO now properly closes SSH connections. As a result, the node SSH servers no longer refuse new connections due to this problem. (link:https://issues.redhat.com/browse/OCPBUGS-60775[OCPBUGS-60775])
 
-* Previously, if an internally used config map needed to be deleted and re-created, a nil error was dereferenced when logging the event. As a consequence, the WMCO pod panicked and restarted. With this fix, the error handling logic has been reworked. As a result, the Operator pod no longer panics. (link:https://issues.redhat.com/browse/OCPBUGS-60792[OCPBUGS-60792])
+* Before this update, if an internally used config map needed to be deleted and re-created, a nil error was dereferenced when logging the event. As a consequence, the WMCO pod panicked and restarted. With this release, the error handling logic has been reworked. As a result, the Operator pod no longer panics. (link:https://issues.redhat.com/browse/OCPBUGS-60792[OCPBUGS-60792])
 
-* Previously, during secret reconciliations, secret change data was being added to the logs on each reconciliation loop. As a result, this secret change data was persisting, causing the logs to grow in size with unrelated data. With this fix, only the current secret change data is being logged, reducing the size and complexity of the logs. (link:https://issues.redhat.com/browse/OCPBUGS-61832[OCPBUGS-61832])
+* Before this update, during secret reconciliations, secret change data was being added to the logs on each reconciliation loop. As a result, this secret change data was persisting, causing the logs to grow in size with unrelated data. With this release, only the current secret change data is being logged, reducing the size and complexity of the logs. (link:https://issues.redhat.com/browse/OCPBUGS-61832[OCPBUGS-61832])

--- a/modules/windows-containers-release-notes-10-19-2.adoc
+++ b/modules/windows-containers-release-notes-10-19-2.adoc
@@ -1,0 +1,26 @@
+// Module included in the following assemblies:
+//
+// * windows_containers/wmco_rn/windows-containers-release-notes-10-19-x.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="windows-containers-release-notes-10-19-2_{context}"]
+= Release notes for Red Hat Windows Machine Config Operator 10.19.2
+
+Issued: DD MONTH 2026
+
+[role="_abstract"]
+You can review the following release notes to learn about the bug fixes provided in this release of the Windows Machine Config Operator (WMCO). 
+
+The components of the WMCO 10.19.2 were released in link:https://access.redhat.com/errata/RHSA-2026:TBD[RHSA-2026:TBD].
+
+[id="wmco-10-19-2-new-features_{context}"]
+== New features and improvements
+
+New feature::
+Description
+
+[id="wmco-10-19-2-bug-fixes_{context}"]
+== Bug fixes
+
+* Before this update, With this release, (link:https://issues.redhat.com/browse/OCPBUGS-55915[*OCPBUGS-55915*])
+

--- a/windows_containers/wmco_rn/windows-containers-release-notes-past.adoc
+++ b/windows_containers/wmco_rn/windows-containers-release-notes-past.adoc
@@ -6,8 +6,11 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-The following release notes are for previous versions of the Windows Machine Config Operator (WMCO).
+[role="_abstract"]
+You can review the following release notes to learn about changes in previous versions of the Custom Metrics Autoscaler Operator.
 
 For the current version, see xref:../../windows_containers/wmco_rn/windows-containers-release-notes.adoc#windows-containers-release-notes[{productwinc} release notes].
+
+include::modules/windows-containers-release-notes-10-19-1.adoc[leveloffset=+1]
 
 include::modules/windows-containers-release-notes-10-19-0.adoc[leveloffset=+1]

--- a/windows_containers/wmco_rn/windows-containers-release-notes.adoc
+++ b/windows_containers/wmco_rn/windows-containers-release-notes.adoc
@@ -6,6 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-This release of the WMCO provides bug fixes for running Windows compute nodes in an {product-title} cluster. 
+[role="_abstract"]
+You can review the following release notes to learn about changes in the Windows Machine Config Operator (WMCO) version 10.19.2.
 
-include::modules/windows-containers-release-notes-10-19-1.adoc[leveloffset=+1]
+include::modules/windows-containers-release-notes-10-19-2.adoc[leveloffset=+1]


### PR DESCRIPTION
Updates to the current WMCO 10.19/4/19 release notes in preparation for the 10.19.2 release. Mostly a sanity check is all that is required at this point.

**DO NOT MERGE UNTIL NEEDED AT RELEASE**

[Red Hat OpenShift support for Windows Containers release notes](https://108967--ocpdocs-pr.netlify.app/openshift-enterprise/latest/windows_containers/wmco_rn/windows-containers-release-notes.html) -- Moved the 10.19.1 module to past release notes. Added the 10.19.2 release notes module.
[Release notes for Red Hat Windows Machine Config Operator 10.19.2](https://108967--ocpdocs-pr.netlify.app/openshift-enterprise/latest/windows_containers/wmco_rn/windows-containers-release-notes.html#windows-containers-release-notes-10-19-2_windows-containers-release-notes) -- New module in template format for filling out later.
[Release notes for past releases of the Windows Machine Config Operator](https://108967--ocpdocs-pr.netlify.app/openshift-enterprise/latest/windows_containers/wmco_rn/windows-containers-release-notes-past) -- Added the 10.19.1 module. 
[Release notes for Red Hat Windows Machine Config Operator 10.19.1](https://108967--ocpdocs-pr.netlify.app/openshift-enterprise/latest/windows_containers/wmco_rn/windows-containers-release-notes-past#windows-containers-release-notes-10-19-1_windows-containers-release-notes-past) -- Added abstract, made small editorial, vale, CQA-type changes.
[Release notes for Red Hat Windows Machine Config Operator 10.19.0](https://108967--ocpdocs-pr.netlify.app/openshift-enterprise/latest/windows_containers/wmco_rn/windows-containers-release-notes-past#windows-containers-release-notes-10-19-0_windows-containers-release-notes-past) -- Added abstract, made small editorial, vale, CQA-type changes.