### PR TITLE
[WIP] OSDOCS-19150 [NETOBSERV] 1.12 FLP Enhancements

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -3301,6 +3301,8 @@ Topics:
     File: network-observability-network-policy
   - Name: Network observability DNS resolution analysis
     File: network-observability-dns-resolution-analysis
+  - Name: Optimizing Flow-logs Pipeline
+    File: network-observability-optimizing-flowlogs-pipeline
   - Name: Observing the network traffic
     File: observing-network-traffic
   - Name: Network observability health rules

--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -3399,6 +3399,8 @@ Topics:
     File: network-observability-network-policy
   - Name: Network observability DNS resolution analysis
     File: network-observability-dns-resolution-analysis
+  - Name: Optimizing Flow-logs Pipeline
+    File: network-observability-optimizing-flowlogs-pipeline
   - Name: Observing the network traffic
     File: observing-network-traffic
   - Name: Network observability health rules

--- a/modules/network-observability-flowlogs-pipeline-reducing-api-server-load-in-large-clusters.adoc
+++ b/modules/network-observability-flowlogs-pipeline-reducing-api-server-load-in-large-clusters.adoc
@@ -1,0 +1,48 @@
+//Module included in the following assemblies:
+//
+// network_observability/network-observability-scaling.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="network-observability-flowlogs-pipeline-reducing-api-server-load-in-large-clusters_{context}"]
+= Reducing API server load in large clusters
+
+[role="_abstract"]
+To reduce Kubernetes API server load and optimize resource consumption in large clusters, enable the Flow-logs Pipeline (FLP) shared cache.
+
+.Prerequisites
+
+* The Network Observability Operator is installed.
+* Access to the cluster as a user with the `cluster-admin` role.
+
+.Procedure
+
+. In the {product-title} web console, navigate to *Operators* → *Installed Operators*.
+. Select the *Network Observability Operator*, and then click the *FlowCollector* tab.
+. Click the `cluster` instance, and then click the *YAML* tab.
+. In the `spec.processor` section, set the `informers` configuration to enable the shared cache:
++
+[source,yaml]
+----
+apiVersion: flows.netobserv.io/v1alpha1
+kind: FlowCollector
+metadata:
+  name: cluster
+spec:
+  processor:
+    informers:
+      enabled: true
+      replicas: 2
+----
++
+where:
+
+`spec.processor.informers.replicas`:: Specifies the number of replicas. For high availability in production environments, the minimum is `2`. The operator enforces this requirement with leader election to prevent a single point of failure.
+
+. Click *Save*.
+
+.Verification
+
+. Navigate to *Workloads* → *Pods*.
+. Ensure that the pods beginning with `flp-informers` are in the *Running* state.
+. Verify that one pod shows as the active leader by checking the pod logs for leader election messages.
+. Confirm that the `flowlogs-pipeline` pods remain *Running* and show decreased CPU and memory utilization in the *Metrics* tab.

--- a/modules/network-observability-flowlogs-pipeline-reducing-api-server-load-in-large-clusters.adoc
+++ b/modules/network-observability-flowlogs-pipeline-reducing-api-server-load-in-large-clusters.adoc
@@ -23,7 +23,7 @@ To reduce Kubernetes API server load and optimize resource consumption in large 
 +
 [source,yaml]
 ----
-apiVersion: flows.netobserv.io/v1alpha1
+apiVersion: flows.netobserv.io/v1beta2
 kind: FlowCollector
 metadata:
   name: cluster

