### PR TITLE
OSDOCS-18645-abstracts

### DIFF
--- a/modules/configuring-egress-proxy-edns-operator.adoc
+++ b/modules/configuring-egress-proxy-edns-operator.adoc
@@ -7,7 +7,7 @@
 = Trusting the certificate authority of the cluster-wide proxy
 
 [role="_abstract"]
-To enable the External DNS Operator to authenticate with the cluster-wide proxy, configure the Operator to trust the certificate authority (CA) of the proxy. This ensures secure communication when routing DNS traffic through the proxy.
+You can configure the External DNS Operator to trust the certificate authority of the cluster-wide proxy.
 
 .Procedure
 

--- a/modules/nw-control-dns-records-public-aws-with-VPC.adoc
+++ b/modules/nw-control-dns-records-public-aws-with-VPC.adoc
@@ -7,7 +7,9 @@
 = Creating DNS records in a different AWS account by using a shared VPC
 
 [role="_abstract"]
-To create DNS records in a different AWS account, configure the ExternalDNS Operator to use a shared Virtual Private Cloud (VPC). Your organization can then use a single Route 53 instance for name resolution across multiple accounts and projects.
+You can use the ExternalDNS Operator to create DNS records in a different AWS account using a shared Virtual Private Cloud (VPC).
+
+By using a shared VPC, an organization can connect resources from multiple projects to a common VPC network. Organizations can then use VPC sharing to use a single Route 53 instance across multiple AWS accounts.
 
 .Prerequisites
 

--- a/modules/nw-external-dns-operator-configuration-parameters.adoc
+++ b/modules/nw-external-dns-operator-configuration-parameters.adoc
@@ -7,7 +7,7 @@
 = External DNS Operator configuration parameters
 
 [role="_abstract"]
-To customize the behavior of the External DNS Operator, configure the available parameters in the `ExternalDNS` custom resource (CR). By configuring parameters, you can control how the Operator synchronizes services and routes with your external DNS provider.
+To customize the behavior of the External DNS Operator, configure the available parameters in the `ExternalDNS` custom resource (CR).
 
 [cols="3a,8a",options="header"]
 |===

--- a/modules/nw-external-dns-operator.adoc
+++ b/modules/nw-external-dns-operator.adoc
@@ -6,8 +6,6 @@
 = Deploying the External DNS Operator
 
 [role="_abstract"]
-You can deploy the External DNS Operator on-demand from the Software Catalog. Deploying the External DNS Operator creates a `Subscription` object.
-
 The External DNS Operator implements the External DNS API from the `olm.openshift.io` API group. The External DNS Operator updates services, routes, and external DNS providers.
 
 .Prerequisites

--- a/networking/networking_operators/external_dns_operator/understanding-external-dns-operator.adoc
+++ b/networking/networking_operators/external_dns_operator/understanding-external-dns-operator.adoc
@@ -7,7 +7,7 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 [role="_abstract"]
-To provide name resolution for services and routes from an External DNS provider to {product-title}, use the External DNS Operator. This Operator deploys and manages `ExternalDNS` to synchronize your cluster resources with the external provider.
+The External DNS Operator deploys and manages `ExternalDNS` to provide the name resolution for services and routes from the external DNS provider to {product-title}.
 
 // External DNS Operator domain name limitations
 include::modules/nw-external-dns-operator-domain-limitations.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s):
4.20+

Issue:
[OSDOCS-18645](https://redhat.atlassian.net/browse/OSDOCS-18645)

Link to docs preview:

* [Trusting the certificate authority of the cluster-wide proxy](https://109482--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/networking_operators/external_dns_operator/nw-configuring-cluster-wide-egress-proxy.html#nw-configuring-cluster-wide-proxy_external-dns-operator-cluster-wide-proxy)
* [Creating DNS records in a different AWS account by using a shared VPC](https://109482--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/networking_operators/external_dns_operator/nw-creating-dns-records-on-aws.html#nw-control-dns-records-public-aws-with-VPC_creating-dns-records-on-aws)
* [External DNS Operator configuration parameters](https://109482--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/networking_operators/external_dns_operator/nw-configuration-parameters.html)
* [Deploying the External DNS Operator](https://109482--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/networking_operators/external_dns_operator/understanding-external-dns-operator.html#nw-external-dns-operator_external-dns-operator)
* [Understanding the External DNS Operator](https://109482--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/networking_operators/external_dns_operator/understanding-external-dns-operator.html#nw-external-dns-operator_external-dns-operator)
