### PR TITLE
OSDOCS-19024:Virt GNV updates.

### DIFF
--- a/modules/osd-release-notes-Q2-2026.adoc
+++ b/modules/osd-release-notes-Q2-2026.adoc
@@ -8,6 +8,15 @@
 [role="_abstract"]
 The following items were added during the second quarter of 2026.
 
+* **{GCP} NetApp Volumes (GCNV) for {VirtProductName} on {GCP}.** {VirtProductName} on {product-title} on {GCP} 4.21 and later now supports link:https://cloud.google.com/netapp/volumes/docs[Google Cloud NetApp Volumes] (GCNV) as a certified NFS storage backend when you use the NetApp Trident CSI Operator version 26.02.0 or later together with {VirtProductName} 4.21.2 or later.
++
+GCNV provides NFS-based shared storage that supports ReadWriteMany (RWX) access in `Filesystem` mode. The NetApp Trident CSI driver provisions GCNV storage volumes.
++
+For more information about using GCNV with {VirtProductName} on {GCP}, see the following articles in the Red{nbsp}Hat Knowledgebase:
++
+** link:https://access.redhat.com/articles/7141472[{GCP} with {GCP} NetApp Volumes - Configuration]
+** link:https://access.redhat.com/articles/7141471[{GCP} with {GCP} NetApp Volumes - Known errors and limits]
+
 * **Support for excluding namespaces from default ingress load controller using label selectors.** You can now use the `ocm` CLI to configure default ingress namespace exclusions for your cluster. For more information, see link:https://docs.redhat.com/en/documentation/openshift_dedicated/4/html/networking_operators/configuring-ingress#osd-ingress-excluded-namespaces-ocm-cli_configuring-ingress[Configure excluded namespaces for the default ingress controller].
 
 * **Support for new {gcp-short} instances.** You can now create clusters with `g2` and `g4` instance types on {product-title} version 4.21 and later. For more information, see link:https://docs.redhat.com/en/documentation/openshift_dedicated/4/html/introduction_to_openshift_dedicated/policies-and-service-definition#gcp-compute-types_osd-service-definition[{gcp-full} instance types].

--- a/modules/virt-about-storage-volumes-for-vm-disks.adoc
+++ b/modules/virt-about-storage-volumes-for-vm-disks.adoc
@@ -14,20 +14,11 @@ ifndef::openshift-dedicated[]
 For a list of known storage providers for {VirtProductName}, see the link:https://catalog.redhat.com/search?searchType=software&badges_and_features=OpenShift+Virtualization&subcategories=Storage[ Red Hat Ecosystem Catalog].
 endif::openshift-dedicated[]
 
-ifdef::openshift-dedicated[]
-For best results, use the `Block` volume mode. This is important for the following reasons:
-
-* Shared storage that supports live migration is required to migrate virtual machines between nodes.
-
-* The `Block` volume mode performs significantly better than the `Filesystem` volume mode. This is because the `Filesystem` volume mode uses more storage layers, including a file system layer and a disk image file. These layers are not necessary for VM disk storage.
-endif::openshift-dedicated[]
-ifndef::openshift-dedicated[]
 For best results, use the `ReadWriteMany` (RWX) access mode and the `Block` volume mode. This is important for the following reasons:
 
 * `ReadWriteMany` (RWX) access mode is required for live migration.
-
 * The `Block` volume mode performs significantly better than the `Filesystem` volume mode. This is because the `Filesystem` volume mode uses more storage layers, including a file system layer and a disk image file. These layers are not necessary for VM disk storage.
-endif::openshift-dedicated[]
+
 ifndef::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
 +
 For example, if you use {rh-storage-first}, Ceph RBD volumes are preferable to CephFS volumes.

--- a/modules/virt-aws-bm.adoc
+++ b/modules/virt-aws-bm.adoc
@@ -65,7 +65,7 @@ ifndef::openshift-dedicated[]
 AWS
 endif::openshift-dedicated[]
 ifdef::openshift-dedicated[]
-Google Cloud
+{gcp-short}
 endif::openshift-dedicated[]
 and manages its lifecycle. A security group is also created for the load balancer, and you can use annotations to attach existing security groups. When you remove the service, {product-title} removes the load balancer and its associated resources.
 ====
@@ -86,13 +86,14 @@ ifndef::openshift-dedicated[]
 * You can use any storage solution that is certified by the storage vendor to work with the underlying platform.
 endif::openshift-dedicated[]
 ifdef::openshift-dedicated[]
-* You can use {gcp-short} Hyperdisk storage with {VirtProductName} on {product-title} on {gcp-short}. {gcp-short} Hyperdisk storage provides high performance and flexibility for VM workloads. For more information about using Hyperdisk storage, see link:https://access.redhat.com/articles/7139046[Storage configuration for OpenShift Virtualization 4.21.x on Google Cloud].
 * In {product-title} on {gcp-short}, you must ensure your StorageClass uses the GCP PD CSI driver or {gcp-short} Filestore CSI driver.
-+
-[NOTE]
-====
-For more information about configuring {VirtProductName} on {product-title} on {gcp-short}, see link:https://access.redhat.com/articles/7139682[OpenShift Virtualization on Google Cloud: Known Issues and Limitations].
-====
+* You can use {gcp-short} Hyperdisk storage with {VirtProductName} on {product-title} on {gcp-short}. {gcp-short} Hyperdisk storage provides high performance and flexibility for VM workloads. For more information about using Hyperdisk storage, see "Storage configuration for OpenShift Virtualization 4.21.x on Google Cloud" in the _Additional resources_ section.
+* You can use {gcp-short} NetApp Volumes (GCNV) with {VirtProductName} on {product-title} on {gcp-short}. GCNV provides NFS-based shared storage that supports `ReadWriteMany` access in `Filesystem` mode, which is required for features such as virtual machine live migration.
+** Running {VirtProductName} with GCNV storage requires {product-title} 4.21 and {VirtProductName} 4.21.2, and Trident 26.02.0 or later versions.
+** Only the *Flex File* service level is supported in this release. When creating storage pools, select the *File* storage type. *Flex Unified* is not supported.
+** Flex File volumes are NFS-only and support `volumeMode: Filesystem` exclusively. `volumeMode: Block` is not available with Flex File.
+** GCNV Flex pools are limited to 50 volumes per pool. To support larger deployments, create multiple storage pools and list them all in the `TridentBackendConfig` file. For more information, see "GCNV storage pool limits" in the _Additional resources_ section.
+** Flex File pools can be *Zonal* or *Regional*. Regional pools replicate volumes across zones but only support default performance, not custom. For more information on service levels and performance, see "GCNV service levels" in the _Additional resources_ section.
 endif::openshift-dedicated[]
 +
 ifdef::openshift-rosa,openshift-rosa-hcp[]

--- a/modules/virt-supported-cluster-version.adoc
+++ b/modules/virt-supported-cluster-version.adoc
@@ -9,13 +9,22 @@
 
 [role="_abstract"]
 ifdef::openshift-dedicated[]
-{VirtProductName} on {product-title} on {gcp-short} requires {product-title} 4.21.5 or later and {VirtProductName} Operator 4.21.1 or later.
+{VirtProductName} on {gcp-short} is supported on {product-title} using either {gcp-short} Hyperdisk or {gcp-short} NetApp Volumes (GCNV) for persistent storage.
+
+Refer to the following table for the minimum version you need to install based on your chosen storage solution.
+
+|===
+|Component |Version required with {gcp-short} Hyperdisk |Version required with {gcp-short} NetApp Volumes (GCNV)
+
+|{product-title}  |4.21.5 or later |4.21 or later
+|{VirtProductName} Operator |4.21.1 or later |4.21.2 or later
+|NetApp Trident CSI Operator |N/A |26.02.0 or later
+|===
 endif::openshift-dedicated[]
 ifndef::openshift-dedicated[]
 {VirtProductName} {VirtVersion} is supported for use on {product-title} {product-version} clusters. To use the latest z-stream release of {VirtProductName}, you must first upgrade to the latest version of {product-title}.
-endif::openshift-dedicated[]
 The latest stable release of {VirtProductName} {VirtVersion} is {HCOVersion}.
-
+endif::openshift-dedicated[]
 
 ifdef::openshift-rosa,openshift-rosa-hcp[]
 [NOTE]

--- a/virt/about_virt/about-virt.adoc
+++ b/virt/about_virt/about-virt.adoc
@@ -30,7 +30,9 @@ ifdef::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
 You can check your {VirtProductName} cluster for compliance issues by installing the Compliance Operator and running a scan with the `ocp4-moderate` and `ocp4-moderate-node` profiles. The Compliance Operator uses OpenSCAP, a link:https://www.nist.gov/[NIST-certified tool], to scan and enforce security policies.
 endif::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
 
+ifndef::openshift-dedicated[]
 For information about partnering with Independent Software Vendors (ISVs) and Services partners for specialized storage, networking, backup, and additional functionality, see link:https://red.ht/workswithvirt[the Red Hat Ecosystem Catalog].
+endif::openshift-dedicated[]
 
 include::modules/virt-vmware-comparison.adoc[leveloffset=+1]
 

--- a/virt/install/preparing-cluster-for-virt.adoc
+++ b/virt/install/preparing-cluster-for-virt.adoc
@@ -111,14 +111,6 @@ endif::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
 
 include::modules/virt-aws-bm.adoc[leveloffset=+2]
 
-
-[role="_additional-resources"]
-.Additional resources
-ifndef::openshift-dedicated[]
-* xref:../../virt/vm_networking/virt-connecting-vm-to-ovn-secondary-network.adoc#virt-connecting-vm-to-ovn-secondary-network[Connecting a virtual machine to an OVN-Kubernetes secondary network]
-endif::openshift-dedicated[]
-* xref:../../virt/vm_networking/virt-exposing-vm-with-service.adoc#virt-exposing-vm-with-service[Exposing a virtual machine by using a service]
-
 //Hiding in OSD as not supported
 ifndef::openshift-dedicated[]
 [id="arm-compatibility_{context}"]
@@ -324,11 +316,6 @@ ifndef::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
 include::modules/virt-sno-differences.adoc[leveloffset=+1]
 endif::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
 
-[role="_additional-resources"]
-.Additional resources
-
-* xref:../../storage/index.adoc#openshift-storage-common-terms_storage-overview[Glossary of common terms for {product-title} storage]
-
 ifndef::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
 [id="object-maximums_preparing-cluster-for-virt"]
 == Object maximums
@@ -371,4 +358,19 @@ endif::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
 [role="_additional-resources"]
 [id="additional-resources_preparing-cluster-for-virt"]
 == Additional resources
+
+ifndef::openshift-dedicated[]
+* xref:../../virt/vm_networking/virt-connecting-vm-to-ovn-secondary-network.adoc#virt-connecting-vm-to-ovn-secondary-network[Connecting a virtual machine to an OVN-Kubernetes secondary network]
+endif::openshift-dedicated[]
+* xref:../../virt/vm_networking/virt-exposing-vm-with-service.adoc#virt-exposing-vm-with-service[Exposing a virtual machine by using a service]
 * xref:../../virt/nodes/virt-eviction-strategies.adoc#virt-runstrategies-vms_virt-eviction-strategies[Run strategies]
+ifdef::openshift-dedicated[]
+* link:https://cloud.google.com/netapp/volumes/docs[Google Cloud NetApp Volumes]
+* link:https://docs.cloud.google.com/netapp/volumes/docs/quotas#storage_pool_limits[GCNV storage pool limits]
+* link:https://access.redhat.com/articles/7139046[Storage configuration for OpenShift Virtualization 4.21.x on Google Cloud]
+* link:https://access.redhat.com/articles/7139682[OpenShift Virtualization on Google Cloud: Known Issues and Limitations]
+* link:https://access.redhat.com/articles/7141472[{GCP} with {GCP} NetApp Volumes - Configuration]
+* link:https://access.redhat.com/articles/7141471[{GCP} with {GCP} NetApp Volumes - Known errors and limits]
+endif::openshift-dedicated[]
+* link:https://docs.cloud.google.com/netapp/volumes/docs/discover/service-levels[GCNV service levels]
+* xref:../../storage/index.adoc#openshift-storage-common-terms_storage-overview[Glossary of common terms for {product-title} storage]

--- a/virt/storage/virt-storage-config-overview.adoc
+++ b/virt/storage/virt-storage-config-overview.adoc
@@ -9,7 +9,7 @@ toc::[]
 [role="_abstract"]
 You can configure a default storage class, storage profiles, Containerized Data Importer (CDI), data volumes (DVs), and automatic boot source updates.
 ifdef::openshift-dedicated[]
-On {product-title}, specific configurations for Hyperdisk are required to ensure performance and support features like live migration. For more information, see "Storage configuration for OpenShift Virtualization 4.21.x on Google Cloud" in the _Additional resources_ section.
+On {product-title}, specific configurations for Hyperdisk and {gcp-short} NetApp Volumes (GCNV) are required to ensure performance and support features like live migration. For more information, see "Storage configuration for OpenShift Virtualization 4.21.x on Google Cloud" and "{GCP} with {GCP} NetApp Volumes - Configuration" in the _Additional resources_ section.
 endif::openshift-dedicated[]
 
 [id="storage-configuration-tasks"]
@@ -78,4 +78,7 @@ ifdef::openshift-dedicated[]
 [role="_additional-resources"]
 == Additional resources
 * link:https://access.redhat.com/articles/7139046[Storage configuration for OpenShift Virtualization 4.21.x on Google Cloud]
+* link:https://access.redhat.com/articles/7139682[OpenShift Virtualization on Google Cloud: Known Issues and Limitations]
+* link:https://access.redhat.com/articles/7141472[{GCP} with {GCP} NetApp Volumes - Configuration]
+* link:https://access.redhat.com/articles/7141471[{GCP} with {GCP} NetApp Volumes - Known errors and limits]
 endif::openshift-dedicated[]


### PR DESCRIPTION
Version(s):
4.21+

Issue:
[OSDOCS-19024](https://redhat.atlassian.net/browse/OSDOCS-19024)

Link to docs preview:

- [What's new](https://110137--ocpdocs-pr.netlify.app/openshift-dedicated/latest/osd_whats_new/osd-whats-new.html)
- [Supported cluster versions for OpenShift Virtualization](https://110137--ocpdocs-pr.netlify.app/openshift-dedicated/latest/virt/about_virt/about-virt.html#virt-supported-cluster-version_about-virt)
- [Preparing your cluster for OpenShift Virtualization](https://110137--ocpdocs-pr.netlify.app/openshift-dedicated/latest/virt/install/preparing-cluster-for-virt.html)

Peer review:
- [x] Peer reviewer has approved this change.

SME review:
- [x] SME has approved this change. (Content approved in #110285 ).

QE review:
- QE approval is not required to merge this PR as no procedural updates.

**Note to peer reviewer:**
The kb articles are commented out until they go live.
