### PR TITLE
OSDOCS-18664-abstracts: CQA for MetalLB Ingress and Route Configuration

### DIFF
--- a/modules/nw-metallb-addresspool-cr.adoc
+++ b/modules/nw-metallb-addresspool-cr.adoc
@@ -7,7 +7,7 @@
 = About the IPAddressPool custom resource
 
 [role="_abstract"]
-To define the IP address ranges available for load balancer services, configure the properties of the MetalLB `IPAddressPool` custom resource (CR). Establishing these parameters allows your cluster to automatically allocate specific external addresses to your application workloads.
+To define the IP address ranges available for load balancer services, configure the properties of the MetalLB `IPAddressPool` custom resource (CR).
 
 The following table details the parameters for the `IPAddressPool` CR:
 

--- a/modules/nw-metallb-advertise-address-pool-with-bgp-advanced.adoc
+++ b/modules/nw-metallb-advertise-address-pool-with-bgp-advanced.adoc
@@ -7,9 +7,7 @@
 = Advertising an advanced address pool configuration with BGP
 
 [role="_abstract"]
-To ensure application services are reachable from external network peers through specific routing paths, configure MetalLB to advertise an advanced address pool by using the BGP. Establishing this advertisement allows your cluster to precisely communicate routing information to the external infrastructure.
-
-The procedure demonstrates how to configure MetalLB to advertise an advanced address pool by using the BGP.
+Configure MetalLB to advertise an advanced address pool by using the BGP.
 
 .Prerequisites
 

--- a/modules/nw-metallb-advertise-address-pool-with-bgp.adoc
+++ b/modules/nw-metallb-advertise-address-pool-with-bgp.adoc
@@ -7,9 +7,7 @@
 = Advertising a basic address pool configuration with BGP
 
 [role="_abstract"]
-To ensure application services are reachable from external network peers, configure MetalLB to advertise an `IPAddressPool` by using the BGP advertisement. Establishing this advertisement allows the external network to correctly route traffic to the load balancer IP addresses of your cluster services.
-
-The procedure demonstrates how to configure MetalLB to advertise the `IPAddressPool` by using BGP.
+Configure MetalLB to advertise the `IPAddressPool` by using Border Gateway Protocol (BGP).
 
 .Prerequisites
 

--- a/modules/nw-metallb-advertise-ip-pools-from-node-subset.adoc
+++ b/modules/nw-metallb-advertise-ip-pools-from-node-subset.adoc
@@ -7,7 +7,7 @@
 = Advertising an IP address pool from a subset of nodes
 
 [role="_abstract"]
-To restrict IP address advertisements to a specific set of nodes, such as a public-facing subnet, configure the `nodeSelector` parameter in the `BGPAdvertisement` custom resource (CR). When you configure these selectors, {product-title} routes external traffic only through designated network interfaces for improved security and isolation.
+To advertise an IP address from an IP addresses pool, from a specific set of nodes only, use the `.spec.nodeSelector` specification in the `BGPAdvertisement` custom resource (CR). This specification associates a pool of IP addresses with a set of nodes in the cluster. This is useful when you have nodes on different subnets in a cluster and you want to advertise an IP addresses from an address pool from a specific subnet, for example a public-facing subnet only.
 
 .Prerequisites
 

--- a/modules/nw-metallb-bfdprofile-cr.adoc
+++ b/modules/nw-metallb-bfdprofile-cr.adoc
@@ -7,7 +7,7 @@
 = About the BFD profile custom resource
 
 [role="_abstract"]
-To enable rapid detection of communication failures between routing peers, configure the properties of the MetalLB BFD profile custom resource (CR). Defining these parameters ensures that network traffic is quickly rerouted if a path becomes unavailable, maintaining high cluster reachability and stability.
+As a cluster administrator, you can specify parameters in the BFD profile CR. The MetalLB Operator uses the BFD profile custom resources to identify which BGP sessions use BFD to provide faster path failure detection than BGP alone provides.
 
 The following table describes parameters for the BFD profile CR:
 

--- a/modules/nw-metallb-configure-bgp-advertisement-advanced.adoc
+++ b/modules/nw-metallb-configure-bgp-advertisement-advanced.adoc
@@ -7,8 +7,6 @@
 = Configuring MetalLB with a BGP advertisement and an advanced use case
 
 [role="_abstract"]
