### PR TITLE
TELCODOCS-2854: Fix AsciiDocDITA violations for SR-IOV QinQ docs

### DIFF
--- a/modules/nw-configuring-qinq-sriov-proc.adoc
+++ b/modules/nw-configuring-qinq-sriov-proc.adoc
@@ -9,6 +9,9 @@
 [id="nw-configuring-qinq-sriov-proc_{context}"]
 = Configuring QinQ support for SR-IOV enabled workloads
 
+[role="_abstract"]
+Configure QinQ support for SR-IOV enabled workloads to enable double VLAN tagging on your cluster.
+
 .Prerequisites
 
 * You have installed the OpenShift CLI (`oc`).
@@ -72,14 +75,16 @@ metadata:
   namespace: openshift-sriov-network-operator
 spec:
   ipam: '{}'
-  vlan: 171 <1>
-  vlanProto: "802.1ad" <2>
+  vlan: <vlan_id>
+  vlanProto: <vlan_protocol>
   networkNamespace: default
   resourceName: resource810
 ----
 +
-<1> Sets the S-tag VLAN tag to `171`. 
-<2> Specifies the VLAN protocol to assign to the virtual function (VF). Supported values are `802.1ad` and `802.1q`. The default value is `802.1q`. 
+--
+* `<vlan_id>` specifies the S-tag VLAN tag, for example `171`.
+* `<vlan_protocol>` specifies the VLAN protocol to assign to the virtual function (VF). Supported values are `802.1ad` and `802.1q`. The default value is `802.1q`.
+--
 
 .. Create the object by running the following command:
 +
@@ -105,13 +110,15 @@ spec:
     "cniVersion": "0.3.1",
     "type": "vlan",
     "linkInContainer": true,
-    "master": "net1", <1>
+    "master": "<vf_interface>",
     "vlanId": 100,
     "ipam": {"type": "static"}
   }'
 ----
 +
-<1> Specifies the VF interface inside the pod. The default name is `net1` as the name is not set in the pod annotation. 
+--
+* `<vf_interface>` specifies the VF interface inside the pod. The default name is `net1` because the name is not set in the pod annotation.
+--
 
 .. Apply the YAML file by running the following command:
 +

--- a/modules/nw-sriov-about-qinq.adoc
+++ b/modules/nw-sriov-about-qinq.adoc
@@ -7,6 +7,7 @@
 [id="nw-about-qinq-support_{context}"]
 = About 802.1Q-in-802.1Q support
 
+[role="_abstract"]
 In traditional VLAN setups, frames typically contain a single VLAN tag, such as VLAN-100, as well as other metadata such as Quality of Service (QoS) bits and protocol information. QinQ introduces a second VLAN tag, where the service provider designates the outer tag for their use, offering them flexibility, while the inner tag remains dedicated to the customer's VLAN.
 
 QinQ facilitates the creation of nested VLANs by using double VLAN tagging, enabling finer segmentation and isolation of traffic within a network environment. This approach is particularly valuable in service provider networks where you need to deliver VLAN-based services to multiple customers over a common infrastructure, while ensuring separation and isolation of traffic.

--- a/networking/hardware_networks/configuring-sriov-qinq-support.adoc
+++ b/networking/hardware_networks/configuring-sriov-qinq-support.adoc
@@ -6,6 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 QinQ, formally known as 802.1Q-in-802.1Q, is a networking technique defined by IEEE 802.1ad. IEEE 802.1ad extends the IEEE 802.1Q-1998 standard and enriches VLAN capabilities by introducing an additional 802.1Q tag to packets already tagged with 802.1Q. This method is also referred to as VLAN stacking or double VLAN.
 
 Before you perform any tasks in the following documentation, ensure that you xref:../../networking/networking_operators/sr-iov-operator/installing-sriov-operator.adoc#installing-sriov-operator[installed the SR-IOV Network Operator].


### PR DESCRIPTION
## Summary
- Add `[role="_abstract"]` short descriptions to the assembly and both included modules for DITA conversion compatibility
- Convert callout lists to bullet lists with user-replaceable placeholders in the SR-IOV QinQ procedure module

## Test plan
- [ ] Verify Vale reports zero AsciiDocDITA errors on all three files
- [ ] Verify AsciiDoc renders correctly with `asciibinder build`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)