### PR TITLE
[enterprise-4.22] TELCODOCS-2723: fix(telco-core-rds): DITA compatibility fixes for all modules

### DIFF
--- a/modules/telco-core-about-the-telco-core-cluster-use-model.adoc
+++ b/modules/telco-core-about-the-telco-core-cluster-use-model.adoc
@@ -6,6 +6,7 @@
 [id="telco-core-about-the-telco-core-cluster-use-model_{context}"]
 = About the telco core cluster use model
 
+[role="_abstract"]
 The telco core cluster use model is designed for clusters running on commodity hardware.
 Telco core clusters support large scale telco applications including control plane functions like signaling, aggregation, session border controller (SBC), and centralized data plane functions such as 5G user plane functions (UPF).
 Telco core cluster functions require scalability, complex networking support, resilient software-defined storage, and support performance requirements that are less stringent and constrained than far-edge RAN deployments.

--- a/modules/telco-core-additional-storage-solutions.adoc
+++ b/modules/telco-core-additional-storage-solutions.adoc
@@ -5,6 +5,8 @@
 :_mod-docs-content-type: REFERENCE
 [id="telco-core-additional-storage-solutions_{context}"]
 = Additional storage solutions
+
+[role="_abstract"]
 You can use other storage solutions to provide persistent storage for telco core clusters.
 The configuration and integration of these solutions is outside the scope of the reference design specifications (RDS).
 

--- a/modules/telco-core-agent-based-installer.adoc
+++ b/modules/telco-core-agent-based-installer.adoc
@@ -7,6 +7,9 @@
 [id="telco-core-agent-based-installer_{context}"]
 = Agent-based Installer
 
+[role="_abstract"]
+The Agent-based Installer provides an installation method for {product-title} in environments without existing deployment infrastructure.
+
 New in this release::
 * No reference design updates in this release.
 

--- a/modules/telco-core-application-workloads.adoc
+++ b/modules/telco-core-application-workloads.adoc
@@ -6,6 +6,7 @@
 [id="telco-core-application-workloads_{context}"]
 = Application workloads
 
+[role="_abstract"]
 Application workloads running on telco core clusters can include a mix of high performance cloud-native network functions (CNFs) and traditional best-effort or burstable pod workloads.
 
 Guaranteed QoS scheduling is available to pods that require exclusive or dedicated use of CPUs due to performance or security requirements.

--- a/modules/telco-core-cert-manager-operator.adoc
+++ b/modules/telco-core-cert-manager-operator.adoc
@@ -6,6 +6,9 @@
 [id="telco-core-cert-manager-operator_{context}"]
 = cert-manager Operator
 
+[role="_abstract"]
+The cert-manager Operator for {product-title} manages the lifecycle of TLS certificates for cluster components and workloads.
+
 New in this release::
 * The cert-manager Operator is a new optional component in this release.
 

--- a/modules/telco-core-cluster-common-use-model-engineering-considerations.adoc
+++ b/modules/telco-core-cluster-common-use-model-engineering-considerations.adoc
@@ -6,6 +6,9 @@
 [id="telco-core-cluster-common-use-model-engineering-considerations_{context}"]
 = Telco core cluster common use model engineering considerations
 
+[role="_abstract"]
+The following engineering considerations apply to the telco core cluster common use model.
+
 * Cluster workloads are detailed in "Application workloads".
 * Worker nodes should run on either of the following CPUs:
 ** Intel 3rd Generation Xeon (IceLake) CPUs or better when supported by {product-title}, or CPUs with the silicon security bug (Spectre and similar) mitigations turned off.

--- a/modules/telco-core-cluster-network-operator.adoc
+++ b/modules/telco-core-cluster-network-operator.adoc
@@ -6,6 +6,9 @@
 [id="telco-core-cluster-network-operator_{context}"]
 = Cluster Network Operator
 
+[role="_abstract"]
+The Cluster Network Operator (CNO) deploys and manages the cluster network components including the default OVN-Kubernetes network plugin during cluster installation.
+
 New in this release::
 
 *  No reference design updates in this release

--- a/modules/telco-core-common-baseline-model.adoc
+++ b/modules/telco-core-common-baseline-model.adoc
@@ -6,6 +6,7 @@
 [id="telco-core-common-baseline-model_{context}"]
 = Telco core common baseline model
 
