### PR TITLE
PR2 for SRVCOM-4313: CQA + DITA readiness for assemblies and modules under the "Integration" section

### DIFF
--- a/integrations/serverless-integrating-service-mesh/serverless-integrating-ossm-3-x-setup.adoc
+++ b/integrations/serverless-integrating-service-mesh/serverless-integrating-ossm-3-x-setup.adoc
@@ -7,39 +7,15 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 [role="_abstract"]
-The {ServerlessOperatorName} provides Kourier as the default ingress for Knative. However, you can use {SMProductShortName} with {ServerlessProductName} whether Kourier is enabled or not. Integrating with Kourier disabled allows you to configure additional networking and routing options that the Kourier ingress does not support, such as mTLS functionality.
+The {ServerlessOperatorName} uses Kourier as the default ingress for Knative. You can use {SMProductShortName} with {ServerlessProductName} whether you enable Kourier or disable it. If you disable Kourier, you can configure additional networking and routing options that Kourier does not support, such as mTLS.
 
-Note the following assumptions and limitations:
+include::modules/serverless-ossm-integration-3-x-assumption-limitations.adoc[leveloffset=+1]
 
-* All Knative internal components, as well as Knative Services, are part of the {SMProductShortName} and have sidecars injection enabled. This means that strict mutual Transport Layer Security (mTLS) is enforced within the whole mesh. All requests to Knative Services require an mTLS connection, with the client having to send its certificate, except calls coming from OpenShift Routing.
-
-* {ServerlessProductName} with {SMProductShortName} integration can only target one service mesh. Multiple meshes can be present in the cluster, but {ServerlessProductName} is only available on one of them.
-
-[id="prerequisites_serverless-integrating-ossm-3-x-setup"]
-== Prerequisites
-
-* You have access to an {product-title} account with cluster administrator access.
-
-* You have installed the OpenShift CLI (`oc`).
-
-* You have installed the {ServerlessProductShortName} Operator.
-
-* You have installed the {SMProductName} 3.x Operator.
-
-* The examples in the following procedures use the domain `example.com`. The example certificate for this domain is used as a certificate authority (CA) that signs the subdomain certificate.
-+
-To complete and verify these procedures in your deployment, you need either a certificate signed by a widely trusted public CA or a CA provided by your organisation. Example commands must be adjusted according to your domain, subdomain, and CA.
-
-* You must configure the wildcard certificate to match the domain of your {ocp-product-title} cluster. For example, if your {ocp-product-title} console address is `https://console-openshift-console.apps.openshift.example.com`, you must configure the wildcard certificate so that the domain is `*.apps.openshift.example.com`. For more information, see _Creating a certificate to encrypt incoming external traffic_.
-
-* If you want to use any domain name, including those which are not subdomains of the default {ocp-product-title} cluster domain, you must set up a domain mapping for those domains. For more information, see xref:../../knative-serving/config-custom-domains/create-domain-mapping.adoc#serverless-create-domain-mapping_create-domain-mapping[Creating a custom domain mapping {ServerlessProductName} documentation].
+include::modules/serverless-ossm-integration-prereqs-3-x-setup.adoc[leveloffset=+1]
 
 include::modules/serverless-ossm-external-certs.adoc[leveloffset=+1]
 
-[id="configuring-verifying-ossm-3-x-integration-with-serverless"]
-== Configuring and verifying {SMProductShortName} 3.x integration with {ServerlessProductName}
- 
-You can integrate {SMProductShortName} 3.x with {ServerlessProductName} to enable advanced traffic management, security, and observability for your serverless applications. This section provides the steps to verify prerequisites, install and configure both components, and confirm that the integration is functioning as expected.
+include::modules/configure-verify-ossm-3-x-serverless-integration.adoc[leveloffset=+1]
 
 include::modules/serverless-ossm-verifying-installation-prerequisites.adoc[leveloffset=+2]
 
@@ -50,3 +26,8 @@ include::modules/serverless-ossm-installing-and-configuring-openshift-serverless
 include::modules/serverless-ossm-verifying-the-ossm-3-x-integration.adoc[leveloffset=+2]
 
 include::modules/serverless-ossm-disabling-network-policies.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+== Additional resources
+
+* xref:../../knative-serving/config-custom-domains/create-domain-mapping.adoc#serverless-create-domain-mapping_create-domain-mapping[Creating a custom domain mapping {ServerlessProductName} documentation]

--- a/integrations/serverless-integrating-service-mesh/serverless-ossm-setup.adoc
+++ b/integrations/serverless-integrating-service-mesh/serverless-ossm-setup.adoc
@@ -7,62 +7,37 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 [role="_abstract"]
-The {ServerlessOperatorName} provides Kourier as the default ingress for Knative. However, you can use {SMProductShortName} with {ServerlessProductName} whether Kourier is enabled or not. Integrating with Kourier disabled allows you to configure additional networking and routing options that the Kourier ingress does not support, such as mTLS functionality.
+The {ServerlessOperatorName} uses Kourier as the default ingress for Knative. You can use {SMProductShortName} with {ServerlessProductName} whether you enable Kourier or disable it. If you disable Kourier, you can configure additional networking and routing options, such as mTLS that Kourier does not support.
 
-Note the following assumptions and limitations:
+include::modules/serverless-ossm-integration-assumption-limitations.adoc[leveloffset=+1]
 
