### PR TITLE
TELCODOCS-2097: interface IP forwarding

### DIFF
--- a/modules/nw-metallb-configure-secondary-interface.adoc
+++ b/modules/nw-metallb-configure-secondary-interface.adoc
@@ -1,125 +1,93 @@
 :_mod-docs-content-type: PROCEDURE
 [id="nw-metallb-configure-secondary-interface_{context}"]
-= Configuring MetalLB with secondary networks
+= Configure MetalLB with secondary networks
 
 [role="_abstract"]
-From {product-title} 4.14 the default network behavior is to not allow forwarding of IP packets between network interfaces. Therefore, when MetalLB is configured on a secondary interface, you need to add a machine configuration to enable IP forwarding for only the required interfaces. 
+In environments with multiple network interfaces, you might need MetalLB to advertise load-balancer IP addresses on a secondary interface for network traffic segmentation. To route traffic using a secondary interface, you must do the following:
+
+* Enable IP forwarding on the secondary interface so that the interface can forward packets to the pods.
+* Enable local gateway mode at the cluster level so that traffic uses the host networking stack.
 
 [NOTE]
 ====
-{product-title} clusters upgraded from 4.13 are not affected because a global parameter is set during upgrade to enable global IP forwarding. 
+From {product-title} 4.14, IP forwarding is disabled by default on cluster nodes for improved security. Clusters upgraded from 4.13 might already have IP forwarding enabled because existing node settings are preserved during upgrade.
 ====
 
-To enable IP forwarding for the secondary interface, you have two options:
+.Prerequisites
 
-* Enable IP forwarding for a specific interface.
-* Enable IP forwarding for all interfaces.
-
-[NOTE]
-====
-Enabling IP forwarding for a specific interface provides more granular control, while enabling it for all interfaces applies a global setting.
-====
+* You installed and configured MetalLB.
+* You identified the secondary network interface on each node.
+* You installed the Kubernetes NMState Operator.
+* You have access to the cluster as a user with the `cluster-admin` role.
+* You have installed the OpenShift CLI (`oc`).
 
 .Procedure
 
-. Patch the Cluster Network Operator, setting the parameter `routingViaHost` to `true` by running the following command: 
+. Enable local gateway mode by patching the Cluster Network Operator to set `routingViaHost` to `true`:
 +
 [source,terminal]
 ----
 $ oc patch network.operator cluster -p '{"spec":{"defaultNetwork":{"ovnKubernetesConfig":{"gatewayConfig": {"routingViaHost": true} }}}}' --type=merge
 ----
++
+This setting routes traffic through the host networking stack, which is required for MetalLB to use secondary interfaces.
 
-. Enable forwarding for a specific secondary interface, such as `bridge-net`, by creating and applying a `MachineConfig` CR:
-+
-..  Base64-encode the string that is used to configure network kernel parameters by running the following command on your local machine:
-+
-[source,terminal]
-----
-$ echo -e "net.ipv4.conf.bridge-net.forwarding = 1" | base64 -w0
-----
-+
-.Example output
-[source,terminal]
-----
-bmV0LmlwdjQuY29uZi5icmlkZ2UtbmV0LmZvcndhcmRpbmcgPSAxCg==
-----
-+
-.. Create the `MachineConfig` CR to enable IP forwarding for the specified secondary interface named `bridge-net`.
-+
-.. Save the following YAML in the `enable-ip-forward.yaml` file:
+. Create a `NodeNetworkConfigurationPolicy` manifest to enable IP forwarding on the secondary interface, such as `eth1`:
 +
 [source,yaml]
 ----
-apiVersion: machineconfiguration.openshift.io/v1
-kind: MachineConfig
+apiVersion: nmstate.io/v1
+kind: NodeNetworkConfigurationPolicy
 metadata:
-  labels:
-    machineconfiguration.openshift.io/role: <node_role>
-  name: 81-enable-global-forwarding
+  name: enable-forwarding-eth1
 spec:
-  config:
-    ignition:
-      version: 3.2.0
-    storage:
-      files:
-      - contents:
-          source: data:text/plain;charset=utf-8;base64,bmV0LmlwdjQuY29uZi5icmlkZ2UtbmV0LmZvcndhcmRpbmcgPSAxCg==
-          verification: {}
-        filesystem: root
-        mode: 420
-        path: /etc/sysctl.d/enable-global-forwarding.conf
-  osImageURL: ""
-# ...
+  nodeSelector:
+    node-role.kubernetes.io/worker: ""
+  desiredState:
+    interfaces:
+    - name: eth1
+      type: ethernet
+      state: up
+      ipv4:
+        enabled: true
+        forwarding: true
 ----
 +
-where:
-+
-`<node_role>`:: Node role where you want to enable IP forwarding, for example, `worker`.
-`contents.source`:: Populate with the generated Base64 string.
-+
-.. Apply the configuration by running the following command:
-+
-[source,terminal]
-----
-$ oc apply -f enable-ip-forward.yaml
-----
+* `interfaces.name` defines the name of the secondary interface on which to enable IP forwarding.
+* `ipv4.forwarding` enables IPv4 forwarding on the interface.
 
-. Optional: Enable IP forwarding globally by running the following command:
+. Apply the policy by running the following command:
 +
 [source,terminal]
 ----
-$ oc patch network.operator cluster -p '{"spec":{"defaultNetwork":{"ovnKubernetesConfig":{"gatewayConfig":{"ipForwarding": "Global"}}}}}' --type=merge
+$ oc apply -f enable-forwarding-eth1.yaml
 ----
 
 .Verification
 
-.  After you apply the machine config, verify the changes by completing the following steps: 
-+
-.. Enter into a debug session on the target node by running the following command. This command instantiates a debug pod called `<node-name>-debug`.
+. Verify that the policy was applied by running the following command:
 +
 [source,terminal]
 ----
-$ oc debug node/<node-name>
-----
-+
-.. Set `/host` as the root directory within the debug shell by running the following command. The debug pod mounts root file system of the host in `/host` within the pod. By changing the root directory to `/host`, you can run binaries contained in the executable paths of the host.
-+
-[source,terminal]
-----
-$ chroot /host
-----
-+
-.. Verify that IP forwarding is enabled by running the following command: 
-+
-[source,terminal]
-----
-$ cat /etc/sysctl.d/enable-global-forwarding.conf
+$ oc get nncp
 ----
 +
 .Example output
 [source,terminal]
 ----
-net.ipv4.conf.bridge-net.forwarding = 1 
+NAME                      STATUS      REASON
+enable-forwarding-eth1    Available   SuccessfullyConfigured
+----
+
+. Verify that IP forwarding is enabled on a node by running the following command, replacing `<node_name>` with the name of the node:
++
+[source,terminal]
+----
+$ oc debug node/<node_name> -- chroot /host sysctl net.ipv4.conf.eth1.forwarding
 ----
 +
-The output indicates that IPv4 forwarding is enabled on the `bridge-net` interface.
+.Example output
+[source,terminal]
+----
+net.ipv4.conf.eth1.forwarding = 1
+----

