### PR TITLE
OSDOCS-14868: Removed an important note that explains limits to httpasswd

### DIFF
--- a/.vale.ini
+++ b/.vale.ini
@@ -1,62 +1,13 @@
 StylesPath = .vale/styles
+MinAlertLevel = warning
+Packages = https://github.com/jhradilek/asciidoctor-dita-vale/releases/latest/download/AsciiDocDITA.zip
 
-MinAlertLevel = suggestion
+[*.adoc]
+BasedOnStyles = AsciiDocDITA
 
-Packages = RedHat, AsciiDoc, OpenShiftAsciiDoc, https://github.com/jhradilek/asciidoctor-dita-vale/releases/latest/download/AsciiDocDITA.zip
-
-Vocab = OpenShiftDocs
-
-# Ignore files in dirs starting with `.` to avoid raising errors for `.vale/fixtures/*/testinvalid.adoc` files
-[[!.]*.adoc]
-BasedOnStyles = RedHat, AsciiDoc, OpenShiftAsciiDoc
-
-# Disabling rules (NO)
-RedHat.ReleaseNotes = NO
-
-# Use local OpenShiftDocs Vocab terms
-Vale.Terms = YES
-Vale.Avoid = YES
-
-# Enable specifc DITA rules on assemblies
-AsciiDocDITA.AdmonitionTitle = error
-AsciiDocDITA.AssemblyContents = error
-AsciiDocDITA.AuthorLine = error
-AsciiDocDITA.BlockTitle = error
-AsciiDocDITA.CalloutList = error
-AsciiDocDITA.ConceptLink = error
-AsciiDocDITA.ContentType = error
-AsciiDocDITA.DiscreteHeading = error
-AsciiDocDITA.DocumentID = error
-AsciiDocDITA.DocumentTitle = error
-AsciiDocDITA.EntityReference = error
-AsciiDocDITA.EquationFormula = error
-AsciiDocDITA.ExampleBlock = error
-AsciiDocDITA.LineBreak = error
-AsciiDocDITA.MismatchedID = error
-AsciiDocDITA.NestedSection = error
-AsciiDocDITA.PageBreak = error
-AsciiDocDITA.RelatedLinks = error
-AsciiDocDITA.ShortDescription = error
-AsciiDocDITA.SidebarBlock = error
-AsciiDocDITA.TableFooter = error
-AsciiDocDITA.TaskContents = error
-AsciiDocDITA.TaskDuplicate = error
-AsciiDocDITA.TaskExample = error
-AsciiDocDITA.TaskSection = error
-AsciiDocDITA.TaskStep = error
-AsciiDocDITA.TaskTitle = error
-AsciiDocDITA.ThematicBreak = error
-
-# Disable module specific rules
-OpenShiftAsciiDoc.ModuleContainsParentAssemblyComment = NO
-OpenShiftAsciiDoc.NoNestingInModules = NO
-OpenShiftAsciiDoc.NoXrefInModules = NO
-OpenShiftAsciiDoc.IdHasContextVariable = NO
-OpenShiftAsciiDoc.NoTocInModules = NO
-
-# Optional: pass doc attributes to asciidoctor before linting
-# Temp values are used for Prow CI comment linting only
-[asciidoctor]
-temp-ifdef = YES
-temp-ifndef = NO
-temp-ifeval = temp
+# The rules below are based on recommended practices and do not prevent
+# successful conversion to DITA.  If your product is not bound by these
+# guidelines, uncomment the following lines to disable them:
+#AsciiDocDITA.CalloutList = NO
+#AsciiDocDITA.ShortDescription = NO
+#AsciiDocDITA.ConceptLink = NO

--- a/modules/config-htpasswd-idp.adoc
+++ b/modules/config-htpasswd-idp.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * osd_install_access_delete_cluster/config-identity-providers.adoc
+// * authentication/sd-configuring-identity-providers.adoc
 // * rosa_install_access_delete_clusters/rosa-sts-config-identity-providers.adoc
 
 :_mod-docs-content-type: CONCEPT
@@ -20,10 +20,12 @@ endif::[]
 [role="_abstract"]
 Configure an htpasswd identity provider to create a single, static user with cluster administration privileges. You can log in to your cluster as the user to troubleshoot problems. You can use the web user interface (UI) or your command-line interface (CLI) to create an htpasswd identity provider.
 
+ifndef::openshift-rosa,openshift-rosa-hcp[]
 [IMPORTANT]
 ====
 The htpasswd identity provider option is included only to create a single, static administration user. htpasswd is not supported as a general-use identity provider for {product-title}.
 ====
+endif::openshift-rosa,openshift-rosa-hcp[]
 
 ifeval::["{context}" == "config-identity-providers"]
 :!osd-distro:

--- a/modules/understanding-idp.adoc
+++ b/modules/understanding-idp.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * osd_install_access_delete_cluster/config-identity-providers.adoc
+// * authentication/sd-configuring-identity-providers.adoc
 // * rosa_install_access_delete_clusters/rosa-sts-config-identity-providers.adoc
 
 :_mod-docs-content-type: CONCEPT
@@ -40,9 +40,11 @@ You can configure the following types of identity providers:
 |htpasswd
 |Configure an htpasswd identity provider for a single, static administration user. You can log in to the cluster as the user to troubleshoot issues.
 
+ifndef::openshift-rosa,openshift-rosa-hcp[]
 [IMPORTANT]
 ====
 The htpasswd identity provider option is included only to enable the creation of a single, static administration user. htpasswd is not supported as a general-use identity provider for {product-title}. For the steps to configure the single user, see _Configuring an htpasswd identity provider_.
 ====
+endif::openshift-rosa,openshift-rosa-hcp[]
 
 |===


### PR DESCRIPTION
Version(s):
`enterprise-4.21+`

Issue:
**[OSDOCS-14868](https://redhat.atlassian.net/browse/OSDOCS-14868)**

Link to docs preview:
- [Configuring an htpasswd identity provider](https://110051--ocpdocs-pr.netlify.app/openshift-dedicated/latest/authentication/sd-configuring-identity-providers.html#config-htpasswd-idp_sd-configuring-identity-providers) (OSD)
- [Supported Identity Providers](https://110051--ocpdocs-pr.netlify.app/openshift-dedicated/latest/authentication/sd-configuring-identity-providers#understanding-idp-supported_sd-configuring-identity-providers) note
- [Configuring an htpasswd identity provider](https://110051--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/authentication/sd-configuring-identity-providers.html#config-htpasswd-idp_sd-configuring-identity-providers) (ROSA)
- [Supported Identity Providers](https://110051--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/authentication/sd-configuring-identity-providers#understanding-idp-supported_sd-configuring-identity-providers) note
- ROSA Classic
    - [Configuring an htpasswd identity provider](https://110051--ocpdocs-pr.netlify.app/openshift-rosa/latest/authentication/sd-configuring-identity-providers.html#config-htpasswd-idp_sd-configuring-identity-providers) 1
    - [Configuring an htpasswd identity provider](https://110051--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_install_access_delete_clusters/rosa-sts-config-identity-providers.html#config-htpasswd-idp_rosa-sts-config-identity-providers) 2
    - [Supported Identity Providers](https://110051--ocpdocs-pr.netlify.app/openshift-rosa/latest/authentication/sd-configuring-identity-providers#understanding-idp-supported_sd-configuring-identity-providers) note 

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
This PR removes the following note from `openshift-rosa-hcp`:

> The` htpasswd identity provider option is included only to enable the creation of a single, static administration user. htpasswd is not supported as a general-use identity provider for Red Hat OpenShift Service on AWS.