### PR TITLE
ROX-34433: Document tailored profiles and check count behavior

### DIFF
--- a/modules/coverage-page-overview.adoc
+++ b/modules/coverage-page-overview.adoc
@@ -1,6 +1,7 @@
 // Module included in the following assemblies:
 //
 // * operating/manage-compliance/scheduling-compliance-scans-and-assessing-profile-compliance.adoc
+// * operating/manage-compliance/using-openshift-compliance.adoc
 
 :_mod-docs-content-type: CONCEPT
 [id="coverage-page-overview_{context}"]
@@ -8,7 +9,9 @@
 
 When you view the *Coverage* page and apply a filter to a schedule, all results are filtered accordingly. This filter remains active for all coverage pages until you delete it. You can always view the results based on a single profile. 
 
-You can select profiles grouped according to their associated benchmarks by using the toggle group. You calculate the compliance percentage based on the number of passed checks in relation to the total number of checks.
+You can select profiles grouped according to their associated benchmarks by using the toggle group. Tailored profiles appear under a dedicated *Tailored Profiles* tab.
+
+You calculate the compliance percentage based on the number of passed checks in relation to the total number of checks.
 
 [NOTE]
 ====
@@ -26,6 +29,16 @@ Pass status:: Shows the checks that have been successfully passed.
 Manual status:: Shows the checks that require a manual review because additional organizational or technical knowledge is required that you cannot automate.
 Other status:: Shows the checks with a status other than pass or fail, such as warnings or informational statuses.
 Compliance:: Shows the overall compliance status and helps you to ensure that your environment meets the required standards.
+
+[NOTE]
+====
+A profile might show different numbers of checks across clusters. This can happen for the following reasons:
+
+* Clusters run different versions of the Compliance Operator. Compliance Operator releases can add or remove rules, which changes the number of checks for a given profile.
+* A tailored profile has a different definition on each cluster.
+
+You can expect this behavior. Each cluster's check results reflect the actual profile definition on that cluster. For more information, see "Understanding tailored profiles in compliance scans".
+====
 
 The *Clusters* view lists the clusters and enables you to effectively monitor and manage your clusters.
 

--- a/modules/customizing-and-automating-your-compliance-scans.adoc
+++ b/modules/customizing-and-automating-your-compliance-scans.adoc
@@ -1,6 +1,7 @@
 // Module included in the following assemblies:
 //
 // * operating/manage-compliance/scheduling-compliance-scans-and-assessing-profile-compliance.adoc
