### PR TITLE
OSDOCS-18624-abstracts: CQA for NOP-4 SR-IOV Operator

### DIFF
--- a/modules/about-network-resource-injector.adoc
+++ b/modules/about-network-resource-injector.adoc
@@ -7,7 +7,7 @@
 = About the Network Resources Injector
 
 [role="_abstract"]
-To automate network configuration for your workloads, use the Network Resources Injector. This Kubernetes Dynamic Admission Controller intercepts pod creation requests to automatically inject the necessary network resources and parameters defined for your cluster.
+You can use the Network Resources Injector, a Kubernetes Dynamic Admission Controller application, to mutate resource requests and limits in a pod specification and mutate a pod specification with a Downward API volume.
 
 The Network Resources Injector provides the following capabilities:
 

--- a/modules/about-sr-iov-operator-admission-control-webhook.adoc
+++ b/modules/about-sr-iov-operator-admission-control-webhook.adoc
@@ -7,9 +7,7 @@
 = About the SR-IOV Network Operator admission controller webhook
 
 [role="_abstract"]
-To validate network configurations and prevent errors, rely on the SR-IOV Network Operator admission controller webhook. This Kubernetes Dynamic Admission Controller intercepts API requests to ensure that your SR-IOV resource definitions and pod specifications comply with cluster policies.
-
-The SR-IOV Network Operator Admission Controller webhook provides the following capabilities:
+You can use the SR-IOV Network Operator Admission Controller webhook to mutate or validate the `SriovNetworkNodePolicy` CR.
 
 * Validation of the `SriovNetworkNodePolicy` CR when it is created or updated.
 * Mutation of the `SriovNetworkNodePolicy` CR by setting the default value for the `priority` and `deviceType` fields when the CR is created or updated.

--- a/modules/configuring-custom-nodeselector.adoc
+++ b/modules/configuring-custom-nodeselector.adoc
@@ -7,9 +7,7 @@
 = Configuring a custom NodeSelector for the SR-IOV Network Config daemon
 
 [role="_abstract"]
-To specify which nodes host the SR-IOV Network Config daemon, configure a custom node selector by using node labels. By completing this task, you can restrict deployment to specific nodes instead of the default compute nodes.
-
-The SR-IOV Network Config daemon discovers and configures the SR-IOV network devices on cluster nodes. By default, the daemon is deployed to all the compute nodes in the cluster.
+The SR-IOV Network Config daemon discovers and configures the SR-IOV network devices on cluster nodes. By default, the daemon is deployed to all the compute nodes in the cluster. You can use node labels to specify on which nodes the SR-IOV Network Config daemon runs.
 
 [IMPORTANT]
 =====

--- a/modules/disable-enable-network-resource-injector.adoc
+++ b/modules/disable-enable-network-resource-injector.adoc
@@ -7,7 +7,7 @@
 = Disabling or enabling the Network Resources Injector
 
 [role="_abstract"]
-To control the automatic configuration of your cluster workloads, enable or disable the Network Resources Injector. By adjusting these settings you can better manage whether the Kubernetes Dynamic Admission Controller automatically injects network resources and parameters into pods during their creation.
+To control the automatic configuration of your cluster workloads, enable or disable the Network Resources Injector.
 
 .Prerequisites
 

--- a/modules/disable-enable-sr-iov-operator-admission-control-webhook.adoc
+++ b/modules/disable-enable-sr-iov-operator-admission-control-webhook.adoc
@@ -7,7 +7,7 @@
 = Disabling or enabling the SR-IOV Network Operator admission controller webhook
 
 [role="_abstract"]
-To manage validation of your network configurations, enable or disable the SR-IOV Network Operator admission controller webhook. When enabled, the Operator automatically verifies SR-IOV resource definitions and pod specifications against cluster policies.
+To manage validation of your network configurations, enable or disable the SR-IOV Network Operator admission controller webhook.
 
 .Prerequisites
 

--- a/modules/nw-sriov-configuring-operator.adoc
+++ b/modules/nw-sriov-configuring-operator.adoc
@@ -7,7 +7,7 @@
 = Configuring the SR-IOV Network Operator
 
 [role="_abstract"]
-To manage SR-IOV network devices and network attachments in your cluster, configure the Single Root I/O Virtualization (SR-IOV) Network Operator. You can then deploy the Operator components to your cluster.
+To manage SR-IOV network devices and network attachments in your cluster, configure the Single Root I/O Virtualization (SR-IOV) Network Operator.
 
 .Procedure
 

--- a/modules/nw-sriov-installing-operator-web-console.adoc
+++ b/modules/nw-sriov-installing-operator-web-console.adoc
@@ -8,7 +8,7 @@
 = Using the web console to install the SR-IOV Network Operator
 
 [role="_abstract"]
-You can use the web console to install the SR-IOV Network Operator. By using the web console, you can deploy the Operator and manage SR-IOV network devices and attachments directly from a graphical interface without having to the CLI.
+You can use the web console to install the SR-IOV Network Operator. By using the web console, you can deploy the Operator and manage SR-IOV network devices and attachments directly from a graphical interface without having to use the CLI.
 
 .Prerequisites
 

--- a/modules/nw-sriov-operator-cr.adoc
+++ b/modules/nw-sriov-operator-cr.adoc
@@ -7,7 +7,7 @@
 = SR-IOV Network Operator config custom resource
 
 [role="_abstract"]
-To customize the SR-IOV Network Operator, configure the `sriovoperatorconfig` custom resource. The reference lists the parameters available for controlling the global settings and deployment behavior of the Operator.
+To customize the SR-IOV Network Operator, configure the `sriovoperatorconfig` custom resource.
 
 The following table describes the `sriovoperatorconfig` CR fields:
 

--- a/modules/sriov-network-metrics-exporter.adoc
+++ b/modules/sriov-network-metrics-exporter.adoc
@@ -7,7 +7,7 @@
 = About the SR-IOV network metrics exporter
 
 [role="_abstract"]
-To monitor the networking activity of SR-IOV pods, enable the SR-IOV network metrics exporter. This tool exposes metrics for SR-IOV virtual functions (VFs) in Prometheus format, so that you can query and visualize data through the {product-title} web console.
+The Single Root I/O Virtualization (SR-IOV) network metrics exporter reads the metrics for SR-IOV virtual functions (VFs) and exposes these VF metrics in Prometheus format. When the SR-IOV network metrics exporter is enabled, you can query the SR-IOV VF metrics by using the {product-title} web console to monitor the networking activity of the SR-IOV pods.
 
 When you query the SR-IOV VF metrics by using the web console, the SR-IOV network metrics exporter fetches and returns the VF network statistics along with the name and namespace of the pod that the VF is attached to.
 

--- a/modules/sriov-operator-metrics.adoc
+++ b/modules/sriov-operator-metrics.adoc
@@ -7,7 +7,7 @@
 = Enabling the SR-IOV network metrics exporter
 
 [role="_abstract"]
-To enable the SR-IOV network metrics exporter, set the `spec.featureGates.metricsExporter` field to `true`. Because the exporter is disabled by default, you must explicitly activate this feature gate to start exposing metrics for your SR-IOV devices.
+To enable the SR-IOV network metrics exporter, set the `spec.featureGates.metricsExporter` field to `true`. Because the exporter is disabled by default, you must explicitly enable the SR-IOV network metrics exporter.
 
 [IMPORTANT]
 ====


### PR DESCRIPTION
DROP LABEL AS SOON AS OTHER PRs ARE MERGED

**MERGER: PLEASE LET ME KNOW IF PROVIDING A SCREENSHOT OF THE ORIGINAL TEXT (NON-CQA'D TEXT) UNDER EACH ABSTRACT WOULD MAKE FOR AN EASIER REVIEW**

The short description NotebookLM was used to generate abstracts. However, as part of the remediation process, I've reviewed abstracts, to what I think, require rolling back to a closer alignment with the original text. As a reference point for the original text (pre-CQA), here are the original CQA PRs:

* https://github.com/openshift/openshift-docs/pull/105729
* https://github.com/openshift/openshift-docs/pull/105763

Version(s):
4.20+

Issue:
https://redhat.atlassian.net/browse/OSDOCS-16845 and https://redhat.atlassian.net/browse/OSDOCS-18624

Link to docs preview:

