### PR TITLE
DOCPLAN-178: CQA updating docs

### DIFF
--- a/modules/virt-about-control-plane-only-updates.adoc
+++ b/modules/virt-about-control-plane-only-updates.adoc
@@ -7,15 +7,15 @@
 = Control Plane Only updates
 
 [role="_abstract"]
-A Control Plane Only update allows you to update between Extended Update Support (EUS) versions of {product-title} while preventing virtual machine workloads from updating during the intermediate upgrade.
+You can use a Control Plane Only update to move between Extended Update Support (EUS) versions of {product-title}. This prevents virtual machine workloads from updating during the intermediate upgrade.
 
-Every even-numbered minor version of {product-title} is an Extended Update Support (EUS) version. However, Kubernetes requires minor version updates to occur sequentially. As a result, you cannot update directly from one EUS version to the next.
+Every even-numbered minor version of {product-title} is an Extended Update Support (EUS) version. Kubernetes requires minor version updates to occur in sequence. You cannot update directly from one EUS version to the next.
 
-To move between EUS versions, you must first update {VirtProductName} to the latest z-stream release of the next odd-numbered minor version. After the cluster updates to the target EUS version of {product-title}, the corresponding update for {VirtProductName} becomes available. You can then update {VirtProductName} to the target EUS version.
+To move between EUS versions, first update {VirtProductName} to the latest z-stream release of the next odd-numbered minor version. Then update the cluster to the target EUS version of {product-title}. After the cluster update, update {VirtProductName} to the target EUS version.
 
 [NOTE]
 ====
-You can directly update {VirtProductName} to the latest z-stream release of your current minor version without applying each intermediate z-stream update.
+You can update {VirtProductName} directly to the latest z-stream release of your current minor version without applying each intermediate z-stream update.
 ====
 
 For more information about EUS versions, see the link:https://access.redhat.com/support/policy/updates/openshift[{product-title} Life Cycle Policy].

--- a/modules/virt-about-upgrading-virt.adoc
+++ b/modules/virt-about-upgrading-virt.adoc
@@ -8,59 +8,58 @@
 = About updating {VirtProductName}
 
 [role="_abstract"]
-When you install {VirtProductName}, you select an update channel and an approval strategy. The update channel determines the version that {VirtProductName} is updated to. The approval strategy setting determines whether updates occur automatically or require manual approval. Both settings can impact supportability.
+When you install {VirtProductName}, you select an update channel and an approval strategy. The update channel determines the version of {VirtProductName} that you use. The approval strategy determines whether updates occur automatically or require manual approval. Both settings affect supportability.
 
 [id="recommended-settings_{context}"]
 == Recommended settings
 
-To maintain a supportable environment, use the following settings:
+To keep a supportable environment, use the following settings:
 
 * Update channel: *stable*
 * Approval strategy: *Automatic*
 
-The *stable* release channel and the *Automatic* approval strategy are recommended for most {VirtProductName} installations. Use other settings only if you understand the risks.
+Most {VirtProductName} installations use the *stable* release channel and the *Automatic* approval strategy. Use other settings only if you understand the risks.
 
-With these settings, the update process automatically starts when a new version of the Operator is available in the *stable* channel. This ensures that your {VirtProductName} and {product-title} versions remain compatible, and that your version of {VirtProductName} is suitable for production environments.
+With these settings, the update process starts automatically when a new Operator version is available in the *stable* channel. This keeps {VirtProductName} and {product-title} versions compatible and ensures that {VirtProductName} is suitable for production environments.
 
 [NOTE]
 ====
-Each minor version of {VirtProductName} is supported only if you run the corresponding {product-title} version. For example, you must run {VirtProductName} {VirtVersion} on {product-title} {VirtVersion}.
+Each minor version of {VirtProductName} is supported only with the corresponding {product-title} version. For example, you must run {VirtProductName} {VirtVersion} on {product-title} {VirtVersion}.
 ====
 
 [id="what-to-expect_{context}"]
 == What to expect
 
-You can anticipate update behavior in {VirtProductName}, including duration, automation, and data preservation.
+You can expect consistent update behavior in {VirtProductName}, including duration, automation, and data preservation.
 
-* The amount of time an update takes to complete depends on your network
-connection. Most automatic updates complete within fifteen minutes.
+* The time required to complete an update depends on your network connection. Most automatic updates complete within fifteen minutes.
 
 * Updating {VirtProductName} does not interrupt network connections.
 
-* Data volumes and their associated persistent volume claims are preserved during an update.
+* An update preserves data volumes and their associated persistent volume claims.
 
 ifndef::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
 [IMPORTANT]
 ====
-If you have virtual machines running that use hostpath provisioner storage, they cannot be live migrated and might block an {product-title} cluster update.
+If virtual machines use hostpath provisioner storage, they cannot be live migrated and might block an {product-title} cluster update.
 
-As a workaround, you can reconfigure the virtual machines so that they can be powered off automatically during a cluster update. Set the `evictionStrategy` field to `None` and the `runStrategy` field to `Always`.
+As a workaround, reconfigure the virtual machines so they can power off automatically during a cluster update. Set the `evictionStrategy` field to `None` and the `runStrategy` field to `Always`.
 ====
 endif::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
 ifdef::openshift-rosa,openshift-rosa-hcp[]
 [IMPORTANT]
 ====
-If you have virtual machines running that use AWS Elastic Block Store (EBS) storage, they cannot be live migrated and might block an {product-title} cluster update.
+If virtual machines use AWS Elastic Block Store (EBS) storage, they cannot be live migrated and might block an {product-title} cluster update.
 
-As a workaround, you can reconfigure the virtual machines so that they can be powered off automatically during a cluster update. Set the `evictionStrategy` field to `None` and the `runStrategy` field to `Always`.
+As a workaround, reconfigure the virtual machines so they can power off automatically during a cluster update. Set the `evictionStrategy` field to `None` and the `runStrategy` field to `Always`.
 ====
 endif::openshift-rosa,openshift-rosa-hcp[]
 
 [id="how-updates-work_{context}"]
 == How updates work
 
-Learn how the {VirtProductName} Operator is updated through the Operator Lifecycle Manager (OLM) and how update channels and approval strategies affect upgrade behavior.
+Learn how Operator Lifecycle Manager (OLM) updates the {VirtProductName} Operator and how update channels and approval strategies affect upgrade behavior.
 
-* Operator Lifecycle Manager (OLM) manages the lifecycle of the {VirtProductName} Operator. The Marketplace Operator, which is deployed during {product-title} installation, makes external Operators available to your cluster.
+* Operator Lifecycle Manager (OLM) manages the lifecycle of the {VirtProductName} Operator. The Marketplace Operator, deployed during {product-title} installation, makes external Operators available to your cluster.
 
 * OLM provides z-stream and minor version updates for {VirtProductName}. Minor version updates become available when you update {product-title} to the next minor version. You cannot update {VirtProductName} to the next minor version without first updating {product-title}.

--- a/modules/virt-early-access-releases.adoc
+++ b/modules/virt-early-access-releases.adoc
@@ -7,15 +7,15 @@
 = Early access releases
 
 [role="_abstract"]
-You can gain access to builds in development by subscribing to the *candidate* update channel for your version of {VirtProductName}.
+You can access development builds by subscribing to the *candidate* update channel for your version of {VirtProductName}.
 
-These releases have not been fully tested by Red{nbsp}Hat and are not supported, but you can use them on non-production clusters to test capabilities and bug fixes being developed for that version.
+These releases are not fully tested by Red{nbsp}Hat and are not supported. Use them only on non-production clusters to test new capabilities and bug fixes.
 
-The *stable* channel, which matches the underlying {product-title} version and is fully tested, is suitable for production systems. You can switch between the *stable* and *candidate* channels in OperatorHub. However, updating from a *candidate* channel release to a *stable* channel release is not tested by Red{nbsp}Hat.
+The *stable* channel matches the underlying {product-title} version and is fully tested. It is suitable for production systems. You can switch between the *stable* and *candidate* channels in OperatorHub. Updating from a *candidate* release to a *stable* release is not tested by Red{nbsp}Hat.
 
-Some candidate releases are promoted to the *stable* channel. However, releases present only in *candidate* channels might not contain all features that will be made generally available (GA), and some features in candidate builds might be removed before GA. Additionally, candidate releases might not offer update paths to later GA releases.
+Red{nbsp}Hat promotes some candidate releases to the *stable* channel. Other candidate releases might not include all GA features. Red{nbsp}Hat might remove some features from candidate builds before GA. Candidate releases might not offer update paths to later GA releases.
 
 [IMPORTANT]
 ====
-The candidate channel is only suitable for testing purposes where destroying and recreating a cluster is acceptable.
+Use the candidate channel only for testing where you can delete and re-create the cluster.
 ====

--- a/modules/virt-manual-approval-strategy.adoc
+++ b/modules/virt-manual-approval-strategy.adoc
@@ -7,6 +7,6 @@
 = Manual approval strategy
 
 [role="_abstract"]
-If you use the *Manual* approval strategy, you must manually approve every pending update. If {product-title} and {VirtProductName} updates are out of sync, your cluster becomes unsupported.
+If you use the *Manual* approval strategy, you must approve every pending update. If {product-title} and {VirtProductName} updates are out of sync, your cluster becomes unsupported.
 
-To avoid risking the supportability and functionality of your cluster, use the *Automatic* approval strategy. If you must use the *Manual* approval strategy, maintain a supportable cluster by approving pending Operator updates as soon as they become available.
+To avoid risk to cluster supportability and functionality, use the *Automatic* approval strategy. If you must use the *Manual* approval strategy, approve pending Operator updates as soon as they become available.

--- a/modules/virt-preventing-workload-updates-during-control-plane-only-update.adoc
+++ b/modules/virt-preventing-workload-updates-during-control-plane-only-update.adoc
@@ -7,27 +7,27 @@
 = Preventing workload updates during a Control Plane Only update
 
 [role="_abstract"]
-When you update from one Extended Update Support (EUS) version to the next, you must temporarily disable automatic workload updates to prevent {VirtProductName} from migrating or evicting virtual machines during the upgrade process.
+When updating between Extended Update Support (EUS) versions, temporarily disable automatic workload updates. This prevents {VirtProductName} from migrating or evicting virtual machines during the upgrade.
 
 [IMPORTANT]
 ====
-In {product-title} 4.16, the underlying {op-system-first} upgraded to version 9.4 of {op-system-base-full}. To operate correctly, all `virt-launcher` pods in the cluster must use the same version of {op-system-base}.
+In {product-title} 4.16, the underlying {op-system-first} upgraded to version 9.4 of {op-system-base-full}. All `virt-launcher` pods in the cluster must use the same {op-system-base} version.
 
-After upgrading to {product-title} 4.16 from an earlier version, re-enable workload updates in {VirtProductName} to allow `virt-launcher` pods to update. Before upgrading to the next {product-title} version, verify that all VMIs use up-to-date workloads:
+After upgrading to {product-title} 4.16, re-enable workload updates in {VirtProductName}. This allows `virt-launcher` pods to update. Before upgrading to the next {product-title} version, verify that all VMIs use up-to-date workloads:
 
 [source,terminal]
 ----
 $ oc get kv kubevirt-kubevirt-hyperconverged -o json -n openshift-cnv | jq .status.outdatedVirtualMachineInstanceWorkloads
 ----
 
-If the previous command returns a value larger than `0`, list all VMIs with outdated `virt-launcher` pods and start live migration to update them:
+If the command returns a value greater than `0`, list VMIs with outdated `virt-launcher` pods and start live migration:
 
 [source,terminal]
 ----
 $ oc get vmi -l kubevirt.io/outdatedLauncherImage --all-namespaces
 ----
 
-For the list of supported {product-title} releases and the {op-system-base} versions they use, see link:https://access.redhat.com/articles/6907891[{op-system-base} Versions Utilized by {op-system} and {product-title}].
+For supported {product-title} releases and their {op-system-base} versions, see link:https://access.redhat.com/articles/6907891[{op-system-base} Versions Utilized by {op-system} and {product-title}].
 ====
 
 .Prerequisites
@@ -36,11 +36,11 @@ For the list of supported {product-title} releases and the {op-system-base} vers
 * You are running an EUS version of {product-title} and plan to update to the next EUS version.
 * You have not yet updated to the intermediate odd-numbered minor version.
 * You paused the worker nodes' machine config pools as described in the {product-title} documentation.
-* It is recommended that you use the default *Automatic* approval strategy. If you use the *Manual* approval strategy, you must approve all pending updates in the web console. For more details, see "Manually approving a pending Operator update".
+* Use the default *Automatic* approval strategy. If you use the *Manual* approval strategy, you must approve all pending updates in the web console. For more details, see "Manually approving a pending Operator update".
 
 .Procedure
 
-. Run the following command and record the `workloadUpdateMethods` configuration:
+. Run the following command and record the `workloadUpdateMethods` value:
 +
 [source,terminal,subs="attributes+"]
 ----
@@ -56,14 +56,14 @@ $ oc patch hyperconverged kubevirt-hyperconverged -n {CNVNamespace} \
   --type json -p '[{"op":"replace","path":"/spec/workloadUpdateStrategy/workloadUpdateMethods", "value":[]}]'
 ----
 
-. Ensure that the `HyperConverged` Operator is `Upgradeable` before continuing:
+. Ensure that the `HyperConverged` Operator is `Upgradeable`:
 +
 [source,terminal,subs="attributes+"]
 ----
 $ oc get hyperconverged kubevirt-hyperconverged -n {CNVNamespace} -o json | jq ".status.conditions"
 ----
 
-. Manually update your cluster from the source EUS version to the next minor version of {product-title}:
+. Update your cluster from the source EUS version to the next minor version of {product-title}:
 +
 [source,terminal]
 ----
@@ -113,7 +113,7 @@ $ oc get clusterversion
 ----
 +
 . Update {VirtProductName} to the target EUS version.
-
++
 * With the default *Automatic* approval strategy, {VirtProductName} updates automatically.
 * If you use the *Manual* approval strategy, approve the pending update in the web console.
 

--- a/modules/virt-update-removing-unused.adoc
+++ b/modules/virt-update-removing-unused.adoc
@@ -7,4 +7,4 @@
 = Remove unused Operators and resources
 
 [role="_abstract"]
-As a cluster administrator who is updating {VirtProductName} from a previous version to version {VirtVersion}, you can remove certain Operators and resources that are no longer required. This can help you to reclaim space and resources on your cluster.
+When updating {VirtProductName} to version {VirtVersion}, you can remove certain Operators and resources that are no longer required. This helps reclaim space and resources on your cluster.


### PR DESCRIPTION
Version(s):
4.20+

Issue:
https://redhat.atlassian.net/browse/DOCPLAN-178

Link to docs preview:

- https://109818--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/updating/upgrading-virt.html#virt-manual-approval-strategy_upgrading-virt
- https://109818--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/updating/upgrading-virt.html#virt-early-access-releases_upgrading-virt
- https://109818--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/updating/upgrading-virt.html#virt-about-upgrading-virt_upgrading-virt
- https://109818--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/updating/upgrading-virt.html#virt-update-removing-unused_upgrading-virt
- https://109818--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/updating/upgrading-virt.html#virt-about-control-plane-only-updates_upgrading-virt

QE review:
NA

Additional information:

This is a related (but dupe) work item
* https://redhat.atlassian.net/browse/DOCPLAN-179
