### PR TITLE
OSDOCS-18942: adds observability to MCP gateway

### DIFF
--- a/_attributes/attributes.adoc
+++ b/_attributes/attributes.adoc
@@ -20,7 +20,9 @@
 :ocp-min-version: 4.19
 :oc-first: pass:quotes[OpenShift CLI (`oc`)]
 
-:ossm: OpenShift Service Mesh
+:OTELName: Red{nbsp}Hat build of OpenTelemetry
+
+:service-mesh: OpenShift Service Mesh
 :service-mesh-version: 3.2
 
 :cert-manager: cert-manager Operator for Red Hat OpenShift
@@ -32,3 +34,4 @@
 :TempoShortName: Distributed Tracing Platform
 :TempoOperator: Tempo Operator
 :TempoVersion: 2.3.1
+:DTShortName: distributed tracing

--- a/modules/proc-mcp-gateway-otel.adoc
+++ b/modules/proc-mcp-gateway-otel.adoc
@@ -1,0 +1,110 @@
+// Module included in the following assemblies:
+//
+// *mcp_gateway_config/mcp-gateway-observe.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="proc-mcp-gateway-otel_{context}"]
+= Enabling {OTELName} for the {mcpg}
+
+[role="_abstract"]
+The MCP gateway uses {OTELName} throughout all components to give you consistent logging, {DTShortName}, and metrics. By using observability, you can achieve the following goals:
+
+* Discover which component generated an error, such as Envoy, an MCP gateway component, or a backend MCP server.
+* Understand how requests flow through the system components.
+* See which tools were called and which MCP servers executed those tools.
+* Understand where to find relevant logs for each component.
+* Examine metrics about tool call patterns, success rates, and error rates.
+* Examine {DTShortName} across the request path.
+
+.Prerequisites
+
+* You installed {mcpg}.
+* You installed {prodname}.
+* You configured a `Gateway` object.
+* You are logged into a running {ocp} cluster with an `admin` role.
+* You installed {OTELName}.
+* You configured the {TempoName} for traces.
+* You installed the OpenShift Logging Operator (Loki).
+* You configured an S3-compatible persistent storage volume for Loki to store long-term MCP tool call logs.
+
+.Procedure
+
+. Use the following example YAML to create a collector in your MCP gateway deployment namespace:
++
+.Example OpenTelemetryCollector custom resource (CR)
+[source,yaml,subs="+quotes"]
+----
+apiVersion: opentelemetry.io/v1alpha1
+kind: OpenTelemetryCollector
+metadata:
+  name: _<mcp_otel_collector>_
+  namespace: _<mcp_gateway_system>_
+spec:
+  mode: deployment
+  config:
+    receivers:
+      otlp:
+        protocols:
+          http:
+            endpoint: 0.0.0.0:4318
+          grpc:
+            endpoint: 0.0.0.0:4317
+    exporters:
+      otlp/tempo:
+        endpoint: tempo-gateway-http.openshift-tracing.svc.cluster.local:4317
+        tls:
+          insecure: true
+      debug:
+        verbosity: basic
+    service:
+      pipelines:
+        traces:
+          receivers: [otlp]
+          exporters: [otlp/tempo, debug]
+        logs:
+          receivers: [otlp]
+          exporters: [debug]
+----
++
+* Replace the value of `metadata.name:` with the name you want to assign to this collector.
+* Replace the value of `metadata.namespace:` with the namespace of your MCP gateway deployment.
+* The `spec.config.exporters:` field value points to {DTShortName}.
+* The setting, `spec.config.exporters.otlp/tempo.tls.insecure: true` is for internal cluster communication without TLS.
+
+. Apply the following environment variables to your {ocp} cluster by running the following command:
++
+[source,terminal]
+----
+$ oc set env deployment/mcp-gateway \
+  OTEL_EXPORTER_OTLP_ENDPOINT="http://mcp-otel-collector-collector.mcp-gateway-system.svc.cluster.local:4318" \
+  OTEL_EXPORTER_OTLP_INSECURE="true" \
+  OTEL_SERVICE_NAME="mcp-gateway"
+----
++
+When {OTELName} creates a collector, the service name is `[metadata.name]-collector`.
+
+. Optional. If you want to send traces to one collector and logs to a different one, set the following additional environment variables:
++
+[source,terminal]
+----
+$ oc set env deployment/mcp-gateway \
+  OTEL_EXPORTER_OTLP_TRACES_ENDPOINT="http://trace-collector.tracing-namespace.svc:4317" \
+  OTEL_EXPORTER_OTLP_LOGS_ENDPOINT="http://log-collector.logging-namespace.svc:4317"
+----
++
+* Set `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` to override the endpoint for traces.
+* Set `OTEL_EXPORTER_OTLP_LOGS_ENDPOINT` to override the endpoint for logs.
+
+. If you are using {TempoName}, select your stack name as the data source in the OpenShift Web Console *Observe > Traces* dashboard. For example, `tempo-mcp`.
+
+. After you select the stack name, you can consult an attribute in your OpenShift Web Console *OpenShift Observe > Traces* dashboard to find where errors have occurred or to gather information for trend identification.
+
+* You can also filter by `service.name="mcp-gateway"`.
+
+. When using Loki, use the *Observe > Logs* view and toggle the *Structured* view to filter by `mcp.session.id`.
+
+. When using Loki, use the *Trace timeline* view, look for the `Log` icon next to `spans` to jump directly to the relevant logs.
+
+.Troubleshooting
+
+* If you do not see any traces, check if the `NetworkPolicy` CR in your namespace allows traffic from the MCP gateway to the {OTELName} collector service.

--- a/modules/ref-mcp-gateway-router-spans.adoc
+++ b/modules/ref-mcp-gateway-router-spans.adoc
@@ -1,0 +1,153 @@
+// Module included in the following assemblies:
+//
+// *mcp_gateway_config/mcp-gateway-observe.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="ref-mcp-gateway-router-spans_{context}"]
+= {mcpg} router spans for observability
+
+[role="_abstract"]
+When enabled, the MCP router, `ext_proc`, emits trace spans for every request and can export structured logs through {OTELName}.
+
+With traces, you can see one continuous timeline of traffic events across different pods and services. This can help you identify bottlenecks and conduct root-cause analysis.
+
+Spans show one part of the journey. The attributes attached to those spans give you the contextual metadata that you need to have searchable and meaningful traces. The attributes are simple `key: value` pairs attached to each span.
+
+The MCP gateway uses the following router spans:
+
+.MCP router spans
+[cols="1,1,2", options="header"]
+|===
+|Span |When |Description
+
+|`mcp-router.process`
+|Every `ext_proc` stream
+|Root span. Starts when request headers arrive, ends after response headers are processed.
+
+|`mcp-router.route-decision`
+|The request body is parsed
+|Routing decision: `tool-call` versus pass-through to broker.
+
+|`mcp-router.broker-passthrough`
+|Non-`tool-call` requests
+|Pass-through to broker: `initialize`, `tools/list`, `notifications`. No child spans means the broker is not instrumented.
+
+|`mcp-router.tool-call`
+|`tools/call` requests
+|Full tool call handling including session and server resolution.
+
+|`mcp-router.broker.get-server-info`
+|Inside `tool-call`
+|Call out to broker to resolve which backend server owns the tool.
+
+|`mcp-router.session-cache.get`
+|Inside `tool-call`
+|Call out to session cache to look up an existing backend session.
+
+|`mcp-router.session-init`
+|Cache miss during `tool-call`
+|Hairpin `initialize` request through the gateway to the backend MCP server.
+
+|`mcp-router.session-cache.store`
+|After `session-init`
+|Call out to session cache to store the new backend session.
+|===
+
+The attributes in the following tables use link:https://opentelemetry.io/docs/specs/semconv/gen-ai/mcp/#server[OpenTelemetry MCP Semantic Conventions].
+
+.MCP router root span, `mcp-router.process`, attributes
+[cols="1,1,2", options="header"]
+|===
+|Attribute |Source |Description
+
+|`http.method`
+|`:method` header
+|HTTP method, `POST`
+
+|`http.path`
+|`:path` header
+|Request path, `/mcp`
+
+|`http.request_id`
+|`x-request-id` header
+|Envoy request ID
+
+|`mcp.method.name`
+|JSON-RPC `method` field
+|MCP method, `initialize`, `tools/call`, `tools/list`, and so on
+
+|`gen_ai.tool.name`
+|JSON-RPC `params.name`
+|Tool name, only for `tools/call`
+
+|`jsonrpc.request.id`
+|JSON-RPC `id` field
+|JSON-RPC request ID
+
+|`jsonrpc.protocol.version`
+|JSON-RPC `jsonrpc` field
+|Always "2.0"
+
+|`gen_ai.operation.name`
+|JSON-RPC `method` field
+|Same as `mcp.method.name`
+
+|`mcp.session.id`
+|`mcp-session-id` header
+|Gateway session ID
+
+|`client.address`
+|`x-forwarded-for` header
+|Client IP address
+
+|`http.status_code`
+|`:status` response header
+|Response status code
+|===
+
+.MCP route decision span, `mcp-router.route-decision`, attributes
+[cols="1,2", options="header"]
+|===
+|Attribute |Description
+
+|`mcp.method.name`
+|MCP method
+
+|`mcp.route`
+|Routing decision: `tool-call`, `broker`, or `elicitation-response`
+|===
+
+.MCP tool call span, `mcp-router.tool-call`, attributes
+[cols="1,2", options="header"]
+|===
+|Attribute |Description
+
+|`gen_ai.tool.name`
+|Tool name from the request
+
+|`mcp.session.id`
+|Gateway session ID
+
+|`mcp.server`
+|Resolved backend server name
+
+|`mcp.server.hostname`
+|Resolved backend server hostname
+|===
+
+.MCP error attributes
+[cols="1,2", options="header"]
+|===
+|Attribute |Description
+
+|`error.type`
+|Error classification, such as `tool_not_found`, `missing_tool_name`, `invalid_session`, `session_cache_error`, `session_init_error`, `marshal_error`, `path_parse_error`
+
+|`error_source`
+|Component that generated the error, such as`ext-proc`
+
+|`http.status_code`
+|HTTP status code returned
+|===
+
+When there is an error, spans include these attributes.

--- a/observe_troubleshoot/mcp-gateway-observe.adoc
+++ b/observe_troubleshoot/mcp-gateway-observe.adoc
@@ -5,4 +5,16 @@ include::_attributes/attributes.adoc[]
 :context: mcp-gateway-observe
 
 [role="_abstract"]
-FPO assembly
+You can use observability in {mcpg} to debug things such as silent failures, track destructive annotations, track latencies, and make an audit trail.
+
+include::modules/proc-mcp-gateway-otel.adoc[leveloffset=+1]
+
+include::modules/ref-mcp-gateway-router-spans.adoc[leveloffset=+2]
+
+[id="additional-resources_mcp-gateway-observe"]
+[role="_additional-resources"]
+== Additional resources
+
+* link:https://docs.redhat.com/en/documentation/red_hat_build_of_opentelemetry/3.9/html-single/configuring_the_collector/index[Chapter 1. Configuring the Collector (OpenTelemetry documentation)]
+
+* link:https://modelcontextprotocol.io/docs/tools/inspector[MCP Inspector (Model Context Protocol developer tools documentation)]


### PR DESCRIPTION
Version(s):
mcp-gateway-docs-tp

Issue:
[OSDOCS-18942](https://redhat.atlassian.net/browse/OSDOCS-18942)

Link to docs preview:
https://109810--ocpdocs-pr.netlify.app/rhcl/latest/observe_troubleshoot/mcp-gateway-observe.html

QE review:
- [x] SME approved this change.
- [x] QE approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Docs merge reviewer, the `mcp-gateway-docs-tp` is a Release branch, so content work is incremental. The entire branch will be integrated into the `rhcl-docs-main`, `rhcl-docs-1.3`, and `rhcl-docs-1.4` docs in late April, and therefore, not published anywhere now.
