### PR TITLE
CNV#77496: Backport storage migration documentation to 4.20.z and create release note

### DIFF
--- a/modules/virt-migrating-bulk-vms-different-storage-class-web.adoc
+++ b/modules/virt-migrating-bulk-vms-different-storage-class-web.adoc
@@ -15,11 +15,6 @@ When you migrate a virtual machine disk from one storage class to another, the s
 After you verify that the migration was successful, you must manually delete the source PVC. This behavior is expected and applies only to storage class migrations.
 ====
 
-.Prerequisites
-
-* The VMs you select for each bulk migration must be in the same namespace.
-* The {mtc-first} must be installed.
-
 .Procedure
 
 . From the {product-title} web console, navigate to *Virtualization* → *VirtualMachines*.

--- a/modules/virt-migrating-storage-class-ui.adoc
+++ b/modules/virt-migrating-storage-class-ui.adoc
@@ -10,13 +10,6 @@
 [role="_abstract"]
 You can migrate one or more disks attached to a virtual machine (VM) to a different storage class by using the {product-title} web console. When performing this action on a running VM, the operation of the VM is not interrupted and the data on the migrated disks remains accessible.
 
-[NOTE]
-====
-With the {VirtProductName} Operator, you can only start storage class migration for one VM at the time and the VM must be running. If you need to migrate more VMs at once or migrate a mix of running and stopped VMs, consider using the link:https://docs.redhat.com/en/documentation/migration_toolkit_for_containers/{mtc-version}/html/migration_toolkit_for_containers/index[{mtc-first}].
-
-{mtc-full} is not part of {VirtProductName} and requires separate installation.
-====
-
 .Prerequisites
 
 * You must have a data volume or a persistent volume claim (PVC) available for storage class migration.


### PR DESCRIPTION
Version(s): 4.20

Issue: [CNV-77496](https://redhat.atlassian.net/browse/CNV-77496)

Link to docs preview:

- https://109352--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/managing_vms/virt-migrating-vms-in-single-cluster-to-different-storage-class.html

- https://109352--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/managing_vms/virtual_disks/virt-migrating-storage-class.html

QE review:
- [x] QE has approved this change.

