### PR TITLE
TELCODOCS-2855: Fix AsciiDocDITA issues for namespaced SR-IOV modules

### DIFF
--- a/modules/nw-configuring-sriov-in-app-namespace.adoc
+++ b/modules/nw-configuring-sriov-in-app-namespace.adoc
@@ -6,6 +6,7 @@
 [id="nw-configuring-sriov-in-app-namespace_{context}"]
 = Configuring SriovNetwork in application namespaces
 
+[role="_abstract"]
 When an SriovNetwork custom resource (CR) is deployed in an application namespace, do not define or populate the `spec.networkNamespace` field. In this scenario, the NetworkAttachmentDefinition will be created in the same namespace as the SriovNetwork CR.
 
 The SR-IOV Network Operator webhook rejects the creation of an `SriovNetwork` resource in an application namespace if the `spec.networkNamespace` field is defined.
@@ -76,8 +77,11 @@ spec:
         gw: "10.0.0.1"
   vlan: 10
 ----
++
+--
 * `namespace`: The value must match the name of the application namespace, for example, `sriov-app`.
 * `resourceName`: This value must match the `spec.resourceName` defined in the `SriovNetworkNodePolicy` created by the cluster administrator, which in the example is `intelnics`.
+--
 
 . Apply the YAML file to create the `SriovNetwork` object in the application namespace.
 +
@@ -106,8 +110,10 @@ spec:
     command: ["/bin/bash", "-c", "sleep 3600"]
 ----
 +
+--
 * `namespace`: The namespace where the pod is created. This must be the same namespace where the `SriovNetwork` object is created.
-* `annotations`: `k8s.v1.cni.cncf.io/networks` specifies the additional network that the pod connects to. The value must match the `metadata.name` of the `SriovNetwork` object.  
+* `annotations`: `k8s.v1.cni.cncf.io/networks` specifies the additional network that the pod connects to. The value must match the `metadata.name` of the `SriovNetwork` object.
+--
 
 . Apply the YAML file to create the pod in the application namespace by running the following command:
 +
@@ -127,7 +133,7 @@ $ oc get net-attach-def -n sriov-app
 +
 Where `sriov-app` is the application namespace where the `SriovNetwork` object is created.
 +
-.Example output
+The following is example output:
 +
 [source,terminal]
 ----

--- a/modules/nw-introduction-namespaced-sriov.adoc
+++ b/modules/nw-introduction-namespaced-sriov.adoc
@@ -6,10 +6,11 @@
 [id="introduction-to-namespaced-sriovnetwork-resources_{context}"]
 = An introduction to namespaced SriovNetwork resources
 
+[role="_abstract"]
 SR-IOV networks can be created and managed directly within application namespaces. This capability provides application owners with fine-grained control over network configurations, simplifying their workflow.
 
 This approach offers several key advantages that enhance the user experience:
 
 * Increased Autonomy and Control: Application owners gain direct control over their network configurations, eliminating the need for a cluster administrator to create `SriovNetwork` objects on their behalf.
-* Enhanced Security: By allowing users to manage resources within their own namespaces, the feature improves security and provides better separation between applications. This also helps avoid the unintentional misconfiguration of other applications' NetworkAttachmentDefinition objects.
-* Simplified Permissions: Managing `SriovNetwork` resources directly in their own namespaces simplifies user permissions. This streamlines the workflow and reduces the operational overhead for developers. 
+* Enhanced Security: By allowing users to manage resources within their own namespaces, the feature improves security and provides better separation between applications. This also helps avoid the unintentional incorrect configuration of other applications' NetworkAttachmentDefinition objects.
+* Simplified Permissions: Managing `SriovNetwork` resources directly in their own namespaces simplifies user permissions. This streamlines the workflow and reduces the operational burden for developers.


### PR DESCRIPTION
## Summary
- Add missing `[role="_abstract"]` short descriptions to `nw-introduction-namespaced-sriov.adoc` and `nw-configuring-sriov-in-app-namespace.adoc` for DITA conversion compatibility
- Replace unsupported `.Example output` block title with lead-in text in `nw-configuring-sriov-in-app-namespace.adoc`
- Fix Vale spelling warning ("misconfiguration") and do-not-use term ("overhead")

## Test plan
- [ ] Verify Vale AsciiDocDITA linting passes with no errors or warnings
- [ ] Verify AsciiDoc renders correctly with `asciibinder build`
- [ ] Confirm short descriptions appear correctly in rendered output

🤖 Generated with [Claude Code](https://claude.com/claude-code)