### PR TITLE
DOCPLAN-169: Updated short descriptions for DITA compliance

### DIFF
--- a/virt/vm_networking/virt-accessing-vm-internal-fqdn.adoc
+++ b/virt/vm_networking/virt-accessing-vm-internal-fqdn.adoc
@@ -6,9 +6,8 @@ include::_attributes/common-attributes.adoc[]
                                                                 
 toc::[]         
 
-You can access a virtual machine (VM) that is connected to the default internal pod network on a stable fully qualified domain name (FQDN) by using headless services.
-
-A Kubernetes _headless service_ is a form of service that does not allocate a cluster IP address to represent a set of pods. Instead of providing a single virtual IP address for the service, a headless service creates a DNS record for each pod associated with the service. You can expose a VM through its FQDN without having to expose a specific TCP or UDP port. 
+[role="_abstract"]
+You can access a virtual machine (VM) that is connected to the default internal pod network on a stable fully qualified domain name (FQDN) by using headless services. A Kubernetes _headless service_ creates a DNS record for each pod associated with the service instead of providing a single virtual IP address for the service. You can expose a VM through its FQDN without having to expose a specific TCP or UDP port. 
  
 [IMPORTANT]
 ====

--- a/virt/vm_networking/virt-accessing-vm-secondary-network-fqdn.adoc
+++ b/virt/vm_networking/virt-accessing-vm-secondary-network-fqdn.adoc
@@ -6,7 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-You can access a virtual machine (VM) that is attached to a secondary network interface from outside the cluster by using its fully qualified domain name (FQDN).
+[role="_abstract"]
+You can access a virtual machine (VM) that is attached to a secondary network interface from outside the cluster by using its fully qualified domain name (FQDN). To connect to a VM by using its external FQDN, you must configure the DNS server, retrieve the cluster FQDN, and then connect to the VM by using the `ssh` command.
 
 :FeatureName: Accessing a VM from outside the cluster by using its FQDN
 include::snippets/technology-preview.adoc[]

--- a/virt/vm_networking/virt-configuring-viewing-ips-for-vms.adoc
+++ b/virt/vm_networking/virt-configuring-viewing-ips-for-vms.adoc
@@ -6,9 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-You can configure an IP address when you create a virtual machine (VM). The IP address is provisioned with cloud-init.
-
-You can view the IP address of a VM by using the {product-title} web console or the command line. The network information is collected by the QEMU guest agent.
+[role="_abstract"]
+You can configure an IP address when you create a virtual machine (VM). The IP address is provisioned with cloud-init. View the IP address of a VM by using the {product-title} web console or the command line. The network information is collected by the QEMU guest agent.
 
 [id="configuring-ips_virt-configuring-viewing-ips-for-vms"]
 == Configuring IP addresses for virtual machines

--- a/virt/vm_networking/virt-connecting-vm-to-default-pod-network.adoc
+++ b/virt/vm_networking/virt-connecting-vm-to-default-pod-network.adoc
@@ -6,6 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 You can connect a virtual machine to the default internal pod network by configuring its network interface to use the `masquerade` binding mode.
 
 [NOTE]

--- a/virt/vm_networking/virt-connecting-vm-to-ovn-secondary-network.adoc
+++ b/virt/vm_networking/virt-connecting-vm-to-ovn-secondary-network.adoc
@@ -6,24 +6,17 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-ifdef::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
-You can connect a VM to an Open Virtual Network (OVN)-Kubernetes secondary network. {VirtProductName} supports the `layer2` topology for OVN-Kubernetes.
-
-A `layer2` topology connects workloads by a cluster-wide logical switch. The OVN-Kubernetes Container Network Interface (CNI) plugin uses the Geneve (Generic Network Virtualization Encapsulation) protocol to create an overlay network between nodes. You can use this overlay network to connect VMs on different nodes, without having to configure any additional physical networking infrastructure.
-endif::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
+[role="_abstract"]
+You can connect a VM to an OVN-Kubernetes custom secondary overlay network. A layer 2 topology connects workloads by a cluster-wide logical switch. The OVN-Kubernetes Container Network Interface (CNI) plugin uses the Geneve (Generic Network Virtualization Encapsulation) protocol to create an overlay network between nodes. You can use this overlay network to connect VMs on different nodes, without having to configure any additional physical networking infrastructure.
 
 ifndef::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
-You can connect a virtual machine (VM) to an OVN-Kubernetes `layer2` secondary network by using the CLI.
-
-A `layer2` topology connects workloads by a cluster-wide logical switch. The OVN-Kubernetes Container Network Interface (CNI) plugin uses the Geneve (Generic Network Virtualization Encapsulation) protocol to create an overlay network between nodes. You can use this overlay network to connect VMs on different nodes, without having to configure any additional physical networking infrastructure.
-
 [NOTE]
 ====
 An OVN-Kubernetes secondary network is compatible with the xref:../../networking/multiple_networks/secondary_networks/configuring-multi-network-policy.adoc#compatibility-with-multi-network-policy_configuring-additional-network[multi-network policy API] which provides the `MultiNetworkPolicy` custom resource definition (CRD) to control traffic flow to and from VMs. You must use the `ipBlock` attribute to define network policy ingress and egress rules for specific CIDR blocks. You cannot use pod or namespace selectors for virtualization workloads.
 ====
 endif::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
 
-To configure an OVN-Kubernetes `layer2` secondary network and attach a VM to that network, perform the following steps:
+To configure an OVN-Kubernetes layer 2 secondary network and attach a VM to that network, perform the following steps:
 
 . xref:../../virt/vm_networking/virt-connecting-vm-to-ovn-secondary-network.adoc#virt-connecting-vm-to-ovn-secondary-network[Configure an OVN-Kubernetes layer 2 secondary network].
 

--- a/virt/vm_networking/virt-connecting-vm-to-primary-udn.adoc
+++ b/virt/vm_networking/virt-connecting-vm-to-primary-udn.adoc
@@ -7,6 +7,7 @@ include::_attributes/common-attributes.adoc[]
                                                                 
 toc::[]                
 
+[role="_abstract"]
 You can connect a virtual machine (VM) to a user-defined network (UDN) on the VM's primary interface by using the {product-title} web console or the CLI. The primary user-defined network replaces the default pod network in your specified namespace. Unlike the pod network, you can define the primary UDN per project, where each project can use its specific subnet and topology.
 
 {VirtProductName} supports the namespace-scoped `UserDefinedNetwork` and the cluster-scoped `ClusterUserDefinedNetwork` custom resource definitions (CRD). 

--- a/virt/vm_networking/virt-connecting-vm-to-secondary-udn.adoc
+++ b/virt/vm_networking/virt-connecting-vm-to-secondary-udn.adoc
@@ -6,6 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 You can connect a virtual machine (VM) to an OVN-Kubernetes localnet secondary network by using the CLI. Cluster administrators can use the `ClusterUserDefinedNetwork` (CUDN) custom resource definition (CRD) to create a shared OVN-Kubernetes network across multiple namespaces.
 
 An OVN-Kubernetes secondary network is compatible with the xref:../../networking/multiple_networks/secondary_networks/configuring-multi-network-policy.adoc#compatibility-with-multi-network-policy_configuring-additional-network[multi-network policy API] which provides the `MultiNetworkPolicy` custom resource definition (CRD) to control traffic flow to and from VMs.

--- a/virt/vm_networking/virt-connecting-vm-to-service-mesh.adoc
+++ b/virt/vm_networking/virt-connecting-vm-to-service-mesh.adoc
@@ -6,7 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-{VirtProductName} is now integrated with OpenShift Service Mesh. You can monitor, visualize, and control traffic between pods that run virtual machine workloads on the default pod network with IPv4.
+[role="_abstract"]
+{VirtProductName} is now integrated with {SMProductName}. You can monitor, visualize, and control traffic between pods that run virtual machine (VM) workloads on the default pod network with IPv4.
 
 include::modules/virt-adding-vm-to-service-mesh.adoc[leveloffset=+1]
 

--- a/virt/vm_networking/virt-dedicated-network-live-migration.adoc
+++ b/virt/vm_networking/virt-dedicated-network-live-migration.adoc
@@ -6,18 +6,17 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-ifndef::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
-You can configure a dedicated xref:../../virt/vm_networking/virt-connecting-vm-to-linux-bridge.adoc#virt-connecting-vm-to-linux-bridge[Multus network] for live migration. A dedicated network minimizes the effects of network saturation on tenant workloads during live migration.
-endif::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
-ifdef::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
-You can configure a dedicated xref:../../virt/vm_networking/virt-dedicated-network-live-migration.adoc#virt-configuring-secondary-network-vm-live-migration_virt-dedicated-network-live-migration[secondary network] for live migration. A dedicated network minimizes the effects of network saturation on tenant workloads during live migration.
-endif::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
+[role="_abstract"]
+You can configure a dedicated secondary network for live migration. A dedicated network minimizes the effects of network saturation on tenant workloads during live migration.
 
 include::modules/virt-configuring-secondary-network-vm-live-migration.adoc[leveloffset=+1]
 
 include::modules/virt-selecting-migration-network-ui.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
-[id="additional-resources_virt-migrating-vm-on-secondary-network"]
+[id="additional-resources_{context}"]
 == Additional resources
 * xref:../../virt/live_migration/virt-configuring-live-migration.adoc#virt-configuring-live-migration[Configuring live migration limits and timeouts]
+ifndef::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
+* xref:../../virt/vm_networking/virt-connecting-vm-to-linux-bridge.adoc#virt-connecting-vm-to-linux-bridge[Connecting a VM to a Linux bridge network]
+endif::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]

--- a/virt/vm_networking/virt-exposing-vm-with-service.adoc
+++ b/virt/vm_networking/virt-exposing-vm-with-service.adoc
@@ -6,7 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-You can expose a virtual machine within the cluster or outside the cluster by creating a `Service` object.
+[role="_abstract"]
+You can expose a virtual machine (VM) within the cluster or outside the cluster by creating a `Service` object. By exposing a VM as a Kubernetes service, you can leverage native load balancing and observability tools that provide unified traffic management, consistent SSL termination, and centralized security policies across hybrid workloads.
 
 include::modules/virt-about-services.adoc[leveloffset=+1]
 

--- a/virt/vm_networking/virt-hot-plugging-network-interfaces.adoc
+++ b/virt/vm_networking/virt-hot-plugging-network-interfaces.adoc
@@ -6,6 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 ifdef::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
 You can add or remove secondary network interfaces without stopping your virtual machine (VM). {VirtProductName} supports hot plugging and hot unplugging for secondary interfaces that use bridge binding and the VirtIO device driver.
 endif::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]

--- a/virt/vm_networking/virt-setting-interface-link-state.adoc
+++ b/virt/vm_networking/virt-setting-interface-link-state.adoc
@@ -6,6 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 You can manage the link state of a primary or secondary virtual machine (VM) interface by using the {product-title} web console or the CLI. By specifying the link state, you can logically connect or disconnect the virtual network interface controller (vNIC) from a network.
 
 [NOTE]

--- a/virt/vm_networking/virt-using-dpdk-with-sriov.adoc
+++ b/virt/vm_networking/virt-using-dpdk-with-sriov.adoc
@@ -6,9 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-The Data Plane Development Kit (DPDK) provides a set of libraries and drivers for fast packet processing.
-
-You can configure clusters and virtual machines (VMs) to run DPDK workloads over SR-IOV networks.
+[role="_abstract"]
+The Data Plane Development Kit (DPDK) provides a set of libraries and drivers for fast packet processing. You can configure clusters and virtual machines (VMs) to run ultra-low latency packet processing workloads by using DPDK drivers with SR-IOV hardware.
 
 include::modules/virt-configuring-cluster-dpdk.adoc[leveloffset=+1]
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.18+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://redhat.atlassian.net/browse/DOCPLAN-169
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
https://109371--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/vm_networking/virt-accessing-vm-internal-fqdn.html
https://109371--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/vm_networking/virt-accessing-vm-secondary-network-fqdn.html
https://109371--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/vm_networking/virt-configuring-viewing-ips-for-vms.html
https://109371--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/vm_networking/virt-connecting-vm-to-default-pod-network.html
https://109371--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/vm_networking/virt-connecting-vm-to-ovn-secondary-network.html
https://109371--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/vm_networking/virt-connecting-vm-to-primary-udn.html
https://109371--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/vm_networking/virt-connecting-vm-to-secondary-udn.html
https://109371--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/vm_networking/virt-connecting-vm-to-service-mesh.html
https://109371--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/vm_networking/virt-dedicated-network-live-migration.html
https://109371--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/vm_networking/virt-exposing-vm-with-service.html
https://109371--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/vm_networking/virt-hot-plugging-network-interfaces.html
https://109371--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/vm_networking/virt-setting-interface-link-state.html
https://109371--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/vm_networking/virt-using-dpdk-with-sriov.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review: Not required
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
