### PR TITLE
[RHDEVDOCS-7388] Release notes for Pipelines 1.15.5

### DIFF
--- a/modules/op-release-notes-1-15.adoc
+++ b/modules/op-release-notes-1-15.adoc
@@ -554,7 +554,7 @@ With this update, {pipelines-title} General Availability (GA) 1.15.2 is availabl
 [id="release-notes-1-15-3_{context}"]
 == Release notes for {pipelines-title} General Availability 1.15.3
 
-With this update, {pipelines-title} General Availability (GA) 1.15.3 is available on {OCP} 4.12, 4.14, and later versions.
+With this update, {pipelines-title} General Availability (GA) 1.15.3 is available on {OCP} 4.14, 4.16, and later versions.
 
 [id="fixed-issues-1-15-3_{context}"]
 === Fixed issues
@@ -568,7 +568,7 @@ With this update, {pipelines-title} General Availability (GA) 1.15.3 is availabl
 [id="release-notes-1-15-4_{context}"]
 == Release notes for {pipelines-title} General Availability 1.15.4
 
-With this update, {pipelines-title} General Availability (GA) 1.15.4 is available on {OCP} 4.12, 4.14, and later versions.
+With this update, {pipelines-title} General Availability (GA) 1.15.4 is available on {OCP} 4.14, 4.16, and later versions.
 
 [id="fixed-issues-1-15-4_{context}"]
 === Fixed issues
@@ -580,3 +580,9 @@ With this update, {pipelines-title} General Availability (GA) 1.15.4 is availabl
 * Before this update, the {pipelines-title} Operator logged excessive messages during normal operation. With this update, the Operator logging levels are corrected to reduce extraneous log output.
 
 * Before this update, the {pipelines-shortname} Operator logged high-frequency internal operations at the `INFO` level, generating more than 2,000 log entries per second during normal operation. With this update, these operations are logged at the `DEBUG` level, significantly reducing log volume and improving log signal-to-noise ratio.
+
+
+[id="release-notes-1-15-5_{context}"]
+== Release notes for {pipelines-title} General Availability 1.15.5
+
+With this update, {pipelines-title} General Availability (GA) 1.15.5 is available on {OCP} 4.14, 4.16, and later versions.

--- a/modules/op-release-notes-1-15.adoc
+++ b/modules/op-release-notes-1-15.adoc
@@ -5,7 +5,7 @@
 [id="op-release-notes-1-15_{context}"]
 = Release notes for {pipelines-title} 1.15
 
-With this update, {pipelines-title} General Availability (GA) 1.15 is available on {OCP} 4.14 and later versions.
+With this update, {pipelines-title} General Availability (GA) 1.15 is available on {OCP} 4.14 and later supported versions.
 
 [id="new-features-1-15_{context}"]
 == New features
@@ -457,7 +457,7 @@ $ oc delete tektoninstallerset <installerset_name>
 [id="release-notes-1-15-1_{context}"]
 == Release notes for {pipelines-title} General Availability 1.15.1
 
-With this update, {pipelines-title} General Availability (GA) 1.15.1 is available on {OCP} 4.14 and later versions.
+With this update, {pipelines-title} General Availability (GA) 1.15.1 is available on {OCP} 4.14 and later supported versions.
 
 [id="new-features-1-15-1_{context}"]
 === New features
@@ -538,7 +538,7 @@ spec:
 [id="release-notes-1-15-2_{context}"]
 == Release notes for {pipelines-title} General Availability 1.15.2
 
-With this update, {pipelines-title} General Availability (GA) 1.15.2 is available on {OCP} 4.14 and later versions.
+With this update, {pipelines-title} General Availability (GA) 1.15.2 is available on {OCP} 4.14 and later supported versions.
 
 [id="fixed-issues-1-15-2_{context}"]
 === Fixed issues
@@ -554,7 +554,7 @@ With this update, {pipelines-title} General Availability (GA) 1.15.2 is availabl
 [id="release-notes-1-15-3_{context}"]
 == Release notes for {pipelines-title} General Availability 1.15.3
 
