### PR TITLE
OSDOCS WMCO 10.19.2 release notes

### DIFF
--- a/modules/windows-containers-release-notes-10-19-2.adoc
+++ b/modules/windows-containers-release-notes-10-19-2.adoc
@@ -6,21 +6,14 @@
 [id="windows-containers-release-notes-10-19-2_{context}"]
 = Release notes for Red Hat Windows Machine Config Operator 10.19.2
 
-Issued: DD MONTH 2026
+Issued: 15 April 2026
 
 [role="_abstract"]
 You can review the following release notes to learn about the bug fixes provided in this release of the Windows Machine Config Operator (WMCO). 
 
-The components of the WMCO 10.19.2 were released in link:https://access.redhat.com/errata/RHSA-2026:TBD[RHSA-2026:TBD].
-
-[id="wmco-10-19-2-new-features_{context}"]
-== New features and improvements
-
-New feature::
-Description
+The components of the WMCO 10.19.2 were released in link:https://access.redhat.com/errata/RHBA-2026:8345[RHBA-2026:8345].
 
 [id="wmco-10-19-2-bug-fixes_{context}"]
 == Bug fixes
 
-* Before this update, With this release, (link:https://issues.redhat.com/browse/OCPBUGS-55915[*OCPBUGS-55915*])
-
+* Before this update, the `hybridOverlay` service was not using the trusted CA bundle when connecting to {product-title}, because the `--k8s-cacert` option was missing from the service command. Because of this, users could encounter trust issues or failures when the `hybridOverlay` service attempted to communicate securely with {product-title} clusters by using custom or internal CAs. With this release, the `hybridOverlay` service command now includes the `--k8s-cacert flag` that points to the trusted CA bundle. As a result, the `hybridOverlay` service uses the trusted CA bundle for secure communication, preventing trust issues and ensuring compatibility with the cluster. (link:https://issues.redhat.com/browse/OCPBUGS-65856[OCPBUGS-65856])


### PR DESCRIPTION
https://redhat.atlassian.net/browse/WINC-1783

Link to docs preview:
Release notes for Red Hat Windows Machine Config Operator 10.19.2 -- One bug fix doc text that was previously reviewed for the [bug in the 10.21.1 release](https://github.com/openshift/openshift-docs/pull/107025/changes#diff-f25ecf6560356cac93159579c56144a513d5e33e3f43d7d185766ef34522b5c4R32) and two other releases.

**DO NOT MERGE UNTIL WMCO 10.19.2 RELEASES (planned 8-Apr) AND [PR 108967](https://github.com/openshift/openshift-docs/pull/108967) IS FIRST MERGED**

**UPDATE WITH ERRATA AND LINK WHEN READY**
