### PR TITLE
[OSDOCS#18862]: Added conditions for TNF in backup and restore

### DIFF
--- a/backup_and_restore/control_plane_backup_and_restore/disaster_recovery/about-disaster-recovery.adoc
+++ b/backup_and_restore/control_plane_backup_and_restore/disaster_recovery/about-disaster-recovery.adoc
@@ -28,16 +28,15 @@ xref:../../../backup_and_restore/control_plane_backup_and_restore/disaster_recov
 If you have a majority of your control plane nodes still available and have an etcd quorum, then xref:../../../backup_and_restore/control_plane_backup_and_restore/replacing-unhealthy-etcd-member.adoc#replacing-unhealthy-etcd-member[replace a single unhealthy etcd member].
 ====
 
-xref:../../../backup_and_restore/control_plane_backup_and_restore/disaster_recovery/scenario-2-restoring-cluster-state.adoc#dr-restoring-cluster-state[Restoring to a previous cluster state]::
 This solution handles situations where you want to restore your cluster to
-a previous state, for example, if an administrator deletes something critical.
-If you have taken an etcd backup, you can restore your cluster to a previous state.
+an earlier state, for example, if an administrator deletes something critical.
+If you have taken an etcd backup, you can restore your cluster to an earlier state.
 +
 If applicable, you might also need to xref:../../../backup_and_restore/control_plane_backup_and_restore/disaster_recovery/scenario-3-expired-certs.adoc#dr-recovering-expired-certs[recover from expired control plane certificates].
 +
 [WARNING]
 ====
-Restoring to a previous cluster state is a destructive and destablizing action to take on a running cluster. This procedure should only be used as a last resort.
+Restoring to an earlier cluster state is a destructive and destablizing action to take on a running cluster. This procedure should only be used as a last resort.
 
 Prior to performing a restore, see xref:../../../backup_and_restore/control_plane_backup_and_restore/disaster_recovery/scenario-2-restoring-cluster-state.adoc#dr-scenario-2-restoring-cluster-state-about_dr-restoring-cluster-state[About restoring cluster state] for more information on the impact to the cluster.
 ====
@@ -54,4 +53,4 @@ include::modules/dr-testing-restore-procedures.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources
-* xref:../../../backup_and_restore/control_plane_backup_and_restore/disaster_recovery/scenario-2-restoring-cluster-state.adoc#dr-restoring-cluster-state[Restoring to a previous cluster state]
+* xref:../../../backup_and_restore/control_plane_backup_and_restore/disaster_recovery/scenario-2-restoring-cluster-state.adoc#dr-restoring-cluster-state[Restoring to an earlier cluster state]

--- a/modules/backup-etcd.adoc
+++ b/modules/backup-etcd.adoc
@@ -7,12 +7,15 @@
 [id="backing-up-etcd-data_{context}"]
 = Backing up etcd data
 
+[role="_abstract"]
 Follow these steps to back up etcd data by creating an etcd snapshot and backing up the resources for the static pods. This backup can be saved and used at a later time if you need to restore etcd.
 
 [IMPORTANT]
 ====
 Only save a backup from a single control plane host. Do not take a backup from each control plane host in the cluster.
 ====
+
+For a Two-Node with Fencing (TNF) setup, follow the steps to back up etcd data on only one node in the cluster. The cluster restore process is driven by data from a single node, so you can perform the etcd backup steps on only one node.
 
 .Prerequisites
 
@@ -98,7 +101,7 @@ In this example, two files are created in the `/home/core/assets/backup/` direct
 +
 [NOTE]
 ====
-If etcd encryption is enabled, it is recommended to store this second file separately from the etcd snapshot for security reasons. However, this file is required to restore from the etcd snapshot.
+If etcd encryption is enabled, store this second file separately from the etcd snapshot for security reasons. However, this file is required to restore from the etcd snapshot.
 
-Keep in mind that etcd encryption only encrypts values, not keys. This means that resource types, namespaces, and object names are unencrypted.
+The etcd encryption only encrypts values, not keys. This means that resource types, namespaces, and object names are not encrypted.
 ====

--- a/modules/dr-restoring-cluster-state-about.adoc
+++ b/modules/dr-restoring-cluster-state-about.adoc
@@ -5,20 +5,21 @@
 
 :_mod-docs-content-type: CONCEPT
 [id="dr-scenario-2-restoring-cluster-state-about_{context}"]
-= About restoring to a previous cluster state
+= About restoring to an earlier cluster state
 
-To restore the cluster to a previous state, you must have previously backed up the `etcd` data by creating a snapshot. You will use this snapshot to restore the cluster state. For more information, see "Backing up etcd data".
+[role="_abstract"]
+To restore the cluster to an earlier state, you must have already backed up the `etcd` data by creating a snapshot. You can use this snapshot to restore the cluster state. For more information, see "Backing up etcd data".
 
-You can use an etcd backup to restore your cluster to a previous state. This can be used to recover from the following situations:
+You can use an etcd backup to restore your cluster to an earlier state. This can be used to recover from the following situations:
 
 * The cluster has lost the majority of control plane hosts (quorum loss).
 * An administrator has deleted something critical and must restore to recover the cluster.
 
 [WARNING]
 ====
-Restoring to a previous cluster state is a destructive and destablizing action to take on a running cluster. This should only be used as a last resort.
+Restoring to an earlier cluster state is a destructive and destablizing action to take on a running cluster. This should only be used as a last resort.
 
-If you are able to retrieve data using the Kubernetes API server, then etcd is available and you should not restore using an etcd backup.
+If you cannot retrieve data using the Kubernetes API server, then etcd is available and you should not restore using an etcd backup.
 ====
 
 Restoring etcd effectively takes a cluster back in time and all clients will experience a conflicting, parallel history. This can impact the behavior of watching components like kubelets, Kubernetes controller managers, persistent volume controllers, and {product-title} Operators, including the network Operator.

--- a/modules/dr-restoring-cluster-state-sno.adoc
+++ b/modules/dr-restoring-cluster-state-sno.adoc
@@ -5,9 +5,10 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="dr-restoring-cluster-state-sno_{context}"]
-= Restoring to a previous cluster state for a single node
+= Restoring to an earlier cluster state for a single node
 
-You can use a saved etcd backup to restore a previous cluster state on a single node.
+[role="_abstract"]
+You can use a saved etcd backup to restore an earlier cluster state on a single node.
 
 [IMPORTANT]
 ====
@@ -29,7 +30,7 @@ When you restore your cluster, you must use an etcd backup that was taken from t
 $ cp <etcd_backup_directory> /home/core
 ----
 
-. Run the following command in the single node to restore the cluster from a previous backup:
+. To restore the cluster from an earlier backup, run the following command on the single node::
 +
 [source,terminal]
 ----

--- a/modules/dr-restoring-cluster-state.adoc
+++ b/modules/dr-restoring-cluster-state.adoc
@@ -15,15 +15,28 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="dr-scenario-2-restoring-cluster-state_{context}"]
-= Restoring to a previous cluster state for more than one node
+= Restoring to an earlier cluster state for more than one node
 
-You can use a saved etcd backup to restore a previous cluster state or restore a cluster that has lost the majority of control plane hosts.
+[role="abstract"]
+You can use a saved etcd backup to restore an earlier cluster state or restore a cluster that has lost the majority of control plane hosts.
 
-For high availability (HA) clusters, a three-node HA cluster requires you to shut down etcd on two hosts to avoid a cluster split. On four-node and five-node HA clusters, you must shut down three hosts. Quorum requires a simple majority of nodes. The minimum number of nodes required for quorum on a three-node HA cluster is two. On four-node and five-node HA clusters, the minimum number of nodes required for quorum is three. If you start a new cluster from backup on your recovery host, the other etcd members might still be able to form quorum and continue service.
+For a Two-Node with Fencing (TNF) setup, a single surviving node can continue to operate in degraded mode. Use a saved etcd backup to restore an earlier cluster state if only one node is operational, or when both nodes have failed and you need to restart the cluster from a known safe state. In both cases, perform the restore procedure on a single node. The peer node automatically synchronizes its data with the restored node when it rejoins the cluster.
+
+For a 3-node HA cluster, shut down etcd on the following number of hosts: 
+
+- For 3-node clusters: Shut down etcd on 2 hosts.
+- For 4-node and 5-node clusters: Shut down etcd on 3 hosts. 
+
+Quorum requires a simple majority of nodes. The minimum number of nodes required for a quorum is as follows: 
+
+- For 3-node HA cluster: 2. 
+- For 4-node and 5-node HA clusters: 3. 
+
+If you start a new cluster from backup on your recovery host, the other etcd members might still form a quorum and continue service.
 
 [NOTE]
 ====
-If your cluster uses a control plane machine set, see "Recovering a degraded etcd Operator" in "Troubleshooting the control plane machine set" for an etcd recovery procedure. For {product-title} on a single node, see "Restoring to a previous cluster state for a single node".
+If your cluster uses a control plane machine set, see "Recovering a degraded etcd Operator" in "Troubleshooting the control plane machine set" for an etcd recovery procedure. For {product-title} on a single node, see "Restoring to an earlier cluster state for a single node".
 ====
 
 [IMPORTANT]
@@ -54,7 +67,7 @@ For non-recovery control plane nodes, it is not required to establish SSH connec
 +
 [IMPORTANT]
 ====
-If you do not complete this step, you will not be able to access the control plane hosts to complete the restore procedure, and you will be unable to recover your cluster from this state.
+If you do not complete this step, you cannot access the control plane hosts to complete the restore procedure, and you cannot recover your cluster from this state.
 ====
 
 . Using SSH, connect to each control plane node and run the following command to disable etcd:
@@ -68,7 +81,7 @@ $ sudo -E /usr/local/bin/disable-etcd.sh
 +
 This procedure assumes that you copied the `backup` directory containing the etcd snapshot and the resources for the static pods to the `/home/core/` directory of your recovery control plane host.
 
-. Use SSH to connect to the recovery host and restore the cluster from a previous backup by running the following command:
+. Use SSH to connect to the recovery host. To restore the cluster from an earlier backup, run the following command:
 +
 [source,terminal]
 ----
@@ -77,7 +90,18 @@ $ sudo -E /usr/local/bin/cluster-restore.sh /home/core/<etcd-backup-directory>
 
 . Exit the SSH session.
 
-. Once the API responds, turn off the etcd Operator quorum guard by running the following command:
+. When the API responds, to turn off the etcd Operator quorum guard, run the following command:
+
+[IMPORTANT]
+====
+For a TNF setup, do not:
+
+  * Change the etcd Operator quorum setting. 
+
+  * Turn the etcd Operator quorum off.
+
+  * Turn the etcd Operator quorum on back.
+====
 +
 [source,terminal]
 ----
@@ -93,10 +117,10 @@ $ oc adm wait-for-stable-cluster
 +
 [NOTE]
 ====
-It can take up to 15 minutes for the control plane to recover.
+It can take up to 15 minutes for the control plane to recover. Wait for the control plane to recover before using the next step.
 ====
 
-. Once recovered, enable the quorum guard by running the following command:
+. Enable the quorum guard by running the following command:
 +
 [source,terminal]
 ----
@@ -105,7 +129,7 @@ $ oc patch etcd/cluster --type=merge -p '{"spec": {"unsupportedConfigOverrides":
 
 .Troubleshooting
 
-If you see no progress rolling out the etcd static pods, you can force redeployment from the `cluster-etcd-operator` by running the following command:
+If the etcd static pods do not roll out , you can manually force an etcd redeployment from the `cluster-etcd-operator` by running the following command:
 
 [source,terminal]
 ----


### PR DESCRIPTION
Version(s):
4.22

Issue:
https://redhat.atlassian.net/browse/OSDOCS-18862

Link to docs preview:

Backup: 
https://110077--ocpdocs-pr.netlify.app/openshift-enterprise/latest/etcd/etcd-backup-restore/etcd-backup.html#backing-up-etcd-data_etcd-backup

Restore: 
https://110077--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/control_plane_backup_and_restore/disaster_recovery/scenario-2-restoring-cluster-state.html#dr-scenario-2-restoring-cluster-state-about_dr-restoring-cluster-state


QE review:
- [x] QE has approved this change.
See https://github.com/openshift/openshift-docs/pull/109960 for QE ack.

Additional information:
In this PR, I fixed comments from Shauna given in https://github.com/openshift/openshift-docs/pull/109960. Unfortunately, my local repo setup got some issues. So, to have a clean start, I created this new PR. 
