### PR TITLE
[enterprise-4.16] Add cert-manager operator release note 1.17.1

### DIFF
--- a/security/cert_manager_operator/cert-manager-operator-release-notes.adoc
+++ b/security/cert_manager_operator/cert-manager-operator-release-notes.adoc
@@ -13,6 +13,105 @@ These release notes track the development of {cert-manager-operator}.
 
 For more information, see xref:../../security/cert_manager_operator/index.adoc#cert-manager-operator-about[About the {cert-manager-operator}].
 
+[id="cert-manager-operator-release-notes-1-18-1_{context}"]
+== {cert-manager-operator} 1.18.1
+
+Issued: 2026-01-26
+
+The following advisories are available for the {cert-manager-operator} 1.18.1:
+
+* link:https://access.redhat.com/errata/RHSA-2026:1166[RHSA-2026:1166]
+* link:https://access.redhat.com/errata/RHSA-2026:1168[RHSA-2026:1168]
+* link:https://access.redhat.com/errata/RHSA-2026:1176[RHSA-2026:1176]
+* link:https://access.redhat.com/errata/RHBA-2026:1319[RHBA-2026:1319]
+
+Version `1.18.1` of the {cert-manager-operator} is based on the upstream cert-manager version `v1.18.4`. For more information, see the link:https://cert-manager.io/docs/releases/release-notes/release-notes-1.18/#v1184[cert-manager project release notes for v1.18.4].
+
+[id="cert-manager-operator-1-18-1-features-enhancements_{context}"]
+=== New features and enhancements
+
+The final images use `ubi9-minimal` as base images::
+With this update, the {cert-manager-operator} images use ubi9-minimal as their base images providing improved security compliance. No manual action is required, as the Operator automatically uses the updated images upon installation or upgrade.
+
+
+[id="cert-manager-operator-1-18-1-cves_{context}"]
+=== CVEs
+
+* link:https://access.redhat.com/security/cve/CVE-2025-66418[CVE-2025-66418]
+* link:https://access.redhat.com/security/cve/CVE-2025-66471[CVE-2025-66471]
+* link:https://access.redhat.com/security/cve/CVE-2025-61729[CVE-2025-61729]
+* link:https://access.redhat.com/security/cve/CVE-2026-21441[CVE-2025-21441]
+* link:https://access.redhat.com/security/cve/CVE-2025-61727[CVE-2025-61727]
+* link:https://access.redhat.com/security/cve/CVE-2025-61729[CVE-2025-61729]
+
+[id="cert-manager-operator-release-notes-1-18-0_{context}"]
+== {cert-manager-operator} 1.18.0
+
+Issued: 2025-11-12
+
+The following advisories are available for the {cert-manager-operator} 1.18.0:
+
+* link:https://access.redhat.com/errata/RHBA-2025:21087[RHBA-2025:21087]
+* link:https://access.redhat.com/errata/RHBA-2025:21086[RHBA-2025:21086]
+* link:https://access.redhat.com/errata/RHBA-2025:21088[RHBA-2025:21088]
+* link:https://access.redhat.com/errata/RHBA-2025:21114[RHBA-2025:21114]
+
+Version `1.18.0` of the {cert-manager-operator} is based on the upstream cert-manager version `v1.18.3`. For more information, see the link:https://cert-manager.io/docs/releases/release-notes/release-notes-1.18#v1183[cert-manager project release notes for v1.18.3].
+
+[id="cert-manager-operator-1-18-0-features-enhancements_{context}"]
+=== New features and enhancements
+
+Istio-CSR integration with {cert-manager-operator} (Generally Available)::
+With this release, the integration of the {cert-manager-operator} with Istio-CSR, which was previously provided as a Technology Preview feature, is fully supported. This feature offers enhanced support for securing workloads and control plane components within {SMProductName} or Istio environments. By utilizing the {cert-manager-operator} managed Istio-CSR agent, Istio can obtain, sign, deliver, and renew certificates required for mutual TLS (mTLS).
+For more information, see xref:../../security/cert_manager_operator/cert-manager-operator-integrating-istio.adoc#cert-manager-operator-istio-csr-installing_cert-manager-operator-integrating-istio[Integrating the cert-manager Operator with Istio-CSR].
+
+Replica count configuration for {cert-manager-operator} operands::
+With this release, you can override the default replica counts for the {cert-manager-operator} `controller`, `webhook`, and `cainjector` operands. To configure these values, specify the new `overrideReplicas` fields in the `CertManager` custom resource. With this enhancement, you can configure high availability (HA) and scale operands based on your specific operational requirements. For more information, see xref:../../security/cert_manager_operator/cert-manager-customizing-api-fields.adoc#cert-manager-explanation-of-certmanager-cr-fields_cert-manager-customizing-api-fields[Common configurable fields in the CertManager CR for the cert-manager components].
+
+Root filesystem is read-only for {cert-manager-operator} containers::
+With this release, to improve security, the {cert-manager-operator} and all its operands have the `readOnlyRootFilesystem` security context set to `true` by default. This enhancement hardens the containers and prevents a potential attacker from modifying the contents of the container's root file system.
+
+Network policy hardening is now available for {cert-manager-operator} components::
+With this release, the {cert-manager-operator} includes predefined `NetworkPolicy` resources to enhance security by controlling ingress and egress traffic for its components. These policies cover internal traffic, such as ingress to metrics and webhook servers, and egress to the OpenShift API and DNS servers.
+
+By default, this feature is disabled to prevent connectivity issues during upgrades. You must explicitly enable it in the `CertManager` custom resource. For more information, see xref:../../security/cert_manager_operator/cert-manager-nw-policy.adoc#cert-manager-nw-policy[Network policy configuration for {cert-manager-operator}].
+
+
+[id="cert-manager-operator-1-18-0-known-issues_{context}"]
+=== Known issues
+
+* The upstream cert-manager `v1.18` release updated the ACME HTTP-01 challenge ingress path type from `ImplementationSpecific` to `Exact`. The OpenShift Route API does not have an equivalent for the `Exact` path type, which prevents the ingress-to-route controller from supporting it. As a result, ingress resources created for HTTP-01 challenges cannot route traffic to the solver pod, causing the challenge to fail with a 503 error.
+To mitigate this issue, the `ACMEHTTP01IngressPathTypeExact` feature gate is disabled by default in this release.
+
+[id="cert-manager-operator-release-notes-1-17-1_{context}"]
+== {cert-manager-operator} 1.17.1
+
+Issued: 2025-03-25
+
+The following advisories are available for the {cert-manager-operator} 1.17.1:
+
+* link:https://access.redhat.com/errata/RHBA-2026:5642[RHBA-2026:5642]
+* link:https://access.redhat.com/errata/RHSA-2026:5645[RHSA-2026:5645]
+* link:https://access.redhat.com/errata/RHBA-2026:5749[RHBA-2026:5749]
+
+Version `1.17.1` of the {cert-manager-operator} is based on the upstream cert-manager version `v1.17.4`. For more information, see the link:https://cert-manager.io/docs/releases/release-notes/release-notes-1.17#v1174[cert-manager project release notes for v1.17.4].
+
+[id="cert-manager-operator-1-17-1-features-enhancements_{context}"]
+=== New features and enhancements
+
+The final images use `ubi9-minimal` as base images::
+With this update, the {cert-manager-operator} images use ubi9-minimal as their base images providing improved security compliance. No manual action is required, as the Operator automatically uses the updated images upon installation or upgrade.
+
+[id="cert-manager-operator-1-17-1-CVEs_{context}"]
+=== CVEs
+
+* link:https://access.redhat.com/security/cve/CVE-2025-47907[CVE-2025-47907]
+* link:https://access.redhat.com/security/cve/CVE-2025-58183[CVE-2025-58183]
+* link:https://access.redhat.com/security/cve/CVE-2025-61726[CVE-2025-61726]
+* link:https://access.redhat.com/security/cve/CVE-2025-61728[CVE-2025-61728]
+* link:https://access.redhat.com/security/cve/CVE-2025-61729[CVE-2025-61729]
+* link:https://access.redhat.com/security/cve/CVE-2025-68121[CVE-2025-68121]
+
 [id="cert-manager-operator-release-notes-1-17-0_{context}"]
 == {cert-manager-operator} 1.17.0
 
@@ -32,7 +131,7 @@ Version `1.17.0` of the {cert-manager-operator} is based on the upstream cert-ma
 * Previously, the `status` field in the `IstioCSR` custom resource (CR) was not set to `Ready` even after the successful deployment of Istio‑CSR. With this fix, the `status` field is correctly set to `Ready`, ensuring consistent and reliable status reporting. (link:https://issues.redhat.com/browse/CM-546[CM-546])
 
 [id="cert-manager-operator-1-17-0-features-enhancements_{context}"]
-== New features and enhancements
+=== New features and enhancements
 
 *Support to configure resource requests and limits for ACME HTTP‑01 solver pods*
 
@@ -46,7 +145,7 @@ With this release, the {cert-manager-operator} supports configuring CPU and memo
 For more information, see xref:../../security/cert_manager_operator/cert-manager-customizing-api-fields.adoc#cert-manager-overridable-arguments_cert-manager-customizing-api-fields[Overridable arguments for the cert‑manager components].
 
 [id="cert-manager-operator-1-17-0-CVEs_{context}"]
-== CVEs
+=== CVEs
 
 * link:https://access.redhat.com/security/cve/CVE-2025-22866[CVE-2025-22866]
 * link:https://access.redhat.com/security/cve/CVE-2025-22868[CVE-2025-22868]


### PR DESCRIPTION
CP of #108729 with commit ID c7a80b0648cb2aee3ed11db1d89e521806dd244f

Version(s):
4.16

Issue:
[OSDOCS-18453](https://redhat.atlassian.net/browse/OSDOCS-18453)


Link to docs preview:
