### PR TITLE
OSSM v3.3.2 release notes and tasks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,5 +16,6 @@ bin
 commercial_package
 .vscode
 .vale/styles/AsciiDoc
+.vale/styles/AsciiDocDITA
 .vale/styles/OpenShiftAsciiDoc
 .vale/styles/RedHat

--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -17,7 +17,7 @@
 :SMProductName: Red{nbsp}Hat OpenShift Service Mesh
 :SMProduct: OpenShift Service Mesh
 :SMProductShortName: Service Mesh
-:SMProductVersion: 3.3.1
+:SMProductVersion: 3.3.2
 //service mesh v2
 //Update when there is a new 2.6.z release
 :SMv2Version: 2.6.14

--- a/modules/ossm-release-notes-3-3-2.adoc
+++ b/modules/ossm-release-notes-3-3-2.adoc
@@ -1,0 +1,25 @@
+//
+// * service-mesh-docs-main/ossm-release-notes/ossm-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="ossm-release-3-3-2_{context}"]
+= {SMProductName} version 3.3.2
+
+[role="_abstract"]
+
+This release of {SMProductName} is included with the {SMProductName} Operator 3.3.2 and is supported on {ocp-product-title} 4.18 and later. This release addresses enhancements, fixed issues, and Common Vulnerabilities and Exposures (CVEs).
+
+For supported component versions for 3.3.2, see "Service Mesh version support tables".
+
+[id="ossm-fixed-issues-3-3-2_{context}"]
+== Fixed issues
+
+ztunnel version updated for consistency with Istio and IstioCNI resources::
+Previously, the default ztunnel version in the {ocp-product-title} web console was outdated and inconsistent with the versions used in the {istio} and IstioCNI resources. The default version now aligns across all three resources, ensuring consistency during creation.
++
+link:https://redhat.atlassian.net/browse/OSSM-13103[OSSM-13103]
+
+Operator failure due to issue with `metrics-reader` ClusterRole resolved::
+Previously, the {SMProduct} Operator could fail to install if other operators used the same name for a ClusterRole (specifically `metrics-reader`). To resolve this issue, the {SMProduct} Operator now applies unique prefixes to its ClusterRoles.
++
+link:https://redhat.atlassian.net/browse/OSSM-13106[OSSM-13106]

--- a/modules/ossm-release-notes-supported-versions.adoc
+++ b/modules/ossm-release-notes-supported-versions.adoc
@@ -8,6 +8,41 @@
 
 [role="_abstract"]
 
+See the following table for information about {SMProduct} 3.3.2 supported versions.
+
+== {SMProduct} 3.3.2 supported versions
+
+[cols="1,1"]
+|===
+| Feature | Supported versions
+
+|{SMProduct} 3 Operator
+|3.3.2
+
+|{SMProduct} `Istio` control plane resource
+|1.28.5
+
+|{ocp-product-title}
+|4.18 and later
+
+| Envoy proxy
+| 1.36.6
+
+| `IstioCNI` resource
+| 1.28.5
+
+| `Ztunnel` resource
+| 1.28.5
+
+|Kiali Operator
+|2.22.2
+
+|Kiali server
+|2.22.2
+
+|===
+
+
 See the following table for information about {SMProduct} 3.3.1 supported versions.
 
 == {SMProduct} 3.3.1 supported versions

--- a/ossm-release-notes/ossm-release-notes.adoc
+++ b/ossm-release-notes/ossm-release-notes.adoc
@@ -11,6 +11,8 @@ toc::[]
 
 Review new features, compatibility updates, fixed issues, and known issues for {SMProductName} to stay informed about changes across different product versions.
 
+include::modules/ossm-release-notes-3-3-2.adoc[leveloffset=+1]
+
 include::modules/ossm-release-notes-3-3-1.adoc[leveloffset=+1]
 
 include::modules/ossm-release-notes-3-3-new-features-enhancements.adoc[leveloffset=+1]


### PR DESCRIPTION
[OSSM-12738](https://redhat.atlassian.net/browse/OSSM-12738): OSSM 3.3.2 & 3.2.4 & 3.1.7 & 3.0.10 At ReleaseCandidate Documentation Tasks

Version(s):
service-mesh-docs-3.3

Issue:
https://redhat.atlassian.net/browse/OSSM-12738

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