--- a/modules/network-observability-flowlogs-pipeline-resolving-shared-cache-performance-issues.adoc
+++ b/modules/network-observability-flowlogs-pipeline-resolving-shared-cache-performance-issues.adoc
@@ -1,0 +1,99 @@
+//Module included in the following assemblies:
+//
+// network_observability/network-observability-scaling.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="network-observability-flowlogs-pipeline-resolving-shared-cache-performance-issues_{context}"]
+= Resolving shared cache performance issues
+
+[role="_abstract"]
+Troubleshoot shared cache component failures by verifying pod health, reviewing system logs, and confirming leader election status to restore cluster performance.
+
+.Prerequisites
+
+* You have installed the Network Observability Operator.
+* You have access to the cluster as a user with the `cluster-admin` role.
+* The shared cache architecture is enabled in your FlowCollector configuration.
+
+.Procedure
+
+. Check the status of the shared cache pods:
++
+[source,terminal]
+----
+$ oc get pods -n netobserv -l app=flp-informers
+----
++
+.Example output
+[source,terminal]
+----
+NAME                             READY   STATUS    RESTARTS   AGE
+flp-informers-7d9f8b5c4d-abc12   1/1     Running   0          5m
+flp-informers-7d9f8b5c4d-xyz34   1/1     Running   0          5m
+----
++
+All pods should show `Running` status. If pods are in `CrashLoopBackOff` or `Error` state, proceed to examine the logs.
+
+. Identify the current leader pod:
++
+[source,terminal]
+----
+$ oc logs -n netobserv -l app=flp-informers --tail=50 | grep -i "leader"
+----
++
+Look for log entries indicating leader election status. Only one pod should report itself as the active leader.
+
+. View detailed logs from the leader pod to diagnose issues:
++
+[source,terminal]
+----
+$ oc logs -n netobserv <flp-informers-pod-name>
+----
++
+Common issues to look for:
++
+--
+* **API server connection failures**: Error messages indicating inability to connect to the Kubernetes API server suggest network or RBAC permission issues.
+* **gRPC communication errors**: Messages about failed connections on port 9090 indicate FLP instances cannot reach the shared cache.
+* **Leader election conflicts**: If multiple pods claim to be the leader, there might be a configuration issue with leader election.
+--
+
+. Verify that FLP instances are receiving cache updates:
++
+[source,terminal]
+----
+$ oc logs -n netobserv -l app=flowlogs-pipeline --tail=100 | grep -i "k8scache"
+----
++
+FLP pods should show successful connection messages to the shared cache on port 9090.
+
+. Check the shared cache service:
++
+[source,terminal]
+----
+$ oc get svc -n netobserv flp-informers
+----
++
+Verify that the service exists and is routing to the correct pods.
+
+. If the shared cache is not functioning correctly, check for RBAC permission issues:
++
+[source,terminal]
+----
+$ oc describe clusterrolebinding flp-informers
+----
++
+The ClusterRoleBinding should grant the `flp-informers` ServiceAccount the necessary permissions to watch Kubernetes resources.
+
+.Verification
+
+After resolving issues:
+
+. Confirm all shared cache pods are running and healthy.
+. Verify that one pod shows as the active leader in the logs.
+. Check that FLP pods successfully connect to the shared cache.
+. Monitor flow enrichment in the network observability console to ensure metadata appears correctly on network flows.
+
+.Additional resources
+
+* link:https://kubernetes.io/docs/concepts/architecture/leases/[Kubernetes leader election and leases]

