### PR TITLE
TELCODOCS-2858: Fix AsciiDocDITA violations in using-dpdk-and-rdma

### DIFF
--- a/modules/nw-openstack-ovs-dpdk-testpmd-pod.adoc
+++ b/modules/nw-openstack-ovs-dpdk-testpmd-pod.adoc
@@ -6,6 +6,7 @@
 [id="nw-openstack-ovs-dpdk-testpmd-pod_{context}"]
 = A test pod template for clusters that use OVS-DPDK on OpenStack
 
+[role="_abstract"]
 The following `testpmd` pod demonstrates container creation with huge pages, reserved CPUs, and the SR-IOV port.
 
 .An example `testpmd` pod
@@ -35,7 +36,7 @@ spec:
         memory: 1000Mi
         hugepages-1Gi: 1Gi
         cpu: '2'
-        openshift.io/dpdk1: 1 <1>
+        openshift.io/dpdk1: 1
       limits:
         hugepages-1Gi: 1Gi
         cpu: '2'
@@ -45,11 +46,14 @@ spec:
       - mountPath: /mnt/huge
         name: hugepage
         readOnly: False
-  runtimeClassName: performance-cnf-performanceprofile <2>
+  runtimeClassName: performance-cnf-performanceprofile
   volumes:
   - name: hugepage
     emptyDir:
       medium: HugePages
 ----
-<1> The name `dpdk1` in this example is a user-created `SriovNetworkNodePolicy` resource. You can substitute this name for that of a resource that you create.
-<2> If your performance profile is not named `cnf-performance profile`, replace that string with the correct performance profile name.
+
+--
+* The name `dpdk1` in this example is a user-created `SriovNetworkNodePolicy` resource. You can substitute this name for that of a resource that you create.
+* If your performance profile is not named `cnf-performance profile`, replace that string with the correct performance profile name.
+--

--- a/modules/nw-running-dpdk-rootless-tap.adoc
+++ b/modules/nw-running-dpdk-rootless-tap.adoc
@@ -6,9 +6,10 @@
 [id="nw-running-dpdk-rootless-tap_{context}"]
 = Using the TAP CNI to run a rootless DPDK workload with kernel access
 
+[role="_abstract"]
 DPDK applications can use `virtio-user` as an exception path to inject certain types of packets, such as log messages, into the kernel for processing. For more information about this feature, see link:https://doc.dpdk.org/guides/howto/virtio_user_as_exception_path.html[Virtio_user as Exception Path].
 
-In OpenShift Container Platform version 4.14 and later, you can use non-privileged pods to run DPDK applications alongside the tap CNI plugin. To enable this functionality, you need to mount the `vhost-net` device by setting the `needVhostNet` parameter to `true` within the `SriovNetworkNodePolicy` object.
+In {product-title} version 4.14 and later, you can use non-privileged pods to run DPDK applications alongside the tap CNI plugin. To enable this functionality, you need to mount the `vhost-net` device by setting the `needVhostNet` parameter to `true` within the `SriovNetworkNodePolicy` object.
 
 .DPDK and TAP example configuration
 image::348_OpenShift_rootless_DPDK_0923.png[DPDK and TAP plugin]
@@ -27,7 +28,7 @@ Use the Machine Config Operator to set this SELinux boolean.
 
 .Procedure
 
-. Create a file, such as `test-namespace.yaml`, with content like the following example:
+. Create a file, such as `test-namespace.yaml`, with content such as the following example:
 +
 [source,yaml]
 ----
@@ -49,7 +50,7 @@ metadata:
 $ oc apply -f test-namespace.yaml
 ----
 
-. Create a file, such as `sriov-node-network-policy.yaml`, with content like the following example::
+. Create a file, such as `sriov-node-network-policy.yaml`, with content such as the following example:
 +
 [source,yaml]
 ----
@@ -59,12 +60,12 @@ metadata:
  name: sriovnic
  namespace: openshift-sriov-network-operator
 spec:
- deviceType: netdevice <1>
- isRdma: true <2>
- needVhostNet: true <3>
+ deviceType: netdevice
+ isRdma: true
+ needVhostNet: true
  nicSelector:
-   vendor: "15b3" <4>
-   deviceID: "101b" <5>
+   vendor: "15b3"
+   deviceID: "101b"
    rootDevices: ["00:05.0"]
  numVfs: 10
  priority: 99
@@ -72,11 +73,14 @@ spec:
  nodeSelector:
     feature.node.kubernetes.io/network-sriov.capable: "true"
 ----
-<1> This indicates that the profile is tailored specifically for Mellanox Network Interface Controllers (NICs).
-<2> Setting `isRdma` to `true` is only required for a Mellanox NIC.
-<3> This mounts the `/dev/net/tun` and `/dev/vhost-net` devices into the container so the application can create a tap device and connect the tap device to the DPDK workload.
-<4> The vendor hexadecimal code of the SR-IOV network device. The value 15b3 is associated with a Mellanox NIC.
-<5> The device hexadecimal code of the SR-IOV network device.
++
+where:
++
+`spec.deviceType`:: Specifies that the profile is tailored specifically for Mellanox Network Interface Controllers (NICs). Set to `netdevice`.
+`spec.isRdma`:: Setting to `true` is only required for a Mellanox NIC.
+`spec.needVhostNet`:: Setting to `true` mounts the `/dev/net/tun` and `/dev/vhost-net` devices into the container so the application can create a tap device and connect the tap device to the DPDK workload.
+`spec.nicSelector.vendor`:: Specifies the vendor hexadecimal code of the SR-IOV network device. The value `"15b3"` is associated with a Mellanox NIC.
+`spec.nicSelector.deviceID`:: Specifies the device hexadecimal code of the SR-IOV network device.
 
 . Create the `SriovNetworkNodePolicy` object by running the following command:
 +
@@ -115,7 +119,7 @@ An optional library, `app-netutil`, provides several API methods for gathering n
 $ oc create -f sriov-network-attachment.yaml
 ----
 
-. Create a file, such as `tap-example.yaml`, that defines a network attachment definition, with content like the following example:
+. Create a file, such as `tap-example.yaml`, that defines a network attachment definition, with content such as the following example:
 +
 [source,yaml]
 ----
@@ -123,7 +127,7 @@ apiVersion: "k8s.cni.cncf.io/v1"
 kind: NetworkAttachmentDefinition
 metadata:
  name: tap-one
- namespace: test-namespace <1>
+ namespace: test-namespace
 spec:
  config: '{
    "cniVersion": "0.4.0",
@@ -143,7 +147,10 @@ spec:
    ]
  }'
 ----
