### PR TITLE
4.19 Revert "OSDOCS-16842-2:  CQA for NOP-1 AWS Load Balancer Operator (AL…

### DIFF
--- a/modules/adding-tls-termination.adoc
+++ b/modules/adding-tls-termination.adoc
@@ -6,12 +6,11 @@
 [id="nw-adding-tls-termination_{context}"]
 = Adding TLS termination on the AWS Load Balancer
 
-[role="_abstract"]
-To secure traffic for your domain, configure TLS termination on the AWS Load Balancer. This setup routes traffic to the pods of a service while ensuring that encrypted connections are decrypted at the load balancer level.
+You can route the traffic for the domain to pods of a service and add TLS termination on the AWS Load Balancer.
 
 .Prerequisites
 
-* You have access to the {oc-first}.
+* You have an access to the OpenShift CLI (`oc`).
 
 .Procedure
 
@@ -26,13 +25,9 @@ metadata:
   name: cluster
 spec:
   subnetTagging: Auto
-  ingressClass: tls-termination
-# ...
+  ingressClass: tls-termination <1>
 ----
-+
-where:
-+
-`spec.ingressClass`:: Specifies the ingress class name. If the ingress class is not present in your cluster the AWS Load Balancer Controller creates one. The AWS Load Balancer Controller reconciles the additional ingress class values if `spec.controller` is set to `ingress.k8s.aws/alb`.
+<1> Defines the ingress class name. If the ingress class is not present in your cluster the AWS Load Balancer Controller creates one. The AWS Load Balancer Controller reconciles the additional ingress class values if `spec.controller` is set to `ingress.k8s.aws/alb`.
 
 . Create a YAML file that defines the `Ingress` resource:
 +
@@ -42,31 +37,27 @@ where:
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: <example>
+  name: <example> <1>
   annotations:
-    alb.ingress.kubernetes.io/scheme: internet-facing
-    alb.ingress.kubernetes.io/certificate-arn: arn:aws:acm:us-west-2:xxxxx
+    alb.ingress.kubernetes.io/scheme: internet-facing <2>
+    alb.ingress.kubernetes.io/certificate-arn: arn:aws:acm:us-west-2:xxxxx <3>
 spec:
-  ingressClassName: tls-termination
+  ingressClassName: tls-termination <4>
   rules:
-  - host: example.com
+  - host: example.com <5>
     http:
         paths:
           - path: /
             pathType: Exact
             backend:
               service:
-                name: <example_service>
+                name: <example_service> <6>
                 port:
                   number: 80
-# ...
 ----
-+
-where:
-+
-`metadata.name`:: Specifies the ingress name.
-`annotations.alb.ingress.kubernetes.io/scheme`:: Specifies the controller that provisions the load balancer for ingress. The provisioning happens in a public subnet to access the load balancer over the internet.
-`annotations.alb.ingress.kubernetes.io/certificate-arn`:: Specifies the Amazon Resource Name (ARN) of the certificate that you attach to the load balancer.
-`spec.ingressClassName`:: Specifies the ingress class name.
-`rules.host`:: Specifies the domain for traffic routing.
-`backend.service`:: Specifies the service for traffic routing.
+<1> Specifies the ingress name.
+<2> The controller provisions the load balancer for ingress in a public subnet to access the load balancer over the internet.
+<3> The Amazon Resource Name (ARN) of the certificate that you attach to the load balancer.
+<4> Defines the ingress class name.
+<5> Defines the domain for traffic routing.
+<6> Defines the service for traffic routing.

--- a/modules/configuring-egress-proxy.adoc
+++ b/modules/configuring-egress-proxy.adoc
@@ -6,12 +6,7 @@
 [id="nw-configuring-cluster-wide-proxy_{context}"]
 = Trusting the certificate authority of the cluster-wide proxy
 