+[role="_abstract"]
 The following configurations and use models are applicable to all telco core use cases.
 The telco core use cases build on this common baseline of features.
 

--- a/modules/telco-core-cpu-partitioning-and-performance-tuning.adoc
+++ b/modules/telco-core-cpu-partitioning-and-performance-tuning.adoc
@@ -6,6 +6,9 @@
 [id="telco-core-cpu-partitioning-and-performance-tuning_{context}"]
 = CPU partitioning and performance tuning
 
+[role="_abstract"]
+CPU partitioning separates sensitive workloads from general-purpose tasks, interrupts, and driver work queues to improve performance and reduce latency.
+
 New in this release::
 * Optional support for the `acpi_idle` CPUIdle driver.
 * The `systemReserved` field replaces the `autoSizingReserved` field to specify 11Gi memory for worker nodes and 30Gi for control plane nodes.

--- a/modules/telco-core-crs-cluster-infrastructure.adoc
+++ b/modules/telco-core-crs-cluster-infrastructure.adoc
@@ -6,6 +6,9 @@
 [id="cluster-infrastructure-crs_{context}"]
 = Cluster infrastructure reference CRs
 
+[role="_abstract"]
+Use the following custom resources (CRs) to configure cluster infrastructure components for the telco core profile.
+
 .Cluster infrastructure CRs
 [cols="4*", options="header", format=csv]
 |====

--- a/modules/telco-core-crs-networking.adoc
+++ b/modules/telco-core-crs-networking.adoc
@@ -6,6 +6,9 @@
 [id="networking-crs_{context}"]
 = Networking reference CRs
 
+[role="_abstract"]
+Use the following custom resources (CRs) to configure networking components for the telco core profile.
+
 .Networking CRs
 [cols="4*", options="header", format=csv]
 |====

--- a/modules/telco-core-crs-node-configuration.adoc
+++ b/modules/telco-core-crs-node-configuration.adoc
@@ -6,6 +6,9 @@
 [id="node-configuration-crs_{context}"]
 = Node configuration reference CRs
 
+[role="_abstract"]
+Use the following custom resources (CRs) to configure node settings for the telco core profile.
+
 .Node configuration CRs
 [cols="4*", options="header", format=csv]
 |====

--- a/modules/telco-core-crs-resource-tuning.adoc
+++ b/modules/telco-core-crs-resource-tuning.adoc
@@ -6,6 +6,9 @@
 [id="resource-tuning-crs_{context}"]
 = Resource tuning reference CRs
 
+[role="_abstract"]
+Use the following custom resources (CRs) to configure resource tuning for the telco core profile.
+
 .Resource tuning CRs
 [cols="4*", options="header", format=csv]
 |====

--- a/modules/telco-core-crs-scheduling.adoc
+++ b/modules/telco-core-crs-scheduling.adoc
@@ -6,6 +6,9 @@
 [id="scheduling-crs_{context}"]
 = Scheduling reference CRs
 
+[role="_abstract"]
+Use the following custom resources (CRs) to configure scheduling for the telco core profile.
+
 .Scheduling CRs
 [cols="4*", options="header", format=csv]
 |====

--- a/modules/telco-core-crs-security.adoc
+++ b/modules/telco-core-crs-security.adoc
@@ -6,6 +6,9 @@
 [id="security-crs_{context}"]
 = Security reference CRs
 
+[role="_abstract"]
+Use the following custom resources (CRs) to configure security components for the telco core profile.
+
 .Security CRs
 [cols="4*", options="header", format=csv]
 |====

--- a/modules/telco-core-crs-storage.adoc
+++ b/modules/telco-core-crs-storage.adoc
@@ -6,6 +6,9 @@
 [id="storage-crs_{context}"]
 = Storage reference CRs
 
+[role="_abstract"]
+Use the following custom resources (CRs) to configure storage for the telco core profile.
+
 .Storage CRs
 [cols="4*", options="header", format=csv]
 |====

