### PR TITLE
[enterprise-4.18] Resolves ADV errors for ingress MS docs

### DIFF
--- a/microshift_configuring/microshift-disable-lvms-csi-provider-csi-snapshot.adoc
+++ b/microshift_configuring/microshift-disable-lvms-csi-provider-csi-snapshot.adoc
@@ -7,7 +7,7 @@ include::_attributes/attributes-microshift.adoc[]
 toc::[]
 
 [role="_abstract"]
-You can configure {microshift-short} to disable the built-in logical volume manager storage (LVMS) Container Storage Interface (CSI) provider or the CSI snapshot capabilities to reduce the use of runtime resources such as RAM, CPU, and storage.
+To reduce use of runtime resources such as RAM, CPU, and storage in {microshift-short}, you can disable the built-in LVMS CSI provider or CSI snapshot. Configure the storage section in the configuration file before you install or run the product.
 
 include::modules/microshift-disabling-lvms-csi-snapshot.adoc[leveloffset=+1]
 

--- a/microshift_configuring/microshift-greenboot-checking-status.adoc
+++ b/microshift_configuring/microshift-greenboot-checking-status.adoc
@@ -6,6 +6,7 @@ include::_attributes/attributes-microshift.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 To deploy applications or make other changes through the {microshift-short} API with tools other than `kustomize` manifests, you must wait until the greenboot health checks have finished. This ensures that your changes are not lost if greenboot rolls your `rpm-ostree` system back to an earlier state.
 
 The `greenboot-healthcheck` service runs one time and then exits. After greenboot has exited and the system is in a healthy state, you can proceed with configuration changes and deployments.

--- a/microshift_configuring/microshift-ingress-controller.adoc
+++ b/microshift_configuring/microshift-ingress-controller.adoc
@@ -13,6 +13,8 @@ include::modules/microshift-ingress-controller-conc.adoc[leveloffset=+1]
 
 include::modules/microshift-ingress-controller-config.adoc[leveloffset=+1]
 
+include::modules/microshift-ingress-control-config-fields.adoc[leveloffset=+2]
+
 [id="additional-resources_microshift-ingress-controller"]
 [role="_additional-resources"]
 == Additional resources

--- a/modules/microshift-disabling-lvms-csi-snapshot.adoc
+++ b/modules/microshift-disabling-lvms-csi-snapshot.adoc
@@ -31,9 +31,9 @@ Use the procedure if you are defining the configuration file before installing a
 # ...
 ----
 +
-where
+where:
 +
-`storage`: Specifies the storage details. You can choose to not define `optionalCsiComponents`. If you do specify the `optionalCsiComponents` field, valid values include: an empty value (`[]`) or a single empty string element (`[""]`), `snapshot-controller`, or `none`. A value of `none` is mutually exclusive with all other values.
+`storage`:: Specifies the storage details. You can choose to not define `optionalCsiComponents`. If you do specify the `optionalCsiComponents` field, valid values include: an empty value (`[]`) or a single empty string element (`[""]`), `snapshot-controller`, or `none`. A value of `none` is mutually exclusive with all other values.
 +
 [NOTE]
 ====

--- a/modules/microshift-ingress-control-config-fields.adoc
+++ b/modules/microshift-ingress-control-config-fields.adoc
@@ -1,0 +1,89 @@
+
+// Module included in the following assemblies:
+//
+// * microshift_configuring/microshift-ingress-controller.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="microshift-ingress-control-config-fields_{context}"]
+= Ingress controller configuration fields in {microshift-short}
+
+[role="_abstract"]
+The following table lists and defines the ingress controller configuration parameters in the {microshift-short} `config.yaml` file. You use these parameters when you configure access logging, TLS, timeouts, route admission, and other ingress options.
+
+.Ingress controller configuration fields definitions table
+[cols="3a,8a",options="header"]
+|===
+|Parameter |Description
+
+|`defaultHTTPVersion`
+|Sets the HTTP version for the ingress controller. Default value is `1` for HTTP 1.1.
+//Q: do we need to configure a load balancer for 2 and 3?
+
+|`forwardedHeaderPolicy`
+|Specifies when and how the ingress controller sets the `Forwarded`, `X-Forwarded-For`, `X-Forwarded-Host`, `X-Forwarded-Port`, `X-Forwarded-Proto`, and `X-Forwarded-Proto-Version` HTTP headers. The following values are valid:
+
+* `Append`, preserves any existing headers by specifying that the ingress controller appends them.
+* `Replace`, removes any existing headers by specifying that the ingress controller sets the headers.
+* `IfNone` sets the headers set by specifying that the ingress controller sets the headers if they are not already set.
+* `Never`, preserves any existing headers by specifying that the ingress controller never sets the headers.
+
+|`httpCompression`
+|Defines the policy for HTTP traffic compression.
+
+* `httpCompression.mimeTypes` defines a list of or a single MIME type to which compression is applied. For example, `text/css; charset=utf-8`, `text/html`, `text/*`, `image/svg+xml`, `application/octet-stream`, `X-custom/customsub`, using the format pattern, `type/subtype; [;attribute=value]`. The `types` are: application, image, message, multipart, text, video, or a custom type prefaced by `X-`. To see the full notation for MIME types and subtypes, see link:https://datatracker.ietf.org/doc/html/rfc1341#page-7[RFC1341] (IETF Datatracker documentation).
+
+|`httpEmptyRequestsPolicy`
+|Describes how HTTP connections are handled if the connection times out before a request is received. Allowed values for this field are `Respond` and `Ignore`. The default value is `Respond`. The following are valid values:
+
+* `Respond`, causes the ingress controller to send an HTTP `400` or `408` response, logs the connection if access logging is enabled, and counts the connection in the appropriate metrics.
+* `Ignore`, adds the `http-ignore-probes` parameter in the `HAproxy` configuration. If the field is set to `Ignore`, the ingress controller closes the connection without sending a response, then logs the connection or incrementing metrics.
+
+Usually, empty request connections come from load balancer health probes or web browser preconnects and can be safely ignored. However, network errors and port scans can also create these empty requests, so setting this field to `Ignore` can impede detecting or diagnosing problems and also impede the detection of intrusion attempts.
+
+|`logEmptyRequests`
+|Specifies connections for which no request is received and logged. Usually, these empty requests come from load balancer health probes or web browser speculative connections such as preconnects. Logging these types of empty requests can be undesirable. However, network errors and port scans can also create empty requests, so setting this field to `Ignore` can impede detecting or diagnosing problems and also impede the detection of intrusion attempts.
+
+The following are valid values:
+
+* `Log`, which indicates that an event should be logged.
+* `Ignore`, which sets the `dontlognull` option in the `HAproxy` configuration.
+
+|`tuningOptions`
+|Specifies options for tuning the performance of ingress controller pods.
+
+* The `tuningOptions.clientFinTimeout` parameter specifies how long a connection is held open while waiting for the client response to the server closing the connection. The default timeout is `1s`.
+
+* The `tuningOptions.clientTimeout` parameter specifies how long a connection is held open while waiting for a client response. The default timeout is `30s`.
+
+* The `tuningOptions.headerBufferBytes` parameter specifies how much memory is reserved, in bytes, for Ingress Controller connection sessions. This value must be at least `16384` if HTTP/2 is enabled for the Ingress Controller. If not set, the default value is `32768` bytes.
++
+[IMPORTANT]
+====
+Setting this field not recommended because `headerBufferMaxRewriteBytes` parameter values that are too small can break the ingress controller. Conversely, values for `headerBufferMaxRewriteBytes` that are too large could cause the ingress controller to use significantly more memory than necessary.
+====
+
+* The `tuningOptions.headerBufferMaxRewriteBytes` parameter specifies how much memory should be reserved, in bytes, from `headerBufferBytes` for HTTP header rewriting and appending for Ingress Controller connection sessions. The minimum value for `headerBufferMaxRewriteBytes` is `4096`. The `headerBufferBytes` value must be greater than the `headerBufferMaxRewriteBytes` value for incoming HTTP requests.
+* If not set, the default value is `8192` bytes.
++
+[IMPORTANT]
+====
+Setting this field is not recommended because `headerBufferMaxRewriteBytes` parameter values that are too small can break the ingress controller. Conversely, values for `headerBufferMaxRewriteBytes` that are too large could cause the ingress controller to use significantly more memory than necessary.
+====
+
+* The `tuningOptions.healthCheckInterval` parameter specifies how long the router waits between health checks. The default is `5s`.
+
+* The `tuningOptions.serverFinTimeout` parameter specifies how long a connection is held open while waiting for the server response to the client that is closing the connection. The default timeout is `1s`.
+
+* The `tuningOptions.serverTimeout` parameter specifies how long a connection is held open while waiting for a server response. The default timeout is `30s`.
+
+* The `tuningOptions.threadCount` parameter specifies the number of threads to create per HAProxy process. Creating more threads allows each ingress controller pod to handle more connections, at the cost of more system resources being used. `HAProxy` supports up to `64` threads. If this field is empty, default value is `4` threads.
++
+[IMPORTANT]
+====
+Setting this field is not recommended because increasing the number of `HAProxy` threads allows ingress controller pods to use more CPU time under load, and prevent other pods from receiving the CPU resources they need to perform.
+====
+
+* The `tuningOptions.tlsInspectDelay` parameter specifies how long the router can hold data to find a matching route. Setting this value too short can cause the router to fall back to the default certificate for edge-terminated, re-encrypted, or passthrough routes, even when using a better-matched certificate. The default inspect delay is `5s`.
+
+* The `tuningOptions.tunnelTimeout` parameter specifies how long a tunnel connection, including websockets, remains open while the tunnel is idle. The default timeout is `1h`.
+|===

