### PR TITLE
OSDOCS-18925:Docs updates for [OSD-GCP] allowing for edit of ingress controller to use namespaceSelector.

### DIFF
--- a/modules/osd-create-cluster-exclude-namespace-selector-cli.adoc
+++ b/modules/osd-create-cluster-exclude-namespace-selector-cli.adoc
@@ -1,0 +1,57 @@
+// Module included in the following assemblies:
+//
+// * networking/networking_operators/ingress-operator.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="osd-create-cluster-exclude-namespace-selector-cli_{context}"]
+= Set namespace exclusions for the default ingress when creating a cluster
+
+[role="_abstract"]
+When you create an {product-title} cluster in noninteractive mode, you can pass a namespace label selector so that namespaces matching those labels are excluded from the default `application ingress`. This allows you to exclude namespaces that host workloads through the default ingress, such as namespaces with sensitive data or internal services.
+
+.Prerequisites
+
+* You installed the `ocm` CLI and logged in with credentials that can create clusters in {cluster-manager-first}.
+* You are using the noninteractive mode for `ocm create cluster`. For interactive mode, use the prompts for ingress settings when they are available for your `ocm` version.
+
+[NOTE]
+====
+Do not exclude namespaces that host required platform routes (for example, `openshift-console` or `openshift-authentication`). Excluding them can break the web console, downloads, or OAuth flows.
+====
+
+.Procedure
+
+. Run `ocm create cluster -h` and confirm that your `ocm` version lists the `--exclude-namespace-selector` flag.
+
+. Build your `ocm create cluster` command with the required parameters for your cloud provider and subscription model.
++
+The following example shows only the ingress-related fragment. Replace the rest of the flags with the values required for your environment.
++
+[source,terminal]
+----
+$ ocm create cluster <cluster_name> \
+  --provider=<aws_or_gcp> \
+  <other_required_flags> \
+  --default-ingress-excluded-namespace-selectors '<key>=<value>,<key2>=<value2>'
+----
++
+where:
+
+`<cluster_name>`:: Specifies the cluster name.
+
+`--provider=<aws_or_gcp>`:: Specifies the cloud provider.
+
+`<other_required_flags>`:: Required parameters such as region, version, CCS settings, or billing flags, as described in the cluster creation documentation for your platform.
+
+`--default-ingress-excluded-namespace-selectors`:: Specifies label selectors; namespaces whose labels match are excluded from the default application ingress, subject to validation by the service. Replace `<key>=<value>` with your labels. Do not include spaces around the `=` sign.
+
+.Verification
+
+* After the cluster reaches `ready` state, confirm ingress settings and inspect the default ingress object for the configured exclusion data.
++
+[source,terminal]
+----
+$ ocm list ingress -c <cluster_name>
+----
+
+

--- a/modules/osd-ingress-excluded-namespaces-ocm-cli.adoc
+++ b/modules/osd-ingress-excluded-namespaces-ocm-cli.adoc
@@ -1,0 +1,66 @@
+// Module included in the following assemblies:
+//
+// * networking/networking_operators/ingress-operator.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="osd-ingress-excluded-namespaces-ocm-cli_{context}"]
+= Configure excluded namespaces for the default ingress controller
+
+[role="_abstract"]
+As a cluster administrator, you can use the {cluster-manager} CLI (`ocm`) to set which namespaces are excluded from the default application ingress on an existing cluster. Excluded namespaces do not have routes served by that ingress.
+
+.Prerequisites
+
+* You installed the `ocm` CLI and logged in with credentials that can modify cluster ingress settings in {cluster-manager-first}.
+* You have the cluster name, cluster ID, or external ID of your cluster.
+
+[IMPORTANT]
+====
+Do not exclude namespaces that host required platform routes (for example, `openshift-console` or `openshift-authentication`). Excluding them can break the web console, downloads, or OAuth flows.
+====
+
+.Procedure
+
+. Optional: Set your cluster name in a variable:
++
+[source,terminal]
+----
+$ export CLUSTER_NAME=<cluster_name>
+----
++
+. List ingress endpoints for the cluster and note the `id` of the default ingress:
++
+[source,terminal]
+----
+$ ocm list ingress -c ${CLUSTER_NAME}
+----
+
+. Optional: To store the default ingress ID in a variable:
++
+[source,terminal]
+----
+$ export INGRESS_ID=$(ocm list ingress -c ${CLUSTER_NAME}| jq -r '.[] | select(.default == true) | .id')
+----
+
+. Edit the default ingress and set excluded namespaces as a comma-separated list of namespace names:
++
+[source,terminal]
+----
+$ ocm edit ingress -c ${CLUSTER_NAME} ${INGRESS_ID} \
+    --excluded-namespaces 'namespace-one,namespace-two'
+----
++
+Substitute `namespace-one`, `namespace-two`, and any additional entries with the metadata names of the namespaces to exclude.
+
+.Verification
+
+* After the command completes, verify that the updated ingress object reflects your excluded namespace settings.
++
+[source,terminal]
+----
+$ ocm list ingress -c <cluster_name>
+----
+
+
+
+

--- a/modules/osd-release-notes-Q2-2026.adoc
+++ b/modules/osd-release-notes-Q2-2026.adoc
@@ -8,6 +8,8 @@
 [role="_abstract"]
 The following items were added during the second quarter of 2026.
 
+* **Support for excluding namespaces from default ingress load controller using label selectors.** You can now use the `ocm` CLI to configure default ingress namespace exclusions for your cluster. For more information, see link:https://docs.redhat.com/en/documentation/openshift_dedicated/4/html/networking_operators/configuring-ingress#configuring-default-ingress-namespace-exclusions[Configuring excluded namespaces for the default ingress controller].
+
 * **Support for new {gcp-short} instances.** You can now create clusters with `g2` and `g4` instance types on {product-title} version 4.21 and later. For more information, see link:https://docs.redhat.com/en/documentation/openshift_dedicated/4/html/introduction_to_openshift_dedicated/policies-and-service-definition#gcp-compute-types_osd-service-definition[{gcp-full} instance types].
 
 * **{product-title} managed DNS zones now available.**

--- a/networking/networking_operators/ingress-operator.adoc
+++ b/networking/networking_operators/ingress-operator.adoc
@@ -140,6 +140,13 @@ include::modules/sd-ingress-responsibilities.adoc[leveloffset=+1]
 
 endif::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 
+ifdef::openshift-dedicated[]
+include::modules/osd-create-cluster-exclude-namespace-selector-cli.adoc[leveloffset=+1]
+
+include::modules/osd-ingress-excluded-namespaces-ocm-cli.adoc[leveloffset=+1]
+
+endif::openshift-dedicated[]
+
 ifndef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 [role="_additional-resources"]
 == Additional resources


### PR DESCRIPTION
Version(s):
4.21+

Issue:
[OSDOCS-18925](https://redhat.atlassian.net/browse/OSDOCS-18925)

Link to docs preview:

- [What's new](https://109873--ocpdocs-pr.netlify.app/openshift-dedicated/latest/osd_whats_new/osd-whats-new.html)
- [Setting namespace exclusions for the default ingress when creating a cluster](https://109873--ocpdocs-pr.netlify.app/openshift-dedicated/latest/networking/networking_operators/ingress-operator.html#osd-create-cluster-exclude-namespace-selector-cli_configuring-ingress)
- [Configuring excluded namespaces for the default ingress controller](https://109873--ocpdocs-pr.netlify.app/openshift-dedicated/latest/networking/networking_operators/ingress-operator.html#osd-ingress-excluded-namespaces-ocm-cli_configuring-ingress)

Peer review:
- [x] Peer reviewer has approved this change.

SME review:
- [x] SME has approved this change.

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
