### PR TITLE
[OSDOCS#16800]Update ROSA Learning_Config maps_secrets_CQA assembly jobs

### DIFF
--- a/rosa_learning/deploying_application_workshop/learning-deploying-configmaps-secrets-env-var.adoc
+++ b/rosa_learning/deploying_application_workshop/learning-deploying-configmaps-secrets-env-var.adoc
@@ -7,8 +7,15 @@ include::_attributes/attributes-openshift-dedicated.adoc[]
 
 toc::[]
 [role="_abstract"]
-This tutorial shows how to configure the OSToy application by using link:https://docs.openshift.com/rosa/nodes/pods/nodes-pods-configmaps.html[config maps], link:https://docs.openshift.com/container-platform/latest/cicd/builds/creating-build-inputs.html#builds-input-secrets-configmaps_creating-build-inputs[secrets], and link:https://docs.openshift.com/container-platform/3.11/dev_guide/environment_variables.html[environment variables].
+To securely manage sensitive information and decouple configurations from your container image, configure your OSToy application by using config maps, secrets, and environment variables.
 
 include::modules/learning-deploying-configmaps-secrets-envvar-configmaps.adoc[leveloffset=+1]
 include::modules/learning-deploying-configmaps-secrets-envvar-secrets.adoc[leveloffset=+1]
 include::modules/learning-deploying-configmaps-secrets-envvar-environment-variables.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+[id="additional-resources_{context}"]
+== Additional resources
+
+* link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html/building_applications/config-maps#nodes-pods-configmap-overview_config-maps[Understanding config maps]
+ * link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html/builds_using_buildconfig/creating-build-inputs#builds-secrets-overview_creating-build-inputs[Secrets]


### PR DESCRIPTION
Version(s):
4.21+

Issue:
https://redhat.atlassian.net/browse/OSDOCS-16800

Link to docs preview:
[Config maps, secrets, and environment variables](https://110229--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/rosa_learning/deploying_application_workshop/learning-deploying-configmaps-secrets-env-var.html)

Peer review:
- [x] Peer reviewer has approved this change.

QE review:
- QE approval is not required for this PR as there are no procedural changes.

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
