### PR TITLE
OSDOCS-19231: adds tool revocation to MCP gateway docs

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -81,8 +81,10 @@ Topics:
   File: mcp-gateway-authentication
 - Name: Configuring authorization for the MCP gateway
   File: mcp-gateway-authorization
-- Name: Using credentials to access external APIs
-  File: mcp-gateway-vault
+- Name: Revoking MCP server tool access
+  File: mcp-gateway-revoke-tool-access
+#- Name: Using credentials to access external APIs
+#  File: mcp-gateway-vault
 ---
 Name: Observability and Troubleshooting
 Dir: observe_troubleshoot

--- a/mcp_gateway_config/mcp-gateway-revoke-tool-access.adoc
+++ b/mcp_gateway_config/mcp-gateway-revoke-tool-access.adoc
@@ -1,0 +1,14 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="mcp-gateway-revoke-mcp-server-tool-access"]
+= Revoking MCP server tool access
+include::_attributes/attributes.adoc[]
+:context: mcp-gateway-revoke-mcp-server-tool-access
+
+[role="_abstract"]
+You can revoke tool access for users and groups. Tool revocation prevents a user or group from calling specific MCP tools.
+
+include::modules/con-mcp-gateway-understand-tool-access-revocation.adoc[leveloffset=+1]
+
+include::modules/proc-mcp-gateway-revoking-tools-call-requests.adoc[leveloffset=+1]
+
+include::modules/proc-mcp-gateway-filter-revoked-tools-display.adoc[leveloffset=+1]

--- a/modules/con-mcp-gateway-understand-tool-access-revocation.adoc
+++ b/modules/con-mcp-gateway-understand-tool-access-revocation.adoc
@@ -1,0 +1,28 @@
+// Module included in the following assemblies:
+//
+// *mcp_gateway_config/mcp-gateway-revoke-tool-access.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="con-mcp-gateway-understand-tool-access-revocation_{context}"]
+= Understanding tool access revocation
+
+[role="_abstract"]
+Tool revocation uses the authorization setup where tool access is controlled by roles in identity provider JWT tokens. Revoking a tool means removing the corresponding role from a user or group, so their next token no longer grants access.
+
+[TIP]
+====
+You cannot revoke a specific in-flight token or revoke access instantly. JWT tokens govern access, and these tokens are valid until they expire. Revocation relies on the token expiring and being reissued with changed permissions. To force faster revocation, reduce the access-token lifespan in your identity provider.
+====
+
+The following two enforcement points apply:
+
+* `tools/call`: The `AuthPolicy` custom resource (CR) CEL expression checks the `x-mcp-toolname` header against the user's `resource_access` roles. A revoked tool returns a `failed to create session for mcp server: failed to create client: transport error: server returned 4xx for initialize POST, likely a legacy SSE server` error.
+* `tools/list`: The broker filters the tools list using the signed `x-authorized-tools` header. A revoked tool is no longer displayed in the list.
+
+The timing of tool revocation depends on the following session events:
+
+* New sessions: Users who authenticate after revocation receive a token without the revoked tool. They are denied immediately.
+
+* Existing sessions: Users with an active token keep access until the token expires. You configure token lifetime in your identity provider, for example, the **Access Token Lifespan** setting in {keycloak}. Shorter token lifetimes mean that tokens are refreshed more frequently, picking up role changes sooner. You must decide on the balance between revocation latency and token-refresh resource utilization.
+
+* In-flight requests: A `tools/call` request that is already being processed completes normally. The authorization check occurs before the request reaches the backend MCP server, so only new requests can be denied.

