### PR TITLE
[standalone-logging-docs-6.2] PR for OBSDOCS-3258 Manual CP: CQA + DITA readiness for assemblies and modules under "Installing logging" & "Uninstalling logging" sections.

### DIFF
--- a/installing/installing-logging.adoc
+++ b/installing/installing-logging.adoc
@@ -1,55 +1,39 @@
 :_mod-docs-content-type: ASSEMBLY
-include::_attributes/common-attributes.adoc[]
 [id="installing-logging"]
 = Installing Logging
+include::_attributes/common-attributes.adoc[]
 :context: installing-logging
 
 toc::[]
 
-{ocp-product-title} Operators use custom resources (CRs) to manage applications and their components. You provide high-level configuration and settings through the CR. The Operator translates high-level directives into low-level actions, based on best practices embedded within the logic of the Operator. A custom resource definition (CRD) defines a CR and lists all the configurations available to users of the Operator. Installing an Operator creates the CRDs to generate CRs.
+[role="_abstract"]
+{ocp-product-title} Operators use custom resources (CRs) to manage applications and their components. You specify high-level configuration and settings in a CR, and the Operator converts them into low-level actions based on built-in best practices. A custom resource definition (CRD) defines a CR and lists the available configuration options. When you install an Operator, it creates the CRDs that you use to create CRs.
 
+include::modules/logging-installation-prereqs.adoc[leveloffset=+1]
 
-To get started with {logging}, you must install the following Operators:
-
-* {loki-op} to manage your log store.
-* {clo} to manage log collection and forwarding.
-* {coo-first} to manage visualization.
-
-You can use either the {ocp-product-title} web console or the {ocp-product-title} CLI to install or configure {logging}.
-
-[IMPORTANT]
-====
-* You must configure the {clo} after the {loki-op}.
-* You must install the {clo} and the {loki-op} with the same major and minor version.
-====
-
-////
-[id="prerequisites_cluster-logging-deploying_{context}"]
-== Prerequisites
-* If you are using OKD, you have downloaded the {cluster-manager-url-pull} as shown in "Obtaining the installation program" in the installation documentation for your platform.
-+
-If you have the pull secret, add the `redhat-operators` catalog to the `OperatorHub` custom resource (CR) as shown in "Configuring {ocp-product-title} to use Red{nbsp}Hat Operators".
-////
-
-[id="installing-loki-and-logging-cli_{context}"]
-== Installation by using the CLI
-
-The following sections describe installing the {loki-op} and the {clo} by using the CLI.
+include::modules/installing-loki-and-logging-by-cli.adoc[leveloffset=+1]
 
 include::modules/installing-loki-operator-cli.adoc[leveloffset=+2]
+
 include::modules/installing-logging-operator-cli.adoc[leveloffset=+2]
+
 include::modules/installing-the-logging-ui-plug-in-cli.adoc[leveloffset=+2]
 
-[id="installing-loki-and-logging-gui_{context}"]
-== Installation by using the web console
-
-The following sections describe installing the {loki-op} and the {clo} by using the web console.
+include::modules/installing-loki-and-logging-by-web-console.adoc[leveloffset=+1]
 
 include::modules/installing-loki-operator-web-console.adoc[leveloffset=+2]
+
 include::modules/installing-logging-operator-web-console.adoc[leveloffset=+2]
+
 include::modules/installing-the-logging-ui-plug-in-gui.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
-.Additional resources
+== Additional resources
 
 * link:https://docs.openshift.com/container-platform/latest/networking/ovn_kubernetes_network_provider/about-ovn-kubernetes.html[About the OVN-Kubernetes network policy]
+
+* link:https://docs.redhat.com/en/documentation/red_hat_openshift_logging/{logging-major-version}/html/configuring_logging/configuring-lokistack-storage#logging-loki-storage_configuring-the-log-store[Loki object storage section]
+
+* link:https://docs.redhat.com/en/documentation/red_hat_openshift_logging/6.2/html/configuring_logging/configuring-lokistack-storage#logging-loki-retention_configuring-the-log-store[Enabling stream-based retention with Loki]
+
+* link:https://docs.redhat.com/en/documentation/red_hat_openshift_cluster_observability_operator/{coo-version}/html/installing_red_hat_openshift_cluster_observability_operator/installing-the-cluster-observability-operator[Installing the Cluster Observability Operator]

--- a/modules/deleting-logging-pvcs-by-using-the-cli.adoc
+++ b/modules/deleting-logging-pvcs-by-using-the-cli.adoc
@@ -1,14 +1,12 @@
 // Module included in the following assemblies:
-// * uninstalling/uninstalling-logging.adoc
+// uninstalling/uninstalling-logging.adoc
 
-:_newdoc-version: 2.18.4
-:_template-generated: 2025-07-28
 :_mod-docs-content-type: PROCEDURE
-
 [id="deleting-logging-pvcs-by-using-the-cli_{context}"]
 = Deleting logging PVCs by using the CLI
 
-You can delete persistent volume claims (PVCs) if you do not want to reuse them in other installations of LokiStack by using the {oc-first}.
+[role="_abstract"]
+You can delete persistent volume claims (PVCs) if you do not want to reuse them in other installations of `LokiStack` by using the {oc-first}.
 
 .Prerequisites
 * You have administrator permissions.
@@ -22,6 +20,3 @@ You can delete persistent volume claims (PVCs) if you do not want to reuse them 
 ----
 $ oc -n openshift-logging delete pvc -l app.kubernetes.io/name=lokistack
 ----
-
-.Next steps
-* https://docs.redhat.com/en/documentation/openshift_container_platform/latest/html-single/storage/index#reclaim-manual_understanding-persistent-storage[Reclaiming a persistent volume manually]

--- a/modules/deleting-logging-pvcs-by-using-the-web-console.adoc
+++ b/modules/deleting-logging-pvcs-by-using-the-web-console.adoc
@@ -1,14 +1,12 @@
 // Module included in the following assemblies:
 // * uninstalling/uninstalling-logging.adoc
 
-:_newdoc-version: 2.18.4
-:_template-generated: 2025-07-05
 :_mod-docs-content-type: PROCEDURE
-
 [id="deleting-logging-pvcs-by-using-the-web-console_{context}"]
 = Deleting logging PVCs by using the web console
 
-You can delete persistent volume claims (PVCs) if you do not want to reuse them in other installations of LokiStack, by using the web console.
+[role="_abstract"]
+You can delete persistent volume claims (PVCs) if you do not want to reuse them in other installations of `LokiStack`, by using the web console.
 
 .Prerequisites
 * You have administrator permissions.
@@ -19,6 +17,3 @@ You can delete persistent volume claims (PVCs) if you do not want to reuse them 
 . In the web console, go to the *Storage* -> *Persistent Volume Claims* page.
 
 . Click {kebab} next to each PVC, and select *Delete Persistent Volume Claim*.
-
-.Next steps
-* https://docs.redhat.com/en/documentation/openshift_container_platform/latest/html-single/storage/index#reclaim-manual_understanding-persistent-storage[Reclaiming a persistent volume manually]

