### PR TITLE
OSDOCS-19012: Add cluster-monitoring namespace label to Kueue install docs

### DIFF
--- a/modules/kueue-install-kueue-operator.adoc
+++ b/modules/kueue-install-kueue-operator.adoc
@@ -19,6 +19,27 @@ You can install the {kueue-op} on a {product-title} cluster by using the Operato
 
 . In the {product-title} web console, click *Operators* -> *OperatorHub*.
 . Choose *{kueue-op}* from the list of available Operators, and click *Install*.
+. Select *Enable Operator recommended cluster monitoring on this Namespace*.
++
+This option sets the `openshift.io/cluster-monitoring: "true"` label in the Namespace object.
+You must select this option to ensure that cluster monitoring scrapes the `openshift-kueue-operator` namespace.
+. Click *Install*.
++
+[NOTE]
+====
+Alternatively, if you are creating the `Namespace` object by using YAML, ensure that you include the `openshift.io/cluster-monitoring: "true"` label:
++
+[source,yaml]
+----
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    openshift.io/cluster-monitoring: "true"
+  name: openshift-kueue-operator
+----
+====
+
 
 .Verification
 


### PR DESCRIPTION
Add cluster-monitoring namespace label to Kueue install docs

Version(s): 4.21, 4.22 CP 4.18, 4.19, 4.20

Issue:
https://redhat.atlassian.net/browse/OSDOCS-19012

Link to docs preview:
https://109700--ocpdocs-pr.netlify.app/openshift-enterprise/latest/ai_workloads/kueue/install-kueue.html#install-kueue-operator_install-kueue

SME @kannon92 
QE review: @anahas-redhat
- [ ] QE has approved this change.



