### PR TITLE
OSSM 12576:  Corrected OCP version for 3.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,5 +16,6 @@ bin
 commercial_package
 .vscode
 .vale/styles/AsciiDoc
+.vale/styles/AsciiDocDITA
 .vale/styles/OpenShiftAsciiDoc
 .vale/styles/RedHat

--- a/modules/ossm-supported-platforms.adoc
+++ b/modules/ossm-supported-platforms.adoc
@@ -11,10 +11,10 @@
 The following platform versions support {SMProductShortName} control plane version {SMProductVersion}:
 
 ifdef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
-* Red Hat OpenShift Container Platform version 4.16 or later
+* Red Hat OpenShift Container Platform version 4.18 or later
 endif::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 ifndef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
-* Red Hat {ocp-product-title} version 4.16 or later
+* Red Hat {ocp-product-title} version 4.18 or later
 endif::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 * {product-dedicated} version 4
 * Azure Red Hat OpenShift (ARO) version 4


### PR DESCRIPTION
OSSM 12576: Incorrect Red Hat OpenShift Container Platform version mentioned in OSSM documentation

Version(s):
3.2

Issue:
https://redhat.atlassian.net/browse/OSSM-12576

Link to docs preview:
https://109616--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/install/ossm-supported-platforms-configurations.html#ossm-supported-platforms_ossm-supported-platforms-configurations

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