--- a/modules/nw-nmstate-enable-per-interface-ip-forwarding.adoc
+++ b/modules/nw-nmstate-enable-per-interface-ip-forwarding.adoc
@@ -1,0 +1,104 @@
+// Module included in the following assemblies:
+//
+// * networking/k8s_nmstate/k8s-nmstate-updating-node-network-config.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="nw-nmstate-enable-per-interface-ip-forwarding_{context}"]
+= Enable IP forwarding on specific interfaces
+
+[role="_abstract"]
+You can enable IPv4 forwarding on specific network interfaces by configuring the `forwarding` field in a `NodeNetworkConfigurationPolicy` custom resource (CR).
+
+Enabling IP forwarding is useful when you need specific secondary network interfaces to forward IP packets. For example, MetalLB load balancers on secondary network interfaces require IP forwarding to function. IP forwarding at the interface level enables this functionality, while retaining global forwarding rules that still disable IP forwarding at the node or cluster level.
+
+[IMPORTANT]
+====
+The Kubernetes NMState Operator configures forwarding on secondary network interfaces for IPv4 packets only.
+====
+
+.Prerequisites
+
+* You installed Kubernetes NMState Operator.
+* You have access to the cluster as a user with the `cluster-admin` role.
+* You have identified the network interfaces that require IPv4 forwarding.
+* You have installed the OpenShift CLI (`oc`).
+
+.Procedure
+
+. Create a `NodeNetworkConfigurationPolicy` manifest file to enable IP forwarding on the target interface:
++
+[source,yaml]
+----
+apiVersion: nmstate.io/v1
+kind: NodeNetworkConfigurationPolicy
+metadata:
+  name: enable-forwarding-eth1 
+spec:
+  nodeSelector:
+    node-role.kubernetes.io/worker: ""
+  desiredState:
+    interfaces:
+    - name: eth1
+      type: ethernet
+      state: up
+      ipv4:
+        enabled: true
+        forwarding: true
+----
++
+where:
++
+* `metadata.name` defines the name of the policy.
+* `spec.nodeSelector` specifies which nodes to apply the policy to based on node labels or roles.
+* `interfaces.name` defines the name of the interface on which to enable IP forwarding. This can be a physical, bond, or VLAN interface.
+* `interfaces.ipv4.enabled` defines whether the IPv4 protocol is active.
+* `interfaces.ipv4.forwarding` specifies whether IPv4 forwarding is enabled on the interface. Setting this to `true` enables IPv4 forwarding on the interface.
+
+. Apply the policy by running the following command:
++
+[source,terminal]
+----
+$ oc apply -f enable-forwarding-eth1.yaml
+----
+
+.Verification
+
+. Verify that the policy was applied successfully by running the following command:
++
+[source,terminal]
+----
+$ oc get nncp
+----
++
+.Example output
+[source,terminal]
+----
+NAME                      STATUS      REASON
+enable-forwarding-eth1    Available   SuccessfullyConfigured
+----
++
+The `SuccessfullyConfigured` status indicates that the policy was successfully applied.
+
+. Start a debug session on a target node and access the root file system:
++
+[source,terminal]
+----
+$ oc debug node/<node_name>
+# chroot /host
+----
+* Replace `<node_name>` with the name of the node.
+
+. Verify that IP forwarding is enabled on the interface:
++
+[source,terminal]
+----
+# sysctl net.ipv4.conf.eth1.forwarding
+----
++
+.Example output
+[source,terminal]
+----
+net.ipv4.conf.eth1.forwarding = 1
+----
++
+A value of `1` indicates that IPv4 forwarding is enabled on the interface.

--- a/networking/ingress_load_balancing/metallb/about-advertising-ipaddresspool.adoc
+++ b/networking/ingress_load_balancing/metallb/about-advertising-ipaddresspool.adoc
@@ -53,3 +53,5 @@ include::modules/nw-metallb-configure-secondary-interface.adoc[leveloffset=+1]
 == Additional resources
 
 * xref:../../../networking/ingress_load_balancing/metallb/metallb-configure-community-alias.adoc#metallb-configure-community-alias[Configuring a community alias]
+
+* xref:../../../networking/k8s_nmstate/k8s-nmstate-updating-node-network-config.adoc#nw-nmstate-enable-per-interface-ip-forwarding_k8s-nmstate-updating-node-network-config[Enable IP forwarding on specific interfaces]

--- a/networking/k8s_nmstate/k8s-nmstate-updating-node-network-config.adoc
+++ b/networking/k8s_nmstate/k8s-nmstate-updating-node-network-config.adoc
@@ -127,6 +127,9 @@ include::modules/virt-example-enabling-lldp-policy.adoc[leveloffset=+2]
 // Examples: IP management
 include::modules/virt-example-nmstate-IP-management.adoc[leveloffset=+1]
 
+// Enabling per-interface IP forwarding
+include::modules/nw-nmstate-enable-per-interface-ip-forwarding.adoc[leveloffset=+1]
+
 // Routes and route tables
 include::modules/virt-routes-route-rules.adoc[leveloffset=+1]
 


### PR DESCRIPTION
[TELCODOCS-2097](https://redhat.atlassian.net/browse/TELCODOCS-2097): interface IP forwarding

Version(s):
4.22+

Issue:
https://redhat.atlassian.net/browse/TELCODOCS-2097

Link to docs preview:
- https://110798--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ingress_load_balancing/metallb/about-advertising-ipaddresspool.html#nw-metallb-configure-secondary-interface_about-advertising-ip-address-pool
- https://110798--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/k8s_nmstate/k8s-nmstate-updating-node-network-config.html#nw-nmstate-enable-per-interface-ip-forwarding_k8s-nmstate-updating-node-network-config

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
