### PR TITLE
OSSM-12961 CQA on all the modules in "Updating" chapter

### DIFF
--- a/modules/ossm-about-inplace-strategy.adoc
+++ b/modules/ossm-about-inplace-strategy.adoc
@@ -8,8 +8,8 @@
 
 [role="_abstract"]
 
-The `InPlace` update strategy runs only one revision of the control plane at a time. During an update, all the workloads immediately connect to the new control plane version. To maintain compatibility between the sidecars and the control plane, you can upgrade only one minor version at a time.
+The `InPlace` update strategy runs only one revision of the control plane at a time. During an update, all the workloads immediately connect to the new control plane version. To support compatibility between the sidecars and the control plane, you can upgrade only one minor version at a time.
 
 The `InPlace` strategy updates and restarts the existing {istio} control plane in place. During this process, only one instance of the control plane exists, eliminating the need to move workloads to a new control plane instance. To complete the update, restart the application workloads and gateways to refresh the Envoy proxies.
 
-While the `InPlace` strategy offers simplicity and efficiency, there's a slight possibility of application traffic interruption if a workload pod updates, restarts, or scales while the control plane is restarting. You can mitigate this risk by running multiple replicas of the {istio} control plane (istiod).
+While the `InPlace` strategy offers simplicity and efficiency, there's a slight possibility of application traffic interruption if a workload pod updates, restarts, or scales while the control plane is restarting. You can mitigate this risk by running many replicas of the {istio} control plane (istiod).

--- a/modules/ossm-about-istio-control-plane-update-strategies.adoc
+++ b/modules/ossm-about-istio-control-plane-update-strategies.adoc
@@ -8,11 +8,9 @@
 
 [role="_abstract"]
 
-You can define how the {SMProduct} Operator manages control plane upgrades by configuring the `spec.updateStrategy` field to handle version changes and automated release aliases.
+The update strategy affects how the Operator performs the update. The `spec.updateStrategy` field in the `{istio}` resource configuration determines how the {SMProduct} Operator updates the {istio} control plane.
 
-The update strategy defines the steps for making an update. The `spec.updateStrategy` field in the `{istio}` resource configuration determines how the {SMProduct} Operator updates the {istio} control plane. When the Operator detects a change in the `spec.version` field or identifies a new minor release with a configured `vX.Y-latest` alias, it initiates an upgrade procedure.
-
-For each mesh, select one of the two strategies:
+When the Operator detects a change in the `spec.version` field or identifies a new minor release with a configured `vX.Y-latest` alias, it initiates an upgrade procedure. For each mesh, you select one of two strategies:
 
 * `InPlace`
 * `RevisionBased`
@@ -23,6 +21,6 @@ If you use ambient mode, you must update the {istio} Container Network Interface
 
 [IMPORTANT]
 ====
-{SMProduct} recommends the `InPlace` update strategy for ambient mode. Using `RevisionBased` updates with ambient mode has limitations and requires manual intervention.
+{SMProductShortName} recommends the `InPlace` update strategy for ambient mode. Using `RevisionBased` updates with ambient mode has limitations and requires manual intervention.
 ====
 

--- a/modules/ossm-about-istio-update-process.adoc
+++ b/modules/ossm-about-istio-update-process.adoc
@@ -12,11 +12,11 @@ After updating the {SMProduct} Operator, update the {istio} control plane to the
 
 The `{istio}` resource configuration includes the following fields that are relevant to the upgrade process:
 
-`spec.version`:: specifies the version of {istio} to install. Use the format `vX.Y.Z`, where `X.Y.Z` is the desired {istio} release. For example, set the field to `v1.24.4` to install {istio} `1.24.4`. Alternatively, set the value to an alias such as `vX.Y-latest` to automatically install the latest supported patch version for the specified minor release.
+`spec.version`:: specifies the version of {istio} to install. Use the format `vX.Y.Z`, where `X.Y.Z` is the required {istio} release. For example, set the field to `v1.24.4` to install {istio} `1.24.4`. Or, set the value to an alias such as `vX.Y-latest` to automatically install the latest supported patch version for the specified minor release.
 
 `spec.updateStrategy`:: defines the strategy for updating the {istio} control plane. The available update strategies are `InPlace` and `RevisionBased`.
 
 [NOTE]
 ====
-To enable automatic patch upgrades, set the approval strategy of the Operator to `Automatic`. When the Operator detects a new patch release and the `version` field uses the `vX.Y-latest` alias, the control plane is updated based on the configured `updateStrategy` type.
+To enable automatic patch upgrades, set the approval strategy of the Operator to `Automatic`. When the Operator detects a new patch release and the `version` field uses the `vX.Y-latest` alias, it updates the control plane based on the configured `updateStrategy` type.
 ====

--- a/modules/ossm-about-operator-update-process.adoc
+++ b/modules/ossm-about-operator-update-process.adoc
@@ -8,6 +8,8 @@
 
 [role="_abstract"]
 