+// * operating/manage-compliance/using-openshift-compliance.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="customizing-and-automating-your-compliance-scans_{context}"]
@@ -70,7 +71,7 @@ These values are only applicable if you specify the frequency of scan as `Weekly
 . Click *Next*.
 . Select one or more healthy clusters that you want to include in the scan.
 . Click *Next*.
-. Select one or more profiles that you want to include in the scan.
+. Select one or more profiles that you want to include in the scan. The *Type* column shows the profile type as *Built-in* or *Tailored*. You can include both built-in and tailored profiles in the same scan schedule.
 . Click *Next*.
 . Optional: To configure email delivery destinations for manually triggered reports, perform the following steps:
 +

--- a/modules/tailored-profiles-appearance.adoc
+++ b/modules/tailored-profiles-appearance.adoc
@@ -1,0 +1,27 @@
+// Module included in the following assemblies:
+//
+// * operating/manage-compliance/using-openshift-compliance.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="tailored-profiles-appearance_{context}"]
+= How tailored profiles appear in {product-title-short}
+
+[role="_abstract"]
+Tailored profiles behave like built-in profiles in most respects, with the following differences:
+
+Scan schedules:: When you create or edit a scan schedule, the profile selection table includes a *Type* column that displays *Built-in* for built-in profiles and *Tailored* for tailored profiles. You can select both types together in the same scan schedule.
+
+CSV reports:: In downloaded CSV compliance reports, the *Profile type* column displays *Tailored Profile* instead of *Profile*. The *Control Reference* column displays *N/A* for tailored profiles because tailored profile names do not map to a known compliance standard.
+
+Coverage page:: On the *Coverage* page, tailored profiles appear under a dedicated *Tailored Profiles* tab.
+
+[NOTE]
+====
+Tailored profiles with the same name can produce different check counts across clusters. Because each cluster manages its own tailored profile as a Kubernetes resource, they can differ in several ways:
+
+* Different sets of enabled or disabled rules.
+* Extending different base profiles.
+* Extending the same base profile but on clusters running different Compliance Operator versions, which can cause the base profile itself to contain different rules.
+
+You can expect this behavior. Each cluster's check results reflect the actual tailored profile definition on that cluster.
+====

--- a/modules/understanding-tailored-profiles-in-compliance-scans.adoc
+++ b/modules/understanding-tailored-profiles-in-compliance-scans.adoc
@@ -1,0 +1,19 @@
+// Module included in the following assemblies:
+//
+// * operating/manage-compliance/using-openshift-compliance.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="understanding-tailored-profiles-in-compliance-scans_{context}"]
+= Understanding tailored profiles in compliance scans
+
+[role="_abstract"]
+Tailored profiles are custom compliance profiles that you create with the Compliance Operator `TailoredProfile` custom resource. Use them to adapt built-in profiles to your organization's needs.
+
+[NOTE]
+====
+Tailored profile support is available starting with {product-title-short} version 4.11.
+====
+
+You can enable or disable specific rules and override variable values in tailored profiles.
+
+You can include tailored profiles in your compliance scan schedules with built-in profiles. {product-title-short} detects tailored profiles from your clusters automatically. They become available when you create or edit a scan schedule.

--- a/operating/manage-compliance/using-openshift-compliance.adoc
+++ b/operating/manage-compliance/using-openshift-compliance.adoc
@@ -47,8 +47,24 @@ include::modules/assessing-the-profile-compliance-across-clusters.adoc[leveloffs
 //OpenShift Coverage page overview
 include::modules/coverage-page-overview.adoc[leveloffset=+2]
 
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../operating/manage-compliance/using-openshift-compliance.adoc#understanding-tailored-profiles-in-compliance-scans_using-openshift-compliance[Understanding tailored profiles in compliance scans]
+
 //Monitoring and analyzing the health of your clusters
 include::modules/monitoring-and-analyzing-the-health-of-your-clusters.adoc[leveloffset=+2]
 
 //Compliance scan status overview
 include::modules/compliance-scan-status-overview.adoc[leveloffset=+2]
+
+//Understanding tailored profiles in compliance scans
+include::modules/understanding-tailored-profiles-in-compliance-scans.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* link:https://docs.redhat.com/en/documentation/openshift_container_platform/{ocp-latest-version}/html-single/security_and_compliance/index#compliance-new-tailored-profiles_compliance-tailor[Creating a new tailored profile]
+
+//How tailored profiles appear in RHACS
+include::modules/tailored-profiles-appearance.adoc[leveloffset=+2]


### PR DESCRIPTION
Version(s): 4.11+

Issue: [ROX-26033](https://issues.redhat.com/browse/ROX-26033)

Link to docs preview: https://110817--ocpdocs-pr.netlify.app/openshift-acs/latest/operating/manage-compliance/using-openshift-compliance.html

QE review: ACS does not have QE

## Summary

Documents the tailored profiles feature and adds a note about varying check counts across clusters.

### Changes

**New module** (`modules/understanding-tailored-profiles-in-compliance-scans.adoc`):
- Concept module explaining what tailored profiles are (Compliance Operator `TailoredProfile` CRD)
- Links to OCP documentation for creating tailored profiles

**New module** (`modules/tailored-profiles-appearance.adoc`):
- Reference module documenting UX differences: Coverage page "Tailored Profiles" tab, scan schedule "Type" column, CSV report "Profile type" and "Control Reference" columns
- Includes a NOTE about profiles showing different check counts across clusters (applies to both regular and tailored profiles due to CO version differences or per-cluster TP definitions)

**Inline updates to existing modules**:
- `coverage-page-overview.adoc`: mention Tailored Profiles tab + add check count note with cross-reference to the new tailored profiles module
- `customizing-and-automating-your-compliance-scans.adoc`: mention Type column in profile selection step

**Assembly update** (`using-openshift-compliance.adoc`):
- Include both new modules and add additional resources cross-reference from Coverage section