--- a/modules/deleting-the-cluster-logging-operator-by-using-the-cli.adoc
+++ b/modules/deleting-the-cluster-logging-operator-by-using-the-cli.adoc
@@ -1,14 +1,12 @@
 // Module included in the following assemblies:
-// * uninstalling/uninstalling-logging.adoc
+// uninstalling/uninstalling-logging.adoc
 
-:_newdoc-version: 2.18.4
-:_template-generated: 2025-07-05
 :_mod-docs-content-type: PROCEDURE
-
 [id="deleting-the-cluster-logging-operator-by-using-the-cli_{context}"]
 = Deleting the {clo} by using the CLI
 
-Delete the {clo} by using the {oc-first}.
+[role="_abstract"]
+You can delete the {clo} by using the {oc-first}.
 
 .Prerequisites
 
@@ -72,7 +70,8 @@ $  oc -n openshift-logging delete LogFileMetricExporter --all
 $ oc get csv -n openshift-logging | grep cluster-logging
 ----
 +
-.Example output
+You get an output similar to the following example:
++
 ----
 cluster-logging.v6.2.4    Red Hat OpenShift Logging   6.2.4     cluster-logging.v6.2.3    Succeeded
 ----

--- a/modules/deleting-the-cluster-logging-operator-by-using-the-web-console.adoc
+++ b/modules/deleting-the-cluster-logging-operator-by-using-the-web-console.adoc
@@ -1,14 +1,11 @@
 // Module included in the following assemblies:
-// * uninstalling/uninstalling-logging.adoc
+// uninstalling/uninstalling-logging.adoc
 
-
-:_newdoc-version: 2.18.4
-:_template-generated: 2025-07-05
 :_mod-docs-content-type: PROCEDURE
-
 [id="deleting-the-cluster-logging-operator-by-using-the-web-console_{context}"]
 = Deleting the {clo} by using the web console
 
+[role="_abstract"]
 Delete the {clo} by using the {product-title} web console.
 
 .Prerequisites

--- a/modules/deleting-the-loki-operator-by-using-the-cli.adoc
+++ b/modules/deleting-the-loki-operator-by-using-the-cli.adoc
@@ -1,13 +1,11 @@
 // Module included in the following assemblies:
-// * uninstalling/uninstalling-logging.adoc
+// uninstalling/uninstalling-logging.adoc
 
-:_newdoc-version: 2.18.4
-:_template-generated: 2025-07-05
 :_mod-docs-content-type: PROCEDURE
-
 [id="deleting-the-loki-operator-by-using-the-cli_{context}"]
 = Deleting the {loki-op} by using the CLI
 
+[role="_abstract"]
 Delete the {loki-op} by using the {oc-first}.
 
 .Prerequisites
@@ -33,7 +31,8 @@ Substitute `logging-loki` with the name of your `LokiStack` CR if you have used 
 $ oc get csv -n openshift-operators-redhat | grep loki-operator
 ----
 +
-.Example output
+You get an output similar to the following example:
++
 ----
 loki-operator.v6.2.4      Loki Operator               6.2.4     loki-operator.v6.2.3                    Succeeded
 ----

--- a/modules/deleting-the-loki-operator-by-using-the-web-console.adoc
+++ b/modules/deleting-the-loki-operator-by-using-the-web-console.adoc
@@ -1,13 +1,11 @@
 // Module included in the following assemblies:
-// * uninstalling/uninstalling-logging.adoc
+// uninstalling/uninstalling-logging.adoc
 
-:_newdoc-version: 2.18.4
-:_template-generated: 2025-07-05
 :_mod-docs-content-type: PROCEDURE
-
 [id="deleting-the-loki-operator-by-using-the-web-console_{context}"]
 = Deleting the {loki-op} by using the web console
 
+[role="_abstract"]
 Delete the {loki-op} by using the {product-title} web console.
 
 .Prerequisites

--- a/modules/deleting-the-uiplugin-by-using-the-cli.adoc
+++ b/modules/deleting-the-uiplugin-by-using-the-cli.adoc
@@ -1,13 +1,11 @@
 // Module included in the following assemblies:
-// * uninstalling/uninstalling-logging.adoc
+// uninstalling/uninstalling-logging.adoc
 
-:_newdoc-version: 2.18.4
-:_template-generated: 2025-07-14
 :_mod-docs-content-type: PROCEDURE
-
 [id="deleting-the-uiplugin-by-using-the-cli_{context}"]
 = Deleting the UIPlugin by using the CLI
 
+[role="_abstract"]
 Delete the `UIPlugin` by using the {oc-first}. 
 
 .Prerequisites

--- a/modules/deleting-the-uiplugin-by-using-the-web-console.adoc
+++ b/modules/deleting-the-uiplugin-by-using-the-web-console.adoc
@@ -1,13 +1,11 @@
 // Module included in the following assemblies:
-// * uninstalling/uninstalling-logging.adoc
+// uninstalling/uninstalling-logging.adoc
 
-:_newdoc-version: 2.18.4
-:_template-generated: 2025-07-05
 :_mod-docs-content-type: PROCEDURE
-
 [id="deleting-the-uiplugin-by-using-the-web-console_{context}"]
 = Deleting the UIPlugin by using the web console
 
+[role="_abstract"]
 Delete the `UIPlugin` plugin by using the {product-title} web console.
 
 .Prerequisites
@@ -20,4 +18,4 @@ Delete the `UIPlugin` plugin by using the {product-title} web console.
 
 . Click *{coo-full}* from the *Installed Operators* list and go to the *UIPlugin* tab.
 
-. Click {kebab} for the UIPlugin *logging* entry and select *Delete UIPlugin*.
+. Click {kebab} for the `UIPlugin` *logging* entry and select *Delete UIPlugin*.

--- a/modules/installing-logging-operator-cli.adoc
+++ b/modules/installing-logging-operator-cli.adoc
@@ -1,10 +1,11 @@
-// Module is included in the following assemblies:
-//
-// 
+// Module included in the following assemblies:
+// installing/installing-logging.adoc
+ 
 :_mod-docs-content-type: PROCEDURE
 [id="installing-logging-operator-cli_{context}"]
 = Installing {clo} by using the CLI
 
+[role="_abstract"]
 Install {clo} on your {ocp-product-title} cluster to collect and forward logs to a log store by using the {oc-first}.
 
 .Prerequisites
@@ -18,18 +19,22 @@ Install {clo} on your {ocp-product-title} cluster to collect and forward logs to
 
 . Create an `OperatorGroup` object:
 +
-.Example `OperatorGroup` object
+The following example displays a `OperatorGroup` object:
++
 [source,yaml]
 ----
 apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:
   name: cluster-logging
-  namespace: openshift-logging # <1>
+  namespace: openshift-logging
 spec:
   upgradeStrategy: Default
 ----
-<1> You must specify `openshift-logging` as the namespace.
++
+where:
++
+* `namespace: openshift-logging`: You must specify `openshift-logging` as the namespace.
 
 . Apply the `OperatorGroup` object by running the following command:
 +
@@ -40,25 +45,29 @@ $ oc apply -f <filename>.yaml
 
 . Create a `Subscription` object for {clo}:
 +
