### PR TITLE
RHDEVDOCS-7100: CQA 2.0 fixes for Configuring a cluster-scoped Argo Rollouts instance to manage rollout resources

### DIFF
--- a/argo_rollouts/using-cluster-scoped-rollouts-instance-to-manage-rollouts-resources.adoc
+++ b/argo_rollouts/using-cluster-scoped-rollouts-instance-to-manage-rollouts-resources.adoc
@@ -7,15 +7,15 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 [role="_abstract"]
-By default, Argo Rollouts supports the cluster-scoped mode of installation for Argo Rollouts custom resources (CRs). This mode of installation uses the `CLUSTER_SCOPED_ARGO_ROLLOUTS_NAMESPACES` environment variable to specify a list of namespaces that can be used to manage the rollout resources.
+Cluster-scoped installation mode allows a single Argo Rollouts controller instance to manage rollout resources across multiple namespaces. This reduces resource consumption compared to deploying separate namespace-scoped controllers in each namespace. You can control which namespaces a cluster-scoped RolloutManager instance manages by setting the `CLUSTER_SCOPED_ARGO_ROLLOUTS_NAMESPACES` environment variable in the {gitops-title} Operator Subscription to a comma-separated list of namespace names. 
 
-To manage Argo Rollouts resources, after you install the {gitops-title} Operator on the cluster, you can create and configure a `RolloutManager` custom resource (CR) instance in the namespace of your choice. You can then update the existing `Subscription` object for the {gitops-title} Operator and add user-defined namespaces to the `CLUSTER_SCOPED_ARGO_ROLLOUTS_NAMESPACES` environment variable in the `spec` section of the Argo CD instance.
+To configure a cluster-scoped Argo Rollouts instance, you must first install the {gitops-title} Operator, create a `RolloutManager` custom resource (CR), and then update the Operator Subscription to specify the namespaces.
 
 [id="prerequisites_{context}"]
 == Prerequisites
 * You have logged in to the {OCP} cluster as an administrator.
 * You have installed the {gitops-title} Operator on your {OCP} cluster.
-* You have created a `RolloutManager` custom resource.
+* You have created a `RolloutManager` custom resource in the namespace where you want to run the Argo Rollouts controller.
 
 // Configuring a cluster-scoped Argo Rollouts instance to manage rollout resources 
 include::modules/gitops-configuring-a-cluster-scoped-argo-rollouts-instance-to-manage-rollouts-resources.adoc[leveloffset=+1]

--- a/modules/gitops-configuring-a-cluster-scoped-argo-rollouts-instance-to-manage-rollouts-resources.adoc
+++ b/modules/gitops-configuring-a-cluster-scoped-argo-rollouts-instance-to-manage-rollouts-resources.adoc
@@ -7,12 +7,7 @@
 = Configuring a cluster-scoped Argo Rollouts instance to manage rollout resources
 
 [role="_abstract"]
-To configure a cluster-scoped Argo Rollouts instance for managing rollout resources, add the `CLUSTER_SCOPED_ARGO_ROLLOUTS_NAMESPACES` environment variable in the `Subscription` resource. This variable contains a list of user-defined namespaces which can be configured for a cluster-scoped Argo Rollouts installation. If the `CLUSTER_SCOPED_ARGO_ROLLOUTS_NAMESPACES` environment variable is empty, you can create cluster-scoped Argo Rollouts installation in the `openshift-gitops` namespace.
-
-[NOTE]
-====
-You can only create a cluster-scoped Argo Rollouts instance if the `NAMESPACE_SCOPED_ARGO_ROLLOUTS` variable is set to `false`. By default, if the `NAMESPACE_SCOPED_ARGO_ROLLOUTS` variable is not defined, it is set to `false`.
-====
+To configure which namespaces a cluster-scoped Argo Rollouts instance manages, set the `CLUSTER_SCOPED_ARGO_ROLLOUTS_NAMESPACES` environment variable in the {gitops-title} Operator Subscription to a comma-separated list of namespace names. If this variable is not set, the RolloutManager manages rollouts only in the namespace where it is deployed.
 
 .Procedure
 
@@ -20,7 +15,7 @@ You can only create a cluster-scoped Argo Rollouts instance if the `NAMESPACE_SC
 
 . Click the *Actions* list and then click *Edit Subscription*.
 
-. On the *openshift-gitops-operator* Subscription details page, under the *YAML* tab, edit the `Subscription` YAML file by adding the namespace of the Argo CD instance to the `CLUSTER_SCOPED_ARGO_ROLLOUTS_NAMESPACES` environment variable in the `spec` section:
+. On the *openshift-gitops-operator* Subscription details page, under the *YAML* tab, edit the `Subscription` YAML file by setting the `CLUSTER_SCOPED_ARGO_ROLLOUTS_NAMESPACES` environment variable to a comma-separated list of namespaces:
 +
 --
 *Example configuring the `CLUSTER_SCOPED_ARGO_ROLLOUTS_NAMESPACES` environment variable:*
@@ -32,20 +27,30 @@ metadata:
   name: openshift-gitops-operator
 spec:
   config:
-   env: 
-    - name: NAMESPACE_SCOPED_ARGO_ROLLOUTS
-      value: 'false'
-    - name: CLUSTER_SCOPED_ARGO_ROLLOUTS_NAMESPACES
-      value: <list_of_namespaces_in_the_cluster-scoped_Argo_CD_instances>
- ...
+    env:
+      - name: NAMESPACE_SCOPED_ARGO_ROLLOUTS
+        value: "false"
+      - name: CLUSTER_SCOPED_ARGO_ROLLOUTS_NAMESPACES
+        value: "namespace1,namespace2,namespace3"
 ----
 --
 +
 --
 where:
 
-spec.config.env.value ('false'):: Specify this value to enable or disable the cluster-scoped installation. Set the value to `'false'` to enable cluster-scoped installation. Set to `'true'` to enable namespace-scoped installation. If this value is empty, the operator defaults to `false`.
-spec.config.env.value (list_of_namespaces):: Specifies a comma-separated list of namespaces that can host a cluster-scoped Argo Rollouts instance, for example `test-123-cluster-scoped,test-456-cluster-scoped`.
+`spec.config.env[].value` (NAMESPACE_SCOPED_ARGO_ROLLOUTS):: Specify this value to enable or disable the cluster-scoped installation. Set the value to `'false'` to enable cluster-scoped installation. Set to `'true'` to enable namespace-scoped installation. If this value is empty, the operator defaults to `false`.
+`spec.config.env[].value` (CLUSTER_SCOPED_ARGO_ROLLOUTS_NAMESPACES):: Specifies a comma-separated list of namespaces that can host a cluster-scoped Argo Rollouts instance. For example `test-123-cluster-scoped,test-456-cluster-scoped`.
 --
 
 . Click *Save* and *Reload*.
+
+.Verification
+
+Verify that the {gitops-title} Operator has restarted after the Subscription update:
+
+. In the Administrator perspective, navigate to *Workloads* → *Pods*.
+. Locate the `openshift-gitops-operator-controller-manager` pod and verify that it has a recent restart time.
+. Verify that the Argo Rollouts controller is managing the specified namespaces:
+.. Navigate to the namespace where you created the RolloutManager CR.
+.. Click the argo-rollouts- pod, and then click the Logs tab.
+.. Confirm that the logs show the controller is watching the namespaces you specified in CLUSTER_SCOPED_ARGO_ROLLOUTS_NAMESPACES.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

gitops-docs-1.20, gitops-docs-1.19

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

https://redhat.atlassian.net/browse/RHDEVDOCS-7100

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

[Using a cluster-scoped Argo Rollouts instance to manage rollout resources](https://109847--ocpdocs-pr.netlify.app/openshift-gitops/latest/argo_rollouts/using-cluster-scoped-rollouts-instance-to-manage-rollouts-resources.html)

Peer review:
- [x] Peer has approved this change.
<!--- Peer approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

SME reviewer: @jgwest 
Peer reviewer: @briandooley 

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
