### PR TITLE
OSSM v3.0.10 release notes and tasks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,5 +16,6 @@ bin
 commercial_package
 .vscode
 .vale/styles/AsciiDoc
+.vale/styles/AsciiDocDITA
 .vale/styles/OpenShiftAsciiDoc
 .vale/styles/RedHat

--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -17,7 +17,7 @@
 :SMProductName: Red{nbsp}Hat OpenShift Service Mesh
 :SMProduct: OpenShift Service Mesh
 :SMProductShortName: Service Mesh
-:SMProductVersion: 3.0.9
+:SMProductVersion: 3.0.10
 //service mesh v2
 //Update when there is a new 2.6.z release
 :SMv2Version: 2.6.14

--- a/modules/ossm-release-notes-3-0-10.adoc
+++ b/modules/ossm-release-notes-3-0-10.adoc
@@ -1,0 +1,12 @@
+// Module included in the following assemblies:
+//
+// * service-mesh-docs-main/ossm-release-notes/ossm-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="ossm-release-3-0-10_{context}"]
+= {SMProductName} version 3.0.10
+
+[role="_abstract"]
+This release of {SMProductName} is included with the {SMProductName} Operator 3.0.10 and is supported on {ocp-product-title} 4.14-4.19. This release addresses Common Vulnerabilities and Exposures (CVEs). 
+
+For supported component versions for 3.0.10, see "Service Mesh version support tables".

--- a/modules/ossm-release-notes-supported-versions.adoc
+++ b/modules/ossm-release-notes-supported-versions.adoc
@@ -8,6 +8,37 @@
 
 [role="_abstract"]
 
+See the following table for information about {SMProduct} 3.0.10 supported versions.
+
+== {SMProduct} 3.0.10 supported versions
+
+[cols="1,1"]
+|===
+| Feature | Supported versions
+
+|{SMProduct} 3 Operator
+|3.0.10
+
+|{SMProduct} `Istio` control plane resource
+|1.24.6
+
+|{ocp-product-title}
+|4.14-4.19
+
+| Envoy proxy
+| 1.32.13
+
+| `IstioCNI` resource
+| 1.24.6
+
+|Kiali Operator
+|2.22.2
+
+|Kiali server
+|2.4.15
+
+|===
+
 See the following table for information about {SMProduct} 3.0.9 supported versions.
 
 == {SMProduct} 3.0.9 supported versions

--- a/ossm-release-notes/ossm-release-notes.adoc
+++ b/ossm-release-notes/ossm-release-notes.adoc
@@ -16,6 +16,8 @@ The {SMProductName} release notes provide details about new features and enhance
 For additional information about the {SMProductName} life cycle and supported platforms, refer to the "{ocp-short-name} Operator Life Cycles".
 ====
 
+include::modules/ossm-release-notes-3-0-10.adoc[leveloffset=+1]
+
 include::modules/ossm-release-notes-3-0-9.adoc[leveloffset=+1]
 
 include::modules/ossm-release-notes-3-0-8.adoc[leveloffset=+1]


### PR DESCRIPTION
[OSSM-12738](https://redhat.atlassian.net/browse/OSSM-12738): OSSM 3.3.2 & 3.2.4 & 3.1.7 & 3.0.10 At ReleaseCandidate Documentation Tasks

Version(s):
service-mesh-docs-3.0

Issue:
https://redhat.atlassian.net/browse/OSSM-12738

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->