### PR TITLE
[standalone-logging-docs-6.0] PR for OBSDOCS-3258 Manual CP: CQA + DITA readiness for assemblies and modules under "Scheduling resources" sections.

### DIFF
--- a/modules/cluster-logging-collector-pod-location.adoc
+++ b/modules/cluster-logging-collector-pod-location.adoc
@@ -6,6 +6,7 @@
 [id="cluster-logging-collector-pod-location_{context}"]
 = Viewing logging collector pods
 
+[role="_abstract"]
 You can view the logging collector pods and the corresponding nodes that they are running on.
 
 .Procedure
@@ -17,7 +18,8 @@ You can view the logging collector pods and the corresponding nodes that they ar
 $ oc get pods --selector component=collector -o wide -n <project_name>
 ----
 +
-.Example output
+You get an output similar to the following example:
++
 [source,terminal]
 ----
 NAME           READY  STATUS    RESTARTS   AGE     IP            NODE                  NOMINATED NODE   READINESS GATES

--- a/modules/log-collector-resources-scheduling.adoc
+++ b/modules/log-collector-resources-scheduling.adoc
@@ -6,9 +6,14 @@
 [id="log-collector-resources-scheduling_{context}"]
 = Configuring resources and scheduling for logging collectors
 
+<<<<<<< HEAD
 Administrators can modify the resources or scheduling of the collector by creating a `ClusterLogging` custom resource (CR) that is in the same namespace and has the same name as the `ClusterLogForwarder` CR that it supports.
 
 The applicable stanzas for the `ClusterLogging` CR when using multiple log forwarders in a deployment are `managementState` and `collection`. All other stanzas are ignored.
+=======
+[role="_abstract"]
+Administrators can change the resources and scheduling of the collector by configuring the `collector` field in a `ClusterLogForwarder` custom resource (CR).
+>>>>>>> 632c6efaba (OBSDOCS-3275-CQA: CQA and DITA readiness for scheduling resources section)
 
 .Prerequisites
 
@@ -20,7 +25,12 @@ The applicable stanzas for the `ClusterLogging` CR when using multiple log forwa
 
 . Create a `ClusterLogging` CR that supports your existing `ClusterLogForwarder` CR:
 +
+<<<<<<< HEAD
 .Example `ClusterLogging` CR YAML
+=======
+The following example displays `ClusterLogForwarder` CR YAML:
++
+>>>>>>> 632c6efaba (OBSDOCS-3275-CQA: CQA and DITA readiness for scheduling resources section)
 [source,yaml]
 ----
 apiVersion: logging.openshift.io/v1

--- a/modules/logging-about-pod-scheduling-controls.adoc
+++ b/modules/logging-about-pod-scheduling-controls.adoc
@@ -1,0 +1,23 @@
+// Module included in the following assemblies:
+//
+// * observability/logging/log_storage/cluster-logging-loki.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="logging-about-pod-scheduling-controls_{context}"]
+= About pod scheduling controls
+
+[role="_abstract"]
+Learn how node selectors, taints and tolerations, and affinity rules control where pods run in the cluster.
+
+Pod scheduling controls decide where the scheduler places pods in the cluster. You can use node selectors, taints and tolerations, and affinity rules to influence scheduling decisions. 
+
+Node selector:: A node selector specifies a map of key-value pairs that are defined using custom labels on nodes and selectors specified in pods. For the pod to be eligible to run on a node, the pod must have the same key-value pair as the label on the node.
+
+Taints and toleration:: Taints and tolerations control which pods can be scheduled on nodes. A taint prevents pods from being scheduled unless the pod defines a matching toleration.
+
+Affinity and anti-affinity:: Affinity and anti-affinity rules constrain pod scheduling based on labels. Pod affinity attracts pods to nodes with specific labeled pods. Pod anti-affinity prevents pods from running with certain other pods.
+
+[IMPORTANT]
+====
+If you configure `nodeSelector` and `nodeAffinity` fields, the conditions of both fields must be met for the pod to be scheduled onto a candidate node.
+====

--- a/modules/logging-loki-pod-placement.adoc
+++ b/modules/logging-loki-pod-placement.adoc
@@ -5,11 +5,14 @@
 :_mod-docs-content-type: CONCEPT
 [id="logging-loki-pod-placement_{context}"]
 = Loki pod placement