--- a/modules/network-observability-flowlogs-pipeline-scaling-large-scale-deployment-challenges.adoc
+++ b/modules/network-observability-flowlogs-pipeline-scaling-large-scale-deployment-challenges.adoc
@@ -1,0 +1,42 @@
+//Module included in the following assemblies:
+//
+// network_observability/network-observability-scaling.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="network-observability-flowlogs-pipeline-scaling-large-scale-deployment-challenges_{context}"]
+= Performance challenges in large-scale deployments
+
+[role="_abstract"]
+In large-scale deployments, the default Flow-logs Pipeline (FLP) architecture can impact performance. Each FLP instance independently queries the Kubernetes API server to enrich network flows with cluster metadata. This results in a linear increase in API queries as the number of FLP instances scales.
+
+The Flow-logs Pipeline (FLP) enriches network flow data with Kubernetes metadata, such as pod names, labels, and namespace information. To retrieve this metadata, each FLP instance independently queries the Kubernetes API server using informers that watch for resource changes.
+
+[id="api-server-load-at-scale_{context}"]
+== API server load at scale
+
+In the default deployment model, the number of API queries increases linearly with the number of FLP instances:
+
+* Each FLP pod maintains separate informers for pods, nodes, services, and other Kubernetes resources.
+* Every informer establishes a watch connection to the API server.
+* Resource updates are sent independently to each FLP instance.
+
+For example, in a cluster with 10 FLP processor pods, the API server handles 10 times the watch connections and update notifications compared to a single instance. As you scale FLP horizontally to handle increased network traffic, the API server load multiplies accordingly.
+
+[id="resource-consumption-patterns_{context}"]
+== Resource consumption patterns
+
+This architecture creates several performance challenges:
+
+Memory footprint:: Each FLP instance maintains a full in-memory cache of all watched Kubernetes resources. In large clusters with thousands of pods and services, this cache can consume significant memory per FLP instance.
+
+CPU utilization:: Processing redundant API server updates and maintaining separate caches increases CPU usage across all FLP pods.
+
+API server impact:: The cumulative load from multiple FLP instances can degrade API server performance, potentially affecting other cluster components that depend on the API server for critical operations.
+
+Network bandwidth:: Duplicate resource updates consume network bandwidth between the API server and FLP instances.
+
+These resource consumption patterns become particularly pronounced in clusters with:
+
+* High pod churn rates where applications frequently scale up and down
+* Large numbers of namespaces and services
+* Multiple FLP instances deployed to handle high network traffic volumes

--- a/modules/network-observability-flowlogs-pipeline-scaling-shared-cache-cluster-stability.adoc
+++ b/modules/network-observability-flowlogs-pipeline-scaling-shared-cache-cluster-stability.adoc
@@ -1,0 +1,48 @@
+//Module included in the following assemblies:
+//
+// network_observability/network-observability-scaling.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="network-observability-flowlogs-pipeline-scaling-shared-cache-cluster-stability_{context}"]
+= How the shared cache improves cluster stability
+
+[role="_abstract"]
+The Flow-logs Pipeline shared cache architecture improves cluster stability and performance in large-scale deployments by centralizing metadata retrieval.
+
+In the default deployment model, each Flow-logs Pipeline (FLP) instance independently queries the Kubernetes API server to enrich network flows with cluster metadata, such as pod names and labels. At scale, this can result in a high volume of redundant requests that impact the API server performance.
+
+When you enable the shared cache, a centralized component queries the API server and shares the cached metadata with all FLP instances.
+
+[id="shared-cache-performance-benefits_{context}"]
+== Performance benefits
+Based on internal benchmarks, using the shared cache architecture can provide the following resource savings for FLP pods:
+
+* Reductions of up to 42% in CPU usage.
+* Reductions of up to 23% in memory footprint.
+
+[id="shared-cache-high-availability_{context}"]
+== High availability with leader election
+
+The shared cache architecture uses leader election to ensure continuous operation when multiple replicas are deployed. Among the cache replicas, one pod is elected as the active leader that queries the Kubernetes API server and distributes updates. The remaining replicas remain on standby.
+
+If the leader pod fails or is terminated, the remaining replicas automatically elect a new leader, typically within seconds. During this transition, flow enrichment continues using cached metadata, though new resource changes might not be reflected until the new leader is established.
+
+The operator enforces a minimum of 2 replicas to ensure high availability. Deploying only a single replica creates a single point of failure where flow enrichment would be lost if that pod becomes unavailable.
+
+[id="when-to-use-shared-cache_{context}"]
+== When to use the shared cache
+
+Enable the shared cache architecture in environments with any of the following characteristics:
+
+* High pod churn rates where applications scale frequently.
+* Large numbers of namespaces and services.
+* Multiple FLP instances deployed to handle high network traffic volumes.
+
+[id="shared-cache-considerations_{context}"]
+== Considerations
+
+Before modifying the shared cache configuration, consider the following trade-offs:
+
+* Data freshness: There might be a minor delay in flow enrichment updates as metadata propagates from the API server through the cache to the FLP instances.
+* Cluster-wide memory: While individual FLP pods consume fewer resources, the addition of shared cache replicas increases the total memory allocated to the network observability namespace.
+* Port allocation: The shared cache uses port 9090 for internal gRPC communication. This port allocation moved the default FLP metrics port from 9090 to 9401.

