### PR TITLE
TELCODOCS-2483: Support T-GM for NAC of Intel GNR-D platform

### DIFF
--- a/modules/nw-ptp-configuring-linuxptp-services-as-grandmaster-clock-gnrd.adoc
+++ b/modules/nw-ptp-configuring-linuxptp-services-as-grandmaster-clock-gnrd.adoc
@@ -1,0 +1,77 @@
+// Module included in the following assemblies:
+//
+// * networking/advanced_networking/ptp/configuring-ptp.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="configuring-linuxptp-services-as-grandmaster-clock-gnrd_{context}"]
+= Configuring linuxptp services as a Telecom Grandmaster clock on Intel Granite Rapids-D hardware
+
+[role="_abstract"]
+Use this procedure to configure the `linuxptp` services (`ptp4l`, `phc2sys`, `ts2phc`) as a Telecom Grandmaster (T-GM) on Intel Granite Rapids-D (GNR-D) hardware that uses onboard Network Acceleration Complex (NAC) ports and optional Carter Flat expansion network interface cards (NICs).
+In this deployment, GNSS input disciplines the platform clock and the example `PtpConfig` CR uses the `e830` and `e825` plugins for onboard NAC and optional Carter Flat ports.
+
+:FeatureName: Telecom Grandmaster clock configuration on Intel Granite Rapids-D (GNR-D) hardware
+include::snippets/technology-preview.adoc[]
+
+.Prerequisites
+
+* You have verified your qualified GNR-D hardware layout, including NAC ports, Carter Flat ports, and interface naming.
+
+* The {oc-first} is installed.
+
+* You are logged in as a user with `cluster-admin` privileges.
+
+* The PTP Operator is installed.
+
+* You have verified that interface names, GNSS serial paths, and plugin device entries are aligned with your qualified hardware layout.
+
+.Procedure
+
+. Create a `PtpConfig` custom resource (CR) that matches your qualified GNR-D Telecom Grandmaster hardware layout:
++
+[source,yaml]
+----
+include::snippets/ptp_PtpConfigGnrdTGM.yaml[]
+----
++
+where:
+
+* `eno8703` -- Specifies the example leading NAC interface name used in `phc2sysOpts`, `plugins.e825.devices`, and the primary `ts2phcConf` stanza. Replace this value with the NAC interface name from your qualified GNR-D hardware layout.
+* `enp108s0f0` and `enp110s0f0` -- Specify the example Carter Flat (E830) interface names listed in `plugins.e830.devices` and used as Carter Flat `ts2phcConf` stanzas. Replace these values with your Carter Flat interface names. Add or remove stanzas and `plugins` entries if you install fewer than two expansion cards.
+* `enp108s0f1` through `enp108s0f7` and `enp110s0f1` through `enp110s0f7` -- Specify additional example time transmitter interfaces on the two Carter Flat cards as `masterOnly 1` ports in `ptp4lConf`. Align or remove these stanzas to match your port count and naming.
+* `eno8403`, `eno8503`, `eno8603`, `eno8703`, `eno8803`, `eno8903`, and `eno9003` -- Specify example onboard NAC time transmitter interfaces as `masterOnly 1` ports in `ptp4lConf`. Replace these values with your NAC port names. Remove stanzas you do not use.
+
+. Customize interface names, the `plugins` device list, `ts2phcConf`, `ptp4lConf`, and the `recommend` stanza in the preceding example to match your qualified hardware layout.
+
+. Add or remove Carter Flat interface blocks in `ts2phcConf` and `ptp4lConf` to match the number of expansion cards on your server.
+
+. In the `recommend` stanza, replace the `$mcp` placeholder with the machine config pool label for the nodes that run this PTP profile, for example, `worker`.
+
+. Save the customized `PtpConfig` CR as `gnrd-grandmaster-clock-ptp-config.yaml`.
+
+. Verify that the `plugins` stanza lists the `e830` and `e825` device entries your qualified hardware layout requires.
+
+. Apply the `PtpConfig` CR by running the following command:
++
+[source,terminal]
+----
+$ oc apply -f gnrd-grandmaster-clock-ptp-config.yaml
+----
+
+.Verification
+
+. Verify that the `PtpConfig` profile is applied:
+
+.. Retrieve the pods in the `openshift-ptp` namespace by running the following command:
++
+[source,terminal]
+----
+$ oc get pods -n openshift-ptp -o wide
+----
+
+.. Review `linuxptp` daemon logs for the pod on your Granite Rapids-D node by running the following command, replacing `<linuxptp_daemon_pod>` with the pod name that is scheduled on your target node:
++
+[source,terminal]
+----
+$ oc logs <linuxptp_daemon_pod> -n openshift-ptp -c linuxptp-daemon-container
+----

