### PR TITLE
PR for OBSDOCS-3258-CQA: CQA + DITA readiness for assemblies and modules under "Installing logging" & "Uninstalling logging" sections.

### DIFF
--- a/installing/installing-the-loki-operator.adoc
+++ b/installing/installing-the-loki-operator.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: ASSEMBLY
-include::_attributes/common-attributes.adoc[]
 [id="installing-the-loki-operator"]
 = Installing the {loki-op}
+include::_attributes/common-attributes.adoc[]
 :context: installing-the-loki-operator
 
 toc::[]
@@ -23,7 +23,23 @@ include::modules/creating-the-loki-object-storage-secret.adoc[leveloffset=+1]
 
 include::modules/creating-the-lokistack.adoc[leveloffset=+1]
 
-[id="next-steps_{context}"]
-== Next steps
+[role="_additional-resources"]
+== Additional resources
 
 * xref:../installing/installing-the-red-hat-openshift-logging-operator.adoc#installing-the-red-hat-openshift-logging-operator[Installing the {clo}]
+
+* link:https://aws.amazon.com/[AWS S3]
+
+* link:https://azure.microsoft.com[Azure]
+
+* link:https://cloud.google.com/[Google Cloud Storage]
+
+* link:https://min.io/[MinIO]
+
+* link:https://www.redhat.com/en/technologies/cloud-computing/openshift-data-foundation[{rh-storage}]
+
+* link:https://docs.openstack.org/swift/latest/[Swift]
+
+* link:https://docs.redhat.com/en/documentation/red_hat_openshift_logging/{logging-major-version}/html/configuring_logging/configuring-lokistack-storage#logging-loki-storage_configuring-the-log-store[Loki object storage]
+
+* link:https://docs.redhat.com/en/documentation/red_hat_openshift_logging/{logging-major-version}/html/configuring_logging/configuring-lokistack-storage#logging-loki-retention_configuring-the-log-store[Enabling stream-based retention with Loki]

--- a/installing/installing-the-red-hat-openshift-logging-operator.adoc
+++ b/installing/installing-the-red-hat-openshift-logging-operator.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: ASSEMBLY
-include::_attributes/common-attributes.adoc[]
 [id="installing-the-red-hat-openshift-logging-operator"]
 = Installing the {clo}
+include::_attributes/common-attributes.adoc[]
 :context: installing-the-red-hat-openshift-logging-operator
 
 toc::[]
@@ -27,4 +27,11 @@ include::modules/troubleshooting-logging-installation.adoc[leveloffset=+1]
 .Additional resources
 
 * xref:../installing/installing-the-loki-operator.adoc#installing-the-loki-operator[Installing the {loki-op}]
+
 * link:https://docs.redhat.com/en/documentation/red_hat_openshift_logging/{logging-major-version}/html/configuring_logging/configuring-log-forwarding[Configuring log forwarding]
+
+* link:https://docs.redhat.com/en/documentation/red_hat_openshift_cluster_observability_operator/{coo-version}/html/installing_red_hat_openshift_cluster_observability_operator/installing-the-cluster-observability-operator[Installing the {coo-full}]
+
+* link:https://issues.redhat.com/browse/OU-587[OU-587 - Known issues for the logging UI plugin]
+
+* link:https://issues.redhat.com/browse/LOG-6589[LOG-6589 - Non-administrator users cannot query logs by using the otel attribute]

--- a/installing/overview-of-openshift-logging-installation.adoc
+++ b/installing/overview-of-openshift-logging-installation.adoc
@@ -1,10 +1,13 @@
 :_mod-docs-content-type: ASSEMBLY
-include::_attributes/common-attributes.adoc[]
 [id="overview-of-openshift-logging-installation"]
 = Overview of {product-title} installation
+include::_attributes/common-attributes.adoc[]
 :context: overview-of-openshift-logging-installation
 
 toc::[]
+
+[role="_abstract"]
+Learn how to install {product-title} by understanding the Logging Operator, selecting the required Operators, and reviewing logging storage prerequisites.
 
 include::modules/logging-operator-overview.adoc[leveloffset=+1]
 
@@ -12,8 +15,9 @@ include::modules/logging-installation-use-cases.adoc[leveloffset=+1]
 
 include::modules/logging-storage-prerequisites.adoc[leveloffset=+1]
 
-[id="next-steps_{context}"]
-== Next steps
+[role="_additional-resources"]
+== Additional resources
 
 * xref:../installing/installing-the-loki-operator.adoc#installing-the-loki-operator[Installing the {loki-op}]
+
 * xref:../installing/installing-the-red-hat-openshift-logging-operator.adoc#installing-the-red-hat-openshift-logging-operator[Installing the {clo}]

--- a/modules/creating-the-lokistack.adoc
+++ b/modules/creating-the-lokistack.adoc
@@ -45,7 +45,7 @@ spec:
 `spec.storage.schemas[0].effectiveDate`:: Set to a date at least two months in the past.
 `spec.storage.secret.name`:: Specify the name of the object storage secret you created.
 `spec.storage.secret.type`:: Specify the corresponding storage type.
-`spec.storageClassName`:: Specify the name of a StorageClass for LokiStack internal PVCs (write ahead log, index cache, compactor working space). Run `oc get storageclasses` to list available options.
+`spec.storageClassName`:: Specify the name of a `StorageClass` for `LokiStack` internal PVCs (write ahead log, index cache, compactor working space). Run `oc get storageclasses` to list available options.
 `spec.tenants.mode`:: The `openshift-logging` mode is the default tenancy mode where a tenant is created for each log type (audit, infrastructure, and application). This enables access control for individual users and user groups to different log streams.
 `spec.limits.global.retention.days`:: Optional. Set the global retention period in days. When this block is included, retention is enabled for the `LokiStack` instance.
 +
@@ -63,7 +63,7 @@ $ oc apply -f <filename>.yaml
 
 .Verification
 
-* Verify that the LokiStack is ready by running the following command:
+* Verify that the `LokiStack` is ready by running the following command:
 +
 [source,terminal]
 ----
@@ -72,7 +72,7 @@ $ oc get lokistack logging-loki -n openshift-logging -o jsonpath='{.status.condi
 +
 The output should show `All components ready`.
 
-* To verify individual components, check that the LokiStack pods are running by running the following command:
+* To verify individual components, check that the `LokiStack` pods are running by running the following command:
 +
 [source,terminal]
 ----
@@ -80,9 +80,3 @@ $ oc get pods -n openshift-logging -l app.kubernetes.io/managed-by=lokistack-con
 ----
 +
 You should see 7-8 pods: compactor, distributor, gateway (x2), index-gateway, ingester, querier, and query-frontend.
-
-[role="_additional-resources"]
-.Additional resources
-
-* link:https://docs.redhat.com/en/documentation/red_hat_openshift_logging/{logging-major-version}/html/configuring_logging/configuring-lokistack-storage#logging-loki-storage_configuring-the-log-store[Loki object storage]
-* link:https://docs.redhat.com/en/documentation/red_hat_openshift_logging/{logging-major-version}/html/configuring_logging/configuring-lokistack-storage#logging-loki-retention_configuring-the-log-store[Enabling stream-based retention with Loki]

--- a/modules/deleting-logging-pvcs-by-using-the-cli.adoc
+++ b/modules/deleting-logging-pvcs-by-using-the-cli.adoc
@@ -4,11 +4,11 @@
 :_newdoc-version: 2.18.4
 :_template-generated: 2025-07-28
 :_mod-docs-content-type: PROCEDURE
-
 [id="deleting-logging-pvcs-by-using-the-cli_{context}"]
 = Deleting logging PVCs by using the CLI
 
