### PR TITLE
OSDOCS-18201-rn: Release note for default NPs in OCP

### DIFF
--- a/modules/rn-ocp-release-notes-new-features.adoc
+++ b/modules/rn-ocp-release-notes-new-features.adoc
@@ -141,6 +141,18 @@ For more information, see xref:../installing/installing_azure/ipi/installing-azu
 [id="ocp-release-notes-networking_{context}"]
 == Networking
 
+Network policy enhancement::
++
+{product-title} now includes `NetworkPolicy` objects in some of its own namespaces by default. This inclusion improves overall security and better protects control plane components. 
++
+Do not modify the `NetworkPolicy` objects that {product-title} includes in its own namespaces by default. To check the namespaces that include the objects by default, you can run the following command:
++
+[source,terminal]
+----
+$ oc get networkpolicies --all-namespaces
+----
++
+The {product-title} {product-version} release did not include these objects in all {product-title} namespaces; later {product-title} releases might include the objects in additional namespaces.
 
 [id="ocp-release-notes-nodes_{context}"]
 == Nodes


### PR DESCRIPTION
Version(s):
4.22

Issue:
https://redhat.atlassian.net/browse/OSDOCS-18200

Link to docs preview:

https://110724--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-22-release-notes.html#ocp-release-notes-networking_release-notes

- [x] SME has approved this change (Dan W.).
- [x] QE has approved this change (Rahul G.).
