### PR TITLE
OSDOCS-16835-abstracts

### DIFF
--- a/modules/configuration-ovnk-network-plugin-json-object.adoc
+++ b/modules/configuration-ovnk-network-plugin-json-object.adoc
@@ -7,7 +7,7 @@
 = OVN-Kubernetes network plugin JSON configuration table
 
 [role="_abstract"]
-The OVN-Kubernetes network plugin JSON configuration object describes the configuration parameters for the OVN-Kubernetes CNI network plugin. The following table details these parameters:
+The OVN-Kubernetes network plugin JSON configuration object describes the configuration parameters for the OVN-Kubernetes CNI network plugin.
 
 .OVN-Kubernetes network plugin JSON configuration table
 [cols=".^2,.^2,.^6",options="header"]

--- a/modules/nodes-control-plane-osp-migrating.adoc
+++ b/modules/nodes-control-plane-osp-migrating.adoc
@@ -6,7 +6,7 @@
 [id="nodes-control-plane-osp-migrating_{context}"]
 = Migrating control plane nodes from one RHOSP host to another manually
 
-[role="_abstract"] 
+[role="_abstract"]
 If control plane machine sets are not enabled on your cluster, you can run a script that moves a control plane node from one {rh-openstack-first} node to another.
 
 [NOTE]

--- a/modules/nodes-nodes-kernel-arguments.adoc
+++ b/modules/nodes-nodes-kernel-arguments.adoc
@@ -7,7 +7,7 @@
 [id="nodes-nodes-kernel-arguments_{context}"]
 = Adding kernel arguments to nodes
 
-[role="_abstract"] 
+[role="_abstract"]
 In some special cases, you can add kernel arguments to a set of nodes in your cluster to customize the kernel behavior to meet specific needs you might have. 
 
 You should add kernel arguments with caution and a clear understanding of the implications of the arguments you set.

--- a/modules/nodes-nodes-managing-about.adoc
+++ b/modules/nodes-nodes-managing-about.adoc
@@ -6,7 +6,7 @@
 [id="nodes-nodes-managing-about_{context}"]
 = Modifying nodes
 
-[role="_abstract"] 
+[role="_abstract"]
 To make configuration changes to a cluster, or machine pool, you must create a custom resource definition (CRD), or `kubeletConfig` object. {product-title} uses the Machine Config Controller to watch for changes introduced through the CRD to apply the changes to the cluster.
 
 Most https://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/[Kubelet Configuration options] can be set by the user. However, you cannot overwrite the following options:

--- a/modules/nodes-nodes-parallel-container-pulls-about.adoc
+++ b/modules/nodes-nodes-parallel-container-pulls-about.adoc
@@ -6,7 +6,7 @@
 [id="nodes-nodes-parallel-container-pulls-about_{context}"]
 = About configuring parallel container image pulls
 
-[role="_abstract"] 
+[role="_abstract"]
 To help control bandwidth issues, you can configure the number of workload images that can be pulled at the same time. 
 
 By default, the cluster pulls images in parallel, which allows multiple workloads to pull images at the same time. Pulling multiple images in parallel can improve workload start-up time because workloads can pull needed images without waiting for each other. However, pulling too many images at the same time can use excessive network bandwidth and cause latency issues throughout your cluster.

--- a/modules/nodes-nodes-parallel-container-pulls-configure.adoc
+++ b/modules/nodes-nodes-parallel-container-pulls-configure.adoc
@@ -6,7 +6,7 @@
 [id="nodes-nodes-parallel-container-pulls-configure_{context}"]
 = Configuring parallel container image pulls
 
-[role="_abstract"] 
+[role="_abstract"]
 You can control the number of images that can be pulled by your workload simultaneously by using a kubelet configuration. You can set a maximum number of images that can be pulled or force workloads to pull images one at a time.
 
 .Prerequisites

--- a/modules/nodes-nodes-working-master-schedulable.adoc
+++ b/modules/nodes-nodes-working-master-schedulable.adoc
@@ -6,7 +6,7 @@
 [id="nodes-nodes-working-master-schedulable_{context}"]
 = Configuring control plane nodes as schedulable
 
