### PR TITLE
[RHACS] [Docs] ROX-34180: Add release notes for RHACS 4.10.2

### DIFF
--- a/modules/bug-fixes-in-version-4102.adoc
+++ b/modules/bug-fixes-in-version-4102.adoc
@@ -1,0 +1,51 @@
+// Module included in the following assemblies:
+//
+// * release_notes/410-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="bug-fixes_4102_{context}"]
+= Bug fixes in version 4.10.2
+
+[role="_abstract"]
+This release provides the following bug fixes:
+
+//ROX-34014
+* Before this update, label search filters did not work correctly in the {product-title-short} portal. When users entered free-form text filters, the system did not properly handle label searches requiring special formatting for exact matches and regex patterns. With this release, Red{nbsp}Hat has corrected label search handling to properly format queries with equals signs and regex modifiers. As a result, label searches now work correctly for both exact matches and regex patterns.
+
+//ROX-34000
+* Before this update, the documentation for Central exposure route reencrypt TLS certificate and key configuration requirements was unclear. Users attempting to configure these fields encountered Operator failures with the following error message:
++
+`FATAL ERROR: The reencrypt route must specify either both, certificate and key, or neither.`
++
+With this release, Red{nbsp}Hat has clarified the documentation to specify that users must configure the certificate and key fields together or omit both. As a result, users can now correctly configure reencrypt routes.
+
+//ROX-33977
+* Before this update, the system calculated image component risk scores but did not store them. With this release, Red{nbsp}Hat has corrected the issue. As a result, image component risk scores are now properly stored and displayed.
+
+//ROX-33941
+* With this release, Red{nbsp}Hat introduced performance optimizations with CVE fetching. As a result, image retrieval performance has improved.
+
+//ROX-33935
+* Before this update, the image component initialization process caused excessive memory usage in large deployments. With this release, Red{nbsp}Hat has optimized the initialization process. As a result, memory usage has decreased and out-of-memory risks have decreased.
+
+//ROX-33451
+* With this release, Red{nbsp}Hat made changes to the Operator reconciliation to improve performance and reduce resource usage.
+
+This release also addresses the following security vulnerabilities:
+
+//ROX-34144
+* Security vulnerability in OpenTelemetry components (link:https://access.redhat.com/security/cve/CVE-2026-24051[CVE-2026-24051])
+//ROX-34143
+* Security vulnerability in Docker components (link:https://access.redhat.com/security/cve/CVE-2025-15558[CVE-2025-15558])
+//ROX-34121
+* Kubelet, CRI-O, kube-apiserver: Denial of service via SPDY streaming code (link:https://access.redhat.com/security/cve/CVE-2026-35469[CVE-2026-35469])
+//ROX-34043, ROX-34041, ROX-34039, ROX-34038, ROX-34037, ROX-34036, ROX-34035, ROX-34034
+* `github.com/jackc/pgx`: Memory-safety vulnerability (link:https://access.redhat.com/security/cve/CVE-2026-33815[CVE-2026-33815], link:https://access.redhat.com/security/cve/CVE-2026-33816[CVE-2026-33816])
+//ROX-33987
+* Go JOSE: Denial of service via crafted JSON Web Encryption (JWE) object (link:https://access.redhat.com/security/cve/CVE-2026-34986[CVE-2026-34986])
+//ROX-33812
+* gRPC-Go: Authorization bypass due to improper HTTP/2 path validation (link:https://access.redhat.com/security/cve/CVE-2026-33186[CVE-2026-33186])
+//ROX-33773
+* Immutable.js: Improperly controlled modification of object prototype attributes (prototype pollution) in immutable (link:https://access.redhat.com/security/cve/CVE-2026-29063[CVE-2026-29063])
+//ROX-32832
+* lodash: Prototype pollution in `+++_.unset+++` and `+++_.omit+++` functions (link:https://access.redhat.com/security/cve/CVE-2025-13465[CVE-2025-13465])

--- a/modules/common-attributes.adoc
+++ b/modules/common-attributes.adoc
@@ -64,9 +64,10 @@ endif::[]
 :product-registry: OpenShift image registry
 :olm-first: Operator Lifecycle Manager (OLM)
 :olm: OLM
-:rhacs-version: 4.10.1
+:rhacs-version: 4.10.2
 :ga-date-410: 3 March 2026
 :ga-date-4101: 8 April 2026
+:ga-date-4102: 4 May 2026
 :ocp-supported-version: 4.12
 :ocp-latest-version: 4.21
 :pipelines-shortname: OpenShift Pipelines

--- a/modules/release-dates-410.adoc
+++ b/modules/release-dates-410.adoc
@@ -17,5 +17,6 @@ Review the official release dates and update schedule for {product-title-short} 
 
 |`4.10.0` | {ga-date-410}
 |`4.10.1` | {ga-date-4101}
+|`4.10.2` | {ga-date-4102}
 
 |====

--- a/release_notes/410-release-notes.adoc
+++ b/release_notes/410-release-notes.adoc
@@ -81,6 +81,8 @@ include::modules/bug-fixes-in-version-410.adoc[leveloffset=+1]
 
 include::modules/bug-fixes-in-version-4101.adoc[leveloffset=+1]
 
+include::modules/bug-fixes-in-version-4102.adoc[leveloffset=+1]
+
 include::modules/known-issues-in-version-4101.adoc[leveloffset=+1]
 
 include::modules/image-versions.adoc[leveloffset=+1]


### PR DESCRIPTION
## Summary
This PR adds patch release notes for Red Hat Advanced Cluster Security for Kubernetes (RHACS) version 4.10.2, scheduled for GA on 27 April 2026.

## Changes
- Created `modules/bug-fixes-in-version-4102.adoc` with release notes content
- Updated `modules/common-attributes.adoc` with version 4.10.2 and GA date
- Added include directive in `release_notes/410-release-notes.adoc`

## 🔗 Netlify Preview Links

**Main Release Notes Page:**
https://110840--ocpdocs-pr.netlify.app/openshift-acs/latest/release_notes/410-release-notes

**Direct Link to Bug Fixes 4.10.2 Section:**
https://110840--ocpdocs-pr.netlify.app/openshift-acs/latest/release_notes/410-release-notes#bug-fixes_4102_release-notes-410

---

## Issues Documented

### Bug Fixes (6 issues)
- **ROX-34014**: Label search filters do not work correctly via UI
- **ROX-34000**: DOCS: Clarify reencrypt route TLS certificate and key configuration requirements
- **ROX-33977**: Image Component Risk Score is not persisted
- **ROX-33941**: Image store CVE fetching uses N+1 query pattern causing slow image retrieval
- **ROX-33935**: Optimize image component ranker initialization to avoid excessive memory usage
- **ROX-33451**: Prevent unnecessary reconciliations in operator

### Security Vulnerabilities (9 CVEs)
- CVE-2026-24051: Security vulnerability in OpenTelemetry components
- CVE-2025-15558: Security vulnerability in Docker components
- CVE-2026-35469: Kubelet, CRI-O, kube-apiserver - Denial of service via SPDY streaming code
- CVE-2026-33815: github.com/jackc/pgx - Memory-safety vulnerability
- CVE-2026-33816: github.com/jackc/pgx - Memory-safety vulnerability
- CVE-2026-34986: Go JOSE - Denial of service via crafted JSON Web Encryption (JWE) object
- CVE-2026-33186: gRPC-Go - Authorization bypass due to improper HTTP/2 path validation
- CVE-2026-29063: Immutable.js - Prototype pollution vulnerability
- CVE-2025-13465: Prototype pollution in _.unset and _.omit functions

---

**Version:** 4.10.2  
**GA Date:** 27 April 2026  
**Issue:** https://redhat.atlassian.net/browse/ROX-34180  
**Jira Board:** https://redhat.atlassian.net/projects/ROX/versions/104472/tab/release-report-all-issues

**QE review:**
- [ ] QE has approved this change.