### PR TITLE
[gitops-docs-1.19] RHDEVDOCS-7099: CQA 2.0 fixes for Enabling high availability support for Argo Rollouts

### DIFF
--- a/argo_rollouts/enabling-ha-support-for-argo-rollouts.adoc
+++ b/argo_rollouts/enabling-ha-support-for-argo-rollouts.adoc
@@ -6,11 +6,12 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-Argo Rollouts support enabling high availability (HA) in the `RolloutManager` Custom Resource (CR). When you configure high availability in Argo Rollouts, the {gitops-title} Operator automatically sets the number of pods to 2 for the Argo Rollouts controller using the `.spec.ha` field in the `RolloutManager` CR. It also activates leader election, allowing the pods to run in an active-passive process. A single pod actively manages rollouts, while the other pod remains in a passive state, ensuring the additional replica provides redundancy and availability if a node fails.
+[role="_abstract"]
+Argo Rollouts supports enabling high availability (HA) in the `RolloutManager` Custom Resource (CR). When you configure high availability in Argo Rollouts, the {gitops-title} Operator automatically sets the number of pods to 2 for the Argo Rollouts controller using the `.spec.ha` field in the `RolloutManager` CR. It also activates leader election, allowing the pods to run in an active-passive process. A single pod actively manages rollouts, while the other pod remains in a passive state, ensuring the additional replica provides redundancy and availability if a node fails.
 
 This feature benefits the Rollouts controller by ensuring it runs without downtime or manual intervention. It also operates during planned maintenance, as the second replica ensures the controller runs smoothly. Enabling high availability in Argo Rollouts ensures the controller remains reliable and resilient, even during node failures or heavy workloads.
 
-The {gitops-title} Operator also ensures that anti-affinity rules apply by default. Although these rules are not user-defined, they ensure the controller pods distribute across different nodes to avoid a single point of failure, providing resilience against node failure.
+The {gitops-title} Operator also ensures that anti-affinity rules apply by default. These rules are not user-defined, they ensure the controller pods distribute across different nodes to avoid a single point of failure, providing resilience against node failure.
 
 .Prerequisites
 * You are logged in to the {OCP} cluster as an administrator.

--- a/modules/gitops-configuring-high-availability-for-argo-rollouts.adoc
+++ b/modules/gitops-configuring-high-availability-for-argo-rollouts.adoc
@@ -26,7 +26,7 @@ To enable high availability, configure the `ha` specification in the `RolloutMan
 *Example enabling the `ha` field in the `RolloutManager` CR:*
 [source,yaml]
 ----
-apiVersion: argoproj.io/v1alpha1
+apiVersion: argoproj.io/v1beta1
 kind: RolloutManager
 metadata:
   name: argo-rollouts
@@ -58,6 +58,7 @@ where:
 *Example Argo Rollouts deployment configuration file:*
 [source,yaml]
 ----
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: argo-rollouts
@@ -69,14 +70,14 @@ spec:
       app.kubernetes.io/name: argo-rollouts
   template:
     metadata:
-      creationTimestamp: null
       labels:
         app.kubernetes.io/name: argo-rollouts
     spec:
       containers:
+        - name: argo-rollouts
+          image: argoproj/argo-rollouts:latest
           args:
-            - '--leader-elect'
-            - 'true'
+            - --leader-elect=true
 ----
 --
 +
@@ -84,5 +85,5 @@ spec:
 where:
 
 `spec.replicas`:: Specifies the number of pods.
-`spec.template.spec.containers.args`:: Specifies that the `--leader-elect=true` flag is passed to the Rollouts deployment. Although this flag is set to `true` by default, explicitly setting it ensures that leader election remains consistently enforced.
+`spec.template.spec.containers.args`:: Specifies that the `--leader-elect=true` flag is passed to the Rollouts deployment. The `--leader-elect=true` flag enables leader election, allowing only one pod to actively manage rollouts while others remain in standby.
 --


### PR DESCRIPTION
This PR is a manual cherry-pick of https://github.com/openshift/openshift-docs/pull/109839/