### PR TITLE
OSDOCS-16862-abstracts: CORE-3 Ingress Controllers and Load Balancing…

### DIFF
--- a/modules/installation-osp-api-scaling.adoc
+++ b/modules/installation-osp-api-scaling.adoc
@@ -7,7 +7,7 @@
 = Scaling clusters by using Octavia
 
 [role="_abstract"]
-To ensure high availability and distribute traffic across multiple cluster API access points in {product-title} on {rh-openstack}, create an Octavia load balancer. Configuring your cluster to use multiple balancers prevents network bottlenecks and ensures continuous access to your API services.
+If you want to use multiple API load balancers, create an Octavia load balancer and then configure your cluster to use it.
 
 .Prerequisites
 

--- a/modules/nw-configuring-lb-allowed-source-ranges-migration.adoc
+++ b/modules/nw-configuring-lb-allowed-source-ranges-migration.adoc
@@ -7,9 +7,7 @@
 = Migrating to load balancer allowed source ranges
 
 [role="_abstract"]
-To ensure long-term compatibility and use stable API parameters in {product-title}, migrate from the legacy `service.beta.kubernetes.io/load-balancer-source-ranges` annotation to load balancer allowed source ranges.
-
-When you set the `AllowedSourceRanges`, the Ingress Controller sets the `spec.loadBalancerSourceRanges` parameter based on the `AllowedSourceRanges` value and unsets the `service.beta.kubernetes.io/load-balancer-source-ranges` annotation.
+If you have already set the annotation `service.beta.kubernetes.io/load-balancer-source-ranges`, you can migrate to load balancer allowed source ranges. When you set the `AllowedSourceRanges`, the Ingress Controller sets the `spec.loadBalancerSourceRanges` field based on the `AllowedSourceRanges` value and unsets the `service.beta.kubernetes.io/load-balancer-source-ranges` annotation.
 
 [NOTE]
 ====

--- a/modules/nw-ingress-gateway-api-deployment-topologies.adoc
+++ b/modules/nw-ingress-gateway-api-deployment-topologies.adoc
@@ -6,8 +6,8 @@
 [id="nw-ingress-gateway-api-deployment_{context}"]
 = Gateway API deployment topologies
 
-[role="_abstract"] 
-To optimise network security and resource allocation in {product-title}, choose between shared or dedicated gateway topologies when implementing the Gateway API. Selecting the appropriate topology ensures your infrastructure meets specific security requirements and operational advantages for your workloads.
+[role="_abstract"]
+Gateway API is designed to accommodate two topologies: shared gateways or dedicated gateways. You can choose a topology based on its own advantages and different security implications.
 
 Dedicated gateway:: Routes and any load balancers or proxies are served from the same namespace. The `Gateway`
 object restricts routes to a particular application namespace. This is the default topology when deploying a Gateway API resource in {product-title}.

--- a/modules/nw-ingress-gateway-api-enable.adoc
+++ b/modules/nw-ingress-gateway-api-enable.adoc
@@ -7,7 +7,7 @@
 = Getting started with Gateway API for the Ingress Operator
 
 [role="_abstract"]
-To implement routing policies in your {product-title} cluster, create a GatewayClass resource. This resource initializes the Gateway API infrastructure, providing the foundational template required to define and manage how external traffic reaches your internal services.
+After you create a `GatewayClass` resource, the resource configures Gateway API for use on your cluster.
 
 [IMPORTANT]
 ====
@@ -15,7 +15,7 @@ The {product-title} Gateway API implementation relies on the Cluster Ingress Ope
 
 A conflict occurs if your cluster already has an active OpenShift Service Mesh (OSSM v2.x) subscription in any namespace. OSSM v2.x and OSSM v3.x cannot coexist on the same cluster.
 
-If a conflicting OSSM v2.x subscription is present when you create a GatewayClass resource, the Cluster Ingress Operator attempts to install the required OSSM v3.x components but fails this installation operation. As a result, Gateway API resources, such as Gateway or HTTPRoute, have no effect and no proxy gets configured to route traffic. In {product-title} 4.19, this failure is silent. For {product-title} 4.20 and later, this conflict causes the ingress ClusterOperator to report a Degraded status.
+If a conflicting OSSM v2.x subscription is present when you create a `GatewayClass` resource, the Cluster Ingress Operator attempts to install the required OSSM v3.x components but fails this installation operation. As a result, Gateway API resources, such as Gateway or HTTPRoute, have no effect and no proxy gets configured to route traffic. In {product-title} 4.19, this failure is silent. For {product-title} 4.20 and later, this conflict causes the ingress ClusterOperator to report a Degraded status.
 
 Before enabling Gateway API by creating a `GatewayClass`, verify that you do not have an active OSSM v2.x subscription on the cluster.
 ====
