### PR TITLE
TELCODOCS-2633: Add SNO agent-based installer toolkit documentation

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -427,6 +427,9 @@ Topics:
     File: install-sno-preparing-to-install-sno
   - Name: Installing OpenShift on a single node
     File: install-sno-installing-sno
+  - Name: Installing single-node OpenShift clusters with the agent-based installer toolkit
+    File: install-sno-with-agent-based-installer
+    Distros: openshift-enterprise
 - Name: Installing a Two Node OpenShift Cluster
   Dir: installing_two_node_cluster
   Distros: openshift-origin,openshift-enterprise

--- a/installing/installing_sno/install-sno-with-agent-based-installer.adoc
+++ b/installing/installing_sno/install-sno-with-agent-based-installer.adoc
@@ -1,0 +1,48 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="install-sno-with-agent-based-installer"]
+= Installing {sno} with the agent-based installer toolkit
+include::_attributes/common-attributes.adoc[]
+:context: install-sno-with-agent-based-installer
+
+toc::[]
+
+[role="_abstract"]
+You can deploy {sno} clusters by using the agent-based installer toolkit. The toolkit automates the end-to-end process of generating a bootable ISO, deploying the cluster through Baseboard Management Controller (BMC) integration, and applying postinstallation configurations.
+
+The toolkit targets Telco RAN workloads and offers deployment profiles, Operator management, and validation capabilities for bare-metal environments.
+
+[id="prerequisites_{context}"]
+== Prerequisites
+
+* You reviewed details about the {product-title} installation and update processes.
+* You read the documentation on selecting a cluster installation method and preparing it for users.
+* You have BMC or Redfish access to the target bare-metal server.
+* You have an HTTP server available to host the generated ISO image.
+
+include::modules/sno-agent-toolkit-about.adoc[leveloffset=+1]
+
+include::modules/sno-agent-toolkit-prerequisites.adoc[leveloffset=+1]
+
+include::modules/sno-agent-toolkit-configuring-deployment.adoc[leveloffset=+1]
+
+include::modules/sno-agent-toolkit-deployment-profiles.adoc[leveloffset=+2]
+
+include::modules/sno-agent-toolkit-network-config.adoc[leveloffset=+2]
+
+include::modules/sno-agent-toolkit-generating-iso.adoc[leveloffset=+1]
+
+include::modules/sno-agent-toolkit-deploying-cluster.adoc[leveloffset=+1]
+
+include::modules/sno-agent-toolkit-day2-operations.adoc[leveloffset=+1]
+
+include::modules/sno-agent-toolkit-validating-deployment.adoc[leveloffset=+1]
+
+include::modules/sno-agent-toolkit-profiles-reference.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+== Additional resources
+
+* xref:../../installing/installing_with_agent_based_installer/preparing-to-install-with-agent-based-installer.adoc#preparing-to-install-with-agent-based-installer[Preparing to install with the Agent-based Installer]
+* xref:../../installing/installing_sno/install-sno-preparing-to-install-sno.adoc#preparing-to-install-sno[Preparing to install on a single node]
+* xref:../../installing/installing_with_agent_based_installer/installing-with-agent-based-installer.adoc#installing-ocp-agent-inputs_installing-with-agent-based-installer[Creating the preferred configuration inputs]
+* xref:../../installing/installing_sno/install-sno-installing-sno.adoc#install-sno-installing-sno[Installing OpenShift on a single node]

