### PR TITLE
OSDOCS-19045-19 Adding jobset to additional release notes in 4.19

### DIFF
--- a/release_notes/addtl-release-notes.adoc
+++ b/release_notes/addtl-release-notes.adoc
@@ -44,6 +44,9 @@ xref:../security/file_integrity_operator/file-integrity-operator-release-notes.a
 H::
 xref:../hosted_control_planes/hosted-control-planes-release-notes.adoc#hosted-control-planes-release-notes[{hcp-capital}]
 
+J::
+xref:../ai_workloads/jobset_operator/jobset-release-notes.adoc#js-release-notes[{js-operator}]
+
 K::
 xref:../nodes/scheduling/descheduler/nodes-descheduler-release-notes.adoc#nodes-descheduler-release-notes[{descheduler-operator}]
 +


### PR DESCRIPTION

Version(s):4.19
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [OSDOCS-19045](https://redhat.atlassian.net/browse/OSDOCS-19045)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://109894--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/addtl-release-notes.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review: NA. no new content.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: Adding a link to the JobSet release notes to the additional release notes file.
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
