### PR TITLE
OSDOCS-18782 adding ESO docs to 4.19 for GA

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -1320,6 +1320,14 @@ Topics:
     File: external-secrets-operator-release-notes
   - Name: Installing the External Secrets Operator
     File: external-secrets-operator-install
+  - Name: Configuring Network Policy for the Operand
+    File: external-secrets-operator-config-net-policy
+  - Name: Configuring the egress proxy
+    File: external-secrets-operator-proxy
+  - Name: Monitoring the External Secrets Operator for Red Hat OpenShift
+    File: external-secrets-monitoring
+  - Name: Customizing the External Secrets Operator for Red Hat OpenShift
+    File: external-secrets-log-levels
   - Name: Uninstalling the External Secrets Operator
     File: external-secrets-operator-uninstall
   - Name: External Secrets Operator APIs

--- a/modules/eso-bitwarden-secret.adoc
+++ b/modules/eso-bitwarden-secret.adoc
@@ -6,7 +6,8 @@
 [id="eso-bitwarden-secret_{context}"]
 = bitwardenSecretManagerProvider
 
-The `bitwardenSecretManagerProvider` field enables the bitwarden secrets manager provider and sets up the additional service required to connect to the bitwarden server.
+[role="_abstract"]
+The `bitwardenSecretManagerProvider` field enables the Bitwarden secrets manager provider and sets up the additional service required to connect to the Bitwarden server.
 
 [cols="1,1,1,1,1",options="header"]
 |===
@@ -16,16 +17,17 @@ The `bitwardenSecretManagerProvider` field enables the bitwarden secrets manager
 | Default
 | Validation
 
-| `enabled`
+| `mode`
 | _string_
-| `enabled` field enables the `bitwardenSecretManagerProvider`. you can set this field to `true` or `false`.
-| false
-| enum: [true false] +
+| `mode` field enables the `bitwardenSecretManagerProvider` provider state, which can be set to `Enabled` or `Disabled`. If set to `Enabled`, the Operator ensures the plugin is deployed and synchronized. If set to `Disabled`, the Bitwarden provider plugin reconciliation is disabled. The plugin and resources remain in their current state, and are not managed by the Operator.
+| `Disabled`
+| enum: [Enabled Disabled]
+
 Optional
 
 | `secretRef`
 | _SecretReference_
-| `SecretRef` specifies the kubernetes secret that contains the TLS key pair for the bitwarden server. If this reference is not provided and `certManagerConfig` field is configured, the issuer defined in `certManagerConfig` generates the required certificate. The secret must use `tls.crt` for certificate, `tls.key` for the private key, and `ca.crt` for CA certificate.
+| `SecretRef` specifies the Kubernetes secret that contains the TLS key pair for the Bitwarden server. If this reference is not provided and the `certManagerConfig` field is configured, the issuer defined in `certManagerConfig` generates the required certificate. The secret must use `tls.crt` for certificate, `tls.key` for the private key, and `ca.crt` for CA certificate.
 |
 | Optional
 |===

--- a/modules/eso-cert-manager-config.adoc
+++ b/modules/eso-cert-manager-config.adoc
@@ -6,6 +6,7 @@
 [id="eso-cert-manager-config_{context}"]
 = certManagerConfig
 
+[role="_abstract"]
 The `certManagerConfig` field configures the `cert-manager` Operator settings.
 
 [cols="1,1,1,1,1",options="header"]
@@ -16,18 +17,20 @@ The `certManagerConfig` field configures the `cert-manager` Operator settings.
 | Default
 | Validation
 
-| `enabled`
+| `mode`
 | _string_
-| `enabled` specifies whether cert-manager must obtain and renew certificates for the webhook server instead of using built-in certificates. Set this field to `true` or `false`.
+| `mode` specifies whether to use the cert-manager Operator for certificate management instead of the built-in `cert-controller` controller which can be indicated by setting either `Enabled` or `Disabled`. If set to `Enabled`, the Operator uses `cert-manager` for obtaining the certificates for the webhook server and other components. If set to `Disabled`, the Operator uses the `cert-controller` controller for obtaining the certificates for the webhook server. `Disabled` is the default behavior.
 | false
-| enum: [true false] +
+| enum: [true false]
+
 Required
 
-| `addInjectorAnnotations`
+| `injectAnnotations`
 | _string_
-| `addInjectorAnnotations` adds the `cert-manager.io/inject-ca-from` annotation to the webhooks and custom resource definitions (CRDs) to automatically configure the webhook with the `cert-manager` Operator certificate authority (CA). This requires CA Injector to be enabled in `cert-manager` Operator. Set this field to `true` or `false`.
+| `injectAnnotations` adds the `cert-manager.io/inject-ca-from` annotation to the webhooks and custom resource definitions (CRDs) to automatically configure the webhook with the `cert-manager` Operator certificate authority (CA). This requires the CA Injector to be enabled in the `cert-manager` Operator. Set this field to `true` or `false`. When set, this field cannot be changed.
 | false
-| enum: [true false] +
+| enum: [true false]
+
 Optional
 
 | `issuerRef`

--- a/modules/eso-cert-providers-config.adoc
+++ b/modules/eso-cert-providers-config.adoc
@@ -1,0 +1,23 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-operator-api.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="eso-cert-providers-config_{context}"]
+= certProvidersConfig
+
+[role="_abstract"]
+The `certProvidersConfig` defines the configuration for the certificate providers used to manage TLS certificates for webhook and plugins.
+
+[cols="1,1,1,1",options="header"]
+|===
+| Field
+| Type
+| Description
+| Validation
+
+| `certManager`
+| _object_
+| `certManager` defines the configuration for `cert-manager` provider specifics.
+| Optional
+|===

--- a/modules/eso-component-config.adoc
+++ b/modules/eso-component-config.adoc
@@ -1,0 +1,39 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-operator-api.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="eso-comoponent-config_{context}"]
+= componentConfig
+
+[role="_abstract"]
+The `componentConfig` field defines configuration overrides for a specific `external-secrets` component.
+
+[cols="1,1,1,1",options="header"]
+|===
+| Field
+| Type
+| Description
+| Validation
+
+| `componentName`
+| _string_
+| `componentName` identifies which `external-secrets` component this configuration applies to. Valid values are `ExternalSecretsCoreController`, `Webhook`, `CertController`, and `BitwardenSDKServer`.
+a| Enum: [`ExternalSecretsCoreController`, `Webhook`, `CertController`, `BitwardenSDKServer`]
+
+Required
+
+| `deploymentConfigs`
+| _object_
+| `deploymentConfigs` specifies overrides for the Kubernetes Deployment resource of this component.
+|Optional
+
+| `overrideEnv`
+a| *EnvVar*
+
+_array_
+| `overrideEnv` specifies custom environment variables for this component's container. These are merged with Operator-managed environment variables, with user-defined values taking precedence. Environment variable names starting with `HOSTNAME`, `KUBERNETES_` or `EXTERNAL_SECRETS_` are reserved and are not allowed.
+a| The maximum number of items is 50.
+
+Optional
+|===

--- a/modules/eso-condition.adoc
+++ b/modules/eso-condition.adoc
@@ -1,0 +1,33 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-operator-api.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="eso-condition_{context}"]
+= condition
+
+[role="_abstract"]
+The `condition` field holds information about the condition of the `external-secrets` deployment.
+
+[cols="1,1,1,1",options="header"]
+|===
+| Field
+| Type
+| Description
+| Validation
+
+| `type`
+| _string_
+| `type` contains the condition of the deployment.
+| Required
+
+| `status`
+| link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#conditionstatus-v1-meta[_ConditionStatus_]
+| `status` contains the status of the condition of the deployment
+|
+
+| `message`
+| _string_
+| `message` provides details on the state of the deployment
+|
+|===

--- a/modules/eso-conditional-status.adoc
+++ b/modules/eso-conditional-status.adoc
@@ -1,0 +1,21 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-operator-api.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="eso-conditional-status_{context}"]
+= conditionalStatus
+
+[role="_abstract"]
+The `conditionalStatus` field holds information about the current state of the `external-secrets` deployment.
+
+[cols="1,1,1",options="header"]
+|===
+| Field
+| Type
+| Description
+
+| `conditions`
+| _array_
+| `conditions` contains information on the current state of the deployment.
+|===

--- a/modules/eso-controller-config.adoc
+++ b/modules/eso-controller-config.adoc
@@ -6,25 +6,46 @@
 [id="eso-controller-config_{context}"]
 = controllerConfig
 
-The `controllerConfig` field configures the operator to set the default values for installing `external-secrets` operand.
+[role="_abstract"]
+The `controllerConfig` specifies the configurations used by the controller when installing the `external-secrets` Operand and the plugins.
 
-[cols="1,1,1,1,1",options="header"]
+[cols="1,1,1,1",options="header"]
 |===
 | Field
 | Type
 | Description
-| Default
 | Validation
 
-| `namespace`
+| `certProvider`
 | _string_
-| `namespace` configures the namespace for installing the `external-secrets` operand.
-| external-secrets
+| `certProvider` defines the configuration for the certificate providers used to manage TLS certificates for webhook and plugins.
 | Optional
 
 | `labels`
 | _object (keys:string, values:string)_
-| `labels` field applies labels to all resources created for the `external-secrets` operand deployment.
-|
-| Optional
+| `labels` field applies labels to all resources created for the `external-secrets` Operand deployment.
+a| The maximum number of properties is 20.
+
+The minimum number of properties is 0.
+
+Optional
+
+| `annotations`
+| _object (keys:string, values:string)_
+| `annotations` add custom annotations to all the resources created for the `external-secrets` deployment. The annotations are merged with any default annotations set by the Operator. User-specified annotations take precedence over defaults in case of conflicts. Annotation keys containing the reserved domains `kubernetes.io/`, `openshift.io/`, `k8s.io/`, or `cert-manager.io/` (including subdomains like `*.kubernetes.io/`) are not allowed.
+a| The maximum number of properties is 20.
+
+The minimum number of properties is 0.
+
+Optional
+
+| `componentConfigs`
+| _ComponentConfig array_
+| `componentConfigs` allows specifying deployment-level configuration overrides for individual `external-secrets` components. Each component can have only one configuration entry.
+a| The maximum number of items is 4.
+
+The minimum number of items is 0.
+
+Optional
+
 |===

--- a/modules/eso-controller-status.adoc
+++ b/modules/eso-controller-status.adoc
@@ -8,29 +8,25 @@
 
 The `controllerStatus` field contains the observed conditions of the controllers used by the Operator.
 
-[cols="1,1,1,1,1",options="header"]
+[cols="1,1,1,1",options="header"]
 |===
 | Field
 | Type
 | Description
-| Default
 | Validation
 
 | `name`
 | _string_
 | `name` specifies the name of the controller for which the observed condition is recorded.
-|
 | Required
 
 | `conditions`
 | _array_
 | `conditions` contains information about the current state of the {external-secrets-operator-short} controllers.
 |
-|
 
 | `observedGeneration`
 | _integer_
 | `observedGeneration` represents the `.metadata.generation` on the observed resource.
-|
 | Minimum: 0
 |===

--- a/modules/eso-deployment-config.adoc
+++ b/modules/eso-deployment-config.adoc
@@ -1,0 +1,29 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-operator-api.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="eso-deployment-config_{context}"]
+= deploymentConfig
+
+[role="_abstract"]
+The `deploymentConfig` field defines configuration overrides for a Kubernetes Deployment resource.
+
+[cols="1,1,1,1,1",options="header"]
+|===
+| Field
+| Type
+| Description
+| Default
+| Validation
+
+| `revisionHistoryLimit`
+| _integer_
+| `revisionHistoryLimit` specifies the number of old `ReplicaSets` to retain for rollback purposes. This allows rolling back to previous deployment versions using the command `oc rollout undo`. Must be at least 1 to ensure rollback capability.
+| 10
+a| The minimum value is 1.
+
+The maximum value is 50.
+
+Optional
+|===

--- a/modules/eso-external-secrets-config.adoc
+++ b/modules/eso-external-secrets-config.adoc
@@ -4,9 +4,10 @@
 
 :_mod-docs-content-type: REFERENCE
 [id="eso-external-secrets-config_{context}"]
-= externalSecretsConfig
+= applicationConfig
 
-The `externalSecretsConfig` field configures the behavior of `external-secrets` operand.
+[role="_abstract"]
+The `applicationConfig` specifies the configurations for the `external-secrets` operand.
 
 [cols="1,1,1,1,1",options="header"]
 |===
@@ -20,33 +21,27 @@ The `externalSecretsConfig` field configures the behavior of `external-secrets` 
 | _integer_
 | `logLevel` supports a range of values as defined in the link:https://github.com/kubernetes/community/blob/master/contributors/devel/sig-instrumentation/logging.md#what-method-to-use[kubernetes logging guidelines].
 | 1
-| The maximum range value is 5 +
-The minimum range value is 1 +
+| The maximum range value is 5
+
+The minimum range value is 1
+
 Optional
 
 | `operatingNamespace`
 | _string_
 | `operatingNamespace` restricts the `external-secrets` operand operations to the provided namespace. Enabling this field disables `ClusterSecretStore` and `ClusterExternalSecret`.
 |
-| Optional
+| The maximum length is 63
 
-| `bitwardenSecretManagerProvider`
-| _object_
-| `bitwardenSecretManagerProvider` enables the bitwarden secrets manager provider and sets up the additional service required for connecting to the bitwarden server.
-|
-| Optional
+The minimum length is 1
+
+Optional
 
 | `webhookConfig`
 | _object_
 | `webhookConfig` configures webhook specifics of the `external-secrets` operand.
 |
 |
-
-| `certManagerConfig`
-| _object_
-| `certManagerConfig` configures `cert-manager` Operator settings that are used to generate certificates for the webhook and `bitwarden-sdk-server` components.
-|
-|Optional
 
 | `resources`
 | link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#resourcerequirements-v1-core[_ResourceRequirements_]
@@ -64,11 +59,25 @@ Optional
 | link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#toleration-v1-core[_Toleration_] _array_
 | `tolerations` sets the pod tolerations. For more information, see link:https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/[]
 |
-| Optional
+| The maximum number of items is 50
+
+The minimum number of items is 0
+
+Optional
 
 | `nodeSelector`
 | _object (keys:string, values:string)_
 | `nodeSelector` defines the scheduling criteria by using node labels. For more information, see link:https://kubernetes.io/docs/concepts/configuration/assign-pod-node/[]
+|
+| The maximum number of properties is 50
+
+The minimum number of properties is 0
+
+Optional
+
+| `proxy`
+| _object (keys:string, values:string)_
+| `proxy` sets the proxy configurations available in operand containers managed by the Operator as environment variables.
 |
 | Optional
 |===

--- a/modules/eso-external-secrets-list.adoc
+++ b/modules/eso-external-secrets-list.adoc
@@ -8,35 +8,25 @@
 
 The `externalSecretsList` object fetches the list of `externalSecrets` objects.
 
-[cols="1,1,1,1,1",options="header"]
+[cols="1,1,1",options="header"]
 |===
 | Field
 | Type
 | Description
-| Default
-| Validation
 
 | `apiVersion`
 | _string_
 | The `apiVersion` specifies the version of the schema in use, which is `operator.openshift.io/v1alpha1`
-|
-|
 
 | `kind`
 | _string_
 | `kind` specifies the type of the object, which is `externalSecretsList` for this API.
-|
-|
 
 | `metadata`
 | link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#listmeta-v1-meta[_ListMeta_]
 | Refer to Kubernetes API documentation for details about the `metadata` fields.
-|
-|
 
 | `items`
 | _array_
 | `Items` contains a list of `externalSecrets` objects.
-|
-|
 |===

