### PR TITLE
OSDOCS-16609 - Addressing Vale errors in ROSA Monitoring

### DIFF
--- a/modules/monitoring-excluding-a-user-defined-project-from-monitoring.adoc
+++ b/modules/monitoring-excluding-a-user-defined-project-from-monitoring.adoc
@@ -7,6 +7,7 @@
 [id="excluding-a-user-defined-project-from-monitoring_{context}"]
 = Excluding a user-defined project from monitoring
 
+[role="_abstract"]
 Individual user-defined projects can be excluded from user workload monitoring. To do so, add the `openshift.io/user-monitoring` label to the project's namespace with a value of `false`.
 
 .Procedure
@@ -27,5 +28,5 @@ $ oc label namespace my-project 'openshift.io/user-monitoring-'
 +
 [NOTE]
 ====
-If there were any active monitoring targets for the project, it may take a few minutes for Prometheus to stop scraping them after adding the label.
+If there were any active monitoring targets for the project, it can take a few minutes for Prometheus to stop scraping them after adding the label.
 ====

--- a/modules/monitoring-support-considerations.adoc
+++ b/modules/monitoring-support-considerations.adoc
@@ -6,6 +6,9 @@
 [id="support-considerations_{context}"]
 = Support considerations for monitoring
 
+[role="_abstract"]
+The {product-title} monitoring has configuration limitations. Understanding them is essential for avoiding automated configuration resets.
+
 [NOTE]
 ====
 Backward compatibility for metrics, recording rules, or alerting rules is not guaranteed.
@@ -19,20 +22,17 @@ ifndef::openshift-dedicated,openshift-rosa[]
 +
 [NOTE]
 ====
-The Alertmanager configuration is deployed as the `alertmanager-main` secret resource in the `openshift-monitoring` namespace.
-If you have enabled a separate Alertmanager instance for user-defined alert routing, an Alertmanager configuration is also deployed as the `alertmanager-user-workload` secret resource in the `openshift-user-workload-monitoring` namespace.
-To configure additional routes for any instance of Alertmanager, you need to decode, modify, and then encode that secret.
-This procedure is a supported exception to the preceding statement.
+The Alertmanager configuration is deployed as the `alertmanager-main` secret resource in the `openshift-monitoring` namespace. If you have enabled a separate Alertmanager instance for user-defined alert routing, an Alertmanager configuration is also deployed as the `alertmanager-user-workload` secret resource in the `openshift-user-workload-monitoring` namespace. To configure additional routes for any instance of Alertmanager, you need to decode, modify, and then encode that secret. This procedure is a supported exception to the preceding statement.
 ====
 +
 * *Modifying resources of the stack.* The {product-title} monitoring stack ensures its resources are always in the state it expects them to be. If they are modified, the stack will reset them.
-* *Deploying user-defined workloads to `openshift-&#42;`, and `kube-&#42;` projects.* These projects are reserved for Red Hat provided components and they should not be used for user-defined workloads.
+* *Deploying user-defined workloads to `openshift-&#42;`, and `kube-&#42;` projects.* These projects are reserved for Red{nbsp}Hat provided components and they should not be used for user-defined workloads.
 * *Enabling symptom based monitoring by using the `Probe` custom resource definition (CRD) in Prometheus Operator.*
-* *Manually deploying monitoring resources into namespaces that have the `openshift.io/cluster-monitoring: "true"` label.* 
+* *Manually deploying monitoring resources into namespaces that have the `openshift.io/cluster-monitoring: "true"` label.*
 * *Adding the `openshift.io/cluster-monitoring: "true"` label to namespaces.* This label is reserved only for the namespaces with core {product-title} components and Red{nbsp}Hat certified components.
 endif::openshift-dedicated,openshift-rosa[]
 
 * *Installing custom Prometheus instances on {product-title}.* A custom instance is a Prometheus custom resource (CR) managed by the Prometheus Operator.
 ifdef::openshift-dedicated,openshift-rosa[]
-* *Modifying the default platform monitoring components.* You should not modify any of the components defined in the `cluster-monitoring-config` config map. Red Hat SRE uses these components to monitor the core cluster components and Kubernetes services.
+* *Modifying the default platform monitoring components.* You should not modify any of the components defined in the `cluster-monitoring-config` config map. Red{nbsp}Hat SRE uses these components to monitor the core cluster components and Kubernetes services.
 endif::openshift-dedicated,openshift-rosa[]

--- a/modules/monitoring-support-policy-for-monitoring-operators.adoc
+++ b/modules/monitoring-support-policy-for-monitoring-operators.adoc
@@ -6,11 +6,12 @@
 [id="support-policy-for-monitoring-operators_{context}"]
 = Support policy for monitoring Operators
 