--- a/modules/network-observability-flowlogs-pipeline-shared-cache-parameters.adoc
+++ b/modules/network-observability-flowlogs-pipeline-shared-cache-parameters.adoc
@@ -1,0 +1,56 @@
+//Module included in the following assemblies:
+//
+// network_observability/network-observability-scaling.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="network-observability-flowlogs-pipeline-shared-cache-parameters_{context}"]
+= Shared cache configuration parameters
+
+[role="_abstract"]
+Use the `FlowCollector` informer parameters to configure how the Flowlogs Pipeline queries metadata from the Kubernetes API server, including cache settings and resource selection.
+
+[NOTE]
+====
+The shared cache feature uses centralized Kubernetes informers. Configure this feature in the `spec.processor.informers` field of the `FlowCollector` custom resource.
+====
+
+.Shared cache parameters
+[cols="3,2,2,5",options="header"]
+|===
+|Parameter |Type |Default |Description
+
+|`enabled`
+|Boolean
+|`true`
+|Enables the shared cache architecture to centralize Kubernetes API metadata retrieval. When enabled, a dedicated `flp-informers` deployment queries the Kubernetes API server and distributes cached metadata to all Flow-logs Pipeline instances via gRPC on port 9090.
+
+|`replicas`
+|Integer
+|`2`
+|The number of shared cache pods to deploy. The minimum value is `2` to ensure high availability with leader election. The operator enforces this requirement.
+
+|`resources`
+|Object
+|See FlowCollector API
+|Configures CPU and memory resource requests and limits for the shared cache pods. Specify `requests.cpu`, `requests.memory`, `limits.cpu`, and `limits.memory` according to your cluster size and performance requirements.
+
+|`advanced.resyncInterval`
+|Duration
+|Kubernetes default
+|The interval at which the shared cache performs a full resynchronization with the Kubernetes API server to ensure cache consistency.
+
+|`advanced.batchSize`
+|Integer
+|Operator default
+|The number of cache update events to batch together before sending to Flow-logs Pipeline instances. Larger batches improve efficiency but increase latency for metadata updates.
+
+|`advanced.sendTimeout`
+|Duration
+|Operator default
+|The maximum time to wait when sending cache updates to Flow-logs Pipeline instances. If a send operation exceeds this timeout, the update is retried.
+
+|`advanced.updateBufferSize`
+|Integer
+|Operator default
+|The size of the internal buffer queue for cache updates. Increase this value in high-churn environments where Kubernetes resources change frequently.
+|===

--- a/observability/network_observability/network-observability-optimizing-flowlogs-pipeline.adoc
+++ b/observability/network_observability/network-observability-optimizing-flowlogs-pipeline.adoc
@@ -1,0 +1,21 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="network-observability-optimizing-flowlogs-pipeline_{context}"]
+= Optimizing flowlogs-pipeline resource consumption in large clusters
+include::_attributes/common-attributes.adoc[]
+:context: optimizing-flowlogs-pipeline
+
+
+toc::[]
+
+[role="_abstract"]
+Use the shared cache architecture to reduce Kubernetes API server load and resource consumption in large-scale `flowlogs-pipeline` deployments while maintaining network flow visibility.
+
+include::modules/network-observability-flowlogs-pipeline-scaling-large-scale-deployment-challenges.adoc[leveloffset=+1]
+
+include::modules/network-observability-flowlogs-pipeline-scaling-shared-cache-cluster-stability.adoc[leveloffset=+1]
+
+include::modules/network-observability-flowlogs-pipeline-reducing-api-server-load-in-large-clusters.adoc[leveloffset=+1]
+
+include::modules/network-observability-flowlogs-pipeline-shared-cache-parameters.adoc[leveloffset=+1]
+
+include::modules/network-observability-flowlogs-pipeline-resolving-shared-cache-performance-issues.adoc[leveloffset=+1]

