### PR TITLE
[standalone-logging-docs-6.0] PR for OBSDOCS-3257 Manual CP: CQA + DITA readiness for assemblies and modules under "About" sections.

### DIFF
--- a/about/about-logging.adoc
+++ b/about/about-logging.adoc
@@ -1,42 +1,20 @@
 :_mod-docs-content-type: ASSEMBLY
-include::_attributes/common-attributes.adoc[]
 [id="about-logging"]
 = {product-title} overview
+include::_attributes/common-attributes.adoc[]
 :context: about-logging
 
 toc::[]
 
+[role="_abstract"]
 The `ClusterLogForwarder` custom resource (CR) is the central configuration point for log collection and forwarding.
 
-== Inputs and Outputs
+include::modules/logging-inputs-and-outputs.adoc[leveloffset=+1]
 
-Inputs specify the sources of logs to be forwarded. Logging provides the following built-in input types that select logs from different parts of your cluster: 
+include::modules/logging-receiver-input-type.adoc[leveloffset=+1]
 
-* `application`
-* `receiver`
-* `infrastructure`
-* `audit`
+include::modules/logging-pipelines-and-filters.adoc[leveloffset=+1]
 
-You can also define custom inputs based on namespaces or pod labels to fine-tune log selection.
+include::modules/logging-operator-behavior.adoc[leveloffset=+1]
 
-Outputs define the destinations where logs are sent. Each output type has its own set of configuration options, allowing you to customize the behavior and authentication settings.
-
-
-== Receiver Input Type
-The receiver input type enables the Logging system to accept logs from external sources. It supports two formats for receiving logs: `http` and `syslog`.
-
-The `ReceiverSpec` field defines the configuration for a receiver input.
-
-== Pipelines and Filters
-
-Pipelines determine the flow of logs from inputs to outputs. A pipeline consists of one or more input refs, output refs, and optional filter refs. You can use filters to transform or drop log messages within a pipeline. The order of filters matters, as they are applied sequentially, and earlier filters can prevent log messages from reaching later stages.
-
-== Operator Behavior
-
-The Cluster Logging Operator manages the deployment and configuration of the collector based on the `managementState` field:
-
-- When set to `Managed` (default), the Operator actively manages the logging resources to match the configuration defined in the spec.
-- When set to `Unmanaged`, the Operator does not take any action, allowing you to manually manage the logging components.
-
-== Validation
-Logging includes extensive validation rules and default values to ensure a smooth and error-free configuration experience. The `ClusterLogForwarder` resource enforces validation checks on required fields, dependencies between fields, and the format of input values. Default values are provided for certain fields, reducing the need for explicit configuration in common scenarios.
+include::modules/logging-validation.adoc[leveloffset=+1]

--- a/about/cluster-logging-support.adoc
+++ b/about/cluster-logging-support.adoc
@@ -6,43 +6,30 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
+Ensure cluster stability and full support by using only official logging configurations.
+
 include::snippets/logging-supported-config-snip.adoc[]
+
 include::snippets/logging-compatibility-snip.adoc[]
+
 include::snippets/logging-loki-statement-snip.adoc[]
 
-{logging-uc} {for} is an opinionated collector and normalizer of application, infrastructure, and audit logs. It is intended to be used for forwarding logs to various supported systems.
+include::modules/logging-uc-capabilities-and-limitations.adoc[leveloffset=+1]
 
-{logging-uc} is not:
-
-* Security Information and Event Monitoring (SIEM) compliant
-* A "bring your own" (BYO) log collector configuration
-* Historical or long term log retention or storage
-* A guaranteed log sink
-* Secure storage - audit logs are not stored by default
-
-[id="cluster-logging-support-CRDs_{context}"]
-== Supported API custom resource definitions
-
-The following table describes the supported {logging-uc} APIs.
-
-include::snippets/logging-api-support-states-snip.adoc[]
+include::modules/supported-api-custom-resource-definitions.adoc[leveloffset=+1]
 
 include::modules/cluster-logging-maintenance-support-list-6x.adoc[leveloffset=+1]
+
 include::modules/unmanaged-operators.adoc[leveloffset=+1]
 
-//[id="support-exception-for-coo-logging-ui-plugin_{context}"]
-//== Support exception for the Logging UI Plugin
-//
-//Until the approaching General Availability (GA) release of the Cluster Observability Operator (COO), which is currently in link:https://access.redhat.com/support/offerings/techpreview/[Technology Preview] (TP), Red{nbsp}Hat provides support to customers who are using Logging 6.0 or later with the COO for its Logging UI Plugin on {ocp-product-title} 4.14 or later. This support exception is temporary as the COO includes several independent features, some of which are still TP features, but the Logging UI Plugin is ready for GA.
-//
-
-[id="cluster-logging-support-must-gather_{context}"]
-== Collecting {logging} data for Red Hat Support
-
-When opening a support case, it is helpful to provide debugging information about your cluster to Red{nbsp}Hat Support.
-
-You can use the link:https://docs.openshift.com/container-platform/latest/support/gathering-cluster-data.html#gathering-cluster-data[must-gather tool] to collect diagnostic information for project-level resources, cluster-level resources, and each of the {logging} components.
-For prompt support, supply diagnostic information for both {ocp-product-title} and {logging}.
+include::modules/collecting-logging-data-for-red-hat-support.adoc[leveloffset=+1]
 
 include::modules/cluster-logging-must-gather-about.adoc[leveloffset=+2]
+
 include::modules/cluster-logging-must-gather-collecting.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+== Additional resources
+
+* link:https://docs.openshift.com/container-platform/latest/support/gathering-cluster-data.html#gathering-cluster-data[must-gather tool]

--- a/about/logging-visualization.adoc
+++ b/about/logging-visualization.adoc
@@ -6,4 +6,12 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-You can visualize logs by deploying the link:https://docs.openshift.com/container-platform/latest/observability/cluster_observability_operator/ui_plugins/logging-ui-plugin.adoc#logging-ui-plugin[Logging UI Plugin] of the link:https://docs.redhat.com/en/documentation/red_hat_openshift_cluster_observability_operator/{coo-version}/html/about_red_hat_openshift_cluster_observability_operator/cluster-observability-operator-overview-1[Cluster Observability Operator], which requires Operator installation.
+[role="_abstract"]
+Enhance the observability capabilities of the {product-title} web console by installing and managing UI plugins.
+
+[role="_additional-resources"]
+== Additional resources
+
+* link:https://docs.openshift.com/container-platform/latest/observability/cluster_observability_operator/ui_plugins/logging-ui-plugin.adoc#logging-ui-plugin[Logging UI Plugin]
+
+* link:https://docs.redhat.com/en/documentation/red_hat_openshift_cluster_observability_operator/{coo-version}/html/about_red_hat_openshift_cluster_observability_operator/cluster-observability-operator-overview-1[Cluster Observability Operator]

--- a/about/quick-start.adoc
+++ b/about/quick-start.adoc
@@ -1,138 +1,16 @@
 :_mod-docs-content-type: ASSEMBLY
-include::_attributes/common-attributes.adoc[]
 [id="quick-start"]
 = Quick start
+include::_attributes/common-attributes.adoc[]
 :context: quick-start
 
 toc::[]
 
-.Prerequisites
-* You have access to an {ocp-product-title} cluster with `cluster-admin` permissions.
-* You have installed the {oc-first}.
-* You have access to a supported object store. For example, AWS S3, Google Cloud Storage, {azure-short}, Swift, Minio, or {rh-storage}.
+[role="_abstract"]
+Choose the data model that best meets your requirements for log forwarding by configuring the `lokiStack.dataModel` field in the `ClusterLogForwarder`. OpenShift Logging supports `ViaQ`, the default data model, and `OpenTelemetry`.
 
-.Procedure
+In future releases of OpenShift Logging, the default data model will change from `ViaQ` to `OpenTelemetry`.
 
-. Install the `{clo}`, `{loki-op}`, and `{coo-first}` from OperatorHub.
+include::modules/quickstart-viaq.adoc[leveloffset=+1]
 
