### PR TITLE
[enterprise-4.22] Vale fixes for managing VMs sections 9.6 through 9.8

### DIFF
--- a/modules/virt-about-services.adoc
+++ b/modules/virt-about-services.adoc
@@ -10,22 +10,22 @@
 [role="_abstract"]
 A Kubernetes service exposes network access for clients to an application running on a set of pods. Services offer abstraction, load balancing, and, in the case of the `NodePort` and `LoadBalancer` types, exposure to the outside world.
 
-ClusterIP:: Exposes the service on an internal IP address and as a DNS name to other applications within the cluster. A single service can map to multiple virtual machines. When a client tries to connect to the service, the client's request is load balanced among available backends. `ClusterIP` is the default service type.
+`ClusterIP`:: Exposes the service on an internal IP address and as a DNS name to other applications within the cluster. A single service can map to multiple virtual machines. When a client tries to connect to the service, the client's request is load balanced among available backends. `ClusterIP` is the default service type.
 
-NodePort:: Exposes the service on the same port of each selected node in the cluster. `NodePort` makes a port accessible from outside the cluster, as long as the node itself is externally accessible to the client.
+`NodePort`:: Exposes the service on the same port of each selected node in the cluster. `NodePort` makes a port accessible from outside the cluster, provided that the node itself is externally accessible to the client.
 
-LoadBalancer:: Creates an external load balancer in the current cloud (if supported) and assigns a fixed, external IP address to the service.
+`LoadBalancer`:: Creates an external load balancer in the current cloud (if supported) and assigns a fixed, external IP address to the service.
 
 ifndef::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
 [NOTE]
 ====
-For on-premise clusters, you can configure a load-balancing service by deploying the MetalLB Operator.
+For on-premise clusters, you can configure a load balancing service by deploying the MetalLB Operator.
 ====
 endif::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
 
 ifdef::openshift-rosa,openshift-rosa-hcp[]
 [NOTE]
 ====
-For {product-rosa}, you must use `externalTrafficPolicy: Cluster` when configuring a load-balancing service, to minimize the network downtime during live migration.
+For {product-rosa}, you must use `externalTrafficPolicy: Cluster` when configuring a load balancing service, to minimize the network downtime during live migration.
 ====
 endif::openshift-rosa,openshift-rosa-hcp[]

--- a/modules/virt-change-vm-instance-type.adoc
+++ b/modules/virt-change-vm-instance-type.adoc
@@ -25,7 +25,7 @@ You can change the instance type associated with a running virtual machine (VM) 
 
 . Edit the instance type by using the *Series* and *Size* lists.
 .. Select an item from the *Series* list to show the relevant sizes for that series. For example, select *General Purpose*.
-.. Select the VM's new instance type from the *Size* list. For example, select *medium: 1 CPUs, 4Gi Memory*, which is available in the *General Purpose* series.
+.. Select the new instance type for the VM from the *Size* list. For example, select *medium: 1 CPUs, 4Gi Memory*, which is available in the *General Purpose* series.
 
 . Click *Save*.
 

--- a/modules/virt-configure-multiple-iothreads.adoc
+++ b/modules/virt-configure-multiple-iothreads.adoc
@@ -4,14 +4,14 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="virt-configure-multiple-iothreads_{context}"]
-= Configuring multiple IOThreads for fast storage access
+= Configuring multiple I/O threads for fast storage access
 
 [role="_abstract"]
-You can improve storage performance by configuring multiple IOThreads for a virtual machine (VM) that uses fast storage, such as solid-state drive (SSD) or non-volatile memory express (NVMe). This configuration option is only available by editing YAML of the VM.
+You can improve storage performance by configuring multiple I/O threads for a virtual machine (VM) that uses fast storage, such as solid-state drive (SSD) or non-volatile memory express (NVMe). This configuration option is only available by editing YAML of the VM.
 
 [NOTE]
 ====
-Multiple IOThreads are supported only when `blockMultiQueue` is enabled and the disk bus is set to `virtio`. You must set this configuration for the configuration to work correctly.
+Multiple I/O threads are supported only when `blockMultiQueue` is enabled and the disk bus is set to `virtio`. You must set this configuration for the configuration to work correctly.
 ====
 
 .Procedure

--- a/modules/virt-connecting-service-ssh.adoc
+++ b/modules/virt-connecting-service-ssh.adoc
@@ -8,7 +8,7 @@
 = Connecting to a VM exposed by a service by using SSH
 
 [role="_abstract"]
-You can connect to a virtual machine (VM) that is exposed by a service by using SSH.
+You can connect to a virtual machine (VM) that a service exposes by using SSH.
 
 .Prerequisites
 

--- a/modules/virt-create-custom-console-tabs.adoc
+++ b/modules/virt-create-custom-console-tabs.adoc
@@ -17,7 +17,7 @@ As a cluster administrator, you can customize the {product-title} web console by
 
 .Procedure
 