+
+[role="_abstract"]
 You can control which nodes the Loki pods run on, and prevent other workloads from using those nodes, by using tolerations or node selectors on the pods.
 
-You can apply tolerations to the log store pods with the LokiStack custom resource (CR) and apply taints to a node with the node specification. A taint on a node is a `key:value` pair that instructs the node to repel all pods that do not allow the taint. Using a specific `key:value` pair that is not on other pods ensures that only the log store pods can run on that node.
+You can apply tolerations to the log store pods with the `LokiStack` custom resource (CR) and apply taints to a node with the node specification. A taint on a node is a `key:value` pair that instructs the node to repel all pods that do not allow the taint. Using a specific `key:value` pair that is not on other pods ensures that only the log store pods can run on that node.
 
-.Example LokiStack with node selectors
+The following example displays `LokiStack` with node selectors:
+
 [source,yaml]
 ----
 apiVersion: loki.grafana.com/v1
@@ -20,9 +23,9 @@ metadata:
 spec:
 # ...
   template:
-    compactor: # <1>
+    compactor:
       nodeSelector:
-        node-role.kubernetes.io/infra: "" # <2>
+        node-role.kubernetes.io/infra: ""
     distributor:
       nodeSelector:
         node-role.kubernetes.io/infra: ""
@@ -47,13 +50,15 @@ spec:
 # ...
 ----
 
-<1> Specifies the component pod type that applies to the node selector.
-<2> Specifies the pods that are moved to nodes containing the defined label.
+where:
+--
+* `compactor`: Specifies the component pod type that applies to the node selector.
+* `node-role.kubernetes.io/infra`: Specifies the pods that are moved to nodes containing the defined label.
+--
 
-In the previous example configuration, all Loki pods are moved to nodes containing the `node-role.kubernetes.io/infra: ""` label.
+In the earlier example configuration, all Loki pods are moved to nodes containing the `node-role.kubernetes.io/infra: ""` label.
 
-
-.Example LokiStack CR with node selectors and tolerations
+The following example displays `LokiStack` CR with node selectors and tolerations:
 [source,yaml]
 ----
 apiVersion: loki.grafana.com/v1
@@ -147,14 +152,15 @@ spec:
 # ...
 ----
 
-To configure the `nodeSelector` and `tolerations` fields of the LokiStack (CR), you can use the [command]`oc explain` command to view the description and fields for a particular resource:
+To configure the `nodeSelector` and `tolerations` fields of the `LokiStack` (CR), you can use the [command]`oc explain` command to view the description and fields for a particular resource:
 
 [source,terminal]
 ----
 $ oc explain lokistack.spec.template
 ----
 
-.Example output
+You get an output similar to the following example:
+
 [source,text]
 ----
 KIND:     LokiStack
@@ -182,7 +188,8 @@ For more detailed information, you can add a specific field:
 $ oc explain lokistack.spec.template.compactor
 ----
 
-.Example output
+You get an output similar to the following example:
+
 [source,text]
 ----
 KIND:     LokiStack

--- a/modules/nodes-scheduler-node-selectors-about.adoc
+++ b/modules/nodes-scheduler-node-selectors-about.adoc
@@ -7,13 +7,18 @@
 [id="nodes-scheduler-node-selectors-about_{context}"]
 = About node selectors
 
+[role="_abstract"]
 You can use node selectors on pods and labels on nodes to control where the pod is scheduled. With node selectors, {product-title} schedules the pods on nodes that contain matching labels.
 
-You can use a node selector to place specific pods on specific nodes, cluster-wide node selectors to place new pods on specific nodes anywhere in the cluster, and project node selectors to place new pods in a project on specific nodes.
+You can use node selectors to place pods on specific nodes. Cluster-wide node selectors place new pods on selected nodes across the cluster, while project node selectors place new pods in a project on specific nodes.
 
-For example, as a cluster administrator, you can create an infrastructure where application developers can deploy pods only onto the nodes closest to their geographical location by including a node selector in every pod they create. In this example, the cluster consists of five data centers spread across two regions. In the U.S., label the nodes as `us-east`, `us-central`, or `us-west`. In the Asia-Pacific region (APAC), label the nodes as `apac-east` or `apac-west`. The developers can add a node selector to the pods they create to ensure the pods get scheduled on those nodes.
+As a cluster administrator, you can use node selectors in pod configurations to ensure that developers deploy pods only on nodes near their geographic location.
 
-A pod is not scheduled if the `Pod` object contains a node selector, but no node has a matching label.
+In this example, the cluster spans five data centers across two regions. In the United States (U.S), label nodes as `us-east`, `us-central`, or `us-west`. In the Asia-Pacific (APAC) region, label nodes as `apac-east` or `apac-west`.
+
+Developers can add a node selector to their pods to ensure the scheduler places them on nodes with the required labels.
+
+A pod is not scheduled if the `Pod` object has a node selector, but no node has a matching label.
 
 [IMPORTANT]
 ====
@@ -34,12 +39,13 @@ To use node selectors and labels, first label the node to avoid pods being desch
 +
 [NOTE]
 ====
-You cannot add a node selector directly to an existing scheduled pod. You must label the object that controls the pod, such as deployment config.
+You cannot add a node selector directly to an existing scheduled pod. Label the resource that manages the pod, such as a `Deployment` or other controller.
 ====
 +
 For example, the following `Node` object has the `region: east` label:
 +
-.Sample `Node` object with a label
+The following example displays a `Node` object with a label:
++
 [source,yaml]
 ----
 kind: Node
@@ -60,16 +66,20 @@ metadata:
     node.kubernetes.io/instance-type: m4.large
     kubernetes.io/hostname: ip-10-0-131-14
     kubernetes.io/arch: amd64
-    region: east <1>
+    region: east
     type: user-node
 #...
 ----
-<1> Labels to match the pod node selector.
 
-+
+Where:
+--
+* `region: east`: Labels to match the pod node selector.
+--
+
 A pod has the `type: user-node,region: east` node selector:
-+
-.Sample `Pod` object with node selectors
+
+The following example displays a `Pod` object with node selectors:
+
 [source,yaml]
 ----
 apiVersion: v1
@@ -78,14 +88,18 @@ metadata:
   name: s1
 #...
 spec:
-  nodeSelector: <1>
+  nodeSelector:
     region: east
     type: user-node
 #...
 ----
-<1> Node selectors to match the node label. The node must have a label for each node selector.
-+
-When you create the pod using the example pod spec, it can be scheduled on the example node.
+
+Where:
+--
+* `spec.nodeSelector`: Node selectors to match the node label. The node must have a label for each node selector.
+--
+
+When you create the pod by using the example pod spec, it can be scheduled on the example node.
 
 Default cluster-wide node selectors::
 +
@@ -94,7 +108,8 @@ the pod on nodes with matching labels.
 +
 For example, the following `Scheduler` object has the default cluster-wide `region=east` and `type=user-node` node selectors:
 +
-.Example Scheduler Operator Custom Resource
+The following example displays a Scheduler Operator Custom Resource:
+
 [source,yaml]
 ----
 apiVersion: config.openshift.io/v1
@@ -109,7 +124,7 @@ spec:
 +
 A node in that cluster has the `type=user-node,region=east` labels:
 +
-.Example `Node` object
+The following example displays a `Node` object:
 [source,yaml]
 ----
 apiVersion: v1
@@ -123,7 +138,7 @@ metadata:
 #...
 ----
 +
-.Example `Pod` object with a node selector
+The following example displays a `Pod` object with a node selector:
 [source,yaml]
 ----
 apiVersion: v1
@@ -137,15 +152,16 @@ spec:
 #...
 ----
 +
-When you create the pod using the example pod spec in the example cluster, the pod is created with the cluster-wide node selector and is scheduled on the labeled node:
-+
+When you create the pod by using the example pod spec in the example cluster, the pod is created with the cluster-wide node selector and is scheduled on the labeled node:
+
+The following example displays pod list with the pod on the labeled node:
+
 [source,terminal]
-.Example pod list with the pod on the labeled node
 ----
 NAME     READY   STATUS    RESTARTS   AGE   IP           NODE                                       NOMINATED NODE   READINESS GATES
 pod-s1   1/1     Running   0          20s   10.131.2.6   ci-ln-qg1il3k-f76d1-hlmhl-worker-b-df2s4   <none>           <none>
 ----
-+
+
 [NOTE]
 ====
 If the project where you create the pod has a project node selector, that selector takes preference over a cluster-wide node selector. Your pod is not created or scheduled if the pod does not have the project node selector.
