### PR TITLE
[OSDOCS#16803]Update ROSA Learning_S2I depoloyment_CQA_assembly jobs

### DIFF
--- a/rosa_learning/deploying_application_workshop/learning-deploying-application-s2i-deployments.adoc
+++ b/rosa_learning/deploying_application_workshop/learning-deploying-application-s2i-deployments.adoc
@@ -6,9 +6,14 @@ include::_attributes/attributes-openshift-dedicated.adoc[]
 :context: cloud-experts-deploying-application-s2i-deployments
 toc::[]
 [role="_abstract"]
-The integrated Source-to-Image (S2I) builder is one method to deploy applications in {OCP-short}. The S2I is a tool for building reproducible, Docker-formatted container images. For more information, see link:https://docs.redhat.com/en/documentation/openshift_container_platform/latest/html/overview/getting-started-openshift-common-terms_openshift-editions[Glossary of common terms for {OCP}]. You must have a deployed {product-title} cluster before starting this process.
+You can deploy applications in {product-title} by using the integrated Source-to-Image (S2I) builder. Compiling your source code with S2I helps you efficiently build reproducible, Docker-formatted container images.
 
 include::modules/learning-deploying-application-s2i-deployments-retrieving-login.adoc[leveloffset=+1]
 include::modules/learning-deploying-application-s2i-deployments-create-new-project.adoc[leveloffset=+1]
 include::modules/learning-deploying-application-s2i-deployments-fork-repo.adoc[leveloffset=+1]
 include::modules/learning-deploying-application-s2i-deployments-deploy-to-cluster.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+== Additional resources
+
+* link:https://docs.redhat.com/en/documentation/openshift_container_platform/latest/html/overview/getting-started-openshift-common-terms_openshift-editions[Glossary of common terms for {OCP}]


### PR DESCRIPTION
Version(s):
4.21+

Issue:
https://redhat.atlassian.net/browse/OSDOCS-16803

Link to docs preview:
[S2I deployments](https://110054--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/rosa_learning/deploying_application_workshop/learning-deploying-application-s2i-deployments.html)

Peer review:
- [ ] Peer reviewer has approved this change.

QE review:
- QE approval is not required for this PR as no procedural changes.

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