-The {SMProduct} Operator will upgrade automatically to the latest available version based on the selected channel when the *approval strategy* field is set to `Automatic` (default). If the *approval strategy* field is set to `Manual`, {olm-first} will generate an update request, which a cluster administrator must approve to update the Operator to the latest version.
+Manage the lifecycle of the {SMProduct} Operator and the {istio} control plane by configuring OLM approval strategies and resource update settings for automated or manual upgrades.
 
-The Operator update process does not automatically update the {istio} control plane unless the `{istio}` resource version is set to an alias (for example, `vX.Y-latest`) and the `updateStrategy` is set to `InPlace`. This triggers a control plane update when a new version is available in the Operator. By default, the Operator will not update the {istio} control plane unless the `{istio}` resource is updated with a new version.
+The {SMProduct} Operator upgrades automatically to the latest available version based on the selected channel when you set the *approval strategy* field to `Automatic` (default). If you set the *approval strategy* field to `Manual`, {olm-first} generates an update request, which a cluster administrator must approve to update the Operator to the latest version.
+
+The Operator update process does not automatically update the {istio} control plane unless you set the `{istio}` resource version to an alias (for example, `vX.Y-latest`) and the `updateStrategy` to `InPlace`. This triggers a control plane update when a new version is available in the Operator. By default, the Operator will not update the {istio} control plane unless the `{istio}` resource is updated with a new version.

--- a/modules/ossm-about-revisionbased-strategy.adoc
+++ b/modules/ossm-about-revisionbased-strategy.adoc
@@ -10,6 +10,6 @@
 
 The `RevisionBased` strategy runs two revisions of the control plane during an upgrade. This approach supports gradual workload migration from the old control plane to the new one, enabling canary upgrades. It also supports upgrades across more than one minor version.
 
-The `RevisionBased` strategy creates a new {istio} control plane instance for each change to the `spec.version` field. The existing control plane remains active until all workloads transition to the new instance. You can move the workloads to the new control plane by updating the `istio.io/rev` labels or using the `IstioRevisionTag` resource, followed by a restart.
+The `RevisionBased` strategy creates a new {istio} control plane instance for each change to the `spec.version` field. The existing control plane remains active until all workloads move to the new instance. You can move the workloads to the new control plane by updating the `istio.io/rev` labels or using the `IstioRevisionTag` resource, followed by a restart.
 
-Although the `RevisionBased` strategy involves additional steps and requires multiple control plane instances to run concurrently during the upgrade, it allows for gradual migration of workloads. This approach enables validation of the updated control plane with a subset of workloads before migrating the rest, making it useful for large meshes with mission-critical workloads.
+Although the `RevisionBased` strategy involves additional steps and requires many control plane instances to run concurrently during the upgrade, it allows for gradual migration of workloads. This approach enables validation of the updated control plane with a subset of workloads before migrating the rest, making it useful for large meshes with mission-critical workloads.

--- a/modules/ossm-about-update-strategies-in-ambient-mode.adoc
+++ b/modules/ossm-about-update-strategies-in-ambient-mode.adoc
@@ -8,7 +8,7 @@
 
 [role="_abstract"]
 
-In ambient mode, components update directly through `InPlace` updates. Unlike sidecar mode, ambient mode allows you to move application pods to an upgraded ztunnel proxy without restarting or rescheduling the pods.
+In ambient mode, components update directly through `InPlace` updates. In ambient mode, you can move application pods to an upgraded ztunnel proxy without restarting or rescheduling them, unlike sidecar mode.
 
 Update sequence:: To update in ambient mode, use the following sequence:
 

--- a/modules/ossm-installing-istio-with-inplace-strategy.adoc
+++ b/modules/ossm-installing-istio-with-inplace-strategy.adoc
@@ -8,7 +8,7 @@
 
 [role="_abstract"]
 
-You can install the {istio} control plane, {istio} CNI, and the Bookinfo demo application using the `Inplace` update strategy.
+You can install the {istio} control plane, {istio} CNI, and the Bookinfo demo application by using the `Inplace` update strategy.
 
 [NOTE]
 ====
@@ -70,7 +70,7 @@ spec:
     type: InPlace
 ----
 
-. Install the {istio} CNI plugin with the desired version. The following example configuration creates an `IstioCNI` resource named `default` in the `istio-cni` namespace:
+. Install the {istio} CNI plugin with the required version. The following example configuration creates an `IstioCNI` resource named `default` in the `istio-cni` namespace:
 +
 [source,yaml]
 ----

--- a/modules/ossm-installing-istio-with-revisionbased-strategy-istiorevisiontag.adoc
+++ b/modules/ossm-installing-istio-with-revisionbased-strategy-istiorevisiontag.adoc
@@ -8,7 +8,7 @@
 
 [role="_abstract"]
 
