### PR TITLE
DOCPLAN-153: Resolve outstanding ConceptLink warnings in `virt/monitoring/`

### DIFF
--- a/virt/monitoring/virt-exposing-downward-metrics.adoc
+++ b/virt/monitoring/virt-exposing-downward-metrics.adoc
@@ -11,7 +11,7 @@ As an administrator, you can expose a set of host and virtual machine (VM) metri
 
 [NOTE]
 ====
-On Red Hat Enterprise Linux (RHEL) 9, use the command line to view downward metrics. See xref:../../virt/monitoring/virt-exposing-downward-metrics.adoc#virt-viewing-downward-metrics-cli_virt-exposing-downward-metrics[Viewing downward metrics by using the command line].
+On Red Hat Enterprise Linux (RHEL) 9, use the command line to view downward metrics.
 
 The `vm-dump-metrics` tool is not supported on the Red Hat Enterprise Linux (RHEL) 9 platform.
 ====
@@ -25,3 +25,9 @@ include::modules/virt-configuring-downward-metrics.adoc[leveloffset=+1]
 include::modules/virt-viewing-downward-metrics-cli.adoc[leveloffset=+1]
 
 include::modules/virt-viewing-downward-metrics-tool.adoc[leveloffset=+1]
+
+[id="additional-resources_virt-exposing-downward-metrics-for-vms"]
+[role="_additional-resources"]
+== Additional resources
+
+* xref:../../virt/monitoring/virt-exposing-downward-metrics.adoc#virt-viewing-downward-metrics-cli_virt-exposing-downward-metrics[Viewing downward metrics by using the command line]

--- a/virt/monitoring/virt-monitoring-overview.adoc
+++ b/virt/monitoring/virt-monitoring-overview.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: REFERENCE
 [id="virt-monitoring-overview"]
 = Monitoring overview
 include::_attributes/common-attributes.adoc[]

--- a/virt/monitoring/virt-prometheus-queries.adoc
+++ b/virt/monitoring/virt-prometheus-queries.adoc
@@ -14,7 +14,7 @@ Monitor the consumption of cluster infrastructure resources using the metrics pr
 ====
 // Hiding in ROSA/OSD as user cannot edit MCO
 ifndef::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
-* To use the vCPU metric, the `schedstats=enable` kernel argument must be applied to the `MachineConfig` object. This kernel argument enables scheduler statistics used for debugging and performance tuning and adds a minor additional load to the scheduler. For more information, see xref:../../machine_configuration/machine-configs-configure.adoc#nodes-nodes-kernel-arguments_machine-configs-configure[Adding kernel arguments to nodes].
+* To use the vCPU metric, the `schedstats=enable` kernel argument must be applied to the `MachineConfig` object. This kernel argument enables scheduler statistics used for debugging and performance tuning and adds a minor additional load to the scheduler.
 endif::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
 
 * For guest memory swapping queries to return data, memory swapping must be enabled on the virtual guests.
@@ -31,6 +31,10 @@ include::modules/virt-live-migration-metrics.adoc[leveloffset=+2]
 [id="additional-resources_virt-prometheus-queries"]
 [role="_additional-resources"]
 == Additional resources
+// Hiding in ROSA/OSD as user cannot edit MCO
+ifndef::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
+* xref:../../machine_configuration/machine-configs-configure.adoc#nodes-nodes-kernel-arguments_machine-configs-configure[Adding kernel arguments to nodes]
+endif::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
 // HCP link removed for now
 ifndef::openshift-rosa-hcp,openshift-rosa,openshift-dedicated[]
 * link:https://docs.redhat.com/en/documentation/monitoring_stack_for_red_hat_openshift/4.21/html/about_monitoring/about-ocp-monitoring[About {product-title} monitoring]

--- a/virt/monitoring/virt-runbooks.adoc
+++ b/virt/monitoring/virt-runbooks.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: ASSEMBLY
+:_mod-docs-content-type: REFERENCE
 [id="virt-runbooks"]
 = {VirtProductName} runbooks
 include::_attributes/common-attributes.adoc[]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.20+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [DOCPLAN-153](https://redhat.atlassian.net/browse/DOCPLAN-153)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:

CQA changes only, no QE review is therefore needed. To address the outstanding `AsciiDocDITA.ConceptLink` warnings, I did the following:

- In `virt/monitoring/virt-exposing-downward-metrics.adoc` and `virt/monitoring/virt-prometheus-queries.adoc`,  I created a new Additional resources section and moved the cross references to it. I ensured these entries use the same conditions as the original text.
- In `virt/monitoring/virt-monitoring-overview.adoc` and `virt/monitoring/virt-runbooks.adoc`, I changed the content type to `REFERENCE` as this content type best describes what these modules are. I suspect these files were placed among the assemblies to work around the restriction on linking to other modules from modules.

Vale output with the latest version of the `AsciiDocDITA` style:

```console
$ find virt/monitoring/ -name '*.adoc' | xargs vale --config ~/dita.ini
✔ 0 errors, 0 warnings and 0 suggestions in 8 files.
```

<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
