### PR TITLE
OSDOCS-18876 - Reformatting ROSA and OSD release notes

### DIFF
--- a/modules/osd-release-notes-Q1-2024.adoc
+++ b/modules/osd-release-notes-Q1-2024.adoc
@@ -8,6 +8,10 @@
 [role="_abstract"]
 The following items were added during the first quarter of 2024.
 
-* **{product-title} regions added.** {product-title} on {GCP} is now available in the Delhi, India (`asia-south2`) region. For more information on region availabilities, see link:https://docs.redhat.com/en/documentation/openshift_dedicated/4/html/introduction_to_openshift_dedicated/policies-and-service-definition#regions-availability-zones_osd-service-definition[Regions and availability zones].
+{product-title} regions added::
++
+{product-title} on {GCP} is now available in the Delhi, India (`asia-south2`) region. For more information on region availabilities, see link:https://docs.redhat.com/en/documentation/openshift_dedicated/4/html/introduction_to_openshift_dedicated/policies-and-service-definition#regions-availability-zones_osd-service-definition[Regions and availability zones].
 
-* **Policy constraint update.** {product-title} on {GCP} users are now allowed to deploy clusters with the `constraints/iam.allowedPolicyMemberDomains` constraint in place. This feature allows users to restrict the set of identities that are allowed to be used in Identity and Access Management policies, further enhancing overall security for their resources.
+Policy constraint update::
++
+{product-title} on {GCP} users are now allowed to deploy clusters with the `constraints/iam.allowedPolicyMemberDomains` constraint in place. This feature allows users to restrict the set of identities that are allowed to be used in Identity and Access Management policies, further enhancing overall security for their resources.

--- a/modules/osd-release-notes-Q1-2025.adoc
+++ b/modules/osd-release-notes-Q1-2025.adoc
@@ -8,23 +8,34 @@
 [role="_abstract"]
 The following items were added during the first quarter of 2025.
 
-* **Support for new {gcp-short} instances.** {product-title} version 4.18 and later now supports `n4` and `c3` instance types on {gcp-full}. For more information, see link:https://docs.redhat.com/en/documentation/openshift_dedicated/4/html/introduction_to_openshift_dedicated/policies-and-service-definition#gcp-compute-types_osd-service-definition[{gcp-full} compute types].
+Support for new {gcp-short} instances::
++
+{product-title} version 4.18 and later now supports `n4` and `c3` instance types on {gcp-full}. For more information, see link:https://docs.redhat.com/en/documentation/openshift_dedicated/4/html/introduction_to_openshift_dedicated/policies-and-service-definition#gcp-compute-types_osd-service-definition[{gcp-full} compute types].
 
-* **New version of {product-title} available.** {product-title} on {gcp} and {product-title} on {aws} versions 4.18 are now available. For more information about upgrading to this latest version, see link:https://docs.redhat.com/en/documentation/openshift_dedicated/4/html/upgrading/osd-upgrades[OpenShift Dedicated cluster upgrades].
+New version of {product-title} available::
++
+{product-title} on {gcp} and {product-title} on {aws} versions 4.18 are now available. For more information about upgrading to this latest version, see link:https://docs.redhat.com/en/documentation/openshift_dedicated/4/html/upgrading/osd-upgrades[OpenShift Dedicated cluster upgrades].
 
-* **Support for assigning newly created machine pools to specific availability zones within a Multi-AZ cluster.**
+Support for assigning newly created machine pools to specific availability zones within a Multi-AZ cluster::
++
 {product-title} on {GCP} users can now assign machine pools to specific availability zones using the {cluster-manager} command line interface (CLI) (`ocm`). For more information, see link:https://docs.redhat.com/en/documentation/openshift_dedicated/4/html/cluster_administration/managing-compute-nodes-using-machine-pools#deploying-a-machine-pool-in-a-single-availability-zone-within-a-multi-az-cluster[Deploying a machine pool in a single availability zone within a Multi-AZ cluster].
 
-* ** Support for specifying {product-title} versions when creating or updating a Workload Identity Federation (WIF) configuration.**
+Support for specifying {product-title} versions when creating or updating a Workload Identity Federation (WIF) configuration::
++
 {product-title} on {GCP} users can now specify minor versions when creating or updating a WIF configuration. For more information, see link:https://docs.redhat.com/en/documentation/openshift_dedicated/4/html/openshift_dedicated_clusters_on_google_cloud/osd-creating-a-cluster-on-gcp-with-workload-identity-federation[Creating a Workload Identity Federation cluster using the OCM CLI].
 
-* **Cluster node limit update.** {product-title} clusters versions 4.14.14 and greater can now scale to 249 worker nodes. This is an increase from the previous limit of 180 nodes. For more information, see link:https://docs.redhat.com/en/documentation/openshift_dedicated/4/html/planning_your_environment/osd-limits-scalability[Limits and scalability].
+Cluster node limit update::
++
+{product-title} clusters versions 4.14.14 and greater can now scale to 249 worker nodes. This is an increase from the previous limit of 180 nodes. For more information, see link:https://docs.redhat.com/en/documentation/openshift_dedicated/4/html/planning_your_environment/osd-limits-scalability[Limits and scalability].
 // * **{product-title} SDN network plugin blocks future major upgrades**
-* **Initiate live migration from OpenShift SDN to OVN-Kubernetes.**
+Initiate live migration from OpenShift SDN to OVN-Kubernetes::
++
 As part of the {product-title} move to OVN-Kubernetes as the only supported network plugin starting with {product-title} version 4.17, users can now initiate live migration from the OpenShift SDN network plugin to the OVN-Kubernetes network plugin.
 +
 If your cluster uses the OpenShift SDN network plugin, you cannot upgrade to future major versions of {product-title} without migrating to OVN-Kubernetes.
 +
 For more information about migrating to OVN-Kubernetes, see link:https://docs.redhat.com/en/documentation/openshift_dedicated/4/html/ovn-kubernetes_network_plugin/migrate-from-openshift-sdn-osd[Migrating from OpenShift SDN network plugin to OVN-Kubernetes network plugin].
 
-* **Red{nbsp}Hat SRE log-based alerting endpoints have been updated.** {product-title} customers who are using a firewall to control egress traffic can now remove all references to `*.osdsecuritylogs.splunkcloud.com:9997` from your firewall allowlist. {product-title} clusters still require the `http-inputs-osdsecuritylogs.splunkcloud.com:443` log-based alerting endpoint to be accessible from the cluster.
+Red{nbsp}Hat SRE log-based alerting endpoints have been updated::
++
+{product-title} customers who are using a firewall to control egress traffic can now remove all references to `*.osdsecuritylogs.splunkcloud.com:9997` from your firewall allowlist. {product-title} clusters still require the `http-inputs-osdsecuritylogs.splunkcloud.com:443` log-based alerting endpoint to be accessible from the cluster.

--- a/modules/osd-release-notes-Q1-2026.adoc
+++ b/modules/osd-release-notes-Q1-2026.adoc
@@ -8,24 +8,30 @@
 [role="_abstract"]
 The following items were added during the first quarter of 2026.
 
-*  **Virtualization support for {product-title} on {GCP}.** {product-title} on {GCP} version 4.21.5 now supports running virtualized workloads using the {VirtProductName} Operator version 4.21.1, leveraging {GCP} C3 bare-metal instances and {GCP} Hyperdisk. This enables you to migrate and modernize virtual machines (VMs) from existing platforms directly onto {product-title}, managing them alongside containerized workloads on a single, unified application platform.
+Virtualization support for {product-title} on {GCP}::
++
+{product-title} on {GCP} version 4.21.5 now supports running virtualized workloads using the {VirtProductName} Operator version 4.21.1, leveraging {GCP} C3 bare-metal instances and {GCP} Hyperdisk. This enables you to migrate and modernize virtual machines (VMs) from existing platforms directly onto {product-title}, managing them alongside containerized workloads on a single, unified application platform.
 +
 For more information about using {VirtProductName} on {product-title} on {gcp}, see link:https://docs.redhat.com/en/documentation/openshift_dedicated/4/html/virtualization/index[Virtualization].
 //link to Virtualization 4.21.z release note documentation to be added when available
 
-* **{product-title} now available in {GCP} console.**
+{product-title} now available in {GCP} console::
++
 {product-title} is now available directly within the link:https://console.cloud.google.com/redhat-openshift/landing[{GCP} console], making it easier to find and deploy alongside native {GCP} services. This integration simplifies the initial setup by allowing you to validate environment prerequisites for {product-title} cluster deployment.
 +
 **Key improvements:**
-+
-** Improved discoverability: Locate {product-title} quickly within the {GCP} console alongside Google's native compute and container offerings, allowing you to start creating clusters immediately.
-** Streamlined onboarding: Validate your {GCP} configuration directly in the console before transitioning to a guided deployment flow in the {hybrid-console}.
-** Unified billing and procurement: Use the {GCP} Marketplace to simplify setup and apply your existing {GCP} committed spend, negotiated discounts, or pay-as-you-go pricing.
+
+* Improved discoverability: Locate {product-title} quickly within the {GCP} console alongside Google's native compute and container offerings, allowing you to start creating clusters immediately.
+* Streamlined onboarding: Validate your {GCP} configuration directly in the console before transitioning to a guided deployment flow in the {hybrid-console}.
+* Unified billing and procurement: Use the {GCP} Marketplace to simplify setup and apply your existing {GCP} committed spend, negotiated discounts, or pay-as-you-go pricing.
 
 +
 For more information about deploying {product-title} on {GCP}, see link:https://docs.redhat.com/en/documentation/openshift_dedicated/4/html/planning_your_environment/gcp-ccs#ccs-gcp-understand_gcp-ccs[Understanding Customer Cloud Subscriptions on Google Cloud].
 
-* **Cluster admins can now create multiple users with htpasswd identity providers.** Cluster administrators can now add multiple users to an htpasswd identity providers (IDPs) for {product-title} clusters using the command-line interface (CLI). You can add multiple users to a single htpasswd IDP, streamlining managing user identities. Using the CLI, administrators can add multiple users interactively and noninteractively. For more information, see link:https://docs.redhat.com/en/documentation/openshift_dedicated/4/html/authentication_and_authorization/sd-configuring-identity-providers#config-htpasswd-idp_sd-configuring-identity-providers[Configuring an htpasswd identity provider].
+Cluster admins can now create multiple users with htpasswd identity providers::
++
+Cluster administrators can now add multiple users to an htpasswd identity providers (IDPs) for {product-title} clusters using the command-line interface (CLI). You can add multiple users to a single htpasswd IDP, streamlining managing user identities. Using the CLI, administrators can add multiple users interactively and noninteractively. For more information, see link:https://docs.redhat.com/en/documentation/openshift_dedicated/4/html/authentication_and_authorization/sd-configuring-identity-providers#config-htpasswd-idp_sd-configuring-identity-providers[Configuring an htpasswd identity provider].
 
-* **New version of {product-title} available.** {product-title} on {gcp} and {product-title} on {aws} versions 4.21 are now available for new clusters.
-
+New version of {product-title} available::
++
+{product-title} on {gcp} and {product-title} on {aws} versions 4.21 are now available for new clusters.

--- a/modules/osd-release-notes-Q2-2024.adoc
+++ b/modules/osd-release-notes-Q2-2024.adoc
@@ -8,10 +8,16 @@
 [role="_abstract"]
 The following items were added during the second quarter of 2024.
 
-* **Cluster delete protection.** {product-title} on {GCP}  users can now enable the cluster delete protection option, which helps to prevent users from accidentally deleting a cluster.
+Cluster delete protection::
++
+{product-title} on {GCP}  users can now enable the cluster delete protection option, which helps to prevent users from accidentally deleting a cluster.
 //Removed link as is no longer valid. Need to decide if we need a link here and if so, what it will be.
 // For more information, see xref:../osd_gcp_clusters/creating-a-gcp-cluster.adoc#osd-create-gcp-cluster-ccs_osd-creating-a-cluster-on-gcp[Creating a cluster on GCP with CCS].
 
-* **CSI Operator update.** {product-title} is capable of provisioning persistent volumes (PVs) using the Container Storage Interface (CSI) driver for Google Compute Platform (GCP) Filestore Storage. For more information, see link:https://docs.redhat.com/en/documentation/openshift_dedicated/4/html/storage/using-container-storage-interface-csi#persistent-storage-csi-google-cloud-file[Google Cloud Filestore CSI Driver Operator].
+CSI Operator update::
++
+{product-title} is capable of provisioning persistent volumes (PVs) using the Container Storage Interface (CSI) driver for Google Compute Platform (GCP) Filestore Storage. For more information, see link:https://docs.redhat.com/en/documentation/openshift_dedicated/4/html/storage/using-container-storage-interface-csi#persistent-storage-csi-google-cloud-file[Google Cloud Filestore CSI Driver Operator].
 
-* **Support for new {gcp-short} instances.** {product-title} now supports more worker node types and sizes on {gcp-full}. For more information, see link:https://docs.redhat.com/en/documentation/openshift_dedicated/4/html/introduction_to_openshift_dedicated/policies-and-service-definition#gcp-compute-types_osd-service-definition[{gcp-full} instance types].
+Support for new {gcp-short} instances::
++
+{product-title} now supports more worker node types and sizes on {gcp-full}. For more information, see link:https://docs.redhat.com/en/documentation/openshift_dedicated/4/html/introduction_to_openshift_dedicated/policies-and-service-definition#gcp-compute-types_osd-service-definition[{gcp-full} instance types].

