### PR TITLE
OSDOCS-19410 back porting most recent zero-trust docs to 4.18 PR#1

### DIFF
--- a/modules/zero-trust-manager-about-controller-manager.adoc
+++ b/modules/zero-trust-manager-about-controller-manager.adoc
@@ -1,0 +1,12 @@
+// Module included in the following assemblies:
+//
+// * security/zero_trust_workload_identity_manager/zero-trust-manager-features.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="zero-trust-manager-about-controller-manager_{context}"]
+= SPIRE Controller Manager
+
+[role="_abstract"]
+Use the SPIRE Controller Manager to automate workload registration with custom resource definitions (CRDs). The manager monitors pods and CRDs to create, update, or delete entries on the SPIRE Server. This process helps ensure that your SPIRE entries accurately reflect your active resources.
+
+The SPIRE Controller Manager is designed to be deployed on the same pod as the SPIRE Server. The manager communicates with the SPIRE Server API using a private UNIX Domain Socket within a shared volume.

--- a/modules/zero-trust-manager-about-csi-driver.adoc
+++ b/modules/zero-trust-manager-about-csi-driver.adoc
@@ -1,0 +1,12 @@
+// Module included in the following assemblies:
+//
+// * security/zero_trust_workload_identity_manager/zero-trust-manager-features.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="zero-trust-manager-about-csi-driver_{context}"]
+= SPIFFE CSI Driver
+
+[role="_abstract"]
+The SPIFFE Container Storage Interface (CSI) driver helps pods securely obtain their {svid-full} by delivering the Workload API socket. By using Kubernetes ephemeral inline volumes, the driver simplifies how applications request temporary storage for identity management.
+
+When the pod starts, the Kubelet calls the SPIFFE CSI driver to provision and mount a volume into the pod's containers. The SPIFFE CSI driver mounts a directory that contains the SPIFFE Workload API into the pod. Applications in the pod then communicate with the Workload API to obtain their SVIDs. The driver guarantees that each SVID is unique.

--- a/modules/zero-trust-manager-about-oidc-provider.adoc
+++ b/modules/zero-trust-manager-about-oidc-provider.adoc
@@ -1,0 +1,12 @@
+// Module included in the following assemblies:
+//
+// * security/zero_trust_workload_identity_manager/zero-trust-manager-features.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="zero-trust-manager-about-oidc-provider_{context}"]
+= SPIRE OpenID Connect Discovery Provider
+
+[role="_abstract"]
+Use the SPIRE OpenID Connect (OIDC) Discovery Provider to integrate SPIRE workload identities with OIDC-compliant systems. This component exposes endpoints for token verification. It helps ensure compatibility between SPIRE-issued credentials and external APIs requiring standard OIDC tokens.
+
+While SPIRE primarily issues identities for workloads, additional workload-related claims can be embedded into JWT-SVIDs through the configuration of SPIRE, which allows these claims to be included in the token and verified by OIDC-compliant clients.

--- a/modules/zero-trust-manager-oidc-config.adoc
+++ b/modules/zero-trust-manager-oidc-config.adoc
@@ -6,7 +6,8 @@
 [id="zero-trust-manager-oidc-config_{context}"]
 = Deploying the SPIRE OpenID Connect Discovery Provider
 
-You can configure the `SpireOIDCDiscoveryProvider` custom resource (CR) to deploy and configure the SPIRE OpenID Connect (OIDC) Discovery Provider.
+[role="_abstract"]
+Deploy the SPIRE OpenID Connect (OIDC) Discovery Provider by configuring the `SpireOIDCDiscoveryProvider` CR. This allows you to define the trust domain and JSON web token (JWT) issuer for your cluster.
 
 .Prerequisites
 
@@ -29,13 +30,31 @@ kind: SpireOIDCDiscoveryProvider
 metadata:
   name: cluster
 spec:
-  trustDomain: <trust_domain> #<1>
-  agentSocketName: 'spire-agent.sock' #<2>
-  jwtIssuer: <jwt_issuer_domain> #<3>
+  logLevel: "info"
+  logFormat: "text"
+  csiDriverName: "csi.spiffe.io"
+  jwtIssuer: "https://oidc-discovery.apps.cluster.example.com"
+  replicaCount: 1
+  managedRoute: "true"
+  externalSecretRef: ""
 ----
-<1> The trust domain to be used for the SPIFFE identifiers.
-<2> The name of the SPIRE agent unix socket.
-<3> The JSON Web Token (JWT) issuer domain. The default value is set to the value specified in `oidc-discovery.$trustDomain`.
+where:
+
+`metadata.name`:: Specifies that the value must be `cluster`.
+
+`spec.logLevel`:: Specifies the logging level for the SPIRE Server. The valid options are `debug`, `info`, `warn`, and `error`.
+
+`spec.logFormat`:: Specifies the logging format for the SPIRE Server. The valid options are `text` and `json`.
+
+`spec.csiDriverName`:: Specifies the name of the CSI driver to use for mounting the Workload API socket. This must match the `SpiffeCSIDriver.spec.pluginName` value for the OIDC provider to access SPIFFE identities. Must be a valid DNS subdomain format (for example, `csi.spiffe.io`) with a maximum length of 127 characters.
+
+`spec.jwtIssuer`:: Specifies the JWT issuer URL. Must be a valid HTTPS or HTTP URL with a maximum length of 512 characters. This value must match the `SpireServer.spec.jwtIssuer` value.
+
+`spec.replicaCount`:: Specifies the number of replicas for the OIDC Discovery Provider deployment. Must be between 1 and 5.
+
+`spec.managedRoute`:: Specifies whether the Operator automatically creates an OpenShift route for the OIDC Discovery Provider endpoints. Set to `true` to have the Operator automatically create and maintain an OpenShift route for OIDC discovery endpoints (`*.apps.`). Set to `false` for administrators to manually configure routes or ingress.
+
+`spec.externalSecretRef`:: Optional: Specifies a reference to an externally managed secret that contains the TLS certificate for the OIDC Discovery Provider route host. Must be a valid Kubernetes secret reference name with a maximum length of 253 characters.
 
 .. Apply the configuration by running the following command:
 +

--- a/modules/zero-trust-manager-server-agent-telemetry.adoc
+++ b/modules/zero-trust-manager-server-agent-telemetry.adoc
@@ -1,0 +1,10 @@
+// Module included in the following assemblies:
+//
+// * security/zero_trust_workload_identity_manager/zero-trust-manager-features.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="zero-trust-manager-server-agent-telemetry_{context}"]
+= SPIRE Server and Agent telemetry
+
+[role="_abstract"]
+Use the SPIRE Controller Manager to register workloads by using custom resource definitions (CRDs). The manager monitors pods and CRDs for changes and triggers a reconciliation process. This process creates, updates, or deletes SPIRE Server entries to help ensure they match your configuration.

--- a/modules/zero-trust-manager-spiffe-csidriver-config.adoc
+++ b/modules/zero-trust-manager-spiffe-csidriver-config.adoc
@@ -6,7 +6,8 @@
 [id="zero-trust-manager-spire-csidriver-config_{context}"]
 = Deploying the SPIFFE Container Storage Interface driver
 
-You can configure the `SpiffeCSIDriver` custom resource (CR) to deploy and configure a SPIRE agent.
+[role="_abstract"]
+Configure the Container Storage Interface (CSI) driver using the `SpiffeCSIDriver` CR. This configuration mounts SPIFFE sockets directly into workload pods, which allows your applications to access the SPIFFE Workload API securely.
 
 .Prerequisites
 
@@ -29,9 +30,16 @@ kind: SpiffeCSIDriver
 metadata:
   name: cluster
 spec:
-  agentSocketPath: '/run/spire/agent-sockets/spire-agent.sock' #<1>
+  agentSocketPath: "/run/spire/agent-sockets"
+  pluginName: "csi.spiffe.io"
 ----
