### PR TITLE
[enterprise-4.16] Update for titles and short stories on assemblies

### DIFF
--- a/modules/virt-booting-vms-uefi-mode.adoc
+++ b/modules/virt-booting-vms-uefi-mode.adoc
@@ -40,15 +40,16 @@ spec:
         features:
           acpi: {}
           smm:
-            enabled: true <1>
+            enabled: true
         firmware:
           bootloader:
             efi:
-              secureBoot: true <2>
+              secureBoot: true
 # ...
 ----
-<1> {VirtProductName} requires System Management Mode (`SMM`) to be enabled for Secure Boot in UEFI mode to occur.
-<2> {VirtProductName} supports a VM with or without Secure Boot when using UEFI mode. If Secure Boot is enabled, then UEFI mode is required. However, UEFI mode can be enabled without using Secure Boot.
++
+* You must set `spec.template.spec.domain.features.ssm.enabled` to have a value of `true`.
+* If `spec.template.spec.domain.firmware.bootloader.efi.secureBoot` is set to `true`, then UEFI mode is required. However, you can enable UEFI mode without using Secure Boot.
 
 . Apply the manifest to your cluster by running the following command:
 +

--- a/modules/virt-configuring-disk-sharing-lun-cli.adoc
+++ b/modules/virt-configuring-disk-sharing-lun-cli.adoc
@@ -28,9 +28,9 @@ spec:
               bus: sata
             name: rootdisk
           - errorPolicy: report
-            lun: <1>
+            lun:
               bus: scsi
-              reservation: true <2>
+              reservation: true
             name: na-shared
             serial: shared1234
       volumes:
@@ -41,7 +41,9 @@ spec:
         persistentVolumeClaim:
           claimName: pvc-na-share
 ----
-<1> Identifies a LUN disk.
-<2> Identifies that the persistent reservation is enabled.
++
+* `spec.template.spec.domain.devices.disks.errorPolicy` defines how the hypervisor should behave when an IO error occurs.
+* `spec.template.spec.domain.devices.disks.lun` defines a volume exposed as a LUN device.
+* `spec.template.spec.domain.devices.disks.lun.reservation` defines whether the persistent reservation is enabled.
 
 . Save the `VirtualMachine` manifest file to apply your changes.

--- a/modules/virt-configuring-disk-sharing-lun.adoc
+++ b/modules/virt-configuring-disk-sharing-lun.adoc
@@ -2,7 +2,7 @@
 //
 // *  virt/virtual_machines/virtual_disks/virt-configuring-shared-volumes-for-vms.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="virt-configuring-disk-sharing-lun_{context}"]
 = Configuring disk sharing by using LUN
 
@@ -57,10 +57,10 @@ spec:
           - disk:
               bus: sata
             name: rootdisk
-          - errorPolicy: report <1>
-            lun: <2>
+          - errorPolicy: report
+            lun:
               bus: scsi
-              reservation: true <3>
+              reservation: true
             name: na-shared
             serial: shared1234
       volumes:
@@ -71,8 +71,9 @@ spec:
         persistentVolumeClaim:
           claimName: pvc-na-share
 ----
-<1> Identifies the error policy.
-<2> Identifies a LUN disk.
-<3> Identifies that the persistent reservation is enabled.
++
+* `spec.template.spec.domain.devices.disks.errorPolicy` defines how the hypervisor should behave when an IO error occurs.
+* `spec.template.spec.domain.devices.disks.lun` defines a volume exposed as a LUN device.
+* `spec.template.spec.domain.devices.disks.lun.reservation` defines whether the persistent reservation is enabled.
 
 . Save the `VirtualMachine` manifest file to apply your changes.

--- a/modules/virt-configuring-huge-pages-for-vms.adoc
+++ b/modules/virt-configuring-huge-pages-for-vms.adoc
@@ -39,18 +39,18 @@ spec:
   domain:
     resources:
       requests:
-        memory: "4Gi" <1>
+        memory: "4Gi"
     memory:
       hugepages:
-        pageSize: "1Gi" <2>
+        pageSize: "1Gi"
 # ...
 ----
-<1> The total amount of memory requested for the virtual machine. This value must be divisible by the page size.
-<2> The size of each huge page. Valid values for x86_64 architecture are `1Gi` and `2Mi`. The page size must be smaller than the requested memory.
++
+* `memory` defines the total amount of memory requested for the virtual machine. This value must be divisible by the page size.
+* `pageSize` defines the size of each huge page. Valid values for x86_64 architecture are `1Gi` and `2Mi`. The page size must be smaller than the requested memory.
 
 . Apply the virtual machine configuration:
 +
-
 [source,terminal]
 ----
 $ oc apply -f <virtual_machine>.yaml

--- a/modules/virt-configuring-vm-disk-sharing.adoc
+++ b/modules/virt-configuring-vm-disk-sharing.adoc
@@ -2,8 +2,9 @@
 //
 // * virt/virtual_machines/virtual_disks/virt-configuring-shared-volumes-for-vms.adoc
 
