### PR TITLE
TELCODOCS-2857: Fix DITA conversion issues in SR-IOV net attach docs

### DIFF
--- a/modules/cnf-assigning-a-sriov-network-to-a-vrf.adoc
+++ b/modules/cnf-assigning-a-sriov-network-to-a-vrf.adoc
@@ -6,13 +6,14 @@
 [id="cnf-assigning-a-sriov-network-to-a-vrf_{context}"]
 = Assigning an SR-IOV network to a VRF
 
+[role="_abstract"]
 As a cluster administrator, you can assign an SR-IOV network interface to your VRF domain by using the CNI VRF plugin.
 
 To do this, add the VRF configuration to the optional `metaPlugins` parameter of the `SriovNetwork` resource.
 
 [NOTE]
 ====
-Applications that use VRFs need to bind to a specific device. The common usage is to use the `SO_BINDTODEVICE` option for a socket. `SO_BINDTODEVICE` binds the socket to a device that is specified in the passed interface name, for example, `eth1`. To use `SO_BINDTODEVICE`, the application must have `CAP_NET_RAW` capabilities.
+Applications that use VRF instances need to bind to a specific device. The common usage is to use the `SO_BINDTODEVICE` option for a socket. `SO_BINDTODEVICE` binds the socket to a device that is specified in the passed interface name, for example, `eth1`. To use `SO_BINDTODEVICE`, the application must have `CAP_NET_RAW` capabilities.
 
 Using a VRF through the `ip vrf exec` command is not supported in {product-title} pods. To use VRF, bind applications directly to the VRF interface.
 ====

--- a/modules/nw-multus-add-pod.adoc
+++ b/modules/nw-multus-add-pod.adoc
@@ -149,9 +149,7 @@ status:
 +
 where:
 +
-`k8s.v1.cni.cncf.io/network-status`:: Specifies a JSON array of
-objects. Each object describes the status of a secondary network attached
-to the pod. The annotation value is stored as a plain text value.
+`k8s.v1.cni.cncf.io/network-status`:: Specifies a JSON array of objects. Each object describes the status of a secondary network attached to the pod. The annotation value is stored as a plain text value.
 
 ifeval::["{context}" == "configuring-sr-iov"]
 :!sriov:

--- a/modules/nw-multus-configure-dualstack-ip-address.adoc
+++ b/modules/nw-multus-configure-dualstack-ip-address.adoc
@@ -63,4 +63,4 @@ $ oc exec -it <pod_name> -- ip a
 +
 where:
 +
-`<podname>`:: The name of the pod.
+`<pod_name>`:: The name of the pod.

--- a/modules/nw-multus-ipam-object.adoc
+++ b/modules/nw-multus-ipam-object.adoc
@@ -73,7 +73,7 @@ The `addresses` array requires objects with the following fields:
 
 |`address`
 |`string`
-|An IP address and network prefix that you specify. For example, if you specify `10.10.21.10/24`, the secondary network gets assigned an IP address of `10.10.21.10` and the netmask of `255.255.255.0`.
+|An IP address and network prefix that you specify. For example, if you specify `10.10.21.10/24`, the secondary network gets assigned an IP address of `10.10.21.10` and the `netmask` of `255.255.255.0`.
 
 |`gateway`
 |`string`

--- a/modules/nw-multus-whereabouts-fast-ipam.adoc
+++ b/modules/nw-multus-whereabouts-fast-ipam.adoc
@@ -60,14 +60,14 @@ metadata:
   namespace: openshift-multus
 spec:
   config: '{
-	"cniVersion": "0.3.0",
-	"name": "wb-ipam-cni-name",
-	"type": "bridge",
-	"bridge": "cni0",
-	"ipam": {
-  	"type": "whereabouts",
-  	"range": "10.5.0.0/20",
-  	"node_slice_size": "/24"
+    "cniVersion": "0.3.0",
+    "name": "wb-ipam-cni-name",
+    "type": "bridge",
+    "bridge": "cni0",
+    "ipam": {
+      "type": "whereabouts",
+      "range": "10.5.0.0/20",
+      "node_slice_size": "/24"
     }
   }'
 # ...

--- a/modules/nw-multus-whereabouts.adoc
+++ b/modules/nw-multus-whereabouts.adoc
@@ -37,7 +37,7 @@ The following table describes the configuration objects for dynamic IP address a
 
 |`network_name`
 |`string`
-| Optional: Helps ensure that each group or domain of pods gets its own set of IP addresses, even if they share the same range of IP addresses. Setting this field is important for keeping networks separate and organized, notably in multi-tenant environments.
+| Optional: Helps ensure that each group or domain of pods gets its own set of IP addresses, even if they share the same range of IP addresses. Setting this field is important for keeping networks separate and organized, notably in multitenant environments.
 
 |====
 

