### PR TITLE
OSDOCS-18839: Update commands in nw-configure-ingress-access-logging …

### DIFF
--- a/modules/nw-configure-ingress-access-logging.adoc
+++ b/modules/nw-configure-ingress-access-logging.adoc
@@ -18,26 +18,27 @@ Syslog is needed for high-traffic clusters where access logs could exceed the Op
 
 .Procedure
 
-Configure Ingress access logging to a sidecar.
-
-* To configure Ingress access logging, you must specify a destination using `spec.logging.access.destination`. To specify logging to a sidecar container, you must specify `Container` `spec.logging.access.destination.type`. The following example is an Ingress Controller definition that logs to a `Container` destination:
+* For Ingress access logging to a sidecar, complete the following commands:
 +
-[source,yaml]
+** To enable Ingress access logging to a sidecar, enter the following command:
++
+[source,terminal]
 ----
-apiVersion: operator.openshift.io/v1
-kind: IngressController
-metadata:
-  name: default
-  namespace: openshift-ingress-operator
-spec:
-  replicas: 2
-  logging:
-    access:
-      destination:
-        type: Container
+$ oc patch ingresscontroller default -n openshift-ingress-operator --type=merge \
+  -p '{"spec":{"logging":{"access":{"destination":{"type":"Container"}}}}}'
 ----
-
-* When you configure the Ingress Controller to log to a sidecar, the operator creates a container named `logs` inside the Ingress Controller Pod:
++
+After you configure the Ingress Controller to log to a sidecar, the Operator creates a container named `logs` inside a router pod that exists in the `openshift-ingress` namespace.
++
+** If you need to disable Ingress access logging, enter the following command that does not specify any values for `spec.logging`:
++
+[source,terminal]
+----
+$ oc patch ingresscontroller default -n openshift-ingress-operator --type=json \
+  -p='[{"op": "remove", "path": "/spec/logging"}]'
+----
++
+** To stream the access logs and system events from the {product-title} Ingress Controller, enter the following command:     
 +
 [source,terminal]
 ----
@@ -50,120 +51,41 @@ $ oc -n openshift-ingress logs deployment.apps/router-default -c logs
 2020-05-11T19:11:50.135710+00:00 router-default-57dfc6cd95-bpmk6 router-default-57dfc6cd95-bpmk6 haproxy[108]: 174.19.21.82:39654 [11/May/2020:19:11:50.133] public be_http:hello-openshift:hello-openshift/pod:hello-openshift:hello-openshift:10.128.2.12:8080 0/0/1/0/1 200 142 - - --NI 1/1/0/0/0 0/0 "GET / HTTP/1.1"
 ----
 
-Configure Ingress access logging to a Syslog endpoint.
-
-* To configure Ingress access logging, you must specify a destination using `spec.logging.access.destination`. To specify logging to a Syslog endpoint destination, you must specify `Syslog` for `spec.logging.access.destination.type`. If the destination type is `Syslog`, you must also specify a destination endpoint using `spec.logging.access.destination.syslog.address` and you can specify a facility using `spec.logging.access.destination.syslog.facility`. The following example is an Ingress Controller definition that logs to a `Syslog` destination:
+* To enable logging to an external Syslog server, enter the following command. Use this option if you need to forward logs to a centralized logging solution such as Splunk, Rsyslog, or Logstash.
 +
-[source,yaml]
+[source,terminal]
 ----
-apiVersion: operator.openshift.io/v1
-kind: IngressController
-metadata:
-  name: default
-  namespace: openshift-ingress-operator
-spec:
-  replicas: 2
-  logging:
-    access:
-      destination:
-        type: Syslog
-        syslog:
-          address: 1.2.3.4
-          port: 10514
+$ oc patch ingresscontroller default -n openshift-ingress-operator --type=merge \
+  -p '{"spec":{"logging":{"access":{"destination":{"type":"Syslog","syslog":{"address":"1.2.3.4","port":514,"maxLenght":1024}}}}}}'
+----
++
+** Replace `1.2.3.4` with the destination IP address of your logging server. Syslog does not support a DNS hostname value. 
+** Replace `514` with the UDP destination port of your logging server.
+** Replace `1024` with the maximum length of a log message in bytes that you want to set for log messages.
+
+* To customize the log format, append an HAProxy-compatible log string to the following command. The string determines what information gets captured in the log format, such as a client IP address.
++
+[source,terminal]
+----
+$ oc patch ingresscontroller default -n openshift-ingress-operator --type=merge \
+  -p '{"spec":{"logging":{"access":{"httpLogFormat":"%ci:%cp [%t] %ft %b/%s %B %bq %HM %HU %HV"}}}}'
 ----
 +
 [NOTE]
 ====
