### PR TITLE
[enterprise-4.16] resolves ADV errors for 4.16

### DIFF
--- a/microshift_configuring/microshift-greenboot-checking-status.adoc
+++ b/microshift_configuring/microshift-greenboot-checking-status.adoc
@@ -6,6 +6,7 @@ include::_attributes/attributes-microshift.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 To deploy applications or make other changes through the {microshift-short} API with tools other than `kustomize` manifests, you must wait until the greenboot health checks have finished. This ensures that your changes are not lost if greenboot rolls your `rpm-ostree` system back to an earlier state.
 
 The `greenboot-healthcheck` service runs one time and then exits. After greenboot has exited and the system is in a healthy state, you can proceed with configuration changes and deployments.


### PR DESCRIPTION
Discrepancy:

The other files do not exist in version 4.16. 

xref: https://github.com/openshift/openshift-docs/pull/109316
cherry picked from: 7fee68ae0414964ac5b926e0892d945911b7af04