### PR TITLE
Telcodocs 2886: SR-IOV VF Promiscuous and All-Multicast Mode Setup

### DIFF
--- a/modules/nw-cfg-config-all-multi-cni.adoc
+++ b/modules/nw-cfg-config-all-multi-cni.adoc
@@ -8,6 +8,7 @@
 [role="_abstract"]
 You can enable promiscuous mode and all-multicast mode on network interfaces in {product-title} by using the tuning Container Network Interface (CNI) meta plugin in a network attachment definition.
 Promiscuous mode allows the interface to receive all packets on the network, while all-multicast mode allows the interface to receive all multicast packets.
+These modes are independent of each other and can be enabled separately or together.
 These modes are available for any main CNI plugin, such as bridge or SR-IOV.
 
 .Procedure
@@ -51,7 +52,7 @@ where:
 `"allmulti"`:: Optional: Set to `true` to enable all-multicast mode. The interface receives all multicast packets on the network.
 --
 +
-.Example network attachment definition with both modes
+.Example network attachment definition with all-multicast mode only
 [source,yaml]
 ----
 apiVersion: "k8s.cni.cncf.io/v1"
@@ -63,6 +64,30 @@ spec:
   config: '{
     "cniVersion": "0.4.0",
     "name": "setallmulti",
+    "plugins": [
+      {
+        "type": "bridge"
+      },
+      {
+        "type": "tuning",
+        "allmulti": true
+      }
+    ]
+  }'
+----
++
+.Example network attachment definition with both modes
+[source,yaml]
+----
+apiVersion: "k8s.cni.cncf.io/v1"
+kind: NetworkAttachmentDefinition
+metadata:
+  name: setpromiscallmulti
+  namespace: default
+spec:
+  config: '{
+    "cniVersion": "0.4.0",
+    "name": "setpromiscallmulti",
     "plugins": [
       {
         "type": "bridge"
@@ -166,7 +191,20 @@ $ oc rsh allmultipod
 sh-4.4# ip link
 ----
 +
-.Example output
+The expected output depends on which mode you configured:
++
+.Example output for all-multicast mode only
+[source,terminal]
+----
+1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN mode DEFAULT group default qlen 1000
+    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
+2: eth0@if22: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 8901 qdisc noqueue state UP mode DEFAULT group default
+    link/ether 0a:58:0a:83:00:10 brd ff:ff:ff:ff:ff:ff link-netnsid 0
+3: net1@if24: <BROADCAST,MULTICAST,ALLMULTI,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP mode DEFAULT group default
+    link/ether ee:9b:66:a4:ec:1d brd ff:ff:ff:ff:ff:ff link-netnsid 0
+----
++
+.Example output for both modes
 [source,terminal]
 ----
 1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN mode DEFAULT group default qlen 1000
@@ -180,7 +218,7 @@ sh-4.4# ip link
 where:
 
 `eth0@if22`:: Specifies the primary interface.
-`net1@if24`:: Specifies the secondary interface configured with the network-attachment-definition. The PROMISC flag indicates promiscuous mode is enabled. The ALLMULTI flag indicates all-multicast mode is enabled. If you configured only one mode, you would see only that flag.
+`net1@if24`:: Specifies the secondary interface configured with the network-attachment-definition. The `ALLMULTI` flag indicates all-multicast mode is enabled. The `PROMISC` flag indicates promiscuous mode is enabled. You will see only the flags for the modes you configured.
 
 For SR-IOV networks that require PF-level configuration for promiscuous mode, see the related resource below.
 

--- a/modules/nw-cfg-config-all-multi-cni.adoc
+++ b/modules/nw-cfg-config-all-multi-cni.adoc
@@ -3,10 +3,12 @@
 // * networking/setting-interface-level-network-sysctls.adoc
 :_mod-docs-content-type: PROCEDURE
 [id="nw-enabling-all-multi-cni_{context}"]
-= Enabling all-multicast mode by using the tuning CNI
+= Enabling promiscuous and all-multicast modes by using the tuning CNI
 
 [role="_abstract"]
-To enable all-multicast mode on network interfaces in {product-title}, you can use the tuning Container Network Interface (CNI) meta plugin in a network attachment definition. When enabled, the interface receives all multicast packets on the network.
+You can enable promiscuous mode and all-multicast mode on network interfaces in {product-title} by using the tuning Container Network Interface (CNI) meta plugin in a network attachment definition.
+Promiscuous mode allows the interface to receive all packets on the network, while all-multicast mode allows the interface to receive all multicast packets.
+These modes are available for any main CNI plugin, such as bridge or SR-IOV.
 
 .Procedure
 
@@ -28,11 +30,11 @@ spec:
       },
       {
        "type": "tuning",
+       "promisc": true,
        "allmulti": true
-        }
       }
-     ]
-}
+    ]
+  }'
 ----
 +
 where:
@@ -45,10 +47,11 @@ where:
 `"<name>"`:: Specifies the name for the configuration. Match the configuration name to the name value of the network attachment definition.
 `"<main_CNI_plugin>"`:: Specifies the name of the main CNI plugin to configure.
 `"tuning"`:: Specifies the name of the CNI meta plugin.
-`"true"`:: Specifies the all-multicast mode of interface. If enabled, all multicast packets on the network will be received by the interface.
+`"promisc"`:: Optional: Set to `true` to enable promiscuous mode. The interface receives all packets on the network.
+`"allmulti"`:: Optional: Set to `true` to enable all-multicast mode. The interface receives all multicast packets on the network.
 --
 +
-.Example network attachment definition
+.Example network attachment definition with both modes
 [source,yaml]
 ----
 apiVersion: "k8s.cni.cncf.io/v1"
@@ -66,6 +69,7 @@ spec:
       },
       {
         "type": "tuning",
+        "promisc": true,
         "allmulti": true
       }
     ]
@@ -169,11 +173,17 @@ sh-4.4# ip link
     link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
 2: eth0@if22: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 8901 qdisc noqueue state UP mode DEFAULT group default
     link/ether 0a:58:0a:83:00:10 brd ff:ff:ff:ff:ff:ff link-netnsid 0
-3: net1@if24: <BROADCAST,MULTICAST,ALLMULTI,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP mode DEFAULT group default
+3: net1@if24: <BROADCAST,MULTICAST,ALLMULTI,PROMISC,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP mode DEFAULT group default
     link/ether ee:9b:66:a4:ec:1d brd ff:ff:ff:ff:ff:ff link-netnsid 0
 ----
 +
 where:
 
 `eth0@if22`:: Specifies the primary interface.
-`net1@if24`:: Specifies the secondary interface configured with the network-attachment-definition that supports the all-multicast mode (ALLMULTI flag).
+`net1@if24`:: Specifies the secondary interface configured with the network-attachment-definition. The PROMISC flag indicates promiscuous mode is enabled. The ALLMULTI flag indicates all-multicast mode is enabled. If you configured only one mode, you would see only that flag.
+
+For SR-IOV networks that require PF-level configuration for promiscuous mode, see the related resource below.
+
+.Additional resources
+
+* xref:../../networking/hardware_networks/configuring-interface-sysctl-sriov-device.adoc#nw-sriov-pf-promisc-machineconfig_configuring-sysctl-interface-sriov-device[Enabling PF-level promiscuous support through MachineConfig]

