### PR TITLE
[enterprise-4.19] OSDOCS-18563 [NETOBSERV] Update remaining callouts

### DIFF
--- a/modules/network-observability-RTT.adoc
+++ b/modules/network-observability-RTT.adoc
@@ -31,9 +31,12 @@ spec:
     type: eBPF
     ebpf:
       features:
-       - FlowRTT   <1>
+       - FlowRTT
 ----
-<1> You can start tracing RTT network flows by listing the `FlowRTT` parameter in the `spec.agent.ebpf.features` specification list.
++
+where:
+
+`spec.agent.ebpf.features`:: Specifies the list of eBPF features to enable. Add `FlowRTT` to this list to start tracing Round-trip time (RTT) network flows.
 
 .Verification
 After the *Network Traffic* page is refreshed, the *Overview*, *Traffic flows*, and *Topology* views display RTT information.

--- a/modules/network-observability-configuring-custom-metrics-examples.adoc
+++ b/modules/network-observability-configuring-custom-metrics-examples.adoc
@@ -19,23 +19,26 @@ apiVersion: flows.netobserv.io/v1alpha1
 kind: FlowMetric
 metadata:
   name: flowmetric-cluster-external-ingress-traffic
-  namespace: netobserv                              <1>
+  namespace: netobserv
 spec:
-  metricName: cluster_external_ingress_bytes_total  <2>
-  type: Counter                                     <3>
+  metricName: cluster_external_ingress_bytes_total
+  type: Counter
   valueField: Bytes
-  direction: Ingress                                <4>
-  labels: [DstK8S_HostName,DstK8S_Namespace,DstK8S_OwnerName,DstK8S_OwnerType] <5>
-  filters:                                          <6>
+  direction: Ingress
+  labels: [DstK8S_HostName,DstK8S_Namespace,DstK8S_OwnerName,DstK8S_OwnerType]
+  filters:
   - field: SrcSubnetLabel
     matchType: Absence
 ----
-<1> The `FlowMetric` resources need to be created in the namespace defined in the `FlowCollector` `spec.namespace`, which is `netobserv` by default.
-<2> The name of the Prometheus metric, which in the web console appears with the prefix `netobserv-<metricName>`.
-<3> The `type` specifies the type of metric. The `Counter` `type` is useful for counting bytes or packets.
-<4> The direction of traffic to capture. If not specified, both ingress and egress are captured, which can lead to duplicated counts.
-<5> Labels define what the metrics look like and the relationship between the different entities and also define the metrics cardinality. For example, `SrcK8S_Name` is a high cardinality metric.
-<6> Refines results based on the listed criteria. In this example,  selecting only the cluster external traffic is done by matching only flows where `SrcSubnetLabel` is absent. This assumes the subnet labels feature is enabled (via `spec.processor.subnetLabels`), which is done by default.
+
+where:
+
+`metadata.namespace`:: Specifies the namespace where the `FlowMetric` resources are created. This must match the namespace defined in the `FlowCollector` resource `spec.namespace` field, which is `netobserv` by default.
+`spec.metricName`:: Specifies the name of the Prometheus metric, which in the {product-title} web console appears with the prefix `netobserv-<metricName>`.
+`spec.type`:: Specifies the type of metric. The `Counter` type is useful for counting bytes or packets.
+`spec.direction`:: Specifies the direction of traffic to capture. If not specified, both ingress and egress are captured, which can lead to duplicated counts.
+`spec.labels`:: Specifies the labels that define what the metrics look like, the relationship between the different entities, and the metrics cardinality. For example, `SrcK8S_Name` is a high cardinality metric.
+`spec.filters`:: Specifies the criteria to refine results based on the listed criteria. In this example, selecting only the cluster external traffic is done by matching only flows where `SrcSubnetLabel` is absent. This assumes the subnet labels feature is enabled (via `spec.processor.subnetLabels`), which is done by default
 
 [id="monitoring-rtt-latency-for-cluster-external-ingress-traffic_{context}"]
 == Monitoring RTT latency for cluster external ingress traffic
@@ -48,10 +51,10 @@ apiVersion: flows.netobserv.io/v1alpha1
 kind: FlowMetric
 metadata:
   name: flowmetric-cluster-external-ingress-rtt
