### PR TITLE
OADP-7040: Prepare OADP 1.4 RNs for DITA

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -3569,6 +3569,8 @@ Topics:
     Topics:
     - Name: OADP 1.4 release notes
       File: oadp-1-4-release-notes
+    - Name: Upgrading OADP 1.3 to 1.4
+      File: oadp-upgrade-notes-1-4
   - Name: OADP performance
     Dir: oadp-performance
     Topics:

--- a/backup_and_restore/application_backup_and_restore/release-notes/oadp-1-4-release-notes.adoc
+++ b/backup_and_restore/application_backup_and_restore/release-notes/oadp-1-4-release-notes.adoc
@@ -8,11 +8,11 @@ include::_attributes/attributes-openshift-dedicated.adoc[]
 toc::[]
 
 [role="_abstract"]
-The release notes for {oadp-first} describe new features and enhancements, deprecated features, product recommendations, known issues, and resolved issues.
+The release notes for {oadp-first} 1.4 describe new features and enhancements, deprecated features, product recommendations, known issues, and resolved issues.
 
 [NOTE]
 ====
-For additional information about {oadp-short}, see link:https://access.redhat.com/articles/5456281[{oadp-first} FAQs]
+For additional information about {oadp-short}, see _{oadp-first} FAQ_.
 ====
 
 include::modules/oadp-1-4-9-release-notes.adoc[leveloffset=+1]
@@ -20,10 +20,15 @@ include::modules/oadp-1-4-9-release-notes.adoc[leveloffset=+1]
 include::modules/oadp-1-4-8-release-notes.adoc[leveloffset=+1]
 
 include::modules/oadp-1-4-7-release-notes.adoc[leveloffset=+1]
+
 include::modules/oadp-1-4-6-release-notes.adoc[leveloffset=+1]
+
 include::modules/oadp-1-4-5-release-notes.adoc[leveloffset=+1]
+
 include::modules/oadp-1-4-4-release-notes.adoc[leveloffset=+1]
+
 include::modules/oadp-1-4-3-release-notes.adoc[leveloffset=+1]
+
 include::modules/oadp-1-4-2-release-notes.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
@@ -31,20 +36,10 @@ include::modules/oadp-1-4-2-release-notes.adoc[leveloffset=+1]
 * xref:../../../backup_and_restore/application_backup_and_restore/backing_up_and_restoring/oadp-deleting-backups.adoc#oadp-about-kopia-repo-maintenance_deleting-backups[About Kopia repository maintenance]
 
 include::modules/oadp-1-4-1-release-notes.adoc[leveloffset=+1]
+
 include::modules/oadp-1-4-0-release-notes.adoc[leveloffset=+1]
-include::modules/oadp-backing-up-dpa-configuration-1-4-0.adoc[leveloffset=+3]
-include::modules/oadp-upgrading-oadp-operator-1-4-0.adoc[leveloffset=+3]
 
-// TODO: Include this xref when the Operators book is added to the ROSA HCP docs.
-ifndef::openshift-rosa-hcp[]
 [role="_additional-resources"]
-.Additional resources
-* xref:../../../operators/admin/olm-upgrading-operators.adoc#olm-changing-update-channel_olm-upgrading-operators[Updating installed Operators]
-endif::openshift-rosa-hcp[]
+== Additional resources
 
-[id="oadp-converting-dpa-to-new-version-1-4-0_{context}"]
-=== Converting DPA to the new version
-
-To upgrade from OADP 1.3 to 1.4, no Data Protection Application (DPA) changes are required.
-
-include::modules/oadp-verifying-upgrade-1-4-0.adoc[leveloffset=+2]
+* link:https://access.redhat.com/articles/5456281[{oadp-first} FAQ]

--- a/backup_and_restore/application_backup_and_restore/release-notes/oadp-upgrade-notes-1-4.adoc
+++ b/backup_and_restore/application_backup_and_restore/release-notes/oadp-upgrade-notes-1-4.adoc
@@ -1,0 +1,34 @@
+:_mod-docs-content-type: ASSEMBLY
+
+[id="upgrade-notes-1-4"]
+= Upgrading OADP 1.3 to 1.4
+include::_attributes/common-attributes.adoc[]
+include::_attributes/attributes-openshift-dedicated.adoc[]
+:context: oadp-upgrade-notes-1-4
+
+toc::[]
+
+[role="_abstract"]
+Learn how to upgrade your existing {oadp-short} 1.3 installation to {oadp-short} 1.4.
+
+[NOTE]
+====
+Always upgrade to the next minor version. *Do not* skip versions. To update to a later version, upgrade only one channel at a time. For example, to upgrade from {oadp-first} 1.1 to 1.3, upgrade first to 1.2, and then to 1.3.
+====
+
+include::modules/oadp-changes-from-oadp-1-3-to-1-4.adoc[leveloffset=+1]
+
+include::modules/oadp-backing-up-dpa-configuration-1-4-0.adoc[leveloffset=+1]
+
+include::modules/oadp-upgrading-oadp-operator-1-4-0.adoc[leveloffset=+1]
+
+// TODO: Include this xref when the Operators book is added to the ROSA HCP docs.
+ifndef::openshift-rosa-hcp[]
+[role="_additional-resources"]
+.Additional resources
+* xref:../../../operators/admin/olm-upgrading-operators.adoc#olm-changing-update-channel_olm-upgrading-operators[Updating installed Operators]
+endif::openshift-rosa-hcp[]
+
+include::modules/oadp-converting-dpa-to-the-new-version-for-oadp-1-4-0.adoc[leveloffset=+1]
+
+include::modules/oadp-verifying-upgrade-1-4-0.adoc[leveloffset=+1]

--- a/modules/oadp-1-4-0-release-notes.adoc
+++ b/modules/oadp-1-4-0-release-notes.adoc
@@ -9,21 +9,22 @@
 [id="oadp-1-4-0-release-notes_{context}"]
 = OADP 1.4.0 release notes
 
-The {oadp-first} 1.4.0 release notes lists resolved issues and known issues.
+[role="_abstract"]
+The {oadp-first} 1.4.0 release notes list resolved issues and known issues.
 
 [id="resolved-issues-1-4-0_{context}"]
 == Resolved issues
 
-.Restore works correctly in {product-title} 4.16
-
+Restore works correctly in {product-title} 4.16::
 Previously, while restoring the deleted application namespace, the restore operation partially failed with the `resource name may not be empty` error in {product-title} 4.16.
 With this update, restore works as expected in {product-title} 4.16.
++
 link:https://issues.redhat.com/browse/OADP-4075[OADP-4075]
 
-.Data Mover backups work properly in the {product-title} 4.16 cluster
-
+Data Mover backups work properly in the {product-title} 4.16 cluster::
 Previously, Velero was using the earlier version of SDK where the `Spec.SourceVolumeMode` field did not exist. As a consequence, Data Mover backups failed in the {product-title} 4.16 cluster on the external snapshotter with version 4.2.
 With this update, external snapshotter is upgraded to version 7.0 and later. As a result, backups do not fail in the {product-title} 4.16 cluster.
++
 link:https://issues.redhat.com/browse/OADP-3922[OADP-3922]
 
 For a complete list of all issues resolved in this release, see the list of link:https://issues.redhat.com/issues/?filter=12438505[OADP 1.4.0 resolved issues] in Jira.
@@ -32,35 +33,10 @@ For a complete list of all issues resolved in this release, see the list of link
 [id="known-issues-1-4-0_{context}"]
 == Known issues
 
-.Backup fails when checksumAlgorithm is not set for MCG
-
+Backup fails when checksumAlgorithm is not set for MCG::
 While performing a backup of any application with Noobaa as the backup location, if the `checksumAlgorithm` configuration parameter is not set, backup fails. To fix this problem, if you do not provide a value for `checksumAlgorithm` in the Backup Storage Location (BSL) configuration, an empty value is added.
 The empty value is only added for BSLs that are created using Data Protection Application (DPA) custom resource (CR), and this value is not added if BSLs are created using any other method.
++
 link:https://issues.redhat.com/browse/OADP-4274[OADP-4274]
 
 For a complete list of all known issues in this release, see the list of link:https://issues.redhat.com/issues/?filter=12438506[OADP 1.4.0 known issues] in Jira.
-
-
-[id="upgrade-notes-1-4-0_{context}"]
-== Upgrade notes
-
-[NOTE]
-====
-Always upgrade to the next minor version. *Do not* skip versions. To update to a later version, upgrade only one channel at a time. For example, to upgrade from {oadp-first} 1.1 to 1.3, upgrade first to 1.2, and then to 1.3.
-====
-
-[id="changes-oadp-1-3-to-1-4_{context}"]
-=== Changes from OADP 1.3 to 1.4
-
-The Velero server has been updated from version 1.12 to 1.14. Note that there are no changes in the Data Protection Application (DPA).
-
-This changes the following:
-
-* The `velero-plugin-for-csi` code is now available in the Velero code, which means an `init` container is no longer required for the plugin.
-
-* Velero changed client Burst and QPS defaults from 30 and 20 to 100 and 100, respectively.
-
-* The `velero-plugin-for-aws` plugin updated default value of the `spec.config.checksumAlgorithm` field in `BackupStorageLocation` objects (BSLs) from `""` (no checksum calculation) to the `CRC32` algorithm. The checksum algorithm types are known to work only with AWS.
-Several S3 providers require the `md5sum` to be disabled by setting the checksum algorithm to `""`. Confirm `md5sum` algorithm support and configuration with your storage provider.
-+
-In OADP 1.4, the default value for BSLs created within DPA for this configuration is `""`. This default value means that the `md5sum` is not checked, which is consistent with OADP 1.3. For BSLs created within DPA, update it by using the `spec.backupLocations[].velero.config.checksumAlgorithm` field in the DPA. If your BSLs are created outside DPA, you can update this configuration by using `spec.config.checksumAlgorithm` in the BSLs.

--- a/modules/oadp-1-4-1-release-notes.adoc
+++ b/modules/oadp-1-4-1-release-notes.adoc
@@ -7,98 +7,104 @@
 [id="oadp-1-4-1-release-notes_{context}"]
 = OADP 1.4.1 release notes
 
-The {oadp-first} 1.4.1 release notes lists new features, resolved issues and bugs, and known issues.
+[role="_abstract"]
+The {oadp-first} 1.4.1 release notes list new features, resolved issues, and known issues.
 
 [id="new-features-1-4-1_{context}"]
 == New features
 
-.New DPA fields to update client qps and burst
-
+New DPA fields to update client qps and burst::
 You can now change Velero Server Kubernetes API queries per second and burst values by using the new Data Protection Application (DPA) fields. The new DPA fields are `spec.configuration.velero.client-qps` and `spec.configuration.velero.client-burst`, which both default to 100.
++
 link:https://issues.redhat.com/browse/OADP-4076[OADP-4076]
 
-.Enabling non-default algorithms with Kopia
-
+Enabling non-default algorithms with Kopia::
 With this update, you can now configure the hash, encryption, and splitter algorithms in Kopia to select non-default options to optimize performance for different backup workloads.
-
++
 To configure these algorithms, set the `env` variable of a `velero` pod in the `podConfig` section of the DataProtectionApplication (DPA) configuration. If this variable is not set, or an unsupported algorithm is chosen, Kopia will default to its standard algorithms.
++
 link:https://issues.redhat.com/browse/OADP-4640[OADP-4640]
 
 
 [id="resolved-issues-1-4-1_{context}"]
 == Resolved issues
 
-.Restoring a backup without pods is now successful
-
-Previously, restoring a backup without pods and having `StorageClass VolumeBindingMode` set as `WaitForFirstConsumer`, resulted in the `PartiallyFailed` status with an error: `fail to patch dynamic PV, err: context deadline exceeded`. 
+Restoring a backup without pods is now successful::
+Previously, restoring a backup without pods and having `StorageClass VolumeBindingMode` set as `WaitForFirstConsumer`, resulted in the `PartiallyFailed` status with an error: `fail to patch dynamic PV, err: context deadline exceeded`.
 With this update, patching dynamic PV is skipped and restoring a backup is successful without any `PartiallyFailed` status.
++
 link:https://issues.redhat.com/browse/OADP-4231[OADP-4231]
 
 
-.PodVolumeBackup CR now displays correct message
-
+PodVolumeBackup CR now displays correct message::
 Previously, the `PodVolumeBackup` custom resource (CR) generated an incorrect message, which was: `get a podvolumebackup with status "InProgress" during the server starting, mark it as "Failed"`.
 With this update, the message produced is now:
++
 [source,text]
 ----
 found a podvolumebackup with status "InProgress" during the server starting,
 mark it as "Failed".
 ----
++
 link:https://issues.redhat.com/browse/OADP-4224[OADP-4224]
 
-.Overriding imagePullPolicy is now possible with DPA
-
+Overriding imagePullPolicy is now possible with DPA::
 Previously, {oadp-short} set the `imagePullPolicy` parameter to `Always` for all images.
 With this update, {oadp-short} checks if each image contains `sha256` or `sha512` digest, then it sets `imagePullPolicy` to `IfNotPresent`; otherwise `imagePullPolicy` is set to `Always`. You can now override this policy by using the new `spec.containerImagePullPolicy` DPA field.
++
 link:https://issues.redhat.com/browse/OADP-4172[OADP-4172]
 
-.OADP Velero can now retry updating the restore status if initial update fails
-
+OADP Velero can now retry updating the restore status if initial update fails::
 Previously, {oadp-short} Velero failed to update the restored CR status. This left the status at `InProgress` indefinitely. Components which relied on the backup and restore CR status to determine the completion would fail.
 With this update, the restore CR status for a restore correctly proceeds to the `Completed` or `Failed` status.
++
 link:https://issues.redhat.com/browse/OADP-3227[OADP-3227]
 
-.Restoring BuildConfig Build from a different cluster is successful without any errors
-
+Restoring BuildConfig Build from a different cluster is successful without any errors::
 Previously, when performing a restore of the `BuildConfig` Build resource from a different cluster, the application generated an error on TLS verification to the internal image registry. The resulting error was `failed to verify certificate: x509: certificate signed by unknown authority` error.
 With this update, the restore of the `BuildConfig` build resources to a different cluster can proceed successfully without generating the `failed to verify certificate` error.
++
 link:https://issues.redhat.com/browse/OADP-4692[OADP-4692]
 
-.Restoring an empty PVC is successful
-
+Restoring an empty PVC is successful::
 Previously, downloading data failed while restoring an empty persistent volume claim (PVC). It failed with the following error:
++
 [source,text]
 ----
 data path restore failed: Failed to run kopia restore: Unable to load
     snapshot : snapshot not found
 ----
-With this update, the downloading of data proceeds to correct conclusion when restoring an empty PVC and the error message is not generated. 
++
+With this update, the downloading of data proceeds to correct conclusion when restoring an empty PVC and the error message is not generated.
++
 link:https://issues.redhat.com/browse/OADP-3106[OADP-3106]
 
-.There is no Velero memory leak in CSI and DataMover plugins
-
+There is no Velero memory leak in CSI and DataMover plugins::
 Previously, a Velero memory leak was caused by using the CSI and DataMover plugins. When the backup ended, the Velero plugin instance was not deleted and the memory leak consumed memory until an `Out of Memory` (OOM) condition was generated in the Velero pod. With this update, there is no resulting Velero memory leak when using the CSI and DataMover plugins.
++
 link:https://issues.redhat.com/browse/OADP-4448[OADP-4448]
 
-.Post-hook operation does not start before the related PVs are released
-
+Post-hook operation does not start before the related PVs are released::
 Previously, due to the asynchronous nature of the Data Mover operation, a post-hook might be attempted before the Data Mover persistent volume claim (PVC) releases the persistent volumes (PVs) of the related pods. This problem would cause the backup to fail with a `PartiallyFailed` status.
 With this update, the post-hook operation is not started until the related PVs are released by the Data Mover PVC, eliminating the `PartiallyFailed` backup status.
++
 link:https://issues.redhat.com/browse/OADP-3140[OADP-3140]
 
-.Deploying a DPA works as expected in namespaces with more than 37 characters
-
+Deploying a DPA works as expected in namespaces with more than 37 characters::
 When you install the OADP Operator in a namespace with more than 37 characters to create a new DPA, labeling the "cloud-credentials" Secret fails and the DPA reports the following error:
++
 ----
 The generated label name is too long.
 ----
++
 With this update, creating a DPA does not fail in namespaces with more than 37 characters in the name.
++
 link:https://issues.redhat.com/browse/OADP-3960[OADP-3960]
 
-.Restore is successfully completed by overriding the timeout error
-
+Restore is successfully completed by overriding the timeout error::
 Previously, in a large scale environment, the restore operation would result in a `Partiallyfailed` status with the error: `fail to patch dynamic PV, err: context deadline exceeded`.
 With this update, the `resourceTimeout` Velero server argument is used to override this timeout error resulting in a successful restore.
++
 link:https://issues.redhat.com/browse/OADP-4344[OADP-4344]
 
 For a complete list of all issues resolved in this release, see the list of link:https://issues.redhat.com/issues/?filter=12442016[OADP 1.4.1 resolved issues] in Jira.
@@ -107,21 +113,20 @@ For a complete list of all issues resolved in this release, see the list of link
 [id="known-issues-1-4-1_{context}"]
 == Known issues
 
-.Cassandra application pods enter into the `CrashLoopBackoff` status after restoring OADP
-
+Cassandra application pods enter into the `CrashLoopBackoff` status after restoring OADP::
 After {oadp-short} restores, the Cassandra application pods might enter `CrashLoopBackoff` status. To work around this problem, delete the `StatefulSet` pods that are returning the error `CrashLoopBackoff` state after restoring {oadp-short}. The `StatefulSet` controller then recreates these pods and it runs normally.
++
 link:https://issues.redhat.com/browse/OADP-4407[OADP-4407]
 
-.Deployment referencing ImageStream is not restored properly leading to corrupted pod and volume contents
-
+Deployment referencing ImageStream is not restored properly leading to corrupted pod and volume contents::
 During a File System Backup (FSB) restore operation, a `Deployment` resource referencing an `ImageStream` is not restored properly. The restored pod that runs the FSB, and the `postHook` is terminated prematurely.
-
++
 During the restore operation, the {ocp} controller updates the `spec.template.spec.containers[0].image` field in the `Deployment` resource with an updated `ImageStreamTag` hash. The update triggers the rollout of a new pod, terminating the pod on which `velero` runs the FSB along with the post-hook. 
 // TODO: Include this xref when the Images book is added to ROSA HCP.
 ifndef::openshift-rosa-hcp[]
 For more information about image stream trigger, see xref:../../../openshift_images/triggering-updates-on-imagestream-changes.adoc#triggering-updates-on-imagestream-changes[Triggering updates on image stream changes].
 endif::openshift-rosa-hcp[]
-
++
 The workaround for this behavior is a two-step restore process:
 
 . Perform a restore excluding the `Deployment` resources, for example:
@@ -141,4 +146,6 @@ $ velero restore create <RESTORE_NAME> \
   --from-backup <BACKUP_NAME> \
   --include-resources=deployment.apps
 ----
+
++
 link:https://issues.redhat.com/browse/OADP-3954[OADP-3954]

--- a/modules/oadp-1-4-2-release-notes.adoc
+++ b/modules/oadp-1-4-2-release-notes.adoc
@@ -7,42 +7,45 @@
 [id="oadp-1-4-2-release-notes_{context}"]
 = {oadp-short} 1.4.2 release notes
 
-The {oadp-first} 1.4.2 release notes lists new features, resolved issues and bugs, and known issues.
+[role="_abstract"]
+The {oadp-first} 1.4.2 release notes list new features, resolved issues, and known issues.
 
 [id="new-features-1-4-2_{context}"]
 == New features
 
-.Backing up different volumes in the same namespace by using the VolumePolicy feature is now possible
-
+Backing up different volumes in the same namespace by using the VolumePolicy feature is now possible::
 With this release, Velero provides resource policies to back up different volumes in the same namespace by using the `VolumePolicy` feature. The supported `VolumePolicy` feature to back up different volumes includes `skip`, `snapshot`, and `fs-backup` actions.
++
 link:https://issues.redhat.com/browse/OADP-1071[OADP-1071]
 
-.File system backup and data mover can now use short-term credentials
-
+File system backup and data mover can now use short-term credentials::
 File system backup and data mover can now use short-term credentials such as {aws-short} {sts-first} and {gcp-short} WIF. With this support, backup is successfully completed without any `PartiallyFailed` status.
++
 link:https://issues.redhat.com/browse/OADP-5095[OADP-5095]
 
 [id="resolved-issues-1-4-2_{context}"]
 == Resolved issues
 
-.DPA now reports errors if VSL contains an incorrect provider value 
-
+DPA now reports errors if VSL contains an incorrect provider value::
 Previously, if the provider of a Volume Snapshot Location (VSL) spec was incorrect, the Data Protection Application (DPA) reconciled successfully. With this update, DPA reports errors and requests for a valid provider value.
++
 link:https://issues.redhat.com/browse/OADP-5044[OADP-5044]
 
-.Data Mover restore is successful irrespective of using different OADP namespaces for backup and restore
-
+Data Mover restore is successful irrespective of using different OADP namespaces for backup and restore::
 Previously, when backup operation was executed by using {oadp-short} installed in one namespace but was restored by using {oadp-short} installed in a different namespace, the Data Mover restore failed. With this update, Data Mover restore is now successful.
++
 link:https://issues.redhat.com/browse/OADP-5460[OADP-5460]
 
-.SSE-C backup works with the calculated MD5 of the secret key
-
+SSE-C backup works with the calculated MD5 of the secret key::
 Previously, backup failed with the following error:
++
 [source,terminal]
 ----
 Requests specifying Server Side Encryption with Customer provided keys must provide the client calculated MD5 of the secret key.
 ----
++
 With this update, missing Server-Side Encryption with Customer-Provided Keys (SSE-C) base64 and MD5 hash are now fixed. As a result, SSE-C backup works with the calculated MD5 of the secret key. In addition, incorrect `errorhandling` for the `customerKey` size is also fixed.
++
 link:https://issues.redhat.com/browse/OADP-5388[OADP-5388]
 
 For a complete list of all issues resolved in this release, see the list of link:https://issues.redhat.com/issues/?filter=12452476[OADP 1.4.2 resolved issues] in Jira.
@@ -51,17 +54,17 @@ For a complete list of all issues resolved in this release, see the list of link
 [id="known-issues-1-4-2_{context}"]
 == Known issues
 
-.The nodeSelector spec is not supported for the Data Mover restore action
-
-When a Data Protection Application (DPA) is created with the `nodeSelector` field set in the `nodeAgent` parameter, Data Mover restore partially fails instead of completing the restore operation. 
+The nodeSelector spec is not supported for the Data Mover restore action::
+When a Data Protection Application (DPA) is created with the `nodeSelector` field set in the `nodeAgent` parameter, Data Mover restore partially fails instead of completing the restore operation.
++
 link:https://issues.redhat.com/browse/OADP-5260[OADP-5260]
 
-.The S3 storage does not use proxy environment when TLS skip verify is specified
-
+The S3 storage does not use proxy environment when TLS skip verify is specified::
 In the image registry backup, the S3 storage does not use the proxy environment when the `insecureSkipTLSVerify` parameter is set to `true`.
++
 link:https://issues.redhat.com/browse/OADP-3143[OADP-3143]
 
-.Kopia does not delete artifacts after backup expiration
-
+Kopia does not delete artifacts after backup expiration::
 Even after you delete a backup, Kopia does not delete the volume artifacts from the `${bucket_name}/kopia/${namespace}` on the S3 location after backup expired. For more information, see "About Kopia repository maintenance".
++
 link:https://issues.redhat.com/browse/OADP-5131[OADP-5131]

--- a/modules/oadp-1-4-3-release-notes.adoc
+++ b/modules/oadp-1-4-3-release-notes.adoc
@@ -7,13 +7,13 @@
 [id="oadp-1-4-3-release-notes_{context}"]
 = {oadp-short} 1.4.3 release notes
 
-The {oadp-first} 1.4.3 release notes lists the following new feature. 
+[role="_abstract"]
+The {oadp-first} 1.4.3 release notes list the following new feature.
 
 [id="new-features-1-4-3_{context}"]
 == New features
 
-.Notable changes in the `kubevirt` velero plugin in version 0.7.1
-
+Notable changes in the `kubevirt` velero plugin in version 0.7.1::
 With this release, the `kubevirt` velero plugin has been updated to version 0.7.1. Notable improvements include the following bug fix and new features:
 
 * Virtual machine instances (VMIs) are no longer ignored from backup when the owner VM is excluded.

--- a/modules/oadp-1-4-4-release-notes.adoc
+++ b/modules/oadp-1-4-4-release-notes.adoc
@@ -7,10 +7,13 @@
 [id="oadp-1-4-4-release-notes_{context}"]
 = {oadp-short} 1.4.4 release notes
 
-{oadp-first} 1.4.4 is a Container Grade Only (CGO) release, which is released to refresh the health grades of the containers. No code was changed in the product itself compared to that of {oadp-short} 1.4.3.
+[role="_abstract"]
+{oadp-first} 1.4.4 is a Container Grade Only (CGO) release, which is released to refresh the health grades of the containers. No code was changed in the product itself compared to that of {oadp-short} 1.4.3. One known issue was identified.
 
 [id="known-issues-1-4-4_{context}"]
 == Known issues
 
-.Issue with restoring stateful applications 
-When you restore a stateful application that uses the `azurefile-csi` storage class, the restore operation remains in the `Finalizing` phase. link:https://issues.redhat.com/browse/OADP-5508[(OADP-5508)]
+Issue with restoring stateful applications::
+When you restore a stateful application that uses the `azurefile-csi` storage class, the restore operation remains in the `Finalizing` phase.
++
+link:https://issues.redhat.com/browse/OADP-5508[OADP-5508]

--- a/modules/oadp-1-4-5-release-notes.adoc
+++ b/modules/oadp-1-4-5-release-notes.adoc
@@ -7,20 +7,22 @@
 [id="oadp-1-4-5-release-notes_{context}"]
 = {oadp-short} 1.4.5 release notes
 
-The {oadp-first} 1.4.5 release notes lists new features and resolved issues.
+[role="_abstract"]
+The {oadp-first} 1.4.5 release notes list new features and resolved issues.
 
 [id="new-features-1-4-5_{context}"]
 == New features
 
-.Collecting logs with the `must-gather` tool has been improved with a Markdown summary
-
+Collecting logs with the `must-gather` tool has been improved with a Markdown summary::
 You can collect logs and information about {oadp-first} custom resources by using the `must-gather` tool. The `must-gather` data must be attached to all customer cases.
-This tool generates a Markdown output file with the collected information, which is located in the clusters directory of the `must-gather` logs.  link:https://issues.redhat.com/browse/OADP-5904[(OADP-5904)]
+This tool generates a Markdown output file with the collected information, which is located in the clusters directory of the `must-gather` logs.
++
+link:https://issues.redhat.com/browse/OADP-5904[OADP-5904]
 
 [id="resolved-issues-1-4-5_{context}"]
 == Resolved issues
 
-{oadp-short} 1.4.5 fixes the following CVEs:: 
+{oadp-short} 1.4.5 fixes the following CVEs::
 
 * link:https://access.redhat.com/security/cve/CVE-2024-45337[CVE-2024-45337] 
 

--- a/modules/oadp-1-4-6-release-notes.adoc
+++ b/modules/oadp-1-4-6-release-notes.adoc
@@ -7,4 +7,5 @@
 [id="oadp-1-4-6-release-notes_{context}"]
 = {oadp-short} 1.4.6 release notes
 
+[role="_abstract"]
 {oadp-first} 1.4.6 is a Container Grade Only (CGO) release, which is released to refresh the health grades of the containers. No code was changed in the product itself compared to that of {oadp-short} 1.4.5.

--- a/modules/oadp-1-4-7-release-notes.adoc
+++ b/modules/oadp-1-4-7-release-notes.adoc
@@ -7,4 +7,5 @@
 [id="oadp-1-4-7-release-notes_{context}"]
 = {oadp-short} 1.4.7 release notes
 
+[role="_abstract"]
 {oadp-first} 1.4.7 is a Container Grade Only (CGO) release, which is released to refresh the health grades of the containers. No code was changed in the product itself compared to that of {oadp-short} 1.4.6.

--- a/modules/oadp-backing-up-dpa-configuration-1-4-0.adoc
+++ b/modules/oadp-backing-up-dpa-configuration-1-4-0.adoc
@@ -7,7 +7,8 @@
 [id="oadp-backing-up-dpa-configuration-1-4-0_{context}"]
 = Backing up the DPA configuration
 
-You must back up your current `DataProtectionApplication` (DPA) configuration.
+[role="_abstract"]
+Save your current `DataProtectionApplication` (DPA) configuration to a file. Backing up your configuration helps ensure you can restore your settings if any issues occur during the upgrade process.
 
 .Procedure
 * Save your current DPA configuration by running the following command:

--- a/modules/oadp-changes-from-oadp-1-3-to-1-4.adoc
+++ b/modules/oadp-changes-from-oadp-1-3-to-1-4.adoc
@@ -1,0 +1,22 @@
+// Module included in the following assemblies:
+//
+// * backup_and_restore/oadp-1-4-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+
+[id="oadp-changes-from-oadp-1-3-to-1-4_{context}"]
+= Changes from OADP 1.3 to 1.4
+
+[role="_abstract"]
+The Velero server has been updated from version 1.12 to 1.14. Although the Data Protection Application (DPA) remains unchanged, several plugins and default configuration values were updated.
+
+The changes are as follows:
+
+* The `velero-plugin-for-csi` code is now available in the Velero code, which means an `init` container is no longer required for the plugin.
+
+* Velero changed the client Burst default from 30 to 100 and the QPS default from 20 to 100.
+
+* The `velero-plugin-for-aws` plugin updated default value of the `spec.config.checksumAlgorithm` field in `BackupStorageLocation` objects (BSLs) from `""` (no checksum calculation) to the `CRC32` algorithm. For more information, see link:https://github.com/vmware-tanzu/velero-plugin-for-aws/blob/release-1.10/backupstoragelocation.md[Velero plugins for AWS Backup Storage Location]. The checksum algorithm types are known to work only with AWS.
+Several S3 providers require the `md5sum` to be disabled by setting the checksum algorithm to `""`. Confirm `md5sum` algorithm support and configuration with your storage provider.
++
+In OADP 1.4, the default value for BSLs created within DPA for this configuration is `""`. This default value means that the `md5sum` is not checked, which is consistent with OADP 1.3. For BSLs created within DPA, update it by using the `spec.backupLocations[].velero.config.checksumAlgorithm` field in the DPA. If your BSLs are created outside DPA, you can update this configuration by using `spec.config.checksumAlgorithm` in the BSLs.

