### PR TITLE
DOCPLAN-161: CQA live_migration

### DIFF
--- a/modules/nw-multus-bridge-object.adoc
+++ b/modules/nw-multus-bridge-object.adoc
@@ -74,7 +74,7 @@ ifndef::microshift[]
 
 |`preserveDefaultVlan`
 |`string`
-|Optional: Indicates whether the default vlan must be preserved on the `veth` end connected to the bridge. Defaults to `false`.
+|Optional: Indicates whether the default VLAN must be preserved on the `veth` end connected to the bridge. Defaults to `false`.
 
 |`vlanTrunk`
 |`list`

--- a/modules/virt-configuring-live-migration-heavy.adoc
+++ b/modules/virt-configuring-live-migration-heavy.adoc
@@ -8,13 +8,9 @@
 = Configure live migration for heavy workloads
 
 [role="_abstract"]
-When migrating a VM running a heavy workload (for example, database processing) with higher memory dirty rates, you need a higher bandwidth to complete the migration.
+When migrating a VM running a heavy workload, such as database processing, higher memory dirty rates can prevent the migration from completing. To address this, you can enable post copy mode, which allows the migration to complete when the pre-copy phase cannot converge.
 
-If the dirty rate is too high, the migration from one node to another does not converge. To prevent this, enable post copy mode.
-
-Post copy mode triggers if the initial pre-copy phase does not complete within the defined timeout. During post copy, the VM CPUs pause on the source host while transferring the minimum required memory pages. Then the VM CPUs activate on the destination host, and the remaining memory pages transfer into the destination node at runtime.
-
-Configure live migration for heavy workloads by updating the `HyperConverged` custom resource (CR), which is located in the `{CNVNamespace}` namespace.
+Configure live migration for heavy workloads by updating the `HyperConverged` custom resource (CR) in the `{CNVNamespace}` namespace.
 
 .Prerequisites
 

--- a/modules/virt-initiating-vm-migration-cli.adoc
+++ b/modules/virt-initiating-vm-migration-cli.adoc
@@ -35,7 +35,7 @@ spec:
 $ oc create -f <migration_name>.yaml
 ----
 +
-The `VirtualMachineInstanceMigration` object triggers a live migration of the VM. This object exists in the cluster for as long as the virtual machine instance is running, unless manually deleted.
+The `VirtualMachineInstanceMigration` object triggers a live migration of the VM. This object exists in the cluster only while the virtual machine instance is running, unless manually deleted.
 
 .Verification
 

--- a/modules/virt-initiating-vm-migration-web.adoc
+++ b/modules/virt-initiating-vm-migration-web.adoc
@@ -17,7 +17,7 @@ The *Migrate* action is visible to all users but only cluster administrators can
 .Prerequisites
 
 * You have the `kubevirt.io:migrate` RBAC role or you are a cluster administrator.
-* The VM is migratable.
+* The VM is able to be migrated.
 * If the VM is configured with a host model CPU, the cluster has an available node that supports the CPU model.
 
 .Procedure

--- a/virt/live_migration/virt-about-live-migration.adoc
+++ b/virt/live_migration/virt-about-live-migration.adoc
@@ -21,7 +21,8 @@ include::modules/virt-granting-live-migration-permissions.adoc[leveloffset=+1]
 
 include::modules/virt-vm-migration-tuning.adoc[leveloffset=+1]
 
-[id="additional-resources_virt-about-live-migration"]
+[role="_additional-resources"]
+[id="additional-resources_{context}"]
 == Additional resources
 * xref:../../virt/about_virt/virt-security-policies.adoc#default-cluster-roles-for-virt_virt-security-policies[Default cluster roles for {VirtProductName}]
 * xref:../../virt/monitoring/virt-prometheus-queries.adoc#virt-live-migration-metrics_virt-prometheus-queries[Prometheus queries for live migration]

--- a/virt/live_migration/virt-about-mtv-providers.adoc
+++ b/virt/live_migration/virt-about-mtv-providers.adoc
@@ -8,12 +8,15 @@ include::_attributes/attributes-openshift-dedicated.adoc[]
 toc::[]
 
 [role="_abstract"]
-To migrate a virtual machine (VM) across {product-title} clusters, you must configure an {product-title} provider for each cluster that you are including in the migration. If MTV is already installed on a cluster, a local provider already exists.
-
-.Next steps
-
-* See link:https://docs.redhat.com/en/documentation/migration_toolkit_for_virtualization/2.9/html-single/installing_and_using_the_migration_toolkit_for_virtualization/index#adding-source-provider_cnv[Adding a Red Hat {VirtProductName} source provider] and link:https://docs.redhat.com/en/documentation/migration_toolkit_for_virtualization/2.9/html-single/installing_and_using_the_migration_toolkit_for_virtualization/index#adding-source-provider_dest_cnv[Adding an {VirtProductName} destination provider].
+To migrate a virtual machine (VM) across {product-title} clusters, you must configure an {product-title} provider for each cluster that you are including in the migration. If {mtv-short} is already installed on a cluster, a local provider already exists.
 
 include::modules/virt-configuring-root-ca-for-providers.adoc[leveloffset=+1]
 
 include::modules/virt-creating-long-lived-account-and-token.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+[id="additional-resources_{context}"]
+== Additional resources
+
+* link:https://docs.redhat.com/en/documentation/migration_toolkit_for_virtualization/2.9/html-single/installing_and_using_the_migration_toolkit_for_virtualization/index#adding-source-provider_cnv[Adding a Red Hat {VirtProductName} source provider]
+* link:https://docs.redhat.com/en/documentation/migration_toolkit_for_virtualization/2.9/html-single/installing_and_using_the_migration_toolkit_for_virtualization/index#adding-source-provider_dest_cnv[Adding an {VirtProductName} destination provider]