-You can install the {istio} control plane, `IstioRevisionTag` resource, {istio} CNI, and the Bookinfo demo application using the `RevisionBased` update strategy.
+You can install the {istio} control plane, `IstioRevisionTag` resource, {istio} CNI, and the Bookinfo demo application by using the `RevisionBased` update strategy.
 
 [NOTE]
 ====
@@ -26,7 +26,8 @@ $ oc create ns istio-system
 
 . Deploy the {istio} control plane using the `RevisionBased` update strategy. The following example configuration creates an `{istio}` resource named `default` in the `istio-system` namespace:
 +
-.Example configuration
+You can see the following example configuration for reference:
++
 [source,yaml]
 ----
 apiVersion: sailoperator.io/v1
@@ -42,7 +43,8 @@ spec:
 
 . Create an `IstioRevisionTag` resource. The following example configuration creates an `IstioRevisionTag` resource named `default`:
 +
-.Example configuration
+You can see the following example configuration for reference:
++
 [source,yaml]
 ----
 apiVersion: sailoperator.io/v1
@@ -55,7 +57,7 @@ spec:
     name: default
 ----
 +
-Verify that the `targetRef` field points to the desired `{istio}` resource. In the example above, the `IstioRevisionTag` references the `{istio}` resource named `default`.
+Verify that the `targetRef` field points to the required `{istio}` resource. In the example above, the `IstioRevisionTag` references the `{istio}` resource named `default`.
 
 . Create the `istio-cni` namespace by running the following command:
 +
@@ -64,9 +66,10 @@ Verify that the `targetRef` field points to the desired `{istio}` resource. In t
 $ oc create ns istion-cni
 ----
 
-. Install the {istio} CNI plugin with the desired version. The following example configuration creates an `IstioCNI` resource named `default` in the `istio-cni` namespace:
+. Install the {istio} CNI plugin with the required version. The following example configuration creates an `IstioCNI` resource named `default` in the `istio-cni` namespace:
 +
-.Example configuration
+You can see the following example configuration for reference:
++
 [source,yaml]
 ----
 apiVersion: sailoperator.io/v1
@@ -108,7 +111,7 @@ $ oc apply -f https://raw.githubusercontent.com/openshift-service-mesh/istio/rel
 $ oc get istiorevisiontag
 ----
 +
-.Example output
+You will get an output similar to the following example:
 +
 [source,terminal]
 ----
@@ -127,7 +130,7 @@ $ istioctl proxy-status
 +
 The `VERSION` column should match the control plane version.
 +
-.Example output
+You will get an output similar to the following example:
 +
 [source,terminal]
 ----

--- a/modules/ossm-installing-istio-with-revisionbased-strategy.adoc
+++ b/modules/ossm-installing-istio-with-revisionbased-strategy.adoc
@@ -8,7 +8,7 @@
 
 [role="_abstract"]
 
-You can install the {istio} control plane, {istio} CNI, and the Bookinfo demo application using the `RevisionBased` update strategy.
+You can install the {istio} control plane, {istio} CNI, and the Bookinfo demo application by using the `RevisionBased` update strategy.
 
 [NOTE]
 ====
@@ -26,7 +26,8 @@ $ oc create ns istio-system
 
 . Deploy the {istio} control plane using the `RevisionBased` update strategy. The following example configuration creates an `{istio}` resource named `default` in the `istio-system` namespace:
 +
-.Example configuration
+You can see the following example configuration for reference:
++
 [source,yaml]
 ----
 apiVersion: sailoperator.io/v1
@@ -40,9 +41,10 @@ spec:
     type: RevisionBased
 ----
 
-. Install the {istio} CNI plugin with the desired version. The following example configuration creates an `IstioCNI` resource named `default` in the `istio-cni` namespace:
+. Install the {istio} CNI plugin with the required version. The following example configuration creates an `IstioCNI` resource named `default` in the `istio-cni` namespace:
 +
-.Example configuration
+You can see the following example configuration for reference:
++
 [source,yaml]
 ----
 apiVersion: sailoperator.io/v1
@@ -61,7 +63,8 @@ spec:
 $ oc get istiorevision -n istio-system
 ----
 +
-.Example output
+You will get an output similar to the following example:
++
 [source,terminal]
 ----
 NAME              TYPE    READY   STATUS    IN USE   VERSION   AGE
@@ -100,7 +103,7 @@ $ oc apply -f https://raw.githubusercontent.com/openshift-service-mesh/istio/rel
 $ oc get istio -n istio-system
 ----
 +
-.Example output
+You will get an output similar to the following example:
 +
 [source,terminal]
 ----
@@ -119,7 +122,7 @@ $ istioctl proxy-status
 +
 The `VERSION` column should match the control plane version.
 +
-.Example output
+You will get an output similar to the following example:
 +
 [source,terminal]
 ----

