### PR TITLE
PR for SRVCOM-4355: CQA + DITA readiness for assemblies and modules under the "Knative CLI" section

### DIFF
--- a/cli_tools/advanced-kn-config.adoc
+++ b/cli_tools/advanced-kn-config.adoc
@@ -1,39 +1,19 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="advanced-kn-config"]
 = Configuring the Knative CLI
-:context: advanced-kn-config
 include::_attributes/common-attributes.adoc[]
+:context: advanced-kn-config
 
 toc::[]
 
 [role="_abstract"]
-You can customize your Knative (`kn`) CLI setup by creating a `config.yaml` configuration file. You can provide this configuration by using the `--config` flag, otherwise the configuration is picked up from a default location. The default configuration location conforms to the https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html[XDG Base Directory Specification], and is different for UNIX systems and Windows systems.
+You can customize your Knative (`kn`) CLI setup by creating a `config.yaml` configuration file. You can give this configuration by using the `--config` flag, otherwise the CLI picks up the configuration from a default location. 
 
-For UNIX systems:
+The default configuration location conforms to the Cross-Desktop Group (XDG) Base Directory Specification, and is different for UNIX systems and Windows systems.
 
-* If the `XDG_CONFIG_HOME` environment variable is set, the default configuration location that the Knative (`kn`) CLI looks for is `$XDG_CONFIG_HOME/kn`.
+include::modules/serverless-kn-cli-config-locations-structures.adoc[leveloffset=+1]
 
-* If the `XDG_CONFIG_HOME` environment variable is not set, the Knative (`kn`) CLI looks for the configuration in the home directory of the user at `$HOME/.config/kn/config.yaml`.
+[role="_additional-resources"]
+== Additional resources
 
-For Windows systems, the default Knative (`kn`) CLI configuration location is `%APPDATA%\kn`.
-
-.Example configuration file
-[source,yaml]
-----
-plugins:
-  path-lookup: true <1>
-  directory: ~/.config/kn/plugins <2>
-eventing:
-  sink-mappings: <3>
-  - prefix: svc <4>
-    group: core <5>
-    version: v1 <6>
-    resource: services <7>
-----
-<1> Specifies whether the Knative (`kn`) CLI should look for plugins in the `PATH` environment variable. This is a boolean configuration option. The default value is `false`.
-<2> Specifies the directory where the Knative (`kn`) CLI looks for plugins. The default path depends on the operating system, as described previously. This can be any directory that is visible to the user.
-<3> The `sink-mappings` spec defines the Kubernetes addressable resource that is used when you use the `--sink` flag with a Knative (`kn`) CLI command.
-<4> The prefix you want to use to describe your sink. `svc` for a service, `channel`, and `broker` are predefined prefixes for the Knative (`kn`) CLI.
-<5> The API group of the Kubernetes resource.
-<6> The version of the Kubernetes resource.
-<7> The plural name of the Kubernetes resource type. For example, `services` or `brokers`.
+* link:https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html[XDG Base Directory Specification]

--- a/cli_tools/eventing_cli/kn-source.adoc
+++ b/cli_tools/eventing_cli/kn-source.adoc
@@ -10,8 +10,15 @@ toc::[]
 You can use the following commands to list, create, and manage Knative event sources.
 
 include::modules/serverless-list-source-types-kn.adoc[leveloffset=+1]
+
 include::modules/specifying-sink-flag-kn.adoc[leveloffset=+1]
+
 include::modules/serverless-kn-containersource.adoc[leveloffset=+1]
+
 include::modules/apiserversource-kn.adoc[leveloffset=+1]
+
 include::modules/serverless-pingsource-kn.adoc[leveloffset=+1]
+
+include::modules/serverless-deleting-pingsource.adoc[leveloffset=+1]
+
 include::modules/serverless-kafka-source-kn.adoc[leveloffset=+1]

--- a/cli_tools/functions_cli/kn-functions.adoc
+++ b/cli_tools/functions_cli/kn-functions.adoc
@@ -1,18 +1,28 @@
 :_mod-docs-content-type: ASSEMBLY
-include::_attributes/common-attributes.adoc[]
 [id="kn-functions"]
 = kn functions commands
+include::_attributes/common-attributes.adoc[]
 :context: kn-functions
 
 toc::[]
 
 [role="_abstract"]
+You can use the following commands to list, create, and manage Knative functions.
+
 include::modules/serverless-create-func-kn.adoc[leveloffset=+1]
+
 include::modules/serverless-kn-func-run.adoc[leveloffset=+1]
+
 include::modules/serverless-build-func-kn.adoc[leveloffset=+1]
+
 include::modules/serverless-deploy-func-kn.adoc[leveloffset=+1]
+
 include::modules/functions-list-kn.adoc[leveloffset=+1]
+
 include::modules/describe-function-kn.adoc[leveloffset=+1]
+
 include::modules/serverless-kn-func-invoke.adoc[leveloffset=+1]
+
 include::modules/serverless-kn-func-invoke-reference.adoc[leveloffset=+2]
+
 include::modules/serverless-kn-func-delete.adoc[leveloffset=+1]

--- a/cli_tools/kn-plugins.adoc
+++ b/cli_tools/kn-plugins.adoc
@@ -7,13 +7,8 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 [role="_abstract"]
-The Knative (`kn`) CLI supports the use of plugins, which enable you to extend the functionality of your `kn` installation by adding custom commands and other shared commands that are not part of the core distribution. Knative (`kn`) CLI plugins are used in the same way as the main `kn` functionality.
+The Knative (`kn`) CLI supports plugins. You can use plugins to extend your `kn` installation with custom commands and other shared commands that are not part of the core distribution. You use Knative (`kn`) CLI plugins in the same way as the main `kn` functionality. Currently, Red{nbsp}Hat supports the `kn-source-kafka` plugin and the `kn-event` plugin.
 
-Currently, Red Hat supports the `kn-source-kafka` plugin and the `kn-event` plugin.
-
-// kn event commands
-//Building events by using the kn-event plugin
 include::modules/serverless-build-events-kn.adoc[leveloffset=+1]
 
-//Sending events by using the kn-event plugin
 include::modules/serverless-send-events-kn.adoc[leveloffset=+1]

