### PR TITLE
DOCPLAN-83: CQA updates for virt-creating-linux-bridge-nad-web

### DIFF
--- a/modules/virt-creating-linux-bridge-nad-web.adoc
+++ b/modules/virt-creating-linux-bridge-nad-web.adoc
@@ -9,7 +9,7 @@
 = Creating a Linux bridge NAD by using the web console
 
 [role="_abstract"]
-You can create a network attachment definition (NAD) to provide layer-2 networking to pods and virtual machines by using the {product-title} web console.
+Use the {product-title} web console to create a network attachment definition (NAD) that connects pods and virtual machines to a layer-2 network.
 
 [WARNING]
 ====
@@ -34,7 +34,7 @@ ifndef::openshift-dedicated[]
 +
 [NOTE]
 ====
-OSA interfaces on {ibm-z-name} do not support VLAN filtering and VLAN-tagged traffic is dropped. Avoid using VLAN-tagged NADs with OSA interfaces.
+Open Systems Adapter (OSA) interfaces on {ibm-z-name} do not support VLAN filtering and drop VLAN-tagged traffic. Avoid using VLAN-tagged NADs with OSA interfaces.
 ====
 +
 endif::openshift-dedicated[]


### PR DESCRIPTION
Version(s):
Main, 4.21, 4.22

Issue:
[DOCPLAN-83](https://redhat.atlassian.net/browse/DOCPLAN-83)

[Link to docs preview](https://110018--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/post_installation_configuration/virt-post-install-network-config.html#virt-creating-linux-bridge-nad-web_virt-post-install-network-config)

QE review:
- [x] QE has approved this change.
