### PR TITLE
[OSDOCS#19417]: Added files for 4.21.12 z-stream release notes

### DIFF
--- a/modules/zstream-4-21-12.adoc
+++ b/modules/zstream-4-21-12.adoc
@@ -1,0 +1,37 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-21-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-21-12_{context}"]
+= RHBA-2026:10088 - {product-title} {product-version}.12 fixed issues
+
+Issued: 28 April 2026
+
+[role="_abstract"]
+{product-title} release {product-version}.12 is now available. The list of fixed issues that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2026:10088[RHBA-2026:10088] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2026:10086[RHBA-2026:10086] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.21.12 --pullspecs
+----
+
+[id="zstream-4-21-12-enhancements_{context}"]
+== Enhancements
+
+* In {product-title} release {product-version}.12 and later, you can limit the duration of Kubernetes events by setting the `eventTTLMinutes` property. Previously, that etcd feature was listed as a Technology Preview feature. The feature is now generally available for {product-title} release {product-version}.12 and later. (link:https://redhat.atlassian.net/browse/OCPBUGS-83858[OCPBUGS-83858])
+
+[id="zstream-4-21-12-fixed-issues_{context}"]
+== Fixed issues
+
+* Before this update, {gcp-first} Internal Load Balancers (ILBs) failed to provision when node names were configured as fully qualified domain names (FQDNs). With this update, the filtering logic is corrected. As a consequence, {gcp-short} ILBs now provision successfully when node names are FQDNs. (link:https://redhat.atlassian.net/browse/OCPBUGS-83615[OCPBUGS-83615])
+
+
+[id="zstream-4-21-12-updating_{context}"]
+== Updating
+
+To update an {product-title} 4.21 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].

--- a/release_notes/ocp-4-21-release-notes.adoc
+++ b/release_notes/ocp-4-21-release-notes.adoc
@@ -44,6 +44,9 @@ include::modules/rn-ocp-release-notes-known-issues.adoc[leveloffset=+1]
 // Asynchronous errata updates
 include::modules/rn-async-errata.adoc[leveloffset=+1]
 
+// 4.21.12 RNs and updating
+include::modules/zstream-4-21-12.adoc[leveloffset=+2]
+
 // 4.21.11 RNs and updating
 include::modules/zstream-4-21-11.adoc[leveloffset=+2]
 


### PR DESCRIPTION
Version(s):
4.21

Issue:
https://redhat.atlassian.net/browse/OSDOCS-19417

Link to docs preview:
https://110876--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-21-release-notes.html#zstream-4-21-12_release-notes

QE review:
N/A
