### PR TITLE
OSDOCS-17038: Agent install CQA

### DIFF
--- a/installing/installing_with_agent_based_installer/installing-with-agent-based-installer.adoc
+++ b/installing/installing_with_agent_based_installer/installing-with-agent-based-installer.adoc
@@ -6,63 +6,60 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-Use the following procedures to install an {product-title} cluster with customizations using the Agent-based Installer.
+[role="_abstract"]
+You can install an {product-title} cluster using the Agent-based Installer, with customizations to meet your deployment needs.
 
-[id="prerequisites_{context}"]
-== Prerequisites
+The following procedures deploy a single-node {product-title} cluster in a disconnected environment. You can use these procedures as a basis and modify according to your requirements.
 
-* You reviewed details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
-* You read the documentation on xref:../../installing/overview/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].
-* If you use a firewall or proxy, you xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configured it to allow the sites] that your cluster requires access to.
-
-[id="installing-ocp-agent_{context}"]
-== Installing {product-title} with the Agent-based Installer
-
-The following procedures deploy a single-node {product-title} in a disconnected environment. You can use these procedures as a basis and modify according to your requirements.
-
-// Downloading the Agent-based Installer
-include::modules/installing-ocp-agent-download.adoc[leveloffset=+2]
-
-// Verifying the supported architecture for an Agent-based installation
-include::modules/agent-installer-architectures.adoc[leveloffset=+2]
-
-// Creating the preferred configuration inputs
-include::modules/installing-ocp-agent-inputs.adoc[leveloffset=+2]
+include::modules/installing-ocp-agent-prereqs.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources
+
+* xref:../../architecture/architecture-installation.adoc#architecture-installation[Installation and update]
+* xref:../../installing/overview/installing-preparing.adoc#installing-preparing[Selecting a cluster installation method and preparing it for users]
+* xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[Configuring your firewall]
+
+// Downloading the Agent-based Installer
+include::modules/installing-ocp-agent-download.adoc[leveloffset=+1]
+
+// Verifying the supported architecture for an Agent-based installation
+include::modules/agent-installer-architectures.adoc[leveloffset=+1]
+
+// Creating the preferred configuration inputs
+include::modules/installing-ocp-agent-inputs.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+* xref:../../installing/installing_bare_metal/ipi/ipi-install-installation-workflow.adoc#modifying-install-config-for-dual-stack-network_ipi-install-installation-workflow[Deploying with dual-stack networking]
+* xref:../../installing/installing_bare_metal/ipi/ipi-install-installation-workflow.adoc#configuring-the-install-config-file_ipi-install-installation-workflow[Configuring the install-config yaml file]
+* xref:../../installing/installing_bare_metal/upi/installing-restricted-networks-bare-metal.adoc#installation-three-node-cluster_installing-restricted-networks-bare-metal[Configuring a three-node cluster]
+* xref:../../installing/installing_with_agent_based_installer/preparing-to-install-with-agent-based-installer.adoc#root-device-hints_preparing-to-install-with-agent-based-installer[About root device hints]
+* link:https://nmstate.io/examples.html[NMState state examples (NMState documentation)]
 * xref:../../installing/installing_vsphere/ipi/installing-vsphere-installer-provisioned-customizations.adoc#configuring-vsphere-regions-zones_installing-vsphere-installer-provisioned-customizations[Configuring regions and zones for a VMware vCenter]
 * xref:../../installing/installing_with_agent_based_installer/installing-with-agent-based-installer.adoc#agent-install-verifying-architectures_installing-with-agent-based-installer[Verifying the supported architecture for installing an Agent-based installer cluster]
 * xref:../../installing/installing_with_agent_based_installer/understanding-disconnected-installation-mirroring.adoc#agent-install-configuring-for-disconnected-registry_understanding-disconnected-installation-mirroring[Configuring the Agent-based Installer to use mirrored images]
 
-[id="installing-ocp-agent-opt-manifests_{context}"]
-=== Creating additional manifest files
-
-As an optional task, you can create additional manifests to further configure your cluster beyond the configurations available in the `install-config.yaml` and `agent-config.yaml` files.
-
-[IMPORTANT]
-====
-Customizations to the cluster made by additional manifests are not validated, are not guaranteed to work, and might result in a nonfunctional cluster.
-====
+include::modules/installing-ocp-agent-additional-manifests.adoc[leveloffset=+1]
 
 // Creating a directory to contain additional manifests
-include::modules/installing-ocp-agent-manifest-folder.adoc[leveloffset=+3]
+include::modules/installing-ocp-agent-manifest-folder.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
 .Additional resources
 * xref:../../machine_configuration/machine-configs-configure.adoc#machine-configs-configure[Using MachineConfig objects to configure nodes]
 
 // Disk partitioning
-include::modules/installation-user-infra-machines-advanced-disk.adoc[leveloffset=+3]
+include::modules/installation-user-infra-machines-advanced-disk.adoc[leveloffset=+2]
 
 // Using ZTP manifests
 include::modules/installing-ocp-agent-ZTP.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
 .Additional resources
-* xref:../../installing/installing_with_agent_based_installer/installing-with-agent-based-installer.adoc#sample-ztp-custom-resources_installing-with-agent-based-installer[Sample {ztp} custom resources].
+* xref:../../installing/installing_with_agent_based_installer/installing-with-agent-based-installer.adoc#sample-ztp-custom-resources_installing-with-agent-based-installer[Sample {ztp} custom resources]
 
-* See xref:../../edge_computing/ztp-deploying-far-edge-clusters-at-scale.adoc#ztp-deploying-far-edge-clusters-at-scale[Challenges of the network far edge] to learn more about {ztp-first}.
+* xref:../../edge_computing/ztp-deploying-far-edge-clusters-at-scale.adoc#ztp-deploying-far-edge-clusters-at-scale[Challenges of the network far edge]
 
 // Encrypting the disk
 include::modules/installing-ocp-agent-encrypt.adoc[leveloffset=+2]
@@ -73,34 +70,26 @@ include::modules/installing-ocp-agent-encrypt.adoc[leveloffset=+2]
 * xref:../../installing/install_config/installing-customizing.adoc#installation-special-config-encrypt-disk_installing-customizing[About disk encryption]
 
 // Creating and booting the agent image
-include::modules/installing-ocp-agent-boot.adoc[leveloffset=+2]
+include::modules/installing-ocp-agent-boot.adoc[leveloffset=+1]
 
 // Adding {ibm-z-name} agents with {op-system-base} KVM
-include::modules/installing-ocp-agent-ibm-z-kvm.adoc[leveloffset=+2]
+include::modules/installing-ocp-agent-ibm-z-kvm.adoc[leveloffset=+1]
 
 // Configuring a local arbiter node
-include::modules/installing-ocp-agent-local-arbiter-node.adoc[leveloffset=+2]
+include::modules/installing-ocp-agent-local-arbiter-node.adoc[leveloffset=+1]
 
 // Verifying that the current installation host can pull release images
-include::modules/installing-ocp-agent-tui.adoc[leveloffset=+2]
+include::modules/installing-ocp-agent-tui.adoc[leveloffset=+1]
 
 // Tracking and verifying installation progress
-include::modules/installing-ocp-agent-verify.adoc[leveloffset=+2]
-
-[role="_additional-resources"]
-.Additional resources
-* See xref:../../installing/installing_bare_metal/ipi/ipi-install-installation-workflow.adoc#modifying-install-config-for-dual-stack-network_ipi-install-installation-workflow[Deploying with dual-stack networking].
-* See xref:../../installing/installing_bare_metal/ipi/ipi-install-installation-workflow.adoc#configuring-the-install-config-file_ipi-install-installation-workflow[Configuring the install-config yaml file].
-* See xref:../../installing/installing_bare_metal/upi/installing-restricted-networks-bare-metal.adoc#installation-three-node-cluster_installing-restricted-networks-bare-metal[Configuring a three-node cluster] to deploy three-node clusters in bare-metal environments.
-* See xref:../../installing/installing_with_agent_based_installer/preparing-to-install-with-agent-based-installer.adoc#root-device-hints_preparing-to-install-with-agent-based-installer[About root device hints].
-* See link:https://nmstate.io/examples.html[NMState state examples].
+include::modules/installing-ocp-agent-verify.adoc[leveloffset=+1]
 
 include::modules/sample-ztp-custom-resources.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources
 
-* See xref:../../edge_computing/ztp-deploying-far-edge-clusters-at-scale.adoc#ztp-deploying-far-edge-clusters-at-scale[Challenges of the network far edge] to learn more about {ztp-first}.
+* xref:../../edge_computing/ztp-deploying-far-edge-clusters-at-scale.adoc#ztp-deploying-far-edge-clusters-at-scale[Challenges of the network far edge]
 
 // Gathering log data from a failed Agent-based installation
 include::modules/installing-ocp-agent-gather-log.adoc[leveloffset=+1]

--- a/modules/agent-installer-architectures.adoc
+++ b/modules/agent-installer-architectures.adoc
@@ -6,7 +6,8 @@
 [id="agent-install-verifying-architectures_{context}"]
 = Verifying the supported architecture for an Agent-based installation
 
-Before installing an {product-title} cluster using the Agent-based Installer, you can verify the supported architecture on which you can install the cluster. This procedure is optional.
+[role="_abstract"]
+Before installing an {product-title} cluster using the Agent-based Installer, you can optionally verify the supported architecture on which you can install the cluster.
 
 .Prerequisites
 
@@ -39,9 +40,10 @@ If you are using the release image with the `multi` payload, the `release archit
 [source,terminal]
 +
 ----
-$ oc adm release info <release_image> -o jsonpath="{ .metadata.metadata}" <1>
+$ oc adm release info <release_image> -o jsonpath="{ .metadata.metadata}"
 ----
-<1> Replace `<release_image>` with the release image. For example: `quay.io/openshift-release-dev/ocp-release@sha256:123abc456def789ghi012jkl345mno678pqr901stu234vwx567yz0`.
++
+Replace `<release_image>` with the release image. For example: `quay.io/openshift-release-dev/ocp-release@sha256:123abc456def789ghi012jkl345mno678pqr901stu234vwx567yz0`.
 +
 .Example output when the release image uses the `multi` payload
 [source,terminal]

--- a/modules/installation-user-infra-machines-advanced-disk.adoc
+++ b/modules/installation-user-infra-machines-advanced-disk.adoc
@@ -13,10 +13,11 @@ ifeval::["{context}" == "installing-restricted-networks-bare-metal"]
 endif::[]
 
 :_mod-docs-content-type: PROCEDURE
+ifndef::agent[]
 [id="installation-user-infra-machines-advanced-disk_{context}"]
 = Disk partitioning
 
-ifndef::agent[]
+
 [role="_abstract"]
 During {op-system-first} installation, {product-title} applies a default partition layout that automatically expands the root file system to fill available space. By understanding this default configuration, you can override partitioning settings to customize the layout for specific node architecture requirements.
 
@@ -42,6 +43,9 @@ If you have resized your disk size to host a larger file system, consider creati
 ====
 endif::agent[]
 ifdef::agent[]
+[id="installation-user-infra-machines-advanced-disk_{context}"]
+= Creating disk partitions
+
 [role="_abstract"]
 To accommodate directories expected to grow, create separate partitions during the {op-system} installation. This configuration overrides the default partitioning layout, ensuring specific storage requirements are met for dynamic data.
 endif::agent[]

--- a/modules/installing-ocp-agent-ZTP.adoc
+++ b/modules/installing-ocp-agent-ZTP.adoc
@@ -6,7 +6,10 @@
 [id="installing-ocp-agent-ztp_{context}"]
 = Using ZTP manifests
 
+[role="_abstract"]
 As an optional task, you can use {ztp-first} manifests to configure your installation beyond the options available through the `install-config.yaml` and `agent-config.yaml` files.
+
+See "Challenges of the network far edge" to learn more about {ztp-first}.
 
 [NOTE]
 ====

--- a/modules/installing-ocp-agent-additional-manifests.adoc
+++ b/modules/installing-ocp-agent-additional-manifests.adoc
@@ -1,0 +1,11 @@
+:_mod-docs-content-type: CONCEPT
+[id="installing-ocp-agent-opt-manifests_{context}"]
+= Creating additional manifest files
+
+[role="_abstract"]
+As an optional task, you can create additional manifests to further configure your cluster beyond the configurations available in the `install-config.yaml` and `agent-config.yaml` files.
+
+[IMPORTANT]
+====
+Customizations to the cluster made by additional manifests are not validated, are not guaranteed to work, and might result in a nonfunctional cluster.
+====

--- a/modules/installing-ocp-agent-boot.adoc
+++ b/modules/installing-ocp-agent-boot.adoc
@@ -7,7 +7,8 @@
 [id="installing-ocp-agent-boot_{context}"]
 = Creating and booting the agent image
 
-Use this procedure to boot the agent image on your machines.
+[role="_abstract"]
+After you have prepared the configuration inputs for your installation, create the ISO image and boot it on your machines.
 
 .Prerequisites
 
@@ -22,7 +23,10 @@ Use this procedure to boot the agent image on your machines.
 $ openshift-install --dir <install_directory> agent create image
 ----
 +
-NOTE: Red Hat Enterprise Linux CoreOS (RHCOS) supports multipathing on the primary disk, allowing stronger resilience to hardware failure to achieve higher host availability. Multipathing is enabled by default in the agent ISO image, with a default `/etc/multipath.conf` configuration.
+[NOTE]
+====
+{op-system-first} supports multipathing on the primary disk, allowing stronger resilience to hardware failure to achieve higher host availability. Multipathing is enabled by default in the agent ISO image, with a default `/etc/multipath.conf` configuration.
+====
 
 . If you plan to boot the ISO image from a USB drive, add a master boot record to the image by running the following command:
 +

--- a/modules/installing-ocp-agent-download.adoc
+++ b/modules/installing-ocp-agent-download.adoc
@@ -9,7 +9,8 @@
 [id="installing-ocp-agent-retrieve_{context}"]
 = Downloading the Agent-based Installer
 
-Use this procedure to download the Agent-based Installer and the CLI needed for your installation.
+[role="_abstract"]
+Begin the installation process by downloading the Agent-based Installer and the CLI needed for your installation.
 
 .Procedure
 

--- a/modules/installing-ocp-agent-encrypt.adoc
+++ b/modules/installing-ocp-agent-encrypt.adoc
@@ -6,7 +6,8 @@
 [id="installing-ocp-agent-encrypt_{context}"]
 = Encrypting the disk
 
-As an optional task, you can use this procedure to encrypt your disk or partition while installing {product-title} with the Agent-based Installer.
+[role="_abstract"]
+As an optional task, you can encrypt your disk or partition while installing {product-title} with the Agent-based Installer.
 
 [IMPORTANT]
 ====
@@ -53,10 +54,13 @@ $ cd <installation_directory>/cluster-manifests
 [source,yaml]
 ----
 diskEncryption:
-    enableOn: all <1>
-    mode: tang <2>
-    tangServers: "server1": "http://tang-server-1.example.com:7500" <3>
+    enableOn: all
+    mode: tang
+    tangServers: "server1": "http://tang-server-1.example.com:7500"
 ----
-<1> Specify which nodes to enable disk encryption on. Valid values are `none`, `all`, `masters`, and `workers`.
-<2> Specify which disk encryption mode to use. Valid values are `tpmv2` and `tang`.
-<3> Optional: If you are using Tang, specify the Tang servers.
++
+where:
+
+`diskEncryption.enableOn`:: Specifies which nodes to enable disk encryption on. Valid values are `none`, `all`, `masters`, and `workers`.
+`diskEncryption.mode`:: Specifies which disk encryption mode to use. Valid values are `tpmv2` and `tang`.
+`diskEncryption.tangServers`:: Specifies the Tang servers if you are using Tang. This value is optional.

--- a/modules/installing-ocp-agent-gather-log.adoc
+++ b/modules/installing-ocp-agent-gather-log.adoc
@@ -7,7 +7,8 @@
 [id="installing-ocp-agent-gather-log_{context}"]
 = Gathering log data from a failed Agent-based installation
 
-Use the following procedure to gather log data about a failed Agent-based installation to provide for a support case.
+[role="_abstract"]
+If you encounter a failed Agent-based installation, you can gather log data to provide for a support case.
 
 .Prerequisites
 

--- a/modules/installing-ocp-agent-ibm-z-kvm.adoc
+++ b/modules/installing-ocp-agent-ibm-z-kvm.adoc
@@ -11,12 +11,16 @@ endif::[]
 [id="installing-ocp-agent-ibm-z-kvm_{context}"]
 = Adding {ibm-z-title} agents with {op-system-base} KVM
 
-Use the following procedure to manually add {ibm-z-name} agents with {op-system-base} KVM.
+[role="_abstract"]
+You can manually add {ibm-z-name} agents with {op-system-base} KVM.
+
 Only use this procedure for {ibm-z-name} clusters with {op-system-base} KVM.
+
 [NOTE]
 ====
 The `nmstateconfig` parameter must be configured for the KVM boot.
 ====
+
 .Procedure
 
 . Boot your {op-system-base} KVM machine.
@@ -33,7 +37,7 @@ $ virt-install \
    --ram=16384 \
    --cpu host \
    --vcpus=8 \
-   --location <path_to_kernel_initrd_image>,kernel=kernel.img,initrd=initrd.img \// <1>
+   --location <path_to_kernel_initrd_image>,kernel=kernel.img,initrd=initrd.img \
    --disk <qcow_image_path> \
    --network network:macvtap ,mac=<mac_address> \
    --graphics none \
@@ -48,7 +52,8 @@ $ virt-install \
    --extra-args "coreos.inst.persistent-kargs=console=tty1 console=ttyS1,115200n8" \
    --osinfo detect=on,require=off
 ----
-<1> For the `--location` parameter, specify the location of the `kernel` and `initrd` files. The location can be a local server path or a URL using HTTP or HTTPS.
++
+For the `--location` parameter, specify the location of the `kernel` and `initrd` files. The location can be a local server path or a URL using HTTP or HTTPS.
 
 endif::pxe-boot[]
 
@@ -63,7 +68,7 @@ $ virt-install
     --memory=<memory> \
     --cpu host \
     --vcpus=<vcpus> \
-    --cdrom \<path_to_image>/<agent_iso_image> \ <1>
+    --cdrom \<path_to_image>/<agent_iso_image> \
     --disk pool=default,size=<disk_pool_size> \
     --network network:default,mac=<mac_address> \
     --graphics none \
@@ -71,7 +76,8 @@ $ virt-install
     --os-variant rhel9.0 \
     --wait=-1
 ----
-<1> For the `--cdrom` parameter, specify the location of the ISO image on the local server, for example, `<path_to_image>/home/<image>.iso`.
++
+For the `--cdrom` parameter, specify the location of the ISO image on the local server, for example, `<path_to_image>/home/<image>.iso`.
 +
 [NOTE]
 ====
@@ -93,7 +99,7 @@ $ virt-install \
    --ram=16384 \
    --cpu host \
    --vcpus=8 \
-   --location <path_to_kernel_initrd_image>,kernel=kernel.img,initrd=initrd.img \// <1>
+   --location <path_to_kernel_initrd_image>,kernel=kernel.img,initrd=initrd.img \
    --disk <qcow_image_path> \
    --network network:macvtap ,mac=<mac_address> \
    --graphics none \
@@ -106,21 +112,20 @@ $ virt-install \
    --extra-args "ignition.firstboot ignition.platform.id=metal" \
    --extra-args "console=tty1 console=ttyS1,115200n8" \
    --extra-args "coreos.inst.persistent-kargs=console=tty1 console=ttyS1,115200n8" \
-   --extra-args "fips=1" \// <2>
+   --extra-args "fips=1" \
    --osinfo detect=on,require=off
 ----
 +
-[NOTE]
-====
-For KVM-based installations using DASD devices on {ibm-z-title}, a partition (for example, `/dev/dasdb1`) must be created using the `fdasd` partitioning tool.
-====
-+
-<1> For the `--location` parameter, specify the location of the kernel/initrd on the HTTP or HTTPS server.
-<2> To enable FIPS mode, specify `fips=1`. This entry is required in addition to setting the `fips` parameter to `true` in the `install-config.yaml` file.
+where:
+
+`--location`:: Specifies the location of the kernel/initrd on the HTTP or HTTPS server.
+`--extra-args "fips=1"`:: Specifies the enablement of FIPS mode. This entry is required in addition to setting the `fips` parameter to `true` in the `install-config.yaml` file.
 +
 [NOTE]
 ====
-Currently, only PXE boot is supported to enable FIPS mode on {ibm-z-name}.
+* For KVM-based installations using DASD devices on {ibm-z-title}, a partition (for example, `/dev/dasdb1`) must be created using the `fdasd` partitioning tool.
+
+* Currently, only PXE boot is supported to enable FIPS mode on {ibm-z-name}.
 ====
 
 ifeval::["{context}" == "prepare-pxe-assets-agent"]

--- a/modules/installing-ocp-agent-inputs.adoc
+++ b/modules/installing-ocp-agent-inputs.adoc
@@ -16,8 +16,9 @@ endif::[]
 [id="installing-ocp-agent-inputs_{context}"]
 = Creating the preferred configuration inputs
 
+[role="_abstract"]
 ifndef::pxe-boot[]
-Use this procedure to create the preferred configuration inputs used to create the agent image.
+Create the preferred configuration inputs used to create the agent image.
 
 [NOTE]
 ====
@@ -25,7 +26,7 @@ Configuring the `install-config.yaml` and `agent-config.yaml` files is the prefe
 ====
 endif::pxe-boot[]
 ifdef::pxe-boot[]
-Use this procedure to create the preferred configuration inputs used to create the PXE files.
+Create the preferred configuration inputs used to create the PXE files.
 
 [NOTE]
 ====
@@ -60,7 +61,7 @@ $ cat << EOF > ./<directory_name>/install-config.yaml
 apiVersion: v1
 baseDomain: test.example.com
 compute:
-- architecture: amd64 // <1>
+- architecture: amd64
   hyperthreading: Enabled
   name: worker
   replicas: 0
@@ -70,25 +71,25 @@ controlPlane:
   name: master
   replicas: 1
 metadata:
-  name: sno-cluster // <2>
+  name: sno-cluster
 networking:
   clusterNetwork:
   - cidr: 10.128.0.0/14
     hostPrefix: 23
   machineNetwork:
   - cidr: 192.168.0.0/16
-  networkType: OVNKubernetes // <3>
+  networkType: OVNKubernetes
   serviceNetwork:
   - 172.30.0.0/16
-platform: <4>
+platform:
   none: {}
-pullSecret: '<pull_secret>' // <5>
-sshKey: '<ssh_pub_key>' // <6>
-additionalTrustBundle: | // <7>
+pullSecret: '<pull_secret>'
+sshKey: '<ssh_pub_key>'
+additionalTrustBundle: |
   -----BEGIN CERTIFICATE-----
   ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ
   -----END CERTIFICATE-----
-imageContentSources: // <8>
+imageContentSources:
 - mirrors:
   - <local_registry>/<local_repository_name>/release
   source: quay.io/openshift-release-dev/ocp-release
@@ -97,41 +98,18 @@ imageContentSources: // <8>
   source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
 EOF
 ----
-<1> Specify the system architecture. Valid values are `amd64`, `arm64`, `ppc64le`, and `s390x`.
+
+where:
+
+`compute.architecture`:: Specifies the system architecture. Valid values are `amd64`, `arm64`, `ppc64le`, and `s390x`.
 +
 If you are using the release image with the `multi` payload, you can install the cluster on different architectures such as `arm64`, `amd64`, `s390x`, and `ppc64le`. Otherwise, you can install the cluster only on the `release architecture` displayed in the output of the `openshift-install version` command. For more information, see "Verifying the supported architecture for installing an Agent-based Installer cluster".
-<2> Required. Specify your cluster name.
-<3> The cluster network plugin to install. The default value `OVNKubernetes` is the only supported value.
-<4> Specify your platform.
-+
-[NOTE]
-====
-For bare-metal platforms, host settings made in the platform section of the `install-config.yaml` file are used by default, unless they are overridden by configurations made in the `agent-config.yaml` file.
-====
-<5> Specify your pull secret.
-<6> Specify your SSH public key.
-<7> Provide the contents of the certificate file that you used for your mirror registry.
-The certificate file can be an existing, trusted certificate authority or the self-signed certificate that you generated for the mirror registry.
-You must specify this parameter if you are using a disconnected mirror registry.
-<8> Provide the `imageContentSources` section according to the output of the command that you used to mirror the repository.
-You must specify this parameter if you are using a disconnected mirror registry.
-+
-[IMPORTANT]
-====
-* When using the `oc adm release mirror` command, use the output from the `imageContentSources` section.
-* When using the `oc mirror` command, use the `repositoryDigestMirrors` section of the `ImageContentSourcePolicy` file that results from running the command.
-* The `ImageContentSourcePolicy` resource is deprecated.
-====
---
-+
-[NOTE]
-====
-If you set the platform to `vSphere`, `baremetal`, or `none`, you can configure IP address endpoints for cluster nodes in three ways:
 
-* IPv4
-* IPv6
-* IPv4 and IPv6 in parallel (dual-stack)
-====
+`metadata.name`:: Specifies your cluster name. This value is required.
+
+`networking.networkingType`:: Specifies the cluster network plugin to install. The default value `OVNKubernetes` is the only supported value.
+
+`platform`:: Specifies your platform. If you set the platform to `vSphere`, `baremetal`, or `none`, you can configure IP address endpoints for cluster nodes in three ways: IPv4, IPv6, or IPv4 and IPv6 in parallel (dual-stack).
 +
 .Example of dual-stack networking
 [source,yaml]
@@ -161,8 +139,27 @@ platform:
 +
 [NOTE]
 ====
-When you use a disconnected mirror registry, you must add the certificate file that you created previously for your mirror registry to the `additionalTrustBundle` field of the `install-config.yaml` file.
+For bare-metal platforms, host settings made in the platform section of the `install-config.yaml` file are used by default, unless they are overridden by configurations made in the `agent-config.yaml` file.
 ====
+
+`pullSecret`:: Specifies your pull secret.
+
+`sshKey`:: Specifies your SSH public key.
+
+`additionalTrustBundle`:: Specifies the contents of the certificate file that you used for your mirror registry.
+The certificate file can be an existing, trusted certificate authority or the self-signed certificate that you generated for the mirror registry.
+You must specify this parameter if you are using a disconnected mirror registry.
+
+`imageContentSources`:: Specifies the `imageContentSources` section according to the output of the command that you used to mirror the repository.
+You must specify this parameter if you are using a disconnected mirror registry.
++
+[IMPORTANT]
+====
+* When using the `oc adm release mirror` command, use the output from the `imageContentSources` section.
+* When using the `oc mirror` command, use the `repositoryDigestMirrors` section of the `ImageContentSourcePolicy` file that results from running the command.
+* The `ImageContentSourcePolicy` resource is deprecated.
+====
+--
 
 . Create the `agent-config.yaml` file by running the following command:
 +
@@ -174,15 +171,15 @@ apiVersion: v1beta1
 kind: AgentConfig
 metadata:
   name: sno-cluster
-rendezvousIP: 192.168.111.80 // <1>
-hosts: // <2>
-  - hostname: master-0 // <3>
+rendezvousIP: 192.168.111.80
+hosts:
+  - hostname: master-0
     interfaces:
       - name: eno1
         macAddress: 00:ef:44:21:e6:a5
-    rootDeviceHints: // <4>
+    rootDeviceHints:
       deviceName: /dev/sdb
-    networkConfig: // <5>
+    networkConfig:
       interfaces:
         - name: eno1
           type: ethernet
@@ -204,23 +201,29 @@ hosts: // <2>
             next-hop-address: 192.168.111.2
             next-hop-interface: eno1
             table-id: 254
-ifdef::iscsi-boot[minimalISO: true  <6>]
+ifdef::iscsi-boot[minimalISO: true]
 EOF
 ----
-<1> This IP address is used to determine which node performs the bootstrapping process as well as running the `assisted-service` component.
+
+where:
+
+`rendezvousIP`:: Specifies the IP address used to determine which node performs the bootstrapping process as well as running the `assisted-service` component.
 You must provide the rendezvous IP address when you do not specify at least one host's IP address in the `networkConfig` parameter. If this address is not provided, one IP address is selected from the provided hosts' `networkConfig`.
-<2> Optional: Host configuration. The number of hosts defined must not exceed the total number of hosts defined in the `install-config.yaml` file, which is the sum of the values of the `compute.replicas` and `controlPlane.replicas` parameters.
-<3> Optional: Overrides the hostname obtained from either the Dynamic Host Configuration Protocol (DHCP) or a reverse DNS lookup. Each host must have a unique hostname supplied by one of these methods.
-<4> Enables provisioning of the {op-system-first} image to a particular device. The installation program examines the devices in the order it discovers them, and compares the discovered values with the hint values. It uses the first discovered device that matches the hint value.
+
+`hosts`:: Specifies host configuration. The number of hosts defined must not exceed the total number of hosts defined in the `install-config.yaml` file, which is the sum of the values of the `compute.replicas` and `controlPlane.replicas` parameters. This configuration is optional.
+
+`hosts.hostname`:: Specifies a value that overrides the hostname obtained from either the Dynamic Host Configuration Protocol (DHCP) or a reverse DNS lookup. Each host must have a unique hostname supplied by one of these methods. This configuration is optional.
+
+`hosts.rootDeviceHints`:: Specifies a configuration that enables provisioning of the {op-system-first} image to a particular device. The installation program examines the devices in the order it discovers them, and compares the discovered values with the hint values. It uses the first discovered device that matches the hint value.
 +
 [NOTE]
 ====
 This parameter is mandatory for FCP multipath configurations on {ibm-z-title}.
 ====
-+
-<5> Optional: Configures the network interface of a host in NMState format.
+
+`hosts.networkConfig`:: Specifies the network interface configuration of a host in NMState format. This configuration is optional.
 ifdef::iscsi-boot[]
-<6> Generates an ISO image without the rootfs image file, and instead provides details about where to pull the rootfs file from.
+`minimalISO`:: Specifies whether to generate an ISO image without the rootfs image file, instead providing details about where to pull the rootfs file from.
 You must set this parameter to `true` to enable iSCSI booting.
 endif::iscsi-boot[]
 --

--- a/modules/installing-ocp-agent-manifest-folder.adoc
+++ b/modules/installing-ocp-agent-manifest-folder.adoc
@@ -6,6 +6,7 @@
 [id="installing-ocp-agent-manifest-folder_{context}"]
 = Creating a directory to contain additional manifests
 
+[role="_abstract"]
 If you create additional manifests to configure your Agent-based installation beyond the `install-config.yaml` and `agent-config.yaml` files, you must create an `openshift` subdirectory within your installation directory.
 All of your additional machine configurations must be located within this subdirectory.
 

--- a/modules/installing-ocp-agent-prereqs.adoc
+++ b/modules/installing-ocp-agent-prereqs.adoc
@@ -1,0 +1,11 @@
+
+:_mod-docs-content-type: REFERENCE
+[id="prerequisites_{context}"]
+= Prerequisites for installing a cluster with the Agent-based Installer
+
+[role="_abstract"]
+Before beginning your cluster installation, you must complete prerequisite tasks that prepare your environment.
+
+* You reviewed details about the {product-title} installation and update processes. For more information, see "Installation and update".
+* You read "Selecting a cluster installation method and preparing it for users".
+* If you use a firewall or proxy, you configured it to allow the sites that your cluster requires access to. For more information, see "Configuring your firewall".

--- a/modules/installing-ocp-agent-tui.adoc
+++ b/modules/installing-ocp-agent-tui.adoc
@@ -7,6 +7,7 @@
 [id="installing-ocp-agent-tui_{context}"]
 = Verifying that the current installation host can pull release images
 
+[role="_abstract"]
 After you boot the agent image and network services are made available to the host, the agent console application performs a pull check to verify that the current host can retrieve release images.
 
 If the primary pull check passes, you can quit the application to continue with the installation. If the pull check fails, the application performs additional checks, as seen in the `Additional checks` section of the TUI, to help you troubleshoot the problem. A failure for any of the additional checks is not necessarily critical as long as the primary pull check succeeds.

--- a/modules/installing-ocp-agent-verify.adoc
+++ b/modules/installing-ocp-agent-verify.adoc
@@ -11,7 +11,8 @@ endif::[]
 [id="installing-ocp-agent-verify_{context}"]
 = Tracking and verifying installation progress
 
-Use the following procedure to track installation progress and to verify a successful installation.
+[role=_abstract]
+After the installation has started, you can track installation progress and verify a successful installation.
 
 .Prerequisites
 
@@ -20,16 +21,20 @@ Use the following procedure to track installation progress and to verify a succe
 .Procedure
 
 . Optional: To know when the bootstrap host (rendezvous host) reboots, run the following command:
-
 +
+--
 [source,terminal]
 ----
-$ ./openshift-install --dir <install_directory> agent wait-for bootstrap-complete \// <1>
-    --log-level=info <2>
+$ ./openshift-install --dir <install_directory> agent wait-for bootstrap-complete \
+    --log-level=info
 ----
-<1> For `<install_directory>`, specify the path to the directory where the agent ISO was generated.
-<2> To view different installation details, specify `warn`, `debug`, or `error` instead of `info`.
 
+where:
+
+`--dir`:: specifies the path to the directory where the agent ISO was generated.
+
+`--log-level`:: Specifies the level of installation details. Valid values are `info`, `warn`, `debug`, and `error`.
+--
 +
 .Example output
 [source,terminal]
@@ -42,14 +47,14 @@ INFO cluster bootstrap is complete
 +
 The command succeeds when the Kubernetes API server signals that it has been bootstrapped on the control plane machines.
 
-. To track the progress and verify successful installation, run the following command:
+. Track the progress and verify successful installation by running the following command:
 +
 [source,terminal]
 ----
 $ openshift-install --dir <install_directory> agent wait-for install-complete <1>
 ----
-<1> For `<install_directory>` directory, specify the path to the directory where the agent ISO was generated.
-
++
+Replace `<install_directory>` with the path to the directory where the agent ISO was generated.
 +
 .Example output
 [source,terminal]
@@ -63,9 +68,8 @@ INFO     export KUBECONFIG=/home/core/installer/auth/kubeconfig
 INFO Access the OpenShift web-console here: https://console-openshift-console.apps.sno-cluster.test.example.com
 ----
 
-
-// Note for a later doc effort - now that there is a section for ztp manifests, maybe this NOTE can be moved to that section?
 ifndef::basic[]
++
 [NOTE]
 ====
 If you are using the optional method of {ztp} manifests, you can configure IP address endpoints for cluster nodes through the `AgentClusterInstall.yaml` file in three ways:
@@ -76,6 +80,7 @@ If you are using the optional method of {ztp} manifests, you can configure IP ad
 
 IPv6 is supported only on bare metal platforms.
 ====
++
 .Example of dual-stack networking
 [source,yaml,subs="attributes+"]
 ----

--- a/modules/sample-ztp-custom-resources.adoc
+++ b/modules/sample-ztp-custom-resources.adoc
@@ -6,6 +6,7 @@
 [id="sample-ztp-custom-resources_{context}"]
 = Sample {ztp} custom resources
 
+[role="_abstract"]
 You can optionally use {ztp-first} custom resource (CR) objects to install an {product-title} cluster with the Agent-based Installer.
 
 You can customize the following {ztp} custom resources to specify more details about your {product-title} cluster. The following sample {ztp} custom resources are for a single-node cluster.


### PR DESCRIPTION
[OSDOCS-17038](https://redhat.atlassian.net/browse/OSDOCS-17038)

Version(s): 4.20+

QE review: No technical changes imo, let me know if you disagree.

Previews:

- [Installing a cluster with customizations](https://110558--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_with_agent_based_installer/installing-with-agent-based-installer) (everything but two node arbiter section is affected)
- [Disk partitioning](https://110558--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/upi/installing-bare-metal-network-customizations.html#installation-user-infra-machines-advanced-disk_installing-bare-metal-network-customizations) (in a non-Agent context, should be unchanged)
- [Adding IBM Z agents with RHEL KVM](https://110558--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_with_agent_based_installer/prepare-pxe-assets-agent#installing-ocp-agent-ibm-z-kvm_prepare-pxe-assets-agent)(PXE boot page)
- [Creating the preferred configuration inputs](https://110558--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_with_agent_based_installer/prepare-pxe-assets-agent#installing-ocp-agent-inputs_prepare-pxe-assets-agent) (PXE boot page)
- [Creating the preferred configuration inputs](https://110558--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_with_agent_based_installer/installing-using-iscsi#installing-ocp-agent-inputs_installing-using-iscsi) (iSCSI boot page)
