### PR TITLE
[enterprise-4.19] OSDOCS-19033: kueue.x-k8s.io/queue-name referring to non-existent queue

### DIFF
--- a/ai_workloads/kueue/release-notes.adoc
+++ b/ai_workloads/kueue/release-notes.adoc
@@ -10,6 +10,12 @@ toc::[]
 
 include::modules/kueue-compatible-environments.adoc[leveloffset=+1]
 
+include::modules/kueue-release-notes-1.3.1.adoc[leveloffset=+1]
+
+include::modules/kueue-release-notes-1.3.adoc[leveloffset=+1]
+
+include::modules/kueue-release-notes-1.2.adoc[leveloffset=+1]
+
 include::modules/kueue-release-notes-1.1.adoc[leveloffset=+1]
 
 include::modules/kueue-release-notes-1.0.1.adoc[leveloffset=+1]

--- a/modules/kueue-release-notes-1.3.1.adoc
+++ b/modules/kueue-release-notes-1.3.1.adoc
@@ -1,0 +1,18 @@
+// Module included in the following assemblies:
+//
+// * ai_workloads/kueue/release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="release-notes-1.3.1_{context}"]
+= Release notes for {kueue-name} version 1.3.1
+
+[role="_abstract"]
+{kueue-name} version 1.3.1 is a generally available release that is supported on {product-title} versions 4.18 and later. {kueue-name} version 1.3 uses link:https://kueue.sigs.k8s.io/docs/overview/[Kueue] version 0.16.5.
+
+[id="release-notes-1.3.1-fixed-issues_{context}"]
+== Fixed issues
+
+kueue.x-k8s.io/queue-name refers to a non-existent queue::
+Fixed a bug where referencing a non-existent `LocalQueue via kueue.x-k8s.io/queue-name` could cause a running pod to be terminated and permanently stuck with unremovable scheduling gates.
++
+(link:https://redhat.atlassian.net/browse/OCPBUGS-78789[OCPBUGS-78789])


### PR DESCRIPTION
Manual cherry-pick of https://github.com/openshift/openshift-docs/pull/109782