--- a/modules/nw-ptp-configuring-linuxptp-services-as-grandmaster-clock-gnrd.adoc
+++ b/modules/nw-ptp-configuring-linuxptp-services-as-grandmaster-clock-gnrd.adoc
@@ -1,0 +1,75 @@
+// Module included in the following assemblies:
+//
+// * networking/advanced_networking/ptp/configuring-ptp.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="configuring-linuxptp-services-as-grandmaster-clock-gnrd_{context}"]
+= Configuring linuxptp services as a Telecom Grandmaster clock on Intel Granite Rapids-D hardware
+
+[role="_abstract"]
+Use this procedure after Zero Touch Provisioning (ZTP) completes for your far-edge distributed unit (DU) cluster when you must apply a Telecom Grandmaster (T-GM) `PtpConfig` custom resource (CR) that matches Intel Granite Rapids-D (GNR-D) onboard Network Acceleration Complex (NAC) ports and optional Carter Flat expansion cards.
+The following example `PtpConfig` CR matches the shipping telco-reference manifest; you must customize interface names, plugin device lists, and the `recommend` stanza for your site before you apply the file.
+
+:FeatureName: Telecom Grandmaster clock configuration on Intel Granite Rapids-D (GNR-D) hardware
+include::snippets/technology-preview.adoc[]
+
+.Prerequisites
+
+* The ZTP deployment for your far-edge DU site is complete, including the GNR-D interface renaming MachineConfig manifest `10-rename-gnrd-interfaces-master.yaml` from your RAN profile so onboard and Carter Flat interfaces keep distinct prefixes.
+
+* The {oc-first} is installed.
+
+* You are logged in as a user with `cluster-admin` privileges.
+
+* The PTP Operator is installed.
+
+* Interface names, GNSS serial paths, and plugin device entries are aligned with the qualification package for your server model.
+
+The following example `PtpConfig` CR matches the shipping `PtpConfigGnrdTGM.yaml` manifest in the openshift-kni/telco-reference repository.
+The same content is maintained in this repository as `snippets/ptp_PtpConfigGnrdTGM.yaml` so documentation stays aligned with the upstream source.
+The YAML listing shows an example Telecom Grandmaster `PtpConfig` CR.
+
+[source,yaml]
+----
+include::snippets/ptp_PtpConfigGnrdTGM.yaml[]
+----
+
+where:
+
+* `eno8703` -- Specifies the example leading NAC interface name used in `phc2sysOpts`, `plugins.e825.devices`, and the primary `ts2phcConf` stanza; replace with the NAC interface name from your site bill of materials.
+* `enp108s0f0` and `enp110s0f0` -- Specify the example Carter Flat (E830) interface names listed in `plugins.e830.devices` and used as Carter Flat `ts2phcConf` stanzas; replace with your Carter Flat interface names (add or remove stanzas and `plugins` entries if you install fewer than two expansion cards).
+* `enp108s0f1` through `enp108s0f7` and `enp110s0f1` through `enp110s0f7` -- Specify additional example time transmitter interfaces on the two Carter Flat cards as `masterOnly 1` ports in `ptp4lConf`; align or remove these stanzas with your port count and naming.
+* `eno8403`, `eno8503`, `eno8603`, `eno8703`, `eno8803`, `eno8903`, and `eno9003` -- Specify example onboard NAC time transmitter interfaces as `masterOnly 1` ports in `ptp4lConf`; replace with your NAC port names and remove stanzas you do not use.
+
+Customize every interface name, `plugins` device list, `ts2phcConf`, `ptp4lConf`, and `recommend` stanza so they match your site qualification package before you apply the manifest to the cluster.
+On current Intel Granite Rapids-D platforms, a server can ship with zero, one, or two Carter Flat expansion cards; add or remove the Carter Flat interface blocks in `ts2phcConf` and `ptp4lConf` so they match your bill of materials (the example reflects two cards).
+Replace the `$mcp` placeholder in the `recommend` stanza with the machine config pool label that selects your distributed unit (DU) nodes (for example, `worker`).
+
+.Procedure
+
+. Customize the preceding example `PtpConfig` CR for your site and save the manifest to `gnrd-grandmaster-clock-ptp-config.yaml` on your workstation. Ensure the `plugins` stanza lists the `e830` and `e825` device entries your qualified layout requires so that `linuxptp` can start with the expected configuration after you apply the manifest.
+
+. Apply the manifest by running the following command, replacing `gnrd-grandmaster-clock-ptp-config.yaml` with the path to the customized `PtpConfig` manifest that you saved:
++
+[source,terminal]
+----
+$ oc apply -f gnrd-grandmaster-clock-ptp-config.yaml
+----
+
+.Verification
+
+. Confirm that the `PtpConfig` profile is applied to the node.
+
+.. Retrieve the pods in the `openshift-ptp` namespace by running the following command:
++
+[source,terminal]
+----
+$ oc get pods -n openshift-ptp -o wide
+----
+
+.. Examine the logs for the `linuxptp` daemon pod that schedules on your Granite Rapids-D node by running the following command, replacing `<linuxptp_daemon_pod>` with the pod name that is bound to your worker node:
++
+[source,terminal]
+----
+$ oc logs <linuxptp_daemon_pod> -n openshift-ptp -c linuxptp-daemon-container
+----

