### PR TITLE
TELCODOCS-2883: Adding egressIPConfig line to Core RDS

### DIFF
--- a/modules/telco-core-cluster-network-operator.adoc
+++ b/modules/telco-core-cluster-network-operator.adoc
@@ -43,7 +43,8 @@ Review the source code for more details:
 * EgressIP
 ** EgressIP failover time depends on the `reachabilityTotalTimeoutSeconds` parameter in the `Network` CR.
 This parameter determines the frequency of probes used to detect when the selected egress node is unreachable.
-The recommended value of this parameter is `1` second.
+The recommended value of this parameter is `1` second, which is also the platform default.
+You can either set this value explicitly or use `egressIPConfig: {}` to accept the default.
 ** When EgressIP is configured with multiple egress nodes, the failover time is expected to be on the order of seconds or longer.
 ** On nodes with additional network interfaces EgressIP traffic will egress through the interface on which the EgressIP address has been assigned.
 For more information, see "Configuring an egress IP address".


### PR DESCRIPTION
[TELCODOCS-2883](https://redhat.atlassian.net/browse/TELCODOCS-2883): Adding egressIPConfig line to Core RDS

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
https://redhat.atlassian.net/browse/TELCODOCS-2883

Link to docs preview:
https://110386--ocpdocs-pr.netlify.app/openshift-enterprise/latest/scalability_and_performance/telco-core-rds.html#telco-core-cluster-network-operator_telco-core

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->


