### PR TITLE
OSDOCS-18665-abstracts

### DIFF
--- a/modules/accessing-hosts-on-aws.adoc
+++ b/modules/accessing-hosts-on-aws.adoc
@@ -7,7 +7,7 @@
 = Accessing hosts on Amazon Web Services in an installer-provisioned infrastructure cluster
 
 [role="_abstract"]
-To establish Secure Shell (SSH) access to {product-title} hosts on Amazon EC2 instances that lack public IP addresses, configure a bastion host or secure gateway. Defining this access path ensures that you can safely manage and troubleshoot your private infrastructure within an installer-provisioned environment.
+The {product-title} installer does not create any public IP addresses for any of the Amazon Elastic Compute Cloud (Amazon EC2) instances that it provisions for your {product-title} cluster. After you provisioned your Amazon EC2 instance, you can use SSH to access your {product-title} hosts.
 
 .Procedure
 

--- a/modules/hcp-cidr-ranges.adoc
+++ b/modules/hcp-cidr-ranges.adoc
@@ -7,7 +7,7 @@
 = CIDR ranges for {hcp}
 
 [role="_abstract"]
-To successfully deploy {hcp} on {product-title}, define the network environment by using specific Classless Inter-Domain Routing (CIDR) subnet ranges. Establishing these nonoverlapping ranges ensures reliable communication between cluster components and prevents internal IP address conflicts.
+To successfully deploy {hcp} on {product-title}, define the network environment by using specific Classless Inter-Domain Routing (CIDR) subnet ranges.
 
 The following Classless Inter-Domain Routing (CIDR) subnet ranges are the default settings for {hcp}:
 

--- a/modules/host-prefix-description.adoc
+++ b/modules/host-prefix-description.adoc
@@ -7,7 +7,7 @@
 = Host prefix
 
 [role="_abstract"]
-To allocate a dedicated pool of IP addresses for pods on each node in {product-title}, specify the subnet prefix length in the hostPrefix parameter. Defining an appropriate prefix ensures that every machine has sufficient unique addresses to support its scheduled workloads without exhausting the cluster's network resources.
+In the `hostPrefix` parameter, you must specify the subnet prefix length assigned to pods scheduled to individual machines. The host prefix determines the pod IP address pool for each machine.
 
 ifdef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 For example, if you set the `hostPrefix` parameter to `/23`, each machine is assigned a `/23` subnet from the pod CIDR address range. The default is `/23`, allowing 512 cluster nodes and 512 pods per node. Note that where 512 cluster nodes and 512 pods are beyond the maximum supported.

--- a/modules/machine-cidr-description.adoc
+++ b/modules/machine-cidr-description.adoc
@@ -7,7 +7,7 @@
 = Machine CIDR
 
 [role="_abstract"]
-To establish the network scope for cluster nodes in {product-title}, specify an IP address range in the Machine Classless Inter-Domain Routing (CIDR) parameter. Defining this range ensures that all machines within the environment have valid, routable addresses for internal cluster communication.
+In the Machine classless inter-domain routing (CIDR) field, you must specify the IP address range for machines or cluster nodes.
 
 [NOTE]
 ====

--- a/modules/nw-understanding-networking-core-layers-and-components.adoc
+++ b/modules/nw-understanding-networking-core-layers-and-components.adoc
@@ -7,7 +7,7 @@
 = Core network layers and components
 
 [role="_abstract"]
-To build and expose resilient applications in {product-title}, configure the pod and service network layers. Defining these foundational layers ensures that your application workloads have a secure environment to run and remain reliably accessible to other services.
+{openshift-networking} is built on two fundamental layers: the pod network and the service network. The pod network is where your applications live. The service network makes your applications reliably accessible.
 
 The pod network::
 

--- a/modules/nw-understanding-networking-managing-traffic-entering-leaving.adoc
+++ b/modules/nw-understanding-networking-managing-traffic-entering-leaving.adoc
@@ -7,7 +7,7 @@
 = Managing traffic entering and leaving the cluster
 
 [role="_abstract"]
-To enable external access and securely manage traffic flow into and out of your {product-title} cluster, configure ingress and egress mechanisms. Establishing these traffic rules ensures that external users can reach your applications reliably while maintaining secure communication with external services.
+You need a way for external users to access your applications and for your applications to securely access external services. {product-title} provides several tools to manage this flow of traffic into and out of your cluster.
 
 Exposing applications with Ingress and Route objects::
 

--- a/modules/nw-understanding-networking-managing-traffic-within.adoc
+++ b/modules/nw-understanding-networking-managing-traffic-within.adoc
@@ -7,7 +7,7 @@
 = Managing traffic within the cluster
 
 [role="_abstract"]
-To ensure reliable communication between applications in {product-title}, configure pod-to-pod traffic and service discovery mechanisms. Implementing these mechanisms allows cluster workloads to exchange data efficiently through either direct connections or robust discovery rules.
+Your applications need to communicate with each other inside the cluster. {product-title} provides two primary mechanisms that you can use to handle internal traffic: direct pod-to-pod communication for simple exchanges and robust service discovery for reliable connections.
 
 Pod-to-pod communication::
 

--- a/modules/pod-cidr-description.adoc
+++ b/modules/pod-cidr-description.adoc
@@ -4,10 +4,10 @@
 
 :_mod-docs-content-type: CONCEPT
 [id="pod-cidr-description_{context}"]
-= Pod CIDR
+= Pod classless inter-domain routing (CIDR)
 
 [role="_abstract"]
-To allocate internal network addresses for cluster workloads in {product-title}, specify an IP address range in the pod Classless Inter-Domain Routing (CIDR) field. Defining this range ensures that pods can communicate with each other reliably without overlapping with the node or service networks.
+In the pod CIDR field, you must specify the IP address range for pods.
 
 ifdef::openshift-enterprise[]
 The pod CIDR is the same as the `clusterNetwork` CIDR and the cluster CIDR.

--- a/modules/service-cidr-description.adoc
+++ b/modules/service-cidr-description.adoc
@@ -4,10 +4,10 @@
 
 :_mod-docs-content-type: CONCEPT
 [id="service-cidr-description_{context}"]
-= Service CIDR
+= Service classless inter-domain routing (CIDR)
 
 [role="_abstract"]
-To allocate IP addresses for cluster services in {product-title}, specify an IP address range in the Service Classless Inter-Domain Routing (CIDR) parameter. Defining this range ensures that internal services have a dedicated block of addresses for reliable communication without overlapping with node or pod networks.
+In the Service CIDR field, you must specify the IP address range for services.
 
 ifdef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 Red{nbsp}Hat recommends, but this task is not mandatory, that the address block is the same between clusters. This does not create IP address conflicts.

--- a/networking/networking_overview/cidr-range-definitions.adoc
+++ b/networking/networking_overview/cidr-range-definitions.adoc
@@ -10,7 +10,7 @@ endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 toc::[]
 
 [role="_abstract"]
-To ensure stable and accurate network routing in {product-title} clusters that use OVN-Kubernetes, define non-overlapping Classless Inter-Domain Routing (CIDR) subnet ranges. Establishing unique ranges prevents IP address conflicts so that internal traffic reaches its intended destination without interference.
+If your cluster uses OVN-Kubernetes, you must specify non-overlapping ranges for Classless Inter-Domain Routing (CIDR) subnet ranges.
 
 [IMPORTANT]
 ====

--- a/networking/networking_overview/networking-dashboards.adoc
+++ b/networking/networking_overview/networking-dashboards.adoc
@@ -7,7 +7,7 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 [role="_abstract"]
-To monitor and analyze network performance within your cluster, view networking metrics in the {product-title} web console. By accessing these dashboards through *Observe* -> *Dashboards*,  you can identify traffic patterns and troubleshoot connectivity issues to ensure consistent workload availability.
+To monitor and analyze network performance within your cluster, view networking metrics in the {product-title} web console.
 
 Network Observability Operator::
 

--- a/networking/networking_overview/understanding-networking.adoc
+++ b/networking/networking_overview/understanding-networking.adoc
@@ -7,7 +7,7 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 [role="_abstract"]
-To build resilient and secure applications in {product-title}, configure the networking infrastructure for your cluster. Defining reliable pod-to-pod communication and traffic routing rules ensures that every application component functions correctly within the environment.
+Understanding networking is essential for building resilient, secure, and scalable applications in {product-title}. From basic pod-to-pod communication to complex traffic routing and security rules, every component of your application relies on the network to function correctly.
 
 include::modules/nw-understanding-networking-core-layers-and-components.adoc[leveloffset=+1]
 


### PR DESCRIPTION
Version(s):
4.16+

Issue:
[OSDOCS-18665](https://redhat.atlassian.net/browse/OSDOCS-18665)

Link to docs preview:

* [Accessing hosts on Amazon Web Services in an installer-provisioned infrastructure cluster](https://109480--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/networking_overview/accessing-hosts.html#accessing-hosts-on-aws_accessing-hosts)
* [CIDR ranges for hosted control planes](https://109480--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/networking_overview/cidr-range-definitions.html#hcp-cidr-ranges_cidr-range-definitions)
* [Host prefix](https://109480--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/networking_overview/cidr-range-definitions.html#host-prefix-description_cidr-range-definitions)
* [Machine CIDR](https://109480--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/networking_overview/cidr-range-definitions.html#machine-cidr-description_cidr-range-definitions)
* [Core network layers and components](https://109480--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/networking_overview/understanding-networking.html#nw-understanding-networking-core-layers-and-components_understanding-networking)
* [Managing traffic entering and leaving the cluster](https://109480--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/networking_overview/understanding-networking.html#nw-understanding-networking-managing-traffic-entering-leaving_understanding-networking)
* [Managing traffic within the cluster](https://109480--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/networking_overview/understanding-networking.html#nw-understanding-networking-managing-traffic-within_understanding-networking)
* [Pod CIDR](https://109480--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/networking_overview/cidr-range-definitions.html#pod-cidr-description_cidr-range-definitions)
* [Service CIDR](https://109480--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/networking_overview/cidr-range-definitions.html#service-cidr-description_cidr-range-definitions)
* [CIDR range definitions](https://109480--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/networking_overview/cidr-range-definitions.html#service-cidr-description_cidr-range-definitions)
* [Networking dashboards](https://109480--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/networking_overview/networking-dashboards.html)
* [Understanding networking](https://109480--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/networking_overview/understanding-networking.html#nw-understanding-networking-managing-traffic-within_understanding-networking)