--- a/modules/nw-ptp-granite-rapids-telecom-grandmaster-clock-overview.adoc
+++ b/modules/nw-ptp-granite-rapids-telecom-grandmaster-clock-overview.adoc
@@ -1,0 +1,41 @@
+// Module included in the following assemblies:
+//
+// * networking/advanced_networking/ptp/configuring-ptp.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="nw-ptp-granite-rapids-telecom-grandmaster-clock-overview_{context}"]
+= Telecom Grandmaster clocks on Intel Granite Rapids-D hardware
+
+[role="_abstract"]
+Intel Granite Rapids-D (GNR-D) server platforms support Telecom Grandmaster (T-GM) clock deployments that use onboard Network Acceleration Complex (NAC) ports and optional Carter Flat expansion network interface cards (NICs) to share timing across a single GNSS feed.
+Before you configure a T-GM profile on GNR-D hardware, verify that your qualified hardware layout, cabling, port counts, and interface naming align with your deployment requirements.
+The associated procedure provides an example `PtpConfig` CR, `linuxptp` plugin expectations, and verification steps for Granite Rapids-D nodes.
+
+In addition to Telecom Grandmaster configurations, Intel Granite Rapids-D (GNR-D) hardware supports a Precision Time Protocol (PTP) boundary clock profile without holdover.
+For more information about boundary clock configuration on GNR-D hardware, see the Additional resources section.
+
+:FeatureName: Telecom Grandmaster clocks on Intel Granite Rapids-D hardware
+include::snippets/technology-preview.adoc[]
+
+[NOTE]
+====
+Follower digital phase-locked loop (DPLL) behavior on GNR-D add-on network interface cards (NICs) such as Carter Flat cards is only partially visible through the Intel NIC driver: you can read high-level follower DPLL lock state (locked or not locked).
+Intel does not plan to add interfaces that expose further follower DPLL lock accuracy in software or firmware.
+
+The PTP Operator can surface follower DPLL lock state when the Intel NIC driver exposes it, but it cannot report additional follower DPLL accuracy metrics or diagnose follower DPLL problems on add-on NICs beyond that driver data.
+Resolution of complex follower DPLL problems might require on-site hardware access and coordination with Intel rather than diagnosis inside {product-title}.
+====
+
+[id="nw-ptp-granite-rapids-telecom-grandmaster-clock-overview-physical_{context}"]
+Physical architecture and timing paths::
+
+GNSS receivers attach to the shared timing module on supported GNR-D systems so one antenna feed can discipline multiple time transmitters across NAC and Carter Flat ports.
+Compared with earlier Intel E810 Westport Channel layouts that relied on faceplate jumpers between cards, GNR-D routes synchronization between cards by using proprietary PCIe wiring instead of external jumper cables, which supports up to 24 time transmitter ports in the same server footprint when you combine onboard ports with two expansion cards.
+
+On current Intel Granite Rapids-D platforms, a server can ship with zero, one, or two Carter Flat expansion cards. The example `PtpConfig` CR in the associated procedure reflects two cards.
+
+[id="nw-ptp-granite-rapids-telecom-grandmaster-clock-overview-interfaces_{context}"]
+Interface naming and the GNR-D MachineConfig::
+
+Onboard NAC ports and Carter Flat ports can appear in the same kernel namespace, which makes Precision Time Protocol (PTP) metrics ambiguous unless interfaces are renamed with distinct prefixes.
+A common layout applies the MachineConfig manifest `10-rename-gnrd-interfaces-master.yaml` so each card presents a unique interface prefix before you apply a Telecom Grandmaster `PtpConfig` CR.

--- a/modules/nw-ptp-granite-rapids-telecom-grandmaster-clock-overview.adoc
+++ b/modules/nw-ptp-granite-rapids-telecom-grandmaster-clock-overview.adoc
@@ -1,0 +1,39 @@
+// Module included in the following assemblies:
+//
+// * networking/advanced_networking/ptp/configuring-ptp.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="nw-ptp-granite-rapids-telecom-grandmaster-clock-overview_{context}"]
+= Telecom Grandmaster clocks on Intel Granite Rapids-D hardware
+
+[role="_abstract"]
+Intel Granite Rapids-D (GNR-D) server platforms target high-density Radio Access Network (RAN) sites where onboard Network Acceleration Complex (NAC) ports and optional Carter Flat expansion network interface cards (NICs) share timing across a single GNSS feed.
+After you deploy {product-title} with Zero Touch Provisioning (ZTP) for distributed unit (DU) workloads, align Telecom Grandmaster (T-GM) clock configuration with GNR-D cabling, port counts, and interface naming before you customize the example `PtpConfig` custom resource (CR).
+The associated procedure provides the example `PtpConfig` manifest, operator expectations, and verification steps for your Granite Rapids-D nodes.
+
+In addition to Telecom Grandmaster configurations, Intel Granite Rapids-D (GNR-D) hardware supports a Precision Time Protocol (PTP) boundary clock profile without holdover.
+For more information about boundary clock configuration on GNR-D hardware, see the Additional resources section.
+
+:FeatureName: Telecom Grandmaster clocks on Intel Granite Rapids-D hardware
+include::snippets/technology-preview.adoc[]
+
+[NOTE]
+====
+Follower digital phase-locked loop (DPLL) behavior on GNR-D add-on network interface cards (NICs) such as Carter Flat cards is only partially visible through the Intel NIC driver: you can read high-level follower DPLL lock state (locked or not locked).
+Intel does not plan to add interfaces that expose further follower DPLL lock accuracy in software or firmware.
+
+Red Hat tools therefore cannot report follower DPLL metrics beyond that lock state or troubleshoot follower DPLL issues on add-on NICs beyond what the driver exposes.
+Resolution of complex follower DPLL problems might require on-site hardware access and coordination with Intel rather than diagnosis inside {product-title}.
+====
+
+[id="nw-ptp-granite-rapids-telecom-grandmaster-clock-overview-physical_{context}"]
+== Physical architecture and timing paths
+
+GNSS receivers attach to the shared timing module on supported GNR-D systems so one antenna feed can discipline multiple time transmitters across NAC and Carter Flat ports.
+Compared with earlier Intel E810 Westport Channel layouts that relied on faceplate jumpers between cards, GNR-D routes synchronization between cards by using proprietary PCIe wiring instead of external jumper cables, which supports up to 24 time transmitter ports in the same server footprint when you combine onboard ports with two expansion cards.
+
+[id="nw-ptp-granite-rapids-telecom-grandmaster-clock-overview-interfaces_{context}"]
+== Interface naming and the GNR-D MachineConfig
+
+Onboard NAC ports and Carter Flat ports can appear in the same kernel namespace, which makes Precision Time Protocol (PTP) metrics ambiguous unless interfaces are renamed with distinct prefixes.
+The recommended Zero Touch Provisioning (ZTP) RAN profile includes the MachineConfig manifest `10-rename-gnrd-interfaces-master.yaml` so each card presents a unique interface prefix before you apply a Telecom Grandmaster `PtpConfig` CR.

--- a/modules/ztp-sno-du-configuring-ptp.adoc
+++ b/modules/ztp-sno-du-configuring-ptp.adoc
@@ -6,9 +6,10 @@
 [id="ztp-sno-du-configuring-ptp_{context}"]
 = PTP
 