-.Example `Subscription` object
+The following example displays a `Subscription` object:
++
 [source,yaml]
 ----
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
   name: cluster-logging
-  namespace: openshift-logging # <1>
+  namespace: openshift-logging
 spec:
-  channel: stable-6.<y> # <2>
-  installPlanApproval: Automatic # <3>
+  channel: stable-6.<y>
+  installPlanApproval: Automatic
   name: cluster-logging
-  source: redhat-operators # <4>
+  source: redhat-operators
   sourceNamespace: openshift-marketplace
 ----
-<1> You must specify `openshift-logging` as the namespace.
-<2> Specify `stable-6.<y>` as the channel.
-<3> If the approval strategy in the subscription is set to `Automatic`, the update process initiates as soon as a new operator version is available in the selected channel. If the approval strategy is set to `Manual`, you must manually approve pending updates.
-<4> Specify `redhat-operators` as the value. If your {ocp-product-title} cluster is installed on a restricted network, also known as a disconnected cluster, specify the name of the `CatalogSource` object that you created when you configured Operator Lifecycle Manager (OLM).
++
+where:
++
+* `namespace: openshift-logging`: You must specify `openshift-logging` as the namespace.
+* `channel: stable-6.<y>`: Specify `stable-6.<y>` as the channel.
+* `installPlanApproval: Automatic`: If the approval strategy in the subscription is set to `Automatic`, the update process initiates as soon as a new operator version is available in the selected channel. If the approval strategy is set to `Manual`, you must manually approve pending updates.
+* `source: redhat-operators`: Specify `redhat-operators` as the value. If your {ocp-product-title} cluster is installed on a restricted network, also known as a disconnected cluster, specify the name of the `CatalogSource` object that you created when you configured Operator Lifecycle Manager (OLM).
 
 . Apply the `Subscription` object by running the following command:
 +
@@ -93,22 +102,23 @@ $ oc adm policy add-cluster-role-to-user collect-infrastructure-logs -z logging-
 
 . Create a `ClusterLogForwarder` CR:
 +
-.Example `ClusterLogForwarder` CR
+The following example displays a `ClusterLogForwarder` CR:
++
 [source,yaml]
 ----
 apiVersion: observability.openshift.io/v1
 kind: ClusterLogForwarder
 metadata:
   name: instance
-  namespace: openshift-logging # <1>
+  namespace: openshift-logging
 spec:
   serviceAccount:
-    name: logging-collector # <2>
+    name: logging-collector
   outputs:
   - name: lokistack-out
-    type: lokiStack # <3>
+    type: lokiStack
     lokiStack:
-      target: # <4>
+      target:
         name: logging-loki 
         namespace: openshift-logging
       authentication:
@@ -120,17 +130,21 @@ spec:
         configMapName: openshift-service-ca.crt
   pipelines:
   - name: infra-app-logs
-    inputRefs: # <5>
+    inputRefs:
     - application
     - infrastructure
     outputRefs:
     - lokistack-out
 ----
-<1> You must specify the `openshift-logging` namespace.
-<2> Specify the name of the service account created before.
-<3> Select the `lokiStack` output type to send logs to the `LokiStack` instance.
-<4> Point the `ClusterLogForwarder` to the `LokiStack` instance created earlier.
-<5> Select the log output types you want to send to the `LokiStack` instance.
++
+where:
++
+
+* `namespace: openshift-logging`: You must specify the `openshift-logging` namespace.
+* `name: logging-collector`: Specify the name of the service account created before.
+* `type: lokiStack`: Select the `lokiStack` output type to send logs to the `LokiStack` instance.
+* `outputs.lokiStack.target`: Point the `ClusterLogForwarder` to the `LokiStack` instance created earlier.
+* `pipelines.inputRefs`: Select the log output types you want to send to the `LokiStack` instance.
 
 . Apply the `ClusterLogForwarder CR` object by running the following command:
 +
@@ -148,7 +162,8 @@ $ oc apply -f <filename>.yaml
 $ oc get pods -n openshift-logging
 ----
 +
-.Example output
+You get an output similar to the following example:
++
 [source,terminal]
 ----
 $ oc get pods -n openshift-logging

--- a/modules/installing-logging-operator-web-console.adoc
+++ b/modules/installing-logging-operator-web-console.adoc
@@ -1,7 +1,11 @@
+// Module included in the following assemblies:
+// installing/installing-logging.adoc
+
 :_mod-docs-content-type: PROCEDURE
 [id="installing-logging-operator-web-console_{context}"]
 = Installing {clo} by using the web console
 
+[role="_abstract"]
 Install {clo} on your {ocp-product-title} cluster to collect and forward logs to a log store from the OperatorHub by using the {ocp-product-title} web console.
 
 .Prerequisites
