### PR TITLE
OSDOCS-18673-abstracts

### DIFF
--- a/modules/adding-tls-termination.adoc
+++ b/modules/adding-tls-termination.adoc
@@ -7,7 +7,7 @@
 = Adding TLS termination on the AWS Load Balancer
 
 [role="_abstract"]
-To secure traffic for your domain, configure TLS termination on the AWS Load Balancer. This setup routes traffic to the pods of a service while ensuring that encrypted connections are decrypted at the load balancer level.
+You can route the traffic for the domain to pods of a service and add TLS termination on the {aws-short} Load Balancer.
 
 .Prerequisites
 

--- a/modules/albo-prerequisites.adoc
+++ b/modules/albo-prerequisites.adoc
@@ -7,7 +7,7 @@
 = Prepare to install the AWS Load Balancer Operator
 
 [role="_abstract"]
-To prepare your cluster for the AWS Load Balancer Operator, verify that your AWS VPC resources are tagged correctly and meet all requirements. You can also configure environment variables to customize the installation.
+Before you install the AWS Load Balancer Operator, ensure that your cluster fulfills requirements and that your AWS VPC resources are appropriately tagged. You also have the option to configure some helpful environment variables.
 
 Cluster requirements::
 

--- a/modules/aws-load-balancer-operator-environment.adoc
+++ b/modules/aws-load-balancer-operator-environment.adoc
@@ -7,7 +7,7 @@
 = Set up temporary environment variables
 
 [role="_abstract"]
-To streamline the installation of the AWS Load Balancer Operator, define temporary environment variables for resource identifiers and configuration details. This optional configuration simplifies the execution of installation commands by storing reusable values.
+You have the option to set up temporary environment variables to hold resource identifiers and configuration details. Using temporary environment variables streamlines the process of running the installation commands for the AWS Load Balancer Operator.
 
 If you do not want to use environment variables to store certain values, you can manually enter those values in the relevant installation commands.
 
@@ -18,7 +18,7 @@ If you do not want to use environment variables to store certain values, you can
 
 .Procedure
 
-. Log in to your cluster as a cluster administrator using the OpenShift CLI (`oc`).
+. Log in to your cluster as a cluster administrator using the {oc-first}.
 +
 [source,terminal]
 ----

--- a/modules/nw-aws-load-balancer-operator.adoc
+++ b/modules/nw-aws-load-balancer-operator.adoc
@@ -6,19 +6,19 @@
 = Deploying the AWS Load Balancer Operator
 
 [role="_abstract"]
-After you deploy the The AWS Load Balancer Operator, the Operator automatically tags public subnets if the `kubernetes.io/role/elb` tag is missing. The Operator then identifies specific network resources in the underlying AWS cloud to ensure successful cluster integration.
+The {aws-short} Load Balancer Operator can tag the public subnets if the `kubernetes.io/role/elb` tag is missing. Also, the {aws-short} Load Balancer Operator detects information from the underlying {aws-short} cloud.
 
-The AWS Load Balancer Operator detects the following information from the underlying AWS cloud:
+The {aws-short} Load Balancer Operator detects the following information from the underlying {aws-short} cloud:
 
 * The ID of the virtual private cloud (VPC) on which the cluster hosting the Operator is deployed.
 
 * Public and private subnets of the discovered VPC.
 
-The AWS Load Balancer Operator supports the Kubernetes service resource of type `LoadBalancer` by using Network Load Balancer (NLB) with the `instance` target type only.
+The {aws-short} Load Balancer Operator supports the Kubernetes service resource of type `LoadBalancer` by using Network Load Balancer (NLB) with the `instance` target type only.
 
 .Procedure
 
-. To deploy the AWS Load Balancer Operator on-demand from the software catalog, create a `Subscription` object by running the following command:
+. To deploy the {aws-short} Load Balancer Operator on-demand from the software catalog, create a `Subscription` object by running the following command:
 +
 [source,terminal]
 ----

