### PR TITLE
OSDOCS-18854:Update the z-stream RNs for 4.17.52

### DIFF
--- a/modules/zstream-4-17-52.adoc
+++ b/modules/zstream-4-17-52.adoc
@@ -1,0 +1,37 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-17-release-notes.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="zstream-4-17-52-about_{context}"]
+= RHSA-2026:5907 - {product-title} {product-version}.52 fixed issues and security update
+
+Issued: 01 April 2026
+
+[role="_abstract"]
+{product-title} release {product-version}.52 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2026:5907[RHSA-2026:5907] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2026:5866[RHSA-2026:5866] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.17.52--pullspecs
+----
+
+[id="zstream-4-17-52-fixed-issues_{context}"]
+== Fixed issues
+
+* Before this update, the systemd use in the container entry point prevented the `ConfigMap` mount from working correctly, which caused broken file permissions. As a consequence, users could not access config files due to the broken file permissions in the containers. With this release, the systemd entry point issue is resolved, which allows the config map mount with the correct file permissions. As a result, the file permissions are correct for the containers. (link:https://redhat.atlassian.net/browse/OCPBUGS-69673[OCPBUGS-69673])
+
+* Before this update, the Cluster Version Operator (CVO) on {product-rosa} Hosted Control Plane (HCP) clusters using Red Hat Observability Service (RHOBS) monitoring (`--rhobs-monitoring=true`), could not access the Prometheus metrics endpoint, which meant conditional update risks could not be properly evaluated. This issue prevented you from receiving accurate risk assessments, which often stalled or complicated the upgrade process. With this release, the `--rhobs-monitoring` flag automatically enables CVO access to the RHOBS Prometheus endpoint, which is supported by updated network policies that allow for proper egress based on the specific stack configuration. Additionally, a new `--cvo-prometheus-url` flag is introduced for optional customization of the endpoint. (link:https://redhat.atlassian.net/browse/OCPBUGS-76533[OCPBUGS-76533])
+
+* Before this update, cluster namespaces with the "nodes" suffix caused the Performance Profile Creator (PPC) to fail because it did not exclude the `namespaces` directory when it processed the must-gather data. With this release, the PPC now correctly excludes the `namespaces` directory when it processes the must-gather data. As a result, a suggested `PerformanceProfile` object is successfully created.  (link:https://redhat.atlassian.net/browse/OCPBUGS-78214[OCPBUGS-78214])
+
+* Before this update, the Machine API Operator used the `infraID-rg` resource group name when it created a default image ID. As a consequence, clusters with a resource group that did not use that name received an incorrect default machine set, which prevented the provisioning of the machines. With this release, the Machine API Operator reads the resource group from the infrastructure configuration. As a result, the correct image ID is generated and the machine set can scale the machines. (link:https://redhat.atlassian.net/browse/OCPBUGS-79373[OCPBUGS-79373])
+
+[id="zstream-4-17-52-updating_{context}"]
+== Updating
+
+To update an {product-title} 4.17 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].

--- a/release_notes/ocp-4-17-release-notes.adoc
+++ b/release_notes/ocp-4-17-release-notes.adoc
@@ -2947,6 +2947,9 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+// 4.17.52
+include::modules/zstream-4-17-52.adoc[leveloffset=+2]
+
 // 4.17.51
 include::modules/zstream-4-17-51.adoc[leveloffset=+2]
 


### PR DESCRIPTION
Version(s):
4.17

Issue:
https://redhat.atlassian.net/browse/OSDOCS-18854

Link to docs preview:
https://109068--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-17-release-notes.html#zstream-4-17-52-about_release-notes

Additional information:
4.17.52 MR: https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/439
ART Dashboard: https://art-dash.engineering.redhat.com/dashboard/release/openshift-4.17