### PR TITLE
OCPBUGS-81191 2 Port Ordinary clock is GA 4.19 RN removal

### DIFF
--- a/release_notes/ocp-4-19-release-notes.adoc
+++ b/release_notes/ocp-4-19-release-notes.adoc
@@ -906,9 +906,9 @@ With this release, you can now allocate load balancers to customize deployments 
 For more information, see xref:../installing/installing_aws/installation-config-parameters-aws.adoc#installation-configuration-parameters-network_installation-config-parameters-aws[Installation configuration parameters on AWS] and xref:../installing/installing_aws/ipi/installing-aws-vpc.adoc#allocating-load-balancers_installing-aws-vpc[Allocating load balancers to specific subnets].
 
 [id="ocp-4-19-networking-ptp-dual-oc_{context}"]
-==== Dual-port NICs for improved redundancy in PTP ordinary clocks (Technology Preview)
+==== Dual-port NICs for improved redundancy in PTP ordinary clocks
 With this release, you can use a dual-port network interface controller (NIC) to improve redundancy for Precision Time Protocol (PTP) ordinary clocks.
-Available as a Technology Preview, in a dual-port NIC configuration for an ordinary clock, if one port fails, the standby port takes over, maintaining PTP timing synchronization.
+In a dual-port NIC configuration for an ordinary clock, if one port fails, the standby port takes over, maintaining PTP timing synchronization.
 
 [NOTE]
 ====
@@ -2619,7 +2619,7 @@ In the following tables, features are marked with the following statuses:
 |Dual-port NIC for PTP ordinary clock
 |Not Available
 |Not Available
-|Technology Preview
+|General Availability
 
 |DPU Operator
 |Not Available


### PR DESCRIPTION
[OCPBUGS-81191]: 2 Port Ordinary clock is GA since 4.19

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.19 RN
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://redhat.atlassian.net/browse/OCPBUGS-81191
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->