--- a/modules/nw-aws-load-balancer-with-outposts.adoc
+++ b/modules/nw-aws-load-balancer-with-outposts.adoc
@@ -8,9 +8,9 @@
 = Using the AWS Load Balancer Operator in an AWS VPC cluster extended into an Outpost
 
 [role="_abstract"]
-To provision an AWS Application Load Balancer in an AWS VPC cluster extended into an Outpost, configure the AWS Load Balancer Operator. Note that the Operator cannot provision AWS Network Load Balancers because AWS Outposts does not support them.
+You can configure the AWS Load Balancer Operator to provision an {aws-short} Application Load Balancer in an {aws-short} VPC cluster extended into an Outpost. {aws-short} Outposts does not support {aws-short} Network Load Balancers. As a result, the {aws-short} Load Balancer Operator cannot provision Network Load Balancers in an Outpost.
 
-You can create an AWS Application Load Balancer either in the cloud subnet or in the Outpost subnet.
+You can create an {aws-short} Application Load Balancer either in the cloud subnet or in the Outpost subnet.
 
 An Application Load Balancer in the cloud can attach to cloud-based compute nodes. An Application Load Balancer in the Outpost can attach to edge compute nodes.
 
@@ -18,9 +18,9 @@ You must annotate Ingress resources with the Outpost subnet or the VPC subnet, b
 
 .Prerequisites
 
-* You have extended an AWS VPC cluster into an Outpost.
+* You have extended an {aws-short} VPC cluster into an Outpost.
 * You have installed the {oc-first}.
-* You have installed the AWS Load Balancer Operator and created the AWS Load Balancer Controller.
+* You have installed the {aws-short} Load Balancer Operator and created the {aws-short} Load Balancer Controller.
 
 .Procedure
 

--- a/modules/specifying-role-arn-albo-sts.adoc
+++ b/modules/specifying-role-arn-albo-sts.adoc
@@ -7,7 +7,7 @@
 = Configuring the ARN role for the AWS Load Balancer Operator
 
 [role="_abstract"]
-To authorize the {aws-short} Load Balancer Operator, configure the Amazon Resource Name (ARN) role as an environment variable by using the CLI. This ensures the Operator has the necessary permissions to manage resources within the cluster.
+You can configure the Amazon Resource Name (ARN) role for the {aws-short} Load Balancer Operator as an environment variable. You can configure the ARN role by using the CLI.
 
 .Prerequisites
 

--- a/modules/the-iam-role-albo-controller.adoc
+++ b/modules/the-iam-role-albo-controller.adoc
@@ -7,7 +7,7 @@
 = The IAM role for the AWS Load Balancer Controller
 
 [role="_abstract"]
-To authorize the {aws-short} Load Balancer Controller, configure the `CredentialsRequest` object with a manually provisioned IAM role. This ensures the controller functions correctly by using the specific permissions defined in your manual provisioning process.
+The `CredentialsRequest` object for the {aws-short} Load Balancer Controller must be set with a manually provisioned Identity and Access Management (IAM) role.
 
 You can create the IAM role by using the following options:
 

--- a/modules/the-iam-role-albo-operator.adoc
+++ b/modules/the-iam-role-albo-operator.adoc
@@ -7,7 +7,7 @@
 = The IAM role for the AWS Load Balancer Operator
 
 [role="_abstract"]
-To install the {aws-first} Load Balancer Operator on a cluster by using {sts-short}, configure an additional Identity and Access Management (IAM) role. This role enables the Operator to interact with subnets and Virtual Private Clouds (VPCs), allowing the Operator to generate the `CredentialsRequest` object required for bootstrapping.
+To install the {aws-first} Load Balancer Operator on a cluster by using {sts-short}, configure an additional Identity and Access Management (IAM) role.
 
 You can create the IAM role by using the following options:
 

--- a/modules/using-ccoctl-create-iam-role-alb-operator.adoc
+++ b/modules/using-ccoctl-create-iam-role-alb-operator.adoc
@@ -7,7 +7,7 @@
 = Creating an AWS IAM role by using the Cloud Credential Operator utility
 
 [role="_abstract"]
-To enable the {aws-short} Load Balancer Operator to interact with subnets and VPCs, create an {aws-short} IAM role by using the Cloud Credential Operator utility (`ccoctl`). By doing this task, you can generate the necessary credentials for the operator to function correctly within the cluster environment.
+To enable the {aws-short} Load Balancer Operator to interact with subnets and VPCs, create an {aws-short} IAM role by using the Cloud Credential Operator utility (`ccoctl`).
 
 .Prerequisites
 

--- a/networking/networking_operators/aws-load-balancer-operator.adoc
+++ b/networking/networking_operators/aws-load-balancer-operator.adoc
@@ -7,7 +7,7 @@ include::_attributes/attributes-openshift-dedicated.adoc[]
 toc::[]
 
 [role="_abstract"]
-To manage AWS Elastic Load Balancers (ELB) directly from your cluster, install the AWS Load Balancer Operator. This optional Operator is supported by Red{nbsp}Hat for use on SRE-managed {product-title} clusters.
+The AWS Load Balancer Operator is an Operator supported by Red{nbsp}Hat that you can optionally install on SRE-managed {product-title} clusters.
 
 [IMPORTANT]
 ====


### PR DESCRIPTION


Version(s):
4.16+

Issue:
[OSDOCS-18673](https://redhat.atlassian.net/browse/OSDOCS-18673)

Link to docs preview:

* [Adding TLS termination on the AWS Load Balancer](https://109486--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/networking_operators/aws_load_balancer_operator/configuring-aws-load-balancer-operator.html#nw-adding-tls-termination_aws-load-balancer-operator)
* [Prepare to install the AWS Load Balancer Operator](https://109486--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/networking/networking_operators/aws-load-balancer-operator.html#aws-load-balancer-operator-prerequisites_aws-load-balancer-operator)
* [Set up temporary environment variables](https://109486--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/networking/networking_operators/aws-load-balancer-operator.html#aws-load-balancer-operator-environment_aws-load-balancer-operator)
* [Deploying the AWS Load Balancer Operator](https://109486--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/networking_operators/aws_load_balancer_operator/understanding-aws-load-balancer-operator.html#nw-aws-load-balancer-operator_aws-load-balancer-operator)
* [Using the AWS Load Balancer Operator in an AWS VPC cluster extended into an Outpost](https://109486--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/networking_operators/aws_load_balancer_operator/understanding-aws-load-balancer-operator.html#nw-aws-load-balancer-with-outposts_aws-load-balancer-operator)
* [Configuring the ARN role for the AWS Load Balancer Operator](https://109486--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/networking_operators/aws_load_balancer_operator/preparing-sts-cluster-for-albo.html#specifying-role-arn-albo-sts_albo-sts-cluster)
* [The IAM role for the AWS Load Balancer Controller](https://109486--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/networking_operators/aws_load_balancer_operator/preparing-sts-cluster-for-albo.html#the-iam-role-albo-controller.adoc_albo-sts-cluster)
* [The IAM role for the AWS Load Balancer Operator](https://109486--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/networking_operators/aws_load_balancer_operator/preparing-sts-cluster-for-albo.html#the-iam-role-albo-operator_albo-sts-cluster)
* [Creating an AWS IAM role by using the Cloud Credential Operator utility](https://109486--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/networking_operators/aws_load_balancer_operator/preparing-sts-cluster-for-albo.html#using-ccoctl-create-iam-role-alb-operator_albo-sts-cluster)
* [AWS Load Balancer Operator](https://109486--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/networking/networking_operators/aws-load-balancer-operator.html#aws-load-balancer-operator-environment_aws-load-balancer-operator)
