### PR TITLE
OSDOCS#18595: Improve documentation for ESO network policy

### DIFF
--- a/security/external_secrets_operator/external-secrets-operator-config-net-policy.adoc
+++ b/security/external_secrets_operator/external-secrets-operator-config-net-policy.adoc
@@ -7,7 +7,7 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 [role="_abstract"]
-The {external-secrets-operator} includes pre-defined `NetworkPolicies` for security, but you must configure additional, custom policies through the `ExternalSecretsConfig` custom resource to set the external-secrets controller egress allow policies to communicate with external providers. These configurable policies are set via the `ExternalSecretsConfig` custom resource to establish the egress allow policy.
+The {external-secrets-operator} for {product-title} includes pre-defined `NetworkPolicies` for security that rejects all egress traffic and allows traffic towards services that are required for the operand functionality. You must configure additional custom policies to allow the `external-secrets` controller to egress traffic towards external providers. These configurable policies are set through the `ExternalSecretsConfig` custom resource to establish the egress allow policy.
 
 // Adding network policy to connect to permit all egress traffic
 include::modules/external-secrets-operator-egress-allow-all-traffic.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s):
4.18+

Issue:
https://redhat.atlassian.net/browse/OSDOCS-18595?actionerId=63c10c428a7d2f693bf779a3&sourceType=assign

Link to docs preview:
https://109598--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/external_secrets_operator/external-secrets-operator-config-net-policy.html

QE review:
- [x] QE has approved this change.