### PR TITLE
[RHACS] [Docs] [rhacs-docs-main] ROX-34000: Clarify reencrypt route TLS certificate and key configuration requirements

### DIFF
--- a/modules/central-configuration-options-operator.adoc
+++ b/modules/central-configuration-options-operator.adoc
@@ -59,13 +59,23 @@ Otherwise, you must reinstall the custom resource to log back in.
 |Use this parameter to specify a PEM-encoded certificate chain that might be used to establish a complete chain of trust. By default, {ocp} provides the certificate authority.
 
 |`central.exposure.route.reencrypt.tls.certificate`
-|Use this parameter to specify the PEM-encoded certificate that is served on the route. The {ocp} certificate authority signs the default certificate.
+a|Use this parameter to specify the PEM-encoded certificate that the route serves. The {ocp} certificate authority signs the default certificate.
+
+[IMPORTANT]
+====
+You must specify both `certificate` and `key` together, or omit both. Specifying only one of these parameters causes the Operator to fail with a validation error.
+====
 
 |`central.exposure.route.reencrypt.tls.destinationCACertificate`
 |Use this parameter to specify the CA certificate of the final destination, that is of Central. The {ocp} router uses this certificate to perform health checks on the secure connection. By default, Central provides the certificate authority.
 
 |`central.exposure.route.reencrypt.tls.key`
-|Use this parameter to specify the PEM-encoded private key of the certificate that is served on the route. The {ocp} certificate authority signs the default certificate.
+a|Use this parameter to specify the PEM-encoded private key of the certificate that the route serves. The {ocp} certificate authority signs the default certificate.
+
+[IMPORTANT]
+====
+You must specify both `certificate` and `key` together, or omit both. Specifying only one of these parameters causes the Operator to fail with a validation error.
+====
 
 |`central.exposure.nodeport.enabled`
 |Set this to `true` to expose Central through a node port. The default value is `false`.

--- a/modules/central-services-public-config.adoc
+++ b/modules/central-services-public-config.adoc
@@ -208,17 +208,27 @@ By default, {ocp} provides the certificate authority.
 This parameter is only available for {ocp} clusters.
 
 | `central.exposure.route.reencrypt.tls.certificate`
-| Use this parameter to specify the PEM-encoded certificate that is served on the route. The {ocp} certificate authority signs the default certificate.
+a| Use this parameter to specify the PEM-encoded certificate that the route serves. The {ocp} certificate authority signs the default certificate.
 This parameter is only available for {ocp} clusters.
+
+[IMPORTANT]
+====
+You must specify both `certificate` and `key` together, or omit both. Specifying only one of these parameters causes the installation to fail with a validation error.
+====
 
 | `central.exposure.route.reencrypt.tls.destinationCACertificate`
 | Use this parameter to specify the CA certificate of the final destination, that is of Central.
 The {ocp} router uses this certificate to perform health checks on the secure connection. By default, Central provides the certificate authority.
 
 | `central.exposure.route.reencrypt.tls.key`
-| Use this parameter to specify the PEM-encoded private key of the certificate that is served on the route.
+a| Use this parameter to specify the PEM-encoded private key of the certificate that the route serves.
 The {ocp} certificate authority signs the default certificate.
 This parameter is only available for {ocp} clusters.
+
+[IMPORTANT]
+====
+You must specify both `certificate` and `key` together, or omit both. Specifying only one of these parameters causes the installation to fail with a validation error.
+====
 
 | `central.db.external`
 | Use `true` to specify that Central DB should not be deployed and that an external database will be used.


### PR DESCRIPTION
Added IMPORTANT admonitions to both certificate and key parameters to clarify that they must be specified together or both omitted. This addresses customer feedback about operator validation failures when only one parameter is set.

Also fixed passive voice in parameter descriptions.

Resolves: [ROX-34000](https://redhat.atlassian.net/browse/ROX-34000)
Related: [DOCS-4997](https://redhat.atlassian.net/browse/DOCS-4997)

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.10+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
https://redhat.atlassian.net/browse/ROX-34000
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Modified Files and Their Preview Links:                                                 
                                          
  1. modules/central-configuration-options-operator.adoc                                 
                                                                                         
  Operator-based installation configuration reference                                    
                                                                                         
  🔗 https://109670--ocpdocs-pr.netlify.app/openshift-acs/latest/installing/installing_ocp/install-central-config-options-ocp.html                                              
   
  This page shows the IMPORTANT admonitions for the certificate and key parameters in the
   Operator installation method.          
                                                                                         
  ---                                                                                    
  2. modules/central-services-public-config.adoc
                                                                                         
  Helm-based installation configuration reference (appears in 2 locations)
                                              
  🔗 OpenShift installation:                                                             
  https://109670--ocpdocs-pr.netlify.app/openshift-acs/latest/installing/installing_ocp/install-central-ocp.html                                                                
                                                                                         
  🔗 Other platforms installation:                                                       
  https://109670--ocpdocs-pr.netlify.app/openshift-acs/latest/installing/installing_other/install-central-other.html
                                                                                         
  These pages show the IMPORTANT admonitions for Helm-based installations.
                                                                                         
  ---             
  Quick Navigation                                                                       
                  
  To see the changes directly, scroll to the "Central configuration options" section on 
  each page and look for the `central.exposure.route.reencrypt.tls.certificate` and
  `central.exposure.route.reencrypt.tls.key` parameters. The IMPORTANT admonitions should
  be clearly visible under each parameter.

<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

SME review:
- [ ] SME has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
- Cherry-pick to:
    - `rhacs-docs-4.10`
    - `rhacs-docs-4.9`
    - `rhacs-docs-4.8`
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