-. Create a secret to access an existing object storage bucket: 
-+
-.Example command for AWS
-[source,terminal,subs="+quotes"]
-----
-$ oc create secret generic logging-loki-s3 \
-  --from-literal=bucketnames="<bucket_name>" \
-  --from-literal=endpoint="<aws_bucket_endpoint>" \
-  --from-literal=access_key_id="<aws_access_key_id>" \
-  --from-literal=access_key_secret="<aws_access_key_secret>" \
-  --from-literal=region="<aws_region_of_your_bucket>" \
-  -n openshift-logging
-----
-
-. Create a `LokiStack` custom resource (CR) in the `openshift-logging` namespace:
-+
-[source,yaml]
-----
-apiVersion: loki.grafana.com/v1
-kind: LokiStack
-metadata:
-  name: logging-loki
-  namespace: openshift-logging
-spec:
-  managementState: Managed
-  size: 1x.extra-small
-  storage:
-    schemas:
-    - effectiveDate: '2022-06-01'
-      version: v13
-    secret:
-      name: logging-loki-s3
-      type: s3
-  storageClassName: gp3-csi
-  tenants:
-    mode: openshift-logging
-----
-
-. Create a service account for the collector:
-+
-[source,shell]
-----
-$ oc create sa collector -n openshift-logging
-----
-
-. Bind the `ClusterRole` to the service account:
-+
-[source,shell]
-----
-$ oc adm policy add-cluster-role-to-user logging-collector-logs-writer -z collector -n openshift-logging
-----
-
-. Create a `UIPlugin` to enable the Log section in the Observe tab:
-+
-[source,yaml]
-----
-apiVersion: observability.openshift.io/v1alpha1
-kind: UIPlugin
-metadata:
-  name: logging
-spec:
-  type: Logging
-  logging:
-    lokiStack:
-      name: logging-loki
-----
-
-. Add additional roles to the collector service account:
-+
-[source,shell]
-----
-$ oc adm policy add-cluster-role-to-user collect-application-logs -z collector -n openshift-logging
-----
-+
-[source,terminal]
-----
-$ oc adm policy add-cluster-role-to-user collect-audit-logs -z collector -n openshift-logging
-----
-+
-[source,terminal]
-----
-$ oc adm policy add-cluster-role-to-user collect-infrastructure-logs -z collector -n openshift-logging
-----
-
-. Create a `ClusterLogForwarder` CR to configure log forwarding:
-+
-[source,yaml]
-----
-apiVersion: observability.openshift.io/v1
-kind: ClusterLogForwarder
-metadata:
-  name: collector
-  namespace: openshift-logging
-spec:
-  serviceAccount:
-    name: collector
-  outputs:
-  - name: default-lokistack
-    type: lokiStack
-    lokiStack:
-      target:
-        name: logging-loki
-        namespace: openshift-logging
-      authentication:
-        token:
-          from: serviceAccount
-    tls:
-      ca:
-        key: service-ca.crt
-        configMapName: openshift-service-ca.crt
-  pipelines:
-  - name: default-logstore
-    inputRefs:
-    - application
-    - infrastructure
-    outputRefs:
-    - default-lokistack
-----
-
-.Verification
-* Verify that logs are visible in the *Log* section of the *Observe* tab in the {ocp-product-title} web console.
+include::modules/quickstart-opentelemetry.adoc[leveloffset=+1]

--- a/modules/cluster-logging-maintenance-support-list-6x.adoc
+++ b/modules/cluster-logging-maintenance-support-list-6x.adoc
@@ -1,7 +1,11 @@
+// Module included in the following assemblies:
+// about/cluster-logging-support.adoc
+
 :_mod-docs-content-type: REFERENCE
 [id="cluster-logging-maintenance-support-list_{context}"]
 = Unsupported configurations
 
+[role="_abstract"]
 You must set the Red{nbsp}Hat OpenShift Logging Operator to the `Unmanaged` state to modify the following components:
 
 * The collector configuration file

--- a/modules/cluster-logging-must-gather-about.adoc
+++ b/modules/cluster-logging-must-gather-about.adoc
@@ -1,12 +1,16 @@
+// Module included in the following assemblies:
+// about/cluster-logging-support.adoc
+
 :_mod-docs-content-type: CONCEPT
 [id="about-must-gather_{context}"]
 = About the must-gather tool
 
+[role="_abstract"]
 The `oc adm must-gather` CLI command collects the information from your cluster that is most likely needed for debugging issues.
 
 For your {logging}, `must-gather` collects the following information:
 
-* Project-level resources, including pods, configuration maps, service accounts, roles, role bindings, and events at the project level
+* Project-level resources, including pods, config maps, service accounts, roles, role bindings, and events at the project level
 * Cluster-level resources, including nodes, roles, and role bindings at the cluster level
 * OpenShift Logging resources in the `openshift-logging` and `openshift-operators-redhat` namespaces, including health status for the log collector, the log store, and the log visualizer
 

--- a/modules/cluster-logging-must-gather-collecting.adoc
+++ b/modules/cluster-logging-must-gather-collecting.adoc
@@ -1,28 +1,18 @@
+// Module included in the following assemblies:
+// about/cluster-logging-support.adoc
+
 :_mod-docs-content-type: PROCEDURE
 [id="cluster-logging-must-gather-collecting_{context}"]
 = Collecting {logging} data
 
+[role="_abstract"]
 You can use the `oc adm must-gather` CLI command to collect information about {logging}.
 
 .Procedure
 
-To collect {logging} information with `must-gather`:
-
 . Navigate to the directory where you want to store the `must-gather` information.
 
 . Run the `oc adm must-gather` command against the {logging} image:
-+
-////
-If you are using OKD:
-+
-[source,terminal]
-----
-$ oc adm must-gather --image=quay.io/openshift/origin-cluster-logging-operator
-----
-+
-Otherwise:
-+
-////
 +
 [source,terminal]
 ----

--- a/modules/collecting-logging-data-for-red-hat-support.adoc
+++ b/modules/collecting-logging-data-for-red-hat-support.adoc
@@ -1,0 +1,12 @@
+// Module included in the following assemblies:
+// about/cluster-logging-support.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="collecting-logging-data-for-red-hat-support_{context}"]
+= Collecting {logging} data for Red Hat Support
+
+[role="_abstract"]
+When opening a support case, provide debugging information about your cluster to Red{nbsp}Hat Support.
+
+You can use the must-gather tool to collect diagnostic information for project-level resources, cluster-level resources, and each of the {logging} components.
+For prompt support, supply diagnostic information for both {ocp-product-title} and {logging}.

--- a/modules/logging-inputs-and-outputs.adoc
+++ b/modules/logging-inputs-and-outputs.adoc
@@ -1,0 +1,20 @@
+// Module included in the following assemblies:
+// about/about-logging.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="logging-inputs-and-outputs_{context}"]
+= Inputs and outputs
+
+[role="_abstract"]
+Inputs specify the sources of logs to forward. Outputs define the destinations where logs are sent.
+
+Logging provides the following built-in input types to select logs from different parts of your cluster:
+
+* `application`
+* `receiver`
+* `infrastructure`
+* `audit`
+
+You can also define custom inputs based on namespaces or pod labels to fine-tune log selection.
+
+Each output type has its own set of configuration options, allowing you to customize the behavior and authentication settings.

--- a/modules/logging-operator-behavior.adoc
+++ b/modules/logging-operator-behavior.adoc
@@ -1,0 +1,12 @@
+// Module included in the following assemblies:
+// about/about-logging.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="operator-behavior_{context}"]
+= Operator behavior
+
+[role="_abstract"]
+The Cluster Logging Operator manages the deployment and configuration of the collector based on the `managementState` field of the `ClusterLogForwarder` resource:
+
+- When set to `Managed` (default), the Operator actively manages the logging resources to match the configuration defined in the spec.
+- When set to `Unmanaged`, the Operator does not take any action, allowing you to manually manage the logging components.

--- a/modules/logging-pipelines-and-filters.adoc
+++ b/modules/logging-pipelines-and-filters.adoc
@@ -1,0 +1,10 @@
+// Module included in the following assemblies:
+// about/about-logging.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="pipelines-and-filters_{context}"]
+= Pipelines and filters
+
+[role="_abstract"]
+Pipelines determine the flow of logs from inputs to outputs. A pipeline consists of one or more input refs, output refs, and optional filter refs. 
+You can use filters to transform or drop log messages within a pipeline. The order of filters matters because they are applied sequentially, and earlier filters can prevent log messages from reaching later stages.

--- a/modules/logging-receiver-input-type.adoc
+++ b/modules/logging-receiver-input-type.adoc
@@ -1,0 +1,11 @@
+// Module included in the following assemblies:
+// about/about-logging.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="logging-receiver-input-type_{context}"]
+= Receiver input type
+
+[role="_abstract"]
+The receiver input type enables the Logging system to accept logs from external sources. It supports two formats for receiving logs: `http` and `syslog`.
+
+The `ReceiverSpec` field defines the configuration for a receiver input.

--- a/modules/logging-uc-capabilities-and-limitations.adoc
+++ b/modules/logging-uc-capabilities-and-limitations.adoc
@@ -1,0 +1,17 @@
+// Module included in the following assemblies:
+// about/cluster-logging-support.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="logging-uc-capabilities-and-limitations_{context}"]
+= {logging-uc} capabilities and limitations
+
+[role="_abstract"]
+{logging-uc} {for} is an opinionated collector and normalizer of application, infrastructure, and audit logs. It is intended to be used for forwarding logs to various supported systems.
+
+{logging-uc} is not:
+
+* Security Information and Event Monitoring (SIEM) compliant
+* A "bring your own" (BYO) log collector configuration
+* Historical or long term log retention or storage
+* A guaranteed log sink
+* Secure storage - audit logs are not stored by default

--- a/modules/logging-validation.adoc
+++ b/modules/logging-validation.adoc
@@ -1,0 +1,10 @@
+// Module included in the following assemblies:
+// about/about-logging.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="validation_{context}"]
+= Validation
+
+[role="_abstract"]
+Logging includes extensive validation rules and default values to ensure a smooth and error-free configuration experience. The `ClusterLogForwarder` resource enforces validation checks on required fields, dependencies between fields, and the format of input values. 
+Default values are provided for certain fields, which reduces the need for explicit configuration in common scenarios.

--- a/modules/quickstart-opentelemetry.adoc
+++ b/modules/quickstart-opentelemetry.adoc
@@ -1,0 +1,157 @@
+// Module included in the following assemblies:
+// about/quick-start.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="quick-start-opentelemetry_{context}"]
+= Quick start with OpenTelemetry
+
+[role="_abstract"]
+Standardize your observability pipeline by enabling OpenTelemetry (OTLP) ingestion on OpenShift Logging.
+
+.Prerequisites
+* Cluster administrator permissions
+
+.Procedure
+
+. Install the {clo}, {loki-op}, and {coo-first} from OperatorHub.
+
+. Create a `LokiStack` custom resource (CR) in the `openshift-logging` namespace:
++
+[source,yaml]
+----
+apiVersion: loki.grafana.com/v1
+kind: LokiStack
+metadata:
+  name: logging-loki
+  namespace: openshift-logging
+spec:
+  managementState: Managed
+  size: 1x.extra-small
+  storage:
+    schemas:
+    - effectiveDate: '2024-10-01'
+      version: v13
+    secret:
+      name: logging-loki-s3
+      type: s3
+  storageClassName: gp3-csi
+  tenants:
+    mode: openshift-logging
+----
++
+[NOTE]
+====
+Ensure that the `logging-loki-s3` secret is created beforehand. The contents of this secret vary depending on the object storage in use. For more information, see "Secrets and TLS Configuration".
+====
+
+. Create a service account for the collector:
++
+[source,terminal]
+----
+$ oc create sa collector -n openshift-logging
+----
+
+. Allow the collector's service account to write data to the `LokiStack` CR:
++
+[source,terminal]
+----
+$ oc adm policy add-cluster-role-to-user logging-collector-logs-writer -z collector
+----
++
+[NOTE]
+====
+The `ClusterRole` resource is created automatically during the Cluster Logging Operator installation and does not need to be created manually.
+====
+
+. Allow the collector's service account to collect logs:
++
+[source,terminal]
+----
+$ oc project openshift-logging
+----
++
+[source,terminal]
+----
+$ oc adm policy add-cluster-role-to-user collect-application-logs -z collector
+----
++
+[source,terminal]
+----
+$ oc adm policy add-cluster-role-to-user collect-audit-logs -z collector
+----
++
+[source,terminal]
+----
+$ oc adm policy add-cluster-role-to-user collect-infrastructure-logs -z collector
+----
++
+[NOTE]
+====
+The example binds the collector to all three roles (application, infrastructure, and audit). By default, only application and infrastructure logs are collected. To collect audit logs, update your `ClusterLogForwarder` configuration to include them. Assign roles based on the specific log types required for your environment.
+====
+
+. Create a `UIPlugin` CR to enable the *Log* section in the *Observe* tab:
++
+[source,yaml]
+----
+apiVersion: observability.openshift.io/v1alpha1
+kind: UIPlugin
+metadata:
+  name: logging
+spec:
+  type: Logging
+  logging:
+    lokiStack:
+      name: logging-loki
+----
+
+. Create a `ClusterLogForwarder` CR to configure log forwarding:
++
+[source,yaml]
+----
+apiVersion: observability.openshift.io/v1
+kind: ClusterLogForwarder
+metadata:
+  name: collector
+  namespace: openshift-logging
+spec:
+  serviceAccount:
+    name: collector
+  outputs:
+  - name: loki-otlp
+    type: lokiStack
+    lokiStack:
+      target:
+        name: logging-loki
+        namespace: openshift-logging
+      dataModel: Otel
+      authentication:
+        token:
+          from: serviceAccount
+    tls:
+      ca:
+        key: service-ca.crt
+        configMapName: openshift-service-ca.crt
+  pipelines:
+  - name: my-pipeline
+    inputRefs:
+    - application
+    - infrastructure
+    outputRefs:
+    - loki-otlp
+----
++
+Where:
+
+* `lokiStack`: Specifies the output type for the `ClusterLogForwarder` CR.
+
+* `Otel`: Specifies the OpenTelemetry data model for log forwarding.
+
++
+[NOTE]
+====
+You cannot use `lokiStack.labelKeys` when `dataModel` is `Otel`. To achieve similar functionality when `dataModel` is `Otel`, refer to "Configuring LokiStack for OTLP data ingestion".
+====
+
+.Verification
+* Verify that OTLP is functioning correctly by navigating to *Observe* -> *OpenShift Logging* -> *LokiStack* -> *Writes* in the OpenShift web console, and checking *Distributor - Structured Metadata*.

