### PR TITLE
OSDOCS-17013-oc-mirror-callouts-v1

### DIFF
--- a/modules/oc-mirror-creating-image-set-config.adoc
+++ b/modules/oc-mirror-creating-image-set-config.adoc
@@ -67,7 +67,7 @@ where:
 `mirror.platform.graph`:: Specifies `graph: true` to build and push the graph-data image to the mirror registry. The graph-data image is required to create OpenShift Update Service (OSUS). The `graph: true` field also generates the `UpdateService` custom resource manifest. The `oc` command-line interface (CLI) can use the `UpdateService` custom resource manifest to create OSUS. For more information, see _About the OpenShift Update Service_.
 `mirror.operators.catalog`:: Specifies the Operator catalog to retrieve the {product-title} images from.
 `mirror.operators.packages.name`:: Specifies only certain Operator packages to include in the image set. Remove this field to retrieve all packages in the catalog.
-`mirror.operators.packages.channels.name`:: Specifies only certain channels of the Operator packages to include in the image set. You must always include the default channel for the Operator package even if you do not use the bundles in that channel. You can find the default channel by running the following command: `oc mirror list operators --catalog=<catalog_name> --package=<package_name> --v1`.
+`mirror.operators.packages.channels.name`:: Specifies only certain channels of the Operator packages to include in the image set. You must always include the default channel for the Operator package even if you do not use the bundles in that channel. You can find the default channel by running the following command: `oc mirror list operators --catalog=<catalog_name> --package=<package_name>`.
 `mirror.additionalImages.name`:: Specifies any additional images to include in image set.
 +
 [NOTE]


### PR DESCRIPTION
Remove "v12" from https://github.com/openshift/openshift-docs/pull/109427

Version(s):
4.17

Issue:
[OSDOCS-17013](https://redhat.atlassian.net/browse/OSDOCS-17013)

Link to docs preview:

* [Creating the image set configuration](https://109435--ocpdocs-pr.netlify.app/openshift-enterprise/latest/disconnected/mirroring/installing-mirroring-disconnected.html#oc-mirror-creating-image-set-config_installing-mirroring-disconnected)