@@ -92,7 +92,7 @@ $ DOMAIN=$(oc get ingresses.config/cluster -o jsonpath={.spec.domain})
 +
 .. Create a YAML file, `example-gateway.yaml`, that contains the following information:
 +
-.Example `Gateway` CR
+.Example Gateway CR
 [source,yaml]
 ----
 apiVersion: gateway.networking.k8s.io/v1
@@ -200,7 +200,7 @@ For {gcp-first} installations, you can use a custom DNS solution. You must manua
 +
 .. Create a YAML file, `example-route.yaml`, that contains the following information:
 +
-.Example `HTTPRoute` CR
+.Example HTTPRoute CR
 [source,yaml]
 ----
 apiVersion: gateway.networking.k8s.io/v1

--- a/modules/nw-ingress-gateway-api-troubleshooting-degraded.adoc
+++ b/modules/nw-ingress-gateway-api-troubleshooting-degraded.adoc
@@ -7,7 +7,7 @@
 = Removing conflicts between the Gateway API and the OSSM v2.x
 
 [role="_abstract"]
-To restore cluster health and resolve operator degradation in {product-title} 4.20 and later, identify and remove conflicts between the Gateway API and OpenShift Service Mesh (OSSM) v2.x. Ensuring these subscriptions do not overlap allows the ingress Cluster Operator to maintain a healthy status when you create a GatewayClass resource.
+In {product-title} 4.20 and later, if you create a `GatewayClass` resource while a conflicting OpenShift Service Mesh (OSSM) v2.x subscription exists, the `ingress` Cluster Operator (CIO) reports a `Degraded` status. You can check for this status and resolve the conflict.
 
 The conflict occurs because the Gateway API implementation requires OSSM v3.x, which cannot coexist with OSSM v2.x. The CIO detects this conflict, stops the Gateway API provisioning, and reports the `Degraded` status to alert administrators. 
 

--- a/modules/nw-ingress-sharding-dns.adoc
+++ b/modules/nw-ingress-sharding-dns.adoc
@@ -7,7 +7,7 @@
 = Ingress sharding and DNS
 
 [role="_abstract"]
-To ensure ingress traffic reaches the correct router in {product-title}, create separate DNS entries for each router in your project. Because a router does not forward unknown traffic to other routers, distinct entries are required to resolve specific domains to their hosting nodes."
+As a cluster administrator, ensure that you add a separate DNS entry for each router in a project. A router will not forward unknown routes to another router.
 
 Consider the following example:
 

--- a/modules/nw-ingress-sharding-route-configuration.adoc
+++ b/modules/nw-ingress-sharding-route-configuration.adoc
@@ -8,7 +8,7 @@
 = Creating a route for Ingress Controller sharding
 
 [role="_abstract"]
-To host applications at specific URLs and balance traffic load in {product-title}, configure Ingress Controller sharding. By sharding, you can isolate traffic for specific workloads or tenants, ensuring efficient resource management across your cluster.
+You can use a route to host your application at a URL. Ingress Controller sharding helps balance incoming traffic load among a set of Ingress Controllers. Ingress Controller sharding can also isolate traffic to a specific Ingress Controller. For example, company A goes to one Ingress Controller and company B to another.
 
 The following procedure describes how to create a route for Ingress Controller sharding, using the `hello-openshift` application as an example.
 

--- a/modules/nw-ingresscontroller-change-external.adoc
+++ b/modules/nw-ingresscontroller-change-external.adoc
@@ -7,11 +7,9 @@
 = Configuring the Ingress Controller endpoint publishing scope to External
 
 [role="_abstract"]
-To expose cluster services to public networks or the internet in {product-title}, configure the Ingress Controller endpoint publishing scope to `External`.
-
-When a cluster administrator installs a new cluster without specifying that the cluster is private, the default Ingress Controller is created with a `scope` set to `External`.
-
 As an installation or post-installation task, a cluster administrator can configure the Ingress Controller to `Internal`. Additionally, a cluster administrator can change an `Internal` Ingress Controller to `External`.
+
+When you install a new cluster without specifying that the cluster is private, the default Ingress Controller is created with a `scope` set to `External`.
 
 [IMPORTANT]
 ====

