### PR TITLE
TELCODOCS-2853: Fix AsciiDocDITA violations for hardware offloading docs

### DIFF
--- a/modules/nw-sriov-hwol-about-hardware-offloading.adoc
+++ b/modules/nw-sriov-hwol-about-hardware-offloading.adoc
@@ -6,6 +6,7 @@
 [id="about-hardware-offloading_{context}"]
 = About hardware offloading
 
+[role="_abstract"]
 Open vSwitch hardware offloading is a method of processing network tasks by diverting them away from the CPU and offloading them to a dedicated processor on a network interface controller.
 As a result, clusters can benefit from faster data transfer speeds, reduced CPU workloads, and lower computing costs.
 
@@ -14,7 +15,7 @@ A SmartNIC is a network interface controller that is able to handle computationa
 In the same way that a dedicated graphics card can improve graphics performance, a SmartNIC can improve network performance.
 In each case, a dedicated processor improves performance for a specific type of processing task.
 
-In {product-title}, you can configure hardware offloading for bare metal nodes that have a compatible SmartNIC.
+In {product-title}, you can configure hardware offloading for bare-metal nodes that have a compatible SmartNIC.
 Hardware offloading is configured and enabled by the SR-IOV Network Operator.
 
 Hardware offloading is not compatible with all workloads or application types.

--- a/modules/nw-sriov-hwol-adding-network-attachment-definitions-to-pods.adoc
+++ b/modules/nw-sriov-hwol-adding-network-attachment-definitions-to-pods.adoc
@@ -6,6 +6,7 @@
 [id="adding-network-attachment-definition-to-pods_{context}"]
 = Adding the network attachment definition to your pods
 
+[role="_abstract"]
 After you create the machine config pool, the `SriovNetworkPoolConfig` and `SriovNetworkNodePolicy` custom resources, and the network attachment definition, you can apply these configurations to your pods by adding the network attachment definition to your pod specifications.
 
 .Procedure
