### PR TITLE
OSDOCS-19045 Adding Jobset to additional release notes in 4.21.

### DIFF
--- a/release_notes/addtl-release-notes.adoc
+++ b/release_notes/addtl-release-notes.adoc
@@ -46,6 +46,9 @@ xref:../security/file_integrity_operator/file-integrity-operator-release-notes.a
 H::
 xref:../hosted_control_planes/hcp-release-notes.adoc#hcp-release-notes[{hcp-capital}]
 
+J::
+xref:../ai_workloads/jobset_operator/jobset-release-notes.adoc#js-release-notes[{js-operator}]
+
 K::
 xref:../nodes/scheduling/descheduler/nodes-descheduler-release-notes.adoc#nodes-descheduler-release-notes[{descheduler-operator}]
 +


### PR DESCRIPTION


Version(s):4.21
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [OSDOCS-19045](https://redhat.atlassian.net/browse/OSDOCS-19045)

Link to docs preview: https://109892--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/addtl-release-notes.html

QE review: NA. no new content.

Additional information: Adding a link to the JobSet release notes to the additional release notes file.