### PR TITLE
DOCPLAN-82: Fix vale issues in virt-creating-linux-bridge-nncp.adoc

### DIFF
--- a/modules/virt-creating-linux-bridge-nncp.adoc
+++ b/modules/virt-creating-linux-bridge-nncp.adoc
@@ -46,13 +46,13 @@ spec:
 ** `spec.desiredState.interfaces.type` defines the interface type. In this example, the type is a Linux bridge.
 ** `spec.desiredState.interfaces.state` defines the requested state for the interface after creation.
 ** `spec.desiredState.interfaces.ipv4.enabled` defines whether the ipv4 protocol is active. Setting this to `false` disables IPv4 addressing on this bridge.
-** `spec.desiredState.interfaces.bridge.options.stp.enabled` defines whether STP is active. Setting this to `false` disables STP on this bridge.
-** `spec.desiredState.interfaces.bridge.port.name` defines the node NIC to which the bridge is attached.
+** `spec.desiredState.interfaces.bridge.options.stp.enabled` defines whether Spanning Tree Protocol (STP) is active. Setting this to `false` disables STP on this bridge.
+** `spec.desiredState.interfaces.bridge.port.name` defines the node NIC that the bridge is attached to.
 +
 ifndef::openshift-dedicated[]
 [NOTE]
 ====
-To create the NNCP manifest for a Linux bridge using OSA with {ibm-z-name}, you must disable VLAN filtering by the setting the `rx-vlan-filter` to `false` in the `NodeNetworkConfigurationPolicy` manifest.
+To create the NNCP manifest for a Linux bridge using Open Systems Adapter (OSA) with {ibm-z-name}, you must disable VLAN filtering by the setting the `rx-vlan-filter` to `false` in the `NodeNetworkConfigurationPolicy` manifest.
 
 Alternatively, if you have SSH access to the node, you can disable VLAN filtering by running the following command:
 


### PR DESCRIPTION
Version(s):
4.16+

Issue:
https://redhat.atlassian.net/browse/DOCPLAN-82

Link to docs preview:
https://109574--ocpdocs-pr.netlify.app/openshift-dedicated/latest/virt/post_installation_configuration/virt-post-install-network-config.html

QE review:
N/A, DITA / vale updates only

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
