### PR TITLE
PR for SRVCOM-4358: CQA + DITA readiness for assemblies and modules under the "Observability" section

### DIFF
--- a/modules/distr-tracing-product-overview.adoc
+++ b/modules/distr-tracing-product-overview.adoc
@@ -23,8 +23,8 @@ With {DTShortName} you can perform the following functions:
 
 {DTProductName} consists of two main components:
 
-* *{JaegerName}* - This component uses the open source link:https://www.jaegertracing.io/[Jaeger project].
+* *{JaegerName}* - This component uses the open source Jaeger project.
 
-* *{OTELNAME}* - This component uses the open source link:https://opentelemetry.io/[OpenTelemetry project].
+* *{OTELNAME}* - This component uses the open source OpenTelemetry project.
 
-Both components use vendor-neutral link:https://opentracing.io/[OpenTracing] APIs and instrumentation.
+Both components use vendor-neutral OpenTracing APIs and instrumentation.

--- a/modules/serverless-config-request-log.adoc
+++ b/modules/serverless-config-request-log.adoc
@@ -15,7 +15,8 @@ For information about the available parameters for configuring request logging, 
 
 * Configure request logging for your service by modifying the `observability` field in your `KnativeServing` CR:
 +
-.Example `KnativeServing` CR
+You get an output similar to the following example:
++
 [source,yaml]
 ----
 apiVersion: operator.knative.dev/v1beta1

--- a/modules/serverless-default-metrics-knative-services.adoc
+++ b/modules/serverless-default-metrics-knative-services.adoc
@@ -1,0 +1,110 @@
+// Module is included in the following assemblies:
+//
+// * /serverless/monitor/serverless-monitoring-services-default-metrics
+
+:_mod-docs-content-type: REFERENCE
+[id="serverless-default-metrics-knative-services_{context}"]
+= Default metrics for Knative services
+
+[role="_abstract"]
+The following table describes the default metrics that Knative services expose on port `9091`, including their units, types, descriptions, and metric tags.
+
+Knative services expose the following metrics by default on port `9091`.
+
+.Metrics exposed by default for each Knative service on port 9091
+[options=header]
+|===
+
+|Metric name, unit, and type |Description |Metric tags
+
+// New row
+|`request_count`
+
+Metric unit: dimensionless
+
+Metric type: counter
+
+|The number of requests that are routed to `queue-proxy`.
+
+|configuration_name="event-display",
+container_name="queue-proxy",
+namespace_name="apiserversource1",
+pod_name="event-display-00001-deployment-658fd4f9cf-qcnr5",
+response_code="200",
+response_code_class="2xx",
+revision_name="event-display-00001",
+service_name="event-display"
+
+// New row
+|`request_latencies`
+
+Metric unit: milliseconds
+
+Metric type: histogram
+
+|The response time in milliseconds.
+
+|configuration_name="event-display",
+container_name="queue-proxy",
+namespace_name="apiserversource1",
+pod_name="event-display-00001-deployment-658fd4f9cf-qcnr5",
+response_code="200",
+response_code_class="2xx",
+revision_name="event-display-00001",
+service_name="event-display"
+
+// New row
+|`app_request_count`
+
+Metric unit: dimensionless
+
+Metric type: counter
+
+|The number of requests that are routed to `user-container`.
+
+|configuration_name="event-display",
+container_name="queue-proxy",
+namespace_name="apiserversource1",
+pod_name="event-display-00001-deployment-658fd4f9cf-qcnr5",
+response_code="200",
+response_code_class="2xx",
+revision_name="event-display-00001",
+service_name="event-display"
+
+// New row
+|`app_request_latencies`
+
+Metric unit: milliseconds
+
+Metric type: histogram
+
+|The response time in milliseconds.
+
+|configuration_name="event-display",
+container_name="queue-proxy",
+namespace_name="apiserversource1",
+pod_name="event-display-00001-deployment-658fd4f9cf-qcnr5",
+response_code="200",
+response_code_class="2xx",
+revision_name="event-display-00001",
+service_name="event-display"
+
+// New row
+|`queue_depth`
+
+Metric unit: dimensionless
+
+Metric type: gauge
+
+|The current number of items in the serving and waiting queue, or not reported if unlimited concurrency. `breaker.inFlight` is used.
+
+|configuration_name="event-display",
+container_name="queue-proxy",
+namespace_name="apiserversource1",
+pod_name="event-display-00001-deployment-658fd4f9cf-qcnr5",
+response_code="200",
+response_code_class="2xx",
+revision_name="event-display-00001",
+service_name="event-display"
+
+|===

--- a/modules/serverless-event-source-metrics.adoc
+++ b/modules/serverless-event-source-metrics.adoc
@@ -24,7 +24,7 @@ You can use the following metrics to verify that the event source delivered even
 |Integer (no units)
 
 |`retry_event_count`
-|The event source retries and sends events that failed during the initial delivery attempt.
+|The event source retries and sends events that failed during the initial delivery trial.
 |Counter
 |`event_source`, `event_type`, `name`, `namespace_name`, `resource_group`, `response_code`, `response_code_class`, `response_error`, `response_timeout` |Integer (no units)
 |===

--- a/modules/serverless-go-application-custom-metrics-example.adoc
+++ b/modules/serverless-go-application-custom-metrics-example.adoc
@@ -1,0 +1,80 @@
+// Module is included in the following assemblies:
+//
+// * /serverless/monitor/serverless-developer-metrics.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="serverless-go-application-custom-metrics-example_{context}"]
+= Go application example for exporting custom metrics
+
+[role="_abstract"]
+The following section provides a sample Go application that exports a custom metric to track the number of processed events by using Prometheus.
+
+The following example shows a Go application that exposes a custom Prometheus metric for the total number of processed events:
+
+[source,go]
+----
+package main
+
+import (
+  "fmt"
+  "log"
+  "net/http"
+  "os"
+
+  "github.com/prometheus/client_golang/prometheus"
+  "github.com/prometheus/client_golang/prometheus/promauto"
+  "github.com/prometheus/client_golang/prometheus/promhttp"
+)
+
+var (
+  opsProcessed = promauto.NewCounter(prometheus.CounterOpts{
+     Name: "myapp_processed_ops_total",
+     Help: "The total number of processed events",
+  })
+)
+
+
+func handler(w http.ResponseWriter, r *http.Request) {
+  log.Print("helloworld: received a request")
+  target := os.Getenv("TARGET")
+  if target == "" {
+     target = "World"
+  }
+  fmt.Fprintf(w, "Hello %s!\n", target)
+  opsProcessed.Inc()
+}
+
+func main() {
+  log.Print("helloworld: starting server...")
+
+  port := os.Getenv("PORT")
+  if port == "" {
+     port = "8080"
+  }
+
+  http.HandleFunc("/", handler)
+
+  // Separate server for metrics requests
+  go func() {
+     mux := http.NewServeMux()
+     server := &http.Server{
+        Addr: fmt.Sprintf(":%s", "9095"),
+        Handler: mux,
+     }
+     mux.Handle("/metrics", promhttp.Handler())
+     log.Printf("prometheus: listening on port %s", 9095)
+     log.Fatal(server.ListenAndServe())
+  }()
+
+   // Use same port as normal requests for metrics
+  //http.Handle("/metrics", promhttp.Handler())
+  log.Printf("helloworld: listening on port %s", port)
+  log.Fatal(http.ListenAndServe(fmt.Sprintf(":%s", port), nil))
+}
+----
+
+`github.com/prometheus/client_golang/prometheus`:: Including the Prometheus packages.
+`opsProcessed = promauto.NewCounter`:: Defining the `opsProcessed` metric.
+`opsProcessed.Inc()`:: Incrementing the `opsProcessed` metric.
+`go func()`:: Configuring to use a separate server for metrics requests.
+`http.Handle`:: Configuring to use the same port as normal requests for metrics and the `metrics` subpath.

