### PR TITLE
OSDOCS#19207: Update the MicroShift zstream RNs for 4.21.11

### DIFF
--- a/microshift_release_notes/microshift-4-21-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-21-release-notes.adoc
@@ -23,6 +23,8 @@ include::modules/microshift-4-21-additional-release-notes.adoc[leveloffset=+1]
 
 include::modules/microshift-4-21-asynch-updates.adoc[leveloffset=+1]
 
+include::modules/microshift-4-21-11-async.adoc[leveloffset=+2]
+
 include::modules/microshift-4-21-7-async.adoc[leveloffset=+2]
 
 include::modules/microshift-4-21-0-async.adoc[leveloffset=+2]

--- a/modules/microshift-4-21-11-async.adoc
+++ b/modules/microshift-4-21-11-async.adoc
@@ -1,0 +1,33 @@
+// Module included in the following assemblies:
+//
+//microshift_release_notes/microshift-4-21-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="microshift-4-21-11-async_{context}"]
+= RHBA-2026:8932 - {microshift-short} 4.21.11 known issue update
+
+Issued: 21 April 2026
+
+[role="_abstract"]
+{product-title} release 4.21.11 is now available. Bug fixes and enhancements are listed in the link:https://access.redhat.com/errata/RHBA-2026:8932[RHBA-2026:8932] advisory. Release notes for bug fixes and enhancements are provided in this documentation. The images that are included in the update are provided by the {OCP} link:https://access.redhat.com/errata/RHBA-2026:8424[RHBA-2026:8424] advisory.
+
+See the latest images included with {microshift-short} by using the following instructions:
+
+* xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[Listing the contents of the {microshift-short} RPM release package]
+* xref:../microshift_install_bootc/microshift-install-bootc-image.adoc#microshift-install-bootc-get-published-image_microshift-install-publish-bootc-image[Getting the published bootc image for {microshift-short}]
+
+[id="microshift-4-21-11-known-issues_{context}"]
+== Known issues
+
+* If pods fail to start due to missing sigstore signatures for images in the `registry.redhat.io` domain name, add the following affected images to your exception list to prevent CI failures.
+
+ ** registry.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9
+
+ ** registry.redhat.io/cert-manager/cert-manager-istio-csr-rhel9
+
+ ** registry.redhat.io/cert-manager/cert-manager-operator-rhel9
+
+ ** registry.redhat.io/cert-manager/jetstack-cert-manager-rhel9
+
+For the implementation, see this example: https://github.com/openshift/microshift/pull/6381/files. (link:https://issues.redhat.com/browse/OCPBUGS-81681[OCPBUGS-81681])
+

--- a/modules/zstream-4-21-11.adoc
+++ b/modules/zstream-4-21-11.adoc
@@ -1,0 +1,33 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-21-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-21-10_{context}"]
+= RHSA-2026:7245 - {product-title} {product-version}.10 fixed issues and security update
+
+Issued: 14 April 2026
+
+[role="_abstract"]
+{product-title} release {product-version}.10 is now available. The list of fixed issues that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2026:7245[RHSA-2026:7245] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2026:7240[RHBA-2026:7240] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.21.10 --pullspecs
+----
+
+[id="zstream-4-21-10-fixed-issues_{context}"]
+== Fixed issues
+
+* Before this update, navigating from a dynamic plugin's tab on one resource detail page to another plugin tab on a different detail page caused the web console to display an error and become unresponsive. This affected plugins that added horizontal navigation tabs to resource detail pages, such as virtual machines, PersistentVolumeClaims, or storage classes. With this update, the web console correctly loads plugin tab components during navigation. As a result, navigation between dynamic plugin tabs on different resource detail pages works as expected.(link:https://redhat.atlassian.net/browse/OCPBUGS-77246[OCPBUGS-77246])
+
+* Before this update, when a new node joined a cluster, the synchronization process was delayed because the system only checked for updates periodically. As a consequence, the synchronization is delayed for up to 15 minutes. With this update, the `global-pull-secret-syncer` tool is triggered the moment the cluster's management layer identifies the new node. As a result, the synchronization process begins as soon as the node is ready, significantly reducing the wait time. (link:https://redhat.atlassian.net/browse/OCPBUGS-77966[OCPBUGS-77966])
+
+[id="zstream-4-21-10-updating_{context}"]
+== Updating
+
+To update an {product-title} 4.21 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].


### PR DESCRIPTION
Version(s):
4.21

Issue:
[OSDOCS-19207](https://redhat.atlassian.net/browse/OSDOCS-19207)

Link to docs preview:
[4.21.11](https://110528--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-21-release-notes.html#microshift-4-21-11-async_release-notes)

QE review:
- [ ] QE has approved this change.
N/A

Additional information:
 - Shipment [MR](https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/472)
 - ART [Dashboard](https://art-dash.engineering.redhat.com/dashboard/release/openshift-4.21)
