### PR TITLE
DOCPLAN-164: CQA ocp virt storage docs

### DIFF
--- a/modules/virt-managing-auto-update-all-system-boot-sources.adoc
+++ b/modules/virt-managing-auto-update-all-system-boot-sources.adoc
@@ -10,7 +10,7 @@
 [role="_abstract"]
 Disabling automatic boot source imports and updates can lower resource usage. In disconnected environments, disabling automatic boot source updates prevents `CDIDataImportCronOutdated` alerts from filling up logs.
 
-To disable automatic updates for all system-defined boot sources, set the `enableCommonBootImageImport` field value to `false`. Setting this value to `true` turns automatic updates back on.
+To disable automatic updates for all system-defined boot sources, set the `enableCommonBootImageImport` field value to `false`. Disabling automatic updates deletes the associated `DataImportCron` objects but does not remove previously imported boot source images. Setting this value to `true` turns automatic updates back on.
 
 [NOTE]
 ====

--- a/virt/creating_vms_advanced/creating_vms_advanced_web/virt-creating-vms-from-rh-images-overview.adoc
+++ b/virt/creating_vms_advanced/creating_vms_advanced_web/virt-creating-vms-from-rh-images-overview.adoc
@@ -12,8 +12,6 @@ Red Hat images are xref:../../../virt/creating_vms_advanced/creating_vms_advance
 
 * xref:../../../virt/creating_vms_advanced/creating_vms_advanced_web/virt-creating-vms-from-rh-images-overview.adoc#virt-golden-images-namespace-cli_virt-creating-vms-from-rh-images-overview[Configuring a custom namespace for golden images by using the CLI]
 
-Red Hat images are automatically updated. You can disable and re-enable automatic updates for these images. See xref:../../../virt/storage/virt-automatic-bootsource-updates.adoc#managing-rh-boot-source-updates_virt-automatic-bootsource-updates[Managing Red Hat boot source updates].
-
 Cluster administrators can enable automatic subscription for {op-system-base-full} virtual machines in the {VirtProductName} xref:../../../virt/about_virt/about-virt.adoc#about-virt[web console].
 
 You can create virtual machines (VMs) from operating system images provided by Red Hat by using one of the following methods:
@@ -36,3 +34,9 @@ include::modules/virt-about-vms-and-boot-sources.adoc[leveloffset=+1]
 include::modules/virt-golden-images-namespace-web.adoc[leveloffset=+1]
 
 include::modules/virt-golden-images-namespace-cli.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+[id="additional-resources_{context}"]
+== Additional resources
+
+* xref:../../../virt/storage/virt-automatic-bootsource-updates.adoc#virt-managing-auto-update-all-system-boot-sources_virt-automatic-bootsource-updates[Managing automatic updates for all system-defined boot sources]

--- a/virt/storage/install-configure-fusion-access-san.adoc
+++ b/virt/storage/install-configure-fusion-access-san.adoc
@@ -6,6 +6,9 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
+You configure SAN-based storage for virtual machines by using {IBMFusionFirst} with {VirtProductName}. You must install the {FusionSAN} Operator (Fusion Access for SAN) and set up the storage cluster and file systems.
+
 include::modules/virt-about-fusion-access-san.adoc[leveloffset=+1]
 
 include::modules/virt-fusion-access-san-prereqs.adoc[leveloffset=+1]
@@ -22,15 +25,12 @@ include::modules/virt-creating-filesystem-fusion-access-san.adoc[leveloffset=+1]
 
 include::modules/virt-troubleshoot-fusion-access-san.adoc[leveloffset=+1]
 
-[id="fusion-san-next-steps_{context}"]
-== Next steps
-
-Once you create a storage cluster with file systems, you can create a virtual machine (VM) on the storage cluster.
-
-Create a VM from an instance type or template and select a storage class that corresponds to one of the file systems you created as the storage type.
-
-* xref:../../virt/creating_vm/virt-creating-vms-from-instance-types.adoc#virt-creating-vms-from-instance-types[Creating virtual machines from instance types].
-
-* xref:../../virt/creating_vm/virt-creating-vms-from-templates.adoc#virt-creating-vms-from-templates[Creating virtual machines from templates].
-
 include::modules/virt-fusion-access-san-release-updates.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+[id="additional-resources_{context}"]
+== Additional resources
+
+* xref:../../virt/creating_vm/virt-creating-vms-from-instance-types.adoc#virt-creating-vms-from-instance-types[Creating virtual machines from instance types]
+
+* xref:../../virt/creating_vm/virt-creating-vms-from-templates.adoc#virt-creating-vms-from-templates[Creating virtual machines from templates]

