### PR TITLE
[OSDOCS-19329]: Networking overview for HCP

### DIFF
--- a/hosted_control_planes/hcp-networking.adoc
+++ b/hosted_control_planes/hcp-networking.adoc
@@ -9,6 +9,12 @@ toc::[]
 [role="_abstract"]
 Ensure optimal performance with {hcp} by configuring network settings. Those settings include internal subnets and proxy support for control-plane workloads, compute nodes, management clusters, and hosted clusters.
 
+include::modules/hcp-networking-overview.adoc[leveloffset=+1]
+
+//include::modules/hcp-network-planning.adoc[leveloffset=+2]
+
+//include::modules/hcp-network-segmentation.adoc[leveloffset=+2]
+
 //hcp isolation overview
 include::modules/hcp-isolation-overview.adoc[leveloffset=+1]
 
@@ -20,14 +26,23 @@ include::modules/hcp-isolation-overview.adoc[leveloffset=+1]
 //control plane isolation
 include::modules/hcp-isolation.adoc[leveloffset=+2]
 
+//firewall, port, and svc reqs
+include::modules/hcp-networking-firewall.adoc[leveloffset=+1]
+
+include::modules/hcp-bm-firewall-port-svc-reqs.adoc[leveloffset=+2]
+
+include::modules/hcp-virt-firewall-port.adoc[leveloffset=+2]
+
+include::modules/hcp-non-bm-firewall-port-svc-reqs.adoc[leveloffset=+2]
+
+include::modules/hcp-ingress-egress-example.adoc[leveloffset=+2]
+
 //ingress and egress for hcp
 include::modules/hcp-ingress-egress-reqs.adoc[leveloffset=+1]
 
 include::modules/hcp-ingress-reqs.adoc[leveloffset=+2]
 
 include::modules/hcp-egress-reqs.adoc[leveloffset=+2]
-
-include::modules/hcp-ingress-egress-example.adoc[leveloffset=+2]
 
 include::modules/hcp-bm-ingress.adoc[leveloffset=+2]
 

--- a/modules/hcp-networking-firewall.adoc
+++ b/modules/hcp-networking-firewall.adoc
@@ -1,0 +1,10 @@
+// Module included in the following assemblies:
+//
+// * hosted_control_planes/hcp-networking.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="hcp-networking-firewall_{context}"]
+= Firewall, port, and service requirements for {hcp}
+
+[role="_abstract"]
+Ensure that you meet the firewall and port requirements so that ports can communicate between the management cluster, the control plane, and hosted clusters.

--- a/modules/hcp-networking-firewall.adoc
+++ b/modules/hcp-networking-firewall.adoc
@@ -1,0 +1,10 @@
+// Module included in the following assemblies:
+//
+// * hosted_control_planes/hcp-networking.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="hcp-networking-firewall_{context}"]
+= Firewall, port, and service requirements for {hcp}
+
+[role="_abstract"]
+Ensure that you meet the firewall, port, and service requirements so that ports can communicate between the management cluster, the control plane, and hosted clusters.

--- a/modules/hcp-networking-overview.adoc
+++ b/modules/hcp-networking-overview.adoc
@@ -1,0 +1,39 @@
+// Module included in the following assemblies:
+//
+// * hosted_control_planes/hcp-networking.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="hcp-networking-overview_{context}"]
+= Networking overview for {hcp}
+
+[role="_abstract"]
+Proper network design can ensure the performance, automation, and security of {hcp}. Your network configuration depends on the provider that you use, such as bare metal on the Agent platform or {VirtProductName}, and the segmentation that you need.
+
+For example, for {hcp} on {VirtProductName}, you can create `NodePool` virtual machines (VMs) with different network configurations, including using the pod network, bridging an external network into the VMs, and using a user-defined network (UDN) that uses localnet topology. Network latency and throughput are important factors to ensure control-plane communication, workload traffic, and storage access. The use of dedicated physical network adapters can ensure adequate throughput and low latency for all components.
+
+[id="hcp-networking-considerations_{context}"]
+== Control plane and data plane networking considerations
+
+When you consider your networking configuration for {hcp}, remember the structure of the control plane and data plane:
+
+Control plane:: The control plane includes pods that run on the management cluster in a dedicated namespace. The pods expose the hosted control plane `kube-apiserver` component, OAuth, Ignition server, and Konnectivity service. Hosted cluster nodes access those services through the data plane network, so the services must be reachable from the data plane network, even if a firewall is in place.
++
+The management cluster hosts different control planes, and their services are exposed through its network. Network segmentation by API is not currently supported.
+
+Data plane:: The data plane includes compute nodes that are represented by bare-metal servers or VMs that are hosted on {VirtProductName}. The data plane has a minimum of 2 nodes, and hosts default ingress controller and user applications.
++
+For {VirtProductName}, you can host different data planes on the management cluster. For bare-metal servers or an external {VirtProductName} cluster, you can host data planes by external infrastructure. Some VLAN-based network segmentation is possible if the following conditions are true: 
+
+** All of the configured VLANs can route traffic to the endpoints of the API, OAuth, Ignition server, and Konnectivity service.
+** Hosted cluster users can access the API and OAuth.
+
++
+The node pools in hosted clusters on the data plane depend on the components that run on the control plane, such as Konnectivity, Ignition, and OAuth. By default, you install those components by using a `Route` endpoint publishing strategy, and admit them on the default ingress controller, which is often installed on primary networks from the management cluster. To segment this implementation on a secondary network, you must change several network flows between the control plane and the data plane.
+
+[id="hcp-networking-dhcp_{context}"]
+== DHCP requirements for {hcp}
+
+The requirements for Dynamic Host Configuration Protocol (DHCP) differ depending on your platform provider:
+
+* For bare metal providers, you can use dynamic or manual IP segmentation, so a DHCP server is not mandatory. Ensure that the same node always has the same IP address.
+* For {VirtProductName}, dynamic IP assignment is the only option, so a DHCP server is mandatory.