--- a/cli_tools/serving_cli/kn-container.adoc
+++ b/cli_tools/serving_cli/kn-container.adoc
@@ -1,12 +1,12 @@
 :_mod-docs-content-type: ASSEMBLY
-include::_attributes/common-attributes.adoc[]
 [id="kn-container"]
 = kn container commands
+include::_attributes/common-attributes.adoc[]
 :context: kn-container
 
 toc::[]
 
 [role="_abstract"]
-You can use the following commands to create and manage multiple containers in a Knative service spec.
+You can use the following commands to create and manage many containers in a Knative service spec.
 
 include::modules/serverless-kn-container.adoc[leveloffset=+1]

--- a/cli_tools/serving_cli/kn-domain.adoc
+++ b/cli_tools/serving_cli/kn-domain.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: ASSEMBLY
-include::_attributes/common-attributes.adoc[]
 [id="kn-domain"]
 = kn domain commands
+include::_attributes/common-attributes.adoc[]
 :context: kn-domain
 
 toc::[]
@@ -10,4 +10,5 @@ toc::[]
 You can use the following commands to create and manage domain mappings.
 
 include::modules/serverless-create-domain-mapping-kn.adoc[leveloffset=+1]
+
 include::modules/serverless-manage-domain-mapping-kn.adoc[leveloffset=+1]

--- a/cli_tools/serving_cli/kn-service-offline.adoc
+++ b/cli_tools/serving_cli/kn-service-offline.adoc
@@ -1,12 +1,14 @@
 :_mod-docs-content-type: ASSEMBLY
-include::_attributes/common-attributes.adoc[]
 [id="kn-service-offline"]
 = kn service commands in offline mode
+include::_attributes/common-attributes.adoc[]
 :context: kn-service-offline
 
 toc::[]
 
 [role="_abstract"]
-// offline mode
+Overview of `kn service` commands in offline mode for managing service configurations without cluster deployment.
+
 include::modules/kn-service-offline-about.adoc[leveloffset=+1]
+
 include::modules/kn-service-offline-create.adoc[leveloffset=+1]

--- a/cli_tools/serving_cli/kn-service.adoc
+++ b/cli_tools/serving_cli/kn-service.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: ASSEMBLY
-include::_attributes/common-attributes.adoc[]
 [id="kn-service"]
 = kn service commands
+include::_attributes/common-attributes.adoc[]
 :context: kn-service
 
 toc::[]
@@ -9,8 +9,10 @@ toc::[]
 [role="_abstract"]
 You can use the following commands to create and manage Knative services.
 
-
 include::modules/creating-serverless-apps-kn.adoc[leveloffset=+1]
+
 include::modules/kn-service-update.adoc[leveloffset=+1]
+
 include::modules/kn-service-apply.adoc[leveloffset=+1]
+
 include::modules/kn-service-describe.adoc[leveloffset=+1]

--- a/modules/apiserversource-kn.adoc
+++ b/modules/apiserversource-kn.adoc
@@ -27,7 +27,6 @@ include::snippets/serverless-service-account-apiserversource.adoc[]
 ----
 $ kn source apiserver create <event_source_name> --sink broker:<broker_name> --resource "event:v1" --service-account <service_account_name> --mode Resource
 ----
-// need to revisit these docs and give better tutorial examples with different sinks; out of scope for the current PR
 
 . To verify the API server source setup, create a Knative service that dumps incoming messages to its log.
 +
@@ -57,7 +56,8 @@ $ oc create deployment event-origin --image quay.io/openshift-knative/showcase
 $ kn source apiserver describe <source_name>
 ----
 +
-.Example output
+You get an output similar to the following example:
++
 [source,terminal]
 ----
 Name:                mysource
@@ -93,18 +93,19 @@ To verify that Kubernetes sends events to Knative, examine the `event-display` l
 $ kn service describe event-display -o url
 ----
 +
-.Example browser page
+The following example shows the browser page:
 +
 image::serverless-apiserversource-eventdisplay-gui.png[Example visualization of ApiServerSource event]
 
-* You can also see the logs in the terminal, view the event-display logs for the pods by entering the following command:
+* You can also see the logs in the terminal, view the event-display logs for the pods by running the following command:
 +
 [source,terminal]
 ----
 $ oc logs $(oc get pod -o name | grep event-display) -c user-container
 ----
 +
-.Example output
+You get an output similar to the following example:
++
 [source,terminal]
 ----
 ☁️  cloudevents.Event
@@ -136,8 +137,6 @@ Data,
     ...
   }
 ----
-
-.Deleting the API server source
 
 . Delete the trigger:
 +

--- a/modules/creating-serverless-apps-kn.adoc
+++ b/modules/creating-serverless-apps-kn.adoc
@@ -30,14 +30,16 @@ Where:
 ** `--image` is the URI of the image for the application.
 ** `--tag` is an optional flag that you can use to add a tag to the initial revision that Knative creates with the service.
 +
-.Example command
+You get an output similar to the following example command:
++
 [source,terminal]
 ----
 $ kn service create showcase \
     --image quay.io/openshift-knative/showcase
 ----
 +
-.Example output
+You get an output similar to the following example:
++
 [source,terminal]
 ----
 Creating service 'showcase' in namespace 'default':

--- a/modules/describe-function-kn.adoc
+++ b/modules/describe-function-kn.adoc
@@ -11,20 +11,22 @@ The `kn func info` command prints information about a deployed function, such as
 
 .Procedure
 
-* Describe a function:
+* Describe a function by running the following command:
 +
-[source,termnal]
+[source,terminal]
 ----
 $ kn func info [-f <format> -n <namespace> -p <path>]
 ----
 +
-.Example command
+You can run the following example command to display information about a function:
++
 [source,terminal]
 ----
 $ kn func info -p function/example-function
 ----
 +
-.Example output
+You get an output similar to the following example:
++
 [source,terminal]
 ----
 Function name:

--- a/modules/functions-list-kn.adoc
+++ b/modules/functions-list-kn.adoc
@@ -11,28 +11,30 @@ You can list existing functions by running `kn func list` command. To list funct
 
 .Procedure
 
-* List existing functions:
+* List existing functions by running the following command:
 +
 [source,terminal]
 ----
 $ kn func list [-n <namespace> -p <path>]
 ----
 +
-.Example output
+You get an output similar to the following example:
++
 [source,terminal]
 ----
 NAME           NAMESPACE  RUNTIME  URL                                                                                      READY
 example-function  default    node     http://example-function.default.apps.ci-ln-g9f36hb-d5d6b.origin-ci-int-aws.dev.rhcloud.com  True
 ----
 
-* List functions deployed as Knative services:
+* List functions deployed as Knative services by running the following command:
 +
 [source,terminal]
 ----
 $ kn service list -n <namespace>
 ----
 +
-.Example output
+You get an output similar to the following example:
++
 [source,terminal]
 ----
 NAME            URL                                                                                       LATEST                AGE   CONDITIONS   READY   REASON

--- a/modules/kn-service-apply.adoc
+++ b/modules/kn-service-apply.adoc
@@ -2,34 +2,32 @@
 //
 // * serverless/reference/kn-serving-ref.adoc
 
-:_mod-docs-content-type: REFERENCE
+:_mod-docs-content-type: PROCEDURE
 [id="kn-service-apply_{context}"]
 = Applying service declarations
 
 [role="_abstract"]
 Use the `kn service apply` command to declaratively configure a Knative service. If the service does not exist, the command creates it. If it exists, the command updates the service with the specified options.
 
-The `kn service apply` command works well in shell scripts or CI pipelines. In these environments, users often specify the complete service state in a single command.
+The `kn service apply` command works well in shell scripts or CI pipelines. In these environments, users often specify the complete service state in a single command. When you use `kn service apply`, give the full configuration for the Knative service. The `kn` service update command only requires the options that you want to change.
 
-When you use `kn service apply`, give the full configuration for the Knative service. The `kn` service update command only requires the options that you want to change.
+.Procedure
 
-.Example commands
-
-* Create a service:
+. Create a service by running the command:
 +
 [source,terminal]
 ----
 $ kn service apply <service_name> --image <image>
 ----
 
-* Add an environment variable to a service:
+. Add an environment variable to a service by running the command:
 +
 [source,terminal]
 ----
 $ kn service apply <service_name> --image <image> --env <key>=<value>
 ----
 
-* Read the service declaration from a JSON or YAML file:
+. Read the service declaration from a JSON or YAML file by running the command:
 +
 [source,terminal]
 ----

--- a/modules/kn-service-describe.adoc
+++ b/modules/kn-service-describe.adoc
@@ -2,16 +2,16 @@
 //
 // * serverless/reference/kn-serving-ref.adoc
 
-:_mod-docs-content-type: REFERENCE
+:_mod-docs-content-type: PROCEDURE
 [id="kn-service-describe_{context}"]
 = Describing serverless applications by using the Knative CLI
 
 [role="_abstract"]
 You can describe a Knative service by using the `kn service describe` command.
 
-.Example commands
+.Procedure
 
-* Describe a service:
+. Describe a service by running the command:
 +
 [source,terminal]
 ----
@@ -20,7 +20,8 @@ $ kn service describe --verbose <service_name>
 +
 The `--verbose` flag is optional and provides a more detailed description. The following examples show the difference between regular and verbose output:
 +
-.Example output without `--verbose` flag
+You get an output similar to the following example:
++
 [source,terminal]
 ----
 Name:       showcase
@@ -39,7 +40,8 @@ Conditions:
   ++ RoutesReady             1m
 ----
 +
-.Example output with `--verbose` flag
+You get an output similar to the following example:
++
 [source,terminal]
 ----
 Name:         showcase
@@ -62,21 +64,21 @@ Conditions:
   ++ RoutesReady             3m
 ----
 
-* Describe a service in YAML format:
+. Describe a service in YAML format by running the command:
 +
 [source,terminal]
 ----
 $ kn service describe <service_name> -o yaml
 ----
 
-* Describe a service in JSON format:
+. Describe a service in JSON format by running the command:
 +
 [source,terminal]
 ----
 $ kn service describe <service_name> -o json
 ----
 
-* Print the service URL only:
+. Print the service URL only by running the command:
 +
 [source,terminal]
 ----

--- a/modules/kn-service-offline-about.adoc
+++ b/modules/kn-service-offline-about.adoc
@@ -13,7 +13,6 @@ When you run `kn service` commands, the changes immediately propagate to the clu
 include::snippets/technology-preview.adoc[leveloffset=+1]
 
 After you create the descriptor file, you can manually change it and track it in a version control system. You can also propagate changes to the cluster by running `kn service create -f`, `kn service apply -f`, or `oc apply -f` on the descriptor file.
-// Once `update` works, add it here and make it into a list
 
 The offline mode has several uses:
 

--- a/modules/kn-service-offline-create.adoc
+++ b/modules/kn-service-offline-create.adoc
@@ -30,7 +30,8 @@ $ kn service create showcase \
     --namespace test
 ----
 +
-.Example output
+You get an output similar to the following example:
++
 [source,terminal]
 ----
 Service 'showcase' created in namespace 'test'.
@@ -53,7 +54,8 @@ If you do not use `--namespace` and you log in to an {ocp-product-title} cluster
 $ tree ./
 ----
 +
-.Example output
+You get an output similar to the following example:
++
 [source,terminal]
 ----
 ./
@@ -75,7 +77,8 @@ $ tree ./
 $ cat test/ksvc/showcase.yaml
 ----
 +
-.Example output
+You get an output similar to the following example:
++
 [source,yaml]
 ----
 apiVersion: serving.knative.dev/v1
@@ -105,7 +108,8 @@ status: {}
 $ kn service describe showcase --target ./ --namespace test
 ----
 +
-.Example output
+You get an output similar to the following example:
++
 [source,terminal]
 ----
 Name:       showcase
@@ -134,7 +138,8 @@ If you do not use `--namespace` and you log in to an {ocp-product-title} cluster
 $ kn service create -f test/ksvc/showcase.yaml
 ----
 +
-.Example output
+You get an output similar to the following example:
++
 [source,terminal]
 ----
 Creating service 'showcase' in namespace 'test':