-[role="_abstract"] 
+[role="_abstract"]
 You can configure control plane nodes to be schedulable, meaning that new pods are allowed for placement on the control plane nodes.
 
 By default, control plane nodes are not schedulable. You can set the control plane nodes to be schedulable, but you must retain the compute nodes.

--- a/modules/nw-multus-configuring-whereabouts-ip-reconciler-schedule.adoc
+++ b/modules/nw-multus-configuring-whereabouts-ip-reconciler-schedule.adoc
@@ -6,7 +6,7 @@
 [id="nw-multus-configuring-whereabouts-ip-reconciler-schedule_{context}"]
 = Configuring the Whereabouts IP reconciler schedule
 
-[role="_abstract"] 
+[role="_abstract"]
 The Whereabouts IPAM CNI plugin runs the IP address reconciler daily. This process cleans up any stranded IP address allocations that might result in exhausting IP addresses and therefore prevent new pods from getting a stranded IP address allocated to them.
 
 Use this procedure to change the frequency at which the IP reconciler runs. 

--- a/modules/nw-multus-creating-whereabouts-reconciler-daemon-set.adoc
+++ b/modules/nw-multus-creating-whereabouts-reconciler-daemon-set.adoc
@@ -6,7 +6,7 @@
 [id="nw-multus-creating-whereabouts-reconciler-daemon-set_{context}"]
 = Creating a whereabouts-reconciler daemon set
 
-[role="_abstract"] 
+[role="_abstract"]
 The Whereabouts reconciler is responsible for managing dynamic IP address assignments for the pods within a cluster by using the Whereabouts IP Address Management (IPAM) solution. The Whereabouts reconciler ensures that each pod gets a unique IP address from the specified IP address range. The Whereabouts reconciler also handles IP address releases when pods are deleted or scaled down.
 
 [NOTE]

--- a/modules/nw-multus-tap-object.adoc
+++ b/modules/nw-multus-tap-object.adoc
@@ -7,7 +7,9 @@
 = Configuration for a TAP secondary network
 
 [role="_abstract"]
-The TAP CNI plugin JSON configuration object describes the configuration parameters for the TAP CNI plugin. The following table describes these parameters:
+The TAP CNI plugin JSON configuration object describes the configuration parameters for the TAP CNI plugin. 
+
+The following table describes these  configuration parameters:
 
 [cols=".^2,.^2,.^6",options="header"]
 |====

--- a/modules/nw-multus-whereabouts.adoc
+++ b/modules/nw-multus-whereabouts.adoc
@@ -8,7 +8,7 @@
 [id="nw-multus-whereabouts_{context}"]
 = Dynamic IP address assignment configuration with Whereabouts
 
-[role="_abstract"] 
+[role="_abstract"]
 The Whereabouts CNI plugin helps the dynamic assignment of an IP address to a secondary network without the use of a DHCP server.
 
 The Whereabouts CNI plugin also supports overlapping IP address ranges and configuration of the same CIDR range multiple times within separate `NetworkAttachmentDefinition` CRDs. This provides greater flexibility and management capabilities in multitenant environments.

--- a/modules/nw-networkpolicy-allow-application-particular-namespace.adoc
+++ b/modules/nw-networkpolicy-allow-application-particular-namespace.adoc
@@ -17,7 +17,9 @@ endif::[]
 = Creating a {name} policy allowing traffic to an application from a namespace
 
 [role="_abstract"]
-You can configure a policy that allows traffic to a pod with the label `app=web` from a particular namespace. This configuration is useful in the following use cases:
+You can configure a policy that allows traffic to a pod with the label `app=web` from a particular namespace. 
+
+This configuration is useful in the following use cases:
 
 * Restrict traffic to a production database only to namespaces that have production workloads deployed.
 * Enable monitoring tools deployed to a particular namespace to scrape metrics from the current namespace.

--- a/modules/nw-networkpolicy-deny-all-allowed.adoc
+++ b/modules/nw-networkpolicy-deny-all-allowed.adoc
@@ -17,7 +17,9 @@ endif::[]
 = Creating a default deny all {name} policy
 
 [role="_abstract"]
