### PR TITLE
[gitops-docs-1.20] RHDEVDOCS-7100: CQA 2.0 fixes for Configuring a cluster-scoped Argo Rollouts instance to manage rollout resources

### DIFF
--- a/argo_rollouts/using-cluster-scoped-rollouts-instance-to-manage-rollouts-resources.adoc
+++ b/argo_rollouts/using-cluster-scoped-rollouts-instance-to-manage-rollouts-resources.adoc
@@ -6,15 +6,16 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-By default, Argo Rollouts supports the cluster-scoped mode of installation for Argo Rollouts custom resources (CRs). This mode of installation uses the `CLUSTER_SCOPED_ARGO_ROLLOUTS_NAMESPACES` environment variable to specify a list of namespaces that can be used to manage the rollout resources.
+[role="_abstract"]
+Cluster-scoped installation mode allows a single Argo Rollouts controller instance to manage rollout resources across multiple namespaces. This reduces resource consumption compared to deploying separate namespace-scoped controllers in each namespace. You can control which namespaces a cluster-scoped RolloutManager instance manages by setting the `CLUSTER_SCOPED_ARGO_ROLLOUTS_NAMESPACES` environment variable in the {gitops-title} Operator Subscription to a comma-separated list of namespace names. 
 
-To manage Argo Rollouts resources, after you install the {gitops-title} Operator on the cluster, you can create and configure a `RolloutManager` custom resource (CR) instance in the namespace of your choice. You can then update the existing `Subscription` object for the {gitops-title} Operator and add user-defined namespaces to the `CLUSTER_SCOPED_ARGO_ROLLOUTS_NAMESPACES` environment variable in the `spec` section of the Argo CD instance.
+To configure a cluster-scoped Argo Rollouts instance, you must first install the {gitops-title} Operator, create a `RolloutManager` custom resource (CR), and then update the Operator Subscription to specify the namespaces.
 
 [id="prerequisites_{context}"]
 == Prerequisites
 * You have logged in to the {OCP} cluster as an administrator.
 * You have installed the {gitops-title} Operator on your {OCP} cluster.
-* You have created a `RolloutManager` custom resource.
+* You have created a `RolloutManager` custom resource in the namespace where you want to run the Argo Rollouts controller.
 
 // Configuring a cluster-scoped Argo Rollouts instance to manage rollout resources 
 include::modules/gitops-configuring-a-cluster-scoped-argo-rollouts-instance-to-manage-rollouts-resources.adoc[leveloffset=+1]

--- a/modules/gitops-configuring-a-cluster-scoped-argo-rollouts-instance-to-manage-rollouts-resources.adoc
+++ b/modules/gitops-configuring-a-cluster-scoped-argo-rollouts-instance-to-manage-rollouts-resources.adoc
@@ -6,12 +6,8 @@
 [id="gitops-configuring-a-cluster-scoped-argo-rollouts-instance-to-manage-rollouts-resources_{context}"]
 = Configuring a cluster-scoped Argo Rollouts instance to manage rollout resources
 
-To configure a cluster-scoped Argo Rollouts instance for managing rollout resources, add the `CLUSTER_SCOPED_ARGO_ROLLOUTS_NAMESPACES` environment variable in the `Subscription` resource. This variable contains a list of user-defined namespaces which can be configured for a cluster-scoped Argo Rollouts installation. If the `CLUSTER_SCOPED_ARGO_ROLLOUTS_NAMESPACES` environment variable is empty, you can create cluster-scoped Argo Rollouts installation in the `openshift-gitops` namespace.
-
-[NOTE]
-====
-You can only create a cluster-scoped Argo Rollouts instance if the `NAMESPACE_SCOPED_ARGO_ROLLOUTS` variable is set to `false`. By default, if the `NAMESPACE_SCOPED_ARGO_ROLLOUTS` variable is not defined, it is set to `false`.
-====
+[role="_abstract"]
+To configure which namespaces a cluster-scoped Argo Rollouts instance manages, set the `CLUSTER_SCOPED_ARGO_ROLLOUTS_NAMESPACES` environment variable in the {gitops-title} Operator Subscription to a comma-separated list of namespace names. If this variable is not set, the RolloutManager manages rollouts only in the namespace where it is deployed.
 
 .Procedure
 
