### PR TITLE
[enterprise-4.17][OCPBUGS-80926]: Correcting text in on-premise backup procedure for HCP

### DIFF
--- a/hosted_control_planes/hcp_high_availability/hcp-backup-restore-on-premise.adoc
+++ b/hosted_control_planes/hcp_high_availability/hcp-backup-restore-on-premise.adoc
@@ -6,7 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-You can back up and restore etcd on a hosted cluster in an on-premise environment to fix failures.
+You can back up and restore etcd for {hcp} in an on-premise environment to fix failures.
 
 include::modules/hosted-cluster-etcd-backup-restore-on-premise.adoc[leveloffset=+1]
 

--- a/modules/hosted-cluster-etcd-backup-restore-on-premise.adoc
+++ b/modules/hosted-cluster-etcd-backup-restore-on-premise.adoc
@@ -7,10 +7,7 @@
 = Backing up etcd and restoring it on a different management cluster
 
 [role="_abstract"]
-By backing up etcd and then restoring it on a different management cluster, you can fix failures, such as corrupted or missing data in an etcd member of a 3-node cluster. If members of the etcd cluster lose data or have a `CrashLoopBackOff` status, this approach helps prevent an etcd quorum loss.
-
-:FeatureName: Backing up etcd and restoring it on a different management cluster
-include::snippets/technology-preview.adoc[]
+By backing up and restoring etcd on a hosted cluster, you can fix failures, such as corrupted or missing data in an etcd member of a three-node cluster. If members of the etcd cluster lose data or have a `CrashLoopBackOff` status, this approach helps prevent an etcd quorum loss.
 
 .Prerequisites
 
@@ -25,8 +22,12 @@ include::snippets/technology-preview.adoc[]
 ** You have access to the `openshift-adp` subscription through a `CatalogSource` object.
 
 * Hosted cluster service publishing strategy prerequisites:
-+
+
 ** When you restore a hosted cluster to a different management cluster, all services in the hosted cluster must be configured with a fixed hostname in its `servicePublishingStrategy` property. This requirement applies to all platforms: {aws-short}, Agent, {VirtProductName}, and {rh-openstack-first}.
+
+:FeatureName: Restoring a hosted cluster to a different management cluster
+include::snippets/technology-preview.adoc[]
+
 ** The `APIServer` service must have a fixed hostname. Otherwise, the restore process fails and nodes cannot rejoin the cluster. For {hcp} on {aws-short}, the `APIServer` service can also use a `Route` service publishing strategy with a fixed hostname.
 ** For production environments, it is strongly recommended to configure all services with fixed hostnames. By having fixed hostnames, you can ensure full service continuity and DNS consistency during the restore process on a different management cluster.
 


### PR DESCRIPTION
cherry picked from https://github.com/openshift/openshift-docs/pull/109614