### PR TITLE
OSDOCS#18972: Update the z-stream RNs for 4.12.87

### DIFF
--- a/modules/zstream-4-12-87-about.adoc
+++ b/modules/zstream-4-12-87-about.adoc
@@ -1,0 +1,24 @@
+// Module included in the following assembly:
+//
+// * release_notes/ocp-4-12-release-notes.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="zstream-4-12-87-about_{context}"]
+= RHSA-2026:6493 - {product-title} {product-version}.87 bug fix and security update
+
+[role="_abstract"]
+Issued: 9 April 2026
+
+{product-title} release {product-version}.87, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2026:6493[RHSA-2026:6493] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2026:6491[RHBA-2026:6491] advisory.
+
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+
+You can view the container images in this release by running the following command:
+
+
+[source,terminal]
+----
+$ oc adm release info 4.12.87 --pullspecs
+----

--- a/modules/zstream-4-12-87-fixed-issues.adoc
+++ b/modules/zstream-4-12-87-fixed-issues.adoc
@@ -1,0 +1,12 @@
+// Module included in the following assembly:
+//
+// * release_notes/ocp-4-12-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-12-87-fixed-issues_{context}"]
+= Fixed issues
+
+[role="_abstract"]
+The following issue is fixed with this release:
+
+* Before this update, a service account creation issue in earlier {product-title} versions resulted in provider inconsistency. As a consequence, service account creation errors caused inconsistent results with the provider, and affected service account key creation. With this release, the service account creation issue is resolved by upgrading Terraform and the provider in the installation program for {product-title} 4.12 and later. As a result, there are no inconsistent results in the provider, and the {product-title} cluster installation in {gcp-first} is improved. (link:https://issues.redhat.com/browse/OCPBUGS-78352[OCPBUGS-78352])

--- a/modules/zstream-4-12-87-updating.adoc
+++ b/modules/zstream-4-12-87-updating.adoc
@@ -1,0 +1,10 @@
+// Module included in the following assembly:
+//
+// * release_notes/ocp-4-12-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-12-87-updating_{context}"]
+= Updating
+
+[role="_abstract"]
+To update an existing {product-title} 4.12 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].

--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -5375,3 +5375,12 @@ include::modules/zstream-4-12-86-fixed-issues.adoc[leveloffset=+3]
 
 // 4.12.86 updating
 include::modules/zstream-4-12-86-updating.adoc[leveloffset=+3]
+
+// 4.12.87 about
+include::modules/zstream-4-12-87-about.adoc[leveloffset=+2]
+
+// 4.12.87 fixes
+include::modules/zstream-4-12-87-fixed-issues.adoc[leveloffset=+3]
+
+// 4.12.87 updating
+include::modules/zstream-4-12-87-updating.adoc[leveloffset=+3]


### PR DESCRIPTION
Version(s):
4.12

Issue:
[OSDOCS-18972](https://redhat.atlassian.net/browse/OSDOCS-18972)

Link to docs preview:
[4.12.87](https://109833--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-12-release-notes.html#zstream-4-12-87-about_release-notes)

QE review:
- [ ] QE has approved this change.
N/A for z-stream RNs

Additional information:
Shipment [MR](https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/457#e7a40c34fd66c644c2736c495b3e5515c429606b)
ART [Dashboard](https://art-dash.engineering.redhat.com/dashboard/release/openshift-4.12)