### PR TITLE
OSDOCS#19222: Add since and sincetime fields to MustGather CR

### DIFF
--- a/modules/support-log-gather-config-params.adoc
+++ b/modules/support-log-gather-config-params.adoc
@@ -27,6 +27,14 @@ The following table provides an overview of the parameters that you can configur
 |Optional: Overrides the default command of the container. The Operator passes this value to the `command` field of the container.
 |List of strings
 
+|`spec.gatherSpec.since`
+|Optional: Specifies a time duration to restrict log collection to entries newer than the specified duration. By default, the controller collects all available logs. You can specify either `spec.gatherSpec.since` or `spec.gatherSpec.sinceTime`, but not both.
+|The value must be a number with a time unit. The valid units are `s` (seconds), `m` (minutes), or `h` (hours).
+
+|`spec.gatherSpec.sinceTime`
+|Optional: Specifies a timestamp to restrict log collection to entries newer than the specified timestamp. By default, the controller collects all available logs. You can specify either `spec.gatherSpec.since` or `spec.gatherSpec.sinceTime`, but not both.
+|The value must be in link:https://www.rfc-editor.org/rfc/rfc3339[RFC3339] format.
+
 |`spec.imageStreamRef`
 a|Optional: Overrides the default image by defining a specific custom image.
 
@@ -46,23 +54,7 @@ Each `MustGather` CR supports only one custom image. To use multiple custom imag
 
 |`spec.mustGatherTimeout`
 |Optional: Specifies the time limit for the `must-gather` command to complete.
-|The value must be a floating-point number with a time unit. The valid units are `s` (seconds), `m` (minutes), or `h` (hours). By default, no time is limit set.
-
-|`spec.proxyConfig`
-|Optional: Defines the proxy configuration to be used. The default value is set to the cluster-level proxy configuration.
-|`Object`
-
-|`spec.proxyConfig.httpProxy`
-|Specifies the URL of the proxy for HTTP requests.
-|URL
-
-|`spec.proxyConfig.httpsProxy`
-|Specifies the URL of the proxy for HTTPS requests.
-|
-
-|`spec.proxyConfig.noProxy`
-|Specifies a comma-separated list of domains for which the proxy must not be used.
-|List of URLs
+|The value must be a number with a time unit. The valid units are `s` (seconds), `m` (minutes), or `h` (hours). By default, no time limit is set.
 
 |`spec.retainResourcesOnCompletion`
 |Optional: Specifies whether to retain the `must-gather` job and its related resources after the completion of data collection. The valid values are `true` and `false`. The default value is `false`.
@@ -105,10 +97,6 @@ Because the `default` service account has minimal permissions, you can specify t
 |Optional: Defines the upload location for the `must-gather` bundle.
 |`Object`
 
-|`spec.uploadTarget.host`
-|Optional: Specifies the destination server for the bundle upload. By default, the bundle is uploaded to `sftp.access.redhat.com`.
-|By default, the bundle is uploaded to `sftp.access.redhat.com`.
-
 |`spec.uploadTarget.sftp.caseID`
 |Specifies the Red{nbsp}Hat Support case ID for which the diagnostic data is collected.
 |`string`
@@ -120,6 +108,10 @@ Because the `default` service account has minimal permissions, you can specify t
 |`spec.uploadTarget.sftp.caseManagementAccountSecretRef.name`
 |Specifies the name of the Kubernetes secret that contains the credentials.
 |`string`
+
+|`spec.uploadTarget.sftp.host`
+|Optional: Specifies the destination server for the bundle upload. By default, the bundle is uploaded to `sftp.access.redhat.com`.
+|
 
 |`spec.uploadTarget.sftp.internalUser`
 |Optional: Specifies whether the user provided in the `caseManagementAccountSecretRef` is a Red{nbsp}Hat internal user. The valid values are `true` and `false`. The default value is `false`.

--- a/modules/support-log-gather-reduce-size.adoc
+++ b/modules/support-log-gather-reduce-size.adoc
@@ -1,0 +1,41 @@
+// Module included in the following assemblies:
+//
+// * troubleshooting/gathering-diagnostic-data.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="must-gather-operator-size-reduction-examples_{context}"]
+= Configurations for reducing the must-gather log size
+
+[role="_abstract"]
+Large `must-gather` logs can take a significant amount of time to upload to support cases and also consume considerable cluster storage. You can optimize the size of the collected diagnostic data by applying specific configurations to your `MustGather` custom resource (CR).
+
+The following examples demonstrate different methods for reducing the must-gather log size:
+
+*Skipping rotated logs*
+You can exclude older, rotated log files, such as `+*.gz+` or `+*.1+` files, from the collection by setting the shell variable `REDUCE_LOGS=skip_rotated_logs` before running the `gather` script.
+
+.Example `MustGather` CR configured to skip rotated logs
+[source,yaml]
+----
+apiVersion: operator.openshift.io/v1alpha1
+kind: MustGather
+metadata:
+  name: full-mustgather
+spec:
+  serviceAccountName: must-gather-operator
+  gatherSpec:
+    command:
+      - /bin/sh
+      - -c
+      - |
+        REDUCE_LOGS=skip_rotated_logs gather
+  uploadTarget:
+    type: SFTP
+    sftp:
+      caseID: '02527285'
+      caseManagementAccountSecretRef:
+        name: sftp-access-rh-creds
+      internalUser: true
+----
+
+`REDUCE_LOGS=skip_rotated_logs gather`:: Sets the `REDUCE_LOGS` shell variable and executes the `gather` script. As a result, the script excludes the collection of rotated log files.

--- a/modules/support-must-gather-targeted-collection-gathering-data.adoc
+++ b/modules/support-must-gather-targeted-collection-gathering-data.adoc
@@ -29,6 +29,13 @@ $ oc adm must-gather --dest-dir=my-project-must-gather -- oc adm inspect ns/my-p
 $ oc adm must-gather --dest-dir=apiserver-must-gather -- oc adm inspect clusteroperator/openshift-apiserver
 ----
 
+* To exclude rotated logs, such as `+*.gz+` or `+*.1+` files, from data collection, set the `REDUCE_LOGS` environment variable by running the following command:
++
+[source,terminal]
+----
+$ oc adm must-gather -- REDUCE_LOGS=skip_rotated_logs /usr/bin/gather
+----
+
 * To exclude logs entirely and significantly reduce the size of the `must-gather` archive, add a double dash (`--`) after `oc adm must-gather` command and add the `--no-logs` argument:
 +
 [source,terminal]

--- a/support/gathering-cluster-data.adoc
+++ b/support/gathering-cluster-data.adoc
@@ -100,6 +100,8 @@ include::modules/support-log-gather-install-cli.adoc[leveloffset=+2]
 //Support log gather configuration
 include::modules/support-log-gather-configure-cli.adoc[leveloffset=+2]
 
+include::modules/support-log-gather-reduce-size.adoc[leveloffset=+2]
+
 [role="_additional-resources"]
 .Additional resources
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.22+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://redhat.atlassian.net/browse/OSDOCS-19222
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:https://110571--ocpdocs-pr.netlify.app/openshift-enterprise/latest/support/gathering-cluster-data.html#support-log-gather-config-params_gathering-cluster-data

https://110571--ocpdocs-pr.netlify.app/openshift-enterprise/latest/support/gathering-cluster-data.html#must-gather-operator-size-reduction-examples_gathering-cluster-data
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
