### PR TITLE
ROX-34031: created RHACS 4.9.5 release notes

### DIFF
--- a/modules/common-attributes.adoc
+++ b/modules/common-attributes.adoc
@@ -61,12 +61,13 @@ endif::[]
 :product-registry: OpenShift image registry
 :olm-first: Operator Lifecycle Manager (OLM)
 :olm: OLM
-:rhacs-version: 4.9.4
+:rhacs-version: 4.9.5
 :ga-date-490: 30 October 2025
 :ga-date-491: 24 November 2025
 :ga-date-492: 16 December 2025
 :ga-date-493: 17 February 2026
 :ga-date-494: 16 March 2026
+:ga-date-495: 8 April 2026
 :ocp-supported-version: 4.12
 :ocp-latest-version: 4.21
 :pipelines-shortname: OpenShift Pipelines

--- a/release_notes/49-release-notes.adoc
+++ b/release_notes/49-release-notes.adoc
@@ -20,6 +20,7 @@ toc::[]
 |`4.9.2` | {ga-date-492}
 |`4.9.3` | {ga-date-493}
 |`4.9.4` | {ga-date-494}
+|`4.9.5` | {ga-date-495}
 
 |====
 
@@ -631,5 +632,42 @@ This release also addresses the following security vulnerabilities:
 * jsPDF: Cross-user Data Leakage via race condition in `addJS` method (link:https://access.redhat.com/security/cve/cve-2026-24040[CVE-2026-24040])
 * lodash: Prototype pollution in `+++_.unset+++` and `+++_.omit+++` functions (link:https://access.redhat.com/security/cve/cve-2025-13465[CVE-2025-13465])
 * urllib3: urllib3 vulnerable to decompression-bomb safeguard bypass when following HTTP redirects (streaming API) (link:https://access.redhat.com/security/cve/cve-2026-21441[CVE-2026-21441])
+
+[id="about-this-release-495_{context}"]
+== About release 4.9.5
+
+*Release date*: {ga-date-495}
+
+This release provides the following bug fixes:
+
+//ROX-33574
+* Before this update, Helm charts did not configure image pull secrets for the Scanner service account when you disabled Scanner V4 and used only Scanner V2. This caused Scanner images to fail to pull. With this release, Red{nbsp}Hat has corrected the Helm chart configuration to properly inject image pull secrets into the Scanner service account. As a result, Scanner images pull successfully in all configurations.
+
+//ROX-33757
+* Before this update, selected execution paths in Sensor did not check whether the cluster entities store history enabled or disabled the history feature. This caused an issue where Sensor allocated memory that was never used for clusters with enabled history. With this release, Red{nbsp}Hat has added a check for cluster entities history to prevent unnecessary storage. As a result, the system maintains optimal memory usage because it no longer stores unnecessary items in the cluster entities store history.
+
+//ROX-33758
+* Before this update, the `endpointsStore.addToHistory` function performed unnecessary operations, which increased sensor CPU load and elevated event-processing latency in larger clusters. With this release, Red{nbsp}Hat has improved CPU efficiency in `endpointsStore` mutations to reduce latency. As a result, the system processes events faster and maintains lower CPU usage in large clusters with many endpoints.
+
+This release addresses the following security vulnerabilities:
+
+* jsPDF:
+** Denial of service via malicious GIF dimensions (link:https://access.redhat.com/security/cve/cve-2026-25535[CVE-2026-25535])
+** PDF object injection via unsanitized input in `addJS` method (link:https://access.redhat.com/security/cve/cve-2026-25755[CVE-2026-25755])
+** PDF injection in AcroForm module allows arbitrary JavaScript execution (link:https://access.redhat.com/security/cve/cve-2026-25940[CVE-2026-25940])
+** Cross site scripting via unsanitized output options (link:https://access.redhat.com/security/cve/cve-2026-31938[CVE-2026-31938])
+** CVE-2026-31898 Arbitrary code execution via unsanitized input in `createAnnotation` method (link:https://access.redhat.com/security/cve/cve-2026-31898[CVE-2026-31898])
+* fast-xml-parser:
+** fast-xml-parser has `RangeError` DoS numeric entities bug (link:https://access.redhat.com/security/cve/cve-2026-25128[CVE-2026-25128])
+** Denial of service via unlimited XML entity expansion (link:https://access.redhat.com/security/cve/cve-2026-26278[CVE-2026-26278])
+** Cross-site scripting (XSS) due to improper `<DOCTYPE>` entity handling (link:https://access.redhat.com/security/cve/cve-2026-25896[CVE-2026-25896])
+** Stack overflow leads to denial of service (link:https://access.redhat.com/security/cve/cve-2026-27942[CVE-2026-27942])
+** Denial of service via XML entity expansion bypass (link:https://access.redhat.com/security/cve/cve-2026-33036[CVE-2026-33036])
+* gRPC-Go: Authorization bypass due to improper HTTP/2 path validation (link:https://access.redhat.com/security/cve/cve-2026-33186[CVE-2026-33186])
++
+[NOTE]
+====
+This CVE is not addressed in Scanner V2 images in this release.
+====
 
 include::modules/image-versions.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s):
4.9

Issue:
[ROX-34031](https://redhat.atlassian.net/browse/ROX-34031)

Link to docs preview:
https://109770--ocpdocs-pr.netlify.app/

QE review: RHACS has no QE, approved by SMEs
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:

