### PR TITLE
OSDOCS-19226 updated release notes for minor release 1.0.1

### DIFF
--- a/modules/zero-trust-manager-release-notes-0-1-0.adoc
+++ b/modules/zero-trust-manager-release-notes-0-1-0.adoc
@@ -1,0 +1,23 @@
+// Module included in the following assemblies:
+//
+// * security/zero_trust_workload_identity_manager/zero-trust-manager-install.adoc
+:_mod-docs-content-type: REFERENCE
+[id="zero-trust-manager-release-notes-0-1-0_{context}"]
+= Zero Trust Workload Identity Manager 0.1.0 (General Availability)
+
+[role="_abstract"]
+Issued: 16 June 2025
+
+The following advisories are available for the {zero-trust-full}:
+
+* https://access.redhat.com/errata/RHBA-2025:9088[RHBA-2025:9088]
+* https://access.redhat.com/errata/RHBA-2025:9085[RHBA-2025:9085]
+* https://access.redhat.com/errata/RHBA-2025:9090[RHBA-2025:9090]
+* https://access.redhat.com/errata/RHBA-2025:9084[RHBA-2025:9084]
+* https://access.redhat.com/errata/RHBA-2025:9089[RHBA-2025:9089]
+* https://access.redhat.com/errata/RHBA-2025:9087[RHBA-2025:9087]
+* https://access.redhat.com/errata/RHBA-2025:9101[RHBA-2025:9101]
+* https://access.redhat.com/errata/RHBA-2025:9104[RHBA-2025:9104]
+
+
+