--- a/modules/microshift-ingress-controller-conc.adoc
+++ b/modules/microshift-ingress-controller-conc.adoc
@@ -6,7 +6,8 @@
 [id="microshift-ingress-control-concept_{context}"]
 = Using ingress control in {microshift-short}
 
-When you create your {microshift-short} node, each pod and service running on the node is allocated an IP address. These IP addresses are accessible to other pods and services running nearby by default, but are not accessible to external clients. {microshift-short} uses a minimal implementation of the {ocp} `IngressController` API to enable external access to node services.
+[role="_abstract"]
+When you create your {microshift-short} node, each pod and service running on the node is allocated an IP address. These IP addresses are accessible to other pods and services running nearby by default, but are not accessible to external clients. {microshift-short} uses a minimal implementation of the {OCP} `IngressController` API to enable external access to node services.
 
 With more configuration options, you can fine-tune ingress to meet your specific needs. To use enhanced ingress control, update the parameters in the {microshift-short} configuration file and restart the service. Ingress configuration is useful in a variety of ways, for example:
 

--- a/modules/microshift-ingress-controller-config.adoc
+++ b/modules/microshift-ingress-controller-config.adoc
@@ -7,7 +7,8 @@
 [id="microshift-ingress-control-config_{context}"]
 = Configuring ingress control in {microshift-short}
 
-You can use detailed ingress control settings by updating the {microshift-short} service configuration file.
+[role="_abstract"]
+To apply detailed ingress control such as timeouts, TLS, and logging in {microshift-short}, you can update the `config.yaml` file or add a configuration snippet in the `/etc/microshift/config.d/` directory. Replace the default values in the ingress section and restart the service.
 
 .Prerequisites
 
@@ -57,83 +58,7 @@ ingress:
 # ...
 ----
 +