-[role="_abstract"]
-You can configure the cluster-wide proxy in the AWS Load Balancer Operator. After configuring the cluster-wide proxy, Operator Lifecycle Manager (OLM) automatically updates all the deployments of the Operators with the environment variables.
-
-Environment variables include `HTTP_PROXY`, `HTTPS_PROXY`, and `NO_PROXY`. These variables are populated to the managed controller by the AWS Load Balancer Operator.
-
-.Procedure
+You can configure the cluster-wide proxy in the AWS Load Balancer Operator. After configuring the cluster-wide proxy, Operator Lifecycle Manager (OLM) automatically updates all the deployments of the Operators with the environment variables such as `HTTP_PROXY`, `HTTPS_PROXY`, and `NO_PROXY`. These variables are populated to the managed controller by the AWS Load Balancer Operator.
 
 . Create the config map to contain the certificate authority (CA) bundle in the `aws-load-balancer-operator` namespace by running the following command:
 +

--- a/modules/creating-instance-aws-load-balancer-controller.adoc
+++ b/modules/creating-instance-aws-load-balancer-controller.adoc
@@ -6,13 +6,12 @@
 [id="nw-creating-instance-aws-load-balancer-controller_{context}"]
 = Creating the AWS Load Balancer Controller
 
-[role="_abstract"]
 You can install only a single instance of the `AWSLoadBalancerController` object in a cluster. You can create the AWS Load Balancer Controller by using CLI. The AWS Load Balancer Operator reconciles only the `cluster` named resource.
 
 .Prerequisites
 
 * You have created the `echoserver` namespace.
-* You have access to the {oc-first}.
+* You have access to the OpenShift CLI (`oc`).
 
 .Procedure
 
@@ -22,33 +21,30 @@ You can install only a single instance of the `AWSLoadBalancerController` object
 [source,yaml]
 ----
 apiVersion: networking.olm.openshift.io/v1
-kind: AWSLoadBalancerController
+kind: AWSLoadBalancerController <1>
 metadata:
-  name: cluster
+  name: cluster <2>
 spec:
-  subnetTagging: Auto
-  additionalResourceTags:
+  subnetTagging: Auto <3>
+  additionalResourceTags: <4>
   - key: example.org/security-scope
     value: staging
-  ingressClass: alb
+  ingressClass: alb <5>
   config:
-    replicas: 2
-  enabledAddons:
-    - AWSWAFv2
+    replicas: 2 <6>
+  enabledAddons: <7>
+    - AWSWAFv2 <8>
 ----
-+
-where:
-+
-`kind`:: Specifies the `AWSLoadBalancerController` object.
-`metadata.name`:: Specifies the AWS Load Balancer Controller name. The Operator adds this instance name as a suffix to all related resources.
-`spec.subnetTagging`:: Specifies the subnet tagging method for the AWS Load Balancer Controller. The following values are valid:
+<1> Defines the `AWSLoadBalancerController` object.
+<2> Defines the AWS Load Balancer Controller name. This instance name gets added as a suffix to all related resources.
+<3> Configures the subnet tagging method for the AWS Load Balancer Controller. The following values are valid:
 * `Auto`: The AWS Load Balancer Operator determines the subnets that belong to the cluster and tags them appropriately. The Operator cannot determine the role correctly if the internal subnet tags are not present on internal subnet.
 * `Manual`: You manually tag the subnets that belong to the cluster with the appropriate role tags. Use this option if you installed your cluster on user-provided infrastructure.
-`spec.additionalResourceTags`:: Specifies the tags used by the AWS Load Balancer Controller when it provisions AWS resources.
-`ingressClass`:: Specifies the ingress class name. The default value is `alb`.
-`config.replicas`:: Specifies the number of replicas of the AWS Load Balancer Controller.
-`enabledAddons`:: Specifies annotations as an add-on for the AWS Load Balancer Controller.
-`AWSWAFv2`:: Specifies that enablement of the `alb.ingress.kubernetes.io/wafv2-acl-arn` annotation.
+<4> Defines the tags used by the AWS Load Balancer Controller when it provisions AWS resources.
+<5> Defines the ingress class name. The default value is `alb`.
+<6> Specifies the number of replicas of the AWS Load Balancer Controller.
+<7> Specifies annotations as an add-on for the AWS Load Balancer Controller.
+<8> Enables the `alb.ingress.kubernetes.io/wafv2-acl-arn` annotation.
 
 . Create the `AWSLoadBalancerController` object by running the following command:
 +
