### PR TITLE
[gitops-docs-1.19] RHDEVDOCS-7103: CQA 2.0 fixes for Managing secrets securely using Secrets Store CSI driver with GitOps

### DIFF
--- a/modules/gitops-configure-hashicorp-vault-as-a-secrets-provider-on-openshift-with-gitops.adoc
+++ b/modules/gitops-configure-hashicorp-vault-as-a-secrets-provider-on-openshift-with-gitops.adoc
@@ -6,7 +6,8 @@
 [id="gitops-configure-hashicorp-vault-as-a-secrets-provider-on-openshift-with-gitops_{context}"]
 = Configure HashiCorp Vault as a secrets provider on OpenShift with GitOps
 
-You can configure HashiCorp Vault as a secrets provider by using the Secrets Store CSI Driver Operator on the {OCP}. When combined with GitOps workflows managed by Argo CD, this setup enables you to securely retrieve secrets from Vault and inject it into your applications running on OpenShift.
+[role="_abstract"]
+You can configure HashiCorp Vault as a secrets provider by using the Secrets Store CSI Driver Operator on the {OCP}. When combined with GitOps workflows managed by Argo CD, this setup enables you to securely retrieve secrets from Vault and inject them into your applications running on OpenShift.
 
 Structure the {gitops-shortname} repository and configure the Vault CSI provider to integrate with the Secrets Store CSI Driver in {OCP}.
 

--- a/modules/gitops-configuring-gitops-managed-resources-to-use-mounted-secrets.adoc
+++ b/modules/gitops-configuring-gitops-managed-resources-to-use-mounted-secrets.adoc
@@ -26,18 +26,19 @@ You must configure the {gitops-shortname} managed resources by adding volume mou
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: taxi                                
+  name: taxi
   namespace: dev
 spec:
   replicas: 1
   template:
     metadata:
-# ...
+      # ...
     spec:
+      serviceAccountName: default
       containers:
-        - image: nginxinc/nginx-unprivileged:latest
+        - name: taxi
+          image: nginxinc/nginx-unprivileged:latest
           imagePullPolicy: Always
-          name: taxi
           ports:
             - containerPort: 8080
           volumeMounts:
@@ -45,15 +46,13 @@ spec:
               mountPath: "/mnt/secrets-store"
               readOnly: true
           resources: {}
-    serviceAccountName: default
-    volumes:
-      - name: secrets-store-inline
-        csi:
-          driver: secrets-store.csi.k8s.io
-          readOnly: true
-          volumeAttributes:
-            secretProviderClass: "my-aws-provider"
-    status: {}
+      volumes:
+        - name: secrets-store-inline
+          csi:
+            driver: secrets-store.csi.k8s.io
+            readOnly: true
+            volumeAttributes:
+              secretProviderClass: "my-aws-provider"
 # ...
 ----
 --
@@ -74,7 +73,7 @@ where:
 
 . Verify that all the resources are successfully synchronized on the target application page.
 
-. Verify that you can you can access the secrets from AWS Secrets manager in the pod volume mount:
+. Verify that you can access the secrets from AWS Secrets manager in the pod volume mount:
 
 .. List the secrets in the pod mount: 
 +

--- a/modules/gitops-configuring-gitops-managed-resources-to-use-vault-mounted-secrets.adoc
+++ b/modules/gitops-configuring-gitops-managed-resources-to-use-vault-mounted-secrets.adoc
@@ -15,26 +15,27 @@ Securely inject secrets from HashiCorp Vault into GitOps-managed Kubernetes work
 .. Create a `SecretProviderClass` resource in the application's manifest directory for example, `environments/dev/apps/demo-app/manifest/secretProviderClass.yaml`. This resource defines how the Secrets Store CSI driver retrieves secrets from Vault.
 +
 --
-*Example `vault-secret-provider-app.yaml` file:*
+*Example `secretProviderClass.yaml` file:*
 [source,yaml]
 ----
 apiVersion: secrets-store.csi.x-k8s.io/v1
