### PR TITLE
[standalone-logging-docs-6.0] PR for OBSDOCS-3301: CQA + DITA readiness for assemblies and modules under v6.0 Release notes.

### DIFF
--- a/modules/logging-6-0-0-release-notes-bug-fixes.adoc
+++ b/modules/logging-6-0-0-release-notes-bug-fixes.adoc
@@ -1,0 +1,12 @@
+// Module included in the following assemblies:
+//
+// * release_notes/logging-release-notes-6.0.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="logging-6-0-0-release-notes-bug-fixes_{context}"]
+= Bug fixes for Logging 6.0.0
+
+[role="_abstract"]
+The following section describes Bug fixes in this release of {logging} 6.0.0.
+
+* Before this update, the `CollectorHighErrorRate` and `CollectorVeryHighErrorRate` alerts were still present. With this update, both alerts are removed in the {logging} 6.0 release but might return in a future release. (link:https://issues.redhat.com/browse/LOG-3432[LOG-3432])

--- a/modules/logging-6-0-0-release-notes-cve.adoc
+++ b/modules/logging-6-0-0-release-notes-cve.adoc
@@ -1,0 +1,12 @@
+// Module included in the following assemblies:
+//
+// * release_notes/logging-release-notes-6.0.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="logging-6-0-0-release-notes-cve_{context}"]
+= CVEs for Logging 6.0.0
+
+[role="_abstract"]
+The following section describes CVEs in this release of {logging} 6.0.0.
+
+* link:https://access.redhat.com/security/cve/CVE-2024-34397[CVE-2024-34397]

--- a/modules/logging-6-0-0-release-notes-enhancements.adoc
+++ b/modules/logging-6-0-0-release-notes-enhancements.adoc
@@ -1,0 +1,52 @@
+// Module included in the following assemblies:
+//
+// * release_notes/logging-release-notes-6.0.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="logging-6-0-0-release-notes-enhancements_{context}"]
+= New features and enhancements for Logging 6.0.0 
+
+[role="_abstract"]
+The following section describes the new features and enhancements introduced in {logging} 6.0.0. It highlights added capabilities and key improvements.
+
+* This feature introduces a new architecture for {logging} {for} by shifting component responsibilities to their relevant Operators, such as for storage, visualization, and collection. It introduces the `ClusterLogForwarder.observability.openshift.io` API for log collection and forwarding. Support for the `ClusterLogging.logging.openshift.io` and `ClusterLogForwarder.logging.openshift.io` APIs, along with the Red Hat managed Elastic stack (Elasticsearch and Kibana), is removed. Users are encouraged to migrate to the Red Hat `LokiStack` for log storage. Existing managed Elasticsearch deployments can be used for a limited time. Automated migration for log collection is not provided, so administrators need to create a new `ClusterLogForwarder.observability.openshift.io` specification to replace their earlier custom resources. Refer to the official product documentation for more details. (link:https://issues.redhat.com/browse/LOG-3493[LOG-3493])
+
+* With this release, the responsibility for deploying the {logging} view plugin shifts from the {clo} to the {coo-first}. For new log storage installations that need visualization, the {coo-full} and the associated `UIPlugin` resource must be deployed. Refer to the link:https://docs.openshift.com/container-platform/latest/observability/cluster_observability_operator/cluster-observability-operator-overview.html#cluster-observability-operator-overview[Cluster Observability Operator Overview] product documentation for more details. (link:https://issues.redhat.com/browse/LOG-5461[LOG-5461])
+
+* This enhancement sets default requests and limits for Vector collector deployments' memory and CPU usage based on Vector documentation recommendations. (link:https://issues.redhat.com/browse/LOG-4745[LOG-4745])
+
+* This enhancement updates Vector to align with the upstream version v0.37.1. (link:https://issues.redhat.com/browse/LOG-5296[LOG-5296])
+
+* This enhancement introduces an alert that triggers when log collectors buffer logs to a node's file system and use over 15% of the available space, indicating potential back pressure issues. (link:https://issues.redhat.com/browse/LOG-5381[LOG-5381])
+
+* This enhancement updates the selectors for all components to use common Kubernetes labels. (link:https://issues.redhat.com/browse/LOG-5906[LOG-5906])
+
+* This enhancement changes the collector configuration to deploy as a ConfigMap instead of a secret, allowing users to view and edit the configuration when the `ClusterLogForwarder` is set to Unmanaged. (link:https://issues.redhat.com/browse/LOG-5599[LOG-5599])
+
+* This enhancement adds the ability to configure the Vector collector log level using an annotation on the `ClusterLogForwarder`, with options including trace, debug, info, warn, error, or off. (link:https://issues.redhat.com/browse/LOG-5372[LOG-5372])
+
+* This enhancement adds validation to reject configurations where Amazon CloudWatch outputs use many AWS roles, preventing wrong log routing. (link:https://issues.redhat.com/browse/LOG-5640[LOG-5640])
+* This enhancement removes the Log Bytes Collected and Log Bytes Sent graphs from the metrics dashboard. (link:https://issues.redhat.com/browse/LOG-5964[LOG-5964])
+
+* This enhancement updates the must-gather functionality to only capture information for inspecting Logging 6.0 components, including Vector deployments from `ClusterLogForwarder`.observability.openshift.io resources and the Red Hat managed `LokiStack`. (link:https://issues.redhat.com/browse/LOG-5949[LOG-5949])
+
+* This enhancement improves Azure storage secret validation by providing early warnings for specific error conditions. (link:https://issues.redhat.com/browse/LOG-4571[LOG-4571])
+
+* This enhancement updates the `ClusterLogForwarder` API to follow the Kubernetes standards. (link:https://issues.redhat.com/browse/LOG-5977[LOG-5977])
++
+The following example displays a new configuration in the `ClusterLogForwarder` custom resource for the updated API:
++
+[source,yaml]
+----
+apiVersion: observability.openshift.io/v1
+kind: ClusterLogForwarder
+metadata:
+  name: <name>
+spec:
+  outputs:
+  - name: <output_name>
+    type: <output_type>
+    <output_type>:
+      tuning:
+         deliveryMode: AtMostOnce
+----

--- a/modules/logging-6-0-0-release-notes-removal-notice.adoc
+++ b/modules/logging-6-0-0-release-notes-removal-notice.adoc
@@ -1,0 +1,19 @@
+// Module included in the following assemblies:
+//
+// * release_notes/logging-release-notes-6.0.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="logging-6-0-0-release-notes-removal-notice_{context}"]
+= Removal notice
+
+[role="_abstract"]
+The following section describes features and capabilities removed in this release of {logging}. It highlights changes that might impact existing deployments.
+
+* With this release, {logging} no longer supports the `ClusterLogging.logging.openshift.io` and `ClusterLogForwarder.logging.openshift.io` custom resources. Refer to the product documentation for details on the replacement features. (link:https://issues.redhat.com/browse/LOG-5803[LOG-5803])
+
+* With this release, {logging} no longer manages or deploys log storage (such as Elasticsearch), visualization (such as Kibana), or Fluentd-based log collectors. (link:https://issues.redhat.com/browse/LOG-5368[LOG-5368])
+
+[NOTE]
+====
+To continue to use Elasticsearch and Kibana managed by the elasticsearch-operator, the administrator must change those objects' `ownerRefs` before deleting the ClusterLogging resource.
+====

--- a/modules/logging-6-0-0-release-notes-technology-preview.adoc
+++ b/modules/logging-6-0-0-release-notes-technology-preview.adoc
@@ -1,0 +1,12 @@
+// Module included in the following assemblies:
+//
+// * release_notes/logging-release-notes-6.0.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="logging-6-0-0-release-notes-technology-preview_{context}"]
+= Technology Preview features for Logging 6.0.0
+
+[role="_abstract"]
+The following section describes Technology Preview features in this release of {logging} 6.0.0.
+
+* This release introduces a Technology Preview feature for log forwarding using OpenTelemetry. A new output type, OpenTelemetry Protocol (OTLP), allows sending JSON-encoded log records using the OpenTelemetry data model and resource semantic conventions. (link:https://issues.redhat.com/browse/LOG-4225[LOG-4225])

--- a/modules/logging-6-0-0-release-notes.adoc
+++ b/modules/logging-6-0-0-release-notes.adoc
@@ -1,0 +1,24 @@
+// Module included in the following assemblies:
+//
+// * release_notes/logging-release-notes-6.0.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="logging-6-0-0-release-notes_{context}"]
+= Logging 6.0.0 
+
+[role="_abstract"]
+This release includes link:https://access.redhat.com/errata/RHBA-2024:6693[{logging-uc} {for} Bug Fix Release 6.0.0]
+
+include::snippets/logging-compatibility-snip.adoc[]
+
+.Upstream component versions
+[options="header"]
+|===
+
+| {logging} Version 6+| Component Version
+
+| Operator | `eventrouter` | `logfilemetricexporter` | `loki` | `lokistack-gateway` | `opa-openshift` | `vector`
+
+|6.0 | 0.4 | 1.1 | 3.1.0 | 0.1 | 0.1 | 0.37.1
+
+|===

--- a/modules/logging-release-notes-6-0-1.adoc
+++ b/modules/logging-release-notes-6-0-1.adoc
@@ -1,9 +1,9 @@
 :_mod-docs-content-type: REFERENCE
 [id="logging-release-notes-6-0-1_{context}"]
 = Logging 6.0.1
-This release includes link:https://access.redhat.com/errata/RHSA-2024:8315[OpenShift Logging Bug Fix Release 6.0.1].
 
-// 4.17
+[role="_abstract"]
+This release includes link:https://access.redhat.com/errata/RHSA-2024:8315[OpenShift Logging Bug Fix Release 6.0.1].
 
 [id="openshift-logging-6-0-1-bug-fixes_{context}"]
 == Bug fixes
@@ -13,7 +13,7 @@ This release includes link:https://access.redhat.com/errata/RHSA-2024:8315[OpenS
 * Before this update, the Loki Operator failed to add the default `namespace` label to all `AlertingRule` resources, which caused the User-Workload-Monitoring Alertmanager to skip routing these alerts. This update adds the rule namespace as a label to all alerting and recording rules, resolving the issue and restoring proper alert routing in Alertmanager.
 (link:https://issues.redhat.com/browse/LOG-6151[LOG-6151])
 
-* Before this update, the LokiStack ruler component view did not initialize properly, causing an invalid field error when the ruler component was disabled. This update ensures that the component view initializes with an empty value, resolving the issue.
+* Before this update, the `LokiStack` ruler component view did not initialize properly, causing an invalid field error when the ruler component was disabled. This update ensures that the component view initializes with an empty value, resolving the issue.
 (link:https://issues.redhat.com/browse/LOG-6129[LOG-6129])
 
 * Before this update, it was possible to set `log_source` in the prune filter, which could lead to inconsistent log data. With this update, the configuration is validated before being applied, and any configuration that includes `log_source` in the prune filter is rejected.
@@ -23,11 +23,19 @@ This release includes link:https://access.redhat.com/errata/RHSA-2024:8315[OpenS
 == CVEs
 
 * link:https://access.redhat.com/security/cve/CVE-2024-24791[CVE-2024-24791]
+
 * link:https://access.redhat.com/security/cve/CVE-2024-34155[CVE-2024-34155]
+
 * link:https://access.redhat.com/security/cve/CVE-2024-34156[CVE-2024-34156]
+
 * link:https://access.redhat.com/security/cve/CVE-2024-34158[CVE-2024-34158]
+
 * link:https://access.redhat.com/security/cve/CVE-2024-6104[CVE-2024-6104]
+
 * link:https://access.redhat.com/security/cve/CVE-2024-6119[CVE-2024-6119]
+
 * link:https://access.redhat.com/security/cve/CVE-2024-45490[CVE-2024-45490]
+
 * link:https://access.redhat.com/security/cve/CVE-2024-45491[CVE-2024-45491]
+
 * link:https://access.redhat.com/security/cve/CVE-2024-45492[CVE-2024-45492]

--- a/modules/logging-release-notes-6-0-10.adoc
+++ b/modules/logging-release-notes-6-0-10.adoc
@@ -6,6 +6,7 @@
 [id="logging-release-notes-6-0-10_{context}"]
 = Logging 6.0.10
 
+[role="_abstract"]
 This release includes link:https://access.redhat.com/errata/RHBA-2025:15564[RHBA-2025:15564].
 
 [id="logging-release-notes-6-0-10-bug-fixes_{context}"]

--- a/modules/logging-release-notes-6-0-11.adoc
+++ b/modules/logging-release-notes-6-0-11.adoc
@@ -6,6 +6,7 @@
 [id="logging-release-notes-6-0-11_{context}"]
 = Logging 6.0.11
 
+[role="_abstract"]
 This release includes link:https://access.redhat.com/errata/RHBA-2025:21688[RHBA-2025:21688].
 
 [id="logging-release-notes-6-0-11-bug-fixes_{context}"]

--- a/modules/logging-release-notes-6-0-12.adoc
+++ b/modules/logging-release-notes-6-0-12.adoc
@@ -6,10 +6,12 @@
 [id="logging-release-notes-6-0-12_{context}"]
 = Logging 6.0.12
 
+[role="_abstract"]
 This release includes link:https://access.redhat.com/errata/RHSA-2025:23535[RHSA-2025:23535].
 
 [id="logging-release-notes-6-0-12-cves_{context}"]
 == CVEs
 
 * link:https://access.redhat.com/security/cve/CVE-2025-22868[CVE-2025-22868]
+
 * link:https://access.redhat.com/security/cve/CVE-2025-30204[CVE-2025-30204]

--- a/modules/logging-release-notes-6-0-13.adoc
+++ b/modules/logging-release-notes-6-0-13.adoc
@@ -6,4 +6,5 @@
 [id="logging-release-notes-6-0-13_{context}"]
 = Logging 6.0.13
 
+[role="_abstract"]
 This release includes link:https://access.redhat.com/errata/RHBA-2026:2564[RHBA-2026:2564].

--- a/modules/logging-release-notes-6-0-14.adoc
+++ b/modules/logging-release-notes-6-0-14.adoc
@@ -6,11 +6,14 @@
 [id="logging-release-notes-6-0-14_{context}"]
 = Logging 6.0.14
 
+[role="_abstract"]
 This release includes link:https://access.redhat.com/errata/RHSA-2026:7052[RHBA-2026:7052].
 
 [id="logging-release-notes-6-0-14-cves_{context}"]
 == CVEs
 
 * link:https://access.redhat.com/security/cve/CVE-2025-61726[CVE-2025-61726]
+
 * link:https://access.redhat.com/security/cve/CVE-2025-61729[CVE-2025-61729]
+
 * link:https://access.redhat.com/security/cve/CVE-2025-68121[CVE-2025-68121]

--- a/modules/logging-release-notes-6-0-2.adoc
+++ b/modules/logging-release-notes-6-0-2.adoc
@@ -1,25 +1,28 @@
 :_mod-docs-content-type: REFERENCE
 [id="logging-release-notes-6-0-2_{context}"]
 = Logging 6.0.2
+
+[role="_abstract"]
 This release includes link:https://access.redhat.com/errata/RHBA-2024:10051[RHBA-2024:10051].
 
 [id="logging-release-notes-6-0-2-bug-fixes_{context}"]
 == Bug fixes
 
-* Before this update, Loki did not correctly load some configurations, which caused issues when using Alibaba Cloud or IBM Cloud object storage. This update fixes the configuration-loading code in Loki, resolving the issue. (link:https://issues.redhat.com/browse/LOG-5325[LOG-5325])
+* Before this update, Loki did not correctly load some configurations, which caused issues when using {alibaba} or {ibm-cloud-title} object storage. This update fixes the configuration-loading code in Loki, resolving the issue. (link:https://issues.redhat.com/browse/LOG-5325[LOG-5325])
 
-* Before this update, the collector would discard audit log messages that exceeded the configured threshold. This modifies the audit configuration thresholds for the maximum line size as well as the number of bytes read during a read cycle. (link:https://issues.redhat.com/browse/LOG-5998[LOG-5998])
+* Before this update, the collector would discard audit log messages that exceeded the configured threshold. This modifies the audit configuration thresholds for the maximum line size and the number of bytes read during a read cycle. (link:https://issues.redhat.com/browse/LOG-5998[LOG-5998])
 
-* Before this update, the Cluster Logging Operator did not watch and reconcile resources associated with an instance of a ClusterLogForwarder like it did in prior releases. This update modifies the operator to watch and reconcile all resources it owns and creates. (link:https://issues.redhat.com/browse/LOG-6264[LOG-6264])
+* Before this update, the Cluster Logging Operator did not watch and reconcile resources associated with an instance of a `ClusterLogForwarder` in the same way it did in prior releases. This update modifies the operator to watch and reconcile all resources it owns and creates. (link:https://issues.redhat.com/browse/LOG-6264[LOG-6264])
 
 * Before this update, log events with an unknown severity level sent to Google Cloud Logging would trigger a warning in the vector collector, which would then default the severity to 'DEFAULT'. With this update, log severity levels are now standardized to match Google Cloud Logging specifications, and audit logs are assigned a severity of 'INFO'. (link:https://issues.redhat.com/browse/LOG-6296[LOG-6296])
 
 * Before this update, when infrastructure namespaces were included in application inputs, the `log_type` was set as `application`. With this update, the `log_type` of infrastructure namespaces included in application inputs is set to `infrastructure`. (link:https://issues.redhat.com/browse/LOG-6354[LOG-6354])
 
-* Before this update, specifying a value for the `syslog.enrichment` field of the ClusterLogForwarder added `namespace_name`, `container_name`, and `pod_name` to the messages of non-container logs. With this update, only container logs include `namespace_name`, `container_name`, and `pod_name` in their messages when `syslog.enrichment` is set. (link:https://issues.redhat.com/browse/LOG-6402[LOG-6402])
+* Before this update, specifying a value for the `syslog.enrichment` field of the `ClusterLogForwarder` added `namespace_name`, `container_name`, and `pod_name` to the messages of non-container logs. With this update, only container logs include `namespace_name`, `container_name`, and `pod_name` in their messages when `syslog.enrichment` is set. (link:https://issues.redhat.com/browse/LOG-6402[LOG-6402])
 
 [id="logging-release-notes-6-0-2-CVEs_{context}"]
 == CVEs
 
 * link:https://access.redhat.com/security/cve/CVE-2024-6119[CVE-2024-6119]
+
 * link:https://access.redhat.com/security/cve/CVE-2024-6232[CVE-2024-6232]

--- a/modules/logging-release-notes-6-0-3.adoc
+++ b/modules/logging-release-notes-6-0-3.adoc
@@ -2,6 +2,7 @@
 [id="logging-release-notes-6-0-3_{context}"]
 = Logging 6.0.3
 
+[role="_abstract"]
 This release includes link:https://access.redhat.com/errata/RHBA-2024:10991[RHBA-2024:10991].
 
 [id="logging-release-notes-6-0-3-enhancements_{context}"]
@@ -32,10 +33,17 @@ This release includes link:https://access.redhat.com/errata/RHBA-2024:10991[RHBA
 == CVEs
 
 * link:https://access.redhat.com/security/cve/CVE-2019-12900[CVE-2019-12900]
+
 * link:https://access.redhat.com/security/cve/CVE-2024-2511[CVE-2024-2511]
+
 * link:https://access.redhat.com/security/cve/CVE-2024-3596[CVE-2024-3596]
+
 * link:https://access.redhat.com/security/cve/CVE-2024-4603[CVE-2024-4603]
+
 * link:https://access.redhat.com/security/cve/CVE-2024-4741[CVE-2024-4741]
+
 * link:https://access.redhat.com/security/cve/CVE-2024-5535[CVE-2024-5535]
+
 * link:https://access.redhat.com/security/cve/CVE-2024-10963[CVE-2024-10963]
+
 * link:https://access.redhat.com/security/cve/CVE-2024-50602[CVE-2024-50602]

--- a/modules/logging-release-notes-6-0-4.adoc
+++ b/modules/logging-release-notes-6-0-4.adoc
@@ -1,6 +1,8 @@
 :_mod-docs-content-type: REFERENCE
 [id="logging-release-notes-6-0-4_{context}"]
 = Logging 6.0.4
+
+[role="_abstract"]
 This release includes link:https://access.redhat.com/errata/RHBA-2025:1228[RHBA-2025:1228].
 
 [id="logging-release-notes-6-0-4-enhancements_{context}"]

--- a/modules/logging-release-notes-6-0-5.adoc
+++ b/modules/logging-release-notes-6-0-5.adoc
@@ -1,11 +1,15 @@
 :_mod-docs-content-type: REFERENCE
 [id="logging-release-notes-6-0-5_{context}"]
 = Logging 6.0.5
+
+[role="_abstract"]
 This release includes link:https://access.redhat.com/errata/RHBA-2025:1986[RHBA-2025:1986].
 
 [id="logging-release-notes-6-0-5-cves_{context}"]
 == CVEs
 
 * link:https://access.redhat.com/security/cve/CVE-2020-11023[CVE-2020-11023]
+
 * link:https://access.redhat.com/security/cve/CVE-2024-9287[CVE-2024-9287]
+
 * link:https://access.redhat.com/security/cve/CVE-2024-12797[CVE-2024-12797]

--- a/modules/logging-release-notes-6-0-6.adoc
+++ b/modules/logging-release-notes-6-0-6.adoc
@@ -1,6 +1,8 @@
 :_mod-docs-content-type: REFERENCE
 [id="logging-release-notes-6-0-6_{context}"]
 = Logging 6.0.6
+
+[role="_abstract"]
 This release includes link:https://access.redhat.com/errata/RHSA-2025:3132[RHSA-2025:3132].
 
 [id="logging-release-notes-6-0-6-bug-fixes_{context}"]
@@ -12,9 +14,13 @@ This release includes link:https://access.redhat.com/errata/RHSA-2025:3132[RHSA-
 == CVEs
 
 * link:https://access.redhat.com/security/cve/CVE-2022-49043[CVE-2022-49043]
+
 * link:https://access.redhat.com/security/cve/CVE-2024-45338[CVE-2024-45338]
+
 * link:https://access.redhat.com/security/cve/CVE-2024-56171[CVE-2024-56171]
+
 * link:https://access.redhat.com/security/cve/CVE-2025-24928[CVE-2025-24928]
+
 * link:https://access.redhat.com/security/cve/CVE-2025-27144[CVE-2025-27144]
 
 [NOTE]

--- a/modules/logging-release-notes-6-0-7.adoc
+++ b/modules/logging-release-notes-6-0-7.adoc
@@ -2,8 +2,8 @@
 [id="logging-release-notes-6-0-7_{context}"]
 = Logging 6.0.7
 
+[role="_abstract"]
 This release includes link:https://access.redhat.com/errata/RHSA-2025:3905[RHSA-2025:3905].
-
 
 [id="logging-release-notes-6-0-7-enhancements_{context}"]
 == New features and enhancements

--- a/modules/logging-release-notes-6-0-8.adoc
+++ b/modules/logging-release-notes-6-0-8.adoc
@@ -6,6 +6,7 @@
 [id="logging-release-notes-6-0-8_{context}"]
 = Logging 6.0.8
 
+[role="_abstract"]
 This release includes link:https://access.redhat.com/errata/RHBA-2025:4520[RHBA-2025:4520].
 
 [id="logging-release-notes-6-0-8-bug-fixes_{context}"]
@@ -17,6 +18,7 @@ This release includes link:https://access.redhat.com/errata/RHBA-2025:4520[RHBA-
 == CVEs
 
 * https://access.redhat.com/security/cve/CVE-2024-2236[CVE-2024-2236]
+
 * https://access.redhat.com/security/cve/CVE-2024-5535[CVE-2024-5535]
 
 [NOTE]

--- a/modules/logging-release-notes-6-0-9.adoc
+++ b/modules/logging-release-notes-6-0-9.adoc
@@ -6,6 +6,7 @@
 [id="logging-release-notes-6-0-9_{context}"]
 = Logging 6.0.9
 
+[role="_abstract"]
 This release includes link:https://access.redhat.com/errata/RHBA-2025:8144[RHBA-2025:8144].
 
 [id="logging-release-notes-6-0-9-bug-fixes_{context}"]
@@ -19,13 +20,21 @@ This release includes link:https://access.redhat.com/errata/RHBA-2025:8144[RHBA-
 == CVEs
 
 * link:https://access.redhat.com/security/cve/CVE-2022-49043[CVE-2022-49043]
+
 * link:https://access.redhat.com/security/cve/CVE-2024-12087[CVE-2024-12087]
+
 * link:https://access.redhat.com/security/cve/CVE-2024-12088[CVE-2024-12088]
+
 * link:https://access.redhat.com/security/cve/CVE-2024-12133[CVE-2024-12133]
+
 * link:https://access.redhat.com/security/cve/CVE-2024-12243[CVE-2024-12243]
+
 * link:https://access.redhat.com/security/cve/CVE-2024-12747[CVE-2024-12747]
+
 * link:https://access.redhat.com/security/cve/CVE-2024-56171[CVE-2024-56171]
+
 * link:https://access.redhat.com/security/cve/CVE-2025-0395[CVE-2025-0395]
+
 * link:https://access.redhat.com/security/cve/CVE-2025-24928[CVE-2025-24928]
 
 For detailed information about Red{nbsp}Hat security ratings, see link:https://access.redhat.com/security/updates/classification/#important[Severity ratings].

--- a/release_notes/logging-release-notes-6-0.adoc
+++ b/release_notes/logging-release-notes-6-0.adoc
@@ -1,11 +1,13 @@
 :_mod-docs-content-type: ASSEMBLY
-include::_attributes/common-attributes.adoc[]
 [id="logging-release-notes-6-0"]
-= Release notes
-
+= Logging 6.0 Release notes
+include::_attributes/common-attributes.adoc[]
 :context: logging-release-notes-6-0
 
 toc::[]
+
+[role="_abstract"]
+These release notes describe the updates in {LoggingProductName} 6.0. They include new features and enhancements, bug fixes, security updates (CVEs), known issues, and Technology Preview features.
 
 include::modules/logging-release-notes-6-0-14.adoc[leveloffset=+1]
 
@@ -35,91 +37,14 @@ include::modules/logging-release-notes-6-0-2.adoc[leveloffset=+1]
 
 include::modules/logging-release-notes-6-0-1.adoc[leveloffset=+1]
 
-[id="log6x0-release-notes"]
-== Logging 6.0.0
-This release includes link:https://access.redhat.com/errata/RHBA-2024:6693[{logging-uc} {for} Bug Fix Release 6.0.0]
+include::modules/logging-6-0-0-release-notes.adoc[leveloffset=+1]
 
-include::snippets/logging-compatibility-snip.adoc[]
+include::modules/logging-6-0-0-release-notes-removal-notice.adoc[leveloffset=+1]
 
-.Upstream component versions
-[options="header"]
-|===
+include::modules/logging-6-0-0-release-notes-enhancements.adoc[leveloffset=+1]
 
-| {logging} Version 6+| Component Version
+include::modules/logging-6-0-0-release-notes-technology-preview.adoc[leveloffset=+1]
 
-| Operator | `eventrouter` | `logfilemetricexporter` | `loki` | `lokistack-gateway` | `opa-openshift` | `vector`
+include::modules/logging-6-0-0-release-notes-bug-fixes.adoc[leveloffset=+1]
 
-|6.0 | 0.4 | 1.1 | 3.1.0 | 0.1 | 0.1 | 0.37.1
-
-|===
-
-[id="log6x-release-notes-6-0-0-removal-notice"]
-== Removal notice
-
-* With this release, {logging} no longer supports the `ClusterLogging.logging.openshift.io` and `ClusterLogForwarder.logging.openshift.io` custom resources. Refer to the product documentation for details on the replacement features. (link:https://issues.redhat.com/browse/LOG-5803[LOG-5803])
-
-* With this release, {logging} no longer manages or deploys log storage (such as Elasticsearch), visualization (such as Kibana), or Fluentd-based log collectors. (link:https://issues.redhat.com/browse/LOG-5368[LOG-5368])
-
-[NOTE]
-====
-To continue to use Elasticsearch and Kibana managed by the elasticsearch-operator, the administrator must modify those object's ownerRefs before deleting the ClusterLogging resource.
-====
-
-[id="log6x-release-notes-6-0-0-enhancements"]
-== New features and enhancements
-
-* This feature introduces a new architecture for {logging} {for} by shifting component responsibilities to their relevant Operators, such as for storage, visualization, and collection. It introduces the `ClusterLogForwarder.observability.openshift.io` API for log collection and forwarding. Support for the `ClusterLogging.logging.openshift.io` and `ClusterLogForwarder.logging.openshift.io` APIs, along with the Red Hat managed Elastic stack (Elasticsearch and Kibana), is removed. Users are encouraged to migrate to the Red Hat `LokiStack` for log storage. Existing managed Elasticsearch deployments can be used for a limited time. Automated migration for log collection is not provided, so administrators need to create a new ClusterLogForwarder.observability.openshift.io specification to replace their previous custom resources. Refer to the official product documentation for more details. (link:https://issues.redhat.com/browse/LOG-3493[LOG-3493])
-
-* With this release, the responsibility for deploying the {logging} view plugin shifts from the {clo} to the {coo-first}. For new log storage installations that need visualization, the {coo-full} and the associated UIPlugin resource must be deployed. Refer to the link:https://docs.openshift.com/container-platform/latest/observability/cluster_observability_operator/cluster-observability-operator-overview.html#cluster-observability-operator-overview[Cluster Observability Operator Overview] product documentation for more details. (link:https://issues.redhat.com/browse/LOG-5461[LOG-5461])
-
-* This enhancement sets default requests and limits for Vector collector deployments' memory and CPU usage based on Vector documentation recommendations. (link:https://issues.redhat.com/browse/LOG-4745[LOG-4745])
-
-* This enhancement updates Vector to align with the upstream version v0.37.1. (link:https://issues.redhat.com/browse/LOG-5296[LOG-5296])
-
-* This enhancement introduces an alert that triggers when log collectors buffer logs to a node's file system and use over 15% of the available space, indicating potential back pressure issues. (link:https://issues.redhat.com/browse/LOG-5381[LOG-5381])
-
-* This enhancement updates the selectors for all components to use common Kubernetes labels. (link:https://issues.redhat.com/browse/LOG-5906[LOG-5906])
-
-* This enhancement changes the collector configuration to deploy as a ConfigMap instead of a secret, allowing users to view and edit the configuration when the ClusterLogForwarder is set to Unmanaged. (link:https://issues.redhat.com/browse/LOG-5599[LOG-5599])
-
-* This enhancement adds the ability to configure the Vector collector log level using an annotation on the ClusterLogForwarder, with options including trace, debug, info, warn, error, or off. (link:https://issues.redhat.com/browse/LOG-5372[LOG-5372])
-
-* This enhancement adds validation to reject configurations where Amazon CloudWatch outputs use multiple AWS roles, preventing incorrect log routing. (link:https://issues.redhat.com/browse/LOG-5640[LOG-5640])
-* This enhancement removes the Log Bytes Collected and Log Bytes Sent graphs from the metrics dashboard. (link:https://issues.redhat.com/browse/LOG-5964[LOG-5964])
-
-* This enhancement updates the must-gather functionality to only capture information for inspecting Logging 6.0 components, including Vector deployments from ClusterLogForwarder.observability.openshift.io resources and the Red Hat managed LokiStack. (link:https://issues.redhat.com/browse/LOG-5949[LOG-5949])
-
-* This enhancement improves Azure storage secret validation by providing early warnings for specific error conditions. (link:https://issues.redhat.com/browse/LOG-4571[LOG-4571])
-
-* This enhancement updates the `ClusterLogForwarder` API to follow the Kubernetes standards. (link:https://issues.redhat.com/browse/LOG-5977[LOG-5977])
-+
-.Example of a new configuration in the `ClusterLogForwarder` custom resource for the updated API
-[source,yaml]
-----
-apiVersion: observability.openshift.io/v1
-kind: ClusterLogForwarder
-metadata:
-  name: <name>
-spec:
-  outputs:
-  - name: <output_name>
-    type: <output_type>
-    <output_type>:
-      tuning:
-         deliveryMode: AtMostOnce
-----
-
-[id="log6x-release-notes-6-0-0-technology-preview-features"]
-== Technology Preview features
-
-* This release introduces a Technology Preview feature for log forwarding using OpenTelemetry. A new output type,` OTLP`, allows sending JSON-encoded log records using the OpenTelemetry data model and resource semantic conventions. (link:https://issues.redhat.com/browse/LOG-4225[LOG-4225])
-
-[id="log6x-release-notes-6-0-0-bug-fixes"]
-== Bug fixes
-
-* Before this update, the `CollectorHighErrorRate` and `CollectorVeryHighErrorRate` alerts were still present. With this update, both alerts are removed in the {logging} 6.0 release but might return in a future release. (link:https://issues.redhat.com/browse/LOG-3432[LOG-3432])
-
-[id="log6x-release-notes-6-0-0-CVEs"]
-== CVEs
-
-* link:https://access.redhat.com/security/cve/CVE-2024-34397[CVE-2024-34397]
+include::modules/logging-6-0-0-release-notes-cve.adoc[leveloffset=+1]


### PR DESCRIPTION
**Note for the peer & merge reviewer:** 
- This PR updates the only "6.0 release notes" sections to prepare them for Phase 0 DITA migration.
- No other CQA changes, error types, or content refinements are included. 

**Changes:** 
This PR prepares the "6.0 release notes" section for Phase 0 DITA migration by applying Vale (AsciiDoc DITA) rules and cleaning up the existing content.

**Doc preview:** 
- [v6.0 Release notes](https://110014--ocpdocs-pr.netlify.app/openshift-logging/latest/release_notes/logging-release-notes-6-0)

**Tracking JIRA:** https://redhat.atlassian.net/browse/OBSDOCS-3301

**Reviews:**
- [x] Peer has approved this change