### PR TITLE
OSDOCS-17013-abstracts-remediation-1

### DIFF
--- a/modules/bonding-multiple-network-interfaces-to-single-interface.adoc
+++ b/modules/bonding-multiple-network-interfaces-to-single-interface.adoc
@@ -47,7 +47,7 @@ ifndef::ibm-z-kvm[]
 = Bonding multiple network interfaces to a single interface
 
 [role="_abstract"]
-As an optional task, you can bond multiple network interfaces to a single interface by using the `bond=` option. By completing this task, you can eliminate a single point of failure for your network environment.
+As an optional task, you can bond multiple network interfaces to a single interface by using the `bond=` option.
 
 The following example demonstrates editing the `/etc/config/network` file and specifying the following syntax for bonding multiple network interfaces to a single interface:
 
@@ -67,7 +67,6 @@ When you create a bonded interface using the `bond=` command, you must specify h
 +
 [source,terminal]
 ----
-bond=bond0:em1,em2:mode=active-backup
 ip=bond0:dhcp
 ----
 
@@ -76,18 +75,18 @@ ip=bond0:dhcp
 ifndef::ibm-z[]
 [source,terminal]
 ----
-bond=bond0:em1,em2:mode=active-backup
 ip=10.10.10.2::10.10.10.254:255.255.255.0:core0.example.com:bond0:none
 ----
 endif::ibm-z[]
 ifdef::ibm-z[]
 [source,terminal]
 ----
-bond=bond0:em1,em2:mode=active-backup,fail_over_mac=1
-ip=10.10.10.2::10.10.10.254:255.255.255.0:core0.example.com:bond0:none
+bond=bond0:em1,em2:mode=active-backup 
+ip=10.10.10.2::10.10.10.254:255.255.255.0:core0.example.com:bond0:none::AA:BB:CC:DD:EE:FF ip=em1:none::AA:BB:CC:DD:EE:FF 
+ip=em2:none::AA:BB:CC:DD:EE:FF
 ----
 +
-Always set the `fail_over_mac=1` option in active-backup mode to avoid problems when shared OSA/RoCE cards are used.
+{ibm-z-title} supports value `1` for the `fail_over_mac` parameter, so always set the `fail_over_mac=1` option in active-backup mode to avoid problems when shared OSA/RoCE cards are used.
 endif::ibm-z[]
 
 ifdef::ibm-z[]

--- a/modules/bonding-multiple-network-interfaces-to-single-interface.adoc
+++ b/modules/bonding-multiple-network-interfaces-to-single-interface.adoc
@@ -47,7 +47,7 @@ ifndef::ibm-z-kvm[]
 = Bonding multiple network interfaces to a single interface
 
 [role="_abstract"]
-As an optional task, you can bond multiple network interfaces to a single interface by using the `bond=` option. By completing this task, you can eliminate a single point of failure for your network environment.
+As an optional task, you can bond multiple network interfaces to a single interface by using the `bond=` option.
 
 The following example demonstrates editing the `/etc/config/network` file and specifying the following syntax for bonding multiple network interfaces to a single interface:
 
@@ -67,7 +67,6 @@ When you create a bonded interface using the `bond=` command, you must specify h
 +
 [source,terminal]
 ----
-bond=bond0:em1,em2:mode=active-backup
 ip=bond0:dhcp
 ----
 
@@ -76,18 +75,19 @@ ip=bond0:dhcp
 ifndef::ibm-z[]
 [source,terminal]
 ----
-bond=bond0:em1,em2:mode=active-backup
 ip=10.10.10.2::10.10.10.254:255.255.255.0:core0.example.com:bond0:none
 ----
 endif::ibm-z[]
 ifdef::ibm-z[]
 [source,terminal]
 ----
