### PR TITLE
[enterprise-4.16] TELCODOCS#2676: Fixes for cnf-image-based-upgrade-install-operators

### DIFF
--- a/modules/cnf-image-based-upgrade-installing-lifecycle-agent-using-cli.adoc
+++ b/modules/cnf-image-based-upgrade-installing-lifecycle-agent-using-cli.adoc
@@ -5,6 +5,7 @@
 [id="cnf-image-based-upgrade-installing-lifecycle-agent-using-cli_{context}"]
 = Installing the {lcao} by using the CLI
 
+[role="_abstract"]
 You can use the OpenShift CLI (`oc`) to install the {lcao}.
 
 .Prerequisites

--- a/modules/cnf-image-based-upgrade-installing-lifecycle-agent-using-web-console.adoc
+++ b/modules/cnf-image-based-upgrade-installing-lifecycle-agent-using-web-console.adoc
@@ -5,6 +5,7 @@
 [id="cnf-image-based-upgrade-installing-lifecycle-agent-using-web-console_{context}"]
 = Installing the {lcao} by using the web console
 
+[role="_abstract"]
 You can use the {product-title} web console to install the {lcao}.
 
 .Prerequisites

--- a/modules/ztp-image-based-upgrade-installing-lca.adoc
+++ b/modules/ztp-image-based-upgrade-installing-lca.adoc
@@ -5,6 +5,7 @@
 [id="ztp-image-based-upgrade-installing-lcao-with-gitops_{context}"]
 = Installing the {lcao} with {ztp}
 
+[role="_abstract"]
 Install the {lcao} with {ztp-first} to do an image-based upgrade.
 
 .Procedure
@@ -12,7 +13,8 @@ Install the {lcao} with {ztp-first} to do an image-based upgrade.
 . Extract the following CRs from the `ztp-site-generate` container image and push them to the `source-cr` directory:
 +
 --
-.Example `LcaSubscriptionNS.yaml` file
+Example `LcaSubscriptionNS.yaml` file:
+
 [source,yaml]
 ----
 apiVersion: v1
@@ -26,7 +28,8 @@ metadata:
     kubernetes.io/metadata.name: openshift-lifecycle-agent
 ----
 
-.Example `LcaSubscriptionOperGroup.yaml` file
+Example `LcaSubscriptionOperGroup.yaml` file:
+
 [source,yaml]
 ----
 apiVersion: operators.coreos.com/v1
@@ -41,7 +44,8 @@ spec:
     - openshift-lifecycle-agent
 ----
 
-.Example `LcaSubscription.yaml` file
+Example `LcaSubscription.yaml` file:
+
 [source,yaml]
 ----
 apiVersion: operators.coreos.com/v1alpha1
@@ -61,7 +65,8 @@ status:
   state: AtLatestKnown
 ----
 
-.Example directory structure
+Example directory structure:
+
 [source,terminal]
 ----
 ├── kustomization.yaml

--- a/modules/ztp-image-based-upgrade-installing-oadp.adoc
+++ b/modules/ztp-image-based-upgrade-installing-oadp.adoc
@@ -5,6 +5,7 @@
 [id="ztp-image-based-upgrade-installing-oadp_{context}"]
 = Installing and configuring the {oadp-short} Operator with {ztp}
 
+[role="_abstract"]
 Install and configure the {oadp-short} Operator with {ztp} before starting the upgrade.
 
 .Procedure
@@ -12,7 +13,8 @@ Install and configure the {oadp-short} Operator with {ztp} before starting the u
 . Extract the following CRs from the `ztp-site-generate` container image and push them to the `source-cr` directory:
 +
 --
-.Example `OadpSubscriptionNS.yaml` file
+Example `OadpSubscriptionNS.yaml` file:
+
 [source,yaml]
 ----
 apiVersion: v1
@@ -25,7 +27,8 @@ metadata:
     kubernetes.io/metadata.name: openshift-adp
 ----
 
-.Example `OadpSubscriptionOperGroup.yaml` file
+Example `OadpSubscriptionOperGroup.yaml` file:
+
 [source,yaml]
 ----
 apiVersion: operators.coreos.com/v1
@@ -40,7 +43,8 @@ spec:
   - openshift-adp
 ----
 
-.Example `OadpSubscription.yaml` file
+Example `OadpSubscription.yaml` file:
+
 [source,yaml]
 ----
 apiVersion: operators.coreos.com/v1alpha1
@@ -60,7 +64,8 @@ status:
   state: AtLatestKnown
 ----
 
-.Example `OadpOperatorStatus.yaml` file
+Example `OadpOperatorStatus.yaml` file:
+
 [source,yaml]
 ----
 apiVersion: operators.coreos.com/v1
@@ -90,7 +95,8 @@ status:
         reason: InstallSucceeded
 ----
 
-.Example directory structure
+Example directory structure:
+
 [source,terminal]
 ----
 ├── kustomization.yaml
@@ -138,7 +144,8 @@ spec:
 .. Extract the following CRs from the `ztp-site-generate` container image and push them to the `source-cr` directory:
 +
 --
-.Example `DataProtectionApplication.yaml` file
+Example `DataProtectionApplication.yaml` file:
+
 [source,yaml]
 ----
 apiVersion: oadp.openshift.io/v1alpha1