--- a/modules/proc-mcp-gateway-filter-revoked-tools-display.adoc
+++ b/modules/proc-mcp-gateway-filter-revoked-tools-display.adoc
@@ -1,0 +1,209 @@
+// Module included in the following assemblies:
+//
+// *mcp_gateway_config/mcp-gateway-revoke-tool-access.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="proc-mcp-gateway-filter-revoked-tools-display_{context}"]
+= Filtering revoked tools from tools/list display
+
+[role="_abstract"]
+After you revoke a tool by using your identity provider, `tools/call` requests are blocked. However, the revoked tool is still displayed in `tools/list` responses. To filter revoked tools from the displayed list, you must give the MCP broker component a signed header that carries the user's authorized tools.
+
+You can remove blocked tools from responses by configuring the Authorino Operator to generate the header by using a wristband JWT signed with an ECDSA key pair.
+
+.Prerequisites
+
+* You installed {mcpg}.
+* You configured a `Gateway` object with both `mcp` and `mcps` listeners.
+* You are logged into a running {ocp} cluster with an `admin` role.
+* You configured an `HTTPRoute` object for the gateway.
+* You registered an MCP server.
+* You configured authentication with an `AuthPolicy` CR on the `mcp` listener.
+* You configured authorization with a tool-level `AuthPolicy` CR on the `mcps` listener.
+
+.Procedure
+
+. Generate an ECDSA key pair by running the following commands:
+
+.. Generate the private key and save it to a file by running the following command:
++
+[source,terminal]
+----
+$ openssl ecparam -name prime256v1 -genkey -noout -out private-key.pem
+----
+
+.. Generate the public key and save it to a file by running the following command:
++
+[source,terminal]
+----
+$ openssl ec -in private-key.pem -pubout -out public-key.pem
+----
+
+. Create a Kubernetes `Secret` object in the Authorino Operator namespace by adding the private key with the following command:
++
+[source,terminal,subs="+quotes"]
+----
+$ oc create secret generic trusted-headers-private-key \
+  --from-file=key.pem=private-key.pem \
+  -n _<kuadrant_system>_ \
+  --dry-run=client -o yaml | oc apply -f -
+----
++
+Replace `_<kuadrant_system>_` with the namespace where {prodname} is installed.
+
+. Create a Kubernetes `Secret` object in the MCP broker component namespace by adding the public key with the following command:
++
+[source,terminal,subs="+quotes"]
+----
+$ oc create secret generic trusted-headers-public-key \
+  --from-file=key=public-key.pem \
+  -n _<mcp_system>_ \
+  --dry-run=client -o yaml | oc apply -f -
+----
++
+Replace `_<mcp_system>_` with the namespace where {mcpg} is installed.
+
+. Delete only the existing `AuthPolicy` CR on the `mcp` listener by running the following command:
++
+[source,terminal,subs="+quotes"]
+----
+$ oc delete authpolicy _<mcp_authn_policy>_ -n _<authn_namespace>_ --ignore-not-found
+----
++
+* Replace `_<mcp_authn_policy>_` with the name of your `AuthPolicy` CR.
+* Replace `_<authn_namespace>_` with the namespace where your `AuthPolicy` CR is applied.
++
+[IMPORTANT]
+====
+You must delete the `AuthPolicy` CR and create a new one. Using `$ oc apply` merges both the new and old policies.
+====
+
+. Generate a new `x-authorized-tools` header by creating and applying a new `AuthPolicy` CR. Use the following example:
++
+.Example AuthPolicy CR
+[source,yaml]
+----
+$ oc create -f - <<EOF
+apiVersion: kuadrant.io/v1
+kind: AuthPolicy
+metadata:
+  name: _<mcp_auth_policy>_
+  namespace: _<authn_namespace>_
+spec:
+  targetRef:
+    group: gateway.networking.k8s.io
+    kind: Gateway
+    name: _<mcp_gateway>_
+    sectionName: mcp
+  when:
+    - predicate: "!request.path.contains('/.well-known')"
+  rules:
+    authentication:
+      'keycloak':
+        jwt:
+          issuerUrl: https://keycloak.example.com:port/realms/mcp
+    authorization:
+      'allow-mcp-method':
+        patternMatching:
+          patterns:
+          - predicate: |
+              !request.headers.exists(h, h == 'x-mcp-method') || (request.headers['x-mcp-method'] in ["tools/list","initialize","notifications/initialized"])
+      'authorized-tools':
+        opa:
+          rego: |
+            allow = true
+            tools = { server: roles | server := object.keys(input.auth.identity.resource_access)[_]; roles := object.get(input.auth.identity.resource_access, server, {}).roles }
+          allValues: true
+    response:
+      success:
+        headers:
+          x-authorized-tools:
+            wristband:
+              issuer: 'authorino'
+              customClaims:
+                'allowed-tools':
+                  selector: auth.authorization.authorized-tools.tools.@tostr
+              tokenDuration: 300
+              signingKeyRefs:
+                - name: trusted-headers-private-key
+                  algorithm: ES256
+      unauthenticated:
+        headers:
+          'WWW-Authenticate':
+            value: Bearer resource_metadata=https://mcp.example.com:port/.well-known/oauth-protected-resource
+        body:
+          value: |
+            {
+              "error": "Unauthorized",
+              "message": "Access denied: Authentication required."
+            }
+      unauthorized:
+        code: 401
+        headers:
+          'WWW-Authenticate':
+            value: Bearer resource_metadata=https://mcp.example.com:port/.well-known/oauth-protected-resource
+        body:
+          value: |
+            {
+              "error": "Forbidden",
+              "message": "Access denied: Unsupported method. New authentication required (401)."
+            }
+EOF
+----
++
+* Replace `_<mcp_auth_policy>_` with the name of your new `AuthPolicy` CR.
+* Replace `_<authn_namespace>_` with the namespace where you removed the `AuthPolicy CR` that was on the `mcp` listener.
+* Replace `_<mcp_gateway>_` with the name of your {mcpg} deployment.
+
+. Configure the MCP broker component to validate the signed header by running the following command:
++
+[source,terminal,subs="+quotes"]
+----
+$ oc patch mcpgatewayextension _<mcp_gateway_extension>_ -n _<mcp_system>_ --type='merge' \
+  -p='{"spec":{"trustedHeadersKey":{"secretName":"trusted-headers-public-key"}}}'
+----
++
+* Replace `_<mcp_gateway_extension>_` with the name of your `MCPGatewayExtension` CR.
+* Replace `_<mcp_system>_` with the namespace where {mcpg} is installed.
+
+. Wait for the automatic MCP broker component redeployment to load the public key from the `Secret` CR created in the earlier step by running the following command:
++
+[source,terminal,subs="+quotes"]
+----
+$ oc rollout status deployment/_<mcp_gateway>_ -n _<mcp_system>_ --timeout=60s
+----
++
+* Replace `_<mcp_gateway>_` with the name of your {mcpg} deployment.
+* Replace `_<mcp_system>_` with the namespace where your {mcpg} deployment is applied.
+
+. If the redeployment does not start, force it by running the following command:
++
+[source,terminal,subs="+quotes"]
+----
+$ oc rollout restart deployment/_<mcp_gateway>_ -n _<mcp_system>_
+----
++
+* Replace `_<mcp_gateway>_` with the name of your {mcpg} deployment.
+* Replace `_<mcp_system>_` with the namespace where your {mcpg} deployment is applied.
+
+.Verification
+
+. Verify that the new `AuthPolicy` CR is enforced by running the following command:
++
+[source,terminal,subs="+quotes"]
+----
+$ oc get authpolicy _<mcp_auth_policy>_ -n _<authn_namespace>_ -o jsonpath='{.status.conditions[?(@.type=="Enforced")].status}'
+----
++
+* Replace `_<mcp_auth_policy>_` with the name of your new `AuthPolicy` CR.
+* Replace `_<authn_namespace>_` with the namespace where your `AuthPolicy` CR is applied.
++
+.Example output
+[source,text]
+----
+True
+----
+
+. Log out and log back in with the user credentials that you changed access for to get a fresh token.
+
+. Request all available tools from your MCP servers for the user or group whose access you revoked. The expected response is a list of all tools that the user or group can access from all registered MCP servers.