-.Ingress controller configuration fields definitions table
-[cols="3a,8a",options="header"]
-|===
-|Parameter |Description
-
-|`defaultHTTPVersion`
-|Sets the HTTP version for the ingress controller. Default value is `1` for HTTP 1.1.
-//Q: do we need to configure a load balancer for 2 and 3?
-
-|`forwardedHeaderPolicy`
-|Specifies when and how the ingress controller sets the `Forwarded`, `X-Forwarded-For`, `X-Forwarded-Host`, `X-Forwarded-Port`, `X-Forwarded-Proto`, and `X-Forwarded-Proto-Version` HTTP headers. The following values are valid:
-
-* `Append`, preserves any existing headers by specifying that the ingress controller appends them.
-* `Replace`, removes any existing headers by specifying that the ingress controller sets the headers.
-* `IfNone` sets the headers set by specifying that the ingress controller sets the headers if they are not already set.
-* `Never`, preserves any existing headers by specifying that the ingress controller never sets the headers.
-
-|`httpCompression`
-|Defines the policy for HTTP traffic compression.
-
-* `httpCompression.mimeTypes` defines a list of or a single MIME type to which compression is applied. For example, `text/css; charset=utf-8`, `text/html`, `text/*`, `image/svg+xml`, `application/octet-stream`, `X-custom/customsub`, using the format pattern, `type/subtype; [;attribute=value]`. The `types` are: application, image, message, multipart, text, video, or a custom type prefaced by `X-`. To see the full notation for MIME types and subtypes, see link:https://datatracker.ietf.org/doc/html/rfc1341#page-7[RFC1341] (IETF Datatracker documentation).
-
-|`httpEmptyRequestsPolicy`
-|Describes how HTTP connections are handled if the connection times out before a request is received. Allowed values for this field are `Respond` and `Ignore`. The default value is `Respond`. The following are valid values:
-
-* `Respond`, causes the ingress controller to send an HTTP `400` or `408` response, logs the connection if access logging is enabled, and counts the connection in the appropriate metrics.
-* `Ignore`, adds the `http-ignore-probes` parameter in the `HAproxy` configuration. If the field is set to `Ignore`, the ingress controller closes the connection without sending a response, then logs the connection or incrementing metrics.
-
-Usually, empty request connections come from load balancer health probes or web browser preconnects and can be safely ignored. However, network errors and port scans can also create these empty requests, so setting this field to `Ignore` can impede detecting or diagnosing problems and also impede the detection of intrusion attempts.
-
-|`logEmptyRequests`
-|Specifies connections for which no request is received and logged. Usually, these empty requests come from load balancer health probes or web browser speculative connections such as preconnects. Logging these types of empty requests can be undesirable. However, network errors and port scans can also create empty requests, so setting this field to `Ignore` can impede detecting or diagnosing problems and also impede the detection of intrusion attempts.
-
-The following are valid values:
-
-* `Log`, which indicates that an event should be logged.
-* `Ignore`, which sets the `dontlognull` option in the `HAproxy` configuration.
-
-|`tuningOptions`
-|Specifies options for tuning the performance of ingress controller pods.
-
-* The `tuningOptions.clientFinTimeout` parameter specifies how long a connection is held open while waiting for the client response to the server closing the connection. The default timeout is `1s`.
-
-* The `tuningOptions.clientTimeout` parameter specifies how long a connection is held open while waiting for a client response. The default timeout is `30s`.
-
-* The `tuningOptions.headerBufferBytes` parameter specifies how much memory is reserved, in bytes, for Ingress Controller connection sessions. This value must be at least `16384` if HTTP/2 is enabled for the Ingress Controller. If not set, the default value is `32768` bytes.
-+
-[IMPORTANT]
-====
-Setting this field not recommended because `headerBufferMaxRewriteBytes` parameter values that are too small can break the ingress controller. Conversely, values for `headerBufferMaxRewriteBytes` that are too large could cause the ingress controller to use significantly more memory than necessary.
-====
-
-* The `tuningOptions.headerBufferMaxRewriteBytes` parameter specifies how much memory should be reserved, in bytes, from `headerBufferBytes` for HTTP header rewriting and appending for Ingress Controller connection sessions. The minimum value for `headerBufferMaxRewriteBytes` is `4096`. The `headerBufferBytes` value must be greater than the `headerBufferMaxRewriteBytes` value for incoming HTTP requests.
-* If not set, the default value is `8192` bytes.
-+
-[IMPORTANT]
-====
-Setting this field is not recommended because `headerBufferMaxRewriteBytes` parameter values that are too small can break the ingress controller. Conversely, values for `headerBufferMaxRewriteBytes` that are too large could cause the ingress controller to use significantly more memory than necessary.
-====
-
-* The `tuningOptions.healthCheckInterval` parameter specifies how long the router waits between health checks. The default is `5s`.
-
-* The `tuningOptions.serverFinTimeout` parameter specifies how long a connection is held open while waiting for the server response to the client that is closing the connection. The default timeout is `1s`.
-
-* The `tuningOptions.serverTimeout` parameter specifies how long a connection is held open while waiting for a server response. The default timeout is `30s`.
-
-* The `tuningOptions.threadCount` parameter specifies the number of threads to create per HAProxy process. Creating more threads allows each ingress controller pod to handle more connections, at the cost of more system resources being used. `HAProxy` supports up to `64` threads. If this field is empty, default value is `4` threads.
-+
-[IMPORTANT]
-====
-Setting this field is not recommended because increasing the number of `HAProxy` threads allows ingress controller pods to use more CPU time under load, and prevent other pods from receiving the CPU resources they need to perform.
-====
-
-* The `tuningOptions.tlsInspectDelay` parameter specifies how long the router can hold data to find a matching route. Setting this value too short can cause the router to fall back to the default certificate for edge-terminated, re-encrypted, or passthrough routes, even when using a better-matched certificate. The default inspect delay is `5s`.
-
-* The `tuningOptions.tunnelTimeout` parameter specifies how long a tunnel connection, including websockets, remains open while the tunnel is idle. The default timeout is `1h`.
-|===
+See "Ingress controller configuration fields in {microshift-short}" for more information about each field.
 
 . Complete any other configurations you require, then start or restart {microshift-short} by running one the following commands:
 +
