### PR TITLE
OCPBUGS-81283: Document ServiceCIDR expansion not supported

### DIFF
--- a/modules/nw-operator-cr.adoc
+++ b/modules/nw-operator-cr.adoc
@@ -49,7 +49,7 @@ The CNO configuration inherits the following fields during cluster installation 
 ifdef::post-install-network-configuration,operator[]
 [NOTE]
 ====
-After cluster installation, you can only modify the `clusterNetwork` IP address range.
+After cluster installation, you can only modify the `clusterNetwork` IP address range. The `serviceNetwork` range cannot be modified post-installation, either directly or by using the `ServiceCIDR` API.
 ====
 endif::[]
 

--- a/networking/configuring_network_settings/configuring-cluster-network-range.adoc
+++ b/networking/configuring_network_settings/configuring-cluster-network-range.adoc
@@ -17,6 +17,11 @@ The following limitations apply when modifying the cluster network IP address ra
 - The host prefix cannot be modified
 - Pods that are configured with an overridden default gateway must be recreated after the cluster network expands
 
+[IMPORTANT]
+====
+You cannot expand the service network CIDR range after installing the cluster, either directly or through the ServiceCIDR API. You must configure the service network CIDR during installation using the `install-config.yaml` file. To avoid service IP address exhaustion, ensure that your initial service network range is large enough to accommodate future growth.
+====
+
 include::modules/nw-cluster-network-range-edit.adoc[leveloffset=+1]
 
 [role="_additional-resources"]


### PR DESCRIPTION
[OCPBUGS-81283]: ServiceCIDR Expansion Not Supported with OVN-Kubernetes in OCP 4.20
<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.20 +
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:https://redhat.atlassian.net/browse/OCPBUGS-81283
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: 
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->



## Summary
- Adds an `[IMPORTANT]` admonition to `configuring-cluster-network-range.adoc` noting that expanding the service network CIDR post-installation is not supported, even though the upstream Kubernetes `ServiceCIDR` API is visible in OCP. The Cluster Network Operator blocks this via a `ValidatingAdmissionPolicy`.
- Strengthens the existing post-install note in `nw-operator-cr.adoc` to explicitly call out that `serviceNetwork` is immutable and the `ServiceCIDR` API is blocked.

## Related
- JIRA: [OCPBUGS-81283](https://issues.redhat.com/browse/OCPBUGS-81283)
- RFE: [RFE-8780](https://issues.redhat.com/browse/RFE-8780)

Preview: 

- https://110733--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/ipi/installing-aws-customizations.html
- https://110733--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_azure/ipi/installing-azure-customizations.html
- https://110733--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_azure_stack_hub/ipi/installing-azure-stack-hub-network-customizations.html
- https://110733--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/upi/installing-bare-metal-network-customizations.html
- https://110733--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-customizations.html
- https://110733--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_ibm_cloud/installing-ibm-cloud-customizations.html
- https://110733--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_ibm_power/installing-ibm-power.html
- https://110733--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_ibm_power/installing-restricted-networks-ibm-power.html
- https://110733--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_ibm_z/upi/installing-ibm-z.html
- https://110733--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_ibm_z/upi/installing-ibm-z-kvm.html
- https://110733--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_ibm_z/upi/installing-ibm-z-lpar.html
- https://110733--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_ibm_z/upi/installing-restricted-networks-ibm-z.html
- https://110733--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_ibm_z/upi/installing-restricted-networks-ibm-z-kvm.html
- https://110733--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_ibm_z/upi/installing-restricted-networks-ibm-z-lpar.html
- https://110733--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/ipi/installing-vsphere-installer-provisioned-customizations.html
- https://110733--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/upi/installing-vsphere-network-customizations.html
- https://110733--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/configuring_network_settings/configuring-cluster-network-range.html
- https://110733--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/networking_operators/cluster-network-operator.html
- https://110733--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/network_security/logging-network-security.html
- https://110733--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/networking/network_security/logging-network-security.html
- https://110733--ocpdocs-pr.netlify.app/openshift-rosa/latest/networking/network_security/logging-network-security.html