### PR TITLE
OSDOCS-18938: adds creating virt servers to MCP gateway docs

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -77,6 +77,8 @@ Topics:
   File: mcp-gateway-register-on-prem-mcp-servers
 - Name: Registering external MCP servers
   File: mcp-gateway-register-ext-mcp-servers
+- Name: Creating virtual MCP servers
+  File: mcp-gateway-creating-virtual-mcp-servers
 - Name: Configuring authentication for the MCP gateway
   File: mcp-gateway-authz
 - Name: Configuring authentication for the MCP gateway

--- a/mcp_gateway_config/mcp-gateway-creating-virtual-mcp-servers.adoc
+++ b/mcp_gateway_config/mcp-gateway-creating-virtual-mcp-servers.adoc
@@ -1,0 +1,18 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="mcp-gateway-create-virtual-mcp-servers"]
+= Creating virtual MCP servers
+include::_attributes/attributes.adoc[]
+:context: mcp-gateway-register-virtual-mcp-servers
+
+[role="_abstract"]
+Create focused, curated tool collections from your aggregated internal and external MCP servers by creating virtual MCP servers from any of your registered MCP servers.
+
+include::modules/con-register-virt-mcp-server.adoc[leveloffset=+1]
+
+include::modules/con-virt-mcp-server-auth-tool-filtering.adoc[leveloffset=+1]
+
+include::modules/proc-mcp-gateway-create-virt-mcp-server.adoc[leveloffset=+1]
+
+include::modules/proc-verify-virt-mcp-server.adoc[leveloffset=+1]
+
+include::modules/proc-mcp-gateway-delete-virtual-server.adoc[leveloffset=+1]

--- a/mcp_gateway_config/mcp-gateway-register-on-prem-mcp-servers.adoc
+++ b/mcp_gateway_config/mcp-gateway-register-on-prem-mcp-servers.adoc
@@ -2,7 +2,7 @@
 [id="mcp-gateway-register-on-prem-mcp-servers"]
 = Registering on-prem MCP servers
 include::_attributes/attributes.adoc[]
-:context: mcp-gateway-register-servers
+:context: mcp-gateway-register-on-prem-servers
 
 [role="_abstract"]
 To begin using MCP servers with your {mcpg}, you must register each server by creating an `HTTPRoute` custom resource (CR) and a corresponding `MCPServerRegistration` CR that references the route.

--- a/modules/con-register-virt-mcp-server.adoc
+++ b/modules/con-register-virt-mcp-server.adoc
@@ -1,0 +1,21 @@
+
+// Module included in the following assemblies:
+//
+// *mcp_gateway_config/mcp-gateway-register-virtual-mcp-servers.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="con-create-virt-mcp-server_{context}"]
+= About virtual MCP servers
+
+[role="_abstract"]
+When you aggregate all your MCP servers centrally, you solve for authentication, authorization, and configuration management. At the same time, this aggregation can overwhelm large-language models (LLMs) and AI agents with too many tool choices. You can create virtual MCP servers to curate tools for each situation.
+
+You can narrow the scope for your agentic services and applications by creating virtual MCP servers that filter the complete tool list based on a curated selection and access only the relevant tools with HTTP headers. You can use virtual MCP servers to accomplish the following efficiencies:
+
+* Create specialized collections of tools for specific use cases.
+* Reduce the load on LLMs by presenting fewer, more relevant tools.
+* Group tools by function, for example, development tools, data analysis tools, and so on.
+* Make it easier for users and agents to find the right tools.
+* Combine with authorization policies for fine-grained access management.
+
+Virtual MCP servers only filter which tools a client can discover by using the `tools/list` concept. Virtual MCP servers do not change `tools/call` routing or authorization.

--- a/modules/con-virt-mcp-server-auth-tool-filtering.adoc
+++ b/modules/con-virt-mcp-server-auth-tool-filtering.adoc
@@ -1,0 +1,19 @@
+// Module included in the following assemblies:
+//
+// *mcp_gateway_config/mcp-gateway-register-virtual-mcp-servers.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="con-virt-mcp-server-auth-tool-filtering_{context}"]
+= About virtual MCP servers authorization and tool filtering
+
+[role="_abstract"]
+If you have authentication and user-based tool filtering configured on your MCP servers, and then set up virtual MCP servers, the resulting tool list is the intersection of two filters.
+
+The `AuthPolicy` custom resource (CR) configurations you applied when you registered the MCP servers are used. You do not need to make additional configurations when creating virtual MCP servers.
+
+The MCP gateway broker component applies filters sequentially when handling a `tools/list` request with a virtual MCP server header. The following are the applied filters in order:
+
+. Identity-based filtering: The `x-authorized-tools` header, injected by the `AuthPolicy` CR, reduces the tool list to only the tools that the user has `resource_access` roles configured for.
+. Virtual MCP server filtering: The `X-Mcp-Virtualserver` header further reduces the available-tools list to only those tools that are defined in the `MCPVirtualServer` CR.
+
+For example, if the `accounting` virtual server lists `test1_greet` and `test3_add`, but the user only has the `greet` role on `mcp-test/test-server1`, that user only sees the tool, `test1_greet`.