@@ -26,30 +30,34 @@ This option sets the `openshift.io/cluster-monitoring: "true"` label in the `Nam
 
 . For *Update approval* select *Automatic*, then click *Install*.
 +
-If the approval strategy in the subscription is set to *Automatic*, the update process initiates as soon as a new operator version is available in the selected channel. If the approval strategy is set to *Manual*, you must manually approve pending updates.
+If the approval strategy in the subscription is set to *Automatic*, the update process initiates as soon as a new Operator version is available in the selected channel. If the approval strategy is set to *Manual*, you must manually approve pending updates.
 +
 [NOTE]
 ====
 An Operator might display a `Failed` status before the installation completes. If the operator installation completes with an `InstallSucceeded` message, refresh the page.
 ====
 
-. While the operator installs, create the service account that will be used by the log collector to collect the logs. 
+. While the Operator installs, create the service account that will be used by the log collector to collect the logs. 
 
 .. Click the *+* in the top right of the screen to access the *Import YAML* page. 
 
 .. Enter the YAML definition for the service account. 
 +
-.Example `ServiceAccount` object
+The following example displays a `ServiceAccount` object:
++
 [source,yaml]
 ----
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: logging-collector # <1>
-  namespace: openshift-logging # <2>
+  name: logging-collector
+  namespace: openshift-logging
 ----
-<1> Note down the name used for the service account `logging-collector` to use it later when creating the `ClusterLogForwarder` resource.
-<2> Set the namespace to `openshift-logging` because that is the namespace for deploying the `ClusterLogForwarder` resource.
++
+where:
++
+* `name: logging-collector`: Note down the name used for the service account `logging-collector` to use it later when creating the `ClusterLogForwarder` resource.
+* `namespace: openshift-logging`: Set the namespace to `openshift-logging` because that is the namespace for deploying the `ClusterLogForwarder` resource.
 
 .. Click the *Create* button.
 
@@ -59,7 +67,8 @@ metadata:
 
 .. Enter the YAML definition for the `ClusterRoleBinding` resources.
 +
-.Example `ClusterRoleBinding` resources
+The following example displays a `ClusterRoleBinding` resources:
++
 [source,yaml]
 ----
 apiVersion: rbac.authorization.k8s.io/v1
@@ -69,7 +78,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: logging-collector-logs-writer # <1>
+  name: logging-collector-logs-writer
 subjects:
 - kind: ServiceAccount
   name: logging-collector
@@ -82,7 +91,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: collect-application-logs # <2>
+  name: collect-application-logs
 subjects:
 - kind: ServiceAccount
   name: logging-collector
@@ -95,15 +104,18 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: collect-infrastructure-logs # <3>
+  name: collect-infrastructure-logs
 subjects:
 - kind: ServiceAccount
   name: logging-collector
   namespace: openshift-logging
 ----
-<1> The cluster role to allow the log collector to write logs to LokiStack.
-<2> The cluster role to allow the log collector to collect logs from applications.
-<3> The cluster role to allow the log collector to collect logs from infrastructure.
++
+where:
++
+* `name: logging-collector-logs-writer`: The cluster role to allow the log collector to write logs to `LokiStack`.
+* `name: collect-application-logs`: The cluster role to allow the log collector to collect logs from applications.
+* `name: collect-infrastructure-logs`: The cluster role to allow the log collector to collect logs from infrastructure.
 
 .. Click the *Create* button.
 
@@ -113,22 +125,23 @@ subjects:
 
 . Select *YAML view*, and then use the following template to create a `ClusterLogForwarder` CR:
 +
-.Example `ClusterLogForwarder` CR
+The following example displays a `ClusterLogForwarder` CR:
++
 [source,yaml]
 ----
 apiVersion: observability.openshift.io/v1
 kind: ClusterLogForwarder
 metadata:
   name: instance
-  namespace: openshift-logging # <1>
+  namespace: openshift-logging
 spec:
   serviceAccount:
-    name: logging-collector # <2>
+    name: logging-collector
   outputs:
   - name: lokistack-out
-    type: lokiStack # <3>
+    type: lokiStack
     lokiStack:
-      target: # <4>
+      target:
         name: logging-loki 
         namespace: openshift-logging
       authentication:
@@ -140,24 +153,28 @@ spec:
         configMapName: openshift-service-ca.crt
   pipelines:
   - name: infra-app-logs
-    inputRefs: # <5>
+    inputRefs:
     - application
     - infrastructure
     outputRefs:
     - lokistack-out
 ----
-<1> You must specify `openshift-logging` as the namespace.
-<2> Specify the name of the service account created earlier.
-<3> Select the `lokiStack` output type to send logs to the `LokiStack` instance.
-<4> Point the `ClusterLogForwarder` to the `LokiStack` instance created earlier.
-<5> Select the log output types you want to send to the `LokiStack` instance.
++
+where:
++
+* `namespace: openshift-logging`: You must specify `openshift-logging` as the namespace.
+* `name: logging-collector`: Specify the name of the service account created earlier.
+* `type: lokiStack`: Select the `lokiStack` output type to send logs to the `LokiStack` instance.
+* `target`: Point the `ClusterLogForwarder` to the `LokiStack` instance created earlier.
+* `inputRefs`: Select the log output types you want to send to the `LokiStack` instance.
 
 . Click *Create*.
 
 .Verification
+
 . In the *ClusterLogForwarder* tab verify that you see your `ClusterLogForwarder` instance.
 
-. In the *Status* column, verify that you see the messages: 
+. In the *Status* column, verify that you see the following messages: 
 
 * `Condition: observability.openshift.io/Authorized`
 * `observability.openshift.io/Valid, Ready`

--- a/modules/installing-loki-and-logging-by-cli.adoc
+++ b/modules/installing-loki-and-logging-by-cli.adoc
@@ -1,0 +1,6 @@
+:_mod-docs-content-type: REFERENCE
+[id="installing-loki-and-logging-by-cli_{context}"]
+= Installation by using the CLI
+
+[role="_abstract"]
+The following sections describe installing the {loki-op} and the {clo} by using the CLI.

--- a/modules/installing-loki-and-logging-by-web-console.adoc
+++ b/modules/installing-loki-and-logging-by-web-console.adoc
@@ -1,0 +1,6 @@
+:_mod-docs-content-type: REFERENCE
+[id="installing-loki-and-logging-by-web-console_{context}"]
+= Installation by using the web console
+
+[role="_abstract"]
+The following sections describe installing the {loki-op} and the {clo} by using the web console.

--- a/modules/installing-loki-operator-cli.adoc
+++ b/modules/installing-loki-operator-cli.adoc
@@ -1,8 +1,12 @@
+// Module included in the following assemblies:
+// installing/installing-logging.adoc
+
 :_mod-docs-content-type: PROCEDURE
 [id="install-loki-operator-cli_{context}"]
 = Installing the {loki-op} by using the CLI
 
-Install {loki-op} on your {ocp-product-title} cluster to manage the log store `Loki` by using the {ocp-product-title} command-line interface (CLI). You can deploy and configure the `Loki` log store by reconciling the resource LokiStack with the {loki-op}.
+[role="_abstract"]
+Install {loki-op} on your {ocp-product-title} cluster to manage the log store `Loki` by using the {ocp-product-title} command-line interface (CLI). You can deploy and configure the `Loki` log store by reconciling the resource `LokiStack` with the {loki-op}.
 
 .Prerequisites
 
@@ -12,173 +16,177 @@ Install {loki-op} on your {ocp-product-title} cluster to manage the log store `L
 
 .Procedure
 
-. Create a `Namespace` object for {loki-op}:
+. Create a `Namespace` for the {loki-op}:
 +
-.Example `Namespace` object
 [source,yaml]
 ----
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: openshift-operators-redhat # <1>
+  name: openshift-operators-redhat
   labels:
-    openshift.io/cluster-monitoring: "true" # <2>
+    openshift.io/cluster-monitoring: "true"
 ----
-<1> You must specify `openshift-operators-redhat` as the namespace. To enable monitoring for the operator, configure Cluster Monitoring Operator to scrape metrics from the `openshift-operators-redhat` namespace and not the `openshift-operators` namespace. The `openshift-operators` namespace might contain community operators, which are untrusted and could publish a metric with the same name as an {ocp-product-title} metric, causing conflicts.
-<2> A string value that specifies the label as shown to ensure that cluster monitoring scrapes the `openshift-operators-redhat` namespace.
++
+where:
++
+* `name: openshift-operators-redhat`: Use this namespace for Red Hat Operators. Avoid using `openshift-operators`, which might contain untrusted community Operators and cause metric conflicts.
+* `openshift.io/cluster-monitoring: "true"`: Ensures that cluster monitoring scrapes metrics from this namespace.
 
-. Apply the `Namespace` object by running the following command:
+. Apply the `Namespace`:
 +
 [source,terminal]
 ----
 $ oc apply -f <filename>.yaml
 ----
 
-. Create an `OperatorGroup` object.
+. Create an `OperatorGroup`:
 +
-.Example `OperatorGroup` object
 [source,yaml]
 ----
 apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:
   name: loki-operator
-  namespace: openshift-operators-redhat # <1>
+  namespace: openshift-operators-redhat
 spec:
   upgradeStrategy: Default
 ----
-<1> You must specify `openshift-operators-redhat` as the namespace.
++
+where:
++
+* `namespace: openshift-operators-redhat`: Specifies the namespace for the Operator.
 
