### PR TITLE
OSDOCS-18936: adds MCP server registration to MCP gateway

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -73,10 +73,8 @@ Name: Configuring the MCP gateway, register servers, and create policies
 Dir: mcp_gateway_config
 Distros: rhcl
 Topics:
-- Name: Configuring the MCP gateway
-  File: mcp-gateway-config-listener-route
-- Name: Register MCP servers
-  File: mcp-gateway-register-servers
+- Name: Registering on-premise MCP servers
+  File: mcp-gateway-register-on-prem-mcp-servers
 - Name: Configuring authentication for the MCP gateway
   File: mcp-gateway-authz
 - Name: Configuring authorization for the MCP gateway

--- a/mcp_gateway_config/mcp-gateway-config-listener-route.adoc
+++ b/mcp_gateway_config/mcp-gateway-config-listener-route.adoc
@@ -1,8 +1,0 @@
-:_mod-docs-content-type: ASSEMBLY
-include::_attributes/attributes.adoc[]
-[id="mcp-gateway-config-listener-route"]
-= Configuring the {mcpg} listener and route
-:context: mcp-gateway-config-listener-route
-
-[role="_abstract"]
-FPO assembly

--- a/mcp_gateway_config/mcp-gateway-register-on-prem-mcp-servers.adoc
+++ b/mcp_gateway_config/mcp-gateway-register-on-prem-mcp-servers.adoc
@@ -1,0 +1,14 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="mcp-gateway-register-on-prem-mcp-servers"]
+= Registering on-prem MCP servers
+include::_attributes/attributes.adoc[]
+:context: mcp-gateway-register-servers
+
+[role="_abstract"]
+To begin using MCP servers with your {mcpg}, you must register each server by creating an `HTTPRoute` custom resource (CR) and a corresponding `MCPServerRegistration` CR that references the route.
+
+include::modules/proc-mcp-gateway-register-mcp-server.adoc[leveloffset=+1]
+
+include::modules/ref-mcp-gateway-mcpserverregistration-cr.adoc[leveloffset=+2]
+
+include::modules/proc-mcp-gateway-verify-mcp-server-registration.adoc[leveloffset=+1]

--- a/mcp_gateway_config/mcp-gateway-register-servers.adoc
+++ b/mcp_gateway_config/mcp-gateway-register-servers.adoc
@@ -1,8 +1,0 @@
-:_mod-docs-content-type: ASSEMBLY
-[id="mcp-gateway-register-servers"]
-= Registering MCP servers
-include::_attributes/attributes.adoc[]
-:context: mcp-gateway-register-servers
-
-[role="_abstract"]
-FPO assembly

