### PR TITLE
OCPBUGS-81437: Added br-ex doc to ABI assembly

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -419,6 +419,8 @@ Topics:
     File: preparing-an-agent-based-installed-cluster-for-mce
   - Name: Installation configuration parameters for the Agent-based Installer
     File: installation-config-parameters-agent
+  - Name: Postinstallation tasks
+    File: agent-based-installer-postinstallation
 - Name: Installing on a single node
   Dir: installing_sno
   Distros: openshift-enterprise,openshift-origin

--- a/installing/installing_bare_metal/bare-metal-postinstallation-configuration.adoc
+++ b/installing/installing_bare_metal/bare-metal-postinstallation-configuration.adoc
@@ -36,7 +36,7 @@ include::modules/bare-metal-install-new-bmc-ca.adoc[leveloffset=+2]
 include::modules/nw-enabling-a-provisioning-network-after-installation.adoc[leveloffset=+1]
 
 // Creating a manifest object that includes a customized `br-ex` bridge
-include::modules/creating-manifest-file-customized-br-ex-bridge.adoc[leveloffset=+1]
+include::modules/creating-manifest-file-customized-br-ex-bridge-post.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources

--- a/installing/installing_with_agent_based_installer/agent-based-installer-postinstallation.adoc
+++ b/installing/installing_with_agent_based_installer/agent-based-installer-postinstallation.adoc
@@ -1,0 +1,20 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="agent-based-installer-postinstallation"]
+= Postinstallation tasks
+include::_attributes/common-attributes.adoc[]
+:context: agent-based-installer-postinstallation
+
+toc::[]
+
+[role="_abstract"]
+After using the Agent-based Installer to deploy your cluster, you can perform post-installation procedures such as customizing a `br-ex` bridge for nodes in your cluster. Customizing your cluster can help prepare the cluster for specific workloads and deployment requirements.
+
+include::modules/creating-manifest-file-customized-br-ex-bridge-post.adoc[leveloffset=+1]
+ 
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../networking/ovn_kubernetes_network_provider/converting-to-dual-stack.adoc#nw-dual-stack-convert_converting-to-dual-stack[Converting to a dual-stack cluster network]
+
+* xref:../../installing/installing_bare_metal/bare-metal-expanding-the-cluster.adoc#bare-metal-expanding-the-cluster[Expanding the cluster]
+

--- a/installing/installing_with_agent_based_installer/installing-with-agent-based-installer.adoc
+++ b/installing/installing_with_agent_based_installer/installing-with-agent-based-installer.adoc
@@ -47,7 +47,10 @@ include::modules/installing-ocp-agent-manifest-folder.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
 .Additional resources
+
 * xref:../../machine_configuration/machine-configs-configure.adoc#machine-configs-configure[Using MachineConfig objects to configure nodes]
+
+include::modules/creating-manifest-file-customized-br-ex-bridge.adoc[leveloffset=+2]
 
 // Disk partitioning
 include::modules/installation-user-infra-machines-advanced-disk.adoc[leveloffset=+2]