-:_content-type: PROCEDURE
-[id="virt-configuring-vm-disk-sharing{context}"]
+:_mod-docs-content-type: PROCEDURE
+[id="virt-configuring-vm-disk-sharing_{context}"]
+
 = Configuring disk sharing by using virtual machine disks
 
 You can configure block volumes so that multiple virtual machines (VMs) can share storage.
@@ -57,8 +58,9 @@ spec:
           - masquerade: {}
             name: default
 ----
-<1> Identifies the error policy.
-<2> Identifies a device as a disk.
-<3> Identifies a shared disk.
++
+* `spec.template.spec.domain.devices.disks.errorPolicy` defines how the hypervisor should behave when an IO error occurs.
+* `spec.template.spec.domain.devices.disks.disk1` defines a device as a disk.
+* `spec.template.spec.domain.devices.disks.shareable` defines whether multiple virtual machines (VMs) can use the same underlying disk.
 
 . Save the `VirtualMachine` manifest file to apply your changes.

--- a/modules/virt-connecting-service-ssh.adoc
+++ b/modules/virt-connecting-service-ssh.adoc
@@ -21,6 +21,9 @@ You can connect to a virtual machine (VM) that is exposed by a service by using 
 +
 [source,terminal]
 ----
-$ ssh <user_name>@<ip_address> -p <port> <1>
+$ ssh <user_name>@<ip_address> -p <port>
 ----
-<1> Specify the cluster IP for a cluster IP service, the node IP for a node port service, or the external IP address for a load balancer service.
++
+where:
++
+`<ip_address>`:: Specifies the cluster IP for a cluster IP service, the node IP for a node port service, or the external IP address for a load balancer service.

--- a/modules/virt-creating-service-cli.adoc
+++ b/modules/virt-creating-service-cli.adoc
@@ -15,7 +15,7 @@ You can create a service and associate it with a virtual machine (VM) by using t
 
 .Procedure
 
-. Edit the `VirtualMachine` manifest to add the label for service creation:
+. Edit the `VirtualMachine` manifest to add the label for service creation. Add `special: key` to the `spec.template.metadata.labels` stanza:
 +
 [source,yaml]
 ----
@@ -29,10 +29,9 @@ spec:
   template:
     metadata:
       labels:
-        special: key <1>
+        special: key
 # ...
 ----
-<1> Add `special: key` to the `spec.template.metadata.labels` stanza.
 +
 [NOTE]
 ====
@@ -53,17 +52,18 @@ metadata:
 spec:
 # ...
   selector:
-    special: key <1>
-  type: NodePort <2>
-  ports: <3>
+    special: key
+  type: NodePort
+  ports:
     protocol: TCP
     port: 80
     targetPort: 9376
     nodePort: 30000
 ----
-<1> Specify the label that you added to the `spec.template.metadata.labels` stanza of the `VirtualMachine` manifest.
-<2> Specify `ClusterIP`, `NodePort`, or `LoadBalancer`.
-<3> Specifies a collection of network ports and protocols that you want to expose from the virtual machine.
++
+* `spec.selector` defines the label that you added to the `spec.template.metadata.labels` stanza of the `VirtualMachine` manifest.
+* `spec.type` defines the type of service by the way it is exposed. Choose one of `ClusterIP`, `NodePort`, or `LoadBalancer`.
+* `spec.ports` defines a collection of network ports and protocols that you want to expose from the virtual machine.
 
 . Save the `Service` manifest file.
 . Create the service by running the following command:

--- a/modules/virt-creating-service-virtctl.adoc
+++ b/modules/virt-creating-service-virtctl.adoc
@@ -20,9 +20,15 @@ You can create a service for a virtual machine (VM) by using the `virtctl` comma
 +
 [source,terminal]
 ----
-$ virtctl expose vm <vm_name> --name <service_name> --type <service_type> --port <port> <1>
+$ virtctl expose vm <vm_name> --name <service_name> --type <service_type> --port <port>
 ----
-<1> Specify the `ClusterIP`, `NodePort`, or `LoadBalancer` service type.
++
+where:
++
+`<vm_name>`:: Specifies the name of the VM you are exposing.
+`<service_name>`:: Specifies a user-defined name for the service you are creating.
+`<service_type>`:: Specifies one of `ClusterIP`, `NodePort`, or `LoadBalancer`.
+`<port>`:: Specifies the network port on the VM that the service will expose.
 +
 .Example
 +

--- a/modules/virt-creating-virtualmachineexport.adoc
+++ b/modules/virt-creating-virtualmachineexport.adoc
@@ -38,18 +38,21 @@ metadata:
   name: example-export
 spec:
   source:
-    apiGroup: "kubevirt.io" <1>
-    kind: VirtualMachine <2>
+    apiGroup: "kubevirt.io"
+    kind: VirtualMachine
     name: example-vm
-  ttlDuration: 1h <3>
+  ttlDuration: 1h
 ----
-<1> Specify the appropriate API group:
 +
