### PR TITLE
RHDEVDOCS-6495: Add "Install the the Builds Operator" as prerequisite

### DIFF
--- a/modules/ephemeral-storage-creating-a-shared-secret-instance.adoc
+++ b/modules/ephemeral-storage-creating-a-shared-secret-instance.adoc
@@ -11,10 +11,11 @@ Create a `SharedSecret` custom resource (CR) to share a `Secret` object across n
 
 .Prerequisites
 
+* You have installed the {builds-operator} on the {ocp-product-title} cluster.
 * You are logged in to the {ocp-product-title} cluster as an administrator.
 * You have created a `Secret` object that you want to share in other namespaces. To create a `Secret` object, see "Creating Secrets".
 * You have subscribed to the cluster and have entitlement keys synced through the Insights Operator.
-* You must have permissions to perform the following actions: 
+* You must have permissions to perform the following actions:
 ** Create the `sharedsecrets.sharedresource.openshift.io` CR at a cluster-scoped level.
 ** Create the `ClusterRole` object for the `SharedSecret` CR.
 ** Create the `Role` and `RoleBinding` objects for the Shared Resource CSI Driver.
@@ -63,7 +64,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: share-etc-pki-entitlement 
+  name: share-etc-pki-entitlement
 subjects:
   - kind: ServiceAccount
     name: csi-driver-shared-resource
@@ -88,7 +89,7 @@ spec:
 ----
 * `spec.secretRef.namespace` defines the name of the `SharedSecret` CR.
 
-. Create a `ClusterRole` object that grants RBAC permission to use the referenced shared resource by using the following example configuration: 
+. Create a `ClusterRole` object that grants RBAC permission to use the referenced shared resource by using the following example configuration:
 +
 [source,yaml]
 ----

--- a/modules/ephemeral-storage-creating-sharedconfigmap-custom-resource.adoc
+++ b/modules/ephemeral-storage-creating-sharedconfigmap-custom-resource.adoc
@@ -11,6 +11,7 @@ Create a `SharedConfigMap` custom resource (CR) to share a `ConfigMap` object ac
 
 .Prerequisites
 
+* You have installed the {builds-operator} on the {ocp-product-title} cluster.
 * You are logged in to the {ocp-product-title} cluster as an administrator.
 * You have created a `ConfigMap` object that you want to share in other namespaces. To create a `ConfigMap` object, see "Adding input secrets and configmaps".
 * You must have permissions to perform the following actions:

--- a/modules/ephemeral-storage-using-a-sharedconfigmap-object-in-a-pod.adoc
+++ b/modules/ephemeral-storage-using-a-sharedconfigmap-object-in-a-pod.adoc
@@ -26,7 +26,7 @@ If you are unable to complete the last two prerequisites, the cluster administra
 
 .Procedure
 
-. Create the `RoleBinding` object associated with the role and grant the permission to your service account to use the shared resource. 
+. Create the `RoleBinding` object associated with the role and grant the permission to your service account to use the shared resource.
 +
 [source,yaml]
 ----
@@ -49,7 +49,7 @@ where:
 `<app_namespace>`:: Specifies the name of the namespace of your application.
 `<service_account_name>`:: Specifies the service account name of your application.
 
-. Mount the Shared Resource Container Storage Interface (CSI) Driver into a pod or any other resource that accepts `csi` volumes. 
+. Mount the Shared Resource Container Storage Interface (CSI) Driver into a pod or any other resource that accepts `csi` volumes.
 +
 [source,yaml]
 ----
@@ -64,7 +64,7 @@ spec:
   volumes:
     - name: shared-config
       csi:
-        readOnly: true 
+        readOnly: true
         driver: csi.sharedresource.openshift.io
         volumeAttributes:
           sharedConfigMap: share-test-config
@@ -74,7 +74,7 @@ where:
 
 `<app_namespace>`:: Specifies the name of the namespace of your application.
 
-`volumes.volumeAttributes.sharedConfigMap`:: Specifies the name of the `sharedConfigMap` object. 
+`volumes.volumeAttributes.sharedConfigMap`:: Specifies the name of the `sharedConfigMap` object.
 
 +
 [IMPORTANT]

--- a/modules/ephemeral-storage-using-a-sharedsecret-object-in-a-pod.adoc
+++ b/modules/ephemeral-storage-using-a-sharedsecret-object-in-a-pod.adoc
@@ -45,7 +45,7 @@ subjects:
 +
 where:
 
-`metadata.name`:: Defines the name of the `RoleBinding` CR. 
+`metadata.name`:: Defines the name of the `RoleBinding` CR.
 
 `<service_account_name>`:: Specifies the name of the service account of your application.
 
@@ -64,7 +64,7 @@ spec:
   volumes:
     - name: shared-secret
       csi:
-        readOnly: true 
+        readOnly: true
         driver: csi.sharedresource.openshift.io
         volumeAttributes:
           sharedSecret: shared-test-secret

--- a/modules/sharing-RHEL-entitlement-secret-across-namespaces.adoc
+++ b/modules/sharing-RHEL-entitlement-secret-across-namespaces.adoc
@@ -11,10 +11,11 @@ You can use a `SharedSecret` object to securely share and synchronize the RHEL e
 
 .Prerequisites
 
+* You have installed the {builds-operator} on the {ocp-product-title} cluster.
 * You must have permissions to perform the following actions:
 ** Create `SharedSecret` object.
 ** Create build configs and start builds.
-** Run the `oc get sharedsecrets` command to discover which `SharedSecret` custom resource (CR) instances are available. 
+** Run the `oc get sharedsecrets` command to discover which `SharedSecret` custom resource (CR) instances are available.
 ** Run the `oc adm policy who-can use <sharedsecret_identifier>` command to check if a service account is allowed to use the `SharedSecret` CR and the service account is listed in your namespace.
 
 [NOTE]
@@ -176,7 +177,7 @@ spec:
       readOnly: true
       volumeAttributes:
         sharedSecret: <sharedsecret_object_name>
-    name: etc-pki-entitlement 
+    name: etc-pki-entitlement
   output:
     image: <output_image_location>
 EOF


### PR DESCRIPTION
Version(s): 1.5, 1.6, 1.7

Issue: https://redhat.atlassian.net/browse/RHDEVDOCS-6495

Link to docs preview: https://109490--ocpdocs-pr.netlify.app/openshift-builds/latest/work_with_shared_resources/using-shared-resource-csi-driver.html

Dev review:
- [x] Dev has approved this change.