### PR TITLE
[OSDOCS#18851]: Removed Ingress LB statement for TNF

### DIFF
--- a/backup_and_restore/application_backup_and_restore/installing/about-installing-oadp.adoc
+++ b/backup_and_restore/application_backup_and_restore/installing/about-installing-oadp.adoc
@@ -14,10 +14,10 @@ As a cluster administrator, you install the OpenShift API for Data Protection (O
 
 To back up Kubernetes resources and internal images, you must have object storage as a backup location, such as one of the following storage types:
 
-* xref:../../../backup_and_restore/application_backup_and_restore/installing/installing-oadp-aws.adoc#installing-oadp-aws[Amazon Web Services]
-* xref:../../../backup_and_restore/application_backup_and_restore/installing/installing-oadp-azure.adoc#installing-oadp-azure[Microsoft Azure]
-* xref:../../../backup_and_restore/application_backup_and_restore/installing/installing-oadp-gcp.adoc#installing-oadp-gcp[{gcp-full}]
-* xref:../../../backup_and_restore/application_backup_and_restore/installing/installing-oadp-mcg.adoc#installing-oadp-mcg[Multicloud Object Gateway]
+* Amazon Web Services
+* Microsoft Azure
+* {gcp-full}
+* Multicloud Object Gateway
 * {ibm-cloud-name} Object Storage S3
 * AWS S3 compatible object storage, such as Multicloud Object Gateway or MinIO
 
@@ -29,14 +29,14 @@ You can back up persistent volumes (PVs) by using snapshots or a File System Bac
 
 To back up PVs with snapshots, you must have a cloud provider that supports either a native snapshot API or Container Storage Interface (CSI) snapshots, such as one of the following cloud providers:
 
-* xref:../../../backup_and_restore/application_backup_and_restore/installing/installing-oadp-aws.adoc#installing-oadp-aws[Amazon Web Services]
-* xref:../../../backup_and_restore/application_backup_and_restore/installing/installing-oadp-azure.adoc#installing-oadp-azure[Microsoft Azure]
-* xref:../../../backup_and_restore/application_backup_and_restore/installing/installing-oadp-gcp.adoc#installing-oadp-gcp[{gcp-full}]
-* CSI snapshot-enabled cloud provider, such as xref:../../../backup_and_restore/application_backup_and_restore/installing/installing-oadp-ocs.adoc#installing-oadp-ocs[OpenShift Data Foundation]
+* Amazon Web Services
+* Microsoft Azure
+* {gcp-full}
+* CSI snapshot-enabled cloud provider, such as {rh-storage}
 
 include::snippets/oadp-ocp-compat.adoc[]
 
-If your cloud provider does not support snapshots or if your storage is NFS, you can back up applications with xref:../../../backup_and_restore/application_backup_and_restore/backing_up_and_restoring/oadp-backing-up-applications-restic-doc.adoc#backing-up-applications[Backing up applications with File System Backup: Kopia or Restic] on object storage.
+If your cloud provider does not support snapshots or if your storage is NFS, you can back up applications with File System Backup: Kopia or Restic on object storage.
 
 You create a default `Secret` and then you install the Data Protection Application.
 
@@ -44,19 +44,22 @@ include::modules/oadp-s3-compatible-backup-storage-providers.adoc[leveloffset=+1
 
 include::modules/oadp-configuring-noobaa-for-dr.adoc[leveloffset=+1]
 
-[role="_additional-resources"]
-.Additional resources
 
-* {velero-overview}
+[role="_additional-resources"]
+[id="additional-resources_{context}"]
+== Additional resources
+
+* xref:../../../backup_and_restore/application_backup_and_restore/installing/installing-oadp-aws.adoc#installing-oadp-aws[Installing OADP on Amazon Web Services]
+* xref:../../../backup_and_restore/application_backup_and_restore/installing/installing-oadp-azure.adoc#installing-oadp-azure[Installing OADP on Microsoft Azure]
+* xref:../../../backup_and_restore/application_backup_and_restore/installing/installing-oadp-gcp.adoc#installing-oadp-gcp[Installing OADP on {gcp-full}]
+* xref:../../../backup_and_restore/application_backup_and_restore/installing/installing-oadp-mcg.adoc#installing-oadp-mcg[Installing OADP on Multicloud Object Gateway]
+* xref:../../../backup_and_restore/application_backup_and_restore/installing/installing-oadp-ocs.adoc#installing-oadp-ocs[Installing OADP on {rh-storage}]
+* xref:../../../backup_and_restore/application_backup_and_restore/backing_up_and_restoring/oadp-backing-up-applications-restic-doc.adoc#backing-up-applications[Backing up applications with File System Backup: Kopia or Restic]
+* xref:../../../operators/understanding/olm/olm-understanding-olm.adoc#olm-csv_olm-understanding-olm[Cluster service version]
 
 include::modules/about-oadp-update-channels.adoc[leveloffset=+1]
 include::modules/about-installing-oadp-on-multiple-namespaces.adoc[leveloffset=+1]
 include::modules/oadp-support-backup-data-immutability.adoc[leveloffset=+1]
-
-[role="_additional-resources"]
-.Additional resources
-
-* xref:../../../operators/understanding/olm/olm-understanding-olm.adoc#olm-csv_olm-understanding-olm[Cluster service version]
 
 include::modules/oadp-velero-cpu-memory-requirements.adoc[leveloffset=+1]
 include::modules/oadp-backup-restore-for-large-usage.adoc[leveloffset=+2]

--- a/backup_and_restore/application_backup_and_restore/installing/about-oadp-data-mover.adoc
+++ b/backup_and_restore/application_backup_and_restore/installing/about-oadp-data-mover.adoc
@@ -9,7 +9,7 @@ toc::[]
 [role="_abstract"]
 Use the {oadp-first} built-in Data Mover to move Container Storage Interface (CSI) volume snapshots to remote object storage and restore stateful applications after cluster failures. This provides disaster recovery capabilities for both containerized and virtual machine workloads.
 
-The Data Mover uses xref:../../../backup_and_restore/application_backup_and_restore/backing_up_and_restoring/oadp-about-kopia.adoc#oadp-about-kopia[Kopia] as the uploader mechanism to read the snapshot data and write to the unified repository. 
+The Data Mover uses Kopia as the uploader mechanism to read the snapshot data and write to the unified repository. 
 
 {oadp-short} supports CSI snapshots on the following:
 
@@ -23,3 +23,9 @@ include::modules/oadp-enabling-built-in-data-mover.adoc[leveloffset=+1]
 include::modules/oadp-data-mover-crds.adoc[leveloffset=+1]
 
 include::modules/oadp-incremental-backup-support.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+[id="additional-resources_{context}"]
+== Additional resources
+
+* xref:../../../backup_and_restore/application_backup_and_restore/backing_up_and_restoring/oadp-about-kopia.adoc#oadp-about-kopia[About Kopia]

--- a/backup_and_restore/application_backup_and_restore/installing/installing-oadp-azure.adoc
+++ b/backup_and_restore/application_backup_and_restore/installing/installing-oadp-azure.adoc
@@ -12,11 +12,11 @@ toc::[]
 [role="_abstract"]
 Configure the {oadp-first} with Microsoft Azure to back up and restore cluster resources by using Azure storage. This provides data protection capabilities for your {product-title} clusters.
 
-The {oadp-short} Operator installs link:https://{velero-domain}/docs/v{velero-version}/[Velero {velero-version}].
+The {oadp-short} Operator installs Velero {velero-version}.
 
-You configure Azure for Velero, create a default `Secret`, and then install the Data Protection Application. For more details, see xref:../../../backup_and_restore/application_backup_and_restore/installing/oadp-installing-operator.adoc#oadp-installing-operator-doc[Installing the OADP Operator].
+You configure Azure for Velero, create a default `Secret`, and then install the Data Protection Application.
 
-To install the OADP Operator in a restricted network environment, you must first disable the default software catalog sources and mirror the Operator catalog. See xref:../../../disconnected/using-olm.adoc#olm-restricted-networks[Using Operator Lifecycle Manager in disconnected environments] for details.
+To install the OADP Operator in a restricted network environment, you must first disable the default software catalog sources and mirror the Operator catalog.
 
 
 include::modules/migration-configuring-azure.adoc[leveloffset=+1]
@@ -62,12 +62,14 @@ include::modules/oadp-enabling-csi-dpa.adoc[leveloffset=+2]
 include::modules/oadp-about-disable-node-agent-dpa.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
-.Additional resources
+[id="additional-resources_{context}"]
+== Additional resources
 
+* link:https://{velero-domain}/docs/v{velero-version}/[Velero {velero-version}]
+* xref:../../../backup_and_restore/application_backup_and_restore/installing/oadp-installing-operator.adoc#oadp-installing-operator-doc[Installing the OADP Operator]
+* xref:../../../disconnected/using-olm.adoc#olm-restricted-networks[Using Operator Lifecycle Manager in disconnected environments]
 * xref:../../../backup_and_restore/application_backup_and_restore/installing/installing-oadp-kubevirt.adoc#oadp-installing-dpa_installing-oadp-kubevirt[Installing the Data Protection Application with the `kubevirt` and `openshift` plugins]
-
 * xref:../../../nodes/jobs/nodes-nodes-jobs.adoc#nodes-nodes-jobs[Running tasks in pods using jobs]
-
 * xref:../../../backup_and_restore/application_backup_and_restore/installing/configuring-oadp-multiple-bsl.adoc#configuring-oadp-multiple-bsl[Configuring the {oadp-first} with multiple backup storage locations]
 
 :installing-oadp-azure!:

--- a/backup_and_restore/application_backup_and_restore/installing/installing-oadp-gcp.adoc
+++ b/backup_and_restore/application_backup_and_restore/installing/installing-oadp-gcp.adoc
@@ -10,11 +10,11 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 [role="_abstract"]
-You install the OpenShift API for Data Protection (OADP) with {gcp-first} by installing the OADP Operator. The Operator installs link:https://{velero-domain}/docs/v{velero-version}/[Velero {velero-version}].
+You install the OpenShift API for Data Protection (OADP) with {gcp-first} by installing the OADP Operator. The Operator installs Velero {velero-version}.
 
-You configure {gcp-short} for Velero, create a default `Secret`, and then install the Data Protection Application. For more details, see xref:../../../backup_and_restore/application_backup_and_restore/installing/oadp-installing-operator.adoc#oadp-installing-operator-doc[Installing the OADP Operator].
+You configure {gcp-short} for Velero, create a default `Secret`, and then install the Data Protection Application.
 
-To install the OADP Operator in a restricted network environment, you must first disable the default software catalog sources and mirror the Operator catalog. See xref:../../../disconnected/using-olm.adoc#olm-restricted-networks[Using Operator Lifecycle Manager in disconnected environments] for details.
+To install the OADP Operator in a restricted network environment, you must first disable the default software catalog sources and mirror the Operator catalog.
 
 
 include::modules/migration-configuring-gcp.adoc[leveloffset=+1]
@@ -60,12 +60,14 @@ include::modules/oadp-enabling-csi-dpa.adoc[leveloffset=+2]
 include::modules/oadp-about-disable-node-agent-dpa.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
-.Additional resources
+[id="additional-resources_{context}"]
+== Additional resources
 
+* link:https://{velero-domain}/docs/v{velero-version}/[Velero {velero-version}]
+* xref:../../../backup_and_restore/application_backup_and_restore/installing/oadp-installing-operator.adoc#oadp-installing-operator-doc[Installing the OADP Operator]
+* xref:../../../disconnected/using-olm.adoc#olm-restricted-networks[Using Operator Lifecycle Manager in disconnected environments]
 * xref:../../../backup_and_restore/application_backup_and_restore/installing/installing-oadp-kubevirt.adoc#oadp-installing-dpa_installing-oadp-kubevirt[Installing the Data Protection Application with the `kubevirt` and `openshift` plugins]
-
 * xref:../../../nodes/jobs/nodes-nodes-jobs.adoc#nodes-nodes-jobs[Running tasks in pods using jobs]
-
 * xref:../../../backup_and_restore/application_backup_and_restore/installing/configuring-oadp-multiple-bsl.adoc#configuring-oadp-multiple-bsl[Configuring the {oadp-first} with multiple backup storage locations]
 
 :installing-oadp-gcp!:

--- a/backup_and_restore/application_backup_and_restore/installing/installing-oadp-kubevirt.adoc
+++ b/backup_and_restore/application_backup_and_restore/installing/installing-oadp-kubevirt.adoc
@@ -13,7 +13,7 @@ toc::[]
 [role="_abstract"]
 You can install the {oadp-first} with {VirtProductName} by installing the OADP Operator and configuring a backup location. Then, you can install the Data Protection Application.
 
-Back up and restore virtual machines by using the xref:../../../backup_and_restore/index.adoc#application-backup-restore-operations-overview[{oadp-full}].
+Back up and restore virtual machines by using the {oadp-full}.
 
 {oadp-full} with {VirtProductName} supports the following backup and restore storage options:
 
@@ -27,9 +27,7 @@ The following storage options are excluded:
 
 * Volume snapshot backups and restores
 
-For more information, see xref:../../../backup_and_restore/application_backup_and_restore/backing_up_and_restoring/oadp-backing-up-applications-restic-doc.adoc#oadp-backing-up-applications-restic-doc[Backing up applications with File System Backup: Kopia or Restic].
-
-To install the OADP Operator in a restricted network environment, you must first disable the default software catalog sources and mirror the Operator catalog. See xref:../../../disconnected/using-olm.adoc#olm-restricted-networks[Using Operator Lifecycle Manager in disconnected environments] for details.
+To install the OADP Operator in a restricted network environment, you must first disable the default software catalog sources and mirror the Operator catalog.
 
 [IMPORTANT]
 ====
@@ -73,6 +71,8 @@ include::modules/oadp-incremental-backup-support.adoc[leveloffset=+1]
 [role="_additional-resources"]
 [id="additional-resources_{context}"]
 == Additional resources
+* xref:../../../backup_and_restore/index.adoc#application-backup-restore-operations-overview[Application backup and restore operations]
+* xref:../../../backup_and_restore/application_backup_and_restore/backing_up_and_restoring/oadp-backing-up-applications-restic-doc.adoc#oadp-backing-up-applications-restic-doc[Backing up applications with File System Backup: Kopia or Restic]
 * xref:../../../backup_and_restore/application_backup_and_restore/oadp-features-plugins.adoc#oadp-plugins_oadp-features-plugins[{oadp-short} plugins]
 * xref:../../../backup_and_restore/application_backup_and_restore/backing_up_and_restoring/backing-up-applications.adoc#backing-up-applications[`Backup` custom resource (CR)]
 * xref:../../../backup_and_restore/application_backup_and_restore/backing_up_and_restoring/restoring-applications.adoc#restoring-applications[`Restore` CR]

--- a/backup_and_restore/application_backup_and_restore/installing/installing-oadp-mcg.adoc
+++ b/backup_and_restore/application_backup_and_restore/installing/installing-oadp-mcg.adoc
@@ -13,11 +13,11 @@ toc::[]
 [role="_abstract"]
 Configure {oadp-first} to use Multicloud Object Gateway (MCG), a component of {rh-storage}, as a backup storage location by setting up credentials, secrets, and the Data Protection Application.
 
-You can install the {oadp-first} with MCG by installing the OADP Operator. The Operator installs link:https://{velero-domain}/docs/v{velero-version}/[Velero {velero-version}].
+You can install the {oadp-first} with MCG by installing the OADP Operator. The Operator installs Velero {velero-version}.
 
-You can create a `Secret` CR for the backup location and install the Data Protection Application. For more details, see xref:../../../backup_and_restore/application_backup_and_restore/installing/oadp-installing-operator.adoc#oadp-installing-operator-doc[Installing the OADP Operator].
+You can create a `Secret` CR for the backup location and install the Data Protection Application.
 
-To install the OADP Operator in a restricted network environment, you must first disable the default software catalog sources and mirror the Operator catalog. For details, see xref:../../../disconnected/using-olm.adoc#olm-restricted-networks[Using Operator Lifecycle Manager in disconnected environments].
+To install the OADP Operator in a restricted network environment, you must first disable the default software catalog sources and mirror the Operator catalog.
 
 
 include::modules/migration-configuring-mcg.adoc[leveloffset=+1]
@@ -61,15 +61,16 @@ include::modules/oadp-enabling-csi-dpa.adoc[leveloffset=+2]
 include::modules/oadp-about-disable-node-agent-dpa.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
-.Additional resources
+[id="additional-resources_{context}"]
+== Additional resources
 
+* link:https://{velero-domain}/docs/v{velero-version}/[Velero {velero-version}]
+* xref:../../../backup_and_restore/application_backup_and_restore/installing/oadp-installing-operator.adoc#oadp-installing-operator-doc[Installing the OADP Operator]
+* xref:../../../disconnected/using-olm.adoc#olm-restricted-networks[Using Operator Lifecycle Manager in disconnected environments]
 * link:https://access.redhat.com/solutions/6719951[Performance tuning guide for Multicloud Object Gateway]
-
 * xref:../../../backup_and_restore/application_backup_and_restore/installing/installing-oadp-kubevirt.adoc#oadp-installing-dpa_installing-oadp-kubevirt[Installing the Data Protection Application with the `kubevirt` and `openshift` plugins]
 * xref:../../../nodes/jobs/nodes-nodes-jobs.adoc#nodes-nodes-jobs[Running tasks in pods using jobs]
-
 * xref:../../../backup_and_restore/application_backup_and_restore/installing/configuring-oadp-multiple-bsl.adoc#configuring-oadp-multiple-bsl[Configuring the {oadp-first} with multiple backup storage locations]
-
 * xref:../../../backup_and_restore/application_backup_and_restore/installing/installing-oadp-mcg.adoc#oadp-configuring-node-agents_installing-oadp-mcg[Configuring node agents and node labels]
 
 

--- a/backup_and_restore/application_backup_and_restore/installing/installing-oadp-ocs.adoc
+++ b/backup_and_restore/application_backup_and_restore/installing/installing-oadp-ocs.adoc
@@ -12,11 +12,11 @@ toc::[]
 [role="_abstract"]
 Install the {oadp-first} with {rh-storage} by installing the {oadp-short} Operator and configuring a backup location and a snapshot location. You then install the Data Protection Application.
 
-You can configure xref:../../../backup_and_restore/application_backup_and_restore/installing/installing-oadp-mcg.adoc#installing-oadp-mcg[Multicloud Object Gateway] or any AWS S3-compatible object storage as a backup location.
+You can configure Multicloud Object Gateway or any AWS S3-compatible object storage as a backup location.
 
-You can create a `Secret` CR for the backup location and install the Data Protection Application. For more details, see xref:../../../backup_and_restore/application_backup_and_restore/installing/oadp-installing-operator.adoc#oadp-installing-operator-doc[Installing the OADP Operator].
+You can create a `Secret` CR for the backup location and install the Data Protection Application.
 
-To install the OADP Operator in a restricted network environment, you must first disable the default software catalog sources and mirror the Operator catalog. For details, see xref:../../../disconnected/using-olm.adoc#olm-restricted-networks[Using Operator Lifecycle Manager in disconnected environments].
+To install the OADP Operator in a restricted network environment, you must first disable the default software catalog sources and mirror the Operator catalog.
 
 
 include::modules/oadp-about-backup-snapshot-locations-secrets.adoc[leveloffset=+1]
@@ -62,16 +62,16 @@ include::modules/oadp-enabling-csi-dpa.adoc[leveloffset=+2]
 include::modules/oadp-about-disable-node-agent-dpa.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
-.Additional resources
+[id="additional-resources_{context}"]
+== Additional resources
 
+* xref:../../../backup_and_restore/application_backup_and_restore/installing/installing-oadp-mcg.adoc#installing-oadp-mcg[Configuring OADP with Multicloud Object Gateway]
+* xref:../../../backup_and_restore/application_backup_and_restore/installing/oadp-installing-operator.adoc#oadp-installing-operator-doc[Installing the OADP Operator]
+* xref:../../../disconnected/using-olm.adoc#olm-restricted-networks[Using Operator Lifecycle Manager in disconnected environments]
 * xref:../../../backup_and_restore/application_backup_and_restore/installing/installing-oadp-kubevirt.adoc#oadp-installing-dpa_installing-oadp-kubevirt[Installing the Data Protection Application with the `kubevirt` and `openshift` plugins]
-
 * xref:../../../nodes/jobs/nodes-nodes-jobs.adoc#nodes-nodes-jobs[Running tasks in pods using jobs]
-
 * xref:../../../backup_and_restore/application_backup_and_restore/installing/configuring-oadp-multiple-bsl.adoc#configuring-oadp-multiple-bsl[Configuring the {oadp-first} with multiple backup storage locations]
-
 * https://access.redhat.com/documentation/en-us/red_hat_openshift_data_foundation/4.13/html/managing_hybrid_and_multicloud_resources/object-bucket-claim#creating-an-object-bucket-claim-using-the-openshift-web-console_rhodf[Creating an Object Bucket Claim using the OpenShift Web Console]
-
 * xref:../../../backup_and_restore/application_backup_and_restore/installing/installing-oadp-ocs.adoc#oadp-configuring-node-agents_installing-oadp-ocs[Configuring node agents and node labels]
 
 :installing-oadp-ocs!:

--- a/backup_and_restore/application_backup_and_restore/installing/oadp-installing-operator.adoc
+++ b/backup_and_restore/application_backup_and_restore/installing/oadp-installing-operator.adoc
@@ -9,8 +9,14 @@ toc::[]
 [role="_abstract"]
 Install the {oadp-first} Operator on {product-title} {product-version} by using Operator Lifecycle Manager (OLM).
 
-The {oadp-short} Operator installs link:https://{velero-domain}/docs/v{velero-version}/[Velero {velero-version}].
+The {oadp-short} Operator installs Velero {velero-version}.
 
 include::modules/installing-operator-oadp.adoc[leveloffset=+1]
 
 include::modules/velero-oadp-version-relationship.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+[id="additional-resources_{context}"]
+== Additional resources
+
+* link:https://{velero-domain}/docs/v{velero-version}/[Velero {velero-version}]

--- a/backup_and_restore/application_backup_and_restore/installing/uninstalling-oadp.adoc
+++ b/backup_and_restore/application_backup_and_restore/installing/uninstalling-oadp.adoc
@@ -7,4 +7,10 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 [role="_abstract"]
-You uninstall the OpenShift API for Data Protection (OADP) by deleting the OADP Operator. See xref:../../../operators/admin/olm-deleting-operators-from-cluster.adoc#olm-deleting-operators-from-cluster[Deleting Operators from a cluster] for details.
+You uninstall the OpenShift API for Data Protection (OADP) by deleting the OADP Operator.
+
+[role="_additional-resources"]
+[id="additional-resources_{context}"]
+== Additional resources
+
+* xref:../../../operators/admin/olm-deleting-operators-from-cluster.adoc#olm-deleting-operators-from-cluster[Deleting Operators from a cluster]

--- a/backup_and_restore/application_backup_and_restore/oadp-api.adoc
+++ b/backup_and_restore/application_backup_and_restore/oadp-api.adoc
@@ -15,7 +15,7 @@ include::_attributes/common-attributes.adoc[]
 You can use the following APIs with {oadp-short}:
 
 Velero API::
-Velero API documentation is maintained by Velero and is not maintained by Red{nbsp}Hat. For more information, see link:https://velero.io/docs/main/api-types/[API types] (Velero documentation).
+Velero API documentation is maintained by Velero and is not maintained by Red{nbsp}Hat.
 
 OADP API::
 
@@ -31,8 +31,6 @@ The following are the {oadp-short} APIs:
 * `PodConfig`
 * `Features`
 * `DataMover`
-+
-For more information, see in link:https://pkg.go.dev/github.com/openshift/oadp-operator[OADP Operator](Go documentation).
 
 include::modules/dataprotectionapplicationspec-type.adoc[leveloffset=+1]
 
@@ -50,12 +48,15 @@ include::modules/resticconfig-type.adoc[leveloffset=+1]
 
 include::modules/podconfig-type.adoc[leveloffset=+1]
 
-[role="_additional-resources"]
-.Additional resources
-
-* xref:../../backup_and_restore/application_backup_and_restore/oadp-features-plugins#oadp-features-plugins[OADP plugins]
-* link:https://pkg.go.dev/github.com/openshift/oadp-operator/api/v1alpha1#PodConfig[Complete schema definitions for the type `PodConfig`](Go documentation)
-
 include::modules/features-type.adoc[leveloffset=+1]
 
 include::modules/datamover-type.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+[id="additional-resources_{context}"]
+== Additional resources
+
+* link:https://velero.io/docs/main/api-types/[Velero API types]
+* link:https://pkg.go.dev/github.com/openshift/oadp-operator[OADP Operator (Go documentation)] 
+* xref:../../backup_and_restore/application_backup_and_restore/oadp-features-plugins#oadp-features-plugins[OADP plugins]
+* link:https://pkg.go.dev/github.com/openshift/oadp-operator/api/v1alpha1#PodConfig[Complete schema definitions for the type `PodConfig`]

--- a/backup_and_restore/application_backup_and_restore/troubleshooting/oadp-timeouts.adoc
+++ b/backup_and_restore/application_backup_and_restore/troubleshooting/oadp-timeouts.adoc
@@ -15,20 +15,6 @@ Configure {oadp-short} timeout parameters for Restic, Velero, Data Mover, CSI sn
 
 Ensure that you balance timeout extensions in a logical manner so that you do not configure excessively long timeouts that might hide underlying issues in the process. Consider and monitor an appropriate timeout value that meets the needs of the process and the overall system performance.
 
-Review the following {oadp-short} timeout instructions:
-
-* xref:../../../backup_and_restore/application_backup_and_restore/troubleshooting/oadp-timeouts.adoc#restic-timeout_oadp-timeouts[Restic timeout]
-
-* xref:../../../backup_and_restore/application_backup_and_restore/troubleshooting/oadp-timeouts.adoc#velero-timeout_oadp-timeouts[Velero resource timeout]
-
-* xref:../../../backup_and_restore/application_backup_and_restore/troubleshooting/oadp-timeouts.adoc#datamover-timeout_oadp-timeouts[Data Mover timeout]
-
-* xref:../../../backup_and_restore/application_backup_and_restore/troubleshooting/oadp-timeouts.adoc#csisnapshot-timeout_oadp-timeouts[CSI snapshot timeout]
-
-* xref:../../../backup_and_restore/application_backup_and_restore/troubleshooting/oadp-timeouts.adoc#item-operation-timeout-backup_oadp-timeouts[Item operation timeout - backup]
-
-* xref:../../../backup_and_restore/application_backup_and_restore/troubleshooting/oadp-timeouts.adoc#item-operation-timeout-restore_oadp-timeouts[Item operation timeout - restore]
-
 include::modules/oadp-restic-timeouts.adoc[leveloffset=+1]
 
 include::modules/oadp-velero-timeouts.adoc[leveloffset=+1]
@@ -42,3 +28,14 @@ include::modules/oadp-csi-snapshot-timeouts.adoc[leveloffset=+1]
 include::modules/oadp-item-restore-timeouts.adoc[leveloffset=+1]
 
 include::modules/oadp-item-backup-timeouts.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+[id="additional-resources_{context}"]
+== Additional resources
+
+* xref:../../../backup_and_restore/application_backup_and_restore/troubleshooting/oadp-timeouts.adoc#restic-timeout_oadp-timeouts[Restic timeout]
+* xref:../../../backup_and_restore/application_backup_and_restore/troubleshooting/oadp-timeouts.adoc#velero-timeout_oadp-timeouts[Velero resource timeout]
+* xref:../../../backup_and_restore/application_backup_and_restore/troubleshooting/oadp-timeouts.adoc#datamover-timeout_oadp-timeouts[Data Mover timeout]
+* xref:../../../backup_and_restore/application_backup_and_restore/troubleshooting/oadp-timeouts.adoc#csisnapshot-timeout_oadp-timeouts[CSI snapshot timeout]
+* xref:../../../backup_and_restore/application_backup_and_restore/troubleshooting/oadp-timeouts.adoc#item-operation-timeout-backup_oadp-timeouts[Item operation timeout - backup]
+* xref:../../../backup_and_restore/application_backup_and_restore/troubleshooting/oadp-timeouts.adoc#item-operation-timeout-restore_oadp-timeouts[Item operation timeout - restore]

--- a/backup_and_restore/application_backup_and_restore/troubleshooting/troubleshooting.adoc
+++ b/backup_and_restore/application_backup_and_restore/troubleshooting/troubleshooting.adoc
@@ -18,21 +18,38 @@ Troubleshoot {oadp-first} issues by using diagnostic tools such as the Velero CL
 
 You can troubleshoot OADP issues by using the following methods:
 
-* Debug Velero custom resources (CRs) by using the xref:../../../backup_and_restore/application_backup_and_restore/troubleshooting/velero-cli-tool.adoc#oadp-debugging-oc-cli_velero-cli-tool[OpenShift CLI tool] or the xref:../../../backup_and_restore/application_backup_and_restore/troubleshooting/velero-cli-tool.adoc#migration-debugging-velero-resources_velero-cli-tool[Velero CLI tool]. The Velero CLI tool provides more detailed logs and information.
+* Debug Velero custom resources (CRs) by using the OpenShift CLI tool or the Velero CLI tool. The Velero CLI tool provides more detailed logs and information.
 
-* Debug Velero or Restic pod crashes, which are caused due to a lack of memory or CPU by using xref:../../../backup_and_restore/application_backup_and_restore/troubleshooting/pods-crash-or-restart-due-to-lack-of-memory-or-cpu.adoc#pods-crash-or-restart-due-to-lack-of-memory-or-cpu[Pods crash or restart due to lack of memory or CPU].
+* Debug Velero or Restic pod crashes, which are caused due to a lack of memory or CPU.
 
-* Debug issues with Velero and admission webhooks by using xref:../../../backup_and_restore/application_backup_and_restore/troubleshooting/restoring-workarounds-for-velero-backups-that-use-admission-webhooks.adoc#restoring-workarounds-for-velero-backups-that-use-admission-webhooks[Restoring workarounds for Velero backups that use admission webhooks].
+* Debug issues with Velero and admission webhooks.
 
-* Check xref:../../../backup_and_restore/application_backup_and_restore/troubleshooting/oadp-installation-issues.adoc#oadp-installation-issues[OADP installation issues], xref:../../../backup_and_restore/application_backup_and_restore/troubleshooting/oadp-operator-issues.adoc#oadp-operator-issues[OADP Operator issues], xref:../../../backup_and_restore/application_backup_and_restore/troubleshooting/backup-and-restore-cr-issues.adoc#backup-and-restore-cr-issues[backup and restore CR issues], and xref:../../../backup_and_restore/application_backup_and_restore/troubleshooting/restic-issues.adoc#restic-issues[Restic issues].
+* Check OADP installation issues, OADP Operator issues, backup and restore CR issues, and Restic issues.
 
-* Use the available xref:../../../backup_and_restore/application_backup_and_restore/troubleshooting/oadp-timeouts.adoc#oadp-timeouts[OADP timeouts] to reduce errors, retries, or failures.
+* Use the available OADP timeouts to reduce errors, retries, or failures.
 
-* Run the xref:../../../backup_and_restore/application_backup_and_restore/troubleshooting/oadp-data-protection-test.adoc#oadp-data-protection-test[`DataProtectionTest` (DPT)] custom resource to verify your backup storage bucket configuration and check the CSI snapshot readiness for persistent volume claims.
+* Run the `DataProtectionTest` (DPT) custom resource to verify your backup storage bucket configuration and check the CSI snapshot readiness for persistent volume claims.
 
-* Collect logs and CR information by using the xref:../../../backup_and_restore/application_backup_and_restore/troubleshooting/using-the-must-gather-tool.adoc#using-the-must-gather-tool[`must-gather` tool].
+* Collect logs and CR information by using the `must-gather` tool.
 
-* Monitor and analyze the workload performance with the help of xref:../../../backup_and_restore/application_backup_and_restore/troubleshooting/oadp-monitoring.adoc#oadp-monitoring[OADP monitoring].
+* Monitor and analyze the workload performance with the help of OADP monitoring.
+
+[role="_additional-resources"]
+[id="additional-resources_{context}"]
+== Additional resources
+
+* xref:../../../backup_and_restore/application_backup_and_restore/troubleshooting/velero-cli-tool.adoc#oadp-debugging-oc-cli_velero-cli-tool[Debugging with the OpenShift CLI tool]
+* xref:../../../backup_and_restore/application_backup_and_restore/troubleshooting/velero-cli-tool.adoc#migration-debugging-velero-resources_velero-cli-tool[Debugging with the Velero CLI tool]
+* xref:../../../backup_and_restore/application_backup_and_restore/troubleshooting/pods-crash-or-restart-due-to-lack-of-memory-or-cpu.adoc#pods-crash-or-restart-due-to-lack-of-memory-or-cpu[Pods crash or restart due to lack of memory or CPU]
+* xref:../../../backup_and_restore/application_backup_and_restore/troubleshooting/restoring-workarounds-for-velero-backups-that-use-admission-webhooks.adoc#restoring-workarounds-for-velero-backups-that-use-admission-webhooks[Restoring workarounds for Velero backups that use admission webhooks]
+* xref:../../../backup_and_restore/application_backup_and_restore/troubleshooting/oadp-installation-issues.adoc#oadp-installation-issues[OADP installation issues]
+* xref:../../../backup_and_restore/application_backup_and_restore/troubleshooting/oadp-operator-issues.adoc#oadp-operator-issues[OADP Operator issues]
+* xref:../../../backup_and_restore/application_backup_and_restore/troubleshooting/backup-and-restore-cr-issues.adoc#backup-and-restore-cr-issues[Backup and restore CR issues]
+* xref:../../../backup_and_restore/application_backup_and_restore/troubleshooting/restic-issues.adoc#restic-issues[Restic issues]
+* xref:../../../backup_and_restore/application_backup_and_restore/troubleshooting/oadp-timeouts.adoc#oadp-timeouts[OADP timeouts]
+* xref:../../../backup_and_restore/application_backup_and_restore/troubleshooting/oadp-data-protection-test.adoc#oadp-data-protection-test[DataProtectionTest custom resource]
+* xref:../../../backup_and_restore/application_backup_and_restore/troubleshooting/using-the-must-gather-tool.adoc#using-the-must-gather-tool[Using the must-gather tool]
+* xref:../../../backup_and_restore/application_backup_and_restore/troubleshooting/oadp-monitoring.adoc#oadp-monitoring[OADP monitoring]
 
 
 :oadp-troubleshooting!:

--- a/installing/installing_two_node_cluster/installing_tnf/installing-two-node-fencing.adoc
+++ b/installing/installing_two_node_cluster/installing_tnf/installing-two-node-fencing.adoc
@@ -6,21 +6,19 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-:FeatureName: Two-node OpenShift cluster with fencing
-include::snippets/technology-preview.adoc[leveloffset=+1]
+[role="_abstract"]
+A two-node OpenShift cluster with fencing (TNF) provides high availability (HA) with a reduced hardware footprint. This configuration is designed for distributed or edge environments where deploying a full three-node control plane cluster is not practical.
 
-A two-node OpenShift cluster with fencing provides high availability (HA) with a reduced hardware footprint. This configuration is designed for distributed or edge environments where deploying a full three-node control plane cluster is not practical.
+A two-node cluster does not include compute nodes. The two control plane machines run user workloads and manage the cluster.
 
-A two-node cluster does not include compute nodes. The two control plane machines run user workloads in addition to managing the cluster.
-
-Fencing is managed by Pacemaker, which can isolate an unresponsive node by using the Baseboard Management Console (BMC) of the node. After the unresponsive node is fenced, the remaining node can safely continue operating the cluster without the risk of resource corruption.
+Pacemaker uses the Baseboard Management Console (BMC) of the node to fence and isolate a failed node. This prevents resource corruption and allows the remaining node to continue operating.
 
 [NOTE]
 ====
-You can deploy a two-node OpenShift cluster with fencing by using either the user-provisioned infrastructure  method or the installer-provisioned infrastructure method.
+You can deploy a two-node OpenShift cluster with fencing by using either the `user-provisioned infrastructure` method or the `installer-provisioned infrastructure` method.
 ====
 
-The two-node OpenShift cluster with fencing requires the following hosts:
+The TNF fencing requires the following hosts:
 
 .Minimum required hosts
 [options="header"]
@@ -36,12 +34,9 @@ The two-node OpenShift cluster with fencing requires the following hosts:
 
 |===
 
-The bootstrap and control plane machines must use Red Hat Enterprise Linux CoreOS (RHCOS) as the operating system. For instructions on installing RHCOS and starting the bootstrap process, see xref:../../../installing/installing_bare_metal/upi/installing-bare-metal#creating-machines-bare-metal_installing-bare-metal[Installing RHCOS and starting the {product-title} bootstrap process]
-
-[NOTE]
-====
-The requirement to use RHCOS applies only to user-provisioned infrastructure deployments. For installer-provisioned infrastructure deployments, the bootstrap and control plane machines are provisioned automatically by the installation program, and you do not need to manually install RHCOS.
-====
+[role="_additional-resources"]
+.Additional resources
+* xref:../../../installing/installing_bare_metal/upi/installing-bare-metal#creating-machines-bare-metal_installing-bare-metal[Installing RHCOS and starting the {product-title} bootstrap process]
 
 include::modules/installation-two-node-cluster-min-resource-reqs.adoc[leveloffset=+1]
 
@@ -53,17 +48,11 @@ include::modules/installation-dns-user-infra-example.adoc[leveloffset=+2]
 // Two-node-dns-requirements - installer-provisioned infrastructure
 include::modules/installation-dns-installer-infra.adoc[leveloffset=+1]
 
-// Cofiguration for Ingress LB to get it to work with Pacemaker
-include::modules/installation-two-node-ingress-lb-configuration.adoc[leveloffset=+1]
-
 //  Creating a manifest object that includes a customized br-ex bridge
 include::modules/installation-two-node-creating-manifest-custom-br-ex.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
-== Additional resources
-
+.Additional resources
 * xref:../../../installing/installing_bare_metal/ipi/ipi-install-installation-workflow.adoc#creating-manifest-file-customized-br-ex-bridge_ipi-install-installation-workflow[Creating a manifest file for a customized br-ex bridge]
 
-* link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/configuring_and_managing_high_availability_clusters/index[Configuring and managing high availability clusters in RHEL].
-
-
+* link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/configuring_and_managing_high_availability_clusters/index[Configuring and managing high availability clusters in RHEL]

--- a/installing/installing_two_node_cluster/installing_tnf/installing-two-node-fencing.adoc
+++ b/installing/installing_two_node_cluster/installing_tnf/installing-two-node-fencing.adoc
@@ -6,21 +6,19 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-:FeatureName: Two-node OpenShift cluster with fencing
-include::snippets/technology-preview.adoc[leveloffset=+1]
+[role="_abstract"]
+A two-node OpenShift cluster with fencing (TNF) provides high availability (HA) with a reduced hardware footprint. This configuration is designed for distributed or edge environments where deploying a full three-node control plane cluster is not practical.
 
-A two-node OpenShift cluster with fencing provides high availability (HA) with a reduced hardware footprint. This configuration is designed for distributed or edge environments where deploying a full three-node control plane cluster is not practical.
+A two-node cluster does not include compute nodes. The two control plane machines run user workloads and manage the cluster.
 
-A two-node cluster does not include compute nodes. The two control plane machines run user workloads in addition to managing the cluster.
-
-Fencing is managed by Pacemaker, which can isolate an unresponsive node by using the Baseboard Management Console (BMC) of the node. After the unresponsive node is fenced, the remaining node can safely continue operating the cluster without the risk of resource corruption.
+Pacemaker uses the Baseboard Management Console (BMC) of the node to fence and isolate a failed node. This prevents resource corruption and allows the remaining node to continue operating.
 
 [NOTE]
 ====
-You can deploy a two-node OpenShift cluster with fencing by using either the user-provisioned infrastructure  method or the installer-provisioned infrastructure method.
+You can deploy a two-node OpenShift cluster with fencing by using either the `user-provisioned infrastructure` method or the `installer-provisioned infrastructure` method.
 ====
 
-The two-node OpenShift cluster with fencing requires the following hosts:
+The TNF fencing requires the following hosts:
 
 .Minimum required hosts
 [options="header"]
@@ -36,12 +34,9 @@ The two-node OpenShift cluster with fencing requires the following hosts:
 
 |===
 
-The bootstrap and control plane machines must use Red Hat Enterprise Linux CoreOS (RHCOS) as the operating system. For instructions on installing RHCOS and starting the bootstrap process, see "Installing RHCOS and starting the {product-title} bootstrap process".
-
-[NOTE]
-====
-The requirement to use RHCOS applies only to user-provisioned infrastructure deployments. For installer-provisioned infrastructure deployments, the bootstrap and control plane machines are provisioned automatically by the installation program, and you do not need to manually install RHCOS.
-====
+[role="_additional-resources"]
+.Additional resources
+* xref:../../../installing/installing_bare_metal/upi/installing-bare-metal#creating-machines-bare-metal_installing-bare-metal[Installing RHCOS and starting the {product-title} bootstrap process]
 
 include::modules/installation-two-node-cluster-min-resource-reqs.adoc[leveloffset=+1]
 
@@ -53,19 +48,11 @@ include::modules/installation-dns-user-infra-example.adoc[leveloffset=+2]
 // Two-node-dns-requirements - installer-provisioned infrastructure
 include::modules/installation-dns-installer-infra.adoc[leveloffset=+1]
 
-// Cofiguration for Ingress LB to get it to work with Pacemaker
-include::modules/installation-two-node-ingress-lb-configuration.adoc[leveloffset=+1]
-
 //  Creating a manifest object that includes a customized br-ex bridge
 include::modules/installation-two-node-creating-manifest-custom-br-ex.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
-== Additional resources
-
-* xref:../../../installing/installing_bare_metal/upi/installing-bare-metal#creating-machines-bare-metal_installing-bare-metal[Installing RHCOS and starting the {product-title} bootstrap process]
-
+.Additional resources
 * xref:../../../installing/installing_bare_metal/ipi/ipi-install-installation-workflow.adoc#creating-manifest-file-customized-br-ex-bridge_ipi-install-installation-workflow[Creating a manifest file for a customized br-ex bridge]
 
-* link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/configuring_and_managing_high_availability_clusters/index[Configuring and managing high availability clusters in RHEL].
-
-
+* link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/configuring_and_managing_high_availability_clusters/index[Configuring and managing high availability clusters in RHEL]

--- a/modules/installation-two-node-ingress-lb-configuration.adoc
+++ b/modules/installation-two-node-ingress-lb-configuration.adoc
@@ -2,7 +2,8 @@
 [id="two-node-ingress-lb-configuration_{context}"]
 = Configuring an Ingress load balancer for a two-node cluster with fencing
 
-You must configure an external Ingress load balancer (LB) before you install a two-node OpenShift cluster with fencing. The Ingress LB forwards external application traffic to the Ingress Controller pods that run on the control plane nodes. Both nodes can actively receive traffic.
+[role="_abstract"]
+The Ingress load balancer (LB) forwards external application traffic to the Ingress Controller pods that run on the control plane nodes. In a Two-Node with Fencing (TNF) clusters, both nodes can actively receive traffic.
 
 .Prerequisites
 
@@ -13,16 +14,14 @@ You must configure an external Ingress load balancer (LB) before you install a t
 
 .Procedure
 
-. Configure the load balancer to forward traffic for the following ports:
+. Configure your external load balancer to forward traffic for the following ports to both control plane nodes:
 +
 * `6443`: Kubernetes API server  
 * `80` and `443`: Application ingress
-+
-You must forward traffic to both control plane nodes.
 
-. Configure health checks on the load balancer. You must monitor the backend endpoints so that the load balancer only sends traffic to nodes that respond.
+. Configure health checks on the load balancer to monitor the backend endpoints. This ensures that the load balancer only sends traffic to responsive nodes.
 
-. Configure the load balancer to forward traffic to both control plane nodes. The following example shows how to configure two control plane nodes:  
+. Add the node configurations to your load balancer settings. The following example shows a configuration for two control plane nodes in an `HAProxy` format:  
 +
 [source,terminal]
 ----
@@ -67,5 +66,5 @@ $ curl -k https://api.<cluster_name>.<base_domain>:6443/version
 ----
 $ curl https://<app>.<cluster_name>.<base_domain>
 ----
-
-You can shut down a control plane node and verify that the load balancer stops sending traffic to that node while the other node continues to serve requests.
++
+.. Optional: Shut down one control plane node and repeat the commands to verify that the load balancer redirects traffic to the remaining active node.


### PR DESCRIPTION
Version(s):
4.22

Issue:
https://redhat.atlassian.net/browse/OSDOCS-18851

Link to docs preview:
https://110094--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_two_node_cluster/installing_tnf/installing-two-node-fencing.html

QE review:
- [ ] QE has approved this change.


Additional information:
Just need to remove the following sentence: 
You must configure an external Ingress load balancer (LB) before you install a two-node OpenShift cluster with fencing.

Additionally, implemented vale suggestions for better content.
