### PR TITLE
PR for SRVCOM-4378: CQA + DITA readiness for assemblies and modules under the "Eventing" section

### DIFF
--- a/eventing/brokers/kafka-broker.adoc
+++ b/eventing/brokers/kafka-broker.adoc
@@ -1,46 +1,41 @@
 :_mod-docs-content-type: ASSEMBLY
-include::_attributes/common-attributes.adoc[]
 [id="kafka-broker"]
 = Knative broker implementation for Apache Kafka
+include::_attributes/common-attributes.adoc[]
 :context: kafka-broker
 
 toc::[]
 
 [role="_abstract"]
+You can use the Knative broker implementation for Apache Kafka to enable scalable and reliable event delivery in {ServerlessProductName}.
+
 include::snippets/serverless-about-kafka-broker.adoc[]
 
-
-[id="creating-kafka-broker"]
-== Creating an Apache Kafka broker when it is not configured as the default broker type
-
-If your {ServerlessProductName} deployment is not configured to use Kafka broker as the default broker type, you can use one of the following procedures to create a Kafka-based broker.
+include::modules/serverless-creating-kafka-broker.adoc[leveloffset=+1]
 
 include::modules/serverless-kafka-broker.adoc[leveloffset=+2]
+
 include::modules/serverless-kafka-broker-with-kafka-topic.adoc[leveloffset=+2]
+
 include::modules/serverless-kafka-broker-with-isolated-dataplane.adoc[leveloffset=+2]
+
 include::modules/serverless-create-kafka-namespaced-broker.adoc[leveloffset=+2]
 
-// kafka broker general configmap
 include::modules/serverless-kafka-broker-configmap.adoc[leveloffset=+1]
 
+include::modules/serverless-kafka-admin-security.adoc[leveloffset=+1]
 
-[id="serverless-kafka-admin-security"]
-== Security configuration for the Knative broker implementation for Apache Kafka
-
-Kafka clusters are generally secured by using the TLS or SASL authentication methods. You can configure a Kafka broker or channel to work against a protected Red{nbsp}Hat AMQ Streams cluster by using TLS or SASL.
-
-[NOTE]
-====
-Red{nbsp}Hat recommends that you enable both SASL and TLS together.
-====
-
-// kafka broker security config
 include::modules/serverless-kafka-broker-tls-default-config.adoc[leveloffset=+2]
+
 include::modules/serverless-kafka-broker-sasl-default-config.adoc[leveloffset=+2]
 
-
-[id="additional-resources_serverless-kafka-admin"]
 [role="_additional-resources"]
 == Additional resources
+
 * link:https://docs.redhat.com/en/documentation/red_hat_amq/2021.q3/html/amq_streams_on_openshift_overview/kafka-concepts_str#kafka-concepts-key_str[Red{nbsp}Hat AMQ Streams documentation]
+
 * link:https://docs.redhat.com/en/documentation/red_hat_amq/2021.q3/html/using_amq_streams_on_rhel/configuring_kafka#con-kafka-securing-listeners-str[TLS and SASL on Kafka]
+
+* link:https://docs.redhat.com/en/documentation/red_hat_amq/2021.q3/html/amq_streams_on_openshift_overview/kafka-concepts_str#kafka-concepts-key_str[Red{nbsp}Hat AMQ Streams]
+
+* link:https://kafka.apache.org/documentation/#topicconfigs[full set of possible options and values]

--- a/eventing/brokers/serverless-broker-backing-channel-default.adoc
+++ b/eventing/brokers/serverless-broker-backing-channel-default.adoc
@@ -1,49 +1,10 @@
 :_mod-docs-content-type: ASSEMBLY
-include::_attributes/common-attributes.adoc[]
 [id="serverless-broker-backing-channel-default"]
 = Configuring the default broker backing channel
-
-[role="_abstract"]
+include::_attributes/common-attributes.adoc[]
 :context: serverless-broker-backing-channel-default
 
+[role="_abstract"]
 If you are using a channel-based broker, you can set the default backing channel type for the broker to either `InMemoryChannel` or `KafkaChannel`.
 
-.Prerequisites
-
-* You have administrator permissions on {ocp-product-title}.
-* You have installed the {ServerlessOperatorName} and Knative Eventing on your cluster.
-* You have installed the OpenShift (`oc`) CLI.
-* If you want to use Apache Kafka channels as the default backing channel type, you must also install the `KnativeKafka` CR on your cluster.
-
-.Procedure
-
-. Modify the `KnativeEventing` custom resource (CR) to add configuration details for the `config-br-default-channel` config map:
-+
-[source,yaml]
-----
-apiVersion: operator.knative.dev/v1beta1
-kind: KnativeEventing
-metadata:
-  name: knative-eventing
-  namespace: knative-eventing
-spec:
-  config: <1>
-    config-br-default-channel:
-      channel-template-spec: |
-        apiVersion: messaging.knative.dev/v1beta1
-        kind: KafkaChannel <2>
-        spec:
-          numPartitions: 6 <3>
-          replicationFactor: 3 <4>
-----
-<1> In `spec.config`, you can specify the config maps that you want to add modified configurations for.
-<2> The default backing channel type configuration. In this example, the default channel implementation for the cluster is `KafkaChannel`.
-<3> The number of partitions for the Kafka channel that backs the broker.
-<4> The replication factor for the Kafka channel that backs the broker.
-
-. Apply the updated `KnativeEventing` CR:
-+
-[source,terminal]
-----
-$ oc apply -f <filename>
-----
+include::modules/serverless-setting-default-backing-channel-brokers.adoc[leveloffset=+1]

--- a/eventing/brokers/serverless-broker-types.adoc
+++ b/eventing/brokers/serverless-broker-types.adoc
@@ -1,20 +1,14 @@
 :_mod-docs-content-type: ASSEMBLY
-include::_attributes/common-attributes.adoc[]
 [id="serverless-broker-types"]
 = Broker types
+include::_attributes/common-attributes.adoc[]
 :context: serverless-broker-types
 
 [role="_abstract"]
-Cluster administrators can set the default broker implementation for a cluster. When you create a broker, the default broker implementation is used, unless you provide set configurations in the `Broker` object.
+Cluster administrators can set the default broker implementation for a cluster. When you create a broker, the default broker implementation is used, unless you give set configurations in the `Broker` object.
 
-[id="serverless-broker-types-default_{context}"]
-== Default broker implementation for development purposes
+include::modules/serverless-default-broker-implementation.adoc[leveloffset=+1]
 
-Knative provides a default, channel-based broker implementation. This channel-based broker can be used for development and testing purposes, but does not provide adequate event delivery guarantees for production environments. The default broker is backed by the `InMemoryChannel` channel implementation by default.
-
-If you want to use Apache Kafka to reduce network hops, use the Knative broker implementation for Apache Kafka. Do not configure the channel-based broker to be backed by the `KafkaChannel` channel implementation.
-
-[id="serverless-broker-types-production_{context}"]
-== Production-ready Knative broker implementation for Apache Kafka
+include::modules/serverless-broker-types-production.adoc[leveloffset=+1]
 
 include::snippets/serverless-about-kafka-broker.adoc[]

--- a/eventing/brokers/serverless-brokers.adoc
+++ b/eventing/brokers/serverless-brokers.adoc
@@ -1,11 +1,13 @@
 :_mod-docs-content-type: ASSEMBLY
-include::_attributes/common-attributes.adoc[]
 [id="serverless-brokers"]
 = Brokers
+include::_attributes/common-attributes.adoc[]
 :context: serverless-brokers
 
 toc::[]
 
 [role="_abstract"]
+Learn how to create, configure, and manage brokers to route events between producers and consumers in {ServerlessProductName}.
+
 include::snippets/serverless-brokers-intro.adoc[]
 

--- a/eventing/brokers/serverless-global-config-broker-class-default.adoc
+++ b/eventing/brokers/serverless-global-config-broker-class-default.adoc
@@ -1,60 +1,12 @@
 :_mod-docs-content-type: ASSEMBLY
-include::_attributes/common-attributes.adoc[]
 [id="serverless-global-config-broker-class-default"]
 = Configuring the default broker class
+include::_attributes/common-attributes.adoc[]
 :context: serverless-global-config-broker-class-default
+
+toc::[]
 
 [role="_abstract"]
 You can use the `config-br-defaults` config map to specify default broker class settings for Knative Eventing. You can specify the default broker class for the entire cluster or for one or more namespaces. Currently the `MTChannelBasedBroker` and `Kafka` broker types are supported.
 
-.Prerequisites
-
-* You have administrator permissions on {ocp-product-title}.
-* You have installed the {ServerlessOperatorName} and Knative Eventing on your cluster.
-* If you want to use the Knative broker for Apache Kafka as the default broker implementation, you must also install the `KnativeKafka` CR on your cluster.
-
-.Procedure
-
-* Modify the `KnativeEventing` custom resource to add configuration details for the `config-br-defaults` config map:
-+
-[source,yaml]
-----
-apiVersion: operator.knative.dev/v1beta1
-kind: KnativeEventing
-metadata:
-  name: knative-eventing
-  namespace: knative-eventing
-spec:
-  defaultBrokerClass: Kafka <1>
-  config: <2>
-    config-br-defaults: <3>
-      default-br-config: |
-        clusterDefault: <4>
-          brokerClass: Kafka
-          apiVersion: v1
-          kind: ConfigMap
-          name: kafka-broker-config <5>
-          namespace: knative-eventing <6>
-        namespaceDefaults: <7>
-          my-namespace:
-            brokerClass: MTChannelBasedBroker
-            apiVersion: v1
-            kind: ConfigMap
-            name: config-br-default-channel <8>
-            namespace: knative-eventing <9>
-...
-----
-<1> The default broker class for Knative Eventing.
-<2> In `spec.config`, you can specify the config maps that you want to add modified configurations for.
-<3> The `config-br-defaults` config map specifies the default settings for any broker that does not specify `spec.config` settings or a broker class.
-<4> The cluster-wide default broker class configuration. In this example, the default broker class implementation for the cluster is `Kafka`.
-<5> The `kafka-broker-config` config map specifies default settings for the Kafka broker. See "Configuring Knative broker for Apache Kafka settings" in the "Additional resources" section.
-<6> The namespace where the `kafka-broker-config` config map exists.
-<7> The namespace-scoped default broker class configuration. In this example, the default broker class implementation for the `my-namespace` namespace is `MTChannelBasedBroker`. You can specify default broker class implementations for multiple namespaces.
-<8> The `config-br-default-channel` config map specifies the default backing channel for the broker. See "Configuring the default broker backing channel" in the "Additional resources" section.
-<9> The namespace where the `config-br-default-channel` config map exists.
-+
-[IMPORTANT]
-====
-Configuring a namespace-specific default overrides any cluster-wide settings.
-====
+include::modules/serverless-setting-default-broker-class-and-configuration.adoc[leveloffset=+1]

--- a/eventing/brokers/serverless-using-brokers-managing-brokers.adoc
+++ b/eventing/brokers/serverless-using-brokers-managing-brokers.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: ASSEMBLY
-include::_attributes/common-attributes.adoc[]
 [id="serverless-using-brokers-managing-brokers"]
 = Managing brokers
+include::_attributes/common-attributes.adoc[]
 :context: serverless-using-brokers-managing-brokers
 
 toc::[]
@@ -9,14 +9,11 @@ toc::[]
 [role="_abstract"]
 After you have created a broker, you can manage your broker by using Knative (`kn`) CLI commands, or by modifying it in the {ocp-product-title} web console.
 
-[id="serverless-using-brokers-managing-brokers-cli"]
-== Managing brokers using the CLI
-
-The Knative (`kn`) CLI provides commands that can be used to describe and list existing brokers.
+include::modules/serverless-managing-brokers-using-cli.adoc[leveloffset=+1]
 
 include::modules/serverless-list-broker-kn.adoc[leveloffset=+2]
+
 include::modules/serverless-describe-broker-kn.adoc[leveloffset=+2]
 
-// Connect sinks to brokers in ODC
 include::modules/serverless-connect-sink-broker-odc.adoc[leveloffset=+1]
 

--- a/eventing/brokers/serverless-using-brokers.adoc
+++ b/eventing/brokers/serverless-using-brokers.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: ASSEMBLY
-include::_attributes/common-attributes.adoc[]
 [id="serverless-using-brokers"]
 = Creating brokers
+include::_attributes/common-attributes.adoc[]
 :context: serverless-using-brokers
 
 toc::[]
@@ -9,24 +9,25 @@ toc::[]
 [role="_abstract"]
 Knative provides a default, channel-based broker implementation. This channel-based broker can be used for development and testing purposes, but does not provide adequate event delivery guarantees for production environments.
 
-If a cluster administrator has configured your {ServerlessProductName} deployment to use Apache Kafka as the default broker type, creating a broker by using the default settings creates a Knative broker for Apache Kafka.
-
-If your {ServerlessProductName} deployment is not configured to use the Knative broker for Apache Kafka as the default broker type, the channel-based broker is created when you use the default settings in the following procedures.
+include::modules/serverless-understanding-defaul-broker-types.adoc[leveloffset=+1]
 
 include::modules/serverless-create-broker-kn.adoc[leveloffset=+1]
+
 include::modules/serverless-creating-broker-annotation.adoc[leveloffset=+1]
+
 include::modules/serverless-creating-broker-labeling.adoc[leveloffset=+1]
+
 include::modules/serverless-deleting-broker-injection.adoc[leveloffset=+1]
-// Creating brokers in the web console
+
 include::modules/serverless-creating-a-broker-odc.adoc[leveloffset=+1]
 
-[id="next-steps_serverless-using-brokers"]
-== Next steps
-* Configure xref:../../eventing/serverless-event-delivery.adoc#serverless-configuring-event-delivery-examples_serverless-event-delivery[event delivery parameters] that are applied in cases where an event fails to be delivered to an event sink.
-
-[id="additional-resources_serverless-using-brokers"]
 [role="_additional-resources"]
 == Additional resources
+
 * xref:../../eventing/brokers/serverless-global-config-broker-class-default.adoc#serverless-global-config-broker-class-default[Configuring the default broker class]
+
 * xref:../../eventing/triggers/serverless-triggers.adoc#serverless-triggers[Triggers]
+
 * xref:../../eventing/brokers/serverless-using-brokers-managing-brokers.adoc#serverless-connect-sink-broker-odc_serverless-using-brokers-managing-brokers[Connect a broker to a sink]
+
+* xref:../../eventing/serverless-event-delivery.adoc#serverless-configuring-event-delivery-examples_serverless-event-delivery[event delivery parameters]

--- a/eventing/channels/connecting-channels-sinks.adoc
+++ b/eventing/channels/connecting-channels-sinks.adoc
@@ -1,20 +1,23 @@
 :_mod-docs-content-type: ASSEMBLY
-include::_attributes/common-attributes.adoc[]
 [id="connecting-channels-sinks"]
 = Connecting channels to sinks
+include::_attributes/common-attributes.adoc[]
 :context: connecting-channels-sinks
 
 toc::[]
 
 [role="_abstract"]
-Events that have been sent to a channel from an event source or producer can be forwarded to one or more sinks by using _subscriptions_.
-You can create subscriptions by configuring a `Subscription` object, which specifies the channel and the sink (also known as a _subscriber_) that consumes the events sent to that channel.
+You can send events from an event source or producer to a channel, then forward them to one or more sinks by using subscriptions. Create subscriptions by configuring a `Subscription` object that specifies the channel and the sink (also known as a subscriber) that consumes the events.
 
 include::modules/serverless-creating-subscriptions-odc.adoc[leveloffset=+1]
+
 include::modules/serverless-creating-subscriptions-yaml.adoc[leveloffset=+1]
+
 include::modules/serverless-creating-subscriptions-kn.adoc[leveloffset=+1]
+
 include::modules/serverless-creating-subscription-admin-web-console.adoc[leveloffset=+1]
 
-[id="next-steps_connecting-channels-sinks"]
-== Next steps
-* Configure xref:../../eventing/serverless-event-delivery.adoc#serverless-configuring-event-delivery-examples_serverless-event-delivery[Event delivery] parameters that are applied in cases where an event fails to be delivered to an event sink.
+[role="_additional-resources"]
+== Additional resources
+
+* xref:../../eventing/serverless-event-delivery.adoc#serverless-configuring-event-delivery-examples_serverless-event-delivery[Event delivery]

--- a/eventing/channels/serverless-channel-default.adoc
+++ b/eventing/channels/serverless-channel-default.adoc
@@ -1,11 +1,10 @@
 :_mod-docs-content-type: ASSEMBLY
-include::_attributes/common-attributes.adoc[]
 [id="serverless-channel-default"]
 = Default channel implementation
+include::_attributes/common-attributes.adoc[]
 :context: serverless-channel-default
 
 [role="_abstract"]
 You can use the `default-ch-webhook` config map to specify the default channel implementation of Knative Eventing. You can specify the default channel implementation for the entire cluster or for one or more namespaces. Currently the `InMemoryChannel` and `KafkaChannel` channel types are supported.
 
-// Knative Eventing
 include::modules/serverless-channel-default.adoc[leveloffset=+1]

--- a/eventing/channels/serverless-channels.adoc
+++ b/eventing/channels/serverless-channels.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: ASSEMBLY
-include::_attributes/common-attributes.adoc[]
 [id="serverless-channels"]
 = Channels and subscriptions
+include::_attributes/common-attributes.adoc[]
 :context: serverless-channels
 
 toc::[]
@@ -9,39 +9,6 @@ toc::[]
 [role="_abstract"]
 include::snippets/serverless-channels-intro.adoc[]
 
-After you create a `Channel` object, a mutating admission webhook adds a set of `spec.channelTemplate` properties for the `Channel` object based on the default channel implementation. For example, for an `InMemoryChannel` default implementation, the `Channel` object looks as follows:
+include::modules/serverless-channel-template-backing-channel.adoc[leveloffset=+1]
 
-[source,yaml]
-----
-apiVersion: messaging.knative.dev/v1
-kind: Channel
-metadata:
-  name: example-channel
-  namespace: default
-spec:
-  channelTemplate:
-    apiVersion: messaging.knative.dev/v1
-    kind: InMemoryChannel
-----
-
-The channel controller then creates the backing channel instance based on the `spec.channelTemplate` configuration.
-
-[NOTE]
-====
-The `spec.channelTemplate` properties cannot be changed after creation, because they are set by the default channel mechanism rather than by the user.
-====
-
-When this mechanism is used with the preceding example, two objects are created: a generic backing channel and an `InMemoryChannel` channel. If you are using a different default channel implementation, the `InMemoryChannel` is replaced with one that is specific to your implementation. For example, with the Knative broker for Apache Kafka, the `KafkaChannel` channel is created.
-
-The backing channel acts as a proxy that copies its subscriptions to the user-created channel object, and sets the user-created channel object status to reflect the status of the backing channel.
-
-[id="serverless-channels-implementations"]
-== Channel implementation types
-
-{ServerlessProductName} supports the `InMemoryChannel` and `KafkaChannel` channels implementations. The `InMemoryChannel` channel is recommended for development use only due to its limitations. You can use the `KafkaChannel` channel for a production environment.
-
-The following are limitations of `InMemoryChannel` type channels:
-
-* No event persistence is available. If a pod goes down, events on that pod are lost.
-* `InMemoryChannel` channels do not implement event ordering, so two events that are received in the channel at the same time can be delivered to a subscriber in any order.
-* If a subscriber rejects an event, there are no re-delivery attempts by default. You can configure re-delivery attempts by modifying the `delivery` spec in the `Subscription` object.
+include::modules/serverless-channel-implementations-types.adoc[leveloffset=+1]

--- a/eventing/channels/serverless-creating-channels.adoc
+++ b/eventing/channels/serverless-creating-channels.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: ASSEMBLY
-include::_attributes/common-attributes.adoc[]
 [id="serverless-creating-channels"]
 = Creating channels
+include::_attributes/common-attributes.adoc[]
 :context: serverless-creating-channels
 
 toc::[]
@@ -9,13 +9,19 @@ toc::[]
 [role="_abstract"]
 include::snippets/serverless-channels-intro.adoc[]
 
-// Channel
 include::modules/serverless-create-channel-odc.adoc[leveloffset=+1]
+
 include::modules/serverless-create-channel-kn.adoc[leveloffset=+1]
+
+include::modules/serverless-delete-channel-kn.adoc[leveloffset=+1]
+
 include::modules/serverless-create-default-channel-yaml.adoc[leveloffset=+1]
+
 include::modules/serverless-create-kafka-channel-yaml.adoc[leveloffset=+1]
 
-[id="next-steps_serverless-creating-channels"]
-== Next steps
-* After you have created a channel, you can xref:../../eventing/channels/connecting-channels-sinks.adoc#connecting-channels-sinks[connect the channel to a sink] so that the sink can receive events.
-* Configure xref:../../eventing/serverless-event-delivery.adoc#serverless-configuring-event-delivery-examples_serverless-event-delivery[event delivery parameters] that are applied in cases where an event fails to be delivered to an event sink.
+[role="_additional-resources"]
+== Additional resources
+
+* xref:../../eventing/channels/connecting-channels-sinks.adoc#connecting-channels-sinks[Connect the channel to a sink]
+
+* xref:../../eventing/serverless-event-delivery.adoc#serverless-configuring-event-delivery-examples_serverless-event-delivery[Event delivery parameters]

--- a/eventing/channels/serverless-kafka-admin-security-channels.adoc
+++ b/eventing/channels/serverless-kafka-admin-security-channels.adoc
@@ -1,12 +1,14 @@
 :_mod-docs-content-type: ASSEMBLY
-include::_attributes/common-attributes.adoc[]
 [id="serverless-kafka-admin-security-channels"]
 = Security configuration for channels
+include::_attributes/common-attributes.adoc[]
 :context: serverless-kafka-admin-security-channels
 
 toc::[]
 
 [role="_abstract"]
-// kafka channel security config
+You can configure Transport Layer Security (TLS) and Simple Authentication and Security Layer (SASL) settings to secure channel communication in {ServerlessProductName}.
+
 include::modules/serverless-kafka-tls-channels.adoc[leveloffset=+1]
+
 include::modules/serverless-kafka-sasl-channels.adoc[leveloffset=+1]

--- a/eventing/containersource-with-ossm.adoc
+++ b/eventing/containersource-with-ossm.adoc
@@ -1,12 +1,12 @@
 :_mod-docs-content-type: ASSEMBLY
-include::_attributes/common-attributes.adoc[]
 [id="containersource-with-ossm"]
 = Using ContainerSource with {SMProductShortName}
+include::_attributes/common-attributes.adoc[]
 :context: containersource-with-ossm
 
 toc::[]
 
 [role="_abstract"]
-You can use container source with {SMProductShortName}.
+You can use `ContainerSource` with {SMProductShortName}.
 
 include::modules/configuring-containersource-with-ossm.adoc[leveloffset=+1]

--- a/eventing/discovery/list-event-source-types-cli.adoc
+++ b/eventing/discovery/list-event-source-types-cli.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: ASSEMBLY
-include::_attributes/common-attributes.adoc[]
 [id="list-event-source-types-cli"]
 = Listing event source types from the command line
+include::_attributes/common-attributes.adoc[]
 :context: list-event-source-types-cli
 
 [role="_abstract"]

--- a/eventing/discovery/list-event-source-types-odc.adoc
+++ b/eventing/discovery/list-event-source-types-odc.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: ASSEMBLY
-include::_attributes/common-attributes.adoc[]
 [id="list-event-source-types-odc"]
 = Listing event source types from the web console
+include::_attributes/common-attributes.adoc[]
 :context: list-event-source-types-odc
 
 [role="_abstract"]

--- a/eventing/discovery/list-event-sources-cli.adoc
+++ b/eventing/discovery/list-event-sources-cli.adoc
@@ -1,11 +1,10 @@
 :_mod-docs-content-type: ASSEMBLY
-include::_attributes/common-attributes.adoc[]
 [id="list-event-sources-cli"]
 = Listing event sources from the command line
+include::_attributes/common-attributes.adoc[]
 :context: list-event-sources-cli
 
 [role="_abstract"]
 Using the Knative (`kn`) CLI provides a streamlined and intuitive user interface to view existing event sources on your cluster.
 
-// move ODC to own section?
 include::modules/serverless-list-source-cli.adoc[leveloffset=+1]

--- a/eventing/discovery/serverless-listing-event-sources.adoc
+++ b/eventing/discovery/serverless-listing-event-sources.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: ASSEMBLY
-include::_attributes/common-attributes.adoc[]
 [id="serverless-listing-event-sources"]
 = Listing event sources and event source types
+include::_attributes/common-attributes.adoc[]
 :context: serverless-listing-event-sources
 
 toc::[]

--- a/eventing/event-sinks/serverless-creating-sinks.adoc
+++ b/eventing/event-sinks/serverless-creating-sinks.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: ASSEMBLY
-include::_attributes/common-attributes.adoc[]
 [id="serverless-creating-sinks"]
 = Creating event sinks
+include::_attributes/common-attributes.adoc[]
 :context: serverless-creating-sinks
 
 toc::[]
@@ -9,9 +9,13 @@ toc::[]
 [role="_abstract"]
 include::snippets/serverless-about-event-sinks.adoc[]
 
-For information about creating resources that can be used as event sinks, see the following documentation:
+[role="_additional-resources"]
+== Additional resources
 
 * xref:../../knative-serving/getting-started/serverless-applications.adoc#serverless-applications[Serverless applications]
+
 * xref:../../eventing/brokers/serverless-using-brokers.adoc#serverless-using-brokers[Creating brokers]
+
 * xref:../../eventing/channels/serverless-creating-channels.adoc#serverless-creating-channels[Creating channels]
+
 * xref:../../eventing/event-sinks/serverless-kafka-developer-sink.adoc#serverless-kafka-developer-sink[Kafka sink]

--- a/eventing/event-sinks/serverless-event-sinks.adoc
+++ b/eventing/event-sinks/serverless-event-sinks.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: ASSEMBLY
-include::_attributes/common-attributes.adoc[]
 [id="serverless-event-sinks"]
 = Event sinks
+include::_attributes/common-attributes.adoc[]
 :context: serverless-event-sinks
 
 toc::[]
@@ -9,14 +9,11 @@ toc::[]
 [role="_abstract"]
 include::snippets/serverless-about-event-sinks.adoc[]
 
-Addressable objects receive and acknowledge an event delivered over HTTP to an address defined in their `status.address.url` field. As a special case, the core Kubernetes `Service` object also fulfills the addressable interface.
+include::modules/serverless-event-sink-addressable-callable-objects.adoc[leveloffset=+1]
 
-Callable objects are able to receive an event delivered over HTTP and transform the event, returning `0` or `1` new events in the HTTP response. These returned events may be further processed in the same way that events from an external event source are processed.
-
-// Using --sink flag with kn (generic)
 include::modules/specifying-sink-flag-kn.adoc[leveloffset=+1]
 
-[TIP]
-====
-You can configure which CRs can be used with the `--sink` flag for Knative (`kn`) CLI commands by xref:../../cli_tools/advanced-kn-config.adoc#advanced-kn-config[Customizing `kn`].
-====
+[role="_additional-resources"]
+== Additional resources
+
+* xref:../../cli_tools/advanced-kn-config.adoc#advanced-kn-config[Customizing `kn`]

--- a/eventing/event-sinks/serverless-getting-started-integrationsink.adoc
+++ b/eventing/event-sinks/serverless-getting-started-integrationsink.adoc
@@ -7,19 +7,12 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 [role="_abstract"]
+The `IntegrationSink` API is a Knative Eventing custom resource (CR) that sends events from Knative to external systems by using selected Kamelets from the Apache Camel project.
+
+Kamelets act as reusable connectors that function as sources or sinks. You can use the `IntegrationSink` API to deliver `CloudEvents` from Knative Eventing to external services, including AWS Simple Storage Service (S3), AWS Simple Notification Service (SNS), AWS Simple Queue Service (SQS), and a generic logger sink.
+
 :FeatureName: {ServerlessProductName} IntegrationSink feature
 include::snippets/technology-preview.adoc[]
-
-The `IntegrationSink` API is a Knative Eventing custom resource (CR) that enables you to send events from Knative into external systems. It leverages selected Kamelets from the Apache Camel project.
-
-Kamelets act as reusable connectors that can function either as sources or sinks.By using an `IntegrationSink` API, you can reliably deliver CloudEvents produced within Knative Eventing to third-party services and external systems.
-
-{ServerlessProductName} supports the following Kamelet sinks:
-
-* AWS Simple Storage Service (S3) 
-* AWS Simple Notification Service (SNS) 
-* AWS Simple Queue Service (SQS) 
-* Generic logger sink 
 
 include::modules/serverless-integrationsink-creating-aws-credentials.adoc[leveloffset=+1]
 

