### PR TITLE
[enterprise-4.18] OCPBUGS#77836: Remove references to Elasticsearch from OKE docs

### DIFF
--- a/welcome/oke_about.adoc
+++ b/welcome/oke_about.adoc
@@ -194,7 +194,7 @@ the kubevirt.io open source project.
 === Advanced cluster management
 {oke} is compatible with your additional purchase of {rh-rhacm-first} for
 Kubernetes. An {oke} subscription does not offer a cluster-wide log aggregation
-solution or support Elasticsearch, Fluentd, or Kibana-based logging solutions.
+solution.
 {SMProductName} capabilities derived from the open-source istio.io and kiali.io
 projects that offer OpenTracing observability for containerized services on
 {product-title} are not supported in {oke}.


### PR DESCRIPTION
CP of #109243 with commit ID dc9dc921dad87f075912070d2bb4a0fea6821f1d

Version(s):
4.18

Issue:

