### PR TITLE
RHDEVDOCS-7083: CQA 2.0 fixes for Managing the application resources in non-control plane namespaces

### DIFF
--- a/argocd_applications/managing-apps-in-non-control-plane-namespaces.adoc
+++ b/argocd_applications/managing-apps-in-non-control-plane-namespaces.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY   
+:_mod-docs-content-type: ASSEMBLY
 include::_attributes/common-attributes.adoc[]
 [id="managing-apps-in-non-control-plane-namespaces"]
 = Managing the application resources in non-control plane namespaces

--- a/modules/gitops-configuring-argo-cd-cr-of-your-user-defined-cluster-scoped-instance-with-target-namespaces.adoc
+++ b/modules/gitops-configuring-argo-cd-cr-of-your-user-defined-cluster-scoped-instance-with-target-namespaces.adoc
@@ -74,8 +74,8 @@ metadata:
 --
 where:
 
-`metadata.name`:: Specifies the namespace of the user-defined cluster-scoped Argo CD instance.
-`spec.sourceRepos` or `spec.destinations` (Application):: the target namespace for the Argo CD server to create and manage `Application` resources.
+`metadata.name`:: Specifies the name of the namespace.
+`argocd.argoproj.io/managed-by-cluster-argocd`:: Specifies the Argo CD instance (`spring-petclinic`) that owns and manages this namespace.
 --
 
 . Verify that Operator adds the `argocd.argoproj.io/managed-by-cluster-argocd` label to the specified namespace:
@@ -88,6 +88,9 @@ The *Namespaces* page displays the created target namespaces.
 .. Click the target namespace and go to the *YAML* tab to verify the `argocd.argoproj.io/managed-by-cluster-argocd` label added by the Operator.
 
 .Verification
+
+When you create a cluster-scoped Argo CD instance, the {gitops-shortname} Operator automatically creates the required RBAC resources. Verify that these resources exist to ensure that the Argo CD instance can manage cluster-scoped and namespace-scoped resources.
+
 . Verify that your user-defined cluster-scoped Argo CD instance is configured with a cluster role to manage cluster-scoped resources:
 .. Go to *User Management* -> *Roles* and from the *Filter* list, select *Cluster-wide Roles*.
 .. Search for the created cluster roles by using the *Search by name* field. For example, `example-spring-petclinic-argocd-application-controller` and `example-spring-petclinic-argocd-server`.

--- a/modules/gitops-creating-and-configuring-the-app-cr-to-reference-the-target-namespace-and-user-defined-appproject-instance.adoc
+++ b/modules/gitops-creating-and-configuring-the-app-cr-to-reference-the-target-namespace-and-user-defined-appproject-instance.adoc
@@ -9,6 +9,7 @@
 As a cluster administrator, you can define a certain set of non-control plane namespaces in which users can create, update, and reconcile `Application` resources. After you configure the target namespaces in the `.spec.sourceNamespaces` field of the user-defined `AppProject` instance, you must explicitly create and configure the `Application` custom resource (CR) with the parameters for the `metadata.namespace` and `.spec.project` fields to reference the target namespace and user-defined `AppProject` instance.
 
 .Prerequisites
+
 * You are logged in to the {OCP} cluster as an administrator.
 * You have installed {gitops-title} 1.13.0 or a later version on your {OCP} cluster.
 
@@ -20,7 +21,7 @@ As a cluster administrator, you can define a certain set of non-control plane na
 .. Click *Create Application* and enter the following configuration in the YAML view:
 +
 --
-*Example user-defined `AppProject` instance:*
+*Example Application CR:*
 [source,yaml]
 ----
 kind: Application
@@ -32,17 +33,21 @@ spec:
   project: project-one
   # ...
 ----
+--
 +
 --
 where:
 
 `metadata.name`:: Specifies the name of the application.
-`spec.project` (Application):: the name of the target namespace for the Argo CD server to create and manage `Application` resources.
-`spec.project` (AppProject):: the name of the user-defined `AppProject` instance.
+`metadata.namespace`:: Specifies the target namespace where the Application CR is created.
+`spec.project`:: Specifies the name of the AppProject that this application belongs to.
 --
 .. Click *Create*.
++
+--
+The *Applications* page displays the created application. 
 --
 +
-The *Applications* page displays the created application. 
-+
-The `cluster-configs` Argo CD application now has the statuses *Healthy* and *Synced*. 
+--
+The `cluster-configs` Argo CD application now has the statuses *Healthy* and *Synced*.
+--

--- a/modules/gitops-creating-and-configuring-user-defined-appproject-instance-with-target-namespaces.adoc
+++ b/modules/gitops-creating-and-configuring-user-defined-appproject-instance-with-target-namespaces.adoc
@@ -14,6 +14,7 @@ Applications in the {gitops-shortname} control plane namespace (`openshift-gitop
 ====
 
 .Prerequisites
+
 * You are logged in to the {OCP} cluster as an administrator.
 * You have installed {gitops-title} 1.13.0 or a later version on your {OCP} cluster.
 
@@ -34,26 +35,24 @@ metadata:
   namespace: openshift-gitops
 spec:
   sourceNamespaces:
-  - dev
-  - app-team-*
+    - dev
+    - app-team-*
   destinations:
     - name: '*'
       namespace: '*'
       server: '*'
-   sourceRepos:
-    - '*'     
+  sourceRepos:
+    - '*'
 ----
 +
 --
 where:
 
-`kind` (AppProject):: Specifies the name of the user-defined `AppProject` instance.
-`kind` (AppProject):: Specifies the control plane namespace where you want to run the user-defined `AppProject` instance.
-`spec` (Application):: Specifies the list of non-control plane namespaces for creating and managing `Application` resources.
-`spec` (Application):: Specifies the name of the target namespace for the Argo CD server to create and manage `Application` resources.
-`spec.sourceRepos` or `spec.destinations` (wildcard [*]):: Specifies a wildcard (`[*]`), that contains the name of the target namespaces matching the pattern `app-team-pass:[*]`, such as `app-team-1` and `app-team-2`, for the Argo CD server to create and manage `Application` resources.
-`kind` (AppProject):: Specifies the references to the clusters and namespaces into which applications within the user-defined `AppProject` instance can deploy.
-`kind` (AppProject):: Specifies the references to the repositories from which applications within the user-defined `AppProject` instance can pull manifests.
+`metadata.name`:: Specifies the name of the user-defined `AppProject` instance.
+`metadata.namespace`:: Specifies the control plane namespace where you want to run the user-defined `AppProject` instance.
+`spec.sourceNamespaces`:: Specifies the list of non-control plane namespaces for creating and managing `Application` resources.
+`spec.destinations`:: Specifies the clusters and namespaces where applications within this `AppProject` can deploy resources. Using wildcard values allows deployments to any cluster, server, or namespace.
+`spec.sourceRepos`:: Specifies the Git repositories from which applications within this `AppProject` can pull manifests. Using a wildcard allows any repository.
 --
 .. Click *Create*.
 +


### PR DESCRIPTION
This is a manual cherry-pick of https://github.com/openshift/openshift-docs/pull/108441.