-  namespace: netobserv    <1>
+  namespace: netobserv
 spec:
   metricName: cluster_external_ingress_rtt_seconds
-  type: Histogram                 <2>
+  type: Histogram
   valueField: TimeFlowRttNs
   direction: Ingress
   labels: [DstK8S_HostName,DstK8S_Namespace,DstK8S_OwnerName,DstK8S_OwnerType]
@@ -60,10 +63,13 @@ spec:
     matchType: Absence
   - field: TimeFlowRttNs
     matchType: Presence
-  divider: "1000000000"      <3>
-  buckets: [".001", ".005", ".01", ".02", ".03", ".04", ".05", ".075", ".1", ".25", "1"]  <4>
+  divider: "1000000000"
+  buckets: [".001", ".005", ".01", ".02", ".03", ".04", ".05", ".075", ".1", ".25", "1"]
 ----
-<1> The `FlowMetric` resources need to be created in the namespace defined in the `FlowCollector` `spec.namespace`, which is `netobserv` by default.
-<2> The `type` specifies the type of metric. The `Histogram` `type` is useful for a latency value (`TimeFlowRttNs`).
-<3> Since the Round-trip time (RTT) is provided as nanos in flows, use a divider of 1 billion to convert into seconds, which is standard in Prometheus guidelines.
-<4> The custom buckets specify precision on RTT, with optimal precision ranging between 5ms and 250ms.
+
+where:
+
+`metadata.namespace`:: Specifies the namespace where the `FlowMetric` resources are created. This must match the namespace defined in the `FlowCollector` resource `spec.namespace` field, which is `netobserv` by default.
+`spec.type`:: Specifies the type of metric. The `Histogram` type is useful for a latency value, such as `TimeFlowRttNs`.
+`spec.divider`:: Specifies the value used to divide the metric. Because the Round-trip time (RTT) is provided as nanoseconds in flows, use a divider of 1,000,000,000 to convert the value into seconds, which is standard in Prometheus guidelines.
+`spec.buckets`:: Specifies custom buckets for RTT precision. The optimal precision ranges between 5ms and 250ms.

--- a/modules/network-observability-creating-metrics-network-events.adoc
+++ b/modules/network-observability-creating-metrics-network-events.adoc
@@ -40,20 +40,23 @@ metadata:
 spec:
   metricName: network_policy_events_total
   type: Counter
-  labels: [NetworkEvents>Type, NetworkEvents>Namespace, NetworkEvents>Name, NetworkEvents>Action, NetworkEvents>Direction]       <1>
+  labels: [NetworkEvents>Type, NetworkEvents>Namespace, NetworkEvents>Name, NetworkEvents>Action, NetworkEvents>Direction]
   filters:
   - field: NetworkEvents>Feature
     value: acl
-  flatten: [NetworkEvents]       <2>
-  remap:                         <3>
+  flatten: [NetworkEvents]
+  remap:
     "NetworkEvents>Type": type
     "NetworkEvents>Namespace": namespace
     "NetworkEvents>Name": name
     "NetworkEvents>Direction": direction
 ----
-<1> These labels represent the nested fields for *Network Events* from the *Traffic flows* table. Each network event has a specific type, namespace, name, action, and direction. You can alternatively specify the `Interfaces` if `NetworkEvents` is unavailable in your {product-title} version.
-<2> Optional: You can choose to represent a field that contains a list of items as distinct items.
-<3> Optional: You can rename the fields in Prometheus.
++
+where:
+
+`spec.labels`:: Specifies the labels that represent the nested fields for *Network Events* from the *Traffic flows* table. Each network event has a specific type, namespace, name, action, and direction. You can alternatively specify `Interfaces` if `NetworkEvents` is unavailable in your version of {product-title}.
+`spec.flatten`:: Specifies an optional field that contains a list of items to be represented as distinct items.
+`spec.remap`:: Specifies an optional set of fields to rename in Prometheus.
 
 .Verification
 . In the web console, navigate to *Observe* -> *Dashboards* and scroll down to see the *Network Policy* tab.

--- a/modules/network-observability-deploy-network-policy.adoc
+++ b/modules/network-observability-deploy-network-policy.adoc
@@ -36,9 +36,12 @@ metadata:
 spec:
   namespace: netobserv
   networkPolicy:
-    enable: true <1>
-    additionalNamespaces: ["openshift-console", "openshift-monitoring"] <2>
+    enable: true
+    additionalNamespaces: ["openshift-console", "openshift-monitoring"]
 # ...
 ----
-<1> By default, the `enable` value is `true`.
-<2> Default values are `["openshift-console", "openshift-monitoring"]`.
++
+where:
+
+`spec.networkPolicy.enable`:: Specifies whether to enable network policy management. The default value is `true`.
+`spec.networkPolicy.additionalNamespaces`:: Specifies the namespaces to include in the network policy. The default values are `["openshift-console", "openshift-monitoring"]`.

--- a/modules/network-observability-disabling-health-alerts.adoc
+++ b/modules/network-observability-disabling-health-alerts.adoc
@@ -25,6 +25,9 @@ metadata:
 spec:
   processor:
     metrics:
-      disableAlerts: [NetObservLokiError, NetObservNoFlows] <1>
+      disableAlerts: [NetObservLokiError, NetObservNoFlows]
 ----
-<1> You can specify one or a list with both types of alerts to disable.
++
+where:
+
+`spec.processor.metrics.disableAlerts`:: Specifies one or more types of alerts to disable.

--- a/modules/network-observability-ebpf-agent-alert.adoc
+++ b/modules/network-observability-ebpf-agent-alert.adoc
@@ -37,6 +37,9 @@ spec:
   agent:
     type: eBPF
     ebpf:
-      cacheMaxFlows: 200000 <1>
+      cacheMaxFlows: 200000
 ----
-<1> Increase the `cacheMaxFlows` value from its value at the time of the `NetObservAgentFlowsDropped` alert.
++
+where:
+
+`spec.agent.ebpf.cacheMaxFlows`:: Specifies the maximum number of flows to cache. If a `NetObservAgentFlowsDropped` alert occurs, increase this value from its current level.

--- a/modules/network-observability-enriched-flows.adoc
+++ b/modules/network-observability-enriched-flows.adoc
@@ -33,40 +33,43 @@ metadata:
   name: cluster
 spec:
   exporters:
-  - type: Kafka                         <1>
+  - type: Kafka
       kafka:
         address: "kafka-cluster-kafka-bootstrap.netobserv"
-        topic: netobserv-flows-export   <2>
+        topic: netobserv-flows-export
         tls:
-          enable: false                 <3>
-  - type: IPFIX                         <1>
+          enable: false
+  - type: IPFIX
       ipfix:
         targetHost: "ipfix-collector.ipfix.svc.cluster.local"
         targetPort: 4739
-        transport: tcp or udp           <4>
- -  type: OpenTelemetry                 <1>
+        transport: tcp
+ -  type: OpenTelemetry
       openTelemetry:
         targetHost: my-otelcol-collector-headless.otlp.svc
         targetPort: 4317
-        type: grpc                      <5>
-        logs:                           <6>
+        type: grpc
+        logs:
           enable: true
-        metrics:                        <7>
+        metrics:
           enable: true
           prefix: netobserv
-          pushTimeInterval: 20s         <8>
+          pushTimeInterval: 20s
           expiryTime: 2m
-   #    fieldsMapping:                  <9>
+   #    fieldsMapping:
    #      input: SrcAddr
    #      output: source.address
 ----
-<1> You can export flows to IPFIX, OpenTelemetry, and Kafka individually or concurrently.
-<2> The Network Observability Operator exports all flows to the configured Kafka topic.
-<3> You can encrypt all communications to and from Kafka with SSL/TLS or mTLS. When enabled, the Kafka CA certificate must be available as a ConfigMap or a Secret, both in the namespace where the `flowlogs-pipeline` processor component is deployed (default: netobserv). It must be referenced with `spec.exporters.tls.caCert`. When using mTLS, client secrets must be available in these namespaces as well (they can be generated for instance using the AMQ Streams User Operator) and referenced with `spec.exporters.tls.userCert`.
-<4> You have the option to specify transport. The default value is `tcp` but you can also specify `udp`.
-<5> The protocol of OpenTelemetry connection. The available options are `http` and `grpc`.
-<6> OpenTelemetry configuration for exporting logs, which are the same as the logs created for Loki.
-<7> OpenTelemetry configuration for exporting metrics, which are the same as the metrics created for Prometheus. These configurations are specified in the `spec.processor.metrics.includeList` parameter of the `FlowCollector` custom resource, along with any custom metrics you defined using the `FlowMetrics` custom resource.
-<8> The time interval that metrics are sent to the OpenTelemetry collector.
-<9> *Optional*:Network Observability network flows formats get automatically renamed to an OpenTelemetry compliant format. The `fieldsMapping` specification gives you the ability to customize the OpenTelemetry format output. For example in the YAML sample, `SrcAddr` is the Network Observability input field, and it is being renamed `source.address` in OpenTelemetry output. You can see both Network Observability and OpenTelemetry formats in the "Network flows format reference".
++
+where:
 
