### PR TITLE
RHDEVDOCS-7062: Addresses DITA migration issues for OpenShift Pipelines

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -1,11 +1,8 @@
 :_mod-docs-content-type: SNIPPET
-
 // The {product-title} attribute provides the context-sensitive name of the relevant OpenShift distribution, for example, "OpenShift Container Platform" or "OKD". The {product-version} attribute provides the product version relative to the distribution, for example "4.9".
 // {product-title} and {product-version} are parsed when AsciiBinder queries the _distro_map.yml file in relation to the base branch of a pull request.
 // See https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#product-name-and-version for more information on this topic.
 // Other common attributes are defined in the following lines:
-:_mod-docs-content-type: SNIPPET
-
 :data-uri:
 :icons:
 :experimental:
@@ -43,9 +40,15 @@
 
 :oc-first: pass:quotes[OpenShift CLI (`oc`)]
 
+// Attributes not present in the main branch
+:OCP: OpenShift Container Platform
+
+//We should use lowercase like regular OCP docs and deprecate the above.
+:ocp: OpenShift Container Platform
+
+
 :ols-official: Red{nbsp}Hat OpenShift Lightspeed
 :ols: OpenShift Lightspeed
 
 // Attributes not present in the main branch
-:OCP: OpenShift Container Platform
 :rhosp: Red Hat OpenStack Platform

--- a/modules/op-authenticating-to-an-oci-registry.adoc
+++ b/modules/op-authenticating-to-an-oci-registry.adoc
@@ -19,6 +19,7 @@ The {tekton-chains} controller uses the same service account under which task ru
 $ export NAMESPACE=<namespace>
 $ export SERVICE_ACCOUNT_NAME=<service_account>
 ----
++
 `<namespace>`:: The namespace associated with the service account.
 `<service_account>`:: The name of the service account.
 
@@ -31,6 +32,7 @@ $ oc create secret registry-credentials \
   --type=kubernetes.io/dockerconfigjson \
   -n $NAMESPACE
 ----
++
 `--from-file`:: Substitute with the path to your Docker config file. Default path is `~/.docker/config.json`.
 
 . Give the service account access to the secret.
@@ -65,4 +67,5 @@ spec:
     name: build-push
 ...
 ----
++
 `serviceAccountName`:: Substitute with the name of the newly created service account.

--- a/modules/op-chains-generating-cosign-secret.adoc
+++ b/modules/op-chains-generating-cosign-secret.adoc
@@ -24,7 +24,7 @@ $ oc edit TektonConfig config
 
 . In the `TektonConfig` CR, set the `generateSigningSecret` value to `true`:
 +
-.Example of creating an ECDSA cosign key pair by using the TektonConfig CR
+.Example of creating an ECDSA cosign key pair by using the `TektonConfig` CR
 [source,yaml]
 ----
 apiVersion: operator.tekton.dev/v1
@@ -38,6 +38,7 @@ spec:
     generateSigningSecret: true
 # ...
 ----
++
 `generateSigningSecret`:: The default value is `false`. Setting the value to `true` generates the `ecdsa` key pair.
 
 . After a few minutes, extract the public key from the secret and store it, so that you can use it to verify artifact attestations. Run the following command to extract the key:
@@ -46,24 +47,22 @@ spec:
 ----
 $ oc extract -n openshift-pipelines secret/signing-secrets --keys=cosign.pub
 ----
-
-.Result
-
++
 The {pipelines-shortname} Operator generates an `ecdsa` type `cosign` key pair and stores it in the `signing-secrets` secret in the `openshift-pipelines` namespace. The secret includes the following files:
-
++
 * `cosign.key`: The private key
 * `cosign.password`: The password for decrypting the private key
 * `cosign.pub` The public key
-
++
 If a `signing-secrets` secret already exists, the Operator does not overwrite the secret.
-
++
 The `cosign.pub` file in your current directory has the public key extracted from the secret.
-
++
 [WARNING]
 ====
 If you set the `generateSigningSecret` field from `true` to `false`, the {pipelines-title} Operator overrides and empties any value in the `signing-secrets` secret.
 ====
-
++
 The {pipelines-title} Operator does not offer the following security functions:
 
 * Key rotation

--- a/modules/op-chains-signing-secrets-skopeo.adoc
+++ b/modules/op-chains-signing-secrets-skopeo.adoc
@@ -21,18 +21,19 @@ You can generate keys by using the `skopeo` tool and use them in the `cosign` si
 ----
 $ skopeo generate-sigstore-key --output-prefix <mykey>
 ----
++
 `<mykey>`:: Replace `<mykey>` with a key name of your choice.
 +
 Skopeo prompts you for a passphrase for the private key and then creates the key files named `<mykey>.private` and `<mykey>.pub`.
 
-. Encode the `<mykey>.pub` file using the `base64` tool by running the following command:
+. Encode the `<mykey>.pub` file by using the `base64` tool and running the following command:
 +
 [source,terminal]
 ----
 $ base64 -w 0 <mykey>.pub > b64.pub
 ----
 
-. Encode the `<mykey>.private` file using the `base64` tool by running the following command:
+. Encode the `<mykey>.private` file by using the `base64` tool and running the following command:
 +
 [source,terminal]
 ----
@@ -45,6 +46,7 @@ $ base64 -w 0 <mykey>.private > b64.private
 ----
 $ echo -n '<passphrase>' | base64 -w 0 > b64.passphrase
 ----
++
 `<passphrase>`:: Replace `<passphrase>` with the passphrase that you used for the key pair.
 
 . Create the `signing-secrets` secret in the `openshift-pipelines` namespace by running the following command:
@@ -53,9 +55,10 @@ $ echo -n '<passphrase>' | base64 -w 0 > b64.passphrase
 ----
 $ oc create secret generic signing-secrets -n openshift-pipelines
 ----
-+
+
 . Edit the `signing-secrets` secret by running the following command:
 +
+[source,terminal]
 ----
 $ oc edit secret -n openshift-pipelines signing-secrets
 ----
@@ -76,6 +79,7 @@ metadata:
 # ...
 type: Opaque
 ----
-`<mykey>`:: Replace `<Encoded <mykey>.private>` with the content of the `b64.private` file.
-`cosign.password`:: Replace `<Encoded passphrase>` with the content of the `b64.passphrase` file.
-`<mykey>`:: Replace `<Encoded <mykey>.pub>` with the content of the `b64.pub` file.
++
+`<Encoded <mykey>.private>`:: Replace with the content of the `b64.private` file.
+`<Encoded passphrase>`:: Replace with the content of the `b64.passphrase` file.
+`<Encoded <mykey>.pub>`:: Replace with the content of the `b64.pub` file.