--- a/modules/osd-release-notes-Q2-2025.adoc
+++ b/modules/osd-release-notes-Q2-2025.adoc
@@ -9,14 +9,18 @@
 The following items were added during the second quarter of 2025.
 
 // * **{product-title} SDN network plugin blocks future major upgrades**
-* **Updated version requirements for migration from OpenShift SDN to OVN-Kubernetes.**
+Updated version requirements for migration from OpenShift SDN to OVN-Kubernetes::
++
 Your cluster version must be 4.16.43 or above to initiate live migration from the OpenShift SDN network plugin to the OVN-Kubernetes network plugin.
 +
 If your cluster uses the OpenShift SDN network plugin, you cannot upgrade to future major versions of {product-title} without migrating to OVN-Kubernetes.
 +
 For more information about migrating to OVN-Kubernetes, see link:https://docs.redhat.com/en/documentation/openshift_dedicated/4/html/ovn-kubernetes_network_plugin/migrate-from-openshift-sdn-osd[Migrating from OpenShift SDN network plugin to OVN-Kubernetes network plugin].
 
-* **New version of {product-title} available.** {product-title} on {gcp} and {product-title} on {aws} versions 4.19 are now available for new clusters.
+New version of {product-title} available::
++
+{product-title} on {gcp} and {product-title} on {aws} versions 4.19 are now available for new clusters.
 
-* **Support for enabling and disabling Secure Boot for Shielded VMs on a per machine basis.**
+Support for enabling and disabling Secure Boot for Shielded VMs on a per machine basis::
++
 {product-title} on {GCP} users can now enable or disable Secure Boot for Shielded VMs on a per machine basis. For more information, see link:https://docs.redhat.com/en/documentation/openshift_dedicated/4/html/cluster_administration/managing-compute-nodes-using-machine-pools#osd-managing-worker-nodes[Managing compute nodes].

--- a/modules/osd-release-notes-Q2-2026.adoc
+++ b/modules/osd-release-notes-Q2-2026.adoc
@@ -8,20 +8,28 @@
 [role="_abstract"]
 The following items were added during the second quarter of 2026.
 
-* **{GCP} NetApp Volumes (GCNV) for {VirtProductName} on {GCP}.** {VirtProductName} on {product-title} on {GCP} 4.21 and later now supports link:https://cloud.google.com/netapp/volumes/docs[Google Cloud NetApp Volumes] (GCNV) as a certified NFS storage backend when you use the NetApp Trident CSI Operator version 26.02.0 or later together with {VirtProductName} 4.21.2 or later.
+{GCP} NetApp Volumes (GCNV) for {VirtProductName} on {GCP}::
++
+{VirtProductName} on {product-title} on {GCP} 4.21 and later now supports link:https://cloud.google.com/netapp/volumes/docs[Google Cloud NetApp Volumes] (GCNV) as a certified NFS storage backend when you use the NetApp Trident CSI Operator version 26.02.0 or later together with {VirtProductName} 4.21.2 or later.
 +
 GCNV provides NFS-based shared storage that supports ReadWriteMany (RWX) access in `Filesystem` mode. The NetApp Trident CSI driver provisions GCNV storage volumes.
 +
 For more information about using GCNV with {VirtProductName} on {GCP}, see the following articles in the Red{nbsp}Hat Knowledgebase:
 +
-** link:https://access.redhat.com/articles/7141472[{GCP} with {GCP} NetApp Volumes - Configuration]
-** link:https://access.redhat.com/articles/7141471[{GCP} with {GCP} NetApp Volumes - Known errors and limits]
 
-* **Support for excluding namespaces from default ingress load controller using label selectors.** You can now use the `ocm` CLI to configure default ingress namespace exclusions for your cluster. For more information, see link:https://docs.redhat.com/en/documentation/openshift_dedicated/4/html/networking_operators/configuring-ingress#osd-ingress-excluded-namespaces-ocm-cli_configuring-ingress[Configure excluded namespaces for the default ingress controller].
+* link:https://access.redhat.com/articles/7141472[{GCP} with {GCP} NetApp Volumes - Configuration]
+* link:https://access.redhat.com/articles/7141471[{GCP} with {GCP} NetApp Volumes - Known errors and limits]
 
-* **Support for new {gcp-short} instances.** You can now create clusters with `g2` and `g4` instance types on {product-title} version 4.21 and later. For more information, see link:https://docs.redhat.com/en/documentation/openshift_dedicated/4/html/introduction_to_openshift_dedicated/policies-and-service-definition#gcp-compute-types_osd-service-definition[{gcp-full} instance types].
+Support for excluding namespaces from default ingress load controller using label selectors::
++
+You can now use the `ocm` CLI to configure default ingress namespace exclusions for your cluster. For more information, see link:https://docs.redhat.com/en/documentation/openshift_dedicated/4/html/networking_operators/configuring-ingress#osd-ingress-excluded-namespaces-ocm-cli_configuring-ingress[Configure excluded namespaces for the default ingress controller].
 
-* **{product-title} managed DNS zones now available.**
+Support for new {gcp-short} instances::
++
+You can now create clusters with `g2` and `g4` instance types on {product-title} version 4.21 and later. For more information, see link:https://docs.redhat.com/en/documentation/openshift_dedicated/4/html/introduction_to_openshift_dedicated/policies-and-service-definition#gcp-compute-types_osd-service-definition[{gcp-full} instance types].
+
+{product-title} managed DNS zones now available::
++
 You can now create and manage your own DNS zones for Shared VPC deployments on {GCP}, giving you greater control over your {product-title} cluster's network configuration and security. This new capability allows you to maintain ownership of your DNS infrastructure while still leveraging the powerful features of {product-title}.
 +
 By using managed DNS zones, you can ensure that your cluster's DNS records are managed according to your organization's policies and compliance requirements, without granting broad administrative access to your host projects. This improvement enhances security and provides a more flexible deployment option for customers with strict governance needs.
@@ -30,5 +38,6 @@ To support these managed DNS zones, additional permissions have been added to th
 +
 For more information about managed DNS zones for {product-title} on {GCP}, see link:https://docs.redhat.com/en/documentation/openshift_dedicated/4/html/planning_your_environment/gcp-ccs#ocm-cli-create-managed-dns-zone_gcp-ccs[Creating a managed DNS zone].
 
-* **Support for new {gcp-short} instances.** {product-title} version 4.18 and later now supports `c2d`, `c3d`, `n2d` and `t2d` instance types on {gcp-full}. For more information, see link:https://docs.redhat.com/en/documentation/openshift_dedicated/4/html/introduction_to_openshift_dedicated/policies-and-service-definition#gcp-compute-types_osd-service-definition[{gcp-full} compute types].
-
+Support for new {gcp-short} instances::
++
+{product-title} version 4.18 and later now supports `c2d`, `c3d`, `n2d` and `t2d` instance types on {gcp-full}. For more information, see link:https://docs.redhat.com/en/documentation/openshift_dedicated/4/html/introduction_to_openshift_dedicated/policies-and-service-definition#gcp-compute-types_osd-service-definition[{gcp-full} compute types].

--- a/modules/osd-release-notes-Q3-2024.adoc
+++ b/modules/osd-release-notes-Q3-2024.adoc
@@ -8,21 +8,26 @@
 [role="_abstract"]
 The following items were added during the third quarter of 2024.
 
-* ** Support for {gcp-short} A2 instance types with A100 80GB GPUs.** {product-title} on {GCP} now supports A2 instance types with A100 80GB GPUs. These instance types meet the specific requirements listed by IBM Watsonx.ai. For more information, see link:https://docs.redhat.com/en/documentation/openshift_dedicated/4/html/introduction_to_openshift_dedicated/policies-and-service-definition#gcp-compute-types_osd-service-definition[{gcp-full} instance types].
+Support for {gcp-short} A2 instance types with A100 80GB GPUs::
++
+{product-title} on {GCP} now supports A2 instance types with A100 80GB GPUs. These instance types meet the specific requirements listed by IBM Watsonx.ai. For more information, see link:https://docs.redhat.com/en/documentation/openshift_dedicated/4/html/introduction_to_openshift_dedicated/policies-and-service-definition#gcp-compute-types_osd-service-definition[{gcp-full} instance types].
 
-* **Expanded support for {gcp-short} standard instance types.** {product-title} on {GCP} now supports standard instance types for control plane and infrastructure nodes.
+Expanded support for {gcp-short} standard instance types::
++
+{product-title} on {GCP} now supports standard instance types for control plane and infrastructure nodes.
 For more information, see link:https://docs.redhat.com/en/documentation/openshift_dedicated/4/html/planning_your_environment/osd-limits-scalability#control-plane-and-infra-node-sizing-and-scaling-sd_osd-limits-scalability[Control plane and infrastructure node sizing and scaling].
 
-* **{product-title} regions added.** {product-title} on {GCP} is now available in the following additional regions:
+{product-title} regions added::
 +
---
-** Melbourne (`australia-southeast2`)
-** Milan (`europe-west8`)
-** Turin (`europe-west12`)
-** Madrid (`europe-southwest1`)
-** Santiago (`southamerica-west1`)
-** Doha (`me-central1`)
-** Dammam (`me-central2`)
---
+{product-title} on {GCP} is now available in the following additional regions:
+
+* Melbourne (`australia-southeast2`)
+* Milan (`europe-west8`)
+* Turin (`europe-west12`)
+* Madrid (`europe-southwest1`)
+* Santiago (`southamerica-west1`)
+* Doha (`me-central1`)
+* Dammam (`me-central2`)
+
 +
 For more information about region availabilities, see link:https://docs.redhat.com/en/documentation/openshift_dedicated/4/html/introduction_to_openshift_dedicated/policies-and-service-definition#regions-availability-zones_osd-service-definition[Regions and availability zones].

--- a/modules/osd-release-notes-Q3-2025.adoc
+++ b/modules/osd-release-notes-Q3-2025.adoc
@@ -8,18 +8,22 @@
 [role="_abstract"]
 The following items were added during the third quarter of 2025.
 
-* **Updates to Workload Identity Federation (WIF) permissions and roles.**
+Updates to Workload Identity Federation (WIF) permissions and roles::
++
 The default IAM permissions for WIF in the link:https://github.com/openshift/managed-cluster-config/blob/master/resources/wif/4.19/vanilla.yaml[managed-cluster-config] template have been updated. This means newly created WIF configurations will have fewer, less overly permissive permissions by default.
-** The `sd-sre-platform-gcp-access@redhat.com` principal no longer needs the `compute.firewalls.create` permission. If Red{nbsp}Hat site reliability engineering (SRE) ever need this permission, they will reach out through a support case.
-** The `osd-deployer` service account no longer requires the `resourcemanager.projects.setIamPolicy` permission, which has been removed.
-** The `osd-deployer` service account no longer uses the `iam.serviceAccounts.signBlob` permission. This has been replaced with the `iam.serviceAccountTokenCreator` role, which is now specifically assigned to the service accounts that require it.
-** The `osd-deployer` service account no longer uses the `iam.serviceAccounts.actAs` permission. This has been replaced with the `iam.serviceAccountUser` role, which is now specifically assigned to the service accounts that require it.
+
+* The `sd-sre-platform-gcp-access@redhat.com` principal no longer needs the `compute.firewalls.create` permission. If Red{nbsp}Hat site reliability engineering (SRE) ever need this permission, they will reach out through a support case.
+* The `osd-deployer` service account no longer requires the `resourcemanager.projects.setIamPolicy` permission, which has been removed.
+* The `osd-deployer` service account no longer uses the `iam.serviceAccounts.signBlob` permission. This has been replaced with the `iam.serviceAccountTokenCreator` role, which is now specifically assigned to the service accounts that require it.
+* The `osd-deployer` service account no longer uses the `iam.serviceAccounts.actAs` permission. This has been replaced with the `iam.serviceAccountUser` role, which is now specifically assigned to the service accounts that require it.
 
 +
 If you have existing `wif-config` instances, you can get these new, less permissive permissions by running the `ocm gcp update wif-config` command. For more information, see link:https://docs.redhat.com/en/documentation/openshift_dedicated/4/html/openshift_dedicated_clusters_on_google_cloud/osd-creating-a-cluster-on-gcp-with-workload-identity-federation#wif-configuration-update_osd-creating-a-cluster-on-gcp-with-workload-identity-federation[Updating a Workload Identify Federation configuration].
 
-* **Workload Identify Federation (WIF) is now the default authentication type for {product-title} clusters on {GCP}.**
+Workload Identify Federation (WIF) is now the default authentication type for {product-title} clusters on {GCP}::
++
 In alignment with the principle of least privilege as well as {gcp-full}'s preferred method of credential authentication, WIF is now the default authentication type when creating an {product-title} cluster on {GCP}. WIF greatly improves an {product-title} cluster's resilience against unauthorized access by using short-lived, least-privilege credentials and eliminating the need for static service account keys. For more information, see link:https://docs.redhat.com/en/documentation/openshift_dedicated/4/html/openshift_dedicated_clusters_on_google_cloud/osd-creating-a-cluster-on-gcp-with-workload-identity-federation[Creating a cluster on {gcp-short} with Workload Identity Federation authentication].
 
