### PR TITLE
OSDOCS#18984: CQA: Updating the index.adoc page for the tutorials book

### DIFF
--- a/modules/tutorial-additional-learning.adoc
+++ b/modules/tutorial-additional-learning.adoc
@@ -1,0 +1,12 @@
+// Module included in the following assemblies:
+//
+// * tutorials/index.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="tutorial-additional-learning_{context}"]
+= Additional learning resources
+
+[role="_abstract"]
+Explore the additional learning resources that are available for {product-title}.
+
+To review the Red{nbsp}Hat Developer learning paths, training courses, and cheat sheets for {product-title}, see xref:../tutorials/additional-tutorials#additional-tutorials[Additional hands-on learning].

--- a/modules/tutorial-dev-tutorials.adoc
+++ b/modules/tutorial-dev-tutorials.adoc
@@ -1,0 +1,15 @@
+// Module included in the following assemblies:
+//
+// * tutorials/index.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="tutorial-dev-tutorials_{context}"]
+= Tutorials for developers
+
+[role="_abstract"]
+You can follow an end-to-end example of deploying an application on {product-title} either by using the {oc-first} or the web console.
+
+Choose one of the following tutorials:
+
+* xref:../tutorials/dev-app-cli#dev-app-cli[Tutorial: Deploying an application by using the CLI]
+* xref:../tutorials/dev-app-web-console#dev-app-web-console[Tutorial: Deploying an application by using the web console]

--- a/tutorials/index.adoc
+++ b/tutorials/index.adoc
@@ -6,25 +6,9 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-////
-[id="tutorials-developers_{context}"]
-== Tutorials for developers
-////
-
 [role="_abstract"]
-You can follow an end-to-end example of deploying an application on {product-title} either by using the {oc-first} or the web console.
+To learn how to use {product-title}, review the tutorials and other learning resources that are available.
 
-Choose one of the following tutorials:
+include::modules/tutorial-dev-tutorials.adoc[leveloffset=+1]
 
-* xref:../tutorials/dev-app-cli#dev-app-cli[Tutorial: Deploying an application by using the CLI]
-* xref:../tutorials/dev-app-web-console#dev-app-web-console[Tutorial: Deploying an application by using the web console]
-
-////
-[id="tutorials-admins_{context}"]
-== Tutorials for administrators
-////
-
-[id="additional-learning-resources_{context}"]
-== Additional learning resources
-
-To discover additional tutorials and hands-on learning resources for {product-title}, see xref:../tutorials/additional-tutorials#additional-tutorials[Additional hands-on learning].
+include::modules/tutorial-additional-learning.adoc[leveloffset=+1]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.20+

Issue:
https://redhat.atlassian.net/browse/OSDOCS-18984

Link to docs preview:

- https://109793--ocpdocs-pr.netlify.app/openshift-enterprise/latest/tutorials/index.html


QE review:
N/A CQA work
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->



- Since this is resolving an index.adoc navigation file, xrefs are allowed in the resulting reference modules. These reference modules must only ever be included in one location