### PR TITLE
OSDOCS-17077: updates CQA pt 5

### DIFF
--- a/modules/migrating-from-x86-to-arm-cp.adoc
+++ b/modules/migrating-from-x86-to-arm-cp.adoc
@@ -6,6 +6,7 @@
 [id="migrating-from-x86-to-arm64-cp_{context}"]
 = Migrating the x86 control plane to arm64 architecture on {aws-full}
 
+[role="_abstract"]
 You can migrate the control plane in your cluster from `x86` to `arm64` architecture on {aws-first}.
 
 .Prerequisites
@@ -53,7 +54,7 @@ If you see the following output, the cluster is multi-architecture compatible.
 }
 ----
 +
-If the cluster is not using the multi payload, migrate the cluster to a multi-architecture cluster. For more information, see "Migrating to a cluster with multi-architecture compute machines". 
+If the cluster is not using the multi payload, migrate the cluster to a multi-architecture cluster. For more information, see "Migrating to a cluster with multi-architecture compute machines using the CLI".
 
 . Update your image stream from single-architecture to multi-architecture by running the following command:
 +
@@ -65,9 +66,10 @@ include::snippets/update-image-stream-to-multi-arch.adoc[]
 +
 [source,terminal]
 ----
-$ oc get configmap/coreos-bootimages -n openshift-machine-config-operator -o jsonpath='{.data.stream}' | jq -r '.architectures.aarch64.images.aws.regions."<aws_region>".image' <1>
+$ oc get configmap/coreos-bootimages -n openshift-machine-config-operator -o jsonpath='{.data.stream}' | jq -r '.architectures.aarch64.images.aws.regions."<aws_region>".image'
 ----
-<1> Replace `<aws_region>` with the {aws-short} region where the current cluster is installed. You can get the {aws-short} region for the installed cluster by running the following command:
++
+Replace `<aws_region>` with the {aws-short} region where the current cluster is installed. You can get the {aws-short} region for the installed cluster by running the following command:
 +
 [source,terminal]
 ----
@@ -86,14 +88,14 @@ ami-xxxxxxx
 ----
 $ oc edit controlplanemachineset.machine.openshift.io cluster -n openshift-machine-api
 ----
-+
-Update the `instanceType` field to a type that supports the `arm64` architecture, and set the `ami.id` field to an AMI that is compatible with the `arm64` architecture. For information about supported instance types, see "Tested instance types for {aws-short} on 64-bit ARM infrastructures".
+
+.. Update the `instanceType` field to a type that supports the `arm64` architecture, and set the `ami.id` field to an AMI that is compatible with the `arm64` architecture. For information about supported instance types, see "Tested instance types for {aws-short} on 64-bit ARM infrastructures".
 +
 For more information about configuring the control plane machine set for {aws-short}, see "Control plane configuration options for {aws-full}".
 
 .Verification
 
-* Verify that the control plane nodes are now running on the `arm64` architecture:
+* Verify that the control plane nodes are now running on the `arm64` architecture by running the following command:
 +
 [source,terminal]
 ----

--- a/modules/migrating-to-multi-arch-cli.adoc
+++ b/modules/migrating-to-multi-arch-cli.adoc
@@ -6,17 +6,21 @@
 [id="migrating-to-multi-arch-cli_{context}"]
 = Migrating to a cluster with multi-architecture compute machines using the CLI
 
+[role="_abstract"]
+You can use the {oc-first} to migrate to a cluster with multi-architecture compute machines.
+
+
 .Prerequisites
 
 * You have access to the cluster as a user with the `cluster-admin` role.
-* Your {product-title} version is up to date to at least version 4.13.0.
+* Your {product-title} version is 4.13.0 or later.
 +