--- a/modules/telco-core-deployment-components.adoc
+++ b/modules/telco-core-deployment-components.adoc
@@ -1,0 +1,10 @@
+// Module included in the following assemblies:
+//
+// * scalability_and_performance/telco-core-rds.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="telco-reference-core-deployment-components_{context}"]
+= Telco core deployment components
+
+[role="_abstract"]
+The following sections describe the various {product-title} components and configurations that you use to configure the hub cluster with {rh-rhacm-first}.

--- a/modules/telco-core-deployment-planning.adoc
+++ b/modules/telco-core-deployment-planning.adoc
@@ -6,4 +6,5 @@
 [id="telco-core-deployment-planning_{context}"]
 = Deployment planning
 
+[role="_abstract"]
 Proper deployment planning is essential for telco core clusters to ensure high availability, minimize service disruption during upgrades, and optimize cluster performance.

--- a/modules/telco-core-disconnected-environment.adoc
+++ b/modules/telco-core-disconnected-environment.adoc
@@ -6,6 +6,9 @@
 [id="telco-core-disconnected-environment_{context}"]
 = Disconnected environment
 
+[role="_abstract"]
+Telco core clusters are expected to be installed in networks without direct access to the internet.
+
 New in this release::
 * No reference design updates in this release.
 

--- a/modules/telco-core-gitops-operator-and-ztp-plugins.adoc
+++ b/modules/telco-core-gitops-operator-and-ztp-plugins.adoc
@@ -6,6 +6,9 @@
 [id="telco-core-gitops-operator-and-ztp-plugins_{context}"]
 = GitOps Operator and {ztp} plugins
 
+[role="_abstract"]
+The GitOps Operator provides a GitOps-driven infrastructure for managing cluster deployment and configuration.
+
 New in this release::
 * No reference design updates in this release.
 

--- a/modules/telco-core-host-firmware-and-boot-loader-configuration.adoc
+++ b/modules/telco-core-host-firmware-and-boot-loader-configuration.adoc
@@ -6,6 +6,9 @@
 [id="telco-core-host-firmware-and-boot-loader-configuration_{context}"]
 = Host firmware and boot loader configuration
 
+[role="_abstract"]
+Configure host firmware and boot loader settings to support telco core cluster requirements.
+
 New in this release::
 * No reference design updates in this release.
 

--- a/modules/telco-core-kubelet-settings.adoc
+++ b/modules/telco-core-kubelet-settings.adoc
@@ -6,6 +6,7 @@
 [id="telco-core-kubelet-settings_{context}"]
 = Kubelet Settings
 
+[role="_abstract"]
 Some CNF workloads make use of sysctls which are not in the list of system-wide safe `sysctls`.
 Generally network sysctls are namespaced and can be enabled by using the `kubeletconfig.experimental` annotation in the PerformanceProfile as a string of JSON in the form `allowedUnsafeSysctls`.
 
@@ -28,7 +29,7 @@ metadata:
        "systemReserved":{"memory":"11Gi"}
       }
 ----
-+
+
 [NOTE]
 ====
 Although these are namespaced they may allow a pod to consume memory or other resources beyond any limits specified in the pod description. You must ensure that these `sysctls` do not exhaust platform resources.

--- a/modules/telco-core-load-balancer.adoc
+++ b/modules/telco-core-load-balancer.adoc
@@ -6,6 +6,9 @@
 [id="telco-core-load-balancer_{context}"]
 = Load balancer
 
+[role="_abstract"]
+MetalLB is a load-balancer implementation for bare metal Kubernetes clusters that uses standard routing protocols.
+
 New in this release::
 
 *   No reference design updates in this release.

--- a/modules/telco-core-logging.adoc
+++ b/modules/telco-core-logging.adoc
@@ -6,6 +6,9 @@
 [id="telco-core-logging_{context}"]
 = Logging
 
+[role="_abstract"]
+The Cluster Logging Operator enables collection and shipping of logs off the node for remote archival and analysis.
+
 New in this release::
 
 * No reference design updates in this release

--- a/modules/telco-core-monitoring.adoc
+++ b/modules/telco-core-monitoring.adoc
@@ -6,6 +6,9 @@
 [id="telco-core-monitoring_{context}"]
 = Monitoring
 
+[role="_abstract"]
+The Cluster Monitoring Operator (CMO) is included by default in {product-title} and provides monitoring for the platform components and optionally user projects.
+
 New in this release::
 * Optionally use the `remoteWrite` field in Prometheus configurations for direct export of metrics
 