-You can delete persistent volume claims (PVCs) if you do not want to reuse them in other installations of LokiStack by using the {oc-first}.
+[role="_abstract"]
+You can delete persistent volume claims (PVCs) if you do not want to reuse them in other installations of `LokiStack` by using the {oc-first}.
 
 .Prerequisites
 * You have administrator permissions.
@@ -22,6 +22,3 @@ You can delete persistent volume claims (PVCs) if you do not want to reuse them 
 ----
 $ oc -n openshift-logging delete pvc -l app.kubernetes.io/name=lokistack
 ----
-
-.Next steps
-* https://docs.redhat.com/en/documentation/openshift_container_platform/latest/html-single/storage/index#reclaim-manual_understanding-persistent-storage[Reclaiming a persistent volume manually]

--- a/modules/deleting-logging-pvcs-by-using-the-web-console.adoc
+++ b/modules/deleting-logging-pvcs-by-using-the-web-console.adoc
@@ -4,11 +4,11 @@
 :_newdoc-version: 2.18.4
 :_template-generated: 2025-07-05
 :_mod-docs-content-type: PROCEDURE
-
 [id="deleting-logging-pvcs-by-using-the-web-console_{context}"]
 = Deleting logging PVCs by using the web console
 
-You can delete persistent volume claims (PVCs) if you do not want to reuse them in other installations of LokiStack, by using the web console.
+[role="_abstract"]
+You can delete persistent volume claims (PVCs) if you do not want to reuse them in other installations of `LokiStack`, by using the web console.
 
 .Prerequisites
 * You have administrator permissions.
@@ -19,6 +19,3 @@ You can delete persistent volume claims (PVCs) if you do not want to reuse them 
 . In the web console, go to the *Storage* -> *Persistent Volume Claims* page.
 
 . Click {kebab} next to each PVC, and select *Delete Persistent Volume Claim*.
-
-.Next steps
-* https://docs.redhat.com/en/documentation/openshift_container_platform/latest/html-single/storage/index#reclaim-manual_understanding-persistent-storage[Reclaiming a persistent volume manually]

--- a/modules/deleting-the-cluster-logging-operator-by-using-the-cli.adoc
+++ b/modules/deleting-the-cluster-logging-operator-by-using-the-cli.adoc
@@ -4,10 +4,10 @@
 :_newdoc-version: 2.18.4
 :_template-generated: 2025-07-05
 :_mod-docs-content-type: PROCEDURE
-
 [id="deleting-the-cluster-logging-operator-by-using-the-cli_{context}"]
 = Deleting the {clo} by using the CLI
 
+[role="_abstract"]
 Delete the {clo} by using the {oc-first}.
 
 .Prerequisites
@@ -72,7 +72,8 @@ $  oc -n openshift-logging delete LogFileMetricExporter --all
 $ oc get csv -n openshift-logging | grep cluster-logging
 ----
 +
-.Example output
+You get an output similar to the following example:
++
 ----
 cluster-logging.v6.2.4    Red Hat OpenShift Logging   6.2.4     cluster-logging.v6.2.3    Succeeded
 ----

--- a/modules/deleting-the-cluster-logging-operator-by-using-the-web-console.adoc
+++ b/modules/deleting-the-cluster-logging-operator-by-using-the-web-console.adoc
@@ -5,11 +5,11 @@
 :_newdoc-version: 2.18.4
 :_template-generated: 2025-07-05
 :_mod-docs-content-type: PROCEDURE
-
 [id="deleting-the-cluster-logging-operator-by-using-the-web-console_{context}"]
 = Deleting the {clo} by using the web console
 
-Delete the {clo} by using the {product-title} web console.
+[role="_abstract"]
+You can delete the {clo} by using the {product-title} web console.
 
 .Prerequisites
 * You have administrator permissions.

--- a/modules/deleting-the-loki-operator-by-using-the-cli.adoc
+++ b/modules/deleting-the-loki-operator-by-using-the-cli.adoc
@@ -4,11 +4,11 @@
 :_newdoc-version: 2.18.4
 :_template-generated: 2025-07-05
 :_mod-docs-content-type: PROCEDURE
-
 [id="deleting-the-loki-operator-by-using-the-cli_{context}"]
 = Deleting the {loki-op} by using the CLI
 
-Delete the {loki-op} by using the {oc-first}.
+[role="_abstract"]
+You can delete the {loki-op} by using the {oc-first}.
 
 .Prerequisites
 
@@ -33,7 +33,8 @@ Substitute `logging-loki` with the name of your `LokiStack` CR if you have used 
 $ oc get csv -n openshift-operators-redhat | grep loki-operator
 ----
 +
-.Example output
+You get an output similar to the following example:
++
 ----
 loki-operator.v6.2.4      Loki Operator               6.2.4     loki-operator.v6.2.3                    Succeeded
 ----

--- a/modules/deleting-the-loki-operator-by-using-the-web-console.adoc
+++ b/modules/deleting-the-loki-operator-by-using-the-web-console.adoc
@@ -4,11 +4,11 @@
 :_newdoc-version: 2.18.4
 :_template-generated: 2025-07-05
 :_mod-docs-content-type: PROCEDURE
-
 [id="deleting-the-loki-operator-by-using-the-web-console_{context}"]
 = Deleting the {loki-op} by using the web console
 
-Delete the {loki-op} by using the {product-title} web console.
+[role="_abstract"]
+You can delete the {loki-op} by using the {product-title} web console.
 
 .Prerequisites
 * You have administrator permissions.

--- a/modules/deleting-the-uiplugin-by-using-the-cli.adoc
+++ b/modules/deleting-the-uiplugin-by-using-the-cli.adoc
@@ -4,11 +4,11 @@
 :_newdoc-version: 2.18.4
 :_template-generated: 2025-07-14
 :_mod-docs-content-type: PROCEDURE
-
 [id="deleting-the-uiplugin-by-using-the-cli_{context}"]
 = Deleting the UIPlugin by using the CLI
 
-Delete the `UIPlugin` by using the {oc-first}. 
+[role="_abstract"]
+You can delete the `UIPlugin` by using the {oc-first}. 
 
 .Prerequisites
 * You have administrator permissions.

--- a/modules/deleting-the-uiplugin-by-using-the-web-console.adoc
+++ b/modules/deleting-the-uiplugin-by-using-the-web-console.adoc
@@ -4,11 +4,11 @@
 :_newdoc-version: 2.18.4
 :_template-generated: 2025-07-05
 :_mod-docs-content-type: PROCEDURE
-
 [id="deleting-the-uiplugin-by-using-the-web-console_{context}"]
 = Deleting the UIPlugin by using the web console
 
-Delete the `UIPlugin` plugin by using the {product-title} web console.
+[role="_abstract"]
+You can delete the `UIPlugin` plugin by using the {product-title} web console.
 
 .Prerequisites
 * You have administrator permissions.
@@ -20,4 +20,4 @@ Delete the `UIPlugin` plugin by using the {product-title} web console.
 
 . Click *{coo-full}* from the *Installed Operators* list and go to the *UIPlugin* tab.
 
-. Click {kebab} for the UIPlugin *logging* entry and select *Delete UIPlugin*.
+. Click {kebab} for the `UIPlugin` *logging* entry and select *Delete UIPlugin*.

--- a/modules/enabling-the-logs-tab.adoc
+++ b/modules/enabling-the-logs-tab.adoc
@@ -45,7 +45,7 @@ spec:
 `metadata.name`:: Set the name to `logging`.
 `spec.type`:: Set the type to `Logging`.
 `spec.logging.lokiStack.name`:: Must match the name of your `LokiStack` instance.
-`spec.logging.schema`:: Set to `otel`, `viaq`, or `select`. The default is `viaq` if no value is specified. When you choose `select`, you can select the mode in the UI when you run a query.
+`spec.logging.schema`:: Set to `otel`, `viaq`, or `select`. The default is `viaq` if no value is specified. When you select `select`, you can select the mode in the UI when you run a query.
 +
 [NOTE]
 ====