-* Add the `kubevirt.tab/horizontalNav` extension to the `plugin-extensions.ts` file of the KubeVirt plugin:
+* Add the `kubevirt.tab/horizontalNav` extension to the `plugin-extensions.ts` file of the `KubeVirt` plugin:
 +
 [source,typescript]
 ----
@@ -54,7 +54,7 @@ const isKubevirtTabVisible = ({
 export default isKubevirtTabVisible;
 ----
 +
-This parameter is provided by the KubeVirt plugin, and is `true` if the referenced object has been already created. This flag ensures that the plugin author can prevent the custom tab from being displayed on certain pages, such as the *Create Virtual Machine* page.
+The `KubeVirt` plugin provides this parameter, and it is `true` if the referenced object has been already created. This flag ensures that the plugin author can prevent the custom tab from being displayed on certain pages, such as the *Create Virtual Machine* page.
 
 .Verification
 

--- a/modules/virt-creating-service-cli.adoc
+++ b/modules/virt-creating-service-cli.adoc
@@ -37,7 +37,7 @@ spec:
 +
 [NOTE]
 ====
-Labels on a virtual machine are passed through to the pod. The `special: key` label must match the label in the `spec.selector` attribute of the `Service` manifest.
+Labels on a virtual machine pass through to the pod. The `special: key` label must match the label in the `spec.selector` attribute of the `Service` manifest.
 ====
 
 . Save the `VirtualMachine` manifest file to apply your changes.
@@ -65,7 +65,7 @@ spec:
 +
 * `spec.selector` defines the label that you added to the `spec.template.metadata.labels` stanza of the `VirtualMachine` manifest.
 * `spec.type` defines the type of service by the way it is exposed. Choose one of `ClusterIP`, `NodePort`, or `LoadBalancer`.
-* `spec.ports` defines a collection of network ports and protocols that you want to expose from the virtual machine.
+* `spec.ports` defines a collection of network ports and protocols to expose from the virtual machine.
 
 . Save the `Service` manifest file.
 . Create the service by running the following command:

--- a/modules/virt-enable-bulk-operations-web-console.adoc
+++ b/modules/virt-enable-bulk-operations-web-console.adoc
@@ -7,9 +7,9 @@
 = Enable bulk operations for virtual machines
 
 [role="_abstract"]
-You can enable virtual machine (VM) owners to perform large-scale management tasks, such as backups and storage migrations, across multiple virtual machines simultaneously, by creating a dynamic plugin that enables bulk actions in the web console.
+You can enable virtual machine (VM) owners to perform large-scale management tasks, such as backups and storage migrations, across many virtual machines simultaneously, by creating a dynamic plugin that enables bulk actions in the web console.
 
-This integration reduces manual overhead for multi-VM environments and ensures that custom actions are available as native, selectable bulk actions from within the *Virtualization* page.
+This integration reduces manual tasks for multi-VM environments and ensures that custom actions are available as native, selectable bulk actions from within the *Virtualization* page.
 
 .Prerequisites
 
@@ -37,7 +37,7 @@ Example `console-extensions.json` file excerpt:
    },
  }
 ----
-** `properties.contextId` specifies a string for which the KubeVirt plugin declares support.
+** `properties.contextId` specifies a string for which the `KubeVirt` plugin declares support.
 ** `properties.provider` specifies the React hook or function in your source code that generates the action items.
 
 . In the source file referenced by the extension, implement a hook that handles the array of selected resources.

--- a/modules/virt-hot-plugging-cpu.adoc
+++ b/modules/virt-hot-plugging-cpu.adoc
@@ -16,7 +16,7 @@ You can increase or decrease the number of CPU sockets allocated to a virtual ma
 . Select the required VM to open the *VirtualMachine details* page.
 . On the *Configuration* tab, click *Edit CPU|Memory*.
 . Select the *vCPU* radio button.
-. Enter the desired number of vCPU sockets and click *Save*.
+. Enter the required number of vCPU sockets and click *Save*.
 +
 [NOTE]
 ====
@@ -31,5 +31,5 @@ If a VM has the `spec.template.spec.domain.devices.networkInterfaceMultiQueue` f
 
 * Existing network interfaces that you attach before the CPU hot plug retain their original queue count, even after you add more virtual CPUs (vCPUs). The underlying virtualization technology causes this expected behavior.  
 * To update the queue count of existing interfaces to match the new vCPU configuration, you can restart the VM. A restart is only necessary if the update improves performance.  
-* New VirtIO network interfaces that you hot plugged after the CPU hotplug automatically receive a queue count that matches the updated vCPU configuration.
+* New VirtIO network interfaces that you hot plugged after the CPU hot plug automatically receive a queue count that matches the updated vCPU configuration.
 ====


### PR DESCRIPTION
DOCPLAN#36

Vale fixes for managing VMs sections 9.6 through 9.8
Cherry-picked from: da96eed54f70b61ee0e1e324891fedc8276d4216
Original merge: https://github.com/openshift/openshift-docs/pull/110349/changes

Version(s):
4.22

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
https://redhat.atlassian.net/browse/DOCPLAN-36

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
