### PR TITLE
RHDEVDOCS-7408: Content creation for GitOps 1.20.1 RN

### DIFF
--- a/modules/gitops-release-notes-1-20-1.adoc
+++ b/modules/gitops-release-notes-1-20-1.adoc
@@ -1,0 +1,36 @@
+// Module included in the following assembly:
+//
+// * release_notes/gitops-release-notes-1-20.adoc
+
+:_mod-docs-content-type: REFERENCE
+
+[id="gitops-release-notes-1-20-1_{context}"]
+= Release notes for {gitops-title} 1.20.1
+
+[role="_abstract"]
+{gitops-title} 1.20.1 is available on {OCP} 4.14, 4.16, 4.17, 4.18, 4.19, 4.20, and 4.21.
+
+[id="errata-updates-1-20-1_{context}"]
+== Errata updates
+
+RHEA-2026:6378 - {gitops-title} 1.20.1 enhancement update advisory::
+Issued: 2026-04-01
++
+The list of enhancements that are included in this release is documented in the following advisory:
++
+* link:https://access.redhat.com/errata/RHEA-2026:6378[RHEA-2026:6378]
+
+If you have installed the {gitops-title} Operator in the default namespace, run the following command to view the container images in this release:
+
+[source,terminal]
+----
+$ oc describe deployment gitops-operator-controller-manager -n openshift-gitops-operator
+----
+
+[id="fixed-issues-1-20-1_{context}"]
+== Fixed issues
+
+Prevent unintended AppProjects deletion during resync::
+Before this update, `AppProjects` managed by autonomous agents could be unintentionally deleted during resync operations. This occurred when a principal restart triggered resync and the `AppProject` destination names did not match the agent name, leading to incorrect reconciliation. With this update, the reconciliation logic preserves these `AppProjects`, preventing unintended deletion during resync.
++
+link:https://issues.redhat.com/browse/GITOPS-9200[GITOPS-9200]

--- a/release_notes/gitops-release-notes-1-20.adoc
+++ b/release_notes/gitops-release-notes-1-20.adoc
@@ -30,6 +30,9 @@ include::modules/go-compatibility-and-support-matrix.adoc[leveloffset=+1]
 
 // Modules included, most to least recent
 
+// Release notes for Red Hat OpenShift GitOps 1.20.1
+include::modules/gitops-release-notes-1-20-1.adoc[leveloffset=+1]
+
 // Release notes for Red Hat OpenShift GitOps 1.20.0
 include::modules/gitops-release-notes-1-20-0.adoc[leveloffset=+1]
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

gitops-docs-1.20

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

https://redhat.atlassian.net/browse/RHDEVDOCS-7408

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

[Release notes for Red Hat OpenShift GitOps 1.20.1](https://109416--ocpdocs-pr.netlify.app/openshift-gitops/latest/release_notes/gitops-release-notes-1-20.html#gitops-release-notes-1-20-1_gitops-release-notes)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

SME review: @jparsai 
Peer review: bdooley@redhat.com
QE review: @Naveena-058 

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
