### PR TITLE
OLS-2400: Document support for OLS API

### DIFF
--- a/configure/ols-configuring-openshift-lightspeed.adoc
+++ b/configure/ols-configuring-openshift-lightspeed.adoc
@@ -37,6 +37,8 @@ include::modules/ols-verifying-openshift-lightspeed-deployment.adoc[leveloffset=
 
 include::modules/ols-about-lightspeed-and-role-based-access-control.adoc[leveloffset=+1]
 
+include::modules/ols-proc-expose-the-ols-service-by-using-a-route.adoc[leveloffset=+1]
+
 include::modules/ols-granting-a-user-access-by-using-the-cli.adoc[leveloffset=+2]
 
 include::modules/ols-granting-a-user-access-by-using-yaml-configuration-file.adoc[leveloffset=+2]

--- a/modules/ols-proc-access-the-rest-api-directly.adoc
+++ b/modules/ols-proc-access-the-rest-api-directly.adoc
@@ -1,0 +1,24 @@
+// Module included in the following assemblies:
+// lightspeed-docs-main/operate/ols-using-openshift-lightspeed.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="ols-proc-access-the-rest-api-directly_{context}"]
+= Access the {ols-long} REST API directly
+
+[role="_abstract"]
+
+You can integrate {ols-official}  with external tools and scripts by using the {ols-long} REST API. Use the versioned endpoints to programmatically interact with the service and extend its capabilities into your existing workflows.
+
+All versioned API endpoints use the `/v1` path, such as, `https://<route-host>/v1/<endpoint>`.
+
+[IMPORTANT]
+====
+Direct API access supports up to 100 concurrent connections. Behavior beyond this limit is currently unsupported.
+====
+
+.Prerequisites
+
+* {ols-long} is installed and running thorugh the {ols-long} Operator.
+* You have `oc` or `kubectl` CLI access to the cluster.
+* You have exposed the `lightspeed-app-server` service by using an {ocp-short-name} route.
+* You have the `ols-user` `ClusterRole`.

--- a/modules/ols-proc-authenticate-with-the-api.adoc
+++ b/modules/ols-proc-authenticate-with-the-api.adoc
@@ -1,0 +1,53 @@
+// Module included in the following assemblies:
+// lightspeed-docs-main/operate/ols-using-openshift-lightspeed.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="ols-proc-authenticate-with-the-api_{context}"]
+= Authenticate with the API
+
+[role="_abstract"]
+
+To interact with the {ols-long} API, you must use token-based authentication. The Service validates your identity through a {k8s} `TokenReview` and `SubjectAccessReview` (SAR) against the `/ols-access` URL. Every request must include a valid {ocp-short-name} bearer token in the `Authorization` header.
+
+.Procedure
+
+. Grant the `ols-user` role by using any of the following code:
+
+** To the user:
++
+[source,bash]
+----
+oc adm policy add-cluster-role-to-user ols-user _<username>_
+----
+** To the Service account:
++
+[source,bash]
+----
+oc adm policy add-cluster-role-to-user ols-user \
+  system:serviceaccount:_<namespace>_:_<service_account_name>_
+----
+
+. Obtain a bearer token for your authentication method by any of the following ways:
+** For your own user:
++
+[source,bash]
+----
+TOKEN=$(oc whoami -t)
+----
+
+** For a Service account:
++
+[source,bash]
+----
+TOKEN=$(oc create token <service_account_name> -n <namespace>)
+----
+
+.Verification
+
+* Confirm the token is valid by querying the `/authorized` endpoint:
++
+[source,bash]
+----
+curl -k -X POST "https://${OLS_HOST}/authorized" \
+  -H "Authorization: Bearer ${TOKEN}"
+----

--- a/modules/ols-proc-expose-the-ols-service-by-using-a-route.adoc
+++ b/modules/ols-proc-expose-the-ols-service-by-using-a-route.adoc
@@ -1,0 +1,65 @@
+// Module included in the following assemblies:
+// * lightspeed-docs-main/configure/ols-configuring-openshift-lightspeed.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="ols-proc-expose-the-ols-service-by-using-a-route_{context}"]
+= Expose the {ols-long} Service by using a route
+
+The {ols-long} Service is an internal-only `ClusterIP` type by default. To enable external access to the {ols-long} REST API, you must create an {ocp-short-name} route.
+
+.Prerequisites
+
+* You have `oc` CLI access to the cluster through the {ols-long} Operator.
+* You have cluster-admin permissions.
+
+.Procedure
+
+. Create a YAML file named `route.yaml` with the following content:
++
+[source,yaml]
+----
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: lightspeed-app-server
+  namespace: openshift-lightspeed
+  labels:
+    app: ols
+spec:
+  port:
+    targetPort: 8443-tcp
+  tls:
+    insecureEdgeTerminationPolicy: Redirect
+    termination: reencrypt
+  to:
+    kind: Service
+    name: lightspeed-app-server
+    weight: 100
+  wildcardPolicy: None
+----
++
+[NOTE]
+====
+Use the `reencrypt` termination policy to ensure that TLS is maintained end-to-end between the router and the pod.
+====
+
+. Apply the configuration to your cluster:
++
+[source,bash]
+----
+oc apply -f route.yaml
+----
+
+. Retrieve the exposed hostname to use as your API base URL:
++
+[source,bash]
+----
+OLS_HOST=$(oc get route lightspeed-app-server -n openshift-lightspeed -o jsonpath='{.spec.host}')
+echo "https://${OLS_HOST}"
+----
+
+.Verification
+To verify the connection, you must ensure your client trusts the cluster's internal certificate authority (CA):
+
+* *For production:* Retrieve the cluster CA bundle from the `kube-root-ca.crt` ConfigMap and add it to your trust store.
+* *For testing:* You can use the `-k` or `--insecure` flag with `curl` to bypass CA verification.

--- a/modules/ols-ref-api-endpoints-reference.adoc
+++ b/modules/ols-ref-api-endpoints-reference.adoc
@@ -1,0 +1,34 @@
+// Module included in the following assemblies:
+// lightspeed-docs-main/operate/ols-using-openshift-lightspeed.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="ols-ref-api-endpoints-reference_{context}"]
+= {ols-long} API endpoints reference
+
+[role="_abstract"]
+
+The following versioned endpoints allow you to interact with the Service, manage conversation history, and submit user feedback.
+
+[cols="1,3"]
+|===
+|Endpoint |Description
+
+|`POST /v1/query`
+|Sends a prompt to the LLM. Required field: `query`. Optional fields: `conversation_id`, `provider`, `model`, `attachments`.
+
+|`POST /v1/streaming_query`
+|Delivers responses as a server-sent events (SSE) stream. Supports types: `text`, `tool_call`, `tool_result`, `approval_required`, `reasoning`, and `end`.
+
+|`GET /v1/conversations`
+|Lists conversation IDs, summaries, and message counts for the user.
+
+|`GET /v1/conversations/{id}`
+|Retrieves history for a specific conversation.
+
+|`DELETE /v1/conversations/{id}`
+|Deletes a specific conversation history.
+
+|`POST /v1/feedback`
+|Submits sentiment (`1` or `-1`) or text feedback. Feedback must be enabled in the OLS configuration.
+|===
+

--- a/modules/ols-ref-api-error-handling.adoc
+++ b/modules/ols-ref-api-error-handling.adoc
@@ -1,0 +1,27 @@
+// Module included in the following assemblies:
+// lightspeed-docs-main/operate/ols-using-openshift-lightspeed.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="ols-ref-api-error-handling_{context}"]
+= {ols-long} API error handling
+
+[role="_abstract"]
+
+The {ols-long} API returns JSON objects that contain a `detail` field with a `response` and a `cause`.
+
+[cols="1,3",options="header"]
+|===
+|Status code |Description
+
+|401
+|Unauthorized. The request is missing a token or the token is invalid.
+
+|403
+|Forbidden. The user lacks the `ols-user` cluster role.
+
+|413
+|Payload too large. The prompt exceeds the large language model (LLM) context window.
+
+|503
+|Service unavailable. The Service or LLM is still initializing.
+|===

--- a/modules/ols-ref-supported-attachement-formats.adoc
+++ b/modules/ols-ref-supported-attachement-formats.adoc
@@ -1,0 +1,21 @@
+// Module included in the following assemblies:
+// lightspeed-docs-main/operate/ols-using-openshift-lightspeed.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="supported-attachment-formats_{context}"]
+= Supported attachment formats
+
+[role="_abstract"]
+
+To provide extra context such as logs or configurations, you must include an `attachments` array in the `POST /v1/query` request body.
+
+[cols="1,3",options="header"]
+|===
+|Attachment type |Details
+
+|**Logs**
+|Use the `text/plain` content type.
+
+|**Configurations**
+|Use the `application/yaml` content type. If the YAML includes a `kind` and `metadata.name`, the large language model (LLM) treats it as a named {k8s} resource.
+|===

--- a/operate/ols-interacting-with-the-api.adoc
+++ b/operate/ols-interacting-with-the-api.adoc
@@ -15,3 +15,13 @@ include::modules/ols-authenticate-api-requests.adoc[leveloffset=+1]
 include::modules/ols-provide-authentication-mcp-server.adoc[leveloffset=+1]
 
 include::modules/ols-api-authentication-matrix.adoc[leveloffset=+1]
+
+include::modules/ols-proc-access-the-rest-api-directly.adoc[leveloffset=+1]
+
+include::modules/ols-proc-authenticate-with-the-api.adoc[leveloffset=+2]
+
+include::modules/ols-ref-api-endpoints-reference.adoc[leveloffset=+2]
+
+include::modules/ols-ref-supported-attachement-formats.adoc[leveloffset=+2]
+
+include::modules/ols-ref-api-error-handling.adoc[leveloffset=+2]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
lightspeed-docs-main, lightspeed-docs-1.0

Issue:
[OLS-2400](https://redhat.atlassian.net/browse/OLS-2400)

Link to docs preview:
- Configure: https://110626--ocpdocs-pr.netlify.app/openshift-lightspeed/latest/configure/ols-configuring-openshift-lightspeed.html#ols-proc-expose-the-ols-service-by-using-a-route_ols-configuring-openshift-lightspeed
- Operate: https://110626--ocpdocs-pr.netlify.app/openshift-lightspeed/latest/operate/ols-interacting-with-the-api.html#ols-proc-access-the-rest-api-directly_ols-interacting-with-the-api

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
