### PR TITLE
[enterprise-4.18] OSDOCS-19033: kueue.x-k8s.io/queue-name referring to non-existent queue

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -3389,6 +3389,8 @@ Topics:
     File: configuring-quotas
   - Name: Managing jobs and workloads
     File: managing-workloads
+  - Name: Monitoring pending workloads
+    File: monitoring-pending-workloads
   - Name: Using cohorts
     File: using-cohorts
   - Name: Configuring fair sharing

--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -3379,6 +3379,10 @@ Topics:
     File: install-kueue
   - Name: Installing Red Hat build of Kueue in a disconnected environment
     File: install-disconnected
+  - Name: Integrating the Leader Worker Set Operator
+    File: integrating-lws
+  - Name: Integrating the JobSet Operator
+    File: integrating-jobset
   - Name: Configuring role-based permissions
     File: rbac-permissions
   - Name: Configuring quotas

--- a/ai_workloads/kueue/integrating-jobset.adoc
+++ b/ai_workloads/kueue/integrating-jobset.adoc
@@ -1,0 +1,33 @@
+:_mod-docs-content-type: ASSEMBLY
+include::_attributes/common-attributes.adoc[]
+[id="integrating-jobset"]
+= Integrating the {js-operator}
+:context: integrating-jobset
+
+toc::[]
+
+[role="_abstract"]
+You can integrate {js-operator} with {kueue-name} so you can leverage the scheduling and resource management functionality provided by {kueue-name} when running the {js-operator}.
+
+You can use the {js-operator} to manage and run large-scale, coordinated workloads like high-performance computing (HPC) and AI training.
+
+The {js-operator} models a distributed batch workload as a group of Kubernetes Jobs. This allows you to easily specify different pod templates for different distinct groups of pods, for example, a leader, workers, parameter servers, and so on. 
+
+
+include::modules/kueue-installing-jobset.adoc[leveloffset=+1]
+[role="_additional-resources"]
+.Additional resources
+* xref:../../ai_workloads/jobset_operator/index.adoc#js-about_js-about[About the {js-operator}]
+
+* link:https://kueue.sigs.k8s.io/docs/tasks/run/jobsets/[Run A JobSet (Kubernetes documentation)]
+
+* xref:../../security/cert_manager_operator/cert-manager-operator-install.adoc#installing-the-cert-manager-operator-for-red-hat-openshift[Installing the {cert-manager-operator} by using the web console]
+
+include::modules/kueue-running-jobset.adoc[leveloffset=+1]
+[role="_additional-resources"]
+.Additional resources
+* xref:../../ai_workloads/kueue/configuring-quotas.adoc#configuring-clusterqueues_configuring-quotas[Configuring a cluster queue]
+
+* xref:../../ai_workloads/kueue/configuring-quotas.adoc#configuring-resourceflavors_configuring-quotas[Configuring a resource flavor]
+
+* xref:../../ai_workloads/kueue/configuring-quotas.adoc#configuring-localqueues_configuring-quotas[Configuring a local queue]

--- a/ai_workloads/kueue/integrating-lws.adoc
+++ b/ai_workloads/kueue/integrating-lws.adoc
@@ -1,0 +1,30 @@
+:_mod-docs-content-type: ASSEMBLY
+include::_attributes/common-attributes.adoc[]
+[id="integrating-lws"]
+= Integrating the {lws-operator}
+:context: integrating-lws
+
+toc::[]
+
+[role="_abstract"]
+You can integrate the {lws-operator} with {kueue-name} so you can leverage the scheduling and resource management functionality when running LeaderWorkerSets.
+
+The {lws-operator} allows you to manage multi-node AI/ML inference deployments efficiently. {kueue-name} provides scheduling and resource management capabilities for these deployments. You can configure {lws-operator} to leverage these capabilities when running the `LeaderWorkerSet` API for deploying a group of pods as a unit of replication.
+
+include::modules/kueue-installing-lws.adoc[leveloffset=+1]
+[role="_additional-resources"]
+.Additional resources
+* xref:../../ai_workloads/leader_worker_set/index.adoc#lws-about_lws-about[About the {lws-operator}]
+
+* link:https://lws.sigs.k8s.io/docs/reference/leaderworkerset.v1/[LeaderWorkerSet API (Kubernetes documentation)]
+
+* xref:../../security/cert_manager_operator/cert-manager-operator-install.adoc#installing-the-cert-manager-operator-for-red-hat-openshift[Installing the {cert-manager-operator} by using the web console]
+
+include::modules/kueue-running-lws.adoc[leveloffset=+1]
+[role="_additional-resources"]
+.Additional resources
+* xref:../../ai_workloads/kueue/configuring-quotas.adoc#configuring-clusterqueues_configuring-quotas[Configuring a cluster queue]
+
+* xref:../../ai_workloads/kueue/configuring-quotas.adoc#configuring-resourceflavors_configuring-quotas[Configuring a resource flavor]
+
+* xref:../../ai_workloads/kueue/configuring-quotas.adoc#configuring-localqueues_configuring-quotas[Configuring a local queue]