--- a/modules/eso-external-secrets-manager-list.adoc
+++ b/modules/eso-external-secrets-manager-list.adoc
@@ -9,35 +9,26 @@
 The `externalSecretsManagerList` object fetches the list of `externalSecretsManager` objects.
 
 
-[cols="1,1,1,1,1",options="header"]
+[cols="1,1,1",options="header"]
 |===
 | Field
 | Type
 | Description
-| Default
-| Validation
 
 | `apiVersion`
 | _string_
 | The `apiVersion` specifies the version of the schema in use, which is `operator.openshift.io/v1alpha1`.
-|
-|
 
 | `kind`
 | _string_
 | `kind` specifies the type of the object, which is `externalSecretsManagerList` for this API.
-|
-|
+
 
 | `metadata`
 | link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#listmeta-v1-meta[_ListMeta_]
 | Refer to Kubernetes API documentation for details about the `metadata` fields.
-|
-|
 
 | `items`
 | _array_
 | `Items` contains a list of `externalSecretsManager` objects.
-|
-|
 |===

--- a/modules/eso-external-secrets-manager-spec.adoc
+++ b/modules/eso-external-secrets-manager-spec.adoc
@@ -6,25 +6,23 @@
 [id="eso-external-secrets-manager-spec_{context}"]
 = externalSecretsManagerSpec
 
+[role="_abstract"]
 The `externalSecretsManagerSpec` field defines the desired behavior of the `externalSecretsManager` object.
 
-[cols="1,1,1,1,1",options="header"]
+[cols="1,1,1,1",options="header"]
 |===
 | Field
 | type
 | Description
-| Default
 | Validation
 
 | `globalConfig`
 | _object_
 | `globalConfig` configures the behavior of deployments that {external-secrets-operator-short} manages.
-|
 | Optional
 
 | `feature`
 | _array_
 | `feature` enables the optional features of the Operator.
-|
 | Optional
 |===

--- a/modules/eso-external-secrets-manager-status.adoc
+++ b/modules/eso-external-secrets-manager-status.adoc
@@ -8,24 +8,21 @@
 
 The `externalSecretsManagerStatus` field shows the most recently observed status of the `externalSecretsManager` object.
 
-[cols="1,1,1,1,1",options="header"]
+[cols="1,1,1,1",options="header"]
 |===
 | Field
 | Type
 | Description
-| Default
 | Validation
 
 | `controllerStatus`
 |  _array_
 | `controllerStatus` holds the observed conditions of the controllers used by the Operator.
 |
-|
 
 | `lastTransitionTime`
 | link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#time-v1-meta[_Time_]
 | `lastTransitionTime` records the most recent time the status of the condition changed.
-|
 | Format: date-time +
 Type: string
 |===

--- a/modules/eso-external-secrets-manager.adoc
+++ b/modules/eso-external-secrets-manager.adoc
@@ -10,41 +10,29 @@ The `externalSecretsManager` object defines the configuration and information of
 
 You can configure global options and enable optional features by using `externalSecretsManager`. This serves as a centralized configuration for managing multiple controllers of the Operator. The Operator automatically creates the `externalSecretsManager` object during installation.
 
-[cols="1,1,1,1,1",options="header"]
+[cols="1,1,1",options="header"]
 |===
 | Field
 | Type
 | Description
-| Default
-| Validation
 
 | `apiVersion`
 | _string_
 | The `apiVersion` specifies the version of the schema in use, which is `operator.openshift.io/v1alpha1`.
-|
-|
 
 | `kind`
 | _string_
 | `kind` specifies the type of the object, which is `externalSecretsManager` for this Object.
-|
-|
 
 | `metadata`
 | link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#objectmeta-v1-meta[_ObjectMeta_]
 | Refer to Kubernetes API documentation for details about the `metadata` fields.
-|
-|
 
 | `spec`
 | _object_
 | `spec` contains specifications of the desired behavior.
-|
-|
 
 | `status`
 | _object_
 | `status` displays the most recently observed state of the controllers in the {external-secrets-operator-short}.
-|
-|
 |===

--- a/modules/eso-external-secrets-spec.adoc
+++ b/modules/eso-external-secrets-spec.adoc
@@ -1,30 +1,34 @@
+
 // Module included in the following assemblies:
 //
 // * security/external_secrets_operator/external-secrets-operator-api.adoc
 
 :_mod-docs-content-type: REFERENCE
 [id="eso-external-secrets-spec_{context}"]
-= externalSecretsSpec
+= externalSecretsConfigSpec
 
-The `externalSecretsSpec` field defines the desired behavior of the `externalSecrets` object.
+[role="_abstract"]
+The `externalSecretsConfigSpec` field defines the desired behavior of the `externalSecrets` object.
 
-[cols="1,1,1,1,1",options="header"]
+[cols="1,1,1,1",options="header"]
 |===
 | Field
 | Type
 | Description
-| Default
 | Validation
 
-| `externalSecretsConfig`
+| `appConfig`
 | _object_
-| `externalSecretsConfig` configures the behavior of `external-secrets` operand.
-|
+| `appConfig` configures the behavior of the `external-secrets` Operand.
+| Optional
+
+| `plugins`
+| _object_
+| `plugins` configures the optional provider plugins.
 | Optional
 
 | `controllerConfig`
 | _object_
-| `controllerConfig` configures the controller to set up defaults that enable `external-secrets` operand.
-|
+| `controllerConfig` configures the controller to set up defaults that enable `external-secrets` Operand.
 | Optional
 |===

--- a/modules/eso-external-secrets-status.adoc
+++ b/modules/eso-external-secrets-status.adoc
@@ -4,27 +4,26 @@
 
 :_mod-docs-content-type: REFERENCE
 [id="eso-external-secrets-status_{context}"]
-= externalSecretsStatus
+= externalSecretsConfigStatus
 
-The `externalSecretsStatus` field shows the most recently observed status of the `externalSecrets` Object.
+[role="_abstract"]
+The `externalSecretsConfigStatus` field shows the most recently observed status of the `externalSecretsConfig` Object.
 
-[cols="1,1,1,1,1",options="header"]
+[cols="1,1,1",options="header"]
 |===
 | Field
 | Type
 | Description
-| Default
-| Validation
 
 | `conditions`
 | link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#condition-v1-meta[_Condition_] _array_
 | `conditions` contains information about the current state of deployment.
-|
-|
 
 | `externalSecretsImage`
 | _string_
 | `externalSecretsImage` specifies the image name and tag used for deploy `external-secrets` operand.
-|
-|
+
+| `bitwardenSDKServerImage`
+| _string_
+| `bitwardenSDKServerImage` specifies the name of the image and tag used for deploying the `bitwarden-sdk-server`.
 |===

--- a/modules/eso-external-secrets.adoc
+++ b/modules/eso-external-secrets.adoc
@@ -10,41 +10,29 @@ The `externalSecrets` object defines the configuration and information for the m
 
 Creating an `externalSecrets` object triggers the creation of a deployment that manages the `external-secrets` operand and maintains the desired state.
 
-[cols="1,1,1,1,1",options="header"]
+[cols="1,1,1",options="header"]
 |===
 | Field
 | Type
 | Description
-| Default
-| Validation
 
 | `apiVersion`
 | _string_
 | The `apiVersion` specifies the version of the schema in use, which is `operator.openshift.io/v1alpha1`.
-|
-|
 
 | `kind`
 | _string_
 | `kind` specifies the type of the object, which is `externalSecrets` for this object.
-|
-|
 
 | `metadata`
 | link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#objectmeta-v1-meta[_ObjectMeta_]
 | Refer to Kubernetes API documentation for details about the `metadata` fields.
-|
-|
 
 | `spec`
 | _object_
 | `spec` Contains the specifications of the desired behavior of the `externalSecrets` object.
-|
-|
 
 | `status`
 | _object_
 | `status` displays the most recently observed status of the `externalSecrets` object.
-|
-|
 |===

--- a/modules/eso-global-config.adoc
+++ b/modules/eso-global-config.adoc
@@ -6,6 +6,7 @@
 [id="eso-global-config_{context}"]
 = globalConfig
 
+[role="_abstract"]
 The `globalConfig` field configures the behavior of the {external-secrets-operator-short}.
 
 
@@ -17,12 +18,24 @@ The `globalConfig` field configures the behavior of the {external-secrets-operat
 | Default
 | Validation
 
+| `labels`
+| _integer_
+| `labels` applies to all resources created by the Operator. This field can have a maximum of 20 entries
+| 1
+| The maximum number of properties is 20
+
+The minimum number of properties is 0
+
+Optional
+
 | `logLevel`
 | _integer_
 | `logLevel` supports a range of values as defined in the link:https://github.com/kubernetes/community/blob/master/contributors/devel/sig-instrumentation/logging.md#what-method-to-use[kubernetes logging guidelines].
 | 1
-| The maximum range value is 5 +
-The minimum range value is 1 +
+| The maximum range value is 5
+
+The minimum range value is 1
+
 Optional
 
 | `resources`
@@ -41,17 +54,25 @@ Optional
 | link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#toleration-v1-core[_Toleration_] _array_
 | `tolerations` sets the pod tolerations. For more information, see link:https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/[]
 |
-| Optional
+| The maximum number of items is 50
+
+The minimum number of items is 0
+
+Optional
 
 | `nodeSelector`
 | _object (keys:string, values:string)_
-| nodeSelector defines the scheduling criteria by using the node labels. For more information, see link:https://kubernetes.io/docs/concepts/configuration/assign-pod-node/[]
+| `nodeSelector` defines the scheduling criteria by using the node labels. For more information, see link:https://kubernetes.io/docs/concepts/configuration/assign-pod-node/[]
 |
-| Optional
+| The maximum number of properties is 50
 
-| `labels`
-| _object (keys:string, values:string)_
-| `labels` applies labels to all resources created for the `external-secrets` operand deployment.
+The minimum number of properties is 0
+
+Optional
+
+| `proxy`
+| _object_
+| `proxy` sets the proxy configurations available in the operand containers managed by the Operator as environment variables.
 |
 | Optional
 |===

--- a/modules/eso-mode.adoc
+++ b/modules/eso-mode.adoc
@@ -1,0 +1,22 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-operator-api.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="eso-mode_{context}"]
+= mode
+
+[role="_abstract"]
+The `mode` field indicates the operational state of the optional features.
+
+[cols="1,1",options="header"]
+|===
+| Field
+| Description
+
+| `Enabled`
+| `Enabled` indicates the optional configuration is enabled.
+
+| `Disabled`
+| `Disabled` indicates the optional configuration is disabled.
+|===

--- a/modules/eso-object-reference.adoc
+++ b/modules/eso-object-reference.adoc
@@ -8,29 +8,25 @@
 
 The `ObjectReference` field refers to an object by its name, kind, and group.
 
-[cols="1,1,1,1,1",options="header"]
+[cols="1,1,1,1",options="header"]
 |===
 | Field
 | Type
 | Description
-| Default
 | Validation
 
 | `name`
 | _string_
 | `name` specifies the name of the resource being referred to.
-|
 | Required
 
 | `kind`
 | _string_
 | `kind` specifies the kind of the resource being referred to.
-|
 | Optional
 
 | `group`
 | _string_
 | `group` specifies the group of the resource being referred to.
-|
 | Optional
 |===

--- a/modules/eso-plugins-config.adoc
+++ b/modules/eso-plugins-config.adoc
@@ -1,0 +1,23 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-operator-api.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="eso-plugiins-config_{context}"]
+= pluginsConfig
+
+[role="_abstract"]
+The `pluginsConfig` configures the optional plugins.
+
+[cols="1,1,1,1",options="header"]
+|===
+| Field
+| Type
+| Description
+| Validation
+
+| `bitwardenSecretManagerProvider`
+| _object_
+| `bitwardenSecretManagerProvider` enables the `bitwarden-secrets-manager` provider plugin for connecting with the 'bitwarden-secrets-manager'.
+| Optional
+|===

--- a/modules/eso-proxy-config.adoc
+++ b/modules/eso-proxy-config.adoc
@@ -1,0 +1,45 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-operator-api.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="eso-proxy-config_{context}"]
+= proxyConfig
+
+[role="_abstract"]
+The `proxyConfig` holds the proxy configurations which are made available in the operand containers and managed by the Operator as environment variables.
+
+[cols="1,1,1,1",options="header"]
+|===
+| Field
+| Type
+| Description
+| Validation
+
+| `httpProxy`
+| _string_
+| The `httpProxy` field contains the URL of the proxy for HTTP requests. This field can have a maximum of 2048 characters.
+| The maximum length is 2048 characters.
+
+The minimum length is 0 characters.
+
+Optional
+
+| `httpsProxy`
+| _string_
+| The `httpsProxy` field contains the URL of the proxy for HTTPS requests. This field can have a maximum of 2048 characters.
+| The maximum length is 2048 characters.
+
+The minimum length is 0 characters.
+
+Optional
+
+| `noProxy`
+| _string_
+| The `noProxy` field is a comma-separated list of hostnames, classless inter-domain routings (CIDRs), and IP addresses or a combination of the three for which the proxy should not be used. This field can have a maximum of 4096 characters.
+| The maximum length is 4096 characters.
+
+The minimum length is 0 characters.
+
+Optional
+|===

--- a/modules/eso-secret-reference.adoc
+++ b/modules/eso-secret-reference.adoc
@@ -8,17 +8,15 @@
 
 The `secretReference` field refers to a secret with the given name in the same namespace where it used.
 
-[cols="1,1,1,1,1",options="header"]
+[cols="1,1,1,1",options="header"]
 |===
 | Field
 | Type
 | Description
-| Default
 | Validation
 
 | `name`
 | _string_
 | `name` specifies the name of the secret resource being referred to.
-|
 | Required
 |===

--- a/modules/external-secrets-bit-warden-config.adoc
+++ b/modules/external-secrets-bit-warden-config.adoc
@@ -1,0 +1,67 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-log-levels.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="external-secrets-bit-warden-config_{context}"]
+= Configuring the bitwardenSecretManagerProvider plugin
+
+[role="_abstract"]
+Configure the `bitwardenSecretManagerProvider` plugin to use Bitwarden Secrets Manager as a source for your secrets. By using this integration, you can sync external secrets to your {product-title} cluster.
+
+.Prerequisites
+
+* You have access to the cluster with the `cluster-admin` role.
+* You have created the `ExternalSecretsConfig` custom resource.
+
+.Procedure
+
+. Edit the `ExternalSecretsConfig` custom resource by running the following command:
++
+[source,terminal]
+----
+$  oc edit externalsecretsconfigs.operator.openshift.io cluster
+----
+
+. Edit the `spec.plugins.bitwardenSecretManagerProvider` section as follows to enable the Bitwarden Secrets Manager:
++
+[source,yaml]
+----
+apiVersion: operator.openshift.io/v1alpha1
+kind: ExternalSecretsConfig
+...
+spec:
+  plugins:
+    bitwardenSecretManagerProvider:
+      mode: Enabled
+      secretRef:
+        name: <secret_object_name>
+----
++
+where:
+
+`name`:: The name of the secret containing the certificate key pair for the plugin. The key name in the secret for the certificate must be `tls.crt`. The key name for the private key must be `tls.key`. The key name for the Certificate Authority (CA) certificate key name must be `ca.crt`. Configuring the secret is optional when the `cert-manager` certificate provider is configured.
+
+. Save your changes and exit the editor.
+
+. If you disable the plugin, the following resources must be deleted manually by running the following commands:
++
+[source,terminal]
+----
+$ oc delete deployments.apps bitwarden-sdk-server -n external-secrets
+----
++
+[source,terminal]
+----
+$ oc delete certificates.cert-manager.io bitwarden-tls-certs -n external-secrets
+----
++
+[source,terminal]
+----
+$ oc delete service bitwarden-sdk-server -n external-secrets
+----
++
+[source,terminal]
+----
+$ oc delete serviceaccounts bitwarden-sdk-server -n external-secrets
+----

