### PR TITLE
OSDOCS-19110: remove plus and fix term

### DIFF
--- a/modules/installation-configure-proxy.adoc
+++ b/modules/installation-configure-proxy.adoc
@@ -174,7 +174,7 @@ additionalTrustBundlePolicy: <policy_to_add_additionalTrustBundle>
 # ...
 ----
 +
-where: 
+where:
 +
 `proxy.httpProxy`:: Specifies a proxy URL to use for creating HTTP connections outside the cluster. The URL scheme must be `http`.
 `proxy.httpsProxy`:: Specifies a proxy URL to use for creating HTTPS connections outside the cluster.
@@ -197,8 +197,8 @@ The installation program does not support the proxy `readinessEndpoints` field.
 +
 [NOTE]
 ====
-If the installer times out, restart and then complete the deployment by using the `wait-for` command of the installer. For example:
-+
+If the installation program times out, restart and then complete the deployment by using the `wait-for` command of the installation program. For example:
+
 [source,terminal]
 ----
 $ ./openshift-install wait-for install-complete --log-level debug

--- a/modules/installation-osp-deploying-bare-metal-machines.adoc
+++ b/modules/installation-osp-deploying-bare-metal-machines.adoc
@@ -108,9 +108,9 @@ endif::osp-ipi[]
 
 [NOTE]
 ====
-The installer may time out while waiting for bare metal machines to boot.
+The installation program may time out while waiting for bare metal machines to boot.
 
-If the installer times out, restart and then complete the deployment by using the `wait-for` command of the installer. For example:
+If the installation program times out, restart and then complete the deployment by using the `wait-for` command of the installation program. For example:
 
 [source,terminal]
 ----


### PR DESCRIPTION
Version(s):
4.16+

Issue:
[OSDOCS-19110](https://redhat.atlassian.net/browse/OSDOCS-19110)

Link to docs preview:


QE review:
N/A

Additional information:
Stumbled across this `+` rendering in the output and fixed it. Notcied use of "installer" while fixing. Any other changes in these topics are out of scope.