--- a/observability/network_observability/network-observability-optimizing-flowlogs-pipeline.adoc
+++ b/observability/network_observability/network-observability-optimizing-flowlogs-pipeline.adoc
@@ -1,5 +1,5 @@
 :_mod-docs-content-type: ASSEMBLY
-[id="network-observability-optimizing-flowlogs-pipeline_{context}"]
+[id="network-observability-optimizing-flowlogs-pipeline"]
 = Optimizing flowlogs-pipeline resource consumption in large clusters
 include::_attributes/common-attributes.adoc[]
 :context: optimizing-flowlogs-pipeline


### PR DESCRIPTION
[OSDOCS-19150](https://redhat.atlassian.net/browse/OSDOCS-19150) [NETOBSERV] 1.12 FLP Enhancements

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
Merge into `no-2.0` only. No cherry-picks are required.

Issue:
https://redhat.atlassian.net/browse/OSDOCS-19150

Link to docs preview:
* Optimizing FLP resource consumption: https://110637--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/network-observability-optimizing-flowlogs-pipeline.html
* Performance challenges in large-scale environments: https://110637--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/network-observability-optimizing-flowlogs-pipeline.html#network-observability-flowlogs-pipeline-scaling-large-scale-deployment-challenges_network-observability-optimizing-flowlogs-pipeline
* API server load at scale: https://110637--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/network-observability-optimizing-flowlogs-pipeline.html#api-server-load-at-scale_network-observability-optimizing-flowlogs-pipeline
* Resource consumption patterns: https://110637--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/network-observability-optimizing-flowlogs-pipeline.html#resource-consumption-patterns_network-observability-optimizing-flowlogs-pipeline
* How shared cache improves cluster stability: https://110637--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/network-observability-optimizing-flowlogs-pipeline.html#network-observability-flowlogs-pipeline-scaling-shared-cache-cluster-stability_network-observability-optimizing-flowlogs-pipeline
* Performance benefits: https://110637--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/network-observability-optimizing-flowlogs-pipeline.html#shared-cache-performance-benefits_network-observability-optimizing-flowlogs-pipeline
* High availability with leader election: https://110637--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/network-observability-optimizing-flowlogs-pipeline.html#shared-cache-high-availability_network-observability-optimizing-flowlogs-pipeline
* When to use the shared cache: https://110637--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/network-observability-optimizing-flowlogs-pipeline.html#when-to-use-shared-cache_network-observability-optimizing-flowlogs-pipeline
* Considerations: https://110637--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/network-observability-optimizing-flowlogs-pipeline.html#shared-cache-considerations_network-observability-optimizing-flowlogs-pipeline
* Reducing API server load in large clusters: https://110637--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/network-observability-optimizing-flowlogs-pipeline.html#network-observability-flowlogs-pipeline-reducing-api-server-load-in-large-clusters_network-observability-optimizing-flowlogs-pipeline
* Shared cache configuration parameters: https://110637--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/network-observability-optimizing-flowlogs-pipeline.html#network-observability-flowlogs-pipeline-shared-cache-parameters_network-observability-optimizing-flowlogs-pipeline
* Resolving shared cache performance issues: https://110637--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/network-observability-optimizing-flowlogs-pipeline.html#network-observability-flowlogs-pipeline-resolving-shared-cache-performance-issues_network-observability-optimizing-flowlogs-pipeline

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
* A separate PR for all `no-2.0` content will be created, and then merged into `main`.
   * Note to self: `no-2.0` integration PR applies to 4.12, 4.14, 4.16+
* Follows JTBD.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
