### PR TITLE
OSDOCS 4.22 Specify that user-created machinesets should use the latest bootimages

### DIFF
--- a/machine_configuration/mco-update-boot-images-manual.adoc
+++ b/machine_configuration/mco-update-boot-images-manual.adoc
@@ -37,6 +37,7 @@ include::modules/mco-update-boot-images-plat-none.adoc[leveloffset=+1]
 == Additional resources
 * xref:../machine_configuration/mco-update-boot-images.adoc#mco-update-boot-images[Boot image management]
 * xref:../machine_configuration/mco-update-boot-skew-mgmt.adoc#mco-update-boot-skew-mgmt[Updating the boot image skew enforcement version]
+* xref:../machine_configuration/mco-update-boot-images-manual.adoc#mco-update-boot-images-manual[Manually updating the boot image]
 * xref:../installing/installing_aws/ipi/ipi-aws-preparing-to-install.adoc#installation-obtaining-installer_ipi-aws-preparing-to-install[Obtaining the installation program]
 * xref:../machine_management/user_infra/adding-bare-metal-compute-user-infra.adoc#adding-bare-metal-compute-user-infra[Adding compute machines to bare metal]
 * xref:../installing/installing_aws/installing-aws-account.adoc#installing-aws-account[Configuring an AWS account]

--- a/machine_configuration/mco-update-boot-images.adoc
+++ b/machine_configuration/mco-update-boot-images.adoc
@@ -10,6 +10,10 @@ include::snippets/mco-update-boot-images-abstract.adoc[]
 
 include::snippets/mco-update-boot-images-intro.adoc[]
 
+[role="_additional-resources"]
+.Additional resources
+* xref:../machine_configuration/mco-update-boot-images-manual.adoc#mco-update-boot-images-manual[Manually updating the boot image]
+
 include::modules/mco-update-boot-images-about.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
@@ -20,3 +24,5 @@ include::modules/mco-update-boot-images-about.adoc[leveloffset=+1]
 include::modules/mco-update-boot-images-configuring.adoc[leveloffset=+1]
 
 include::modules/mco-update-boot-images-disable.adoc[leveloffset=+1]
+
+

--- a/machine_management/creating-infrastructure-machinesets.adoc
+++ b/machine_management/creating-infrastructure-machinesets.adoc
@@ -52,7 +52,17 @@ include::modules/machineset-yaml-nutanix.adoc[leveloffset=+3]
 
 include::modules/machineset-yaml-osp.adoc[leveloffset=+3]
 
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../machine_configuration/mco-update-boot-images-manual.adoc#mco-update-boot-images-manual[Manually updating the boot image]
+
 include::modules/machineset-yaml-vsphere.adoc[leveloffset=+3]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../machine_configuration/mco-update-boot-images-manual.adoc#mco-update-boot-images-manual[Manually updating the boot image]
 
 include::modules/machineset-creating.adoc[leveloffset=+2]
 

--- a/machine_management/creating_machinesets/creating-machineset-aws.adoc
+++ b/machine_management/creating_machinesets/creating-machineset-aws.adoc
@@ -15,6 +15,11 @@ include::snippets/machine-user-provisioned-limitations.adoc[leveloffset=+1]
 //Sample YAML for a compute machine set custom resource on AWS
 include::modules/machineset-yaml-aws.adoc[leveloffset=+1]
 
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../machine_configuration/mco-update-boot-images-manual.adoc#mco-update-boot-images-manual[Manually updating the boot image]
+
 //Creating a compute machine set
 include::modules/machineset-creating.adoc[leveloffset=+1]
 

--- a/machine_management/creating_machinesets/creating-machineset-azure-stack-hub.adoc
+++ b/machine_management/creating_machinesets/creating-machineset-azure-stack-hub.adoc
@@ -15,6 +15,11 @@ include::snippets/machine-user-provisioned-limitations.adoc[leveloffset=+1]
 //Sample YAML for a compute machine set custom resource on Azure Stack Hub
 include::modules/machineset-yaml-azure-stack-hub.adoc[leveloffset=+1]
 
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../machine_configuration/mco-update-boot-images-manual.adoc#mco-update-boot-images-manual[Manually updating the boot image]
+
 //Creating a compute machine set
 include::modules/machineset-creating.adoc[leveloffset=+1]
 

