### PR TITLE
DOCPLAN-154: Correct the broken anchor in `virt/monitoring/`

### DIFF
--- a/virt/monitoring/virt-exposing-custom-metrics-for-vms.adoc
+++ b/virt/monitoring/virt-exposing-custom-metrics-for-vms.adoc
@@ -33,6 +33,6 @@ ifndef::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
 * xref:../../applications/application-health.adoc#application-health[Monitoring application health by using health checks]
 endif::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
 
-* xref:../../nodes/pods/nodes-pods-configmaps.adoc#nodes-pods-configmaps[Creating and using config maps]
+* xref:../../nodes/pods/nodes-pods-configmaps.adoc#nodes-pods-configmap-overview_configmaps[Creating and using config maps]
 
 * xref:../../virt/managing_vms/virt-controlling-vm-states.adoc#virt-controlling-vm-states[Controlling virtual machine states]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.20+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [DOCPLAN-154](https://redhat.atlassian.net/browse/DOCPLAN-154)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

- https://110419--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/monitoring/virt-exposing-custom-metrics-for-vms.html

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:

CQA changes only, no QE review is therefore needed. I reviewed the reported anchors and after ruling out false positives, I fixed the incorrect link to Creating and using config maps.
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
