### PR TITLE
OSDOCS WMCO 10.17.2 release notes

### DIFF
--- a/modules/windows-containers-release-notes-10-17-2.adoc
+++ b/modules/windows-containers-release-notes-10-17-2.adoc
@@ -6,21 +6,14 @@
 [id="windows-containers-release-notes-10-17-2_{context}"]
 = Release notes for Red Hat Windows Machine Config Operator 10.17.2
 
-Issued: DD MONTH 2026
+Issued: 15 APRIL 2026
 
 [role="_abstract"]
 You can review the following release notes to learn about the bug fixes provided in this release of the Windows Machine Config Operator (WMCO). 
 
-The components of the WMCO 10.17.2 were released in link:https://access.redhat.com/errata/RHSA-2026:TBD[RHSA-2026:TBD].
-
-[id="wmco-10-17-2-new-features_{context}"]
-== New features and improvements
-
-New feature::
-Description
+The components of the WMCO 10.17.2 were released in link:https://access.redhat.com/errata/RHBA-2026:8343[RHBA-2026:8343].
 
 [id="wmco-10-17-2-bug-fixes_{context}"]
 == Bug fixes
 
-* Before this update, With this release, (link:https://issues.redhat.com/browse/OCPBUGS-55915[*OCPBUGS-55915*])
-
+Before this update, Windows Server 2019 machines might not have a running SSH server because of network instability. As a result, the WMCO could not access some VMs to complete configuration. With this release, the WMCO makes multiple attempts to SSH into the VM. As such, SSH connectivity to VMs is restored, ensuring smooth configuration and management of nodes. (link:https://issues.redhat.com/browse/OCPBUGS-61212[*OCPBUGS-61212*])

--- a/windows_containers/wmco_rn/windows-containers-release-notes.adoc
+++ b/windows_containers/wmco_rn/windows-containers-release-notes.adoc
@@ -10,4 +10,3 @@ toc::[]
 You can review the following release notes to learn about changes in the Windows Machine Config Operator (WMCO) version 10.17.2.
 
 include::modules/windows-containers-release-notes-10-17-2.adoc[leveloffset=+1]
-


### PR DESCRIPTION
https://redhat.atlassian.net/browse/WINC-1799

Link to docs preview:
Release notes for Red Hat Windows Machine Config Operator 10.17.2 -- One bug fix doc text that was previously reviewed for the [bug in the 10.21.1 release](https://github.com/openshift/openshift-docs/pull/107025/changes#diff-f25ecf6560356cac93159579c56144a513d5e33e3f43d7d185766ef34522b5c4R32) and two other releases.

**DO NOT MERGE UNTIL WMCO 10.17.2 RELEASES (planned 8-Apr) AND [PR 108961](https://github.com/openshift/openshift-docs/pull/108961) IS FIRST MERGED**

**UPDATE WITH ERRATA AND LINK WHEN READY**