@@ -17,6 +18,9 @@ After you create the machine config pool, the `SriovNetworkPoolConfig` and `Srio
 ....
 metadata:
   annotations:
-    v1.multus-cni.io/default-network: net-attach-def/net-attach-def <1>
+    v1.multus-cni.io/default-network: <namespace>/<net_attach_def_name>
 ----
-<1> The value must be the name and namespace of the network attachment definition you created for hardware offloading.
++
+--
+* `<namespace>/<net_attach_def_name>` specifies the namespace and name of the network attachment definition you created for hardware offloading.
+--

--- a/modules/nw-sriov-hwol-configuring-machine-config-pool.adoc
+++ b/modules/nw-sriov-hwol-configuring-machine-config-pool.adoc
@@ -6,6 +6,7 @@
 [id="configuring-machine-config-pool_{context}"]
 = Configuring a machine config pool for hardware offloading
 
+[role="_abstract"]
 To enable hardware offloading, you now create a dedicated machine config pool and configure it to work with the SR-IOV Network Operator.
 
 .Prerequisites
@@ -16,24 +17,26 @@ To enable hardware offloading, you now create a dedicated machine config pool an
 
 . Create a machine config pool for machines you want to use hardware offloading on.
 
-.. Create a file, such as `mcp-offloading.yaml`, with content like the following example:
+.. Create a file, such as `mcp-offloading.yaml`, with content such as the following example:
 +
 [source,yaml]
 ----
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfigPool
 metadata:
-  name: mcp-offloading <1>
+  name: <mcp_name>
 spec:
   machineConfigSelector:
     matchExpressions:
-      - {key: machineconfiguration.openshift.io/role, operator: In, values: [worker,mcp-offloading]} <1>
+      - {key: machineconfiguration.openshift.io/role, operator: In, values: [worker,<mcp_name>]}
   nodeSelector:
     matchLabels:
-      node-role.kubernetes.io/mcp-offloading: "" <2>
+      node-role.kubernetes.io/<mcp_name>: ""
 ----
-<1> The name of your machine config pool for hardware offloading.
-<2> This node role label is used to add nodes to the machine config pool.
++
+--
+* `<mcp_name>` specifies the name of your machine config pool for hardware offloading. This value is used as the machine config pool name, the machine config selector value, and the node role label.
+--
 
 .. Apply the configuration for the machine config pool:
 +
@@ -57,7 +60,8 @@ $ oc get nodes
 ----
 +
 --
-.Example output
+The following is example output:
+
 [source,terminal]
 ----
 NAME       STATUS   ROLES                   AGE   VERSION
@@ -71,7 +75,7 @@ worker-2   Ready    mcp-offloading,worker   47h   v1.34.2
 
 . Add this machine config pool to the `SriovNetworkPoolConfig` custom resource:
 
-.. Create a file, such as `sriov-pool-config.yaml`, with content like the following example:
+.. Create a file, such as `sriov-pool-config.yaml`, with content such as the following example:
 +
 [source,yaml]
 ----
@@ -82,9 +86,12 @@ metadata:
   namespace: openshift-sriov-network-operator
 spec:
   ovsHardwareOffloadConfig:
-    name: mcp-offloading <1>
+    name: <mcp_name>
 ----
-<1> The name of your machine config pool for hardware offloading.
++
+--
+* `<mcp_name>` specifies the name of your machine config pool for hardware offloading.
+--
 
 .. Apply the configuration:
 +

--- a/modules/nw-sriov-hwol-configuring-systemd-mode.adoc
+++ b/modules/nw-sriov-hwol-configuring-systemd-mode.adoc
@@ -6,6 +6,7 @@
 [id="nw-sriov-hwol-configuring-systemd-mode_{context}"]
 = Setting the SR-IOV Network Operator into systemd mode
 
+[role="_abstract"]
 To support hardware offloading, you must first set the SR-IOV Network Operator into `systemd` mode.
 
 .Prerequisites
@@ -24,17 +25,19 @@ To support hardware offloading, you must first set the SR-IOV Network Operator i
 apiVersion: sriovnetwork.openshift.io/v1
 kind: SriovOperatorConfig
 metadata:
-  name: default <1>
+  name: default
   namespace: openshift-sriov-network-operator
 spec:
   enableInjector: true
   enableOperatorWebhook: true
-  configurationMode: "systemd" <2>
+  configurationMode: "systemd"
   logLevel: 2
 ----
 +
-<1> The only valid name for the `SriovOperatorConfig` resource is `default` and it must be in the namespace where the Operator is deployed.
-<2> Setting the SR-IOV Network Operator into `systemd` mode is only relevant for Open vSwitch hardware offloading. 
+--
+* The only valid name for the `SriovOperatorConfig` resource is `default` and it must be in the namespace where the Operator is deployed.
+* Setting the SR-IOV Network Operator into `systemd` mode is only relevant for Open vSwitch hardware offloading.
+--
 
 .. Create the resource by running the following command:
 +

--- a/modules/nw-sriov-hwol-creating-network-attachment-definition.adoc
+++ b/modules/nw-sriov-hwol-creating-network-attachment-definition.adoc
@@ -6,7 +6,8 @@
 [id="create-network-attachment-definition_{context}"]
 = Creating a network attachment definition
 
-After you define the machine config pool and the SR-IOV network node policy, you can create a network attachment definition for the network interface card you specified.
+[role="_abstract"]
+After you define the machine config pool and the SR-IOV network node policy, you can create a network attachment definition for the network interface controller (NIC) you specified.
 
 .Prerequisites
 
@@ -15,23 +16,26 @@ After you define the machine config pool and the SR-IOV network node policy, you
 
 .Procedure
 
-. Create a file, such as `net-attach-def.yaml`, with content like the following example:
+. Create a file, such as `net-attach-def.yaml`, with content such as the following example:
 +
 [source,yaml]
 ----
 apiVersion: "k8s.cni.cncf.io/v1"
 kind: NetworkAttachmentDefinition
 metadata:
-  name: net-attach-def <1>
-  namespace: net-attach-def <2>
+  name: <net_attach_def_name>
+  namespace: <net_attach_def_namespace>
   annotations:
-    k8s.v1.cni.cncf.io/resourceName: openshift.io/mlxnics <3>
+    k8s.v1.cni.cncf.io/resourceName: openshift.io/<resource_name>
 spec:
   config: '{"cniVersion":"0.3.1","name":"ovn-kubernetes","type":"ovn-k8s-cni-overlay","ipam":{},"dns":{}}'
 ----
-<1> The name for your network attachment definition.
-<2> The namespace for your network attachment definition.
-<3> This is the value of the `spec.resourceName` field you specified in the `SriovNetworkNodePolicy` object.
++
+--
+* `<net_attach_def_name>` specifies the name for your network attachment definition.
+* `<net_attach_def_namespace>` specifies the namespace for your network attachment definition.
+* `<resource_name>` specifies the value of the `spec.resourceName` field from the `SriovNetworkNodePolicy` object.
+--
 
 . Apply the configuration for the network attachment definition:
 +

--- a/modules/nw-sriov-hwol-creating-sriov-policy.adoc
+++ b/modules/nw-sriov-hwol-creating-sriov-policy.adoc
@@ -6,6 +6,7 @@
 [id="configure-sriov-node-policy_{context}"]
 = Configuring the SR-IOV network node policy
 
+[role="_abstract"]
 You can create an SR-IOV network device configuration for a node by creating an SR-IOV network node policy.
 To enable hardware offloading, you must define the `.spec.eSwitchMode` field with the value `"switchdev"`.
 
@@ -18,18 +19,18 @@ The following procedure creates an SR-IOV interface for a network interface cont
 
 .Procedure
 
-. Create a file, such as `sriov-node-policy.yaml`, with content like the following example:
+. Create a file, such as `sriov-node-policy.yaml`, with content such as the following example:
 +
 [source,yaml]
 ----
 apiVersion: sriovnetwork.openshift.io/v1
 kind: SriovNetworkNodePolicy
 metadata:
-  name: sriov-node-policy <1>
+  name: <name>
   namespace: openshift-sriov-network-operator
 spec:
-  deviceType: netdevice <2>
-  eSwitchMode: "switchdev" <3>
+  deviceType: netdevice
+  eSwitchMode: "switchdev"
   nicSelector:
     deviceID: "1019"
     rootDevices:
@@ -43,9 +44,12 @@ spec:
   priority: 5
   resourceName: mlxnics
 ----
-<1> The name for the custom resource object.
-<2> Required. Hardware offloading is not supported with `vfio-pci`.
-<3> Required.
++
+--
+* `<name>` specifies the name for the custom resource object.
+* The `deviceType` field must be set to `netdevice`. Hardware offloading is not supported with `vfio-pci`.
+* The `eSwitchMode` field must be set to `"switchdev"`.
+--
 
 . Apply the configuration for the policy:
 +

--- a/modules/nw-sriov-hwol-improving-network-traffic-performance.adoc
+++ b/modules/nw-sriov-hwol-improving-network-traffic-performance.adoc
@@ -6,6 +6,7 @@
 [id="improving-network-traffic-performance-using-vf_{context}"]
 = Improving network traffic performance using a virtual function
 
+[role="_abstract"]
 Follow this procedure to assign a virtual function to the OVN-Kubernetes management port and increase its network traffic performance.
 
 This procedure results in the creation of two pools: the first has a virtual function used by OVN-Kubernetes, and the second comprises the remaining virtual functions.
@@ -44,15 +45,18 @@ spec:
     - 0000:d8:00.0
     vendor: "15b3"
     pfNames:
-    - ens8f0#0-0 <1>
+    - <pf_name>#0-0
   nodeSelector:
     network.operator.openshift.io/smart-nic: ""
-  numVfs: 6 <2>
+  numVfs: <num_vfs>
   priority: 5
   resourceName: mgmtvf
 ----
-<1> Replace this device with the appropriate network device for your use case. The `#0-0` part of the `pfNames` value reserves a single virtual function used by OVN-Kubernetes.
-<2> The value provided here is an example. Replace this value with one that meets your requirements. For more information, see _SR-IOV network node configuration object_ in the _Additional resources_ section.
++
+--
+* `<pf_name>` specifies the network device for your use case. The `#0-0` part of the `pfNames` value reserves a single virtual function used by OVN-Kubernetes.
+* `<num_vfs>` specifies the number of virtual functions. Replace this value with one that meets your requirements. For more information, see _SR-IOV network node configuration object_ in the _Additional resources_ section.
+--
 
 . Create a policy named `sriov-node-policy.yaml` with content such as the following example:
 +
