### PR TITLE
DOCPLAN-80: Post install network config vale updates

### DIFF
--- a/modules/virt-configuring-secondary-network-vm-live-migration.adoc
+++ b/modules/virt-configuring-secondary-network-vm-live-migration.adoc
@@ -8,6 +8,8 @@
 = Configuring a dedicated secondary network for live migration
 
 [role="_abstract"]
+After you have configured a Linux bridge network, you can configure a dedicated network for live migration. A dedicated network minimizes the effects of network saturation on tenant workloads during live migration.
+
 To configure a dedicated secondary network for live migration, you must first create a bridge network attachment definition (NAD) by using the CLI. You can then add the name of the `NetworkAttachmentDefinition` object to the `HyperConverged` custom resource (CR).
 
 .Prerequisites

--- a/modules/virt-creating-linux-bridge-nncp.adoc
+++ b/modules/virt-creating-linux-bridge-nncp.adoc
@@ -8,6 +8,8 @@
 = Creating a Linux bridge NNCP
 
 [role="_abstract"]
+After you install the Kubernetes NMState Operator, you can configure a Linux bridge network for live migration or external access to virtual machines (VMs).
+
 You can create a `NodeNetworkConfigurationPolicy` (NNCP) manifest for a Linux bridge network.
 
 .Prerequisites

--- a/virt/post_installation_configuration/virt-post-install-network-config.adoc
+++ b/virt/post_installation_configuration/virt-post-install-network-config.adoc
@@ -11,64 +11,39 @@ By default, {VirtProductName} uses a single internal pod network after installat
 
 ifndef::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
 After you install {VirtProductName}, you can install networking Operators and configure additional networks.
+
+* You must install the Kubernetes NMState Operator to configure a Linux bridge network for live migration or external access to virtual machines (VMs).
+* You can install the SR-IOV Operator to manage SR-IOV network devices and network attachments.
+* You can add the MetalLB Operator to manage the lifecycle for an instance of MetalLB on your cluster.
 endif::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
 
-[id="installing-operators"]
-== Installing networking Operators
+include::modules/virt-creating-linux-bridge-nncp.adoc[leveloffset=+1]
+
+include::modules/virt-creating-linux-bridge-nad-web.adoc[leveloffset=+1]
+
+include::modules/virt-configuring-secondary-network-vm-live-migration.adoc[leveloffset=+1]
+
+include::modules/virt-selecting-migration-network-ui.adoc[leveloffset=+1]
 
 ifndef::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
-You must install the xref:../../networking/networking_operators/k8s-nmstate-about-the-k8s-nmstate-operator.adoc#k8s-nmstate-about-the-k8s-nmstate-operator[Kubernetes NMState Operator] to configure a Linux bridge network for live migration or external access to virtual machines (VMs). For installation instructions, see xref:../../networking/networking_operators/k8s-nmstate-about-the-k8s-nmstate-operator.adoc#installing-the-kubernetes-nmstate-operator-web-console_k8s-nmstate-operator[Installing the Kubernetes NMState Operator by using the web console].
-endif::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
 
-ifndef::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
-You can install the xref:../../networking/hardware_networks/about-sriov.adoc#about-sriov[SR-IOV Operator] to manage SR-IOV network devices and network attachments. For installation instructions, see xref:../../networking/networking_operators/sr-iov-operator/installing-sriov-operator.adoc#installing-sr-iov-operator_installing-sriov-operator[Installing the SR-IOV Network Operator].
-endif::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
+include::modules/nw-sriov-configuring-device.adoc[leveloffset=+1]
 
-ifndef::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
-You can add the xref:../../networking/networking_operators/metallb-operator/about-metallb.adoc#about-metallb[About MetalLB and the MetalLB Operator] to manage the lifecycle for an instance of MetalLB on your cluster. For installation instructions, see xref:../../networking/networking_operators/metallb-operator/metallb-operator-install.adoc#metallb-installing-using-web-console_metallb-operator-install[Installing the MetalLB Operator from the software catalog by using the web console].
-endif::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
+include::modules/nw-sriov-network-attachment.adoc[leveloffset=+1]
 
