### PR TITLE
OSDOCS-19012: Add cluster-monitoring namespace label to Kueue install docs

### DIFF
--- a/modules/kueue-install-kueue-operator.adoc
+++ b/modules/kueue-install-kueue-operator.adoc
@@ -19,6 +19,23 @@ You can install the {kueue-op} on a {product-title} cluster by using the Operato
 
 . In the {product-title} web console, click *Operators* -> *OperatorHub*.
 . Choose *{kueue-op}* from the list of available Operators, and click *Install*.
+. Select *Enable Operator recommended cluster monitoring on this Namespace*.
++
+This option sets the `openshift.io/cluster-monitoring: "true"` label in the Namespace object.
+You must select this option to ensure that cluster monitoring scrapes the `openshift-kueue-operator` namespace.
+. Click *Install*.
++
+Alternatively, if you are creating the `Namespace` object by using YAML, ensure that you include the `openshift.io/cluster-monitoring: "true"` label:
++
+[source,yaml]
+----
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    openshift.io/cluster-monitoring: "true"
+  name: openshift-kueue-operator
+----
 
 .Verification
 


### PR DESCRIPTION
## Summary
- Adds the `openshift.io/cluster-monitoring: "true"` namespace label to the Kueue operator installation procedure
- Documents the web console checkbox (*Enable Operator recommended cluster monitoring on this Namespace*) following the same pattern as other operator install docs (Loki, Logging, Tempo, WMCO)
- Includes YAML alternative for users creating the namespace manually

## Bug
https://redhat.atlassian.net/browse/OSDOCS-19012

Without this label, Kueue operator ServiceMonitors are incorrectly routed to user-workload Prometheus instead of cluster Prometheus.

## Test plan
- [ ] Verify the adoc renders correctly for both the console and YAML install paths
- [ ] Confirm the label matches what the Kueue operator expects (`openshift.io/cluster-monitoring: "true"`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)