### PR TITLE
CNV-78917: Use versioned type name for the HyperConverged type

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -124,6 +124,7 @@ endif::[]
 :VirtVersion: 4.21
 :HCOVersion: 4.21.0
 :HCOVersionPrev: 4.20.0
+:HCOCliKind: hyperconvergeds.v1beta1.hco.kubevirt.io
 :CNVNamespace: openshift-cnv
 :CNVOperatorDisplayName: OpenShift Virtualization Operator
 :CNVSubscriptionSpecSource: redhat-operators

--- a/modules/hcp-virt-evict-vms.adoc
+++ b/modules/hcp-virt-evict-vms.adoc
@@ -14,23 +14,23 @@ In cases where KubeVirt virtual machines (VMs) cannot be live migrated, such as 
 +
 [source,terminal]
 ----
-$ oc explain hyperconverged.spec.evictionStrategy
+$ oc explain --api-version=hco.kubevirt.io/v1beta1 hyperconverged.spec.evictionStrategy
 ----
 
 . Patch the `hyperconverged` resource by entering the following command:
 +
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
-$ oc -n openshift-cnv patch hyperconverged kubevirt-hyperconverged \
+$ oc patch -n {CNVNamespace} {HCOCliKind} kubevirt-hyperconverged \
   --type=merge \
   -p '{"spec": {"evictionStrategy": "External"}}'
 ----
 
 . Patch the workload update strategy and the workload update methods by entering the following command:
 +
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
-$ oc -n openshift-cnv patch hyperconverged kubevirt-hyperconverged \
+$ oc patch -n {CNVNamespace} {HCOCliKind} kubevirt-hyperconverged \
   --type=merge \
   -p '{"spec": {"workloadUpdateStrategy": {"workloadUpdateMethods": ["LiveMigrate","Evict"]}}}'
 ----
@@ -41,9 +41,9 @@ By applying this patch, you specify that VMs should be live-migrated if possible
 
 * Check whether the patch command was applied properly by entering the following command:
 +
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
-$ oc -n openshift-cnv get hyperconverged kubevirt-hyperconverged -ojsonpath='{.spec.evictionStrategy}'
+$ oc get -n {CNVNamespace} {HCOCliKind} kubevirt-hyperconverged -ojsonpath='{.spec.evictionStrategy}'
 ----
 +
 .Example output

--- a/modules/virt-add-custom-golden-image-heterogeneous-cluster.adoc
+++ b/modules/virt-add-custom-golden-image-heterogeneous-cluster.adoc
@@ -23,7 +23,7 @@ Add a custom golden image in a heterogeneous cluster by setting the `ssp.kubevir
 +
 [source,terminal,subs="attributes+"]
 ----
-$ oc edit hyperconverged kubevirt-hyperconverged -n {CNVNamespace}
+$ oc edit {HCOCliKind} kubevirt-hyperconverged -n {CNVNamespace}
 ----
 
 . Edit the `HyperConverged` CR, to add the custom golden image. You must add the appropriate values for `ssp.kubevirt.io/dict.architectures` annotation in the `dataImportCronTemplates` section. For example:

--- a/modules/virt-attaching-vm-to-primary-udn.adoc
+++ b/modules/virt-attaching-vm-to-primary-udn.adoc
@@ -49,9 +49,9 @@ spec:
 . Optional: If you are using the Plug a Simple Socket Transport (passt) network binding plugin, set the `hco.kubevirt.io/deployPasstNetworkBinding` annotation to `true` in the `HyperConverged` custom resource (CR) by running the following command:
 +
 --
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
-$ oc annotate hco kubevirt-hyperconverged -n kubevirt-hyperconverged hco.kubevirt.io/deployPasstNetworkBinding=true --overwrite
+$ oc annotate {HCOCliKind} kubevirt-hyperconverged -n {CNVNamespace} hco.kubevirt.io/deployPasstNetworkBinding=true --overwrite
 ----
 
 :FeatureName: Using the passt binding plugin to attach a VM to the primary UDN

--- a/modules/virt-autoupdate-custom-bootsource.adoc
+++ b/modules/virt-autoupdate-custom-bootsource.adoc
@@ -21,7 +21,7 @@
 +
 [source,terminal,subs="attributes+"]
 ----
-$ oc edit hyperconverged kubevirt-hyperconverged -n {CNVNamespace}
+$ oc edit {HCOCliKind} kubevirt-hyperconverged -n {CNVNamespace}
 ----
 
 . Edit the `HyperConverged` CR, adding the appropriate template and boot source in the `dataImportCronTemplates` section. For example:

--- a/modules/virt-configure-ksm-cli.adoc
+++ b/modules/virt-configure-ksm-cli.adoc
@@ -20,7 +20,7 @@ You can enable or disable {VirtProductName}'s kernel samepage merging (KSM) acti
 +
 [source,terminal,subs="attributes+"]
 ----
-$ oc edit hyperconverged kubevirt-hyperconverged -n {CNVNamespace}
+$ oc edit {HCOCliKind} kubevirt-hyperconverged -n {CNVNamespace}
 ----
 
 . Edit the `ksmConfiguration` stanza:

--- a/modules/virt-configuring-aaq-operator.adoc
+++ b/modules/virt-configuring-aaq-operator.adoc
@@ -16,9 +16,9 @@ You can configure the AAQ Operator by specifying the fields of the `spec.applica
 .Procedure
 * Update the `HyperConverged` CR by running the following command:
 +
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
-$ oc patch hco kubevirt-hyperconverged -n openshift-cnv --type merge -p '{
+$ oc patch {HCOCliKind} kubevirt-hyperconverged -n {CNVNamespace} --type merge -p '{
   "spec": {
     "applicationAwareConfig": {
       "vmiCalcConfigName": "DedicatedVirtualResources",

--- a/modules/virt-configuring-certificate-rotation.adoc
+++ b/modules/virt-configuring-certificate-rotation.adoc
@@ -19,7 +19,7 @@ You can do this during {VirtProductName} installation in the web console or afte
 +
 [source,terminal,subs="attributes+"]
 ----
-$ oc edit hyperconverged kubevirt-hyperconverged -n {CNVNamespace}
+$ oc edit {HCOCliKind} kubevirt-hyperconverged -n {CNVNamespace}
 ----
 
 . Edit the `spec.certConfig` fields as shown in the following example. To avoid overloading the system, ensure that all values are greater than or equal to 10 minutes. Express all values as strings that comply with the link:https://golang.org/pkg/time/#ParseDuration[golang `ParseDuration` format].

--- a/modules/virt-configuring-cluster-dpdk.adoc
+++ b/modules/virt-configuring-cluster-dpdk.adoc
@@ -106,7 +106,7 @@ $ oc get performanceprofiles.performance.openshift.io profile-1 -o=jsonpath='{.s
 +
 [source,terminal,subs="attributes+"]
 ----
-$ oc patch hyperconverged kubevirt-hyperconverged -n {CNVNamespace} \
+$ oc patch {HCOCliKind} kubevirt-hyperconverged -n {CNVNamespace} \
     --type='json' -p='[{"op": "add", "path": "/spec/defaultRuntimeClass", "value":"<runtimeclass-name>"}]'
 ----
 +
@@ -119,7 +119,7 @@ Editing the `HyperConverged` CR changes a global setting that affects all VMs th
 +
 [source,terminal,subs="attributes+"]
 ----
-$ oc patch hyperconverged kubevirt-hyperconverged -n {CNVNamespace} \
+$ oc patch {HCOCliKind} kubevirt-hyperconverged -n {CNVNamespace} \
     --type='json' -p='[{"op": "replace", "path": "/spec/featureGates/alignCPUs", "value": true}]'
 ----
 +

--- a/modules/virt-configuring-cluster-eviction-strategy-cli.adoc
+++ b/modules/virt-configuring-cluster-eviction-strategy-cli.adoc
@@ -19,7 +19,7 @@ You can configure an eviction strategy for a cluster by using the command line.
 +
 [source,terminal,subs="attributes+"]
 ----
-$ oc edit hyperconverged kubevirt-hyperconverged -n {CNVNamespace}
+$ oc edit {HCOCliKind} kubevirt-hyperconverged -n {CNVNamespace}
 ----
 
 . Set the cluster eviction strategy as shown in the following example:

--- a/modules/virt-configuring-default-cpu-model.adoc
+++ b/modules/virt-configuring-default-cpu-model.adoc
@@ -24,7 +24,7 @@ The `defaultCPUModel` is case sensitive.
 +
 [source,terminal,subs="attributes+"]
 ----
-$ oc edit hyperconverged kubevirt-hyperconverged -n {CNVNamespace}
+$ oc edit {HCOCliKind} kubevirt-hyperconverged -n {CNVNamespace}
 ----
 
 . Add the `defaultCPUModel` field to the CR and set the value to the name of a CPU model that exists in the cluster:

--- a/modules/virt-configuring-highburst-profile.adoc
+++ b/modules/virt-configuring-highburst-profile.adoc
@@ -20,7 +20,7 @@ You can use the `highBurst` profile to create and maintain a large number of vir
 +
 [source,terminal,subs="attributes+"]
 ----
-$ oc patch hyperconverged kubevirt-hyperconverged -n {CNVNamespace} \
+$ oc patch {HCOCliKind} kubevirt-hyperconverged -n {CNVNamespace} \
   --type=json -p='[{"op": "add", "path": "/spec/tuningPolicy", \
   "value": "highBurst"}]'
 ----

--- a/modules/virt-configuring-live-migration-heavy.adoc
+++ b/modules/virt-configuring-live-migration-heavy.adoc
@@ -22,7 +22,7 @@ Configure live migration for heavy workloads by updating the `HyperConverged` cu
 +
 [source,terminal,subs="attributes+"]
 ----
-$ oc edit hyperconverged kubevirt-hyperconverged -n {CNVNamespace}
+$ oc edit {HCOCliKind} kubevirt-hyperconverged -n {CNVNamespace}
 ----
 +
 Example configuration file:

--- a/modules/virt-configuring-live-migration-limits.adoc
+++ b/modules/virt-configuring-live-migration-limits.adoc
@@ -20,7 +20,7 @@ Configure live migration limits and timeouts for the cluster by updating the `Hy
 +
 [source,terminal,subs="attributes+"]
 ----
-$ oc edit hyperconverged kubevirt-hyperconverged -n {CNVNamespace}
+$ oc edit {HCOCliKind} kubevirt-hyperconverged -n {CNVNamespace}
 ----
 +
 Example configuration file:

--- a/modules/virt-configuring-pod-log-verbosity.adoc
+++ b/modules/virt-configuring-pod-log-verbosity.adoc
@@ -19,7 +19,7 @@ You can configure the verbosity level of {VirtProductName} pod logs by editing t
 +
 [source,terminal,subs="attributes+"]
 ----
-$ oc edit hyperconverged kubevirt-hyperconverged -n {CNVNamespace}
+$ oc edit {HCOCliKind} kubevirt-hyperconverged -n {CNVNamespace}
 ----
 
 . Set the log level for one or more components by editing the `spec.logVerbosityConfig` stanza. For example:

--- a/modules/virt-configuring-secondary-dns-server.adoc
+++ b/modules/virt-configuring-secondary-dns-server.adoc
@@ -21,7 +21,7 @@ The Cluster Network Addons Operator (CNAO) deploys a Domain Name Server (DNS) se
 +
 [source,terminal,subs="attributes+"]
 ----
-$ oc edit hyperconverged kubevirt-hyperconverged -n {CNVNamespace}
+$ oc edit {HCOCliKind} kubevirt-hyperconverged -n {CNVNamespace}
 ----
 
 . Enable the DNS server and monitoring components according to the following example:
@@ -69,7 +69,7 @@ dns-lb     LoadBalancer     172.30.27.5    10.46.41.94      53:31829/TCP     5s
 +
 [source,terminal,subs="attributes+"]
 ----
-$ oc edit hyperconverged kubevirt-hyperconverged -n {CNVNamespace}
+$ oc edit {HCOCliKind} kubevirt-hyperconverged -n {CNVNamespace}
 ----
 
 . Add the external IP address that you previously retrieved to the `kubeSecondaryDNSNameServerIP` field in the enterprise DNS server records. For example:

--- a/modules/virt-configuring-secondary-network-vm-live-migration.adoc
+++ b/modules/virt-configuring-secondary-network-vm-live-migration.adoc
@@ -50,7 +50,7 @@ spec:
 +
 [source,terminal,subs="attributes+"]
 ----
-$ oc edit hyperconverged kubevirt-hyperconverged -n {CNVNamespace}
+$ oc edit {HCOCliKind} kubevirt-hyperconverged -n {CNVNamespace}
 ----
 
 . Add the name of the `NetworkAttachmentDefinition` object to the `spec.liveMigrationConfig` stanza of the `HyperConverged` CR.

--- a/modules/virt-configuring-storage-class-bootsource-update.adoc
+++ b/modules/virt-configuring-storage-class-bootsource-update.adoc
@@ -25,7 +25,7 @@ To ensure stable behavior and avoid unnecessary re-importing, you can specify th
 +
 [source,terminal,subs="attributes+"]
 ----
-$ oc edit hyperconverged kubevirt-hyperconverged -n {CNVNamespace}
+$ oc edit {HCOCliKind} kubevirt-hyperconverged -n {CNVNamespace}
 ----
 
 . Add the `dataImportCronTemplate` to the spec section of the `HyperConverged` resource and set the `storageClassName`:

--- a/modules/virt-configuring-vm-use-usb-device.adoc
+++ b/modules/virt-configuring-vm-use-usb-device.adoc
@@ -18,9 +18,9 @@ You can configure virtual machine (VM) access to a USB device. This configuratio
 
 . In the `HyperConverged` custom resource (CR), find the assigned resource name of the USB device:
 +
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
-$ oc get hyperconverged kubevirt-hyperconverged -n openshift-cnv
+$ oc get {HCOCliKind} kubevirt-hyperconverged -n {CNVNamespace}
 ----
 +
 *Example output*

--- a/modules/virt-configuring-workload-update-methods.adoc
+++ b/modules/virt-configuring-workload-update-methods.adoc
@@ -26,7 +26,7 @@ If a `VirtualMachineInstance` CR contains `evictionStrategy: LiveMigrate` and th
 +
 [source,terminal,subs="attributes+"]
 ----
-$ oc edit hyperconverged kubevirt-hyperconverged -n {CNVNamespace}
+$ oc edit {HCOCliKind} kubevirt-hyperconverged -n {CNVNamespace}
 ----
 
 . Edit the `workloadUpdateStrategy` stanza of the `HyperConverged` CR. For example:

--- a/modules/virt-creating-and-exposing-mediated-devices.adoc
+++ b/modules/virt-creating-and-exposing-mediated-devices.adoc
@@ -86,7 +86,7 @@ NVIDIA A2-2Q
 +
 [source,terminal,subs="attributes+"]
 ----
-$ oc edit hyperconverged kubevirt-hyperconverged -n {CNVNamespace}
+$ oc edit {HCOCliKind} kubevirt-hyperconverged -n {CNVNamespace}
 ----
 
 . Create and expose the mediated devices by updating the configuration:
@@ -97,7 +97,7 @@ Example `HyperConverged` CR:
 +
 [source,yaml,subs="attributes+"]
 ----
-apiVersion: hco.kubevirt.io/v1
+apiVersion: hco.kubevirt.io/v1beta1
 kind: HyperConverged
 metadata:
   name: kubevirt-hyperconverged

--- a/modules/virt-custom-kubemacpool-range.adoc
+++ b/modules/virt-custom-kubemacpool-range.adoc
@@ -22,7 +22,7 @@ As a cluster administrator, you can configure this range to ensure that MAC addr
 +
 [source,terminal,subs="attributes+"]
 ----
-$ oc edit hyperconverged kubevirt-hyperconverged -n {CNVNamespace}
+$ oc edit {HCOCliKind} kubevirt-hyperconverged -n {CNVNamespace}
 ----
 
 . Update the `HyperConverged` CR to configure the `rangeStart` and `rangeEnd` parameters that define your required MAC address range:
@@ -46,7 +46,7 @@ spec:
 +
 [source,terminal,subs="attributes+"]
 ----
-$ oc get hco kubevirt-hyperconverged -n {CNVNamespace} -o=jsonpath='{.spec.kubeMacPoolConfiguration}'
+$ oc get {HCOCliKind} kubevirt-hyperconverged -n {CNVNamespace} -o=jsonpath='{.spec.kubeMacPoolConfiguration}'
 ----
 +
 If you have successfully applied the configuration changes, the output shows the new MAC pool range you have configured:

--- a/modules/virt-defining-storageclass.adoc
+++ b/modules/virt-defining-storageclass.adoc
@@ -19,7 +19,7 @@ You can define the storage class that the Containerized Data Importer (CDI) uses
 +
 [source,terminal,subs="attributes+"]
 ----
-$ oc edit hyperconverged kubevirt-hyperconverged -n {CNVNamespace}
+$ oc edit {HCOCliKind} kubevirt-hyperconverged -n {CNVNamespace}
 ----
 
 . Add the `spec.scratchSpaceStorageClass` field to the CR, setting the value to the name of a storage class that exists in the cluster:

--- a/modules/virt-disable-auto-updates-single-boot-source.adoc
+++ b/modules/virt-disable-auto-updates-single-boot-source.adoc
@@ -20,7 +20,7 @@ You can disable automatic updates for an individual boot source, whether it is c
 +
 [source,terminal,subs="attributes+"]
 ----
-$ oc edit hyperconverged kubevirt-hyperconverged -n {CNVNamespace}
+$ oc edit {HCOCliKind} kubevirt-hyperconverged -n {CNVNamespace}
 ----
 
 . Disable automatic updates for an individual boot source by editing the `spec.dataImportCronTemplates` field.

--- a/modules/virt-disable-kubervirt-hotplug-ratio.adoc
+++ b/modules/virt-disable-kubervirt-hotplug-ratio.adoc
@@ -18,13 +18,13 @@ If you are a cluster administrator and want to disable hot plugging for an entir
 
 . Modify the `HyperConverged` CR and set the `maxHotplugRatio` value to `1.0`:
 +
-[source,yaml]
+[source,yaml,subs="attributes+"]
 ----
 apiVersion: hco.kubevirt.io/v1beta1
 kind: HyperConverged
 metadata:
   name: kubevirt-hyperconverged
-  namespace: kubevirt-hyperconverged
+  namespace: {CNVNamespace}
 spec:
   # ...
   kubevirtConfiguration:
@@ -44,9 +44,9 @@ $ oc apply -f <filename>.yaml
 
 . Check that you have configured the `maxHotplugRatio` value correctly, by running the following command:
 +
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
-$ oc get hyperconverged -n openshift-cnv -o jsonpath='{.spec.liveUpdateConfiguration.maxHotplugRatio}'
+$ oc get {HCOCliKind} -n {CNVNamespace} -o jsonpath='{.spec.liveUpdateConfiguration.maxHotplugRatio}'
 ----
 +
 If the configuration was successful, the output is the `maxHotplugRatio` value that you set in the previous procedure:

--- a/modules/virt-disabling-tls-for-registry.adoc
+++ b/modules/virt-disabling-tls-for-registry.adoc
@@ -19,7 +19,7 @@ You can disable TLS (transport layer security) for one or more container registr
 +
 [source,terminal,subs="attributes+"]
 ----
-$ oc edit hyperconverged kubevirt-hyperconverged -n {CNVNamespace}
+$ oc edit {HCOCliKind} kubevirt-hyperconverged -n {CNVNamespace}
 ----
 
 . Add a list of insecure registries to the `spec.storageImport.insecureRegistries` field.

--- a/modules/virt-enable-guest-log-default-cli.adoc
+++ b/modules/virt-enable-guest-log-default-cli.adoc
@@ -19,7 +19,7 @@ You can enable default access to VM guest system logs by editing the `HyperConve
 +
 [source,terminal,subs="attributes+"]
 ----
-$ oc edit hyperconverged kubevirt-hyperconverged -n {CNVNamespace}
+$ oc edit {HCOCliKind} kubevirt-hyperconverged -n {CNVNamespace}
 ----
 
 . Update the `disableSerialConsoleLog` value. For example:

--- a/modules/virt-enabling-aaq-operator.adoc
+++ b/modules/virt-enabling-aaq-operator.adoc
@@ -16,8 +16,8 @@ To deploy the AAQ Operator, set the `enableApplicationAwareQuota` field value to
 .Procedure
 * Set the `enableApplicationAwareQuota` field value to `true` in the `HyperConverged` CR by running the following command:
 +
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
-$ oc patch hco kubevirt-hyperconverged -n openshift-cnv \
+$ oc patch {HCOCliKind} kubevirt-hyperconverged -n {CNVNamespace} \
  --type json -p '[{"op": "add", "path": "/spec/enableApplicationAwareQuota", "value": true}]'
 ----

--- a/modules/virt-enabling-disabling-downward-metrics-feature-gate-cli.adoc
+++ b/modules/virt-enabling-disabling-downward-metrics-feature-gate-cli.adoc
@@ -22,7 +22,7 @@ To expose downward metrics for a host virtual machine, you can enable the `downw
 +
 [source,terminal,subs="attributes+"]
 ----
-$ oc patch hco kubevirt-hyperconverged -n openshift-cnv \
+$ oc patch {HCOCliKind} kubevirt-hyperconverged -n {CNVNamespace} \
   --type json -p '[{"op": "replace", "path": \
   "/spec/featureGates/downwardMetrics", \
   "value": true}]'
@@ -32,7 +32,7 @@ $ oc patch hco kubevirt-hyperconverged -n openshift-cnv \
 +
 [source,terminal,subs="attributes+"]
 ----
-$ oc patch hco kubevirt-hyperconverged -n openshift-cnv \
+$ oc patch {HCOCliKind} kubevirt-hyperconverged -n {CNVNamespace} \
   --type json -p '[{"op": "replace", "path": \
   "/spec/featureGates/downwardMetrics", \
   "value": false}]'

--- a/modules/virt-enabling-disabling-downward-metrics-feature-gate-yaml.adoc
+++ b/modules/virt-enabling-disabling-downward-metrics-feature-gate-yaml.adoc
@@ -18,22 +18,22 @@ To expose downward metrics for a host virtual machine, you can enable the `downw
 
 . Open the HyperConverged custom resource (CR) in your default editor by running the following command:
 +
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
-$ oc edit hyperconverged kubevirt-hyperconverged -n openshift-cnv
+$ oc edit {HCOCliKind} kubevirt-hyperconverged -n {CNVNamespace}
 ----
 
 . Choose to enable or disable the downwardMetrics feature gate as follows:
 
 * To enable the `downwardMetrics` feature gate, add and then set `spec.featureGates.downwardMetrics` to `true`. For example:
 +
-[source,yaml]
+[source,yaml,subs="attributes+"]
 ----
 apiVersion: hco.kubevirt.io/v1beta1
 kind: HyperConverged
 metadata:
   name: kubevirt-hyperconverged
-  namespace: openshift-cnv
+  namespace: {CNVNamespace}
 spec:
     featureGates:
       downwardMetrics: true
@@ -43,13 +43,13 @@ spec:
 
 * To disable the `downwardMetrics` feature gate, set `spec.featureGates.downwardMetrics` to `false`. For example:
 +
-[source,yaml]
+[source,yaml,subs="attributes+"]
 ----
 apiVersion: hco.kubevirt.io/v1beta1
 kind: HyperConverged
 metadata:
   name: kubevirt-hyperconverged
-  namespace: openshift-cnv
+  namespace: {CNVNamespace}
 spec:
     featureGates:
       downwardMetrics: false

--- a/modules/virt-enabling-heterogeneous-clusters.adoc
+++ b/modules/virt-enabling-heterogeneous-clusters.adoc
@@ -23,6 +23,6 @@ include::snippets/technology-preview.adoc[]
 +
 [source,terminal,subs="attributes+"]
 ----
-$ oc patch hyperconverged kubevirt-hyperconverged -n {CNVNamespace} \
+$ oc patch {HCOCliKind} kubevirt-hyperconverged -n {CNVNamespace} \
   --type json -p '[{"op":"replace","path":"/spec/featureGates/enableMultiArchBootImageImport", "value": true}]'
 ----

--- a/modules/virt-enabling-persistent-efi.adoc
+++ b/modules/virt-enabling-persistent-efi.adoc
@@ -31,6 +31,6 @@ endif::openshift-dedicated[]
 +
 [source,terminal,subs="attributes+"]
 ----
-$ oc patch hyperconverged kubevirt-hyperconverged -n {CNVNamespace} \
+$ oc patch {HCOCliKind} kubevirt-hyperconverged -n {CNVNamespace} \
   --type json -p '[{"op":"replace","path":"/spec/featureGates/VMPersistentState", "value": true}]'
 ----

--- a/modules/virt-enabling-persistentreservation-feature-gate-cli.adoc
+++ b/modules/virt-enabling-persistentreservation-feature-gate-cli.adoc
@@ -19,6 +19,6 @@ You can enable the `persistentReservation` feature gate by using the command lin
 +
 [source,terminal,subs="attributes+"]
 ----
-$ oc patch hyperconverged kubevirt-hyperconverged -n openshift-cnv --type json -p \
+$ oc patch {HCOCliKind} kubevirt-hyperconverged -n {CNVNamespace} --type json -p \
 '[{"op":"replace","path":"/spec/featureGates/persistentReservation", "value": true}]'
 ----

--- a/modules/virt-enabling-usb-host-passthrough.adoc
+++ b/modules/virt-enabling-usb-host-passthrough.adoc
@@ -79,10 +79,10 @@ Device: 3-7
 
 . Add the required USB device to the `permittedHostDevices` stanza of the `HyperConvered` CR. The following example adds a device with vendor ID `045e` and product ID `07a5`: 
 +
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
-oc patch hyperconverged kubevirt-hyperconverged \
-  -n openshift-cnv \
+oc patch {HCOCliKind} kubevirt-hyperconverged \
+  -n {CNVNamespace} \
   --type=merge \
   -p '{
     "metadata": {
@@ -97,9 +97,9 @@ oc patch hyperconverged kubevirt-hyperconverged \
 
 * Ensure that the HCO CR contains the required USB devices:
 +
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
-$ oc get hyperconverged kubevirt-hyperconverged -n openshift-cnv
+$ oc get {HCOCliKind} kubevirt-hyperconverged -n {CNVNamespace}
 ----
 +
 *Example output*

--- a/modules/virt-exposing-pci-device-in-cluster-cli.adoc
+++ b/modules/virt-exposing-pci-device-in-cluster-cli.adoc
@@ -19,7 +19,7 @@ To expose PCI host devices in the cluster, add details about the PCI devices to 
 +
 [source,terminal,subs="attributes+"]
 ----
-$ oc edit hyperconverged kubevirt-hyperconverged -n {CNVNamespace}
+$ oc edit {HCOCliKind} kubevirt-hyperconverged -n {CNVNamespace}
 ----
 
 . Add the PCI device information to the `spec.permittedHostDevices.pciHostDevices` array.
@@ -28,7 +28,7 @@ Example configuration file:
 +
 [source,yaml,subs="attributes+"]
 ----
-apiVersion: hco.kubevirt.io/v1
+apiVersion: hco.kubevirt.io/v1beta1
 kind: HyperConverged
 metadata:
   name: kubevirt-hyperconverged

--- a/modules/virt-golden-images-namespace-cli.adoc
+++ b/modules/virt-golden-images-namespace-cli.adoc
@@ -20,7 +20,7 @@ You can configure a custom namespace for golden images in your cluster by settin
 +
 [source,terminal,subs="attributes+"]
 ----
-$ oc edit hyperconverged kubevirt-hyperconverged -n {CNVNamespace}
+$ oc edit {HCOCliKind} kubevirt-hyperconverged -n {CNVNamespace}
 ----
 
 . Configure the custom namespace by updating the value of the `spec.commonBootImageNamespace` field.
@@ -29,7 +29,7 @@ Example configuration file:
 +
 [source,yaml,subs="attributes+"]
 ----
-apiVersion: hco.kubevirt.io/v1
+apiVersion: hco.kubevirt.io/v1beta1
 kind: HyperConverged
 metadata:
   name: kubevirt-hyperconverged

--- a/modules/virt-managing-auto-update-all-system-boot-sources.adoc
+++ b/modules/virt-managing-auto-update-all-system-boot-sources.adoc
@@ -29,7 +29,7 @@ Custom boot sources are not affected by this setting.
 +
 [source,terminal,subs="attributes+"]
 ----
-$ oc patch hyperconverged kubevirt-hyperconverged -n {CNVNamespace} \
+$ oc patch {HCOCliKind} kubevirt-hyperconverged -n {CNVNamespace} \
   --type json -p '[{"op": "replace", "path": \
   "/spec/enableCommonBootImageImport", \
   "value": false}]'
@@ -39,7 +39,7 @@ $ oc patch hyperconverged kubevirt-hyperconverged -n {CNVNamespace} \
 +
 [source,terminal,subs="attributes+"]
 ----
-$ oc patch hyperconverged kubevirt-hyperconverged -n {CNVNamespace} \
+$ oc patch {HCOCliKind} kubevirt-hyperconverged -n {CNVNamespace} \
   --type json -p '[{"op": "replace", "path": \
   "/spec/enableCommonBootImageImport", \
   "value": true}]'

--- a/modules/virt-mod-golden-image-heterogeneous-clusters.adoc
+++ b/modules/virt-mod-golden-image-heterogeneous-clusters.adoc
@@ -22,7 +22,7 @@ include::snippets/technology-preview.adoc[]
 +
 [source,terminal,subs="attributes+"]
 ----
-$ oc edit hyperconverged kubevirt-hyperconverged -n {CNVNamespace}
+$ oc edit {HCOCliKind} kubevirt-hyperconverged -n {CNVNamespace}
 ----
 
 . Edit the `HyperConverged` CR, adding the appropriate values for `ssp.kubevirt.io/dict.architectures` annotation in the `dataImportCronTemplates` section. For example:

--- a/modules/virt-modify-workload-node-heterogeneous-cluster.adoc
+++ b/modules/virt-modify-workload-node-heterogeneous-cluster.adoc
@@ -23,7 +23,7 @@ If you have a heterogeneous cluster but do not want to enable multiple architect
 +
 [source,terminal,subs="attributes+"]
 ----
-$ oc edit hyperconverged kubevirt-hyperconverged -n {CNVNamespace}
+$ oc edit {HCOCliKind} kubevirt-hyperconverged -n {CNVNamespace}
 ----
 
 . Edit the `HyperConverged` CR, to modify the workloads node placement to include only nodes with a specific architecture. For example:

--- a/modules/virt-monitoring-upgrade-status.adoc
+++ b/modules/virt-monitoring-upgrade-status.adoc
@@ -42,7 +42,7 @@ conditions by running the following command:
 +
 [source,terminal,subs="attributes+"]
 ----
-$ oc get hyperconverged kubevirt-hyperconverged -n {CNVNamespace} \
+$ oc get {HCOCliKind} kubevirt-hyperconverged -n {CNVNamespace} \
   -o=jsonpath='{range .status.conditions[*]}{.type}{"\t"}{.status}{"\t"}{.message}{"\n"}{end}'
 ----
 +

--- a/modules/virt-overriding-cpu-and-memory-defaults.adoc
+++ b/modules/virt-overriding-cpu-and-memory-defaults.adoc
@@ -19,7 +19,7 @@ Modify the default settings for CPU and memory requests and limits for your use 
 +
 [source,terminal,subs="attributes+"]
 ----
-$ oc edit hyperconverged kubevirt-hyperconverged -n {CNVNamespace}
+$ oc edit {HCOCliKind} kubevirt-hyperconverged -n {CNVNamespace}
 ----
 
 . Add the `spec.resourceRequirements.storageWorkloads` stanza to the CR, setting the values based on your use case. For example:

--- a/modules/virt-overriding-default-fs-overhead-value.adoc
+++ b/modules/virt-overriding-default-fs-overhead-value.adoc
@@ -19,7 +19,7 @@ Change the amount of persistent volume claim (PVC) space that the {VirtProductNa
 +
 [source,terminal,subs="attributes+"]
 ----
-$ oc edit hyperconverged kubevirt-hyperconverged -n {CNVNamespace}
+$ oc edit {HCOCliKind} kubevirt-hyperconverged -n {CNVNamespace}
 ----
 
 . Edit the `spec.filesystemOverhead` fields, populating them with your chosen values:

--- a/modules/virt-preventing-workload-updates-during-control-plane-only-update.adoc
+++ b/modules/virt-preventing-workload-updates-during-control-plane-only-update.adoc
@@ -52,7 +52,7 @@ $ oc get kv kubevirt-kubevirt-hyperconverged \
 +
 [source,terminal,subs="attributes+"]
 ----
-$ oc patch hyperconverged kubevirt-hyperconverged -n {CNVNamespace} \
+$ oc patch {HCOCliKind} kubevirt-hyperconverged -n {CNVNamespace} \
   --type json -p '[{"op":"replace","path":"/spec/workloadUpdateStrategy/workloadUpdateMethods", "value":[]}]'
 ----
 
@@ -60,7 +60,7 @@ $ oc patch hyperconverged kubevirt-hyperconverged -n {CNVNamespace} \
 +
 [source,terminal,subs="attributes+"]
 ----
-$ oc get hyperconverged kubevirt-hyperconverged -n {CNVNamespace} -o json | jq ".status.conditions"
+$ oc get {HCOCliKind} kubevirt-hyperconverged -n {CNVNamespace} -o json | jq ".status.conditions"
 ----
 
 . Update your cluster from the source EUS version to the next minor version of {product-title}:
@@ -98,7 +98,7 @@ $ oc get csv -n {CNVNamespace}
 +
 [source,terminal,subs="attributes+"]
 ----
-$ oc get hyperconverged kubevirt-hyperconverged -n {CNVNamespace} -o json | jq ".status.versions"
+$ oc get {HCOCliKind} kubevirt-hyperconverged -n {CNVNamespace} -o json | jq ".status.versions"
 ----
 
 . Wait until the `HyperConverged` Operator again reports the `Upgradeable` condition.
@@ -130,7 +130,7 @@ The update completes when the `VERSION` field matches the target EUS version and
 +
 [source,terminal,subs="attributes+"]
 ----
-$ oc patch hyperconverged kubevirt-hyperconverged -n {CNVNamespace} --type json -p \
+$ oc patch {HCOCliKind} kubevirt-hyperconverged -n {CNVNamespace} --type json -p \
 "[{\"op\":\"add\",\"path\":\"/spec/workloadUpdateStrategy/workloadUpdateMethods\", \"value\":{WorkloadUpdateMethodConfig}}]"
 ----
 

--- a/modules/virt-querying-metrics.adoc
+++ b/modules/virt-querying-metrics.adoc
@@ -195,13 +195,13 @@ You can expose and ignore specific labels by editing the `kubevirt-vm-labels-con
 +
 Example config map:
 +
-[source,yaml]
+[source,yaml,subs="attributes+"]
 ----
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: kubevirt-vm-labels-config
-  namespace: openshift-cnv
+  namespace: {CNVNamespace}
 data:
   allowlist: "*"
   ignorelist: ""

--- a/modules/virt-removing-mediated-device-from-cluster-cli.adoc
+++ b/modules/virt-removing-mediated-device-from-cluster-cli.adoc
@@ -19,14 +19,14 @@ As a cluster administrator you can remove mediated devices from the cluster so t
 +
 [source,terminal,subs="attributes+"]
 ----
-$ oc edit hyperconverged kubevirt-hyperconverged -n {CNVNamespace}
+$ oc edit {HCOCliKind} kubevirt-hyperconverged -n {CNVNamespace}
 ----
 
 . Remove the device information from the `spec.permittedHostDevices` stanza of the `HyperConverged` CR. For example:
 +
 [source,yaml,subs="attributes+"]
 ----
-apiVersion: hco.kubevirt.io/v1
+apiVersion: hco.kubevirt.io/v1beta1
 kind: HyperConverged
 metadata:
   name: kubevirt-hyperconverged

--- a/modules/virt-removing-pci-device-from-cluster-cli.adoc
+++ b/modules/virt-removing-pci-device-from-cluster-cli.adoc
@@ -17,7 +17,7 @@ To remove a PCI host device from the cluster, delete the information for that de
 +
 [source,terminal,subs="attributes+"]
 ----
-$ oc edit hyperconverged kubevirt-hyperconverged -n {CNVNamespace}
+$ oc edit {HCOCliKind} kubevirt-hyperconverged -n {CNVNamespace}
 ----
 
 . Remove the PCI device information from the `spec.permittedHostDevices.pciHostDevices` array by deleting the `pciDeviceSelector`, `resourceName` and `externalResourceProvider` (if applicable) fields for the appropriate device. In this example, the `intel.com/qat` resource has been deleted.
@@ -26,7 +26,7 @@ Example configuration file:
 +
 [source,yaml,subs="attributes+"]
 ----
-apiVersion: hco.kubevirt.io/v1
+apiVersion: hco.kubevirt.io/v1beta1
 kind: HyperConverged
 metadata:
   name: kubevirt-hyperconverged

--- a/modules/virt-removing-wasp-agent.adoc
+++ b/modules/virt-removing-wasp-agent.adoc
@@ -18,9 +18,9 @@ If you no longer need memory overcommitment, you can remove the `wasp-agent` com
 
 . Revert the memory overcommitment configuration by running the following command:
 +
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
-$ oc -n openshift-cnv patch HyperConverged/kubevirt-hyperconverged \
+$ oc patch -n {CNVNamespace} {HCOCliKind} kubevirt-hyperconverged \
   --type='json' \
   -p='[{"op": "remove", "path": "/spec/higherWorkloadDensity"}]'
 ----

--- a/modules/virt-setting-cpu-allocation-ratio.adoc
+++ b/modules/virt-setting-cpu-allocation-ratio.adoc
@@ -21,9 +21,9 @@ To change the default number of vCPUs mapped to each physical CPU, set the `vmiC
 
 . Open the `HyperConverged` CR in your default editor by running the following command:
 +
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
-$ oc edit hyperconverged kubevirt-hyperconverged -n openshift-cnv
+$ oc edit {HCOCliKind} kubevirt-hyperconverged -n {CNVNamespace}
 ----
 
 . Set the `vmiCPUAllocationRatio`:

--- a/modules/virt-subscribing-cli.adoc
+++ b/modules/virt-subscribing-cli.adoc
@@ -129,7 +129,7 @@ kubevirt-hyperconverged-operator.v{HCOVersion}   {VirtProductName}   {HCOVersion
 +
 [source,terminal,subs="attributes+"]
 ----
-$ oc get hco -n {CNVNamespace} kubevirt-hyperconverged -o json | jq .status.versions
+$ oc get {HCOCliKind} -n {CNVNamespace} kubevirt-hyperconverged -o json | jq .status.versions
 ----
 +
 Example output:
@@ -146,7 +146,7 @@ Example output:
 +
 [source,terminal,subs="attributes+"]
 ----
-$ oc get hco kubevirt-hyperconverged -n {CNVNamespace} -o json | jq -r '.status.conditions[] | {type,status}'
+$ oc get {HCOCliKind} kubevirt-hyperconverged -n {CNVNamespace} -o json | jq -r '.status.conditions[] | {type,status}'
 ----
 +
 Example output:

--- a/modules/virt-temporary-token-VNC.adoc
+++ b/modules/virt-temporary-token-VNC.adoc
@@ -25,7 +25,7 @@ Kubernetes also supports authentication using client certificates, instead of a 
 +
 [source,terminal,subs="attributes+"]
 ----
-$ oc patch hyperconverged kubevirt-hyperconverged -n {CNVNamespace} --type json -p '[{"op": "replace", "path": "/spec/deployVmConsoleProxy", "value": true}]'
+$ oc patch {HCOCliKind} kubevirt-hyperconverged -n {CNVNamespace} --type json -p '[{"op": "replace", "path": "/spec/deployVmConsoleProxy", "value": true}]'
 ----
 
 . Generate a token by entering the following command:

--- a/modules/virt-using-wasp-agent-to-configure-higher-vm-workload-density.adoc
+++ b/modules/virt-using-wasp-agent-to-configure-higher-vm-workload-density.adoc
@@ -147,9 +147,9 @@ The *Memory density* field shows the actual and requested values.
 * CLI
 ** Configure your {VirtProductName} to enable higher memory density and set the overcommit rate:
 +
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
-$ oc -n openshift-cnv patch HyperConverged/kubevirt-hyperconverged --type='json' -p='[ \
+$ oc patch -n {CNVNamespace} {HCOCliKind} kubevirt-hyperconverged --type='json' -p='[ \
   { \
   "op": "replace", \
   "path": "/spec/higherWorkloadDensity/memoryOvercommitPercentage", \
@@ -212,9 +212,9 @@ If swap is provisioned, an amount greater than zero is displayed in the `Swap:` 
 
 . Verify the {VirtProductName} memory overcommitment configuration by running the following command:
 +
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
-$ oc -n openshift-cnv get HyperConverged/kubevirt-hyperconverged -o jsonpath='{.spec.higherWorkloadDensity}{"\n"}'
+$ oc get -n {CNVNamespace} {HCOCliKind} kubevirt-hyperconverged -o jsonpath='{.spec.higherWorkloadDensity}{"\n"}'
 ----
 +
 Example output:

--- a/modules/virt-verify-status-bootsource-update.adoc
+++ b/modules/virt-verify-status-bootsource-update.adoc
@@ -20,7 +20,7 @@ You can determine if a boot source is system-defined or custom by viewing the `H
 +
 [source,terminal,subs="attributes+"]
 ----
-$ oc get hyperconverged kubevirt-hyperconverged -n {CNVNamespace} -o yaml
+$ oc get {HCOCliKind} kubevirt-hyperconverged -n {CNVNamespace} -o yaml
 ----
 +
 Example output:

--- a/snippets/virt-cdrom-feature-gate-requirements.adoc
+++ b/snippets/virt-cdrom-feature-gate-requirements.adoc
@@ -9,7 +9,7 @@
 +
 [source,yaml,subs="attributes+"]
 ----
-apiVersion: hco.kubevirt.io/v1
+apiVersion: hco.kubevirt.io/v1beta1
 kind: HyperConverged
 metadata:
   name: kubevirt-hyperconverged
@@ -23,7 +23,7 @@ spec:
 +
 [source,yaml,subs="attributes+"]
 ----
-apiVersion: hco.kubevirt.io/v1
+apiVersion: hco.kubevirt.io/v1beta1
 kind: HyperConverged
 metadata:
   name: kubevirt-hyperconverged


### PR DESCRIPTION
In v4.22, we are intrucing a new API version for the HyperConverged type (A.K.A hco or hyperconverged). This version is not the default one in v4.22, but because of the way kubernetes works, any non-versioned request of this type (get/edit/patch...), will use the newest API version, regadless if it's the default one or not.

This breaks many examples or intructions in the documentation.

To solve this, we'll use a versioned name of the HyperConverged type. To ease that, this PR defined a new attibute named `HCOCliKind`, with the value of `hyperconvergeds.v1beta1.hco.kubevirt.io`. Then the PR replaces any read or write command line operation with `hco` or `hyperconverged`, with the new attribute.

This will also ease the fix in future release, to get it back to the shorter, non-versioned name.

Version(s):
v4.22

Issue:
https://redhat.atlassian.net/browse/CNV-78917

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
