### PR TITLE
OCPBUGS 77039 Encourage use of SCCs instead of namespace annotations to overwrite UIDs/GIDs for Linux user namespaces

### DIFF
--- a/modules/nodes-pods-user-namespaces-configuring.adoc
+++ b/modules/nodes-pods-user-namespaces-configuring.adoc
@@ -18,7 +18,7 @@ Also, you can optionally use the `procMount` parameter in a pod specification to
 
 .Prerequisites
 
-* Log into an {product-title} cluster as a user configured with the `restricted-v3` or `nested-container` SCC, or as a user from a user group configured with either SCC. Alternatively, you can set the `restricted-v3` or  SCC directly in the workload object.
+* Log in to an {product-title} cluster as a user configured with the `restricted-v3` or `nested-container` SCC, or as a user from a user group configured with either SCC. Alternatively, you can set the `restricted-v3` or  SCC directly in the workload object.
 
 .Procedure
 

--- a/modules/nodes-pods-user-namespaces-configuring.adoc
+++ b/modules/nodes-pods-user-namespaces-configuring.adoc
@@ -18,49 +18,11 @@ Also, you can optionally use the `procMount` parameter in a pod specification to
 
 .Prerequisites
 
-* Log into an {product-title} cluster as a user configured with the `restricted-v3` or `nested-container` SCC, or as a user from a user group configured with either SCC. Alternatively, you can set the `restricted-v3` or `nested-container` SCC directly in the workload object.
+* Log into an {product-title} cluster as a user configured with the `restricted-v3` or `nested-container` SCC, or as a user from a user group configured with either SCC. Alternatively, you can set the `restricted-v3` or  SCC directly in the workload object.
 
 .Procedure
 
-. Edit the default user ID (UID) and group ID (GID) range of the {product-title} namespace where your pod is deployed by running the following command:
-+
-[source,terminal]
-----
-$ oc edit ns/<namespace_name>
-----
-+
-.Example namespace
-[source,yaml]
-----
-apiVersion: v1
-kind: Namespace
-metadata:
-  annotations:
-    openshift.io/description: ""
-    openshift.io/display-name: ""
-    openshift.io/requester: system:admin
-    openshift.io/sa.scc.mcs: s0:c27,c24
-    openshift.io/sa.scc.supplemental-groups: 1000/10000
-    openshift.io/sa.scc.uid-range: 1000/10000
-# ...
-  name: userns
-# ...
-----
-+
---
-where:
-
-`metadata.annotations.openshift.io/sa.scc.supplemental-groups`:: Specifies the default GID to require in the pod spec. The range for a Linux user namespace must be `65535` or lower. The default is `1000000000/10000`.
-
-`metadata.annotations.openshift.io/sa.scc.uid-range`:: Specifies the default UID to require in the pod spec. The range for a Linux user namespace must be `65535` or lower. The default is `1000000000/10000`.
---
-+
-[NOTE]
-====
-The range 1000/10000 means 10,000 values starting with ID 1000, so it specifies the range of IDs from 1000 to 10,999.
-====
-
-. Enable the use of Linux user namespaces by creating a workload configured to run with an appropriate SCC and the `hostUsers` parameter set to `false`.
+* Enable the use of Linux user namespaces by creating a workload configured to run with an appropriate SCC and the `hostUsers` parameter set to `false`.
 
 .. Create a YAML file similar to the following:
 +
@@ -78,18 +40,26 @@ spec:
       type: RuntimeDefault
   hostUsers: false
   containers:
-    name: userns-container
+  - name: userns-container
     image: registry.access.redhat.com/ubi9
     command: ["sleep", "1000"]
     securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop: ["ALL"]
+        add:
+        - "SETGID"
+        - "SETUID"
       runAsUser: 1000
       runAsGroup: 1000
       runAsNonRoot: true
       procMount: Unmasked
-      capabilities:
-        add:
-        - "SETGID"
-        - "SETUID"
+  template:
+    metadata:
+      labels:
+        app: name
+      annotations:
+        openshift.io/required-scc: "restricted-v3"
 # ...
 ----
 +
@@ -101,6 +71,7 @@ where:
 `spec.containers.securityContext.runAsNonRoot`:: Specifies that processes inside the container run with a user that has any UID other than 0.
 `spec.containers.securityContext.procMount`:: Specifies the type of proc mount to use for the containers. The `unmasked` value ensures that a container's `/proc` file system is mounted as read/write by the container process. The default is `Default`. This value is optional.
 `spec.containers.securityContext.capabilities.add`:: Specifies Linux capabilities to set in the user namespace. This permits privileged actions without giving full root access. Technically, setting capabilities inside of a user namespace is safer than setting them outside, as the scope of the capabilities are limited by being inside user namespace, and can generally be considered to be safe. However, giving pods capabilities like `CAP_SYS_ADMIN` to any untrusted workload could increase the potential kernel surface area that a containerized process has access to and could find exploits in. Thus, capabilities inside of a user namespace are allowed at `baseline` level in pod security admission. This value is optional.
+`spec.template.metadata.annotations.openshift.io/required-scc:: Specifies the required SCC if the user or user group is not configured with the required SCC, either `restricted-v3` or `nested-container`. This value is optional if the the user or user group is not configured with the required SCC.
 
 .. Create the object by running the following command:
 +
@@ -135,7 +106,7 @@ sh-5.1$ id
 .Example output
 [source,terminal]
 ----
-uid=1000(1000) gid=1000(1000) groups=1000(1000) <1>
+uid=1000(1000) gid=1000(1000) groups=1000(1000),0(root) <1>
 ----
 <1> The UID and group for the container should be the same as you set in the pod specification.
 
@@ -150,7 +121,7 @@ sh-5.1$ lsns -t user
 [source,terminal]
 ----
         NS TYPE  NPROCS PID USER COMMAND
-4026532447 user       3   1 1000 /usr/bin/coreutils --coreutils-prog-shebang=sleep /usr/bin/sleep 1000 <1>
+4026532630 user       3   1 1000 /usr/bin/coreutils --coreutils-prog-shebang=sleep /usr/bin/sleep 1000 <1>
 ----
 <1> The UID for the process should be the same as you set in the pod spec.
 
@@ -194,8 +165,9 @@ sh-5.1#  lsns -t user
 [source,terminal]
 ----
         NS TYPE  NPROCS   PID USER       COMMAND
-4026531837 user     233     1 root       /usr/lib/systemd/systemd --switched-root --system --deserialize 28
-4026532447 user       1  4767 2908816384 /usr/bin/coreutils --coreutils-prog-shebang=sleep /usr/bin/sleep 1000 <1>
+4026531837 user     250     1 root       /usr/lib/systemd/systemd --switched-root --system --deserialize 28
+4026532378 user       1   965 root       /usr/sbin/irqbalance
+4026532630 user       1 39580 3505521640 /usr/bin/coreutils --coreutils-prog-shebang=sleep /usr/bin/sleep 1000 <1>
 ----
 <1> The UID should be different from what you set in the pod specification.
 +


### PR DESCRIPTION
https://redhat.atlassian.net/browse/OCPBUGS-77039

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
