### PR TITLE
OSDOCS-19016: Fixing TP wording of Agent install method

### DIFF
--- a/installing/installing_with_agent_based_installer/installing-ove.adoc
+++ b/installing/installing_with_agent_based_installer/installing-ove.adoc
@@ -11,7 +11,7 @@ You can deploy an {product-title} cluster without the need for an external image
 
 Although the method supports general clusters, the downloaded media contains an Operator bundle that is curated specifically for {ove-first}, meaning additional Operators must be retrieved separately if required for other use cases.
 
-:FeatureName: Installing an {ove} cluster using this method
+:FeatureName: Installing a cluster without an external registry
 include::snippets/technology-preview.adoc[]
 
 include::modules/installing-ove-advantages.adoc[leveloffset=+1]


### PR DESCRIPTION
[OSDOCS-19016](https://redhat.atlassian.net/browse/OSDOCS-19016)

Version(s): 4.20+

This PR fixes the TP disclaimer in an Agent installation doc to match the name of the feature as described by the page title.

QE review:
- [x] QE has approved this change.

Preview: [Installing a cluster without an external registry](https://109688--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_with_agent_based_installer/installing-ove)