--- a/modules/proc-mcp-gateway-register-mcp-server.adoc
+++ b/modules/proc-mcp-gateway-register-mcp-server.adoc
@@ -1,0 +1,186 @@
+// Module included in the following assemblies:
+//
+// *mcp_gateway_config/mcp-gateway-register-servers.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="proc-register-mcp-server_{context}"]
+= Registering an MCP server for use with the MCP gateway
+
+[role="_abstract"]
+Direct your {mcpg} to discover and route to your MCP servers by registering them. To connect each MCP server to the {mcpg}, you must first create an `HTTPRoute` custom resource (CR) that routes to the server. Then, you must create an `MCPServerRegistration` custom resource (CR) that references the `HTTPRoute` CR.
+
+.Prerequisites
+
+* You installed the {mcpg}.
+* You have a `Gateway` object configured with your requirements.
+* You configured a listener for the {mcpg}.
+* You created an `HTTPRoute` CR for the {mcpg}.
+* You created and applied an `MCPGatewayExtension` CR.
+* If you are using a gateway in a namespace that is different from the one where the `MCPGatewayExtension` CR was applied, you created a `ReferenceGrant` object.
+* You are logged into an {ocp} cluster with an `admin` role.
+
+.Procedure
+
+. Create an `HTTPRoute` CR that routes to your MCP server by using the following template:
++
+.Example HTTPRoute CR
+[source,yaml,subs="+quotes"]
+----
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: _<mcp_api_key_server_route>_
+  namespace: _<mcp_test>_
+  labels:
+    mcp-server: 'true'
+spec:
+  parentRefs:
+    - name: _<mcp_gateway>_
+      namespace: _<gateway_system>_
+  hostnames:
+    - 'api-key-server.mcp.local'
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: _<mcp_api_key_server>_
+          port: 9090
+----
++
+* For the `metadata.name:` parameter value, replace `_<mcp_api_key_server_route>_` with the name of the http route.
+* For the `metadata.namespace:` parameter value, replace `_<mcp_test>_` with the namespace you need to use. The `HTTPRoute` CR must be in the same namespace as the `MCPServerRegistration` CR unless `targetRef.namespace` is set in the `MCPServerRegistration` CR.
+* For the `spec.parentRefs.name:` and `spec.parentRefs.namespace:` parameter values, use the values from the `Gateway` CR that you are targeting.
+* For the  `spec.hostnames:` parameter value, replace the list with your required internal routing hostname.
+* For the `spec.rules.backendRefs.name:` parameter value, replace `_<mcp_api_key_server>_` with your {mcpg} service name.
+* For the `spec.rules.backendRefs.port:` parameter value, replace `9090` with your MCP server port.
+
+. Apply the CR by running the following command:
++
+[source,terminal,subs="+quotes"]
+----
+$ oc apply -f _<mcp_api_key_server_route>_
+----
++
+Replace `_<mcp_api_key_server_route>_` with the name of the http route you created.
+
+. Create an `MCPServerRegistration` CR that references your `HTTPRoute` CR by using the following template:
++
+.Example MCPServerRegistration CR
+[source,yaml,subs="+quotes"]
+----
+apiVersion: mcp.kuadrant.io/v1alpha1
+kind: MCPServerRegistration
+metadata:
+  name: _<mcp_server_one>_
+  namespace: _<mcp_test>_
+spec:
+  toolPrefix: _<serverone_>_
+  targetRef:
+    group: "gateway.networking.k8s.io"
+    kind: "HTTPRoute"
+    name: "_<mcp_api_key_server_route>_"
+    namespace: "_<mcp_test>_"
+  credentialRef:
+    name: _<mcp_server_one_secret>_
+    key: api-key
+----
++
+* Replace the `metadata.name:` and `metadata.namespace:` field values with the ones you want to use. If you did not use a `ReferenceGrant` CR, the value of `metadata.namespace:` must be the same as specified in the `HTTPRoute` object.
+* Replace the `spec.toolPrefix:` field with the value that you want to prefix the tools available with this MCP server.
+* Replace the `spec.targetRef.name field` value with the name of the `HTTPRoute` CR you applied. In this example, `_<mcp_api_key_server_route>_` is used.
+* Replace the `spec.targetRef.namespace:` field value with the namespace where your `HTTPRoute` CR is applied. In this example, `_<mcp_test>_` is used.
+* Replace the `credentialRef.name:` field value with the name of your `Secret` CR. In this example, `_<mcp_server_one_secret>_` is used. You can omit this parameter if your MCP server does not require authentication or authorization.
+* For more information about these parameters, see "Understanding the `MCPServerRegistration` custom resource."
+
+. Apply the CR by running the following command:
++
+[source,terminal,subs="+quotes"]
+----
+$ oc apply -f _<mcp_server_one>_
+----
++
+Replace `_<mcp_server_one>_` with the `name` of your `MCPServerRegistration` CR.
+
+. Check the status of your current `MCPServerRegistration` CR by running the following command:
++
+[source,terminal,subs="+quotes"]
+----
+$ oc get mcpsr -n _<mcp_server_one>_
+----
++
+Replace `_<mcp_server_one>_` with the `name` of your `MCPServerRegistration` CR.
++
+.Example output
+[source,text]
+----
+NAMESPACE   NAME            PREFIX      TARGET                     PATH   READY   TOOLS   CREDENTIALS   AGE
+mcp-test    my-mcp-server   myserver_   mcp-api-key-server-route   /mcp   True    4                     30s
+----
+
+. Check the status of all `MCPServerRegistration` CRs in the cluster by running the following command:
++
+[source,terminal]
+----
+$ oc get mcpsr -A
+----
++
+.Example output
+[source,text]
+----
+NAMESPACE    NAME               READY   TARGET-ROUTE           PREFIX       AGE
+mcp-test     mcp-server-one     True    mcp-api-key-server     serverone    14m
+mcp-test     mcp-server-two     True    mcp-generic-route      servertwo    2d
+mcp-prod     analytics-tools    True    analytics-route        stats        5h
+----
+
+. Check on tool discovery status by running the following command:
++
+[source,terminal]
+----
+$ oc get mcpsr -A -o yaml
+----
++
+.Example output
+[source,yaml]
+----
+apiVersion: v1
+items:
+- apiVersion: mcp.kuadrant.io/v1alpha1
+  kind: MCPServerRegistration
+  metadata:
+    annotations:
+      kubectl.kubernetes.io/last-applied-configuration: |
+        {"apiVersion":"mcp.kuadrant.io/v1alpha1","kind":"MCPServerRegistration","metadata":{"annotations":{},"labels":{"mcp.kuadrant.io/managed":"true"},"name":"test-server1","namespace":"mcp-test"},"spec":{"targetRef":{"group":"gateway.networking.k8s.io","kind":"HTTPRoute","name":"mcp-server1-route"},"toolPrefix":"test1_"}}
+    creationTimestamp: "2026-03-31T09:50:26Z"
+    finalizers:
+    - mcp.kuadrant.io/finalizer
+    generation: 1
+    labels:
+      mcp.kuadrant.io/managed: "true"
+    name: test-server1
+    namespace: mcp-test
+    resourceVersion: "302234"
+    uid: d9603011-2e0f-4f3f-88d6-eda986f365d1
+  spec:
+    path: /mcp
+    targetRef:
+      group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: mcp-server1-route
+    toolPrefix: test1_
+  status:
+    conditions:
+    - lastTransitionTime: "2026-04-07T08:49:53Z"
+      message: server added successfully. Total tools added 5
+      reason: Ready
+      status: "True"
+      type: Ready
+    discoveredTools: 5
+kind: List
+metadata:
+  resourceVersion: "
+----
++
+When you examine the `status` block for `discoveredTools`, you can see that the `status.conditions:` fields show that an MCP server is present and that tools are available and ready.

--- a/modules/proc-mcp-gateway-verify-mcp-server-registration.adoc
+++ b/modules/proc-mcp-gateway-verify-mcp-server-registration.adoc
@@ -1,0 +1,57 @@
+
+// Module included in the following assemblies:
+//
+// *mcp_gateway_config/mcp-gateway-register-servers.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="proc-mcp-gateway-verify-mcp-server-registration_{context}"]
+= Verifying an MCP server registration
+
+[role="_abstract"]
+You can test that your MCP server tools are available through the MCP gateway by starting a session and listing available tools.
+
+.Prerequisites
+
+* You registered the MCP server you want to verify.
+* You completed all {mcpg} installation and configuration steps.
+
+.Procedure
+
+. Connect to the MCP gateway and initialize a session to dump response headers to a file by running the following command:
++
+[source,terminal]
+----
+$ curl -s -D /tmp/mcp_headers -X POST http://_<example.com>_/mcp \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {"protocolVersion": "2025-11-25", "capabilities": {}, "clientInfo": {"name": "test-client", "version": "1.0.0"}}}'
+----
++
+Replace _<example.com>_ with your URL and port.
+
+. Extract the MCP session ID from the dumped response headers by running the following command:
++
+[source,terminal]
+----
+$ SESSION_ID=$(grep -i "mcp-session-id:" /tmp/mcp_headers | cut -d' ' -f2 | tr -d '\r') \
+echo "MCP Session ID: $SESSION_ID"
+----
+
+. List the tools using the session ID by running the following command:
++
+[source,terminal,subs="+quotes"]
+----
+$ curl -X POST http://_<example.com>_/mcp \
+  -H "Content-Type: application/json" \
+  -H "mcp-session-id: $SESSION_ID" \
+  -d '{"jsonrpc": "2.0", "id": 2, "method": "tools/list"}'
+----
++
+Replace _<example.com>_ with your URL and port.
+Your MCP server tools are listed in the response, prefixed with the `toolPrefix` value you configured in the `MCPServerRegistration` CR.
+
+. Clean up by running the following command:
++
+[source,terminal]
+----
+$ rm -f /tmp/mcp_headers
+----

