### PR TITLE
OSDOCS-19235:Update the z-stream RNs for 4.19.29

### DIFF
--- a/modules/zstream-4-19-29.adoc
+++ b/modules/zstream-4-19-29.adoc
@@ -1,0 +1,37 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-19-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-19-29_{context}"]
+= RHSA-2026:10093 - {product-title} {product-version}.29 fixed issues and security update
+
+Issued: 29 April 2026
+
+[role="_abstract"]
+{product-title} release {product-version}.29 is now available. The list of fixed issues that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2026:10093[RHSA-2026:10093] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2026:10080[RHBA-2026:10080] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.19.29 --pullspecs
+----
+
+[id="zstream-4-19-29-fixed-issues_{context}"]
+== Fixed issues
+
+* Before this update, Kube API server rollouts in clusters that had encrypted etcd caused transmission control protocol (TCP) reset (RST) storms. This behavior resulted in application pod traffic drops. With this release, the Kube API server rollouts do not cause traffic drops in encrypted clusters, which improves service stability. (link:https://redhat.atlassian.net/browse/OCPBUGS-81478[OCPBUGS-81478])
+
+* Before this update, the accumulation of unique session cookies across multi-pod deployments caused *Header Too Large* errors. With this release, the console proactively expires outdated pod-specific cookies whenever a new session is created. As a result, the cookie header remains within size limits during frequent re-authentications, while maintaining a stable, single active session. This behavior is most noticeable in {azure-first} Active Directory (AD) SSO. (link:https://redhat.atlassian.net/browse/OCPBUGS-81574[OCPBUGS-81574])
+
+* Before this update, DNS name rules in the `EgressFirewall` custom resource (CR) were not working correctly when an error was encountered during DNS name resolution or a zero TTL value was returned by the DNS name server. For both scenarios, the next lookup occurred only after 30 minutes. However, these scenarios could be transient and might have gotten resolved well before the next lookup. With this update, the lookup occurs every five seconds when an error is encountered during DNS name resolution or a zero TTL value is returned by the DNS name server. When an error is encountered during the DNS lookup, the lookup occurs with an exponential backoff after 10 retries, with the maximum backoff time capped at two minutes. (link:https://redhat.atlassian.net/browse/OCPBUGS-82032[OCPBUGS-82032])
+
+* Before this update, when you clicked on a link that included `monitoring/graph`, you were redirected to `monitoring/query-browser` and the query parameters were not re-encoded. As a consequence, invalid queries occurred. With this release, the parameters are re-encoded to produce valid queries. (link:https://redhat.atlassian.net/browse/OCPBUGS-82520[OCPBUGS-82520])
+
+[id="zstream-4-19-29-updating_{context}"]
+== Updating
+
+To update an {product-title} 4.19 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].

--- a/release_notes/ocp-4-19-release-notes.adoc
+++ b/release_notes/ocp-4-19-release-notes.adoc
@@ -2975,6 +2975,9 @@ To save the `vmcore` file, use the `crashkernel` setting to reserve 1024 MB of m
 // 4.19.z about errata updates
 include::modules/ocp-release-asynch-errata-updates.adoc[leveloffset=+1]
 
+// 4.19.29 z-stream RNs full document
+include::modules/zstream-4-19-29.adoc[leveloffset=+2]
+
 // 4.19.28 z-stream RNs full document
 include::modules/zstream-4-19-28.adoc[leveloffset=+2]
 


### PR DESCRIPTION
Version(s):
4.19

Issue:
https://redhat.atlassian.net/browse/OSDOCS-19235

Link to docs preview:
https://110740--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-19-release-notes.html#zstream-4-19-29_release-notes

Additional information:
4.19.29 MR: https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/479
ART Dashboard: https://art-dash.engineering.redhat.com/dashboard/release/openshift-4.19
