### PR TITLE
ROX-31914 image scanning new policy criterion

### DIFF
--- a/modules/common-attributes.adoc
+++ b/modules/common-attributes.adoc
@@ -9,6 +9,7 @@
 :toc-title:
 :imagesdir: images
 :prewrap!:
+:company-name: Red{nbsp}Hat
 :op-system-first: Red{nbsp}Hat Enterprise Linux CoreOS (RHCOS)
 :op-system: RHCOS
 :op-system-base: RHEL

--- a/modules/policy-criteria.adoc
+++ b/modules/policy-criteria.adoc
@@ -313,6 +313,19 @@ AND, OR
 | *Build*, +
 *Deploy*, +
 *Runtime* (when used with a Runtime criterion)
+
+| Days since CVE fix was available
+a| This criterion results in a violation if it has been more than a specified number of days since the date when the CVE fix became available. Use this criterion to create a custom grace period for fixing vulnerabilities. For vulnerabilities that are associated with {company-name} packages, CVE fix dates are included in the vulnerability information. For non {company-name} packages, the fix date is approximated as follows:
+
+* For existing CVEs, {product-title-short} records the date that the status changed from `not fixable` to `fixable`.
+* For new and fixable CVEs, {product-title-short} records the date that the CVE was discovered in {product-title-short}.
+
+| Days Since CVE Fix Was Available
+| Integer
+| X
+| *Build*, +
+*Deploy*, +
+*Runtime* (when used with a Runtime criterion)
 |===
 
 [id="workload-config-criteria_{context}"]


### PR DESCRIPTION
Image scanning new policy criterion days since CVE fix was available

Version(s):
4.10

Issue:
https://redhat.atlassian.net/browse/ROX-29708

Link to docs preview: https://109353--ocpdocs-pr.netlify.app/openshift-acs/latest/operating/manage_security_policies/security-policy-reference.html

<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
RHACS has no formal QE team to review
Source content with doc change pasted in [ROX-31914](https://redhat.atlassian.net/browse/ROX-31914) Jira issue comments, approved by SME AJ Heflin via Slack DM.


Additional information:

