### PR TITLE
RHDEVDOCS-7298: CQA 2.0 fixes for Masking sensitive annotations in the Argo CD web UI

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -176,7 +176,7 @@ Topics:
   File: configuring-secure-communication-with-redis
 - Name: Managing secrets securely using Secrets Store CSI driver with GitOps
   File: managing-secrets-securely-using-sscsid-with-gitops
-- Name: Masking sensitive annotations in the Argo CD Web UI
+- Name: Masking sensitive annotations in the Argo CD web UI
   File: masking-sensitive-annotations-in-the-argo-cd-web-ui
 ---
 Name: GitOps CLI (argocd) reference

--- a/modules/gitops_enabling_sensitive_annotations_in_the_argo_cd_web_ui.adoc
+++ b/modules/gitops_enabling_sensitive_annotations_in_the_argo_cd_web_ui.adoc
@@ -4,9 +4,10 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="gitops_enabling_sensitive_annotations_in_the_argo_cd_web_ui_{context}"]
-= Enabling sensitive annotations masking in the Argo CD Web UI
+= Enabling sensitive annotations masking in the Argo CD web UI
 
-To enable sensitive annotations masking in the Argo CD user interface (UI), you can add the annotation key, `resource.sensitive.mask.annotations`, in the Argo CD custom resource (CR).
+[role="_abstract"]
+Configure the Argo CD web UI to hide sensitive values in annotations on `Secret` resources by specifying the annotation keys to mask in the Argo CD custom resource (CR).
 
 .Procedure
 
@@ -36,9 +37,15 @@ spec:
 --
 where:
 
-`<spec.extraConfig.resource.sensitive.mask.annotations>`:: Specifies a comma-separated list of sensitive annotation values, such as `openshift.io/token-secret.value`, `api-key`, and `token`.
+`spec.extraConfig.resource.sensitive.mask.annotations`:: Specifies a comma-separated list of annotation keys to mask in the Argo CD web UI, such as `openshift.io/token-secret.value`, `api-key`, and `token`.
 --
 +
+[IMPORTANT]
+====
+Ensure that the annotation keys listed in `resource.sensitive.mask.annotations` are accurate and relevant to your use case. Wildcards are not supported. Specify each annotation key explicitly.
+====
++
+. Click *Save*.
 . To verify that the value in the Argo CD resource has been updated successfully, complete the following steps:
 .. In the *Administrator* perspective of the web console, click *Operators* -> *Installed Operators*.
 .. In the *Project* option, select the `Argo CD` namespace.

--- a/securing_openshift_gitops/masking-sensitive-annotations-in-the-argo-cd-web-ui.adoc
+++ b/securing_openshift_gitops/masking-sensitive-annotations-in-the-argo-cd-web-ui.adoc
@@ -1,24 +1,19 @@
 :_mod-docs-content-type: ASSEMBLY
 include::_attributes/common-attributes.adoc[]
 [id="masking-sensitive-annotations-in-the-argo-cd-web-ui"]
-= Masking sensitive annotations in the Argo CD Web UI
+= Masking sensitive annotations in the Argo CD web UI
 :context: masking-sensitive-annotations-in-the-argo-cd-web-ui
 
 toc::[]
 
-Argo CD hides sensitive annotation values on `Secret` resources from the Argo CD user interface (UI) and command-line interface (CLI). Users can configure this by specifying annotation keys to be masked in the Argo CD custom resource (CR). This feature enhances security by preventing accidental exposure of sensitive information, such as tokens or API keys, stored in annotations on `Secret` resources.
+[role="_abstract"]
 
-To enable this feature, add the `resource.sensitive.mask.annotations` key under `.spec.extraConfig` in the Argo CD CR. Specify a comma-separated list of annotation keys to mask.
-
-[IMPORTANT]
-====
-Ensure that the annotation keys listed in `resource.sensitive.mask.annotations` are accurate and relevant to your use case. This feature does not support wildcards and requires explicit configuration in the Argo CD CR.
-====
+Prevent accidental exposure of sensitive information by masking annotation values in the Argo CD web UI. Configure which annotation keys to hide by adding them to the Argo CD custom resource (CR). This enhances security for sensitive data, such as tokens or API keys, stored in annotations on `Secret` resources.
 
 .Prerequisites
 * You have created an Argo CD instance. For more information, see "Installing a user-defined Argo CD instance".
 
-// Enabling sensitive annotations masking in the Argo CD Web UI
+// Enabling sensitive annotations masking in the Argo CD web UI
 include::modules/gitops_enabling_sensitive_annotations_in_the_argo_cd_web_ui.adoc[leveloffset=+1]
 
 [role="_additional-resources"]


### PR DESCRIPTION
This PR is a manual cherry-pick of https://github.com/openshift/openshift-docs/pull/110398/