### PR TITLE
OCPBUGS-74539: Replace ambiguous <user> with kni in libvirt group step

### DIFF
--- a/modules/ipi-install-preparing-the-provisioner-node-for-openshift-install.adoc
+++ b/modules/ipi-install-preparing-the-provisioner-node-for-openshift-install.adoc
@@ -81,8 +81,13 @@ $ sudo dnf install -y libvirt qemu-kvm mkisofs python3-devel jq ipmitool
 +
 [source,terminal]
 ----
-$ sudo usermod --append --groups libvirt <user>
+$ sudo usermod --append --groups libvirt kni
 ----
++
+[NOTE]
+====
+You must log out and log back in for the group membership changes to take effect.
+====
 
 . Restart `firewalld` and enable the `http` service:
 +


### PR DESCRIPTION
## Summary
- Replaces the undefined `<user>` placeholder with `kni` in the `usermod --append --groups libvirt` command for baremetal IPI provisioner setup
- The doc already establishes `kni` as the provisioner user (`su - kni` on the same page), so this aligns the instruction with the existing context
- Adds a NOTE about logging out and back in for group membership changes to take effect

## Bug
https://redhat.atlassian.net/browse/OCPBUGS-74539

## Test plan
- [ ] Verify the rendered docs page shows `kni` instead of `<user>` in the libvirt group step
- [ ] Verify the NOTE block renders correctly below the command