### PR TITLE
OSDOCS Document how to perform boot image updates on none/external clusters

### DIFF
--- a/machine_configuration/mco-update-boot-images-manual.adoc
+++ b/machine_configuration/mco-update-boot-images-manual.adoc
@@ -30,6 +30,8 @@ include::modules/mco-update-boot-images-openstack.adoc[leveloffset=+1]
 
 include::modules/mco-update-boot-images-vsphere.adoc[leveloffset=+1]
 
+include::modules/mco-update-boot-images-plat-none.adoc[leveloffset=+1]
+
 [role="_additional-resources"]
 [id="additional-resources_{context}"]
 == Additional resources
@@ -40,4 +42,4 @@ include::modules/mco-update-boot-images-vsphere.adoc[leveloffset=+1]
 * xref:../installing/installing_aws/installing-aws-account.adoc#installing-aws-account[Configuring an AWS account]
 * xref:../installing/installing_gcp/installing-restricted-networks-gcp.adoc#installation-creating-gcp-worker_installing-restricted-networks-gcp[Creating additional worker machines in {gcp-short}]
 * xref:../installing/installing_vsphere/upi/upi-vsphere-installation-reqs.adoc#installation-vsphere-encrypted-vms_upi-vsphere-installation-reqs[Requirements for encrypting virtual machines]
-
+* xref:../machine_management/user_infra/adding-compute-user-infra-general.adoc#adding-compute-user-infra-general[Adding compute machines to clusters with user-provisioned infrastructure manually]

--- a/modules/mco-update-boot-images-plat-none.adoc
+++ b/modules/mco-update-boot-images-plat-none.adoc
@@ -1,0 +1,40 @@
+// Module included in the following assemblies:
+//
+// * machine_configuration/mco-update-boot-images-manual.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="mco-update-boot-images-plat-none_{context}"]
+= Manually updating the boot image on a platform none or external cluster
+
+[role="_abstract"]
+For `platform: None` and `platform: External` clusters, you can manually update the boot image for your cluster by configuring your machine sets to use the latest {product-title} image as the boot image to help ensure any new nodes can scale up properly.
+
+For these clusters, {product-title} does not manage node provisioning or {op-system-first} boot images. These clusters do not use Machine API machine sets. 
+
+[NOTE]
+====
+The standard boot image management feature is not supported for `platform: None` or `platform: External` clusters.
+====
+
+The method for updating boot images depends on how nodes are added to your cluster as a day-2 operation. 
+
+[cols="1,1",options="header"]
+|===
+| Method | Description
+| User-provisioned infrastructure clusters | Nodes are provisioned manually by a user-managed infrastructure.
+| {rh-rhacm-first}-managed clusters | Nodes are added by using a discovery ISO managed by an `InfraEnv` object on the hub cluster.
+| External provider clusters | Nodes are provisioned by using provider-specific tooling with a user-uploaded {op-system} image.
+|===
+
+User-provisioned infrastructure::
+For user-provisioned infrastructure clusters, you manage boot images as part of your infrastructure. To update the boot image, download the latest {op-system} image for your architecture from link:https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/[mirror.openshift.com] and update your infrastructure to serve the new image.
++
+For the full procedure, see the section for your platform in "Adding compute machines to clusters with user-provisioned infrastructure manually".
+
+{rh-rhacm}-managed clusters::
+For clusters managed by {rh-rhacm}, the boot image used to generate the discovery ISO image is controlled by the `spec.osImageVersion` parameter in the `InfraEnv` object on the hub cluster. After an {product-title} upgrade, you need to update the existing `InfraEnv` object to add or update `spec.osImageVersion` field, specifying the {product-title} version of the new boot image.  
+
+External provider clusters::
+For clusters managed by an external infrastructure provider, such as Oracle Cloud Infrastructure (OCI), you must upload the new boot image to the provider's image store and update your node provisioning configuration to reference the new image when creating new nodes. The exact steps are provider-specific.
+
+If boot image skew enforcement in your cluster is set to the manual mode, after updating the boot image, update the version of the new boot image in the `MachineConfiguration` object as described in "Updating the boot image skew enforcement version".


### PR DESCRIPTION
https://redhat.atlassian.net/browse/OSDOCS-18560

Link to docs preview:
[Manually updating the boot image on a platform none or external cluster](https://109248--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_configuration/mco-update-boot-images-manual#mco-update-boot-images-plat-none_mco-update-boot-images-manual)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
