### PR TITLE
TELCODOCS-2653: Backport DITA-prep fixes to enterprise-4.18

### DIFF
--- a/edge_computing/cnf-talm-for-cluster-upgrades.adoc
+++ b/edge_computing/cnf-talm-for-cluster-upgrades.adoc
@@ -6,6 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 You can use the {cgu-operator-first} to manage the software lifecycle of multiple clusters. {cgu-operator} uses {rh-rhacm-first} policies to perform changes on the target clusters.
 
 :Featurename: Using PolicyGenerator resources with {ztp}

--- a/modules/cnf-about-topology-aware-lifecycle-manager-blocking-crs.adoc
+++ b/modules/cnf-about-topology-aware-lifecycle-manager-blocking-crs.adoc
@@ -6,6 +6,7 @@
 [id="cnf-about-topology-aware-lifecycle-manager-blocking-crs_{context}"]
 = Blocking ClusterGroupUpgrade CRs
 
+[role="_abstract"]
 You can create multiple `ClusterGroupUpgrade` CRs and control their order of application.
 
 For example, if you create `ClusterGroupUpgrade` CR C that blocks the start of `ClusterGroupUpgrade` CR A, then `ClusterGroupUpgrade` CR A cannot start until the status of `ClusterGroupUpgrade` CR C becomes `UpgradeComplete`.
@@ -32,7 +33,7 @@ metadata:
   name: cgu-a
   namespace: default
 spec:
-  blockingCRs: <1>
+  blockingCRs:
   - name: cgu-c
     namespace: default
   clusters:
@@ -74,7 +75,8 @@ status:
   - - spoke1
   - - spoke2
 ----
-<1> Defines the blocking CRs. The `cgu-a` update cannot start until `cgu-c` is complete.
+
+* `spec.blockingCRs.name` defines the blocking CRs. The `cgu-a` update cannot start until `cgu-c` is complete.
 
 [source,yaml]
 ----
@@ -84,7 +86,7 @@ metadata:
   name: cgu-b
   namespace: default
 spec:
-  blockingCRs: <1>
+  blockingCRs:
   - name: cgu-a
     namespace: default
   clusters:
@@ -129,7 +131,8 @@ status:
   - - spoke5
   status: {}
 ----
-<1> The `cgu-b` update cannot start until `cgu-a` is complete.
+
+The `cgu-b` update cannot start until `cgu-a` is complete.
 
 [source,yaml]
 ----
@@ -138,7 +141,7 @@ kind: ClusterGroupUpgrade
 metadata:
   name: cgu-c
   namespace: default
-spec: <1>
+spec:
   clusters:
   - spoke6
   enable: false
@@ -174,7 +177,8 @@ status:
   - - spoke6
   status: {}
 ----
-<1> The `cgu-c` update does not have any blocking CRs. {cgu-operator} starts the `cgu-c` update when the `enable` field is set to `true`.
+
+The `cgu-c` update does not have any blocking CRs. {cgu-operator} starts the `cgu-c` update when the `enable` field is set to `true`.
 --
 
 . Create the `ClusterGroupUpgrade` CRs by running the following command for each relevant CR:
@@ -195,7 +199,8 @@ $ oc --namespace=default patch clustergroupupgrade.ran.openshift.io/<name> \
 The following examples show `ClusterGroupUpgrade` CRs where the `enable` field is set to `true`:
 +
 --
-.Example for `cgu-a` with blocking CRs
+Example for `cgu-a` with blocking CRs:
+
 [source,yaml]
 ----
 apiVersion: ran.openshift.io/v1alpha1
@@ -224,7 +229,7 @@ spec:
 status:
   conditions:
   - message: 'The ClusterGroupUpgrade CR is blocked by other CRs that have not yet
-      completed: [cgu-c]' <1>
+      completed: [cgu-c]'
     reason: UpgradeCannotStart
     status: "False"
     type: Ready
@@ -248,9 +253,11 @@ status:
   - - spoke2
   status: {}
 ----
-<1> Shows the list of blocking CRs.
 
-.Example for `cgu-b` with blocking CRs
+Shows the list of blocking CRs.
+
+Example for `cgu-b` with blocking CRs:
+
 [source,yaml]
 ----
 apiVersion: ran.openshift.io/v1alpha1
@@ -277,7 +284,7 @@ spec:
 status:
   conditions:
   - message: 'The ClusterGroupUpgrade CR is blocked by other CRs that have not yet
-      completed: [cgu-a]' <1>
+      completed: [cgu-a]'
     reason: UpgradeCannotStart
     status: "False"
     type: Ready
@@ -305,9 +312,11 @@ status:
   - - spoke5
   status: {}
 ----
-<1> Shows the list of blocking CRs.
 
-.Example for `cgu-c` with blocking CRs
+Shows the list of blocking CRs.
+
+Example for `cgu-c` with blocking CRs:
+
 [source,yaml]
 ----
 apiVersion: ran.openshift.io/v1alpha1
@@ -329,7 +338,7 @@ spec:
     timeout: 240
 status:
   conditions:
-  - message: The ClusterGroupUpgrade CR has upgrade policies that are still non compliant <1>
+  - message: The ClusterGroupUpgrade CR has upgrade policies that are still non compliant
     reason: UpgradeNotCompleted
     status: "False"
     type: Ready
@@ -354,5 +363,6 @@ status:
     remediationPlanForBatch:
       spoke6: 0
 ----
-<1> The `cgu-c` update does not have any blocking CRs.
+
+The `cgu-c` update does not have any blocking CRs.
 --

