### PR TITLE
Sync telco core RDS modules with upstream 4.21 specification

### DIFF
--- a/modules/telco-core-about-the-telco-core-cluster-use-model.adoc
+++ b/modules/telco-core-about-the-telco-core-cluster-use-model.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * scalability_and_performance/telco_core_ref_design_specs/telco-core-rds.adoc
+// * scalability_and_performance/telco-core-rds.adoc
 
 :_mod-docs-content-type: REFERENCE
 [id="telco-core-about-the-telco-core-cluster-use-model_{context}"]
@@ -8,7 +8,7 @@
 
 [role="_abstract"]
 The telco core cluster use model is designed for clusters running on commodity hardware.
-Telco core clusters support large scale telco applications including control plane functions like signaling, aggregation, session border controller (SBC), and centralized data plane functions such as 5G user plane functions (UPF).
+Telco core clusters support large scale telco applications including control plane functions like signaling, aggregation, session border controller (SBC); and centralized data plane functions such as 5G user plane functions (UPF).
 Telco core cluster functions require scalability, complex networking support, resilient software-defined storage, and support performance requirements that are less stringent and constrained than far-edge RAN deployments.
 
 Networking requirements for telco core functions vary widely across a range of networking features and performance points.

--- a/modules/telco-core-additional-storage-solutions.adoc
+++ b/modules/telco-core-additional-storage-solutions.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * scalability_and_performance/telco_core_ref_design_specs/telco-core-rds.adoc
+// * scalability_and_performance/telco-core-rds.adoc
 
 :_mod-docs-content-type: REFERENCE
 [id="telco-core-additional-storage-solutions_{context}"]

--- a/modules/telco-core-agent-based-installer.adoc
+++ b/modules/telco-core-agent-based-installer.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * scalability_and_performance/telco_core_ref_design_specs/telco-core-rds.adoc
+// * scalability_and_performance/telco-core-rds.adoc
 
 :_mod-docs-content-type: REFERENCE
 
@@ -15,7 +15,7 @@ New in this release::
 
 Description::
 The recommended method for Telco Core cluster installation is using Red Hat Advanced Cluster Management.
-The Agent Based Installer (ABI) is a separate installation flow for Openshift in environments without existing infrastructure for running cluster deployments.
+The Agent Based Installer (ABI) is a separate installation flow for {product-title} in environments without existing infrastructure for running cluster deployments.
 Use the ABI to install {product-title} on bare-metal servers without requiring additional servers or VMs for managing the installation, but does not provide ongoing lifecycle management, monitoring or automations.
 The ABI can be run on any system for example, from a laptop to generate an ISO installation image.
 The ISO is used as the installation media for the cluster control plane nodes.

--- a/modules/telco-core-application-workloads.adoc
+++ b/modules/telco-core-application-workloads.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * scalability_and_performance/telco_core_ref_design_specs/telco-core-rds.adoc
+// * scalability_and_performance/telco-core-rds.adoc
 
 :_mod-docs-content-type: REFERENCE
 [id="telco-core-application-workloads_{context}"]

--- a/modules/telco-core-cert-manager-operator.adoc
+++ b/modules/telco-core-cert-manager-operator.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * scalability_and_performance/telco_core_ref_design_specs/telco-core-rds.adoc
+// * scalability_and_performance/telco-core-rds.adoc
 
 :_mod-docs-content-type: REFERENCE
 [id="telco-core-cert-manager-operator_{context}"]

--- a/modules/telco-core-cluster-common-use-model-engineering-considerations.adoc
+++ b/modules/telco-core-cluster-common-use-model-engineering-considerations.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * scalability_and_performance/telco_core_ref_design_specs/telco-core-rds.adoc
+// * scalability_and_performance/telco-core-rds.adoc
 
 :_mod-docs-content-type: REFERENCE
 [id="telco-core-cluster-common-use-model-engineering-considerations_{context}"]
@@ -11,7 +11,7 @@ The following engineering considerations apply to the telco core cluster common 
 
 * Cluster workloads are detailed in "Application workloads".
 * Worker nodes should run on either of the following CPUs:
-** Intel 3rd Generation Xeon (IceLake) CPUs or better when supported by {product-title}, or CPUs with the silicon security bug (Spectre and similar) mitigations turned off.
+** Intel 3rd Generation Xeon (Ice Lake) CPUs or better when supported by {product-title}, or CPUs with the silicon security bug (Spectre and similar) mitigations turned off.
 Skylake and older CPUs can experience 40% transaction performance drops when Spectre and similar mitigations are enabled.
 ** AMD EPYC Zen 4 CPUs (Genoa, Bergamo) or AMD EPYC Zen 5 CPUs (Turin) when supported by {product-title}.
 ** Intel Sierra Forest CPUs when supported by the {product-title}.