--- a/modules/proc-mcp-gateway-revoking-tools-call-requests.adoc
+++ b/modules/proc-mcp-gateway-revoking-tools-call-requests.adoc
@@ -1,0 +1,42 @@
+// Module included in the following assemblies:
+//
+// *mcp_gateway_config/mcp-gateway-revoke-tool-access.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="proc-mcp-gateway-revoking-tool-call-requests_{context}"]
+= Revoking tools/call requests
+
+[role="_abstract"]
+Use your existing authorization setup to revoke `tools/call` requests for individual users and groups by removing the tool role from the user or group in your identity provider.
+
+In this example, {keycloak} is used. Remove the client-role mapping. The client name corresponds to the namespaced MCPServerRegistration custom resource (CR), such as `mcp-test/test-server1`. Each role represents a tool name, such as `greet`, or `headers`.
+
+.Prerequisites
+
+* You installed {mcpg}.
+* You configured a `Gateway` object.
+* You are logged into a running {ocp} cluster with an `admin` role.
+* You configured an `HTTPRoute` object for the gateway.
+* You registered an MCP server.
+* You created a `Secret` CR for authentication.
+* You configured authorization with a tool-level `AuthPolicy` CR.
+
+.Procedure
+
+. Revoke a tool for a group by using the {keycloak} interface:
+
+.. Go to **Groups** > select the group, such as `accounting`.
+.. Go to **Role mapping** > remove the tool role from the relevant client.
+
+. Revoke a tool for a single user by using the interface:
+
+.. Go to **Users** > select the user.
+.. Go to **Role mapping** > remove the tool role from the relevant client.
+
+.Verification
+
+. After revoking a tool, verify that the user can no longer call it by using MCP Inspector. Log out of any existing MCP Inspector session and log back in as the affected user to get a fresh token.
+
+.. Open MCP Inspector and connect to your gateway's `/mcp` endpoint. Authenticate through the OAuth flow.
+
+.. Under **Tools > List Tools**, the revoked tool is displayed. Try calling the revoked tool. The request should return `500`.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
mcp-gateway-docs-tp

Issue:
[OSDOCS-19231](https://redhat.atlassian.net/browse/OSDOCS-19231)

Link to docs preview:
https://110614--ocpdocs-pr.netlify.app/rhcl/latest/mcp_gateway_config/mcp-gateway-revoke-tool-access.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Reviewer, the `mcp-gateway-docs-tp` is a Release branch, so content work is incremental. The entire branch will be integrated into the `rhcl-docs-main`, `rhcl-docs-1.3`, and `rhcl-docs-1.4` docs in late April, and therefore, not published anywhere now.

Docs reviewer: Please review but do not merge. QE is pending. Merge freeze is Monday, April 27.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
