### PR TITLE
OSDOCS-18930: adds mcp gateway release note

### DIFF
--- a/modules/ref-relnotes-1.3.1-z-stream.adoc
+++ b/modules/ref-relnotes-1.3.1-z-stream.adoc
@@ -1,0 +1,17 @@
+// Module used in the following assemblies
+//
+// *release_notes/release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="rhcl-relnotes-1.3.1-z-stream_{context}"]
+= {product-title} 1.3.1 bug fix and security update
+
+Issued: 18 March 2026
+
+[role="_abstract"]
+{product-title} release 1.3.1 is now available. A description is available in the link:https://access.redhat.com/errata/RHBA-2026:4903[RHBA-2026:4903] advisory. {product-title} uses the `stable` update channel to track and receive updates for the {product-title} Operator. You can manage how your updates are applied through your Operator Lifecycle Manager (OLM) subscription resource. For more information, see xref:../updating/updating-rhcl.adoc#proc-update-rhcl-with-web-console_updating-rhcl[Updating Red Hat Connectivity Link].
+
+[id="rhcl-relnotes-1.3.1-z-stream-bug-fixes_{context}"]
+== Bug fixes
+
+* Previously, the `wasm-shim` networking protcol incorrectly appended values to existing request headers instead of replacing them during the external authorization flow. This caused inconsistent behavior, leading to comma-separated header values that could disrupt upstream processing. With this release, the logic is updated to ensure that the headers provided in the `CheckResponse` object now correctly replace existing values. This fix restores predictable header management. (https://redhat.atlassian.net/browse/CONNLINK-867[CONNLINK-867])

--- a/modules/ref-relnotes-1.3.2-z-stream.adoc
+++ b/modules/ref-relnotes-1.3.2-z-stream.adoc
@@ -1,0 +1,17 @@
+// Module used in the following assemblies
+//
+// *release_notes/release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="rhcl-relnotes-1.3.2-z-stream_{context}"]
+= {product-title} 1.3.2 bug fix and security update
+
+Issued: 8 April 2026
+
+[role="_abstract"]
+{product-title} release 1.3.2 is now available. A description is available in the link:https://access.redhat.com/errata/RHBA-2026:7016[RHBA-2026:7016] advisory. {product-title} uses the `stable` update channel to track and receive updates for the {product-title} Operator. You can manage how your updates are applied through your Operator Lifecycle Manager (OLM) subscription resource. For more information, see xref:../updating/updating-rhcl.adoc#proc-update-rhcl-with-web-console_updating-rhcl[Updating Red Hat Connectivity Link].
+
+[id="rhcl-relnotes-1.3.2-z-stream-bug-fixes_{context}"]
+== Bug fixes
+
+* Previously, the `wasm-shim` component processed protection policies, such as authentication or rate-limiting rules, out of sequence with the actual data forwarding. This created a race condition where the `Gateway` started sending the request to the upstream server at the same time it was asking the policy if the request was allowed. As a result, the upstream server had already received and potentially acted upon the request before the connection could be cut when the request was denied. Meanwhile, the downstream client correctly received a `Denied` message. With this release, the logic is updated to ensure that the policy check is a blocking operation that must complete before any data is dispatched to the upstream backend. This fix synchronizes the state machine so that the connection to the upstream is only opened after the protection policy returns a definitive `Allow` decision. Denied requests are strictly terminated at the Gateway, ensuring the upstream server never sees unauthorized or throttled traffic. (https://redhat.atlassian.net/browse/CONNLINK-912[CONNLINK-912])

--- a/modules/ref-relnotes-1.3.3-z-stream.adoc
+++ b/modules/ref-relnotes-1.3.3-z-stream.adoc
@@ -1,0 +1,37 @@
+// Module used in the following assemblies
+//
+// *release_notes/release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="rhcl-relnotes-1.3.3-z-stream_{context}"]
+= {product-title} 1.3.3 new feature and enhancement update
+
+Issued: 30 April 2026
+
+[role="_abstract"]
+{product-title} release 1.3.3 is now available. {product-title} uses the `stable` update channel to track and receive updates for the {product-title} Operator. You can manage how your updates are applied through your Operator Lifecycle Manager (OLM) subscription resource. For more information, see xref:../updating/updating-rhcl.adoc#proc-update-rhcl-with-web-console_updating-rhcl[Updating Red Hat Connectivity Link].
+
+[id="rhcl-relnotes-1.3.3-z-stream-enhancements_{context}"]
+== New features and enhancements
+
+With this release, the Model Context Protocol (MCP) gateway is now available as a Technology Preview feature. This experimental feature is not intended for production use. Note the following scope of support on the Red Hat Customer Portal for this feature: link:https://access.redhat.com/support/offerings/techpreview[Technology Preview Features - Scope of Support].
+
+The MCP gateway aggregates in-cluster and remote MCP servers behind a single endpoint. The MCP gateway discovers every tool available to you on registered MCP servers. You can achieve the following goals by using the MCP gateway:
+
+* Focus on your agentic AI applications without building networking into your code by using the MCP gateway.
+* Standardize access and security governance of MCP servers by setting policies that span clusters.
+* Add and remove MCP servers without restarting your systems because the MCP gateway system state updates dynamically.
+* Curate your MCP server tools by creating virtual MCP servers.
+
+//For more information, see xref:../mcp_gateway_discover/mcp-gateway-introduction.adoc#mcp-gateway-introduction[Introduction to the MCP gateway]
+
+* With this release, elicitation support is available with the MCP gateway if your client supports them. MCP servers can implement interactive workflows by enabling user input requests. For more information, see the link:https://modelcontextprotocol.io/specification/2025-11-25/client/elicitation[Elicitation documentation (MCP specification)].
+
+[id="rhcl-relnotes-1.3.3-z-stream-known-issues_{context}"]
+== Known issues
+
+When the default setting `httpRouteManagement: Enabled` is set on an `MCPGatewayExtension` custom resource, the MCP controller component `buildGatewayHTTPRoute()` only creates a single rule for `/mcp` endpoints. The `/.well-known/oauth-protected-resource` rule is missing.
+
+The workaround is to set `httpRouteManagement: Disabled` in the `MCPGatewayExtension` CR in the `config/mcp-gateway/` with a manually managed `HTTPRoute` CR.
+
+//See xref:../mcp_gateway_install/mcp-gateway-install.adoc#proc-mcp-gateway-custom-route_mcp-gateway-install[Applying a customized HTTPRoute object] for instructions.

--- a/modules/ref-relnotes-z-streams.adoc
+++ b/modules/ref-relnotes-z-streams.adoc
@@ -12,19 +12,3 @@ Security, bug fix, and enhancement updates for {product-title} 1.3 are released 
 Red{nbsp}Hat Customer Portal users can enable update notifications in the account settings for Red{nbsp}Hat Subscription Management (RHSM). When notifications are enabled, you are notified through email whenever new updates relevant to your registered systems are released.
 
 This section is updated over time to provide notes on enhancements and bug fixes for future asynchronous releases of {product-title} 1.3. Versioned asynchronous releases, for example with the {product-title} 1.3.z, are detailed in the following subsections.
-
-{product-title} 1.3.1 bug fix and security update::
-
-Issued: 18 March 2026
-+
-{product-title} release 1.3.1 is now available. A description is available in the link:https://access.redhat.com/errata/RHBA-2026:4903[RHBA-2026:4903] advisory. {product-title} uses the `stable` update channel to track and receive updates for the {product-title} Operator. You can manage how your updates are applied through your Operator Lifecycle Manager (OLM) subscription resource. For more information, see xref:../updating/updating-rhcl.adoc#proc-update-rhcl-with-web-console_updating-rhcl[Updating Red Hat Connectivity Link]
-
-* Previously, the `wasm-shim` networking protcol incorrectly appended values to existing request headers instead of replacing them during the external authorization flow. This caused inconsistent behavior, leading to comma-separated header values that could disrupt upstream processing. With this release, the logic is updated to ensure that the headers provided in the `CheckResponse` object now correctly replace existing values. This fix restores predictable header management. (https://redhat.atlassian.net/browse/CONNLINK-867[CONNLINK-867])
-
-{product-title} 1.3.2 bug fix and security update::
-
-Issued: 8 April 2026
-+
-{product-title} release 1.3.2 is now available. A description is available in the link:https://access.redhat.com/errata/RHBA-2026:7016[RHBA-2026:7016] advisory. {product-title} uses the `stable` update channel to track and receive updates for the {product-title} Operator. You can manage how your updates are applied through your Operator Lifecycle Manager (OLM) subscription resource. For more information, see xref:../updating/updating-rhcl.adoc#proc-update-rhcl-with-web-console_updating-rhcl[Updating Red Hat Connectivity Link]
-
-* Previously, the `wasm-shim` component processed protection policies, such as authentication or rate-limiting rules, out of sequence with the actual data forwarding. This created a race condition where the `Gateway` started sending the request to the upstream server at the same time it was asking the policy if the request was allowed. As a result, the upstream server had already received and potentially acted upon the request before the connection could be cut when the request was denied. Meanwhile, the downstream client correctly received a `Denied` message. With this release, the logic is updated to ensure that the policy check is a blocking operation that must complete before any data is dispatched to the upstream backend. This fix synchronizes the state machine so that the connection to the upstream is only opened after the protection policy returns a definitive `Allow` decision. Denied requests are strictly terminated at the Gateway, ensuring the upstream server never sees unauthorized or throttled traffic. (https://redhat.atlassian.net/browse/CONNLINK-912[CONNLINK-912])

--- a/release_notes/rhcl-release-notes.adoc
+++ b/release_notes/rhcl-release-notes.adoc
@@ -13,4 +13,10 @@ include::modules/ref-relnotes-new-features.adoc[leveloffset=+2]
 
 include::modules/ref-relnotes-known-issues.adoc[leveloffset=+2]
 
-include::modules/ref-relnotes-z-streams.adoc[leveloffset=+2]
+include::modules/ref-relnotes-z-streams.adoc[leveloffset=+1]
+
+include::modules/ref-relnotes-1.3.3-z-stream.adoc[leveloffset=+2]
+
+include::modules/ref-relnotes-1.3.2-z-stream.adoc[leveloffset=+2]
+
+include::modules/ref-relnotes-1.3.1-z-stream.adoc[leveloffset=+2]


### PR DESCRIPTION
Version(s):
rhcl-docs-1.3

Issue:
[OSDOCS-18930](https://redhat.atlassian.net/browse/OSDOCS-18930)

Link to docs preview:
https://109796--ocpdocs-pr.netlify.app/rhcl/latest/release_notes/rhcl-release-notes.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Docs merge reviewer, the `mcp-gateway-docs-tp` is a Release branch, so content work is incremental. The entire branch will be integrated into the `rhcl-docs-main`, `rhcl-docs-1.3`, and `rhcl-docs-1.4` docs in late April, and therefore, not published anywhere now.

HELD for release date. Do not merge!

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