-[id="configuring-linux-bridge-network"]
-== Configuring a Linux bridge network
-
-After you install the Kubernetes NMState Operator, you can configure a Linux bridge network for live migration or external access to virtual machines (VMs).
-
-include::modules/virt-creating-linux-bridge-nncp.adoc[leveloffset=+2]
-
-include::modules/virt-creating-linux-bridge-nad-web.adoc[leveloffset=+2]
-
-ifndef::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
-[id="configuring-linux-bridge-network-next-steps"]
-== Next steps
-
-* xref:../../virt/vm_networking/virt-connecting-vm-to-linux-bridge.adoc#virt-attaching-vm-secondary-network-cli_virt-connecting-vm-to-linux-bridge[Attaching a virtual machine (VM) to a Linux bridge network]
-endif::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
-
-[id="configuring-network-live-migration"]
-== Configuring a network for live migration
-
-After you have configured a Linux bridge network, you can configure a dedicated network for live migration. A dedicated network minimizes the effects of network saturation on tenant workloads during live migration.
-
-include::modules/virt-configuring-secondary-network-vm-live-migration.adoc[leveloffset=+2]
-
-include::modules/virt-selecting-migration-network-ui.adoc[leveloffset=+2]
-
-ifndef::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
-[id="configuring-sriov-network"]
-== Configuring an SR-IOV network
-
-After you install the SR-IOV Operator, you can configure an SR-IOV network.
-
-include::modules/nw-sriov-configuring-device.adoc[leveloffset=+2]
-
-include::modules/nw-sriov-network-attachment.adoc[leveloffset=+2]
-
-[id="next-steps_{context}"]
-== Next steps
-
-* xref:../../virt/vm_networking/virt-connecting-vm-to-sriov.adoc#virt-attaching-vm-to-sriov-network_virt-connecting-vm-to-sriov[Attaching a virtual machine (VM) to an SR-IOV network]
 endif::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
 
 include::modules/virt-enabling-load-balancer-service-web.adoc[leveloffset=+1]
+
 include::modules/virt-configuring-cdiuploadproxy-routes.adoc[leveloffset=+1]
 
+ifndef::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
+[role="_additional-resources"]
+[id="additional-resources_{context}"]
+== Additional resources
+* xref:../../networking/networking_operators/k8s-nmstate-about-the-k8s-nmstate-operator.adoc#k8s-nmstate-about-the-k8s-nmstate-operator[Kubernetes NMState Operator]
+* xref:../../networking/hardware_networks/about-sriov.adoc#about-sriov[SR-IOV Operator]
+* xref:../../networking/networking_operators/metallb-operator/about-metallb.adoc#about-metallb[About MetalLB and the MetalLB Operator]
+* xref:../../virt/vm_networking/virt-connecting-vm-to-linux-bridge.adoc#virt-attaching-vm-secondary-network-cli_virt-connecting-vm-to-linux-bridge[Attaching a virtual machine (VM) to a Linux bridge network]
+* xref:../../virt/vm_networking/virt-connecting-vm-to-sriov.adoc#virt-attaching-vm-to-sriov-network_virt-connecting-vm-to-sriov[Attaching a virtual machine (VM) to an SR-IOV network]
+endif::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]


### PR DESCRIPTION
Version(s):
4.20+

Issue:
https://redhat.atlassian.net/browse/DOCPLAN-80

Link to docs preview:
- https://110800--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/post_installation_configuration/virt-post-install-network-config.html (OCP) / https://110800--ocpdocs-pr.netlify.app/openshift-dedicated/latest/virt/post_installation_configuration/virt-post-install-network-config.html (OSD)

QE review:
n/a

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