--- a/modules/nw-sriov-configure-exclude-topology-manager.adoc
+++ b/modules/nw-sriov-configure-exclude-topology-manager.adoc
@@ -6,6 +6,7 @@
 [id="nw-sriov-configure-exclude-topology-manager_{context}"]
 = Excluding the SR-IOV network topology for NUMA-aware scheduling
 
+[role="_abstract"]
 To exclude advertising the SR-IOV network resource's Non-Uniform Memory Access (NUMA) node to the Topology Manager, you can configure the `excludeTopology` specification in the `SriovNetworkNodePolicy` custom resource. Use this configuration for more flexible SR-IOV network deployments during NUMA-aware pod scheduling.
 
 .Prerequisites
@@ -29,19 +30,22 @@ metadata:
   name: <policy_name>
   namespace: openshift-sriov-network-operator
 spec:
-  resourceName: sriovnuma0 <1>
+  resourceName: sriovnuma0
   nodeSelector:
     kubernetes.io/hostname: <node_name>
   numVfs: <number_of_Vfs>
-  nicSelector: <2>
+  nicSelector:
     vendor: "<vendor_ID>"
     deviceID: "<device_ID>"
   deviceType: netdevice
-  excludeTopology: true <3>
+  excludeTopology: true
 ----
-<1> The resource name of the SR-IOV network device plugin. This YAML uses a sample `resourceName` value.
-<2> Identify the device for the Operator to configure by using the network interface controller (NIC selector).
-<3> To exclude advertising the NUMA node for the SR-IOV network resource to the Topology Manager, set the value to `true`. The default value is `false`.
++
+--
+`spec.resourceName`:: Specifies the resource name of the SR-IOV network device plugin. This YAML uses a sample `resourceName` value.
+`spec.nicSelector`:: Identifies the device for the Operator to configure by using the network interface controller (NIC selector).
+`spec.excludeTopology`:: Excludes advertising the NUMA node for the SR-IOV network resource to the Topology Manager. Set the value to `true`. The default value is `false`.
+--
 +
 [NOTE]
 ====
@@ -64,20 +68,23 @@ $ oc create -f sriov-network-node-policy.yaml
 apiVersion: sriovnetwork.openshift.io/v1
 kind: SriovNetwork
 metadata:
-  name: sriov-numa-0-network <1>
+  name: <sriov_network_name>
   namespace: openshift-sriov-network-operator
 spec:
-  resourceName: sriovnuma0 <2>
-  networkNamespace: <namespace> <3>
-  ipam: |- <4>
+  resourceName: sriovnuma0
+  networkNamespace: <namespace>
+  ipam: |-
     {
       "type": "<ipam_type>",
     }
 ----
-<1> Replace `sriov-numa-0-network` with the name for the SR-IOV network resource.
-<2> Specify the resource name for the `SriovNetworkNodePolicy` CR from the previous step. This YAML uses a sample `resourceName` value.
-<3> Enter the namespace for your SR-IOV network resource.
-<4> Enter the IP address management configuration for the SR-IOV network.
++
+--
+`metadata.name`:: Specifies the name for the SR-IOV network resource.
+`spec.resourceName`:: Specifies the resource name for the `SriovNetworkNodePolicy` CR from the earlier step. This YAML uses a sample `resourceName` value.
+`spec.networkNamespace`:: Specifies the namespace for your SR-IOV network resource.
+`spec.ipam`:: Specifies the IP address management configuration for the SR-IOV network.
+--
 +
 .. Create the `SriovNetwork` resource by running the following command. Successful output lists the name of the `SriovNetwork` resource and the `created` status.
 +
@@ -100,7 +107,7 @@ metadata:
     k8s.v1.cni.cncf.io/networks: |-
       [
         {
-          "name": "sriov-numa-0-network", <1>
+          "name": "<sriov_network_name>",
         }
       ]
 spec:
@@ -110,7 +117,10 @@ spec:
     imagePullPolicy: IfNotPresent
     command: ["sleep", "infinity"]
 ----
-<1> This is the name of the `SriovNetwork` resource that uses the `SriovNetworkNodePolicy` resource.
++
+--
+`metadata.annotations."k8s.v1.cni.cncf.io/networks"`:: Specifies the name of the `SriovNetwork` resource that uses the `SriovNetworkNodePolicy` resource.
+--
 +
 .. Create the `Pod` resource by running the following command. The expected output shows the name of the `Pod` resource and the `created` status.
 +
