### PR TITLE
OSDOCS-16573: Fixed Vale warnings in ROSA CLI docs

### DIFF
--- a/cli_reference/rosa_cli/rosa-cli-permission-examples.adoc
+++ b/cli_reference/rosa_cli/rosa-cli-permission-examples.adoc
@@ -1,12 +1,12 @@
 :_mod-docs-content-type: ASSEMBLY
 include::_attributes/attributes-openshift-dedicated.adoc[]
 [id="rosa-cli-permission-examples"]
-= Least privilege permissions for ROSA CLI commands
+= Least privilege permissions for {rosa-cli} commands
 :context: rosa-cli-permission-examples
 toc::[]
 
-You can create roles with permissions that adhere to the principal of least privilege, in which the users assigned the roles have no other permissions assigned to them outside the scope of the specific action they need to perform. These policies contain only the minimum required permissions needed to perform specific actions by using the {rosa-cli-first}.
-
+[role="_abstract"]
+Create IAM roles that grant only the rights each user needs for {rosa-cli-first} tasks. The examples here use least privilege with the {rosa-cli}.
 [IMPORTANT]
 ====
 Although the policies and commands presented in this topic will work in conjunction with one another, you might have other restrictions within your AWS environment that make the policies for these commands insufficient for your specific needs. Red{nbsp}Hat provides these examples as a baseline, assuming no other AWS Identity and Access Management (IAM) restrictions are present.
@@ -15,10 +15,8 @@ Although the policies and commands presented in this topic will work in conjunct
 // Omitting from HCP build until BM gets to review
 // [NOTE]
 // ====
-// The examples listed cover several of the most common ROSA CLI commands. For more information regarding ROSA CLI commands, see xref:../../cli_reference/rosa_cli/rosa-manage-objects-cli.adoc#rosa-common-commands_rosa-managing-objects-cli[Common commands and arguments].
+// The examples listed cover several of the most common {rosa-cli} commands. For more information regarding {rosa-cli} commands, see xref:../../cli_reference/rosa_cli/rosa-manage-objects-cli.adoc#rosa-common-commands_rosa-managing-objects-cli[Common commands and arguments].
 // ====
-
-For more information about configuring permissions, policies, and roles in the AWS console, see link:https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies.html[AWS Identity and Access Management] in the AWS documentation.
 
 // include::modules/rosa-cli-hcp-classic-examples.adoc[leveloffset=+1]
 ifdef::openshift-rosa-hcp[]

--- a/cli_reference/rosa_cli/rosa-get-started-cli.adoc
+++ b/cli_reference/rosa_cli/rosa-get-started-cli.adoc
@@ -5,6 +5,9 @@ include::_attributes/attributes-openshift-dedicated.adoc[]
 :context: rosa-getting-started-cli
 toc::[]
 
+[role="_abstract"]
+Use this guide to learn how to install, configure, and update the {rosa-cli-first}.
+
 include::modules/rosa-about.adoc[leveloffset=+1]
 include::modules/rosa-setting-up-cli.adoc[leveloffset=+1]
 include::modules/rosa-configure.adoc[leveloffset=+1]

--- a/cli_reference/rosa_cli/rosa-updating-billing-account-cli.adoc
+++ b/cli_reference/rosa_cli/rosa-updating-billing-account-cli.adoc
@@ -5,16 +5,17 @@ include::_attributes/attributes-openshift-dedicated.adoc[]
 :context: rosa-updating-account-cli
 toc::[]
 
-
-You can use the ROSA CLI (`rosa`) to link your cluster to the desired AWS billing account after the cluster has been deployed.
-
-This can be useful if you have accidentally linked to the wrong AWS billing account during cluster deployment, or if you simply want to update the billing account.
+[role="_abstract"]
+You can use the {rosa-cli-first} to point an existing cluster at a different AWS billing account after deployment. This process lets you correct a billing account linked at install time or change the account at a later date.
 
 [NOTE]
 ====
-You also have the option to update your billing account through the {cluster-manager}. For more information, see link:https://docs.redhat.com/en/documentation/openshift_cluster_manager/1-latest/html-single/managing_clusters/index#proc_updating-billing-accts-rosa-hcp_assembly-managing-clusters[Updating billing accounts for {product-title} clusters.]
+You also have the option to update your billing account through the {cluster-manager}.
 ====