--- a/modules/sno-agent-toolkit-about.adoc
+++ b/modules/sno-agent-toolkit-about.adoc
@@ -1,0 +1,34 @@
+// Module included in the following assemblies:
+//
+// * installing/installing_sno/install-sno-with-agent-based-installer.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="sno-agent-toolkit-about_{context}"]
+= About the {sno} agent-based installer toolkit
+
+[role="_abstract"]
+The {sno} agent-based installer toolkit offers an automated workflow for deploying and managing {sno} clusters by using the {product-title} Agent-based Installer. The toolkit generates bootable ISO images that contain pre-configured Operators and system tunings, deploys clusters through BMC and Redfish integration, and applies postinstallation configurations.
+
+The toolkit supports the following deployment phases:
+
+ISO generation:: Generates a bootable ISO image with pre-configured Operators, cluster tunings, and network settings by using the `sno-iso.sh` script.
+
+Cluster deployment:: Deploys the {sno} cluster to bare-metal servers through BMC and Redfish integration by using the `sno-install.sh` script.
+
+Day 2 operations:: Applies postinstallation configurations, including performance profiles, Precision Time Protocol (PTP), and Single Root I/O Virtualization (SR-IOV) settings by using the `sno-day2.sh` script.
+
+Cluster validation:: Validates the cluster configuration and health, including node status, Operator readiness, and performance settings by using the `sno-ready.sh` script.
+
+The toolkit uses a hierarchical configuration system with deployment profiles that offer pre-configured templates for different use cases, such as Telco RAN workloads, hub cluster management, and minimal installations.
+
+The toolkit supports the following bare metal platforms:
+
+* Hewlett Packard Enterprise (HPE) Integrated Lights-Out (iLO)
+* ZT Systems
+* Dell Integrated Dell Remote Access Controller (iDRAC)
+* KVM with sushy-tools
+
+The toolkit supports the following CPU architectures:
+
+* `x86_64`
+* `ARM64` / `AArch64`

--- a/modules/sno-agent-toolkit-configuring-deployment.adoc
+++ b/modules/sno-agent-toolkit-configuring-deployment.adoc
@@ -1,0 +1,167 @@
+// Module included in the following assemblies:
+//
+// * installing/installing_sno/install-sno-with-agent-based-installer.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="sno-agent-toolkit-configuring-deployment_{context}"]
+= Configuring the {sno} deployment
+
+[role="_abstract"]
+Configure the {sno} deployment by creating a YAML configuration file. The configuration file defines the cluster settings, host details, network parameters, and Operator selections for your deployment.
+
+You can start with a sample configuration or use a pre-configured deployment profile template.
+
+.Procedure
+
+. Obtain and extract the {sno} agent-based installer toolkit.
+
+. Change to the toolkit directory by running the following command:
++
+[source,terminal]
+----
+$ cd sno-agent-based-installer
+----
+
+. Create a configuration file by using one of the following methods:
++
+--
+* Copy the sample configuration file:
++
+[source,terminal]
+----
+$ cp config.yaml.sample config-<cluster_name>.yaml
+----
++
+Replace `<cluster_name>` with the name of your cluster.
+
+* Copy a pre-configured deployment profile template:
++
+[source,terminal]
+----
+$ cp templates/cluster-profile-ran-<ocp_version>.yaml config-<cluster_name>.yaml
+----
++
+Replace `<ocp_version>` with your target {product-title} version, for example `4.18`. Replace `<cluster_name>` with the name of your cluster.
+--
+
+. Edit the configuration file and set the required cluster parameters:
++
+The following table describes the required configuration parameters:
++
+.Required configuration parameters
+[cols="2,3",options="header"]
+|===
+|Parameter |Description
+
+|`cluster.domain`
+|The base domain for your cluster.
+
+|`cluster.name`
+|The name of the cluster.
+
+|`cluster.profile`
+|The deployment profile to use. Valid values are `ran`, `hub`, and `none`.
+
+|`host.hostname`
+|The fully qualified hostname of the node.
+
+|`host.interface`
+|The primary network interface name.
+
+|`host.mac`
+|The MAC address of the primary network interface.
+
+|`host.ipv4.ip`
+|The static IPv4 address for the node.
+
+|`host.ipv4.dns`
+|The DNS server addresses.
+
+|`host.ipv4.gateway`
+|The default gateway address.
+
+|`host.ipv4.prefix`
+|The subnet prefix length.
+
+|`host.ipv4.machine_network_cidr`
+|The machine network CIDR.
+
+|`host.disk`
+|The installation disk path. Use a persistent path from `/dev/disk/by-path/`.
+
+|`bmc.address`
+|The BMC IP address.
+
+|`bmc.username`
+|The BMC username.
+
+|`bmc.password`
+|The BMC password.
+
+|`iso.address`
+|The URL that hosts the generated ISO.
+
+|`pull_secret`
+|The path to your pull secret file.
+
+|`ssh_key`
+|The path to your SSH public key file.
+|===
++
+[source,yaml]
+----
+cluster:
+  domain: example.com
+  name: mysno
+  profile: ran
+
+host:
+  hostname: mysno.example.com
+  interface: ens1f0
+  mac: b4:96:91:b4:9d:f0
+  ipv4:
+    enabled: true
+    ip: 192.168.1.100
+    dns:
+      - 192.168.1.1
+    gateway: 192.168.1.1
+    prefix: 24
+    machine_network_cidr: 192.168.1.0/24
+  disk: /dev/disk/by-path/pci-0000:c2:00.0-nvme-1
+
+bmc:
+  address: 192.168.1.200
+  username: Administrator
+  password: password
+
+iso:
+  address: http://192.168.1.10/iso/mysno.iso
+
+pull_secret: ${HOME}/pull-secret.json
+ssh_key: ${HOME}/.ssh/id_rsa.pub
+----
+
+. Optional: Configure operator-specific settings. For example, to configure local storage:
++
+[source,yaml]
+----
+operators:
+  local-storage:
+    data:
+      disk_by_path: pci-0000:03:00.0-nvme-1
+----
+
+. Optional: Configure performance tuning overrides:
++
+[source,yaml]
+----
+node_tunings:
+  performance_profile:
+    spec:
+      cpu:
+        isolated: 2-31,34-63
+        reserved: 0-1,32-33
+      hardwareTuning:
+        isolatedCpuFreq: 2500000
+        reservedCpuFreq: 2500000
+----