--- a/modules/kn-service-update.adoc
+++ b/modules/kn-service-update.adoc
@@ -2,51 +2,51 @@
 //
 // * serverless/reference/kn-serving-ref.adoc
 
-:_mod-docs-content-type: REFERENCE
+:_mod-docs-content-type: PROCEDURE
 [id="kn-service-update_{context}"]
 = Updating serverless applications by using the Knative CLI
 
 [role="_abstract"]
 You can use the `kn service update` command for interactive sessions on the command line as you build up a service incrementally. In contrast to the `kn service apply` command, when using the `kn service update` command you only have to specify the changes that you want to update, rather than the full configuration for the Knative service.
 
-.Example commands
+.Procedure
 
-* Update a service by adding a new environment variable:
+. Update a service by adding a new environment variable by running the command:
 +
 [source,terminal]
 ----
 $ kn service update <service_name> --env <key>=<value>
 ----
 
-* Update a service by adding a new port:
+. Update a service by adding a new port by running the command:
 +
 [source,terminal]
 ----
 $ kn service update <service_name> --port 80
 ----
 
-* Update a service by adding new request and limit parameters:
+. Update a service by adding new request and limit parameters by running the command:
 +
 [source,terminal]
 ----
 $ kn service update <service_name> --request cpu=500m --limit memory=1024Mi --limit cpu=1000m
 ----
 
-* Assign the `latest` tag to a revision:
+. Assign the `latest` tag to a revision by running the command:
 +
 [source,terminal]
 ----
 $ kn service update <service_name> --tag <revision_name>=latest
 ----
 
-* Update a tag from `testing` to `staging` for the latest `READY` revision of a service:
+. Update a tag from `testing` to `staging` for the latest `READY` revision of a service by running the command:
 +
 [source,terminal]
 ----
 $ kn service update <service_name> --untag testing --tag @latest=staging
 ----
 
-* Add the `test` tag to a revision that receives 10% of traffic, and send the rest of the traffic to the latest `READY` revision of a service:
+. Add the `test` tag to a revision that receives 10% of traffic, and send the rest of the traffic to the latest `READY` revision of a service:
 +
 [source,terminal]
 ----

--- a/modules/serverless-build-events-kn.adoc
+++ b/modules/serverless-build-events-kn.adoc
@@ -1,4 +1,6 @@
 // Module included in the following assemblies:
+//
+//cli_tools/kn-plugins.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="serverless-build-events-kn_{context}"]
@@ -27,13 +29,15 @@ where:
 +
 All of these flags are optional.
 +
-.Building a simple event
+Run the following command to build an event:
++
 [source,terminal]
 ----
 $ kn event build -o yaml
 ----
 +
-.Resultant event in the YAML format
+The following example shows the event in YAML format:
++
 [source,yaml]
 ----
 data: {}
@@ -45,7 +49,8 @@ time: "2021-10-15T10:42:57.713226203Z"
 type: dev.knative.cli.plugin.event.generic
 ----
 +
-.Building a sample transaction event
+Run the following command to build a sample transaction event:
++
 [source,terminal]
 ----
 $ kn event build \
@@ -60,7 +65,8 @@ $ kn event build \
     --output json
 ----
 +
