### PR TITLE
Corrects Service Mesh for DITA migration

### DIFF
--- a/modules/ossm-config-default.adoc
+++ b/modules/ossm-config-default.adoc
@@ -6,7 +6,8 @@
 [id="ossm-config-default_{context}"]
 = Distributed tracing default configuration options
 
-The Jaeger custom resource (CR) defines the architecture and settings to be used when creating the {JaegerShortName} resources. You can modify these parameters to customize your {JaegerShortName} implementation to your business needs.
+[role="_abstract"]
+See the Jaeger custom resource (CR) for a description for building your {JaegerShortName}. Change the fields to match what you need.
 
 .Generic YAML example of the Jaeger CR
 [source,yaml]
@@ -67,7 +68,7 @@ spec:
 
 |`spec:`
 |Specification for the object to be created.
-|Contains all of the configuration parameters for your {JaegerShortName} instance. When a common definition for all Jaeger components is required, it is defined under the `spec` node. When the definition relates to an individual component, it is placed under the `spec/<component>` node.
+|Lists all settings for your {JaegerShortName} instance. Put shared settings under `spec`. Put settings for one part under `spec/<component>`.
 |N/A
 
 |`strategy:`

--- a/modules/ossm-config-ingester.adoc
+++ b/modules/ossm-config-ingester.adoc
@@ -6,7 +6,8 @@
 [id="ossm-config-ingester_{context}"]
 = Ingester configuration options
 
-Ingester is a service that reads from a Kafka topic and writes to the Elasticsearch storage backend. If you are using the `allInOne` or `production` deployment strategies, you do not need to configure the Ingester service.
+[role="_abstract"]
+Use the Ingester to read data from a Kafka topic and to write data to Elasticsearch. You do not need the Ingester for `allInOne` or `production` strategies.
 
 .Jaeger parameters passed to the Ingester
 [options="header"]
@@ -29,7 +30,7 @@ The deadlock interval is disabled by default (set to `0`), to avoid terminating 
   kafka:
     consumer:
       topic:
-|The `topic` parameter identifies the Kafka configuration used by the collector to produce the messages, and the Ingester to consume the messages.
+|The `topic` value names the Kafka setup. The collector writes to it. The Ingester reads from it.
 |Label for the consumer. For example, `jaeger-spans`.
 
 |options:

--- a/modules/ossm-config-jaeger-collector.adoc
+++ b/modules/ossm-config-jaeger-collector.adoc
@@ -6,9 +6,10 @@
 [id="ossm-config-jaeger-collector_{context}"]
 = Jaeger Collector configuration options
 
-The Jaeger Collector is the component responsible for receiving the spans that were captured by the tracer and writing them to persistent Elasticsearch storage when using the `production` strategy, or to AMQ Streams when using the `streaming` strategy.
+[role="_abstract"]
+The Jaeger Collector receives spans from the tracer. When you apply the `production` strategy, the Jaeger Collector sends them to Elasticsearch. When you apply the`streaming` strategy, it sends them to AMQ Streams.
 
-The Collectors are stateless and thus many instances of Jaeger Collector can be run in parallel. Collectors require almost no configuration, except for the location of the Elasticsearch cluster.
+Collectors do not store state. You can run many Collectors at the same time. You only need to set where Elasticsearch runs.
 
 .Parameters used by the Operator to define the Jaeger Collector
 [options="header"]
@@ -49,14 +50,14 @@ The Collectors are stateless and thus many instances of Jaeger Collector can be 
   kafka:
     producer:
       topic: jaeger-spans
-|The `topic` parameter identifies the Kafka configuration used by the Collector to produce the messages, and the Ingester to consume the messages.
+|The `topic` value names the Kafka setup. The Collector writes to it. The Ingester reads from it.
 |Label for the producer.
 
 |options:
   kafka:
     producer:
       brokers: my-cluster-kafka-brokers.kafka:9092
-|Identifies the Kafka configuration used by the Collector to produce the messages. If brokers are not specified, and you have AMQ Streams 1.4.0+ installed, the {JaegerName} Operator will self-provision Kafka.
+|Names the Kafka setup for the Collector. If you omit brokers and AMQ Streams 1.4.0+ is installed, the {JaegerName} Operator creates Kafka for you.
 |
 
 |options:

--- a/modules/ossm-config-manage-es-certificates.adoc
+++ b/modules/ossm-config-manage-es-certificates.adoc
@@ -1,0 +1,82 @@
+// Module included in the following assemblies:
+//
+// * service_mesh/v2x/ossm-reference-jaeger.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="distr-tracing-manage-es-certificates_{context}"]
+= Managing certificates with Elasticsearch
+
+[role="_abstract"]
+You can create and manage certificates with the {es-op}. You can also use one Elasticsearch cluster with more than one Jaeger Collector.
+
+:FeatureName: Managing certificates with Elasticsearch
+include::snippets/technology-preview.adoc[leveloffset=+1]
+
+Starting with version 2.4, the {JaegerName} Operator asks the {es-op} to create certificates. Add these annotations to the Elasticsearch custom resource:
+
+* `logging.openshift.io/elasticsearch-cert-management: "true"`
+* `logging.openshift.io/elasticsearch-cert.jaeger-<shared-es-node-name>: "user.jaeger"`
+* `logging.openshift.io/elasticsearch-cert.curator-<shared-es-node-name>: "system.logging.curator"`
+
+Where the `<shared-es-node-name>` is the name of the Elasticsearch node. For example, if you create an Elasticsearch node named `custom-es`, your custom resource might look like the following example.
+
+.Example Elasticsearch CR showing annotations
+[source,yaml]
+----
+apiVersion: logging.openshift.io/v1
+kind: Elasticsearch
+metadata:
+  annotations:
+    logging.openshift.io/elasticsearch-cert-management: "true"
+    logging.openshift.io/elasticsearch-cert.jaeger-custom-es: "user.jaeger"
+    logging.openshift.io/elasticsearch-cert.curator-custom-es: "system.logging.curator"
+  name: custom-es
+spec:
+  managementState: Managed
+  nodeSpec:
+    resources:
+      limits:
+        memory: 16Gi
+      requests:
+        cpu: 1
+        memory: 16Gi
+  nodes:
+    - nodeCount: 3
+      proxyResources: {}
+      resources: {}
+      roles:
+        - master
+        - client
+        - data
+      storage: {}
+  redundancyPolicy: ZeroRedundancy
+----
+
+*Prerequisites*
+
+* Install the {SMProductName} Operator.
+* Install the {logging-title} with the default configuration in your cluster.
+* Deploy the Elasticsearch node and the Jaeger instances must be deployed in the same namespace. For example, `tracing-system`.
+
+Now, you can enable certificate management by setting `spec.storage.elasticsearch.useCertManagement` to `true` in the Jaeger custom resource.
+
+.Example showing `useCertManagement`
+[source,yaml]
+----
+apiVersion: jaegertracing.io/v1
+kind: Jaeger
+metadata:
+  name: jaeger-prod
+spec:
+  strategy: production
+  storage:
+    type: elasticsearch
+    elasticsearch:
+      name: custom-es
+      doNotProvision: true
+      useCertManagement: true
+----
+
+When it provisions Elasticsearch, the {JaegerName} Operator sets the Elasticsearch CR `name` from `spec.storage.elasticsearch.name` in the Jaeger CR.
+
+The {es-op} creates the certificates. The {JaegerName} Operator adds them to the deployment.

--- a/modules/ossm-config-query.adoc
+++ b/modules/ossm-config-query.adoc
@@ -6,6 +6,7 @@
 [id="ossm-config-query_{context}"]
 = Query configuration options
 
+[role="_abstract"]
 Query is a service that retrieves traces from storage and hosts the user interface to display them.
 
 .Parameters used by the {JaegerName} Operator to define Query

--- a/modules/ossm-config-security-ossm-cli.adoc
+++ b/modules/ossm-config-security-ossm-cli.adoc
@@ -6,6 +6,7 @@
 [id="ossm-config-security-ossm-cli_{context}"]
 = Configuring distributed tracing security for service mesh from the command line
 
+[role="_abstract"]
 You can modify the Jaeger resource to configure {JaegerShortName} security for use with {SMproductShortName} from the command line by running the {oc-first}.
 
 .Prerequisites

--- a/modules/ossm-config-security-ossm-web.adoc
+++ b/modules/ossm-config-security-ossm-web.adoc
@@ -6,6 +6,7 @@
 [id="ossm-config-security-ossm-web_{context}"]
 = Configuring distributed tracing security for service mesh from the web console
 
+[role="_abstract"]
 You can modify the Jaeger resource to configure {JaegerShortName} security for use with {SMproductShortName} in the web console.
 
 .Prerequisites

--- a/modules/ossm-config-security-ossm.adoc
+++ b/modules/ossm-config-security-ossm.adoc
@@ -6,6 +6,11 @@
 [id="ossm-config-security-ossm_{context}"]
 = Configuring distributed tracing security for service mesh
 
