### PR TITLE
DOCPLAN-159: node CQA fixes

### DIFF
--- a/modules/virt-configuring-obsolete-cpu-models.adoc
+++ b/modules/virt-configuring-obsolete-cpu-models.adoc
@@ -22,8 +22,9 @@ metadata:
   namespace: {CNVNamespace}
 spec:
   obsoleteCPUs:
-    cpuModels: <1>
+    cpuModels:
       - "<obsolete_cpu_1>"
       - "<obsolete_cpu_2>"
 ----
-<1> Replace the example values in the `cpuModels` array with obsolete CPU models. Any value that you specify is added to a predefined list of obsolete CPU models. The predefined list is not visible in the CR.
++
+Replace the example values in the `cpuModels` array with obsolete CPU models. Any value that you specify is added to a predefined list of obsolete CPU models. The predefined list is not visible in the CR.

--- a/virt/nodes/virt-managing-node-labeling-obsolete-cpu-models.adoc
+++ b/virt/nodes/virt-managing-node-labeling-obsolete-cpu-models.adoc
@@ -1,13 +1,13 @@
 :_mod-docs-content-type: ASSEMBLY
+include::_attributes/common-attributes.adoc[]
 [id="virt-managing-node-labeling-obsolete-cpu-models"]
 = Managing node labeling for obsolete CPU models
-include::_attributes/common-attributes.adoc[]
 :context: virt-managing-node-labeling-obsolete-cpu-models
 
 toc::[]
 
 [role="_abstract"]
-You can schedule a virtual machine (VM) on a node as long as the VM CPU model and policy are supported by the node.
+You can schedule a virtual machine (VM) on a node if the VM CPU model and policy are supported by the node.
 
 include::modules/virt-about-node-labeling-obsolete-cpu-models.adoc[leveloffset=+1]
 

--- a/virt/nodes/virt-preventing-node-reconciliation.adoc
+++ b/virt/nodes/virt-preventing-node-reconciliation.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: ASSEMBLY
+include::_attributes/common-attributes.adoc[]
 [id="virt-using-skip-node"]
 = Preventing node reconciliation
-include::_attributes/common-attributes.adoc[]
 :context: virt-preventing-node-reconciliation
 
 toc::[]


### PR DESCRIPTION
Version(s):
4.20+

Issue:
https://redhat.atlassian.net/browse/DOCPLAN-159

Link to docs preview:
- https://110168--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/nodes/virt-managing-node-labeling-obsolete-cpu-models.html#virt-configuring-obsolete-cpu-models_virt-managing-node-labeling-obsolete-cpu-models
- https://110168--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/nodes/virt-managing-node-labeling-obsolete-cpu-models

QE review:
n/a

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
