### PR TITLE
Fix Wherabouts typo in fast IPAM module

### DIFF
--- a/modules/nw-multus-whereabouts-fast-ipam.adoc
+++ b/modules/nw-multus-whereabouts-fast-ipam.adoc
@@ -9,9 +9,9 @@
 = Fast IPAM configuration for the Whereabouts IPAM CNI plugin
 
 [role="_abstract"]
-Wherabouts is an IP Address Management (IPAM) Container Network Interface (CNI) plugin that assigns IP addresses at a cluster-wide level. Whereabouts does not require a Dynamic Host Configuration Protocol (DHCP) server.
+Whereabouts is an IP Address Management (IPAM) Container Network Interface (CNI) plugin that assigns IP addresses at a cluster-wide level. Whereabouts does not require a Dynamic Host Configuration Protocol (DHCP) server.
 
-A typical Wherabouts workflow is described as follows:
+A typical Whereabouts workflow is described as follows:
 
 . Whereabouts takes an address range in classless inter-domain routing (CIDR) notation, such as `192.168.2.0/24`, and assigns IP addresses within that range, such as `192.168.2.1` to `192.168.2.254`.
 . Whereabouts assigns an IP address, the lowest value address in a CIDR range, to a pod and tracks the IP address in a data store for the lifetime of that pod.


### PR DESCRIPTION
## Summary
- Fixes typo `Wherabouts` → `Whereabouts` in `modules/nw-multus-whereabouts-fast-ipam.adoc` (2 occurrences)

## Test plan
- [ ] Verify correct spelling in built docs
- [ ] Run Vale linting to confirm no new warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)