-.Resultant event in the JSON format
+The following example shows the event in JSON format:
++
 [source,json]
 ----
 {

--- a/modules/serverless-build-func-kn.adoc
+++ b/modules/serverless-build-func-kn.adoc
@@ -16,7 +16,8 @@ You can run the kn func build command to create an OCI container image that you 
 
 By default, `kn func build` creates a container image by using Red Hat Source-to-Image (S2I) technology.
 
-.Example build command by using Red Hat Source-to-Image (S2I)
+You can build a function by using Red{nbsp}Hat Source-to-Image (S2I):
+
 [source,terminal]
 ----
 $ kn func build
@@ -27,13 +28,14 @@ $ kn func build
 
 By default, the system stores function images in the OpenShift Container Registry.
 
-.Example build command by using OpenShift Container Registry
+You can build a function by using the OpenShift Container Registry:
+
 [source,terminal]
 ----
 $ kn func build
 ----
 
-.Example output
+You get an output similar to the following example:
 [source,terminal]
 ----
 Building function image
@@ -42,13 +44,13 @@ Function image has been built, image: registry.redhat.io/example/example-functio
 
 You can override using OpenShift Container Registry as the default image registry by using the `--registry` flag:
 
-.Example build command overriding OpenShift Container Registry to use quay.io
 [source,terminal]
 ----
 $ kn func build --registry quay.io/username
 ----
 
-.Example output
+You get an output similar to the following example:
+
 [source,terminal]
 ----
 Building function image
@@ -60,7 +62,6 @@ Function image has been built, image: quay.io/username/example-function:latest
 
 You can add the `--push` flag to a `kn func build` command to automatically push the function image after it is successfully built:
 
-.Example build command by using OpenShift Container Registry
 [source,terminal]
 ----
 $ kn func build --push
@@ -71,7 +72,6 @@ $ kn func build --push
 
 You can use the help command to learn more about `kn func build` command options:
 
-.Build help command
 [source,terminal]
 ----
 $ kn func help build

--- a/modules/serverless-create-domain-mapping-kn.adoc
+++ b/modules/serverless-create-domain-mapping-kn.adoc
@@ -14,11 +14,7 @@ You can use Knative CLI to map custom domains to Knative services or routes and 
 
 * You have installed the {ServerlessOperatorName} and Knative Serving on your cluster.
 * You have created a Knative service or route, and control a custom domain that you want to map to that CR.
-+
-[NOTE]
-====
-Your custom domain must point to the DNS of the {ocp-product-title} cluster.
-====
+* Your custom domain must point to the DNS of the {ocp-product-title} cluster.
 * You have installed the Knative (`kn`) CLI.
 * You have created a project or have access to a project with the appropriate roles and permissions to create applications and other workloads in {ocp-product-title}.
 
@@ -31,7 +27,8 @@ Your custom domain must point to the DNS of the {ocp-product-title} cluster.
 $ kn domain create <domain_mapping_name> --ref <target_name>
 ----
 +
-.Example command
+You get an output similar to the following example command:
++
 [source,terminal]
 ----
 $ kn domain create example.com --ref showcase
@@ -48,7 +45,8 @@ If you do not give a prefix when using the `--ref` flag, the system treats the t
 $ kn domain create <domain_mapping_name> --ref <ksvc:service_name:service_namespace>
 ----
 +
-.Example command
+You get an output similar to the following example command:
++
 [source,terminal]
 ----
 $ kn domain create example.com --ref ksvc:showcase:example-namespace
@@ -61,7 +59,8 @@ $ kn domain create example.com --ref ksvc:showcase:example-namespace
 $ kn domain create <domain_mapping_name> --ref <kroute:route_name>
 ----
 +
-.Example command
+You get an output similar to the following example command:
++
 [source,terminal]
 ----
 $ kn domain create example.com --ref kroute:example-route

--- a/modules/serverless-create-func-kn.adoc
+++ b/modules/serverless-create-func-kn.adoc
@@ -17,7 +17,7 @@ You can specify the path, runtime, template, and image registry for a function a
 
 .Procedure
 
-* Create a function project:
+. Create a function project:
 +
 [source,terminal]
 ----
@@ -26,21 +26,24 @@ $ kn func create -r <repository> -l <runtime> -t <template> <path>
 ** Accepted runtime values include `quarkus`, `node`, `typescript`, `go`, `python`, `springboot`, and `rust`.
 ** Accepted template values include `http` and `cloudevents`.
 +
-.Example command
+You get an output similar to the following example:
++
 [source,terminal]
 ----
 $ kn func create -l typescript -t cloudevents examplefunc
 ----
 +
-.Example output
+You get an output similar to the following example:
++
 [source,terminal]
 ----
 Created typescript function in /home/user/demo/examplefunc
 ----
+
+. Specify a repository that has a custom template.
 +
-** You can also specify a repository that has a custom template.
+You get an output similar to the following example:
 +
-.Example command
 [source,terminal]
 ----
 $ $ kn func create -r <templates_repository> -l node -t hello-world examplefunc
@@ -48,7 +51,8 @@ $ $ kn func create -r <templates_repository> -l node -t hello-world examplefunc
 +
 Replace <templates_repository> with the repository that has the function templates.
 +
-.Example output
+You get an output similar to the following example:
++
 [source,terminal]
 ----
 Created node function in /home/user/demo/examplefunc

--- a/modules/serverless-deleting-pingsource.adoc
+++ b/modules/serverless-deleting-pingsource.adoc
@@ -1,0 +1,37 @@
+// Module included in the following assemblies:
+//
+// * serverless/eventing/event-sources/serverless-pingsource.adoc
+// * serverless/reference/kn-eventing-ref.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="serverless-deleting-pingsource_{context}"]
+= Deleting a ping source
+
+[role="_abstract"]
+You can delete an existing ping source by using the Knative (kn) CLI command.
+
+.Prerequisites
+
+* You have installed the Knative (`kn`) CLI.
+* You have access to a cluster with the required permissions.
+* The ping source exists in your namespace.
+
+.Procedure
+
+* Delete the ping source by running the following command:
++
+[source,terminal]
+----
+$ kn delete pingsources.sources.knative.dev <ping_source_name>
+----
+
+.Verification
+
+. Verify that the ping source no longer exists by running the following command:
++
+[source,terminal]
+----
+$ kn get pingsources.sources.knative.dev
+----
+
+. Confirm that the deleted ping source is not listed in the output.

--- a/modules/serverless-deploy-func-kn.adoc
+++ b/modules/serverless-deploy-func-kn.adoc
@@ -25,7 +25,8 @@ You can deploy a function to your cluster as a Knative service by using the kn f
 $ kn func deploy [-n <namespace> -p <path> -i <image>]
 ----
 +
-.Example output
+You get an output similar to the following example:
++
 [source,terminal]
 ----
 Function deployed at: http://func.example.com

--- a/modules/serverless-kafka-source-kn.adoc
+++ b/modules/serverless-kafka-source-kn.adoc
@@ -12,7 +12,7 @@ You can use the `kn source kafka create` command to create a Kafka source by usi
 
 .Prerequisites
 
-* The {ServerlessOperatorName}, Knative Eventing, Knative Serving, and the `KnativeKafka` custom resource (CR) are installed on your cluster.
+* You have installed the {ServerlessOperatorName}, Knative Eventing, Knative Serving, and the `KnativeKafka` custom resource (CR) on your cluster.
 * You have created a project or have access to a project with the appropriate roles and permissions to create applications and other workloads in {ocp-product-title}.
 * You have access to a Red Hat AMQ Streams (Kafka) cluster that produces the Kafka messages you want to import.
 * You have installed the Knative (`kn`) CLI.
@@ -52,7 +52,8 @@ The `--servers`, `--topics`, and `--consumergroup` options specify the connectio
 $ kn source kafka describe <kafka_source_name>
 ----
 +
-.Example output
+You get an output similar to the following example:
++
 [source, terminal]
 ----
 Name:              example-kafka-source
@@ -74,7 +75,7 @@ Conditions:
   ++ SinkProvided     1h
 ----
 
-.Verification steps
+.Verification
 
 . Trigger the Kafka instance to send a message to the topic:
 +
@@ -88,8 +89,8 @@ $ oc -n kafka run kafka-producer \
 +
 Enter the message in the prompt. This command assumes that:
 +
-* The Kafka cluster is installed in the `kafka` namespace.
-* The `KafkaSource` object has been configured to use the `my-topic` topic.
+* The Kafka cluster is now installed in the `kafka` namespace.
+* The `KafkaSource` object is now configured to use the `my-topic` topic.
 
 . Verify that the message arrived by viewing the logs:
 +
@@ -98,7 +99,8 @@ Enter the message in the prompt. This command assumes that:
 $ oc logs $(oc get pod -o name | grep event-display) -c user-container
 ----
 +
-.Example output
+You get an output similar to the following example:
++
 [source,terminal]
 ----
 ☁️  cloudevents.Event

--- a/modules/serverless-kn-cli-config-locations-structures.adoc
+++ b/modules/serverless-kn-cli-config-locations-structures.adoc
@@ -1,0 +1,36 @@
+:_mod-docs-content-type: CONCEPT
+[id="serverless-kn-cli-config-locations-structures_{context}"]
+= Knative CLI configuration file locations and structure
+
+[role="_abstract"]
+Default configuration file locations for the Knative (`kn`) CLI across different operating systems and an overview of the configuration file structure and key fields.
+
+For UNIX systems:
+
+* If the `XDG_CONFIG_HOME` environment variable is set, the default configuration location that the Knative (`kn`) CLI looks for is `$XDG_CONFIG_HOME/kn`.
+
+* If the `XDG_CONFIG_HOME` environment variable is not set, the Knative (`kn`) CLI looks for the configuration in the home directory of the user at `$HOME/.config/kn/config.yaml`.
+
+For Windows systems, the default Knative (`kn`) CLI configuration location is `%APPDATA%\kn`.
+
+You get an output similar to the following example:
+[source,yaml]
+----
+plugins:
+  path-lookup: true
+  directory: ~/.config/kn/plugins
+eventing:
+  sink-mappings:
+  - prefix: svc
+    group: core
+    version: v1
+    resource: services
+----
+
+`plugins.path-lookup`:: Specifies whether the Knative (`kn`) CLI should look for plugins in the `PATH` environment variable. This is a boolean configuration option. The default value is `false`.
+`plugins.directory`:: Specifies the directory where the Knative (`kn`) CLI looks for plugins. The default path depends on the operating system, as described earlier. This can be any directory that is visible to the user.
+`eventing.sink-mappings`:: The `sink-mappings` spec defines the Kubernetes addressable resource that is used when you use the `--sink` flag with a Knative (`kn`) CLI command.
+`sink-mappings.prefix`:: The prefix you want to use to describe your sink. `svc` for a service, `channel`, and `broker` are predefined prefixes for the Knative (`kn`) CLI.
+`sink-mappings.group`:: The API group of the Kubernetes resource.
+`sink-mappings.version`:: The version of the Kubernetes resource.
+`sink-mappings.resource`:: The plural name of the Kubernetes resource type. For example, `services` or `brokers`.

--- a/modules/serverless-kn-container.adoc
+++ b/modules/serverless-kn-container.adoc
@@ -7,28 +7,30 @@
 = Knative client multi-container support
 
 [role="_abstract"]
-You can use the `kn container add` command to print YAML container spec to standard output. This command is useful for multi-container use cases because it can be used along with other standard `kn` flags to create definitions.
+You can use the `kn container` add command to print the YAML container specification to standard output. Use this command for multi-container use cases and combine it with other `kn` flags to create definitions.
 
-The `kn container add` command accepts all container-related flags that are supported for use with the `kn service create` command. The `kn container add` command can also be chained by using UNIX pipes (`|`) to create multiple container definitions at once.
+The `kn container add` command accepts all container-related flags that the `kn service create` command supports. You can also chain the `kn container add` command by using UNIX pipes (`|`) to create many container definitions.
 
 [discrete]
 [id="serverless-kn-container-examples_{context}"]
 == Example commands
 
-* Add a container from an image and print it to standard output:
+* You can add a container from an image and print it to standard output:
 +
 [source,terminal]
 ----
 $ kn container add <container_name> --image <image_uri>
 ----
 +
-.Example command
+You get an output similar to the following example command:
++
 [source,terminal]
 ----
 $ kn container add sidecar --image docker.io/example/sidecar
 ----
 +
-.Example output
+You get an output similar to the following example:
++
 [source,terminal]
 ----
 containers:
@@ -37,7 +39,7 @@ containers:
   resources: {}
 ----
 
-* Chain two `kn container add` commands together, and then pass them to a `kn service create` command to create a Knative service with two containers:
+* You can chain two `kn container add` commands together, and then pass them to a `kn service create` command to create a Knative service with two containers:
 +
 [source,terminal]
 ----
@@ -48,7 +50,8 @@ kn service create <service_name> --image <image_uri> --extra-containers -
 +
 `--extra-containers -` specifies a special case where `kn` reads the pipe input instead of a YAML file.
 +
-.Example command
+You get an output similar to the following example command:
++
 [source,terminal]
 ----
 $ kn container add sidecar --image docker.io/example/sidecar:first | \
@@ -63,7 +66,8 @@ The `--extra-containers` flag can also accept a path to a YAML file:
 $ kn service create <service_name> --image <image_uri> --extra-containers <filename>
 ----
 +
-.Example command
+You get an output similar to the following example command:
++
 [source,terminal]
 ----
 $ kn service create my-service --image docker.io/example/my-app:latest --extra-containers my-extra-containers.yaml

--- a/modules/serverless-kn-containersource.adoc
+++ b/modules/serverless-kn-containersource.adoc
@@ -3,49 +3,54 @@
 // * serverless/eventing/event-sources/serverless-custom-event-sources.adoc
 // * serverless/reference/kn-eventing-ref.adoc
 
-:_mod-docs-content-type: REFERENCE
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-kn-containersource_{context}"]
 = Creating and managing container sources by using the Knative CLI
 
 [role="_abstract"]
-// needs to be revised as separate procedure modules; out of scope for this PR
-
 You can use the `kn source container` commands to create  and manage container sources by using the Knative (`kn`) CLI. Using the Knative CLI to create event sources provides a more streamlined and intuitive user interface than modifying YAML files directly. 
 
-.Create a container source
+.Procedure
+
+. Create a container source by running the folloing command:
 [source,terminal]
++
 ----
 $ kn source container create <container_source_name> --image <image_uri> --sink <sink>
 ----
 
-.Delete a container source
+. Delete a container source by running the folloing command:
++
 [source,terminal]
 ----
 $ kn source container delete <container_source_name>
 ----
 
-.Describe a container source
+. Describe a container source by running the folloing command:
++
 [source,terminal]
 ----
 $ kn source container describe <container_source_name>
 ----
 
-.List existing container sources
+. List existing container sources by running the folloing command:
++
 [source,terminal]
 ----
 $ kn source container list
 ----
 
-.List existing container sources in YAML format
+. List existing container sources in YAML format by running the folloing command:
++
 [source,terminal]
 ----
 $ kn source container list -o yaml
 ----
 
-.Update a container source
-
+. Update a container source by running the folloing command:
++
 This command updates the image URI for an existing container source:
-
++
 [source,terminal]
 ----
 $ kn source container update <container_source_name> --image <image_uri>

--- a/modules/serverless-kn-func-invoke-reference.adoc
+++ b/modules/serverless-kn-func-invoke-reference.adoc
@@ -44,7 +44,7 @@ Event data (`--data`):: Allows you to specify a `data` value for the event sent 
 Functions that have been deployed to a cluster can respond to events from an existing event source that provides values for properties such as `source` and `type`. These events often have a `data` value in JSON format, which captures the domain specific context of the event. By using the CLI flags noted in this document, developers can simulate those events for local testing.
 ====
 +
-You can also send event data using the `--file` flag to provide a local file containing data for the event. In this case, specify the content type using `--content-type`.
+You can also send event data by using the `--file` flag to provide a local file containing data for the event. In this case, specify the content type by using `--content-type`.
 Data content type (`--content-type`):: If you are using the `--data` flag to add data for events, you can use the `--content-type` flag to specify what type of data is carried by the event. In the previous example, the data is plain text, so you might specify `kn func invoke --data "Hello world!" --content-type "text/plain"`.
 
 [id="serverless-kn-func-invoke-example-commands_{context}"]

--- a/modules/serverless-kn-func-invoke.adoc
+++ b/modules/serverless-kn-func-invoke.adoc
@@ -12,14 +12,14 @@ You can use the `kn func invoke` CLI command to send a test request to invoke a 
 
 .Prerequisites
 
-* The {ServerlessOperatorName} and Knative Serving are installed on the cluster.
+* You have installed the {ServerlessOperatorName} and Knative Serving on the cluster.
 * You have installed the Knative (`kn`) CLI.
 * You have created a project or have access to a project with the appropriate roles and permissions to create applications and other workloads in {ocp-product-title}.
-* You must have already deployed the function that you want to invoke.
+* You must have already deployed the function that you want to call.
 
 .Procedure
 
-* Invoke a function:
+* Start a function:
 +
 [source,terminal]
 ----

--- a/modules/serverless-kn-func-run.adoc
+++ b/modules/serverless-kn-func-run.adoc
@@ -8,15 +8,19 @@
 = Running a function locally
 
 [role="_abstract"]
-You can use the `kn func run` command to run a function locally in the current directory or in the directory specified by the `--path` flag. If the function that you are running has never previously been built, or if the project files have been modified since the last time it was built, the `kn func run` command builds the function before running it by default.
+You can run a function locally by using the `kn func` run command in the current directory or by specifying a directory with the `--path` flag.
 
-.Example command to run a function in the current directory
+If you run the function for the first time, or if you change the project files, the `kn func run` command builds the function before running it.
+
+You can run a function in the current directory by using the following command:
+
 [source,terminal]
 ----
 $ kn func run
 ----
 
-.Example command to run a function in a directory specified as a path
+You can run a function in a specific directory by specifying the path with the `--path` flag:
+
 [source,terminal]
 ----
 $ kn func run --path=<directory_path>
@@ -24,15 +28,17 @@ $ kn func run --path=<directory_path>
 
 You can also force a rebuild of an existing image before running the function, even if there have been no changes to the project files, by using the `--build` flag:
 
-.Example run command using the build flag
+You can run a function and trigger a build by using the `--build` flag:
+
 [source,terminal]
 ----
 $ kn func run --build
 ----
 
-If you set the `build` flag as false, this disables building of the image, and runs the function using the previously built image:
+If you set the `build` flag as false, this disables building of the image, and runs the function by using the previously built image:
 
-.Example run command using the build flag
+You can run a function without building it by using the `--build=false` flag:
+
 [source,terminal]
 ----
 $ kn func run --build=false

--- a/modules/serverless-list-source-types-kn.adoc
+++ b/modules/serverless-list-source-types-kn.adoc
@@ -7,11 +7,11 @@
 = Listing available event source types by using the Knative CLI
 
 [role="_abstract"]
-You can list event source types that can be created and used on your cluster by using the `kn source list-types` CLI command.
+You can list event source types that you can create and use on your cluster by using the `kn source list-types` CLI command.
 
 .Prerequisites
 
-* The {ServerlessOperatorName} and Knative Eventing are installed on the cluster.
+* You have installed the {ServerlessOperatorName} and Knative Eventing on the cluster.
 * You have installed the Knative (`kn`) CLI.
 
 .Procedure
@@ -23,7 +23,8 @@ You can list event source types that can be created and used on your cluster by 
 $ kn source list-types
 ----
 +
-.Example output
+You get an output similar to the following example:
++
 [source,terminal]
 ----
 TYPE              NAME                                            DESCRIPTION
@@ -39,5 +40,3 @@ SinkBinding       sinkbindings.sources.knative.dev                Binding for co
 ----
 $ kn source list-types -o yaml
 ----
-
-// optional step not allowed yet for OSD due to upstream https://github.com/knative/client/issues/1385

--- a/modules/serverless-manage-domain-mapping-kn.adoc
+++ b/modules/serverless-manage-domain-mapping-kn.adoc
@@ -11,35 +11,35 @@ After you have created a `DomainMapping` custom resource (CR), you can list exis
 
 .Prerequisites
 
-* The {ServerlessOperatorName} and Knative Serving are installed on your cluster.
+* You have installed the {ServerlessOperatorName} and Knative Serving on your cluster.
 * You have created at least one `DomainMapping` CR.
 * You have installed the Knative (`kn`) CLI tool.
 * You have created a project or have access to a project with the appropriate roles and permissions to create applications and other workloads in {ocp-product-title}.
 
 .Procedure
 
-* List existing `DomainMapping` CRs:
+. List existing `DomainMapping` CRs:
 +
 [source,terminal]
 ----
 $ kn domain list -n <domain_mapping_namespace>
 ----
 
-* View details of an existing `DomainMapping` CR:
+. View details of an existing `DomainMapping` CR:
 +
 [source,terminal]
 ----
 $ kn domain describe <domain_mapping_name>
 ----
 
-* Update a `DomainMapping` CR to point to a new target:
+. Update a `DomainMapping` CR to point to a new target:
 +
 [source,terminal]
 ----
 $ kn domain update --ref <target>
 ----
 
-* Delete a `DomainMapping` CR:
+. Delete a `DomainMapping` CR:
 +
 [source,terminal]
 ----

--- a/modules/serverless-pingsource-kn.adoc
+++ b/modules/serverless-pingsource-kn.adoc
@@ -12,7 +12,7 @@ You can use the `kn source ping create` command to create a ping source by using
 
 .Prerequisites
 
-* The {ServerlessOperatorName}, Knative Serving and Knative Eventing are installed on the cluster.
+* You have installed the {ServerlessOperatorName}, Knative Serving and Knative Eventing on the cluster.
 * You have installed the Knative (`kn`) CLI.
 * You have created a project or have access to a project with the appropriate roles and permissions to create applications and other workloads in {ocp-product-title}.
 * Optional: If you want to use the verification steps for this procedure, install the OpenShift CLI (`oc`).
@@ -45,7 +45,8 @@ $ kn source ping create test-ping-source \
 $ kn source ping describe test-ping-source
 ----
 +
-.Example output
+You get an output similar to the following example:
++
 [source,terminal]
 ----
 Name:         test-ping-source
@@ -72,10 +73,10 @@ Conditions:
 
 .Verification
 
-You can verify that the Kubernetes events were sent to the Knative event sink by looking at the logs of the sink pod.
+You can verify that the Kubernetes events reached the Knative event sink by checking the logs of the sink pod.
 
-By default, Knative services terminate their pods if no traffic is received within a 60 second period.
-The example shown in this guide creates a ping source that sends a message every 2 minutes, so each message should be observed in a newly created pod.
+By default, Knative services cancel pods if they do not receive traffic within 60 seconds.
+The example in this guide creates a ping source that sends a message every 2 minutes, so each message is displayed in a newly created pod.
 
 . Watch for new pods created:
 +
@@ -84,7 +85,7 @@ The example shown in this guide creates a ping source that sends a message every
 $ watch oc get pods
 ----
 
-. Cancel watching the pods using Ctrl+C, then look at the logs of the created pod:
+. Cancel watching the pods using Ctrl+C, then check the logs of the created pod:
 +
 [source,terminal]
 ----
@@ -109,12 +110,3 @@ Data,
   }
 ----
 
