### PR TITLE
OSDOCS-18790-RN: KMM 2.6 Release Notes

### DIFF
--- a/hardware_enablement/kmm-release-notes.adoc
+++ b/hardware_enablement/kmm-release-notes.adoc
@@ -403,10 +403,82 @@ Kernel Module Management (KMM) 2.5 is now supported on {ibm-z-title} architectur
 // TELCODOCS-2636
 * Kernel Module Management (KMM) version 2.5 does not run on Red Hat OpenShift Service on AWS (ROSA) clusters or any other cluster that doesn't install the `MachineConfig` CRD.
 
-** Cause: This happens because the BMC controller that monitors `MachineConfig` objects on clusters cannot find these objects on ROSA clusters because they do not exist.
+** *Cause*: This happens because the BMC controller that monitors `MachineConfig` objects on clusters cannot find these objects on ROSA clusters because they do not exist.
 
-** Consequence: Causes the BMC controller to fail and the KMM controller pods to continually restart.
+** *Consequence*: Causes the BMC controller to fail and the KMM controller pods to continually restart.
 
-** Fix: In this version, the Operator verifies that the `MachineConfig` CRD is present on a cluster and runs the BMC controller on a cluster only when the `MachineConfig` CRD is present.
+** *Fix*: In this version, the Operator verifies that the `MachineConfig` CRD is present on a cluster and runs the BMC controller on a cluster only when the `MachineConfig` CRD is present.
 
-** Result: ROSA controller pods start successfully. 
+** *Result*: ROSA controller pods start successfully. 
+
+[id="kmm-2-6-RN"]
+== Release notes for Kernel Module Management Operator 2.6
+=== New features and enhancements
+// OSDOCS-18465
+* In this release, wildcard and GLOB pattern support for the `filesToSign` field has been added for signing kernel modules in a specific folder. Previously, you had to specify the exact path to each `.ko` file you wanted to sign. Now, you can add the full path to explicit files, as previously required, or any GLOB patterns supported by the `Ash` shell.
++
+Additionally, this commit propagates `DirName` string from the API into the sign image template, and adds the signed files to the validation webhook.
+// For more information, see 
+
+// OSDOCS-18476
+* In this release, you can use the `AutomountServiceAccountToken` parameter to disable the auto-mounting of the projected volume. You can set `AutomountServiceAccountToken` to `false` to disable auto-mounting and mount the configmaps and tokens necessary for the `DevicePlugin` application.
++
+Kubernetes automatically mounts the service account token and root Certificate Authoritys (CAs) 
+into the `/var/run/secrets/kubernetes.io/serviceaccount` of the device-plugin pods using projected volumes. In some cases, you may want to use additional custom CAs or tokens for the device-plugin but Kubernetes does not allow mounting them to the same path unless the auto-mount is disabled.
+
+// OSDOCS-18474
+* In this release, new security settings have been added to prevent filesystem tampering and remove privileged kernel operations. The new settings enhance container security by restricting system capabilities and enabling read-only root filesystems across manager, webhook-server, and Operator components to strengthen security posture and reduce attack surface. For more information, see https://redhat.atlassian.net/browse/MGMT-20929[KMM RapiDAST "Root file system is not read-only" while checking DAST].
+
+// OSDOCS-18475
+* In this release, when installing KMM using OLM, you can add additional tolerations to the Operator where worker nodes have custom taints or no accessible control-plane nodes. 
++
+By default, the KMM Operator is installed on control plane nodes when possible and includes tolerations that allow for the KMM Operator to be scheduled on the nodes. In environments where the control plane is not accessible, the KMM Operator is installed on worker nodes. 
+// For more information, see 
+
+// OSDOCS-18468
+* In this release, a new optional `imageRebuildTrigger` counter field has been added in the `Module`, `ManagedClusterModule`, and `ModuleImagesConfig` CRDs that allows you to force Kernel Module Management (KMM) to reverify and rebuild module images when using ephemeral image registries. When this counter's value changes, the system automatically clears cached image statuses and reverifies the image existence, potentially triggering rebuilds. 
+// For more information, see 
+
+=== Bug fixes
+
+// OSDOCS-18470
+* Unwarranted kernel module removal due to memory and disk limitations.
+
+** *Cause*: Memory and disk limitations can cause the removal of kernel modules. 
+
+** *Consequence*: The kernel module is removed.   
+
+** *Fix*: This release contains a new set of internal tolerations such as `DiskPressure`, `MemoryPressure`, and `PIDPressure` that are propagated through the module loader data flow and node selection process. These internal tolerations are appended to module-specific tolerations when handling module scheduling.
+
+** *Result*: The internal tolerations improve module scheduling to account for additional system resource pressure conditions. Modules can now be deployed across a broader range of cluster nodes, enhancing resource utilization and deployment flexibility.
+
+// OSDOCS-18467
+* Kernel Module Management (KMM) cannot delete module names that contain a `.`.
+
+** *Cause*: The Kernel Module Management (KMM) Operator cannot delete modules that contain a `.` in their name.
+
+** *Consequence*: The module intended for deletion hangs indefinitely.
+
+** *Fix*: The finalizer `regexp` used to remove the node label has been modified to complete deletion.
+
+** *Result*: When the node label has been correctly deleted, the module deletes successfully. 
++
+For more information, see https://redhat.atlassian.net/browse/MGMT-19647[MGMT-19647]. 
+
+// OSDOCS-18472
+* Build and sign pods do not inherit Module tolerations.
+
+** *Cause*: Build and sign pods created through the `ModuleImagesConfig` (MIC) and `ModuleBuildSignConfig` (MBSC) flows do not inherit tolerations from the parent Module.
+
+** *Consequence*: Build pods fail scheduling on nodes with custom taints. Build pods should have the same tolerations as defined in the `Module.spec.tolerations` parameter, allowing them to schedule on tainted nodes where kernel headers are available.
+
+** *Fix*: Added a `Tolerations` field to module build and image configurations that specifies the tolerations for build and sign pods.
+
+** *Result*: You can now specify tolerations for build and sign pods, enabling control over pod scheduling on nodes with taints. This fix supports standard toleration properties including effect, key, operator, and duration settings.
+
+
+=== Known issues
+// OSDOCS-18469
+* Issues have been encountered when loading out-of-tree (OOT) drivers for QDU x100 DU PCIe cards from v4.14. For more information, see link:https://access.redhat.com/support/cases/#/case/04245147[Case 04245147].
+
+


### PR DESCRIPTION
KMM 2.6 Release Notes

Version(s):
4.21, 4.22

Issue:
https://redhat.atlassian.net/browse/OSDOCS-18790

Link to docs preview:
https://109171--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hardware_enablement/kmm-release-notes.html#kmm-2-6-RN

Dev: @ybettan 

QE review: @cdvultur 