--- a/virt/live_migration/virt-configuring-live-migration.adoc
+++ b/virt/live_migration/virt-configuring-live-migration.adoc
@@ -8,9 +8,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-You can configure live migration settings to ensure that the migration processes do not overwhelm the cluster.
-
-You can configure live migration policies to apply different migration configurations to groups of virtual machines (VMs).
+[role="_abstract"]
+You can configure live migration settings to ensure that the migration processes do not overwhelm the cluster. You can configure live migration policies to apply different migration configurations to groups of virtual machines (VMs).
 
 include::modules/virt-configuring-live-migration-limits.adoc[leveloffset=+1]
 

--- a/virt/live_migration/virt-enabling-cclm-for-vms.adoc
+++ b/virt/live_migration/virt-enabling-cclm-for-vms.adoc
@@ -7,10 +7,11 @@ include::_attributes/attributes-openshift-dedicated.adoc[]
 
 toc::[]
 
-[role=”_abstract”]
+[role="_abstract"]
 Cross-cluster live migration enables users to move a virtual machine (VM) workload from one {product-title} cluster to another cluster without disruption.
 
-.Prerequisites
+[id="prerequisites_{context}"]
+== Prerequisites
 
 * {VirtProductName} 4.20 or later must be installed.
 

--- a/virt/live_migration/virt-initiating-live-migration.adoc
+++ b/virt/live_migration/virt-initiating-live-migration.adoc
@@ -9,31 +9,29 @@ toc::[]
 [role="_abstract"]
 To move a running virtual machine (VM) to a different node without interrupting the workload, you can initiate a live migration. You can also cancel an ongoing migration to keep the VM on its original node.
 
-You can initiate the live migration of a virtual machine (VM) to another node by using the xref:../../virt/live_migration/virt-initiating-live-migration.adoc#virt-initiating-vm-migration-web_virt-initiating-live-migration[{product-title} web console] or the xref:../../virt/live_migration/virt-initiating-live-migration.adoc#virt-initiating-vm-migration-cli_virt-initiating-live-migration[command line].
+You can initiate the live migration of a virtual machine (VM) to another node by using the {product-title} web console or the command line.
 
-You can cancel a live migration by using the xref:../../virt/live_migration/virt-initiating-live-migration.adoc#virt-canceling-vm-migration-web_virt-initiating-live-migration[web console] or the xref:../../virt/live_migration/virt-initiating-live-migration.adoc#virt-canceling-vm-migration-cli_virt-initiating-live-migration[command line]. The VM remains on its original node.
+You can cancel a live migration by using the web console or the command line. The VM remains on its original node.
 
 [TIP]
 ====
 You can also initiate and cancel live migration by using the `virtctl migrate <vm_name>` and `virtctl migrate-cancel <vm_name>` commands.
 ====
 
-[id="initating-live-migration_initiating-canceling"]
-== Initiating live migration
+include::modules/virt-initiating-vm-migration-web.adoc[leveloffset=+1]
 
-include::modules/virt-initiating-vm-migration-web.adoc[leveloffset=+2]
+include::modules/virt-initiating-vm-migration-cli.adoc[leveloffset=+1]
 
-include::modules/virt-initiating-vm-migration-cli.adoc[leveloffset=+2]
+include::modules/virt-canceling-vm-migration-web.adoc[leveloffset=+1]
 
-[id="canceling-live-migration_initiating-canceling"]
-== Canceling live migration
-
-include::modules/virt-canceling-vm-migration-web.adoc[leveloffset=+2]
-
-include::modules/virt-canceling-vm-migration-cli.adoc[leveloffset=+2]
+include::modules/virt-canceling-vm-migration-cli.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 [id="additional-resources_{context}"]
 == Additional resources
 
 * xref:../../virt/live_migration/virt-about-live-migration.adoc#virt-about-live-migration-permissions_virt-about-live-migration[About live migration permissions]
+* xref:../../virt/live_migration/virt-initiating-live-migration.adoc#virt-initiating-vm-migration-web_virt-initiating-live-migration[Initiating live migration by using the web console]
+* xref:../../virt/live_migration/virt-initiating-live-migration.adoc#virt-initiating-vm-migration-cli_virt-initiating-live-migration[Initiating live migration by using the CLI]
+* xref:../../virt/live_migration/virt-initiating-live-migration.adoc#virt-canceling-vm-migration-web_virt-initiating-live-migration[Canceling live migration by using the web console]
+* xref:../../virt/live_migration/virt-initiating-live-migration.adoc#virt-canceling-vm-migration-cli_virt-initiating-live-migration[Canceling live migration by using the CLI]


### PR DESCRIPTION
Version(s):
4.20+

Issue:
https://redhat.atlassian.net/browse/DOCPLAN-161

Link to docs preview:
* https://109615--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/live_migration/virt-about-live-migration.html
* https://109615--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/live_migration/virt-about-mtv-providers.html
* https://109615--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/live_migration/virt-configuring-live-migration.html
* https://109615--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/live_migration/virt-enabling-cclm-for-vms.html
* https://109615--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/live_migration/virt-initiating-live-migration.html

Additional information:
These are related tasks that are essentially all dupes for the live_migration CQA work. Leaving them here for posterity
* https://redhat.atlassian.net/browse/DOCPLAN-107
* https://redhat.atlassian.net/browse/DOCPLAN-109
* https://redhat.atlassian.net/browse/DOCPLAN-110
* https://redhat.atlassian.net/browse/DOCPLAN-160
* https://redhat.atlassian.net/browse/DOCPLAN-162
* https://redhat.atlassian.net/browse/DOCPLAN-163
