### PR TITLE
OSDOCS-16408 [ROSA] CQA - Vale Check for Modules Included in ROSA Support 

### DIFF
--- a/modules/managed-cluster-notification-view-in-hcc.adoc
+++ b/modules/managed-cluster-notification-view-in-hcc.adoc
@@ -8,10 +8,10 @@
 = Viewing cluster notifications using the {hybrid-console}
 
 [role="_abstract"]
-Cluster notifications provide important information about the health of your cluster. You can view notifications that have been sent to your cluster in the **Cluster history** tab on the {hybrid-console}.
+Cluster notifications give important information about the health of your cluster. You can view notifications sent to your cluster in the **Cluster history** tab on the {hybrid-console}.
 
 .Prerequisites
-* You are logged in to the {hybrid-console-second}.
+* You have logged in to the {hybrid-console-second}.
 
 .Procedure
 . Navigate to the link:https://console.redhat.com/openshift[Clusters] page of the {hybrid-console-second}.
@@ -21,8 +21,9 @@ Cluster notifications provide important information about the health of your clu
 Cluster notifications appear under the Cluster history heading.
 . Optional: Filter for relevant cluster notifications
 +
-Use the filter controls to hide cluster notifications that are not relevant to you, so that you can focus on your area of expertise or on resolving a critical issue. You can filter notifications based on text in the notification description, severity level, notification type, when the notification was received, and which system or person triggered the notification.
+Use the filter controls to hide cluster notifications that are not relevant to you, so that you can focus on your area of expertise or on resolving a critical issue. You can filter notifications based on text in the notification description, severity level, notification type, when you received the notification, and the system or person that triggered the notification.
 
+// [role="_additional-resources"]
 // .Additional resources
 // * Cluster notification types
 // * Cluster notification severity levels

--- a/modules/rosa-hcp-no-console-access.adoc
+++ b/modules/rosa-hcp-no-console-access.adoc
@@ -6,7 +6,7 @@
 = Troubleshooting access to {hybrid-console}
 
 [role="_abstract"]
-In {product-title} clusters, the {product-title} OAuth server is hosted in the Red Hat service's AWS account while the web console service is published using the cluster's default ingress controller in the cluster's AWS account. If you can log in to your cluster using the OpenShift CLI (oc) but cannot access the {product-title} web console, verify the following criteria are met:
+In {product-title} clusters, the {product-title} OAuth server is hosted in the Red Hat service's AWS account while the web console service is published by using the cluster's default ingress controller in the cluster's AWS account. If you can log in to your cluster by using the OpenShift CLI (oc) but cannot access the {product-title} web console, verify the following criteria are met:
 
 .Procedure
 

--- a/modules/rosa-sts-ocm-and-user-role-troubleshooting.adoc
+++ b/modules/rosa-sts-ocm-and-user-role-troubleshooting.adoc
@@ -7,7 +7,7 @@
 = Resolving issues with ocm-roles and user-role IAM resources
 
 [role="_abstract"]
-You may receive an error when trying to create a cluster using the {rosa-cli-first}. This error means that the `user-role` IAM role is not linked to your AWS account. The most likely cause of this error is that another user in your Red{nbsp}Hat organization created the `ocm-role` IAM role. Your `user-role` IAM role needs to be created.
+You might receive an error when trying to create a cluster by using the {rosa-cli-first}. This error means that the `user-role` IAM role is not linked to your AWS account. The most likely cause of this error is that another user in your Red{nbsp}Hat organization created the `ocm-role` IAM role. Your `user-role` IAM role needs to be created.
 
 [NOTE]
 ====

--- a/modules/rosa-sts-ocm-role-creation.adoc
+++ b/modules/rosa-sts-ocm-role-creation.adoc
@@ -8,7 +8,7 @@
 = Creating an ocm-role IAM role
 
 [role="_abstract"]
-You create your `ocm-role` IAM roles by using the {rosa-cli-first}. If you want to create and manage clusters using only the {rosa-cli-first} and the OpenShift CLI (`oc`), you do not need these roles. You only need these roles when you want to use {cluster-manager} to create and manage clusters.
+You create your `ocm-role` IAM roles by using the {rosa-cli-first}. If you want to create and manage clusters by using only the {rosa-cli-first} and the OpenShift CLI (`oc`), you do not need these roles. You only need these roles when you want to use {cluster-manager} to create and manage clusters.
 
 .Prerequisites
 
@@ -33,7 +33,7 @@ $ rosa create ocm-role --admin
 ----
 +
 This command allows you to create the role by specifying specific attributes. The following example output shows the "auto mode" selected, which lets the {rosa-cli} (`rosa`) create your Operator roles and policies.
-See "Methods of account-wide role creation" for more information. The following example shows what your creation flow may look like.
+See "Methods of account-wide role creation" for more information. The following example shows what your creation flow might look like.
 +
 [source,terminal]
 ----
@@ -65,8 +65,8 @@ You do not see this prompt if you used the `--admin` option.
 +
 `Permissions boundary ARN (optional)`:: The Amazon Resource Name (ARN) of the policy to set permission boundaries.
 `Role Path (optional)`:: Specify an IAM path for the user name.
-`Role creation mode`:: Choose the method to create your AWS roles. Using `auto`, the {rosa-cli} generates and links the roles and policies. In the `auto` mode, you receive some different prompts to create the AWS roles.
-`Create the 'ManagedOpenShift-OCM-Role-182' role?`:: The `auto` method asks if you want to create a specific `ocm-role` using your prefix.
+`Role creation mode`:: Choose the method to create your AWS roles. By using `auto`, the {rosa-cli} generates and links the roles and policies. In the `auto` mode, you receive some different prompts to create the AWS roles.
+`Create the 'ManagedOpenShift-OCM-Role-182' role?`:: The `auto` method asks if you want to create a specific `ocm-role` by using your prefix.
 `OCM Role ARN`:: Confirm that you want to associate your IAM role with your {cluster-manager}.
 `Link the 'arn:aws:iam::<ARN>:role/ManagedOpenShift-OCM-Role-182' role with organization '<AWS ARN>'?`:: Links the created role with your AWS organization.
 --

--- a/modules/rosa-sts-user-role-creation.adoc
+++ b/modules/rosa-sts-user-role-creation.adoc
@@ -23,7 +23,7 @@ You can create your `user-role` IAM roles by using the {rosa-cli-first}.
 $ rosa create user-role
 ----
 +
-This command allows you to create the role by specifying specific attributes. The following example output shows the "auto mode" selected, which lets the {rosa-cli} (`rosa`) to create your Operator roles and policies. See "Understanding the auto and manual deployment modes" for more information. The following example shows what your creation flow may look like.
+This command allows you to create the role by specifying specific attributes. The following example output shows the "auto mode" selected, which lets the {rosa-cli} (`rosa`) to create your Operator roles and policies. See "Understanding the auto and manual deployment modes" for more information. The following example shows what your creation flow might look like.
 +
 [source,terminal]
 ----
@@ -47,8 +47,8 @@ where:
 `Role prefix`:: A prefix value for all of the created AWS resources. In this example, `ManagedOpenShift` prepends all of the AWS resources.
 `Permissions boundary ARN (optional)`:: The Amazon Resource Name (ARN) of the policy to set permission boundaries.
 `Role Path (optional)`:: Specify an IAM path for the user name.
-`Role creation mode`:: Choose the method to create your AWS roles. Using `auto`, the {rosa-cli} generates and links the roles and policies. In the `auto` mode, you receive some different prompts to create the AWS roles.
-`Create the 'ManagedOpenShift-User.osdocs-Role' role?`:: The `auto` method asks if you want to create a specific `user-role` using your prefix.
+`Role creation mode`:: Choose the method to create your AWS roles. By using `auto`, the {rosa-cli} generates and links the roles and policies. In the `auto` mode, you receive some different prompts to create the AWS roles.
+`Create the 'ManagedOpenShift-User.osdocs-Role' role?`:: The `auto` method asks if you want to create a specific `user-role` by using your prefix.
 `Link the 'arn:aws:iam::2066:role/ManagedOpenShift-User.osdocs-Role' role with account '1AGE'?`:: Links the created role with your AWS organization.
 --
 +

--- a/modules/rosa-troubleshoot-hcp-install.adoc
+++ b/modules/rosa-troubleshoot-hcp-install.adoc
@@ -16,11 +16,11 @@ The following table lists {product-title} installation error codes and what you 
 
 | OCM3999
 | Unknown error.
-| Check the cluster installation logs for more details, or delete this cluster and retry cluster installation. If this issue persists, contact support by logging in to the link:https://access.redhat.com/support/cases/#/case/list[*Customer Support* page].
+| Check the cluster installation logs for more details, or delete this cluster and retry cluster installation. If this issue persists, contact Red{nbsp}Hat support. See _Additional resources_ for more information.
 
 | OCM5001
 | {product-title} cluster provision has failed.
-| Check the cluster installation logs for more details, or delete this cluster and retry cluster installation. If this issue persists, contact support by logging in to the link:https://access.redhat.com/support/cases/#/case/list[*Customer Support* page].
+| Check the cluster installation logs for more details, or delete this cluster and retry cluster installation. If this issue persists, contact Red{nbsp}Hat support. See _Additional resources_ for more information.
 
 | OCM5002
 | The maximum resource tag size of 25 has been exceeded.
@@ -67,3 +67,7 @@ For more information about {product-title} IAM role resources, see _ROSA IAM rol
 | Try your cluster installation in another region or retry cluster installation.
 
 |===
+
+[role="_additional-resources"]
+.Additional resources
+* link:https://access.redhat.com/support/cases/#/case/list[Red Hat Customer Support]

--- a/modules/rosa-troubleshooting-awsapiratelimitexceeded-failure-deployment.adoc
+++ b/modules/rosa-troubleshooting-awsapiratelimitexceeded-failure-deployment.adoc
@@ -8,13 +8,15 @@
 [role="_abstract"]
 If a cluster creation action fails, you might receive the following error messages.
 
-.Example install logs output
+The following example shows the install logs output:
+
 [source,terminal]
 ----
 level=error\nlevel=error msg=Error: error waiting for Route53 Hosted Zone .* creation: timeout while waiting for state to become 'INSYNC' (last state: 'PENDING', timeout: 15m0s)
 ----
 
-.Example {cluster-manager} output
+The following example shows the {cluster-manager} output:
+
 [source,terminal]
 ----
 Provisioning Error Code:    OCM3008

--- a/modules/rosa-troubleshooting-awsec2quotaexceeded-failure-deployment.adoc
+++ b/modules/rosa-troubleshooting-awsec2quotaexceeded-failure-deployment.adoc
@@ -8,7 +8,8 @@
 [role="_abstract"]
 If a cluster creation action fails, you might receive the following error message.
 
-.Example output
+The following example shows the output:
+
 [source,terminal]
 ----
 Provisioning Error Code:    OCM3042
@@ -33,7 +34,7 @@ This error indicates that you have reached the EC2 quota limit for the region me
 .. If you have a CNAME record for your domain that points to your load balancer, point it to a new location and wait for the DNS change to take effect before deleting your load balancer.
 .. Open the link:https://console.aws.amazon.com/ec2/[Amazon EC2 console].
 .. On the navigation pane, choose **Instances**.
-.. Select the instance, and choose **Terminate instance**.
+.. Select the instance, and choose **Stop instance**.
 
 
 

--- a/modules/rosa-troubleshooting-awsinsufficientcapacity-failure-deployment.adoc
+++ b/modules/rosa-troubleshooting-awsinsufficientcapacity-failure-deployment.adoc
@@ -6,9 +6,8 @@
 = Troubleshooting cluster creation with an AWSInsufficientCapacity error
 
 [role="_abstract"]
-If a cluster creation action fails, you might receive the following error message.
+If a cluster creation action fails, you might receive the following error message:
 
-.Example output
 [source,terminal]
 ----
 Provisioning Error Code:    OCM3052

--- a/modules/rosa-troubleshooting-awsinsufficientpermission-failure-deployment.adoc
+++ b/modules/rosa-troubleshooting-awsinsufficientpermission-failure-deployment.adoc
@@ -8,7 +8,8 @@
 [role="_abstract"]
 If a cluster creation action fails, you might receive the following error message.
 
-.Example {cluster-manager} output
+The following example shows the {cluster-manager} output:
+
 [source,terminal]
 ----
 Provisioning Error Code:    OCM3033
@@ -49,7 +50,7 @@ $ rosa create account-roles -f
 $ rosa create operator-roles -c ${CLUSTER} -f
 ----
 
-. Validate all the prerequisites and attempt cluster reinstallation.
+. Validate all the prerequisites and attempt cluster re-installation.
 
 
 

--- a/modules/rosa-troubleshooting-awsnatgatewaylimitexceeded-failure-deployment.adoc
+++ b/modules/rosa-troubleshooting-awsnatgatewaylimitexceeded-failure-deployment.adoc
@@ -8,13 +8,15 @@
 [role="_abstract"]
 If a cluster creation action fails, you might receive the following error messages.
 
-.Example install logs output
+The following example shows the install logs output:
+
 [source,terminal]
 ----
 Failed to create cluster: Error creating NAT Gateway: NatGatewayLimitExceeded: Performing this operation would exceed the limit of 5 NAT gateways.
 ----
 
-.Example {cluster-manager} output
+The following example shows the {cluster-manager} output:
+
 [source,terminal]
 ----
 Provisioning Error Code:    OCM3019

--- a/modules/rosa-troubleshooting-awssubnetnotexist-failure-deployment.adoc
+++ b/modules/rosa-troubleshooting-awssubnetnotexist-failure-deployment.adoc
@@ -8,13 +8,15 @@
 [role="_abstract"]
 If a cluster creation action fails, you can receive the following error messages.
 
-.Example install logs output
+The following example shows the install logs output:
+
 [source,terminal]
 ----
 The subnet ID 'subnet-<somesubnetID>' does not exist.
 ----
 
-.Example {cluster-manager} output
+The following example shows the {cluster-manager} output:
+
 [source,terminal]
 ----
 Provisioning Error Code:    OCM3032

--- a/modules/rosa-troubleshooting-awsvpclimit-failure-deployment.adoc
+++ b/modules/rosa-troubleshooting-awsvpclimit-failure-deployment.adoc
@@ -8,7 +8,8 @@
 [role="_abstract"]
 If a cluster creation action fails, you might receive the following error message.
 
-.Example {cluster-manager} output
+The following example shows the {cluster-manager} output:
+
 [source,terminal]
 ----
 Provisioning Error Code:    OCM3013
@@ -29,9 +30,9 @@ This error indicates that you have reached the quota for the number of VPCs.
 .. For **Increase quota value**, enter the new value. The new value must be greater than the current value.
 .. Choose **Request**.
 +
-* Clean unused VPCs. Before you can delete a VPC, you must first terminate or delete any resources that created a requester-managed network interface in the VPC. For example, you must terminate your EC2 instances and delete your load balancers, NAT gateways, transit gateways, and interface VPC endpoints before deleting a VPC:
+* Clean unused VPCs. Before you can delete a VPC, you must first stop or delete any resources that created a requester-managed network interface in the VPC. For example, you must stop your EC2 instances and delete your load balancers, NAT gateways, transit gateways, and interface VPC endpoints before deleting a VPC:
 .. Sign in to the link:https://console.aws.amazon.com/ec2/[AWS EC2 console].
-.. Terminate all instances in the VPC. For more information, see link:https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/terminating-instances.html[Terminate Amazon EC2 instances].
+.. Stop all instances in the VPC. For more information, see link:https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/terminating-instances.html[Stop Amazon EC2 instances].
 .. Open the link:https://console.aws.amazon.com/vpc[Amazon VPC console].
 .. In the navigation pane, choose **Your VPCs**.
 .. Select the VPC to delete and choose **Actions, Delete VPC**.

--- a/modules/rosa-troubleshooting-cluster-deletion.adoc
+++ b/modules/rosa-troubleshooting-cluster-deletion.adoc
@@ -6,9 +6,8 @@
 = Repairing a cluster that cannot be deleted
 
 [role="_abstract"]
-In specific cases, the following error appears in {cluster-manager-url} if you attempt to delete your cluster.
+In specific cases, the following error is displayed in {cluster-manager-url} if you attempt to delete your cluster:
 
-.Example output
 [source,terminal]
 ----
 Error deleting cluster
@@ -17,9 +16,8 @@ CLUSTERS-MGMT-400: Failed to delete cluster <hash>: sts_user_role is not linked 
 Operation ID: b0572d6e-fe54-499b-8c97-46bf6890011c
 ----
 
-If you try to delete your cluster from the CLI, the following error appears.
+If you try to delete your cluster from the CLI, the following error is displayed:
 
-.Example output
 [source,terminal]
 ----
 E: Failed to delete cluster <hash>: sts_user_role is not linked to your account. sts_ocm_role is linked to your organization <org_number> which requires sts_user_role to be linked to your Red Hat account <account_id>.Please create a user role and link it to the account: User Account <account ID> is not authorized to perform STS cluster operations

--- a/modules/rosa-troubleshooting-deleteiamrole-deployment.adoc
+++ b/modules/rosa-troubleshooting-deleteiamrole-deployment.adoc
@@ -6,9 +6,8 @@
 = Troubleshooting cluster creation with a DeletingIAMRole error
 
 [role="_abstract"]
-If a cluster creation action fails, you might receive the following error message.
+If a cluster creation action fails, you might receive the following error message:
 
-.Example output
 [source,terminal]
 ----
 OCM3031: Error deleting IAM Role (role-name): DeleteConflict: Cannot delete entity, must detach all policies first.\nlevel=error msg=\tstatus code: 409
@@ -25,7 +24,8 @@ The cluster's installation was blocked as the cluster installer was not able to 
 $ aws iam list-attached-role-policies --role-name <role-name>
 ----
 +
-.Example output
+This command returns output similar to the following:
++
 [source,terminal]
 ----
 {

--- a/modules/rosa-troubleshooting-elb-service-role.adoc
+++ b/modules/rosa-troubleshooting-elb-service-role.adoc
@@ -6,9 +6,8 @@
 = Creating the Elastic Load Balancing (ELB) service-linked role
 
 [role="_abstract"]
-If you have not created a load balancer in your AWS account, it is possible that the service-linked role for Elastic Load Balancing (ELB) might not exist yet. You may receive the following error:
+If you have not created a load balancer in your AWS account, it is possible that the service-linked role for Elastic Load Balancing (ELB) might not exist yet. You might receive the following error:
 
-.Example output
 [source,terminal]
 ----
 Error: Error creating network Load Balancer: AccessDenied: User: arn:aws:sts::xxxxxxxxxxxx:assumed-role/ManagedOpenShift-Installer-Role/xxxxxxxxxxxxxxxxxxx is not authorized to perform: iam:CreateServiceLinkedRole on resource: arn:aws:iam::xxxxxxxxxxxx:role/aws-service-role/elasticloadbalancing.amazonaws.com/AWSServiceRoleForElasticLoadBalancing"

--- a/modules/rosa-troubleshooting-expired-token.adoc
+++ b/modules/rosa-troubleshooting-expired-token.adoc
@@ -9,9 +9,10 @@
 = Troubleshooting expired offline access tokens
 
 [role="_abstract"]
-If you use the {product-title} (ROSA) CLI, `rosa`, and your api.openshift.com offline access token expires, an error message appears. This happens when sso.redhat.com invalidates the token.
+If you use the {product-title} (ROSA) CLI, `rosa`, and your api.openshift.com offline access token expires, an error message is displayed. This happens when sso.redhat.com invalidates the token.
 
-.Example output
+The following example shows the output:
+
 [source,terminal]
 ----
 Can't get tokens ....
@@ -19,4 +20,4 @@ Can't get access tokens ....
 ----
 
 .Procedure
-* Generate a new offline access token at the following URL. A new offline access token is generated every time you visit the {cluster-manager-url} URL.
+* Generate a new offline access token at the following URL. The {cluster-manager-url} URL generates a new offline access token every time you visit it.

--- a/modules/rosa-troubleshooting-installing.adoc
+++ b/modules/rosa-troubleshooting-installing.adoc
@@ -62,12 +62,12 @@ Run the following command to verify you have the available quota on your AWS acc
 $ rosa verify quota
 ----
 +
-AWS quotas change based on region. Be sure you are verifying your quota for the correct AWS region. If you need to increase your quota, navigate to your link:https://aws.amazon.com/console/[AWS console], and request a quota increase for the service that failed.
+AWS quotas change based on region. Be sure you are verifying your quota for the correct AWS region. If you need to increase your quota, go to your link:https://aws.amazon.com/console/[AWS console], and request a quota increase for the service that failed.
 
 * AWS notification emails:
 +
 When creating a cluster, the {product-title} service creates small instances in all supported regions. This check ensures the AWS account being used can deploy to each supported region.
 +
-For AWS accounts that are not using all supported regions, AWS may send one or more emails confirming that "Your Request For Accessing AWS Resources Has Been Validated". Typically the sender of this email is aws-verification@amazon.com.
+For AWS accounts that are not using all supported regions, AWS might send one or more emails confirming that "Your Request For Accessing AWS Resources Has Been Validated." Typically the sender of this email is aws-verification@amazon.com.
 +
 This is expected behavior as the {product-title} service is validating your AWS account configuration.

--- a/modules/rosa-troubleshooting-invalidinstallconfigsubnet-failure-deployment.adoc
+++ b/modules/rosa-troubleshooting-invalidinstallconfigsubnet-failure-deployment.adoc
@@ -8,20 +8,22 @@
 [role="_abstract"]
 If a cluster creation action fails, you might receive the following error messages.
 
-.Example install logs output
+The following example shows the install logs output:
+
 [source,terminal]
 ----
-platform.aws.subnets[1]: Invalid value: "subnet-0babad72exxxxxxxx": subnet's CIDR range start 10.69.1x.3x is outside of the specified machine networks
+platform.aws.subnets[1]: Invalid value: "subnet-0babad72exxxxxxxx": subnet CIDR range start 10.69.1x.3x is outside of the specified machine networks
 ----
 
-.Example {cluster-manager} output
+The following example shows the {cluster-manager} output:
+
 [source,terminal]
 ----
 Provisioning Error Code:    OCM3020
 Provisioning Error Message: Subnet CIDR ranges are outside of specified machine CIDR.
 ----
 
-These errors indicate that a subnet's CIDR range start is outside of the specified machine networks.
+These errors indicate that a subnet CIDR range start is outside of the specified machine networks.
 
 .Procedure
 

--- a/modules/rosa-troubleshooting-invalidkmskey-failure-deployment.adoc
+++ b/modules/rosa-troubleshooting-invalidkmskey-failure-deployment.adoc
@@ -8,13 +8,15 @@
 [role="_abstract"]
 If a cluster creation action fails, you might receive the following error messages.
 
-.Example install logs output
+The following example shows the install logs output:
+
 [source,terminal]
 ----
 Client.InvalidKMSKey.InvalidState: The KMS key provided is in an incorrect state
 ----
 
-.Example {cluster-manager} output
+The following example shows the {cluster-manager} output:
+
 [source,terminal]
 ----
 Provisioning Error Code:    OCM3055

--- a/modules/rosa-troubleshooting-lblimitexceeded-failure-deployment.adoc
+++ b/modules/rosa-troubleshooting-lblimitexceeded-failure-deployment.adoc
@@ -6,9 +6,8 @@
 = Troubleshooting cluster creation with an ALoadBalancerLimitExceeded error
 
 [role="_abstract"]
-If a cluster creation action fails, you might receive the following error message.
+If a cluster creation action fails, you might receive the following error message:
 
-.Example output
 [source,terminal]
 ----
 Provisioning Error Code:    OCM3036

--- a/modules/rosa-troubleshooting-multipleroute53zonesfound-failure-deployment.adoc
+++ b/modules/rosa-troubleshooting-multipleroute53zonesfound-failure-deployment.adoc
@@ -6,9 +6,8 @@
 = Troubleshooting cluster creation with a MultipleRoute53ZonesFound error
 
 [role="_abstract"]
-If a cluster creation action fails, you might receive the following error message.
+If a cluster creation action fails, you might receive the following error message:
 
-.Example output
 [source,terminal]
 ----
 Provisioning Error Code:    OCM3049

--- a/modules/rosa-troubleshooting-networking-nlb.adoc
+++ b/modules/rosa-troubleshooting-networking-nlb.adoc
@@ -3,11 +3,11 @@
 // * support/rosa-troubleshooting-deployments.adoc
 :_mod-docs-content-type: PROCEDURE
 [id="rosa-troubleshooting-general-deployment-failure_{context}"]
-= Connectivity issues on clusters with private Network Load Balancers
+= Connectivity issues on clusters with private network load balancers
 
 [role="_abstract"]
-{product-title} clusters created with version {product-version} deploy AWS Network Load Balancers (NLB) by default for the `default` ingress controller. In the case of a private NLB, the NLB's client IP address preservation might cause connections to be dropped where the source and destination are the same host. See the AWS's documentation about how to link:https://docs.aws.amazon.com/elasticloadbalancing/latest/network/load-balancer-troubleshooting.html#loopback-timeout[Troubleshoot your Network Load Balancer]. This IP address preservation has the implication that any customer workloads cohabitating on the same node with the router pods, may not be able send traffic to the private NLB fronting the ingress controller router.
+{product-title} clusters created with version {product-version} deploy AWS Network Load Balancers (NLB) by default for the `default` ingress controller. In the case of a private NLB, the NLB client IP address preservation might drop connections where the source and destination are the same host. See the AWS documentation about how to link:https://docs.aws.amazon.com/elasticloadbalancing/latest/network/load-balancer-troubleshooting.html#loopback-timeout[Troubleshoot your Network Load Balancer]. This IP address preservation means that customer workloads co-located on the same node with the router pods might not be able to send traffic to the private NLB fronting the ingress controller router.
 
 .Procedure
 
-* To mitigate this impact, reschedule your workloads onto nodes separate from those where the router pods are scheduled. Alternatively, rely on the internal pod and service networks for accessing other workloads co-located within the same cluster.
+* To mitigate this impact, reschedule your workloads onto nodes separate from those where the router pods run. Or, rely on the internal pod and service networks for accessing other workloads co-located within the same cluster.

--- a/modules/rosa-troubleshooting-osdccsadmin-deployment.adoc
+++ b/modules/rosa-troubleshooting-osdccsadmin-deployment.adoc
@@ -8,7 +8,8 @@
 [role="_abstract"]
 If a cluster creation action fails, you might receive the following error message.
 
-.Example output
+The following example shows the output:
+
 [source,terminal]
 ----
 Failed to create cluster: Unable to create cluster spec: Failed to get access keys for user 'osdCcsAdmin': NoSuchEntity: The user with name osdCcsAdmin cannot be found.

--- a/modules/rosa-troubleshooting-pendingverification-failure-deployment.adoc
+++ b/modules/rosa-troubleshooting-pendingverification-failure-deployment.adoc
@@ -8,7 +8,8 @@
 [role="_abstract"]
 If a cluster creation action fails, you might receive the following error message.
 
-.Example output
+The following example shows the output:
+
 [source,terminal]
 ----
 Provisioning Error Code:    OCM3021
@@ -17,9 +18,9 @@ Provisioning Error Message: Account pending verification for region. Verify the 
 
 When creating a cluster, the {product-title} service creates small instances in all supported regions. This check ensures the AWS account being used can deploy to each supported region.
 
-For AWS accounts that are not using all supported regions, AWS may send one or more emails confirming that "Your Request For Accessing AWS Resources Has Been Validated". Typically the sender of this email is aws-verification@amazon.com. This is expected behavior as the {product-title} service is validating your AWS account configuration.
+For AWS accounts that are not using all supported regions, AWS might send one or more emails confirming that "Your Request For Accessing AWS Resources Has Been Validated". Typically the sender of this email is aws-verification@amazon.com. This is expected behavior as the {product-title} service is validating your AWS account configuration.
 
-Normally, this validation gets completed within 15 minutes, but in some cases it can take up to 4 hours for AWS to validate. In order to attempt successful provisioning, Red{nbsp}Hat has configured our installer to reattempt installation if this issue occurs, but the installation can still fail if the validation continues to time out or if the validation itself fails.
+Normally, this validation gets completed within 15 minutes, but in some cases it can take up to 4 hours for AWS to validate. To attempt successful provisioning, Red{nbsp}Hat has configured our installer to reattempt installation if this issue occurs, but the installation can still fail if the validation continues to time out or if the validation itself fails.
 
 .Procedure
 * Reinstall the cluster or select a different AWS region or different availability zone(s).

--- a/modules/rosa-troubleshooting-s3bucketslimitexceeded-failure-deployment.adoc
+++ b/modules/rosa-troubleshooting-s3bucketslimitexceeded-failure-deployment.adoc
@@ -8,13 +8,15 @@
 [role="_abstract"]
 If a cluster creation action fails, you might receive the following error messages.
 
-.Example install logs output
+The following example shows the install logs output:
+
 [source,terminal]
 ----
 level=error msg="Error: Error creating S3 bucket: TooManyBuckets: You have attempted to create more buckets than allowed"
 ----
 
-.Example {cluster-manager} output
+The following example shows the {cluster-manager} output:
+
 [source,terminal]
 ----
 Provisioning Error Code:    OCM3014

--- a/modules/rosa-troubleshooting-toomanyroute53zones-failure-deployment.adoc
+++ b/modules/rosa-troubleshooting-toomanyroute53zones-failure-deployment.adoc
@@ -8,13 +8,15 @@
 [role="_abstract"]
 If a cluster creation action fails, you might receive the following error messages.
 
-.Example install logs output
+The following example shows the install logs output:
+
 [source,terminal]
 ----
 error msg=Error: error creating Route53 Hosted Zone: TooManyHostedZones: Limits Exceeded: MAX_HOSTED_ZONES_BY_OWNER - Cannot create more hosted zones.\\nlevel=error msg=\\tstatus code: 400
 ----
 
-.Example {cluster-manager} output
+The following example shows the {cluster-manager} output:
+
 [source,terminal]
 ----
 Provisioning Error Code:    OCM3006
@@ -37,9 +39,9 @@ The error suggests that the hosted zone quota is at capacity. By default, each A
 .. For **Increase quota value**, enter the new value. The new value must be greater than the current value.
 .. Choose **Request**.
 +
-** Delete unused VPCs. Before you can delete a VPC, you must first terminate or delete any resources that created a requester-managed network interface in the VPC. For example, you must terminate your EC2 instances and delete your load balancers, NAT gateways, transit gateways, and interface VPC endpoints:
+** Delete unused VPCs. Before you can delete a VPC, you must first stop or delete any resources that created a requester-managed network interface in the VPC. For example, you must stop your EC2 instances and delete your load balancers, NAT gateways, transit gateways, and interface VPC endpoints:
 .. Sign in to the link:https://console.aws.amazon.com/ec2/[AWS EC2 console].
-.. Terminate all instances in the VPC. For more information, see link:https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/terminating-instances.html[Terminate Amazon EC2 instances].
+.. Stop all instances in the VPC. For more information, see link:https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/terminating-instances.html[Stop Amazon EC2 instances].
 .. Open the link:https://console.aws.amazon.com/vpc[Amazon VPC console].
 .. In the navigation pane, choose **Your VPCs**.
 .. Select the VPC to delete and choose **Actions, Delete VPC**.

--- a/modules/rosa-verify-hcp-install.adoc
+++ b/modules/rosa-verify-hcp-install.adoc
@@ -6,10 +6,10 @@
 = Verifying installation of {product-title} clusters
 
 [role="_abstract"]
-If the {product-title} cluster is in the installing state for over 30 minutes and has not become ready, ensure the AWS account environment is prepared for the required cluster configurations. If the AWS account environment is prepared for the required cluster configurations correctly, try to delete and recreate the cluster. If the problem persists, contact support.
+If the {product-title} cluster is in the installing state for over 30 minutes and has not become ready, ensure the AWS account environment is prepared for the required cluster configurations. If the AWS account environment is prepared for the required cluster configurations correctly, try to delete and re-create the cluster. If the problem persists, contact support.
 
 .Procedure
 
 * Verify the AWS account environment is prepared for the required cluster configurations.
-* If the AWS account environment is prepared correctly, try to delete and recreate the cluster.
+* If the AWS account environment is prepared correctly, try to delete and re-create the cluster.
 * If the problem persists, contact support.

--- a/modules/support-reviewing-an-access-request-from-an-email-notification.adoc
+++ b/modules/support-reviewing-an-access-request-from-an-email-notification.adoc
@@ -10,7 +10,7 @@
 = Reviewing an access request from an email notification
 
 [role="_abstract"]
-Cluster owners will receive an email notification when Red{nbsp}Hat Site Reliability Engineering (SRE) request access to their cluster with a link to review the request in the {hybrid-console-second}.
+Cluster owners receive an email notification when Red{nbsp}Hat Site Reliability Engineering (SRE) request access to their cluster with a link to review the request in the {hybrid-console-second}.
 
 ifndef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 .Prerequisites
@@ -26,7 +26,7 @@ endif::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 +
 [NOTE]
 ====
-Denying an access request requires you to complete the *Justification* field. In this case, SRE can not directly act on the resources related to the incident. Customers can still use the link:https://access.redhat.com/support/cases/#/case/list[*Customer Support*] to help investigate and resolve any issues.
+Denying an access request requires you to complete the *Justification* field. In this case, SRE cannot directly act on the resources related to the incident. Customers can still use the link:https://access.redhat.com/support/cases/#/case/list[*Customer Support*] to help investigate and resolve any issues.
 ====
 
 . Click *Save*.

--- a/modules/support-reviewing-an-access-request-from-the-hybrid-console.adoc
+++ b/modules/support-reviewing-an-access-request-from-the-hybrid-console.adoc
@@ -30,7 +30,7 @@ endif::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 +
 [NOTE]
 ====
-Denying an access request requires you to complete the *Justification* field. In this case, SRE can not directly act on the resources related to the incident. Customers can still use the link:https://access.redhat.com/support/cases/#/case/list[*Customer Support*] to help investigate and resolve any issues.
+Denying an access request requires you to complete the *Justification* field. In this case, Site Reliability Engineering (SRE) cannot directly act on the resources related to the incident. Customers can still use the link:https://access.redhat.com/support/cases/#/case/list[*Customer Support*] to help investigate and resolve any issues.
 ====
 
 . Click *Save*.

--- a/modules/support-submitting-a-case-enable-approved-access.adoc
+++ b/modules/support-submitting-a-case-enable-approved-access.adoc
@@ -5,7 +5,7 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="support-submitting-a-case-enable-approved-access_{context}"]
-= Enabling Approved Access for ROSA clusters by submitting a support case
+= Enabling approved access for ROSA clusters by submitting a support case
 
 [role="_abstract"]
 {product-rosa} _Approved Access_ is not enabled by default. To enable _Approved Access_ for your {product-rosa} clusters, you should create a support ticket.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.20+

Issue:
https://redhat.atlassian.net/browse/OSDOCS-16408

Link to docs preview:

- https://110007--ocpdocs-pr.netlify.app/openshift-dedicated/latest/osd_cluster_admin/osd-cluster-notifications.html
- https://110007--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/rosa_architecture/rosa-sts-about-iam-resources.html
- https://110007--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/rosa_planning/rosa-hcp-prepare-iam-roles-resources.html
- https://110007--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/support/approved-access.html
- https://110007--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/support/troubleshooting/mos-tshoot-cluster-notifications.html
- https://110007--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/support/troubleshooting/rosa-troubleshooting-deployments.html
- https://110007--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/support/troubleshooting/rosa-troubleshooting-expired-tokens.html
- https://110007--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/support/troubleshooting/rosa-troubleshooting-iam-resources.html
- https://110007--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/support/troubleshooting/rosa-troubleshooting-installations-hcp.html
- https://110007--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/support/troubleshooting/rosa-troubleshooting-networking.html
- https://110007--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_architecture/rosa-sts-about-iam-resources.html
- https://110007--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_planning/rosa-sts-ocm-role.html
- https://110007--ocpdocs-pr.netlify.app/openshift-rosa/latest/support/approved-access.html
- https://110007--ocpdocs-pr.netlify.app/openshift-rosa/latest/support/troubleshooting/mos-tshoot-cluster-notifications.html
- https://110007--ocpdocs-pr.netlify.app/openshift-rosa/latest/support/troubleshooting/rosa-troubleshooting-deployments.html
- https://110007--ocpdocs-pr.netlify.app/openshift-rosa/latest/support/troubleshooting/rosa-troubleshooting-expired-tokens.html
- https://110007--ocpdocs-pr.netlify.app/openshift-rosa/latest/support/troubleshooting/rosa-troubleshooting-iam-resources.html
- https://110007--ocpdocs-pr.netlify.app/openshift-rosa/latest/support/troubleshooting/rosa-troubleshooting-installations.html
- https://110007--ocpdocs-pr.netlify.app/openshift-rosa/latest/support/troubleshooting/rosa-troubleshooting-networking.html

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