-  kind: SecretProviderClass
-     metadata:
-         name: demo-app-creds
-         namespace: demo-app
- spec:
-        provider: vault
-        parameters:
-              vaultAddress: http://vault.vault-csi-provider:8200 # <name>.<namespace>:port
-              roleName: app
-        objects: |
-           - objectName: "demoAppUsername"
-             secretPath: "secret/demo/config"
-             secretKey: "username"
-          - objectName: "demoAppPassword"
-            secretPath: "secret/demo/config"
-             secretKey: "password"
+kind: SecretProviderClass
+metadata:
+  name: demo-app-creds
+  namespace: demo-app
+spec:
+  provider: vault
+  parameters:
+    vaultAddress: http://vault.vault-csi-provider:8200 # <name>.<namespace>:port
+    roleName: app
+    objects: |
+      - objectName: "demoAppUsername"
+        secretPath: "secret/demo/config"
+        secretKey: "username"
+      - objectName: "demoAppPassword"
+        secretPath: "secret/demo/config"
+        secretKey: "password"
+---
 ----
 --
 +

--- a/modules/gitops-configuring-sscsi-driver-to-mount-secrets-from-aws-secrets-manager.adoc
+++ b/modules/gitops-configuring-sscsi-driver-to-mount-secrets-from-aws-secrets-manager.adoc
@@ -70,8 +70,8 @@ serviceAccountNames:
 --
 where:
 
-`metadata.namespace`:: Specifies the namespace for the secret reference. Update the value of this `namespace` field according to your project deployment setup.
-`<metadata.annotations.aws_region>`:: Specifies the aRN of your secret in the region where your cluster is on. The `<aws_region>` of `<aws_secret_arn>` has to match the cluster region. If it does not match, create a replication of your secret in the region where your cluster is on.
+`metadata.namespace`:: Specifies the namespace for the secret reference. Update this value according to your project deployment setup.
+`spec.providerSpec.statementEntries[].resource`:: Specifies the ARN of your secret in the cluster region. The `<aws_region>` in `<aws_secret_arn>` must match the cluster region. If it does not match, replicate the secret in the cluster region.
 --
 +
 [TIP]
@@ -113,20 +113,21 @@ Copy the OIDC provider name `<oidc_provider_name>` from the output to use in the
 $ ccoctl aws create-iam-roles \
     --name my-role --region=<aws_region> \
     --credentials-requests-dir=credentialsrequest-dir-aws \
-`    --identity-provider-arn arn:aws:iam`::<aws_account>:oidc-provider/<oidc_provider_name> --output-dir=credrequests-ccoctl-output
+    --identity-provider-arn arn:aws:iam::<aws_account>:oidc-provider/<oidc_provider_name> \
+    --output-dir=credrequests-ccoctl-output
 ----
 +
 --
 *Example output:*
 [source,terminal]
 ----
-`2023/05/15 18:10:34 Role arn:aws:iam`::<aws_account_id>:role/my-role-my-namespace-aws-creds created
+2023/05/15 18:10:34 Role arn:aws:iam::<aws_account_id>:role/my-role-my-namespace-aws-creds created
 2023/05/15 18:10:34 Saved credentials configuration to: credrequests-ccoctl-output/manifests/my-namespace-aws-creds-credentials.yaml
 2023/05/15 18:10:35 Updated Role policy for Role my-role-my-namespace-aws-creds
 ----
 --
 +
-`Copy the `<aws_role_arn>` from the output to use in the next step. For example, `arn:aws:iam`::<aws_account_id>:role/my-role-my-namespace-aws-creds`.
+Copy the `<aws_role_arn>` from the output to use in the next step. For example, `arn:aws:iam::<aws_account_id>:role/my-role-my-namespace-aws-creds`.
 
 .. Check the role policy on AWS to confirm the `<aws_region>` of `"Resource"` in the role policy matches the cluster region:
 +

--- a/modules/gitops-initializing-and-configuring-vault-to-store-a-secret.adoc
+++ b/modules/gitops-initializing-and-configuring-vault-to-store-a-secret.adoc
@@ -48,8 +48,8 @@ Store these credentials securely. At least 3 out of 5 unseal keys are required t
 [source,terminal]
 ----
 $ vault operator unseal <Unseal Key 1>
-  vault operator unseal <Unseal Key 2>
-  vault operator unseal <Unseal Key 3>
+$ vault operator unseal <Unseal Key 2>
+$ vault operator unseal <Unseal Key 3>
 ----
 +
 Once unsealed, the Vault becomes active and ready for use.
