### PR TITLE
RHDEVDOCS-7107: CQA 2.0 fixes for Running gitops control plane workloads on infrastructure nodes

### DIFF
--- a/gitops_workloads_infranodes/running-gitops-control-plane-workloads-on-infrastructure-nodes.adoc
+++ b/gitops_workloads_infranodes/running-gitops-control-plane-workloads-on-infrastructure-nodes.adoc
@@ -21,5 +21,5 @@ include::modules/moving-the-gitops-operator-pod-to-infrastructure-nodes.adoc[lev
 [role="_additional-resources"]
 [id="additional-resources_{context}"]
 == Additional resources
-* For more information about taints and tolerations, see link:https://docs.openshift.com/container-platform/latest/nodes/scheduling/nodes-scheduler-taints-tolerations.html#nodes-scheduler-taints-tolerations[Controlling pod placement using node taints].
-* For more information about infrastructure machine sets, see link:https://docs.openshift.com/container-platform/latest/machine_management/creating-infrastructure-machinesets.html#creating-infrastructure-machinesets[Creating infrastructure machine sets].
+* link:https://docs.openshift.com/container-platform/latest/nodes/scheduling/nodes-scheduler-taints-tolerations.html#nodes-scheduler-taints-tolerations[Controlling pod placement using node taints]
+* link:https://docs.openshift.com/container-platform/latest/machine_management/creating-infrastructure-machinesets.html#creating-infrastructure-machinesets[Creating infrastructure machine sets]

--- a/modules/go-add-infra-nodes.adoc
+++ b/modules/go-add-infra-nodes.adoc
@@ -14,7 +14,7 @@ You can move the {gitops-shortname} control plane workloads installed by the {gi
 * `openshift-gitops-dex-server deployment`
 * `openshift-gitops-redis deployment`
 * `openshift-gitops-redis-ha-haproxy deployment`
-* `openshift-gitops-repo-sever deployment`
+* `openshift-gitops-repo-server deployment`
 * `openshift-gitops-server deployment`
 * `openshift-gitops-application-controller statefulset`
 * `openshift-gitops-redis-server statefulset`
@@ -67,8 +67,10 @@ spec:
     value: reserved
 ----
 
-To verify that the workloads are scheduled on infrastructure nodes in the {gitops-title} namespace, click any of the pod names and ensure that the *Node selector* and *Tolerations* have been added.
+.Verification
 
+* To verify that the workloads are scheduled on infrastructure nodes in the {gitops-title} namespace, click any of the pod names and ensure that the *Node selector* and *Tolerations* have been added.
++
 [NOTE]
 ====
 Any manually added *Node selectors* and *Tolerations* in the default Argo CD CR will be overwritten by the toggle and the tolerations in the `GitOpsService` CR.

--- a/modules/moving-the-gitops-operator-pod-to-infrastructure-nodes.adoc
+++ b/modules/moving-the-gitops-operator-pod-to-infrastructure-nodes.adoc
@@ -67,8 +67,8 @@ spec:
 --
 where:
 
-`<metadata.name>`:: Specifies that the operator pod is only scheduled on an infrastructure node.
-`<metadata.namespace>`:: Defines the namespace of the pod to be accepted by the infrastructure node.
+`<metadata.name>`:: Specifies that the operator pod should only be scheduled on nodes with the `node-role.kubernetes.io/infra` label.
+`<metadata.namespace>`:: Allows the operator pod to tolerate taints on infrastructure nodes so it can run there.
 --
 +
 --
@@ -79,7 +79,9 @@ subscription.operators.coreos.com/openshift-gitops-operator edited
 ----
 --
 
-. Verify that the {gitops-shortname} Operator pod is running on the infrastructure node by running the following command:
+.Verification
+
+* Verify that the {gitops-shortname} Operator pod is running on the infrastructure node by running the following command:
 +
 [source,terminal]
 ----


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

gitops-docs-1.19, gitops-docs-1.20

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

https://redhat.atlassian.net/browse/RHDEVDOCS-7107

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

[Running GitOps control plane workloads on infrastructure nodes](https://109994--ocpdocs-pr.netlify.app/openshift-gitops/latest/gitops_workloads_infranodes/running-gitops-control-plane-workloads-on-infrastructure-nodes.html)

Peer review:
- [x] Peer has approved this change.
<!--- Peer approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Peer reviewer:

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
