### PR TITLE
PR for SRVLOGIC-782: Add a section for upgrading the OpenShift Serverless Logic Operator from 1.37.2 to 1.38.0

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -422,6 +422,8 @@ Topics:
     File: serverless-logic-upgrading-operator-from-1-36-to-1-37
   - Name: Upgrading Serverless Logic Operator from 1.37.0 to 1.37.1
     File: serverless-logic-upgrading-operator-from-1-37-0-to-1-37-1
+  - Name: Upgrading Serverless Logic Operator from 1.37.2 to 1.38.0
+    File: serverless-logic-upgrading-operator-from-1-37-2-to-1-38-0
 
 ---
 # Knative kn CLI

--- a/modules/serverless-logic-1-37-1-restoring-jobs-service-retry-interval.adoc
+++ b/modules/serverless-logic-1-37-1-restoring-jobs-service-retry-interval.adoc
@@ -6,7 +6,7 @@
 = Restoring the Jobs Service retry interval
 
 [role="_abstract"]
-After you redeploy all workflows, restore the Jobs Service retry interval to its original configuration.
+After you redeploy all workflows, restore the Job Service retry interval to its original configuration.
 
 .Procedure
 
@@ -24,4 +24,4 @@ After you redeploy all workflows, restore the Jobs Service retry interval to its
 oc apply -f <sonataflowplatform.yaml>
 ----
 
-. Verify that the Jobs Service deployment updates successfully.
+. Verify that the Job Service deployment updates successfully.

--- a/modules/serverless-logic-1-38-0-finalizing-the-upgrade.adoc
+++ b/modules/serverless-logic-1-38-0-finalizing-the-upgrade.adoc
@@ -1,0 +1,18 @@
+// Module included in the following assemblies:
+// * serverless-logic/serverless-logic-upgrading-operator-from-1-37-2-to-1-38-0
+
+:_mod-docs-content-type: REFERENCE
+[id="serverless-logic-1-38-0-finalizing-the-upgrade_{context}"]
+= Finalizing the upgrade
+
+[role="_abstract"]
+After upgrading the {ServerlessLogicOperatorName} to version 1.38.0, you must complete the upgrade process by redeploying the workflows.
+
+Follow the appropriate steps based on the profile of your workflows and services.
+
+.Prerequisites
+* You have access to the cluster with `cluster-admin` privileges.
+* You have {ServerlessLogicOperatorName} installed on your cluster.
+* You have access to a {ServerlessLogicProductName} project with the appropriate roles and permissions to create applications and other workloads in {ocp-product-title}.
+* You have installed the OpenShift CLI (`oc`).
+

--- a/modules/serverless-logic-1-38-0-preparing-for-the-upgrade.adoc
+++ b/modules/serverless-logic-1-38-0-preparing-for-the-upgrade.adoc
@@ -1,0 +1,30 @@
+// Module included in the following assemblies:
+// * serverless-logic/serverless-logic-upgrading-operator-from-1-37-2-to-1-38-0
+
+:_mod-docs-content-type: REFERENCE
+[id="serverless-logic-1-38-0-preparing-for-the-upgrade_{context}"]
+= Preparing for the 1.37.2 to 1.38.0 upgrade
+
+[role="_abstract"]
+Before starting the upgrade process, prepare your {ServerlessLogicProductName} environment to upgrade from version 1.37.2 to 1.38.0.
+
+[IMPORTANT]
+====
+Different workflow profiles require different upgrade steps. Follow the instructions for each profile carefully.
+====
+
+The preparation process is as follows:
+
+* Increasing the Jobs Service retry interval.
+* Deleting workflows based on their profiles.
+* Backing up all necessary databases and resources.
+* Ensuring you have a record of all custom configurations.
+
+.Prerequisites
+* You have access to the cluster with `cluster-admin` privileges.
+* You have {ServerlessLogicOperatorName} installed on your cluster.
+* You have access to a {ServerlessLogicProductName} project with the appropriate roles and permissions to create applications and other workloads in {ocp-product-title}.
+* You have backups for all workflow, Data Index, and Job Service databases where persistence is enabled.
+* You have access to all namespaces where `SonataFlow`, Data Index, and Job Service are deployed.
+* You have installed the OpenShift CLI (`oc`).
+

--- a/modules/serverless-logic-upgrade-1-37-backing-up-job-service-database.adoc
+++ b/modules/serverless-logic-upgrade-1-37-backing-up-job-service-database.adoc
@@ -3,12 +3,13 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="serverless-logic-upgrade-1-37-backing-up-job-service-database_{context}"]
-= Backing up the Jobs Service database
+= Backing up the Job Service database
 
 [role="_abstract"]
-You must back up the Jobs Service database before upgrading to maintain the job scheduling data.
+You must back up the Job Service database before upgrading to maintain the job scheduling data.
 
 .Procedure
-* Take a full backup of the Jobs Service database, ensuring:
+* Take a full backup of the Job Service database, ensuring:
 ** The backup includes all database objects and not just table data.
 ** Ensure that you store the backup in a secure location.
+

--- a/modules/serverless-logic-upgrade-1-37-deleting-migrating-workflows-with-preview-profile.adoc
+++ b/modules/serverless-logic-upgrade-1-37-deleting-migrating-workflows-with-preview-profile.adoc
@@ -19,3 +19,4 @@ Before upgrading the Operator, you must delete workflows running with the `previ
 ----
 $ oc delete -f <workflow.yaml> -n <target_namespace>
 ----
+

--- a/modules/serverless-logic-upgrade-1-37-deleting-workflows-with-dev-profile.adoc
+++ b/modules/serverless-logic-upgrade-1-37-deleting-workflows-with-dev-profile.adoc
@@ -17,3 +17,4 @@ Before upgrading the Operator, you must delete workflows running with the `dev` 
 ----
 $ oc delete -f <workflow.yaml> -n <target_namespace>
 ----
+

--- a/modules/serverless-logic-upgrade-1-38-0-deleting-migrating-workflows-with-gitops-profile.adoc
+++ b/modules/serverless-logic-upgrade-1-38-0-deleting-migrating-workflows-with-gitops-profile.adoc
@@ -1,0 +1,91 @@
+// Module included in the following assemblies:
+// * serverless-logic/serverless-logic-upgrading-operator-from-1-37-2-to-1-38-0
+
+:_mod-docs-content-type: PROCEDURE
+[id="serverless-logic-upgrade-1-38-0-deleting-migrating-workflows-with-gitops-profile_{context}"]
+= Deleting workflows with the gitops profile
+
+[role="_abstract"]
+For workflows that use the `gitops` profile, it is strongly recommended to rebuild the workflow image that you generated for version `1.37.2` before upgrading the Operator. Rebuilding the image ensures compatibility with {ServerlessLogicProductName} `1.38.0`.
+
+For each workflow, for example `my-workflow`, complete the following steps.
+
+.Procedure
+
+. Rebuild the workflow image by using the {ServerlessLogicProductName} `1.38.0` workflow builder image:
++
+[source,terminal]
+----
+$ registry.redhat.io/openshift-serverless-1/logic-swf-builder-rhel9:1.38.0
+----
+
+. Reconfigure the workflow image by considering the following behavior:
++
+By default, {ServerlessLogicProductName} generates a workflow `Deployment` with `imagePullPolicy: IfNotPresent`. If you redeploy a workflow with the same image name, the cluster reuses the earlier downloaded image, even if the image was rebuilt.
+
+. Do not change the workflow definition or any related metadata when rebuilding the image.
++ 
+Rebuilding the image creates a new image build, not a new workflow version. The workflow name, version, and description must remain unchanged.
+
+. To ensure that the cluster pulls the rebuilt image, use one of the following approaches:
+
+* Use a new image tag and update the workflow to reference the new tag (recommended).
++
+You get an output similar to the following example:
++
+[source,yaml]
+----
+current image: quay.io/my-images/my-workflow:1.0
+new image: quay.io/my-images/my-workflow:1.0-1
+
+apiVersion: sonataflow.org/v1alpha08
+kind: SonataFlow
+metadata: # don't change
+  name: my-workflow
+  annotations:
+    sonataflow.org/description: My Workflow
+    sonataflow.org/version: '1.0'
+    sonataflow.org/profile: gitops
+spec:
+  podTemplate:
+    container:
+      # only change the image name/tag
+      image: quay.io/my-images/my-workflow:1.0-1
+  flow:
+    # the workflow definition (don't change)
+----
+
+* Preserve the image name and configure the workflow with `imagePullPolicy: Always`.
++
+You get an output similar to the following example:
++
+[source,yaml]
+----
+apiVersion: sonataflow.org/v1alpha08
+kind: SonataFlow
+metadata: # do not change
+  name: my-workflow
+  annotations:
+    sonataflow.org/description: My Workflow
+    sonataflow.org/version: '1.0'
+    sonataflow.org/profile: gitops
+spec:
+  podTemplate:
+    container:
+      image: quay.io/my-images/my-workflow:1.0
+      # change only the image pull policy
+      imagePullPolicy: Always
+  flow:
+    # do not change the workflow definition
+----
+
+. If the workflow uses persistence, back up the workflow database. Ensure that the backup includes all database objects, not only table data.
+
+. Ensure that you have a copy of the corresponding `SonataFlow` custom resource (CR) and any related Kubernetes resources created for the workflow. For example, if the workflow uses custom property configurations, keep a copy of the user-provided `ConfigMap` that has the `application.properties` file.
+
+. Delete the workflow by running the following command: 
++
+[source,terminal]
+----
+$ oc delete -f <my-workflow.yaml> -n <target_namespace>
+----

--- a/modules/serverless-logic-upgrade-1-38-0-finalizing-data-index.adoc
+++ b/modules/serverless-logic-upgrade-1-38-0-finalizing-data-index.adoc
@@ -1,0 +1,10 @@
+// Module included in the following assemblies:
+// * serverless-logic/serverless-logic-upgrading-operator-from-1-37-2-to-1-38-0
+
+:_mod-docs-content-type: REFERENCE
+[id="serverless-logic-upgrade-1-38-0-finalizing-data-index_{context}"]
+= Finalizing the Data Index upgrade
+
+[role="_abstract"]
+After you upgrade the {ServerlessLogicOperatorName} to version 1.38.0, the Data Index service restarts automatically and runs version 1.38.0.
+

--- a/modules/serverless-logic-upgrade-1-38-0-finalizing-job-service.adoc
+++ b/modules/serverless-logic-upgrade-1-38-0-finalizing-job-service.adoc
@@ -1,0 +1,10 @@
+// Module included in the following assemblies:
+// * serverless-logic/serverless-logic-upgrading-operator-from-1-37-2-to-1-38-0
+
+:_mod-docs-content-type: REFERENCE
+[id="serverless-logic-upgrade-1-38-0-finalizing-job-service_{context}"]
+= Finalizing the Job Service upgrade
+
+[role="_abstract"]
+After you upgrade the {ServerlessLogicOperatorName} to version 1.38.0, the Job Service restarts automatically and runs version 1.38.0.
+

--- a/modules/serverless-logic-upgrade-1-38-0-redeploying-workflows-with-dev-profile.adoc
+++ b/modules/serverless-logic-upgrade-1-38-0-redeploying-workflows-with-dev-profile.adoc
@@ -1,0 +1,20 @@
+// Module included in the following assemblies:
+// * serverless-logic/serverless-logic-upgrading-operator-from-1-37-2-to-1-38-0
+
+:_mod-docs-content-type: PROCEDURE
+[id="serverless-logic-upgrade-1-38-0-redeploying-workflows-with-dev-profile_{context}"]
+= Redeploying workflows with the dev profile
+
+[role="_abstract"]
+After upgrading the {ServerlessLogicOperatorName} to version 1.38.0, you must redeploy workflows that use the `dev` profile to complete the upgrade process.
+
+.Procedure
+. Restore all required Kubernetes resources before redeploying the workflow. These resources include the `ConfigMap` resource with the `application.properties` field.
+
+. Redeploy the workflow by running the following command: 
++
+[source,terminal]
+----
+$ oc apply -f <workflow_yaml> -n <target_namespace>
+----
+

--- a/modules/serverless-logic-upgrade-1-38-0-redeploying-workflows-with-gitops-profile.adoc
+++ b/modules/serverless-logic-upgrade-1-38-0-redeploying-workflows-with-gitops-profile.adoc
@@ -1,0 +1,19 @@
+// Module included in the following assemblies:
+// * serverless-logic/serverless-logic-upgrading-operator-from-1-37-2-to-1-38-0
+
+:_mod-docs-content-type: PROCEDURE
+[id="serverless-logic-upgrade-1-38-0-redeploying-workflows-with-gitops-profile_{context}"]
+= Redeploying workflows with the gitops profile
+
+[role="_abstract"]
+After upgrading the {ServerlessLogicOperatorName} to version 1.38.0, you must redeploy workflows that use the `gitops` profile to complete the upgrade process.
+
+.Procedure
+. Restore all required Kubernetes resources before redeploying the workflow. These resources include the `ConfigMap` resource with the `application.properties` field.
+
+. Redeploy the workflow by running the following command: 
++
+[source,terminal]
+----
+$ oc apply -f <workflow_yaml> -n <target_namespace>
+----

--- a/modules/serverless-logic-upgrade-1-38-0-redeploying-workflows-with-preview-profile.adoc
+++ b/modules/serverless-logic-upgrade-1-38-0-redeploying-workflows-with-preview-profile.adoc
@@ -1,0 +1,20 @@
+// Module included in the following assemblies:
+// * serverless-logic/serverless-logic-upgrading-operator-from-1-37-2-to-1-38-0
+
+:_mod-docs-content-type: PROCEDURE
+[id="serverless-logic-upgrade-1-38-0-redeploying-workflows-with-preview-profile_{context}"]
+= Redeploying workflows with the preview profile
+
+[role="_abstract"]
+After upgrading the {ServerlessLogicOperatorName} to version 1.38.0, you must redeploy workflows that use the `preview` profile to complete the upgrade process.
+
+.Procedure
+. Restore all required Kubernetes resources before redeploying the workflow. These resources include the `ConfigMap` resource with the `application.properties` field.
+
+. Redeploy the workflow by running the following command: 
++
+[source,terminal]
+----
+$ oc apply -f <workflow_yaml> -n <target_namespace>
+----
+

--- a/modules/serverless-logic-upgrading-1-38-0-osl-operator.adoc
+++ b/modules/serverless-logic-upgrading-1-38-0-osl-operator.adoc
@@ -1,0 +1,82 @@
+// Module included in the following assemblies:
+// * serverless-logic/serverless-logic-upgrading-operator-from-1-37-2-to-1-38-0
+
+:_mod-docs-content-type: PROCEDURE
+[id="serverless-logic-upgrading-1-38-0-osl-operator_{context}"]
+= Upgrading the {ServerlessLogicOperatorName} to 1.38.0
+
+[role="_abstract"]
+You can upgrade the {ServerlessLogicOperatorName} from version 1.37.2 to 1.38.0 by performing the following steps.
+
+.Prerequisites
+* You have access to the cluster with `cluster-admin` privileges.
+* You have {ServerlessLogicOperatorName} installed on your cluster.
+* You have access to a {ServerlessLogicProductName} project with the appropriate roles and permissions to create applications and other workloads in {ocp-product-title}.
+* You have installed the OpenShift CLI (`oc`).
+* You have version 1.37.2 of {ServerlessLogicOperatorName} installed.
+
+.Procedure
+
+. Query the available installation plans for the Operator upgrade by running the following command:
++
+[source, terminal]
+----
+$ oc get installplan -n openshift-serverless-logic
+----
++
+You get an output similar to the following:
++
+[source, terminal]
+----
+NAME            CSV                      APPROVAL   APPROVED
+install-YYYY    logic-operator.v1.38.0   Manual     false
+install-XXXX    logic-operator.v1.37.2   Manual     true
+----
+
+. Approve the install plan by running the following command:
++
+[source, terminal]
+----
+$ oc patch installplan install-YYYY -n openshift-serverless-logic --type merge -p '{"spec":{"approved":true}}'
+----
+
+. Verify that the Operator upgrade completed successfully by running the following command:
++
+[source, terminal]
+----
+$ oc get csv -n openshift-serverless-logic
+----
++
+You get an output similar to the following:
++
+[source, terminal]
+----
+NAME                     DISPLAY                               VERSION   REPLACES                 PHASE
+logic-operator.v1.38.0   OpenShift Serverless Logic Operator   1.38.0    logic-operator.v1.37.2   Succeeded
+----
+
+.Verification
+
+. If you configure `dbMigrationStrategy: job` for Data Index or Job Service, verify that the database initialization job exists by running the following command:
++
+[source, terminal]
+----
+$ oc get jobs \
+  -n <target_namespace> \
+  -l app=<platform_name>,app.kubernetes.io/version=1.38.0
+----
++
+You get an output similar to the following:
++
+[source, terminal]
+----
+NAME                                  STATUS     COMPLETIONS   DURATION   AGE
+sonataflow-db-migrator-job-b81d6bb3   Complete   1/1           15s        16m
+----
+
+. Verify the job logs by running the following command:
++
+[source, terminal]
+----
+$ oc logs job/sonataflow-db-migrator-job-b81d6bb3 -n <target_namespace>
+----

--- a/serverless-logic/serverless-logic-managing-upgrades/serverless-logic-upgrading-operator-from-1-37-2-to-1-38-0.adoc
+++ b/serverless-logic/serverless-logic-managing-upgrades/serverless-logic-upgrading-operator-from-1-37-2-to-1-38-0.adoc
@@ -1,0 +1,47 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="serverless-logic-upgrading-operator-from-1-37-2-to-1-38-0"]
+= Upgrading OpenShift Serverless Logic Operator from version 1.37.2 to 1.38.0
+include::_attributes/common-attributes.adoc[]
+:context: serverless-logic-upgrading-operator-from-1-37-2-to-1-38-0
+
+toc::[]
+
+[role="_abstract"]
+You can upgrade the {ServerlessLogicOperatorName} from version 1.37.2 to 1.38.0. The upgrade process involves preparing the existing workflows and services, updating the Operator, and restoring the workflows after the upgrade.
+
+[IMPORTANT]
+====
+The following feature applies to {ServerlessLogicProductName} 1.38.
+{ServerlessLogicProductName} and {ServerlessProductName} follow different release cadences. This release introduces features for OpenShift Serverless Logic 1.38.
+====
+
+include::modules/serverless-logic-1-38-0-preparing-for-the-upgrade.adoc[leveloffset=+1]
+
+include::modules/serverless-logic-1-37-1-increasing-jobs-service-retry-interval.adoc[leveloffset=+2]
+
+include::modules/serverless-logic-upgrade-1-37-deleting-workflows-with-dev-profile.adoc[leveloffset=+2]
+
+include::modules/serverless-logic-upgrade-1-37-deleting-migrating-workflows-with-preview-profile.adoc[leveloffset=+2]
+
+include::modules/serverless-logic-upgrade-1-38-0-deleting-migrating-workflows-with-gitops-profile.adoc[leveloffset=+2]
+
+include::modules/serverless-logic-upgrade-1-37-backing-up-data-index-database.adoc[leveloffset=+2]
+
+include::modules/serverless-logic-upgrade-1-37-backing-up-job-service-database.adoc[leveloffset=+2]
+
+include::modules/serverless-logic-upgrading-1-38-0-osl-operator.adoc[leveloffset=+1]
+
+include::modules/serverless-logic-1-38-0-finalizing-the-upgrade.adoc[leveloffset=+1]
+
+include::modules/serverless-logic-upgrade-1-38-0-finalizing-data-index.adoc[leveloffset=+2]
+
+include::modules/serverless-logic-upgrade-1-38-0-finalizing-job-service.adoc[leveloffset=+2]
+
+include::modules/serverless-logic-upgrade-1-38-0-redeploying-workflows-with-gitops-profile.adoc[leveloffset=+2]
+
+include::modules/serverless-logic-upgrade-1-38-0-redeploying-workflows-with-dev-profile.adoc[leveloffset=+2]
+
+include::modules/serverless-logic-upgrade-1-38-0-redeploying-workflows-with-preview-profile.adoc[leveloffset=+2]
+
+include::modules/serverless-logic-1-37-1-restoring-jobs-service-retry-interval.adoc[leveloffset=+2]
+


### PR DESCRIPTION
**Affected versions:** 
- `serverless-docs-1.37`
- `serverless-docs-1.38`

**Tracking JIRA:** https://issues.redhat.com/browse/SRVLOGIC-782

**Doc preview:**

- [Upgrading OpenShift Serverless Logic Operator from version 1.37.2 to 1.38.0](https://109922--ocpdocs-pr.netlify.app/openshift-serverless/latest/serverless-logic/serverless-logic-managing-upgrades/serverless-logic-upgrading-operator-from-1-37-2-to-1-38-0.html)

**Reviews:**
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
- [x] SME has approved this change.
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
- [x] Peer has approved this change.
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->