### PR TITLE
TELCODOCS-2272-RN422 NUMA-aware scheduler 500 node scalability release note

### DIFF
--- a/modules/rn-ocp-release-notes-new-features.adoc
+++ b/modules/rn-ocp-release-notes-new-features.adoc
@@ -184,6 +184,12 @@ Detailed information.
 [id="ocp-release-notes-scale-and-perform_{context}"]
 == Scalability and performance
 
+// TELCODOCS-2272
+NUMA-aware scheduler supports clusters with up to 500 nodes::
++
+With this release, you can scale the NUMA-aware secondary scheduler to support clusters with up to 500 nodes. The scheduler defaults to a `Burstable` quality of service (QoS) profile, which reduces baseline resource consumption while allowing the scheduler to scale up during peak loads.
++
+For more information, see xref:../scalability_and_performance/cnf-numa-aware-scheduling.adoc#cnf-topology-aware-scheduler-scalability_numa-aware[Topology-aware scheduler scalability].
 
 // [id="ocp-release-notes-support-sigstore_{context}"]
 // == Support for sigstore bring your own PKI (BYOPKI) image validation


### PR DESCRIPTION
Version(s): 4.22

Issue: https://redhat.atlassian.net/browse/TELCODOCS-2272

Preview: https://110693--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-22-release-notes.html#ocp-release-notes-scale-and-perform_release-notes

QE review:
- [x] QE has approved this change.

Additional information:
Add release note for the NUMA-aware scheduler scalability to 500 nodes and QoS default change under the Scalability and performance section.
