### PR TITLE
OSDOCS-19045 adding jobset to additional release notes

### DIFF
--- a/release_notes/addtl-release-notes.adoc
+++ b/release_notes/addtl-release-notes.adoc
@@ -43,6 +43,9 @@ xref:../security/external_secrets_operator/external-secrets-operator-release-not
 F::
 xref:../security/file_integrity_operator/file-integrity-operator-release-notes.adoc#file-integrity-operator-release-notes-v0[File Integrity Operator]
 
+J::
+xref:../ai_workloads/jobset_operator/jobset-release-notes.adoc#js-release-notes[{js-operator}]
+
 K::
 xref:../nodes/scheduling/descheduler/nodes-descheduler-release-notes.adoc#nodes-descheduler-release-notes[{descheduler-operator}]
 +


### PR DESCRIPTION

Version(s): 4.22 
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [OSDOCS-19045](https://redhat.atlassian.net/browse/OSDOCS-19045)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://109891--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/addtl-release-notes.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review: NA. no new content.
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: Adding a link to the JobSet release notes to the additional release notes file.
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