-
 
 include::modules/rosa-update-billing-cli.adoc[leveloffset=+1]
 
+[role="_additional-resources"]
+.Additional resources
+
+* link:https://docs.redhat.com/en/documentation/openshift_cluster_manager/1-latest/html-single/managing_clusters/index#proc_updating-billing-accts-rosa-hcp_assembly-managing-clusters[Updating billing accounts for {product-title} clusters]

--- a/modules/rosa-about.adoc
+++ b/modules/rosa-about.adoc
@@ -8,4 +8,5 @@
 [id="rosa-about_{context}"]
 = About the ROSA CLI
 
+[role="_abstract"]
 Use the {rosa-cli-first} to create, update, manage, and delete {product-title} clusters and resources.

--- a/modules/rosa-cli-classic-examples.adoc
+++ b/modules/rosa-cli-classic-examples.adoc
@@ -6,7 +6,8 @@
 [id="rosa-cli-classic-examples_{context}"]
 = Least privilege permissions for common {rosa-cli} commands
 
-The following examples show the least privilege permissions needed for the most common ROSA CLI commands when building {product-title} clusters.
+[role="_abstract"]
+These examples list the least privilege IAM permissions for common {rosa-cli} commands when you build {product-title} clusters.
 
 [id="rosa-create-OIDC-providers-hcp-classic_{context}"]
 == Create a managed OpenID Connect (OIDC) provider

--- a/modules/rosa-cli-hcp-examples.adoc
+++ b/modules/rosa-cli-hcp-examples.adoc
@@ -4,9 +4,10 @@
 
 :_mod-docs-content-type: REFERENCE
 [id="rosa-cli-hcp-examples_{context}"]
-= Least privilege permissions for common {product-title} CLI commands
+= Least privilege permissions for common {rosa-cli} commands
 
-The following examples show the least privilege permissions needed for the most common ROSA CLI commands when building {product-title} clusters.
+[role="_abstract"]
+These examples list the least privilege IAM permissions for common {rosa-cli-first} commands when you build {product-title} clusters.
 
 [id="rosa-create-OIDC-providers-hcp-classic_{context}"]
 == Create a managed OpenID Connect (OIDC) provider

--- a/modules/rosa-cli-no-permissions-required.adoc
+++ b/modules/rosa-cli-no-permissions-required.adoc
@@ -4,9 +4,10 @@
 
 :_mod-docs-content-type: REFERENCE
 [id="rosa-cli-no-permissions-required_{context}"]
-= ROSA CLI commands with no required permissions
+= {rosa-cli} commands with no required permissions
 
-The following ROSA CLI commands do not require permissions or policies to run. Instead, they require an access key and configured secret key or an attached role.
+[role="_abstract"]
+These {rosa-cli-first} commands do not need IAM policies. They need an access key, a secret key, or an attached role.
 
 .Commands
 [cols="30,70", options="header"]

--- a/modules/rosa-configure.adoc
+++ b/modules/rosa-configure.adoc
@@ -3,20 +3,21 @@
 //
 // * rosa_cli/rosa-get-started-cli.adoc
 
-:_mod-docs-content-type: PROCEDURE
+:_mod-docs-content-type: REFERENCE
 [id="rosa-configure_{context}"]
-= Configuring the ROSA CLI
+= Configuring the {rosa-cli}
 
-Use the following commands to configure the {rosa-cli-first}.
+[role="_abstract"]
+Use these commands to log in, log out, verify AWS settings, and download `rosa` or `oc` clients with the {rosa-cli-first}.
 
 [id="rosa-login_{context}"]
 == login
 There are several methods you can use to log in to your Red{nbsp}Hat account using the {rosa-cli-first}. These methods are described in detail below.
 
 [id="rosa-login-sso_{context}"]
-=== Authenticating the ROSA CLI with Red Hat single sign-on
+=== Authenticating the {rosa-cli} with Red Hat single sign-on
 
