### PR TITLE
TELCODOCS-2272: Add NUMA-aware scheduler scalability and QoS change docs

### DIFF
--- a/modules/cnf-optimizing-topology-aware-scheduler-large-clusters.adoc
+++ b/modules/cnf-optimizing-topology-aware-scheduler-large-clusters.adoc
@@ -1,0 +1,55 @@
+// Module included in the following assemblies:
+//
+// *scalability_and_performance/cnf-numa-aware-scheduling.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="cnf-optimizing-topology-aware-scheduler-large-clusters_{context}"]
+= Optimization strategies for large-cluster NUMA-aware scheduling
+
+[role="_abstract"]
+You can optimize the NUMA-aware secondary scheduler for clusters with 200 or more nodes by tuning cache resync intervals, polling configurations, and the scheduler QoS profile.
+These optimization points help you balance scheduling accuracy, API server load, and control plane resource consumption for your specific cluster size and workload profile.
+
+To get the best performance, coordinate the `NUMAResourcesOperator` and `NUMAResourcesScheduler` settings. The operator controls how frequently topology data is exported, and the scheduler controls how frequently it consumes that data. Aligning these intervals ensures accurate scheduling decisions while minimizing API server traffic.
+
+== NUMAResourcesOperator settings
+
+In the `NUMAResourcesOperator` CR, configure the following parameters to optimize for large clusters:
+
+* For NUMA-sensitive workloads with minimal overhead, set `podsFingerprinting` to `EnabledExclusiveResources`, which is the default.
+* For higher accuracy, set `podsFingerprinting` to `Enabled`. This increases the API load.
+* Set `infoRefreshMode` to `Periodic` for large clusters. `PeriodicAndEvents` provides the highest accuracy but increases API load.
+* Set `infoRefreshPeriod` to control how often the exporter updates topology data. This value must be shorter than the scheduler `cacheResyncPeriod` so that the cache always pulls fresh data. For example, set `infoRefreshPeriod` to 5 seconds.
+
+== NUMAResourcesScheduler settings
+
+In the `NUMAResourcesScheduler` CR, configure the following parameters:
+
+* Set `cacheResyncPeriod` to control how often the scheduler refreshes its cache from the exported topology data. This value must be longer than `infoRefreshPeriod`. For example, set `cacheResyncPeriod` to 10 seconds.
+
+* Choose a QoS profile that matches your operational requirements:
++
+* `Burstable` QoS (default): The recommended setting from {product-title} 4.22. Minimizes baseline resource usage while allowing the scheduler to scale up during peak loads.
++
+* `Guaranteed` QoS (opt-in): Ensures the scheduler pod is protected from eviction. Use this profile for clusters where control plane memory is frequently overcommitted or under pressure.
++
+Apply the Guaranteed QoS profile by annotating the `NUMAResourcesScheduler` custom resource with the following command:
++
+[source,terminal]
+----
+$ oc patch numaresourcesscheduler numaresourcesscheduler --type='merge'
+-p '{"metadata":{"annotations":{"config.numa-operator.openshift.io/scheduler-qos-request":"guaranteed"}}}'
+----
++
+[NOTE]
+====
+This option is expected to be removed in a later {product-title} release.
+====
+
+== Best practices for large clusters
+
+When you deploy the NUMA-aware scheduler in clusters with 200 or more nodes:
+
+* Enable HA mode to distribute replicas across control plane nodes.
+* Use `oc adm top pod` in the `openshift-numaresources` namespace to monitor actual resource consumption.
+* Align your refresh intervals so the exporter provides updates faster than the scheduler cache consumes them.

--- a/modules/cnf-topology-aware-scheduler-scalability.adoc
+++ b/modules/cnf-topology-aware-scheduler-scalability.adoc
@@ -1,0 +1,20 @@
+// Module included in the following assemblies:
+//
+// *scalability_and_performance/cnf-numa-aware-scheduling.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="cnf-topology-aware-scheduler-scalability_{context}"]
+= Topology-aware scheduler scalability
+
+[role="_abstract"]
+You can scale the NUMA-aware secondary scheduler to support clusters with up to 500 nodes.
+Understanding how the scheduler consumes resources at scale helps you size your control plane correctly and avoid resource exhaustion during cluster growth.
+
+The NUMA-aware secondary scheduler relies on the `NodeResourceTopology` custom resource (CR) to track per-node NUMA zone availability.
+As the number of nodes in a cluster increases, the scheduler must process a larger set of `NodeResourceTopology` objects during each scheduling cycle.
+This relationship between node count, cache refresh interval, and scheduling latency determines the scalability profile of the scheduler.
+
+From {product-title} 4.22, the NUMA-aware scheduler pod defaults to `Burstable` quality of service (QoS), which reduces baseline resource consumption while allowing the scheduler to scale up in larger clusters. Switching to `Guaranteed` QoS is generally not recommended because it mandates a higher resource commitment that can unnecessarily constrain the control plane.
+
+When high availability (HA) mode is enabled, the NUMA Resources Operator deploys multiple scheduler replicas across the control plane nodes to ensure redundancy.
+

--- a/scalability_and_performance/cnf-numa-aware-scheduling.adoc
+++ b/scalability_and_performance/cnf-numa-aware-scheduling.adoc
@@ -85,6 +85,10 @@ include::modules/cnf-configuring-nrop-on-schedlable-control-planes.adoc[leveloff
 
 include::modules/cnf-configuring-node-groups-for-the-numaresourcesoperator.adoc[leveloffset=+1]
 
+include::modules/cnf-topology-aware-scheduler-scalability.adoc[leveloffset=+1]
+
+include::modules/cnf-optimizing-topology-aware-scheduler-large-clusters.adoc[leveloffset=+2]
+
 include::modules/cnf-troubleshooting-numa-aware-workloads.adoc[leveloffset=+1]
 
 include::modules/cnf-reporting-more-exact-reource-availability.adoc[leveloffset=+2]


### PR DESCRIPTION
Add new concept modules for NUMA-aware scheduler scalability at 500 nodes and optimization strategies for large clusters. Add release note for the QoS default change from Guaranteed to Burstable in OCP 4.22.

[TELCODOCS-2272]: D/S Docs: topology-aware scheduler: 500 nodes scalability

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.22
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:https://redhat.atlassian.net/browse/TELCODOCS-2272
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:https://109852--ocpdocs-pr.netlify.app/openshift-enterprise/latest/scalability_and_performance/cnf-numa-aware-scheduling.html#cnf-topology-aware-scheduler-scalability_numa-aware
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
   ## Summary                                                                                                                                              
   - Add concept module for NUMA-aware scheduler scalability profile (resource consumption, HA impact, cache resync behavior, large-cluster                
   considerations)                                                                                                                                         
   - Add concept module for optimization strategies in clusters with 200+ nodes (cacheResyncPeriod tuning, podsFingerprinting, polling modes, QoS          
   profile selection)                                                                                                                                      
   - Add release note for the QoS default change from Guaranteed to Burstable in OCP 4.22
   - Update `cnf-numa-aware-scheduling.adoc` assembly to include new modules

   ## JIRA
   [TELCODOCS-2272](https://redhat.atlassian.net/browse/TELCODOCS-2272)

   ## New modules
   | Module | Type | Description |
   |--------|------|-------------|
   | `cnf-topology-aware-scheduler-scalability.adoc` | CONCEPT | Scalability characteristics, resource profiles, HA resource budget, cache resync and
   scheduling latency |
   | `cnf-optimizing-topology-aware-scheduler-large-clusters.adoc` | CONCEPT | Tuning guidance for cacheResyncPeriod, podsFingerprinting, polling
   refresh, QoS profile selection, best practices |
   | `cnf-numa-aware-scheduler-qos-change-rn.adoc` | REFERENCE | Release note: QoS default change, opt-in mechanism, deprecation timeline (annotation
   removal in 4.24) |

   ## SME validation needed
   - Scalability characterization data (resource benchmarks at 100/250/500 nodes)
   - Recommended `cacheResyncPeriod` values by cluster size
   - Scheduling latency benchmarks under thundering herd conditions

   ## Test plan
   - [ ] Verify asciibinder build passes
   - [ ] Verify new modules render correctly in preview
   - [ ] SME review of scalability data and tuning recommendations
   - [ ] Verify assembly include order is correct

<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