--- a/modules/telco-core-cluster-network-operator.adoc
+++ b/modules/telco-core-cluster-network-operator.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * scalability_and_performance/telco_core_ref_design_specs/telco-core-rds.adoc
+// * scalability_and_performance/telco-core-rds.adoc
 
 :_mod-docs-content-type: REFERENCE
 [id="telco-core-cluster-network-operator_{context}"]

--- a/modules/telco-core-common-baseline-model.adoc
+++ b/modules/telco-core-common-baseline-model.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * scalability_and_performance/telco_core_ref_design_specs/telco-core-rds.adoc
+// * scalability_and_performance/telco-core-rds.adoc
 
 :_mod-docs-content-type: REFERENCE
 [id="telco-core-common-baseline-model_{context}"]

--- a/modules/telco-core-cpu-partitioning-and-performance-tuning.adoc
+++ b/modules/telco-core-cpu-partitioning-and-performance-tuning.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * scalability_and_performance/telco_core_ref_design_specs/telco-core-rds.adoc
+// * scalability_and_performance/telco-core-rds.adoc
 
 :_mod-docs-content-type: REFERENCE
 [id="telco-core-cpu-partitioning-and-performance-tuning_{context}"]
@@ -57,7 +57,7 @@ With no configuration, the default queue count is one RX/TX queue per online CPU
 To prevent this condition the reference configuration excludes this kernel module from loading through a kernel commandline argument in the `PerformanceProfile` resource.
 Typically Core workloads do not require this kernel module.
 * To enable the `acpi_idle` CPUIdle driver, for example for Intel FlexRAN workloads, add `intel_idle.max_cstate=0` to the `additionalKernelArgs` list in the `PerformanceProfile` resource.
-* The `TunedPerformancePatch.yaml` file in the reference configures the `kernel.panic_on_unrecovered_nmi` sysctl parameter to enable triggering a kernel panic through BMC Non-Maskable Interrupt (NMI) on x86_64 architures.
+* The `TunedPerformancePatch.yaml` resource configures the `kernel.panic_on_unrecovered_nmi` sysctl parameter to enable triggering a kernel panic through BMC Non-Maskable Interrupt (NMI) on x86_64 architectures.
 This provides a mechanism to force a kernel panic for system recovery and diagnostic purposes when nodes become unresponsive.
 +
 [NOTE]

--- a/modules/telco-core-deployment-planning.adoc
+++ b/modules/telco-core-deployment-planning.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * scalability_and_performance/telco_core_ref_design_specs/telco-core-rds.adoc
+// * scalability_and_performance/telco-core-rds.adoc
 
 :_mod-docs-content-type: REFERENCE
 [id="telco-core-deployment-planning_{context}"]

--- a/modules/telco-core-disconnected-environment.adoc
+++ b/modules/telco-core-disconnected-environment.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * scalability_and_performance/telco_core_ref_design_specs/telco-core-rds.adoc
+// * scalability_and_performance/telco-core-rds.adoc
 
 :_mod-docs-content-type: REFERENCE
 [id="telco-core-disconnected-environment_{context}"]

--- a/modules/telco-core-gitops-operator-and-ztp-plugins.adoc
+++ b/modules/telco-core-gitops-operator-and-ztp-plugins.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * scalability_and_performance/telco_core_ref_design_specs/telco-core-rds.adoc
+// * scalability_and_performance/telco-core-rds.adoc
 
 :_mod-docs-content-type: REFERENCE
 [id="telco-core-gitops-operator-and-ztp-plugins_{context}"]

--- a/modules/telco-core-host-firmware-and-boot-loader-configuration.adoc
+++ b/modules/telco-core-host-firmware-and-boot-loader-configuration.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * scalability_and_performance/telco_core_ref_design_specs/telco-core-rds.adoc
+// * scalability_and_performance/telco-core-rds.adoc
 
 :_mod-docs-content-type: REFERENCE
 [id="telco-core-host-firmware-and-boot-loader-configuration_{context}"]

--- a/modules/telco-core-kubelet-settings.adoc
+++ b/modules/telco-core-kubelet-settings.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * scalability_and_performance/telco_core_ref_design_specs/telco-core-rds.adoc
+// * scalability_and_performance/telco-core-rds.adoc
 
 :_mod-docs-content-type: REFERENCE
 [id="telco-core-kubelet-settings_{context}"]

