### PR TITLE
[enterprise-4.16]_[OCPBUGS#35043]: Added_note_for_interface_names #109289 

### DIFF
--- a/modules/agent-configuration-parameters.adoc
+++ b/modules/agent-configuration-parameters.adoc
@@ -92,8 +92,13 @@ If a `NetworkConfig` section is provided in the `agent-config.yaml` file, this t
 |hosts:
   interfaces:
     name:
-|The name of an interface on the host.
-|String.
+a|The name of an interface on the host.
+[NOTE]
+====
+This value does not need to match the device name.
+====
+
+|*Value:* String.
 
 |hosts:
   interfaces:

--- a/modules/agent-install-sample-config-bond-sriov.adoc
+++ b/modules/agent-install-sample-config-bond-sriov.adoc
@@ -101,6 +101,11 @@ hosts:
 <1> The `networkConfig` field includes information about the network configuration of the host, with subfields including `interfaces`,`dns-resolver`, and `routes`.
 <2> The `interfaces` field is an array of network interfaces defined for the host.
 <3> The name of the interface.
++
+[NOTE]
+====
+This value does not need to match the device name.
+====
 <4> The type of interface. This example creates an ethernet interface.
 <5> Set this to `false` to disable DHCP for the physical function (PF) if it is not strictly required.
 <6> Set this to the number of SR-IOV virtual functions (VFs) to instantiate.

--- a/modules/agent-install-sample-config-bonds-vlans.adoc
+++ b/modules/agent-install-sample-config-bonds-vlans.adoc
@@ -63,6 +63,11 @@ The following `agent-config.yaml` file is an example of a manifest for bond and 
               table-id: 254
 ----
 <1> Name of the interface.
++
+[NOTE]
+====
+This value does not need to match the device name.
+====
 <2> The type of interface. This example creates a VLAN.
 <3> The type of interface. This example creates a bond.
 <4> The mac address of the interface.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.16

Issue:
https://redhat.atlassian.net/browse/OCPBUGS-37922

Link to docs preview:
1. https://109748--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_with_agent_based_installer/preparing-to-install-with-agent-based-installer.html#agent-install-sample-config-bond-sriov_preparing-to-install-with-agent-based-installer
2. https://109748--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_with_agent_based_installer/preparing-to-install-with-agent-based-installer.html#agent-install-sample-config-bonds-vlans_preparing-to-install-with-agent-based-installer
3. https://109748--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_with_agent_based_installer/installation-config-parameters-agent.html#agent-configuration-parameters-optional_installation-config-parameters-agent


QE review:
N/A

Additional information:
“Cherry Picked from "24af6692b83b8b4319d56de708e658559bf0868d" Main PR: https://github.com/openshift/openshift-docs/pull/109289

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
