### PR TITLE
OSDOCS-16883-4.16:CQA MNW

### DIFF
--- a/modules/nw-multus-ipam-object.adoc
+++ b/modules/nw-multus-ipam-object.adoc
@@ -154,7 +154,7 @@ spec:
 
 where:
 
-`type`:: Specifies dynamic IP address assignment for the cluster.
+`spec.additionalNetworks.name.type`:: Specifies dynamic IP address assignment for the cluster.
 
 The following table describes the configuration parameters for dynamic IP address address assignment with DHCP.
 
@@ -184,12 +184,12 @@ The following JSON example describes the configuration p for dynamic IP address 
 [id="nw-multus-whereabouts_{context}"]
 == Dynamic IP address assignment configuration with Whereabouts
 
-The Whereabouts CNI plugin allows the dynamic assignment of an IP address to an additional network without the use of a DHCP server. 
+The Whereabouts CNI plugin allows the dynamic assignment of an IP address to an additional network without the use of a DHCP server.
 
 The Whereabouts CNI plugin also supports overlapping IP address ranges and configuration of the same CIDR range multiple times within separate `NetworkAttachmentDefinition` CRDs. This provides greater flexibility and management capabilities in multi-tenant environments.
 
 [id="dynamic-ip-address-assignment-objects_{context}"]
-=== Dynamic IP address configuration objects
+== Dynamic IP address configuration objects
 
 The following table describes the configuration objects for dynamic IP address assignment with Whereabouts:
 
@@ -217,7 +217,7 @@ The following table describes the configuration objects for dynamic IP address a
 |====
 
 [id="dynamic-ip-address-assignment-whereabouts_{context}"]
-=== Dynamic IP address assignment configuration that uses Whereabouts
+== Dynamic IP address assignment configuration that uses Whereabouts
 
 The following example shows a dynamic address assignment configuration that uses Whereabouts:
 
@@ -237,9 +237,9 @@ The following example shows a dynamic address assignment configuration that uses
 ----
 
 [id="dynamic-ip-address-assignment-whereabouts-overlapping-ip-ranges_{context}"]
-=== Dynamic IP address assignment that uses Whereabouts with overlapping IP address ranges
+== Dynamic IP address assignment that uses Whereabouts with overlapping IP address ranges
 
-The following example shows a dynamic IP address assignment that uses overlapping IP address ranges for multi-tenant networks. 
+The following example shows a dynamic IP address assignment that uses overlapping IP address ranges for multi-tenant networks.
 
 .NetworkAttachmentDefinition 1
 [source,json]
@@ -248,11 +248,12 @@ The following example shows a dynamic IP address assignment that uses overlappin
   "ipam": {
     "type": "whereabouts",
     "range": "192.0.2.192/29",
-    "network_name": "example_net_common", <1>
+    "network_name": "example_net_common",
   }
 }
 ----
-<1> Optional. If set, must match the `network_name` of `NetworkAttachmentDefinition 2`.
+
+`network_name` is an optional field that if set, must match the `network_name` of `NetworkAttachmentDefinition 2`.
 
 .NetworkAttachmentDefinition 2
 [source,json]
@@ -261,8 +262,10 @@ The following example shows a dynamic IP address assignment that uses overlappin
   "ipam": {
     "type": "whereabouts",
     "range": "192.0.2.192/24",
-    "network_name": "example_net_common", <1>
+    "network_name": "example_net_common",
   }
 }
 ----
-<1> Optional. If set, must match the `network_name` of `NetworkAttachmentDefinition 1`. 
+
+`network_name` is an optional field that if set, must match the `network_name` of `NetworkAttachmentDefinition 1`.
+


### PR DESCRIPTION
This PR remediates work done here: https://github.com/openshift/openshift-docs/pull/104854
See additional details.



<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.16
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
https://redhat.atlassian.net/browse/OSDOCS-16867
https://redhat.atlassian.net/browse/OSDOCS-18678
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
https://109095--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/multiple_networks/configuring-additional-network.html#nw-multus-ipam-object_configuring-additional-network
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
In 4.16 much of the strucuture for MNW doesn't exist so it had to be made during CQA work a bit. Here is how I reviewed things for CQA remediation checks: I opened my original PR, imploded any assembly it touched, reran ditavaleocp on all of the assembly and modules files. I found the following errors in files my PR didn't originally touch and were part of another ticket, but I'm fixing them: modules/nw-multus-ipam-object.adoc
 192:1  error    Level 2, 3, 4, and 5 sections   AsciiDocDITA.NestedSection 
                 are not supported in DITA.                                 
 220:1  error    Level 2, 3, 4, and 5 sections   AsciiDocDITA.NestedSection 
                 are not supported in DITA.                                 
 240:1  error    Level 2, 3, 4, and 5 sections   AsciiDocDITA.NestedSection 
                 are not supported in DITA.                                 
 255:1  warning  Callouts are not supported in   AsciiDocDITA.CalloutList   
                 DITA.                                                      
 268:1  warning  Callouts are not supported in   AsciiDocDITA.CalloutList   
                 DITA.                                                      
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