+[role="_abstract"]
 {sno-caps} clusters use Precision Time Protocol (PTP) for network time synchronization.
-The following example `PtpConfig` CRs illustrate the required PTP configurations for ordinary clocks, boundary clocks, and grandmaster clocks.
-The exact configuration you apply will depend on the node hardware and specific use case.
+The following example `PtpConfig` custom resources (CRs) illustrate configurations for ordinary clocks, boundary clocks, and Telecom Grandmaster clocks on supported Intel Ethernet hardware.
+You must select the profile that matches your qualified GNR-D hardware layout and complete interface renaming prerequisites before you apply Granite Rapids-D Telecom Grandmaster YAML on Intel Granite Rapids-D servers.
 
 .Recommended PTP ordinary clock configuration (`PtpConfigSlave.yaml`)
 [source,yaml]
@@ -29,6 +30,16 @@ include::snippets/ztp_PtpConfigBoundary.yaml[]
 include::snippets/ztp_PtpConfigGmWpc.yaml[]
 ----
 
+:FeatureName: Telecom Grandmaster clock configuration on Intel Granite Rapids-D (GNR-D) hardware
+include::snippets/technology-preview.adoc[]
+:!FeatureName:
+
+.Recommended PTP Granite Rapids-D Telecom Grandmaster clock configuration (`PtpConfigGnrdTGM.yaml`)
+[source,yaml]
+----
+include::snippets/ptp_PtpConfigGnrdTGM.yaml[]
+----
+
 The following optional `PtpOperatorConfig` CR configures PTP events reporting for the node.
 
 .Recommended PTP events configuration (`PtpOperatorConfigForEvent.yaml`)
@@ -36,3 +47,8 @@ The following optional `PtpOperatorConfig` CR configures PTP events reporting fo
 ----
 include::snippets/ztp_PtpOperatorConfigForEvent.yaml[]
 ----
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../networking/advanced_networking/ptp/configuring-ptp.adoc#configuring-linuxptp-services-as-grandmaster-clock-gnrd_configuring-ptp[Configuring linuxptp services as a Telecom Grandmaster clock on Intel Granite Rapids-D hardware]

--- a/modules/ztp-sno-du-configuring-ptp.adoc
+++ b/modules/ztp-sno-du-configuring-ptp.adoc
@@ -6,9 +6,10 @@
 [id="ztp-sno-du-configuring-ptp_{context}"]
 = PTP
 
+[role="_abstract"]
 {sno-caps} clusters use Precision Time Protocol (PTP) for network time synchronization.
-The following example `PtpConfig` CRs illustrate the required PTP configurations for ordinary clocks, boundary clocks, and grandmaster clocks.
-The exact configuration you apply will depend on the node hardware and specific use case.
+The following example `PtpConfig` custom resources (CRs) illustrate configurations for ordinary clocks, boundary clocks, and Telecom Grandmaster clocks on supported Intel Ethernet hardware.
+You must select the profile that matches your bill of materials and complete interface renaming prerequisites before you apply Granite Rapids-D Telecom Grandmaster YAML on Intel Granite Rapids-D servers.
 
 .Recommended PTP ordinary clock configuration (`PtpConfigSlave.yaml`)
 [source,yaml]
@@ -29,6 +30,16 @@ include::snippets/ztp_PtpConfigBoundary.yaml[]
 include::snippets/ztp_PtpConfigGmWpc.yaml[]
 ----
 
+:FeatureName: Telecom Grandmaster clock configuration on Intel Granite Rapids-D (GNR-D) hardware
+include::snippets/technology-preview.adoc[]
+:!FeatureName:
+
+.Recommended PTP Granite Rapids-D Telecom Grandmaster clock configuration (`PtpConfigGnrdTGM.yaml`)
+[source,yaml]
+----
+include::snippets/ptp_PtpConfigGnrdTGM.yaml[]
+----
+
 The following optional `PtpOperatorConfig` CR configures PTP events reporting for the node.
 
 .Recommended PTP events configuration (`PtpOperatorConfigForEvent.yaml`)
@@ -36,3 +47,8 @@ The following optional `PtpOperatorConfig` CR configures PTP events reporting fo
 ----
 include::snippets/ztp_PtpOperatorConfigForEvent.yaml[]
 ----
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../networking/advanced_networking/ptp/configuring-ptp.adoc#configuring-linuxptp-services-as-grandmaster-clock-gnrd_configuring-ptp[Configuring linuxptp services as a Telecom Grandmaster clock on Intel Granite Rapids-D hardware]

--- a/networking/advanced_networking/ptp/configuring-ptp.adoc
+++ b/networking/advanced_networking/ptp/configuring-ptp.adoc
@@ -15,7 +15,7 @@ Network interface controller (NIC) hardware with built-in PTP capabilities somet
 
 [IMPORTANT]
 ====
-In {product-title} {product-version}, the Intel E810 NIC is supported with a `PtpConfig` plugin.
+In {product-title} {product-version}, supported `PtpConfig` plugins include Intel E810 hardware configuration, Intel Granite Rapids-D plugin configurations (`e830` and `e825`), and optional `ntpfailover` behavior.
 ====
 
 include::modules/nw-ptp-installing-operator-cli.adoc[leveloffset=+1]
@@ -30,10 +30,25 @@ include::modules/nw-ptp-configuring-linuxptp-services-as-grandmaster-clock-dual-
 
 include::modules/nw-ptp-configuring-linuxptp-services-as-grandmaster-clock-three-nic.adoc[leveloffset=+2]
 
+include::modules/nw-ptp-granite-rapids-telecom-grandmaster-clock-overview.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../../networking/advanced_networking/ptp/configuring-ptp.adoc#nw-ptp-granite-rapids-boundary-clock-overview_configuring-ptp[Boundary clocks without holdover on Intel Granite Rapids-D hardware]
+* xref:../../../networking/advanced_networking/ptp/configuring-ptp.adoc#ptp-configuring-linuxptp-services-as-boundary-clock-gnrd_configuring-ptp[Configuring linuxptp services as a boundary clock without holdover on Intel Granite Rapids-D hardware]
+* xref:../../../networking/advanced_networking/ptp/configuring-ptp.adoc#nw-ptp-gnrd-t-bc-holdover_configuring-ptp[Configuring GNR-D T-BC holdover on a GNR-D platform]
+
+
+include::modules/nw-ptp-configuring-linuxptp-services-as-grandmaster-clock-gnrd.adoc[leveloffset=+2]
+
 [role="_additional-resources"]
 .Additional resources
 
 * xref:../../../networking/advanced_networking/ptp/ptp-cloud-events-consumer-dev-reference-v2.adoc#cnf-configuring-the-ptp-fast-event-publisher-v2_ptp-consumer[Configuring the PTP fast event notifications publisher]
+* xref:../../../networking/advanced_networking/ptp/configuring-ptp.adoc#nw-ptp-granite-rapids-boundary-clock-overview_configuring-ptp[Boundary clocks without holdover on Intel Granite Rapids-D hardware]
+* xref:../../../networking/advanced_networking/ptp/configuring-ptp.adoc#ptp-configuring-linuxptp-services-as-boundary-clock-gnrd_configuring-ptp[Configuring linuxptp services as a boundary clock without holdover on Intel Granite Rapids-D hardware]
+* xref:../../../networking/advanced_networking/ptp/configuring-ptp.adoc#nw-ptp-gnrd-t-bc-holdover_configuring-ptp[Configuring GNR-D T-BC holdover on a GNR-D platform]
 
 include::modules/nw-ptp-grandmaster-clock-configuration-reference.adoc[leveloffset=+1]
 

--- a/networking/advanced_networking/ptp/configuring-ptp.adoc
+++ b/networking/advanced_networking/ptp/configuring-ptp.adoc
@@ -15,7 +15,7 @@ Network interface controller (NIC) hardware with built-in PTP capabilities somet
 
 [IMPORTANT]
 ====
-In {product-title} {product-version}, the Intel E810 NIC is supported with a `PtpConfig` plugin.
+In {product-title} {product-version}, supported `PtpConfig` plugins include Intel E810 hardware configuration, Intel Granite Rapids-D plugin configurations (`e830` and `e825`), and optional `ntpfailover` behavior.
 ====
 
 include::modules/nw-ptp-installing-operator-cli.adoc[leveloffset=+1]
@@ -30,10 +30,18 @@ include::modules/nw-ptp-configuring-linuxptp-services-as-grandmaster-clock-dual-
 
 include::modules/nw-ptp-configuring-linuxptp-services-as-grandmaster-clock-three-nic.adoc[leveloffset=+2]
 
+include::modules/nw-ptp-granite-rapids-telecom-grandmaster-clock-overview.adoc[leveloffset=+2]
+
+include::modules/nw-ptp-configuring-linuxptp-services-as-grandmaster-clock-gnrd.adoc[leveloffset=+2]
+
 [role="_additional-resources"]
 .Additional resources
 
 * xref:../../../networking/advanced_networking/ptp/ptp-cloud-events-consumer-dev-reference-v2.adoc#cnf-configuring-the-ptp-fast-event-publisher-v2_ptp-consumer[Configuring the PTP fast event notifications publisher]
+// Reinstate when `ptp-configuring-ptp-boundary-clocks.adoc` is included in the openshift-enterprise distro (for example, after the boundary-clock docs merge).
+//* xref:../../../networking/advanced_networking/ptp/ptp-configuring-ptp-boundary-clocks.adoc#gnrd-boundary-clock-without-holdover_ptp-configuring-ptp-boundary-clocks[GNR-D boundary clock without holdover]
+//* xref:../../../networking/advanced_networking/ptp/ptp-configuring-ptp-boundary-clocks.adoc#configuring-a-gnrd-boundary-clock-without-holdover_ptp-configuring-ptp-boundary-clocks[Configuring a GNR-D boundary clock without holdover]
+//* xref:../../../networking/advanced_networking/ptp/ptp-configuring-ptp-boundary-clocks.adoc#checking-synchronization-state-on-carter-flats-devices_ptp-configuring-ptp-boundary-clocks[Checking synchronization state on Carter Flats devices]
 
 include::modules/nw-ptp-grandmaster-clock-configuration-reference.adoc[leveloffset=+1]
 

