### PR TITLE
OSDOCS-16608 - Addressing Vale errors in ROSA OSD Nodes

### DIFF
--- a/modules/rosa-creating-node-tuning.adoc
+++ b/modules/rosa-creating-node-tuning.adoc
@@ -7,11 +7,11 @@
 = Creating node tuning configurations
 
 [role="_abstract"]
-You can create tuning configurations by using the {product-title} (ROSA) CLI, `rosa`.
+You can create tuning configurations by using the {rosa-cli-first}.
 
 .Prerequisites
 
-* You have downloaded the latest version of the ROSA CLI.
+* You have downloaded the latest version of the {rosa-cli}.
 * You have a cluster on the latest version.
 * You have a specification file configured for node tuning.
 

--- a/modules/rosa-deleting-node-tuning.adoc
+++ b/modules/rosa-deleting-node-tuning.adoc
@@ -7,7 +7,7 @@
 = Deleting node tuning configurations
 
 [role="_abstract"]
-You can delete tuning configurations if you no longer need them by using the {product-title} (ROSA) CLI, `rosa`.
+You can delete tuning configurations if you no longer need them by using the {rosa-cli-first}.
 
 [NOTE]
 ====
@@ -16,8 +16,8 @@ You cannot delete a tuning configuration referenced in a machine pool. You must 
 
 .Prerequisites
 
-* You have downloaded the latest version of the ROSA CLI.
-* You have a cluster on the latest version .
+* You have downloaded the latest version of the {rosa-cli}.
+* You have a cluster on the latest version.
 * Your cluster has a node tuning configuration that you want delete.
 
 .Procedure
@@ -29,7 +29,7 @@ You cannot delete a tuning configuration referenced in a machine pool. You must 
 $ rosa delete tuning-config -c <cluster_id> <name_of_tuning>
 ----
 +
-The tuning configuration on the cluster is deleted
+The tuning configuration on the cluster is deleted.
 +
 .Example output
 [source,terminal]

--- a/modules/rosa-modifying-node-tuning.adoc
+++ b/modules/rosa-modifying-node-tuning.adoc
@@ -7,13 +7,13 @@
 = Modifying your node tuning configurations
 
 [role="_abstract"]
-You can view and update the node tuning configurations by using the {product-title} (ROSA) CLI, `rosa`.
+You can view and update the node tuning configurations by using the {rosa-cli-first}.
 
 .Prerequisites
 
-* You have downloaded the latest version of the ROSA CLI.
-* You have a cluster on the latest version
-* Your cluster has a node tuning configuration added to it
+* You have downloaded the latest version of the {rosa-cli}.
+* You have a cluster on the latest version.
+* Your cluster has a node tuning configuration added to it.
 
 .Procedure
 

--- a/modules/sd-nodes-cma-autoscaling-custom-install.adoc
+++ b/modules/sd-nodes-cma-autoscaling-custom-install.adoc
@@ -6,6 +6,7 @@
 [id="sd-nodes-cma-autoscaling-custom-install_{context}"]
 = Installing the custom metrics autoscaler
 
+[role="_abstract"]
 You can use the following procedure to install the Custom Metrics Autoscaler Operator.
 
 .Prerequisites
@@ -32,7 +33,7 @@ $ oc delete crd scaledobjects.keda.k8s.io
 $ oc delete crd triggerauthentications.keda.k8s.io
 ----
 
-* Ensure that the `keda` namespace exists. If not, you must manaully create the `keda` namespace.
+* Ensure that the `keda` namespace exists. If not, you must manually create the `keda` namespace.
 
 * Optional: If you need the Custom Metrics Autoscaler Operator to connect to off-cluster services, such as an external Kafka cluster or an external Prometheus service, put any required service CA certificates into a config map. The config map must exist in the same namespace where the Operator is installed. For example:
 +
@@ -45,10 +46,9 @@ $ oc create configmap -n openshift-keda thanos-cert  --from-file=ca-cert.pem
 
 . In the {product-title} web console, click *Ecosystem* -> *Software Catalog*.
 
-. Choose *Custom Metrics Autoscaler* from the list of available Operators, and click *Install*.
+. From the list of available Operators, choose *Custom Metrics Autoscaler*, and click *Install*.
 
