### PR TITLE
[enterprise-4.17] Power monitoring - remove content from OCP and add one redirect page

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -3190,24 +3190,8 @@ Topics:
   Dir: power_monitoring
   Distros: openshift-enterprise,openshift-origin
   Topics:
-  - Name: Power monitoring 0.5 release notes
-    File: power-monitoring-release-notes-tp-0-5
-  - Name: Power monitoring release notes
-    File: power-monitoring-release-notes
-  - Name: Power monitoring overview
-    File: power-monitoring-overview
-  - Name: Installing power monitoring
-    File: installing-power-monitoring
-  - Name: Configuring power monitoring
-    File: configuring-power-monitoring
-  - Name: Visualizing power monitoring metrics
-    File: visualizing-power-monitoring-metrics
-  - Name: Uninstalling power monitoring
-    File: uninstalling-power-monitoring
-  - Name: Power monitoring references
-    File: power-monitoring-references
-  - Name: Power monitoring API reference
-    File: power-monitoring-api-reference
+  - Name: About power monitoring
+    File: about-power-monitoring
 ---
 Name: Scalability and performance
 Dir: scalability_and_performance

--- a/observability/overview/index.adoc
+++ b/observability/overview/index.adoc
@@ -71,5 +71,5 @@ For more information, see xref:../../observability/network_observability/network
 == Power monitoring
 Monitor the power usage of workloads and identify the most power-consuming namespaces running in a cluster with key power consumption metrics, such as CPU or DRAM measured at the container level. Visualize energy-related system statistics with the {PM-operator}.
 
-For more information, see xref:../../observability/power_monitoring/power-monitoring-overview.adoc#power-monitoring-overview[Power monitoring overview].
+For more information, see link:https://docs.redhat.com/en/documentation/power_monitoring_for_red_hat_openshift/latest/html/about_power_monitoring/about-power-monitoring[About {PM-shortname}].
 endif::[]

--- a/observability/power_monitoring/about-power-monitoring.adoc
+++ b/observability/power_monitoring/about-power-monitoring.adoc
@@ -1,0 +1,15 @@
+:_mod-docs-content-type: ASSEMBLY
+include::_attributes/common-attributes.adoc[]
+[id="about-power-monitoring"]
+= About {PM-title}
+:context: about-power-monitoring
+
+toc::[]
+
+[role="_abstract"]
+{PM-title-c} enables you to monitor the power usage of workloads and identify the most power-consuming namespaces running in an {product-title} cluster with key power consumption metrics, such as CPU or DRAM, measured at container level.
+
+[NOTE]
+====
+The {PM-shortname} documentation is available as a separate documentation set at link:https://docs.redhat.com/en/documentation/power_monitoring_for_red_hat_openshift/latest[{PM-title-c}].
+====

--- a/release_notes/addtl-release-notes.adoc
+++ b/release_notes/addtl-release-notes.adoc
@@ -84,7 +84,7 @@ xref:../virt/release_notes/virt-4-17-release-notes.adoc#virt-4-17-release-notes[
 link:https://docs.redhat.com/en/documentation/red_hat_build_of_opentelemetry/latest/html-single/release_notes_for_the_red_hat_build_of_opentelemetry/index[{OTELName}]
 
 P::
-xref:../observability/power_monitoring/power-monitoring-release-notes.adoc#power-monitoring-release-notes[{PM-title-c}]
+link:https://docs.redhat.com/en/documentation/power_monitoring_for_red_hat_openshift/latest/html/release_notes/index[{PM-title-c}]
 
 R::
 xref:../nodes/pods/run_once_duration_override/run-once-duration-override-release-notes.adoc#run-once-duration-override-release-notes[{run-once-operator}]

--- a/welcome/learn_more_about_openshift.adoc
+++ b/welcome/learn_more_about_openshift.adoc
@@ -213,7 +213,7 @@ a|* xref:../observability/network_observability/metrics-alerts-dashboards.adoc#m
 
 | link:https://docs.redhat.com/en/documentation/monitoring_stack_for_red_hat_openshift/4.17/html/about_monitoring/about-ocp-monitoring[About {product-title} monitoring]
 a|* xref:../support/remote_health_monitoring/about-remote-health-monitoring.adoc#about-remote-health-monitoring_about-remote-health-monitoring[Remote health monitoring]
-* xref:../observability/power_monitoring/power-monitoring-overview.adoc#power-monitoring-overview[{PM-title-c} (Technology Preview)]
+* link:https://docs.redhat.com/en/documentation/power_monitoring_for_red_hat_openshift/latest/html/about_power_monitoring/about-power-monitoring[{PM-title-c} (Technology Preview)]
 
 |===
 


### PR DESCRIPTION
manual cherry-pick of https://github.com/openshift/openshift-docs/pull/106816 to 4.17