+`spec.exporters.type`:: Specifies the export type. You can export flows to `IPFIX`, `OpenTelemetry`, and `Kafka` individually or concurrently.
+`spec.exporters.kafka.topic`:: Specifies the Kafka topic where the Network Observability Operator exports all flows.
+`spec.exporters.kafka.tls.enable`::
+Specifies whether to encrypt communications to and from Kafka with SSL/TLS or mTLS. When enabled, the Kafka CA certificate must be available as a `ConfigMap` or a `Secret` in the namespace where the `flowlogs-pipeline` processor component is deployed (default: `netobserv`). Reference the certificate with `spec.exporters.tls.caCert`. For mTLS, client secrets must also be available in these namespaces and referenced with `spec.exporters.tls.userCert`.
+`spec.exporters.ipfix.transport`:: Specifies the transport protocol. The default value is `tcp`, but you can also specify `udp`.
+`spec.exporters.openTelemetry.type`:: Specifies the OpenTelemetry connection protocol. The available options are `http` and `grpc`.
+`spec.exporters.openTelemetry.logs`:: Specifies the OpenTelemetry configuration for exporting logs, which are identical to the logs created for Loki.
+`spec.exporters.openTelemetry.metrics`:: Specifies the OpenTelemetry configuration for exporting metrics, which are identical to the metrics created for Prometheus. These are defined in the `spec.processor.metrics.includeList` parameter of the `FlowCollector` resource or via the `FlowMetrics` resource.
+`spec.exporters.openTelemetry.metrics.pushTimeInterval`:: Specifies the time interval for sending metrics to the OpenTelemetry collector.
+`spec.exporters.openTelemetry.fieldsMapping`:: Specifies an optional mapping to customize the OpenTelemetry format output. Network Observability flow formats are automatically renamed to an OpenTelemetry-compliant format, but this parameter allows for custom overrides. For example in the YAML sample, `SrcAddr` is the Network Observability input field, and it is being renamed to `source.address` in OpenTelemetry output. You can see both Network Observability and OpenTelemetry formats in the "Network flows format reference".

--- a/modules/network-observability-filter-network-flows-at-ingestion.adoc
+++ b/modules/network-observability-filter-network-flows-at-ingestion.adoc
@@ -81,10 +81,11 @@ spec:
     filters:
       - query: |
           (SrcK8S_Namespace="netobserv" OR (SrcK8S_Namespace="openshift-ingress" AND DstK8S_Namespace="netobserv"))
-        outputTarget: Loki  <1>
-        sampling: 10  <2>
+        outputTarget: Loki
+        sampling: 10
 ----
-<1> Sends matching flows to a specific output, such as Loki, Prometheus, or an external system. When omitted, sends to all configured outputs.
-<2> Optional. Applies a sampling interval to limit the number of matching flows to be stored or exported. For example, `sampling: 10` means that there is a 1 in 10 chance that a flow will be kept.
 
+where:
 
+`spec.processor.filters.outputTarget`:: Specifies the output destination for matching flows, such as `Loki`, `Prometheus`, or an external system. If you omit this parameter, the system sends the flows to all configured outputs.
+`spec.processor.filters.sampling`:: Specifies an optional sampling interval to limit the number of matching flows stored or exported. For example, a value of `10` means there is a 1 in 10 chance that a flow is kept.