@@ -19,7 +15,7 @@ You can only create a cluster-scoped Argo Rollouts instance if the `NAMESPACE_SC
 
 . Click the *Actions* list and then click *Edit Subscription*.
 
-. On the *openshift-gitops-operator* Subscription details page, under the *YAML* tab, edit the `Subscription` YAML file by adding the namespace of the Argo CD instance to the `CLUSTER_SCOPED_ARGO_ROLLOUTS_NAMESPACES` environment variable in the `spec` section:
+. On the *openshift-gitops-operator* Subscription details page, under the *YAML* tab, edit the `Subscription` YAML file by setting the `CLUSTER_SCOPED_ARGO_ROLLOUTS_NAMESPACES` environment variable to a comma-separated list of namespaces:
 +
 --
 *Example configuring the `CLUSTER_SCOPED_ARGO_ROLLOUTS_NAMESPACES` environment variable:*
@@ -31,20 +27,30 @@ metadata:
   name: openshift-gitops-operator
 spec:
   config:
-   env: 
-    - name: NAMESPACE_SCOPED_ARGO_ROLLOUTS
-      value: 'false'
-    - name: CLUSTER_SCOPED_ARGO_ROLLOUTS_NAMESPACES
-      value: <list_of_namespaces_in_the_cluster-scoped_Argo_CD_instances>
- ...
+    env:
+      - name: NAMESPACE_SCOPED_ARGO_ROLLOUTS
+        value: "false"
+      - name: CLUSTER_SCOPED_ARGO_ROLLOUTS_NAMESPACES
+        value: "namespace1,namespace2,namespace3"
 ----
 --
 +
 --
 where:
 
-spec.config.env.value ('false'):: Specify this value to enable or disable the cluster-scoped installation. Set the value to `'false'` to enable cluster-scoped installation. Set to `'true'` to enable namespace-scoped installation. If this value is empty, the operator defaults to `false`.
-spec.config.env.value (list_of_namespaces):: Specifies a comma-separated list of namespaces that can host a cluster-scoped Argo Rollouts instance, for example `test-123-cluster-scoped,test-456-cluster-scoped`.
+`spec.config.env[].value` (NAMESPACE_SCOPED_ARGO_ROLLOUTS):: Specify this value to enable or disable the cluster-scoped installation. Set the value to `'false'` to enable cluster-scoped installation. Set to `'true'` to enable namespace-scoped installation. If this value is empty, the operator defaults to `false`.
+`spec.config.env[].value` (CLUSTER_SCOPED_ARGO_ROLLOUTS_NAMESPACES):: Specifies a comma-separated list of namespaces that can host a cluster-scoped Argo Rollouts instance. For example `test-123-cluster-scoped,test-456-cluster-scoped`.
 --
 
 . Click *Save* and *Reload*.
+
+.Verification
+
+Verify that the {gitops-title} Operator has restarted after the Subscription update:
+
+. In the Administrator perspective, navigate to *Workloads* → *Pods*.
+. Locate the `openshift-gitops-operator-controller-manager` pod and verify that it has a recent restart time.
+. Verify that the Argo Rollouts controller is managing the specified namespaces:
+.. Navigate to the namespace where you created the RolloutManager CR.
+.. Click the argo-rollouts- pod, and then click the Logs tab.
+.. Confirm that the logs show the controller is watching the namespaces you specified in CLUSTER_SCOPED_ARGO_ROLLOUTS_NAMESPACES.


### PR DESCRIPTION
This PR is a manual cherry pick of https://github.com/openshift/openshift-docs/pull/109847