@@ -63,15 +59,15 @@ $ oc create -f sample-aws-lb.yaml
 [source,yaml]
 ----
 apiVersion: apps/v1
-kind: Deployment
+kind: Deployment <1>
 metadata:
-  name: <echoserver>
+  name: <echoserver> <2>
   namespace: echoserver
 spec:
   selector:
     matchLabels:
       app: echoserver
-  replicas: 3
+  replicas: 3 <3>
   template:
     metadata:
       labels:
@@ -89,12 +85,9 @@ spec:
           ports:
             - containerPort: 8080
 ----
-+
-where:
-+
-`kind`:: Specifies the deployment resource.
-`metadata.name`:: Specifies the deployment name.
-`spec.replicas`:: Specifies the number of replicas of the deployment.
+<1> Defines the deployment resource.
+<2> Specifies the deployment name.
+<3> Specifies the number of replicas of the deployment.
 
 . Create a YAML file that defines the `Service` resource:
 +
@@ -102,9 +95,9 @@ where:
 [source,yaml]
 ----
 apiVersion: v1
-kind: Service
+kind: Service <1>
 metadata:
-  name: <echoserver>
+  name: <echoserver> <2>
   namespace: echoserver
 spec:
   ports:
@@ -115,11 +108,8 @@ spec:
   selector:
     app: echoserver
 ----
-+
-where:
-+
-`apiVersion`:: Specifies the service resource.
-`metadata.name`:: Specifies the service name.
+<1> Defines the service resource.
+<2> Specifies the service name.
 
 . Create a YAML file that defines the `Ingress` resource:
 +
@@ -129,7 +119,7 @@ where:
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: <name>
+  name: <name> <1>
   namespace: echoserver
   annotations:
     alb.ingress.kubernetes.io/scheme: internet-facing
@@ -143,15 +133,12 @@ spec:
             pathType: Exact
             backend:
               service:
-                name: <echoserver>
+                name: <echoserver> <2>
                 port:
                   number: 80
 ----
-+
-where:
-+
-`metadata.name`:: Specifies a name for the `Ingress` resource.
-`service.name`:: Specifies the service name.
+<1> Specify a name for the `Ingress` resource.
+<2> Specifies the service name.
 
 .Verification
 

--- a/modules/creating-multiple-ingress-through-single-alb.adoc
+++ b/modules/creating-multiple-ingress-through-single-alb.adoc
@@ -6,12 +6,11 @@
 [id="nw-creating-multiple-ingress-through-single-alb_{context}"]
 = Creating multiple ingress resources through a single AWS Load Balancer
 
-[role="_abstract"]
-To route traffic to different services within a single domain, configure multiple ingress resources on a single AWS Load Balancer. This setup allows each resource to provide different endpoints while sharing the same load balancing infrastructure.
+You can route the traffic to different services with multiple ingress resources that are part of a single domain through a single AWS Load Balancer. Each ingress resource provides different endpoints of the domain.
 
 .Prerequisites
 
-* You have access to the {oc-first}.
+* You have an access to the OpenShift CLI (`oc`).
 
 .Procedure
 
@@ -19,20 +18,17 @@ To route traffic to different services within a single domain, configure multipl
 +
 [source,yaml]
 ----
-apiVersion: elbv2.k8s.aws/v1beta1
+apiVersion: elbv2.k8s.aws/v1beta1 <1>
 kind: IngressClassParams
 metadata:
-  name: single-lb-params
+  name: single-lb-params <2>
 spec:
   group:
-    name: single-lb
+    name: single-lb <3>
 ----
-+
-where:
-+
-`apiVersion`:: Specifies the API group and version of the `IngressClassParams` resource.
-`metadata.name`:: Specifies the `IngressClassParams` resource name.
-`spec.group.name`:: Specifies the `IngressGroup` resource name. All of the `Ingress` resources of this class belong to this `IngressGroup`.
+<1> Defines the API group and version of the `IngressClassParams` resource.
+<2> Specifies the `IngressClassParams` resource name.
+<3> Specifies the `IngressGroup` resource name. All of the `Ingress` resources of this class belong to this `IngressGroup`.
 
 . Create the `IngressClassParams` resource by running the following command:
 +