-* All Knative internal components, and Knative Services, are part of the {SMProductShortName} and have sidecars injection enabled. This means that strict mTLS is enforced within the whole mesh. All requests to Knative Services require an mTLS connection, with the client having to send its certificate, except calls coming from OpenShift Routing.
-
-* {ServerlessProductName} with {SMProductShortName} integration can only target *one* service mesh. Multiple meshes can be present in the cluster, but {ServerlessProductName} is only available on one of them.
-
-* Changing the target `ServiceMeshMemberRoll` that {ServerlessProductName} is part of, meaning moving {ServerlessProductName} to another mesh, is not supported. The only way to change the targeted Service mesh is to uninstall and reinstall {ServerlessProductName}.
-
-[id="prerequisites_serverless-ossm-setup"]
-== Prerequisites
-
-* You have access to an {product-title} account with cluster administrator access.
-
-* You have installed the OpenShift CLI (`oc`).
-
-* You have installed the {ServerlessProductShortName} Operator.
-
-* You have installed the {SMProductName} 2.x Operator.
-
-* The examples in the following procedures use the domain `example.com`. The example certificate for this domain is used as a certificate authority (CA) that signs the subdomain certificate.
-+
-To complete and verify these procedures in your deployment, you need either a certificate signed by a widely trusted public CA or a CA provided by your organization. Example commands must be adjusted according to your domain, subdomain, and CA.
-
-* You must configure the wildcard certificate to match the domain of your {ocp-product-title} cluster. For example, if your {ocp-product-title} console address is `https://console-openshift-console.apps.openshift.example.com`, you must configure the wildcard certificate so that the domain is `*.apps.openshift.example.com`. For more information about configuring wildcard certificates, see the following topic about _Creating a certificate to encrypt incoming external traffic_.
-
-* If you want to use any domain name, including those which are not subdomains of the default {ocp-product-title} cluster domain, you must set up domain mapping for those domains. For more information, see the {ServerlessProductName} documentation about xref:../../knative-serving/config-custom-domains/create-domain-mapping.adoc#serverless-create-domain-mapping_create-domain-mapping[Creating a custom domain mapping].
-
-[IMPORTANT]
-====
-{ServerlessProductName} only supports the use of {SMProductName} functionality that is explicitly documented in this guide, and does not support other undocumented features.
-
-Using {ServerlessProductShortName} 1.31 with {SMProductShortName} is only supported with {SMProductShortName} version 2.2 or later. For details and information about versions other than 1.31, see the "Red Hat OpenShift Serverless Supported Configurations" page.
-====
+include::modules/serverless-ossm-integration-prereqs-2-x-setup.adoc[leveloffset=+1]
 
 include::modules/serverless-ossm-external-certs.adoc[leveloffset=+1]
 
-// without kourier
-[id="serverless-ossm-setup_integrating-ossm-with-serverless"]
-== Integrating {SMProductShortName} with {ServerlessProductName}
-
-You can integrate {SMProductShortName} 2.x with {ServerlessProductName} to enable advanced traffic management, security, and observability for your serverless applications. This section provides the steps to verify prerequisites, install and configure both components, and confirm that the integration is functioning as expected.
+include::modules/serverless-ossm-integration-2-x-with-serverless.adoc[leveloffset=+1]
 
 include::modules/serverless-ossm-verifying-installation-prerequisites.adoc[leveloffset=+2]
+
 include::modules/serverless-ossm-installing-and-configuring-openshift-service-mesh.adoc[leveloffset=+2]
+
 include::modules/serverless-ossm-installing-and-configuring-openshift-serverless.adoc[leveloffset=+2]
+
 include::modules/serverless-ossm-verifying-the-integration.adoc[leveloffset=+2]
 
 include::modules/serverless-ossm-enabling-serving-metrics.adoc[leveloffset=+1]
+
 include::modules/serverless-ossm-disabling-network-policies.adoc[leveloffset=+1]
 
 include::modules/serverless-ossm-secret-filtering-net-istio.adoc[leveloffset=+1]
 
-[id="additional-resources_serverless-ossm-setup"]
 [role="_additional-resources"]
 == Additional resources
+
 * link:https://access.redhat.com/articles/4912821[Red Hat OpenShift Serverless Supported Configurations]
+
 * xref:../../knative-serving/kourier-and-istio-ingresses.adoc#kourier-and-istio-ingresses[Kourier and Istio ingresses]
+
+* xref:../../knative-serving/config-custom-domains/create-domain-mapping.adoc#serverless-create-domain-mapping_create-domain-mapping[Creating a custom domain mapping]
+
+* link:https://www.plural.sh/blog/manage-kubernetes-events-informers/[Informers]

--- a/integrations/serverless-integrating-service-mesh/serverless-ossm-traffic-isolation.adoc
+++ b/integrations/serverless-integrating-service-mesh/serverless-ossm-traffic-isolation.adoc
@@ -9,11 +9,7 @@ toc::[]
 [role="_abstract"]
 You can use {SMProductShortName} 2.x with {ServerlessProductName} to control and isolate network traffic between services. This integration helps you define fine-grained communication policies, enhance security through mutual TLS, and manage traffic flow within your serverless environment.
 
-:FeatureName: Using {SMProductShortName} to isolate network traffic with {ServerlessProductName}
-include::snippets/technology-preview.adoc[leveloffset=+2]
-:!FeatureName:
-
-{SMProductShortName} can be used to isolate network traffic between tenants on a shared {product-title} cluster by using Service Mesh `AuthorizationPolicy` resources. {ServerlessProductShortName} can also use this, using several {SMProductShortName} resources. A tenant is a group of one or multiple projects that can access each other over the network on a shared cluster.
+include::modules/serverless-ossm-network-traffic-isolation.adoc[leveloffset=+1]
 
 include::modules/serverless-ossm-traffic-isolation-architecture.adoc[leveloffset=+1]
 

--- a/modules/configure-verify-ossm-3-x-serverless-integration.adoc
+++ b/modules/configure-verify-ossm-3-x-serverless-integration.adoc
@@ -1,0 +1,10 @@
+// Module included in the following assemblies:
+//
+// * /serverless/integrations/serverless-integrating-ossm-3-x-setup.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="configure-verify-ossm-3-x-serverless-integration_{context}"]
+= Configure and verify {SMProductShortName} 3.x integration with {ServerlessProductName}
+
+[role="_abstract"]
+Integrate {SMProductShortName} 3.x with {ServerlessProductName} to enable advanced traffic management, security, and observability for serverless applications. Verify prerequisites, install and configure both components, and then verify the integration.

--- a/modules/serverless-ossm-disabling-network-policies.adoc
+++ b/modules/serverless-ossm-disabling-network-policies.adoc
@@ -43,7 +43,8 @@ The {ServerlessOperatorName} generates the required network policies by default.
 $ oc edit KnativeEventing -n knative-eventing
 ----
 +