--- a/ai_workloads/kueue/monitoring-pending-workloads.adoc
+++ b/ai_workloads/kueue/monitoring-pending-workloads.adoc
@@ -1,0 +1,38 @@
+:_mod-docs-content-type: ASSEMBLY
+include::_attributes/common-attributes.adoc[]
+[id="monitoring-pending-workloads-install-kueue"]
+= Monitoring pending workloads 
+:context: monitoring-pending-workloads
+
+toc::[]
+
+[role="_abstract"]
+{kueue-name} provides the `VisibilityOnDemand` feature to monitor pending workloads. A workload is an application that runs to completion. It can be composed by one or multiple pods that, loosely or tightly coupled, as a whole, complete a task. A workload is the unit of admission in {kueue-name}.
+
+The `VisibilityOnDemand` feature provides the ability for batch administrators to monitor the pipeline of pending jobs in the cluster queue and the local queue and batch users just for local queue, and help users to estimate when their jobs will start.
+
+You can regulate inbound requests and high request volumes, and provide user permissions for viewing the pending workloads.
+
+include::modules/kueue-configuring-api-priority-and-fairness.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* link:https://kubernetes.io/docs/concepts/cluster-administration/flow-control/[API Priority and Fairness]
+
+include::modules/kueue-providing-user-permissions.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.20/html/ai_workloads/red-hat-build-of-kueue#rbac-permissions[Configuring role-based permissions]
+
+
+include::modules/kueue-monitoring-pending-workloads-on-demand.adoc[leveloffset=+1]
+
+include::modules/kueue-viewing-pending-workloads-clusterqueue.adoc[leveloffset=+2]
+
+include::modules/kueue-viewing-pending-workloads-localqueue.adoc[leveloffset=+2]
+
+include::modules/kueue-modifying-monitoring-settings.adoc[leveloffset=+1]
+

--- a/ai_workloads/kueue/monitoring-pending-workloads.adoc
+++ b/ai_workloads/kueue/monitoring-pending-workloads.adoc
@@ -25,7 +25,7 @@ include::modules/kueue-providing-user-permissions.adoc[leveloffset=+1]
 [role="_additional-resources"]
 .Additional resources
 
-* link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.20/html/ai_workloads/red-hat-build-of-kueue#rbac-permissions[Configuring role-based permissions]
+* link:https://docs.redhat.com/en/documentation/openshift_container_platform/latest/html/ai_workloads/red-hat-build-of-kueue#rbac-permissions[Configuring role-based permissions]
 
 
 include::modules/kueue-monitoring-pending-workloads-on-demand.adoc[leveloffset=+1]

--- a/ai_workloads/kueue/release-notes.adoc
+++ b/ai_workloads/kueue/release-notes.adoc
@@ -10,6 +10,12 @@ toc::[]
 
 include::modules/kueue-compatible-environments.adoc[leveloffset=+1]
 
+include::modules/kueue-release-notes-1.3.1.adoc[leveloffset=+1]
+
+include::modules/kueue-release-notes-1.3.adoc[leveloffset=+1]
+
+include::modules/kueue-release-notes-1.2.adoc[leveloffset=+1]
+
 include::modules/kueue-release-notes-1.1.adoc[leveloffset=+1]
 
 include::modules/kueue-release-notes-1.0.1.adoc[leveloffset=+1]

--- a/modules/kueue-configuring-api-priority-and-fairness.adoc
+++ b/modules/kueue-configuring-api-priority-and-fairness.adoc
@@ -1,0 +1,13 @@
+// Module included in the following assemblies:
+//
+// * ai_workloads/kueue/monitoring-pending-workloads.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="configuring-api-priority-and-fairness_{context}"]
+= API Priority and Fairness
+
+[role="_abstract"]
+{kueue-name} uses Kubernetes API Priority and Fairness (APF) To help manage pending workloads. APF is a flow control mechanism that allows you to define API-level policies to regulate inbound requests to the API server. It protects the API server from being overwhelmed by unexpectedly high request volume, while protecting critical traffic from the throttling effect on best-effort workloads.
+
+
+

--- a/modules/kueue-installing-jobset.adoc
+++ b/modules/kueue-installing-jobset.adoc
@@ -1,0 +1,38 @@
+// Module included in the following assemblies:
+//
+// * ai_workloads/kueue/integrating-jobset.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="kueue-installing-jobset_{context}"]
+= Installing {js-operator} with {kueue-name}
+
+[role="_abstract"]
+You can configure {kueue-name} to work with the {js-operator}.
+
+.Prerequisites
+
+* You have installed {kueue-name} using the {kueue-op} in the software catalog.
+* You have installed {js-operator} in the software catalog.
+* You have cluster administrator permissions and the `kueue-batch-admin-role` role.
+* You have access to the {product-title} web console.
+* You have installed the {cert-manager-operator} for your cluster. 
+
+.Procedure 
+
+* Add `JobSet` to the `config.integrations.frameworks` section of the {kueue-name} 
+cluster object, as shown in the following example:
++
+[source,yaml]
+----
+apiVersion: kueue.openshift.io/v1
+kind: Kueue
+metadata:
+  name: cluster
+  namespace: openshift-kueue-operator
+spec:
+  managementState: Managed
+  config:
+    integrations:
+      frameworks:
+      - JobSet
+----