@@ -83,10 +83,10 @@ This allows Kubernetes workloads, for example, pods, to authenticate with Vault 
 [source,terminal]
 ----
 $ vault write auth/kubernetes/config \
-issuer="https://kubernetes.default.svc" \
-token_reviewer_jwt="$(cat/var/run/secrets/kubernetes.io/serviceaccount/token)" \
-kubernetes_host="https://${KUBERNETES_PORT_443_TCP_ADDR}:443" \
-kubernetes_ca_cert=@/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+  issuer="https://kubernetes.default.svc" \
+  token_reviewer_jwt="$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" \
+  kubernetes_host="https://${KUBERNETES_PORT_443_TCP_ADDR}:443" \
+  kubernetes_ca_cert=@/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
 ----
 +
 As a result, the following output is displayed.
@@ -96,7 +96,7 @@ As a result, the following output is displayed.
 Success! Data written to: auth/kubernetes/config
 ----
 +
-Where:
+where:
 +
 * `<issuer>` is the name of the Kubernetes token issuer URL.
 * `<token_reviewer_jwt>` is a JSON Web Token (JWT) that Vault uses to call the Kubernetes `TokenReview` API and to validate service account tokens.

--- a/modules/gitops-installing-the-vault-csi-provider-using-gitops.adoc
+++ b/modules/gitops-installing-the-vault-csi-provider-using-gitops.adoc
@@ -18,7 +18,7 @@ Install the Vault CSI provider by deploying an Argo CD Application that uses Has
 
 .Procedure
 
-. Creating the Argo CD Application resource for the Vault CSI Provider.
+. Create the Argo CD Application resource for the Vault CSI Provider.
 
 .. Create an Argo CD Application resource to deploy the Vault CSI provider. Add this resource to your {gitops-shortname} repository, for example, `config/argocd/vault-secret-provider-app.yaml`:
 +
@@ -93,7 +93,8 @@ $ oc patch daemonset vault-csi-provider -n vault-csi-provider --type=json --patc
 +
 [source,terminal]
 ----
-$ oc adm policy add-scc-to-user privileged \ system:serviceaccount:openshift-cluster-csi-drivers:secrets-store-csi-driver-operator
+$ oc adm policy add-scc-to-user privileged \
+  system:serviceaccount:openshift-cluster-csi-drivers:secrets-store-csi-driver-operator
 ----
 
 ... Grant the Vault CSI Provider service account access to the privileged Security Context Constraints (SCC) in {OCP}.

--- a/modules/gitops-managing-secrets-policies-and-roles-in-vault.adoc
+++ b/modules/gitops-managing-secrets-policies-and-roles-in-vault.adoc
@@ -10,7 +10,7 @@ To create a secret in Vault, define a Vault policy and configure a Kubernetes au
 
 .Procedure
 
-. Enable the KV Secrets Engine
+. Enable the KV Secrets Engine.
 
 .. Use the Key-Value (KV) Version 2 secrets engine to store arbitrary secrets with versioning support. Run the following command to enable the KV secrets engine at the path secret/:
 +
@@ -34,11 +34,11 @@ $ vault kv put secret/demo/config username="demo-user" password="demo-pass"
 +
 [source,terminal]
 ----
-$ vault policy write demo-app-policy -<<EOF
-path "secret/demo/config" {
-  capabilities = ["read"]
-}
-EOF
+$ vault write auth/kubernetes/role/app \
+  bound_service_account_names=demo-app-sa \
+  bound_service_account_namespaces=demo-app \
+  policies=demo-app-policy \
+  ttl=24h
 ----
 +
 This `demo-app-policy` grants read access to the secret at `secret/demo/config` and is later linked to a Kubernetes role.
@@ -49,12 +49,16 @@ This `demo-app-policy` grants read access to the secret at `secret/demo/config` 
 +
 [source,terminal]
 ----
-$ vault write auth/kubernetes/role/app \ bound_service_account_names=demo-app-sa \ bound_service_account_namespaces=demo-app \ policies=demo-app-policy \ ttl=24h
+$ vault write auth/kubernetes/role/app \
+  bound_service_account_names=demo-app-sa \
+  bound_service_account_namespaces=demo-app \
+  policies=demo-app-policy \
+  ttl=24h
 ----
 +
 This allows any pod using the service account to authenticate to Vault and retrieve the secret.
 +
-Where:
+where:
 +
 * `<bound_service_account_names>` is the name of the Kubernetes service account that Vault trusts.
 * `<bound_service_account_namespaces>` is the name of the namespace where the service account is located.

--- a/modules/gitops-managing-secrets-using-sscsid-with-gitops-overview.adoc
+++ b/modules/gitops-managing-secrets-using-sscsid-with-gitops-overview.adoc
@@ -6,7 +6,8 @@
 [id="gitops-managing-secrets-using-sscsid-with-gitops-overview_{context}"]
 = Overview of managing secrets using Secrets Store CSI driver with {gitops-shortname}
 
-Some applications need sensitive information, such as passwords and usernames which must be concealed as good security practice. If sensitive information is exposed because role-based access control (RBAC) is not configured properly on your cluster, anyone with API or etcd access can retrieve or modify a secret. 
+[role="_abstract"]
+Applications require sensitive information, such as passwords and usernames, which must be protected as a security best practice. If RBAC is not configured properly on your cluster, anyone with API or etcd access can retrieve or modify a secret.
 
 [IMPORTANT]
 ====
@@ -23,6 +24,6 @@ Avoid modifying the `argocd-secret` secret that {gitops-shortname} creates, usin
 == Benefits
 Integrating the SSCSI driver with the {gitops-shortname} Operator provides the following benefits:
 
-* Enhance the security and efficiency of your {gitops-shortname} workflows
-* Facilitate the secure attachment of secrets into deployment pods as a volume
-* Ensure that sensitive information is accessed securely and efficiently
+* Prevent secrets from being stored in etcd by mounting them directly from external providers
+* Reduce the risk of unauthorized access through centralized secret management
+* Enable automatic secret rotation without modifying application code

--- a/modules/gitops-verifying-secret-injection.adoc
+++ b/modules/gitops-verifying-secret-injection.adoc
@@ -30,13 +30,13 @@ $ oc exec -it <your-app-pod-name> -n demo-app -- sh
 
 . Verify mounted secrets.
 
-.. To verify that the secrets are mounted at the expected path, run the following command:
+.. To verify that the secrets are mounted at the expected path, run the following commands:
 +
 [source,terminal]
 ----
 $ ls -l /mnt/secrets-store
-  cat /mnt/secrets-store/demoAppUsername
-  cat /mnt/secrets-store/demoAppPassword
+$ cat /mnt/secrets-store/demoAppUsername
+$ cat /mnt/secrets-store/demoAppPassword
 ----
 +
 Verify that the mounted secret files `demoAppUsername` and `demoAppPassword` contain the expected values from Vault.

--- a/securing_openshift_gitops/managing-secrets-securely-using-sscsid-with-gitops.adoc
+++ b/securing_openshift_gitops/managing-secrets-securely-using-sscsid-with-gitops.adoc
@@ -1,12 +1,13 @@
 :_mod-docs-content-type: ASSEMBLY
 include::_attributes/common-attributes.adoc[]
 [id="managing-secrets-securely-using-sscsid-with-gitops"]
-= Managing secrets securely using Secrets Store CSI driver with {gitops-shortname}
+= Managing secrets securely using Secrets Store CSI driver with GitOps
 :context: managing-secrets-securely-using-sscsid-with-gitops
 
 toc::[]
 
-This guide walks you through the process of integrating the Secrets Store Container Storage Interface (SSCSI) driver with the {gitops-shortname} Operator in {OCP} 4.14 and later.
+[role="_abstract"]
+You can integrate the Secrets Store Container Storage Interface (SSCSI) driver with the {gitops-shortname} Operator in {OCP} 4.14 and later to manage secrets securely.
 
 // Overview of managing secrets using Secrets Store CSI driver with GitOps
 include::modules/gitops-managing-secrets-using-sscsid-with-gitops-overview.adoc[leveloffset=+1]


### PR DESCRIPTION


This PR is a manual cherry-pick of https://github.com/openshift/openshift-docs/pull/109929