--- a/snippets/ptp_PtpConfigGnrdTGM.yaml
+++ b/snippets/ptp_PtpConfigGnrdTGM.yaml
@@ -1,0 +1,276 @@
+# Example Telecom Grandmaster PtpConfig for Intel Granite Rapids-D (GNR-D).
+#
+# Note:  This example configuration should be customized to match the desired
+# configuration For this GNR-D T-GM configuration, we support GNSS incoming to
+# the onboard connection, and up to 24 Time Transmitter ports including any NAC
+# ports and any additional Carter Flats ports.
+apiVersion: ptp.openshift.io/v1
+kind: PtpConfig
+metadata:
+  name: gnrd-tgm
+  namespace: openshift-ptp
+  annotations:
+    ran.openshift.io/ztp-deploy-wave: "10"
+spec:
+  profile:
+    - name: "grandmaster"
+      ptp4lOpts: "-2 --summary_interval -4"
+      phc2sysOpts: -r -u 0 -m -w -N 8 -R 16 -n 24 -s eno8703
+      ptpSchedulingPolicy: SCHED_FIFO
+      ptpSchedulingPriority: 10
+      ptpSettings:
+        logReduce: "true"
+      plugins:
+        e830:
+          devices:
+            - enp108s0f0
+            - enp110s0f0
+        e825:
+          devices:
+            - eno8703
+          settings:
+            LocalMaxHoldoverOffSet: 1500
+            LocalHoldoverTimeout: 14400
+            MaxInSpecOffset: 100
+          ublxCmds:
+            - args: #ubxtool -P 29.25 -z CFG-HW-ANT_CFG_VOLTCTRL,1
+                - "-P"
+                - "29.25"
+                - "-z"
+                - "CFG-HW-ANT_CFG_VOLTCTRL,1"
+              reportOutput: false
+            - args: #ubxtool -P 29.25 -e GPS
+                - "-P"
+                - "29.25"
+                - "-e"
+                - "GPS"
+              reportOutput: false
+            - args: #ubxtool -P 29.25 -d Galileo
+                - "-P"
+                - "29.25"
+                - "-d"
+                - "Galileo"
+              reportOutput: false
+            - args: #ubxtool -P 29.25 -d GLONASS
+                - "-P"
+                - "29.25"
+                - "-d"
+                - "GLONASS"
+              reportOutput: false
+            - args: #ubxtool -P 29.25 -d BeiDou
+                - "-P"
+                - "29.25"
+                - "-d"
+                - "BeiDou"
+              reportOutput: false
+            - args: #ubxtool -P 29.25 -d SBAS
+                - "-P"
+                - "29.25"
+                - "-d"
+                - "SBAS"
+              reportOutput: false
+            - args: #ubxtool -P 29.25 -t -w 5 -v 1 -e SURVEYIN,600,50000
+                - "-P"
+                - "29.25"
+                - "-t"
+                - "-w"
+                - "5"
+                - "-v"
+                - "1"
+                - "-e"
+                - "SURVEYIN,600,50000"
+              reportOutput: true
+            - args: #ubxtool -P 29.25 -p MON-HW
+                - "-P"
+                - "29.25"
+                - "-p"
+                - "MON-HW"
+              reportOutput: true
+            - args: #ubxtool -P 29.25 -p CFG-MSG,1,38,300
+                - "-P"
+                - "29.25"
+                - "-p"
+                - "CFG-MSG,1,38,248"
+              reportOutput: true    
+      ts2phcOpts: "-m"
+      ts2phcConf: |
+        [nmea]
+        ts2phc.master 1
+        [global]
+        use_syslog  0
+        verbose 1
+        logging_level 7
+        ts2phc.pulsewidth 100000000
+        ts2phc.nmea_serialport /dev/ttyACM0 
+        [eno8703]
+        ts2phc.extts_polarity rising
+        ts2phc.extts_correction 0
+        ts2phc.master  0
+        ts2phc.channel 0
+        ts2phc.pin_index 1
+        # This should be one section per Carter Flats (e830) card:
+        [enp108s0f0]
+        ts2phc.extts_polarity rising
+        ts2phc.extts_correction 0
+        ts2phc.master 0
+        ts2phc.channel 0
+        ts2phc.pin_index 1
+        [enp110s0f0]
+        ts2phc.extts_polarity rising
+        ts2phc.extts_correction 0
+        ts2phc.master 0
+        ts2phc.channel 0
+        ts2phc.pin_index 1
+      ptp4lConf: |
+        # All TimeTransmitter ports should be outlined here with 'masterOnly 1'
+        #[eno8303]
+        # ** Host management interface
+        [eno8403]
+        masterOnly 1
+        [eno8503]
+        masterOnly 1
+        [eno8603]
+        masterOnly 1
+        [eno8703]
+        masterOnly 1
+        [eno8803]
+        masterOnly 1
+        [eno8903]
+        masterOnly 1
+        [eno9003]
+        masterOnly 1
+        [enp108s0f0]
+        masterOnly 1
+        [enp108s0f1]
+        masterOnly 1
+        [enp108s0f2]
+        masterOnly 1
+        [enp108s0f3]
+        masterOnly 1
+        [enp108s0f4]
+        masterOnly 1
+        [enp108s0f5]
+        masterOnly 1
+        [enp108s0f6]
+        masterOnly 1
+        [enp108s0f7]
+        masterOnly 1
+        [enp110s0f0]
+        masterOnly 1
+        [enp110s0f1]
+        masterOnly 1
+        [enp110s0f2]
+        masterOnly 1
+        [enp110s0f3]
+        masterOnly 1
+        [enp110s0f4]
+        masterOnly 1
+        [enp110s0f5]
+        masterOnly 1
+        [enp110s0f6]
+        masterOnly 1
+        [enp110s0f7]
+        masterOnly 1
+        [global]
+        #
+        # Default Data Set
+        #
+        twoStepFlag 1
+        priority1 128
+        priority2 128
+        domainNumber 24
+        #utc_offset 37
+        clockClass 6
+        clockAccuracy 0x27
+        offsetScaledLogVariance 0xFFFF
+        free_running 0
+        freq_est_interval 1
+        dscp_event 0
+        dscp_general 0
+        dataset_comparison G.8275.x
+        G.8275.defaultDS.localPriority 128
+        #
+        # Port Data Set
+        #
+        logAnnounceInterval -3
+        logSyncInterval -4
+        logMinDelayReqInterval -4
+        logMinPdelayReqInterval 0
+        announceReceiptTimeout 3
+        syncReceiptTimeout 0
+        delayAsymmetry 0
+        fault_reset_interval 4
+        neighborPropDelayThresh 20000000
+        masterOnly 0
+        G.8275.portDS.localPriority 128
+        #
+        # Run time options
+        #
+        assume_two_step 0
+        logging_level 6
+        path_trace_enabled 0
+        follow_up_info 0
+        hybrid_e2e 0
+        inhibit_multicast_service 0
+        net_sync_monitor 0
+        tc_spanning_tree 0
+        tx_timestamp_timeout 50
+        unicast_listen 0
+        unicast_master_table 0
+        unicast_req_duration 3600
+        use_syslog 1
+        verbose 0
+        summary_interval -4
+        kernel_leap 1
+        check_fup_sync 0
+        #
+        # Servo Options
+        #
+        pi_proportional_const 0.0
+        pi_integral_const 0.0
+        pi_proportional_scale 0.0
+        pi_proportional_exponent -0.3
+        pi_proportional_norm_max 0.7
+        pi_integral_scale 0.0
+        pi_integral_exponent 0.4
+        pi_integral_norm_max 0.3
+        step_threshold 0.0
+        first_step_threshold 0.00002
+        clock_servo pi
+        sanity_freq_limit  200000000
+        ntpshm_segment 0
+        #
+        # Transport options
+        #
+        transportSpecific 0x0
+        ptp_dst_mac 01:1B:19:00:00:00
+        p2p_dst_mac 01:80:C2:00:00:0E
+        udp_ttl 1
+        udp6_scope 0x0E
+        uds_address /var/run/ptp4l
+        #
+        # Default interface options
+        #
+        clock_type BC
+        network_transport L2
+        delay_mechanism E2E
+        time_stamping hardware
+        tsproc_mode filter
+        delay_filter moving_median
+        delay_filter_length 10
+        egressLatency 0
+        ingressLatency 0
+        boundary_clock_jbod 1
+        #
+        # Clock description
+        #
+        productDescription ;;
+        revisionData ;;
+        manufacturerIdentity 00:00:00
+        userDescription ;
+        timeSource 0x20
+  recommend:
+    - match:
+      - nodeLabel: node-role.kubernetes.io/$mcp
+      priority: 4
+      profile: grandmaster

