### PR TITLE
OSDOCS-18900-Updating correct url for proof-of-concept purposes in Converting a connected cluster to a disconnected cluster document

### DIFF
--- a/disconnected/connected-to-disconnected.adoc
+++ b/disconnected/connected-to-disconnected.adoc
@@ -34,7 +34,7 @@ include::modules/installation-about-mirror-registry.adoc[leveloffset=+1]
 ** link:https://goharbor.io/[Harbor]
 --
 +
-If you have a subscription to Red{nbsp}Hat Quay, see the documentation on deploying Red{nbsp}Hat Quay link:https://access.redhat.com/documentation/en-us/red_hat_quay/3/html/deploy_red_hat_quay_for_proof-of-concept_non-production_purposes/[for proof-of-concept purposes] or link:https://access.redhat.com/documentation/en-us/red_hat_quay/3/html/deploying_the_red_hat_quay_operator_on_openshift_container_platform/index[by using the Quay Operator].
+If you have a subscription to Red{nbsp}Hat Quay, see the documentation on deploying Red{nbsp}Hat Quay link:https://docs.redhat.com/en/documentation/red_hat_quay/3/html/proof_of_concept_-_deploying_red_hat_quay[for proof-of-concept purposes] or link:https://access.redhat.com/documentation/en-us/red_hat_quay/3/html/deploying_the_red_hat_quay_operator_on_openshift_container_platform/index[by using the Quay Operator].
 
 * The mirror repository must be configured to share images. For example, a {quay} repository requires link:https://access.redhat.com/documentation/en-us/red_hat_quay/3/html-single/use_red_hat_quay/index#user-org-intro_use-quay[Organizations] in order to share images.
 


### PR DESCRIPTION
updating the correct URL for for proof-of-concept purposes as it was pointing to incorrect url

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.17, 4.18, 4.19, 4.20, 4.21

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://redhat.atlassian.net/browse/OSDOCS-18900

Link to docs preview:
https://109220--ocpdocs-pr.netlify.app/openshift-enterprise/latest/disconnected/connected-to-disconnected.html

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
Disregard 4.16 cherry pick, URL works fine in that version (also the content is located in a different place). 