### PR TITLE
[TELCODOCS-2868] Fix AsciiDocDITA Vale errors in CPU Manager and Topology Manager docs

### DIFF
--- a/modules/pod-interactions-with-topology-manager.adoc
+++ b/modules/pod-interactions-with-topology-manager.adoc
@@ -6,6 +6,7 @@
 [id="pod-interactions-with-topology-manager_{context}"]
 = Pod interactions with Topology Manager policies
 
+[role="_abstract"]
 The example `Pod` specs illustrate pod interactions with Topology Manager.
 
 The following pod runs in the `BestEffort` QoS class because no resource requests or limits are specified.
@@ -33,7 +34,7 @@ spec:
         memory: "100Mi"
 ----
 
-If the selected policy is anything other than `none`, Topology Manager would process all the pods and it enforces resource alignment only for the `Guaranteed` Qos `Pod` specification.
+If the selected policy is anything other than `none`, Topology Manager would process all the pods and it enforces resource alignment only for the `Guaranteed` QoS `Pod` specification.
 When the Topology Manager policy is set to `none`, the relevant containers are pinned to any available CPU without considering NUMA affinity. This is the default behavior and it does not optimize for performance-sensitive workloads.
 Other values enable the use of topology awareness information from device plugins core resources, such as CPU and memory. The Topology Manager attempts to align the CPU, memory, and device allocations according to the topology of the node when the policy is set to other values than `none`. For more information about the available values, see _Topology Manager policies_.
 

--- a/modules/setting-up-cpu-manager.adoc
+++ b/modules/setting-up-cpu-manager.adoc
@@ -7,7 +7,8 @@
 [id="setting_up_cpu_manager_{context}"]
 = Setting up CPU Manager
 
-To configure CPU manager, create a KubeletConfig custom resource (CR) and apply it to the desired set of nodes.
+[role="_abstract"]
+To configure CPU manager, create a `KubeletConfig` custom resource (CR) and apply it to the required set of nodes.
 
 .Procedure
 
@@ -49,13 +50,16 @@ spec:
     matchLabels:
       custom-kubelet: cpumanager-enabled
   kubeletConfig:
-     cpuManagerPolicy: static <1>
-     cpuManagerReconcilePeriod: 5s <2>
+     cpuManagerPolicy: static
+     cpuManagerReconcilePeriod: 5s
 ----
-<1> Specify a policy:
-* `none`. This policy explicitly enables the existing default CPU affinity scheme, providing no affinity beyond what the scheduler does automatically. This is the default policy.
-* `static`. This policy allows containers in guaranteed pods with integer CPU requests. It also limits access to exclusive CPUs on the node. If `static`, you must use a lowercase `s`.
-<2> Optional. Specify the CPU Manager reconcile frequency. The default is `5s`.
++
+--
+* `cpuManagerPolicy` specifies a policy:
+** `none`. This policy explicitly enables the existing default CPU affinity scheme, providing no affinity beyond what the scheduler does automatically. This is the default policy.
+** `static`. This policy allows containers in guaranteed pods with integer CPU requests. It also limits access to exclusive CPUs on the node. If `static`, you must use a lowercase `s`.
+* `cpuManagerReconcilePeriod` is optional. Specify the CPU Manager reconcile frequency. The default is `5s`.
+--
 
 . Create the dynamic kubelet config by running the following command:
 +
@@ -94,14 +98,18 @@ This adds the CPU Manager feature to the kubelet config and, if needed, the Mach
 sh-4.2# cat /host/etc/kubernetes/kubelet.conf | grep cpuManager
 ----
 +
-.Example output
+The following is example output:
++
 [source,terminal]
 ----
-cpuManagerPolicy: static        <1>
-cpuManagerReconcilePeriod: 5s   <2>
+cpuManagerPolicy: static
+cpuManagerReconcilePeriod: 5s
 ----
-<1> `cpuManagerPolicy` is defined when you create the `KubeletConfig` CR.
-<2> `cpuManagerReconcilePeriod` is defined when you create the `KubeletConfig` CR.
++
+--
+* `cpuManagerPolicy` is defined when you create the `KubeletConfig` CR.
+* `cpuManagerReconcilePeriod` is defined when you create the `KubeletConfig` CR.
+--
 
 . Create a project by running the following command:
 +

--- a/modules/setting-up-topology-manager.adoc
+++ b/modules/setting-up-topology-manager.adoc
@@ -7,6 +7,7 @@
 [id="setting_up_topology_manager_{context}"]
 = Setting up Topology Manager
 
+[role="_abstract"]
 To use Topology Manager, you must configure an allocation policy in the `KubeletConfig` custom resource (CR) named `cpumanager-enabled`. This file might exist if you have set up CPU Manager. If the file does not exist, you can create the file.
 
 .Prerequisites
@@ -15,9 +16,7 @@ To use Topology Manager, you must configure an allocation policy in the `Kubelet
 
 .Procedure
 
-To activate Topology Manager:
-
-. Configure the Topology Manager allocation policy in the custom resource.
+. To activate Topology Manager, configure the Topology Manager allocation policy in the custom resource.
 +
 [source,terminal]
 ----
@@ -35,10 +34,12 @@ spec:
     matchLabels:
       custom-kubelet: cpumanager-enabled
   kubeletConfig:
-     cpuManagerPolicy: static <1>
+     cpuManagerPolicy: static
      cpuManagerReconcilePeriod: 5s
-     topologyManagerPolicy: single-numa-node <2>
+     topologyManagerPolicy: single-numa-node
 ----
-<1> This parameter must be `static` with a lowercase `s`.
-<2> Specify your selected Topology Manager allocation policy. Here, the policy is `single-numa-node`.
-Acceptable values are: `default`, `best-effort`, `restricted`, `single-numa-node`.
++
+--
+* `cpuManagerPolicy` must be `static` with a lowercase `s`.
+* `topologyManagerPolicy` specifies your selected Topology Manager allocation policy. In this example, the policy is `single-numa-node`. Acceptable values are: `default`, `best-effort`, `restricted`, `single-numa-node`.
+--

--- a/modules/topology-manager-policies.adoc
+++ b/modules/topology-manager-policies.adoc
@@ -7,6 +7,7 @@
 [id="topology-manager-policies_{context}"]
 = Topology Manager policies
 
+[role="_abstract"]
 Topology Manager aligns `Pod` resources of all Quality of Service (QoS) classes by collecting topology hints from Hint Providers, such as CPU Manager and Device Manager, and using the collected hints to align the `Pod` resources.
 
 Topology Manager supports four allocation policies, which you assign in the `KubeletConfig` custom resource (CR) named `cpumanager-enabled`:

--- a/scalability_and_performance/using-cpu-manager.adoc
+++ b/scalability_and_performance/using-cpu-manager.adoc
@@ -6,6 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 CPU Manager manages groups of CPUs and constrains workloads to specific CPUs.
 
 CPU Manager is useful for workloads that have some of these attributes:


### PR DESCRIPTION
## Summary
- Add `[role="_abstract"]` short descriptions to all 5 files (assembly + 4 modules) for DITA conversion compatibility
- Replace 3 unsupported callout lists with bulleted lists in open blocks in `setting-up-cpu-manager.adoc` and `setting-up-topology-manager.adoc`
- Fix broken procedure step list (`TaskStep` error) in `setting-up-topology-manager.adoc` by merging standalone text into the first step
- Correct "Qos" typo to "QoS" in `pod-interactions-with-topology-manager.adoc`
- Replace "desired" with "required" per style guide in `setting-up-cpu-manager.adoc`

## Test plan
- [x] Verify Vale AsciiDocDITA rules produce no errors or warnings on all 5 modified files
- [x] Verify AsciiDoc renders correctly with `asciibinder build`
- [x] Confirm callout replacement bullet lists display correctly in preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)