--- a/modules/creating-manifest-file-customized-br-ex-bridge-post.adoc
+++ b/modules/creating-manifest-file-customized-br-ex-bridge-post.adoc
@@ -1,0 +1,130 @@
+// Module included in the following assemblies:
+//
+// * installing/installing_bare_metal/bare-metal-postinstallation-configuration.adoc
+// * installing/installing_with_agent_based_installer/installing-with-agent-based-installer.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="creating-manifest-file-customized-br-ex-bridge-post_{context}"]
+= Creating a manifest object that includes a customized br-ex bridge
+
+[role="_abstract"]
+Use the default OVS br-ex bridge configuration for standard environments. This configuration applies when you have a single network interface controller (NIC) and standard OVS settings. 
+
+By default, {product-title} automatically configures the Open vSwitch (OVS) `br-ex` bridge on bare-metal nodes. For advanced networking requirements, you can override this default behavior on bare-metal platforms. To do this, create an `NodeNetworkConfigurationPolicy` (NNCP) custom resource (CR) that includes an NMState configuration file.
+
+The Kubernetes NMState Operator uses the NMState configuration file to create a customized `br-ex` bridge network configuration. This configuration applies to each node in your cluster.
+
+[IMPORTANT]
+====
+After creating the `NodeNetworkConfigurationPolicy` CR, copy content from the installation NMState configuration file into the NNCP CR. An incomplete NNCP CR can result in loss of network connectivity, because the NNCP overrides all existing policies.
+====
+
+Consider using the customized `br-ex` bridge configuration for any of the following tasks:
+
+* You need to modify the `br-ex` bridge after you installed the cluster.
+* You need to modify the maximum transmission unit (MTU) for your cluster.
+* You need to update DNS values.
+* You need to modify attributes for a different bond interface, such as MIImon (Media Independent Interface Monitor), bonding mode, or Quality of Service (QoS).
+* You need to enable Link Layer Discovery Protocol (LLDP) to discover and troubleshoot switch connectivity.
+
+[WARNING]
+====
+The following list of interface names are reserved and you cannot use the names with NMstate configurations:
+
+* `br-ext`
+* `br-int`
+* `br-local`
+* `br-nexthop`
+* `br0`
+* `ext-vxlan`
+* `ext`
+* `genev_sys_*`
+* `int`
+* `k8s-*`
+* `ovn-k8s-*`
+* `patch-br-*`
+* `tun0`
+* `vxlan_sys_*`
+====
+
+.Prerequisites
+* You have installed the Kubernetes NMState Operator.
+* You have identified the specific nodes where you want to apply the policy.
+
+.Procedure
+
+* Create a `NodeNetworkConfigurationPolicy` (NNCP) CR and define a customized `br-ex` bridge network configuration. The `br-ex` NNCP CR must include the OVN-Kubernetes masquerade IP address and subnet of your network. The example NNCP CR includes default values in the `ipv4.address.ip` and `ipv6.address.ip` parameters. You can set the masquerade IP address in the `ipv4.address.ip`, `ipv6.address.ip`, or both parameters.
++
+[IMPORTANT]
+====
+As a post-installation task, you cannot change the primary IP address of the customized `br-ex` bridge. If you want to convert your single-stack cluster network to a dual-stack cluster network, you can add or change a secondary IPv6 address in the NNCP CR, but the existing primary IP address cannot be changed.
+====
++
+[source,yaml]
+----
+apiVersion: nmstate.io/v1
+kind: NodeNetworkConfigurationPolicy
+metadata:
+  name: worker-0-br-ex
+spec:
+  nodeSelector:
+    kubernetes.io/hostname: worker-0
+    desiredState:
+    interfaces:
+    - name: enp2s0
+      type: ethernet
+      state: up
+      ipv4:
+        enabled: false
+      ipv6:
+        enabled: false
+    - name: br-ex
+      type: ovs-bridge
+      state: up
+      ipv4:
+        enabled: false
+        dhcp: false
+      ipv6:
+        enabled: false
+        dhcp: false
+      bridge:
+        options:
+          mcast-snooping-enable: true
+        port:
+        - name: enp2s0
+        - name: br-ex
+    - name: br-ex
+      type: ovs-interface
+      state: up
+      copy-mac-from: enp2s0
+      ipv4:
+        enabled: true
+        dhcp: true
+        auto-route-metric: 48
+        address:
+        - ip: "169.254.0.2"
+          prefix-length: 17
+      ipv6:
+        enabled: true
+        dhcp: true
+        auto-route-metric: 48
+        address:
+        - ip: "fd69::2"
+        prefix-length: 112
+# ...
+----
++
+where:
++
+`metadata.name`:: Specifies the name of the policy.
+`interfaces.name`:: Specifies the name of the interface.
+`interfaces.type`:: Specifies the type of ethernet.
+`interfaces.state`:: Specifies the requested state for the interface after creation.
+`ipv4.enabled`:: Disables IPv4 and IPv6 in this example.
+`port.name`:: Specifies the node NIC to which the bridge is attached.
+`address.ip`:: Shows the default IPv4 and IPv6 IP addresses. Ensure that you set the masquerade IPv4 and IPv6 IP addresses of your network. 
+`auto-route-metric`:: Set the parameter to `48` to ensure the `br-ex` default route always has the highest precedence (lowest metric). This configuration prevents routing conflicts with any other interfaces automatically configured by the `NetworkManager` service.
+
+.Next steps
+
+* Scaling compute nodes to apply the manifest object that includes a customized `br-ex` bridge to each compute node that exists in your cluster. For more information, see "Expanding the cluster" in the _Additional resources_ section.