@@ -159,7 +84,6 @@ $ oc get pods -n openshift-ingress
 ----
 +
 .Example output
-+
 [source,terminal]
 ----
 NAME                              READY   STATUS    RESTARTS   AGE


### PR DESCRIPTION
xref: https://github.com/openshift/openshift-docs/pull/109256
cherry picked from: 6e22ddff726080f61a7e5342233dc218f3f0e4e8

Discrepancy explanation:

There are two additional files in version 4.19+ that are not in version 4.18: 

include::modules/microshift-ingress-controller-create-cert-secret.adoc[leveloffset=+2] (File was added 9 months ago and cherry picked back to 4.18 via https://github.com/openshift/openshift-docs/pull/94817) 

include::modules/microshift-ingress-controller-tls-config.adoc[leveloffset=+2] (File was added 9 months ago and added via https://github.com/openshift/openshift-docs/pull/94817) 

Thus, this PR should touch 2 less files than version 4.19+ (it does). 

In the file modules/microshift-ingress-controller-config.adoc, there is a 120 line difference; this version removes 120 less lines than 4.19. This is because additional configuration fields and information about some fields were added in https://github.com/openshift/openshift-docs/pull/94817, which was applicable only to 4.19; there might have been other PRs to add additional updates to that table. 

To properly assess the changes here, I compared the table of THIS cherry pick to the table that was in modules/microshift-ingress-controller-config.adoc in version 4.18.

The goal here is to make sure that the table in modules/microshift-ingress-controller-config.adoc that was in 4.18 stays the same as the table in the newly added modules/microshift-ingress-control-config-fields.adoc module, which was split into a reference module. 

Content between both of those files match, which is CORRECT. The additional fields that are making version 4.19 have so many more line changes need to remain in 4.19, as they were never part of version 4.18.

In short: the tables in modules/microshift-ingress-controller-config.adoc and modules/microshift-ingress-control-config-fields.adoc must match. They do. 