### PR TITLE
[SSCSI-275]Hashicorp vault integration with IBM Z SSCSI operator

### DIFF
--- a/modules/secrets-store-providers.adoc
+++ b/modules/secrets-store-providers.adoc
@@ -14,6 +14,11 @@ The {secrets-store-operator} has been tested with the following secrets store pr
 * Google Secret Manager
 * HashiCorp Vault
 
+[IMPORTANT]
+====
+{ibm-z-title} supports only HashiCorp Vault. 
+====
+
 [NOTE]
 ====
 Red{nbsp}Hat does not test all factors associated with third-party secrets store provider functionality. For more information about third-party support, see the link:https://access.redhat.com/third-party-software-support[Red{nbsp}Hat third-party support policy].

--- a/modules/secrets-store-vault.adoc
+++ b/modules/secrets-store-vault.adoc
@@ -70,6 +70,29 @@ $ oc adm policy add-scc-to-user privileged -z vault -n vault
 $ oc adm policy add-scc-to-user privileged -z vault-csi-provider -n vault
 ----
 
+.. If you are using {ibm-z-title}, create a `vault-license` secret for HashiCorp Vault Enterprise:
++
+... Create a `vault-license.yaml` file with the following content:
++
+[source,yaml]
+----
+apiVersion: v1
+data:
+  license: <license-string>
+kind: Secret
+metadata:
+  name: vault-license
+  namespace: vault
+type: Opaque
+----
++
+... Create the secret by running the following command:
++
+[source,terminal]
+----
+$ oc create -f vault-license.yaml
+----
+
 .. Deploy HashiCorp Vault by running the following command:
 +
 [source,terminal]
@@ -84,6 +107,28 @@ $ helm install vault hashicorp/vault --namespace=vault \
   --set "csi.image.repository=docker.io/hashicorp/vault-csi-provider" \
   --set "csi.agent.image.repository=docker.io/hashicorp/vault" \
   --set "csi.daemonSet.providersDir=/var/run/secrets-store-csi-providers"
+----
++
+If you are using {ibm-z-title}, you must use Vault Enterprise images and the Vault license secret. Run the following command instead:
++
+[source,terminal]
+----
+$ helm install vault hashicorp/vault \
+  --namespace vault \
+  --create-namespace \
+  --set server.dev.enabled=true \
+  --set server.image.repository="docker.io/hashicorp/vault-enterprise" \
+  --set server.image.tag="1.21-ent" \
+  --set server.enterpriseLicense.secretName="vault-license" \
+  --set server.logLevel=debug \
+  --set server.serviceAccount.name="vault" \
+  --set "injector.enabled=false" \
+  --set global.openshift=true \
+  --set csi.enabled=true \
+  --set "csi.daemonSet.providersDir=/var/run/secrets-store-csi-providers" \
+  --set csi.image.repository="registry.connect.redhat.com/hashicorp/vault-csi-provider" \
+  --set csi.image.tag="1.7.1-ubi" \
+  --set csi.agent.enabled=false
 ----
 
 .. Patch the `vault-csi-driver` daemon set to set the `securityContext` to `privileged` by running the following command:


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.22 +
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:

https://redhat.atlassian.net/browse/SSCSI-275
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:

https://110433--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/pods/nodes-pods-secrets-store.html
https://110433--ocpdocs-pr.netlify.app/openshift-enterprise/latest/storage/container_storage_interface/persistent-storage-csi-secrets-store.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
