### PR TITLE
OSDOCS-19027:Added new instance types.

### DIFF
--- a/modules/osd-release-notes-Q2-2026.adoc
+++ b/modules/osd-release-notes-Q2-2026.adoc
@@ -8,6 +8,8 @@
 [role="_abstract"]
 The following items were added during the second quarter of 2026.
 
+* **Support for new {gcp-short} instances.** You can now create clusters with `g2` and `g4` instance types on {product-title} version 4.21 and later. For more information, see link:https://docs.redhat.com/en/documentation/openshift_dedicated/4/html/introduction_to_openshift_dedicated/policies-and-service-definition#gcp-compute-types_osd-service-definition[{gcp-full} instance types].
+
 * **{product-title} managed DNS zones now available.**
 You can now create and manage your own DNS zones for Shared VPC deployments on {GCP}, giving you greater control over your {product-title} cluster's network configuration and security. This new capability allows you to maintain ownership of your DNS infrastructure while still leveraging the powerful features of {product-title}.
 +
@@ -18,3 +20,4 @@ To support these managed DNS zones, additional permissions have been added to th
 For more information about managed DNS zones for {product-title} on {GCP}, see link:https://docs.redhat.com/en/documentation/openshift_dedicated/4/html/planning_your_environment/gcp-ccs#ocm-cli-create-managed-dns-zone_gcp-ccs[Creating a managed DNS zone].
 
 * **Support for new {gcp-short} instances.** {product-title} version 4.18 and later now supports `c2d`, `c3d`, `n2d` and `t2d` instance types on {gcp-full}. For more information, see link:https://docs.redhat.com/en/documentation/openshift_dedicated/4/html/introduction_to_openshift_dedicated/policies-and-service-definition#gcp-compute-types_osd-service-definition[{gcp-full} compute types].
+

--- a/modules/sdpolicy-am-gcp-compute-types.adoc
+++ b/modules/sdpolicy-am-gcp-compute-types.adoc
@@ -9,9 +9,14 @@
 {product-title} offers the following worker node types and sizes on {gcp-full} that are chosen to have a common CPU and memory capacity that are the same as other cloud instance types:
 [NOTE]
 ====
-`a2`, `a3`, `e2`, `c3`, `n4`, `c2d`, `c3d`, `n2d`, and `t2d` instance types are available for Customer Cloud Subscription (CCS) only.
 
-`c3` and `n4` instance types are available for {osd} version 4.18 and later.
+`a2`, `a3`, `e2`, `c3`, `n4`, `c2d`, `c3d`, `g2`, `g4`, `n2d`, and `t2d` instance types are available for clusters created with the Customer Cloud Subscription (CCS) infrastructure type only.
+
+`custom`, `c2`, and `n2` instance types are available for clusters created with both CCS and Red{nbsp}Hat cloud account infrastructure types.
+
+`g2` and `g4` instance types are available for {product-title} version 4.21 and later.
+
+`c3` and `n4` instance types are available for {product-title} version 4.18 and later.
 ====
 
 .General purpose
@@ -197,10 +202,6 @@
 * n4-highcpu-48 (48 vCPU, 96 GiB)
 * n4-highcpu-64 (64 vCPU, 128 GiB)
 * n4-highcpu-80 (80 vCPU, 160 GiB)
-
-
-
-
 ====
 
 .Accelerated computing
@@ -221,4 +222,19 @@
 * a3-highgpu-8g (208 vCPU, 1872 GiB)
 * a3-megagpu-8g (208 vCPU, 1872 GiB)
 * a3-edgegpu-8g (208 vCPU, 1872 GiB)
+* g2-standard-4 (4 vCPU, 16 GiB)
+* g2-standard-8 (8 vCPU, 32 GiB)
+* g2-standard-12 (12 vCPU, 48 GiB)
+* g2-standard-16 (16 vCPU, 64 GiB)
+* g2-standard-24 (24 vCPU, 96 GiB)
+* g2-standard-32 (32 vCPU, 128 GiB)
+* g2-standard-48 (48 vCPU, 192 GiB)
+* g2-standard-96 (96 vCPU, 384 GiB)
+* g4-standard-6 (6 vCPU, 22 GiB)
+* g4-standard-12 (12 vCPU, 45 GiB)
+* g4-standard-24 (24 vCPU, 90 GiB)
+* g4-standard-48 (48 vCPU, 180 GiB)
+* g4-standard-96 (96 vCPU, 360 GiB)
+* g4-standard-192 (192 vCPU, 720 GiB)
+* g4-standard-384 (384 vCPU, 1440 GiB)
 ====


### PR DESCRIPTION
Version(s):
4.21+

Issue:
[OSDOCS-19027](https://redhat.atlassian.net/browse/OSDOCS-19027)

Link to docs preview:

- [Google Cloud instance types](https://109744--ocpdocs-pr.netlify.app/openshift-dedicated/latest/osd_architecture/osd_policy/osd-service-definition.html#gcp-compute-types_osd-service-definition)
- [What's new](https://109744--ocpdocs-pr.netlify.app/openshift-dedicated/latest/osd_whats_new/osd-whats-new.html)

Peer review:
- [x] Peer reviewer has approved this change.

SME review:
- [x] SME has approved this change.


Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
