### PR TITLE
(enterprise-4.18) OSDOCS-17109:CQA-2-MSH-INST-3-bootc-CP-4.18

### DIFF
--- a/microshift_install_bootc/microshift-about-rhel-image-mode.adoc
+++ b/microshift_install_bootc/microshift-about-rhel-image-mode.adoc
@@ -1,11 +1,12 @@
 :_mod-docs-content-type: ASSEMBLY
-[id="microshift-about-rhel-image-mode"]
 include::_attributes/attributes-microshift.adoc[]
+[id="microshift-about-rhel-image-mode"]
 = Understanding image mode for RHEL with {microshift-short}
 :context: microshift-about-rhel-image-mode
 
 toc::[]
 
+[role="_abstract"]
 You can embed {microshift-short} into an operating system image using image mode for {op-system-base-full}.
 
 :FeatureName: Image mode for {op-system-base}

--- a/modules/microshift-install-bootc-conc.adoc
+++ b/modules/microshift-install-bootc-conc.adoc
@@ -6,6 +6,7 @@
 [id="microshift-bootc-conc_{context}"]
 = About image mode for {op-system-base-full}
 
+[role="_abstract"]
 Image mode for {op-system-base-full} is a Technology Preview deployment method that uses a container-native approach to build, deploy, and manage the operating system as a bootc image. By using bootc, you can build, deploy, and manage the operating system as if it is any other container.
 
 * This container image uses standard OCI or Docker containers as a transport and delivery format for base operating system updates.


### PR DESCRIPTION
Version(s):
4.18

Issue:
https://redhat.atlassian.net/browse/OSDOCS-17109

Link to docs preview:
https://110862--ocpdocs-pr.netlify.app/microshift/latest/microshift_install_bootc/microshift-about-rhel-image-mode.html

Cherrypick for https://github.com/openshift/openshift-docs/pull/106530