### PR TITLE
CNV#82727_422: Removing “Setting a live migration feature gate for each cluster in OpenShift Virtualization" 

### DIFF
--- a/virt/live_migration/virt-configuring-cross-cluster-live-migration-network.adoc
+++ b/virt/live_migration/virt-configuring-cross-cluster-live-migration-network.adoc
@@ -7,11 +7,8 @@ include::_attributes/attributes-openshift-dedicated.adoc[]
 
 toc::[]
 
-[role="_abstract"] 
+[role="_abstract"]
 Cross-cluster live migration requires that the clusters be connected in the same network. Specifically, `virt-handler` pods must be able to communicate.
-
-:FeatureName: Cross-cluster live migration
-include::snippets/technology-preview.adoc[]
 
 include::modules/nw-multus-bridge-object.adoc[leveloffset=+1]
 

--- a/virt/live_migration/virt-enabling-cclm-for-vms.adoc
+++ b/virt/live_migration/virt-enabling-cclm-for-vms.adoc
@@ -20,7 +20,3 @@ Cross-cluster live migration enables users to move a virtual machine (VM) worklo
 
 * You must have cluster administration privileges and appropriate RBAC privileges to manage VMs on both clusters.
 
-include::snippets/technology-preview.adoc[]
-
-include::modules/virt-setting-openshiftv-lm-feature-gates.adoc[leveloffset=+1]
-

--- a/virt/live_migration/virt-enabling-cclm-for-vms.adoc
+++ b/virt/live_migration/virt-enabling-cclm-for-vms.adoc
@@ -7,6 +7,7 @@ include::_attributes/attributes-openshift-dedicated.adoc[]
 
 toc::[]
 
+[role=”_abstract”]
 Cross-cluster live migration enables users to move a virtual machine (VM) workload from one {product-title} cluster to another cluster without disruption. You enable cross-cluster live migration by setting cluster feature gates in {VirtProductName} and {mtv-first}.
 
 .Prerequisites
@@ -19,9 +20,7 @@ Cross-cluster live migration enables users to move a virtual machine (VM) worklo
 
 * You must have cluster administration privileges and appropriate RBAC privileges to manage VMs on both clusters.
 
-:FeatureName: Cross-cluster live migration
 include::snippets/technology-preview.adoc[]
 
 include::modules/virt-setting-openshiftv-lm-feature-gates.adoc[leveloffset=+1]
 
-include::modules/virt-setting-mtv-lm-feature-gates.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s): 4.22+

Issue: [CNV-82727](https://redhat.atlassian.net/browse/CNV-82727)

Link to docs preview:

QE review:
- [ ] QE has approved this change.
