### PR TITLE
TELCODOCS-2610: Configuring alt names for network interfaces

### DIFF
--- a/modules/k8s-nmstate-about-alternative-names.adoc
+++ b/modules/k8s-nmstate-about-alternative-names.adoc
@@ -1,0 +1,19 @@
+// Module included in the following assemblies:
+//
+// * networking/k8s_nmstate/k8s-nmstate-updating-node-network-config.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="k8s-nmstate-alternative-interface-names_{context}"]
+= Configure alternative network interface names
+
+[role="_abstract"]
+You can assign alternative names to network interfaces to create consistent, descriptive labels across cluster nodes.
+Alternative names help you overcome the 15-character kernel interface name limitation and simplify automation in environments where interface naming varies across hardware.
+
+Alternative interface names provide the following benefits:
+
+* **Consistent naming**: Apply standardized names regardless of underlying hardware naming schemes, which is useful in heterogeneous clusters.
+* **Descriptive labels**: Use descriptive names up to 127 characters, such as `production-external-interface`, in addition to kernel-assigned names like `ens3f0`.
+* **Simplified automation**: Reference interfaces by names that remain constant across different node types, reducing configuration errors.
+
+You can use alternative names anywhere that accepts a standard interface name, including bond ports, VLAN base interfaces, bridge ports, and route next-hop interfaces.

--- a/modules/k8s-nmstate-creating-alternative-interface-names-by-identifier.adoc
+++ b/modules/k8s-nmstate-creating-alternative-interface-names-by-identifier.adoc
@@ -1,0 +1,142 @@
+// Module included in the following assemblies:
+//
+// * networking/k8s_nmstate/k8s-nmstate-updating-node-network-config.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="k8s-nmstate-creating-alternative-interface-names-by-identifier_{context}"]
+= Create alternative interface names by MAC address or PCI address
+
+[role="_abstract"]
+You can match network interfaces by MAC address or peripheral component interconnect (PCI) address to create configurations that target interfaces based on hardware identifiers rather than interface name.
+
+MAC address matching is useful when you want to target a specific network interface controller.
+PCI address matching is useful when interface names vary across nodes but hardware slot locations remain consistent.
+
+.Prerequisites
+
+* You installed the Kubernetes NMState Operator.
+* You have access to the cluster as a user with the `cluster-admin` role.
+* You installed the OpenShift CLI (`oc`).
+* You identified the target interface by MAC address or PCI address.
+
+.Procedure
+
+. Create a `NodeNetworkConfigurationPolicy` custom resource (CR) to define alternative names for a target interface by using one of the following methods:
++
+.. To target an interface by MAC address, create a file named `identifier-alt-names.yaml` with content similar to the following example:
++
+[source,yaml]
+----
+apiVersion: nmstate.io/v1
+kind: NodeNetworkConfigurationPolicy
+metadata:
+  name: mac-alt-names-policy
+spec:
+  nodeSelector:
+    kubernetes.io/hostname: <node_name>
+  desiredState:
+    interfaces:
+      - name: <interface_name>
+        type: ethernet
+        identifier: mac-address
+        mac-address: <mac_address>
+        state: up
+        alt-names:
+          - name: <alternative_name_1>
+          - name: <alternative_name_2>
+----
++
+where:
++
+* `<node_name>` is the target node name.
+* `<interface_name>` is any identifier because the interface is matched by MAC address.
+* `<mac_address>` is the MAC address of the target interface.
+* `<alternative_name_1>` and `<alternative_name_2>` are the alternative names you want to assign.
+
+.. To target an interface by PCI address, create a file named `identifier-alt-names.yaml` with content similar to the following example:
++
+[source,yaml]
+----
+apiVersion: nmstate.io/v1
+kind: NodeNetworkConfigurationPolicy
+metadata:
+  name: pci-alt-names-policy
+spec:
+  nodeSelector:
+    node-role.kubernetes.io/worker: ""
+  desiredState:
+    interfaces:
+      - name: <interface_name>
+        type: ethernet
+        state: up
+        identifier: pci-address
+        pci-address: <pci_address>
+        alt-names:
+          - name: <alternative_name_1>
+          - name: <alternative_name_2>
+----
++
+where:
++
+* `<interface_name>` is any identifier because the interface is matched by PCI address.
+* `<pci_address>` is the PCI address of the target interface in the format `domain:bus:device.function`, for example, `0000:01:00.0`.
+* `<alternative_name_1>` and `<alternative_name_2>` are the alternative names you want to assign.
++
+[NOTE]
+====
+This example uses `node-role.kubernetes.io/worker: ""` to target all worker nodes. Use this only when all workers have the same PCI slot configuration. For heterogeneous clusters, use `kubernetes.io/hostname: <node_name>` or hardware-specific labels.
+====
+
+. Apply the policy to the cluster by running the following command:
++
+[source,terminal]
+----
+$ oc apply -f identifier-alt-names.yaml
+----
+
+.Verification
+
+. Verify that the policy was applied successfully by running the following command:
++
+[source,terminal]
+----
+$ oc get nncp <policy_name> -o yaml
+----
++
+Check the `status` section to confirm the policy state is `Available`:
++
+[source,yaml]
+----
+status:
+  conditions:
+  - lastTransitionTime: "2026-03-31T12:00:00Z"
+    message: 3/3 nodes successfully configured
+    reason: SuccessfullyConfigured
+    status: "True"
+    type: Available
+----
+
+. Create a debug pod on the target node and open a shell to the node filesystem by running the following command:
++
+[source,terminal]
+----
+$ oc debug node/<node_name>
+----
+
+. Verify that the alternative names are configured on the interface by running the following command:
++
+[source,terminal]
+----
+sh-4.4# ip link show <interface_name>
+----
++
+.Example output
+[source,terminal]
+----
+2: ens1f0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc mq state UP mode DEFAULT group default qlen 1000
+    link/ether 00:11:22:33:44:55 brd ff:ff:ff:ff:ff:ff
+    altname production-uplink
+    altname external-interface
+----
++
+The `altname` entries show the configured alternative names.

