### PR TITLE
OCPBUGS-59598:Added leastconn example to nw-route-specific-annotation…

### DIFF
--- a/modules/nw-route-specific-annotations.adoc
+++ b/modules/nw-route-specific-annotations.adoc
@@ -82,6 +82,15 @@ metadata:
     haproxy.router.openshift.io/ip_allowlist: 192.168.1.10
 ----
 
+.A route that sets the load-balancing algorithm to leastconn
+[source,yaml]
+----
+metadata:
+  annotations:
+    haproxy.router.openshift.io/balance: leastconn
+----
+* The default load-balancing algorithm is `random`.
+
 .A route that allows several IP addresses
 [source,yaml]
 ----


### PR DESCRIPTION
Version(s):
4.16+

Issue:
[OCPBUGS-59598](https://redhat.atlassian.net/browse/OCPBUGS-59598)

Link to docs preview:

- [x] SME has approved this change (Ali Syed).
- [x] QE has approved this change (Hongan Li).

Preview

* https://109014--ocpdocs-pr.netlify.app/openshift-dedicated/latest/networking/ingress_load_balancing/routes/nw-configuring-routes.html
* https://109014--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ingress_load_balancing/routes/nw-configuring-routes.html
* https://109014--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/networking/ingress_load_balancing/routes/nw-configuring-routes.html
* https://109014--ocpdocs-pr.netlify.app/openshift-rosa/latest/networking/ingress_load_balancing/routes/nw-configuring-routes.html

Review mentioned on [Slack](https://redhat-internal.slack.com/archives/CCH60A77E/p1774447987221579)