### PR TITLE
OCPBUGS-76497: Added note to nw-ingress-gateway-api-manage-succession…

### DIFF
--- a/modules/nw-ingress-gateway-api-manage-succession.adoc
+++ b/modules/nw-ingress-gateway-api-manage-succession.adoc
@@ -6,17 +6,35 @@
 [id="nw-ingress-gateway-api-manage-succession_{context}"]
 = Preparing for Gateway API management succession by the Ingress Operator
 
-Starting in {product-title} 4.19, the Ingress Operator manages the lifecycle of any Gateway API custom resource definitions (CRDs). This means that you will be denied access to creating, updating, and deleting any CRDs within the API groups that are grouped under Gateway API.
+[role="_abstract"]
+To ensure your Gateway API custom resource definitions (CRDs) conform to required {product-title} specifications, allow the Ingress Operator to manage their lifecycle. Preparing your older {product-title} environment for this automated management helps prevent resource conflicts and deployment errors.
 
-Updating from a version before 4.19 of {product-title} where this management was not present requires you to replace or remove any Gateway API CRDs that already exist in the cluster so that they conform to the specific {product-title} specification required by the Ingress Operator. {product-title} version 4.19 requires Gateway API Standard version 1.2.1 CRDs.
+Starting in {product-title} 4.19, the Ingress Operator manages the lifecycle of any Gateway API custom resource definitions (CRDs). This means you cannot create, update, or delete any CRDs within the API groups under the Gateway API.
+
+Updating from a version earlier than {product-title} 4.19 where the API CRD management was not present requires replacing or removing any Gateway API CRDs. 
 
 [WARNING]
 ====
-Updating or deleting Gateway API resources can result in downtime and loss of service or data. Be sure you understand how this will affect your cluster before performing the steps in this procedure. If necessary, back up any Gateway API objects in YAML format in order to restore it later.
+Updating or deleting Gateway API resources can result in downtime and loss of service or data. Be sure you understand how this impacts your cluster before performing the steps in this procedure. If necessary, back up any Gateway API objects in YAML format in order to restore it later.
+====
+
+The updated CRDs must conform to the specific {product-title} specification that is required by the Ingress Operator. {product-title} version 4.19 requires Gateway API Standard version 1.2.1 CRDs.
+
+[IMPORTANT]
+====
+When upgrading your {product-title} 4.18 cluster to {product-title} 4.19, you might see a `Gateway API CRDs have been detected` message. A cluster administrator must understand the implications before applying the `ack-4.18-gateway-api-management-in-4.19` acknowledgment. {product-title} 4.19 can then manage the Gateway API CRDs during the upgrade operation.
+
+You can run the following command to apply the `ack-4.18-gateway-api-management-in-4.19` acknowledgment:
+
+[source,terminal]
+----
+$ oc -n openshift-config patch configmap admin-acks --patch '{"data":{"ack-4.18-gateway-api-management-in-4.19":"true"}}' --type=merge
+----
 ====
 
 .Prerequisites
-* You have installed the OpenShift CLI (`oc`).
+
+* You have installed the {oc-first}.
 * You have access to an {product-title} account with cluster administrator access.
 * Optional: You have backed up any necessary Gateway API objects.
 +
@@ -35,7 +53,6 @@ $ oc get crd | grep -F -e gateway.networking.k8s.io -e gateway.networking.x-k8s.
 ----
 +
 .Example output
-+
 [source,terminal]
 ----
 gatewayclasses.gateway.networking.k8s.io
@@ -45,15 +62,31 @@ httproutes.gateway.networking.k8s.io
 referencegrants.gateway.networking.k8s.io
 ----
 
-. Delete the Gateway API CRDs from the previous step by running the following command:
+. Delete the Gateway API CRDs from the previous step by running the following commands:
 +
 [source,terminal]
 ----
-$ oc delete crd gatewayclasses.networking.k8s.io && \
-oc delete crd gateways.networking.k8s.io && \
-oc delete crd grpcroutes.gateway.networking.k8s.io && \
-oc delete crd httproutes.gateway.networking.k8s.io && \
-oc delete crd referencesgrants.gateway.networking.k8s.io
+$ oc delete crd gatewayclasses.networking.k8s.io
+----
++
+[source,terminal]
+----
+$ oc delete crd gateways.networking.k8s.io
+----
++
+[source,terminal]
+----
+$ oc delete crd grpcroutes.gateway.networking.k8s.io
+----
++
+[source,terminal]
+----
+$ oc delete crd httproutes.gateway.networking.k8s.io
+----
++
+[source,terminal]
+----
+$ oc delete crd referencesgrants.gateway.networking.k8s.io
 ----
 +
 [IMPORTANT]
@@ -74,5 +107,3 @@ You can perform this step without deleting your CRDs. If your update to a CRD re
 
 For more information on the {product-title} implementation and the dead fields issue, see _Gateway API implementation for {product-title}_.
 ====
-
-


### PR DESCRIPTION
Version(s):
4.19 only because of upgrade path

Issue:
[OCPBUGS-76497](https://redhat.atlassian.net/browse/OCPBUGS-76497)

Link to docs preview:
* [Preparing for Gateway API management succession by the Ingress Operator](https://110130--ocpdocs-pr.netlify.app/openshift-enterprise/latest/updating/preparing_for_updates/updating-cluster-prepare.html#nw-ingress-gateway-api-manage-succession_updating-cluster-prepare)

- [x] SME has approved this change (Miciah Masters).
- [x] QE has approved this change (Ishmam Amin).

[Slack thread](https://redhat-internal.slack.com/archives/D056UKF7J93/p1776162578084639)