--- a/modules/ossm-selecting-inplace-strategy.adoc
+++ b/modules/ossm-selecting-inplace-strategy.adoc
@@ -10,7 +10,8 @@
 
 To select the `InPlace` strategy, set the `spec.updateStrategy.type` value in the {istio} resource to `InPlace`.
 
-.Example specification to select InPlace update strategy
+You can see the following example configuration for reference:
+
 [source,yaml, subs="attributes,verbatim"]
 ----
 kind: Istio

--- a/modules/ossm-selecting-revisionbased-strategy.adoc
+++ b/modules/ossm-selecting-revisionbased-strategy.adoc
@@ -10,7 +10,8 @@
 
 To deploy {istio} with the `RevisionBased` strategy, create the `{istio}` resource with the following `spec.updateStrategy` value:
 
-.Example specification to select `RevisionBased` strategy
+You can see the following example configuration for reference:
+
 [source,yaml, subs="attributes,verbatim"]
 ----
 kind: Istio

--- a/modules/ossm-understanding-operator-updates-and-channels.adoc
+++ b/modules/ossm-understanding-operator-updates-and-channels.adoc
@@ -14,7 +14,7 @@ To ensure that your {SMProduct} stays current with the latest security patches, 
 
 OLM provides the following channels for the {SMProduct} Operator:
 
-* *Stable* channel: tracks the most recent version of the {SMProduct} 3 Operator and the latest supported version of {istio}. This channel enables upgrades to new operator versions and corresponding {istio} updates as soon as they are released. Use the stable channel to stay current with the latest features, bug fixes, and security updates.
+* *Stable* channel: tracks the most recent version of the {SMProduct} 3 Operator and the latest supported version of {istio}. This channel enables upgrades to new operator versions and {istio} updates immediately following their release. Use the stable channel to stay current with the latest features, bug fixes, and security updates.
 
 * *Versioned* channel: restricts updates to patch-level releases within a specific minor version. For example, `stable-3.0` provides access to the latest `{SMProductVersion}` patch version. When a new patch release becomes available, you can upgrade the Operator to the newer patch version. To move to a newer minor release, you must manually switch to a different channel. You can use a versioned channel to maintain a consistent minor version while applying only patch updates.
 

--- a/modules/ossm-understanding-sm-istio-versions.adoc
+++ b/modules/ossm-understanding-sm-istio-versions.adoc
@@ -8,4 +8,6 @@
 
 [role="_abstract"]
 
-The most current {SMProduct} Operator version is {SMProductVersion}. This version supports the features listed in the "{SMProductShortName} {SMProductVersion} feature support tables". The {SMProduct} Operator includes additional {istio} releases for upgrades but supports only the latest {istio} version available for each Operator version. See the "{SMProductShortName} version support tables" to identify the supported {istio} version for each Operator release.
+The most current {SMProduct} Operator version is {SMProductVersion}. This version supports the features listed in the "{SMProductShortName} {SMProductVersion} feature support tables".
+
+The {SMProduct} Operator includes additional {istio} releases for upgrades but supports only the latest {istio} version available for each Operator version. See the "{SMProductShortName} version support tables" to identify the supported {istio} version for each Operator release.

--- a/modules/ossm-updating-istio-cni-resource-version.adoc
+++ b/modules/ossm-updating-istio-cni-resource-version.adoc
@@ -8,13 +8,16 @@
 
 [role="_abstract"]
 
-You can update the {istio} Container Network Interface (CNI) resource version by changing the version in the resource. Then, the {SMProductShortName} Operator deploys a new version of the CNI plugin that replaces the old version of the CNI plugin. The `istio-cni-node` pods automatically reconnect to the new CNI plugin.
+Update the {istio} CNI plugin by modifying the version in the resource, triggering the {SMProductShortName} Operator to deploy new plugin versions and automatically reconnect the node pods.
 
 .Prerequisites
 
-* You are logged in to {ocp-product-title} as a user with the `cluster-admin` role.
+* You have logged in to {ocp-product-title} as a user with the `cluster-admin` role.
+
 * You have installed the {SMProductName} Operator and deployed {istio}.
-* You have installed the {istio} CNI plugin with the required version. In the following example, the `IstioCNI` resource named `default` is deployed in the `istio-cni` namespace.
+
+* You have installed the {istio} CNI plugin with the required version. In the following example, the deployment of the `IstioCNI` resource named `default` is in the `istio-cni` namespace.
+
 * You have either updated the {istio} control plane to the required version (for `Inplace` strategy) or created a new control plane revision (for `RevisionBased` strategy). 
 
 .Procedure

--- a/modules/ossm-updating-istio-control-plane-with-inplace.adoc
+++ b/modules/ossm-updating-istio-control-plane-with-inplace.adoc
@@ -8,16 +8,27 @@
 
 [role="_abstract"]
 