--- a/modules/creating-manifest-file-customized-br-ex-bridge.adoc
+++ b/modules/creating-manifest-file-customized-br-ex-bridge.adoc
@@ -1,13 +1,13 @@
 // Module included in the following assemblies:
 //
 // * installing/installing_bare_metal/ipi/ipi-install-installation-workflow.adoc
-// * installing/installing_bare_metal/bare-metal-postinstallation-configuration.adoc
 // * installing/installing_bare_metal/upi/installing-bare-metal-network-customizations.adoc
 // * installing/installing_bare_metal/upi/installing-restricted-networks-bare-metal.adoc
 // * installing/installing_bare_metal/upi/installing-bare-metal.adoc
+// * installing/installing_with_agent_based_installer/installing-with-agent-based-installer.adoc
 
-ifeval::["{context}" == "bare-metal-postinstallation-configuration"]
-:postinstall-bare-metal:
+ifeval::["{context}" == "installing-with-agent-based-installer"]
+:agent:
 endif::[]
 
 :_mod-docs-content-type: PROCEDURE
@@ -15,45 +15,37 @@ endif::[]
 = Creating a manifest object that includes a customized br-ex bridge
 
 [role="_abstract"]
-ifndef::postinstall-bare-metal[]
-By default, {product-title} automatically configures the Open vSwitch (OVS) `br-ex` bridge. For advanced networking requirements, on a bare-metal platform you can override the default behavior by creating a `MachineConfig` object that includes an NMState configuration file. 
+ifndef::agent[]
+By default, {product-title} automatically configures the Open vSwitch (OVS) `br-ex` bridge on bare-metal nodes. For advanced networking requirements, you can override this default behavior on bare-metal platforms. To do this, create a `MachineConfig` object that includes an NMState configuration file.
+endif::agent[]
+
+ifdef::agent[]
+By default, {product-title} automatically configures the Open vSwitch (OVS) `br-ex` bridge on nodes. For advanced networking requirements, you can override this default behavior on bare-metal platforms. To do this, use the Agent-based Installer to create a `MachineConfig` object that includes an NMState configuration file.
+
+[IMPORTANT]
+====
+Customizations to the cluster made by additional manifests are not validated and not guaranteed to work. These manifests might result in a nonfunctional cluster.
+
+For more information about an additional manifest file, see "Creating a directory to contain additional manifests".
+====
+endif::agent[]
 
 Consider using the customized `br-ex` bridge configuration for any of the following tasks:
 
 * You need to modify the `br-ex` bridge after you installed the cluster.
 * You need to modify the maximum transmission unit (MTU) for your cluster.
 * You need to update DNS values.
-* You need to modify attributes for a different bond interface, such as MIImon (Media Independent Interface Monitor), bonding mode, or Quality of Service (QoS).
+* You need to modify attributes for a different bond interface. Examples include MIImon (Media Independent Interface Monitor), bonding mode or Quality of Service (QoS).
 * You need to enable Link Layer Discovery Protocol (LLDP) to discover and troubleshoot switch connectivity.
-endif::postinstall-bare-metal[]
 
