### PR TITLE
TELCODOCS-2859: Fix AsciiDocDITA violations in attaching-pod docs

### DIFF
--- a/modules/nw-multus-advanced-annotations.adoc
+++ b/modules/nw-multus-advanced-annotations.adoc
@@ -106,9 +106,8 @@ To set a static IP address or MAC address for a pod you can use the JSON formatt
 $ oc edit networks.operator.openshift.io cluster
 ----
 +
-The following YAML describes the configuration parameters for the CNO:
+The following YAML describes the Cluster Network Operator (CNO) configuration parameters:
 +
-.Cluster Network Operator YAML configuration
 [source,terminal,subs="attributes+"]
 ----
 name: <name>
@@ -127,9 +126,8 @@ where:
 `rawCNIConfig`:: Specifies the CNI plugin configuration in JSON format, which is based on the following template.
 --
 +
-The following object describes the configuration parameters for utilizing static MAC address and IP address using the macvlan CNI plugin:
+The following object describes the configuration parameters for the macvlan CNI plugin by using a static MAC address and IP address:
 +
-.macvlan CNI plugin JSON configuration object using static IP and MAC address
 [source,json]
 ----
 {
@@ -170,7 +168,8 @@ The above network attachment can be referenced in a JSON formatted annotation, a
 $ oc edit pod <name>
 ----
 +
-.macvlan CNI plugin JSON configuration object using static IP and MAC address
+The following example shows a macvlan CNI plugin JSON configuration object by using a static IP and MAC address:
++
 [source,yaml]
 ----
 apiVersion: v1

--- a/networking/multiple_networks/secondary_networks/attaching-pod.adoc
+++ b/networking/multiple_networks/secondary_networks/attaching-pod.adoc
@@ -1,6 +1,7 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="attaching-pod"]
 = Attaching a pod to a secondary network
+
 include::_attributes/common-attributes.adoc[]
 :context: attaching-pod
 


### PR DESCRIPTION
## Summary
- Fix 4 AsciiDocDITA warnings to prepare files for DITA conversion
- Add blank line after assembly title to prevent author line detection in `attaching-pod.adoc`
- Replace 3 unsupported block titles with inline lead-in text in `nw-multus-advanced-annotations.adoc`

## Test plan
- [ ] Verify Vale AsciiDocDITA rules pass with 0 errors and 0 warnings
- [ ] Verify AsciiDoc renders correctly with `asciibinder build`
- [ ] Review that block title content is preserved in lead-in sentences

🤖 Generated with [Claude Code](https://claude.com/claude-code)