### PR TITLE
[SRVLOGIC-816|817_a] Add assembly for HPA and PDB

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -409,6 +409,8 @@ Topics:
   File: serverless-logic-managing-persistence
 - Name: Workflow eventing system
   File: serverless-logic-workflow-eventing-system
+- Name: Configuring workflow scaling and disruption protection
+  File: serverless-logic-configuring-workflow-scaling
 - Name: Configuring custom Maven mirrors
   File: serverless-logic-configuring-custom-maven-mirrors
 - Name: Managing upgrades

--- a/modules/serverless-logic-configuring-workflow-scaling-and-disruption.adoc
+++ b/modules/serverless-logic-configuring-workflow-scaling-and-disruption.adoc
@@ -1,0 +1,423 @@
+// Module included in the following assemblies:
+// * serverless-logic/serverless-logic-configuring-workflow-scaling.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="serverless-logic-configuring-workflow-scaling-and-disruption_{context}"]
+= Configuring workflow scaling and disruption protection
+
+[role="_abstract"]
+You can configure scaling for workflows using the {ServerlessLogicOperatorName}. This includes manual scaling, horizontal pod autoscaling (HPA), and pod disruption budgets for production deployments.
+
+[id="workflow-scaling_{context}"]
+== Scaling a workflow
+
+The `SonataFlow` custom resource definition (CRD) exposes the Kubernetes `scale` subresource, which enables you to scale workflows using the standard Kubernetes API. You can scale workflows manually or automatically using Horizontal Pod Autoscalers.
+
+[NOTE]
+====
+Workflows deployed with the `dev` profile are intended for development use and are not designed for scaling.
+====
+
+[id="querying-workflow-scale-subresource_{context}"]
+== Querying the workflow scale subresource
+
+To query the workflow `scale` subresource, run the following command:
+
+[source,terminal,subs="+quotes"]
+----
+$ *oc get sonataflow <workflow_name> -n <namespace> --subresource=scale -o yaml*
+----
+
+[source,yaml]
+----
+apiVersion: autoscaling/v1
+kind: Scale
+metadata:
+  creationTimestamp: "2026-02-12T12:48:46Z"
+  name: example-workflow
+  namespace: example-workflow-namespace
+  resourceVersion: "38397"
+  uid: de53b549-dcb5-4b46-bb4e-9a576341e099
+spec:
+  replicas: 1
+status:
+  replicas: 1
+  selector: app=example-workflow,app.kubernetes.io/component=serverless-workflow,app.kubernetes.io/instance=example-workflow,app.kubernetes.io/managed-by=sonataflow-operator,app.kubernetes.io/name=example-workflow,app.kubernetes.io/version=main,sonataflow.org/workflow-app=example-workflow,sonataflow.org/workflow-namespace=example-workflow-namespace
+----
+
+The output displays the following information:
+
+* `spec.replicas` - Number of configured replicas.
+* `status.replicas` - Number of currently available replicas.
+* `status.selector` - Selector to query the observed pods.
+
+[id="scaling-workflow-manually_{context}"]
+== Scaling the workflow manually
+
+You can scale a workflow using any of the following methods:
+
+.Procedure: Scaling using the `oc scale` command
+
+. Run the following command:
++
+[source,terminal,subs="+quotes"]
+----
+$ *oc scale sonataflow <workflow_name> -n <namespace> --replicas=<number>*
+----
++
+where:
++
+`<workflow_name>`:: Specifies the name of your workflow.
+`<namespace>`:: Specifies the namespace where your workflow is deployed.
+`<number>`:: Specifies the desired number of replicas.
+
++
+[source,terminal,subs="+quotes"]
+----
+$ *oc scale sonataflow example-workflow -n example-workflow-namespace --replicas=3*
+----
+
+[source,terminal]
+----
+sonataflow.sonataflow.org/example-workflow scaled
+----
+
+.Procedure: Scaling by configuring the `SonataFlow` custom resource
+
+. Edit your `SonataFlow` CR to include the `spec.podTemplate.replicas` field:
++
+[source,yaml]
+----
+apiVersion: sonataflow.org/v1alpha08
+kind: SonataFlow
+metadata:
+  name: example-workflow
+  namespace: example-workflow-namespace
+  annotations:
+    sonataflow.org/description: Example Workflow
+    sonataflow.org/version: 0.0.1
+    sonataflow.org/profile: preview
+spec:
+  podTemplate:
+    replicas: 3
+  flow:
+    start: ExampleStartState
+# ...
+----
++
+Use the `spec.podTemplate.replicas` field to configure the number of replicas.
+
+. Apply the configuration:
++
+[source,terminal,subs="+quotes"]
+----
+$ *oc apply -f example-workflow.yaml -n example-workflow-namespace*
+----
++
+[source,terminal]
+----
+sonataflow.sonataflow.org/example-workflow configured
+----
+
+.Procedure: Scaling by patching the `SonataFlow` custom resource
+
+. Run the following command:
++
+[source,terminal,subs="+quotes"]
+----
+$ *oc patch sonataflow <workflow_name> -n <namespace> \
+  --type merge \
+  -p '{
+    "spec": {
+      "podTemplate": {
+        "replicas": <number>
+      }
+    }
+  }'*
+----
++
+where:
++
+`<workflow_name>`:: Specifies the name of your workflow.
+`<namespace>`:: Specifies the namespace where your workflow is deployed.
+`<number>`:: Specifies the desired number of replicas.
+
++
+[source,terminal,subs="+quotes"]
+----
+$ *oc patch sonataflow example-workflow -n example-workflow-namespace \
+  --type merge \
+  -p '{
+    "spec": {
+      "podTemplate": {
+        "replicas": 3
+      }
+    }
+  }'*
+----
++
+[source,terminal]
+----
+sonataflow.sonataflow.org/example-workflow patched
+----
+
+[id="workflow-horizontal-pod-autoscaling_{context}"]
+== Configuring horizontal pod autoscaling for workflows
+
+By using a `HorizontalPodAutoscaler` (HPA), you can configure how a Kubernetes workload resource scales based on a set of metrics, such as CPU or memory usage.
+
+Workload resources that support autoscaling expose the scale subresource, which allows Kubernetes to adjust the number of replicas dynamically. When you configure horizontal pod autoscaling for a workflow, the {ServerlessLogicOperatorName} automatically manages the coordination between the workflow scale subresource and the associated Kubernetes Deployment, making the workflow pods scale accordingly.
+
+Before configuring an HPA for a workflow, you must define the resources to be used as scaling metrics in the `SonataFlow` CR.
+
+.Prerequisites
+
+* You have installed the {ServerlessLogicOperatorName}.
+* You have deployed a workflow using the `preview` or `gitops` profile.
+
+.Procedure
+
+. Configure resource requests in your `SonataFlow` CR:
++
+[source,yaml]
+----
+apiVersion: sonataflow.org/v1alpha08
+kind: SonataFlow
+metadata:
+  name: example-workflow
+  namespace: example-workflow-namespace
+  annotations:
+    sonataflow.org/description: Example Workflow
+    sonataflow.org/version: 0.0.1
+    sonataflow.org/profile: preview
+spec:
+  podTemplate:
+    container:
+      resources:
+        requests:
+          cpu: 100m
+          memory: 256Mi
+        limits:
+          cpu: 500m
+          memory: 512Mi
+  flow:
+    start: ExampleStartState
+# ...
+----
++
+This example configures the following resource settings:
++
+* The `spec.podTemplate.container` field supports most of the standard `PodSpec` configurations. For more information, see link:https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#Container[Container] in the Kubernetes documentation.
+* The `resources.requests.cpu` field specifies the CPU request for the workflow container.
+* The `resources.requests.memory` field specifies the memory request for the workflow container.
++
+[NOTE]
+====
+`HorizontalPodAutoscalers` use the request resources for metrics calculations. The resource limits in the example are illustrative and are not used for scaling decisions.
+====
+
+. Create a `HorizontalPodAutoscaler` CR:
++
+[source,yaml]
+----
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: example-autoscaler
+  namespace: example-workflow-namespace
+spec:
+  scaleTargetRef:
+    apiVersion: sonataflow.org/v1alpha08
+    kind: SonataFlow
+    name: example-workflow
+  minReplicas: 2
+  maxReplicas: 5
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 70
+----
++
+This configuration includes the following settings:
++
+* The `scaleTargetRef` field references the target workflow by specifying the `apiVersion`, `kind`, and `name`.
+* The `metrics` field defines a metric based on CPU resource utilization.
+
+. Apply the `HorizontalPodAutoscaler` configuration by running the following command:
++
+[source,terminal,subs="+quotes"]
+----
+$ *oc apply -f example-autoscaler.yaml -n example-workflow-namespace*
+----
+
+[IMPORTANT]
+====
+Workflows deployed with `spec.podTemplate.deploymentModel: knative` cannot be scaled with a `HorizontalPodAutoscaler` because Knative Serving automatically controls the number of replicas. Additionally, workflows deployed using the `dev` profile are not designed to scale.
+====
+
+[role="_additional-resources"]
+[id="additional-resources_{context}"]
+== Additional resources
+
+* link:https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/[Horizontal Pod Autoscaling] in the Kubernetes documentation
+
+[id="workflow-pod-disruption-budget-configuration_{context}"]
+== Configuring pod disruption budgets for workflows
+
+By using a `PodDisruptionBudget` (PDB), you can configure the required availability of a workflow during a voluntary disruption, such as a node drain, in the cluster.
+
+A PDB limits the number of pods that can be unavailable simultaneously during such disruptions, ensuring that the workflow maintains the desired level of availability.
+
+In general, any tool that needs to guarantee availability should respect the PDB by using the Kubernetes Eviction API instead of directly deleting pods or deployments. The Eviction API ensures that disruption constraints defined by the PDB are honored.
+
+The {ServerlessLogicOperatorName} can automatically generate a `PodDisruptionBudget` for a workflow based on the `SonataFlow` CR configuration.
+
+.Available fields for PDB configuration
+
+To configure a PDB for a workflow, use the `spec.podTemplate.podDisruptionBudget` field in your `SonataFlow` CR:
+
+[source,yaml]
+----
+# ...
+spec:
+  podTemplate:
+    podDisruptionBudget:
+      minAvailable: 2
+      maxUnavailable: 1
+# ...
+----
+
+This configuration includes the following fields:
+
+* `minAvailable` - Specifies the number of pods that must still be available after an eviction. This value can be either an absolute number or a percentage, for example `2` or `50%`.
+* `maxUnavailable` - Specifies the number of pods that can be unavailable after an eviction. This value can be either an absolute number or a percentage, for example `1` or `50%`.
+
+[NOTE]
+====
+The `minAvailable` and `maxUnavailable` fields are mutually exclusive. You must configure only one of these fields. If both fields are specified, the `minAvailable` value takes precedence.
+
+The semantics of these fields are aligned with the corresponding fields in the Kubernetes PodDisruptionBudget. For more information, see link:https://kubernetes.io/docs/concepts/workloads/pods/disruptions/#pod-disruption-budgets[Pod Disruption Budgets] in the Kubernetes documentation.
+====
+
+.PodDisruptionBudget generation rules
+
+The {ServerlessLogicOperatorName} applies the following rules to generate the PDB:
+
+. The PDB is generated only if the workflow has the `spec.podTemplate.podDisruptionBudget` field properly configured.
+. The PDB is generated only if the workflow has `spec.podTemplate.replicas` configured with a value greater than 1.
+. If the workflow has a configured `HorizontalPodAutoscaler` (HPA), the HPA `spec.minReplicas` value takes precedence over the workflow `spec.podTemplate.replicas` value.
+. When an HPA is configured, the PDB is generated only if the HPA `spec.minReplicas` value is greater than 1.
+. If the workflow is scaled to zero (that is, `spec.podTemplate.replicas = 0`), no PDB is generated.
+
+[NOTE]
+====
+If any of the above conditions change after a PDB has been generated, for example, if the workflow is rescaled to 1, the previously generated PDB is automatically deleted.
+====
+
+[IMPORTANT]
+====
+Workflows deployed with `spec.podTemplate.deploymentModel: knative` cannot use a `PodDisruptionBudget` because Knative Serving automatically manages the number of replicas, and a PDB cannot reliably enforce minimum availability. Additionally, workflows deployed using the `dev` profile are not designed to scale.
+====
+
+.Prerequisites
+
+* You have installed the {ServerlessLogicOperatorName}.
+* You have deployed a workflow using the `preview` or `gitops` profile.
+
+.Procedure
+
+. Configure a PDB in your `SonataFlow` CR:
++
+[source,yaml]
+----
+apiVersion: sonataflow.org/v1alpha08
+kind: SonataFlow
+metadata:
+  name: example-workflow
+  namespace: example-workflow-namespace
+  annotations:
+    sonataflow.org/description: Example Workflow
+    sonataflow.org/version: 0.0.1
+    sonataflow.org/profile: preview
+spec:
+  podTemplate:
+    replicas: 2
+    podDisruptionBudget:
+      minAvailable: 1
+  flow:
+    start: ExampleStartState
+# ...
+----
++
+This configuration includes the following settings:
++
+* `replicas: 2` - The workflow runs with 2 replicas.
+* `podDisruptionBudget.minAvailable: 1` - The generated PDB ensures that 1 pod must remain available during a disruption.
+
+. Apply the configuration:
++
+[source,terminal,subs="+quotes"]
+----
+$ *oc apply -f example-workflow.yaml -n example-workflow-namespace*
+----
+
+.Verification
+
+* Verify that the PDB was created:
++
+[source,terminal,subs="+quotes"]
+----
+$ *oc get pdb -n example-workflow-namespace*
+----
++
+[source,terminal]
+----
+NAME               MIN AVAILABLE   MAX UNAVAILABLE   ALLOWED DISRUPTIONS   AGE
+example-workflow   1               N/A               1                     5m
+----
+
+Given this configuration, the {ServerlessLogicOperatorName} generates the following PDB for the workflow:
+
+[source,yaml]
+----
+kind: PodDisruptionBudget
+apiVersion: policy/v1
+metadata:
+  name: example-workflow
+  namespace: example-workflow-namespace
+  ownerReferences:
+    - apiVersion: sonataflow.org/v1alpha08
+      kind: SonataFlow
+      name: example-workflow
+      uid: 5b7f96d4-1ddf-45f7-af38-555d93339cca
+      controller: true
+      blockOwnerDeletion: true
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: example-workflow
+      app.kubernetes.io/component: serverless-workflow
+      app.kubernetes.io/instance: example-workflow
+      app.kubernetes.io/managed-by: sonataflow-operator
+      app.kubernetes.io/name: example-workflow
+      sonataflow.org/workflow-app: example-workflow
+      sonataflow.org/workflow-namespace: example-workflow-namespace
+----
+
+This generated PDB has the following characteristics:
+
+* The PDB has the same name as the workflow.
+* The PDB is created in the same namespace as the workflow.
+* The workflow is configured as the PDB owner.
+* The PDB `minAvailable` field is configured with the value from `spec.podTemplate.podDisruptionBudget.minAvailable` in the workflow CR.
+* The PDB selector is configured to target the workflow pods.
+
+[role="_additional-resources-2"]
+[id="additional-resources-2_{context}"]
+== Additional resources
+
+* link:https://kubernetes.io/docs/concepts/workloads/pods/disruptions/#pod-disruption-budgets[Pod Disruption Budgets] in the Kubernetes documentation

--- a/serverless-logic/serverless-logic-configuring-workflow-scaling.adoc
+++ b/serverless-logic/serverless-logic-configuring-workflow-scaling.adoc
@@ -1,0 +1,21 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="serverless-logic-configuring-workflow-scaling"]
+= Workflow scaling and disruption protection
+include::_attributes/common-attributes.adoc[]
+:context: serverless-logic-configuring-workflow-scaling
+
+toc::[]
+
+[role="_abstract"]
+You can configure scaling and disruption protection for your {ServerlessLogicProductName} workflows to handle varying workloads efficiently and maintain availability during cluster maintenance operations. This section describes how to scale workflows manually, configure horizontal pod autoscaling (HPA) for automatic scaling based on resource utilization metrics, and configure pod disruption budgets (PDB) to maintain availability during voluntary disruptions.
+
+Proper scaling and disruption protection configuration helps ensure your workflows can handle increased load while optimizing resource usage and maintaining availability in your {product-title} cluster.
+
+include::modules/serverless-logic-configuring-workflow-scaling-and-disruption.adoc[leveloffset=+1]
+
+[role="_additional-resources-scaling"]
+[id="additional-resources-scaling_{context}"]
+== Additional resources
+
+* xref:../serverless-logic/serverless-logic-managing-persistence.adoc#serverless-logic-managing-persistence[Managing workflow persistence]
+* xref:../serverless-logic/serverless-logic-supporting-services/serverless-logic-managing-supporting-services.adoc#serverless-logic-managing-supporting-services[Managing supporting services]


### PR DESCRIPTION
Version(s):
- `serverless-docs-1.37`
- `serverless-docs-1.38`

Issue:
- https://redhat.atlassian.net/browse/SRVLOGIC-816
- https://redhat.atlassian.net/browse/SRVLOGIC-817

Link to docs preview:
- [Workflow scaling and disruption protection](https://109727--ocpdocs-pr.netlify.app/openshift-serverless/latest/serverless-logic/serverless-logic-configuring-workflow-scaling.html)

QE review:
- [x] QE has approved this change in https://github.com/openshift/openshift-docs/pull/108120.

Additional information:
New PR to keep the size under **XL**. Original at https://github.com/openshift/openshift-docs/pull/108120.