--- a/modules/serverless-go-metrics.adoc
+++ b/modules/serverless-go-metrics.adoc
@@ -7,7 +7,7 @@
 = Go runtime metrics
 
 [role="_abstract"]
-Each Knative Serving control plane process emits a number of Go runtime memory statistics (link:https://golang.org/pkg/runtime/#MemStats[MemStats]).
+Each Knative Serving control plane process emits many Go runtime memory statistics, as defined in `MemStats`.
 
 [NOTE]
 ====
@@ -53,7 +53,7 @@ The `name` tag for each metric is an empty tag.
 |Integer (no units)
 
 |`go_frees`
-|The cumulative count of heap objects that have been freed.
+|The cumulative count of heap objects that are free.
 |Gauge
 |`name`
 |Integer (no units)
@@ -155,7 +155,7 @@ The `name` tag for each metric is an empty tag.
 |Integer (no units)
 
 |`go_last_gc`
-|The time that the last garbage collection was completed in link:https://en.wikipedia.org/wiki/Unix_time[_Epoch_ or Unix time].
+|The time that the last garbage collection was completed.
 |Gauge
 |`name`
 |Nanoseconds

--- a/modules/serverless-inmemory-dispatch-metrics.adoc
+++ b/modules/serverless-inmemory-dispatch-metrics.adoc
@@ -7,7 +7,7 @@
 = InMemoryChannel dispatcher metrics
 
 [role="_abstract"]
-You can use the following metrics to debug `InMemoryChannel` channels, see how they are performing, and see which events are being dispatched by the channels.
+You can use the following metrics to debug `InMemoryChannel` channels, evaluate their performance, and identify the events that the channels dispatch.
 
 [cols=5*,options="header"]
 |===

--- a/modules/serverless-jaeger-config.adoc
+++ b/modules/serverless-jaeger-config.adoc
@@ -4,15 +4,14 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="serverless-jaeger-config_{context}"]
-= Configuring Jaeger to enable distributed tracing
+= Configuring Jaeger to enable {DTShortName}
 
 [role="_abstract"]
-To enable distributed tracing using Jaeger, you must install and configure Jaeger as a standalone integration.
+To enable {DTShortName} using Jaeger, you must install and configure Jaeger as a standalone integration.
 
 .Prerequisites
 
 * You have cluster administrator permissions on {ocp-product-title}, or you have cluster or dedicated administrator permissions on {rosa-product-title} or {dedicated-product-title}.
-
 * You have installed the {ServerlessOperatorName}, Knative Serving, and Knative Eventing.
 * You have installed the {JaegerName} Operator.
 * You have installed the OpenShift CLI (`oc`).
@@ -20,9 +19,8 @@ To enable distributed tracing using Jaeger, you must install and configure Jaege
 
 .Procedure
 
-. Create and apply a `Jaeger` custom resource (CR) that contains the following:
+. Create and apply a `Jaeger` custom resource (CR) that has the following:
 +
-.Jaeger CR
 [source,yaml]
 ----
 apiVersion: jaegertracing.io/v1
@@ -34,7 +32,6 @@ metadata:
 
 . Enable tracing for Knative Serving, by editing the `KnativeServing` CR and adding a YAML configuration for tracing:
 +
-.Tracing YAML example for Serving
 [source,yaml]
 ----
 apiVersion: operator.knative.dev/v1beta1
@@ -45,20 +42,19 @@ metadata:
 spec:
   config:
     tracing:
-      sample-rate: "0.1" <1>
-      backend: zipkin <2>
-      zipkin-endpoint: "http://jaeger-collector.default.svc.cluster.local:9411/api/v2/spans" <3>
-      debug: "false" <4>
+      sample-rate: "0.1"
+      backend: zipkin
+      zipkin-endpoint: "http://jaeger-collector.default.svc.cluster.local:9411/api/v2/spans"
+      debug: "false"
 ----
-+
-<1> The `sample-rate` defines sampling probability. Using `sample-rate: "0.1"` means that 1 in 10 traces are sampled.
-<2> `backend` must be set to `zipkin`.
-<3> The `zipkin-endpoint` must point to your `jaeger-collector` service endpoint. To get this endpoint, substitute the namespace where the Jaeger CR is applied.
-<4> Debugging should be set to `false`. Enabling debug mode by setting `debug: "true"` allows all spans to be sent to the server, bypassing sampling.
+
+`sample-rate`:: The `sample-rate` defines sampling probability. Using `sample-rate: "0.1"` means that 1 in 10 traces are sampled.
+`backend: zipkin`:: You must set `backend` to `zipkin`.
+`zipkin-endpoint`:: The `zipkin-endpoint` must point to your `jaeger-collector` service endpoint. To get this endpoint, substitute the namespace where the Jaeger CR is applied.
+`debug`:: Debugging should be set to `false`. Enabling debug mode by setting `debug: "true"` allows all spans to be sent to the server, bypassing sampling.
 
 . Enable tracing for Knative Eventing by editing the `KnativeEventing` CR:
 +
-.Tracing YAML example for Eventing
 [source,yaml]
 ----
 apiVersion: operator.knative.dev/v1beta1
@@ -69,16 +65,16 @@ metadata:
 spec:
   config:
     tracing:
-      sample-rate: "0.1" <1>
-      backend: zipkin <2>
-      zipkin-endpoint: "http://jaeger-collector.default.svc.cluster.local:9411/api/v2/spans" <3>
-      debug: "false" <4>
+      sample-rate: "0.1"
+      backend: zipkin
+      zipkin-endpoint: "http://jaeger-collector.default.svc.cluster.local:9411/api/v2/spans"
+      debug: "false"
 ----
