### PR TITLE
OADP-7028: Fix ConceptLink in OADP 1.5 RNs

### DIFF
--- a/backup_and_restore/application_backup_and_restore/release-notes/oadp-1-5-release-notes.adoc
+++ b/backup_and_restore/application_backup_and_restore/release-notes/oadp-1-5-release-notes.adoc
@@ -13,7 +13,7 @@ The release notes for {oadp-first} 1.5 describe new features and enhancements, d
 
 [NOTE]
 ====
-For additional information about {oadp-short}, see link:https://access.redhat.com/articles/5456281[{oadp-first} FAQ].
+For additional information about {oadp-short}, see _{oadp-first} FAQ_.
 ====
 
 include::modules/oadp-1-5-5-release-notes.adoc[leveloffset=+1]
@@ -27,3 +27,8 @@ include::modules/oadp-1-5-2-release-notes.adoc[leveloffset=+1]
 include::modules/oadp-1-5-1-release-notes.adoc[leveloffset=+1]
 
 include::modules/oadp-1-5-0-release-notes.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+== Additional resources
+
+* link:https://access.redhat.com/articles/5456281[{oadp-first} FAQ]


### PR DESCRIPTION
Version(s):
OCP 4.19+

Issue:
[OADP-7028](https://issues.redhat.com/browse/OADP-7028)

Link to docs preview:
- [OADP 1.5 release notes](https://109414--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/release-notes/oadp-1-5-release-notes.html)

QE review not required as these are markup changes only.

Summary: Fix ConceptLink in OADP 1.5 Release Notes in preparation for DITA.