### PR TITLE
OBSDOCS-3270: Added z-stream release notes for 6.0.14.

### DIFF
--- a/modules/logging-release-notes-6-0-14.adoc
+++ b/modules/logging-release-notes-6-0-14.adoc
@@ -1,0 +1,16 @@
+// Module included in the following assemblies:
+//
+// * release_notes/logging-release-notes-6.0.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="logging-release-notes-6-0-14_{context}"]
+= Logging 6.0.14
+
+This release includes link:https://access.redhat.com/errata/RHSA-2026:7052[RHBA-2026:7052].
+
+[id="logging-release-notes-6-0-14-cves_{context}"]
+== CVEs
+
+* link:https://access.redhat.com/security/cve/CVE-2025-61726[CVE-2025-61726]
+* link:https://access.redhat.com/security/cve/CVE-2025-61729[CVE-2025-61729]
+* link:https://access.redhat.com/security/cve/CVE-2025-68121[CVE-2025-68121]

--- a/release_notes/logging-release-notes-6-0.adoc
+++ b/release_notes/logging-release-notes-6-0.adoc
@@ -7,6 +7,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+include::modules/logging-release-notes-6-0-14.adoc[leveloffset=+1]
+
 include::modules/logging-release-notes-6-0-13.adoc[leveloffset=+1]
 
 include::modules/logging-release-notes-6-0-12.adoc[leveloffset=+1]
@@ -60,7 +62,7 @@ include::snippets/logging-compatibility-snip.adoc[]
 
 [NOTE]
 ====
-In order to continue to use Elasticsearch and Kibana managed by the elasticsearch-operator, the administrator must modify those object's ownerRefs before deleting the ClusterLogging resource.
+To continue to use Elasticsearch and Kibana managed by the elasticsearch-operator, the administrator must modify those object's ownerRefs before deleting the ClusterLogging resource.
 ====
 
 [id="log6x-release-notes-6-0-0-enhancements"]


### PR DESCRIPTION
Added z-stream release notes for 6.0.14. NOTE: The errata link must be updated.

Version(s): 6.0

Issue: https://redhat.atlassian.net/browse/OBSDOCS-3270
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://109729--ocpdocs-pr.netlify.app/openshift-logging/latest/release_notes/logging-release-notes-6-0.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
