### PR TITLE
OSSM-12757-3.3.1 At ReleaseCandidate Documentation Tasks

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -17,14 +17,14 @@
 :SMProductName: Red{nbsp}Hat OpenShift Service Mesh
 :SMProduct: OpenShift Service Mesh
 :SMProductShortName: Service Mesh
-:SMProductVersion: 3.3.0
+:SMProductVersion: 3.3.1
 //service mesh v2
 //Update when there is a new 2.6.z release
-:SMv2Version: 2.6.13
+:SMv2Version: 2.6.14
 //SMv2Version must be updated with each 2.x release because users can only migrate from the latest 2.x.z version. Update 02/24/2025 for service-mesh-docs-3.0
 //Istio
 :istio: Istio
-:istio-latest: 1.27.8
+:istio-latest: 1.28.5
 //update istio-latest as necessary
 //Kiali Operator
 :KialiProduct: Kiali Operator provided by Red{nbsp}Hat

--- a/modules/ossm-release-notes-3-3-1.adoc
+++ b/modules/ossm-release-notes-3-3-1.adoc
@@ -1,0 +1,29 @@
+//
+// * service-mesh-docs-main/ossm-release-notes/ossm-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="ossm-release-3-3-1_{context}"]
+= {SMProductName} version 3.3.1
+
+[role="_abstract"]
+
+This release of {SMProductName} is included with the {SMProductName} Operator 3.3.1 and is supported on {ocp-product-title} 4.18-4.21. This release addresses enhancements, fixed issues, and Common Vulnerabilities and Exposures (CVEs).
+
+For supported component versions for 3.3.1, see "Service Mesh version support tables".
+
+[id="ossm-fixed-issues-3-3-1_{context}"]
+== Fixed issues
+
+Smart load balancing issue in OpenShift AI and llm-d resolved::
+Before this update, a bug in {istio} caused a smart load balancing issue in {ocp-short-name} AI and llm-d on {ocp-product-title} 4.20 and possibly 4.21. As a consequence, improper load distribution affected user experience. With this release, the update fixes the smart load balancing issue. As a result, sharing a Gateway now provides greater stability for many models.
++
+link:https://issues.redhat.com/browse/OSSM-12585[OSSM-12585]
+
+Increased xDS keepalive timeout for FIPS-enabled clusters::
+Before this update, the proxy in {SMProductName} processed a high volume of clusters with Transport Layer Security (TLS) contexts on a FIPS-enabled cluster. As a consequence, the Envoy main thread missed keepalive signals due to the additional cryptographic checks, which caused the xDS proxy downstream to stop with the following error:
++
+`xdsproxy downstream terminated with unexpected error ... rpc error: code = Unavailable desc = transport is closing`
++
+With this release, the new default configuration extends the keepalive timeout to 2 minutes from 30 seconds. As a result, the proxy maintains a stable connection even during intensive configuration processing in FIPS environments.
++
+link:https://issues.redhat.com/browse/OSSM-12930[OSSM-12930]

--- a/modules/ossm-release-notes-supported-versions.adoc
+++ b/modules/ossm-release-notes-supported-versions.adoc
@@ -8,6 +8,40 @@
 
 [role="_abstract"]
 
+See the following table for information about {SMProduct} 3.3.1 supported versions.
+
+== {SMProduct} 3.3.1 supported versions
+
+[cols="1,1"]
+|===
+| Feature | Supported versions
+
+|{SMProduct} 3 Operator
+|3.3.1
+
+|{SMProduct} `Istio` control plane resource
+|1.28.5
+
+|{ocp-product-title}
+|4.18 and later
+
+| Envoy proxy
+| 1.36.5
+
+| `IstioCNI` resource
+| 1.28.5
+
+| `Ztunnel` resource
+| 1.28.5
+
+|Kiali Operator
+|2.22.1
+
+|Kiali server
+|2.22.1
+
+|===
+
 See the following table for information about {SMProduct} 3.3.0 supported versions.
 
 == {SMProduct} 3.3.0 supported versions

--- a/ossm-release-notes/ossm-release-notes.adoc
+++ b/ossm-release-notes/ossm-release-notes.adoc
@@ -10,6 +10,8 @@ toc::[]
 
 Review new features, compatibility updates, fixed issues, and known issues for {SMProductName} to stay informed about changes across different product versions.
 
+include::modules/ossm-release-notes-3-3-1.adoc[leveloffset=+1]
+
 include::modules/ossm-release-notes-3-3-new-features-enhancements.adoc[leveloffset=+1]
 
 include::modules/ossm-release-notes-3-3-technology-preview-features.adoc[leveloffset=+1]


### PR DESCRIPTION
Change type: Doc update; OSSM 3.1.3 (At Stage): Release Notes

Doc JIRA: https://issues.redhat.com/browse/OSSM-12757

Fix Version: [service-mesh-docs-3.3](https://github.com/openshift/openshift-docs/tree/service-mesh-docs-3.3)

Doc Previews:

- Release notes: https://108984--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/ossm-release-notes/ossm-release-notes#ossm-release-3-3-1_ossm-release-notes
- Version support table: https://108984--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/ossm-release-notes/ossm-release-notes-version-support-tables#openshift-service-mesh-3-3-1-supported-versions

QE Review: @mkralik3 
Peer Review: @kaldesai 