-<1> Specify the same `target_namespace` where the `SriovNetwork` object is created.
++
+where:
++
+`metadata.namespace`:: Specifies the same `target_namespace` where the `SriovNetwork` object is created.
 
 . Create the `NetworkAttachmentDefinition` object by running the following command:
 +
@@ -152,7 +159,7 @@ spec:
 $ oc apply -f tap-example.yaml
 ----
 
-. Create a file, such as `dpdk-pod-rootless.yaml`, with content like the following example:
+. Create a file, such as `dpdk-pod-rootless.yaml`, with content such as the following example:
 +
 [source,yaml]
 ----
@@ -160,7 +167,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: dpdk-app
-  namespace: test-namespace <1>
+  namespace: test-namespace
   annotations:
     k8s.v1.cni.cncf.io/networks: '[
       {"name": "sriov-network", "namespace": "test-namespace"},
@@ -169,64 +176,63 @@ spec:
   nodeSelector:
     kubernetes.io/hostname: "worker-0"
   securityContext:
-      fsGroup: 1001 <2>
-      runAsGroup: 1001 <3>
+      fsGroup: 1001
+      runAsGroup: 1001
       seccompProfile:
         type: RuntimeDefault
   containers:
   - name: testpmd
-    image: <DPDK_image> <4>
+    image: <DPDK_image>
     securityContext:
       capabilities:
-        drop: ["ALL"] <5>
-        add: <6>
+        drop: ["ALL"]
+        add:
           - IPC_LOCK
-          - NET_RAW #for mlx only <7>
-      runAsUser: 1001 <8>
-      privileged: false <9>
-      allowPrivilegeEscalation: true <10>
-      runAsNonRoot: true <11>
+          - NET_RAW #for mlx only
+      runAsUser: 1001
+      privileged: false
+      allowPrivilegeEscalation: true
+      runAsNonRoot: true
     volumeMounts:
-    - mountPath: /mnt/huge <12>
+    - mountPath: /mnt/huge
       name: hugepages
     resources:
       limits:
-        openshift.io/sriovnic: "1" <13>
+        openshift.io/sriovnic: "1"
         memory: "1Gi"
-        cpu: "4" <14>
-        hugepages-1Gi: "4Gi" <15>
+        cpu: "4"
+        hugepages-1Gi: "4Gi"
       requests:
         openshift.io/sriovnic: "1"
         memory: "1Gi"
         cpu: "4"
         hugepages-1Gi: "4Gi"
     command: ["sleep", "infinity"]
-  runtimeClassName: performance-cnf-performanceprofile <16>
+  runtimeClassName: performance-cnf-performanceprofile
   volumes:
   - name: hugepages
     emptyDir:
       medium: HugePages
 ----
 +
---
-<1> Specify the same `target_namespace` in which the `SriovNetwork` object is created. If you want to create the pod in a different namespace, change `target_namespace` in both the `Pod` spec and the `SriovNetwork` object.
-<2> Sets the group ownership of volume-mounted directories and files created in those volumes.
-<3> Specify the primary group ID used for running the container.
-<4> Specify the DPDK image that contains your application and the DPDK library used by application.
-<5> Removing all capabilities (`ALL`) from the container's securityContext means that the container has no special privileges beyond what is necessary for normal operation.
-<6> Specify additional capabilities required by the application inside the container for hugepage allocation, system resource allocation, and network interface access. These capabilities must also be set in the binary file by using the `setcap` command.
-<7> Mellanox network interface controller (NIC) requires the `NET_RAW` capability.
-<8> Specify the user ID used for running the container.
-<9> This setting indicates that the container or containers within the pod should not be granted privileged access to the host system.
-<10>  This setting allows a container to escalate its privileges beyond the initial non-root privileges it might have been assigned.
-<11> This setting ensures that the container runs with a non-root user. This helps enforce the principle of least privilege, limiting the potential impact of compromising the container and reducing the attack surface.
-<12> Mount a hugepage volume to the DPDK pod under `/mnt/huge`. The hugepage volume is backed by the emptyDir volume type with the medium being `Hugepages`.
-<13> Optional: Specify the number of DPDK devices allocated for the DPDK pod. If not explicitly specified, this resource request and limit is automatically added by the SR-IOV network resource injector. The SR-IOV network resource injector is an admission controller component managed by SR-IOV Operator. It is enabled by default and can be disabled by setting the `enableInjector` option to `false` in the default `SriovOperatorConfig` CR.
-<14> Specify the number of CPUs. The DPDK pod usually requires exclusive CPUs to be allocated from the kubelet. This is achieved by setting CPU Manager policy to `static` and creating a pod with `Guaranteed` QoS.
-<15> Specify hugepage size `hugepages-1Gi` or `hugepages-2Mi` and the quantity of hugepages that will be allocated to the DPDK pod. Configure `2Mi` and `1Gi` hugepages separately. Configuring `1Gi` hugepage requires adding kernel arguments to Nodes. For example, adding kernel arguments `default_hugepagesz=1GB`, `hugepagesz=1G` and `hugepages=16` will result in `16*1Gi` hugepages be allocated during system boot.
-<16> If your performance profile is not named `cnf-performance profile`, replace that string with the correct performance profile name.
---
+where:
 +
