### PR TITLE
OSDOCS-19411: fixes supported endpoints RHCL observability

### DIFF
--- a/modules/proc-configure-obs-data-plane-tracing.adoc
+++ b/modules/proc-configure-obs-data-plane-tracing.adoc
@@ -69,7 +69,7 @@ spec:
 +
 [IMPORTANT]
 ====
-If you are setting the controller manually, you must set the OpenTelemetry Collector protocol in the `Service` CR port `name` and `appProtocol` fields. For example, when using gRPC, the port name should begin with `grpc-` or the `appProtocol` should be `grpc`:
+If you are setting the controller manually, you must set the OpenTelemetry protocol (OTLP) in the `Service` CR port `name` and `appProtocol` fields. For example, when using gRPC, the port name should begin with `grpc-` or the `appProtocol` should be `grpc`:
 [source,yaml]
 ----
 kind: Service
@@ -166,19 +166,16 @@ spec:
   observability:
     dataPlane:
       defaultLevels:
-        - debug: "true" # Enable DEBUG level trace filtering
+        - debug: "true"
       httpHeaderIdentifier: x-request-id
     tracing:
       defaultEndpoint: rpc://tempo.tempo.svc.cluster.local:4317
       insecure: true
 ----
 +
-where:
-+
-* `spec.observability.tracing.defaultEndpoint`:: The URL of the tracing collector backend. That is, the OpenTelemetry endpoint. The following are supported protocols:
-** `rpc://` for gRPC OTLP, port 4317
-** `http://` for HTTP OTLP, port 4318
-* ``spec.observability.tracing.insecure`:: Set to `true` to skip TLS certificate verification in development environments. Set to `false` for production environments.
+* `spec.observability.dataPlane.defaultLevels`: Set this value to enable trace filtering at the required level, for example `debug: "true"` for debug-level trace filtering.
+* `spec.observability.tracing.defaultEndpoint`: The URL of the tracing collector backend, such as the OTLP endpoint. Use `rpc://`, `gRPC OTLP`, `port 4317`, for full compatibility across all components.
+* `spec.observability.tracing.insecure`: Set to `true` to skip TLS certificate verification in development environments. Set to `false` for production environments.
 +
 [IMPORTANT]
 ====

--- a/modules/ref-obs-control-plane-tracing-env-variables.adoc
+++ b/modules/ref-obs-control-plane-tracing-env-variables.adoc
@@ -21,7 +21,8 @@ Control plane traces appear under the service name `kuadrant-operator` in the Gr
 
 - `rpc://host:port` → gRPC OTLP
 - Insecure: `http://host:port` → HTTP OTLP
-- Secure: `https://host:port` → HTTP OTLP
+- Secure: `https://host:port` → HTTPS OTLP
+
 |Tracing disabled
 
 |`OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`


### PR DESCRIPTION
Version(s):
rhcl-docs-1.4
rhcl-docs-1.3

Issue:
[OSDOCS-19411](https://redhat.atlassian.net/browse/OSDOCS-19411)

Link to docs preview:
https://110835--ocpdocs-pr.netlify.app/rhcl/latest/observability/observability.html#configure-obs-data-plane-tracing_rhcl-observability

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
