### PR TITLE
[SRVLOGIC-816|817_b] Add HPA and PDB to supporting services

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -409,6 +409,8 @@ Topics:
   File: serverless-logic-managing-persistence
 - Name: Workflow eventing system
   File: serverless-logic-workflow-eventing-system
+- Name: Configuring workflow scaling and disruption protection
+  File: serverless-logic-configuring-workflow-scaling
 - Name: Configuring custom Maven mirrors
   File: serverless-logic-configuring-custom-maven-mirrors
 - Name: Managing upgrades

--- a/modules/serverless-logic-configuring-hpa.adoc
+++ b/modules/serverless-logic-configuring-hpa.adoc
@@ -1,0 +1,112 @@
+// Module included in the following assemblies:
+// * serverless-logic/serverless-logic-configuring-workflow-scaling.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="serverless-logic-configuring-hpa_{context}"]
+= Configuring horizontal pod autoscaling for workflows
+
+[role="_abstract"]
+By using a `HorizontalPodAutoscaler` (HPA), you can configure how a Kubernetes workload resource scales based on a set of metrics, such as CPU or memory usage.
+
+Workload resources that support autoscaling expose the scale subresource, which allows Kubernetes to adjust the number of replicas dynamically. When you configure horizontal pod autoscaling for a workflow, the {ServerlessLogicOperatorName} automatically manages the coordination between the workflow scale subresource and the associated Kubernetes Deployment, making the workflow pods scale accordingly.
+
+Before configuring an HPA for a workflow, you must define the resources to be used as scaling metrics in the `SonataFlow` CR.
+
+[IMPORTANT]
+====
+The following feature requires {ServerlessLogicProductName} 1.38 or later and is not available in earlier versions.
+====
+
+.Prerequisites
+
+* You have installed the {ServerlessLogicOperatorName}.
+* You have deployed a workflow using the `preview` or `gitops` profile.
+
+.Procedure
+
+. Configure resource requests in your `SonataFlow` CR:
++
+[source,yaml]
+----
+apiVersion: sonataflow.org/v1alpha08
+kind: SonataFlow
+metadata:
+  name: example-workflow
+  namespace: example-workflow-namespace
+  annotations:
+    sonataflow.org/description: Example Workflow
+    sonataflow.org/version: 0.0.1
+    sonataflow.org/profile: preview
+spec:
+  podTemplate:
+    container:
+      resources:
+        requests:
+          cpu: 100m
+          memory: 256Mi
+        limits:
+          cpu: 500m
+          memory: 512Mi
+  flow:
+    start: ExampleStartState
+# ...
+----
++
+This example configures the following resource settings:
++
+* The `spec.podTemplate.container` field supports most of the standard `PodSpec` configurations. For more information, see link:https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#Container[Container] in the Kubernetes documentation.
+* The `resources.requests.cpu` field specifies the CPU request for the workflow container.
+* The `resources.requests.memory` field specifies the memory request for the workflow container.
++
+[NOTE]
+====
+`HorizontalPodAutoscalers` use the request resources for metrics calculations. The resource limits in the example are illustrative and are not used for scaling decisions.
+====
+
+. Create a `HorizontalPodAutoscaler` CR:
++
+[source,yaml]
+----
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: example-autoscaler
+  namespace: example-workflow-namespace
+spec:
+  scaleTargetRef:
+    apiVersion: sonataflow.org/v1alpha08
+    kind: SonataFlow
+    name: example-workflow
+  minReplicas: 2
+  maxReplicas: 5
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 70
+----
++
+This configuration includes the following settings:
++
+* The `scaleTargetRef` field references the target workflow by specifying the `apiVersion`, `kind`, and `name`.
+* The `metrics` field defines a metric based on CPU resource utilization.
+
+. Apply the `HorizontalPodAutoscaler` configuration by running the following command:
++
+[source,terminal,subs="+quotes"]
+----
+$ *oc apply -f example-autoscaler.yaml -n example-workflow-namespace*
+----
+
+[IMPORTANT]
+====
+Workflows deployed with `spec.podTemplate.deploymentModel: knative` cannot be scaled with a `HorizontalPodAutoscaler` because Knative Serving automatically controls the number of replicas. Additionally, workflows deployed using the `dev` profile are not designed to scale.
+====
+
+[role="_additional-resources"]
+[id="additional-resources-hpa_{context}"]
+== Additional resources
+
+* link:https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/[Horizontal Pod Autoscaling] in the Kubernetes documentation

