### PR TITLE
[enterprise-4.17] OSDOCS-17013-oc-mirror-callouts

### DIFF
--- a/modules/oc-mirror-creating-image-set-config.adoc
+++ b/modules/oc-mirror-creating-image-set-config.adoc
@@ -36,36 +36,39 @@ $ oc mirror init --registry <storage_backend> > imageset-config.yaml <1>
 ----
 kind: ImageSetConfiguration
 apiVersion: mirror.openshift.io/v1alpha2
-archiveSize: 4                                                      <1>
-storageConfig:                                                      <2>
+archiveSize: 4
+storageConfig:
   registry:
-    imageURL: example.com/mirror/oc-mirror-metadata                 <3>
+    imageURL: example.com/mirror/oc-mirror-metadata
     skipTLS: false
 mirror:
   platform:
     channels:
-    - name: stable-{product-version}                                             <4>
+    - name: stable-{product-version}
       type: ocp
-    graph: true                                                     <5>
+    graph: true
   operators:
-  - catalog: registry.redhat.io/redhat/redhat-operator-index:v{product-version}  <6>
+  - catalog: registry.redhat.io/redhat/redhat-operator-index:v{product-version}
     packages:
-    - name: serverless-operator                                     <7>
+    - name: serverless-operator
       channels:
-      - name: stable                                                <8>
+      - name: stable
   additionalImages:
-  - name: registry.redhat.io/ubi9/ubi:latest                        <9>
+  - name: registry.redhat.io/ubi9/ubi:latest
   helm: {}
 ----
-<1> Add `archiveSize` to set the maximum size, in GiB, of each file within the image set.
-<2> Set the back-end location to save the image set metadata to. This location can be a registry or local directory. It is required to specify `storageConfig` values.
-<3> Set the registry URL for the storage backend.
-<4> Set the channel to retrieve the {product-title} images from.
-<5> Add `graph: true` to build and push the graph-data image to the mirror registry. The graph-data image is required to create OpenShift Update Service (OSUS). The `graph: true` field also generates the `UpdateService` custom resource manifest. The `oc` command-line interface (CLI) can use the `UpdateService` custom resource manifest to create OSUS. For more information, see _About the OpenShift Update Service_.
-<6> Set the Operator catalog to retrieve the {product-title} images from.
-<7> Specify only certain Operator packages to include in the image set. Remove this field to retrieve all packages in the catalog.
-<8> Specify only certain channels of the Operator packages to include in the image set. You must always include the default channel for the Operator package even if you do not use the bundles in that channel. You can find the default channel by running the following command: `oc mirror list operators --catalog=<catalog_name> --package=<package_name>`.
-<9> Specify any additional images to include in image set.
++
+where:
++
+`archiveSize`::  Specifies the `archiveSize` to set the maximum size, in GiB, of each file within the image set.
+`storageConfig`:: Specifies the back-end location to save the image set metadata to. This location can be a registry or local directory. It is required to specify `storageConfig` values.
+`storageConfig.registry.imageURL`:: Specifies the registry URL for the storage backend.
+`mirror.platform.channels.name`:: Specifies the channel to retrieve the {product-title} images from.
+`mirror.platform.graph`:: Specifies `graph: true` to build and push the graph-data image to the mirror registry. The graph-data image is required to create OpenShift Update Service (OSUS). The `graph: true` field also generates the `UpdateService` custom resource manifest. The `oc` command-line interface (CLI) can use the `UpdateService` custom resource manifest to create OSUS. For more information, see _About the OpenShift Update Service_.
+`mirror.operators.catalog`:: Specifies the Operator catalog to retrieve the {product-title} images from.
+`mirror.operators.packages.name`:: Specifies only certain Operator packages to include in the image set. Remove this field to retrieve all packages in the catalog.
+`mirror.operators.packages.channels.name`:: Specifies only certain channels of the Operator packages to include in the image set. You must always include the default channel for the Operator package even if you do not use the bundles in that channel. You can find the default channel by running the following command: `oc mirror list operators --catalog=<catalog_name> --package=<package_name> --v1`.
+`mirror.additionalImages.name`:: Specifies any additional images to include in image set.
 +
 [NOTE]
 ====


### PR DESCRIPTION
CP of #109403 with commit ID a1b5fc34be2116245b762810a20ed1754d5b98f3

Version(s):
4.17

Issue:
[OSDOCS-17013](https://redhat.atlassian.net/browse/OSDOCS-17013)

Link to docs preview:

* [Creating the image set configuration](https://109403--ocpdocs-pr.netlify.app/openshift-enterprise/latest/disconnected/installing-mirroring-disconnected.html#oc-mirror-creating-image-set-config_installing-mirroring-disconnected)