--- a/modules/nw-cfg-config-all-multi-cni.adoc
+++ b/modules/nw-cfg-config-all-multi-cni.adoc
@@ -8,7 +8,7 @@
 [role="_abstract"]
 You can enable promiscuous mode and all-multicast mode on network interfaces in {product-title} by using the tuning Container Network Interface (CNI) meta plugin in a network attachment definition.
 Promiscuous mode allows the interface to receive all packets on the network, while all-multicast mode allows the interface to receive all multicast packets.
-These modes are independent of each other and can be enabled separately or together.
+These modes are independent of each other, and you can enable them separately or together.
 These modes are available for any main CNI plugin, such as bridge or SR-IOV.
 
 .Procedure
@@ -43,7 +43,7 @@ where:
 --
 
 `<name>`:: Specifies the name for the additional network attachment to create. The name must be unique within the specified namespace.
-`default`:: Specifies the namespace that the object is associated with.
+`default`:: Specifies the namespace for the object.
 `"0.4.0"`:: Specifies the CNI specification version.
 `"<name>"`:: Specifies the name for the configuration. Match the configuration name to the name value of the network attachment definition.
 `"<main_CNI_plugin>"`:: Specifies the name of the main CNI plugin to configure.
@@ -52,7 +52,8 @@ where:
 `"allmulti"`:: Optional: Set to `true` to enable all-multicast mode. The interface receives all multicast packets on the network.
 --
 +
-.Example network attachment definition with all-multicast mode only
+The following example shows a network attachment definition with all-multicast mode only:
++
 [source,yaml]
 ----
 apiVersion: "k8s.cni.cncf.io/v1"
@@ -76,7 +77,8 @@ spec:
   }'
 ----
 +
-.Example network attachment definition with both modes
+The following example shows a network attachment definition with both modes:
++
 [source,yaml]
 ----
 apiVersion: "k8s.cni.cncf.io/v1"
@@ -108,7 +110,8 @@ spec:
 $ oc apply -f tuning-allmulti.yaml
 ----
 +
-.Example output
+The following is example output:
++
 [source,terminal]
 ----
 networkattachmentdefinition.k8s.cni.cncf.io/setallmulti created
@@ -170,7 +173,8 @@ $ oc apply -f examplepod.yaml
 $ oc get pod
 ----
 +
-.Example output
+The following is example output:
++
 [source,terminal]
 ----
 NAME          READY   STATUS    RESTARTS   AGE
@@ -193,7 +197,8 @@ sh-4.4# ip link
 +
 The expected output depends on which mode you configured:
 +
-.Example output for all-multicast mode only
+The following is example output for all-multicast mode only:
++
 [source,terminal]
 ----
 1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN mode DEFAULT group default qlen 1000
@@ -204,7 +209,8 @@ The expected output depends on which mode you configured:
     link/ether ee:9b:66:a4:ec:1d brd ff:ff:ff:ff:ff:ff link-netnsid 0
 ----
 +
-.Example output for both modes
+The following is example output for both modes:
++
 [source,terminal]
 ----
 1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN mode DEFAULT group default qlen 1000
@@ -218,10 +224,8 @@ The expected output depends on which mode you configured:
 where:
 
 `eth0@if22`:: Specifies the primary interface.
-`net1@if24`:: Specifies the secondary interface configured with the network-attachment-definition. The `ALLMULTI` flag indicates all-multicast mode is enabled. The `PROMISC` flag indicates promiscuous mode is enabled. You will see only the flags for the modes you configured.
+`net1@if24`:: Specifies the secondary interface configured with the network attachment definition. The `ALLMULTI` flag indicates that all-multicast mode is enabled. The `PROMISC` flag indicates that promiscuous mode is enabled. You see only the flags for the modes you configured.
 
-For SR-IOV networks that require PF-level configuration for promiscuous mode, see the related resource below.
+.Next steps
 
-.Additional resources
-
-* xref:../../networking/hardware_networks/configuring-interface-sysctl-sriov-device.adoc#nw-sriov-pf-promisc-machineconfig_configuring-sysctl-interface-sriov-device[Enabling PF-level promiscuous support through MachineConfig]
+* For SR-IOV networks that require PF-level configuration for promiscuous mode, see "Enabling PF-level promiscuous support through `MachineConfig`".

--- a/modules/nw-enable-all-multicast-mode-sriov-network.adoc
+++ b/modules/nw-enable-all-multicast-mode-sriov-network.adoc
@@ -7,7 +7,7 @@
 = Enabling promiscuous and all-multicast modes on an SR-IOV network
 
 [role="_abstract"]
-You can enable promiscuous mode and all-multicast mode on SR-IOV Virtual Functions by configuring the tuning CNI metaPlugins in the SriovNetwork resource.
+You can enable promiscuous mode and all-multicast mode on SR-IOV Virtual Functions by configuring the tuning Container Network Interface (CNI) `metaPlugins` in the `SriovNetwork` resource.
 This approach avoids granting elevated capabilities to pods while ensuring the configuration persists across node reboots.
 
 You can enable these modes on an SR-IOV interface by:
@@ -17,8 +17,8 @@ You can enable these modes on an SR-IOV interface by:
 +
 [NOTE]
 ====
-Ensure that you create the virtual function (VF) with trust enabled by setting `trust: "on"` in the SriovNetwork resource.
-For promiscuous mode on Intel NICs with `i40e` or `ice` drivers, you must also complete the PF-level configuration described in "Enabling PF-level promiscuous support via MachineConfig".
+Ensure that you create the virtual function (VF) with trust enabled by setting `trust: "on"` in the `SriovNetwork` resource.
+For promiscuous mode on Intel NICs with `i40e` or `ice` drivers, you must also complete the PF-level configuration described in "Enabling PF-level promiscuous support via `MachineConfig`".
 PF-level configuration is not required for all-multicast mode.
 ====
 
@@ -38,7 +38,7 @@ Enable promiscuous mode, all-multicast mode, or both on an SR-IOV network by fol
 * You have installed the SR-IOV Network Operator.
 * You have created an `SriovNetworkNodePolicy` object that allocates the VFs for this network.
 * You understand that SR-IOV VFs must have `trust: "on"` set in the `SriovNetwork` resource to accept promiscuous or all-multicast mode settings.
-* For promiscuous mode only: If your cluster nodes use Intel NICs with `i40e` or `ice` drivers, you have completed the PF-level configuration by enabling `vf-true-promisc-support` via MachineConfig as described in "Enabling PF-level promiscuous support through MachineConfig". This prerequisite does not apply to all-multicast mode.
+* For promiscuous mode only: If your cluster nodes use Intel NICs with `i40e` or `ice` drivers, you have completed the PF-level configuration by enabling `vf-true-promisc-support` by using a `MachineConfig` resource as described in "Enabling PF-level promiscuous support through `MachineConfig`". This prerequisite does not apply to all-multicast mode.
 
 .Procedure
 
@@ -85,7 +85,7 @@ After applying the configuration update, all the pods in the `sriov-network-oper
 $ oc create namespace enable-allmulti-test
 ----
 
-. Create a `SriovNetwork` custom resource (CR) for the additional SR-IOV network attachment with tuning CNI metaPlugins configuration. Choose the configuration that matches your use case:
+. Create a `SriovNetwork` custom resource (CR) for the additional SR-IOV network attachment with tuning CNI `metaPlugins` configuration. Choose the configuration that matches your use case:
 +
 --
 
@@ -96,15 +96,15 @@ To enable only all-multicast mode:: All-multicast mode requires only `trust: "on
 apiVersion: sriovnetwork.openshift.io/v1
 kind: SriovNetwork
 metadata:
-  name: enableallmulti <1>
-  namespace: openshift-sriov-network-operator <2>
+  name: <name>
+  namespace: openshift-sriov-network-operator
 spec:
-  resourceName: resourcemlx <3>
-  networkNamespace: enable-allmulti-test <4>
-  ipam: '{ "type": "static" }' <5>
-  capabilities: '{ "mac": true, "ips": true }' <6>
-  trust: "on" <7>
-  metaPlugins : | <8>
+  resourceName: <resource_name>
+  networkNamespace: <namespace>
+  ipam: '{ "type": "static" }'
+  capabilities: '{ "mac": true, "ips": true }'
+  trust: "on"
+  metaPlugins : |
     {
       "type": "tuning",
       "capabilities":{
@@ -113,14 +113,17 @@ spec:
       "allmulti": true
     }
 ----
-<1> Specify a name for the object. The SR-IOV Network Operator creates a `NetworkAttachmentDefinition` object with the same name.
-<2> Specify the namespace where the SR-IOV Network Operator is installed.
-<3> Specify a value for the `spec.resourceName` parameter from the `SriovNetworkNodePolicy` object that defines the SR-IOV hardware for this additional network.
-<4> Specify the target namespace for the `SriovNetwork` object. Only pods in the target namespace can attach to the additional network.
-<5> Specify a configuration object for the IPAM CNI plugin as a YAML block scalar. The plugin manages IP address assignment for the attachment definition.
-<6> Optional: Set capabilities for the additional network. You can specify `"{ "ips": true }"` to enable IP address support or `"{ "mac": true }"` to enable MAC address support.
-<7> Specify the trust mode of the virtual function. This must be set to `"on"`.
-<8> Add more capabilities to the device by using the `metaPlugins` parameter. Set the `type` field to `tuning` and set `allmulti` to `true` to enable all-multicast mode.
++
+--
+* `<name>` specifies a name for the object. The SR-IOV Network Operator creates a `NetworkAttachmentDefinition` object with the same name.
+* `openshift-sriov-network-operator` specifies the namespace where the SR-IOV Network Operator is installed.
+* `<resource_name>` specifies a value for the `spec.resourceName` parameter from the `SriovNetworkNodePolicy` object that defines the SR-IOV hardware for this additional network.
+* `<namespace>` specifies the target namespace for the `SriovNetwork` object. Only pods in the target namespace can attach to the additional network.
+* `ipam` specifies a configuration object for the IPAM CNI plugin as a YAML block scalar. The plugin manages IP address assignment for the attachment definition.
+* `capabilities`: Optional. Set capabilities for the additional network. You can specify `"{ "ips": true }"` to enable IP address support or `"{ "mac": true }"` to enable MAC address support.
+* `trust` specifies the trust mode of the virtual function. You must set this to `"on"`.
+* `metaPlugins` adds more capabilities to the device. Set the `type` field to `tuning` and set `allmulti` to `true` to enable all-multicast mode.
+--
 
 To enable only promiscuous mode:: Promiscuous mode requires `trust: "on"`, the `promisc` tuning flag, and PF-level configuration for Intel `i40e`/`ice` NICs. Save the file as `sriov-enable-promisc.yaml`.
 +
@@ -177,15 +180,18 @@ spec:
 $ oc create -f <sriov_network_filename>.yaml
 ----
 
-.Verification of the `NetworkAttachmentDefinition` CR
+.Verification
 
-* Confirm that the SR-IOV Network Operator created the `NetworkAttachmentDefinition` CR by running the following command:
+. Confirm that the SR-IOV Network Operator created the `NetworkAttachmentDefinition` CR by running the following command:
 +
 [source,terminal]
 ----
-$ oc get network-attachment-definitions -n <namespace> <1>
+$ oc get network-attachment-definitions -n <namespace>
 ----
-<1> Replace `<namespace>` with the value for `networkNamespace` that you specified in the `SriovNetwork` object. For this example, that is `enable-allmulti-test`. The expected output shows the name of the NAD CR and the creation age in minutes.
++
+--
+* `<namespace>` is the value for `networkNamespace` that you specified in the `SriovNetwork` object. For this example, that is `enable-allmulti-test`. The expected output shows the name of the `NetworkAttachmentDefinition` CR and the creation age in minutes.
+--
 +
 [NOTE]
 ====
@@ -199,11 +205,7 @@ There might be a delay before the SR-IOV Network Operator creates the CR.
 $ oc get sriovnetwork -n openshift-sriov-network-operator
 ----
 
-.Verification of the additional SR-IOV network attachment
-
-To verify that the tuning CNI is correctly configured and that the additional SR-IOV network attachment is attached, follow these steps:
-
-. Create a `Pod` CR. Save the following sample YAML in a file named `examplepod.yaml`:
+. Verify that the tuning CNI is correctly configured and that the additional SR-IOV network attachment is attached. Create a `Pod` CR and save the following sample YAML in a file named `examplepod.yaml`:
 +
 [source,yaml]
 ----
@@ -216,9 +218,9 @@ metadata:
     k8s.v1.cni.cncf.io/networks: |-
       [
         {
-          "name": "enableallmulti",  <1>
-          "mac": "0a:56:0a:83:04:0c", <2>
-          "ips": ["10.100.100.200/24"] <3>
+          "name": "<network_attachment>",
+          "mac": "<mac_address>",
+          "ips": ["<ip_address>"]
        }
       ]
 spec:
@@ -237,9 +239,12 @@ spec:
     seccompProfile:
       type: RuntimeDefault
 ----
-<1> Specify the name of the SR-IOV network attachment definition CR.
-<2> Optional: Specify the MAC address for the SR-IOV device that is allocated from the resource type defined in the SR-IOV network attachment definition CR. To use this feature, you also must specify `{"mac": true}` in the SriovNetwork object.
-<3> Optional: Specify the IP addresses for the SR-IOV device that are allocated from the resource type defined in the SR-IOV network attachment definition CR. Both IPv4 and IPv6 addresses are supported. To use this feature, you also must specify `{ "ips": true }` in the `SriovNetwork` object.
++
+--
+* `<network_attachment>` specifies the name of the SR-IOV network attachment definition CR.
+* `<mac_address>`: Optional. Specifies the MAC address for the SR-IOV device that is allocated from the resource type defined in the SR-IOV network attachment definition CR. To use this feature, you must also specify `{ "mac": true }` in the `SriovNetwork` object.
+* `<ip_address>`: Optional. Specifies the IP addresses for the SR-IOV device. The IP addresses are allocated from the resource type defined in the SR-IOV network attachment definition CR. Both IPv4 and IPv6 addresses are supported. To use this feature, you must also specify `{ "ips": true }` in the `SriovNetwork` object.
+--
 
 . Create the `Pod` CR by running the following command:
 +
@@ -255,7 +260,7 @@ $ oc apply -f examplepod.yaml
 $ oc get pod -n enable-allmulti-test
 ----
 +
-.Example output
+The following is example output:
 +
 [source,terminal]
 ----
@@ -279,41 +284,53 @@ sh-4.4# ip link
 +
 The expected output depends on which mode you configured:
 +
-.Example output for all-multicast mode only
+The following is example output for all-multicast mode only:
++
 [source,terminal]
 ----
 1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN mode DEFAULT group default qlen 1000
     link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
 2: eth0@if22: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 8901 qdisc noqueue state UP mode DEFAULT group default
-    link/ether 0a:58:0a:83:00:10 brd ff:ff:ff:ff:ff:ff link-netnsid 0 <1>
+    link/ether 0a:58:0a:83:00:10 brd ff:ff:ff:ff:ff:ff link-netnsid 0
 3: net1@if24: <BROADCAST,MULTICAST,ALLMULTI,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP mode DEFAULT group default
-    link/ether ee:9b:66:a4:ec:1d brd ff:ff:ff:ff:ff:ff link-netnsid 0 <2>
+    link/ether ee:9b:66:a4:ec:1d brd ff:ff:ff:ff:ff:ff link-netnsid 0
 ----
-<1> `eth0@if22` is the primary interface.
-<2> `net1@if24` is the secondary SR-IOV interface configured with the `ALLMULTI` flag. The `PROMISC` flag is not present because only all-multicast mode was configured.
 +
-.Example output for promiscuous mode only
+--
+* `eth0@if22` is the primary interface.
+* `net1@if24` is the secondary SR-IOV interface configured with the `ALLMULTI` flag. The `PROMISC` flag is not present because only all-multicast mode is configured.
+--
++
+The following is example output for promiscuous mode only:
++
 [source,terminal]
 ----
 1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN mode DEFAULT group default qlen 1000
     link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
 2: eth0@if22: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 8901 qdisc noqueue state UP mode DEFAULT group default
-    link/ether 0a:58:0a:83:00:10 brd ff:ff:ff:ff:ff:ff link-netnsid 0 <1>
+    link/ether 0a:58:0a:83:00:10 brd ff:ff:ff:ff:ff:ff link-netnsid 0
 3: net1@if24: <BROADCAST,MULTICAST,PROMISC,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP mode DEFAULT group default
-    link/ether ee:9b:66:a4:ec:1d brd ff:ff:ff:ff:ff:ff link-netnsid 0 <2>
+    link/ether ee:9b:66:a4:ec:1d brd ff:ff:ff:ff:ff:ff link-netnsid 0
 ----
-<1> `eth0@if22` is the primary interface.
-<2> `net1@if24` is the secondary SR-IOV interface configured with the `PROMISC` flag. The `ALLMULTI` flag is not present because only promiscuous mode was configured.
 +
-.Example output for both modes
+--
+* `eth0@if22` is the primary interface.
+* `net1@if24` is the secondary SR-IOV interface configured with the `PROMISC` flag. The `ALLMULTI` flag is not present because only promiscuous mode is configured.
+--
++
+The following is example output for both modes:
++
 [source,terminal]
 ----
 1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN mode DEFAULT group default qlen 1000
     link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
 2: eth0@if22: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 8901 qdisc noqueue state UP mode DEFAULT group default
-    link/ether 0a:58:0a:83:00:10 brd ff:ff:ff:ff:ff:ff link-netnsid 0 <1>
+    link/ether 0a:58:0a:83:00:10 brd ff:ff:ff:ff:ff:ff link-netnsid 0
 3: net1@if24: <BROADCAST,MULTICAST,ALLMULTI,PROMISC,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP mode DEFAULT group default
-    link/ether ee:9b:66:a4:ec:1d brd ff:ff:ff:ff:ff:ff link-netnsid 0 <2>
+    link/ether ee:9b:66:a4:ec:1d brd ff:ff:ff:ff:ff:ff link-netnsid 0
 ----
-<1> `eth0@if22` is the primary interface.
-<2> `net1@if24` is the secondary SR-IOV interface configured with both `ALLMULTI` and `PROMISC` flags.
++
+--
+* `eth0@if22` is the primary interface.
+* `net1@if24` is the secondary SR-IOV interface configured with both `ALLMULTI` and `PROMISC` flags.
+--

--- a/modules/nw-enable-all-multicast-mode-sriov-network.adoc
+++ b/modules/nw-enable-all-multicast-mode-sriov-network.adoc
@@ -18,7 +18,8 @@ You can enable these modes on an SR-IOV interface by:
 [NOTE]
 ====
 Ensure that you create the virtual function (VF) with trust enabled by setting `trust: "on"` in the SriovNetwork resource.
-For promiscuous mode, you must also complete the PF-level configuration described in "Enabling PF-level promiscuous support via MachineConfig".
+For promiscuous mode on Intel NICs with `i40e` or `ice` drivers, you must also complete the PF-level configuration described in "Enabling PF-level promiscuous support via MachineConfig".
+PF-level configuration is not required for all-multicast mode.
 ====
 
 The SR-IOV Network Operator manages additional network definitions. When you specify an additional SR-IOV network to create, the SR-IOV Network Operator creates the `NetworkAttachmentDefinition` custom resource (CR) automatically.
@@ -28,7 +29,7 @@ The SR-IOV Network Operator manages additional network definitions. When you spe
 Do not edit `NetworkAttachmentDefinition` custom resources that the SR-IOV Network Operator manages. Doing so might disrupt network traffic on your additional network.
 ====
 
-Enable the all-multicast mode on a SR-IOV network by following this guidance.
+Enable promiscuous mode, all-multicast mode, or both on an SR-IOV network by following this guidance.
 
 .Prerequisites
 
@@ -37,7 +38,7 @@ Enable the all-multicast mode on a SR-IOV network by following this guidance.
 * You have installed the SR-IOV Network Operator.
 * You have created an `SriovNetworkNodePolicy` object that allocates the VFs for this network.
 * You understand that SR-IOV VFs must have `trust: "on"` set in the `SriovNetwork` resource to accept promiscuous or all-multicast mode settings.
-* For promiscuous mode on Intel NICs, you have completed the PF-level configuration by enabling `vf-true-promisc-support` via MachineConfig as described in "Enabling PF-level promiscuous support through MachineConfig".
+* For promiscuous mode only: If your cluster nodes use Intel NICs with `i40e` or `ice` drivers, you have completed the PF-level configuration by enabling `vf-true-promisc-support` via MachineConfig as described in "Enabling PF-level promiscuous support through MachineConfig". This prerequisite does not apply to all-multicast mode.
 
 .Procedure
 
@@ -77,14 +78,18 @@ $ oc create -f sriovnetpolicy-mlx.yaml
 +
 After applying the configuration update, all the pods in the `sriov-network-operator` namespace automatically move to a `Running` status.
 
-. Create the `enable-allmulti-test` namespace by running the following command:
+. Create the test namespace by running the following command:
 +
 [source,terminal]
 ----
 $ oc create namespace enable-allmulti-test
 ----
 
-. Create the `SriovNetwork` custom resource (CR) for the additional SR-IOV network attachment and insert the `metaPlugins` configuration with promiscuous and all-multicast mode settings. Save the file as `sriov-enable-all-multicast.yaml`.
+. Create a `SriovNetwork` custom resource (CR) for the additional SR-IOV network attachment with tuning CNI metaPlugins configuration. Choose the configuration that matches your use case:
++
+--
+
+To enable only all-multicast mode:: All-multicast mode requires only `trust: "on"` and the `allmulti` tuning flag. No PF-level configuration is needed. Save the file as `sriov-enable-all-multicast.yaml`.
 +
 [source,yaml]
 ----
@@ -94,7 +99,7 @@ metadata:
   name: enableallmulti <1>
   namespace: openshift-sriov-network-operator <2>
 spec:
-  resourceName: enableallmulti <3>
+  resourceName: resourcemlx <3>
   networkNamespace: enable-allmulti-test <4>
   ipam: '{ "type": "static" }' <5>
   capabilities: '{ "mac": true, "ips": true }' <6>
@@ -105,7 +110,6 @@ spec:
       "capabilities":{
         "mac":true
       },
-      "promisc": true,
       "allmulti": true
     }
 ----