@@ -45,26 +41,23 @@ $ oc create -f sample-single-lb-params.yaml
 +
 [source,yaml]
 ----
-apiVersion: networking.k8s.io/v1
+apiVersion: networking.k8s.io/v1 <1>
 kind: IngressClass
 metadata:
-  name: single-lb
+  name: single-lb <2>
 spec:
-  controller: ingress.k8s.aws/alb
+  controller: ingress.k8s.aws/alb <3>
   parameters:
-    apiGroup: elbv2.k8s.aws
-    kind: IngressClassParams
-    name: single-lb-params
+    apiGroup: elbv2.k8s.aws <4>
+    kind: IngressClassParams <5>
+    name: single-lb-params <6>
 ----
-+
-where:
-+
-`apiVersion`:: Specifies the API group and version of the `IngressClass` resource.
-`metadata.name`:: Specifies the ingress class name.
-`spec.controller`:: Specifies the controller name. The `ingress.k8s.aws/alb` value denotes that all ingress resources of this class should be managed by the AWS Load Balancer Controller.
-`parameters.apiGroup`:: Specifies the API group of the `IngressClassParams` resource.
-`parameters.kind`:: Specifies the resource type of the `IngressClassParams` resource.
-`parameters.name`:: Specifies the `IngressClassParams` resource name.
+<1> Defines the API group and version of the `IngressClass` resource.
+<2> Specifies the ingress class name.
+<3> Defines the controller name. The `ingress.k8s.aws/alb` value denotes that all ingress resources of this class should be managed by the AWS Load Balancer Controller.
+<4> Defines the API group of the `IngressClassParams` resource.
+<5> Defines the resource type of the `IngressClassParams` resource.
+<6> Defines the `IngressClassParams` resource name.
 
 . Create the `IngressClass` resource by running the following command:
 +
@@ -83,12 +76,9 @@ metadata:
   name: cluster
 spec:
   subnetTagging: Auto
-  ingressClass: single-lb
+  ingressClass: single-lb <1>
 ----
-+
-where:
-+
-`spec.ingressClass`:: Specifies the name of the `IngressClass` resource.
+<1> Defines the name of the `IngressClass` resource.
 
 . Create the `AWSLoadBalancerController` resource by running the following command:
 +
@@ -104,24 +94,24 @@ $ oc create -f sample-single-lb.yaml
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: example-1
+  name: example-1 <1>
   annotations:
-    alb.ingress.kubernetes.io/scheme: internet-facing
-    alb.ingress.kubernetes.io/group.order: "1"
-    alb.ingress.kubernetes.io/target-type: instance
+    alb.ingress.kubernetes.io/scheme: internet-facing <2>
+    alb.ingress.kubernetes.io/group.order: "1" <3>
+    alb.ingress.kubernetes.io/target-type: instance <4>
 spec:
-  ingressClassName: single-lb
+  ingressClassName: single-lb <5>
   rules:
-  - host: example.com
+  - host: example.com <6>
     http:
         paths:
-        - path: /blog
+        - path: /blog <7>
           pathType: Prefix
           backend:
             service:
-              name: example-1
+              name: example-1 <8>
               port:
-                number: 80
+                number: 80 <9>
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
@@ -167,18 +157,15 @@ spec:
               port:
                 number: 80
 ----
-+
-where:
-+
-`metadata.name`:: Specifies the ingress name.
-`alb.ingress.kubernetes.io/scheme`:: Specifies the load balancer to provision in the public subnet to access the internet.
-`alb.ingress.kubernetes.io/group.order`:: Specifies the order in which the rules from the multiple ingress resources are matched when the request is received at the load balancer.
-`alb.ingress.kubernetes.io/target-type`:: Specifies that the load balancer will target {product-title} nodes to reach the service.
-`spec.ingressClassName`:: Specifies the ingress class that belongs to this ingress.
-`rules.host`:: Specifies a domain name used for request routing.
-`http.paths.path`:: Specifies the path that must route to the service.
-`backend.service.name`:: Specifies the service name that serves the endpoint configured in the `Ingress` resource.
-`port.number`:: Specifies the port on the service that serves the endpoint.
+<1> Specifies the ingress name.
+<2> Indicates the load balancer to provision in the public subnet to access the internet.
+<3> Specifies the order in which the rules from the multiple ingress resources are matched when the request is received at the load balancer.
+<4> Indicates that the load balancer will target {product-title} nodes to reach the service.
+<5> Specifies the ingress class that belongs to this ingress.
+<6> Defines a domain name used for request routing.
+<7> Defines the path that must route to the service.
+<8> Defines the service name that serves the endpoint configured in the `Ingress` resource.
+<9> Defines the port on the service that serves the endpoint.
 
 . Create the `Ingress` resource by running the following command:
 +

--- a/modules/installing-aws-load-balancer-operator-cli.adoc
+++ b/modules/installing-aws-load-balancer-operator-cli.adoc
@@ -6,19 +6,20 @@
 [id="nw-installing-aws-load-balancer-operator-cli_{context}"]
 = Installing the AWS Load Balancer Operator by using the CLI
 
-[role="_abstract"]
-To deploy the AWS Load Balancer Controller, install the AWS Load Balancer Operator by using the command-line interface (CLI).
+You can install the AWS Load Balancer Operator by using the CLI.
 
 .Prerequisites
 
 * You are logged in to the {product-title} web console as a user with `cluster-admin` permissions.
+
 * Your cluster is configured with AWS as the platform type and cloud provider.
-* You have logged into the {oc-first}.
+
+* You are logged into the OpenShift CLI (`oc`).
 
 .Procedure
 
 . Create a `Namespace` object:
-+
+
 .. Create a YAML file that defines the `Namespace` object:
 +
 .Example `namespace.yaml` file
@@ -28,9 +29,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: aws-load-balancer-operator
-# ...
 ----
-+
+
 .. Create the `Namespace` object by running the following command:
 +
 [source,terminal]
@@ -39,7 +39,7 @@ $ oc apply -f namespace.yaml
 ----
 
 . Create an `OperatorGroup` object:
-+
+
 .. Create a YAML file that defines the `OperatorGroup` object:
 +
 .Example `operatorgroup.yaml` file
@@ -53,7 +53,7 @@ metadata:
 spec:
   upgradeStrategy: Default
 ----
-+
+
 .. Create the `OperatorGroup` object by running the following command:
 +
 [source,terminal]
@@ -62,7 +62,7 @@ $ oc apply -f operatorgroup.yaml
 ----
 
 . Create a `Subscription` object:
-+
+
 .. Create a YAML file that defines the `Subscription` object:
 +
 .Example `subscription.yaml` file
@@ -80,7 +80,7 @@ spec:
   source: redhat-operators
   sourceNamespace: openshift-marketplace
 ----
-+
+
 .. Create the `Subscription` object by running the following command:
 +
 [source,terminal]
@@ -108,4 +108,4 @@ $ oc -n aws-load-balancer-operator \
   --template='{{.status.phase}}{{"\n"}}'
 ----
 +
-The output must be `Complete`.
+The output must be `Complete`. 

--- a/modules/installing-aws-load-balancer-operator.adoc
+++ b/modules/installing-aws-load-balancer-operator.adoc
@@ -6,33 +6,26 @@
 [id="nw-installing-aws-load-balancer-operator_{context}"]
 = Installing the AWS Load Balancer Operator by using the web console
 
-[role="_abstract"]
-To deploy the AWS Load Balancer Operator, install the Operator by using the web console. You can manage the lifecycle of the Operator by using a graphical interface.
+You can install the AWS Load Balancer Operator by using the web console.
 
 .Prerequisites
 
 * You have logged in to the {product-title} web console as a user with `cluster-admin` permissions.
+
 * Your cluster is configured with AWS as the platform type and cloud provider.