--- a/virt/storage/virt-automatic-bootsource-updates.adoc
+++ b/virt/storage/virt-automatic-bootsource-updates.adoc
@@ -6,49 +6,29 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-You can manage automatic updates for the following boot sources:
+[role="_abstract"]
+You can manage automatic updates for boot sources used to create virtual machines. This includes configuring update behavior for Red Hat and custom boot sources.
 
-* xref:../../virt/storage/virt-automatic-bootsource-updates.adoc#managing-rh-boot-source-updates_virt-automatic-bootsource-updates[All Red Hat boot sources]
-* xref:../../virt/storage/virt-automatic-bootsource-updates.adoc#managing-custom-boot-source-updates_virt-automatic-bootsource-updates[All custom boot sources]
-* xref:../../virt/storage/virt-automatic-bootsource-updates.adoc#virt-disable-auto-updates-single-boot-source_virt-automatic-bootsource-updates[Individual Red Hat or custom boot sources]
+include::modules/virt-managing-auto-update-all-system-boot-sources.adoc[leveloffset=+1]
 
-Boot sources can make virtual machine (VM) creation more accessible and efficient for users. If automatic boot source updates are enabled, the Containerized Data Importer (CDI) imports, polls, and updates the images so that they are ready to be cloned for new VMs. By default, CDI automatically updates Red Hat boot sources.
+include::modules/virt-configuring-default-and-virt-default-storage-class.adoc[leveloffset=+1]
 
-[id="managing-rh-boot-source-updates_virt-automatic-bootsource-updates"]
-== Managing Red Hat boot source updates
+include::modules/virt-configuring-storage-class-bootsource-update.adoc[leveloffset=+1]
 
-You can opt out of automatic updates for all system-defined boot sources by setting the `enableCommonBootImageImport` field value to `false`. If you set the value to `false`, all `DataImportCron` objects are deleted. This does not, however, remove previously imported boot source objects that store operating system images, though administrators can delete them manually.
+include::modules/virt-autoupdate-custom-bootsource.adoc[leveloffset=+1]
 
-When the `enableCommonBootImageImport` field value is set to `false`, `DataSource` objects are reset so that they no longer point to the original boot source. An administrator can manually provide a boot source by creating a new persistent volume claim (PVC) or volume snapshot for the `DataSource` object, and then populating it with an operating system image.
-
-include::modules/virt-managing-auto-update-all-system-boot-sources.adoc[leveloffset=+2]
-
-[id="managing-custom-boot-source-updates_virt-automatic-bootsource-updates"]
-== Managing custom boot source updates
-
-_Custom_ boot sources that are not provided by {VirtProductName} are not controlled by the feature gate. You must manage them individually by editing the `HyperConverged` custom resource (CR).
-
-ifndef::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
-[IMPORTANT]
-====
-You must configure a storage class. Otherwise, the cluster cannot receive automated updates for custom boot sources. See xref:../../storage/dynamic-provisioning.adoc#defining-storage-classes_dynamic-provisioning[Defining a storage class] for details.
-====
-endif::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
-ifdef::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
-[IMPORTANT]
-====
-You must configure a storage profile. Otherwise, the cluster cannot receive automated updates for custom boot sources. See xref:../../virt/storage/virt-configuring-storage-profile.adoc#virt-configuring-storage-profile[Configure storage profiles] for details.
-====
-endif::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
-
-include::modules/virt-configuring-default-and-virt-default-storage-class.adoc[leveloffset=+2]
-
-include::modules/virt-configuring-storage-class-bootsource-update.adoc[leveloffset=+2]
-
-include::modules/virt-autoupdate-custom-bootsource.adoc[leveloffset=+2]
-
-include::modules/virt-enabling-volume-snapshot-boot-source.adoc[leveloffset=+2]
+include::modules/virt-enabling-volume-snapshot-boot-source.adoc[leveloffset=+1]
 
 include::modules/virt-disable-auto-updates-single-boot-source.adoc[leveloffset=+1]
 
 include::modules/virt-verify-status-bootsource-update.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+[id="additional-resources_{context}"]
+== Additional resources
+
+* xref:../../virt/storage/virt-automatic-bootsource-updates.adoc#virt-managing-auto-update-all-system-boot-sources_virt-automatic-bootsource-updates[All Red Hat boot sources]
+
+* xref:../../virt/storage/virt-automatic-bootsource-updates.adoc#virt-autoupdate-custom-bootsource_virt-automatic-bootsource-updates[All custom boot sources]
+
+* xref:../../virt/storage/virt-automatic-bootsource-updates.adoc#virt-disable-auto-updates-single-boot-source_virt-automatic-bootsource-updates[Individual Red Hat or custom boot sources]

