### PR TITLE
OSDOCS-19040:Update the z-stream RNs for 4.13.65

### DIFF
--- a/modules/zstream-4-13-65-about.adoc
+++ b/modules/zstream-4-13-65-about.adoc
@@ -1,0 +1,15 @@
+:_mod-docs-content-type: CONCEPT
+[id="zstream-4-13-65-about_{context}"]
+= RHSA-2026:7252 - {product-title} 4.13.65 bug fix and security updates
+
+Issued: 16 April 2026
+
+[role="_abstract"]
+{product-title} release 4.13.65, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2026:7252[RHSA-2026:7252] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2026:7238[RHSA-2026:7238] advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.13.65 --pullspecs
+----

--- a/modules/zstream-4-13-65-bug-fixes.adoc
+++ b/modules/zstream-4-13-65-bug-fixes.adoc
@@ -1,0 +1,6 @@
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-13-65-bug-fixes_{context}"]
+= Fixed issues
+
+[role="_abstract"]
+* Before this update, service account creation with the `openshift/local/google` provider in earlier {product-title} versions caused inconsistent results during service account creation. As a consequence, errors occurred during the apply process, which affected cluster provisioning in {gcp-first}. With this release, Terraform and the provider are upgraded. As a result, service account creation issues are resolved, which reduces inconsistencies during cluster installation in {gcp-short}. (link:https://issues.redhat.com/browse/OCPBUGS-76931[OCPBUGS-76931])

--- a/modules/zstream-4-13-65-updating.adoc
+++ b/modules/zstream-4-13-65-updating.adoc
@@ -1,0 +1,6 @@
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-13-65-updating_{context}"]
+= Updating
+
+[role="_abstract"]
+To update an existing {product-title} 4.13 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].

--- a/release_notes/ocp-4-13-release-notes.adoc
+++ b/release_notes/ocp-4-13-release-notes.adoc
@@ -4663,3 +4663,10 @@ include::modules/zstream-4-13-64-about.adoc[leveloffset=+2]
 include::modules/zstream-4-13-64-bug-fixes.adoc[leveloffset=+2]
 
 include::modules/zstream-4-13-64-updating.adoc[leveloffset=+2]
+
+//4.13.65
+include::modules/zstream-4-13-65-about.adoc[leveloffset=+2]
+
+include::modules/zstream-4-13-65-bug-fixes.adoc[leveloffset=+2]
+
+include::modules/zstream-4-13-65-updating.adoc[leveloffset=+2]


### PR DESCRIPTION
Version(s):
4.13

Issue:
https://redhat.atlassian.net/browse/OSDOCS-19040

Link to docs preview:
https://109926--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-13-release-notes.html#zstream-4-13-65-about_release-notes

Additional information:
4.13.65 MR: https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/464
ART Dashboard: https://art-dash.engineering.redhat.com/dashboard/release/openshift-4.13
