### PR TITLE
[standalone-logging-docs-6.0] OBSDOCS-3326 Manual CP: CQA + DITA readiness for assemblies and modules under v6.0 "Upgrading" section.

### DIFF
--- a/modules/changes-in-logging-6.adoc
+++ b/modules/changes-in-logging-6.adoc
@@ -1,0 +1,30 @@
+// Module included in the following assemblies:
+//
+// * upgrading/upgrading-to-logging-6
+
+:_mod-docs-content-type: REFERENCE
+[id="changes-in-logging-6_{context}"]
+= An overview of changes in Logging 6
+
+[role="_abstract"]
+{LoggingProductName} 6 is a significant upgrade from earlier releases, achieving several longstanding goals of Cluster Logging.
+
+The notable changes include:
+
+Introduction of distinct Operators to manage logging components::
+
+* {clo} manages both collection and forwarding.
+* {loki-op} manages storage.
+* {coo-first} manages visualization.
+
+Removal of support for managed log storage and visualization based on Elastic products::
+
+* Elasticsearch is replaced with Loki.
+* Kibana is replaced with the UIplugin provided by {coo-short}.
+
+Removal of the Fluentd log collector implementation::
+Vector is now the supported collection service.
+
+API change for log collection and forwarding::
+* The API for log collection is changed from `logging.openshift.io` to `observability.openshift.io`.
+* `ClusterLogForwarder` and `ClusterLogging` have been combined under the `ClusterLogForwarder` resource in the new API.

--- a/modules/changes-to-cluster-logging-and-forwarding-in-logging-6.adoc
+++ b/modules/changes-to-cluster-logging-and-forwarding-in-logging-6.adoc
@@ -5,7 +5,8 @@
 [id="changes-to-cluster-logging-and-forwarding-in-logging-6_{context}"]
 = Changes to cluster logging and forwarding in Logging 6
 
-Log collection and forwarding configurations are now specified under the new link:https://github.com/openshift/cluster-logging-operator/blob/master/docs/reference/operator/api_observability_v1.adoc[API], part of the `observability.openshift.io` API group. The following sections highlight the differences from the old API resources.
+[role="_abstract"]
+Log collection and forwarding configurations are now specified under the new API, part of the `observability.openshift.io` API group. The following sections highlight the differences from the old API resources.
 
 [NOTE]
 ====
@@ -17,7 +18,8 @@ Vector is the only supported collector implementation.
 
 Configuration for management state, resource requests and limits, tolerations, and node selection is now part of the new `ClusterLogForwarder` API.
 
-.Logging 5.x configuration
+The following example displays a Logging 5.x configuration: 
+
 [source,yaml]
 ----
 apiVersion: "logging.openshift.io/v1"
@@ -32,7 +34,8 @@ spec:
     tolerations: {}
 ----
 
-.Logging 6 configuration
+The following example displays a Logging 6 configuration:
+
 [source,yaml]
 ----
 apiVersion: "observability.openshift.io/v1"
@@ -54,7 +57,8 @@ The input specification is an optional part of the `ClusterLogForwarder` specifi
 
 Namespace and container inclusions and exclusions have been consolidated into a single field.
 
-.5.x application input with namespace and container includes and excludes
+The following example displays 5.x application input with namespace and container includes and excludes:
+
 [source,yaml]
 ----
 apiVersion: "logging.openshift.io/v1"
@@ -74,7 +78,8 @@ spec:
        - container: too-verbose
 ----
 
-.6.x application input with namespace and container includes and excludes
+The following example displays 6.x application input with namespace and container includes and excludes:
+
 [source,yaml]
 ----
 apiVersion: "observability.openshift.io/v1"
@@ -103,7 +108,8 @@ Changes to input receivers include:
 * Explicit configuration of the type at the receiver level.
 * Port settings moved to the receiver level.
 
-.5.x input receivers
+The following example displays 5.x input receivers:
+
 [source,yaml]
 ----
 apiVersion: "logging.openshift.io/v1"
@@ -122,7 +128,8 @@ spec:
         port: 9442
 ----
 
-.6.x input receivers
+The following example displays 6.x input receivers:
+
 [source,yaml]
 ----
 apiVersion: "observability.openshift.io/v1"
@@ -158,7 +165,8 @@ High-level changes to output specifications include:
 
 Secrets and TLS configurations are now separated into authentication and TLS configuration for each output. They must be explicitly defined in the specification rather than relying on administrators to define secrets with recognized keys. Upgrading TLS and authorization configurations requires administrators to understand previously recognized keys to continue using existing secrets. The examples in this section illustrate how to configure `ClusterLogForwarder` secrets to forward to existing Red{nbsp}Hat managed log storage solutions.
 
-.Logging 6.x output configuration using service account token and config map
+The following example displays Logging 6.x output configuration by using service account token and config map:
+
 [source,yaml]
 ----
 ...
@@ -180,7 +188,8 @@ spec:
 ...
 ----
 
-.Logging 6.x output authentication and TLS configuration using secrets
+The following example displays Logging 6.x output authentication and TLS configuration by using secrets:
+
 [source,yaml]
 ----
 ...
@@ -215,7 +224,8 @@ spec:
 
 All attributes of pipelines in previous releases have been converted to filters in this release. Individual filters are defined in the `filters` spec and referenced by a pipeline.
 
-.5.x filters
+The following example displays 5.x filters:
+
 [source,yaml]
 ----
 ...
@@ -229,7 +239,8 @@ spec:
 ...
 ----
 
-.6.x filters and pipelines spec
+The following example displays 6.x filters and pipelines spec:
+
 [source,yaml]
 ----
 ...
@@ -261,10 +272,10 @@ spec:
 
 Most validations are now enforced when a resource is created or updated which provides immediate feedback. This is a departure from previous releases where all validation occurred post creation requiring inspection of the resource status location. Some validation still occurs post resource creation for cases where is not possible to do so at creation or update time.
 
-Instances of the `ClusterLogForwarder.observability.openshift.io` resource must satisfy the following conditions before the operator deploys the log collector:
+Instances of the `ClusterLogForwarder.observability.openshift.io` resource must satisfy the following conditions before the Operator deploys the log collector:
 
 * Resource status conditions: Authorized, Valid, Ready
 
-* Spec validations: Filters, Inputs, Outputs, Pipelines
+* spec validations: Filters, Inputs, Outputs, Pipelines
 
 All must evaluate to the status value of `True`.

--- a/modules/checking-update-readiness-of-clo.adoc
+++ b/modules/checking-update-readiness-of-clo.adoc
@@ -2,10 +2,7 @@
 //
 // * upgrading/updating-openshift-logging
 
-:_newdoc-version: 2.18.4
-:_template-generated: 2026-02-06
 :_mod-docs-content-type: PROCEDURE
-
 [id="checking-update-readiness-of-clo_{context}"]
 = Checking update readiness of {clo}
 
@@ -40,7 +37,8 @@ Ensure that no upgrade-blocking alerts are listed.
 $ oc get pod -l app.kubernetes.io/component=collector -A
 ----
 +
-.Example output
+You get an output similar to the following example:
++
 [source,options="nowrap"]
 ----
 NAMESPACE           NAME             READY   STATUS    RESTARTS   AGE

--- a/modules/checking-update-readiness-of-loki-operator.adoc
+++ b/modules/checking-update-readiness-of-loki-operator.adoc
@@ -2,10 +2,7 @@
 //
 // * upgrading/updating-openshift-logging
 
-:_newdoc-version: 2.18.4
-:_template-generated: 2026-02-06
 :_mod-docs-content-type: PROCEDURE
-
 [id="checking-update-readiness-of-loki-operator_{context}"]
 = Checking update readiness of {loki-op}
 
@@ -40,7 +37,8 @@ Ensure that no upgrade-blocking alerts are listed.
 $ oc get pods -l app.kubernetes.io/managed-by=lokistack-controller -n openshift-logging
 ----
 +
-.Example output
+You get an output similar to the following example:
++
 [options="nowrap"]
 ----
 NAME                                          READY   STATUS    RESTARTS   AGE

--- a/modules/deleting-red-hat-openshift-logging-5-crd.adoc
+++ b/modules/deleting-red-hat-openshift-logging-5-crd.adoc
@@ -1,12 +1,13 @@
-:_newdoc-version: 2.18.4
-:_template-generated: 2025-06-03
-:_mod-docs-content-type: PROCEDURE
+// Module included in the following assemblies:
+//
+// * upgrading/upgrading-to-logging-6
 
+:_mod-docs-content-type: PROCEDURE
 [id="deleting-red-hat-openshift-logging-5-crds_{context}"]
 = Deleting Red{nbsp}Hat OpenShift Logging 5 CRD
 
+[role="_abstract"]
 Delete Red{nbsp}Hat OpenShift Logging 5 custom resource definitions (CRD) when upgrading to Logging 6.
-
 
 .Prerequisites
 * You have administrator permissions.

--- a/modules/deleting-the-clusterlogging-instance.adoc
+++ b/modules/deleting-the-clusterlogging-instance.adoc
@@ -1,18 +1,20 @@
-:_newdoc-version: 2.18.4
-:_template-generated: 2025-06-03
-:_mod-docs-content-type: PROCEDURE
+// Module included in the following assemblies:
+//
+// * upgrading/upgrading-to-logging-6
 
+:_mod-docs-content-type: PROCEDURE
 [id="deleting-the-clusterlogging-instance_{context}"]
 = Deleting the ClusterLogging instance
 
-Delete the ClusterLogging instance because it is no longer needed in Logging 6.x.
+[role="_abstract"]
+Delete the `ClusterLogging` instance because it is no longer needed in Logging 6.x.
 
 .Prerequisites
 * You have administrator permissions.
 * You installed the {oc-first}.
 
 .Procedure
-* Delete the ClusterLogging instance.
+* Delete the `ClusterLogging` instance by running the following command:
 +
 [source,terminal]
 ----

--- a/modules/deleting-the-logging-view-plugin.adoc
+++ b/modules/deleting-the-logging-view-plugin.adoc
@@ -1,11 +1,13 @@
-:_newdoc-version: 2.18.4
-:_template-generated: 2025-06-03
-:_mod-docs-content-type: PROCEDURE
+// Module included in the following assemblies:
+//
+// * upgrading/upgrading-to-logging-6
 
+:_mod-docs-content-type: PROCEDURE
 [id="deleting-the-logging-view-plugin_{context}"]
 = Deleting the logging view plugin
 
-When updating from Logging 5 to Logging 6, delete the logging view plugin before installing the UIPlugin.
+[role="_abstract"]
+When you update from Logging 5 to Logging 6, delete the logging view plugin before installing the `UIPlugin`.
 
 .Prerequisites
 * You have administrator permissions.

--- a/modules/installing-the-logging-ui-plug-in-gui.adoc
+++ b/modules/installing-the-logging-ui-plug-in-gui.adoc
@@ -3,13 +3,11 @@
 // * installing/installing-logging.adoc
 // * upgrading/upgrading-to-logging-60.adoc
 
-:_newdoc-version: 2.18.4
-:_template-generated: 2025-04-18
 :_mod-docs-content-type: PROCEDURE
-
 [id="installing-the-logging-ui-plugin_gui{context}"]
 = Installing the logging UI plugin by using the web console
 
+[role="_abstract"]
 Install the logging UI plugin by using the web console so that you can visualize logs.
 
 .Prerequisites
@@ -18,32 +16,36 @@ Install the logging UI plugin by using the web console so that you can visualize
 * You installed and configured {loki-op}.
 
 .Procedure
-. Install the {coo-full}. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_cluster_observability_operator/{coo-version}/html/installing_red_hat_openshift_cluster_observability_operator/installing-the-cluster-observability-operator[Installing the Cluster Observability Operator].
+. Install the {coo-full}.
 
 . Navigate to the *Installed Operators* page. Under *Provided APIs*, select *ClusterObservabilityOperator*. Find the `UIPlugin` resource and click *Create Instance*.
 
 . Select the YAML view, and then use the following template to create a `UIPlugin` custom resource (CR):
 +
-.Example `UIPlugin` CR
+The following example displays a `UIPlugin` CR:
++
 [source,yaml]
 ----
 apiVersion: observability.openshift.io/v1alpha1
 kind: UIPlugin
 metadata:
-  name: logging  # <1>
+  name: logging
 spec:
-  type: Logging  # <2>
+  type: Logging
   logging:
     lokiStack:
-      name: logging-loki  # <3>
+      name: logging-loki
     logsLimit: 50
     timeout: 30s
-    schema: otel # <4>
+    schema: otel
 ----
-<1> Set `name` to `logging`.
-<2> Set `type` to `Logging`.
-<3> The `name` value must match the name of your LokiStack instance. If you did not install LokiStack in the `openshift-logging` namespace, set the LokiStack namespace under the `lokiStack` configuration.
-<4> `schema` is one of `otel`, `viaq`, or `select`. The default is `viaq` if no value is specified. When you choose `select`, you can select the mode in the UI when you run a query.
+
+Where:
+
+* `name: logging`:  Set `name` to `logging`.
+* `type: Logging`: Set `type` to `Logging`.
+* `name: logging-loki`: The `name` value must match the name of your LokiStack instance. If you did not install LokiStack in the `openshift-logging` namespace, set the LokiStack namespace under the `lokiStack` configuration.
+* `schema: otel`: `schema` is one of `otel`, `viaq`, or `select`. The default is `viaq` if no value is specified. When you choose `select`, you can select the mode in the UI when you run a query.
 +
 [NOTE]
 ====
@@ -58,4 +60,4 @@ These are the known issues for the logging UI plugin - for more information, see
 
 .Verification
 . Refresh the page when a pop-up message instructs you to do so.
-. Navigate to the *Observe → Logs* panel, where you can run LogQL queries. You can also query logs for individual pods from the *Aggregated Logs* tab of a specific pod.
+. Navigate to the *Observe → Logs* panel, where you can run `LogQL` queries. You can also query logs for individual pods from the *Aggregated Logs* tab of a specific pod.

--- a/modules/logging-checking-update-readiness.adoc
+++ b/modules/logging-checking-update-readiness.adoc
@@ -1,0 +1,10 @@
+// Module included in the following assemblies:
+//
+// * upgrading/updating-openshift-logging
+
+:_mod-docs-content-type: CONCEPT
+[id="logging-checking-update-readiness_{context}"]
+= Checking update readiness
+
+[role="_abstract"]
+You can check the readiness of installed Operators before updating {logging-title-uc}. You can verify the status of the {clo} and the {loki-op} to ensure a safe update.

--- a/modules/logging-deleting-old-resources.adoc
+++ b/modules/logging-deleting-old-resources.adoc
@@ -1,0 +1,10 @@
+// Module included in the following assemblies:
+//
+// * upgrading/upgrading-to-logging-6
+
+:_mod-docs-content-type: REFERENCE
+[id="logging-deleting-old-resources_{context}"]
+= Deleting old resources
+
+[role="_abstract"]
+Remove existing Logging 5 resources after the upgrade by deleting the `ClusterLogging` instance, related CRDs, and Elasticsearch.

--- a/modules/logging-update-considerations.adoc
+++ b/modules/logging-update-considerations.adoc
@@ -1,0 +1,52 @@
+// Module included in the following assemblies:
+//
+// * upgrading/updating-openshift-logging
+
+:_mod-docs-content-type: CONCEPT
+[id="logging-update-considerations_{context}"]
+= Understanding {LoggingProductName} update considerations
+
+[role="_abstract"]
+Learn the key considerations, constraints, and supported update paths for {logging-title-uc}. This information helps you plan safe and supported updates based on your installed Operators.
+
+{logging-title-uc} update considerations:
+
+* If you are on an Extended Update Support (EUS) release of {logging-title-uc}, it is recommended to update to an EUS release.
+
+* You must update the {clo} and the {loki-op} to the same major and minor version.
+
+* The maximum supported update channel for {loki-op} is the N+2 version, where N is your current version. Updating to a version that is more than two versions newer is not supported.
+
+You only need to update the Operators for {logging-title-uc} that you have installed. The following list describes the high-level steps for updating {logging-title-uc}.
+
+Only the {clo} is installed::
+
+. Check the update readiness for the {clo}.
+. Update the {clo}.
+
+The {clo} and the {loki-op} are installed::
+
+Update the Operators in the following order:
++
+[IMPORTANT]
+====
+You must update the {clo} and the {loki-op} to the same channel.
+====
+
+. Check the update readiness for both the {loki-op} and the {clo}.
+. Update the {loki-op}.
+. Update the {clo}.
+
+The {clo}, the {loki-op}, and {coo-first} are installed::
+
+Update the Operators in the following order:
++
+[IMPORTANT]
+====
+You must update the {clo} and the {loki-op} to the same channel. 
+====
+
+. Check the update readiness for both the {loki-op} and the {clo}.
+. Update the {loki-op}.
+. Update the {clo}.
+. Update the {coo-first}.

--- a/modules/logging-upgrading-clo.adoc
+++ b/modules/logging-upgrading-clo.adoc
@@ -6,7 +6,8 @@
 [id="logging-upgrading-clo_{context}"]
 = Updating the {clo}
 
-The {clo} does not provide an automated upgrade from Logging 5.x to Logging 6.x because of the different combinations in which Logging can be configured. You must install all the different operators for managing logging separately.
+[role="_abstract"]
+The {clo} does not provide an automated upgrade from Logging 5.x to Logging 6.x because of the different combinations in which Logging can be configured. You must install all the different Operators for managing logging separately.
 
 You can update {clo} by either changing the subscription channel in the {ocp-product-title} web console, or by uninstalling it. The following procedure demonstrates updating {clo} by changing the subscription channel in the {ocp-product-title} web console.
 
@@ -23,7 +24,7 @@ When you migrate, all the logs that have not been compressed will be reprocessed
 
 .Prerequisites
 
-* You have updated the log collection and forwarding configurations to the link:https://github.com/openshift/cluster-logging-operator/blob/master/docs/reference/operator/api_observability_v1.adoc[`observability.openshift.io`] API.
+* You have updated the log collection and forwarding configurations to the `observability.openshift.io` API.
 * You have administrator permissions.
 * You have access to the {ocp-product-title} web console and are viewing the *Administrator* perspective.
 
@@ -70,16 +71,10 @@ $ oc adm policy add-cluster-role-to-user collect-audit-logs -z logging-collector
 ----
  $ oc adm policy add-cluster-role-to-user collect-infrastructure-logs -z logging-collector -n openshift-logging
 ----
-+
-////
-. Transfom the current configuration to the new API in Logging 6.
-+
-For more information, see link:[Changes to Cluster logging and forwarding in Logging 6].
-////
 
 . Move Vector checkpoints to the new path.
 +
-The Vector checkpoints in Logging v5 are located at the path `/var/lib/vector/input*/checkpoints.json`. Move these checkpoints to the path `/var/lib/vector/<namespace>/<clusterlogforwarder cr name>/*`. The following example uses `openshift-logging` as the namespace and `collector` as the ClusterForwarder custom resource name. 
+The Vector checkpoints in Logging v5 are located at the path `/var/lib/vector/input*/checkpoints.json`. Move these checkpoints to the path `/var/lib/vector/<namespace>/<clusterlogforwarder cr name>/*`. The following example uses `openshift-logging` as the namespace and `collector` as the `ClusterForwarder` custom resource name. 
 +
 [source,terminal]
 ----
@@ -110,4 +105,4 @@ Only update to an N+2 version, where N is your current version. For example, if 
 
 .. On the *Operators* -> *Installed Operators* page, wait for the *Status* field to report *Succeeded*.
 +
-Your existing Logging v5 resources will continue to run, but are no longer managed by your operator. These unmanaged resources can be removed once your new resources are ready to be created. 
+Your existing Logging v5 resources will continue to run, but are no longer managed by your Operator. These unmanaged resources can be removed once your new resources are ready to be created. 

--- a/modules/logging-upgrading-loki-schema.adoc
+++ b/modules/logging-upgrading-loki-schema.adoc
@@ -6,6 +6,7 @@
 [id="logging-upgrading-loki-schema_{context}"]
 = Upgrading the LokiStack storage schema
 
+[role="_abstract"]
 If you are using the {clo} with the {loki-op}, the {clo} supports the `v13` schema version in the `LokiStack` custom resource. Adding the `v13` schema version is recommended because it is the schema version to be supported going forward. The schema will be upgraded to `v13` when the date matches the value defined in the `effectiveDate` attribute.
 
 .Procedure
@@ -22,13 +23,16 @@ spec:
   storage:
     schemas:
     # ...
-      version: v12 # <1>
-    - effectiveDate: "<yyyy>-<mm>-<future_dd>" # <2>
+      version: v12
+    - effectiveDate: "<yyyy>-<mm>-<future_dd>"
       version: v13
 # ...
 ----
-<1> Do not delete this line so that the data persists in its original schema version. Deleting the previous schema versions might lead to data loss.
-<2> Set a future date that has not yet started in the Coordinated Universal Time (UTC) time zone format.
+
+Where:
+
+* `version: v12`: Do not delete this line so that the data persists in its original schema version. Deleting the previous schema versions might lead to data loss.
+* `effectiveDate: "<yyyy>-<mm>-<future_dd>`: Set a future date that has not yet started in the Coordinated Universal Time (UTC) time zone format.
 +
 [TIP]
 ====

--- a/modules/logging-upgrading-loki.adoc
+++ b/modules/logging-upgrading-loki.adoc
@@ -6,7 +6,8 @@
 [id="logging-upgrading-loki_{context}"]
 = Updating the {loki-op}
 
-To update the {loki-op} to a new major release version, you must modify the update channel for the Operator subscription.
+[role="_abstract"]
+To update the {loki-op} to a new major release version, you must change the update channel for the Operator subscription.
 
 .Prerequisites
 
@@ -35,6 +36,4 @@ Only update to an N+2 version, where N is your current version. For example, if 
 
 . On the *Operators* -> *Installed Operators* page, wait for the *Status* field to report *Succeeded*.
 
-. Check whether the `LokiStack` custom resource contains the `v13` schema version.
-If the `v13` schema version is missing, add it.
-For information about adding the `v13` schema version, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_logging/{logging-major-version}/html/upgrading_logging/upgrading-to-logging-6#logging-upgrading-loki-schema_upgrading-to-logging-6[Upgrading the LokiStack storage schema].
+. Check whether the `LokiStack` custom resource has the `v13` schema version. If the `v13` schema version is missing, add it.

--- a/modules/migrating-logging-virtualization.adoc
+++ b/modules/migrating-logging-virtualization.adoc
@@ -1,0 +1,10 @@
+// Module included in the following assemblies:
+//
+// * upgrading/upgrading-to-logging-6
+
+:_mod-docs-content-type: REFERENCE
+[id="migrating-logging-virtualization_{context}"]
+= Migrating logging visualization
+
+[role="_abstract"]
+The OpenShift console UI plugin for log visualization moved from the Cluster Logging Operator to the {coo-full}.

--- a/modules/migrating-storage-from-elasticsearch-to-lokistack.adoc
+++ b/modules/migrating-storage-from-elasticsearch-to-lokistack.adoc
@@ -1,11 +1,13 @@
-:_newdoc-version: 2.18.4
-:_template-generated: 2025-06-03
-:_mod-docs-content-type: PROCEDURE
+// Module included in the following assemblies:
+//
+// * upgrading/upgrading-to-logging-6
 
+:_mod-docs-content-type: PROCEDURE
 [id="migrating-storage-from-elasticsearch-to-lokistack_{context}"]
 = Migrating storage from Elasticsearch to LokiStack
 
-You can migrate your existing Red{nbsp}Hat managed Elasticsearch to LokiStack.
+[role="_abstract"]
+You can migrate your existing Red{nbsp}Hat managed Elasticsearch to `LokiStack`.
 
 .Prerequisites
 
@@ -38,7 +40,7 @@ The following command ensures that `ClusterLogging` no longer owns the `Kibana` 
 $ oc -n openshift-logging patch kibana/kibana -p '{"metadata":{"ownerReferences": []}}' --type=merge
 ----
 
-. Update cluster logging to use LokiStack as the log store:
+. Update cluster logging to use `LokiStack` as the log store:
 +
 [source,yaml]
 ----

--- a/modules/overview-steps-for-upgrading-logging-5-to-6.adoc
+++ b/modules/overview-steps-for-upgrading-logging-5-to-6.adoc
@@ -1,0 +1,18 @@
+// Module included in the following assemblies:
+//
+// * upgrading/upgrading-to-logging-6
+
+:_mod-docs-content-type: REFERENCE
+[id="overview-steps-for-upgrading-logging-5-to-6_{context}"]
+= An overview of steps for upgrading {LoggingProductName} 5 to 6
+
+[role="_abstract"]
+Learn the overall process for upgrading from {LoggingProductName} 5 to 6, including migration and resource updates.
+
+The broad steps are as follows: 
+
+. Ensure that you are not using any deprecated resources.
+. Migrate log visualization from Kibana to {coo-first}.
+. Upgrade log storage.
+. Upgrade log collection and forwarding.
+. Finally, delete resources that you no longer need.

--- a/modules/preparation-for-upgrading-to-logging-6.adoc
+++ b/modules/preparation-for-upgrading-to-logging-6.adoc
@@ -1,0 +1,16 @@
+// Module included in the following assemblies:
+//
+// * upgrading/upgrading-to-logging-6
+
+:_mod-docs-content-type: REFERENCE
+[id="preparation-for-upgrading-to-logging-6_{context}"]
+= Preparation for upgrading to Logging 6
+
+[role="_abstract"]
+Before being able to upgrade to Logging 6 from Logging 5, you must first ensure that you are not using any deprecated resources.
+
+Therefore, if you have not already, you must make the following migrations:
+
+* Migrate collection service from Fluentd to Vector.
+ 
+* Migrate storage from Elasticsearch to `LokiStack`.

--- a/modules/uninstalling-elasticsearch.adoc
+++ b/modules/uninstalling-elasticsearch.adoc
@@ -6,7 +6,8 @@
 [id="uninstall-es-operator_{context}"]
 = Uninstalling Elasticsearch
 
-You can uninstall Elasticsearch by using the {ocp-product-title} web console. Uninstall Elasticsearch only if it is not used for by component such as Jaeger, Service Mesh, or Kiali.
+[role="_abstract"]
+You can uninstall Elasticsearch by using the {ocp-product-title} web console. Uninstall Elasticsearch only if it is not used by a component such as Jaeger, Service Mesh, or Kiali.
 
 .Prerequisites
 

--- a/modules/updating-logging-by-using-cli.adoc
+++ b/modules/updating-logging-by-using-cli.adoc
@@ -1,0 +1,10 @@
+// Module included in the following assemblies:
+//
+// * upgrading/updating-openshift-logging
+
+:_mod-docs-content-type: CONCEPT
+[id="updating-logging-by-using-cli_{context}"]
+= Updating {LoggingProductName} by using the CLI
+
+[role="_abstract"]
+You can update {logging-title-uc} by using the CLI. You can follow the required sequence to update the {loki-op} and the {clo}.

--- a/modules/updating-logging-by-using-web-console.adoc
+++ b/modules/updating-logging-by-using-web-console.adoc
@@ -1,0 +1,10 @@
+// Module included in the following assemblies:
+//
+// * upgrading/updating-openshift-logging
+
+:_mod-docs-content-type: CONCEPT
+[id="updating-logging-by-using-web-console_{context}"]
+= Updating {LoggingProductName} by using the web console
+
+[role="_abstract"]
+You can update {logging-title-uc} by using the web console. You can follow the required sequence to update the {loki-op} and the {clo}.

--- a/modules/updating-the-clo-by-using-the-cli.adoc
+++ b/modules/updating-the-clo-by-using-the-cli.adoc
@@ -1,11 +1,13 @@
-:_newdoc-version: 2.18.4
-:_template-generated: 2026-02-02
-:_mod-docs-content-type: PROCEDURE
+// Module included in the following assemblies:
+//
+// * upgrading/updating-openshift-logging
 
+:_mod-docs-content-type: PROCEDURE
 [id="updating-the-clo-by-using-the-cli_{context}"]
 = Updating the {clo} by using the CLI
 
-To update the {clo} to a new version, modify the update channel for the Operator subscription.
+[role="_abstract"]
+To update the {clo} to a new version, change the update channel for the Operator subscription.
 
 .Prerequisites
 
@@ -21,7 +23,8 @@ To update the {clo} to a new version, modify the update channel for the Operator
 $ oc get subscription -n openshift-logging
 ----
 +
-.Example output
+You get an output similar to the following example:
++
 [source,options="nowrap"]
 ----
 NAME              PACKAGE           SOURCE             CHANNEL
@@ -51,7 +54,8 @@ Replace `<subscription_name>` with the subscription name obtained in the previou
 $ oc get installplan -n openshift-logging
 ----
 +
-.Example output
+You get an output similar to the following example:
++
 [options="nowrap"]
 ----
 NAME            CSV                      APPROVAL    APPROVED
@@ -70,14 +74,15 @@ Replace `<plan_name>` with the result obtained in the previous step.
 
 .Verification
 
-* Check the ClusterServiceVersion (CSV) in the namespace.
+* Check the `ClusterServiceVersion` (CSV) in the namespace.
 +
 [source,terminal]
 ----
 $ oc get csv -n openshift-logging | grep cluster-logging
 ----
 +
-.Example output
+You get an output similar to the following example:
++
 [subs="attributes",options="nowrap"]
 ----
 NAME                     DISPLAY                     VERSION   REPLACES                 PHASE

--- a/modules/updating-the-clo.adoc
+++ b/modules/updating-the-clo.adoc
@@ -2,14 +2,12 @@
 //
 // * upgrading/updating-logging.adoc
 
-:_newdoc-version: 2.18.4
-:_template-generated: 2026-01-06
 :_mod-docs-content-type: PROCEDURE
-
 [id="updating-the-clo_{context}"]
 = Updating the {clo}
 
-To update the {clo} to a new minor version, modify the update channel for the Operator subscription.
+[role="_abstract"]
+To update the {clo} to a new minor version, change the update channel for the Operator subscription.
 
 .Prerequisites
 

--- a/modules/updating-the-loki-operator-by-using-the-cli.adoc
+++ b/modules/updating-the-loki-operator-by-using-the-cli.adoc
@@ -1,11 +1,13 @@
-:_newdoc-version: 2.18.4
-:_template-generated: 2026-02-02
-:_mod-docs-content-type: PROCEDURE
+// Module included in the following assemblies:
+//
+// * upgrading/updating-openshift-logging
 
+:_mod-docs-content-type: PROCEDURE
 [id="updating-the-loki-operator-by-using-the-cli_{context}"]
 = Updating the {loki-op} by using the CLI
 
-To update the {loki-op} to a new version, modify the update channel for the Operator subscription.
+[role="_abstract"]
+To update the {loki-op} to a new version, change the update channel for the Operator subscription.
 
 .Prerequisites
 * You have checked readiness for update.
@@ -22,7 +24,8 @@ To update the {loki-op} to a new version, modify the update channel for the Oper
 $ oc get subscription -n openshift-operators-redhat
 ----
 +
-.Example output
+You get an output similar to the following example:
++
 [source,options="nowrap"]
 ----
 NAME            PACKAGE         SOURCE             CHANNEL
@@ -57,7 +60,8 @@ The maximum supported update channel is N+2 version, where N is your current ver
 $ oc get installplan -n openshift-operators-redhat
 ----
 +
-.Example output
+You get an output similar to the following example:
++
 [source,options="nowrap"]
 ----
 NAME            CSV                    APPROVAL    APPROVED
@@ -74,14 +78,15 @@ Replace `<plan_name>` with the result obtained in the previous step.
 
 .Verification
 
-* Check the ClusterServiceVersion (CSV) in the namespace.
+* Check the `ClusterServiceVersion` (CSV) in the namespace.
 +
 [source,terminal]
 ----
 $ oc get csv -n openshift-operators-redhat | grep loki-operator
 ----
 +
-.Example output
+You get an output similar to the following example:
++
 [subs="attributes",options="nowrap"]
 ----
 NAME                     DISPLAY                     VERSION   REPLACES                 PHASE

--- a/modules/updating-the-loki-operator.adoc
+++ b/modules/updating-the-loki-operator.adoc
@@ -6,7 +6,8 @@
 [id="updating-the-loki-operator_{context}"]
 = Updating the {loki-op}
 
-To update the {loki-op} to a new version, you must modify the update channel for the Operator subscription.
+[role="_abstract"]
+To update the {loki-op} to a new version, you must change the update channel for the Operator subscription.
 
 .Prerequisites
 
@@ -48,6 +49,4 @@ include::snippets/installed-operator-navigation.adoc[]
 
 . On the *Operators* > *Installed Operators* page, wait for the *Status* field to report *Succeeded*.
 
-. Check whether the `LokiStack` custom resource contains the `v13` schema version.
-If the `v13` schema version is missing, add it. 
-For information about adding the `v13` schema version, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_logging/{logging-major-version}/html/upgrading_logging/upgrading-to-logging-6#logging-upgrading-loki-schema_upgrading-to-logging-6[Upgrading the LokiStack storage schema].
+. Check whether the `LokiStack` custom resource has the `v13` schema version. If the `v13` schema version is missing, add it.

--- a/modules/upgrading-log-collection-and-forwarding.adoc
+++ b/modules/upgrading-log-collection-and-forwarding.adoc
@@ -1,0 +1,20 @@
+// Module included in the following assemblies:
+//
+// * upgrading/upgrading-to-logging-6
+
+:_mod-docs-content-type: REFERENCE
+[id="upgrading-log-collection-and-forwarding_{context}"]
+= Upgrading log collection and forwarding
+
+[role="_abstract"]
+Log collection and forwarding configurations are now specified under the new API, part of the `observability.openshift.io` API group.
+
+[NOTE]
+====
+Vector is the only supported collector implementation.
+====
+
+To upgrade the {clo}, follow these steps:
+
+. Update the log collection and forwarding configurations by going through the changes listed in "Changes to Cluster logging and forwarding in Logging 6".
+. Update the {clo}.

--- a/modules/upgrading-log-storage.adoc
+++ b/modules/upgrading-log-storage.adoc
@@ -1,0 +1,21 @@
+// Module included in the following assemblies:
+//
+// * upgrading/upgrading-to-logging-6
+
+:_mod-docs-content-type: REFERENCE
+[id="upgrading-log-storage_{context}"]
+= Upgrading log storage
+
+[role="_abstract"]
+The only managed log storage solution available in this release is a `LokiStack`, managed by the {loki-op}. This solution, previously available as the preferred alternative to the managed Elasticsearch offering, remains unchanged in its deployment process.
+
+[IMPORTANT]
+====
+* You must install the {clo} and the {loki-op} with the same major and minor version.
+* To continue using an existing Red{nbsp}Hat-managed Elasticsearch or Kibana deployment provided by the `elasticsearch-operator`, remove the owner references from the `Elasticsearch` resource named `elasticsearch`, and  the `Kibana` resource named `kibana` in the `openshift-logging` namespace before removing the `ClusterLogging` resource named `instance` in the same namespace.
+====
+
+To upgrade Loki storage, follow these steps:
+
+. Update the {loki-op}.
+. Upgrade the `LokiStack` storage schema.

--- a/upgrading/updating-openshift-logging.adoc
+++ b/upgrading/updating-openshift-logging.adoc
@@ -1,77 +1,39 @@
-:_newdoc-version: 2.18.4
-:_template-generated: 2026-01-06
 :_mod-docs-content-type: ASSEMBLY
-include::_attributes/common-attributes.adoc[]
 [id="updating-openshift-logging"]
 = Updating {LoggingProductName}
-
+include::_attributes/common-attributes.adoc[]
 :context: updating-logging
+
 toc::[]
 
+[role="_abstract"]
 You can update {logging-title-uc} by modifying the Operator subscription update channel.
 
-{logging-title-uc} update considerations:
+include::modules/logging-update-considerations.adoc[leveloffset=+1]
 
-* If you are on an Extended Update Support (EUS) release of {logging-title-uc}, it is recommended to update to an EUS release.
-For information about the support cycle for releases, see link:https://access.redhat.com/support/policy/updates/openshift_operators?extIdCarryOver=true&sc_cid=7013a000003StsiAAC#platform-agnostic[OpenShift Operator Life Cycles].
-
-* You must update the {clo} and the {loki-op} to the same major and minor version.
-
-* The maximum supported update channel for {loki-op} is the N+2 version, where N is your current version. Updating to a version that is more than two versions newer is not supported.
-
-You only need to update the Operators for {logging-title-uc} that you have installed. The following list describes the high-level steps for updating {logging-title-uc}.
-
-Only the {clo} is installed::
-
-. Check the update readiness for the {clo}.
-. Update the {clo}.
-
-The {clo} and the {loki-op} are installed::
-
-Update the Operators in the following order:
-+
-[IMPORTANT]
-====
-You must update the {clo} and the {loki-op} to the same channel.
-====
-
-. Check the update readiness for both the {loki-op} and the {clo}.
-. Update the {loki-op}.
-. Update the {clo}.
-
-The {clo}, the {loki-op}, and {coo-first} are installed::
-
-Update the Operators in the following order:
-+
-[IMPORTANT]
-====
-You must update the {clo} and the {loki-op} to the same channel. 
-====
-
-. Check the update readiness for both the {loki-op} and the {clo}.
-. Update the {loki-op}.
-. Update the {clo}.
-. Update the {coo-first}.
-+
-For information about updating {coo-short}, the see link:https://docs.redhat.com/en/documentation/red_hat_openshift_cluster_observability_operator[{coo-first} documentation].
-
-[id="checking_update_readiness_{context}"]
-== Checking update readiness
+include::modules/logging-checking-update-readiness.adoc[leveloffset=+1]
 
 include::modules/checking-update-readiness-of-clo.adoc[leveloffset=+2]
 
 include::modules/checking-update-readiness-of-loki-operator.adoc[leveloffset=+2]
 
-[id="updating-logging-by-using-cli_{context}"]
-== Updating {LoggingProductName} by using the CLI
+include::modules/updating-logging-by-using-cli.adoc[leveloffset=+1]
 
 include::modules/updating-the-loki-operator-by-using-the-cli.adoc[leveloffset=+2]
 
 include::modules/updating-the-clo-by-using-the-cli.adoc[leveloffset=+2]
 
-[id="updating-logging-by-using-web-console_{context}"]
-== Updating {LoggingProductName} by using the web console
+include::modules/updating-logging-by-using-web-console.adoc[leveloffset=+1]
 
 include::modules/updating-the-loki-operator.adoc[leveloffset=+2]
 
 include::modules/updating-the-clo.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+== Additional resources
+
+* link:https://access.redhat.com/support/policy/updates/openshift_operators?extIdCarryOver=true&sc_cid=7013a000003StsiAAC#platform-agnostic[OpenShift Operator Life Cycles]
+
+* link:https://docs.redhat.com/en/documentation/red_hat_openshift_cluster_observability_operator[{coo-first} documentation]
+
+* link:https://docs.redhat.com/en/documentation/red_hat_openshift_logging/{logging-major-version}/html/upgrading_logging/upgrading-to-logging-6#logging-upgrading-loki-schema_upgrading-to-logging-6[Upgrading the `LokiStack` storage schema]

--- a/upgrading/upgrading-to-logging-60.adoc
+++ b/upgrading/upgrading-to-logging-60.adoc
@@ -1,112 +1,55 @@
 :_mod-docs-content-type: ASSEMBLY
-include::_attributes/common-attributes.adoc[]
 [id="upgrading-to-logging-6"]
 = Upgrading to logging 6
-
+include::_attributes/common-attributes.adoc[]
 :context: upgrading-to-logging-6
 
 toc::[]
 
-[id="changes-in-logging-6_{context}"]
-== An overview of changes in Logging 6
+[role="_abstract"]
+Learn how to upgrade to {logging-title-uc} 6 by checking update readiness and updating installed Operators by using supported methods.
 
-Logging 6 is a significant upgrade from earlier releases, achieving several longstanding goals of Cluster Logging. Following are some of the notable changes:
+include::modules/changes-in-logging-6.adoc[leveloffset=+1]
 
-Introduction of distinct Operators to manage logging components::
+include::modules/overview-steps-for-upgrading-logging-5-to-6.adoc[leveloffset=+1]
 
-* {clo} manages both collection and forwarding.
-* {loki-op} manages storage.
-* {coo-first} manages visualization.
-
-Removal of support for managed log storage and visualization based on Elastic products::
-
-* Elasticsearch is replaced with Loki.
-* Kibana is replaced with the UIplugin provided by {coo-short}.
-
-Removal of the Fluentd log collector implementation::
-Vector is now the supported collection service.
-
-API change for log collection and forwarding::
-* The API for log collection is changed from `logging.openshift.io` to `observability.openshift.io`.
-* `ClusterLogForwarder` and `ClusterLogging` have been combined under the `ClusterLogForwarder` resource in the new API.
-
-[id="steps-for-upgrading-logging-5-to-6_{context}"]
-== An overview of steps for upgrading Logging 5 to 6
-The broad steps to upgrade Logging 5 to Logging 6 are as follows:
-
-. Ensure that you are not using any deprecated resources. For more information, see "Preparation for upgrading to Logging 6".
-. Migrate log visualization from Kibana to {coo-first}. For more information, see "Migrating logging visualization". 
-. Upgrade log storage. For more information, see "Upgrading log storage".
-. Upgrade log collection and forwarding. For more information, see "Upgrading log collection and forwarding".
-. Finally, delete resources that you no longer need. For more information, see "Deleting old resources".
-
-[id="preparation-for-upgrading-to-logging-6_{context}"]
-== Preparation for upgrading to Logging 6
-
-Before being able to upgrade to Logging 6 from Logging 5, you must first ensure that you are not using any deprecated resources. Therefore, if you haven't already, you must make the following migrations:
-
-* Migrate collection service from Fluentd to Vector.
-For more information, see https://access.redhat.com/articles/6999658[how to migrate Fluentd to Vector in Red Hat OpenShift Logging 5.5+ versions]. 
-
-* Migrate storage from Elasticsearch to LokiStack. For more information, see "Migrating storage from Elasticsearch to LokiStack".
+include::modules/preparation-for-upgrading-to-logging-6.adoc[leveloffset=+1]
 
 include::modules/migrating-storage-from-elasticsearch-to-lokistack.adoc[leveloffset=+2]
 
-
-[id="migrating-logging-visualization_{context}"]
-== Migrating logging visualization
-
-The OpenShift console UI plugin for log visualization is moved to the {coo-full} from the Cluster Logging Operator.
+include::modules/migrating-logging-virtualization.adoc[leveloffset=+1]
 
 include::modules/deleting-the-logging-view-plugin.adoc[leveloffset=+2]
 
 include::modules/installing-the-logging-ui-plug-in-gui.adoc[leveloffset=+2]
 
-[id="log-storage_{context}"]
-== Upgrading log storage
-
-The only managed log storage solution available in this release is a LokiStack, managed by the {loki-op}. This solution, previously available as the preferred alternative to the managed Elasticsearch offering, remains unchanged in its deployment process.
-
-[IMPORTANT]
-====
-* You must install the {clo} and the {loki-op} with the same major and minor version.
-* To continue using an existing Red{nbsp}Hat-managed Elasticsearch or Kibana deployment provided by the `elasticsearch-operator`, remove the owner references from the `Elasticsearch` resource named `elasticsearch`, and  the `Kibana` resource named `kibana` in the `openshift-logging` namespace before removing the `ClusterLogging` resource named `instance` in the same namespace.
-====
-
-To upgrade Loki storage, follow these steps:
-
-. Update the {loki-op}. For more information, see "Updating the {loki-op}".
-
-. Upgrade the LokiStack storage schema. For more information, see "Upgrading the LokiStack storage schema".
+include::modules/upgrading-log-storage.adoc[leveloffset=+1]
 
 include::modules/logging-upgrading-loki.adoc[leveloffset=+2]
 
 include::modules/logging-upgrading-loki-schema.adoc[leveloffset=+2]
 
-[id="log-collection-and-forwarding_{context}"]
-== Upgrading log collection and forwarding
-
-Log collection and forwarding configurations are now specified under the new link:https://github.com/openshift/cluster-logging-operator/blob/master/docs/reference/operator/api_observability_v1.adoc[API], part of the `observability.openshift.io` API group. 
-
-[NOTE]
-====
-Vector is the only supported collector implementation.
-====
-
-To upgrade the {clo}, follow these steps:
-
-. Update the log collection and forwarding configurations by going through the changes listed in "Changes to Cluster logging and forwarding in Logging 6".
-. Update the {clo}.
+include::modules/upgrading-log-collection-and-forwarding.adoc[leveloffset=+1]
 
 include::modules/changes-to-cluster-logging-and-forwarding-in-logging-6.adoc[leveloffset=+2]
 
 include::modules/logging-upgrading-clo.adoc[leveloffset=+2]
 
-[id="deleting-old-resources_{context}"]
-== Deleting old resources
+include::modules/logging-deleting-old-resources.adoc[leveloffset=+1]
 
 include::modules/deleting-the-clusterlogging-instance.adoc[leveloffset=+2]
 
 include::modules/deleting-red-hat-openshift-logging-5-crd.adoc[leveloffset=+2]
 
 include::modules/uninstalling-elasticsearch.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+== Additional resources
+
+* link:https://access.redhat.com/articles/6999658[How to migrate Fluentd to Vector in Red Hat OpenShift Logging 5.5+ versions]
+
+* link:https://github.com/openshift/cluster-logging-operator/blob/master/docs/reference/operator/api_observability_v1.adoc[API]
+
+* link:https://docs.redhat.com/en/documentation/red_hat_openshift_cluster_observability_operator/{coo-version}/html/installing_red_hat_openshift_cluster_observability_operator/installing-the-cluster-observability-operator[Installing the Cluster Observability Operator]
+
+* link:https://docs.redhat.com/en/documentation/red_hat_openshift_logging/{logging-major-version}/html/upgrading_logging/upgrading-to-logging-6#logging-upgrading-loki-schema_upgrading-to-logging-6[Upgrading the LokiStack storage schema]


### PR DESCRIPTION
This is a manual CP of #110456

Commit ID: 375a63e4d1bdcaca08fff1de3dab1cb4846469c8

**Note for the peer & merge reviewer:** 
- This PR updates the only "upgrading" sections to prepare them for Phase 0 DITA migration.
- No other CQA changes, error types, or content refinements are included. 

**Changes:** 
This PR prepares the "upgrading" section for Phase 0 DITA migration by applying Vale (AsciiDoc DITA) rules and cleaning up the existing content.

**Doc preview:** 
https://110660--ocpdocs-pr.netlify.app/openshift-logging/latest/upgrading/updating-openshift-logging.html
https://110660--ocpdocs-pr.netlify.app/openshift-logging/latest/upgrading/upgrading-to-logging-60.html

**Tracking JIRA:** https://redhat.atlassian.net/browse/OBSDOCS-3326

**Reviews:**
- [x] Peer has approved this change