-Consider using the default OVS br-ex bridge configuration if you require a standard environment with a single network interface controller (NIC) and standard OVS settings.
-
-ifdef::postinstall-bare-metal[]
-By default, {product-title} automatically configures the Open vSwitch (OVS) `br-ex` bridge on bare-metal nodes. For advanced networking requirements, you can override the default behavior by creating a `NodeNetworkConfigurationPolicy` (NNCP) custom resource (CR) that includes an NMState configuration file. 
-
-The Kubernetes NMState Operator uses the NMState configuration file to create a customized `br-ex` bridge network configuration on each node in your cluster.
-
-[IMPORTANT]
-====
-After creating the `NodeNetworkConfigurationPolicy` CR, copy content from the NMState configuration file that was created during cluster installation into the NNCP CR. An incomplete NNCP CR can result in loss of network connectivity, because the NNCP overrides all existing policies.
-====
-
-Consider using the customized `br-ex` bridge configuration for any of the following tasks:
-
-* You want to make postinstallation changes to the bridge, such as changing the Open vSwitch (OVS) or OVN-Kubernetes `br-ex` bridge network. The default OVS `br-ex` bridge mechanism does not support making postinstallation changes to the bridge.
-* You want to deploy the bridge on a different interface than the interface available on a host or server IP address.
-* You want to make advanced configurations to the bridge that are not possible with the default OVS `br-ex` bridge mechanism. Using the default mechanism for these configurations might result in the bridge failing to connect multiple network interfaces and facilitating data forwarding between the interfaces.
-endif::postinstall-bare-metal[]
-
-ifndef::postinstall-bare-metal[]
 [NOTE]
 ====
-If you require an environment with a single network interface controller (NIC) and default network settings, use the default OVS `br-ex` bridge mechanism.
+Use the default OVS `br-ex` bridge for standard environments. 
+
+Use the default OVS `br-ex` bridge mechanism for single network interface controller (NIC) environments with default network settings.
 ====
 
-After you install {op-system-first} and the system reboots, the Machine Config Operator injects Ignition configuration files into each node in your cluster, so that each node receives the `br-ex` bridge network configuration. To prevent configuration conflicts, the default OVS `br-ex` bridge mechanism is disabled.
-endif::postinstall-bare-metal[]
+After you install {op-system-first} and the system reboots, the Machine Config Operator injects Ignition configuration files into each node. This operation ensures that each node receives the `br-ex` bridge network configuration. To prevent configuration conflicts, the default OVS `br-ex` bridge mechanism is disabled.
 
 [WARNING]
 ====
@@ -76,18 +68,13 @@ The following list of interface names are reserved and you cannot use the names 
 ====
 
 .Prerequisites
-ifndef::postinstall-bare-metal[]
 * Optional: You have installed the link:https://nmstate.io/user/quick_guide.html[`nmstatectl`] CLI tool to validate your NMState configuration.
-endif::postinstall-bare-metal[]
-
-ifdef::postinstall-bare-metal[]
-* You have installed the Kubernetes NMState Operator.
-* You have identified the specific nodes where you want to apply the policy.
-endif::postinstall-bare-metal[]
+ifdef::agent[]
+* You checked that an `openshift` subdirectory exists in your installation directory. If the subdirectory does not exist, create the subdirectory.
+endif::agent[]
 
 .Procedure
 
-ifndef::postinstall-bare-metal[]
 . Create an NMState configuration file and define a customized `br-ex` bridge network configuration in the file:
 +
 .Example of an NMState configuration for a customized `br-ex` bridge network
@@ -138,7 +125,7 @@ where:
 `interfaces.state`:: The requested state for the interface after creation.
 `ipv4.enabled`:: Disables IPv4 and IPv6 in this example.
 `port.name`:: The node NIC to which the bridge attaches.
-`auto-route-metric`:: Set the parameter to `48` to ensure the `br-ex` default route always has the highest precedence (lowest metric). This configuration prevents routing conflicts with any other interfaces that are automatically configured by the `NetworkManager` service.
+`auto-route-metric`:: Set the parameter to `48` to ensure the `br-ex` default route always has the highest precedence (lowest metric). This configuration prevents routing conflicts with any other interfaces automatically configured by the `NetworkManager` service.
 
 . Use the `cat` command to base64-encode the contents of the NMState configuration:
 +
