### PR TITLE
Telcodocs 2565: Transition Multi-network Policy away from iptables (GA)

### DIFF
--- a/modules/nw-multi-network-policy-differences.adoc
+++ b/modules/nw-multi-network-policy-differences.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * networking/multiple_networks/configuring-multi-network-policy.adoc
+// * networking/multiple_networks/secondary_networks/configuring-multi-network-policy.adoc
 
 :_mod-docs-content-type: CONCEPT
 [id="nw-multi-network-policy-differences_{context}"]

--- a/modules/nw-multi-network-policy-ipv6-suppport.adoc
+++ b/modules/nw-multi-network-policy-ipv6-suppport.adoc
@@ -1,17 +1,17 @@
 // Module included in the following assemblies:
 //
-// * networking/multiple_networks/configuring-multi-network-policy.adoc
+// * networking/multiple_networks/secondary_networks/configuring-multi-network-policy.adoc
 
 :_mod-docs-content-type: CONCEPT
 [id="nw-multi-network-policy-ipv6-support_{context}"]
 = Supporting multi-network policies in IPv6 networks
 
 [role="_abstract"]
-The ICMPv6 Neighbor Discovery Protocol (NDP) is a set of messages and processes that enable devices to discover and maintain information about neighboring nodes. NDP plays a crucial role in IPv6 networks, facilitating the interaction between devices on the same link.
+The ICMPv6 Neighbor Discovery Protocol (NDP) is a set of messages and processes that enable devices to discover and maintain information about neighboring nodes. NDP is essential in IPv6 networks, facilitating the interaction between devices on the same link.
 
-The Cluster Network Operator (CNO) deploys the iptables implementation of multi-network policy when the `useMultiNetworkPolicy` parameter is set to `true`.
+The Cluster Network Operator (CNO) deploys the `nftables` implementation of multi-network policy when the `useMultiNetworkPolicy` parameter is set to `true`.
 
-To support multi-network policies in IPv6 networks the Cluster Network Operator deploys the following set of custom rules in every pod affected by a multi-network policy:
+To support multi-network policies in IPv6 networks, the Cluster Network Operator deploys the following predefined `nftables` rules in every pod affected by a multi-network policy. The CNO automatically creates and manages the following `ConfigMap`. You do not need to create this resource.
 
 [source,yaml]
 ----
@@ -21,22 +21,21 @@ metadata:
   name: multi-networkpolicy-custom-rules
   namespace: openshift-multus
 data:
-
   custom-v6-rules.txt: |
     # accept NDP
-    -p icmpv6 --icmpv6-type neighbor-solicitation -j ACCEPT
-    -p icmpv6 --icmpv6-type neighbor-advertisement -j ACCEPT
+    icmpv6 type nd-neighbor-solicit accept
+    icmpv6 type nd-neighbor-advert accept
     # accept RA/RS
-    -p icmpv6 --icmpv6-type router-solicitation -j ACCEPT
-    -p icmpv6 --icmpv6-type router-advertisement -j ACCEPT
+    icmpv6 type nd-router-advert accept
+    icmpv6 type nd-router-solicit accept
 ----
 
 where:
 
-`icmpv6-type neighbor-solicitation`:: This rule allows incoming ICMPv6 neighbor solicitation messages, which are part of the neighbor discovery protocol (NDP). These messages help determine the link-layer addresses of neighboring nodes.
-`icmpv6-type neighbor-advertisement`:: This rule allows incoming ICMPv6 neighbor advertisement messages, which are part of NDP and provide information about the link-layer address of the sender.
-`icmpv6-type router-solicitation`:: This rule permits incoming ICMPv6 router solicitation messages. Hosts use these messages to request router configuration information.
-`icmpv6-type router-advertisement`:: This rule allows incoming ICMPv6 router advertisement messages, which give configuration information to hosts.
+`icmpv6 type nd-neighbor-solicit`:: This rule allows incoming ICMPv6 neighbor solicitation messages, which are part of the Neighbor Discovery Protocol (NDP). These messages help determine the link-layer addresses of neighboring nodes. In a multi-network setup, this allows other pods or the secondary interface gateway to resolve the pod's MAC address. Without this, the pod becomes 'invisible' to its neighbors on the secondary network.
+`icmpv6 type nd-neighbor-advert`:: This rule allows incoming ICMPv6 neighbor advertisement messages, which are part of NDP and provide information about the link-layer address of the sender. This ensures the pod can receive MAC address updates from other nodes.
+`icmpv6 type nd-router-advert`:: This rule allows incoming ICMPv6 router advertisement messages, which provide configuration information to hosts. This allows the pod to receive its default gateway and routing prefix dynamically from the network infrastructure.
+`icmpv6 type nd-router-solicit`:: This rule allows incoming ICMPv6 router solicitation messages. Hosts use these messages to request router configuration information. This ensures that when a pod's interface comes online, it can immediately request network parameters rather than waiting for the next scheduled broadcast, reducing container startup latency.
 
 [NOTE]
 ====

--- a/networking/multiple_networks/secondary_networks/configuring-multi-network-policy.adoc
+++ b/networking/multiple_networks/secondary_networks/configuring-multi-network-policy.adoc
@@ -9,7 +9,7 @@ toc::[]
 [role="_abstract"]
 As an administrator, you can use the `MultiNetworkPolicy` API to create multiple network policies that manage traffic for pods that are attached to secondary networks. For example, you can create policies that allow or deny traffic based on specific ports, IPs and ranges, or labels.
 
-Multi-network policies can be used to manage traffic on secondary networks in the cluster. These policies cannot manage the default cluster network or primary network of user-defined networks. 
+Multi-network policies can be used to manage traffic on secondary networks in the cluster. These policies cannot manage the default cluster network or primary network of user-defined networks.
 
 As a cluster administrator, you can configure a multi-network policy for any of the following network types:
 
@@ -22,6 +22,13 @@ As a cluster administrator, you can configure a multi-network policy for any of 
 [NOTE]
 ====
 Support for configuring multi-network policies for SR-IOV secondary networks is only supported with kernel network interface controllers (NICs). SR-IOV is not supported for Data Plane Development Kit (DPDK) applications.
+====
+
+[IMPORTANT]
+====
+In {product-title} 4.22 and later, the multi-network policy backend uses `nftables`.
+The `iptables` backend has been removed and there is no option to revert to it.
+The `MultiNetworkPolicy` API and user-facing configuration are unchanged.
 ====
 
 include::modules/nw-multi-network-policy-differences.adoc[leveloffset=+1]


### PR DESCRIPTION
[TELCODOCS-2565]: Transition Multi-network Policy away from iptables (GA)

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.22
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:https://redhat.atlassian.net/browse/TELCODOCS-2565
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://109771--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/multiple_networks/secondary_networks/configuring-multi-network-policy.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
