### PR TITLE
OSDOCS-17013-oc-mirror-callouts

### DIFF
--- a/modules/oc-mirror-creating-image-set-config.adoc
+++ b/modules/oc-mirror-creating-image-set-config.adoc
@@ -66,13 +66,13 @@ where:
 +
 `archiveSize`::  Specifies the `archiveSize` to set the maximum size, in GiB, of each file within the image set.
 `storageConfig`:: Specifies the back-end location to save the image set metadata to. This location can be a registry or local directory. It is required to specify `storageConfig` values.
-`imageURL`:: Specifies the registry URL for the storage backend.
-`channels.name`:: Specifies the channel to retrieve the {product-title} images from.
-`graph`:: Specifies `graph: true` to build and push the graph-data image to the mirror registry. The graph-data image is required to create OpenShift Update Service (OSUS). The `graph: true` field also generates the `UpdateService` custom resource manifest. The `oc` command-line interface (CLI) can use the `UpdateService` custom resource manifest to create OSUS. For more information, see _About the OpenShift Update Service_.
-`operators.catalog`:: Specifies the Operator catalog to retrieve the {product-title} images from.
-`packages.name`:: Specifies only certain Operator packages to include in the image set. Remove this field to retrieve all packages in the catalog.
-`operators.name`:: Specifies only certain channels of the Operator packages to include in the image set. You must always include the default channel for the Operator package even if you do not use the bundles in that channel. You can find the default channel by running the following command: `oc mirror list operators --catalog=<catalog_name> --package=<package_name> --v1`.
-`additionalImages.name`:: Specifies any additional images to include in image set.
+`storageConfig.registry.imageURL`:: Specifies the registry URL for the storage backend.
+`mirror.platform.channels.name`:: Specifies the channel to retrieve the {product-title} images from.
+`mirror.platform.graph`:: Specifies `graph: true` to build and push the graph-data image to the mirror registry. The graph-data image is required to create OpenShift Update Service (OSUS). The `graph: true` field also generates the `UpdateService` custom resource manifest. The `oc` command-line interface (CLI) can use the `UpdateService` custom resource manifest to create OSUS. For more information, see _About the OpenShift Update Service_.
+`mirror.operators.catalog`:: Specifies the Operator catalog to retrieve the {product-title} images from.
+`mirror.operators.packages.name`:: Specifies only certain Operator packages to include in the image set. Remove this field to retrieve all packages in the catalog.
+`mirror.operators.packages.channels.name`:: Specifies only certain channels of the Operator packages to include in the image set. You must always include the default channel for the Operator package even if you do not use the bundles in that channel. You can find the default channel by running the following command: `oc mirror list operators --catalog=<catalog_name> --package=<package_name> --v1`.
+`mirror.additionalImages.name`:: Specifies any additional images to include in image set.
 +
 [NOTE]
 ====


### PR DESCRIPTION
Version(s):
4.16+

Issue:
[OSDOCS-17013](https://redhat.atlassian.net/browse/OSDOCS-17013)

Link to docs preview:

* [Creating the image set configuration](https://109403--ocpdocs-pr.netlify.app/openshift-enterprise/latest/disconnected/installing-mirroring-disconnected.html#oc-mirror-creating-image-set-config_installing-mirroring-disconnected)
