### PR TITLE
CNV#77496_releasenote: Backport storage migration documentation to 4.20.z and create release note

### DIFF
--- a/virt/release_notes/virt-4-20-release-notes.adoc
+++ b/virt/release_notes/virt-4-20-release-notes.adoc
@@ -123,6 +123,11 @@ For more information about selecting huge pages for an instance type, see xref:.
 // CNV-62056
 * The {product-title} web console now displays read and write latency metrics in the *Top Consumers* tab of the *Virtualization > Overview* pane and in the *Metrics* tab of individual virtual machines. This data can help you evaluate your storage performance in more detail, identify processing slowdowns, and optimize workloads.
 
+//CNV-77946_releasenote
+* Previously, installation of Migration Toolkit for Containers (MTC) was required before migrating VM disks to different storage classes. This requirement no longer exists, as VM disk storage class migration is now native to OpenShift Virtualization.
++
+In addition, it is no longer a requirement that the VMs you select for each bulk migration be in the same namespace.
+
 [id="virt-4-20-monitoring_{context}"]
 === Monitoring
 //CNV-63662


### PR DESCRIPTION
Version(s): 4.20

Issue: [CNV-74496](https://redhat.atlassian.net/browse/CNV-77496)

Link to docs preview:

QE review:
- [x] QE has approved this change.