@@ -72,15 +76,18 @@ spec:
     - 0000:d8:00.0
     vendor: "15b3"
     pfNames:
-    - ens8f0#1-5 <1>
+    - <pf_name>#1-5
   nodeSelector:
     network.operator.openshift.io/smart-nic: ""
-  numVfs: 6 <2>
+  numVfs: <num_vfs>
   priority: 5
   resourceName: mlxnics
 ----
-<1> Replace this device with the appropriate network device for your use case.
-<2> The value provided here is an example. Replace this value with the value specified in the `sriov-node-mgmt-vf-policy.yaml` file. For more information, see _SR-IOV network node configuration object_ in the _Additional resources_ section.
++
+--
+* `<pf_name>` specifies the network device for your use case.
+* `<num_vfs>` specifies the number of virtual functions. Replace this value with the value specified in the `sriov-node-mgmt-vf-policy.yaml` file. For more information, see _SR-IOV network node configuration object_ in the _Additional resources_ section.
+--
 +
 [NOTE]
 ====

--- a/modules/nw-sriov-hwol-prerequisites.adoc
+++ b/modules/nw-sriov-hwol-prerequisites.adoc
@@ -1,0 +1,15 @@
+// Module included in the following assemblies:
+//
+// * networking/hardware_networks/configuring-hardware-offloading.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="configuring-hardware-offloading-prerequisites_{context}"]
+= Prerequisites
+
+[role="_abstract"]
+Before you configure hardware offloading, ensure that the following conditions are met.
+
+* Your cluster has at least one bare-metal machine with a network interface controller that is supported for hardware offloading.
+* You installed the SR-IOV Network Operator.
+* Your cluster uses the OVN-Kubernetes network plugin.
+* In your OVN-Kubernetes network plugin configuration, the `gatewayConfig.routingViaHost` field is set to `false`.