+`metadata.namespace`:: Specifies the same `target_namespace` in which the `SriovNetwork` object is created. If you want to create the pod in a different namespace, change `target_namespace` in both the `Pod` spec and the `SriovNetwork` object.
+`spec.securityContext.fsGroup`:: Sets the group ownership of volume-mounted directories and files created in those volumes.
+`spec.securityContext.runAsGroup`:: Specifies the primary group ID used for running the container.
+`spec.containers.image`:: Specifies the DPDK image that contains your application and the DPDK library used by application.
+`spec.containers.securityContext.capabilities.drop`:: Removing all capabilities (`ALL`) from the container's `securityContext` means that the container has no special privileges beyond what is necessary for normal operation.
+`spec.containers.securityContext.capabilities.add`:: Specifies additional capabilities required by the application inside the container for hugepage allocation, system resource allocation, and network interface access. These capabilities must also be set in the binary file by using the `setcap` command. Mellanox network interface controller (NIC) requires the `NET_RAW` capability.
+`spec.containers.securityContext.runAsUser`:: Specifies the user ID used for running the container.
+`spec.containers.securityContext.privileged`:: Setting to `false` indicates that the container or containers within the pod should not be granted privileged access to the host system.
+`spec.containers.securityContext.allowPrivilegeEscalation`:: Setting to `true` allows a container to escalate its privileges beyond the initial non-root privileges it might have been assigned.
+`spec.containers.securityContext.runAsNonRoot`:: Setting to `true` ensures that the container runs with a non-root user. This helps enforce the principle of least privilege, limiting the potential impact of compromising the container and reducing the attack surface.
+`spec.containers.volumeMounts.mountPath`:: Specifies the path where a hugepage volume is mounted in the DPDK pod. The hugepage volume is backed by the `emptyDir` volume type with the medium being `Hugepages`.
+`spec.containers.resources.limits.openshift.io/sriovnic`:: Optional: Specifies the number of DPDK devices allocated for the DPDK pod. If not explicitly specified, this resource request and limit is automatically added by the SR-IOV network resource injector. The SR-IOV network resource injector is an admission controller component managed by SR-IOV Operator. It is enabled by default and can be disabled by setting the `enableInjector` option to `false` in the default `SriovOperatorConfig` CR.
+`spec.containers.resources.limits.cpu`:: Specifies the number of CPUs. The DPDK pod usually requires exclusive CPUs to be allocated from the kubelet. This is achieved by setting CPU Manager policy to `static` and creating a pod with `Guaranteed` QoS.
+`spec.containers.resources.limits.hugepages-1Gi`:: Specifies the hugepage size `hugepages-1Gi` or `hugepages-2Mi` and the quantity of hugepages that will be allocated to the DPDK pod. Configure `2Mi` and `1Gi` hugepages separately. Configuring `1Gi` hugepage requires adding kernel arguments to Nodes. For example, adding kernel arguments `default_hugepagesz=1GB`, `hugepagesz=1G` and `hugepages=16` will result in `16*1Gi` hugepages be allocated during system boot.
+`spec.runtimeClassName`:: Specifies the performance profile runtime class. If your performance profile is not named `cnf-performance profile`, replace that string with the correct performance profile name.
+
 . Create the DPDK pod by running the following command:
 +
 [source,terminal]

--- a/modules/nw-sriov-app-netutil.adoc
+++ b/modules/nw-sriov-app-netutil.adoc
@@ -6,6 +6,7 @@
 [id="nw-sriov-app-netutil_{context}"]
 = DPDK library for use with container applications
 
+[role="_abstract"]
 An link:https://github.com/openshift/app-netutil[optional library], `app-netutil`, provides several API methods for gathering network information about a pod from within a container running within that pod.
 
 This library can assist with integrating SR-IOV virtual functions (VFs) in Data Plane Development Kit (DPDK) mode into the container.

--- a/modules/nw-sriov-concept-dpdk-line-rate.adoc
+++ b/modules/nw-sriov-concept-dpdk-line-rate.adoc
@@ -6,6 +6,7 @@
 [id="nw-sriov-example-dpdk-line-rate_{context}"]
 = Overview of achieving a specific DPDK line rate
 
+[role="_abstract"]
 To achieve a specific Data Plane Development Kit (DPDK) line rate, deploy a Node Tuning Operator and configure Single Root I/O Virtualization (SR-IOV). You must also tune the DPDK settings for the following resources:
 
 - Isolated CPUs
@@ -17,13 +18,12 @@ To achieve a specific Data Plane Development Kit (DPDK) line rate, deploy a Node
 In previous versions of {product-title}, the Performance Addon Operator was used to implement automatic tuning to achieve low latency performance for {product-title} applications. In {product-title} 4.11 and later, this functionality is part of the Node Tuning Operator.
 ====
 
-.DPDK test environment
-The following diagram shows the components of a traffic-testing environment:
+The following diagram shows the components of a DPDK test environment:
 
 image::261_OpenShift_DPDK_0722.png[DPDK test environment]
 
 - **Traffic generator**: An application that can generate high-volume packet traffic.
-- **SR-IOV-supporting NIC**: A network interface card compatible with SR-IOV. The card runs a number of virtual functions on a physical interface.
+- **SR-IOV-supporting NIC**: A network interface controller (NIC) compatible with SR-IOV. The card runs several virtual functions on a physical interface.
 - **Physical Function (PF)**: A PCI Express (PCIe) function of a network adapter that supports the SR-IOV interface.
 - **Virtual Function (VF)**:  A lightweight PCIe function on a network adapter that supports SR-IOV. The VF is associated with the PCIe PF on the network adapter. The VF represents a virtualized instance of the network adapter.
 - **Switch**: A network switch. Nodes can also be connected back-to-back.

--- a/modules/nw-sriov-create-object.adoc
+++ b/modules/nw-sriov-create-object.adoc
@@ -6,6 +6,7 @@
 [id="nw-sriov-create-object_{context}"]
 = Example SR-IOV network operator
 
+[role="_abstract"]
 The following is an example definition of an `sriovNetwork` object. In this case, Intel and Mellanox configurations are identical:
 [source,yaml]
 ----
@@ -16,11 +17,11 @@ metadata:
   namespace: openshift-sriov-network-operator
 spec:
   ipam: '{"type": "host-local","ranges": [[{"subnet": "10.0.1.0/24"}]],"dataDir":
-   "/run/my-orchestrator/container-ipam-state-1"}' <1>
-  networkNamespace: dpdk-test <2>
+   "/run/my-orchestrator/container-ipam-state-1"}'
+  networkNamespace: dpdk-test
   spoofChk: "off"
   trust: "on"
-  resourceName: dpdk_nic_1 <3>
+  resourceName: dpdk_nic_1
 ---
 apiVersion: sriovnetwork.openshift.io/v1
 kind: SriovNetwork
@@ -35,6 +36,9 @@ spec:
   trust: "on"
   resourceName: dpdk_nic_2
 ----
-<1> You can use a different IP Address Management (IPAM) implementation, such as Whereabouts. For more information, see _Dynamic IP address assignment configuration with Whereabouts_.
-<2> You must request the `networkNamespace` where the network attachment definition will be created. You must create the `sriovNetwork` CR under the `openshift-sriov-network-operator` namespace.
-<3> The `resourceName` value must match that of the `resourceName` created under the `sriovNetworkNodePolicy`.
+
+--
+* You can use a different IP Address Management (IPAM) implementation, such as Whereabouts. For more information, see _Dynamic IP address assignment configuration with Whereabouts_.
+* You must request the `networkNamespace` where the network attachment definition will be created. You must create the `sriovNetwork` CR under the `openshift-sriov-network-operator` namespace.
+* The `resourceName` value must match that of the `resourceName` created under the `sriovNetworkNodePolicy`.
+--

--- a/modules/nw-sriov-dpdk-base-workload.adoc
+++ b/modules/nw-sriov-dpdk-base-workload.adoc
@@ -6,6 +6,7 @@
 [id="nw-sriov-dpdk-base-workload_{context}"]
 = Example DPDK base workload
 
+[role="_abstract"]
 The following is an example of a Data Plane Development Kit (DPDK) container:
 [source,yaml]
 ----
