### PR TITLE
[OSDOCS#18230]: Support TNA with Platform=none

### DIFF
--- a/installing/installing_bare_metal/ipi/ipi-install-installation-workflow.adoc
+++ b/installing/installing_bare_metal/ipi/ipi-install-installation-workflow.adoc
@@ -64,6 +64,9 @@ include::modules/nw-osp-configuring-external-load-balancer.adoc[leveloffset=+2]
 // Setting the cluster node hostnames through DHCP
 include::modules/ipi-install-setting-cluster-node-hostnames-dhcp.adoc[leveloffset=+1]
 
+// Local arbiter node configuration prerequisites
+include::modules/local-arbiter-node-config-prerequisites.adoc[leveloffset=+1]
+
 // Configuring a local arbiter node
 include::modules/ipi-install-config-local-arbiter-node.adoc[leveloffset=+1]
 

--- a/installing/installing_bare_metal/upi/installing-bare-metal.adoc
+++ b/installing/installing_bare_metal/upi/installing-bare-metal.adoc
@@ -162,6 +162,11 @@ include::modules/installation-configure-proxy.adoc[leveloffset=+2]
 
 include::modules/installation-three-node-cluster.adoc[leveloffset=+2]
 
+include::modules/local-arbiter-node-config-prerequisites.adoc[leveloffset=+2]
+
+//For OSDOCS-18230
+include::modules/upi-install-config-local-arbiter-node.adoc[leveloffset=+2]
+
 include::modules/installation-user-infra-generate-k8s-manifest-ignition.adoc[leveloffset=+1]
 
 [role="_additional-resources"]

--- a/installing/installing_two_node_cluster/about-two-node-arbiter-installation.adoc
+++ b/installing/installing_two_node_cluster/about-two-node-arbiter-installation.adoc
@@ -9,14 +9,18 @@ To install a cluster with two control plane nodes and one local arbiter node, as
 
 After installation, you can add additional arbiter nodes to a cluster with two control plane nodes and one local arbiter node but not to a standard multi-node cluster. It is also not possible to convert between a two-node OpenShift cluster with a local node arbiter and standard topology.
 
-You can install a cluster with two control plane nodes and one local arbiter node by using one of the following methods:
-
-* Installing on bare metal: xref:../installing_bare_metal/ipi/ipi-install-installation-workflow.adoc#ipi-install-config-local-arbiter-node_ipi-install-installation-workflow[Configuring a local arbiter node]
-
-* Installing with the Agent-based Installer: xref:../../installing/installing_with_agent_based_installer/installing-with-agent-based-installer.adoc#installing-ocp-agent-local-arbiter-node_installing-with-agent-based-installer[Configuring a local arbiter node]
-
 [NOTE]
 ====
-For a cluster with an arbiter, the same networking requirements as a regular cluster for connectivity between machines apply. For more information, see xref:../../installing/installing_platform_agnostic/installing-platform-agnostic.adoc#installation-network-connectivity-user-infra_installing-platform-agnostic[Network connectivity requirements].
+For a cluster with an arbiter, the same networking requirements as a regular cluster for connectivity between machines apply. 
 ====
 
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../installing/installing_platform_agnostic/installing-platform-agnostic.adoc#installation-network-connectivity-user-infra_installing-platform-agnostic[Network connectivity requirements]
+
+* xref:../installing_bare_metal/ipi/ipi-install-installation-workflow.adoc#ipi-install-config-local-arbiter-node_ipi-install-installation-workflow[Configuring a local arbiter node with installer-provisioned infrastructure]
+
+* xref:../../installing/installing_with_agent_based_installer/installing-with-agent-based-installer.adoc#installing-ocp-agent-local-arbiter-node_installing-with-agent-based-installer[Configuring a local arbiter node with the Agent-based Installer]
+
+* xref:../installing_bare_metal/upi/installing-bare-metal.adoc#upi-install-config-local-arbiter-node_installing-bare-metal[Configuring a local arbiter node with user-provisioned infrastructure]

--- a/modules/local-arbiter-node-config-prerequisites.adoc
+++ b/modules/local-arbiter-node-config-prerequisites.adoc
@@ -1,0 +1,38 @@
+// Module included in the following assemblies:
+//
+//  *installing/installing_bare_metal/ipi/ipi-install-installation-workflow.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="local-arbiter-node-config-prerequisites_{context}"]
+= Local arbiter node configuration prerequisites
+
+[role="_abstract"]
+To retain high availability (HA) while reducing infrastructure costs for your cluster, you can configure an {product-title} cluster with two control plane nodes and one local arbiter node.
+
+A local arbiter node is a lower-cost, co-located machine that participates in control plane quorum decisions. Unlike a standard control plane node, the arbiter node does not run the full set of control plane services. You can use this configuration to maintain HA in your cluster with only two fully provisioned control plane nodes instead of three.
+
+[IMPORTANT]
+====
+You can configure a local arbiter node only. Remote arbiter nodes are not supported.
+====
+
+To deploy a cluster with two control plane nodes and one local arbiter node, you must define the following nodes in the `install-config.yaml` file:
+
+* 2 control plane nodes
+* 1 arbiter node
+
+The arbiter node must meet the following minimum system requirements:
+
+* 2 threads
+* 8 GB of RAM
+* 50 GB of SSD or equivalent storage
+
+The arbiter node must be located in a network environment with an end-to-end latency of less than 500 milliseconds, including disk I/O. In high-latency environments, you might need to apply the `etcd` slow profile.
+
+The control plane nodes must meet the following minimum system requirements:
+
+* 4 threads
+* 16 GB of RAM
+* 120 GB of SSD or equivalent storage
+
+Additionally, the control plane nodes must also have enough storage for the workload.

--- a/modules/upi-install-config-local-arbiter-node.adoc
+++ b/modules/upi-install-config-local-arbiter-node.adoc
@@ -1,10 +1,10 @@
 // Module included in the following assemblies:
 //
-//  *installing/installing_bare_metal/ipi/ipi-install-installation-workflow.adoc
+//  installing/installing_bare_metal/upi/installing-bare-metal.adoc
 
 :_mod-docs-content-type: PROCEDURE
-[id="ipi-install-config-local-arbiter-node_{context}"]
-= Configuring a local arbiter node by using installer-provisioned infrastructure
+[id="upi-install-config-local-arbiter-node_{context}"]
+= Configuring a local arbiter node by using user-provisioned infrastructure
 
 [role="_abstract"]
 To retain high availability (HA) while reducing infrastructure costs for your cluster, you can configure an {product-title} cluster with two control plane nodes and one local arbiter node.
@@ -29,38 +29,29 @@ compute:
     name: worker
     platform: {}
     replicas: 0
-arbiter: <1>
+   
+arbiter: 
   architecture: amd64
   hyperthreading: Enabled
-  replicas: 1 <2>
-  name: arbiter <3>
+  replicas: 1 
+  name: <Specifies a name for the arbiter machine pool>
   platform:
     baremetal: {}
-controlPlane: <4>
+controlPlane:
   architecture: amd64
   hyperthreading: Enabled
   name: master
   platform:
     baremetal: {}
-  replicas: 2 <5>
+  replicas: 2 
+
 platform:
-  baremetal:
-# ...
-    hosts:
-      - name: cluster-master-0
-        role: master
-# ...
-      - name: cluster-master-1
-        role: master
-        ...
-      - name: cluster-arbiter-0
-        role: arbiter
-# ...
+  none: {}
+
 ----
-<1> Defines the arbiter machine pool. You must configure this field to deploy a cluster with an arbiter node.
-<2> Set the `replicas` field to `1` for the arbiter pool. You cannot set this field to a value that is greater than 1.
-<3> Specifies a name for the arbiter machine pool.
-<4> Defines the control plane machine pool.
-<5> When an arbiter pool is defined, two control plane replicas are valid.
++
+Set the `arbiter.replicas` field to `1` for the arbiter pool. You cannot set this field to a value that is greater than 1.
++
+For `controlPlane.replicas` field, when an arbiter pool is defined, two control plane replicas are valid.
 
 . Save the modified `install-config.yaml` file.


### PR DESCRIPTION

Version(s):
4.22

Issue:
https://redhat.atlassian.net/browse/OSDOCS-18230

Link to docs preview:
https://110815--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_two_node_cluster/about-two-node-arbiter-installation.html

QE review:
- [x] QE has approved this change.