-.Deleting the ping source
-// move to a separate procedure, out of scope for this PR
-
-* Delete the ping source:
-+
-[source,terminal]
-----
-$ kn delete pingsources.sources.knative.dev <ping_source_name>
-----

--- a/modules/serverless-send-events-kn.adoc
+++ b/modules/serverless-send-events-kn.adoc
@@ -3,7 +3,7 @@
 = Sending events by using the kn-event plugin
 
 [role="_abstract"]
-You can use the `kn event send` command to send an event. The events can be sent either to publicly available addresses or to addressable resources inside a cluster, such as Kubernetes services, as well as Knative services, brokers, and channels. The command uses the same builder-like interface as the `kn event build` command.
+You can use the `kn event send` command to send an event. The events can be sent either to publicly available addresses or to addressable resources inside a cluster, such as Kubernetes services, and Knative services, brokers, and channels. The command uses the same builder-like interface as the `kn event build` command.
 
 .Prerequisites
 
@@ -24,7 +24,7 @@ $ kn event send \
 ----
 where:
 ** The `--field` flag adds data to the event as a field-value pair. You can use it multiple times.
-** The `--type` flag enables you to specify a string that designates the type of the event.
+** The `--type` flag specifies a string that designates the type of the event.
 ** The `--id` flag specifies the ID of the event.
 ** The `--to` flag specifies the destination of the event.
 ** The `--namespace` flag specifies the namespace. If omitted, the namespace is taken from the current context.