-You can log in to the ROSA CLI (`rosa`) with Red{nbsp}Hat single sign-on. Red{nbsp}Hat recommends using the `rosa` command line tool with Red{nbsp}Hat single sign-on, instead of using an offline authentication token.
+You can log in to the {rosa-cli} with Red{nbsp}Hat single sign-on. Red{nbsp}Hat recommends using the `rosa` command line tool with Red{nbsp}Hat single sign-on, instead of using an offline authentication token.
 
 An offline authentication token is long-lived, stored on your operating system, and cannot be revoked. These factors increase overall security risks and the likelihood of unauthorized access to your account.
 
@@ -29,32 +30,28 @@ The method of authenticating using Red{nbsp}Hat single sign-on does not break an
 
 Use one of the following methods of authentication:
 
-* If your system has a web browser, see the "Authenticating the ROSA CLI with a single sign-on authorization code" section to authenticate with Red Hat single sign-on.
-
-* If you are working with containers, remote hosts, or other environments without a web browser, see the "Authenticating the ROSA CLI with a single sign-on device code" section to authenticate with Red{nbsp}Hat single sign-on.
-
-* To authenticate the ROSA CLI using an offline token, see the "Authenticating the ROSA CLI with an offline token" section.
+* If your system has a web browser, see the "Authenticating the {rosa-cli} with a single sign-on authorization code" section to authenticate with Red Hat single sign-on.
+* If you are working with containers, remote hosts, or other environments without a web browser, see the "Authenticating the {rosa-cli} with a single sign-on device code" section to authenticate with Red{nbsp}Hat single sign-on.
+* To authenticate the {rosa-cli} using an offline token, see the "Authenticating the {rosa-cli} with an offline token" section.
 
 [NOTE]
 ====
-Single sign-on authorization is supported with ROSA CLI (`rosa`) version 1.2.36 or later.
+Single sign-on authorization is supported with {rosa-cli} version 1.2.36 or later.
 ====
 
 [id="rosa-login-sso_auth{context}"]
-=== Authenticating the ROSA CLI with a single sign-on authorization code
+=== Authenticating the {rosa-cli} with a single sign-on authorization code
 
-
-* To log in to the ROSA CLI (`rosa`) with a Red{nbsp}Hat single sign-on authorization code, run the following command:
-
+* To log in to the {rosa-cli} with a Red{nbsp}Hat single sign-on authorization code, run the following command:
 +
 .Syntax
 [source,terminal]
 ----
 $ rosa login --use-auth-code
 ----
-+
+
 Running this command redirects you to the Red{nbsp}Hat single sign-on login. Log in with your Red{nbsp}Hat login or email.
-+
+
 .Optional arguments inherited from parent commands
 [cols="30,70"]
 |===
@@ -67,27 +64,29 @@ Running this command redirects you to the Red{nbsp}Hat single sign-on login. Log
 |Enables debug mode.
 
 |===
-+
+
 To switch accounts, logout from link:https://sso.redhat.com[https://sso.redhat.com] and run the `rosa logout` command in your terminal before attempting to login again.
 
 [id="rosa-login-sso-device_{context}"]
-=== Authenticating the ROSA CLI with a single sign-on device code
+=== Authenticating the {rosa-cli} with a single sign-on device code
+
 If you are working with containers, remote hosts, and other environments without a web browser, you can use a Red{nbsp}Hat single sign-on device code for secure authentication. To do this, you must use a second device that has a web browser to approve the login.
+
 [NOTE]
 ====
-Single sign-on authorization is supported with ROSA CLI (`rosa`) version 1.2.36 or later.
+Single sign-on authorization is supported with {rosa-cli} version 1.2.36 or later.
 ====
-* To log in to the ROSA CLI (`rosa`) with a Red Hat single sign-on device code, run the following command:
 
+* To log in to the {rosa-cli} with a Red Hat single sign-on device code, run the following command:
 +
 .Syntax
 [source,terminal]
 ----
 $ rosa login --use-device-code
 ----
-+
+
 Running this command will redirect you to the Red{nbsp}Hat SSO login and provide a log in code.
-+
+
 .Optional arguments inherited from parent commands
 [cols="30,70"]
 |===
@@ -100,12 +99,11 @@ Running this command will redirect you to the Red{nbsp}Hat SSO login and provide
 |Enables debug mode.
 
 |===
-+
+
 To switch accounts, logout from link:https://sso.redhat.com[https://sso.redhat.com] and run the `rosa logout` command in your terminal before attempting to login again.
 