--- a/modules/sno-agent-toolkit-day2-operations.adoc
+++ b/modules/sno-agent-toolkit-day2-operations.adoc
@@ -1,0 +1,62 @@
+// Module included in the following assemblies:
+//
+// * installing/installing_sno/install-sno-with-agent-based-installer.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="sno-agent-toolkit-day2-operations_{context}"]
+= Applying Day 2 postinstallation configurations
+
+[role="_abstract"]
+After you deploy the {sno} cluster, apply Day 2 configurations to complete the cluster setup. Day 2 operations include applying performance profiles, configuring PTP, setting up SR-IOV, and other post-deployment tasks.
+
+The toolkit applies Day 2 configurations based on the Operator profiles defined in your configuration file. Each Operator can define Day 2 profiles that specify the configurations to apply after deployment.
+
+.Prerequisites
+
+* You deployed the {sno} cluster and it is accessible.
+* You set the `KUBECONFIG` environment variable to the cluster `kubeconfig` file.
+
+.Procedure
+
+. Apply Day 2 configurations by running the following command:
++
+[source,terminal]
+----
+$ ./sno-day2.sh
+----
++
+The script applies configurations to the most recently deployed cluster by default. To target a specific cluster, append the cluster name: `./sno-day2.sh <cluster_name>`.
+
+. The script applies configurations in the following order:
++
+--
+.. Shell scripts (`.sh` files) run first.
+.. The toolkit applies YAML manifests (`.yaml` files) and Jinja2 templates (`.yaml.j2` files) next.
+--
+
+. Optional: Configure Day 2 profiles for each Operator in your configuration file:
++
+[source,yaml]
+----
+operators:
+  ptp:
+    enabled: true
+    day2:
+      - profile: grandmaster # Applies from templates/day2/ptp/grandmaster/
+  sriov:
+    enabled: true
+    day2:
+      - profile: default # Applies from templates/day2/sriov/default/
+----
++
+When you do not specify Day 2 profiles, the toolkit applies the files under `templates/day2/<operator_name>/` and `templates/day2/<operator_name>/default/`.
+
+. Optional: Include custom manifests by adding paths to the `extra_manifests` section of your configuration file:
++
+[source,yaml]
+----
+extra_manifests:
+  day2:
+    - ${HOME}/day2-manifests
+    - ./post-install-configs
+----

