### PR TITLE
Telcodocs 2613 Docs and RN: CNF-20333 MetalLB ConfigurationStatus CRD

### DIFF
--- a/modules/nw-metallb-checking-configuration-status.adoc
+++ b/modules/nw-metallb-checking-configuration-status.adoc
@@ -1,0 +1,126 @@
+// Module included in the following assemblies:
+//
+// * networking/ingress_load_balancing/metallb/monitoring-metallb-status.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="nw-metallb-checking-configuration-status_{context}"]
+= Checking MetalLB configuration status
+
+[role="_abstract"]
+You can verify that the MetalLB controller and speakers have successfully applied the current configuration by viewing the `ConfigurationState` custom resource (CR). MetalLB creates a `ConfigurationState` resource for the controller and one for each speaker node. These resources report whether the configuration is valid and surface error details when validation fails, such as incompatible custom resources.
+
+.Prerequisites
+
+* You have an {product-title} cluster with the MetalLB Operator installed.
+* You have deployed a MetalLB instance.
+* You have configured MetalLB resources such as `IPAddressPool`, `BGPPeer`, `BFDProfile`, `Community`, or `FRRConfiguration`.
+
+.Procedure
+
+. List the `ConfigurationState` resources by running the following command:
++
+[source,terminal]
+----
+$ oc get configurationstates -n metallb-system
+----
++
+.Example output
+[source,terminal]
+----
+NAME                         RESULT   ERRORSUMMARY   AGE
+controller                   Valid                   75m
+speaker-mysno-sno.demo.lab   Valid                   28m
+----
++
+The `controller` resource shows the status for the MetalLB controller. Each `speaker-<node-name>` resource shows the status for the speaker on that node.
+
+. Verify that the controller has a valid configuration by inspecting the `ConfigurationState` details. Run the following command:
++
+[source,terminal]
+----
+$ oc get configurationstates controller -n metallb-system -o yaml
+----
++
+.Example output
+[source,yaml]
+----
+apiVersion: metallb.io/v1beta1
+kind: ConfigurationState
+metadata:
+  creationTimestamp: "2026-04-21T09:46:47Z"
+  generation: 1
+  labels:
+    metallb.io/component-type: controller
+  name: controller
+  namespace: metallb-system
+  resourceVersion: "28268"
+  uid: 23f5c492-4d5c-4893-84ea-77904c006404
+status:
+  conditions:
+  - lastTransitionTime: "2026-04-21T09:54:00Z"
+    message: ""
+    reason: Reconciled
+    status: "True"
+    type: poolReconcilerValid
+  result: Valid
+----
++
+Confirm that the output has the following values:
++
+* `result: Valid` indicates that all configured resources are compatible and active. If this value is `Invalid`, check the `errorSummary` field for aggregated error messages that identify which part of the configuration has failed.
+* `message: Describes any configuration problem that occurs.  Here, `""` confirms that no errors were reported.
+* `reason: Reconciled` with `status: "True"` confirms that the reconciler has successfully processed the configuration. If the `reason` is `ReconciliationFailed` and `status` is `"False"`, the `message` field contains details about the failure.
++
+[NOTE]
+====
+The controller does not validate peer-level settings. Errors such as a missing `BFDProfile`, undefined `Community`, or missing authentication secret are reported only by the speakers. A `Valid` controller with one or more `Invalid` speakers is expected in these cases. Always check both controller and speaker `ConfigurationState` resources.
+====
++
+If the configuration is invalid, the output is similar to the following example:
++
+[source,yaml]
+----
+apiVersion: metallb.io/v1beta1
+kind: ConfigurationState
+metadata:
+  creationTimestamp: "2026-04-21T09:51:17Z"
+  generation: 1
+  labels:
+    metallb.io/component-type: speaker
+    metallb.io/node-name: mysno-sno.demo.lab
+  name: speaker-mysno-sno.demo.lab
+  namespace: metallb-system
+  resourceVersion: "31161"
+  uid: 339781bf-ec9a-4ba9-aaba-0a9ac8ebce78
+status:
+  conditions:
+  - lastTransitionTime: "2026-04-21T10:09:34Z"
+    message: 'configuration error: peer peer1 referencing non existing bfd profile
+      my-bfd-profile'
+    reason: ConfigurationError
+    status: "False"
+    type: configReconcilerValid
+  errorSummary: 'configuration error: peer peer1 referencing non existing bfd profile
+    my-bfd-profile'
+  result: Invalid
+----
++
+Confirm that the output has the following values to identify the problem:
++
+* `result: Invalid` indicates that one or more configured resources are incompatible. The `errorSummary` field provides an aggregated description of the problem.
+* `reason: ConfigurationError` with `status: "False"` indicates that the reconciler failed to process the configuration. The `message` field describes the specific error.
+* In this example, the `BGPPeer` resource `peer1` references a `BFDProfile` named `my-bfd-profile` that does not exist. To resolve this error, either create the missing `BFDProfile` resource or update the `BGPPeer` to reference an existing `BFDProfile`.
++
+[NOTE]
+====
+The `ConfigurationState` resource does not report errors that arise when the configuration applied by the speaker to the `frr-k8s` daemon conflicts with other external configurations within that daemon.
+====
+
+. After correcting the configuration, verify that the status shows a valid configuration by running the following command:
++
+[source,terminal]
+----
+$ oc get configurationstates -n metallb-system -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.status.result}{"\n"}{end}'
+----
++
+A return value of `Valid` for all entries confirms that the MetalLB controller and speakers are operating with a valid configuration.

--- a/modules/nw-metallb-status-reporting.adoc
+++ b/modules/nw-metallb-status-reporting.adoc
@@ -28,6 +28,10 @@ MetalLB exposes status information for several key components, providing a compr
 | Shows the real-time operational state of the border gateway protocol (BGP) and bidirectional forwarding detection (BFD) sessions between a specific cluster node and a BGP peer, indicating if the channel is `Established` or `Up` based on routing stack feedback.
 | `oc get bgpsessionstatus -o wide`
 
+| *`ConfigurationState`*
+| Shows whether the MetalLB controller and speakers have successfully validated and applied the current configuration. MetalLB creates one resource for the controller and one for each speaker node. Reports errors when custom resources are incompatible.
+| `oc get configurationstates -n metallb-system`
+
 |===
 
 The MetalLB controller, typically deployed as `metallb-system/controller`, is responsible for managing IP address assignments and updating the `IPAddressPool` status. When a service requests a `LoadBalancer` IP, the controller allocates an IP from an appropriate `IPAddressPool` and updates the status fields to reflect the current number of assigned and available IP addresses.

--- a/networking/ingress_load_balancing/metallb/monitoring-metallb-status.adoc
+++ b/networking/ingress_load_balancing/metallb/monitoring-metallb-status.adoc
@@ -21,6 +21,9 @@ include::modules/nw-metallb-viewing-servicebgpstatus.adoc[leveloffset=+1]
 // Verify BGP session establishment
 include::modules/nw-metallb-verifying-bgp-session.adoc[leveloffset=+1]
 
+// Check configuration status
+include::modules/nw-metallb-checking-configuration-status.adoc[leveloffset=+1]
+
 [role="_additional-resources"]
 == Additional resources
 


### PR DESCRIPTION
[TELCODOCS-2613]: Docs and RN: [CNF-20333](https://redhat.atlassian.net/browse/CNF-20333) MetalLB ConfigurationStatus CRD

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.22
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:https://redhat.atlassian.net/browse/TELCODOCS-2613
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://109781--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ingress_load_balancing/metallb/monitoring-metallb-status.html#nw-metallb-checking-configuration-status_monitor-metallb-config-status
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
