### PR TITLE
[enterprise-4.22] OSDOCS-14868: Removed an important note that explains limits to httpasswd

### DIFF
--- a/modules/config-htpasswd-idp.adoc
+++ b/modules/config-htpasswd-idp.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * osd_install_access_delete_cluster/config-identity-providers.adoc
+// * authentication/sd-configuring-identity-providers.adoc
 // * rosa_install_access_delete_clusters/rosa-sts-config-identity-providers.adoc
 
 :_mod-docs-content-type: CONCEPT
@@ -20,10 +20,12 @@ endif::[]
 [role="_abstract"]
 Configure an htpasswd identity provider to create a single, static user with cluster administration privileges. You can log in to your cluster as the user to troubleshoot problems. You can use the web user interface (UI) or your command-line interface (CLI) to create an htpasswd identity provider.
 
+ifndef::openshift-rosa,openshift-rosa-hcp[]
 [IMPORTANT]
 ====
 The htpasswd identity provider option is included only to create a single, static administration user. htpasswd is not supported as a general-use identity provider for {product-title}.
 ====
+endif::openshift-rosa,openshift-rosa-hcp[]
 
 ifeval::["{context}" == "config-identity-providers"]
 :!osd-distro:

--- a/modules/understanding-idp.adoc
+++ b/modules/understanding-idp.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * osd_install_access_delete_cluster/config-identity-providers.adoc
+// * authentication/sd-configuring-identity-providers.adoc
 // * rosa_install_access_delete_clusters/rosa-sts-config-identity-providers.adoc
 
 :_mod-docs-content-type: CONCEPT
@@ -40,9 +40,11 @@ You can configure the following types of identity providers:
 |htpasswd
 |Configure an htpasswd identity provider for a single, static administration user. You can log in to the cluster as the user to troubleshoot issues.
 
+ifndef::openshift-rosa,openshift-rosa-hcp[]
 [IMPORTANT]
 ====
 The htpasswd identity provider option is included only to enable the creation of a single, static administration user. htpasswd is not supported as a general-use identity provider for {product-title}. For the steps to configure the single user, see _Configuring an htpasswd identity provider_.
 ====
+endif::openshift-rosa,openshift-rosa-hcp[]
 
 |===


### PR DESCRIPTION
This is an `enterprise-4.22` manual cherrypick of #110051.