### PR TITLE
OCPBUGS-82061: Documented the baremetal-runtimecfg tool IP address as…

### DIFF
--- a/installing/installing_bare_metal/ipi/ipi-install-installation-workflow.adoc
+++ b/installing/installing_bare_metal/ipi/ipi-install-installation-workflow.adoc
@@ -25,6 +25,13 @@ include::modules/ipi-install-checking-ntp-sync.adoc[leveloffset=+1]
 // Configuring networking
 include::modules/ipi-install-configuring-networking.adoc[leveloffset=+1]
 
+include::modules/ipi-install-baremetal-runtimecfg-ip-assignment.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../../support/troubleshooting/troubleshooting-network-issues.adoc#overriding-default-node-ip-selection-logic_troubleshooting-network-issues[Optional: Overriding the default node IP selection logic]
+
 // Creating a manifest object that includes a customized `br-ex` bridge
 include::modules/creating-manifest-file-customized-br-ex-bridge.adoc[leveloffset=+1]
 

--- a/modules/ipi-install-baremetal-runtimecfg-ip-assignment.adoc
+++ b/modules/ipi-install-baremetal-runtimecfg-ip-assignment.adoc
@@ -1,0 +1,35 @@
+// This is included in the following assemblies:
+//
+// ipi-install-installation-workflow.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="ipi-install-baremetal-runtimecfg-ip-assignment_{context}"]
+= The baremetal-runtimecfg tool
+
+[role="_abstract"]
+The `baremetal-runtimecfg` tool handles configuration properties between the underlying physical network and the Kubernetes control plane. Understanding how this tool determines the advertised IP address of a node can prevent incorrect IP address assignment.
+
+The `baremetal-runtimecfg` tool uses the following selection logic to determine the IP address for a node:
+
+* Looks at the `NODEIP_HINT` value and selects an IP address from the specified classless inter-domain routing (CIDR) range.
+
+* Looks at the API VIP address and selects an IP address on the same subnet.
+
+* Looks at the default route and selects an IP address from the interface used by that route.
+
+The `baremetal-runtimecfg` tool uses the following component order of precedence to sort IP addresses for a node:
+
+. Default route priority
+. Link state
+. IP address family
+. Gateway on CIDR range
+. Public versus private
+. Real IPv6 versus IPv4-mapped IPv6 addresses
+. Alphanumeric stability
+
+If the wrong IP address is provided because a node has multiple IP addresses on the primary interface, such as `br-ex`, an IP address mismatch is likely the issue because of the following scenarios:
+
+* Specifically for a secondary IP address that exists on the same subnet as the primary interface. During a node reboot, if a secondary IP address gets assigned to the `br-ex` interface, the `baremetal-runtimecfg` tool might see the secondary IP address as more routable.
+
+* If the `baremetal-runtimecfg` tool does not pass the `--node-ip` flag to the Kubelet, the Kubelet uses its internal logic. This internal logic selects the first IP address of the default gateway.
+

--- a/modules/ipi-install-baremetal-runtimecfg-ip-assignment.adoc
+++ b/modules/ipi-install-baremetal-runtimecfg-ip-assignment.adoc
@@ -1,0 +1,34 @@
+// This is included in the following assemblies:
+//
+// ipi-install-installation-workflow.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="ipi-install-baremetal-runtimecfg-ip-assignment_{context}"]
+= The baremetal-runtimecfg tool
+
+[role="_abstract"]
+To prevent incorrect IP address assignments, learn how the `baremetal-runtimecfg` tool determines node IP addresses between your physical network and the Kubernetes control plane.
+
+The `baremetal-runtimecfg` tool uses the following selection logic sequence to determine the IP address for a node:
+
+. The tool looks at the `NODEIP_HINT` and all API and Ingress VIP addresses. 
+. The tool selects an IP address on the same subnet. 
+. If no address match is found, the tool looks at the default route and selects an IP address from the interface used by that route.
+
+The `baremetal-runtimecfg` tool uses the following component order of precedence to sort IP addresses for a node:
+
+. Default route priority
+. Link index
+. IP address family
+. Address subnet contains the default gateway
+. Public versus private
+. Real IPv6 versus IPv4-mapped IPv6 addresses
+. Alphanumeric stability
+
+If the wrong IP address is provided because a node has multiple IP addresses on the primary interface, such as `br-ex`, an IP address mismatch is likely the issue because of the following scenarios:
+
+* Specifically for a secondary IP address on the same subnet as the primary IP address. During a node reboot, if both IP addresses are candidates, the `baremetal-runtimecfg` tool might select the secondary IP address based on the sort criteria of the tool.
+
+* During a node reboot, if a primary IP address and a secondary IP address on the same subnet are both candidates, the `baremetal-runtimecfg` tool might select the secondary IP address based on sorting criteria of the tool.
+
+* If the `baremetal-runtimecfg` tool does not set a node IP for the Kubelet service, Kubelet chooses an IP address associated with the default route.

--- a/modules/ipi-install-network-requirements.adoc
+++ b/modules/ipi-install-network-requirements.adoc
@@ -10,6 +10,13 @@ Installer-provisioned installation of {product-title} involves multiple network 
 
 image::210_OpenShift_Baremetal_IPI_Deployment_updates_0122_2.png[Installer-provisioned networking]
 
+[id="network-requirements-one-ip-per-subnet_{context}"]
+== One IP address for each subnet
+
+For the primary interface, ensure that you assign one IP address for each subnet. This configuration ensures the node IP address selection handles traffic without experiencing traffic handling issues.
+
+You can assign multiple IP addresses from the same subnet to a single interface, known as _IP aliasing_. However, the node IP address selection cannot consistently determine which address to use, causing routing conflicts and unpredictable IP selection.
+
 [id="network-requirements-ensuring-required-ports-are-open_{context}"]
 == Ensuring required ports are open
 

--- a/modules/ipi-install-network-requirements.adoc
+++ b/modules/ipi-install-network-requirements.adoc
@@ -19,6 +19,13 @@ Red Hat supports any valid host network configuration that meets the documented 
 * Other tools might be supported to perform a specific task. Red Hat does not support these other tools for general network configurations.
 ====
 
+[id="network-requirements-one-ip-per-subnet_{context}"]
+== One IP address for each subnet
+
+For the primary interface, assign one IP address for each subnet. This configuration ensures the node IP address selection handles traffic without experiencing traffic handling issues.
+
+You can assign multiple IP addresses from the same subnet to a single interface, in a process known as _IP aliasing_. However, the node IP address selection process cannot consistently determine which address to use, causing routing conflicts and unpredictable IP selection.
+
 [id="network-requirements-ensuring-required-ports-are-open_{context}"]
 == Ensuring required ports are open
 


### PR DESCRIPTION
Version(s):
4.16+

Issue:
[OCPBUGS-82061](https://redhat.atlassian.net/browse/OCPBUGS-82061)

Link to docs preview:

* [The baremetal-runtimecfg tool](https://109928--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/ipi/ipi-install-installation-workflow.html#ipi-install-baremetal-runtimecfg-ip-assignment_ipi-install-installation-workflow)
* [One IP address for each subnet](https://109928--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/ipi/ipi-install-prerequisites.html#network-requirements-one-ip-per-subnet_ipi-install-prerequisites)

- [x] SME has approved this change.
- [x] QE has approved this change.