@@ -115,10 +119,10 @@ spec:
 <4> Specify the target namespace for the `SriovNetwork` object. Only pods in the target namespace can attach to the additional network.
 <5> Specify a configuration object for the IPAM CNI plugin as a YAML block scalar. The plugin manages IP address assignment for the attachment definition.
 <6> Optional: Set capabilities for the additional network. You can specify `"{ "ips": true }"` to enable IP address support or `"{ "mac": true }"` to enable MAC address support.
-<7> Specify the trust mode of the virtual function. This must be set to "on".
-<8> Add more capabilities to the device by using the `metaPlugins` parameter. Set the `type` field to `tuning` and configure the interface attributes. Set `promisc` to `true` to enable promiscuous mode, `allmulti` to `true` to enable all-multicast mode, or both to enable both modes.
+<7> Specify the trust mode of the virtual function. This must be set to `"on"`.
+<8> Add more capabilities to the device by using the `metaPlugins` parameter. Set the `type` field to `tuning` and set `allmulti` to `true` to enable all-multicast mode.
 
-. To enable only promiscuous mode without all-multicast mode, you can use a simplified configuration:
+To enable only promiscuous mode:: Promiscuous mode requires `trust: "on"`, the `promisc` tuning flag, and PF-level configuration for Intel `i40e`/`ice` NICs. Save the file as `sriov-enable-promisc.yaml`.
 +
 [source,yaml]
 ----
