### PR TITLE
OSDOCS#18573: Microshift - updates for RHEL 10 support

### DIFF
--- a/_attributes/attributes-microshift.adoc
+++ b/_attributes/attributes-microshift.adoc
@@ -31,6 +31,8 @@
 :op-system-image: image mode for RHEL
 :op-system-version: 9.8
 :op-system-version-major: 9
+:op-system-version-10: 10.2
+:op-system-version-major-10: 10
 :op-system-bundle: Red{nbsp}Hat Device Edge
 :ovms: OpenVINO Model Server
 :ov: OVMS

--- a/_topic_maps/_topic_map_ms.yml
+++ b/_topic_maps/_topic_map_ms.yml
@@ -108,6 +108,8 @@ Topics:
   File: microshift-update-rpms-ostree
 - Name: Manual updates with RPMs
   File: microshift-update-rpms-manually
+- Name: Migrating from RHEL 9 to RHEL 10
+  File: microshift-update-rhel9-to-rhel-10
 - Name: Migrating from RHEL for Edge to image mode for RHEL
   File: microshift-update-rhel-edge-to-image-mode
 - Name: Listing update package contents

--- a/microshift_updating/microshift-update-options.adoc
+++ b/microshift_updating/microshift-update-options.adoc
@@ -23,6 +23,13 @@ include::modules/microshift-updates-rhde-config-rhel-repos.adoc[leveloffset=+3]
 
 include::modules/microshift-standalone-rhel-updates.adoc[leveloffset=+1]
 
+[role="_additional-resources"]
+.Additional resources
+* link:https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/10[Red Hat Enterprise Linux 10]
+* link:https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9[Red Hat Enterprise Linux 9]
+* link:https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9/html/composing_installing_and_managing_rhel_for_edge_images/index[Composing, installing, and managing RHEL for Edge images]
+* link:https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9/html/using_image_mode_for_rhel_to_build_deploy_and_manage_operating_systems/introducing-image-mode-for-rhel_using-image-mode-for-rhel-to-build-deploy-and-manage-operating-systems[Introducing image mode for RHEL]
+
 include::modules/microshift-simultaneous-microshift-rhel-updates.adoc[leveloffset=+1]
 
 include::modules/microshift-migrate-rhel-edge-to-image-mode.adoc[leveloffset=+1]

--- a/microshift_updating/microshift-update-rhel9-to-rhel-10.adoc
+++ b/microshift_updating/microshift-update-rhel9-to-rhel-10.adoc
@@ -1,0 +1,14 @@
+:_mod-docs-content-type: ASSEMBLY
+include::_attributes/attributes-microshift.adoc[]
+[id="microshift-update-rhel9-to-rhel-10"]
+= Upgrading the host operating system from {op-system-version} to {op-system-version-10}
+:context: microshift-update-rhel9-to-rhel-10
+
+toc::[]
+
+[role="_abstract"]
+To migrate {microshift-short} from an existing {op-system-ostree-first} system, you must embed {microshift-short} on a new operating system image to ensure a successful transition.
+
+include::modules/microshift-update-edge-to-image.adoc[leveloffset=+1]
+
+include::modules/microshift-updates-edge-to-image-uid-drift.adoc[leveloffset=+2]

--- a/modules/microshift-standalone-rhel-updates.adoc
+++ b/modules/microshift-standalone-rhel-updates.adoc
@@ -8,9 +8,3 @@
 
 [role="_abstract"]
 You can update to any {op-system-base} type without updating {microshift-short} if the two final versions in your {op-system-bundle} are compatible. Check compatibilities before beginning an update. Use the {op-system-base} documentation specific to your use case.
-
-For example:
-
-* link:https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9[Red Hat Enterprise Linux 9]
-* link:https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9/html/composing_installing_and_managing_rhel_for_edge_images/index[Composing, installing, and managing RHEL for Edge images]
-* link:https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9/html/using_image_mode_for_rhel_to_build_deploy_and_manage_operating_systems/introducing-image-mode-for-rhel_using-image-mode-for-rhel-to-build-deploy-and-manage-operating-systems[Introducing image mode for RHEL]


### PR DESCRIPTION
Version(s):
4.22+

Issue:
[OSDOCS-18573](https://redhat.atlassian.net/browse/OSDOCS-18573)

Link to docs preview:
[Migrating from RHEL 9 to RHEL 10](https://110814--ocpdocs-pr.netlify.app/microshift/latest/microshift_updating/microshift-update-rhel9-to-rhel-10)
[Red Hat Device Edge release compatibility matrix](https://110814--ocpdocs-pr.netlify.app/microshift/latest/microshift_install_get_ready/microshift-install-get-ready#microshift-rhde-compatibility-table_microshift-install-get-ready)
[Standalone RHEL updates](https://110814--ocpdocs-pr.netlify.app/microshift/latest/microshift_updating/microshift-update-options)

QE review:
- [ x] QE has approved this change.