### PR TITLE
TELCODOCS-2856: Fix DITA conversion issues in SR-IOV multicast docs

### DIFF
--- a/modules/nw-configuring-high-performance-multicast-with-sriov.adoc
+++ b/modules/nw-configuring-high-performance-multicast-with-sriov.adoc
@@ -6,7 +6,8 @@
 [id="nw-using-an-sriov-interface-for-multicast_{context}"]
 = Configuring an SR-IOV interface for multicast
 
-The follow procedure creates an example SR-IOV interface for multicast.
+[role="_abstract"]
+The following procedure creates an example SR-IOV interface for multicast.
 
 .Prerequisites
 
@@ -46,9 +47,9 @@ metadata:
   namespace: openshift-sriov-network-operator
 spec:
   networkNamespace: default
-  ipam: | <1>
+  ipam: |
     {
-      "type": "host-local", <1>
+      "type": "host-local",
       "subnet": "10.56.217.0/24",
       "rangeStart": "10.56.217.171",
       "rangeEnd": "10.56.217.181",
@@ -60,7 +61,10 @@ spec:
     }
   resourceName: example
 ----
-<1> If you choose to configure DHCP as IPAM, ensure that you provision the following default routes through your DHCP server: `224.0.0.0/5` and `232.0.0.0/5`. This is to override the static multicast route set by the default network provider.
++
+--
+* If you choose to configure DHCP as IPAM, ensure that you provision the following default routes through your DHCP server: `224.0.0.0/5` and `232.0.0.0/5`. This is to override the static multicast route set by the default network provider.
+--
 
 . Create a pod with multicast application:
 +
@@ -79,9 +83,10 @@ spec:
     image: rhel7:latest
     securityContext:
       capabilities:
-        add: ["NET_ADMIN"] <1>
+        add: ["NET_ADMIN"]
     command: [ "sleep", "infinity"]
 ----
-<1> The `NET_ADMIN` capability is required only if your application needs to
-assign the multicast IP address to the SR-IOV interface. Otherwise, it can be
-omitted.
++
+--
+* The `NET_ADMIN` capability is required only if your application needs to assign the multicast IP address to the SR-IOV interface. Otherwise, you can omit it.
+--

--- a/modules/nw-high-performance-multicast.adoc
+++ b/modules/nw-high-performance-multicast.adoc
@@ -6,8 +6,9 @@
 [id="nw-high-performance-multicast_{context}"]
 = High performance multicast
 
+[role="_abstract"]
 The OVN-Kubernetes network plugin supports multicast between pods on the default network. This is best used for low-bandwidth coordination or service discovery, and not high-bandwidth applications.
-For applications such as streaming media, like Internet Protocol television (IPTV) and multipoint videoconferencing, you can utilize Single Root I/O Virtualization (SR-IOV) hardware to provide near-native performance.
+For applications such as streaming media, such as Internet Protocol television (IPTV) and multipoint videoconferencing, you can use Single Root I/O Virtualization (SR-IOV) hardware to provide near-native performance.
 
 When using additional SR-IOV interfaces for multicast:
 

--- a/networking/hardware_networks/using-sriov-multicast.adoc
+++ b/networking/hardware_networks/using-sriov-multicast.adoc
@@ -6,6 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 You can use multicast on your Single Root I/O Virtualization (SR-IOV) hardware network.
 
 Before you perform any tasks in the following documentation, ensure that you xref:../../networking/networking_operators/sr-iov-operator/installing-sriov-operator.adoc#installing-sriov-operator[installed the SR-IOV Network Operator].


### PR DESCRIPTION
## Summary
- Add `[role="_abstract"]` short descriptions to the assembly and both included modules for DITA conversion
- Replace unsupported callout lists with bullet lists in open blocks
- Fix terminology: "utilize" → "use", "like" → "such as"
- Fix typo ("follow" → "following") and unwrap hard-wrapped lines

## Test plan
- [ ] Verify Vale AsciiDocDITA rules pass with no errors
- [ ] Verify AsciiDoc renders correctly with `asciibinder build`
- [ ] Review callout-to-bullet-list conversions for accuracy

🤖 Generated with [Claude Code](https://claude.com/claude-code)