### PR TITLE
DOCPLAN-164: ocp virt storage docs 02

### DIFF
--- a/modules/virt-about-creating-storage-classes.adoc
+++ b/modules/virt-about-creating-storage-classes.adoc
@@ -9,7 +9,7 @@
 [role="_abstract"]
 When you create a storage class, you set parameters that affect the dynamic provisioning of persistent volumes (PVs) that belong to that storage class. You cannot update a `StorageClass` object's parameters after you create it.
 
-In order to use the hostpath provisioner (HPP) you must create an associated storage class for the CSI driver with the `storagePools` stanza.
+To use the hostpath provisioner (HPP) you must create an associated storage class for the CSI driver with the `storagePools` stanza.
 
 [NOTE]
 ====

--- a/modules/virt-about-fusion-access-san.adoc
+++ b/modules/virt-about-fusion-access-san.adoc
@@ -9,7 +9,7 @@
 [role="_abstract"]
 {IBMFusionFirst} provides a scalable clustered file system for enterprise storage, primarily designed to offer access to consolidated, block-level data storage. It presents storage devices, such as disk arrays, to the operating system as if they were direct-attached storage.
 
-This solution is particularly geared towards enterprise storage for {VirtProductName} and leverages existing Storage Area Network (SAN) infrastructure. A SAN is a dedicated network of storage devices that is typically not accessible through the local area network (LAN).
+{IBMFusionFirst} uses existing Storage Area Network (SAN) infrastructure to provide enterprise storage for {VirtProductName}. A SAN is a dedicated network of storage devices that is typically not accessible through the local area network (LAN).
 
 To use {VirtProductName} with {IBMFusionFirst}, you must first install the {FusionSAN} Operator.
 
@@ -18,11 +18,11 @@ Then you must create a Kubernetes pull secret and create the `FusionAccess` cust
 Finally, follow the {product-title} web console wizard to configure the storage cluster, local disk, and file systems.
 
 [id="why-use-fusion-san_{context}"]
-== Why use {FusionSAN}?
+== Why use {FusionSAN}
 
 Easy user experience:: {FusionSAN} features a wizard-driven user interface (UI) for installing and configuring storage clusters, file systems, and storage classes, to simplify the setup process.
 
-Leverage existing infrastructure:: Organizations can leverage their existing SAN investments, including Fibre Channel (FC) and iSCSI technologies, as they transition to or expand with {VirtProductName}.
+Use existing infrastructure:: Organizations can use their existing SAN investments, including Fibre Channel (FC) and iSCSI technologies, as they migrate to or expand with {VirtProductName}.
 
 Scalability:: The storage cluster is designed to scale with {product-title} clusters and virtual machine (VM) workloads. It can support up to approximately 3000 VMs on 6 bare-metal hosts, with possibilities for further scaling by adding more file systems or using specific storage class parameters.
 
@@ -32,4 +32,4 @@ High-speed data transfer:: By using a dedicated high-speed network for storage, 
 
 File-level access:: Although a SAN primarily operates at the block level, file systems built on top of SAN storage can provide file-level access through shared-disk file systems.
 
-Centralized management:: The underlying SAN software manages servers, storage devices, and the network to ensure that data moves directly between storage devices with minimal server intervention. It also supports centralized management and configuration of SAN components like Logical Unit Numbers (LUNs).
+Centralized management:: The underlying SAN software manages servers, storage devices, and the network to ensure that data moves directly between storage devices with minimal server intervention. It also supports centralized management and configuration of SAN components such as Logical Unit Numbers (LUNs).

--- a/modules/virt-about-storage-pools-pvc-templates.adoc
+++ b/modules/virt-about-storage-pools-pvc-templates.adoc
@@ -31,6 +31,6 @@ spec:
 
 The `spec.volumeMode` value is only required for block volume mode PVs.
 
-You define a storage pool using a `pvcTemplate` specification in the HPP CR. The Operator creates a PVC from the `pvcTemplate` specification for each node containing the HPP CSI driver. The PVC created from the PVC template consumes the single large PV, allowing the HPP to create smaller dynamic volumes.
+You define a storage pool by using a `pvcTemplate` specification in the HPP CR. The Operator creates a PVC from the `pvcTemplate` specification for each node containing the HPP CSI driver. The PVC created from the PVC template consumes the single large PV, allowing the HPP to create smaller dynamic volumes.
 
 You can combine basic storage pools with storage pools created from PVC templates.

--- a/modules/virt-cdi-supported-operations-matrix.adoc
+++ b/modules/virt-cdi-supported-operations-matrix.adoc
@@ -18,7 +18,7 @@
 This matrix shows the supported CDI operations for content types against endpoints, and which of these operations requires scratch space.
 
 |===
