### PR TITLE
OSSM 9894_DNS capture

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ commercial_package
 .vale/styles/AsciiDocDITA
 .vale/styles/OpenShiftAsciiDoc
 .vale/styles/RedHat
+migrating/JIRA-9894-dns-capture-documentation-plan.md

--- a/migrating/checklists/ossm-migrating-read-me.adoc
+++ b/migrating/checklists/ossm-migrating-read-me.adoc
@@ -38,6 +38,8 @@ include::modules/ossm-migrating-read-me-kubernetes-network-policy-management.ado
 
 include::modules/ossm-migrating-read-me-tls-configuration-change.adoc[leveloffset=+1]
 
+include::modules/ossm-migrating-read-me-dns-capture-configuration.adoc[leveloffset=+1]
+
 [role="_additional-resources"]
 [id="additional-resources_{context}"]
 == Additional resources

--- a/modules/ossm-migrating-2-and-3-differences.adoc
+++ b/modules/ossm-migrating-2-and-3-differences.adoc
@@ -23,5 +23,6 @@ If you are a current {SMProductName} user, there are several important differenc
 * Support for Istioctl
 * Change to Kubernetes network policy management
 * Transport layer security (TLS) configuration change
+* DNS capture configuration for ServiceEntry resources
 
 You must be using {SMProduct} 2.6 to migrate to {SMProduct} 3.

--- a/modules/ossm-migrating-read-me-dns-capture-configuration.adoc
+++ b/modules/ossm-migrating-read-me-dns-capture-configuration.adoc
@@ -1,0 +1,22 @@
+// Module included in the following assemblies:
+//
+// * service-mesh-docs-main/migrating/checklists/ossm-migrating-read-me.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="ossm-migrating-read-me-dns-capture-configuration_{context}"]
+= DNS capture configuration for ServiceEntry resources
+
+[role="_abstract"]
+
+To maintain access to external services when migrating to {SMProductName} 3.0, you must explicitly enable DNS capture in the proxy metadata settings.
+
+This is required for any `ServiceEntry` resources that rely on DNS resolution. Failure to enable this feature results in application errors such as `Name or service not known`.
+
+{SMProduct} 2.6 enabled DNS capture by default to support federation, which did not align with the upstream {istio} project. {SMProduct} 3.0 removes this default configuration and aligns with the upstream project's multicluster topologies.
+
+To configure DNS capture in {SMProduct} 3.0, set the `ISTIO_META_DNS_AUTO_ALLOCATE` and `ISTIO_META_DNS_CAPTURE` fields to `true` in the `spec.values.meshConfig.defaultConfig.proxyMetadata` path of your `{istio}` resource. 
+
+[NOTE]
+====
+The equivalent of `spec.values.meshConfig.defaultConfig.proxyMetadata` in {SMProduct} 2.6 was `spec.proxy.runtime.container.env`.
+====


### PR DESCRIPTION
[OSSM-9894](https://redhat.atlassian.net/browse/OSSM-9894): behavior change between OSSM 2.x and 3.x

**PEER REVIEWER:** Please note that this new module follows an established pattern in a migration guide that probably doesn't have a very long shelf life.

Version(s):
service-mesh-docs-3.0

Issue:
https://redhat.atlassian.net/browse/OSSM-9894

Link to docs preview:
https://110676--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/migrating/checklists/ossm-migrating-read-me.html#ossm-migrating-read-me-dns-capture-configuration_ossm-migrating-read-me

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
