### PR TITLE
OCPBUGS#77836: Remove references to Elasticsearch from OKE docs

### DIFF
--- a/welcome/oke_about.adoc
+++ b/welcome/oke_about.adoc
@@ -194,7 +194,7 @@ the kubevirt.io open source project.
 === Advanced cluster management
 {oke} is compatible with your additional purchase of {rh-rhacm-first} for
 Kubernetes. An {oke} subscription does not offer a cluster-wide log aggregation
-solution or support Fluentd, or Kibana-based logging solutions.
+solution.
 {SMProductName} capabilities derived from the open-source istio.io and kiali.io
 projects that offer OpenTracing observability for containerized services on
 {product-title} are not supported in {oke}.


### PR DESCRIPTION
Version(s):
4.18+

Issue:
[OCPBUGS-77836](https://redhat.atlassian.net/browse/OCPBUGS-77836)

Link to docs preview:
Advanced Cluster Management
https://109243--ocpdocs-pr.netlify.app/openshift-enterprise/latest/welcome/oke_about.html

QE review:
- [x] QE has approved this change.