+[role="_abstract"]
 Monitoring Operators ensure that {product-title} monitoring resources function as designed and tested. If Cluster Version Operator (CVO) control of an Operator is overridden, the Operator does not respond to configuration changes, reconcile the intended state of cluster objects, or receive updates.
 
 While overriding CVO control for an Operator can be helpful during debugging, this is  unsupported and the cluster administrator assumes full control of the individual component configurations and upgrades.
 
-.Overriding the Cluster Version Operator
+*Overriding the Cluster Version Operator*
 
 The `spec.overrides` parameter can be added to the configuration for the CVO to allow administrators to provide a list of overrides to the behavior of the CVO for a component. Setting the `spec.overrides[].unmanaged` parameter to `true` for a component blocks cluster upgrades and alerts the administrator after a CVO override has been set:
 

--- a/modules/monitoring-support-version-matrix-for-monitoring-components.adoc
+++ b/modules/monitoring-support-version-matrix-for-monitoring-components.adoc
@@ -6,6 +6,7 @@
 [id="support-version-matrix-for-monitoring-components_{context}"]
 = Support version matrix for monitoring components
 
+[role="_abstract"]
 The following matrix contains information about versions of monitoring components for {product-title} 4.12 and later releases:
 
 .{product-title} and component versions

--- a/modules/sd-disabling-monitoring-for-user-defined-projects.adoc
+++ b/modules/sd-disabling-monitoring-for-user-defined-projects.adoc
@@ -6,6 +6,7 @@
 [id="sd-disabling-monitoring-for-user-defined-projects_{context}"]
 = Disabling monitoring for user-defined projects
 
+[role="_abstract"]
 By default, monitoring for user-defined projects is enabled. If you do not want to use the built-in monitoring stack to monitor user-defined projects, you can disable it.
 
 .Prerequisites
@@ -18,6 +19,6 @@ By default, monitoring for user-defined projects is enabled. If you do not want 
 
 . Click the *Settings* tab.
 
-. Click the *Enable user workload monitoring* check box to unselect the option, and then click *Save*.
+. Click the *Enable user workload monitoring* checkbox to deselect the option, and then click *Save*.
 +
 User workload monitoring is disabled. The Prometheus, Prometheus Operator, and Thanos Ruler components are stopped in the `openshift-user-workload-monitoring` project.

--- a/modules/sd-monitoring-troubleshooting-issues.adoc
+++ b/modules/sd-monitoring-troubleshooting-issues.adoc
@@ -7,6 +7,7 @@
 [id="troubleshooting-monitoring-issues_{context}"]
 = Determining why user-defined project metrics are unavailable
 
+[role="_abstract"]
 If metrics are not displaying when monitoring user-defined projects, follow these steps to troubleshoot the issue.
 
 .Procedure
@@ -59,9 +60,9 @@ $ oc get service
 [source,terminal]
 ----
 apiVersion: v1
-kind: Service <1>
+kind: Service
 metadata:
-  labels: <2>
+  labels:
     app: prometheus-example-app
   name: prometheus-example-app
   namespace: ns1
@@ -76,8 +77,12 @@ spec:
   type: ClusterIP
 ----
 +
-<1> Specifies that this is a service API.
-<2> Specifies the labels that are being used for this service.
+--
+where:
+
+`kind`:: Specifies an API type. This example shows a service API.
+`metadata.labels`:: Specifies the labels that are used for this service.
+--
 
 .. Query the `serviceIP`, `port`, and `/metrics` endpoints to see if the same metrics from the `curl` command you ran on the pod previously:
 ... Run the following command to find the service IP:
@@ -105,7 +110,7 @@ Valid metrics are returned in the following example.
 # TYPE version gauge
 version{version="v0.1.0"} 1
 ----
-.. Use label matching to verify that the `ServiceMonitor` object is configured to point to the desired service. To do this, compare the `Service` object from the `oc get service` output to the `ServiceMonitor` object from the `oc get servicemonitor` output. The labels must match for the metrics to be displayed.
+.. Use label matching to verify that the `ServiceMonitor` object is configured to point to the required service. To do this, compare the `Service` object from the `oc get service` output to the `ServiceMonitor` object from the `oc get servicemonitor` output. The labels must match for the metrics to be displayed.
 +
 For example, from the previous steps, notice how the `Service` object has the `app: prometheus-example-app` label and the `ServiceMonitor` object has the same `app: prometheus-example-app` match label.
-. If everything looks valid and the metrics are still unavailable, please contact the support team for further help.
+. If the configuration is valid and metrics remain unavailable, contact the support team.

