### PR TITLE
[enterprise-4.22][OSDOCS-18929]: Removing AWS-specific language from the HCP backup and restore procedure

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -2713,7 +2713,7 @@ Topics:
 #     File: hcp-recovering-etcd-cluster
 #   - Name: Backing up and restoring etcd in an on-premise environment
 #     File: hcp-backup-restore-on-premise
-#   - Name: Backing up and restoring etcd on AWS
+#   - Name: Backing up and restoring etcd the management cluster
 #     File: hcp-backup-restore-aws
 #   - Name: Backing up and restoring a hosted cluster on OpenShift Virtualization
 #     File: hcp-backup-restore-virt

--- a/hosted_control_planes/hcp_high_availability/hcp-backup-restore-aws.adoc
+++ b/hosted_control_planes/hcp_high_availability/hcp-backup-restore-aws.adoc
@@ -1,12 +1,12 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="hcp-backup-restore-aws"]
-= Backing up and restoring etcd on AWS
+= Backing up and restoring etcd on the management cluster
 include::_attributes/common-attributes.adoc[]
 :context: hcp-backup-restore-aws
 
 toc::[]
 
-You can back up and restore etcd on a hosted cluster on {aws-first} to fix failures.
+You can back up and restore etcd on the management cluster to fix failures.
 
 include::modules/backup-etcd-hosted-cluster.adoc[leveloffset=+1]
 


### PR DESCRIPTION
cherry picked from https://github.com/openshift/openshift-docs/pull/109329
