### PR TITLE
OSDOCS 18820 Managing boot images for ControlPlaneMachineSets (GA)

### DIFF
--- a/machine_configuration/mco-update-boot-images.adoc
+++ b/machine_configuration/mco-update-boot-images.adoc
@@ -10,9 +10,6 @@ include::snippets/mco-update-boot-images-abstract.adoc[]
 
 include::snippets/mco-update-boot-images-intro.adoc[]
 
-:FeatureName: Boot image management for control plane nodes
-include::snippets/technology-preview.adoc[]
-
 include::modules/mco-update-boot-images-about.adoc[leveloffset=+1]
 
 [role="_additional-resources"]

--- a/modules/mco-update-boot-images-configuring.adoc
+++ b/modules/mco-update-boot-images-configuring.adoc
@@ -24,10 +24,6 @@ Because the boot image management feature for worker nodes is default for the {g
 
 Enabling the feature updates the boot image to the {op-system-first} boot image version appropriate for your cluster. If the cluster is again updated to a new {product-title} version in the future, the boot image is updated again. New nodes created after enabling the feature use the updated boot image. This feature has no effect on existing nodes.
 
-.Prerequisites
-
-* If you are enabling boot image management for control plane machine sets, you enabled the required Technology Preview features for your cluster by editing the `FeatureGate` CR named `cluster`.
-
 .Procedure
 
 . Edit the `MachineConfiguration` object, named `cluster`, by using the following command:

--- a/nodes/nodes/nodes-update-boot-images.adoc
+++ b/nodes/nodes/nodes-update-boot-images.adoc
@@ -12,9 +12,6 @@ include::snippets/mco-update-boot-images-abstract.adoc[]
 
 include::snippets/mco-update-boot-images-intro.adoc[]
 
-:FeatureName: Boot image management for control plane nodes
-include::snippets/technology-preview.adoc[]
-
 include::modules/mco-update-boot-images-about.adoc[leveloffset=+1]
 
 include::modules/mco-update-boot-images-disable.adoc[leveloffset=+1]


### PR DESCRIPTION
https://redhat.atlassian.net/browse/OSDOCS-18820

Remove tech preview snippets and featureset prereq step. No technology changes from GA to TP. 

Link to docs preview:
Machine configuration -> [Boot image management](https://109199--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_configuration/mco-update-boot-images.html) -- No TP note.
Machine configuration -> [Enabling boot image management](https://109199--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_configuration/mco-update-boot-images.html#mco-update-boot-images-configuring_machine-configs-configure) -- No TP prerequisite.
Nodes -> Working with nodes -> [Boot image management](https://109199--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/nodes/nodes-update-boot-images) -- No TP note.

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