--- a/modules/k8s-nmstate-creating-alternative-interface-names.adoc
+++ b/modules/k8s-nmstate-creating-alternative-interface-names.adoc
@@ -1,0 +1,122 @@
+// Module included in the following assemblies:
+//
+// * networking/k8s_nmstate/k8s-nmstate-updating-node-network-config.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="k8s-nmstate-creating-alternative-interface-names-by-name_{context}"]
+= Create alternative interface names by interface name
+
+[role="_abstract"]
+You can create alternative names for network interfaces to enable consistent, descriptive interface references across cluster nodes.
+Alternative names persist across reboots and can be used anywhere standard interface names are accepted.
+
+[IMPORTANT]
+====
+You cannot configure alternative names on the `br-ex` bridge or any OVN-Kubernetes-managed Open vSwitch bridge.
+You also cannot configure alternative names on interfaces, bonds, VLANs, or other devices associated with the `br-ex` bridge.
+====
+
+.Prerequisites
+
+* You installed the Kubernetes NMState Operator.
+* You have access to the cluster as a user with the `cluster-admin` role.
+* You installed the OpenShift CLI (`oc`).
+* You identified the target interface by interface name.
+* The target interface is not the `br-ex` bridge, an OVN-Kubernetes-managed bridge, or associated with these bridges.
+
+.Procedure
+
+. Create a `NodeNetworkConfigurationPolicy` custom resource (CR) to define alternative names for a target interface.
++
+[NOTE]
+====
+Alternative names are appended to any existing alternative names.
+If you apply a policy multiple times with the same alternative names, the configuration remains unchanged.
+====
++
+The following example creates a file named `ethernet-alt-names.yaml`:
++
+[source,yaml]
+----
+apiVersion: nmstate.io/v1
+kind: NodeNetworkConfigurationPolicy
+metadata:
+  name: ethernet-alt-names-policy
+spec:
+  nodeSelector:
+    kubernetes.io/hostname: <node_name>
+  desiredState:
+    interfaces:
+      - name: <interface_name>
+        type: ethernet
+        state: up
+        alt-names:
+          - name: <alternative_name_1>
+          - name: <alternative_name_2>
+----
++
+where:
++
+* `<node_name>` is the target node name. To target multiple nodes, use a different label selector such as `node-role.kubernetes.io/worker: ""`.
+* `<interface_name>` is the target interface name.
+* `<alternative_name_1>` and `<alternative_name_2>` are the alternative names you want to assign.
+
+. Apply the policy to the cluster by running the following command:
++
+[source,terminal]
+----
+$ oc apply -f ethernet-alt-names.yaml
+----
++
+.Example output
+[source,terminal]
+----
+nodenetworkconfigurationpolicy.nmstate.io/ethernet-alt-names-policy created
+----
+
+.Verification
+
+. Verify that the policy was applied successfully by running the following command:
++
+[source,terminal]
+----
+$ oc get nncp ethernet-alt-names-policy -o yaml
+----
++
+Check the `status` section to confirm the policy state is `Available`:
++
+[source,yaml]
+----
+status:
+  conditions:
+  - lastTransitionTime: "2026-03-31T12:00:00Z"
+    message: 2/2 nodes successfully configured
+    reason: SuccessfullyConfigured
+    status: "True"
+    type: Available
+----
+
+. Create a debug pod on the target node and open a shell to the node filesystem by running the following command:
++
+[source,terminal]
+----
+$ oc debug node/<node_name>
+----
+
+. Verify that the alternative names are configured on the interface by running the following command:
++
+[source,terminal]
+----
+sh-4.4# ip link show <interface_name>
+----
++
+.Example output
+[source,terminal]
+----
+2: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc fq_codel state UP mode DEFAULT group default qlen 1000
+    link/ether 00:11:22:33:44:55 brd ff:ff:ff:ff:ff:ff
+    altname production-network
+    altname external-interface
+----
++
+The `altname` entries show the configured alternative names.

--- a/modules/k8s-nmstate-deleting-alternative-interface-names.adoc
+++ b/modules/k8s-nmstate-deleting-alternative-interface-names.adoc
@@ -1,0 +1,183 @@
+// Module included in the following assemblies:
+//
+// * networking/k8s_nmstate/k8s-nmstate-updating-node-network-config.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="k8s-nmstate-deleting-alternative-interface-names_{context}"]
+= Delete alternative interface names
+
+[role="_abstract"]
+You can remove alternative names from network interfaces when they are no longer needed.
+Removing alternative names requires explicitly marking them for deletion in a `NodeNetworkConfigurationPolicy` resource.
+
+[WARNING]
+====
+Alternative names used as bond ports (`link-aggregation.port.name`), VLAN base interfaces (`vlan.base-iface`), bridge ports (`linux-bridge.port.name`), or route next-hop interfaces might cause those configurations to fail if the name is removed.
+====
+
+.Prerequisites
+
+* The Kubernetes NMState Operator is installed.
+* You have access to the cluster as a user with the `cluster-admin` role.
+* You installed the OpenShift CLI (`oc`).
+* You configured alternative names on the target interface.
+
+.Procedure
+
+. Create or update a `NodeNetworkConfigurationPolicy` custom resource (CR) to remove specific alternative names by using one of the following methods:
+
+.. To target an interface by interface name, create a file named `remove-alt-names.yaml` with content similar to the following example:
++
+[source,yaml]
+----
+apiVersion: nmstate.io/v1
+kind: NodeNetworkConfigurationPolicy
+metadata:
+  name: remove-alt-names-policy
+spec:
+  nodeSelector:
+    kubernetes.io/hostname: <node_name>
+  desiredState:
+    interfaces:
+      - name: <interface_name>
+        type: ethernet
+        state: up
+        alt-names:
+          - name: <alternative_name_to_remove>
+            state: absent
+          - name: <another_alternative_name_to_remove>
+            state: absent
+----
++
+where:
++
+* `<node_name>` is the target node name. To target multiple nodes, use a different label selector such as `node-role.kubernetes.io/worker: ""`.
+* `<interface_name>` is the target interface name.
+* `<alternative_name_to_remove>` is the alternative name you want to delete.
+
+.. To target an interface by MAC address, create a file named `remove-alt-names.yaml` with content similar to the following example:
++
+[source,yaml]
+----
+apiVersion: nmstate.io/v1
+kind: NodeNetworkConfigurationPolicy
+metadata:
+  name: remove-alt-names-policy
+spec:
+  nodeSelector:
+    kubernetes.io/hostname: <node_name>
+  desiredState:
+    interfaces:
+      - name: <interface_name>
+        type: ethernet
+        identifier: mac-address
+        mac-address: <mac_address>
+        state: up
+        alt-names:
+          - name: <alternative_name_to_remove>
+            state: absent
+          - name: <another_alternative_name_to_remove>
+            state: absent
+----
++
+where:
++
+* `<node_name>` is the target node name.
+* `<interface_name>` is any identifier because the interface is matched by MAC address.
+* `<mac_address>` is the MAC address of the target interface.
+* `<alternative_name_to_remove>` is the alternative name you want to delete.
+
+.. To target an interface by PCI address, create a file named `remove-alt-names.yaml` with content similar to the following example:
++
+[source,yaml]
+----
+apiVersion: nmstate.io/v1
+kind: NodeNetworkConfigurationPolicy
+metadata:
+  name: remove-alt-names-policy
+spec:
+  nodeSelector:
+    kubernetes.io/hostname: <node_name>
+  desiredState:
+    interfaces:
+      - name: <interface_name>
+        type: ethernet
+        identifier: pci-address
+        pci-address: <pci_address>
+        state: up
+        alt-names:
+          - name: <alternative_name_to_remove>
+            state: absent
+          - name: <another_alternative_name_to_remove>
+            state: absent
+----
++
+where:
++
+* `<node_name>` is the target node name.
+* `<interface_name>` is any identifier because the interface is matched by PCI address.
+* `<pci_address>` is the PCI address of the target interface in the format `domain:bus:device.function` (for example, `0000:01:00.0`).
+* `<alternative_name_to_remove>` is the alternative name you want to delete.
+
+. Apply the policy to remove the alternative names by running the following command:
++
+[source,terminal]
+----
+$ oc apply -f remove-alt-names.yaml
+----
+
+.Verification
+
+. Verify that the policy was applied successfully:
++
+[source,terminal]
+----
+$ oc get nncp remove-alt-names-policy -o yaml
+----
++
+Check the `status` section to confirm the policy state is `Available`:
++
+[source,yaml]
+----
+status:
+  conditions:
+  - lastTransitionTime: "2026-03-31T12:00:00Z"
+    message: 1/1 nodes successfully configured
+    reason: SuccessfullyConfigured
+    status: "True"
+    type: Available
+----
+
+. Access the target node:
++
+[source,terminal]
+----
+$ oc debug node/<node_name>
+----
+
+. Verify that the alternative name was removed:
++
+[source,terminal]
+----
+sh-4.4# ip link show <interface_name>
+----
++
+.Example output
+[source,terminal]
+----
+2: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc fq_codel state UP mode DEFAULT group default qlen 1000
+    link/ether 00:11:22:33:44:55 brd ff:ff:ff:ff:ff:ff
+    altname production-network
+    altname external-interface
+----
++
+The removed alternative name (for example, `deprecated-name`) should no longer appear in the `altname` entries.
++
+[NOTE]
+====
+* If you remove an alternative name from the policy YAML without setting `state: absent`, the NMState Operator does not delete it from the interface.
+Alternative names use an incremental change model where applying a policy appends new names.
+You must explicitly mark names for deletion with `state: absent`.
+
+* If you delete the entire interface configuration, all associated alternative names are also deleted.
+====