@@ -129,7 +133,7 @@ metadata:
   namespace: openshift-sriov-network-operator
 spec:
   resourceName: resourcemlx
-  networkNamespace: enable-promisc-test
+  networkNamespace: enable-allmulti-test
   ipam: '{ "type": "static" }'
   trust: "on"
   metaPlugins : |
@@ -139,11 +143,38 @@ spec:
     }
 ----
 
+To enable both promiscuous and all-multicast modes:: You can combine both modes in a single configuration. The PF-level prerequisite applies because promiscuous mode is included. Save the file as `sriov-enable-promisc-allmulti.yaml`.
++
+[source,yaml]
+----
+apiVersion: sriovnetwork.openshift.io/v1
+kind: SriovNetwork
+metadata:
+  name: enablepromiscallmulti
+  namespace: openshift-sriov-network-operator
+spec:
+  resourceName: resourcemlx
+  networkNamespace: enable-allmulti-test
+  ipam: '{ "type": "static" }'
+  capabilities: '{ "mac": true, "ips": true }'
+  trust: "on"
+  metaPlugins : |
+    {
+      "type": "tuning",
+      "capabilities":{
+        "mac":true
+      },
+      "promisc": true,
+      "allmulti": true
+    }
+----
+--
+
 . Create the `SriovNetwork` resource by running the following command:
 +
 [source,terminal]
 ----
-$ oc create -f sriov-enable-all-multicast.yaml
+$ oc create -f <sriov_network_filename>.yaml
 ----
 
 .Verification of the `NetworkAttachmentDefinition` CR
@@ -246,7 +277,35 @@ $ oc rsh -n enable-allmulti-test samplepod
 sh-4.4# ip link
 ----
 +
-.Example output
+The expected output depends on which mode you configured:
++
+.Example output for all-multicast mode only
+[source,terminal]
+----
+1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN mode DEFAULT group default qlen 1000
+    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
+2: eth0@if22: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 8901 qdisc noqueue state UP mode DEFAULT group default
+    link/ether 0a:58:0a:83:00:10 brd ff:ff:ff:ff:ff:ff link-netnsid 0 <1>
+3: net1@if24: <BROADCAST,MULTICAST,ALLMULTI,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP mode DEFAULT group default
+    link/ether ee:9b:66:a4:ec:1d brd ff:ff:ff:ff:ff:ff link-netnsid 0 <2>
+----
+<1> `eth0@if22` is the primary interface.
+<2> `net1@if24` is the secondary SR-IOV interface configured with the `ALLMULTI` flag. The `PROMISC` flag is not present because only all-multicast mode was configured.
++
+.Example output for promiscuous mode only
+[source,terminal]
+----
+1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN mode DEFAULT group default qlen 1000
+    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
+2: eth0@if22: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 8901 qdisc noqueue state UP mode DEFAULT group default
+    link/ether 0a:58:0a:83:00:10 brd ff:ff:ff:ff:ff:ff link-netnsid 0 <1>
+3: net1@if24: <BROADCAST,MULTICAST,PROMISC,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP mode DEFAULT group default
+    link/ether ee:9b:66:a4:ec:1d brd ff:ff:ff:ff:ff:ff link-netnsid 0 <2>
+----
+<1> `eth0@if22` is the primary interface.
+<2> `net1@if24` is the secondary SR-IOV interface configured with the `PROMISC` flag. The `ALLMULTI` flag is not present because only promiscuous mode was configured.
++
+.Example output for both modes
 [source,terminal]
 ----
 1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN mode DEFAULT group default qlen 1000
@@ -256,6 +315,5 @@ sh-4.4# ip link
 3: net1@if24: <BROADCAST,MULTICAST,ALLMULTI,PROMISC,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP mode DEFAULT group default
     link/ether ee:9b:66:a4:ec:1d brd ff:ff:ff:ff:ff:ff link-netnsid 0 <2>
 ----
-+
 <1> `eth0@if22` is the primary interface.
-<2> `net1@if24` is the secondary SR-IOV interface configured with both `ALLMULTI` and `PROMISC` flags. If you enabled only promiscuous mode, you would see only the `PROMISC` flag. If you enabled only all-multicast mode, you would see only the `ALLMULTI` flag.
+<2> `net1@if24` is the secondary SR-IOV interface configured with both `ALLMULTI` and `PROMISC` flags.

--- a/modules/nw-enable-all-multicast-mode-sriov-network.adoc
+++ b/modules/nw-enable-all-multicast-mode-sriov-network.adoc
@@ -4,16 +4,21 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="enabling-all-multicast-sriov-network_{context}"]
-= Enabling the all-multicast mode on an SR-IOV network
+= Enabling promiscuous and all-multicast modes on an SR-IOV network
 
-You can enable the all-multicast mode on an SR-IOV interface by:
+[role="_abstract"]
+You can enable promiscuous mode and all-multicast mode on SR-IOV Virtual Functions by configuring the tuning CNI metaPlugins in the SriovNetwork resource.
+This approach avoids granting elevated capabilities to pods while ensuring the configuration persists across node reboots.
+
+You can enable these modes on an SR-IOV interface by:
 
 * Adding the tuning configuration to the `metaPlugins` parameter of the `SriovNetwork` resource
-* Setting the `allmulti` field to `true` in the tuning configuration
+* Setting the `promisc` field, `allmulti` field, or both to `true` in the tuning configuration
 +
 [NOTE]
 ====
