### PR TITLE
Fixed a mistake in pushing the wrong vale file

### DIFF
--- a/.vale.ini
+++ b/.vale.ini
@@ -1,13 +1,62 @@
 StylesPath = .vale/styles
-MinAlertLevel = warning
-Packages = https://github.com/jhradilek/asciidoctor-dita-vale/releases/latest/download/AsciiDocDITA.zip
 
-[*.adoc]
-BasedOnStyles = AsciiDocDITA
+MinAlertLevel = suggestion
 
-# The rules below are based on recommended practices and do not prevent
-# successful conversion to DITA.  If your product is not bound by these
-# guidelines, uncomment the following lines to disable them:
-#AsciiDocDITA.CalloutList = NO
-#AsciiDocDITA.ShortDescription = NO
-#AsciiDocDITA.ConceptLink = NO
+Packages = RedHat, AsciiDoc, OpenShiftAsciiDoc, https://github.com/jhradilek/asciidoctor-dita-vale/releases/latest/download/AsciiDocDITA.zip
+
+Vocab = OpenShiftDocs
+
+# Ignore files in dirs starting with `.` to avoid raising errors for `.vale/fixtures/*/testinvalid.adoc` files
+[[!.]*.adoc]
+BasedOnStyles = RedHat, AsciiDoc, OpenShiftAsciiDoc
+
+# Disabling rules (NO)
+RedHat.ReleaseNotes = NO
+
+# Use local OpenShiftDocs Vocab terms
+Vale.Terms = YES
+Vale.Avoid = YES
+
+# Enable specifc DITA rules on assemblies
+AsciiDocDITA.AdmonitionTitle = error
+AsciiDocDITA.AssemblyContents = error
+AsciiDocDITA.AuthorLine = error
+AsciiDocDITA.BlockTitle = error
+AsciiDocDITA.CalloutList = error
+AsciiDocDITA.ConceptLink = error
+AsciiDocDITA.ContentType = error
+AsciiDocDITA.DiscreteHeading = error
+AsciiDocDITA.DocumentID = error
+AsciiDocDITA.DocumentTitle = error
+AsciiDocDITA.EntityReference = error
+AsciiDocDITA.EquationFormula = error
+AsciiDocDITA.ExampleBlock = error
+AsciiDocDITA.LineBreak = error
+AsciiDocDITA.MismatchedID = error
+AsciiDocDITA.NestedSection = error
+AsciiDocDITA.PageBreak = error
+AsciiDocDITA.RelatedLinks = error
+AsciiDocDITA.ShortDescription = error
+AsciiDocDITA.SidebarBlock = error
+AsciiDocDITA.TableFooter = error
+AsciiDocDITA.TaskContents = error
+AsciiDocDITA.TaskDuplicate = error
+AsciiDocDITA.TaskExample = error
+AsciiDocDITA.TaskSection = error
+AsciiDocDITA.TaskStep = error
+AsciiDocDITA.TaskTitle = error
+AsciiDocDITA.ThematicBreak = error
+
+# Disable module specific rules
+OpenShiftAsciiDoc.ModuleContainsParentAssemblyComment = NO
+OpenShiftAsciiDoc.NoNestingInModules = NO
+OpenShiftAsciiDoc.NoXrefInModules = NO
+OpenShiftAsciiDoc.IdHasContextVariable = NO
+OpenShiftAsciiDoc.NoTocInModules = NO
+
+# Optional: pass doc attributes to asciidoctor before linting
+# Temp values are used for Prow CI comment linting only
+[asciidoctor]
+temp-ifdef = YES
+temp-ifndef = NO
+temp-ifeval = temp


### PR DESCRIPTION
This PR fixes the vale.ini that I accidentally merged here: https://github.com/openshift/openshift-docs/pull/110051/changes#diff-0da89932043a07a361f29194237fa0cb85aba0bebef98a012a03f84989c26e2e