-|Content types | HTTP | HTTPS | HTTP basic auth | Registry | Upload
+|Content types | HTTP | HTTPS | Basic HTTP authentication | Registry | Upload
 
 | KubeVirt (QCOW2)
 a|&#10003; QCOW2
@@ -51,32 +51,32 @@ a| &#10003; QCOW2*
 
 &#10003; XZ*
 
-| KubeVirt (RAW)
-a|&#10003; RAW
+| KubeVirt (raw)
+a|&#10003; raw
 
 &#10003; GZ
 
 &#10003; XZ
 
-a|&#10003; RAW
+a|&#10003; raw
 
 &#10003; GZ
 
 &#10003; XZ
 
-a| &#10003; RAW
+a| &#10003; raw
 
 &#10003; GZ
 
 &#10003; XZ
 
-a| &#10003; RAW*
+a| &#10003; raw*
 
 &#9633; GZ
 
 &#9633; XZ
 
-a| &#10003; RAW*
+a| &#10003; raw*
 
 &#10003; GZ*
 

--- a/modules/virt-creating-filesystem-fusion-access-san.adoc
+++ b/modules/virt-creating-filesystem-fusion-access-san.adoc
@@ -25,9 +25,9 @@ The file system is based on the storage available in the worker nodes you select
 
 . Select the LUNs that you want to use as the storage volumes for your file system.
 
-. Click *Create file system*. 
+. Click *Create file system*.
 +
-The *{FusionSAN}* page reloads, and the new file system appears in the *File systems* tab.
+The *{FusionSAN}* page reloads, and the new file system is displayed in the *File systems* tab.
 
 .Next steps
 
@@ -35,14 +35,9 @@ Repeat this procedure for each file system that you want to create.
 
 .Verification
 
-. Watch the *Status* of the file system in the *File systems* tab until it is marked as *Healthy*.
-+
-[NOTE]
-====
-This may take several minutes.
-====
+. Watch the *Status* of the file system in the *File systems* tab until it is marked as *Healthy*. This might take several minutes.
 
-. Click on the *StorageClass* for the file system.
+. Click the *StorageClass* for the file system.
 
 . In the *YAML* tab, verify the following:
 +

--- a/modules/virt-creating-fusionaccess-cr.adoc
+++ b/modules/virt-creating-fusionaccess-cr.adoc
@@ -21,7 +21,7 @@ Creating the `FusionAccess` CR triggers the installation of the correct version 
 
 . In the {product-title} web console, navigate to *Ecosystem* -> *Installed Operators*.
 
-. Click on the {FusionSAN} Operator you installed.
+. Click the {FusionSAN} Operator you installed.
 
 . In the *Fusion Access for SAN* page, select the *Fusion Access* tab.
 
@@ -37,4 +37,4 @@ Creating the `FusionAccess` CR triggers the installation of the correct version 
 
 .Verification
 
-* In the *Fusion Access for SAN* Operator page, in the *Fusion Access* tab, verify that the created `FusionAccess` CR appears with the status *Ready*.
+* In the *Fusion Access for SAN* Operator page, in the *Fusion Access* tab, verify that the created `FusionAccess` CR is displayed with the status *Ready*.

--- a/modules/virt-creating-hpp-basic-storage-pool.adoc
+++ b/modules/virt-creating-hpp-basic-storage-pool.adoc
@@ -33,14 +33,15 @@ metadata:
 spec:
   imagePullPolicy: IfNotPresent
   storagePools:
-  - name: any_name <1>
-    path: "/var/myvolumes" <2>
+  - name: any_name
+    path: "/var/myvolumes"
   workload:
     nodeSelector:
       kubernetes.io/os: linux
 ----
-<1> Specifies the name to identify the source to use. It must be the same as the `storagePools` name in the `StorageClass.yaml`. For example, `local`.
-<2> Specifies the storage pool directories under this node path. Ensure that the path `/var/myvolumes` has been created on each worker node.
++
+* `spec.storagePools.name` defines the name to identify the source to use. It must be the same as the `storagePools` name in the `StorageClass.yaml`.
+* `spec.storagePools.path` defines the storage pool directories under this node path. Ensure that the path `/var/myvolumes` value specifies a directory that exists on each worker node.
 
 . Save the file and exit.
 

--- a/modules/virt-creating-pull-secret-fusion-san.adoc
+++ b/modules/virt-creating-pull-secret-fusion-san.adoc
@@ -27,14 +27,13 @@ After installing the {FusionSAN} Operator, you must create a Kubernetes secret o
 
 . Save the entitlement key in a safe place.
 
-. Create the secret object by running the `oc create` command:
+. Create the secret object by running the `oc create` command, replacing `<ibm-entitlement-key>` with the entitlement key that you copied in step 2.
 +
 [source,terminal]
 ----
 $ oc create secret -n ibm-fusion-access generic fusion-pullsecret \
---from-literal=ibm-entitlement-key=<ibm-entitlement-key> <1>
+--from-literal=ibm-entitlement-key=<ibm-entitlement-key>
 ----
