### PR TITLE
OSDOCS-18618-errate-ref-fix: Fixed the wrong Errata reference

### DIFF
--- a/modules/zstream-4-20-15.adoc
+++ b/modules/zstream-4-20-15.adoc
@@ -9,7 +9,7 @@
 Issued: 25 February 2026
 
 [role="_abstract"]
-{product-title} release {product-version}.15 is now available. The list of fixed issues that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2026:2987[RHSA-2026-2987] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2026:2980[RHBA-2026:2980] advisory.
+{product-title} release {product-version}.15 is now available. The list of fixed issues that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2026:2987[RHBA-2026:2987] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2026:2980[RHBA-2026:2980] advisory.
 
 Space precluded documenting all of the container images for this release in the advisory.
 


### PR DESCRIPTION
Wrong Errata reference, should be https://access.redhat.com/errata/RHBA-2026:2987. 


Version(s):
4.20

Issue:
[OSDOCS-18618](https://issues.redhat.com/browse/OSDOCS-18618)

Link to docs preview:
[4.20.15](https://110576--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-20-release-notes.html#zstream-4-20-15_release-notes)

<img width="1041" height="780" alt="Screenshot From 2026-04-22 09-48-07" src="https://github.com/user-attachments/assets/6f8e32b7-a2a1-4e50-b656-7de2ff963986" />

github.com/openshift/openshift-docs/pull/108155