--- a/modules/nw-sriov-hwol-ref-openstack-sriov-policy.adoc
+++ b/modules/nw-sriov-hwol-ref-openstack-sriov-policy.adoc
@@ -2,13 +2,15 @@
 //
 // * networking/configuring-hardware-offloading.adoc
 
-:_mod-docs-content-type: PROCEDURE
+:_mod-docs-content-type: REFERENCE
 [id="nw-sriov-hwol-ref-openstack-sriov-policy_{context}"]
 = An example SR-IOV network node policy for OpenStack
 
+[role="_abstract"]
 The following example describes an SR-IOV interface for a network interface controller (NIC) with hardware offloading on {rh-openstack-first}.
 
-.An SR-IOV interface for a NIC with hardware offloading on {rh-openstack}
+The following example shows an SR-IOV interface for a NIC with hardware offloading on {rh-openstack}:
+
 [source,yaml]
 ----
 apiVersion: sriovnetwork.openshift.io/v1

--- a/modules/nw-sriov-hwol-supported-devices.adoc
+++ b/modules/nw-sriov-hwol-supported-devices.adoc
@@ -6,6 +6,7 @@
 [id="supported_devices_{context}"]
 = Supported devices
 
+[role="_abstract"]
 Hardware offloading is supported on the following network interface controllers:
 
 .Supported network interface controllers

