### PR TITLE
DOCPLAN-170: Restructured primary udn assembly for DITA compliance

### DIFF
--- a/modules/virt-attaching-vm-to-primary-udn-intro.adoc
+++ b/modules/virt-attaching-vm-to-primary-udn-intro.adoc
@@ -1,0 +1,24 @@
+// Module included in the following assemblies:
+//
+// * virt/vm_networking/virt-connecting-vm-to-primary-udn.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="virt-attaching-vm-to-primary-udn-intro_{context}"]                      
+= Attach a virtual machine to the primary user-defined network
+
+[role="_abstract"]
+You can connect a virtual machine (VM) to the primary user-defined network (UDN) by requesting the pod network attachment and configuring the interface binding.
+
+{VirtProductName} supports the following network binding plugins to connect the network interface to the VM:
+
+Layer 2 bridge:: The Layer 2 bridge binding creates a direct Layer 2 connection between the VM's virtual interface and the virtual switch of the UDN.
+
+Passt:: The Plug a Simple Socket Transport (passt) binding provides a user-space networking solution that integrates seamlessly with the pod network, providing better integration with the {product-title} networking ecosystem.
++
+Passt binding has the following benefits:
+
+* You can define readiness and liveness HTTP probes to configure VM health checks.
+* You can use Red Hat Advanced Cluster Security to monitor TCP traffic within the cluster with detailed insights.
+
+:FeatureName: Using the passt binding plugin to attach a VM to the primary UDN
+include::snippets/technology-preview.adoc[]

--- a/modules/virt-creating-primary-udn-cli-intro.adoc
+++ b/modules/virt-creating-primary-udn-cli-intro.adoc
@@ -1,0 +1,10 @@
+// Module included in the following assemblies:
+//
+// * virt/vm_networking/virt-connecting-vm-to-primary-udn.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="virt-creating-primary-udn-cli-intro_{context}"]                      
+= Create a primary user-defined network by using the CLI
+
+[role="_abstract"]
+You can create a primary `UserDefinedNetwork` or `ClusterUserDefinedNetwork` custom resource definition (CRD) by using the {oc-first}. After you define the custom primary overlay network, you can create namespaces that are associated with the cluster-scoped UDN.

--- a/modules/virt-creating-primary-udn-web-intro.adoc
+++ b/modules/virt-creating-primary-udn-web-intro.adoc
@@ -1,0 +1,12 @@
+// Module included in the following assemblies:
+//
+// * virt/vm_networking/virt-connecting-vm-to-primary-udn.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="virt-creating-primary-udn-web-intro_{context}"]                      
+= Create a primary user-defined network by using the web console
+
+[role="_abstract"]
+You can use the {product-title} web console to create a primary namespace-scoped `UserDefinedNetwork` or a cluster-scoped `ClusterUserDefinedNetwork` custom resource definition (CRD). The UDN serves as the default primary network for pods and VMs that you create in namespaces associated with the network.
+
+After you define the custom primary overlay network, you can create namespaces that are associated with the cluster-scoped UDN.

--- a/virt/vm_networking/virt-connecting-vm-to-primary-udn.adoc
+++ b/virt/vm_networking/virt-connecting-vm-to-primary-udn.adoc
@@ -30,10 +30,8 @@ You must consider the following limitations before implementing a primary UDN:
 * You cannot use headless services to access a VM.
  
 
-[id="creating-primary-udn-web_{context}"]
-== Creating a primary user-defined network by using the web console
 
-You can use the {product-title} web console to create a primary namespace-scoped `UserDefinedNetwork` or a cluster-scoped `ClusterUserDefinedNetwork` CRD. The UDN serves as the default primary network for pods and VMs that you create in namespaces associated with the network.
+include::modules/virt-creating-primary-udn-web-intro.adoc[leveloffset=+1]
 
 include::modules/virt-creating-udn-namespace-web.adoc[leveloffset=+2]
 
@@ -43,14 +41,8 @@ include::modules/virt-creating-a-localnet-cudn-web.adoc[leveloffset=+2]
 
 include::modules/virt-creating-primary-cluster-udn-web.adoc[leveloffset=+2]
 
-[id="next-steps-web_{context}"]
-.Next steps
-* xref:../../virt/vm_networking/virt-connecting-vm-to-primary-udn.adoc#virt-creating-udn-namespace-web_virt-connecting-vm-to-primary-udn[Create namespaces that are associated with the cluster-scoped UDN]
 
-[id="creating-primary-udn-cli_{context}"]
-== Creating a primary user-defined network by using the CLI
-
-You can create a primary `UserDefinedNetwork` or `ClusterUserDefinedNetwork` CRD by using the CLI.
+include::modules/virt-creating-primary-udn-cli-intro.adoc[leveloffset=+1]
 
 include::modules/virt-creating-udn-namespace-cli.adoc[leveloffset=+2]
 
@@ -58,28 +50,8 @@ include::modules/virt-creating-a-primary-udn.adoc[leveloffset=+2]
 
 include::modules/virt-creating-a-primary-cluster-udn.adoc[leveloffset=+2]
 
-[id="next-steps-cli_{context}"]
-.Next steps
-* xref:../../virt/vm_networking/virt-connecting-vm-to-primary-udn.adoc#virt-creating-udn-namespace-cli_virt-connecting-vm-to-primary-udn[Create namespaces that are associated with the cluster-scoped UDN]
 
-[id="attaching-vm-to-primary-udn_{context}"]
-== Attaching a virtual machine to the primary user-defined network
-
-You can connect a virtual machine (VM) to the primary user-defined network (UDN) by requesting the pod network attachment and configuring the interface binding.
-
-{VirtProductName} supports the following network binding plugins to connect the network interface to the VM:
-
-Layer 2 bridge:: The Layer 2 bridge binding creates a direct Layer 2 connection between the VM's virtual interface and the virtual switch of the UDN.
-
-Passt:: The Plug a Simple Socket Transport (passt) binding provides a user-space networking solution that integrates seamlessly with the pod network, providing better integration with the {product-title} networking ecosystem.
-+
-Passt binding has the following benefits:
-
-* You can define readiness and liveness HTTP probes to configure VM health checks.
-* You can use Red Hat Advanced Cluster Security to monitor TCP traffic within the cluster with detailed insights.
-
-:FeatureName: Using the passt binding plugin to attach a VM to the primary UDN
-include::snippets/technology-preview.adoc[]
+include::modules/virt-attaching-vm-to-primary-udn-intro.adoc[leveloffset=+1]
 
 include::modules/virt-attaching-vm-to-primary-udn-web.adoc[leveloffset=+2]
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.20+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://redhat.atlassian.net/browse/DOCPLAN-170
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://110244--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/vm_networking/virt-connecting-vm-to-primary-udn.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review: N/A
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