@@ -63,10 +63,3 @@ $ oc apply -f <filename>.yaml
 ----
 
 . Refresh the {ocp-product-title} web console. Navigate to *Observe -> Logs* to verify that the *Logs* tab is available. You can also view aggregated logs for individual pods from the *Aggregated Logs* tab on a pod's detail page.
-
-[role="_additional-resources"]
-.Additional resources
-
-* link:https://docs.redhat.com/en/documentation/red_hat_openshift_cluster_observability_operator/{coo-version}/html/installing_red_hat_openshift_cluster_observability_operator/installing-the-cluster-observability-operator[Installing the {coo-full}]
-* link:https://issues.redhat.com/browse/OU-587[OU-587 - Known issues for the logging UI plugin]
-* link:https://issues.redhat.com/browse/LOG-6589[LOG-6589 - Non-administrator users cannot query logs by using the otel attribute]

--- a/modules/installing-the-clo-cli.adoc
+++ b/modules/installing-the-clo-cli.adoc
@@ -12,8 +12,8 @@ Install the {clo} to manage log collection and forwarding by using the {oc-first
 .Prerequisites
 
 * You have administrator permissions.
-* You installed the {oc-first}.
-* You installed and configured the {loki-op} and deployed a `LokiStack` instance.
+* You have installed the {oc-first}.
+* You have installed and configured the {loki-op} and deployed a `LokiStack` instance.
 * You have created the `openshift-logging` namespace.
 
 .Procedure
@@ -72,14 +72,10 @@ $ oc apply -f <filename>.yaml
 $ oc get csv -n openshift-logging
 ----
 +
-.Example output
+You get an output similar to the following example:
++
 [source,terminal,subs="attributes+"]
 ----
 NAME                                            DISPLAY                      VERSION                       PHASE
 cluster-logging.v{logging-major-version}.0   Red Hat OpenShift Logging   {logging-major-version}.0     Succeeded
 ----
-
-[role="_additional-resources"]
-.Additional resources
-
-* xref:../installing/installing-the-loki-operator.adoc#installing-the-loki-operator[Installing the {loki-op}]

--- a/modules/installing-the-clo-web-console.adoc
+++ b/modules/installing-the-clo-web-console.adoc
@@ -154,8 +154,3 @@ The `tls.ca` block is required. Without it, the collector pods fail to connect t
 . In the *Status* column, verify that you see the following conditions:
 * `observability.openshift.io/Authorized`
 * `observability.openshift.io/Valid, Ready`
-
-[role="_additional-resources"]
-.Additional resources
-
-* xref:../installing/installing-the-loki-operator.adoc#installing-the-loki-operator[Installing the {loki-op}]

--- a/modules/installing-the-loki-operator-cli.adoc
+++ b/modules/installing-the-loki-operator-cli.adoc
@@ -12,7 +12,7 @@ Install the {loki-op} to manage the `LokiStack` log store by using the {oc-first
 .Prerequisites
 
 * You have administrator permissions.
-* You installed the {oc-first}.
+* You have installed the {oc-first}.
 * You have access to a supported object store.
 
 .Procedure
@@ -29,7 +29,7 @@ metadata:
     openshift.io/cluster-monitoring: "true"
 ----
 +
-`metadata.name`:: You must specify `openshift-operators-redhat` as the namespace for the {loki-op}. The `openshift-operators` namespace might contain community operators, which are untrusted and could publish metrics with the same name as {ocp-product-title} metrics, causing conflicts.
+`metadata.name`:: You must specify `openshift-operators-redhat` as the namespace for the {loki-op}. The `openshift-operators` namespace might contain community Operators, which are untrusted and could publish metrics with the same name as {ocp-product-title} metrics, causing conflicts.
 `metadata.labels."openshift.io/cluster-monitoring"`:: A string value that enables cluster monitoring to scrape this namespace.
 
 . Apply the `Namespace` object by running the following command:
@@ -77,7 +77,7 @@ spec:
 ----
 +
 `spec.channel`:: Specify `stable-{logging-major-version}` as the channel.
-`spec.installPlanApproval`:: If the approval strategy in the subscription is set to `Automatic`, the update process initiates as soon as a new operator version is available in the selected channel. If the approval strategy is set to `Manual`, you must manually approve pending updates.
+`spec.installPlanApproval`:: If the approval strategy in the subscription is set to `Automatic`, the update process initiates as soon as a new Operator version is available in the selected channel. If the approval strategy is set to `Manual`, you must manually approve pending updates.
 `spec.source`:: Specify `redhat-operators` as the value. If your {ocp-product-title} cluster is installed on a restricted network, also known as a disconnected cluster, specify the name of the `CatalogSource` object that you created when you configured {olm-first}.
 +
 [WARNING]
@@ -99,7 +99,8 @@ $ oc apply -f <filename>.yaml
 $ oc get csv -n openshift-operators-redhat
 ----
 +
-.Example output
+You get an output similar to the following example:
++
 [source,terminal,subs="attributes+"]
 ----
 NAME                                     DISPLAY         VERSION                PHASE

--- a/modules/installing-the-loki-operator-web-console.adoc
+++ b/modules/installing-the-loki-operator-web-console.adoc
@@ -30,7 +30,7 @@ The Community {loki-op} is not supported by Red{nbsp}Hat. Select the operator pr
 
 . Select *stable-{logging-major-version}* as the *Update channel*.
 +
-The {loki-op} must be deployed to the global operator group namespace `openshift-operators-redhat`, so the *Installation mode* and *Installed Namespace* are already selected. If this namespace does not already exist, it is created for you.
+The {loki-op} must be deployed to the global Operator group namespace `openshift-operators-redhat`, so the *Installation mode* and *Installed Namespace* are already selected. If this namespace does not already exist, it is created for you.
 
 . Select *Enable Operator-recommended cluster monitoring on this namespace*.
 +

--- a/modules/logging-installation-use-cases.adoc
+++ b/modules/logging-installation-use-cases.adoc
@@ -7,7 +7,7 @@
 = Choosing which operators to install
 
 [role="_abstract"]
-The operators you need depend on your use case:
+The Operators you need depend on your use case:
 
 * *Collect and forward logs to a third-party log store*: Install only the {clo}.
 
@@ -24,9 +24,3 @@ The operators you need depend on your use case:
 * You must install and configure the {loki-op} *before* configuring the {clo}.
 * The {loki-op} and the {clo} must use the same major and minor version. For example, both operators must be on `stable-{logging-major-version}`.
 ====
-
-[role="_additional-resources"]
-.Additional resources
-
-* xref:../installing/installing-the-red-hat-openshift-logging-operator.adoc#installing-the-red-hat-openshift-logging-operator[Installing the {clo}]
-* xref:../installing/installing-the-loki-operator.adoc#installing-the-loki-operator[Installing the {loki-op}]

--- a/modules/logging-loki-storage.adoc
+++ b/modules/logging-loki-storage.adoc
@@ -25,13 +25,3 @@ The following table shows the `type` values within the `LokiStack` custom resour
 | {rh-storage}              | s3
 | Swift                     | swift
 |===
-
-[role="_additional-resources"]
-.Additional resources
-
-* link:https://aws.amazon.com/[AWS S3]
-* link:https://azure.microsoft.com[Azure]
-* link:https://cloud.google.com/[Google Cloud Storage]
-* link:https://min.io/[MinIO]
-* link:https://www.redhat.com/en/technologies/cloud-computing/openshift-data-foundation[{rh-storage}]
-* link:https://docs.openstack.org/swift/latest/[Swift]

--- a/modules/logging-operator-overview.adoc
+++ b/modules/logging-operator-overview.adoc
@@ -7,7 +7,7 @@
 = Logging operator overview
 
 [role="_abstract"]
-{product-title} provides three operators to deploy and manage {logging}. Each operator manages a distinct layer of the logging stack:
+{product-title} provides three Operators to deploy and manage {logging}. Each Operator manages a distinct layer of the logging stack:
 
 {loki-op}::
 Installs into the `openshift-operators-redhat` namespace. Manages the log store: receives, indexes, and stores logs in S3-compatible object storage by using a `LokiStack` instance.

--- a/modules/logging-storage-prerequisites.adoc
+++ b/modules/logging-storage-prerequisites.adoc
@@ -11,7 +11,7 @@ Before you begin the installation, ensure that you have the following:
 
 * Cluster administrator access to an {ocp-product-title} cluster.
 * The {oc-first} installed.
-* A *StorageClass* available in your cluster for LokiStack internal persistent volume claims (PVCs). Run `oc get storageclasses` to list available options. If no StorageClass exists, install one first. For bare metal or {sno} clusters, {lvms-first} can provide a StorageClass.
+* A *StorageClass* available in your cluster for `LokiStack` internal persistent volume claims (PVCs). Run `oc get storageclasses` to list available options. If no `StorageClass` exists, install one first. For bare metal or {sno} clusters, {lvms-first} can give a `StorageClass`.
 * Access to an *S3-compatible object store* for log data. Supported providers include {aws-short} S3, {azure-short}, {gcp-short}, MinIO, {rh-storage}, and Swift.
 
 [IMPORTANT]

--- a/modules/troubleshooting-logging-installation.adoc
+++ b/modules/troubleshooting-logging-installation.adoc
@@ -7,7 +7,7 @@
 = Troubleshooting the logging installation
 
 [role="_abstract"]
-The following table lists common issues that you might encounter when installing {logging} and their solutions.
+The following table lists common issues that you might get when installing {logging} and their solutions.
 
 [cols="2,3",options="header"]
 |===

--- a/modules/uninstalling-the-cluster-logging-operator.adoc
+++ b/modules/uninstalling-the-cluster-logging-operator.adoc
@@ -1,0 +1,9 @@
+// Module included in the following assemblies:
+// * uninstalling/uninstalling-logging.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="uninstalling-the-cluster-logging-operator_{context}"]
+= Uninstalling the {clo}
+
+[role="_abstract"]
+You can uninstall {clo} by using either the {oc-first} or the {product-title} web console.

--- a/modules/uninstalling-the-loki-operator.adoc
+++ b/modules/uninstalling-the-loki-operator.adoc
@@ -1,0 +1,9 @@
+// Module included in the following assemblies:
+// * uninstalling/uninstalling-logging.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="uninstalling-the-loki-operator_{context}"]
+= Uninstalling the {loki-op}
+
+[role="_abstract"]
+You can uninstall {loki-op} by using either the {oc-first} or the {product-title} web console. After uninstalling {loki-op}, delete persistent volume claims (PVCs) if you do not want to reuse them in other installations of `LokiStack`.

--- a/modules/uninstalling-the-uiplugin.adoc
+++ b/modules/uninstalling-the-uiplugin.adoc
@@ -1,0 +1,9 @@
+// Module included in the following assemblies:
+// * uninstalling/uninstalling-logging.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="uninstalling-the-uiplugin_{context}"]
+= Uninstalling the UIPlugin
+
+[role="_abstract"]
+You can uninstall `UIPlugin` by using either the {oc-first} or the {product-title} web console.

--- a/modules/verifying-logging-installation.adoc
+++ b/modules/verifying-logging-installation.adoc
@@ -27,11 +27,11 @@ You should see one collector pod per node in your cluster.
 $ oc logs -n openshift-logging -l app.kubernetes.io/component=collector --tail=20
 ----
 +
-Healthy output contains only `WARN` messages about small files. If you see `certificate verify failed`, verify the `tls.ca` block in your `ClusterLogForwarder`.
+Healthy output has only `WARN` messages about small files. If you see `certificate verify failed`, verify the `tls.ca` block in your `ClusterLogForwarder`.
 
 . Query logs from the web console:
 +
-Navigate to *Observe -> Logs* and run the following query:
+Click to *Observe -> Logs* and run the following query:
 +
 ----
 {log_type="infrastructure"}

--- a/uninstalling/uninstalling-logging.adoc
+++ b/uninstalling/uninstalling-logging.adoc
@@ -1,24 +1,21 @@
 :_mod-docs-content-type: ASSEMBLY
-include::_attributes/common-attributes.adoc[]
 [id="uninstalling-logging"]
 = Uninstalling logging
+include::_attributes/common-attributes.adoc[]
 :context: installing-logging
 
 toc::[]
 
-[id="uninstalling-the-cluster-logging-operator_{context}"]
-== Uninstalling the {clo}
+[role="_abstract"]
+The following section provides instructions to uninstall the {clo}, {loki-op}, and `UIPlugin` from your cluster.
 
-You can uninstall {clo} by using either the {oc-first} or the {product-title} web console.
+include::modules/uninstalling-the-cluster-logging-operator.adoc[leveloffset=+1]
 
 include::modules/deleting-the-cluster-logging-operator-by-using-the-cli.adoc[leveloffset=+2]
 
 include::modules/deleting-the-cluster-logging-operator-by-using-the-web-console.adoc[leveloffset=+2]
 
-[id="uninstalling-the-loki-operator_{context}"]
-== Uninstalling the {loki-op}
-
-You can uninstall {loki-op} by using either the {oc-first} or the {product-title} web console. After uninstalling {loki-op}, delete persistent volume claims (PVCs) if you do not want to reuse them in other installations of LokiStack.
+include::modules/uninstalling-the-loki-operator.adoc[leveloffset=+1]
 
 include::modules/deleting-the-loki-operator-by-using-the-cli.adoc[leveloffset=+2]
 
@@ -28,11 +25,13 @@ include::modules/deleting-logging-pvcs-by-using-the-cli.adoc[leveloffset=+2]
 
 include::modules/deleting-logging-pvcs-by-using-the-web-console.adoc[leveloffset=+2]
 
-[id="uninstalling-the-uiplugin_{context}"]
-== Uninstalling the UIPlugin
-
-You can uninstall `UIPlugin` by using either the {oc-first} or the {product-title} web console.
+include::modules/uninstalling-the-uiplugin.adoc[leveloffset=+1]
 
 include::modules/deleting-the-uiplugin-by-using-the-cli.adoc[leveloffset=+2]
 
 include::modules/deleting-the-uiplugin-by-using-the-web-console.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+== Additional resources
+
+* link:https://docs.redhat.com/en/documentation/openshift_container_platform/latest/html-single/storage/index#reclaim-manual_understanding-persistent-storage[Reclaiming a persistent volume manually]


### PR DESCRIPTION
**You can cherry-pick for the following branches:** 

- `standalone-logging-docs-6.5`
- `standalone-logging-docs-6.4`
- `standalone-logging-docs-6.2`
- `standalone-logging-docs-6.0`

**Note for the peer & merge reviewer:** 
- This PR updates the only "Installing & uninstalling logging" sections to prepare them for Phase 0 DITA migration.
- No other CQA changes, error types, or content refinements are included. 

**Changes:** 
This PR prepares the "Installing logging" section for Phase 0 DITA migration by applying Vale (AsciiDoc DITA) rules and cleaning up the existing content.

**Doc preview:** 
- [Installing](https://109497--ocpdocs-pr.netlify.app/openshift-logging/latest/installing/overview-of-openshift-logging-installation)
- [Uninstalling](https://109497--ocpdocs-pr.netlify.app/openshift-logging/latest/uninstalling/uninstalling-logging.html)

**Tracking JIRA:** https://redhat.atlassian.net/browse/OBSDOCS-3258

**Reviews:**
- [x] Peer has approved this change