### PR TITLE
OSDOCS#18988: Updating the storage index.adoc navigation file

### DIFF
--- a/modules/csi.adoc
+++ b/modules/csi.adoc
@@ -1,0 +1,10 @@
+// Module included in the following assemblies:
+//
+// * storage/index.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="container-storage-interface_{context}"]
+= Container Storage Interface (CSI)
+
+[role="_abstract"]
+CSI is an API specification for managing container storage across different orchestration systems. With CSI, you can manage storage volumes without requiring specific knowledge of the underlying infrastructure, providing uniform storage functionality regardless of your storage vendors.

--- a/modules/dynamic-provisioning.adoc
+++ b/modules/dynamic-provisioning.adoc
@@ -1,0 +1,10 @@
+// Module included in the following assemblies:
+//
+// * storage/index.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="dynamic-provisioning-overview_{context}"]
+= Dynamic Provisioning
+
+[role="_abstract"]
+With Dynamic Provisioning, you can create storage volumes on-demand, eliminating the need for cluster administrators to pre-provision storage.

--- a/modules/openshift-storage-common-terms.adoc
+++ b/modules/openshift-storage-common-terms.adoc
@@ -6,7 +6,8 @@
 [id="openshift-storage-common-terms_{context}"]
 = Glossary of common terms for {product-title} storage
 
-This glossary defines common terms that are used in the storage content.
+[role="_abstract"]
+Review this glossary that defines common terms that are used in the storage content.
 
 Access modes:: Volume access modes describe volume capabilities. You can use access modes to match persistent volume claim (PVC) and persistent volume (PV). The following are the examples of access modes:
 
@@ -53,8 +54,7 @@ Local volumes:: A local volume represents a mounted local storage device such as
 Nested mount points:: A nested mount point is a mount point that attempts to use a mount point created by a previous volume.
 +
 .Example pod definition with nested mount points
-+
-[source,terminal]
+[source,yaml]
 ----
 kind: Pod
 apiVersion: v1
@@ -72,7 +72,7 @@ spec:
       volumeMounts:
       - mountPath: /mnt/web
         name: web
-      - mountPath: /mnt/web/redis <1>
+      - mountPath: /mnt/web/redis
         name: redis
   volumes:
     - name: redis
@@ -82,9 +82,13 @@ spec:
       persistentVolumeClaim:
         claimName: "web"
 ----
-<1> Nested mount point
 +
+The `spec.containers.volumeMounts.mountPath` value of `/mnt/web/redis` is a nested mount point.
++
+[WARNING]
+====
 Do _not_ use nested mount points because {product-title} does not guarantee the order in which mount points are created. Such usage is prone to race conditions and undefined behavior.
+====
 
 ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 NFS:: A Network File System (NFS) that allows remote hosts to mount file systems over a network and interact with those file systems as though they are mounted locally. This enables system administrators to consolidate resources onto centralized servers on the network.

--- a/modules/storage-types.adoc
+++ b/modules/storage-types.adoc
@@ -1,0 +1,20 @@
+// Module included in the following assemblies:
+//
+// * storage/index.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="storage-types_{context}"]
+= Storage types
+
+[role="_abstract"]
+{product-title} storage is broadly classified into two categories, namely ephemeral storage and persistent storage.
+
+[id="ephemeral-storage_{context}"]
+== Ephemeral storage
+
+Pods and containers are ephemeral or transient in nature and designed for stateless applications. Ephemeral storage allows administrators and developers to better manage the local storage for some of their operations.
+
+[id="persistent-storage_{context}"]
+== Persistent storage
+
+Stateful applications deployed in containers require persistent storage. {product-title} uses a pre-provisioned storage framework called persistent volumes (PV) to allow cluster administrators to provision persistent storage. The data inside these volumes can exist beyond the lifecycle of an individual pod. Developers can use persistent volume claims (PVCs) to request storage requirements.

--- a/storage/index.adoc
+++ b/storage/index.adoc
@@ -7,36 +7,33 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 ifndef::openshift-rosa,openshift-rosa-hcp[]
+[role="_abstract"]
 {product-title} supports multiple types of storage, both for on-premise and cloud providers. You can manage container storage for persistent and non-persistent data in an {product-title} cluster.
 endif::openshift-rosa,openshift-rosa-hcp[]
 
 ifdef::openshift-rosa,openshift-rosa-hcp[]
+[role="_abstract"]
 {product-title} supports Amazon Elastic Block Store (Amazon EBS) and Amazon Elastic File System (Amazon EFS) storage. You can manage container storage for persistent and non-persistent data in an {product-title} cluster.
 endif::openshift-rosa,openshift-rosa-hcp[]
 
 include::modules/openshift-storage-common-terms.adoc[leveloffset=+1]
 
-[id="storage-types"]
-== Storage types
+include::modules/storage-types.adoc[leveloffset=+1]
 
-{product-title} storage is broadly classified into two categories, namely ephemeral storage and persistent storage.
+[role="_additional-resources"]
+.Additional resources
+* xref:../storage/understanding-ephemeral-storage.adoc#understanding-ephemeral-storage[Understanding ephemeral storage]
+* xref:../storage/understanding-persistent-storage.adoc#understanding-persistent-storage[Understanding persistent storage]
 
-[id="ephemeral-storage"]
-=== Ephemeral storage
+include::modules/dynamic-provisioning.adoc[leveloffset=+1]
 
-Pods and containers are ephemeral or transient in nature and designed for stateless applications. Ephemeral storage allows administrators and developers to better manage the local storage for some of their operations. For more information about ephemeral storage overview, types, and management, see xref:../storage/understanding-ephemeral-storage.adoc#understanding-ephemeral-storage[Understanding ephemeral storage].
+[role="_additional-resources"]
+.Additional resources
+* xref:../storage/dynamic-provisioning.adoc#dynamic-provisioning[Dynamic provisioning]
 
-[id="persistent-storage"]
-=== Persistent storage
 
-Stateful applications deployed in containers require persistent storage. {product-title} uses a pre-provisioned storage framework called persistent volumes (PV) to allow cluster administrators to provision persistent storage. The data inside these volumes can exist beyond the lifecycle of an individual pod. Developers can use persistent volume claims (PVCs) to request storage requirements. For more information about persistent storage overview, configuration, and lifecycle, see xref:../storage/understanding-persistent-storage.adoc#understanding-persistent-storage[Understanding persistent storage].
+include::modules/csi.adoc[leveloffset=+1]
 
-[id="container-storage-interface"]
-== Container Storage Interface (CSI)
-
-CSI is an API specification for the management of container storage across different container orchestration (CO) systems. You can manage the storage volumes within the container native environments, without having specific knowledge of the underlying storage infrastructure. With the CSI, storage works uniformly across different container orchestration systems, regardless of the storage vendors you are using. For more information about CSI, see xref:../storage/container_storage_interface/persistent-storage-csi.adoc#persistent-storage-csi[Using Container Storage Interface (CSI)].
-
-[id="dynamic-provisioning-overview"]
-== Dynamic Provisioning
-
-Dynamic Provisioning allows you to create storage volumes on-demand, eliminating the need for cluster administrators to pre-provision storage. For more information about dynamic provisioning, see xref:../storage/dynamic-provisioning.adoc#dynamic-provisioning[Dynamic provisioning].
+[role="_additional-resources"]
+.Additional resources
+* xref:../storage/container_storage_interface/persistent-storage-csi.adoc#persistent-storage-csi[Using Container Storage Interface (CSI)]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.20+

Issue:
https://redhat.atlassian.net/browse/OSDOCS-18988

Link to docs preview:

- https://108999--ocpdocs-pr.netlify.app/microshift/latest/microshift_storage/index.html
- https://108999--ocpdocs-pr.netlify.app/openshift-dedicated/latest/storage/index.html
- https://108999--ocpdocs-pr.netlify.app/openshift-enterprise/latest/storage/index.html
- https://108999--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/storage/index.html
- https://108999--ocpdocs-pr.netlify.app/openshift-rosa/latest/storage/index.html

QE review:
N/A - CQA work, just moving text around, no new technical info
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->

- Since this is resolving an index.adoc navigation file, xrefs are allowed in the resulting reference modules. These reference modules must only ever be included in one location
- Content was copied from the assembly to the modules without any changes other than the abstract lines.