@@ -18,7 +19,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   annotations:
-    k8s.v1.cni.cncf.io/networks: '[ <1>
+    k8s.v1.cni.cncf.io/networks: '[
      {
       "name": "dpdk-network-1",
       "namespace": "dpdk-test"
@@ -28,7 +29,7 @@ metadata:
       "namespace": "dpdk-test"
      }
    ]'
-    irq-load-balancing.crio.io: "disable" <2>
+    irq-load-balancing.crio.io: "disable"
     cpu-load-balancing.crio.io: "disable"
     cpu-quota.crio.io: "disable"
   labels:
@@ -36,7 +37,7 @@ metadata:
   name: testpmd
   namespace: dpdk-test
 spec:
-  runtimeClassName: performance-performance <3>
+  runtimeClassName: performance-performance
   containers:
     - command:
         - /bin/bash
@@ -45,7 +46,7 @@ spec:
       image: registry.redhat.io/openshift4/dpdk-base-rhel8
       imagePullPolicy: Always
       name: dpdk
-      resources: <4>
+      resources:
         limits:
           cpu: "16"
           hugepages-1Gi: 8Gi
@@ -71,10 +72,13 @@ spec:
         medium: HugePages
       name: hugepages
 ----
-<1> Request the SR-IOV networks you need. Resources for the devices will be injected automatically.
-<2> Disable the CPU and IRQ load balancing base. See _Disabling interrupt processing for individual pods_ for more information.
-<3> Set the `runtimeClass` to `performance-performance`. Do not set the `runtimeClass` to `HostNetwork` or `privileged`.
-<4> Request an equal number of resources for requests and limits to start the pod with `Guaranteed` Quality of Service (QoS).
+
+--
+* Request the SR-IOV networks you need. Resources for the devices are injected automatically.
+* Disable the CPU and IRQ load balancing base. See _Disabling interrupt processing for individual pods_ for more information.
+* Set the `runtimeClass` to `performance-performance`. Do not set the `runtimeClass` to `HostNetwork` or `privileged`.
+* Request an equal number of resources for requests and limits to start the pod with `Guaranteed` Quality of Service (QoS).
+--
 
 [NOTE]
 ====

--- a/modules/nw-sriov-dpdk-example-intel.adoc
+++ b/modules/nw-sriov-dpdk-example-intel.adoc
@@ -6,6 +6,9 @@
 [id="example-vf-use-in-dpdk-mode-intel_{context}"]
 = Using a virtual function in DPDK mode with an Intel NIC
 
+[role="_abstract"]
+You can use a virtual function (VF) in Data Plane Development Kit (DPDK) mode with an Intel NIC by creating a `SriovNetworkNodePolicy` object and then deploying a pod.
+
 .Prerequisites
 
 * Install the OpenShift CLI (`oc`).
@@ -34,16 +37,19 @@ spec:
     deviceID: "158b"
     pfNames: ["<pf_name>", ...]
     rootDevices: ["<pci_bus_id>", "..."]
-  deviceType: vfio-pci <1>
+  deviceType: vfio-pci
 ----
-<1> Specify the driver type for the virtual functions to `vfio-pci`.
++
+where:
++
+`spec.deviceType`:: Specifies the driver type for the virtual functions. Set to `vfio-pci`.
 +
 [NOTE]
 =====
 See the `Configuring SR-IOV network devices` section for a detailed explanation on each option in `SriovNetworkNodePolicy`.
 
-When applying the configuration specified in a `SriovNetworkNodePolicy` object, the SR-IOV Operator may drain the nodes, and in some cases, reboot nodes.
-It may take several minutes for a configuration change to apply.
+When applying the configuration specified in a `SriovNetworkNodePolicy` object, the SR-IOV Operator might drain the nodes, and in some cases, reboot nodes.
+It might take several minutes for a configuration change to apply.
 Ensure that there are enough available nodes in your cluster to handle the evicted workload beforehand.
 
 After the configuration update is applied, all the pods in `openshift-sriov-network-operator` namespace will change to a `Running` status.
@@ -68,11 +74,14 @@ metadata:
 spec:
   networkNamespace: <target_namespace>
   ipam: |-
-# ... <1>
+# ...
   vlan: <vlan>
   resourceName: intelnics
 ----
-<1> Specify a configuration object for the ipam CNI plugin as a YAML block scalar. The plugin manages IP address assignment for the attachment definition.
++
+where:
++
+`spec.ipam`:: Specifies a configuration object for the IPAM CNI plugin as a YAML block scalar. The plugin manages IP address assignment for the attachment definition.
 +
 [NOTE]
 =====
@@ -96,26 +105,26 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: dpdk-app
-  namespace: <target_namespace> <1>
+  namespace: <target_namespace>
   annotations:
     k8s.v1.cni.cncf.io/networks: intel-dpdk-network
 spec:
   containers:
   - name: testpmd
-    image: <DPDK_image> <2>
+    image: <DPDK_image>
     securityContext:
       runAsUser: 0
       capabilities:
-        add: ["IPC_LOCK","SYS_RESOURCE","NET_RAW"] <3>
+        add: ["IPC_LOCK","SYS_RESOURCE","NET_RAW"]
     volumeMounts:
-    - mountPath: /mnt/huge <4>
+    - mountPath: /mnt/huge
       name: hugepage
     resources:
       limits:
-        openshift.io/intelnics: "1" <5>
+        openshift.io/intelnics: "1"
         memory: "1Gi"
-        cpu: "4" <6>
-        hugepages-1Gi: "4Gi" <7>
+        cpu: "4"
+        hugepages-1Gi: "4Gi"
       requests:
         openshift.io/intelnics: "1"
         memory: "1Gi"
@@ -127,13 +136,16 @@ spec:
     emptyDir:
       medium: HugePages
 ----
