### PR TITLE
OCPBUGS-81191 2 Port Ordinary clock is GA since 4.19

### DIFF
--- a/modules/ptp-dual-ports-oc.adoc
+++ b/modules/ptp-dual-ports-oc.adoc
@@ -9,9 +9,6 @@
 [role="_abstract"]
 {product-title} supports single-port networking interface cards (NICs) as ordinary clocks for PTP timing. To improve redundancy, you can configure a dual-port NIC with one port as active and the other as standby.
 
-:FeatureName: Configuring linuxptp services as an ordinary clock with dual-port NIC redundancy
-include::snippets/technology-preview.adoc[leveloffset=+1]
-
 In this configuration, the ports in a dual-port NIC operate as follows:
 
 * The active port functions as an ordinary clock in the `Following` port state.


### PR DESCRIPTION
[OCPBUGS-81191]: 2 Port Ordinary clock is GA since 4.19

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.19+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://redhat.atlassian.net/browse/OCPBUGS-81191
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:https://110138--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/advanced_networking/ptp/about-ptp.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
