### PR TITLE
[enterprise-4.17] resolves ADV errors for Ingress MS docs

### DIFF
--- a/microshift_configuring/microshift-disable-lvms-csi-provider-csi-snapshot.adoc
+++ b/microshift_configuring/microshift-disable-lvms-csi-provider-csi-snapshot.adoc
@@ -7,7 +7,7 @@ include::_attributes/attributes-microshift.adoc[]
 toc::[]
 
 [role="_abstract"]
-You can configure {microshift-short} to disable the built-in logical volume manager storage (LVMS) Container Storage Interface (CSI) provider or the CSI snapshot capabilities to reduce the use of runtime resources such as RAM, CPU, and storage.
+To reduce use of runtime resources such as RAM, CPU, and storage in {microshift-short}, you can disable the built-in LVMS CSI provider or CSI snapshot. Configure the storage section in the configuration file before you install or run the product.
 
 include::modules/microshift-disabling-lvms-csi-snapshot.adoc[leveloffset=+1]
 

--- a/microshift_configuring/microshift-greenboot-checking-status.adoc
+++ b/microshift_configuring/microshift-greenboot-checking-status.adoc
@@ -6,6 +6,7 @@ include::_attributes/attributes-microshift.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 To deploy applications or make other changes through the {microshift-short} API with tools other than `kustomize` manifests, you must wait until the greenboot health checks have finished. This ensures that your changes are not lost if greenboot rolls your `rpm-ostree` system back to an earlier state.
 
 The `greenboot-healthcheck` service runs one time and then exits. After greenboot has exited and the system is in a healthy state, you can proceed with configuration changes and deployments.

--- a/modules/microshift-disabling-lvms-csi-snapshot.adoc
+++ b/modules/microshift-disabling-lvms-csi-snapshot.adoc
@@ -31,9 +31,9 @@ Use the procedure if you are defining the configuration file before installing a
 # ...
 ----
 +
-where
+where:
 +
-`storage`: Specifies the storage details. You can choose to not define `optionalCsiComponents`. If you do specify the `optionalCsiComponents` field, valid values include: an empty value (`[]`) or a single empty string element (`[""]`), `snapshot-controller`, or `none`. A value of `none` is mutually exclusive with all other values.
+`storage`:: Specifies the storage details. You can choose to not define `optionalCsiComponents`. If you do specify the `optionalCsiComponents` field, valid values include: an empty value (`[]`) or a single empty string element (`[""]`), `snapshot-controller`, or `none`. A value of `none` is mutually exclusive with all other values.
 +
 [NOTE]
 ====


### PR DESCRIPTION
xref: https://github.com/openshift/openshift-docs/pull/109275
cherry pick: 7b91d4388cd414f6c8db5f8b6da01dec9cc18031

Discrepancy between 4.18 and 4.17:

The Ingress documentation was introduced in 4.18, and it included 4 files total (1 assembly, 3 modules). The original PR for the content is here: https://github.com/openshift/openshift-docs/pull/84542

It was never part of version 4.17, so the discrepancy between this version and 4.18 is 4 files. 