### PR TITLE
OSDOCS-19162: Updated viewing-stats-collected-kubernetes-nmtate-op.ad…

### DIFF
--- a/modules/viewing-stats-collected-kubernetes-nmtate-op.adoc
+++ b/modules/viewing-stats-collected-kubernetes-nmtate-op.adoc
@@ -7,7 +7,15 @@
 = Viewing metrics collected by the Kubernetes NMState Operator
 
 [role="_abstract"]
-The Kubernetes NMState Operator, `kubernetes-nmstate-operator`, can collect metrics from the `kubernetes_nmstate_features_applied` component and expose them as ready-to-use metrics. As a use case for viewing metrics, consider a situation where you created a `NodeNetworkConfigurationPolicy` custom resource (CR) and you want to confirm that the policy is active.
+The Kubernetes NMState Operator, `kubernetes-nmstate-operator`, can collect metrics from the Kubernetes components and expose them as ready-to-use metrics.
+
+The Kubernetes NMState Operator can collect metrics from the following Kubernetes components:
+
+* `kubernetes_nmstate_features_applied`, which tracks what NMState features are enabled and successfully applied to the cluster. 
+* `kubernetes_nmstate_policies_status`, which tracks the active status of `NodeNetworkConfigurationPolicy` (NNCP) resources across the cluster.
+* `kubernetes_nmstate_enactments_status`, which tracks the active status of `NodeNetworkConfigurationEnactment` (NNCE) resources on a per-node basis.
+
+As a use case for viewing metrics, consider a situation where you created a `NodeNetworkConfigurationPolicy` custom resource (CR) and you want to confirm that the policy is active.
 
 [NOTE]
 ====


### PR DESCRIPTION
Version(s):
4.22

Issue:
[OSDOCS-19162](https://redhat.atlassian.net/browse/OSDOCS-19162)

Link to docs preview:

* [Viewing metrics collected by the Kubernetes NMState Operator](https://110345--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/networking_operators/k8s-nmstate-about-the-k8s-nmstate-operator.html#viewing-stats-collected-kubernetes-nmtate-op_k8s-nmstate-operator)

- [x] SME has approved this change.
- [x] QE has approved this change.