@@ -186,7 +202,7 @@ metadata:
 #...
 ----
 +
-When you create the pod using the example pod spec in this example project, the pod is created with the project node selectors and is scheduled on the labeled node:
+When you create the pod by using the example pod spec in this example project, the pod is created with the project node selectors and is scheduled on the labeled node:
 +
 .Example `Pod` object
 [source,yaml]
@@ -210,9 +226,10 @@ NAME     READY   STATUS    RESTARTS   AGE   IP           NODE                   
 pod-s1   1/1     Running   0          20s   10.131.2.6   ci-ln-qg1il3k-f76d1-hlmhl-worker-b-df2s4   <none>           <none>
 ----
 +
-A pod in the project is not created or scheduled if the pod contains different node selectors. For example, if you deploy the following pod into the example project, it is not created:
+A pod in the project is not created or scheduled if the pod has different node selectors. For example, if you deploy the following pod into the example project, it is not created:
 +
-.Example `Pod` object with an invalid node selector
+The following example displays `Pod` object with an invalid node selector:
++
 [source,yaml]
 ----
 apiVersion: v1

--- a/modules/nodes-scheduler-taints-tolerations-about.adoc
+++ b/modules/nodes-scheduler-taints-tolerations-about.adoc
@@ -17,11 +17,12 @@ endif::[]
 [id="nodes-scheduler-taints-tolerations-about_{context}"]
 = Understanding taints and tolerations
 
+[role="_abstract"]
 A _taint_ allows a node to refuse a pod to be scheduled unless that pod has a matching _toleration_.
 
 You apply taints to a node through the `Node` specification (`NodeSpec`) and apply tolerations to a pod through the `Pod` specification (`PodSpec`). When you apply a taint to a node, the scheduler cannot place a pod on that node unless the pod can tolerate the taint.
 
-.Example taint in a node specification
+The following example displays a taint in a node specification:
 [source,yaml]
 ----
 apiVersion: v1
@@ -37,7 +38,7 @@ spec:
 #...
 ----
 
-.Example toleration in a `Pod` spec
+The following example displays toleration in a `Pod` spec:
 [source,yaml]
 ----
 apiVersion: v1
@@ -65,10 +66,10 @@ Taints and tolerations consist of a key, value, and effect.
 |Parameter |Description
 
 |`key`
-|The `key` is any string, up to 253 characters. The key must begin with a letter or number, and may contain letters, numbers, hyphens, dots, and underscores.
+|The `key` is any string, up to 253 characters. The key must begin with a letter or number, and might contain letters, numbers, hyphens, dots, and underscores.
 
 |`value`
-| The `value` is any string, up to 63 characters. The value must begin with a letter or number, and may contain letters, numbers, hyphens, dots, and underscores.
+| The `value` is any string up to 63 characters. The value must begin with a letter or number and might contain letters, numbers, hyphens, dots, and underscores.
 
 |`effect`
 
@@ -156,7 +157,8 @@ ifdef::nodes-scheduler-taints-tolerations,node-tasks[]
 
 You can specify how long a pod can remain bound to a node before being evicted by specifying the `tolerationSeconds` parameter in the `Pod` specification or `MachineSet` object. If a taint with the `NoExecute` effect is added to a node, a pod that does tolerate the taint, which has the `tolerationSeconds` parameter, the pod is not evicted until that time period expires.
 
-.Example output
+You get an output similar to the following example:
+
 [source,yaml]
 ----
 apiVersion: v1
@@ -276,8 +278,6 @@ If you use the `tolerationSeconds` parameter with no value, pods are never evict
 {product-title} evicts pods in a rate-limited way to prevent massive pod evictions in scenarios such as the master becoming partitioned from the nodes.
 
 By default, if more than 55% of nodes in a given zone are unhealthy, the node lifecycle controller changes that zone's state to `PartialDisruption` and the rate of pod evictions is reduced. For small clusters (by default, 50 nodes or less) in this state, nodes in this zone are not tainted and evictions are stopped.
-
-For more information, see link:https://kubernetes.io/docs/concepts/architecture/nodes/#rate-limits-on-eviction[Rate limits on eviction] in the Kubernetes documentation.
 ====
 
 {product-title} automatically adds a toleration for `node.kubernetes.io/not-ready` and `node.kubernetes.io/unreachable` with `tolerationSeconds=300`, unless the `Pod` configuration specifies either toleration.
