### PR TITLE
OSDOCS-18266: Added options to nw-multus-bridge-object.adoc

### DIFF
--- a/modules/configuring-localnet-switched-topology.adoc
+++ b/modules/configuring-localnet-switched-topology.adoc
@@ -46,15 +46,15 @@ spec:
         bridge: br-ex
         state: present
 ----
-+
+
 where:
-+
+
 `metadata.name`:: The name for the configuration object.
 `spec.nodeSelector.node-role.kubernetes.io/worker`:: A node selector that specifies the nodes to apply the node network configuration policy to.
 `spec.desiredState.ovn.bridge-mappings.localnet`:: The name for the secondary network from which traffic is forwarded to the OVS bridge. This secondary network must match the name of the `spec.config.name` field of the `NetworkAttachmentDefinition` CRD that defines the OVN-Kubernetes secondary network.
 `spec.desiredState.ovn.bridge-mappings.bridge`:: The name of the OVS bridge on the node. This value is required only if you specify `state: present`.
 `spec.desiredState.ovn.bridge-mappings.state`:: The state for the mapping. Must be either `present` to add the bridge or `absent` to remove the bridge. The default value is `present`.
-+
+
 The following JSON example configures a localnet secondary network that is named `localnet1`. Note that the value for the `mtu` parameter must match the MTU value that was set for the secondary network interface that is mapped to the `br-ex` bridge interface.
 
 [source,json]
@@ -105,9 +105,9 @@ spec:
         bridge: ovs-br1
         state: present
 ----
-+
+
 where:
-+
+
 `metadata.name`:: Specifies the name of the configuration object.
 `node-role.kubernetes.io/worker`:: Specifies a node selector that identifies the nodes to which the node network configuration policy applies.
 `desiredState.interfaces.name`:: Specifies a new OVS bridge that operates separately from the default bridge used by OVN-Kubernetes for cluster traffic.
@@ -116,7 +116,7 @@ where:
 `ovn.bridge-mappings.localnet`:: Specifies the name of the secondary network that forwards traffic to the OVS bridge. This name must match the value of the `spec.config.name` field in the `NetworkAttachmentDefinition` CRD that defines the OVN-Kubernetes secondary network.
 `ovn.bridge-mappings.bridge`:: Specifies the name of the OVS bridge on the node. The value is required only when `state: present` is set.
 `ovn.bridge-mappings.state`:: Specifies the state of the mapping. Valid values are `present` to add the bridge or `absent` to remove the bridge. The default value is `present`.
-+
+
 The following JSON example configures a localnet secondary network that is named `localnet2`. Note that the value for the `mtu` parameter must match the MTU value that was set for the `eth1` secondary network interface.
 
 [source,json]

--- a/modules/nw-multus-bridge-object.adoc
+++ b/modules/nw-multus-bridge-object.adoc
@@ -8,7 +8,9 @@
 = Configuration for a bridge secondary network
 
 [role="_abstract"]
-The bridge CNI plugin JSON configuration object describes the configuration parameters for the Bridge CNI plugin. The following table details these parameters:
+The Bridge CNI plugin JSON configuration object describes the configuration parameters for the Bridge CNI plugin.
+
+The following table details the configuration parameters:
 
 [cols=".^2,.^2,.^6",options="header"]
 |====
@@ -22,7 +24,6 @@ ifndef::microshift[]
 |`name`
 |`string`
 |The mandatory, unique identifier assigned to this CNI network attachment definition. It is used by the container runtime to select the correct network configuration and serves as the key for persistent resource state management, such as IP address allocations.
-
 endif::microshift[]
 
 ifdef::microshift[]
@@ -47,13 +48,17 @@ endif::microshift[]
 |`boolean`
 |Optional: Set to `true` to enable IP masquerading for traffic that leaves the virtual network. The source IP address for all traffic is rewritten to the bridge's IP address. If the bridge does not have an IP address, this setting has no effect. The default value is `false`.
 
+|`disableContainerInterface`
+|`boolean`
+|Optional: Controls the container interface (`veth` peer inside the `netns` container). When set to `true`, the container interface link-state is set to `down`, you cannot use the IPAM CNI plugin. The default value is `false`.
+
 |`isGateway`
 |`boolean`
 |Optional: Set to `true` to assign an IP address to the bridge. The default value is `false`.
 
 |`isDefaultGateway`
 |`boolean`
-|Optional: Set to `true` to configure the bridge as the default gateway for the virtual network. The default value is `false`. If `isDefaultGateway` is set to `true`, then `isGateway` is also set to `true` automatically.
+|Optional: Set to `true` to configure the bridge as the default gateway for the virtual network. The assigned IP address of the bridge is used as the default route. If `isDefaultGateway` is set to `true`, `isGateway` is also set to `true` automatically. The default value is `false`.
 
 |`forceAddress`
 |`boolean`
@@ -69,12 +74,16 @@ endif::microshift[]
 
 ifndef::microshift[]
 |`vlan`
-|`string`
+|`integer`
 |Optional: Specify a virtual LAN (VLAN) tag as an integer value. By default, no VLAN tag is assigned.
 
 |`preserveDefaultVlan`
-|`string`
+|`boolean`
 |Optional: Indicates whether the default VLAN must be preserved on the `veth` end connected to the bridge. Defaults to `false`.
+
+|`portIsolation`
+|`boolean`
+|Optional: If `true`, prevents containers on the same bridge from communicating with each other. A container can still reach non-isolated ports. For example, a bridge interface that allows access to the host or an optional uplink that allows access outside the host. The default value is `false`.
 
 |`vlanTrunk`
 |`list`


### PR DESCRIPTION
Version(s):
4.16+

Issue:
[OSDOCS-18266](https://redhat.atlassian.net/browse/OSDOCS-18266)

Link to docs preview:

* https://110459--ocpdocs-pr.netlify.app/microshift/latest/microshift_networking/microshift_multiple_networks/microshift-cni-multus.html
* https://110459--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/multiple_networks/secondary_networks/creating-secondary-nwt-other-cni.html
* https://110459--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/multiple_networks/secondary_networks/creating-secondary-nwt-ovnk.html
* https://110459--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/live_migration/virt-configuring-cross-cluster-live-migration-network.html


- [x] SME has approved this change (Andrea P/Zeeke).
- [x] QE has approved this change (Anat Wax).

https://github.com/openshift/openshift-docs/pull/107014
https://github.com/openshift/openshift-docs/pull/92544