--- a/modules/kueue-installing-lws.adoc
+++ b/modules/kueue-installing-lws.adoc
@@ -1,0 +1,41 @@
+// Module included in the following assemblies:
+//
+// * ai_workloads/kueue/integrating-leader-worker-set.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="kueue-installing-lws_{context}"]
+= Installing {lws-operator} with {kueue-name}
+
+[role="_abstract"]
+You can configure {kueue-name} to work with the {lws-operator}.
+
+.Prerequisites
+
+* You have installed {kueue-name} using the {kueue-op} in the software catalog.
+* You have installed {lws-operator} and Operand in the software catalog.
+* You have cluster administrator permissions and the `kueue-batch-admin-role` role.
+* You have access to the {product-title} web console.
+* You have installed the {cert-manager-operator} for your cluster. 
+
+.Procedure
+
+* Add `LeaderWorkerSet` to the `config.integrations.framework` section of the {kueue-name} cluster object, as shown in the following example:
++
+[source,yaml]
+----
+apiVersion: kueue.openshift.io/v1
+kind: Kueue
+metadata:
+  labels:
+    app.kubernetes.io/name: kueue-operator
+    app.kubernetes.io/managed-by: kustomize
+  name: cluster
+  namespace: openshift-kueue-operator
+spec:
+  managementState: Managed
+  config:
+    integrations:
+      frameworks:
+      - BatchJob
+      - LeaderWorkerSet
+----

--- a/modules/kueue-modifying-monitoring-settings.adoc
+++ b/modules/kueue-modifying-monitoring-settings.adoc
@@ -1,0 +1,57 @@
+// Module included in the following assemblies:
+//
+// * ai_workloads/kueue/monitoring-pending-workloads.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="modifying-monitoring-settings_{context}"]
+= Modifying monitoring settings
+
+[role="_abstract"]
+Modify the monitoring settings according to your organization's requirements to ensure users can access and view the pending workloads in a timely and reliable manner.
+
+This procedure tells you how to modify the resource flow control for the {kueue-name} `VisibilityOnDemand` feature. Modifications directly impact the system's ability to handle concurrent requests for job visibility information.
+
+.Procedure
+. Edit the `PriorityLevelConfiguration` asset for `VisibilityOnDemand` on `Kueue` by running the following command:
++
+[source,terminal]
+----
+$ oc edit prioritylevelconfiguration kueue-visibility
+----
+
+. Modify the `nominalConcurrencyShares` field in the `PriorityLevelConfiguration` asset by setting the value for `kueue.openshift.io/allow-nominal-concurrency-shares-update`  to `true`. 
++
+The possible values you can specify for `nominalConcurrencyShares` are `0`, `2` (the default) until `5`. If you specify a value that is not acceptable (the value `1` or any value above `5`), the default value `2`, is enforced.
++
+See the following example:
++
+[source,yaml]
+----
+apiVersion: flowcontrol.apiserver.k8s.io/v1
+kind: PriorityLevelConfiguration
+metadata:
+  name: kueue-visibility
+  annotations:
+    kueue.openshift.io/allow-nominal-concurrency-shares-update: "false"
+spec:
+  limited:
+    borrowingLimitPercent: 0
+    lendablePercent: 90
+    limitResponse:
+      queuing:
+        handSize: 4
+        queueLengthLimit: 50
+        queues: 16
+      type: Queue
+    nominalConcurrencyShares: 2
+  type: Limited
+----
++
+The default value for `kueue.openshift.io/allow-nominal-concurrency-shares-update` is `false`. If you change the value of `nominalConcurrencyShares` to any value other than `2`, then you must first change the value of `kueue.openshift.io/allow-nominal-concurrency-shares-update` to `true`. Otherwise, the value you assign for `nominalConcurrencyShares` will not take effect.
+
+. Verify the value is kept by running the following command:
++
+[source,terminal]
+----
+$ oc get prioritylevelconfiguration kueue-visibility
+----

--- a/modules/kueue-monitoring-pending-workloads-on-demand.adoc
+++ b/modules/kueue-monitoring-pending-workloads-on-demand.adoc
@@ -1,0 +1,106 @@
+// Module included in the following assemblies:
+//
+// * ai_workloads/kueue/monitoring-pending-workloads.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="monitoring-pending-workloads-on-demand_{context}"]
+= Monitoring pending workloads on demand
+
+[role="_abstract"]
+To test the monitoring of pending workloads, you must correctly configure both the `ClusterQueue` and the `LocalQueue` resources. After that, you can create jobs on that `LocalQueue`. Kueue manages the workload object created from the job so, when a job is submitted and saturates the `ClusterQueue`, its corresponding workloads can be seen in the list of pending workloads.
+
+.Prerequisites 
+
+* You have cluster administrator permissions.
+* The {kueue-name} Operator is installed on your cluster, and you have created a `Kueue` custom resource (CR).
+* You have installed the {oc-first}. 
+* The {oc-first} has communication with your cluster.
+
+The following procedure tells you how to install and test workload monitoring.
+
+.Procedure
+
+. Create the assets by running the following command:
++
+[source,terminal]
+----
+cat <<EOF| oc create -f -
+---
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: ResourceFlavor
+metadata:
+  name: "default-flavor"
+---
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: ClusterQueue
+metadata:
+  name: "cluster-queue"
+spec:
+  namespaceSelector: {} # match all.
+  resourceGroups:
+  - coveredResources: ["cpu", "memory"]
+    flavors:
+    - name: "default-flavor"
+      resources:
+      - name: "cpu"
+        nominalQuota: 9
+      - name: "memory"
+        nominalQuota: 36Gi
+---
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: LocalQueue
+metadata:
+  namespace: "default"
+  name: "user-queue"
+spec:
+  clusterQueue: "cluster-queue"
+---
+EOF
+----
+
+. Create the following file with the job manifest:
++
+[source,terminal]
+----
+cat >> job.yaml << EOF
+apiVersion: batch/v1
+kind: Job
+metadata:
+  generateName: sample-job-
+  namespace: default
+  labels:
+    kueue.x-k8s.io/queue-name: user-queue
+spec:
+  parallelism: 3
+  completions: 3
+  suspend: true
+  template:
+    spec:
+      containers:
+      - name: <example-job>
+        image: registry.k8s.io/e2e-test-images/agnhost:2.53
+        command: [ "/bin/sh" ]
+        args: [ "-c", "sleep 60" ]
+        resources:
+          requests:
+            cpu: "1"
+            memory: "200Mi"
+      restartPolicy: Never
+EOF
+----
+
+. Label the default namespace to be managed by Kueue by running the following command:
++
+[source,terminal]
+----
+$ oc label namespace default kueue.openshift.io/managed=true
+----
+
+. Create the six jobs by running the following command: 
++
+[source,terminal]
+----
+for i in {1..6}; do oc create -f job.yaml; done
+----
++
+In this example, three of the jobs saturate the `ClusterQueue` resource and the other three jobs should be pending.

--- a/modules/kueue-monitoring-pending-workloads-on-demand.adoc
+++ b/modules/kueue-monitoring-pending-workloads-on-demand.adoc
@@ -26,12 +26,12 @@ The following procedure tells you how to install and test workload monitoring.
 ----
 cat <<EOF| oc create -f -
 ---
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: ResourceFlavor
 metadata:
   name: "default-flavor"
 ---
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: ClusterQueue
 metadata:
   name: "cluster-queue"
@@ -47,7 +47,7 @@ spec:
       - name: "memory"
         nominalQuota: 36Gi
 ---
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: LocalQueue
 metadata:
   namespace: "default"

--- a/modules/kueue-providing-user-permissions.adoc
+++ b/modules/kueue-providing-user-permissions.adoc
@@ -1,0 +1,16 @@
+// Module included in the following assemblies:
+//
+// * ai_workloads/kueue/monitoring-pending-workloads.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="providing-user-permissions_{context}"]
+= Providing user permissions
+
+[role="_abstract"]
+You can configure role-based access control (RBAC) objects for the users of your {kueue-name} deployment. These objects determine which types of users can create which types of {kueue-name} objects.  
+
+You need to provide permissions to the users that require access to the specific APIs.
+
+* If the user needs access to the pending workloads from the `ClusterQueue` resource, a `ClusterRoleBinding` schema needs to be created referencing the ClusterRole `kueue-batch-admin-role`.
+
+* If the user needs access to the pending workloads from the `LocalQueue` resource, a `RoleBinding` schema needs to be created referencing the ClusterRole `kueue-batch-user-role`.

--- a/modules/kueue-release-notes-1.2.adoc
+++ b/modules/kueue-release-notes-1.2.adoc
@@ -1,0 +1,50 @@
+// Module included in the following assemblies:
+//
+// * ai_workloads/kueue/release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="release-notes-1.2_{context}"]
+= Release notes for {kueue-name} version 1.2
+
+[role="_abstract"]
+{kueue-name} version 1.2 is a generally available release that is supported on {product-title} versions 4.18 and later. {kueue-name} version 1.2 uses link:https://kueue.sigs.k8s.io/docs/overview/[Kueue] version 0.14.
+
+[id="release-notes-1.2-new-features_{context}"]
+== New features and enhancements
+
+Monitoring of pending workloads::
+{kueue-name} version 1.2 provides the `VisibilityOnDemand` feature to monitor the pipeline of pending jobs in the cluster queue and the local queue, and help users to estimate when their jobs will start. For more information, see link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.20/html/ai_workloads/red-hat-build-of-kueue#monitoring-pending-workloads-install-kueue[Monitoring pending workloads].
+
+[id="release-notes-1.2-fixed-issues_{context}"]
+== Fixed issues
+
+Custom resources are not deleted properly when you uninstall {kueue-name}::
+After you uninstall the {kueue-op} using the *Delete all operand instances for this operator* option in the {product-title} web console, {kueue-name} custom resources were attempted to be deleted. With this release, they are not considered for deletion.
++
+(link:https://issues.redhat.com/browse/OCPBUGS-62254[OCPBUGS-62254])
+
+Documentation error in previous versions of {kueue-name}::
+In link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.20/html/ai_workloads/red-hat-build-of-kueue#create-kueue-cr_install-kueue[Creating a Kueue custom resource], the optional workload types `Pod`, `Deployment`, `StatefulSet` were omitted. They are now included. 
++
+(link:https://issues.redhat.com/browse/OCPBUGS-62877[OCPBUGS-62877])
+
+{kueue-name} metrics were not being exposed to Prometheus from version 1.1::
+Prometheus was not scraping metrics from the Operator's controller, even though the ServiceMonitor and RBAC resources were successfully created as part of the Operator installation. As a result, none of the Kueue metrics were available in the cluster monitoring stack. 
++
+The metrics service added during the installation was configured with an incorrect port reference, causing Prometheus to fail in scraping metrics from the Kueue endpoint. The port name has been updated with the correct port name.
++
+(link:https://issues.redhat.com/browse/OCPBUGS-63441[OCPBUGS-63441])
+
+
+[id="release-notes-1.2-known-issues_{context}"]
+== Known issues
+
+Reconcile jobs only in opt-in namespaces::
+{product-title} allows reconciliation of `Job` resources that have the `kueue.x-k8s.io/queue-name` label, even if these resources are in namespaces which are not configured to opt in to being managed by {product-title}. This is inconsistent with the behavior for other core integrations like pods, deployments, and stateful sets, which are only reconciled if they are in namespaces which have been configured to opt in to being managed by {product-title} by adding the `kueue.openshift.io/managed=true`.
++
+(link:https://issues.redhat.com/browse/OCPBUGS-58205[OCPBUGS-58205])
+
+`Kueue` CR description reads as "Not available" in the {product-title} web console:: 
+After installing {kueue-name}, in the *Operator details* view, the description for the `Kueue` CR reads as "Not available". This issue does not affect or degrade the {kueue-name} Operator functionality. 
++
+(link:https://issues.redhat.com/browse/OCPBUGS-62185[OCPBUGS-62185])

--- a/modules/kueue-release-notes-1.3.1.adoc
+++ b/modules/kueue-release-notes-1.3.1.adoc
@@ -1,0 +1,18 @@
+// Module included in the following assemblies:
+//
+// * ai_workloads/kueue/release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="release-notes-1.3.1_{context}"]
+= Release notes for {kueue-name} version 1.3.1
+
+[role="_abstract"]
+{kueue-name} version 1.3.1 is a generally available release that is supported on {product-title} versions 4.18 and later. {kueue-name} version 1.3 uses link:https://kueue.sigs.k8s.io/docs/overview/[Kueue] version 0.16.5.
+
+[id="release-notes-1.3.1-fixed-issues_{context}"]
+== Fixed issues
+
+kueue.x-k8s.io/queue-name refers to a non-existent queue::
+Fixed a bug where referencing a non-existent `LocalQueue via kueue.x-k8s.io/queue-name` could cause a running pod to be terminated and permanently stuck with unremovable scheduling gates.
++
+(link:https://redhat.atlassian.net/browse/OCPBUGS-78789[OCPBUGS-78789])

--- a/modules/kueue-release-notes-1.3.adoc
+++ b/modules/kueue-release-notes-1.3.adoc
@@ -1,0 +1,54 @@
+// Module included in the following assemblies:
+//
+// * ai_workloads/kueue/release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="release-notes-1.3_{context}"]
+= Release notes for {kueue-name} version 1.3
+
+[role="_abstract"]
+{kueue-name} version 1.3 is a generally available release that is supported on {product-title} versions 4.18 and later. {kueue-name} version 1.3 uses link:https://kueue.sigs.k8s.io/docs/overview/[Kueue] version 0.16.
+
+[id="release-notes-1.3-new-features_{context}"]
+== New features and enhancements
+
+{lws-operator}::
+{kueue-name} version 1.3 provides for the integration of the {lws-operator} with {kueue-name} so you can leverage the {kueue-name} scheduling and resource management functionality when running LeaderWorkerSets. For more information, see xref:../../ai_workloads/kueue/integrating-lws.adoc#integrating-lws[Integrating the Leader Worker Set Operator].
+
+{js-operator}::
+{kueue-name} version 1.3 provides for the integration of the {js-operator} so you can use the {js-operator} to manage and run large-scale, coordinated workloads like high-performance computing (HPC) and AI training. For more information, see xref:../../ai_workloads/kueue/integrating-jobset.adoc#integrating-jobset[Integrating the JobSet Operator].
+
+Upstream progression of the {kueue-name} API to `v1beta2`::
+{kueue-name} version 1.3 provides the `v1beta2` version of the {kueue-name} API. This update continues the evolution of the {kueue-name} APIs with the ultimate goal of graduating the API to `v1`. 
++
+All new Kueue objects created after the upgrade will be stored using the `v1beta2` version. The earlier version of the API, `v1beta1` is deprecated. Objects can still be created using `v1beta1`, if necessary. In these cases, a deprecation message is shown.
++
+However, existing objects are only auto-converted to the new storage version by Kubernetes during a write request. This means that {kueue-name} API objects that rarely receive updates such as Topologies, ResourceFlavors, or long-running Workloads could remain in the older `v1beta1` format indefinitely.
+
+[id="release-notes-1.3-fixed-issues_{context}"]
+== Fixed issues
+
+Reconcile jobs only in opt-in namespaces::
+{product-title} allowed reconciliation of `Job` resources that have the `kueue.x-k8s.io/queue-name` label, even if these resources are in namespaces that are not configured to opt in to being managed by {product-title}. With this release, there is ongoing upstream work that updates this behavior so that Jobs with queue-name labels are also ignored unless their namespace matches the `managedJobsNamespaceSelector`. This change makes {kueue-name} behavior consistent across all integrations.
++
+(link:https://issues.redhat.com/browse/OCPBUGS-58205[OCPBUGS-58205])
+
+`Kueue` CR description reads as "Not available" in the {product-title} web console:: 
+After installing {kueue-name}, in the *Operator details* view, the description for the `Kueue` CR read as "Not available". This issue did not affect or degrade the {kueue-name} Operator functionality. With this release, the "Not available" message no longer displays.
++
+(link:https://issues.redhat.com/browse/OCPBUGS-62185[OCPBUGS-62185])
+
+LeaderWorkerSet and Jobset validation errors::
+Currently, the {lws-operator} and {js-operator} are only validated after the Operand CR is updated and the full Kueue hierarchy (ResourceFlavor, ClusterQueue, and LocalQueue) is established. Any configuration errors appear only when applying a LeaderWorkerSet or JobSet template.
++
+(link:https://issues.redhat.com/browse/OCPBUGS-74210[OCPBUGS-74210])
+
+[id="release-notes-1.3-known-issues_{context}"]
+== Known issues
+
+LeaderWorkerSet pods update sequentially by default::
+If you have integrated {lws-operator} with your {kueue-name} installation and you are using the rollout strategy option for updating LeaderWorkerSet pods, be aware that the `MaxUnavailable` feature gate in {product-title} is disabled by default. 
++
+When any change is made to LeaderWorkerSet pods, a rolling update is triggered. This action gradually replaces the old pods of a deployment with new ones, keeping as many pods alive as possible to avoid downtime. If `MaxUnavailable` is disabled, which is the {product-title} default setting, the pods are updated one at a time.
++
+If you want to run updates in parallel instead of running them sequentially, `MaxUnavailable` feature gate must be enabled. For more information, see xref:../../nodes/clusters/nodes-cluster-enabling-features.adoc#nodes-cluster-enabling-features-install_nodes-cluster-enabling[Enabling feature sets at installation] and link:https://lws.sigs.k8s.io/docs/concepts/rollout-strategy/[Rollout Strategy]. 

--- a/modules/kueue-running-jobset.adoc
+++ b/modules/kueue-running-jobset.adoc
@@ -1,0 +1,93 @@
+// Module included in the following assemblies:
+//
+// * ai_workloads/kueue/integrating-jobset.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="kueue-running-jobset_{context}"]
+= Running {js-operator} with {kueue-name}
+
+[role="_abstract"]
+You can add and run {js-operator} to your existing frameworks.
+
+.Prerequisites
+
+* {kueue-name} using the {kueue-op} is installed.
+* {js-operator} is installed.
+* The {cert-manager-operator} is installed.
+* The `namespace` where `JobSet` will be created is labeled using `kueue.openshift.io/managed=true`.
+* Ensure that the following objects have been configured:
+** `ClusterQueue`
+** `ResourceFlavor`
+** `LocalQueue`
+** `Namespace`
+
+.Procedure
+
+. Create a file named `jobset.yaml`.
++
+.Example of a `JobSet`
+[source,yaml]
+----
+apiVersion: jobset.x-k8s.io/v1alpha2
+kind: JobSet
+metadata:
+  name: jobset
+  namespace: my-namespace
+spec:
+  replicatedJobs:
+    - name: workers
+      replicas: 1
+      template:
+        spec:
+          parallelism: 3
+          completions: 3
+          backoffLimit: 1
+          template:
+            spec:
+              containers:
+                - name: sleep
+                  image: busybox
+                  resources:
+                    requests:
+                      cpu: 200m
+                      memory: "200Mi"
+                  command:
+                    - sleep
+                  args:
+                    - 220s
+    - name: driver
+      template:
+        spec:
+          parallelism: 1
+          completions: 1
+          backoffLimit: 0
+          template:
+            spec:
+              containers:
+                - name: sleep
+                  image: busybox
+                  resources:
+                    requests:
+                      cpu: 200m
+                      memory: "200Mi"
+                  command:
+                    - sleep
+                  args:
+                    - 220s
+----
+
+. Specify the target local queue in the `metadata.labels` section of the `JobSet` configuration.
++
+[source,yaml]
+----
+metadata:
+  labels:
+    kueue.x-k8s.io/queue-name: <local-queue-name>
+----
+
+. Apply the JobSet configuration by running the following command: 
++
+[source,terminal]
+----
+$ oc apply -f jobset.yaml
+----

--- a/modules/kueue-running-lws.adoc
+++ b/modules/kueue-running-lws.adoc
@@ -1,0 +1,83 @@
+// Module included in the following assemblies:
+//
+// * ai_workloads/kueue/integrating-leader-worker-set.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="kueue-running-lws_{context}"]
+= Running {lws-operator} with {kueue-name}
+
+[role="_abstract"]
+You can add and run the {lws-operator} to your existing frameworks.
+
+.Prerequisites
+
+* {kueue-name} using the {kueue-op} is installed.
+* {lws-operator} and Operand are installed.
+* The {cert-manager-operator} is installed.
+* The `namespace` where `LeaderWorkerSet` will be created is labeled using `kueue.openshift.io/managed=true`.
+* Ensure that the following objects have been configured:
+** `ClusterQueue`
+** `ResourceFlavor`
+** `LocalQueue`
+** `Namespace`
+
+.Procedure
+
+. Create a file named `leaderworkerset.yaml`.
++
+.Example of a `LeaderWorkerSet`
+[source,yaml]
+----
+apiVersion: leaderworkerset.x-k8s.io/v1
+kind: LeaderWorkerSet
+metadata:
+  generation: 1
+  name: my-lws
+  namespace: my-namespace
+spec:
+  leaderWorkerTemplate:
+    leaderTemplate:
+      metadata: {}
+      spec:
+        containers:
+        - image: nginxinc/nginx-unprivileged:1.27
+          name: leader
+          resources: {}
+    restartPolicy: RecreateGroupOnPodRestart
+    size: 3
+    workerTemplate:
+      metadata: {}
+      spec:
+        containers:
+        - image: nginxinc/nginx-unprivileged:1.27
+          name: worker
+          ports:
+          - containerPort: 8080
+            protocol: TCP
+          resources: {}
+  networkConfig:
+    subdomainPolicy: Shared
+  replicas: 2
+  rolloutStrategy:
+    rollingUpdateConfiguration:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
+  startupPolicy: LeaderCreated
+----
+
+. Specify the target local queue in the `metadata.labels` section of the `LeaderWorkerSet` configuration.
++
+[source,yaml]
+----
+metadata:
+  labels:
+    kueue.x-k8s.io/queue-name: user-queue
+----
+
+. Apply the leader worker set configuration by running the following command: 
++
+[source,terminal]
+----
+$ oc apply -f leaderworkerset.yaml
+----

--- a/modules/kueue-viewing-pending-workloads-clusterqueue.adoc
+++ b/modules/kueue-viewing-pending-workloads-clusterqueue.adoc
@@ -1,0 +1,103 @@
+// Module included in the following assemblies:
+//
+// * ai_workloads/kueue/monitoring-pending-workloads.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="viewing-pending-workloads-clusterqueue_{context}"]
+= Viewing pending workloads in ClusterQueue
+
+[role="_abstract"]
+To view all pending workloads at the cluster level, administrators can use the `ClusterQueue` object visibility endpoint of Kueue's visibility API. This endpoint returns a list of all workloads currently waiting for admission by that `ClusterQueue` resource.
+
+.Procedure
+
+. To view pending workloads in `ClusterQueue` run the following command:
++
+[source,terminal]
+----
+$ oc get --raw "/apis/visibility.kueue.x-k8s.io/v1beta1/clusterqueues/cluster-queue/pendingworkloads"
+----
++
+.Example output
+[source,yaml]
+----
+{
+  "kind": "PendingWorkloadsSummary",
+  "apiVersion": "visibility.kueue.x-k8s.io/v1beta1",
+  "metadata": {
+    "creationTimestamp": null
+  },
+  "items": [
+    {
+      "metadata": {
+        "name": "job-sample-job-jrjfr-8d56e",
+        "namespace": "default",
+        "creationTimestamp": "2023-12-05T15:42:03Z",
+        "ownerReferences": [
+          {
+            "apiVersion": "batch/v1",
+            "kind": "Job",
+            "name": "sample-job-jrjfr",
+            "uid": "5863cf0e-b0e7-43bf-a445-f41fa1abedfa"
+          }
+        ]
+      },
+      "priority": 0,
+      "localQueueName": "user-queue",
+      "positionInClusterQueue": 0,
+      "positionInLocalQueue": 0
+    },
+    {
+      "metadata": {
+        "name": "job-sample-job-jg9dw-5f1a3",
+        "namespace": "default",
+        "creationTimestamp": "2023-12-05T15:42:03Z",
+        "ownerReferences": [
+          {
+            "apiVersion": "batch/v1",
+            "kind": "Job",
+            "name": "sample-job-jg9dw",
+            "uid": "fd5d1796-f61d-402f-a4c8-cbda646e2676"
+          }
+        ]
+      },
+      "priority": 0,
+      "localQueueName": "user-queue",
+      "positionInClusterQueue": 1,
+      "positionInLocalQueue": 1
+    },
+    {
+      "metadata": {
+        "name": "job-sample-job-t9b8m-4e770",
+        "namespace": "default",
+        "creationTimestamp": "2023-12-05T15:42:03Z",
+        "ownerReferences": [
+          {
+            "apiVersion": "batch/v1",
+            "kind": "Job",
+            "name": "sample-job-t9b8m",
+            "uid": "64c26c73-6334-4d13-a1a8-38d99196baa5"
+          }
+        ]
+      },
+      "priority": 0,
+      "localQueueName": "user-queue",
+      "positionInClusterQueue": 2,
+      "positionInLocalQueue": 2
+    }
+  ]
+}
+----
++
+You can pass the following optional query parameters:
++
+`limit <integer>`:: 1000 is the default. Specifies the maximum number of pending workloads that should be fetched.
++
+`offset <integer>`:: 0 is the default. Specifies the position of the first pending workload that should be fetched, starting from 0.
+
+. To view only one pending workload starting from position 0 in `ClusterQueue` run the following command:
++
+[source,terminal]
+----
+$ oc get --raw "/apis/visibility.kueue.x-k8s.io/v1beta1/clusterqueues/cluster-queue/pendingworkloads?limit=1&offset=0"
+----

--- a/modules/kueue-viewing-pending-workloads-localqueue.adoc
+++ b/modules/kueue-viewing-pending-workloads-localqueue.adoc
@@ -1,0 +1,103 @@
+// Module included in the following assemblies:
+//
+// * ai_workloads/kueue/monitoring-pending-workloads.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="viewing-pending-workloads-localqueue_{context}"]
+= Viewing pending workloads in LocalQueue 
+
+[role="_abstract"]
+To view the pending workloads submitted by a specific tenant within their namespace, users can query the `LocalQueue` resource visibility endpoint of Kueue's visibility API. This provides an ordered list of their jobs waiting in that queue. 
+
+.Procedure
+
+. To view pending workloads in `LocalQueue` run the following command:
++
+[source,terminal]
+----
+$ oc get --raw /apis/visibility.kueue.x-k8s.io/v1beta1/namespaces/default/localqueues/user-queue/pendingworkloads
+----
++
+.Example output
+[source,yaml]
+----
+{
+  "kind": "PendingWorkloadsSummary",
+  "apiVersion": "visibility.kueue.x-k8s.io/v1beta1",
+  "metadata": {
+    "creationTimestamp": null
+  },
+  "items": [
+    {
+      "metadata": {
+        "name": "job-sample-job-jrjfr-8d56e",
+        "namespace": "default",
+        "creationTimestamp": "2023-12-05T15:42:03Z",
+        "ownerReferences": [
+          {
+            "apiVersion": "batch/v1",
+            "kind": "Job",
+            "name": "sample-job-jrjfr",
+            "uid": "5863cf0e-b0e7-43bf-a445-f41fa1abedfa"
+          }
+        ]
+      },
+      "priority": 0,
+      "localQueueName": "user-queue",
+      "positionInClusterQueue": 0,
+      "positionInLocalQueue": 0
+    },
+    {
+      "metadata": {
+        "name": "job-sample-job-jg9dw-5f1a3",
+        "namespace": "default",
+        "creationTimestamp": "2023-12-05T15:42:03Z",
+        "ownerReferences": [
+          {
+            "apiVersion": "batch/v1",
+            "kind": "Job",
+            "name": "sample-job-jg9dw",
+            "uid": "fd5d1796-f61d-402f-a4c8-cbda646e2676"
+          }
+        ]
+      },
+      "priority": 0,
+      "localQueueName": "user-queue",
+      "positionInClusterQueue": 1,
+      "positionInLocalQueue": 1
+    },
+    {
+      "metadata": {
+        "name": "job-sample-job-t9b8m-4e770",
+        "namespace": "default",
+        "creationTimestamp": "2023-12-05T15:42:03Z",
+        "ownerReferences": [
+          {
+            "apiVersion": "batch/v1",
+            "kind": "Job",
+            "name": "sample-job-t9b8m",
+            "uid": "64c26c73-6334-4d13-a1a8-38d99196baa5"
+          }
+        ]
+      },
+      "priority": 0,
+      "localQueueName": "user-queue",
+      "positionInClusterQueue": 2,
+      "positionInLocalQueue": 2
+    }
+  ]
+}
+----
++
+You can pass the following optional query parameters:
++
+`limit <integer>`:: 1000 is the default. Specifies the maximum number of pending workloads that should be fetched.
++
+`offset <integer>`:: 0 is the default. Specifies the position of the first pending workload that should be fetched, starting from 0.
+
+. To view only one pending workload starting from position 0 in LocalQueue run the following command:
++
+[source,terminal]
+----
+$ oc get --raw "/apis/visibility.kueue.x-k8s.io/v1beta1/namespaces/default/localqueues/user-queue/pendingworkloads?limit=1&offset=0"
+----

--- a/modules/kueue-viewing-pending-workloads-localqueue.adoc
+++ b/modules/kueue-viewing-pending-workloads-localqueue.adoc
@@ -15,7 +15,7 @@ To view the pending workloads submitted by a specific tenant within their namesp
 +
 [source,terminal]
 ----
-$ oc get --raw /apis/visibility.kueue.x-k8s.io/v1beta1/namespaces/default/localqueues/user-queue/pendingworkloads
+$ oc get --raw /apis/visibility.kueue.x-k8s.io/v1beta2/namespaces/default/localqueues/user-queue/pendingworkloads
 ----
 +
 .Example output
@@ -23,7 +23,7 @@ $ oc get --raw /apis/visibility.kueue.x-k8s.io/v1beta1/namespaces/default/localq
 ----
 {
   "kind": "PendingWorkloadsSummary",
-  "apiVersion": "visibility.kueue.x-k8s.io/v1beta1",
+  "apiVersion": "visibility.kueue.x-k8s.io/v1beta2",
   "metadata": {
     "creationTimestamp": null
   },
@@ -99,5 +99,5 @@ You can pass the following optional query parameters:
 +
 [source,terminal]
 ----
-$ oc get --raw "/apis/visibility.kueue.x-k8s.io/v1beta1/namespaces/default/localqueues/user-queue/pendingworkloads?limit=1&offset=0"
+$ oc get --raw "/apis/visibility.kueue.x-k8s.io/v1beta2/namespaces/default/localqueues/user-queue/pendingworkloads?limit=1&offset=0"
 ----


### PR DESCRIPTION
Manual cherrypick of https://github.com/openshift/openshift-docs/pull/109782