-* **Support for managing workload identity pools and providers in a dedicated {GCP} project.**
+Support for managing workload identity pools and providers in a dedicated {GCP} project::
++
 {product-title} on {GCP} now supports the option of creating and managing workload identity pools and providers in a specified dedicated project during the creation of a WIF configuration. Red{nbsp}Hat plans on offering this option for existing WIF configurations in an upcoming release. For more information, see link:https://docs.redhat.com/en/documentation/openshift_dedicated/4/html/openshift_dedicated_clusters_on_google_cloud/osd-creating-a-cluster-on-gcp-with-workload-identity-federation#create-wif-configuration_osd-creating-a-cluster-on-gcp-with-workload-identity-federation[Creating a Workload Identify Federation configuration].

--- a/modules/osd-release-notes-Q4-2023.adoc
+++ b/modules/osd-release-notes-Q4-2023.adoc
@@ -8,8 +8,14 @@
 [role="_abstract"]
 The following items were added during the fourth quarter of 2023.
 
-* **Policy constraint update.** {product-title} on {gcp-full} users can now enable UEFISecureBoot during cluster installation, as required by the {gcp-full} ShieldVM policy. This new feature adds further protection from boot or kernel-level malware or rootkits.
+Policy constraint update::
++
+{product-title} on {gcp-full} users can now enable UEFISecureBoot during cluster installation, as required by the {gcp-full} ShieldVM policy. This new feature adds further protection from boot or kernel-level malware or rootkits.
 
-* **Cluster install update.** {product-title} clusters can now be installed on {gcp-full} shared VPCs.
+Cluster install update::
++
+{product-title} clusters can now be installed on {gcp-full} shared VPCs.
 
-* **{product-title} on {gcp-full} Marketplace availability.** When creating an {product-title} cluster on {gcp-full} through the Hybrid Cloud Console, customers can now select {gcp-full} Marketplace as their preferred billing model. This billing model allows Red{nbsp}Hat customers to take advantage of their link:https://cloud.google.com/docs/cuds[Google Committed Use Discounts (CUD)] towards {product-title} purchased through the {gcp-full} Marketplace.
+{product-title} on {gcp-full} Marketplace availability::
++
+When creating an {product-title} cluster on {gcp-full} through the Hybrid Cloud Console, customers can now select {gcp-full} Marketplace as their preferred billing model. This billing model allows Red{nbsp}Hat customers to take advantage of their link:https://cloud.google.com/docs/cuds[Google Committed Use Discounts (CUD)] towards {product-title} purchased through the {gcp-full} Marketplace.

--- a/modules/osd-release-notes-Q4-2024.adoc
+++ b/modules/osd-release-notes-Q4-2024.adoc
@@ -8,16 +8,21 @@
 [role="_abstract"]
 The following items were added during the fourth quarter of 2024.
 
-* **Workload Identity Federation (WIF) authentication type is now available.** {product-title} on {gcp-first} customers can now use WIF as an authentication type when creating a cluster. WIF is a {gcp-short} Identity and Access Management (IAM) feature that provides third parties a secure method to access resources on a customer's cloud account.
-WIF is {gcp-full}'s preferred method for credential authentication.
+Workload Identity Federation (WIF) authentication type is now available::
++
+{product-title} on {gcp-first} customers can now use WIF as an authentication type when creating a cluster. WIF is a {gcp-short} Identity and Access Management (IAM) feature that provides third parties a secure method to access resources on a customer's cloud account. WIF is {gcp-full}'s preferred method for credential authentication.
 +
 For more information, see
 link:https://docs.redhat.com/en/documentation/openshift_dedicated/4/html/openshift_dedicated_clusters_on_google_cloud/osd-creating-a-cluster-on-gcp-with-workload-identity-federation[Creating a cluster on {gcp-short} with Workload Identity Federation authentication].
 
-* **Private Service Connect (PSC) networking feature is now available.** You can now create a private {product-title} cluster on {gcp-first} using {gcp-full}'s security-enhanced networking feature Private Service Connect (PSC).
+Private Service Connect (PSC) networking feature is now available::
++
+You can now create a private {product-title} cluster on {gcp-first} using {gcp-full}'s security-enhanced networking feature Private Service Connect (PSC).
 +
 PSC is a capability of {gcp-full} networking that enables private communication between services across different {gcp-short} projects or organizations. Implementing PSC as part of your network connectivity allows you to deploy OpenShift Dedicated clusters in a private and secured environment within {gcp-short} without using any public-facing cloud resources.
 +
 For more information, see link:https://docs.redhat.com/en/documentation/openshift_dedicated/4/html/openshift_dedicated_clusters_on_google_cloud/creating-a-gcp-psc-enabled-private-cluster[Private Service Connect overview].
 
-* ** Support for {gcp-short} A3 instances with NVIDIA H100 80GB GPUs.** {product-title} on {GCP} now supports A3 instance types with NVIDIA H100 80GB GPUs. The {gcp-short} A3 instance type is available in all three zones of a {gcp-short} region, which is a prerequisite for multiple Availability Zone (Multiple AZ) deployment. For more information, see link:https://docs.redhat.com/en/documentation/openshift_dedicated/4/html/introduction_to_openshift_dedicated/policies-and-service-definition#gcp-compute-types_osd-service-definition[{gcp-full} instance types].
+Support for {gcp-short} A3 instances with NVIDIA H100 80GB GPUs::
++
+{product-title} on {GCP} now supports A3 instance types with NVIDIA H100 80GB GPUs. The {gcp-short} A3 instance type is available in all three zones of a {gcp-short} region, which is a prerequisite for multiple Availability Zone (Multiple AZ) deployment. For more information, see link:https://docs.redhat.com/en/documentation/openshift_dedicated/4/html/introduction_to_openshift_dedicated/policies-and-service-definition#gcp-compute-types_osd-service-definition[{gcp-full} instance types].

--- a/modules/osd-release-notes-Q4-2025.adoc
+++ b/modules/osd-release-notes-Q4-2025.adoc
@@ -8,24 +8,29 @@
 [role="_abstract"]
 The following items were added during the fourth quarter of 2025.
 
-* **Support for managing workload identity pools and providers in a dedicated {GCP} project.**
+Support for managing workload identity pools and providers in a dedicated {GCP} project::
++
 {product-title} on {GCP} now lets you update an existing Workload Identity Federation (WIF) configuration to use a dedicated project for managing workload identity pools and providers.
 For more information, see link:http://docs.redhat.com/en/documentation/openshift_dedicated/4/html-single/openshift_dedicated_clusters_on_google_cloud/index#wif-configuration-update_osd-creating-a-cluster-on-gcp-with-workload-identity-federation[Updating a Workload Identity Federation configuration].
 
-* **Required API services table updated.**
+Required API services table updated::
++
 The _Required API services_ table within the _Required customer procedure_ guide has been updated to restore APIs that were previously removed due to a bug. These APIs are required for new {product-title} on {GCP} cluster creation.
 +
 The APIs that were restored are:
+
+* link:https://cloud.google.com/apis/docs/overview[Google Cloud APIs]
+* link:https://cloud.google.com/firewall/docs/reference/network-security/rest[Network Security API]
+
 +
---
-** link:https://cloud.google.com/apis/docs/overview[Google Cloud APIs]
-** link:https://cloud.google.com/firewall/docs/reference/network-security/rest[Network Security API]
---
 For more information, see the _Required API services_ table in the link:https://docs.redhat.com/en/documentation/openshift_dedicated/4/html/planning_your_environment/gcp-ccs#ccs-gcp-customer-procedure_gcp-ccs[Required customer procedure].
 
-* **New version of {product-title} available.** {product-title} on {gcp} and {product-title} on {aws} versions 4.20 are now available for new clusters.
+New version of {product-title} available::
++
+{product-title} on {gcp} and {product-title} on {aws} versions 4.20 are now available for new clusters.
 
-* **Extended Update Support (EUS) channel group now available.**
+Extended Update Support (EUS) channel group now available::
++
 You can now select the EUS channel group when creating or editing your {product-title} cluster. The EUS channel group allows you to extend the life cycle of your even-numbered version {product-title} cluster, giving you additional time to plan and budget for future upgrades. This channel group also provides continued security patches and critical bug fixes.
 +
 For additional information, see link:https://docs.redhat.com/en/documentation/openshift_dedicated/4/html/introduction_to_openshift_dedicated/policies-and-service-definition#sd-life-cycle-dates_osd-life-cycle[Life cycle dates].

--- a/modules/rosa-release-notes-Q1-2023.adoc
+++ b/modules/rosa-release-notes-Q1-2023.adoc
@@ -5,7 +5,9 @@
 [id="rosa-q1-2023_{context}"]
 = Q1 2023
 
-[role="_abstract"] 
+[role="_abstract"]
 The following items were added during the first quarter of 2023.
 
-* **OIDC provider endpoint URL update.** Starting with ROSA CLI version 1.2.7, all new cluster OIDC provider endpoint URLs are no longer regional. Amazon CloudFront is part of this implementation to improve access speed, reduce latency, and improve resiliency. This change is only available for new clusters created with ROSA CLI 1.2.7 or later. There are no supported migration paths for existing OIDC provider configurations.
+OIDC provider endpoint URL update::
++
+Starting with ROSA CLI version 1.2.7, all new cluster OIDC provider endpoint URLs are no longer regional. Amazon CloudFront is part of this implementation to improve access speed, reduce latency, and improve resiliency. This change is only available for new clusters created with ROSA CLI 1.2.7 or later. There are no supported migration paths for existing OIDC provider configurations.

--- a/modules/rosa-release-notes-Q1-2024.adoc
+++ b/modules/rosa-release-notes-Q1-2024.adoc
@@ -5,14 +5,18 @@
 [id="rosa-q1-2024_{context}"]
 = Q1 2024
 
-[role="_abstract"] 
+[role="_abstract"]
 The following items were added during the first quarter of 2024.
 
 ifdef::openshift-rosa-hcp[]
-* **Machine pool update.** You can now upgrade machine pools that are configured on ROSA with HCP clusters. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html-single/cli_tools/#rosa-upgrade-machinepool_rosa-managing-objects-cli[upgrade machinepool].
-
-* **{product-title} regions added.** {product-title} is now available in the following regions:
+Machine pool update::
 +
+You can now upgrade machine pools that are configured on ROSA with HCP clusters. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html-single/cli_tools/#rosa-upgrade-machinepool_rosa-managing-objects-cli[upgrade machinepool].
+
+{product-title} regions added::
++
+{product-title} is now available in the following regions:
+
 ** Hyderabad (`ap-south-2`)
 ** Milan (`eu-south-1`)
 ** London (`eu-west-2`)
@@ -20,11 +24,14 @@ ifdef::openshift-rosa-hcp[]
 ** Cape Town (`af-south-1`)
 ** Seoul (`ap-northeast-2`)
 ** Stockholm (`eu-north-1`)
+
 +
 For more information on region availabilities, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html-single/introduction_to_rosa/#rosa-sdpolicy-regions-az_rosa-hcp-service-definition[Regions and availability zones].
 endif::openshift-rosa-hcp[]
 
-* **ROSA CLI update.** The ROSA CLI (`rosa`) was updated to a new version. For information about what has changed in this release, see the link:https://github.com/openshift/rosa/releases/tag/v1.2.36[ROSA CLI release notes]. For more information about the ROSA CLI (`rosa`), see 
+ROSA CLI update::
++
+The ROSA CLI (`rosa`) was updated to a new version. For information about what has changed in this release, see the link:https://github.com/openshift/rosa/releases/tag/v1.2.36[ROSA CLI release notes]. For more information about the ROSA CLI (`rosa`), see
 ifdef::openshift-rosa[]
 link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws_classic_architecture/4/html-single/cli_tools/#rosa-about_rosa-getting-started-cli[About the ROSA CLI].
 endif::openshift-rosa[]
@@ -32,9 +39,13 @@ ifdef::openshift-rosa-hcp[]
 link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html-single/cli_tools/index#rosa-about_rosa-getting-started-cli[About the ROSA CLI].
 endif::openshift-rosa-hcp[]
 
-* **Log linking is enabled by default.** Beginning with {product-title} 4.15, log linking is enabled by default. Log linking gives you access to the container logs for your pods.
+Log linking is enabled by default::
++
+Beginning with {product-title} 4.15, log linking is enabled by default. Log linking gives you access to the container logs for your pods.
 
-* **Availability zone update.** You can now optionally select a single availability zone (AZ) for machine pools when you have a multi-AZ cluster. For more information, see 
+Availability zone update::
++
+You can now optionally select a single availability zone (AZ) for machine pools when you have a multi-AZ cluster. For more information, see
 ifdef::openshift-rosa[]
 link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws_classic_architecture/4/html-single/cluster_administration/#creating_machine_pools_cli_rosa-managing-worker-nodes[Creating a machine pool using the ROSA CLI].
 endif::openshift-rosa[]