--- a/modules/sno-agent-toolkit-deploying-cluster.adoc
+++ b/modules/sno-agent-toolkit-deploying-cluster.adoc
@@ -1,0 +1,52 @@
+// Module included in the following assemblies:
+//
+// * installing/installing_sno/install-sno-with-agent-based-installer.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="sno-agent-toolkit-deploying-cluster_{context}"]
+= Deploying the {sno} cluster
+
+[role="_abstract"]
+Deploy the {sno} cluster by using BMC and Redfish integration to boot the target server from the generated ISO image.
+
+.Prerequisites
+
+* You generated the agent-based installer ISO image.
+* The ISO image is accessible at the URL configured in the `iso.address` field.
+* You have BMC or Redfish access to the target hardware.
+
+.Procedure
+
+. Deploy the cluster by running the following command on the bastion host:
++
+[source,terminal]
+----
+$ ./sno-install.sh
+----
++
+The script deploys the most recently generated cluster by default. To deploy a specific cluster, append the cluster name: `./sno-install.sh <cluster_name>`.
+
+. Monitor the installation progress. The script interacts with the BMC to mount the ISO image, set the boot order, and power cycle the server.
++
+The installation process mounts the ISO image on the target server, boots {op-system-first}, and runs the {product-title} installer. The process typically takes 30 to 60 minutes to complete, depending on your hardware and network configuration.
+
+.Verification
+
+* After the installation completes, verify the cluster is accessible:
++
+[source,terminal]
+----
+$ export KUBECONFIG=instances/<cluster_name>/auth/kubeconfig
+----
++
+[source,terminal]
+----
+$ oc get nodes
+----
++
+.Example output
+[source,terminal]
+----
+NAME                    STATUS   ROLES                         AGE   VERSION
+mysno.example.com       Ready    control-plane,master,worker   30m   v1.27.0+xxxx
+----

--- a/modules/sno-agent-toolkit-deployment-profiles.adoc
+++ b/modules/sno-agent-toolkit-deployment-profiles.adoc
@@ -1,0 +1,48 @@
+// Module included in the following assemblies:
+//
+// * installing/installing_sno/install-sno-with-agent-based-installer.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="sno-agent-toolkit-deployment-profiles_{context}"]
+= Understanding deployment profiles
+
+[role="_abstract"]
+The agent-based installer toolkit uses deployment profiles to offer pre-configured templates for different use cases. When you specify a profile in your configuration file, the toolkit loads the corresponding template and applies your configuration overrides on top of the profile defaults.
+
+The profile system follows a hierarchical inheritance model:
+
+. The toolkit reads the `cluster.profile` field from your configuration file.
+. The toolkit loads the matching profile template from `templates/cluster-profile-<profile_name>-<ocp_version>.yaml`.
+. Any values that you define in your configuration file override the profile defaults.
+. If a version-specific template does not exist, the toolkit falls back to the base profile template.
+
+The following deployment profiles are available:
+
+[cols="1,2,3",options="header"]
+|===
+|Profile |Use case |Key features
+
+|`ran`
+|Telco RAN workloads
+|Performance tuning, workload partitioning, RAN Operators including PTP, SR-IOV, Forward Error Correction (FEC), Lifecycle Agent, and OpenShift API for Data Protection (OADP)
+
+|`hub`
+|Hub cluster management
+|{rh-rhacm-first}, {gitops-title}, {cgu-operator-first}, and cluster logging
+
+|`none`
+|Minimal setup
+|Basic cluster capabilities only
+|===
+
+When you do not specify a profile, the toolkit does not load any template. You must manually configure all settings.
+
+The `ran` profile includes version-specific templates optimized for each {product-title} release. For example, the `cluster-profile-ran-4.18.yaml` template includes cluster tunings specific to {product-title} 4.18.
+
+Each profile template has the following configuration sections:
+
+* Cluster capabilities and baseline settings
+* Version-specific cluster tunings
+* Node tunings, including workload partitioning and performance profiles
+* Operator update control settings
+* Pre-configured Operator subscriptions