--- a/modules/nw-ingresscontroller-change-internal.adoc
+++ b/modules/nw-ingresscontroller-change-internal.adoc
@@ -7,9 +7,7 @@
 = Configuring the Ingress Controller endpoint publishing scope to Internal
 
 [role="_abstract"]
-To restrict cluster access to internal traffic and enhance network security in {product-title}, change the Ingress Controller scope from `External` to `Internal`.
-
-When a cluster administrator installs a new cluster without specifying that the cluster is private, the default Ingress Controller is created with a `scope` set to `External`.
+As a cluster administrator, when you install a new cluster without specifying that the cluster is private, the default Ingress Controller is created with a `scope` set to `External`. You can change an `External` scoped Ingress Controller to `Internal`.
 
 .Prerequisites
 

--- a/modules/nw-osp-configuring-external-load-balancer.adoc
+++ b/modules/nw-osp-configuring-external-load-balancer.adoc
@@ -35,11 +35,11 @@ endif::[]
 = Configuring a user-managed load balancer
 
 [role="_abstract"]
-To integrate your infrastructure with existing network standards or gain more control over traffic management in {product-title}
+You can configure an {product-title} cluster
 ifdef::openstack[]
 on {rh-openstack-first}
 endif::openstack[]
-, use a user-managed load balancer in place of the default load balancer.
+to use a user-managed load balancer in place of the default load balancer.
 
 [IMPORTANT]
 ====

--- a/modules/nw-osp-loadbalancer-limitations.adoc
+++ b/modules/nw-osp-loadbalancer-limitations.adoc
@@ -7,7 +7,7 @@
 = Limitations of load balancer services
 
 [role="_abstract"]
-To optimise network resource management and mitigate operational risks in {product-title} clusters on {rh-openstack-first}, review the implementation of Octavia for load balancer services. 
+{product-title} clusters on {rh-openstack-first} use Octavia to handle load balancer services. As a result of this choice, such clusters might have functional limitations.
 
 {product-title} clusters on {rh-openstack-first} use Octavia to handle load balancer services. As a result, your cluster has several functional limitations.
 

--- a/modules/nw-osp-services-external-load-balancer.adoc
+++ b/modules/nw-osp-services-external-load-balancer.adoc
@@ -16,11 +16,11 @@
 = Services for a user-managed load balancer
 
 [role="_abstract"]
-To integrate your infrastructure with existing network standards or gain more control over traffic management in {product-title}
+You can configure an {product-title} cluster
 ifeval::["{context}" == "load-balancing-openstack"]
 on {rh-openstack-first}
 endif::[]
-, configure services for a user-managed load balancer. 
+to use a user-managed load balancer in place of the default load balancer.
 
 [IMPORTANT]
 ====

--- a/modules/nw-service-externalip-create.adoc
+++ b/modules/nw-service-externalip-create.adoc
@@ -7,9 +7,7 @@
 = Attaching an ExternalIP to a service
 
 [role="_abstract"]
-To route traffic from external networks to your applications in {product-title}, attach an ExternalIP resource to a service. 
-
-If you configured your cluster to automatically attach the resource to a service, you might not need to manually attach an ExternalIP to the service.
+You can attach an ExternalIP resource to a service. If you configured your cluster to automatically attach the resource to a service, you might not need to manually attach an ExternalIP to the service.
 
 The examples in the procedure use a scenario that manually attaches an ExternalIP resource to a service in a cluster with an IP failover configuration. 
 

--- a/networking/ingress_load_balancing/configuring_ingress_cluster_traffic/ingress-controller-dnsmgt.adoc
+++ b/networking/ingress_load_balancing/configuring_ingress_cluster_traffic/ingress-controller-dnsmgt.adoc
@@ -7,9 +7,7 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 [role="_abstract"]
-To ensure application accessiblity across external networks in {product-title}, you can manually configure DNS records for an Ingress Controller.
-
-As a cluster administrator, when you create an Ingress Controller, the Operator manages the DNS records automatically. This has some limitations when the required DNS zone is different from the cluster DNS zone or when the DNS zone is hosted outside the cloud provider.
+As a cluster administrator, when you create an Ingress Controller, the Operator manages the DNS records automatically. This approach has some limitations when the required DNS zone is different from the cluster DNS zone or when the DNS zone is hosted outside the cloud provider.
 
 The following list details key aspects for a managed DNS management policy:
 