--- a/modules/network-observability-flowmetrics-charts-examples.adoc
+++ b/modules/network-observability-flowmetrics-charts-examples.adoc
@@ -19,17 +19,17 @@ apiVersion: flows.netobserv.io/v1alpha1
 kind: FlowMetric
 metadata:
   name: flowmetric-cluster-external-ingress-traffic
-  namespace: netobserv   <1>
+  namespace: netobserv
 # ...
   charts:
-  - dashboardName: Main  <2>
+  - dashboardName: Main
     title: External ingress traffic
     unit: Bps
     type: SingleStat
     queries:
     - promQL: "sum(rate($METRIC[2m]))"
       legend: ""
-  - dashboardName: Main  <2>
+  - dashboardName: Main
     sectionName: External
     title: Top external ingress traffic per workload
     unit: Bps
@@ -39,7 +39,11 @@ metadata:
       legend: "{{DstK8S_Namespace}} / {{DstK8S_OwnerName}}"
 # ...
 ----
-<1> The `FlowMetric` resources need to be created in the namespace defined in the `FlowCollector` `spec.namespace`, which is `netobserv` by default.
+
+where:
+
+`metadata.namespace`:: Specifies the namespace where the `FlowMetric` resources are created. This must match the namespace defined in the `FlowCollector` `spec.namespace`, which is `netobserv` by default.
+`spec.charts.dashboardName`:: Specifies the name of the dashboard. Using a different `dashboardName` creates a new dashboard that is prefixed with `Netobserv`. For example, *Netobserv / <dashboard_name>*.
 
 [id="chart-rtt-latency-cluster-external-ingress-traffic_{context}"]
 == RTT latency chart for cluster external ingress traffic
@@ -52,17 +56,17 @@ apiVersion: flows.netobserv.io/v1alpha1
 kind: FlowMetric
 metadata:
   name: flowmetric-cluster-external-ingress-traffic
-  namespace: netobserv   <1>
+  namespace: netobserv
 # ...
   charts:
-  - dashboardName: Main  <2>
+  - dashboardName: Main
     title: External ingress TCP latency
     unit: seconds
     type: SingleStat
     queries:
     - promQL: "histogram_quantile(0.99, sum(rate($METRIC_bucket[2m])) by (le)) > 0"
       legend: "p99"
-  - dashboardName: Main  <2>
+  - dashboardName: Main
     sectionName: External
     title: "Top external ingress sRTT per workload, p50 (ms)"
     unit: seconds
@@ -70,7 +74,7 @@ metadata:
     queries:
     - promQL: "histogram_quantile(0.5, sum(rate($METRIC_bucket{DstK8S_Namespace!=\"\"}[2m])) by (le,DstK8S_Namespace,DstK8S_OwnerName))*1000 > 0"
       legend: "{{DstK8S_Namespace}} / {{DstK8S_OwnerName}}"
-  - dashboardName: Main  <2>
+  - dashboardName: Main
     sectionName: External
     title: "Top external ingress sRTT per workload, p99 (ms)"
     unit: seconds
@@ -80,8 +84,11 @@ metadata:
       legend: "{{DstK8S_Namespace}} / {{DstK8S_OwnerName}}"
 # ...
 ----
-<1> The `FlowMetric` resources need to be created in the namespace defined in the `FlowCollector` `spec.namespace`, which is `netobserv` by default.
-<2> Using a different `dashboardName` creates a new dashboard that is prefixed with `Netobserv`. For example, *Netobserv / <dashboard_name>*.
+
+where:
+
+`metadata.namespace`:: Specifies the namespace where the `FlowMetric` resources are created. This must match the namespace defined in the `FlowCollector` `spec.namespace`, which is `netobserv` by default.
+`spec.charts.dashboardName`:: Specifies the name of the dashboard. Using a different `dashboardName` creates a new dashboard that is prefixed with `Netobserv`. For example, *Netobserv / <dashboard_name>*.
 
 [id="calculate-histogram-averages_{context}"]
 == Calculate histogram averages


### PR DESCRIPTION
Manual cherry-pick

Original commit: 31ebed9cd80f388b316ab3886d06f5c971d3900f

Original PR: https://github.com/openshift/openshift-docs/pull/108408

Version(s):
`enterprise-4.19`

QE review:
QE is not required for this PR.

Additional information:
* 9 files. Same as original PR.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
