### PR TITLE
OSDOCS-16589 - Addressing Vale errors in ROSA Building applications

### DIFF
--- a/applications/deployments/rosa-config-custom-domains-applications.adoc
+++ b/applications/deployments/rosa-config-custom-domains-applications.adoc
@@ -6,12 +6,13 @@ include::_attributes/attributes-openshift-dedicated.adoc[]
 
 toc::[]
 
+[role="_abstract"]
+You can configure a custom domain for your applications. Custom domains are specific wildcard domains that can be used with {product-title} applications.
+
 [WARNING]
 ====
 Starting with {product-title} 4.14, the Custom Domain Operator is deprecated. To manage Ingress in {product-title} 4.14, use the Ingress Operator. The functionality is unchanged for {product-title} 4.13 and earlier versions.
 ====
-
-You can configure a custom domain for your applications. Custom domains are specific wildcard domains that can be used with {product-title} applications. 
 
 include::modules/rosa-applications-config-custom-domains.adoc[leveloffset=+1]
 

--- a/modules/odc-adding-health-checks.adoc
+++ b/modules/odc-adding-health-checks.adoc
@@ -6,6 +6,7 @@
 [id="odc-adding-health-checks_{context}"]
 = Adding health checks using the Developer perspective
 
+[role="_abstract"]
 You can use the *Topology* view to add health checks to your deployed application.
 
 .Prerequisites
@@ -13,11 +14,11 @@ You can use the *Topology* view to add health checks to your deployed applicatio
 * You have created and deployed an application on {product-title} using the *Developer* perspective.
 
 .Procedure
-. In the *Topology* view, click on the application node to see the side panel. If the container does not have health checks added, a *Health Checks* notification is displayed with a link to add health checks.
+. In the *Topology* view, click the application node to see the side panel. If the container does not have health checks added, a *Health Checks* notification is displayed with a link to add health checks.
 . In the displayed notification, click the *Add Health Checks* link.
 . Alternatively, you can also click the *Actions* list and select *Add Health Checks*. Note that if the container already has health checks, you will see the *Edit Health Checks* option instead of the add option.
 . In the *Add Health Checks* form, if you have deployed multiple containers, use the *Container* list to ensure that the appropriate container is selected.
-. Click the required health probe links to add them to the container. Default data for the health checks is prepopulated. You can add the probes with the default data or further customize the values and then add them. For example, to add a Readiness probe that checks if your container is ready to handle requests:
+. Click the required health probe links to add them to the container. Default data for the health checks is pre-populated. You can add the probes with the default data or further customize the values and then add them. For example, to add a Readiness probe that checks if your container is ready to handle requests:
 .. Click *Add Readiness Probe*, to see a form containing the parameters for the probe.
 .. Click the *Type* list to select the request type you want to add. For example, in this case, select *Container Command* to select the command that will be executed inside the container.
 .. In the *Command* field, add an argument `cat`, similarly, you can add multiple arguments for the check, for example, add another argument `/tmp/healthy`.
@@ -27,7 +28,7 @@ You can use the *Topology* view to add health checks to your deployed applicatio
 ====
 The `Timeout` value must be lower than the `Period` value. The `Timeout` default value is `1`. The `Period` default value is `10`.
 ====
-.. Click the check mark at the bottom of the form. The *Readiness Probe Added* message is displayed.
+.. Click the checkmark at the bottom of the form. The *Readiness Probe Added* message is displayed.
 
 . Click *Add* to add the health check. You are redirected to the *Topology* view and the container is restarted.
 . In the side panel, verify that the probes have been added by clicking on the deployed pod under the *Pods* section.

--- a/modules/rosa-applications-config-custom-domains.adoc
+++ b/modules/rosa-applications-config-custom-domains.adoc
@@ -6,6 +6,7 @@
 [id="rosa-applications-config-custom-domains_{context}"]
 = Configuring custom domains for applications
 
+[role="_abstract"]
 The top-level domains (TLDs) are owned by the customer that is operating the {product-title} cluster. The Custom Domains Operator sets up a new ingress controller with a custom certificate as a second day operation. The public DNS record for this ingress controller can then be used by an external DNS to create a wildcard CNAME record for use with a custom domain.
 
 [NOTE]
