### PR TITLE
[OCPBUGS#34889]: Add warning about rebooting nodes

### DIFF
--- a/updating/updating_a_cluster/updating-hardware-on-nodes-running-on-vsphere.adoc
+++ b/updating/updating_a_cluster/updating-hardware-on-nodes-running-on-vsphere.adoc
@@ -13,15 +13,18 @@ To do: Remove this comment once 4.13 docs are EOL.
 ////
 
 [role="_abstract"]
-You must ensure that your nodes running in vSphere are running on the hardware version supported by {product-title}. Currently, hardware version 15 or later is supported for vSphere virtual machines in a cluster.
-
-You can update your virtual hardware immediately or schedule an update in vCenter.
+You must ensure that your nodes running in vSphere are running on the hardware version supported by {product-title}. Currently, hardware version 15 or later is supported for vSphere virtual machines in a cluster. You can update your virtual hardware immediately or schedule an update in vCenter.
 
 [IMPORTANT]
 ====
 * Version {product-version} of {product-title} requires VMware virtual hardware version 15 or later.
 
 * Before upgrading OpenShift 4.12 to OpenShift 4.13, you must update vSphere to *v8.0 Update 1 or later*; otherwise, the OpenShift 4.12 cluster is marked *un-upgradeable*.
+====
+
+[WARNING]
+====
+Updating custom API certificates triggers the Machine Config Operator (MCO) to initiate a rolling reboot of the control plane nodes. These nodes must be updated serially. Ensure each node returns to a `Ready` state and the `etcd` static pods are healthy before the next node in the sequence begins its update. Failure to do so might result in a loss of etcd quorum and cluster-wide downtime.
 ====
 
 // Updating the virtual hardware for control plane nodes on vSphere


### PR DESCRIPTION
Version(s):
4.16+

Issue:
https://redhat.atlassian.net/browse/OCPBUGS-34889actionerId=63c10c428a7d2f693bf779a3&sourceType=assign

Link to docs preview:
https://110736--ocpdocs-pr.netlify.app/openshift-enterprise/latest/updating/updating_a_cluster/updating-hardware-on-nodes-running-on-vsphere.html

QE review:
- [x] QE has approved this change.