### PR TITLE
OSDOCS 18559 Document how to perform boot image updates on the IBM Cloud platform follow up

### DIFF
--- a/machine_configuration/mco-update-boot-images.adoc
+++ b/machine_configuration/mco-update-boot-images.adoc
@@ -22,8 +22,4 @@ include::modules/mco-update-boot-images-about.adoc[leveloffset=+1]
 
 include::modules/mco-update-boot-images-configuring.adoc[leveloffset=+1]
 
-[role="_additional-resources"]
-.Additional resources
-* xref:../installing/installing_aws/ipi/ipi-aws-preparing-to-install.adoc#installation-obtaining-installer_ipi-aws-preparing-to-install[Obtaining the installation program]
-
 include::modules/mco-update-boot-images-disable.adoc[leveloffset=+1]


### PR DESCRIPTION
Neglected to remove the additional resources no longer needed. 