### PR TITLE
OSDOCS-16873-abstracts: SCALE-3: Low-Latency/CNF Provisioning and Tuning

### DIFF
--- a/modules/cnf-about-hyperthreading-for-low-latency-and-real-time-applications.adoc
+++ b/modules/cnf-about-hyperthreading-for-low-latency-and-real-time-applications.adoc
@@ -7,7 +7,9 @@
 = About Hyper-Threading for low latency and real-time applications
 
 [role="_abstract"]
-To improve system throughput for parallel workloads, you can use Hyper-Threading to enable a physical CPU core to function as two logical cores, executing independent threads simultaneously. The default {product-title} configuration expects Hyper-Threading to be enabled.
+You can use Hyper-Threading, an Intel processor technology, to allow a physical CPU processor core to function as two logical cores, executing two independent threads simultaneously.
+
+Hyper-Threading allows for better system throughput for certain workload types where parallel processing is beneficial. The default {product-title} configuration expects Hyper-Threading to be enabled.
 
 For telecommunications applications, design your application infrastructure to minimize latency as much as possible. Hyper-Threading can slow performance times and negatively affect throughput for compute-intensive workloads that require low latency. Disabling Hyper-Threading ensures predictable performance and can decrease processing times for these workloads.
 

--- a/modules/cnf-about-irq-affinity-setting.adoc
+++ b/modules/cnf-about-irq-affinity-setting.adoc
@@ -8,7 +8,7 @@
 = Finding the effective IRQ affinity setting for a node
 
 [role="_abstract"]
-To verify actual interrupt handling, determine the effective IRQ affinity setting for a node. Some IRQ controllers do not support affinity settings and effectively run on CPU 0, even when the IRQ mask exposes all online CPUs.
+Some IRQ controllers lack support for an IRQ affinity setting and might always expose all online CPUs as the IRQ mask. Because these IRQ controllers effectively run on CPU 0, you must find the effective IRQ affinity setting for a node.
 
 The following are examples of drivers and hardware that Red Hat are aware lack support for IRQ affinity setting. The list is, by no means, exhaustive:
 

--- a/modules/cnf-adjusting-nic-queues-with-the-performance-profile.adoc
+++ b/modules/cnf-adjusting-nic-queues-with-the-performance-profile.adoc
@@ -7,9 +7,7 @@
 = Adjusting the NIC queues with the performance profile
 
 [role="_abstract"]
-To optimize network traffic handling, adjust the queue count for each network device by using the performance profile. By using this configuration, you can tune your network settings to meet specific workload requirements.
-
-You can use a performance profile to adjust the queue count for each network device.
+You can use a performance profile to adjust the queue count for each network device. By using the Node Tuning Operator, you can reduce NIC queues for enhanced performance. 
 
 Supported network devices:
 

--- a/modules/cnf-configure_for_irq_dynamic_load_balancing.adoc
+++ b/modules/cnf-configure_for_irq_dynamic_load_balancing.adoc
@@ -7,11 +7,11 @@
 = Configuring node interrupt affinity
 
 [role="_abstract"]
-To control which cores receive device interrupt requests (IRQ), configure IRQ dynamic load balancing on a cluster node. With this configuration, you can isolate interrupt handling to specific CPUs, ensuring consistent performance for latency-sensitive workloads.
+Configure a cluster node for IRQ dynamic load balancing to control which cores can receive device interrupt requests (IRQ).
 
 .Prerequisites
 
-* For core isolation, all server hardware components must support IRQ affinity. To check if the hardware components of your server support IRQ affinity, view the server's hardware specifications or contact your hardware provider.
+* For core isolation, all server hardware components must support IRQ affinity. To check if the hardware components of your server support IRQ affinity, view the hardware specifications of the server or contact your hardware provider.
 
 .Procedure
 
@@ -38,8 +38,5 @@ spec:
 +
 [NOTE]
 ====
-When you configure reserved and isolated CPUs, operating system processes, kernel processes, and systemd services run on reserved CPUs.
-Infrastructure pods run on any CPU except where the low latency workload is running.
-Low latency workload pods run on exclusive CPUs from the isolated pool.
-For more information, see "Restricting CPUs for infra and application containers".
+When you configure reserved and isolated CPUs, operating system processes, kernel processes, and systemd services run on reserved CPUs. Infrastructure pods run on any CPU except where the low latency workload is running. Low latency workload pods run on exclusive CPUs from the isolated pool. For more information, see "Partitioning CPUs for infra and application containers".
 ====

--- a/modules/cnf-configuring-huge-pages.adoc
+++ b/modules/cnf-configuring-huge-pages.adoc
@@ -8,7 +8,7 @@
 = Configuring huge pages
 
 [role="_abstract"]
-To pre-allocate huge pages on a specific node, use the Node Tuning Operator. This configuration ensures that your {product-title} cluster reserves the necessary memory resources for workloads that require them.
+Because nodes must pre-allocate huge pages used in an {product-title} cluster, use the Node Tuning Operator to allocate huge pages on a specific node.
 
 {product-title} provides a method for creating and allocating huge pages. Node Tuning Operator provides an easier method for doing  this using the performance profile.
 

--- a/modules/cnf-disabling-cpu-cfs-quota.adoc
+++ b/modules/cnf-disabling-cpu-cfs-quota.adoc
@@ -7,7 +7,7 @@
 = Disabling CPU CFS quota
 
 [role="_abstract"]
-To prevent CPU throttling for latency-sensitive workloads, disable the CPU CFS quota. This configuration allows pods to use unallocated CPU resources on the node, ensuring consistent application performance.
+To eliminate CPU throttling for pinned pods, create a pod with the `cpu-quota.crio.io: "disable"` annotation. This annotation disables the CPU completely fair scheduler (CFS) quota when the pod runs.
 
 .Procedure
 

--- a/modules/cnf-logging-associated-with-adjusting-nic-queues.adoc
+++ b/modules/cnf-logging-associated-with-adjusting-nic-queues.adoc
@@ -7,7 +7,7 @@
 = Logging associated with adjusting NIC queues
 
 [role="_abstract"]
-To verify NIC queue adjustments, review the Tuned daemon logs. These logs record messages detailing the assigned devices so that you can confirm that the system applied your configuration changes correctly.
+To verify NIC queue adjustments, review the Tuned daemon logs. These log messages detail the assigned devices that are recorded in the respective Tuned daemon logs.
 
 The following messages might be recorded to the `/var/log/tuned/tuned.log` file:
 

--- a/modules/cnf-node-tuning-operator-disabling-cpu-load-balancing-for-dpdk.adoc
+++ b/modules/cnf-node-tuning-operator-disabling-cpu-load-balancing-for-dpdk.adoc
@@ -7,12 +7,10 @@
 = Disabling CPU load balancing in a Pod
 
 [role="_abstract"]
-To optimize performance, disable or enable CPU load balancing for your Pods. CRI-O implements this functionality and applies the configuration only when specific requirements are met.
+Functionality to disable or enable CPU load balancing is implemented on the CRI-O level. Before CRI-O disables or enables CPU load balancing, you must ensure certain prerequisites are met. 
 
-Functionality to disable or enable CPU load balancing is implemented on the CRI-O level. The code under the CRI-O disables or enables CPU load balancing only when the following requirements are met.
+The pod must use the `performance-<profile-name>` runtime class. You can get the proper name by looking at the status of the performance profile, as shown here:
 
-* The pod must use the `performance-<profile-name>` runtime class. You can get the proper name by looking at the status of the performance profile, as shown here:
-+
 [source,yaml]
 ----
 apiVersion: performance.openshift.io/v2

--- a/modules/cnf-performance-profile-creator-arguments.adoc
+++ b/modules/cnf-performance-profile-creator-arguments.adoc
@@ -7,7 +7,7 @@
 = Performance Profile Creator arguments
 
 [role="_abstract"]
-To customize the generation of performance profiles, review the arguments for the Performance Profile Creator. By using these command-line options, you can define specific tuning parameters, such as CPU isolation and huge pages, to meet your workload requirements.
+To customize the generation of performance profiles, review the arguments for the Performance Profile Creator.
 
 .Required Performance Profile Creator arguments
 [cols="30%,70%",options="header"]

--- a/modules/cnf-scheduling-workload-onto-worker-with-real-time-capabilities.adoc
+++ b/modules/cnf-scheduling-workload-onto-worker-with-real-time-capabilities.adoc
@@ -7,7 +7,7 @@
 = Scheduling a low latency workload onto a compute node
 
 [role="_abstract"]
-To run low latency workloads, schedule them onto a compute node associated with a performance profile that configures real-time capabilities. This ensures that the node is tuned to meet the specific timing and performance requirements of your application.
+You can schedule low latency workloads onto a compute node where a performance profile that configures real-time capabilities is applied.
 
 [NOTE]
 ====