--- a/modules/hcp-networking-overview.adoc
+++ b/modules/hcp-networking-overview.adoc
@@ -1,0 +1,41 @@
+// Module included in the following assemblies:
+//
+// * hosted_control_planes/hcp-networking.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="hcp-networking-overview_{context}"]
+= Networking overview for {hcp}
+
+[role="_abstract"]
+Proper network design can ensure the performance, automation, and security of {hcp}. Your network configuration depends on the segmentation that you need and the provider that you use, such as a cloud provider, bare metal on the Agent platform, or {VirtProductName}.
+
+For example, for {hcp} on {VirtProductName}, you can create `NodePool` virtual machines (VMs) with different network configurations, including using the pod network and bridging an external network into the VMs. Network latency and throughput are important factors to ensure control-plane communication, workload traffic, and storage access. The use of dedicated physical network adapters can ensure adequate throughput and low latency for all components.
+
+[id="hcp-networking-considerations_{context}"]
+== Control plane and data plane networking considerations
+
+When you consider your networking configuration for {hcp}, remember the structure of the control plane and data plane:
+
+Control plane:: The control plane includes pods that run on the management cluster in a dedicated namespace. The pods expose the hosted control plane `kube-apiserver` component, OAuth, Ignition server, and Konnectivity service. Hosted cluster nodes access those services through the data plane network, so the services must be reachable from the data plane network, even if a firewall is in place.
++
+The management cluster hosts different control planes, and their services are exposed through its network. Network segmentation by API is not currently supported.
+
+Data plane:: The data plane includes the compute, storage, and networking where workloads and applications run. It has a minimum of 2 compute nodes. 
++
+For example, the data plane includes compute nodes that are represented by bare-metal servers or VMs that are hosted on {VirtProductName}. For {VirtProductName}, you can host different data planes on the management cluster. For bare-metal servers or an external {VirtProductName} cluster, you can host data planes by external infrastructure.
++
+Some VLAN-based network segmentation is possible if the following conditions are true: 
+
+** All of the configured VLANs can route traffic to the endpoints of the API, OAuth, Ignition server, and Konnectivity service.
+** Hosted cluster users can access the API and OAuth.
+
++
+The node pools in hosted clusters on the data plane depend on the components that run on the control plane, such as Konnectivity, Ignition, and OAuth. By default, you install those components by using a `Route` endpoint publishing strategy, and admit them on the default ingress controller, which is often installed on primary networks from the management cluster. To segment this implementation on a secondary network, you must change several network flows between the control plane and the data plane.
+
+[id="hcp-networking-dhcp_{context}"]
+== DHCP requirements for {hcp}
+
+The requirements for Dynamic Host Configuration Protocol (DHCP) differ depending on your platform provider:
+
+* For bare metal providers, you can use dynamic or manual IP segmentation, so a DHCP server is not mandatory. Ensure that the same node always has the same IP address.
+* For {VirtProductName}, dynamic IP assignment is the only option, so a DHCP server is mandatory.

--- a/modules/hcp-virt-firewall-port.adoc
+++ b/modules/hcp-virt-firewall-port.adoc
@@ -4,8 +4,9 @@
 
 :_mod-docs-content-type: CONCEPT
 [id="hcp-virt-firewall-port_{context}"]
-= Firewall and port requirements
+= {VirtProductName} firewall and port requirements
 
+[role="_abstract"]
 Ensure that you meet the firewall and port requirements so that ports can communicate between the management cluster, the control plane, and hosted clusters:
 
 * The `kube-apiserver` service runs on port 6443 by default and requires ingress access for communication between the control plane components.

--- a/modules/hcp-virt-firewall-port.adoc
+++ b/modules/hcp-virt-firewall-port.adoc
@@ -4,7 +4,7 @@
 
 :_mod-docs-content-type: CONCEPT
 [id="hcp-virt-firewall-port_{context}"]
-= Firewall and port requirements
+= {VirtProductName} firewall and port requirements
 
 [role="_abstract"]
 Ensure that you meet the firewall and port requirements so that ports can communicate between the management cluster, the control plane, and hosted clusters.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.18+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://redhat.atlassian.net/browse/OSDOCS-19329
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://110711--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-networking.html#hcp-networking-overview_hcp-networking
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Note for reviewers:
This PR adds a high-level overview of networking for hosted control planes. In subsequent PRs, I will add more granular documentation about network segmentation as well as high-level diagrams for this overview and detailed diagrams for the network segmentation docs.
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