--- a/modules/nw-sriov-device-discovery.adoc
+++ b/modules/nw-sriov-device-discovery.adoc
@@ -8,7 +8,7 @@
 = Automated discovery of SR-IOV network devices
 
 The SR-IOV Network Operator searches your cluster for SR-IOV capable network devices on worker nodes.
-The Operator creates and updates a SriovNetworkNodeState custom resource (CR) for each worker node that provides a compatible SR-IOV network device.
+The Operator creates and updates a `SriovNetworkNodeState` custom resource (CR) for each worker node that provides a compatible SR-IOV network device.
 
 The CR is assigned the same name as the worker node.
 The `status.interfaces` list provides information about the network devices on a node.
@@ -19,18 +19,14 @@ Do not modify a `SriovNetworkNodeState` object.
 The Operator creates and manages these resources automatically.
 ====
 
-[id="example-sriovnetworknodestate_{context}"]
-== Example SriovNetworkNodeState object
-
 The following YAML is an example of a `SriovNetworkNodeState` object created by the SR-IOV Network Operator:
 
-.An SriovNetworkNodeState object
 [source,yaml]
 ----
 apiVersion: sriovnetwork.openshift.io/v1
 kind: SriovNetworkNodeState
 metadata:
-  name: node-25 <1>
+  name: node-25
   namespace: openshift-sriov-network-operator
   ownerReferences:
   - apiVersion: sriovnetwork.openshift.io/v1
@@ -41,11 +37,13 @@ metadata:
 spec:
   dpConfigVersion: "39824"
 status:
-  interfaces: <2>
+  interfaces:
   - deviceID: "1017"
     driver: mlx5_core
     mtu: 1500
     name: ens785f0
+    altNames:
+    - production-nic
     pciAddress: "0000:18:00.0"
     totalvfs: 8
     vendor: 15b3
@@ -79,5 +77,7 @@ status:
     vendor: "8086"
   syncStatus: Succeeded
 ----
-<1> The value of the `name` field is the same as the name of the worker node.
-<2> The `interfaces` stanza includes a list of all of the SR-IOV devices discovered by the Operator on the worker node.
+
+* `metadata.name` is the same as the name of the worker node.
+* `status.interfaces` lists all SR-IOV devices discovered by the Operator on the worker node.
+* `status.interfaces.altNames` lists any alternative interface names configured through the Kubernetes NMState Operator. You can use these names in the `nicSelector.pfNames` field of a `SriovNetworkNodePolicy` CR.