-* `"kubevirt.io"` for `VirtualMachine`.
-* `"snapshot.kubevirt.io"` for `VirtualMachineSnapshot`.
-* `""` for `PersistentVolumeClaim`.
-<2> Specify `VirtualMachine`, `VirtualMachineSnapshot`, or `PersistentVolumeClaim`.
-<3> Optional. The default duration is 2 hours.
+* `spec.source.apiGroup` defines the API group of the resource that you want to export:
+** Use `"kubevirt.io"` for `VirtualMachine`.
+** Use `"snapshot.kubevirt.io"` for `VirtualMachineSnapshot`.
+** Use `""` for `PersistentVolumeClaim`.
+* `spec.source.kind` defines the data source for the export. There are three primary values used for this field:
+** `VirtualMachine`
+** `VirtualMachineSnapshot`
+** `PersistentVolumeClaim`
+* `spec.ttlDuration` defines the length of time before the export resource is automatically deleted. The default is 2 hours.
 
 . Create the `VirtualMachineExport` CR:
 +
@@ -94,7 +97,7 @@ status:
     status: "True"
     type: PVCReady
   links:
-    external: <1>
+    external:
       cert: |-
         -----BEGIN CERTIFICATE-----
         ...
@@ -106,7 +109,7 @@ status:
         - format: gzip
           url: https://vmexport-proxy.test.net/api/export.kubevirt.io/v1alpha1/namespaces/example/virtualmachineexports/example-export/volumes/example-disk/disk.img.gz
         name: example-disk
-    internal:  <2>
+    internal:
       cert: |-
         -----BEGIN CERTIFICATE-----
         ...
@@ -121,5 +124,6 @@ status:
   phase: Ready
   serviceName: virt-export-example-export
 ----
-<1> External links are accessible from outside the cluster by using an `Ingress` or `Route`.
-<2> Internal links are only valid inside the cluster.
++
+* `status.links.external` defines external links that are accessible from outside the cluster by using an `Ingress` or `Route`.
+* `status.links.internal` defines internal links that are valid only inside the cluster.

--- a/modules/virt-edit-boot-order-yaml-web.adoc
+++ b/modules/virt-edit-boot-order-yaml-web.adoc
@@ -23,7 +23,7 @@ $ oc edit vm <vm_name> -n <namespace>
 [source,yaml]
 ----
 disks:
-  - bootOrder: 1 <1>
+  - bootOrder: 1
     disk:
       bus: virtio
     name: containerdisk
@@ -34,12 +34,13 @@ disks:
       bus: virtio
     name: cd-drive-1
 interfaces:
-  - boot Order: 2 <2>
+  - boot Order: 2
     macAddress: '02:96:c4:00:00'
     masquerade: {}
     name: default
 ----
-<1> The boot order value specified for the disk.
-<2> The boot order value specified for the network interface controller.
++
+* `disks.bootOrder` defines the boot order value specified for the disk.
+* `interfaces.bootOrder` defines the boot order value specified for the network interface controller.
 
 . Save the YAML file.

--- a/modules/virt-enabling-dynamic-key-injection-cli.adoc
+++ b/modules/virt-enabling-dynamic-key-injection-cli.adoc
@@ -28,9 +28,9 @@ The key is added to the VM by the QEMU guest agent, which is installed automatic
 ----
 include::snippets/virt-dynamic-key.yaml[]
 ----
-<1> Specify the `cloudInitNoCloud` data source.
-<2> Specify the `Secret` object name.
-<3> Paste the public SSH key.
+* `spec.template.spec.volumes.cloudInitNoCloud` defines the data source, for example `userData`.
+* `spec.template.spec.accessCredentials.sshPublicKey.source.secret.secretName` defines the `secret` object name.
+* `data.key` within the `secret` object defines the full public SSH key.
 
 . Create the `VirtualMachine` and `Secret` objects by running the following command:
 +

--- a/modules/virt-example-vm-node-placement-node-affinity.adoc
+++ b/modules/virt-example-vm-node-placement-node-affinity.adoc
@@ -21,7 +21,7 @@ spec:
     spec:
       affinity:
         nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution: <1>
+          requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
               - key: example.io/example-key
@@ -29,7 +29,7 @@ spec:
                 values:
                 - example-value-1
                 - example-value-2
-          preferredDuringSchedulingIgnoredDuringExecution: <2>
+          preferredDuringSchedulingIgnoredDuringExecution:
           - weight: 1
             preference:
               matchExpressions:
@@ -39,5 +39,5 @@ spec:
                 - example-node-label-value
 # ...
 ----
-<1> If you use the `requiredDuringSchedulingIgnoredDuringExecution` rule type, the VM is not scheduled if the constraint is not met.
-<2> If you use the `preferredDuringSchedulingIgnoredDuringExecution` rule type, the VM is still scheduled if the constraint is not met, as long as all required constraints are met.
+* If you use the `requiredDuringSchedulingIgnoredDuringExecution` rule type, the VM is not scheduled if the constraint is not met.
+* If you use the `preferredDuringSchedulingIgnoredDuringExecution` rule type, the VM is still scheduled if the constraint is not met, provided that all required constraints are met.

--- a/modules/virt-example-vm-node-placement-pod-affinity.adoc
+++ b/modules/virt-example-vm-node-placement-pod-affinity.adoc
@@ -21,7 +21,7 @@ spec:
     spec:
       affinity:
         podAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution: <1>
+          requiredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:
               matchExpressions:
               - key: example-key-1
@@ -30,7 +30,7 @@ spec:
                 - example-value-1
             topologyKey: kubernetes.io/hostname
         podAntiAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution: <2>
+          preferredDuringSchedulingIgnoredDuringExecution:
           - weight: 100
             podAffinityTerm:
               labelSelector:
@@ -42,5 +42,5 @@ spec:
               topologyKey: kubernetes.io/hostname
 # ...
 ----
-<1> If you use the `requiredDuringSchedulingIgnoredDuringExecution` rule type, the VM is not scheduled if the constraint is not met.
-<2> If you use the `preferredDuringSchedulingIgnoredDuringExecution` rule type, the VM is still scheduled if the constraint is not met, as long as all required constraints are met.
+* If you use the `requiredDuringSchedulingIgnoredDuringExecution` rule type, the VM is not scheduled if the constraint is not met.
+* If you use the `preferredDuringSchedulingIgnoredDuringExecution` rule type, the VM is still scheduled if the constraint is not met, provided that all required constraints are met.

--- a/modules/virt-how-virtual-gpus-assigned-nodes.adoc
+++ b/modules/virt-how-virtual-gpus-assigned-nodes.adoc
@@ -6,12 +6,8 @@
 [id="how-vgpus-are-assigned-to-nodes_{context}"]
 = How vGPUs are assigned to nodes
 
-For each physical device, {VirtProductName} configures the following values:
-
-* A single mdev type.
-* The maximum number of instances of the selected `mdev` type.
-
-The cluster architecture affects how devices are created and assigned to nodes.
+[role="_abstract"]
+{VirtProductName} configures a single `mdev` type and the maximum number of instances of the selected `mdev` type for each physical device. The cluster architecture affects how devices are created and assigned to nodes.
 
 Large cluster with multiple cards per node:: On nodes with multiple cards that can support similar vGPU types, the relevant device types are created in a round-robin manner.
 For example:

--- a/modules/virt-storage-wizard-fields-web.adoc
+++ b/modules/virt-storage-wizard-fields-web.adoc
@@ -66,14 +66,13 @@ If you do not specify these parameters, the system uses the default storage prof
 
 .2+|Access Mode
 |ReadWriteOnce (RWO)
-|Volume can be mounted as read-write by a single node.
+|Volume can be mounted as read/write by a single node.
 |ReadWriteMany (RWX)
-|Volume can be mounted as read-write by many nodes at one time.
+|Volume can be mounted as read/write by many nodes at one time.
 [NOTE]
 ====
 This mode is required for live migration.
 ====
-
 |ReadOnlyMany (ROX)
 |Volume can be mounted as read only by many nodes.
 |===

--- a/snippets/virt-dynamic-key.yaml
+++ b/snippets/virt-dynamic-key.yaml
@@ -27,7 +27,7 @@ spec:
         - dataVolume:
             name: example-vm-volume
           name: rootdisk
-        - cloudInitNoCloud: # <1>
+        - cloudInitNoCloud:
             userData: |-
               #cloud-config
               runcmd:
@@ -40,11 +40,11 @@ spec:
                 users: ["cloud-user"]
             source:
               secret:
-                secretName: authorized-keys # <2>
+                secretName: authorized-keys
 ---
 apiVersion: v1
 kind: Secret
 metadata:
   name: authorized-keys
 data:
-  key: c3NoLXJzYSB... # <3>
+  key: c3NoLXJzYSB...

--- a/virt/virtual_machines/advanced_vm_management/virt-about-multi-queue.adoc
+++ b/virt/virtual_machines/advanced_vm_management/virt-about-multi-queue.adoc
@@ -6,20 +6,21 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 Use multi-queue functionality to scale network throughput and performance on virtual machines (VMs) with multiple vCPUs.
 
-By default, the `queueCount` value, which is derived from the domain XML, is determined by the number of vCPUs allocated to a VM. Network performance does not scale as the number of vCPUs increases. Additionally, because virtio-net has only one Tx and Rx queue, guests cannot transmit or retrieve packs in parallel.
+By default, the `queueCount` value, which is derived from the domain XML, is determined by the number of vCPUs allocated to a VM. Network performance does not scale as the number of vCPUs increases. Additionally, because `virtio-net` has only one transmit and receive queue, guests cannot send or receive packs in parallel.
 
 [NOTE]
 ====
-Enabling virtio-net multiqueue does not offer significant improvements when the number of vNICs in a guest instance is proportional to the number of vCPUs.
+Enabling `virtio-net` multi-queue does not offer significant improvements when the number of vNICs in a guest instance is proportional to the number of vCPUs.
 ====
 
 [id="virt-about-multi-queue-_{context}"]
 == Known limitations
 
-* MSI vectors are still consumed if virtio-net multiqueue is enabled in the host but not enabled in the guest operating system by the administrator.
-* Each virtio-net queue consumes 64 KiB of kernel memory for the vhost driver.
-* Starting a VM with more than 16 CPUs results in no connectivity if `networkInterfaceMultiqueue` is set to 'true' (link:https://issues.redhat.com/browse/CNV-16107[CNV-16107]).
+* Message signaled interrupt (MSI) vectors are still consumed if `virtio-net` multi-queue is enabled in the host but not enabled in the guest operating system by the administrator.
+* Each `virtio-net` queue consumes 64 KiB of kernel memory for the `vhost` driver.
+* Starting a VM with more than 16 CPUs results in no connectivity if `networkInterfaceMultiqueue` is set to `true`. (link:https://issues.redhat.com/browse/CNV-16107[CNV-16107]).
 
 include::modules/virt-enabling-multi-queue.adoc[leveloffset=+1]

--- a/virt/virtual_machines/advanced_vm_management/virt-assigning-compute-resources.adoc
+++ b/virt/virtual_machines/advanced_vm_management/virt-assigning-compute-resources.adoc
@@ -6,6 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 In {VirtProductName}, compute resources assigned to virtual machines (VMs) are backed by either guaranteed CPUs or time-sliced CPU shares.
 
 Guaranteed CPUs, also known as CPU reservation, dedicate CPU cores or threads to a specific workload, which makes them unavailable to any other workload. Assigning guaranteed CPUs to a VM ensures that the VM will have sole access to a reserved physical CPU. xref:../../../virt/virtual_machines/advanced_vm_management/virt-dedicated-resources-vm.adoc#virt-dedicated-resources-vm[Enable dedicated resources for VMs] to use a guaranteed CPU.

--- a/virt/virtual_machines/advanced_vm_management/virt-configuring-default-cpu-model.adoc
+++ b/virt/virtual_machines/advanced_vm_management/virt-configuring-default-cpu-model.adoc
@@ -4,6 +4,7 @@
 include::_attributes/common-attributes.adoc[]
 :context: virt-configuring-default-cpu-model
 
+[role="_abstract"]
 Use the `defaultCPUModel` setting in the `HyperConverged` custom resource (CR) to define a cluster-wide default CPU model.
 
 The virtual machine (VM) CPU model depends on the availability of CPU models within the VM and the cluster.

--- a/virt/virtual_machines/advanced_vm_management/virt-configuring-pci-passthrough.adoc
+++ b/virt/virtual_machines/advanced_vm_management/virt-configuring-pci-passthrough.adoc
@@ -13,6 +13,7 @@ toc::[]
 //When this feature is available in the web console, please
 //add the new content to this assembly.
 
+[role="_abstract"]
 The Peripheral Component Interconnect (PCI) passthrough feature enables you to access and manage hardware devices from a virtual machine (VM). When PCI passthrough is configured, the PCI devices function as if they were physically attached to the guest operating system.
 
 Cluster administrators can expose and manage host devices that are permitted to be used in the cluster by using the `oc` command-line interface (CLI).

--- a/virt/virtual_machines/advanced_vm_management/virt-configuring-pxe-booting.adoc
+++ b/virt/virtual_machines/advanced_vm_management/virt-configuring-pxe-booting.adoc
@@ -6,11 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-PXE booting, or network booting, is available in {VirtProductName}.
-Network booting allows a computer to boot and load an
-operating system or other program without requiring a locally attached
-storage device. For example, you can use it to choose your desired OS
-image from a PXE server when deploying a new host.
+[role="_abstract"]
+PXE booting, or network booting, is available in {VirtProductName}. Network booting allows a computer to boot and load an operating system or other program without requiring a locally attached storage device. For example, you can use it to choose your desired OS image from a PXE server when deploying a new host.
 
 ifndef::openshift-rosa,openshift-dedicated[]
 == Prerequisites

--- a/virt/virtual_machines/advanced_vm_management/virt-dedicated-resources-vm.adoc
+++ b/virt/virtual_machines/advanced_vm_management/virt-dedicated-resources-vm.adoc
@@ -6,6 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 To improve performance, you can dedicate node resources, such as CPU, to a virtual machine.
 
 include::modules/virt-about-dedicated-resources.adoc[leveloffset=+1]

--- a/virt/virtual_machines/advanced_vm_management/virt-enabling-descheduler-evictions.adoc
+++ b/virt/virtual_machines/advanced_vm_management/virt-enabling-descheduler-evictions.adoc
@@ -8,6 +8,7 @@ toc::[]
 
 :FeatureName: Descheduler eviction for virtual machines
 
+[role="_abstract"]
 You can use the descheduler to evict pods so that the pods can be rescheduled onto more appropriate nodes. If the pod is a virtual machine, the pod eviction causes the virtual machine to be live migrated to another node.
 
 include::snippets/technology-preview.adoc[]

--- a/virt/virtual_machines/advanced_vm_management/virt-high-availability-for-vms.adoc
+++ b/virt/virtual_machines/advanced_vm_management/virt-high-availability-for-vms.adoc
@@ -8,15 +8,14 @@ toc::[]
 
 // Hiding manual delete item as not supported
 ifndef::openshift-rosa,openshift-dedicated[]
+[role="_abstract"]
 You can enable high availability for virtual machines (VMs) by manually deleting a failed node to trigger VM failover or by configuring remediating nodes.
 
-.Manually deleting a failed node
-
-If a node fails and machine health checks are not deployed on your cluster, virtual machines with `runStrategy: Always` configured are not automatically relocated to healthy nodes. To trigger VM failover, you must manually delete the `Node` object.
+Manually deleting a failed node:: If a node fails and machine health checks are not deployed on your cluster, virtual machines with `runStrategy: Always` configured are not automatically relocated to healthy nodes. To trigger VM failover, you must manually delete the `Node` object.
 
 See xref:../../../virt/nodes/virt-triggering-vm-failover-resolving-failed-node.adoc#virt-triggering-vm-failover-resolving-failed-node[Deleting a failed node to trigger virtual machine failover].
 
-.Configuring remediating nodes
+Configuring remediating nodes::
 endif::openshift-rosa,openshift-dedicated[]
 ifdef::openshift-rosa,openshift-dedicated[]
 You can enable high availability for virtual machines (VMs) by configuring remediating nodes.

--- a/virt/virtual_machines/advanced_vm_management/virt-schedule-vms.adoc
+++ b/virt/virtual_machines/advanced_vm_management/virt-schedule-vms.adoc
@@ -6,6 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 You can schedule a virtual machine (VM) on a node by ensuring that the VM's CPU model and policy attribute are matched for compatibility with the CPU models and policy attributes supported by the node.
 
 include::modules/virt-policy-attributes.adoc[leveloffset=+1]

--- a/virt/virtual_machines/advanced_vm_management/virt-specifying-nodes-for-vms.adoc
+++ b/virt/virtual_machines/advanced_vm_management/virt-specifying-nodes-for-vms.adoc
@@ -6,6 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 You can place virtual machines (VMs) on specific nodes by using node placement rules.
 
 include::modules/virt-about-node-placement-vms.adoc[leveloffset=+1]

--- a/virt/virtual_machines/advanced_vm_management/virt-uefi-mode-for-vms.adoc
+++ b/virt/virtual_machines/advanced_vm_management/virt-uefi-mode-for-vms.adoc
@@ -6,7 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-You can boot a virtual machine (VM) in Unified Extensible Firmware Interface (UEFI) mode.
+[role="_abstract"]
+You can boot a virtual machine (VM) in Unified Extensible Firmware Interface (UEFI) mode for faster boot times, the ability to boot to larger disks, and added security features.
 
 include::modules/virt-about-uefi-mode-for-vms.adoc[leveloffset=+1]
 include::modules/virt-booting-vms-uefi-mode.adoc[leveloffset=+1]

--- a/virt/virtual_machines/advanced_vm_management/virt-using-huge-pages-with-vms.adoc
+++ b/virt/virtual_machines/advanced_vm_management/virt-using-huge-pages-with-vms.adoc
@@ -6,6 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 You can use huge pages as backing memory for virtual machines in your cluster.
 
 == Prerequisites

--- a/virt/virtual_machines/advanced_vm_management/virt-vm-control-plane-tuning.adoc
+++ b/virt/virtual_machines/advanced_vm_management/virt-vm-control-plane-tuning.adoc
@@ -6,9 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-{VirtProductName} offers the following tuning options at the control-plane level:
-
-* The `highBurst` profile, which uses fixed `QPS` and `burst` rates, to create hundreds of virtual machines (VMs) in one batch
-* Migration setting adjustment based on workload type
+[role="_abstract"]
+In {VirtProductName}, you can control how the control plane handles concurrency when you create or migrate virtual machines (VMs). For example, you can use the the `highBurst` profile with either the fixed `QPS` or `burst` rates to batch create virtual machines (VMs) in a batch, or tune migration settings in the `HyperConverged` custom resource (CR).
 
 include::modules/virt-configuring-highburst-profile.adoc[leveloffset=+1]

--- a/virt/virtual_machines/creating_vms_custom/virt-installing-qemu-guest-agent.adoc
+++ b/virt/virtual_machines/creating_vms_custom/virt-installing-qemu-guest-agent.adoc
@@ -1,14 +1,13 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="virt-installing-qemu-guest-agent"]
-= Installing the QEMU guest agent and VirtIO drivers
+= Install the QEMU guest agent and VirtIO drivers
 include::_attributes/common-attributes.adoc[]
 :context: virt-installing-qemu-guest-agent
 
 toc::[]
 
-The QEMU guest agent is a daemon that runs on the virtual machine (VM) and passes information to the host about the VM, users, file systems, and secondary networks.
-
-You must install the QEMU guest agent on VMs created from operating system images that are not provided by Red Hat.
+[role="_abstract"]
+Enable advanced features like quiesced snapshots and improved monitoring by installing the QEMU guest agent on your virtual machines (VMs). The QEMU guest agent is a daemon that runs on the VM and passes information to the host about the VM, users, file systems, and secondary networks. You must install the QEMU guest agent on VMs created from operating system images that are not provided by Red{nbsp}Hat.
 
 [id="installing-qemu-guest-agent"]
 == Installing the QEMU guest agent

--- a/virt/virtual_machines/virt-accessing-vm-ssh.adoc
+++ b/virt/virtual_machines/virt-accessing-vm-ssh.adoc
@@ -1,13 +1,14 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="virt-accessing-vm-ssh"]
-= Configuring SSH access to virtual machines
+= Configure SSH access to a virtual machine
 include::_attributes/common-attributes.adoc[]
 :context: virt-accessing-vm-ssh
 :toclevels: 3
 
 toc::[]
 