-+
-<1> The `sample-rate` defines sampling probability. Using `sample-rate: "0.1"` means that 1 in 10 traces are sampled.
-<2> Set `backend` to `zipkin`.
-<3> Point the `zipkin-endpoint` to your `jaeger-collector` service endpoint. To get this endpoint, substitute the namespace where the Jaeger CR is applied.
-<4> Debugging should be set to `false`. Enabling debug mode by setting `debug: "true"` allows all spans to be sent to the server, bypassing sampling.
+
+`sample-rate`:: The `sample-rate` defines sampling probability. Using `sample-rate: "0.1"` means that 1 in 10 traces are sampled.
+`backend: zipkin`:: Set `backend` to `zipkin`.
+`zipkin-endpoint`:: Point the `zipkin-endpoint` to your `jaeger-collector` service endpoint. To get this endpoint, substitute the namespace where the Jaeger CR is applied.
+`debug`:: Debugging should be set to `false`. Enabling debug mode by setting `debug: "true"` allows all spans to be sent to the server, bypassing sampling.
 
 .Verification
 
@@ -91,7 +87,8 @@ You can access the Jaeger web console to see tracing data, by using the `jaeger`
 $ oc get route jaeger -n default
 ----
 +
-.Example output
+You get an output similar to the following example:
++
 [source,terminal]
 ----
 NAME     HOST/PORT                         PATH   SERVICES       PORT    TERMINATION   WILDCARD

--- a/modules/serverless-knative-kafka-subscription-metrics.adoc
+++ b/modules/serverless-knative-kafka-subscription-metrics.adoc
@@ -23,7 +23,7 @@ You can use the following metrics to debug and visualize the performance of subs
 a|
 `consumer_name`:: Subscription name
 `namespace_name`:: Subscription namespace
-`name`:: KafkaChannel name
+`name`:: `KafkaChannel` name
 `event_type`:: event type
 `response_code`:: HTTP response code returned by the `Subscription` subscriber service
 `response_code_class`:: HTTP response code class returned by the `Subscription` subscriber service: 2xx, 3xx, 4xx, 5xx
@@ -35,7 +35,7 @@ a|
 a|
 `consumer_name`:: Subscription name
 `namespace_name`:: Subscription namespace
-`name`:: KafkaChannel name
+`name`:: `KafkaChannel` name
 `event_type`:: event type
 `response_code`:: HTTP response code returned by the `Subscription` subscriber service
 `response_code_class`:: HTTP response code class returned by the `Subscription` subscriber service: 2xx, 3xx, 4xx, 5xx
@@ -47,7 +47,7 @@ a|
 a|
 `consumer_name`:: Subscription name
 `namespace_name`:: Subscription namespace
-`name`:: KafkaChannel name
+`name`:: `KafkaChannel` name
 `event_type`:: event type
 |Dimensionless
 

--- a/modules/serverless-knative-service-metrics-scraping-config-example.adoc
+++ b/modules/serverless-knative-service-metrics-scraping-config-example.adoc
@@ -1,0 +1,75 @@
+// Module is included in the following assemblies:
+//
+// * /serverless/monitor/serverless-developer-metrics.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="serverless-knative-service-metrics-scraping-config-example_{context}"]
+= Knative service metrics scraping configuration example
+
+[role="_abstract"]
+This reference provides a sample configuration for a Knative service and a `ServiceMonitor` resource to enable metrics scraping for an application.
+
+The following example defines a Knative service and configures a `ServiceMonitor` resource to scrape metrics. The exact configuration depends on the application and how it exports metrics.
+
+[source,yaml]
+----
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  name: helloworld-go
+spec:
+  template:
+    metadata:
+      labels:
+        app: helloworld-go
+      annotations:
+    spec:
+      containers:
+      - image: docker.io/skonto/helloworld-go:metrics
+        resources:
+          requests:
+            cpu: "200m"
+        env:
+        - name: TARGET
+          value: "Go Sample v1"
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+  name: helloworld-go-sm
+spec:
+  endpoints:
+  - port: queue-proxy-metrics
+    scheme: http
+  - port: app-metrics
+    scheme: http
+  namespaceSelector: {}
+  selector:
+    matchLabels:
+       name:  helloworld-go-sm
+---
+apiVersion: v1 <3>
+kind: Service
+metadata:
+  labels:
+    name:  helloworld-go-sm
+  name:  helloworld-go-sm
+spec:
+  ports:
+  - name: queue-proxy-metrics
+    port: 9091
+    protocol: TCP
+    targetPort: 9091
+  - name: app-metrics
+    port: 9095
+    protocol: TCP
+    targetPort: 9095
+  selector:
+    serving.knative.dev/service: helloworld-go
+  type: ClusterIP
+----
+
+`apiVersion: serving.knative.dev/v1`:: Application specification.
+`apiVersion: monitoring.coreos.com/v1`:: Configuration of which application's metrics are scraped.
+`apiVersion: v1`:: Configuration of the way metrics are scraped.

--- a/modules/serverless-open-telemetry.adoc
+++ b/modules/serverless-open-telemetry.adoc
@@ -4,7 +4,7 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="serverless-open-telemetry_{context}"]
-= Using {DTProductName} to enable distributed tracing
+= Using {DTProductName} to enable {DTProductName}
 
 [role="_abstract"]
 {DTProductName} is made up of several components that work together to collect, store, and display tracing data. 
@@ -12,7 +12,7 @@
 .Prerequisites
 
 * You have access to an {ocp-product-title} account with cluster administrator access.
-* You have installed {DTProductName} by following the {ocp-product-title} "Installing distributed tracing" documentation.
+* You have installed {DTProductName} by following the {ocp-product-title} "Installing {DTProductName}" documentation.
 * You have installed the OpenShift CLI (`oc`).
 * You have created a project or have access to a project with the appropriate roles and permissions to create applications and other workloads in {ocp-product-title}.
 
@@ -20,7 +20,6 @@
 
 . Create an `OpenTelemetryCollector` custom resource (CR):
 +
-.Example OpenTelemetryCollector CR
 [source,yaml]
 ----
 apiVersion: opentelemetry.io/v1alpha1
@@ -55,7 +54,8 @@ spec:
 $ oc get pods -n <namespace>
 ----
 +
-.Example output
+You get an output similar to the following example:
++
 [source,terminal]
 ----
 NAME                                          READY   STATUS    RESTARTS   AGE
@@ -70,7 +70,8 @@ jaeger-all-in-one-inmemory-ccbc9df4b-ndkl5    2/2     Running   0          15m
 $ oc get svc -n <namespace> | grep headless
 ----
 +
-.Example output
+You get an output similar to the following example:
++
 [source,terminal]
 ----
 cluster-collector-collector-headless            ClusterIP   None             <none>        9411/TCP                                 7m28s