@@ -43,24 +44,29 @@ kind: CustomDomain
 metadata:
   name: <company_name>
 spec:
-  domain: apps.<company_name>.io <1>
+  domain: apps.<company_name>.io
   scope: External
-  loadBalancerType: Classic <2>
+  loadBalancerType: Classic
   certificate:
-    name: <name>-tls <3>
+    name: <name>-tls
     namespace: <my_project>
-  routeSelector: <4>
+  routeSelector:
     matchLabels:
      route: acme
-  namespaceSelector: <5>
+  namespaceSelector:
     matchLabels:
      type: sharded
 ----
-<1> The custom domain.
-<2> The type of load balancer for your custom domain. This type can be the default `classic` or `NLB` if you use a network load balancer.
-<3> The secret created in the previous step.
-<4> Optional: Filters the set of routes serviced by the CustomDomain ingress. If no value is provided, the default is no filtering.
-<5> Optional: Filters the set of namespaces serviced by the CustomDomain ingress. If no value is provided, the default is no filtering.
++
+--
+where:
+
+`spec.domain`:: Specifies the custom domain.
+`spec.loadBalancerType`:: Specifies the type of load balancer for your custom domain. This type can be the default `classic` or `NLB` if you use a network load balancer.
+`spec.certificate.name`:: Specifies the secret created in the previous step.
+`spec.routeSelector`:: Optional. Filters the set of routes serviced by the CustomDomain ingress. If no value is provided, the default is no filtering.
+`spec.namespaceSelector`:: Optional. Filters the set of namespaces serviced by the CustomDomain ingress. If no value is provided, the default is no filtering.
+--
 
 . Apply the CR:
 +
@@ -85,10 +91,10 @@ NAME               ENDPOINT                                                    D
 ----
 
 ifdef::openshift-rosa[]
-. Using the endpoint value, add a new wildcard CNAME recordset to your managed DNS provider, such as Route53.
+. Using the endpoint value, add a new wildcard CNAME record set to your managed DNS provider, such as Route53.
 endif::openshift-rosa[]
 ifndef::openshift-rosa[]
-. Using the endpoint value, add a new wildcard CNAME recordset to your managed DNS provider, such as Route53, Azure DNS, or Google DNS.
+. Using the endpoint value, add a new wildcard CNAME record set to your managed DNS provider, such as Route53, Azure DNS, or Google DNS.
 endif::openshift-rosa[]
 
 +

--- a/modules/rosa-applications-renew-custom-domains.adoc
+++ b/modules/rosa-applications-renew-custom-domains.adoc
@@ -6,6 +6,7 @@
 [id="rosa-applications-renew-custom-domains_{context}"]
 = Renewing a certificate for custom domains
 
+[role="_abstract"]
 You can renew certificates with the Custom Domains Operator (CDO) by using the `oc` CLI tool.
 
 //s a customer of OSD/ROSA, I would like instructions on how to renew certificates with Custom Domains Operator (CDO).


### PR DESCRIPTION
Version(s):
4.21+

Issue:
https://redhat.atlassian.net/browse/OSDOCS-16589

Link to docs preview:

**1. Whole assembly:**

- ROSA HCP: [Custom domains for applications](https://110284--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/applications/deployments/rosa-config-custom-domains-applications.html)
- ROSA Classic [Custom domains for applications](https://110284--ocpdocs-pr.netlify.app/openshift-rosa/latest/applications/deployments/rosa-config-custom-domains-applications.html)

**2. HCM-only module** in the _application-health.adoc_ assembly:

- ROSA HCP: [Adding health checks using the Developer perspective](https://110284--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/applications/application-health.html#odc-adding-health-checks_application-health)
- ROSA Classic: [Adding health checks using the Developer perspective](https://110284--ocpdocs-pr.netlify.app/openshift-rosa/latest/applications/application-health.html#odc-adding-health-checks_application-health)
- OSD: [Adding health checks using the Developer perspective](https://110284--ocpdocs-pr.netlify.app/openshift-dedicated/latest/applications/application-health.html#odc-adding-health-checks_application-health)
- OCP: No preview, the module is excluded from the OCP docs.

QE review:
N/A

Additional information:
Addressing DITA Vale errors and warning in ROSA exclusive content from Building applications.