-You can configure SSH access to virtual machines (VMs) by using the following methods:
+[role="_abstract"]
+You can use SSH to securely access your virtual machines (VMs) from the command line. To set up your SSH configuration, use one of the following methods:
 
 * xref:../../virt/virtual_machines/virt-accessing-vm-ssh.adoc#using-virtctl-ssh_virt-accessing-vm-ssh[`virtctl ssh` command]
 +

--- a/virt/virtual_machines/virt-controlling-vm-states.adoc
+++ b/virt/virtual_machines/virt-controlling-vm-states.adoc
@@ -1,14 +1,14 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="virt-controlling-vm-states"]
-= Controlling virtual machine states
+= Control virtual machine states
 include::_attributes/common-attributes.adoc[]
 :context: virt-controlling-vm-states
 
 toc::[]
 
-You can stop, start, restart, and unpause virtual machines from the web console.
-
 You can use xref:../../virt/getting_started/virt-using-the-cli-tools.adoc#virt-using-the-cli-tools[`virtctl`] to manage virtual machine states and perform other actions from the CLI. For example, you can use `virtctl` to force stop a VM or expose a port.
+
+You can also stop, start, restart, and unpause virtual machines from the web console.
 
 include::modules/virt-configure-rbac-console-subresources-api.adoc[leveloffset=+1]
 