-
 [id="rosa-login-token_{context}"]
-=== Authenticating the ROSA CLI with an offline token
+=== Authenticating the {rosa-cli} with an offline token
 
 Log in to your Red{nbsp}Hat account, saving the credentials to the `rosa` configuration file.
 
@@ -120,7 +118,7 @@ To use service accounts for automation purposes, see the link:https://console.re
 Red{nbsp}Hat recommends using service accounts for automation purposes.
 ====
 
-* To log in to ROSA CLI (`rosa`) with a Red{nbsp}Hat offline token, run the following command:
+* To log in to {rosa-cli} with a Red{nbsp}Hat offline token, run the following command:
 +
 .Syntax
 [source,terminal]
@@ -194,7 +192,7 @@ $ rosa logout [arguments]
 |===
 
 [id="rosa-verify-permissions_{context}"]
-== verify permissions
+=== verify permissions
 
 Verify that the AWS permissions required to create a {product-title} cluster are configured correctly:
 
@@ -235,14 +233,13 @@ $ rosa verify permissions
 ----
 
 Verify that the AWS permissions are configured correctly in a specific region:
-
 [source,terminal]
 ----
 $ rosa verify permissions --region=us-west-2
 ----
 
 [id="rosa-verify-quota_{context}"]
-== verify quota
+=== verify quota
 
 Verifies that AWS quotas are configured correctly for your default region.
 
@@ -335,7 +332,7 @@ $ rosa download oc [arguments]
 |Enables debug mode.
 |===
 
-.Example
+.Examples
 Download `oc` client tools:
 
 [source,terminal]
@@ -366,7 +363,7 @@ $ rosa verify oc [arguments]
 |Enables debug mode.
 |===
 
-.Example
+*Example*
 Verify `oc` client tools:
 
 [source,terminal]

--- a/modules/rosa-setting-up-cli.adoc
+++ b/modules/rosa-setting-up-cli.adoc
@@ -6,16 +6,17 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="rosa-setting-up-cli_{context}"]
-= Setting up the ROSA CLI
+= Setting up the {rosa-cli}
 
-Use the following steps to install and configure the ROSA CLI (`rosa`) on your installation host.
+[role="_abstract"]
+Put the {rosa-cli-first} on the computer you use to run cluster commands.
 
 .Procedure
 
 . Install and configure the latest AWS CLI (`aws`).
 .. Follow the link:https://aws.amazon.com/cli/[AWS Command Line Interface] documentation to install and configure the AWS CLI for your operating system.
 +
-Specify your `aws_access_key_id`, `aws_secret_access_key`, and `region` in the `.aws/credentials` file. See link:https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-quickstart.html[AWS Configuration basics] in the AWS documentation.
+Put `aws_access_key_id`, `aws_secret_access_key`, and `region` in the `.aws/credentials` file. See link:https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-quickstart.html[AWS Configuration basics] in the AWS documentation.
 +
 [NOTE]
 ====
@@ -34,7 +35,7 @@ $ aws sts get-caller-identity  --output text
 <aws_account_id>    arn:aws:iam::<aws_account_id>:user/<username>  <aws_user_id>
 ----
 
-. Download the latest version of the ROSA CLI (`rosa`) for your operating system from the link:https://console.redhat.com/openshift/downloads[*Downloads*] page on {cluster-manager}.
+. Download the latest version of the {rosa-cli-first} for your operating system from the link:https://console.redhat.com/openshift/downloads[*Downloads*] page on {cluster-manager}.
 
 . Extract the `rosa` binary file from the downloaded archive. The following example extracts the binary from a Linux tar archive:
 +
@@ -50,7 +51,7 @@ $ tar xvf rosa-linux.tar.gz
 $ sudo mv rosa /usr/local/bin/rosa
 ----
 
-. Verify if the ROSA CLI is installed correctly by querying the `rosa` version:
+. Verify if the {rosa-cli} is installed correctly by querying the `rosa` version:
 +
 [source,terminal]
 ----
@@ -61,10 +62,10 @@ $ rosa version
 [source,terminal]
 ----
 1.2.15
-Your ROSA CLI is up to date.
+Your {rosa-cli} is up to date.
 ----
 
-. Optional: Enable tab completion for the ROSA CLI. With tab completion enabled, you can press the `Tab` key twice to automatically complete subcommands and receive command suggestions:
+. Optional: Turn on tab completion for the {rosa-cli}. Press `Tab` twice to finish subcommands or see hints:
 +
 --
 ** To enable persistent tab completion for Bash on a Linux host:

--- a/modules/rosa-update-billing-cli.adoc
+++ b/modules/rosa-update-billing-cli.adoc
@@ -1,9 +1,12 @@
 // Module included in the following assemblies:
 //
-// * * rosa_cli/rosa-updating-billing-account-cli.adoc
+// * rosa_cli/rosa-updating-billing-account-cli.adoc
 :_mod-docs-content-type: PROCEDURE
 [id="rosa-update-billing_{context}"]
 = Update billing accounts for {product-title} clusters
+
+[role="_abstract"]
+Change which AWS billing account a deployed cluster uses by running `rosa edit cluster` in interactive mode.
 
 .Prerequisites
 
@@ -12,29 +15,19 @@
 
 
 .Procedure
-. Run the following command in your terminal window:
-
+. Run the following command in your terminal window. Replace `<cluster_ID>` with the ID of the cluster whose billing account you want to update.
 +
-
-.Syntax
 [source,terminal]
 ----
-$ rosa edit cluster -c <cluster_ID> <1>
+$ rosa edit cluster -c <cluster_ID>
 ----
-<1>  Replace `<cluster_ID>` with the ID of the cluster that you want to update the AWS billing account.
-
 +
 [NOTE]
 ====
 To locate the IDs of your active clusters, run the `$ rosa list clusters` command in your terminal window.
 ====
-
 +
-
 . Skip to the `Billing Account` parameter within the interactive mode.
-
 . Select the desired AWS billing account from the list of available options and press "Enter".
-
 +
-
 The AWS billing account for your cluster is now updated.

--- a/modules/rosa-updating-rosa-cli.adoc
+++ b/modules/rosa-updating-rosa-cli.adoc
@@ -4,13 +4,14 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="rosa-updating-the-rosa-cli_{context}"]
-= Updating the ROSA CLI
+= Updating the {rosa-cli}
 
-Update to the latest compatible version of the ROSA CLI (`rosa`).
+[role="_abstract"]
+Update the {rosa-cli-first} to the latest version that works with your cluster.
 
 .Procedure
 
-. Confirm that a new version of the ROSA CLI (`rosa`) is available:
+. Confirm that a new version of the {rosa-cli} (`rosa`) is available:
 +
 [source,terminal]
 ----
@@ -24,7 +25,7 @@ $ rosa version
 There is a newer release version '1.2.15', please consider updating: https://mirror.openshift.com/pub/openshift-v4/clients/rosa/latest/
 ----
 
-. Download the latest compatible version of the ROSA CLI:
+. Download the latest compatible version of the {rosa-cli}:
 +
 [source,terminal]
 ----
@@ -40,7 +41,7 @@ This command downloads an archive called `rosa-*.tar.gz` into the current direct
 $ tar -xzf rosa-linux.tar.gz
 ----
 
-. Install the new version of the ROSA CLI by moving the extracted file into your path. In the following example, the `/usr/local/bin` directory is included in the path of the user:
+. Install the new version of the {rosa-cli} by moving the extracted file into your path. In the following example, the `/usr/local/bin` directory is included in the path of the user:
 +
 [source,terminal]
 ----
@@ -59,5 +60,5 @@ $ rosa version
 [source,terminal]
 ----
 1.2.15
-Your ROSA CLI is up to date.
+Your {rosa-cli} is up to date.
 ----


### PR DESCRIPTION
Version(s):
`enterprise-4.21+`

Issue:
[OSDOCS-16573](https://redhat.atlassian.net/browse/OSDOCS-16573)

Link to docs preview:
- **[ROSA CLI](https://110749--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/cli_reference/rosa_cli/rosa-get-started-cli.html)** (hcp)
- **[ROSA CLI](https://110749--ocpdocs-pr.netlify.app/openshift-rosa/latest/cli_reference/rosa_cli/rosa-get-started-cli.html)** (classic)

Additional information:
This PR corrects some warnings and errors for DITA migration in the ROSA CLI documentation.