### PR TITLE
OADP-7690 - add note about updating default bsl

### DIFF
--- a/backup_and_restore/application_backup_and_restore/installing/configuring-oadp-multiple-bsl.adoc
+++ b/backup_and_restore/application_backup_and_restore/installing/configuring-oadp-multiple-bsl.adoc
@@ -16,6 +16,8 @@ Configure multiple backup storage locations (BSLs) in the Data Protection Applic
 // module for configuring the DPA with multiple BSLs.
 include::modules/oadp-configuring-dpa-multiple-bsl.adoc[leveloffset=+1]
 
+include::modules/oadp-changing-default-bsl.adoc[leveloffset=+1]
+
 // module for multiple BSL use case.
 include::modules/oadp-multiple-bsl-use-case.adoc[leveloffset=+1]
 

--- a/backup_and_restore/application_backup_and_restore/installing/installing-oadp-aws.adoc
+++ b/backup_and_restore/application_backup_and_restore/installing/installing-oadp-aws.adoc
@@ -10,11 +10,11 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 [role="_abstract"]
-You install the OpenShift API for Data Protection (OADP) with Amazon Web Services (AWS) S3 compatible storage by installing the OADP Operator. The Operator installs link:https://{velero-domain}/docs/v{velero-version}/[Velero {velero-version}].
+Install the {oadp-first} with Amazon Web Services (AWS) S3 compatible storage by installing the {oadp-short} Operator. The Operator installs Velero {velero-version}.
 
-You configure AWS for Velero, create a default `Secret`, and then install the Data Protection Application. For more details, see xref:../../../backup_and_restore/application_backup_and_restore/installing/oadp-installing-operator.adoc#oadp-installing-operator-doc[Installing the OADP Operator].
+You configure AWS for Velero, create a default `Secret`, and then install the Data Protection Application. For more details, see _Installing the OADP Operator_.
 
-To install the OADP Operator in a restricted network environment, you must first disable the default software catalog sources and mirror the Operator catalog. See xref:../../../disconnected/using-olm.adoc#olm-restricted-networks[Using Operator Lifecycle Manager in disconnected environments] for details.
+To install the OADP Operator in a restricted network environment, you must first disable the default software catalog sources and mirror the Operator catalog. See _Using Operator Lifecycle Manager in disconnected environments_ for details.
 
 include::modules/oadp-s3-and-gov-cloud.adoc[leveloffset=+1]
 
@@ -31,6 +31,8 @@ include::modules/oadp-ssec-encrypted-backups.adoc[leveloffset=+2]
 include::modules/oadp-ssec-encrypted-backups-velero.adoc[leveloffset=+3]
 
 include::modules/oadp-installing-dpa-1-3.adoc[leveloffset=+1]
+
+include::modules/oadp-changing-default-bsl.adoc[leveloffset=+1]
 
 include::modules/oadp-setting-resource-limits-and-requests.adoc[leveloffset=+2]
 
@@ -67,6 +69,12 @@ include::modules/oadp-about-disable-node-agent-dpa.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources
+
+* xref:../../../backup_and_restore/application_backup_and_restore/installing/oadp-installing-operator.adoc#oadp-installing-operator-doc[Installing the OADP Operator]
+
+* link:https://{velero-domain}/docs/v{velero-version}/[Velero {velero-version}]
+
+* xref:../../../disconnected/using-olm.adoc#olm-restricted-networks[Using Operator Lifecycle Manager in disconnected environments]
 
 * xref:../../../backup_and_restore/application_backup_and_restore/installing/installing-oadp-kubevirt.adoc#oadp-installing-dpa_installing-oadp-kubevirt[Installing the Data Protection Application with the `kubevirt` and `openshift` plugins]
 

--- a/modules/oadp-changing-default-bsl.adoc
+++ b/modules/oadp-changing-default-bsl.adoc
@@ -1,0 +1,48 @@
+// Module included in the following assemblies:
+//
+// * backup_and_restore/application_backup_and_restore/installing/configuring-oadp-multiple-bsl.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="oadp-changing-default-bsl_{context}"]
+= Changing the default backup storage location in a DPA
+
+[role="_abstract"]
+Understand why the `default` field of the `backupLocations` object in a `DataProtectionApplication` (DPA) does not change the default `BackupStorageLocation` (BSL) when you configure multiple backup locations. This helps you to identify the root cause and apply the correct workaround.
+
+When a DPA includes multiple backup locations, updating the `default` field to change the default BSL does not take effect. After you set `default: true` on a different BSL and set `default: false` on the previously default BSL, the `oc get bsl` command shows that the original BSL remains the default.
+
+Root cause::
+The {oadp-short} Operator sets the `default` field on a BSL resource only during initial creation of the DPA. On subsequent reconciliations, the Operator preserves the default BSL.
++
+This behavior is intentional. Velero independently manages the `default` field on BSL resources. If the {oadp-short} Operator overwrites this field on every reconciliation, it conflicts with Velero, causing a race condition where both controllers compete over the value. 
++
+To prevent this conflict, the Operator checks whether the BSL already exists. If it exists, the Operator preserves the current `default` value instead of applying the value from the DPA specification.
+
+
+Workaround::
+To change the default BSL, delete and re-create the DPA. Deleting and re-creating the DPA ensures that the BSL resources are created from scratch. The new `default` setting is applied during initial creation and re-deployment of the DPA.
+
+
+.Procedure
+
+. Delete the existing DPA by running the following command:
++
+[source,terminal]
+----
+$ oc delete dpa <dpa_name> -n openshift-adp
+----
++
+Replace `<dpa_name>` with the name of the DPA custom resource.
+
+
+. Re-create the DPA with the updated default BSL configuration by running the following command:
++
+[source,terminal]
+----
+$ oc apply -f <updated_dpa_file>
+----
++
+Replace `<updated_dpa_file>` with the file name of the updated DPA custom resource definition.
+
+
+


### PR DESCRIPTION
## Jira 

* [OADP-7690](https://redhat.atlassian.net/browse/OADP-7690)

##  Version

* OCP 4.14 -> 4.22

## Preview

* [About updating default backup storage location in a DPA](https://109915--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/installing/configuring-oadp-multiple-bsl.html#oadp-about-updating-default-bsl_configuring-oadp-multiple-bsl)

## QE Review

* [x] QE has approved this change.