@@ -42,7 +53,9 @@ ifdef::openshift-rosa-hcp[]
 link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html-single/cluster_administration/index#creating_machine_pools_cli_rosa-managing-worker-nodes[Creating a machine pool using the ROSA CLI].
 endif::openshift-rosa-hcp[]
 
-* **Delete cluster command enhancement.** With the release of ROSA CLI (`rosa`) version 1.2.31, the `--best-effort` argument was added, which allows you to force-delete clusters when using the `rosa delete cluster` command. For more information, see 
+Delete cluster command enhancement::
++
+With the release of ROSA CLI (`rosa`) version 1.2.31, the `--best-effort` argument was added, which allows you to force-delete clusters when using the `rosa delete cluster` command. For more information, see
 ifdef::openshift-rosa[]
 link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws_classic_architecture/4/html-single/cli_tools/index#rosa-delete-cluster_rosa-managing-objects-cli[delete cluster].
 endif::openshift-rosa[]

--- a/modules/rosa-release-notes-Q1-2025.adoc
+++ b/modules/rosa-release-notes-Q1-2025.adoc
@@ -5,58 +5,85 @@
 [id="rosa-q1-2025_{context}"]
 = Q1 2025
 
-[role="_abstract"] 
+[role="_abstract"]
 The following items were added during the first quarter of 2025.
 
 ifdef::openshift-rosa-hcp[]
-* **Cluster autoscaling is now available for {product-title}.** You can configure cluster autoscaling for {product-title}. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html/cluster_administration/rosa-cluster-autoscaling-hcp#cluster-autoscaler-about_rosa-cluster-autoscaling-hcp[Cluster autoscaling].
+Cluster autoscaling is now available for {product-title}::
++
+You can configure cluster autoscaling for {product-title}. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html/cluster_administration/rosa-cluster-autoscaling-hcp#cluster-autoscaler-about_rosa-cluster-autoscaling-hcp[Cluster autoscaling].
 endif::openshift-rosa-hcp[]
 
 ifdef::openshift-rosa[]
-* **{product-title} region added.** {product-title} is now available in the following regions:
+{product-title} region added::
 +
-** Tel Aviv (`il-central-1`)
-** Calgary (`ca-west-1`)
+{product-title} is now available in the following regions:
+
+* Tel Aviv (`il-central-1`)
+* Calgary (`ca-west-1`)
+
 +
 For more information on region availabilities, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws_classic_architecture/4/html-single/introduction_to_rosa/index#rosa-sdpolicy-regions-az_rosa-service-definition[Regions and availability zones].
 endif::openshift-rosa[]
 
 ifdef::openshift-rosa-hcp[]
-* **{product-title} region added.** {product-title} is now available in the following regions:
+{product-title} region added::
 +
-** Malaysia (`ap-southeast-5`)
-** Tel Aviv (`il-central-1`)
-** Calgary (`ca-west-1`)
+{product-title} is now available in the following regions:
+
+* Malaysia (`ap-southeast-5`)
+* Tel Aviv (`il-central-1`)
+* Calgary (`ca-west-1`)
+
 +
 For more information on region availabilities, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html-single/introduction_to_rosa/index#rosa-sdpolicy-regions-az_rosa-hcp-service-definition[Regions and availability zones].
 endif::openshift-rosa-hcp[]
 
 ifdef::openshift-rosa[]
-* **Cluster autoscaling is now available for {product-title}.** You can configure cluster autoscaling for {product-title}. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws_classic_architecture/4/html-single/cluster_administration/index#rosa-cluster-autoscaling[Cluster autoscaling].
+Cluster autoscaling is now available for {product-title}::
++
+You can configure cluster autoscaling for {product-title}. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws_classic_architecture/4/html-single/cluster_administration/index#rosa-cluster-autoscaling[Cluster autoscaling].
 
-* **New version of {product-title} available.** {product-title} version 4.18 is now available. For more information about upgrading to this latest version, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws_classic_architecture/4/html-single/upgrading/index#rosa-upgrading-sts[Upgrading {product-title} clusters].
+New version of {product-title} available::
++
+{product-title} version 4.18 is now available. For more information about upgrading to this latest version, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws_classic_architecture/4/html-single/upgrading/index#rosa-upgrading-sts[Upgrading {product-title} clusters].
 endif::openshift-rosa[]
 
 ifdef::openshift-rosa-hcp[]
-* **New version of {product-title} available.** {product-title} version 4.18 is now available. For more information about upgrading to this latest version, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html-single/upgrading/index#rosa-hcp-upgrading[Upgrading {product-title} clusters].
+New version of {product-title} available::
++
+{product-title} version 4.18 is now available. For more information about upgrading to this latest version, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html-single/upgrading/index#rosa-hcp-upgrading[Upgrading {product-title} clusters].
 endif::openshift-rosa-hcp[]
 
-* **Graphical installer enhancements.** You can now use the graphical installer in {hybrid-console} to configure the following options when you create your cluster:
-** Configure a `cluster-admin` user and optionally define a custom password.
-** Configure the root disk size for the default machine pool.
+Graphical installer enhancements::
++
+You can now use the graphical installer in {hybrid-console} to configure the following options when you create your cluster:
+
+* Configure a `cluster-admin` user and optionally define a custom password.
+* Configure the root disk size for the default machine pool.
 
 ifdef::openshift-rosa-hcp[]
-* **Image configuration is now available for {product-title}.** You can configure registries within a cluster to exclude some registries or allow only a defined list. It also allows to expose additional trusted bundle for registries to pull from. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html-single/images/index#images-configuration-parameters-hcp_image-configuration-hcp[Image configuration resources for {product-title}].
+Image configuration is now available for {product-title}::
++
+You can configure registries within a cluster to exclude some registries or allow only a defined list. It also allows to expose additional trusted bundle for registries to pull from. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html-single/images/index#images-configuration-parameters-hcp_image-configuration-hcp[Image configuration resources for {product-title}].
 endif::openshift-rosa-hcp[]
 
 ifdef::openshift-rosa[]
-* **{product-title} cluster node limit update.** {product-title} clusters versions 4.14.14 and greater can now scale to 249 worker nodes. This is an increase from the previous limit of 180 nodes.
+{product-title} cluster node limit update::
++
+{product-title} clusters versions 4.14.14 and greater can now scale to 249 worker nodes. This is an increase from the previous limit of 180 nodes.
 
-* **Red{nbsp}Hat SRE log-based alerting endpoints have been updated.** {product-title} customers who are using a firewall to control egress traffic can now remove all references to `*.osdsecuritylogs.splunkcloud.com:9997` from your firewall allowlist. {product-title} clusters still require the `http-inputs-osdsecuritylogs.splunkcloud.com:443` log-based alerting endpoint to be accessible from the cluster.
+Red{nbsp}Hat SRE log-based alerting endpoints have been updated::
++
+{product-title} customers who are using a firewall to control egress traffic can now remove all references to `*.osdsecuritylogs.splunkcloud.com:9997` from your firewall allowlist. {product-title} clusters still require the `http-inputs-osdsecuritylogs.splunkcloud.com:443` log-based alerting endpoint to be accessible from the cluster.
 endif::openshift-rosa[]
 
 ifdef::openshift-rosa-hcp[]
-* **{product-title} now creates independent security groups for the AWS PrivateLink endpoint and worker nodes.** {product-title} clusters version 4.17.2 and greater can now add additional AWS security groups to the AWS PrivateLink endpoint to allow additional ingress traffic to the cluster's API. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html-single/install_clusters/index#rosa-hcp-aws-private-security-groups_rosa-hcp-aws-private-creating-cluster[Adding additional AWS security groups to the AWS PrivateLink endpoint].
+{product-title} now creates independent security groups for the AWS PrivateLink endpoint and worker nodes::
++
+{product-title} clusters version 4.17.2 and greater can now add additional AWS security groups to the AWS PrivateLink endpoint to allow additional ingress traffic to the cluster's API. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html-single/install_clusters/index#rosa-hcp-aws-private-security-groups_rosa-hcp-aws-private-creating-cluster[Adding additional AWS security groups to the AWS PrivateLink endpoint].
 
-* **Egress zero is now generally available on {product-title} clusters.** You can create a fully operational cluster that does not require a public egress by configuring a virtual private cloud (VPC) and using the `--properties zero_egress:true` flag when creating your cluster. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html-single/install_clusters/index#rosa-hcp-egress-zero-install[Creating a {egress-zero-title}].
+Egress zero is now generally available on {product-title} clusters::
++
+You can create a fully operational cluster that does not require a public egress by configuring a virtual private cloud (VPC) and using the `--properties zero_egress:true` flag when creating your cluster. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html-single/install_clusters/index#rosa-hcp-egress-zero-install[Creating a {egress-zero-title}].
 endif::openshift-rosa-hcp[]

--- a/modules/rosa-release-notes-Q1-2026.adoc
+++ b/modules/rosa-release-notes-Q1-2026.adoc
@@ -8,20 +8,30 @@
 [role="_abstract"]
 The following items were added during the first quarter of 2026.
 
-* **Cluster admins can now create multiple users with htpasswd identity providers.** Cluster administrators can now add multiple users to an htpasswd identity providers (IDPs) for {product-title} clusters using the command-line interface (CLI). You can add multiple users to a single htpasswd IDP, streamlining managing user identities. Using the CLI or Terraform, administrators can add users interactively and noninteractively. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html/authentication_and_authorization/sd-configuring-identity-providers#config-htpasswd-idp_sd-configuring-identity-providers[Configuring an htpasswd identity provider].
+Cluster admins can now create multiple users with htpasswd identity providers::
++
+Cluster administrators can now add multiple users to an htpasswd identity providers (IDPs) for {product-title} clusters using the command-line interface (CLI). You can add multiple users to a single htpasswd IDP, streamlining managing user identities. Using the CLI or Terraform, administrators can add users interactively and noninteractively. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html/authentication_and_authorization/sd-configuring-identity-providers#config-htpasswd-idp_sd-configuring-identity-providers[Configuring an htpasswd identity provider].
 
 ifdef::openshift-rosa-hcp[]
-* **Platform monitoring using the Cluster Monitoring Operator.** You can now configure the in-cluster monitoring stack components, metrics, and alerts to monitor both core platform components and user-defined projects. Previously, you could only monitor user-defined projects. This change applies to both new and existing {product-title} clusters. However, it affects them differently.
+Platform monitoring using the Cluster Monitoring Operator::
 +
-** For new clusters created after this change, the default, in-cluster monitoring stack is installed during cluster installation and immediately begins collecting metrics. After installation, you can use the default configuration, or you can modify the monitoring components to suit your needs.
-** For existing clusters created prior to this change, no changes will be made to the cluster's monitoring configuration. However, you can begin to use the core platform monitoring components, and modify them to suit your needs.
+You can now configure the in-cluster monitoring stack components, metrics, and alerts to monitor both core platform components and user-defined projects. Previously, you could only monitor user-defined projects. This change applies to both new and existing {product-title} clusters. However, it affects them differently.
+
+* For new clusters created after this change, the default, in-cluster monitoring stack is installed during cluster installation and immediately begins collecting metrics. After installation, you can use the default configuration, or you can modify the monitoring components to suit your needs.
+* For existing clusters created prior to this change, no changes will be made to the cluster's monitoring configuration. However, you can begin to use the core platform monitoring components, and modify them to suit your needs.
 
 +
 For more information, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html-single/monitoring/index[Monitoring].
 
-* **AWS Windows License Included now available for {product-title}.** You can now add a Windows License Included enabled machine pool to a {product-title} cluster. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html/cluster_administration/managing-compute-nodes-using-machine-pools#creating_a_machine_pools_cli_win_li_rosa-managing-worker-nodes[Creating a machine pool with AWS Windows License Included enabled using the {rosa-cli}].
+AWS Windows License Included now available for {product-title}::
++
+You can now add a Windows License Included enabled machine pool to a {product-title} cluster. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html/cluster_administration/managing-compute-nodes-using-machine-pools#creating_a_machine_pools_cli_win_li_rosa-managing-worker-nodes[Creating a machine pool with AWS Windows License Included enabled using the {rosa-cli}].
 
-* **Updating the global pull secret now available for {product-title} clusters.** You can now modify the global pull secret to include additional pull secrets for accessing container images from private registries. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html/images/managing-images#images-update-global-pull-secret_using-image-pull-secrets[Updating the global cluster pull secret].
+Updating the global pull secret now available for {product-title} clusters::
++
+You can now modify the global pull secret to include additional pull secrets for accessing container images from private registries. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html/images/managing-images#images-update-global-pull-secret_using-image-pull-secrets[Updating the global cluster pull secret].
 endif::openshift-rosa-hcp[]
 
-* **New version of {product-title} available.** {product-title} version 4.21 is now available for new clusters.
+New version of {product-title} available::
++
+{product-title} version 4.21 is now available for new clusters.

--- a/modules/rosa-release-notes-Q2-2023.adoc
+++ b/modules/rosa-release-notes-Q2-2023.adoc
@@ -5,9 +5,13 @@
 [id="rosa-q2-2023_{context}"]
 = Q2 2023
 
-[role="_abstract"] 
+[role="_abstract"]
 The following items were added during the second quarter of 2023.
 