-<1> This is the entitlement key you copied in step 2 from the *IBM Container software library*.
 
 .Verification
 

--- a/modules/virt-creating-storage-pool-pvc-template.adoc
+++ b/modules/virt-creating-storage-pool-pvc-template.adoc
@@ -7,7 +7,7 @@
 = Creating a storage pool with a PVC template
 
 [role="_abstract"]
-You can create a storage pool for multiple hostpath provisioner (HPP) volumes by specifying a PVC template in the HPP custom resource (CR).
+You can create a storage pool for multiple hostpath provisioner (HPP) volumes by specifying a persistent volume claim (PVC) template in the HPP custom resource (CR).
 
 [IMPORTANT]
 ====
@@ -21,7 +21,7 @@ Do not create storage pools in the same partition as the operating system. Other
 
 .Procedure
 
-. Create an `hpp_pvc_template_pool.yaml` file for the HPP CR that specifies a persistent volume (PVC) template in the `storagePools` stanza according to the following example:
+. Create an `hpp_pvc_template_pool.yaml` file for the HPP CR that specifies a PVC template in the `storagePools` stanza according to the following example:
 +
 [source,yaml]
 ----
@@ -31,26 +31,27 @@ metadata:
   name: hostpath-provisioner
 spec:
   imagePullPolicy: IfNotPresent
-  storagePools: <1>
+  storagePools:
   - name: my-storage-pool
-    path: "/var/myvolumes" <2>
+    path: "/var/myvolumes"
     pvcTemplate:
-      volumeMode: Block <3>
-      storageClassName: my-storage-class <4>
+      volumeMode: Block
+      storageClassName: my-storage-class
       accessModes:
       - ReadWriteOnce
       resources:
         requests:
-          storage: 5Gi <5>
+          storage: 5Gi
   workload:
     nodeSelector:
       kubernetes.io/os: linux
 ----
-<1> The `storagePools` stanza is an array that can contain both basic and PVC template storage pools.
-<2> Specify the storage pool directories under this node path.
-<3> Optional: The `volumeMode` parameter can be either `Block` or `Filesystem` as long as it matches the provisioned volume format. If no value is specified, the default is `Filesystem`. If the `volumeMode` is `Block`, the mounting pod creates an XFS file system on the block volume before mounting it.
-<4> If the `storageClassName` parameter is omitted, the default storage class is used to create PVCs. If you omit `storageClassName`, ensure that the HPP storage class is not the default storage class.
-<5> You can specify statically or dynamically provisioned storage. In either case, ensure the requested storage size is appropriate for the volume you want to virtually divide or the PVC cannot be bound to the large PV. If the storage class you are using uses dynamically provisioned storage, pick an allocation size that matches the size of a typical request.
++
+* `spec.storagePools` defines an array that can contain both basic and PVC template storage pools.
+* `spec.storagePools.path` defines the storage pool directories under this node path.
+* `spec.storagePools.pvcTemplate.volumeMode` is an optional parameter, which can be either `Block` or `Filesystem` if it matches the provisioned volume format. If no value is specified, the default is `Filesystem`. If the `volumeMode` is `Block`, the mounting pod creates an XFS file system on the block volume before mounting it.
+* `spec.storagePools.pvcTemplate.storageClassName` specifies if the `storageClassName` parameter is omitted, the default storage class is used to create PVCs. If you omit `storageClassName`, ensure that the HPP storage class is not the default storage class.
+* `spec.storagePools.pvcTemplate.resources.requests.storage` defines the storage request for statically or dynamically provisioned storage. Ensure the requested storage size is appropriate for the volume you want to virtually divide or the PVC cannot be bound to the large PV. If the storage class uses dynamically provisioned storage, pick an allocation size that matches the size of a typical request.
 
 . Save the file and exit.
 

--- a/modules/virt-customizing-storage-profile-default-cloning-strategy.adoc
+++ b/modules/virt-customizing-storage-profile-default-cloning-strategy.adoc
@@ -11,17 +11,19 @@ You can use storage profiles to set a default cloning method for a storage class
 
 Cloning strategies are specified by setting the `cloneStrategy` attribute in a storage profile to one of the following values:
 
-* `snapshot` is used by default when snapshots are configured. The Containerized Data Importer (CDI) will use the snapshot method if it recognizes the storage provider and the provider supports Container Storage Interface (CSI) snapshots. This cloning strategy uses a temporary volume snapshot to clone the volume.
+* `snapshot` is used by default when snapshots are configured. The Containerized Data Importer (CDI) uses the snapshot method if it recognizes the storage provider and the provider supports Container Storage Interface (CSI) snapshots. This cloning strategy uses a temporary volume snapshot to clone the volume.
 * `copy` uses a source pod and a target pod to copy data from the source volume to the target volume. Host-assisted cloning is the least efficient method of cloning.
