### PR TITLE
OSDOCS Nodes fix secret store vault

### DIFF
--- a/modules/secrets-store-azure.adoc
+++ b/modules/secrets-store-azure.adoc
@@ -6,7 +6,7 @@
 [id="secrets-store-azure_{context}"]
 = Mounting secrets from {azure-short} Key Vault
 
-You can use the {secrets-store-operator} to mount secrets from {azure-first} Key Vault to a Container Storage Interface (CSI) volume in {product-title}. To mount secrets from {azure-short} Key Vault.
+You can use the {secrets-store-operator} to mount secrets from {azure-first} Key Vault to a Container Storage Interface (CSI) volume in {product-title}. To mount secrets from Azure Key Vault, your cluster must be installed on Microsoft Azure.
 
 .Prerequisites
 

--- a/modules/secrets-store-vault.adoc
+++ b/modules/secrets-store-vault.adoc
@@ -369,7 +369,7 @@ $ oc create -f deployment.yaml
 
 .Verification
 
-.. Verify that all of the `vault` pods are running properly by running the following command:
+* Verify that all of the `vault` pods are running properly by running the following command:
 +
 [source,terminal]
 ----
@@ -386,7 +386,7 @@ vault-csi-provider-bd6hp   2/2     Running   0          19m
 vault-csi-provider-smlv7   2/2     Running   0          19m
 ----
 
-.. Verify that all of the `secrets-store-csi-driver` pods are running by running the following command:
+* Verify that all of the `secrets-store-csi-driver` pods are running by running the following command:
 +
 [source,terminal]
 ----
@@ -405,7 +405,7 @@ secrets-store-csi-driver-node-vlz28                  3/3     Running   0        
 secrets-store-csi-driver-operator-84bd699478-fpxrw   1/1     Running   0             47m
 ----
 
-. Verify that you can access the secrets from your HashiCorp Vault in the pod volume mount:
+* Verify that you can access the secrets from your HashiCorp Vault in the pod volume mount:
 
 .. List the secrets in the pod mount by running the following command:
 +

--- a/modules/secrets-store-vault.adoc
+++ b/modules/secrets-store-vault.adoc
@@ -364,7 +364,7 @@ $ oc create -f deployment.yaml
 
 .Verification
 
-.. Verify that all of the `vault` pods are running properly by running the following command:
+. Verify that all of the `vault` pods are running properly by running the following command:
 +
 [source,terminal]
 ----
@@ -381,7 +381,7 @@ vault-csi-provider-bd6hp   2/2     Running   0          19m
 vault-csi-provider-smlv7   2/2     Running   0          19m
 ----
 
-.. Verify that all of the `secrets-store-csi-driver` pods are running by running the following command:
+. Verify that all of the `secrets-store-csi-driver` pods are running by running the following command:
 +
 [source,terminal]
 ----


### PR DESCRIPTION
Fixing a formatting error introduced here: https://github.com/openshift/openshift-docs/commit/2502edde55cbdca4e03d345d387f34d080179888#diff-d8123ccf70eed56fc019d3178890d1c5c320dea9c8b25741d4b5c2228af62010R7

Nodes -> Working with pods -> Providing sensitive data to pods by using an external secrets store -> [Mounting secrets from HashiCorp Vault](https://110813--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/pods/nodes-pods-secrets-store.html#secrets-store-vault_nodes-pods-secrets-store) -- Fixed Verification step numbering. [Current docs. See misplaced step after verification step **b**.](https://docs.redhat.com/en/documentation/openshift_container_platform/4.21/html/nodes/working-with-pods#secrets-store-vault_nodes-pods-secrets-store)