### PR TITLE
TELCODOCS-2852: Add short description attributes for DITA conversion

### DIFF
--- a/modules/proc-switching-bf2-nic.adoc
+++ b/modules/proc-switching-bf2-nic.adoc
@@ -6,6 +6,7 @@
 [id="proc-switching-bf2-nic_{context}"]
 = Switching Bluefield-2 from DPU mode to NIC mode
 
+[role="_abstract"]
 Use the following procedure to switch Bluefield-2 from data processing units (DPU) mode to network interface controller (NIC) mode.
 
 [IMPORTANT]
@@ -26,6 +27,7 @@ Currently, only switching Bluefield-2 from DPU to NIC mode is supported. Switchi
 ----
 $ oc label node <node_name> node-role.kubernetes.io/sriov=
 ----
++
 --
 where:
 
@@ -84,13 +86,16 @@ spec:
           [Service]
           SuccessExitStatus=0 120
           RemainAfterExit=True
-          ExecStart=/bin/bash -c '/etc/default/switch_in_sriov_config_daemon.sh nic || shutdown -r now' <1>
+          ExecStart=/bin/bash -c '/etc/default/switch_in_sriov_config_daemon.sh nic || shutdown -r now'
           Type=oneshot
           [Install]
           WantedBy=multi-user.target
 ----
-<1> Optional: The PCI address of a specific card can optionally be specified, for example `ExecStart=/bin/bash -c '/etc/default/switch_in_sriov_config_daemon.sh nic 0000:5e:00.0 || echo done'`. By default, the first device is selected. If there is more than one device, you must specify which PCI address to be used. The PCI address must be the same on all nodes that are switching Bluefield-2 from DPU mode to NIC mode.
++
+--
+* `ExecStart` specifies the command to switch the Bluefield-2 into NIC mode. Optionally, you can specify the PCI address of a specific card, for example `ExecStart=/bin/bash -c '/etc/default/switch_in_sriov_config_daemon.sh nic 0000:5e:00.0 || echo done'`. By default, the first device is selected. If there is more than one device, you must specify which PCI address to use. The PCI address must be the same on all nodes that are switching Bluefield-2 from DPU mode to NIC mode.
+--
 
 . Wait for the compute nodes to restart. After restarting, the Bluefield-2 network device on the compute nodes is switched into NIC mode.
 
-. Optional: You might need to restart the host hardware because most recent Bluefield-2 firmware releases require a hardware restart to switch into NIC mode. 
+. Optional: You might need to restart the host hardware because most recent Bluefield-2 firmware releases require a hardware restart to switch into NIC mode.

--- a/networking/hardware_networks/switching-bf2-nic-dpu.adoc
+++ b/networking/hardware_networks/switching-bf2-nic-dpu.adoc
@@ -6,6 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 You can switch the Bluefield-2 network device from data processing unit (DPU) mode to network interface controller (NIC) mode.
 
 Before you perform any tasks in the following documentation, ensure that you xref:../../networking/networking_operators/sr-iov-operator/installing-sriov-operator.adoc#installing-sriov-operator[installed the SR-IOV Network Operator].


### PR DESCRIPTION
## Summary
- Add `[role="_abstract"]` to the Bluefield-2 DPU-to-NIC assembly and procedure module to fix AsciiDocDITA `ShortDescription` errors for DITA conversion compatibility.

## Test plan
- [ ] Verify Vale reports no AsciiDocDITA errors on either file
- [ ] Confirm AsciiDoc renders correctly with `asciibinder build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)