--- a/modules/oadp-converting-dpa-to-the-new-version-for-oadp-1-4-0.adoc
+++ b/modules/oadp-converting-dpa-to-the-new-version-for-oadp-1-4-0.adoc
@@ -1,0 +1,11 @@
+// Module included in the following assemblies:
+//
+// * backup_and_restore/oadp-1-4-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+
+[id="oadp-converting-dpa-to-the-new-version-for-oadp-1-4-0_{context}"]
+= Converting DPA to the new version for OADP 1.4.0
+
+[role="_abstract"]
+To upgrade from OADP 1.3 to 1.4, no Data Protection Application (DPA) changes are required.

--- a/modules/oadp-upgrading-oadp-operator-1-4-0.adoc
+++ b/modules/oadp-upgrading-oadp-operator-1-4-0.adoc
@@ -7,7 +7,8 @@
 [id="oadp-upgrading-dpa-operator-1-4-0_{context}"]
 = Upgrading the OADP Operator
 
-Use the following procedure when upgrading the {oadp-first} Operator.
+[role="_abstract"]
+Upgrade the {oadp-first} Operator to ensure your installation has the latest enhancements and bug fixes.
 
 .Procedure
 

--- a/modules/oadp-verifying-upgrade-1-4-0.adoc
+++ b/modules/oadp-verifying-upgrade-1-4-0.adoc
@@ -7,7 +7,8 @@
 [id="verifying-upgrade-1-4-0_{context}"]
 = Verifying the upgrade
 
-Use the following procedure to verify the upgrade.
+[role="_abstract"]
+Verify the upgrade to ensure the integrity of the installation and the availability of backup storage locations.
 
 .Procedure
 
@@ -19,7 +20,7 @@ $ oc get all -n openshift-adp
 ----
 +
 .Example output
-+
+[source,terminal]
 ----
 NAME                                                     READY   STATUS    RESTARTS   AGE
 pod/oadp-operator-controller-manager-67d9494d47-6l8z8    2/2     Running   0          2m8s
@@ -49,9 +50,9 @@ replicaset.apps/velero-588db7f655                              1         1      
 ----
 $ oc get dpa dpa-sample -n openshift-adp -o jsonpath='{.status}'
 ----
++
 .Example output
 [source,yaml]
-+
 ----
 {"conditions":[{"lastTransitionTime":"2023-10-27T01:23:57Z","message":"Reconcile complete","reason":"Complete","status":"True","type":"Reconciled"}]}
 ----
@@ -64,9 +65,9 @@ $ oc get dpa dpa-sample -n openshift-adp -o jsonpath='{.status}'
 ----
 $ oc get backupstoragelocations.velero.io -n openshift-adp
 ----
++
 .Example output
 [source,yaml]
-+
 ----
 NAME           PHASE       LAST VALIDATED   AGE     DEFAULT
 dpa-sample-1   Available   1s               3d16h   true


### PR DESCRIPTION
This work is Cherry Picked OADP 1.4 Release Notes portion from 03c8181 xref:https://github.com/openshift/openshift-docs/pull/103873.


============
Version(s):
OCP 4.16-4.18

Issue:
[OADP-7040](https://redhat.atlassian.net/browse/OADP-7040)

Link to docs preview:
- [OADP 1.4 release notes](TBD)
- [Upgrading OADP 1.3 to 1.4](TBD)

QE review: Bypassing as this is markup changes only.

Changes:
Rewrite OADP 1.4 Release Notes in accordance with DITA (add abstracts, definition lists, split assemblies, etc.).