### PR TITLE
TELCODOCS-2569 RAN PerformanceProfile is displayed in Core profile example

### DIFF
--- a/modules/cnf-telco-core-reference-design-performance-profile-template.adoc
+++ b/modules/cnf-telco-core-reference-design-performance-profile-template.adoc
@@ -12,5 +12,5 @@ You can use a pre-configured design performance profile that configures node-lev
 .Telco core reference design performance profile
 [source,yaml]
 ----
-include::snippets/ztp_PerformanceProfile.yaml[]
+include::snippets/telco-core_PerformanceProfile.yaml[]
 ----


### PR DESCRIPTION

[TELCODOCS-2569]: RAN PerformanceProfile is displayed in Core profile example
<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.16+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:https://redhat.atlassian.net/browse/TELCODOCS-2569
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:https://110395--ocpdocs-pr.netlify.app/openshift-enterprise/latest/scalability_and_performance/cnf-tuning-low-latency-nodes-with-perf-profile.html#cnf-telco-core-reference-design-performance-profile-template_cnf-tuning-low-latency-nodes-with-perf-profile
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
