### PR TITLE
[enterprise-4.20] Vale fixes for managing VMs sections 9.6 through 9.8

### DIFF
--- a/modules/virt-about-services.adoc
+++ b/modules/virt-about-services.adoc
@@ -10,22 +10,22 @@
 [role="_abstract"]
 A Kubernetes service exposes network access for clients to an application running on a set of pods. Services offer abstraction, load balancing, and, in the case of the `NodePort` and `LoadBalancer` types, exposure to the outside world.
 
-ClusterIP:: Exposes the service on an internal IP address and as a DNS name to other applications within the cluster. A single service can map to multiple virtual machines. When a client tries to connect to the service, the client's request is load balanced among available backends. `ClusterIP` is the default service type.
+`ClusterIP`:: Exposes the service on an internal IP address and as a DNS name to other applications within the cluster. A single service can map to multiple virtual machines. When a client tries to connect to the service, the client's request is load balanced among available backends. `ClusterIP` is the default service type.
 
-NodePort:: Exposes the service on the same port of each selected node in the cluster. `NodePort` makes a port accessible from outside the cluster, as long as the node itself is externally accessible to the client.
+`NodePort`:: Exposes the service on the same port of each selected node in the cluster. `NodePort` makes a port accessible from outside the cluster, provided that the node itself is externally accessible to the client.
 
-LoadBalancer:: Creates an external load balancer in the current cloud (if supported) and assigns a fixed, external IP address to the service.
+`LoadBalancer`:: Creates an external load balancer in the current cloud (if supported) and assigns a fixed, external IP address to the service.
 
 ifndef::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
 [NOTE]
 ====
-For on-premise clusters, you can configure a load-balancing service by deploying the MetalLB Operator.
+For on-premise clusters, you can configure a load balancing service by deploying the MetalLB Operator.
 ====
 endif::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
 
 ifdef::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
 [NOTE]
 ====
-For {product-rosa}, you must use `externalTrafficPolicy: Cluster` when configuring a load-balancing service, to minimize the network downtime during live migration.
+For {product-rosa}, you must use `externalTrafficPolicy: Cluster` when configuring a load balancing service, to minimize the network downtime during live migration.
 ====
 endif::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]

--- a/modules/virt-change-vm-instance-type.adoc
+++ b/modules/virt-change-vm-instance-type.adoc
@@ -25,7 +25,7 @@ You can change the instance type associated with a running virtual machine (VM) 
 
 . Edit the instance type by using the *Series* and *Size* lists.
 .. Select an item from the *Series* list to show the relevant sizes for that series. For example, select *General Purpose*.
-.. Select the VM's new instance type from the *Size* list. For example, select *medium: 1 CPUs, 4Gi Memory*, which is available in the *General Purpose* series.
+.. Select the new instance type for the VM from the *Size* list. For example, select *medium: 1 CPUs, 4Gi Memory*, which is available in the *General Purpose* series.
 
 . Click *Save*.
 

--- a/modules/virt-configure-multiple-iothreads.adoc
+++ b/modules/virt-configure-multiple-iothreads.adoc
@@ -4,14 +4,14 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="virt-configure-multiple-iothreads_{context}"]
-= Configuring multiple IOThreads for fast storage access
+= Configuring multiple I/O threads for fast storage access
 
 [role="_abstract"]
-You can improve storage performance by configuring multiple IOThreads for a virtual machine (VM) that uses fast storage, such as solid-state drive (SSD) or non-volatile memory express (NVMe). This configuration option is only available by editing YAML of the VM.
+You can improve storage performance by configuring multiple I/O threads for a virtual machine (VM) that uses fast storage, such as solid-state drive (SSD) or non-volatile memory express (NVMe). This configuration option is only available by editing YAML of the VM.
 
 [NOTE]
 ====
-Multiple IOThreads are supported only when `blockMultiQueue` is enabled and the disk bus is set to `virtio`. You must set this configuration for the configuration to work correctly.
+Multiple I/O threads are supported only when `blockMultiQueue` is enabled and the disk bus is set to `virtio`. You must set this configuration for the configuration to work correctly.
 ====
 
 .Procedure

--- a/modules/virt-connecting-service-ssh.adoc
+++ b/modules/virt-connecting-service-ssh.adoc
@@ -8,7 +8,7 @@
 = Connecting to a VM exposed by a service by using SSH
 
 [role="_abstract"]
-You can connect to a virtual machine (VM) that is exposed by a service by using SSH.
+You can connect to a virtual machine (VM) that a service exposes by using SSH.
 
 .Prerequisites
 

--- a/modules/virt-creating-service-cli.adoc
+++ b/modules/virt-creating-service-cli.adoc
@@ -37,7 +37,7 @@ spec:
 +
 [NOTE]
 ====
-Labels on a virtual machine are passed through to the pod. The `special: key` label must match the label in the `spec.selector` attribute of the `Service` manifest.
+Labels on a virtual machine pass through to the pod. The `special: key` label must match the label in the `spec.selector` attribute of the `Service` manifest.
 ====
 
 . Save the `VirtualMachine` manifest file to apply your changes.
@@ -65,7 +65,7 @@ spec:
 +
 * `spec.selector` defines the label that you added to the `spec.template.metadata.labels` stanza of the `VirtualMachine` manifest.
 * `spec.type` defines the type of service by the way it is exposed. Choose one of `ClusterIP`, `NodePort`, or `LoadBalancer`.
-* `spec.ports` defines a collection of network ports and protocols that you want to expose from the virtual machine.
+* `spec.ports` defines a collection of network ports and protocols to expose from the virtual machine.
 
 . Save the `Service` manifest file.
 . Create the service by running the following command:

--- a/modules/virt-hot-plugging-cpu.adoc
+++ b/modules/virt-hot-plugging-cpu.adoc
@@ -16,7 +16,7 @@ You can increase or decrease the number of CPU sockets allocated to a virtual ma
 . Select the required VM to open the *VirtualMachine details* page.
 . On the *Configuration* tab, click *Edit CPU|Memory*.
 . Select the *vCPU* radio button.
-. Enter the desired number of vCPU sockets and click *Save*.
+. Enter the required number of vCPU sockets and click *Save*.
 +
 [NOTE]
 ====
@@ -31,5 +31,5 @@ If a VM has the `spec.template.spec.domain.devices.networkInterfaceMultiQueue` f
 
 * Existing network interfaces that you attach before the CPU hot plug retain their original queue count, even after you add more virtual CPUs (vCPUs). The underlying virtualization technology causes this expected behavior.  
 * To update the queue count of existing interfaces to match the new vCPU configuration, you can restart the VM. A restart is only necessary if the update improves performance.  
-* New VirtIO network interfaces that you hot plugged after the CPU hotplug automatically receive a queue count that matches the updated vCPU configuration.
+* New VirtIO network interfaces that you hot plugged after the CPU hot plug automatically receive a queue count that matches the updated vCPU configuration.
 ====


### PR DESCRIPTION
DOCPLAN#36

Vale fixes for managing VMs sections 9.6 through 9.8
Cherry-picked from: https://github.com/openshift/openshift-docs/commit/da96eed54f70b61ee0e1e324891fedc8276d4216
Original merge: https://github.com/openshift/openshift-docs/pull/110349/changes

Version(s):
4.20

Issue:
https://redhat.atlassian.net/browse/DOCPLAN-36

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
