### PR TITLE
[enterprise-4.17] NO-JIRA: Fix the "Enabling USB host passthrough" wrong procedure

### DIFF
--- a/modules/virt-enabling-usb-host-passthrough.adoc
+++ b/modules/virt-enabling-usb-host-passthrough.adoc
@@ -75,55 +75,39 @@ Device: 3-7
   Product ID: 0a60
 ----
 
-. Add the required USB device to the `permittedHostDevices` stanza of the `HyperConvered` CR. The following example adds a device with vendor ID `045e` and product ID `07a5`: 
+
+. Open the `HyperConverged` CR in your default editor by running the following command:
 +
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
-oc patch hyperconverged kubevirt-hyperconverged \
-  -n openshift-cnv \
-  --type=merge \
-  -p '{
-    "metadata": {
-      "annotations": {
-        "kubevirt.kubevirt.io/jsonpatch": "[{\"op\": \"add\", \"path\": \"/spec/permittedHostDevices/usbHostDevices/-\", \"value\": {\"resourceName\": \"kubevirt.io/peripherals\", \"selectors\": [{\"vendor\": \"045e\", \"product\": \"07a5\"}]}}]"
-      }
-    }
-  }'
+$ oc edit hyperconverged kubevirt-hyperconverged -n {CNVNamespace}
 ----
 
-.Verification
 
-* Ensure that the `HyperConverged` CR contains the required USB devices:
+. Add the required USB device to the `permittedHostDevices` stanza of the `HyperConvered` CR. The following example adds a device with vendor ID `045e` and product ID `07a5`:
 +
-[source,terminal]
-----
-$ oc get hyperconverged kubevirt-hyperconverged -n openshift-cnv
-----
-+
-*Example output*
-+
-[source,yaml,subs="attributes+"]
+[source,yaml,highlight=11..12,subs="attributes+"]
 ----
 apiVersion: hco.kubevirt.io/v1beta1
 kind: HyperConverged
 metadata:
-   name: kubevirt-hyperconverged
-   namespace: {CNVNamespace}
+  name: kubevirt-hyperconverged
+  namespace: {CNVNamespace}
 spec:
-  configuration:
-    permittedHostDevices: <1>
-      usbHostDevices: <2>
-        - resourceName: kubevirt.io/peripherals <3>
-          selectors:
-            - vendor: "045e"
-              product: "07a5"
-            - vendor: "062a"
-              product: "4102"
-            - vendor: "072f"
-              product: "b100"
-
+    permittedHostDevices:
+      usbHostDevices:
+        - resourceName: kubevirt.io/peripherals
+      selectors:
+      - vendor: "045e"
+        product: "07a5"
+      - vendor: "062a"
+        product: "4102"
+      - vendor: "072f"
+        product: "b100"
 ----
 +
 * `spec.permittedHostDevices` defines the host devices that have permission to be used in the cluster.
-* `spec.permittedHostDevices.usbHostDevices` defines the available USB devices.
-* Use `resourceName: deviceName` for each device you want to add and assign to the VM. In this example, the resource is bound to three devices, each of which is identified by `vendor` and `product` and is known as a `selector`.
+* `spec.permittedHostDevices.usbHostDevices` defines a list of available USB devices.
+* `spec.permittedHostDevices.usbHostDevices.resourceName` defines the USB device that you want to add and assign to the
+  VM. In this example, the resource is bound to three devices, each of which is identified by `vendor` and `product` and
+  is known as a `selector`.


### PR DESCRIPTION
The current "Enabling USB host passthrough procedure" is wrong in three ways:

* First, it uses the HyperConverged jsonpatch anntoation, which is not formally supported, and is should only be use as last resort, while the HyperConverged type contain the fields to implement the procedure in a supported way.
* Using the jsonpatch annotation, triggers an alert!
* In addition, the verification phase is also wrong, as it checks the HyperConverged CR instead of the KubeVirt CR.

Version(s):
v4.17

Original PR https://github.com/openshift/openshift-docs/pull/110064