-The `syslog` destination port must be UDP.
-
-The `syslog` destination address must be an IP address. It does not support DNS hostname.
+For a list of HAProxy log variable descriptions, see link:https://docs.haproxy.org/2.8/configuration.html#8.2.6[Custom log format] in the upstream HAProxy documentation. 
 ====
 
-Configure Ingress access logging with a specific log format.
-
-* You can specify `spec.logging.access.httpLogFormat` to customize the log format. The following example is an Ingress Controller definition that logs to a `syslog` endpoint with IP address 1.2.3.4 and port 10514:
+* To capture custom HTTP headers or response headers in your logs, enter the following command. Consider this option if you need to track an `X-Forwarded-For` header or custom application IDs in the Ingress and application logs.
 +
-[source,yaml]
+[source,terminal]
 ----
-apiVersion: operator.openshift.io/v1
-kind: IngressController
-metadata:
-  name: default
-  namespace: openshift-ingress-operator
-spec:
-  replicas: 2
-  logging:
-    access:
-      destination:
-        type: Syslog
-        syslog:
-          address: 1.2.3.4
-          port: 10514
-      httpLogFormat: '%ci:%cp [%t] %ft %b/%s %B %bq %HM %HU %HV'
+$ oc patch ingresscontroller default -n openshift-ingress-operator --type=merge -p '{"spec":{"logging":{"access":{"httpCaptureHeaders":{"request":[{"name":"User-Agent","maxLength": 1024}],"response":[{"name":"Content-Type","maxLength": 1024}]}}}}}'
 ----
 
-Disable Ingress access logging.
-
-* To disable Ingress access logging, leave `spec.logging` or `spec.logging.access` empty:
+* To configure a log empty requests policy, enter the following command and set the `logEmptyRequests` parameter to `Log`. By default, HAProxy might not log empty requests or health checks, so you must manually enable this feature. To disable the feature, set the `logEmptyRequests` parameter to `Ignore`.
 +
-[source,yaml]
+[source,terminal]
 ----
-apiVersion: operator.openshift.io/v1
-kind: IngressController
-metadata:
-  name: default
-  namespace: openshift-ingress-operator
-spec:
-  replicas: 2
-  logging:
-    access: null
+$ oc patch ingresscontroller default -n openshift-ingress-operator --type=merge -p '{"spec":{"logging":{"access":{"logEmptyRequests":"Ignore"}}}}'
 ----
-
-Allow the Ingress Controller to modify the HAProxy log length when using a sidecar.
-
-* Use `spec.logging.access.destination.syslog.maxLength` if you are using `spec.logging.access.destination.type: Syslog`.
-
-+
-[source,yaml]
-----
-apiVersion: operator.openshift.io/v1
-kind: IngressController
-metadata:
-  name: default
-  namespace: openshift-ingress-operator
-spec:
-  replicas: 2
-  logging:
-    access:
-      destination:
-        type: Syslog
-        syslog:
-          address: 1.2.3.4
-          maxLength: 4096
-          port: 10514
-----
-* Use `spec.logging.access.destination.container.maxLength` if you are using `spec.logging.access.destination.type: Container`.
-
-+
-[source,yaml]
-----
-apiVersion: operator.openshift.io/v1
-kind: IngressController
-metadata:
-  name: default
-  namespace: openshift-ingress-operator
-spec:
-  replicas: 2
-  logging:
-    access:
-      destination:
-        container:
-          maxLength: 8192
-        type: Container
-      httpCaptureHeaders:
-        request:
-        - maxLength: 128
-          name: X-Forwarded-For
-----
-
-* To view the original client source IP address by using the `X-Forwarded-For` header in the `Ingress` access logs, see the "Capturing Original Client IP from the X-Forwarded-For Header in Ingress and Application Logs" Red{nbsp}Hat Knowledgebase solution.


### PR DESCRIPTION
Version(s):
4.16+

Issue:
[OSDOCS-18839](https://redhat.atlassian.net/browse/OSDOCS-18839)

Link to docs preview:

* https://109003--ocpdocs-pr.netlify.app/openshift-dedicated/latest/networking/networking_operators/ingress-operator.html
* https://109003--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/networking_operators/ingress-operator.html
* https://109003--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/networking/networking_operators/ingress-operator.html
* https://109003--ocpdocs-pr.netlify.app/openshift-rosa/latest/networking/networking_operators/ingress-operator.html

- [x] SME has approved this change (Ramesh Sahoo ).
- [x] QE has approved this change (Shudi LI).

Find reviewers on previous PR: https://github.com/openshift/openshift-docs/pull/79308 and https://github.com/openshift/openshift-docs/pull/97479