@@ -43,7 +43,7 @@ You can use the following destination formats for the `--to` flag:
 * `--to special.eventing.dev/v1alpha1/channels:<channel>`: Specifies `GroupVersionResource` of `v1alpha1` channel
 * `--to \https://example.receiver.uri`: Specifies an HTTP URL
 
-If you do not provide a prefix, the destination defaults to a Knative service in the current namespace.
+If you do not give a prefix, the destination defaults to a Knative service in the current namespace.
 ====
 
 .Sending an event to a URL

--- a/modules/specifying-sink-flag-kn.adoc
+++ b/modules/specifying-sink-flag-kn.adoc
@@ -15,13 +15,15 @@ When you create an event source by using the Knative (`kn`) CLI, you can specify
 
 The following example creates a sink binding that uses a service, `\http://event-display.svc.cluster.local`, as the sink:
 
-.Example command using the sink flag
+You get an output similar to the following example:
+
 [source,terminal]
 ----
 $ kn source binding create bind-heartbeat \
   --namespace sinkbinding-example \
   --subject "Job:batch/v1:app=heartbeat-cron" \
-  --sink http://event-display.svc.cluster.local \ <1>
+  --sink http://event-display.svc.cluster.local \
   --ce-override "sink=bound"
 ----
-<1> `svc` in `\http://event-display.svc.cluster.local` determines that the sink is a Knative service. Other default sink prefixes include `channel`, and `broker`.
+
+`svc` in `\http://event-display.svc.cluster.local` determines that the sink is a Knative service. Other default sink prefixes include `channel`, and `broker`.


### PR DESCRIPTION
**You can cherry-pick for the following branches:** 
- `serverless-docs-1.37`
- `serverless-docs-1.38`

**Note for the peer & merge reviewer:** 
- This PR updates the only "Knative CLI" section to prepare it for Phase 0 DITA migration.
- No other CQA changes, error types, or content refinements are included. 

**Changes:** 
This PR prepares the "Knative CLI" section for Phase 0 DITA migration by applying Vale (AsciiDoc DITA) rules and cleaning up the existing content.

Doc preview: https://109034--ocpdocs-pr.netlify.app/openshift-serverless/latest/cli_tools/eventing_cli/kn-source.html

**Tracking JIRA:** https://redhat.atlassian.net/browse/SRVCOM-4313

**Reviews:**
- [x] Peer has approved this change