### PR TITLE
PR for SRVCOM-4364: CQA + DITA readiness for assemblies and modules under the "Functions" section.

### DIFF
--- a/functions/configuring/serverless-functions-accessing-secrets-configmaps-using-cli.adoc
+++ b/functions/configuring/serverless-functions-accessing-secrets-configmaps-using-cli.adoc
@@ -7,14 +7,8 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 [role="_abstract"]
-After your functions have been deployed to the cluster, they can access data stored in secrets and config maps. This data can be mounted as volumes, or assigned to environment variables. You can configure this access interactively by using the Knative CLI, or by manually by editing the function configuration YAML file.
-
-[IMPORTANT]
-====
-To access secrets and config maps, the function must be deployed on the cluster. This functionality is not available to a function running locally.
-
-If a secret or config map value cannot be accessed, the deployment fails with an error message specifying the inaccessible values.
-====
+After you deploy functions to the cluster, they can access data in secrets and config maps. Mount this data as volumes or assign it to environment variables. Configure this access by using the Knative CLI or by editing the function configuration YAML file.
 
 include::modules/serverless-functions-secrets-configmaps-interactively.adoc[leveloffset=+1]
+
 include::modules/serverless-functions-secrets-configmaps-interactively-specialized.adoc[leveloffset=+1]

--- a/functions/configuring/serverless-functions-secrets-configmaps-manually.adoc
+++ b/functions/configuring/serverless-functions-secrets-configmaps-manually.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="serverless-functions-secrets-configmaps-manually"]
-== Adding function access to secrets and config maps manually
+= Adding function access to secrets and config maps manually
 include::_attributes/common-attributes.adoc[]
 :context: serverless-functions-yaml
 
@@ -9,9 +9,14 @@ toc::[]
 [role="_abstract"]
 You can manually add configuration for accessing secrets and config maps to your function. This might be preferable to using the `kn func config` interactive utility and commands, for example when you have an existing configuration snippet.
 
-include::modules/serverless-functions-mounting-secret-as-volume.adoc[leveloffset=+2]
-include::modules/serverless-functions-mounting-configmap-as-volume.adoc[leveloffset=+2]
-include::modules/serverless-functions-key-value-in-secret-to-env-variable.adoc[leveloffset=+2]
-include::modules/serverless-functions-key-value-in-configmap-to-env-variable.adoc[leveloffset=+2]
-include::modules/serverless-functions-all-values-in-secret-to-env-variables.adoc[leveloffset=+2]
-include::modules/serverless-functions-all-values-in-configmap-to-env-variables.adoc[leveloffset=+2]
+include::modules/serverless-functions-mounting-secret-as-volume.adoc[leveloffset=+1]
+
+include::modules/serverless-functions-mounting-configmap-as-volume.adoc[leveloffset=+1]
+
+include::modules/serverless-functions-key-value-in-secret-to-env-variable.adoc[leveloffset=+1]
+
+include::modules/serverless-functions-key-value-in-configmap-to-env-variable.adoc[leveloffset=+1]
+
+include::modules/serverless-functions-all-values-in-secret-to-env-variables.adoc[leveloffset=+1]
+
+include::modules/serverless-functions-all-values-in-configmap-to-env-variables.adoc[leveloffset=+1]

--- a/functions/configuring/serverless-functions-yaml.adoc
+++ b/functions/configuring/serverless-functions-yaml.adoc
@@ -7,27 +7,21 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 [role="_abstract"]
-The `func.yaml` file contains the configuration for your function project. Values specified in `func.yaml` are used when you execute a `kn func` command. For example, when you run the `kn func build` command, the value in the `build` field is used. In some cases, you can override these values with command line flags or environment variables.
+The `func.yaml` file has the configuration for your function project. The `kn func` command uses the values in `func.yaml`. For example, when you run kn `func build`, the command uses the value in the build field. You can override these values with command-line flags or environment variables.
 
 include::modules/serverless-functions-func-yaml-environment-variables.adoc[leveloffset=+1]
 
-[id="serverless-functions-annotations"]
-== Adding annotations to functions
-
-You can add Kubernetes annotations to a deployed Serverless function. Annotations enable you to attach arbitrary metadata to a function, for example, a note about the function's purpose. Annotations are added to the `annotations` section of the `func.yaml` configuration file.
-
-There are two limitations of the function annotation feature:
-
-* After a function annotation propagates to the corresponding Knative service on the cluster, it cannot be removed from the service by deleting it from the `func.yaml` file. You must remove the annotation from the Knative service by modifying the YAML file of the service directly, or by using the {ocp-product-title} web console.
-
-* You cannot set annotations that are set by Knative, for example, the `autoscaling` annotations.
+include::modules/serverless-adding-annotations-to-functions.adoc[leveloffset=+1]
 
 include::modules/serverless-functions-adding-annotations.adoc[leveloffset=+1]
 
-[id="additional-resources_serverless-functions-project-configuration"]
 [role="_additional-resources"]
 == Additional resources
+
 * xref:../serverless-functions-getting-started.adoc#serverless-functions-getting-started[Getting started with functions]
+
 * link:https://knative.dev/docs/serving/autoscaling/[Knative documentation on Autoscaling]
+
 * link:https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/[Kubernetes documentation on managing resources for containers]
+
 * link:https://knative.dev/docs/serving/autoscaling/concurrency/[Knative documentation on configuring concurrency]

--- a/functions/reference/serverless-developing-go-functions.adoc
+++ b/functions/reference/serverless-developing-go-functions.adoc
@@ -1,36 +1,42 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="serverless-developing-go-functions"]
 = Developing Go functions
-:context: serverless-developing-go-functions
 include::_attributes/common-attributes.adoc[]
+:context: serverless-developing-go-functions
 
 toc::[]
 
 [role="_abstract"]
+After you have created a Go function project, you can change the template files provided to add business logic to your function. This includes configuring function invocation and the returned headers and status codes.
+
 :FeatureName: {FunctionsProductName} with Go
 include::snippets/technology-preview.adoc[leveloffset=+2]
 
-After you have xref:../../functions/serverless-functions-creating.adoc#serverless-create-func-kn_serverless-functions-creating[created a Go function project], you can modify the template files provided to add business logic to your function. This includes configuring function invocation and the returned headers and status codes.
-
-[id="prerequisites_serverless-developing-go-functions"]
-== Prerequisites
-
-* Before you can develop functions, you must complete the steps in xref:../../install/configuring-serverless-functions.adoc#configuring-serverless-functions[Configuring {FunctionsProductName}].
-
 include::modules/serverless-go-template.adoc[leveloffset=+1]
 
-[id="serverless-developing-go-functions-about-invoking"]
-== About invoking Go functions
-
-When using the Knative (`kn`) CLI to create a function project, you can generate a project that responds to CloudEvents, or one that responds to simple HTTP requests. Go functions are invoked by using different methods, depending on whether they are triggered by an HTTP request or a CloudEvent.
+include::modules/serverless-about-invoking-go-functions.adoc[leveloffset=+1]
 
 include::modules/serverless-invoking-go-functions-http.adoc[leveloffset=+2]
+
 include::modules/serverless-invoking-go-functions-cloudevent.adoc[leveloffset=+2]
 
 include::modules/serverless-go-function-return-values.adoc[leveloffset=+1]
+
 include::modules/serverless-testing-go-functions.adoc[leveloffset=+1]
 
-[id="next-steps_serverless-developing-go-functions"]
-== Next steps
+[role="_additional-resources"]
+== Additional resources
 
-* xref:../../functions/serverless-functions-building.adoc#serverless-build-func-kn_serverless-functions-building[Build] and xref:../../functions/serverless-functions-deploying.adoc#serverless-deploy-func-kn_serverless-functions-deploying[deploy] a function.
+* link:https://golang.org/pkg/context/[Go Context]
+
+* link:https://golang.org/pkg/net/http/#ResponseWriter[`http.ResponseWriter` parameter]
+
+* link:https://golang.org/pkg/net/http/#Request[`http.Request` parameter]
+
+* link:https://cloudevents.github.io/sdk-go/[CloudEvents Go SDK]
+
+* xref:../../install/configuring-serverless-functions.adoc#configuring-serverless-functions[Configuring {FunctionsProductName}]
+
+* xref:../../functions/serverless-functions-building.adoc#serverless-build-func-kn_serverless-functions-building[Build a function]
+
+* xref:../../functions/serverless-functions-deploying.adoc#serverless-deploy-func-kn_serverless-functions-deploying[deploy a function]

--- a/functions/reference/serverless-developing-nodejs-functions.adoc
+++ b/functions/reference/serverless-developing-nodejs-functions.adoc
@@ -7,29 +7,29 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 [role="_abstract"]
-After you have xref:../../functions/serverless-functions-creating.adoc#serverless-create-func-kn_serverless-functions-creating[created a Node.js function project], you can modify the template files provided to add business logic to your function. This includes configuring function invocation and the returned headers and status codes.
-
-[id="prerequisites_serverless-developing-nodejs-functions"]
-== Prerequisites
-
-* Before you can develop functions, you must complete the steps in xref:../../install/configuring-serverless-functions.adoc#configuring-serverless-functions[Configuring {FunctionsProductName}].
+After you have created a Node.js function project, you can change the template files provided to add business logic to your function. This includes configuring function invocation and the returned headers and status codes.
 
 include::modules/serverless-nodejs-template.adoc[leveloffset=+1]
 
-[id="serverless-developing-nodejs-functions-about-invoking"]
-== About invoking Node.js functions
-
-When using the Knative (`kn`) CLI to create a function project, you can generate a project that responds to CloudEvents, or one that responds to simple HTTP requests. CloudEvents in Knative are transported over HTTP as a POST request, so both function types listen for and respond to incoming HTTP events.
-
-Node.js functions can be invoked with a simple HTTP request. When an incoming request is received, functions are invoked with a `context` object as the first parameter.
+include::modules/serverless-about-invoking-nodejs-functions.adoc[leveloffset=+1]
 
 include::modules/serverless-nodejs-functions-context-objects.adoc[leveloffset=+2]
+
 include::modules/serverless-nodejs-function-return-values.adoc[leveloffset=+1]
+
 include::modules/serverless-testing-nodejs-functions.adoc[leveloffset=+1]
-include::modules/serverless-nodejs-functions-overriding-liveness-readiness.adoc[leveloffset=+1]
+
+include::modules/serverless-overriding-liveness-readiness-nodejs-functions.adoc[leveloffset=+1]
+
 include::modules/serverless-nodejs-context-object-reference.adoc[leveloffset=+1]
 
-[id="next-steps_serverless-developing-nodejs-functions"]
-== Next steps
+[role="_additional-resources"]
+== Additional resources
 
-* xref:../../functions/serverless-functions-building.adoc#serverless-build-func-kn_serverless-functions-building[Build] and xref:../../functions/serverless-functions-deploying.adoc#serverless-deploy-func-kn_serverless-functions-deploying[deploy] a function.
+* xref:../../functions/serverless-functions-creating.adoc#serverless-create-func-kn_serverless-functions-creating[created a Node.js function project]
+
+* xref:../../functions/serverless-functions-building.adoc#serverless-build-func-kn_serverless-functions-building[Build a function]
+
+* xref:../../functions/serverless-functions-deploying.adoc#serverless-deploy-func-kn_serverless-functions-deploying[deploy a function]
+
+* link:https://getpino.io/#/docs/api[Pino logging API]

--- a/functions/reference/serverless-developing-python-functions.adoc
+++ b/functions/reference/serverless-developing-python-functions.adoc
@@ -1,29 +1,31 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="serverless-developing-python-functions"]
 = Developing Python functions
-:context: serverless-developing-python-functions
 include::_attributes/common-attributes.adoc[]
+:context: serverless-developing-python-functions
 
 toc::[]
 
 [role="_abstract"]
-After you have xref:../../functions/serverless-functions-creating.adoc#serverless-create-func-kn_serverless-functions-creating[created a Python function project], you can modify the template files provided to add business logic to your function. This includes configuring function invocation and the returned headers and status codes.
+After you have created a Python function project, you can change the template files provided to add business logic to your function. This includes configuring function invocation and the returned headers and status codes.
 
-[id="prerequisites_serverless-developing-python-functions"]
-== Prerequisites
-
-* Before you can develop functions, you must complete the steps in xref:../../install/configuring-serverless-functions.adoc#configuring-serverless-functions[Configuring {FunctionsProductName}].
-
-//Python function template structure
 include::modules/serverless-python-template.adoc[leveloffset=+1]
-//About invoking Python functions
+
 include::modules/serverless-invoking-python-functions.adoc[leveloffset=+1]
-//Python function return values
+
 include::modules/serverless-python-function-return-values.adoc[leveloffset=+1]
-//Testing Python functions
+
 include::modules/serverless-testing-python-functions.adoc[leveloffset=+1]
 
-[id="next-steps_serverless-developing-python-functions"]
-== Next steps
+[role="_additional-resources"]
+== Additional resources
 
-* xref:../../functions/serverless-functions-building.adoc#serverless-build-func-kn_serverless-functions-building[Build] and xref:../../functions/serverless-functions-deploying.adoc#serverless-deploy-func-kn_serverless-functions-deploying[deploy] a function.
+* xref:../../functions/serverless-functions-creating.adoc#serverless-create-func-kn_serverless-functions-creating[created a Python function project]
+
+* xref:../../functions/serverless-functions-building.adoc#serverless-build-func-kn_serverless-functions-building[Build a function]
+
+* xref:../../functions/serverless-functions-deploying.adoc#serverless-deploy-func-kn_serverless-functions-deploying[deploy a function]
+
+* link:https://flask.palletsprojects.com/en/1.1.x/quickstart/#about-responses[Flask]
+
+* link:https://github.com/cloudevents/spec/blob/v1.0.1/spec.md#event-data[`CloudEvent` `data` property]

--- a/functions/reference/serverless-developing-quarkus-functions.adoc
+++ b/functions/reference/serverless-developing-quarkus-functions.adoc
@@ -7,25 +7,29 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 [role="_abstract"]
-After you have xref:../../functions/serverless-functions-creating.adoc#serverless-create-func-kn_serverless-functions-creating[created a Quarkus function project], you can modify the template files provided to add business logic to your function. This includes configuring function invocation and the returned headers and status codes.
+After you have created a Quarkus function project, you can change the template files provided to add business logic to your function. This includes configuring function invocation and the returned headers and status codes.
 
-[id="prerequisites_serverless-developing-quarkus-functions"]
-== Prerequisites
-
-* Before you can develop functions, you must complete the setup steps in xref:../../install/configuring-serverless-functions.adoc#configuring-serverless-functions[Configuring {FunctionsProductName}].
-
-// templates, invoking
 include::modules/serverless-quarkus-template.adoc[leveloffset=+1]
+
 include::modules/serverless-invoking-quarkus-functions.adoc[leveloffset=+1]
+
 include::modules/serverless-quarkus-cloudevent-attributes.adoc[leveloffset=+1]
-// return values
+
 include::modules/serverless-quarkus-function-return-values.adoc[leveloffset=+1]
+
 include::modules/serverless-functions-quarkus-return-value-types.adoc[leveloffset=+2]
-// testing
+
 include::modules/serverless-testing-quarkus-functions.adoc[leveloffset=+1]
+
 include::modules/serverless-quarkus-functions-overriding-liveness-readiness.adoc[leveloffset=+1]
 
-[id="next-steps_serverless-developing-quarkus-functions"]
-== Next steps
+[role="_additional-resources"]
+== Additional resources
 
-* xref:../../functions/serverless-functions-building.adoc#serverless-build-func-kn_serverless-functions-building[Build] and xref:../../functions/serverless-functions-deploying.adoc#serverless-deploy-func-kn_serverless-functions-deploying[deploy] a function.
+* xref:../../functions/serverless-functions-creating.adoc#serverless-create-func-kn_serverless-functions-creating[created a Python function project]
+
+* xref:../../functions/serverless-functions-building.adoc#serverless-build-func-kn_serverless-functions-building[Build a function]
+
+* xref:../../functions/serverless-functions-deploying.adoc#serverless-deploy-func-kn_serverless-functions-deploying[deploy a function]
+
+* xref:../../install/configuring-serverless-functions.adoc#configuring-serverless-functions[Configuring {FunctionsProductName}].

--- a/functions/reference/serverless-developing-typescript-functions.adoc
+++ b/functions/reference/serverless-developing-typescript-functions.adoc
@@ -7,30 +7,29 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 [role="_abstract"]
-After you have xref:../../functions/serverless-functions-creating.adoc#serverless-create-func-kn_serverless-functions-creating[created a TypeScript function project], you can modify the template files provided to add business logic to your function. This includes configuring function invocation and the returned headers and status codes.
-
-[id="prerequisites_serverless-developing-typescript-functions"]
-== Prerequisites
-
-* Before you can develop functions, you must complete the steps in xref:../../install/configuring-serverless-functions.adoc#configuring-serverless-functions[Configuring {FunctionsProductName}].
+After you have created a TypeScript function project, you can change the template files provided to add business logic to your function. This includes configuring function invocation and the returned headers and status codes.
 
 include::modules/serverless-typescript-template.adoc[leveloffset=+1]
 
-[id="serverless-developing-typescript-functions-about-invoking"]
-== About invoking TypeScript functions
-
-When using the Knative (`kn`) CLI to create a function project, you can generate a project that responds to CloudEvents or one that responds to simple HTTP requests. CloudEvents in Knative are transported over HTTP as a POST request, so both function types listen for and respond to incoming HTTP events.
-
-TypeScript functions can be invoked with a simple HTTP request. When an incoming request is received, functions are invoked with a `context` object as the first parameter.
+include::modules/serverless-about-invoking-typescript-functions.adoc[leveloffset=+1]
 
 include::modules/serverless-typescript-functions-context-objects.adoc[leveloffset=+2]
+
 include::modules/serverless-typescript-function-return-values.adoc[leveloffset=+1]
+
 include::modules/serverless-testing-typescript-functions.adoc[leveloffset=+1]
-include::modules/serverless-typescript-functions-overriding-liveness-readiness.adoc[leveloffset=+1]
+
+include::modules/serverless-overriding-liveness-readiness-typescript-functions.adoc[leveloffset=+1]
+
 include::modules/serverless-typescript-context-object-reference.adoc[leveloffset=+1]
 
-[id="next-steps_serverless-developing-typescript-functions"]
-== Next steps
+[role="_additional-resources"]
+== Additional resources
 
-* xref:../../functions/serverless-functions-building.adoc#serverless-build-func-kn_serverless-functions-building[Build] and xref:../../functions/serverless-functions-deploying.adoc#serverless-deploy-func-kn_serverless-functions-deploying[deploy] a function.
-* See link:https://getpino.io/#/docs/api[the Pino API documentation] for more information about logging with functions.
+* xref:../../functions/serverless-functions-building.adoc#serverless-build-func-kn_serverless-functions-building[Build a function]
+
+* xref:../../functions/serverless-functions-deploying.adoc#serverless-deploy-func-kn_serverless-functions-deploying[deploy a function]
+
+* xref:../../install/configuring-serverless-functions.adoc#configuring-serverless-functions[Configuring {FunctionsProductName}]
+
+link:https://getpino.io/#/docs/api[the Pino API documentation]

--- a/functions/serverless-functions-building.adoc
+++ b/functions/serverless-functions-building.adoc
@@ -1,8 +1,8 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="serverless-functions-building"]
 = Building functions
-:context: serverless-functions-building
 include::_attributes/common-attributes.adoc[]
+:context: serverless-functions-building
 
 toc::[]
 

--- a/functions/serverless-functions-creating.adoc
+++ b/functions/serverless-functions-creating.adoc
@@ -1,13 +1,14 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="serverless-functions-creating"]
 = Creating functions
-:context: serverless-functions-creating
 include::_attributes/common-attributes.adoc[]
+:context: serverless-functions-creating
 
 toc::[]
 
 [role="_abstract"]
-Before you can build and deploy a function, you must create it. You can create functions using the Knative (`kn`) CLI.
+Before you can build and deploy a function, you must create it. You can create functions by using the Knative (`kn`) CLI.
 
 include::modules/serverless-create-func-kn.adoc[leveloffset=+1]
+
 include::modules/odc-creating-functions.adoc[leveloffset=+1]

--- a/functions/serverless-functions-deleting.adoc
+++ b/functions/serverless-functions-deleting.adoc
@@ -1,8 +1,8 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="serverless-functions-deleting"]
 = Deleting functions
-:context: serverless-functions-deleting
 include::_attributes/common-attributes.adoc[]
+:context: serverless-functions-deleting
 
 toc::[]
 

--- a/functions/serverless-functions-deploying.adoc
+++ b/functions/serverless-functions-deploying.adoc
@@ -1,8 +1,8 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="serverless-functions-deploying"]
 = Deploying functions
-:context: serverless-functions-deploying
 include::_attributes/common-attributes.adoc[]
+:context: serverless-functions-deploying
 
 toc::[]
 

--- a/functions/serverless-functions-eventing.adoc
+++ b/functions/serverless-functions-eventing.adoc
@@ -7,6 +7,6 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 [role="_abstract"]
-Functions are deployed as Knative services on an {ocp-product-title} cluster. You can connect functions to Knative Eventing components so that they can receive incoming events.
+When you deploy functions, the platform creates Knative services on an {ocp-product-title} cluster. You can connect these functions to Knative Eventing components to receive incoming events.
 
 include::modules/serverless-connect-func-source-odc.adoc[leveloffset=+1]

--- a/functions/serverless-functions-getting-started.adoc
+++ b/functions/serverless-functions-getting-started.adoc
@@ -7,45 +7,31 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 [role="_abstract"]
-Function lifecycle management includes creating and deploying a function, after which it can be invoked. You can do all of these operations on {ServerlessProductName} using the `kn func` tool.
+Function lifecycle management includes creating and deploying a function, after that you can call it. Use the `kn func` tool to perform these operations on {ServerlessProductName}.
 
-[id="prerequisites_serverless-functions-getting-started"]
-== Prerequisites
-
-To enable the use of {FunctionsProductName} on your cluster, you must complete the following steps:
-
-* The {ServerlessOperatorName} and Knative Serving are installed on your cluster.
-+
-[NOTE]
-====
-Functions are deployed as a Knative service. If you want to use event-driven architecture with your functions, you must also install Knative Eventing.
-====
-
-* You have the link:https://docs.openshift.com/container-platform/latest/cli_reference/openshift_cli/getting-started-cli.html#cli-getting-started[`oc` CLI] installed.
-
-* You have the xref:../install/installing-kn.adoc#installing-kn[Knative (`kn`) CLI] installed. Installing the Knative CLI enables the use of `kn func` commands which you can use to create and manage functions.
-
-* You have installed Docker Container Engine or Podman version 3.4.7 or higher.
-
-* You have access to an available image registry, such as the OpenShift Container Registry.
-
-* If you are using link:https://quay.io/[Quay.io] as the image registry, you must ensure that either the repository is not private, or that you have followed the {ocp-product-title} documentation on link:https://docs.openshift.com/container-platform/latest/openshift_images/managing_images/using-image-pull-secrets.html#images-allow-pods-to-reference-images-from-secure-registries_using-image-pull-secrets[Allowing pods to reference images from other secured registries].
-
-* If you are using the OpenShift Container Registry, a cluster administrator must link:https://docs.openshift.com/container-platform/latest/registry/securing-exposing-registry.html#securing-exposing-registry[expose the registry].
+include::modules/serverless-functions-getting-started-prereuisites.adoc[leveloffset=+1]
 
 include::modules/serverless-functions-creating-deploying-invoking.adoc[leveloffset=+1]
 
-[id="additional-resources_serverless-functions-getting-started"]
 [role="_additional-resources"]
-== Additional resources for {ocp-product-title}
+== Additional resources
+
+* link:https://docs.openshift.com/container-platform/latest/registry/securing-exposing-registry.html#securing-exposing-registry[Expose the registry]
+
+* link:https://docs.openshift.com/container-platform/latest/cli_reference/openshift_cli/getting-started-cli.html#cli-getting-started[`oc` CLI]
+
+* xref:../install/installing-kn.adoc#installing-kn[Knative (`kn`) CLI]
+
+* link:https://quay.io/[Quay.io]
+
+* link:https://docs.openshift.com/container-platform/latest/openshift_images/managing_images/using-image-pull-secrets.html#images-allow-pods-to-reference-images-from-secure-registries_using-image-pull-secrets[Allowing pods to reference images from other secured registries]
+
 * link:https://docs.openshift.com/container-platform/latest/registry/securing-exposing-registry.html#securing-exposing-registry[Exposing a default registry manually]
+
 * link:https://plugins.jetbrains.com/plugin/16476-knative\--serverless-functions-by-red-hat[Marketplace page for the Intellij Knative plugin]
+
 * link:https://marketplace.visualstudio.com/items?itemName=redhat.vscode-knative&utm_source=VSCode.pro&utm_campaign=AhmadAwais[Marketplace page for the Visual Studio Code Knative plugin]
+
 * link:https://docs.openshift.com/container-platform/latest/applications/creating_applications/odc-creating-applications-using-developer-perspective.html#odc-creating-applications-using-the-developer-perspective[Creating applications]
-// This Additional resource applies only to OCP, but not to OSD nor ROSA.
 
-
-[id="next-steps_serverless-functions-getting-started"]
-== Next steps
-
-* See xref:../functions/serverless-functions-eventing.adoc#serverless-functions-eventing[Connecting an event source to a function]
+* xref:../functions/serverless-functions-eventing.adoc#serverless-functions-eventing[Connecting an event source to a function] 

--- a/functions/serverless-functions-invoking.adoc
+++ b/functions/serverless-functions-invoking.adoc
@@ -1,8 +1,8 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="serverless-functions-invoking"]
 = Invoking functions
-:context: serverless-functions-invoking
 include::_attributes/common-attributes.adoc[]
+:context: serverless-functions-invoking
 
 toc::[]
 

--- a/functions/serverless-functions-listing.adoc
+++ b/functions/serverless-functions-listing.adoc
@@ -1,8 +1,8 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="serverless-functions-listing"]
 = Listing existing functions
-:context: serverless-functions-listing
 include::_attributes/common-attributes.adoc[]
+:context: serverless-functions-listing
 
 toc::[]
 

--- a/functions/serverless-functions-on-cluster-builds.adoc
+++ b/functions/serverless-functions-on-cluster-builds.adoc
@@ -1,15 +1,18 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="serverless-functions-on-cluster-builds"]
 = Building and deploying functions on the cluster
-:context: serverless-functions-on-cluster-builds
 include::_attributes/common-attributes.adoc[]
+:context: serverless-functions-on-cluster-builds
 
 toc::[]
 
 [role="_abstract"]
-Instead of building a function locally, you can build a function directly on the cluster. When using this workflow on a local development machine, you only need to work with the function source code. This is useful, for example, when you cannot install on-cluster function building tools, such as docker or podman.
+Instead of building a function locally, you can build a function directly on the cluster. When using this workflow on a local development machine, you only need to work with the function source code. This is useful, for example, when you cannot install on-cluster function building tools, such as docker or Podman.
 
 include::modules/serverless-functions-creating-on-cluster-builds.adoc[leveloffset=+1]
+
 include::modules/serverless-functions-specifying-function-revision.adoc[leveloffset=+1]
+
 include::modules/serverless-functions-setting-custom-volume-size.adoc[leveloffset=+1]
+
 include::modules/odc-invoke-serverless-function.adoc[leveloffset=+1]

--- a/functions/serverless-functions-reference-guide.adoc
+++ b/functions/serverless-functions-reference-guide.adoc
@@ -7,13 +7,14 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 [role="_abstract"]
-{FunctionsProductName} provides templates that can be used to create basic functions. A template initiates the function project boilerplate and prepares it for use with the `kn func` tool. Each function template is tailored for a specific runtime and follows its conventions. With a template, you can initiate your function project automatically.
+{FunctionsProductName} provides templates to create basic functions. A template starts the function project boilerplate and prepares it for use with the `kn func` tool. Each function template targets a specific runtime and follows its conventions. With a template, you can start your function project automatically.
 
-Templates for the following runtimes are available:
+[role="_additional-resources"]
+== Additional resources
 
-// add xref links to docs once added
 * xref:../functions/serverless-developing-nodejs-functions.adoc#serverless-developing-nodejs-functions[Node.js]
+
 * xref:../functions/serverless-developing-quarkus-functions.adoc#serverless-developing-quarkus-functions[Quarkus]
+
 * xref:../functions/serverless-developing-typescript-functions.adoc#serverless-developing-typescript-functions[TypeScript]
-//* SpringBoot - TBC
 

--- a/functions/serverless-functions-running-locally.adoc
+++ b/functions/serverless-functions-running-locally.adoc
@@ -1,8 +1,8 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="serverless-functions-running-locally"]
 = Running functions locally
-:context: serverless-functions-running-locally
 include::_attributes/common-attributes.adoc[]
+:context: serverless-functions-running-locally
 
 toc::[]
 

--- a/modules/odc-creating-functions.adoc
+++ b/modules/odc-creating-functions.adoc
@@ -16,13 +16,11 @@ You can create a function from a Git repository by using the {ocp-product-title}
 ** Install the {pipelines-shortname} Operator on the cluster.
 ** Create the following pipeline tasks so that they are available for all namespaces on the cluster:
 +
-.func-s2i and func-deploy tasks
 [source,terminal]
 ----
 $ kn func tkn-tasks | oc apply -f -
 ----
 +
-.Node.js function
 [source,terminal]
 ----
 $ oc apply -f https://raw.githubusercontent.com/openshift-knative/kn-plugin-func/serverless-1.34/pkg/pipelines/resources/tekton/pipeline/dev-console/0.1/nodejs-pipeline.yaml

--- a/modules/odc-invoke-serverless-function.adoc
+++ b/modules/odc-invoke-serverless-function.adoc
@@ -24,10 +24,15 @@ You can test a deployed serverless function by invoking it in the {ocp-product-t
 . In the *Test Serverless Function* dialog box, change the settings for your test as required:
 
 .. Choose the *Format* for your test. This can be either *CloudEvent* or *HTTP*.
+
 .. The *Content-Type* defaults to the `Content-Type` HTTP header value.
+
 .. You can use the *Advanced Settings* to change the *Type* or *Source* for `CloudEvent` tests, or to add optional headers.
+
 .. You can change the input data for the test.
 
 . Click *Test* to run your test.
+
 . After the test is complete, the *Test Serverless Function* dialog box displays a status code and a message that informs you whether your test was succesful.
+
 . Click *Back* to perform another test, or *Close* to close the testing dialog box.

--- a/modules/serverless-about-invoking-go-functions.adoc
+++ b/modules/serverless-about-invoking-go-functions.adoc
@@ -1,0 +1,10 @@
+// Module included in the following assemblies
+//
+// * serverless/functions/serverless-developing-go-functions.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="serverless-about-invoking-go-functions_{context}"]
+= About invoking Go functions
+
+[role="_abstract"]
+When you use the Knative (`kn`) CLI to create a function project, you can generate a project that responds to `CloudEvents` or simple HTTP requests. Different methods call Go functions, depending on whether an HTTP request or a `CloudEvent` triggers them.

--- a/modules/serverless-about-invoking-nodejs-functions.adoc
+++ b/modules/serverless-about-invoking-nodejs-functions.adoc
@@ -1,0 +1,12 @@
+// Module included in the following assemblies
+//
+// * serverless/functions/serverless-developing-nodejs-functions.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="serverless-about-invoking-nodejs-functions_{context}"]
+= About invoking Node.js functions
+
+[role="_abstract"]
+When using the Knative (`kn`) CLI to create a function project, you can generate a project that responds to `CloudEvents`, or one that responds to simple HTTP requests. `CloudEvents` in Knative are transported over HTTP as a POST request, so both function types listen for and respond to incoming HTTP events.
+
+Node.js functions can be invoked with a simple HTTP request. When an incoming request is received, functions are invoked with a `context` object as the first parameter.

--- a/modules/serverless-about-invoking-typescript-functions.adoc
+++ b/modules/serverless-about-invoking-typescript-functions.adoc
@@ -1,0 +1,12 @@
+// Module included in the following assemblies
+//
+// * serverless/functions/serverless-developing-nodejs-functions.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="serverless-about-invoking-typescript-functions_{context}"]
+= About invoking TypeScript functions
+
+[role="_abstract"]
+When you use the Knative (`kn`) CLI to create a function project, you can generate a project that responds to `CloudEvents` or simple HTTP requests. Knative sends `CloudEvents` over HTTP as POST requests, so both function types listen for and respond to incoming HTTP events.
+
+You can call TypeScript functions with a simple HTTP request. When a function receives a request, the runtime calls it with a `context` object as the first parameter.

--- a/modules/serverless-adding-annotations-to-functions.adoc
+++ b/modules/serverless-adding-annotations-to-functions.adoc
@@ -1,0 +1,16 @@
+// Module included in the following assemblies:
+//
+// * serverless/functions/serverless-functions-yaml.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="serverless-adding-annotations-to-functions_{context}"]
+= Adding annotations to functions
+
+[role="_abstract"]
+You can add Kubernetes annotations to a deployed Serverless function. Use annotations to attach arbitrary metadata to a function, for example, a note about the function's purpose. Add annotations to the annotations section of the func.yaml configuration file.
+
+The function annotation feature has the following limitations:
+
+* After an annotation propagates to the corresponding Knative service on the cluster, you cannot remove it from the service by deleting it from the `func.yaml` file. Remove the annotation by modifying the Knative service YAML directly or by using the {ocp-product-title} web console.
+
+* You cannot set annotations that `Knative` sets, for example, the autoscaling annotations.

--- a/modules/serverless-deploy-func-kn.adoc
+++ b/modules/serverless-deploy-func-kn.adoc
@@ -18,7 +18,7 @@ You can deploy a function to your cluster as a Knative service by using the kn f
 
 .Procedure
 
-* Deploy a function:
+* Deploy a function by running the following command:
 +
 [source,terminal]
 ----

--- a/modules/serverless-functions-all-values-in-configmap-to-env-variables.adoc
+++ b/modules/serverless-functions-all-values-in-configmap-to-env-variables.adoc
@@ -11,7 +11,7 @@ You can set an environment variable from all values defined in a config map. Val
 
 .Prerequisites
 
-* The {ServerlessOperatorName} and Knative Serving are installed on the cluster.
+* You have installed the {ServerlessOperatorName} and Knative Serving on the cluster.
 * You have installed the Knative (`kn`) CLI.
 * You have created a function.
 
@@ -28,9 +28,10 @@ namespace: ""
 runtime: go
 ...
 envs:
-- value: '{{ configMap:myconfigmap }}' <1>
+- value: '{{ configMap:myconfigmap }}'
 ----
-<1> Substitute `myconfigmap` with the name of the target config map.
++
+Substitute `myconfigmap` with the name of the target config map.
 +
 For example, to access all user data that is stored in `userdetailsmap`, use the following YAML:
 +

--- a/modules/serverless-functions-all-values-in-secret-to-env-variables.adoc
+++ b/modules/serverless-functions-all-values-in-secret-to-env-variables.adoc
@@ -11,7 +11,7 @@ You can set an environment variable from all values defined in a secret. Values 
 
 .Prerequisites
 
-* The {ServerlessOperatorName} and Knative Serving are installed on the cluster.
+* You have installed the {ServerlessOperatorName} and Knative Serving on the cluster.
 * You have installed the Knative (`kn`) CLI.
 * You have created a function.
 

--- a/modules/serverless-functions-creating-deploying-invoking.adoc
+++ b/modules/serverless-functions-creating-deploying-invoking.adoc
@@ -7,59 +7,64 @@
 = Creating, deploying, and invoking a function
 
 [role="_abstract"]
-On {ServerlessProductName}, you can use the `kn func` to create, deploy, and invoke a function.
+On {ServerlessProductName}, you can use the `kn func` to create, deploy, and call a function.
 
 .Procedure
 
-. Create a function project:
+. Create a function project by running the following command:
 +
 [source,terminal]
 ----
 $ kn func create -l <runtime> -t <template> <path>
 ----
 +
-.Example command
+You get an output similar to the following example command:
++
 [source,terminal]
 ----
 $ kn func create -l typescript -t cloudevents examplefunc
 ----
 +
-.Example output
+You get an output similar to the following example:
++
 [source,terminal]
 ----
 Created typescript function in /home/user/demo/examplefunc
 ----
 
-. Navigate to the function project directory:
+. Navigate to the function project directory by running the following command:
 +
-.Example command
+You get an output similar to the following example command:
++
 [source,terminal]
 ----
 $ cd examplefunc
 ----
 
-. Build and run the function locally:
+. Build and run the function locally by running the following command:
 +
-.Example command
+You get an output similar to the following example command:
++
 [source,terminal]
 ----
 $ kn func run
 ----
 
-. Deploy the function to your cluster:
+. Deploy the function to your cluster by running the following command:
 +
 [source,terminal]
 ----
 $ kn func deploy
 ----
 +
-.Example output
+You get an output similar to the following example:
++
 [source,terminal]
 ----
 Function deployed at: http://func.example.com
 ----
 
-. Invoke the function:
+. Call the function by running the following command:
 +
 [source,terminal]
 ----

--- a/modules/serverless-functions-creating-on-cluster-builds.adoc
+++ b/modules/serverless-functions-creating-on-cluster-builds.adoc
@@ -7,11 +7,11 @@
 = Building and deploying a function on the cluster
 
 [role="_abstract"]
-You can use the Knative (`kn`) CLI to initiate a function project build and then deploy the function directly on the cluster. To build a function project in this way, the source code for your function project must exist in a Git repository branch that is accessible to your cluster.
+You can use the Knative (`kn`) CLI to start a function project build and then deploy the function directly on the cluster. To build a function project in this way, the source code for your function project must exist in a Git repository branch that is accessible to your cluster.
 
 .Prerequisites
 
-* {pipelines-title} must be installed on your cluster.
+* You have installed the {pipelines-title} on your cluster.
 
 * You have installed the OpenShift CLI (`oc`).
 
@@ -19,7 +19,7 @@ You can use the Knative (`kn`) CLI to initiate a function project build and then
 
 .Procedure
 
-. Create a function:
+. Create a function by running the following command:
 +
 [source,terminal]
 ----
@@ -28,16 +28,17 @@ $ kn func create <function_name> -l <runtime>
 
 . Implement the business logic of your function. Then, use Git to commit and push the changes.
 
-. Deploy your function:
+. Deploy your function by running the following command:
 +
 [source,terminal]
 ----
 $ kn func deploy --remote
 ----
 +
-If you are not logged into the container registry referenced in your function configuration, you are prompted to provide credentials for the remote container registry that hosts the function image:
+If you are not logged into the container registry referenced in your function configuration, you are prompted to give credentials for the remote container registry that hosts the function image:
 +
-.Example output and prompts
+You get an output similar to the following example:
++
 [source,terminal]
 ----
 🕕 Creating Pipeline resources
@@ -52,18 +53,18 @@ Please provide credentials for image registry used by Pipeline.
 
 . Optional. You can configure your function to be built on the cluster after every Git push by using pipelines-as-code:
 
-.. Generate the Tekton `Pipelines` and `PipelineRuns` configuration for your function:
+.. Generate the Tekton `Pipelines` and `PipelineRuns` configuration for your function by running the following command:
 +
 [source,terminal]
 ----
 $ kn func config git set
 ----
 +
-Apart from generating configuration files, this command connects to the cluster and validates that the pipeline is installed. By using the token, it also creates, on behalf of the user, a webhook on the function repository. That webhook triggers the pipeline on the cluster every time changes are pushed to the repository.
+Apart from generating configuration files, this command connects to the cluster and verifies the pipeline installation. By using the token, it also creates a webhook on the function repository on behalf of the user. That webhook triggers the pipeline on the cluster every time you push changes to the repository.
 +
 You need to have a valid GitHub personal access token with the repository access to use this command.
 
-.. Commit and push the generated `.tekton/pipeline.yaml` and `.tekton/pipeline-run.yaml` files:
+.. Commit and push the generated `.tekton/pipeline.yaml` and `.tekton/pipeline-run.yaml` files by running the following commands:
 +
 [source,terminal]
 ----

--- a/modules/serverless-functions-func-yaml-environment-variables.adoc
+++ b/modules/serverless-functions-func-yaml-environment-variables.adoc
@@ -18,7 +18,7 @@ If you want to avoid storing sensitive information such as an API key in the fun
 
 * To refer to a local environment variable, use the following syntax:
 +
-[source]
+[source,terminal]
 ----
 {{ env:ENV_VAR }}
 ----
@@ -27,7 +27,8 @@ Substitute `ENV_VAR` with the name of the variable in the local environment that
 +
 For example, you might have the `API_KEY` variable available in the local environment. You can assign its value to the `MY_API_KEY` variable, which you can then directly use within your function:
 +
-.Example function
+You get an output similar to the following example:
++
 [source,yaml]
 ----
 name: test

--- a/modules/serverless-functions-func-yaml-fields.adoc
+++ b/modules/serverless-functions-func-yaml-fields.adoc
@@ -7,12 +7,12 @@
 = Configurable fields in func.yaml
 
 [role="_abstract"]
-Many of the fields in `func.yaml` are generated automatically when you create, build, and deploy your function. However, there are also fields that you modify manually to change things, such as the function name or the image name.
+Many of the fields in `func.yaml` are generated automatically when you create, build, and deploy your function. However, there are also fields that you change manually to change things, such as the function name or the image name.
 
 [id="serverless-functions-func-yaml-buildenvs_{context}"]
-== buildEnvs
+== `buildEnvs`
 
-The `buildEnvs` field enables you to set environment variables to be available to the environment that builds your function. Unlike variables set using `envs`, a variable set using `buildEnv` is not available during function runtime.
+You can use the `buildEnvs` field to set environment variables for the build environment. Variables that you set by using `buildEnvs` are not available during function runtime, unlike variables set by using `envs`.
 
 You can set a `buildEnv` variable directly from a value. In the following example, the `buildEnv` variable named `EXAMPLE1` is directly assigned the `one` value:
 
@@ -33,7 +33,7 @@ buildEnvs:
 ----
 
 [id="serverless-functions-func-yaml-envs_{context}"]
-== envs
+== `envs`
 
 The `envs` field enables you to set environment variables to be available to your function at runtime. You can set an environment variable in several different ways:
 
@@ -42,7 +42,7 @@ The `envs` field enables you to set environment variables to be available to you
 . From a key-value pair stored in a secret or config map.
 . You can also import all key-value pairs stored in a secret or config map, with keys used as names of the created environment variables.
 
-This examples demonstrates the different ways to set an environment variable:
+The following examples demonstrates the different ways to set an environment variable:
 
 [source,yaml]
 ----
@@ -51,38 +51,41 @@ namespace: ""
 runtime: go
 ...
 envs:
-- name: EXAMPLE1 <1>
+- name: EXAMPLE1
   value: value
-- name: EXAMPLE2 <2>
+- name: EXAMPLE2
   value: '{{ env:LOCAL_ENV_VALUE }}'
-- name: EXAMPLE3 <3>
+- name: EXAMPLE3
   value: '{{ secret:mysecret:key }}'
-- name: EXAMPLE4 <4>
+- name: EXAMPLE4
   value: '{{ configMap:myconfigmap:key }}'
-- value: '{{ secret:mysecret2 }}' <5>
-- value: '{{ configMap:myconfigmap2 }}' <6>
+- value: '{{ secret:mysecret2 }}'
+- value: '{{ configMap:myconfigmap2 }}'
 ----
-<1> An environment variable set directly from a value.
-<2> An environment variable set from a value assigned to a local environment variable.
-<3> An environment variable assigned from a key-value pair stored in a secret.
-<4> An environment variable assigned from a key-value pair stored in a config map.
-<5> A set of environment variables imported from key-value pairs of a secret.
-<6> A set of environment variables imported from key-value pairs of a config map.
+
+--
+* `name: EXAMPLE1`: An environment variable set directly from a value.
+* `name: EXAMPLE2`: An environment variable set from a value assigned to a local environment variable.
+* `name: EXAMPLE3`: An environment variable assigned from a key-value pair stored in a secret.
+* `name: EXAMPLE4`: An environment variable assigned from a key-value pair stored in a config map.
+* `secret:mysecret2`: A set of environment variables imported from key-value pairs of a secret.
+* `configMap:myconfigmap2`: A set of environment variables imported from key-value pairs of a config map.
+--
 
 [id="serverless-functions-func-yaml-builder_{context}"]
-== builder
+== `builder`
 
 The `builder` field specifies the strategy used by the function to build the image. It accepts values of `pack` or `s2i`.
 
 [id="serverless-functions-func-yaml-build_{context}"]
-== build
+== `build`
 
 The `build` field indicates how the function should be built. The value `local` indicates that the function is built locally on your machine. The value `git` indicates that the function is built on a cluster by using the values specified in the `git` field.
 
 [id="serverless-functions-func-yaml-volumes_{context}"]
-== volumes
+== `volumes`
 
-The `volumes` field enables you to mount secrets and config maps as a volume accessible to the function at the specified path, as shown in the following example:
+You can use the `volumes` field to mount secrets and config maps as `volumes` that the function can access at the specified path, as shown in the following example:
 
 [source,yaml]
 ----
@@ -91,18 +94,21 @@ namespace: ""
 runtime: go
 ...
 volumes:
-- secret: mysecret <1>
+- secret: mysecret
   path: /workspace/secret
-- configMap: myconfigmap <2>
+- configMap: myconfigmap
   path: /workspace/configmap
 ----
-<1> The `mysecret` secret is mounted as a volume residing at `/workspace/secret`.
-<2> The `myconfigmap` config map is mounted as a volume residing at `/workspace/configmap`.
+
+--
+* `secret: mysecret`: The system mounts the `mysecret` secret as a volume at `/workspace/secret`.
+* `configMap: myconfigmap`: The system mounts the `myconfigmap` config map as a volume at `/workspace/configmap`.
+--
 
 [id="serverless-functions-func-yaml-options_{context}"]
-== options
+== `options`
 
-The `options` field enables you to modify Knative Service properties for the deployed function, such as autoscaling. If these options are not set, the default ones are used.
+You can use the options field to change Knative Service properties for the deployed function, such as autoscaling. If you do not set these options, the system uses default values.
 
 These options are available:
 
@@ -111,7 +117,7 @@ These options are available:
 ** `max`: The maximum number of replicas. Must be a non-negative integer. The default is 0, which means no limit.
 ** `metric`: Defines which metric type is watched by the Autoscaler. It can be set to `concurrency`, which is the default, or `rps`.
 ** `target`: Recommendation for when to scale up based on the number of concurrently incoming requests. The `target` option can be a float value greater than 0.01. The default is 100, unless the `options.resources.limits.concurrency` is set, in which case `target` defaults to its value.
-** `utilization`: Percentage of concurrent requests utilization allowed before scaling up. It can be a float value between 1 and 100. The default is 70.
+** `utilization`: Percentage of concurrent requests usage allowed before scaling up. It can be a float value between 1 and 100. The default is 70.
 * `resources`
 ** `requests`
 *** `cpu`: A CPU resource request for the container with deployed function.
@@ -147,17 +153,17 @@ options:
 ----
 
 [id="serverless-functions-func-yaml-image_{context}"]
-== image
+== `image`
 
-The `image` field sets the image name for your function after it has been built. You can modify this field. If you do, the next time you run `kn func build` or `kn func deploy`, the function image will be created with the new name.
+The `image` field sets the image name for your function after it has been built. You can change this field. If you do, the next time you run `kn func build` or `kn func deploy`, the function image will be created with the new name.
 
 [id="serverless-functions-func-yaml-imagedigest_{context}"]
-== imageDigest
+== `imageDigest`
 
-The `imageDigest` field contains the SHA256 hash of the image manifest when the function is deployed. Do not modify this value.
+The `imageDigest` field contains the SHA256 hash of the image manifest when the function is deployed. Do not change this value.
 
 [id="serverless-functions-func-yaml-labels_{context}"]
-== labels
+== `labels`
 
 The `labels` field enables you to set labels on a deployed function.
 
@@ -180,16 +186,16 @@ labels:
 ----
 
 [id="serverless-functions-func-yaml-name_{context}"]
-== name
+== `name`
 
-The `name` field defines the name of your function. This value is used as the name of your Knative service when it is deployed. You can change this field to rename the function on subsequent deployments.
+The `name` field defines the name of your function. This value is used as the name of your Knative service when it is deployed. You can change this field to rename the function on next deployments.
 
 [id="serverless-functions-func-yaml-namespace_{context}"]
-== namespace
+== `namespace`
 
 The `namespace` field specifies the namespace in which your function is deployed.
 
 [id="serverless-functions-func-yaml-runtime_{context}"]
-== runtime
+== `runtime`
 
 The `runtime` field specifies the language runtime for your function, for example, `python`.

--- a/modules/serverless-functions-getting-started-prereuisites.adoc
+++ b/modules/serverless-functions-getting-started-prereuisites.adoc
@@ -1,0 +1,29 @@
+// Module included in the following assemblies:
+//
+// * serverless/functions/serverless-functions-getting-started.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="serverless-functions-getting-started-prereuisites_{context}"]
+= Prerequisites for {FunctionsProductName}
+
+[role="_abstract"]
+To enable the use of {FunctionsProductName} on your cluster, you must complete the following steps:
+
+* You have installed the {ServerlessOperatorName} and Knative Serving on your cluster.
++
+[NOTE]
+====
+Functions are deployed as a Knative service. If you want to use event-driven architecture with your functions, you must also install Knative Eventing.
+====
+
+* You have installed the `oc` CLI.
+
+* You have the Knative (`kn`) CLI installed. Installing the Knative CLI enables the use of `kn func` commands which you can use to create and manage functions.
+
+* You have installed Docker Container Engine or Podman version 3.4.7 or higher.
+
+* You have access to an available image registry, such as the OpenShift Container Registry.
+
+* If you are using `Quay.io` as the image registry, you must ensure that either the repository is not private, or that you have followed the {ocp-product-title} documentation on Allowing pods to reference images from other secured registries.
+
+* If you are using the OpenShift Container Registry, a cluster administrator must expose the registry.

--- a/modules/serverless-functions-key-value-in-configmap-to-env-variable.adoc
+++ b/modules/serverless-functions-key-value-in-configmap-to-env-variable.adoc
@@ -11,7 +11,7 @@ You can set an environment variable from a key value defined as a config map. A 
 
 .Prerequisites
 
-* The {ServerlessOperatorName} and Knative Serving are installed on the cluster.
+* You have installed the {ServerlessOperatorName} and Knative Serving on the cluster.
 * You have installed the Knative (`kn`) CLI.
 * You have created a function.
 

--- a/modules/serverless-functions-key-value-in-secret-to-env-variable.adoc
+++ b/modules/serverless-functions-key-value-in-secret-to-env-variable.adoc
@@ -11,7 +11,7 @@ You can set an environment variable from a key value defined as a secret. A valu
 
 .Prerequisites
 
-* The {ServerlessOperatorName} and Knative Serving are installed on the cluster.
+* You have installed the {ServerlessOperatorName} and Knative Serving on the cluster.
 * You have installed the Knative (`kn`) CLI.
 * You have created a function.
 

--- a/modules/serverless-functions-mounting-configmap-as-volume.adoc
+++ b/modules/serverless-functions-mounting-configmap-as-volume.adoc
@@ -7,11 +7,11 @@
 = Mounting a config map as a volume
 
 [role="_abstract"]
-You can mount a config map as a volume. Once a config map is mounted, you can access it from the function as a regular file. This enables you to store on the cluster data needed by the function, for example, a list of URIs that need to be accessed by the function.
+You can mount a config map as a volume. After you mount it, access it from the function as a regular file. Store data on the cluster that the function needs, for example, a list of URIs that the function accesses.
 
 .Prerequisites
 
-* The {ServerlessOperatorName} and Knative Serving are installed on the cluster.
+* You have installed the {ServerlessOperatorName} and Knative Serving on the cluster.
 * You have installed the Knative (`kn`) CLI.
 * You have created a function.
 

--- a/modules/serverless-functions-mounting-secret-as-volume.adoc
+++ b/modules/serverless-functions-mounting-secret-as-volume.adoc
@@ -7,11 +7,11 @@
 = Mounting a secret as a volume
 
 [role="_abstract"]
-You can mount a secret as a volume. Once a secret is mounted, you can access it from the function as a regular file. This enables you to store on the cluster data needed by the function, for example, a list of URIs that need to be accessed by the function.
+You can mount a secret as a volume. After you mount it, access it from the function as a regular file. Store data on the cluster that the function needs, for example, a list of URIs that the function accesses.
 
 .Prerequisites
 
-* The {ServerlessOperatorName} and Knative Serving are installed on the cluster.
+* You have installed the {ServerlessOperatorName} and Knative Serving on the cluster.
 * You have installed the Knative (`kn`) CLI.
 * You have created a function.
 

--- a/modules/serverless-functions-quarkus-return-value-types.adoc
+++ b/modules/serverless-functions-quarkus-return-value-types.adoc
@@ -11,7 +11,8 @@ The input and output of a function can be any of the `void`, `String`, or `byte[
 
 Maps, lists, arrays, the `<T>` type parameter of the `CloudEvents<T>` type, and attributes of Javabeans can only be of types listed here.
 
-.Example
+Similar to the following example:
+
 [source,java]
 ----
 public class Functions {

--- a/modules/serverless-functions-secrets-configmaps-interactively-specialized.adoc
+++ b/modules/serverless-functions-secrets-configmaps-interactively-specialized.adoc
@@ -7,46 +7,46 @@
 = Modifying function access to secrets and config maps interactively by using specialized commands
 
 [role="_abstract"]
-Every time you run the `kn func config` utility, you need to navigate the entire dialogue to select the operation you need, as shown in the previous section. To save steps, you can directly execute a specific operation by running a more specific form of the `kn func config` command:
+Every time you run the `kn func config` utility, you need to go to the entire dialogue to select the operation you need, as shown in the earlier section. To save steps, you can directly run a specific operation by running a more specific form of the `kn func config` command:
 
 * To list configured environment variables:
 +
 [source,terminal]
 ----
-$ kn func config envs [-p <function-project-path>]
+$ kn func config envs [-p <function_project_path>]
 ----
 
 * To add environment variables to the function configuration:
 +
 [source,terminal]
 ----
-$ kn func config envs add [-p <function-project-path>]
+$ kn func config envs add [-p <function_project_path>]
 ----
 
 * To remove environment variables from the function configuration:
 +
 [source,terminal]
 ----
-$ kn func config envs remove [-p <function-project-path>]
+$ kn func config envs remove [-p <function_project_path>]
 ----
 
 * To list configured volumes:
 +
 [source,terminal]
 ----
-$ kn func config volumes [-p <function-project-path>]
+$ kn func config volumes [-p <function_project_path>]
 ----
 
 * To add a volume to the function configuration:
 +
 [source,terminal]
 ----
-$ kn func config volumes add [-p <function-project-path>]
+$ kn func config volumes add [-p <function_project_path>]
 ----
 
 * To remove a volume from the function configuration:
 +
 [source,terminal]
 ----
-$ kn func config volumes remove [-p <function-project-path>]
+$ kn func config volumes remove [-p <function_project_path>]
 ----

--- a/modules/serverless-functions-secrets-configmaps-interactively.adoc
+++ b/modules/serverless-functions-secrets-configmaps-interactively.adoc
@@ -7,11 +7,18 @@
 = Modifying function access to secrets and config maps interactively
 
 [role="_abstract"]
-You can manage the secrets and config maps accessed by your function by using the `kn func config` interactive utility. The available operations include listing, adding, and removing values stored in config maps and secrets as environment variables, as well as listing, adding, and removing volumes. This functionality enables you to manage what data stored on the cluster is accessible by your function.
+You can use the `kn func` config interactive utility to manage the secrets and config maps that your function accesses. You can list, add, and remove values stored as environment variables, and list, add, and remove volumes. Control which cluster data your function can access.
+
+[IMPORTANT]
+====
+To access secrets and config maps, deploy the function on the cluster. A function running locally cannot access them.
+
+If the function cannot access a secret or config map value, the deployment fails and reports the inaccessible values.
+====
 
 .Prerequisites
 
-* The {ServerlessOperatorName} and Knative Serving are installed on the cluster.
+* You have installed the {ServerlessOperatorName} and Knative Serving on the cluster.
 * You have installed the Knative (`kn`) CLI.
 * You have created a function.
 
@@ -24,7 +31,7 @@ You can manage the secrets and config maps accessed by your function by using th
 $ kn func config
 ----
 +
-Alternatively, you can specify the function project directory using the `--path` or `-p` option.
+You can also specify the function project directory by using the `--path` or `-p` option.
 
 . Use the interactive interface to perform the necessary operation. For example, using the utility to list configured volumes produces an output similar to this:
 +
@@ -38,7 +45,7 @@ Configured Volumes mounts:
 - Secret "mysecret2" mounted at path: "/workspace/secret2"
 ----
 +
-This scheme shows all operations available in the interactive utility and how to navigate to them:
+This scheme shows all operations available in the interactive utility and how to go to them:
 +
 [source]
 ----
@@ -59,7 +66,7 @@ kn func config
            └─> Remove: Remove a configured volume
 ----
 
-. Optional. Deploy the function to make the changes take effect:
+. Optional: Deploy the function to make the changes take effect:
 +
 [source,terminal]
 ----

--- a/modules/serverless-functions-setting-custom-volume-size.adoc
+++ b/modules/serverless-functions-setting-custom-volume-size.adoc
@@ -11,7 +11,7 @@ For projects that require a volume with a larger size to build, you might need t
 
 .Prerequisites
 
-* {pipelines-title} must be installed on your cluster.
+* You have installed the {pipelines-title} on your cluster.
 
 * You have installed the OpenShift (`oc`) CLI.
 

--- a/modules/serverless-functions-specifying-function-revision.adoc
+++ b/modules/serverless-functions-specifying-function-revision.adoc
@@ -11,7 +11,7 @@ When building and deploying a function on the cluster, you must specify the loca
 
 .Prerequisites
 
-* {pipelines-title} must be installed on your cluster.
+* You have installed the {pipelines-title} on your cluster.
 
 * You have installed the OpenShift (`oc`) CLI.
 
@@ -23,20 +23,20 @@ When building and deploying a function on the cluster, you must specify the loca
 +
 [source,terminal]
 ----
-$ kn func deploy --remote \ <1>
-                 --git-url <repo-url> \ <2>
-                 [--git-branch <branch>] \ <3>
-                 [--git-dir <function-dir>] <4>
+$ kn func deploy --remote \
+                 --git-url <repo_url> \
+                 [--git-branch <branch>] \
+                 [--git-dir <function_dir>]
 ----
 +
 --
-<1> With the `--remote` flag, the build runs remotely.
-<2> Substitute `<repo-url>` with the URL of the Git repository.
-<3> Substitute `<branch>` with the Git branch, tag, or commit. If using the latest commit on the `main` branch, you can skip this flag.
-<4> Substitute `<function-dir>` with the directory containing the function if it is different than the repository root directory.
+`--remote`:: With the `--remote` flag, the build runs remotely.
+`git-url <repo_url>`:: Substitute `<repo_url>` with the URL of the Git repository.
+`--git-branch <branch>`:: Substitute `<branch>` with the Git branch, tag, or commit. If using the latest commit on the `main` branch, you can skip this flag.
+`--git-dir <function_dir>`:: Substitute `<function_dir>` with the directory containing the function if it is different from the repository root directory.
 --
 +
-For example:
+Similar to the following example:
 +
 [source,terminal]
 ----

--- a/modules/serverless-go-function-return-values.adoc
+++ b/modules/serverless-go-function-return-values.adoc
@@ -7,9 +7,9 @@
 = Go function return values
 
 [role="_abstract"]
-Functions triggered by HTTP requests can set the response directly. You can configure the function to do this by using the Go link:https://golang.org/pkg/net/http/#ResponseWriter[http.ResponseWriter].
+Functions triggered by HTTP requests can set the response directly. You can configure the function to do this by using the Go `http.ResponseWriter` parameter.
 
-.Example HTTP response
+The following example displays HTTP response:
 [source,go]
 ----
 func Handle(ctx context.Context, res http.ResponseWriter, req *http.Request) {
@@ -24,9 +24,9 @@ func Handle(ctx context.Context, res http.ResponseWriter, req *http.Request) {
 }
 ----
 
-Functions triggered by a cloud event might return nothing, `error`, or `CloudEvent` in order to push events into the Knative Eventing system. In this case, you must set a unique `ID`, proper `Source`, and a `Type` for the cloud event. The data can be populated from a defined structure, or from a `map`.
+Functions triggered by a cloud event might return nothing, `error`, or `CloudEvent` to push events into the Knative Eventing system. In this case, you must set a unique `ID`, proper `Source`, and a `Type` for the cloud event. The data can be populated from a defined structure, or from a `map`.
 
-.Example CloudEvent response
+The following example displays `CloudEvent` response:
 [source,go]
 ----
 func Handle(ctx context.Context, event cloudevents.Event) (resp *cloudevents.Event, err error) {

--- a/modules/serverless-go-template.adoc
+++ b/modules/serverless-go-template.adoc
@@ -7,27 +7,32 @@
 = Go function template structure
 
 [role="_abstract"]
-When you create a Go function using the Knative (`kn`) CLI, the project directory looks like a typical Go project. The only exception is the additional `func.yaml` configuration file, which is used for specifying the image.
+When you create a Go function by using the Knative (`kn`) CLI, the project directory looks like a typical Go project. The only exception is the additional `func.yaml` configuration file, which is used for specifying the image.
+
+[NOTE]
+====
+Before you can develop functions, you must configure the function.
+====
 
 Go functions have few restrictions. The only requirements are that your project must be defined in a `function` module, and must export the function `Handle()`.
 
 Both `http` and `event` trigger functions have the same template structure:
 
-.Template structure
 [source,terminal]
 ----
 fn
 ├── README.md
-├── func.yaml <1>
-├── go.mod <2>
+├── func.yaml
+├── go.mod
 ├── go.sum
 ├── handle.go
 └── handle_test.go
 ----
-<1> The `func.yaml` configuration file is used to determine the image name and registry.
-<2> You can add any required dependencies to the `go.mod` file, which can include additional local Go files. When the project is built for deployment, these dependencies are included in the resulting runtime container image.
-+
-.Example of adding dependencies
+--
+`func.yaml`:: The `func.yaml` configuration file is used to decide the image name and registry.
+`go.mod`:: You can add any required dependencies to the `go.mod` file, which can include additional local Go files. When the project is built for deployment, these dependencies are included in the resulting runtime container image.
+--
+
 [source,terminal]
 ----
 $ go get gopkg.in/yaml.v2@v2.4.0

--- a/modules/serverless-invoking-go-functions-cloudevent.adoc
+++ b/modules/serverless-invoking-go-functions-cloudevent.adoc
@@ -7,11 +7,11 @@
 = Functions triggered by a cloud event
 
 [role="_abstract"]
-When an incoming cloud event is received, the event is invoked by the link:https://cloudevents.github.io/sdk-go/[CloudEvents Go SDK]. The invocation uses the `Event` type as a parameter.
+When an incoming cloud event is received, the event is invoked by the `CloudEvents` Go SDK. The invocation uses the `Event` type as a parameter.
 
-You can leverage the Go link:https://golang.org/pkg/context/[Context] as an optional parameter in the function contract, as shown in the list of supported function signatures:
+You can use the Go Context as an optional parameter in the function contract, as shown in the list of supported function signatures:
 
-.Supported function signatures
+The following example displays supported function signatures:
 [source,go]
 ----
 Handle()
@@ -28,8 +28,7 @@ Handle(context.Context, cloudevents.Event) *cloudevents.Event
 Handle(context.Context, cloudevents.Event) (*cloudevents.Event, error)
 ----
 
-[id="serverless-invoking-go-functions-cloudevent-example_{context}"]
-== CloudEvent trigger example
+The following example displays `CloudEvent` trigger:
 
 A cloud event is received which contains a JSON string in the data property:
 
@@ -60,7 +59,7 @@ func Handle(ctx context.Context, event cloudevents.Event) (err error) {
 }
 ----
 
-Alternatively, a Go `encoding/json` package could be used to access the cloud event directly as JSON in the form of a bytes array:
+A Go `encoding/json` package could be used to access the cloud event directly as JSON in the form of a bytes array:
 
 [source,go]
 ----

--- a/modules/serverless-invoking-go-functions-http.adoc
+++ b/modules/serverless-invoking-go-functions-http.adoc
@@ -7,9 +7,10 @@
 = Functions triggered by an HTTP request
 
 [role="_abstract"]
-When an incoming HTTP request is received, functions are invoked with a standard Go link:https://golang.org/pkg/context/[Context] as the first parameter, followed by the link:https://golang.org/pkg/net/http/#ResponseWriter[`http.ResponseWriter`] and link:https://golang.org/pkg/net/http/#Request[`http.Request`] parameters. You can use standard Go techniques to access the request, and set a corresponding HTTP response for your function.
+When a function receives an incoming HTTP request, the runtime calls it with a standard Go Context as the first parameter, followed by the `http.ResponseWriter` and `http.Request` parameters. You can use standard Go techniques to access the request and set the HTTP response.
 
-.Example HTTP response
+The following example displays the HTTP response:
+
 [source,go]
 ----
 func Handle(ctx context.Context, res http.ResponseWriter, req *http.Request) {

--- a/modules/serverless-invoking-python-functions.adoc
+++ b/modules/serverless-invoking-python-functions.adoc
@@ -7,16 +7,17 @@
 = About invoking Python functions
 
 [role="_abstract"]
-Python functions can be invoked with a simple HTTP request. When an incoming request is received, functions are invoked with a `context` object as the first parameter.
+You can call Python functions with a simple HTTP request. When a function receives a request, the runtime calls it with a context object as the first parameter.
 
 The `context` object is a Python class with two attributes:
 
-* The `request` attribute is always present, and contains the Flask `request` object.
+* The `request` attribute is always present, and has the Flask `request` object.
 * The second attribute, `cloud_event`, is populated if the incoming request is a `CloudEvent` object.
 
 Developers can access any `CloudEvent` data from the context object.
 
-.Example context object
+You get an output similar to the following example:
+
 [source,python]
 ----
 def main(context: Context):

--- a/modules/serverless-invoking-quarkus-functions.adoc
+++ b/modules/serverless-invoking-quarkus-functions.adoc
@@ -11,7 +11,8 @@ You can create a Quarkus project that responds to cloud events, or one that resp
 
 When an incoming request is received, Quarkus functions are invoked with an instance of a permitted type.
 
-.Function invocation options
+The following table displays function invocation options:
+
 [options="header",cols="d,d,m"]
 |====
 |Invocation method |Data type contained in the instance |Example of data
@@ -20,9 +21,10 @@ When an incoming request is received, Quarkus functions are invoked with an inst
 |`CloudEvent` | JSON object in the `data` property |`{ "customerId": "0123456", "productId": "6543210" }`
 |====
 
-The following example shows a function that receives and processes the `customerId` and `productId` purchase data that is listed in the previous table:
+The following example shows a function that receives and processes the `customerId` and `productId` buy data that is listed in the earlier table:
 
-.Example Quarkus function
+You get an output similar to the following example:
+
 [source,java]
 ----
 public class Functions {
@@ -33,9 +35,10 @@ public class Functions {
 }
 ----
 
-The corresponding `Purchase` JavaBean class that contains the purchase data looks as follows:
+The corresponding `Purchase` `JavaBean` class that has the purchase data looks as follows:
 
-.Example class
+You get an output similar to the following example:
+
 [source,java]
 ----
 public class Purchase {
@@ -50,7 +53,8 @@ public class Purchase {
 
 The following example code defines three functions named `withBeans`, `withCloudEvent`, and `withBinary`;
 
-.Example
+You get an output similar to the following example:
+
 [source,java]
 ----
 import io.quarkus.funqy.Funq;

--- a/modules/serverless-kn-func-delete.adoc
+++ b/modules/serverless-kn-func-delete.adoc
@@ -11,11 +11,11 @@ You can delete a function by using the `kn func delete` command. This is useful 
 
 .Procedure
 
-* Delete a function:
+* Delete a function by running the following command:
 +
 [source,terminal]
 ----
 $ kn func delete [<function_name> -n <namespace> -p <path>]
 ----
-** If the name or path of the function to delete is not specified, the current directory is searched for a `func.yaml` file that is used to determine the function to delete.
+** If you do not specify the name or path of the function to delete, the system searches the current directory for a `func.yaml` file and uses it to decide which function to delete.
 ** If the namespace is not specified, it defaults to the `namespace` value in the `func.yaml` file.

--- a/modules/serverless-kn-func-invoke.adoc
+++ b/modules/serverless-kn-func-invoke.adoc
@@ -19,7 +19,7 @@ You can use the `kn func invoke` CLI command to send a test request to invoke a 
 
 .Procedure
 
-* Start a function:
+* Start a function by running the following command:
 +
 [source,terminal]
 ----

--- a/modules/serverless-kn-func-run.adoc
+++ b/modules/serverless-kn-func-run.adoc
@@ -46,7 +46,6 @@ $ kn func run --build=false
 
 You can use the help command to learn more about `kn func run` command options:
 
-.Build help command
 [source,terminal]
 ----
 $ kn func help run

--- a/modules/serverless-nodejs-context-object-reference.adoc
+++ b/modules/serverless-nodejs-context-object-reference.adoc
@@ -7,14 +7,13 @@
 = Node.js context object reference
 
 [role="_abstract"]
-The `context` object has several properties that can be accessed by the function developer. Accessing these properties can provide information about HTTP requests and write output to the cluster logs.
+The `context` object has several properties that can be accessed by the function developer. Accessing these properties can give information about HTTP requests and write output to the cluster logs.
 
 [id="serverless-nodejs-context-object-reference-log_{context}"]
-== log
+== Log
 
-Provides a logging object that can be used to write output to the cluster logs. The log adheres to the link:https://getpino.io/#/docs/api[Pino logging API].
+Provides a logging object that can be used to write output to the cluster logs. The log adheres to the Pino logging API.
 
-.Example log
 [source,javascript]
 ----
 function handle(context) {
@@ -24,26 +23,25 @@ function handle(context) {
 
 You can access the function by using the `kn func invoke` command:
 
-.Example command
+You get an output similar to the following example command:
 [source,terminal]
 ----
 $ kn func invoke --target 'http://example.function.com'
 ----
 
-.Example output
+You get an output similar to the following example:
 [source,terminal]
 ----
 {"level":30,"time":1604511655265,"pid":3430203,"hostname":"localhost.localdomain","reqId":1,"msg":"Processing customer"}
 ----
 
-You can change the log level to one of `fatal`, `error`, `warn`, `info`, `debug`, `trace`, or `silent`. To do that, change the value of `logLevel` by assigning one of these values to the environment variable `FUNC_LOG_LEVEL` using the `config` command.
+You can change the log level to one of `fatal`, `error`, `warn`, `info`, `debug`, `trace`, or `silent`. To do that, change the value of `logLevel` by using one of these values to the environment variable `FUNC_LOG_LEVEL` by using the `config` command.
 
 [id="serverless-nodejs-context-object-reference-query_{context}"]
 == query
 
 Returns the query string for the request, if any, as key-value pairs. These attributes are also found on the context object itself.
 
-.Example query
 [source,javascript]
 ----
 function handle(context) {
@@ -56,13 +54,13 @@ function handle(context) {
 
 You can access the function by using the `kn func invoke` command:
 
-.Example command
+You get an output similar to the following example command:
 [source,terminal]
 ----
 $ kn func invoke --target 'http://example.com?name=tiger'
 ----
 
-.Example output
+You get an output similar to the following example:
 [source,terminal]
 ----
 {"level":30,"time":1604511655265,"pid":3430203,"hostname":"localhost.localdomain","reqId":1,"msg":"tiger"}
@@ -73,7 +71,6 @@ $ kn func invoke --target 'http://example.com?name=tiger'
 
 Returns the request body if any. If the request body contains JSON code, this will be parsed so that the attributes are directly available.
 
-.Example body
 [source,javascript]
 ----
 function handle(context) {
@@ -84,13 +81,13 @@ function handle(context) {
 
 You can access the function by using the `curl` command to invoke it:
 
-.Example command
+You get an output similar to the following example command:
 [source,terminal]
 ----
 $ kn func invoke -d '{"Hello": "world"}'
 ----
 
-.Example output
+You get an output similar to the following example:
 [source,terminal]
 ----
 {"level":30,"time":1604511655265,"pid":3430203,"hostname":"localhost.localdomain","reqId":1,"msg":"world"}
@@ -101,7 +98,6 @@ $ kn func invoke -d '{"Hello": "world"}'
 
 Returns the HTTP request headers as an object.
 
-.Example header
 [source,javascript]
 ----
 function handle(context) {
@@ -111,13 +107,13 @@ function handle(context) {
 
 You can access the function by using the `kn func invoke` command:
 
-.Example command
+You get an output similar to the following example command:
 [source,terminal]
 ----
 $ kn func invoke --target 'http://example.function.com'
 ----
 
-.Example output
+You get an output similar to the following example:
 [source,terminal]
 ----
 {"level":30,"time":1604511655265,"pid":3430203,"hostname":"localhost.localdomain","reqId":1,"msg":"some-value"}

--- a/modules/serverless-nodejs-function-return-values.adoc
+++ b/modules/serverless-nodejs-function-return-values.adoc
@@ -9,9 +9,9 @@
 [role="_abstract"]
 Functions can return any valid JavaScript type or can have no return value. When a function has no return value specified, and no failure is indicated, the caller receives a `204 No Content` response.
 
-Functions can also return a CloudEvent or a `Message` object in order to push events into the Knative Eventing system. In this case, the developer is not required to understand or implement the CloudEvent messaging specification. Headers and other relevant information from the returned values are extracted and sent with the response.
+Functions can also return a `CloudEvent` or a `Message` object to push events into the Knative Eventing system. In this case, the developer is not required to understand or implement the `CloudEvent` messaging specification. Headers and other relevant information from the returned values are extracted and sent with the response.
 
-.Example
+You get an output similar to the following example:
 [source,javascript]
 ----
 function handle(context, customer) {
@@ -28,7 +28,7 @@ function handle(context, customer) {
 
 Functions can return any valid JavaScript type, including primitives such as strings, numbers, and booleans:
 
-.Example function returning a string
+You get an output similar to the following example:
 [source,javascript]
 ----
 function handle(context) {
@@ -48,7 +48,7 @@ $ curl https://myfunction.example.com
 This function Works!
 ----
 
-.Example function returning a number
+You get an output similar to the following example:
 [source,javascript]
 ----
 function handle(context) {
@@ -69,7 +69,7 @@ $ curl https://myfunction.example.com
 100
 ----
 
-.Example function returning a boolean
+You get an output similar to the following example:
 [source,javascript]
 ----
 function handle(context) {
@@ -92,7 +92,7 @@ false
 
 Returning primitives directly without wrapping them in an object results in a `204 No Content` status code with an empty body:
 
-.Example function returning a primitive directly
+You get an output similar to the following example:
 [source,javascript]
 ----
 function handle(context) {
@@ -120,7 +120,7 @@ Connection: keep-alive
 
 You can set a response header by adding a `headers` property to the `return` object. These headers are extracted and sent with the response to the caller.
 
-.Example response header
+You get an output similar to the following example:
 [source,javascript]
 ----
 function handle(context, customer) {
@@ -135,7 +135,7 @@ function handle(context, customer) {
 
 You can set a status code that is returned to the caller by adding a `statusCode` property to the `return` object:
 
-.Example status code
+You get an output similar to the following example:
 [source,javascript]
 ----
 function handle(context, customer) {
@@ -148,7 +148,7 @@ function handle(context, customer) {
 
 Status codes can also be set for errors that are created and thrown by the function:
 
-.Example error status code
+You get an output similar to the following example:
 [source,javascript]
 ----
 function handle(context, customer) {

--- a/modules/serverless-nodejs-functions-context-objects.adoc
+++ b/modules/serverless-nodejs-functions-context-objects.adoc
@@ -9,16 +9,16 @@
 [role="_abstract"]
 Functions are invoked by providing a `context` object as the first parameter. This object provides access to the incoming HTTP request information.
 
-This information includes the HTTP request method, any query strings or headers sent with the request, the HTTP version, and the request body. Incoming requests that contain a `CloudEvent` attach the incoming instance of the CloudEvent to the context object so that it can be accessed by using `context.cloudevent`.
+This information includes the HTTP request method, any query strings or headers sent with the request, the HTTP version, and the request body. Incoming requests that contain a `CloudEvent` attach the incoming instance of the `CloudEvent` to the context object so that it can be accessed by using `context.cloudevent`.
 
 [id="serverless-nodejs-functions-context-objects-methods_{context}"]
 == Context object methods
 
-The `context` object has a single method, `cloudEventResponse()`, that accepts a data value and returns a CloudEvent.
+The `context` object has a single method, `cloudEventResponse()`, that accepts a data value and returns a `CloudEvent`.
 
-In a Knative system, if a function deployed as a service is invoked by an event broker sending a CloudEvent, the broker examines the response. If the response is a CloudEvent, this event is handled by the broker.
+In a Knative system, if a function deployed as a service is invoked by an event broker sending a `CloudEvent`, the broker examines the response. If the response is a `CloudEvent`, this event is handled by the broker.
 
-.Example context object method
+The following example displays the context object method:
 [source,javascript]
 ----
 // Expects to receive a CloudEvent with customer data
@@ -33,9 +33,9 @@ function handle(context, customer) {
 ----
 
 [id="serverless-nodejs-functions-context-objects-cloudevent-data_{context}"]
-== CloudEvent data
+== `CloudEvent` data
 
-If the incoming request is a CloudEvent, any data associated with the CloudEvent is extracted from the event and provided as a second parameter. For example, if a CloudEvent is received that contains a JSON string in its data property that is similar to the following:
+If the incoming request is a `CloudEvent`, any data associated with the `CloudEvent` is extracted from the event and provided as a second parameter. For example, if a `CloudEvent` is received that has a JSON string in its data property that is similar to the following:
 
 [source,json]
 ----
@@ -47,13 +47,13 @@ If the incoming request is a CloudEvent, any data associated with the CloudEvent
 
 When invoked, the second parameter to the function, after the `context` object, will be a JavaScript object that has `customerId` and `productId` properties.
 
-.Example signature
+You get an output similar to the following example:
 [source,javascript]
 ----
 function handle(context, data)
 ----
 
-The `data` parameter in this example is a JavaScript object that contains the `customerId` and `productId` properties.
+The `data` parameter in this example is a JavaScript object that has the `customerId` and `productId` properties.
 
 [id="serverless-nodejs-functions-context-objects-arbitrary-data_{context}"]
 == Arbitrary data
@@ -91,7 +91,7 @@ Hello Mr. Smith
 [id="serverless-nodejs-functions-context-objects-supported-data-types_{context}"]
 == Supported data types
 
-CloudEvents can contain various data types, including JSON, XML, plain text, and binary data. These data types are provided to the function in their respective formats:
+CloudEvents can contain various data types, including JSON, XML, plain text, and binary data. These data types are provided to the function in their dedicated formats:
 
 * *JSON Data*: Provided as a JavaScript object.
 * *XML Data*: Provided as an XML document.
@@ -101,7 +101,7 @@ CloudEvents can contain various data types, including JSON, XML, plain text, and
 [id="serverless-nodejs-functions-context-objects-multiple-data-types-in-a-function_{context}"]
 == Multiple data types in a function
 
-Ensure your function can handle different data types by checking the Content-Type header and parsing the data accordingly. For example:
+Ensure your function can handle different data types by checking the Content-Type header and parsing the data. For example:
 
 [source,javascript]
 ----

--- a/modules/serverless-nodejs-template.adoc
+++ b/modules/serverless-nodejs-template.adoc
@@ -7,11 +7,15 @@
 = Node.js function template structure
 
 [role="_abstract"]
-When you create a Node.js function using the Knative (`kn`) CLI, the project directory looks like a typical Node.js project. The only exception is the additional `func.yaml` file, which is used to configure the function.
+When you create a Node.js function by using the Knative (`kn`) CLI, the project directory looks like a typical Node.js project. The only exception is the additional `func.yaml` file, which is used to configure the function.
+
+[NOTE]
+====
+Before you can develop functions, you must configure the function.
+====
 
 Both `http` and `event` trigger functions have the same template structure:
 
-.Template structure
 [source,terminal]
 ----
 .
@@ -23,15 +27,18 @@ Both `http` and `event` trigger functions have the same template structure:
     ├── integration.js
     └── unit.js
 ----
-<1> The `func.yaml` configuration file is used to determine the image name and registry.
-<2> Your project must contain an `index.js` file which exports a single function.
-<3> You are not restricted to the dependencies provided in the template `package.json` file. You can add additional dependencies as you would in any other Node.js project.
-+
-.Example of adding npm dependencies
+--
+`func.yaml`:: The `func.yaml` configuration file is used to determine the image name and registry.
+`index.js`:: Your project must contain an `index.js` file which exports a single function.
+`package.json`:: You are not restricted to the dependencies provided in the template `package.json` file. You can add additional dependencies as you would in any other Node.js project.
+`test`:: Integration and unit test scripts are provided as part of the function template.
+--
+
+You get an output similar to the following example:
+
 [source,terminal]
 ----
 npm install --save opossum
 ----
-+
+
 When the project is built for deployment, these dependencies are included in the created runtime container image.
-<4> Integration and unit test scripts are provided as part of the function template.

--- a/modules/serverless-overriding-liveness-readiness-nodejs-functions.adoc
+++ b/modules/serverless-overriding-liveness-readiness-nodejs-functions.adoc
@@ -1,0 +1,106 @@
+// Module included in the following assemblies
+//
+// * /serverless/functions/serverless-developing-nodejs-functions.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="serverless-overriding-liveness-readiness-nodejs-functions_{context}"]
+= Overriding liveness and readiness probe values for Node.js functions
+
+[role="_abstract"]
+You can override `liveness` and `readiness` probe values for your Node.js functions. You can configure health checks performed on the function.
+
+.Prerequisites
+
+* You have installed the {ServerlessOperatorName} and Knative Serving on the cluster.
+* You have installed the Knative (`kn`) CLI.
+* You have created a function by using `kn func create`.
+
+.Procedure
+
+* In your function code, create the `Function` object, which implements the following interface:
+
+[source,javascript]
+----
+export interface Function {
+  init?: () => any;
+
+  shutdown?: () => any;
+
+  liveness?: HealthCheck;
+
+  readiness?: HealthCheck;
+
+  logLevel?: LogLevel;
+
+  handle: CloudEventFunction | HTTPFunction;
+}
+----
+
+--
+`init?: () => any`:: The initialization function, called before the server is started. This function is optional and should be synchronous.
+`shutdown?: () => any;`:: The shutdown function, called after the server is stopped. This function is optional and should be synchronous.
+`liveness?: HealthCheck;`:: The liveness function, called to check if the server is alive. This function is optional and should return 200/OK if the server is alive.
+`readiness?: HealthCheck;`:: The readiness function, called to check if the server is ready to accept requests. This function is optional and should return `200/OK` if the server is ready.
+`handle: CloudEventFunction | HTTPFunction;`:: The function to handle HTTP requests.
+--
+
+For example, add the following code to the `index.js` file:
+
+[source,javascript]
+----
+const Function = {
+
+  handle: (context, body) => {
+    // The function logic goes here
+    return 'function called'
+  },
+
+  liveness: () => {
+    process.stdout.write('In liveness\n');
+    return 'ok, alive';
+  },
+
+  readiness: () => {
+    process.stdout.write('In readiness\n');
+    return 'ok, ready';
+  }
+};
+
+Function.liveness.path = '/alive';
+Function.readiness.path = '/ready';
+
+module.exports = Function;
+----
+
+--
+`Function.liveness.path = '/alive';`:: Custom `liveness` endpoint.
+`Function.readiness.path = '/ready';`:: Custom `readiness` endpoint.
+--
+
+As an alternative to `Function.liveness.path` and `Function.readiness.path`, you can specify custom endpoints by using the `LIVENESS_URL` and `READINESS_URL` environment variables:
+
+[source,yaml]
+----
+run:
+  envs:
+  - name: LIVENESS_URL
+    value: /alive
+  - name: READINESS_URL
+    value: /ready
+----
+
+--
+`value: /alive`:: The liveness path, set to `/alive` here.
+`value: /ready`:: The readiness path, set to `/ready` here.
+--
+
+* Add the new endpoints to the `func.yaml` file, so that they are properly bound to the container for the Knative service:
+
+[source,yaml]
+----
+deploy:
+  healthEndpoints:
+    liveness: /alive
+    readiness: /ready
+----
+

--- a/modules/serverless-overriding-liveness-readiness-typescript-functions.adoc
+++ b/modules/serverless-overriding-liveness-readiness-typescript-functions.adoc
@@ -1,0 +1,110 @@
+// Module included in the following assemblies
+//
+// * /serverless/functions/serverless-developing-nodejs-functions.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="serverless-overriding-liveness-readiness-typescript-functions_{context}"]
+= Overriding liveness and readiness probe values for TypeScript functions
+
+[role="_abstract"]
+You can override `liveness` and `readiness` probe values for your TypeScript functions. Use these probes to configure how the platform performs health checks on the function.
+
+.Prerequisites
+
+* You have installed the {ServerlessOperatorName} and Knative Serving on the cluster.
+* You have installed the Knative (`kn`) CLI.
+* You have created a function by using `kn func create`.
+
+.Procedure
+
+. In your function code, create the `Function` object, which implements the following interface:
++
+[source,javascript]
+----
+export interface Function {
+  init?: () => any;
+
+  shutdown?: () => any;
+
+  liveness?: HealthCheck;
+
+  readiness?: HealthCheck;
+
+  logLevel?: LogLevel;
+
+  handle: CloudEventFunction | HTTPFunction;
+}
+----
++
+
+--
+`init?: () => any;`:: The initialization function, called before the server is started. This function is optional and should be synchronous.
+`shutdown?: () => any; <2>`:: The shutdown function, called after the server is stopped. This function is optional and should be synchronous.
+`liveness?: HealthCheck;`:: The liveness function, called to check if the server is alive. This function is optional and should return 200/OK if the server is alive.
+`readiness?: HealthCheck;`:: The readiness function, called to check if the server is ready to accept requests. This function is optional and should return 200/OK if the server is ready.
+`handle: CloudEventFunction | HTTPFunction;`:: The function to handle HTTP requests.
+--
++
+For example, add the following code to the `index.js` file:
++
+[source,javascript]
+----
+const Function = {
+
+  handle: (context, body) => {
+    // The function logic goes here
+    return 'function called'
+  },
+
+  liveness: () => {
+    process.stdout.write('In liveness\n');
+    return 'ok, alive';
+  },
+
+  readiness: () => {
+    process.stdout.write('In readiness\n');
+    return 'ok, ready';
+  }
+};
+
+Function.liveness.path = '/alive';
+Function.readiness.path = '/ready';
+
+module.exports = Function;
+----
++
+
+--
+`liveness: () => {`:: Custom `liveness` function.
+`readiness: () => {`:: Custom `readiness` function.
+`Function.liveness.path = '/alive';`:: Custom `liveness` endpoint.
+`Function.readiness.path = '/ready';`:: Custom `readiness` endpoint.
+--
++
+As an alternative to `Function.liveness.path` and `Function.readiness.path`, you can specify custom endpoints by using the `LIVENESS_URL` and `READINESS_URL` environment variables:
++
+[source,yaml]
+----
+run:
+  envs:
+  - name: LIVENESS_URL
+    value: /alive
+  - name: READINESS_URL
+    value: /ready
+----
++
+
+--
+`value: /alive`:: The liveness path, set to `/alive` here.
+`value: /ready`:: The readiness path, set to `/ready` here.
+--
+
+. Add the new endpoints to the `func.yaml` file, so that they are properly bound to the container for the Knative service:
++
+[source,yaml]
+----
+deploy:
+  healthEndpoints:
+    liveness: /alive
+    readiness: /ready
+----

--- a/modules/serverless-python-function-return-values.adoc
+++ b/modules/serverless-python-function-return-values.adoc
@@ -7,9 +7,10 @@
 = Python function return values
 
 [role="_abstract"]
-Functions can return any value supported by link:https://flask.palletsprojects.com/en/1.1.x/quickstart/#about-responses[Flask]. This is because the invocation framework proxies these values directly to the Flask server.
+Functions can return any value supported by `Flask`. This is because the invocation framework proxies these values directly to the `Flask` server.
 
-.Example
+You get an output similar to the following example:
+
 [source,python]
 ----
 def main(context: Context):
@@ -21,11 +22,12 @@ def main(context: Context):
 Functions can set both headers and response codes as secondary and tertiary response values from function invocation.
 
 [id="serverless-python-function-return-values-returning-events_{context}"]
-== Returning CloudEvents
+== Returning `CloudEvents`
 
-Developers can use the `@event` decorator to tell the invoker that the function return value must be converted to a CloudEvent before sending the response.
+Developers can use the `@event` decorator to tell the invoker that the function return value must be converted to a `CloudEvent` before sending the response.
 
-.Example
+You get an output similar to the following example:
+
 [source,python]
 ----
 @event("event_source"="/my/function", "event_type"="my.type")
@@ -36,4 +38,4 @@ def main(context):
     return data
 ----
 
-This example sends a CloudEvent as the response value, with a type of `"my.type"` and a source of `"/my/function"`. The CloudEvent link:https://github.com/cloudevents/spec/blob/v1.0.1/spec.md#event-data[`data` property] is set to the returned `data` variable. The `event_source` and `event_type` decorator attributes are both optional.
+This example sends a `CloudEvent` as the response value, with a type of `"my.type"` and a source of `"/my/function"`. The `CloudEvent` `data` property is set to the returned `data` variable. The `event_source` and `event_type` decorator attributes are both optional.

--- a/modules/serverless-python-template.adoc
+++ b/modules/serverless-python-template.adoc
@@ -9,6 +9,11 @@
 [role="_abstract"]
 When you create a Python function by using the Knative (`kn`) CLI, the project directory looks similar to a typical Python project. Python functions have very few restrictions. The only requirements are that your project contains a `func.py` file that contains a `main()` function, and a `func.yaml` configuration file.
 
+[NOTE]
+====
+Before you can develop functions, you must configure the function.
+====
+
 Developers are not restricted to the dependencies provided in the template `requirements.txt` file. Additional dependencies can be added as they would be in any other Python project. When the project is built for deployment, these dependencies will be included in the created runtime container image.
 
 Both `http` and `event` trigger functions have the same template structure:

--- a/modules/serverless-quarkus-cloudevent-attributes.adoc
+++ b/modules/serverless-quarkus-cloudevent-attributes.adoc
@@ -7,9 +7,9 @@
 = CloudEvent attributes
 
 [role="_abstract"]
-If you need to read or write the attributes of a CloudEvent, such as `type` or `subject`, you can use the `CloudEvent<T>` generic interface and the `CloudEventBuilder` builder. The `<T>` type parameter must be one of the permitted types.
+If you need to read or write the attributes of a `CloudEvent`, such as `type` or `subject`, you can use the `CloudEvent<T>` generic interface and the `CloudEventBuilder` builder. The `<T>` type parameter must be one of the permitted types.
 
-In the following example, `CloudEventBuilder` is used to return success or failure of processing the purchase:
+In the following example, `CloudEventBuilder` is used to return success or failure of processing the `purchase`:
 
 [source,java]
 ----

--- a/modules/serverless-quarkus-function-return-values.adoc
+++ b/modules/serverless-quarkus-function-return-values.adoc
@@ -7,7 +7,7 @@
 = Quarkus function return values
 
 [role="_abstract"]
-Functions can return an instance of any type from the list of permitted types. Alternatively, they can return the `Uni<T>` type, where the `<T>` type parameter can be of any type from the permitted types.
+Functions can return an instance of any type from the list of permitted types. Or, they can return the `Uni<T>` type, where the `<T>` type parameter can be of any type from the permitted types.
 
 The `Uni<T>` type is useful if a function calls asynchronous APIs, because the returned object is serialized in the same format as the received object. For example:
 
@@ -17,7 +17,6 @@ The `Uni<T>` type is useful if a function calls asynchronous APIs, because the r
 
 The following example shows a function that fetches a list of purchases:
 
-.Example command
 [source,java]
 ----
 public class Functions {
@@ -28,6 +27,6 @@ public class Functions {
 }
 ----
 
-* Invoking this function through an HTTP request produces an HTTP response that contains a list of purchases in the body of the response.
+* Invoking this function through an HTTP request produces an HTTP response that has a list of purchases in the body of the response.
 
 * Invoking this function through an incoming `CloudEvent` object produces a `CloudEvent` response with a list of purchases in the `data` property.

--- a/modules/serverless-quarkus-functions-overriding-liveness-readiness.adoc
+++ b/modules/serverless-quarkus-functions-overriding-liveness-readiness.adoc
@@ -4,14 +4,14 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="serverless-quarkus-functions-overriding-liveness-readiness_{context}"]
-= Overriding liveness and readiness probe values
+= Overriding liveness and readiness probe values for Quarkus functions
 
 [role="_abstract"]
-You can override `liveness` and `readiness` probe values for your Quarkus functions. This allows you to configure health checks performed on the function.
+You can override `liveness` and `readiness` probe values for your Quarkus functions. Configure these probes to define how the platform performs health checks on the function.
 
 .Prerequisites
 
-* The {ServerlessOperatorName} and Knative Serving are installed on the cluster.
+* You have installed the {ServerlessOperatorName} and Knative Serving on the cluster.
 * You have installed the Knative (`kn`) CLI.
 * You have created a function by using `kn func create`.
 
@@ -21,15 +21,18 @@ You can override `liveness` and `readiness` probe values for your Quarkus functi
 
 .. To override the paths using the function source, update the path properties in the `src/main/resources/application.properties` file:
 +
-[source]
+[source,terminal]
 ----
-quarkus.smallrye-health.root-path=/health <1>
-quarkus.smallrye-health.liveness-path=alive <2>
-quarkus.smallrye-health.readiness-path=ready <3>
+quarkus.smallrye-health.root-path=/health
+quarkus.smallrye-health.liveness-path=alive
+quarkus.smallrye-health.readiness-path=ready
 ----
-<1> The root path, which is automatically prepended to the `liveness` and `readiness` paths.
-<2> The liveness path, set to `/health/alive` here.
-<3> The readiness path, set to `/health/ready` here.
++
+--
+`quarkus.smallrye-health.root-path=/health`:: The root path, which is automatically prepended to the `liveness` and `readiness` paths.
+`quarkus.smallrye-health.liveness-path=alive`:: The liveness path, set to `/health/alive` here.
+`quarkus.smallrye-health.readiness-path=ready`:: The readiness path, set to `/health/ready` here.
+--
 
 .. To override the paths using environment variables, define the path variables in the `build` block of the `func.yaml` file:
 +
@@ -43,8 +46,12 @@ build:
   - name: QUARKUS_SMALLRYE_HEALTH_READINESS_PATH
     value: ready <2>
 ----
-<1> The liveness path, set to `/health/alive` here.
-<2> The readiness path, set to `/health/ready` here.
++
+
+--
+`value: alive`:: The liveness path, set to `/health/alive` here.
+`value: ready`:: The readiness path, set to `/health/ready` here.
+--
 
 . Add the new endpoints to the `func.yaml` file, so that they are properly bound to the container for the Knative service:
 +

--- a/modules/serverless-quarkus-template.adoc
+++ b/modules/serverless-quarkus-template.adoc
@@ -7,11 +7,15 @@
 = Quarkus function template structure
 
 [role="_abstract"]
-When you create a Quarkus function by using the Knative (`kn`) CLI, the project directory looks similar to a typical Maven project. Additionally, the project contains the `func.yaml` file, which is used for configuring the function.
+When you create a Quarkus function by using the Knative (`kn`) CLI, the project directory looks similar to a typical Maven project. Additionally, the project has the `func.yaml` file, which is used for configuring the function.
+
+[NOTE]
+====
+Before you can develop functions, you must configure the function.
+====
 
 Both `http` and `event` trigger functions have the same template structure:
 
-.Template structure
 [source,terminal]
 ----
 .
@@ -35,10 +39,15 @@ Both `http` and `event` trigger functions have the same template structure:
                 ├── FunctionTest.java
                 └── NativeFunctionIT.java
 ----
-<1> Used to determine the image name and registry.
-<2> The Project Object Model (POM) file contains project configuration, such as information about dependencies. You can add additional dependencies by modifying this file.
-+
-.Example of additional dependencies
+--
+`func.yaml`:: Used to find the image name and registry.
+`pom.xml`:: The Project Object Model (POM) file has project configuration, such as information about dependencies. You can add additional dependencies by modifying this file.
+`Function.java`:: The function project must contain a Java method annotated with `@Funq`. You can place this method in the `Function.java` class.
+`functions`:: Contains simple test cases that can be used to test your function locally.
+--
+
+You get an output similar to the following example:
+
 [source,xml]
 ----
 ...
@@ -58,7 +67,6 @@ Both `http` and `event` trigger functions have the same template structure:
   </dependencies>
 ...
 ----
-+
+
 Dependencies are downloaded during the first compilation.
-<3> The function project must contain a Java method annotated with `@Funq`. You can place this method in the `Function.java` class.
-<4> Contains simple test cases that can be used to test your function locally.
+

--- a/modules/serverless-subscribing-a-function-to-cloudevents.adoc
+++ b/modules/serverless-subscribing-a-function-to-cloudevents.adoc
@@ -1,9 +1,13 @@
+// Module included in the following assemblies:
+//
+// * serverless/functions/serverless-functions-subscribing.adoc
+
 :_mod-docs-content-type: PROCEDURE
 [id="serverless-subscribing-a-function-to-cloudevents_{context}"]
 = Subscribing a function to CloudEvents
 
 [role="_abstract"]
-The `subscribe` command connects the function to a set of events, matching a series of filters for `CloudEvent` metadata and a Knative Broker as the source of events, from where they are consumed.
+The `subscribe` command connects the function to events by matching filters for `CloudEvent` metadata and using a Knative Broker as the source. The function then consumes events from the broker.
 
 .Prerequisites
 
@@ -15,7 +19,8 @@ The `subscribe` command connects the function to a set of events, matching a ser
 
 . Subscribe the function to events for a given broker by running the following command:
 +
-.Example command
+You get an output similar to the following example command:
++
 [source,terminal]
 ----
 $ kn func subscribe --filter type=com.example.Hello --source my-broker
@@ -25,7 +30,8 @@ Use the `--source` flag to specify the broker and one or more `--filter` flags t
 +
 You can also omit the `--source` flag to use the default broker:
 +
-.Example command
+You get an output similar to the following example command:
++
 [source,terminal]
 ----
 $ kn func subscribe --filter type=com.example --filter extension=my-extension-value
@@ -33,13 +39,15 @@ $ kn func subscribe --filter type=com.example --filter extension=my-extension-va
 
 . Deploy the function with Knative Triggers:
 +
-.Example command
+You get an output similar to the following example command:
++
 [source,terminal]
 ----
 $ kn func deploy
 ----
 +
-.Example output
+You get an output similar to the following example:
++
 [source,terminal]
 ----
 🙌 Function image built: <registry>/hello:latest

--- a/modules/serverless-testing-go-functions.adoc
+++ b/modules/serverless-testing-go-functions.adoc
@@ -7,11 +7,11 @@
 = Testing Go functions
 
 [role="_abstract"]
-Go functions can be tested locally on your computer. In the default project that is created when you create a function using `kn func create`, there is a `handle_test.go` file, which contains some basic tests. These tests can be extended as needed.
+Go functions can be tested locally on your computer. In the default project that is created when you create a function by using `kn func create`, there is a `handle_test.go` file, which has some basic tests. These tests can be extended as needed.
 
 .Prerequisites
 
-* The {ServerlessOperatorName} and Knative Serving are installed on the cluster.
+* You have installed the {ServerlessOperatorName} and Knative Serving on the cluster.
 * You have installed the Knative (`kn`) CLI.
 * You have created a function by using `kn func create`.
 
@@ -19,7 +19,7 @@ Go functions can be tested locally on your computer. In the default project that
 
 . Navigate to the *test* folder for your function.
 
-. Run the tests:
+. Run the tests by running the following command:
 +
 [source,terminal]
 ----

--- a/modules/serverless-testing-nodejs-functions.adoc
+++ b/modules/serverless-testing-nodejs-functions.adoc
@@ -7,17 +7,18 @@
 = Testing Node.js functions
 
 [role="_abstract"]
-Node.js functions can be tested locally on your computer. In the default project that is created when you create a function by using `kn func create`, there is a *test* folder that contains some simple unit and integration tests.
+Node.js functions can be tested locally on your computer. In the default project that is created when you create a function by using `kn func create`, there is a *test* folder that has some simple unit and integration tests.
 
 .Prerequisites
 
-* The {ServerlessOperatorName} and Knative Serving are installed on the cluster.
+* You have installed the {ServerlessOperatorName} and Knative Serving on the cluster.
 * You have installed the Knative (`kn`) CLI.
 * You have created a function by using `kn func create`.
 
 .Procedure
 
 . Navigate to the *test* folder for your function.
+
 . Run the tests:
 +
 [source,terminal]

--- a/modules/serverless-testing-python-functions.adoc
+++ b/modules/serverless-testing-python-functions.adoc
@@ -7,7 +7,7 @@
 = Testing Python functions
 
 [role="_abstract"]
-You can test Python functions locally on your computer. The default project contains a `test_func.py` file, which provides a simple unit test for functions.
+You can test Python functions locally on your computer. The default project has a `test_func.py` file, which provides a simple unit test for functions.
 
 [NOTE]
 ====
@@ -25,7 +25,7 @@ $ pip install -r requirements.txt
 
 .Procedure
 
-. Navigate to the folder for your function that contains the `test_func.py` file.
+. Navigate to the folder for your function that has the `test_func.py` file.
 
 . Run the tests:
 +

--- a/modules/serverless-testing-quarkus-functions.adoc
+++ b/modules/serverless-testing-quarkus-functions.adoc
@@ -7,7 +7,7 @@
 = Testing Quarkus functions
 
 [role="_abstract"]
-Quarkus functions can be tested locally on your computer. In the default project that is created when you create a function using `kn func create`, there is the  `src/test/` directory, which contains basic Maven tests. These tests can be extended as needed.
+You can test Quarkus functions locally on your computer. The default project that `kn func create` creates has a `src/test/` directory with basic Maven tests. You can extend these tests as needed.
 
 .Prerequisites
 

--- a/modules/serverless-testing-typescript-functions.adoc
+++ b/modules/serverless-testing-typescript-functions.adoc
@@ -7,17 +7,17 @@
 = Testing TypeScript functions
 
 [role="_abstract"]
-TypeScript functions can be tested locally on your computer. In the default project that is created when you create a function using `kn func create`, there is a *test* folder that contains some simple unit and integration tests.
+TypeScript functions can be tested locally on your computer. In the default project that is created when you create a function by using `kn func create`, there is a *test* folder that has some simple unit and integration tests.
 
 .Prerequisites
 
-* The {ServerlessOperatorName} and Knative Serving are installed on the cluster.
+* You have installed the {ServerlessOperatorName} and Knative Serving on the cluster.
 * You have installed the Knative (`kn`) CLI.
 * You have created a function by using `kn func create`.
 
 .Procedure
 
-. If you have not previously run tests, install the dependencies first:
+. If you have not previously run tests, install the dependencies first by running the following command:
 +
 [source,terminal]
 ----

--- a/modules/serverless-typescript-context-object-reference.adoc
+++ b/modules/serverless-typescript-context-object-reference.adoc
@@ -7,14 +7,15 @@
 = TypeScript context object reference
 
 [role="_abstract"]
-The `context` object has several properties that can be accessed by the function developer. Accessing these properties can provide information about incoming HTTP requests and write output to the cluster logs.
+The `context` object has several properties that can be accessed by the function developer. Accessing these properties can give information about incoming HTTP requests and write output to the cluster logs.
 
 [id="serverless-typescript-context-object-reference-log_{context}"]
 == log
 
-Provides a logging object that can be used to write output to the cluster logs. The log adheres to the link:https://getpino.io/#/docs/api[Pino logging API].
+Provides a logging object that can be used to write output to the cluster logs. The log adheres to the Pino logging API.
 
-.Example log
+You get an output similar to the following log example:
+
 [source,javascript]
 ----
 export function handle(context: Context): string {
@@ -30,26 +31,29 @@ export function handle(context: Context): string {
 
 You can access the function by using the `kn func invoke` command:
 
-.Example command
+You get an output similar to the following example command:
+
 [source,terminal]
 ----
 $ kn func invoke --target 'http://example.function.com'
 ----
 
-.Example output
+You get an output similar to the following example:
+
 [source,terminal]
 ----
 {"level":30,"time":1604511655265,"pid":3430203,"hostname":"localhost.localdomain","reqId":1,"msg":"Processing customer"}
 ----
 
-You can change the log level to one of `fatal`, `error`, `warn`, `info`, `debug`, `trace`, or `silent`. To do that, change the value of `logLevel` by assigning one of these values to the environment variable `FUNC_LOG_LEVEL` using the `config` command.
+You can change the log level to one of `fatal`, `error`, `warn`, `info`, `debug`, `trace`, or `silent`. To do that, change the value of `logLevel` by assigning one of these values to the environment variable `FUNC_LOG_LEVEL` by using the `config` command.
 
 [id="serverless-typescript-context-object-reference-query_{context}"]
 == query
 
 Returns the query string for the request, if any, as key-value pairs. These attributes are also found on the context object itself.
 
-.Example query
+You get an output similar to the following query example:
+
 [source,javascript]
 ----
 export function handle(context: Context): string {
@@ -66,13 +70,15 @@ export function handle(context: Context): string {
 
 You can access the function by using the `kn func invoke` command:
 
-.Example command
+You get an output similar to the following example command:
+
 [source,terminal]
 ----
 $ kn func invoke --target 'http://example.function.com' --data '{"name": "tiger"}'
 ----
 
-.Example output
+You get an output similar to the following example:
+
 [source,terminal]
 ----
 {"level":30,"time":1604511655265,"pid":3430203,"hostname":"localhost.localdomain","reqId":1,"msg":"tiger"}
@@ -84,7 +90,8 @@ $ kn func invoke --target 'http://example.function.com' --data '{"name": "tiger"
 
 Returns the request body, if any. If the request body contains JSON code, this will be parsed so that the attributes are directly available.
 
-.Example body
+You get an output similar to the following body example:
+
 [source,javascript]
 ----
 export function handle(context: Context): string {
@@ -100,13 +107,15 @@ export function handle(context: Context): string {
 
 You can access the function by using the `kn func invoke` command:
 
-.Example command
+You get an output similar to the following example command:
+
 [source,terminal]
 ----
 $ kn func invoke --target 'http://example.function.com' --data '{"hello": "world"}'
 ----
 
-.Example output
+You get an output similar to the following example:
+
 [source,terminal]
 ----
 {"level":30,"time":1604511655265,"pid":3430203,"hostname":"localhost.localdomain","reqId":1,"msg":"world"}
@@ -117,7 +126,8 @@ $ kn func invoke --target 'http://example.function.com' --data '{"hello": "world
 
 Returns the HTTP request headers as an object.
 
-.Example header
+You get an output similar to the following headers example:
+
 [source,javascript]
 ----
 export function handle(context: Context): string {
@@ -131,15 +141,17 @@ export function handle(context: Context): string {
 }
 ----
 
-You can access the function by using the `curl` command to invoke it:
+You can access the function by using the `curl` command to call it:
 
-.Example command
+You get an output similar to the following example command:
+
 [source,terminal]
 ----
 $ curl -H'x-custom-header: some-value’' http://example.function.com
 ----
 
-.Example output
+You get an output similar to the following example:
+
 [source,terminal]
 ----
 {"level":30,"time":1604511655265,"pid":3430203,"hostname":"localhost.localdomain","reqId":1,"msg":"some-value"}
@@ -148,7 +160,7 @@ $ curl -H'x-custom-header: some-value’' http://example.function.com
 [id="serverless-typescript-context-object-reference-http-requests_{context}"]
 == HTTP requests
 
-method:: Returns the HTTP request method as a string.
-httpVersion:: Returns the HTTP version as a string.
-httpVersionMajor:: Returns the HTTP major version number as a string.
-httpVersionMinor:: Returns the HTTP minor version number as a string.
+`method`:: Returns the HTTP request method as a string.
+`httpVersion`:: Returns the HTTP version as a string.
+`httpVersionMajor`:: Returns the HTTP major version number as a string.
+`httpVersionMinor`:: Returns the HTTP minor version number as a string.

--- a/modules/serverless-typescript-function-return-values.adoc
+++ b/modules/serverless-typescript-function-return-values.adoc
@@ -9,9 +9,10 @@
 [role="_abstract"]
 Functions can return any valid JavaScript type or can have no return value. When a function has no return value specified, and no failure is indicated, the caller receives a `204 No Content` response.
 
-Functions can also return a CloudEvent or a `Message` object in order to push events into the Knative Eventing system. In this case, the developer is not required to understand or implement the CloudEvent messaging specification. Headers and other relevant information from the returned values are extracted and sent with the response.
+Functions can also return a `CloudEvent` or a `Message` object to push events into the Knative Eventing system. In this case, the developer is not required to understand or implement the `CloudEvent` messaging specification. Headers and other relevant information from the returned values are extracted and sent with the response.
 
-.Example
+You get an output similar to the following example:
+
 [source,javascript]
 ----
 export const handle: Invokable = function (
@@ -34,7 +35,8 @@ export const handle: Invokable = function (
 
 You can set a response header by adding a `headers` property to the `return` object. These headers are extracted and sent with the response to the caller.
 
-.Example response header
+The following example displayes response header:
+
 [source,javascript]
 ----
 export function handle(context: Context, cloudevent?: CloudEvent): Record<string, any> {
@@ -49,7 +51,8 @@ export function handle(context: Context, cloudevent?: CloudEvent): Record<string
 
 You can set a status code that is returned to the caller by adding a `statusCode` property to the `return` object:
 
-.Example status code
+The following example displayes status code:
+
 [source,javascript]
 ----
 export function handle(context: Context, cloudevent?: CloudEvent): Record<string, any> {
@@ -69,7 +72,8 @@ export function handle(context: Context, cloudevent?: CloudEvent): Record<string
 
 Status codes can also be set for errors that are created and thrown by the function:
 
-.Example error status code
+The following example displayes error status code:
+
 [source,javascript]
 ----
 export function handle(context: Context, cloudevent?: CloudEvent): Record<string, string> {

--- a/modules/serverless-typescript-functions-context-objects.adoc
+++ b/modules/serverless-typescript-functions-context-objects.adoc
@@ -7,24 +7,26 @@
 = TypeScript context objects
 
 [role="_abstract"]
-To invoke a function, you provide a `context` object as the first parameter. Accessing properties of the `context` object can provide information about the incoming HTTP request.
+To call a function, pass a `context` object as the first parameter. Access its properties to get information about the incoming HTTP request.
 
-.Example context object
+The following example displayes `context` object:
+
 [source,javascript]
 ----
 function handle(context:Context): string
 ----
 
-This information includes the HTTP request method, any query strings or headers sent with the request, the HTTP version, and the request body. Incoming requests that contain a `CloudEvent` attach the incoming instance of the CloudEvent to the context object so that it can be accessed by using `context.cloudevent`.
+This information includes the HTTP request method, any query strings or headers sent with the request, the HTTP version, and the request body. Incoming requests that contain a `CloudEvent` attach the incoming instance of the `CloudEvent` to the context object so that it can be accessed by using `context.cloudevent`.
 
 [id="serverless-typescript-functions-context-objects-methods_{context}"]
 == Context object methods
 
-The `context` object has a single method, `cloudEventResponse()`, that accepts a data value and returns a CloudEvent.
+The `context` object has a single method, `cloudEventResponse()`, that accepts a data value and returns a `CloudEvent`.
 
-In a Knative system, if a function deployed as a service is invoked by an event broker sending a CloudEvent, the broker examines the response. If the response is a CloudEvent, this event is handled by the broker.
+In a Knative system, if a function deployed as a service is invoked by an event broker sending a `CloudEvent`, the broker examines the response. If the response is a `CloudEvent`, this event is handled by the broker.
 
-.Example context object method
+The following example displayes `context` object method:
+
 [source,javascript]
 ----
 // Expects to receive a CloudEvent with customer data
@@ -44,7 +46,8 @@ export function handle(context: Context, cloudevent?: CloudEvent): CloudEvent {
 
 The TypeScript type definition files export the following types for use in your functions.
 
-.Exported type definitions
+The following example displayes exported type definitions:
+
 [source,javascript]
 ----
 // Invokable is the expeted Function signature for user functions
@@ -90,9 +93,9 @@ export interface CloudEventResponse {
 ----
 
 [id="serverless-typescript-functions-context-objects-cloudevent-data_{context}"]
-== CloudEvent data
+== `CloudEvent` data
 
-If the incoming request is a CloudEvent, any data associated with the CloudEvent is extracted from the event and provided as a second parameter. For example, if a CloudEvent is received that contains a JSON string in its data property that is similar to the following:
+If the incoming request is a `CloudEvent`, any data associated with the `CloudEvent` is extracted from the event and provided as a second parameter. For example, if a `CloudEvent` is received that has a JSON string in its data property that is similar to the following:
 
 [source,json]
 ----
@@ -104,10 +107,11 @@ If the incoming request is a CloudEvent, any data associated with the CloudEvent
 
 When invoked, the second parameter to the function, after the `context` object, will be a JavaScript object that has `customerId` and `productId` properties.
 
-.Example signature
+You get an output similar to the following example signature:
+
 [source,javascript]
 ----
 function handle(context: Context, cloudevent?: CloudEvent): CloudEvent
 ----
 
-The `cloudevent` parameter in this example is a JavaScript object that contains the `customerId` and `productId` properties.
+The `cloudevent` parameter in this example is a JavaScript object that has the `customerId` and `productId` properties.

--- a/modules/serverless-typescript-template.adoc
+++ b/modules/serverless-typescript-template.adoc
@@ -7,34 +7,43 @@
 = TypeScript function template structure
 
 [role="_abstract"]
-When you create a TypeScript function using the Knative (`kn`) CLI, the project directory looks like a typical TypeScript project. The only exception is the additional `func.yaml` file, which is used for configuring the function.
+When you create a TypeScript function by using the Knative (`kn`) CLI, the project directory looks like a typical TypeScript project. The only exception is the additional `func.yaml` file, which is used for configuring the function.
+
+[NOTE]
+====
+Before you can develop functions, you must configure the function.
+====
 
 Both `http` and `event` trigger functions have the same template structure:
 
-.Template structure
 [source,terminal]
+
 ----
 .
-├── func.yaml <1>
-├── package.json <2>
+├── func.yaml
+├── package.json
 ├── package-lock.json
 ├── README.md
 ├── src
-│   └── index.ts <3>
-├── test <4>
+│   └── index.ts
+├── test
 │   ├── integration.ts
 │   └── unit.ts
 └── tsconfig.json
 ----
-<1> The `func.yaml` configuration file is used to determine the image name and registry.
-<2> You are not restricted to the dependencies provided in the template `package.json` file. You can add additional dependencies as you would in any other TypeScript project.
-+
-.Example of adding npm dependencies
+
+--
+`func.yaml`:: The `func.yaml` configuration file is used to find the image name and registry.
+`package.json`:: You are not restricted to the dependencies provided in the template `package.json` file. You can add additional dependencies as you would in any other TypeScript project.
+`index.ts`:: Your project must contain an `src/index.js` file that exports a function named `handle`.
+`test`:: Integration and unit test scripts are provided as part of the function template.
+--
+
+The following displays how to add npm dependencies:
+
 [source,terminal]
 ----
 npm install --save opossum
 ----
-+
+
 When the project is built for deployment, these dependencies are included in the created runtime container image.
-<3> Your project must contain an `src/index.js` file which exports a function named `handle`.
-<4> Integration and unit test scripts are provided as part of the function template.


### PR DESCRIPTION
**You can cherry-pick for the following branches:** 
- `serverless-docs-1.37`
- `serverless-docs-1.38`

**Note for the peer & merge reviewer:** 
- This PR updates the only "Functions" section to prepare it for Phase 0 DITA migration.
- No other CQA changes, error types, or content refinements are included. 

**Changes:** 
This PR prepares the "Functions" section for Phase 0 DITA migration by applying Vale (AsciiDoc DITA) rules and cleaning up the existing content.

**Doc preview:** https://109170--ocpdocs-pr.netlify.app/openshift-serverless/latest/functions/serverless-functions-getting-started

**Tracking JIRA:** https://redhat.atlassian.net/browse/SRVCOM-4364

**Reviews:**
- [x] Peer has approved this change