--- a/machine_management/creating_machinesets/creating-machineset-azure.adoc
+++ b/machine_management/creating_machinesets/creating-machineset-azure.adoc
@@ -14,6 +14,11 @@ include::snippets/machine-user-provisioned-limitations.adoc[leveloffset=+1]
 //Sample YAML for a compute machine set custom resource on Azure
 include::modules/machineset-yaml-azure.adoc[leveloffset=+1]
 
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../machine_configuration/mco-update-boot-images-manual.adoc#mco-update-boot-images-manual[Manually updating the boot image]
+
 //Creating a compute machine set
 include::modules/machineset-creating.adoc[leveloffset=+1]
 

--- a/machine_management/creating_machinesets/creating-machineset-bare-metal.adoc
+++ b/machine_management/creating_machinesets/creating-machineset-bare-metal.adoc
@@ -13,6 +13,11 @@ include::snippets/machine-user-provisioned-limitations.adoc[leveloffset=+1]
 
 include::modules/machineset-yaml-baremetal.adoc[leveloffset=+1]
 
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../machine_configuration/mco-update-boot-images-manual.adoc#mco-update-boot-images-manual[Manually updating the boot image]
+
 include::modules/machineset-creating.adoc[leveloffset=+1]
 
 //Labeling GPU machine sets for the cluster autoscaler

--- a/machine_management/creating_machinesets/creating-machineset-gcp.adoc
+++ b/machine_management/creating_machinesets/creating-machineset-gcp.adoc
@@ -15,6 +15,11 @@ include::snippets/machine-user-provisioned-limitations.adoc[leveloffset=+1]
 //Sample YAML for a compute machine set custom resource on GCP
 include::modules/machineset-yaml-gcp.adoc[leveloffset=+1]
 
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../machine_configuration/mco-update-boot-images-manual.adoc#mco-update-boot-images-manual[Manually updating the boot image]
+
 //Creating a compute machine set
 include::modules/machineset-creating.adoc[leveloffset=+1]
 

--- a/machine_management/creating_machinesets/creating-machineset-ibm-cloud.adoc
+++ b/machine_management/creating_machinesets/creating-machineset-ibm-cloud.adoc
@@ -15,6 +15,11 @@ include::snippets/machine-user-provisioned-limitations.adoc[leveloffset=+1]
 //Sample YAML for a machine set custom resource on {ibm-cloud-title}
 include::modules/machineset-yaml-ibm-cloud.adoc[leveloffset=+1]
 
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../machine_configuration/mco-update-boot-images-manual.adoc#mco-update-boot-images-manual[Manually updating the boot image]
+
 //Creating a compute machine set
 include::modules/machineset-creating.adoc[leveloffset=+1]
 

--- a/machine_management/creating_machinesets/creating-machineset-ibm-power-vs.adoc
+++ b/machine_management/creating_machinesets/creating-machineset-ibm-power-vs.adoc
@@ -13,6 +13,11 @@ include::snippets/machine-user-provisioned-limitations.adoc[leveloffset=+1]
 //Sample YAML for a machine set custom resource on {ibm-cloud-title}
 include::modules/machineset-yaml-ibm-power-vs.adoc[leveloffset=+1]
 
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../machine_configuration/mco-update-boot-images-manual.adoc#mco-update-boot-images-manual[Manually updating the boot image]
+
 //Creating a compute machine set
 include::modules/machineset-creating.adoc[leveloffset=+1]
 

--- a/machine_management/creating_machinesets/creating-machineset-nutanix.adoc
+++ b/machine_management/creating_machinesets/creating-machineset-nutanix.adoc
@@ -15,6 +15,11 @@ include::snippets/machine-user-provisioned-limitations.adoc[leveloffset=+1]
 //Sample YAML for a compute machine set custom resource on Nutanix
 include::modules/machineset-yaml-nutanix.adoc[leveloffset=+1]
 
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../machine_configuration/mco-update-boot-images-manual.adoc#mco-update-boot-images-manual[Manually updating the boot image]
+
 //Creating a compute machine set
 include::modules/machineset-creating.adoc[leveloffset=+1]
 

--- a/machine_management/creating_machinesets/creating-machineset-osp.adoc
+++ b/machine_management/creating_machinesets/creating-machineset-osp.adoc
@@ -15,11 +15,17 @@ include::snippets/machine-user-provisioned-limitations.adoc[leveloffset=+1]
 
 include::modules/machineset-yaml-osp.adoc[leveloffset=+1]
 
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../machine_configuration/mco-update-boot-images-manual.adoc#mco-update-boot-images-manual[Manually updating the boot image]
+
 include::modules/machineset-yaml-osp-sr-iov.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources
 * xref:../../installing/installing_openstack/installing-openstack-nfv-preparing.adoc#installing-openstack-nfv-preparing[Preparing to install a cluster that uses SR-IOV or OVS-DPDK on OpenStack]
+* xref:../../machine_configuration/mco-update-boot-images-manual.adoc#mco-update-boot-images-manual[Manually updating the boot image]
 
 include::modules/machineset-yaml-osp-sr-iov-port-security.adoc[leveloffset=+1]
 

--- a/machine_management/creating_machinesets/creating-machineset-vsphere.adoc
+++ b/machine_management/creating_machinesets/creating-machineset-vsphere.adoc
@@ -14,6 +14,11 @@ include::snippets/machine-user-provisioned-limitations.adoc[leveloffset=+1]
 //Sample YAML for a compute machine set custom resource on vSphere
 include::modules/machineset-yaml-vsphere.adoc[leveloffset=+1]
 
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../machine_configuration/mco-update-boot-images-manual.adoc#mco-update-boot-images-manual[Manually updating the boot image]
+
 //Minimum required vCenter privileges for compute machine set management
 include::modules/machineset-vsphere-required-permissions.adoc[leveloffset=+1]
 

--- a/machine_management/index.adoc
+++ b/machine_management/index.adoc
@@ -31,6 +31,11 @@ include::modules/machine-api-overview.adoc[leveloffset=+1]
 
 include::modules/machine-managing-compute-machines.adoc[leveloffset=+1]
 
+[role="_additional-resources"]
+.Additional resources
+* xref:../machine_configuration/mco-update-boot-images-manual.adoc#mco-update-boot-images-manual[Manually updating the boot image]
+* xref:../machine_configuration/mco-update-boot-images.adoc#mco-update-boot-images[Boot image management]
+
 include::modules/machine-control-plane-machines.adoc[leveloffset=+1]
 
 include::modules/machine-applying-autoscaling.adoc[leveloffset=+1]

--- a/modules/machine-managing-compute-machines.adoc
+++ b/modules/machine-managing-compute-machines.adoc
@@ -44,3 +44,8 @@ For example, you can perform the following actions:
 * xref:../machine_management/creating-infrastructure-machinesets.adoc#creating-infrastructure-machinesets[Create infrastructure compute machine sets].
 
 * Configure and deploy a xref:../machine_management/deploying-machine-health-checks.adoc#deploying-machine-health-checks[machine health check] to automatically fix damaged machines in a machine pool.
+
+[NOTE]
+====
+When creating a new machine set, you should specify the latest image to use for the boot image. For more information about updating the boot image on your cluster, see "Manually updating the boot image" and "Boot image management". The method to update or specify the image varies by platform.  
+====

--- a/modules/machineset-yaml-aws.adoc
+++ b/modules/machineset-yaml-aws.adoc
@@ -195,7 +195,7 @@ ifdef::edge[]
 endif::edge[]
 [NOTE]
 ====
-The `spec.template.spec.providerSpec.value.ami.id` stanza specifies a valid {op-system-first} Amazon Machine Image (AMI) for your AWS zone for your {product-title} nodes. If you want to use an {aws-short} Marketplace image, you must complete the {product-title} subscription from the link:https://aws.amazon.com/marketplace/fulfillment?productId=59ead7de-2540-4653-a8b0-fa7926d5c845[{aws-short} Marketplace] to obtain an AMI ID for your region.
+The `spec.template.spec.providerSpec.value.ami.id` stanza specifies a valid {op-system-first} Amazon Machine Image (AMI) for your {aws-short} zone for your {product-title} nodes. If you want to use an {aws-short} Machine Image (AMI) for your {aws-short} zone as a boot image for your {product-title} nodes, you should use the latest image when adding a new machine set. If you want to use an {aws-short} Marketplace image, you must complete the {product-title} subscription from the link:https://aws.amazon.com/marketplace/fulfillment?productId=59ead7de-2540-4653-a8b0-fa7926d5c845[AWS Marketplace] to obtain an AMI ID for your region.
 
 [source,terminal]
 ----

--- a/modules/machineset-yaml-azure-stack-hub.adoc
+++ b/modules/machineset-yaml-azure-stack-hub.adoc
@@ -173,6 +173,7 @@ The `spec.template.spec.providerSpec.value.zone` specifies the zone within your 
 ====
 
 `<availability_set>`:: Specifies the availability set for the cluster.
+`<image>`:: Specifies the boot image to use. You should use the use the latest image when adding a new machine set.
 endif::infra[]
 ifdef::infra[]
 `<infra>`:: Specifies the `<infra>` node label.
@@ -185,6 +186,7 @@ The `spec.template.spec.providerSpec.value.zone` specifies the zone within your 
 ====
 
 `<availability_set>`:: Specifies the availability set for the cluster.
+`<image>`:: Specifies the boot image to use. You should use the use the latest image when adding a new machine set.
 endif::infra[]
 
 ifeval::["{context}" == "creating-infrastructure-machinesets"]

--- a/modules/machineset-yaml-azure.adoc
+++ b/modules/machineset-yaml-azure.adoc
@@ -151,7 +151,7 @@ ifdef::infra[]
 <2> Specify the `infra` node label.
 <3> Specify the infrastructure ID, `infra` node label, and region.
 endif::infra[]
-<4> Specify the image details for your compute machine set. If you want to use an Azure Marketplace image, see "Using the Azure Marketplace offering".
+<4> Specify the image details of the boot image for your nodes. You should use the use the latest image when adding a new machine set. If you want to use an Azure Marketplace image, see "Using the Azure Marketplace offering".
 <5> Specify an image that is compatible with your instance type. The Hyper-V generation V2 images created by the installation program have a `-gen2` suffix, while V1 images have the same name without the suffix.
 <6> Specify the region to place machines on.
 <7> Optional: Specify custom tags in your machine set. Provide the tag name in `<custom_tag_name>` field and the corresponding tag value in `<custom_tag_value>` field.

--- a/modules/machineset-yaml-baremetal.adoc
+++ b/modules/machineset-yaml-baremetal.adoc
@@ -74,4 +74,6 @@ $ oc get -o jsonpath='{.status.infrastructureName}{"\n"}' infrastructure cluster
 `<image_checksum>`:: Specifies the image checksum, the URL that you edit to use the API VIP address, in the following format:  `\http://172.22.0.3:6181/images/rhcos-<version>.<architecture>.qcow2.<md5sum>`.
 
 `<image_url>`:: Specifies the image URL, the URL that you edit to use the API VIP address, in the following format: `\http://172.22.0.3:6181/images/rhcos-<version>.<architecture>.qcow2`.
+
+You should use the latest image when adding a new machine set.
 ====

--- a/modules/machineset-yaml-gcp.adoc
+++ b/modules/machineset-yaml-gcp.adoc
@@ -135,7 +135,7 @@ endif::infra[]
 ifdef::infra[]
 `<infra>`:: Specifies the `<infra>` node label.
 endif::infra[]
-`<path_to_image>`:: Specifies the path to the image that is used in current compute machine sets. To use a {gcp-short} Marketplace image, specify the offer to use:
+`<path_to_image>`:: Specifies the path to the image that is used as a boot image in current compute machine sets. You should use the use the latest image when adding a new machine set. To use a {gcp-short} Marketplace image, specify the offer to use:
 +
 * {product-title}: `\https://www.googleapis.com/compute/v1/projects/redhat-marketplace-public/global/images/redhat-coreos-ocp-413-x86-64-202305021736`
 * {opp}: `\https://www.googleapis.com/compute/v1/projects/redhat-marketplace-public/global/images/redhat-coreos-opp-413-x86-64-202305021736`