--- a/modules/sno-agent-toolkit-generating-iso.adoc
+++ b/modules/sno-agent-toolkit-generating-iso.adoc
@@ -1,0 +1,49 @@
+// Module included in the following assemblies:
+//
+// * installing/installing_sno/install-sno-with-agent-based-installer.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="sno-agent-toolkit-generating-iso_{context}"]
+= Generating the agent-based installer ISO
+
+[role="_abstract"]
+Generate a bootable ISO image that has all the information required to deploy your {sno} cluster, including pre-configured Operators and system tunings.
+
+.Prerequisites
+
+* You created a configuration file as described in "Configuring the {sno} deployment".
+* You installed the required tools on the bastion host.
+* You have a valid pull secret file and SSH public key.
+
+.Procedure
+
+. Generate the ISO image by running the following command on the bastion host:
++
+[source,terminal]
+----
+$ ./sno-iso.sh config-<cluster_name>.yaml
+----
++
+Replace `<cluster_name>` with the name of your cluster configuration file.
+
+. Optional: Specify a target {product-title} version:
++
+[source,terminal]
+----
+$ ./sno-iso.sh config-<cluster_name>.yaml <ocp_version>
+----
++
+Replace `<ocp_version>` with the {product-title} version or release channel, for example `4.18.5` or `stable-4.18`.
++
+If you do not specify a version, the toolkit defaults to the `stable-4.18` channel.
+
+. Copy the generated ISO image to your HTTP server so that it is accessible at the URL specified in the `iso.address` field of your configuration file.
+
+.Verification
+
+* Verify that the toolkit generated the ISO image in the `instances/<cluster_name>/` directory by running the following command:
++
+[source,terminal]
+----
+$ ls instances/<cluster_name>/
+----

--- a/modules/sno-agent-toolkit-network-config.adoc
+++ b/modules/sno-agent-toolkit-network-config.adoc
@@ -1,0 +1,96 @@
+// Module included in the following assemblies:
+//
+// * installing/installing_sno/install-sno-with-agent-based-installer.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="sno-agent-toolkit-network-config_{context}"]
+= Network configuration options
+
+[role="_abstract"]
+The agent-based installer toolkit supports the following network configuration options for {sno} deployments. You define network settings in the `host` section of the configuration file.
+
+IPv4 configuration::
+[source,yaml]
+----
+host:
+  ipv4:
+    enabled: true
+    dhcp: false # Set to true to use DHCP instead of a static address
+    ip: 192.168.1.100
+    dns:
+      - 192.168.1.1
+    gateway: 192.168.1.1
+    prefix: 24
+    machine_network_cidr: 192.168.1.0/24
+----
+
+IPv6 configuration::
+[source,yaml]
+----
+host:
+  ipv6:
+    enabled: true
+    dhcp: false
+    ip: 2001:db8::100
+    dns:
+      - 2001:db8::1
+    gateway: 2001:db8::1
+    prefix: 64
+    machine_network_cidr: 2001:db8::/64
+----
+
+Dual-stack configuration::
+You can enable both IPv4 and IPv6 by setting `enabled: true` for both protocol stacks.
+
+VLAN configuration::
+When you enable VLAN tagging, the toolkit creates an NMState VLAN interface on the parent interface. The toolkit applies IPv4 and IPv6 addresses to the VLAN interface rather than the raw parent interface.
++
+
+[source,yaml]
+----
+host:
+  vlan:
+    enabled: true
+    name: ens1f0.100 # The logical VLAN interface name in NMState
+    id: 100 # The VLAN ID
+----
+
+Bond configuration::
+When you enable bonding, the `host.interface` value specifies the bond interface name. You must enable VLAN for bond NMState generation.
++
+
+[source,yaml]
+----
+host:
+  interface: bond0 # The bond interface name
+  mac: 02:00:00:ab:cd:ef # The MAC address assigned to the bond
+  bond:
+    enabled: true
+    mode: 802.3ad # The bonding mode, for example 802.3ad for LACP
+    miimon: 100 # Optional: MII monitoring interval in milliseconds
+    members: # List of member interfaces with their MAC addresses
+      - interface: ens1f0
+        mac: b4:96:91:b4:9d:f0
+      - interface: ens2f0
+        mac: b4:96:91:b4:9e:f0
+----
+
+Additional interfaces::
+You can define extra network interfaces to include in the NMState configuration:
++
+
+[source,yaml]
+----
+host:
+  additional_interfaces:
+    - name: eno8403np1
+      mac: c4:d6:d3:5e:34:3b
+      state: up # Optional: valid values are up, down, and unknown
+      ipv4:
+        enabled: true
+        dhcp: false
+        ip: 192.168.14.31
+        prefix: 27
+      ipv6:
+        enabled: false
+----

