### PR TITLE
MULTIARCH-5383 adding fallbackArchitecture

### DIFF
--- a/modules/multi-arch-creating-podplacment-config.adoc
+++ b/modules/multi-arch-creating-podplacment-config.adoc
@@ -24,34 +24,36 @@ You can create only one instance of the `ClusterPodPlacementConfig` object.
 apiVersion: multiarch.openshift.io/v1beta1
 kind: ClusterPodPlacementConfig
 metadata:
-  name: cluster <1>
+  name: cluster
 spec:
-  logVerbosityLevel: Normal <2>
-  namespaceSelector: <3>
+  logVerbosity: Normal
+  namespaceSelector:
     matchExpressions:
       - key: multiarch.openshift.io/exclude-pod-placement
         operator: DoesNotExist
-  plugins: <4>
-    nodeAffinityScoring: <5>
-      enabled: true <6>
-      platforms: <7>
-        - architecture: amd64 <8>
-          weight: 100 <9>
+  plugins:
+    nodeAffinityScoring:
+      enabled: true
+      platforms:
+        - architecture: amd64
+          weight: 100
         - architecture: arm64
           weight: 50
     execFormatErrorMonitor:
-      enabled: true <10>
+      enabled: true
+  fallbackArchitecture: amd64
 ----
-<1> You must set this field value to `cluster`.
-<2> Optional: You can set the field value to `Normal`, `Debug`, `Trace`, or `TraceAll`. The value is set to `Normal` by default.
-<3> Optional: You can configure the `namespaceSelector` to select the namespaces in which the Multiarch Tuning Operator's pod placement operand must process the `nodeAffinity` of the pods. All namespaces are considered by default.
-<4> Optional: Includes a list of plugins for architecture-aware workload scheduling.
-<5> Optional: You can use this plugin to set architecture preferences for pod placement. When enabled, the scheduler first filters out nodes that do not meet the pod's requirements. Then, it prioritizes the remaining nodes based on the architecture scores defined in the `nodeAffinityScoring.platforms` field.
-<6> Optional: Set this field to `true` to enable the `nodeAffinityScoring` plugin. The default value is `false`.
-<7> Optional: Defines a list of architectures and their corresponding scores.
-<8> Specify the node architecture to score. The scheduler prioritizes nodes for pod placement based on the architecture scores that you set and the scheduling requirements defined in the pod specification. Accepted values are `arm64`, `amd64`, `ppc64le`, or `s390x`.
-<9> Assign a score to the architecture. The value for this field must be configured in the range of `1` (lowest priority) to `100` (highest priority). The scheduler uses this score to prioritize nodes for pod placement, favoring nodes with architectures that have higher scores.
-<10> Optional: Set this field to `true` to enable the `execFormatErrorMonitor` plugin. When enabled, the plugin detects `ENOEXEC` errors, caused when a pod executes a binary incompatible with the node's architecture. The plugin generates events in the affected pods, and triggers the `ExecFormatErrorsDetected` Prometheus alert if one or more errors are found in the last six hours.
+where:
+
+`metadata.name`:: Specifies the name of the object. You must set this parameter to `cluster`.
+`spec.logVerbosity`:: Optional: Specifies the log verbosity level. You can set the field value to `Normal`, `Debug`, `Trace`, or `TraceAll`. The value is set to `Normal` by default.
+`spec.namespaceSelector`:: Optional: You can configure the `namespaceSelector` to select the namespaces in which the Multiarch Tuning Operator's pod placement operand must process the `nodeAffinity` of the pods. All namespaces are considered by default.
+`spec.plugins.nodeAffinityScoring.enabled`:: Optional: You can enable the node affinity scoring plugin to set architecture preferences for pod placement. When enabled, the scheduler first filters out nodes that do not meet the pod's requirements. Then, it prioritizes the remaining nodes based on the architecture scores defined in the `nodeAffinityScoring.platforms` field. The default value is false.
+`spec.plugins.nodeAffinityScoring.platforms`:: Optional: Defines a list of architectures and their corresponding scores. The scheduler prioritizes nodes for pod placement based on the architecture scores that you set and the scheduling requirements defined in the pod specification.
+`spec.plugins.nodeAffinityScoring.platforms.architecture`:: Specifies the architecture for the node affinity scoring plugin. Accepted values are `arm64`, `amd64`, `ppc64le`, or `s390x`.
+`spec.plugins.nodeAffinityScoring.platforms.weight`:: Specifies the weight for the architecture you specified in the `spec.plugins.nodeAffinityScoring.platforms.architecture` parameter. The value must be configured in the range of `1` (lowest priority) to `100` (highest priority). The scheduler uses this score to prioritize nodes for pod placement, favoring nodes with architectures that have higher scores.
+`spec.plugins.execFormatErrorMonitor.enabled`:: Optional: Set this field to `true` to enable the `execFormatErrorMonitor` plugin. When enabled, the plugin detects `ENOEXEC` errors, caused when a pod executes a binary incompatible with the node's architecture. The plugin generates events in the affected pods, and triggers the `ExecFormatErrorsDetected` Prometheus alert if one or more errors are found in the last six hours.
+`spec.fallbackArchitecture`:: Optional: Specifies an architecture where pods will be scheduled if the image inspector cannot determine the architecture of the image. Valid values are `""`, `arm64`, `amd64`, `ppc64le`, or `s390x`.  The value is set to `""` by default.
 
 In this example, the `operator` field value is set to `DoesNotExist`. Therefore, if the `key` field value (`multiarch.openshift.io/exclude-pod-placement`) is set as a label in a namespace, the operand does not process the `nodeAffinity` of the pods in that namespace. Instead, the operand processes the `nodeAffinity` of the pods in namespaces that do not contain the label.
 


### PR DESCRIPTION
Version(s):
4.21+

Issue:
https://redhat.atlassian.net/browse/MULTIARCH-5383

Link to docs preview:
https://109087--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/configuring-multi-arch-compute-machines/multiarch-tuning-operator.html#multi-architecture-creating-podplacement-config_multiarch-tuning-operator

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
This PR also includes some changes to soothe the Vale linter.