### PR TITLE
OSDOCS-18465: Wildcard matching for signing kernel modules

### DIFF
--- a/hardware_enablement/kmm-kernel-module-management.adoc
+++ b/hardware_enablement/kmm-kernel-module-management.adoc
@@ -119,6 +119,13 @@ include::modules/kmm-checking-the-keys.adoc[leveloffset=+2]
 
 include::modules/kmm-signing-kmods-in-a-prebuilt-image.adoc[leveloffset=+1]
 
+// Added for OSDOCS-18465
+include::modules/kmm-specifying-files-to-sign.adoc[leveloffset=+1]
+
+include::modules/kmm-defining-full-paths.adoc[leveloffset=+2]
+
+include::modules/kmm-using-wildcard-and-glob-patterns.adoc[leveloffset=+2]
+
 include::modules/kmm-building-and-signing-a-kmod-image.adoc[leveloffset=+1]
 
 [role="_additional-resources"]

--- a/hardware_enablement/kmm-release-notes.adoc
+++ b/hardware_enablement/kmm-release-notes.adoc
@@ -415,10 +415,11 @@ Kernel Module Management (KMM) 2.5 is now supported on {ibm-z-title} architectur
 == Release notes for Kernel Module Management Operator 2.6
 === New features and enhancements
 // OSDOCS-18465
-* In this release, wildcard and GLOB pattern support for the `filesToSign` field has been added for signing kernel modules in a specific folder. Previously, you had to specify the exact path to each `.ko` file you wanted to sign. Now, you can add the full path to explicit files, as previously required, or any GLOB patterns supported by the `Ash` shell.
+* In this release, wildcard and glob pattern support for the `filesToSign` field has been added for signing kernel modules in a specific folder. Previously, you had to specify the exact path to each `.ko` file you wanted to sign. Now, you can add the full path to explicit files, as previously required, or any glob patterns supported by the `Ash` shell.
 +
-Additionally, this commit propagates `DirName` string from the API into the sign image template, and adds the signed files to the validation webhook.
-// For more information, see 
+The `DirName` value from `moduleLoader.container.modprobe` is propagated into the sign image. The validation webhook also verifies that all `filesToSign` entries fall under the configured `DirName`.
++
+For more information, see xref:../hardware_enablement/kmm-kernel-module-management.adoc#kmm-specifying-files-to-sign_kernel-module-management-operator[Specifying files to sign].
 
 // OSDOCS-18476
 * In this release, you can use the `AutomountServiceAccountToken` parameter to disable the auto-mounting of the projected volume. You can set `AutomountServiceAccountToken` to `false` to disable auto-mounting and mount the configmaps and tokens necessary for the `DevicePlugin` application.
@@ -436,7 +437,7 @@ By default, the KMM Operator is installed on control plane nodes when possible a
 // For more information, see 
 
 // OSDOCS-18468
-* In this release, a new optional `imageRebuildTrigger` counter field has been added in the `Module`, `ManagedClusterModule`, and `ModuleImagesConfig` CRDs that allows you to force Kernel Module Management (KMM) to reverify and rebuild module images when using ephemeral image registries. When this counter's value changes, the system automatically clears cached image statuses and reverifies the image existence, potentially triggering rebuilds. 
+* In this release, a new optional `imageRebuildTriggerGeneration` counter field has been added in the `Module`, `ManagedClusterModule`, and `ModuleImagesConfig` CRDs that allows you to force Kernel Module Management (KMM) to reverify and rebuild module images when using ephemeral image registries. When this counter's value changes, the system automatically clears cached image statuses and reverifies the image existence, potentially triggering rebuilds. 
 // For more information, see 
 
 === Bug fixes

--- a/modules/kmm-defining-full-paths.adoc
+++ b/modules/kmm-defining-full-paths.adoc
@@ -1,0 +1,28 @@
+// Module included in the following assemblies:
+//
+// * hardware_enablement/kmm-kernel-module-management.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="kmm-defining-full-paths_{context}"]
+= Defining full paths
+
+[role="_abstract"]
+You can define one or more absolute paths to kernel module `.ko` files inside the image.
+
+The following example shows full path usage in the `sign.filesToSign` field: 
+
+[source,yaml]
+----
+sign:
+  certSecret:
+    name: <cert_secret>  
+  keySecret:
+    name: <key_secret>  
+  filesToSign:
+    - /opt/lib/modules/${KERNEL_FULL_VERSION}/<my-kmod>.ko
+    - /opt/lib/modules/${KERNEL_FULL_VERSION}/<my_kmod1>.ko
+    - /opt/lib/modules/${KERNEL_FULL_VERSION}/<my_kmod2>.ko
+----
+
+
+

--- a/modules/kmm-specifying-files-to-sign.adoc
+++ b/modules/kmm-specifying-files-to-sign.adoc
@@ -1,0 +1,19 @@
+// Module included in the following assemblies:
+//
+// * hardware_enablement/kmm-kernel-module-management.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="kmm-specifying-files-to-sign_{context}"]
+= Specifying files to sign
+
+[role="_abstract"]
+You can specify full paths or wildcard and glob patterns to sign kernel module (`.ko`) files in specific directories. 
+
+Kernel Module Management (KMM) provides support for wildcard and glob pattern support for the `sign.filesToSign` field in the `Module` CR for signing kernel modules. In addition to using a full path to explicit files, you can use any glob patterns supported by the Bash shell to specify the files to sign. 
+
+The `DirName` value from `moduleLoader.container.modprobe` is propagated into the sign image. The validation webhook also verifies that all `filesToSign` entries fall under the configured `DirName`.
+
+All paths in `filesToSign` must be under the directory defined by `DirName` in the same `moduleLoader.container.modprobe` (default `/opt`).
+
+The KMM Operator loads the signed kmods onto all of the nodes that match the selector. The kmods should be successfully loaded on any nodes that have the public key in their Machine Owner Key (MOK) database and on any nodes that are not secure-boot enabled (which will just ignore the signature). They should fail to load on any that have secure-boot enabled but do not have that key in their MOK database.
+

--- a/modules/kmm-using-wildcard-and-glob-patterns.adoc
+++ b/modules/kmm-using-wildcard-and-glob-patterns.adoc
@@ -1,0 +1,62 @@
+// Module included in the following assemblies:
+//
+// * hardware_enablement/kmm-kernel-module-management.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="kmm-using-wildcard-and-glob-patterns_{context}"]
+= Using wildcard and glob patterns
+
+[role="_abstract"]
+You can use wildcard and any glob expression supported by the Ash shell in the `sign.filesToSign` field. The shell expands each entry at sign time, so you can match multiple modules with a single entry. 
+
+* The following example signs all `.ko` files in that directory:
++
+[source,yaml]
+----
+sign:
+  certSecret:
+    name: <cert_secret>  
+  keySecret:
+    name: <key_secret>  
+  filesToSign:
+    - /opt/lib/modules/${KERNEL_FULL_VERSION}/*.ko    
+----
+
+* The following example signs all modules matching that pattern, for example, `kmm_ci_a.ko`, `kmm_ci_b.ko`, and so on:
++
+[source,yaml]
+----
+sign:
+  certSecret:
+    name: <cert_secret>  
+  keySecret:
+    name: <key_secret>  
+  filesToSign:
+    - /opt/lib/modules/${KERNEL_FULL_VERSION}/kmm_ci_?.ko   
+----
+
+* The following example signs `driver-a.ko`, `driver-b.ko`, or `driver-c.ko`:
++
+[source,yaml]
+----
+sign:
+  certSecret:
+    name: <cert_secret>  
+  keySecret:
+    name: <key_secret>  
+  filesToSign:
+    - /opt/lib/modules/${KERNEL_FULL_VERSION}/driver-[abc].ko    
+----
+
+* The following example signs `mod-0.ko` through `mod-9.ko`:
++
+[source,yaml]
+----
+sign:
+  certSecret:
+    name: <cert_secret>  
+  keySecret:
+    name: <key_secret>  
+  filesToSign:
+    - /opt/lib/modules/${KERNEL_FULL_VERSION}/mod-[0-9].ko 
+----


### PR DESCRIPTION
[MGMT-22330] KMM 2.6 Wildcard matching for signing kernel modules in a specific folder

Version(s):
4.21, 4.22

Issue:
https://redhat.atlassian.net/browse/OSDOCS-18465

Link to docs preview:
https://110379--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hardware_enablement/kmm-kernel-module-management.html#kmm-specifying-files-to-sign_kernel-module-management-operator

SME: @ybettan 
QE review: @cdvultur 
- [ ] QE has approved this change.