@@ -83,7 +84,6 @@ These services are used to configure Jaeger, Knative Serving, and Knative Eventi
 
 . Install Knative Serving by creating the following `KnativeServing` CR:
 +
-.Example KnativeServing CR
 [source,yaml]
 ----
 apiVersion: operator.knative.dev/v1beta1
@@ -97,13 +97,13 @@ spec:
       backend: "zipkin"
       zipkin-endpoint: "http://cluster-collector-collector-headless.tracing-system.svc:9411/api/v2/spans"
       debug: "false"
-      sample-rate: "0.1" <1>
+      sample-rate: "0.1"
 ----
-<1> The `sample-rate` defines sampling probability. Using `sample-rate: "0.1"` means that 1 in 10 traces are sampled.
+
+`sample-rate`::  The `sample-rate` defines sampling probability. Using `sample-rate: "0.1"` means that 1 in 10 traces are sampled.
 
 . Install Knative Eventing by creating the following `KnativeEventing` CR:
 +
-.Example KnativeEventing CR
 [source,yaml]
 ----
 apiVersion: operator.knative.dev/v1beta1
@@ -119,11 +119,14 @@ spec:
       debug: "false"
       sample-rate: "0.1" <1>
 ----
-<1> The `sample-rate` defines sampling probability. Using `sample-rate: "0.1"` means that 1 in 10 traces are sampled.
++
+
+`sample-rate`:: The `sample-rate` defines sampling probability. Using `sample-rate: "0.1"` means that 1 in 10 traces are sampled.
 
 . Create a Knative service:
 +
-.Example service
+You get an output similar to the following example:
++
 [source,yaml]
 ----
 apiVersion: serving.knative.dev/v1
@@ -152,7 +155,6 @@ spec:
 
 . Make some requests to the service:
 +
-.Example HTTPS request
 [source,terminal]
 ----
 $ curl https://helloworld-go.example.com
@@ -160,7 +162,6 @@ $ curl https://helloworld-go.example.com
 
 . Get the URL for the Jaeger web console:
 +
-.Example command
 [source,terminal]
 ----
 $ oc get route jaeger-all-in-one-inmemory  -o jsonpath='{.spec.host}' -n <namespace>

--- a/modules/serverless-prereqs-for-admin-metrics.adoc
+++ b/modules/serverless-prereqs-for-admin-metrics.adoc
@@ -1,0 +1,22 @@
+// Module included in the following assemblies:
+//
+// * serverless/observability/admin-metrics/serverless-admin-metrics.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="serverless-prereqs-for-admin-metrics_{context}"]
+= Prerequisites for OpenShift Serverless administrator metrics
+
+[role="_abstract"]
+
+* You have enabled metrics for your cluster.
+
+* You have access to an account with cluster administrator access (or dedicated administrator access for {dedicated-product-title} or {rosa-product-title}).
+
+[WARNING]
+====
+If {SMProductShortName} is enabled with mTLS, metrics for Knative Serving are disabled by default because Service Mesh prevents Prometheus from scraping metrics.
+
+To resolve this issue, see the Enabling Knative Serving metrics when using Service Mesh with mTLS section in the Service Mesh integration documentation.
+
+Scraping the metrics does not affect autoscaling of a Knative service, because scraping requests do not go through the activator. so, no scraping takes place if no pods are running.
+====

--- a/modules/serverless-queue-proxy-metrics.adoc
+++ b/modules/serverless-queue-proxy-metrics.adoc
@@ -1,0 +1,51 @@
+// Module is included in the following assemblies:
+//
+// * /serverless/monitor/serverless-monitoring-services-default-metrics
+
+:_mod-docs-content-type: REFERENCE
+[id="serverless-queue-proxy-metrics_{context}"]
+= Queue proxy metrics
+
+[role="_abstract"]
+Each Knative service has a proxy container that proxies the connections to the application container. Several metrics are reported for the queue proxy performance.
+
+You can use the following metrics to measure if requests are queued at the proxy side and the actual delay in serving requests at the application side.
+
+[cols=5*,options="header"]
+|===
+|Metric name
+|Description
+|Type
+|Tags
+|Unit
+
+|`revision_request_count`
+|The number of requests that are routed to `queue-proxy` pod.
+|Counter
+|`configuration_name`, `container_name`, `namespace_name`, `pod_name`, `response_code`, `response_code_class`, `revision_name`, `service_name`
+|Integer (no units)
+
+|`revision_request_latencies`
+|The response time of revision requests.
+|Histogram
+|`configuration_name`, `container_name`, `namespace_name`, `pod_name`, `response_code`, `response_code_class`, `revision_name`, `service_name`
+|Milliseconds
+
+|`revision_app_request_count`
+|The number of requests that are routed to the `user-container` pod.
+|Counter
+|`configuration_name`, `container_name`, `namespace_name`, `pod_name`, `response_code`, `response_code_class`, `revision_name`, `service_name`
+|Integer (no units)
+
+|`revision_app_request_latencies`
+|The response time of revision app requests.
+|Histogram
+|`configuration_name`, `namespace_name`, `pod_name`, `response_code`, `response_code_class`, `revision_name`, `service_name`
+|Milliseconds
+
+|`revision_queue_depth`
+| The current number of items in the `serving` and `waiting` queues. This metric is not reported if unlimited concurrency is configured.
+|Gauge
+|`configuration_name`, `event-display`, `container_name`, `namespace_name`, `pod_name`, `response_code_class`, `revision_name`, `service_name`
+|Integer (no units)
+|===

--- a/modules/serverless-request-log-parameters.adoc
+++ b/modules/serverless-request-log-parameters.adoc
@@ -26,7 +26,7 @@ The following table describes parameters used to configure request logging.
 
 |`logging.request-log-template`
 |Go `text/template` string
-|Determine the shape of the request logs. Use a single line to prevent logs from being split into multiple records.
+|Decide the shape of the request logs. Use a single line to prevent logs from being split into many records.
 |===
 
 The `logging.request-log-template` parameter includes the following functions:
@@ -36,7 +36,7 @@ The `logging.request-log-template` parameter includes the following functions:
 ** `Code` is the HTTP status code. 
 ** `Size` is the response size in bytes.
 ** `Latency` is the response latency in seconds.
-* `Revision` contains revision details and includes the following fields: 
+* `Revision` has revision details and includes the following fields: 
 ** `Name` is the name of the revision.
 ** `Namespace` is the namespace of the revision.
 ** `Service` is the name of the service.