-<1> The UNIX socket path to the SPIRE agent.
+where:
+
+`metadata.name`:: Specifies that the name must be `cluster`.
+
+`spec.agentSocketPath`:: Specifies the path to the directory containing the SPIRE agent's Workload API socket. This directory is bind-mounted into workload containers by the CSI driver. The directory is shared between the SPIRE agent and CSI driver via a `hostPath` volume. Must be an absolute path with a maximum length of 256 characters. This value must match `SpireAgent.spec.socketPath` for workloads to access the socket.
+
+`spec.pluginName`:: Specifies the name of the CSI plugin. This sets the CSI driver name that is deployed to the cluster and used in `VolumeMount` configurations. Must match the driver name referenced in the workload pods. Must be a valid domain name format (for example, `csi.spiffe.io`) with a maximum length of 127 characters.
 
 .. Apply the configuration by running the following command:
 +
@@ -42,7 +50,7 @@ $ oc apply -f SpiffeCSIDriver.yaml
 
 .Verification
 
-. Verify that the daemon set of the SPIFFE CSI driver is ready and available by running the following command:
+* Verify that the daemon set of the SPIFFE CSI driver is ready and available by running the following command:
 +
 [source,terminal]
 ----
@@ -56,7 +64,7 @@ NAME                      DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE   N
 spire-spiffe-csi-driver   3         3         3       3            3           <none>          114s
 ----
 
-. Verify that the status of SPIFFE Container Storage Interface (CSI) Driver pods is `Running` by running the following command:
+* Verify that the status of SPIFFE Container Storage Interface (CSI) Driver pods is `Running` by running the following command:
 +
 [source,terminal]
 ----

--- a/modules/zero-trust-manager-spire-agent-config.adoc
+++ b/modules/zero-trust-manager-spire-agent-config.adoc
@@ -4,9 +4,11 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="zero-trust-manager-spire-agent-config_{context}"]
-= Deploying the SPIRE agent
+= Deploying the SPIRE Agent
 
-You can configure the `SpireAgent` custom resource (CR) to deploy and configure a SPIRE agent.
+[role="_abstract"]
+Use the `SpireAgent` custom resource to configure the SPIRE Agent `DaemonSet` on your nodes. This defines how the agent verifies workloads and manages identity attestation across your {product-title} cluster.
+
 
 .Prerequisites
 
@@ -29,20 +31,44 @@ kind: SpireAgent
 metadata:
   name: cluster
 spec:
-  trustDomain: <trust_domain> #<1>
-  clusterName: <cluster_name> #<2>
+  socketPath: "/run/spire/agent-sockets"
+  logLevel: "info"
+  logFormat: "text"
   nodeAttestor:
-    k8sPSATEnabled: "true" #<3>
+    k8sPSATEnabled: "true"
   workloadAttestors:
-    k8sEnabled: "true" #<4>
+    k8sEnabled: "true"
     workloadAttestorsVerification:
-      type: "auto" #<5>
+      type: "auto"
+      hostCertBasePath: "/etc/kubernetes"
+      hostCertFileName: "kubelet-ca.crt"
+    disableContainerSelectors: "false"
+    useNewContainerLocator: "true"
 ----
-<1> The trust domain to be used for the SPIFFE identifiers.
-<2> The name of your cluster.
-<3> Enable or disable the projected service account token (PSAT) Kubernetes node attestor. The valid options are `true` and `false`.
-<4> Enable or disable the Kubernetes workload attestor. The valid options are `true` and `false`.
-<5> The type of verification to be done against kubelet. Valid options are `auto`, `hostCert`, `apiServerCA`, `skip`. The `auto` option initially attempts to use `hostCert`, and then falls back to `apiServerCA`.
++
+where:
+
+`metadata.name`:: Specifies that the value must be `cluster`.
+
+`spec.socketPath`:: Specifies the directory on the host where the SPIRE agent socket is created. This directory is shared with the SPIFFE CSI driver via the `hostPath` volume. Must match the `SpiffeCSIDriver.spec.agentSocketPath` for workloads to access the socket. Must be an absolute path with a maximum length of 256 characters.
+
+`spec.logLevel`:: Specifies the logging level for the SPIRE Server. The valid options are `debug`, `info`, `warn`, and `error`.
+
+`spec.logFormat`:: Specifies the logging format for the SPIRE Server. The valid options are `text` and `json`.
+
+`spec.nodeAttestor.k8sPSATEnabled`:: Specifies whether Kubernetes Projected Service Account Token (PSAT) node attestation is enabled. When enabled, the SPIRE agent uses K8s PSATs to prove its identity to the SPIRE server during node attestation. The valid options are `true` and `false`.
+
+`spec.workloadAttestors.k8sEnabled`:: Specifies whether the Kubernetes workload attestor is enabled. When enabled, the SPIRE agent can verify workload identities using Kubernetes pod information and service account tokens. The valid options are `true` and `false`.
+
+`spec.workloadAttestors.workloadAttestorsVerification.type`:: Specifies the kubelet certificate verification mode. The valid options are `auto`, `hostCert`, and `skip`.
+
+`spec.workloadAttestors.workloadAttestorsVerification.hostCertBasePath`:: Specifies the directory containing the kubelet CA certificate. This value is required only when type is `hostCert`. When `skip` is specified, the TLS verification is skipped. When `auto` is specified, {product-name} defaults to `/etc/kubernetes/kubelet-ca.crt` unless `hostCertBasePath` and `hostCertFileName` are explicitly specified.
+
+`spec.workloadAttestors.workloadAttestorsVerification.hostCertFileName`:: Specifies the file name of the kubelet CA certificate, which combines with `hostCertBasePath` to form the full path. This value is required only when type is `hostCert`. For all other modes, it is optional and defaults to `/etc/kubernetes`.
+
+`spec.workloadAttestors.disableContainerSelectors`:: Specifies whether to disable container selectors in the Kubernetes workload attestor. Set to `true` if using `holdApplicationUntilProxyStarts` in Istio. The valid options are `true` and `false`.
+
+`spec.workloadAttestors.useNewContainerLocator`:: Specifies enabling the new container locator algorithm that has support for cgroups v2. The valid options are `true` and `false`.
 
 .. Apply the configuration by running the following command:
 +
@@ -53,7 +79,7 @@ $ oc apply -f SpireAgent.yaml
 
 .Verification
 
-. Verify that the daemon set of the SPIRE agent is ready and available by running the following command
+* Verify that the daemon set of the SPIRE Agent is ready and available by running the following command:
 +
 [source,terminal]
 ----
@@ -67,7 +93,7 @@ NAME          DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE   NODE SELECTOR
 spire-agent   3         3         3       3            3           <none>          10m
 ----
 
-. Verify that the status of SPIRE agent pods is `Running` by running the following command:
+* Verify that the status of SPIRE Agent pods is `Running` by running the following command:
 +
 [source,terminal]
 ----

--- a/modules/zero-trust-manager-spire-server-config.adoc
+++ b/modules/zero-trust-manager-spire-server-config.adoc
@@ -4,14 +4,17 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="zero-trust-manager-spire-server-config_{context}"]
-= Deploying the SPIRE server
+= Deploying the SPIRE Server
 
-You can configure the `SpireServer` custom resource (CR) to deploy and configure a SPIRE server.
+[role="_abstract"]
+Deploy the SPIRE Server by configuring the `SpireServer` custom resource (CR). This establishes a central authority that manages and issues identities to the workloads in your cluster.
 
 .Prerequisites
 
 * You have access to the cluster as a user with the `cluster-admin` role.
+
 * You have installed {zero-trust-full} in the cluster.
+
 .Procedure
 
 . Create the `SpireServer` CR:
@@ -27,36 +30,73 @@ kind: SpireServer
 metadata:
   name: cluster
 spec:
-  trustDomain: <trust_domain> #<1>
-  clusterName: <cluster_name> #<2>
+  logLevel: "info"
+  logFormat: "text"
+  jwtIssuer: "https://oidc-discovery.apps.cluster.example.com"
+  caValidity: "24h"
+  defaultX509Validity: "1h"
+  defaultJWTValidity: "5m"
+  jwtKeyType: "rsa-2048"
   caSubject:
-    commonName: example.org #<3>
-    country: "US" #<4>
-    organization: "RH" #<5>
+    country: "US"
+    organization: "Example Corporation"
+    commonName: "SPIRE Server CA"
   persistence:
-    type: pvc #<6>
-    size: "5Gi" #<7>
-    accessMode: ReadWriteOnce #<8>
+    size: "5Gi"
+    accessMode: "ReadWriteOnce"
+    storageClass: "gp3-csi"
   datastore:
-    databaseType: sqlite3
+    databaseType: "sqlite3"
     connectionString: "/run/spire/data/datastore.sqlite3"
-    maxOpenConns: 100 #<9>
-    maxIdleConns: 2 #<10>
-    connMaxLifetime: 3600 #<11>
-  jwtIssuer: <jwt_issuer_domain> #<12>
+    tlsSecretName: ""
+    maxOpenConns: 100
+    maxIdleConns: 10
+    connMaxLifetime: 0
+    disableMigration: "false"
 ----
-<1> The trust domain to be used for the SPIFFE identifiers.
-<2> The name of your cluster.
-<3> The common name for SPIRE server CA.
-<4> The country for SPIRE server CA.
-<5> The organization for SPIRE server CA.
-<6> The type of volume to be used for persistence. The valid options are `pvc` and `hostPath`.
-<7> The size of volume to be used for persistence
-<8> The access mode to be used for persistence. The valid options are `ReadWriteOnce`, `ReadWriteOncePod`, and `ReadWriteMany`.
-<9> The maximum number of open database connections.
-<10> The maximum number of idle connections in the pool.
-<11> The maximum amount of time a connection can be reused. To specify an unlimited time, you can set the value to `0`.
-<12> The JSON Web Token (JWT) issuer domain. The default value is set to the value specified in `oidc-discovery.$trustDomain`.
+where:
+
+`metadata.name`:: Specifies that the value must be `cluster`.
+
+`spec.logLevel`:: Specifies the logging level for the SPIRE Server. The valid options are `debug`, `info`, `warn`, and `error`.
+
+`spec.logFormat`:: Specifies the logging format for the SPIRE Server. The valid options are `text` and `json`.
+
+`spec.jwtIssuer`:: Specifies the JWT issuer URL. Must be a valid HTTPS or HTTP URL with a maximum length of 512 characters.
+
+`spec.caValidity`:: Specifies the validity period (Time to Live (TTL)) for the SPIRE Server's CA certificate. This determines how long the server's root or intermediate certificate is valid. The format is a duration string (for example, `24h`, `168h`).
+
+`spec.defaultX509Validity`:: Specifies the default validity period (TTL) for X.509 SVIDs issued to workloads. This value is used if a specific TTL is not configured for a registration entry.
+
+`spec.defaultJWTValidity`:: Specifies the default validity period (TTL) for JWT SVIDs issued to workloads. This value is used if a specific TTL is not configured for a registration entry.
+
+`spec.jwtKeyType`:: Optional: Specifies the key type used for JWT signing. The valid options are `rsa-2048`, `rsa-4096`, `ec-p256`, and `ec-p384`.
+
+`spec.caSubject.country`:: Specifies the country for the SPIRE Server certificate authority (CA). Must be an ISO 3166-1 alpha-2 country code (2 characters).
+
+`spec.caSubject.organization`:: Specifies the organization for the SPIRE Server CA. Maximum length is 64 characters.
+
+`spec.caSubject.commonName`:: Specifies the common name for the SPIRE Server CA. Maximum length is 255 characters.
+
+`spec.persistence.size`:: Specifies the size of the persistent volume (for example, `1Gi`, `5Gi`). Once set, this field is immutable.
+
+`spec.persistence.accessMode`:: Specifies the access mode for the persistent volume. The valid options are `ReadWriteOnce`, `ReadWriteOncePod`, and `ReadWriteMany`. Once set, this field is immutable.
+
+`spec.persistence.storageClass`::  Specifies the storage class to be used for the PVC. Once set, this field is immutable.
+
+`spec.datastore.databaseType`:: Specifies the type of database to use for the datastore. The valid options are `sql`, `sqlite3`, `postgres`, `mysql`, `aws_postgresql`, and `aws_mysql`.
+
+`spec.datastore.connectionString`:: Specifies the connection string for the database. For PostgreSQL with SSL, include `sslmode` and certificate paths (for example, `dbname=spire user=spire host=postgres.example.com sslmode=verify-full`).
+
+`spec.datastore.tlsSecretName`:: Optional: Specifies the name of a Kubernetes Secret containing TLS certificates for database connections. The Secret will be mounted at `/run/spire/db/certs`.
+
+`spec.datastore.maxOpenConns`:: Specifies the maximum number of open database connections. Must be between 1 and 10000.
+
+`spec.datastore.maxIdleConns`:: Specifies the maximum number of idle database connections in the pool. Must be between 0 and 10000.
+
+`spec.datastore.connMaxLifetime`:: Specifies the maximum lifetime of a database connection in seconds. A value of 0 means connections are not closed due to age.
+
+`spec.datastore.disableMigration`:: Specifies whether to disable automatic database migration. The valid options are `true` and `false`.
 
 .. Apply the configuration by running the following command:
 +
@@ -67,7 +107,7 @@ $ oc apply -f SpireServer.yaml
 
 .Verification
 
-. Verify that the stateful set of SPIRE server is ready and available by running the following command:
+* Verify that the stateful set of SPIRE Server is ready and available by running the following command:
 +
 [source,terminal]
 ----
@@ -81,7 +121,7 @@ NAME            READY   AGE
 spire-server    1/1     65s
 ----
 
-. Verify that the status of SPIRE server pod is `Running` by running the following command:
+* Verify that the status of the SPIRE Server pod is `Running` by running the following command:
 +
 [source,terminal]
 ----
@@ -95,7 +135,7 @@ NAME               READY   STATUS    RESTARTS        AGE
 spire-server-0     2/2     Running   1 (108s ago)    111s
 ----
 
-. Verify that the persistent volume claim (PVC) is bound, by running the following command:
+* Verify that the persistent volume claim (PVC) is bound, by running the following command:
 +
 [source,terminal]
 ----

--- a/modules/zero-trust-manager-verify-operands.adoc
+++ b/modules/zero-trust-manager-verify-operands.adoc
@@ -1,0 +1,60 @@
+// Module included in the following assemblies:
+//
+// * security/zero_trust_workload_identity_manageer/zero-trust-manager-configuration.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="zero-trust-manager-verify-operands_{context}"]
+= Verify the health of the operands
+
+[role="_abstract"]
+View the status fields to verify the operational health of managed components. By viewing this information, you can confirm that the SPIRE Server, SPIRE Agent, SPIFFE CSI driver, and the SPIRE OIDC discovery provider operands are ready and functioning correctly.
+
+* To verify the operands, run the following command:
++
+[source,terminal]
+----
+oc get ZeroTrustWorkloadIdentityManager cluster -o yaml
+----
++
+.Example output
++
+[source,yaml]
+----
+status:
+  conditions:
+  - lastTransitionTime: "2025-12-16T10:59:06Z"
+    message: All components are ready
+    reason: Ready
+    status: "True"
+    type: Ready
+  - lastTransitionTime: "2025-12-16T10:59:06Z"
+    message: All operand CRs are ready
+    reason: Ready
+    status: "True"
+    type: OperandsAvailable
+  operands:
+  - kind: SpireServer
+    message: Ready
+    name: cluster
+    ready: "true"
+  - kind: SpireAgent
+    message: Ready
+    name: cluster
+    ready: "true"
+  - kind: SpiffeCSIDriver
+    message: Ready
+    name: cluster
+    ready: "true"
+  - kind: SpireOIDCDiscoveryProvider
+    message: Ready
+    name: cluster
+    ready: "true"
+   # ...
+----
+
+This status is reflected when all operands are healthy and stable.
+
+[IMPORTANT]
+====
+The Operator adds the owner reference for the `ZeroTrustWorkloadIdentityManager` CR on the other CRs owned by the operand. This causes the resources of the operands to be deleted after the `ZeroTrustWorkloadIdentityManager` CRs are deleted.
+====