-When updating {istio} using the `InPlace` strategy, you can increment the version by only one minor release at a time. To update by more than one minor version, you must increment the version and restart the workloads after each update. Restarting workloads ensures compatibility between the sidecar and control plane versions. The update process is complete after restarting all workloads.
+When updating {istio} using the `InPlace` strategy, you can increment the version by only one minor release at a time. To update by more than one minor version, you must increment the version and restart the workloads after each update. 
+
+[NOTE]
+====
+Restarting workloads ensures compatibility between the sidecar and control plane versions. The update process is complete after restarting all workloads.
+====
 
 .Prerequisites
 
-* You are logged in to {ocp-product-title} as a user with the `cluster-admin` role.
+* You have logged in to {ocp-product-title} as a user with the `cluster-admin` role.
+
 * You have installed the {SMProductName} Operator, and deployed {istio}.
+
 * You have installed `istioctl` on your local machine.
+
 * You have configured the {istio} control plane to use the `InPlace` update strategy. In this example, the `{istio}` resource named `default` is deployed in the `istio-system` namespace.
-* You have installed the {istio} CNI plugin with the desired version. In this example, the `IstioCNI` resource named `default` is deployed in the `istio-cni` namespace.
+
+* You have installed the {istio} CNI plugin with the required version. In this example, the `IstioCNI` resource named `default` is deployed in the `istio-cni` namespace.
+
 * You have labeled the `bookinfo` namespace to enable sidecar injection.
+
 * You have application workloads running in the cluster. In this example, the `bookinfo` application is deployed in the `bookinfo` namespace.
 
 .Procedure
@@ -29,7 +40,7 @@ When updating {istio} using the `InPlace` strategy, you can increment the versio
 $ oc patch istio default --type='merge' -p '{"spec":{"version":"v1.24.4"}}'
 ----
 +
-.Version update in {istio} CR
+You can see the following example configuration for reference:
 +
 [source,yaml]
 ----
@@ -49,7 +60,7 @@ The {SMProductShortName} Operator deploys a new version of the control plane tha
 $ oc get istio
 ----
 +
-.Example output
+You will get an output similar to the following example:
 +
 [source,terminal]
 ----
@@ -73,7 +84,7 @@ $ oc rollout restart deployment -n bookinfo
 $ istioctl proxy-status 
 ----
 +
-.Example output
+You will get an output similar to the following example:
 +
 [source,terminal]
 ----

--- a/modules/ossm-updating-istio-control-plane-with-revisionbased-istiorevisiontag.adoc
+++ b/modules/ossm-updating-istio-control-plane-with-revisionbased-istiorevisiontag.adoc
@@ -12,14 +12,21 @@ When updating {istio} using the `RevisionBased` strategy, you can create an `Ist
 
 .Prerequisites
 
-* You are logged in to {ocp-product-title} as a user with the `cluster-admin` role.
+* You have logged in to {ocp-product-title} as a user with the `cluster-admin` role.
+
 * You have installed the {SMProductName} Operator 3, and deployed {istio} with the `RevisionBased` strategy. In this example, the `{istio}` resource named `default` is deployed in the `istio-system` namespace.
-* You have created an `IstioRevisionTag` resource and the `targetRef` field is referencing the desired `{istio}` resource.
-* You have installed the {istio} CNI plugin with the desired version.
+
+* You have created an `IstioRevisionTag` resource and the `targetRef` field is referencing the required `{istio}` resource.
+
+* You have installed the {istio} CNI plugin with the required version.
+
 * You have labeled the `bookinfo` namespace to enable sidecar injection.
+
 * You have application workloads running in the cluster. In this example, the `bookinfo` application is deployed in the `bookinfo` namespace.
+
 * You have installed `istioctl` on your local machine.
-* You have confirmed that the `InUse` field in the `IstioRevisionTag` resource is set to `true`.
+
+* You have set the `InUse` field in the `IstioRevisionTag` resource to `true`.
 
 .Procedure
 
@@ -30,7 +37,7 @@ When updating {istio} using the `RevisionBased` strategy, you can create an `Ist
 $ oc patch istio default --type='merge' -p '{"spec":{"version":"v1.24.4"}}'
 ----
 +
-.Version Update in {istio} CR
+You can see the following example configuration for reference:
 +
 [source,yaml]
 ----
@@ -52,7 +59,7 @@ The {SMProductShortName} Operator deploys a new version of the control plane alo
 $ oc get istio
 ----
 +
-.Example output
+You will get an output similar to the following example:
 +
 [source,terminal]
 ----
@@ -67,7 +74,7 @@ default   2           2       1        default-v1-24-3   Healthy   v1.24.3   9m2
 $ oc get istiorevision
 ----
 +
-.Example output
+You will get an output similar to the following example:
 +
 [source,terminal]
 ----
@@ -83,7 +90,7 @@ default-v1-24-4   Local   True    Healthy   True     v1.24.4   66s
 $ oc get istiorevisiontag
 ----
 +
-.Example output
+You will get an output similar to the following example:
 +
 [source,terminal]
 ----
