### PR TITLE
DOCPLAN-211: CQA fixes for installation docs

### DIFF
--- a/modules/virt-configuring-certificate-rotation.adoc
+++ b/modules/virt-configuring-certificate-rotation.adoc
@@ -22,7 +22,7 @@ You can do this during {VirtProductName} installation in the web console or afte
 $ oc edit {HCOCliKind} kubevirt-hyperconverged -n {CNVNamespace}
 ----
 
-. Edit the `spec.certConfig` fields as shown in the following example. To avoid overloading the system, ensure that all values are greater than or equal to 10 minutes. Express all values as strings that comply with the link:https://golang.org/pkg/time/#ParseDuration[golang `ParseDuration` format].
+. Edit the `spec.certConfig` fields as shown in the following example. To avoid overloading the system, ensure that all values are greater than or equal to 10 minutes. Express all values as strings that comply with the golang `ParseDuration` format.
 +
 [source,yaml,subs="attributes+"]
 ----

--- a/virt/install/installing-virt.adoc
+++ b/virt/install/installing-virt.adoc
@@ -6,14 +6,15 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 Install {VirtProductName} to add virtualization functionality to your {product-title} cluster.
 
 ifndef::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
 [IMPORTANT]
 ====
-If you install {VirtProductName} in a restricted environment with no internet connectivity, you must xref:../../disconnected/using-olm.adoc#olm-restricted-networks[configure Operator Lifecycle Manager for disconnected environments].
+If you install {VirtProductName} in a restricted environment with no internet connectivity, you must configure {olm-first} for a disconnected environment.
 
-If you have limited internet connectivity, you can xref:../../operators/admin/olm-configuring-proxy-support.adoc#olm-configuring-proxy-support[configure proxy support in OLM] to access the software catalog.
+If you have limited internet connectivity, you can configure proxy support in {olm} to access the software catalog.
 ====
 endif::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
 
@@ -24,20 +25,6 @@ Install the {VirtProductName} Operator by using the {product-title} web console 
 
 include::modules/virt-installing-virt-operator.adoc[leveloffset=+2]
 
-ifdef::openshift-rosa,openshift-rosa-hcp[]
-[role="_additional-resources"]
-.Additional resources
-
-* xref:../../rosa_cluster_admin/rosa_nodes/rosa-managing-worker-nodes.html#creating_a_machine_pool_rosa-managing-worker-nodes[Creating a machine pool]
-endif::openshift-rosa,openshift-rosa-hcp[]
-
-ifdef::openshift-dedicated[]
-[role="_additional-resources"]
-.Additional resources
-
-* xref:../../osd_cluster_admin/osd_nodes/osd-managing-worker-nodes.html#creating_machine_pools_ocm_osd-managing-worker-nodes[Creating a machine pool]
-endif::openshift-dedicated[]
-
 [id="installing-virt-operator-cli_installing-virt"]
 === Installing the {VirtProductName} Operator by using the command line
 
@@ -47,31 +34,34 @@ include::modules/virt-subscribing-cli.adoc[leveloffset=+3]
 
 [NOTE]
 ====
-You can xref:../../virt/post_installation_configuration/virt-configuring-certificate-rotation.adoc#virt-configuring-certificate-rotation[configure certificate rotation] parameters in the YAML file.
+You can configure certificate rotation parameters in the YAML file.
 ====
 
 include::modules/virt-deploying-operator-cli.adoc[leveloffset=+3]
-
-ifdef::openshift-rosa,openshift-rosa-hcp[]
-[role="_additional-resources"]
-.Additional resources
-
-* xref:../../rosa_cluster_admin/rosa_nodes/rosa-managing-worker-nodes.html#creating_a_machine_pool_rosa-managing-worker-nodes[Creating a machine pool]
-endif::openshift-rosa,openshift-rosa-hcp[]
-
-ifdef::openshift-dedicated[]
-[role="_additional-resources"]
-.Additional resources
-
-* xref:../../osd_cluster_admin/osd_nodes/osd-managing-worker-nodes.html#creating_machine_pools_ocm_osd-managing-worker-nodes[Creating a machine pool]
-endif::openshift-dedicated[]
 
 [id="installing-virt-web-next-steps"]
 == Next steps
 
 // Until cluster checkup framework is supported in ROSA/OSD this is just for OCP
 ifdef::openshift-enterprise[]