--- a/modules/proc-mcp-gateway-create-virt-mcp-server.adoc
+++ b/modules/proc-mcp-gateway-create-virt-mcp-server.adoc
@@ -1,0 +1,90 @@
+// Module included in the following assemblies:
+//
+// *mcp_gateway_config/mcp-gateway-create-virtual-mcp-servers.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="proc-mcp-gateway-create-virt-mcp-server_{context}"]
+= Creating virtual MCP servers
+
+[role="_abstract"]
+To create virtual MCP servers for different use cases, you must define the virtual server with an `MCPVirtualServer` custom resource (CR) that specifies required fields. When a client includes the virtual MCP server header, the MCP gateway filters responses to only include the specified tools.
+
+An `MCPVirtualServer` CR must contain the following information:
+
+* Tool selection: Which tools from the aggregated pool to expose.
+* Description: A human-readable description of the virtual MCP server's purpose.
+* Access method: Tools are accessed by the `X-Mcp-Virtualserver` header with the `namespace/name` format.
+
+.Prerequisites
+
+* You completed all of the installation and configuration steps for {mcpg}.
+* You registered your MCP servers.
+* You installed the {oc-first}.
+
+.Procedure
+
+. Create an `MCPVirtualServer` CR for a virtual MCP server that curates development tools by using the following example:
++
+.Example developer tools MCPVirtualServer CR
+[source,yaml,subs="+quotes"]
+----
+apiVersion: mcp.kuadrant.io/v1alpha1
+kind: MCPVirtualServer
+metadata:
+  name: _<dev_tools>_
+  namespace: _<mcp_system>_
+spec:
+  description: "Development and debugging tools"
+  tools:
+  - mcpserver1_devtool1
+  - mcpserver2_headers1
+  - mcpserver3_debug1
+----
++
+* Replace the `metadata.name:` value with the name you want to use.
+* Replace the `metadata.namespace:` value with the name you want to use.
+* Replace the list values in the `spec.tools:` parameter with the names of the tools you want to curate to this CR.
+
+. Apply the CR by running the following command:
++
+[source,terminal,subs="+quotes"]
+----
+$ oc apply -f _<mcpvs_devtools.yaml>_
+----
++
+Replace `_<mcpvs_devtools.yaml>_` with the name of your CR.
+
+. Create an `MCPVirtualServer` CR for a virtual server that curates data analysis tools by using the following example:
++
+.Example data analysis tools MCPVirtualServer CR
+[source,yaml,subs="+quotes"]
+----
+apiVersion: mcp.kuadrant.io/v1alpha1
+kind: MCPVirtualServer
+metadata:
+  name: _<data_tools>_
+  namespace: _<mcp_system>_
+spec:
+  description: "Data analysis and reporting tools"
+  tools:
+  - mcpserver2_time
+  - mcpserver2_dozen
+  - mcpserver1_get_stats
+----
++
+* Replace the `metadata.name:` value with the name you want to use.
+* Replace the `metadata.namespace:` value with the namespace you want to use. The `metadata.namespace:` value can be any namespace where you have permission to create resources.
+* Replace the list values in `spec.tools:` with the names of the tools you want to curate to this CR.
+
+. Apply the CR by running the following command:
++
+[source,terminal,subs="+quotes"]
+----
+$ oc apply -f _<mcpvs_datatools.yaml>_
+----
++
+Replace `_<mcpvs_datatools.yaml>_` with the name of your CR.
+
+.Next step
+
+* Verify that your virtual MCP servers are returning the tools you expect to see by following the instructions in "Verifying virtual MCP servers".

--- a/modules/proc-mcp-gateway-delete-virtual-server.adoc
+++ b/modules/proc-mcp-gateway-delete-virtual-server.adoc
@@ -1,0 +1,29 @@
+// Module included in the following assemblies:
+//
+// *mcp_gateway_config/mcp-gateway-create-virtual-mcp-servers.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="proc-mcp-gateway-delete-virt-mcp-server_{context}"]
+= Deleting virtual MCP servers
+
+[role="_abstract"]
+You can delete a virtual MCP server when you no longer need it or when your MCP servers change.
+
+.Prerequisites
+
+* You completed all of the installation and configuration steps for {mcpg}.
+* You registered your MCP servers.
+* You installed the {oc-first}.
+* You created a virtual MCP server.
+
+.Procedure
+
+* Delete a virtual MCP server by running the following command:
++
+[source,terminal,subs="+quotes"]
+----
+$ oc delete mcpvirtualserver _<dev_tools>_ -n _<mcp_system>_
+----
++
+* Replace `_<dev_tools>_` with the name of the `MCPVirtualServer` custom resource you want to remove.
+* Replace `_<mcp_system>_` with the namespace where the CR is applied.

--- a/modules/proc-verify-virt-mcp-server.adoc
+++ b/modules/proc-verify-virt-mcp-server.adoc
@@ -1,0 +1,117 @@
+// Module included in the following assemblies:
+//
+// *mcp_gateway_config/mcp-gateway-register-virtual-mcp-servers.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="proc-verify-virt-mcp-server_{context}"]
+= Verifying virtual MCP servers
+
+[role="_abstract"]
+After you create your virtual MCP servers, you can check that they are returning the tool lists that you want.
+
+.Prerequisites
+
+* You completed all of the installation and configuration steps for {mcpg}.
+* You registered your MCP servers.
+* You installed the {oc-first}.
+* You applied `MCPVirtualServer` custom resource (CRs) for your virtual servers.
+
+.Procedure
+
+. List all of your virtual MCP servers by running the following command:
++
+[source,terminal]
+----
+$ oc get mcpvirtualserver -A
+----
++
+The expected output is a list of all of the virtual MCP servers that you created.
+
+. Performs a connectivity and handshake test of your virtual `dev_tools` MCP server by running the following `curl` command with the relevant URL and header:
++
+[source,terminal,subs="+quotes"]
+----
+$ curl -s -D /tmp/mcp_headers -X POST _<http:example.com:port/mcp>_ \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {"protocolVersion": "2025-11-25", "capabilities": {}, "clientInfo": {"name": "test-client", "version": "1.0.0"}}}'
+----
++
+* Replace `_<http:example.com:port/mcp>_` with the target URL and MCP gateway endpoint.
++
+.Example output
+[source,json]
+----
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "protocolVersion": "2025-11-25",
+    "capabilities": {
+      "tools": {},
+      "prompts": {},
+      "resources": {}
+    },
+    "serverInfo": {
+      "name": "mcp-gateway-server",
+      "version": "1.0.0"
+    }
+  }
+}
+----
+
+. Extract the MCP session ID from response headers by running the following command:
++
+[source,terminal]
+----
+$ SESSION_ID=$(grep -i "mcp-session-id:" /tmp/mcp_headers | cut -d' ' -f2 | tr -d '\r')
+----
++
+.Expected output
+[source,text]
+----
+echo "MCP Session ID: $SESSION_ID"
+----
+
+. Request the tools from the `dev_tools` virtual MCP server by running the following command:
++
+[source,terminal,subs="+quotes"]
+----
+$ curl -X POST _<http:example.com:port/mcp>_ \
+  -H "Content-Type: application/json" \
+  -H "mcp-session-id: $SESSION_ID" \
+  -H "X-Mcp-Virtualserver: _<mcp_system>_/_<dev_tools>_" \
+  -d '{"jsonrpc": "2.0", "id": 1, "method": "tools/list"}' | jq '.result.tools[].name'
+----
++
+* Replace `_<http:example.com:port/mcp>_` with the target URL and MCP gateway endpoint.
+* Replace `_<mcp_system>_` with the namespace of the MCP gateway.
+* Replace `_<dev_tools>_` with the tool headers that you want to request.
+* The expected response is a list of only the tools you specified in the `dev_tools` virtual MCP server specification.
+
+. Request the tools from the `data_tools` virtual MCP server by running the following command:
++
+[source,terminal,subs="+quotes"]
+----
+$ curl -X POST _<http:example.com:port>_/mcp \
+  -H "Content-Type: application/json" \
+  -H "mcp-session-id: $SESSION_ID" \
+  -H "X-Mcp-Virtualserver: _<mcp_system>_/_<data_tools>_" \
+  -d '{"jsonrpc": "2.0", "id": 1, "method": "tools/list"}' | jq '.result.tools[].name'
+----
++
+* Replace `_<http:example.com:port/mcp>_` with the target URL and MCP gateway endpoint.
+* Replace `_<mcp_system>_` with the namespace of the MCP gateway.
+* Replace `_<data_tools>_` with the tool headers that you want to request.
+* The expected response is a list of only the tools you specified in the `data_tools` virtual MCP server specification.
+
+. Request all available tools from your MCP servers by running the following command:
++
+[source,terminal,subs="+quotes"]
+----
+$ curl -X POST _<http:example.com:port>_/mcp \
+  -H "mcp-session-id: $SESSION_ID" \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc": "2.0", "id": 1, "method": "tools/list"}' | jq '.result.tools[].name'
+----
++
+The expected response is a list of all tools from all registered MCP servers.


### PR DESCRIPTION
Version(s):
mcp-gateway-docs-tp

Issue:
[OSDOCS-18938](https://redhat.atlassian.net/browse/OSDOCS-18938)

Link to docs preview:
https://109621--ocpdocs-pr.netlify.app/rhcl/latest/mcp_gateway_config/mcp-gateway-creating-virtual-mcp-servers.html

QE review:
- [x] SME has approved this change.
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Docs merge reviewer, the `mcp-gateway-docs-tp` is a Release branch, so content work is incremental. The entire branch will be integrated into the `rhcl-docs-main`, `rhcl-docs-1.3`, and `rhcl-docs-1.4` docs in late April, and therefore, not published anywhere now.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
