### PR TITLE
CNV-85066: Remove low level implementation details

### DIFF
--- a/modules/virt-managing-auto-update-all-system-boot-sources.adoc
+++ b/modules/virt-managing-auto-update-all-system-boot-sources.adoc
@@ -10,7 +10,7 @@
 [role="_abstract"]
 Disabling automatic boot source imports and updates can lower resource usage. In disconnected environments, disabling automatic boot source updates prevents `CDIDataImportCronOutdated` alerts from filling up logs.
 
-To disable automatic updates for all system-defined boot sources, set the `enableCommonBootImageImport` field value to `false`. Disabling automatic updates deletes the associated `DataImportCron` objects but does not remove previously imported boot source images. Setting this value to `true` turns automatic updates back on.
+To disable automatic updates for all system-defined boot sources, set the `enableCommonBootImageImport` field value to `false`. Disabling automatic updates deletes the associated `DataImportCron` objects. Setting this value to `true` turns automatic updates back on.
 
 [NOTE]
 ====


### PR DESCRIPTION
In virt-managing-auto-update-all-system-boot-sources.adoc, the document states that:

> Disabling automatic updates deletes the associated `DataImportCron` objects but does not remove previously imported boot source images

This default behavior was changed in v4.22, and now the previously imported boot source images are getting deleted as well.

But since this is a low level detail, and since the user may override it, it would be simpler to just remove this part.

Version(s):
v4.22.0

Issue:
https://redhat.atlassian.net/browse/CNV-85066