--- a/modules/external-secrets-cert-manager-config.adoc
+++ b/modules/external-secrets-cert-manager-config.adoc
@@ -1,0 +1,85 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-log-levels.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="external-secrets-cert-manager-config_{context}"]
+= Configuring cert-manager for the external-secrets certificate requirements
+
+[role="_abstract"]
+Configure the cert-manager Operator to handle certificate management for the external-secrets webhook and plugins. This optional configuration automates certificate generation for plugins and eliminates the need for manual configuration.
+
+When the `cert-manager` Operator is not used, `external-secrets` defaults to its own certificate management. In this mode, it automatically generates the required certificates for the webhook, while you are responsible for manually configuring certificates for the plugins.
+
+.Prerequisites
+
+* You have access to the cluster with the `cluster-admin` role.
+* You created the `ExternalSecretsConfig` custom resource.
+* You installed the {cert-manager-operator}. For more information, see "Installing the {cert-manager-operator}"
+
+.Procedure
+
+. Edit the `ExternalSecretsConfig` custom resource by running the following command:
++
+[source,terminal]
+----
+$  oc edit externalsecretsconfigs.operator.openshift.io cluster
+----
+
+. Configure cert-manager by editing the `spec.controllerConfig.certProvider.certManager` section as follows:
++
+[source,yaml]
+----
+apiVersion: operator.openshift.io/v1alpha1
+kind: ExternalSecretsConfig
+...
+spec:
+  controllerConfig:
+    certProvider:
+      certManager:
+        injectAnnotations: "true"
+        issuerRef:
+          name: <issuer_name>
+          kind: <issuer_kind>
+          group: <issuer_group>
+        mode: Enabled
+----
++
+where:
+
+`spec.controllerConfig.certProvider.certManager.issuerRef.injectAnnotation`:: Must be set to `true` when enabled.
+`spec.controllerConfig.certProvider.certManager.issuerRef.name`:: Specifies the name of the issuer object referenced in `ExternalSecretsConfig`.
+`spec.controllerConfig.certProvider.certManager.issuerRef.kind`:: Specifies the API issuer. Can be set to either `Issuer` or `ClusterIssuer`.
+`spec.controllerConfig.certProvider.certManager.issuerRef.group`:: Specifies the API issuer group. The group name must be `cert-manager.io`.
+`spec.controllerConfig.certProvider.certManager.mode`:: Must be set to `Enabled`. This is an immutable field and cannot be modified once it is configured.
+
+. Save your changes.
+
+. After you update the cert-manager configurations in the `externalsecretsconfig.operator.openshift.io` object, you must manually delete `external-secrets-cert-controller` deployment by running the following command. This prevents performance degradation of the `external-secrets` application.
++
+[source,terminal]
+----
+$ oc delete deployments.apps external-secrets-cert-controller -n external-secrets
+----
+
+. Optionally, you can delete other resources created for the `cert-controller` by running the following commands:
++
+[source,terminal]
+----
+$ oc delete clusterrolebindings.rbac.authorization.k8s.io external-secrets-cert-controller
+----
++
+[source,terminal]
+----
+$ oc delete clusterroles.rbac.authorization.k8s.io external-secrets-cert-controller
+----
++
+[source,terminal]
+----
+$ oc delete serviceaccounts external-secrets-cert-controller -n external-secrets
+----
++
+[source,terminal]
+----
+$ oc delete secrets external-secrets-webhook -n external-secrets
+----

--- a/modules/external-secrets-enable-metrics.adoc
+++ b/modules/external-secrets-enable-metrics.adoc
@@ -1,0 +1,121 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/exteernal-secrets-monitoring.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="external-secrets-enable-metrics_{context}"]
+= Configuring metrics collection for {external-secrets-operator} Operands by using a ServiceMonitor
+
+[role="_abstract"]
+The {external-secrets-operator} Operands exposes metrics by default on port `8080` at the `/metrics` service endpoint for all three components (`external-secrets`, `external-secrets-cert-controll`, and `external-secrets-webhook`). You can configure metrics collection for the external-secrets Operands by creating a `ServiceMonitor` custom resource (CR) that enables the Prometheus Operator to collect custom metrics. For more information, see "Configuring user workload monitoring".
+
+.Prerequisites
+
+* You have access to the cluster as a user with the `cluster-admin` role.
+* You have installed the {external-secrets-operator}.
+* You have enabled the user workload monitoring.
+
+.Procedure
+
+. Create the `ClusterRoleBinding` resource required for granting permissions to access metrics:
+
+.. Create the `clusterrolebinding-external-secrets.yaml` file:
++
+.Example Cluster Rolebinding External Secrets YAML:
++
+[source,yaml]
+----
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app: external-secrets
+  name: external-secrets-allow-metrics-access
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: external-secrets-operator-metrics-reader
+subjects:
+  - kind: ServiceAccount
+    name: external-secrets
+    namespace: external-secrets
+  - kind: ServiceAccount
+    name: external-secrets-cert-controller
+    namespace: external-secrets
+  - kind: ServiceAccount
+    name: external-secrets-webhook
+    namespace: external-secrets
+----
+
+.. Apply the `ClusterRoldeBinding` custom resource by running the following command:
++
+[source,terminal]
+----
+$ oc apply -f clusterrolebinding-external-secrets.yaml
+----
+
+. Create the `ServiceMonitor` CR:
+
+.. Create the `servicemonitor-external-secrets.yaml` file:
++
+.Eample Service Monitor External Secrets YAML
++
+[source,yaml]
+----
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    app: external-secrets
+  name: external-secrets-metrics-monitor
+  namespace: external-secrets
+spec:
+  endpoints:
+    - interval: 60s
+      path: /metrics
+      port: metrics
+      scheme: http
+      scrapeTimeout: 30s
+  namespaceSelector:
+    matchNames:
+      - external-secrets
+  selector:
+    matchExpressions:
+      - key: app.kubernetes.io/name
+        operator: In
+        values:
+          - external-secrets
+          - external-secrets-cert-controller
+          - external-secrets-webhook
+      - key: app.kubernetes.io/instance
+        operator: In
+        values:
+          - external-secrets
+      - key: app.kubernetes.io/managed-by
+        operator: In
+        values:
+          - external-secrets-operator
+----
+
+.. Apply the `ServiceMonitor` CR by running the following command:
++
+[source,terminal]
+----
+$ oc apply -f servicemonitor-external-secrets.yaml
+----
++
+After the `ServiceMonitor` CR is created, the user-workload Prometheus instance begins metrics collection from the {external-secrets-operator} Operands. The collected metrics are labeled with `job="external-secrets"`,`job="external-secrets-cainjector"`, and `job="external-secrets-webhook"`.
+
+.Verification
+
+. In the {product-title} web console, navigate to *Observe* -> *Targets*.
+
+. In the *Label* filter field, enter the following labels to filter the metrics targets for each Operand:
++
+* service=external-secrets
+
+* service=external-secrets-cert-controller-metrics
+
+* service=external-secrets-webhook
+
+. Confirm that the *Status* column shows `Up` for the `external-secrets`, `external-secrets-cert-controller` and `external-secrets-webhook`.

--- a/modules/external-secrets-enable-operand-log-level.adoc
+++ b/modules/external-secrets-enable-operand-log-level.adoc
@@ -1,0 +1,47 @@
+
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-log-levels.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="external-secrets-enable-operand-log-level_{context}"]
+= Setting a log level for the {external-secrets-operator} Operand
+
+[role="_abstract"]
+Adjust the amount of detail recorded for troubleshooting or monitoring purposes by configuring log levels and verbosity for the {external-secrets-operator} Operand.
+
+.Prerequisites
+
+* You have access to the cluster with the `cluster-admin` role.
+* You created the `ExternalSecretsConfig` custom resource (CR).
+
+.Procedure
+
+. Edit the `ExternalSecretsConfig` CR by running the following command:
++
+[source,terminal]
+----
+$ oc edit externalsecretsconfigs.operator.openshift.io cluster
+----
+
+. Set the log level value by editing the `spec.appConfig.logLevel` section:
++
+[source,yaml]
+----
+apiVersion: operator.openshift.io/v1alpha1
+kind: ExternalSecretsConfig
+...
+spec:
+  appConfig:
+    logLevel: <log_level>
+----
++
+where:
+
+`spec.appConfig.<log_level>`:: Specifies the value range of 1-5. The log level gets mapped to the following Operand support levels:
+ * 1 - warnings
+ * 2 - error logs
+ * 3 - info logs
+ * 4 and 5 - debug logs
+
+. Save your changes and exit the editor.

--- a/modules/external-secrets-enable-operator-log-level.adoc
+++ b/modules/external-secrets-enable-operator-log-level.adoc
@@ -1,0 +1,55 @@
+
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-log-levels.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="external-secrets-enable-operator-log-level_{context}"]
+= Setting a log level for the {external-secrets-operator}
+
+[role="_abstract"]
+You can adjust the verbosity of your logs to both troubleshoot issues effectively and manage the volume of log data. Set the log level for the {external-secrets-operator} to control the detail of log messages.
+
+.Prerequisites
+
+* You have access to the cluster with `cluster-admin` privileges.
+* You have created the `ExternalSecretsConfig` custom resource.
+
+.Procedure
+
+* Update the subscription object for the {external-secrets-operator} to provide the verbosity level for the Operator logs by running the following command:
++
+[source,terminal]
+----
+$ oc -n <external_secrets_operator_namespace> patch subscription openshift-external-secrets-operator --type='merge' -p '{"spec":{"config":{"env":[{"name":"OPERATOR_LOG_LEVEL","value":"<log_level>"}]}}}'
+----
++
+where:
+
+`<external_secrets_operator_namespace>`:: Specifies the namespace where the Operator is installed.
+
+`<log_level>`:: Specifies the level of log detail. Values range from 1-5. The default is 2.
+
+.Verification
+
+. Verify that the log level of the {external-secrets-operator} is updated by running the following command:
++
+[source,terminal]
+----
+$ oc set env deploy/external-secrets-operator-controller-manager -n external-secrets-operator --list | grep -e OPERATOR_LOG_LEVEL -e container
+----
++
+.Example output
++
+[source,terminal]
+----
+# deployments/external-secrets-operator-controller-manager, container manager
+OPERATOR_LOG_LEVEL=2
+----
+
+. Verify that the log level of the {external-secrets-operator} is updated by running the following command:
++
+[source,terminal]
+----
+$ oc logs -n external-secrets-operator -f deployments/external-secrets-operator-controller-manager -c manager
+----

--- a/modules/external-secrets-enable-operator-metrics.adoc
+++ b/modules/external-secrets-enable-operator-metrics.adoc
@@ -1,0 +1,199 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/exteernal-secrets-monitoring.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="external-secrets-enable-operator-metrics_{context}"]
+= Configuring metrics collection for {external-secrets-operator} by using a ServiceMonitor
+
+[role="_abstract"]
+The {external-secrets-operator} exposes metrics by default on port `8443` at the `/metrics` service endpoint. You can configure metrics collection for the Operator by creating a `ServiceMonitor` custom resource (CR) that enables the Prometheus Operator to collect custom metrics. For more information, see "Configuring user workload monitoring".
+
+.Prerequisites
+
+* You have access to the cluster as a user with the `cluster-admin` role.
+* You have installed the {external-secrets-operator}.
+* You have enabled the user workload monitoring.
+
+.Procedure
+
+. Configure the Operator to use `HTTP` for the metrics server. `HTTPS` is enabled by default.
+
+.. Update the subscription object for {external-secrets-operator} to configure the `HTTP` protocol by running the following command:
++
+[source,terminal]
+----
+$ oc -n external-secrets-operator patch subscription openshift-external-secrets-operator --type='merge' -p '{"spec":{"config":{"env":[{"name":"METRICS_BIND_ADDRESS","value":":8080"}, {"name": "METRICS_SECURE", "value": "false"}]}}}'
+----
+
+.. To verify that the {external-secrets-operator-short} pod is redeployed and that the configured values for `METRICS_BIND_ADDRESS` and `METRICS_SECURE` are updated, run the following command:
++
+[source,terminal]
+----
+$ oc set env --list deployment/external-secrets-operator-controller-manager -n external-secrets-operator | grep -e METRICS_BIND_ADDRESS -e METRICS_SECURE -e container
+----
++
+.example output
++
+[source,terminal]
+----
+# deployments/external-secrets-operator-controller-manager, container manager
+METRICS_BIND_ADDRESS=:8080
+METRICS_SECURE=false
+----
+
+. Create the `Secret` resource with the `kubernetes.io/service-account.name` annotation to inject the token required for authenticating with the metrics server.
+
+.. Create the `secret-external-secrets-operator.yaml` file:
++
+[source,yaml]
+----
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    app: external-secrets-operator
+  name: external-secrets-operator-metrics-auth
+  namespace: external-secrets-operator
+  annotations:
+    kubernetes.io/service-account.name: external-secrets-operator-controller-manager
+type: kubernetes.io/service-account-token
+----
+
+.. Apply the `Secret` resource by running the following command:
++
+[source,terminal]
+----
+$ oc apply -f secret-external-secrets-operator.yaml
+----
+
+. Create the `ClusterRoleBinding` resource required for granting permissions to access metrics:
+
+.. Create the `clusterrolebinding-external-secrets.yaml` file:
++
+.Example output
++
+[source,yaml]
+----
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app: external-secrets-operator
+  name: external-secrets-allow-metrics-access
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: external-secrets-operator-metrics-reader
+subjects:
+  - kind: ServiceAccount
+    name: external-secrets-operator-controller-manager
+    namespace: external-secrets-operator
+----
+
+.. Apply the `ClusterRoldeBinding` custom resource by running the following command:
++
+[source,terminal]
+----
+$ oc apply -f clusterrolebinding-external-secrets.yaml
+----
+
+. Create the `ServiceMonitor` CR if using the default `HTTPS`:
+
+.. Create the `servicemonitor-external-secrets-operator-https.yaml` file:
++
+[source,yaml]
+----
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    app: external-secrets-operator
+  name: external-secrets-operator-metrics-monitor
+  namespace: external-secrets-operator
+spec:
+  endpoints:
+    - authorization:
+        credentials:
+          name: external-secrets-operator-metrics-auth
+          key: token
+        type: Bearer
+      interval: 60s
+      path: /metrics
+      port: metrics-https
+      scheme: https
+      scrapeTimeout: 30s
+      tlsConfig:
+        ca:
+          configMap:
+            name: openshift-service-ca.crt
+            key: service-ca.crt
+        serverName: external-secrets-operator-controller-manager-metrics-service.external-secrets-operator.svc.cluster.local
+  namespaceSelector:
+    matchNames:
+      - external-secrets-operator
+  selector:
+    matchLabels:
+      app: external-secrets-operator
+      svc: external-secrets-operator-controller-manager-metrics-service
+----
+
+.. Apply the `ServiceMonitor` CR by running the following command:
++
+[source,terminal]
+----
+$ oc apply -f servicemonitor-external-secrets-operator-https.yaml
+----
+
+. Create the `ServiceMonitor` CR if configured to use `HTTP`:
+
+.. Create the `servicemonitor-external-secrets-operator-http.yaml` file:
++
+[source,yaml]
+----
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    app: external-secrets-operator
+  name: external-secrets-operator-metrics-monitor
+  namespace: external-secrets-operator
+spec:
+  endpoints:
+    - authorization:
+        credentials:
+          name: external-secrets-operator-metrics-auth
+          key: token
+        type: Bearer
+      interval: 60s
+      path: /metrics
+      port: metrics-http
+      scheme: http
+      scrapeTimeout: 30s
+  namespaceSelector:
+    matchNames:
+      - external-secrets-operator
+  selector:
+    matchLabels:
+      app: external-secrets-operator
+      svc: external-secrets-operator-controller-manager-metrics-service
+----
+
+.. Apply the `ServiceMonitor` CR by running the following command:
++
+[source,terminal]
+----
+$ oc apply -f servicemonitor-external-secrets-operator-http.yaml
+----
++
+After the `ServiceMonitor` CR is created, the user workload Prometheus instance begins metrics collection from the Operator. The collected metrics are labeled with `job="external-secrets-operator-controller-manager-metrics-service"`.
+
+.Verification
+
+. In the {product-title} web console, navigate to *Observe* -> *Targets*.
+
+. In the *Label* filter field, enter the following label to filter the metrics targets for each Operand:
++
+* service=external-secrets-operator-controller-manager-metrics-service
+
+. Confirm that the *Status* column shows `Up` for the `external-secrets-operator`.

--- a/modules/external-secrets-enable-user-workload-monitor.adoc
+++ b/modules/external-secrets-enable-user-workload-monitor.adoc
@@ -1,0 +1,59 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-monitoring.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="external-secrets-enable-user-workload-monitor_{context}"]
+= Enabling user workload monitoring
+
+[role="_abstract"]
+To enable metrics collection for user-defined projects, configure user workload monitoring in the {product-title} cluster. With this configuration, you can maintain visibility into the performance and status of your specific project workloads.
+
+For more information, see "Setting up metrics collection for user-defined projects".
+
+.Prerequisites
+
+* You have access to the cluster as a user with the `cluster-admin` role.
+
+.Procedure
+
+. Create the `cluster-monitoring-config.yaml` file as shown in the example belowsd:
++
+[source,yaml]
+----
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cluster-monitoring-config
+  namespace: openshift-monitoring
+data:
+  config.yaml: |
+    enableUserWorkload: true
+----
+
+. Apply the `ConfigMap` by running the following command:
++
+[source,terminal]
+----
+$ oc apply -f cluster-monitoring-config.yaml
+----
+
+.Verification
+
+* Verify that the monitoring components for user workloads are running in the `openshift-user-workload-monitoring` namespace by running the following command:
++
+[source,terminal]
+----
+$ oc -n openshift-user-workload-monitoring get pod
+----
++
+.Example output
+[source,terminal]
+----
+NAME                                   READY   STATUS    RESTARTS   AGE
+prometheus-operator-5f79cff9c9-67pjb   2/2     Running   0          25h
+prometheus-user-workload-0             6/6     Running   0          25h
+thanos-ruler-user-workload-0           4/4     Running   0          25h
+----
++
+The status of the pods such as `prometheus-operator`, `prometheus-user-workload`, and `thanos-ruler-user-workload` must be `Running`.

--- a/modules/external-secrets-operand-install-cli.adoc
+++ b/modules/external-secrets-operand-install-cli.adoc
@@ -4,37 +4,46 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="external-secrets-operand-install-cli_{context}"]
-= Installing the External Secrets operand for Red Hat OpenShift by using the CLI
+= Installing the External Secrets Operand by using the CLI
 
-You can use the command-line interface (CLI) to install the External Secrets operand.
+[role="_abstract"]
+Configure the {external-secrets-short} Operand by creating the `ExternalSecretsConfig` custom resource (CR) using the CLI.
 
 .Prerequisites
 
-* You have access to the cluster with `cluster-admin` privileges.
+* You have access to the cluster with the `cluster-admin` role.
 
 .Procedure
 
-. Create a `externalsecrets.openshift.operator.io` object by defining a YAML file with the following content:
+. Create an `externalsecretsconfig.openshift.operator.io` object by defining a YAML file with the following content:
 +
-.Example `externalsecrets.yaml` file
+.Example YAML file
++
 [source,yaml]
 ----
 apiVersion: operator.openshift.io/v1alpha1
-kind: ExternalSecrets
+kind: ExternalSecretsConfig
 metadata:
   labels:
-    app.kubernetes.io/name: external-secrets-operator
+    app: external-secrets-operator
+    app.kubernetes.io/name: cluster
   name: cluster
-spec: {}
+spec:
+  controllerConfig:
+    networkPolicies:
+    - componentName: ExternalSecretsCoreController
+      egress:
+      - {}
+      name: allow-external-secrets-egress
 ----
 +
 For more information on spec configuration, see "External Secrets Operator for Red Hat OpenShift APIs".
 
-. Create the `externalsecrets.openshift.operator.io` object by running the following command:
+. Create the `externalsecretsconfigs.openshift.operator.io` object by running the following command:
 +
 [source,terminal]
 ----
-$ oc create -f externalsecrets.yaml
+$ oc create -f externalsecretsconfig.yaml
 ----
 
 .Verification
@@ -47,6 +56,7 @@ $ oc get pods -n external-secrets
 ----
 +
 .Example output
++
 [source,terminal]
 ----
 NAME                                                READY   STATUS    RESTARTS   AGE
@@ -59,28 +69,33 @@ external-secrets-webhook-b566658ff-7m4d5            1/1     Running   0         
 +
 [source,terminal]
 ----
-$ oc get externalsecrets.operator.openshift.io cluster -n external-secrets-operator -o jsonpath='{.status.conditions}' | jq .
+$ oc get externalsecretsconfig.operator.openshift.io cluster -n external-secrets-operator -o jsonpath='{.status.conditions}' | jq .
 ----
 +
 .Example output
++
 [source,terminal]
 ----
 [
   {
     "lastTransitionTime": "2025-06-17T14:57:04Z",
     "message": "",
-    "observedGeneration": 1,
+    "observedGeneration": 2,
     "reason": "Ready",
     "status": "False",
     "type": "Degraded"
   },
   {
-    "lastTransitionTime": "2025-06-17T14:57:04Z",
+    "lastTransitionTime": "2025-11-27T05:58:38Z,
     "message": "reconciliation successful",
-    "observedGeneration": 1,
+    "observedGeneration": 2,
     "reason": "Ready",
     "status": "True",
     "type": "Ready"
   }
 ]
 ----
+
+.Next step
+
+* Configure the network policies of the Operand as described in "Configuring network policy for the Operand".

--- a/modules/external-secrets-operator-adding-custom-annotations.adoc
+++ b/modules/external-secrets-operator-adding-custom-annotations.adoc
@@ -1,0 +1,82 @@
+
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-log-levels.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="external-secrets-enable-operator-adding-custom-annotations_{context}"]
+= Adding custom annotations to external-secrets resources
+
+[role="_abstract"]
+To customize your resources, you can define up to 20 custom annotations in the custom resource (CR). The Operator merges the annotations with the defaults, prioritizes them, and safely preserves annotations set by external systems.
+
+When an annotation is removed from the CR, the Operator automatically removes it from all managed resources during the next reconciliation. Annotations set by external sources, such as Kubernetes system annotations or annotations added by other controllers, are preserved and are not affected by the Operator.
+
+Annotation keys containing the following reserved domain prefixes are not allowed and are rejected by validation if applied:
+
+* `kubernetes.io/` (including subdomains such as `*.kubernetes.io/`)
+
+* `k8s.io/` (including subdomains such as `*.k8s.io/`)
+
+* `openshift.io/` (including subdomains such as `*.openshift.io/`)
+
+* `cert-manager.io/`
+
+.Prerequisites
+
+* You have access to the cluster with the `cluster-admin` role.
+
+* You have created the `ExternalSecretsConfig` custom resource.
+
+.Procedure
+
+. Edit the `ExternalSecretsConfig` CR by running the following command:
++
+[source,terminal]
+----
+$ oc edit externalsecretsconfigs.operator.openshift.io cluster
+----
+
+. Add the `annotations` field under `spec.controllerConfig` as follows:
++
+[source,yaml]
+----
+apiVersion: operator.openshift.io/v1alpha1
+kind: ExternalSecretsConfig
+metadata:
+  name: cluster
+spec:
+  controllerConfig:
+    annotations:
+      prometheus.io/scrape: "true"
+      example.com/environment: "production"
+----
+
+.Verification
+
+. Verify that annotations are applied to the external-secrets deployment by running the following command:
++
+[source,terminal]
+----
+$ oc get deployment external-secrets -n external-secrets -o jsonpath='{.metadata.annotations}' | jq .
+----
++
+The output should include the custom annotations you specified.
+
+. Verify that annotations are applied to the pod template by running the following command:
++
+[source,terminal]
+----
+$ oc get deployment external-secrets -n external-secrets -o jsonpath='{.spec.template.metadata.annotations}' | jq .
+----
++
+The output should include the custom annotations you specified.
+
+. Verify that annotations are applied to other managed resources such as Services by running the following command:
++
+[source,terminal]
+----
+$ oc get service external-secrets-webhook -n external-secrets -o jsonpath='{.metadata.annotations}' | jq .
+----
++
+The output should include the custom annotations you specified.

--- a/modules/external-secrets-operator-configure-history-limit.adoc
+++ b/modules/external-secrets-operator-configure-history-limit.adoc
@@ -1,0 +1,82 @@
+
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-log-levels.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="external-secrets-enable-operator-configure-history-limit_{context}"]
+= Configuring the revisionHistoryLimit for external-secrets components
+
+[role="_abstract"]
+Configure the number of old `ReplicaSet` objects retained for rollback by setting the `revisionHistoryLimit` parameter for `external-secrets` components.
+
+The following components can be configured:
+
+[cols="1,1",options="header"]
+|===
+| Component name
+| Description
+
+| `ExternalSecretsCoreController`
+| The main `external-secrets` controller.
+
+| `Webhook`
+| The `external-secrets` webhook server.
+
+| `CertController`
+| The certificate controller for webhook TLS.
+
+| `BitwardenSDKServer`
+| The Bitwarden SDK server plugin.
+|===
+
+Each component can only have one configuration entry. A maximum of 4 component configuration entries are allowed, one per component.
+
+.Prerequisites
+
+* You have access to the cluster with the `cluster-admin` role.
+
+* You have created the `ExternalSecretsConfig` custom resource.
+
+.Procedure
+
+. Edit the `ExternalSecretsConfig` CR by running the following command:
++
+[source,terminal]
+----
+$ oc edit externalsecretsconfigs.operator.openshift.io cluster
+----
+
+. Add the `componentConfigs` field under `spec.controllerConfig` as follows:
++
+[source,yaml]
+----
+apiVersion: operator.openshift.io/v1alpha1
+kind: ExternalSecretsConfig
+metadata:
+  name: cluster
+spec:
+  controllerConfig:
+    componentConfigs:
+      - componentName: ExternalSecretsCoreController
+        deploymentConfigs:
+          revisionHistoryLimit: 5
+      - componentName: Webhook
+        deploymentConfigs:
+          revisionHistoryLimit: 3
+----
++
+where
+
+`spec.controllerConfig.componentConfigs.componentName.deploymentConfigs.revisionHistoryLimit`:: Specifies the number of old `ReplicaSet` objects to retain for rollback. The value must be at least 1 to ensure rollback capability. The maximum value is 50. If not specified, the default is 10.
+
+.Verification
+
+* Verify that the `revisionHistoryLimit` parameter is applied to the deployment by running the following command:
++
+[source,terminal]
+----
+$ oc get deployment external-secrets -n external-secrets -o jsonpath='{.spec.revisionHistoryLimit}'
+----
++
+The output should display the value you configured.

--- a/modules/external-secrets-operator-configure-proxy.adoc
+++ b/modules/external-secrets-operator-configure-proxy.adoc
@@ -1,0 +1,82 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-operator-proxy.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="external-secrets-operator-configure-proxy_{context}"]
+= Configuring the egress proxy for the {external-secrets-operator}
+
+[role="_abstract"]
+The egress proxy can be configured in the `ExternalSecretsConfig` or the `ExternalSecretsManager` custom resource (CR). The Operator and the Operand make use of the {product-title} supported certificate authority (CA) bundle for the proxy validations.
+
+.Prerequisites
+
+* You have access to the cluster as a user with the `cluster-admin` role.
+
+* You have created the `ExternalSecretsConfig` custom CR.
+
+.Procedure
+
+. To set the proxy in the `ExternalSecretsConfig` resource, perform the following steps:
+
+.. Edit the `ExternalSecretsConfig` resource by running the following command:
++
+[source,terminal]
+----
+$ oc edit externalsecretsconfigs.operator.openshift.io cluster
+----
+
+.. Edit the `spec.appConfig.proxy` section to set the proxy values as follows:
++
+[source,yaml]
+----
+apiVersion: operator.openshift.io/v1alpha1
+kind: ExternalSecretsConfig
+...
+spec:
+  appConfig:
+    proxy:
+      httpProxy: <http_proxy>
+      httpsProxy: <https_proxy>
+      noProxy: <no_proxy>
+----
++
+where:
+
+'spec.appConfig.proxy.<http_proxy>`:: Specifies the proxy URL for the http requests.
+
+'spec.appConfig.proxy.<https_proxy>`:: Specifies the proxy URL for the https requests.
+
+'spec.appConfig.proxy.<no_proxy>`:: Specifies a comma-separated list of hostnames, CIDRs, IPs or a combination of these, for which the proxy should not be used.
+
+. To set the proxy in the `ExternalSecretsManager` CR, perform the following steps.
+
+.. Edit the `ExternalSecretsManager` CR by running the following command:
++
+[source,terminal]
+----
+$ oc edit externalsecretsmanagers.operator.openshift.io cluster
+----
+
+.. Edit the `spec.globalConfig.proxy` section to set the proxy values as follows:
++
+[source,yaml]
+----
+apiVersion: operator.openshift.io/v1alpha1
+kind: ExternalSecretsManager
+...
+spec:
+  globalConfig:
+    proxy:
+      httpProxy: <http_proxy>
+      httpsProxy: <https_proxy>
+      noProxy: <no_proxy>
+----
++
+where:
+
+`spec.globalConfig.proxy.<http_proxy>`:: Specifies the proxy URL for the http requests.
+
+`spec.globalConfig.proxy.<https_proxy>`:: Proxy URL for the https requests.
+
+`spec.globalConfig.proxy.<no_proxy>`:: Comma-separated list of hostnames, CIDRs, IPs or a combination of these for which the proxy should not be used.

--- a/modules/external-secrets-operator-create-externalsecretsconfig.adoc
+++ b/modules/external-secrets-operator-create-externalsecretsconfig.adoc
@@ -1,0 +1,175 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-operator-migrate-downstream-upstream.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="external-secrets-operator-create-externalsecretsconfig_{context}"]
+= Creating the ExternalSecretsConfig Operator
+
+[role="_abstract"]
+Create the `ExternalSecretsConfig` resource to install and configure the core `external-secrets` component. This setup helps ensure that features like Bitwarden and cert-manager support are correctly enabled.
+
+.Prerequisites
+
+* {external-secrets-operator} is installed.
+
+* {cert-manager-operator} is installed.
+
+* You have access to the cluster with the `cluster-admin` role.
+
+.Procedure
+
+. Create an `externalsecretsconfig` file by defining a YAML file with the following content:
++
+[source,yml]
+----
+apiVersion: operator.openshift.io/v1alpha1
+kind: ExternalSecretsConfig
+metadata:
+  labels:
+    app.kubernetes.io/name: cluster
+  name: cluster
+spec:
+  appConfig:
+    logLevel: 1
+  controllerConfig:
+    networkPolicies:
+      - componentName: ExternalSecretsCoreController
+        egress:
+          - {}
+        name: allow-external-secrets-egress
+  plugins: {}
+----
+
+. Create the `ExternalSecretsConfig` object by running the following command:
++
+[source,terminal]
+----
+$ oc create -f externalsecretsconfig.yaml
+----
+
+.Verification
+
+Verify that all custom resources (CRs) are present and that the APIs are using `v1` instead of `v1beta1`. There CRs are retained and automatically converted by the new Operator.
+
+. To verify that the `external-secrets` pods are in a `running` state, run the following command:
++
+[source,terminal]
+----
+$ oc get pods -n external-secret
+----
++
+.Example output
++
+[source,terminal]
+----
+NAME                                          READY        STATUS        RESTARTS     AGE
+bitwarden-sdk-server-5b4cf48766-w7zp7         1/1          Running       0            5m
+external-secrets-5854b85dd5-m6zf9             1/1          Running       0            5m
+external-secrets-webhook-5cb85b8fdb-6jtqb     1/1          Running       0            5m
+----
+
+. To verify that the `SecretStore` CR is present, run the following command:
++
+[source,terminal]
+----
+$ oc get secretstores.external-secrets.io -A
+----
++
+.Example output
++
+[source,terminal]
+----
+NAMESPACE               NAME                         AGE         STATUS      CAPABILITIES    READY
+external-secrets-1      gcp-store                    18min       Valid       ReadWrite       True
+external-secrets-2      aws-secretstore              11min       Valid       ReadWrite       True
+external-secrets        bitwarden-secretsmanager     20min       Valid       Readwrite       True
+----
+
+. To verify that the `ExternalSecret` CR is present, run the following command:
++
+[source,terminal]
+----
+$ oc get externalsecrets.external-secrets.io -A
+----
++
+.Example output
++
+[source,terminal]
+----
+NAMESPACE             NAME                    STORE                      REFRESH INTERVAL    STATUS          READY
+external-secrets-1    gcp-externalsecret      gcp-store                  1hr                 SecretSynced    True
+external-secrets-2    aws-external-secret     aws-secret-store           1hr                 SecretSynced    True
+external-secrets      bitwarden               bitwarden-secretsmanager   1hr                 SecretSynced    True
+----
+
+. To verify that the `SecretStore` is `apiVersion: external-secrets.io/v1`, run the following command:
++
+[source,terminal]
+----
+$ oc get secretstores.external-secrets.io -n external-secrets-1 gcp-store -o yaml
+----
++
+.Example output
++
+[source,yml]
+----
+apiVersion: external-secrets.io/v1
+kind: SecretStore
+metadata:
+  creationTimestamp: "2025-10-27T11:38:19Z"
+  generation: 1
+  name: gcp-store
+  namespace: external-secrets-1
+  resourceVersion: "104519"
+  uid: 7bccb0cc-2557-4f4a-9caa-1577f0108f4b
+spec:
+.
+.
+.
+status:
+  capabilities: ReadWrite
+  conditions:
+  - lastTransitionTime: "2025-10-27T11:38:19Z"
+    message: store validated
+    reason: Valid
+    status: "True"
+    type: Ready
+----
+
+. To verify that the `ExternalSecret` is `apiVersion: external-secrets.io/v1`, run the following command:
++
+[source,terminal]
+----
+$ oc get externalsecrets.external-secrets.io -n external-secrets-1 gcp-externalsecret -o yaml
+----
++
+.Example output
++
+[source,yml]
+----
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  creationTimestamp: "2025-10-27T11:39:03Z"
+  generation: 1
+  name: gcp-externalsecret
+  namespace: external-secrets-1
+  resourceVersion: "104532"
+  uid: 93a3295a-a3ad-4304-90e1-1328d951e5fb
+spec:
+.
+.
+.
+status:
+  binding:
+    name: k8s-secret-gcp
+  conditions:
+  - lastTransitionTime: "2025-10-27T11:39:03Z"
+    message: secret synced
+    reason: SecretSynced
+    status: "True"
+    type: Ready
+  refreshTime: "2025-10-27T12:13:15Z"
+  syncedResourceVersion: 1-f47fe3c0b255b6dd8047cdffa772587bb829efe7a1cb70febeda2eb2
+----

--- a/modules/external-secrets-operator-delete-upstream-operatorconfig.adoc
+++ b/modules/external-secrets-operator-delete-upstream-operatorconfig.adoc
@@ -1,0 +1,65 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-operator-migrate-downstream-upstream.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="external-secrets-operator-delete-upstream-operatorconfig_{context}"]
+= Deleting the community {external-secrets-operator-short}
+
+[role="_abstract"]
+Delete the configuration resource for the community Operator so that the legacy application is fully removed. This action prevents conflicts before installing the {external-secrets-operator}.
+
+.Prerequisites
+
+* You must be logged in as a user with the `cluster-admin` role.
+
+* You must have the `oc` command-line tool installed and configured.
+
+.Procedure
+
+. Find your community Operator's `namespace` by running the following command:
++
+[source,terminal]
+----
+$ oc get operatorconfigs.operator.external-secrets.io -A
+----
++
+.Example output
++
+[source,terminal]
+----
+NAMESPACE             NAME        AGE
+external-secrets      cluster     9m18s
+----
+
+. Delete the `operatorconfig` custom resrouce (CR) by running the following command:
++
+[source,terminal]
+----
+$ oc delete operatorconfig <config_name> -n <operator_namespace>
+----
+
+.Verification
+
+. To verify that the `operatorconfig` CR is deleted, run the following command:
++
+[source,terminal]
+----
+$ oc get operatorconfig -n <operator_namespace>
+----
++
+The command must return `no resource found`.
+
+. To verify that the old webhooks are deleted, run the following commands:
++
+[source,terminal]
+----
+$ oc get validatingwebhookconfigurations | grep external-secrets
+----
++
+[source,terminal]
+----
+$ oc get mutatingwebhookconfigurations | grep external-secrets
+----
++
+The commands must return no results.

--- a/modules/external-secrets-operator-egress-allow-all-traffic.adoc
+++ b/modules/external-secrets-operator-egress-allow-all-traffic.adoc
@@ -1,0 +1,41 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-operator-install.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="external-secrets-operator-egress-allow-all-traffic_{context}"]
+= Adding a custom network policy to allow egress to all external providers
+
+[role="_abstract"]
+You must configure custom policies through the `ExternalSecretsConfig` custom resource to allow all egress to all external providers.
+
+.Prerequisites
+
+* An `ExternalSecretsConfig` must be predefined.
+
+* You must be able to define specific egress rules, including destination ports and protocols.
+
+.Procedure
+
+. Edit the `ExternalSecretsConfig` CR by running the following command:
++
+[source,terminal]
+----
+$ oc edit externalsecretsconfigs.operator.openshift.io cluster
+----
+
+. Set the policy by editing the `networkPolicies` section:
++
+[source,yaml]
+----
+apiVersion: operator.openshift.io/v1alpha1
+kind: ExternalSecretsConfig
+metadata:
+  name: cluster
+spec:
+  controllerConfig:
+    networkPolicies:
+      - name: allow-external-secrets-egress
+        componentName: CoreController
+        egress: # Allow all egress traffic
+----

--- a/modules/external-secrets-operator-egress-specific-provider.adoc
+++ b/modules/external-secrets-operator-egress-specific-provider.adoc
@@ -1,0 +1,49 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-operator-install.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="external-secrets-operator-egress-specific-provider_{context}"]
+= Adding a custom network policy to allow egress to a specific provider
+
+[role="_abstract"]
+You must configure custom policies through the `ExternalSecretsConfig` custom resource (CR) to allow all egress to a specific provider.
+
+.Prerequisites
+
+* An `ExternalSecretsConfig` must be predefined.
+
+* You must be able to define specific egress rules, including destination ports and protocols
+
+.Procedure
+
+. Edit the `ExternalSecretsConfig` CR by running the following command:
++
+[source,terminal]
+----
+$ oc edit externalsecretsconfigs.operator.openshift.io cluster
+----
+
+. Set the policy by editing the `networkPolicies` section. The following example shows how to allow egress to {aws-first} endpoints.
++
+[source,yaml]
+----
+apiVersion: operator.openshift.io/v1alpha1
+kind: ExternalSecretsConfig
+metadata:
+  name: cluster
+spec:
+  controllerConfig:
+    networkPolicies:
+      - componentName: ExternalSecretsCoreController
+        egress:
+          # Allow egress to Kubernetes API server, AWS endpoints, and DNS
+          - ports:
+              - port: 443   # HTTPS (AWS Secrets Manager)
+                protocol: TCP
+      - name: allow-external-secrets-egress
+----
++
+where:
+
+`spec.controllerConfig.networkPolicies.componentName`:: Specifies the name for the core controller which is `ExternalSecretsCoreController`. Egress rules must specify the required ports, such as Transmission Control Protocol (TCP) port 443, for services such as the {aws-short} Secrets Manager.

--- a/modules/external-secrets-operator-eso-install.adoc
+++ b/modules/external-secrets-operator-eso-install.adoc
@@ -1,0 +1,15 @@
+
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-operator-migrate-downstream-upstream.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="external-secrets-operator-eso-install_{context}"]
+= Installing the {external-secrets-operator}
+
+[role="_abstract"]
+Install the {external-secrets-operator} after cleaning up the community version. This establishes the officially supported service for managing secrets in your cluster.
+
+.Procedure
+
+* To install the {external-secrets-operator} see link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.19/html-single/security_and_compliance/index#external-secrets-operator-install[Installing the External Secrets Operator for Red Hat OpenShift].

--- a/modules/external-secrets-operator-ingress-egress-rules.adoc
+++ b/modules/external-secrets-operator-ingress-egress-rules.adoc
@@ -1,0 +1,43 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-operator-install.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="external-secrets-operator-ingress-egress-rules_{context}"]
+= Default ingress and egress rules
+
+[role="_abstract"]
+The following table summarizes the default ingress and egress rules.
+
+[cols="1,1,1,1",options="header"]
+|===
+| Component
+| Ingress ports
+| Egress ports
+| Description
+
+| `external-secrets`
+| 8080
+| 6443
+| Allows retrieving metrics and interacting with the API server
+
+| `external-secrets-webhook`
+| 8080/10250
+| 6443
+| Allows retrieving metrics, handling webhook requests, and interacting with the API server
+
+| `external-secrets-cert-controller`
+| 8080
+| 6443
+| Allows retrieving metrics and interacting with the API server
+
+| `external-secrets-bitwarden-server`
+| 9998
+| 6443
+| Handles Bitwarden server connections and interacts with the API server
+
+| `external-secrets-allow-dns`
+|
+| 5353
+| Enables DNS lookups to find external secret providers.
+|===

--- a/modules/external-secrets-operator-install-cli.adoc
+++ b/modules/external-secrets-operator-install-cli.adoc
@@ -6,11 +6,12 @@
 [id="external-secrets-operator-install-cli_{context}"]
 = Installing the {external-secrets-operator} by using the CLI
 
-You can use the command-line interface (CLI) to install the {external-secrets-operator}.
+[role="_abstract"]
+Install the {external-secrets-operator-short} by creating a project, `OperatorGroup`, and `Subscription` objects using the OpenShift CLI.
 
 .Prerequisites
 
-* You have access to the cluster with `cluster-admin` privileges.
+* You have access to the cluster with the `cluster-admin` fole.
 
 .Procedure
 
@@ -24,6 +25,7 @@ $ oc new-project external-secrets-operator
 . Create an `OperatorGroup` object by defining a YAML file with the following content:
 +
 .Example `operatorGroup.yaml` file
++
 [source,yaml]
 ----
 apiVersion: operators.coreos.com/v1
@@ -45,6 +47,7 @@ $ oc create -f operatorGroup.yaml
 . Create a `Subscription` object by defining a YAML file with the following content:
 +
 .Example `subscription.yaml` file
++
 [source,yaml]
 ----
 apiVersion: operators.coreos.com/v1alpha1
@@ -77,6 +80,7 @@ $ oc get subscription -n external-secrets-operator
 ----
 +
 .Example output
++
 [source,terminal]
 ----
 NAME                                  PACKAGE                               SOURCE          CHANNEL
@@ -91,6 +95,7 @@ $ oc get csv -n external-secrets-operator
 ----
 +
 .Example output
++
 [source,terminal]
 ----
 NAME                               DISPLAY                                           VERSION   REPLACES   PHASE
@@ -105,6 +110,7 @@ $ oc get pods -n external-secrets-operator
 ----
 +
 .Example output
++
 [source,terminal]
 ----
 NAME                                                            READY   STATUS    RESTARTS   AGE

--- a/modules/external-secrets-operator-install-console.adoc
+++ b/modules/external-secrets-operator-install-console.adoc
@@ -6,30 +6,27 @@
 [id="external-secrets-operator-install-console_{context}"]
 = Installing the {external-secrets-operator} by using the web console
 
-You can use the web console to install the {external-secrets-operator}.
+[role="_abstract"]
+Install the {external-secrets-operator} by using the web console to add secret management features to your cluster. By doing this task, you can select an update channel and approval strategy to ensure the Operator stays current.
 
 .Prerequisites
 
-* You have access to the cluster with `cluster-admin` privileges.
+* You have access to the cluster with the `cluster-admin` role.
 * You have access to the {product-title} web console.
 
 .Procedure
 
 . Log in to the {product-title} web console.
 
-. Navigate to *Operators* -> *OperatorHub*.
+. Navigate to *Ecosystem* -> *Software Catalog*.
 
 . Enter *{external-secrets-operator-short}* in the search box.
 
 . Select the *{external-secrets-operator}* from the generated list and click *Install*.
-//+
-//[NOTE]
-//====
-//place holder for TechPreview release details or See supported {external-secrets-operator-short} versions in the following "Additional resources" section.
-//====
+
 . On the *Install Operator* page:
 
-.. Update the *Update channel*, if necessary. The channel defaults to *tech-preview-v0.1*, which installs the latest stable release of the {external-secrets-operator-short}.
+.. Update the *Update channel*, if necessary. The channel defaults to *stable-v1*, which installs the latest stable release of the {external-secrets-operator-short}.
 
 .. Select the version from *Version* drop-down list.
 
@@ -51,6 +48,6 @@ You can use the web console to install the {external-secrets-operator}.
 
 .Verification
 
-. Navigate to *Operators* -> *Installed Operators*.
+. Navigate to *Ecosystem* -> *Installed Operators*.
 
 . Verify that *{external-secrets-operator-short}* is listed with a *Status* of *Succeeded* in the `external-secrets-operator` namespace.

--- a/modules/external-secrets-operator-limitations.adoc
+++ b/modules/external-secrets-operator-limitations.adoc
@@ -2,13 +2,17 @@
 //
 // * security/external_secrets_operator/external-secrets-operator-install.adoc
 
-:_mod-docs-content-type: PROCEDURE
+:_mod-docs-content-type: CONCEPT
 [id="external-secrets-operator-limitations_{context}"]
 = Limitations of {external-secrets-operator}
 
-The following are the limitations of {external-secrets-operator} during the installation and uninstallation of the `external-secrets` application.
+[role="_abstract"]
+The {external-secrets-operator-short} has limitations related to resource cleanup, cert-manager dependencies, and architecture support that require manual intervention during installation and uninstallation.
 
-* Uninstalling the {external-secrets-operator} does not delete the resources created for `external-secrets` application. you must clean up the resources manually.
-* When you add `cert-manager` Operator configurations in `externalsecrets.operator.openshift.io` object after creation, delete the `external-secrets-cert-controller` deployment resource manually to prevent degradation of the `external-secrets` application.
-* Enable the `BitwardenSecretManagerProvider` field in `externalsecrets.operator.openshift.io` object only when installed on OpenShift Cluster running on x86_64 and arm64 architectures .
-* Ensure `cert-manager` Operator is installed and operational before deploying the {external-secrets-operator} for seamless functioning. If you install the `cert-manager` Operator later, manually restart the `external-secrets-operator` pod to apply cert-manager configurations in `externalsecrets.operator.openshift.io` object.
+* Uninstalling the {external-secrets-operator} does not delete the resources created for the `external-secrets` application. You must clean up the resources manually.
+
+* When you add the `cert-manager` Operator configurations in the `externalsecrets.operator.openshift.io` object after creation, delete the `external-secrets-cert-controller` deployment resource manually to prevent degradation of the `external-secrets` application.
+
+* Enable the `BitwardenSecretManagerProvider` field in the `externalsecrets.operator.openshift.io` object only when installed on an OpenShift Cluster running on x86_64 and arm64 architectures.
+
+* Ensure that the `cert-manager` Operator is installed and operational before deploying the {external-secrets-operator} for seamless functioning. If you install the `cert-manager` Operator later, manually restart the `external-secrets-operator` pod to apply the cert-manager configurations in the `externalsecrets.operator.openshift.io` object.

--- a/modules/external-secrets-operator-proxy-considerations.adoc
+++ b/modules/external-secrets-operator-proxy-considerations.adoc
@@ -1,0 +1,16 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/index.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="external-secrets-operator-proxy-considerations_{context}"]
+= Security considerations
+
+[role="_abstract"]
+When using the {external-secrets-operator}, there are some security concerns you should consider:
+
+* The `external-secrets` operand fetches the secrets from the configured external providers and stores it in a Kubernetes native `Secrets` resource. This results in a secret zero problem. It is recommended to secure the secret objects using additional encryption. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_data_foundation/4.9/html/planning_your_deployment/security-considerations_rhodf#data-encryption-options_rhodf[Data encryption options].
+
+* When configuring `SecretStore` and `ClusterSecretStore` resources, consider using short-term credential-based authorization. This approach enhances security by limiting the window of opportunity for unauthorized access, even if credentials are compromised.
+
+* To enhance the security of the {external-secrets-operator}, it is crucial to implement role-based access controls (RBACs). These RBACs should define and limit access to the custom resources provided by the {external-secrets-operator-short}.

--- a/modules/external-secrets-operator-rn-0-1.adoc
+++ b/modules/external-secrets-operator-rn-0-1.adoc
@@ -1,0 +1,20 @@
+:_mod-docs-content-type: REFERENCE
+[id="external-secrets-operator-rn-0-1_{context}"]
+= Release notes for {external-secrets-operator} 0.1.0 (Technology Preview)
+
+[role="_abstract"]
+Version `0.1.0` of the {external-secrets-operator} is based on the upstream external-secrets version `0.14.3`. For more information, see the link:https://github.com/external-secrets/external-secrets/releases/tag/v0.14.3[external-secrets project release notes for v0.14.3].
+
+Issued: 2025-06-26
+
+The following advisories are available for the {external-secrets-operator} 0.1.0:
+
+* link:https://access.redhat.com/errata/RHBA-2025:9747[RHBA-2025:9747]
+* link:https://access.redhat.com/errata/RHBA-2025:9746[RHBA-2025:9746]
+* link:https://access.redhat.com/errata/RHBA-2025:9757[RHBA-2025:9757]
+* link:https://access.redhat.com/errata/RHBA-2025:9763[RHBA-2025:9763]
+
+[id="external-secrets-operator-0-1-0-features-enhancements_{context}"]
+== New features and enhancements
+
+There are no new features and enhancements for this release.

--- a/modules/external-secrets-operator-rn-1-0.adoc
+++ b/modules/external-secrets-operator-rn-1-0.adoc
@@ -1,0 +1,52 @@
+:_mod-docs-content-type: REFERENCE
+[id="external-secrets-operator-rn-1-0_{context}"]
+= Release notes for {external-secrets-operator} 1.0.0 (General Availability)
+
+[role="_abstract"]
+{external-secrets-operator} version 1.0.0 is based on the upstream external-secrets project, version v0.19.0. For more information, see the link:https://github.com/external-secrets/external-secrets/releases/tag/v0.19.0[external-secrets project release notes for v0.19.0].
+
+Issued: 2025-11-03
+
+The following advisories are available for the {external-secrets-operator} 1.0.0:
+
+* link:https://access.redhat.com/errata/RHBA-2025:19416[RHBA-2025:19416]
+* link:https://access.redhat.com/errata/RHBA-2025:19417[RHBA-2025:19417]
+* link:https://access.redhat.com/errata/RHBA-2025:19418[RHBA-2025:19418]
+* link:https://access.redhat.com/errata/RHBA-2025:19463[RHBA-2025:19463]
+
+[id="external-secrets-operator-1-0-0-fixed-issues_{context}"]
+== Fixed issues
+
+* Before this release, many of the APIs listed in the console for the {external-secrets-operator} were missing descriptions. With this release, the API descriptions have been added. (link:https://issues.redhat.com/browse/OCPBUGS-61081[OCPBUGS-61081])
+
+[id="external-secrets-operator-1-0-0-features-enhancements_{context}"]
+== New features and enhancements
+
+*Renaming and improvements on the Operator API*
+
+With this release, the Operator API, `externalsecrets.operator.openshift.io` has been renamed to `externalsecretsconfigs.operator.openshift.io` to avoid confusion with the external-secrets provided API that has the same name, but a different purpose. The external-secrets provided API has also been restructured and new features are added.
+
+For more information, see link:https://docs.redhat.com/en/documentation/openshift_container_platform/latest/html-single/security_and_compliance/index#external-secrets-operator-api[External Secrets Operator for Red Hat OpenShift APIs].
+
+*Support to collect metrics of {external-secrets-operator-short}*
+
+With this release, the {external-secrets-operator} supports collecting metrics for both the Operator and operands. This is optional and must be enabled.
+
+For more information, see link:https://docs.redhat.com/en/documentation/openshift_container_platform/latest/html-single/security_and_compliance/index#external-secrets-monitoring[Monitoring the External Secrets Operator for Red Hat OpenShift].
+
+*Support to configure proxy for {external-secrets-operator-short}*
+
+With this release, the {external-secrets-operator} supports configuring proxy for both the Operator and operand.
+
+For more information, see link:https://docs.redhat.com/en/documentation/openshift_container_platform/latest/html-single/security_and_compliance/index#external-secrets-operator-proxy[About the egress proxy for the External Secrets Operator for Red Hat OpenShift].
+
+*Root filesystem is read-only for {external-secrets-operator} containers*
+
+With this release, to improve security, the {external-secrets-operator} and all its operands have the `readOnlyRootFilesystem` security context set to true by default. This enhancement hardens the containers and prevents a potential attacker from modifying the contents of the container’s root file system.
+
+*Network policy hardening is now available for {external-secrets-operator-short} components*
+
+With this release, {external-secrets-operator} includes pre-defined `NetworkPolicy` resources designed for enhanced security by governing ingress and egress traffic for operand components. These policies cover essential internal traffic, such as ingress to the metrics and webhook servers, and egress to the OpenShift API server and DNS server. Note that deployment of the `NetworkPolicy` is enabled by default and egress allow policies must be explicitly defined in the `ExternalSecretsConfig` custom resource for the `external-secrets` component to fetch secrets from external providers.
+
+For more information, see link:https://docs.redhat.com/en/documentation/openshift_container_platform/latest/html-single/security_and_compliance/index#external-secrets-operator-config-net-policy[Configuring network policy for the operand].
+

--- a/modules/external-secrets-operator-rn-1-1.adoc
+++ b/modules/external-secrets-operator-rn-1-1.adoc
@@ -1,0 +1,55 @@
+:_mod-docs-content-type: REFERENCE
+[id="external-secrets-operator-rn-1-1_{context}"]
+= Release notes for {external-secrets-operator} 1.1.0 (General Availability)
+
+[role="_abstract"]
+{external-secrets-operator} version 1.1.0 is based on the upstream external-secrets project, version v0.20.4. For more information, see the link:https://https://github.com/external-secrets/external-secrets/tree/v0.20.4[external-secrets project release notes for v0.20.4].
+
+Issued: 2026-03-17
+
+The following advisories are available for the {external-secrets-operator} 1.1.0:
+
+* link:https://access.redhat.com/errata/RHBA-2026:5554[RHBA-2026:5554]
+* link:https://access.redhat.com/errata/RHBA-2026:5555[RHBA-2026:5555]
+* link:https://access.redhat.com/errata/RHBA-2026:5557[RHBA-2026:5558] 
+* link:https://access.redhat.com/errata/RHBA-2026:5589[RHBA-2026:5589]
+
+//[id="external-secrets-operator-1-1-0-bug-fixes_{context}"]
+//== Bug fixes
+
+[id="external-secrets-operator-1-1-0-features-enhancements_{context}"]
+== New features and enhancements
+
+*Customization feature is now available for {external-secrets-operator-short} components*
+
+With this release, the Operator API, `externalsecretsconfig.operator.openshift.io` allows users to customize various aspects of the `external-secrets` controllers. The new API allows users to add custom annotations and environment variables, and allows configuring revision history limits for the `external-secrets` deployments.
+
+For more information, see link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.20/html-single/security_and_compliance/index#external-secrets-log-levels[Customizing the External Secrets Operator for Red Hat OpenShift].
+
+*Renaming and improvements on the Operator API*
+
+With this release, the Operator API, `externalsecrets.operator.openshift.io` has been renamed to `externalsecretsconfigs.operator.openshift.io` to avoid confusion with the external-secrets provided API that has the same name, but a different purpose. The external-secrets provided API has also been restructured and new features are added.
+
+For more information, see link:https://docs.redhat.com/en/documentation/openshift_container_platform/latest/html-single/security_and_compliance/index#external-secrets-operator-api[External Secrets Operator for Red Hat OpenShift APIs].
+
+*Support to collect metrics of {external-secrets-operator-short}*
+
+With this release, the {external-secrets-operator} supports collecting metrics for both the Operator and operands. This is optional and must be enabled.
+
+For more information, see link:https://docs.redhat.com/en/documentation/openshift_container_platform/latest/html-single/security_and_compliance/index#external-secrets-monitoring[Monitoring the External Secrets Operator for Red Hat OpenShift].
+
+*Support to configure proxy for {external-secrets-operator-short}*
+
+With this release, the {external-secrets-operator} supports configuring proxy for both the Operator and operand.
+
+For more information, see link:https://docs.redhat.com/en/documentation/openshift_container_platform/latest/html-single/security_and_compliance/index#external-secrets-operator-proxy[About the egress proxy for the External Secrets Operator for Red Hat OpenShift].
+
+*Root filesystem is read-only for {external-secrets-operator} containers*
+
+With this release, to improve security, the {external-secrets-operator} and all its operands have the `readOnlyRootFilesystem` security context set to true by default. This enhancement hardens the containers and prevents a potential attacker from modifying the contents of the container’s root file system.
+
+*Network policy hardening is now available for {external-secrets-operator-short} components*
+
+With this release, {external-secrets-operator} includes pre-defined `NetworkPolicy` resources designed for enhanced security by governing ingress and egress traffic for operand components. These policies cover essential internal traffic, such as ingress to the metrics and webhook servers, and egress to the OpenShift API server and DNS server. Note that deployment of the `NetworkPolicy` is enabled by default and egress allow policies must be explicitly defined in the `ExternalSecretsConfig` custom resource for the `external-secrets` component to fetch secrets from external providers.
+
+For more information, see link:https://docs.redhat.com/en/documentation/openshift_container_platform/latest/html-single/security_and_compliance/index#external-secrets-operator-config-net-policy[Configuring network policy for the operand].

--- a/modules/external-secrets-operator-set-custom-variables.adoc
+++ b/modules/external-secrets-operator-set-custom-variables.adoc
@@ -1,0 +1,69 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-log-levels.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="external-secrets-operator-set-custom-variables_{context}"]
+=  Setting custom environment variables for external-secrets components
+
+[role="_abstract"]
+To configure component behavior at runtime or integrate with external services, set custom environment variables for individual `external-secrets` components.
+
+Custom environment variables are merged with the default environment variables set by the Operator. User-specified variables take precedence in case of conflicts with the Operator defaults. A maximum of 50 custom environment variables can be specified per component.
+
+The environment variable names starting with the following prefixes are reserved:
+
+* `HOSTNAME`
+
+* `KUBERNETES_`
+
+* `EXTERNAL_SECRETS_`
+
+.Prerequisites
+
+* You have access to the cluster with the `cluster-admin` role.
+
+* You have created the `ExternalSecretsConfig` custom resource.
+
+.Procedure
+
+. Edit the `ExternalSecretsConfig` CR by running the following command:
++
+[source,terminal]
+----
+$ oc edit externalsecretsconfigs.operator.openshift.io cluster
+----
+
+. Add the `overrideEnv` field under the desired component in the `spec.controllerConfig.componentConfigs` YAML as follows:
++
+[source,yaml]
+----
+apiVersion: operator.openshift.io/v1alpha1
+kind: ExternalSecretsConfig
+metadata:
+  name: cluster
+spec:
+  controllerConfig:
+    componentConfigs:
+      - componentName: ExternalSecretsCoreController
+        overrideEnv:
+          - name: Example
+            value: "4"
+----
++
+where
+
+`spec.controllerConfig.componentConfigs.overrideEnv.name`:: Specifies the name of the environment variable. Environment variable names starting with `HOSTNAME`, `KUBERNETES_`, or `EXTERNAL_SECRETS_` are reserved and are not allowed.
+
+`spec.controllerConfig.componentConfigs.overrideEnv.value`:: Specifies the value of the environment variable.
+
+.Verification
+
+* Verify that the environment variable is set on the deployment by running the following command:
++
+[source,terminal]
+----
+$ oc set env deployment/external-secrets -n external-secrets --list
+----
++
+The output should include the custom environment variable you specified.

--- a/modules/external-secrets-operator-stablev1-channel.adoc
+++ b/modules/external-secrets-operator-stablev1-channel.adoc
@@ -1,0 +1,21 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-operator-install.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="external-secrets-operator-stablev1-channel_{context}"]
+= About the {external-secrets-operator} stable-v1 channel
+
+[role="_abstract"]
+Select the `stable-v1` channel to install and update the latest release of the {external-secrets-operator}. By selecting this channel, you can use the most recent stable release for your Operator.
+
+[NOTE]
+====
+The `stable-v1` channel is the default and suggested channel while installing the {external-secrets-operator}.
+====
+
+The `stable-v1` channel offers the following update approval strategies:
+
+Automatic:: If you choose automatic updates for an installed {external-secrets-operator-short}, a new version of the {external-secrets-operator-short} is available in the `stable-v1` channel. The Operator Lifecycle Manager (OLM) automatically upgrades the running instance of your Operator without human intervention.
+
+Manual:: If you select manual updates, when a newer version of the {external-secrets-operator} is available, OLM creates an update request. As a cluster administrator, you must then manually approve that update request to have the {cert-manager-operator} updated to the new version.

--- a/modules/external-secrets-operator-stablev1-y-channel.adoc
+++ b/modules/external-secrets-operator-stablev1-y-channel.adoc
@@ -1,0 +1,19 @@
+
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-operator-install.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="external-secrets-operator-stablev1-y-channel_{context}"]
+= About the {external-secrets-operator} stable-v1.y channel
+
+[role="_abstract"]
+Select the stable-v1 channel to install and update the latest release of the {external-secrets-operator}. By selecting this channel, you can use the latest stable release and allows you to choose between automatic and manual updates.
+
+The y-stream version of the {external-secrets-operator} installs updates from the `stable-v1.y` channels such as `stable-v1.0`, `stable-v1.1`, and `stable-v1.2`. Select the `stable-v1.y` channel if you want to use the y-stream version and stay updated to the z-stream version of the {external-secrets-operator}.
+
+The `stable-v1.y` channel offers the following update approval strategies:
+
+Automatic:: If you choose automatic updates for an installed {external-secrets-operator}, a new z-stream version of the {external-secrets-operator} is available in the `stable-v1.y` channel. OLM automatically upgrades the running instance of your Operator without human intervention.
+
+Manual:: If you select manual updates, when a newer version of the {external-secrets-operator} is available, OLM creates an update request. As a cluster administrator, you must then manually approve that update request to have the {external-secrets-operator} updated to the new version of the z-stream releases.

--- a/modules/external-secrets-operator-uninstall-console.adoc
+++ b/modules/external-secrets-operator-uninstall-console.adoc
@@ -20,7 +20,7 @@ You can uninstall the {external-secrets-operator} by using the web console.
 
 . Uninstall the {external-secrets-operator} using the following steps:
 
-.. Navigate to *Operators* -> *Installed Operators*.
+.. Navigate to *Ecosystem* -> *Installed Operators*.
 
 .. Click the Options menu {kebab} next to the *{external-secrets-operator}* entry and click *Uninstall Operator*.
 

--- a/modules/external-secrets-operator-uninstall-helm.adoc
+++ b/modules/external-secrets-operator-uninstall-helm.adoc
@@ -1,0 +1,32 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-operator-migrate-downstream-upstream.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="external-secrets-operator-uninstall-helm_{context}"]
+= Uninstalling a helm installed community {external-secrets-operator-short}
+
+[role="_abstract"]
+Remove the community {external-secrets-operator-short} that was installed using Helm. This helps you free up resources and maintain a clean environment for your cluster.
+
+.Prerequisites
+
+* You must be logged in as a user with the `cluster-admin` role.
+
+* You must have deleted the `operatorconfig` custom resource (CR).
+
+.Procedure
+
+. Install the {external-secrets-operator}. The `external-secrets-operator` namespace must be null.
+
+. Delete the {external-secrets-operator-short} by running the following command:
++
+[source,terminal]
+----
+$ oc helm delete <release_name> -n <operator_namespace>
+----
++
+[NOTE]
+====
+Using `helm delete` might delete all custom resource definitions (CRDs) and CRs. It is recommended to installl the downstream Operator first if the namespace `external-secrets-operator` is empty.
+====

--- a/modules/external-secrets-operator-uninstall-olm.adoc
+++ b/modules/external-secrets-operator-uninstall-olm.adoc
@@ -1,0 +1,40 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-operator-migrate-downstream-upstream.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="external-secrets-operator-uninstall-olm_{context}"]
+= Uninstalling an Operator Lifecylce Manager installed community {external-secrets-operator-short}
+
+
+[role="_abstract"]
+Remove the community {external-secrets-operator-short} that was installed by an Operator Lifecycle Manager (OLM) subscription. This helps you free up resources and maintain a clean environment for your cluster.
+
+.Prerequisites
+
+* You must be logged in as a user with the `cluster-admin` role.
+
+* You must have deleted the `operatorconfig` CR.
+
+.Procedure
+
+. Find the subscription name by running the following command:
++
+[source,terminal]
+----
+$ oc get subscription -n <operator_namespace> | grep external-secrets
+----
+
+. Delete the subscription by running the following command:
++
+[source,terminal]
+----
+$ oc delete subscription <subscription_name> -n <operator_namespace>
+----
+
+. Delete the `ClusterServiceVersion` by running the following command:
++
+[source,terminal]
+----
+$ oc delete csv <csv_name> -n <operator_namespace>
+----

--- a/modules/external-secrets-operator-uninstall-raw-manifests.adoc
+++ b/modules/external-secrets-operator-uninstall-raw-manifests.adoc
@@ -1,0 +1,26 @@
+
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-operator-migrate-downstream-upstream.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="external-secrets-operator-uninstall-raw-manifests_{context}"]
+= Uninstalling a raw manifest installed community {external-secrets-operator-short}
+
+[role="_abstract"]
+Remove the community {external-secrets-operator-short} that was installed by raw manifests. This helps you free up resources and maintain a clean environment for your cluster.
+
+.Prerequisites
+
+* You must be logged in as a user with the `cluster-admin` role.
+
+* You must have deleted the `operatorconfig` CR.
+
+.Procedure
+
+* To remove the communiity {external-secrets-operator-short} that was installed by raw manifests, run the following command:
++
+[source,terminal]
+----
+$ oc delete -f /path/to/your/old/manifests.yaml -n <operator_namespace>
+----

--- a/modules/external-secrets-operator-uninstall-upstream-eso.adoc
+++ b/modules/external-secrets-operator-uninstall-upstream-eso.adoc
@@ -1,0 +1,13 @@
+
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-operator-migrate-downstream-upstream.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="external-secrets-operator-uninstall-upstream-eso_{context}"]
+= Uninstalling the community {external-secrets-operator-short}
+
+[role="_abstract"]
+Uninstall the community {external-secrets-operator-short} to prevent conflicts or accidental recreation after you migrate to {external-secrets-operator}.
+
+You must uninstall the community {external-secrets-operator-short} to prevent it from being recreated or conflicting with the new one. The steps to uninstall are different based on how the community {external-secrets-operator-short} was installed but the prerequisites are the same for each.

--- a/modules/external-secrets-operator-update-channels.adoc
+++ b/modules/external-secrets-operator-update-channels.adoc
@@ -1,0 +1,15 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-operator-install.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="external-secrets-operator-update-channels_{context}"]
+= Understanding update channels of the {external-secrets-operator}
+
+[role="_abstract"]
+Control the version of the {external-secrets-operator} in your cluster by selecting an update channel. By using this mechanism, you can declare a specific version track, ensuring your environment receives only the updates you require for stability.
+
+The {external-secrets-operator} offers the following update channels:
+
+* `stable-v1`
+* `stable-v1.y`

--- a/modules/external-secrets-query-metrics.adoc
+++ b/modules/external-secrets-query-metrics.adoc
@@ -1,0 +1,36 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-monitoring.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="external-secrets-query-metrics_{context}"]
+= Querying metrics for the external-secrets operand
+
+As a cluster administrator, or as a user with view access to all namespaces, you can query `external-secrets` operand metrics by using the {product-title} web console or the command-line interface (CLI). For more information, see "Accessing metrics".
+
+.Prerequisites
+
+* You have access to the cluster as a user with the `cluster-admin` role.
+* You have installed the {external-secrets-operator}.
+* You have enabled monitoring and metrics collection by creating a `ServiceMonitor` object.
+
+.Procedure
+
+. In the {product-title} web console, navigate to *Observe* -> *Metrics*.
+
+. In the query field, enter the following PromQL expressions to query the {external-secrets-operator} operands metric for each operand:
++
+[source,promql]
+----
+{job="external-secrets"}
+----
++
+[source,promql]
+----
+{job="external-secrets-webhook"}
+----
++
+[source,promql]
+----
+{job="external-secrets-cert-controller-metrics"}
+----

--- a/modules/external-secrets-query-operator-metrics.adoc
+++ b/modules/external-secrets-query-operator-metrics.adoc
@@ -1,0 +1,27 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-monitoring.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="external-secrets-query-operator-metrics_{context}"]
+= Querying metrics for the {external-secrets-operator}
+
+[role="_abstract"]
+As a cluster administrator, or as a user with view access to all namespaces, you can query the Operator metrics by using the {product-title} web console or the command-line interface (CLI). For more information, see "Accessing metrics".
+
+.Prerequisites
+
+* You have access to the cluster as a user with the `cluster-admin` role.
+* You installed the {external-secrets-operator}.
+* You enabled the monitoring and metrics collection by creating a `ServiceMonitor` object.
+
+.Procedure
+
+. In the {product-title} web console, navigate to *Observe* -> *Metrics*.
+
+. In the query field, enter the following PromQL expressions to query the {external-secrets-operator} metric:
++
+[source,promql]
+----
+{job="external-secrets-operator-controller-manager-metrics-service"}
+----

--- a/modules/external-secrets-remove-resources-cli.adoc
+++ b/modules/external-secrets-remove-resources-cli.adoc
@@ -6,6 +6,7 @@
 [id="external-secrets-remove-resources-cli_{context}"]
 = Removing {external-secrets-operator} resources by using the CLI
 
+[role="_abstract"]
 After you have uninstalled the {external-secrets-operator}, you can optionally eliminate its associated resources from your cluster by using the command-line interface (CLI).
 
 .Prerequisites

--- a/modules/external-secrets-remove-resources.adoc
+++ b/modules/external-secrets-remove-resources.adoc
@@ -6,7 +6,8 @@
 [id="external-secrets-remove-resources_{context}"]
 = Removing {external-secrets-operator} resources by using the web console
 
-After you have uninstalled the {external-secrets-operator}, you can optionally eliminate its associated resources from your cluster.
+[role="_abstract"]
+To clean up your cluster after uninstalling the {external-secrets-operator}, remove its associated resources. This deletes residual components, such as deployments and custom resource definitions.
 
 .Prerequisites
 
@@ -40,6 +41,7 @@ After you have uninstalled the {external-secrets-operator}, you can optionally e
 *** ACRAccessToken
 *** ClusterExternalSecret
 *** ClusterGenerator
+*** ClusterPushSecret
 *** ClusterSecretStore
 *** ECRAuthorizationToken
 *** ExternalSecret
@@ -47,10 +49,12 @@ After you have uninstalled the {external-secrets-operator}, you can optionally e
 *** GeneratorState
 *** GithubAccessToken
 *** Grafana
+*** MFA
 *** Password
 *** PushSecret
 *** QuayAccessToken
 *** SecretStore
+*** SSHKey
 *** STSSessionToken
 *** UUID
 *** VaultDynamicSecret

--- a/security/external_secrets_operator/external-secrets-log-levels.adoc
+++ b/security/external_secrets_operator/external-secrets-log-levels.adoc
@@ -1,0 +1,54 @@
+
+:_mod-docs-content-type: ASSEMBLY
+[id="external-secrets-log-levels"]
+= Customizing the External Secrets Operator for Red Hat OpenShift
+include::_attributes/common-attributes.adoc[]
+:context: external-secrets-log-levels
+
+toc::[]
+
+[role="_abstract"]
+You can customize the behavior of the {external-secrets-operator} Operand components by configuring custom annotations, deployment lifecycle settings, and environment variables through the `ExternalSecretsConfig` custom resource (CR).
+
+These configurations provide administrators with fine-grained control over the external-secrets deployment.
+
+You can customize the {external-secrets-operator} Operand by using the `ExternalSecretsConfig` custom resource (CR). The CR supports a set of deployment and runtime options, such as custom annotations, revision history limits, environment variables, resource limits, tolerations, and proxy settings so you can control how the operand is deployed and run without editing the operand resources directly.
+
+All supported options are defined in the `ExternalSecretsConfig` CR (for example under the `spec.controllerConfig` for controller-related settings). The Operator reconciles the Operand from this CR. Changes made directly to Operand resources are overwritten. Use the `ExternalSecretsConfig` CR as the only supported way to customize the operand.
+
+For the complete list of fields and allowed values, see the `ExternalSecretsConfig` API reference in the {external-secrets-operator} documentation.
+
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../external_secrets_operator/external-secrets-operator-api.adoc#external-secrets-operator-api[External Secrets Operator for Red Hat OpenShift APIs]
+
+//include::modules/cert-manager-enable-operand-log-level.adoc[leveloffset=+1]
+
+include::modules/external-secrets-enable-operator-log-level.adoc[leveloffset=+1]
+
+// enable operand log level
+include::modules/external-secrets-enable-operand-log-level.adoc[leveloffset=+1]
+
+// configure cert-manager certificate requirements
+include::modules/external-secrets-cert-manager-config.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+[id="external-secrets-log-levels_additional-resources"]
+.Additional resources
+
+* xref:../cert_manager_operator/index.adoc#cert-manager-operator-about[cert-manager Operator for Red Hat OpenShift]
+* xref:../cert_manager_operator/cert-manager-operator-install#cert-manager-operator-install[Installing the cert-manager-Operator for Red Hat OpenShift]
+
+// configuring bitwarden
+include::modules/external-secrets-bit-warden-config.adoc[leveloffset=+1]
+
+// add custom annotations
+include::modules/external-secrets-operator-adding-custom-annotations.adoc[leveloffset=+1]
+
+// configure history limit
+include::modules/external-secrets-operator-configure-history-limit.adoc[leveloffset=+1]
+
+// Set custom environment variables
+include::modules/external-secrets-operator-set-custom-variables.adoc[leveloffset=+1]

--- a/security/external_secrets_operator/external-secrets-monitoring.adoc
+++ b/security/external_secrets_operator/external-secrets-monitoring.adoc
@@ -1,0 +1,50 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="external-secrets-monitoring"]
+= Monitoring the External Secrets Operator for Red Hat OpenShift
+include::_attributes/common-attributes.adoc[]
+:context: external-secrets-monitoring
+
+toc::[]
+
+[role="_abstract"]
+By default, the {external-secrets-operator} exposes metrics for the Operator and the Operands. You can configure OpenShift Monitoring to collect these metrics by using the Prometheus Operator format.
+
+// Enabling user workload monitoring for the external-secrets-operator Operand
+include::modules/external-secrets-enable-user-workload-monitor.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+* link:https://docs.redhat.com/en/documentation/monitoring_stack_for_red_hat_openshift/4.21/html/configuring_user_workload_monitoring/configuring-metrics-uwm#setting-up-metrics-collection-for-user-defined-projects_configuring-metrics-uwm[Setting up metrics collection for user-defined projects]
+
+// Metrics scraping for external-secrets-operator
+include::modules/external-secrets-enable-operator-metrics.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* link:https://docs.redhat.com/en/documentation/monitoring_stack_for_red_hat_openshift/4.21/html/configuring_user_workload_monitoring/preparing-to-configure-the-monitoring-stack-uwm#configurable-monitoring-components_preparing-to-configure-the-monitoring-stack-uwm[Configurable monitoring components]
+
+// Querying metrics for the external-secrets operator
+include::modules/external-secrets-query-operator-metrics.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* link:https://docs.redhat.com/en/documentation/monitoring_stack_for_red_hat_openshift/4.21/html/accessing_metrics/index[Accessing metrics]
+
+
+// Metrics scraping for external-secrets operands by using a ServiceMonitor
+include::modules/external-secrets-enable-metrics.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* link:https://docs.redhat.com/en/documentation/monitoring_stack_for_red_hat_openshift/4.21/html/configuring_user_workload_monitoring/preparing-to-configure-the-monitoring-stack-uwm[Configuring user workload monitoring]
+
+// Querying metrics for the external-secrets operands
+include::modules/external-secrets-query-metrics.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* link:https://docs.redhat.com/en/documentation/monitoring_stack_for_red_hat_openshift/4.21/html/accessing_metrics/index[Accessing metrics]

--- a/security/external_secrets_operator/external-secrets-operator-api.adoc
+++ b/security/external_secrets_operator/external-secrets-operator-api.adoc
@@ -1,11 +1,13 @@
+
 :_mod-docs-content-type: ASSEMBLY
 [id="external-secrets-operator-api"]
-= {external-secrets-operator} APIs
+= External Secrets Operator for Red Hat OpenShift APIs
 include::_attributes/common-attributes.adoc[]
 :context: external-secrets-operator-api
 
 toc::[]
 
+[role="_abstract"]
 {external-secrets-operator} uses the following two APIs to configure the `external-secrets` application deployment.
 
 //:FeatureName: The {external-secrets-operator}
@@ -19,7 +21,7 @@ toc::[]
 
 | `operator.openshift.io`
 | `v1alpha1`
