### PR TITLE
[OSDOCS#12997]: Update agent-based installer documentation to include 2NO

### DIFF
--- a/installing/installing_oci/installing-oci-agent-based-installer.adoc
+++ b/installing/installing_oci/installing-oci-agent-based-installer.adoc
@@ -73,7 +73,6 @@ include::modules/running-cluster-oci-agent-based.adoc[leveloffset=+1]
 [role="_additional-resources"]
 .Additional resources
 
-* xref:../../installing/installing_with_agent_based_installer/preparing-to-install-with-agent-based-installer.adoc#agent-based-installer-recommended-resources_preparing-to-install-with-agent-based-installer[Recommended resources for topologies]
 * link:https://docs.oracle.com/iaas/Content/openshift-on-oci/installing-agent-about-instance-configurations.htm[Instance Sizing Recommendations for {product-title} Nodes (Oracle documentation)]
 * link:https://docs.oracle.com/iaas/Content/openshift-on-oci/openshift-troubleshooting.htm[Troubleshooting {product-title} on {oci} (Oracle documentation)]
 

--- a/installing/installing_two_node_cluster/installing_tnf/install-tnf.adoc
+++ b/installing/installing_two_node_cluster/installing_tnf/install-tnf.adoc
@@ -7,16 +7,25 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 [role="_abstract"]
+For a highly available, small-footprint container platform at your edge sites or resource-constrained environments, you can deploy a two-node OpenShift cluster with fencing (TNF). This fencing mechanism protects your applications and data from `split-brain` scenarios by safely isolating a node if communication fails. To match your existing environment, you can deploy this cluster using automated, manual, or agent-based infrastructure methods.
 
-You can deploy two-node OpenShift cluster with fencing (TNF) clusters by using either the installer-provisioned infrastructure or the user-provisioned infrastructure installation method. The following examples provide sample `install-config.yaml` configurations for both methods.
+Automated Infrastructure (installer-provisioned):: The cluster installation program controls all aspects of the deployment, including provisioning the underlying cloud or virtualization platforms, configuring network resources, and spinning up the nodes.
+
+Manual Infrastructure (user-provisioned):: You provision and manage your own operating system images, networking, storage, and load balancers before starting the OpenShift deployment. This method offers maximum control over custom enterprise environments.
+
+Agent-Based Infrastructure:: You use a bootable ISO image containing an agent that automates the deployment on bare metal or pre-provisioned infrastructure. This combines the flexibility of manual setups with the ease of an automated workflow, making it ideal for disconnected environments.
 
 [IMPORTANT]
 ====
-Configure node access during installation, for example, by including SSH keys in the `install-config.yaml` file. Two-Node with Fencing (TNF) clusters might require manual intervention in specific error scenarios that can only be resolved through direct node access.
+Configure node access during installation, for example, by including SSH keys in the `install-config.yaml` file. TNF clusters might require manual intervention in specific error scenarios that can only be resolved through direct node access.
 ====
 
-// Sample install-config.yaml for a two-node installer-provisioned infrastructure cluster with fencing
-include::modules/installation-sample-install-config-two-node-fencing-ipi.adoc[leveloffset=+1]
+include::modules/sample-install-config-two-node-fencing-ipi.adoc[leveloffset=+1]
 
-// Sample install-config.yaml for a two-node user-provisioned infrastructure cluster with fencing
-include::modules/installation-sample-install-config-two-node-fencing-upi.adoc[leveloffset=+1]
+include::modules/sample-install-config-two-node-fencing-upi.adoc[leveloffset=+1]
+
+include::modules/sample-install-config-two-node-fencing-abi.adoc[leveloffset=+1]
+
+include::modules/sample-agent-config-two-node-fencing-abi.adoc[leveloffset=+1]
+
+

--- a/installing/installing_two_node_cluster/installing_tnf/installing-two-node-fencing.adoc
+++ b/installing/installing_two_node_cluster/installing_tnf/installing-two-node-fencing.adoc
@@ -36,7 +36,7 @@ The two-node OpenShift cluster with fencing requires the following hosts:
 
 |===
 
-The bootstrap and control plane machines must use Red Hat Enterprise Linux CoreOS (RHCOS) as the operating system. For instructions on installing RHCOS and starting the bootstrap process, see xref:../../../installing/installing_bare_metal/upi/installing-bare-metal#creating-machines-bare-metal_installing-bare-metal[Installing RHCOS and starting the {product-title} bootstrap process]
+The bootstrap and control plane machines must use Red Hat Enterprise Linux CoreOS (RHCOS) as the operating system. For instructions on installing RHCOS and starting the bootstrap process, see "Installing RHCOS and starting the {product-title} bootstrap process".
 
 [NOTE]
 ====
@@ -61,6 +61,8 @@ include::modules/installation-two-node-creating-manifest-custom-br-ex.adoc[level
 
 [role="_additional-resources"]
 == Additional resources
+
+* xref:../../../installing/installing_bare_metal/upi/installing-bare-metal#creating-machines-bare-metal_installing-bare-metal[Installing RHCOS and starting the {product-title} bootstrap process]
 
 * xref:../../../installing/installing_bare_metal/ipi/ipi-install-installation-workflow.adoc#creating-manifest-file-customized-br-ex-bridge_ipi-install-installation-workflow[Creating a manifest file for a customized br-ex bridge]
 

--- a/modules/installation-two-node-cluster-min-resource-reqs.adoc
+++ b/modules/installation-two-node-cluster-min-resource-reqs.adoc
@@ -14,6 +14,7 @@ Each cluster machine must meet the following minimum requirements:
 | Bootstrap | RHCOS | 4 | 16 GB | 120 GB | 300
 | Control plane |RHCOS | 4 | 16 GB | 120 GB | 300
 
+
 |===
 
 [.small]

--- a/modules/installing-ocp-agent-ZTP.adoc
+++ b/modules/installing-ocp-agent-ZTP.adoc
@@ -11,11 +11,18 @@ As an optional task, you can use {ztp-first} manifests to configure your install
 
 See "Challenges of the network far edge" to learn more about {ztp-first}.
 
+[IMPORTANT]
+====
+Zero Touch Provisioning (ZTP) is not supported for two-node clusters with fencing (TNF). Although you can use Red Hat Advanced Cluster Management (RHACM) for installations, the additional infrastructure components required for ZTP are not validated for this topology.
+====
+
 [NOTE]
 ====
 {ztp} manifests can be generated with or without configuring the `install-config.yaml` and `agent-config.yaml` files beforehand.
 If you chose to configure the `install-config.yaml` and `agent-config.yaml` files, the configurations will be imported to the ZTP cluster manifests when they are generated.
 ====
+
+
 
 .Prerequisites
 

--- a/modules/sample-agent-config-two-node-fencing-abi.adoc
+++ b/modules/sample-agent-config-two-node-fencing-abi.adoc
@@ -1,0 +1,97 @@
+//module is included in 
+// installing/installing_two_node_cluster/installing_tnf/install-tnf.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="sample-agent-config-two-node-fencing-abi_{context}"]
+= Sample agent-config.yaml file for a two-node cluster with fencing for Agent-based Installer
+
+[role="_abstract"]
+You can use the following `agent-config.yaml` configuration file as a template for deploying a two-node {product-title} cluster with fencing (TNF) by using the Agent-based Installer method:
+
+See the following sample `agent-config.yaml` file with minimal configuration:
+
+[source,yaml]
+----
+apiVersion: v1beta1
+metadata:
+  name: <cluster_name>
+rendezvousIP: <rendezvous_ip>
+----
+
+* `rendezvousIP`: Specifies the IP address of the node that will act as the rendezvous host during installation. This node runs the Assisted Service and coordinates the installation of both nodes.
+
+See the following sample `agent-config.yaml` file with host configuration and static networking:
+
+[NOTE]
+====
+The `hostname` values in the `agent-config.yaml` file must match the `hostname` values in the fencing credentials section of the `install-config.yaml`.
+====
+
+
+[source,yaml]
+----
+apiVersion: v1beta1
+metadata:
+  name: <cluster_name>
+rendezvousIP: <rendezvous_ip>
+additionalNTPSources:
+- 0.rhel.pool.ntp.org
+- 1.rhel.pool.ntp.org
+hosts:
+- hostname: master-0
+  role: master
+  interfaces:
+  - name: <nic_name>
+    macAddress: <mac_address_0>
+  networkConfig:
+    interfaces:
+    - name: <nic_name>
+      type: ethernet
+      state: up
+      ipv4:
+        enabled: true
+        dhcp: false
+        address:
+        - ip: <master_0_ip>
+          prefix-length: <prefix_length>
+      ipv6:
+        enabled: false
+    dns-resolver:
+      config:
+        server:
+        - <dns_server>
+    routes:
+      config:
+      - destination: 0.0.0.0/0
+        next-hop-address: <gateway>
+        next-hop-interface: <nic_name>
+        table-id: 254
+- hostname: master-1
+  role: master
+  interfaces:
+  - name: <nic_name>
+    macAddress: <mac_address_1>
+  networkConfig:
+    interfaces:
+    - name: <nic_name>
+      type: ethernet
+      state: up
+      ipv4:
+        enabled: true
+        dhcp: false
+        address:
+        - ip: <master_1_ip>
+          prefix-length: <prefix_length>
+      ipv6:
+        enabled: false
+    dns-resolver:
+      config:
+        server:
+        - <dns_server>
+    routes:
+      config:
+      - destination: 0.0.0.0/0
+        next-hop-address: <gateway>
+        next-hop-interface: <nic_name>
+        table-id: 254
+----

--- a/modules/sample-install-config-two-node-fencing-abi.adoc
+++ b/modules/sample-install-config-two-node-fencing-abi.adoc
@@ -1,0 +1,110 @@
+// Module included in the following assemblies:
+//
+//* installing/installing_two_node_cluster/installing_tnf/install-tnf.adoc
+:_mod-docs-content-type: CONCEPT
+[id="sample-install-config-two-node-fencing-abi_{context}"]
+= Sample install-config.yaml file for a two-node cluster with fencing for Agent-based Installer
+
+[role="abstract"]
+You can use the following `install-config.yaml` configuration file as a template for deploying a two-node {product-title} cluster with fencing (TNF) by using the Agent-based Installer method.
+
+See the following sample `install-config.yaml` configuration file for bare-metal:
+
+[source,yaml]
+----
+apiVersion: v1
+baseDomain: example.com
+controlPlane:
+  name: master
+  replicas: 2
+  fencing:
+    credentials:
+    - hostname: master-0
+      address: redfish+https://<bmc_ip_0>:<bmc_port>/redfish/v1/Systems/<system_id_0>
+      username: <bmc_username>
+      password: <bmc_password>
+      certificateVerification: Disabled
+    - hostname: master-1
+      address: redfish+https://<bmc_ip_1>:<bmc_port>/redfish/v1/Systems/<system_id_1>
+      username: <bmc_username>
+      password: <bmc_password>
+      certificateVerification: Disabled
+compute:
+- name: worker
+  replicas: 0
+metadata:
+  name: <cluster_name>
+networking:
+  clusterNetwork:
+  - cidr: 10.128.0.0/14
+    hostPrefix: 23
+  networkType: OVNKubernetes
+  machineNetwork:
+  - cidr: <machine_network_cidr>
+  serviceNetwork:
+  - 172.30.0.0/16
+platform:
+  baremetal:
+    apiVIPs:
+    - <api_vip>
+    ingressVIPs:
+    - <ingress_vip>
+pullSecret: '<pull_secret>'
+sshKey: '<ssh_public_key>'
+----
+
+* `platform.baremetal.apiVIPs` and `ingressVIPs`: Specifies virtual IPs for the API and Ingress endpoints. Required for bare-metal platform; not applicable for none.
+
+For other bare metal specific fields, see "Installation configuration parameters for the Agent-based Installer".
+
+The following sample `install-config.yaml` configuration file is for the attribute platform with value `none`.
+
+You must provide DNS name resolution and load balancing infrastructure. 
+
+[source,yaml]
+----
+apiVersion: v1
+baseDomain: example.com
+controlPlane:
+  name: master
+  replicas: 2
+  fencing:
+    credentials:
+    - hostname: master-0
+      address: redfish+https://<bmc_ip_0>:<bmc_port>/redfish/v1/Systems/<system_id_0>
+      username: <bmc_username>
+      password: <bmc_password>
+      certificateVerification: Disabled
+    - hostname: master-1
+      address: redfish+https://<bmc_ip_1>:<bmc_port>/redfish/v1/Systems/<system_id_1>
+      username: <bmc_username>
+      password: <bmc_password>
+      certificateVerification: Disabled
+compute:
+- name: worker
+  replicas: 0
+metadata:
+  name: <cluster_name>
+networking:
+  clusterNetwork:
+  - cidr: 10.128.0.0/14
+    hostPrefix: 23
+  networkType: OVNKubernetes
+  machineNetwork:
+  - cidr: <machine_network_cidr>
+  serviceNetwork:
+  - 172.30.0.0/16
+platform:
+  none: {}
+pullSecret: '<pull_secret>'
+sshKey: '<ssh_public_key>'
+----
+
+* `controlPlane.replicas`: Must be `2` for a two-node {product-title} cluster with fencing (TNF).  
+* `compute[0].replicas`: Must be `0`. A two-node {product-title} cluster with fencing does not support compute nodes.  
+* `controlPlane.fencing.credentials`: Exactly 2 entries required, one per control plane node. 
+* `fencing.credentials[].hostname`: The hostname of the control plane node. Must be unique across credentials.
+* `fencing.credentials[].address`: The Redfish BMC URL. Must use the `redfish+https://` scheme (for example, `redfish+[\https://192.168.1.10:443/redfish/v1/Systems/1](\https://192.168.1.10:443/redfish/v1/Systems/1))`. IPMI addresses are not supported. Vendor-specific Redfish schemes such as `idrac-redfish+https://` and `ilo5-redfish+https://` are also accepted.  
+* `fencing.credentials[].username`: BMC username for the node.  
+* `fencing.credentials[].password`: BMC password for the node.
+* `fencing.credentials[].certificateVerification`: Optional. Set to Disabled if your BMC uses self-signed certificates (common for internally-hosted endpoints). Set to Enabled (default) for BMCs with valid CA-signed certificates.

--- a/modules/sample-install-config-two-node-fencing-ipi.adoc
+++ b/modules/sample-install-config-two-node-fencing-ipi.adoc
@@ -1,12 +1,13 @@
 :_mod-docs-content-type: CONCEPT
 [id="sample-install-config-two-node-fencing-ipi_{context}"]
-= Sample install-config.yaml for a two-node installer-provisioned infrastructure cluster with fencing
+= Sample install-config.yaml file for a two-node installer-provisioned infrastructure cluster with fencing
 
-You can use the following `install-config.yaml` configuration as a template for deploying a two-node OpenShift cluster with fencing by using the installer-provisioned infrastructure method:
+[role="_abstract"]
+You can use the following `install-config.yaml` configuration file as a template for deploying a two-node OpenShift cluster with fencing (TNF) by using the installer-provisioned infrastructure method:
 
 [NOTE]
 ====
-Do an etcd backup before proceeding to ensure that you can restore the cluster if any issues occur.
+Back up etcd before proceeding to ensure that you can restore the cluster if an issue occurs.
 ====
 
 .Sample `install-config.yaml` configuration
@@ -59,8 +60,9 @@ platform:
 pullSecret: '<pull_secret>'
 sshKey: '<ssh_public_key>'
 ----
-* `compute.replicas`: Set this field to `0` because a two-node fencing cluster does not include worker nodes.  
-* `controlPlane.replicas`: Set this field to `2` for a two-node fencing deployment.  
+
+* `compute.replicas`: Set this field to `0` because a two-node {product-title} cluster with fencing does not include worker nodes.  
+* `controlPlane.replicas`: Set this field to `2` for a two-node {product-title} cluster with fencing deployment.  
 * `fencing.credentials.hostname`: Provide the Baseboard Management Console (BMC) credentials for each control plane node. These credentials are required for node fencing and prevent split-brain scenarios. 
 * `fencing.credentials.certificateVerification`: Set this field to `Disabled` if your Redfish URL uses self-signed certificates, which is common for internally-hosted endpoints. Set this field to `Enabled` for URLs with valid CA-signed certificates.
 * `metadata.name`: The cluster name is used as a prefix for hostnames and DNS records.  

--- a/modules/sample-install-config-two-node-fencing-upi.adoc
+++ b/modules/sample-install-config-two-node-fencing-upi.adoc
@@ -1,12 +1,13 @@
 :_mod-docs-content-type: CONCEPT
 [id="sample-install-config-two-node-fencing-upi_{context}"]
-= Sample install-config.yaml for a two-node user-provisioned infrastructure cluster with fencing
+= Sample install-config.yaml file for a two-node user-provisioned infrastructure cluster with fencing
 
-You can use the following `install-config.yaml` configuration as a template for deploying a two-node OpenShift cluster with fencing by using the user-provisioned infrastructure method:
+[role="_abstract"]
+You can use the following `install-config.yaml` configuration file as a template for deploying a two-node {product-title} cluster with fencing by using the user-provisioned infrastructure method:
 
 [NOTE]
 ====
-Do an etcd backup before proceeding to ensure that you can restore the cluster if any issues occur.
+Back up etcd before proceeding to ensure that you can restore the cluster if an issue occurs.
 ====
 
 .Sample `install-config.yaml` configuration
@@ -38,11 +39,12 @@ platform:
 pullSecret: '<pull_secret>'
 sshKey: '<ssh_public_key>'
 ----
-* `compute.replicas`: Set this field to `0` because a two-node fencing cluster does not include worker nodes.  
+
+* `compute.replicas`: Set this field to `0` because a two-node {product-title} cluster with fencing does not include worker nodes.  
 * `controlPlane.replicas`: Set this field to `2` for a two-node fencing deployment.  
 * `fencing.credentials.hostname`: Provide BMC credentials for each control plane node.  
 * `metadata.name`: Cluster name is used as a prefix for hostnames and DNS records.  
-* `featureSet`: Enables two-node OpenShift cluster deployments.  
+* `featureSet`: Enables a two-node {product-title} cluster with fencing deployments.  
 * `platform.none` Set the platform to `none` for user-provisioned infrastructure deployments. Bare-metal hosts are pre-provisioned outside of the installation program.
 * `pullSecret`: Contains credentials required to pull container images for the cluster components.  
 * `sshKey`: The SSH public key for accessing cluster nodes after installation.

--- a/modules/understanding-agent-install.adoc
+++ b/modules/understanding-agent-install.adoc
@@ -58,6 +58,9 @@ Recommended cluster resources for the following topologies:
 |====
 |Topology|Number of control plane nodes|Number of compute nodes|vCPU|Memory|Storage
 |Single-node cluster|1|0|8 vCPUs|16 GB of RAM| 120 GB
+|Two-Node OpenShift cluster with Arbiter (standard Control Plane nodes)|2|0|4 vCPUs|16 GB of RAM|120 GB
+|Two-Node OpenShift cluster with Arbiter (Arbiter node)|1|0|2 vCPUs|8 GB of RAM|50 GB
+|Two-node OpenShift cluster with fencing (TNF)|2|0|4 vCPUs|16 GB of RAM|120 GB
 |Compact cluster|3|0 or 1|8 vCPUs|16 GB of RAM|120 GB
 |HA cluster|3 to 5|2 and above |8 vCPUs|16 GB of RAM|120 GB
 |====
@@ -85,6 +88,14 @@ In the `install-config.yaml`, specify the platform on which to perform the insta
 * `nutanix`
 * `external`
 * `none`
+
+For a two-node {product-title} cluster with fencing (TNF), only the following platforms are supported:
+
+* `baremetal`
+* `external`
+* `none`
++
+The `vsphere` and `nutanix` platforms are not supported for two-node clusters with fencing.
 +
 [IMPORTANT]
 ====

--- a/modules/validations-before-agent-iso-creation.adoc
+++ b/modules/validations-before-agent-iso-creation.adoc
@@ -24,6 +24,15 @@ is created.
 * World Wide Name (WWN) vendor extensions are not supported in root device hints.
 * The `role` parameter in the `host` object must have a value of either `master` or `worker`.
 
+.Two-Node with Fencing (TNF) additional validation checks
+
+* When the `controlPlane.replicas` parameter is set to `2`, you must provide exactly 2 fencing credentials.
+* Each fencing credential must include `hostName`, `address`, `username`, and `password`.
+* The `address` field must contain a Redfish URL, that is, the string must contain "redfish". IPMI addresses are explicitly rejected.
+* All `hostName` values must be unique.
+* If you specify `certificateVerification`, the value must be either `Enabled` or `Disabled`.
+* Fencing credentials are valid only with `baremetal`, `external`, or `none` platforms. Other platforms result in a validation error.
+
 [id="agent-validations-ztp_{context}"]
 == ZTP manifests
 
@@ -34,3 +43,8 @@ is created.
 .`cluster-image-set.yaml`
 
 * The `ReleaseImage` parameter must match the release defined in the installer.
+
+[IMPORTANT]
+====
+Zero Touch Provisioning (ZTP) is not supported for two-node clusters with fencing (TNF). Although you can use Red Hat Advanced Cluster Management (RHACM) for installations, the additional infrastructure components required for ZTP are not validated for this topology.
+====


### PR DESCRIPTION
Version(s):
4.22

Issue:
https://redhat.atlassian.net/browse/OSDOCS-12997

Link to docs preview:
https://110741--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_two_node_cluster/installing_tnf/install-tnf.html

QE review:
- [x] QE has approved this change.

