### PR TITLE
[OSDOCS#16805]Update ROSA Learning_Health check assembly_short description

### DIFF
--- a/rosa_learning/deploying_application_workshop/learning-deploying-application-health-check.adoc
+++ b/rosa_learning/deploying_application_workshop/learning-deploying-application-health-check.adoc
@@ -7,7 +7,7 @@ include::_attributes/attributes-openshift-dedicated.adoc[]
 
 toc::[]
 [role="_abstract"]
-See how Kubernetes responds to pod failure by intentionally crashing your pod and making it unresponsive to the Kubernetes liveness probes.
+You can see how Kubernetes responds to pod failure by purposely crashing your pod and making it unresponsive to Kubernetes liveness probes. Observing this failure allows you to verify how the cluster automatically handles recovery.
 
 include::modules/learning-deploying-application-health-check-prepare.adoc[leveloffset=+1]
 include::modules/learning-deploying-application-health-check-crash-pod.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s):
4.21+

Issue:
https://redhat.atlassian.net/browse/OSDOCS-16805

Link to docs preview:
[Health check](https://110031--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/rosa_learning/deploying_application_workshop/learning-deploying-application-health-check.html)

Peer review:
- [x] Peer reviewer has approved this change.

QE review:
- QE approval is not required for this PR as no procedural updates.

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
