### PR TITLE
OCPBUGS-45054: Updated worker/master reference with control-plane/com…

### DIFF
--- a/modules/agent-install-dns-none.adoc
+++ b/modules/agent-install-dns-none.adoc
@@ -106,12 +106,12 @@ api-int.ocp4.example.com.	IN	A	192.168.1.5 <2>
 ;
 *.apps.ocp4.example.com.	IN	A	192.168.1.5 <3>
 ;
-master0.ocp4.example.com.	IN	A	192.168.1.97 <4>
-master1.ocp4.example.com.	IN	A	192.168.1.98 <4>
-master2.ocp4.example.com.	IN	A	192.168.1.99 <4>
+control-plane0.ocp4.example.com.	IN	A	192.168.1.97 <4>
+control-plane1.ocp4.example.com.	IN	A	192.168.1.98 <4>
+control-plane2.ocp4.example.com.	IN	A	192.168.1.99 <4>
 ;
-worker0.ocp4.example.com.	IN	A	192.168.1.11 <5>
-worker1.ocp4.example.com.	IN	A	192.168.1.7 <5>
+compute0.ocp4.example.com.	IN	A	192.168.1.11 <5>
+compute1.ocp4.example.com.	IN	A	192.168.1.7 <5>
 ;
 ;EOF
 ----
@@ -150,12 +150,12 @@ $TTL 1W
 5.1.168.192.in-addr.arpa.	IN	PTR	api.ocp4.example.com. <1>
 5.1.168.192.in-addr.arpa.	IN	PTR	api-int.ocp4.example.com. <2>
 ;
-97.1.168.192.in-addr.arpa.	IN	PTR	master0.ocp4.example.com. <3>
-98.1.168.192.in-addr.arpa.	IN	PTR	master1.ocp4.example.com. <3>
-99.1.168.192.in-addr.arpa.	IN	PTR	master2.ocp4.example.com. <3>
+97.1.168.192.in-addr.arpa.	IN	PTR	control-plane0.ocp4.example.com. <3>
+98.1.168.192.in-addr.arpa.	IN	PTR	control-plane1.ocp4.example.com. <3>
+99.1.168.192.in-addr.arpa.	IN	PTR	control-plane2.ocp4.example.com. <3>
 ;
-11.1.168.192.in-addr.arpa.	IN	PTR	worker0.ocp4.example.com. <4>
-7.1.168.192.in-addr.arpa.	IN	PTR	worker1.ocp4.example.com. <4>
+11.1.168.192.in-addr.arpa.	IN	PTR	compute0.ocp4.example.com. <4>
+7.1.168.192.in-addr.arpa.	IN	PTR	compute1.ocp4.example.com. <4>
 ;
 ;EOF
 ----

--- a/modules/agent-install-load-balancing-none.adoc
+++ b/modules/agent-install-load-balancing-none.adoc
@@ -150,27 +150,27 @@ defaults
 listen api-server-6443 <1>
   bind *:6443
   mode tcp
-  server master0 master0.ocp4.example.com:6443 check inter 1s
-  server master1 master1.ocp4.example.com:6443 check inter 1s
-  server master2 master2.ocp4.example.com:6443 check inter 1s
+  server control-plane0 control-plane0.ocp4.example.com:6443 check inter 1s
+  server control-plane1 control-plane1.ocp4.example.com:6443 check inter 1s
+  server control-plane2 control-plane2.ocp4.example.com:6443 check inter 1s
 listen machine-config-server-22623 <2>
   bind *:22623
   mode tcp
-  server master0 master0.ocp4.example.com:22623 check inter 1s
-  server master1 master1.ocp4.example.com:22623 check inter 1s
-  server master2 master2.ocp4.example.com:22623 check inter 1s
+  server control-plane0 control-plane0.ocp4.example.com:22623 check inter 1s
+  server control-plane1 control-plane1.ocp4.example.com:22623 check inter 1s
+  server control-plane2 control-plane2.ocp4.example.com:22623 check inter 1s
 listen ingress-router-443 <3>
   bind *:443
   mode tcp
   balance source
-  server worker0 worker0.ocp4.example.com:443 check inter 1s
-  server worker1 worker1.ocp4.example.com:443 check inter 1s
+  server compute0 compute0.ocp4.example.com:443 check inter 1s
+  server compute1 compute1.ocp4.example.com:443 check inter 1s
 listen ingress-router-80 <4>
   bind *:80
   mode tcp
   balance source
-  server worker0 worker0.ocp4.example.com:80 check inter 1s
-  server worker1 worker1.ocp4.example.com:80 check inter 1s
+  server compute0 compute0.ocp4.example.com:80 check inter 1s
+  server compute1 compute1.ocp4.example.com:80 check inter 1s
 ----
 
 <1> Port `6443` handles the Kubernetes API traffic and points to the control plane machines.

