### PR TITLE
[RHDEVDOCS-7428] Release notes for Pipelines 1.20.4

### DIFF
--- a/modules/op-release-notes-1-20-4.adoc
+++ b/modules/op-release-notes-1-20-4.adoc
@@ -1,0 +1,9 @@
+// This module is included in the following assemblies:
+// * release_notes/op-release-notes-1-20.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="op-release-notes-1-20-4_{context}"]
+= Release notes for {pipelines-title} 1.20.4
+
+[role="_abstract"]
+With this update, {pipelines-title} General Availability (GA) 1.20.4 is available on {OCP} 4.14, 4.16, and later versions.

--- a/release_notes/op-release-notes-1-20.adoc
+++ b/release_notes/op-release-notes-1-20.adoc
@@ -28,10 +28,10 @@ For an overview of {pipelines-title}, see xref:../about/understanding-openshift-
 // Compatibility and support matrix 1.20
 include::modules/op-tkn-pipelines-compatibility-support-matrix.adoc[leveloffset=+1]
 
-// Release notes for Red Hat OpenShift Pipelines 1.20.0 
+// Release notes for Red Hat OpenShift Pipelines 1.20.0
 include::modules/op-release-notes-1-20-0.adoc[leveloffset=+1]
 
-// Release notes for Red Hat OpenShift Pipelines 1.20.1 
+// Release notes for Red Hat OpenShift Pipelines 1.20.1
 include::modules/op-release-notes-1-20-1.adoc[leveloffset=+1]
 
 // Release notes for Red Hat OpenShift Pipelines 1.20.2
@@ -40,11 +40,13 @@ include::modules/op-release-notes-1-20-2.adoc[leveloffset=+1]
 // Release notes for Red Hat OpenShift Pipelines 1.20.3
 include::modules/op-release-notes-1-20-3.adoc[leveloffset=+1]
 
+// Release notes for Red Hat OpenShift Pipelines 1.20.4
+include::modules/op-release-notes-1-20-4.adoc[leveloffset=+1]
 
 //Additional resources 1.20
 .Additional resources
 * xref:../secure/using-buildah-ns-tekton-task.adoc#op-differences-between-buildah-buildah-ns-tasks_using-buildah-ns-tekton-task[Differences between `buildah` and `buildah-ns` tasks]
-//* xref:../install_config/customizing-configurations-in-the-tektonconfig-cr.adoc#op-configuration-rbac-trusted-ca-flags_customizing-configurations-in-the-tektonconfig-cr[Configuration of RBAC and Trusted CA flags].  
+//* xref:../install_config/customizing-configurations-in-the-tektonconfig-cr.adoc#op-configuration-rbac-trusted-ca-flags_customizing-configurations-in-the-tektonconfig-cr[Configuration of RBAC and Trusted CA flags].
 * xref:../install_config/customizing-configurations-in-the-tektonconfig-cr.adoc#event-pruner-configuration_customizing-configurations-in-the-tektonconfig-cr[Enabling the event-based pruner]
 * xref:../pac/install-config-pipelines-as-code.adoc#customizing-pipelines-as-code-configuration_install-config-pipelines-as-code[Customizing {pac} configuration]
 * xref:../pac/creating-pipeline-runs-pac.adoc#op-parameters-pipeline-run-using-pipelines-as-code_creating-pipeline-runs-pac[Commit and URL Information]


### PR DESCRIPTION
Version(s):
- _none for cherry-picking_

Issue:
- https://redhat.atlassian.net/browse/RHDEVDOCS-7428

Link to docs preview:
- [1.20.4 Release Notes](https://109684--ocpdocs-pr.netlify.app/openshift-pipelines/latest/release_notes/op-release-notes-1-20.html#op-release-notes-1-20-4_op-release-notes-1-20)

QE review:
- [x] QE has approved this change.