-. Apply the `OperatorGroup` object by running the following command:
+. Apply the `OperatorGroup`:
 +
 [source,terminal]
 ----
 $ oc apply -f <filename>.yaml
 ----
 
-. Create a `Subscription` object for {loki-op}:
+. Create a `Subscription` for the {loki-op}:
 +
-.Example `Subscription` object
 [source,yaml]
 ----
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
   name: loki-operator
-  namespace: openshift-operators-redhat # <1>
+  namespace: openshift-operators-redhat
 spec:
-  channel: stable-6.<y> # <2>
-  installPlanApproval: Automatic # <3>
+  channel: stable-6.<y>
+  installPlanApproval: Automatic
   name: loki-operator
-  source: redhat-operators # <4>
+  source: redhat-operators
   sourceNamespace: openshift-marketplace
 ----
-<1> You must specify `openshift-operators-redhat` as the namespace.
-<2> Specify `stable-6.<y>` as the channel.
-<3> If the approval strategy in the subscription is set to `Automatic`, the update process initiates as soon as a new operator version is available in the selected channel. If the approval strategy is set to `Manual`, you must manually approve pending updates.
-<4> Specify `redhat-operators` as the value. If your {ocp-product-title} cluster is installed on a restricted network, also known as a disconnected cluster, specify the name of the `CatalogSource` object that you created when you configured Operator Lifecycle Manager (OLM).
++
+where:
++
+* `channel: stable-6.<y>`: Specifies the update channel.
+* `installPlanApproval: Automatic`: Automatically installs updates when available. Set to `Manual` to approve updates manually.
+* `source: redhat-operators`: Uses the Red Hat-provided catalog. For disconnected clusters, specify your custom `CatalogSource`.
 
-. Apply the `Subscription` object by running the following command:
+. Apply the `Subscription`:
 +
 [source,terminal]
 ----
 $ oc apply -f <filename>.yaml
 ----
 
-. Create a `namespace` object for deploy the LokiStack:
+. Create a `Namespace` for the `LokiStack`:
 +
-.Example `namespace` object
 [source,yaml]
 ----
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: openshift-logging # <1>
+  name: openshift-logging
   labels:
-    openshift.io/cluster-monitoring: "true" # <2>
+    openshift.io/cluster-monitoring: "true"
 ----
-<1> The `openshift-logging` namespace is dedicated for all {logging} workloads.
-<2> A string value that specifies the label, as shown, to ensure that cluster monitoring scrapes the `openshift-logging` namespace.
++
+where:
++
+* `name: openshift-logging`: Dedicated namespace for {logging} workloads.
+* `openshift.io/cluster-monitoring: "true"`: Enables metric collection.
 
-. Apply the `namespace` object by running the following command:
+. Apply the `Namespace`:
 +
 [source,terminal]
 ----
 $ oc apply -f <filename>.yaml
 ----
 
-. Create a secret with the credentials to access the object storage. For example, create a secret to access {aws-first} s3.
+. Create a secret for object storage credentials:
 +
-.Example `Secret` object
 [source,yaml]
 ----
 apiVersion: v1
 kind: Secret
 metadata:
-  name: logging-loki-s3 # <1>
+  name: logging-loki-s3
   namespace: openshift-logging
-stringData: # <2>
+stringData:
   access_key_id: <access_key_id>
   access_key_secret: <secret_access_key>
   bucketnames: <s3_bucket_name>
   endpoint: https://s3.eu-central-1.amazonaws.com
   region: eu-central-1
 ----
-<1> Use the name `logging-loki-s3` to match the name used in LokiStack.
-<2> For the contents of the secret see the link:https://docs.redhat.com/en/documentation/red_hat_openshift_logging/{logging-major-version}/html/configuring_logging/configuring-lokistack-storage#logging-loki-storage_configuring-the-log-store[Loki object storage section].
++
+where:
++
+* `name: logging-loki-s3`: Must match the secret name referenced in the `LokiStack`.
+
 +
 --
 include::snippets/logging-retention-period-snip.adoc[leveloffset=+1]
 --
 
-. Apply the `Secret` object by running the following command:
+. Apply the secret:
 +
 [source,terminal]
 ----
 $ oc apply -f <filename>.yaml
 ----
 
-. Create a `LokiStack` CR:
+. Create a `LokiStack` custom resource (CR):
 +
-.Example `LokiStack` CR
 [source,yaml]
 ----
 apiVersion: loki.grafana.com/v1
 kind: LokiStack
 metadata:
-  name: logging-loki # <1>
-  namespace: openshift-logging # <2>
+  name: logging-loki
+  namespace: openshift-logging
 spec:
   managementState: Managed
   limits:
-    global: # <3>
-      retention: # <4>
-        days: 20 # Set the value as per requirement
-  size: 1x.small # <5>
+    global:
+      retention:
+        days: 20
+  size: 1x.small
   storage:
     schemas:
     - version: v13
-      effectiveDate: "<yyyy>-<mm>-<dd>" # <6>
+      effectiveDate: "<yyyy>-<mm>-<dd>"
     secret:
-      name: logging-loki-s3 # <7>
-      type: s3 # <8>
-  storageClassName: <storage_class_name> # <9>
+      name: logging-loki-s3
+      type: s3
+  storageClassName: <storage_class_name>
   tenants:
-    mode: openshift-logging # <10>
+    mode: openshift-logging
 ----
-<1> Use the name `logging-loki`.
-<2> You must specify `openshift-logging` as the namespace.
-<3> Define global limits that apply to the LokiStack instance. For information about setting stream-based retention, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_logging/6.3/html/configuring_logging/configuring-lokistack-storage#logging-loki-retention_configuring-the-log-store[Enabling stream-based retention with Loki]. This field does not impact the retention period for stored logs in object storage.
-<4> Retention is enabled in the cluster when this block is added to the CR.
-<5> Specify the deployment size. Supported size options for production instances of Loki are `1x.extra-small`, `1x.small`, or `1x.medium`. Additionally, `1x.pico` is supported starting with {logging} 6.1.
-<6> Set the date two months ago.
-<7> Specify the name of your log store secret.
-<8> Specify the corresponding storage type.
-<9> Specify the name of a storage class for temporary storage. For best performance, specify a storage class that allocates block storage. You can list the available storage classes for your cluster by using the `oc get storageclasses` command.
-<10> The `openshift-logging` mode is the default tenancy mode where a tenant is created for log types, such as audit, infrastructure, and application. This enables access control for individual users and user groups to different log streams.
++
+where:
++
+* `size: 1x.small`: Select a deployment size. Supported production sizes include `1x.extra-small`, `1x.small`, and `1x.medium`.
+* `effectiveDate`: Set a date two months before the current date.
+* `storageClassName`: Specify a storage class for temporary storage. Use block storage for better performance.
+* `mode: openshift-logging`: Enables multitenant logging for application, infrastructure, and audit logs.
 
-
-. Apply the `LokiStack` CR object by running the following command:
+. Apply the `LokiStack` CR:
 +
 [source,terminal]
 ----
@@ -187,24 +195,19 @@ $ oc apply -f <filename>.yaml
 
 .Verification
 
-* Verify the installation by running the following command:
+. Verify that the pods are running:
 +
 [source,terminal]
 ----
 $ oc get pods -n openshift-logging
 ----
 +
-.Example output
+You get an output similar to the following example:
++
 [source,terminal]
 ----
-$ oc get pods -n openshift-logging
 NAME                                               READY   STATUS    RESTARTS   AGE
 logging-loki-compactor-0                           1/1     Running   0          42m
-logging-loki-distributor-7d7688bcb9-dvcj8          1/1     Running   0          42m
-logging-loki-gateway-5f6c75f879-bl7k9              2/2     Running   0          42m
-logging-loki-gateway-5f6c75f879-xhq98              2/2     Running   0          42m
-logging-loki-index-gateway-0                       1/1     Running   0          42m
-logging-loki-ingester-0                            1/1     Running   0          42m
-logging-loki-querier-6b7b56bccc-2v9q4              1/1     Running   0          42m
-logging-loki-query-frontend-84fb57c578-gq2f7       1/1     Running   0          42m
+logging-loki-distributor-xxxx                      1/1     Running   0          42m
+...
 ----

--- a/modules/installing-loki-operator-web-console.adoc
+++ b/modules/installing-loki-operator-web-console.adoc
@@ -1,8 +1,12 @@
+// Module included in the following assemblies:
+// installing/installing-logging.adoc
+
 :_mod-docs-content-type: PROCEDURE
 [id="installing-loki-operator-web-console_{context}"]
 = Installing {loki-op} by using the web console
 
-Install {loki-op} on your {ocp-product-title} cluster to manage the log store `Loki` from the OperatorHub by using the {ocp-product-title} web console. You can deploy and configure the `Loki` log store by reconciling the resource LokiStack with the {loki-op}.
+[role="_abstract"]
+Install {loki-op} on your {ocp-product-title} cluster to manage the log store `Loki` from the OperatorHub by using the {ocp-product-title} web console. You can deploy and configure the `Loki` log store by reconciling the resource `LokiStack` with the {loki-op}.
 
 .Prerequisites
 
@@ -46,18 +50,22 @@ An Operator might display a `Failed` status before the installation completes. I
 
 .. Add the YAML definition for the `openshift-logging` namespace:
 +
-.Example `namespace` object
+The following example displays a `namespace` object:
++
 [source,yaml]
 ----
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: openshift-logging # <1>
+  name: openshift-logging
   labels:
-    openshift.io/cluster-monitoring: "true" # <2>
+    openshift.io/cluster-monitoring: "true"
 ----
-<1> The `openshift-logging` namespace is dedicated for all {logging} workloads.
-<2> A string value that specifies the label, as shown, to ensure that cluster monitoring scrapes the `openshift-logging` namespace.
++
+where:
++
+* `name: openshift-logging`: The `openshift-logging` namespace is dedicated for all {logging} workloads.
+* `openshift.io/cluster-monitoring: "true"`: A string value that specifies the label, as shown, to ensure that cluster monitoring scrapes the `openshift-logging` namespace.
 
 .. Click *Create*.
 
@@ -67,24 +75,27 @@ metadata:
 
 .. Add the YAML definition for the secret. For example, create a secret to access Amazon Web Services (AWS) s3:
 +
-.Example `Secret` object
+The following example displays a `Secret` object:
++
 [source,yaml]
 ----
 apiVersion: v1
 kind: Secret
 metadata:
-  name: logging-loki-s3 <1>
-  namespace: openshift-logging <2>
-stringData: <3>
+  name: logging-loki-s3
+  namespace: openshift-logging
+stringData:
   access_key_id: <access_key_id>
   access_key_secret: <secret_access_key>
   bucketnames: <s3_bucket_name>
   endpoint: https://s3.eu-central-1.amazonaws.com
   region: eu-central-1
 ----
-<1> Note down the name used for the secret `logging-loki-s3` to use it later when creating the `LokiStack` resource.
-<2> Set the namespace to `openshift-logging` as that will be the namespace used to deploy `LokiStack`.
-<3> For the contents of the secret see the link:https://docs.redhat.com/en/documentation/red_hat_openshift_logging/{logging-major-version}/html/configuring_logging/configuring-lokistack-storage#logging-loki-storage_configuring-the-log-store[Loki object storage section].
++
+where:
++
+* `name: logging-loki-s3`: Note down the name used for the secret `logging-loki-s3` to use it later when creating the `LokiStack` resource.
+* `namespace: openshift-logging`: Set the namespace to `openshift-logging` as that will be the namespace used to deploy `LokiStack`.
 +
 --
 include::snippets/logging-retention-period-snip.adoc[leveloffset=+1]
@@ -96,48 +107,51 @@ include::snippets/logging-retention-period-snip.adoc[leveloffset=+1]
 
 . Select *YAML view*, and then use the following template to create a `LokiStack` CR:
 +
---
-.Example `LokiStack` CR
+The following example displays a `LokiStack` CR:
++
 [source,yaml]
 ----
 apiVersion: loki.grafana.com/v1
 kind: LokiStack
 metadata:
-  name: logging-loki # <1>
-  namespace: openshift-logging # <2>
+  name: logging-loki
+  namespace: openshift-logging
 spec:
   managementState: Managed
   limits:
-    global: # <3>
-      retention: # <4>
+    global:
+      retention:
         days: 20 # Set the value as per requirement
-  size: 1x.small # <5>
+  size: 1x.small
   storage:
     schemas:
     - version: v13
-      effectiveDate: "<yyyy>-<mm>-<dd>" # <6>
+      effectiveDate: "<yyyy>-<mm>-<dd>"
     secret:
-      name: logging-loki-s3 # <7>
-      type: s3 # <8>
-  storageClassName: <storage_class_name> # <9>
+      name: logging-loki-s3
+      type: s3
+  storageClassName: <storage_class_name>
   tenants:
-    mode: openshift-logging # <10>
+    mode: openshift-logging
 ----