--- a/eventing/event-sinks/serverless-jobsink.adoc
+++ b/eventing/event-sinks/serverless-jobsink.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: ASSEMBLY
-include::_attributes/common-attributes.adoc[]
 [id="serverless-jobsink"]
 = JobSink
+include::_attributes/common-attributes.adoc[]
 :context: serverless-jobsink
 
 toc::[]
@@ -9,21 +9,14 @@ toc::[]
 [role="_abstract"]
 Event processing usually completes within a short time frame, such as a few minutes. This ensures that the HTTP connection remains open and the service does not scale down prematurely.
 
-Maintaining long-running connections increases the risk of failure, potentially leading to processing restarts and repeated request retries.
+Long-running connections increase the risk of failures, which can trigger restarts and repeated retries. You can use `JobSink` to run long-running asynchronous jobs by using Kubernetes `batch/v1` Job resources and Job queuing systems such as Kueue.
 
-You can use JobSink to support long-running asynchronous jobs and tasks using the full Kubernetes `batch/v1` Job resource and features and Kubernetes job queuing systems such as Kueue.
-
-//Using JobSink
 include::modules/serverless-using-jobsink.adoc[leveloffset=+1]
 
-//Reading the Job event file
 include::modules/serverless-jobsink-reading-event-file.adoc[leveloffset=+1]
 
-//Customizing Event File Directory
 include::modules/serverless-jobsink-customizing-event-file-directory.adoc[leveloffset=+1]
 
-//Cleaning Up Finished Jobs
 include::modules/serverless-jobsink-cleaning-up-jobs.adoc[leveloffset=+1]
 
-//JobSink examples
 include::modules/serverless-jobsink-examples.adoc[leveloffset=+1]

--- a/eventing/event-sinks/serverless-kafka-developer-sink.adoc
+++ b/eventing/event-sinks/serverless-kafka-developer-sink.adoc
@@ -1,19 +1,23 @@
 :_mod-docs-content-type: ASSEMBLY
-include::_attributes/common-attributes.adoc[]
 [id="serverless-kafka-developer-sink"]
 = Sink for Apache Kafka
+include::_attributes/common-attributes.adoc[]
 :context: serverless-kafka-developer-sink
 
 toc::[]
 
 [role="_abstract"]
-Apache Kafka sinks are a type of xref:../../eventing/event-sinks/serverless-event-sinks.adoc#serverless-event-sinks[event sink] that are available if a cluster administrator has enabled Apache Kafka on your cluster. You can send events directly from an xref:../../eventing/event-sources/knative-event-sources.adoc#knative-event-sources[event source] to a Kafka topic by using a Kafka sink.
+Apache Kafka sinks are a type of event sink that are available if a cluster administrator has enabled Apache Kafka on your cluster. You can send events directly from an event source to a Kafka topic by using a Kafka sink.
 
-// Kafka sink via YAML
 include::modules/serverless-kafka-sink.adoc[leveloffset=+1]
 
-// Creating a Kafka sink via ODC
 include::modules/serverless-creating-a-kafka-event-sink.adoc[leveloffset=+1]
 
-// kafka sink security config
 include::modules/serverless-kafka-sink-security-config.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+== Additional resources
+
+* xref:../../eventing/event-sinks/serverless-event-sinks.adoc#serverless-event-sinks[event sink]
+
+* xref:../../eventing/event-sources/knative-event-sources.adoc#knative-event-sources[event source]

--- a/eventing/event-sources/event-source-admin-perspective.adoc
+++ b/eventing/event-sources/event-source-admin-perspective.adoc
@@ -1,11 +1,12 @@
 :_mod-docs-content-type: ASSEMBLY
-include::_attributes/common-attributes.adoc[]
 [id="event-source-admin-perspective"]
 = Event source in the Administrator perspective
+include::_attributes/common-attributes.adoc[]
 :context: event-source-admin-perspective
+
+toc::[]
 
 [role="_abstract"]
 Sourcing events is critical to developing a distributed system that reacts to events.
 
-// Event sources
 include::modules/serverless-creating-event-source-admin-web-console.adoc[leveloffset=+1]

--- a/eventing/event-sources/knative-event-sources.adoc
+++ b/eventing/event-sources/knative-event-sources.adoc
@@ -1,25 +1,29 @@
 :_mod-docs-content-type: ASSEMBLY
-include::_attributes/common-attributes.adoc[]
 [id="knative-event-sources"]
 = Event sources
+include::_attributes/common-attributes.adoc[]
 :context: knative-event-sources
 
 toc::[]
 
 [role="_abstract"]
-A Knative _event source_ can be any Kubernetes object that generates or imports cloud events, and relays those events to another endpoint, known as a xref:../../eventing/event-sinks/serverless-event-sinks.adoc#serverless-event-sinks[_sink_]. Sourcing events is critical to developing a distributed system that reacts to events.
+A Knative `event source` can be any Kubernetes object that generates or imports cloud events and relays those events to another endpoint, known as `sink`. Sourcing events is critical to developing a distributed system that reacts to events.
 
 You can create and manage Knative event sources in the {ocp-product-title} web console, the Knative (`kn`) CLI, or by applying YAML files.
 
-Currently, {ServerlessProductName} supports the following event source types:
+include::modules/serverless-supported-event-source-types.adoc[leveloffset=+1]
 
-xref:../../eventing/event-sources/serverless-apiserversource.adoc#serverless-apiserversource[API server source]:: Brings Kubernetes API server events into Knative. The API server source sends a new event each time a Kubernetes resource is created, updated or deleted.
-
-xref:../../eventing/event-sources/serverless-pingsource.adoc#serverless-pingsource[Ping source]:: Produces events with a fixed payload on a specified cron schedule.
-
-xref:../../eventing/event-sources/serverless-kafka-developer-source.adoc#serverless-kafka-developer-source[Kafka event source]:: Connects an Apache Kafka cluster to a sink as an event source.
-
-You can also create a xref:../../eventing/event-sources/serverless-custom-event-sources.adoc#serverless-custom-event-sources[custom event source].
-
-// Event sources
 include::modules/serverless-creating-event-source-admin-web-console.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+== Additional resources
+
+* xref:../../eventing/event-sinks/serverless-event-sinks.adoc#serverless-event-sinks[Sink]
+
+* xref:../../eventing/event-sources/serverless-apiserversource.adoc#serverless-apiserversource[API server source]
+
+* xref:../../eventing/event-sources/serverless-pingsource.adoc#serverless-pingsource[Ping source]
+
+* xref:../../eventing/event-sources/serverless-kafka-developer-source.adoc#serverless-kafka-developer-source[Kafka event source]
+
+* xref:../../eventing/event-sources/serverless-custom-event-sources.adoc#serverless-custom-event-sources[custom event source]

--- a/eventing/event-sources/serverless-apiserversource.adoc
+++ b/eventing/event-sources/serverless-apiserversource.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: ASSEMBLY
-include::_attributes/common-attributes.adoc[]
 [id="serverless-apiserversource"]
 = Creating an API server source
+include::_attributes/common-attributes.adoc[]
 :context: serverless-apiserversource
 
 toc::[]
@@ -9,10 +9,10 @@ toc::[]
 [role="_abstract"]
 The API server source is an event source that can be used to connect an event sink, such as a Knative service, to the Kubernetes API server. The API server source watches for Kubernetes events and forwards them to the Knative Eventing broker.
 
-// dev console
 include::modules/odc-creating-apiserversource.adoc[leveloffset=+1]
-// kn commands
+
 include::modules/apiserversource-kn.adoc[leveloffset=+1]
+
 include::modules/specifying-sink-flag-kn.adoc[leveloffset=+2]
-// YAML
+
 include::modules/apiserversource-yaml.adoc[leveloffset=+1]

--- a/eventing/event-sources/serverless-custom-event-sources.adoc
+++ b/eventing/event-sources/serverless-custom-event-sources.adoc
@@ -7,45 +7,35 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 [role="_abstract"]
-If you need to ingress events from an event producer that is not included in Knative, or from a producer that emits events which are not in the `CloudEvent` format, you can do this by creating a custom event source. You can create a custom event source by using one of the following methods:
+If your event producer is not part of Knative or does not use the `CloudEvent` format, you can create a custom event source. You can use a `PodSpecable` object with a sink binding or use a container by creating a container source.
 
-* Use a `PodSpecable` object as an event source, by creating a sink binding.
-* Use a container as an event source, by creating a container source.
-
-// sinkbinding intro
 include::modules/serverless-sinkbinding-intro.adoc[leveloffset=+1]
-// YAML
+
 include::modules/serverless-sinkbinding-yaml.adoc[leveloffset=+2]
-// kn commands
+
 include::modules/serverless-sinkbinding-kn.adoc[leveloffset=+2]
-include::modules/specifying-sink-flag-kn.adoc[leveloffset=+3]
-// ODC
+
+include::modules/specifying-sink-flag-kn.adoc[leveloffset=+2]
+
 include::modules/serverless-sinkbinding-odc.adoc[leveloffset=+2]
-// Reference
+
 include::modules/serverless-sinkbinding-reference.adoc[leveloffset=+2]
-// OSSM
+
 include::modules/serverless-sinkbinding-ossm.adoc[leveloffset=+2]
 
-.Additional resources
+include::modules/serverless-custom-event-source-containersource-intro.adoc[leveloffset=+1]
 
-* xref:../../integrations/serverless-integrating-service-mesh/serverless-ossm-setup.adoc#serverless-ossm-setup_serverless-ossm-setup[Integrating {SMProductShortName} with {ServerlessProductName}]
-
-[id="serverless-custom-event-sources-containersource"]
-== Container source
-
-Container sources create a container image that generates events and sends events to a sink. You can use a container source to create a custom event source, by creating a container image and a `ContainerSource` object that uses your image URI.
-
-// intro
 include::modules/serverless-containersource-guidelines.adoc[leveloffset=+2]
-// kn
+
 include::modules/serverless-kn-containersource.adoc[leveloffset=+2]
-// ODC
+
 include::modules/serverless-odc-create-containersource.adoc[leveloffset=+2]
-// Reference
+
 include::modules/serverless-containersource-reference.adoc[leveloffset=+2]
-// OSSM
+
 include::modules/serverless-containersource-ossm.adoc[leveloffset=+2]
 
-.Additional resources
+[role="_additional-resources"]
+== Additional resources
 
 * xref:../../integrations/serverless-integrating-service-mesh/serverless-ossm-setup.adoc#serverless-ossm-setup_serverless-ossm-setup[Integrating {SMProductShortName} with {ServerlessProductName}]

--- a/eventing/event-sources/serverless-getting-started-integrationsource.adoc
+++ b/eventing/event-sources/serverless-getting-started-integrationsource.adoc
@@ -7,19 +7,12 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 [role="_abstract"]
+The `IntegrationSource` API is a Knative Eventing custom resource (CR) for connecting external systems by using selected Kamelets from the Apache Camel project. Kamelets act as reusable connectors that work as event sources or sinks.
+
+You can use the `IntegrationSource` API to consume data from external systems and send it as `CloudEvents` to Knative Eventing. {ServerlessProductName} supports Kamelet sources such as AWS `DynamoDB` Streams, AWS Simple Storage Service (S3), AWS Simple Queue Service (SQS), and Timer Source.
+
 :FeatureName: {ServerlessProductName} IntegrationSource feature
 include::snippets/technology-preview.adoc[]
-
-The `IntegrationSource` API is a Knative Eventing custom resource (CR) that enables you to connect to external systems by leveraging selected Kamelets from the Apache Camel project.
-
-Kamelets act as reusable connectors that can function either as sources or sinks. By using an `IntegrationSource` API, you can consume data from external systems and forward the data as CloudEvents into Knative Eventing.
-
-{ServerlessProductName} supports the following Kamelet sources:
-
-* AWS DynamoDB Streams
-* AWS S3
-* AWS SQS
-* Timer Source
 
 include::modules/serverless-integrationsource-creating-aws-credentials.adoc[leveloffset=+1]
 

--- a/eventing/event-sources/serverless-kafka-developer-source.adoc
+++ b/eventing/event-sources/serverless-kafka-developer-source.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: ASSEMBLY
-include::_attributes/common-attributes.adoc[]
 [id="serverless-kafka-developer-source"]
 = Source for Apache Kafka
+include::_attributes/common-attributes.adoc[]
 :context: serverless-kafka-developer-source
 
 toc::[]
@@ -9,20 +9,19 @@ toc::[]
 [role="_abstract"]
 You can create an Apache Kafka source that reads events from an Apache Kafka cluster and passes these events to a sink. You can create a Kafka source by using the {ocp-product-title} web console, the Knative (`kn`) CLI, or by creating a `KafkaSource` object directly as a YAML file and using the OpenShift CLI (`oc`) to apply it.
 
-
-[NOTE]
-====
-See the documentation for xref:../../install/installing-knative-eventing.adoc#serverless-install-kafka-odc_installing-knative-eventing[Installing Knative broker for Apache Kafka].
-====
-
-// dev console
 include::modules/serverless-kafka-source-odc.adoc[leveloffset=+1]
-// kn commands
+
 include::modules/serverless-kafka-source-kn.adoc[leveloffset=+1]
+
 include::modules/specifying-sink-flag-kn.adoc[leveloffset=+2]
-// YAML
+
 include::modules/serverless-kafka-source-yaml.adoc[leveloffset=+1]
 
 include::modules/serverless-kafka-sasl-source.adoc[leveloffset=+1]
 
 include::modules/serverless-kafka-source-autoscale-keda.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+== Additional resources
+
+* xref:../../install/installing-knative-eventing.adoc#serverless-install-kafka-odc_installing-knative-eventing[Installing Knative broker for Apache Kafka]

--- a/eventing/event-sources/serverless-pingsource.adoc
+++ b/eventing/event-sources/serverless-pingsource.adoc
@@ -7,12 +7,16 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 [role="_abstract"]
-A ping source is an event source that can be used to periodically send ping events with a constant payload to an event consumer. A ping source can be used to schedule sending events, similar to a timer.
+A ping source sends periodic ping events with a constant payload to an event consumer. Use a ping source to schedule event delivery, similar to a timer.
 
-// dev console
 include::modules/serverless-pingsource-odc.adoc[leveloffset=+1]
-// kn commands
+
+include::modules/serverless-deleting-the-pingsource.adoc[leveloffset=+1]
+
 include::modules/serverless-pingsource-kn.adoc[leveloffset=+1]
+
 include::modules/specifying-sink-flag-kn.adoc[leveloffset=+2]
-// YAML
+
 include::modules/serverless-pingsource-yaml.adoc[leveloffset=+1]
+
+include::modules/serverless-deleting-the-pingsource-using-yaml.adoc[leveloffset=+1]

--- a/eventing/event-sources/serverless-sink-source-odc.adoc
+++ b/eventing/event-sources/serverless-sink-source-odc.adoc
@@ -1,11 +1,10 @@
 :_mod-docs-content-type: ASSEMBLY
-include::_attributes/common-attributes.adoc[]
 [id="serverless-sink-source-odc"]
 = Connecting an event source to an event sink
+include::_attributes/common-attributes.adoc[]
 :context: serverless-sink-source-odc
 
 [role="_abstract"]
 When you create an event source by using the {ocp-product-title} web console, you can specify a target event sink that events are sent to from that source. The event sink can be any addressable or callable resource that can receive incoming events from other resources.
 
-// Connect sinks to sources in ODC
 include::modules/serverless-connect-sink-source-odc.adoc[leveloffset=+1]

--- a/eventing/kn-event-plugin/kn-plugins-events.adoc
+++ b/eventing/kn-event-plugin/kn-plugins-events.adoc
@@ -1,18 +1,14 @@
 :_mod-docs-content-type: ASSEMBLY
-include::_attributes/common-attributes.adoc[]
 [id="kn-plugins-events"]
 = Knative CLI plugins
+include::_attributes/common-attributes.adoc[]
 :context: kn-plugins-events
 
 toc::[]
 
 [role="_abstract"]
-The Knative (`kn`) CLI supports the use of plugins, which enable you to extend the functionality of your `kn` installation by adding custom commands and other shared commands that are not part of the core distribution. Knative (`kn`) CLI plugins are used in the same way as the main `kn` functionality.
+The Knative (`kn`) CLI supports plugins that extend its functionality by adding custom commands beyond the core distribution. You use these plugins the same way as standard `kn` commands. Red{nbsp}Hat supports the `kn-source-kafka` and `kn-event` plugins.
 
-Currently, Red Hat supports the `kn-source-kafka` plugin and the `kn-event` plugin.
-
-:FeatureName: The `kn-event` plugin
-include::snippets/technology-preview.adoc[leveloffset=+1]
-// kn event commands
 include::modules/serverless-build-events-kn.adoc[leveloffset=+1]
+
 include::modules/serverless-send-events-kn.adoc[leveloffset=+1]

--- a/eventing/knative-eventing.adoc
+++ b/eventing/knative-eventing.adoc
@@ -1,24 +1,19 @@
 :_mod-docs-content-type: ASSEMBLY
-include::_attributes/common-attributes.adoc[]
 [id="knative-eventing-overview"]
 = Knative Eventing
+include::_attributes/common-attributes.adoc[]
 :context: knative-eventing-overview
 
 [role="_abstract"]
-Knative Eventing on {ocp-product-title} enables developers to use an link:https://www.redhat.com/en/topics/integration/what-is-event-driven-architecture[event-driven architecture] with serverless applications. An event-driven architecture is based on the concept of decoupled relationships between event producers and event consumers.
+Knative Eventing on {ocp-product-title} supports event-driven architectures for serverless applications by decoupling event producers and consumers.
 
-Event producers create events, and event _sinks_, or consumers, receive events. Knative Eventing uses standard HTTP POST requests to send and receive events between event producers and sinks. These events conform to the link:https://cloudevents.io[CloudEvents specifications], which enables creating, parsing, sending, and receiving events in any programming language.
+Producers create events, and sinks consume them. Knative Eventing uses HTTP POST requests to deliver events that follow the `CloudEvents` specification, which supports event handling across programming languages.
 
-== Knative Eventing use cases:
+include::modules/serverless-knative-eventing-usecases.adoc[leveloffset=+1]
 
-Knative Eventing supports the following use cases:
+[role="_additional-resources"]
+== Additional resources
 
-Publish an event without creating a consumer:: You can send events to a broker as an HTTP POST, and use binding to decouple the destination configuration from your application that produces events.
+* link:https://www.redhat.com/en/topics/integration/what-is-event-driven-architecture[Event-driven architecture]
 
-Consume an event without creating a publisher:: You can use a trigger to consume events from a broker based on event attributes. The application receives events as an HTTP POST.
-
-To enable delivery to multiple types of sinks, Knative Eventing defines the following generic interfaces that can be implemented by multiple Kubernetes resources:
-
-Addressable resources:: Able to receive and acknowledge an event delivered over HTTP to an address defined in the `status.address.url` field of the event. The Kubernetes `Service` resource also satisfies the addressable interface.
-
-Callable resources:: Able to receive an event delivered over HTTP and transform it, returning `0` or `1` new events in the HTTP response payload. These returned events may be further processed in the same way that events from an external event source are processed.
+* link:https://cloudevents.io[CloudEvents specifications]

--- a/eventing/kube-rbac-proxy-eventing.adoc
+++ b/eventing/kube-rbac-proxy-eventing.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: ASSEMBLY
-include::_attributes/common-attributes.adoc[]
 [id="kube-rbac-proxy-eventing"]
 = Configuring kube-rbac-proxy for Eventing
+include::_attributes/common-attributes.adoc[]
 :context: kube-rbac-proxy-eventing
 
 toc::[]
@@ -11,5 +11,4 @@ The `kube-rbac-proxy` component provides internal authentication and authorizati
 
 include::modules/serverless-configuring-kube-rbac-proxy-resources-for-eventing.adoc[leveloffset=+1]
 
-[id="kube-rbac-proxy-eventing-kafka"]
 include::modules/serverless-configuring-kube-rbac-proxy-resources-for-kafka.adoc[leveloffset=+1]

--- a/eventing/serverless-config-tls-encryption-eventing.adoc
+++ b/eventing/serverless-config-tls-encryption-eventing.adoc
@@ -9,37 +9,33 @@ toc::[]
 [role="_abstract"]
 With the transport encryption feature, you can transport data and events over secured and encrypted HTTPS connections by using  _Transport Layer Security_ (TLS).
 
-
-The `transport-encryption` feature flag is an `enum` configuration that defines how Addressables, such as Broker, Channel, and Sink, accept events. It controls whether Addressables must accept events over HTTP or HTTPS based on the selected setting.
-
-The possible values for `transport-encryption` are as follows:
-[cols=2,options=header]
-|===
-|Value
-|Description
-
-|`disabled`
-a|
-* Addressables can accept events to HTTPS endpoints.
-* Producers can send events to HTTPS endpoints.
-
-|`permissive`
-a|
-* Addressables must accept events on both HTTP and HTTPS endpoints.
-* Addressables must advertise both HTTP and HTTPS endpoints.
-* Producers must send events to HTTPS endpoints, if available.
-
-|`strict`
-a|
-* Addressables must not accept events to non-HTTPS endpoints.
-* Addressables must only advertise HTTPS endpoints.
-|===
+include::modules/serverless-transport-encryption-config-values.adoc[leveloffset=+1]
 
 include::modules/serverless-tls-creating-selfsigned-cluster-issuer-eventing.adoc[leveloffset=+1]
+
 include::modules/serverless-tls-creating-cluster-issuer-eventing.adoc[leveloffset=+1]
+
 include::modules/serverless-tls-enabling-transport-encryption-eventing.adoc[leveloffset=+1]
+
 include::modules/serverless-tls-config-additional-ca-bundles-eventing.adoc[leveloffset=+1]
+
 include::modules/serverless-tls-config-custom-event-sources.adoc[leveloffset=+1]
+
 include::modules/serverless-tls-adding-selfsigned-to-ca-bundles-eventing.adoc[leveloffset=+1]
+
 include::modules/serverless-tls-ensuring-seamless-ca-rotation-eventing.adoc[leveloffset=+1]
+
 include::modules/serverless-tls-verifying-transport-encryption-eventing.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+== Additional resources
+
+* link:https://cert-manager.io/docs/concepts/issuer/[Issuer]
+
+* link:https://cert-manager.io/docs/configuration/selfsigned/[SelfSigned issuers]
+
+* link:https://cert-manager.io/docs/configuration/ca/[certificate authorities (CAs)]
+
+* link:https://docs.openshift.com/container-platform/latest/networking/configuring-a-custom-pki.html[Configuring a custom PKI]
+
+* link:https://cert-manager.io/docs/usage/certificate/#reissuance-triggered-by-user-actions[Reissuance triggered by user actions]

--- a/eventing/serverless-event-authorization-eventpolicy.adoc
+++ b/eventing/serverless-event-authorization-eventpolicy.adoc
@@ -7,14 +7,9 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 [role="_abstract"]
-Knative Eventing provides a mechanism to secure event delivery to prevent unauthorized access. Event-driven systems often rely on multiple producers and consumers of events, and without proper authorization controls, malicious or unintended event flows could compromise the system.
+Knative Eventing provides a way to secure event delivery and prevent unauthorized access. Event-driven systems often involve many producers and consumers. Without proper authorization controls, unintended or malicious event flows can compromise the system.
 
-To achieve fine-grained access control, Knative Eventing introduces the EventPolicy custom resource. This resource allows administrators and developers to define which entities are authorized to send events to specific consumers within a namespace. By applying EventPolicies, you can ensure that only trusted event sources or service accounts are able to send data to selected event consumers and this improves the overall security posture of their event-driven architecture.
-
-[NOTE]
-====
-You must enable the `transport-encryption` feature flag along with `authentication-oidc` to ensure secure and authenticated event delivery.
-====
+include::modules/serverless-eventing-eventpolicy-securing-event-delivery.adoc[leveloffset=+1]
 
 include::modules/serverless-event-default-authorization-mode.adoc[leveloffset=+1]
 

--- a/eventing/serverless-event-delivery.adoc
+++ b/eventing/serverless-event-delivery.adoc
@@ -7,20 +7,15 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 [role="_abstract"]
-You can configure event delivery parameters that are applied in cases where an event fails to be delivered to an event sink. Different channel and broker types have their own behavior patterns that are followed for event delivery.
+You can configure event delivery parameters to handle cases where delivery to an event sink fails. Each channel and broker type follows its own event delivery behavior.
 
-Configuring event delivery parameters, including a dead letter sink, ensures that any events that fail to be delivered to an event sink are retried. Otherwise, undelivered events are dropped.
+Configure event delivery parameters, including a dead letter sink, to retry failed events. If you do not configure these parameters, the system drops undelivered events.
 
-[IMPORTANT]
-====
-If an event is successfully delivered to a channel or broker receiver for Apache Kafka, the receiver responds with a `202` status code, which means that the event has been safely stored inside a Kafka topic and is not lost. If the receiver responds with any other status code, the event is not safely stored, and steps must be taken by the user to resolve the issue.
-====
-
-// event delivery configurable parameters
 include::modules/serverless-event-delivery-parameters.adoc[leveloffset=+1]
 
-// configuring parameters examples
 include::modules/serverless-configuring-event-delivery-examples.adoc[leveloffset=+1]
 
-// event delivery ordering
-//include::modules/trigger-event-delivery-config.adoc[leveloffset=+1]
+[role="_additional-resources"]
+== Additional resources
+
+* link:https://en.wikipedia.org/wiki/ISO_8601#Durations[ISO 8601]

--- a/eventing/serverless-event-transformation.adoc
+++ b/eventing/serverless-event-transformation.adoc
@@ -7,18 +7,9 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 [role="_abstract"]
-`EventTransform` is a Knative API resource that enables declarative transformations of HTTP requests and responses without requiring custom code. With `EventTransform`, you can:
+`EventTransform` is a Knative API resource that enables declarative transformations of HTTP requests and responses without requiring custom code.
 
-* Modify the event attributes
-* Extract data from the event payloads
-* Reshape events to meet the requirements of different systems
-
-`EventTransform` is designed as a flexible component in an event-driven architecture. You can place it at various points in the event flow to support seamless integration between diverse producers and consumers.
-
-[NOTE]
-====
-`EventTransform` is an addressable resource and can be referenced from Knative sources, triggers, and subscriptions.
-====
+include::modules/serverless-event-transform-overview.adoc[leveloffset=+1]
 
 include::modules/serverless-event-transformation-key-features.adoc[leveloffset=+1]
 

--- a/eventing/sinkbinding-with-ossm.adoc
+++ b/eventing/sinkbinding-with-ossm.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: ASSEMBLY
-include::_attributes/common-attributes.adoc[]
 [id="sinkbinding-with-ossm"]
 = Using a sink binding with {SMProductShortName}
+include::_attributes/common-attributes.adoc[]
 :context: sinkbinding-with-ossm
 
 toc::[]

--- a/eventing/subscriptions/serverless-subs-managing.adoc
+++ b/eventing/subscriptions/serverless-subs-managing.adoc
@@ -7,9 +7,10 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 [role="_abstract"]
-// describe subs
+You can manage subscriptions in Knative Eventing by describing, listing, and updating existing subscription resources by using the `kn` CLI.
+
 include::modules/serverless-describe-subs-kn.adoc[leveloffset=+1]
-// list subs
+
 include::modules/serverless-list-subs-kn.adoc[leveloffset=+1]
-// update subs
+
 include::modules/serverless-update-subscriptions-kn.adoc[leveloffset=+1]

--- a/eventing/subscriptions/serverless-subs.adoc
+++ b/eventing/subscriptions/serverless-subs.adoc
@@ -9,11 +9,17 @@ toc::[]
 [role="_abstract"]
 After you have created a channel and an event sink, you can create a subscription to enable event delivery. Subscriptions are created by configuring a `Subscription` object, which specifies the channel and the sink (also known as a _subscriber_) to deliver events to.
 
-// Subscription
 include::modules/serverless-creating-subscriptions-odc.adoc[leveloffset=+1]
+
 include::modules/serverless-creating-subscriptions-yaml.adoc[leveloffset=+1]
+
 include::modules/serverless-creating-subscriptions-kn.adoc[leveloffset=+1]
 
-[id="next-steps_serverless-subs"]
-== Next steps
-* Configure xref:../../eventing/serverless-event-delivery.adoc#serverless-configuring-event-delivery-examples_serverless-event-delivery[event delivery parameters] that are applied in cases where an event fails to be delivered to an event sink.
+include::modules/serverless-deleting-subscriptions-kn-cli.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+== Additional resources
+
+* xref:../../eventing/serverless-event-delivery.adoc#serverless-configuring-event-delivery-examples_serverless-event-delivery[Event delivery parameters]
+
+* link:https://pkg.go.dev/knative.dev/pkg/apis/duck/v1?tab=doc#Destination[Destination]

--- a/eventing/triggers/advanced-trigger-filters.adoc
+++ b/eventing/triggers/advanced-trigger-filters.adoc
@@ -7,9 +7,17 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 [role="_abstract"]
-The advanced trigger filters give you advanced options for more precise event routing. You can filter events by exact matches, prefixes, or suffixes, as well as by CloudEvent extensions. This added control makes it easier to fine-tune how events flow ensuring that only relevant events trigger specific actions.
+The advanced trigger filters give you more precise event routing options. You can filter events by exact matches, prefixes, or suffixes and by `CloudEvent` extensions. This added control makes it easier to fine-tune how events flow, ensuring that only relevant events trigger specific actions.
 
 include::modules/advanced-trigger-filter-overview.adoc[leveloffset=+1]
+
 include::modules/triggers-supported-filter-dialects.adoc[leveloffset=+1]
+
 include::modules/triggers-conflict-current-filter-field.adoc[leveloffset=+1]
+
 include::modules/triggers-legacy-attribute-filters.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+== Additional resources
+
+* link:https://github.com/cloudevents/spec/blob/cesql/v1.0.0/cesql/spec.md[CloudEvents SQL Expression Language]

--- a/eventing/triggers/connect-trigger-sink.adoc
+++ b/eventing/triggers/connect-trigger-sink.adoc
@@ -1,26 +1,12 @@
 :_mod-docs-content-type: ASSEMBLY
-include::_attributes/common-attributes.adoc[]
 [id="connect-trigger-sink"]
 = Connecting a trigger to a sink
+include::_attributes/common-attributes.adoc[]
 :context: connect-trigger-sink
 
-[role="_abstract"]
-You can connect a trigger to a sink, so that events from a broker are filtered before they are sent to the sink. A sink that is connected to a trigger is configured as a `subscriber` in the `Trigger` object's resource spec.
+toc::[]
 
-.Example of a `Trigger` object connected to an Apache Kafka sink
-[source,yaml]
-----
-apiVersion: eventing.knative.dev/v1
-kind: Trigger
-metadata:
-  name: <trigger_name> <1>
-spec:
-...
-  subscriber:
-    ref:
-      apiVersion: eventing.knative.dev/v1alpha1
-      kind: KafkaSink
-      name: <kafka_sink_name> <2>
-----
-<1> The name of the trigger being connected to the sink.
-<2> The name of a `KafkaSink` object.
+[role="_abstract"]
+You can connect a trigger to a sink so that it filters events from a broker before sending them to the sink. When you connect a sink to a trigger, you configure the sink as a subscriber in the `Trigger` resource.
+
+include::modules/serverless-trigger-config-connecting-to-kafka-sink.adoc[leveloffset=+1]

--- a/eventing/triggers/create-triggers.adoc
+++ b/eventing/triggers/create-triggers.adoc
@@ -6,70 +6,15 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 [role="_abstract"]
-Triggers in Knative Eventing allow you to route events from a broker to a specific subscriber based on your requirements. By defining a Trigger, you can connect event producers to consumers dynamically, ensuring events are delivered to the correct destination. This section describes the steps to create a Trigger, configure its filters, and verify its functionality. Whether you're working with simple routing needs or complex event-driven workflows. 
+Triggers in Knative Eventing route events from a broker to a specific subscriber based on defined criteria. You can use a trigger to connect event producers to consumers dynamically and ensure that events reach the correct destination. You can create a trigger, configure filters, and verify its behavior to support both simple routing and complex event-driven workflows.
 
-The following examples displays common configurations for Triggers, demonstrating how to route events to Knative services or custom endpoints.
+include::modules/serverless-common-trigger-configurations.adoc[leveloffset=+1]
 
-.Example of routing events to a Knative Serving service
-
-The following Trigger routes all events from the default broker to the Knative Serving service named `my-service`:
-[source,yaml]
-----
-apiVersion: eventing.knative.dev/v1
-kind: Trigger
-metadata:
-  name: my-service-trigger
-spec:
-  broker: default
-  filter:
-    attributes:
-      type: dev.knative.foo.bar
-  subscriber:
-    ref:
-      apiVersion: serving.knative.dev/v1
-      kind: Service
-      name: my-service
-----
-
-[NOTE]
-====
-Routing all events without a `filter` attribute is recommended for debugging purposes. It allows you to observe and analyze all incoming events, helping identify issues or validate the flow of events through the broker before applying specific filters. To know more about filtering, see xref:../../eventing/triggers/advanced-trigger-filters.adoc#advanced-trigger-filter-overview_advanced-trigger-filters[Advanced trigger filters].
-====
-
-To apply this trigger, you can save the configuration to a file, for example, `trigger.yaml` and run the following command:
-[source,terminal]
-----
-$ oc apply -f trigger.yaml
-----
-
-.Example of routing events to a custom path
-
-This Trigger routes all events from the default broker to a custom path `/my-custom-path` on the service named `my-service`:
-
-[source,yaml]
-----
-apiVersion: eventing.knative.dev/v1
-kind: Trigger
-metadata:
-  name: my-service-trigger
-spec:
-  broker: default
-  subscriber:
-    ref:
-      apiVersion: v1
-      kind: Service
-      name: my-service
-    uri: /my-custom-path
-----
-
-You can save the configuration to a file, for example, `custom-path-trigger.yaml` and run the following command:
-[source,terminal]
-----
-$ oc apply -f custom-path-trigger.yaml
-----
-
-// ODC
 include::modules/serverless-create-trigger-odc.adoc[leveloffset=+1]
 
-// kn trigger
 include::modules/serverless-create-kn-trigger.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+== Additional resources
+
+* xref:../../eventing/triggers/advanced-trigger-filters.adoc#advanced-trigger-filter-overview_advanced-trigger-filters[Advanced trigger filters]

--- a/eventing/triggers/delete-triggers-cli.adoc
+++ b/eventing/triggers/delete-triggers-cli.adoc
@@ -4,6 +4,8 @@
 include::_attributes/common-attributes.adoc[]
 :context: delete-triggers-cli
 
+toc::[]
+
 [role="_abstract"]
 Using the Knative (`kn`) CLI to delete a trigger provides a streamlined and intuitive user interface. 
 

--- a/eventing/triggers/describe-triggers-cli.adoc
+++ b/eventing/triggers/describe-triggers-cli.adoc
@@ -1,8 +1,10 @@
 :_mod-docs-content-type: ASSEMBLY
-include::_attributes/common-attributes.adoc[]
 [id="describe-triggers-cli"]
 = Describe triggers from the command line
+include::_attributes/common-attributes.adoc[]
 :context: describe-triggers-cli
+
+toc::[]
 
 [role="_abstract"]
 Using the Knative (`kn`) CLI to describe triggers provides a streamlined and intuitive user interface.

--- a/eventing/triggers/filter-triggers-cli.adoc
+++ b/eventing/triggers/filter-triggers-cli.adoc
@@ -1,11 +1,12 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="filter-triggers-cli"]
 = Filtering triggers from the command line
+include::_attributes/common-attributes.adoc[]
 :context: filter-triggers-cli
 
-[role="_abstract"]
-include::_attributes/common-attributes.adoc[]
+toc::[]
 
+[role="_abstract"]
 Using the Knative (`kn`) CLI to filter events by using triggers provides a streamlined and intuitive user interface. You can use the `kn trigger create` command, along with the appropriate flags, to filter events by using triggers.
 
 include::modules/kn-trigger-filtering.adoc[leveloffset=+1]

--- a/eventing/triggers/list-triggers-cli.adoc
+++ b/eventing/triggers/list-triggers-cli.adoc
@@ -1,8 +1,10 @@
 :_mod-docs-content-type: ASSEMBLY
-include::_attributes/common-attributes.adoc[]
 [id="list-triggers-cli"]
 = List triggers from the command line
+include::_attributes/common-attributes.adoc[]
 :context: list-triggers-cli
+
+toc::[]
 
 [role="_abstract"]
 Using the Knative (`kn`) CLI to list triggers provides a streamlined and intuitive user interface. 

--- a/eventing/triggers/serverless-triggers.adoc
+++ b/eventing/triggers/serverless-triggers.adoc
@@ -1,14 +1,13 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="serverless-triggers"]
 = Triggers overview
-:context: serverless-triggers
 include::_attributes/common-attributes.adoc[]
+:context: serverless-triggers
 
 toc::[]
 
 [role="_abstract"]
-Triggers are an essential component in Knative Eventing that connect specific event sources to subscriber services based on defined filters. By creating a Trigger, you can dynamically manage how events are routed within your system, ensuring they reach the appropriate destination based on your business logic.
+Triggers are an essential component in Knative Eventing that connect event sources to subscriber services based on defined filters. You can create a trigger to manage event routing dynamically within your system and ensure that events reach the appropriate destination based on your business logic.
 
 include::snippets/serverless-brokers-intro.adoc[]
 
-//If you are using a Knative broker for Apache Kafka, you can configure the delivery order of events from triggers to event sinks. See xref:../../eventing/triggers/serverless-triggers.adoc#trigger-event-delivery-config_serverless-triggers[Configuring event delivery ordering for triggers].

--- a/eventing/triggers/triggers-event-delivery-order.adoc
+++ b/eventing/triggers/triggers-event-delivery-order.adoc
@@ -7,10 +7,11 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 [role="_abstract"]
-In Knative Eventing, the delivery order of events plays a critical role in ensuring messages are processed according to application requirements. When using a Kafka broker, you can specify whether events should be delivered in order or without strict ordering. By configuring the delivery order, you can optimize event handling for use cases that require sequential processing or prioritize performance for unordered delivery.
+In Knative Eventing, event delivery order affects how applications process messages. When you use a Kafka broker, you can select ordered or unordered delivery. Configure the delivery order to support sequential processing or rank performance over ordering when strict order is not required.
 
 include::modules/config-event-delivery-order-for-triggers.adoc[leveloffset=+1]
 
-[id="next-steps_serverless-triggers"]
-== Next steps
-* Configure xref:../../eventing/serverless-event-delivery.adoc#serverless-configuring-event-delivery-examples_serverless-event-delivery[event delivery parameters] that are applied in cases where an event fails to be delivered to an event sink.
+[role="_additional-resources"]
+== Additional resources
+
+* xref:../../eventing/serverless-event-delivery.adoc#serverless-configuring-event-delivery-examples_serverless-event-delivery[Event delivery parameters]

--- a/eventing/triggers/update-triggers-cli.adoc
+++ b/eventing/triggers/update-triggers-cli.adoc
@@ -1,8 +1,10 @@
 :_mod-docs-content-type: ASSEMBLY
-include::_attributes/common-attributes.adoc[]
 [id="update-triggers-cli"]
 = Updating triggers from the command line
+include::_attributes/common-attributes.adoc[]
 :context: update-triggers-cli
+
+toc::[]
 
 [role="_abstract"]
 Using the Knative (`kn`) CLI to update triggers provides a streamlined and intuitive user interface. 

--- a/eventing/tuning/overriding-config-eventing.adoc
+++ b/eventing/tuning/overriding-config-eventing.adoc
@@ -1,27 +1,19 @@
 :_mod-docs-content-type: ASSEMBLY
-include::_attributes/common-attributes.adoc[]
 [id="overriding-config-eventing"]
 =  Overriding Knative Eventing system deployment configurations
+include::_attributes/common-attributes.adoc[]
 :context: overriding-config-eventing
 
 toc::[]
 
 [role="_abstract"]
-You can override the default configurations for some specific deployments by modifying the `workloads` spec in the `KnativeEventing` custom resource (CR). Currently, overriding default configuration settings is supported for the `eventing-controller`, `eventing-webhook`, and `imc-controller` fields, as well as for the `readiness` and `liveness` fields for probes.
-
-[IMPORTANT]
-====
-The `replicas` spec cannot override the number of replicas for deployments that use the Horizontal Pod Autoscaler (HPA), and does not work for the `eventing-webhook` deployment.
-====
-
-[NOTE]
-====
-You can only override probes that are defined in the deployment by default.
-====
+You can override the default configurations for specific deployments by modifying the `workloads` spec in the `KnativeEventing` custom resource (CR). Currently, overriding default configuration settings is supported for the `eventing-controller`, `eventing-webhook`, and `imc-controller` fields and for the `readiness` and `liveness` fields for probes.
 
 include::modules/knative-eventing-CR-system-deployments.adoc[leveloffset=+1]
+
 include::modules/knative-eventing-modifying-consumer-group-ids-and-topic-names.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources
+
 * link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#probe-v1-core[Probe configuration section of the Kubernetes API documentation]

--- a/eventing/tuning/serverless-ha.adoc
+++ b/eventing/tuning/serverless-ha.adoc
@@ -1,17 +1,18 @@
 :_mod-docs-content-type: ASSEMBLY
-include::_attributes/common-attributes.adoc[]
 [id="serverless-ha"]
 = High availability
+include::_attributes/common-attributes.adoc[]
 :context: serverless-ha
 
 toc::[]
 
 [role="_abstract"]
-include::snippets/serverless-ha-intro.adoc[]
+High availability (HA) keeps Kubernetes APIs operational during disruptions. If an active controller fails, another controller takes over and continues processing requests.
 
-HA in {ServerlessProductName} is available through leader election, which is enabled by default after the Knative Serving or Eventing control plane is installed. When using a leader election HA pattern, instances of controllers are already scheduled and running inside the cluster before they are required.
-These controller instances compete to use a shared resource, known as the leader election lock. The instance of the controller that has access to the leader election lock resource at any given time is called the leader.
+{ServerlessProductName} uses leader election for HA. After installation, the system runs multiple controller instances that compete for a shared leader election lock. The controller that holds the lock acts as the leader.
 
 include::modules/serverless-config-replicas-eventing.adoc[leveloffset=+1]
+
 include::modules/serverless-config-replicas-kafka.adoc[leveloffset=+1]
+
 include::modules/serverless-overriding-pdbs-eventing.adoc[leveloffset=+1]

--- a/modules/apiserversource-yaml.adoc
+++ b/modules/apiserversource-yaml.adoc
@@ -155,7 +155,7 @@ To verify that Kubernetes sends events to Knative, check the event-display logs 
 $ oc get ksvc event-display -o jsonpath='{.status.url}'
 ----
 +
-.Example browser page
+The following example displayes browser page:
 +
 image::serverless-apiserversource-eventdisplay-gui.png[Example visualization of ApiServerSource event]
 