-bond=bond0:em1,em2:mode=active-backup,fail_over_mac=1
-ip=10.10.10.2::10.10.10.254:255.255.255.0:core0.example.com:bond0:none
+bond=bond0:em1,em2:mode=active-backup 
+ip=10.10.10.2::10.10.10.254:255.255.255.0:core0.example.com:bond0:none::AA:BB:CC:DD:EE:FF 
+ip=em1:none::AA:BB:CC:DD:EE:FF
+ip=em2:none::AA:BB:CC:DD:EE:FF
 ----
 +
-Always set the `fail_over_mac=1` option in active-backup mode to avoid problems when shared OSA/RoCE cards are used.
+{ibm-z-title} supports value `1` for the `fail_over_mac` parameter, so always set the `fail_over_mac=1` option in active-backup mode to avoid problems when shared OSA/RoCE cards are used.
 endif::ibm-z[]
 
 ifdef::ibm-z[]

--- a/modules/bonding-multiple-sriov-network-interfaces-to-dual-port.adoc
+++ b/modules/bonding-multiple-sriov-network-interfaces-to-dual-port.adoc
@@ -47,10 +47,10 @@ endif::ibm-z,ibm-z-kvm[]
 
 [role="_abstract"]
 ifndef::ibm-z,ibm-z-kvm[]
-You can bond multiple SR-IOV network interfaces to a dual port NIC interface by using the `bond=` option. This task provides high availability capabilities to your network by preventing a single physical port from becoming a single point of failure. Ensure you apply the procedure tasks to each node.
+You can bond multiple SR-IOV network interfaces to a dual port NIC interface by using the `bond=` option. Ensure you apply the procedure tasks to each node.
 endif::ibm-z,ibm-z-kvm[]
 ifdef::ibm-z,ibm-z-kvm[]
-You can use network teaming as an alternative to bonding by using the `team=` parameter. Consider this task for servers that need highly customizable network logic and better performance in virtualized or high-traffic environments. 
+You can use network teaming as an alternative to bonding by using the `team=` parameter.
 endif::ibm-z,ibm-z-kvm[]
 
 .Procedure
@@ -78,7 +78,9 @@ The following examples illustrate the syntax you must use:
 [source,terminal]
 ----
 bond=bond0:eno1f0,eno2f0:mode=active-backup
-ip=bond0:dhcp
+ip=bond0:dhcp::AA:BB:CC:DD:EE:FF
+ip=eno1f0:none::AA:BB:CC:DD:EE:FF
+ip=eno2f0:none::AA:BB:CC:DD:EE:FF
 ----
 +
 ** To configure the bonded interface to use a static IP address, enter the specific IP address you want and related information. For example:

--- a/modules/installation-user-infra-machines-advanced-enabling-serial-console.adoc
+++ b/modules/installation-user-infra-machines-advanced-enabling-serial-console.adoc
@@ -25,8 +25,8 @@ ifndef::restricted[]
 [source,terminal]
 ----
 $ coreos-installer install \
---console=tty0 \//
---console=ttyS0,<options> \//
+--console=tty0 \
+--console=ttyS0,<options> \
 --ignition-url=http://host/worker.ign /dev/disk/by-id/scsi-<serial_number>
 ----
 endif::[]
@@ -34,8 +34,8 @@ ifdef::restricted[]
 [source,terminal]
 ----
 $ coreos-installer install \
---console=tty0 \//
---console=ttyS0,<options> \//
+--console=tty0 \
+--console=ttyS0,<options> \
 --ignition-url=http://host/worker.ign \
 --offline \
 /dev/disk/by-id/scsi-<serial_number>


### PR DESCRIPTION
A merge conflict error pulled in older content. My [CQA-OSDOCS-17013-bm-upi-3](https://github.com/openshift/openshift-docs/pull/103963) placed in older content. See the file modules/installation-user-infra-machines-static-network.adoc in OSDOCS-17013-bm-upi-3 (deleted so you'll need to expand it).


Version(s):
4.16+

Issue:
[OSDOCS-18622](https://redhat.atlassian.net/browse/OSDOCS-18622)

Link to docs preview:


https://github.com/openshift/openshift-docs/pull/93160/changes