--- a/modules/installation-approve-csrs.adoc
+++ b/modules/installation-approve-csrs.adoc
@@ -65,10 +65,10 @@ $ oc get nodes
 .Example output
 [source,terminal]
 ----
-NAME      STATUS    ROLES   AGE  VERSION
-master-0  Ready     master  63m  v1.34.2
-master-1  Ready     master  63m  v1.34.2
-master-2  Ready     master  64m  v1.34.2
+NAME             STATUS    ROLES   AGE  VERSION
+control-plane-0  Ready     master  63m  v1.34.2
+control-plane-1  Ready     master  63m  v1.34.2
+control-plane-2  Ready     master  64m  v1.34.2
 ----
 +
 The output lists all of the machines that you created.
@@ -202,26 +202,26 @@ ifndef::ibm-power[]
 .Example output
 [source,terminal]
 ----
-NAME      STATUS    ROLES   AGE  VERSION
-master-0  Ready     master  73m  v1.34.2
-master-1  Ready     master  73m  v1.34.2
-master-2  Ready     master  74m  v1.34.2
-worker-0  Ready     worker  11m  v1.34.2
-worker-1  Ready     worker  11m  v1.34.2
+NAME             STATUS    ROLES   AGE  VERSION
+control-plane-0  Ready     master  73m  v1.34.2
+control-plane-1  Ready     master  73m  v1.34.2
+control-plane-2  Ready     master  74m  v1.34.2
+compute-0        Ready     worker  11m  v1.34.2
+compute-1        Ready     worker  11m  v1.34.2
 ----
 endif::ibm-power[]
 ifdef::ibm-power[]
 .Example output
 [source,terminal]
 ----
-NAME               STATUS   ROLES                  AGE   VERSION   INTERNAL-IP      EXTERNAL-IP   OS-IMAGE                                                       KERNEL-VERSION                  CONTAINER-RUNTIME
-worker-0-ppc64le   Ready    worker                 42d   v1.34.2   192.168.200.21   <none>        Red Hat Enterprise Linux CoreOS 415.92.202309261919-0 (Plow)   5.14.0-284.34.1.el9_2.ppc64le   cri-o://1.34.2-3.rhaos4.15.gitb36169e.el9
-worker-1-ppc64le   Ready    worker                 42d   v1.34.2   192.168.200.20   <none>        Red Hat Enterprise Linux CoreOS 415.92.202309261919-0 (Plow)   5.14.0-284.34.1.el9_2.ppc64le   cri-o://1.34.2-3.rhaos4.15.gitb36169e.el9
-master-0-x86       Ready    control-plane,master   75d   v1.34.2   10.248.0.38      10.248.0.38   Red Hat Enterprise Linux CoreOS 415.92.202309261919-0 (Plow)   5.14.0-284.34.1.el9_2.x86_64    cri-o://1.34.2-3.rhaos4.15.gitb36169e.el9
-master-1-x86       Ready    control-plane,master   75d   v1.34.2   10.248.0.39      10.248.0.39   Red Hat Enterprise Linux CoreOS 415.92.202309261919-0 (Plow)   5.14.0-284.34.1.el9_2.x86_64    cri-o://1.34.2-3.rhaos4.15.gitb36169e.el9
-master-2-x86       Ready    control-plane,master   75d   v1.34.2   10.248.0.40      10.248.0.40   Red Hat Enterprise Linux CoreOS 415.92.202309261919-0 (Plow)   5.14.0-284.34.1.el9_2.x86_64    cri-o://1.34.2-3.rhaos4.15.gitb36169e.el9
-worker-0-x86       Ready    worker                 75d   v1.34.2   10.248.0.43      10.248.0.43   Red Hat Enterprise Linux CoreOS 415.92.202309261919-0 (Plow)   5.14.0-284.34.1.el9_2.x86_64    cri-o://1.34.2-3.rhaos4.15.gitb36169e.el9
-worker-1-x86       Ready    worker                 75d   v1.34.2   10.248.0.44      10.248.0.44   Red Hat Enterprise Linux CoreOS 415.92.202309261919-0 (Plow)   5.14.0-284.34.1.el9_2.x86_64    cri-o://1.34.2-3.rhaos4.15.gitb36169e.el9
+NAME                 STATUS    ROLES                  AGE   VERSION   INTERNAL-IP      EXTERNAL-IP   OS-IMAGE                                                       KERNEL-VERSION                  CONTAINER-RUNTIME
+compute-0-ppc64le     Ready    worker                 42d   v1.34.2   192.168.200.21   <none>        Red Hat Enterprise Linux CoreOS 415.92.202309261919-0 (Plow)   5.14.0-284.34.1.el9_2.ppc64le   cri-o://1.34.2-3.rhaos4.15.gitb36169e.el9
+compute-1-ppc64le     Ready    worker                 42d   v1.34.2   192.168.200.20   <none>        Red Hat Enterprise Linux CoreOS 415.92.202309261919-0 (Plow)   5.14.0-284.34.1.el9_2.ppc64le   cri-o://1.34.2-3.rhaos4.15.gitb36169e.el9
+control-plane-0-x86   Ready    control-plane,master   75d   v1.34.2   10.248.0.38      10.248.0.38   Red Hat Enterprise Linux CoreOS 415.92.202309261919-0 (Plow)   5.14.0-284.34.1.el9_2.x86_64    cri-o://1.34.2-3.rhaos4.15.gitb36169e.el9
+control-plane-1-x86   Ready    control-plane,master   75d   v1.34.2   10.248.0.39      10.248.0.39   Red Hat Enterprise Linux CoreOS 415.92.202309261919-0 (Plow)   5.14.0-284.34.1.el9_2.x86_64    cri-o://1.34.2-3.rhaos4.15.gitb36169e.el9
+control-plane-2-x86   Ready    control-plane,master   75d   v1.34.2   10.248.0.40      10.248.0.40   Red Hat Enterprise Linux CoreOS 415.92.202309261919-0 (Plow)   5.14.0-284.34.1.el9_2.x86_64    cri-o://1.34.2-3.rhaos4.15.gitb36169e.el9
+compute-0-x86         Ready    worker                 75d   v1.34.2   10.248.0.43      10.248.0.43   Red Hat Enterprise Linux CoreOS 415.92.202309261919-0 (Plow)   5.14.0-284.34.1.el9_2.x86_64    cri-o://1.34.2-3.rhaos4.15.gitb36169e.el9
+compute-1-x86         Ready    worker                 75d   v1.34.2   10.248.0.44      10.248.0.44   Red Hat Enterprise Linux CoreOS 415.92.202309261919-0 (Plow)   5.14.0-284.34.1.el9_2.x86_64    cri-o://1.34.2-3.rhaos4.15.gitb36169e.el9
 ----
 endif::ibm-power[]
 +

--- a/modules/installation-load-balancing-user-infra-example.adoc
+++ b/modules/installation-load-balancing-user-infra-example.adoc
@@ -76,16 +76,16 @@ listen api-server-6443
   option  log-health-checks
   balance roundrobin
   server bootstrap bootstrap.ocp4.example.com:6443 verify none check check-ssl inter 10s fall 2 rise 3 backup
-  server master0 master0.ocp4.example.com:6443 weight 1 verify none check check-ssl inter 10s fall 2 rise 3
-  server master1 master1.ocp4.example.com:6443 weight 1 verify none check check-ssl inter 10s fall 2 rise 3
-  server master2 master2.ocp4.example.com:6443 weight 1 verify none check check-ssl inter 10s fall 2 rise 3
+  server control-plane0 control-plane0.ocp4.example.com:6443 weight 1 verify none check check-ssl inter 10s fall 2 rise 3
+  server control-plane1 control-plane1.ocp4.example.com:6443 weight 1 verify none check check-ssl inter 10s fall 2 rise 3
+  server control-plane2 control-plane2.ocp4.example.com:6443 weight 1 verify none check check-ssl inter 10s fall 2 rise 3
 listen machine-config-server-22623
   bind *:22623
   mode tcp
   server bootstrap bootstrap.ocp4.example.com:22623 check inter 1s backup
-  server master0 master0.ocp4.example.com:22623 check inter 1s
-  server master1 master1.ocp4.example.com:22623 check inter 1s
-  server master2 master2.ocp4.example.com:22623 check inter 1s
+  server control-plane0 control-plane0.ocp4.example.com:22623 check inter 1s
+  server control-plane1 control-plane1.ocp4.example.com:22623 check inter 1s
+  server control-plane2 control-plane2.ocp4.example.com:22623 check inter 1s
 listen ingress-router-443
   bind *:443
   mode tcp


### PR DESCRIPTION
Version(s):
4.16+

Issue:
[OCPBUGS-45054](https://redhat.atlassian.net/browse/OCPBUGS-45054)

Link to docs preview:

* [Example DNS configuration for user-provisioned clusters](https://109791--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/upi/installing-restricted-networks-bare-metal.html#installation-dns-user-infra-example_installing-restricted-networks-bare-metal)
* [Approving the certificate signing requests for your machines](https://109791--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-user-infra.html#installation-approve-csrs_installing-gcp-user-infra)
* [Example load balancer configuration for user-provisioned clusters](https://109791--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_ibm_z/upi/installing-restricted-networks-ibm-z.html#installation-load-balancing-user-infra-example_installing-restricted-networks-ibm-z)
* [Platform "none" DNS requirements](https://109791--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_with_agent_based_installer/preparing-to-install-with-agent-based-installer#agent-install-dns-none_preparing-to-install-with-agent-based-installer)

SME review (Atharva Shinde): Done
QE review: 