--- a/modules/zero-trust-manager-ztwim-cr.adoc
+++ b/modules/zero-trust-manager-ztwim-cr.adoc
@@ -1,0 +1,34 @@
+// Module included in the following assemblies:
+//
+// * security/zero_trust_workload_identity_manageer/zero-trust-manager-configuration.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="zero-trust-manager-ztwim-cr_{context}"]
+= About the ZeroTrustWorkloadIdentityManager custom resource
+
+[role="_abstract"]
+The `ZeroTrustWorkloadIdentityManager` is the primary custom resource (CR) that initializes the SPIRE deployments. This primary resource defines the trust domain and cluster name to help ensure secure workload identity management.
+
+Reference the complete YAML specification to correctly structure the `ZeroTrustWorkloadIdentityManager` CR. This example helps you identify required fields and immutable parameters for your configuration.
+
+[source,yaml]
+----
+apiVersion: operator.openshift.io/v1alpha1
+kind: ZeroTrustWorkloadIdentityManager
+metadata:
+ name: cluster
+ labels:
+   app.kubernetes.io/name: zero-trust-workload-identity-manager
+   app.kubernetes.io/managed-by: zero-trust-workload-identity-manager
+spec:
+  trustDomain: "example.com"
+  clusterName: "production-cluster"
+  bundleConfigMap: "spire-bundle"
+----
+where:
+
+`spec.trustDomain`:: Specifies the trust domain to be used for the SPIFFE identifiers. Must be a valid SPIFFE trust domain (lowercase alphanumeric, hyphens, and dots). Maximum length is 255 characters. After setting a value for the field, the field is immutable. Red{nbsp}Hat highly recommends to set this value to match the base application URL (for example, `apps.mycluster.example.com`) of your {product-title} cluster. Using a different value might cause automatically generated OpenShift Routes or federation endpoints to be created with incorrect or mismatched hostnames later in the configuration process.
+
+`spec.clusterName`:: Specifies the name that identifies this cluster within the trust domain. Must be a valid DNS-1123 subdomain with a maximum length of 63 characters. Once set, this field is immutable.
+
+`spec.bundleConfigMap`:: Optional: Specifies the name of the ConfigMap that stores the SPIRE trust bundle. This ConfigMap contains the root certificates for the trust domain and is created and maintained by the Operator. Must be a valid Kubernetes name with a maximum length of 253 characters. The default value is `spire-bundle`. Once this value is set, it is immutable.

--- a/security/zero_trust_workload_identity_manager/zero-trust-manager-components.adoc
+++ b/security/zero_trust_workload_identity_manager/zero-trust-manager-components.adoc
@@ -1,0 +1,25 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="zero-trust-manager-components"]
+= Zero Trust Workload Identity Manager components
+include::_attributes/common-attributes.adoc[]
+:context: zero-trust-manager-components
+
+toc::[]
+
+[role="_abstract"]
+Review the components available in {zero-trust-full} to understand the architecture. These components provide the foundation for identifying and securing your workloads.
+
+// about csi driver
+include::modules/zero-trust-manager-about-csi-driver.adoc[leveloffset=+1]
+
+// about oidc provider
+include::modules/zero-trust-manager-about-oidc-provider.adoc[leveloffset=+1]
+
+// about controller manager
+include::modules/zero-trust-manager-about-controller-manager.adoc[leveloffset=+1]
+
+// about telemetry
+include::modules/zero-trust-manager-server-agent-telemetry.adoc[leveloffset=+1]
+
+// about the workflow
+include::modules/zero-trust-manager-how-it-works.adoc[leveloffset=+1]