--- a/modules/machineset-yaml-ibm-cloud.adoc
+++ b/modules/machineset-yaml-ibm-cloud.adoc
@@ -117,7 +117,7 @@ ifdef::infra[]
 `<infra>`:: Specifies the `<infra>` node label.
 `<infrastructure_id>-<infra>-<region>`:: Specifies the infrastructure ID, `<infra>` node label, and region.
 endif::infra[]
-`<infrastructure_id>-rhcos`:: Specifies the custom {op-system-first} image that was used for cluster installation.
+`<infrastructure_id>-rhcos`:: Specifies the custom {op-system-first} image to use as a boot image for your nodes. You should use the use the latest image when adding a new machine set.
 `<infrastructure_id>-subnet-compute-<zone>`:: Specifies the infrastructure ID and zone within your region to place machines on. Be sure that your region supports the zone that you specify.
 `<instance_profile>`:: Specifies the link:https://cloud.ibm.com/docs/vpc?topic=vpc-profiles&interface=ui[{ibm-cloud-name} instance profile].
 `<region>`:: Specifies the region to place machines on.

--- a/modules/machineset-yaml-ibm-power-vs.adoc
+++ b/modules/machineset-yaml-ibm-power-vs.adoc
@@ -74,6 +74,6 @@ $ oc get -o jsonpath='{.status.infrastructureName}{"\n"}' infrastructure cluster
 ----
 `<role>`:: Specifies the node label to add.
 `<infrastructure_id>-<role>-<region>`:: Specifies the infrastructure ID, node label, and region.
-`rhcos-<infrastructure_id>`:: Specifies the custom {op-system-first} image that was used for cluster installation.
+`rhcos-<infrastructure_id>`:: Specifies the custom {op-system-first} image to use as a boot image for your nodes. You should use the use the latest image when adding a new machine set.
 `<ibm_power_vs_service_instance_id>`:: Specifies the infrastructure ID within your region to place machines on.
 --

--- a/modules/machineset-yaml-nutanix.adoc
+++ b/modules/machineset-yaml-nutanix.adoc
@@ -36,7 +36,7 @@ Infrastructure ID:: The `<infrastructure_id>` string is the infrastructure ID th
 ----
 $ oc get -o jsonpath='{.status.infrastructureName}{"\n"}' infrastructure cluster
 ----
-
++
 [source,yaml]
 ----
 apiVersion: machine.openshift.io/v1beta1
@@ -126,9 +126,9 @@ ifdef::infra[]
         effect: NoSchedule
 endif::infra[]
 ----
-
 where:
-
++
+--
 `<infrastructure_id>`:: Specifies the infrastructure ID that is based on the cluster ID that you set when you provisioned the cluster.
 ifndef::infra[]
 `<role>`:: Specifies the node label to add.
@@ -147,7 +147,7 @@ You must use the `Legacy` boot type in {product-title} {product-version}.
 ====
 `<categories>`:: Specifies one or more Nutanix Prism categories to apply to compute machines. This stanza requires `key` and `value` parameters for a category key-value pair that exists in Prism Central. For more information about categories, see link:https://portal.nutanix.com/page/documents/details?targetId=Prism-Central-Guide-vpc_2022_6:ssp-ssp-categories-manage-pc-c.html[Category management].
 `<cluster>`:: Specifies a Nutanix Prism Element cluster configuration. In this example, the cluster type is `uuid`, so there is a `uuid` stanza.
-`<infrastructure_id>-rhcos`:: Specifies the image to use. Use an image from an existing default compute machine set for the cluster.
+`<infrastructure_id>-rhcos`:: Specifies the image to use as a boot image for your nodes. You should use the use the latest image when adding a new machine set.
 `16Gi`:: Specifies the amount of memory for the cluster in Gi.
 `project`:: Specifies the Nutanix project that you use for your cluster. In this example, the project type is `name`, so there is a `name` stanza.
 `subnets`:: Specifies one or more UUID for the Prism Element subnet object.
@@ -166,6 +166,7 @@ taints::  Specifies a taint to prevent user workloads from being scheduled on in
 After adding the `NoSchedule` taint on the infrastructure node, existing DNS pods running on that node are marked as `misscheduled`. You must either delete or link:https://access.redhat.com/solutions/6592171[add toleration on `misscheduled` DNS pods].
 ====
 endif::infra[]
+--
 
 ifeval::["{context}" == "creating-infrastructure-machinesets"]
 :!infra:

--- a/modules/machineset-yaml-osp-sr-iov.adoc
+++ b/modules/machineset-yaml-osp-sr-iov.adoc
@@ -102,6 +102,7 @@ spec:
 where:
 
 --
+`<glance_image_name_or_location>`:: Specifies the image to use as a boot image for your nodes. You should use the latest image when adding a new machine set.
 `<radio_network_UUID>`:: Specifies a network UUID for each port.
 `<radio_subnet_UUID>`:: Specifies a subnet UUID for each port.
 

--- a/modules/machineset-yaml-osp.adoc
+++ b/modules/machineset-yaml-osp.adoc
@@ -88,7 +88,12 @@ endif::infra[]
             name: openstack-cloud-credentials
             namespace: openshift-machine-api
           flavor: <nova_flavor>
+ifdef::infra[]
           image: <glance_image_name_or_location>
+endif::infra[]
+ifndef::infra[]
+          image: <glance_image_name_or_location>
+endif::infra[]
 ifndef::infra[]
           serverGroupID: <optional_UUID_of_server_group>
 endif::infra[]
@@ -140,6 +145,8 @@ ifndef::infra[]
 `<role>`:: Specifies the node label to add.
 `<infrastructure_id>-<role>`:: Specifies the infrastructure ID and node label.
 
+`<glance_image_name_or_location>`::  Specifies the image to use as a boot image for your nodes. You should use the latest image when adding a new machine set.
+
 `<optional_UUID_of_server_group>`:: Sets a server group policy for the `MachineSet` YAML by entering the value that is returned from
 link:https://access.redhat.com/documentation/en-us/red_hat_openstack_platform/16.0/html/command_line_interface_reference/server#server_group_create[creating a server group]. For most deployments, `anti-affinity` or `soft-anti-affinity` policies are recommended.
 
@@ -155,6 +162,8 @@ endif::infra[]
 
 ifdef::infra[]
 `<infrastructure_id>-infra`:: Specifies the infrastructure ID and `infra` node label.
+
+`<glance_image_name_or_location>`::  Specifies the image to use as a boot image for your nodes. You should use the latest image when adding a new machine set.
 
 `<optional_UUID_of_server_group>`:: Sets a server group policy for the `MachineSet` YAML, by entering the value that is returned from
 link:https://access.redhat.com/documentation/en-us/red_hat_openstack_platform/16.0/html/command_line_interface_reference/server#server_group_create[creating a server group]. For most deployments, `anti-affinity` or `soft-anti-affinity` policies are recommended.

--- a/modules/machineset-yaml-vsphere.adoc
+++ b/modules/machineset-yaml-vsphere.adoc
@@ -9,12 +9,12 @@ endif::[]
 
 :_mod-docs-content-type: REFERENCE
 [id="machineset-yaml-vsphere_{context}"]
-= Sample YAML for a compute machine set custom resource on vSphere
+= Sample YAML for a compute machine set custom resource on {vmw-short}
 
 [role="_abstract"]
-To enable the Machine API to automate node provisioning on VMware vSphere infrastructure, define a `MachineSet` resource with parameters that are specific to VMware vSphere, for example data center, resource pool, and template.
+To enable the Machine API to automate node provisioning on {vmw-first} infrastructure, define a `MachineSet` resource with parameters that are specific to {vmw-short}, for example data center, resource pool, and template.
 
-The sample YAML file defines a compute machine set that runs on VMware vSphere and creates nodes that are labeled with
+The sample YAML file defines a compute machine set that runs on {vmw-short} and creates nodes that are labeled with
 ifndef::infra[`node-role.kubernetes.io/<role>: ""`.]
 ifdef::infra[`node-role.kubernetes.io/infra: ""`.]
 
@@ -126,12 +126,13 @@ ifdef::infra[]
 `infra`:: Specifies the `infra` node label.
 endif::infra[]
 `<disk_name>`:: Specifies one or more data disk definitions. For more information, see "Configuring data disks by using machine sets".
-`<vm_network_name>`:: Specifies the vSphere VM network to deploy the compute machine set to. This VM network must be where other compute machines reside in the cluster.
-`<vm_template_name>`:: Specifies the vSphere VM template to use, such as `user-5ddjd-rhcos`.
+`<image_name>`:: Specifies the image to use as a boot image for your nodes.
+`<vm_network_name>`:: Specifies the {vmw-short} VM network to deploy the compute machine set to. This VM network must be where other compute machines reside in the cluster.
+`<vm_template_name>`:: Specifies the {vmw-short} VM template to use as a boot image for your nodes, such as `user-5ddjd-rhcos`. You should use a template with the latest {product-title} image when adding a new machine set.
 `<vcenter_data_center_name>`:: Specifies the vCenter datacenter to deploy the compute machine set on.
 `<vcenter_datastore_name>`:: Specifies the vCenter datastore to deploy the compute machine set on.
-`<vcenter_vm_folder_path>`:: Specifies the path to the vSphere VM folder in vCenter, such as `/dc1/vm/user-inst-5ddjd`.
-`<vsphere_resource_pool>`:: Specifies the vSphere resource pool for your VMs.
+`<vcenter_vm_folder_path>`:: Specifies the path to the {vmw-short} VM folder in vCenter, such as `/dc1/vm/user-inst-5ddjd`.
+`<vsphere_resource_pool>`:: Specifies the {vmw-short} resource pool for your VMs.
 `<vcenter_server_ip>`:: Specifies the vCenter server IP or fully qualified domain name.
 
 ifdef::infra[]

--- a/modules/mco-update-boot-images-nutanix.adoc
+++ b/modules/mco-update-boot-images-nutanix.adoc
@@ -201,6 +201,8 @@ $ oc patch machineset <machineset_name> -n openshift-machine-api --type merge -p
 +
 Replace `<machineset_name>` with the name of your machine set.
 
+. If boot image skew enforcement in your cluster is set to the manual mode, update the version of the new boot image in the `MachineConfiguration` object as described in "Updating the boot image skew enforcement version".
+
 .Verification
 
 . Scale up a machine set to check that the new node is using the new boot image:

--- a/modules/mco-update-boot-images-openstack.adoc
+++ b/modules/mco-update-boot-images-openstack.adoc
@@ -240,6 +240,8 @@ Replace `<machineset_name>` with the name of your machine set.
 +
 `IMAGE_NAME` is the environment variable you created in a previous step.
 
+. If boot image skew enforcement in your cluster is set to the manual mode, update the version of the new boot image in the `MachineConfiguration` object as described in "Updating the boot image skew enforcement version".
+
 .Verification
 
 . Scale up a machine set to check that the new node is using the new boot image:

--- a/nodes/nodes/nodes-update-boot-images.adoc
+++ b/nodes/nodes/nodes-update-boot-images.adoc
@@ -23,4 +23,4 @@ include::modules/mco-update-boot-images-configuring.adoc[leveloffset=+1]
 == Additional resources
 * xref:../../machine_configuration/mco-update-boot-images.adoc#mco-update-boot-images-disable_machine-configs-configure[Disabling boot image management]
 * xref:../../machine_configuration/mco-update-boot-images.adoc#mco-update-boot-images-configuring_machine-configs-configure[Enabling boot image management]
-
+* xref:../../machine_configuration/mco-update-boot-images-manual.adoc#mco-update-boot-images-manual[Manually updating the boot image]

--- a/snippets/mco-update-boot-images-intro.adoc
+++ b/snippets/mco-update-boot-images-intro.adoc
@@ -28,4 +28,4 @@ The following table lists the platforms on which boot image management is availa
 
 |===
 
-For all other platforms, the MCO does not update the boot image with each cluster update.
+For all other platforms, the MCO does not automatically update the boot image with each cluster update. For clusters where automatic updates are disabled or not supported, you can manually update the boot image on your cluster. See "Manually updating the boot image" for information. The method to update or specify the image varies by platform.  


### PR DESCRIPTION
https://redhat.atlassian.net/browse/OSDOCS-18752

