### PR TITLE
OSDOCS-18808: adds x-rate-limit docs RHCL

### DIFF
--- a/deployment/deployment.adoc
+++ b/deployment/deployment.adoc
@@ -27,6 +27,8 @@ include::modules/proc-set-default-auth-policy.adoc[leveloffset=+2]
 
 include::modules/proc-set-default-rate-limit-policy.adoc[leveloffset=+2]
 
+include::modules/proc-add-rate-limit-headers.adoc[leveloffset=+2]
+
 include::modules/con-about-token-based-rate-limiting.adoc[leveloffset=+1]
 
 include::modules/proc-configure-token-based-rate-limiting.adoc[leveloffset=+2]

--- a/modules/proc-add-rate-limit-headers.adoc
+++ b/modules/proc-add-rate-limit-headers.adoc
@@ -1,0 +1,60 @@
+// Module included in the following assemblies:
+//
+// *deployment/deployment.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="proc-add-rate-limit-headers_{context}"]
+= Adding rate-limit headers to an API response
+
+[role="_abstract"]
+When you need to ensure that your traffic remains stable under heavy load, you can add rate-limit headers to your API responses.
+
+By adding `x-ratelimit-*` headers, you can turn your APIs into self-documenting systems that can proactively throttle their own request frequency and time their retries. You can simplify debugging for developers and reduce unnecessary traffic spikes.
+
+.Prerequisites
+
+* You installed {prodname} on one or more clusters.
+* If you plan to use rate-limiting in a multicluster environment, you have a shared Redis-based datastore.
+* You installed the {oc-first}.
+* You have write access to the {ocp} namespaces you need to work with.
+* You have access to external or on-premise DNS.
+* You created a `Gateway` object.
+* You configured your gateway policies and `HTTP` routes.
+* You applied a default `RateLimitPolicy` CR to your deployment.
+* You have write access to the namespace where {prodname} is installed.
+
+.Procedure
+
+. Find the name of the `Limitador` CR in your cluster by running the following command:
++
+[source,terminal]
+----
+$ oc get limitador -A
+----
+
+. Apply a patch to add headers to the CR by running the following command:
++
+[source,terminal,subs="+quotes"]
+----
+$ oc patch limitador limitador -n KUADRANT-NAMESPACE --type=merge -p '{"spec": {"rateLimitHeaders": "DRAFT_VERSION_03"}}'
+----
+
+.Verification
+
+* Test for the presence of headers by running the following command:
++
+[source,terminal,subs="+quotes"]
+----
+$ curl -i -X GET http://_<gateway_url>_/path
+----
++
+Replace `_<gateway_url>_` with the URL of your `Gateway` object.
++
+.Example output
+[source,text]
+----
+HTTP/1.1 200 OK
+x-ratelimit-limit: 5, 5;w=60
+x-ratelimit-remaining: 4
+x-ratelimit-reset: 58
+----

--- a/modules/proc-app-dev-override-rlp.adoc
+++ b/modules/proc-app-dev-override-rlp.adoc
@@ -3,7 +3,7 @@
 // *deployment/deployment.adoc
 
 :_mod-docs-content-type: PROCEDURE
-[id="app-developer-workflow_{context}"]
+[id="proc-app-dev-override-rlp_{context}"]
 = Overriding the low-limit RateLimitPolicy for specific users
 
 [role="_abstract"]


### PR DESCRIPTION
Version(s):
rhcl-docs-1.2
rhcl-docs-1.3
rhcl-docs-1.4

Issue:
[OSDOCS-18808](https://redhat.atlassian.net/browse/OSDOCS-18808)

Link to docs preview:
https://110280--ocpdocs-pr.netlify.app/rhcl/latest/deployment/deployment.html#proc-add-rate-limit-headers_rhcl-config-deploy-gateway-policies

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