--- a/virt/storage/virt-storage-config-overview.adoc
+++ b/virt/storage/virt-storage-config-overview.adoc
@@ -8,8 +8,9 @@ toc::[]
 
 [role="_abstract"]
 You can configure a default storage class, storage profiles, Containerized Data Importer (CDI), data volumes (DVs), and automatic boot source updates.
+
 ifdef::openshift-dedicated[]
-On {product-title}, specific configurations for Hyperdisk and {gcp-short} NetApp Volumes (GCNV) are required to ensure performance and support features like live migration. For more information, see "Storage configuration for OpenShift Virtualization 4.21.x on Google Cloud" and "{GCP} with {GCP} NetApp Volumes - Configuration" in the _Additional resources_ section.
+On {product-title}, specific configurations for Hyperdisk are required to ensure performance and support features like live migration. For more information, see "Storage configuration for {VirtProductName} 4.21.x on Google Cloud" in the "Additional resources" section.
 endif::openshift-dedicated[]
 
 [id="storage-configuration-tasks"]
@@ -18,26 +19,28 @@ endif::openshift-dedicated[]
 The following storage configuration tasks are mandatory:
 
 ifndef::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
-xref:../../storage/dynamic-provisioning.adoc#defining-storage-classes_dynamic-provisioning[Configure a default storage class]::
+
+Configure a default storage class::
 
 You must configure a default storage class for the cluster. Otherwise, {VirtProductName} cannot automatically import boot source images. `DataVolume` objects (DVs) and `PersistentVolumeClaim` objects (PVCs) that do not explicitly specify a storage class remain in the `Pending` state until you set a default storage class.
+
 endif::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
 
-xref:../../virt/storage/virt-configuring-storage-profile.adoc#virt-configuring-storage-profile[Configure storage profiles]::
+Configure storage profiles::
 
 You must configure storage profiles if your storage provider is not recognized by CDI. A storage profile provides recommended storage settings based on the associated storage class.
 
 The following storage configuration tasks are optional:
 
-xref:../../virt/storage/virt-reserving-pvc-space-fs-overhead.adoc#virt-reserving-pvc-space-fs-overhead[Reserve additional PVC space for file system overhead]::
+Reserve additional PVC space for file system overhead::
 
 By default, 5.5% of a file system PVC is reserved for overhead, reducing the space available for VM disks by that amount. You can configure a different overhead value.
 
-xref:../../virt/storage/virt-configuring-local-storage-with-hpp.adoc#virt-configuring-local-storage-with-hpp[Configure local storage by using the hostpath provisioner]::
+Configure local storage by using the hostpath provisioner::
 
 You can configure local storage for virtual machines by using the hostpath provisioner (HPP). When you install the {VirtProductName} Operator, the HPP Operator is automatically installed.
 
-xref:../../virt/storage/virt-enabling-user-permissions-to-clone-datavolumes.adoc#virt-enabling-user-permissions-to-clone-datavolumes[Configure user permissions to clone data volumes between namespaces]::
+Configure user permissions to clone data volumes between namespaces::
 
 You can configure RBAC roles to enable users to clone data volumes between namespaces.
 
@@ -46,10 +49,12 @@ You can configure RBAC roles to enable users to clone data volumes between names
 
 You can perform the following Containerized Data Importer (CDI) configuration tasks:
 
-xref:../../virt/storage/virt-configuring-cdi-for-namespace-resourcequota.adoc#virt-configuring-cdi-for-namespace-resourcequota[Override the resource request limits of a namespace]::
+Override the resource request limits of a namespace::
+
 You can configure CDI to import, upload, and clone VM disks into namespaces that are subject to CPU and memory resource restrictions.
 
-xref:../../virt/storage/virt-preparing-cdi-scratch-space.adoc#virt-preparing-cdi-scratch-space[Configure CDI scratch space]::
+Configure CDI scratch space::
+
 CDI requires scratch space (temporary storage) to complete some operations, such as importing and uploading VM images. During this process, CDI provisions a scratch space PVC equal to the size of the PVC backing the destination data volume (DV).
 
 [id="dv-configuration-tasks"]
@@ -57,11 +62,11 @@ CDI requires scratch space (temporary storage) to complete some operations, such
 
 You can perform the following data volume configuration tasks:
 
-xref:../../virt/storage/virt-using-preallocation-for-datavolumes.adoc#virt-using-preallocation-for-datavolumes[Enable preallocation for data volumes]::
+Enable preallocation for data volumes::
 
 CDI can preallocate disk space to improve write performance when creating data volumes. You can enable preallocation for specific data volumes.
 
-xref:../../virt/storage/virt-managing-data-volume-annotations.adoc#virt-managing-data-volume-annotations[Manage data volume annotations]::
+Manage data volume annotations::
 
 Data volume annotations allow you to manage pod behavior. You can add one or more annotations to a data volume, which then propagates to the created importer pods.
 