-. On the *Install Operator* page, ensure that the *A specific namespace on the cluster* option
-is selected for *Installation Mode*.
+. On the *Install Operator* page, ensure that the *A specific namespace on the cluster* option is selected for *Installation Mode*.
 
 . For *Installed Namespace*, click *Select a namespace*.
 
@@ -73,14 +73,12 @@ is selected for *Installation Mode*.
 
 .. Navigate to *Workloads* -> *Deployments* to verify that the `custom-metrics-autoscaler-operator` deployment is running.
 
-. Optional: Verify the installation in the OpenShift CLI using the following command:
+. Optional: Verify the installation in the {oc-first} using the following command:
 +
 [source,terminal]
 ----
 $ oc get all -n keda
 ----
-+
-The output appears similar to the following:
 +
 .Example output
 [source,text]

--- a/nodes/clusters/nodes-cluster-overcommit.adoc
+++ b/nodes/clusters/nodes-cluster-overcommit.adoc
@@ -21,9 +21,9 @@ ifdef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 [role="_abstract"]
 {product-title} administrators can manage container density on nodes by configuring pod placement behavior and per-project resource limits that overcommit cannot exceed.
 
-Alternatively, administrators can disable project-level resource overcommitment on customer-created namespaces that are not managed by Red Hat.
+Alternatively, administrators can disable project-level resource overcommitment on customer-created namespaces that are not managed by Red{nbsp}Hat.
 
-For more information about container resource management, see Additional resources.
+For more information about container resource management, see the __Additional resources__ section.
 endif::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 
 In an _overcommitted_ state, the sum of the container compute resource requestsand limits exceeds the resources available on the system. For example, you might want to use overcommitment in development environments where a trade-off of guaranteed performance for capacity is acceptable.

--- a/nodes/nodes/nodes-node-tuning-operator.adoc
+++ b/nodes/nodes/nodes-node-tuning-operator.adoc
@@ -2,6 +2,7 @@
 [id="nodes-node-tuning-operator"]
 = Using the Node Tuning Operator
 include::_attributes/common-attributes.adoc[]
+include::_attributes/attributes-openshift-dedicated.adoc[]
 :context: nodes-node-tuning-operator
 
 toc::[]


### PR DESCRIPTION
Version(s):
4.21+

Issue:
https://redhat.atlassian.net/browse/OSDOCS-16608

Link to docs preview:
"Nodes" only has ROSA/OSD-exclusive modules (no assemblies).

- **Three ROSA HCP modules** in _nodes/nodes/nodes-node-tuning-operator.adoc_:
[Creating node tuning configurations + Modifying your node tuning configurations + Deleting node tuning configurations](https://110750--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/nodes/nodes/nodes-node-tuning-operator#rosa-creating-node-tuning_nodes-node-tuning-operator)
They only got the rosa-cli attributes.

- 1 module in _nodes/cma/nodes-cma-autoscaling-custom-install.adoc_:
-- **ROSA HCP**: [Installing the custom metrics autoscaler](https://110750--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/nodes/cma/nodes-cma-autoscaling-custom-install#sd-nodes-cma-autoscaling-custom-install_nodes-cma-autoscaling-custom-install)
-- **ROSA Classic**: [Installing the custom metrics autoscaler](https://110750--ocpdocs-pr.netlify.app/openshift-rosa/latest/nodes/cma/nodes-cma-autoscaling-custom-install#sd-nodes-cma-autoscaling-custom-install_nodes-cma-autoscaling-custom-install)
-- **OSD**: [Installing the custom metrics autoscaler](https://110750--ocpdocs-pr.netlify.app/openshift-dedicated/latest/nodes/cma/nodes-cma-autoscaling-custom-install#sd-nodes-cma-autoscaling-custom-install_nodes-cma-autoscaling-custom-install)

- Intro paragraphs in _nodes/clusters/nodes-cluster-overcommit.adoc_:
-- **ROSA HCP**: [Configuring your cluster to place pods on overcommitted nodes](https://110750--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/nodes/clusters/nodes-cluster-overcommit)
-- **ROSA Classic**: [Configuring your cluster to place pods on overcommitted nodes](https://110750--ocpdocs-pr.netlify.app/openshift-rosa/latest/nodes/clusters/nodes-cluster-overcommit)
-- **OSD**: [Configuring your cluster to place pods on overcommitted nodes](https://110750--ocpdocs-pr.netlify.app/openshift-dedicated/latest/nodes/clusters/nodes-cluster-overcommit)


QE review:
N/A

Additional information:
