### PR TITLE
[TELCODOCS-2375]: Improve MetalLB Operator supported platforms documentation

### DIFF
--- a/modules/nw-metallb-infra-considerations.adoc
+++ b/modules/nw-metallb-infra-considerations.adoc
@@ -7,9 +7,18 @@
 = Infrastructure considerations for MetalLB
 
 [role="_abstract"]
-You can use MetalLB for bare metal and on-premise installations that lack a native load balancer.
+MetalLB is designed for bare metal and on-premise environments where no native cloud load balancer is available. Before you deploy MetalLB, verify that your infrastructure meets the networking requirements for your chosen mode.
 
-In addition to bare-metal installations, installations of {product-title} on some infrastructures might not include a native load-balancer capability. For example, the following infrastructures can benefit from adding the MetalLB Operator:
+[IMPORTANT]
+====
+MetalLB is not supported on cloud provider platforms such as AWS, Azure, or Google Cloud. Cloud platforms virtualize the network layer and expose proprietary APIs instead of standard network protocols. As a result, MetalLB cannot function correctly on these platforms.
+
+Use the load balancing service that the platform provides if your cluster runs on a cloud platform.
+====
+
+== Supported platforms
+
+The following infrastructure platforms support MetalLB:
 
 * Bare metal
 
@@ -20,3 +29,18 @@ In addition to bare-metal installations, installations of {product-title} on som
 * {ibm-z-name} and {ibm-linuxone-name} for {op-system-base-full} KVM
 
 * {ibm-power-name}
+
+== Network prerequisites
+
+MetalLB requires the following network capabilities, depending on the operating mode:
+
+For Layer 2 mode::
+* Standard ARP (IPv4) or NDP (IPv6) must function on the network. The network must not block or emulate ARP/NDP traffic.
+* Anti-ARP-spoofing protections, if present, must be disabled on nodes running MetalLB speakers. Some virtualization platforms, such as {rh-openstack-first}, enable this protection by default.
+
+For BGP mode::
+* An external BGP-capable router must be available and reachable from the cluster nodes.
+* The network must allow BGP sessions (TCP port 179) between the cluster nodes and the upstream router.
+
+For both modes::
+* Configure external network infrastructure to route traffic destined for the external IP addresses to the cluster nodes.

--- a/modules/nw-metallb-when-metallb.adoc
+++ b/modules/nw-metallb-when-metallb.adoc
@@ -9,11 +9,11 @@
 [role="_abstract"]
 To get fault-tolerant access to applications through an external IP on bare metal in {product-title}, you can use MetalLB.
 
-Using MetalLB is valuable when you have a bare-metal cluster, or an infrastructure that is like bare metal, and you want fault-tolerant access to an application through an external IP address.
+MetalLB is useful when you have a bare-metal cluster, or an on-premise infrastructure without a native load balancer, and you need to expose services through external IP addresses.
 
-You must configure your networking infrastructure to ensure that network traffic for the external IP address is routed from clients to the host network for the cluster.
+You must configure your networking infrastructure to route network traffic for the external IP address from clients to the host network for the cluster.
 
-After deploying MetalLB with the MetalLB Operator, when you add a service of type `LoadBalancer`, MetalLB provides a platform-native load balancer. 
+When you deploy MetalLB with the MetalLB Operator, and add a service of type `LoadBalancer`, MetalLB provides a platform-native load balancer.
 
 When external traffic enters your {product-title} cluster through a MetalLB `LoadBalancer` service, the return traffic to the client has the external IP address of the load balancer as the source IP.
 

--- a/networking/ingress_load_balancing/metallb/monitoring-metallb-status.adoc
+++ b/networking/ingress_load_balancing/metallb/monitoring-metallb-status.adoc
@@ -6,9 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-As an {product-title} system administrator, you can gain insights into the operational status of your MetalLB deployments by examining the status of its custom resources (CRs). These status fields provide information about IP address allocations, BGP peer announcements, and session states, which are important for effective monitoring and troubleshooting.
-
-For more information about how to install the MetalLB Operator, see xref:../../../networking/networking_operators/metallb-operator/about-metallb.adoc#about-metallb[About MetalLB and the MetalLB Operator].
+[role="_abstract"]
+As an {product-title} system administrator, you can monitor the operational status of your MetalLB deployment by examining its custom resources (CRs). These status fields provide information about IP address allocations, BGP peer announcements, and session states, which are important for effective monitoring and troubleshooting.
 
 // Address pool custom resource
 include::modules/nw-metallb-status-reporting.adoc[leveloffset=+1]
@@ -21,3 +20,8 @@ include::modules/nw-metallb-viewing-servicebgpstatus.adoc[leveloffset=+1]
 
 // Verify BGP session establishment
 include::modules/nw-metallb-verifying-bgp-session.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+== Additional resources
+
+* xref:../../../networking/networking_operators/metallb-operator/about-metallb.adoc#about-metallb[About MetalLB and the MetalLB Operator]


### PR DESCRIPTION
Version(s):
All supported versions (4.16+)

Issue:
https://redhat.atlassian.net/browse/TELCODOCS-2375

Link to docs preview:

- https://110765--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ingress_load_balancing/metallb/monitoring-metallb-status.html
- https://110765--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/networking_operators/metallb-operator/about-metallb.html

QE review:
- [x] QE has approved this change.

Additional information:

The current MetalLB documentation does not clearly state that MetalLB is not supported on cloud provider platforms (AWS, Azure, Google Cloud, etc.), which has caused customer confusion and support cases. The upstream MetalLB docs at https://metallb.io/installation/clouds/ explicitly state this incompatibility.

This PR makes the following changes:

- **`modules/nw-metallb-infra-considerations.adoc`**: Rewrites the infrastructure considerations module to include an IMPORTANT admonition explicitly stating that MetalLB is not supported on cloud platforms, adds a "Supported platforms" section, and adds a new "Network prerequisites" section documenting Layer 2 and BGP mode requirements (ARP/NDP, anti-spoofing, BGP router reachability).
- **`modules/nw-metallb-when-metallb.adoc`**: Replaces the ambiguous phrase "an infrastructure that is like bare metal" with "a supported on-premise infrastructure without a native load balancer".
- **`networking/ingress_load_balancing/metallb/monitoring-metallb-status.adoc`**: Moves an inline xref to an Additional resources section per modular docs guidelines.