@@ -151,7 +138,13 @@ where:
 +
 `<nmstate_configuration>`:: Replace `<nmstate_configuration>` with the name of your NMState resource YAML file.
 
-. Create a `MachineConfig` manifest file and define a customized `br-ex` bridge network configuration analogous to the following example:
+ifndef::agent[]
+. Create a `MachineConfig` manifest file and define a customized `br-ex` bridge network configuration analogous to the following example. The installation program automatically applies the updates from the `MachineConfig` object to your cluster.
+endif::agent[]
+
+ifdef::agent[]
+. Create a `MachineConfig` file as an additional manifest file. Define a customized `br-ex` bridge network configuration analogous to the following example in the file. The Agent-based Installer automatically applies the updates from the `MachineConfig` object to your cluster.
+endif::agent[]
 +
 [source,yaml]
 ----
@@ -182,12 +175,13 @@ spec:
 +
 where:
 +
-`metadata.name`:: The name of the policy.
+`metadata.name`:: Specifies the name of the policy.
 `contents.source`:: Writes the encoded base64 information to the specified path.
-`path`:: For each node in your cluster, specify the hostname path to your node and the base-64 encoded Ignition configuration file data for the machine type. The `worker` role is the default role for nodes in your cluster. You must use the `.yml` extension for configuration files, such as `$(hostname -s).yml` when specifying the short hostname path for each node or all nodes in the `MachineConfig` manifest file.
+`path`:: For each node in your cluster, specify the hostname path to your node and the base-64 encoded Ignition configuration file data for the machine type. The `worker` role is the default role for nodes in your cluster. Use the `.yml` extension for configuration files. For example, use `$(hostname -s).yml` when specifying the short hostname path for each node or all nodes in the `MachineConfig` manifest file.
 +
-If you have a single global configuration specified in an `/etc/nmstate/openshift/cluster.yml` configuration file that you want to apply to all nodes in your cluster, you do not need to specify the short hostname path for each node, such as `/etc/nmstate/openshift/<node_hostname>.yml`. For example:
+You can apply a single global configuration to all nodes by using the `/etc/nmstate/openshift/cluster.yml` configuration file. In this case, you do not need to specify individual hostname paths for each node, such as `/etc/nmstate/openshift/<node_hostname>.yml`.
 +
+.Example /etc/nmstate/openshift/cluster.yml configuration file
 [source,yaml]
 ----
 # ...
@@ -199,92 +193,18 @@ If you have a single global configuration specified in an `/etc/nmstate/openshif
 # ...
 ----
 
-. Apply the updates from the `MachineConfig` object to your cluster by entering the following command:
+ifdef::agent[]
+. Save the additional manifest file in the `openshift` subdirectory of your installation directory.
 +
-[source,terminal]
-----
-$ oc apply -f <machine_config>.yml
-----
-endif::postinstall-bare-metal[]
+On completing other configuration inputs for your installation, such as encrypting the disk, you create the ISO image. After booting this image, the customized `br-ex` bridge configuration applies to each node in your cluster.
+endif::agent[]
 
-ifdef::postinstall-bare-metal[]
-* Create a `NodeNetworkConfigurationPolicy` (NNCP) CR and define a customized `br-ex` bridge network configuration. The `br-ex` NNCP CR must include the OVN-Kubernetes masquerade IP address and subnet of your network. The example NNCP CR includes default values in the `ipv4.address.ip` and `ipv6.address.ip` parameters. You can set the masquerade IP address in the `ipv4.address.ip`, `ipv6.address.ip`, or both parameters.
-+
-[IMPORTANT]
-====
-As a post-installation task, you cannot change the primary IP address of the customized `br-ex` bridge. If you want to convert your single-stack cluster network to a dual-stack cluster network, you can add or change a secondary IPv6 address in the NNCP CR, but the existing primary IP address cannot be changed.
-====
-+
-[source,yaml]
-----
-apiVersion: nmstate.io/v1
-kind: NodeNetworkConfigurationPolicy
-metadata:
-  name: worker-0-br-ex
-spec:
-  nodeSelector:
-    kubernetes.io/hostname: worker-0
-    desiredState:
-    interfaces:
-    - name: enp2s0
-      type: ethernet
-      state: up
-      ipv4:
-        enabled: false
-      ipv6:
-        enabled: false
-    - name: br-ex
-      type: ovs-bridge
-      state: up
-      ipv4:
-        enabled: false
-        dhcp: false
-      ipv6:
-        enabled: false
-        dhcp: false
-      bridge:
-        options:
-          mcast-snooping-enable: true
-        port:
-        - name: enp2s0
-        - name: br-ex
-    - name: br-ex
-      type: ovs-interface
-      state: up
-      copy-mac-from: enp2s0
-      ipv4:
-        enabled: true
-        dhcp: true
-        auto-route-metric: 48
-        address:
-        - ip: "169.254.0.2"
-          prefix-length: 17
-      ipv6:
-        enabled: true
-        dhcp: true
-        auto-route-metric: 48
-        address:
-        - ip: "fd69::2"
-        prefix-length: 112
-# ...
-----
-+
-where:
-+
-`metadata.name`:: Name of the policy.
-`interfaces.name`:: Name of the interface.
-`interfaces.type`:: The type of ethernet.
-`interfaces.state`:: The requested state for the interface after creation.
-`ipv4.enabled`:: Disables IPv4 and IPv6 in this example.
-`port.name`:: The node NIC to which the bridge is attached.
-`address.ip`:: Shows the default IPv4 and IPv6 IP addresses. Ensure that you set the masquerade IPv4 and IPv6 IP addresses of your network. 
-`auto-route-metric`:: Set the parameter to `48` to ensure the `br-ex` default route always has the highest precedence (lowest metric). This configuration prevents routing conflicts with any other interfaces that are automatically configured by the `NetworkManager` service.
-endif::postinstall-bare-metal[]
-
+ifndef::agent[]
 .Next steps
 
 * Scaling compute nodes to apply the manifest object that includes a customized `br-ex` bridge to each compute node that exists in your cluster. For more information, see "Expanding the cluster" in the _Additional resources_ section.
+endif::agent[]
 
-ifeval::["{context}" == "bare-metal-postinstallation-configuration"]
-:!postinstall-bare-metal:
+ifeval::["{context}" == "installing-with-agent-based-installer"]
+:!agent:
 endif::[]


### PR DESCRIPTION
This PR adds the Creating a manifest object that includes a customized br-ex bridge to the Agent-based Installer doc. I've included other preview links as I changed the metadata in the creating-manifest-file-customized-br-ex-bridge.adoc file to include `installing-with-agent-based-installer.adoc`.

Version(s):
4.18+

Issue:
[OCPBUGS-81437](https://redhat.atlassian.net/browse/OCPBUGS-81437)

Link to docs preview:

PRIMARY CHANGE: 

* https://109880--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_with_agent_based_installer/agent-based-installer-postinstallation.html
* https://109880--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_with_agent_based_installer/installing-with-agent-based-installer.html#creating-manifest-file-customized-br-ex-bridge_installing-with-agent-based-installer

OTHER GENERATED BOOK LINKS

* https://109880--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/bare-metal-postinstallation-configuration.html
* https://109880--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/ipi/ipi-install-installation-workflow.html
* https://109880--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/upi/installing-bare-metal.html
* https://109880--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/upi/installing-bare-metal-network-customizations.html
* https://109880--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/upi/installing-restricted-networks-bare-metal.html

- [x] SME has approved this change (Bob Fournier/Ben Nemec).
- [x] QE has approved this change (Manoj Hans).