-For more information on how to update your cluster version, see _Updating a cluster using the web console_ or _Updating a cluster using the CLI_.
-* You have installed the OpenShift CLI (`oc`) that matches the version for your current cluster.
-* Your `oc` client is updated to at least verion 4.13.0.
-* Your {product-title} cluster is installed on AWS, Azure, {gcp-short}, bare metal or IBM P/Z platforms.
+For more information on how to update your cluster version, see "Updating a cluster using the web console" or "Updating a cluster using the CLI".
+* You have installed the {oc-first} that matches the version for your current cluster.
+* Your `oc` client is updated to version 4.13.0 or later.
+* Your {product-title} cluster is installed on AWS, Azure, {gcp-short}, bare metal, or IBM P/Z platforms.
 +
-For more information on selecting a supported platform for your cluster installation, see _Selecting a cluster installation type_.
+For more information on selecting a supported platform for your cluster installation, see "Selecting a cluster installation type".
 
 
 .Procedure
@@ -34,10 +38,10 @@ If the `RetrievedUpates` condition is `False`, you can find supplemental informa
 $ oc adm upgrade
 ----
 +
-For more information about cluster version condition types, see _Understanding cluster version condition types_.
+For more information about cluster version condition types, see "Understanding cluster version condition types".
 
 ifndef::openshift-origin[]
-. If the condition `RetrievedUpdates` is `False`, change the channel to `stable-<4.y>` or `fast-<4.y>` with the following command:
+. If the condition `RetrievedUpdates` is `False`, change the channel to `stable-<4.y>` or `fast-<4.y>` by running the following command:
 +
 [source,terminal]
 ----
@@ -46,10 +50,10 @@ $ oc adm upgrade channel <channel>
 +
 After setting the channel, verify if `RetrievedUpdates` is `True`.
 +
-For more information about channels, see _Understanding update channels and releases_.
+For more information about channels, see "Understanding update channels and releases".
 endif::openshift-origin[]
 
-. Migrate to the multi-architecture payload with following command:
+. Migrate to the multi-architecture payload by running the following command:
 +
 [source,terminal]
 ----
@@ -58,7 +62,7 @@ $ oc adm upgrade --to-multi-arch
 
 .Verification
 
-* You can monitor the migration by running the following command:
+* Monitor the migration by running the following command:
 +
 [source,terminal]
 ----
@@ -66,7 +70,6 @@ $ oc adm upgrade
 ----
 +
 .Example output
-
 [source,terminal]
 ----
 working towards ${VERSION}: 106 of 841 done (12% complete), waiting on machine-config
@@ -74,18 +77,16 @@ working towards ${VERSION}: 106 of 841 done (12% complete), waiting on machine-c
 +
 [IMPORTANT]
 ====
-Machine launches may fail as the cluster settles into the new state. To notice and recover when machines fail to launch, we recommend deploying machine health checks. For more information about machine health checks and how to deploy them, see _About machine health checks_.
+Machine launches may fail as the cluster settles into the new state. To notice and recover when machines fail to launch, it is recommended that you deploy machine health checks. For more information about machine health checks and how to deploy them, see "About machine health checks".
 ====
 +
-. Optional: To retrieve more detailed information about the status of your update, monitor the migration by running the following command:
+. Optional: Retrieve more detailed information about the status of your update and monitor the migration by running the following command:
 +
 [source,terminal]
 ----
 $ oc adm upgrade status
 ----
 +
-For more information about how to use the `oc adm upgrade status` command, see _Gathering cluster update status using oc adm upgrade status (Technology Preview)_.
+For more information about how to use the `oc adm upgrade status` command, see "Gathering cluster update status using oc adm upgrade status (Technology Preview)".
 
 The migrations must be complete and all the cluster operators must be stable before you can add compute machine sets with different architectures to your cluster.
-
-

--- a/modules/multiarch-migrating-cp-infra-gcp.adoc
+++ b/modules/multiarch-migrating-cp-infra-gcp.adoc
@@ -6,6 +6,7 @@
 [id="multiarch-migrating-cp-infra-gcp_{context}"]
 = Migrating control plane or infra machine sets between architectures on {gcp-full}
 