--- a/modules/serverless-logic-configuring-pdb.adoc
+++ b/modules/serverless-logic-configuring-pdb.adoc
@@ -1,0 +1,167 @@
+// Module included in the following assemblies:
+// * serverless-logic/serverless-logic-configuring-workflow-scaling.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="serverless-logic-configuring-pdb_{context}"]
+= Configuring pod disruption budgets for workflows
+
+[role="_abstract"]
+By using a `PodDisruptionBudget` (PDB), you can configure the required availability of a workflow during a voluntary disruption, such as a node drain, in the cluster.
+
+A PDB limits the number of pods that can be unavailable simultaneously during such disruptions, ensuring that the workflow maintains the desired level of availability.
+
+In general, any tool that needs to guarantee availability should respect the PDB by using the Kubernetes Eviction API instead of directly deleting pods or deployments. The Eviction API ensures that disruption constraints defined by the PDB are honored.
+
+The {ServerlessLogicOperatorName} can automatically generate a `PodDisruptionBudget` for a workflow based on the `SonataFlow` CR configuration.
+
+[IMPORTANT]
+====
+The following feature requires {ServerlessLogicProductName} 1.38 or later and is not available in earlier versions.
+====
+
+.Available fields for PDB configuration
+
+To configure a PDB for a workflow, use the `spec.podTemplate.podDisruptionBudget` field in your `SonataFlow` CR:
+
+[source,yaml]
+----
+# ...
+spec:
+  podTemplate:
+    podDisruptionBudget:
+      minAvailable: 2
+      maxUnavailable: 1
+# ...
+----
+
+This configuration includes the following fields:
+
+* `minAvailable` - Specifies the number of pods that must still be available after an eviction. This value can be either an absolute number or a percentage, for example `2` or `50%`.
+* `maxUnavailable` - Specifies the number of pods that can be unavailable after an eviction. This value can be either an absolute number or a percentage, for example `1` or `50%`.
+
+[NOTE]
+====
+The `minAvailable` and `maxUnavailable` fields are mutually exclusive. You must configure only one of these fields. If both fields are specified, the `minAvailable` value takes precedence.
+
+The semantics of these fields are aligned with the corresponding fields in the Kubernetes PodDisruptionBudget. For more information, see link:https://kubernetes.io/docs/concepts/workloads/pods/disruptions/#pod-disruption-budgets[Pod Disruption Budgets] in the Kubernetes documentation.
+====
+
+.PodDisruptionBudget generation rules
+
+The {ServerlessLogicOperatorName} applies the following rules to generate the PDB:
+
+. The PDB is generated only if the workflow has the `spec.podTemplate.podDisruptionBudget` field properly configured.
+. The PDB is generated only if the workflow has `spec.podTemplate.replicas` configured with a value greater than 1.
+. If the workflow has a configured `HorizontalPodAutoscaler` (HPA), the HPA `spec.minReplicas` value takes precedence over the workflow `spec.podTemplate.replicas` value.
+. When an HPA is configured, the PDB is generated only if the HPA `spec.minReplicas` value is greater than 1.
+. If the workflow is scaled to zero (that is, `spec.podTemplate.replicas = 0`), no PDB is generated.
+
+[NOTE]
+====
+If any of the above conditions change after a PDB has been generated, for example, if the workflow is rescaled to 1, the previously generated PDB is automatically deleted.
+====
+
+[IMPORTANT]
+====
+Workflows deployed with `spec.podTemplate.deploymentModel: knative` cannot use a `PodDisruptionBudget` because Knative Serving automatically manages the number of replicas, and a PDB cannot reliably enforce minimum availability. Additionally, workflows deployed using the `dev` profile are not designed to scale.
+====
+
+.Prerequisites
+
+* You have installed the {ServerlessLogicOperatorName}.
+* You have deployed a workflow using the `preview` or `gitops` profile.
+
+.Procedure
+
+. Configure a PDB in your `SonataFlow` CR:
++
+[source,yaml]
+----
+apiVersion: sonataflow.org/v1alpha08
+kind: SonataFlow
+metadata:
+  name: example-workflow
+  namespace: example-workflow-namespace
+  annotations:
+    sonataflow.org/description: Example Workflow
+    sonataflow.org/version: 0.0.1
+    sonataflow.org/profile: preview
+spec:
+  podTemplate:
+    replicas: 2
+    podDisruptionBudget:
+      minAvailable: 1
+  flow:
+    start: ExampleStartState
+# ...
+----
++
+This configuration includes the following settings:
++
+* `replicas: 2` - The workflow runs with 2 replicas.
+* `podDisruptionBudget.minAvailable: 1` - The generated PDB ensures that 1 pod must remain available during a disruption.
+
+. Apply the configuration:
++
+[source,terminal,subs="+quotes"]
+----
+$ *oc apply -f example-workflow.yaml -n example-workflow-namespace*
+----
+
+.Verification
+
+* Verify that the PDB was created:
++
+[source,terminal,subs="+quotes"]
+----
+$ *oc get pdb -n example-workflow-namespace*
+----
++
+[source,terminal]
+----
+NAME               MIN AVAILABLE   MAX UNAVAILABLE   ALLOWED DISRUPTIONS   AGE
+example-workflow   1               N/A               1                     5m
+----
+
+Given this configuration, the {ServerlessLogicOperatorName} generates the following PDB for the workflow:
+
+[source,yaml]
+----
+kind: PodDisruptionBudget
+apiVersion: policy/v1
+metadata:
+  name: example-workflow
+  namespace: example-workflow-namespace
+  ownerReferences:
+    - apiVersion: sonataflow.org/v1alpha08
+      kind: SonataFlow
+      name: example-workflow
+      uid: 5b7f96d4-1ddf-45f7-af38-555d93339cca
+      controller: true
+      blockOwnerDeletion: true
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: example-workflow
+      app.kubernetes.io/component: serverless-workflow
+      app.kubernetes.io/instance: example-workflow
+      app.kubernetes.io/managed-by: sonataflow-operator
+      app.kubernetes.io/name: example-workflow
+      sonataflow.org/workflow-app: example-workflow
+      sonataflow.org/workflow-namespace: example-workflow-namespace
+----
+
+This generated PDB has the following characteristics:
+
+* The PDB has the same name as the workflow.
+* The PDB is created in the same namespace as the workflow.
+* The workflow is configured as the PDB owner.
+* The PDB `minAvailable` field is configured with the value from `spec.podTemplate.podDisruptionBudget.minAvailable` in the workflow CR.
+* The PDB selector is configured to target the workflow pods.
+
+[role="_additional-resources"]
+[id="additional-resources-pdb_{context}"]
+== Additional resources
+
+* link:https://kubernetes.io/docs/concepts/workloads/pods/disruptions/#pod-disruption-budgets[Pod Disruption Budgets] in the Kubernetes documentation

--- a/modules/serverless-logic-scaling-workflow-manually.adoc
+++ b/modules/serverless-logic-scaling-workflow-manually.adoc
@@ -1,0 +1,162 @@
+// Module included in the following assemblies:
+// * serverless-logic/serverless-logic-configuring-workflow-scaling.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="serverless-logic-scaling-workflow-manually_{context}"]
+= Scaling a workflow manually
+
+[role="_abstract"]
+The `SonataFlow` custom resource definition (CRD) exposes the Kubernetes `scale` subresource, which enables you to scale workflows using the standard Kubernetes API. You can scale workflows manually using several methods.
+
+[IMPORTANT]
+====
+The following feature requires {ServerlessLogicProductName} 1.38 or later and is not available in earlier versions.
+====
+
+[NOTE]
+====
+Workflows deployed with the `dev` profile are intended for development use and are not designed for scaling.
+====
+
+[id="querying-workflow-scale-subresource_{context}"]
+== Querying the workflow scale subresource
+
+To query the workflow `scale` subresource, run the following command:
+
+[source,terminal,subs="+quotes"]
+----
+$ *oc get sonataflow <workflow_name> -n <namespace> --subresource=scale -o yaml*
+----
+
+[source,yaml]
+----
+apiVersion: autoscaling/v1
+kind: Scale
+metadata:
+  creationTimestamp: "2026-02-12T12:48:46Z"
+  name: example-workflow
+  namespace: example-workflow-namespace
+  resourceVersion: "38397"
+  uid: de53b549-dcb5-4b46-bb4e-9a576341e099
+spec:
+  replicas: 1
+status:
+  replicas: 1
+  selector: app=example-workflow,app.kubernetes.io/component=serverless-workflow,app.kubernetes.io/instance=example-workflow,app.kubernetes.io/managed-by=sonataflow-operator,app.kubernetes.io/name=example-workflow,app.kubernetes.io/version=main,sonataflow.org/workflow-app=example-workflow,sonataflow.org/workflow-namespace=example-workflow-namespace
+----
+
+The output displays the following information:
+
+* `spec.replicas` - Number of configured replicas.
+* `status.replicas` - Number of currently available replicas.
+* `status.selector` - Selector to query the observed pods.
+
+[id="scaling-workflow-manually-methods_{context}"]
+== Scaling methods
+
+You can scale a workflow using any of the following methods:
+
+.Scaling using the oc scale command
+
+. Run the following command:
++
+[source,terminal,subs="+quotes"]
+----
+$ *oc scale sonataflow <workflow_name> -n <namespace> --replicas=<number>*
+----
++
+where:
++
+`<workflow_name>`:: Specifies the name of your workflow.
+`<namespace>`:: Specifies the namespace where your workflow is deployed.
+`<number>`:: Specifies the desired number of replicas.
+
++
+[source,terminal,subs="+quotes"]
+----
+$ *oc scale sonataflow example-workflow -n example-workflow-namespace --replicas=3*
+----
+
+[source,terminal]
+----
+sonataflow.sonataflow.org/example-workflow scaled
+----
+
+.Scaling by configuring the SonataFlow custom resource
+
+. Edit your `SonataFlow` CR to include the `spec.podTemplate.replicas` field:
++
+[source,yaml]
+----
+apiVersion: sonataflow.org/v1alpha08
+kind: SonataFlow
+metadata:
+  name: example-workflow
+  namespace: example-workflow-namespace
+  annotations:
+    sonataflow.org/description: Example Workflow
+    sonataflow.org/version: 0.0.1
+    sonataflow.org/profile: preview
+spec:
+  podTemplate:
+    replicas: 3
+  flow:
+    start: ExampleStartState
+# ...
+----
++
+Use the `spec.podTemplate.replicas` field to configure the number of replicas.
+
+. Apply the configuration:
++
+[source,terminal,subs="+quotes"]
+----
+$ *oc apply -f example-workflow.yaml -n example-workflow-namespace*
+----
++
+[source,terminal]
+----
+sonataflow.sonataflow.org/example-workflow configured
+----
+
+.Scaling by patching the SonataFlow custom resource
+
+. Run the following command:
++
+[source,terminal,subs="+quotes"]
+----
+$ *oc patch sonataflow <workflow_name> -n <namespace> \
+  --type merge \
+  -p '{
+    "spec": {
+      "podTemplate": {
+        "replicas": <number>
+      }
+    }
+  }'*
+----
++
+where:
++
+`<workflow_name>`:: Specifies the name of your workflow.
+`<namespace>`:: Specifies the namespace where your workflow is deployed.
+`<number>`:: Specifies the desired number of replicas.
+
++
+[source,terminal,subs="+quotes"]
+----
+$ *oc patch sonataflow example-workflow -n example-workflow-namespace \
+  --type merge \
+  -p '{
+    "spec": {
+      "podTemplate": {
+        "replicas": 3
+      }
+    }
+  }'*
+----
++
+[source,terminal]
+----
+sonataflow.sonataflow.org/example-workflow patched
+----

--- a/modules/serverless-logic-supporting-services-advanced-configuration.adoc
+++ b/modules/serverless-logic-supporting-services-advanced-configuration.adoc
@@ -1,13 +1,13 @@
 // Module included in the following assemblies:
-// * serverless-logic/serverless-logic-managing-supporting-services
+// * serverless-logic/serverless-logic-managing-supporting-services.adoc
 
 
 :_mod-docs-content-type: REFERENCE
 [id="serverless-logic-supporting-services-advanced-configuration_{context}"]
-= Advanced supporting services configurations
+= Advanced supporting services configuration options
 
 [role="_abstract"]
-In scenarios where you must apply advanced configurations for supporting services, use the `podTemplate` field in the `SonataFlowPlatform` custom resource (CR). This field allows you to customize the service pod deployment by specifying configurations like the number of replicas, environment variables, container images, and initialization options.
+In scenarios where you must apply advanced configurations for supporting services, use the `podTemplate` field in the `SonataFlowPlatform` custom resource (CR). This field allows you to customize the service pod deployment by specifying configurations like the number of replicas, environment variables, container images, resource requirements, and initialization options.
 
 You can configure advanced settings for the service by using the following example:
 
@@ -21,29 +21,42 @@ metadata:
   namespace: example-namespace
 spec:
   services:
-    # This can be either 'dataIndex' or 'jobService'
     dataIndex:
       enabled: true
       podTemplate:
-        replicas: 2 <1>
-        container: <2>
-          env: <3>
+        replicas: 2
+        container:
+          env:
             - name: <any_advanced_config_property>
               value: <any_value>
-          image: <4>
-        initContainers: <5>
+          image:
+          resources:
+            limits:
+              cpu:
+              memory:
+            requests:
+              cpu:
+              memory:
+        initContainers:
+# ...
 ----
 
 [NOTE]
 ====
-You can set the 'services' field to either 'dataIndex' or 'jobService' depending on your requirement. The rest of the configuration remains the same.
+You can set either `spec.services.dataIndex` or `spec.services.jobService` depending on your requirement. The rest of the configuration remains the same.
 ====
 
-<1> Defines the number of replicas. Default value is `1`. In the case of `jobService`, this value is always overridden to `1` because it operates as a singleton service.
-<2> Holds specific configurations for the container running the service.
-<3> Allows you to fine-tune service properties by specifying environment variables.
-<4> Configures the container image for the service, useful if you need to update or customize the image.
-<5> Configures init containers for the pod, useful for setting up prerequisites before the main container starts.
+This configuration includes the following settings:
+
+* `replicas` - Defines the number of replicas. Default value is `1`. In the case of `jobService`, this value is always overridden to `1` because it operates as a singleton service.
+* `container` - Holds specific configurations for the container running the service.
+* `env` - Allows you to fine-tune service properties by specifying environment variables.
+* `image` - Configures the container image for the service, useful if you need to update or customize the image.
+* `resources.limits.cpu` - Configures the CPU limit. Default value is `200m`.
+* `resources.limits.memory` - Configures the memory limit. Default value is `1Gi`.
+* `resources.requests.cpu` - Configures the CPU request. Default value is `100m`.
+* `resources.requests.memory` - Configures the memory request. Default value is `1Gi`.
+* `initContainers` - Configures init containers for the pod, useful for setting up prerequisites before the main container starts.
 
 [NOTE]
 ====

--- a/modules/serverless-logic-supporting-services-hpa-configuration.adoc
+++ b/modules/serverless-logic-supporting-services-hpa-configuration.adoc
@@ -1,0 +1,109 @@
+// Module included in the following assemblies:
+// * serverless-logic/serverless-logic-managing-supporting-services.adoc
+
+
+:_mod-docs-content-type: PROCEDURE
+[id="serverless-logic-supporting-services-autoscaling_{context}"]
+= Configuring horizontal pod autoscaling for Data Index
+
+[role="_abstract"]
+By using a `HorizontalPodAutoscaler` (HPA), you can configure how a Kubernetes workload resource scales based on a set of metrics, such as CPU or memory usage.
+
+You can configure horizontal pod autoscaling for the Data Index service to automatically scale based on resource utilization. The Job Service does not support autoscaling because it operates as a singleton service.
+
+[IMPORTANT]
+====
+This feature requires {ServerlessLogicProductName} 1.38 or later and is not available in earlier versions.
+====
+
+.Prerequisites
+
+* You have deployed a `SonataFlowPlatform` custom resource (CR) with the Data Index service enabled.
+* You have configured resource requests for the Data Index service.
+
+.Procedure
+
+. Determine the Data Index deployment name:
++
+The deployment name follows the pattern: `<sonataflowplatform-name>-data-index-service`.
++
+For example, if your `SonataFlowPlatform` CR is named `sonataflow-platform-example`, the deployment name is `sonataflow-platform-example-data-index-service`.
+
+. Create a `HorizontalPodAutoscaler` CR that targets the Data Index deployment:
++
+[source,yaml]
+----
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: data-index-example-autoscaler
+  namespace: example-namespace
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: sonataflow-platform-example-data-index-service
+  minReplicas: 3
+  maxReplicas: 5
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 70
+----
++
+where:
++
+* `metrics` - Defines metrics based on CPU resource utilization.
+
+. Apply the `HorizontalPodAutoscaler` configuration by running the following command:
++
+[source,terminal,subs="+quotes"]
+----
+$ oc apply -f data-index-autoscaler.yaml -n example-namespace
+----
+
+.Verification
+
+* Verify that the HPA is configured correctly by running the following command:
++
+[source,terminal,subs="+quotes"]
+----
+$ oc get hpa -n example-namespace
+----
+
+[NOTE]
+====
+When the {ServerlessLogicOperatorName} detects a `HorizontalPodAutoscaler` targeting the Data Index deployment, replica management is delegated to the HPA controller. If you remove the `HorizontalPodAutoscaler`, the operator resumes control of replica management.
+====
+
+[NOTE]
+====
+You can configure the `HorizontalPodAutoscaler` metrics using any of the resource requests automatically configured by the {ServerlessLogicOperatorName}. The default resource values are:
+
+[source,yaml]
+----
+resources:
+  limits:
+    cpu: 200m
+    memory: 1Gi
+  requests:
+    cpu: 100m
+    memory: 1Gi
+----
+
+To modify these default values, configure the `resources` field in the `podTemplate` as shown in the advanced configurations example.
+====
+
+[IMPORTANT]
+====
+Integration with a `HorizontalPodAutoscaler` (HPA) is supported only for the Data Index service. You must not create an HPA for the Job Service, as it is designed to run as a singleton service. Any HPA configuration targeting the Job Service might cause conflicts with the {ServerlessLogicOperatorName}, because the operator manages the replica count for that service.
+====
+
+[role="_additional-resources"]
+[id="additional-resources-hpa_{context}"]
+== Additional resources
+
+* link:https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/[Horizontal Pod Autoscaling] in the Kubernetes documentation

--- a/modules/serverless-logic-supporting-services-pdb-configuration.adoc
+++ b/modules/serverless-logic-supporting-services-pdb-configuration.adoc
@@ -1,0 +1,158 @@
+// Module included in the following assemblies:
+// * serverless-logic/serverless-logic-managing-supporting-services.adoc
+
+
+:_mod-docs-content-type: PROCEDURE
+[id="serverless-logic-supporting-services-pdb_{context}"]
+= Configuring pod disruption budgets for Data Index
+
+[role="_abstract"]
+By using a `PodDisruptionBudget` (PDB), you can configure the required availability of a Kubernetes `Deployment` during a voluntary disruption, such as a node drain, in the cluster. This also applies to the Data Index service `Deployment`.
+
+[IMPORTANT]
+====
+This feature requires {ServerlessLogicProductName} 1.38 or later and is not available in earlier versions.
+====
+
+A PDB limits the number of pods that can be unavailable simultaneously during such disruptions, ensuring that the Data Index maintains the desired level of availability.
+
+In general, any tool that needs to guarantee availability should respect the PDB by using the Kubernetes Eviction API instead of directly deleting pods or deployments. The Eviction API ensures that disruption constraints defined by the PDB are honored.
+
+The {ServerlessLogicOperatorName} can automatically generate a PDB for the Data Index based on the `SonataFlowPlatform` custom resource (CR) configuration.
+
+To configure a PDB for the Data Index, use the `spec.services.dataIndex.podTemplate.podDisruptionBudget` field in your `SonataFlowPlatform` CR. The following fields are available:
+
+[source,yaml]
+----
+# ...
+spec:
+  services:
+    dataIndex:
+      podTemplate:
+        podDisruptionBudget:
+          minAvailable: 2
+          maxUnavailable: 1
+# ...
+----
+
+This configuration includes the following fields:
+
+* `minAvailable` - Specifies the number of pods that must still be available after an eviction. This value can be either an absolute number or a percentage, for example `2` or `50%`.
+* `maxUnavailable` - Specifies the number of pods that can be unavailable after an eviction. This value can be either an absolute number or a percentage, for example `1` or `50%`.
+
+[NOTE]
+====
+The `minAvailable` and `maxUnavailable` fields are mutually exclusive. You must configure only one of these fields. If both fields are specified, the `minAvailable` value takes precedence.
+
+The semantics of these fields are aligned with the corresponding fields in the Kubernetes PodDisruptionBudget. For more information, see the link:https://kubernetes.io/docs/concepts/workloads/pods/disruptions/#pod-disruption-budgets[Pod Disruption Budgets] in the Kubernetes documentation.
+====
+
+[IMPORTANT]
+====
+The `podDisruptionBudget` configuration and automatic PDB generation are supported only for the Data Index service. Any `podDisruptionBudget` configuration defined for the Job Service is ignored by the {ServerlessLogicOperatorName}.
+====
+
+The {ServerlessLogicOperatorName} applies the following generation rules for the PDB:
+
+. The PDB is generated only if the `SonataFlowPlatform` CR has the `spec.services.dataIndex.podTemplate.podDisruptionBudget` field properly configured.
+. The PDB is generated only if the `SonataFlowPlatform` CR has the `spec.services.dataIndex.podTemplate.replicas` field configured with a value greater than 1.
+. If the Data Index `Deployment` has a configured `HorizontalPodAutoscaler` (HPA), the HPA `spec.minReplicas` value takes precedence over the `SonataFlowPlatform` CR `spec.services.dataIndex.podTemplate.replicas` value.
+. When an HPA is configured, the PDB is generated only if the HPA `spec.minReplicas` value is greater than 1.
+. If the Data Index is scaled to zero (that is, `spec.services.dataIndex.podTemplate.replicas = 0`), no PDB is generated.
+
+[NOTE]
+====
+If any of the above conditions change after a PDB has been generated, for example, if the Data Index is rescaled to 1, the previously generated PDB is automatically deleted.
+====
+
+.Prerequisites
+
+* You have deployed a `SonataFlowPlatform` CR with the Data Index service enabled.
+
+.Procedure
+
+. Configure a PDB for the Data Index in your `SonataFlowPlatform` CR:
++
+[source,yaml]
+----
+apiVersion: sonataflow.org/v1alpha08
+kind: SonataFlowPlatform
+metadata:
+  name: sonataflow-platform-example
+  namespace: example-namespace
+spec:
+  services:
+    dataIndex:
+      enabled: true
+      podTemplate:
+        replicas: 2
+        podDisruptionBudget:
+          minAvailable: 1
+    jobService:
+      enabled: true
+# ...
+----
++
+This configuration includes the following settings:
++
+* `replicas: 2` - The Data Index runs with 2 replicas.
+* `podDisruptionBudget.minAvailable: 1` - The generated PDB ensures that 1 pod must remain available during a disruption.
+
+. Apply the configuration by running the following command:
++
+[source,terminal,subs="+quotes"]
+----
+$ oc apply -f sonataflow-platform-example.yaml -n example-namespace
+----
+
+.Verification
+
+* Verify that the PDB was created by running the following command:
++
+[source,terminal,subs="+quotes"]
+----
+$ oc get pdb -n example-namespace
+----
++
+[source,terminal]
+----
+NAME                                                MIN AVAILABLE   MAX UNAVAILABLE   ALLOWED DISRUPTIONS   AGE
+sonataflow-platform-example-data-index-service     1               N/A               1                     5m
+----
+
+Given this configuration, the {ServerlessLogicOperatorName} generates the following PDB for the Data Index:
+
+[source,yaml]
+----
+kind: PodDisruptionBudget
+apiVersion: policy/v1
+metadata:
+  name: sonataflow-platform-example-data-index-service
+  namespace: example-namespace
+  ownerReferences:
+    - apiVersion: sonataflow.org/v1alpha08
+      kind: SonataFlowPlatform
+      name: sonataflow-platform-example
+      uid: 5e94401d-e645-47f6-abd0-5261b471a9d7
+      controller: true
+      blockOwnerDeletion: true
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      sonataflow.org/service: sonataflow-platform-example-data-index-service
+----
+
+This generated PDB has the following characteristics:
+
+* The PDB has the same name as the Data Index `Deployment`.
+* The PDB is created in the same namespace as the `SonataFlowPlatform` CR.
+* The `SonataFlowPlatform` CR is configured as the PDB owner.
+* The PDB `minAvailable` field is configured with the value from `spec.services.dataIndex.podTemplate.podDisruptionBudget.minAvailable` in the `SonataFlowPlatform` CR.
+* The PDB selector is configured to target the Data Index `Deployment` pods.
+
+[role="_additional-resources"]
+[id="additional-resources-pdb_{context}"]
+== Additional resources
+
+* link:https://kubernetes.io/docs/concepts/workloads/pods/disruptions/#pod-disruption-budgets[Pod Disruption Budgets] in the Kubernetes documentation

--- a/serverless-logic/serverless-logic-configuring-workflow-scaling.adoc
+++ b/serverless-logic/serverless-logic-configuring-workflow-scaling.adoc
@@ -1,0 +1,31 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="serverless-logic-configuring-workflow-scaling"]
+= Workflow scaling and disruption protection
+
+include::_attributes/common-attributes.adoc[]
+:context: serverless-logic-configuring-workflow-scaling
+
+toc::[]
+
+[role="_abstract"]
+You can configure scaling and disruption protection for your {ServerlessLogicProductName} workflows to handle varying workloads efficiently and maintain availability during cluster maintenance operations. This section describes how to scale workflows manually, configure horizontal pod autoscaling (HPA) for automatic scaling based on resource utilization metrics, and configure pod disruption budgets (PDB) to maintain availability during voluntary disruptions.
+
+Proper scaling and disruption protection configuration helps ensure your workflows can handle increased load while optimizing resource usage and maintaining availability in your {product-title} cluster.
+
+[IMPORTANT]
+====
+The following features require {ServerlessLogicProductName} 1.38 or later and are not available in earlier versions.
+====
+
+include::modules/serverless-logic-scaling-workflow-manually.adoc[leveloffset=+1]
+
+include::modules/serverless-logic-configuring-hpa.adoc[leveloffset=+1]
+
+include::modules/serverless-logic-configuring-pdb.adoc[leveloffset=+1]
+
+[role="_additional-resources-scaling"]
+[id="additional-resources-scaling_{context}"]
+== Additional resources
+
+* xref:../serverless-logic/serverless-logic-managing-persistence.adoc#serverless-logic-managing-persistence[Managing workflow persistence]
+* xref:../serverless-logic/serverless-logic-supporting-services/serverless-logic-managing-supporting-services.adoc#serverless-logic-managing-supporting-services[Managing supporting services]

--- a/serverless-logic/serverless-logic-supporting-services/serverless-logic-managing-supporting-services.adoc
+++ b/serverless-logic/serverless-logic-supporting-services/serverless-logic-managing-supporting-services.adoc
@@ -1,6 +1,7 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="serverless-logic-managing-supporting-services"]
 = Managing supporting services
+
 include::_attributes/common-attributes.adoc[]
 :context: serverless-logic-managing-supporting-services
 
@@ -44,6 +45,10 @@ include::modules/serverless-logic-supporting-services-eventing-system-precedence
 include::modules/serverless-logic-supporting-services-eventing-system-linking-objects.adoc[leveloffset=+2]
 
 include::modules/serverless-logic-supporting-services-advanced-configuration.adoc[leveloffset=+1]
+
+include::modules/serverless-logic-supporting-services-hpa-configuration.adoc[leveloffset=+2]
+
+include::modules/serverless-logic-supporting-services-pdb-configuration.adoc[leveloffset=+2]
 
 include::modules/serverless-logic-cluster-scope-supporting-services.adoc[leveloffset=+1]
  


### PR DESCRIPTION
Version(s):
- `serverless-docs-1.37`
- `serverless-docs-1.38`

Issue:
- https://redhat.atlassian.net/browse/SRVLOGIC-816
- https://redhat.atlassian.net/browse/SRVLOGIC-817

Link to docs preview:
- [Configuring horizontal pod autoscaling for Data Index](https://109728--ocpdocs-pr.netlify.app/openshift-serverless/latest/serverless-logic/serverless-logic-supporting-services/serverless-logic-managing-supporting-services.html#serverless-logic-supporting-services-autoscaling_serverless-logic-managing-supporting-services)

QE review:
- [x] QE has approved this change in https://github.com/openshift/openshift-docs/pull/108120.

Additional information:
New PR to keep the size under **XL**. Original at https://github.com/openshift/openshift-docs/pull/108120.