-<1> Specify the same `target_namespace` where the `SriovNetwork` object `intel-dpdk-network` is created. If you would like to create the pod in a different namespace, change `target_namespace` in both the `Pod` spec and the `SriovNetwork` object.
-<2> Specify the DPDK image which includes your application and the DPDK library used by application.
-<3> Specify additional capabilities required by the application inside the container for hugepage allocation, system resource allocation, and network interface access.
-<4> Mount a hugepage volume to the DPDK pod under `/mnt/huge`. The hugepage volume is backed by the emptyDir volume type with the medium being `Hugepages`.
-<5> Optional: Specify the number of DPDK devices allocated to DPDK pod. This resource request and limit, if not explicitly specified, will be automatically added by the SR-IOV network resource injector. The SR-IOV network resource injector is an admission controller component managed by the SR-IOV Operator. It is enabled by default and can be disabled by setting `enableInjector` option to `false` in the default `SriovOperatorConfig` CR.
-<6> Specify the number of CPUs. The DPDK pod usually requires exclusive CPUs to be allocated from the kubelet. This is achieved by setting CPU Manager policy to `static` and creating a pod with `Guaranteed` QoS.
-<7> Specify hugepage size `hugepages-1Gi` or `hugepages-2Mi` and the quantity of hugepages that will be allocated to the DPDK pod. Configure `2Mi` and `1Gi` hugepages separately. Configuring `1Gi` hugepage requires adding kernel arguments to Nodes. For example, adding kernel arguments `default_hugepagesz=1GB`, `hugepagesz=1G` and `hugepages=16` will result in `16*1Gi` hugepages be allocated during system boot.
++
+where:
++
+`metadata.namespace`:: Specifies the same namespace where the `SriovNetwork` object `intel-dpdk-network` is created. If you want to create the pod in a different namespace, change `target_namespace` in both the `Pod` spec and the `SriovNetwork` object.
+`spec.containers.image`:: Specifies the DPDK image which includes your application and the DPDK library used by application.
+`spec.containers.securityContext.capabilities.add`:: Specifies additional capabilities required by the application inside the container for hugepage allocation, system resource allocation, and network interface access.
+`spec.containers.volumeMounts.mountPath`:: Specifies the path where a hugepage volume is mounted in the DPDK pod. The hugepage volume is backed by the `emptyDir` volume type with the medium being `Hugepages`.
+`spec.containers.resources.limits.openshift.io/intelnics`:: Optional: Specifies the number of DPDK devices allocated to DPDK pod. If not explicitly specified, this resource request and limit is automatically added by the SR-IOV network resource injector. The SR-IOV network resource injector is an admission controller component managed by the SR-IOV Operator. It is enabled by default and can be disabled by setting `enableInjector` option to `false` in the default `SriovOperatorConfig` CR.
+`spec.containers.resources.limits.cpu`:: Specifies the number of CPUs. The DPDK pod usually requires exclusive CPUs to be allocated from the kubelet. This is achieved by setting CPU Manager policy to `static` and creating a pod with `Guaranteed` QoS.
+`spec.containers.resources.limits.hugepages-1Gi`:: Specifies the hugepage size `hugepages-1Gi` or `hugepages-2Mi` and the quantity of hugepages that will be allocated to the DPDK pod. Configure `2Mi` and `1Gi` hugepages separately. Configuring `1Gi` hugepage requires adding kernel arguments to Nodes. For example, adding kernel arguments `default_hugepagesz=1GB`, `hugepagesz=1G` and `hugepages=16` will result in `16*1Gi` hugepages be allocated during system boot.
 
 . Create the DPDK pod by running the following command:
 +

--- a/modules/nw-sriov-dpdk-example-mellanox.adoc
+++ b/modules/nw-sriov-dpdk-example-mellanox.adoc
@@ -6,7 +6,8 @@
 [id="example-vf-use-in-dpdk-mode-mellanox_{context}"]
 = Using a virtual function in DPDK mode with a Mellanox NIC
 
-You can create a network node policy and create a Data Plane Development Kit (DPDK) pod using a virtual function in DPDK mode with a Mellanox NIC.
+[role="_abstract"]
+You can create a network node policy and create a Data Plane Development Kit (DPDK) pod by using a virtual function in DPDK mode with a Mellanox NIC.
 
 .Prerequisites
 
@@ -33,15 +34,18 @@ spec:
   numVfs: <num>
   nicSelector:
     vendor: "15b3"
-    deviceID: "1015" <1>
+    deviceID: "1015"
     pfNames: ["<pf_name>", ...]
     rootDevices: ["<pci_bus_id>", "..."]
-  deviceType: netdevice <2>
-  isRdma: true <3>
+  deviceType: netdevice
+  isRdma: true
 ----
-<1> Specify the device hex code of the SR-IOV network device.
-<2> Specify the driver type for the virtual functions to `netdevice`. A Mellanox SR-IOV Virtual Function (VF) can work in DPDK mode without using the `vfio-pci` device type. The VF device appears as a kernel network interface inside a container.
-<3> Enable Remote Direct Memory Access (RDMA) mode. This is required for Mellanox cards to work in DPDK mode.
++
+where:
++
+`spec.nicSelector.deviceID`:: Specifies the device hex code of the SR-IOV network device. The value `"1015"` is associated with a Mellanox NIC.
+`spec.deviceType`:: Specifies the driver type for the virtual functions. A Mellanox SR-IOV Virtual Function (VF) can work in DPDK mode without using the `vfio-pci` device type. Set to `netdevice`. The VF device is displayed as a kernel network interface inside a container.
+`spec.isRdma`:: Setting to `true` enables Remote Direct Memory Access (RDMA) mode. This is required for Mellanox cards to work in DPDK mode.
 +
 [NOTE]
 =====
@@ -72,12 +76,15 @@ metadata:
   namespace: openshift-sriov-network-operator
 spec:
   networkNamespace: <target_namespace>
-  ipam: |- <1>
+  ipam: |-
 ...
   vlan: <vlan>
   resourceName: mlxnics
 ----
-<1> Specify a configuration object for the IP Address Management (IPAM) Container Network Interface (CNI) plugin as a YAML block scalar. The plugin manages IP address assignment for the attachment definition.
++
+where:
++
+`spec.ipam`:: Specifies a configuration object for the IP Address Management (IPAM) Container Network Interface (CNI) plugin as a YAML block scalar. The plugin manages IP address assignment for the attachment definition.
 +
 [NOTE]
 =====
@@ -101,26 +108,26 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: dpdk-app
-  namespace: <target_namespace> <1>
+  namespace: <target_namespace>
   annotations:
     k8s.v1.cni.cncf.io/networks: mlx-dpdk-network
 spec:
   containers:
   - name: testpmd
-    image: <DPDK_image> <2>
+    image: <DPDK_image>
     securityContext:
       runAsUser: 0
       capabilities:
-        add: ["IPC_LOCK","SYS_RESOURCE","NET_RAW"] <3>
+        add: ["IPC_LOCK","SYS_RESOURCE","NET_RAW"]
     volumeMounts:
-    - mountPath: /mnt/huge <4>
+    - mountPath: /mnt/huge
       name: hugepage
     resources:
       limits:
-        openshift.io/mlxnics: "1" <5>
+        openshift.io/mlxnics: "1"
         memory: "1Gi"
-        cpu: "4" <6>
-        hugepages-1Gi: "4Gi" <7>
+        cpu: "4"
+        hugepages-1Gi: "4Gi"
       requests:
         openshift.io/mlxnics: "1"
         memory: "1Gi"
@@ -132,13 +139,16 @@ spec:
     emptyDir:
       medium: HugePages
 ----
-<1> Specify the same `target_namespace` where `SriovNetwork` object `mlx-dpdk-network` is created. To create the pod in a different namespace, change `target_namespace` in both the `Pod` spec and `SriovNetwork` object.
-<2> Specify the DPDK image which includes your application and the DPDK library used by the application.
-<3> Specify additional capabilities required by the application inside the container for hugepage allocation, system resource allocation, and network interface access.
-<4> Mount the hugepage volume to the DPDK pod under `/mnt/huge`. The hugepage volume is backed by the `emptyDir` volume type with the medium being `Hugepages`.
-<5> Optional: Specify the number of DPDK devices allocated for the DPDK pod. If not explicitly specified, this resource request and limit is automatically added by the SR-IOV network resource injector. The SR-IOV network resource injector is an admission controller component managed by SR-IOV Operator. It is enabled by default and can be disabled by setting the `enableInjector` option to `false` in the default `SriovOperatorConfig` CR.
-<6> Specify the number of CPUs. The DPDK pod usually requires that exclusive CPUs be allocated from the kubelet. To do this, set the CPU Manager policy to `static` and create a pod with `Guaranteed` Quality of Service (QoS).
-<7> Specify hugepage size `hugepages-1Gi` or `hugepages-2Mi` and the quantity of hugepages that will be allocated to the DPDK pod. Configure `2Mi` and `1Gi` hugepages separately. Configuring `1Gi` hugepages requires adding kernel arguments to Nodes.
++
+where:
++
+`metadata.namespace`:: Specifies the same namespace where `SriovNetwork` object `mlx-dpdk-network` is created. To create the pod in a different namespace, change `target_namespace` in both the `Pod` spec and `SriovNetwork` object.
+`spec.containers.image`:: Specifies the DPDK image which includes your application and the DPDK library used by the application.
+`spec.containers.securityContext.capabilities.add`:: Specifies additional capabilities required by the application inside the container for hugepage allocation, system resource allocation, and network interface access.
+`spec.containers.volumeMounts.mountPath`:: Specifies the path where the hugepage volume is mounted in the DPDK pod. The hugepage volume is backed by the `emptyDir` volume type with the medium being `Hugepages`.
+`spec.containers.resources.limits.openshift.io/mlxnics`:: Optional: Specifies the number of DPDK devices allocated for the DPDK pod. If not explicitly specified, this resource request and limit is automatically added by the SR-IOV network resource injector. The SR-IOV network resource injector is an admission controller component managed by SR-IOV Operator. It is enabled by default and can be disabled by setting the `enableInjector` option to `false` in the default `SriovOperatorConfig` CR.
+`spec.containers.resources.limits.cpu`:: Specifies the number of CPUs. The DPDK pod usually requires that exclusive CPUs be allocated from the kubelet. To do this, set the CPU Manager policy to `static` and create a pod with `Guaranteed` Quality of Service (QoS).
+`spec.containers.resources.limits.hugepages-1Gi`:: Specifies the hugepage size `hugepages-1Gi` or `hugepages-2Mi` and the quantity of hugepages that will be allocated to the DPDK pod. Configure `2Mi` and `1Gi` hugepages separately. Configuring `1Gi` hugepages requires adding kernel arguments to Nodes.
 
 . Create the DPDK pod by running the following command:
 +

--- a/modules/nw-sriov-dpdk-running-testpmd.adoc
+++ b/modules/nw-sriov-dpdk-running-testpmd.adoc
@@ -6,6 +6,7 @@
 [id="nw-sriov-dpdk-running-testpmd_{context}"]
 = Example testpmd script
 
+[role="_abstract"]
 The following is an example script for running `testpmd`:
 
 [source,terminal]

--- a/modules/nw-sriov-example-dpdk-line-rate.adoc
+++ b/modules/nw-sriov-example-dpdk-line-rate.adoc
@@ -6,6 +6,7 @@
 [id="nw-example-dpdk-line-rate_{context}"]
 = Using SR-IOV and the Node Tuning Operator to achieve a DPDK line rate
 
+[role="_abstract"]
 You can use the Node Tuning Operator to configure isolated CPUs, hugepages, and a topology scheduler.
 You can then use the Node Tuning Operator with Single Root I/O Virtualization (SR-IOV) to achieve a specific Data Plane Development Kit (DPDK) line rate.
 
@@ -33,10 +34,10 @@ metadata:
 spec:
   globallyDisableIrqLoadBalancing: true
   cpu:
-    isolated: 21-51,73-103 <1>
-    reserved: 0-20,52-72 <2>
+    isolated: 21-51,73-103
+    reserved: 0-20,52-72
   hugepages:
-    defaultHugepagesSize: 1G <3>
+    defaultHugepagesSize: 1G
     pages:
       - count: 32
         size: 1G
@@ -47,9 +48,17 @@ spec:
   nodeSelector:
     node-role.kubernetes.io/worker-cnf: ""
 ----
-<1> If hyperthreading is enabled on the system, allocate the relevant symbolic links to the `isolated` and `reserved` CPU groups. If the system contains multiple non-uniform memory access nodes (NUMAs), allocate CPUs from both NUMAs to both groups. You can also use the Performance Profile Creator for this task. For more information, see _Creating a performance profile_.
-<2> You can also specify a list of devices that will have their queues set to the reserved CPU count. For more information, see _Reducing NIC queues using the Node Tuning Operator_.
-<3> Allocate the number and size of hugepages needed. You can specify the NUMA configuration for the hugepages. By default, the system allocates an even number to every NUMA node on the system. If needed, you can request the use of a realtime kernel for the nodes. See _Provisioning a worker with real-time capabilities_ for more information.
++
+where:
++
+`metadata.name`:: Specifies the name of the performance profile.
+`spec.cpu.isolated`:: Specifies the CPUs that are isolated for the application workloads. If Hyper-Threading is enabled on the system, allocate the relevant symbolic links to the `isolated` and `reserved` CPU groups. If the system has multiple non-uniform memory access (NUMA) nodes, allocate CPUs from both NUMAs to both groups. You can also use the Performance Profile Creator for this task. For more information, see _Creating a performance profile_.
+`spec.cpu.reserved`:: Specifies the CPUs that are reserved for the operating system and Kubernetes system daemons. You can also specify a list of devices that will have their queues set to the reserved CPU count. For more information, see _Reducing NIC queues using the Node Tuning Operator_.
+`spec.hugepages.defaultHugepagesSize`:: Specifies the default size of hugepages.
+`spec.hugepages.pages`:: Specifies the number and size of hugepages to allocate. You can specify the NUMA configuration for the hugepages. By default, the system allocates an even number to every NUMA node on the system.
+`spec.net.userLevelNetworking`:: Specifies whether to enable user-level networking. Set to `true` for DPDK workloads.
+`spec.numa.topologyPolicy`:: Specifies the NUMA topology policy. Set to `single-numa-node` to ensure that all resources are allocated from the same NUMA node.
+`spec.nodeSelector`:: Specifies the node selector label for nodes that this performance profile applies to.
 . Save the `yaml` file as `mlx-dpdk-perfprofile-policy.yaml`.
 . Apply the performance profile using the following command:
 +