--- a/modules/serverless-viewing-knative-service-metrics-web-console.adoc
+++ b/modules/serverless-viewing-knative-service-metrics-web-console.adoc
@@ -1,0 +1,50 @@
+// Module is included in the following assemblies:
+//
+// * /serverless/monitor/serverless-monitoring-services-default-metrics
+
+:_mod-docs-content-type: PROCEDURE
+[id="serverless-viewing-knative-service-metrics-web-console_{context}"]
+= Viewing Knative service metrics in the web console
+
+[role="_abstract"]
+The following procedure describes how to view and query Knative service and application metrics by using the {ocp-product-title} web console.
+
+.Prerequisites
+
+* You have logged in to the {ocp-product-title} web console.
+* You have installed the {ServerlessOperatorName} and Knative Serving.
+
+.Procedure
+
+. Optional: Run requests against your application that you will be able to see in the metrics:
++
+[source,terminal]
+----
+$ hello_route=$(oc get ksvc helloworld-go -n ns1 -o jsonpath='{.status.url}') && \
+    curl $hello_route
+----
++
+You get an output similar to the following example:
++
+[source,terminal]
+----
+Hello Go Sample v1!
+----
+
+. In the web console, navigate to the *Observe* -> *Metrics* interface.
+
+. In the input field, enter the query for the metric you want to observe, for example:
++
+[source]
+----
+revision_app_request_count{namespace="ns1", job="helloworld-go-sm"}
+----
++
+Another example:
++
+[source]
+----
+myapp_processed_ops_total{namespace="ns1", job="helloworld-go-sm"}
+----
+
+. Observe the visualized metrics.

--- a/observability/admin-metrics/serverless-admin-metrics-eventing.adoc
+++ b/observability/admin-metrics/serverless-admin-metrics-eventing.adoc
@@ -7,18 +7,24 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 [role="_abstract"]
-Cluster administrators can view the following metrics for Knative Eventing components.
-
-By aggregating the metrics from HTTP code, events can be separated into two categories; successful events (2xx) and failed events (5xx).
+Cluster administrators can view the following metrics for Knative Eventing components. By aggregating the metrics from HTTP code, you can separate the events into two categories; successful events (2xx) and failed events (5xx).
 
 include::modules/serverless-broker-ingress-metrics.adoc[leveloffset=+1]
+
 include::modules/serverless-broker-filter-metrics.adoc[leveloffset=+1]
+
 include::modules/serverless-inmemory-dispatch-metrics.adoc[leveloffset=+1]
+
 include::modules/serverless-event-source-metrics.adoc[leveloffset=+1]
 
 include::modules/serverless-knative-kafka-broker-metrics.adoc[leveloffset=+1]
+
 include::modules/serverless-knative-kafka-trigger-metrics.adoc[leveloffset=+1]
+
 include::modules/serverless-knative-kafka-channel-metrics.adoc[leveloffset=+1]
+
 include::modules/serverless-knative-kafka-subscription-metrics.adoc[leveloffset=+1]
+
 include::modules/serverless-knative-kafka-source-metrics.adoc[leveloffset=+1]
+
 include::modules/serverless-knative-kafka-sink-metrics.adoc[leveloffset=+1]

--- a/observability/admin-metrics/serverless-admin-metrics-serving.adoc
+++ b/observability/admin-metrics/serverless-admin-metrics-serving.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: ASSEMBLY
-include::_attributes/common-attributes.adoc[]
 [id="serverless-admin-metrics-serving"]
 = Knative Serving metrics
+include::_attributes/common-attributes.adoc[]
 :context: serverless-admin-metrics-serving
 
 toc::[]
@@ -10,6 +10,12 @@ toc::[]
 Cluster administrators can view the following metrics for Knative Serving components.
 
 include::modules/serverless-activator-metrics.adoc[leveloffset=+1]
+
 include::modules/serverless-autoscaler-metrics.adoc[leveloffset=+1]
+
 include::modules/serverless-go-metrics.adoc[leveloffset=+1]
 
+[role="_additional-resources"]
+== Additional resources
+
+* link:https://golang.org/pkg/runtime/#MemStats[MemStats]

--- a/observability/admin-metrics/serverless-admin-metrics.adoc
+++ b/observability/admin-metrics/serverless-admin-metrics.adoc
@@ -9,20 +9,15 @@ toc::[]
 [role="_abstract"]
 Metrics enable cluster administrators to monitor how {ServerlessProductName} cluster components and workloads are performing.
 
-You can view different metrics for {ServerlessProductName} by navigating to link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.18/html-single/monitoring/index#about-monitoring-dashboards_key-concepts[*About monitoring dashboards*].
+To view different metrics for {ServerlessProductName}, you can check the {ocp-product-title} monitoring documentation.
 
-[id="prerequisites_serverless-admin-metrics"]
-== Prerequisites
+include::modules/serverless-prereqs-for-admin-metrics.adoc[leveloffset=+1]
 
-* See the {ocp-product-title} documentation on link:https://docs.openshift.com/container-platform/latest/observability/monitoring/managing-metrics.html[Managing metrics] for information about enabling metrics for your cluster.
+[role="_additional-resources"]
+== Additional resources
 
-* You have access to an account with cluster administrator access (or dedicated administrator access for {dedicated-product-title} or {rosa-product-title}).
+* link:https://docs.openshift.com/container-platform/latest/observability/monitoring/managing-metrics.html[Managing metrics]
 
-[WARNING]
-====
-If {SMProductShortName} is enabled with mTLS, metrics for Knative Serving are disabled by default because Service Mesh prevents Prometheus from scraping metrics.
+* link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.18/html-single/monitoring/index#about-monitoring-dashboards_key-concepts[*About monitoring dashboards*]
 
-For information about resolving this issue, see xref:../../integrations/serverless-integrating-service-mesh/serverless-ossm-setup.adoc#serverless-ossm-enabling-serving-metrics_serverless-ossm-setup[Enabling Knative Serving metrics when using Service Mesh with mTLS].
-
-Scraping the metrics does not affect autoscaling of a Knative service, because scraping requests do not go through the activator. Consequently, no scraping takes place if no pods are running.
-====
+* xref:../../integrations/serverless-integrating-service-mesh/serverless-ossm-setup.adoc#serverless-ossm-enabling-serving-metrics_serverless-ossm-setup[Enabling Knative Serving metrics when using Service Mesh with mTLS]

--- a/observability/admin-metrics/serverless-controller-metrics.adoc
+++ b/observability/admin-metrics/serverless-controller-metrics.adoc
@@ -1,11 +1,11 @@
 :_mod-docs-content-type: ASSEMBLY
-include::_attributes/common-attributes.adoc[]
 [id="serverless-controller-metrics"]
 = {ServerlessProductShortName} controller metrics
+include::_attributes/common-attributes.adoc[]
 :context: serverless-controller-metrics
 
 [role="_abstract"]
-The following metrics are emitted by any component that implements a controller logic. These metrics show details about reconciliation operations and the work queue behavior upon which reconciliation requests are added to the work queue.
+Any component that implements controller logic emits the following metrics. These metrics show details about reconciliation operations and the work queue behavior that adds reconciliation requests to the queue.
 
 [cols=5*,options="header"]
 |===

