### PR TITLE
OSSM-12757-3.2.3 At ReleaseCandidate Documentation Tasks

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -17,14 +17,14 @@
 :SMProductName: Red{nbsp}Hat OpenShift Service Mesh
 :SMProduct: OpenShift Service Mesh
 :SMProductShortName: Service Mesh
-:SMProductVersion: 3.2.2
+:SMProductVersion: 3.2.3
 //service mesh v2
 //Update when there is a new 2.6.z release
-:SMv2Version: 2.6.12
+:SMv2Version: 2.6.14
 //SMv2Version must be updated with each 2.x release because users can only migrate from the latest 2.x.z version. Update 02/24/2025 for service-mesh-docs-3.0
 //Istio
 :istio: Istio
-:istio-latest: 1.27.5
+:istio-latest: 1.27.8
 //update istio-latest as necessary
 //Kiali Operator
 :KialiProduct: Kiali Operator provided by Red{nbsp}Hat

--- a/modules/ossm-release-notes-3-2-3.adoc
+++ b/modules/ossm-release-notes-3-2-3.adoc
@@ -1,0 +1,21 @@
+// Module included in the following assemblies:
+//
+// * service-mesh-docs-main/ossm-release-notes/ossm-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="ossm-release-3-2-3_{context}"]
+= {SMProductName} version 3.2.3
+
+[role="_abstract"]
+
+This release of {SMProductName} is included with the {SMProductName} Operator 3.2.3 and is supported on {ocp-product-title} 4.18-4.21. This release addresses enhancements, fixed issues, and Common Vulnerabilities and Exposures (CVEs).
+
+For supported component versions for 3.2.3, see "Service Mesh version support tables".
+
+[id="ossm-fixed-issues-3-2-3_{context}"]
+== Fixed issues
+
+Smart load balancing issue in OpenShift AI and llm-d resolved::
+Before this update, a bug in {istio} caused a smart load balancing issue in {ocp-short-name} AI and llm-d on {ocp-product-title} 4.20 and possibly 4.21. As a consequence, improper load distribution affected user experience. With this release, the update fixes the smart load balancing issue. As a result, sharing a Gateway now provides greater stability for many models.
++
+link:https://issues.redhat.com/browse/OSSM-12585[OSSM-12585]

--- a/modules/ossm-release-notes-supported-versions.adoc
+++ b/modules/ossm-release-notes-supported-versions.adoc
@@ -8,6 +8,40 @@
 
 [role="_abstract"]
 
+See the following table for information about {SMProduct} 3.2.3 supported versions.
+
+== {SMProduct} 3.2.3 supported versions
+
+[cols="1,1"]
+|===
+| Feature | Supported versions
+
+|{SMProduct} 3 Operator
+|3.2.3
+
+|{SMProduct} `Istio` control plane resource
+|1.27.8
+
+|{ocp-product-title}
+|4.18-4.21
+
+| Envoy proxy
+| 1.35.9
+
+| `IstioCNI` resource
+| 1.27.8
+
+| `Ztunnel` resource
+| 1.27.8
+
+|Kiali Operator
+|2.22.1
+
+|Kiali server
+|2.17.5
+
+|===
+
 See the following table for information about {SMProduct} 3.2.2 supported versions.
 
 == {SMProduct} 3.2.2 supported versions

--- a/ossm-release-notes/ossm-release-notes.adoc
+++ b/ossm-release-notes/ossm-release-notes.adoc
@@ -15,6 +15,8 @@ toc::[]
 For additional information about the {SMProductName} life cycle and supported platforms, refer to the link:https://access.redhat.com/support/policy/updates/openshift_operators[{ocp-short-name} Operator Life Cycles].
 ====
 
+include::modules/ossm-release-notes-3-2-3.adoc[leveloffset=+1]
+
 include::modules/ossm-release-notes-3-2-2.adoc[leveloffset=+1]
 
 include::modules/ossm-release-notes-3-2-1.adoc[leveloffset=+1]


### PR DESCRIPTION
Change type: Doc update; OSSM 3.2.3 (At Stage): Release Notes

Doc JIRA: https://issues.redhat.com/browse/OSSM-12757

Fix Version: [service-mesh-docs-3.2](https://github.com/openshift/openshift-docs/tree/service-mesh-docs-3.2)

Doc Previews:

- Release notes: https://108982--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/ossm-release-notes/ossm-release-notes#ossm-release-3-2-3_ossm-release-notes
- Version support table: https://108982--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/ossm-release-notes/ossm-release-notes-version-support-tables#openshift-service-mesh-3-2-3-supported-versions

QE Review: @mkralik3 
Peer Review: @kaldesai 