-The {JaegerShortName} uses OAuth for default authentication. However {SMProductName} uses a secret called `htpasswd` to facilitate communication between dependent services such as Grafana, Kiali, and the {JaegerShortName}. When you configure your {JaegerShortName} in the `ServiceMeshControlPlane` the {SMProductShortName} automatically configures security settings to use `htpasswd`.
+[role="_abstract"]
+By default, the {JaegerShortName} uses OAuth to sign users in.
 
-If you are specifying your {JaegerShortName} configuration in a Jaeger custom resource, you must manually configure the `htpasswd` settings and ensure the `htpasswd` secret is mounted into your Jaeger instance so that Kiali can communicate with it.
+{SMProductName} also uses a secret named `htpasswd`. Grafana, Kiali, and the {JaegerShortName} use this secret to talk to each other.
+
+When you set Jaeger in the `ServiceMeshControlPlane`, service mesh turns on `htpasswd` security for you.
+
+If you set Jaeger in a Jaeger custom resource instead, you must add the `htpasswd` settings yourself. Mount the `htpasswd` secret in your Jaeger instance so Kiali can reach it.

--- a/modules/ossm-config-smcp-jaeger.adoc
+++ b/modules/ossm-config-smcp-jaeger.adoc
@@ -6,6 +6,7 @@
 [id="ossm-specifying-jaeger-configuration_{context}"]
 = Specifying Jaeger configuration in the SMCP
 
-You configure Jaeger under the `addons` section of the `ServiceMeshControlPlane` resource. However, there are some limitations to what you can configure in the SMCP.
+[role="_abstract"]
+Set Jaeger options in the `addons` section of the `ServiceMeshControlPlane` resource. The SMCP only supports some settings.
 
-When the SMCP passes configuration information to the {JaegerName} Operator, it triggers one of three deployment strategies: `allInOne`, `production`, or `streaming`.
+When the SMCP sends settings to the {JaegerName} Operator, the Operator picks one of three deployment strategies: `allInOne`, `production`, or `streaming`.

--- a/modules/ossm-config-storage.adoc
+++ b/modules/ossm-config-storage.adoc
@@ -6,7 +6,8 @@
 [id="ossm-config-storage_{context}"]
 = Distributed tracing storage configuration options
 
-You configure storage for the Collector, Ingester, and Query services under `spec.storage`. Multiple instances of each of these components can be provisioned as required for performance and resilience purposes.
+[role="_abstract"]
+Use the `spec.storage` field to set storage for the Collector, Ingester, and Query . You can run more than one copy of each part when you need better speed or uptime.
 
 .General storage parameters used by the {JaegerName} Operator to define distributed tracing storage
 