--- a/observability/admin-metrics/serverless-webhook-metrics.adoc
+++ b/observability/admin-metrics/serverless-webhook-metrics.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: ASSEMBLY
-include::_attributes/common-attributes.adoc[]
 [id="serverless-webhook-metrics"]
 = Webhook metrics
+include::_attributes/common-attributes.adoc[]
 :context: serverless-webhook-metrics
 
 [role="_abstract"]

--- a/observability/cluster-logging/serverless-config-log-settings.adoc
+++ b/observability/cluster-logging/serverless-config-log-settings.adoc
@@ -1,13 +1,13 @@
 :_mod-docs-content-type: ASSEMBLY
-include::_attributes/common-attributes.adoc[]
 [id="serverless-config-log-setting"]
 = Configuring log settings for Serving and Eventing
+include::_attributes/common-attributes.adoc[]
 :context: serverless-config-log-setting
 
 toc::[]
 
 [role="_abstract"]
-You can configure logging for OpenShift Serverless Serving and OpenShift Serverless Eventing using the `KnativeServing` and `KnativeEventing` custom resource (CR). The level of logging is determined by the specified `loglevel` value.
+You can configure logging for OpenShift Serverless Serving and OpenShift Serverless Eventing by using the `KnativeServing` and `KnativeEventing` custom resource (CR). The specified `loglevel` value determines the logging level.
 
 include::modules/serverless-config-log-supported-log-levels.adoc[leveloffset=+1]
 

--- a/observability/developer-metrics/serverless-developer-metrics-dashboard.adoc
+++ b/observability/developer-metrics/serverless-developer-metrics-dashboard.adoc
@@ -1,10 +1,10 @@
 :_mod-docs-content-type: ASSEMBLY
-include::_attributes/common-attributes.adoc[]
 [id="serverless-developer-metrics-dashboard"]
 = Dashboard for service metrics
+include::_attributes/common-attributes.adoc[]
 :context: serverless-developer-metrics-dashboard
 
 [role="_abstract"]
-You can examine the metrics using a dedicated dashboard that aggregates queue proxy metrics by namespace.
+You can examine the metrics by using a dedicated dashboard that aggregates queue proxy metrics by namespace.
 
 include::modules/serverless-monitoring-services-examining-metrics-dashboard.adoc[leveloffset=+1]

--- a/observability/developer-metrics/serverless-developer-metrics.adoc
+++ b/observability/developer-metrics/serverless-developer-metrics.adoc
@@ -9,19 +9,22 @@ toc::[]
 [role="_abstract"]
 Metrics enable developers to monitor how Knative services are performing. You can use the {ocp-product-title} monitoring stack to record and view health checks and metrics for your Knative services.
 
-You can view different metrics for {ServerlessProductName} by navigating to link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.18/html-single/monitoring/index#about-monitoring-dashboards_key-concepts[*About monitoring dashboards*]
+To view different metrics for {ServerlessProductName}, you can check the {ocp-product-title} monitoring documentation.
 
 [WARNING]
 ====
 If {SMProductShortName} is enabled with mTLS, metrics for Knative Serving are disabled by default because Service Mesh prevents Prometheus from scraping metrics.
 
-For information about resolving this issue, see xref:../../integrations/serverless-integrating-service-mesh/serverless-ossm-setup.adoc#serverless-ossm-enabling-serving-metrics_serverless-ossm-setup[Enabling Knative Serving metrics when using Service Mesh with mTLS].
+To resolve this issue, see the Enabling Knative Serving metrics when using Service Mesh with mTLS section in the Service Mesh integration documentation.
 
-Scraping the metrics does not affect autoscaling of a Knative service, because scraping requests do not go through the activator. Consequently, no scraping takes place if no pods are running.
+Scraping the metrics does not affect autoscaling of a Knative service, because scraping requests do not go through the activator. So, no scraping takes place if no pods are running.
 ====
 
-[id="additional-resources_serverless-service-monitoring"]
 [role="_additional-resources"]
-== Additional resources for {ocp-product-title}
+== Additional resources
+
 * link:https://docs.openshift.com/container-platform/latest/observability/monitoring/monitoring-overview.html#monitoring-overview[Monitoring overview]
+
 * link:https://docs.openshift.com/container-platform/latest/observability/monitoring/enabling-monitoring-for-user-defined-projects.html[Enabling monitoring for user-defined projects]
+
+* xref:../../integrations/serverless-integrating-service-mesh/serverless-ossm-setup.adoc#serverless-ossm-enabling-serving-metrics_serverless-ossm-setup[Enabling Knative Serving metrics when using Service Mesh with mTLS]

--- a/observability/developer-metrics/serverless-monitoring-services-configuration-scraping.adoc
+++ b/observability/developer-metrics/serverless-monitoring-services-configuration-scraping.adoc
@@ -1,72 +1,10 @@
 :_mod-docs-content-type: ASSEMBLY
-include::_attributes/common-attributes.adoc[]
 [id="serverless-monitoring-services-configuration-scraping"]
 = Configuration for scraping custom metrics
+include::_attributes/common-attributes.adoc[]
 :context: serverless-monitoring-services-configuration-scraping
 
 [role="_abstract"]
 Custom metrics scraping is performed by an instance of Prometheus purposed for user workload monitoring. After you enable user workload monitoring and create the application, you need a configuration that defines how the monitoring stack will scrape the metrics.
 
-The following sample configuration defines the `ksvc` for your application and configures the service monitor. The exact configuration depends on your application and how it exports the metrics.
-
-[source,yaml]
-----
-apiVersion: serving.knative.dev/v1 <1>
-kind: Service
-metadata:
-  name: helloworld-go
-spec:
-  template:
-    metadata:
-      labels:
-        app: helloworld-go
-      annotations:
-    spec:
-      containers:
-      - image: docker.io/skonto/helloworld-go:metrics
-        resources:
-          requests:
-            cpu: "200m"
-        env:
-        - name: TARGET
-          value: "Go Sample v1"
----
-apiVersion: monitoring.coreos.com/v1 <2>
-kind: ServiceMonitor
-metadata:
-  labels:
-  name: helloworld-go-sm
-spec:
-  endpoints:
-  - port: queue-proxy-metrics
-    scheme: http
-  - port: app-metrics
-    scheme: http
-  namespaceSelector: {}
-  selector:
-    matchLabels:
-       name:  helloworld-go-sm
----
-apiVersion: v1 <3>
-kind: Service
-metadata:
-  labels:
-    name:  helloworld-go-sm
-  name:  helloworld-go-sm
-spec:
-  ports:
-  - name: queue-proxy-metrics
-    port: 9091
-    protocol: TCP
-    targetPort: 9091
-  - name: app-metrics
-    port: 9095
-    protocol: TCP
-    targetPort: 9095
-  selector:
-    serving.knative.dev/service: helloworld-go
-  type: ClusterIP
-----
-<1> Application specification.
-<2> Configuration of which application's metrics are scraped.
-<3> Configuration of the way metrics are scraped.
+include::modules/serverless-knative-service-metrics-scraping-config-example.adoc[leveloffset=+1]

--- a/observability/developer-metrics/serverless-monitoring-services-custom-metrics.adoc
+++ b/observability/developer-metrics/serverless-monitoring-services-custom-metrics.adoc
@@ -1,77 +1,10 @@
 :_mod-docs-content-type: ASSEMBLY
-include::_attributes/common-attributes.adoc[]
 [id="serverless-monitoring-services-custom-metrics"]
 = Knative service with custom application metrics
+include::_attributes/common-attributes.adoc[]
 :context: serverless-monitoring-services-custom-metrics
 
 [role="_abstract"]
 You can extend the set of metrics exported by a Knative service. The exact implementation depends on your application and the language used.
 
-The following listing implements a sample Go application that exports the count of processed events custom metric.
-
-[source,go]
-----
-package main
-
-import (
-  "fmt"
-  "log"
-  "net/http"
-  "os"
-
-  "github.com/prometheus/client_golang/prometheus" <1>
-  "github.com/prometheus/client_golang/prometheus/promauto"
-  "github.com/prometheus/client_golang/prometheus/promhttp"
-)
-
-var (
-  opsProcessed = promauto.NewCounter(prometheus.CounterOpts{ <2>
-     Name: "myapp_processed_ops_total",
-     Help: "The total number of processed events",
-  })
-)
-
-
-func handler(w http.ResponseWriter, r *http.Request) {
-  log.Print("helloworld: received a request")
-  target := os.Getenv("TARGET")
-  if target == "" {
-     target = "World"
-  }
-  fmt.Fprintf(w, "Hello %s!\n", target)
-  opsProcessed.Inc() <3>
-}
-
-func main() {
-  log.Print("helloworld: starting server...")
-
-  port := os.Getenv("PORT")
-  if port == "" {
-     port = "8080"
-  }
-
-  http.HandleFunc("/", handler)
-
-  // Separate server for metrics requests
-  go func() { <4>
-     mux := http.NewServeMux()
-     server := &http.Server{
-        Addr: fmt.Sprintf(":%s", "9095"),
-        Handler: mux,
-     }
-     mux.Handle("/metrics", promhttp.Handler())
-     log.Printf("prometheus: listening on port %s", 9095)
-     log.Fatal(server.ListenAndServe())
-  }()
-
-   // Use same port as normal requests for metrics
-  //http.Handle("/metrics", promhttp.Handler()) <5>
-  log.Printf("helloworld: listening on port %s", port)
-  log.Fatal(http.ListenAndServe(fmt.Sprintf(":%s", port), nil))
-}
-----
-<1> Including the Prometheus packages.
-<2> Defining the `opsProcessed` metric.
-<3> Incrementing the `opsProcessed` metric.
-<4> Configuring to use a separate server for metrics requests.
-<5> Configuring to use the same port as normal requests for metrics and the `metrics` subpath.
+include::modules/serverless-go-application-custom-metrics-example.adoc[leveloffset=+1]

--- a/observability/developer-metrics/serverless-monitoring-services-default-metrics.adoc
+++ b/observability/developer-metrics/serverless-monitoring-services-default-metrics.adoc
@@ -1,104 +1,10 @@
 :_mod-docs-content-type: ASSEMBLY
-include::_attributes/common-attributes.adoc[]
 [id="serverless-monitoring-services-default-metrics"]
 = Knative service metrics exposed by default
+include::_attributes/common-attributes.adoc[]
 :context: serverless-monitoring-services-default-metrics
 
 [role="_abstract"]
-.Metrics exposed by default for each Knative service on port 9091
-[options=header]
-|===
+Knative services expose a set of default metrics that give insights into request traffic, performance, and system behavior.
 
-|Metric name, unit, and type |Description |Metric tags
-
-// New row
-|`request_count`
-
-Metric unit: dimensionless
-
-Metric type: counter
-
-|The number of requests that are routed to `queue-proxy`.
-
-|configuration_name="event-display",
-container_name="queue-proxy",
-namespace_name="apiserversource1",
-pod_name="event-display-00001-deployment-658fd4f9cf-qcnr5",
-response_code="200",
-response_code_class="2xx",
-revision_name="event-display-00001",
-service_name="event-display"
-
-// New row
-|`request_latencies`
-
-Metric unit: milliseconds
-
-Metric type: histogram
-
-|The response time in milliseconds.
-
-|configuration_name="event-display",
-container_name="queue-proxy",
-namespace_name="apiserversource1",
-pod_name="event-display-00001-deployment-658fd4f9cf-qcnr5",
-response_code="200",
-response_code_class="2xx",
-revision_name="event-display-00001",
-service_name="event-display"
-
-// New row
-|`app_request_count`
-
-Metric unit: dimensionless
-
-Metric type: counter
-
-|The number of requests that are routed to `user-container`.
-
-|configuration_name="event-display",
-container_name="queue-proxy",
-namespace_name="apiserversource1",
-pod_name="event-display-00001-deployment-658fd4f9cf-qcnr5",
-response_code="200",
-response_code_class="2xx",
-revision_name="event-display-00001",
-service_name="event-display"
-
-// New row
-|`app_request_latencies`
-
-Metric unit: milliseconds
-
-Metric type: histogram
-
-|The response time in milliseconds.
-
-|configuration_name="event-display",
-container_name="queue-proxy",
-namespace_name="apiserversource1",
-pod_name="event-display-00001-deployment-658fd4f9cf-qcnr5",
-response_code="200",
-response_code_class="2xx",
-revision_name="event-display-00001",
-service_name="event-display"
-
-// New row
-|`queue_depth`
-
-Metric unit: dimensionless
-
-Metric type: gauge
-
-|The current number of items in the serving and waiting queue, or not reported if unlimited concurrency. `breaker.inFlight` is used.
-
-|configuration_name="event-display",
-container_name="queue-proxy",
-namespace_name="apiserversource1",
-pod_name="event-display-00001-deployment-658fd4f9cf-qcnr5",
-response_code="200",
-response_code_class="2xx",
-revision_name="event-display-00001",
-service_name="event-display"
-
-|===
+include::modules/serverless-default-metrics-knative-services.adoc[leveloffset=+1]

--- a/observability/developer-metrics/serverless-monitoring-services-examining-metrics.adoc
+++ b/observability/developer-metrics/serverless-monitoring-services-examining-metrics.adoc
@@ -1,95 +1,13 @@
 :_mod-docs-content-type: ASSEMBLY