--- a/modules/ref-mcp-gateway-mcpserverregistration-cr.adoc
+++ b/modules/ref-mcp-gateway-mcpserverregistration-cr.adoc
@@ -1,0 +1,71 @@
+// Module included in the following assemblies:
+//
+// *mcp_gateway_config/mcp-gateway-register-servers.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="ref-mcp-server-registration-cr_{context}"]
+= Understanding the MCPServerRegistration custom resource
+
+[role="_abstract"]
+You can explore the required parts and values for an `MCPServerRegistration` custom resource (CR) by studying the references contained here.
+
+.MCPServerRegistration
+
+[width="100%",cols="23%,19%,^26%,32%",options="header",]
+|===
+|*Field* |*Type* |*Required* |*Description*
+|`spec` |MCPServerRegistrationSpec |Yes
+|The specification for the `MCPServerRegistration` CR
+
+|`status`
+|MCPServerRegistrationStatus |No |The status for the CR
+|===
+
+.MCPServerRegistrationSpec
+
+[width="100%",cols="23%,19%,^26%,32%",options="header",]
+|===
+|*Field* |*Type* |*Required* |*Description*
+|`targetRef` |TargetReference |Yes |An `HTTPRoute` object that points to a backend MCP server. The controller discovers the backend service from this `HTTPRoute` CR and configures the broker to consolidate the MCP server's tools.
+
+|`toolPrefix` |String |No |The prefix added to all consolidated tools from referenced servers. Avoids naming conflicts when aggregating tools from multiple sources, such as `server1++_++search` and `server2++_++search`. Immutable setting.
+
+|`path` |String |No |The URL path where the MCP server endpoint is exposed. Default value is `/mcp`.
+
+|`credentialRef` |SecretReference |No |Reference to a `Secret` object that contains authentication credentials. The secret must have the `mcp.kuadrant.io/secret=true` label. The gateway makes the credentials available to the broker automatically.
+|===
+
+.TargetReference
+
+[width="100%",cols="23%,19%,^26%,32%",options="header",]
+|===
+|*Field* |*Type* |*Required* |*Description*
+|`group` |String |No |Group of the target resource. Default value is `gateway.networking.k8s.io`.
+
+|`kind` |String |No |Kind of the target resource. Default value is `HTTPRoute`.
+
+|`name` |String |Yes |Name of the target `HTTPRoute` object.
+
+|`namespace` |String |No |Namespace of the target resource. Defaults to same namespace.
+|===
+
+.SecretReference
+
+[width="100%",cols="23%,19%,^26%,32%",options="header",]
+|===
+|*Field* |*Type* |*Required* |*Description*
+|`name` |String |Yes |Name of the `Secret` CR.
+
+|`key` |String |No |Key within the `Secret` CR that has the credential value. Default value is `token`.
+|===
+
+.MCPServerRegistrationStatus
+
+[width="100%",cols="30%,26%,44%",options="header",]
+|===
+|*Field* |*Type* |*Description*
+|`conditions` |link:https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1++#++Condition[++Kubernetes meta/v1.Condition++]
+|List of conditions that define the status of the Kubernetes resource.
+
+|`discoveredTools` |Integer |Number of tools discovered from this `MCPServerRegistration` CR.
+|===


### PR DESCRIPTION
Version:
mcp-gateway-docs-tp

Issue:
https://redhat.atlassian.net/browse/OSDOCS-18936

Link to docs preview:
https://109444--ocpdocs-pr.netlify.app/rhcl/latest/mcp_gateway_config/mcp-gateway-register-on-prem-mcp-servers.html

QE review:
- [x] SME approved this change.
- [x] QE approved this change.
NOTE: this PR is just for on-prem/vanilla mcp server

Additional information:
Docs merge reviewer, the `mcp-gateway-docs-tp` is a Release branch, so content work is incremental. The entire branch will be integrated into the `rhcl-docs-main`, `rhcl-docs-1.3`, and `rhcl-docs-1.4` docs in late April, and therefore, not published anywhere now.