@@ -19,7 +20,7 @@ You configure storage for the Collector, Ingester, and Query services under `spe
     type:
 |Type of storage to use for the deployment.
 |`memory` or `elasticsearch`.
-Memory storage is only appropriate for development, testing, demonstrations, and proof of concept environments as the data does not persist if the pod is shut down. For production environments {JaegerShortName} supports Elasticsearch for persistent storage.
+Use memory storage only for dev, test, demos, or proofs of concept. Data is lost if the pod stops. For production, use Elasticsearch so data persists.
 |`memory`
 
 |storage:
@@ -65,25 +66,25 @@ Memory storage is only appropriate for development, testing, demonstrations, and
 [id="distributed-tracing-config-auto-provisioning-es_{context}"]
 == Auto-provisioning an Elasticsearch instance
 
-When you deploy a Jaeger custom resource, the {JaegerName} Operator uses the {es-op} to create an Elasticsearch cluster based on the configuration provided in the `storage` section of the custom resource file. The {JaegerName} Operator will provision Elasticsearch if the following configurations are set:
+When you deploy a Jaeger CR, the {JaegerName} Operator can use the {es-op} to create an Elasticsearch cluster. It uses the `storage` section of the Jaeger CR. The Operator provisions Elasticsearch when all of these are true:
 
-* `spec.storage:type` is set to `elasticsearch`
-* `spec.storage.elasticsearch.doNotProvision` set to `false`
-* `spec.storage.options.es.server-urls` is not defined, that is, there is no connection to an Elasticsearch instance that was not provisioned by the {es-op}.
+* `spec.storage.type` is `elasticsearch`
+* `spec.storage.elasticsearch.doNotProvision` is `false`
+* `spec.storage.options.es.server-urls` is not set (no link to Elasticsearch that the {es-op} did not create)
 
-When provisioning Elasticsearch, the {JaegerName} Operator sets the Elasticsearch custom resource `name` to the value of `spec.storage.elasticsearch.name` from the Jaeger custom resource.  If you do not specify a value for `spec.storage.elasticsearch.name`, the Operator uses `elasticsearch`.
+When it provisions Elasticsearch, the Operator sets the Elasticsearch CR `name` from `spec.storage.elasticsearch.name` in the Jaeger CR. If you omit that field, the name is `elasticsearch`.
 
-.Restrictions
+*Restrictions*
 
-* You can have only one {JaegerShortName} with self-provisioned Elasticsearch instance per namespace. The Elasticsearch cluster is meant to be dedicated for a single {JaegerShortName} instance.
+* You can run only one {JaegerShortName} with self-provisioned Elasticsearch in each namespace. That Elasticsearch cluster is for one {JaegerShortName} only.
 * There can be only one Elasticsearch per namespace.
 
 [NOTE]
 ====
-If you already have installed Elasticsearch as part of OpenShift Logging, the {JaegerName} Operator can use the installed {es-op} to provision storage.
+If you already installed Elasticsearch with OpenShift Logging, the {JaegerName} Operator can use the same {es-op} to provision storage.
 ====
 
-The following configuration parameters are for a _self-provisioned_ Elasticsearch instance, that is an instance created by the {JaegerName} Operator using the {es-op}. You specify configuration options for self-provisioned Elasticsearch under `spec:storage:elasticsearch` in your configuration file.
+These parameters apply to _self-provisioned_ Elasticsearch. That means the {JaegerName} Operator creates the instance with the {es-op}. Set those options under `spec:storage:elasticsearch` in your file.
 
 .Elasticsearch resource configuration parameters
 [options="header"]
@@ -161,7 +162,7 @@ Minimum deployment = 16Gi*
 
 |===
 
-Each Elasticsearch node can operate with a lower memory setting though this is NOT recommended for production deployments. For production use, you must have no less than 16 Gi allocated to each pod by default, but preferably allocate as much as you can, up to 64 Gi per pod.
+You can give each Elasticsearch node less memory, but do not do that in production. In production, give each pod at least 16 Gi by default. Use as much as you can, up to 64 Gi per pod.
 
 .Production storage example
 [source,yaml]
@@ -195,9 +196,9 @@ spec:
   strategy: production
   storage:
     type: elasticsearch
-    elasticsearch:
+      elasticsearch:
       nodeCount: 1
-      storage: # <1>
+      storage:
         storageClassName: gp2
         size: 5Gi
       resources:
@@ -209,27 +210,27 @@ spec:
       redundancyPolicy: ZeroRedundancy
 ----
 
-<1> Persistent storage configuration. In this case AWS `gp2` with `5Gi` size. When no value is specified, {JaegerShortName} uses `emptyDir`. The {es-op} provisions `PersistentVolumeClaim` and `PersistentVolume` which are not removed with {JaegerShortName} instance. You can mount the same volumes if you create a {JaegerShortName} instance with the same name and namespace.
+The `storage` field under `elasticsearch` sets persistent storage. This example uses AWS `gp2` with size `5Gi`. If you omit it, {JaegerShortName} uses `emptyDir`. The {es-op} creates `PersistentVolumeClaim` and `PersistentVolume` objects. They stay when you remove the {JaegerShortName} instance. You can attach the same volumes to a new {JaegerShortName} with the same name and namespace.
 
 
 [id="distributed-tracing-config-external-es_{context}"]
 == Connecting to an existing Elasticsearch instance
 
-You can use an existing Elasticsearch cluster for storage with {DTShortName}. An existing Elasticsearch cluster, also known as an _external_ Elasticsearch instance, is an instance that was not installed by the {JaegerName} Operator or by the {es-op}.
+You can use an existing Elasticsearch cluster for {DTShortName} storage. An _external_ cluster is one that the {JaegerName} Operator or {es-op} did not install.
 
-When you deploy a Jaeger custom resource, the {JaegerName} Operator will not provision Elasticsearch if the following configurations are set:
+When you deploy a Jaeger CR, the Operator does not provision Elasticsearch if any of these are true:
 
 * `spec.storage.elasticsearch.doNotProvision` set to `true`
 * `spec.storage.options.es.server-urls` has a value
-* `spec.storage.elasticsearch.name` has a value, or if the Elasticsearch instance name is `elasticsearch`.
+* `spec.storage.elasticsearch.name` is set, or the Elasticsearch instance name is `elasticsearch`.
 
-The {JaegerName} Operator uses the Elasticsearch instance specified in `spec.storage.elasticsearch.name` to connect to Elasticsearch.
+The {JaegerName} Operator connects to the cluster named in `spec.storage.elasticsearch.name`.
 
-.Restrictions
+*Restrictions*
 
-* You cannot share or reuse a {product-title} logging Elasticsearch instance with {JaegerShortName}. The Elasticsearch cluster is meant to be dedicated for a single {JaegerShortName} instance.
+* Do not share the {product-title} logging Elasticsearch cluster with {JaegerShortName}. Use a cluster that is only for one {JaegerShortName} instance.
 
-The following configuration parameters are for an already existing Elasticsearch instance, also known as an _external_ Elasticsearch instance. In this case, you specify configuration options for Elasticsearch under `spec:storage:options:es` in your custom resource file.
+These parameters apply to an existing cluster (_external_ Elasticsearch). Set them under `spec:storage:options:es` in your CR.
 
 .General ES configuration parameters
 [options="header"]
@@ -611,7 +612,7 @@ spec:
         secretName: quickstart-es-http-certs-public
 ----
 
-The following example shows a Jaeger CR using an external Elasticsearch cluster with TLS CA certificate mounted from a volume and user/password stored in a secret.
+The next example uses an external Elasticsearch cluster. It mounts a TLS CA from a volume. It stores the user name and password in a secret.
 
 .External Elasticsearch example
 [source,yaml]
@@ -626,12 +627,12 @@ spec:
     type: elasticsearch
     options:
       es:
-        server-urls: https://quickstart-es-http.default.svc:9200 # <1>
+        server-urls: https://quickstart-es-http.default.svc:9200
         index-prefix: my-prefix
-        tls: # <2>
+        tls:
           ca: /es/certificates/ca.crt
-    secretName: tracing-secret # <3>
-  volumeMounts: # <4>
+    secretName: tracing-secret
+  volumeMounts:
     - name: certificates
       mountPath: /es/certificates/
       readOnly: true
@@ -640,86 +641,9 @@ spec:
       secret:
         secretName: quickstart-es-http-certs-public
 ----
-<1> URL to Elasticsearch service running in default namespace.
-<2> TLS configuration. In this case only CA certificate, but it can also contain es.tls.key and es.tls.cert when using mutual TLS.
-<3> Secret which defines environment variables ES_PASSWORD and ES_USERNAME. Created by kubectl create secret generic tracing-secret --from-literal=ES_PASSWORD=changeme --from-literal=ES_USERNAME=elastic
-<4> Volume mounts and volumes which are mounted into all storage components.
+The example uses these settings:
 
-ifndef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
-[id="distr-tracing-manage-es-certificates_{context}"]
-= Managing certificates with Elasticsearch
-
-You can create and manage certificates using the {es-op}. Managing certificates using the {es-op} also lets you use a single Elasticsearch cluster with multiple Jaeger Collectors.
-
-:FeatureName: Managing certificates with Elasticsearch
-include::snippets/technology-preview.adoc[leveloffset=+1]
-
-Starting with version 2.4, the {JaegerName} Operator delegates certificate creation to the {es-op} by using the following annotations in the Elasticsearch custom resource:
-
-* `logging.openshift.io/elasticsearch-cert-management: "true"`
-* `logging.openshift.io/elasticsearch-cert.jaeger-<shared-es-node-name>: "user.jaeger"`
-* `logging.openshift.io/elasticsearch-cert.curator-<shared-es-node-name>: "system.logging.curator"`
-
-Where the `<shared-es-node-name>` is the name of the Elasticsearch node. For example, if you create an Elasticsearch node named `custom-es`, your custom resource might look like the following example.
-
-.Example Elasticsearch CR showing annotations
-[source,yaml]
-----
-apiVersion: logging.openshift.io/v1
-kind: Elasticsearch
-metadata:
-  annotations:
-    logging.openshift.io/elasticsearch-cert-management: "true"
-    logging.openshift.io/elasticsearch-cert.jaeger-custom-es: "user.jaeger"
-    logging.openshift.io/elasticsearch-cert.curator-custom-es: "system.logging.curator"
-  name: custom-es
-spec:
-  managementState: Managed
-  nodeSpec:
-    resources:
-      limits:
-        memory: 16Gi
-      requests:
-        cpu: 1
-        memory: 16Gi
-  nodes:
-    - nodeCount: 3
-      proxyResources: {}
-      resources: {}
-      roles:
-        - master
-        - client
-        - data
-      storage: {}
-  redundancyPolicy: ZeroRedundancy
-----
-
-.Prerequisites
-
-* The {SMProductName} Operator is installed.
-* The {logging-title} is installed with default configuration in your cluster.
-* The Elasticsearch node and the Jaeger instances must be deployed in the same namespace. For example, `tracing-system`.
-
-You enable certificate management by setting `spec.storage.elasticsearch.useCertManagement` to `true` in the Jaeger custom resource.
-
-.Example showing `useCertManagement`
-[source,yaml]
-----
-apiVersion: jaegertracing.io/v1
-kind: Jaeger
-metadata:
-  name: jaeger-prod
-spec:
-  strategy: production
-  storage:
-    type: elasticsearch
-    elasticsearch:
-      name: custom-es
-      doNotProvision: true
-      useCertManagement: true
-----
-
-The {JaegerName} Operator sets the Elasticsearch custom resource `name` to the value of `spec.storage.elasticsearch.name` from the Jaeger custom resource when provisioning Elasticsearch.
-
-The certificates are provisioned by the {es-op} and the {JaegerName} Operator injects the certificates.
-endif::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
+* `server-urls` — Address of the Elasticsearch service in the default namespace.
+* `tls` — TLS settings. Here only the CA is set. For mutual TLS you can also set `es.tls.key` and `es.tls.cert`.
+* `secretName` — Secret for `ES_PASSWORD` and `ES_USERNAME`. For example: `kubectl create secret generic tracing-secret --from-literal=ES_PASSWORD=changeme --from-literal=ES_USERNAME=elastic`.
+* `volumeMounts` and `volumes` — Mounts used by all storage parts.

--- a/modules/ossm-configuring-external-jaeger.adoc
+++ b/modules/ossm-configuring-external-jaeger.adoc
@@ -6,11 +6,12 @@
 [id="ossm-specifying-external-jaeger_{context}"]
 = Specifying Jaeger configuration in a Jaeger custom resource
 
-You can fully customize your Jaeger deployment by configuring Jaeger in the Jaeger custom resource (CR) rather than in the `ServiceMeshControlPlane` (SMCP) resource. This configuration is sometimes referred to as an "external Jaeger" since the configuration is specified outside of the SMCP.
+[role="_abstract"]
+You can set all Jaeger options in the Jaeger custom resource (CR) instead of the `ServiceMeshControlPlane` (SMCP). This setup is often called an _external Jaeger_ because the settings live outside the SMCP.
 
 [NOTE]
 ====
 You must deploy the SMCP and Jaeger CR in the same namespace. For example, `istio-system`.
 ====
 
-You can configure and deploy a standalone Jaeger instance and then specify the `name` of the Jaeger resource as the value for `spec.addons.jaeger.name` in the SMCP resource. If a Jaeger CR matching the value of `name` exists, the {SMProductShortName} control plane will use the existing installation. This approach lets you fully customize your Jaeger configuration.
+Deploy a standalone Jaeger instance. Set `spec.addons.jaeger.name` in the SMCP to the name of that Jaeger resource. If a Jaeger CR exists with that name, the {SMProductShortName} control plane uses it. You can then change every Jaeger setting in the CR.

--- a/modules/ossm-deploying-jaeger.adoc
+++ b/modules/ossm-deploying-jaeger.adoc
@@ -2,23 +2,25 @@
 //
 // * service_mesh/v2x/ossm-custom-resources.adoc
 
+:_mod-docs-content-type: CONCEPT
 [id="ossm-deploying-jaeger_{context}"]
 = Deploying the distributed tracing platform
 
-The {JaegerShortName} has predefined deployment strategies. You specify a deployment strategy in the Jaeger custom resource (CR) file. When you create an instance of the {JaegerShortName}, the {JaegerName} Operator uses this configuration file to create the objects necessary for the deployment.
+[role="_abstract"]
+The {JaegerShortName} includes fixed deployment strategies. You set the strategy in the Jaeger custom resource (CR). When you create a {JaegerShortName} instance, the {JaegerName} Operator uses the CR to create what you need.
 
-The {JaegerName} Operator currently supports the following deployment strategies:
+The {JaegerName} Operator supports these deployment strategies:
 
-* *allInOne* (default) - This strategy is intended for development, testing, and demo purposes and it is not for production use. The main back-end components, Agent, Collector, and Query service, are all packaged into a single executable, which is configured (by default) to use in-memory storage. You can configure this deployment strategy in the SMCP.
+* *allInOne* (default) - Use this strategy for development, tests, and demos. Do not use it in production. Agent, Collector, and Query run in one process. By default it uses memory for storage. You can set this strategy in the SMCP.
 +
 [NOTE]
 ====
-In-memory storage is not persistent, which means that if the Jaeger instance shuts down, restarts, or is replaced, your trace data will be lost. And in-memory storage cannot be scaled, since each pod has its own memory. For persistent storage, you must use the `production` or `streaming` strategies, which use Elasticsearch as the default storage.
+Memory storage does not last. If the Jaeger pod stops, restarts, or is replaced, you lose trace data. You cannot scale memory storage because each pod has its own memory. For data that persists, use the `production` or `streaming` strategies. Both use Elasticsearch for storage by default.
 ====
 
-* *production* - The production strategy is intended for production environments, where long term storage of trace data is important, and a more scalable and highly available architecture is required. Each back-end component is therefore deployed separately. The Agent can be injected as a sidecar on the instrumented application. The Query and Collector services are configured with a supported storage type, which is currently Elasticsearch. Multiple instances of each of these components can be provisioned as required for performance and resilience purposes. You can configure this deployment strategy in the SMCP, but in order to be fully customized, you must specify your configuration in the Jaeger CR and link that to the SMCP.
+* *production* - Use this strategy when you need trace data kept long term and a layout that scales and stays up. Each back-end part runs on its own. You can add the Agent as a sidecar on your app. Query and Collector use a supported storage type. Today that type is Elasticsearch. You can run more than one copy of each part for speed and uptime. You can start this strategy in the SMCP. For full control, put your settings in the Jaeger CR and point the SMCP to that CR.
 
-* *streaming* - The streaming strategy is designed to augment the production strategy by providing a streaming capability that sits between the Collector and the Elasticsearch back-end storage. This provides the benefit of reducing the pressure on the back-end storage, under high load situations, and enables other trace post-processing capabilities to tap into the real-time span data directly from the streaming platform (https://access.redhat.com/documentation/en-us/red_hat_amq/7.6/html/using_amq_streams_on_openshift/index[AMQ Streams]/ https://kafka.apache.org/documentation/[Kafka]). You cannot configure this deployment strategy in the SMCP; you must configure a Jaeger CR and link that to the SMCP.
+* *streaming* - This strategy adds a stream between the Collector and Elasticsearch. It eases load on storage when traffic is high. Other tools can also read span data from the stream (AMQ Streams and Apache Kafka). You cannot set this strategy in the SMCP. Create a Jaeger CR and link it from the SMCP.
 
 [NOTE]
 ====
@@ -133,3 +135,9 @@ spec:
     jaeger:
       name: MyJaegerInstance  #name of Jaeger CR
 ----
+
+[role="_additional-resources"]
+.Additional resources
+
+* link:https://access.redhat.com/documentation/en-us/red_hat_amq/7.6/html/using_amq_streams_on_openshift/index[Using AMQ Streams on OpenShift]
+* link:https://kafka.apache.org/documentation/[Apache Kafka documentation]

--- a/modules/ossm-deployment-best-practices.adoc
+++ b/modules/ossm-deployment-best-practices.adoc
@@ -6,6 +6,9 @@
 [id="ossm-deployment-best-practices_{context}"]
 = Deployment best practices
 
-* {DTProductName} instance names must be unique. If you want to have multiple {JaegerName} instances and are using sidecar injected agents, then the {JaegerName} instances should have unique names, and the injection annotation should explicitly specify the {JaegerName} instance name the tracing data should be reported to.
+[role="_abstract"]
+Use these tips when you deploy {DTProductName} and {JaegerName} with service mesh.
 
-* If you have a multitenant implementation and tenants are separated by namespaces, deploy a {JaegerName} instance to each tenant namespace.
+* Each {DTProductName} instance needs a unique name. If you run more than one {JaegerName} instance with sidecar agents, give each instance a unique name. Set the injection annotation to the instance name that should receive trace data.
+
+* If each tenant has its own namespace, deploy one {JaegerName} instance in each of those namespaces.

--- a/modules/ossm-distr-tracing-config-sampling.adoc
+++ b/modules/ossm-distr-tracing-config-sampling.adoc
@@ -6,22 +6,23 @@
 [id="ossm-distr-tracing-config-sampling_{context}"]
 = Distributed tracing sampling configuration options
 
-The {JaegerName} Operator can be used to define sampling strategies that will be supplied to tracers that have been configured to use a remote sampler.
+[role="_abstract"]
+The {JaegerName} Operator sets sampling plans for tracers that use a remote sampler.
 
-While all traces are generated, only a few are sampled. Sampling a trace marks the trace for further processing and storage.
+The system creates all traces, but only some are sampled. A sampled trace is kept for more work and storage.
 
 [NOTE]
 ====
-This is not relevant if a trace was started by the Envoy proxy, as the sampling decision is made there. The Jaeger sampling decision is only relevant when the trace is started by an application using the client.
+This does not apply if the Envoy proxy starts the trace. The proxy makes the sampling choice there. Jaeger sampling only applies when an app starts the trace with the client.
 ====
 
-When a service receives a request that contains no trace context, the client starts a new trace, assigns it a random trace ID, and makes a sampling decision based on the currently installed sampling strategy. The sampling decision propagates to all subsequent requests in the trace so that other services are not making the sampling decision again.
+When a service gets a request with no trace data, the client starts a new trace. It picks a random trace ID. It samples based on the current plan. That choice applies to later requests in the same trace. Other services do not sample again.
 
-{JaegerShortName} libraries support the following samplers:
+{JaegerShortName} libraries support these samplers:
 
-* *Probabilistic* - The sampler makes a random sampling decision with the probability of sampling equal to the value of the `sampling.param` property. For example, using `sampling.param=0.1` samples approximately 1 in 10 traces.
+* *Probabilistic* - The sampler picks at random. The chance of sampling matches `sampling.param`. For example, `sampling.param=0.1` keeps about 1 in 10 traces.
 
-* *Rate Limiting* - The sampler uses a leaky bucket rate limiter to ensure that traces are sampled with a certain constant rate. For example, using `sampling.param=2.0` samples requests with the rate of 2 traces per second.
+* *Rate Limiting* - The sampler uses a rate limiter. Traces are sampled at a steady rate. For example, `sampling.param=2.0` keeps 2 traces per second.
 
 .Jaeger sampling options
 [options="header"]
@@ -54,7 +55,7 @@ service_strategy:
 |1
 |===
 
-This example defines a default sampling strategy that is probabilistic, with a 50% chance of the trace instances being sampled.
+This example sets the default plan to probabilistic sampling. It keeps half of the traces.
 
 .Probabilistic sampling example
 [source,yaml]

--- a/modules/ossm-enabling-jaeger.adoc
+++ b/modules/ossm-enabling-jaeger.adoc
@@ -2,10 +2,11 @@
 //
 // * service_mesh/v2x/customizing-installation-ossm.adoc
 
-
+:_mod-docs-content-type: CONCEPT
 [id="ossm-enabling-tracing_{context}"]
 = Enabling and disabling tracing
 
+[role="_abstract"]
 You enable distributed tracing by specifying a tracing type and a sampling rate in the `ServiceMeshControlPlane` resource.
 
 .Default `all-in-one` Jaeger parameters

--- a/service_mesh/v2x/ossm-reference-jaeger.adoc
+++ b/service_mesh/v2x/ossm-reference-jaeger.adoc
@@ -6,6 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 When the {SMProductShortName} Operator deploys the `ServiceMeshControlPlane` resource, it can also create the resources for distributed tracing. {SMProductShortName} uses Jaeger for distributed tracing.
 
 [IMPORTANT]
@@ -25,10 +26,6 @@ include::modules/ossm-configuring-external-jaeger.adoc[leveloffset=+1]
 
 include::modules/ossm-deployment-best-practices.adoc[leveloffset=+2]
 
-ifdef::openshift-enterprise,openshift-dedicated[]
-For information about configuring persistent storage, see xref:../../storage/understanding-persistent-storage.adoc[Understanding persistent storage] and the appropriate configuration topic for your chosen storage option.
-endif::[]
-
 include::modules/ossm-config-security-ossm.adoc[leveloffset=+2]
 
 include::modules/ossm-config-security-ossm-web.adoc[leveloffset=+3]
@@ -43,6 +40,17 @@ include::modules/ossm-distr-tracing-config-sampling.adoc[leveloffset=+2]
 
 include::modules/ossm-config-storage.adoc[leveloffset=+2]
 
+ifndef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
+include::modules/ossm-config-manage-es-certificates.adoc[leveloffset=+2]
+endif::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
+
 include::modules/ossm-config-query.adoc[leveloffset=+2]
 
 include::modules/ossm-config-ingester.adoc[leveloffset=+2]
+
+ifdef::openshift-dedicated[]
+[role="_additional-resources"]
+[id="additional-resources_{context}"]
+== Additional resources
+* xref:../../storage/understanding-persistent-storage.adoc#understanding-persistent-storage[Understanding persistent storage]
+endif::openshift-dedicated[]


### PR DESCRIPTION
Version(s):
`enterprise-4.21+`

Issue:
* Service Mesh Vale Checks: **[OSDOCS-16610](https://redhat.atlassian.net/browse/OSDOCS-16610)**

Link to docs preview:
Jaeger configuration reference

- [ROSA](https://109159--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/service_mesh/v2x/ossm-reference-jaeger.html)
- [ROSA Classic](https://109159--ocpdocs-pr.netlify.app/openshift-rosa/latest/service_mesh/v2x/ossm-reference-jaeger.html)
- [OpenShift Dedicated](https://109159--ocpdocs-pr.netlify.app/openshift-dedicated/latest/service_mesh/v2x/ossm-reference-jaeger.html)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
This PR fixes the Service Mesh topics that are exclusive to ROSA/ROSA classic for DITA migration.