-* **ROSA CLI update.** The ROSA CLI (`rosa`) was updated to a new version. For information about what has changed in this release, see the link:https://github.com/openshift/rosa/releases/tag/v1.2.23[ROSA CLI release notes]. For more information about the ROSA CLI (`rosa`), see link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws_classic_architecture/4/html-single/cli_tools/index#rosa-about_rosa-getting-started-cli[About the ROSA CLI].
+ROSA CLI update::
++
+The ROSA CLI (`rosa`) was updated to a new version. For information about what has changed in this release, see the link:https://github.com/openshift/rosa/releases/tag/v1.2.23[ROSA CLI release notes]. For more information about the ROSA CLI (`rosa`), see link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws_classic_architecture/4/html-single/cli_tools/index#rosa-about_rosa-getting-started-cli[About the ROSA CLI].
 
-* **{product-title}  region added.** {product-title} is now available in the United Arab Emirates (`me-central-1`) region. For more information on region availability, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws_classic_architecture/4/html-single/introduction_to_rosa/index#rosa-sdpolicy-regions-az_rosa-service-definition[Regions and availability zones].
+{product-title} region added::
++
+{product-title} is now available in the United Arab Emirates (`me-central-1`) region. For more information on region availability, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws_classic_architecture/4/html-single/introduction_to_rosa/index#rosa-sdpolicy-regions-az_rosa-service-definition[Regions and availability zones].

--- a/modules/rosa-release-notes-Q2-2024.adoc
+++ b/modules/rosa-release-notes-Q2-2024.adoc
@@ -5,14 +5,18 @@
 [id="rosa-q2-2024_{context}"]
 = Q2 2024
 
-[role="_abstract"] 
+[role="_abstract"]
 The following items were added during the second quarter of 2024.
 
 ifdef::openshift-rosa-hcp[]
-* **Approve additional principals for {product-title} clusters.** You can approve additional user-roles to connect to your cluster's private API server endpoint. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html-single/install_clusters/index#rosa-additional-principals-overview_rosa-hcp-aws-private-creating-cluster[Additional principals on your {product-title} cluster].
+Approve additional principals for {product-title} clusters::
++
+You can approve additional user-roles to connect to your cluster's private API server endpoint. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html-single/install_clusters/index#rosa-additional-principals-overview_rosa-hcp-aws-private-creating-cluster[Additional principals on your {product-title} cluster].
 endif::openshift-rosa-hcp[]
 
-* **ROSA CLI update.** The ROSA CLI (`rosa`) was updated to a new version. For information about what has changed in this release, see the link:https://github.com/openshift/rosa/releases/tag/v1.2.41[ROSA CLI release notes]. For more information about the ROSA CLI (`rosa`), 
+ROSA CLI update::
++
+The ROSA CLI (`rosa`) was updated to a new version. For information about what has changed in this release, see the link:https://github.com/openshift/rosa/releases/tag/v1.2.41[ROSA CLI release notes]. For more information about the ROSA CLI (`rosa`),
 ifdef::openshift-rosa[]
 see link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws_classic_architecture/4/html-single/cli_tools/#rosa-about_rosa-getting-started-cli[About the ROSA CLI].
 endif::openshift-rosa[]
@@ -20,9 +24,11 @@ ifdef::openshift-rosa-hcp[]
 see link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html-single/cli_tools/index#rosa-about_rosa-getting-started-cli[About the ROSA CLI].
 endif::openshift-rosa-hcp[]
 
-* **Approved Access for {product-title} clusters.** Red{nbsp}Hat Site Reliability Engineering (SRE) managing and proactively supporting {product-title} clusters will typically not require elevated access to customer clusters as part of the normal operations. In the unlikely event should Red{nbsp}Hat SRE (Site Reliability Engineer) need elevated access, the _Approved Access_ functionality provides an interface for customers to review and _approve_ or _deny_ access requests.
+Approved Access for {product-title} clusters::
 +
-Elevated access requests to {product-title} clusters and the corresponding cloud accounts can be created by Red{nbsp}Hat SRE either in response to a customer-initiated support ticket or in response to alerts received by a Red{nbsp}Hat SRE, as part of the standard incident response process. For more information, 
+Red{nbsp}Hat Site Reliability Engineering (SRE) managing and proactively supporting {product-title} clusters will typically not require elevated access to customer clusters as part of the normal operations. In the unlikely event should Red{nbsp}Hat SRE (Site Reliability Engineer) need elevated access, the _Approved Access_ functionality provides an interface for customers to review and _approve_ or _deny_ access requests.
++
+Elevated access requests to {product-title} clusters and the corresponding cloud accounts can be created by Red{nbsp}Hat SRE either in response to a customer-initiated support ticket or in response to alerts received by a Red{nbsp}Hat SRE, as part of the standard incident response process. For more information,
 ifdef::openshift-rosa[]
 see link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws_classic_architecture/4/html-single/support/#approved-access[Approved Access].
 endif::openshift-rosa[]
@@ -30,7 +36,9 @@ ifdef::openshift-rosa-hcp[]
 see link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html-single/support/index#approved-access[Approved Access].
 endif::openshift-rosa-hcp[]
 
-* **`rosa` command enhancement.** The `rosa describe` command has a new optional argument, `--get-role-policy-bindings`. This new argument allows users to view the policies attached to STS roles assigned to the selected cluster. For more information, 
+`rosa` command enhancement::
++
+The `rosa describe` command has a new optional argument, `--get-role-policy-bindings`. This new argument allows users to view the policies attached to STS roles assigned to the selected cluster. For more information,
 ifdef::openshift-rosa[]
 see link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws_classic_architecture/4/html-single/cli_tools/index#rosa-describe-cluster_rosa-managing-objects-cli[describe cluster].
 endif::openshift-rosa[]
@@ -38,7 +46,9 @@ ifdef::openshift-rosa-hcp[]
 see link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html-single/cli_tools/index#rosa-describe-cluster_rosa-managing-objects-cli[describe cluster].
 endif::openshift-rosa-hcp[]
 
-* **Expanded customer-managed policy capabilities.** You can now attach customer-managed policies to the IAM roles required to run {product-title} clusters. Furthermore, these customer-managed policies, including the permissions attached to those policies, are not modified during cluster or role upgrades. For more information, 
+Expanded customer-managed policy capabilities::
++
+You can now attach customer-managed policies to the IAM roles required to run {product-title} clusters. Furthermore, these customer-managed policies, including the permissions attached to those policies, are not modified during cluster or role upgrades. For more information,
 ifdef::openshift-rosa[]
 see link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws_classic_architecture/4/html-single/introduction_to_rosa/#rosa-aws-customer-managed-policies_rosa-sts-about-iam-resources[Customer-managed policies].
 endif::openshift-rosa[]
@@ -47,25 +57,36 @@ see link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_a
 endif::openshift-rosa-hcp[]
 
 ifdef::openshift-rosa[]
-* **Permission boundaries for the installer role policy.** You can apply a policy as a _permissions boundary_ on the {product-title} installer role. The combination of policy and boundary policy limits the maximum permissions for the Amazon Web Services(AWS) Identity and Access Management (IAM) entity role. {product-title} includes a set of three prepared permission boundary policy files, with which you can restrict permissions for the installer role since changing the installer policy itself is not supported. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws_classic_architecture/4/html-single/introduction_to_rosa/index#rosa-sts-aws-requirements-attaching-boundary-policy_rosa-sts-about-iam-resources[Permission boundaries for the installer role].
+Permission boundaries for the installer role policy::
++
+You can apply a policy as a _permissions boundary_ on the {product-title} installer role. The combination of policy and boundary policy limits the maximum permissions for the Amazon Web Services(AWS) Identity and Access Management (IAM) entity role. {product-title} includes a set of three prepared permission boundary policy files, with which you can restrict permissions for the installer role since changing the installer policy itself is not supported. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws_classic_architecture/4/html-single/introduction_to_rosa/index#rosa-sts-aws-requirements-attaching-boundary-policy_rosa-sts-about-iam-resources[Permission boundaries for the installer role].
 
-* **Cluster delete protection.** You can now enable the cluster delete protection option, which helps to prevent you from accidentally deleting a cluster. For more information on using the cluster delete protection option with the ROSA CLI, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws_classic_architecture/4/html-single/cli_tools/index#rosa-edit-cluster_rosa-managing-objects-cli[edit cluster]. For more information on using the cluster delete protection option in the UI, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws_classic_architecture/4/html-single/install_rosa_classic_clusters/index#rosa-sts-creating-a-cluster-using-defaults-ocm_rosa-sts-creating-a-cluster-quickly[Creating a cluster with the default options using OpenShift Cluster Manager].
+Cluster delete protection::
++
+You can now enable the cluster delete protection option, which helps to prevent you from accidentally deleting a cluster. For more information on using the cluster delete protection option with the ROSA CLI, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws_classic_architecture/4/html-single/cli_tools/index#rosa-edit-cluster_rosa-managing-objects-cli[edit cluster]. For more information on using the cluster delete protection option in the UI, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws_classic_architecture/4/html-single/install_rosa_classic_clusters/index#rosa-sts-creating-a-cluster-using-defaults-ocm_rosa-sts-creating-a-cluster-quickly[Creating a cluster with the default options using OpenShift Cluster Manager].
 endif::openshift-rosa[]
 ifdef::openshift-rosa-hcp[]
-* **{product-title} regions added.** {product-title} is now available in the following regions:
+{product-title} regions added::
 +
+{product-title} is now available in the following regions:
+
 ** Zurich (`eu-central-2`)
 ** Hong Kong (`ap-east-1`)
 ** Osaka (`ap-northeast-3`)
 ** Spain (`eu-south-2`)
 ** UAE (`me-central-1`)
+
 +
 For more information on region availabilities, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html-single/introduction_to_rosa/index#rosa-sdpolicy-regions-az_rosa-hcp-service-definition[Regions and availability zones].
 
-* **Added support for external authentication providers.** You can now create clusters configured with external authentication providers, such as Microsoft Entra ID and KeyCloak. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html-single/install_clusters/index#rosa-hcp-sts-creating-a-cluster-ext-auth[Creating {product-title} clusters with external authentication].
+Added support for external authentication providers::
++
+You can now create clusters configured with external authentication providers, such as Microsoft Entra ID and KeyCloak. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html-single/install_clusters/index#rosa-hcp-sts-creating-a-cluster-ext-auth[Creating {product-title} clusters with external authentication].
 endif::openshift-rosa-hcp[]
 
-* **Longer cluster names enhancement.** You can now specify a cluster name that is longer than 15 characters. For cluster names that are longer than 15 characters, you can customize the domain prefix for the cluster URL by using the `domain-prefix` flag in the ROSA CLI (`rosa`) or by selecting the **Create custom domain prefix** checkbox in the {hybrid-console}. For more information, 
+Longer cluster names enhancement::
++
+You can now specify a cluster name that is longer than 15 characters. For cluster names that are longer than 15 characters, you can customize the domain prefix for the cluster URL by using the `domain-prefix` flag in the ROSA CLI (`rosa`) or by selecting the **Create custom domain prefix** checkbox in the {hybrid-console}. For more information,
 ifdef::openshift-rosa[]
 see link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws_classic_architecture/4/html-single/cli_tools/index#rosa-create-cluster-command_rosa-managing-objects-cli[create cluster in Managing objects with the ROSA CLI].
 endif::openshift-rosa[]
@@ -74,10 +95,14 @@ see link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_a
 endif::openshift-rosa-hcp[]
 
 ifdef::openshift-rosa-hcp[]
-* **Additional Security Groups for {product-title}.** Starting with ROSA CLI version 1.2.37, you can now use the `--additional-security-group-ids <sec_group_id>` when creating machine pools on {hcp-title} clusters. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html-single/cluster_administration/index#creating_machine_pools_cli_rosa-managing-worker-nodes[Creating a machine pool using the ROSA CLI] and the link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html-single/cli_tools/index#rosa-create-machinepool_rosa-managing-objects-cli[create machinepool] section of the ROSA CLI reference.
+Additional Security Groups for {product-title}::
++
+Starting with ROSA CLI version 1.2.37, you can now use the `--additional-security-group-ids <sec_group_id>` when creating machine pools on {hcp-title} clusters. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html-single/cluster_administration/index#creating_machine_pools_cli_rosa-managing-worker-nodes[Creating a machine pool using the ROSA CLI] and the link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html-single/cli_tools/index#rosa-create-machinepool_rosa-managing-objects-cli[create machinepool] section of the ROSA CLI reference.
 endif::openshift-rosa-hcp[]
 
-* **Node management improvements.** Now, you can perform specific tasks to make clusters more efficient. You can cordon, uncordon, and drain a specific node. For more information, 
+Node management improvements::
++
+Now, you can perform specific tasks to make clusters more efficient. You can cordon, uncordon, and drain a specific node. For more information,
 ifdef::openshift-rosa[]
 see link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws_classic_architecture/4/html-single/nodes/#working-with-nodes[Working with nodes].
 endif::openshift-rosa[]
@@ -86,7 +111,9 @@ see link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_a
 endif::openshift-rosa-hcp[]
 
 ifdef::openshift-rosa-hcp[]
-* **Node drain grace periods.** You can now configure node drain grace periods in {hcp-title} clusters with the `rosa` CLI.
+Node drain grace periods::
++
+You can now configure node drain grace periods in {hcp-title} clusters with the `rosa` CLI.
 +
 For more information about configuring node drain grace periods, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html-single/cluster_administration/index#rosa-node-drain-grace-period_rosa-managing-worker-nodes[Configuring node drain grace periods in {product-title}].
 endif::openshift-rosa-hcp[]

--- a/modules/rosa-release-notes-Q2-2025.adoc
+++ b/modules/rosa-release-notes-Q2-2025.adoc
@@ -5,10 +5,11 @@
 [id="rosa-q2-2025_{context}"]
 = Q2 2025
 
-[role="_abstract"] 
+[role="_abstract"]
 The following items were added during the second quarter of 2025.
 
-* **Updated version requirements for migration from OpenShift SDN to OVN-Kubernetes.**
+Updated version requirements for migration from OpenShift SDN to OVN-Kubernetes::
++
 Your cluster version must be 4.16.43 or above to initiate live migration from the OpenShift SDN network plugin to the OVN-Kubernetes network plugin.
 +
 If your cluster uses the OpenShift SDN network plugin, you cannot upgrade to future major versions of {product-title} without migrating to OVN-Kubernetes.
@@ -17,7 +18,9 @@ ifdef::openshift-rosa[]
 For more information about migrating to OVN-Kubernetes, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws_classic_architecture/4/html-single/ovn-kubernetes_network_plugin/index#migrate-from-openshift-sdn[Migrating from OpenShift SDN network plugin to OVN-Kubernetes network plugin].
 endif::openshift-rosa[]
 
-* **AWS Trainium and Inferentia instance types now supported.** You can now use {AWS} Trainium and Inferentia instance types for your {product-title} clusters. For more information, see
+AWS Trainium and Inferentia instance types now supported::
++
+You can now use {AWS} Trainium and Inferentia instance types for your {product-title} clusters. For more information, see
 ifdef::openshift-rosa[]
 link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws_classic_architecture/4/html-single/introduction_to_rosa/index#rosa-instance-types[{product-title} instance types].
 endif::openshift-rosa[]
@@ -26,13 +29,19 @@ link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4
 endif::openshift-rosa-hcp[]
 
 ifdef::openshift-rosa[]
-* **New version of {product-title} available.** {product-title} version 4.19 is now available for new clusters. For more information about upgrading to this latest version, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws_classic_architecture/4/html/upgrading/rosa-upgrading-sts[Upgrading ROSA (classic architecture) clusters].
+New version of {product-title} available::
++
+{product-title} version 4.19 is now available for new clusters. For more information about upgrading to this latest version, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws_classic_architecture/4/html/upgrading/rosa-upgrading-sts[Upgrading ROSA (classic architecture) clusters].
 endif::openshift-rosa[]
 
 ifdef::openshift-rosa-hcp[]
-* **New version of {product-title} available.** {product-title} version 4.19 is now available for new clusters. For more information about upgrading to this latest version, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html/upgrading/index[Upgrading {hcp-title} clusters].
+New version of {product-title} available::
++
+{product-title} version 4.19 is now available for new clusters. For more information about upgrading to this latest version, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html/upgrading/index[Upgrading {hcp-title} clusters].
 endif::openshift-rosa-hcp[]
 
 ifdef::openshift-rosa[]
-* **{product-title} cluster ownership transfer is now available for {product-title}.** You can now transfer ownership of {product-title} clusters. For more information, see link:https://docs.redhat.com/en/documentation/openshift_cluster_manager/1-latest/html/managing_clusters/assembly-managing-clusters#initiating-rosa-classic-ownership-transfer-proc_downloading-and-updating-pull-secrets[Initiating ownership transfer of a {product-title} cluster].
+{product-title} cluster ownership transfer is now available for {product-title}::
++
+You can now transfer ownership of {product-title} clusters. For more information, see link:https://docs.redhat.com/en/documentation/openshift_cluster_manager/1-latest/html/managing_clusters/assembly-managing-clusters#initiating-rosa-classic-ownership-transfer-proc_downloading-and-updating-pull-secrets[Initiating ownership transfer of a {product-title} cluster].
 endif::openshift-rosa[]

--- a/modules/rosa-release-notes-Q2-2026.adoc
+++ b/modules/rosa-release-notes-Q2-2026.adoc
@@ -9,5 +9,7 @@
 The following items were added during the second quarter of 2026.
 
 ifdef::openshift-rosa-hcp[]
-* **Users can create FIPS-encrypted Red Hat OpenShift Service on AWS clusters**. With this update, you can create Red Hat OpenShift Service on AWS clusters with Federal Information Processing Standards (FIPS) encryption that adhere to the highest data security levels. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html-single/install_clusters/index#rosa-hcp-creating-cluster-with-fips-encryption[Deploying {product-title} clusters using FIPS encryption].
+Users can create FIPS-encrypted Red Hat OpenShift Service on AWS clusters::
++
+With this update, you can create Red Hat OpenShift Service on AWS clusters with Federal Information Processing Standards (FIPS) encryption that adhere to the highest data security levels. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html-single/install_clusters/index#rosa-hcp-creating-cluster-with-fips-encryption[Deploying {product-title} clusters using FIPS encryption].
 endif::openshift-rosa-hcp[]

--- a/modules/rosa-release-notes-Q3-2023.adoc
+++ b/modules/rosa-release-notes-Q3-2023.adoc
@@ -5,19 +5,33 @@
 [id="rosa-q3-2023_{context}"]
 = Q3 2023
 
-[role="_abstract"] 
+[role="_abstract"]
 The following items were added during the third quarter of 2023.
 
-* **ROSA CLI update.** The ROSA CLI (`rosa`) was updated to a new version. For information about what has changed in this release, see the link:https://github.com/openshift/rosa/releases/tag/v1.2.27[ROSA CLI release notes]. For more information about the ROSA CLI (`rosa`), see link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws_classic_architecture/4/html-single/cli_tools/index#rosa-about_rosa-getting-started-cli[About the ROSA CLI].
+ROSA CLI update::
++
+The ROSA CLI (`rosa`) was updated to a new version. For information about what has changed in this release, see the link:https://github.com/openshift/rosa/releases/tag/v1.2.27[ROSA CLI release notes]. For more information about the ROSA CLI (`rosa`), see link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws_classic_architecture/4/html-single/cli_tools/index#rosa-about_rosa-getting-started-cli[About the ROSA CLI].
 
-* **Cluster autoscaling.** You can now enable cluster autoscaling using {product-title} clusters. Cluster autoscaling automatically adjusts the size of a cluster so that all pods have a place to run, and there are no unneeded nodes. You can enable autoscaling during and after cluster creation using either OpenShift Cluster Manager or the ROSA CLI (`rosa`). For more information, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws_classic_architecture/4/html-single/cluster_administration/index#rosa-cluster-autoscaling[Cluster autoscaling].
+Cluster autoscaling::
++
+You can now enable cluster autoscaling using {product-title} clusters. Cluster autoscaling automatically adjusts the size of a cluster so that all pods have a place to run, and there are no unneeded nodes. You can enable autoscaling during and after cluster creation using either OpenShift Cluster Manager or the ROSA CLI (`rosa`). For more information, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws_classic_architecture/4/html-single/cluster_administration/index#rosa-cluster-autoscaling[Cluster autoscaling].
 
-* **Shared virtual private clouds.** {product-title} now supports installing clusters into VPCs shared among AWS accounts that are part of AWS organizations. AWS account installing {rosa-classic-title} clusters can now use shared subnets owned by a management account. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws_classic_architecture/4/html-single/install_rosa_classic_clusters/index#configuring-a-shared-virtual-private-cloud-for-rosa-classic-architecture-clusters[Configuring a shared virtual private cloud for {product-title} clusters].
+Shared virtual private clouds::
++
+{product-title} now supports installing clusters into VPCs shared among AWS accounts that are part of AWS organizations. AWS account installing {rosa-classic-title} clusters can now use shared subnets owned by a management account. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws_classic_architecture/4/html-single/install_rosa_classic_clusters/index#configuring-a-shared-virtual-private-cloud-for-rosa-classic-architecture-clusters[Configuring a shared virtual private cloud for {product-title} clusters].
 
-* **Machine pool disk volume size.** You can now configure your machine pool disk volume size for additional flexibility. You can select your own sizing for the disk volumes of their worker machine pool nodes. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws_classic_architecture/4/html-single/cluster_administration/index#configuring_machine_pool_disk_volumerosa-managing-worker-nodes[Configuring machine pool disk volume].
+Machine pool disk volume size::
++
+You can now configure your machine pool disk volume size for additional flexibility. You can select your own sizing for the disk volumes of their worker machine pool nodes. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws_classic_architecture/4/html-single/cluster_administration/index#configuring_machine_pool_disk_volumerosa-managing-worker-nodes[Configuring machine pool disk volume].
 
-* **Machine pool update.** You can now add taints to the machine pool that is automatically generated during cluster creation. You can also delete this machine pool. This new feature provides more flexibility and cost-effectiveness for cluster administrators, specifically in regards to scaling infrastructure based on changing resource requirements. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws_classic_architecture/4/html-single/cluster_administration/index#creating_a_machine_pool_rosa-managing-worker-nodes[Creating a machine pool].
+Machine pool update::
++
+You can now add taints to the machine pool that is automatically generated during cluster creation. You can also delete this machine pool. This new feature provides more flexibility and cost-effectiveness for cluster administrators, specifically in regards to scaling infrastructure based on changing resource requirements. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws_classic_architecture/4/html-single/cluster_administration/index#creating_a_machine_pool_rosa-managing-worker-nodes[Creating a machine pool].
 
-* **Documentation update.** The CLI Tools section was added to the {product-title} documentation and includes more detailed information to help you fully use all of the supported CLI tools. The ROSA CLI section can now be found nested inside the CLI Tools heading. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws_classic_architecture/4/html-single/cli_tools/index#cli-tools-overview-1[CLI tools overview].
+Documentation update::
++
+The CLI Tools section was added to the {product-title} documentation and includes more detailed information to help you fully use all of the supported CLI tools. The ROSA CLI section can now be found nested inside the CLI Tools heading. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws_classic_architecture/4/html-single/cli_tools/index#cli-tools-overview-1[CLI tools overview].
 
-* **Documentation update.** The Monitoring section in the documentation was expanded and now includes more detailed information to help you conveniently manage your {product-title} clusters. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws_classic_architecture/4/html-single/monitoring/#about-ocp-monitoring[About {product-title} monitoring].
+Documentation update::
++
+The Monitoring section in the documentation was expanded and now includes more detailed information to help you conveniently manage your {product-title} clusters. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws_classic_architecture/4/html-single/monitoring/#about-ocp-monitoring[About {product-title} monitoring].

--- a/modules/rosa-release-notes-Q3-2024.adoc
+++ b/modules/rosa-release-notes-Q3-2024.adoc
@@ -5,21 +5,34 @@
 [id="rosa-q3-2024_{context}"]
 = Q3 2024
 
-[role="_abstract"] 
+[role="_abstract"]
 The following items were added during the third quarter of 2024.
 
 ifdef::openshift-rosa-hcp[]
-* **{product-title} multi-architecture cluster update.** {product-title} clusters created before 25 July, 2024 will migrate to a multi-architecture image on their next upgrade allowing you to use {AWS} Arm-based Graviton instance types for your workloads. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html-single/upgrading/index#rosa-upgrade-options_rosa-hcp-upgrading[Upgrading {hcp-title} clusters].
+{product-title} multi-architecture cluster update::
++
+{product-title} clusters created before 25 July, 2024 will migrate to a multi-architecture image on their next upgrade allowing you to use {AWS} Arm-based Graviton instance types for your workloads. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html-single/upgrading/index#rosa-upgrade-options_rosa-hcp-upgrading[Upgrading {hcp-title} clusters].
 
-* **{product-title} cluster node limit update.** {product-title} clusters can now scale to 500 worker nodes. This is an increase from the previous limit of 250 nodes. The 250 node limit is an increase from the previous limit 90 nodes on 26 August, 2024.
+{product-title} cluster node limit update::
++
+{product-title} clusters can now scale to 500 worker nodes. This is an increase from the previous limit of 250 nodes. The 250 node limit is an increase from the previous limit 90 nodes on 26 August, 2024.
 
-* **IMDSv2 support in {product-title}.** You can now enforce the use of the IMDSv2 endpoint for default machine pool worker nodes on new {product-title} clusters and for new machine pools on existing clusters. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html-single/install_clusters/#rosa-hcp-creating-a-cluster-quickly-terraform[Creating a default {product-title} cluster using Terraform].
+IMDSv2 support in {product-title}::
++
+You can now enforce the use of the IMDSv2 endpoint for default machine pool worker nodes on new {product-title} clusters and for new machine pools on existing clusters. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html-single/install_clusters/#rosa-hcp-creating-a-cluster-quickly-terraform[Creating a default {product-title} cluster using Terraform].
 
-* **Upgrade multiple nodes simultaneously.** You can now configure a machine pool to upgrade multiple nodes simultaneously. Two new machine pool parameters, `max-surge` and `max-unavailable`, give you greater control over how machine pool upgrades occur. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html-single/upgrading/index#rosa-hcp-upgrading[Upgrading {product-title} clusters].
+Upgrade multiple nodes simultaneously::
++
+You can now configure a machine pool to upgrade multiple nodes simultaneously. Two new machine pool parameters, `max-surge` and `max-unavailable`, give you greater control over how machine pool upgrades occur. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html-single/upgrading/index#rosa-hcp-upgrading[Upgrading {product-title} clusters].
 
-* **{product-title} Graviton Arm-based instance types.** You can now use {AWS} Arm-based Graviton instance types for your workloads in {product-title} clusters created after 24 July, 2024. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html-single/introduction_to_rosa/index#rosa-sdpolicy-aws-instance-types-graviton_rosa-hcp-instance-types[AWS Graviton Arm-based instance types].
+{product-title} Graviton Arm-based instance types::
++
+You can now use {AWS} Arm-based Graviton instance types for your workloads in {product-title} clusters created after 24 July, 2024. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html-single/introduction_to_rosa/index#rosa-sdpolicy-aws-instance-types-graviton_rosa-hcp-instance-types[AWS Graviton Arm-based instance types].
 endif::openshift-rosa-hcp[]
-* **ROSA CLI update.** The ROSA CLI (`rosa`) was updated to a new version. For information about what has changed in this release, see the link:https://github.com/openshift/rosa/releases/tag/v1.2.42[ROSA CLI release notes]. For more information about the ROSA CLI (`rosa`), see 
+
+ROSA CLI update::
++
+The ROSA CLI (`rosa`) was updated to a new version. For information about what has changed in this release, see the link:https://github.com/openshift/rosa/releases/tag/v1.2.42[ROSA CLI release notes]. For more information about the ROSA CLI (`rosa`), see
 ifdef::openshift-rosa[]
 link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws_classic_architecture/4/html-single/cli_tools/index#rosa-about_rosa-getting-started-cli[About the ROSA CLI].
 endif::openshift-rosa[]

--- a/modules/rosa-release-notes-Q3-2025.adoc
+++ b/modules/rosa-release-notes-Q3-2025.adoc
@@ -5,16 +5,23 @@
 [id="rosa-q3-2025_{context}"]
 = Q3 2025
 
-[role="_abstract"] 
+[role="_abstract"]
 The following items were added during the third quarter of 2025.
 
 ifdef::openshift-rosa-hcp[]
-* ** New cluster deletion policy.**
+New cluster deletion policy::
++
 {product-title} clusters now have a new deletion policy. This policy is based on a set time period of customer non-response to service notifications. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html-single/introduction_to_rosa/index#rosa-delete-policy_rosa-hcp-life-cycle[Deletion policy]. For specific revised terms and conditions, refer to link:https://www.redhat.com/licenses/Appendix-4-Red-Hat-Online-Services-20250805.pdf[Product Appendix 4].
 
-* **Shared VPC for {product-title} clusters.** You can create {product-title} clusters in shared, centrally-managed AWS virtual private clouds (VPCs). For more information, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html-single/install_clusters/index#rosa-hcp-shared-vpc-config[Configuring a shared VPC for ROSA with HCP clusters].
+Shared VPC for {product-title} clusters::
++
+You can create {product-title} clusters in shared, centrally-managed AWS virtual private clouds (VPCs). For more information, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html-single/install_clusters/index#rosa-hcp-shared-vpc-config[Configuring a shared VPC for ROSA with HCP clusters].
 
-* **Deprecated `--private-link` flags for {product-title} clusters**. Architectural changes to the ROSA CLI 1.2.55 make networking more flexible for {product-title} clusters. The `--private-link` flag previously used when creating a {product-title} cluster is now deprecated in favor of the `--private` and `--default-ingress-private` flags. Now, users can choose to have a combination of a public or private API with a public or private ingress. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html-single/install_clusters/index#rosa-hcp-aws-private-create-cluster_rosa-hcp-aws-private-creating-cluster[Creating a private cluster on {product-title}].
+Deprecated `--private-link` flags for {product-title} clusters::
++
+Architectural changes to the ROSA CLI 1.2.55 make networking more flexible for {product-title} clusters. The `--private-link` flag previously used when creating a {product-title} cluster is now deprecated in favor of the `--private` and `--default-ingress-private` flags. Now, users can choose to have a combination of a public or private API with a public or private ingress. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html-single/install_clusters/index#rosa-hcp-aws-private-create-cluster_rosa-hcp-aws-private-creating-cluster[Creating a private cluster on {product-title}].
 endif::openshift-rosa-hcp[]
 
-* **Changed default ingress listening method to begin with Day 1 operations**. Previously, the default ingress listening method was a Day 2 operation. Now, the default ingress listening method is a Day 1 operation.
+Changed default ingress listening method to begin with Day 1 operations::
++
+Previously, the default ingress listening method was a Day 2 operation. Now, the default ingress listening method is a Day 1 operation.

--- a/modules/rosa-release-notes-Q4-2023.adoc
+++ b/modules/rosa-release-notes-Q4-2023.adoc
@@ -5,21 +5,37 @@
 [id="rosa-q4-2023_{context}"]
 = Q4 2023
 
-[role="_abstract"] 
+[role="_abstract"]
 The following items were added during the fourth quarter of 2023.
 
-* **ROSA CLI update.** The ROSA CLI (`rosa`) was updated to a new version. For information about what has changed in this release, see the link:https://github.com/openshift/rosa/releases/tag/v1.2.32[ROSA CLI release notes]. For more information about the ROSA CLI (`rosa`), see link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws_classic_architecture/4/html-single/cli_tools/#rosa-about_rosa-getting-started-cli[About the ROSA CLI].
+ROSA CLI update::
++
+The ROSA CLI (`rosa`) was updated to a new version. For information about what has changed in this release, see the link:https://github.com/openshift/rosa/releases/tag/v1.2.32[ROSA CLI release notes]. For more information about the ROSA CLI (`rosa`), see link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws_classic_architecture/4/html-single/cli_tools/#rosa-about_rosa-getting-started-cli[About the ROSA CLI].
 
-* **Delete cluster command enhancement.** With the release of ROSA CLI (`rosa`) version 1.2.31, the `--best-effort` argument was added, which allows you to force-delete clusters when using the `rosa delete cluster` command. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws_classic_architecture/4/html-single/cli_tools/index#rosa-delete-cluster_rosa-managing-objects-cli[delete cluster].
+Delete cluster command enhancement::
++
+With the release of ROSA CLI (`rosa`) version 1.2.31, the `--best-effort` argument was added, which allows you to force-delete clusters when using the `rosa delete cluster` command. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws_classic_architecture/4/html-single/cli_tools/index#rosa-delete-cluster_rosa-managing-objects-cli[delete cluster].
 
-* ** {hcp-title-first} that uses {hcp} is now generally available.** For more information, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html/install_clusters/rosa-hcp-sts-creating-a-cluster-quickly[Creating {product-title} clusters using the default options].
+{hcp-title-first} that uses {hcp} is now generally available::
++
+For more information, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html/install_clusters/rosa-hcp-sts-creating-a-cluster-quickly[Creating {product-title} clusters using the default options].
 
-* **Configurable process identifier (PID) limits.** With the release of ROSA CLI (`rosa`) version 1.2.31, administrators can use the `rosa create kubeletconfig` and `rosa edit kubeletconfig` commands to set the maximum PIDs for an existing cluster. For more information, see link:https://access.redhat.com/articles/7033551[Changing the maximum number of process IDs per pod (podPidsLimit) for {product-title}].
+Configurable process identifier (PID) limits::
++
+With the release of ROSA CLI (`rosa`) version 1.2.31, administrators can use the `rosa create kubeletconfig` and `rosa edit kubeletconfig` commands to set the maximum PIDs for an existing cluster. For more information, see link:https://access.redhat.com/articles/7033551[Changing the maximum number of process IDs per pod (podPidsLimit) for {product-title}].
 
-* **Configure custom security groups.** With the release of ROSA CLI (`rosa`) version 1.2.31, administrators can use the `rosa create` command or the OpenShift Cluster Manager to create a new cluster or a new machine pool with up to 5 additional custom security groups. Configuring custom security groups gives administrators greater control over resource access in new clusters and machine pools. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws_classic_architecture/4/html-single/install_rosa_classic_clusters/index#rosa-security-groups_prerequisites[Security groups].
+Configure custom security groups::
++
+With the release of ROSA CLI (`rosa`) version 1.2.31, administrators can use the `rosa create` command or the OpenShift Cluster Manager to create a new cluster or a new machine pool with up to 5 additional custom security groups. Configuring custom security groups gives administrators greater control over resource access in new clusters and machine pools. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws_classic_architecture/4/html-single/install_rosa_classic_clusters/index#rosa-security-groups_prerequisites[Security groups].
 
-* **Command update.** With the release of ROSA CLI (`rosa`) version 1.2.28, a new command, `rosa describe machinepool`, was added that allows you to check detailed information regarding a specific {product-title} cluster machine pool. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws_classic_architecture/4/html-single/cli_tools/index#rosa-describe-machinepool_rosa-managing-objects-cli[describe machinepool].
+Command update::
++
+With the release of ROSA CLI (`rosa`) version 1.2.28, a new command, `rosa describe machinepool`, was added that allows you to check detailed information regarding a specific {product-title} cluster machine pool. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws_classic_architecture/4/html-single/cli_tools/index#rosa-describe-machinepool_rosa-managing-objects-cli[describe machinepool].
 
-* **Documentation update.** The Operators section was added to the {product-title} documentation. Operators are the preferred method of packaging, deploying, and managing services on the control plane. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws_classic_architecture/4/html-single/operators/index#operators-overview-1[Operators overview].
+Documentation update::
++
+The Operators section was added to the {product-title} documentation. Operators are the preferred method of packaging, deploying, and managing services on the control plane. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws_classic_architecture/4/html-single/operators/index#operators-overview-1[Operators overview].
 
-* **{VirtProductName} support.** The release of {VirtProductName} 4.14 added support for running {VirtProductName} on {product-title} clusters. For more information, see link:https://docs.openshift.com/container-platform/4.14/virt/install/preparing-cluster-for-virt.html#virt-aws-bm_preparing-cluster-for-virt[{VirtProductName} on AWS bare metal] in the {OCP} documentation.
+{VirtProductName} support::
++
+The release of {VirtProductName} 4.14 added support for running {VirtProductName} on {product-title} clusters. For more information, see link:https://docs.openshift.com/container-platform/4.14/virt/install/preparing-cluster-for-virt.html#virt-aws-bm_preparing-cluster-for-virt[{VirtProductName} on AWS bare metal] in the {OCP} documentation.

--- a/modules/rosa-release-notes-Q4-2024.adoc
+++ b/modules/rosa-release-notes-Q4-2024.adoc
@@ -5,14 +5,18 @@
 [id="rosa-q4-2024_{context}"]
 = Q4 2024
 
-[role="_abstract"] 
+[role="_abstract"]
 The following items were added during the fourth quarter of 2024.
 
 ifdef::openshift-rosa[]
-* **Learning tutorials for {product-title} cluster and application deployment.** You can now use the link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws_classic_architecture/4/html-single/tutorials/index#cloud-experts-getting-started-choose-deployment-method[Getting started with {product-title}] tutorials to quickly deploy a {product-title} cluster for demo or learning purposes. You can also use the link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws_classic_architecture/4/html-single/tutorials/index#cloud-experts-deploying-application-intro[Deploying an application] tutorials to deploy an application on your demo cluster.
+Learning tutorials for {product-title} cluster and application deployment::
++
+You can now use the link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws_classic_architecture/4/html-single/tutorials/index#cloud-experts-getting-started-choose-deployment-method[Getting started with {product-title}] tutorials to quickly deploy a {product-title} cluster for demo or learning purposes. You can also use the link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws_classic_architecture/4/html-single/tutorials/index#cloud-experts-deploying-application-intro[Deploying an application] tutorials to deploy an application on your demo cluster.
 endif::openshift-rosa[]
 
-* **Create a VPC using the ROSA CLI.** The `rosa create network` command lets you use the ROSA CLI to create a VPC for your cluster based on an AWS CloudFormation template. You can use this command to create and configure a VPC before creating your cluster. 
+Create a VPC using the ROSA CLI::
++
+The `rosa create network` command lets you use the ROSA CLI to create a VPC for your cluster based on an AWS CloudFormation template. You can use this command to create and configure a VPC before creating your cluster.
 ifdef::openshift-rosa[]
 For more information, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws_classic_architecture/4/html-single/cli_tools/index#rosa-create-network_rosa-managing-objects-cli[create network].
 endif::openshift-rosa[]
@@ -21,10 +25,14 @@ For more information, see link:https://docs.redhat.com/en/documentation/red_hat_
 endif::openshift-rosa-hcp[]
 
 ifdef::openshift-rosa-hcp[]
-* **Create additional security groups in {product-title} clusters.** Starting with ROSA CLI version 1.2.47, you can now create additional security groups using the ROSA CLI when creating {product-title} clusters. Note that additional security group IDs attached to the machine pool cannot be modified. To remove or add more security group IDs, replace the entire machine pool with a new one.
+Create additional security groups in {product-title} clusters::
++
+Starting with ROSA CLI version 1.2.47, you can now create additional security groups using the ROSA CLI when creating {product-title} clusters. Note that additional security group IDs attached to the machine pool cannot be modified. To remove or add more security group IDs, replace the entire machine pool with a new one.
 endif::openshift-rosa-hcp[]
 
-* **ROSA CLI update.** The ROSA CLI (`rosa`) was updated to a new version. For information about what has changed in this release, see the link:https://github.com/openshift/rosa/releases/[ROSA CLI release notes]. For more information about the ROSA CLI (`rosa`), see 
+ROSA CLI update::
++
+The ROSA CLI (`rosa`) was updated to a new version. For information about what has changed in this release, see the link:https://github.com/openshift/rosa/releases/[ROSA CLI release notes]. For more information about the ROSA CLI (`rosa`), see
 ifdef::openshift-rosa-hcp[]
 link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html-single/cli_tools/index#rosa-about_rosa-getting-started-cli[About the ROSA CLI].
 endif::openshift-rosa-hcp[]
@@ -33,9 +41,15 @@ link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws_c
 endif::openshift-rosa[]
 
 ifdef::openshift-rosa-hcp[]
-* **`VolumeDetachTimeout` configuration applied to machine pools for {product-title}.** {product-title} is applying a `VolumeDetachTimeout` configuration of 5 minutes to all machine pools. This prevents issues with node deletion when volumes fail to detach.
+`VolumeDetachTimeout` configuration applied to machine pools for {product-title}::
++
+{product-title} is applying a `VolumeDetachTimeout` configuration of 5 minutes to all machine pools. This prevents issues with node deletion when volumes fail to detach.
 
-* **Configure machine pool disk volume for {product-title} clusters.** You can now configure the disk volume size for machine pools in {product-title} clusters. The default disk size is 300 GiB, and you can configure it from a minimum of 75 GiB to a maximum of 16,384 GiB. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html-single/cluster_administration/#configuring-machine-pool-disk-volume_rosa-managing-worker-nodes[Configuring machine pool disk volume].
+Configure machine pool disk volume for {product-title} clusters::
++
+You can now configure the disk volume size for machine pools in {product-title} clusters. The default disk size is 300 GiB, and you can configure it from a minimum of 75 GiB to a maximum of 16,384 GiB. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html-single/cluster_administration/#configuring-machine-pool-disk-volume_rosa-managing-worker-nodes[Configuring machine pool disk volume].
 
-* **Edit the billing account for existing {product-title} clusters.** You can now update the billing account associated with your {product-title} clusters after cluster creation. For more information, see link:https://docs.redhat.com/en/documentation/openshift_cluster_manager/1-latest/html-single/managing_clusters/index#proc_updating-billing-accts-rosa-hcp_assembly-managing-clusters[Updating billing accounts for OpenShift Service on AWS Hosted Control Planes clusters].
+Edit the billing account for existing {product-title} clusters::
++
+You can now update the billing account associated with your {product-title} clusters after cluster creation. For more information, see link:https://docs.redhat.com/en/documentation/openshift_cluster_manager/1-latest/html-single/managing_clusters/index#proc_updating-billing-accts-rosa-hcp_assembly-managing-clusters[Updating billing accounts for OpenShift Service on AWS Hosted Control Planes clusters].
 endif::openshift-rosa-hcp[]

--- a/modules/rosa-release-notes-Q4-2025.adoc
+++ b/modules/rosa-release-notes-Q4-2025.adoc
@@ -8,40 +8,48 @@
 [role="_abstract"]
 The following items were added during the fourth quarter of 2025.
 
-* ** AWS GovCloud.**
-The Amazon Web Services (AWS) GovCloud service is now available and for use by federal and government agencies, or by commercial organizations and Federal Information Security Modernization Act (FISMA) R&D Universities supporting a government contract or in the process of bidding on a government contract such as a request for proposal (RFP) or request for information (RFI) pre-bid stage.
-For more information, see
+AWS GovCloud::
++
+The Amazon Web Services (AWS) GovCloud service is now available and for use by federal and government agencies, or by commercial organizations and Federal Information Security Modernization Act (FISMA) R&D Universities supporting a government contract or in the process of bidding on a government contract such as a request for proposal (RFP) or request for information (RFI) pre-bid stage. For more information, see
 ifdef::openshift-rosa-hcp[]
-link:
-https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html/getting_started_with_rosa_govcloud[Getting started with ROSA GovCloud].
+link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html-single/getting_started_with_red_hat_openshift_service_on_aws_in_aws_govcloud[Getting started with ROSA GovCloud].
 endif::openshift-rosa-hcp[]
 ifdef::openshift-rosa[]
-link:
-https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws_classic_architecture/4/html/getting_started_with_rosa_govcloud[Getting started with ROSA GovCloud].
+link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws_classic_architecture/4/html-single/getting_started_with_red_hat_openshift_service_on_aws_in_aws_govcloud[Getting started with ROSA GovCloud].
 endif::openshift-rosa[]
 
 ifdef::openshift-rosa-hcp[]
-* ** ImageDigestMirrorSets (IDMS) now supported.**
+ImageDigestMirrorSets (IDMS) now supported::
++
 {product-title} now supports ImageDigestMirrorSets (IDMS), enabling clusters to redirect image pulls to a private, mirrored registry. This critical enhancement means customers in air-gapped or restricted networks can host their own mirrors for third-party images while satisfying strict security and compliance requirements. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html-single/images/index#images-registry-mirroring_image-configuration-hcp[Image registry mirroring for {product-title}].
 endif::openshift-rosa-hcp[]
 
-* **New version of {product-title} available.** {product-title} version 4.20 is now available for new clusters.
+New version of {product-title} available::
++
+{product-title} version 4.20 is now available for new clusters.
 
 ifdef::openshift-rosa-hcp[]
-* ** On-Demand Capacity Reservations and Capacity Blocks for ML now supported.** You can now use pre-purchased Capacity Reservations when creating new machine pools on {product-title} clusters. For more information, see link:https://docs.redhat.com/documentation/red_hat_openshift_service_on_aws/4/html-single/cluster_administration/index#rosa-managing-worker-nodes[Managing compute nodes].
+On-Demand Capacity Reservations and Capacity Blocks for ML now supported::
++
+You can now use pre-purchased Capacity Reservations when creating new machine pools on {product-title} clusters. For more information, see link:https://docs.redhat.com/documentation/red_hat_openshift_service_on_aws/4/html-single/cluster_administration/index#rosa-managing-worker-nodes[Managing compute nodes].
 
-* ** ImageDigestMirrorSets (IDMS) now supported.**
+ImageDigestMirrorSets (IDMS) now supported::
++
 {product-title} now supports ImageDigestMirrorSets (IDMS), enabling clusters to redirect image pulls to a private, mirrored registry. This critical enhancement means customers in restricted networks can host their own mirrors for third-party images while satisfying strict security and compliance requirements. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html-single/images/index#images-registry-mirroring_image-configuration-hcp[Image registry mirroring for {product-title}].
 
-* **{product-title} regions added.** {product-title} is now available in the following regions:
+{product-title} regions added::
 +
+{product-title} is now available in the following regions:
+
 ** Mexico (`mx-central-1`)
 ** Thailand (`ap-southeast-7`)
+
 +
 For more information on region availabilities, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html-single/introduction_to_rosa/index#rosa-sdpolicy-regions-az_rosa-hcp-service-definition[Regions and availability zones].
 endif::openshift-rosa-hcp[]
 
-* **Extended Update Support (EUS) channel group now available.**
+Extended Update Support (EUS) channel group now available::
++
 You can now select the EUS channel group when creating or editing your {product-title} cluster. The EUS channel group allows you to extend the life cycle of your even-numbered version {product-title} cluster, giving you additional time to plan and budget for future upgrades as well as providing continued security patches and critical bug fixes. For additional information, see
 ifdef::openshift-rosa-hcp[]
  link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html/introduction_to_rosa/policies-and-service-definition#sd-life-cycle-dates_rosa-hcp-life-cycle[Life cycle dates].

--- a/modules/rosa-release-notes-deprecated-removed-features.adoc
+++ b/modules/rosa-release-notes-deprecated-removed-features.adoc
@@ -1,0 +1,25 @@
+// Module included in the following assemblies:
+// * rosa-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="rosa-deprecated-removed-features_{context}"]
+= Deprecated and removed features
+
+[role="_abstract"]
+Some features available in previous releases have been deprecated or removed. Deprecated functionality is still included in {product-title} and continues to be supported; however, it will be removed in a future release of this product and is not recommended for new deployments.
+
+ifdef::openshift-rosa-hcp[]
+Disable workload monitoring::
++
+Previously, users could disable workload monitoring on {product-title} clusters. However, to allow users to own the full Cluster Monitoring Operator (CMO) stack on {product-title} clusters, the ability to disable workload monitoring has been deprecated. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html-single/monitoring/index#preparing-to-configure-the-monitoring-stack-uwm[Preparing to configure the user workload monitoring stack].
+endif::openshift-rosa-hcp[]
+
+ifdef::openshift-rosa[]
+{product-title} non-STS deployment mode::
++
+{product-title} non-STS deployment mode is no longer the preferred method for new clusters. Instead, users must deploy {product-title} with the STS mode. This deprecation is in line with our new {product-title} provisioning wizard UI experience on the link:https://console.redhat.com/openshift/create/rosa/wizard[Red Hat Hybrid Cloud Console].
+endif::openshift-rosa[]
+
+Label removal on core namespaces::
++
+{product-title} is no longer labeling OpenShift core using the `name` label. Customers should migrate to referencing the `kubernetes.io/metadata.name` label if needed for Network Policies or other use cases.

--- a/modules/rosa-release-notes-known-issues.adoc
+++ b/modules/rosa-release-notes-known-issues.adoc
@@ -8,19 +8,10 @@
 [role="_abstract"]
 The following items are known issues with {product-title} releases.
 
-* The {cluster-manager} roles (`ocm-role`) and user roles (`user-role`) that are key to the {product-title} provisioning wizard might get enabled accidentally in your Red{nbsp}Hat organization by another user. However, this behavior does not affect the usability.
-* The `htpasswd` identity provider does not function as expected in all scenarios against the `rosa create admin` function.
+`ocm-role` and `user-role` can be enabled accidentally::
++
+The {cluster-manager} roles (`ocm-role`) and user roles (`user-role`) that are key to the {product-title} provisioning wizard might get enabled accidentally in your Red{nbsp}Hat organization by another user. However, this behavior does not affect the usability.
 
-[id="rosa-deprecated-removed-features_{context}"]
-== Deprecated and removed features
-Some features available in previous releases have been deprecated or removed. Deprecated functionality is still included in {product-title} and continues to be supported; however, it will be removed in a future release of this product and is not recommended for new deployments.
-
-ifdef::openshift-rosa-hcp[]
-* **Disable workload monitoring**. Previously, users could disable workload monitoring on {product-title} clusters. However, to allow users to own the full Cluster Monitoring Operator (CMO) stack on {product-title} clusters, the ability to disable workload monitoring has been deprecated. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html-single/monitoring/index#preparing-to-configure-the-monitoring-stack-uwm[Preparing to configure the user workload monitoring stack].
-endif::openshift-rosa-hcp[]
-
-ifdef::openshift-rosa[]
-* **{product-title} non-STS deployment mode.** {product-title} non-STS deployment mode is no longer the preferred method for new clusters. Instead, users must deploy {product-title} with the STS mode. This deprecation is in line with our new {product-title} provisioning wizard UI experience on the link:https://console.redhat.com/openshift/create/rosa/wizard[Red Hat Hybrid Cloud Console].
-endif::openshift-rosa[]
-
-* **Label removal on core namespaces.** {product-title} is no longer labeling OpenShift core using the `name` label. Customers should migrate to referencing the `kubernetes.io/metadata.name` label if needed for Network Policies or other use cases.
+`htpasswd` does not function as expected::
++
+The `htpasswd` identity provider does not function as expected in all scenarios against the `rosa create admin` function.

--- a/rosa_release_notes/rosa-release-notes.adoc
+++ b/rosa_release_notes/rosa-release-notes.adoc
@@ -45,3 +45,5 @@ include::modules/rosa-release-notes-Q1-2023.adoc[leveloffset=+1]
 endif::openshift-rosa[]
 
 include::modules/rosa-release-notes-known-issues.adoc[leveloffset=+1]
+
+include::modules/rosa-release-notes-deprecated-removed-features.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s):
4.21+

Issue:
https://redhat.atlassian.net/browse/OSDOCS-18876

Link to docs preview:
[ROSA HCP release notes](https://110201--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/rosa_release_notes/rosa-release-notes.html)
[ROSA Classic release notes](https://110201--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_release_notes/rosa-release-notes.html)
[OSD release notes](https://110201--ocpdocs-pr.netlify.app/openshift-dedicated/latest/osd_whats_new/osd-whats-new.html)

QE review:
N/A

Additional information:

* No language or style changes.
* Reformatting into description lists and splitting known issues and removed features into separate modules.