### PR TITLE
OADP-7706: Modularize and DITA prep OADP Performance assembly

### DIFF
--- a/backup_and_restore/application_backup_and_restore/oadp-performance/oadp-recommended-network-settings.adoc
+++ b/backup_and_restore/application_backup_and_restore/oadp-performance/oadp-recommended-network-settings.adoc
@@ -9,18 +9,21 @@ include::_attributes/attributes-openshift-dedicated.adoc[]
 toc::[]
 
 [role="_abstract"]
-For a supported experience with {oadp-first}, you should have a stable and resilient network across {OCP-short} nodes, S3 storage, and in supported cloud environments that meet {OCP-short} network requirement recommendations.
+Keep a stable network across your {OCP-short} nodes, {aws-short} Simple Storage Service (S3) storage, and cloud environments. Meeting these recommended network settings helps you ensure successful {oadp-first} backup and restore operations, even when using remote {aws-short} S3 buckets.
 
-To ensure successful backup and restore operations for deployments with remote S3 buckets located off-cluster with suboptimal data paths, it is recommended that your network settings meet the following minimum requirements in such less optimal conditions:
+include::modules/oadp-performance-network-requirements.adoc[leveloffset=+1]
 
-* Bandwidth (network upload speed to object storage): Greater than 2 Mbps for small backups and 10-100 Mbps depending on the data volume for larger backups.
-* Packet loss: 1%
-* Packet corruption: 1%
-* Latency: 100ms
+[role="_additional-resources"]
+== Additional resources
 
-Ensure that your {product-title} network performs optimally and meets {product-title} network requirements.
+* link:https://docs.redhat.com/en/documentation/openshift_container_platform/{ocp-version}/html/configuring_network_settings/index[Configuring network settings]
 
-[IMPORTANT]
-====
-Although Red Hat provides supports for standard backup and restore failures, it does not provide support for failures caused by network settings that do not meet the recommended thresholds.
-====
+ifndef::openshift-rosa,openshift-rosa-hcp[]
+* xref:../../../backup_and_restore/application_backup_and_restore/installing/about-installing-oadp.adoc#about-installing-oadp[About installing {oadp-short}]
+* xref:../../../backup_and_restore/application_backup_and_restore/troubleshooting/troubleshooting.adoc#troubleshooting[Troubleshooting]
+endif::openshift-rosa,openshift-rosa-hcp[]
+
+ifdef::openshift-rosa,openshift-rosa-hcp[]
+* link:https://docs.redhat.com/en/documentation/openshift_container_platform/{ocp-version}/html/backup_and_restore/oadp-application-backup-and-restore#about-installing-oadp[About installing {oadp-short}]
+* link:https://docs.redhat.com/en/documentation/openshift_container_platform/{ocp-version}/html/backup_and_restore/oadp-application-backup-and-restore#troubleshooting[Troubleshooting]
+endif::openshift-rosa,openshift-rosa-hcp[]

--- a/modules/oadp-performance-network-requirements.adoc
+++ b/modules/oadp-performance-network-requirements.adoc
@@ -1,0 +1,25 @@
+// Module included in the following assemblies:
+//
+// * backup_and_restore/application_backup_and_restore/oadp-performance/oadp-recommended-network-settings.adoc
+
+
+:_mod-docs-content-type: CONCEPT
+[id="oadp-performance-network-requirements_{context}"]
+= {oadp-short} network requirements
+
+[role="_abstract"]
+For a supported experience with {oadp-first}, you should have a stable and resilient network across {OCP-short} nodes, {aws-short} Simple Storage Service (S3)-compatible object storage, and in supported cloud environments that meet {OCP-short} network requirements.
+
+For deployments that use remote S3 buckets located off-cluster with suboptimal data paths, such as high-latency or geographically distant locations, successful backup and restore operations require specific configurations. Ensure your network settings meet the following minimum requirements:
+
+* Bandwidth (network upload speed to object storage): Greater than 2 Mbps for small backups and 10-100 Mbps depending on the data volume for larger backups.
+* Packet loss: 1%
+* Packet corruption: 1%
+* Latency: 100 ms
+
+Ensure that your {product-title} network performs optimally and meets {product-title} network requirements.
+
+[IMPORTANT]
+====
+Although Red Hat provides support for standard backup and restore failures, it does not provide support for failures caused by network settings that do not meet the recommended thresholds.
+====


### PR DESCRIPTION
Version(s):
OCP 4.16+

Issue:
- [OADP-7706](https://redhat.atlassian.net/browse/OADP-7706)
- [OADP-7708](https://redhat.atlassian.net/browse/OADP-7708)
- [OADP-7707](https://redhat.atlassian.net/browse/OADP-7707)

Link to docs preview:
- [OADP recommended network settings](https://110032--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/oadp-performance/oadp-recommended-network-settings.html)

QE review:
- Bypassing QE review.

Summary:
- Modularize OADP performance assembly - create a CONCEPT module. Re-run both the assembly and the new concept module through Vale DITA to ensure all errors are fixed.
- Add Additional resources.
- Fix a typo.
- Expand S3 abbreviation on its first occurrence.
- Clarify 'suboptimal data paths'.