### PR TITLE
Document single FileIntegrity CR for compact control plane/worker nod…

### DIFF
--- a/modules/file-integrity-understanding-file-integrity-cr.adoc
+++ b/modules/file-integrity-understanding-file-integrity-cr.adoc
@@ -6,9 +6,15 @@
 [id="understanding-file-integrity-custom-resource_{context}"]
 =  Creating the FileIntegrity custom resource
 
+[role="_abstract"]
 An instance of a `FileIntegrity` custom resource (CR) represents a set of continuous file integrity scans for one or more nodes.
 
 Each `FileIntegrity` CR is backed by a daemon set running AIDE on the nodes matching the `FileIntegrity` CR specification.
+
+[NOTE]
+====
+For all-in-one control plane and worker nodes, separate `FileIntegrity` CRs that use `node-role.kubernetes.io/master` and `node-role.kubernetes.io/worker` selectors can schedule many daemon sets that run Advanced Intrusion Detection Environment (AIDE) on the same nodes, because schedulable control plane nodes often have both labels. Redundant scans waste resources and can complicate file integrity monitoring. You can avoid this by using a single `FileIntegrity` CR whose `nodeSelector` targets each node only once for your cluster layout.
+====
 
 .Procedure
 
@@ -23,30 +29,31 @@ metadata:
   name: worker-fileintegrity
   namespace: openshift-file-integrity
 spec:
-  nodeSelector: <1>
-      node-role.kubernetes.io/worker: ""
-  tolerations: <2>
-  - key: "myNode"
+  nodeSelector:
+    node-role.kubernetes.io/worker: ""
+  tolerations:
+    key: "myNode"
     operator: "Exists"
     effect: "NoSchedule"
-  config: <3>
+  config:
     name: "myconfig"
     namespace: "openshift-file-integrity"
     key: "config"
-    gracePeriod: 20 <4>
-    maxBackups: 5 <5>
-    initialDelay: 60 <6>
+    gracePeriod: 20
+    maxBackups: 5
+    initialDelay: 60
   debug: false
 status:
-  phase: Active <7>
+  phase: Active
 ----
-<1> Defines the selector for scheduling node scans.
-<2> Specify `tolerations` to schedule on nodes with custom taints. When not specified, a default toleration allowing running on main and infra nodes is applied.
-<3> Define a `ConfigMap` containing an AIDE configuration to use.
-<4> The number of seconds to pause in between AIDE integrity checks. Frequent AIDE checks on a node might be resource intensive, so it can be useful to specify a longer interval. Default is 900 seconds (15 minutes).
-<5> The maximum number of AIDE database and log backups (leftover from the re-init process) to keep on a node. Older backups beyond this number are automatically pruned by the daemon. Default is set to 5.
-<6> The number of seconds to wait before starting the first AIDE integrity check. Default is set to 0.
-<7> The running status of the `FileIntegrity` instance. Statuses are `Initializing`, `Pending`, or `Active`.
+[horizontal]
+`spec.nodeSelector`:: Specifies the selector for scheduling node scans.
+`spec.tolerations`:: Specify `tolerations` to schedule on nodes with custom taints. When not specified, a default toleration allowing running on main and infra nodes is applied.
+`spec.config`:: Specify a `ConfigMap` containing an AIDE configuration to use.
+`spec.config.gracePeriod`:: The number of seconds to pause in between AIDE integrity checks. Frequent AIDE checks on a node might be resource intensive, so it can be useful to specify a longer interval. Default is 900 seconds (15 minutes).
+`spec.config.maxBackups`:: The maximum number of AIDE database and log backups (leftover from the re-init process) to keep on a node. Older backups beyond this number are automatically pruned by the daemon. Default is set to 5.
+`spec.config.initialDelay`:: The number of seconds to wait before starting the first AIDE integrity check. Default is set to 0.
+`status.phase`:: The running status of the `FileIntegrity` instance. Statuses are `Initializing`, `Pending`, or `Active`.
 +
 [horizontal]
 `Initializing`:: The `FileIntegrity` object is currently initializing or re-initializing the AIDE database.


### PR DESCRIPTION
This PR is to correct an omission from the documentation that affects partner/customer Nokia. The Case ID is 04355033. SMES and QE's: Please review this PR to ensure the addition of the NOTE to the FIO documentation is correct.

This NOTE is parallel to Compliance Operator guidance: avoid separate master and worker FileIntegrity CRs when nodes share both role labels, so AIDE is not scheduled twice on the same hosts.

Original PR Made-with: Cursor. This PR is a copy of that one.

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.16+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://redhat.atlassian.net/browse/OCPBUGS-76348 
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://110743--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/file_integrity_operator/file-integrity-operator-understanding.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [X] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: This is a manual recreation of https://github.com/openshift/openshift-docs/pull/109955 with changes to improve parallelism in the footnotes.
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