--- a/modules/sno-agent-toolkit-prerequisites.adoc
+++ b/modules/sno-agent-toolkit-prerequisites.adoc
@@ -1,0 +1,76 @@
+// Module included in the following assemblies:
+//
+// * installing/installing_sno/install-sno-with-agent-based-installer.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="sno-agent-toolkit-prerequisites_{context}"]
+= Prerequisites and system requirements for the {sno} agent-based installer toolkit
+
+[role="_abstract"]
+Before you deploy a {sno} cluster by using the agent-based installer toolkit, verify that your environment meets the following requirements.
+
+Cluster version requirements::
+{product-title} 4.14 or later
+
+Target node hardware requirements::
++
+[cols="1,3",options="header"]
+|===
+|Resource |Minimum requirement
+
+|CPU
+|8 vCPUs
+
+|Memory
+|16 GB RAM
+
+|Storage
+|120 GB disk space
+|===
+
+Bastion host requirements::
++
+--
+* A Linux system with internet access (`x86_64` or `ARM64`/`AArch64`)
+* BMC or Redfish access to the target hardware
+* An HTTP server for hosting the generated ISO image
+--
+
+Required tools::
+Install the following tools on the bastion host before you run the toolkit scripts:
++
+--
+* `nmstatectl` - NMState command-line tool for network configuration
+* `yq` - YAML processor
+* `jinja2-cli` - Jinja2 template command-line interface with YAML support
+* `oc` - {product-title} command-line interface
+--
+
+You can install the required tools by running the following commands:
+
+[source,terminal]
+----
+$ sudo dnf install /usr/bin/nmstatectl -y
+----
+
+[source,terminal]
+----
+$ sudo wget -qO /usr/local/bin/yq https://mirror.openshift.com/pub/openshift-v4/clients/yq/latest/yq_linux_amd64 && sudo chmod +x /usr/local/bin/yq
+----
+
+[source,terminal]
+----
+$ pip3 install jinja2-cli jinja2-cli[yaml]
+----
+
+If you have not installed the `oc` CLI, run the following commands:
+
+[source,terminal]
+----
+$ sudo curl -L -o openshift-client-linux.tar.gz https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest/openshift-client-linux.tar.gz
+----
+
+[source,terminal]
+----
+$ sudo tar -xzvf openshift-client-linux.tar.gz -C /usr/local/bin/
+----

--- a/modules/sno-agent-toolkit-profiles-reference.adoc
+++ b/modules/sno-agent-toolkit-profiles-reference.adoc
@@ -1,0 +1,141 @@
+// Module included in the following assemblies:
+//
+// * installing/installing_sno/install-sno-with-agent-based-installer.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="sno-agent-toolkit-profiles-reference_{context}"]
+= Deployment profiles reference
+
+[role="_abstract"]
+The following tables describe the deployment profile templates and the supported Operators available in the agent-based installer toolkit.
+
+[cols="2,3,3",options="header"]
+|===
+|Template |Purpose |Key features
+
+|`cluster-profile-full.yaml`
+|Complete configuration template
+|All configuration sections with examples
+
+|`cluster-profile-ran-<version>.yaml`
+|RAN-optimized configuration
+|Performance tuning, workload partitioning, RAN Operators
+
+|`cluster-profile-hub.yaml`
+|Hub cluster configuration
+|{rh-rhacm}, {gitops-title}, {cgu-operator} enabled
+
+|`cluster-profile-none.yaml`
+|Minimal configuration
+|Basic cluster setup only
+|===
+
+Version-specific RAN profiles offer optimizations for each {product-title} release:
+
+* `cluster-profile-ran-4.14.yaml`
+* `cluster-profile-ran-4.15.yaml`
+* `cluster-profile-ran-4.16.yaml`
+* `cluster-profile-ran-4.17.yaml`
+* `cluster-profile-ran-4.18.yaml`
+* `cluster-profile-ran-4.19.yaml`
+* `cluster-profile-ran-4.20.yaml`
+* `cluster-profile-ran-4.21.yaml`
+
+[cols="2,3",options="header"]
+|===
+|Operator |Description
+
+|PTP
+|Precision Time Protocol for time synchronization
+
+|SR-IOV
+|Single Root I/O Virtualization network Operator
+
+|Local Storage
+|Local storage Operator for persistent volumes
+
+|{lvms}
+|Logical Volume Manager storage
+
+|Cluster Logging
+|OpenShift Logging stack
+
+|MetalLB
+|Load balancer for bare-metal environments
+
+|NMState
+|Declarative network configuration management
+
+|OpenShift Virtualization
+|KubeVirt hyperconverged platform support
+
+|Node Feature Discovery (NFD)
+|Hardware feature detection and labeling
+
+|NVIDIA GPU
+|GPU workload support
+
+|Red{nbsp}Hat AMQ Streams
+|Apache Kafka messaging platform
+
+|Multicluster Global Hub
+|Multi-cluster management
+
+|Multicluster Engine (MCE)
+|Multi-cluster infrastructure management
+
+|OADP
+|OpenShift API for Data Protection and backup
+
+|Intel Forward Error Correction (FEC)
+|Forward Error Correction acceleration
+
+|Lifecycle Agent (LCA)
+|Image-based cluster lifecycle management
+
+|{gitops-title}
+|GitOps-based continuous delivery
+
+|{rh-rhacm}
+|{rh-rhacm-first}
+
+|{cgu-operator-full}
+|{cgu-operator-full}
+|===
+
+The following list describes the configuration sections in a profile template:
+
+`cluster.capabilities`:: Cluster capability settings, including the baseline capability set and additional enabled capabilities.
+`cluster_tunings`:: Version-specific cluster tunings identifier.
+`node_tunings`:: Node tunings including workload partitioning, performance profiles, and tuned profiles.
+`update_control`:: Operator update control settings to manage upgrades.
+`operators`:: Pre-configured Operator subscriptions and settings.
+
+[source,yaml]
+----
+cluster:
+  capabilities:
+    baselineCapabilitySet: None
+    additionalEnabledCapabilities:
+      - # ...
+
+cluster_tunings: <version>
+
+node_tunings:
+  workload_partitioning:
+    # ...
+  performance_profile:
+    # ...
+  tuned_profile:
+    # ...
+
+update_control:
+  pause_before_update: true
+  disable_operator_auto_upgrade: true
+
+operators:
+  ptp:
+    # ...
+  sriov:
+    # ...
+----

--- a/modules/sno-agent-toolkit-validating-deployment.adoc
+++ b/modules/sno-agent-toolkit-validating-deployment.adoc
@@ -1,0 +1,66 @@
+// Module included in the following assemblies:
+//
+// * installing/installing_sno/install-sno-with-agent-based-installer.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="sno-agent-toolkit-validating-deployment_{context}"]
+= Validating the {sno} cluster deployment
+
+[role="_abstract"]
+After you deploy the {sno} cluster and apply Day 2 configurations, validate the cluster configuration and health by using the toolkit validation script. The validation covers core cluster components, Operator readiness, and performance settings.
+
+.Prerequisites
+
+* You deployed the {sno} cluster and it is accessible.
+* You applied Day 2 configurations.
+
+.Procedure
+
+. Validate the cluster deployment by running the following command:
++
+[source,terminal]
+----
+$ ./sno-ready.sh
+----
++
+The script validates the most recently deployed cluster by default. To validate a specific cluster, append the cluster name: `./sno-ready.sh <cluster_name>`.
+
+. Review the validation results. The script checks the following areas:
++
+[cols="1,3",options="header"]
+|===
+|Area |Checks performed
+
+|Cluster health
+|Node status, cluster Operator health, pod status
+
+|Machine configurations
+|CPU partitioning, kdump, performance settings
+
+|Performance profile
+|Isolated and reserved CPUs, real-time kernel configuration
+
+|Network
+|SR-IOV node state, network diagnostics
+
+|System
+|Kernel parameters, cgroup configuration, container runtime
+
+|Day 1 Operators
+|PTP, SR-IOV, local storage, {lvms}, cluster logging
+
+|Day 2 Operator readiness
+|MetalLB load balancer status, NMState network configuration, Lifecycle Agent (LCA) readiness, OADP backup capability, Intel Forward Error Correction (FEC) acceleration, GPU Operator functionality, OpenShift Virtualization status
+
+|Hub cluster features
+|{rh-rhacm}, {gitops-title}, {cgu-operator}, multicluster engine (MCE), Multicluster Global Hub
+
+|Monitoring
+|AlertManager, Prometheus, telemetry settings
+
+|Storage
+|Local storage, {lvms} configurations and readiness
+
+|Update control
+|Operator upgrade policies and pause mechanisms
+|===


