### PR TITLE
[standalone-logging-docs-6.4] PR for OBSDOCS-3290: CQA + DITA readiness for assemblies and modules under v6.4 Release notes.

### DIFF
--- a/modules/logging-release-notes-6-4-0.adoc
+++ b/modules/logging-release-notes-6-4-0.adoc
@@ -6,6 +6,7 @@
 [id="logging-release-notes-6-4-0_{context}"]
 = Logging 6.4.0 release notes
 
+[role="_abstract"]
 This release of {LoggingProductName} is supported on {ocp-product-title} 4.18 and later. This release includes new features and bug fixes. 
 
 This release includes link:https://access.redhat.com/errata/RHBA-2025:21335[RHBA-2025:21335].
@@ -16,7 +17,7 @@ This release includes link:https://access.redhat.com/errata/RHBA-2025:21335[RHBA
 [id="log-collection_{context}"]
 === Log collection
 
-* With this release, the Vector collector has been updated to be based on Vector version 0.47.0.
+* With this release, the Vector collector is now updated to be based on Vector version 0.47.0.
 (https://issues.redhat.com/browse/LOG-7166[LOG-7166])
 
 
@@ -24,15 +25,15 @@ This release includes link:https://access.redhat.com/errata/RHBA-2025:21335[RHBA
 
 *  This release provides changes to log collector deployments to promote Technology Preview configuration options introduced in link:https://issues.redhat.com/browse/LOG-7196[LOG-7196] to General Availability.
 The change enables caching of kube API server calls and introduces a `ClusterLogForwarder` field to tune collector rollout strategy.
-Administrators managing clusters with large numbers of nodes can now modify the collector upgrade behavior so that the collector requests do not overwhelm the Kubernetes API server. You can control the behavior by setting `MaxUnavailable` field for collectors during upgrade.(https://issues.redhat.com/browse/LOG-7587[LOG-7587])
+Administrators managing clusters with large numbers of nodes can now change the collector upgrade behavior so that the collector requests do not overwhelm the Kubernetes API server. You can control the behavior by setting `MaxUnavailable` field for collectors during upgrade.(https://issues.redhat.com/browse/LOG-7587[LOG-7587])
 
-* With this release, an alert has been added to notify administrators of deprecated features that will be removed in future releases. As a result, you can make adjustments as needed. (link:https://issues.redhat.com/browse/LOG-7596[LOG-7596])
+* With this release, an alert has been added to tell administrators of deprecated features that will be removed in future releases. As a result, you can make adjustments as needed. (link:https://issues.redhat.com/browse/LOG-7596[LOG-7596])
 
 * With this release, you can forward logs to {aws-short} S3-compatible services using a new `s3` output type.
 The output supports custom endpoints and multiple authentication methods.
 It also provides flexible options for log organization that you can configure with dynamic key prefix templating, and tuning of log compression and batching. (link:https://issues.redhat.com/browse/LOG-7683[LOG-7683])
 
-* With this release, cross-account log forwarding is available for both CloudWatch and S3 outputs using the AWS AssumeRole functionality.
+* With this release, cross-account log forwarding is available for both CloudWatch and S3 outputs using the AWS `AssumeRole` functionality.
 This feature enables centralized logging by using a secure, two-step authentication process.
 By doing so, it upholds the principle of least privilege and maintains strong security boundaries, promoting a clear separation of concerns in the target account.
 (link:https://issues.redhat.com/browse/LOG-7687[LOG-7687])
@@ -43,7 +44,7 @@ For more information, see link:https://docs.redhat.com/en/documentation/red_hat_
 [id="log-storage_{context}"]
 === Log storage
 
-* With this release, a new alert has been added to the LokiStack to inform users if LokiStack components have not reached the ready state. (link:https://issues.redhat.com/browse/LOG-5470[LOG-5470])
+* With this release, a new alert has been added to the `LokiStack` to inform users if `LokiStack` components have not reached the ready state. (link:https://issues.redhat.com/browse/LOG-5470[LOG-5470])
 
 * With this release, the statistics page has been improved to help users better understand the performance of a query. (link:https://issues.redhat.com/browse/LOG-7746[LOG-7746])
 
@@ -51,11 +52,10 @@ For more information, see link:https://docs.redhat.com/en/documentation/red_hat_
 For more information, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_logging/6.4/html/configuring_logging/configuring-lokistack-storage#loki-network-policies-for-added-security_configuring-the-log-store[Loki network policies for added security].
 
 [id="logging-release-notes-6-4-0-technology-preview-features_{context}"]
-== Technology preview features
+== Technology Preview features
 
 :FeatureName: The OpenTelemetry Protocol (OTLP) output log forwarder
 include::snippets/technology-preview.adoc[]
-
 
 [id="logging-release-notes-6-4-0-bug-fixes_{context}"]
 == Bug fixes
@@ -73,7 +73,7 @@ With this update, the web console no longer highlights info-level logs containin
 * Before this update, the `clusterLogForwarder` API did not validate the URL scheme for Kafka outputs.
 This could cause users to configure a Kafka output with an invalid URL that was missing the required `tcp://` or `tls://` prefix, leading to a silent failure where logs were not forwarded as expected.
 With this update, new validation has been added to the API.
-The clusterLogForwarder now rejects configurations with a Kafka URL that does not have a tcp or tls scheme, preventing the misconfiguration and ensuring logs can be forwarded successfully. (link:https://issues.redhat.com/browse/LOG-7340[LOG-7340])
+The `clusterLogForwarder` now rejects configurations with a Kafka URL that does not have a tcp or tls scheme, preventing the misconfiguration and ensuring logs can be forwarded successfully. (link:https://issues.redhat.com/browse/LOG-7340[LOG-7340])
 
 * Before this update, the `vector_buffer_byte_size` and `vector_buffer_events` metrics incorrectly reported negative values under certain system load and timing conditions.
 This led to unreliable monitoring, potentially masking buffer issues.
@@ -83,7 +83,7 @@ This ensures that the metrics correctly report buffer sizes helping with accurat
 * Before this fix, Vector could not recover from silently closed TCP connections.
 With this update, Vector uses `keepalive` probes to detect and automatically re-establish unresponsive TCP connections. (link:https://issues.redhat.com/browse/LOG-7502[LOG-7502])
 
-* Before this update, the `ClusterLogForwarder` API required the URL for OTLP endpoints to terminate with `v1/logs`. With this update, this requirement has been relaxed to allow any URL that specifies an `http` or `https` protocol. (link:https://issues.redhat.com/browse/LOG-7582[LOG-7582])
+* Before this update, the `ClusterLogForwarder` API required the URL for OpenTelemetry Protocol (OTLP) endpoints to end with `v1/logs`. With this update, this requirement has been relaxed to allow any URL that specifies an `http` or `https` protocol. (link:https://issues.redhat.com/browse/LOG-7582[LOG-7582])
 
 *  Before this update, any request that exceeded a Kafka broker's `message.max.size` value would be rejected because the collector's tuning did not correctly set an allowable producer configuration.
 With this update, you can set the collector's kafka client configuration to allow message sizes that are equal to or smaller than the `MaxSize` value. (link:https://issues.redhat.com/browse/LOG-7608[LOG-7608])
@@ -92,14 +92,12 @@ With this update, you can set the collector's kafka client configuration to allo
 
 * Before this update, the prune filter failed to remove the `.kubernetes.container_iostream` field from the log record. With this fix, the field is now correctly pruned from the log record. (link:https://issues.redhat.com/browse/LOG-7622[LOG-7622])
 
-
 [id="logging-release-notes-6-4-0-deprecation-notice_{context}"]
 == Deprecation notice
 
 In this release, the 'observability.openshift.io/max-unavailable-rollout' annotation is deprecated and will be removed in a future release.
 The annotation has been replaced by the `spec.collector.maxUnavailable` field in the `ClusterLogForwarder` resource.
 For more information, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_logging/6.4/html/configuring_logging/cluster-logging-collector#configuring-pod-rollout-strategy_cluster-logging-collector[Configuring pod rollout strategy].
-
 
 [id="logging-release-notes-6-4-0-removal-notice_{context}"]
 == Removal notice

--- a/modules/logging-release-notes-6-4-1.adoc
+++ b/modules/logging-release-notes-6-4-1.adoc
@@ -6,6 +6,7 @@
 [id="logging-release-notes-6-4-1_{context}"]
 = Logging 6.4.1 release notes
 
+[role="_abstract"]
 This release includes link:https://access.redhat.com/errata/RHBA-2025:23055[RHBA-2025:23055].
 
 [id="logging-release-notes-6-4-1-bug-fixes_{context}"]

--- a/modules/logging-release-notes-6-4-2.adoc
+++ b/modules/logging-release-notes-6-4-2.adoc
@@ -6,8 +6,8 @@
 [id="logging-release-notes-6-4-2_{context}"]
 = Logging 6.4.2 release notes
 
+[role="_abstract"]
 This release includes link:https://access.redhat.com/errata/RHBA-2026:1923[RHBA-2026:1923].
-
 
 [id="openshift-logging-release-notes-6-4-2-enhancements_{context}"]
 == New features and enhancements
@@ -17,7 +17,6 @@ This release includes link:https://access.redhat.com/errata/RHBA-2026:1923[RHBA-
 
 * With this update, an alert is added to identify when a `ClusterLogForwarder` sink is generating an error condition. For example, the alert triggers when the collector is unable to connect to a sink because the connection is refused.
 (link:https://issues.redhat.com/browse/LOG-7896[LOG-7896])
-
 
 [id="logging-release-notes-6-4-2-bug-fixes_{context}"]
 == Bug fixes
@@ -32,14 +31,14 @@ With this update you cannot pass an empty `logType` field for the Azure Monitor 
 As a result, Vector pods no longer crash due to missing `logType` definition.
 (link:https://issues.redhat.com/browse/LOG-8007[LOG-8007])
 
-* Before this update, an EventRouter message with a newline character (\n) caused malformed syslog data and split events due to broken framing.
+* Before this update, an `EventRouter` message with a newline character (\n) caused malformed syslog data and split events due to broken framing.
 With this update, newline characters in log message payloads are properly escaped.
-As a result, the syslog sink emits a single, well-formed line even when an EventRouter message contains a newline character.
+As a result, the syslog sink emits a single, well-formed line even when an `EventRouter` message has a newline character.
 (link:https://issues.redhat.com/browse/LOG-8090[LOG-8090])
 
-* Before this update, if you did not define a port for the http/https output, enabling NetworkPolicy for the {clo} blocked egress for the collector.
-With this update, the NetworkPolicy is updated to use well-known port values for http/https ports.
-As a result, egress for a collector is not blocked if you enable NetworkPolicy without specifying the port for http/https output.
+* Before this update, if you did not define a port for the http/https output, enabling `NetworkPolicy` for the {clo} blocked egress for the collector.
+With this update, the `NetworkPolicy` is updated to use well-known port values for http/https ports.
+As a result, egress for a collector is not blocked if you enable `NetworkPolicy` without specifying the port for http/https output.
 (link:https://issues.redhat.com/browse/LOG-8091[LOG-8091])
 
 * Before this update, the `RestrictIngressEgress` network policy blocked traffic to the HTTP proxy.
@@ -51,7 +50,7 @@ As a result, you can forward logs to the HTTP output via HTTP proxy with `Restri
 * Before this update, the network policy port list lacked sorting when multiple outputs or inputs receivers were present in the `ClusterLogForwarder` custom resource (CR).
 As a consequence, the user experience was inconsistent with port order in network policies when multiple outputs or inputs were present.
 With this update, network policy port sorting is fixed for serialization consistency.
-As a result, the network policy port order remains consistent, reducing unexpected changes in the end user's ClusterLogForwarder configuration.
+As a result, the network policy port order remains consistent, reducing unexpected changes in the user's `ClusterLogForwarder` configuration.
 (link:https://issues.redhat.com/browse/LOG-8129[LOG-8129])
 
 * Before this update, enabling the `RestrictIngressEgress` network policy rule restricted scraping of collector metrics.
@@ -59,17 +58,17 @@ This update fixes the issue by deploying a network policy that relies upon the p
 As a result, you can now scrape collector metrics with the `RestrictIngressEgress` network policy enabled.
 (link:https://issues.redhat.com/browse/LOG-8130[LOG-8130])
 
-* Before this update, the LokiStack API specification did not specify that container fields cannot be pruned in LokiStack.
-As a result, the output contained the container fields even if users pruned them in the LokiStack CR.
-With this update, the LokiStack API specification states that container cannot be pruned.
+* Before this update, the `LokiStack` API specification did not specify that container fields cannot be pruned in `LokiStack`.
+As a result, the output contained the container fields even if users pruned them in the `LokiStack` CR.
+With this update, the `LokiStack` API specification states that container cannot be pruned.
 (link:https://issues.redhat.com/browse/LOG-8507[LOG-8507])
 
-* Before this update, a short timeout between the distributor and ingester component caused HTTP 503 errors when ingesting logs into LokiStack under high loads.
+* Before this update, a short timeout between the distributor and ingester component caused HTTP 503 errors when ingesting logs into `LokiStack` under high loads.
 With this update, the timeout is increased to prevent the errors.
 (link:https://issues.redhat.com/browse/LOG-8583[LOG-8583])
 
 * Before this update, the `ClusterLogForwarderOutputErrorRate` alert lacked a corresponding runbook. With this update, the missing runbook is added.
 (link:https://issues.redhat.com/browse/LOG-8593[LOG-8593])
 
-* Before this update, enabling `rateLimitPerContainer` caused error events stating `Missing fields on event: ["file"]` due to incorrect configuration generation for the throttle section. With this update, the throttle configuration is generated correctly and all expected event fields are preserved when container rate limiting is active.
+* Before this update, enabling `rateLimitPerContainer` caused error events stating `Missing fields on event: ["file"]` due to wrong configuration generation for the throttle section. With this update, the throttle configuration is generated correctly and all expected event fields are preserved when container rate limiting is active.
 (link:https://issues.redhat.com/browse/LOG-8612[LOG-8612])

--- a/modules/logging-release-notes-6-4-3.adoc
+++ b/modules/logging-release-notes-6-4-3.adoc
@@ -6,6 +6,7 @@
 [id="logging-release-notes-6-4-3_{context}"]
 = Logging 6.4.3 release notes
 
+[role="_abstract"]
 This release includes link:https://access.redhat.com/errata/RHSA-2026:4498[RHSA-2026:4498].
 
 [id="logging-release-notes-6-4-3-bug-fixes_{context}"]
@@ -20,10 +21,11 @@ This release includes link:https://access.redhat.com/errata/RHSA-2026:4498[RHSA-
 * Before this update, prune filters did not work as expected for audit logs when you referenced fields such as `.requestURI` or `.stage`. The logging pipeline stored audit log fields under `.structured` during processing. It applied the prune filter earlier in the pipeline, before restoring those fields to the top-level log structure. As a result, the prune filter did not remove the specified fields. With this update, the system applies the prune filter at the correct stage of the pipeline. As a result, audit log fields are pruned according to the configured rules.
 (link:https://issues.redhat.com/browse/LOG-8597[LOG-8597])
 
-
 [id="logging-release-notes-6-4-3-cves_{context}"]
 == CVEs
 
 * link:https://access.redhat.com/security/cve/CVE-2025-61726[CVE-2025-61726]
+
 * link:https://access.redhat.com/security/cve/CVE-2025-61729[CVE-2025-61729]
+
 * link:https://access.redhat.com/security/cve/CVE-2025-68121[CVE-2025-68121]

--- a/release_notes/logging-release-notes.adoc
+++ b/release_notes/logging-release-notes.adoc
@@ -1,11 +1,14 @@
 :_mod-docs-content-type: ASSEMBLY
-include::_attributes/common-attributes.adoc[]
 [id="logging-release-notes"]
 = Logging 6.4 release notes
 
+include::_attributes/common-attributes.adoc[]
 :context: logging-release-notes
 
 toc::[]
+
+[role="_abstract"]
+The following release notes describe the updates in {LoggingProductName} 6.4. They include new features and enhancements, bug fixes, security updates (CVEs), known issues, and Technology Preview features.
 
 include::modules/logging-release-notes-6-4-3.adoc[leveloffset=+1]
 


### PR DESCRIPTION
**Note for the peer & merge reviewer:** 
- This PR updates the only "6.4 release notes" sections to prepare them for Phase 0 DITA migration.
- No other CQA changes, error types, or content refinements are included. 

**Changes:** 
This PR prepares the "6.4 release notes" section for Phase 0 DITA migration by applying Vale (AsciiDoc DITA) rules and cleaning up the existing content.

**Doc preview:** 
- [v6.4 Release notes](https://110012--ocpdocs-pr.netlify.app/openshift-logging/latest/release_notes/logging-release-notes.html)

**Tracking JIRA:** https://redhat.atlassian.net/browse/OBSDOCS-3299

**Reviews:**
- [x] Peer has approved this change