--- a/modules/telco-core-networking.adoc
+++ b/modules/telco-core-networking.adoc
@@ -6,6 +6,7 @@
 [id="telco-core-networking_{context}"]
 = Networking
 
+[role="_abstract"]
 The following diagram describes the telco core reference design networking configuration.
 
 .Telco core reference design networking configuration

--- a/modules/telco-core-nmstate-operator.adoc
+++ b/modules/telco-core-nmstate-operator.adoc
@@ -6,6 +6,9 @@
 [id="telco-core-nmstate-operator_{context}"]
 = NMState Operator
 
+[role="_abstract"]
+The Kubernetes NMState Operator provides a Kubernetes API for performing state-driven network configuration across cluster nodes.
+
 New in this release::
 * No reference design updates in this release
 

--- a/modules/telco-core-node-configuration.adoc
+++ b/modules/telco-core-node-configuration.adoc
@@ -6,6 +6,9 @@
 [id="telco-core-node-configuration_{context}"]
 = Node Configuration
 
+[role="_abstract"]
+Node configuration for telco core clusters includes additional kernel modules, container mount namespace settings, and kdump configuration.
+
 New in this release::
 * Consult the 4.21 release notes regarding the decrease in the default maximum open files soft limit for containers in this release.
 

--- a/modules/telco-core-openshift-data-foundation.adoc
+++ b/modules/telco-core-openshift-data-foundation.adoc
@@ -6,6 +6,9 @@
 [id="telco-core-openshift-data-foundation_{context}"]
 = {rh-storage}
 
+[role="_abstract"]
+{rh-storage} is a software-defined storage service for containers that provides block storage, file system storage, and on-premise object storage.
+
 New in this release::
 
 * No reference design updates in this release.

--- a/modules/telco-core-power-management.adoc
+++ b/modules/telco-core-power-management.adoc
@@ -6,6 +6,9 @@
 [id="telco-core-power-management_{context}"]
 = Power Management
 
+[role="_abstract"]
+Use the performance profile to configure clusters with high power mode, low power mode, or mixed mode depending on workload latency sensitivity.
+
 New in this release::
 
 * No reference design updates in this release

--- a/modules/telco-core-rds-components.adoc
+++ b/modules/telco-core-rds-components.adoc
@@ -1,0 +1,10 @@
+// Module included in the following assemblies:
+//
+// * scalability_and_performance/telco-core-rds.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="telco-core-rds-components_{context}"]
+= Telco core RDS components
+
+[role="_abstract"]
+The following sections describe the various {product-title} components and configurations that you use to configure and deploy clusters to run telco core workloads.

--- a/modules/telco-core-rds-container.adoc
+++ b/modules/telco-core-rds-container.adoc
@@ -6,6 +6,7 @@
 [id="telco-core-rds-container_{context}"]
 = Extracting the telco core reference design configuration CRs
 
+[role="_abstract"]
 You can extract the complete set of custom resources (CRs) for the telco core profile from the `telco-core-rds-rhel9` container image.
 The container image has both the required CRs, and the optional CRs, for the telco core profile.
 

--- a/modules/telco-core-rds-product-version-use-model-overview.adoc
+++ b/modules/telco-core-rds-product-version-use-model-overview.adoc
@@ -6,6 +6,7 @@
 [id="telco-core-rds-product-version-use-model-overview_{context}"]
 = Telco core RDS use model overview
 
+[role="_abstract"]
 The Telco core reference design specification (RDS) describes a platform that supports large-scale telco applications including control plane functions such as signaling and aggregation.
 It also includes some centralized data plane functions, for example, user plane functions (UPF).
 These functions generally require scalability, complex networking support, resilient software-defined storage, and support performance requirements that are less stringent and constrained than far-edge deployments such as RAN.

--- a/modules/telco-core-red-hat-advanced-cluster-management.adoc
+++ b/modules/telco-core-red-hat-advanced-cluster-management.adoc
@@ -6,6 +6,9 @@
 [id="telco-core-red-hat-advanced-cluster-management_{context}"]
 = Red Hat Advanced Cluster Management
 