-| `externalsecrets`
+| `externalsecretsConfig`
 
 | `operator.openshift.io`
 | `v1alpha1`
@@ -28,10 +30,8 @@ toc::[]
 
 The following list contains the {external-secrets-operator} APIs:
 
-* ExternalSecrets
-* ExternalSecretsList
+* ExternalSecretsConfig
 * ExternalSecretsManager
-* ExternalSecretsManagerList
 
 //ExternalSecretsManagerList
 include::modules/eso-external-secrets-manager-list.adoc[leveloffset=+1]
@@ -39,10 +39,10 @@ include::modules/eso-external-secrets-manager-list.adoc[leveloffset=+1]
 //ExternalSecretsManager
 include::modules/eso-external-secrets-manager.adoc[leveloffset=+1]
 
-//ExternalSecretsList
+//ExternalSecretsConfigList
 include::modules/eso-external-secrets-list.adoc[leveloffset=+1]
 
-//ExternalSecrets
+//ExternalSecretsConfig
 include::modules/eso-external-secrets.adoc[leveloffset=+1]
 
 [id="external-secrets-operator-fields_{context}"]
@@ -56,26 +56,23 @@ include::modules/eso-external-secrets-manager-spec.adoc[leveloffset=+1]
 //externalSecretsManagerStatus
 include::modules/eso-external-secrets-manager-status.adoc[leveloffset=+1]
 
-//ExternalSecretsSpec
+//ExternalSecretsConfigSpec
 include::modules/eso-external-secrets-spec.adoc[leveloffset=+1]
 
-//externalSecretsStatus
+//externalSecretsConfigStatus
 include::modules/eso-external-secrets-status.adoc[leveloffset=+1]
 
 //GlobalConfig
 include::modules/eso-global-config.adoc[leveloffset=+1]
 
-//Feature
-include::modules/eso-feature.adoc[leveloffset=+1]
+//ControllerConfig
+include::modules/eso-controller-config.adoc[leveloffset=+1]
 
 //controllerStatus
 include::modules/eso-controller-status.adoc[leveloffset=+1]
 
-//ExternalSecretsConfig
+//ApplicationConfig
 include::modules/eso-external-secrets-config.adoc[leveloffset=+1]
-
-//ControllerConfig
-include::modules/eso-controller-config.adoc[leveloffset=+1]
 
 //bitwardenSecretManagerProvider
 include::modules/eso-bitwarden-secret.adoc[leveloffset=+1]
@@ -86,8 +83,32 @@ include::modules/eso-web-hook-config.adoc[leveloffset=+1]
 //CertManagerConfig
 include::modules/eso-cert-manager-config.adoc[leveloffset=+1]
 
+//CertProvidersConfig
+include::modules/eso-cert-providers-config.adoc[leveloffset=+1]
+
 //ObjectReference
 include::modules/eso-object-reference.adoc[leveloffset=+1]
 
 //secretReference
 include::modules/eso-secret-reference.adoc[leveloffset=+1]
+
+//condition
+include::modules/eso-condition.adoc[leveloffset=+1]
+
+//conditionalStatus
+include::modules/eso-conditional-status.adoc[leveloffset=+1]
+
+//mode
+include::modules/eso-mode.adoc[leveloffset=+1]
+
+//pluginsConfig
+include::modules/eso-plugins-config.adoc[leveloffset=+1]
+
+//ProxyConfig
+include::modules/eso-proxy-config.adoc[leveloffset=+1]
+
+//componentConfig
+include::modules/eso-component-config.adoc[leveloffset=+1]
+
+//deploymentConfig
+include::modules/eso-deployment-config.adoc[leveloffset=+1]

--- a/security/external_secrets_operator/external-secrets-operator-config-net-policy.adoc
+++ b/security/external_secrets_operator/external-secrets-operator-config-net-policy.adoc
@@ -1,0 +1,19 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="external-secrets-operator-config-net-policy"]
+= Configuring network policy for the Operand
+include::_attributes/common-attributes.adoc[]
+:context: external-secrets-operator-uninstall
+
+toc::[]
+
+[role="_abstract"]
+The {external-secrets-operator} for {product-title} includes pre-defined `NetworkPolicies` for security that rejects all egress traffic and allows traffic towards services that are required for the Operand functionality. You must configure additional custom policies to allow the `external-secrets` controller to egress traffic towards external providers. These configurable policies are set through the `ExternalSecretsConfig` custom resource (CR) to establish the egress allow policy.
+
+// Adding network policy to connect to permit all egress traffic
+include::modules/external-secrets-operator-egress-allow-all-traffic.adoc[leveloffset=+1]
+
+// Adding network policy to connect to a specific provider
+include::modules/external-secrets-operator-egress-specific-provider.adoc[leveloffset=+1]
+
+// Default ingress and egress rules
+include::modules/external-secrets-operator-ingress-egress-rules.adoc[leveloffset=+1]

--- a/security/external_secrets_operator/external-secrets-operator-install.adoc
+++ b/security/external_secrets_operator/external-secrets-operator-install.adoc
@@ -1,15 +1,13 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="external-secrets-operator-install"]
-= Installing the {external-secrets-operator}
+= Installing the External Secrets Operator for Red Hat OpenShift
 include::_attributes/common-attributes.adoc[]
 :context: external-secrets-operator-install
 
 toc::[]
 
-The {external-secrets-operator} is not installed on the {product-title} by default. Install the {external-secrets-operator-short} by using either the web console or the command-line interface (CLI).
-
-:FeatureName: The {external-secrets-operator}
-include::snippets/technology-preview.adoc[leveloffset=+1]
+[role="-abstract"]
+To manage external secrets on {product-title}, install the {external-secrets-operator-short} by using the web console or the command-line interface (CLI).
 
 //Limitations of application installation and uninstallation
 include::modules/external-secrets-operator-limitations.adoc[leveloffset=+1]
@@ -28,3 +26,19 @@ include::modules/external-secrets-operator-install-cli.adoc[leveloffset=+1]
 
 //== Installing the external secrets operand using CLI
 include::modules/external-secrets-operand-install-cli.adoc[leveloffset=+1]
+
+//== updating external secrets channels
+include::modules/external-secrets-operator-update-channels.adoc[leveloffset=+1]
+
+//== updating external secrets stable v1 channels
+include::modules/external-secrets-operator-stablev1-channel.adoc[leveloffset=+2]
+
+//== updating external secrets stable v1.y channels
+include::modules/external-secrets-operator-stablev1-y-channel.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+[id="external-secrets-operator-update-channels_additional-resources"]
+== Additional resources
+
+* xref:../../operators/admin/olm-adding-operators-to-cluster.adoc#olm-adding-operators-to-a-cluster[Adding Operators to a cluster]
+* xref:../../operators/admin/olm-upgrading-operators.adoc#olm-upgrading-operators[Updating installed Operators]

--- a/security/external_secrets_operator/external-secrets-operator-migrate-downstream-upstream.adoc
+++ b/security/external_secrets_operator/external-secrets-operator-migrate-downstream-upstream.adoc
@@ -1,0 +1,58 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="external-secrets-operator-migrate-downstream-upstream"]
+= Migrating from the community External Secrets Operator to the External Secrets Operator for Red Hat OpenShift
+include::_attributes/common-attributes.adoc[]
+:context: external-secrets-operator-migrate-downstream-upstream
+
+toc::[]
+
+[role="_abstract"]
+Migrate from the community {external-secrets-operator-short} to the {external-secrets-operator} supported version. This conversion provides you with enterprise-grade support and seamless integration for managing external secrets.
+
+The following migration versions have been fully tested.
+
+[cols="1,1,1",options="header"]
+|===
+| Upstream version
+| Installation method
+| Downstream version
+
+| 0.11.0
+| OLM
+| v1.0.0 GA
+
+| 0.19.0
+| Helm
+| v1.0.0 GA
+|===
+
+[NOTE]
+====
+The migration does not support rollbacks.
+====
+
+[NOTE]
+====
+{external-secrets-operator} is based on the upstream version 0.19.0. Do not try to migrate from a higher version of the {external-secrets-operator-short}.
+====
+
+// Deleting the operatorconfig
+include::modules/external-secrets-operator-delete-upstream-operatorconfig.adoc[leveloffset=+1]
+
+// Uninstalling the upstream {external-secrets-operator}
+include::modules/external-secrets-operator-uninstall-upstream-eso.adoc[leveloffset=+1]
+
+// Uninstalling the upstream {external-secrets-operator} installed by helm
+include::modules/external-secrets-operator-uninstall-helm.adoc[leveloffset=+2]
+
+// Uninstalling the upstream {external-secrets-operator} installed by OLM
+include::modules/external-secrets-operator-uninstall-olm.adoc[leveloffset=+2]
+
+// Uninstalling the upstream {external-secrets-operator} installed by raw manifests
+include::modules/external-secrets-operator-uninstall-raw-manifests.adoc[leveloffset=+2]
+
+// Removing {external-secrets-operator-short} using CLI
+include::modules/external-secrets-operator-eso-install.adoc[leveloffset=+1]
+
+// Create externalsecretsconfig and verify everything is running
+include::modules/external-secrets-operator-create-externalsecretsconfig.adoc[leveloffset=+1]

--- a/security/external_secrets_operator/external-secrets-operator-proxy.adoc
+++ b/security/external_secrets_operator/external-secrets-operator-proxy.adoc
@@ -1,0 +1,19 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="external-secrets-operator-proxy"]
+= About the egress proxy for the External Secrets Operator for Red Hat OpenShift
+include::_attributes/common-attributes.adoc[]
+:context: external-secrets-operator-proxy
+
+toc::[]
+
+[role="_abstract"]
+If a cluster-wide egress proxy is configured in {product-title}, Operator Lifecycle Manager (OLM) automatically configures Operators that it manages with the cluster-wide proxy. OLM automatically updates all of the Operator’s deployments with the `HTTP_PROXY`, `HTTPS_PROXY`, `NO_PROXY` environment variables.
+
+// Configure egress proxy
+include::modules/external-secrets-operator-configure-proxy.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+[id="external-resources-operator-proxy_additional-resources"]
+== Additional resources
+
+* xref:../../operators/admin/olm-configuring-proxy-support.adoc#olm-configuring-proxy-support[Configuring proxy support in Operator Lifecycle Manager]

--- a/security/external_secrets_operator/external-secrets-operator-release-notes.adoc
+++ b/security/external_secrets_operator/external-secrets-operator-release-notes.adoc
@@ -6,30 +6,16 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 The {external-secrets-operator} is a cluster-wide service that provides lifecycle management for secrets fetched from external secret management systems.
 
 These release notes track the development of {external-secrets-operator-short}.
 
-:FeatureName: The {external-secrets-operator}
-include::snippets/technology-preview.adoc[leveloffset=+1]
-
 For more information, see xref:../../security/external_secrets_operator/index.adoc#external-secrets-operator-about[{external-secrets-operator-short} overview].
 
-[id="external-secrets-operator-release-notes-0-1-0_{context}"]
-== Release notes for {external-secrets-operator} 0.1.0 (Technology Preview)
+// Release notes 1.1.0 General Availability
+include::modules/external-secrets-operator-rn-1-1.adoc[leveloffset=+1]
 
-Issued: 2025-06-26
+// Release notes 0.1.0 General Availability
+include::modules/external-secrets-operator-rn-0-1.adoc[leveloffset=+1]
 
-The following advisories are available for the {external-secrets-operator} 0.1.0:
-
-* link:https://access.redhat.com/errata/RHBA-2025:9747[RHBA-2025:9747]
-* link:https://access.redhat.com/errata/RHBA-2025:9746[RHBA-2025:9746]
-* link:https://access.redhat.com/errata/RHBA-2025:9757[RHBA-2025:9757]
-* link:https://access.redhat.com/errata/RHBA-2025:9763[RHBA-2025:9763]
-
-Version `0.1.0` of the {external-secrets-operator} is based on the upstream external-secrets version `0.14.3`. For more information, see the link:https://github.com/external-secrets/external-secrets/releases/tag/v0.14.3[external-secrets project release notes for v0.14.3].
-
-[id="external-secrets-operator-0-1-0-features-enhancements_{context}"]
-=== New features and enhancements
-
-* This is the initial, Technology Preview release of the {external-secrets-operator}.

--- a/security/external_secrets_operator/external-secrets-operator-uninstall.adoc
+++ b/security/external_secrets_operator/external-secrets-operator-uninstall.adoc
@@ -6,10 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-You can remove the {external-secrets-operator} from {product-title} by uninstalling the Operator and removing its related resources.
-
-:FeatureName: The {external-secrets-operator}
-include::snippets/technology-preview.adoc[leveloffset=+1]
+[role="_abstract"]
+ou can remove the {external-secrets-operator} from {product-title} by uninstalling the Operator and removing its related resources.
 
 // Uninstalling the {external-secrets-operator-short}
 include::modules/external-secrets-operator-uninstall-console.adoc[leveloffset=+1]

--- a/security/external_secrets_operator/index.adoc
+++ b/security/external_secrets_operator/index.adoc
@@ -8,9 +8,6 @@ toc::[]
 
 The {external-secrets-operator} operates as a cluster-wide service to deploy and manage the `external-secrets` application. The `external-secrets` application integrates with external secrets management systems and performs secret fetching, refreshing, and provisioning within the cluster.
 
-:FeatureName: The {external-secrets-operator}
-include::snippets/technology-preview.adoc[leveloffset=+1]
-
 //About the {external-secrets-operator}
 include::modules/external-secrets-about.adoc[leveloffset=+1]
 
@@ -20,6 +17,9 @@ include::modules/external-secrets-provider-types.adoc[leveloffset=+1]
 //FIPS compliant support
 include::modules/external-secrets-fips-support.adoc[leveloffset=+1]
 
+//egress proxy security considerations
+include::modules/external-secrets-operator-proxy-considerations.adoc[leveloffset=+1]
+
 [role="_additional-resources"]
 [id="external-secrets-operator-about_additional-resources"]
 == Additional resources
@@ -28,3 +28,5 @@ include::modules/external-secrets-fips-support.adoc[leveloffset=+1]
 * xref:../../security/container_security/security-compliance.adoc#security-compliance[Understanding compliance]
 * xref:../../installing/overview/installing-fips.adoc#installing-fips-mode_installing-fips[Installing a cluster in FIPS mode]
 * xref:../../installing/overview/installing-preparing.adoc#installing-preparing-security[Do you need extra security for your cluster?]
+* link:https://docs.redhat.com/en/documentation/red_hat_openshift_data_foundation/4.19/html/planning_your_deployment/security-considerations_rhodf[Security considerations]
+* link:https://external-secrets.io/latest/guides/security-best-practices/[Security Best Practices]


### PR DESCRIPTION
Version(s):
4.19

Issue:
https://redhat.atlassian.net/browse/OSDOCS-18782

Link to docs preview:
https://109778--ocpdocs-pr.netlify.app/
https://109778--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/external_secrets_operator/external-secrets-log-levels.html
https://109778--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/external_secrets_operator/external-secrets-monitoring.html
https://109778--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/external_secrets_operator/external-secrets-operator-api.html
https://109778--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/external_secrets_operator/external-secrets-operator-config-net-policy.html
https://109778--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/external_secrets_operator/external-secrets-operator-install.html
https://109778--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/external_secrets_operator/external-secrets-operator-proxy.html
https://109778--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/external_secrets_operator/external-secrets-operator-release-notes.html
https://109778--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/external_secrets_operator/external-secrets-operator-uninstall.html
https://109778--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/external_secrets_operator/index.html


QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
The files listed above were backported from the most recent documentation ESO release since 4.19 is going from TP to GA. 