@@ -70,15 +75,26 @@ Data volume annotations allow you to manage pod behavior. You can add one or mor
 
 You can perform the following boot source update configuration task:
 
-xref:../../virt/storage/virt-automatic-bootsource-updates.adoc#virt-automatic-bootsource-updates[Manage automatic boot source updates]::
+Manage automatic boot source updates::
 
 Boot sources can make virtual machine (VM) creation more accessible and efficient for users. If automatic boot source updates are enabled, CDI imports, polls, and updates the images so that they are ready to be cloned for new VMs. By default, CDI automatically updates Red Hat boot sources. You can enable automatic updates for custom boot sources.
 
-ifdef::openshift-dedicated[]
 [role="_additional-resources"]
+[id="additional-resources_{context}"]
 == Additional resources
-* link:https://access.redhat.com/articles/7139046[Storage configuration for OpenShift Virtualization 4.21.x on Google Cloud]
-* link:https://access.redhat.com/articles/7139682[OpenShift Virtualization on Google Cloud: Known Issues and Limitations]
-* link:https://access.redhat.com/articles/7141472[{GCP} with {GCP} NetApp Volumes - Configuration]
-* link:https://access.redhat.com/articles/7141471[{GCP} with {GCP} NetApp Volumes - Known errors and limits]
+
+ifndef::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
+* xref:../../storage/dynamic-provisioning.adoc#defining-storage-classes_dynamic-provisioning[Configure a default storage class]
+endif::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
+* xref:../../virt/storage/virt-configuring-storage-profile.adoc#virt-configuring-storage-profile[Configure storage profiles]
+* xref:../../virt/storage/virt-reserving-pvc-space-fs-overhead.adoc#virt-reserving-pvc-space-fs-overhead[Reserve additional PVC space for file system overhead]
+* xref:../../virt/storage/virt-configuring-local-storage-with-hpp.adoc#virt-configuring-local-storage-with-hpp[Configure local storage by using the hostpath provisioner]
+* xref:../../virt/storage/virt-enabling-user-permissions-to-clone-datavolumes.adoc#virt-enabling-user-permissions-to-clone-datavolumes[Configure user permissions to clone data volumes between namespaces]
+* xref:../../virt/storage/virt-configuring-cdi-for-namespace-resourcequota.adoc#virt-configuring-cdi-for-namespace-resourcequota[Override the resource request limits of a namespace]
+* xref:../../virt/storage/virt-preparing-cdi-scratch-space.adoc#virt-preparing-cdi-scratch-space[Configure CDI scratch space]
+* xref:../../virt/storage/virt-using-preallocation-for-datavolumes.adoc#virt-using-preallocation-for-datavolumes[Enable preallocation for data volumes]
+* xref:../../virt/storage/virt-managing-data-volume-annotations.adoc#virt-managing-data-volume-annotations[Manage data volume annotations]
+* xref:../../virt/storage/virt-automatic-bootsource-updates.adoc#virt-automatic-bootsource-updates[Manage automatic boot source updates]
+ifdef::openshift-dedicated[]
+* link:https://access.redhat.com/articles/7139046[Storage configuration for {VirtProductName} 4.21.x on Google Cloud]
 endif::openshift-dedicated[]

--- a/virt/storage/virt-storage-with-csi-paradigm.adoc
+++ b/virt/storage/virt-storage-with-csi-paradigm.adoc
@@ -6,6 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 Virtual machines (VMs) in {VirtProductName} use PersistentVolume (PV) and PersistentVolumeClaim (PVC) paradigms to manage storage. This ensures seamless integration with the Container Storage Interface (CSI).
 
 include::modules/virt-storage-pv-csi-overview.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s):
4.20+

Issue:
https://redhat.atlassian.net/browse/DOCPLAN-164

Link to docs preview:
* https://110155--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/storage/install-configure-fusion-access-san.html
* https://110155--ocpdocs-pr.netlify.app/openshift-dedicated/latest/virt/storage/virt-automatic-bootsource-updates.html
* https://110155--ocpdocs-pr.netlify.app/openshift-dedicated/latest/virt/storage/virt-storage-config-overview.html
* https://110155--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/storage/virt-storage-with-csi-paradigm.html
* https://110155--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/creating_vms_advanced/creating_vms_advanced_web/virt-creating-vms-from-rh-images-overview.html

QE review:
NA

Additional information:
Addressed a subset of the DITA/CQA issues. Remaining items will be handled in a follow-up PR. No content was removed. Content that looks like it was removed was preserved and is now correctly located within modules or maintained in the assembly where appropriate.
