### PR TITLE
OSDOCS 17102 CQA 2.0 of MSH-AI-1: Core Concepts Part II Callout Follow Up

### DIFF
--- a/modules/microshift-rhoai-get-model-ready-inference.adoc
+++ b/modules/microshift-rhoai-get-model-ready-inference.adoc
@@ -38,7 +38,7 @@ REQ=./request.json
 echo -n '{"inputs" : [{"name": "0", "shape": [1], "datatype": "BYTES"}]}' > "${REQ}"
 # Get the size of the inference header
 HEADER_LEN="$(stat -c %s "${REQ}")"
-# Add size of the data (image) in binary format (4 bytes, little endian) <2>
+# Add size of the data (image) in binary format (4 bytes, little endian)
 printf "%08X" $(stat --format=%s "${IMAGE}") | sed 's/\(..\)/\1\n/g' | tac | tr -d '\n' | xxd -r -p >> "${REQ}"
 # Add the data, that is, append the image to the request file
 cat "${IMAGE}" >> "${REQ}"


### PR DESCRIPTION
When performing CP review on https://github.com/openshift/openshift-docs/pull/106317, noticed a stray call out left behind.

[Getting your AI model ready for inference](https://109713--ocpdocs-pr.netlify.app/microshift/latest/microshift_ai/microshift-rhoai.html#microshift-rhoai-get-model-ready-inference_microshift-rh-openshift-ai) -- Step 2. Removed call out in the _# Add size of the data _ line in the code block.

**DO NOT MERGE CP TO 4.19 UNTIL FURTHER NOTICE**