@@ -98,7 +105,7 @@ default   Healthy   True     default-v1-24-4   10m44s
 $ oc get pods -n istio-system
 ----
 +
-.Example output
+You will get an output similar to the following example:
 +
 [source,terminal]
 ----
@@ -114,7 +121,7 @@ istiod-default-v1-24-4-7495cdc7bf-v8t4g   1/1     Running   0          113s
 $ istioctl proxy-status
 ----
 +
-.Example output
+You will get an output similar to the following example:
 +
 [source,terminal]
 ----
@@ -172,4 +179,4 @@ $ oc get istiorevision
 
 The {SMProduct} Operator deletes the old `IstioRevision` resource and the associated control plane after the grace period defined in the `spec.updateStrategy.inactiveRevisionDeletionGracePeriodSeconds` field expires. The default grace period is 30 seconds.
 
-You can increase the grace period to allow sufficient time to test the new control plane before removing the previous revision. Set a higher value during canary upgrades to ensure workload stability before fully transitioning.
+You can increase the grace period to allow enough time to test the new control plane before removing the earlier revision. Set a higher value during canary upgrades to ensure workload stability before fully transitioning.

--- a/modules/ossm-updating-istio-control-plane-with-revisionbased.adoc
+++ b/modules/ossm-updating-istio-control-plane-with-revisionbased.adoc
@@ -12,11 +12,16 @@ When updating {istio} using the `RevisionBased` strategy, you can upgrade by mor
 
 .Prerequisites
 
-* You are logged in to {ocp-product-title} as a user with the `cluster-admin` role.
+* You have logged in to {ocp-product-title} as a user with the `cluster-admin` role.
+
 * You have installed the {SMProductName} Operator 3, and deployed {istio} with the `RevisionBased` strategy. In this example, the `{istio}` resource named `default` is deployed in the `istio-system` namespace.
-* You have installed the {istio} CNI plugin with the desired version. In this example, the `IstioCNI` resource named `default` is deployed in the `istio-cni` namespace.
+
+* You have installed the {istio} CNI plugin with the required version. In this example, the `IstioCNI` resource named `default` is deployed in the `istio-cni` namespace.
+
 * You have labeled the `bookinfo` namespace to enable sidecar injection.
+
 * You have application workloads running in the cluster. In this example, the `bookinfo` application is deployed in the `bookinfo` namespace.
+
 * You have installed `istioctl` on your local machine.
 
 .Procedure
@@ -50,7 +55,7 @@ The {SMProductShortName} Operator deploys a new version of the control plane alo
 $ oc get istio
 ----
 +
-.Example output
+You will get an output similar to the following example:
 +
 [source,terminal]
 ----
@@ -65,7 +70,7 @@ default   2           2       1        default-v1-2-4   Healthy   v1.24.4   9m23
 $ oc get istiorevision
 ----
 +
-.Example output
+You will get an output similar to the following example:
 +
 [source,terminal]
 ----
@@ -81,7 +86,7 @@ default-v1-24-4   Local   True    Healthy   False    v1.24.4   66s
 $ oc get pods -n istio-system
 ----
 +
-.Example output
+You will get an output similar to the following example:
 +
 [source,terminal]
 ----
@@ -90,14 +95,14 @@ istiod-default-v1-24-3-c98fd9675-r7bfw    1/1     Running   0          10m
 istiod-default-v1-24-4-7495cdc7bf-v8t4g   1/1     Running   0          113s
 ----
 
-. Confirm that the workload sidecars are still connected to the previous control plane by running the following command:
+. Confirm that the workload sidecars are still connected to the earlier control plane by running the following command:
 +
 [source,terminal]
 ----
 $ istioctl proxy-status
 ----
 +
-.Example output
+You will get an output similar to the following example:
 +
 [source,terminal]
 ----
@@ -162,4 +167,4 @@ $ oc get istiorevision
 
 The {SMProduct} Operator deletes the old `IstioRevision` resource and the associated control plane after the grace period defined in the `spec.updateStrategy.inactiveRevisionDeletionGracePeriodSeconds` field expires. The default grace period is 30 seconds.
 
-You can increase the grace period to allow sufficient time to test the new control plane before removing the previous revision. Set a higher value during canary upgrades to ensure workload stability before fully transitioning.
+You can increase the grace period to allow enough time to test the new control plane before removing the earlier revision. Set a higher value during canary upgrades to ensure workload stability before fully transitioning.

--- a/modules/ossm-updating-waypoint-proxies-with-inplace-strategy.adoc
+++ b/modules/ossm-updating-waypoint-proxies-with-inplace-strategy.adoc
@@ -8,7 +8,7 @@
 
 [role="_abstract"]
 
-During an `InPlace` update in ambient mode, waypoint proxies are going to be updated to the latest control plane version without restarting application workloads because they are deployed and managed as separate Gateway API resources that scale and upgrade independently.
+Maintain application uptime during `InPlace` updates by independently upgrading waypoint proxies through the {k8s} Gateway API without restarting associated workloads.
 
 .Prerequisites
 
