### PR TITLE
OSDOCS-18711-18: Added a 4.18.31 RN for OSDOCS-18711 issue

### DIFF
--- a/modules/zstream-4-18-31-known-issues.adoc
+++ b/modules/zstream-4-18-31-known-issues.adoc
@@ -1,0 +1,18 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-18-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-18-31-known-issues_{context}"]
+= Known issues
+
+[role=”_abstract”]
+Certain known issues exist for {product-title} {product-version}.31.
+
+The following list details these known issues:
+
+* If the range you set for the `serviceNodePortRange` parameter overlaps with the ephemeral port range, `net.ipv4.ip_local_port_range`, of the kernel, a port collision occurs. OVN-Kubernetes uses this ephemeral range for source network address translation (SNAT) source port selection on outbound pod traffic. When a SNAT source port coincides with a node port number, return traffic can be misrouted, causing intermittent outbound TCP connection timeouts.
++
+To prevent this issue on expanding the range for the  `serviceNodePortRange` parameter, ensure the value you set for the parameter does not overlap with the ephemeral port range of the kernel. For more information, see xref:../nodes/containers/nodes-containers-sysctls.adoc#nodes-safe-sysctls-list_nodes-containers-sysctls[Using sysctls in containers]
++
+(link:https://issues.redhat.com/browse/OCPBUGS-77769[OCPBUGS-77769])

--- a/modules/zstream-4-18-31-known-issues.adoc
+++ b/modules/zstream-4-18-31-known-issues.adoc
@@ -1,0 +1,18 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-18-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-18-31-known-issues_{context}"]
+= Known issues
+
+[role=”_abstract”]
+Certain known issues exist for {product-title} {product-version}.31.
+
+The following list details these known issues:
+
+* If the range you set for the `serviceNodePortRange` parameter overlaps with the ephemeral port range of the kernel, which is specified in the `net.ipv4.ip_local_port_range` parameter, a port collision occurs. OVN-Kubernetes uses this ephemeral range for source network address translation (SNAT) source port selection on outbound pod traffic. When a SNAT source port coincides with a node port number, return traffic can be misrouted, causing intermittent outbound TCP connection timeouts.
++
+To prevent this issue on expanding the range for the  `serviceNodePortRange` parameter, ensure the value you set for the parameter does not overlap with the ephemeral port range of the kernel. For more information, see xref:../nodes/containers/nodes-containers-sysctls.adoc#nodes-safe-sysctls-list_nodes-containers-sysctls[Using sysctls in containers]
++
+(link:https://issues.redhat.com/browse/OCPBUGS-77769[OCPBUGS-77769])

--- a/release_notes/ocp-4-18-release-notes.adoc
+++ b/release_notes/ocp-4-18-release-notes.adoc
@@ -3109,6 +3109,9 @@ include::modules/zstream-4-18-31-about.adoc[leveloffset=+2]
 // 4.18.31 fixed issues
 include::modules/zstream-4-18-31-fixed-issues.adoc[leveloffset=+2]
 
+// 4.18.31 Known issues
+include::modules/zstream-4-18-31-known-issues.adoc[leveloffset=+2]
+
 // 4.18.31 updating
 include::modules/zstream-4-18-31-updating.adoc[leveloffset=+2]
 

--- a/release_notes/ocp-4-18-release-notes.adoc
+++ b/release_notes/ocp-4-18-release-notes.adoc
@@ -3092,6 +3092,9 @@ include::modules/zstream-4-18-31-about.adoc[leveloffset=+2]
 // 4.18.31 fixed issues
 include::modules/zstream-4-18-31-fixed-issues.adoc[leveloffset=+2]
 
+// 4.18.31 Known issues
+include::modules/zstream-4-18-31-known-issues.adoc[leveloffset=+2]
+
 // 4.18.31 updating
 include::modules/zstream-4-18-31-updating.adoc[leveloffset=+2]
 


### PR DESCRIPTION
Version(s):
4.18

Issue:
[OSDOCS-18711](https://redhat.atlassian.net/browse/OSDOCS-18711)

Preview: https://109874--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-18-release-notes.html#zstream-4-18-32-known-issues_release-notes

- [x] SME has approved this change (Matteo Dallaglio).
- [x] QE has approved this change (Anurag S).

[Slack thread](https://redhat-internal.slack.com/archives/CDCP2LA9L/p1775567956954719)