### PR TITLE
OSDOCS-19132: fix ifdef whoopsie (review but do not merge)

### DIFF
--- a/modules/cco-ccoctl-deleting-sts-resources.adoc
+++ b/modules/cco-ccoctl-deleting-sts-resources.adoc
@@ -59,7 +59,7 @@ $ oc adm release extract \
 where:
 
 `--included`:: The parameter includes only the manifests that your specific cluster configuration requires.
-`<path_to_directory_for_credentials_requests>':: Specify the path to the directory where you want to store the `CredentialsRequest` objects. If the specified directory does not exist, this command creates it.
+`<path_to_directory_for_credentials_requests>`:: Specify the path to the directory where you want to store the `CredentialsRequest` objects. If the specified directory does not exist, this command creates it.
 
 . Delete the {cp} resources that `ccoctl` created by running the following command:
 endif::gcp-workload-id[]
@@ -71,8 +71,7 @@ endif::aws-sts,azure-workload-id[]
 ----
 $ ccoctl {cp-name} delete \
   --name=<name> \
-ifdef::aws-sts
-[  --region=<{cp-name}_region>]
+ifdef::aws-sts[  --region=<{cp-name}_region>]
 ifdef::gcp-workload-id[]
   --project=<{cp-name}_project_id> \
   --credentials-requests-dir=<path_to_credentials_requests_directory> \


### PR DESCRIPTION
Version(s):
4.18+ (likely, will inspect cherrypicks)

Issue:
[OSDOCS-19132](https://redhat.atlassian.net/browse/OSDOCS-19132)

Link to docs preview:
- [AWS](https://110191--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/uninstalling-cluster-aws.html#cco-ccoctl-deleting-sts-resources_uninstall-cluster-aws)
- [Azure](https://110191--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_azure/uninstalling-cluster-azure.html#cco-ccoctl-deleting-sts-resources_uninstall-cluster-azure)
- [Google](https://110191--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_gcp/uninstalling-cluster-gcp.html#cco-ccoctl-deleting-sts-resources_uninstalling-cluster-gcp)

SME review:
N/A

Additional information: 
Noticed while doing other work, quick fix to tiny errors from #103257 
<img width="749" height="461" alt="image" src="https://github.com/user-attachments/assets/db431fb1-b179-4401-a56f-30325da9de7f" />


Please review but do not merge while I wait for version confirmation