+
 * If you are using a security token service (STS) or user-provisioned infrastructure, follow the related preparation steps. For example, if you are using AWS Security Token Service, see "Preparing for the AWS Load Balancer Operator on a cluster using the AWS Security Token Service (STS)".
 
 .Procedure
 
 . Navigate to *Operators* → *OperatorHub* in the {product-title} web console.
-
-. Select the *AWS Load Balancer Operator*. You can use the *Filter by keyword* text box or the filter list to search for the AWS Load Balancer Operator from the list of Operators.
-
+. Select the *AWS Load Balancer Operator*. You can use the *Filter by keyword* text box or use the filter list to search for the AWS Load Balancer Operator from the list of Operators.
 . Select the `aws-load-balancer-operator` namespace.
-
 . On the *Install Operator* page, select the following options:
-+
-.. For the *Update the channel* option, select *stable-v1*.
-+
-.. For the *Installation mode* option, select *All namespaces on the cluster (default)*.
-+
-.. For the *Installed Namespace* option, select `aws-load-balancer-operator`. If the `aws-load-balancer-operator` namespace does not exist, it gets created during the Operator installation.
-+
-.. Select *Update approval* as *Automatic* or *Manual*. By default, the *Update approval* is set to *Automatic*. If you select automatic updates, the Operator Lifecycle Manager (OLM) automatically upgrades the running instance of your Operator without any intervention. If you select manual updates, the OLM creates an update request. As a cluster administrator, you must then manually approve that update request to have the Operator update to the newer version.
-
+.. *Update the channel* as *stable-v1*.
+.. *Installation mode* as *All namespaces on the cluster (default)*.
+.. *Installed Namespace* as `aws-load-balancer-operator`. If the `aws-load-balancer-operator` namespace does not exist, it gets created during the Operator installation.
+.. Select *Update approval* as *Automatic* or *Manual*. By default, the *Update approval* is set to *Automatic*. If you select automatic updates, the Operator Lifecycle Manager (OLM) automatically upgrades the running instance of your Operator without any intervention. If you select manual updates, the OLM creates an update request. As a cluster administrator, you must then manually approve that update request to update the Operator updated to the new version.
 . Click *Install*.
 
 .Verification

--- a/modules/nw-aws-load-balancer-logs.adoc
+++ b/modules/nw-aws-load-balancer-logs.adoc
@@ -5,8 +5,7 @@
 [id="nw-aws-load-balancer-operator-logs_{context}"]
 = AWS Load Balancer Operator logs
 
-[role="_abstract"]
-To troubleshoot the AWS Load Balancer Operator, view the logs using the `oc logs` command. By viewing the logs, you can diagnose issues and monitor the activity of the Operator.
+You can view the AWS Load Balancer Operator logs by using the `oc logs` command.
 
 .Procedure
 

--- a/networking/networking_operators/aws_load_balancer_operator/install-aws-load-balancer-operator.adoc
+++ b/networking/networking_operators/aws_load_balancer_operator/install-aws-load-balancer-operator.adoc
@@ -6,8 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-[role="_abstract"]
-The AWS Load Balancer Operator deploys and manages the AWS Load Balancer Controller. You can install the AWS Load Balancer Operator from the software catalog by using {product-title} web console or CLI.
+The AWS Load Balancer Operator deploys and manages the AWS Load Balancer Controller. You can install the AWS Load Balancer Operator from the OperatorHub by using {product-title} web console or CLI.
 
 include::modules/installing-aws-load-balancer-operator.adoc[leveloffset=+1]
 


### PR DESCRIPTION
Issues:

https://redhat.atlassian.net/browse/OSDOCS-18673 and https://redhat.atlassian.net/browse/OSDOCS-16842

Version:
4.19

Ran command `git revert -m 1 7c3be4b2ecb4ff10c75fc17f78a1c5b2845d63a9`, which is the commit from https://github.com/openshift/openshift-docs/pull/105438/commits (8 files)

Git blame identified that my CQA edits were the last edits for the listed files on this PR, so no merge conflicts. 

Previews: