### PR TITLE
[OCPBUGS-64699]:Fixing etcd location in HCP HA docs

### DIFF
--- a/modules/hcp-recover-failing-etcd-pods.adoc
+++ b/modules/hcp-recover-failing-etcd-pods.adoc
@@ -14,8 +14,10 @@ Each etcd pod of a 3-node cluster has its own persistent volume claim (PVC) to s
 +
 [source,terminal]
 ----
-$ oc get pods -l app=etcd -n openshift-etcd
+$ oc get pods -l app=etcd -n clusters-<hosted_cluster_name>
 ----
++
+`<hosted_cluster_name>`:: Specifies the hosted cluster of the etcd instance.
 +
 .Example output
 [source,terminal]
@@ -32,8 +34,10 @@ The failing etcd pod might have the `CrashLoopBackOff` or `Error` status.
 +
 [source,terminal]
 ----
-$ oc delete pods etcd-2 -n openshift-etcd
+$ oc delete pods <etcd_pod_name> -n clusters-<hosted_cluster_name>
 ----
++
+`<etcd_pod_name>`:: Specifies the failing pod.
 
 .Verification
 
@@ -41,7 +45,7 @@ $ oc delete pods etcd-2 -n openshift-etcd
 +
 [source,terminal]
 ----
-$ oc get pods -l app=etcd -n openshift-etcd
+$ oc get pods -l app=etcd -n clusters-<hosted_cluster_name>
 ----
 +
 .Example output

--- a/modules/hosted-cluster-etcd-status.adoc
+++ b/modules/hosted-cluster-etcd-status.adoc
@@ -14,7 +14,7 @@ You can check the status of the etcd cluster health by logging into any etcd pod
 +
 [source,terminal]
 ----
-$ oc rsh -n openshift-etcd -c etcd <etcd_pod_name>
+$ oc rsh -n clusters-<hosted_cluster_name> -c etcd <etcd_pod_name>
 ----
 
 . Print the health status of an etcd cluster by entering the following command:


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.17+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://redhat.atlassian.net/browse/OCPBUGS-64699
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://110385--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp_high_availability/hcp-recovering-etcd-cluster.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
