### PR TITLE
[OSDOCS#18862]: Added conditions for TNF in backup and restore

### DIFF
--- a/modules/backup-etcd.adoc
+++ b/modules/backup-etcd.adoc
@@ -7,11 +7,17 @@
 [id="backing-up-etcd-data_{context}"]
 = Backing up etcd data
 
+[role="_abstract"]
 Follow these steps to back up etcd data by creating an etcd snapshot and backing up the resources for the static pods. This backup can be saved and used at a later time if you need to restore etcd.
 
 [IMPORTANT]
 ====
 Only save a backup from a single control plane host. Do not take a backup from each control plane host in the cluster.
+====
+
+[IMPORTANT]
+====
+For a 2-node cluster with fencing (TNF) setup, execute the steps to back up etcd data only on one node in the cluster. The cluster restore process is driven by data from a single node; therefore, it is sufficient to perform the etcd backup steps on only one node.
 ====
 
 .Prerequisites
@@ -40,7 +46,7 @@ $ oc debug --as-root node/<node_name>
 sh-4.4# chroot /host
 ----
 
-. If the cluster-wide proxy is enabled, export the `NO_PROXY`, `HTTP_PROXY`, and `HTTPS_PROXY` environment variables by running the following commands:
+. If the cluster-wide proxy is enabled, to export the `NO_PROXY`, `HTTP_PROXY`, and `HTTPS_PROXY` environment variables, run the following commands:
 +
 [source,terminal]
 ----
@@ -91,14 +97,14 @@ Snapshot saved at /home/core/assets/backup/snapshot_2021-06-25_190035.db
 snapshot db and kube resources are successfully saved to /home/core/assets/backup
 ----
 +
-In this example, two files are created in the `/home/core/assets/backup/` directory on the control plane host:
+In this example, 2 files are created in the `/home/core/assets/backup/` directory on the control plane host:
 
 * `snapshot_<datetimestamp>.db`: This file is the etcd snapshot. The `cluster-backup.sh` script confirms its validity.
-* `static_kuberesources_<datetimestamp>.tar.gz`: This file contains the resources for the static pods. If etcd encryption is enabled, it also contains the encryption keys for the etcd snapshot.
+* `static_kuberesources_<datetimestamp>.tar.gz`: This file has the resources for the static pods. If etcd encryption is enabled, it also contains the encryption keys for the etcd snapshot.
 +
 [NOTE]
 ====
-If etcd encryption is enabled, it is recommended to store this second file separately from the etcd snapshot for security reasons. However, this file is required to restore from the etcd snapshot.
+If etcd encryption is enabled, store this second file separately from the etcd snapshot for security reasons. However, this file is required to restore from the etcd snapshot.
 
-Keep in mind that etcd encryption only encrypts values, not keys. This means that resource types, namespaces, and object names are unencrypted.
+The etcd encryption only encrypts values, not keys. This means that resource types, namespaces, and object names are not encrypted.
 ====

--- a/modules/dr-restoring-cluster-state-sno.adoc
+++ b/modules/dr-restoring-cluster-state-sno.adoc
@@ -5,9 +5,10 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="dr-restoring-cluster-state-sno_{context}"]
-= Restoring to a previous cluster state for a single node
+= Restoring to an earlier cluster state for a single node
 
-You can use a saved etcd backup to restore a previous cluster state on a single node.
+[role="_abstract"]
+You can use a saved etcd backup to restore an earlier cluster state on a single node.
 
 [IMPORTANT]
 ====
@@ -16,7 +17,7 @@ When you restore your cluster, you must use an etcd backup that was taken from t
 
 .Prerequisites
 
-* Access to the cluster as a user with the `cluster-admin` role through a certificate-based `kubeconfig` file, like the one that was used during installation.
+* Access to the cluster as a user with the `cluster-admin` role through a certificate-based `kubeconfig` file, such as the one that was used during installation.
 * You have SSH access to control plane hosts.
 * A backup directory containing both the etcd snapshot and the resources for the static pods, which were from the same backup. The file names in the directory must be in the following formats: `snapshot_<datetimestamp>.db` and `static_kuberesources_<datetimestamp>.tar.gz`.
 
@@ -29,7 +30,7 @@ When you restore your cluster, you must use an etcd backup that was taken from t
 $ cp <etcd_backup_directory> /home/core
 ----
 
-. Run the following command in the single node to restore the cluster from a previous backup:
+. To restore the cluster from an earlier backup, run the following command on the single node:
 +
 [source,terminal]
 ----

--- a/modules/dr-restoring-cluster-state.adoc
+++ b/modules/dr-restoring-cluster-state.adoc
@@ -15,15 +15,28 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="dr-scenario-2-restoring-cluster-state_{context}"]
-= Restoring to a previous cluster state for more than one node
+= Restoring to an earlier cluster state for more than one node
 
-You can use a saved etcd backup to restore a previous cluster state or restore a cluster that has lost the majority of control plane hosts.
+[role="_abstract"]
+You can use a saved etcd backup to restore an earlier cluster state or restore a cluster that has lost the majority of control plane hosts.
 
-For high availability (HA) clusters, a three-node HA cluster requires you to shut down etcd on two hosts to avoid a cluster split. On four-node and five-node HA clusters, you must shut down three hosts. Quorum requires a simple majority of nodes. The minimum number of nodes required for quorum on a three-node HA cluster is two. On four-node and five-node HA clusters, the minimum number of nodes required for quorum is three. If you start a new cluster from backup on your recovery host, the other etcd members might still be able to form quorum and continue service.
+For a 2-node cluster with fencing (TNF) setup, a single surviving node can continue to operate in degraded mode. Use a saved etcd backup to restore an earlier cluster state if only one node is operational, or when both nodes have failed and you need to restart the cluster from a known safe state. In both cases, perform the restore procedure on a single node. The peer node automatically synchronizes its data with the restored node when it rejoins the cluster.
+
+For high availability (HA) clusters, to maintain high availability and prevent a cluster split, shut down etcd on the following number of hosts:
+
+- For 3-node clusters: Shut down etcd on 2 hosts.
+- For 4-node and 5-node clusters: Shut down etcd on 3 hosts. 
+
+Quorum requires a simple majority of nodes. The minimum number of nodes required for a quorum is as follows: 
+
+- For 3-node HA cluster: 2. 
+- For 4-node and 5-node HA clusters: 3. 
+
+If you start a new cluster from backup on your recovery host, the other etcd members might still form a quorum and continue service.
 
 [NOTE]
 ====
-If your cluster uses a control plane machine set, see "Recovering a degraded etcd Operator" in "Troubleshooting the control plane machine set" for an etcd recovery procedure. For {product-title} on a single node, see "Restoring to a previous cluster state for a single node".
+If your cluster uses a control plane machine set, see "Recovering a degraded etcd Operator" in "Troubleshooting the control plane machine set" for an etcd recovery procedure. For {product-title} on a single node, see "Restoring to an earlier cluster state for a single node".
 ====
 
 [IMPORTANT]
@@ -33,7 +46,7 @@ When you restore your cluster, you must use an etcd backup that was taken from t
 
 .Prerequisites
 
-* Access to the cluster as a user with the `cluster-admin` role through a certificate-based `kubeconfig` file, like the one that was used during installation.
+* Access to the cluster as a user with the `cluster-admin` role through a certificate-based `kubeconfig` file, such as the one that was used during installation.
 * A healthy control plane host to use as the recovery host.
 * You have SSH access to control plane hosts.
 * A backup directory containing both the `etcd` snapshot and the resources for the static pods, which were from the same backup. The file names in the directory must be in the following formats: `snapshot_<datetimestamp>.db` and `static_kuberesources_<datetimestamp>.tar.gz`.
