### PR TITLE
TELCODOCS-2613-RN422 MetalLB ConfigurationState release note

### DIFF
--- a/modules/rn-ocp-release-notes-new-features.adoc
+++ b/modules/rn-ocp-release-notes-new-features.adoc
@@ -189,6 +189,15 @@ The `commatrix` plugin generates `nftables` firewall rules in Butane format for 
 +
 For more information, see xref:../installing/install_config/configuring-firewall.adoc#commatrix-generate-butane_configuring-firewall[Generate nftables firewall rules in Butane format].
 
+// TELCODOCS-2613
+MetalLB ConfigurationState resource reports controller and speaker configuration health::
++
+You can now use the new `ConfigurationState` custom resource to verify that MetalLB has successfully applied your settings across the cluster. This feature provides a single, consistent location to identify configuration errors that were previously only visible by searching through individual node logs or FRR status reports
++
+MetalLB creates a `ConfigurationState` resource for the controller and for each speaker node. Each resource reports whether your configuration is valid and surfaces specific error details if validation fails, such as issues with `IPAddressPool`, `BGPPeer`, or `BFDProfile` objects. This centralized reporting helps you monitor system integrity and resolve networking conflicts more quickly.
++
+For more information, see xref:../networking/ingress_load_balancing/metallb/monitoring-metallb-status.adoc#nw-metallb-checking-configuration-status_monitor-metallb-config-status[Checking MetalLB configuration status].
+
 [id="ocp-release-notes-nodes_{context}"]
 == Nodes
 


### PR DESCRIPTION
Version(s): 4.22

Issue: https://redhat.atlassian.net/browse/TELCODOCS-2613

QE review:
- [x] QE has approved this change.

Preview: https://110692--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-22-release-notes.html#ocp-release-notes-networking_release-notes

Additional information:
Add release note for the new MetalLB `ConfigurationState` CRD feature under the Networking section.
