### PR TITLE
TELCODOCS-2860: Fix Vale errors in multi-network policy docs

### DIFF
--- a/modules/nw-multi-network-policy-ipv6-suppport.adoc
+++ b/modules/nw-multi-network-policy-ipv6-suppport.adoc
@@ -9,7 +9,7 @@
 [role="_abstract"]
 The ICMPv6 Neighbor Discovery Protocol (NDP) is a set of messages and processes that enable devices to discover and maintain information about neighboring nodes. NDP plays a crucial role in IPv6 networks, facilitating the interaction between devices on the same link.
 
-The Cluster Network Operator (CNO) deploys the iptables implementation of multi-network policy when the `useMultiNetworkPolicy` parameter is set to `true`.
+The Cluster Network Operator (CNO) deploys the `iptables` implementation of multi-network policy when the `useMultiNetworkPolicy` parameter is set to `true`.
 
 To support multi-network policies in IPv6 networks the Cluster Network Operator deploys the following set of custom rules in every pod affected by a multi-network policy:
 

--- a/modules/nw-networkpolicy-allow-application-all-namespaces.adoc
+++ b/modules/nw-networkpolicy-allow-application-all-namespaces.adoc
@@ -88,7 +88,7 @@ where:
 +
 [NOTE]
 ====
-By default, if you do not specify a `namespaceSelector` parameter in the policy object, no namespaces get selected. This means the policy allows traffic only from the namespace where the network policy deployes.
+By default, if you do not specify a `namespaceSelector` parameter in the policy object, no namespaces get selected. This means the policy allows traffic only from the namespace where the network policy deploys.
 ====
 
 . Apply the policy by entering the following command. Successful output lists the name of the policy object and the `created` status.

--- a/modules/nw-networkpolicy-create-cli.adoc
+++ b/modules/nw-networkpolicy-create-cli.adoc
@@ -71,7 +71,6 @@ ifdef::multi[]
 ----
 apiVersion: k8s.cni.cncf.io/v1beta1
 kind: MultiNetworkPolicy
-endif:: multi[]
 metadata:
   name: deny-by-default
   annotations:
@@ -243,7 +242,7 @@ $ oc apply -f <policy_name>.yaml -n <namespace>
 where:
 
 `<policy_name>`:: Specifies the {name} policy file name.
-`<namespace>`:: Optional parameter. If you defined the object in a different namespace than the current namespace, the parameter specifices the namespace.
+`<namespace>`:: Optional parameter. If you defined the object in a different namespace than the current namespace, the parameter specifies the namespace.
 --
 +
 Successful output lists the name of the policy object and the `created` status.

--- a/modules/nw-networkpolicy-delete-cli.adoc
+++ b/modules/nw-networkpolicy-delete-cli.adoc
@@ -55,7 +55,7 @@ $ oc delete {name}policy <policy_name> -n <namespace>
 where:
 +
 `<policy_name>`:: Specifies the name of the {name} policy.
-`<namespace>`:: Optional parameter. If you defined the object in a different namespace than the current namespace, the parameter specifices the namespace.
+`<namespace>`:: Optional parameter. If you defined the object in a different namespace than the current namespace, the parameter specifies the namespace.
 
 ifdef::multi[]
 :!multi:

--- a/networking/multiple_networks/secondary_networks/configuring-multi-network-policy.adoc
+++ b/networking/multiple_networks/secondary_networks/configuring-multi-network-policy.adoc
@@ -7,7 +7,7 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 [role="_abstract"]
-As an administrator, you can use the `MultiNetworkPolicy` API to create multiple network policies that manage traffic for pods that are attached to secondary networks. For example, you can create policies that allow or deny traffic based on specific ports, IPs and ranges, or labels.
+As an administrator, you can use the `MultiNetworkPolicy` API to create multiple network policies that manage traffic for pods that are attached to secondary networks. For example, you can create policies that allow or deny traffic based on specific ports, IP addresses and ranges, or labels.
 
 Multi-network policies can be used to manage traffic on secondary networks in the cluster. These policies cannot manage the default cluster network or primary network of user-defined networks. 
 
@@ -55,5 +55,5 @@ include::modules/nw-networkpolicy-allow-application-particular-namespace.adoc[le
 
 * xref:../../../networking/network_security/network_policy/about-network-policy.adoc#about-network-policy[About network policy]
 * xref:../../../networking/multiple_networks/understanding-multiple-networks.adoc#understanding-multiple-networks[Understanding multiple networks]
-* xref:../../../networking/multiple_networks/secondary_networks/creating-secondary-nwt-other-cni.adoc#nw-multus-macvlan-object_configuring-additional-network-cni[Configuring a macvlan network]
+* xref:../../../networking/multiple_networks/secondary_networks/creating-secondary-nwt-other-cni.adoc#nw-multus-macvlan-object_configuring-additional-network-cni[Configuring a `macvlan` network]
 * xref:../../../networking/hardware_networks/configuring-sriov-device.adoc#configuring-sriov-device[Configuring an SR-IOV network device]


### PR DESCRIPTION
## Summary
- Fix typos: "specifices" → "specifies" in `nw-networkpolicy-create-cli.adoc` and `nw-networkpolicy-delete-cli.adoc`
- Fix typo: "deployes" → "deploys" in `nw-networkpolicy-allow-application-all-namespaces.adoc`
- Remove spurious `endif:: multi[]` directive inside a YAML code block in `nw-networkpolicy-create-cli.adoc` (caused unbalanced if statement error)
- Wrap `iptables` in backticks in `nw-multi-network-policy-ipv6-suppport.adoc`
- Replace "IPs" with "IP addresses" in `configuring-multi-network-policy.adoc`
- Wrap `macvlan` in backticks in xref link text in `configuring-multi-network-policy.adoc`

## Test plan
- [x] Vale linting passes with 0 errors and 0 warnings on all modified files
- [ ] Verify rendering of xref link text with backticks in `macvlan`

🤖 Generated with [Claude Code](https://claude.com/claude-code)