--- a/modules/zero-trust-manager-release-notes-0-2-0.adoc
+++ b/modules/zero-trust-manager-release-notes-0-2-0.adoc
@@ -1,0 +1,58 @@
+// Module included in the following assemblies:
+//
+// * security/zero_trust_workload_identity_manager/zero-trust-manager-install.adoc
+:_mod-docs-content-type: REFERENCE
+[id="zero-trust-manager-release-notes-0-2-0_{context}"]
+= {zero-trust-full} 0.2.0 (General Availability)
+
+[role="_abstract"]
+Issued: 09 August 2025
+
+The following advisories are available for the {zero-trust-full}:
+
+* https://access.redhat.com/errata/RHBA-2025:15425[RHBA-2025:15425]
+* https://access.redhat.com/errata/RHBA-2025:15426[RHBA-2025:15426]
+* https://access.redhat.com/errata/RHBA-2025:15427[RHBA-2025:15427]
+* https://access.redhat.com/errata/RHBA-2025:15428[RHBA-2025:15428]
+
+[id="zero-trust-manager-0-2-0-features-enhancements_{context}"]
+== New features and enhancements
+
+Support for the managed OIDC Discovery Provider Route::
+
+* The Operator exposes the `SPIREOIDCDiscoveryProvider` spec through {product-title} Routes under the domain `*.apps.<cluster_domain>` for the selected default installation.
+
+* The `managedRoute` and `externalSecretRef` fields have been added to the `spireOidcDiscoveryProvider` spec.
+
+* The `managedRoute` field is boolean and is set to `true` by default. If set to `false`, the Operator stops managing the route and the existing route will not be deleted automatically. If set back to `true`, the Operator resumes managing the route. If a route does not exist, the Operator creates a new one. If a route already exists, the Operator will override the user configuration if a conflict exists.
+
+* The `externalSecretRef` references an externally managed Secret that has the TLS certificate for the `oidc-discovery-provider` Route host. When provided, this populates the route's `.Spec.TLS.ExternalCertificate` field. For more information, see link:https://docs.redhat.com/en/documentation/openshift_container_platform/latest/html-single/ingress_and_load_balancing/index#nw-ingress-route-secret-load-external-cert_secured-routes[Creating a route with externally managed certificate]
+
+Enabling the custom Certificate Authority Time-To-Live for the SPIRE bundle::
+
+* The following Time-To-Live (TTL) fields have been added to the `SpireServer` custom resource definition (CRD) API for SPIRE Server certificate management:
+
+** `CAValidity` (default: 24h)
+
+** `DefaultX509Validity` (default: 1h)
+
+** `DefaultJWTValidity` (default: 5m)
+
+* The default values can be replaced in the server configuration with user-configurable options that give users the flexibility to customize certificate and {svid-full} lifetimes based on their security requirements.
+
+Enabling Manual User Configurations::
+
+* The Operator controller switches to `create-only` mode once the `ztwim.openshift.io/create-only=true` annotation is present on the Operator's APIs. This allows resource creation while skipping the updates. A user can update the resources manually to test their configuration. This annotation supports APIs such as `SpireServer`, `SpireAgents`, `SpiffeCSIDriver`, `SpireOIDCDiscoveryProvider`, and `ZeroTrustWorkloadIdentityManager`.
+
+* When the annotation is applied, all derived resources including resources created and managed by the Operator are created but not updated.
+
+* After the annotation is removed and the pod restarts, the Operator tries to come back to the required state. The annotation is applied only once during start or a restart.
+
+[id="zero-trust-manager-0-2-0-bug-fixes_{context}"]
+== Fixed issues
+
+JSON Web Token Issuer field now requires a valid URL::
++
+* Before this update, the `JwtIssuer` field for both the `SpireServer` and the `SpireOidcDiscoveryProvider` custom resources did not require the input to be a URL, frequently causing configuration errors. With this release, the validation has been updated, and users must now manually enter a valid issuer URL in the `JwtIssuer` field for both custom resources. As a result, misconfigurations caused by a malformed issuer values are prevented, ensuring a stable and reliable setup.
++
+(link:https://issues.redhat.com/browse/SPIRE-117[SPIRE-117])

--- a/modules/zero-trust-manager-release-notes-1-0-0.adoc
+++ b/modules/zero-trust-manager-release-notes-1-0-0.adoc
@@ -1,0 +1,211 @@
+// Module included in the following assemblies:
+//
+// * security/zero_trust_workload_identity_manager/zero-trust-manager-install.adoc
+:_mod-docs-content-type: REFERENCE
+[id="zero-trust-manager-release-notes-1-0-0_{context}"]
+= {zero-trust-full} 1.0.0 (General Availability)
+
+Issued: 12 December 2025
+
+[role="_abstract"]
+This release introduces capabilities for enterprise readiness, security, and operational flexibility. The release includes SPIRE federation for cross-cluster identity, PostgreSQL support for production persistence, and enhanced security through stricter constraints and API validation.
+
+The following advisories are available for the {zero-trust-full}:
+
+* https://access.redhat.com/errata/RHBA-2025:23438[RHBA-2025:23438]
+* https://access.redhat.com/errata/RHBA-2025:23439[RHBA-2025:23439]
+* https://access.redhat.com/errata/RHBA-2025:23440[RHBA-2025:23440]
+* https://access.redhat.com/errata/RHBA-2025:23441[RHBA-2025:23441]
+* https://access.redhat.com/errata/RHBA-2025:23442[RHBA-2025:23442]
+* https://access.redhat.com/errata/RHBA-2025:23443[RHBA-2025:23443]
+* https://access.redhat.com/errata/RHBA-2025:23446[RHBA-2025:23446]
+
+{zero-trust-full} supports the following components and versions:
+
+[cols="1,1",options="header"]
+|===
+| Component
+| Version
+
+| SPIRE Server
+| 1.13.3
+
+| SPIRE Agent
+| 1.13.3
+
+| SPIRE Controller Manager
+| 0.6.3
+
+| SPIRE OIDC Discovery Provider
+| 1.13.3
+
+| SPIFFE CSI Driver
+| 0.2.8
+|===
+
+[id="zero-trust-manager-1-0-0-features-enhancements_{context}"]
+== New features and enhancements
+
+SPIRE federation support::
+
+The Operator now includes support for SPIRE federation, enabling workloads across distinct trust domains to securely communicate and authenticate with each other.
+
+* Key capabilities:
+
+** Configuration of bundle endpoints using `https_spiffe` (TLS) or `https_web` (Web PKI) profiles.
+** Automatic certificate management via the ACME protocol. For example, `Let's Encrypt`.
+** Automatic {product-title} route creation for federation endpoints.
+** Ability to configure relationships with multiple federated trust domains.
+
+* Customer action required:
+
+** Review the `federation` configuration within the `SpireServer` custom resource (CR).
+** Ensure proper DNS resolution and network connectivity to federated trust domains.
+
+PostgreSQL database support::
+
+SPIRE Server now supports PostgreSQL as an external database backend, accommodating production deployments that necessitate enterprise-grade data persistence and high availability.
+
+* Supported Types: `sqlite3` (default), `postgres`, `mysql`.
+
+* Customer action required:
+
+** For production, evaluation of migration from SQLite to PostgreSQL is recommended.
+** Creation and configuration of Kubernetes Secrets for database TLS certificates and credentials are required.
+
+Configurable agent socket path and Container Storage Interface (CSI) plugin name::
+
+The SPIRE Agent socket path and the SPIFFE CSI Driver plugin name are now configurable, providing operational flexibility for environments with specific directory requirements or co-existence with multiple SPIFFE deployments.
+
+* Key configuration points:
+
+** `SpireAgent.spec.socketPath`
+** `SpiffeCSIDriver.spec.agentSocketPath`
+** `SpiffeCSIDriver.spec.pluginName`
+
+* Customer action required:
+
+** Ensure consistency between `socketPath` in the `SpireAgent` CR and `agentSocketPath` in the `SpiffeCSIDriver` CR.
+
+Workload attestors verification API::
+
+A new API has been introduced to configure kubelet certificate verification for workload attestation, enhancing security and supporting various {product-title} configurations.
+
+* Verification types:
+
+** `auto` (default): Verification utilizes {product-title} defaults (`/etc/kubernetes/kubelet-ca.crt`).
+** `hostCert`: Uses a custom CA certificate path.
+** `skip`: Skips TLS verification (not recommended for production use).
+
+Configurable Certificate Authority and JSON Web Token key types::
+
+Administrators can now configure the cryptographic key types used for the SPIRE Server Certificate Authority (CA) and JSON Web Token (JWT) signing, ensuring compliance with organizational security policies.
+
+* Supported Key Types: `rsa-2048` (default), `rsa-4096`, `ec-p256`, `ec-p384`.
+
+* Customer action required:
+
+** Review organizational security policies to determine required key types.
+
+Custom namespace deployment::
+
+* The Operator and all associated operands can now be deployed within a custom namespace, providing flexibility for organizations with specific namespace governance requirements.
+
+Proxy-aware Operator and operands::
+
+* The Operator and all managed operands are now proxy-aware and automatically inherit cluster-wide proxy settings when configured.
+
+Enhanced Security Context Constraints::
+
+* SPIRE Agent and SPIFFE CSI Driver now run with Security Context Constraints (SCC) that prevent root user execution, though privileged container mode remains enabled for necessary host-level operations.
+
+* The Operator and all operand containers are configured with the `ReadOnlyRootFilesystem` set to `true`.
+
+Enhanced API validation::
+
+Comprehensive Common Expression Language (CEL) validation has been integrated into all Custom Resource Definitions (CRDs) to prevent configuration errors during admission control.
+
+* Key validations:
+
+** All Operator CRDs are enforced as singletons (must be named `cluster`).
+** Immutable Fields: Fields including `trustDomain`, `clusterName`, `bundleConfigMap`, `federation`, `bundleEndpoint` profile, and all `Persistence` settings (`size`, `accessMode`, and `storageClass`) are now immutable after initial creation.
+
+* Customer action required:
+
+** Review existing CR configurations to ensure compliance with the new validation rules.
+
+Common configuration consolidation::
+
+* Standard configuration options (`labels`, `resources`, `affinity`, `tolerations`, `nodeSelector`) are now standardized across all operand CRs via a shared `CommonConfig` structure.
+
+Configuring log level and log format for the operands::
+
+This release introduces flexible logging controls to improve observability and debugging across the platform:
+
+* SPIRE Components: Users can now configure the `logLevel` (debug, info, warn, error) and `logFormat` (text, JSON) independently for `SpireServer`, `SpireAgent`, and `SpireOIDCDiscoveryProvider` directly within their CR specifications. The defaults are set to "info" for the `logLevel` and "text" for the `logFormat`.
+
+* Operator: The Operator’s log verbosity is now configurable via the `OPERATOR_LOG_LEVEL` environment variable using klog’s `textlogger`.
+
+Refactor for create-only mode::
+
+By setting the `CREATE_ONLY_MODE` environment variable, users can prevent the Operator from reconciling updates. This allows for manual resource modification without interference. If this mode is disabled, the Operator resumes enforcing the state and overwrites any manual changes.
+
+[id="zero-trust-manager-1-0-0-status-improvements_{context}"]
+== Status and observability improvements
+
+Enhanced status reporting::
+
+* The main CR now aggregates status information from all operand CRs.
+
+* New status conditions include Upgradeable (indicating a safe upgrade path) and Progressing (detailing deployment progress).
+
+Operator metrics::
+
+* Operator metrics are now exposed and secured with appropriate RBAC configuration.
+
+* Integration is supported with the {product-title} monitoring stack.
+
+[id="zero-trust-manager-1-0-0-bug-fixes_{context}"]
+== Fixed issues
+
+Enhanced Security Context Constraints for SPIRE Agent::
++
+* Before this update, the SPIRE Agent and SPIFFE CSI Driver containers were running as root user, leading to potential security violations. With this release, Security Context Constraints (SCC) have been configured to ensure these components no longer run as root. While privileged container mode is still required for necessary capabilities, this change reduces potential security risks for the user.
++
+(link:https://issues.redhat.com/browse/SPIRE-60[SPIRE-60])
+
+SpireServer updates now propagate without Operator restart::
++
+* Before this update, the Operator failed to trigger reconciliation after updating the operand CR spec. As a consequence, user updates to `SpireServer` CR resources were not propagated to the `StatefulSet`, causing reconciliation to fail and changes to be ignored, leading to inconsistent resource allocation. With this release, the race condition between the manager and reconciler's cache to trigger reconciliation after CR updates has been fixed. As a result, post installation patch operations on `SpireServer` CRs reliably trigger reconciliation, ensuring updated values are applied to the StatefulSet without manual Operator restart.
++
+(link:https://issues.redhat.com/browse/SPIRE-68[SPIRE-68])
+
+Removed unnecessary security context constraint for OpenID Connect discovery provider::
++
+* Before this update, the system unnecessarily created a custom security context constraint (SCC) for the OpenID Connect (OIDC) discovery provider, which increased the security footprint and configuration complexity even though the deployment did not require it. With this release, the custom SCC creation logic has been removed, resulting in a configuration where the OIDC discovery provider operates successfully without the extra security constraints.
++
+(link:https://issues.redhat.com/browse/SPIRE-190[SPIRE-190])
+
+Fixed ConfigMap Reconciliation for SPIRE Controller Manager::
++
+* Before this update, Spire-controller manager ConfigMap reconciliation failed due to an unhandled edge case in the previous implementation. As a consequence, users experienced configuration inconsistencies. With this release, the Spire-controller manager ConfigMap reconciliation issue has been resolved. As a result, end users now experience seamless Spire-controller manager configuration.
++
+(link:https://issues.redhat.com/browse/SPIRE-195[SPIRE-195])
+
+OIDC discovery provider now restarts automatically on configuration changes::
++
+* Before this update, the SPIRE OIDC discovery provider failed to automatically restart following `configmap` changes, leading to persistent authentication failures. With this release, updates to the CR now trigger an automatic pod restart, ensuring that `configmap` changes are applied immediately.
++
+(link:https://issues.redhat.com/browse/SPIRE-225[SPIRE-225])
+
+Corrected update rollback for DaemonSets, Deployments, and StatefulSets::
++
+* Before this update, `daemonset`, `deployment`, and `statefulsets` were not properly reverted to their original form in all valid scenarios due to an oversight in the update logic. As a consequence, user data loss or inconsistency occurred in valid scenarios. With this release, the update logic has been corrected, ensuring all valid scenarios revert to their original form.
++
+(link:https://issues.redhat.com/browse/SPIRE-248[SPIRE-248])
+
+* Other bug fixes included:
+
+** Fixed issues related to continuous reconciliation and unnecessary updates.
+
+** Eliminated requeue logic for user input validation errors.

--- a/modules/zero-trust-manager-release-notes-1-0-1.adoc
+++ b/modules/zero-trust-manager-release-notes-1-0-1.adoc
@@ -1,0 +1,32 @@
+// Module included in the following assemblies:
+//
+// * security/zero_trust_workload_identity_manager/zero-trust-manager-install.adoc
+:_mod-docs-content-type: REFERENCE
+[id="zero-trust-manager-release-notes-1-0-1_{context}"]
+= Zero Trust Workload Identity Manager 1.0.1
+
+Issued: 17 May 2026
+
+[role="_abstract"]
+This release fixes some Common Vulnerabilities and Exposures (CVEs).
+
+The following advisories are available for the {zero-trust-full}:
+
+* https://access.redhat.com/errata/RHBA-2026:17483[RHBA-2026:17483]
+* https://access.redhat.com/errata/RHSA-2026:17463[RHSA-2026:17463]
+* https://access.redhat.com/errata/RHSA-2026:17462[RHSA-2026:17462]
+* https://access.redhat.com/errata/RHSA-2026:17461[RHSA-2026:17461]
+* https://access.redhat.com/errata/RHSA-2026:17460[RHSA-2026:17460]
+* https://access.redhat.com/errata/RHSA-2026:17457[RHSA-2026:17457]
+* https://access.redhat.com/errata/RHSA-2026:17456[RHSA-2026:17456]
+
+[is="zero-trust-manager-1-0-1-cves_{context}"]
+== CVEs
+
+* https://access.redhat.com/security/cve/cve-2026-21441[CVE-2026-21441]
+
+* https://access.redhat.com/security/cve/cve-2025-61726[CVE-2025-61726]
+
+* https://access.redhat.com/security/cve/cve-2025-61729[CVE-2025-61729]
+
+* https://access.redhat.com/security/cve/cve-2025-68121[CVE-2025-68121]

--- a/security/zero_trust_workload_identity_manager/zero-trust-manager-release-notes.adoc
+++ b/security/zero_trust_workload_identity_manager/zero-trust-manager-release-notes.adoc
@@ -1,7 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="zero-trust-manager-release-notes"]
 = Zero Trust Workload Identity Manager release notes
-
 include::_attributes/common-attributes.adoc[]
 :context: zero-trust-manager-release-notes
 
@@ -12,14 +11,16 @@ The {zero-trust-full} leverages Secure Production Identity Framework for Everyon
 
 These release notes track the development of {zero-trust-full}.
 
-// ztwim GA 1.0.0 RNs
-include::modules/zero-trust-manager-ga-1-0-0-rns.adoc[leveloffset=+1]
+// RNs 1.0.1
+include::modules/zero-trust-manager-release-notes-1-0-1.adoc[leveloffset=+1]
 
-// ztwim TP 0.2.0 RNs
-include::modules/zero-trust-manager-tp-0-2-0-rns.adoc[leveloffset=+1]
+// RNs 1.0.0
+include::modules/zero-trust-manager-release-notes-1-0-0.adoc[leveloffset=+1]
 
-// ztwim TP 0.1.0 RNs
-include::modules/zero-trust-manager-tp-0-1-0-rns.adoc[leveloffset=+1]
+// RNs 0.2.0
+include::modules/zero-trust-manager-release-notes-0-2-0.adoc[leveloffset=+1]
 
+// RNs 0.1.0
+include::modules/zero-trust-manager-release-notes-0-1-0.adoc[leveloffset=+1]
 
 


### PR DESCRIPTION
Version(s):
4.19+

Issue:
https://redhat.atlassian.net/browse/OSDOCS-19226

Link to docs preview:
https://110523--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/zero_trust_workload_identity_manager/zero-trust-manager-release-notes.html


QE review:
- [ ] QE has approved this change.


Additional information:


