### PR TITLE
OLS-2146: Added more context on watsonx

### DIFF
--- a/modules/ols-support-for-trusted-ca-certificates-and-llm-providers.adoc
+++ b/modules/ols-support-for-trusted-ca-certificates-and-llm-providers.adoc
@@ -2,14 +2,14 @@
 // * lightspeed-docs-main/configure/ols-configuring-openshift-lightspeed.adoc
 
 :_mod-docs-content-type: CONCEPT
-[id="support-for-trusted-ca-certificates-and-llm-providers_{context}"]
-= Support for trusted-ca certificates and LLM providers
+[id="ols-support-for-trusted-ca-certificates-and-llm-providers_{context}"]
+= Configure support for trusted-ca certificates and LLM providers
 
 [role="_abstract"]
 
-Use the {ocp-product-title} web console to configure custom TLS certificates for secure communication between {ols-long} and your service endpoints.
+Configure custom TLS certificates to secure communication between {ols-long} and LLM provider service endpoints.
 
-The {ols-long} Service supports adding trusted-ca certificates for the following LLM providers: 
+The {ols-long} Service supports custom TLS certificates for secure communication with LLM providers. You can use trusted-ca certificates with these providers:
 
 * {rhelai} vLLM
 
@@ -19,11 +19,23 @@ The {ols-long} Service supports adding trusted-ca certificates for the following
 
 * {azure-openai}
 
-To add a trusted-ca certificate you must create a `ConfigMap` object that has the certificates. Then, add the  name of the object to the `OLSConfig` custom resource (CR) file as shown in the following example:
+[NOTE]
+====
+{watsonx} does not support custom certificates.
+====
 
+.Procedure
+
+. Create a `ConfigMap` object that contains the certificates.
+. Add the name of the object in the `OLSConfig` custom resource (CR) file:
++
 [source,yaml]
 ----
 ols:
   additionalCAConfigMapRef:
-    name: <config_map_name>
+    name: _<config_map_name>_
 ----
++
+where
++
+`_<config_map_name>`:: Enter the name of your `ConfigMap` object.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
lightspeed-docs-main, lightspeed-docs-1.0

Issue:
[OLS-2146](https://redhat.atlassian.net/browse/OLS-2146)

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
