### PR TITLE
OSDOCS-18955 created zstream RNs for 4-18-37

### DIFF
--- a/modules/zstream-4-18-37.adoc
+++ b/modules/zstream-4-18-37.adoc
@@ -1,0 +1,53 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-18-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-18-37_{context}"]
+= RHSA-2026:6554 - {product-title} {product-version}.37 fixed issues and security update
+
+Issued: 9 April 2026
+
+[role="_abstract"]
+{product-title} release {product-version}.37 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2026:6554[RHSA-2026:6554] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2026:6552[RHSA-2026:6552] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.18.37 --pullspecs
+----
+
+[id="zstream-4-18-37-enhancements_{context}"]
+== Enhancements
+
+* With this update, support for the `kubevirt-csi-driver` on non-hosted control plane nested clusters by using OpenShift Virtualization VMs has been added through manual mapping annotations. The new manual mapping annotations are:
++
+--
+*  `csi.kubevirt.io/infra-vm-name`: The name of the virtual machine that exists on the infra cluster. This virtual machine repesents the node of the nested cluster.
+
+*  `csi.kubevirt.io/infra-vm-namespace`: The namespace name on the infra cluster where the VMs (representing the node of the nested cluster run.
+--
++
+(link:https://redhat.atlassian.net/browse/OCPBUGS-79362[OCPBUGS-79362])
+
+[id="zstream-4-18-37-fixed-issues_{context}"]
+== Fixed issues
+
+* Before this update, the timing of operations during `br-ex` creation on some Cisco switches caused switch ports to be disabled. As a consequence, network connectivity on the affected ports was disrupted. With this release, the `configure-ovs.sh` script waits for interfaces to become stable before continuing. As a result, switch ports remain enabled during `br-ex` creation. (link:https://redhat.atlassian.net/browse/OCPBUGS-62692[OCPBUGS-62692])
+
+* Before this update, the Machine API Provider OpenStack (MAPO) created an event for every single reconcile, even when no significant state changes such as a create, update, or delete had occurred. This event generation led to cluttered event logs, strained system performance, and frequently disrupted monitoring and alerting systems. With this release, the reconcile function is modified to capture the original `ResourceVersion` and only emit an event when the machine `ResourceVersion` changes. Additionally, the event name was changed from `Reconciled` to `Updated` to better align with other machine API providers. (link:https://redhat.atlassian.net/browse/OCPBUGS-69648[OCPBUGS-69648])
+
+* Before this update, clusters using multi-architecture release payload images that had the `spec.desiredUpdate.architecture` field of the Cluster Version object set to the `Multi` value experienced a significant issue where the `ClusterVersion` resource would not be populated with update recommendations for later releases. With this release, a comparison of incorrect values in the code has been fixed, ensuring that the bug no longer presents itself and update recommendations now shows as expected. (link:https://redhat.atlassian.net/browse/OCPBUGS-70182[OCPBUGS-70182])
+
+* Before this update, the cluster autoscaler would process paused node groups as if they were active, which could lead to the wrong nodes being deleted. With this release, the cluster autoscaler identifies paused node groups and does not act on them. (link:https://redhat.atlassian.net/browse/OCPBUGS-78699[OCPBUGS-78699])
+
+* Before this update, the Machine API Operator used the `infraID-rg` resource group name when it created a default image ID. As a consequence, clusters with a resource group that did not use that name received an incorrect default machine set, which prevented the provisioning of the machines. With this release, the Machine API Operator reads the resource group from the infrastructure configuration. As a result, the correct image ID is generated and the machine set can scale the machines. (link:https://redhat.atlassian.net/browse/OCPBUGS-78796[OCPBUGS-78796])
+
+
+[id="zstream-4-18-37-updating_{context}"]
+== Updating
+
+To update an {product-title} 4.18 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].

--- a/release_notes/ocp-4-18-release-notes.adoc
+++ b/release_notes/ocp-4-18-release-notes.adoc
@@ -3062,6 +3062,9 @@ As a workaround, you must manually reboot the failed host from the disk. (link:h
 // 4.18 about async
 include::modules/rn-async-errata.adoc[leveloffset=+1]
 
+// 4.18.37 Rns and updating
+include::modules/zstream-4-18-37.adoc[leveloffset=+2]
+
 // 4.18.36 Rns and updating
 include::modules/zstream-4-18-36.adoc[leveloffset=+2]
 


### PR DESCRIPTION
Version(s):
4.18

Issue:
https://redhat.atlassian.net/browse/OSDOCS-18955

Link to docs preview:
https://109673--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-18-release-notes.html#zstream-4-18-37_release-notes


QE review:
- [ ] QE has approved this change.


Additional information:

