### PR TITLE
OCPBUGS-41488: Agent instructions for USB boot

### DIFF
--- a/modules/installing-ocp-agent-boot.adoc
+++ b/modules/installing-ocp-agent-boot.adoc
@@ -9,6 +9,10 @@
 
 Use this procedure to boot the agent image on your machines.
 
+.Prerequisites
+
+* If you plan to boot the agent image from a USB drive, you have installed the `syslinux` package.
+
 .Procedure
 
 . Create the agent image by running the following command:
@@ -20,4 +24,17 @@ $ openshift-install --dir <install_directory> agent create image
 +
 NOTE: Red Hat Enterprise Linux CoreOS (RHCOS) supports multipathing on the primary disk, allowing stronger resilience to hardware failure to achieve higher host availability. Multipathing is enabled by default in the agent ISO image, with a default `/etc/multipath.conf` configuration.
 
-. Boot the `agent.x86_64.iso`, `agent.aarch64.iso`, or `agent.s390x.iso` image on the bare metal machines.
+. If you plan to boot the ISO image from a USB drive, add a master boot record to the image by running the following command:
++
+[source,terminal]
+----
+$ isohybrid --uefi <agent_iso_image>
+----
++
+.Example command
+[source,terminal]
+----
+$ isohybrid --uefi agent.x86_64.iso
+----
+
+. Boot the `agent.x86_64.iso`, `agent.aarch64.iso`, or `agent.s390x.iso` image on the bare-metal machines.


### PR DESCRIPTION
[OCPBUGS-41488](https://redhat.atlassian.net/browse/OCPBUGS-41488) 

Version(s): 4.16+

This PR adds steps for how to get Agent ISO images to work when booting from a USB drive.

QE review:
- [x] QE has approved this change.

Preview:  [Creating and booting the agent image](https://109528--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_with_agent_based_installer/installing-with-agent-basic.html#installing-ocp-agent-boot_installing-with-agent-basic)