### PR TITLE
[enterprise-4.21] OSDOCS-18964 - Fix syntax in ROSA Support

### DIFF
--- a/support/gathering-cluster-data.adoc
+++ b/support/gathering-cluster-data.adoc
@@ -65,7 +65,7 @@ endif::openshift-origin[]
 include::modules/gathering-data-specific-features.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
-== Additional resources
+.Additional resources
 
 ifndef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 * xref:../nodes/cma/nodes-cma-autoscaling-custom.adoc#nodes-cma-autoscaling-custom-gather[Gathering debugging data for the Custom Metrics Autoscaler]
@@ -102,7 +102,7 @@ include::modules/support-log-gather-install-cli.adoc[leveloffset=+2]
 include::modules/support-log-gather-configure-cli.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
-== Additional resources
+.Additional resources
 
 * xref:../authentication/understanding-and-creating-service-accounts.adoc#understanding-and-creating-service-accounts[Understanding and creating service accounts]
 

--- a/support/remote_health_monitoring/about-remote-health-monitoring.adoc
+++ b/support/remote_health_monitoring/about-remote-health-monitoring.adoc
@@ -46,7 +46,7 @@ endif::[]
 include::modules/telemetry-about-telemetry.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
-== Additional resources
+.Additional resources
 
 ifndef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 * xref:../../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[{product-title} update documentation]
@@ -70,7 +70,7 @@ include::modules/telemetry-user-telemetry.adoc[leveloffset=+2]
 endif::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 
 [role="_additional-resources"]
-== Additional resources
+.Additional resources
 
 * xref:../../support/remote_health_monitoring/showing-data-collected-by-remote-health-monitoring.adoc#showing-data-collected-from-the-cluster_showing-data-collected-by-remote-health-monitoring[Showing data collected by Telemetry]
 * link:https://github.com/openshift/cluster-monitoring-operator/blob/master/manifests/0000_50_cluster-monitoring-operator_04-config.yaml[Upstream cluster-monitoring-operator source code]
@@ -83,7 +83,7 @@ include::modules/insights-operator-about.adoc[leveloffset=+1]
 
 ifndef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 [role="_additional-resources"]
-== Additional resources
+.Additional resources
 
 * xref:../../support/remote_health_monitoring/remote-health-reporting.adoc#remote-health-reporting[Remote health reporting]
 endif::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
@@ -91,7 +91,7 @@ endif::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 include::modules/insights-operator-what-information-is-collected.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
-== Additional resources
+.Additional resources
 
 ifndef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 * xref:../../support/remote_health_monitoring/showing-data-collected-by-remote-health-monitoring.adoc#insights-operator-showing-data-collected-from-the-cluster_showing-data-collected-by-remote-health-monitoring[Showing data collected by the {insights-operator}]
@@ -108,7 +108,7 @@ include::modules/understanding-telemetry-and-insights-operator-data-flow.adoc[le
 // TODO: Add the first xref to ROSA HCP when the monitoring book is migrated.
 ifndef::openshift-rosa-hcp[]
 [role="_additional-resources"]
-== Additional resources
+.Additional resources
 
 ifdef::openshift-dedicated,openshift-rosa[]
 * xref:../../observability/monitoring/about-ocp-monitoring/about-ocp-monitoring.adoc#about-ocp-monitoring[About {product-title} monitoring]

--- a/support/remote_health_monitoring/using-insights-operator.adoc
+++ b/support/remote_health_monitoring/using-insights-operator.adoc
@@ -14,7 +14,7 @@ toc::[]
 The {insights-operator} periodically gathers configuration and component failure status and, by default, reports that data every two hours to Red{nbsp}Hat. This information enables Red{nbsp}Hat to assess configuration and deeper failure data than is reported through Telemetry. Users of {product-title} can display the report in the {insights-advisor-url} service on {hybrid-console}.
 
 [role="_additional-resources"]
-== Additional resources
+.Additional resources
 
 ifndef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 * xref:../../support/remote_health_monitoring/remote-health-reporting.adoc#remote-health-reporting[Remote health reporting]
@@ -94,7 +94,7 @@ include::modules/running-insights-operator-gather-web-console.adoc[leveloffset=+
 include::modules/running-insights-operator-gather-cli.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
-== Additional resources
+.Additional resources
 * link:https://github.com/openshift/insights-operator/blob/master/docs/gathered-data.md[{insights-operator} Gathered Data GitHub repository]
 
 endif::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]

--- a/support/troubleshooting/rosa-troubleshooting-iam-resources.adoc
+++ b/support/troubleshooting/rosa-troubleshooting-iam-resources.adoc
@@ -15,14 +15,14 @@ include::modules/rosa-sts-ocm-role-creation.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
 [id="additional-resources_ocm-role-creation_{context}"]
-== Additional resources
+.Additional resources
 * xref:../../rosa_architecture/rosa-sts-about-iam-resources.adoc#rosa-sts-account-wide-roles-and-policies-creation-methods_rosa-sts-about-iam-resources[Methods of account-wide role creation]
 
 include::modules/rosa-sts-user-role-creation.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
 [id="additional-resources_user-role-creation_{context}"]
-== Additional resources
+.Additional resources
 * xref:../../rosa_architecture/rosa-sts-about-iam-resources.adoc#rosa-sts-account-wide-roles-and-policies-creation-methods_rosa-sts-about-iam-resources[Methods of account-wide role creation]
 
 include::modules/rosa-sts-aws-requirements-creating-association.adoc[leveloffset=+2]


### PR DESCRIPTION
(cherry picked from commit cbc654b2b8a81b634e3f860b59c3a2abda5b26dd)

[OSDOCS-18964](https://redhat.atlassian.net/browse/OSDOCS-18964) - Fix syntax in ROSA Support

Version(s):
4.21

Issue:
https://redhat.atlassian.net/browse/OSDOCS-18964

Link to docs preview:
The rendering bug is no longer present:
- [About remote health monitoring](https://109912--ocpdocs-pr.netlify.app/openshift-enterprise/latest/support/remote_health_monitoring/about-remote-health-monitoring.html)
- [Using the Insights Operator](https://109912--ocpdocs-pr.netlify.app/openshift-enterprise/latest/support/remote_health_monitoring/using-insights-operator.html)
- [Gathering data about your cluster](https://109912--ocpdocs-pr.netlify.app/openshift-enterprise/latest/support/gathering-cluster-data.html)

QE review:
N/A

Additional information:

