### PR TITLE
[enterprise-4.16] Power monitoring - remove content from OCP and add one redirect page

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -3031,18 +3031,8 @@ Topics:
   Dir: power_monitoring
   Distros: openshift-enterprise,openshift-origin
   Topics:
-  - Name: Power monitoring release notes
-    File: power-monitoring-release-notes
-  - Name: Power monitoring overview
-    File: power-monitoring-overview
-  - Name: Installing power monitoring
-    File: installing-power-monitoring
-  - Name: Configuring power monitoring
-    File: configuring-power-monitoring
-  - Name: Visualizing power monitoring metrics
-    File: visualizing-power-monitoring-metrics
-  - Name: Uninstalling power monitoring
-    File: uninstalling-power-monitoring
+  - Name: About power monitoring
+    File: about-power-monitoring
 ---
 Name: Scalability and performance
 Dir: scalability_and_performance

--- a/observability/overview/index.adoc
+++ b/observability/overview/index.adoc
@@ -73,5 +73,5 @@ For more information, see xref:../../observability/network_observability/network
 == Power monitoring
 Monitor the power usage of workloads and identify the most power-consuming namespaces running in a cluster with key power consumption metrics, such as CPU or DRAM measured at the container level. Visualize energy-related system statistics with the {PM-operator}.
 
-For more information, see xref:../../observability/power_monitoring/power-monitoring-overview.adoc#power-monitoring-overview[Power monitoring overview].
+For more information, see link:https://docs.redhat.com/en/documentation/power_monitoring_for_red_hat_openshift/latest/html/about_power_monitoring/about-power-monitoring[About {PM-shortname}].
 endif::[]

--- a/observability/power_monitoring/about-power-monitoring.adoc
+++ b/observability/power_monitoring/about-power-monitoring.adoc
@@ -1,0 +1,15 @@
+:_mod-docs-content-type: ASSEMBLY
+include::_attributes/common-attributes.adoc[]
+[id="about-power-monitoring"]
+= About {PM-title}
+:context: about-power-monitoring
+
+toc::[]
+
+[role="_abstract"]
+{PM-title-c} enables you to monitor the power usage of workloads and identify the most power-consuming namespaces running in an {product-title} cluster with key power consumption metrics, such as CPU or DRAM, measured at container level.
+
+[NOTE]
+====
+The {PM-shortname} documentation is available as a separate documentation set at link:https://docs.redhat.com/en/documentation/power_monitoring_for_red_hat_openshift/latest[{PM-title-c}].
+====

--- a/welcome/index.adoc
+++ b/welcome/index.adoc
@@ -285,7 +285,7 @@ After configuring monitoring, use the web console to access link:https://docs.re
 
 - **xref:../support/remote_health_monitoring/about-remote-health-monitoring.adoc#about-remote-health-monitoring_about-remote-health-monitoring[Remote health monitoring]**: {product-title} collects anonymized aggregated information about your cluster. By using Telemetry and the Insights Operator, this data is received by Red Hat and used to improve {product-title}. You can view the xref:../support/remote_health_monitoring/showing-data-collected-by-remote-health-monitoring.adoc#showing-data-collected-by-remote-health-monitoring_showing-data-collected-by-remote-health-monitoring[data collected by remote health monitoring].
 
-- **xref:../observability/power_monitoring/power-monitoring-overview.adoc#power-monitoring-overview[{PM-title-c} (Technology Preview)]**: You can use {PM-title} to monitor the power usage and identify power-consuming containers running in an {product-title} cluster. {PM-shortname-c} collects and exports energy-related system statistics from various components, such as CPU and DRAM. {PM-shortname-c} provides granular power consumption data for Kubernetes pods, namespaces, and nodes.
+- **link:https://docs.redhat.com/en/documentation/power_monitoring_for_red_hat_openshift/latest/html/about_power_monitoring/about-power-monitoring[{PM-title-c} (Technology Preview)]**: You can use {PM-title} to monitor the power usage and identify power-consuming containers running in an {product-title} cluster. {PM-shortname-c} collects and exports energy-related system statistics from various components, such as CPU and DRAM. {PM-shortname-c} provides granular power consumption data for Kubernetes pods, namespaces, and nodes.
 
 == Storage activities
 


### PR DESCRIPTION
manual cherry-pick of https://github.com/openshift/openshift-docs/pull/106816 to 4.16