### PR TITLE
OCPBUGS-43969: Updated the Configuring your firewall for OpenShift Co…

### DIFF
--- a/modules/configuring-firewall.adoc
+++ b/modules/configuring-firewall.adoc
@@ -14,7 +14,7 @@ endif::[]
 Before you install {product-title}, you must configure your firewall to grant access to the sites that {product-title} requires. When using a firewall, make additional configurations to the firewall so that {product-title} can access the sites that it requires to function.
 
 ifndef::oci-agent[]
-There are no special configuration considerations for services running on only controller nodes compared to worker nodes.
+There are no special configuration considerations for services running on only controller nodes compared to compute nodes.
 endif::oci-agent[]
 
 ifdef::oci-agent[]
@@ -28,7 +28,7 @@ If your environment has a dedicated load balancer in front of your {product-titl
 
 .Procedure
 
-. Set the following registry URLs for your firewall's allowlist:
+. Allowlist the following container registry URLs for cluster installation and upgrades:
 +
 [cols="3,2,4",options="header"]
 |===
@@ -78,10 +78,6 @@ If your environment has a dedicated load balancer in front of your {product-titl
 |443
 |Provides core container images
 
-|`sso.redhat.com`
-|443
-|The `https://console.redhat.com` site uses authentication from `sso.redhat.com`
-
 |`icr.io`
 |443
 |Provides IBM Cloud Pak container images. This domain is only required if you use IBM Cloud Paks.
@@ -93,11 +89,69 @@ If your environment has a dedicated load balancer in front of your {product-titl
 +
 * You can use the wildcard `*.quay.io` instead of `cdn.quay.io` and `cdn0[1-6].quay.io` in your allowlist.
 * You can use the wildcard `*.access.redhat.com` to simplify the configuration and ensure that all subdomains, including `registry.access.redhat.com`, are allowed.
-* When you add a site, such as `quay.io`, to your allowlist, do not add a wildcard entry, such as `*.quay.io`, to your denylist. In most cases, image registries use a content delivery network (CDN) to serve images. If a firewall blocks access, image downloads are denied when the initial download request redirects to a hostname such as `cdn01.quay.io`.
+* When adding a site such as `quay.io` to your allowlist, do not add a wildcard entry such as `*.quay.io` to your denylist. In most cases, image registries use a content delivery network (CDN) to serve images. If a firewall blocks access, image downloads are denied when the initial download request redirects to a hostname such as `cdn01.quay.io`.
+
+. Allowlist the following URLs to enable cluster access, authentication, and updates:
++
+[cols="3,2,4",options="header"]
+|===
+|URL | Port | Function
+
+|`*.apps.<cluster_name>.<base_domain>`
+|443
+|Allowlist these URLs to enable cluster access, authentication, and updates.
+
+|`api.openshift.com`
+|443
+|API endpoint for cluster tokens and update checks.
+
+|`console.redhat.com`
+|443
+|Authentication service for cluster tokens.
+
+|`sso.redhat.com`
+|443
+|The `https://console.redhat.com` site uses authentication from `sso.redhat.com`
+|===
++
+For egress traffic, Operators require route access to perform health checks to establish a connection for reaching endpoints. The authentication and web console Operators connect to two routes to verify functionality. Cluster administrators who do not want to allow `*.apps.<cluster_name>.<base_domain>`, must allow the following routes:
++
+* `oauth-openshift.apps.<cluster_name>.<base_domain>`
+* `canary-openshift-ingress-canary.apps.<cluster_name>.<base_domain>`
+* `console-openshift-console.apps.<cluster_name>.<base_domain>`, or the hostname
+that is specified in the `spec.route.hostname` field of the
+`consoles.operator/cluster` object if the field is not empty.
+
+. Allowlist the following registry URLs that host related artifacts for cluster installation and upgrades, such as installation content, release images, and client tools:
++
+[cols="3,2,4",options="header"]
+|===
+|URL | Port | Function
+
+|`mirror.openshift.com`
+|443
+|Required to access mirrored installation content and images. This site is also a source of release image signatures, although the Cluster Version Operator needs only a single functioning source.
+
+|`quayio-production-s3.s3.amazonaws.com`
+|443
+|Required to access Quay image content in AWS.
+
+// |`registry.access.redhat.com`
+// |443
+// |Required for `odo` CLI.
+
+|`rhcos.mirror.openshift.com`
+|443
+|Required to download {op-system-first} images.
+
+|`storage.googleapis.com/openshift-release`
+|443
+|A source of release image signatures, although the Cluster Version Operator needs only a single functioning source.
+|===
 
 . Set your firewall's allowlist to include any site that provides resources for a language or framework that your builds require.
 
-. If you do not disable Telemetry, you must grant access to the following URLs to access {red-hat-lightspeed}:
+. If you do not disable Telemetry, you must grant access to the following URLs to access Telemetry and {red-hat-lightspeed}:
 +
 [cols="3,2,4",options="header"]
 |===
@@ -267,57 +321,6 @@ Alternatively, if you choose to not use a wildcard for AWS APIs, you must includ
 
 |===
 
-. Allowlist the following URLs:
-+
-[cols="3,2,4",options="header"]
-|===
-|URL | Port | Function
-
-|`*.apps.<cluster_name>.<base_domain>`
-|443
-|Required to access the default cluster routes unless you set an ingress wildcard during installation.
-
-|`api.openshift.com`
-|443
-|Required both for your cluster token and to check if updates are available for the cluster.
-
-|`console.redhat.com`
-|443
-|Required for your cluster token.
-
-|`mirror.openshift.com`
-|443
-|Required to access mirrored installation content and images. This site is also a source of release image signatures, although the Cluster Version Operator needs only a single functioning source.
-
-|`quayio-production-s3.s3.amazonaws.com`
-|443
-|Required to access Quay image content in AWS.
-
-// |`registry.access.redhat.com`
-// |443
-// |Required for `odo` CLI.
-
-|`rhcos.mirror.openshift.com`
-|443
-|Required to download {op-system-first} images.
-
-|`sso.redhat.com`
-|443
-|The `https://console.redhat.com` site uses authentication from `sso.redhat.com`
-
-|`storage.googleapis.com/openshift-release`
-|443
-|A source of release image signatures, although the Cluster Version Operator needs only a single functioning source.
-|===
-+
-Operators require route access to perform health checks. Specifically, the authentication and web console Operators connect to two routes to verify that the routes work. If you are the cluster administrator and do not want to allow `*.apps.<cluster_name>.<base_domain>`, then allow these routes:
-+
-* `oauth-openshift.apps.<cluster_name>.<base_domain>`
-* `canary-openshift-ingress-canary.apps.<cluster_name>.<base_domain>`
-* `console-openshift-console.apps.<cluster_name>.<base_domain>`, or the hostname
-that is specified in the `spec.route.hostname` field of the
-`consoles.operator/cluster` object if the field is not empty.
-
 . Allowlist the following URL for optional third-party content:
 +
 [cols="3,2,4",options="header"]
@@ -328,18 +331,31 @@ that is specified in the `spec.route.hostname` field of the
 |443
 |Required for all third-party images and certified operators.
 |===
+
+. If you use a default Red Hat Network Time Protocol (NTP) server, allow the following URLs. NTP operates on User Datagram Protocol (UDP) port 123, so this port must be opened on the firewall. 
 +
-. If you use a default Red Hat Network Time Protocol (NTP) server allow the following URLs:
-* `1.rhel.pool.ntp.org`
-* `2.rhel.pool.ntp.org`
-* `3.rhel.pool.ntp.org`
+[cols="3,2,4",options="header"]
+|===
+|URL | Port | Function
+
+|`1.rhel.pool.ntp.org`
+|123
+|Provides NTP services for time synchronization.
+
+|`2.rhel.pool.ntp.org`
+|123
+|Provides NTP services for time synchronization.
+
+|`3.rhel.pool.ntp.org`
+|123
+|Provides NTP services for time synchronization.
+|===
 
 [NOTE]
 ====
 If you do not use a default Red Hat NTP server, verify the NTP server for your platform and allow it in your firewall.
 ====
 endif::oci-agent[]
-
 
 ifeval::["{context}" == "installing-oci-agent-based-installer"]
 :!oci-agent:


### PR DESCRIPTION
Version(s):
4.16+

Issue:
[OCPBUGS-43969](https://redhat.atlassian.net/browse/OCPBUGS-43969)

Link to docs preview:

* https://110035--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/install_config/configuring-firewall.html
* https://110035--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_oci_edge/installing-c3-agent-based-installer.html
* https://110035--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_oci/installing-oci-agent-based-installer.html

- [x] Reporter has approved this change.
- [x] SME has approved this change (Thuan Vo).
- [x] QE has approved this change (Major Deore).

See Slack thread: https://redhat-internal.slack.com/archives/C68TNFWA2/p1775809678448099