-.Example `KnativeEventing` CR
+You get an output similar to the following example:
++
 [source,yaml]
 ----
 apiVersion: operator.knative.dev/v1beta1
@@ -62,7 +63,8 @@ metadata:
 $ oc edit KnativeServing -n knative-serving
 ----
 +
-.Example `KnativeServing` CR
+You get an output similar to the following example:
++
 [source,yaml]
 ----
 apiVersion: operator.knative.dev/v1beta1

--- a/modules/serverless-ossm-enabling-serving-metrics.adoc
+++ b/modules/serverless-ossm-enabling-serving-metrics.adoc
@@ -4,10 +4,10 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="serverless-ossm-enabling-serving-metrics_{context}"]
-= Enabling Knative Serving and Knative Eventing metrics when using Service Mesh with mTLS
+= Enabling Knative Serving and Knative Eventing metrics when using {SMProductShortName} with mTLS
 
 [role="_abstract"]
-If Service Mesh is enabled with Mutual Transport Layer Security (mTLS), metrics for Knative Serving and Knative Eventing are disabled by default, because Service Mesh prevents Prometheus from scraping metrics. You can enable Knative Serving and Knative Eventing metrics when using Service Mesh and mTLS.
+If you enable {SMProductShortName} with Mutual Transport Layer Security (mTLS), {SMProductShortName} prevents Prometheus from scraping metrics. As a result, Knative Serving and Knative Eventing metrics are unavailable by default. You can enable these metrics when you use {SMProductShortName} with mTLS.
 
 .Prerequisites
 
@@ -62,7 +62,7 @@ spec:
 ...
 ----
 
-. Modify and reapply the default Service Mesh control plane in the `istio-system` namespace, so that it includes the following spec:
+. Change and reapply the default Service Mesh control plane in the `istio-system` namespace, so that it includes the following spec:
 +
 [source,yaml]
 ----