-* `csi-clone` uses the CSI clone API to efficiently clone an existing volume without using an interim volume snapshot. Unlike `snapshot` or `copy`, which are used by default if no storage profile is defined, CSI volume cloning is only used when you specify it in the `StorageProfile` object for the provisioner's storage class.
+* `csi-clone` uses the CSI clone API to efficiently clone an existing volume without using an interim volume snapshot. Unlike `snapshot` or `copy`, which are used by default if no storage profile is defined, CSI volume cloning is used only when you specify it in the `StorageProfile` object for the storage class of the provisioner.
 
 [NOTE]
 ====
-You can set clone strategies using the CLI without modifying the default `claimPropertySets` in your YAML `spec` section.
+You can set clone strategies by using the CLI without modifying the default `claimPropertySets` in your YAML `spec` section.
 ====
 
-Example storage profile:
+.Procedure
 
+. Create or edit a `StorageProfile` object to define the cloning strategy. In the `spec` section, set the `cloneStrategy` field and define the required `claimPropertySets` values, as shown in the following example.
++
 [source,yaml]
 ----
 apiVersion: cdi.kubevirt.io/v1beta1
@@ -32,13 +34,20 @@ metadata:
 spec:
   claimPropertySets:
   - accessModes:
-    - ReadWriteOnce <1>
-    volumeMode:  Filesystem <2>
-  cloneStrategy: csi-clone <3>
+    - ReadWriteOnce
+    volumeMode: Filesystem
+  cloneStrategy: csi-clone
 status:
   provisioner: <provisioner>
   storageClass: <provisioner_class>
 ----
-<1> Specify the `accessModes`.
-<2> Specify the `volumeMode`.
-<3> Specify the default `cloneStrategy`.
++
+* `accessModes` and `volumeMode` define the claim properties.
+* `cloneStrategy` sets the default cloning method.
+
+. Apply the configuration:
++
+[source,terminal]
+----
+$ oc apply -f <storage_profile>.yaml
+----

--- a/modules/virt-customizing-storage-profile-snapshot-class-cli.adoc
+++ b/modules/virt-customizing-storage-profile-snapshot-class-cli.adoc
@@ -6,7 +6,8 @@
 [id="virt-customizing-storage-profile-snapshot-class-cli_{context}"]
 = Specifying a volume snapshot class by using the CLI
 
-If you are creating a snapshot of a VM, a warning appears if the storage class of the disk has more than one volume snapshot class associated with it. In this case, you must specify one volume snapshot class; otherwise, any disk that has more than one volume snapshot class is excluded from the snapshots list.
+[role="_abstract"]
+If you are creating a snapshot of a VM, a warning is displayed if the storage class of the disk has more than one volume snapshot class associated with it. In this case, you must specify one volume snapshot class; otherwise, any disk that has more than one volume snapshot class is excluded from the snapshots list.
 
 You can select which volume snapshot class to use by either:
 

--- a/modules/virt-customizing-storage-profile-snapshot-class-web.adoc
+++ b/modules/virt-customizing-storage-profile-snapshot-class-web.adoc
@@ -6,7 +6,8 @@
 [id="virt-customizing-storage-profile-snapshot-class_web_{context}"]
 = Specifying a volume snapshot class by using the web console
 
-If you are creating a snapshot of a VM, a warning appears if the storage class of the disk has more than one volume snapshot class associated with it. In this case, you must specify one volume snapshot class; otherwise, any disk that has more than one volume snapshot class is excluded from the snapshots list.
+[role="_abstract"]
+If you are creating a snapshot of a VM, a warning is displayed if the storage class of the disk has more than one volume snapshot class associated with it. In this case, you must specify one volume snapshot class. Otherwise, any disk that has more than one volume snapshot class is excluded from the snapshots list.
 
 You can specify the default volume snapshot class in the {product-title} web console.
 

--- a/modules/virt-customizing-storage-profile.adoc
+++ b/modules/virt-customizing-storage-profile.adoc
@@ -6,13 +6,14 @@
 [id="virt-customizing-storage-profile_{context}"]
 = Customizing the storage profile
 
-You can specify default parameters by editing the `StorageProfile` object for the provisioner's storage class. These default parameters only apply to the persistent volume claim (PVC) if they are not configured in the `DataVolume` object.
+[role="_abstract"]
+You can specify default parameters by editing the `StorageProfile` object for the storage class of the provisioner. These default parameters only apply to the persistent volume claim (PVC) if they are not configured in the `DataVolume` object.
 
 You cannot modify storage class parameters. To make changes, delete and re-create the storage class. You must then reapply any customizations that were previously made to the storage profile.
 
 An empty `status` section in a storage profile indicates that a storage provisioner is not recognized by the Containerized Data Importer (CDI). Customizing a storage profile is necessary if you have a storage provisioner that is not recognized by CDI. In this case, the administrator sets appropriate values in the storage profile to ensure successful allocations.
 
