### PR TITLE
OSDOCS-18675-abstracts: PC review for REG-3 Registry Core Access, Sec…

### DIFF
--- a/modules/pruning-images.adoc
+++ b/modules/pruning-images.adoc
@@ -7,7 +7,7 @@
 = Automatically pruning images
 
 [role="_abstract"]
-Images from the {product-registry} that are no longer required by the system because of age, status, or exceed limits being automatically pruned. As a cluster administrator, can configure or suspend the pruning Custom Resource (CR).
+To reclaim storage in the {product-registry} in {product-title} and set how long the cluster keeps images, you can configure the automatic image pruner. You set the schedule, suspension, and retention options on the pruning custom resource (CR).
 
 .Prerequisites
 

--- a/modules/registry-operator-distribution-across-availability-zones.adoc
+++ b/modules/registry-operator-distribution-across-availability-zones.adoc
@@ -7,7 +7,7 @@
 = Image Registry Operator distribution across availability zones
 
 [role="_abstract"]
-The default configuration of the Image Registry Operator spreads image registry pods across topology zones to prevent delayed recovery times in case of a complete zone failure where all pods are impacted. Reference the following YAML to understand the default parameter values that the Image Registry Operator uses when the Operator deploys with a zone-related topology constraint:
+The default configuration of the Image Registry Operator spreads image registry pods across topology zones to prevent delayed recovery times in case of a complete zone failure where all pods are impacted. Reference the example YAML to understand the default parameter values that the Image Registry Operator uses when the Operator deploys with a zone-related topology constraint:
 
 [source,yaml]
 ----


### PR DESCRIPTION
The short description NotebookLM was used to generate abstracts. However, as part of the remediation process, I've reviewed abstracts, to what I think, require rolling back to a closer alignment with the original text. I've provided direct links to original CQA work for each revised abstract.

Original CQA PR: https://github.com/openshift/openshift-docs/pull/102217

Version(s):
4.20+

Issue:
[OSDOCS-18675](https://redhat.atlassian.net/browse/OSDOCS-18675)

Link to docs preview:

* [Automatically pruning images](https://109238--ocpdocs-pr.netlify.app/openshift-dedicated/latest/applications/pruning-objects.html#pruning-images_pruning-objects)
* [Image Registry Operator distribution across availability zones](https://109238--ocpdocs-pr.netlify.app/openshift-enterprise/latest/registry/configuring-registry-operator.html#registry-operator-distribution-across-availability-zones_configuring-registry-operator)