--- a/modules/serverless-ossm-installing-and-configuring-openshift-serverless.adoc
+++ b/modules/serverless-ossm-installing-and-configuring-openshift-serverless.adoc
@@ -9,7 +9,8 @@ After installing {SMProductShortName}, you need to install {ServerlessProductSho
 
 . Install Knative Serving with the following `KnativeServing` custom resource, which enables the Istio integration:
 +
-.Example `knative-serving-config.yaml` configuration file
+You get an output similar to the following example:
++
 [source,yaml]
 ----
 apiVersion: operator.knative.dev/v1beta1
@@ -22,8 +23,8 @@ metadata:
 spec:
   ingress:
     istio:
-      enabled: true <1>
-  deployments: <2>
+      enabled: true
+  deployments:
   - name: activator
     labels:
       "sidecar.istio.io/inject": "true"
@@ -35,15 +36,16 @@ spec:
     annotations:
       "sidecar.istio.io/rewriteAppHTTPProbers": "true"
   config:
-    istio: <3>
-      gateway.knative-serving.knative-ingress-gateway: istio-ingressgateway.<your-istio-namespace>.svc.cluster.local
-      local-gateway.knative-serving.knative-local-gateway: knative-local-gateway.<your-istio-namespace>.svc.cluster.local
+    istio:
+      gateway.knative-serving.knative-ingress-gateway: istio-ingressgateway.<your_istio_namespace>.svc.cluster.local
+      local-gateway.knative-serving.knative-local-gateway: knative-local-gateway.<your_istio_namespace>.svc.cluster.local
 ----
-<1> Enable Istio integration.
-<2> Enable sidecar injection for Knative Serving data plane pods.
-<3> If your istio is not running in the `istio-system` namespace, you need to set these two flags with the correct namespace.
 
-. Apply the `KnativeServing` resource:
+`enabled: true`:: Enable Istio integration.
+`deployments`:: Enable sidecar injection for Knative Serving data plane pods.
+`config.istio`:: If your istio is not running in the `istio-system` namespace, you need to set these two flags with the correct namespace.
+
+. Apply the `KnativeServing` resource by running the following command::
 +
 [source,terminal]
 ----
@@ -52,7 +54,8 @@ $ oc apply -f knative-serving-config.yaml
 
 . Install Knative Eventing with the following `KnativeEventing` object, which enables the Istio integration:
 +
-.Example `knative-eventing-config.yaml` configuration file
+You get an output similar to the following example:
++
 [source,yaml]
 ----
 apiVersion: operator.knative.dev/v1beta1
@@ -97,10 +100,11 @@ spec:
       annotations:
         sidecar.istio.io/rewriteAppHTTPProbers: "true"
 ----
-* `spec.config.features.istio` enables Eventing Istio controller to create a `DestinationRule` for each `InMemoryChannel` or `KafkaChannel` service.
-* `spec.workload` enables sidecar injection for Knative Eventing pods.
 
-. Apply the `KnativeEventing` resource:
+`spec.config.features.istio`:: enables Eventing Istio controller to create a `DestinationRule` for each `InMemoryChannel` or `KafkaChannel` service.
+`spec.workload`:: enables sidecar injection for Knative Eventing pods.
+
+. Apply the `KnativeEventing` resource by running the following command::
 +
 [source,terminal]
 ----
@@ -109,7 +113,8 @@ $ oc apply -f knative-eventing-config.yaml
 
 . Install Knative Kafka with the following `KnativeKafka` custom resource, which enables the Istio integration:
 +
-.Example `knative-kafka-config.yaml` configuration file
+You get an output similar to the following example:
++
 [source,yaml]
 ----
 apiVersion: operator.serverless.openshift.io/v1alpha1
@@ -120,18 +125,18 @@ metadata:
 spec:
   channel:
     enabled: true
-    bootstrapServers: <bootstrap_servers> <1>
+    bootstrapServers: <bootstrap_servers>
   source:
     enabled: true
   broker:
     enabled: true
     defaultConfig:
-      bootstrapServers: <bootstrap_servers> <1>
+      bootstrapServers: <bootstrap_servers>
       numPartitions: <num_partitions>
       replicationFactor: <replication_factor>
     sink:
       enabled: true
-  workloads: <2>
+  workloads:
   - name: kafka-controller
     labels:
       "sidecar.istio.io/inject": "true"
@@ -168,10 +173,11 @@ spec:
     annotations:
       "sidecar.istio.io/rewriteAppHTTPProbers": "true"
 ----
-<1> The Apache Kafka cluster URL, for example `my-cluster-kafka-bootstrap.kafka:9092`.
-<2> Enable sidecar injection for Knative Kafka pods.
 
-. Apply the `KnativeEventing` object:
+`bootstrapServers: <bootstrap_servers>`:: The Apache Kafka cluster URL, for example `my-cluster-kafka-bootstrap.kafka:9092`.
+`spec.workloads`:: Enable sidecar injection for Knative Kafka pods.
+
+. Apply the `KnativeEventing` object by running the following command::
 +
 [source,terminal]
 ----
@@ -180,7 +186,8 @@ $ oc apply -f knative-kafka-config.yaml
 
 . Install `ServiceEntry` to inform {SMProductShortName} of the communication between `KnativeKafka` components and an Apache Kafka cluster:
 +
-.Example `kafka-cluster-serviceentry.yaml` configuration file
+You get an output similar to the following example:
++
 [source,yaml]
 ----
 apiVersion: networking.istio.io/v1alpha3
@@ -189,11 +196,11 @@ metadata:
   name: kafka-cluster
   namespace: knative-eventing
 spec:
-  hosts: <1>
+  hosts:
     - <bootstrap_servers_without_port>
   exportTo:
     - "."
-  ports: <2>
+  ports:
     - number: 9092
       name: tcp-plain
       protocol: TCP
@@ -212,15 +219,16 @@ spec:
   location: MESH_EXTERNAL
   resolution: NONE
 ----
-<1> The list of Apache Kafka cluster hosts, for example `my-cluster-kafka-bootstrap.kafka`.
-<2> Apache Kafka cluster listeners ports.
+
+`spec.hosts`:: The list of Apache Kafka cluster hosts, for example `my-cluster-kafka-bootstrap.kafka`.
+`spec.ports`:: Apache Kafka cluster listeners ports.
 +
 [NOTE]
 ====
-The listed ports in `spec.ports` are example TPC ports. The actual values depend on how the Apache Kafka cluster is configured.
+The ports listed in `spec.ports` are example TCP (Transmission Control Protocol) ports. The actual values depend on the Apache Kafka cluster configuration.
 ====
 
-. Apply the `ServiceEntry` resource:
+. Apply the `ServiceEntry` resource by running the following command:
 +
 [source,terminal]
 ----

--- a/modules/serverless-ossm-installing-and-configuring-openshift-service-mesh.adoc
+++ b/modules/serverless-ossm-installing-and-configuring-openshift-service-mesh.adoc
@@ -26,33 +26,35 @@ spec:
   - default
   security:
     dataPlane:
-      mtls: true <1>
+      mtls: true
   techPreview:
     meshConfig:
       defaultConfig:
-        terminationDrainDuration: 35s <2>
+        terminationDrainDuration: 35s
   gateways:
     ingress:
       service:
         metadata:
           labels:
-            knative: ingressgateway <3>
+            knative: ingressgateway
   proxy:
     networking:
       trafficControl:
         inbound:
-          excludedPorts: <4>
+          excludedPorts:
           - 8444 # metrics
           - 8022 # serving: wait-for-drain k8s pre-stop hook
 ----
-<1> Enforce strict mTLS in the mesh. Only calls using a valid client certificate are allowed.
-<2> {ServerlessProductShortName} has a graceful termination for Knative Services of 30 seconds. `istio-proxy` needs to have a longer termination duration to make sure no requests are dropped.
-<3> Define a specific selector for the ingress gateway to target only the Knative gateway.
-<4> These ports are called by Kubernetes and cluster monitoring, which are not part of the mesh and cannot be called using mTLS. Therefore, these ports are excluded from the mesh.
 
-. Add the namespaces that you would like to integrate with {SMProductShortName} to the `ServiceMeshMemberRoll` object as members:
+`mtls: true`:: Enforce strict mTLS in the mesh. Only calls using a valid client certificate are allowed.
+`techPreview.terminationDrainDuration`:: {ServerlessProductShortName} has a graceful termination for Knative Services of 30 seconds. `istio-proxy` needs to have a longer termination duration to make sure no requests are dropped.
+`knative: ingressgateway`:: Define a specific selector for the ingress gateway to target only the Knative gateway.
+`excludedPorts`:: These ports are called by Kubernetes and cluster monitoring, which are not part of the mesh and cannot be called using mTLS. Therefore, these ports are excluded from the mesh.
+
+. Add the namespaces that you want to integrate with {SMProductShortName} to the `ServiceMeshMemberRoll` object as members:
 +
-.Example `servicemesh-member-roll.yaml` configuration file
+You get an output similar to the following example:
++
 [source,yaml]
 ----
 apiVersion: maistra.io/v1
@@ -61,19 +63,20 @@ metadata:
   name: default
   namespace: istio-system
 spec:
-  members: <1>
+  members:
     - knative-serving
     - knative-eventing
     - your-OpenShift-projects
 ----
-<1> A list of namespaces to be integrated with {SMProductShortName}.
+
+`spec.members`:: A list of namespaces to be integrated with {SMProductShortName}.
 +
 [IMPORTANT]
 ====
 This list of namespaces must include the `knative-serving` and `knative-eventing` namespaces.
 ====
 
-. Apply the `ServiceMeshMemberRoll` resource:
+. Apply the `ServiceMeshMemberRoll` resource by running the following commad::
 +
 [source,terminal]
 ----
@@ -82,7 +85,8 @@ $ oc apply -f servicemesh-member-roll.yaml
 
 . Create the necessary gateways so that {SMProductShortName} can accept traffic. The following example uses the `knative-local-gateway` object with the `ISTIO_MUTUAL` mode (mTLS):
 +
-.Example `istio-knative-gateways.yaml` configuration file
+You get an output similar to the following example:
++
 [source,yaml]
 ----
 apiVersion: networking.istio.io/v1alpha3
@@ -102,7 +106,7 @@ spec:
         - "*"
       tls:
         mode: SIMPLE
-        credentialName: <wildcard_certs> <1>
+        credentialName: <wildcard_certs>
 ---
 apiVersion: networking.istio.io/v1alpha3
 kind: Gateway
@@ -116,9 +120,9 @@ spec:
    - port:
        number: 8081
        name: https
-       protocol: HTTPS <2>
+       protocol: HTTPS
      tls:
-       mode: ISTIO_MUTUAL <2>
+       mode: ISTIO_MUTUAL
      hosts:
        - "*"
 ---
@@ -138,10 +142,11 @@ spec:
      port: 80
      targetPort: 8081
 ----
-<1> Name of the secret containing the wildcard certificate.
-<2> The `knative-local-gateway` object serves HTTPS traffic and expects all clients to send requests using mTLS. This means that only traffic coming from within {SMProductShortName} is possible. Workloads from outside the {SMProductShortName} must use the external domain via OpenShift Routing.
 
-. Apply the `Gateway` resources:
+`credentialName: <wildcard_certs>`:: Name of the secret containing the wildcard certificate.
+`protocol: HTTPS` and `mode: ISTIO_MUTUAL`:: The `knative-local-gateway` object serves HTTPS traffic and expects all clients to send requests by using mTLS. This means that only traffic coming from within {SMProductShortName} is possible. Workloads from outside the {SMProductShortName} must use the external domain through OpenShift Routing.
+
+. Apply the `Gateway` resources by running the following commad:
 +
 [source,terminal]
 ----

--- a/modules/serverless-ossm-integration-2-x-with-serverless.adoc
+++ b/modules/serverless-ossm-integration-2-x-with-serverless.adoc
@@ -1,0 +1,10 @@
+// Module included in the following assemblies:
+//
+// * /serverless/integrations/serverless-ossm-setup.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="serverless-ossm-integration-2-x-with-serverless_{context}"]
+= Integrate {SMProductShortName} with {ServerlessProductName}
+
+[role="_abstract"]
+You can integrate {SMProductShortName} 2.x with {ServerlessProductName} to enable advanced traffic management, security, and observability for serverless applications. Follow the steps to verify prerequisites, install and configure both components, and verify the integration.

--- a/modules/serverless-ossm-integration-3-x-assumption-limitations.adoc
+++ b/modules/serverless-ossm-integration-3-x-assumption-limitations.adoc
@@ -1,0 +1,16 @@
+// Module included in the following assemblies:
+//
+// * /serverless/integrations/serverless-ossm-setup.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="serverless-ossm-integration-3-x-assumption-limitations_{context}"]
+= Assumptions and limitations for {SMProductShortName} 3.x integration
+
+[role="_abstract"]
+Learn about the key assumptions and limitations for integrating {ServerlessProductName} with {SMProductShortName} 3.x.
+
+Note the following assumptions and limitations:
+
+* All Knative internal components and Knative Services run within {SMProductShortName} with sidecar injection enabled. As a result, the mesh enforces strict mutual Transport Layer Security (mTLS). Clients must use mTLS when sending requests to Knative Services and must present a valid certificate. OpenShift Routing is the only exception.
+
+* {ServerlessProductName} integrates with only one service mesh. You can run many meshes in the cluster, but {ServerlessProductName} operates in a single mesh.

--- a/modules/serverless-ossm-integration-assumption-limitations.adoc
+++ b/modules/serverless-ossm-integration-assumption-limitations.adoc
@@ -1,0 +1,18 @@
+// Module included in the following assemblies:
+//
+// * /serverless/integrations/serverless-ossm-setup.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="serverless-ossm-integration-assumption-limitations_{context}"]
+= Assumptions and limitations for {SMProductShortName} integration
+
+[role="_abstract"]
+The key assumptions and limitations for integrating {ServerlessProductName} with {SMProductShortName}.
+
+Note the following assumptions and limitations:
+
+* All Knative internal components and Knative Services run within {SMProductShortName} with sidecar injection enabled. As a result, the mesh enforces strict mTLS across all components. Clients must use mTLS when sending requests to Knative Services and must present a valid certificate. OpenShift Routing is the only exception.
+
+* {ServerlessProductName} integrates with only one service mesh. You can run multiple meshes in the cluster, but {ServerlessProductName} operates in a single mesh.
+
+* You cannot change the target `ServiceMeshMemberRoll` for {ServerlessProductName}. To use a different service mesh, uninstall and reinstall {ServerlessProductName}.

--- a/modules/serverless-ossm-integration-prereqs-2-x-setup.adoc
+++ b/modules/serverless-ossm-integration-prereqs-2-x-setup.adoc
@@ -1,0 +1,33 @@
+// Module included in the following assemblies:
+//
+// * /serverless/integrations/serverless-ossm-setup.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="serverless-ossm-integration-prereqs-2-x-setup_{context}"]
+= Prerequisites for {SMProductShortName} 2.x integration
+
+[role="_abstract"]
+Learn about the requirements that you must meet before integrating {SMProductShortName} 2.x with {ServerlessProductName}.
+
+* You have access to an {product-title} account with cluster administrator access.
+
+* You have installed the OpenShift CLI (`oc`).
+
+* You have installed the {ServerlessProductShortName} Operator.
+
+* You have installed the {SMProductName} 2.x Operator.
+
+* The examples in the following procedures use the domain `example.com`. The example certificate for this domain is used as a certificate authority (CA) that signs the subdomain certificate.
++
+To complete and verify these procedures in your deployment, you need either a certificate signed by a widely trusted public CA or a CA provided by your organization. Example commands must be adjusted according to your domain, subdomain, and CA.
+
+* You must configure the wildcard certificate to match the domain of your {ocp-product-title} cluster. For example, if your {ocp-product-title} console address is `https://console-openshift-console.apps.openshift.example.com`, you must configure the wildcard certificate so that the domain is `*.apps.openshift.example.com`.
+
+* If you want to use any domain name, including those which are not subdomains of the default {ocp-product-title} cluster domain, you must set up domain mapping for those domains.
+
+[IMPORTANT]
+====
+{ServerlessProductName} only supports the use of {SMProductName} functionality that is explicitly documented in this guide, and does not support other undocumented features.
+
+Using {ServerlessProductShortName} 1.31 with {SMProductShortName} is only supported with {SMProductShortName} version 2.2 or later. For details and information about versions other than 1.31, see the "Red Hat OpenShift Serverless Supported Configurations" page.
+====

--- a/modules/serverless-ossm-integration-prereqs-3-x-setup.adoc
+++ b/modules/serverless-ossm-integration-prereqs-3-x-setup.adoc
@@ -1,0 +1,26 @@
+// Module included in the following assemblies:
+//
+// * /serverless/integrations/serverless-ossm-setup.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="serverless-ossm-integration-prereqs-3-x-setup_{context}"]
+= Prerequisites for {SMProductShortName} 3.x integration
+
+[role="_abstract"]
+Learn about the requirements that you must meet before integrating {SMProductShortName} 3.x with {ServerlessProductName}.
+
+* You have access to an {product-title} account with cluster administrator access.
+
+* You have installed the OpenShift CLI (`oc`).
+
+* You have installed the {ServerlessProductShortName} Operator.
+
+* You have installed the {SMProductName} 3.x Operator.
+
+* The examples in the following procedures use the domain `example.com`. The example certificate for this domain is used as a certificate authority (CA) that signs the subdomain certificate.
++
+To complete and verify these procedures in your deployment, you need either a certificate signed by a widely trusted public CA or a CA provided by your organisation. Example commands must be adjusted according to your domain, subdomain, and CA.
+
+* You must configure the wildcard certificate to match the domain of your {ocp-product-title} cluster. For example, if your {ocp-product-title} console address is `https://console-openshift-console.apps.openshift.example.com`, you must configure the wildcard certificate so that the domain is `*.apps.openshift.example.com`.
+
+* If you want to use any domain name, including those which are not subdomains of the default {ocp-product-title} cluster domain, you must set up a domain mapping for those domains.

--- a/modules/serverless-ossm-network-traffic-isolation.adoc
+++ b/modules/serverless-ossm-network-traffic-isolation.adoc
@@ -1,0 +1,11 @@
+:_mod-docs-content-type: CONCEPT
+[id="serverless-ossm-network-traffic-isolation_{context}"]
+= Network traffic isolation with {SMProductShortName} and {ServerlessProductName}
+
+[role="_abstract"]
+Learn how to use {SMProductShortName} to isolate network traffic between tenants in {ServerlessProductName}.
+
+:FeatureName: Using {SMProductShortName} to isolate network traffic with {ServerlessProductName}
+include::snippets/technology-preview.adoc[leveloffset=+2]
+
+{SMProductShortName} isolates network traffic between tenants on a shared {product-title} cluster by using Service Mesh `AuthorizationPolicy` resources. {ServerlessProductShortName} supports this approach by using many {SMProductShortName} resources. A tenant is a group of one or more projects that can communicate with each other over the network on a shared cluster.

--- a/modules/serverless-ossm-secret-filtering-net-istio.adoc
+++ b/modules/serverless-ossm-secret-filtering-net-istio.adoc
@@ -7,7 +7,7 @@
 = Improving net-istio memory usage by using secret filtering for {SMProductShortName}
 
 [role="_abstract"]
-By default, the link:https://aly.arriqaaq.com/kubernetes-informers/[informers] implementation for the Kubernetes `client-go` library fetches all resources of a particular type. This can lead to a substantial overhead when many resources are available, which can cause the Knative `net-istio` ingress controller to fail on large clusters due to memory leaking. However, a filtering mechanism is available for the Knative `net-istio` ingress controller, which enables the controllers to only fetch Knative related secrets.
+By default, the `informers` implementation in the Kubernetes `client-go` library fetches all resources of a given type. When many resources exist, this behavior increases memory usage and can cause the Knative `net-istio` ingress controller to fail on large clusters due to memory leaks. The Knative `net-istio` ingress controller provides a filtering mechanism that lets controllers fetch only Knative-related secrets.
 
 The secret filtering is enabled by default on the {ServerlessOperatorName} side. An environment variable, `ENABLE_SECRET_INFORMER_FILTERING_BY_CERT_UID=true`, is added by default to the `net-istio` controller pods.
 
@@ -19,15 +19,17 @@ If you enable secret filtering, you must label all of your secrets with  `networ
 .Prerequisites
 
 * You have cluster administrator permissions on {ocp-product-title}, or you have cluster or dedicated administrator permissions on {rosa-product-title} or {dedicated-product-title}.
-
 * You have created a project or have access to a project with the appropriate roles and permissions to create applications and other workloads.
 * Install {SMProductName}. {ServerlessProductName} with {SMProductShortName} only is supported for use with {SMProductName} version 2.0.5 or later.
 * Install the {ServerlessOperatorName} and Knative Serving.
 * Install the OpenShift CLI (`oc`).
 
-You can disable the secret filtering by setting the `ENABLE_SECRET_INFORMER_FILTERING_BY_CERT_UID` variable to `false` by using the  `workloads` field in the `KnativeServing` custom resource (CR).
+.Procedure
 
-.Example KnativeServing CR
+* Disable the secret filtering by setting the `ENABLE_SECRET_INFORMER_FILTERING_BY_CERT_UID` variable to `false` by using the  `workloads` field in the `KnativeServing` custom resource (CR).
++
+You get an output similar to the following example:
++
 [source,yaml]
 ----
 apiVersion: operator.knative.dev/v1beta1

--- a/modules/serverless-ossm-traffic-isolation-securing-the-service-mesh.adoc
+++ b/modules/serverless-ossm-traffic-isolation-securing-the-service-mesh.adoc
@@ -3,7 +3,7 @@
 = Securing the {SMProductShortName}
 
 [role="_abstract"]
-Authorization policies and mTLS allow you to secure {SMProductShortName}.
+You can use authorization policies and mTLS to secure {SMProductShortName}.
 
 .Prerequisites
 * You have access to an {product-title} account with cluster administrator access.
@@ -224,7 +224,7 @@ These policies restrict the access rules for the network communication between {
 * Allow internal traffic for channel-based brokers in the `knative-eventing` namespace
 
 
-. Apply the authorization policy configuration:
+. Apply the authorization policy configuration by running the following command:
 +
 [source,terminal]
 ----
@@ -239,25 +239,22 @@ $ oc apply -f knative-default-authz-policies.yaml
 +
 Instead of creating these policies manually, install the `helm` utility and create the necessary resources for each tenant:
 +
-.Installing the `helm` utility
 [source,terminal]
 ----
 $ helm repo add openshift-helm-charts https://charts.openshift.io/
 ----
 +
-.Creating example configuration for `team alpha`
 [source,terminal,subs="attributes+"]
 ----
 $ helm template openshift-helm-charts/redhat-knative-istio-authz --version {ServerlessProductVersion} --set "name=team-alpha" --set "namespaces={team-alpha-1,team-alpha-2}" > team-alpha.yaml
 ----
 +
-.Creating example configuration for `team bravo`
 [source,terminal,subs="attributes+"]
 ----
 $ helm template openshift-helm-charts/redhat-knative-istio-authz --version 1.31.0 --set "name=team-bravo" --set "namespaces={team-bravo-1,team-bravo-2}" > team-bravo.yaml
 ----
 
-. Apply the authorization policy configuration:
+. Apply the authorization policy configuration by running the following command:
 +
 [source,terminal]
 ----

--- a/modules/serverless-ossm-traffic-isolation-verifying-the-configuration.adoc
+++ b/modules/serverless-ossm-traffic-isolation-verifying-the-configuration.adoc
@@ -19,7 +19,8 @@ The following examples assume having two tenants, each having one namespace, and
 
 . Deploy Knative Services in the namespaces of both of the tenants:
 +
-.Example command for `team-alpha`
+You get an output similar to the following example command:
++
 [source,terminal]
 ----
 $ kn service create test-webapp -n team-alpha-1 \
@@ -29,7 +30,8 @@ $ kn service create test-webapp -n team-alpha-1 \
     --image docker.io/openshift/hello-openshift
 ----
 +
-.Example command for `team-bravo`
+You get an output similar to the following example command:
++
 [source,terminal]
 ----
 $ kn service create test-webapp -n team-bravo-1 \
@@ -39,7 +41,7 @@ $ kn service create test-webapp -n team-bravo-1 \
     --image docker.io/openshift/hello-openshift
 ----
 +
-Alternatively, use the following YAML configuration:
+You can also use the following YAML configuration:
 +
 [source,yaml]
 ----
@@ -115,17 +117,19 @@ spec:
 EOF
 ----
 
-. Verify the configuration by using the `curl` command.
+. Verify the configuration by using the following `curl` command:
 +
 Test `team-alpha-1 -> team-alpha-1` through cluster local domain, which is allowed:
 +
-.Example command
+You get an output similar to the following example command:
++
 [source,terminal]
 ----
 $ oc exec deployment/curl -n team-alpha-1 -it -- curl -v http://test-webapp.team-alpha-1:80
 ----
 +
-.Example output
+You get an output similar to the following example:
++
 [source,terminal]
 ----
 HTTP/1.1 200 OK
@@ -140,14 +144,16 @@ Hello Serverless!
 +
 Test the `team-alpha-1` to `team-alpha-1` connection through an external domain, which is allowed:
 +
-.Example command
+You get an output similar to the following example command:
++
 [source,terminal]
 ----
 $ EXTERNAL_URL=$(oc get ksvc -n team-alpha-1 test-webapp -o custom-columns=:.status.url --no-headers) && \
 oc exec deployment/curl -n team-alpha-1 -it -- curl -ik $EXTERNAL_URL
 ----
 +
-.Example output
+You get an output similar to the following example:
++
 [source,terminal]
 ----
 HTTP/2 200
@@ -162,13 +168,15 @@ Hello Serverless!
 +
 Test the `team-alpha-1` to `team-bravo-1` connection through the cluster's local domain, which is not allowed:
 +
-.Example command
+You get an output similar to the following example command:
++
 [source,terminal]
 ----
 $ oc exec deployment/curl -n team-alpha-1 -it -- curl -v http://test-webapp.team-bravo-1:80
 ----
 +
-.Example output
+You get an output similar to the following example:
++
 [source,terminal]
 ----
 * processing: http://test-webapp.team-bravo-1:80
@@ -192,14 +200,16 @@ RBAC: access denied
 +
 Test the `team-alpha-1` to `team-bravo-1` connection through an external domain, which is allowed:
 +
-.Example command
+You get an output similar to the following example command:
++
 [source,terminal]
 ----
 $ EXTERNAL_URL=$(oc get ksvc -n team-bravo-1 test-webapp -o custom-columns=:.status.url --no-headers) && \
 oc exec deployment/curl -n team-alpha-1 -it -- curl -ik $EXTERNAL_URL
 ----
 +
-.Example output
+You get an output similar to the following example:
++
 [source,terminal]
 ----
 HTTP/2 200

--- a/modules/serverless-ossm-verifying-installation-prerequisites.adoc
+++ b/modules/serverless-ossm-verifying-installation-prerequisites.adoc
@@ -3,19 +3,19 @@
 = Verifying installation prerequisites
 
 [role="_abstract"]
-Before installing and configuring the {SMProductShortName} integration with {ServerlessProductShortName}, verify that the prerequisites have been met.
+Before you install and configure the {SMProductShortName} integration with {ServerlessProductShortName}, ensure that you meet all prerequisites.
 
 .Procedure
 
-. Check for conflicting gateways:
+* Check for conflicting gateways by running the following command:
 +
-.Example command
 [source,terminal]
 ----
 $ oc get gateway -A -o jsonpath='{range .items[*]}{@.metadata.namespace}{"/"}{@.metadata.name}{" "}{@.spec.servers}{"\n"}{end}' | column -t
 ----
 +
-.Example output
+You get an output similar to the following example:
++
 [source,terminal]
 ----
 knative-serving/knative-ingress-gateway  [{"hosts":["*"],"port":{"name":"https","number":443,"protocol":"HTTPS"},"tls":{"credentialName":"wildcard-certs","mode":"SIMPLE"}}]

--- a/modules/serverless-ossm-verifying-the-integration.adoc
+++ b/modules/serverless-ossm-verifying-the-integration.adoc
@@ -9,36 +9,38 @@ After installing {SMProductShortName} and {ServerlessProductShortName} with Isti
 
 . Create a Knative Service that has sidecar injection enabled and uses a pass-through route:
 +
-.Example `knative-service.yaml` configuration file
+You get an output similar to the following example:
++
 [source,yaml]
 ----
 apiVersion: serving.knative.dev/v1
 kind: Service
 metadata:
   name: <service_name>
-  namespace: <namespace> <1>
+  namespace: <namespace>
   annotations:
-    serving.knative.openshift.io/enablePassthrough: "true" <2>
+    serving.knative.openshift.io/enablePassthrough: "true"
 spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/inject: "true" <3>
+        sidecar.istio.io/inject: "true"
         sidecar.istio.io/rewriteAppHTTPProbers: "true"
     spec:
       containers:
       - image: <image_url>
 ----
-<1> A namespace that is part of the service mesh member roll.
-<2> Instruct Knative Serving to generate a pass-through enabled route, so that the certificates you have generated are served through the ingress gateway directly.
-<3> Inject {SMProductShortName} sidecars into the Knative service pods.
+
+`metadat.namespace`:: A namespace that is part of the service mesh member roll.
+`serving.knative.openshift.io/enablePassthrough: "true"`:: Instruct Knative Serving to generate a pass-through enabled route, so that the certificates you have generated are served through the ingress gateway directly.
+`sidecar.istio.io/inject: "true"`:: Inject {SMProductShortName} sidecars into the Knative service pods.
 +
 [IMPORTANT]
 ====
 Always add the annotation from this example to all of your Knative Service to make them work with {SMProductShortName}.
 ====
 
-. Apply the `Service` resource:
+. Apply the `Service` resource by running the following command:
 +
 [source,terminal]
 ----
@@ -52,15 +54,15 @@ $ oc apply -f knative-service.yaml
 $ curl --cacert root.crt <service_url>
 ----
 +
-For example, run:
+You get an output similar to the following example command:
 +
-.Example command
 [source,terminal]
 ----
 $ curl --cacert root.crt https://hello-default.apps.openshift.example.com
 ----
 +
-.Example output
+You get an output similar to the following example:
++
 [source,terminal]
 ----
 Hello Openshift!

--- a/modules/serverless-ossm-verifying-the-ossm-3-x-integration.adoc
+++ b/modules/serverless-ossm-verifying-the-ossm-3-x-integration.adoc
@@ -5,37 +5,37 @@
 [role="_abstract"]
 After installing and configuring {SMProductShortName} 3.x with {ServerlessProductShortName}, you can verify that the integration is working correctly. This verification ensures that the Service Mesh components, gateways, and Knative Serving configuration are properly set up and that serverless workloads can communicate securely within the mesh.
 
-The folloiwng test deploys a simple Knative service and verifies sidecar injection, mutual Transport Layer Security (mTLS) compatibility, and passthrough via the ingress gateway.
+The folloiwng test deploys a simple Knative service and verifies sidecar injection, mutual Transport Layer Security (mTLS) compatibility, and passthrough by the ingress gateway.
 
 .Procedure
 
-. Verify that the Istio component is running by entering the following command:
+. Verify that the Istio component is running by running the following command:
 +
 [source,terminal]
 ----
 $ oc get pods -n istio-system
 ----
-. Verify that the Istio CNI component is running by entering the following command:
+. Verify that the Istio Container Network Interface (CNI) component is running by running the following command:
 +
 [source,terminal]
 ----
 $ oc get pods -n istio-cni
 ----
-. Verify that the Knative component is running by entering the following command:
+. Verify that the Knative component is running by running the following command:
 +
 [source,terminal]
 ----
 $ oc get pods -n knative-serving
 ----
 
-. Verify gateway services exist by entering the following command:
+. Verify gateway services exist by running the following command:
 +
 [source,terminal]
 ----
 $ oc get svc -n knative-serving-ingress
 ----
 
-. Create a test namespace by entering the following command:
+. Create a test namespace by running the following command:
 +
 [source,terminal]
 ----
@@ -69,14 +69,14 @@ spec:
 * `sidecar.istio.io/inject: "true"` ensures the Istio proxy is injected.
 * `sidecar.istio.io/rewriteAppHTTPProbers: "true"` makes Knative health probes work with mTLS.
 
-. Apply the Knative service by entering the following command:
+. Apply the Knative service by running the following command:
 +
 [source,terminal]
 ----
 $ oc apply -f hello-service.yaml
 ----
 
-. Confirm sidecar injection and pod readiness by entering the following commands:
+. Confirm sidecar injection and pod readiness by running the following commands:
 +
 [source,terminal]
 ----
@@ -88,7 +88,7 @@ $ oc get pods -n demo
 $ oc get pod -n demo -l serving.knative.dev/service=hello-service -o jsonpath='{.items[0].spec.containers[*].name}{"\n"}'
 ----
 
-. Retrieve the service URL by entering the following command:
+. Retrieve the service URL by running the following command:
 +
 [source,terminal]
 ----


### PR DESCRIPTION
**You can cherry-pick for the following branches:** 
- `serverless-docs-1.37`
- `serverless-docs-1.38`

**Note for the peer & merge reviewer:** 
- This PR updates the only "Integration" section to prepare it for Phase 0 DITA migration.
- No other CQA changes, error types, or content refinements are included. 

**Changes:** 
This PR prepares the "Integration" section for Phase 0 DITA migration by applying Vale (AsciiDoc DITA) rules and cleaning up the existing content.

Doc preview: https://109169--ocpdocs-pr.netlify.app/openshift-serverless/latest/integrations/serverless-integrating-service-mesh/serverless-ossm-setup

**Tracking JIRA:** https://redhat.atlassian.net/browse/SRVCOM-4313

**Reviews:**
- [x] Peer has approved this change