@@ -105,8 +105,6 @@ Cpus_allowed_list:  2-3
 ----
 
 .Verification
-
-Ensure the node configuration is applied correctly.
 
 . Log in to the node to verify the configuration.
 +

--- a/modules/cnf-understanding-low-latency.adoc
+++ b/modules/cnf-understanding-low-latency.adoc
@@ -8,9 +8,9 @@
 = About low latency
 
 [role="_abstract"]
-To support Telco applications that require zero packet loss, tune your environment for low latency. This configuration mitigates network performance degradation, ensuring that your system meets strict reliability requirements.
+You can tune for zero packet loss so to mitigate the inherent issues that degrade network performance. 
 
-Tuning for zero packet loss helps mitigate the inherent issues that degrade network performance. For more information, see "Tuning for Zero Packet Loss in {rh-openstack-first}".
+For example, many of the deployed applications in the Telco space require low latency that can only tolerate zero packet loss. For more information, see "Tuning for Zero Packet Loss in {rh-openstack-first}".
 
 The Edge computing initiative also comes in to play for reducing latency rates. Think of it as being on the edge of the cloud and closer to the user. This greatly reduces the distance between the user and distant data centers, resulting in reduced application response times and performance latency.
 

--- a/modules/cnf-verifying-queue-status.adoc
+++ b/modules/cnf-verifying-queue-status.adoc
@@ -7,7 +7,9 @@
 = Verifying the queue status
 
 [role="_abstract"]
-To ensure that your performance profile changes are active, verify the queue status. Reviewing these examples helps you confirm that specific tuning configurations are successfully applied to your environment.
+To ensure that your performance profile changes are active, verify the queue status. 
+
+By reviewing the provided examples, you can confirm that specific tuning configurations are successfully applied to your environment.
 
 In this section, several examples illustrate different performance profiles and how to verify the changes are applied.
 

--- a/modules/nodes-cluster-worker-latency-profiles-examining.adoc
+++ b/modules/nodes-cluster-worker-latency-profiles-examining.adoc
@@ -7,9 +7,7 @@
 = Displaying resulting values of worker latency profile
 
 [role="_abstract"]
-To verify the configuration of your compute nodes, display the resulting values of the worker latency profile configured for those nodes. This ensures that the Kubelet parameters are correctly adjusted for high latency environments and helps you confirm system stability.
-
-The following procedure uses example commands to display the values in the worker latency profile configured for your node.
+You can run specific commands to display the values for the worker latency profile. You can then check the displayed values for information accuracy.
 
 .Procedure
 

--- a/modules/nodes-cluster-worker-latency-profiles-using-at-creation.adoc
+++ b/modules/nodes-cluster-worker-latency-profiles-using-at-creation.adoc
@@ -7,7 +7,7 @@
 = Implementing worker latency profiles at cluster creation
 
 [role="_abstract"]
-To ensure cluster stability in high latency environments, implement worker latency profiles during cluster creation.
+During cluster creation, you can implement worker latency profiles so that you can control the reaction of the cluster to latency issues without relying on manual methods to determine the best values.
 
 [IMPORTANT]
 ====

--- a/modules/restricting-cnf-cpu-infra-container.adoc
+++ b/modules/restricting-cnf-cpu-infra-container.adoc
@@ -5,10 +5,10 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="restricting-cnf-cpu-infra-container_{context}"]
-= Restricting CPUs for infra and application containers
+= Partitioning CPUs for infra and application containers
 
 [role="_abstract"]
-To ensure optimal cluster stability and performance, restrict CPUs for infrastructure and application containers. This configuration isolates workloads to specific CPU sets, preventing resource contention between critical system components and user applications.
+By partitioning CPUs, you can prevent noisy processes from interfering with latency-sensitive processes by separating the processes from each other.
 
 .Procedure
 

--- a/scalability_and_performance/cnf-provisioning-low-latency-workloads.adoc
+++ b/scalability_and_performance/cnf-provisioning-low-latency-workloads.adoc
@@ -7,7 +7,7 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 [role="_abstract"]
-To achieve low latency and consistent response times for {product-title} applications, use the Node Tuning Operator. This Operator implements automatic tuning to optimize your cluster for high-performance computing workloads.
+If your organization needs high performance computing and low, predictable latency, especially in the financial and telecommunications industries, you can use the Node Tuning Operator to implement automatic tuning to achieve low latency performance and consistent response time for {product-title} applications.
 
 You use the performance profile configuration to make these changes.
 