--- a/modules/nw-sriov-example-vf-function-in-pod.adoc
+++ b/modules/nw-sriov-example-vf-function-in-pod.adoc
@@ -6,6 +6,7 @@
 [id="example-vf-use-in-pod_{context}"]
 = Example use of a virtual function in a pod
 
+[role="_abstract"]
 You can run a remote direct memory access (RDMA) or a Data Plane Development Kit (DPDK) application in a pod with SR-IOV VF attached.
 
 This example shows a pod using a virtual function (VF) in RDMA mode:

--- a/modules/nw-sriov-network-operator.adoc
+++ b/modules/nw-sriov-network-operator.adoc
@@ -6,6 +6,7 @@
 [id="nw-sriov-network-operator_{context}"]
 = Example SR-IOV Network Operator for virtual functions
 
+[role="_abstract"]
 You can use the Single Root I/O Virtualization (SR-IOV) Network Operator to allocate and configure Virtual Functions (VFs) from SR-IOV-supporting Physical Function NICs on the nodes.
 
 For more information on deploying the Operator, see _Installing the SR-IOV Network Operator_.
@@ -21,8 +22,8 @@ metadata:
   name: dpdk-nic-1
   namespace: openshift-sriov-network-operator
 spec:
-  deviceType: vfio-pci <1>
-  needVhostNet: true <2>
+  deviceType: vfio-pci
+  needVhostNet: true
   nicSelector:
     pfNames: ["ens3f0"]
   nodeSelector:
@@ -48,8 +49,11 @@ spec:
   resourceName: dpdk_nic_2
 
 ----
-<1> For Intel NICs, `deviceType` must be `vfio-pci`.
-<2> If kernel communication with DPDK workloads is required, add `needVhostNet: true`. This mounts the `/dev/net/tun` and `/dev/vhost-net` devices into the container so the application can create a tap device and connect the tap device to the DPDK workload.
+
+where:
+
+`spec.deviceType`:: For Intel NICs, `deviceType` must be `vfio-pci`.
+`spec.needVhostNet`:: If kernel communication with DPDK workloads is required, set to `true`. This mounts the `/dev/net/tun` and `/dev/vhost-net` devices into the container so the application can create a tap device and connect the tap device to the DPDK workload.
 
 The following is an example of an `sriovNetworkNodePolicy` object for Mellanox NICs:
 [source,yaml]
@@ -60,8 +64,8 @@ metadata:
   name: dpdk-nic-1
   namespace: openshift-sriov-network-operator
 spec:
-  deviceType: netdevice <1>
-  isRdma: true <2>
+  deviceType: netdevice
+  isRdma: true
   nicSelector:
     rootDevices:
       - "0000:5e:00.1"
@@ -88,6 +92,8 @@ spec:
   priority: 99
   resourceName: dpdk_nic_2
 ----
-<1> For Mellanox devices the `deviceType` must be `netdevice`.
-<2> For Mellanox devices `isRdma` must be `true`.
-Mellanox cards are connected to DPDK applications using Flow Bifurcation. This mechanism splits traffic between Linux user space and kernel space, and can enhance line rate processing capability.
+
+where:
+
+`spec.deviceType`:: For Mellanox devices the `deviceType` must be `netdevice`.
+`spec.isRdma`:: For Mellanox devices `isRdma` must be `true`. Mellanox cards are connected to DPDK applications using Flow Bifurcation. This mechanism splits traffic between Linux user space and kernel space, and can enhance line rate processing capability.

--- a/modules/nw-sriov-rdma-example-mellanox.adoc
+++ b/modules/nw-sriov-rdma-example-mellanox.adoc
@@ -6,10 +6,12 @@
 [id="example-vf-use-in-rdma-mode-mellanox_{context}"]
 = Using a virtual function in RDMA mode with a Mellanox NIC
 
-// Extract content for TP notice
-// tag::content[]
-RDMA over Converged Ethernet (RoCE) is the only supported mode when using RDMA
-on {product-title}.
+:FeatureName: RDMA over Converged Ethernet (RoCE)
+include::snippets/technology-preview.adoc[leveloffset=+0]
+:!FeatureName:
+
+[role="_abstract"]
+RDMA over Converged Ethernet (RoCE) is the only supported mode when using RDMA on {product-title}.
 
 .Prerequisites
 
@@ -36,22 +38,25 @@ spec:
   numVfs: <num>
   nicSelector:
     vendor: "15b3"
-    deviceID: "1015" <1>
+    deviceID: "1015"
     pfNames: ["<pf_name>", ...]
     rootDevices: ["<pci_bus_id>", "..."]
-  deviceType: netdevice <2>
-  isRdma: true <3>
+  deviceType: netdevice
+  isRdma: true
 ----
-<1> Specify the device hex code of the SR-IOV network device.
-<2> Specify the driver type for the virtual functions to `netdevice`.
-<3> Enable RDMA mode.
++
+where:
++
+`spec.nicSelector.deviceID`:: Specifies the device hex code of the SR-IOV network device.
+`spec.deviceType`:: Specifies the driver type for the virtual functions. Set to `netdevice` for Mellanox NICs.
+`spec.isRdma`:: Set to `true` to enable RDMA mode.
 +
 [NOTE]
 =====
 See the `Configuring SR-IOV network devices` section for a detailed explanation on each option in `SriovNetworkNodePolicy`.
 
-When applying the configuration specified in a `SriovNetworkNodePolicy` object, the SR-IOV Operator may drain the nodes, and in some cases, reboot nodes.
-It may take several minutes for a configuration change to apply.
+When applying the configuration specified in a `SriovNetworkNodePolicy` object, the SR-IOV Operator might drain the nodes, and in some cases, reboot nodes.
+It might take several minutes for a configuration change to apply.
 Ensure that there are enough available nodes in your cluster to handle the evicted workload beforehand.
 
 After the configuration update is applied, all the pods in the `openshift-sriov-network-operator` namespace will change to a `Running` status.
@@ -75,12 +80,15 @@ metadata:
   namespace: openshift-sriov-network-operator
 spec:
   networkNamespace: <target_namespace>
-  ipam: |- <1>
+  ipam: |-
 # ...
   vlan: <vlan>
   resourceName: mlxnics
 ----
