### PR TITLE
[standalone-logging-docs-6.2] PR for OBSDOCS-3290: CQA + DITA readiness for assemblies and modules under v6.2 Release notes.

### DIFF
--- a/modules/logging-release-notes-6-2-0.adoc
+++ b/modules/logging-release-notes-6-2-0.adoc
@@ -1,12 +1,16 @@
+// Module included in the following assemblies:
+//
+// * release_notes/logging-release-notes-6.2.adoc
+
 :_mod-docs-content-type: REFERENCE
 [id="logging-release-notes-6-2-0_{context}"]
 = Logging 6.2.0 Release Notes
 
+[role="_abstract"]
 This release includes link:https://access.redhat.com/errata/RHBA-2025:2398[{logging-uc} {for} Bug Fix Release 6.2.0].
 
 [id="openshift-logging-release-notes-6-2-0-enhancements_{context}"]
 == New Features and Enhancements
-
 
 === Log Collection
 
@@ -26,7 +30,7 @@ This release includes link:https://access.redhat.com/errata/RHBA-2025:2398[{logg
 :FeatureName: The OpenTelemetry Protocol (OTLP) output log forwarder
 include::snippets/technology-preview.adoc[]
 
-* With this update, OpenTelemetry support offered by OpenShift {logging-uc} continues to improve, specifically in the area of enabling migrations from the ViaQ data model to `OpenTelemetry` when forwarding to `LokiStack`. (link:https://issues.redhat.com/browse/LOG-6146[LOG-6146])
+* With this update, OpenTelemetry support offered by OpenShift {logging-uc} continues to improve, specifically in the area of enabling migrations from the `ViaQ` data model to `OpenTelemetry` when forwarding to `LokiStack`. (link:https://issues.redhat.com/browse/LOG-6146[LOG-6146])
 
 * With this update, the `structuredMetadata` field has been removed from {loki-op} in the `otlp` configuration because structured metadata is now the default type. Additionally, the update introduces a `drop` field that administrators can use to drop `OpenTelemetry` attributes when receiving data through `OpenTelemetry` protocol (OTLP). (link:https://issues.redhat.com/browse/LOG-6507[LOG-6507])
 
@@ -42,7 +46,7 @@ include::snippets/technology-preview.adoc[]
 [id="logging-release-notes-6-2-0-known-issues_{context}"]
 == Known Issues
 
-* The previous data model encoded all information in JSON. The console still uses the query of the previous data model to decode both old and new entries. The logs that are stored by using the new `OpenTelemetry` data model for the `LokiStack` output display the following error in the logging console:
+* The earlier data model encoded all information in JSON. The console still uses the query of the earlier data model to decode both old and new entries. The logs that are stored by using the new `OpenTelemetry` data model for the `LokiStack` output display the following error in the logging console:
 +
 ----
 __error__ JSONParserErr 
@@ -58,4 +62,5 @@ You can ignore the error as it is only a result of the query and not a data-rela
 == CVEs
 
 * link:https://access.redhat.com/security/cve/CVE-2020-11023[CVE-2020-11023]
+
 * link:https://access.redhat.com/security/cve/CVE-2024-12797[CVE-2024-12797]

--- a/modules/logging-release-notes-6-2-1.adoc
+++ b/modules/logging-release-notes-6-2-1.adoc
@@ -1,7 +1,12 @@
+// Module included in the following assemblies:
+//
+// * release_notes/logging-release-notes-6.2.adoc
+
 :_mod-docs-content-type: REFERENCE
 [id="logging-release-notes-6-2-1_{context}"]
 = Logging 6.2.1 Release Notes
 
+[role="_abstract"]
 This release includes link:https://access.redhat.com/errata/RHBA-2025:3908[RHBA-2025:3908].
 
 [id="logging-release-notes-6-2-1-bug-fixes_{context}"]
@@ -12,9 +17,9 @@ This release includes link:https://access.redhat.com/errata/RHBA-2025:3908[RHBA-
 * Before this update, issuing the `oc explain obsclf.spec.filters` command did not list all the supported filters in the command output. With this update, all the supported filter types are listed in the command output. (link:https://issues.redhat.com/browse/LOG-6753[LOG-6753])
 
 
-* Before this update the log collector flagged a `ClusterLogForwarder` resource with multiple inputs to a LokiStack output as invalid due to  incorrect internal processing logic. This update fixes the issue. (link:https://issues.redhat.com/browse/LOG-6758[LOG-6758])
+* Before this update the log collector flagged a `ClusterLogForwarder` resource with multiple inputs to a `LokiStack` output as invalid due to incorrect internal processing logic. This update fixes the issue. (link:https://issues.redhat.com/browse/LOG-6758[LOG-6758])
 
-* Before this update, issuing the `oc explain` command for the `clusterlogforwarder.spec.outputs.syslog` resource returned an incomplete result. With this update, the missing supported types for `rfc` and `enrichment` attributes are listed in the result correctly. (link:https://issues.redhat.com/browse/LOG-6869[LOG-6869])
+* Before this update, issuing the `oc explain` command for the `clusterlogforwarder.spec.outputs.syslog` resource returned an incomplete result. With this update, the missing supported types for `rfc` and `enrichment` attributes are now listed in the result correctly. (link:https://issues.redhat.com/browse/LOG-6869[LOG-6869])
 
 * Before this update, empty OpenTelemetry (OTEL) tuning configuration caused validation errors. With this update, validation rules have been updated to accept empty tuning configuration. (link:https://issues.redhat.com/browse/LOG-6878[LOG-6878])
 
@@ -32,7 +37,11 @@ This release includes link:https://access.redhat.com/errata/RHBA-2025:3908[RHBA-
 == CVEs
 
 * link:https://access.redhat.com/security/cve/CVE-2022-49043[CVE-2022-49043]
+
 * link:https://access.redhat.com/security/cve/CVE-2024-2236[CVE-2024-2236]
+
 * link:https://access.redhat.com/security/cve/CVE-2024-5535[CVE-2024-5535]
+
 * link:https://access.redhat.com/security/cve/CVE-2024-56171[CVE-2024-56171]
+
 * link:https://access.redhat.com/security/cve/CVE-2025-24928[CVE-2025-24928]

--- a/modules/logging-release-notes-6-2-2.adoc
+++ b/modules/logging-release-notes-6-2-2.adoc
@@ -6,6 +6,7 @@
 [id="logging-release-notes-6-2-2_{context}"]
 = Logging 6.2.2 Release Notes
 
+[role="_abstract"]
 This release includes link:https://access.redhat.com/errata/RHBA-2025:4526[RHBA-2025:4526].
 
 [id="logging-release-notes-6-2-2-bug-fixes_{context}"]
@@ -15,6 +16,6 @@ This release includes link:https://access.redhat.com/errata/RHBA-2025:4526[RHBA-
 
 * Before this update, the Cloudwatch output supported log events up to 256 KB in size. With this update, the Cloudwatch output supports up to 1 MB in size to match the updates published by Amazon Web Services (AWS). (link:https://issues.redhat.com/browse/LOG-7013[LOG-7013])
 
-* Before this update, `auditd` log messages with multiple `msg` keys could cause errors in collector pods, because the standard `auditd` log format expects a single `msg` field per log entry that follows the `msg=audit(TIMESTAMP:ID)` structure. With this update, only the first `msg` value is used, which resolves the issue and ensures accurate extraction of audit metadata. (link:https://issues.redhat.com/browse/LOG-7014[LOG-7014])
+* Before this update, `auditd` log messages with many `msg` keys could cause errors in collector pods, because the standard `auditd` log format expects a single `msg` field per log entry that follows the `msg=audit(TIMESTAMP:ID)` structure. With this update, only the first `msg` value is used, which resolves the issue and ensures accurate extraction of audit metadata. (link:https://issues.redhat.com/browse/LOG-7014[LOG-7014])
 
 * Before this update, collector pods would enter a crash loop due to a configuration error when attempting token-based authentication with an Elasticsearch output. With this update, token authentication with an Elasticsearch output generates a valid configuration. (link:https://issues.redhat.com/browse/LOG-7017[LOG-7017])

--- a/modules/logging-release-notes-6-2-3.adoc
+++ b/modules/logging-release-notes-6-2-3.adoc
@@ -6,6 +6,7 @@
 [id="logging-release-notes-6-2-3_{context}"]
 = Logging 6.2.3 Release Notes
 
+[role="_abstract"]
 This release includes link:https://access.redhat.com/errata/RHBA-2025:8138[RHBA-2025:8138].
 
 [id="logging-release-notes-6-2-3-bug-fixes_{context}"]
@@ -15,7 +16,7 @@ This release includes link:https://access.redhat.com/errata/RHBA-2025:8138[RHBA-
 
 * Before this update, the API documentation about default settings of the tuning delivery mode for log forwarding lacked clarity and sufficient detail. This could lead to users experiencing difficulty in understanding or optimally configuring these settings for their logging pipelines. With this update, the documentation has been revised to provide more comprehensive and clearer guidance on tuning delivery mode default settings, resolving potential ambiguities. (link:https://issues.redhat.com/browse/LOG-7131[LOG-7131])
 
-* Before this update, merging data from the `message` field into the root of a Syslog log event caused inconsistencies with the ViaQ data model. These inconsistencies could overwrite system information, duplicate data, or corrupt the log event. This update makes Syslog parsing and merging consistent with the other output types and resolves the issue (link:https://issues.redhat.com/browse/LOG-7185[LOG-7185])
+* Before this update, merging data from the `message` field into the root of a Syslog log event caused inconsistencies with the `ViaQ` data model. These inconsistencies could overwrite system information, duplicate data, or corrupt the log event. This update makes Syslog parsing and merging consistent with the other output types and resolves the issue (link:https://issues.redhat.com/browse/LOG-7185[LOG-7185])
 
 * Before this update, log forwarding failed when the cluster-wide proxy configuration included a URL with a username containing an encoded `@` symbol; for example, `user%40name`. This update adds the correct support for URL-encoded values in proxy configurations and resolves the issue. (link:https://issues.redhat.com/browse/LOG-7188[LOG-7188])
 
@@ -23,11 +24,19 @@ This release includes link:https://access.redhat.com/errata/RHBA-2025:8138[RHBA-
 == CVEs
 
 * link:https://access.redhat.com/security/cve/CVE-2022-49043[CVE-2022-49043]
+
 * link:https://access.redhat.com/security/cve/CVE-2024-12087[CVE-2024-12087]
+
 * link:https://access.redhat.com/security/cve/CVE-2024-12088[CVE-2024-12088]
+
 * link:https://access.redhat.com/security/cve/CVE-2024-12133[CVE-2024-12133]
+
 * link:https://access.redhat.com/security/cve/CVE-2024-12243[CVE-2024-12243]
+
 * link:https://access.redhat.com/security/cve/CVE-2024-12747[CVE-2024-12747]
+
 * link:https://access.redhat.com/security/cve/CVE-2024-56171[CVE-2024-56171]
+
 * link:https://access.redhat.com/security/cve/CVE-2025-0395[CVE-2025-0395]
+
 * link:https://access.redhat.com/security/cve/CVE-2025-24928[CVE-2025-24928]

--- a/modules/logging-release-notes-6-2-4.adoc
+++ b/modules/logging-release-notes-6-2-4.adoc
@@ -6,6 +6,7 @@
 [id="logging-release-notes-6-2-4_{context}"]
 = Logging 6.2.4 Release Notes
 
+[role="_abstract"]
 This release includes link:https://access.redhat.com/errata/RHSA-2025:13241[RHSA-2025:13241].
 
 [id="logging-release-notes-6-2-4-bug-fixes_{context}"]

--- a/modules/logging-release-notes-6-2-5.adoc
+++ b/modules/logging-release-notes-6-2-5.adoc
@@ -6,6 +6,7 @@
 [id="logging-release-notes-6-2-5_{context}"]
 = Logging 6.2.5 Release Notes
 
+[role="_abstract"]
 This release includes link:https://access.redhat.com/errata/RHBA-2025:16075[RHBA-2025:16075].
 
 [id="logging-release-notes-6-2-5-bug-fixes_{context}"]
@@ -14,10 +15,3 @@ This release includes link:https://access.redhat.com/errata/RHBA-2025:16075[RHBA
 * Before this update, the `vector_buffer_byte_size` and `vector_buffer_events` metrics incorrectly reported negative values under certain system load and timing conditions. This led to unreliable monitoring, potentially masking buffer issues. With this update, a concurrent, centralized state tracker ensures that these metrics are always reported as non-negative values. This ensures that the metrics correctly report buffer sizes helping with accurate monitoring. (link:https://issues.redhat.com/browse/LOG-7593[LOG-7593])
 
 *  Before this update, a change to the container image format caused issues when mirroring the images to image registries that do not support the new format. With this update, the container images are published using the older format again resolving the issue.  (link:https://issues.redhat.com/browse/LOG-7700[LOG-7700])
-
-////
-[id="logging-release-notes-6-2-5-cves_{context}"]
-== CVEs
-
-* link:https://access.redhat.com/security/cve/CVE-2025-22871[CVE-2025-22871]
-////

--- a/modules/logging-release-notes-6-2-6.adoc
+++ b/modules/logging-release-notes-6-2-6.adoc
@@ -6,4 +6,5 @@
 [id="logging-release-notes-6-2-6_{context}"]
 = Logging 6.2.6 Release Notes
 
+[role="_abstract"]
 This release includes link:https://access.redhat.com/errata/RHBA-2025:19347[RHBA-2025:19347].

--- a/modules/logging-release-notes-6-2-7.adoc
+++ b/modules/logging-release-notes-6-2-7.adoc
@@ -6,6 +6,7 @@
 [id="logging-release-notes-6-2-7_{context}"]
 = Logging 6.2.7 Release Notes
 
+[role="_abstract"]
 This release includes link:https://access.redhat.com/errata/RHSA-2025:23534[RHSA-2025:23534].
 
 [id="logging-release-notes-6-2-7-bug-fixes_{context}"]
@@ -23,4 +24,5 @@ Use the `MaxUnavailable` field for collectors during upgrade so as to not overwh
 == CVEs
 
 * link:https://access.redhat.com/security/cve/CVE-2025-30204[CVE-2025-30204]
+
 * link:https://access.redhat.com/security/cve/CVE-2025-22868[CVE-2025-22868]

--- a/modules/logging-release-notes-6-2-8.adoc
+++ b/modules/logging-release-notes-6-2-8.adoc
@@ -6,6 +6,7 @@
 [id="logging-release-notes-6-2-8_{context}"]
 = Logging 6.2.8 Release Notes
 
+[role="_abstract"]
 This release includes link:https://access.redhat.com/errata/RHBA-2026:2565[RHBA-2026:2565].
 
 [id="openshift-logging-release-notes-6-2-8-enhancements_{context}"]
@@ -23,5 +24,5 @@ This release includes link:https://access.redhat.com/errata/RHBA-2026:2565[RHBA-
 * Before this update, the `ClusterLogForwarder` API required OpenTelemetry Protocol (OTLP) endpoint URLs to terminate with `v1/logs`, which made validation too restrictive for some receivers. With this update, the validation allows any HTTP or HTTPS URL. As a result, you can configure OTLP endpoints with more flexible URL structures.
 (link:https://issues.redhat.com/browse/LOG-8003[LOG-8003])
 
-* Before this update, the collector merged large application log messages without size restrictions. As a consequence, merged lines could overflow an output buffer. With this update, the `MaxMessageSize` tuning parameter is introduced for application logs. As a result, the collector discards messages that exceed the configured threshold, which prevents buffer overflows and helps ensure collector stability.
+* Before this update, the collector merged large application log messages without size restrictions. As a consequence, merged lines could overflow an output buffer. With this update, the `MaxMessageSize` tuning parameter is now introduced for application logs. As a result, the collector discards messages that exceed the configured threshold, which prevents buffer overflows and helps ensure collector stability.
 (link:https://issues.redhat.com/browse/LOG-8292[LOG-8292])

--- a/modules/logging-release-notes-6-2-9.adoc
+++ b/modules/logging-release-notes-6-2-9.adoc
@@ -6,12 +6,13 @@
 [id="logging-release-notes-6-2-9_{context}"]
 = Logging 6.2.9 Release Notes
 
+[role="_abstract"]
 This release includes link:https://access.redhat.com/errata/RHSA-2026:4500[RHSA-2026:4500].
 
 [id="logging-release-notes-6-2-9-bug-fixes_{context}"]
 == Bug fixes
 
-* Before this update, syslog output could become corrupted when Eventrouter log messages contained newline characters (`\n`). The syslog sink interpreted newlines as delimiters. It split a single event across multiple malformed records and populated metadata fields such as `hostname` and `syslogtag` with invalid data. With this update, the system escapes newline characters in log payloads. As a result, the syslog sink emits a single, well-formed line with correct metadata.
+* Before this update, syslog output could become corrupted when Eventrouter log messages contained newline characters (`\n`). The syslog sink interpreted newlines as delimiters. It split a single event across many malformed records and populated metadata fields such as `hostname` and `syslogtag` with invalid data. With this update, the system escapes newline characters in log payloads. As a result, the syslog sink emits a single, well-formed line with correct metadata.
 (link:https://issues.redhat.com/browse/LOG-8892[LOG-8892])
 
 
@@ -19,5 +20,7 @@ This release includes link:https://access.redhat.com/errata/RHSA-2026:4500[RHSA-
 == CVEs
 
 * link:https://access.redhat.com/security/cve/CVE-2025-61726[CVE-2025-61726]
+
 * link:https://access.redhat.com/security/cve/CVE-2025-61729[CVE-2025-61729]
+
 * link:https://access.redhat.com/security/cve/CVE-2025-68121[CVE-2025-68121]

--- a/release_notes/logging-release-notes-6.2.adoc
+++ b/release_notes/logging-release-notes-6.2.adoc
@@ -1,10 +1,13 @@
 :_mod-docs-content-type: ASSEMBLY
-include::_attributes/common-attributes.adoc[]
 [id="logging-release-notes-6-2"]
 = Logging 6.2 Release Notes
+include::_attributes/common-attributes.adoc[]
 :context: loggging-release-notes-6-2
 
 toc::[]
+
+[role="_abstract"]
+The following release notes describe the updates in {LoggingProductName} 6.2. They include new features and enhancements, bug fixes, security updates (CVEs), known issues, and Technology Preview features.
 
 include::modules/logging-release-notes-6-2-9.adoc[leveloffset=+1]
 


### PR DESCRIPTION
**Note for the peer & merge reviewer:** 
- This PR updates the only "6.2 release notes" sections to prepare them for Phase 0 DITA migration.
- No other CQA changes, error types, or content refinements are included. 

**Changes:** 
This PR prepares the "6.2 release notes" section for Phase 0 DITA migration by applying Vale (AsciiDoc DITA) rules and cleaning up the existing content.

**Doc preview:** 
- [v6.2 Release notes](https://110013--ocpdocs-pr.netlify.app/openshift-logging/latest/release_notes/logging-release-notes-6.2.html)

**Tracking JIRA:** https://redhat.atlassian.net/browse/OBSDOCS-3300

**Reviews:**
- [x] Peer has approved this change