-include::_attributes/common-attributes.adoc[]
 [id="serverless-monitoring-services-examining-metrics"]
 = Examining metrics of a service
+include::_attributes/common-attributes.adoc[]
 :context: serverless-monitoring-services-examining-metrics
 
 [role="_abstract"]
 After you have configured the application to export the metrics and the monitoring stack to scrape them, you can examine the metrics in the web console.
 
-.Prerequisites
+include::modules/serverless-viewing-knative-service-metrics-web-console.adoc[leveloffset=+1]
 
-* You have logged in to the {ocp-product-title} web console.
-* You have installed the {ServerlessOperatorName} and Knative Serving.
+include::modules/serverless-queue-proxy-metrics.adoc[leveloffset=+1]
 
-.Procedure
-
-. Optional: Run requests against your application that you will be able to see in the metrics:
-+
-[source,terminal]
-----
-$ hello_route=$(oc get ksvc helloworld-go -n ns1 -o jsonpath='{.status.url}') && \
-    curl $hello_route
-----
-+
-.Example output
-[source,terminal]
-----
-Hello Go Sample v1!
-----
-
-. In the web console, navigate to the *Observe* -> *Metrics* interface.
-
-. In the input field, enter the query for the metric you want to observe, for example:
-+
-[source]
-----
-revision_app_request_count{namespace="ns1", job="helloworld-go-sm"}
-----
-+
-Another example:
-+
-[source]
-----
-myapp_processed_ops_total{namespace="ns1", job="helloworld-go-sm"}
-----
-
-. Observe the visualized metrics:
-
-[id="serverless-queue-proxy-metrics_{context}"]
-== Queue proxy metrics
-:context: serverless-queue-proxy-metrics
-
-[role="_abstract"]
-Each Knative service has a proxy container that proxies the connections to the application container. A number of metrics are reported for the queue proxy performance.
-
-You can use the following metrics to measure if requests are queued at the proxy side and the actual delay in serving requests at the application side.
-
-[cols=5*,options="header"]
-|===
-|Metric name
-|Description
-|Type
-|Tags
-|Unit
-
-|`revision_request_count`
-|The number of requests that are routed to `queue-proxy` pod.
-|Counter
-|`configuration_name`, `container_name`, `namespace_name`, `pod_name`, `response_code`, `response_code_class`, `revision_name`, `service_name`
-|Integer (no units)
-
-|`revision_request_latencies`
-|The response time of revision requests.
-|Histogram
-|`configuration_name`, `container_name`, `namespace_name`, `pod_name`, `response_code`, `response_code_class`, `revision_name`, `service_name`
-|Milliseconds
-
-|`revision_app_request_count`
-|The number of requests that are routed to the `user-container` pod.
-|Counter
-|`configuration_name`, `container_name`, `namespace_name`, `pod_name`, `response_code`, `response_code_class`, `revision_name`, `service_name`
-|Integer (no units)
-
-|`revision_app_request_latencies`
-|The response time of revision app requests.
-|Histogram
-|`configuration_name`, `namespace_name`, `pod_name`, `response_code`, `response_code_class`, `revision_name`, `service_name`
-|Milliseconds
-
-|`revision_queue_depth`
-| The current number of items in the `serving` and `waiting` queues. This metric is not reported if unlimited concurrency is configured.
-|Gauge
-|`configuration_name`, `event-display`, `container_name`, `namespace_name`, `pod_name`, `response_code_class`, `revision_name`, `service_name`
-|Integer (no units)
-|===

--- a/observability/tracing/serverless-tracing-jaeger.adoc
+++ b/observability/tracing/serverless-tracing-jaeger.adoc
@@ -1,11 +1,10 @@
 :_mod-docs-content-type: ASSEMBLY
-include::_attributes/common-attributes.adoc[]
 [id="serverless-tracing-jaeger"]
-= Using Jaeger distributed tracing
+= Using Jaeger {DTShortName}
+include::_attributes/common-attributes.adoc[]
 :context: serverless-tracing-jaeger
 
 [role="_abstract"]
-If you do not want to install all of the components of {DTProductName}, you can still use distributed tracing on {ocp-product-title} with {ServerlessProductName}. 
+If you do not want to install all of the components of {DTProductName}, you can still use {DTShortName} on {ocp-product-title} with {ServerlessProductName}. 
 
-// standalone Jaeger only integration
 include::modules/serverless-jaeger-config.adoc[leveloffset=+1]

--- a/observability/tracing/serverless-tracing-open-telemetry.adoc
+++ b/observability/tracing/serverless-tracing-open-telemetry.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: ASSEMBLY
-include::_attributes/common-attributes.adoc[]
 [id="serverless-tracing-open-telemetry"]
 = Using Red Hat OpenShift distributed tracing
+include::_attributes/common-attributes.adoc[]
 :context: serverless-tracing-open-telemetry
 
 [role="_abstract"]

--- a/observability/tracing/serverless-tracing.adoc
+++ b/observability/tracing/serverless-tracing.adoc
@@ -11,8 +11,15 @@ Distributed tracing records the path of a request through the various services t
 
 include::modules/distr-tracing-product-overview.adoc[leveloffset=+1]
 
-[id="additional-resources_serverless-tracing"]
 [role="_additional-resources"]
-== Additional resources for {ocp-product-title}
+== Additional resources
+
 * link:https://docs.openshift.com/container-platform/latest/observability/distr_tracing/distr_tracing_arch/distr-tracing-architecture.html[{DTProductName} architecture]
-* link:https://docs.openshift.com/container-platform/latest/observability/distr_tracing/distr_tracing_tempo/distr-tracing-tempo-installing.html[Installing distributed tracing]
+
+* link:https://docs.openshift.com/container-platform/latest/observability/distr_tracing/distr_tracing_tempo/distr-tracing-tempo-installing.html[Installing {DTProductName}]
+
+* link:https://www.jaegertracing.io/[Jaeger project]
+
+* link:https://opentelemetry.io/[OpenTelemetry project]
+
+* link:https://opentracing.io/[OpenTracing]


### PR DESCRIPTION
**You can cherry-pick for the following branches:** 
- `serverless-docs-1.37`
- `serverless-docs-1.38`

**Note for the peer & merge reviewer:** 
- This PR updates the only "Observability" section to prepare it for Phase 0 DITA migration.
- No other CQA changes, error types, or content refinements are included. 

**Changes:** 
This PR prepares the "Observability" section for Phase 0 DITA migration by applying Vale (AsciiDoc DITA) rules and cleaning up the existing content.

Doc preview: 

**Tracking JIRA:** https://redhat.atlassian.net/browse/SRVCOM-4358

**Reviews:**
- [x] Peer has approved this change