-<1> Specify a configuration object for the ipam CNI plugin as a YAML block scalar. The plugin manages IP address assignment for the attachment definition.
++
+where:
++
+`spec.ipam`:: Specifies a configuration object for the IPAM CNI plugin as a YAML block scalar. The plugin manages IP address assignment for the attachment definition.
 +
 [NOTE]
 =====
@@ -104,25 +112,25 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: rdma-app
-  namespace: <target_namespace> <1>
+  namespace: <target_namespace>
   annotations:
     k8s.v1.cni.cncf.io/networks: mlx-rdma-network
 spec:
   containers:
   - name: testpmd
-    image: <RDMA_image> <2>
+    image: <RDMA_image>
     securityContext:
       runAsUser: 0
       capabilities:
-        add: ["IPC_LOCK","SYS_RESOURCE","NET_RAW"] <3>
+        add: ["IPC_LOCK","SYS_RESOURCE","NET_RAW"]
     volumeMounts:
-    - mountPath: /mnt/huge <4>
+    - mountPath: /mnt/huge
       name: hugepage
     resources:
       limits:
         memory: "1Gi"
-        cpu: "4" <5>
-        hugepages-1Gi: "4Gi" <6>
+        cpu: "4"
+        hugepages-1Gi: "4Gi"
       requests:
         memory: "1Gi"
         cpu: "4"
@@ -133,12 +141,15 @@ spec:
     emptyDir:
       medium: HugePages
 ----
-<1> Specify the same `target_namespace` where `SriovNetwork` object `mlx-rdma-network` is created. If you would like to create the pod in a different namespace, change `target_namespace` in both `Pod` spec and `SriovNetwork` object.
-<2> Specify the RDMA image which includes your application and RDMA library used by application.
-<3> Specify additional capabilities required by the application inside the container for hugepage allocation, system resource allocation, and network interface access.
-<4> Mount the hugepage volume to RDMA pod under `/mnt/huge`. The hugepage volume is backed by the emptyDir volume type with the medium being `Hugepages`.
-<5> Specify number of CPUs. The RDMA pod usually requires exclusive CPUs be allocated from the kubelet. This is achieved by setting CPU Manager policy to `static` and create pod with `Guaranteed` QoS.
-<6> Specify hugepage size `hugepages-1Gi` or `hugepages-2Mi` and the quantity of hugepages that will be allocated to the RDMA pod. Configure `2Mi` and `1Gi` hugepages separately. Configuring `1Gi` hugepage requires adding kernel arguments to Nodes.
++
+where:
++
+`metadata.namespace`:: Specifies the same namespace where `SriovNetwork` object `mlx-rdma-network` is created. If you want to create the pod in a different namespace, change `target_namespace` in both the `Pod` spec and the `SriovNetwork` object.
+`spec.containers.image`:: Specifies the RDMA image which includes your application and the RDMA library used by the application.
+`spec.containers.securityContext.capabilities.add`:: Specifies additional capabilities required by the application inside the container for hugepage allocation, system resource allocation, and network interface access.
+`spec.containers.volumeMounts.mountPath`:: Specifies the path where the hugepage volume is mounted in the RDMA pod. The hugepage volume is backed by the `emptyDir` volume type with the medium being `HugePages`.
+`spec.containers.resources.limits.cpu`:: Specifies the number of CPUs. The RDMA pod usually requires exclusive CPUs be allocated from the kubelet. This is achieved by setting CPU Manager policy to `static` and creating a pod with `Guaranteed` QoS.
+`spec.containers.resources.limits.hugepages-1Gi`:: Specifies the hugepage size (`hugepages-1Gi` or `hugepages-2Mi`) and the quantity of hugepages that will be allocated to the RDMA pod. Configure `2Mi` and `1Gi` hugepages separately. Configuring `1Gi` hugepage requires adding kernel arguments to Nodes.
 
 . Create the RDMA pod by running the following command:
 +
@@ -146,4 +157,3 @@ spec:
 ----
 $ oc create -f mlx-rdma-pod.yaml
 ----
-// end::content[]

--- a/networking/hardware_networks/using-dpdk-and-rdma.adoc
+++ b/networking/hardware_networks/using-dpdk-and-rdma.adoc
@@ -6,6 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 The containerized Data Plane Development Kit (DPDK) application is supported on {product-title}. You can use Single Root I/O Virtualization (SR-IOV) network hardware with the Data Plane Development Kit (DPDK) and with remote direct memory access (RDMA).
 
 Before you perform any tasks in the following documentation, ensure that you xref:../../networking/networking_operators/sr-iov-operator/installing-sriov-operator.adoc#installing-sriov-operator[installed the SR-IOV Network Operator].
@@ -44,14 +45,7 @@ include::modules/nw-sriov-dpdk-base-workload.adoc[leveloffset=+2]
 
 include::modules/nw-sriov-dpdk-running-testpmd.adoc[leveloffset=+2]
 
-[id="example-vf-use-in-rdma-mode-mellanox_{context}"]
-== Using a virtual function in RDMA mode with a Mellanox NIC
-
-:FeatureName: RDMA over Converged Ethernet (RoCE)
-include::snippets/technology-preview.adoc[leveloffset=+0]
-
-// Use a tag to skip header and include content only
-include::modules/nw-sriov-rdma-example-mellanox.adoc[tag=content]
+include::modules/nw-sriov-rdma-example-mellanox.adoc[leveloffset=+1]
 
 // A test pod template for clusters that use OVS-DPDK on OpenStack
 include::modules/nw-openstack-ovs-dpdk-testpmd-pod.adoc[leveloffset=+1]
@@ -75,5 +69,3 @@ include::modules/nw-openstack-ovs-dpdk-testpmd-pod.adoc[leveloffset=+1]
 * xref:../../scalability_and_performance/cnf-provisioning-low-latency-workloads.adoc#disabling-interrupt-processing-for-individual-pods_cnf-provisioning-low-latency[Disabling interrupt processing for individual pods]
 
 * xref:../../networking/hardware_networks/configuring-sriov-net-attach.adoc#configuring-sriov-net-attach[Configuring an SR-IOV Ethernet network attachment]
-
-:!FeatureName:


### PR DESCRIPTION
## Summary
- Fix all Error and Warning level AsciiDocDITA Vale violations in `networking/hardware_networks/using-dpdk-and-rdma.adoc` and its 13 included modules to prepare for DITA conversion
- Add `[role="_abstract"]` short descriptions, convert callout lists to bullet lists, fix AssemblyContents by moving TP notice into module, fix terminology and style warnings
- 14 files changed across assembly and modules

## Test plan
- [ ] Verify Vale AsciiDocDITA rules show no remaining Errors or Warnings
- [ ] Verify `asciibinder build` completes without errors
- [ ] Verify rendered content is unchanged in preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)