-* As a cluster administrator, you can run a xref:../../virt/post_installation_configuration/virt-self-validation-checkups.adoc#virt-self-validation-checkups[self validation checkup] to verify that the environment is fully functional and self-sustained before you deploy production workloads.
+* As a cluster administrator, you can run a self validation checkup to verify that the environment is fully functional and self-sustained before you deploy production workloads.
 endif::openshift-enterprise[]
 
-* The xref:../../virt/storage/virt-configuring-local-storage-with-hpp.adoc#virt-creating-hpp-basic-storage-pool_virt-configuring-local-storage-with-hpp[hostpath provisioner] is a local storage provisioner designed for {VirtProductName}. If you want to configure local storage for virtual machines, you must enable the hostpath provisioner first.
+* The hostpath provisioner is a local storage provisioner designed for {VirtProductName}. If you want to configure local storage for virtual machines, you must enable the hostpath provisioner first.
+
+[role="_additional-resources"]
+[id="additional-resources_{context}"]
+== Additional resources
+ifdef::openshift-enterprise[]
+* xref:../../disconnected/using-olm.adoc#olm-restricted-networks[Using Operator Lifecycle Manager in disconnected environments]
+* xref:../../operators/admin/olm-configuring-proxy-support.adoc#olm-configuring-proxy-support[Configuring proxy support in Operator Lifecycle Manager]
+* xref:../../virt/post_installation_configuration/virt-self-validation-checkups.adoc#virt-self-validation-checkups[Self validation checkup]
+endif::openshift-enterprise[]
+ifdef::openshift-rosa,openshift-rosa-hcp[]
+* xref:../../rosa_cluster_admin/rosa_nodes/rosa-managing-worker-nodes.adoc#creating_a_machine_pool_rosa-managing-worker-nodes[Creating a machine pool]
+endif::openshift-rosa,openshift-rosa-hcp[]
+ifdef::openshift-dedicated[]
+* xref:../../osd_cluster_admin/osd_nodes/osd-managing-worker-nodes.adoc#creating_machine_pools_ocm_osd-managing-worker-nodes[Creating a machine pool]
+endif::openshift-dedicated[]
+* xref:../../virt/post_installation_configuration/virt-configuring-certificate-rotation.adoc#virt-configuring-certificate-rotation[Configure certificate rotation]
+* xref:../../virt/storage/virt-configuring-local-storage-with-hpp.adoc#virt-creating-hpp-basic-storage-pool_virt-configuring-local-storage-with-hpp[Creating a hostpath provisioner with a basic storage pool]

--- a/virt/install/uninstalling-virt.adoc
+++ b/virt/install/uninstalling-virt.adoc
@@ -1,41 +1,38 @@
 :_mod-docs-content-type: ASSEMBLY
+include::_attributes/common-attributes.adoc[]
 [id="uninstalling-virt"]
 = Uninstalling {VirtProductName}
-include::_attributes/common-attributes.adoc[]
 :context: uninstalling-virt
 
 toc::[]
 
-You uninstall {VirtProductName} by using the web console or the command-line interface (CLI) to delete the {VirtProductName} workloads, the Operator, and its resources.
+[role="_abstract"]
+You can uninstall {VirtProductName} by using the web console or the command-line interface (CLI) to delete {VirtProductName} workloads, the Operator, and its resources.
 
-[id='uninstalling-virt-web-console_{context}']
-== Uninstalling {VirtProductName} by using the web console
+To uninstall {VirtProductName}, perform the following tasks:
 
-You uninstall {VirtProductName} by using the xref:../../web_console/web-console.adoc#web-console-overview_web-console[web console] to perform the following tasks:
+. Delete the `HyperConverged` CR.
+. Delete the {VirtProductName} Operator.
+. Delete the `openshift-cnv` namespace.
+. Delete the {VirtProductName} custom resource definitions (CRDs).
 
-. xref:../../virt/install/uninstalling-virt.adoc#virt-deleting-deployment-custom-resource_uninstalling-virt[Delete the `HyperConverged` CR].
-. xref:../../virt/install/uninstalling-virt.adoc#olm-deleting-operators-from-a-cluster-using-web-console_uninstalling-virt[Delete the {VirtProductName} Operator].
-. xref:../../virt/install/uninstalling-virt.adoc#deleting-a-namespace-using-the-web-console_uninstalling-virt[Delete the `openshift-cnv` namespace].
-. xref:../../virt/install/uninstalling-virt.adoc#virt-deleting-virt-crds-web_uninstalling-virt[Delete the {VirtProductName} custom resource definitions (CRDs)].
+[id="prerequisites_{context}"]
+== Prerequisites
 
-[IMPORTANT]
-====
-You must first delete all xref:../../virt/managing_vms/virt-delete-vms.adoc#virt-delete-vm-web_virt-delete-vms[virtual machines], and xref:../../virt/managing_vms/virt-manage-vmis.adoc#virt-deleting-vmis-cli_virt-manage-vmis[virtual machine instances].
+* Delete all virtual machine instances. You cannot uninstall {VirtProductName} while its workloads remain on the cluster.
 
-You cannot uninstall {VirtProductName} while its workloads remain on the cluster.
-====
-
-include::modules/virt-deleting-deployment-custom-resource.adoc[leveloffset=+2]
-
-include::modules/olm-deleting-operators-from-a-cluster-using-web-console.adoc[leveloffset=+2]
-
-include::modules/deleting-a-namespace-using-the-web-console.adoc[leveloffset=+2]
-
-include::modules/virt-deleting-virt-crds-web.adoc[leveloffset=+2]
-
+include::modules/virt-deleting-deployment-custom-resource.adoc[leveloffset=+1]
+include::modules/olm-deleting-operators-from-a-cluster-using-web-console.adoc[leveloffset=+1]
+include::modules/deleting-a-namespace-using-the-web-console.adoc[leveloffset=+1]
+include::modules/virt-deleting-virt-crds-web.adoc[leveloffset=+1]
 include::modules/virt-deleting-virt-cli.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
-.Additional resources
-* xref:../../virt/managing_vms/virt-delete-vms.adoc#virt-delete-vm-web_virt-delete-vms[Deleting virtual machines]
-* xref:../../virt/managing_vms/virt-manage-vmis.adoc#virt-deleting-vmis-cli_virt-manage-vmis[Deleting virtual machine instances]
+[id="additional-resources_{context}"]
+== Additional resources
+* xref:../../virt/install/uninstalling-virt.adoc#virt-deleting-deployment-custom-resource_uninstalling-virt[Deleting the `HyperConverged` custom resource]
+* xref:../../virt/install/uninstalling-virt.adoc#olm-deleting-operators-from-a-cluster-using-web-console_uninstalling-virt[Deleting Operators from a cluster using the web console]
+* xref:../../virt/install/uninstalling-virt.adoc#deleting-a-namespace-using-the-web-console_uninstalling-virt[Deleting a namespace using the web console]
+* xref:../../virt/install/uninstalling-virt.adoc#virt-deleting-virt-crds-web_uninstalling-virt[Deleting {VirtProductName} custom resource definitions]
+* xref:../../virt/managing_vms/virt-delete-vms.adoc#virt-delete-vm-web_virt-delete-vms[Deleting a virtual machine using the web console]
+* xref:../../virt/managing_vms/virt-manage-vmis.adoc#virt-deleting-vmis-cli_virt-manage-vmis[Deleting a standalone virtual machine instance using the CLI]

--- a/virt/post_installation_configuration/virt-configuring-certificate-rotation.adoc
+++ b/virt/post_installation_configuration/virt-configuring-certificate-rotation.adoc
@@ -11,3 +11,8 @@ toc::[]
 
 include::modules/virt-configuring-certificate-rotation.adoc[leveloffset=+1]
 include::modules/virt-troubleshooting-cert-rotation-parameters.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+[id="additional-resources_{context}"]
+== Additional resources
+* link:https://golang.org/pkg/time/#ParseDuration[golang `ParseDuration` format]


### PR DESCRIPTION
Version(s):
4.20+

Issue:
https://redhat.atlassian.net/browse/DOCPLAN-211

Link to docs preview:
- https://110103--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/post_installation_configuration/virt-configuring-certificate-rotation.html
- https://110103--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/install/installing-virt
- https://110103--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/install/uninstalling-virt

QE review:
N/A

Additional information:
- moving xrefs to additional resources section
- adding abstract tags