### PR TITLE
[enterprise-4.18] OCPBUGS-73774: Moved Allocating Load Balancers to Specific Subnets cl…

### DIFF
--- a/installing/installing_aws/ipi/installing-aws-vpc.adoc
+++ b/installing/installing_aws/ipi/installing-aws-vpc.adoc
@@ -56,6 +56,15 @@ include::modules/installation-configure-proxy.adoc[leveloffset=+2]
 
 include::modules/installation-applying-aws-security-groups.adoc[leveloffset=+2]
 
+// Allocating Load Balancers to Specific Subnets
+include::modules/allocating-load-balancers.adoc[leveloffset=+2]
+
+// Allocating API and Ingress Load Balancers to Specific Subnets on AWS
+include::modules/nw-allocating-load-balancers-to-subnets.adoc[leveloffset=+3]
+
+// Specifying AWS Subnets for OpenShift Ingress Load Balancers at Installation
+include::modules/nw-allocate-load-balancers-to-subnets-procedure.adoc[leveloffset=+3]
+
 [id="installing-aws-manual-modes_{context}"]
 == Alternatives to storing administrator-level secrets in the kube-system project
 

--- a/modules/allocating-load-balancers.adoc
+++ b/modules/allocating-load-balancers.adoc
@@ -1,0 +1,9 @@
+:_mod-docs-content-type: CONCEPT
+[id="allocating-load-balancers_{context}"]
+= Allocating load balancers to specific subnets
+
+[role="_abstract"]
+You can manage application traffic efficiently by allocating load balancers. Network administrators can allocate load balancers to customize deployments which can ensure optimal traffic distribution, high availability of applications, uninterrupted service, and network segmentation.
+
+You can also limit subnet selection for a load balancer by using subnet roles. Subnet roles prevent security risks by ensuring Load Balancers are automatically placed only in subnets explicitly designated for public or private traffic. This eliminates manual configuration errors and guarantees architectural compliance across multiple availability zones.
+

--- a/modules/nw-allocating-load-balancers-to-subnets.adoc
+++ b/modules/nw-allocating-load-balancers-to-subnets.adoc
@@ -1,0 +1,10 @@
+// Module included in the following assemblies:
+//
+// *networking/allocating-load-balancers.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="nw-allocating-load-balancers-to-subnets_{context}"]
+= Allocating API and Ingress load balancers to specific subnets on AWS
+You can control the network placement of {product-title} load balancers on {aws-short}, including load balancers for the Ingress Controller, by explicitly defining your subnets from the virtual private cloud (VPC). You can then assign the subnets specific roles directly within the `platform.aws.vpc.subnets` section of the `install-config.yaml` file. 
+
+By using this method, you have granular control of subnets that are used for resources, such as the Ingress Controller and other cluster components.


### PR DESCRIPTION

Version(s):
4.18

Issue:
[OCPBUGS-73774](https://issues.redhat.com/browse/OCPBUGS-73774)

Link to docs preview:
