### PR TITLE
OSDOCS-19394 needed to replace resume create-only information

### DIFF
--- a/modules/zero-trust-manager-restart-reconciliation.adoc
+++ b/modules/zero-trust-manager-restart-reconciliation.adoc
@@ -8,7 +8,13 @@
 = Resuming Operator reconciliation
 
 [role="_abstract"]
-To pause Operator reconciliation for manual configuration or debugging, enable the `create-only` mode. This prevents the controller from overwriting your changes. You can enable this mode by setting the environment variable in the subscription object.
+To resume Operator reconciliation after manual configuration or debugging, disable the `create-only` mode. This allows the controller to resume managing resources and applying the desired state. You can disable this mode by setting the environment variable in the subscription object.
+
+.Prerequisites
+
+* You have enabled `create-only` mode on the {zero-trust-full}.
+
+* You have completed your manual configuration or debugging tasks.
 
 .Procedure
 
@@ -18,3 +24,26 @@ To pause Operator reconciliation for manual configuration or debugging, enable t
 ----
 $ oc -n $OPERATOR_NAMESPACE patch subscription openshift-zero-trust-workload-identity-manager --type='merge' -p '{"spec":{"config":{"env":[{"name":"CREATE_ONLY_MODE","value":"false"}]}}}'
 ----
+
+.Verification
+
+* Check the status of the `SpireServer` resource to confirm that `create-only` mode is disabled by running the following command:
++
+[source,terminal]
+----
+$ oc get SpireServer cluster -o yaml
+----
++
+.Example output
+[source,yaml]
+----
+status:
+ conditions:
+ - lastTransitionTime: "2025-12-23T11:40:00Z"
+   message: create-only mode disabled
+   reason: CreateOnlyModeDisabled
+   status: "False"
+   type: CreateOnlyMode
+----
+
+


### PR DESCRIPTION
Version(s):
4.19+

Issue:
https://redhat.atlassian.net/browse/OSDOCS-19394

Link to docs preview:
https://110742--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/zero_trust_workload_identity_manager/zero-trust-manager-reconciliation.html



QE review:
- [ ] QE has approved this change.


Additional information:

