### PR TITLE
testing mock csv update for RDS

### DIFF
--- a/modules/telco-core-crs-cluster-infrastructure.adoc
+++ b/modules/telco-core-crs-cluster-infrastructure.adoc
@@ -22,5 +22,4 @@ Disconnected configuration,`idms.yaml`,Defines a list of mirrored repository dig
 Disconnected configuration,`operator-hub.yaml`,Defines an OperatorHub configuration which disables all default sources.,No
 Monitoring and observability,`monitoring-config-cm.yaml`,Configuring storage and retention for Prometheus and Alertmanager.,Yes
 Power management,`PerformanceProfile.yaml`,"Defines a performance profile resource, specifying CPU isolation, hugepages configuration, and workload hints for performance optimization on selected nodes.",No
-Power management,`TunedPerformancePatch.yaml`,"Applies performance tuning overrides for worker profiles and enables kernel panic on non-maskable interrupts (NMI) for system recovery on unresponsive nodes.",No
 |====

--- a/modules/telco-core-crs-scalability.adoc
+++ b/modules/telco-core-crs-scalability.adoc
@@ -1,0 +1,25 @@
+// Module included in the following assemblies:
+//
+// *
+
+:_mod-docs-content-type: REFERENCE
+[id="scalability-crs_{context}"]
+= Scalability reference CRs
+
+.Scalability CRs
+[cols="4*", options="header", format=csv]
+|====
+Component,Reference CR,Description,Optional
+cluster-autoscaler,`ClusterAutoscaler.yaml`,Enables automatic scaling of cluster nodes based on pending pod resource requests,Yes
+machine-autoscaler,`MachineAutoscaler.yaml`,Configures per-MachineSet scaling boundaries with min and max replica counts,Yes
+vertical-pod-autoscaler,`VerticalPodAutoscaler.yaml`,Automatically adjusts CPU and memory requests for pods based on historical usage,No
+horizontal-pod-autoscaler,`HorizontalPodAutoscaler.yaml`,Scales deployment replicas based on CPU utilization or custom metrics,Yes
+cluster-resource-override,`ClusterResourceOverride.yaml`,Enables overcommitment of CPU and memory resources at the cluster level,No
+priority-class,`PriorityClass.yaml`,Defines pod scheduling priority for resource contention scenarios,Yes
+limit-range,`LimitRange.yaml`,Sets default and maximum resource constraints per namespace,Yes
+resource-quota,`ResourceQuota.yaml`,Enforces aggregate resource consumption limits per namespace,Yes
+pod-disruption-budget,`PodDisruptionBudget.yaml`,Limits voluntary disruptions to maintain application availability during scaling,No
+topology-spread-constraints,`TopologySpreadConstraints.yaml`,Distributes pods evenly across failure domains for high availability,No
+kube-descheduler,`KubeDescheduler.yaml`,Evicts pods to rebalance cluster utilization and improve scheduling efficiency,No
+node-tuning-operator,`PerformanceProfile.yaml`,Configures low-latency tuning and CPU isolation for performance-sensitive workloads,No
+|====

--- a/modules/telco-core-crs-security.adoc
+++ b/modules/telco-core-crs-security.adoc
@@ -10,7 +10,7 @@
 [cols="4*", options="header", format=csv]
 |====
 Component,Reference CR,Description,Optional
-Cert-Manager,`certManagerNS.yaml`,Defines the cert-manager-operator namespace.,Yes
+Cert-Manager,`certManagerNS.yaml`,Defines the cert-manager-operator namespace.,No
 Cert-Manager,`certManagerOperatorgroup.yaml`,Defines the OperatorGroup for cert-manager.,Yes
 Cert-Manager,`certManagerSubscription.yaml`,Installs the OpenShift cert-manager operator.,Yes
 Cert-Manager,`certManagerClusterIssuer.yaml`,Configures an ACME ClusterIssuer using Let's Encrypt with DNS-01 challenge.,Yes

--- a/scalability_and_performance/telco-core-rds.adoc
+++ b/scalability_and_performance/telco-core-rds.adoc
@@ -256,6 +256,8 @@ include::modules/telco-core-crs-storage.adoc[leveloffset=+2]
 
 include::modules/telco-core-crs-security.adoc[leveloffset=+2]
 
+include::modules/telco-core-crs-scalability.adoc[leveloffset=+2]
+
 include::modules/telco-core-software-stack.adoc[leveloffset=+1]
 
 :!telco-core:


### PR DESCRIPTION
Using this updated CSV.

[telco-core-rds.csv](https://github.com/user-attachments/files/26817251/telco-core-rds.csv)

The CSV changed one line item from No to Yes, which Cursor found. And I added a mock section to the CSV, which cursor created a new module for:

````
Scalability | cluster-autoscaler | ClusterAutoscaler.yaml | Enables automatic scaling of cluster nodes based on pending pod resource requests | Yes
-- | -- | -- | -- | --
Scalability | machine-autoscaler | MachineAutoscaler.yaml | Configures per-MachineSet scaling boundaries with min and max replica counts | Yes
Scalability | vertical-pod-autoscaler | VerticalPodAutoscaler.yaml | Automatically adjusts CPU and memory requests for pods based on historical usage | No
Scalability | horizontal-pod-autoscaler | HorizontalPodAutoscaler.yaml | Scales deployment replicas based on CPU utilization or custom metrics | Yes
Scalability | cluster-resource-override | ClusterResourceOverride.yaml | Enables overcommitment of CPU and memory resources at the cluster level | No
Scalability | priority-class | PriorityClass.yaml | Defines pod scheduling priority for resource contention scenarios | Yes
Scalability | limit-range | LimitRange.yaml | Sets default and maximum resource constraints per namespace | Yes
Scalability | resource-quota | ResourceQuota.yaml | Enforces aggregate resource consumption limits per namespace | Yes
Scalability | pod-disruption-budget | PodDisruptionBudget.yaml | Limits voluntary disruptions to maintain application availability during scaling | No
Scalability | topology-spread-constraints | TopologySpreadConstraints.yaml | Distributes pods evenly across failure domains for high availability | No
Scalability | kube-descheduler | KubeDescheduler.yaml | Evicts pods to rebalance cluster utilization and improve scheduling efficiency | No
Scalability | node-tuning-operator | PerformanceProfile.yaml | Configures low-latency tuning and CPU isolation for performance-sensitive workloads | No
````

I used this prompt in Cursor:

Look at the telco core csv file. This is used to generate telco-core-crs reference matrixes in the Telco Core RDS. Review the reference CR matrixes in the Telco Core RDS and update any matrix based on changes in the CSV file, or add a new module and matrix if a new section is added in the CSV file.

The output also removed TunedPerformancePatch, which might be a real bug. 