--- a/virt/virtual_machines/virt-delete-vms.adoc
+++ b/virt/virtual_machines/virt-delete-vms.adoc
@@ -1,12 +1,13 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="virt-delete-vms"]
-= Deleting virtual machines
+= Delete a virtual machine
 include::_attributes/common-attributes.adoc[]
 :context: virt-delete-vms
 
 toc::[]
 
-You can delete a virtual machine from the web console or by using the `oc` command-line interface.
+[role="_abstract"]
+You can remove virtual machines (VMs) from your cluster to free up resources using either the web console or CLI. Deleting a VM removes the virtual machine definition and optionally its associated storage resources.
 
 include::modules/virt-delete-vm-web.adoc[leveloffset=+1]
 include::modules/virt-deleting-vms.adoc[leveloffset=+1]

--- a/virt/virtual_machines/virt-edit-boot-order.adoc
+++ b/virt/virtual_machines/virt-edit-boot-order.adoc
@@ -1,12 +1,13 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="virt-edit-boot-order"]
-= Editing boot order
+= Edit the boot order of a virtual machine
 include::_attributes/common-attributes.adoc[]
 :context: virt-edit-boot-order
 
 toc::[]
 
-You can update the values for a boot order list by using the web console or the CLI.
+[role="_abstract"]
+You can configure the boot order of disks and network devices on your virtual machine (VM) by using the web console or the CLI.
 
 With *Boot Order* in the *Virtual Machine Overview* page, you can:
 

--- a/virt/virtual_machines/virt-edit-vms.adoc
+++ b/virt/virtual_machines/virt-edit-vms.adoc
@@ -1,15 +1,14 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="virt-edit-vms"]
-= Editing virtual machines
+= Edit the configuration of a virtual machine
 include::_attributes/common-attributes.adoc[]
 :context: virt-edit-vms
 
 toc::[]
 
 [role="_abstract"]
-You can update a virtual machine (VM) configuration by using the {product-title} web console. You can update the YAML file or the *VirtualMachine details* page.
+You can update virtual machine (VM) configuration details like CPU, memory, and networking by using the CLI or the {product-title} web console. In the web console, you can modify settings on the *VirtualMachine details* page or by editing the YAML file directly.
 
-You can also edit a VM by using the command line.
 
 ifndef::openshift-rosa,openshift-dedicated[]
 To edit a VM to configure disk sharing by using virtual disks or LUN, see xref:../../virt/virtual_machines/virtual_disks/virt-configuring-shared-volumes-for-vms.adoc#virt-configuring-shared-volumes-for-vms[Configuring shared volumes for virtual machines].

--- a/virt/virtual_machines/virt-exporting-vms.adoc
+++ b/virt/virtual_machines/virt-exporting-vms.adoc
@@ -1,12 +1,13 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="virt-exporting-vms"]
-= Exporting virtual machines
+= Export a virtual machine
 include::_attributes/common-attributes.adoc[]
 :context: virt-exporting-vms
 
 toc::[]
 
-You can export a virtual machine (VM) and its associated disks in order to import a VM into another cluster or to analyze the volume for forensic purposes.
+[role="_abstract"]
+Export a virtual machine (VM) and its associated disks to import it into another cluster, or for another use case, such as forensic volume analysis.
 
 You create a `VirtualMachineExport` custom resource (CR) by using the command-line interface.
 

--- a/virt/virtual_machines/virt-manage-vmis.adoc
+++ b/virt/virtual_machines/virt-manage-vmis.adoc
@@ -1,12 +1,13 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="virt-manage-vmis"]
-= Managing virtual machine instances
+= Manage virtual machine instances
 include::_attributes/common-attributes.adoc[]
 :context: virt-manage-vmis
 
 toc::[]
 