--- a/observability/monitoring/getting-started/maintenance-and-support-for-monitoring.adoc
+++ b/observability/monitoring/getting-started/maintenance-and-support-for-monitoring.adoc
@@ -6,9 +6,10 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-Not all configuration options for the monitoring stack are exposed. The only supported way of configuring {product-title} monitoring is by configuring the {cmo-first} using the options described in the xref:../../../observability/monitoring/config-map-reference-for-the-cluster-monitoring-operator.adoc#cluster-monitoring-operator-configuration-reference[Config map reference for the {cmo-full}]. *Do not use other configurations, as they are unsupported.*
+[role="_abstract"]
+Not all configuration options for the monitoring stack are exposed. To configure {product-title} monitoring, configure the {cmo-first} using the options described in the "Config map reference for the {cmo-full}" linked in the _Additional resources_ section. *Do not use other configurations, as they are unsupported.*
 
-Configuration paradigms might change across Prometheus releases, and such cases can only be handled gracefully if all configuration possibilities are controlled. If you use configurations other than those described in the xref:../../../observability/monitoring/config-map-reference-for-the-cluster-monitoring-operator.adoc#cluster-monitoring-operator-configuration-reference[Config map reference for the {cmo-full}], your changes will disappear because the {cmo-short} automatically reconciles any differences and resets any unsupported changes back to the originally defined state by default and by design.
+Configuration paradigms might change across Prometheus releases, and such cases can only be handled gracefully if all configuration possibilities are controlled. If you use unsupported configurations, your changes will disappear because the {cmo-short} automatically reconciles any differences and resets any unsupported changes back to the originally defined state by default and by design.
 
 ifdef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 [IMPORTANT]
@@ -24,3 +25,8 @@ include::modules/monitoring-support-policy-for-monitoring-operators.adoc[levelof
 endif::openshift-dedicated,openshift-rosa[]
 
 include::modules/monitoring-support-version-matrix-for-monitoring-components.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+[id="additional-resources_{context}"]
+== Additional resources
+* xref:../../../observability/monitoring/config-map-reference-for-the-cluster-monitoring-operator.adoc#cluster-monitoring-operator-configuration-reference[Config map reference for the {cmo-full}]

--- a/observability/monitoring/getting-started/sd-accessing-monitoring-for-user-defined-projects.adoc
+++ b/observability/monitoring/getting-started/sd-accessing-monitoring-for-user-defined-projects.adoc
@@ -6,6 +6,7 @@ include::_attributes/attributes-openshift-dedicated.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 When you install a {product-title} cluster, monitoring for user-defined projects is enabled by default. With monitoring for user-defined projects enabled, you can monitor your own {product-title} projects without the need for an additional monitoring solution.
 
 The `dedicated-admin` user has default permissions to configure and access monitoring for user-defined projects.

--- a/observability/monitoring/getting-started/sd-disabling-monitoring-for-user-defined-projects.adoc
+++ b/observability/monitoring/getting-started/sd-disabling-monitoring-for-user-defined-projects.adoc
@@ -6,6 +6,7 @@ include::_attributes/attributes-openshift-dedicated.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 As a `dedicated-admin`, you can disable monitoring for user-defined projects. You can also exclude individual projects from user workload monitoring.
 
 // Disabling monitoring for user-defined projects


### PR DESCRIPTION
Version(s):
4.21+

Issue:
https://redhat.atlassian.net/browse/OSDOCS-16609

Link to docs preview:

1. **Assembly _maintenance-and-support-for-monitoring_**:
- **ROSA HCP**: [Maintenance and support for monitoring](https://110415--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/observability/monitoring/getting-started/maintenance-and-support-for-monitoring)
- **ROSA Classic**: [Maintenance and support for monitoring](https://110415--ocpdocs-pr.netlify.app/openshift-rosa/latest/observability/monitoring/getting-started/maintenance-and-support-for-monitoring)
- **OSD**: [Maintenance and support for monitoring](https://110415--ocpdocs-pr.netlify.app/openshift-dedicated/latest/observability/monitoring/getting-started/maintenance-and-support-for-monitoring)

2. **Module _sd-monitoring-troubleshooting-issues_**:
- **ROSA Classic**: [Determining why user-defined project metrics are unavailable](https://110415--ocpdocs-pr.netlify.app/openshift-rosa/latest/observability/monitoring/troubleshooting-monitoring-issues#troubleshooting-monitoring-issues_troubleshooting-monitoring-issues)
- **OSD**: [Determining why user-defined project metrics are unavailable](https://110415--ocpdocs-pr.netlify.app/openshift-dedicated/latest/observability/monitoring/troubleshooting-monitoring-issues#troubleshooting-monitoring-issues_troubleshooting-monitoring-issues)

3. No previews for assemblies **sd-accessing-monitoring-for-user-defined-projects** and **sd-disabling-monitoring-for-user-defined-projects** (ROSA Classic and OSD) since they only got **[role="_abstract"]**.

QE review:
N/A

Additional information: