### PR TITLE
OSDOCS-19090:Microshift-Trust Manager operand for cert-manager

### DIFF
--- a/microshift_running_apps/microshift-cert-manager.adoc
+++ b/microshift_running_apps/microshift-cert-manager.adoc
@@ -13,4 +13,10 @@ include::modules/microshift-cert-manager-tasks.adoc[leveloffset=+1]
 
 include::modules/microshift-install-cert-manager.adoc[leveloffset=+1]
 
+include::modules/cert-manager-trust-manager-install.adoc[leveloffset=+1]
+
+include::modules/microshift-cert-manager-configure-trust-bundle.adoc[leveloffset=+1]
+
+include::modules/cert-manager-trust-manager-uninstall.adoc[leveloffset=+1]
+
 include::modules/microshift-install-cert-manager-olm.adoc[leveloffset=+1]

--- a/modules/microshift-cert-manager-configure-trust-bundle.adoc
+++ b/modules/microshift-cert-manager-configure-trust-bundle.adoc
@@ -1,0 +1,133 @@
+// Module included in the following assemblies:
+//
+//  microshift_running_apps/microshift-cert-manager.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="microshift-cert-manager-configure-trust-manager_{context}"]
+= Configuring trust bundle
+
+[role="_abstract"]
+After installing the trust-manager operand, you must use the Bundle custom resource (CR) to distribute certificate authority (CA) certificates on your node. A trust bundle combines certificate sources and maintains target `ConfigMap` and `Secret` objects across selected namespaces.
+
+:FeatureName: Distributing certificates by using trust manager
+include::snippets/technology-preview.adoc[leveloffset=+1]
+
+.Prerequisites
+
+* You have access to the node with `node-admin` privileges.
+
+* You have installed `trust-manager` operand.
+
+.Procedure
+
+. Define a namespace in a YAML file, for example, `namespace.yaml`, as shown in the following example:
++
+[source,yaml]
+----
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: trust-bundle-target
+  labels:
+    trust.cert-manager.io/inject: "true"
+----
+
+. Create the namespace by running the following command:
++
+[source, terminal]
+----
+$ oc create -f namespace.yaml
+----
+
+. Create a YAML file, for example, `bundle.yaml`, that defines the `Bundle` object as shown in the following example:
++
+[source, yaml]
+----
+apiVersion: trust.cert-manager.io/v1alpha1
+kind: Bundle
+metadata:
+  name: example-bundle
+spec:
+  sources:
+    - useDefaultCAs: true
+  target:
+    configMap:
+      key: ca-certificates.crt
+    secret:
+      key: ca-certificates.crt
+    namespaceSelector:
+      matchLabels:
+        trust.cert-manager.io/inject: "true"
+----
++
+For more information on bundle configurations, see link:https://cert-manager.io/docs/trust/trust-manager/#usage[trust-manager usage].
+
+. Create the `Bundle` custom resource by running the following command:
++
+[source, terminal]
+----
+$ oc create -f bundle.yaml
+----
+
+.Verification
+
+* Verify the status of Bundle CR by running the following command:
++
+[source,terminal]
+----
+$ oc get Bundle example-bundle -o jsonpath='{.status.conditions}' | jq
+----
++
+In the output, the `reason` must be set to `Synced` and `status` must be set to `True`, as shown in the following example:
++
+[source,terminal]
+----
+[
+  {
+    "lastTransitionTime": "2026-03-27T12:03:42Z",
+    "message": "Successfully synced Bundle to namespaces that match this label selector: trust.cert-manager.io/inject=true",
+    "observedGeneration": 1,
+    "reason": "Synced",
+    "status": "True",
+    "type": "Synced"
+  }
+]
+----
+
+* Verify the target Secret by running the following command:
++
+[source,terminal]
+----
+$ oc describe secret example-bundle -n trust-bundle-target
+----
++
+The following is an example of the output:
++
+[source,terminal]
+----
+Name:         example-bundle
+Namespace:    trust-bundle-target
+Labels:       trust.cert-manager.io/bundle=example-bundle
+Annotations:  trust.cert-manager.io/hash: 55c00f8109c4c6b1ee4710aa53ad280355973f25444d6bb13a93851af0d8f5d8
+
+Type:  Opaque
+
+Data
+
+ca-certificates.crt:  219257 bytes
+----
+
+* Verify the target ConfigMap by running the following command:
++
+[source,terminal]
+----
+$ oc get cm example-bundle -n trust-bundle-target
+----
++
+The following is an example of the output:
++
+[source,terminal]
+----
+NAME             DATA   AGE
+example-bundle   1      4m25s
+----


### PR DESCRIPTION
Version(s):
4.22

Issue:
https://redhat.atlassian.net/browse/OSDOCS-19090

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