-Ensure that you create the virtual function (VF) with trust enabled.
+Ensure that you create the virtual function (VF) with trust enabled by setting `trust: "on"` in the SriovNetwork resource.
+For promiscuous mode, you must also complete the PF-level configuration described in "Enabling PF-level promiscuous support via MachineConfig".
 ====
 
 The SR-IOV Network Operator manages additional network definitions. When you specify an additional SR-IOV network to create, the SR-IOV Network Operator creates the `NetworkAttachmentDefinition` custom resource (CR) automatically.
@@ -30,7 +35,9 @@ Enable the all-multicast mode on a SR-IOV network by following this guidance.
 * You have installed the {product-title} CLI (oc).
 * You are logged in to the {product-title} cluster as a user with `cluster-admin` privileges.
 * You have installed the SR-IOV Network Operator.
-* You have configured an appropriate `SriovNetworkNodePolicy` object.
+* You have created an `SriovNetworkNodePolicy` object that allocates the VFs for this network.
+* You understand that SR-IOV VFs must have `trust: "on"` set in the `SriovNetwork` resource to accept promiscuous or all-multicast mode settings.
+* For promiscuous mode on Intel NICs, you have completed the PF-level configuration by enabling `vf-true-promisc-support` via MachineConfig as described in "Enabling PF-level promiscuous support through MachineConfig".
 
 .Procedure
 
@@ -77,7 +84,7 @@ After applying the configuration update, all the pods in the `sriov-network-oper
 $ oc create namespace enable-allmulti-test
 ----
 
-. Create the `SriovNetwork` custom resource (CR) for the additional SR-IOV network attachment and insert the `metaPlugins` configuration, as in the following example CR YAML, and save the file as `sriov-enable-all-multicast.yaml`.
+. Create the `SriovNetwork` custom resource (CR) for the additional SR-IOV network attachment and insert the `metaPlugins` configuration with promiscuous and all-multicast mode settings. Save the file as `sriov-enable-all-multicast.yaml`.
 +
 [source,yaml]
 ----
@@ -98,8 +105,8 @@ spec:
       "capabilities":{
         "mac":true
       },
+      "promisc": true,
       "allmulti": true
-      }
     }
 ----
 <1> Specify a name for the object. The SR-IOV Network Operator creates a `NetworkAttachmentDefinition` object with the same name.
@@ -109,7 +116,28 @@ spec:
 <5> Specify a configuration object for the IPAM CNI plugin as a YAML block scalar. The plugin manages IP address assignment for the attachment definition.
 <6> Optional: Set capabilities for the additional network. You can specify `"{ "ips": true }"` to enable IP address support or `"{ "mac": true }"` to enable MAC address support.
 <7> Specify the trust mode of the virtual function. This must be set to "on".
-<8> Add more capabilities to the device by using the `metaPlugins` parameter. In this use case, set the `type` field to `tuning`, and add the `allmulti` field and set it to `true`.
+<8> Add more capabilities to the device by using the `metaPlugins` parameter. Set the `type` field to `tuning` and configure the interface attributes. Set `promisc` to `true` to enable promiscuous mode, `allmulti` to `true` to enable all-multicast mode, or both to enable both modes.
+
+. To enable only promiscuous mode without all-multicast mode, you can use a simplified configuration:
++
+[source,yaml]
+----
+apiVersion: sriovnetwork.openshift.io/v1
+kind: SriovNetwork
+metadata:
+  name: enablepromisc
+  namespace: openshift-sriov-network-operator
+spec:
+  resourceName: resourcemlx
+  networkNamespace: enable-promisc-test
+  ipam: '{ "type": "static" }'
+  trust: "on"
+  metaPlugins : |
+    {
+      "type": "tuning",
+      "promisc": true
+    }
+----
 
 . Create the `SriovNetwork` resource by running the following command:
 +
@@ -225,9 +253,9 @@ sh-4.4# ip link
     link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
 2: eth0@if22: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 8901 qdisc noqueue state UP mode DEFAULT group default
     link/ether 0a:58:0a:83:00:10 brd ff:ff:ff:ff:ff:ff link-netnsid 0 <1>
-3: net1@if24: <BROADCAST,MULTICAST,ALLMULTI,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP mode DEFAULT group default
+3: net1@if24: <BROADCAST,MULTICAST,ALLMULTI,PROMISC,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP mode DEFAULT group default
     link/ether ee:9b:66:a4:ec:1d brd ff:ff:ff:ff:ff:ff link-netnsid 0 <2>
 ----
 +
-<1> `eth0@if22` is the primary interface
-<2> `net1@if24` is the secondary interface configured with the network-attachment-definition that supports the all-multicast mode (`ALLMULTI` flag)
+<1> `eth0@if22` is the primary interface.
+<2> `net1@if24` is the secondary SR-IOV interface configured with both `ALLMULTI` and `PROMISC` flags. If you enabled only promiscuous mode, you would see only the `PROMISC` flag. If you enabled only all-multicast mode, you would see only the `ALLMULTI` flag.

--- a/modules/nw-sriov-about-all-multi-cast-mode.adoc
+++ b/modules/nw-sriov-about-all-multi-cast-mode.adoc
@@ -19,7 +19,7 @@ Without promiscuous mode, these applications would require the `NET_ADMIN` Linux
 
 All-multicast mode allows a network interface to receive all multicast packets on the network.
 This mode is essential when you need SR-IOV-attached applications to receive multicast traffic from other applications on the same or different Virtual Functions.
-Without all-multicast mode, you would be required to grant the `NET_ADMIN` capability to the pod's Security Context Constraints (SCC), which could expose security vulnerabilities.
+Without all-multicast mode, you must grant the `NET_ADMIN` capability to the pod's Security Context Constraints (SCC), which could expose security vulnerabilities.
 
 == How the tuning CNI approach works
 
@@ -47,7 +47,7 @@ This layered approach ensures that promiscuous and all-multicast modes persist a
 
 == NIC vendor considerations
 
-The `vf-true-promisc-support` private flag is required only for promiscuous mode on Intel NICs that use the `i40e` or `ice` drivers (for example, Intel XL710 or E810 series).
-This flag is not required for all-multicast mode on any NIC vendor.
+The `vf-true-promisc-support` private flag applies only to promiscuous mode on Intel NICs that use the `i40e` or `ice` drivers (for example, Intel XL710 or E810 series).
+All-multicast mode does not require this flag on any NIC vendor.
 Other NIC vendors such as Mellanox/NVIDIA ConnectX might not require PF-level configuration for promiscuous mode or might use different mechanisms.
 Always consult your NIC vendor's driver documentation before you configure PF-level settings.

--- a/modules/nw-sriov-about-all-multi-cast-mode.adoc
+++ b/modules/nw-sriov-about-all-multi-cast-mode.adoc
@@ -4,8 +4,38 @@
 
 :_mod-docs-content-type: CONCEPT
 [id="nw-about-all-multi-cast-mode_{context}"]
-= About all-multicast mode
+= About promiscuous and all-multicast modes for SR-IOV networks
 
-Enabling all-multicast mode, particularly in the context of rootless applications, is critical. If you do not enable this mode, you would be required to grant the `NET_ADMIN` capability to the pod's Security Context Constraints (SCC). If you were to allow the `NET_ADMIN` capability to grant the pod privileges to make changes that extend beyond its specific requirements, you could potentially expose security vulnerabilities.
+[role="_abstract"]
+You can use the tuning Container Network Interface (CNI) meta plugin to configure promiscuous mode and all-multicast mode on Virtual Functions (VFs) for SR-IOV networks. These interface attributes enable specialized network applications to receive specific types of traffic while avoiding the security risks of granting elevated capabilities to pods.
 
-The tuning CNI plugin supports changing several interface attributes, including all-multicast mode. By enabling this mode, you can allow applications running on Virtual Functions (VFs) that are configured on a SR-IOV network device to receive multicast traffic from applications on other VFs, whether attached to the same or different physical functions.
+== Understanding promiscuous mode
+
+Promiscuous mode allows a network interface to receive all packets on the network, not just those destined for the interface's MAC address.
+Promiscuous mode is useful for network monitoring, packet analysis, virtual switching, certain Cloud Native Functions (CNFs), and other applications that need to inspect all network traffic.
+Without promiscuous mode, these applications would require the `NET_ADMIN` Linux capability on the pod, which poses security risks.
+
+== Understanding all-multicast mode
+
+All-multicast mode allows a network interface to receive all multicast packets on the network.
+This mode is essential when you need SR-IOV-attached applications to receive multicast traffic from other applications on the same or different Virtual Functions.
+Without all-multicast mode, you would be required to grant the `NET_ADMIN` capability to the pod's Security Context Constraints (SCC), which could expose security vulnerabilities.
+
+== How the tuning CNI approach works
+
+The tuning CNI plugin avoids the security risks of `NET_ADMIN` by enabling promiscuous and all-multicast modes declaratively at the network interface level.
+You configure the interface attributes across three layers:
+
+PF-level preparation:: The underlying physical function (PF) must support promiscuous mode, which you enable on nodes through `MachineConfig` for certain NIC vendors. Intel NICs, for example, require you to enable the `vf-true-promisc-support` private flag.
+
+VF trust mode:: The `SriovNetwork` resource must set `trust: "on"` so the VF accepts promiscuous or all-multicast mode settings.
+
+VF-level interface attributes:: The tuning CNI `metaPlugins` configuration applies the actual `promisc` and `allmulti` interface flags by using the tuning plugin.
+
+This layered approach ensures that promiscuous and all-multicast modes persist across node reboots and cluster upgrades, replacing fragile manual host-level scripting with declarative Kubernetes resources.
+
+== NIC vendor considerations
+
+The `vf-true-promisc-support` private flag requirement is specific to Intel NICs.
+Other NIC vendors such as Mellanox/NVIDIA ConnectX might not require this step or might use different mechanisms.
+Always consult your NIC vendor's driver documentation before you configure PF-level settings.

--- a/modules/nw-sriov-about-all-multi-cast-mode.adoc
+++ b/modules/nw-sriov-about-all-multi-cast-mode.adoc
@@ -24,18 +24,30 @@ Without all-multicast mode, you would be required to grant the `NET_ADMIN` capab
 == How the tuning CNI approach works
 
 The tuning CNI plugin avoids the security risks of `NET_ADMIN` by enabling promiscuous and all-multicast modes declaratively at the network interface level.
-You configure the interface attributes across three layers:
+The configuration requirements depend on which mode you are enabling:
 
-PF-level preparation:: The underlying physical function (PF) must support promiscuous mode, which you enable on nodes through `MachineConfig` for certain NIC vendors. Intel NICs, for example, require you to enable the `vf-true-promisc-support` private flag.
+All-multicast mode:: All-multicast mode requires only two layers of configuration:
++
+--
+* *VF trust mode*: The `SriovNetwork` resource must set `trust: "on"` so the VF accepts the all-multicast mode setting.
+* *VF-level interface attributes*: The tuning CNI `metaPlugins` configuration sets the `allmulti` flag to `true`.
+--
++
+All-multicast mode does not require any PF-level preparation.
 
-VF trust mode:: The `SriovNetwork` resource must set `trust: "on"` so the VF accepts promiscuous or all-multicast mode settings.
-
-VF-level interface attributes:: The tuning CNI `metaPlugins` configuration applies the actual `promisc` and `allmulti` interface flags by using the tuning plugin.
+Promiscuous mode:: Promiscuous mode requires three layers of configuration:
++
+--
+* *PF-level preparation*: For certain NIC vendors, the underlying physical function (PF) must support promiscuous mode, which you enable on nodes through `MachineConfig`. Intel NICs with `i40e` or `ice` drivers, for example, require you to enable the `vf-true-promisc-support` private flag.
+* *VF trust mode*: The `SriovNetwork` resource must set `trust: "on"` so the VF accepts the promiscuous mode setting.
+* *VF-level interface attributes*: The tuning CNI `metaPlugins` configuration sets the `promisc` flag to `true`.
+--
 
 This layered approach ensures that promiscuous and all-multicast modes persist across node reboots and cluster upgrades, replacing fragile manual host-level scripting with declarative Kubernetes resources.
 
 == NIC vendor considerations
 
-The `vf-true-promisc-support` private flag requirement is specific to Intel NICs.
-Other NIC vendors such as Mellanox/NVIDIA ConnectX might not require this step or might use different mechanisms.
+The `vf-true-promisc-support` private flag is required only for promiscuous mode on Intel NICs that use the `i40e` or `ice` drivers (for example, Intel XL710 or E810 series).
+This flag is not required for all-multicast mode on any NIC vendor.
+Other NIC vendors such as Mellanox/NVIDIA ConnectX might not require PF-level configuration for promiscuous mode or might use different mechanisms.
 Always consult your NIC vendor's driver documentation before you configure PF-level settings.

--- a/modules/nw-sriov-pf-promisc-machineconfig.adoc
+++ b/modules/nw-sriov-pf-promisc-machineconfig.adoc
@@ -1,0 +1,119 @@
+// Module included in the following assemblies:
+//
+// * networking/hardware_networks/configuring-interface-sysctl-sriov-device.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="nw-sriov-pf-promisc-machineconfig_{context}"]
+= Enabling PF-level promiscuous support through MachineConfig
+
+[role="_abstract"]
+To use promiscuous mode on SR-IOV Virtual Functions, you must first enable promiscuous mode support at the physical function (PF) level on the host.
+For Intel NICs, this requires enabling the `vf-true-promisc-support` private flag and setting the PF interface to promiscuous mode by using a `MachineConfig` resource.
+
+.Prerequisites
+
+* You have installed the OpenShift CLI (`oc`).
+* You are logged in to the cluster with `cluster-admin` privileges.
+* You have identified the SR-IOV capable nodes and the physical function (PF) device name (for example, `ens5f0`).
+* Your cluster nodes use Intel NICs that require the `vf-true-promisc-support` flag.
+
+.Procedure
+
+. Create a `MachineConfig` YAML file that enables promiscuous support at the PF level. Save the file as `pf-promisc-machineconfig.yaml`:
++
+[source,yaml]
+----
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  labels:
+    machineconfiguration.openshift.io/role: worker
+  name: enable-pf-promisc
+spec:
+  config:
+    ignition:
+      version: 3.2.0
+    systemd:
+      units:
+      - name: enable-pf-promisc.service
+        enabled: true
+        contents: |
+          [Unit]
+          Description=Enable PF promiscuous support for SR-IOV VFs
+          After=network-online.target
+          Wants=network-online.target
+
+          [Service]
+          Type=oneshot
+          ExecStart=/bin/sh -c '/usr/sbin/ethtool --set-priv-flags ens5f0 vf-true-promisc-support on && /usr/sbin/ip link set ens5f0 promisc on'
+          RemainAfterExit=yes
+
+          [Install]
+          WantedBy=multi-user.target
+----
++
+In this example, replace `ens5f0` with the name of your physical function device.
+
+. Apply the `MachineConfig` by running the following command:
++
+[source,terminal]
+----
+$ oc apply -f pf-promisc-machineconfig.yaml
+----
++
+.Example output
+[source,terminal]
+----
+machineconfig.machineconfiguration.openshift.io/enable-pf-promisc created
+----
+
+. Wait for the `MachineConfigPool` to apply the configuration by running the following command:
++
+[source,terminal]
+----
+$ oc wait --for=condition=Updated mcp/worker --timeout=10m
+----
++
+Applying the MachineConfig triggers a node reboot. This process can take several minutes.
+
+. After the nodes reboot and update, verify that the PF-level configuration was applied successfully by running the following command on a node:
++
+[source,terminal]
+----
+$ oc debug node/<node-name> -- chroot /host /bin/bash -c "/usr/sbin/ethtool --show-priv-flags ens5f0 && /usr/sbin/ip link show ens5f0"
+----
+
+.Verification
+
+The command output shows that the `vf-true-promisc-support` flag is enabled and the PF interface has the PROMISC flag set:
+
+[source,terminal]
+----
+Private flags for ens5f0:
+vf-true-promisc-support : on
+
+2: ens5f0: <BROADCAST,MULTICAST,PROMISC,UP,LOWER_UP> mtu 1500 qdisc mq state UP mode DEFAULT group default qlen 1000
+----
+
+The output confirms:
+
+* `vf-true-promisc-support : on` — The `vf-true-promisc-support` flag is enabled on the physical function.
+* `<BROADCAST,MULTICAST,PROMISC,UP,LOWER_UP>` — The PROMISC flag is set on the PF interface.
+
+[WARNING]
+====
+Applying the `MachineConfig` requires a node reboot.
+Plan this change during a maintenance window to avoid disrupting workloads running on the affected nodes.
+====
+
+[NOTE]
+====
+The `vf-true-promisc-support` flag and the process for enabling promiscuous mode vary by NIC vendor.
+Intel NICs use the approach shown in this procedure.
+Other NIC vendors, such as Mellanox/NVIDIA ConnectX, might not require this step or might use different mechanisms.
+Always consult your NIC driver documentation before you configure promiscuous mode.
+====
+
+.Next steps
+
+After enabling PF-level promiscuous support, you can configure promiscuous mode on individual SR-IOV Virtual Functions by using the tuning CNI `metaPlugins` parameter in a `SriovNetwork` resource.

--- a/modules/nw-sriov-pf-promisc-machineconfig.adoc
+++ b/modules/nw-sriov-pf-promisc-machineconfig.adoc
@@ -61,7 +61,8 @@ In this example, replace `ens5f0` with the name of your physical function device
 $ oc apply -f pf-promisc-machineconfig.yaml
 ----
 +
-.Example output
+The following is example output:
++
 [source,terminal]
 ----
 machineconfig.machineconfiguration.openshift.io/enable-pf-promisc created
@@ -74,13 +75,13 @@ machineconfig.machineconfiguration.openshift.io/enable-pf-promisc created
 $ oc wait --for=condition=Updated mcp/worker --timeout=10m
 ----
 +
-Applying the MachineConfig triggers a node reboot. This process can take several minutes.
+Applying the `MachineConfig` triggers a node reboot. This process can take several minutes.
 
-. After the nodes reboot and update, verify that the PF-level configuration was applied successfully by running the following command on a node:
+. After the nodes reboot and update, verify that the PF-level configuration applied successfully by running the following command on a node:
 +
 [source,terminal]
 ----
-$ oc debug node/<node-name> -- chroot /host /bin/bash -c "/usr/sbin/ethtool --show-priv-flags ens5f0 && /usr/sbin/ip link show ens5f0"
+$ oc debug node/<node_name> -- chroot /host /bin/bash -c "/usr/sbin/ethtool --show-priv-flags ens5f0 && /usr/sbin/ip link show ens5f0"
 ----
 
 .Verification
@@ -97,8 +98,8 @@ vf-true-promisc-support : on
 
 The output confirms:
 
-* `vf-true-promisc-support : on` — The `vf-true-promisc-support` flag is enabled on the physical function.
-* `<BROADCAST,MULTICAST,PROMISC,UP,LOWER_UP>` — The PROMISC flag is set on the PF interface.
+* `vf-true-promisc-support : on`: The `vf-true-promisc-support` flag is enabled on the physical function.
+* `<BROADCAST,MULTICAST,PROMISC,UP,LOWER_UP>`: The `PROMISC` flag is set on the PF interface.
 
 [WARNING]
 ====

--- a/networking/configuring_network_settings/configure-syscontrols-interface-tuning-cni.adoc
+++ b/networking/configuring_network_settings/configure-syscontrols-interface-tuning-cni.adoc
@@ -21,4 +21,4 @@ include::modules/nw-cfg-config-all-multi-cni.adoc[leveloffset=+1]
 
 * xref:../../nodes/containers/nodes-containers-sysctls.adoc#nodes-containers-sysctls[Using sysctls in containers]
 * xref:../../networking/hardware_networks/configuring-sriov-device.adoc#nw-sriov-networknodepolicy-object_configuring-sriov-device[SR-IOV network node configuration object]
-* xref:../../networking/hardware_networks/configuring-interface-sysctl-sriov-device.adoc#configuring-interface-level-sysctl-settings-sriov-device[Configuring interface-level network sysctl settings and all-multicast mode for SR-IOV networks]
+* xref:../../networking/hardware_networks/configuring-interface-sysctl-sriov-device.adoc#configuring-interface-level-sysctl-settings-sriov-device[Configuring interface-level network sysctl settings, promiscuous mode, and all-multicast mode for SR-IOV networks]

--- a/networking/hardware_networks/configuring-interface-sysctl-sriov-device.adoc
+++ b/networking/hardware_networks/configuring-interface-sysctl-sriov-device.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="configuring-interface-level-sysctl-settings-sriov-device"]
-= Configuring interface-level network sysctl settings and all-multicast mode for SR-IOV networks
+= Configuring interface-level network sysctl settings, promiscuous mode, and all-multicast mode for SR-IOV networks
 include::_attributes/common-attributes.adoc[]
 :context: configuring-sysctl-interface-sriov-device
 
@@ -26,4 +26,6 @@ include::modules/nw-configure-sysctl-interface-sriov-network-bonded.adoc[levelof
 
 include::modules/nw-sriov-about-all-multi-cast-mode.adoc[leveloffset=+1]
 
-include::modules/nw-enable-all-multicast-mode-sriov-network.adoc[leveloffset=+2]
+include::modules/nw-sriov-pf-promisc-machineconfig.adoc[leveloffset=+1]
+
+include::modules/nw-enable-all-multicast-mode-sriov-network.adoc[leveloffset=+1]


### PR DESCRIPTION
[TELCODOCS-2886]: [<short-description-of-the-pr> --->](https://redhat.atlassian.net/browse/TELCODOCS-2886)

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.18+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:https://redhat.atlassian.net/browse/TELCODOCS-2886
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:

https://110801--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/hardware_networks/configuring-interface-sysctl-sriov-device.html#nw-about-all-multi-cast-mode_configuring-sysctl-interface-sriov-device

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