@@ -166,7 +166,8 @@ image::serverless-apiserversource-eventdisplay-gui.png[Example visualization of 
 $ oc logs $(oc get pod -o name | grep event-display) -c user-container
 ----
 +
-.Example output
+You get an output similar to the following example:
++
 [source,terminal]
 ----
 ☁️  cloudevents.Event

--- a/modules/config-event-delivery-order-for-triggers.adoc
+++ b/modules/config-event-delivery-order-for-triggers.adoc
@@ -39,7 +39,7 @@ The supported consumer delivery guarantees are:
 +
 The default ordering guarantee is `unordered`.
 
-. Apply the `Trigger` object using the following command::
+. Apply the `Trigger` object using the following command:
 +
 [source,terminal]
 ----

--- a/modules/configuring-containersource-with-ossm.adoc
+++ b/modules/configuring-containersource-with-ossm.adoc
@@ -33,10 +33,13 @@ spec:
       containers:
       - image: quay.io/openshift-knative/knative-eventing-sources-event-display:latest
 ----
-<1> A namespace that is a member of the `ServiceMeshMemberRoll`.
-<2> This annotation injects {SMProductShortName} sidecars into the Knative service pods.
++
+--
+* `namespace: <namespace>`: A namespace that is a member of the `ServiceMeshMemberRoll`.
+* `sidecar.istio.io/inject: "true"`: This annotation injects {SMProductShortName} sidecars into the Knative service pods.
+--
 
-. Apply the `Service` resource:
+. Apply the `Service` resource by running the following command:
 +
 [source,terminal]
 ----
@@ -45,17 +48,18 @@ $ oc apply -f event-display-service.yaml
 
 . Create a `ContainerSource` object in a namespace that is member of the `ServiceMeshMemberRoll` and sink set to the `event-display`:
 +
-.Example `test-heartbeats-containersource.yaml` configuration file
+The following example displayes `test-heartbeats-containersource.yaml` configuration file:
++
 [source,yaml]
 ----
 apiVersion: sources.knative.dev/v1
 kind: ContainerSource
 metadata:
   name: test-heartbeats
-  namespace: <namespace> <1>
+  namespace: <namespace>
 spec:
   template:
-    metadata: <2>
+    metadata:
       annotations:
         sidecar.istio.io/inject": "true"
         sidecar.istio.io/rewriteAppHTTPProbers: "true"
@@ -77,10 +81,13 @@ spec:
       kind: Service
       name: event-display-service
 ----
-<1> A namespace that is part of the `ServiceMeshMemberRoll`.
-<2> These annotations enable {SMProductShortName} integration with the `ContainerSource` object.
++
+--
+* `namespace: <namespace>`: A namespace that is part of the `ServiceMeshMemberRoll`.
+* `metadata`: These annotations enable {SMProductShortName} integration with the `ContainerSource` object.
+--
 
-. Apply the `ContainerSource` resource:
+. Apply the `ContainerSource` resource by running the following command:
 +
 [source,terminal]
 ----
@@ -89,13 +96,15 @@ $ oc apply -f test-heartbeats-containersource.yaml
 
 . Optional: Verify that events reach the Knative event sink by checking the message dumper function logs:
 +
-.Example command
+You get an output similar to the following example command:
++
 [source,terminal]
 ----
 $ oc logs $(oc get pod -o name | grep event-display) -c user-container
 ----
 +
-.Example output
+You get an output similar to the following example:
++
 [source,terminal]
 ----
 ☁️  cloudevents.Event

--- a/modules/configuring-sinkbinding-with-ossm.adoc
+++ b/modules/configuring-sinkbinding-with-ossm.adoc
@@ -5,7 +5,7 @@
 = Configuring a sink binding with {SMProductShortName}
 
 [role="_abstract"]
-This procedure describes how to configure a sink binding with {SMProductShortName}.
+Learn how to configure a sink binding with {SMProductShortName}.
 
 .Prerequisites
 
@@ -15,28 +15,29 @@ This procedure describes how to configure a sink binding with {SMProductShortNam
 
 . Create a `Service` object in a namespace that is member of the `ServiceMeshMemberRoll`:
 +
-.Example `event-display-service.yaml` configuration file
+The following example displays `event-display-service.yaml` configuration file:
++
 [source,yaml]
 ----
 apiVersion: serving.knative.dev/v1
 kind: Service
 metadata:
   name: event-display
-  namespace: <namespace> <1>
+  namespace: <namespace>
 spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/inject: "true" <2>
+        sidecar.istio.io/inject: "true"
         sidecar.istio.io/rewriteAppHTTPProbers: "true"
     spec:
       containers:
       - image: quay.io/openshift-knative/knative-eventing-sources-event-display:latest
 ----
-<1> A namespace that is a member of the `ServiceMeshMemberRoll`.
-<2> This annotation injects {SMProductShortName} sidecars into the Knative service pods.
+* `namespace: <namespace>`: a namespace that is a member of the `ServiceMeshMemberRoll`.
+* `sidecar.istio.io/inject: "true"`: This annotation injects {SMProductShortName} sidecars into the Knative service pods.
 
-. Apply the `Service` object:
+. Apply the `Service` object by running the following command:
 +
 [source,terminal]
 ----
@@ -45,18 +46,19 @@ $ oc apply -f event-display-service.yaml
 
 . Create a `SinkBinding` object:
 +
-.Example `heartbeat-sinkbinding.yaml` configuration file
+The following example displays `heartbeat-sinkbinding.yaml` configuration file:
++
 [source,yaml]
 ----
 apiVersion: sources.knative.dev/v1alpha1
 kind: SinkBinding
 metadata:
   name: bind-heartbeat
-  namespace: <namespace> <1>
+  namespace: <namespace>
 spec:
   subject:
     apiVersion: batch/v1
-    kind: Job <2>
+    kind: Job
     selector:
       matchLabels:
         app: heartbeat-cron
@@ -67,10 +69,10 @@ spec:
       kind: Service
       name: event-display
 ----
-<1> A namespace that is part of the `ServiceMeshMemberRoll`.
-<2> Bind any Job with the label `app: heartbeat-cron` to the event sink.
+* `namespace: <namespace>`: A namespace that is part of the `ServiceMeshMemberRoll`.
+* `kind: Job`: Bind any Job with the label `app: heartbeat-cron` to the event sink.
 
-. Apply the `SinkBinding` object:
+. Apply the `SinkBinding` object by running the following command:
 +
 [source,terminal]
 ----
@@ -79,14 +81,15 @@ $ oc apply -f heartbeat-sinkbinding.yaml
 
 . Create a `CronJob` object:
 +
-.Example `heartbeat-cronjob.yaml` configuration file
+The following example displays `heartbeat-cronjob.yaml` configuration file:
++
 [source,yaml]
 ----
 apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: heartbeat-cron
-  namespace: <namespace> <1>
+  namespace: <namespace>
 spec:
   # Run every minute
   schedule: "* * * * *"
@@ -99,7 +102,7 @@ spec:
       template:
         metadata:
           annotations:
-            sidecar.istio.io/inject: "true" <2>
+            sidecar.istio.io/inject: "true"
             sidecar.istio.io/rewriteAppHTTPProbers: "true"
         spec:
           restartPolicy: Never
@@ -120,10 +123,10 @@ spec:
                     fieldRef:
                       fieldPath: metadata.namespace
 ----
-<1> A namespace that is part of the `ServiceMeshMemberRoll`.
-<2> Inject Service Mesh sidecars into the `CronJob` pods.
+* `namespace: <namespace>`: A namespace that is part of the `ServiceMeshMemberRoll`.
+* `sidecar.istio.io/inject: "true"`: Inject Service Mesh sidecars into the `CronJob` pods.
 
-. Apply the `CronJob` object:
+. Apply the `CronJob` object by running the following command:
 +
 [source,terminal]
 ----
@@ -132,13 +135,15 @@ $ oc apply -f heartbeat-cronjob.yaml
 
 . Optional: Verify that the events reach the Knative event sink by checking the message dumper function logs:
 +
-.Example command
+You get an output similar to the following example command:
++
 [source,terminal]
 ----
 $ oc logs $(oc get pod -o name | grep event-display) -c user-container
 ----
 +
-.Example output
+You get an output similar to the following example:
++
 [source,terminal]
 ----
 ☁️  cloudevents.Event

--- a/modules/delete-kn-trigger.adoc
+++ b/modules/delete-kn-trigger.adoc
@@ -17,7 +17,7 @@ You can use the `kn trigger delete` command to delete a trigger.
 
 .Procedure
 
-* Delete a trigger:
+* Delete a trigger by running the following command:
 +
 [source,terminal]
 ----
@@ -26,7 +26,7 @@ $ kn trigger delete <trigger_name>
 
 .Verification
 
-. List existing triggers:
+. List existing triggers by running the following command:
 +
 [source,terminal]
 ----
@@ -35,7 +35,8 @@ $ kn trigger list
 
 . Verify that the trigger no longer exists:
 +
-.Example output
+You get an output similar to the following example:
++
 [source,terminal]
 ----
 No triggers found.

--- a/modules/kn-trigger-describe.adoc
+++ b/modules/kn-trigger-describe.adoc
@@ -24,7 +24,8 @@ You can use the `kn trigger describe` command to print information about existin
 $ kn trigger describe <trigger_name>
 ----
 +
-.Example output
+You get an output similar to the following example:
++
 [source,terminal]
 ----
 Name:         ping

--- a/modules/kn-trigger-filtering.adoc
+++ b/modules/kn-trigger-filtering.adoc
@@ -7,8 +7,6 @@
 = Filtering events with triggers by using the Knative CLI
 
 [role="_abstract"]
-// should be a procedure module but out of scope for this PR
-
 In the following trigger example, the trigger sends only events with the attribute `type: dev.knative.samples.helloworld` to the event sink:
 
 [source,terminal]

--- a/modules/kn-trigger-list.adoc
+++ b/modules/kn-trigger-list.adoc
@@ -16,14 +16,15 @@ You can use the `kn trigger list` command to list existing triggers in your clus
 
 .Procedure
 
-. Print a list of available triggers:
+. Print a list of available triggers by running the following command:
 +
 [source,terminal]
 ----
 $ kn trigger list
 ----
 +
-.Example output
+You get an output similar to the following example:
++
 [source,terminal]
 ----
 NAME    BROKER    SINK           AGE   CONDITIONS   READY   REASON
@@ -31,10 +32,9 @@ email   default   ksvc:edisplay   4s    5 OK / 5     True
 ping    default   ksvc:edisplay   32s   5 OK / 5     True
 ----
 
-. Optional: Print a list of triggers in JSON format:
+. Optional: Print a list of triggers in JSON format by running the following command:
 +
 [source,terminal]
 ----
 $ kn trigger list -o json
 ----
-//example output?

--- a/modules/kn-trigger-update.adoc
+++ b/modules/kn-trigger-update.adoc
@@ -17,7 +17,7 @@ You can use the `kn trigger update` command with certain flags to update attribu
 
 .Procedure
 
-* Update a trigger:
+* Update a trigger by running the following command:
 +
 [source,terminal]
 ----

--- a/modules/knative-eventing-CR-system-deployments.adoc
+++ b/modules/knative-eventing-CR-system-deployments.adoc
@@ -14,6 +14,11 @@ Currently, overriding default configuration settings is supported for the `event
 The `replicas` spec cannot override the number of replicas for deployments that use the Horizontal Pod Autoscaler (HPA), and does not work for the `eventing-webhook` deployment.
 ====
 
+[NOTE]
+====
+You can only override probes that are defined in the deployment by default.
+====
+
 In the following example, a `KnativeEventing` CR overrides the `eventing-controller` deployment so that:
 
 * The `eventing-controller readiness` probe timeout is 10 seconds.
@@ -23,7 +28,8 @@ In the following example, a `KnativeEventing` CR overrides the `eventing-control
 * The deployment includes the `example-annotation: annotation` annotation.
 * The `nodeSelector` field selects nodes with the `disktype: hdd` label.
 
-.`KnativeEventing` CR example
+The following example displayes `KnativeEventing` CR:
+
 [source,yaml]
 ----
 apiVersion: operator.knative.dev/v1beta1
@@ -53,7 +59,10 @@ spec:
     nodeSelector:
       disktype: hdd
 ----
-<1> You can use the `readiness` and `liveness` probe overrides to override all fields of a probe in a container of a deployment as specified in the Kubernetes API except for the fields related to the probe handler: `exec`, `grpc`, `httpGet`, and `tcpSocket`.
+
+--
+* `readinessProbes`: You can use the `readiness` and `liveness` probe overrides to override all fields of a probe in a container of a deployment as specified in the Kubernetes API except for the fields related to the probe handler: `exec`, `grpc`, `httpGet`, and `tcpSocket`.
+--
 
 [NOTE]
 ====

--- a/modules/knative-eventing-modifying-consumer-group-ids-and-topic-names.adoc
+++ b/modules/knative-eventing-modifying-consumer-group-ids-and-topic-names.adoc
@@ -31,15 +31,21 @@ metadata:
 spec:
   config:
     config-kafka-features:
-      triggers.consumergroup.template: <template> <1>
-      brokers.topic.template: <template> <2>
-      channels.topic.template: <template> <3>
+      triggers.consumergroup.template: <template>
+      brokers.topic.template: <template>
+      channels.topic.template: <template>
 ----
-<1> The template for generating the consumer group ID used by your triggers. Use a valid Go `text/template` value. Defaults to `+++"knative-trigger-{{ .Namespace }}-{{ .Name }}"+++`.
-<2> The template for generating Kafka topic names used by your brokers. Use a valid Go `text/template` value. Defaults to `+++"knative-broker-{{ .Namespace }}-{{ .Name }}"+++`.
-<3> The template for generating Kafka topic names used by your channels. Use a valid Go `text/template` value. Defaults to `+++"messaging-kafka.{{ .Namespace }}.{{ .Name }}"+++`.
 +
-.Example template configuration
+--
+* `triggers.consumergroup.template`: The template for generating the consumer group ID used by your triggers. Use a valid Go `text/template` value. Defaults to `+++"knative-trigger-{{ .Namespace }}-{{ .Name }}"+++`.
+
+* `brokers.topic.template`: The template for generating Kafka topic names used by your brokers. Use a valid Go `text/template` value. Defaults to `+++"knative-broker-{{ .Namespace }}-{{ .Name }}"+++`.
+
+* `channels.topic.template`: The template for generating Kafka topic names used by your channels. Use a valid Go `text/template` value. Defaults to `+++"messaging-kafka.{{ .Namespace }}.{{ .Name }}"+++`.
+--
++
+The following example displayes template configuration:
++
 [source,yaml]
 ----
 apiVersion: v1
@@ -56,7 +62,7 @@ spec:
       channels.topic.template: "{% raw %}"messaging-kafka.{{ .Namespace }}.{{ .Name }}-{{ .annotations.my-annotation }}"{% endraw %}"
 ----
 
-. Apply the `KnativeKafka` YAML file:
+. Apply the `KnativeKafka` YAML file by running the following command:
 +
 [source,yaml]
 ----

--- a/modules/serverless-broker-types-production.adoc
+++ b/modules/serverless-broker-types-production.adoc
@@ -1,0 +1,10 @@
+// Module included in the following assemblies:
+//
+// * /serverless/eventing/brokers/serverless-broker-types
+
+:_mod-docs-content-type: REFERENCE
+[id="serverless-broker-types-production_{context}"]
+= Production-ready Knative broker implementation for Apache Kafka
+
+[role="_abstract"]
+You can use the Apache Kafka broker implementation to give scalable, durable, and production-ready event delivery in {ServerlessProductName}.

--- a/modules/serverless-channel-default.adoc
+++ b/modules/serverless-channel-default.adoc
@@ -46,10 +46,13 @@ spec:
               numPartitions: 1
               replicationFactor: 1
 ----
-<1> In `spec.config`, you can specify the config maps that you want to add modified configurations for.
-<2> You can use the `default-ch-webhook` config map to specify the default channel implementation for the cluster or for one or more namespaces.
-<3> The cluster-wide default channel type configuration. In this example, the default channel implementation for the cluster is `InMemoryChannel`.
-<4> The namespace-scoped default channel type configuration. In this example, the default channel implementation for the `my-namespace` namespace is `KafkaChannel`.
++
+--
+* In `spec.config`, you can specify the config maps that you want to add modified configurations for.
+*  You can use the `default-ch-webhook` config map to specify the default channel implementation for the cluster or for one or more namespaces.
+* `clusterDefault`: The cluster-wide default channel type configuration. In this example, the default channel implementation for the cluster is `InMemoryChannel`.
+* `namespaceDefaults`: The namespace-scoped default channel type configuration. In this example, the default channel implementation for the `my-namespace` namespace is `KafkaChannel`.
+--
 +
 [IMPORTANT]
 ====

--- a/modules/serverless-channel-implementations-types.adoc
+++ b/modules/serverless-channel-implementations-types.adoc
@@ -1,0 +1,18 @@
+// Module included in the following assemblies:
+//
+//  * serverless/eventing/channels/serverless-channel-default.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="serverless-channel-implementations-types_{context}"]
+= Channel implementation types
+
+[role="_abstract"]
+Learn the supported channel implementations in {ServerlessProductName} and their use cases.
+
+{ServerlessProductName} supports `InMemoryChannel` and `KafkaChannel` implementations. Use `InMemoryChannel` for development environments and `KafkaChannel` for production workloads.
+
+`InMemoryChannel` has the following limitations:
+
+* It does not persist events. If a pod goes down, events on that pod are lost.
+* It does not guarantee event ordering. Events received at the same time can be delivered in any order.
+* It does not retry delivery by default if a subscriber rejects an event. Configure retries by modifying the `delivery` spec in the `Subscription` object.

--- a/modules/serverless-channel-template-backing-channel.adoc
+++ b/modules/serverless-channel-template-backing-channel.adoc
@@ -1,0 +1,36 @@
+// Module included in the following assemblies:
+//
+//  * serverless/eventing/channels/serverless-channel-default.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="serverless-channel-template-backing-channel_{context}"]
+= Understanding channelTemplate and backing channels
+
+[role="_abstract"]
+Learn how Knative populates `channelTemplate` properties and creates backing channels for `Channel` objects.
+
+After you create a `Channel` object, a mutating admission webhook adds `spec.channelTemplate` properties based on the default channel implementation. For example, with an `InMemoryChannel` default implementation, the `Channel` object is displayed as follows:
+
+[source,yaml]
+----
+apiVersion: messaging.knative.dev/v1
+kind: Channel
+metadata:
+  name: example-channel
+  namespace: default
+spec:
+  channelTemplate:
+    apiVersion: messaging.knative.dev/v1
+    kind: InMemoryChannel
+----
+
+The channel controller creates a backing channel instance based on the `spec.channelTemplate` configuration.
+
+[NOTE]
+====
+You cannot change the `spec.channelTemplate` properties after creation because the default channel mechanism sets them.
+====
+
+This process creates two objects: a generic backing channel and an implementation-specific channel, such as `InMemoryChannel`. If you use a different default channel implementation, Knative creates the corresponding channel type, for example, a `KafkaChannel`.
+
+The backing channel acts as a proxy. It copies subscriptions to the user-created channel object and updates its status to match the backing channel.

--- a/modules/serverless-common-trigger-configurations.adoc
+++ b/modules/serverless-common-trigger-configurations.adoc
@@ -1,0 +1,67 @@
+// Module included in the following assemblies:
+//
+// * /serverless/eventing/triggers/create-trigger-odc.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="serverless-common-trigger-configurations_{context}"]
+= Common trigger configurations
+
+[role="_abstract"]
+The following examples displays common configurations for triggers, demonstrating how to route events to Knative services or custom endpoints:
+
+The following trigger routes all events from the default broker to the Knative Serving service named `my-service`:
+
+[source,yaml]
+----
+apiVersion: eventing.knative.dev/v1
+kind: Trigger
+metadata:
+  name: my-service-trigger
+spec:
+  broker: default
+  filter:
+    attributes:
+      type: dev.knative.foo.bar
+  subscriber:
+    ref:
+      apiVersion: serving.knative.dev/v1
+      kind: Service
+      name: my-service
+----
+
+[NOTE]
+====
+You can route all events without a `filter` attribute for debugging. This approach helps you observe and analyze incoming events, identify issues, and validate event flow through the broker before you apply specific filters.
+====
+
+To apply this trigger, you can save the configuration to a file, for example, `trigger.yaml` and run the following command:
+[source,terminal]
+----
+$ oc apply -f trigger.yaml
+----
+
+The following example displayes routing events to a custom path:
+
+This Trigger routes all events from the default broker to a custom path `/my-custom-path` on the service named `my-service`:
+
+[source,yaml]
+----
+apiVersion: eventing.knative.dev/v1
+kind: Trigger
+metadata:
+  name: my-service-trigger
+spec:
+  broker: default
+  subscriber:
+    ref:
+      apiVersion: v1
+      kind: Service
+      name: my-service
+    uri: /my-custom-path
+----
+
+You can save the configuration to a file, for example, `custom-path-trigger.yaml` and run the following command:
+[source,terminal]
+----
+$ oc apply -f custom-path-trigger.yaml
+----

--- a/modules/serverless-config-replicas-eventing.adoc
+++ b/modules/serverless-config-replicas-eventing.adoc
@@ -17,7 +17,6 @@ For Knative Eventing, the `mt-broker-filter` and `mt-broker-ingress` deployments
 .Prerequisites
 
 * You have cluster administrator permissions on {ocp-product-title}, or you have cluster or dedicated administrator permissions on {rosa-product-title} or {dedicated-product-title}.
-
 * You have installed the {ServerlessOperatorName} and Knative Eventing are  on your cluster.
 
 .Procedure
@@ -32,7 +31,8 @@ For Knative Eventing, the `mt-broker-filter` and `mt-broker-ingress` deployments
 
 . Change the number of replicas in the `KnativeEventing` CR:
 +
-.Example YAML
+You get an output similar to the following example:
++
 [source,yaml]
 ----
 apiVersion: operator.knative.dev/v1beta1
@@ -52,7 +52,8 @@ spec:
 Workload-specific configuration overrides the global setting for Knative Eventing.
 ====
 +
-.Example YAML
+You get an output similar to the following example:
++
 [source,yaml]
 ----
 apiVersion: operator.knative.dev/v1beta1
@@ -70,13 +71,15 @@ spec:
 
 . Verify that the deployment respects the high availability limits:
 +
-.Example command
+You get an output similar to the following example command:
++
 [source,terminal]
 ----
 $ oc get hpa -n knative-eventing
 ----
 +
-.Example output
+You get an output similar to the following example:
++
 [source,terminal]
 ----
 NAME                 REFERENCE                      TARGETS   MINPODS   MAXPODS   REPLICAS   AGE

--- a/modules/serverless-config-replicas-kafka.adoc
+++ b/modules/serverless-config-replicas-kafka.adoc
@@ -27,7 +27,8 @@ By default, the Knative broker implementation for Apache Kafka runs the `kafka-c
 
 . Change the number of replicas in the `KnativeKafka` CR:
 +
-.Example YAML
+You get an output similar to the following example:
++
 [source,yaml]
 ----
 apiVersion: operator.serverless.openshift.io/v1alpha1

--- a/modules/serverless-configuring-event-delivery-examples.adoc
+++ b/modules/serverless-configuring-event-delivery-examples.adoc
@@ -9,7 +9,8 @@
 [role="_abstract"]
 You can configure event delivery parameters for `Broker`, `Trigger`, `Channel`, and `Subscription` objects. If you configure event delivery parameters for a broker or channel, these parameters propagates to triggers or subscriptions created for those objects. You can also set event delivery parameters for triggers or subscriptions to override the settings for the broker or channel.
 
-.Example `Broker` object
+The following example displayes `Broker` object:
+
 [source,yaml]
 ----
 apiVersion: eventing.knative.dev/v1
@@ -29,7 +30,8 @@ spec:
 # ...
 ----
 
-.Example `Trigger` object
+The following example displayes `Trigger` object:
+
 [source,yaml]
 ----
 apiVersion: eventing.knative.dev/v1
@@ -50,7 +52,8 @@ spec:
 # ...
 ----
 
-.Example `Channel` object
+The following example displayes `Channel` object:
+
 [source,yaml]
 ----
 apiVersion: messaging.knative.dev/v1
@@ -70,7 +73,8 @@ spec:
 # ...
 ----
 
-.Example `Subscription` object
+The following example displayes `Subscription` object:
+
 [source,yaml]
 ----
 apiVersion: messaging.knative.dev/v1

--- a/modules/serverless-configuring-kube-rbac-proxy-resources-for-eventing.adoc
+++ b/modules/serverless-configuring-kube-rbac-proxy-resources-for-eventing.adoc
@@ -16,7 +16,8 @@ You can also override resource allocation for a specific deployment.
 
 The following configuration sets Knative Eventing `kube-rbac-proxy` minimum and maximum CPU and memory allocation:
 
-.`KnativeEventing` CR example
+The following example displayes `KnativeEventing` CR:
+
 [source,yaml]
 ----
 apiVersion: operator.knative.dev/v1beta1
@@ -27,12 +28,18 @@ metadata:
 spec:
   config:
     deployment:
-      "kube-rbac-proxy-cpu-request": "10m" <1>
-      "kube-rbac-proxy-memory-request": "20Mi" <2>
-      "kube-rbac-proxy-cpu-limit": "100m" <3>
-      "kube-rbac-proxy-memory-limit": "100Mi" <4>
+      "kube-rbac-proxy-cpu-request": "10m"
+      "kube-rbac-proxy-memory-request": "20Mi"
+      "kube-rbac-proxy-cpu-limit": "100m"
+      "kube-rbac-proxy-memory-limit": "100Mi"
 ----
-<1> Sets minimum CPU allocation.
-<2> Sets minimum RAM allocation.
-<3> Sets maximum CPU allocation.
-<4> Sets maximum RAM allocation.
+
+--
+* `"kube-rbac-proxy-cpu-request": "10m"`: Sets minimum CPU allocation.
+
+* `"kube-rbac-proxy-memory-request": "20Mi"`: Sets minimum RAM allocation.
+
+* `"kube-rbac-proxy-cpu-limit": "100m"`: Sets maximum CPU allocation.
+
+* `"kube-rbac-proxy-memory-limit": "100Mi"`: Sets maximum RAM allocation.
+--

--- a/modules/serverless-configuring-kube-rbac-proxy-resources-for-kafka.adoc
+++ b/modules/serverless-configuring-kube-rbac-proxy-resources-for-kafka.adoc
@@ -34,7 +34,9 @@ spec:
       "kube-rbac-proxy-memory-limit": "100Mi"
 ----
 
-`kube-rbac-proxy-cpu-request`:: Sets minimum CPU allocation.
-`kube-rbac-proxy-memory-request`:: Sets minimum RAM allocation.
-`kube-rbac-proxy-cpu-limit`:: Sets maximum CPU allocation.
-`kube-rbac-proxy-memory-limit`:: Sets maximum RAM allocation.
+--
+* `kube-rbac-proxy-cpu-request`: Sets minimum CPU allocation.
+* `kube-rbac-proxy-memory-request`: Sets minimum RAM allocation.
+* `kube-rbac-proxy-cpu-limit`: Sets maximum CPU allocation.
+* `kube-rbac-proxy-memory-limit`: Sets maximum RAM allocation.
+--

--- a/modules/serverless-containersource-guidelines.adoc
+++ b/modules/serverless-containersource-guidelines.adoc
@@ -9,8 +9,6 @@
 [role="_abstract"]
 The container source controller injects two environment variables: `K_SINK` and `K_CE_OVERRIDES`. The system resolves these variables from the sink and `ceOverrides` specifications. The system sends events to the sink URI specified in the `K_SINK` environment variable. Send the message as a `POST` request by using the `CloudEvent` HTTP format.
 
-.Example container images
-
 The following is an example of a heartbeats container image:
 
 [source,go]

--- a/modules/serverless-containersource-ossm.adoc
+++ b/modules/serverless-containersource-ossm.adoc
@@ -11,8 +11,6 @@ You can integrate {SMProductShortName} with `ContainerSource` event sources by i
 
 .Prerequisites
 
-// TODO link to ../serverless/integrations/serverless-ossm-setup.adoc#serverless-ossm-setup_serverless-ossm-setup
-
 * You have integrated {SMProductShortName} with {ServerlessProductName}.
 
 .Procedure
@@ -25,19 +23,22 @@ apiVersion: serving.knative.dev/v1
 kind: Service
 metadata:
   name: event-display
-  namespace: <namespace> <1>
+  namespace: <namespace>
 spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/inject: "true" <2>
+        sidecar.istio.io/inject: "true"
         sidecar.istio.io/rewriteAppHTTPProbers: "true"
     spec:
       containers:
       - image: quay.io/openshift-knative/showcase
 ----
-<1> A namespace that is a member of the `ServiceMeshMemberRoll`.
-<2> Injects {SMProductShortName} sidecars into the Knative service pods.
++
+--
+* `namespace: <namespace>`: A namespace that is a member of the `ServiceMeshMemberRoll`.
+* `sidecar.istio.io/inject: "true"`: Injects {SMProductShortName} sidecars into the Knative service pods.
+--
 
 . Apply the `Service` resource.
 +
@@ -54,10 +55,10 @@ apiVersion: sources.knative.dev/v1
 kind: ContainerSource
 metadata:
   name: test-heartbeats
-  namespace: <namespace> <1>
+  namespace: <namespace>
 spec:
   template:
-    metadata: <2>
+    metadata:
       annotations:
         sidecar.istio.io/inject: "true"
         sidecar.istio.io/rewriteAppHTTPProbers: "true"
@@ -78,8 +79,6 @@ spec:
       kind: Service
       name: event-display
 ----
-<1> A namespace is part of the `ServiceMeshMemberRoll`.
-<2> Enables {SMProductShortName} integration with a `ContainerSource` object.
 
 . Apply the `ContainerSource` resource.
 +
@@ -106,7 +105,8 @@ $ oc get pods
 $ oc logs $(oc get pod -o name | grep event-display) -c user-container
 ----
 +
-.Example output
+You get an output similar to the following example:
++
 [source,terminal]
 ----
 ☁️  cloudevents.Event

--- a/modules/serverless-containersource-reference.adoc
+++ b/modules/serverless-containersource-reference.adoc
@@ -47,7 +47,7 @@ You can use a container as an event source, by creating a `ContainerSource` obje
 
 |===
 
-.Template parameter example
+The following example displays `Template` parameter:
 [source,yaml]
 ----
 apiVersion: sources.knative.dev/v1
@@ -71,7 +71,7 @@ spec:
 ----
 
 [id="serverless-containersource-reference-cloudevent-overrides_{context}"]
-== CloudEvent overrides
+== `CloudEvent` overrides
 
 A `ceOverrides` definition provides overrides that control the `CloudEvent` output format and modifications sent to the sink. You can configure many fields for the `ceOverrides` definition.
 
@@ -94,7 +94,8 @@ A `ceOverrides` definition supports the following fields:
 Use only valid `CloudEvent` attribute names as extensions. Do not set specification-defined attributes in the extensions override configuration. For example, you cannot change the type attribute.
 ====
 
-.`CloudEvent` Overrides example
+The following example displays `CloudEvent` Overrides:
+
 [source,yaml]
 ----
 apiVersion: sources.knative.dev/v1
@@ -111,7 +112,8 @@ spec:
 
 This sets the `K_CE_OVERRIDES` environment variable on the `subject`:
 
-.Example output
+You get an output similar to the following example:
+
 [source,terminal]
 ----
 { "extensions": { "extra": "this is an extra attribute", "additional": "42" } }

--- a/modules/serverless-create-broker-kn.adoc
+++ b/modules/serverless-create-broker-kn.adoc
@@ -17,7 +17,7 @@ You can use Brokers in combination with triggers to deliver events from an event
 
 .Procedure
 
-* Create a broker:
+* Create a broker by running the following command:
 +
 [source,terminal]
 ----
@@ -33,7 +33,8 @@ $ kn broker create <broker_name>
 $ kn broker list
 ----
 +
-.Example output
+You get an output similar to the following example:
++
 [source,terminal]
 ----
 NAME      URL                                                                     AGE   CONDITIONS   READY   REASON

--- a/modules/serverless-create-channel-kn.adoc
+++ b/modules/serverless-create-channel-kn.adoc
@@ -32,7 +32,8 @@ For example, you can create an `InMemoryChannel` object:
 $ kn channel create mychannel --type messaging.knative.dev:v1:InMemoryChannel
 ----
 +
-.Example output
+You get an output similar to the following example:
++
 [source,terminal]
 ----
 Channel 'mychannel' created in namespace 'default'.
@@ -47,19 +48,11 @@ Channel 'mychannel' created in namespace 'default'.
 $ kn channel list
 ----
 +
-.Example output
+You get an output similar to the following example:
++
 [source,terminal]
 ----
 kn channel list
 NAME        TYPE              URL                                                     AGE   READY   REASON
 mychannel   InMemoryChannel   http://mychannel-kn-channel.default.svc.cluster.local   93s   True
-----
-
-.Deleting a channel
-// split into own module, out of scope for this PR
-* Delete a channel:
-+
-[source,terminal]
-----
-$ kn channel delete <channel_name>
 ----

--- a/modules/serverless-create-default-channel-yaml.adoc
+++ b/modules/serverless-create-default-channel-yaml.adoc
@@ -28,7 +28,7 @@ metadata:
   namespace: default
 ----
 
-. Apply the YAML file:
+. Apply the YAML file by running the following command:
 +
 [source,terminal]
 ----

--- a/modules/serverless-create-kafka-channel-yaml.adoc
+++ b/modules/serverless-create-kafka-channel-yaml.adoc
@@ -13,7 +13,7 @@ You can use YAML files to create Knative resources through a declarative API. De
 .Prerequisites
 
 * You have installed the {ServerlessOperatorName}, Knative Eventing, and the `KnativeKafka` custom resource on your {ocp-product-title} cluster.
-* Install the OpenShift CLI (`oc`).
+* You have installed the OpenShift CLI (`oc`).
 * You have created a project or have access to a project with the appropriate roles and permissions to create applications and other workloads in {ocp-product-title}.
 
 .Procedure
@@ -37,7 +37,7 @@ spec:
 Only the `v1beta1` version of the API for `KafkaChannel` objects on {ServerlessProductName} is supported. Do not use the `v1alpha1` version of this API, as this version is now deprecated.
 ====
 
-. Apply the `KafkaChannel` YAML file:
+. Apply the `KafkaChannel` YAML file by running the following command:
 +
 [source,terminal]
 ----

--- a/modules/serverless-create-kafka-namespaced-broker.adoc
+++ b/modules/serverless-create-kafka-namespaced-broker.adoc
@@ -16,7 +16,7 @@ To create a `KafkaNamespaced` broker, you must set the `eventing.knative.dev/bro
 
 * You have installed the {ServerlessOperatorName}, Knative Eventing, and the `KnativeKafka` custom resource on your {ocp-product-title} cluster.
 
-* You have access to an Apache Kafka instance, such as link:https://docs.redhat.com/en/documentation/red_hat_amq/2021.q3/html/amq_streams_on_openshift_overview/kafka-concepts_str#kafka-concepts-key_str[Red{nbsp}Hat AMQ Streams], and have created a Kafka topic.
+* You have access to an Apache Kafka instance and have created a Kafka topic.
 
 * You have created a project, or have access to a project, with the appropriate roles and permissions to create applications and other workloads in {ocp-product-title}.
 
@@ -32,20 +32,23 @@ apiVersion: eventing.knative.dev/v1
 kind: Broker
 metadata:
   annotations:
-    eventing.knative.dev/broker.class: KafkaNamespaced <1>
+    eventing.knative.dev/broker.class: KafkaNamespaced
   name: default
-  namespace: my-namespace <2>
+  namespace: my-namespace
 spec:
   config:
     apiVersion: v1
     kind: ConfigMap
-    name: my-config <2>
+    name: my-config
 ...
 ----
-<1> To use the Apache Kafka broker with isolated data planes, the broker class value must be `KafkaNamespaced`.
-<2> The referenced `ConfigMap` object `my-config` must be in the same namespace as the `Broker` object, in this case `my-namespace`.
++
+--
+* `eventing.knative.dev/broker.class: KafkaNamespaced`: To use the Apache Kafka broker with isolated data planes, the broker class value must be `KafkaNamespaced`.
+* `name: my-config`: The referenced `ConfigMap` object `my-config` must be in the same namespace as the `Broker` object, in this case `my-namespace`.
+--
 
-. Apply the Apache Kafka-based broker YAML file:
+. Apply the Apache Kafka-based broker YAML file by running the following command::
 +
 [source,terminal]
 ----

--- a/modules/serverless-create-kn-trigger.adoc
+++ b/modules/serverless-create-kn-trigger.adoc
@@ -17,7 +17,7 @@ You can use the `kn trigger create` command to create a trigger.
 
 .Procedure
 
-* Create a trigger:
+* Create a trigger by running the following command:
 +
 [source,terminal]
 ----

--- a/modules/serverless-create-trigger-odc.adoc
+++ b/modules/serverless-create-trigger-odc.adoc
@@ -29,7 +29,6 @@ Using the {ocp-product-title} web console provides a streamlined and intuitive u
 * After you create the subscription, view it on the *Topology* page, where a line connects the broker to the event sink.
 
 .Deleting a trigger
-// should be a separate module; out of scope for this PR
 
 . Navigate to the *Topology* page.
 . Click the trigger that you want to delete.

--- a/modules/serverless-creating-broker-labeling.adoc
+++ b/modules/serverless-creating-broker-labeling.adoc
@@ -42,13 +42,15 @@ You can verify broker creation by using the `oc` CLI or by viewing it in the *To
 $ oc -n <namespace> get broker <broker_name>
 ----
 +
-.Example command
+You get an output similar to the following example command:
++
 [source,terminal]
 ----
 $ oc -n default get broker default
 ----
 +
-.Example output
+You get an output similar to the following example:
++
 [source,terminal]
 ----
 NAME      READY     REASON    URL                                                                     AGE
@@ -58,4 +60,3 @@ default   True                http://broker-ingress.knative-eventing.svc.cluster
 . Optional: If you are using the {ocp-product-title} web console, you can navigate to the *Topology* view and observe that the broker exists:
 +
 image::odc-view-broker.png[View the broker in the web console Topology view]
-// need to add separate docs for broker in ODC - out of scope for this PR

--- a/modules/serverless-creating-integrationsource-for-timer.adoc
+++ b/modules/serverless-creating-integrationsource-for-timer.adoc
@@ -12,7 +12,7 @@ To create an `IntegrationSource` API that produces periodic messages with a cust
 .Prerequisites
 
 * You have the OpenShift CLI (oc) installed and logged in to the target cluster.
-* Specify the namespace where you will create the `IntegrationSource` resource.
+* You have specified the namespace where you will create the `IntegrationSource` resource.
 * A Knative broker or another event sink exists to receive the Amazon Simple Queue Service (SQS) events.
 
 .Procedure

--- a/modules/serverless-creating-kafka-broker.adoc
+++ b/modules/serverless-creating-kafka-broker.adoc
@@ -1,0 +1,10 @@
+// Module included in the following assemblies:
+//
+// * serverless/eventing/brokers/serverless-using-brokers.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="serverless-creating-kafka-broker_{context}"]
+= Creating an Apache Kafka broker when it is not configured as the default broker type
+
+[role="_abstract"]
+If your {ServerlessProductName} deployment is not configured to use Kafka broker as the default broker type, you can use one of the following procedures to create a Kafka-based broker.

--- a/modules/serverless-creating-subscriptions-kn.adoc
+++ b/modules/serverless-creating-subscriptions-kn.adoc
@@ -22,24 +22,20 @@ After you have created a channel and an event sink, you can create a subscriptio
 [source,terminal]
 ----
 $ kn subscription create <subscription_name> \
-  --channel <group:version:kind>:<channel_name> \ <1>
-  --sink <sink_prefix>:<sink_name> \ <2>
-  --sink-dead-letter <sink_prefix>:<sink_name> <3>
+  --channel <group:version:kind>:<channel_name> \
+  --sink <sink_prefix>:<sink_name> \
+  --sink-dead-letter <sink_prefix>:<sink_name>
 ----
-<1> Use `--channel` to specify the source of `CloudEvents` to process. You can give the channel name. If you do not use the default `InMemoryChannel` defined by the `Channel` custom resource, prefix the channel name with `<group:version:kind>` for the channel type. For example, use `messaging.knative.dev:v1beta1:KafkaChannel` for an Apache Kafka channel.
-<2> Use `--sink` to specify the event destination. By default, the system treats `<sink_name>` as a Knative service with that name in the same namespace as the subscription. Use one of the following prefixes to specify the sink type:
-`ksvc`:: A Knative service.
-`channel`:: Specify the channel to use as the destination. Reference only default channel types.
-`broker`:: An Eventing broker.
-<3> Optional: Use the optional `--sink-dead-letter` flag to specify a sink that receives events when delivery fails.
 +
-.Example command
+You get an output similar to the following example command:
++
 [source,terminal]
 ----
 $ kn subscription create mysubscription --channel mychannel --sink ksvc:event-display
 ----
 +
-.Example output
+You get an output similar to the following example:
++
 [source,terminal]
 ----
 Subscription 'mysubscription' created in namespace 'default'.
@@ -54,18 +50,10 @@ Subscription 'mysubscription' created in namespace 'default'.
 $ kn subscription list
 ----
 +
-.Example output
+You get an output similar to the following example:
++
 [source,terminal]
 ----
 NAME            CHANNEL             SUBSCRIBER           REPLY   DEAD LETTER SINK   READY   REASON
 mysubscription   Channel:mychannel   ksvc:event-display                              True
-----
-
-.Deleting a subscription
-// move to own procedure, out of scope for this PR
-* Delete a subscription:
-+
-[source,terminal]
-----
-$ kn subscription delete <subscription_name>
 ----

--- a/modules/serverless-creating-subscriptions-yaml.adoc
+++ b/modules/serverless-creating-subscriptions-yaml.adoc
@@ -18,6 +18,7 @@ After you create a channel and an event sink, create a subscription to deliver e
 .Procedure
 
 * Create a `Subscription` object:
+
 ** Create a YAML file and copy the following sample code into it:
 +
 [source,yaml]
@@ -25,31 +26,34 @@ After you create a channel and an event sink, create a subscription to deliver e
 apiVersion: messaging.knative.dev/v1
 kind: Subscription
 metadata:
-  name: my-subscription <1>
+  name: my-subscription
   namespace: default
 spec:
-  channel: <2>
+  channel:
     apiVersion: messaging.knative.dev/v1
     kind: Channel
     name: example-channel
-  delivery: <3>
+  delivery:
     deadLetterSink:
       ref:
         apiVersion: serving.knative.dev/v1
         kind: Service
         name: error-handler
-  subscriber: <4>
+  subscriber:
     ref:
       apiVersion: serving.knative.dev/v1
       kind: Service
       name: event-display
 ----
 +
-<1> Name of the subscription.
-<2> Configuration settings for the channel that the subscription connects to.
-<3> Configuration settings for event delivery. These settings define how the subscription handles events that the subscriber cannot receive. When you configure this option, the system sends failed events to the `deadLetterSink`. The system drops the event, does not try redelivery, and logs an error. The `deadLetterSink` value must be a link:https://pkg.go.dev/knative.dev/pkg/apis/duck/v1?tab=doc#Destination[Destination].
-<4> Configuration settings for the subscriber. The subscriber is the event sink that receives events from the channel.
-** Apply the YAML file:
+--
+* `name: my-subscription`: Name of the subscription.
+* `spec.channel`: Configuration settings for the channel that the subscription connects to.
+* `spec.delivery`: Configuration settings for event delivery. These settings define how the subscription handles events that the subscriber cannot receive. When you configure this option, the system sends failed events to the `deadLetterSink`. The system drops the event, does not try redelivery, and logs an error. The `deadLetterSink` value must be a `Destination`.
+* `spec.subscriber`: Configuration settings for the subscriber. The subscriber is the event sink that receives events from the channel.
+--
+
+** Apply the YAML file by running the following command:
 +
 [source,terminal]
 ----

--- a/modules/serverless-custom-event-source-containersource-intro.adoc
+++ b/modules/serverless-custom-event-source-containersource-intro.adoc
@@ -1,0 +1,10 @@
+// Module included in the following assemblies:
+//
+// * /serverless/eventing/event-sources/serverless-custom-event-sources.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="serverless-custom-event-source-containersource-intro_{context}"]
+= Container source
+
+[role="_abstract"]
+Container sources create a container image that generates events and sends events to a sink. You can use a container source to create a custom event source, by creating a container image and a `ContainerSource` object that uses your image URI.

--- a/modules/serverless-default-broker-implementation.adoc
+++ b/modules/serverless-default-broker-implementation.adoc
@@ -1,0 +1,12 @@
+// Module included in the following assemblies:
+//
+// * /serverless/eventing/brokers/serverless-broker-types
+
+:_mod-docs-content-type: REFERENCE
+[id="serverless-default-broker-implementation_{context}"]
+= Default broker implementation for development purposes
+
+[role="_abstract"]
+Knative provides a default, channel-based broker implementation. This channel-based broker can be used for development and testing purposes, but does not provide adequate event delivery guarantees for production environments. The broker is backed by the `InMemoryChannel` channel implementation by default.
+
+If you want to use Apache Kafka to reduce network hops, use the Knative broker implementation for Apache Kafka. Do not configure the channel-based broker to be backed by the `KafkaChannel` channel implementation.

--- a/modules/serverless-delete-channel-kn.adoc
+++ b/modules/serverless-delete-channel-kn.adoc
@@ -1,0 +1,25 @@
+// Module included in the following assemblies:
+//
+//  * /serverless/develop/serverless-creating-channels.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="serverless-delete-channel-kn_{context}"]
+= Deleting a channel by using the Knative CLI
+
+[role="_abstract"]
+You can delete a channel by using the `kn` command-line interface.
+
+.Prerequisites
+
+* You have installed the {ServerlessOperatorName} and Knative Eventing on the cluster.
+* You have installed the Knative (`kn`) CLI.
+* You have created a project or have access to a project with the appropriate roles and permissions to create applications and other workloads in {ocp-product-title}.
+
+.Procedure
+
+* Delete the channel by running the following command:
++
+[source,terminal]
+----
+$ kn channel delete <channel_name>
+----

--- a/modules/serverless-deleting-broker-injection.adoc
+++ b/modules/serverless-deleting-broker-injection.adoc
@@ -11,7 +11,7 @@ If you create a broker by injection and later want to delete it, you must delete
 
 .Prerequisites
 
-* Install the OpenShift CLI (`oc`).
+* You have installed the OpenShift CLI (`oc`).
 
 .Procedure
 
@@ -40,13 +40,15 @@ $ oc -n <namespace> delete broker <broker_name>
 $ oc -n <namespace> get broker <broker_name>
 ----
 +
-.Example command
+You get an output similar to the following example command:
++
 [source,terminal]
 ----
 $ oc -n default get broker default
 ----
 +
-.Example output
+You get an output similar to the following example:
++
 [source,terminal]
 ----
 No resources found.

--- a/modules/serverless-deleting-subscriptions-kn-cli.adoc
+++ b/modules/serverless-deleting-subscriptions-kn-cli.adoc
@@ -1,0 +1,33 @@
+// Module included in the following assemblies:
+//
+// * /serverless/develop/serverless-subs.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="serverless-deleting-subscriptions-kn-cli_{context}"]
+= Deleting a subscription by using the kn CLI
+
+[role="_abstract"]
+Delete an existing subscription in Knative Eventing by using the `kn` CLI.
+
+.Prerequisites
+
+* You have installed the {ServerlessOperatorName} and Knative Eventing on your {ocp-product-title} cluster.
+* You have installed the Knative (`kn`) CLI.
+* You have created a project or have access to a project with the appropriate roles and permissions to create applications and other workloads in {ocp-product-title}.
+* The subscription that you want to delete exists.
+
+.Procedure
+
+. Delete the subscription by running the following command:
++
+[source,terminal]
+----
+$ kn subscription delete <subscription_name>
+----
+
+. Optional: Verify that the subscription no longer exists by running the following command:
++
+[source,terminal]
+----
+$ kn subscription list
+----

--- a/modules/serverless-deleting-the-pingsource-using-yaml.adoc
+++ b/modules/serverless-deleting-the-pingsource-using-yaml.adoc
@@ -1,0 +1,32 @@
+// Module included in the following assemblies:
+//
+// * /serverless/eventing/event-sources/serverless-pingsource.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="serverless-deleting-the-pingsource-using-yaml_{context}"]
+= Deleting a ping source by using YAML
+
+[role="_abstract"]
+Delete a ping source by applying a YAML file with the `oc delete` command.
+
+.Prerequisites
+
+* You have logged in to the {ocp-product-title} web console.
+* You have installed the {ServerlessOperatorName}, Knative Serving and Knative Eventing on the cluster.
+* You have created a project or have access to a project with the appropriate roles and permissions to create applications and other workloads in {ocp-product-title}.
+
+.Procedure
+
+. Delete the ping source by running the following command:
++
+[source,terminal]
+----
+$ oc delete -f <filename>
+----
++
+You can see the following example command for reference:
++
+[source,terminal]
+----
+$ oc delete -f ping-source.yaml
+----

--- a/modules/serverless-deleting-the-pingsource.adoc
+++ b/modules/serverless-deleting-the-pingsource.adoc
@@ -1,0 +1,22 @@
+// Module included in the following assemblies:
+//
+// * /serverless/eventing/event-sources/serverless-pingsource.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="serverless-deleting-the-pingsource_{context}"]
+= Deleting a ping source
+
+[role="_abstract"]
+Delete a ping source from the *Topology* view in the {ocp-product-title} web console.
+
+.Prerequisites
+
+* You have logged in to the {ocp-product-title} web console.
+* You have installed the {ServerlessOperatorName}, Knative Serving and Knative Eventing on the cluster.
+* You have created a project or have access to a project with the appropriate roles and permissions to create applications and other workloads in {ocp-product-title}.
+
+.Procedure
+
+. In the {ocp-product-title} web console, navigate to the *Topology* view.
+
+. Right-click the ping source, and then click *Delete Ping Source*.

--- a/modules/serverless-describe-broker-kn.adoc
+++ b/modules/serverless-describe-broker-kn.adoc
@@ -16,20 +16,22 @@ Using the Knative (`kn`) CLI to describe brokers provides a streamlined and intu
 
 .Procedure
 
-* Describe an existing broker:
+* Describe an existing broker by running the following command:
 +
 [source,terminal]
 ----
 $ kn broker describe <broker_name>
 ----
 +
-.Example command by using default broker
+You can see the following example command for reference:
++
 [source,terminal]
 ----
 $ kn broker describe default
 ----
 +
-.Example output
+You get an output similar to the following example:
++
 [source,terminal]
 ----
 Name:         default

--- a/modules/serverless-describe-subs-kn.adoc
+++ b/modules/serverless-describe-subs-kn.adoc
@@ -16,14 +16,15 @@ You can use the `kn subscription describe` command to print information about a 
 
 .Procedure
 
-* Describe a subscription:
+* Describe a subscription by running the following command:
 +
 [source,terminal]
 ----
 $ kn subscription describe <subscription_name>
 ----
 +
-.Example output
+You get an output similar to the following example:
++
 [source,terminal]
 ----
 Name:            my-subscription

--- a/modules/serverless-event-advanced-jsonata-features.adoc
+++ b/modules/serverless-event-advanced-jsonata-features.adoc
@@ -14,7 +14,8 @@ You can use `JSONata` to transform events more effectively by applying advanced 
 
 `JSONata` makes it easy to work with arrays in event payloads. You can count items, filter them based on conditions, and calculate total values.
 
-.Example of processing items in an order and compute totals
+The following example displays how to process items in an order and compute totals:
+
 [source,json]
 ----
 {
@@ -89,7 +90,8 @@ In this example:
 
 `JSONata` includes a wide range of built-in functions that can manipulate strings, numbers, dates, and arrays. These functions can enrich events with new fields derived from existing data.
 
-.Example of adding metadata by using built-in functions
+The following example displays how to add metadata by using built-in functions:
+
 [source,terminal]
 ----
 {

--- a/modules/serverless-event-auth-advanced-cloudevent-filtering-criteria.adoc
+++ b/modules/serverless-event-auth-advanced-cloudevent-filtering-criteria.adoc
@@ -11,7 +11,8 @@ The `.spec.filters` method is optional and provides advanced criteria for event 
 
 For example, you can configure filters to allow only events of type `com.github.push`. You can also configure filters that match a `CloudEvents` SQL (CESQL) expression for event types such as order.created, order.updated, or order.canceled.
 
-.Example of `spec.filters` method
+The following example displayes `spec.filters` method:
+
 [source,yaml]
 ----
 filters:

--- a/modules/serverless-event-auth-applying-eventpolicy.adoc
+++ b/modules/serverless-event-auth-applying-eventpolicy.adoc
@@ -123,7 +123,7 @@ spec:
 +
 At this stage, OIDC remains disabled and no `EventPolicy` exists, so the event-display service shows events from both `PingSources`.
 
-. Enable OIDC in Knative Eventing and create an `EventPolicy` by executing the following example command:
+. Enable OIDC in Knative Eventing and create an `EventPolicy` by running the following example command:
 +
 [source,terminal]
 ----
@@ -157,35 +157,35 @@ spec:
 
 .Verification
 
-. Verify the `EventPolicy` to check the Broker status by executing the following command:
+. Verify the `EventPolicy` to check the Broker status by running the following command:
 +
 [source,terminal]
 ----
 $ oc -n namespace-1 get broker broker -o yaml
 ----
 
-. View logs from the event-display service to confirm only `pingsource-2` events arrive by executing the following command:
+. View logs from the event-display service to confirm only `pingsource-2` events arrive by running the following command:
 +
 [source,terminal]
 ----
 $ oc -n namespace-1 logs -f -l app=event-display
 ----
 
-. Delete the `EventPolicy` by executing the following command:
+. Delete the `EventPolicy` by running the following command:
 +
 [source,terminal]
 ----
 $ oc -n namespace-1 delete eventpolicy event-policy
 ----
 
-. Check the Broker status to confirm it has returned to the default `allow-same-namespace` mode by executing the following command:
+. Check the Broker status to confirm it has returned to the default `allow-same-namespace` mode by running the following command:
 +
 [source,terminal]
 ----
 $ oc -n namespace-1 get broker broker -o yaml
 ----
 
-. View the event-display service logs to confirm that only `pingsource-1` events from the same namespace appear by executing the following command:
+. View the event-display service logs to confirm that only `pingsource-1` events from the same namespace appear by running the following command:
 +
 [source,terminal]
 ----

--- a/modules/serverless-event-auth-defining-senders.adoc
+++ b/modules/serverless-event-auth-defining-senders.adoc
@@ -14,7 +14,8 @@ The `.spec.from` field specifies the entities that can send events to the resour
 
 The `from.ref` method directly references an event source resource. For example, referencing a `PingSource` in a different namespace ensures that only that specific source can deliver events to the defined targets.
 
-.Example of `from.ref` method
+The following example displayes `from.ref` method:
+
 [source,yaml]
 ----
 from:
@@ -30,7 +31,8 @@ from:
 
 The from.sub field specifies subjects, such as service accounts, which can send events. You can use wildcard patterns with `*` to allow many accounts that match a pattern. For example, an `EventPolicy` can allow one trusted service account and allow all accounts that begin with other- in the same namespace.
 
-.Example of `from.sub` method
+The following example displayes `from.sub` method:
+
 [source,yaml]
 ----
 from:

--- a/modules/serverless-event-auth-defining-targets.adoc
+++ b/modules/serverless-event-auth-defining-targets.adoc
@@ -14,7 +14,8 @@ The `.spec.to` field determines that consumers an `EventPolicy` applies to. If y
 
 The `to.ref` method directly references a specific resource by name. For example, referencing a Broker named `my-broker` applies the `EventPolicy` only to that specific Broker. This method is most appropriate when you want to protect or restrict access to a well-defined, individual resource.
 
-.Example of `to.ref` method
+The following example displayes `to.ref` method:
+
 [source,yaml]
 ----
 to:
@@ -29,7 +30,8 @@ to:
 
 The `to.selector` method uses label selectors to match many resources of a specific type. For example, specifying a label selector with `app: special-app` applies the `EventPolicy` to all Brokers that share that label. This method is suitable when you want the same authorization rules applied across a group of similar resources.
 
-.Example of `to.selector` method
+The following example displayes `to.selector` method:
+
 [source,yaml]
 ----
 to:

--- a/modules/serverless-event-common-transformation-patterns.adoc
+++ b/modules/serverless-event-common-transformation-patterns.adoc
@@ -14,7 +14,8 @@ To effectively shape your event data, you can use common `JSONata` transformatio
 
 You can add or adjust attributes while keeping the rest of the event unchanged, so that downstream consumers receive the original data with minimal modifications.
 
-.Example of adding a static attribute while preserving the original event structure
+The following example displays how to add a static attribute while preserving the original event structure:
+
 [source,json]
 ----
 {
@@ -33,7 +34,8 @@ You can add or adjust attributes while keeping the rest of the event unchanged, 
 
 You can promote values from the payload to top-level `CloudEvent` attributes to make filtering and routing easier.
 
-.Example of extracting user ID and region from the payload and expose them as attributes
+The following example displays how to extract user ID and region from the payload and expose them as attributes:
+
 [source,json]
 ----
 {
@@ -55,7 +57,8 @@ In `JSONata`, the `$` symbol represents the entire input object. Using `data: $`
 
 Use `JSONata` to transform events into the schema required by another system by restructuring payloads, renaming fields, nesting objects, and performing calculations.
 
-.Example of restructuring an order event and calculate the total value of items
+The following example displays how to restructure an order event and calculate the total value of items:
+
 [source,json]
 ----
 {
@@ -137,7 +140,8 @@ Use this pattern to integrate with APIs that require specific structures or calc
 
 With `JSONata`, you can embed conditional logic directly into your transformation, enabling dynamic event shaping based on attributes or payload values.
 
-.Example of applying different types and priorities based on conditions
+The following example displays how to apply different types and priorities based on conditions:
+
 [source,json]
 ----
 {

--- a/modules/serverless-event-delivery-parameters.adoc
+++ b/modules/serverless-event-delivery-parameters.adoc
@@ -9,11 +9,15 @@
 [role="_abstract"]
 You can configure the following parameters for event delivery:
 
+[IMPORTANT]
+====
+If an event is successfully delivered to a channel or broker receiver for Apache Kafka, the receiver responds with a `202` status code, which means that the event has been safely stored inside a Kafka topic and is not lost. If the receiver responds with any other status code, the event is not safely stored, and steps must be taken by the user to resolve the issue.
+====
+
 Dead letter sink:: You can configure the `deadLetterSink` delivery parameter to store events that fail delivery in the specified event sink. The system drops undelivered events that are not stored in a dead letter sink. The dead letter sink can be any addressable object that conforms to the Knative Eventing sink contract, such as a Knative service, a Kubernetes service, or a URI.
 
 Retries:: You can configure the retry delivery parameter with an integer value to set the minimum number of delivery attempts before the system sends the event to the dead letter sink.
 
-Back off delay:: You can set the `backoffDelay` delivery parameter to specify the delay before the system retries event delivery after a failure. Specify the `backoffDelay` value by using the https://en.wikipedia.org/wiki/ISO_8601#Durations[ISO
- 8601] duration format. For example, `PT1S` specifies a delay of `1` second.
+Back off delay:: You can set the `backoffDelay` delivery parameter to specify the delay before the system retries event delivery after a failure. Specify the `backoffDelay` value by using the `ISO 8601` duration format. For example, `PT1S` specifies a delay of `1` second.
 
 Back off policy:: You can use the `backoffPolicy` delivery parameter to specify the retry backoff policy. Specify the policy as either `linear` or `exponential`. With the `linear` policy, the system calculates the backoff delay as `backoffDelay * <numberOfRetries>`. With the `exponential` policy, the system calculates the backoff delay as `backoffDelay * 2^<numberOfRetries>`.

--- a/modules/serverless-event-sink-addressable-callable-objects.adoc
+++ b/modules/serverless-event-sink-addressable-callable-objects.adoc
@@ -1,0 +1,19 @@
+// Module included in the following assemblies:
+//
+// * serverless/eventing/event-sources/serverless-event-sinks.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="serverless-event-sink-addressable-callable-objects_{context}"]
+= Understanding addressable and callable objects
+
+[role="_abstract"]
+Learn how addressable and callable objects handle events in Knative Eventing.
+
+Addressable objects receive and acknowledge events delivered over HTTP to an address defined in the `status.address.url` field. The core Kubernetes `Service` object also satisfies the addressable interface.
+
+Callable objects receive events delivered over HTTP, transform the events, and return `0` or `1` new events in the HTTP response. These returned events follow the same processing flow as events from an external event source.
+
+[NOTE]
+====
+You can configure which CRs can be used with the `--sink` flag for Knative (`kn`) CLI commands by Customizing `kn`.
+====

--- a/modules/serverless-event-transform-overview.adoc
+++ b/modules/serverless-event-transform-overview.adoc
@@ -1,0 +1,21 @@
+// Module included in the following assemblies:
+//
+// serverless/eventing/serverless-event-transformation.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="serverless-event-transform-overview_{context}"]
+= Overview of `EventTransform` in event-driven architectures
+
+[role="_abstract"]
+`EventTransform` is a flexible component for changing, extracting, and reshaping event data to meet the requirements of different systems. You can use it to integrate event producers and consumers by applying transformations at different stages of event processing.
+
+With `EventTransform`, you can:
+
+* Change event attributes
+* Extract data from event payloads
+* Reshape events to match target system requirements
+
+[NOTE]
+====
+`EventTransform` is an addressable resource. You can reference it from Knative sources, triggers, and subscriptions.
+====

--- a/modules/serverless-event-transformation-common-use-cases.adoc
+++ b/modules/serverless-event-transformation-common-use-cases.adoc
@@ -14,7 +14,8 @@ You can use `EventTransform` to manipulate and reshape events based on system re
 
 You can extract specific fields from event payloads and expose them as `CloudEvent` attributes. This makes it easier to filter and route events downstream.
 
-.Example of extracting user ID from an event payload
+The following example displays how to extract user ID from an event payload:
+
 [source,yaml]
 ----
 apiVersion: eventing.knative.dev/v1alpha1
@@ -40,7 +41,8 @@ spec:
 
 You can convert the structure of an event into a different format so that it remains compatible with diverse consumer systems.
 
-.Example of converting an order event to a customer-centric format
+The following example displays how to convert an order event to a customer-centric format:
+
 [source,yaml]
 ----
 apiVersion: eventing.knative.dev/v1alpha1
@@ -77,7 +79,8 @@ spec:
 
 You can add fixed or dynamic metadata such as environment or region to events without requiring any changes in the original producer.
 
-.Example of adding environment and region metadata to the event
+The following example displays how to add environment and region metadata to the event:
+
 [source,yaml]
 ----
 apiVersion: eventing.knative.dev/v1alpha1
@@ -104,7 +107,8 @@ spec:
 
 You can transform not only the request sent to a sink but also the response received from the sink, enabling end-to-end event shaping.
 
-.Example of transforming both request and reply messages
+The following example displays how to transform both request and reply messages:
+
 [source,yaml]
 ----
 apiVersion: eventing.knative.dev/v1alpha1

--- a/modules/serverless-event-transformation-json-with-jsonata.adoc
+++ b/modules/serverless-event-transformation-json-with-jsonata.adoc
@@ -11,7 +11,8 @@
 
 You can specify a `JSONata` expression in the `spec.jsonata.expression` field of the `EventTransform` resource. The expression maps the incoming `CloudEvent` into a new `CloudEvent` as shown in the following example: 
 
-.Example of simple event transformation by using `JSONata`
+The following example displays simple event transformation by using `JSONata`:
+
 [source,yaml]
 ----
 apiVersion: eventing.knative.dev/v1alpha1
@@ -63,7 +64,7 @@ Your `JSONata` expression must produce a valid `CloudEvent`. At a minimum, inclu
 
 |`data`
 |Required
-|Contains the event payload being delivered.
+|Has the event payload being delivered.
 
 |====
 

--- a/modules/serverless-eventing-eventpolicy-securing-event-delivery.adoc
+++ b/modules/serverless-eventing-eventpolicy-securing-event-delivery.adoc
@@ -1,0 +1,17 @@
+// Module included in the following assemblies:
+//
+// * /serverless/Eventing/serverless-event-authorization-eventpolicy.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="serverless-eventing-eventpolicy-securing-event-delivery_{context}"]
+= EventPolicy for securing event delivery
+
+[role="_abstract"]
+To achieve fine-grained access control, Knative Eventing introduces the `EventPolicy` custom resource. This resource allows administrators and developers to define which entities can send events to specific consumers within a namespace. 
+
+You can apply `EventPolicies` to ensure that only trusted event sources or service accounts can send data to selected event consumers. This approach improves the overall security of your event-driven architecture.
+
+[NOTE]
+====
+You must enable the `transport-encryption` feature flag along with `authentication-oidc` to ensure secure and authenticated event delivery.
+====

--- a/modules/serverless-integrationsink-aws-simple-notification-service.adoc
+++ b/modules/serverless-integrationsink-aws-simple-notification-service.adoc
@@ -7,6 +7,6 @@
 = AWS SNS with IntegrationSink
 
 [role="_abstract"]
-The Amazon Web Services (AWS) Simple Notification Service (SNS) Kamelet enables you to deliver CloudEvents from Knative Eventing to an SNS topic. This integration is useful when you need broad distribution like email, SMS, HTTP subscribers, SQS queues, Lambda functions, etc. via SNS subscriptions.
+You can use the Amazon Web Services (AWS) Simple Notification Service (SNS) Kamelet to deliver `CloudEvents` from Knative Eventing to an SNS topic. Distribute events to subscribers such as email, Short Message Service (SMS), HTTP endpoints, Amazon SQS queues, and AWS Lambda functions.
 
-To configure an `IntegrationSink` API resource for AWS SNS, reference a Kubernetes Secret with valid AWS credentials, specify the SNS topic Amazon Resource Name (ARN) and region, and configure the event source that will produce the CloudEvents.
+To configure an `IntegrationSink` API resource for AWS SNS, reference a Kubernetes Secret with valid AWS credentials, specify the SNS topic Amazon Resource Name (ARN) and region, and configure the event source that produces `CloudEvents`.

--- a/modules/serverless-integrationsink-aws-simple-queue-service.adoc
+++ b/modules/serverless-integrationsink-aws-simple-queue-service.adoc
@@ -7,6 +7,6 @@
 = AWS SQS with IntegrationSink
 
 [role="_abstract"]
-The Amazon Web Services (AWS) Simple Queue Service (SQS) Kamelet allows you to send CloudEvents from Knative Eventing into an SQS queue. This integration is useful when you need reliable, decoupled message delivery between event producers and consumers, or when downstream systems process events asynchronously from a queue.
+The Amazon Web Services (AWS) Simple Queue Service (SQS) Kamelet allows you to send `CloudEvents` from Knative Eventing into an SQS queue. This integration is useful when you need reliable, decoupled message delivery between event producers and consumers, or when downstream systems process events asynchronously from a queue.
 
-To configure an `IntegrationSink` API resource for AWS SQS, you must reference a Kubernetes Secret with valid AWS credentials, specify the queue Amazon Resource Name (ARN) and region, and configure the event source that produces the CloudEvents.
+To configure an `IntegrationSink` API resource for AWS SQS, you must reference a Kubernetes Secret with valid AWS credentials, specify the queue Amazon Resource Name (ARN) and region, and configure the event source that produces the `CloudEvents`.

--- a/modules/serverless-integrationsink-aws-simple-storage-service.adoc
+++ b/modules/serverless-integrationsink-aws-simple-storage-service.adoc
@@ -7,6 +7,6 @@
 = AWS S3 with IntegrationSink
 
 [role="_abstract"]
-The Amazon Web Services (AWS) Simple Storage Service (S3) Kamelet allows you to deliver CloudEvents from Knative Eventing into an Amazon S3 bucket. This integration makes it possible to store events as objects for long-term storage, analytics, or downstream processing.
+You can use the Amazon Web Services (AWS) Simple Storage Service (S3) Kamelet to deliver `CloudEvents` from Knative Eventing to an Amazon S3 bucket. Store events as objects for long-term storage, analytics, or downstream processing.
 
-To configure an `IntegrationSink` API for AWS S3, you must reference a Kubernetes Secret with valid AWS credentials, specify the Amazon S3 bucket Amazon Resource Name (ARN) and its region, and configure the source that produces the CloudEvents.
+To configure an `IntegrationSink` API for AWS S3, reference a Kubernetes Secret with valid AWS credentials, specify the S3 bucket Amazon Resource Name (ARN) and region, and configure the event source that produces `CloudEvents`.

--- a/modules/serverless-integrationsink-creating-aws-credentials.adoc
+++ b/modules/serverless-integrationsink-creating-aws-credentials.adoc
@@ -7,13 +7,13 @@
 = Creating AWS credentials
 
 [role="_abstract"]
-Several `IntegrationSink` API resources require access to Amazon Web Services (AWS) services such as S3, SNS, and SQS. To connect securely, you must create a Kubernetes Secret containing valid AWS credentials in the namespace where the `IntegrationSink` API resource will be created.
+Several `IntegrationSink` API resources require access to Amazon Web Services (AWS) services such as WS Simple Storage Service (S3), AWS Simple Notification Service (SNS), AWS Simple Queue Service (SQS). To connect securely, you must create a Kubernetes Secret containing valid AWS credentials in the namespace where the `IntegrationSink` API resource will be created.
 
-The Secret must include an AWS access key ID and secret access key with sufficient permissions to access the target AWS service. This Secret will then be referenced in each `IntegrationSink` configuration.
+The Secret must include an AWS access key ID and secret access key with enough permissions to access the target AWS service. This Secret will then be referenced in each `IntegrationSink` configuration.
 
 .Prerequisites
 
-* You have an AWS account with an access key ID and secret access key that provide access to the relevant service.
+* You have an AWS account with an access key ID and secret access key that give access to the relevant service.
 * You have the OpenShift CLI (oc) installed and are logged in to the cluster.
 * You have identified the namespace in which the `IntegrationSink` resource will be created.
 

--- a/modules/serverless-integrationsink-generic-logger-sink.adoc
+++ b/modules/serverless-integrationsink-generic-logger-sink.adoc
@@ -7,6 +7,6 @@
 = Generic logger sink with IntegrationSink
 
 [role="_abstract"]
-The Log Sink Kamelet allows you to output CloudEvents from Knative Eventing directly to the application log. This sink is primarily used for debugging or testing event flows, as it provides visibility into the event payloads and metadata without requiring an external system.
+You can use the Log Sink Kamelet to output `CloudEvents` from Knative Eventing to the application log. Use this sink for debugging or testing event flows, because it provides visibility into event payloads and metadata without requiring an external system.
 
 To configure a `IntegrationSink` API resource for the logger, you can set the logging level and optionally display event headers.

--- a/modules/serverless-integrationsource-aws-dynamodb-streams.adoc
+++ b/modules/serverless-integrationsource-aws-dynamodb-streams.adoc
@@ -7,6 +7,6 @@
 = AWS DynamoDB Streams with IntegrationSource
 
 [role="_abstract"]
-The Amazon Web Services (AWS) DynamoDB Streams Kamelet allows you to consume changes from an Amazon DynamoDB table and forward them into Knative Eventing. This integration makes it easier to react to database changes and propagate events within your serverless applications.
+You can use the Amazon Web Services (AWS) `DynamoDB` Streams Kamelet to consume changes from an Amazon `DynamoDB` table and forward them to Knative Eventing. This integration helps you react to database changes and propagate events in your serverless applications.
 
-To configure an `IntegrationSource` for DynamoDB Streams, you must provide valid AWS credentials, specify the DynamoDB table and its region, and define the event sink, such as a Knative broker.
+To configure an `IntegrationSource` for `DynamoDB` Streams, you must give valid AWS credentials, specify the `DynamoDB` table and its region, and define the event sink, such as a Knative broker.

--- a/modules/serverless-integrationsource-aws-simple-queue-service.adoc
+++ b/modules/serverless-integrationsource-aws-simple-queue-service.adoc
@@ -7,6 +7,6 @@
 = AWS SQS with IntegrationSource
 
 [role="_abstract"]
-The Amazon Web Services (AWS) Simple Queue Service (SQS) Kamelet enables you to consume messages from an Amazon SQS queue and forward them into Knative Eventing. This integration allows {ServerlessProductName} applications to react to queued messages, supporting event-driven architectures that decouple producers and consumers.
+You can use the Amazon Web Services (AWS) Simple Queue Service (SQS) Kamelet to consume messages from an Amazon SQS queue and send them to Knative Eventing. This integration helps {ServerlessProductName} applications react to queued messages and supports event-driven architectures that decouple producers and consumers.
 
-To configure an `IntegrationSource` for SQS, you must provide valid AWS credentials, specify the Amazon SQS queue Amazon Resource Name (ARN) and its region, and define the event sink, such as a Knative broker. The Amazon Resource Name (ARN) uniquely identifies the SQS queue across all AWS accounts and regions.
+You can configure an `IntegrationSource` for SQS by providing valid AWS credentials, specifying the SQS queue Amazon Resource Name (ARN) and region, and defining an event sink such as a Knative broker. The ARN uniquely identifies the SQS queue across AWS accounts and regions.

--- a/modules/serverless-integrationsource-aws-simple-storage-service.adoc
+++ b/modules/serverless-integrationsource-aws-simple-storage-service.adoc
@@ -7,6 +7,6 @@
 = AWS S3 with IntegrationSource
 
 [role="_abstract"]
-The Amazon Web Services (AWS) Simple Storage Service (S3) Kamelet allows you to consume object storage events such as file uploads or updates from an Amazon S3 bucket and forward them into Knative Eventing. This integration helps {ServerlessProductName} applications react to changes in object storage, such as new files or data updates, without the need for polling.
+You can use the Amazon Web Services (AWS) Simple Storage Service (S3) Kamelet to consume object storage events from an Amazon S3 bucket and send them to Knative Eventing. This integration helps {ServerlessProductName} applications react to changes without polling.
 
-To configure an `IntegrationSource` for S3, you must provide valid AWS credentials, specify the Amazon S3 bucket Amazon Resource Name (ARN) and its region, and define the event sink, such as a Knative broker.
+You can configure an `IntegrationSource` for S3 by providing valid AWS credentials, specifying the S3 bucket Amazon Resource Name (ARN) and region, and defining an event sink such as a Knative broker.

--- a/modules/serverless-integrationsource-creating-aws-credentials.adoc
+++ b/modules/serverless-integrationsource-creating-aws-credentials.adoc
@@ -7,7 +7,7 @@
 = Creating AWS credentials
 
 [role="_abstract"]
-To connect to Amazon Web Services (AWS) resources, the `IntegrationSource` requires a Kubernetes Secret that contains valid AWS credentials. You must create this Secret in the same namespace as the `IntegrationSource` resource and must include both the AWS access key and secret key.
+To connect to Amazon Web Services (AWS) resources, the `IntegrationSource` requires a Kubernetes Secret that has valid AWS credentials. You must create this Secret in the same namespace as the `IntegrationSource` resource and must include both the AWS access key and secret key.
 
 .Prerequisites
 

--- a/modules/serverless-jobsink-cleaning-up-jobs.adoc
+++ b/modules/serverless-jobsink-cleaning-up-jobs.adoc
@@ -7,13 +7,14 @@
 = Cleaning up finished jobs
 
 [role="_abstract"]
-You can clean up finished jobs by setting a `ttlSecondsAfterFinished` value in your JobSink definition. For example, setting the value to `600` removes completed jobs 600 seconds (10 minutes) after they finish.
+You can clean up finished jobs by setting a `ttlSecondsAfterFinished` value in your `JobSink` definition. For example, setting the value to `600` removes completed jobs 600 seconds (10 minutes) after they finish.
 
 .Procedure
 
 * In your definition, set the value of `ttlSecondsAfterFinished` to the required amount.
 +
-.Example of ttlSecondsAfterFinished set to 600
+The following example displays `ttlSecondsAfterFinished` set to `600`:
++
 [source,yaml]
 ----
 apiVersion: sinks.knative.dev/v1alpha1

--- a/modules/serverless-jobsink-customizing-event-file-directory.adoc
+++ b/modules/serverless-jobsink-customizing-event-file-directory.adoc
@@ -7,7 +7,7 @@
 = Setting custom event file mount path
 
 [role="_abstract"]
-You can set a custom `event` file mount path in your JobSink definition.
+You can set a custom `event` file mount path in your `JobSink` definition.
 
 .Procedure
 

--- a/modules/serverless-jobsink-examples.adoc
+++ b/modules/serverless-jobsink-examples.adoc
@@ -7,13 +7,14 @@
 = Simulating FailJob action
 
 [role="_abstract"]
-//more info about FailJob?
+Simulate a `FailJob` action to test failure handling and retry behavior in Job execution.
 
 .Procedure
 
-* Trigger a `FailJob` action by including a bug simulating command in your JobSink definition. 
+* Trigger a `FailJob` action by including a bug simulating command in your `JobSink` definition. 
 +
-.Example of JobSink failure
+The following example displays `JobSink` failure:
++
 [source,yaml]
 ----
 apiVersion: sinks.knative.dev/v1alpha1

--- a/modules/serverless-jobsink-reading-event-file.adoc
+++ b/modules/serverless-jobsink-reading-event-file.adoc
@@ -7,6 +7,8 @@
 = Reading the Job event file
 
 [role="_abstract"]
+You can read the Job event file to inspect event data generated during Job execution.
+
 .Procedure
 
 * Read the `event` file and deserialize it by using any CloudEvents JSON deserializer. The following example demonstrates how to read and process an event using CloudEvents Go SDK:

--- a/modules/serverless-kafka-admin-security.adoc
+++ b/modules/serverless-kafka-admin-security.adoc
@@ -1,0 +1,15 @@
+// Module included in the following assemblies:
+//
+// * serverless/eventing/brokers/serverless-using-brokers.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="serverless-kafka-admin-security_{context}"]
+= Security configuration for the Knative broker implementation for Apache Kafka
+
+[role="_abstract"]
+Kafka clusters are generally secured by using the TLS or SASL authentication methods. You can configure a Kafka broker or channel to work against a protected Red{nbsp}Hat AMQ Streams cluster by using TLS or SASL.
+
+[NOTE]
+====
+Red{nbsp}Hat recommends that you enable both SASL and TLS together.
+====

--- a/modules/serverless-kafka-broker-configmap.adoc
+++ b/modules/serverless-kafka-broker-configmap.adoc
@@ -14,40 +14,44 @@ Knative Eventing supports the full set of topic config options that Kafka suppor
 .Prerequisites
 
 * You have cluster or dedicated administrator permissions on {ocp-product-title}.
-* The {ServerlessOperatorName}, Knative Eventing, and the `KnativeKafka` custom resource (CR) are installed on your {ocp-product-title} cluster.
+* You have installed the {ServerlessOperatorName}, Knative Eventing, and the `KnativeKafka` custom resource (CR) on your {ocp-product-title} cluster.
 * You have created a project or have access to a project that has the appropriate roles and permissions to create applications and other workloads in {ocp-product-title}.
 * You have installed the OpenShift CLI (`oc`).
 
 .Procedure
 
-. Modify the `kafka-broker-config` config map, or create your own config map that contains the following configuration:
+. Change the `kafka-broker-config` config map, or create your own config map that has the following configuration:
 +
 [source,yaml]
 ----
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: <config_map_name> <1>
-  namespace: <namespace> <2>
+  name: <config_map_name>
+  namespace: <namespace>
 data:
-  default.topic.partitions: <integer> <3>
-  default.topic.replication.factor: <integer> <4>
-  bootstrap.servers: <list_of_servers> <5>
-  default.topic.config.<config_option>: <value> <6>
+  default.topic.partitions: <integer>
+  default.topic.replication.factor: <integer>
+  bootstrap.servers: <list_of_servers>
+  default.topic.config.<config_option>: <value>
 ----
-<1> The config map name.
-<2> The namespace where the config map exists.
-<3> The number of topic partitions for the Kafka broker. This controls how quickly events can be sent to the broker. A higher number of partitions requires greater compute resources.
-<4> The replication factor of topic messages. This prevents against data loss. A higher replication factor requires greater compute resources and more storage.
-<5> A comma separated list of bootstrap servers. This can be inside or outside of the {ocp-product-title} cluster, and is a list of Kafka clusters that the broker receives events from and sends events to.
-<6> A topic config option. For more information, see the link:https://kafka.apache.org/documentation/#topicconfigs[full set of possible options and values]. 
++
+--
+* `name: <config_map_name>`: The config map name.
+* `namespace: <namespace>`: The namespace where the config map exists.
+* `default.topic.partitions: <integer>`: The number of topic partitions for the Kafka broker. This controls how quickly events can be sent to the broker. A higher number of partitions requires greater compute resources.
+* `default.topic.replication.factor: <integer>`: The replication factor of topic messages. This prevents against data loss. A higher replication factor requires greater compute resources and more storage.
+* `bootstrap.servers: <list_of_servers>`: A comma-separated list of bootstrap servers. This can be inside or outside of the {ocp-product-title} cluster, and is a list of Kafka clusters that the broker receives events from and sends events to.
+* `default.topic.config.<config_option>`: A topic config option.
+--
 +
 [IMPORTANT]
 ====
 The `default.topic.replication.factor` value must be less than or equal to the number of Kafka broker instances in your cluster. For example, if you only have one Kafka broker, the `default.topic.replication.factor` value should not be more than `"1"`.
 ====
 +
-.Example Kafka broker config map
+The following example displays Kafka broker config map:
++
 [source,yaml]
 ----
 apiVersion: v1
@@ -62,7 +66,7 @@ data:
   default.topic.config.retention.ms: "3600"
 ----
 
-. Apply the config map:
+. Apply the config map by running the following command:
 +
 [source,yaml]
 ----
@@ -71,31 +75,25 @@ $ oc apply -f <config_map_filename>
 
 . Specify the config map for the Kafka `Broker` object:
 +
-.Example Broker object
 [source,yaml]
 ----
 apiVersion: eventing.knative.dev/v1
 kind: Broker
 metadata:
-  name: <broker_name> <1>
-  namespace: <namespace> <2>
+  name: <broker_name>
+  namespace: <namespace>
   annotations:
-    eventing.knative.dev/broker.class: Kafka <3>
+    eventing.knative.dev/broker.class: Kafka
 spec:
   config:
     apiVersion: v1
     kind: ConfigMap
-    name: <config_map_name> <4>
-    namespace: <namespace> <5>
+    name: <config_map_name>
+    namespace: <namespace>
 ...
 ----
-<1> The broker name.
-<2> The namespace where the broker exists.
-<3> The broker class annotation. In this example, the broker is a Kafka broker that uses the class value `Kafka`.
-<4> The config map name.
-<5> The namespace where the config map exists.
 
-. Apply the broker:
+. Apply the broker by running the following command:
 +
 [source,yaml]
 ----

--- a/modules/serverless-kafka-broker-sasl-default-config.adoc
+++ b/modules/serverless-kafka-broker-sasl-default-config.adoc
@@ -12,7 +12,7 @@ _Simple Authentication and Security Layer_ (SASL) is used by Apache Kafka for au
 .Prerequisites
 
 * You have cluster or dedicated administrator permissions on {ocp-product-title}.
-* The {ServerlessOperatorName}, Knative Eventing, and the `KnativeKafka` CR are installed on your {ocp-product-title} cluster.
+* You have installed the {ServerlessOperatorName}, Knative Eventing, and the `KnativeKafka` CR on your {ocp-product-title} cluster.
 * You have created a project or have access to a project with the appropriate roles and permissions to create applications and other workloads in {ocp-product-title}.
 * You have a username and password for a Kafka cluster.
 * You have chosen the SASL mechanism to use, for example, `PLAIN`, `SCRAM-SHA-256`, or `SCRAM-SHA-512`.

--- a/modules/serverless-kafka-broker-tls-default-config.adoc
+++ b/modules/serverless-kafka-broker-tls-default-config.adoc
@@ -8,12 +8,12 @@
 = Configuring TLS authentication for Apache Kafka brokers
 
 [role="_abstract"]
-_Transport Layer Security_ (TLS) is used by Apache Kafka clients and servers to encrypt traffic between Knative and Kafka, as well as for authentication. TLS is the only supported method of traffic encryption for the Knative broker implementation for Apache Kafka.
+_Transport Layer Security_ (TLS) is used by Apache Kafka clients and servers to encrypt traffic between Knative and Kafka and for authentication. TLS is the only supported method of traffic encryption for the Knative broker implementation for Apache Kafka.
 
 .Prerequisites
 
 * You have cluster or dedicated administrator permissions on {ocp-product-title}.
-* The {ServerlessOperatorName}, Knative Eventing, and the `KnativeKafka` CR are installed on your {ocp-product-title} cluster.
+* You have installed the {ServerlessOperatorName}, Knative Eventing, and the `KnativeKafka` CR on your {ocp-product-title} cluster.
 * You have created a project or have access to a project with the appropriate roles and permissions to create applications and other workloads in {ocp-product-title}.
 * You have a Kafka cluster CA certificate stored as a `.pem` file.
 * You have a Kafka cluster client certificate and a key stored as `.pem` files.

--- a/modules/serverless-kafka-broker-with-kafka-topic.adoc
+++ b/modules/serverless-kafka-broker-with-kafka-topic.adoc
@@ -11,9 +11,9 @@ If you want to use a Kafka broker without allowing it to create its own internal
 
 .Prerequisites
 
-* The {ServerlessOperatorName}, Knative Eventing, and the `KnativeKafka` custom resource are installed on your {ocp-product-title} cluster.
+* You have installed the {ServerlessOperatorName}, Knative Eventing, and the `KnativeKafka` custom resource on your {ocp-product-title} cluster.
 
-* You have access to a Kafka instance such as link:https://docs.redhat.com/en/documentation/red_hat_amq/2021.q3/html/amq_streams_on_openshift_overview/kafka-concepts_str#kafka-concepts-key_str[Red{nbsp}Hat AMQ Streams], and have created a Kafka topic.
+* You have access to a Kafka instancenand have created a Kafka topic.
 
 * You have created a project or have access to a project with the appropriate roles and permissions to create applications and other workloads in {ocp-product-title}.
 
@@ -33,10 +33,13 @@ metadata:
     kafka.eventing.knative.dev/external.topic: <topic_name> <2>
 ...
 ----
-<1> The broker class. If not specified, brokers use the default class as configured by cluster administrators. To use the Kafka broker, this value must be `Kafka`.
-<2> The name of the Kafka topic that you want to use.
++
+--
+* `eventing.knative.dev/broker.class: Kafka`: The broker class. If not specified, brokers use the default class as configured by cluster administrators. To use the Kafka broker, this value must be `Kafka`.
+* `kafka.eventing.knative.dev/external.topic: <topic_name>`: The name of the Kafka topic that you want to use.
+--
 
-. Apply the Kafka-based broker YAML file:
+. Apply the Kafka-based broker YAML file by running the following command:
 +
 [source,terminal]
 ----

--- a/modules/serverless-kafka-broker.adoc
+++ b/modules/serverless-kafka-broker.adoc
@@ -7,11 +7,11 @@
 = Creating an Apache Kafka broker by using YAML
 
 [role="_abstract"]
-Creating Knative resources by using YAML files uses a declarative API, which enables you to describe applications declaratively and in a reproducible manner. To create a Kafka broker by using YAML, you must create a YAML file that defines a `Broker` object, then apply it by using the `oc apply` command.
+You can use YAML files to create Knative resources through a declarative API. Describe applications declaratively and ensure reproducibility. To create a Kafka broker by using YAML, create a YAML file that defines a `Broker` object, then run the `oc apply` command to apply the configuration.
 
 .Prerequisites
 
-* The {ServerlessOperatorName}, Knative Eventing, and the `KnativeKafka` custom resource are installed on your {ocp-product-title} cluster.
+* You have installed the {ServerlessOperatorName}, Knative Eventing, and the `KnativeKafka` custom resource on your {ocp-product-title} cluster.
 
 * You have created a project or have access to a project with the appropriate roles and permissions to create applications and other workloads in {ocp-product-title}.
 
@@ -27,19 +27,22 @@ apiVersion: eventing.knative.dev/v1
 kind: Broker
 metadata:
   annotations:
-    eventing.knative.dev/broker.class: Kafka <1>
+    eventing.knative.dev/broker.class: Kafka
   name: example-kafka-broker
 spec:
   config:
     apiVersion: v1
     kind: ConfigMap
-    name: kafka-broker-config <2>
+    name: kafka-broker-config
     namespace: knative-eventing
 ----
-<1> The broker class. If not specified, brokers use the default class as configured by cluster administrators. To use the Kafka broker, this value must be `Kafka`.
-<2> The default config map for Knative brokers for Apache Kafka. This config map is created when the Kafka broker functionality is enabled on the cluster by a cluster administrator.
++
+--
+* `eventing.knative.dev/broker.class: Kafka`: The broker class. If not specified, brokers use the default class as configured by cluster administrators. To use the Kafka broker, this value must be `Kafka`.
+* `name: kafka-broker-config`: The default config map for Knative brokers for Apache Kafka. This config map is created when the Kafka broker functionality is enabled on the cluster by a cluster administrator.
+--
 
-. Apply the Kafka-based broker YAML file:
+. Apply the Kafka-based broker YAML file by running the following command:
 +
 [source,terminal]
 ----

--- a/modules/serverless-kafka-sasl-channels.adoc
+++ b/modules/serverless-kafka-sasl-channels.adoc
@@ -12,7 +12,7 @@ _Simple Authentication and Security Layer_ (SASL) is used by Apache Kafka for au
 .Prerequisites
 
 * You have cluster or dedicated administrator permissions on {ocp-product-title}.
-* The {ServerlessOperatorName}, Knative Eventing, and the `KnativeKafka` CR are installed on your {ocp-product-title} cluster.
+* You have installed the {ServerlessOperatorName}, Knative Eventing, and the `KnativeKafka` CR on your {ocp-product-title} cluster.
 * You have created a project or have access to a project with the appropriate roles and permissions to create applications and other workloads in {ocp-product-title}.
 * You have a username and password for a Kafka cluster.
 * You have chosen the SASL mechanism to use, for example, `PLAIN`, `SCRAM-SHA-256`, or `SCRAM-SHA-512`.
@@ -39,7 +39,7 @@ $ oc create secret -n <namespace> generic <kafka_auth_secret> \
 The `ca.crt` key is optional if the Kafka cluster uses a certificate signed by a public CA whose certificate is already in the system truststore.
 ====
 
-. Start editing the `KnativeKafka` custom resource:
+. Start editing the `KnativeKafka` custom resource by running the following command:
 +
 [source,terminal]
 ----

--- a/modules/serverless-kafka-sasl-source.adoc
+++ b/modules/serverless-kafka-sasl-source.adoc
@@ -7,12 +7,12 @@
 = Configuring SASL authentication for Apache Kafka sources
 
 [role="_abstract"]
-_Simple Authentication and Security Layer_ (SASL) is used by Apache Kafka for authentication. If you use SASL authentication on your cluster, users must provide credentials to Knative for communicating with the Kafka cluster; otherwise events cannot be produced or consumed.
+_Simple Authentication and Security Layer_ (SASL) is used by Apache Kafka for authentication. If you use SASL authentication on your cluster, users must give credentials to Knative for communicating with the Kafka cluster; otherwise events cannot be produced or consumed.
 
 .Prerequisites
 
 * You have cluster or dedicated administrator permissions on {ocp-product-title}.
-* The {ServerlessOperatorName}, Knative Eventing, and the `KnativeKafka` CR are installed on your {ocp-product-title} cluster.
+* You have installed the {ServerlessOperatorName}, Knative Eventing, and the `KnativeKafka` CR on your {ocp-product-title} cluster.
 * You have created a project or have access to a project with the appropriate roles and permissions to create applications and other workloads in {ocp-product-title}.
 * You have a username and password for a Kafka cluster.
 * You have chosen the SASL mechanism to use, for example, `PLAIN`, `SCRAM-SHA-256`, or `SCRAM-SHA-512`.
@@ -28,12 +28,13 @@ _Simple Authentication and Security Layer_ (SASL) is used by Apache Kafka for au
 $ oc create secret -n <namespace> generic <kafka_auth_secret> \
   --from-file=ca.crt=caroot.pem \
   --from-literal=password="SecretPassword" \
-  --from-literal=saslType="SCRAM-SHA-512" \ <1>
+  --from-literal=saslType="SCRAM-SHA-512" \
   --from-literal=user="my-sasl-user"
 ----
-<1> The SASL type can be `PLAIN`, `SCRAM-SHA-256`, or `SCRAM-SHA-512`.
++
+`from-literal=saslType="SCRAM-SHA-512"`: The SASL type can be `PLAIN`, `SCRAM-SHA-256`, or `SCRAM-SHA-512`.
 
-. Create or modify your Kafka source so that it contains the following `spec` configuration:
+. Create or change your Kafka source so that it has the following `spec` configuration:
 +
 [source,yaml]
 ----
@@ -60,10 +61,9 @@ spec:
           key: saslType
     tls:
       enable: true
-      caCert: <1>
+      caCert:
         secretKeyRef:
           name: <kafka_auth_secret>
           key: ca.crt
 ...
 ----
-<1> The `caCert` spec is not required if you are using a public cloud Kafka service.

--- a/modules/serverless-kafka-sink-security-config.adoc
+++ b/modules/serverless-kafka-sink-security-config.adoc
@@ -7,14 +7,14 @@
 = Configuring security for Apache Kafka sinks
 
 [role="_abstract"]
-_Transport Layer Security_ (TLS) is used by Apache Kafka clients and servers to encrypt traffic between Knative and Kafka, as well as for authentication. TLS is the only supported method of traffic encryption for the Knative broker implementation for Apache Kafka.
+_Transport Layer Security_ (TLS) is used by Apache Kafka clients and servers to encrypt traffic between Knative and Kafka, and for authentication. TLS is the only supported method of traffic encryption for the Knative broker implementation for Apache Kafka.
 
-_Simple Authentication and Security Layer_ (SASL) is used by Apache Kafka for authentication. If you use SASL authentication on your cluster, users must provide credentials to Knative for communicating with the Kafka cluster; otherwise events cannot be produced or consumed.
+_Simple Authentication and Security Layer_ (SASL) is used by Apache Kafka for authentication. If you use SASL authentication on your cluster, users must give credentials to Knative for communicating with the Kafka cluster; otherwise events cannot be produced or consumed.
 
 .Prerequisites
 
-* The {ServerlessOperatorName}, Knative Eventing, and the `KnativeKafka` custom resources (CRs) are installed on your {ocp-product-title} cluster.
-* Kafka sink is enabled in the `KnativeKafka` CR.
+* You have installed the {ServerlessOperatorName}, Knative Eventing, and the `KnativeKafka` custom resources (CRs) on your {ocp-product-title} cluster.
+* You have enabled Kafka sink in the `KnativeKafka` CR.
 * You have created a project or have access to a project with the appropriate roles and permissions to create applications and other workloads in {ocp-product-title}.
 * You have a Kafka cluster CA certificate stored as a `.pem` file.
 * You have a Kafka cluster client certificate and a key stored as `.pem` files.
@@ -27,7 +27,7 @@ _Simple Authentication and Security Layer_ (SASL) is used by Apache Kafka for au
 +
 [IMPORTANT]
 ====
-Certificates and keys must be in PEM format.
+Certificates and keys must use Privacy-Enhanced Mail (PEM) format.
 ====
 
 ** For authentication using SASL without encryption:
@@ -48,11 +48,12 @@ $ oc create secret -n <namespace> generic <secret_name> \
 $ oc create secret -n <namespace> generic <secret_name> \
   --from-literal=protocol=SASL_SSL \
   --from-literal=sasl.mechanism=<sasl_mechanism> \
-  --from-file=ca.crt=<my_caroot.pem_file_path> \ <1>
+  --from-file=ca.crt=<my_caroot.pem_file_path> \
   --from-literal=user=<username> \
   --from-literal=password=<password>
 ----
-<1> The `ca.crt` can be omitted to use the system's root CA set if you are using a public cloud managed Kafka service.
++
+`from-file=ca.crt=<my_caroot.pem_file_path>`: The `ca.crt` can be omitted to use the system's root CA set if you are using a public cloud managed Kafka service.
 
 ** For authentication and encryption using TLS:
 +
@@ -60,11 +61,12 @@ $ oc create secret -n <namespace> generic <secret_name> \
 ----
 $ oc create secret -n <namespace> generic <secret_name> \
   --from-literal=protocol=SSL \
-  --from-file=ca.crt=<my_caroot.pem_file_path> \ <1>
+  --from-file=ca.crt=<my_caroot.pem_file_path> \
   --from-file=user.crt=<my_cert.pem_file_path> \
   --from-file=user.key=<my_key.pem_file_path>
 ----
-<1> The `ca.crt` can be omitted to use the system's root CA set if you are using a public cloud managed Kafka service.
++
+`from-file=ca.crt=<my_caroot.pem_file_path>`: The `ca.crt` can be omitted to use the system's root CA set if you are using a public cloud managed Kafka service.
 
 . Create or modify a `KafkaSink` object and add a reference to your secret in the `auth` spec:
 +
@@ -84,7 +86,7 @@ spec:
 ...
 ----
 
-. Apply the `KafkaSink` object:
+. Apply the `KafkaSink` object by running the following command:
 +
 [source,terminal]
 ----

--- a/modules/serverless-kafka-sink.adoc
+++ b/modules/serverless-kafka-sink.adoc
@@ -11,7 +11,7 @@ You can create a Kafka sink that sends events to a Kafka topic. By default, a Ka
 
 .Prerequisites
 
-* The {ServerlessOperatorName}, Knative Eventing, and the `KnativeKafka` custom resource (CR) are installed on your cluster.
+* You have installed the {ServerlessOperatorName}, Knative Eventing, and the `KnativeKafka` custom resource (CR) on your cluster.
 * You have created a project or have access to a project with the appropriate roles and permissions to create applications and other workloads in {ocp-product-title}.
 * You have access to a Red Hat AMQ Streams (Kafka) cluster that produces the Kafka messages you want to import.
 * Install the OpenShift CLI (`oc`).
@@ -26,12 +26,12 @@ You can create a Kafka sink that sends events to a Kafka topic. By default, a Ka
 apiVersion: eventing.knative.dev/v1alpha1
 kind: KafkaSink
 metadata:
-  name: <sink-name>
+  name: <sink_name>
   namespace: <namespace>
 spec:
-  topic: <topic-name>
+  topic: <topic_name>
   bootstrapServers:
-   - <bootstrap-server>
+   - <bootstrap_server>
 ----
 
 . To create the Kafka sink, apply the `KafkaSink` YAML file:
@@ -43,16 +43,17 @@ $ oc apply -f <filename>
 
 . Configure an event source so that the sink is specified in its spec:
 +
-.Example of a Kafka sink connected to an API server source
+The following example displays Kafka sink connected to an API server source:
++
 [source,yaml]
 ----
 apiVersion: sources.knative.dev/v1alpha2
 kind: ApiServerSource
 metadata:
-  name: <source-name> <1>
+  name: <source_name> <1>
   namespace: <namespace> <2>
 spec:
-  serviceAccountName: <service-account-name> <3>
+  serviceAccountName: <service_account_name> <3>
   mode: Resource
   resources:
   - apiVersion: v1
@@ -61,9 +62,12 @@ spec:
     ref:
       apiVersion: eventing.knative.dev/v1alpha1
       kind: KafkaSink
-      name: <sink-name> <4>
+      name: <sink_name> <4>
 ----
-<1> The name of the event source.
-<2> The namespace of the event source.
-<3> The service account for the event source.
-<4> The Kafka sink name.
++
+--
+* `name: <source_name>`: The name of the event source.
+* `namespace: <namespace>`: The namespace of the event source.
+* `serviceAccountName: <service_account_name>`: The service account for the event source.
+* `name: <sink_name>`: The Kafka sink name.
+--

--- a/modules/serverless-kafka-source-autoscale-keda.adoc
+++ b/modules/serverless-kafka-source-autoscale-keda.adoc
@@ -14,13 +14,12 @@ include::snippets/technology-preview.adoc[leveloffset=+1]
 
 .Prerequisites
 
-* The {ServerlessOperatorName}, Knative Eventing, and the `KnativeKafka` custom resource are installed on your cluster.
+* You have installed the {ServerlessOperatorName}, Knative Eventing, and the `KnativeKafka` custom resource on your cluster.
 
 .Procedure
 
 . In the `KnativeKafka` custom resource, enable KEDA scaling:
 +
-.Example YAML
 [source,yaml]
 ----
 apiVersion: operator.serverless.openshift.io/v1alpha1
@@ -34,7 +33,7 @@ spec:
       controller-autoscaler-keda: enabled
 ----
 
-. Apply the `KnativeKafka` YAML file:
+. Apply the `KnativeKafka` YAML file by running the following command:
 +
 [source,terminal]
 ----

--- a/modules/serverless-kafka-source-odc.adoc
+++ b/modules/serverless-kafka-source-odc.adoc
@@ -11,7 +11,7 @@ After the Knative broker implementation for Apache Kafka is installed on your cl
 
 .Prerequisites
 
-* The {ServerlessOperatorName}, Knative Eventing, and the `KnativeKafka` custom resource are installed on your cluster.
+* You have installed the {ServerlessOperatorName}, Knative Eventing, and the `KnativeKafka` custom resource on your cluster.
 * You have logged in to the web console.
 * You have access to a Red Hat AMQ Streams (Kafka) cluster that produces the Kafka messages you want to import.
 * You have created a project or have access to a project with the appropriate roles and permissions to create applications and other workloads in {ocp-product-title}.

--- a/modules/serverless-kafka-source-yaml.adoc
+++ b/modules/serverless-kafka-source-yaml.adoc
@@ -7,11 +7,11 @@
 = Creating an Apache Kafka event source by using YAML
 
 [role="_abstract"]
-Creating Knative resources by using YAML files uses a declarative API, which enables you to describe applications declaratively and in a reproducible manner. To create a Kafka source by using YAML, you must create a YAML file that defines a `KafkaSource` object, then apply it by using the `oc apply` command.
+You can use YAML files to create Knative resources through a declarative API. Describe applications declaratively and ensure reproducibility. To create a Kafka source by using YAML, create a YAML file that defines a `KafkaSource` object, then run the oc apply command to apply the configuration.
 
 .Prerequisites
 
-* The {ServerlessOperatorName}, Knative Eventing, and the `KnativeKafka` custom resource are installed on your cluster.
+* You have installed the {ServerlessOperatorName}, Knative Eventing, and the `KnativeKafka` custom resource on your cluster.
 * You have created a project or have access to a project with the appropriate roles and permissions to create applications and other workloads in {ocp-product-title}.
 * You have access to a Red Hat AMQ Streams (Kafka) cluster that produces the Kafka messages you want to import.
 * Install the OpenShift CLI (`oc`).
@@ -35,16 +35,20 @@ spec:
   sink:
   - <list_of_sinks> <3>
 ----
-<1> A consumer group is a group of consumers that use the same group ID, and consume data from a topic.
-<2> A topic provides a destination for the storage of data. Each topic is split into one or more partitions.
-<3> A sink specifies where events are sent to from a source.
++
+--
+* `consumerGroup: <group_name>`: A consumer group is a group of consumers that use the same group ID, and consume data from a topic.
+* `<list_of_topics>`: A topic provides a destination for the storage of data. Each topic is split into one or more partitions.
+* `<list_of_sinks>`: A sink specifies where events are sent to from a source.
+--
 +
 [IMPORTANT]
 ====
 Only the `v1beta1` version of the API for `KafkaSource` objects on {ServerlessProductName} is supported. Do not use the `v1alpha1` version of this API, as this version is now deprecated.
 ====
 +
-.Example `KafkaSource` object
+The following example displays `KafkaSource` object:
++
 [source,yaml]
 ----
 apiVersion: sources.knative.dev/v1beta1
@@ -80,7 +84,8 @@ $ oc apply -f <filename>
 $ oc get pods
 ----
 +
-.Example output
+You get an output similar to the following example:
++
 [source, terminal]
 ----
 NAME                                    READY     STATUS    RESTARTS   AGE

--- a/modules/serverless-kafka-tls-channels.adoc
+++ b/modules/serverless-kafka-tls-channels.adoc
@@ -13,7 +13,7 @@ _Transport Layer Security_ (TLS) is used by Apache Kafka clients and servers to 
 .Prerequisites
 
 * You have cluster or dedicated administrator permissions on {ocp-product-title}.
-* The {ServerlessOperatorName}, Knative Eventing, and the `KnativeKafka` CR are installed on your {ocp-product-title} cluster.
+* You have installed the {ServerlessOperatorName}, Knative Eventing, and the `KnativeKafka` CR on your {ocp-product-title} cluster.
 * You have created a project or have access to a project with the appropriate roles and permissions to create applications and other workloads in {ocp-product-title}.
 * You have a Kafka cluster CA certificate stored as a `.pem` file.
 * You have a Kafka cluster client certificate and a key stored as `.pem` files.
@@ -21,7 +21,7 @@ _Transport Layer Security_ (TLS) is used by Apache Kafka clients and servers to 
 
 .Procedure
 
-. Create the certificate files as secrets in your chosen namespace:
+. Create the certificate files as secrets in your chosen namespace by running the following command:
 +
 [source,terminal]
 ----
@@ -36,7 +36,7 @@ $ oc create secret -n <namespace> generic <kafka_auth_secret> \
 Use the key names `ca.crt`, `user.crt`, and `user.key`. Do not change them.
 ====
 
-. Start editing the `KnativeKafka` custom resource:
+. Start editing the `KnativeKafka` custom resource by running the following command:
 +
 [source,terminal]
 ----

--- a/modules/serverless-knative-eventing-usecases.adoc
+++ b/modules/serverless-knative-eventing-usecases.adoc
@@ -1,0 +1,18 @@
+// Module included in the following assemblies:
+
+:_mod-docs-content-type: REFERENCE
+[id="serverless-knative-eventing-usecases_{context}"]
+= Knative Eventing use cases
+
+[role="_abstract"]
+Knative Eventing supports the following use cases:
+
+Publish an event without creating a consumer:: You can send events to a broker as an HTTP POST, and use binding to decouple the destination configuration from your application that produces events.
+
+Consume an event without creating a publisher:: You can use a trigger to consume events from a broker based on event attributes. The application receives events as an HTTP POST.
+
+To enable delivery to multiple types of sinks, Knative Eventing defines the following generic interfaces that can be implemented by multiple Kubernetes resources:
+
+Addressable resources:: Able to receive and acknowledge an event delivered over HTTP to an address defined in the `status.address.url` field of the event. The Kubernetes `Service` resource also satisfies the addressable interface.
+
+Callable resources:: Able to receive an event delivered over HTTP and transform it, returning `0` or `1` new events in the HTTP response payload. These returned events can be further processed in the same way that events from an external event source are processed.

--- a/modules/serverless-list-broker-kn.adoc
+++ b/modules/serverless-list-broker-kn.adoc
@@ -11,19 +11,20 @@ Using the Knative (`kn`) CLI to list brokers provides a streamlined and intuitiv
 
 .Prerequisites
 
-* The {ServerlessOperatorName} and Knative Eventing are installed on your {ocp-product-title} cluster.
+* You have installed the {ServerlessOperatorName} and Knative Eventing on your {ocp-product-title} cluster.
 * You have installed the Knative (`kn`) CLI.
 
 .Procedure
 
-* List all existing brokers:
+* List all existing brokers by running the following command:
 +
 [source,terminal]
 ----
 $ kn broker list
 ----
 +
-.Example output
+You get an output similar to the following example:
++
 [source,terminal]
 ----
 NAME      URL                                                                     AGE   CONDITIONS   READY   REASON

--- a/modules/serverless-list-source-cli.adoc
+++ b/modules/serverless-list-source-cli.adoc
@@ -11,7 +11,7 @@ You can list existing event sources by using the `kn source list` command.
 
 .Prerequisites
 
-* The {ServerlessOperatorName} and Knative Eventing are installed on the cluster.
+* You have installed the {ServerlessOperatorName} and Knative Eventing on the cluster.
 * You have installed the Knative (`kn`) CLI.
 
 .Procedure
@@ -23,7 +23,8 @@ You can list existing event sources by using the `kn source list` command.
 $ kn source list
 ----
 +
-.Example output
+You get an output similar to the following example:
++
 [source,terminal]
 ----
 NAME   TYPE              RESOURCE                               SINK         READY
@@ -39,13 +40,15 @@ p1     PingSource        pingsources.sources.knative.dev        ksvc:eshow1   Tr
 $ kn source list --type <event_source_type>
 ----
 +
-.Example command
+You can see the following example command for reference:
++
 [source,terminal]
 ----
 $ kn source list --type PingSource
 ----
 +
-.Example output
+You get an output similar to the following example:
++
 [source,terminal]
 ----
 NAME   TYPE              RESOURCE                               SINK         READY

--- a/modules/serverless-list-source-types-kn.adoc
+++ b/modules/serverless-list-source-types-kn.adoc
@@ -33,7 +33,6 @@ PingSource        pingsources.sources.knative.dev                 Periodically s
 SinkBinding       sinkbindings.sources.knative.dev                Binding for connecting a PodSpecable to a sink
 ----
 
-
 . Optional: On {ocp-product-title}, you can also list the available event source types in YAML format:
 +
 [source,terminal]

--- a/modules/serverless-list-subs-kn.adoc
+++ b/modules/serverless-list-subs-kn.adoc
@@ -15,23 +15,17 @@ You can use the `kn subscription list` command to list existing subscriptions on
 
 .Procedure
 
-* List subscriptions on your cluster:
+* List subscriptions on your cluster by running the following command:
 +
 [source,terminal]
 ----
 $ kn subscription list
 ----
 +
-.Example output
+You get an output similar to the following example:
++
 [source,terminal]
 ----
 NAME             CHANNEL             SUBSCRIBER           REPLY   DEAD LETTER SINK   READY   REASON
 mysubscription   Channel:mychannel   ksvc:event-display                              True
 ----
-// . Optional: List subscriptions in YAML format:
-// +
-// [source,terminal]
-// ----
-// $ kn subscription list -o yaml
-// ----
-// Add this step once I have an example output, optional so non urgent

--- a/modules/serverless-managing-brokers-using-cli.adoc
+++ b/modules/serverless-managing-brokers-using-cli.adoc
@@ -1,0 +1,10 @@
+// Module included in the following assemblies:
+//
+// * /serverless/eventing/brokers/serverless-using-brokers-managing-brokers.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="serverless-managing-brokers-using-cli_{context}"]
+= Managing brokers using the CLI
+
+[role="_abstract"]
+The Knative (`kn`) CLI provides commands that can be used to describe and list existing brokers.

--- a/modules/serverless-odc-create-containersource.adoc
+++ b/modules/serverless-odc-create-containersource.adoc
@@ -12,7 +12,7 @@ After Knative Eventing is installed on your cluster, you can create a container 
 .Prerequisites
 
 * You have logged in to the {ocp-product-title} web console.
-* The {ServerlessOperatorName}, Knative Serving, and Knative Eventing are installed on your {ocp-product-title} cluster.
+* You have installed the {ServerlessOperatorName}, Knative Serving, and Knative Eventing on your {ocp-product-title} cluster.
 * You have created a project or have access to a project with the appropriate roles and permissions to create applications and other workloads in {ocp-product-title}.
 
 .Procedure

--- a/modules/serverless-overriding-pdbs-eventing.adoc
+++ b/modules/serverless-overriding-pdbs-eventing.adoc
@@ -13,8 +13,9 @@ A Pod Disruption Budget (PDB) is a standard feature of Kubernetes APIs that help
 .Procedure
 
 * Override the default PDB for a specific resource by modifying the `minAvailable` configuration value in the `KnativeEventing` custom resource (CR).
-
-.Example PDB with a `minAvailable` seting of 70%
++
+The following example displayes PDB with a `minAvailable` seting of 70%:
++
 [source,yaml]
 ----
 apiVersion: operator.knative.dev/v1beta1
@@ -27,7 +28,7 @@ spec:
  - name: eventing-webhook
    minAvailable: 70%
 ----
-
++
 [NOTE]
 ====
 If you disable high-availability, for example, by changing the `high-availability.replicas` value to `1`, make sure you also update the corresponding PDB `minAvailable` value to `0`. Otherwise, the pod disruption budget prevents automatic cluster or Operator updates.

--- a/modules/serverless-pingsource-kn.adoc
+++ b/modules/serverless-pingsource-kn.adoc
@@ -92,7 +92,8 @@ $ watch oc get pods
 $ oc logs $(oc get pod -o name | grep event-display) -c user-container
 ----
 +
-.Example output
+You get an output similar to the following example:
++
 [source,terminal]
 ----
 ☁️  cloudevents.Event

--- a/modules/serverless-pingsource-odc.adoc
+++ b/modules/serverless-pingsource-odc.adoc
@@ -12,7 +12,7 @@ After Knative Eventing is installed on your cluster, you can create a ping sourc
 .Prerequisites
 
 * You have logged in to the {ocp-product-title} web console.
-* The {ServerlessOperatorName}, Knative Serving and Knative Eventing are installed on the cluster.
+* You have installed the {ServerlessOperatorName}, Knative Serving and Knative Eventing on the cluster.
 * You have created a project or have access to a project with the appropriate roles and permissions to create applications and other workloads in {ocp-product-title}.
 
 .Procedure
@@ -47,10 +47,10 @@ spec:
 ====
 You can configure the *PingSource* settings by using the *Form view* or *YAML view* and can switch between the views. The data is persisted when switching between the views.
 ====
-.. Enter a value for *Schedule*. In this example, the value is `*/2 * * * *`, which creates a PingSource that sends a message every two minutes.
+.. Enter a value for *Schedule*. In this example, the value is `*/2 * * * *`, which creates a `PingSource` that sends a message every two minutes.
 .. Optional: You can enter a value for *Data*, which is the message payload.
 .. In the *Target* section, select your event sink. This can be either a *Resource* or a *URI*:
-... Select *Resource* to use a channel, broker, or service as an event sink for the event source. In this example, the `event-display` service created in the previous step is used as the target *Resource*.
+... Select *Resource* to use a channel, broker, or service as an event sink for the event source. In this example, the `event-display` service created in the earlier step is used as the target *Resource*.
 ... Select *URI* to specify a Uniform Resource Identifier (URI) where the events are routed to.
 .. Click *Create*.
 
@@ -65,9 +65,3 @@ image::verify-pingsource-ODC.png[View the ping source and service in the Topolog
 . View the event-display service in the web browser. You should see the ping source events in the web UI.
 +
 image::servlerless-pingsource-showcase-gui.png[View the ping source events in the web UI]
-
-.Deleting the ping source
-// move to separate procedure, out of scope for this PR
-
-. Navigate to the *Topology* view.
-. Right-click the API server source and select *Delete Ping Source*.

--- a/modules/serverless-pingsource-yaml.adoc
+++ b/modules/serverless-pingsource-yaml.adoc
@@ -9,31 +9,10 @@
 [role="_abstract"]
 Creating Knative resources by using YAML files uses a declarative API, which enables you to describe event sources declaratively and in a reproducible manner. To create a serverless ping source by using YAML, you must create a YAML file that defines a `PingSource` object, then apply it by using `oc apply`.
 
-.Example `PingSource` object
-[source,yaml]
-----
-apiVersion: sources.knative.dev/v1
-kind: PingSource
-metadata:
-  name: test-ping-source
-spec:
-  schedule: "*/2 * * * *" <1>
-  data: '{"message": "Hello world!"}' <2>
-  sink: <3>
-    ref:
-      apiVersion: serving.knative.dev/v1
-      kind: Service
-      name: event-display
-----
-
-<1> The schedule of the event specified using https://kubernetes.io/docs/tasks/job/automated-tasks-with-cron-jobs/#schedule[CRON expression].
-<2> The event message body expressed as a JSON encoded data string.
-<3> These are the details of the event consumer. In this example, we are using a Knative service named `event-display`.
-
 .Prerequisites
 
-* The {ServerlessOperatorName}, Knative Serving and Knative Eventing are installed on the cluster.
-* Install the OpenShift CLI (`oc`).
+* You have installed the {ServerlessOperatorName}, Knative Serving and Knative Eventing on the cluster.
+* You have installed the OpenShift CLI (`oc`).
 * You have created a project or have access to a project with the appropriate roles and permissions to create applications and other workloads in {ocp-product-title}.
 
 .Procedure
@@ -95,7 +74,8 @@ $ oc apply -f <filename>
 $ oc get pingsource.sources.knative.dev <ping_source_name> -oyaml
 ----
 +
-.Example output
+You get an output similar to the following example:
++
 [source,terminal]
 ----
 apiVersion: sources.knative.dev/v1
@@ -126,8 +106,8 @@ spec:
 
 You can verify that the Kubernetes events were sent to the Knative event sink by looking at the sink pod's logs.
 
-By default, Knative services terminate their pods if no traffic is received within a 60 second period.
-The example shown in this guide creates a PingSource that sends a message every 2 minutes, so each message should be observed in a newly created pod.
+By default, Knative services stop their pods if no traffic is received within a 60 second period.
+The example shown in this guide creates a `PingSource` that sends a message every 2 minutes, so each message should be observed in a newly created pod.
 
 . Watch for new pods created:
 +
@@ -136,14 +116,15 @@ The example shown in this guide creates a PingSource that sends a message every 
 $ watch oc get pods
 ----
 
-. Cancel watching the pods using Ctrl+C, then look at the logs of the created pod:
+. Cancel watching the pods using Ctrl+C, then examine the logs of the created pod:
 +
 [source,terminal]
 ----
 $ oc logs $(oc get pod -o name | grep event-display) -c user-container
 ----
 +
-.Example output
+You get an output similar to the following example:
++
 [source,terminal]
 ----
 ☁️  cloudevents.Event
@@ -159,20 +140,4 @@ Data,
   {
     "message": "Hello world!"
   }
-----
-
-.Deleting the ping source
-// move to separate procedure; out of scope for this PR
-
-* Delete the ping source:
-+
-[source,terminal]
-----
-$ oc delete -f <filename>
-----
-+
-.Example command
-[source,terminal]
-----
-$ oc delete -f ping-source.yaml
 ----

--- a/modules/serverless-send-events-kn.adoc
+++ b/modules/serverless-send-events-kn.adoc
@@ -1,3 +1,7 @@
+// Module included in the following assemblies:
+//
+//cli_tools/kn-plugins.adoc
+
 :_mod-docs-content-type: PROCEDURE
 [id="serverless-send-events-kn_{context}"]
 = Sending events by using the kn-event plugin
@@ -46,7 +50,8 @@ You can use the following destination formats for the `--to` flag:
 If you do not give a prefix, the destination defaults to a Knative service in the current namespace.
 ====
 
-.Sending an event to a URL
+* Send an event to a URL by running the following command:
++
 [source,terminal]
 ----
 $ kn event send \
@@ -57,7 +62,8 @@ $ kn event send \
     --to http://ce-api.foo.example.com/
 ----
 
-.Sending and event to an in-cluster resource
+* Send and event to an in-cluster resource by running the following command:
++
 [source,terminal]
 ----
 $ kn event send \

--- a/modules/serverless-setting-default-backing-channel-brokers.adoc
+++ b/modules/serverless-setting-default-backing-channel-brokers.adoc
@@ -1,0 +1,46 @@
+// Module included in the following assemblies:
+//
+// * /serverless/eventing/brokers/serverless-broker-backing-channel-default.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="serverless-setting-default-backing-channel-brokers_{context}"]
+= Setting the default backing channel for brokers
+
+[role="_abstract"]
+You can configure the default backing channel for brokers by updating the `config-br-default-channel` settings in the `KnativeEventing` custom resource.
+
+.Prerequisites
+
+* You have administrator permissions on {ocp-product-title}.
+* You have installed the {ServerlessOperatorName} and Knative Eventing on your cluster.
+* You have installed the OpenShift (`oc`) CLI.
+* You have installed the `KnativeKafka` CR on your cluster if you want to use Apache Kafka channels as the default backing channel type.
+
+.Procedure
+
+. Change the `KnativeEventing` custom resource (CR) to add configuration details for the `config-br-default-channel` config map:
++
+[source,yaml]
+----
+apiVersion: operator.knative.dev/v1beta1
+kind: KnativeEventing
+metadata:
+  name: knative-eventing
+  namespace: knative-eventing
+spec:
+  config:
+    config-br-default-channel:
+      channel-template-spec: |
+        apiVersion: messaging.knative.dev/v1beta1
+        kind: KafkaChannel
+        spec:
+          numPartitions: 6
+          replicationFactor: 3
+----
+
+. Apply the updated `KnativeEventing` CR by running the following command::
++
+[source,terminal]
+----
+$ oc apply -f <filename>
+----

--- a/modules/serverless-setting-default-broker-class-and-configuration.adoc
+++ b/modules/serverless-setting-default-broker-class-and-configuration.adoc
@@ -1,0 +1,72 @@
+// Module included in the following assemblies:
+//
+// * /serverless/eventing/brokers/serverless-broker-types
+
+:_mod-docs-content-type: PROCEDURE
+[id="serverless-setting-default-broker-class-and-configuration_{context}"]
+= Setting default broker class and configuration
+
+[role="_abstract"]
+You can configure the default broker class and broker settings by updating the `config-br-defaults` configuration in the `KnativeEventing` custom resource.
+
+.Prerequisites
+
+* You have administrator permissions on {ocp-product-title}.
+* You have installed the {ServerlessOperatorName} and Knative Eventing on your cluster.
+* You have installed the `KnativeKafka` CR on your cluster if you want to use Apache Kafka channels as the default backing channel type.
+
+.Procedure
+
+. Modify the `KnativeEventing` custom resource to add configuration details for the `config-br-defaults` config map:
++
+[source,yaml]
+----
+apiVersion: operator.knative.dev/v1beta1
+kind: KnativeEventing
+metadata:
+  name: knative-eventing
+  namespace: knative-eventing
+spec:
+  defaultBrokerClass: Kafka
+  config:
+    config-br-defaults:
+      default-br-config: |
+        clusterDefault:
+          brokerClass: Kafka
+          apiVersion: v1
+          kind: ConfigMap
+          name: kafka-broker-config
+          namespace: knative-eventing
+        namespaceDefaults:
+          my-namespace:
+            brokerClass: MTChannelBasedBroker
+            apiVersion: v1
+            kind: ConfigMap
+            name: config-br-default-channel
+            namespace: knative-eventing
+...
+----
++
+--
+* `defaultBrokerClass: Kafka`: The default broker class for Knative Eventing.
+* In `spec.config`, specify the config maps to change.
+* `config-br-defaults`: The `config-br-defaults` config map defines default settings for brokers without explicit configuration.
+* `clusterDefault`: The cluster-wide default broker class configuration.
+* `name: kafka-broker-config`: The `kafka-broker-config` config map defines default Kafka broker settings.
+* `namespace: knative-eventing`: The namespace where the `kafka-broker-config` config map exists.
+* `namespaceDefaults`: The namespace-specific default broker class configuration.
+* `name: config-br-default-channel`: The `config-br-default-channel` config map defines the default backing channel.
+* `namespace: knative-eventing`: The namespace where the `config-br-default-channel` config map exists.
+--
++
+[IMPORTANT]
+====
+Namespace-specific defaults override cluster-wide settings.
+====
+
+. Apply the updated `KnativeEventing` custom resource by running the following command:
++
+[source,terminal]
+----
+$ oc apply -f <filename>
+----

--- a/modules/serverless-sinkbinding-intro.adoc
+++ b/modules/serverless-sinkbinding-intro.adoc
@@ -3,7 +3,7 @@
 // * /serverless/eventing/event-sources/serverless-custom-event-sources.adoc
 
 :_mod-docs-content-type: CONCEPT
-[id="serverless-sinkbinding-intro_context"]
+[id="serverless-sinkbinding-intro_{context}"]
 = Sink binding
 
 [role="_abstract"]

--- a/modules/serverless-sinkbinding-kn.adoc
+++ b/modules/serverless-sinkbinding-kn.adoc
@@ -11,10 +11,10 @@ You can use the `kn source binding create` command to create a sink binding by u
 
 .Prerequisites
 
-* The {ServerlessOperatorName}, Knative Serving and Knative Eventing are installed on the cluster.
+* You have installed the {ServerlessOperatorName}, Knative Serving and Knative Eventing on the cluster.
 * You have created a project or have access to a project with the appropriate roles and permissions to create applications and other workloads in {ocp-product-title}.
-* Install the Knative (`kn`) CLI.
-* Install the OpenShift CLI (`oc`).
+* You have installed the Knative (`kn`) CLI.
+* You have installed the OpenShift CLI (`oc`).
 
 [NOTE]
 ====
@@ -43,7 +43,8 @@ $ kn source binding create bind-heartbeat --subject Job:batch/v1:app=heartbeat-c
 
 .. Create a cron job YAML file:
 +
-.Example cron job YAML file
+The following example displays cron job YAML file:
++
 [source,yaml]
 ----
 apiVersion: batch/v1
@@ -111,7 +112,8 @@ $ oc apply -f <filename>
 $ kn source binding describe bind-heartbeat
 ----
 +
-.Example output
+You get an output similar to the following example:
++
 [source,terminal]
 ----
 Name:         bind-heartbeat
@@ -147,7 +149,8 @@ $ oc get pods
 $ oc logs $(oc get pod -o name | grep event-display) -c user-container
 ----
 +
-.Example output
+You get an output similar to the following example:
++
 [source,terminal]
 ----
 ☁️  cloudevents.Event

--- a/modules/serverless-sinkbinding-odc.adoc
+++ b/modules/serverless-sinkbinding-odc.adoc
@@ -12,7 +12,7 @@ After Knative Eventing is installed on your cluster, you can create a sink bindi
 .Prerequisites
 
 * You have logged in to the {ocp-product-title} web console.
-* The {ServerlessOperatorName}, Knative Serving, and Knative Eventing are installed on your {ocp-product-title} cluster.
+* You have installed the {ServerlessOperatorName}, Knative Serving, and Knative Eventing on your {ocp-product-title} cluster.
 * You have created a project or have access to a project with the appropriate roles and permissions to create applications and other workloads in {ocp-product-title}.
 
 .Procedure
@@ -98,7 +98,7 @@ You can configure the *Sink Binding* settings by using the *Form view* or *YAML 
 The `CronJob` kind is not supported directly by {ServerlessProductName} sink binding, so the *Kind* field must target the `Job` objects created by the cron job, rather than the cron job object itself.
 ====
 .. In the *Target* section, select your event sink. This can be either a *Resource* or a *URI*:
-... Select *Resource* to use a channel, broker, or service as an event sink for the event source. In this example, the `event-display` service created in the previous step is used as the target *Resource*.
+... Select *Resource* to use a channel, broker, or service as an event sink for the event source. In this example, the `event-display` service created in the earlier step is used as the target *Resource*.
 ... Select *URI* to specify a Uniform Resource Identifier (URI) where the events are routed to.
 
 .. In the *Match labels* section:

--- a/modules/serverless-sinkbinding-ossm.adoc
+++ b/modules/serverless-sinkbinding-ossm.adoc
@@ -23,19 +23,17 @@ apiVersion: serving.knative.dev/v1
 kind: Service
 metadata:
   name: event-display
-  namespace: <namespace> <1>
+  namespace: <namespace>
 spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/inject: "true" <2>
+        sidecar.istio.io/inject: "true"
         sidecar.istio.io/rewriteAppHTTPProbers: "true"
     spec:
       containers:
       - image: quay.io/openshift-knative/showcase
 ----
-<1> A namespace that is a member of the `ServiceMeshMemberRoll`.
-<2> Injects {SMProductShortName} sidecars into the Knative service pods.
 
 . Apply the `Service` resource.
 +
@@ -52,11 +50,11 @@ apiVersion: sources.knative.dev/v1
 kind: SinkBinding
 metadata:
   name: bind-heartbeat
-  namespace: <namespace> <1>
+  namespace: <namespace>
 spec:
   subject:
     apiVersion: batch/v1
-    kind: Job <2>
+    kind: Job
     selector:
       matchLabels:
         app: heartbeat-cron
@@ -67,8 +65,6 @@ spec:
       kind: Service
       name: event-display
 ----
-<1> A namespace that is a member of the `ServiceMeshMemberRoll`.
-<2> In this example, any Job with the label `app: heartbeat-cron` is bound to the event sink.
 
 . Apply the `SinkBinding` resource.
 +
@@ -85,7 +81,7 @@ apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: heartbeat-cron
-  namespace: <namespace> <1>
+  namespace: <namespace>
 spec:
   # Run every minute
   schedule: "* * * * *"
@@ -98,7 +94,7 @@ spec:
       template:
         metadata:
           annotations:
-            sidecar.istio.io/inject: "true" <2>
+            sidecar.istio.io/inject: "true"
             sidecar.istio.io/rewriteAppHTTPProbers: "true"
         spec:
           restartPolicy: Never
@@ -119,8 +115,6 @@ spec:
                     fieldRef:
                       fieldPath: metadata.namespace
 ----
-<1> A namespace that is a member of the `ServiceMeshMemberRoll`.
-<2> Injects {SMProductShortName} sidecars into the `CronJob` pods.
 
 . Apply the `CronJob` resource.
 +
@@ -147,7 +141,8 @@ $ oc get pods
 $ oc logs $(oc get pod -o name | grep event-display) -c user-container
 ----
 +
-.Example output
+You get an output similar to the following example:
++
 [source,terminal]
 ----
 ☁️  cloudevents.Event

--- a/modules/serverless-sinkbinding-reference.adoc
+++ b/modules/serverless-sinkbinding-reference.adoc
@@ -7,9 +7,7 @@
 = Sink binding reference
 
 [role="_abstract"]
-// this section probably needs a rewrite / restructure; feels like multiple modules maybe for a larger ref doc. Out of scope for this PR.
-
-You can use a `PodSpecable` object as an event source by creating a sink binding. You can configure multiple parameters when creating a `SinkBinding` object.
+You can use a `PodSpecable` object as an event source by creating a sink binding. You can configure many parameters when creating a `SinkBinding` object.
 
 `SinkBinding` objects support the following parameters:
 
@@ -104,8 +102,6 @@ The `Subject` definition supports the following fields:
 
 |===
 
-.Subject parameter examples
-
 Given the following YAML, the `Deployment` object named `mysubject` in the `default` namespace is selected:
 
 [source,yaml]
@@ -189,7 +185,7 @@ A `ceOverrides` definition supports the following fields:
 Only valid `CloudEvent` attribute names are allowed as extensions. You cannot set the spec defined attributes from the extensions override configuration. For example, you can not modify the `type` attribute.
 ====
 
-.CloudEvent Overrides example
+The following example displays `CloudEvent` Overrides example:
 [source,yaml]
 ----
 apiVersion: sources.knative.dev/v1
@@ -206,7 +202,8 @@ spec:
 
 This sets the `K_CE_OVERRIDES` environment variable on the `subject`:
 
-.Example output
+You get an output similar to the following example:
+
 [source,terminal]
 ----
 { "extensions": { "extra": "this is an extra attribute", "additional": "42" } }

--- a/modules/serverless-sinkbinding-yaml.adoc
+++ b/modules/serverless-sinkbinding-yaml.adoc
@@ -7,7 +7,9 @@
 = Creating a sink binding by using YAML
 
 [role="_abstract"]
-Creating Knative resources by using YAML files uses a declarative API, which enables you to describe event sources declaratively and in a reproducible manner. To create a sink binding by using YAML, you must create a YAML file that defines an `SinkBinding` object, then apply it by using the `oc apply` command.
+You can create Knative resources with YAML files by using a declarative API. Describe event sources in a consistent and reproducible way.
+
+To create a sink binding with YAML, define a `SinkBinding` object in a YAML file and apply it by using the `oc apply` command.
 
 .Prerequisites
 
@@ -21,7 +23,8 @@ Creating Knative resources by using YAML files uses a declarative API, which ena
 
 .. Create a service YAML file:
 +
-.Example service YAML file
+The following example displays service YAML file:
++
 [source,yaml]
 ----
 apiVersion: serving.knative.dev/v1
@@ -45,7 +48,8 @@ $ oc apply -f <filename>
 
 .. Create a sink binding YAML file:
 +
-.Example service YAML file
+The following example displays service YAML file:
++
 [source,yaml]
 ----
 apiVersion: sources.knative.dev/v1alpha1
@@ -79,7 +83,8 @@ $ oc apply -f <filename>
 
 .. Create a cron job YAML file:
 +
-.Example cron job YAML file
+The following example displays cron job YAML file:
++
 [source,yaml]
 ----
 apiVersion: batch/v1
@@ -147,7 +152,8 @@ $ oc apply -f <filename>
 $ oc get sinkbindings.sources.knative.dev bind-heartbeat -oyaml
 ----
 +
-.Example output
+You get an output similar to the following example:
++
 [source,yaml]
 ----
 spec:
@@ -184,7 +190,8 @@ $ oc get pods
 $ oc logs $(oc get pod -o name | grep event-display) -c user-container
 ----
 +
-.Example output
+You get an output similar to the following example:
++
 [source,terminal]
 ----
 ☁️  cloudevents.Event

--- a/modules/serverless-supported-event-source-types.adoc
+++ b/modules/serverless-supported-event-source-types.adoc
@@ -1,0 +1,21 @@
+// Module included in the following assemblies:
+//
+// * serverless/admin_guide/serverless-cluster-admin-eventing.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="serverless-supported-event-source-types_{context}"]
+= Supported event source types
+
+[role="_abstract"]
+{ServerlessProductName} supports multiple event source types that generate and send events to sinks in Knative Eventing.
+
+The following event source types are available:
+
+API server source::
+Brings Kubernetes API server events into Knative. The API server source sends an event each time you create, update, or delete a Kubernetes resource.
+
+Ping source::
+Produces events with a fixed payload on a defined cron schedule.
+
+Kafka event source::
+Connects an Apache Kafka cluster to a sink as an event source.

--- a/modules/serverless-tls-config-additional-ca-bundles-eventing.adoc
+++ b/modules/serverless-tls-config-additional-ca-bundles-eventing.adoc
@@ -7,7 +7,7 @@
 = Configuring additional CA trust bundles
 
 [role="_abstract"]
-By default, Eventing clients trust the OpenShift CA bundle configured for custom PKI. For more details, see link:https://docs.openshift.com/container-platform/latest/networking/configuring-a-custom-pki.html[Configuring a custom PKI].
+By default, Eventing clients trust the OpenShift CA bundle configured for custom PKI.
 
 [NOTE]
 ====
@@ -37,5 +37,10 @@ data: <2>
   ca1.crt: ...
   tls.crt: ...
 ----
-<1> Use a unique name to avoid conflicts with existing or future Eventing config maps.
-<2> All keys with valid PEM-encoded CA bundles are trusted by Eventing clients.
++
+--
+* `name: <my_org_eventing_bundle>`: Use a unique name to avoid conflicts with existing or future Eventing config maps.
+
+* `networking.knative.dev/trust-bundle: "true"
+data`: All keys with valid Privacy-Enhanced Mail (PEM) encoded CA bundles are trusted by Eventing clients.
+--

--- a/modules/serverless-tls-creating-selfsigned-cluster-issuer-eventing.adoc
+++ b/modules/serverless-tls-creating-selfsigned-cluster-issuer-eventing.adoc
@@ -7,11 +7,11 @@
 = Creating a SelfSigned ClusterIssuer resource for Eventing
 
 [role="_abstract"]
-`ClusterIssuers` are Kubernetes resources that represent certificate authorities (CAs) that can generate signed certificates by honoring certificate signing requests. All cert-manager certificates require a referenced issuer in a ready condition to attempt to honor the request. For more details, see link:https://cert-manager.io/docs/concepts/issuer/[Issuer].
+`ClusterIssuers` are Kubernetes resources that represent certificate authorities (CAs) that can generate signed certificates by honoring certificate signing requests. All cert-manager certificates require a referenced issuer in a ready condition to try to honor the request.
 
 [IMPORTANT]
 ====
-For simplicity, this procedure uses a `SelfSigned` issuer as the root certificate authority. For more details about `SelfSigned` issuer implications and limitations, see link:https://cert-manager.io/docs/configuration/selfsigned/[SelfSigned issuers]. If you are using a custom public key infrastructure (PKI), you must configure it so its privately signed CA certificates are recognized across the cluster. For more details about cert-manager, see link:https://cert-manager.io/docs/configuration/ca/[certificate authorities (CAs)]. You can use any other issuer that is usable for cluster-local services.
+For simplicity, this procedure uses a `SelfSigned` issuer as the root certificate authority. If you are using a custom public key infrastructure (PKI), you must configure it so its privately signed CA certificates are recognized across the cluster. You can use any other issuer that is usable for cluster-local services.
 ====
 
 .Prerequisites
@@ -50,9 +50,9 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: knative-eventing-selfsigned-ca
-  namespace: cert-manager <1>
+  namespace: cert-manager
 spec:
-  secretName: knative-eventing-ca <2>
+  secretName: knative-eventing-ca
   isCA: true
   commonName: selfsigned-ca
   privateKey:
@@ -63,8 +63,9 @@ spec:
     kind: ClusterIssuer
     group: cert-manager.io
 ----
-<1> Specify the {cert-manager-operator} that is used by default. 
-<2> Specify the secret where the certificate is stored. The name is later used by the `ClusterIssuer` for Eventing.
+
+* `namespace: cert-manager` specifies the {cert-manager-operator} that is used by default. 
+* `secretName: knative-eventing-ca` specifies the secret where the certificate is stored. The name is later used by the `ClusterIssuer` for Eventing.
 
 . Apply the `Certificate` resource by running the following:
 +

--- a/modules/serverless-tls-ensuring-seamless-ca-rotation-eventing.adoc
+++ b/modules/serverless-tls-ensuring-seamless-ca-rotation-eventing.adoc
@@ -27,6 +27,4 @@ Ensure that you also keep the public key of the existing CA.
 Knative Eventing components automatically reload the updated CA trust bundles. For custom workloads that consume trust bundles, reload or restart them as needed.
 . Update the `knative-eventing-ca-issuer` `ClusterIssuer` to reference the secret containing the CA certificate that you created in step 1.
 . Force `cert-manager` to renew certificates in the `knative-eventing namespace`.
-+
-For more information about `cert-manager`, see link:https://cert-manager.io/docs/usage/certificate/#reissuance-triggered-by-user-actions[Reissuance triggered by user actions].
 . As soon as the CA rotation is fully completed, remove the public key of the old CA from the trust bundle config map.

--- a/modules/serverless-tls-verifying-transport-encryption-eventing.adoc
+++ b/modules/serverless-tls-verifying-transport-encryption-eventing.adoc
@@ -42,7 +42,8 @@ $ oc apply -f <filename>
 $ oc get inmemorychannels.messaging.knative.dev transport-encryption-test
 ----
 +
-.Example output
+You get an output similar to the following example:
++
 [source,terminal]
 ----
 NAME                        URL                                                                                           AGE   READY   REASON

--- a/modules/serverless-transport-encryption-config-values.adoc
+++ b/modules/serverless-transport-encryption-config-values.adoc
@@ -1,0 +1,34 @@
+// Module included in the following assemblies:
+//
+// * /serverless/Eventing/serverless-config-tls-encryption-eventing.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="serverless-transport-encryption-config-values_{context}"]
+= Transport encryption configuration values
+
+[role="_abstract"]
+The `transport-encryption` feature flag is an `enum` configuration that defines how Addressables, such as Broker, Channel, and Sink, accept events. It controls whether Addressables must accept events over HTTP or HTTPS based on the selected setting.
+
+The possible values for `transport-encryption` are as follows:
+
+[cols=2,options=header]
+|===
+|Value
+|Description
+
+|`disabled`
+a|
+* Addressables can accept events to HTTPS endpoints.
+* Producers can send events to HTTPS endpoints.
+
+|`permissive`
+a|
+* Addressables must accept events on both HTTP and HTTPS endpoints.
+* Addressables must advertise both HTTP and HTTPS endpoints.
+* Producers must send events to HTTPS endpoints, if available.
+
+|`strict`
+a|
+* Addressables must not accept events to non-HTTPS endpoints.
+* Addressables must only advertise HTTPS endpoints.
+|===

--- a/modules/serverless-trigger-config-connecting-to-kafka-sink.adoc
+++ b/modules/serverless-trigger-config-connecting-to-kafka-sink.adoc
@@ -1,0 +1,30 @@
+// Module included in the following assemblies:
+//
+// * /serverless/eventing/triggers/advanced-trigger-filters.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="serverless-trigger-config-connecting-to-kafka-sink_{context}"]
+= Trigger configuration for connecting to a Kafka sink
+
+[role="_abstract"]
+The following example shows how to configure a Trigger resource to send events to an Apache Kafka sink. It includes an example YAML definition that demonstrates how to define the sink as a subscriber in the Trigger resource spec.
+
+[source,yaml]
+----
+apiVersion: eventing.knative.dev/v1
+kind: Trigger
+metadata:
+  name: <trigger_name>
+spec:
+...
+  subscriber:
+    ref:
+      apiVersion: eventing.knative.dev/v1alpha1
+      kind: KafkaSink
+      name: <kafka_sink_name>
+----
+
+--
+* `name: <trigger_name>`: The name of the trigger being connected to the sink.
+* `name: <kafka_sink_name>`: The name of a `KafkaSink` object.
+--

--- a/modules/serverless-understanding-defaul-broker-types.adoc
+++ b/modules/serverless-understanding-defaul-broker-types.adoc
@@ -1,0 +1,14 @@
+// Module included in the following assemblies:
+//
+// * /serverless/eventing/brokers/serverless-using-brokers.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="serverless-understanding-defaul-broker-types_{context}"]
+= Understanding default broker types
+
+[role="_abstract"]
+Learn how the default broker type is selected based on cluster configuration in {ServerlessProductName}.
+
+If a cluster administrator configures {ServerlessProductName} to use Apache Kafka as the default broker type, creating a broker with default settings creates a Knative broker for Apache Kafka.
+
+If the deployment does not use Apache Kafka as the default broker type, creating a broker with default settings creates a channel-based broker.

--- a/modules/serverless-update-subscriptions-kn.adoc
+++ b/modules/serverless-update-subscriptions-kn.adoc
@@ -7,7 +7,7 @@
 = Updating subscriptions by using the Knative CLI
 
 [role="_abstract"]
-You can use the `kn subscription update` command as well as the appropriate flags to update a subscription from the terminal by using the Knative (`kn`) CLI. Using the Knative CLI to update subscriptions provides a more streamlined and intuitive user interface than updating YAML files directly.
+You can use the `kn subscription update` command and the appropriate flags to update a subscription from the terminal by using the Knative (`kn`) CLI. Using the Knative CLI to update subscriptions provides a more streamlined and intuitive user interface than updating YAML files directly.
 
 .Prerequisites
 
@@ -16,21 +16,17 @@ You can use the `kn subscription update` command as well as the appropriate flag
 
 .Procedure
 
-* Update a subscription:
-+
+* Update a subscription by running the following command:
+
 [source,terminal]
 ----
 $ kn subscription update <subscription_name> \
-  --sink <sink_prefix>:<sink_name> \ <1>
-  --sink-dead-letter <sink_prefix>:<sink_name> <2>
+  --sink <sink_prefix>:<sink_name> \
+  --sink-dead-letter <sink_prefix>:<sink_name>
 ----
-<1> `--sink` specifies the updated target destination to which the event should be delivered. You can specify the type of the sink by using one of the following prefixes:
-`ksvc`:: A Knative service.
-`channel`:: A channel that should be used as destination. Only default channel types can be referenced here.
-`broker`:: An Eventing broker.
-<2> Optional: `--sink-dead-letter` is an optional flag that can be used to specify a sink which events should be sent to in cases where events fail to be delivered. For more information, see the {ServerlessProductName} _Event delivery_ documentation.
-+
-.Example command
+
+You can see the following example command for reference:
+
 [source,terminal]
 ----
 $ kn subscription update mysubscription --sink ksvc:event-display

--- a/modules/serverless-using-jobsink.adoc
+++ b/modules/serverless-using-jobsink.adoc
@@ -13,7 +13,8 @@ When an event is sent to a `JobSink`, Eventing creates a `Job` and mounts the re
 
 . Create a `JobSink` object definition as a YAML file:
 +
-.JobSink YAML
+The following example displays `JobSink` YAML:
++
 [source,yaml]
 ----
 apiVersion: sinks.knative.dev/v1alpha1
@@ -36,20 +37,20 @@ spec:
                 - "/etc/jobsink-event/event"
 ----
 
-. Apply the `JobSink` YAML file:
+. Apply the `JobSink` YAML file by running the following command:
 +
 [source,terminal]
 ----
 $ oc apply -f <job-sink-file.yaml>
 ----
 
-. Verify `JobSink` is ready:
+. Verify `JobSink` is ready by running the following command:
 +
 [source,terminal]
 ----
 $ oc get jobsinks.sinks.knative.dev
 ----
-Example output:
+You get an output similar to the following example:
 +
 [source,terminal]
 ----
@@ -70,13 +71,13 @@ $ oc run curl --image=curlimages/curl --rm=true --restart=Never -ti -- -X POST -
    -d '{"details":"JobSinkDemo"}' \
    http://job-sink.knative-eventing.svc.cluster.local/default/job-sink-logger
 ----
-. Verify a `Job` is created:
+. Verify a `Job` is created by running the following command:
 +
 [source,terminal]
 ----
 $ oc logs job-sink-loggerszoi6-dqbtq
 ----
-Example output: 
+You get an output similar to the following example:
 +
 [source,terminal]
 ----

--- a/modules/triggers-conflict-current-filter-field.adoc
+++ b/modules/triggers-conflict-current-filter-field.adoc
@@ -7,9 +7,10 @@
 = Conflict with the existing filter field
 
 [role="_abstract"]
-You can use the `filters` and the existing `filter` field at the same time. If you enable the new `new-trigger-filters` feature and an object contains both `filter` and `filters`, the `filters` field overrides. This setup allows you to test the new `filters` field while maintaining support for existing filters. You can gradually introduce the new field into existing trigger objects.
+You can use the `filters` and the existing `filter` field at the same time. If you enable the new `new-trigger-filters` feature and an object has both `filter` and `filters`, the `filters` field overrides. This setup allows you to test the new `filters` field while maintaining support for existing filters. You can gradually introduce the new field into existing trigger objects.
 
-.Example of `filters` field overriding the `filter` field:
+The following example displayes the `filters` field overriding the `filter` field:
+
 [source,yaml]
 ----
 apiVersion: eventing.knative.dev/v1

--- a/modules/triggers-legacy-attribute-filters.adoc
+++ b/modules/triggers-legacy-attribute-filters.adoc
@@ -7,11 +7,10 @@
 = Legacy attributes filter
 
 [role="_abstract"]
-The legacy attributes filter enables exact match filtering on any number of CloudEvents attributes, including extensions. Its functionality mirrors the exact filter dialect, and you are encouraged to transition to the exact filter whenever possible. However, for backward compatibility, the attributes filter remains available.
+The existing attributes filter enables exact match filtering on any number of `CloudEvents` attributes, including extensions. Its functionality mirrors the exact filter dialect, and you are encouraged to make the transition to the exact filter whenever possible. However, for backward compatibility, the attributes filter remains available.
 
 The following example displays how to filter events from the default broker that match the `type` attribute `dev.knative.foo.bar` and have the extension `myextension` with the `my-extension-value` value:
 
-.Example of filtering events with specific attributes
 [source,yaml]
 ----
 apiVersion: eventing.knative.dev/v1
@@ -31,9 +30,10 @@ spec:
       name: my-service
 ----
 
-When both the `filters` field and the legacy `filter` field are specified, the `filters` field takes precedence. 
+When both the `filters` field and the existing `filter` field are specified, the `filters` field takes precedence. 
 
 For example, in the following example configuration, events with the `dev.knative.a` type are delivered, while events with the `dev.knative.b` type are ignored:
+
 [source,yaml]
 ----
 apiVersion: eventing.knative.dev/v1

--- a/modules/triggers-supported-filter-dialects.adoc
+++ b/modules/triggers-supported-filter-dialects.adoc
@@ -26,7 +26,8 @@ Each dialect provides a different method for filtering events based on a specifi
 
 The `exact` dialect filters events by comparing a string value of the CloudEvent attribute to exactly match the specified string. The comparison is case sensitive. If the attribute is not a string, the filter converts the attribute to its string representation before comparing it to the specified value.
 
-.Example of the `exact` filter dialect
+The following example displays the `exact` filter dialect:
+
 [source,terminal]
 ----
 apiVersion: eventing.knative.dev/v1
@@ -45,7 +46,8 @@ spec:
 
 The `prefix` dialect filters events by comparing a string value of the CloudEvent attribute that starts with the specified string. This comparison is case sensitive. If the attribute is not a string, the filter converts the attribute to its string representation before matching it against the specified value.
 
-.Example of the `prefix` filter dialect
+The following example displays the `prefix` filter dialect:
+
 [source,terminal]
 ----
 apiVersion: eventing.knative.dev/v1
@@ -62,9 +64,10 @@ spec:
 [id="triggers-filter-suffix-dialect_{context}"]
 == `suffix` filter dialect
 
-The `suffix` dialect filters events by comparing a string value of the CloudEvent attribute that ends with the specified string. This comparison is case-sensitive. If the attribute is not a string, the filter converts the attribute to its string representation before matching it to the specified value.
+The `suffix` dialect filters events by comparing a string value of the `CloudEvent` attribute that ends with the specified string. This comparison is case-sensitive. If the attribute is not a string, the filter converts the attribute to its string representation before matching it to the specified value.
 
-.Example of the `suffix` filter dialect
+The following example displays `suffix` filter dialect:
+
 [source,terminal]
 ----
 apiVersion: eventing.knative.dev/v1
@@ -83,7 +86,8 @@ spec:
 
 The `all` filter dialect needs that all nested filter expressions evaluate to `true` to process the event. If any of the nested expressions return `false`, the event is not sent to the subscriber.
 
-.Example of the `all` filter dialect
+The following example displays `all` filter dialect:
+
 [source,terminal]
 ----
 apiVersion: eventing.knative.dev/v1
@@ -105,7 +109,8 @@ spec:
 
 The `any` filter dialect requires at least one of the nested filter expressions to evaluate to `true`. If none of the nested expressions return `true`, the event is not sent to the subscriber.
 
-.Example of the `any` filter dialect
+The following example displays the `any` filter dialect:
+
 [source,terminal]
 ----
 apiVersion: eventing.knative.dev/v1
@@ -127,7 +132,8 @@ spec:
 
 The `not` filter dialect requires that the nested filter expression evaluates to `false` for the event to be processed. If the nested expression evaluates to `true`, the event is not sent to the subscriber.
 
-.Example of the `not` filter dialect
+The following example displays the `not` filter dialect:
+
 [source,terminal]
 ----
 apiVersion: eventing.knative.dev/v1
@@ -145,11 +151,12 @@ spec:
 [id="triggers-filter-cesql-dialect_{context}"]
 == `cesql` filter dialect 
 
-CloudEvents SQL expressions (cesql) allow computing values and matching of CloudEvent attributes against complex expressions that lean on the syntax of Structured Query Language (SQL) `WHERE` clauses.
+`CloudEvents` SQL expressions (cesql) allow computing values and matching of `CloudEvent` attributes against complex expressions that lean on the syntax of Structured Query Language (SQL) `WHERE` clauses.
 
-The `cesql` filter dialect uses CloudEvents SQL expressions to filter events. The provided CESQL expression must evaluate to `true` for the event to be processed.
+The `cesql` filter dialect uses `CloudEvents` SQL expressions to filter events. The provided `CloudEvents` Structured Query Language (CESQL) expression must evaluate to `true` for the event to be processed.
 
-.Example of the `cesql` filter dialect
+The following example displays the `cesql` filter dialect:
+
 [source,terminal]
 ----
 apiVersion: eventing.knative.dev/v1
@@ -161,5 +168,3 @@ spec:
   filters:
     - cesql: "source LIKE '%commerce%' AND type IN ('order.created', 'order.updated', 'order.canceled')"
 ----
-
-For more information about the syntax and the features of the `cesql` filter dialect, see link:https://github.com/cloudevents/spec/blob/cesql/v1.0.0/cesql/spec.md[CloudEvents SQL Expression Language].

--- a/snippets/serverless-about-kafka-broker.adoc
+++ b/snippets/serverless-about-kafka-broker.adoc
@@ -5,13 +5,13 @@
 
 :_mod-docs-content-type: SNIPPET
 
-For production-ready Knative Eventing deployments, Red Hat recommends using the Knative broker implementation for Apache Kafka. The broker is an Apache Kafka native implementation of the Knative broker, which sends CloudEvents directly to the Kafka instance.
+For production-ready Knative Eventing deployments, Red Hat recommends using the Knative broker implementation for Apache Kafka. The broker is an Apache Kafka native implementation of the Knative broker, which sends `CloudEvents` directly to the Kafka instance.
 
 The Knative broker has a native integration with Kafka for storing and routing events. This allows better integration with Kafka for the broker and trigger model over other broker types, and reduces network hops. Other benefits of the Knative broker implementation include:
 
 * At-least-once delivery guarantees
-* Ordered delivery of events, based on the CloudEvents partitioning extension
+* Ordered delivery of events, based on the `CloudEvents` partitioning extension
 * Control plane high availability
 * A horizontally scalable data plane
 
-The  Knative broker implementation for Apache Kafka stores incoming CloudEvents as Kafka records, using the binary content mode. This means that all CloudEvent attributes and extensions are mapped as headers on the Kafka record, while the `data` spec of the CloudEvent corresponds to the value of the Kafka record.
+The  Knative broker implementation for Apache Kafka stores incoming `CloudEvents` as Kafka records, using the binary content mode. This means that all `CloudEvent` attributes and extensions are mapped as headers on the Kafka record, while the `data` spec of the `CloudEvent` corresponds to the value of the Kafka record.


### PR DESCRIPTION
**You can cherry-pick for the following branches:** 
- `serverless-docs-1.37`
- `serverless-docs-1.38`

**Note for the peer & merge reviewer:** 
- This PR updates the only "Eventing" section to prepare it for Phase 0 DITA migration.
- No other CQA changes, error types, or content refinements are included. 

**Changes:** 
This PR prepares the "Eventing" section for Phase 0 DITA migration by applying Vale (AsciiDoc DITA) rules and cleaning up the existing content.

Doc preview: 

**Tracking JIRA:** https://redhat.atlassian.net/browse/SRVCOM-4378

**Reviews:**
- [x] Peer has approved this change