### PR TITLE
OSDOCS Nodes fix misplaced ifndef

### DIFF
--- a/nodes/pods/nodes-pods-configuring.adoc
+++ b/nodes/pods/nodes-pods-configuring.adoc
@@ -32,10 +32,9 @@ include::modules/pod-disruption-eviction-policy.adoc[leveloffset=+2]
 endif::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 
 //Unsupported
-
+ifndef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 [role="_additional-resources"]
 .Additional resources
-ifndef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 * xref:../../nodes/clusters/nodes-cluster-enabling-features.adoc#nodes-cluster-enabling-features[Enabling features using feature gates]
 * link:https://kubernetes.io/docs/tasks/run-application/configure-pdb/#unhealthy-pod-eviction-policy[Unhealthy Pod Eviction Policy (Kubernetes documentation)]
 


### PR DESCRIPTION
A misplaced `ifndef` statement might be causing issues in the [ROSA](https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html/nodes/working-with-pods#nodes-pods-secrets), [ROSA classic](https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws_classic_architecture/4/html/nodes/working-with-pods#nodes-pods-secrets), and [Dedicated](https://docs.redhat.com/en/documentation/openshift_dedicated/4/html/nodes/working-with-pods#nodes-pods-secrets) docs. The links to the Secrets docs doesn't work.

<img width="1311" height="716" alt="image" src="https://github.com/user-attachments/assets/0abde407-552e-4e17-bac9-bcee57b58289" />

I don't see the problem in local previews. So, I cannot be sure that this change fixes the problem. Screenshot of local preview before the change:

<img width="1324" height="806" alt="image" src="https://github.com/user-attachments/assets/a57d56e6-b0b0-4571-a48f-eb012e30de43" />

Preview: [Providing sensitive data to pods by using secrets](https://110367--ocpdocs-pr.netlify.app/openshift-rosa/latest/nodes/pods/nodes-pods-secrets)

I might make more sense instead of miving the misplaced ifndef from Line 38, to remove the ifndef and the [endif in Line 32](https://github.com/openshift/openshift-docs/pull/110367/changes#diff-78150419d894f8297b625cde5ee538d8250acced21333705a99cb34b1a598201R32). But, I wanted to show the change clearly here. 

Might as well [CP back to when the problem was added](https://github.com/openshift/openshift-docs/pull/62147/changes), 4.13. 