--- a/modules/op-configuring-basic-authentication-for-git.adoc
+++ b/modules/op-configuring-basic-authentication-for-git.adoc
@@ -37,6 +37,7 @@ stringData:
   username: <username>
   password: <password>
 ----
++
 `name`:: Name of the secret. In this example, `basic-user-pass`.
 `<username>`:: Username for the Git repository.
 `<password>`:: Password or personal access token for the Git repository.
@@ -52,12 +53,13 @@ metadata:
 secrets:
   - name: basic-user-pass
 ----
++
 `name`:: Name of the service account. In this example, `build-bot`.
 `- name: basic-user-pass`:: Name of the secret. In this example, `basic-user-pass`.
-+
+
 . Create the YAML manifest for the task run or pipeline run in the `run.yaml` file and associate the service account with the task run or pipeline run. Use one of the following examples:
-+
-* Associate the service account with a `TaskRun` resource:
+
+.. Associate the service account with a `TaskRun` resource:
 +
 [source,yaml,subs="attributes+"]
 ----
@@ -71,11 +73,12 @@ spec:
   taskRef:
     name: build-push
 ----
++
 `name`:: Name of the task run. In this example, `build-push-task-run-2`.
 `serviceAccountName`:: Name of the service account. In this example, `build-bot`.
 `name`:: Name of the task. In this example, `build-push`.
-+
-* Associate the service account with a `PipelineRun` resource:
+
+.. Associate the service account with a `PipelineRun` resource:
 +
 [source,yaml,subs="attributes+"]
 ----
@@ -90,10 +93,11 @@ spec:
   pipelineRef:
     name: demo-pipeline
 ----
++
 `name`:: Name of the pipeline run. In this example, `demo-pipeline`.
 `serviceAccountName`:: Name of the service account. In this example, `build-bot`.
 `name`:: Name of the pipeline. In this example, `demo-pipeline`.
-+
+
 . Apply the YAML manifests that you created by entering the following command:
 +
 [source,terminal]

--- a/modules/op-configuring-buildah-to-use-build-user.adoc
+++ b/modules/op-configuring-buildah-to-use-build-user.adoc
@@ -106,6 +106,7 @@ spec:
   - name: varlibcontainers
     emptyDir: {}
 ----
++
 `runAsUser`:: Run the container explicitly as the user id `1000`, which corresponds to the `build` user in the Buildah image.
 `echo "Running as USER ID `id`"`:: Display the user id to confirm that the process is running as user id `1000`.
 `mountPath`:: You can change the path for the volume mount as necessary.

--- a/modules/op-configuring-container-registry-authentication-using-workspaces.adoc
+++ b/modules/op-configuring-container-registry-authentication-using-workspaces.adoc
@@ -19,6 +19,7 @@ To configure authentication for a container registry, create an authentication s
 $ oc create secret generic my-registry-credentials \
   --from-file=config.json=/home/user/credentials/config.json
 ----
++
 `my-registry-credentials`:: The name of the secret.
 `--from-file`:: The path name of the `config.json` file, in this example, `/home/user/credentials/config.json`
 
@@ -48,8 +49,9 @@ $ tkn task start <task_name>
       --workspace name=<workspace_name>,secret=<secret_name>
       # ...
 ----
++
 `<secret_name>`:: Replace `<workspace_name>` with the name of the workspace that you configured and `<secret_name>` with the name of the secret that you created.
-
++
 .Example task for copying an image from a container repository by using Skopeo
 [source,yaml,subs="attributes+"]
 ----
@@ -72,9 +74,10 @@ spec:
         set -eu
         skopeo copy docker://docker.io/library/ubuntu:latest docker://quay.io/example_repository/ubuntu-copy:latest
 ----
++
 `workspaces.name`:: The name of the workspace that has the `config.json` file.
 `env.value`:: The `DOCKER_CONFIG` environment variable points to the location of the `config.json` file in the `dockerconfig` workspace. Skopeo uses this environment variable to get the authentication information.
-
++
 .Example command for running the task
 [source, terminal]
 ----

--- a/modules/op-configuring-custom-sa-and-scc.adoc
+++ b/modules/op-configuring-custom-sa-and-scc.adoc
@@ -91,7 +91,7 @@ subjects:
 - kind: ServiceAccount
   name: pipelines-sa-userid-1000
 ----
-
++
 `name`:: Define a custom SA.
 `SecurityContextConstraints`:: Define a custom SCC created based on restricted privileges, with modified `runAsUser` field.
 `allowPrivilegeEscalation`:: At this time, Buildah requires enabling the `allowPrivilegeEscalation` setting to run successfully in the container. With this setting, Buildah can use `SETUID` and `SETGID` capabilities when running as a non-root user.

--- a/modules/op-configuring-default-maximum-scc.adoc
+++ b/modules/op-configuring-default-maximum-scc.adoc
@@ -33,5 +33,6 @@ spec:
         default: "restricted-v2"
         maxAllowed: "privileged"
 ----
++
 `default`:: `spec.platforms.openshift.scc.default` specifies the default SCC that {pipelines-shortname} attaches to the service account (SA) used for workloads, which is, by default, the `pipeline` SA. {pipelines-shortname} uses this SCC for all pipeline run and task run pods.
 `maxAllowed`:: `spec.platforms.openshift.scc.maxAllowed` specifies the least restrictive SCC that you can configure for pipeline run and task run pods in any namespace. This setting does not apply when you configure a custom SA and SCC in a particular pipeline run or task run.

--- a/modules/op-configuring-git-ssh-authentication-using-workspaces.adoc
+++ b/modules/op-configuring-git-ssh-authentication-using-workspaces.adoc
@@ -14,12 +14,13 @@ To configure SSH-based authentication for a pipeline, create an authentication s
 
 . Create the Git SSH authentication secret from files in an existing `.ssh` directory by entering the following command:
 +
-[source, terminal]
+[source,terminal]
 ----
 $ oc create secret generic my-github-ssh-credentials \
   --from-file=id_ed25519=/home/user/.ssh/id_ed25519 \
   --from-file=known_hosts=/home/user/.ssh/known_hosts
 ----
++
 `my-github-ssh-credentials`:: The name of the secret.
 `--from-file=id_ed25519`:: The name and full path name of the private key file, in this example, `/home/user/.ssh/id_ed25519`
 `--from-file=known_hosts`:: The name and full path name of the known hosts file, in this example, `/home/user/.ssh/known_hosts`
@@ -50,6 +51,7 @@ $ tkn task start <task_name>
       --workspace name=<workspace_name>,secret=<secret_name>
       # ...
 ----
++
 `<secret_name>`:: Replace `<workspace_name>` with the name of the workspace that you configured and `<secret_name>` with the name of the secret that you created.
 
 .Example task for cloning a Git repository by using an SSH key for authentication
@@ -111,8 +113,9 @@ spec:
         printf "%s" "${RESULT_SHA}" > "$(results.commit.path)"
         printf "%s" "$(params.url)" > "$(results.url.path)"
 ----
++
 `-R`:: The script copies the content of the secret (in the form of a folder) to `${HOME}/.ssh`, which is the standard folder where `ssh` searches for credentials.
-
++
 .Example command for running the task
 [source, terminal]
 ----

--- a/modules/op-configuring-registry-authentication-sa.adoc
+++ b/modules/op-configuring-registry-authentication-sa.adoc
@@ -3,7 +3,7 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="op-configuring-registry-authentication-sa_{context}"]
-= Configuring container registry authentication using a service account
+= Configuring container registry authentication by using a service account
 
 [role="_abstract"]
 For a pipeline to retrieve container images from a registry or push container images to a registry, you must configure the authentication for that registry.
@@ -19,6 +19,7 @@ To configure registry authentication for a pipeline, create an authentication se
 $ oc create secret generic my-registry-credentials \
   --from-file=config.json=/home/user/credentials/config.json
 ----
++
 `my-registry-credentials`:: The name of the secret.
 `--from-file`:: The path name of the `config.json` file, in this example, `/home/user/credentials/config.json`
 
@@ -33,6 +34,7 @@ metadata:
 secrets:
   - name: my-registry-credentials
 ----
++
 `metadata.name`:: Name of the service account. In this example, `container-bot`.
 `secrets.name`:: Name of the secret containing the registry credentials. In this example, `my-registry-credentials`.
 
@@ -52,10 +54,11 @@ spec:
   taskRef:
     name: build-container
 ----
++
 `metadata.name`:: Name of the task run. In this example, `build-container-task-run-2`.
 `serviceAccountName`:: Name of the service account. In this example, `container-bot`.
 `taskRef.name`:: Name of the task. In this example, `build-container`.
-+
+
 ** To associate the service account with a pipeline run:
 +
 [source,yaml,subs="attributes+"]
@@ -71,6 +74,7 @@ spec:
   pipelineRef:
     name: demo-pipeline
 ----
++
 `metadata.name`:: Name of the pipeline run. In this example, `demo-pipeline`.
 `serviceAccountName`:: Name of the service account. In this example, `container-bot`.
 `pipelineRef.name`:: Name of the pipeline. In this example, `demo-pipeline`.

--- a/modules/op-configuring-ssh-authentication-for-git.adoc
+++ b/modules/op-configuring-ssh-authentication-for-git.adoc
@@ -13,6 +13,7 @@ To configure SSH-based authentication for a pipeline, create an authentication s
 .Procedure
 
 . Generate an link:https://docs.github.com/en/authentication/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent[SSH private key], or copy an existing private key, which is usually available in the `~/.ssh/id_rsa` file.
+
 . Create the YAML manifest for the secret in the `secret.yaml` file. In this manifest, set the value of `ssh-privatekey` to the content of the SSH private key file, and set the value of `known_hosts` to the content of the known hosts file.
 +
 [source,yaml,subs="attributes+"]
@@ -28,6 +29,7 @@ stringData:
   ssh-privatekey:
   known_hosts:
 ----
++
 `metadata.name`:: Name of the secret containing the SSH private key. In this example, `ssh-key`.
 `ssh-privatekey`:: The content of the SSH private key file.
 `known_hosts`:: The content of the known hosts file.
@@ -36,8 +38,9 @@ stringData:
 ====
 If you omit the known hosts file, {pipelines-shortname} accepts the public key of any server.
 ====
-+
+
 . Optional: Specify a custom SSH port by adding `:<port_number>` to the end of the annotation value. For example, `tekton.dev/git-0: github.com:2222`.
+
 . Create the YAML manifest for the service account in the `serviceaccount.yaml` file. In this manifest, associate the secret with the service account.
 +
 [source,yaml,subs="attributes+"]
@@ -49,12 +52,13 @@ metadata:
 secrets:
   - name: ssh-key
 ----
++
 `metadata.name`:: Name of the service account. In this example, `build-bot`.
 `secrets.name`:: Name of the secret containing the SSH private key. In this example, `ssh-key`.
-+
+
 . In the `run.yaml` file, associate the service account with a task run or a pipeline run. Use one of the following examples:
-+
-** To associate the service account with a task run:
+
+.. To associate the service account with a task run:
 +
 [source,yaml,subs="attributes+"]
 ----
@@ -68,11 +72,12 @@ spec:
   taskRef:
     name: build-push
 ----
++
 `metadata.name`:: Name of the task run. In this example, `build-push-task-run-2`.
 `serviceAccountName`:: Name of the service account. In this example, `build-bot`.
 `taskRef.name`:: Name of the task. In this example, `build-push`.
-+
-** To associate the service account with a pipeline run:
+
+.. To associate the service account with a pipeline run:
 +
 [source,yaml,subs="attributes+"]
 ----
@@ -87,10 +92,11 @@ spec:
   pipelineRef:
     name: demo-pipeline
 ----
++
 `metadata.name`:: Name of the pipeline run. In this example, `demo-pipeline`.
 `serviceAccountName`:: Name of the service account. In this example, `build-bot`.
 `pipelineRef.name`:: Name of the pipeline. In this example, `demo-pipeline`.
-+
+
 . Apply the changes.
 +
 [source,terminal]

--- a/modules/op-creating-and-verifying-task-run-signatures-without-any-additional-authentication.adoc
+++ b/modules/op-creating-and-verifying-task-run-signatures-without-any-additional-authentication.adoc
@@ -56,6 +56,7 @@ $ oc delete po -n openshift-pipelines -l app=tekton-chains-controller
 ----
 $ oc create -f https://raw.githubusercontent.com/tektoncd/chains/main/examples/taskruns/task-output-image.yaml
 ----
++
 `-f`:: Replace the example URI with the URI or file path pointing to your task run.
 +
 .Example output
@@ -96,10 +97,12 @@ $ export TASKRUN_UID=$(tkn tr describe --last -o  jsonpath='{.metadata.uid}')
 ----
 
 . To verify the signature using the public key that you created, enter the following command:
++
 [source,terminal]
 ----
 $ cosign verify-blob-attestation --insecure-ignore-tlog --key path/to/cosign.pub --signature sig --type slsaprovenance --check-claims=false /dev/null
 ----
++
 `--insecure-ignore-tlog`:: Replace `path/to/cosign.pub` with the path name of the public key file.
 +
 .Example output

--- a/modules/op-creating-mounting-kms-authentication-token-secret.adoc
+++ b/modules/op-creating-mounting-kms-authentication-token-secret.adoc
@@ -21,9 +21,10 @@ You must create this secret, mount it on the {tekton-chains} controller, and set
 +
 [source, terminal]
 ----
-$ oc create secret generic kms-secrets -n tekton-chains \ 
+$ oc create secret generic kms-secrets -n tekton-chains \
   --from-file=KMS_AUTH_TOKEN=<path_and_name>
 ----
++
 `<path_and_name>`:: The full path and name of the file that has the authentication token for the KMS server, for example, `/home/user/KMS_AUTH_TOKEN`. You can use another file name instead of `KMS_AUTH_TOKEN`.
 
 . In the `TektonConfig` custom resource (CR), in the `chain` section, configure mounting the secret on the {tekton-chains} controller and set the `signers.kms.auth.token-path` parameter to the full path name of the authentication token file, as shown in the following example:

--- a/modules/op-creating-mounting-mongo-server-url-secret.adoc
+++ b/modules/op-creating-mounting-mongo-server-url-secret.adoc
@@ -22,6 +22,7 @@ You can give the value of the Mongo server URL to use for `docdb` storage (`MONG
 $ oc create secret generic mongo-url -n tekton-chains \
   --from-file=MONGO_SERVER_URL=<path>/MONGO_SERVER_URL
 ----
++
 `<path>`:: The full path and name of the `MONGO_SERVER_URL` file that has the Mongo server URL value.
 
 . In the `TektonConfig` custom resource (CR), in the `chain` section, configure mounting the secret on the {tekton-chains} controller and set the `storage.docdb.mongo-server-url-dir` parameter to the directory where you mount the secret, as shown in the following example:

--- a/modules/op-enabling-tekton-chains-to-operate-only-in-selected-namespaces.adoc
+++ b/modules/op-enabling-tekton-chains-to-operate-only-in-selected-namespaces.adoc
@@ -37,4 +37,5 @@ spec:
                   - --namespace=dev, test
                   name: tekton-chains-controller
 ----
++
 `--namespace`:: If you do not give the `--namespace` argument or leave it empty, the controller watches all namespaces by default.

--- a/modules/op-limiting-secret-workspace-to-step.adoc
+++ b/modules/op-limiting-secret-workspace-to-step.adoc
@@ -34,6 +34,7 @@ spec:
     - name: build
 # ...
 ----
++
 `spec.workspaces`:: The definition of the `ssh-directory` workspace in the task specification.
 `steps.workspaces`:: The definition of the `ssh-directory` workspace in the step specification. The authentication information is available to this step as the `$(workspaces.ssh-directory.path)` directory.
 `steps.name: build`:: As this step does not include a definition of the `ssh-directory` workspace, the authentication information is not available to this step.

--- a/modules/op-nonroot-buildah-user-namespaces.adoc
+++ b/modules/op-nonroot-buildah-user-namespaces.adoc
@@ -6,7 +6,6 @@
 [id="nonroot-buildah-user-namespaces_{context}"]
 = Running Buildah as a non-root user by configuring user namespaces
 
-Configuring user namespaces is the simplest way to run Buildah in a task as a non-root user. However, some images might not build using this option.
 [role="_abstract"]
 Configuring user namespaces is the simplest way to run Buildah in a task as a non-root user. However, some images might not build using this option.
 
@@ -69,6 +68,7 @@ spec:
     workingDir: $(workspaces.working-directory.path)
 #  ...
 ----
++
 `runAsUser`:: The `runAsUser:` setting is not strictly necessary, because the task uses `podTemplate`.
 
 . Use the new `buildah-as-user` task to build the image in your pipeline.

--- a/modules/op-providing-secure-connection.adoc
+++ b/modules/op-providing-secure-connection.adoc
@@ -2,6 +2,7 @@
 // This module is included in the following assemblies:
 // * secure/securing-webhooks-with-event-listeners.adoc
 
+:_mod-docs-content-type: PROCEDURE
 [id='op-providing-secure-connection_{context}']
 = Providing secure connection with OpenShift routes
 
@@ -62,4 +63,5 @@ Re-encryption requires this field. The `destinationCACertificate` field specifie
 ----
 $ oc create route reencrypt --help
 ----
+
 

--- a/modules/op-running-buildah-ns-task.adoc
+++ b/modules/op-running-buildah-ns-task.adoc
@@ -1,7 +1,7 @@
 // This module is included in the following assemblies:
 // * secure/using-buildah-ns-tekton-task.adoc
 
-:_mod-docs-content-type: CONCEPT
+:_mod-docs-content-type: PROCEDURE
 
 [id="running-buildah-ns-task_{context}"]
 = Running the `buildah-ns` task
@@ -9,6 +9,11 @@
 [role="_abstract"]
 You can run the `buildah-ns` task as part of a `PipelineRun` resource.
 
+.Procedure
+
+. Create a YAML file that defines `PipelineRun` object:
++
+.Example `pipeline-run.yaml` file
 [source,yaml]
 ----
 apiVersion: tekton.dev/v1
@@ -29,10 +34,18 @@ spec:
       persistentVolumeClaim:
         claimName: your-pvc-name
 ----
++
 `value`:: Replace `your-image-name` with the full name of the container image that you want to build.
 `claimName`:: Replace `your-pvc-name` with the name of the `PersistentVolumeClaim` (PVC) that stores the application source code.
-
++
 [NOTE]
 ====
 If the target container registry requires authentication, configure a Kubernetes secret for registry access and link it to the service account that runs the `TaskRun` or `PipelineRun` resources.
 ====
+
+. Create the `PipelineRun` resource by applying the YAML file:
++
+[source,terminal]
+----
+$ oc apply -f pipeline-run.yaml
+----

--- a/modules/op-running-pipeline-run-and-task-run-with-custom-scc-and-service-account.adoc
+++ b/modules/op-running-pipeline-run-and-task-run-with-custom-scc-and-service-account.adoc
@@ -5,7 +5,6 @@
 [id="op-running-pipeline-run-and-task-run-with-custom-scc-and-service-account_{context}"]
 = Running pipeline run and task run by using a custom security context constraint (SCC) and a custom service account
 
-When using the `pipelines-scc` SCC associated with the default `pipelines` service account, the pipeline run and task run pods might face timeouts. This happens because the default `pipelines-scc` SCC sets the `fsGroup.type` parameter to `MustRunAs`.
 [role="_abstract"]
 When using the `pipelines-scc` SCC associated with the default `pipelines` service account, the pipeline run and task run pods might face timeouts. This happens because the default `pipelines-scc` SCC sets the `fsGroup.type` parameter to `MustRunAs`.
 

--- a/modules/op-security-model-buildah-ns-task.adoc
+++ b/modules/op-security-model-buildah-ns-task.adoc
@@ -6,23 +6,18 @@
 [id="security-model-buildah-ns-task_{context}"]
 = Security model of the `buildah-ns` task
 
-The `buildah-ns` task applies user namespace isolation to give privilege separation between containers and the host system.
 [role="_abstract"]
 The `buildah-ns` task applies user namespace isolation to give privilege separation between containers and the host system.
 
-== UID mapping behavior
-
 When the task runs with namespace annotations, the system maps user IDs (UIDs) as follows:
 
-* **Inside the container**: Processes run as UID 0, which is displayed as the root user.  
-* **Outside the container**: The same processes run as a nonzero UID on the host system.  
+* **Inside the container**: Processes run as UID 0, which is displayed as the root user.
+* **Outside the container**: The same processes run as a nonzero UID on the host system.
 
 This mapping allows processes inside the container to behave as if they have root privileges while restricting their privileges on the host system.
 
-== Security benefits
-
 User namespace isolation provides the following security advantages:
 
-* **kernel-level isolation**: Adds an extra isolation boundary between containers.  
-* **Reduced privilege exposure**: Limits the impact of compromised workloads by running them as non-root users on the host.  
+* **kernel-level isolation**: Adds an extra isolation boundary between containers.
+* **Reduced privilege exposure**: Limits the impact of compromised workloads by running them as non-root users on the host.
 * **Container escape protection**: Helps mitigate potential vulnerabilities that allow escaping from the container runtime environment.

--- a/modules/op-setting-eventlistener-scc.adoc
+++ b/modules/op-setting-eventlistener-scc.adoc
@@ -12,7 +12,7 @@ You can configure a custom security context directly in your `EventListener` cus
 
 * Create a YAML file that defines your `EventListener` CR:
 +
-.Example EventListener custom resource with configured security context
+.Example `EventListener` custom resource with configured security context
 [source,yaml,subs="attributes+"]
 ----
 apiVersion: triggers.tekton.dev/v1
@@ -40,5 +40,6 @@ spec:
                   readOnlyRootFilesystem: true
 #...
 ----
++
 `runAsNonRoot`:: Specify the pod-level security context settings. The example setting sets the pod-level security context to prevent the containers from running as the root user.
 `readOnlyRootFilesystem`:: Specify the container-level security context settings. The example setting restricts the container root filesystem to read-only to limit potential file system modifications at runtime.

--- a/modules/op-signing-secrets-in-tekton-chains.adoc
+++ b/modules/op-signing-secrets-in-tekton-chains.adoc
@@ -6,7 +6,7 @@
 = Secrets for signing data in {tekton-chains}
 
 [role="_abstract"]
-Cluster administrators can generate a key pair and use {tekton-chains} to sign artifacts using a Kubernetes secret. For {tekton-chains} to work, a private key and a password for encrypted keys must exist as part of the `signing-secrets` secret in the `openshift-pipelines` namespace.
+Cluster administrators can generate a key pair and use {tekton-chains} to sign artifacts by using a Kubernetes secret. For {tekton-chains} to work, a private key and a password for encrypted keys must exist as part of the `signing-secrets` secret in the `openshift-pipelines` namespace.
 
 Currently, {tekton-chains} supports the `x509` and `cosign` signature schemes.
 
@@ -15,17 +15,14 @@ Currently, {tekton-chains} supports the `x509` and `cosign` signature schemes.
 Use only one of the supported signature schemes.
 ====
 
+* To use the `x509` signing scheme with {tekton-chains}, you must fulfill the following requirements:
 
-.The x509 signing scheme
-To use the `x509` signing scheme with {tekton-chains}, you must fulfill the following requirements:
+** Store the private key in the `signing-secrets` with the `x509.pem` structure.
+** Store the private key as an unencrypted `PKCS #8` Privacy-Enhanced Mail (PEM) file.
+** The key is of `ed25519` or `ecdsa` type.
 
-* Store the private key in the `signing-secrets` with the `x509.pem` structure.
-* Store the private key as an unencrypted `PKCS #8` Privacy Enhanced Mail (PEM) file.
-* The key is of `ed25519` or `ecdsa` type.
+* To use the `cosign` signing scheme with {tekton-chains}, you must fulfill the following requirements:
 
-.The cosign signing scheme
-To use the `cosign` signing scheme with {tekton-chains}, you must fulfill the following requirements:
-
-* Store the private key in the `signing-secrets` with the `cosign.key` structure.
-* Store the password in the `signing-secrets` with the `cosign.password` structure.
-* Store the private key as an encrypted PEM file of type `ENCRYPTED COSIGN PRIVATE KEY`.
+** Store the private key in the `signing-secrets` with the `cosign.key` structure.
+** Store the password in the `signing-secrets` with the `cosign.password` structure.
+** Store the private key as an encrypted PEM file of type `ENCRYPTED COSIGN PRIVATE KEY`.

--- a/modules/op-starting-a-task-run-pipeline-run-build-user.adoc
+++ b/modules/op-starting-a-task-run-pipeline-run-build-user.adoc
@@ -47,6 +47,7 @@ spec:
       name: dockerfile
     name: source
 ----
++
 `configMapRef.name`:: Use a config map because the focus is on the task run, without any prior task that fetches some sources with a Dockerfile.
 `serviceAccountName`:: The name of the service account that you created.
 `workspaces.name`:: Mount a config map as the source workspace for the `buildah-as-user` task.
@@ -128,6 +129,7 @@ spec:
           requests:
             storage: 100Mi
 ----
++
 `tasks.name: fetch-repository`:: Use the `git-clone` task to fetch the source containing a Dockerfile and build it using the modified Buildah task.
 `taskRef.name`:: Refer to the modified Buildah task.
 `taskServiceAccountName`:: Use the service account that you created for the Buildah task.

--- a/modules/op-supported-parameters-tekton-chains-configuration.adoc
+++ b/modules/op-supported-parameters-tekton-chains-configuration.adoc
@@ -5,13 +5,11 @@
 [id="supported-parameters-tekton-chains-configuration_{context}"]
 = Supported parameters for {tekton-chains} configuration
 
-Cluster administrators can use various supported parameter keys and values to configure specifications about task runs, Open Container Initiative (OCI) images, and storage.
 [role="_abstract"]
 Cluster administrators can use various supported parameter keys and values to configure specifications about task runs, Open Container Initiative (OCI) images, and storage.
 
-[id="chains-supported-parameters-task-run_{context}"]
-== Supported parameters for task run artifacts
-
+* Supported parameters for task run artifacts
++
 .Chains configuration: Supported parameters for task run artifacts
 [options="header"]
 |===
@@ -24,7 +22,7 @@ Cluster administrators can use various supported parameter keys and values to co
 | `in-toto`
 
 | `artifacts.taskrun.storage`
-| The storage backend for task run signatures. You can specify many backends as a comma-separated list, such as `“tekton,oci”`. To disable storing task run artifacts, give an empty string `“”`.
+| The storage backend for task run signatures. You can specify many backends as a comma-separated list, such as `”tekton,oci”`. To disable storing task run artifacts, give an empty string `””`.
 | `tekton`, `oci`, `gcs`, `docdb`, `grafeas`
 | `oci`
 
@@ -34,15 +32,14 @@ Cluster administrators can use various supported parameter keys and values to co
 | `x509`
 
 |===
-
++
 [NOTE]
 ====
 `slsa/v1` is an alias of `in-toto` for backwards compatibility.
 ====
 
-[id="chains-supported-parameters-pipeline-run_{context}"]
-== Supported parameters for pipeline run artifacts
-
+* Supported parameters for pipeline run artifacts
++
 .Chains configuration: Supported parameters for pipeline run artifacts
 [options="header"]
 |===
@@ -55,7 +52,7 @@ Cluster administrators can use various supported parameter keys and values to co
 | `in-toto`
 
 | `artifacts.pipelinerun.storage`
-| The storage backend for storing pipeline run signatures. You can specify many backends as a comma-separated list, such as `“tekton,oci”`. To disable storing pipeline run artifacts, give an empty string `“”`.
+| The storage backend for storing pipeline run signatures. You can specify many backends as a comma-separated list, such as `”tekton,oci”`. To disable storing pipeline run artifacts, give an empty string `””`.
 | `tekton`, `oci`, `gcs`, `docdb`, `grafeas`
 | `oci`
 
@@ -69,16 +66,15 @@ Cluster administrators can use various supported parameter keys and values to co
 | `"true", "false"`
 | `"false"`
 |===
-
++
 [NOTE]
 ====
 * `slsa/v1` is an alias of `in-toto` for backwards compatibility.
 * For the `grafeas` storage backend, only Container Analysis is supported. You cannot configure the `grafeas` server address in the current version of {tekton-chains}.
 ====
 
-[id="chains-supported-parameters-oci_{context}"]
-== Supported parameters for OCI artifacts
-
+* Supported parameters for OCI artifacts
++
 .Chains configuration: Supported parameters for OCI artifacts
 [options="header"]
 |===
@@ -91,7 +87,7 @@ Cluster administrators can use various supported parameter keys and values to co
 | `simplesigning`
 
 | `artifacts.oci.storage`
-| The storage backend for storing OCI signatures. You can specify many backends as a comma-separated list, such as `“oci,tekton”`. To disable storing OCI artifacts, give an empty string `“”`.
+| The storage backend for storing OCI signatures. You can specify many backends as a comma-separated list, such as `”oci,tekton”`. To disable storing OCI artifacts, give an empty string `””`.
 | `tekton`, `oci`, `gcs`, `docdb`, `grafeas`
 | `oci`
 
@@ -105,7 +101,9 @@ Cluster administrators can use various supported parameter keys and values to co
 [id="chains-supported-parameters-kms_{context}"]
 == Supported parameters for Key Management Service (KMS) signers
 
+
 .Chains configuration: Supported parameters for KMS signers
+[options="header"]
 |===
 | Parameter | Description | Supported values | Default value
 
@@ -115,9 +113,8 @@ Cluster administrators can use various supported parameter keys and values to co
 |
 |===
 
-[id="chains-supported-parameters-storage_{context}"]
-== Supported parameters for storage
-
+* Supported parameters for storage
++
 .Chains configuration: Supported parameters for storage
 [options="header"]
 |===
@@ -147,11 +144,15 @@ Cluster administrators can use various supported parameter keys and values to co
 
 |===
 
-If you enable the `docdb` storage method is for any artifacts, configure docstore storage options. For more information about the go-cloud docstore URI format, see the link:https://gocloud.dev/howto/docstore/[docstore package documentation]. {pipelines-title} supports the following docstore services:
-
-* `firestore`
-* `dynamodb`
-
+* Supported parameters for docstore storage
++
+If you enable the `docdb` storage method for any artifacts, configure docstore storage options. For more information about the go-cloud docstore URI format, see the link:https://gocloud.dev/howto/docstore/[docstore package documentation]. {pipelines-title} supports the following docstore services:
++
+--
+** `firestore`
+** `dynamodb`
+--
++
 .Chains configuration: Supported parameters for `docstore` storage
 [options="header"]
 |===
@@ -176,12 +177,15 @@ If you enable the `docdb` storage method is for any artifacts, configure docstor
 
 |===
 
+* Supported parameters for Grafeas storage
++
 If you enable the `grafeas` storage method for any artifacts, configure Grafeas storage options. For more information about Grafeas notes and occurrences, see link:https://github.com/grafeas/grafeas/blob/master/docs/grafeas_concepts.md[Grafeas concepts].
 
 To create occurrences, {pipelines-title} must first create notes that link occurrences. {pipelines-title} creates two types of occurrences: `ATTESTATION` Occurrence and `BUILD` Occurrence.
 
-{pipelines-title} uses the configurable `noteid` as the prefix of the note name. It appends the suffix `-simplesigning` for the `ATTESTATION` note and the suffix `-intoto` for the `BUILD` note. If the `noteid` field is not configured, {pipelines-title} uses `tekton-<NAMESPACE>` as the prefix.
 
+{pipelines-title} uses the configurable `noteid` as the prefix of the note name. It appends the suffix `-simplesigning` for the `ATTESTATION` note and the suffix `-intoto` for the `BUILD` note. If the `noteid` field is not configured, {pipelines-title} uses `tekton-<NAMESPACE>` as the prefix.
++
 .Chains configuration: Supported parameters for Grafeas storage
 [options="header"]
 |===
@@ -204,8 +208,10 @@ To create occurrences, {pipelines-title} must first create notes that link occur
 |`This attestation note was generated by Tekton Chains`
 |===
 
+* Supported parameters for transparency attestation storage
++
 Optionally, you can enable additional uploads of binary transparency attestations.
-
++
 .Chains configuration: Supported parameters for transparency attestation storage
 [options="header"]
 |===
@@ -225,13 +231,16 @@ Optionally, you can enable additional uploads of binary transparency attestation
 
 NOTE: If you set `transparency.enabled` to `manual`, {tekton-chains} uploads only task runs and pipeline runs with the following annotation to the transparency log:
 
+
 [source,yaml]
 ----
 chains.tekton.dev/transparency-upload: "true"
 ----
 
+* Supported parameters for `x509` keyless signing with Fulcio
++
 If you configure the `x509` signature backend, you can optionally enable keyless signing with Fulcio.
-
++
 .Chains configuration: Supported parameters for `x509` keyless signing with Fulcio
 [options="header"]
 |===
@@ -269,8 +278,10 @@ If you configure the `x509` signature backend, you can optionally enable keyless
 | `+https://sigstore-tuf-root.storage.googleapis.com+`
 |===
 
+* Supported parameters for specific KMS authentication
++
 If you configure the `kms` signature backend, set the KMS configuration, including OIDC and Spire, as necessary.
-
++
 .Chains configuration: Supported parameters for KMS signing
 [options="header"]
 |===

--- a/modules/op-types-annotation-secrets.adoc
+++ b/modules/op-types-annotation-secrets.adoc
@@ -35,6 +35,7 @@ stringData:
   username: <username>
   password: <password>
 ----
++
 `<username>`:: Username for the repository
 `<password>`:: Password or personal access token for the repository
 
@@ -53,6 +54,7 @@ type: kubernetes.io/ssh-auth
 stringData:
   ssh-privatekey:
 ----
++
 `ssh-privatekey`:: The content of the SSH private key file.
 
 [id="op-types-annotation-secrets-container_{context}"]
@@ -85,6 +87,7 @@ stringData:
   username: <username>
   password: <password>
 ----
++
 `<username>`:: Username for the registry
 `<password>`:: Password or personal access token for the registry
 
@@ -109,6 +112,7 @@ $ oc create secret docker-registry docker-secret-config \
   --docker-password=<password> \
   --docker-server=my-registry.example.com:5000
 ----
++
 `<email>`:: Email address for the registry
 `<username>`:: Username for the registry
 `<password>`:: Password or personal access token for the registry

--- a/modules/op-using-secrets-as-a-nonroot-user.adoc
+++ b/modules/op-using-secrets-as-a-nonroot-user.adoc
@@ -12,9 +12,9 @@ You can configure your tasks to use secrets as a non-root user. This is useful i
 * The steps in a task define a non-root security context.
 * A task specifies a global non-root security context, which applies to all steps in a task.
 
-In such scenarios, consider the following aspects of executing task runs and pipeline runs as a non-root user:
+In such scenarios, consider the following aspects of starting task runs and pipeline runs as a non-root user:
 
 * SSH authentication for Git requires the user to have a valid home directory configured in the `/etc/passwd` directory. Specifying a UID that has no valid home directory results in authentication failure.
 * SSH authentication ignores the `$HOME` environment variable. So you must or symlink the appropriate secret files from the `$HOME` directory defined by {pipelines-shortname} (`/tekton/home`), to the non-root user's valid home directory.
 
-In addition, to configure SSH authentication in a non-root security context, refer to the `git-clone-and-check` step in the link:https://github.com/openshift-pipelines/pipelines-examples/blob/main/v1/taskruns/authenticating-git-commands.yaml[example for authenticating git commands].
+In addition, to configure SSH authentication in a non-root security context, see the `git-clone-and-check` step in the link:https://github.com/openshift-pipelines/pipelines-examples/blob/main/v1/taskruns/authenticating-git-commands.yaml[example for authenticating git commands].

--- a/modules/op-using-ssh-authentication-in-git-type-tasks.adoc
+++ b/modules/op-using-ssh-authentication-in-git-type-tasks.adoc
@@ -29,4 +29,4 @@ spec:
 
 However, explicit symlinks are not necessary when you use a pipeline resource of the `git` type or the `git-clone` task available in the Tekton catalog.
 
-As an example of using SSH authentication in `git` type tasks, refer to link:https://github.com/openshift-pipelines/pipelines-examples/blob/main/v1/taskruns/authenticating-git-commands.yaml[authenticating-git-commands.yaml].
+As an example of using SSH authentication in `git` type tasks, see link:https://github.com/openshift-pipelines/pipelines-examples/blob/main/v1/taskruns/authenticating-git-commands.yaml[authenticating-git-commands.yaml].

--- a/modules/op-using-tekton-chains-to-sign-and-verify-image-and-provenance.adoc
+++ b/modules/op-using-tekton-chains-to-sign-and-verify-image-and-provenance.adoc
@@ -38,6 +38,7 @@ Ensure that you install the following tools on the cluster:
 $ oc create secret generic <docker_config_secret_name> \
   --from-file <path_to_config.json>
 ----
++
 `<docker_config_secret_name>`:: Substitute with the name of the docker config secret.
 `<path_to_config.json>`:: Substitute with the path to docker `config.json` file.
 
@@ -46,9 +47,15 @@ $ oc create secret generic <docker_config_secret_name> \
 [source,terminal]
 ----
 $ oc patch configmap chains-config -n openshift-pipelines -p='{"data":{"artifacts.taskrun.format": "in-toto"}}'
-
+----
++
+[source,terminal]
+----
 $ oc patch configmap chains-config -n openshift-pipelines -p='{"data":{"artifacts.taskrun.storage": "oci"}}'
-
+----
++
+[source,terminal]
+----
 $ oc patch configmap chains-config -n openshift-pipelines -p='{"data":{"transparency.enabled": "true"}}'
 ----
 
@@ -60,6 +67,7 @@ $ oc patch configmap chains-config -n openshift-pipelines -p='{"data":{"transpar
 ----
 $ oc apply -f examples/kaniko/kaniko.yaml
 ----
++
 `examples/kaniko/kaniko.yaml`:: Substitute with the URI or file path to your Kaniko task.
 
 .. Set the appropriate environment variables.
@@ -70,6 +78,7 @@ $ export REGISTRY=<url_of_registry>
 
 $ export DOCKERCONFIG_SECRET_NAME=<name_of_the_secret_in_docker_config_json>
 ----
++
 `<url_of_registry>`:: Substitute with the URL of the registry where you want to push the image.
 `<name_of_the_secret_in_docker_config_json>`:: Substitute with the name of the secret in the docker `config.json` file.
 
@@ -94,6 +103,7 @@ $ oc get tr <task_run_name> \
   ...
 }
 ----