Link to docs preview:
Overview of machine management -> [Compute machine management](https://109278--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/#machine-mgmt-intro-managing-compute_overview-of-machine-management) -- Added note at end of section and link.

Standard machine sets:
[Sample YAML for a compute machine set custom resource on AWS](https://109278--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/creating_machinesets/creating-machineset-aws#machineset-yaml-aws_creating-machineset-aws)
[Sample YAML for a compute machine set custom resource on Azure](https://109278--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/creating_machinesets/creating-machineset-azure#machineset-yaml-azure_creating-machineset-azure)
[Sample YAML for a compute machine set custom resource on Azure Stack Hub](https://109278--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/creating_machinesets/creating-machineset-azure-stack-hub#machineset-yaml-azure-stack-hub_creating-machineset-azure-stack-hub)
[Sample YAML for a compute machine set custom resource on Google Cloud](https://109278--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/creating_machinesets/creating-machineset-gcp#machineset-yaml-gcp_creating-machineset-gcp)
[Sample YAML for a compute machine set custom resource on IBM Cloud](https://109278--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/creating_machinesets/creating-machineset-ibm-cloud#machineset-yaml-ibm-cloud_creating-machineset-ibm-cloud)
[Sample YAML for a compute machine set custom resource on IBM Power Virtual Server](https://109278--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/creating_machinesets/creating-machineset-ibm-power-vs#machineset-yaml-ibm-power-vs_creating-machineset-ibm-power-vs)
[Sample YAML for a compute machine set custom resource on Nutanix](https://109278--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/creating_machinesets/creating-machineset-nutanix#machineset-yaml-nutanix_creating-machineset-nutanix)
[Sample YAML for a compute machine set custom resource on OpenStack](https://109278--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/creating_machinesets/creating-machineset-osp#machineset-yaml-osp_creating-machineset-osp)
[Sample YAML for a compute machine set custom resource that uses SR-IOV on RHOSP](https://109278--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/creating_machinesets/creating-machineset-osp#machineset-yaml-osp-sr-iov_creating-machineset-osp)
[Sample YAML for a compute machine set custom resource on vSphere](https://109278--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/creating_machinesets/creating-machineset-vsphere#machineset-yaml-vsphere_creating-machineset-vsphere)
[Sample YAML for a compute machine set custom resource on bare metal](https://109278--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/creating_machinesets/creating-machineset-bare-metal#machineset-yaml-vsphere_creating-machineset-bare-metal)

Infrastructure machine sets:
[Sample YAML for a compute machine set custom resource on AWS](https://109278--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/creating-infrastructure-machinesets#machineset-yaml-aws_creating-infrastructure-machinesets)
[Sample YAML for a compute machine set custom resource on Azure](https://109278--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/creating-infrastructure-machinesets#machineset-yaml-azure_creating-infrastructure-machinesets)
[Sample YAML for a compute machine set custom resource on Azure Stack Hub](https://109278--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/creating-infrastructure-machinesets#machineset-yaml-azure-stack-hub_creating-infrastructure-machinesets)
[Sample YAML for a compute machine set custom resource on IBM Cloud](https://109278--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/creating-infrastructure-machinesets#machineset-yaml-ibm-cloud_creating-infrastructure-machinesets)
[Sample YAML for a compute machine set custom resource on Google Cloud](https://109278--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/creating-infrastructure-machinesets#machineset-yaml-gcp_creating-infrastructure-machinesets)
[Sample YAML for a compute machine set custom resource on Nutanix](https://109278--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/creating-infrastructure-machinesets#machineset-yaml-nutanix_creating-infrastructure-machinesets)
[Sample YAML for a compute machine set custom resource on RHOSP](https://109278--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/creating-infrastructure-machinesets#machineset-yaml-osp_creating-infrastructure-machinesets)
[Sample YAML for a compute machine set custom resource on vSphere](https://109278--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/creating-infrastructure-machinesets#machineset-yaml-vsphere_creating-infrastructure-machinesets)

Machine configuration -> Manually updating the boot image -> [Manually updating the boot image on a Nutanix cluster](https://109278--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_configuration/mco-update-boot-images-manual#mco-update-boot-images-nutanix_mco-update-boot-images-manual) -- Added boot image skew enforcement wording, as last step in the procedure, right before the verification.
Machine configuration -> Manually updating the boot image -> [Manually updating the boot image on an RHOSP cluster](https://109278--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_configuration/mco-update-boot-images-manual#mco-update-boot-images-openstack_mco-update-boot-images-manual) -- Added boot image skew enforcement wording, as last step in the procedure, right before the verification.


QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
