### PR TITLE
OSDOCS-18201: Added note about default NPs OCP includes in its namesp…

### DIFF
--- a/modules/nw-networkpolicy-about.adoc
+++ b/modules/nw-networkpolicy-about.adoc
@@ -8,6 +8,18 @@
 
 By default, all pods in a project are accessible from other pods and network endpoints. To isolate one or more pods in a project, you can create `NetworkPolicy` objects in that project to indicate the allowed incoming connections. Project administrators can create and delete `NetworkPolicy` objects within their own project.
 
+[IMPORTANT]
+====
+From {product-title} 4.22, {product-title} now includes `NetworkPolicy` objects in some of its own namespaces by default. This inclusion improves overall security and better protects control plane components. Do not modify the `NetworkPolicy` objects that {product-title} includes in its own namespaces by default. To check the namespaces that include the objects by default, you can run the following command:
+
+[source,terminal]
+----
+$ oc get networkpolicies --all-namespaces
+----
+
+The {product-title} 4.22 release does not include these objects in all {product-title} namespaces; later {product-title} releases might include the objects in additional namespaces. 
+====
+
 If a pod is matched by selectors in one or more `NetworkPolicy` objects, then the pod will accept only connections that are allowed by at least one of those `NetworkPolicy` objects. A pod that is not selected by any `NetworkPolicy` objects is fully accessible.
 
 A network policy applies to only the Transmission Control Protocol (TCP), User Datagram Protocol (UDP), Internet Control Message Protocol (ICMP), and Stream Control Transmission Protocol (SCTP) protocols. Other protocols are not affected.


### PR DESCRIPTION
Version(s):
4.22+

Issue:

https://redhat.atlassian.net/browse/OSDOCS-18200

Link to docs preview:

* https://110722--ocpdocs-pr.netlify.app/openshift-dedicated/latest/networking/network_security/network_policy/about-network-policy.html
* https://110722--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/network_security/network_policy/about-network-policy.html
* https://110722--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/networking/network_security/network_policy/about-network-policy.html
* https://110722--ocpdocs-pr.netlify.app/openshift-rosa/latest/networking/network_security/network_policy/about-network-policy.html

- [x] SME has approved this change (Dan W.).
- [x] QE has approved this change (Rahul G.).