-To assign application services specific IP addresses from designated IPv4 and IPv6 ranges, configure MetalLB for advanced address allocation. Establishing these ranges and BGP advertisements ensures that your load-balancer services remain reachable through predictable network paths.
-
 Configure MetalLB so that MetalLB assigns IP addresses to load-balancer services in the ranges between `203.0.113.200` and `203.0.113.203` and between `fc00:f853:ccd:e799::0` and `fc00:f853:ccd:e799::f`.
 
 To explain the two BGP advertisements, consider an instance when MetalLB assigns the IP address of `203.0.113.200` to a service. With that IP address as an example, the speaker advertises the following two routes to BGP peers:

--- a/modules/nw-metallb-configure-bgp-advertisement.adoc
+++ b/modules/nw-metallb-configure-bgp-advertisement.adoc
@@ -7,6 +7,8 @@
 = Configure MetalLB with a BGP advertisement and a basic use case
 
 [role="_abstract"]
-To advertise specific IPv4 and IPv6 routes to peer BGP routers for assigned load-balancer IP addresses, configure MetalLB by using default preference and community settings. Establishing these routes ensures reliable external traffic delivery and consistent network propagation for your application services.
+Configure MetalLB so that the peer BGP routers receive one `203.0.113.200/32` route and one `fc00:f853:ccd:e799::1/128` route for each load-balancer IP address that MetalLB assigns to a service.
+
+Because the `localPref` and `communities` fields are not specified, the routes are advertised with `localPref` set to zero and no BGP communities.
 
 Ensure that you can configure MetalLB so that the peer BGP routers receive one `203.0.113.200/32` route and one `fc00:f853:ccd:e799::1/128` route for each load-balancer IP address that MetalLB assigns to a service. If you do not specify the `localPref` and `communities` parameters, MetalLB advertises the routes with `localPref` set to `0 and no BGP communities.

--- a/modules/nw-metallb-configure-l2-advertisement-interface.adoc
+++ b/modules/nw-metallb-configure-l2-advertisement-interface.adoc
@@ -7,7 +7,7 @@
 = Configuring MetalLB with an L2 advertisement for selected interfaces
 
 [role="_abstract"]
-To restrict which network interfaces advertise assigned service IP addresses, configure the interfaces parameter in the MetalLB `L2Advertisement` custom resource (CR). Defining specific interfaces ensures that cluster services are reachable only through designated network paths for improved traffic management and isolation.
+By default, the IP addresses from IP address pool that has been assigned to the service, is advertised from all the network interfaces. You can use the `interfaces` field in the `L2Advertisement` custom resource definition to restrict those network interfaces that advertise the IP address pool.
 
 The example in the procedure shows how to configure MetalLB so that the IP address pool is advertised only from the network interfaces listed in the `interfaces` parameter of all nodes.
 

--- a/modules/nw-metallb-configure-l2-advertisement-label.adoc
+++ b/modules/nw-metallb-configure-l2-advertisement-label.adoc
@@ -7,7 +7,7 @@
 = Configuring MetalLB with an L2 advertisement and labels
 
 [role="_abstract"]
-To dynamically associate IP address pools with advertisements by using labels instead of specific names, configure the `ipAddressPoolSelectors` parameter in the MetalLB custom resource (CR). By using selectors, you can manage network routing more efficiently by automatically grouping address pools as your cluster scales.
+You can use the `ipAddressPoolSelectors` field in the `BGPAdvertisement` and `L2Advertisement` custom resource definitions to associate the `IPAddressPool` to the advertisement. This association is based on the label assigned to the `IPAddressPool` instead of the name itself.
 
 The example in the procedure shows how to configure MetalLB so that the `IPAddressPool` is advertised with the L2 protocol by configuring the `ipAddressPoolSelectors` field.
 

--- a/modules/nw-metallb-configure-l2-advertisement.adoc
+++ b/modules/nw-metallb-configure-l2-advertisement.adoc
@@ -7,7 +7,7 @@
 = Configuring MetalLB with an L2 advertisement
 
 [role="_abstract"]
-To provide fault-tolerant external IP addresses for cluster services, configure MetalLB to advertise an `IPAddressPool` by using the Layer 2 protocol. Establishing this advertisement ensures that application workloads remain reachable within the local network through standard address discovery protocols.
+You can configure MetalLB so that the `IPAddressPool` is advertised with the L2 protocol.
 
 .Prerequisites
 

--- a/modules/nw-metallb-configure-secondary-interface.adoc
+++ b/modules/nw-metallb-configure-secondary-interface.adoc
@@ -3,13 +3,11 @@
 = Configuring MetalLB with secondary networks
 
 [role="_abstract"]
-To enable traffic forwarding for MetalLB on a secondary network interface, add a machine configuration that allows IP packet forwarding between interfaces. Implementing this configuration ensures that application services remain reachable when they use nondefault network paths.
+From {product-title} 4.14 the default network behavior is to not allow forwarding of IP packets between network interfaces. Therefore, when MetalLB is configured on a secondary interface, you need to add a machine configuration to enable IP forwarding for only the required interfaces. 
 
 [NOTE]
 ====
-From {product-title} 4.14 the default network behavior does not allow forwarding of IP packets between network interfaces.
-
-{product-title} clusters upgraded from 4.13 are not affected because a global parameter is set during an upgrade to enable global IP forwarding. 
+{product-title} clusters upgraded from 4.13 are not affected because a global parameter is set during upgrade to enable global IP forwarding. 
 ====
 
 To enable IP forwarding for the secondary interface, you have two options:

--- a/networking/ingress_load_balancing/metallb/about-advertising-ipaddresspool.adoc
+++ b/networking/ingress_load_balancing/metallb/about-advertising-ipaddresspool.adoc
@@ -7,7 +7,9 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 [role="_abstract"]
-To provide fault-tolerant external IP addresses and load balancing for cluster services, configure MetalLB to advertise addresses by using Layer 2 protocols, the Border Gateway Protocol (BGP), or both. Selecting the appropriate protocol ensures reliable traffic routing and high availability for your application workloads.
+You can configure MetalLB so that the IP address is advertised with layer 2 protocols, the BGP protocol, or both.
+
+With layer 2, MetalLB provides a fault-tolerant external IP address. With BGP, MetalLB provides fault-tolerance for the external IP address and load balancing.
 
 MetalLB supports advertising by using Layer 2 and BGP for the same set of IP addresses.
 

--- a/networking/ingress_load_balancing/metallb/metallb-configure-bfd-profiles.adoc
+++ b/networking/ingress_load_balancing/metallb/metallb-configure-bfd-profiles.adoc
@@ -7,9 +7,7 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 [role="_abstract"]
-To achieve faster path failure detection for BGP sessions, configure MetalLB Bidirectional Forwarding Detection (BFD) profiles. Establishing these profiles ensures that your network routing remains highly available and responsive by identifying connectivity issues more quickly than standard protocols.
-
-You can add, modify, and delete BFD profiles. The MetalLB Operator uses the BFD profile custom resources (CRs) to identify the BGP sessions that use BFD.
+As a cluster administrator, you can add, modify, and delete Bidirectional Forwarding Detection (BFD) profiles. The MetalLB Operator uses the BFD profile custom resources to identify which BGP sessions use BFD to provide faster path failure detection than BGP alone provides.
 
 // BFD profile custom resource
 include::modules/nw-metallb-bfdprofile-cr.adoc[leveloffset=+1]

--- a/networking/ingress_load_balancing/metallb/metallb-configure-bgp-peers.adoc
+++ b/networking/ingress_load_balancing/metallb/metallb-configure-bgp-peers.adoc
@@ -7,9 +7,9 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 [role="_abstract"]
-To establish BGP sessions and advertise routes for load balancer services, configure MetalLB Border Gateway Protocol (BGP) peer custom resources (CRs). Defining these peers ensures that your network infrastructure receives accurate routing information to reach cluster application workloads.
+As a cluster administrator, you can add, modify, and delete Border Gateway Protocol (BGP) peers. The MetalLB Operator uses the BGP peer custom resources to identify which peers that MetalLB `speaker` pods contact to start BGP sessions. 
 
-You can add, modify, and delete BGP peers. The MetalLB Operator uses the BGP peer custom resources to identify the peers that MetalLB `speaker` pods contact to start BGP sessions. The peers receive the route advertisements for the load-balancer IP addresses that MetalLB assigns to services.
+The peers receive the route advertisements for the load-balancer IP addresses that MetalLB assigns to services.
 
 // BGP peer custom resource
 include::modules/nw-metallb-bgppeer-cr.adoc[leveloffset=+1]


### PR DESCRIPTION
The short description NotebookLM was used to generate abstracts. However, as part of the remediation process, I've reviewed abstracts, to what I think, require rolling back to a closer alignment with the original text. As a reference point for the original text (pre-CQA), here are the original CQA PRs:

* https://github.com/openshift/openshift-docs/pull/104829/changes
* https://github.com/openshift/openshift-docs/pull/104836/changes

Version(s):
4.16+

Issue:
[OSDOCS-18664](https://redhat.atlassian.net/browse/OSDOCS-18664)

Link to docs preview:

* https://109307--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ingress_load_balancing/metallb/about-advertising-ipaddresspool.html
* https://109307--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ingress_load_balancing/metallb/metallb-configure-address-pools.html
* https://109307--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ingress_load_balancing/metallb/metallb-configure-bfd-profiles.html
* https://109307--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ingress_load_balancing/metallb/metallb-configure-bgp-peers.html