-<1> Use the name `logging-loki`.
-<2> You must specify `openshift-logging` as the namespace.
-<3> Define global limits that apply to the LokiStack instance. For information about setting stream-based retention, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_logging/6.3/html/configuring_logging/configuring-lokistack-storage#logging-loki-retention_configuring-the-log-store[Enabling stream-based retention with Loki]. This field does not impact the retention period for stored logs in object storage.
-<4> Retention is enabled in the cluster when this block is added to the CR.
-<5> Specify the deployment size. Supported size options for production instances of Loki are `1x.extra-small`, `1x.small`, or `1x.medium`. Additionally, `1x.pico` is supported starting with {logging} 6.1.
-<6> Set the date two months ago.
-<7> Specify the name of your log store secret.
-<8> Specify the corresponding storage type.
-<9> Specify the name of a storage class for temporary storage. For best performance, specify a storage class that allocates block storage. You can list the available storage classes for your cluster by using the `oc get storageclasses` command.
-<10> The `openshift-logging` mode is the default tenancy mode where a tenant is created for log types, such as audit, infrastructure, and application. This enables access control for individual users and user groups to different log streams.
---
++
+where:
++
+* `name: logging-loki`: Use the name `logging-loki`.
+* `namespace: openshift-logging`: You must specify `openshift-logging` as the namespace.
+* `global`: Define global limits that apply to the `LokiStack` instance. For information about setting stream-based retention. This field does not impact the retention period for stored logs in object storage.
+* `retention`: Retention is enabled in the cluster when this block is added to the CR.
+* `size: 1x.small`: Specify the deployment size. Supported size options for production instances of Loki are `1x.extra-small`, `1x.small`, or `1x.medium`. Additionally, `1x.pico` is supported starting with {logging} 6.1.
+* `effectiveDate: "<yyyy>-<mm>-<dd>`: Set the date two months ago.
+* `name: logging-loki-s3`: Specify the name of your log store secret.
+* `type: s3`: Specify the corresponding storage type.
+* `storageClassName: <storage_class_name>`: Specify the name of a storage class for temporary storage. For best performance, specify a storage class that allocates block storage. You can list the available storage classes for your cluster by using the `oc get storageclasses` command.
+* `mode: openshift-logging`: The `openshift-logging` mode is the default tenancy mode where a tenant is created for log types, such as audit, infrastructure, and application. This enables access control for individual users and user groups to different log streams.
 
 . Click *Create*.
 
 .Verification
 
 . In the *LokiStack* tab verify that you see your `LokiStack` instance.
+
 . In the *Status* column, verify that you see the message `Condition: Ready` with a green checkmark.

--- a/modules/installing-the-logging-ui-plug-in-cli.adoc
+++ b/modules/installing-the-logging-ui-plug-in-cli.adoc
@@ -1,14 +1,11 @@
 // Module included in the following assemblies:
-//
-// * installing/installing-logging.adoc
+// installing/installing-logging.adoc
 
-:_newdoc-version: 2.18.4
-:_template-generated: 2025-04-18
 :_mod-docs-content-type: PROCEDURE
-
 [id="installing-the-logging-ui-plugin-cli_{context}"]
 = Installing the logging UI plugin by using the CLI
 
+[role="_abstract"]
 Install the logging UI plugin by using the command-line interface (CLI) so that you can visualize logs.
 
 .Prerequisites
@@ -17,37 +14,42 @@ Install the logging UI plugin by using the command-line interface (CLI) so that 
 * You installed and configured {loki-op}.
 
 .Procedure
-. Install the {coo-full}. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_cluster_observability_operator/{coo-version}/html/installing_red_hat_openshift_cluster_observability_operator/installing-the-cluster-observability-operator[Installing the Cluster Observability Operator].
+
+. Install the {coo-full}.
 
 . Create a `UIPlugin` custom resource (CR):
 +
-.Example `UIPlugin` CR
+The following example displays a `UIPlugin` CR:
++
 [source,yaml]
 ----
 apiVersion: observability.openshift.io/v1alpha1
 kind: UIPlugin
 metadata:
-  name: logging  # <1>
+  name: logging
 spec:
-  type: Logging  # <2>
+  type: Logging
   logging:
     lokiStack:
-      name: logging-loki  # <3>
+      name: logging-loki
     logsLimit: 50
     timeout: 30s
-    schema: otel # <4>
+    schema: otel
 ----
-<1> Set `name` to `logging`.
-<2> Set `type` to `Logging`.
-<3> The `name` value must match the name of your LokiStack instance. If you did not install LokiStack in the `openshift-logging` namespace, set the LokiStack namespace under the `lokiStack` configuration.
-<4> `schema` is one of `otel`, `viaq`, or `select`. The default is `viaq` if no value is specified. When you choose `select`, you can select the mode in the UI when you run a query.
++
+where:
++
+* `name: logging`: Set `name` to `logging`.
+* `type: Logging`: Set `type` to `Logging`.
+* `name: logging-loki`: The `name` value must match the name of your `LokiStack` instance. If you did not install `LokiStack` in the `openshift-logging` namespace, set the `LokiStack` namespace under the `lokiStack` configuration.
+* `schema: otel`: `schema` is one of `otel`, `viaq`, or `select`. The default is `viaq` if no value is specified. When you choose `select`, you can select the mode in the UI when you run a query.
 +
 [NOTE]
 ====
-These are the known issues for the logging UI plugin - for more information, see link:https://issues.redhat.com/browse/OU-587[OU-587].
+These are the known issues for the logging UI plugin. For more information, see link:https://issues.redhat.com/browse/OU-587[OU-587].
 
 * The `schema` feature is only supported in {product-title} 4.15 and later. In earlier versions of {product-title}, the logging UI plugin will only use the `viaq` attribute, ignoring any other values that might be set.
-* Non-administrator users cannot query logs using the `otel` attribute with {logging} {for} versions 5.8 to 6.2. This issue will be fixed in a future {logging} release. (https://issues.redhat.com/browse/LOG-6589[LOG-6589])
+* Non-administrator users cannot query logs using the `otel` attribute with {logging} {for} versions 5.8 to 6.2. This issue will be fixed in a future {logging} release. (link:https://issues.redhat.com/browse/LOG-6589[LOG-6589])
 * In {logging} {for} version 5.9, the `severity_text` Otel attribute is not set.
 ====
 
@@ -61,4 +63,4 @@ $ oc apply -f <filename>.yaml
 .Verification
 
 . Access the {product-title} web console, and refresh the page if a pop-up message instructs you to do so.
-. Navigate to the *Observe → Logs* panel, where you can run LogQL queries. You can also query logs for individual pods from the *Aggregated Logs* tab of a specific pod.
+. Navigate to the *Observe → Logs* panel, where you can run `LogQL` queries. You can also query logs for individual pods from the *Aggregated Logs* tab of a specific pod.

--- a/modules/installing-the-logging-ui-plug-in-gui.adoc
+++ b/modules/installing-the-logging-ui-plug-in-gui.adoc
@@ -1,7 +1,5 @@
 // Module included in the following assemblies:
-//
-// * installing/installing-logging.adoc
-// * upgrading/upgrading-to-logging-60.adoc
+// installing/installing-logging.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="installing-the-logging-ui-plugin_gui{context}"]
@@ -23,7 +21,6 @@ Install the logging UI plugin by using the web console so that you can visualize
 . Select the YAML view, and then use the following template to create a `UIPlugin` custom resource (CR):
 +
 The following example displays a `UIPlugin` CR:
-+
 [source,yaml]
 ----
 apiVersion: observability.openshift.io/v1alpha1
@@ -39,12 +36,12 @@ spec:
     timeout: 30s
     schema: otel
 ----
-
-Where:
-
-* `name: logging`:  Set `name` to `logging`.
++
+where:
++
+* `name: logging`: Set `name` to `logging`.
 * `type: Logging`: Set `type` to `Logging`.
-* `name: logging-loki`: The `name` value must match the name of your LokiStack instance. If you did not install LokiStack in the `openshift-logging` namespace, set the LokiStack namespace under the `lokiStack` configuration.
+* `name: logging-loki`: The `name` value must match the name of your `LokiStack` instance. If you did not install `LokiStack` in the `openshift-logging` namespace, set the `LokiStack` namespace under the `lokiStack` configuration.
 * `schema: otel`: `schema` is one of `otel`, `viaq`, or `select`. The default is `viaq` if no value is specified. When you choose `select`, you can select the mode in the UI when you run a query.
 +
 [NOTE]
@@ -52,7 +49,7 @@ Where:
 These are the known issues for the logging UI plugin - for more information, see link:https://issues.redhat.com/browse/OU-587[OU-587].
 
 * The `schema` feature is only supported in {ocp-product-title} 4.15 and later. In earlier versions of {ocp-product-title}, the logging UI plugin will only use the `viaq` attribute, ignoring any other values that might be set.
-* Non-administrator users cannot query logs using the `otel` attribute with {logging} {for} versions 5.8 to 6.2. This issue will be fixed in a future {logging} release. (https://issues.redhat.com/browse/LOG-6589[LOG-6589])
+* Non-administrator users cannot query logs using the `otel` attribute with {logging} {for} versions 5.8 to 6.2. This issue will be fixed in a future {logging} release. (link:https://issues.redhat.com/browse/LOG-6589[LOG-6589])
 * In {logging} {for} version 5.9, the `severity_text` Otel attribute is not set.
 ====
 

--- a/modules/logging-installation-prereqs.adoc
+++ b/modules/logging-installation-prereqs.adoc
@@ -1,0 +1,20 @@
+:_mod-docs-content-type: CONCEPT
+[id="logging-installation-prereqs_{context}"]
+= Prerequisites for {logging} installation
+
+[role="_abstract"]
+To get started with {logging}, install the required Operators and understand their roles and dependencies.
+
+{logging} uses multiple Operators to manage log collection, storage, and visualization:
+
+* Install the {loki-op} to manage log storage.
+* Install the {clo} to collect and forward logs.
+* Install the {coo-first} to visualize logs.
+
+You can install and configure these Operators by using the {ocp-product-title} web console or the {ocp-product-title} CLI.
+
+[IMPORTANT]
+====
+* Configure the {clo} only after you install the {loki-op}.
+* Install the {clo} and the {loki-op} with the same major and minor versions.
+====

--- a/modules/uninstalling-the-cluster-logging-operator.adoc
+++ b/modules/uninstalling-the-cluster-logging-operator.adoc
@@ -1,0 +1,9 @@
+// Module included in the following assemblies:
+// uninstalling/uninstalling-logging.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="uninstalling-the-cluster-logging-operator_{context}"]
+= Uninstalling the {clo}
+
+[role="_abstract"]
+You can uninstall {clo} by using either the {oc-first} or the {product-title} web console.

--- a/modules/uninstalling-the-loki-operator.adoc
+++ b/modules/uninstalling-the-loki-operator.adoc
@@ -1,0 +1,9 @@
+// Module included in the following assemblies:
+// uninstalling/uninstalling-logging.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="uninstalling-the-loki-operator_{context}"]
+= Uninstalling the {loki-op}
+
+[role="_abstract"]
+You can uninstall {loki-op} by using either the {oc-first} or the {product-title} web console. After uninstalling {loki-op}, delete persistent volume claims (PVCs) if you do not want to reuse them in other installations of `LokiStack`.

--- a/modules/uninstalling-the-uiplugin.adoc
+++ b/modules/uninstalling-the-uiplugin.adoc
@@ -1,0 +1,9 @@
+// Module included in the following assemblies:
+// uninstalling/uninstalling-logging.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="uninstalling-the-uiplugin_{context}"]
+= Uninstalling the UIPlugin
+
+[role="_abstract"]
+You can uninstall `UIPlugin` by using either the {oc-first} or the {product-title} web console.

--- a/uninstalling/uninstalling-logging.adoc
+++ b/uninstalling/uninstalling-logging.adoc
@@ -1,24 +1,21 @@
 :_mod-docs-content-type: ASSEMBLY
-include::_attributes/common-attributes.adoc[]
 [id="uninstalling-logging"]
 = Uninstalling logging
+include::_attributes/common-attributes.adoc[]
 :context: installing-logging
 
 toc::[]
 
-[id="uninstalling-the-cluster-logging-operator_{context}"]
-== Uninstalling the {clo}
+[role="_abstract"]
+The following section provides instructions to uninstall the {clo}, {loki-op}, and `UIPlugin` from your cluster.
 
-You can uninstall {clo} by using either the {oc-first} or the {product-title} web console.
+include::modules/uninstalling-the-cluster-logging-operator.adoc[leveloffset=+1]
 
 include::modules/deleting-the-cluster-logging-operator-by-using-the-cli.adoc[leveloffset=+2]
 
 include::modules/deleting-the-cluster-logging-operator-by-using-the-web-console.adoc[leveloffset=+2]
 
-[id="uninstalling-the-loki-operator_{context}"]
-== Uninstalling the {loki-op}
-
-You can uninstall {loki-op} by using either the {oc-first} or the {product-title} web console. After uninstalling {loki-op}, delete persistent volume claims (PVCs) if you do not want to reuse them in other installations of LokiStack.
+include::modules/uninstalling-the-loki-operator.adoc[leveloffset=+1]
 
 include::modules/deleting-the-loki-operator-by-using-the-cli.adoc[leveloffset=+2]
 
@@ -28,11 +25,13 @@ include::modules/deleting-logging-pvcs-by-using-the-cli.adoc[leveloffset=+2]
 
 include::modules/deleting-logging-pvcs-by-using-the-web-console.adoc[leveloffset=+2]
 
-[id="uninstalling-the-uiplugin_{context}"]
-== Uninstalling the UIPlugin
-
-You can uninstall `UIPlugin` by using either the {oc-first} or the {product-title} web console.
+include::modules/uninstalling-the-uiplugin.adoc[leveloffset=+1]
 
 include::modules/deleting-the-uiplugin-by-using-the-cli.adoc[leveloffset=+2]
 
 include::modules/deleting-the-uiplugin-by-using-the-web-console.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+== Additional resources
+
+* link:https://docs.redhat.com/en/documentation/openshift_container_platform/latest/html-single/storage/index#reclaim-manual_understanding-persistent-storage[Reclaiming a persistent volume manually]


### PR DESCRIPTION
Cherry-picked from #110009

Commit ID: 23309debd172b0aa02023e903844ee78eb8eb0f5

**Note for the peer & merge reviewer:** 
- This PR updates the only "Installing & uninstalling logging" sections to prepare them for Phase 0 DITA migration.
- No other CQA changes, error types, or content refinements are included. 

**Changes:** 
This PR prepares the "Installing logging" section for Phase 0 DITA migration by applying Vale (AsciiDoc DITA) rules and cleaning up the existing content.

**Doc preview:** 
- [v6.2 Installing](https://110675--ocpdocs-pr.netlify.app/openshift-logging/latest/installing/installing-logging.html)
- [v6.2 Uninstalling](https://110675--ocpdocs-pr.netlify.app/openshift-logging/latest/uninstalling/uninstalling-logging.html)

**Tracking JIRA:** https://redhat.atlassian.net/browse/OBSDOCS-3258

**Reviews:**
- [x] Peer has approved this change