--- a/modules/quickstart-viaq.adoc
+++ b/modules/quickstart-viaq.adoc
@@ -1,0 +1,146 @@
+// Module included in the following assemblies:
+// about/quick-start.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="quickstart-viaq_{context}"]
+= Quick start with ViaQ
+
+[role="_abstract"]
+Set up the default `ViaQ` data model to collect and forward logs.
+
+.Prerequisites
+* You have access to an {ocp-product-title} cluster with `cluster-admin` permissions.
+* You installed the {oc-first}.
+* You have access to a supported object store. For example, AWS S3, Google Cloud Storage, {azure-short}, Swift, MinIO, or {rh-storage}.
+
+.Procedure
+
+. Install the `{clo}`, `{loki-op}`, and `{coo-first}` from OperatorHub.
+
+. Create a `LokiStack` custom resource (CR) in the `openshift-logging` namespace:
++
+[source,yaml]
+----
+apiVersion: loki.grafana.com/v1
+kind: LokiStack
+metadata:
+  name: logging-loki
+  namespace: openshift-logging
+spec:
+  managementState: Managed
+  size: 1x.extra-small
+  storage:
+    schemas:
+    - effectiveDate: '2024-10-01'
+      version: v13
+    secret:
+      name: logging-loki-s3
+      type: s3
+  storageClassName: gp3-csi
+  tenants:
+    mode: openshift-logging
+----
++
+[NOTE]
+====
+Ensure that the `logging-loki-s3` secret is created beforehand. The contents of this secret vary depending on the object storage in use. For more information, see Secrets and TLS Configuration.
+====
+
+. Create a service account for the collector:
++
+[source,terminal]
+----
+$ oc create sa collector -n openshift-logging
+----
+
+. Allow the collector's service account to write data to the `LokiStack` CR:
++
+[source,terminal]
+----
+$ oc adm policy add-cluster-role-to-user logging-collector-logs-writer -z collector -n openshift-logging
+----
++
+[NOTE]
+====
+The `ClusterRole` resource is created automatically during the Cluster Logging Operator installation and does not need to be created manually.
+====
+
+. To collect logs, use the service account of the collector by running the following commands:
++
+[source,terminal]
+----
+$ oc adm policy add-cluster-role-to-user collect-application-logs -z collector -n openshift-logging
+----
++
+[source,terminal]
+----
+$ oc adm policy add-cluster-role-to-user collect-audit-logs -z collector -n openshift-logging
+----
++
+[source,terminal]
+----
+$ oc adm policy add-cluster-role-to-user collect-infrastructure-logs -z collector -n openshift-logging
+----
++
+[NOTE]
+====
+The example binds the collector to all three roles (application, infrastructure, and audit), but by default, only application and infrastructure logs are collected. To collect audit logs, update your `ClusterLogForwarder` configuration to include them. Assign roles based on the specific log types required for your environment.
+====
+
+. Create a `UIPlugin` CR to enable the *Log* section in the *Observe* tab:
++
+[source,yaml]
+----
+apiVersion: observability.openshift.io/v1alpha1
+kind: UIPlugin
+metadata:
+  name: logging
+spec:
+  type: Logging
+  logging:
+    lokiStack:
+      name: logging-loki
+----
+
+. Create a `ClusterLogForwarder` CR to configure log forwarding:
++
+[source,yaml]
+----
+apiVersion: observability.openshift.io/v1
+kind: ClusterLogForwarder
+metadata:
+  name: collector
+  namespace: openshift-logging
+spec:
+  serviceAccount:
+    name: collector
+  outputs:
+  - name: default-lokistack
+    type: lokiStack
+    lokiStack:
+      authentication:
+        token:
+          from: serviceAccount
+      target:
+        name: logging-loki
+        namespace: openshift-logging
+    tls:
+      ca:
+        key: service-ca.crt
+        configMapName: openshift-service-ca.crt
+  pipelines:
+  - name: default-logstore
+    inputRefs:
+    - application
+    - infrastructure
+    outputRefs:
+    - default-lokistack
+----
++
+[NOTE]
+====
+The `dataModel` field is optional and left unset (`dataModel: ""`) by default. This allows the Cluster Logging Operator (CLO) to automatically select a data model. Currently, the CLO defaults to the ViaQ model when the field is unset, but this will change in future releases. Specifying `dataModel: ViaQ` ensures the configuration remains compatible if the default changes.
+====
+
+.Verification
+* Verify that logs are visible in the *Log* section of the *Observe* tab in the {ocp-product-title} web console.

--- a/modules/supported-api-custom-resource-definitions.adoc
+++ b/modules/supported-api-custom-resource-definitions.adoc
@@ -1,0 +1,11 @@
+// Module included in the following assemblies:
+// about/cluster-logging-support.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="cluster-logging-support-CRDs_{context}"]
+= Supported API custom resource definitions
+
+[role="_abstract"]
+The following table describes the supported {logging-uc} APIs.
+
+include::snippets/logging-api-support-states-snip.adoc[]

--- a/modules/unmanaged-operators.adoc
+++ b/modules/unmanaged-operators.adoc
@@ -1,46 +1,37 @@
+// Module included in the following assemblies:
+// about/cluster-logging-support.adoc
+
 :_mod-docs-content-type: CONCEPT
 [id="unmanaged-operators_{context}"]
 = Support policy for unmanaged Operators
 
-The _management state_ of an Operator determines whether an Operator is actively
-managing the resources for its related component in the cluster as designed. If
-an Operator is set to an _unmanaged_ state, it does not respond to changes in
+[role="_abstract"]
+The _management state_ of an Operator determines whether an Operator is actively managing the resources for its related component in the cluster as designed. If an Operator is set to an _unmanaged_ state, it does not respond to changes in
 configuration nor does it receive updates.
 
-While this can be helpful in non-production clusters or during debugging,
-Operators in an unmanaged state are unsupported and the cluster administrator
-assumes full control of the individual component configurations and upgrades.
+Although useful for non-production or debugging, Operators in an unmanaged state are unsupported, and the cluster administrator assumes full responsibility for configuration and upgrades.
 
-An Operator can be set to an unmanaged state using the following methods:
+An Operator can be set to an unmanaged state by using the following methods:
 
 * **Individual Operator configuration**
 +
 Individual Operators have a `managementState` parameter in their configuration.
-This can be accessed in different ways, depending on the Operator. For example,
-the Red Hat OpenShift Logging Operator accomplishes this by modifying a custom resource
-(CR) that it manages, while the Cluster Samples Operator uses a cluster-wide
+This can be accessed in different ways, depending on the Operator. For example, the Red Hat OpenShift Logging Operator accomplishes this by modifying a custom resource (CR) that it manages, while the Cluster Samples Operator uses a cluster-wide
 configuration resource.
 +
-Changing the `managementState` parameter to `Unmanaged` means that the Operator
-is not actively managing its resources and will take no action related to the
-related component. Some Operators might not support this management state as it
-might damage the cluster and require manual recovery.
+Changing the `managementState` parameter to `Unmanaged` means that the Operator is not actively managing its resources and will take no action related to the related component. Some Operators might not support this management state as it might damage the cluster and require manual recovery.
 +
 [WARNING]
 ====
-Changing individual Operators to the `Unmanaged` state renders that particular
-component and functionality unsupported. Reported issues must be reproduced in
-`Managed` state for support to proceed.
+Changing individual Operators to the `Unmanaged` state renders that particular component and functionality unsupported. Reported issues must be reproduced in `Managed` state for support to proceed.
 ====
 
 * **Cluster Version Operator (CVO) overrides**
 +
