### PR TITLE
DOCPLAN-156: Vale / CQA fixes

### DIFF
--- a/modules/virt-configuring-vm-eviction-strategy-cli.adoc
+++ b/modules/virt-configuring-vm-eviction-strategy-cli.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * virt/live_migration/virt-configuring-live-migration.adoc
+// * virt/nodes/virt-node-maintenance.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="virt-configuring-vm-eviction-strategy-cli_{context}"]
@@ -40,10 +40,10 @@ metadata:
 spec:
   template:
     spec:
-      evictionStrategy: LiveMigrateIfPossible <1>
+      evictionStrategy: LiveMigrateIfPossible
 # ...
 ----
-<1> Specify the eviction strategy. The default value is `LiveMigrate`.
+** `spec.template.spec.evictionStrategy` defines the eviction strategy. The default value is `LiveMigrate`.
 
 . Restart the VM to apply the changes:
 +

--- a/modules/virt-maintaining-bare-metal-nodes.adoc
+++ b/modules/virt-maintaining-bare-metal-nodes.adoc
@@ -4,12 +4,11 @@
 
 :_mod-docs-content-type: CONCEPT
 [id="virt-maintaining-bare-metal-nodes_{context}"]
-= Maintaining bare metal nodes
+= Maintaining bare-metal nodes
 
 [role="_abstract"]
 When you deploy {product-title} on bare metal infrastructure, there are additional considerations that must be taken into account compared to deploying on cloud infrastructure.
 
-Unlike in cloud environments where the cluster nodes are considered ephemeral, re-provisioning a bare metal node requires significantly more time and effort for maintenance tasks.
+Unlike in cloud environments where the cluster nodes are considered ephemeral, re-provisioning a bare-metal node requires significantly more time and effort for maintenance tasks.
 
-When a bare metal node fails, for example, if a fatal kernel error happens or a NIC card hardware failure occurs, workloads on the failed node need to be restarted elsewhere else on the cluster while the problem node is repaired or replaced. Node maintenance mode allows cluster administrators to gracefully power down nodes, moving workloads to other parts of the cluster and ensuring workloads do not get interrupted. Detailed progress and node status details are provided during maintenance.
-
+When a bare-metal node fails, for example, if a an unrecoverable kernel error happens or a NIC card hardware failure occurs, workloads on the failed node need to be restarted elsewhere else on the cluster while the problem node is repaired or replaced. Node maintenance mode allows cluster administrators to gracefully power down nodes, moving workloads to other parts of the cluster and ensuring workloads do not get interrupted. Detailed progress and node status details are provided during maintenance.

--- a/virt/live_migration/virt-configuring-live-migration.adoc
+++ b/virt/live_migration/virt-configuring-live-migration.adoc
@@ -23,4 +23,3 @@ include::modules/virt-configuring-a-live-migration-policy.adoc[leveloffset=+1]
 [id="additional-resources_virt-configuring-live-migration-heavy"]
 == Additional resources
 * xref:../../virt/vm_networking/virt-dedicated-network-live-migration.adoc#virt-configuring-secondary-network-vm-live-migration_virt-dedicated-network-live-migration[Configuring a dedicated network for live migration]
-

--- a/virt/nodes/virt-activating-ksm.adoc
+++ b/virt/nodes/virt-activating-ksm.adoc
@@ -6,6 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 {VirtProductName} can activate kernel samepage merging (KSM) when nodes are overloaded. KSM deduplicates identical data found in the memory pages of virtual machines (VMs). If you have very similar VMs, KSM can make it possible to schedule more VMs on a single node.
 
 [IMPORTANT]
@@ -29,4 +30,4 @@ include::modules/virt-configure-ksm-cli.adoc[leveloffset=+1]
 == Additional resources
 * xref:../../virt/managing_vms/advanced_vm_management/virt-specifying-nodes-for-vms.adoc#virt-specifying-nodes-for-vms[Specifying nodes for virtual machines]
 * xref:../../nodes/scheduling/nodes-scheduler-node-selectors.adoc#nodes-scheduler-node-selectors[Placing pods on specific nodes using node selectors]
-* link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html-single/configuring_and_managing_virtualization/index#proc_managing-ksm_optimizing-virtual-machine-cpu-performance[Managing kernel samepage merging] in the {op-system-base-full} documentation
+* link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html-single/configuring_and_managing_virtualization/index#proc_managing-ksm_optimizing-virtual-machine-cpu-performance[Managing kernel samepage merging]

--- a/virt/nodes/virt-managing-node-labeling-obsolete-cpu-models.adoc
+++ b/virt/nodes/virt-managing-node-labeling-obsolete-cpu-models.adoc
@@ -6,6 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 You can schedule a virtual machine (VM) on a node as long as the VM CPU model and policy are supported by the node.
 
 include::modules/virt-about-node-labeling-obsolete-cpu-models.adoc[leveloffset=+1]

--- a/virt/nodes/virt-preventing-node-reconciliation.adoc
+++ b/virt/nodes/virt-preventing-node-reconciliation.adoc
@@ -6,6 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 Use `skip-node` annotation to prevent the `node-labeller` from reconciling a node.
 
 include::modules/virt-using-skip-node.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s):
4.20+

Issue:
https://redhat.atlassian.net/browse/DOCPLAN-156

Link to docs preview:
- https://109898--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/nodes/virt-node-maintenance#virt-configuring-vm-eviction-strategy-cli_virt-node-maintenance
- https://109898--ocpdocs-pr.netlify.app/openshift-enterprise/atest/virt/nodes/virt-node-maintenance#virt-maintaining-bare-metal-nodes_virt-node-maintenance
- https://109898--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/nodes/virt-activating-ksm#additional-resources_virt-activating-ksm

QE review:
N/A