-The default deny all {name} policy blocks all cross-pod networking other than network traffic allowed by the configuration of other deployed network policies and traffic between host-networked pods. This procedure enforces a strong deny policy by applying a `deny-by-default` policy in the `my-project` namespace.
+The default deny all {name} policy blocks all cross-pod networking other than network traffic allowed by the configuration of other deployed network policies and traffic between host-networked pods. 
+
+The steps in the procedure enforces a strong deny policy by applying a `deny-by-default` policy in the `my-project` namespace.
 
 [WARNING]
 ====

--- a/modules/nw-networkpolicy-object.adoc
+++ b/modules/nw-networkpolicy-object.adoc
@@ -12,7 +12,7 @@
 = Example NetworkPolicy object
 
 [role="_abstract"]
-The following configuration annotates an example NetworkPolicy object:
+Reference the example `NetworkPolicy` object to understand how to configure this object.
 
 [source,yaml]
 ----

--- a/modules/nw-sriov-expose-mtu.adoc
+++ b/modules/nw-sriov-expose-mtu.adoc
@@ -7,7 +7,7 @@
 [id="nw-sriov-expose-mtu_{context}"]
 = Exposing MTU for vfio-pci SR-IOV devices to pod
 
-[role="_abstract"] 
+[role="_abstract"]
 After adding a pod to an additional network, you can check that the MTU is available for the SR-IOV network.
 
 .Procedure

--- a/modules/nw-sriov-runtime-config-ethernet.adoc
+++ b/modules/nw-sriov-runtime-config-ethernet.adoc
@@ -6,7 +6,7 @@
 [id="nw-sriov-runtime-config-ethernet_{context}"]
 = Runtime configuration for an Ethernet-based SR-IOV attachment
 
-[role="_abstract"] 
+[role="_abstract"]
 When attaching a pod to an additional network, you can specify a runtime configuration to make specific customizations for the pod. For example, you can request a specific MAC hardware address.
 
 You specify the runtime configuration by setting an annotation in the pod specification. The annotation key is `k8s.v1.cni.cncf.io/networks`, and it accepts a JSON object that describes the runtime configuration.

--- a/nodes/nodes/nodes-nodes-managing.adoc
+++ b/nodes/nodes/nodes-nodes-managing.adoc
@@ -7,7 +7,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-[role="_abstract"] 
+[role="_abstract"]
 {product-title} uses a KubeletConfig custom resource (CR) to manage the configuration of nodes. By creating an instance of a `KubeletConfig` object, a managed machine config is created to override setting on the node.
 
 [NOTE]

--- a/virt/live_migration/virt-configuring-cross-cluster-live-migration-network.adoc
+++ b/virt/live_migration/virt-configuring-cross-cluster-live-migration-network.adoc
@@ -7,7 +7,7 @@ include::_attributes/attributes-openshift-dedicated.adoc[]
 
 toc::[]
 
-[role="_abstract"] 
+[role="_abstract"]
 Cross-cluster live migration requires that the clusters be connected in the same network. Specifically, `virt-handler` pods must be able to communicate.
 
 :FeatureName: Cross-cluster live migration


### PR DESCRIPTION
Version(s):
4.20+

Issue:
[OSDOCS-18667](https://redhat.atlassian.net/browse/OSDOCS-18667)

Link to docs preview:
* [OVN-Kubernetes network plugin JSON configuration table](https://109487--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/multiple_networks/secondary_networks/creating-secondary-nwt-ovnk.html#configuration-ovnk-network-plugin-json-object_configuring-additional-network-ovnk)
* [Configuration for a bridge secondary network](https://109487--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/live_migration/virt-configuring-cross-cluster-live-migration-network.html#nw-multus-bridge-object_virt-configuring-cross-cluster-live-migration-network)
* [Creating a multi-network policy allowing traffic to an application from a namespace](https://109487--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/multiple_networks/secondary_networks/configuring-multi-network-policy.html#nw-networkpolicy-allow-traffic-from-a-namespace_configuring-multi-network-policy)
* [Creating a default deny all network policy](https://109487--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/networking/network_security/network_policy/creating-network-policy.html#nw-networkpolicy-deny-all-multi-network-policy_creating-network-policy)
* [Example NetworkPolicy object](https://109487--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/networking/network_security/network_policy/creating-network-policy.html#nw-networkpolicy-object_creating-network-policy)
