### PR TITLE
[OSDOCS#16167]: Added content for Installing CSI driver using CLI

### DIFF
--- a/modules/persistent-storage-csi-secrets-store-driver-install-cli.adoc
+++ b/modules/persistent-storage-csi-secrets-store-driver-install-cli.adoc
@@ -1,0 +1,53 @@
+// Module included in the following assemblies:
+//
+// * storage/container_storage_interface/persistent-storage-csi-secrets-store.adoc
+//
+
+:_mod-docs-content-type: PROCEDURE
+[id="persistent-storage-csi-secrets-store-driver-install-cli_{context}"]
+= Installing the {secrets-store-driver} by using the CLI
+
+[role="_abstract"]
+The {secrets-store-driver} is typically installed in namespace `openshift-cluster-csi-drivers` which is already present in the cluster as part of installation of the cluster storage Operator.
+
+.Prerequisites
+
+The namespace and the operatorgroup must exist already.
+
+.Procedure
+
+. Create a `Subscription` object by defining a YAML file with the following content:
++
+The following is an example of a `subscription.yaml` file.
++
+[source,yaml]
+----
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: secrets-store-csi-driver-operator
+  namespace: openshift-cluster-csi-drivers
+spec:
+  channel: stable
+  installPlanApproval: Automatic
+  name: secrets-store-csi-driver-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+----
+
+. create the driver with a command:
++
+[source,terminal]
+----
+$ cat <<EOF | oc apply -f -
+----
++
+[source,yaml]
+----
+apiVersion: operator.openshift.io/v1
+kind: ClusterCSIDriver
+metadata:
+  name: secrets-store.csi.k8s.io
+spec:
+  managementState: Managed
+----

--- a/storage/container_storage_interface/persistent-storage-csi-secrets-store.adoc
+++ b/storage/container_storage_interface/persistent-storage-csi-secrets-store.adoc
@@ -28,6 +28,8 @@ include::modules/persistent-storage-csi-secrets-store-network-policies.adoc[leve
 
 include::modules/persistent-storage-csi-secrets-store-driver-install.adoc[leveloffset=+1]
 
+include::modules/persistent-storage-csi-secrets-store-driver-install-cli.adoc[leveloffset=+1]
+
 .Next steps
 
 * xref:../../nodes/pods/nodes-pods-secrets-store.adoc#mounting-secrets-external-secrets-store[Mounting secrets from an external secrets store to a CSI volume]


### PR DESCRIPTION
Version(s):
4.22

Issue:
https://redhat.atlassian.net/browse/OSDOCS-16167

Link to docs preview:
https://109587--ocpdocs-pr.netlify.app/openshift-enterprise/latest/storage/container_storage_interface/persistent-storage-csi-secrets-store.html#persistent-storage-csi-secrets-store-driver-install-cli_persistent-storage-csi-secrets-store

QE review:
- [ ] QE has approved this change.