-If you are creating a snapshot of a VM, a warning appears if the storage class of the disk has more than one `VolumeSnapshotClass` associated with it. In this case, you must specify one volume snapshot class; otherwise, any disk that has more than one volume snapshot class is excluded from the snapshots list.
+If you are creating a snapshot of a VM, a warning is displayed if the storage class of the disk has more than one `VolumeSnapshotClass` associated with it. In this case, you must specify one volume snapshot class. Otherwise, any disk that has more than one volume snapshot class is excluded from the snapshots list.
 
 [WARNING]
 ====
@@ -46,11 +47,12 @@ metadata:
 spec:
   claimPropertySets:
   - accessModes:
-    - ReadWriteOnce <1>
-    volumeMode: Filesystem <2>
+    - ReadWriteOnce
+    volumeMode: Filesystem
 status:
   provisioner: <unknown_provisioner>
   storageClass: <unknown_provisioner_class>
 ----
-<1> Specify the `accessModes`.
-<2> Specify the `volumeMode`.
++
+* `spec.claimPropertySets.accessModes` defines how the volume can be mounted. For example, `ReadWriteOnce`
+* `spec.claimPropertySets.accessModes.volumeMode` defines whether the volume uses a file system or raw block storage. For example, `volumeMode`.

--- a/modules/virt-defining-storageclass.adoc
+++ b/modules/virt-defining-storageclass.adoc
@@ -22,7 +22,7 @@ You can define the storage class that the Containerized Data Importer (CDI) uses
 $ oc edit {HCOCliKind} kubevirt-hyperconverged -n {CNVNamespace}
 ----
 
-. Add the `spec.scratchSpaceStorageClass` field to the CR, setting the value to the name of a storage class that exists in the cluster:
+. Add the `spec.scratchSpaceStorageClass` field to the CR and set the value to the name of a storage class that exists in the cluster. If you do not specify a storage class, CDI uses the storage class of the persistent volume claim that is being populated.
 +
 [source,yaml]
 ----
@@ -31,8 +31,7 @@ kind: HyperConverged
 metadata:
   name: kubevirt-hyperconverged
 spec:
-  scratchSpaceStorageClass: "<storage_class>" <1>
+  scratchSpaceStorageClass: "<storage_class>"
 ----
-<1> If you do not specify a storage class, CDI uses the storage class of the persistent volume claim that is being populated.
 
 . Save and exit your default editor to update the `HyperConverged` CR.

--- a/modules/virt-dv-annotations.adoc
+++ b/modules/virt-dv-annotations.adoc
@@ -7,9 +7,9 @@
 = Example: Data volume annotations
 
 [role="_abstract"]
-This example shows how you can configure data volume (DV) annotations to control which network the importer pod uses. The `v1.multus-cni.io/default-network: bridge-network` annotation causes the pod to use the multus network named `bridge-network` as its default network.
+This example shows how you can configure data volume (DV) annotations to control which network the importer pod uses. The `v1.multus-cni.io/default-network: bridge-network` annotation causes the pod to use the Multus network named `bridge-network` as its default network.
 
-If you want the importer pod to use both the default network from the cluster and the secondary multus network, use the `k8s.v1.cni.cncf.io/networks: <network_name>` annotation.
+If you want the importer pod to use both the default network from the cluster and the secondary Multus network, use the `k8s.v1.cni.cncf.io/networks: <network_name>` annotation.
 
 .Multus network annotation example
 ====

--- a/modules/virt-enabling-preallocation-for-dv.adoc
+++ b/modules/virt-enabling-preallocation-for-dv.adoc
@@ -9,7 +9,7 @@
 [role="_abstract"]
 You can enable preallocation for specific data volumes by including the `spec.preallocation` field in the data volume manifest. You can enable preallocation mode in either the web console or by using the OpenShift CLI (`oc`).
 
-Preallocation mode is supported for all CDI source types.
+Preallocation mode is supported for all CDI source types. However, preallocation is ignored for cloning operations.
 
 .Procedure
 
@@ -22,9 +22,9 @@ kind: DataVolume
 metadata:
   name: preallocated-datavolume
 spec:
-  source: <1>
+  source:
     registry:
-      url: <image_url> <2>
+      url: <image_url>
   storage:
     resources:
       requests:
@@ -32,5 +32,7 @@ spec:
   preallocation: true
 # ...
 ----
-<1> All CDI source types support preallocation. However, preallocation is ignored for cloning operations.
-<2> Specify the URL of the data source in your registry.
++
+where:
++
+`<image_url>`:: Specifies the URL of the data source in your registry.

--- a/modules/virt-fusion-access-san-prereqs.adoc
+++ b/modules/virt-fusion-access-san-prereqs.adoc
@@ -6,6 +6,9 @@
 [id="fusion-access-san-prereqs_{context}"]
 = Prerequisites and Limitations for {FusionSAN}
 
+[role="_abstract"]
+Prerequisites and limitations are provided for installing and configuring {FusionSAN}.
+
 == Prerequisites
 
 Installing and configuring {FusionSAN} require the following prerequisites:

--- a/virt/storage/virt-configuring-cdi-for-namespace-resourcequota.adoc
+++ b/virt/storage/virt-configuring-cdi-for-namespace-resourcequota.adoc
@@ -6,6 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 You can configure the Containerized Data Importer (CDI) to import, upload, and clone virtual machine disks into namespaces that are subject to CPU and memory resource restrictions.
 
 include::modules/virt-about-cpu-and-memory-quota-namespace.adoc[leveloffset=+1]

--- a/virt/storage/virt-configuring-local-storage-with-hpp.adoc
+++ b/virt/storage/virt-configuring-local-storage-with-hpp.adoc
@@ -6,6 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 You can configure local storage for virtual machines by using the hostpath provisioner (HPP).
 
 When you install the {VirtProductName} Operator, the Hostpath Provisioner Operator is automatically installed. HPP is a local storage provisioner designed for {VirtProductName} that is created by the Hostpath Provisioner Operator. To use HPP, you create an HPP custom resource (CR) with a basic storage pool.

--- a/virt/storage/virt-configuring-storage-profile.adoc
+++ b/virt/storage/virt-configuring-storage-profile.adoc
@@ -6,7 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-A storage profile provides recommended storage settings based on the associated storage class. A storage profile is allocated for each storage class.
+[role="_abstract"]
+A storage profile provides recommended storage settings based on the associated storage class and is allocated for each storage class.
 
 The Containerized Data Importer (CDI) recognizes a storage provider if it has been configured to identify and interact with the storage provider's capabilities.
 

--- a/virt/storage/virt-enabling-user-permissions-to-clone-datavolumes.adoc
+++ b/virt/storage/virt-enabling-user-permissions-to-clone-datavolumes.adoc
@@ -6,12 +6,9 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-The isolating nature of namespaces means that users cannot by default
-clone resources between namespaces.
+[role="_abstract"]
+By default, users cannot clone resources between namespaces. To enable cloning, a user with the `cluster-admin` role must create and bind a cluster role that grants the required permissions.
 
-To enable a user to clone a virtual machine to another namespace, a
-user with the `cluster-admin` role must create a new cluster role. Bind
-this cluster role to a user to enable them to clone virtual machines
-to the destination namespace.
+To enable a user to clone a virtual machine to another namespace, a user with the `cluster-admin` role must create a new cluster role. Bind this cluster role to a user to enable them to clone virtual machines to the destination namespace.
 
 include::modules/virt-creating-rbac-cloning-dvs.adoc[leveloffset=+1]

--- a/virt/storage/virt-managing-data-volume-annotations.adoc
+++ b/virt/storage/virt-managing-data-volume-annotations.adoc
@@ -6,6 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 Data volume (DV) annotations allow you to manage pod behavior. You can add one or more annotations to a data volume, which then propagates to the created importer pods.
 
 include::modules/virt-dv-annotations.adoc[leveloffset=+1]

--- a/virt/storage/virt-reserving-pvc-space-fs-overhead.adoc
+++ b/virt/storage/virt-reserving-pvc-space-fs-overhead.adoc
@@ -6,6 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 When you create a `DataVolume` custom resource (CR) for a virtual machine (VM) by setting the `spec.storage.volumeMode`  attribute to `Filesystem`, {VirtProductName} automatically accounts for file system overhead.
 
 If you specify the storage type by using the `spec.pvc` attribute in the `DataVolume` CR, {VirtProductName} does not add any file system overhead and the requested size is passed directly to Kubernetes.
@@ -16,7 +17,7 @@ The default file system overhead value is 6%. For example, if you request a 10 G
 [cols="1,1,1", options="header"]
 |===
 |Requested virtual disk size |Calculated overhead (6%) |Total PVC space provisioned
-|10 GiB |0.6 GiB|10.6 GiB  
+|10 GiB |0.6 GiB|10.6 GiB
 |100 GiB |6 GiB |106 GiB
 |===
 [NOTE]

--- a/virt/storage/virt-using-preallocation-for-datavolumes.adoc
+++ b/virt/storage/virt-using-preallocation-for-datavolumes.adoc
@@ -6,11 +6,9 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-The Containerized Data Importer can preallocate disk space to improve write performance when creating data volumes.
-
-You can enable preallocation for specific data volumes.
+[role="_abstract"]
+The Containerized Data Importer (CDI) can preallocate disk space to improve write performance when creating data volumes. You can enable preallocation for specific data volumes.
 
 include::modules/virt-about-preallocation.adoc[leveloffset=+1]
 
 include::modules/virt-enabling-preallocation-for-dv.adoc[leveloffset=+1]
-


### PR DESCRIPTION
Version(s):
4.20+

Issue:
https://redhat.atlassian.net/browse/DOCPLAN-164

Link to docs preview:

- https://110351--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/storage/install-configure-fusion-access-san.html
- https://110351--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/storage/virt-configuring-cdi-for-namespace-resourcequota.html
- https://110351--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/storage/virt-configuring-local-storage-with-hpp.html
- https://110351--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/storage/virt-configuring-storage-profile.html
- https://110351--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/storage/virt-enabling-user-permissions-to-clone-datavolumes.html
- https://110351--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/storage/virt-managing-data-volume-annotations.html
- https://110351--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/storage/virt-preparing-cdi-scratch-space.html
- https://110351--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/storage/virt-reserving-pvc-space-fs-overhead.html
- https://110351--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/storage/virt-using-preallocation-for-datavolumes.html

QE review:
NA

Additional information:
<details>
  <summary>List of Vale checks addressed</summary>  

```
 modules/virt-about-creating-storage-classes.adoc
 12:1  warning  Consider using 'to' rather      RedHat.TermsWarnings 
                than 'In order to' unless
                updating existing content that
                uses the term.


 modules/virt-about-fusion-access-san.adoc
 21:23   warning  Do not use end punctuation in   RedHat.HeadingPunctuation
                  headings.
 25:1    warning  Consider using 'use' rather     RedHat.TermsWarnings
                  than 'Leverage' unless
                  updating existing content that
                  uses the term.
 25:54   warning  Consider using 'use' rather     RedHat.TermsWarnings
                  than 'leverage' unless
                  updating existing content that
                  uses the term.
 25:156  warning  Consider using 'make            RedHat.TermsWarnings
                  the transition', 'move',
                  'migrate', or 'change' rather
                  than 'transition' unless
                  updating existing content that
                  uses the term.
 35:273  warning  Consider using 'such as'        RedHat.TermsWarnings
                  rather than 'like' unless
                  updating existing content that
                  uses the term.


 modules/virt-about-storage-pools-pvc-templates.adoc
 34:22  warning  Use 'by using' instead of       RedHat.Using
                 'using' when it follows a noun
                 for clarity and grammatical
                 correctness.


 modules/virt-cdi-supported-operations-matrix.adoc
 21:38  error    Use 'Basic HTTP                 RedHat.TermsErrors
                 authentication' or 'Basic
                 authentication' rather than
                 'basic auth'.
 21:38  warning  Use 'Basic HTTP                 RedHat.CaseSensitiveTerms
                 authentication' or 'Basic
                 authentication' rather than
                 'basic auth'.
 54:13  warning  Use 'raw' rather than 'RAW'.    RedHat.CaseSensitiveTerms
 55:12  warning  Use 'raw' rather than 'RAW'.    RedHat.CaseSensitiveTerms
 61:12  warning  Use 'raw' rather than 'RAW'.    RedHat.CaseSensitiveTerms
 67:13  warning  Use 'raw' rather than 'RAW'.    RedHat.CaseSensitiveTerms
 73:13  warning  Use 'raw' rather than 'RAW'.    RedHat.CaseSensitiveTerms
 79:13  warning  Use 'raw' rather than 'RAW'.    RedHat.CaseSensitiveTerms


 modules/virt-creating-filesystem-fusion-access-san.adoc
 30:57  warning  Consider using 'is displayed'   RedHat.TermsWarnings
                 rather than 'appears' unless
                 updating existing content that
                 uses the term.
 42:6   warning  Consider using 'might' or       RedHat.TermsWarnings
                 'can' rather than 'may' unless
                 updating existing content that
                 uses the term.
 45:3   warning  Consider using 'click'          RedHat.TermsWarnings
                 rather than 'Click on' unless
                 updating existing content that
                 uses the term.


 modules/virt-creating-fusionaccess-cr.adoc
 24:3    warning  Consider using 'click'          RedHat.TermsWarnings
                  rather than 'Click on' unless
                  updating existing content that
                  uses the term.
 40:119  warning  Consider using 'is displayed'   RedHat.TermsWarnings
                  rather than 'appears' unless
                  updating existing content that
                  uses the term.


 modules/virt-creating-hpp-basic-storage-pool.adoc
 42:1  error  Callouts are not supported in   AsciiDocDITA.CalloutList
              DITA.


 modules/virt-creating-pull-secret-fusion-san.adoc
 37:1    error    Callouts are not supported in   AsciiDocDITA.CalloutList
                  DITA.

 modules/virt-creating-storage-pool-pvc-template.adoc
 49:1   error  Callouts are not supported in   AsciiDocDITA.CalloutList
               DITA.
 51:80  error  Use 'if' or 'provided that'     RedHat.TermsErrors
               rather than 'as long as'.


 modules/virt-customizing-storage-profile-default-cloning-strategy.adoc
 1:1     error    The '.Procedure' block title    AsciiDocDITA.TaskContents
                  is missing.
 16:300  warning  Verify the word                 RedHat.Spelling
                  'provisioner's'. It is not
                  in the American English or
                  Red Hat terminology spelling
                  dictionaries used by Vale.
 42:1    error    Callouts are not supported in   AsciiDocDITA.CalloutList
                  DITA.


 modules/virt-customizing-storage-profile-snapshot-class-cli.adoc
 7:1   error    Assign [role="_abstract"]       AsciiDocDITA.ShortDescription
                to a paragraph to use it as
                <shortdesc> in DITA.
 9:51  warning  Consider using 'is displayed'   RedHat.TermsWarnings
                rather than 'appears' unless
                updating existing content that
                uses the term.


 modules/virt-customizing-storage-profile-snapshot-class-web.adoc
 7:1   error    Assign [role="_abstract"]       AsciiDocDITA.ShortDescription
                to a paragraph to use it as
                <shortdesc> in DITA.
 9:51  warning  Consider using 'is displayed'   RedHat.TermsWarnings
                rather than 'appears' unless
                updating existing content that
                uses the term.


 modules/virt-customizing-storage-profile.adoc
 7:1    error    Assign [role="_abstract"]       AsciiDocDITA.ShortDescription
                 to a paragraph to use it as
                 <shortdesc> in DITA.
 9:83   warning  Verify the word                 RedHat.Spelling
                 'provisioner's'. It is not
                 in the American English or
                 Red Hat terminology spelling
                 dictionaries used by Vale.
 15:51  warning  Consider using 'is displayed'   RedHat.TermsWarnings
                 rather than 'appears' unless
                 updating existing content that
                 uses the term.
 55:1   error    Callouts are not supported in   AsciiDocDITA.CalloutList
                 DITA.


 modules/virt-defining-storageclass.adoc
 36:1  error  Callouts are not supported in   AsciiDocDITA.CalloutList
              DITA.


 modules/virt-dv-annotations.adoc
 10:127  error  Use 'Multus' instead of         Vale.Terms
                'multus'.
 12:97   error  Use 'Multus' instead of         Vale.Terms
                'multus'.


 modules/virt-enabling-preallocation-for-dv.adoc
 35:1  error  Callouts are not supported in   AsciiDocDITA.CalloutList
              DITA.


 modules/virt-fusion-access-san-prereqs.adoc
 7:1  error  Assign [role="_abstract"]       AsciiDocDITA.ShortDescription
             to a paragraph to use it as
             <shortdesc> in DITA.


 virt/storage/virt-configuring-cdi-for-namespace-resourcequota.adoc
 3:1  error  Assign [role="_abstract"]       AsciiDocDITA.ShortDescription
             to a paragraph to use it as
             <shortdesc> in DITA.


 virt/storage/virt-configuring-local-storage-with-hpp.adoc
 3:1  error  Assign [role="_abstract"]       AsciiDocDITA.ShortDescription
             to a paragraph to use it as
             <shortdesc> in DITA.


 virt/storage/virt-configuring-storage-profile.adoc
 3:1  error  Assign [role="_abstract"]       AsciiDocDITA.ShortDescription
             to a paragraph to use it as
             <shortdesc> in DITA.


 virt/storage/virt-enabling-user-permissions-to-clone-datavolumes.adoc
 3:1   error    Assign [role="_abstract"]       AsciiDocDITA.ShortDescription
                to a paragraph to use it as
                <shortdesc> in DITA.
 9:1   warning  Avoid hard-wrapped lines.       OpenShiftAsciiDoc.HardWrappedLines
 12:1  warning  Avoid hard-wrapped lines.       OpenShiftAsciiDoc.HardWrappedLines
 13:1  warning  Avoid hard-wrapped lines.       OpenShiftAsciiDoc.HardWrappedLines
 14:1  warning  Avoid hard-wrapped lines.       OpenShiftAsciiDoc.HardWrappedLines


 virt/storage/virt-managing-data-volume-annotations.adoc
 3:1  error  Assign [role="_abstract"]       AsciiDocDITA.ShortDescription
             to a paragraph to use it as
             <shortdesc> in DITA.


 virt/storage/virt-reserving-pvc-space-fs-overhead.adoc
 3:1     error    Assign [role="_abstract"]       AsciiDocDITA.ShortDescription
                  to a paragraph to use it as
                  <shortdesc> in DITA.

 virt/storage/virt-using-preallocation-for-datavolumes.adoc
 3:1  error  Assign [role="_abstract"]       AsciiDocDITA.ShortDescription
             to a paragraph to use it as
             <shortdesc> in DITA.
```


</details>