--- a/modules/cnf-about-topology-aware-lifecycle-manager-config.adoc
+++ b/modules/cnf-about-topology-aware-lifecycle-manager-config.adoc
@@ -6,6 +6,7 @@
 [id="cnf-about-topology-aware-lifecycle-manager-config_{context}"]
 = About the {cgu-operator-full} configuration
 
+[role="_abstract"]
 The {cgu-operator-first} manages the deployment of {rh-rhacm-first} policies for one or more {product-title} clusters. Using {cgu-operator} in a large network of clusters allows the phased rollout of policies to the clusters in limited batches. This helps to minimize possible service disruptions when updating. With {cgu-operator}, you can control the following actions:
 
 * The timing of the update

--- a/modules/cnf-about-topology-aware-lifecycle-manager-policies.adoc
+++ b/modules/cnf-about-topology-aware-lifecycle-manager-policies.adoc
@@ -6,6 +6,7 @@
 [id="cnf-about-topology-aware-lifecycle-manager-about-policies_{context}"]
 = About managed policies used with {cgu-operator-full}
 
+[role="_abstract"]
 The {cgu-operator-first} uses {rh-rhacm} policies for cluster updates.
 
 {cgu-operator} can be used to manage the rollout of any policy CR where the `remediationAction` field is set to `inform`.

--- a/modules/cnf-topology-aware-lifecycle-manager-about-cgu-crs.adoc
+++ b/modules/cnf-topology-aware-lifecycle-manager-about-cgu-crs.adoc
@@ -6,6 +6,7 @@
 [id="talo-about-cgu-crs_{context}"]
 = About the ClusterGroupUpgrade CR
 
+[role="_abstract"]
 The {cgu-operator-first} builds the remediation plan from the `ClusterGroupUpgrade` CR for a group of clusters. You can define the following specifications in a `ClusterGroupUpgrade` CR:
 
 * Clusters in the group
@@ -78,47 +79,47 @@ metadata:
   uid: cca245a5-4bca-45fa-89c0-aa6af81a596c
 Spec:
   actions:
-    afterCompletion: <1>
+    afterCompletion:
       addClusterLabels:
         upgrade-done: ""
       deleteClusterLabels:
         upgrade-running: ""
       deleteObjects: true
-    beforeEnable: <2>
+    beforeEnable:
       addClusterLabels:
         upgrade-running: ""
-  clusters: <3>
+  clusters:
     - spoke1
-  enable: false <4>
-  managedPolicies: <5>
+  enable: false
+  managedPolicies:
     - talm-policy
   preCaching: false
-  remediationStrategy: <6>
-    canaries: <7>
+  remediationStrategy:
+    canaries:
         - spoke1
-    maxConcurrency: 2 <8>
+    maxConcurrency: 2
     timeout: 240
-  clusterLabelSelectors: <9>
+  clusterLabelSelectors:
     - matchExpressions:
       - key: label1
       operator: In
       values:
         - value1a
         - value1b
-  batchTimeoutAction: <10>
-status: <11>
+  batchTimeoutAction:
+status:
     computedMaxConcurrency: 2
     conditions:
       - lastTransitionTime: '2022-11-18T16:27:15Z'
         message: All selected clusters are valid
         reason: ClusterSelectionCompleted
         status: 'True'
-        type: ClustersSelected <12>
+        type: ClustersSelected
       - lastTransitionTime: '2022-11-18T16:27:15Z'
         message: Completed validation
         reason: ValidationCompleted
         status: 'True'
-        type: Validated <13>
+        type: Validated
       - lastTransitionTime: '2022-11-18T16:37:16Z'
         message: Not enabled
         reason: NotEnabled
@@ -135,19 +136,21 @@ status: <11>
         - spoke3
     status:
 ----
-<1> Specifies the action that {cgu-operator} takes when it completes policy remediation for each cluster.
-<2> Specifies the action that {cgu-operator} takes as it begins the update process.
-<3> Defines the list of clusters to update.
-<4> The `enable` field is set to `false`.
-<5> Lists the user-defined set of policies to remediate.
-<6> Defines the specifics of the cluster updates.
-<7> Defines the clusters for canary updates.
-<8> Defines the maximum number of concurrent updates in a batch. The number of remediation batches is the number of canary clusters, plus the number of clusters, except the canary clusters, divided by the `maxConcurrency` value. The clusters that are already compliant with all the managed policies are excluded from the remediation plan.
-<9> Displays the parameters for selecting clusters.
-<10> Controls what happens if a batch times out. Possible values are `abort` or `continue`. If unspecified, the default is `continue`.
-<11> Displays information about the status of the updates.
-<12> The `ClustersSelected` condition shows that all selected clusters are valid.
-<13> The `Validated` condition shows that all selected clusters have been validated.
+
+- `Spec.actions.afterCompletion` specifies the action that {cgu-operator} takes when it completes policy remediation for each cluster.
+- `Spec.actions.beforeEnable` specifies the action that {cgu-operator} takes as it begins the update process.
+- `Spec.clusters` defines the list of clusters to update.
+- `Spec.enable` the `enable` field is set to `false`.
+- `Spec.managedPolicies` lists the user-defined set of policies to remediate.
+- `Spec.remediationStrategy` defines the specifics of the cluster updates.
+- `Spec.preCaching.canaries` defines the clusters for canary updates.
+- `Spec.preCaching.maxConcurrency` defines the maximum number of concurrent updates in a batch. The number of remediation batches is the number of canary clusters, plus the number of clusters, except the canary clusters, divided by the `maxConcurrency` value. The clusters that are already compliant with all the managed policies are excluded from the remediation plan.
+- `Spec.clusterLabelSelectors` displays the parameters for selecting clusters.
+- `Spec.batchTimeoutAction` controls what happens if a batch times out. Possible values are `abort` or `continue`. If unspecified, the default is `continue`.
+- `status` displays information about the status of the updates.
+- `Spec.preCaching.conditions.type` the `ClustersSelected` condition shows that all selected clusters are valid.
+- `Spec.preCaching.conditions.type` the `Validated` condition shows that all selected clusters have been validated.
+
 
 [NOTE]
 ====