@@ -50,11 +63,11 @@ For non-recovery control plane nodes, it is not required to establish SSH connec
 
 . Establish SSH connectivity to each of the control plane nodes, including the recovery host.
 +
-`kube-apiserver` becomes inaccessible after the restore process starts, so you cannot access the control plane nodes. For this reason, it is recommended to establish SSH connectivity to each control plane host in a separate terminal.
+`kube-apiserver` becomes inaccessible after the restore process starts, so you cannot access the control plane nodes. For this reason, establish SSH connectivity to each control plane host in a separate terminal.
 +
 [IMPORTANT]
 ====
-If you do not complete this step, you will not be able to access the control plane hosts to complete the restore procedure, and you will be unable to recover your cluster from this state.
+If you do not complete this step, you cannot access the control plane hosts to complete the restore procedure, and you cannot recover your cluster from this state.
 ====
 
 . Using SSH, connect to each control plane node and run the following command to disable etcd:
@@ -68,23 +81,34 @@ $ sudo -E /usr/local/bin/disable-etcd.sh
 +
 This procedure assumes that you copied the `backup` directory containing the etcd snapshot and the resources for the static pods to the `/home/core/` directory of your recovery control plane host.
 
-. Use SSH to connect to the recovery host and restore the cluster from a previous backup by running the following command:
+. Use SSH to connect to the recovery host. To restore the cluster from an earlier backup, run the following command:
 +
 [source,terminal]
 ----
-$ sudo -E /usr/local/bin/cluster-restore.sh /home/core/<etcd-backup-directory>
+$ sudo -E /usr/local/bin/cluster-restore.sh /home/core/<etcd_backup_directory>
 ----
 
 . Exit the SSH session.
+  
+. When the API responds, to turn off the etcd Operator quorum guard, run the following command:
++
+[IMPORTANT]
+====
+For a 2-node cluster with fencing (TNF) setup, do not:
 
-. Once the API responds, turn off the etcd Operator quorum guard by running the following command:
+  * Change the etcd Operator quorum setting. 
+
+  * Turn the etcd Operator quorum off.
+
+  * Turn the etcd Operator quorum on back.
+====
 +
 [source,terminal]
 ----
 $ oc patch etcd/cluster --type=merge -p '{"spec": {"unsupportedConfigOverrides": {"useUnsupportedUnsafeNonHANonProductionUnstableEtcd": true}}}'
 ----
 
-. Monitor the recovery progress of the control plane by running the following command:
+. To monitor the recovery progress of the control plane, run the following command:
 +
 [source,terminal]
 ----
@@ -96,7 +120,7 @@ $ oc adm wait-for-stable-cluster
 It can take up to 15 minutes for the control plane to recover.
 ====
 
-. Once recovered, enable the quorum guard by running the following command:
+. When recovered, to enable the quorum guard, run the following command:
 +
 [source,terminal]
 ----
@@ -105,7 +129,7 @@ $ oc patch etcd/cluster --type=merge -p '{"spec": {"unsupportedConfigOverrides":
 
 .Troubleshooting
 
-If you see no progress rolling out the etcd static pods, you can force redeployment from the `cluster-etcd-operator` by running the following command:
+If you see no progress rolling out the etcd static pods, to manually force an etcd redeployment from the `cluster-etcd-operator`, run the following command:
 
 [source,terminal]
 ----


### PR DESCRIPTION
Version(s):
4.22

Issue:
https://redhat.atlassian.net/browse/OSDOCS-18862

Link to docs preview:

For Backup: 
https://109410--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/control_plane_backup_and_restore/backing-up-etcd.html#backing-up-etcd-data_backup-etcd

For restoring: 
https://109410--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/control_plane_backup_and_restore/disaster_recovery/scenario-2-restoring-cluster-state.html

QE review:
- [x] QE has approved this change.


Additional information:
Made changes as per the Google Doc provided: https://docs.google.com/document/d/13kyRrQAGn6611Taa6Fb-_DlXcMjSytcfzmX96rxLO94/edit?tab=t.0
