### PR TITLE
OSDOCS-19127: Fixes ccoctl help output

### DIFF
--- a/modules/cco-ccoctl-configuring.adoc
+++ b/modules/cco-ccoctl-configuring.adoc
@@ -245,7 +245,7 @@ Available Commands:
   azure        Manage credentials objects for Azure
   gcp          Manage credentials objects for Google cloud
   help         Help about any command
-  ibmcloud     Manage credentials objects for {ibm-cloud-title}
+  ibmcloud     Manage credentials objects for IBM Cloud
   nutanix      Manage credentials objects for Nutanix
 
 Flags:


### PR DESCRIPTION
Version(s):
4.17+

Issue:
[OSDOCS-19127](https://redhat.atlassian.net/browse/OSDOCS-19127)

Link to docs preview:


SEM review:
N/A

Additional information:
Noticed this render issue while doing other work (this is verbatim output and shouldn't use an attribute anyway, it should reflect what the code has in it). [The change introducing the error](https://github.com/openshift/openshift-docs/pull/82684/changes#diff-6f0f1b2e8660fb0a6c03a6ceee1cc76715790953c8a035a09fdc0009b6dd8271) is from #82684, which was picked into 4.17+

<img width="627" height="409" alt="image" src="https://github.com/user-attachments/assets/dc7ab69d-cfaf-475b-9635-95f329144160" />