@@ -282,7 +285,7 @@ status:
         message: Remediating non-compliant policies
         reason: InProgress
         status: 'True'
-        type: Progressing <1>
+        type: Progressing
     managedPoliciesForUpgrade:
       - name: talm-policy
         namespace: talm-namespace
@@ -303,7 +306,8 @@ status:
       currentBatchStartedAt: '2022-11-18T16:27:16Z'
       startedAt: '2022-11-18T16:27:15Z'
 ----
-<1> The `Progressing` fields show that {cgu-operator} is in the process of remediating policies.
+
+The `Progressing` fields show that {cgu-operator} is in the process of remediating policies.
 
 [id="update_status_{context}"]
 == Update status
@@ -341,7 +345,7 @@ Policy remediation failed as there were no clusters available for remediation, o
       remediationStrategy:
         maxConcurrency: 1
         timeout: 240
-    status: <3>
+    status:
       clusters:
         - name: spoke1
           state: complete
@@ -359,11 +363,11 @@ Policy remediation failed as there were no clusters available for remediation, o
       - message: All clusters are compliant with all the managed policies
         reason: Completed
         status: "False"
-        type: Progressing <1>
+        type: Progressing
       - message: All clusters are compliant with all the managed policies
         reason: Completed
         status: "True"
-        type: Succeeded <2>
+        type: Succeeded
       managedPoliciesForUpgrade:
       - name: policy1-common-cluster-version-policy
         namespace: default
@@ -377,9 +381,11 @@ Policy remediation failed as there were no clusters available for remediation, o
         startedAt: '2022-11-18T16:27:15Z'
 
 ----
-<1> In the `Progressing` fields, the status is `false` as the update has completed; clusters are compliant with all the managed policies.
-<2> The `Succeeded` fields show that the validations completed successfully.
-<3> The `status` field includes a list of clusters and their respective statuses. The status of a cluster can be `complete` or `timedout`.
+
+- `spec.conditions.type` in the `Progressing` fields, the status is `false` as the update has completed; clusters are compliant with all the managed policies.
+- `spec.conditions.type` the `Succeeded` fields show that the validations completed successfully.
+- `status` the `status` field includes a list of clusters and their respective statuses. The status of a cluster can be `complete` or `timedout`.
+
 
 .Sample `ClusterGroupUpgrade` CR in the `timedout` state
 
@@ -415,7 +421,7 @@ status:
   clusters:
     - name: spoke1
       state: complete
-    - currentPolicy: <1>
+    - currentPolicy:
         name: talm-policy
         status: NonCompliant
       name: spoke2
@@ -441,7 +447,7 @@ status:
       message: Policy remediation took too long
       reason: TimedOut
       status: 'False'
-      type: Succeeded <2>
+      type: Succeeded
   managedPoliciesForUpgrade:
     - name: talm-policy
       namespace: talm-namespace
@@ -454,5 +460,7 @@ status:
         startedAt: '2022-11-18T16:27:15Z'
         completedAt: '2022-11-18T20:27:15Z'
 ----
-<1> If a cluster’s state is `timedout`, the `currentPolicy` field shows the name of the policy and the policy status.
-<2> The status for `succeeded` is `false` and the message indicates that policy remediation took too long.
+
+- `status.clusters.currentPolicy` if a cluster’s state is `timedout`, the `currentPolicy` field shows the name of the policy and the policy status.
+- `status.conditions.type` the status for `succeeded` is `false` and the message indicates that policy remediation took too long.
+

--- a/modules/cnf-topology-aware-lifecycle-manager-about-subscription-crs.adoc
+++ b/modules/cnf-topology-aware-lifecycle-manager-about-subscription-crs.adoc
@@ -6,6 +6,7 @@
 [id="talo-about-subscription-crs_{context}"]
 = Configuring Operator subscriptions for managed clusters that you install with {cgu-operator}
 
+[role="_abstract"]
 {cgu-operator-first} can only approve the install plan for an Operator if the `Subscription` custom resource (CR) of the Operator contains the `status.state.AtLatestKnown` field.
 
 .Procedure
@@ -29,10 +30,10 @@ spec:
   sourceNamespace: openshift-marketplace
   installPlanApproval: Manual
 status:
-  state: AtLatestKnown <1>
+  state: AtLatestKnown
 ----
-<1> The `status.state: AtLatestKnown` field is used for the latest Operator version available from the Operator catalog.
-
++
+The `status.state: AtLatestKnown` field is used for the latest Operator version available from the Operator catalog.
 +
 [NOTE]
 ====

--- a/modules/cnf-topology-aware-lifecycle-manager-apply-policies.adoc
+++ b/modules/cnf-topology-aware-lifecycle-manager-apply-policies.adoc
@@ -6,6 +6,7 @@
 [id="talo-apply-policies_{context}"]
 = Applying update policies to managed clusters
 
+[role="_abstract"]
 You can update your managed clusters by applying your policies.
 
 .Prerequisites
@@ -28,27 +29,29 @@ metadata:
   name: cgu-1
   namespace: default
 spec:
-  managedPolicies: <1>
+  managedPolicies:
     - policy1-common-cluster-version-policy
     - policy2-common-nto-sub-policy
     - policy3-common-ptp-sub-policy
     - policy4-common-sriov-sub-policy
   enable: false
-  clusters: <2>
+  clusters:
   - spoke1
   - spoke2
   - spoke5
   - spoke6
   remediationStrategy:
-    maxConcurrency: 2 <3>
-    timeout: 240 <4>
-  batchTimeoutAction: <5>
+    maxConcurrency: 2
+    timeout: 240
+  batchTimeoutAction:
 ----
-<1> The name of the policies to apply.
-<2> The list of clusters to update.
-<3> The `maxConcurrency` field signifies the number of clusters updated at the same time.
-<4> The update timeout in minutes.
-<5> Controls what happens if a batch times out. Possible values are `abort` or `continue`. If unspecified, the default is `continue`.
+
+- `spec.managedPolicies` the name of the policies to apply.
+- `spec.clusters` the list of clusters to update.
+- `spec.remediationStrategy.maxConcurrency` the `maxConcurrency` field signifies the number of clusters updated at the same time.
+- `spec.remediationStrategy.timeout` the update timeout in minutes.
+- `spec.batchTimeoutAction` controls what happens if a batch times out. Possible values are `abort` or `continue`. If unspecified, the default is `continue`.
+
 
 . Create the `ClusterGroupUpgrade` CR by running the following command:
 +