-If you have standalone virtual machine instances (VMIs) that were created independently outside of the {VirtProductName} environment, you can manage them by using the web console or by using `oc` or xref:../../virt/getting_started/virt-using-the-cli-tools.adoc#virt-using-the-cli-tools[`virtctl`] commands from the command-line interface (CLI).
+[role="_abstract"]
+Manage standalone virtual machine instances (VMIs) that were created independently outside of the {VirtProductName} environment through the web console by using `oc` or xref:../../virt/getting_started/virt-using-the-cli-tools.adoc#virt-using-the-cli-tools[`virtctl`] commands from the command-line interface (CLI).
 
 The `virtctl` command provides more virtualization options than the `oc` command. For example, you can use `virtctl` to pause a VM or expose a port.
 

--- a/virt/virtual_machines/virt-managing-vms-openshift-pipelines.adoc
+++ b/virt/virtual_machines/virt-managing-vms-openshift-pipelines.adoc
@@ -1,10 +1,13 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="virt-managing-vms-openshift-pipelines"]
-= Managing virtual machines with OpenShift Pipelines
+= Manage virtual machines with {pipelines-shortname}
 include::_attributes/common-attributes.adoc[]
 :context: virt-managing-vms-openshift-pipelines
 
 toc::[]
+
+[role="_abstract"]
+Automate virtual machine (VM) provisioning and management in your CI/CD workflows with {pipelines-shortname} tasks designed for virtualization. These tasks allow you to create, configure, and manipulate VMs and their disks as part of your automated deployment pipelines, streamlining VM lifecycle management.
 
 link:https://docs.openshift.com/pipelines/latest/about/understanding-openshift-pipelines.html[{pipelines-title}] is a Kubernetes-native CI/CD framework that allows developers to design and run each step of the CI/CD pipeline in its own container.
 

--- a/virt/virtual_machines/virtual_disks/virt-configuring-shared-volumes-for-vms.adoc
+++ b/virt/virtual_machines/virtual_disks/virt-configuring-shared-volumes-for-vms.adoc
@@ -1,12 +1,13 @@
-:_content-type: ASSEMBLY
+:_mod-docs-content-type: ASSEMBLY
 [id="virt-configuring-shared-volumes-for-vms"]
-= Configuring shared volumes for virtual machines
+= Configure shared volumes for virtual machines
 include::_attributes/common-attributes.adoc[]
 :context: virt-configuring-shared-volumes-for-vms
 
 toc::[]
 
-You can configure shared disks to allow multiple virtual machines (VMs) to share the same underlying storage. A shared disk's volume must be block mode.
+[role="_abstract"]
+Enable high-availability scenarios like Windows Failover Clustering by configuring shared disks to allow multiple virtual machines to access the same storage volume. A shared disk's volume must be block mode.
 
 You configure disk sharing by exposing the storage as either of these types:
 

--- a/virt/virtual_machines/virtual_disks/virt-expanding-vm-disks.adoc
+++ b/virt/virtual_machines/virtual_disks/virt-expanding-vm-disks.adoc
@@ -1,15 +1,13 @@
 :_mod-docs-content-type: ASSEMBLY
 include::_attributes/common-attributes.adoc[]
 [id="virt-expanding-vm-disks"]
-= Expanding virtual machine disks
+= Expand virtual machine disks
 :context: virt-expanding-vm-disks
 
 toc::[]
 
 [role="_abstract"]
-You can increase the size of a virtual machine (VM) disk by expanding the persistent volume claim (PVC) of the disk.
-
-If your storage provider does not support volume expansion, you can expand the available virtual storage of a VM by adding blank data volumes.
+Expand the  persistent volume claim (PVC) of your virtual machine disk to accomodate growing data requirements. If your storage provider does not support volume expansion, you can expand the available virtual storage of a VM by adding blank data volumes.
 
 You cannot reduce the size of a VM disk.
 

--- a/virt/virtual_machines/virtual_disks/virt-hot-plugging-virtual-disks.adoc
+++ b/virt/virtual_machines/virtual_disks/virt-hot-plugging-virtual-disks.adoc
@@ -1,12 +1,13 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="virt-hot-plugging-virtual-disks"]
-= Hot-plugging VM disks
+= Hot-plug virtual disks to running VMs
 include::_attributes/common-attributes.adoc[]
 :context: virt-hot-plugging-virtual-disks
 
 toc::[]
 
-You can add or remove virtual disks without stopping your virtual machine (VM) or virtual machine instance (VMI).
+[role="_abstract"]
+You can hot-plug or hot-unplug virtual disks from running VMs to dynamically adjust storage without downtime.
 
 Only data volumes and persistent volume claims (PVCs) can be hot plugged and hot-unplugged. You cannot hot plug or hot-unplug container disks.
 


### PR DESCRIPTION
Cherry picked from https://github.com/openshift/openshift-docs/commit/a70ce48909dbb3c50cb2ec58e373bd15cae9bd40
xref: https://github.com/openshift/openshift-docs/pull/108230

Update for titles and short stories on assemblies
and CQA improvements
Updates based on peer feedback
Updates to call outs
Co-authored-by: Pan Ousley <pousley@redhat.com>

DOCPLAN#36 Update short descriptions on assemblies and call outs for CQA
Version(s):
4.16

Issue:
https://redhat.atlassian.net/browse/DOCPLAN-36

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