--- a/scalability_and_performance/cnf-understanding-low-latency.adoc
+++ b/scalability_and_performance/cnf-understanding-low-latency.adoc
@@ -7,7 +7,7 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 [role="_abstract"]
-To meet 5G network performance requirements, review the principles of low latency tuning for cluster nodes. By using this configuration, you can reduce congestion and maintain the lowest possible latency for edge computing applications.
+By first understanding low latency tuning for cluster nodes, you can then use edge computing as a key role in reducing latency and congestion problems and improving application performance for telco and 5G network applications.
 
 Maintaining a network architecture with the lowest possible latency is key for meeting the network performance requirements of 5G. Compared to 4G technology, with an average latency of 50 ms, 5G is targeted to reach latency of 1 ms or less. This reduction in latency boosts wireless throughput by a factor of 10.
 

--- a/scalability_and_performance/scaling-worker-latency-profiles.adoc
+++ b/scalability_and_performance/scaling-worker-latency-profiles.adoc
@@ -7,7 +7,7 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 [role="_abstract"]
-To improve cluster stability in high latency environments, apply worker latency profiles. These profiles adjust Kubelet timing parameters to ensure that nodes remain healthy and responsive despite network delays.
+To improve cluster stability in high latency environments, apply worker latency profiles.
 
 include::snippets/worker-latency-profile-intro.adoc[]
 

--- a/snippets/worker-latency-profile-intro.adoc
+++ b/snippets/worker-latency-profile-intro.adoc
@@ -9,14 +9,14 @@
 :_mod-docs-content-type: SNIPPET
 
 [role="_abstract"]
-If the cluster administrator has performed latency tests for platform verification, they can discover the need to adjust the operation of the cluster to ensure stability in cases of high latency. 
+If as a cluster administrator, you performed latency tests for platform verification, you might discover the need to adjust the operation of the cluster to ensure stability in cases of high latency.
 
-The cluster administrator needs to change only one parameter, recorded in a file, which controls four parameters affecting how supervisory processes read status and interpret the health of the cluster. Changing only the one parameter provides cluster tuning in an easy, supportable manner.
+As a cluster administrator, you need to change only one parameter, recorded in a file, which controls four parameters affecting how supervisory processes read status and interpret the health of the cluster. Changing only the one parameter provides cluster tuning in an easy, supportable manner.
 
 The `Kubelet` process provides the starting point for monitoring cluster health. The `Kubelet` sets status values for all nodes in the {product-title} cluster. The Kubernetes Controller Manager (`kube controller`) reads the status values every 10 seconds, by default.
 If the `kube controller` cannot read a node status value, it loses contact with that node after a configured period. The default behavior is:
 
-. The node controller on the control plane updates the node health to `Unhealthy` and marks the node `Ready` condition`Unknown`.
+. The node controller on the control plane updates the node health to `Unhealthy` and marks the node `Ready` condition `Unknown`.
 
 . In response, the scheduler stops scheduling pods to that node.
 


### PR DESCRIPTION
The short description NotebookLM was used to generate abstracts. However, as part of the remediation process, I've reviewed abstracts, to what I think, require rolling back to a closer alignment with the original text. I've provided direct links to original CQA work for each revised abstract.

As a reference point for the original text (pre-CQA), here are the 3 CQA PRs for [SCALE-3](https://redhat.atlassian.net/browse/SCALE-3): Low-Latency/CNF Provisioning and Tuning

* https://github.com/openshift/openshift-docs/pull/106850
* https://github.com/openshift/openshift-docs/pull/107038
* https://github.com/openshift/openshift-docs/pull/107141

Version(s):
4.20+

Issue:
[OSDOCS-16873](https://redhat.atlassian.net/browse/OSDOCS-16873)

Link to docs preview:

* https://109052--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/clusters/nodes-cluster-worker-latency-profiles.html
* https://109052--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/cluster-tasks.html
* https://109052--ocpdocs-pr.netlify.app/openshift-enterprise/latest/scalability_and_performance/cnf-provisioning-low-latency-workloads.html
* https://109052--ocpdocs-pr.netlify.app/openshift-enterprise/latest/scalability_and_performance/cnf-tuning-low-latency-nodes-with-perf-profile.html
* https://109052--ocpdocs-pr.netlify.app/openshift-enterprise/latest/scalability_and_performance/cnf-understanding-low-latency.html
* https://109052--ocpdocs-pr.netlify.app/openshift-enterprise/latest/scalability_and_performance/scaling-worker-latency-profiles.html