### PR DESCRIPTION
## Summary

- Adds a new assembly and 10 modules documenting the single-node OpenShift agent-based installer toolkit for Telco RAN bare-metal deployments
- Covers the full deployment lifecycle: ISO generation, BMC/Redfish cluster deployment, Day 2 postinstallation configurations, and cluster validation
- Includes deployment profiles reference (RAN, hub, none), network configuration options (IPv4/IPv6/dual-stack/VLAN/bonding), and supported Operators table
- Updates `_topic_maps/_topic_map.yml` to add the new assembly under "Installing on a single node"

## Compliance

- **Vale**: 0 errors, 0 warnings (10 suggestions — all readability grade on technical reference content)
- **DITA migration**: `[role="_abstract"]` on all files, no callouts, no unsupported block titles, no discrete headings, no nested sections
- **RH style guide**: Product attributes (`{sno}`, `{rh-rhacm}`, `{gitops-title}`, `{cgu-operator}`, `{lvms}`), "Day 2" (no hyphen), "bare-metal" adjective form, "postinstallation", Operator capitalization, sentence-case headings
- **Modular docs**: Proper content types (ASSEMBLY, CONCEPT, PROCEDURE, REFERENCE), `_{context}` anchors, `leveloffset` includes, no xrefs in modules

## Files

| File | Type | Description |
|------|------|-------------|
| `installing/installing_sno/install-sno-with-agent-based-installer.adoc` | Assembly | Main assembly |
| `modules/sno-agent-toolkit-about.adoc` | Concept | Toolkit overview |
| `modules/sno-agent-toolkit-prerequisites.adoc` | Reference | System requirements |
| `modules/sno-agent-toolkit-configuring-deployment.adoc` | Procedure | Configuration steps |
| `modules/sno-agent-toolkit-deployment-profiles.adoc` | Concept | Profile inheritance model |
| `modules/sno-agent-toolkit-network-config.adoc` | Reference | Network options |
| `modules/sno-agent-toolkit-generating-iso.adoc` | Procedure | ISO generation |
| `modules/sno-agent-toolkit-deploying-cluster.adoc` | Procedure | Cluster deployment |
| `modules/sno-agent-toolkit-day2-operations.adoc` | Procedure | Day 2 operations |
| `modules/sno-agent-toolkit-validating-deployment.adoc` | Procedure | Validation |
| `modules/sno-agent-toolkit-profiles-reference.adoc` | Reference | Profiles and Operators reference |
| `_topic_maps/_topic_map.yml` | Navigation | Topic map entry |

## Test plan

- [ ] Verify Vale passes with 0 errors and 0 warnings
- [ ] Verify the assembly builds correctly with AsciiBinder
- [ ] Verify all xrefs resolve correctly
- [ ] Verify the topic map entry renders in the correct position under "Installing on a single node"
- [ ] SME review of technical accuracy against the RHsyseng/sno-agent-based-installer toolkit

Resolves: [TELCODOCS-2633](https://redhat.atlassian.net/browse/TELCODOCS-2633)


Made with [Cursor](https://cursor.com)