### PR TITLE
OSDOCS-19066 - Removing ROSA About

### DIFF
--- a/_topic_maps/_topic_map_rosa.yml
+++ b/_topic_maps/_topic_map_rosa.yml
@@ -22,20 +22,6 @@
 # topic groups and topics on the main page.
 
 ---
-Name: About
-Dir: welcome
-Distros: openshift-rosa
-Topics:
-- Name: Welcome
-  File: index
-#- Name: Learn more about ROSA with HCP
-#  File: about-hcp
-#- Name: AWS STS and ROSA with HCP explained
-#  File: cloud-experts-rosa-hcp-sts-explained
-- Name: Legal notice
-  File: legal-notice
-  Distros: openshift-rosa
----
 Name: What's new
 Dir: rosa_release_notes
 Distros: openshift-rosa

--- a/_topic_maps/_topic_map_rosa_hcp.yml
+++ b/_topic_maps/_topic_map_rosa_hcp.yml
@@ -34,8 +34,6 @@ Distros: openshift-rosa-hcp
 Topics:
 - Name: Welcome
   File: index
-# - Name: Legal notice
-#   File: legal-notice
 - Name: ROSA overview
   File: about-hcp
 - Name: AWS STS and ROSA explained

--- a/cloud_experts_tutorials/cloud-experts-getting-started/cloud-experts-getting-started-what-is-rosa.adoc
+++ b/cloud_experts_tutorials/cloud-experts-getting-started/cloud-experts-getting-started-what-is-rosa.adoc
@@ -31,7 +31,7 @@ include::modules/cloud-experts-key-features-rosa-infrastructure.adoc[leveloffset
 * link:https://aws.amazon.com/rosa/[AWS product page]
 * link:https://access.redhat.com/products/red-hat-openshift-service-aws[Red{nbsp}Hat Customer Portal]
 * link:https://docs.aws.amazon.com/ROSA/latest/userguide/getting-started.html[AWS ROSA getting started guide]
-* xref:../../welcome/index.adoc#welcome-index[ROSA documentation]
+* xref:../../rosa_architecture/rosa-understanding.adoc#rosa-understanding[About {product-title}]
 * xref:../../rosa_architecture/rosa_policy_service_definition/rosa-service-definition.adoc#rosa-service-definition[ROSA service definition]
 * xref:../../rosa_architecture/rosa_policy_service_definition/rosa-policy-responsibility-matrix.adoc#rosa-policy-responsibility-matrix[ROSA responsibility assignment matrix]
 * xref:../../rosa_architecture/rosa_policy_service_definition/rosa-policy-process-security.adoc#rosa-policy-process-security[Understanding Process and Security]


### PR DESCRIPTION
Version(s):
4.21+

Issue:
https://redhat.atlassian.net/browse/OSDOCS-19066

Link to docs preview:
https://109958--ocpdocs-pr.netlify.app/openshift-rosa/latest/cloud_experts_tutorials/cloud-experts-getting-started/cloud-experts-getting-started-what-is-rosa.html - Updated 1 link in Additional resources (About Red Hat OpenShift Service on AWS (classic architecture)). That tutorial is only published in the Classic docs, no need to check for HCP.

QE review:
N/A

Additional information:
Removing the About book from the ROSA Classic topic map.