--- a/security/zero_trust_workload_identity_manager/zero-trust-manager-configuration.adoc
+++ b/security/zero_trust_workload_identity_manager/zero-trust-manager-configuration.adoc
@@ -5,25 +5,31 @@
 include::_attributes/common-attributes.adoc[]
 :context: zero-trust-manager-configuration
 
+
 toc::[]
 
-:FeatureName: {zero-trust-full}
-include::snippets/technology-preview.adoc[]
+[role="_abstract"]
+Deploy the {zero-trust-full} operands by creating their custom resources in a specific order. Adhering to the sequence ensures the successful installation of components, such as the SPIRE Server, SPIRE Agent, and SPIFFE CSI driver.
 
-You can deploy the following operands by creating the respective custom resources (CRs). You must deploy the operands in the following sequence to ensure successful installation.
+You must deploy the operands in the following sequence to ensure successful installation:
 
-. SPIRE Server
+* `ZeroTrustWorkloadIdentityManager` CR
 
-. SPIRE Agent
+* SPIRE Server
 
-. SPIFFE CSI driver
+* SPIRE Agent
 
-. SPIRE OIDC discovery provider
+* SPIFFE CSI driver
 
-// Deploying and configuring SPIRE server
+* SPIRE OIDC discovery provider
+
+// Deploying and configuring ZTWIM custom resource
+include::modules/zero-trust-manager-ztwim-cr.adoc[leveloffset=+1]
+
+// Deploying and configuring SPIRE Server
 include::modules/zero-trust-manager-spire-server-config.adoc[leveloffset=+1]
 
-// Deploying and configuring SPIRE agent
+// Deploying and configuring SPIRE Agent
 include::modules/zero-trust-manager-spire-agent-config.adoc[leveloffset=+1]
 
 // Deploying and configuring SPIFFE CSI Driver
@@ -31,3 +37,7 @@ include::modules/zero-trust-manager-spiffe-csidriver-config.adoc[leveloffset=+1]
 
 // Deploying and configuring OIDC Discovery Provider
 include::modules/zero-trust-manager-oidc-config.adoc[leveloffset=+1]
+
+
+// Deploying and configuring OIDC Discovery Provider
+include::modules/zero-trust-manager-verify-operands.adoc[leveloffset=+1]

--- a/security/zero_trust_workload_identity_manager/zero-trust-manager-overview.adoc
+++ b/security/zero_trust_workload_identity_manager/zero-trust-manager-overview.adoc
@@ -31,6 +31,3 @@ include::modules/zero-trust-manager-about-agent.adoc[leveloffset=+1]
 
 //Attestation
 include::modules/zero-trust-manager-about-attestation.adoc[leveloffset=+1]
-
-//How it works
-include::modules/zero-trust-manager-how-it-works.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s):
4.18

Issue:
https://redhat.atlassian.net/browse/OSDOCS-19410

Link to docs preview:
https://110828--ocpdocs-pr.netlify.app/
https://110828--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/zero_trust_workload_identity_manager/zero-trust-manager-overview.html


QE review:
- [ ] QE has approved this change.


Additional information:
The 4.18 documentation in this PR is a copy and paste from the most recent zero-trust documentation.

This PR contains the following assemblies:

- zero-trust-manager-components.adoc
- zero-trust-manager-configuration.adoc
- zero-trust-manager-overview.adoc

This is PR #1. This is related to the following PRs:

- https://github.com/openshift/openshift-docs/pull/110927
- https://github.com/openshift/openshift-docs/pull/110932
- https://github.com/openshift/openshift-docs/pull/110952
- https://github.com/openshift/openshift-docs/pull/110970
- https://github.com/openshift/openshift-docs/pull/110988

The PRs were put into smaller PRs instead of having one large PR. This makes it easier for the merge reviewers.

Reviewers: All PRs need to be merged. Thanks.