--- a/modules/telco-core-load-balancer.adoc
+++ b/modules/telco-core-load-balancer.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * scalability_and_performance/telco_core_ref_design_specs/telco-core-rds.adoc
+// * scalability_and_performance/telco-core-rds.adoc
 
 :_mod-docs-content-type: REFERENCE
 [id="telco-core-load-balancer_{context}"]

--- a/modules/telco-core-logging.adoc
+++ b/modules/telco-core-logging.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * scalability_and_performance/telco_core_ref_design_specs/telco-core-rds.adoc
+// * scalability_and_performance/telco-core-rds.adoc
 
 :_mod-docs-content-type: REFERENCE
 [id="telco-core-logging_{context}"]

--- a/modules/telco-core-monitoring.adoc
+++ b/modules/telco-core-monitoring.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * scalability_and_performance/telco_core_ref_design_specs/telco-core-rds.adoc
+// * scalability_and_performance/telco-core-rds.adoc
 
 :_mod-docs-content-type: REFERENCE
 [id="telco-core-monitoring_{context}"]

--- a/modules/telco-core-networking.adoc
+++ b/modules/telco-core-networking.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * scalability_and_performance/telco_core_ref_design_specs/telco-core-rds.adoc
+// * scalability_and_performance/telco-core-rds.adoc
 
 :_mod-docs-content-type: REFERENCE
 [id="telco-core-networking_{context}"]
@@ -30,7 +30,7 @@ One NIC is shared among the primary CNI (OVN-Kubernetes) and IPVLAN and MACVLAN 
 The top-of-rack networking equipment must support and be configured for multi-chassis link aggregation (mLAG) technology.
 * VLAN interfaces are created on top of `bond0`, including for the primary CNI.
 * Bond and VLAN interfaces are created at cluster install time during the network configuration stage of the installation.
-Except for the `vlan0` VLAN used by the primary CNI, all other VLANs can be created during Day 2 activities with the Kubernetes NMstate Operator.
+Except for the `vlan0` VLAN used by the primary CNI, all other VLANs can be created during Day 2 activities with the Kubernetes NMState Operator.
 * MACVLAN and IPVLAN interfaces are created with their corresponding CNIs.
 They do not share the same base interface.
 For more information, see "Cluster Network Operator".

--- a/modules/telco-core-nmstate-operator.adoc
+++ b/modules/telco-core-nmstate-operator.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * scalability_and_performance/telco_core_ref_design_specs/telco-core-rds.adoc
+// * scalability_and_performance/telco-core-rds.adoc
 
 :_mod-docs-content-type: REFERENCE
 [id="telco-core-nmstate-operator_{context}"]

--- a/modules/telco-core-node-configuration.adoc
+++ b/modules/telco-core-node-configuration.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * scalability_and_performance/telco_core_ref_design_specs/telco-core-rds.adoc
+// * scalability_and_performance/telco-core-rds.adoc
 
 :_mod-docs-content-type: REFERENCE
 [id="telco-core-node-configuration_{context}"]

--- a/modules/telco-core-openshift-data-foundation.adoc
+++ b/modules/telco-core-openshift-data-foundation.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * scalability_and_performance/telco_core_ref_design_specs/telco-core-rds.adoc
+// * scalability_and_performance/telco-core-rds.adoc
 
 :_mod-docs-content-type: REFERENCE
 [id="telco-core-openshift-data-foundation_{context}"]

--- a/modules/telco-core-power-management.adoc
+++ b/modules/telco-core-power-management.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * scalability_and_performance/telco_core_ref_design_specs/telco-core-rds.adoc
+// * scalability_and_performance/telco-core-rds.adoc
 
 :_mod-docs-content-type: REFERENCE
 [id="telco-core-power-management_{context}"]

--- a/modules/telco-core-rds-product-version-use-model-overview.adoc
+++ b/modules/telco-core-rds-product-version-use-model-overview.adoc
@@ -1,10 +1,10 @@
 // Module included in the following assemblies:
 //
-// * scalability_and_performance/telco_core_ref_design_specs/telco-core-rds.adoc
+// * scalability_and_performance/telco-core-rds.adoc
 
 :_mod-docs-content-type: REFERENCE
 [id="telco-core-rds-product-version-use-model-overview_{context}"]
-= Telco core RDS use model overview
+= Telco core RDS {product-version} use model overview
 
 [role="_abstract"]
 The Telco core reference design specification (RDS) describes a platform that supports large-scale telco applications including control plane functions such as signaling and aggregation.

--- a/modules/telco-core-red-hat-advanced-cluster-management.adoc
+++ b/modules/telco-core-red-hat-advanced-cluster-management.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * scalability_and_performance/telco_core_ref_design_specs/telco-core-rds.adoc
+// * scalability_and_performance/telco-core-rds.adoc
 
 :_mod-docs-content-type: REFERENCE
 [id="telco-core-red-hat-advanced-cluster-management_{context}"]
@@ -22,14 +22,14 @@ You apply policies with the {rh-rhacm} policy controller as managed by {cgu-oper
 Configuration, upgrades, and cluster status are managed through the policy controller.
 
 When installing managed clusters, {rh-rhacm} applies labels and initial ignition configuration to individual nodes in support of custom disk partitioning, allocation of roles, and allocation to machine config pools.
-You define these configurations with `ClusterInstance` CRs.
+You define these configurations with `SiteConfig` or `ClusterInstance` CRs.
 --
 
 Limits and requirements::
 
-* Hub cluster sizing is discussed in link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.13/html-single/install/index#sizing-your-cluster[Sizing your cluster].
+* Hub cluster sizing is discussed in link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.15/html-single/install/index#sizing-your-cluster[Sizing your cluster].
 
-* {rh-rhacm} scaling limits are described in link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.13/html-single/install/index#performance-and-scalability[Performance and Scalability].
+* {rh-rhacm} scaling limits are described in link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.15/html-single/install/index#performance-and-scalability[Performance and Scalability].
 
 Engineering considerations::
 * When managing multiple clusters with unique content per installation, site, or deployment, using {rh-rhacm} hub templating is strongly recommended.

--- a/modules/telco-core-scalability.adoc
+++ b/modules/telco-core-scalability.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * scalability_and_performance/telco_core_ref_design_specs/telco-core-rds.adoc
+// * scalability_and_performance/telco-core-rds.adoc
 
 :_mod-docs-content-type: REFERENCE
 [id="telco-core-scalability_{context}"]
@@ -20,5 +20,3 @@ Limits and requirements::
 
 * A telco core cluster can scale to at least 120 nodes.
 
-
-:leveloffset!:

--- a/modules/telco-core-scheduling.adoc
+++ b/modules/telco-core-scheduling.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * scalability_and_performance/telco_core_ref_design_specs/telco-core-rds.adoc
+// * scalability_and_performance/telco-core-rds.adoc
 
 :_mod-docs-content-type: REFERENCE
 [id="telco-core-scheduling_{context}"]
@@ -24,7 +24,7 @@ Limits and requirements::
 * The default scheduler does not understand the NUMA locality of workloads.
 It only knows about the sum of all free resources on a worker node.
 This might cause workloads to be rejected when scheduled to a node with the topology manager policy set to single-numa-node or restricted.
-For more information, see "Topology Manager policies"..
+For more information, see "Topology Manager policies".
 ** For example, consider a pod requesting 6 CPUs and being scheduled to an empty node that has 4 CPUs per NUMA node.
 The total allocatable capacity of the node is 8 CPUs. The scheduler places the pod on the empty node.
 The node local admission fails, as there are only 4 CPUs available in each of the NUMA nodes.

--- a/modules/telco-core-security.adoc
+++ b/modules/telco-core-security.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * scalability_and_performance/telco_core_ref_design_specs/telco-core-rds.adoc
+// * scalability_and_performance/telco-core-rds.adoc
 
 :_mod-docs-content-type: REFERENCE
 [id="telco-core-security_{context}"]
@@ -36,7 +36,7 @@ Ensure the rules don't inadvertently block essential services required during th
 * Risk of misconfiguration: Errors in your custom rules can lead to unintended consequences, potentially leading to performance impact or blocking legitimate traffic or isolating nodes.
 Thoroughly test your rules in a non-production environment before deploying them to your main cluster.
 * External endpoints: {product-title} requires access to external endpoints to function.
-For more information about the firewall allowlist, see "Configuring your firewall for {product-title}". Ensure that cluster nodes are permitted access to those endpoints. Ensure that cluster nodes are permitted access to those endpoints.
+For more information about the firewall allowlist, see "Configuring your firewall for {product-title}". Ensure that cluster nodes are permitted access to those endpoints.
 
 * Node reboot: Unless node disruption policies are configured, applying the `MachineConfig` CR with the required firewall settings causes a node reboot.
 Be aware of this impact and schedule a maintenance window accordingly. For more information, see "Using node disruption policies to minimize disruption from machine config changes".

--- a/modules/telco-core-service-mesh.adoc
+++ b/modules/telco-core-service-mesh.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * scalability_and_performance/telco_core_ref_design_specs/telco-core-rds.adoc
+// * scalability_and_performance/telco-core-rds.adoc
 
 :_mod-docs-content-type: REFERENCE
 [id="telco-core-service-mesh_{context}"]

--- a/modules/telco-core-signaling-workloads.adoc
+++ b/modules/telco-core-signaling-workloads.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * scalability_and_performance/telco_core_ref_design_specs/telco-core-rds.adoc
+// * scalability_and_performance/telco-core-rds.adoc
 
 :_mod-docs-content-type: REFERENCE
 [id="telco-core-signaling-workloads_{context}"]

--- a/modules/telco-core-software-stack.adoc
+++ b/modules/telco-core-software-stack.adoc
@@ -1,14 +1,9 @@
 // Module included in the following assemblies:
 //
-// * scalability_and_performance/telco_core_ref_design_specs/telco-core-rds.adoc
+// * scalability_and_performance/telco-core-rds.adoc
 
 :_mod-docs-content-type: REFERENCE
-// Module included in the following assemblies:
-//
-// * scalability_and_performance/telco_core_ref_design_specs/telco-core-rds.adoc
-
-:_mod-docs-content-type: REFERENCE
-[id="telco-core-software-stack_{context}_{context}"]
+[id="telco-core-software-stack_{context}"]
 = Telco core reference configuration software specifications
 
 [role="_abstract"]
@@ -29,7 +24,7 @@ The Red{nbsp}Hat telco core {product-version} solution has been validated using 
 |1.18
 
 |Cluster Logging Operator
-|6.2
+|6.4
 
 |{rh-storage}
 |4.20

--- a/modules/telco-core-sr-iov.adoc
+++ b/modules/telco-core-sr-iov.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * scalability_and_performance/telco_core_ref_design_specs/telco-core-rds.adoc
+// * scalability_and_performance/telco-core-rds.adoc
 
 :_mod-docs-content-type: REFERENCE
 [id="telco-core-sr-iov_{context}"]

--- a/modules/telco-core-storage.adoc
+++ b/modules/telco-core-storage.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * scalability_and_performance/telco_core_ref_design_specs/telco-core-rds.adoc
+// * scalability_and_performance/telco-core-rds.adoc
 
 :_mod-docs-content-type: REFERENCE
 [id="telco-core-storage_{context}"]

--- a/modules/telco-core-topology-aware-lifecycle-manager.adoc
+++ b/modules/telco-core-topology-aware-lifecycle-manager.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * scalability_and_performance/telco_core_ref_design_specs/telco-core-rds.adoc
+// * scalability_and_performance/telco-core-rds.adoc
 
 :_mod-docs-content-type: REFERENCE
 [id="telco-core-topology-aware-lifecycle-manager_{context}"]

--- a/modules/telco-core-worker-nodes-and-machineconfigpools.adoc
+++ b/modules/telco-core-worker-nodes-and-machineconfigpools.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * scalability_and_performance/telco_core_ref_design_specs/telco-core-rds.adoc
+// * scalability_and_performance/telco-core-rds.adoc
 
 :_mod-docs-content-type: REFERENCE
 [id="telco-core-worker-nodes-and-machineconfigpools_{context}"]

--- a/modules/telco-core-workloads-on-schedulable-control-planes.adoc
+++ b/modules/telco-core-workloads-on-schedulable-control-planes.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * scalability_and_performance/telco_core_ref_design_specs/telco-core-rds.adoc
+// * scalability_and_performance/telco-core-rds.adoc
 
 :_mod-docs-content-type: REFERENCE
 [id="telco-core-workloads-on-schedulable-control-planes_{context}"]

--- a/modules/telco-core-zones.adoc
+++ b/modules/telco-core-zones.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * scalability_and_performance/telco_core_ref_design_specs/telco-core-rds.adoc
+// * scalability_and_performance/telco-core-rds.adoc
 
 :_mod-docs-content-type: REFERENCE
 [id="telco-core-zones_{context}"]


### PR DESCRIPTION
## Summary
- Ports substantive content changes from the upstream `telco-core-rds.adoc` (reference-design-specifications GitLab repo) to the downstream modular telco core RDS modules
- Fixes typos (`architures`, `IceLake`, `NMstate`, `Openshift`), punctuation errors (duplicated sentence, stray `..`), and metadata issues (duplicated module header/ID, stray `:leveloffset!:`)
- Updates RHACM documentation links from 2.13 to 2.15, Cluster Logging Operator version from 6.2 to 6.4, and assembly path comments to match current location

## Test plan
- [ ] Verify `asciibinder build` completes without errors
- [ ] Spot-check rendered output for the updated modules
- [ ] Confirm software stack table reflects Cluster Logging Operator 6.4
- [ ] Confirm RHACM links point to 2.15 documentation


Made with [Cursor](https://cursor.com)