### PR TITLE
OSDOCS#19115: Add certificate-request-minimum-backoff-duration arg

### DIFF
--- a/modules/cert-manager-explanation-of-certmanager-cr-fields.adoc
+++ b/modules/cert-manager-explanation-of-certmanager-cr-fields.adoc
@@ -114,6 +114,10 @@ DNS over HTTPS (DoH) is supported starting only from {cert-manager-operator} ver
 |Controller
 |Defines the minimum memory request for ACME HTTP‑01 solver pods. The default value is `64Mi`.
 
+|`--certificate-request-minimum-backoff-duration`
+|Controller
+|Specify the minimum backoff duration for certificate requests. The default value is `1h0m0s`.
+
 |`--v=<verbosity_level>`
 |Controller, Webhook, CA injector
 |Specify the log level verbosity to determine the verbosity of log messages.

--- a/modules/cert-manager-override-arguments.adoc
+++ b/modules/cert-manager-override-arguments.adoc
@@ -45,6 +45,7 @@ spec:
       - '--acme-http01-solver-resource-limits-memory=<quantity>'
       - '--acme-http01-solver-resource-request-cpu=<quantity>'
       - '--acme-http01-solver-resource-request-memory=<quantity>'
+      - '--certificate-request-minimum-backoff-duration=<duration>'
   webhookConfig:
     overrideArgs:
       - '--v=<verbosity_level>'


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.18+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://redhat.atlassian.net/browse/OSDOCS-19115
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:

- https://110125--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/cert_manager_operator/cert-manager-customizing-api-fields.html#cert-manager-overridable-arguments_cert-manager-customizing-api-fields
- https://110125--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/cert_manager_operator/cert-manager-customizing-api-fields.html#cert-manager-override-arguments_cert-manager-customizing-api-fields

<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
