### PR TITLE
[OSDOCS-19337]: Cross-linking node scaling docs for HCP

### DIFF
--- a/hosted_control_planes/hcp-deploy/hcp-deploy-virt.adoc
+++ b/hosted_control_planes/hcp-deploy/hcp-deploy-virt.adoc
@@ -120,6 +120,11 @@ include::modules/hcp-virt-sched-vms.adoc[leveloffset=+2]
 
 include::modules/hcp-virt-scale-nodepool.adoc[leveloffset=+1]
 
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../hosted_control_planes/hcp-machine-config.adoc#scale-up-down-autoscaler-hcp_hcp-machine-config[Scaling up and down workloads in a hosted cluster]
+
 include::modules/hcp-virt-add-node.adoc[leveloffset=+2]
 
 [role="_additional-resources"]

--- a/hosted_control_planes/hcp-machine-config.adoc
+++ b/hosted_control_planes/hcp-machine-config.adoc
@@ -40,6 +40,13 @@ include::modules/hcp-configure-ntp.adoc[leveloffset=+1]
 
 include::modules/scale-up-down-autoscaler-hcp.adoc[leveloffset=+1]
 
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../hosted_control_planes/hcp-manage/hcp-manage-bm.adoc#hcp-bm-scale-np_hcp-manage-bm[Scaling the NodePool object for a hosted cluster (bare-metal platforms)]
+* xref:../hosted_control_planes/hcp-manage/hcp-manage-non-bm.adoc#hcp-bm-scale-np_hcp-manage-non-bm[Scaling the NodePool object for a hosted cluster (non-bare metal agent machines)]
+* xref:../hosted_control_planes/hcp-deploy/hcp-deploy-virt.adoc#hcp-virt-scale-nodpool_hcp-deploy-virt[Scaling a node pool ({VirtProductName})]
+
 include::modules/scale-up-autoscaler-hcp.adoc[leveloffset=+1]
 
 include::modules/priority-expander-autoscaler-hcp.adoc[leveloffset=+1]

--- a/hosted_control_planes/hcp-manage/hcp-manage-bm.adoc
+++ b/hosted_control_planes/hcp-manage/hcp-manage-bm.adoc
@@ -23,6 +23,8 @@ include::modules/hcp-bm-autoscale-disable.adoc[leveloffset=+2]
 
 * xref:../../hosted_control_planes/hcp-troubleshooting.adoc#scale-down-data-plane_hcp-troubleshooting[Scaling down the data plane to zero]
 
+* xref:../../hosted_control_planes/hcp-machine-config.adoc#scale-up-down-autoscaler-hcp_hcp-machine-config[Scaling up and down workloads in a hosted cluster]
+
 include::modules/hcp-bm-ingress.adoc[leveloffset=+1]
 
 [role="_additional-resources"]

--- a/hosted_control_planes/hcp-manage/hcp-manage-non-bm.adoc
+++ b/hosted_control_planes/hcp-manage/hcp-manage-non-bm.adoc
@@ -23,6 +23,8 @@ include::modules/hcp-bm-autoscale-disable.adoc[leveloffset=+2]
 
 * xref:../../hosted_control_planes/hcp-troubleshooting.adoc#scale-down-data-plane_hcp-troubleshooting[Scaling down the data plane to zero]
 
+* xref:../../hosted_control_planes/hcp-machine-config.adoc#scale-up-down-autoscaler-hcp_hcp-machine-config[Scaling up and down workloads in a hosted cluster]
+
 include::modules/hcp-bm-ingress.adoc[leveloffset=+1]
 
 [role="_additional-resources"]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.20+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://redhat.atlassian.net/browse/OSDOCS-19337
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
- Node scaling docs (HCP on OpenShift Virt): https://110615--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-deploy/hcp-deploy-virt.html#hcp-virt-scale-nodpool_hcp-deploy-virt
- Node scaling docs (HCP on bare metal): https://110615--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-manage/hcp-manage-bm.html#hcp-bm-autoscale-disable_hcp-manage-bm
- Node scaling docs (HCP on non-bare metal): https://110615--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-manage/hcp-manage-non-bm.html#hcp-bm-autoscale-disable_hcp-manage-non-bm
- Scaling up and down workloads in a hosted cluster: https://110615--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-machine-config#scale-up-down-autoscaler-hcp_hcp-machine-config
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
N/A - no technical changes
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: This PR cross-links documentation about node scaling in the HCP docs to improve findability. No technical changes were made. 
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
