### PR TITLE
[gitops-docs-1.19] RHDEVDOCS-7097: CQA 2.0 fixes for Enabling support for a namespace-scoped Argo Rollouts installation

### DIFF
--- a/modules/gitops-configuring-namespace-scoped-argo-rollouts-installation.adoc
+++ b/modules/gitops-configuring-namespace-scoped-argo-rollouts-installation.adoc
@@ -6,12 +6,14 @@
 [id="configuring-namespace-scoped-argo-rollouts-installation_{context}"]
 = Configuring a namespace-scoped Argo Rollouts installation
 
-To configure a namespace-scoped instance of Argo Rollouts installation, complete the following steps.
+[role="_abstract"]
+Configuring a namespace-scoped Argo Rollouts installation allows you to limit Argo Rollouts access to a specific namespace instead of granting cluster-wide permissions.
 
 .Prerequisites
 
 * You are logged in to the {product-title} cluster as an administrator.
 * You have installed {gitops-title} on your {product-title} cluster.
+* You have created the namespace where you want to install the namespace-scoped Argo Rollouts instance.
 
 .Procedure 
 
@@ -75,7 +77,7 @@ spec:
 --
 where:
 
-`metadata.namespace`:: Specifies the name of the project where you want to install the namespace-scoped Argo Rollouts instance.
+`metadata.namespace`:: Specifies the namespace where you want to install the namespace-scoped Argo Rollouts instance.
 --
 
 .. Click *Create*. 
@@ -94,11 +96,11 @@ spec:
   namespaceScoped: true
 status:
   conditions:
-    lastTransitionTime: '2024-07-10T14:20:05Z'
-    message: ''
-    reason: Success
-    status: 'True'
-    type: 'Reconciled'
+    - lastTransitionTime: "2024-07-10T14:20:05Z"
+      message: ""
+      reason: Success
+      status: "True"
+      type: Reconciled
   phase: Available
   rolloutController: Available
 ----
@@ -110,7 +112,7 @@ where:
 `status.rolloutController`:: Specifies the status of the Argo Rollouts controller. The value `Available` indicates that the namespace-scoped Argo Rollouts installation is successful.
 --
 +
-If you try to install a namespace-specific Argo Rollouts instance while a cluster-scoped installation already exists on the cluster, an error message is displayed:
+If you try to create a namespace-scoped RolloutManager instance while the {gitops-shortname} Operator is configured for cluster-scoped mode, you receive the following error: 
 +
 --
 *Example of an incorrect installation with an error message:*
@@ -120,11 +122,15 @@ spec:
   namespaceScoped: true
 status:
   conditions:
-    lastTransitionTime: '2024-07-10T14:10:07Z'
-    message: 'when Subscription has environment variable NAMESPACE_SCOPED_ARGO_ROLLOUTS set to False, there may not exist any namespace-scoped RolloutManagers: only a single cluster-scoped RolloutManager is supported'
-    reason: InvalidRolloutManagerScope
-    status: 'False'
-    type: 'Reconciled'
+    - lastTransitionTime: "2024-07-10T14:10:07Z"
+      message: >
+        when Subscription has environment variable
+        NAMESPACE_SCOPED_ARGO_ROLLOUTS set to False, there may not exist any
+        namespace-scoped RolloutManagers: only a single cluster-scoped
+        RolloutManager is supported
+      reason: InvalidRolloutManagerScope
+      status: "False"
+      type: Reconciled
   phase: Failure
   rolloutController: Failure
 ----


### PR DESCRIPTION
This PR is a manual cherry-pick of https://github.com/openshift/openshift-docs/pull/109775.