+[role="_abstract"]
+{rh-rhacm} provides Multi Cluster Engine (MCE) installation and ongoing lifecycle management for deployed clusters.
+
 New in this release::
 * No reference design updates in this release.
 

--- a/modules/telco-core-reference-configuration-crs.adoc
+++ b/modules/telco-core-reference-configuration-crs.adoc
@@ -1,0 +1,11 @@
+// Module included in the following assemblies:
+//
+// * scalability_and_performance/telco-core-rds.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="telco-core-reference-configuration-crs_{context}"]
+= Telco core reference configuration CRs
+
+[role="_abstract"]
+Use the following custom resources (CRs) to configure and deploy {product-title} clusters with the telco core profile.
+Use the CRs to form the common baseline used in all the specific use models unless otherwise indicated.

--- a/modules/telco-core-scalability.adoc
+++ b/modules/telco-core-scalability.adoc
@@ -6,6 +6,9 @@
 [id="telco-core-scalability_{context}"]
 = Scalability
 
+[role="_abstract"]
+Telco core clusters can scale to at least 120 nodes to support large-scale telco application workloads.
+
 New in this release::
 * No reference design updates in this release.
 

--- a/modules/telco-core-scheduling.adoc
+++ b/modules/telco-core-scheduling.adoc
@@ -6,6 +6,9 @@
 [id="telco-core-scheduling_{context}"]
 = Scheduling
 
+[role="_abstract"]
+The scheduler is a cluster-wide component responsible for selecting the right node for a given workload.
+
 New in this release::
 * No reference design updates in this release.
 

--- a/modules/telco-core-security.adoc
+++ b/modules/telco-core-security.adoc
@@ -6,6 +6,9 @@
 [id="telco-core-security_{context}"]
 = Security
 
+[role="_abstract"]
+Telco core clusters require hardening against multiple attack vectors through various security features and configurations.
+
 New in this release::
 * No reference design updates in this release.
 

--- a/modules/telco-core-service-mesh.adoc
+++ b/modules/telco-core-service-mesh.adoc
@@ -6,6 +6,9 @@
 [id="telco-core-service-mesh_{context}"]
 = Service Mesh
 
+[role="_abstract"]
+Telco core cloud-native functions (CNFs) typically require a Service Mesh implementation.
+
 Description::
 Telco core cloud-native functions (CNFs) typically require a Service Mesh implementation.
 Specific Service Mesh features and performance requirements are dependent on the application.

--- a/modules/telco-core-signaling-workloads.adoc
+++ b/modules/telco-core-signaling-workloads.adoc
@@ -5,6 +5,8 @@
 :_mod-docs-content-type: REFERENCE
 [id="telco-core-signaling-workloads_{context}"]
 = Signaling workloads
+
+[role="_abstract"]
 Signaling workloads typically use SCTP, REST, gRPC, or similar TCP or UDP protocols.
 Signaling workloads support hundreds of thousands of transactions per second (TPS) by using a secondary multus CNI configured as MACVLAN or SR-IOV interface.
 These workloads can run in pods with either guaranteed or burstable QoS.

--- a/modules/telco-core-software-stack.adoc
+++ b/modules/telco-core-software-stack.adoc
@@ -11,6 +11,7 @@
 [id="telco-core-software-stack_{context}_{context}"]
 = Telco core reference configuration software specifications
 
+[role="_abstract"]
 The Red{nbsp}Hat telco core {product-version} solution has been validated using the following Red{nbsp}Hat software products for {product-title} clusters.
 
 .Telco core cluster validated software components

--- a/modules/telco-core-sr-iov.adoc
+++ b/modules/telco-core-sr-iov.adoc
@@ -6,6 +6,9 @@
 [id="telco-core-sr-iov_{context}"]
 = SR-IOV
 
+[role="_abstract"]
+SR-IOV enables physical functions (PFs) to be divided into multiple virtual functions (VFs) for higher throughput performance while keeping pods isolated.
+
 New in this release::
 * No reference design updates in this release.
 

--- a/modules/telco-core-storage.adoc
+++ b/modules/telco-core-storage.adoc
@@ -6,6 +6,9 @@
 [id="telco-core-storage_{context}"]
 = Storage
 
+[role="_abstract"]
+Cloud native storage services can be provided by {rh-storage} or other third-party solutions for telco core clusters.
+
 New in this release::
 
 * No reference design updates in this release

--- a/modules/telco-core-topology-aware-lifecycle-manager.adoc
+++ b/modules/telco-core-topology-aware-lifecycle-manager.adoc
@@ -6,6 +6,9 @@
 [id="telco-core-topology-aware-lifecycle-manager_{context}"]
 = Topology Aware Lifecycle Manager
 
+[role="_abstract"]
+{cgu-operator} manages how changes are rolled out to managed clusters in the network.
+
 New in this release::
 * No reference design updates in this release.
 

--- a/modules/telco-core-worker-nodes-and-machineconfigpools.adoc
+++ b/modules/telco-core-worker-nodes-and-machineconfigpools.adoc
@@ -6,6 +6,7 @@
 [id="telco-core-worker-nodes-and-machineconfigpools_{context}"]
 = Worker Nodes and MachineConfigPools
 
+[role="_abstract"]
 `MachineConfigPools` (MCPs) custom resources (CR) enable the subdivision of worker nodes in telco core clusters into different node groups based on customer planning parameters.
 Careful deployment planning using MCPs is crucial to minimize deployment and upgrade time and, more importantly, to minimize interruption of telco-grade services during cluster upgrades.
 

--- a/modules/telco-core-workloads-on-schedulable-control-planes.adoc
+++ b/modules/telco-core-workloads-on-schedulable-control-planes.adoc
@@ -6,9 +6,12 @@
 [id="telco-core-workloads-on-schedulable-control-planes_{context}"]
 = Workloads on schedulable control planes
 
+[role="_abstract"]
+You can enable schedulable control planes to run workloads on control plane nodes, utilizing idle CPU capacity on bare-metal machines.
+
 Enabling workloads on control plane nodes::
 
-You can enable schedulable control planes to run workloads on control plane nodes, utilizing idle CPU capacity on bare metal machines for potential cost savings. This feature is only applicable to clusters with bare metal control plane nodes.
+You can enable schedulable control planes to run workloads on control plane nodes, utilizing idle CPU capacity on bare-metal machines for potential cost savings. This feature is only applicable to clusters with bare-metal control plane nodes.
 +
 There are two distinct parts to this functionality:
 

--- a/modules/telco-core-zones.adoc
+++ b/modules/telco-core-zones.adoc
@@ -6,6 +6,7 @@
 [id="telco-core-zones_{context}"]
 = Zones
 
+[role="_abstract"]
 Designing the cluster to support disruption of multiple nodes simultaneously is critical for high availability (HA) and reduced upgrade times.
 {product-title} and Kubernetes use the label `topology.kubernetes.io/zone` to create pools of nodes which are subject to a common failure domain.
 Annotating nodes for topology (availability) zones allows high-availability workloads to spread such that each zone holds only one replica from a set of HA replicated pods.

--- a/modules/telco-deviations-from-the-ref-design.adoc
+++ b/modules/telco-deviations-from-the-ref-design.adoc
@@ -7,6 +7,7 @@
 [id="telco-deviations-from-the-ref-design_{context}"]
 = Deviations from the reference design
 
+[role="_abstract"]
 Deviating from the validated telco core, telco RAN DU, and telco hub reference design specifications (RDS) can have significant impact beyond the specific component or feature that you change.
 Deviations require analysis and engineering in the context of the complete solution.
 

--- a/modules/telco-ran-core-ref-design-spec.adoc
+++ b/modules/telco-ran-core-ref-design-spec.adoc
@@ -8,6 +8,7 @@
 [id="telco-ran-core-ref-design-spec_{context}"]
 = Reference design scope
 
+[role="_abstract"]
 The telco core, telco RAN and telco hub reference design specifications (RDS) capture the recommended, tested, and supported configurations to get reliable and repeatable performance for clusters running the telco core and telco RAN profiles.
 
 Each RDS includes the released features and supported configurations that are engineered and validated for clusters to run the individual profiles.

--- a/modules/using-cluster-compare-telco-core.adoc
+++ b/modules/using-cluster-compare-telco-core.adoc
@@ -7,6 +7,7 @@
 [id="using-cluster-compare-telco_core_{context}"]
 = Comparing a cluster with the {rds} reference configuration
 
+[role="_abstract"]
 After you deploy a {rds} cluster, you can use the `cluster-compare` plugin to assess the cluster's compliance with the {rds} reference design specifications (RDS). The `cluster-compare` plugin is an OpenShift CLI (`oc`) plugin. The plugin uses a {rds} reference configuration to validate the cluster with the {rds} custom resources (CRs).
 
 The plugin-specific reference configuration for {rds} is packaged in a container image with the {rds} CRs.
@@ -56,14 +57,14 @@ $ tree -L 2
 .
 ├── compare_ignore
 ├── comparison-overrides.yaml
-├── metadata.yaml <1>
-├── optional <2>
+├── metadata.yaml
+├── optional
 │   ├── logging
 │   ├── networking
 │   ├── other
 │   └── tuning
 ├── ReferenceVersionCheck.yaml
-├── required <3>
+├── required
 │   ├── networking
 │   ├── other
 │   ├── performance
@@ -73,9 +74,12 @@ $ tree -L 2
 └── version_match.tmpl
 
 ----
-<1> Configuration file for the reference configuration.
-<2> Directory for optional templates.
-<3> Directory for required templates.
++
+--
+* `metadata.yaml` is the configuration file for the reference configuration.
+* `optional` is the directory for optional templates.
+* `required` is the directory for required templates.
+--
 
 . Compare the configuration for your cluster to the telco core reference configuration by running the following command:
 +
@@ -93,8 +97,8 @@ W1212 14:13:06.281590   36629 compare.go:425] Reference Contains Templates With 
 
 **********************************
 
-Cluster CR: config.openshift.io/v1_OperatorHub_cluster <1>
-Reference File: required/other/operator-hub.yaml <2>
+Cluster CR: config.openshift.io/v1_OperatorHub_cluster
+Reference File: required/other/operator-hub.yaml
 Diff Output: diff -u -N /tmp/MERGED-2801470219/config-openshift-io-v1_operatorhub_cluster /tmp/LIVE-2569768241/config-openshift-io-v1_operatorhub_cluster
 --- /tmp/MERGED-2801470219/config-openshift-io-v1_operatorhub_cluster	2024-12-12 14:13:22.898756462 +0000
 +++ /tmp/LIVE-2569768241/config-openshift-io-v1_operatorhub_cluster	2024-12-12 14:13:22.898756462 +0000
@@ -102,7 +106,7 @@ Diff Output: diff -u -N /tmp/MERGED-2801470219/config-openshift-io-v1_operatorhu
  apiVersion: config.openshift.io/v1
  kind: OperatorHub
  metadata:
-+  annotations: <3>
++  annotations:
 +    include.release.openshift.io/hypershift: "true"
    name: cluster
 -spec:
@@ -110,12 +114,12 @@ Diff Output: diff -u -N /tmp/MERGED-2801470219/config-openshift-io-v1_operatorhu
 
 **********************************
 
-Summary <4>
-CRs with diffs: 3/4 <5>
-CRs in reference missing from the cluster: 22 <6>
+Summary
+CRs with diffs: 3/4
+CRs in reference missing from the cluster: 22
 other:
   other:
-    Missing CRs: <7>
+    Missing CRs:
     - optional/other/control-plane-load-kernel-modules.yaml
     - optional/other/worker-load-kernel-modules.yaml
 required-networking:
@@ -155,17 +159,20 @@ required-storage:
     - required/storage/odf-external/odfNS.yaml
     - required/storage/odf-external/odfOperGroup.yaml
     - required/storage/odf-external/odfSubscription.yaml
-No CRs are unmatched to reference CRs <8>
-Metadata Hash: fe41066bac56517be02053d436c815661c9fa35eec5922af25a1be359818f297 <9>
-No patched CRs <10>
+No CRs are unmatched to reference CRs
+Metadata Hash: fe41066bac56517be02053d436c815661c9fa35eec5922af25a1be359818f297
+No patched CRs
 ----
-<1> The CR under comparison. The plugin displays each CR with a difference from the corresponding template.
-<2> The template matching with the CR for comparison.
-<3> The output in Linux diff format shows the difference between the template and the cluster CR.
-<4> After the plugin reports the line diffs for each CR, the summary of differences are reported.
-<5> The number of CRs in the comparison with differences from the corresponding templates.
-<6> The number of CRs represented in the reference configuration, but missing from the live cluster.
-<7> The list of CRs represented in the reference configuration, but missing from the live cluster.
-<8> The CRs that did not match to a corresponding template in the reference configuration.
-<9> The metadata hash identifies the reference configuration.
-<10> The list of patched CRs.
++
+--
+* `Cluster CR` is the CR under comparison. The plugin displays each CR with a difference from the corresponding template.
+* `Reference File` is the template matching with the CR for comparison.
+* The `diff` output in Linux diff format shows the difference between the template and the cluster CR.
+* `Summary` shows the summary of differences after the plugin reports the line diffs for each CR.
+* `CRs with diffs` is the number of CRs in the comparison with differences from the corresponding templates.
+* `CRs in reference missing from the cluster` is the number of CRs represented in the reference configuration, but missing from the live cluster.
+* `Missing CRs` is the list of CRs represented in the reference configuration, but missing from the live cluster.
+* `No CRs are unmatched to reference CRs` indicates the CRs that did not match to a corresponding template in the reference configuration.
+* `Metadata Hash` identifies the reference configuration.
+* `No patched CRs` is the list of patched CRs.
+--

--- a/scalability_and_performance/telco-core-rds.adoc
+++ b/scalability_and_performance/telco-core-rds.adoc
@@ -42,10 +42,7 @@ include::modules/telco-core-application-workloads.adoc[leveloffset=+2]
 
 include::modules/telco-core-signaling-workloads.adoc[leveloffset=+2]
 
-[id="telco-core-rds-components"]
-== Telco core RDS components
-
-The following sections describe the various {product-title} components and configurations that you use to configure and deploy clusters to run telco core workloads.
+include::modules/telco-core-rds-components.adoc[leveloffset=+1]
 
 include::modules/telco-core-cpu-partitioning-and-performance-tuning.adoc[leveloffset=+2]
 
@@ -134,10 +131,7 @@ include::modules/telco-core-openshift-data-foundation.adoc[leveloffset=+3]
 
 include::modules/telco-core-additional-storage-solutions.adoc[leveloffset=+3]
 
-[id="telco-reference-core-deployment-components_{context}"]
-== Telco core deployment components
-
-The following sections describe the various {product-title} components and configurations that you use to configure the hub cluster with {rh-rhacm-first}.
+include::modules/telco-core-deployment-components.adoc[leveloffset=+1]
 
 include::modules/telco-core-red-hat-advanced-cluster-management.adoc[leveloffset=+2]
 
@@ -228,11 +222,7 @@ include::modules/telco-core-cert-manager-operator.adoc[leveloffset=+1]
 
 include::modules/telco-core-scalability.adoc[leveloffset=+1]
 
-[id="telco-core-reference-configuration-crs"]
-== Telco core reference configuration CRs
-
-Use the following custom resources (CRs) to configure and deploy {product-title} clusters with the telco core profile.
-Use the CRs to form the common baseline used in all the specific use models unless otherwise indicated.
+include::modules/telco-core-reference-configuration-crs.adoc[leveloffset=+1]
 
 include::modules/telco-core-rds-container.adoc[leveloffset=+2]
 


### PR DESCRIPTION
[TELCODOCS-2723]: Backport DITA compatibility fixes for telco-core-rds to enterprise-4.22

Version(s): 4.22

Issue: https://issues.redhat.com/browse/TELCODOCS-2723

Link to docs preview:

- https://106582--ocpdocs-pr.netlify.app/openshift-enterprise/latest/scalability_and_performance/telco-core-rds.html

QE review:
- [x] QE has approved this change.

Additional information:
Cherry-pick of https://github.com/openshift/openshift-docs/pull/106582 to enterprise-4.22.

48 files included, 3 files excluded (not present on enterprise-4.22):
- telco-core-deployment-components
- telco-core-rds-components
- telco-core-reference-configuration-crs

Resolved 2 cherry-pick conflicts (editorial additions of `[role="_abstract"]` short descriptions):
- `modules/telco-core-crs-cluster-infrastructure.adoc`
- `modules/telco-core-crs-networking.adoc`

