### PR TITLE
ROX-33693: Doc updates for admission controller config and resource c…

### DIFF
--- a/cloud_service/acscs-default-requirements.adoc
+++ b/cloud_service/acscs-default-requirements.adoc
@@ -9,3 +9,9 @@ toc::[]
 include::modules/acs-cloud-requirements.adoc[leveloffset=+1]
 
 include::modules/default-requirements-secured-cluster-services.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../installing/installing_ocp/install-secured-cluster-config-options-ocp.adoc#admission-controller-settings_install-secured-cluster-config-options-ocp[Admission controller settings for the Operator]
+* xref:../installing/installing_ocp/install-secured-cluster-ocp.adoc#secured-cluster-services-config_install-secured-cluster-ocp[Configuration parameters for Helm]

--- a/installing/acs-default-requirements.adoc
+++ b/installing/acs-default-requirements.adoc
@@ -12,6 +12,12 @@ include::modules/default-requirements-central-services.adoc[leveloffset=+1]
 
 include::modules/default-requirements-secured-cluster-services.adoc[leveloffset=+1]
 
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../installing/installing_ocp/install-secured-cluster-config-options-ocp.adoc#admission-controller-settings_install-secured-cluster-config-options-ocp[Admission controller settings for the Operator]
+* xref:../installing/installing_ocp/install-secured-cluster-ocp.adoc#secured-cluster-services-config_install-secured-cluster-ocp[Configuration parameters for Helm]
+
 include::modules/default-requirements-external-db.adoc[leveloffset=+1]
 
 [role="_additional-resources"]

--- a/modules/default-requirements-secured-cluster-services.adoc
+++ b/modules/default-requirements-secured-cluster-services.adoc
@@ -61,6 +61,11 @@ By default, the admission control service runs 3 replicas. The following table l
 | 500 MiB
 |===
 
+[NOTE]
+====
+When admission controller policy enforcement is enabled, the memory limit is automatically increased to 1 GiB per replica to support image scan data caching requirements. If you specify a custom memory limit override, the custom value takes priority. For more information, see "Admission controller settings for the Operator" and "Configuration parameters for Helm".
+====
+
 [id="default-requirements-secured-cluster-services-collector_{context}"]
 == Collector
 

--- a/modules/disable-admission-controller-enforcement.adoc
+++ b/modules/disable-admission-controller-enforcement.adoc
@@ -24,8 +24,9 @@ helm upgrade -n stackrox \
 . For clusters that are not managed by the Operator or Helm, you can use the {product-title-short} portal to change this setting:
 .. In the {product-title-short} portal, select *Platform Configuration* -> *Clusters*.
 .. Select an existing cluster from the list.
-.. In the *Dynamic configuration* section, in the *Admission controller enforcement behavior* field, select one of the following options:
+.. In the *Static configuration* section, in the *Admission controller enforcement behavior* field, select one of the following options:
 * Enforce policies: The admission controller enforces policies that are configured for enforcement by rejecting the workload admission or update attempt.
 * No enforcement: Even if enforcement is configured for a policy, if this option is selected, the admission controller does not enforce the policy and allows workload admission attempts or updates that violate the policy.
 .. Select *Next*.
-.. Select *Finish*.
+.. Click *Download YAML File and Keys* to download the updated cluster bundle.
+.. Extract and run the `sensor` script from the cluster bundle to redeploy the configuration to the cluster.

--- a/modules/enable-admission-controller-enforcement-existing-cluster.adoc
+++ b/modules/enable-admission-controller-enforcement-existing-cluster.adoc
@@ -25,9 +25,15 @@ helm upgrade -n stackrox \
 . For clusters installed by another method, you can use the {product-title-short} portal to edit the enforcement option. You cannot edit Operator- or Helm-managed clusters by using the portal. Follow these steps:
 .. In the {product-title-short} portal, go to *Platform Configuration* -> *Clusters*.
 .. Select an existing cluster from the list.
-.. In the *Dynamic configuration* section, in the *Admission controller enforcement behavior* field, select *Enforce policies*. The admission controller enforces policies that are configured for enforcement by rejecting the workload admission or update attempt.
+.. In the *Static configuration* section, in the *Admission controller enforcement behavior* field, select *Enforce policies*. The admission controller enforces policies that are configured for enforcement by rejecting the workload admission or update attempt.
 .. Select *Next*.
-.. Select *Finish*. {product-title-short} automatically synchronizes the admission controller and applies the changes.
+.. Click *Download YAML File and Keys* to download the updated cluster bundle.
+.. Extract and run the `sensor` script from the cluster bundle to redeploy the configuration to the cluster.
++
+[NOTE]
+====
+When you enable admission controller policy enforcement, the admission controller memory limit is automatically increased to 1 GiB per replica to support image scan data caching requirements. If you specify a custom memory limit override, the custom value takes priority. For more information, see "Admission controller settings for the Operator" and "Configuration parameters for Helm".
+====
 
 .Verification
 * The `ValidatingWebhookConfiguration` Kubernetes resource contains information about enforcement configuration behavior. The configuration settings are available in the admission controller logs.