++
 `<task_run_name>`:: Substitute with the name of the task run.
 
 . Verify the image and the attestation.
@@ -119,6 +129,7 @@ $ rekor-cli search --sha <image_digest>
 <uuid_2>
 ...
 ----
++
 `<image_digest>`:: Substitute with the `sha256` digest of the image.
 `<uuid_1>`:: The first matching universally unique identifier (UUID).
 `<uuid_2>`:: The second matching UUID.

--- a/modules/op-workspaces-parameters-results-buildah-ns-task.adoc
+++ b/modules/op-workspaces-parameters-results-buildah-ns-task.adoc
@@ -6,7 +6,6 @@
 [id="workspaces-parameters-results-buildah-ns-task_{context}"]
 = Workspaces, parameters, and results for the `buildah-ns` task
 
-The `buildah-ns` task requires a workspace, accepts several parameters for image build customization, and provides results that contain information about the built image.
 [role="_abstract"]
 The `buildah-ns` task requires a workspace, accepts several parameters for image build customization, and provides results that contain information about the built image.
 

--- a/secure/authenticating-pipelines-repos-using-secrets.adoc
+++ b/secure/authenticating-pipelines-repos-using-secrets.adoc
@@ -6,6 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 Pipelines and tasks can require credentials to authenticate with Git repositories and container repositories. In {pipelines-title}, you can use secrets to authenticate pipeline runs and task runs that interact with a Git repository or container repository during execution.
 
 A secret for authentication with a Git repository is known as a _Git secret_.

--- a/secure/configuring-security-context-for-pods.adoc
+++ b/secure/configuring-security-context-for-pods.adoc
@@ -45,8 +45,8 @@ include::modules/op-configuring-scc-namespace.adoc[leveloffset=+1]
 
 include::modules/op-running-pipeline-run-and-task-run-with-custom-scc-and-service-account.adoc[leveloffset=+1]
 
-[role="_additional-resources"]
 [id="additional-references_configuring-security-context-for-pods"]
+[role="_additional-resources"]
 == Additional resources
 
-* link:https://docs.openshift.com/container-platform/latest/authentication/managing-security-context-constraints.html[Managing security context constraints].
+* link:https://docs.openshift.com/container-platform/latest/authentication/managing-security-context-constraints.html[Managing security context constraints]

--- a/secure/securing-webhooks-with-event-listeners.adoc
+++ b/secure/securing-webhooks-with-event-listeners.adoc
@@ -6,6 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 As an administrator, you can secure webhooks with event listeners. After creating a namespace, you enable HTTPS for the `Eventlistener` resource by adding the `operator.tekton.dev/enable-annotation=enabled` label to the namespace. Then, you create a `Trigger` resource and a secured route using the re-encrypted TLS termination.
 
 Triggers in {pipelines-title} support insecure HTTP and secure HTTPS connections to the `Eventlistener` resource. HTTPS secures connections within and outside the cluster.

--- a/secure/unprivileged-building-of-container-images-using-buildah.adoc
+++ b/secure/unprivileged-building-of-container-images-using-buildah.adoc
@@ -6,6 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 Running {pipelines-shortname} as the root user on a container can expose the container processes and the host to other potentially malicious resources. You can reduce this type of exposure by running the workload as a specific non-root user in the container.
 
 In most cases, you can run Buildah without root privileges by creating a custom task for building the image and configuring user namespaces in this task.

--- a/secure/using-buildah-ns-tekton-task.adoc
+++ b/secure/using-buildah-ns-tekton-task.adoc
@@ -6,6 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 The `buildah-ns` Tekton task builds Open Container Initiative (OCI) images without requiring a container runtime daemon, such as the Docker daemon. The task uses `buildah` and applies user namespace isolation to provide enhanced security.
 
 After a successful build, the task produces the following results:

--- a/secure/using-tekton-chains-for-openshift-pipelines-supply-chain-security.adoc
+++ b/secure/using-tekton-chains-for-openshift-pipelines-supply-chain-security.adoc
@@ -25,11 +25,15 @@ include::modules/op-creating-mounting-mongo-server-url-secret.adoc[leveloffset=+
 include::modules/op-creating-mounting-kms-authentication-token-secret.adoc[leveloffset=+2]
 include::modules/op-enabling-tekton-chains-to-operate-only-in-selected-namespaces.adoc[leveloffset=+2]
 
+:leveloffset: 0
+
 include::modules/op-signing-secrets-in-tekton-chains.adoc[leveloffset=+1]
 include::modules/op-chains-generating-cosign-secret.adoc[leveloffset=+2]
 include::modules/op-chains-signing-secrets-cosign.adoc[leveloffset=+2]
 include::modules/op-chains-signing-secrets-skopeo.adoc[leveloffset=+2]
 include::modules/op-chains-resolving-existing-secret.adoc[leveloffset=+2]
+
+:leveloffset: 0
 
 include::modules/op-authenticating-to-an-oci-registry.adoc[leveloffset=+1]
 


### PR DESCRIPTION
There are no new features. This PR addresses DITA migration issues for OpenShift Pipelines.

Version(s): 1.22, 1.21, 1.20

Issue: https://issues.redhat.com/browse/RHDEVDOCS-7062

Link to docs preview:

QE review:
- [ ] QE has approved this change.