### PR TITLE
OSDOCS-18870:fixes spec path in UDN docs

### DIFF
--- a/modules/nw-udn-additional-config-details.adoc
+++ b/modules/nw-udn-additional-config-details.adoc
@@ -11,24 +11,37 @@ Configure optional advanced settings for `UserDefinedNetwork` CRs when default v
 
 It is not recommended to set these fields without explicit need and understanding of OVN-Kubernetes network topology.
 
-.`UserDefinedNetworks` optional configurations
-[cols="1,1,7", options="header"]
+.Optional configurations for user-defined networks
+[cols="2,1,7", options="header"]
 |====
 
-|Field|Type|Description
+|*UDN field*|*Type*|*Description*
 
-|`spec.joinSubnets`
+|`spec.network.<topology>.joinSubnets`
 |object
 |When omitted, the platform sets default values for the `joinSubnets` field of `100.65.0.0/16` for IPv4 and  `fd99::/64` for IPv6. If the default address values are used anywhere in the cluster's network you must override it by setting the `joinSubnets` field. If you choose to set this field, ensure it does not conflict with other subnets in the cluster such as the cluster subnet, the `default` network cluster subnet, and the masquerade subnet.
 
 The `joinSubnets` field configures the routing between different segments within a user-defined network. Dual-stack clusters can set 2 subnets, one for each IP family; otherwise, only 1 subnet is allowed. This field is only allowed for the `Primary` network.
 
-|`spec.IPAMLifecycle`
+|`spec.network.layer2.ipam.lifecycle`
 |object
-|The `IPAMLifecycle` field configures the IP address management system (IPAM). You might use this field for virtual workloads to ensure persistent IP addresses. This field is allowed when `topology` is `layer2`. The `subnets` field must be specified when this field is specified. Setting a value of `Persistent` ensures that your virtual workloads have persistent IP addresses across reboots and migration. These are assigned by the container network interface (CNI) and used by OVN-Kubernetes to program pod IP addresses. You must not change this for pod annotations.
+|This field configures the IP address management system (IPAM) for a user-defined network. You might use this field for virtual workloads to ensure persistent IP addresses. The only allowed value is `Persistent`, which ensures that your virtual workloads have persistent IP addresses across reboots and migration. These are assigned by the container network interface (CNI) and used by OVN-Kubernetes to program pod IP addresses. You must not change this for pod annotations.
 
-|`spec.layer2.mtu` and `spec.layer3.mtu`
+Setting a value of Persistent is only supported when `ipam.mode` parameter is set to `Enabled`.
+
+|`spec.network.layer2.ipam.mode`
+|object
+a|The `mode` parameter controls how much of the IP configuration is managed by OVN-Kubernetes. The following options are available:
+
+* `Enabled`: When enabled, OVN-Kubernetes applies the IP configuration to the SDN infrastructure and assigns IP addresses from the selected subnet to the individual pods. This is the default setting. When set to `Enabled`, the `subnets` field must be defined. `Enabled` is the default configuration.
+
+* `Disabled`: When disabled, OVN-Kubernetes only assigns MAC addresses and provides layer 2 communication, so that users can configure IP addresses. `Disabled` is only available for layer 2 (secondary) networks. By disabling IPAM, features that rely on selecting pods by IP, for example, network policy, services, and so on, no longer function. Additionally, IP port security is also disabled for interfaces attached to this network. The `subnets` field must be empty when `spec.ipam.mode` is set to `Disabled.`
+
+|`spec.network.<topology>.mtu`
 |integer
-|The maximum transmission units (MTU). The default value is `1400`. The boundary for IPv4 is `574`, and for IPv6 it is `1280`.
-
+|The maximum transmission units (MTU). The default value is `1400`. The boundary for IPv4 is `576`, and for IPv6 it is `1280`.
 |====
+
+where:
+
+`<topology>`:: Is one of `layer2` or `layer3`. For IPAM, the topology must be `layer2`.


### PR DESCRIPTION
Brings [these](#93362) changes into 4.17 without brining back CUDN

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.17
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
https://redhat.atlassian.net/browse/OSDOCS-18870
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
https://109050--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/multiple_networks/primary_networks/about-user-defined-networks.html#nw-udn-additional-config-details_user-defined-networks
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
#93362 changes brought into 4.17 without CUDN
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