--- a/modules/enable-admission-controller-enforcement.adoc
+++ b/modules/enable-admission-controller-enforcement.adoc
@@ -12,9 +12,15 @@ You can enable admission controller enforcement when you install a cluster.
 . When installing a cluster by using the legacy installation method, follow these steps:
 .. In the {product-title-short} portal, select *Platform Configuration* -> *Clusters*.
 .. Click *Secure a cluster* -> *Legacy installation method*.
-.. In the *Dynamic configuration (syncs with Sensor)* section, in the *Admission controller enforcement behavior* field, select *Enforce policies*.
+.. In the *Static configuration* section, in the *Admission controller enforcement behavior* field, select *Enforce policies*.
 .. Select *Next*.
-.. Select *Finish*. {product-title-short} automatically synchronizes the admission controller and applies the changes.
+.. Click *Download YAML File and Keys* to download the updated cluster bundle.
+.. Extract and run the `sensor` script from the cluster bundle to deploy the configuration to the cluster.
++
+[NOTE]
+====
+When you enable admission controller policy enforcement, the admission controller memory limit is automatically increased to 1 GiB per replica to support image scan data caching requirements. If you specify a custom memory limit override, the custom value takes priority. For more information, see "Admission controller settings for the Operator" and "Configuration parameters for Helm".
+====
 
 .Verification
 * The `ValidatingWebhookConfiguration` Kubernetes resource contains information about enforcement configuration behavior. The configuration settings are available in the admission controller logs.

--- a/modules/policy-enforcement-hard.adoc
+++ b/modules/policy-enforcement-hard.adoc
@@ -16,4 +16,9 @@ Hard enforcement is performed by the {product-title-short} admission controller.
 Kubernetes admission webhooks support only `CREATE`, `UPDATE`, `DELETE`, and `CONNECT` operations. The {product-title-short} admission controller supports only `CREATE`, `UPDATE`, and `SCALE` operations. Operations such as `kubectl patch`, `kubectl set`, and `kubectl scale` are `PATCH` operations, not `UPDATE` operations. Because `PATCH` operations are not supported in Kubernetes, {product-title-short} cannot perform enforcement on PATCH operations. However, enforcement against `SCALE` operations is supported.
 ====
 
-For hard enforcement, enable the enforcement settings for the cluster in {product-title-short}. To verify that enforcement is enabled, in the *Dynamic configuration* section, in the *Admission controller enforcement behavior* field, ensure that *Enforce policies* is selected. Additionally, for each policy that you want to enforce, select *Inform and enforce* when configuring the policy.
+For hard enforcement, enable the enforcement settings for the cluster in {product-title-short}. To verify that enforcement is enabled, in the *Static configuration* section, in the *Admission controller enforcement behavior* field, ensure that *Enforce policies* is selected. Additionally, for each policy that you want to enforce, select *Inform and enforce* when configuring the policy.
+
+[NOTE]
+====
+Because admission controller enforcement is a static configuration option, changing this setting for clusters that are installed by using the manifest or `roxctl` method requires you to download the updated YAML bundle and redeploy it to the cluster.
+====

--- a/operating/manage_security_policies/use-admission-controller-enforcement.adoc
+++ b/operating/manage_security_policies/use-admission-controller-enforcement.adoc
@@ -18,8 +18,16 @@ include::modules/enable-admission-controller-enforcement.adoc[leveloffset=+1]
 
 * xref:../../installing/installing_ocp/install-secured-cluster-ocp.adoc#install-secured-cluster-ocp[Installing Secured Cluster services for RHACS on Red Hat OpenShift]
 * xref:../../installing/installing_other/install-secured-cluster-other.adoc#install-secured-cluster-other[Installing Secured Cluster services for RHACS on other platforms]
+* xref:../../installing/installing_ocp/install-secured-cluster-config-options-ocp.adoc#admission-controller-settings_install-secured-cluster-config-options-ocp[Admission controller settings for the Operator]
+* xref:../../installing/installing_ocp/install-secured-cluster-ocp.adoc#secured-cluster-services-config_install-secured-cluster-ocp[Configuration parameters for Helm]
 
 include::modules/enable-admission-controller-enforcement-existing-cluster.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../installing/installing_ocp/install-secured-cluster-config-options-ocp.adoc#admission-controller-settings_install-secured-cluster-config-options-ocp[Admission controller settings for the Operator]
+* xref:../../installing/installing_ocp/install-secured-cluster-ocp.adoc#secured-cluster-services-config_install-secured-cluster-ocp[Configuration parameters for Helm]
 
 include::modules/bypass-admission-controller-enforcement.adoc[leveloffset=+1]
 


### PR DESCRIPTION
Version(s): 4.11

Issue: https://redhat.atlassian.net/browse/ROX-33693

Link to docs preview:

https://110598--ocpdocs-pr.netlify.app/openshift-acs/latest/cloud_service/acscs-default-requirements.html
https://110598--ocpdocs-pr.netlify.app/openshift-acs/latest/installing/acs-default-requirements.html
https://110598--ocpdocs-pr.netlify.app/openshift-acs/latest/operating/manage_security_policies/about-security-policies.html
https://110598--ocpdocs-pr.netlify.app/openshift-acs/latest/operating/manage_security_policies/use-admission-controller-enforcement.html

QE review: **ACS has no QE, approved by SME**
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
