### PR TITLE
OSDOCS-18975: adds ConceptLink rule to CI

### DIFF
--- a/.vale.ini
+++ b/.vale.ini
@@ -23,6 +23,7 @@ AsciiDocDITA.AssemblyContents = error
 AsciiDocDITA.AuthorLine = error
 AsciiDocDITA.BlockTitle = error
 AsciiDocDITA.CalloutList = error
+AsciiDocDITA.ConceptLink = error
 AsciiDocDITA.ContentType = error
 AsciiDocDITA.DiscreteHeading = error
 AsciiDocDITA.DocumentID = error

--- a/modules/.vale.ini
+++ b/modules/.vale.ini
@@ -13,6 +13,7 @@ AsciiDocDITA.AssemblyContents = error
 AsciiDocDITA.AuthorLine = error
 AsciiDocDITA.BlockTitle = error
 AsciiDocDITA.CalloutList = error
+AsciiDocDITA.ConceptLink = error
 AsciiDocDITA.ContentType = error
 AsciiDocDITA.DiscreteHeading = error
 AsciiDocDITA.DocumentID = error


### PR DESCRIPTION
Version(s):
4.16-4.22

Issue:
https://redhat.atlassian.net/browse/OSDOCS-18975

Link to docs preview:
N/A

QE review:
N/A

Additional information:
Adds ConceptLink rule to OpenShift for DITA conversion tasks.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
