### PR TITLE
CQA 2.1 Quality check for Uninstall section with feedback incorporation

### DIFF
--- a/modules/ob-deleting-the-builds-component-and-custom-resources.adoc
+++ b/modules/ob-deleting-the-builds-component-and-custom-resources.adoc
@@ -34,3 +34,8 @@ Deleting the CRs deletes the {builds-shortname} controller and all the related c
 .Verification
 
 * On the *Custom Resource Definition* page, verify that CRDs related to the {builds-operator} are not displayed when you filter by `shipwright.io`.
+
+[role="_additional-resources"]
+.Additional resources
+
+* link:https://docs.redhat.com/en/documentation/openshift_container_platform/latest/html/operators/understanding-operators#crd-managing-resources-from-crds[Managing resources from custom resource definitions]

--- a/modules/ob-uninstalling-the-builds-operator.adoc
+++ b/modules/ob-uninstalling-the-builds-operator.adoc
@@ -29,3 +29,8 @@ You can uninstall the {builds-operator} by using the *Administrator* perspective
 . Go to *Operators* -> *Installed Operators*.
 
 . Verify that *{builds-operator}* is not listed on the *Installed Operators* page.
+
+[role="_additional-resources"]
+.Additional resources
+
+* link:https://docs.redhat.com/en/documentation/openshift_container_platform/latest/html/operators/administrator-tasks#olm-deleting-operators-from-a-cluster[Deleting Operators from a cluster]

--- a/uninstalling/uninstalling-openshift-builds.adoc
+++ b/uninstalling/uninstalling-openshift-builds.adoc
@@ -8,14 +8,8 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 [role="_abstract"]
-As a cluster administrator, delete the default custom resources (CRs) and then uninstall the Operator to completely remove the {builds-operator}. This ensures that all associated {builds-shortname} components are removed from your cluster.
+As a cluster administrator, delete the default custom resources (CRs) and then uninstall the Operator. This completely removes the {builds-operator} and all associated {builds-shortname} components from your cluster.
 
 include::modules/ob-deleting-the-builds-component-and-custom-resources.adoc[leveloffset=+1]
 
 include::modules/ob-uninstalling-the-builds-operator.adoc[leveloffset=+1]
-
-
-[role="_additional-resources"]
-.Additional resources
-
-* link:https://docs.openshift.com/container-platform/latest/operators/admin/olm-deleting-operators-from-cluster.html#olm-deleting-operators-from-a-cluster[Deleting Operators from a cluster]


### PR DESCRIPTION
Version(s): Builds 1.5, 1.6, 1.7

Issue: https://redhat.atlassian.net/browse/RHDEVDOCS-7390

Link to docs preview: Minor CQA updates, does not require QE approval.

Preview: https://109600--ocpdocs-pr.netlify.app/openshift-builds/latest/uninstalling/uninstalling-openshift-builds.html

Additional information: 
[CQA_Assessment_Report_uninstalling-openshift-builds.md](https://github.com/user-attachments/files/26503739/CQA_Assessment_Report_uninstalling-openshift-builds.md)
