### PR TITLE
[enterprise-4.16] OSDOCS#18453: Add cert-manager operator release note 1.17.1

### DIFF
--- a/security/cert_manager_operator/cert-manager-operator-release-notes.adoc
+++ b/security/cert_manager_operator/cert-manager-operator-release-notes.adoc
@@ -13,6 +13,35 @@ These release notes track the development of {cert-manager-operator}.
 
 For more information, see xref:../../security/cert_manager_operator/index.adoc#cert-manager-operator-about[About the {cert-manager-operator}].
 
+[id="cert-manager-operator-release-notes-1-17-1_{context}"]
+== {cert-manager-operator} 1.17.1
+
+Issued: 2025-03-25
+
+The following advisories are available for the {cert-manager-operator} 1.17.1:
+
+* link:https://access.redhat.com/errata/RHBA-2026:5642[RHBA-2026:5642]
+* link:https://access.redhat.com/errata/RHSA-2026:5645[RHSA-2026:5645]
+* link:https://access.redhat.com/errata/RHBA-2026:5749[RHBA-2026:5749]
+
+Version `1.17.1` of the {cert-manager-operator} is based on the upstream cert-manager version `v1.17.4`. For more information, see the link:https://cert-manager.io/docs/releases/release-notes/release-notes-1.17#v1174[cert-manager project release notes for v1.17.4].
+
+[id="cert-manager-operator-1-17-1-features-enhancements_{context}"]
+=== New features and enhancements
+
+The final images use `ubi9-minimal` as base images::
+With this update, the {cert-manager-operator} images use ubi9-minimal as their base images providing improved security compliance. No manual action is required, as the Operator automatically uses the updated images upon installation or upgrade.
+
+[id="cert-manager-operator-1-17-1-CVEs_{context}"]
+=== CVEs
+
+* link:https://access.redhat.com/security/cve/CVE-2025-47907[CVE-2025-47907]
+* link:https://access.redhat.com/security/cve/CVE-2025-58183[CVE-2025-58183]
+* link:https://access.redhat.com/security/cve/CVE-2025-61726[CVE-2025-61726]
+* link:https://access.redhat.com/security/cve/CVE-2025-61728[CVE-2025-61728]
+* link:https://access.redhat.com/security/cve/CVE-2025-61729[CVE-2025-61729]
+* link:https://access.redhat.com/security/cve/CVE-2025-68121[CVE-2025-68121]
+
 [id="cert-manager-operator-release-notes-1-17-0_{context}"]
 == {cert-manager-operator} 1.17.0
 
@@ -32,7 +61,7 @@ Version `1.17.0` of the {cert-manager-operator} is based on the upstream cert-ma
 * Previously, the `status` field in the `IstioCSR` custom resource (CR) was not set to `Ready` even after the successful deployment of Istio‑CSR. With this fix, the `status` field is correctly set to `Ready`, ensuring consistent and reliable status reporting. (link:https://issues.redhat.com/browse/CM-546[CM-546])
 
 [id="cert-manager-operator-1-17-0-features-enhancements_{context}"]
-== New features and enhancements
+=== New features and enhancements
 
 *Support to configure resource requests and limits for ACME HTTP‑01 solver pods*
 
@@ -46,7 +75,7 @@ With this release, the {cert-manager-operator} supports configuring CPU and memo
 For more information, see xref:../../security/cert_manager_operator/cert-manager-customizing-api-fields.adoc#cert-manager-overridable-arguments_cert-manager-customizing-api-fields[Overridable arguments for the cert‑manager components].
 
 [id="cert-manager-operator-1-17-0-CVEs_{context}"]
-== CVEs
+=== CVEs
 
 * link:https://access.redhat.com/security/cve/CVE-2025-22866[CVE-2025-22866]
 * link:https://access.redhat.com/security/cve/CVE-2025-22868[CVE-2025-22868]


### PR DESCRIPTION
Manual cherry-pick of #108729

Version(s):
4.16

Issue:
https://redhat.atlassian.net/browse/OSDOCS-18453

Link to docs preview:
https://109042--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/cert_manager_operator/cert-manager-operator-release-notes.html

QE review:
N/A