-The `spec.overrides` parameter can be added to the CVO's configuration to allow
-administrators to provide a list of overrides to the CVO's behavior for a
-component. Setting the `spec.overrides[].unmanaged` parameter to `true` for a
-component blocks cluster upgrades and alerts the administrator after a CVO
+The `spec.overrides` parameter can be added to the CVO's configuration to allow administrators to provide a list of overrides to the CVO's behavior for a component. Setting the `spec.overrides[].unmanaged` parameter to `true` for a component blocks cluster upgrades and alerts the administrator after a CVO
 override has been set:
 +
+.Example output
 [source,terminal]
 ----
 Disabling ownership via cluster version overrides prevents upgrades. Please remove overrides before continuing.
@@ -48,6 +39,5 @@ Disabling ownership via cluster version overrides prevents upgrades. Please remo
 +
 [WARNING]
 ====
-Setting a CVO override puts the entire cluster in an unsupported state. Reported
-issues must be reproduced after removing any overrides for support to proceed.
+Setting a CVO override puts the entire cluster in an unsupported state. Reported issues must be reproduced after removing any overrides for support to proceed.
 ====

--- a/snippets/logging-compatibility-snip.adoc
+++ b/snippets/logging-compatibility-snip.adoc
@@ -2,5 +2,5 @@
 
 [NOTE]
 ====
-Logging is provided as an installable component, with a distinct release cycle from the core {ocp-product-title}. The link:https://access.redhat.com/support/policy/updates/openshift_operators#platform-agnostic[Red Hat OpenShift Container Platform Life Cycle Policy] outlines release compatibility.
+Logging is provided as an installable component, with a distinct release cycle from the core {ocp-product-title}. The link:https://access.redhat.com/support/policy/updates/openshift_operators#platform-agnostic[Red Hat {product-title} Life Cycle Policy] outlines release compatibility.
 ====

--- a/snippets/logging-loki-statement-snip.adoc
+++ b/snippets/logging-loki-statement-snip.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: SNIPPET
 
-Loki is a horizontally scalable, highly available, multi-tenant log aggregation system offered as a GA log store for {logging} {for} that can be visualized with the OpenShift {ObservabilityShortName} UI. The Loki configuration provided by OpenShift {logging-uc} is a short-term log store designed to enable users to perform fast troubleshooting with the collected logs. For that purpose, the {logging} {for} configuration of Loki has short-term storage, and is optimized for very recent queries.
+Loki is a horizontally scalable, highly available, multitenant log aggregation system offered as a GA log store for {logging} {for} that can be visualized with the OpenShift {ObservabilityShortName} UI. The Loki configuration provided by OpenShift {logging-uc} is a short-term log store designed to help users perform fast troubleshooting with the collected logs. For that purpose, the {logging} {for} configuration of Loki has short-term storage, and is optimized for very recent queries. For long-term storage or queries over a long time period, users should look to log stores external to their cluster.
 
 [IMPORTANT]
 ====

--- a/snippets/logging-supported-config-snip.adoc
+++ b/snippets/logging-supported-config-snip.adoc
@@ -1,8 +1,6 @@
 :_mod-docs-content-type: SNIPPET
 
-Only the configuration options described in this documentation are supported for {logging}.
-
-Do not use any other configuration options, as they are unsupported. Configuration paradigms might change across {ocp-product-title} releases, and such cases can only be handled gracefully if all configuration possibilities are controlled. If you use configurations other than those described in this documentation, your changes will be overwritten, because Operators are designed to reconcile any differences.
+Configuration paradigms might change across {ocp-product-title} releases, and such cases can only be handled gracefully if all configuration possibilities are controlled. If you use configurations other than those described in this documentation, your changes will be overwritten, because Operators are designed to reconcile any differences.
 
 [NOTE]
 ====


### PR DESCRIPTION
Cherry-picked from #109023

Commit ID: 3d1050a3ee78e2a044c5da6ebc4d03844ddf5910

**Note for the peer & merge reviewer:** 
- This PR updates the only "About" section to prepare them for Phase 0 DITA migration.
- No other CQA changes, error types, or content refinements are included. 

**Changes:** 
This PR prepares the "About" section for Phase 0 DITA migration by applying Vale (AsciiDoc DITA) rules and cleaning up the existing content.

**Tracking JIRA:** https://redhat.atlassian.net/browse/OBSDOCS-3257

**Reviews:**
- [x] Peer has approved this change