+[role="_abstract"]
 You can migrate the control plane or infra machine sets in your {gcp-short} cluster between `x86` and `arm64` architectures.
 
 .Prerequisites
@@ -26,7 +27,7 @@ $ oc get nodes -o wide
 [source,terminal]
 ----
 NAME                          STATUS   ROLES                  AGE    VERSION   INTERNAL-IP EXTERNAL-IP   OS-IMAGE                                         KERNEL-VERSION                 CONTAINER-RUNTIME
-worker-001.example.com        Ready    infra                 100d   v1.30.7   10.x.x.x    <none>        Red Hat Enterprise Linux CoreOS 4xx.xx.xxxxx-0   5.x.x-xxx.x.x.el9_xx.x86_64    cri-o://1.30.x
+worker-001.example.com        Ready    infra                  100d   v1.30.7   10.x.x.x    <none>        Red Hat Enterprise Linux CoreOS 4xx.xx.xxxxx-0   5.x.x-xxx.x.x.el9_xx.x86_64    cri-o://1.30.x
 master-001.example.com        Ready    control-plane,master   120d   v1.30.7   10.x.x.x    <none>        Red Hat Enterprise Linux CoreOS 4xx.xx.xxxxx-0   5.x.x-xxx.x.x.el9_xx.x86_64    cri-o://1.30.x
 ----
 +

--- a/modules/updating-bootloader-auto.adoc
+++ b/modules/updating-bootloader-auto.adoc
@@ -1,0 +1,69 @@
+:_mod-docs-content-type: PROCEDURE
+[id="updating-bootloader-auto_{context}"]
+= Updating the boot loader automatically by using a machine config
+
+[role="_abstract"]
+You can automatically update the boot loader with `bootupd` by creating a systemd service unit that will update the boot loader as needed on every boot.
+This unit will run the `bootupctl update` command during the boot process and will be installed on the nodes via a machine config.
+
+[NOTE]
+====
+This configuration is not enabled by default because unexpected interruptions of the update operation might lead to unbootable nodes.
+If you enable this configuration, make sure to avoid interrupting nodes during the boot process while the boot loader update is in progress.
+The boot loader update operation generally completes quickly thus the risk is low.
+====
+
+.Procedure
+
+. Create a Butane config file, `99-worker-bootupctl-update.bu`, including the contents of the `bootupctl-update.service` systemd unit.
++
+[NOTE]
+====
+include::snippets/butane-version.adoc[]
+
+====
++
+.Example output
+[source,yaml,subs="attributes+"]
+----
+variant: openshift
+version: {product-version}.0
+metadata:
+  name: 99-worker-chrony
+  labels:
+    machineconfiguration.openshift.io/role: worker
+systemd:
+  units:
+  - name: bootupctl-update.service
+    enabled: true
+    contents: |
+      [Unit]
+      Description=Bootupd automatic update
+
+      [Service]
+      ExecStart=/usr/bin/bootupctl update
+      RemainAfterExit=yes
+
+      [Install]
+      WantedBy=multi-user.target
+----
++
+On control plane nodes, substitute `master` for `worker` in `metadata.name` and `metadata.labels.machineconfiguration.openshift.io/role`.
+
+. Generate a `MachineConfig` object file, `99-worker-bootupctl-update.yaml`, containing the configuration to be delivered to the nodes by running the following command:
++
+[source,terminal]
+----
+$ butane 99-worker-bootupctl-update.bu -o 99-worker-bootupctl-update.yaml
+----
+
+. Apply the configurations in one of two ways:
++
+* If the cluster is not running yet, after you generate manifest files, add the `MachineConfig` object file to the `<installation_directory>/openshift` directory, and then continue to create the cluster.
++
+* If the cluster is already running, apply the file by running the following command:
++
+[source,terminal]
+----
+$ oc apply -f ./99-worker-bootupctl-update.yaml
+----

--- a/modules/updating-bootloader-manual.adoc
+++ b/modules/updating-bootloader-manual.adoc
@@ -1,0 +1,62 @@
+:_mod-docs-content-type: PROCEDURE
+[id="updating-bootloader-manual_{context}"]
+= Updating the boot loader manually
+
+[role="_abstract"]
+You can manually inspect the status of the system and update the boot loader by using the `bootupctl` command-line tool.
+
+.Procedure
+
+. Inspect the system status by running the following command:
++
+[source,terminal]
+----
+# bootupctl status
+----
++
+.Example output for `x86_64`
+[source,terminal]
+----
+Component EFI
+  Installed: grub2-efi-x64-1:2.04-31.el8_4.1.x86_64,shim-x64-15-8.el8_1.x86_64
+  Update: At latest version
+----
+ifndef::openshift-origin[]
++
+.Example output for `aarch64`
+[source,terminal]
+----
+Component EFI
+  Installed: grub2-efi-aa64-1:2.02-99.el8_4.1.aarch64,shim-aa64-15.4-2.el8_1.aarch64
+  Update: At latest version
+----
+endif::openshift-origin[]
+
+[start=2]
+. {product-title} clusters initially installed on version 4.4 and older require an explicit adoption phase.
++
+If the system status is `Adoptable`, perform the adoption by running the following command:
++
+[source,terminal]
+----
+# bootupctl adopt-and-update
+----
++
+.Example output
+[source,terminal]
+----
+Updated: grub2-efi-x64-1:2.04-31.el8_4.1.x86_64,shim-x64-15-8.el8_1.x86_64
+----
+
+. If an update is available, apply the update so that the changes take effect on the next reboot by running the following command:
++
+[source,terminal]
+----
+# bootupctl update
+----
++
+.Example output
+[source,terminal]
+----
+Updated: grub2-efi-x64-1:2.04-31.el8_4.1.x86_64,shim-x64-15-8.el8_1.x86_64
+----

--- a/updating/updating_a_cluster/disconnected-update.adoc
+++ b/updating/updating_a_cluster/disconnected-update.adoc
@@ -4,6 +4,7 @@
 include::_attributes/common-attributes.adoc[]
 :context: updating-disconnected-cluster
 
+[role="_abstract"]
 You can update a cluster in an environment without access to the internet by taking additional steps to prepare your environment.
 
 For information about updating a cluster in a disconnected environment, see xref:../../disconnected/updating/index.adoc#about-disconnected-updates[About cluster updates in a disconnected environment].

--- a/updating/updating_a_cluster/migrating-to-multi-payload.adoc
+++ b/updating/updating_a_cluster/migrating-to-multi-payload.adoc
@@ -6,12 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-////
-WARNING: This assembly has been moved into a subdirectory for 4.14+. Changes to this assembly for earlier versions should be done in separate PRs based off of their respective version branches. Otherwise, your cherry picks may fail.
-
-To do: Remove this comment once 4.13 docs are EOL.
-////
-
+[role="_abstract"]
 You can migrate your current cluster with single-architecture compute machines to a cluster with multi-architecture compute machines by updating to a multi-architecture, manifest-listed payload. This allows you to add mixed architecture compute nodes to your cluster.
 
 For information about configuring your multi-architecture compute machines, see "Configuring multi-architecture compute machines on an {product-title} cluster".
@@ -29,7 +24,7 @@ include::modules/migrating-to-multi-arch-cli.adoc[leveloffset=+1]
 [role="_additional-resources"]
 .Additional resources
 * xref:../../post_installation_configuration/configuring-multi-arch-compute-machines/multi-architecture-configuration.adoc#multi-architecture-configuration[Configuring multi-architecture compute machines on an {product-title} cluster]
-* xref:../../post_installation_configuration/configuring-multi-arch-compute-machines/multiarch-tuning-operator.adoc#multiarch-tuning-operator[Managing workloads on multi-architecture clusters by using the Multiarch Tuning Operator].
+* xref:../../post_installation_configuration/configuring-multi-arch-compute-machines/multiarch-tuning-operator.adoc#multiarch-tuning-operator[Managing workloads on multi-architecture clusters by using the Multiarch Tuning Operator]
 * xref:../../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[Updating a cluster using the web console]
 * xref:../../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI]
 * xref:../../updating/understanding_updates/intro-to-updates.adoc#understanding-clusterversion-conditiontypes_understanding-openshift-updates[Understanding cluster version condition types]
@@ -40,15 +35,20 @@ include::modules/migrating-to-multi-arch-cli.adoc[leveloffset=+1]
 //  Migrating the x86 control plane to the arm64 architecture on AWS
 include::modules/migrating-from-x86-to-arm-cp.adoc[leveloffset=+1]
 
-// Migrating CP or infra between x86 and arm on GCP
-include::modules/multiarch-migrating-cp-infra-gcp.adoc[leveloffset=+1]
-
 [role="_additional-resources"]
 .Additional resources
 
 * xref:../../machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-config-options-aws.adoc#cpmso-config-options-aws[Control plane configuration options for {aws-full}]
 
 * xref:../../installing/installing_aws/upi/upi-aws-installation-reqs.adoc#installation-aws-arm-tested-machine-types_upi-aws-installation-reqs[Tested instance types for AWS on 64-bit ARM infrastructures]
+
+* xref:../../updating/updating_a_cluster/migrating-to-multi-payload.adoc#migrating-to-multi-arch-cli_updating-clusters-overview[Migrating to a cluster with multi-architecture compute machines using the CLI]
+
+// Migrating CP or infra between x86 and arm on GCP
+include::modules/multiarch-migrating-cp-infra-gcp.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
 
 * xref:../../installing/installing_gcp/installing-gcp-customizations.adoc#installation-gcp-tested-machine-types-arm_installing-gcp-customizations[Tested instance types for {gcp-short} on 64-bit ARM infrastructures]
 

--- a/updating/updating_a_cluster/updating-bootloader-rhcos.adoc
+++ b/updating/updating_a_cluster/updating-bootloader-rhcos.adoc
@@ -2,10 +2,11 @@
 [id="updating-bootloader-rhcos"]
 = Updating the boot loader on {op-system} nodes using bootupd
 include::_attributes/common-attributes.adoc[]
-:context: updating-booloader-rhcos
+:context: updating-bootloader-rhcos
 
 toc::[]
 
+[role="_abstract"]
 To update the boot loader on {op-system} nodes using `bootupd`, you must either run the `bootupctl update` command on {op-system} machines manually or provide a machine config with a `systemd` unit.
 
 Unlike `grubby` or other boot loader tools, `bootupd` does not manage kernel space configuration such as passing kernel arguments.
@@ -16,124 +17,6 @@ To configure kernel arguments, see xref:../../nodes/nodes/nodes-nodes-managing.a
 You can use `bootupd` to update the boot loader to protect against the BootHole vulnerability.
 ====
 
-== Updating the boot loader manually
+include::modules/updating-bootloader-manual.adoc[leveloffset=+1]
 
-You can manually inspect the status of the system and update the boot loader by using the `bootupctl` command-line tool.
-
-. Inspect the system status:
-+
-[source,terminal]
-----
-# bootupctl status
-----
-+
-.Example output for `x86_64`
-[source,terminal]
-----
-Component EFI
-  Installed: grub2-efi-x64-1:2.04-31.el8_4.1.x86_64,shim-x64-15-8.el8_1.x86_64
-  Update: At latest version
-----
-ifndef::openshift-origin[]
-+
-.Example output for `aarch64`
-[source,terminal]
-----
-Component EFI
-  Installed: grub2-efi-aa64-1:2.02-99.el8_4.1.aarch64,shim-aa64-15.4-2.el8_1.aarch64
-  Update: At latest version
-----
-endif::openshift-origin[]
-
-[start=2]
-. {product-title} clusters initially installed on version 4.4 and older require an explicit adoption phase.
-+
-If the system status is `Adoptable`, perform the adoption:
-+
-[source,terminal]
-----
-# bootupctl adopt-and-update
-----
-+
-.Example output
-[source,terminal]
-----
-Updated: grub2-efi-x64-1:2.04-31.el8_4.1.x86_64,shim-x64-15-8.el8_1.x86_64
-----
-
-. If an update is available, apply the update so that the changes take effect on the next reboot:
-+
-[source,terminal]
-----
-# bootupctl update
-----
-+
-.Example output
-[source,terminal]
-----
-Updated: grub2-efi-x64-1:2.04-31.el8_4.1.x86_64,shim-x64-15-8.el8_1.x86_64
-----
-
-== Updating the bootloader automatically via a machine config
-
-Another way to automatically update the boot loader with `bootupd` is to create a systemd service unit that will update the boot loader as needed on every boot.
-This unit will run the `bootupctl update` command during the boot process and will be installed on the nodes via a machine config.
-
-[NOTE]
-====
-This configuration is not enabled by default as unexpected interruptions of the update operation may lead to unbootable nodes.
-If you enable this configuration, make sure to avoid interrupting nodes during the boot process while the bootloader update is in progress.
-The boot loader update operation generally completes quickly thus the risk is low.
-====
-
-. Create a Butane config file, `99-worker-bootupctl-update.bu`, including the contents of the `bootupctl-update.service` systemd unit.
-+
-[NOTE]
-====
-include::snippets/butane-version.adoc[]
-
-====
-+
-.Example output
-[source,yaml,subs="attributes+"]
-----
-variant: openshift
-version: {product-version}.0
-metadata:
-  name: 99-worker-chrony <1>
-  labels:
-    machineconfiguration.openshift.io/role: worker <1>
-systemd:
-  units:
-  - name: bootupctl-update.service
-    enabled: true
-    contents: |
-      [Unit]
-      Description=Bootupd automatic update
-
-      [Service]
-      ExecStart=/usr/bin/bootupctl update
-      RemainAfterExit=yes
-
-      [Install]
-      WantedBy=multi-user.target
-----
-<1> On control plane nodes, substitute `master` for `worker` in both of these locations.
-
-. Use Butane to generate a `MachineConfig` object file, `99-worker-bootupctl-update.yaml`, containing the configuration to be delivered to the nodes:
-+
-[source,terminal]
-----
-$ butane 99-worker-bootupctl-update.bu -o 99-worker-bootupctl-update.yaml
-----
-
-. Apply the configurations in one of two ways:
-+
-* If the cluster is not running yet, after you generate manifest files, add the `MachineConfig` object file to the `<installation_directory>/openshift` directory, and then continue to create the cluster.
-+
-* If the cluster is already running, apply the file:
-+
-[source,terminal]
-----
-$ oc apply -f ./99-worker-bootupctl-update.yaml
-----
+include::modules/updating-bootloader-auto.adoc[leveloffset=+1]


### PR DESCRIPTION
[OSDOCS-17077](https://issues.redhat.com/browse/OSDOCS-17077)

Version(s): 4.20+

This PR is one of several to perform a CQA of the updating procedures in the OTA docs.

No new content added.

QE review: No technical accuracy changes and therefore no need for QE, but let me know if you think anything needs a review.

Previews:
- [Updating a cluster in a disconnected environment](https://109458--ocpdocs-pr.netlify.app/openshift-enterprise/latest/updating/updating_a_cluster/disconnected-update)
- [Migrating to a cluster with multi-architecture compute machines](https://109458--ocpdocs-pr.netlify.app/openshift-enterprise/latest/updating/updating_a_cluster/migrating-to-multi-payload)
- [Updating the boot loader on Red Hat Enterprise Linux CoreOS nodes using bootupd](https://109458--ocpdocs-pr.netlify.app/openshift-enterprise/latest/updating/updating_a_cluster/updating-bootloader-rhcos)