@@ -16,7 +16,7 @@ During an `InPlace` update in ambient mode, waypoint proxies are going to be upd
 
 .Procedure
 
-* Confirm that the waypoint proxy was updated proxy version by running the following command:
+* Confirm that you updated the waypoint proxy to the latest proxy version by running the following command:
 +
 [source,terminal]
 ----

--- a/modules/ossm-updating-waypoint-proxies-with-revisionbased-strategy.adoc
+++ b/modules/ossm-updating-waypoint-proxies-with-revisionbased-strategy.adoc
@@ -12,7 +12,7 @@ In ambient mode, you can update waypoint proxies by using the `RevisionBased` up
 
 [NOTE]
 ====
-Keep waypoint proxies within one minor version of the control plane (same version or `n–1`). This recommendation aligns with the support policy of {istio}, which states that data plane components must not run ahead of the control plane version. Apply the same versioning guidance to {istio} Container Network Interface (CNI) and `Ztunnel` components. For more details, see the "{istio} Supported Releases" documentation.
+Keep waypoint proxies within one minor version of the control plane (same version or `n-1`). This recommendation aligns with the support policy of {istio}, which states that data plane components must not run ahead of the control plane version. Apply the same versioning guidance to {istio} Container Network Interface (CNI) and `Ztunnel` components. For more details, see the "{istio} Supported Releases" documentation.
 ====
 
 .Prerequisites
@@ -36,7 +36,7 @@ NAME                       READY   STATUS    RESTARTS   AGE
 waypoint-5d9c8b7f9-abc12   1/1     Running   0          5m
 ----
 
-. Confirm that the waypoint proxy is updated to the latest version by running the following command:
+. Confirm that you updated the waypoint proxy to the latest version by running the following command:
 +
 [source,terminal]
 ----
@@ -50,4 +50,4 @@ You should see an output similar to the following example:
 waypoint-5d9c8b7f9-abc12.bookinfo     SYNCED     SYNCED     SYNCED     SYNCED     istiod-1-27-3-7b9f8c5d6-xyz78.istio-system     {istio-latest}
 ----
 +
-You can run the command to query the {istio} control plane and verify that the waypoint proxy is connected to the new revision. The output lists the revision-specific `istiod` pod (for example, `istiod-1-27-3`) and shows that the waypoint proxy is running the updated version, {istio-latest}. The revision-specific name in the `ISTIOD` column confirms that the waypoint proxy has successfully migrated to the new control plane revision.
+You can run the command to query the {istio} control plane and verify that the waypoint proxy connects to the new revision. The output lists the revision-specific `istiod` pod (for example, `istiod-1-27-3`) and shows that the waypoint proxy is running the updated version, {istio-latest}. The revision-specific name in the `ISTIOD` column confirms that the waypoint proxy has successfully migrated to the new control plane revision.

--- a/modules/ossm-verifying-l7-features-with-authorization-policies.adoc
+++ b/modules/ossm-verifying-l7-features-with-authorization-policies.adoc
@@ -8,7 +8,7 @@
 
 [role="_abstract"]
 
-After updating the waypoint proxies, verify that the Layer 7 (L7) authorization policies are enforced correctly. In this example, the `AuthorizationPolicy` resource named `productpage-waypoint` allows only requests from the `default/sa/curl` service account to send `GET` requests to the `productpage` service.
+After updating the waypoint proxies, verify that the Layer 7 (L7) authorization policies enforce correctly. In this example, the `AuthorizationPolicy` resource named `productpage-waypoint` allows only requests from the `default/sa/curl` service account to send `GET` requests to the `productpage` service.
 
 .Prerequisites
 
@@ -62,7 +62,7 @@ $ oc exec "$(
 curl -sS productpage:9080/productpage
 ----
 +
-The request will be denied because the `ratings` service is not included in the authorization policy’s `allow` list. Only the `curl` pod using the `default/curl` service account can access `productpage` service.
+The request will be denied because the `ratings` service is not included in the authorization policy's `allow` list. Only the `curl` pod by using the `default/curl` service account can access `productpage` service.
 
 . Verify that the `curl` service can access the `productpage` service with `GET` requests by running the following command:
 +

--- a/modules/ossm-verifying-l7-features-with-traffic-routing.adoc
+++ b/modules/ossm-verifying-l7-features-with-traffic-routing.adoc
@@ -65,4 +65,4 @@ for i in {1..10}; do
 done
 ----
 +
-The output should reflect the traffic distribution defined in your `HTTPRoute`. For example, with a `90/10` weight split between `reviews-v1` and `reviews-v2`, you should observe about nine requests routed to `reviews-v1` and one request routed to `reviews-v2`. The exact ratio can vary slightly due to load-balancing behavior, but should closely match the configured weights over multiple test runs.
+The output should reflect the traffic distribution defined in your `HTTPRoute`. For example, with a `90/10` weight split between `reviews-v1` and `reviews-v2`, you should observe about nine requests routed to `reviews-v1` and one request routed to `reviews-v2`. The exact ratio can vary slightly due to load balancing behavior, but should closely match the configured weights over many test runs.

--- a/modules/ossm-ztunnel-update-lifecycle.adoc
+++ b/modules/ossm-ztunnel-update-lifecycle.adoc
@@ -12,11 +12,11 @@ Understand the Ztunnel rolling update process, and how the process affects conne
 
 Ztunnel operates at Layer 4 (L4) of the Open Systems Interconnection (OSI) model and proxies TCP traffic. Ztunnel cannot transfer connection states to another process. Upgrading the Ztunnel DaemonSet affects all traffic on at least one node at a time.
 
-Ztunnel operates at Layer 4 (L4) of the Open Systems Interconnection (OSI) model and proxies TCP traffic. Ztunnel cannot transfer connection states to another process.  Upgrading the Ztunnel DaemonSet affects all traffic on at least one node at a time. By default, the Ztunnel DaemonSet uses a `RollingUpdate` strategy. During a restart, each node goes through the following phases:
+Ztunnel operates at Layer 4 (L4) of the Open Systems Interconnection (OSI) model and proxies TCP traffic. Ztunnel cannot transfer connection states to another process. Upgrading the Ztunnel DaemonSet affects all traffic on at least one node at a time. By default, the Ztunnel DaemonSet uses a `RollingUpdate` strategy. During a restart, each node goes through the following phases:
 
 * Startup: A new `Ztunnel` pod starts on the node while the old pod continues running.
 
-* Readiness: The new `Ztunnel` establishes listeners in each pod on the node and marks itself as ready. For a brief period, both instances run simultaneously, and new connections may be handled by either one.
+* Readiness: The new `Ztunnel` establishes listeners in each pod on the node and marks itself as ready. For a brief period, both instances run simultaneously, and either one might handle new connections.
 
 * Draining: {k8s} sends a `SIGTERM` to the old `Ztunnel`, which begins the draining process. The old instance closes its listeners so that only the new `Ztunnel` accepts new connections. At all times, at least one `Ztunnel` remains available to handle incoming connections.
 

--- a/update/ossm-about-updating-openshift-service-mesh.adoc
+++ b/update/ossm-about-updating-openshift-service-mesh.adoc
@@ -1,4 +1,4 @@
-:_content-type: ASSEMBLY
+:_mod-docs_content-type: ASSEMBLY
 [id="ossm-about-updating-openshift-service-mesh"]
 = About updating OpenShift Service Mesh
 include::_attributes/common-attributes.adoc[]

--- a/update/ossm-updating-istio-cni.adoc
+++ b/update/ossm-updating-istio-cni.adoc
@@ -1,4 +1,4 @@
-:_content-type: ASSEMBLY
+:_mod-docs_content-type: ASSEMBLY
 [id="ossm-updating-istio-cni"]
 = Updating the Istio CNI
 include::_attributes/common-attributes.adoc[]

--- a/update/ossm-updating-openshift-service-mesh-in-ambient-mode.adoc
+++ b/update/ossm-updating-openshift-service-mesh-in-ambient-mode.adoc
@@ -1,4 +1,4 @@
-:_content-type: ASSEMBLY
+:_mod-docs_content-type: ASSEMBLY
 [id="ossm-updating-openshift-service-mesh-in-ambient-mode"]
 = Updating OpenShift Service Mesh in ambient mode
 include::_attributes/common-attributes.adoc[]

--- a/update/ossm-updating-openshift-service-mesh.adoc
+++ b/update/ossm-updating-openshift-service-mesh.adoc
@@ -1,4 +1,4 @@
-:_content-type: ASSEMBLY
+:_mod-docs_content-type: ASSEMBLY
 [id="ossm-updating-openshift-service-mesh"]
 = Updating OpenShift Service Mesh
 include::_attributes/common-attributes.adoc[]


### PR DESCRIPTION
Change type: Doc update; CQA on all the modules in "Updating" chapter

Doc JIRA: https://issues.redhat.com/browse/OSSM-12961

Fix Version: [service-mesh-docs-main](https://github.com/openshift/openshift-docs/tree/service-mesh-docs-main)

NOTE: Will create manual CPs for the following branches:

[service-mesh-docs-3.0](https://github.com/openshift/openshift-docs/tree/service-mesh-docs-3.0)
[service-mesh-docs-3.1](https://github.com/openshift/openshift-docs/tree/service-mesh-docs-3.1)
[service-mesh-docs-3.2](https://github.com/openshift/openshift-docs/tree/service-mesh-docs-3.2)
[service-mesh-docs-3.3](https://github.com/openshift/openshift-docs/tree/service-mesh-docs-3.3) This branch can be automatically CP'd.

Doc Preview:

Peer Review: