### PR TITLE
TELCODOCS-2844: Fix AsciiDocDITA violations in SR-IOV sysctl docs

### DIFF
--- a/modules/nw-configure-sysctl-interface-sriov-network-bonded.adoc
+++ b/modules/nw-configure-sysctl-interface-sriov-network-bonded.adoc
@@ -6,6 +6,7 @@
 [id="configuring-sysctl-on-bonded-sriov-network_{context}"]
 = Configuring sysctl on a bonded SR-IOV network
 
+[role="_abstract"]
 You can set interface specific `sysctl` settings on a bonded interface created from two SR-IOV interfaces. Do this by adding the tuning configuration to the optional `Plugins` parameter of the bond network attachment definition.
 
 [NOTE]
@@ -29,18 +30,21 @@ To change specific interface-level network `sysctl` settings create the `SriovNe
 apiVersion: sriovnetwork.openshift.io/v1
 kind: SriovNetwork
 metadata:
-  name: allvalidflags <1>
-  namespace: openshift-sriov-network-operator <2>
+  name: allvalidflags
+  namespace: openshift-sriov-network-operator
 spec:
-  resourceName: policyallflags <3>
-  networkNamespace: sysctl-tuning-test <4>
-  capabilities: '{ "mac": true, "ips": true }' <5>
+  resourceName: policyallflags
+  networkNamespace: sysctl-tuning-test
+  capabilities: '{ "mac": true, "ips": true }'
 ----
-<1> A name for the object. The SR-IOV Network Operator creates a NetworkAttachmentDefinition object with same name.
-<2> The namespace where the SR-IOV Network Operator is installed.
-<3> The value for the `spec.resourceName` parameter from the `SriovNetworkNodePolicy` object that defines the SR-IOV hardware for this additional network.
-<4> The target namespace for the `SriovNetwork` object. Only pods in the target namespace can attach to the additional network.
-<5> Optional: The capabilities to configure for this additional network. You can specify `"{ "ips": true }"` to enable IP address support or `"{ "mac": true }"` to enable MAC address support.
++
+--
+* `<name>`: A name for the object. The SR-IOV Network Operator creates a NetworkAttachmentDefinition object with same name.
+* `<namespace>`: The namespace where the SR-IOV Network Operator is installed.
+* `<resourceName>`: The value for the `spec.resourceName` parameter from the `SriovNetworkNodePolicy` object that defines the SR-IOV hardware for this additional network.
+* `<networkNamespace>`: The target namespace for the `SriovNetwork` object. Only pods in the target namespace can attach to the additional network.
+* `<capabilities>`: Optional: The capabilities to configure for this additional network. You can specify `"{ "ips": true }"` to enable IP address support or `"{ "mac": true }"` to enable MAC address support.
+--
 
 . Create the `SriovNetwork` resource:
 +
@@ -64,21 +68,21 @@ spec:
   "name":"bound-net",
   "plugins":[
     {
-      "type":"bond", <1>
-      "mode": "active-backup", <2>
-      "failOverMac": 1, <3>
-      "linksInContainer": true, <4>
+      "type":"bond",
+      "mode": "active-backup",
+      "failOverMac": 1,
+      "linksInContainer": true,
       "miimon": "100",
-      "links": [ <5>
+      "links": [
         {"name": "net1"},
         {"name": "net2"}
       ],
-      "ipam":{ <6>
+      "ipam":{
         "type":"static"
       }
     },
     {
-      "type":"tuning", <7>
+      "type":"tuning",
       "capabilities":{
         "mac":true
       },
@@ -97,19 +101,16 @@ spec:
   ]
 }'
 ----
-<1> The type is `bond`.
-<2> The `mode` attribute specifies the bonding mode. The bonding modes supported are:
-
- * `balance-rr` - 0
- * `active-backup` - 1
- * `balance-xor` - 2
 +
-For `balance-rr` or `balance-xor` modes, you must set the `trust` mode to `on` for the SR-IOV virtual function.
-<3> The `failover` attribute is mandatory for active-backup mode.
-<4> The `linksInContainer=true` flag informs the Bond CNI that the required interfaces are to be found inside the container. By default, Bond CNI looks for these interfaces on the host which does not work for integration with SRIOV and Multus.
-<5> The `links` section defines which interfaces will be used to create the bond. By default, Multus names the attached interfaces as: "net", plus a consecutive number, starting with one.
-<6> A configuration object for the IPAM CNI plugin as a YAML block scalar. The plugin manages IP address assignment for the attachment definition. In this pod example IP addresses are configured manually, so in this case,`ipam` is set to static.
-<7> Add additional capabilities to the device. For example, set the `type` field to `tuning`. Specify the interface-level network `sysctl` you want to set in the sysctl field. This example sets all interface-level network `sysctl` settings that can be set.
+--
+* `<type>`: The type is `bond`.
+* `<mode>`: The `mode` attribute specifies the bonding mode. The bonding modes supported are `balance-rr` - 0, `active-backup` - 1, and `balance-xor` - 2. For `balance-rr` or `balance-xor` modes, you must set the `trust` mode to `on` for the SR-IOV virtual function.
+* `<failOverMac>`: The `failover` attribute is mandatory for active-backup mode.
+* `<linksInContainer>`: The `linksInContainer=true` flag informs the Bond CNI that the required interfaces are to be found inside the container. By default, Bond CNI looks for these interfaces on the host which does not work for integration with SRIOV and Multus.
+* `<links>`: The `links` section defines which interfaces will be used to create the bond. By default, Multus names the attached interfaces as: "net", plus a consecutive number, starting with one.
+* `<ipam>`: A configuration object for the IPAM CNI plugin as a YAML block scalar. The plugin manages IP address assignment for the attachment definition. In this pod example IP addresses are configured manually, so in this case,`ipam` is set to static.
+* `<tuning>`: Add additional capabilities to the device. For example, set the `type` field to `tuning`. Specify the interface-level network `sysctl` you want to set in the sysctl field. This example sets all interface-level network `sysctl` settings that can be set.
+--
 
 . Create the bond network attachment resource:
 +
@@ -118,24 +119,23 @@ For `balance-rr` or `balance-xor` modes, you must set the `trust` mode to `on` f
 $ oc create -f sriov-bond-network-interface.yaml
 ----
 
-.Verifying that the `NetworkAttachmentDefinition` CR is successfully created
+.Verification
 
-* Confirm that the SR-IOV Network Operator created the `NetworkAttachmentDefinition` CR by running the following command:
+. Confirm that the SR-IOV Network Operator created the `NetworkAttachmentDefinition` CR by running the following command:
 +
 [source,terminal]
 ----
-$ oc get network-attachment-definitions -n <namespace> <1>
+$ oc get network-attachment-definitions -n <namespace>
 ----
-<1> Replace `<namespace>` with the networkNamespace that you specified when configuring the network attachment, for example, `sysctl-tuning-test`. Expected output shows the names of the NAD CRDs and the creation age in minutes.
++
+--
+* `<namespace>`: Replace with the networkNamespace that you specified when configuring the network attachment, for example, `sysctl-tuning-test`. Expected output shows the names of the NAD CRDs and the creation age in minutes.
+--
 +
 [NOTE]
 ====
 There might be a delay before the SR-IOV Network Operator creates the CR.
 ====
-
-.Verifying that the additional SR-IOV network resource is successful
-
-To verify that the tuning CNI is correctly configured and the additional SR-IOV network attachment is attached, do the following:
 
 . Create a `Pod` CR. For example, save the following YAML as the file `examplepod.yaml`:
 +
@@ -149,13 +149,13 @@ metadata:
   annotations:
     k8s.v1.cni.cncf.io/networks: |-
       [
-        {"name": "allvalidflags"}, <1>
+        {"name": "allvalidflags"},
         {"name": "allvalidflags"},
         {
           "name": "bond-sysctl-network",
           "interface": "bond0",
-          "mac": "0a:56:0a:83:04:0c", <2>
-          "ips": ["10.100.100.200/24"] <3>
+          "mac": "0a:56:0a:83:04:0c",
+          "ips": ["10.100.100.200/24"]
        }
       ]
 spec:
@@ -174,9 +174,12 @@ spec:
     seccompProfile:
       type: RuntimeDefault
 ----
-<1> The name of the SR-IOV network attachment definition CR.
-<2> Optional: The MAC address for the SR-IOV device that is allocated from the resource type defined in the SR-IOV network attachment definition CR. To use this feature, you also must specify `{ "mac": true }` in the SriovNetwork object.
-<3> Optional: IP addresses for the SR-IOV device that are allocated from the resource type defined in the SR-IOV network attachment definition CR. Both IPv4 and IPv6 addresses are supported. To use this feature, you also must specify `{ "ips": true }` in the `SriovNetwork` object.
++
+--
+* `<allvalidflags>`: The name of the SR-IOV network attachment definition CR.
+* `<mac>`: Optional: The MAC address for the SR-IOV device that is allocated from the resource type defined in the SR-IOV network attachment definition CR. To use this feature, you also must specify `{ "mac": true }` in the SriovNetwork object.
+* `<ips>`: Optional: IP addresses for the SR-IOV device that are allocated from the resource type defined in the SR-IOV network attachment definition CR. Both IPv4 and IPv6 addresses are supported. To use this feature, you also must specify `{ "ips": true }` in the `SriovNetwork` object.
+--
 
 . Apply the YAML:
 +
@@ -192,7 +195,7 @@ $ oc apply -f examplepod.yaml
 $ oc get pod -n sysctl-tuning-test
 ----
 +
-.Example output
+The following is example output:
 +
 [source,terminal]
 ----

--- a/modules/nw-configure-sysctl-interface-sriov-network.adoc
+++ b/modules/nw-configure-sysctl-interface-sriov-network.adoc
@@ -6,6 +6,7 @@
 [id="configuring-sysctl-on-sriov-network_{context}"]
 = Configuring sysctl on a SR-IOV network
 
+[role="_abstract"]
 You can set interface specific `sysctl` settings on virtual interfaces created by SR-IOV by adding the tuning configuration to the optional `metaPlugins` parameter of the `SriovNetwork` resource.
 
 The SR-IOV Network Operator manages additional network definitions. When you specify an additional SR-IOV network to create, the SR-IOV Network Operator creates the `NetworkAttachmentDefinition` custom resource (CR) automatically.
@@ -31,14 +32,14 @@ To change the interface-level network `net.ipv4.conf.IFNAME.accept_redirects` `s
 apiVersion: sriovnetwork.openshift.io/v1
 kind: SriovNetwork
 metadata:
-  name: onevalidflag <1>
-  namespace: openshift-sriov-network-operator <2>
+  name: onevalidflag
+  namespace: openshift-sriov-network-operator
 spec:
-  resourceName: policyoneflag <3>
-  networkNamespace: sysctl-tuning-test <4>
-  ipam: '{ "type": "static" }' <5>
-  capabilities: '{ "mac": true, "ips": true }' <6>
-  metaPlugins : | <7>
+  resourceName: policyoneflag
+  networkNamespace: sysctl-tuning-test
+  ipam: '{ "type": "static" }'
+  capabilities: '{ "mac": true, "ips": true }'
+  metaPlugins : |
     {
       "type": "tuning",
       "capabilities":{
@@ -49,13 +50,16 @@ spec:
       }
     }
 ----
-<1> A name for the object. The SR-IOV Network Operator creates a NetworkAttachmentDefinition object with same name.
-<2> The namespace where the SR-IOV Network Operator is installed.
-<3> The value for the `spec.resourceName` parameter from the `SriovNetworkNodePolicy` object that defines the SR-IOV hardware for this additional network.
-<4> The target namespace for the `SriovNetwork` object. Only pods in the target namespace can attach to the additional network.
-<5> A configuration object for the IPAM CNI plugin as a YAML block scalar. The plugin manages IP address assignment for the attachment definition.
-<6> Optional: Set capabilities for the additional network. You can specify `"{ "ips": true }"` to enable IP address support or `"{ "mac": true }"` to enable MAC address support.
-<7> Optional: The metaPlugins parameter is used to add additional capabilities to the device. In this use case set the `type` field to `tuning`. Specify the interface-level network `sysctl` you want to set in the `sysctl` field.
++
+--
+* `<name>` specifies a name for the object. The SR-IOV Network Operator creates a NetworkAttachmentDefinition object with same name.
+* `<namespace>` specifies the namespace where the SR-IOV Network Operator is installed.
+* `<resourceName>` specifies the value for the `spec.resourceName` parameter from the `SriovNetworkNodePolicy` object that defines the SR-IOV hardware for this additional network.
+* `<networkNamespace>` specifies the target namespace for the `SriovNetwork` object. Only pods in the target namespace can attach to the additional network.
+* `<ipam>` specifies a configuration object for the IPAM CNI plugin as a YAML block scalar. The plugin manages IP address assignment for the attachment definition.
+* `<capabilities>` specifies optional capabilities for the additional network. You can specify `"{ "ips": true }"` to enable IP address support or `"{ "mac": true }"` to enable MAC address support.
+* `<metaPlugins>` specifies optional additional capabilities for the device. In this use case set the `type` field to `tuning`. Specify the interface-level network `sysctl` you want to set in the `sysctl` field.
+--
 
 . Create the `SriovNetwork` resource:
 +
@@ -64,24 +68,23 @@ spec:
 $ oc create -f sriov-network-interface-sysctl.yaml
 ----
 
-.Verifying that the `NetworkAttachmentDefinition` CR is successfully created
+.Verification
 
 * Confirm that the SR-IOV Network Operator created the `NetworkAttachmentDefinition` CR by running the following command:
 +
 [source,terminal]
 ----
-$ oc get network-attachment-definitions -n <namespace> <1>
+$ oc get network-attachment-definitions -n <namespace>
 ----
-<1> Replace `<namespace>` with the value for `networkNamespace` that you specified in the `SriovNetwork` object. For example, `sysctl-tuning-test`. The expected output shows the name of the NAD CRD and the creation age in minutes.
++
+--
+* Replace `<namespace>` with the value for `networkNamespace` that you specified in the `SriovNetwork` object. For example, `sysctl-tuning-test`. The expected output shows the name of the NAD CRD and the creation age in minutes.
+--
 +
 [NOTE]
 ====
 There might be a delay before the SR-IOV Network Operator creates the CR.
 ====
-
-.Verifying that the additional SR-IOV network attachment is successful
-
-To verify that the tuning CNI is correctly configured and the additional SR-IOV network attachment is attached, do the following:
 
 . Create a `Pod` CR. Save the following YAML as the file `examplepod.yaml`:
 +
@@ -96,9 +99,9 @@ metadata:
     k8s.v1.cni.cncf.io/networks: |-
       [
         {
-          "name": "onevalidflag",  <1>
-          "mac": "0a:56:0a:83:04:0c", <2>
-          "ips": ["10.100.100.200/24"] <3>
+          "name": "onevalidflag",
+          "mac": "0a:56:0a:83:04:0c",
+          "ips": ["10.100.100.200/24"]
        }
       ]
 spec:
@@ -117,9 +120,12 @@ spec:
     seccompProfile:
       type: RuntimeDefault
 ----
-<1> The name of the SR-IOV network attachment definition CR.
-<2> Optional: The MAC address for the SR-IOV device that is allocated from the resource type defined in the SR-IOV network attachment definition CR. To use this feature, you also must specify `{ "mac": true }` in the SriovNetwork object.
-<3> Optional: IP addresses for the SR-IOV device that are allocated from the resource type defined in the SR-IOV network attachment definition CR. Both IPv4 and IPv6 addresses are supported. To use this feature, you also must specify `{ "ips": true }` in the `SriovNetwork` object.
++
+--
+* `<name>` specifies the name of the SR-IOV network attachment definition CR.
+* `<mac>` is optional. The MAC address for the SR-IOV device that is allocated from the resource type defined in the SR-IOV network attachment definition CR. To use this feature, you also must specify `{ "mac": true }` in the SriovNetwork object.
+* `<ips>` is optional. IP addresses for the SR-IOV device that are allocated from the resource type defined in the SR-IOV network attachment definition CR. Both IPv4 and IPv6 addresses are supported. To use this feature, you also must specify `{ "ips": true }` in the `SriovNetwork` object.
+--
 
 . Create the `Pod` CR:
 +
@@ -135,7 +141,7 @@ $ oc apply -f examplepod.yaml
 $ oc get pod -n sysctl-tuning-test
 ----
 +
-.Example output
+The following is example output:
 +
 [source,terminal]
 ----
@@ -150,7 +156,7 @@ tunepod   1/1     Running   0          47s
 $ oc rsh -n sysctl-tuning-test tunepod
 ----
 
-. Verify the values of the configured sysctl flag. Find the value  `net.ipv4.conf.IFNAME.accept_redirects` by running the following command::
+. Verify the values of the configured sysctl flag. Find the value  `net.ipv4.conf.IFNAME.accept_redirects` by running the following command:
 +
 [source,terminal]
 ----

--- a/modules/nw-enable-all-multicast-mode-sriov-network.adoc
+++ b/modules/nw-enable-all-multicast-mode-sriov-network.adoc
@@ -6,6 +6,7 @@
 [id="enabling-all-multicast-sriov-network_{context}"]
 = Enabling the all-multicast mode on an SR-IOV network
 
+[role="_abstract"]
 You can enable the all-multicast mode on an SR-IOV interface by:
 
 * Adding the tuning configuration to the `metaPlugins` parameter of the `SriovNetwork` resource
@@ -84,15 +85,15 @@ $ oc create namespace enable-allmulti-test
 apiVersion: sriovnetwork.openshift.io/v1
 kind: SriovNetwork
 metadata:
-  name: enableallmulti <1>
-  namespace: openshift-sriov-network-operator <2>
+  name: enableallmulti
+  namespace: openshift-sriov-network-operator
 spec:
-  resourceName: enableallmulti <3>
-  networkNamespace: enable-allmulti-test <4>
-  ipam: '{ "type": "static" }' <5>
-  capabilities: '{ "mac": true, "ips": true }' <6>
-  trust: "on" <7>
-  metaPlugins : | <8>
+  resourceName: enableallmulti
+  networkNamespace: enable-allmulti-test
+  ipam: '{ "type": "static" }'
+  capabilities: '{ "mac": true, "ips": true }'
+  trust: "on"
+  metaPlugins : |
     {
       "type": "tuning",
       "capabilities":{
@@ -102,14 +103,17 @@ spec:
       }
     }
 ----
-<1> Specify a name for the object. The SR-IOV Network Operator creates a `NetworkAttachmentDefinition` object with the same name.
-<2> Specify the namespace where the SR-IOV Network Operator is installed.
-<3> Specify a value for the `spec.resourceName` parameter from the `SriovNetworkNodePolicy` object that defines the SR-IOV hardware for this additional network.
-<4> Specify the target namespace for the `SriovNetwork` object. Only pods in the target namespace can attach to the additional network.
-<5> Specify a configuration object for the IPAM CNI plugin as a YAML block scalar. The plugin manages IP address assignment for the attachment definition.
-<6> Optional: Set capabilities for the additional network. You can specify `"{ "ips": true }"` to enable IP address support or `"{ "mac": true }"` to enable MAC address support.
-<7> Specify the trust mode of the virtual function. This must be set to "on".
-<8> Add more capabilities to the device by using the `metaPlugins` parameter. In this use case, set the `type` field to `tuning`, and add the `allmulti` field and set it to `true`.
++
+--
+* Replace `<name>` with a name for the object. The SR-IOV Network Operator creates a `NetworkAttachmentDefinition` object with the same name.
+* Replace `<namespace>` with the namespace where the SR-IOV Network Operator is installed.
+* Replace `<resourceName>` with a value for the `spec.resourceName` parameter from the `SriovNetworkNodePolicy` object that defines the SR-IOV hardware for this additional network.
+* Replace `<networkNamespace>` with the target namespace for the `SriovNetwork` object. Only pods in the target namespace can attach to the additional network.
+* Replace `<ipam>` with a configuration object for the IPAM CNI plugin as a YAML block scalar. The plugin manages IP address assignment for the attachment definition.
+* Optional: Set capabilities for the additional network. You can specify `"{ "ips": true }"` to enable IP address support or `"{ "mac": true }"` to enable MAC address support.
+* Specify the trust mode of the virtual function. This must be set to "on".
+* Add more capabilities to the device by using the `metaPlugins` parameter. In this use case, set the `type` field to `tuning`, and add the `allmulti` field and set it to `true`.
+--
 
 . Create the `SriovNetwork` resource by running the following command:
 +
@@ -118,15 +122,18 @@ spec:
 $ oc create -f sriov-enable-all-multicast.yaml
 ----
 
-.Verification of the `NetworkAttachmentDefinition` CR
+.Verification
 
 * Confirm that the SR-IOV Network Operator created the `NetworkAttachmentDefinition` CR by running the following command:
 +
 [source,terminal]
 ----
-$ oc get network-attachment-definitions -n <namespace> <1>
+$ oc get network-attachment-definitions -n <namespace>
 ----
-<1> Replace `<namespace>` with the value for `networkNamespace` that you specified in the `SriovNetwork` object. For this example, that is `enable-allmulti-test`. The expected output shows the name of the NAD CR and the creation age in minutes.
++
+--
+* Replace `<namespace>` with the value for `networkNamespace` that you specified in the `SriovNetwork` object. For this example, that is `enable-allmulti-test`. The expected output shows the name of the NAD CR and the creation age in minutes.
+--
 +
 [NOTE]
 ====
@@ -140,11 +147,7 @@ There might be a delay before the SR-IOV Network Operator creates the CR.
 $ oc get sriovnetwork -n openshift-sriov-network-operator
 ----
 
-.Verification of the additional SR-IOV network attachment
-
-To verify that the tuning CNI is correctly configured and that the additional SR-IOV network attachment is attached, follow these steps:
-
-. Create a `Pod` CR. Save the following sample YAML in a file named `examplepod.yaml`:
+. To verify that the tuning CNI is correctly configured and that the additional SR-IOV network attachment is attached, create a `Pod` CR. Save the following sample YAML in a file named `examplepod.yaml`:
 +
 [source,yaml]
 ----
@@ -157,9 +160,9 @@ metadata:
     k8s.v1.cni.cncf.io/networks: |-
       [
         {
-          "name": "enableallmulti",  <1>
-          "mac": "0a:56:0a:83:04:0c", <2>
-          "ips": ["10.100.100.200/24"] <3>
+          "name": "enableallmulti",
+          "mac": "0a:56:0a:83:04:0c",
+          "ips": ["10.100.100.200/24"]
        }
       ]
 spec:
@@ -178,9 +181,12 @@ spec:
     seccompProfile:
       type: RuntimeDefault
 ----
-<1> Specify the name of the SR-IOV network attachment definition CR.
-<2> Optional: Specify the MAC address for the SR-IOV device that is allocated from the resource type defined in the SR-IOV network attachment definition CR. To use this feature, you also must specify `{"mac": true}` in the SriovNetwork object.
-<3> Optional: Specify the IP addresses for the SR-IOV device that are allocated from the resource type defined in the SR-IOV network attachment definition CR. Both IPv4 and IPv6 addresses are supported. To use this feature, you also must specify `{ "ips": true }` in the `SriovNetwork` object.
++
+--
+* Replace `<name>` with the name of the SR-IOV network attachment definition CR.
+* Optional: Specify the MAC address for the SR-IOV device that is allocated from the resource type defined in the SR-IOV network attachment definition CR. To use this feature, you also must specify `{"mac": true}` in the SriovNetwork object.
+* Optional: Specify the IP addresses for the SR-IOV device that are allocated from the resource type defined in the SR-IOV network attachment definition CR. Both IPv4 and IPv6 addresses are supported. To use this feature, you also must specify `{ "ips": true }` in the `SriovNetwork` object.
+--
 
 . Create the `Pod` CR by running the following command:
 +
@@ -196,7 +202,7 @@ $ oc apply -f examplepod.yaml
 $ oc get pod -n enable-allmulti-test
 ----
 +
-.Example output
+The following is example output:
 +
 [source,terminal]
 ----
@@ -218,16 +224,19 @@ $ oc rsh -n enable-allmulti-test samplepod
 sh-4.4# ip link
 ----
 +
-.Example output
+The following is example output:
++
 [source,terminal]
 ----
 1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN mode DEFAULT group default qlen 1000
     link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
 2: eth0@if22: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 8901 qdisc noqueue state UP mode DEFAULT group default
-    link/ether 0a:58:0a:83:00:10 brd ff:ff:ff:ff:ff:ff link-netnsid 0 <1>
+    link/ether 0a:58:0a:83:00:10 brd ff:ff:ff:ff:ff:ff link-netnsid 0
 3: net1@if24: <BROADCAST,MULTICAST,ALLMULTI,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP mode DEFAULT group default
-    link/ether ee:9b:66:a4:ec:1d brd ff:ff:ff:ff:ff:ff link-netnsid 0 <2>
+    link/ether ee:9b:66:a4:ec:1d brd ff:ff:ff:ff:ff:ff link-netnsid 0
 ----
 +
-<1> `eth0@if22` is the primary interface
-<2> `net1@if24` is the secondary interface configured with the network-attachment-definition that supports the all-multicast mode (`ALLMULTI` flag)
+--
+* `eth0@if22` is the primary interface.
+* `net1@if24` is the secondary interface configured with the network-attachment-definition that supports the all-multicast mode (`ALLMULTI` flag).
+--

--- a/modules/nw-label-nodes-with-sriov.adoc
+++ b/modules/nw-label-nodes-with-sriov.adoc
@@ -6,7 +6,10 @@
 [id="nw-labeling-sriov-enabled-nodes_{context}"]
 = Labeling nodes with an SR-IOV enabled NIC
 
-If you want to enable SR-IOV on only SR-IOV capable nodes there are a couple of ways to do this:
+[role="_abstract"]
+If you want to enable SR-IOV on only SR-IOV capable nodes there are a couple of ways to do this.
+
+.Procedure
 
 . Install the Node Feature Discovery (NFD) Operator. NFD detects the presence of SR-IOV enabled NICs and labels the nodes with `node.alpha.kubernetes-incubator.io/nfd-network-sriov.capable = true`.
 

--- a/modules/nw-sriov-about-all-multi-cast-mode.adoc
+++ b/modules/nw-sriov-about-all-multi-cast-mode.adoc
@@ -6,6 +6,7 @@
 [id="nw-about-all-multi-cast-mode_{context}"]
 = About all-multicast mode
 
+[role="_abstract"]
 Enabling all-multicast mode, particularly in the context of rootless applications, is critical. If you do not enable this mode, you would be required to grant the `NET_ADMIN` capability to the pod's Security Context Constraints (SCC). If you were to allow the `NET_ADMIN` capability to grant the pod privileges to make changes that extend beyond its specific requirements, you could potentially expose security vulnerabilities.
 
 The tuning CNI plugin supports changing several interface attributes, including all-multicast mode. By enabling this mode, you can allow applications running on Virtual Functions (VFs) that are configured on a SR-IOV network device to receive multicast traffic from applications on other VFs, whether attached to the same or different physical functions.

--- a/modules/nw-sriov-interface-level-sysctl-basic-node-policy.adoc
+++ b/modules/nw-sriov-interface-level-sysctl-basic-node-policy.adoc
@@ -6,6 +6,7 @@
 [id="nw-basic-example-setting-one-sysctl-flag-node-policy_{context}"]
 = Setting one sysctl flag on nodes with SR-IOV network devices
 
+[role="_abstract"]
 The SR-IOV Network Operator adds the `SriovNetworkNodePolicy.sriovnetwork.openshift.io` custom resource definition (CRD) to {product-title}. You can configure an SR-IOV network device by creating a `SriovNetworkNodePolicy` custom resource (CR).
 
 [NOTE]
@@ -26,34 +27,32 @@ Follow this procedure to create a `SriovNetworkNodePolicy` custom resource (CR).
 apiVersion: sriovnetwork.openshift.io/v1
 kind: SriovNetworkNodePolicy
 metadata:
-  name: policyoneflag <1>
-  namespace: openshift-sriov-network-operator <2>
+  name: policyoneflag
+  namespace: openshift-sriov-network-operator
 spec:
-  resourceName: policyoneflag <3>
-  nodeSelector: <4>
+  resourceName: policyoneflag
+  nodeSelector:
     feature.node.kubernetes.io/network-sriov.capable="true"
-  priority: 10 <5>
-  numVfs: 5 <6>
-  nicSelector: <7>
-    pfNames: ["ens5"] <8>
-  deviceType: "netdevice" <9>
-  isRdma: false <10>
+  priority: 10
+  numVfs: 5
+  nicSelector:
+    pfNames: ["ens5"]
+  deviceType: "netdevice"
+  isRdma: false
 ----
 +
-<1> The name for the custom resource object.
-<2> The namespace where the SR-IOV Network Operator is installed.
-<3> The resource name of the SR-IOV network device plugin. You can create multiple SR-IOV network node policies for a resource name.
-<4> The node selector specifies the nodes to configure. Only SR-IOV network devices on the selected nodes are configured. The SR-IOV Container Network Interface (CNI) plugin and device plugin are deployed on selected nodes only.
-<5> Optional: The priority is an integer value between `0` and `99`. A smaller value receives higher priority. For example, a priority of `10` is a higher priority than `99`. The default value is `99`.
-<6> The number of the virtual functions (VFs) to create for the SR-IOV physical network device. For an Intel network interface controller (NIC), the number of VFs cannot be larger than the total VFs supported by the device. For a Mellanox NIC, the number of VFs cannot be larger than `127`.
-<7> The NIC selector identifies the device for the Operator to configure. You do not have to specify values for all the parameters. It is recommended to identify the network device with enough precision to avoid selecting a device unintentionally.
-If you specify `rootDevices`, you must also specify a value for `vendor`, `deviceID`, or `pfNames`. If you specify both `pfNames` and `rootDevices` at the same time, ensure that they refer to the same device. If you specify a value for `netFilter`, then you do not need to specify any other parameter because a network ID is unique.
-<8> Optional: An array of one or more physical function (PF) names for the device.
-<9> Optional: The driver type for the virtual functions. The only allowed value is `netdevice`.
-For a Mellanox NIC to work in DPDK mode on bare metal nodes, set `isRdma` to `true`.
-<10> Optional: Configures whether to enable remote direct memory access (RDMA) mode. The default value is `false`.
-If the `isRdma` parameter is set to `true`, you can continue to use the RDMA-enabled VF as a normal network device. A device can be used in either mode.
-Set `isRdma` to `true` and additionally set `needVhostNet` to `true` to configure a Mellanox NIC for use with Fast Datapath DPDK applications.
+--
+* `<name>` specifies the name for the custom resource object.
+* `<namespace>` specifies the namespace where the SR-IOV Network Operator is installed.
+* `<resourceName>` specifies the resource name of the SR-IOV network device plugin. You can create multiple SR-IOV network node policies for a resource name.
+* `<nodeSelector>` specifies the node selector for the nodes to configure. Only SR-IOV network devices on the selected nodes are configured. The SR-IOV Container Network Interface (CNI) plugin and device plugin are deployed on selected nodes only.
+* `<priority>` is optional. The priority is an integer value between `0` and `99`. A smaller value receives higher priority. For example, a priority of `10` is a higher priority than `99`. The default value is `99`.
+* `<numVfs>` specifies the number of the virtual functions (VFs) to create for the SR-IOV physical network device. For an Intel network interface controller (NIC), the number of VFs cannot be larger than the total VFs supported by the device. For a Mellanox NIC, the number of VFs cannot be larger than `127`.
+* `<nicSelector>` identifies the device for the Operator to configure. You do not have to specify values for all the parameters. It is recommended to identify the network device with enough precision to avoid selecting a device unintentionally. If you specify `rootDevices`, you must also specify a value for `vendor`, `deviceID`, or `pfNames`. If you specify both `pfNames` and `rootDevices` at the same time, ensure that they refer to the same device. If you specify a value for `netFilter`, then you do not need to specify any other parameter because a network ID is unique.
+* `<pfNames>` is optional. An array of one or more physical function (PF) names for the device.
+* `<deviceType>` is optional. The driver type for the virtual functions. The only allowed value is `netdevice`. For a Mellanox NIC to work in DPDK mode on bare-metal nodes, set `isRdma` to `true`.
+* `<isRdma>` is optional. Configures whether to enable remote direct memory access (RDMA) mode. The default value is `false`. If the `isRdma` parameter is set to `true`, you can continue to use the RDMA-enabled VF as a normal network device. A device can be used in either mode. Set `isRdma` to `true` and additionally set `needVhostNet` to `true` to configure a Mellanox NIC for use with Fast Data Path DPDK applications.
+--
 +
 [NOTE]
 ====

--- a/modules/nw-sriov-interface-level-sysctl-basic.adoc
+++ b/modules/nw-sriov-interface-level-sysctl-basic.adoc
@@ -6,6 +6,7 @@
 [id="nw-setting-one-sysctl-flag_{context}"]
 = Setting one sysctl flag
 
+[role="_abstract"]
 You can set interface-level network `sysctl` settings for a pod connected to a SR-IOV network device.
 
 In this example, `net.ipv4.conf.IFNAME.accept_redirects` is set to `1` on the created virtual interfaces.

--- a/modules/nw-sriov-interface-level-sysctl-bonded-node-policy.adoc
+++ b/modules/nw-sriov-interface-level-sysctl-bonded-node-policy.adoc
@@ -2,10 +2,11 @@
 //
 // * networking/hardware_networks/configuring-interface-sysctl-sriov-device.adoc
 
-:_mod-docs-content-type: CONCEPT
+:_mod-docs-content-type: PROCEDURE
 [id="nw-setting-all-sysctls-flag-node-policy-bonded_{context}"]
 = Setting all sysctl flag on nodes with bonded SR-IOV network devices
 
+[role="_abstract"]
 The SR-IOV Network Operator adds the `SriovNetworkNodePolicy.sriovnetwork.openshift.io` custom resource definition (CRD) to {product-title}. You can configure an SR-IOV network device by creating a `SriovNetworkNodePolicy` custom resource (CR).
 
 [NOTE]
@@ -26,41 +27,39 @@ Follow this procedure to create a `SriovNetworkNodePolicy` custom resource (CR).
 apiVersion: sriovnetwork.openshift.io/v1
 kind: SriovNetworkNodePolicy
 metadata:
-  name: policyallflags <1>
-  namespace: openshift-sriov-network-operator <2>
+  name: policyallflags
+  namespace: openshift-sriov-network-operator
 spec:
-  resourceName: policyallflags <3>
-  nodeSelector: <4>
+  resourceName: policyallflags
+  nodeSelector:
     node.alpha.kubernetes-incubator.io/nfd-network-sriov.capable = `true`
-  priority: 10 <5>
-  numVfs: 5 <6>
-  nicSelector: <7>
-    pfNames: ["ens1f0"]  <8>
-  deviceType: "netdevice" <9>
-  isRdma: false <10>
+  priority: 10
+  numVfs: 5
+  nicSelector:
+    pfNames: ["ens1f0"]
+  deviceType: "netdevice"
+  isRdma: false
 ----
 +
-<1> The name for the custom resource object.
-<2> The namespace where the SR-IOV Network Operator is installed.
-<3> The resource name of the SR-IOV network device plugin. You can create multiple SR-IOV network node policies for a resource name.
-<4> The node selector specifies the nodes to configure. Only SR-IOV network devices on the selected nodes are configured. The SR-IOV Container Network Interface (CNI) plugin and device plugin are deployed on selected nodes only.
-<5> Optional: The priority is an integer value between `0` and `99`. A smaller value receives higher priority. For example, a priority of `10` is a higher priority than `99`. The default value is `99`.
-<6> The number of virtual functions (VFs) to create for the SR-IOV physical network device. For an Intel network interface controller (NIC), the number of VFs cannot be larger than the total VFs supported by the device. For a Mellanox NIC, the number of VFs cannot be larger than `127`.
-<7> The NIC selector identifies the device for the Operator to configure. You do not have to specify values for all the parameters. It is recommended to identify the network device with enough precision to avoid selecting a device unintentionally.
-If you specify `rootDevices`, you must also specify a value for `vendor`, `deviceID`, or `pfNames`. If you specify both `pfNames` and `rootDevices` at the same time, ensure that they refer to the same device. If you specify a value for `netFilter`, then you do not need to specify any other parameter because a network ID is unique.
-<8> Optional: An array of one or more physical function (PF) names for the device.
-<9> Optional: The driver type for the virtual functions. The only allowed value is `netdevice`.
-For a Mellanox NIC to work in DPDK mode on bare metal nodes, set `isRdma` to `true`.
-<10> Optional: Configures whether to enable remote direct memory access (RDMA) mode. The default value is `false`.
-If the `isRdma` parameter is set to `true`, you can continue to use the RDMA-enabled VF as a normal network device. A device can be used in either mode.
-Set `isRdma` to `true` and additionally set `needVhostNet` to `true` to configure a Mellanox NIC for use with Fast Datapath DPDK applications.
+--
+* `<name>` specifies the name for the custom resource object.
+* `<namespace>` specifies the namespace where the SR-IOV Network Operator is installed.
+* `<resourceName>` specifies the resource name of the SR-IOV network device plugin. You can create multiple SR-IOV network node policies for a resource name.
+* `<nodeSelector>` specifies the node selector for the nodes to configure. Only SR-IOV network devices on the selected nodes are configured. The SR-IOV Container Network Interface (CNI) plugin and device plugin are deployed on selected nodes only.
+* `<priority>` is optional. The priority is an integer value between `0` and `99`. A smaller value receives higher priority. For example, a priority of `10` is a higher priority than `99`. The default value is `99`.
+* `<numVfs>` specifies the number of virtual functions (VFs) to create for the SR-IOV physical network device. For an Intel network interface controller (NIC), the number of VFs cannot be larger than the total VFs supported by the device. For a Mellanox NIC, the number of VFs cannot be larger than `127`.
+* `<nicSelector>` identifies the device for the Operator to configure. You do not have to specify values for all the parameters. It is recommended to identify the network device with enough precision to avoid selecting a device unintentionally. If you specify `rootDevices`, you must also specify a value for `vendor`, `deviceID`, or `pfNames`. If you specify both `pfNames` and `rootDevices` at the same time, ensure that they refer to the same device. If you specify a value for `netFilter`, then you do not need to specify any other parameter because a network ID is unique.
+* `<pfNames>` is optional. An array of one or more physical function (PF) names for the device.
+* `<deviceType>` is optional. The driver type for the virtual functions. The only allowed value is `netdevice`. For a Mellanox NIC to work in DPDK mode on bare-metal nodes, set `isRdma` to `true`.
+* `<isRdma>` is optional. Configures whether to enable remote direct memory access (RDMA) mode. The default value is `false`. If the `isRdma` parameter is set to `true`, you can continue to use the RDMA-enabled VF as a normal network device. A device can be used in either mode. Set `isRdma` to `true` and additionally set `needVhostNet` to `true` to configure a Mellanox NIC for use with Fast Data Path DPDK applications.
+--
 +
 [NOTE]
 ====
 The `vfio-pci` driver type is not supported.
 ====
 +
-. Create the SriovNetworkNodePolicy object:
+. Create the `SriovNetworkNodePolicy` object:
 +
 [source,terminal]
 ----

--- a/modules/nw-sriov-interface-level-sysctl-bonded.adoc
+++ b/modules/nw-sriov-interface-level-sysctl-bonded.adoc
@@ -6,6 +6,7 @@
 [id="nw-configure-sysctl-settings-flag-bonded_{context}"]
 = Configuring sysctl settings for pods associated with bonded SR-IOV interface flag
 
+[role="_abstract"]
 You can set interface-level network `sysctl` settings for a pod connected to a bonded SR-IOV network device.
 
 In this example, the specific network interface-level `sysctl` settings that can be configured are set on the bonded interface.

--- a/networking/hardware_networks/configuring-interface-sysctl-sriov-device.adoc
+++ b/networking/hardware_networks/configuring-interface-sysctl-sriov-device.adoc
@@ -6,6 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 As a cluster administrator, you can change interface-level network sysctls and several interface attributes such as promiscuous mode, all-multicast mode, MTU, and MAC address by using the tuning Container Network Interface (CNI) meta plugin for a pod connected to a SR-IOV network device.
 
 Before you perform any tasks in the following documentation, ensure that you xref:../../networking/networking_operators/sr-iov-operator/installing-sriov-operator.adoc#installing-sriov-operator[installed the SR-IOV Network Operator].


### PR DESCRIPTION
## Summary
- Fix all AsciiDocDITA Vale errors across the SR-IOV sysctl assembly (`configuring-interface-sysctl-sriov-device.adoc`) and its 9 included modules for DITA conversion compatibility
- Add `[role="_abstract"]` short descriptions to all 10 files
- Convert 11 callout lists to DITA-compatible bulleted lists in open blocks
- Fix unsupported block titles (`.Verifying...`, `.Verification of...`, `.Example output`) to supported DITA task titles or lead-in sentences
- Merge duplicate `.Verification` sections into single sections
- Add missing `.Procedure` block title in `nw-label-nodes-with-sriov.adoc`
- Change `nw-sriov-interface-level-sysctl-bonded-node-policy.adoc` content type from CONCEPT to PROCEDURE
- Fix terminology: "bare metal nodes" → "bare-metal nodes", "Datapath" → "Data Path"

## Test plan
- [ ] Verify all files pass Vale AsciiDocDITA rules with no errors
- [ ] Verify AsciiDoc renders correctly with `asciibinder build`
- [ ] Review callout-to-bullet-list conversions for accuracy

🤖 Generated with [Claude Code](https://claude.com/claude-code)