--- a/networking/ingress_load_balancing/configuring_ingress_cluster_traffic/ingress-gateway-api.adoc
+++ b/networking/ingress_load_balancing/configuring_ingress_cluster_traffic/ingress-gateway-api.adoc
@@ -7,7 +7,7 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 [role="_abstract"]
-To manage complex network traffic and implement advanced routing policies in {product-title}, use the Ingress Operator to configure the Gateway API.
+{product-title} provides additional ways of configuring network traffic by using Gateway API with the Ingress Operator.
 
 [IMPORTANT]
 ====


### PR DESCRIPTION
The short description NotebookLM was used to generate abstracts. However, as part of the remediation process, I've reviewed abstracts, to what I think, require rolling back to a closer alignment with the original text. I've provided direct links to original CQA work for each revised abstract.

As a reference point for the original text (pre-CQA), here are the original CQA PRs:

* https://github.com/openshift/openshift-docs/pull/104829/changes
* https://github.com/openshift/openshift-docs/pull/104836/changes

Version(s):
4.20+

Issue:
[OSDOCS-16862](https://redhat.atlassian.net/browse/OSDOCS-16862)

Link to docs preview:

* [Scaling clusters by using Octavia](https://109311--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ingress_load_balancing/load-balancing-openstack.html#installation-osp-api-scaling_load-balancing-openstack)
* [Migrating to load balancer allowed source ranges](https://109311--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ingress_load_balancing/configuring_ingress_cluster_traffic/configuring-ingress-cluster-traffic-load-balancer-allowed-source-ranges.html#nw-configuring-lb-allowed-source-ranges-migration_configuring-ingress-cluster-traffic-lb-allowed-source-ranges)
* [Gateway API deployment topologies](https://109311--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ingress_load_balancing/configuring_ingress_cluster_traffic/ingress-gateway-api.html#nw-ingress-gateway-api-deployment_ingress-gateway-api)
* [Getting started with Gateway API for the Ingress Operator](https://109311--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ingress_load_balancing/configuring_ingress_cluster_traffic/ingress-gateway-api.html#nw-ingress-gateway-api-enable_ingress-gateway-api)
* [Removing conflicts between the Gateway API and the OSSM v2.x](https://109311--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ingress_load_balancing/configuring_ingress_cluster_traffic/ingress-gateway-api.html#nw-ingress-gateway-api-troubleshooting-degraded_ingress-gateway-api)
* [Ingress sharding and DNS](https://109311--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ingress_load_balancing/configuring_ingress_cluster_traffic/configuring-ingress-cluster-traffic-ingress-controller.html#nw-ingress-sharding-dns_configuring-ingress-cluster-traffic-ingress-controller)
* [Creating a route for Ingress Controller sharding](https://109311--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ingress_load_balancing/configuring_ingress_cluster_traffic/configuring-ingress-cluster-traffic-ingress-controller.html#nw-ingress-sharding-route-configuration_configuring-ingress-cluster-traffic-ingress-controller)
* [Configuring the Ingress Controller endpoint publishing scope to External](https://109311--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ingress_load_balancing/configuring_ingress_cluster_traffic/nw-configuring-ingress-controller-endpoint-publishing-strategy.html#nw-ingresscontroller-change-external_nw-configuring-ingress-controller-endpoint-publishing-strategy)
* [Configuring the Ingress Controller endpoint publishing scope to Internal](https://109311--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ingress_load_balancing/configuring_ingress_cluster_traffic/nw-configuring-ingress-controller-endpoint-publishing-strategy.html#nw-ingresscontroller-change-internal_nw-configuring-ingress-controller-endpoint-publishing-strategy)
* [Configuring a user-managed load balancer](https://109311--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/bare-metal-postinstallation-configuration.html#nw-osp-configuring-external-load-balancer_bare-metal-postinstallation-configuration)
* [Limitations of load balancer services](https://109311--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ingress_load_balancing/load-balancing-openstack.html#nw-osp-loadbalancer-limitations_load-balancing-openstack)
* [Services for a user-managed load balancer](https://109311--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ingress_load_balancing/load-balancing-openstack.html#nw-osp-services-external-load-balancer_load-balancing-openstack)
* [Attaching an ExternalIP to a service](https://109311--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ingress_load_balancing/configuring_ingress_cluster_traffic/configuring-ingress-cluster-traffic-service-external-ip.html#nw-service-externalip-create_configuring-ingress-cluster-traffic-service-external-ip)
* [Understanding DNS management policies ](https://109311--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ingress_load_balancing/configuring_ingress_cluster_traffic/ingress-controller-dnsmgt.html)
* [Gateway API with OpenShift Container Platform networking ](https://109311--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ingress_load_balancing/configuring_ingress_cluster_traffic/ingress-gateway-api)