-With this update, {pipelines-title} General Availability (GA) 1.15.3 is available on {OCP} 4.12, 4.14, and later versions.
+With this update, {pipelines-title} General Availability (GA) 1.15.3 is available on {OCP} 4.14, 4.16, and later supported versions.
 
 [id="fixed-issues-1-15-3_{context}"]
 === Fixed issues
@@ -568,7 +568,7 @@ With this update, {pipelines-title} General Availability (GA) 1.15.3 is availabl
 [id="release-notes-1-15-4_{context}"]
 == Release notes for {pipelines-title} General Availability 1.15.4
 
-With this update, {pipelines-title} General Availability (GA) 1.15.4 is available on {OCP} 4.12, 4.14, and later versions.
+With this update, {pipelines-title} General Availability (GA) 1.15.4 is available on {OCP} 4.14, 4.16, and later supported versions.
 
 [id="fixed-issues-1-15-4_{context}"]
 === Fixed issues
@@ -580,3 +580,35 @@ With this update, {pipelines-title} General Availability (GA) 1.15.4 is availabl
 * Before this update, the {pipelines-title} Operator logged excessive messages during normal operation. With this update, the Operator logging levels are corrected to reduce extraneous log output.
 
 * Before this update, the {pipelines-shortname} Operator logged high-frequency internal operations at the `INFO` level, generating more than 2,000 log entries per second during normal operation. With this update, these operations are logged at the `DEBUG` level, significantly reducing log volume and improving log signal-to-noise ratio.
+
+[id="release-notes-1-15-5_{context}"]
+== Release notes for {pipelines-title} General Availability 1.15.5
+
+With this update, {pipelines-title} General Availability (GA) 1.15.5 is available on {OCP} 4.14, 4.16, and later supported versions.
+
+[NOTE]
+====
+{OCP} 4.22 requires {pipelines-shortname} 1.21 or later. Earlier versions of {pipelines-shortname}, including 1.15, are not supported on {OCP} 4.22.
+====
+
+[id="fixed-issues-1-15-5_{context}"]
+=== Fixed issues
+
+* Before this update, a forged HTTP header in a webhook request could trick {pac} into sending GitHub App credentials to an attacker-controlled server. This header was not verified, allowing an attacker to supply their own server address. As a consequence, {pac} would send a valid GitHub App installation token to the attacker's server. With this update, {pac} validates webhook requests to prevent GitHub App credentials from being sent to untrusted servers. As a result, GitHub App credentials are protected from header injection attacks.
++
+[IMPORTANT]
+====
+This is a critical security fix. Upgrade to {pipelines-shortname} 1.15.5 or later as soon as possible.
+====
+
+* Before this update, GitHub App installation tokens issued during webhook processing were not scoped to the triggering repository. As a consequence, an unscoped token could be used to access other repositories in the same installation. With this update, GitHub App installation tokens are scoped to only the triggering repository by default. As a result, namespace-level isolation of GitHub App token scoping is properly enforced.
++
+[IMPORTANT]
+====
+If your pipeline runs fetch remote tasks or pipelines from other private repositories in the same installation, add those repositories to `secret-github-app-scope-extra-repos` in your `pipelines-as-code` config map as comma-separated values in `owner/repo` format.
+====
+
+[id="known-issues-1-15-5_{context}"]
+=== Known issues
+
+* The {pac} CLI (`opc`) reports a {pac} server version of 0.27.3 instead of the actual installed {pac} version 0.27.2. This version mismatch occurs in the output of the `opc version` and `opc version --server` commands. The mismatch is cosmetic and does not affect {pac} functionality.


### PR DESCRIPTION
Version(s):
- _none for cherry-picking_

Issue:
- https://redhat.atlassian.net/browse/RHDEVDOCS-7388

Link to docs preview:
- [Release notes for Red Hat OpenShift Pipelines General Availability 1.15.5](https://108994--ocpdocs-pr.netlify.app/openshift-pipelines/latest/about/op-release-notes.html#release-notes-1-15-5_op-release-notes)

QE review:
- [x] QE has approved this change.