@@ -294,15 +294,13 @@ spec:
   - key: node.kubernetes.io/not-ready
     operator: Exists
     effect: NoExecute
-    tolerationSeconds: 300 <1>
+    tolerationSeconds: 300
   - key: node.kubernetes.io/unreachable
     operator: Exists
     effect: NoExecute
     tolerationSeconds: 300
 #...
 ----
-
-<1> These tolerations ensure that the default pod behavior is to remain bound for five minutes after one of these node conditions problems is detected.
 
 You can configure these tolerations as needed. For example, if you have an application with a lot of local state, you might want to keep the pods bound to node for a longer time in the event of network partition, allowing for the partition to recover and avoiding pod eviction.
 

--- a/scheduling_resources/logging-node-selectors.adoc
+++ b/scheduling_resources/logging-node-selectors.adoc
@@ -1,13 +1,16 @@
 :_mod-docs-content-type: ASSEMBLY
-include::_attributes/common-attributes.adoc[]
 [id="logging-node-selectors"]
 = Using node selectors to move logging resources
+include::_attributes/common-attributes.adoc[]
 :context: logging-node-selectors
 
 toc::[]
 
+[role="_abstract"]
+You can use node selectors to control where logging resources run. Configure node labels and selectors to schedule logging components on specific nodes in the cluster.
+
 include::snippets/about-node-selectors.adoc[leveloffset=+1]
-// TODO REMOVE DEPENDENCY
+
 include::modules/nodes-scheduler-node-selectors-about.adoc[leveloffset=+1]
 
 include::modules/logging-loki-pod-placement.adoc[leveloffset=+1]
@@ -17,6 +20,6 @@ include::modules/log-collector-resources-scheduling.adoc[leveloffset=+1]
 include::modules/cluster-logging-collector-pod-location.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
-[id="additional-resources_logging-node-selection"]
 == Additional resources
+
 * link:https://docs.openshift.com/container-platform/latest/nodes/scheduling/nodes-scheduler-node-selectors.adoc#nodes-scheduler-node-selectors[Placing pods on specific nodes using node selectors]

--- a/scheduling_resources/logging-taints-tolerations.adoc
+++ b/scheduling_resources/logging-taints-tolerations.adoc
@@ -1,11 +1,12 @@
 :_mod-docs-content-type: ASSEMBLY
-include::_attributes/common-attributes.adoc[]
 [id="logging-taints-tolerations"]
 = Using taints and tolerations to control logging pod placement
+include::_attributes/common-attributes.adoc[]
 :context: logging-taints-tolerations
 
 toc::[]
 
+[role="_abstract"]
 Taints and tolerations allow the node to control which pods should (or should not) be scheduled on them.
 
 include::modules/nodes-scheduler-taints-tolerations-about.adoc[leveloffset=+1]
@@ -17,8 +18,10 @@ include::modules/log-collector-resources-scheduling.adoc[leveloffset=+1]
 include::modules/cluster-logging-collector-pod-location.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
-[id="additional-resources_cluster-logging-tolerations"]
 == Additional resources
+
 ifdef::openshift-enterprise,openshift-origin[]
 * xref:../../../nodes/scheduling/nodes-scheduler-taints-tolerations.adoc#nodes-scheduler-taints-tolerations[Controlling pod placement using node taints]
+
+* link:https://kubernetes.io/docs/concepts/architecture/nodes/#rate-limits-on-eviction[Rate limits on eviction]
 endif::[]


### PR DESCRIPTION
Cherry-picked from #109643

Commit ID: 632c6efaba417ad7ff680f6d7541bcae4ad3899a

**Note for the peer & merge reviewer:** 
- This PR updates the only "Scheduling resources" section to prepare them for Phase 0 DITA migration.
- No other CQA changes, error types, or content refinements are included. 

**Changes:** 
This PR prepares the "Scheduling resources" section for Phase 0 DITA migration by applying Vale (AsciiDoc DITA) rules and cleaning up the existing content.

**Tracking JIRA:** https://redhat.atlassian.net/browse/OBSDOCS-3275

**Reviews:**
- [x] Peer has approved this change