### PR TITLE
OCPBUGS#37577: Add a note for identity-provider-arn

### DIFF
--- a/security/cert_manager_operator/cert-manager-operator-install.adoc
+++ b/security/cert_manager_operator/cert-manager-operator-install.adoc
@@ -9,6 +9,11 @@ toc::[]
 [role="_abstract"]
 The {cert-manager-operator} is not installed in {product-title} by default. You can install the {cert-manager-operator} by using the web console.
 
+[NOTE]
+====
+The {cert-manager-operator} sets the `features.operators.openshift.io/token-auth-aws`, `features.operators.openshift.io/token-auth-azure`, and `features.operators.openshift.io/token-auth-gcp` annotations in the `ClusterServiceVersion` custom resource of the Operator. The {product-title} web console requires the credential details when these annotations are set. Currently, the Operator does not use the values collected by the OpenShift web console and you can provide any value when asked for the input. For example, when installing on the managed {product-title} cluster, the `identity-provider-arn` is asked and any value can be provided to proceed.
+====
+
 [IMPORTANT]
 ====
 The {cert-manager-operator} version 1.15 or later supports the `AllNamespaces`, `SingleNamespace`, and `OwnNamespace` installation modes. Earlier versions, such as 1.14, support only the `SingleNamespace` and `OwnNamespace` installation modes.


### PR DESCRIPTION
Version(s):
4.16+

Issue:
https://redhat.atlassian.net/browse/OCPBUGS-37577

Link to docs preview:
[OCPBUGS-37577](https://109763--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/cert_manager_operator/cert-manager-operator-install.html)

QE review:
- [x] QE has approved this change.