### PR TITLE
OSDOCS#19207: Update the z-stream RNs for MicroShift 4.21.11

### DIFF
--- a/microshift_release_notes/microshift-4-21-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-21-release-notes.adoc
@@ -23,6 +23,8 @@ include::modules/microshift-4-21-additional-release-notes.adoc[leveloffset=+1]
 
 include::modules/microshift-4-21-asynch-updates.adoc[leveloffset=+1]
 
+include::modules/microshift-4-21-11-async.adoc[leveloffset=+2]
+
 include::modules/microshift-4-21-7-async.adoc[leveloffset=+2]
 
 include::modules/microshift-4-21-0-async.adoc[leveloffset=+2]

--- a/modules/microshift-4-21-11-async.adoc
+++ b/modules/microshift-4-21-11-async.adoc
@@ -1,0 +1,33 @@
+// Module included in the following assemblies:
+//
+//microshift_release_notes/microshift-4-21-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="microshift-4-21-11-async_{context}"]
+= RHBA-2026:8932 - {microshift-short} 4.21.11 known issue update
+
+Issued: 21 April 2026
+
+[role="_abstract"]
+{product-title} release 4.21.11 is now available. Known issues are listed in the link:https://access.redhat.com/errata/RHBA-2026:8932[RHBA-2026:8932] advisory. The images that are included in the update are provided by the {OCP} link:https://access.redhat.com/errata/RHBA-2026:8424[RHBA-2026:8424] advisory.
+
+See the latest images included with {microshift-short} by using the following instructions:
+
+* xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[Listing the contents of the {microshift-short} RPM release package]
+* xref:../microshift_install_bootc/microshift-install-bootc-image.adoc#microshift-install-bootc-get-published-image_microshift-install-publish-bootc-image[Getting the published bootc image for {microshift-short}]
+
+[id="microshift-4-21-11-known-issues_{context}"]
+== Known issues
+
+* If pods fail to start due to missing sigstore signatures for images in the `registry.redhat.io` domain name, add the following affected images to your exception list to prevent CI failures.
+
+ ** registry.redhat.io/cert-manager/jetstack-cert-manager-acmesolver-rhel9
+
+ ** registry.redhat.io/cert-manager/cert-manager-istio-csr-rhel9
+
+ ** registry.redhat.io/cert-manager/cert-manager-operator-rhel9
+
+** registry.redhat.io/cert-manager/jetstack-cert-manager-rhel9
+
+For the implementation, see this example: https://github.com/openshift/microshift/pull/6381/files. (link:https://issues.redhat.com/browse/OCPBUGS-81681[OCPBUGS-81681])
+


### PR DESCRIPTION
Version(s):
4.21

Issue:
[OSDOCS-19207](https://redhat.atlassian.net/browse/OSDOCS-19207)

Link to docs preview:
[4.21.11](https://110601--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-21-release-notes.html#microshift-4-21-11-async_release-notes)

QE review:
- [ ] QE has approved this change.
N/A for z-stream RNs

Additional information:

- Shipment [MR](https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/472)
- ART [Dashboard](https://art-dash.engineering.redhat.com/dashboard/release/openshift-4.21)