--- a/modules/nw-sriov-networknodepolicy-object.adoc
+++ b/modules/nw-sriov-networknodepolicy-object.adoc
@@ -90,7 +90,7 @@ If you specify `rootDevices`, you must also specify a value for `vendor`, `devic
 
 <12> Optional: The device hexadecimal device identifier of the SR-IOV network device. For example, `101b` is the device ID for a Mellanox ConnectX-6 device.
 
-<13> Optional: An array of one or more physical function (PF) names the resource must apply to.
+<13> Optional: An array of one or more physical function (PF) names the resource must apply to. You can specify either the kernel-assigned interface name or an alternative name configured through the Kubernetes NMState Operator.
 
 <14> Optional: An array of one or more PCI bus addresses the resource must apply to. For example `0000:02:00.1`.
 

--- a/modules/virt-example-nmstate-IP-management.adoc
+++ b/modules/virt-example-nmstate-IP-management.adoc
@@ -123,6 +123,34 @@ interfaces:
 # ...
 ----
 
+[id="virt-example-nmstate-IP-management-pci_{context}"]
+== PCI address
+
+You can use a peripheral component interconnect (PCI) address to identify a network interface based on hardware slot location rather than using the interface name or MAC address. PCI address matching is useful when interface names vary across nodes but hardware slot locations remain consistent.
+
+Set the `identifier` value to `pci-address` to identify a network interface by its PCI address. You must enter a specific PCI address in the `pci-address` parameter field. The PCI address must use the format `domain:bus:device.function`, for example, `0000:01:00.0`.
+
+[NOTE]
+====
+You can still specify a value for the `name` parameter, but setting the `identifier: pci-address` value means that a PCI address is used as the primary identifier for a network interface.
+====
+
+The following snippet specifies a PCI address as the primary identifier for an Ethernet device:
+
+[source,yaml]
+----
+# ...
+interfaces:
+- name: sriov-nic
+  type: ethernet
+  state: up
+  identifier: pci-address
+  pci-address: "0000:86:00.0"
+  ipv4:
+    enabled: false
+# ...
+----
+
 [id="virt-example-nmstate-IP-management-dns_{context}"]
 == DNS
 

--- a/networking/k8s_nmstate/k8s-nmstate-updating-node-network-config.adoc
+++ b/networking/k8s_nmstate/k8s-nmstate-updating-node-network-config.adoc
@@ -73,6 +73,18 @@ include::modules/virt-confirming-policy-updates-on-nodes.adoc[leveloffset=+2]
 // Removing an interface from nodes
 include::modules/virt-removing-interface-from-nodes.adoc[leveloffset=+2]
 
+// Configure alternative network interface names
+include::modules/k8s-nmstate-about-alternative-names.adoc[leveloffset=+1]
+
+// Creating alternative interface names by interface name
+include::modules/k8s-nmstate-creating-alternative-interface-names.adoc[leveloffset=+2]
+
+// Creating alternative interface names by MAC address or PCI address
+include::modules/k8s-nmstate-creating-alternative-interface-names-by-identifier.adoc[leveloffset=+2]
+
+// Deleting alternative interface names
+include::modules/k8s-nmstate-deleting-alternative-interface-names.adoc[leveloffset=+2]
+
 // Example policy configurations for different interfaces
 include::modules/virt-nmstate-example-policy-configurations.adoc[leveloffset=+1]
 


### PR DESCRIPTION
[TELCODOCS-2610](https://redhat.atlassian.net/browse/TELCODOCS-2610): 

Version(s):
4.22+

Issue:
https://redhat.atlassian.net/browse/TELCODOCS-2610

New content preview:

- https://109421--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/k8s_nmstate/k8s-nmstate-updating-node-network-config.html#k8s-nmstate-alternative-interface-names_k8s-nmstate-updating-node-network-config
- https://109421--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/k8s_nmstate/k8s-nmstate-updating-node-network-config.html#virt-example-nmstate-IP-management-pci_k8s-nmstate-updating-node-network-config

Reference in SR-IOV docs preview:

- https://109421--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/hardware_networks/configuring-sriov-device#nw-sriov-networknodepolicy-object_configuring-sriov-device 
- https://109421--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/hardware_networks/configuring-sriov-device#discover-sr-iov-devices_configuring-sriov-device

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