@@ -128,7 +138,8 @@ $ oc create -f sriov-network-pod.yaml
 $ oc get pod <pod_name>
 ----
 +
-.Example output
+The following is example output:
++
 [source,terminal]
 ----
 NAME                                     READY   STATUS    RESTARTS   AGE
@@ -158,8 +169,8 @@ $ chroot /host
 $ lscpu | grep NUMA
 ----
 +
-
-.Example output
+The following is example output:
++
 [source,terminal]
 ----
 NUMA node(s):                    2
@@ -172,7 +183,8 @@ NUMA node1 CPU(s):     1,3,5,7,9,11,13,15,17,19,...
 $ cat /proc/self/status | grep Cpus
 ----
 +
-.Example output
+The following is example output:
++
 [source,terminal]
 ----
 Cpus_allowed:	ffff

--- a/modules/nw-sriov-configuring-multiple-nodes.adoc
+++ b/modules/nw-sriov-configuring-multiple-nodes.adoc
@@ -62,7 +62,7 @@ where:
 $ oc create -f sriov-nw-pool.yaml
 ----
 
-. Create the `sriov-test` namespace by running the following comand:
+. Create the `sriov-test` namespace by running the following command:
 +
 [source,terminal]
 ----

--- a/modules/nw-sriov-network-object.adoc
+++ b/modules/nw-sriov-network-object.adoc
@@ -6,7 +6,7 @@
 // are interpreted as booleans, not strings. The SR-IOV admission controller
 // will reject 'spoofCheck' and 'trust' if the values are not strings.
 // So these values must be explicitly quoted in the YAML.
-// https://github.com/go-yaml/yaml/issues/214
+// See go-yaml/yaml issue #214
 
 ifeval::["{context}" == "configuring-sriov-net-attach"]
 :ocp-sriov-net:
@@ -22,6 +22,7 @@ endif::[]
 [id="nw-sriov-network-object_{context}"]
 = Ethernet device configuration object
 
+[role="_abstract"]
 You can configure an Ethernet network device by defining an `SriovNetwork` object.
 
 The following YAML describes an `SriovNetwork` object:
@@ -31,57 +32,57 @@ The following YAML describes an `SriovNetwork` object:
 apiVersion: sriovnetwork.openshift.io/v1
 kind: SriovNetwork
 metadata:
-  name: <name> <1>
-  namespace: openshift-sriov-network-operator <2>
+  name: <name>
+  namespace: openshift-sriov-network-operator
 spec:
-  resourceName: <sriov_resource_name> <3>
-  networkNamespace: <target_namespace> <4>
-  vlan: <vlan> <5>
-  spoofChk: "<spoof_check>" <6>
+  resourceName: <sriov_resource_name>
+  networkNamespace: <target_namespace>
+  vlan: <vlan>
+  spoofChk: "<spoof_check>"
 ifdef::ocp-sriov-net[]
-  ipam: |- <7>
+  ipam: |-
     {}
-  linkState: <link_state> <8>
-  maxTxRate: <max_tx_rate> <9>
-  minTxRate: <min_tx_rate> <10>
-  vlanQoS: <vlan_qos> <11>
-  trust: "<trust_vf>" <12>
-  capabilities: <capabilities> <13>
+  linkState: <link_state>
+  maxTxRate: <max_tx_rate>
+  minTxRate: <min_tx_rate>
+  vlanQoS: <vlan_qos>
+  trust: "<trust_vf>"
+  capabilities: <capabilities>
 endif::ocp-sriov-net[]
 ----
-<1> A name for the object. The SR-IOV Network Operator creates a `NetworkAttachmentDefinition` object with same name.
-<2> The namespace where the SR-IOV Network Operator is installed. You can also install the SR-IOV Network Operator in any namespace.
-<3> The value for the `spec.resourceName` parameter from the `SriovNetworkNodePolicy` object that defines the SR-IOV hardware for this additional network.
-<4> The target namespace for the SriovNetwork object. Only pods in the target namespace can attach to the additional network. When installing the SR-IOV Network Operator in a namespace other than `openshift-sriov-network-operator`, you must not configure this field..
-<5> Optional: Specifies the VLAN ID to assign to an additional network. The default value of `0` means that an additional network has no VLAN ID tag. Supported VLAN ID values range from `1` to `4094`.
-<6> Optional: The spoof check mode of the VF. The allowed values are the strings `"on"` and `"off"`.
+
+--
+`metadata.name`:: Specifies a name for the object. The SR-IOV Network Operator creates a `NetworkAttachmentDefinition` object with same name.
+`metadata.namespace`:: Specifies the namespace where the SR-IOV Network Operator is installed. You can also install the SR-IOV Network Operator in any namespace.
+`spec.resourceName`:: Specifies the value for the `spec.resourceName` parameter from the `SriovNetworkNodePolicy` object that defines the SR-IOV hardware for this additional network.
+`spec.networkNamespace`:: Specifies the target namespace for the `SriovNetwork` object. Only pods in the target namespace can attach to the additional network. When installing the SR-IOV Network Operator in a namespace other than `openshift-sriov-network-operator`, you must not configure this field.
+`spec.vlan`:: Optional: Specifies the VLAN ID to assign to an additional network. The default value of `0` means that an additional network has no VLAN ID tag. Supported VLAN ID values range from `1` to `4094`.
+`spec.spoofChk`:: Optional: Specifies the spoof check mode of the VF. The allowed values are the strings `"on"` and `"off"`.
 +
 [IMPORTANT]
 ====
 You must enclose the value you specify in quotes or the object is rejected by the SR-IOV Network Operator.
 ====
-+
 ifdef::ocp-sriov-net[]
-<7> A configuration object for the IPAM CNI plugin as a YAML block scalar. The plugin manages IP address assignment for the attachment definition.
-<8> Optional: The link state of virtual function (VF). Allowed value are `enable`, `disable` and `auto`.
-<9> Optional: A maximum transmission rate, in Mbps, for the VF.
-<10> Optional: A minimum transmission rate, in Mbps, for the VF. This value must be less than or equal to the maximum transmission rate.
+`spec.ipam`:: Specifies a configuration object for the IPAM CNI plugin as a YAML block scalar. The plugin manages IP address assignment for the attachment definition.
+`spec.linkState`:: Optional: Specifies the link state of virtual function (VF). Allowed values are `enable`, `disable`, and `auto`.
+`spec.maxTxRate`:: Optional: Specifies a maximum transmission rate, in Mbps, for the VF.
+`spec.minTxRate`:: Optional: Specifies a minimum transmission rate, in Mbps, for the VF. This value must be less than or equal to the maximum transmission rate.
 +
 [NOTE]
 ====
 Intel NICs do not support the `minTxRate` parameter. For more information, see link:https://bugzilla.redhat.com/show_bug.cgi?id=1772847[BZ#1772847].
 ====
-+
-<11> Optional: An IEEE 802.1p priority level for the VF. The default value is `0`.
-<12> Optional: The trust mode of the VF. The allowed values are the strings `"on"` and `"off"`.
+`spec.vlanQoS`:: Optional: Specifies an IEEE 802.1p priority level for the VF. The default value is `0`.
+`spec.trust`:: Optional: Specifies the trust mode of the VF. The allowed values are the strings `"on"` and `"off"`.
 +
 [IMPORTANT]
 ====
 You must enclose the value that you specify in quotes, or the SR-IOV Network Operator rejects the object.
 ====
-+
-<13> Optional: The capabilities to configure for this additional network. You can specify `'{ "ips": true }'` to enable IP address support or `'{ "mac": true }'` to enable MAC address support.
+`spec.capabilities`:: Optional: Specifies the capabilities to configure for this additional network. You can specify `'{ "ips": true }'` to enable IP address support or `'{ "mac": true }'` to enable MAC address support.
 endif::ocp-sriov-net[]
+--
 
 ifdef::object[]
 :object!:


### PR DESCRIPTION
## Summary
- Fix all Vale AsciiDocDITA Error and Warning violations in `configuring-sriov-net-attach.adoc` assembly and its 12 included modules
- Add missing `[role="_abstract"]` short descriptions to 3 modules (`nw-sriov-network-object`, `cnf-assigning-a-sriov-network-to-a-vrf`, `nw-sriov-configure-exclude-topology-manager`)
- Convert 4 callout lists to bullet lists in open blocks (callouts are unsupported in DITA)
- Replace 3 unsupported `.Example output` block titles with lead-in text
- Fix typo ("comand" → "command"), spelling warnings ("VRFs" → "VRF instances", `netmask` backticked), hyphenation ("multi-tenant" → "multitenant"), and hard-wrapped lines

## Test plan
- [ ] Verify Vale reports no Error or Warning violations on modified files
- [ ] Confirm AsciiDoc renders correctly with `asciibinder build`
- [ ] Review bullet list formatting in `nw-sriov-network-object.adoc` and `nw-sriov-configure-exclude-topology-manager.adoc` for correct open block structure

🤖 Generated with [Claude Code](https://claude.com/claude-code)