--- a/networking/hardware_networks/configuring-hardware-offloading.adoc
+++ b/networking/hardware_networks/configuring-hardware-offloading.adoc
@@ -6,6 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 As a cluster administrator, you can configure hardware offloading on compatible nodes to increase data processing performance and reduce load on host CPUs.
 
 Before you perform any tasks in the following documentation, ensure that you xref:../../networking/networking_operators/sr-iov-operator/installing-sriov-operator.adoc#installing-sriov-operator[installed the SR-IOV Network Operator].
@@ -18,13 +19,13 @@ include::modules/nw-sriov-hwol-about-hardware-offloading.adoc[leveloffset=+1]
 
 include::modules/nw-sriov-hwol-supported-devices.adoc[leveloffset=+1]
 
-[id="configuring-hardware-offloading-prerequisites"]
-== Prerequisites
+include::modules/nw-sriov-hwol-prerequisites.adoc[leveloffset=+1]
 
-* Your cluster has at least one bare metal machine with a network interface controller that is supported for hardware offloading.
-* You xref:../../networking/networking_operators/sr-iov-operator/installing-sriov-operator.adoc#installing-sriov-operator[installed the SR-IOV Network Operator].
-* Your cluster uses the xref:../../networking/ovn_kubernetes_network_provider/about-ovn-kubernetes.adoc#about-ovn-kubernetes[OVN-Kubernetes network plugin].
-* In your xref:../../networking/networking_operators/cluster-network-operator.adoc#gatewayConfig-object_cluster-network-operator[OVN-Kubernetes network plugin configuration], the `gatewayConfig.routingViaHost` field is set to `false`.
+[role="_additional-resources"]
+.Additional resources
+* xref:../../networking/networking_operators/sr-iov-operator/installing-sriov-operator.adoc#installing-sriov-operator[Installing the SR-IOV Network Operator]
+* xref:../../networking/ovn_kubernetes_network_provider/about-ovn-kubernetes.adoc#about-ovn-kubernetes[About the OVN-Kubernetes network plugin]
+* xref:../../networking/networking_operators/cluster-network-operator.adoc#gatewayConfig-object_cluster-network-operator[OVN-Kubernetes network plugin configuration]
 
 //Configure a machine config pool for hardware offloading
 include::modules/nw-sriov-hwol-configuring-systemd-mode.adoc[leveloffset=+1]


### PR DESCRIPTION
## Summary
- Add `[role="_abstract"]` short descriptions to all 10 files (assembly + 9 modules)
- Replace all callout lists with DITA-compatible bullet lists using user-replaceable `<value>` placeholders (8 instances across 5 modules)
- Extract inline Prerequisites section from assembly into new `nw-sriov-hwol-prerequisites.adoc` module with adjusted xref paths
- Change `nw-sriov-hwol-ref-openstack-sriov-policy.adoc` content type from PROCEDURE to REFERENCE and convert unsupported block title to normal text
- Convert `.Example output` block title to lead-in sentence in `nw-sriov-hwol-configuring-machine-config-pool.adoc`
- Fix terminology: "bare metal" → "bare-metal", "network interface card" → "network interface controller (NIC)", "like" → "such as"

## Test plan
- [ ] Verify Vale AsciiDocDITA rules pass with no errors or warnings (except legitimate spelling: vSwitch, Dx)
- [ ] Verify `asciibinder build` completes without errors
- [ ] Review rendered output for the hardware offloading assembly
- [ ] Confirm xref paths in the new prerequisites module resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)