### PR TITLE
[enterprise-4.20] DOCPLAN-155: Make editorial changes to `vir/monitoring/`

### DIFF
--- a/virt/monitoring/virt-exposing-custom-metrics-for-vms.adoc
+++ b/virt/monitoring/virt-exposing-custom-metrics-for-vms.adoc
@@ -7,9 +7,8 @@ include::_attributes/attributes-openshift-dedicated.adoc[]
 
 toc::[]
 
-{product-title} includes a preconfigured, preinstalled, and self-updating monitoring stack that provides monitoring for core platform components. This monitoring stack is based on the Prometheus monitoring system. Prometheus is a time-series database and a rule evaluation engine for metrics.
-
-In addition to using the {product-title} monitoring stack, you can enable monitoring for user-defined projects by using the CLI and query custom metrics that are exposed for virtual machines through the `node-exporter` service.
+[role="_abstract"]
+Monitor core platform components by using the {product-title} monitoring stack based on the Prometheus monitoring system. Additionally, enable monitoring for user-defined projects by using the CLI and query custom metrics exposed for virtual machines through the `node-exporter` service.
 
 include::modules/virt-configuring-node-exporter-service.adoc[leveloffset=+1]
 include::modules/virt-configuring-vm-with-node-exporter-service.adoc[leveloffset=+1]
@@ -18,8 +17,8 @@ include::modules/virt-querying-the-node-exporter-service-for-metrics.adoc[levelo
 include::modules/virt-creating-servicemonitor-resource-for-node-exporter.adoc[leveloffset=+1]
 include::modules/virt-accessing-node-exporter-outside-cluster.adoc[leveloffset=+2]
 
-[role="_additional-resources"]
 [id="additional-resources_virt-exposing-custom-metrics-for-vms"]
+[role="_additional-resources"]
 == Additional resources
 // Hiding in ROSA/OSD as not supported
 ifndef::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]

--- a/virt/monitoring/virt-prometheus-queries.adoc
+++ b/virt/monitoring/virt-prometheus-queries.adoc
@@ -7,23 +7,18 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-ifndef::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
-{VirtProductName} provides metrics that you can use to monitor the consumption of cluster infrastructure resources, including vCPU, network, storage, and guest memory swapping. You can also use metrics to query live migration status.
-endif::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
-ifdef::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
-Use the {product-title} monitoring dashboard to query virtualization metrics.
-{VirtProductName} provides metrics that you can use to monitor the consumption of cluster infrastructure resources, including network, storage, and guest memory swapping. You can also use metrics to query live migration status.
-endif::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
+[role="_abstract"]
+Monitor the consumption of cluster infrastructure resources by using the metrics provided by {VirtProductName}. These metrics are also used to query live migration status.
 
-[id="prerequisites_{context}"]
-== Prerequisites
-
+[NOTE]
+====
 // Hiding in ROSA/OSD as user cannot edit MCO
 ifndef::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
-* To use the vCPU metric, the `schedstats=enable` kernel argument must be applied to the `MachineConfig` object. This kernel argument enables scheduler statistics used for debugging and performance tuning and adds a minor additional load to the scheduler.
+* To use the vCPU metric, apply the `schedstats=enable` kernel argument to the `MachineConfig` object. This kernel argument enables scheduler statistics used for debugging and performance tuning and adds a minor additional load to the scheduler.
 endif::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
 
-* For guest memory swapping queries to return data, memory swapping must be enabled on the virtual guests.
+* For guest memory swapping queries to return data, enable memory swapping on the virtual guests.
+====
 
 include::modules/monitoring-querying-metrics-for-all-projects-with-mon-dashboard.adoc[leveloffset=+1]
 

--- a/virt/monitoring/virt-running-cluster-checkups.adoc
+++ b/virt/monitoring/virt-running-cluster-checkups.adoc
@@ -7,12 +7,14 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 [role="_abstract"]
-A _checkup_ is an automated test workload that allows you to verify if a specific cluster functionality works as expected. The cluster checkup framework uses native Kubernetes resources to configure and execute the checkup.
+A _checkup_ is an automated test workload that you can use to verify if a specific cluster functionality works as expected. The cluster checkup framework uses native Kubernetes resources to configure and run the checkup.
 
 :FeatureName: The {VirtProductName} cluster checkup framework
 include::snippets/technology-preview.adoc[]
 
-As a developer or cluster administrator, you can use predefined checkups to improve cluster maintainability, troubleshoot unexpected behavior, minimize errors, and save time. You can review the results of the checkup and share them with experts for further analysis. Vendors can write and publish checkups for features or services that they provide and verify that their customer environments are configured correctly.
+:!FeatureName:
+
+As a developer or cluster administrator, you can use predefined checkups to improve cluster maintainability, troubleshoot unexpected behavior, minimize errors, and save time. You can review the results of the checkup and share them with experts for further analysis. Vendors can write and publish checkups for features or services that they offer and verify that their customer environments are configured correctly.
 
 [id="virt-running-cluster-checkups-latency"]
 == Running predefined latency checkups
@@ -53,8 +55,8 @@ include::modules/virt-troubleshoot-storage-checkup.adoc[leveloffset=+2]
 include::modules/virt-troubleshoot-storage-checkup-error-codes.adoc[leveloffset=+2]
 
 ifndef::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
-[role="_additional-resources"]
 [id="additional-resources_running-cluster-checkups"]
+[role="_additional-resources"]
 == Additional resources
 endif::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
 ifndef::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.20
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [DOCPLAN-155](https://redhat.atlassian.net/browse/DOCPLAN-155)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

- https://110908--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/monitoring/virt-exposing-custom-metrics-for-vms.html
- https://110908--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/monitoring/virt-prometheus-queries.html
- https://110908--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/monitoring/virt-running-cluster-checkups.html

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->
This is a manual cherry-pick for  #110420.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
