### PR TITLE
OSSM v3.1.7 release notes and tasks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,5 +16,6 @@ bin
 commercial_package
 .vscode
 .vale/styles/AsciiDoc
+.vale/styles/AsciiDocDITA
 .vale/styles/OpenShiftAsciiDoc
 .vale/styles/RedHat

--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -17,7 +17,7 @@
 :SMProductName: Red{nbsp}Hat OpenShift Service Mesh
 :SMProduct: OpenShift Service Mesh
 :SMProductShortName: Service Mesh
-:SMProductVersion: 3.1.6
+:SMProductVersion: 3.1.7
 //service mesh v2
 //Update when there is a new 2.6.z release
 :SMv2Version: 2.6.14

--- a/modules/ossm-release-notes-3-1-7.adoc
+++ b/modules/ossm-release-notes-3-1-7.adoc
@@ -1,0 +1,19 @@
+// Module included in the following assemblies:
+//
+// * service-mesh-docs-main/ossm-release-notes/ossm-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="ossm-release-3-1-7_{context}"]
+= {SMProductName} version 3.1.7
+
+[role="_abstract"]
+
+This release of {SMProductName} is included with the {SMProductName} Operator 3.1.7 and is supported on {ocp-product-title} 4.16-4.20. This release addresses enhancements, fixed issues, and Common Vulnerabilities and Exposures (CVEs).
+
+For supported component versions for 3.1.7, see "Service Mesh version support tables".
+
+[id="ossm-fixed-issues-3-1-7_{context}"]
+== Fixed issues
+
+Operator failure due to issue with `metrics-reader` ClusterRole resolved::
+Previously, if other Operators used the same ClusterRole name (specifically metrics-reader), the {SMProduct} Operator could fail to install. The {SMProduct} Operator now applies unique prefixes to its ClusterRoles, preventing this installation failure.

--- a/modules/ossm-release-notes-supported-versions.adoc
+++ b/modules/ossm-release-notes-supported-versions.adoc
@@ -8,6 +8,36 @@
 
 [role="_abstract"]
 
+See the following table for information about {SMProduct} 3.1.7 supported versions.
+
+== {SMProduct} 3.1.7 supported versions
+[cols="1,1"]
+|===
+| Feature | Supported versions
+
+|{SMProduct} 3 Operator
+|3.1.7
+
+|{SMProduct} `Istio` control plane resource
+|1.26.8
+
+|{ocp-product-title}
+|4.16-4.20
+
+| Envoy proxy
+| 1.34.14
+
+| `IstioCNI` resource
+| 1.26.8
+
+|Kiali Operator
+|2.22.2
+
+|Kiali server
+|2.11.9
+
+|===
+
 See the following table for information about {SMProduct} 3.1.6 supported versions.
 
 == {SMProduct} 3.1.6 supported versions

--- a/ossm-release-notes/ossm-release-notes.adoc
+++ b/ossm-release-notes/ossm-release-notes.adoc
@@ -16,6 +16,8 @@ The {SMProductName} release notes provide details about new features and enhance
 For additional information about the {SMProductName} life cycle and supported platforms, refer to the "{ocp-short-name} Operator Life Cycles".
 ====
 
+include::modules/ossm-release-notes-3-1-7.adoc[leveloffset=+1]
+
 include::modules/ossm-release-notes-3-1-6.adoc[leveloffset=+1]
 
 include::modules/ossm-release-notes-3-1-5.adoc[leveloffset=+1]


### PR DESCRIPTION
[OSSM-12738](https://redhat.atlassian.net/browse/OSSM-12738): OSSM 3.3.2 & 3.2.4 & 3.1.7 & 3.0.10 At ReleaseCandidate Documentation Tasks

Version(s):
service-mesh-docs-3.1

Issue:
https://redhat.atlassian.net/browse/OSSM-12738

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