@@ -86,7 +89,7 @@ $ oc get cgu -n default cgu-1 -ojsonpath='{.status}' | jq
   "conditions": [
     {
       "lastTransitionTime": "2022-02-25T15:34:07Z",
-      "message": "Not enabled", <1>
+      "message": "Not enabled",
       "reason": "NotEnabled",
       "status": "False",
       "type": "Progressing"
@@ -147,7 +150,8 @@ $ oc get cgu -n default cgu-1 -ojsonpath='{.status}' | jq
   "status": {}
 }
 ----
-<1> The `spec.enable` field in the `ClusterGroupUpgrade` CR is set to `false`.
++
+The `spec.enable` field in the `ClusterGroupUpgrade` CR is set to `false`.
 
 . Change the value of the `spec.enable` field to `true` by running the following command:
 +
@@ -171,7 +175,7 @@ $ oc get cgu -n default cgu-1 -ojsonpath='{.status}' | jq
 ----
 {
   "computedMaxConcurrency": 2,
-  "conditions": [ <1>
+  "conditions": [
     {
       "lastTransitionTime": "2022-02-25T15:33:07Z",
       "message": "All selected clusters are valid",
@@ -263,7 +267,8 @@ $ oc get cgu -n default cgu-1 -ojsonpath='{.status}' | jq
   }
 }
 ----
-<1> Reflects the update progress of the current batch. Run this command again to receive updated information about the progress.
++
+Reflects the update progress of the current batch. Run this command again to receive updated information about the progress.
 
 . Check the status of the policies by running the following command:
 +
@@ -349,9 +354,10 @@ $ oc get installplan -n <subscription_namespace>
 [source,terminal]
 ----
 NAMESPACE                              NAME            CSV                                 APPROVAL   APPROVED
-openshift-logging                      install-6khtw   cluster-logging.5.3.3-4             Manual     true <1>
+openshift-logging                      install-6khtw   cluster-logging.5.3.3-4             Manual     true
 ----
-<1> The install plans have their `Approval` field set to `Manual` and their `Approved` field changes from `false` to `true` after {cgu-operator} approves the install plan.
++
+The install plans have their `Approval` field set to `Manual` and their `Approved` field changes from `false` to `true` after {cgu-operator} approves the install plan.
 +
 [NOTE]
 ====

--- a/modules/cnf-topology-aware-lifecycle-manager-installation-cli.adoc
+++ b/modules/cnf-topology-aware-lifecycle-manager-installation-cli.adoc
@@ -6,6 +6,7 @@
 [id="installing-topology-aware-lifecycle-manager-using-cli_{context}"]
 = Installing the {cgu-operator-full} by using the CLI
 
+[role="_abstract"]
 You can use the OpenShift CLI (`oc`) to install the {cgu-operator-first}.
 
 .Prerequisites

--- a/modules/cnf-topology-aware-lifecycle-manager-installation-web-console.adoc
+++ b/modules/cnf-topology-aware-lifecycle-manager-installation-web-console.adoc
@@ -6,6 +6,7 @@
 [id="installing-topology-aware-lifecycle-manager-using-web-console_{context}"]
 = Installing the {cgu-operator-full} by using the web console
 
+[role="_abstract"]
 You can use the {product-title} web console to install the {cgu-operator-full}.
 
 .Prerequisites

--- a/modules/cnf-topology-aware-lifecycle-manager-policies-concept.adoc
+++ b/modules/cnf-topology-aware-lifecycle-manager-policies-concept.adoc
@@ -6,6 +6,7 @@
 [id="talo-policies-concept_{context}"]
 = Update policies on managed clusters
 
+[role="_abstract"]
 The {cgu-operator-first} remediates a set of `inform` policies for the clusters specified in the `ClusterGroupUpgrade` custom resource (CR). {cgu-operator} remediates `inform` policies by controlling the `remediationAction` specification in a `Policy` CR through the `bindingOverrides.remediationAction` and `subFilter` specifications in the `PlacementBinding` CR. Each policy has its own corresponding {rh-rhacm} placement rule and {rh-rhacm} placement binding.
 
 One by one, {cgu-operator} adds each cluster from the current batch to the placement rule that corresponds with the applicable managed policy. If a cluster is already compliant with a policy, {cgu-operator} skips applying that policy on the compliant cluster. {cgu-operator} then moves on to applying the next policy to the non-compliant cluster. After {cgu-operator} completes the updates in a batch, all clusters are removed from the placement rules associated with the policies. Then, the update of the next batch starts.

--- a/modules/cnf-topology-aware-lifecycle-manager-precache-concept.adoc
+++ b/modules/cnf-topology-aware-lifecycle-manager-precache-concept.adoc
@@ -6,6 +6,7 @@
 [id="talo-precache-feature-concept_{context}"]
 = Using the container image pre-cache feature
 
+[role="_abstract"]
 {sno-caps} clusters might have limited bandwidth to access the container image registry, which can cause a timeout before the updates are completed.
 
 [NOTE]

--- a/modules/cnf-topology-aware-lifecycle-manager-precache-feature.adoc
+++ b/modules/cnf-topology-aware-lifecycle-manager-precache-feature.adoc
@@ -6,6 +6,7 @@
 [id="talo-precache-start_and_update_{context}"]
 = Creating a ClusterGroupUpgrade CR with pre-caching
 
+[role="_abstract"]
 For {sno}, the pre-cache feature allows the required container images to be present on the spoke cluster before the update starts.
 
 [NOTE]
@@ -31,7 +32,7 @@ metadata:
   name: du-upgrade-4918
   namespace: ztp-group-du-sno
 spec:
-  preCaching: true <1>
+  preCaching: true
   clusters:
   - cnfdb1
   - cnfdb2
@@ -42,7 +43,8 @@ spec:
     maxConcurrency: 2
     timeout: 240
 ----
-<1> The `preCaching` field is set to `true`, which enables {cgu-operator} to pull the container images before starting the update.
++
+The `preCaching` field is set to `true`, which enables {cgu-operator} to pull the container images before starting the update.
 
 . When you want to start pre-caching, apply the `ClusterGroupUpgrade` CR by running the following command:
 +
@@ -60,14 +62,15 @@ $ oc apply -f clustergroupupgrades-group-du.yaml
 $ oc get cgu -A
 ----
 +
-.Example output
+Example output:
 +
 [source,terminal]
 ----
 NAMESPACE          NAME              AGE   STATE        DETAILS
-ztp-group-du-sno   du-upgrade-4918   10s   InProgress   Precaching is required and not done <1>
+ztp-group-du-sno   du-upgrade-4918   10s   InProgress   Precaching is required and not done
 ----
-<1> The CR is created.
++
+The CR is created.
 
 . Check the status of the pre-caching task by running the following command:
 +
@@ -76,7 +79,7 @@ ztp-group-du-sno   du-upgrade-4918   10s   InProgress   Precaching is required a
 $ oc get cgu -n ztp-group-du-sno du-upgrade-4918 -o jsonpath='{.status}'
 ----
 +
-.Example output
+Example output:
 +
 [source,json]
 ----
@@ -99,7 +102,7 @@ $ oc get cgu -n ztp-group-du-sno du-upgrade-4918 -o jsonpath='{.status}'
   ],
   "precaching": {
     "clusters": [
-      "cnfdb1" <1>
+      "cnfdb1"
       "cnfdb2"
     ],
     "spec": {
@@ -110,7 +113,8 @@ $ oc get cgu -n ztp-group-du-sno du-upgrade-4918 -o jsonpath='{.status}'
     }
 }
 ----
-<1> Displays the list of identified clusters.
++
+Displays the list of identified clusters.
 
 . Check the status of the pre-caching job by running the following command on the spoke cluster:
 +
@@ -119,7 +123,7 @@ $ oc get cgu -n ztp-group-du-sno du-upgrade-4918 -o jsonpath='{.status}'
 $ oc get jobs,pods -n openshift-talo-pre-cache
 ----
 +
-.Example output
+Example output:
 +
 [source,terminal]
 ----
@@ -137,7 +141,7 @@ pod/pre-cache--1-9bmlr   1/1     Running   0          3m10s
 $ oc get cgu -n ztp-group-du-sno du-upgrade-4918 -o jsonpath='{.status}'
 ----
 +
-.Example output
+Example output:
 +
 [source,json]
 ----
@@ -154,7 +158,8 @@ $ oc get cgu -n ztp-group-du-sno du-upgrade-4918 -o jsonpath='{.status}'
       "message": "Precaching is completed",
       "reason": "PrecachingCompleted",
       "status": "True",
-      "type": "PrecachingSucceeded" <1>
+      "type": "PrecachingSucceeded"
     }
 ----
-<1> The pre-cache tasks are done.
+
+The pre-cache tasks are done.

--- a/modules/cnf-topology-aware-lifecycle-manager-precache-image-filter.adoc
+++ b/modules/cnf-topology-aware-lifecycle-manager-precache-image-filter.adoc
@@ -6,6 +6,7 @@
 [id="talo-precache-feature-image-filter_{context}"]
 = Using the container image pre-cache filter
 
+[role="_abstract"]
 The pre-cache feature typically downloads more images than a cluster needs for an update. You can control which pre-cache images are downloaded to a cluster. This decreases download time, and saves bandwidth and storage.
 
 You can see a list of all images to be downloaded using the following command:
@@ -25,9 +26,10 @@ metadata:
   name: cluster-group-upgrade-overrides
 data:
   excludePrecachePatterns: |
-    azure <1>
+    azure
     aws
     vsphere
     alibaba
 ----
-<1> {cgu-operator} excludes all images with names that include any of the patterns listed here.
+
+{cgu-operator} excludes all images with names that include any of the patterns listed here.

--- a/modules/cnf-topology-aware-lifecycle-manager-troubleshooting.adoc
+++ b/modules/cnf-topology-aware-lifecycle-manager-troubleshooting.adoc
@@ -6,6 +6,7 @@
 [id="talo-troubleshooting_{context}"]
 = Troubleshooting the {cgu-operator-full}
 
+[role="_abstract"]
 The {cgu-operator-first} is an {product-title} Operator that remediates {rh-rhacm} policies. When issues occur, use the `oc adm must-gather` command to gather details and logs and to take steps in debugging the issues.
 
 
@@ -18,7 +19,7 @@ For more information about related topics, see the following documentation:
 * The "Troubleshooting Operator issues" section
 
 [id="talo-general-troubleshooting_{context}"]
-== General troubleshooting
+**General troubleshooting**
 
 You can determine the cause of the problem by reviewing the following questions:
 
@@ -26,26 +27,14 @@ You can determine the cause of the problem by reviewing the following questions:
 ** Are the {rh-rhacm} and the {product-title} versions compatible?
 ** Are the {cgu-operator} and {rh-rhacm} versions compatible?
 * Which of the following components is causing the problem?
-** <<talo-troubleshooting-managed-policies_{context}>>
-** <<talo-troubleshooting-clusters_{context}>>
-** <<talo-troubleshooting-remediation-strategy_{context}>>
-** <<talo-troubleshooting-remediation-talo_{context}>>
-
-To ensure that the `ClusterGroupUpgrade` configuration is functional, you can do the following:
-
-. Create the `ClusterGroupUpgrade` CR with the `spec.enable` field set to `false`.
-
-. Wait for the status to be updated and go through the troubleshooting questions.
-
-. If everything looks as expected, set the `spec.enable` field to `true` in the `ClusterGroupUpgrade` CR.
-
-[WARNING]
-====
-After you set the `spec.enable` field to `true` in the `ClusterUpgradeGroup` CR, the update procedure starts and you cannot edit the CR's `spec` fields anymore.
-====
+** <<talo-troubleshooting-modify-cgu_{context}, Cannot modify the ClusterUpgradeGroup CR>>
+** <<talo-troubleshooting-managed-policies_{context}, Managed policies>>
+** <<talo-troubleshooting-clusters_{context}, Clusters>>
+** <<talo-troubleshooting-remediation-strategy_{context}, Remediation Strategy>>
+** <<talo-troubleshooting-remediation-talo_{context}, {cgu-operator-full}>>
 
 [id="talo-troubleshooting-modify-cgu_{context}"]
-== Cannot modify the ClusterUpgradeGroup CR
+**Cannot modify the ClusterUpgradeGroup CR**
 
 Issue:: You cannot edit the `ClusterUpgradeGroup` CR after enabling the update.
 
@@ -70,10 +59,9 @@ $ oc apply -f <ClusterGroupUpgradeCR_YAML>
 ----
 
 [id="talo-troubleshooting-managed-policies_{context}"]
-== Managed policies
+**Managed policies**
 
-[discrete]
-== Checking managed policies on the system
+**Checking managed policies on the system**
 
 Issue:: You want to check if you have the correct managed policies on the system.
 
@@ -84,15 +72,14 @@ Resolution:: Run the following command:
 $ oc get cgu lab-upgrade -ojsonpath='{.spec.managedPolicies}'
 ----
 +
-.Example output
+Example output:
 +
 [source,json]
 ----
 ["group-du-sno-validator-du-validator-policy", "policy2-common-nto-sub-policy", "policy3-common-ptp-sub-policy"]
 ----
 
-[discrete]
-== Checking remediationAction mode
+**Checking remediationAction mode**
 
 Issue:: You want to check if the `remediationAction` field is set to `inform` in the `spec` of the managed policies.
 
@@ -103,7 +90,7 @@ Resolution:: Run the following command:
 $ oc get policies --all-namespaces
 ----
 +
-.Example output
+Example output:
 +
 [source,terminal]
 ----
@@ -114,8 +101,7 @@ default     policy3-common-ptp-sub-policy                        inform         
 default     policy4-common-sriov-sub-policy                      inform               NonCompliant       5d21h
 ----
 
-[discrete]
-== Checking policy compliance state
+**Checking policy compliance state**
 
 Issue:: You want to check the compliance state of policies.
 
@@ -126,7 +112,7 @@ Resolution:: Run the following command:
 $ oc get policies --all-namespaces
 ----
 +
-.Example output
+Example output:
 +
 [source,terminal]
 ----
@@ -138,10 +124,9 @@ default     policy4-common-sriov-sub-policy                      inform         
 ----
 
 [id="talo-troubleshooting-clusters_{context}"]
-== Clusters
+**Clusters**
 
-[discrete]
-=== Checking if managed clusters are present
+**Checking if managed clusters are present**
 
 Issue:: You want to check if the clusters in the `ClusterGroupUpgrade` CR are managed clusters.
 
@@ -152,7 +137,7 @@ Resolution:: Run the following command:
 $ oc get managedclusters
 ----
 +
-.Example output
+Example output:
 +
 [source,terminal]
 ----
@@ -171,7 +156,7 @@ spoke3          true           https://api.spoke3.example.com:6443     True     
 $ oc get pod -n openshift-operators
 ----
 +
-.Example output
+Example output:
 +
 [source,terminal]
 ----
@@ -187,17 +172,17 @@ $ oc logs -n openshift-operators \
 cluster-group-upgrades-controller-manager-75bcc7484d-8k8xp -c manager
 ----
 +
-.Example output
+Example output:
 +
 [source,terminal]
 ----
-ERROR	controller-runtime.manager.controller.clustergroupupgrade	Reconciler error	{"reconciler group": "ran.openshift.io", "reconciler kind": "ClusterGroupUpgrade", "name": "lab-upgrade", "namespace": "default", "error": "Cluster spoke5555 is not a ManagedCluster"} <1>
+ERROR	controller-runtime.manager.controller.clustergroupupgrade	Reconciler error	{"reconciler group": "ran.openshift.io", "reconciler kind": "ClusterGroupUpgrade", "name": "lab-upgrade", "namespace": "default", "error": "Cluster spoke5555 is not a ManagedCluster"}
 sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem
 ----
-<1> The error message shows that the cluster is not a managed cluster.
 
-[discrete]
-=== Checking if managed clusters are available
+The error message shows that the cluster is not a managed cluster.
+
+**Checking if managed clusters are available**
 
 Issue:: You want to check if the managed clusters specified in the `ClusterGroupUpgrade` CR are available.
 
@@ -208,19 +193,19 @@ Resolution:: Run the following command:
 $ oc get managedclusters
 ----
 +
-.Example output
+Example output:
 +
 [source,terminal]
 ----
 NAME            HUB ACCEPTED   MANAGED CLUSTER URLS                    JOINED   AVAILABLE   AGE
 local-cluster   true           https://api.hub.testlab.com:6443        True     Unknown     13d
-spoke1          true           https://api.spoke1.testlab.com:6443     True     True        13d <1>
-spoke3          true           https://api.spoke3.testlab.com:6443     True     True        27h <1>
+spoke1          true           https://api.spoke1.testlab.com:6443     True     True        13d
+spoke3          true           https://api.spoke3.testlab.com:6443     True     True        27h
 ----
-<1> The value of the `AVAILABLE` field is `True` for the managed clusters.
 
-[discrete]
-=== Checking clusterLabelSelector
+The value of the `AVAILABLE` field is `True` for the managed clusters.
+
+**Checking clusterLabelSelector**
 
 Issue:: You want to check if the `clusterLabelSelector` field specified in the `ClusterGroupUpgrade` CR matches at least one of the managed clusters.
 
@@ -228,12 +213,13 @@ Resolution:: Run the following command:
 +
 [source,terminal]
 ----
-$ oc get managedcluster --selector=upgrade=true <1>
+$ oc get managedcluster --selector=upgrade=true
 ----
-<1> The label for the clusters you want to update is `upgrade:true`.
-+
-.Example output
-+
+
+The label for the clusters you want to update is `upgrade:true`.
+
+Example output:
+
 [source,terminal]
 ----
 NAME            HUB ACCEPTED   MANAGED CLUSTER URLS                     JOINED    AVAILABLE   AGE
@@ -241,12 +227,11 @@ spoke1          true           https://api.spoke1.testlab.com:6443      True    
 spoke3          true           https://api.spoke3.testlab.com:6443      True     True        27h
 ----
 
-[discrete]
-=== Checking if canary clusters are present
+**Checking if canary clusters are present**
 
 Issue:: You want to check if the canary clusters are present in the list of clusters.
 +
-.Example `ClusterGroupUpgrade` CR
+Example `ClusterGroupUpgrade` CR:
 [source,yaml]
 ----
 spec:
@@ -267,7 +252,7 @@ Resolution:: Run the following commands:
 $ oc get cgu lab-upgrade -ojsonpath='{.spec.clusters}'
 ----
 +
-.Example output
+Example output:
 +
 [source,json]
 ----
@@ -281,7 +266,7 @@ $ oc get cgu lab-upgrade -ojsonpath='{.spec.clusters}'
 $ oc get managedcluster --selector=upgrade=true
 ----
 +
-.Example output
+Example output:
 +
 [source,terminal]
 ----
@@ -295,8 +280,7 @@ spoke3          true           https://api.spoke3.testlab.com:6443   True     Tr
 A cluster can be present in `spec.clusters` and also be matched by the `spec.clusterLabelSelector` label.
 ====
 
-[discrete]
-=== Checking the pre-caching status on spoke clusters
+**Checking the pre-caching status on spoke clusters**
 
 . Check the status of pre-caching by running the following command on the spoke cluster:
 +
@@ -306,10 +290,9 @@ $ oc get jobs,pods -n openshift-talo-pre-cache
 ----
 
 [id="talo-troubleshooting-remediation-strategy_{context}"]
-== Remediation Strategy
+**Remediation Strategy**
 
-[discrete]
-=== Checking if remediationStrategy is present in the ClusterGroupUpgrade CR
+**Checking if remediationStrategy is present in the ClusterGroupUpgrade CR**
 
 Issue:: You want to check if the `remediationStrategy` is present in the `ClusterGroupUpgrade` CR.
 
@@ -320,15 +303,14 @@ Resolution:: Run the following command:
 $ oc get cgu lab-upgrade -ojsonpath='{.spec.remediationStrategy}'
 ----
 +
-.Example output
+Example output:
 +
 [source,json]
 ----
 {"maxConcurrency":2, "timeout":240}
 ----
 
-[discrete]
-=== Checking if maxConcurrency is specified in the ClusterGroupUpgrade CR
+**Checking if maxConcurrency is specified in the ClusterGroupUpgrade CR**
 
 Issue:: You want to check if the `maxConcurrency` is specified in the `ClusterGroupUpgrade` CR.
 
@@ -339,7 +321,7 @@ Resolution:: Run the following command:
 $ oc get cgu lab-upgrade -ojsonpath='{.spec.remediationStrategy.maxConcurrency}'
 ----
 +
-.Example output
+Example output:
 +
 [source,terminal]
 ----
@@ -347,10 +329,9 @@ $ oc get cgu lab-upgrade -ojsonpath='{.spec.remediationStrategy.maxConcurrency}'
 ----
 
 [id="talo-troubleshooting-remediation-talo_{context}"]
-== {cgu-operator-full}
+**{cgu-operator-full}**
 
-[discrete]
-=== Checking condition message and status in the ClusterGroupUpgrade CR
+**Checking condition message and status in the ClusterGroupUpgrade CR**
 
 Issue:: You want to check the value of the `status.conditions` field in the `ClusterGroupUpgrade` CR.
 
@@ -361,15 +342,14 @@ Resolution:: Run the following command:
 $ oc get cgu lab-upgrade -ojsonpath='{.status.conditions}'
 ----
 +
-.Example output
+Example output:
 +
 [source,json]
 ----
 {"lastTransitionTime":"2022-02-17T22:25:28Z", "message":"Missing managed policies:[policyList]", "reason":"NotAllManagedPoliciesExist", "status":"False", "type":"Validated"}
 ----
 
-[discrete]
-=== Checking if status.remediationPlan was computed
+**Checking if status.remediationPlan was computed**
 
 Issue:: You want to check if `status.remediationPlan` is computed.
 
@@ -380,15 +360,14 @@ Resolution:: Run the following command:
 $ oc get cgu lab-upgrade -ojsonpath='{.status.remediationPlan}'
 ----
 +
-.Example output
+Example output:
 +
 [source,json]
 ----
 [["spoke2", "spoke3"]]
 ----
 
-[discrete]
-=== Errors in the {cgu-operator} manager container
+**Errors in the {cgu-operator} manager container**
 
 Issue:: You want to check the logs of the manager container of {cgu-operator}.
 
@@ -400,17 +379,17 @@ $ oc logs -n openshift-operators \
 cluster-group-upgrades-controller-manager-75bcc7484d-8k8xp -c manager
 ----
 +
-.Example output
+Example output:
 +
 [source,terminal]
 ----
-ERROR	controller-runtime.manager.controller.clustergroupupgrade	Reconciler error	{"reconciler group": "ran.openshift.io", "reconciler kind": "ClusterGroupUpgrade", "name": "lab-upgrade", "namespace": "default", "error": "Cluster spoke5555 is not a ManagedCluster"} <1>
+ERROR	controller-runtime.manager.controller.clustergroupupgrade	Reconciler error	{"reconciler group": "ran.openshift.io", "reconciler kind": "ClusterGroupUpgrade", "name": "lab-upgrade", "namespace": "default", "error": "Cluster spoke5555 is not a ManagedCluster"}
 sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem
 ----
-<1> Displays the error.
 
-[discrete]
-=== Clusters are not compliant to some policies after a `ClusterGroupUpgrade` CR has completed
+Displays the error.
+
+**Clusters are not compliant to some policies after a `ClusterGroupUpgrade` CR has completed**
 
 Issue:: The policy compliance status that {cgu-operator} uses to decide if remediation is needed has not yet fully updated for all clusters.
 This may be because:
@@ -419,9 +398,8 @@ This may be because:
 
 Resolution:: Create and apply a new `ClusterGroupUpdate` CR with the same specification.
 
-[discrete]
 [id="talo-troubleshooting-auto-create-policies_{context}"]
-=== Auto-created `ClusterGroupUpgrade` CR in the {ztp} workflow has no managed policies
+**Auto-created `ClusterGroupUpgrade` CR in the {ztp} workflow has no managed policies**
 
 Issue:: If there are no policies for the managed cluster when the cluster becomes `Ready`, a `ClusterGroupUpgrade` CR with no policies is auto-created.
 Upon completion of the `ClusterGroupUpgrade` CR, the managed cluster is labeled as `ztp-done`.
@@ -431,9 +409,8 @@ Resolution:: Verify that the policies you want to apply are available on the hub
 
 You can either manually create the `ClusterGroupUpgrade` CR or trigger auto-creation again. To trigger auto-creation of the `ClusterGroupUpgrade` CR, remove the `ztp-done` label from the cluster and delete the empty `ClusterGroupUpgrade` CR that was previously created in the `zip-install` namespace.
 
-[discrete]
 [id="talo-troubleshooting-pre-cache-failed_{context}"]
-=== Pre-caching has failed
+**Pre-caching has failed**
 
 Issue:: Pre-caching might fail for one of the following reasons:
 * There is not enough free space on the node.


### PR DESCRIPTION
## Summary

Backport of https://github.com/openshift/openshift-docs/pull/106379 to enterprise-4.18.

Resolve Vale AsciiDocDITA errors and warnings across the cnf-talm-for-cluster-upgrades assembly and all 13 included modules to prepare for DITA conversion. Changes include adding [role="_abstract"] short descriptions, transforming callout annotations to inline text, converting unsupported block titles, replacing discrete headings and nested sections with bold text paragraphs, adding list continuations for procedure steps, and restructuring the troubleshooting module.

Version(s): 4.18

Issue: https://issues.redhat.com/browse/TELCODOCS-2653

Link to docs preview: pending

QE review:
- [x] QE has approved this change.

Additional information:
Cherry-pick backport of PR #106379 (merged to main). 14 files included, 0 excluded. 1 conflict resolved in `modules/cnf-topology-aware-lifecycle-manager-troubleshooting.adoc` — kept 4.18 version, excluded placement tolerations section not present on this branch.