--- a/snippets/ptp_PtpConfigGnrdTGM.yaml
+++ b/snippets/ptp_PtpConfigGnrdTGM.yaml
@@ -1,0 +1,277 @@
+# Upstream source (keep in sync when updating this copy):
+# https://github.com/openshift-kni/telco-reference/blob/main/telco-ran/configuration/source-crs/ptp-operator/configuration/PtpConfigGnrdTGM.yaml
+#
+# Note:  This example configuration should be customized to match the desired
+# configuration For this GNR-D T-GM configuration, we support GNSS incoming to
+# the onboard connection, and up to 24 Time Transmitter ports including any NAC
+# ports and any additional Carter Flats ports.
+apiVersion: ptp.openshift.io/v1
+kind: PtpConfig
+metadata:
+  name: gnrd-tgm
+  namespace: openshift-ptp
+  annotations:
+    ran.openshift.io/ztp-deploy-wave: "10"
+spec:
+  profile:
+    - name: "grandmaster"
+      ptp4lOpts: "-2 --summary_interval -4"
+      phc2sysOpts: -r -u 0 -m -w -N 8 -R 16 -n 24 -s eno8703
+      ptpSchedulingPolicy: SCHED_FIFO
+      ptpSchedulingPriority: 10
+      ptpSettings:
+        logReduce: "true"
+      plugins:
+        e830:
+          devices:
+            - enp108s0f0
+            - enp110s0f0
+        e825:
+          devices:
+            - eno8703
+          settings:
+            LocalMaxHoldoverOffSet: 1500
+            LocalHoldoverTimeout: 14400
+            MaxInSpecOffset: 100
+          ublxCmds:
+            - args: #ubxtool -P 29.25 -z CFG-HW-ANT_CFG_VOLTCTRL,1
+                - "-P"
+                - "29.25"
+                - "-z"
+                - "CFG-HW-ANT_CFG_VOLTCTRL,1"
+              reportOutput: false
+            - args: #ubxtool -P 29.25 -e GPS
+                - "-P"
+                - "29.25"
+                - "-e"
+                - "GPS"
+              reportOutput: false
+            - args: #ubxtool -P 29.25 -d Galileo
+                - "-P"
+                - "29.25"
+                - "-d"
+                - "Galileo"
+              reportOutput: false
+            - args: #ubxtool -P 29.25 -d GLONASS
+                - "-P"
+                - "29.25"
+                - "-d"
+                - "GLONASS"
+              reportOutput: false
+            - args: #ubxtool -P 29.25 -d BeiDou
+                - "-P"
+                - "29.25"
+                - "-d"
+                - "BeiDou"
+              reportOutput: false
+            - args: #ubxtool -P 29.25 -d SBAS
+                - "-P"
+                - "29.25"
+                - "-d"
+                - "SBAS"
+              reportOutput: false
+            - args: #ubxtool -P 29.25 -t -w 5 -v 1 -e SURVEYIN,600,50000
+                - "-P"
+                - "29.25"
+                - "-t"
+                - "-w"
+                - "5"
+                - "-v"
+                - "1"
+                - "-e"
+                - "SURVEYIN,600,50000"
+              reportOutput: true
+            - args: #ubxtool -P 29.25 -p MON-HW
+                - "-P"
+                - "29.25"
+                - "-p"
+                - "MON-HW"
+              reportOutput: true
+            - args: #ubxtool -P 29.25 -p CFG-MSG,1,38,300
+                - "-P"
+                - "29.25"
+                - "-p"
+                - "CFG-MSG,1,38,248"
+              reportOutput: true    
+      ts2phcOpts: "-m"
+      ts2phcConf: |
+        [nmea]
+        ts2phc.master 1
+        [global]
+        use_syslog  0
+        verbose 1
+        logging_level 7
+        ts2phc.pulsewidth 100000000
+        ts2phc.nmea_serialport /dev/ttyACM0 
+        [eno8703]
+        ts2phc.extts_polarity rising
+        ts2phc.extts_correction 0
+        ts2phc.master  0
+        ts2phc.channel 0
+        ts2phc.pin_index 1
+        # This should be one section per Carter Flats (e830) card:
+        [enp108s0f0]
+        ts2phc.extts_polarity rising
+        ts2phc.extts_correction 0
+        ts2phc.master 0
+        ts2phc.channel 0
+        ts2phc.pin_index 1
+        [enp110s0f0]
+        ts2phc.extts_polarity rising
+        ts2phc.extts_correction 0
+        ts2phc.master 0
+        ts2phc.channel 0
+        ts2phc.pin_index 1
+      ptp4lConf: |
+        # All TimeTransmitter ports should be outlined here with 'masterOnly 1'
+        #[eno8303]
+        # ** Host management interface
+        [eno8403]
+        masterOnly 1
+        [eno8503]
+        masterOnly 1
+        [eno8603]
+        masterOnly 1
+        [eno8703]
+        masterOnly 1
+        [eno8803]
+        masterOnly 1
+        [eno8903]
+        masterOnly 1
+        [eno9003]
+        masterOnly 1
+        [enp108s0f0]
+        masterOnly 1
+        [enp108s0f1]
+        masterOnly 1
+        [enp108s0f2]
+        masterOnly 1
+        [enp108s0f3]
+        masterOnly 1
+        [enp108s0f4]
+        masterOnly 1
+        [enp108s0f5]
+        masterOnly 1
+        [enp108s0f6]
+        masterOnly 1
+        [enp108s0f7]
+        masterOnly 1
+        [enp110s0f0]
+        masterOnly 1
+        [enp110s0f1]
+        masterOnly 1
+        [enp110s0f2]
+        masterOnly 1
+        [enp110s0f3]
+        masterOnly 1
+        [enp110s0f4]
+        masterOnly 1
+        [enp110s0f5]
+        masterOnly 1
+        [enp110s0f6]
+        masterOnly 1
+        [enp110s0f7]
+        masterOnly 1
+        [global]
+        #
+        # Default Data Set
+        #
+        twoStepFlag 1
+        priority1 128
+        priority2 128
+        domainNumber 24
+        #utc_offset 37
+        clockClass 6
+        clockAccuracy 0x27
+        offsetScaledLogVariance 0xFFFF
+        free_running 0
+        freq_est_interval 1
+        dscp_event 0
+        dscp_general 0
+        dataset_comparison G.8275.x
+        G.8275.defaultDS.localPriority 128
+        #
+        # Port Data Set
+        #
+        logAnnounceInterval -3
+        logSyncInterval -4
+        logMinDelayReqInterval -4
+        logMinPdelayReqInterval 0
+        announceReceiptTimeout 3
+        syncReceiptTimeout 0
+        delayAsymmetry 0
+        fault_reset_interval 4
+        neighborPropDelayThresh 20000000
+        masterOnly 0
+        G.8275.portDS.localPriority 128
+        #
+        # Run time options
+        #
+        assume_two_step 0
+        logging_level 6
+        path_trace_enabled 0
+        follow_up_info 0
+        hybrid_e2e 0
+        inhibit_multicast_service 0
+        net_sync_monitor 0
+        tc_spanning_tree 0
+        tx_timestamp_timeout 50
+        unicast_listen 0
+        unicast_master_table 0
+        unicast_req_duration 3600
+        use_syslog 1
+        verbose 0
+        summary_interval -4
+        kernel_leap 1
+        check_fup_sync 0
+        #
+        # Servo Options
+        #
+        pi_proportional_const 0.0
+        pi_integral_const 0.0
+        pi_proportional_scale 0.0
+        pi_proportional_exponent -0.3
+        pi_proportional_norm_max 0.7
+        pi_integral_scale 0.0
+        pi_integral_exponent 0.4
+        pi_integral_norm_max 0.3
+        step_threshold 0.0
+        first_step_threshold 0.00002
+        clock_servo pi
+        sanity_freq_limit  200000000
+        ntpshm_segment 0
+        #
+        # Transport options
+        #
+        transportSpecific 0x0
+        ptp_dst_mac 01:1B:19:00:00:00
+        p2p_dst_mac 01:80:C2:00:00:0E
+        udp_ttl 1
+        udp6_scope 0x0E
+        uds_address /var/run/ptp4l
+        #
+        # Default interface options
+        #
+        clock_type BC
+        network_transport L2
+        delay_mechanism E2E
+        time_stamping hardware
+        tsproc_mode filter
+        delay_filter moving_median
+        delay_filter_length 10
+        egressLatency 0
+        ingressLatency 0
+        boundary_clock_jbod 1
+        #
+        # Clock description
+        #
+        productDescription ;;
+        revisionData ;;
+        manufacturerIdentity 00:00:00
+        userDescription ;
+        timeSource 0x20
+  recommend:
+    - match:
+      - nodeLabel: node-role.kubernetes.io/$mcp
+      priority: 4
+      profile: grandmaster


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.22
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://redhat.atlassian.net/browse/TELCODOCS-2483
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:  

- [Configuring linuxptp services as a Telecom Grandmaster clock on Intel Granite Rapids-D hardware](https://110859--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/advanced_networking/ptp/configuring-ptp.html#configuring-linuxptp-services-as-grandmaster-clock-gnrd_configuring-ptp)

- [Understand Telecom Grandmaster clocks on Intel Granite Rapids-D hardware](https://110859--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/advanced_networking/ptp/configuring-ptp.html#nw-ptp-granite-rapids-telecom-grandmaster-clock-overview_configuring-ptp)
- [PTP](https://110859--ocpdocs-pr.netlify.app/openshift-enterprise/latest/edge_computing/ztp-reference-cluster-configuration-for-vdu#ztp-sno-du-configuring-ptp_sno-configure-for-vdu)

<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
