### PR TITLE
Document authentication reqs in openapi schema

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -34,6 +34,8 @@ Distros: openshift-lightspeed
 Topics:
 - Name: Using OpenShift Lightspeed
   File: ols-using-openshift-lightspeed
+- Name: Operate OpenShift Lightspeed
+  File: ols-interacting-with-the-api
 ---
 Name: Troubleshoot
 Dir: troubleshoot

--- a/configure/ols-configuring-openshift-lightspeed.adoc
+++ b/configure/ols-configuring-openshift-lightspeed.adoc
@@ -45,6 +45,8 @@ include::modules/ols-granting-user-group-access-by-using-cli.adoc[leveloffset=+2
 
 include::modules/ols-granting-user-group-access-by-using-configuration-file.adoc[leveloffset=+2]
 
+include::modules/ols-obtain-lightspeed-authentication-token.adoc[leveloffset=+2]
+
 include::modules/ols-filtering-and-redacting-information.adoc[leveloffset=+1]
 
 include::modules/ols-about-the-byo-knowledge-tool.adoc[leveloffset=+1]

--- a/modules/ols-api-authentication-matrix.adoc
+++ b/modules/ols-api-authentication-matrix.adoc
@@ -1,0 +1,26 @@
+// Module included in the following assemblies:
+// lightspeed-docs-main/operate/ols-using-openshift-lightspeed.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="ols-api-authentication-matrix_{context}"]
+= {ols-long} API authentication requirements
+
+[role="_abstract"]
+
+The following table lists the {ols-long} endpoints and their authentication requirements.
+
+[cols="3,1,1,2",options="header"]
+|===
+| Endpoint | Method | Authentication Required | Virtual Path
+
+| `/v1/query` | POST | Yes | `/ols-access`
+| `/v1/streaming_query` | POST | Yes | `/ols-access`
+| `/v1/conversations` | GET, PUT, DELETE | Yes | `/ols-access`
+| `/v1/feedback` | POST | Yes | `/ols-access`
+| `/v1/mcp-apps/resources` | POST | Yes | `/ols-access`
+| `/v1/mcp-apps/tools/call` | POST | Yes | `/ols-access`
+| `/authorized` | POST | Yes | `/ols-access`
+| `/metrics` | GET | No | —
+| `/readiness` | GET | No | —
+| `/liveness` | GET | No | —
+|===

--- a/modules/ols-authenticate-api-requests.adoc
+++ b/modules/ols-authenticate-api-requests.adoc
@@ -1,0 +1,29 @@
+// Module included in the following assemblies:
+// lightspeed-docs-main/operate/ols-using-openshift-lightspeed.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="ols-authenticate-api-requests_{context}"]
+= Authenticate API requests
+
+[role="_abstract"]
+
+Authenticate every request to a protected {ols-long} endpoint by including a bearer token in the `Authorization` header to ensure secure access to the API.
+
+.Procedure
+
+. Set the `Authorization` header using the following format:
++
+[source,text]
+----
+Authorization: Bearer <token>
+----
+
+. Submit the request. The following example demonstrates a query sent through `curl`:
++
+[source,bash]
+----
+curl -H "Authorization: Bearer ${TOKEN}" \
+     -H "Content-Type: application/json" \
+     https://<ols_host>/v1/query \
+     -d '{"query": "How do I create a deployment?"}'
+----

--- a/modules/ols-obtain-lightspeed-authentication-token.adoc
+++ b/modules/ols-obtain-lightspeed-authentication-token.adoc
@@ -1,0 +1,31 @@
+// Module included in the following assemblies:
+// * lightspeed-docs-main/configure/ols-configuring-openshift-lightspeed.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="ols-obtain-lightspeed-authentication-token_{context}"]
+= Obtain {ols-long} authentication token
+
+[role="_abstract"]
+Obtain a {k8s} bearer token by using the oc command-line interface to authenticate your requests to the {ols-long} API.
+
+.Procedure
+
+Perform any of the following tasks to retrieve your token:
+
+* Using the {ocp-short-name} CLI (`oc`):
++
+Run the following command to retrieve the token for your current session:
++
+[source,bash]
+----
+TOKEN=$(oc whoami -t)
+----
+
+* Using the {k8s} CLI (`kubectl`):
++
+Run the following command to create a token for a specific service account:
++
+[source,bash]
+----
+TOKEN=$(kubectl create token _<service_account_name>_ -n _<namespace>_)
+----

--- a/modules/ols-provide-authentication-mcp-server.adoc
+++ b/modules/ols-provide-authentication-mcp-server.adoc
@@ -1,0 +1,28 @@
+// Module included in the following assemblies:
+// lightspeed-docs-main/operate/ols-using-openshift-lightspeed.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="ols-provide-authentication-mcp-server_{context}"]
+= Provide authentication for MCP servers
+
+[role="_abstract"]
+
+Authenticate proxy calls to Model Context Protocol (MCP) servers by identifying required headers and including credentials in your API request body.
+
+.Procedure
+
+. Identify required headers by calling the following endpoint:
++
+`GET /v1/mcp/client-auth-headers`
+
+. Include the required credentials in the `mcp_headers` field of your JSON request body:
++
+[source,json]
+----
+{
+  "query": "Show GitHub issues",
+  "mcp_headers": {
+    "github-mcp": {"Authorization": "Bearer <github_token>"}
+  }
+}
+----

--- a/modules/ols-troubleshoot-api-authentication-failures.adoc
+++ b/modules/ols-troubleshoot-api-authentication-failures.adoc
@@ -1,0 +1,27 @@
+// Module included in the following assemblies:
+// lightspeed-docs-main/troubleshoot/ols-troubleshooting-openshift-lightspeed.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="ols-troubleshoot-api-authentication-failures_{context}"]
+= Troubleshoot API authentication failures
+
+[role="_abstract"]
+
+Use the status codes and error details to identify and resolve common authentication failures when connecting to the {ols-long} API.
+
+[cols="1,2,2",options="header"]
+|===
+| Status code | Description | Example detail
+
+| *401 Unauthorized*
+| The `Authorization` header is missing, malformed, or does not use the `Bearer` scheme.
+| `Unauthorized: No auth header found`
+
+| *403 Forbidden*
+| The token is invalid, expired, or the user lacks RBAC permissions for the `/ols-access` path.
+| `Forbidden: User does not have access`
+
+| *500 Internal Error*
+| An unexpected error occurred through the Kubernetes `TokenReview` process.
+| `Forbidden: Unable to Review Token`
+|===

--- a/operate/ols-interacting-with-the-api.adoc
+++ b/operate/ols-interacting-with-the-api.adoc
@@ -1,0 +1,17 @@
+:_content-type: ASSEMBLY
+[id="ols-interacting-with-the-api"]
+= Interacting with the API
+include::_attributes/common-attributes.adoc[]
+:context: ols-interacting-with-the-api
+
+toc::[]
+
+[role="_abstract"]
+
+Secure your interaction with the {ols-long} API by obtaining authentication tokens, configuring request headers for Model Context Protocol (MCP) servers, and troubleshooting common authentication errors.
+
+include::modules/ols-authenticate-api-requests.adoc[leveloffset=+1]
+
+include::modules/ols-provide-authentication-mcp-server.adoc[leveloffset=+1]
+
+include::modules/ols-api-authentication-matrix.adoc[leveloffset=+1]

--- a/troubleshoot/ols-troubleshooting-openshift-lightspeed.adoc
+++ b/troubleshoot/ols-troubleshooting-openshift-lightspeed.adoc
@@ -16,3 +16,5 @@ include::modules/ols-502-bad-gateway-errors.adoc[leveloffset=+1]
 include::modules/ols-operator-missing-from-operatorhub-list.adoc[leveloffset=+1]
 
 include::modules/ols-thinking-model-generates-delineator-prompt.adoc[leveloffset=+1]
+
+include::modules/ols-troubleshoot-api-authentication-failures.adoc[leveloffset=+1]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
lightspeed-docs-main and CP to lightspeed-docs-1.0

Issue:
[OLS-2173](https://redhat.atlassian.net/browse/OLS-2173)

Link to docs preview:
- **Configure**: https://109613--ocpdocs-pr.netlify.app/openshift-lightspeed/latest/configure/ols-configuring-openshift-lightspeed#ols-obtain-lightspeed-authentication-token_ols-configuring-openshift-lightspeed
- **Operate**: https://109613--ocpdocs-pr.netlify.app/openshift-lightspeed/latest/operate/ols-interacting-with-the-api
- **Troubleshooting**: https://109613--ocpdocs-pr.netlify.app/openshift-lightspeed/latest/troubleshoot/ols-troubleshooting-openshift-lightspeed#ols-troubleshoot-api-authentication-failures_ols-troubleshooting-openshift-lightspeed

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
