### PR TITLE
OSDOCS-19307 created zstream RNs for 4-16-60

### DIFF
--- a/modules/zstream-4-16-60.adoc
+++ b/modules/zstream-4-16-60.adoc
@@ -1,0 +1,34 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-16-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-16-60_{context}"]
+= RHSA-2026:10104 - {product-title} {product-version}.60 fixed issues and security updates
+
+Issued: 20 April 2026
+
+[role="_abstract"]
+{product-title} release {product-version}.60 is now available. The list of fixed issues that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2026:10104[RHSA-2026:10104] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2026:10096[RHSA-2026:10096] advisory.
+
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.16.60 --pullspecs
+----
+
+[id="zstream-4-16-60-fixed-issues_{context}"]
+== Fixed issues
+
+* Before this update, the cluster autoscaler processed paused node groups as if they were active, which led to the wrong nodes being deleted. With this release, the cluster autoscaler identifies paused node groups and does not act on them. (link:https://redhat.atlassian.net/browse/OCPBUGS-78702[OCPBUGS-78702])
+
+* Before this update, cluster namespaces with the "nodes" suffix caused the Performance Profile Creator (PPC) to fail. The PPC mistook `namespace-node` directories with the `must-gather` tool `nodes` directories in the `must-gather` data processed by the PPC. With this release, the PPC now correctly excludes the `namespaces` directory when processing the `must-gather` data to create a suggested `PerformanceProfile`. (link:https://redhat.atlassian.net/browse/OCPBUGS-78766[OCPBUGS-78766])
+
+[id="zstream-4-16-60-updating_{context}"]
+== Updating
+
+To update an {product-title} 4.16 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].

--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -3369,9 +3369,12 @@ metadata:
   name: mtu
   namespace: openshift-network-operator
 data:
-  mtu: "1500" <1>
+  mtu: "1500"
 ----
-<1> The `mtu` value must be aligned with the MTU of the node interface.
++
+where
+
+`metadata.data.mtu`:: Specifies that the `mtu` value must be aligned with the MTU of the node interface.
 +
 (link:https://issues.redhat.com//browse/OCPBUGS-35316[OCPBUGS-35316])
 
@@ -3384,6 +3387,10 @@ Testing has shown that wake up latencies are under 20μs for over 99.99999% of t
 
 // 4.16 about async
 include::modules/rn-async-errata.adoc[leveloffset=+1]
+
+// 4.16.60 Rns and updating
+include::modules/zstream-4-16-60.adoc[leveloffset=+2]
+
 
 // 4.16.59 Rns and updating
 include::modules/zstream-4-16-59.adoc[leveloffset=+2]


### PR DESCRIPTION
Version(s):
4.16

Issue:
https://redhat.atlassian.net/browse/OSDOCS-19307

Link to docs preview:
https://110879--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html#zstream-4-16-60_release-notes

QE review:
- N/A, z-stream release notes
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