@@ -151,7 +158,7 @@ metadata:
 spec:
   configuration:
     restic:
-      enable: false <1>
+      enable: false
     velero:
       defaultPlugins:
         - aws
@@ -171,18 +178,20 @@ spec:
           key: cloud
           name: cloud-credentials
         objectStorage:
-          bucket: $bucketName <2>
-          prefix: $prefixName <2>
+          bucket: $bucketName
+          prefix: $prefixName
 status:
   conditions:
   - reason: Complete
     status: "True"
     type: Reconciled
 ----
-<1> The `spec.configuration.restic.enable` field must be set to `false` for an image-based upgrade because persistent volume contents are retained and reused after the upgrade.
-<2> The bucket defines the bucket name that is created in S3 backend. The prefix defines the name of the subdirectory that will be automatically created in the bucket. The combination of bucket and prefix must be unique for each target cluster to avoid interference between them. To ensure a unique storage directory for each target cluster, you can use the {rh-rhacm} hub template function, for example, `prefix: {{hub .ManagedClusterName hub}}`.
 
-.Example `OadpSecret.yaml` file
+* `spec.configuration.restic.enable` must be set to `false` for an image-based upgrade because persistent volume contents are retained and reused after the upgrade.
+* `bucket` defines the bucket name created in S3 backend. `prefix` defines the name of the subdirectory that will be automatically created in the bucket. The combination of bucket and prefix must be unique for each target cluster to avoid interference between them. To ensure a unique storage directory for each target cluster, you can use the {rh-rhacm} hub template function, for example, `prefix: {{hub .ManagedClusterName hub}}`.
+
+Example `OadpSecret.yaml` file:
+
 [source,yaml]
 ----
 apiVersion: v1
@@ -195,7 +204,8 @@ metadata:
 type: Opaque
 ----
 
-.Example `OadpBackupStorageLocationStatus.yaml` file
+Example `OadpBackupStorageLocationStatus.yaml` file:
+
 [source,yaml]
 ----
 apiVersion: velero.io/v1
@@ -230,7 +240,7 @@ spec:
     - fileName: OadpSecret.yaml
       policyName: "config-policy"
       data:
-        cloud: <your_credentials> <1>
+        cloud: <your_credentials>
     - fileName: DataProtectionApplication.yaml
       policyName: "config-policy"
       spec:
@@ -238,7 +248,7 @@ spec:
           - velero:
               config:
                 region: minio
-                s3Url: <your_S3_URL> <2>
+                s3Url: <your_S3_URL>
                 profile: "default"
                 insecureSkipTLSVerify: "true"
                 s3ForcePathStyle: "true"
@@ -248,11 +258,18 @@ spec:
                 key: cloud
                 name: cloud-credentials
               objectStorage:
-                bucket: <your_bucket_name> <3>
-                prefix: <cluster_name> <3>
+                bucket: <your_bucket_name>
+                prefix: <cluster_name>
     - fileName: OadpBackupStorageLocationStatus.yaml
       policyName: "config-policy"
 ----
-<1> Specify your credentials for your S3 storage backend.
-<2> Specify the URL for your S3-compatible bucket.
-<3> The `bucket` defines the bucket name that is created in S3 backend. The `prefix` defines the name of the subdirectory that will be automatically created in the `bucket`. The combination of `bucket` and `prefix` must be unique for each target cluster to avoid interference between them. To ensure a unique storage directory for each target cluster, you can use the {rh-rhacm} hub template function, for example, `prefix: {{hub .ManagedClusterName hub}}`.
++
+where:
+
+`your_credentials`:: Specifies your credentials for your S3 storage backend.
+
+`DataProtectionApplication.yaml`:: If more than one `backupLocations` entries are defined in the `DataProtectionApplication` CR, ensure that each location has a corresponding `OadpBackupStorageLocation` CR added for status tracking. Ensure that the name of each additional `OadpBackupStorageLocation` CR is overridden with the correct index as described in the example `OadpBackupStorageLocationStatus.yaml` file.
+
+`your_S3_URL`:: Specifies the URL for your S3-compatible bucket.
+
+`bucket` and `prefix`:: The `bucket` defines the bucket name that is created in S3 backend. The `prefix` defines the name of the subdirectory that will be automatically created in the `bucket`. The combination of `bucket` and `prefix` must be unique for each target cluster to avoid interference between them. To ensure a unique storage directory for each target cluster, you can use the {rh-rhacm} hub template function, for example, `prefix: {{hub .ManagedClusterName hub}}`.


### PR DESCRIPTION
Version(s): 4.16

Issue: [TELCODOCS-2676](https://redhat.atlassian.net/browse/TELCODOCS-2676)

Link to docs preview:

QE review:

* QE has approved this change.

Additional information:
Manual cherry-pick of #107673 to `enterprise-4.16`. The automated cherry-pick failed due to a merge conflict in `modules/ztp-image-based-upgrade-installing-oadp.adoc`. Conflicts were resolved by adapting the changes to the 4.16 branch content (block titles converted to plain text, callout annotations replaced with bullet lists and description lists, abstract roles added, 4.16-specific attribute names and filenames preserved).