### PR TITLE
docs: add procedure for overriding step compute resources in Pipeline…

### DIFF
--- a/cicd/pipelines/overriding-step-resources-in-pipeline-runs.adoc
+++ b/cicd/pipelines/overriding-step-resources-in-pipeline-runs.adoc
@@ -1,0 +1,19 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="overriding-step-resources-in-pipeline-runs"]
+= Overriding step resources in pipeline runs
+include::_attributes/common-attributes.adoc[]
+:context: overriding-step-resources-in-pipeline-runs
+
+toc::[]
+
+When a pipeline references a task definition that you cannot modify, such as a task from a Tekton bundle or a shared catalog, you can override the compute resources for individual steps at run time. This is useful in environments like {pac} or Konflux, where pipeline and task definitions are managed externally.
+
+include::modules/op-overriding-step-compute-resources-in-pipelineruns.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+[id="additional-resources_overriding-step-resources-in-pipeline-runs"]
+== Additional resources
+
+* xref:../../cicd/pipelines/reducing-pipelines-resource-consumption.adoc#reducing-pipelines-resource-consumption[Reducing resource consumption of {pipelines-shortname}]
+* xref:../../cicd/pipelines/setting-compute-resource-quota-for-openshift-pipelines.adoc#setting-compute-resource-quota-for-openshift-pipelines[Setting compute resource quota for {pipelines-shortname}]
+* link:https://tekton.dev/docs/pipelines/taskruns/#configuring-task-steps-and-sidecars-in-a-taskrun[Configuring Task Steps and Sidecars in a TaskRun (upstream Tekton documentation)]

--- a/modules/op-overriding-step-compute-resources-in-pipelineruns.adoc
+++ b/modules/op-overriding-step-compute-resources-in-pipelineruns.adoc
@@ -1,0 +1,100 @@
+// Module included in the following assemblies:
+//
+// * cicd/pipelines/overriding-step-resources-in-pipeline-runs.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id='op-overriding-step-compute-resources-in-pipelineruns_{context}']
+= Overriding compute resources for steps in pipeline runs
+
+When a pipeline references a task that you cannot modify, such as a task from a Tekton bundle or a shared catalog, you can override the compute resources of individual steps at run time by using the `stepSpecs` field. This allows you to increase or decrease CPU, memory, or ephemeral storage for specific steps without changing the task definition itself.
+
+The `stepSpecs` field is specified under `taskRunSpecs` in a `PipelineRun`. Each entry targets a named step and sets custom resource requests or limits through the `computeResources` field. The values in `stepSpecs` take precedence over any compute resources defined in the task's steps or step template.
+
+The following example shows a `PipelineRun` that overrides compute resources for a step named `build-step` in the `build` task:
+
+.Example `PipelineRun` with step compute resource overrides
+[source,yaml]
+----
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  name: my-pipeline-run
+spec:
+  pipelineRef:
+    name: my-pipeline <1>
+  taskRunSpecs:
+    - pipelineTaskName: build <2>
+      stepSpecs:
+        - name: build-step <3>
+          computeResources: <4>
+            requests:
+              memory: 4Gi
+              cpu: 1
+            limits:
+              memory: 8Gi
+              cpu: 2
+----
+<1> The name of the pipeline to run. This can also reference a pipeline from a Tekton bundle or resolver.
+<2> The name of the task within the pipeline whose steps you want to override.
+<3> The name of the step to override. This must match the `name` field in the task's `steps` definition.
+<4> The compute resource requests and limits for this step, overriding any values defined in the task.
+
+You can override multiple steps in the same task, or steps across different tasks, by adding entries to the `stepSpecs` and `taskRunSpecs` lists.
+
+When merging resource values, each resource type is considered independently. For example, if a step defines both CPU and memory requests and the `stepSpecs` entry sets only memory, the CPU values from the original step are preserved. Requests and limits are also independent: overriding a memory request does not affect the memory limit.
+
+[NOTE]
+====
+The `stepSpecs` field and the task-level `computeResources` field are two different override mechanisms and cannot be used together on the same task in a pipeline run. The `stepSpecs` field overrides compute resources for individual named steps. The task-level `computeResources` field sets a single resource budget that is distributed evenly across all steps in a task. If both are specified for the same task, the pipeline run is rejected at admission time with the following error:
+
+[source,text]
+----
+expected exactly one, got both: spec.taskRunSpecs[0].computeResources, spec.taskRunSpecs[0].stepSpecs.resources
+----
+====
+
+[id='op-overriding-step-compute-resources-in-pipelineruns-pac_{context}']
+== Using step compute resource overrides with {pac}
+
+When using {pac}, add `taskRunSpecs` with `stepSpecs` to the `PipelineRun` definition stored in your source repository (typically under `.tekton/`). {pac} applies these overrides when it creates the pipeline run on the cluster.
+
+[id='op-overriding-step-compute-resources-v1beta1_{context}']
+== Equivalent fields in the v1beta1 API
+
+If your pipeline runs use the `tekton.dev/v1beta1` API version, the field names differ:
+
+.Comparison of v1 and v1beta1 field names
+[cols="1,1",options="header"]
+|===
+|`v1` field
+|`v1beta1` equivalent
+
+|`stepSpecs`
+|`stepOverrides`
+
+|`computeResources`
+|`resources`
+|===
+
+.Example `PipelineRun` using the `v1beta1` API
+[source,yaml]
+----
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: my-pipeline-run
+spec:
+  pipelineRef:
+    name: my-pipeline
+  taskRunSpecs:
+    - pipelineTaskName: build
+      stepOverrides:
+        - name: build-step
+          resources:
+            requests:
+              memory: 4Gi
+              cpu: 1
+            limits:
+              memory: 8Gi
+              cpu: 2
+----


### PR DESCRIPTION
Adds documentation for using taskRunSpecs.stepSpecs to override compute
resources for individual steps at PipelineRun time, without modifying
the Task definition. Covers both v1 and v1beta1 API versions, includes
a Pipelines as Code note, and documents the mutual exclusivity constraint
with task-level computeResources.

Version(s):
1.18

Issue:
No documented procedure on how to allocated additional resources to a task step

Link to docs preview:
----

QE review:
- [ ] QE has approved this change.

Additional information:
- Verified on a kind cluster with Tekton Pipelines latest:
  - `stepSpecs` override correctly applies to the pod container
  - Using both `stepSpecs` and `computeResources` on the same task is rejected at admission with: `expected exactly one, got both: spec.taskRunSpecs[0].computeResources, spec.taskRunSpecs[0].stepSpecs.resources`
- Upstream source: https://tekton.dev/docs/pipelines/taskruns/#configuring-task-steps-and-sidecars-in-a-taskrun
- The new assembly (`cicd/pipelines/overriding-step-resources-in-pipeline-runs.adoc`) still needs to be added to the "Managing performance and resource use" guide-level navigation config.