### PR TITLE
OSDOCS-19410-2 back porting most recent zero-trust docs to 4.18 PR#2

### DIFF
--- a/modules/zero-trust-manager-available-metrics.adoc
+++ b/modules/zero-trust-manager-available-metrics.adoc
@@ -1,0 +1,57 @@
+// Module included in the following assemblies:
+//
+// * security/zer_trust_workload_identity_manager/zero-trust-manager-monitoring.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zero-trust-manager-available-metrics_{context}"]
+= {zero-trust-full} monitoring available metrics
+
+[role="_abstract"]
+Monitor the health and performance of {zero-trust-full} components by reviewing exposed metrics. This reference describes controller, certificate, and runtime metrics that help you maintain system health and troubleshoot errors.
+
+The {zero-trust-full} exposes the following metrics:
+
+Controller runtime metrics::
+
+* `controller_runtime_active_workers`: Number of currently used workers per controller
+
+* `controller_runtime_max_concurrent_reconciles`: Maximum number of concurrent reconciles per controller
+
+* `controller_runtime_reconcile_errors_total`: Total number of reconciliation errors per controller
+
+* `controller_runtime_reconcile_time_seconds`: Length of time per reconciliation per controller
+
+* `controller_runtime_reconcile_total`: Total number of reconciliations per controller
+
+Certificate watcher metrics::
+
+* `certwatcher_read_certificate_errors_total`: Total number of certificate read errors
+
+* `certwatcher_read_certificate_total`: Total number of certificates read
+
+Go runtime metrics::
+
+Standard Go runtime metrics including:
+
+* `go_gc_duration_seconds`: Garbage collection duration
+
+* `go_goroutines`: Number of goroutines
+
+* `go_memstats_*`: Memory statistics
+
+* `process_*`: Process statistics
+
+ Custom Operator metrics::
+
+The Operator also exposes custom metrics related to:
+
+* SPIRE Server status and health
+
+* SPIRE Agent deployment status
+
+* SPIFFE CSI Driver status
+
+* OIDC Discovery Provider status
+
+* Workload identity management operations
+

--- a/modules/zero-trust-manager-enable-metrics-agent.adoc
+++ b/modules/zero-trust-manager-enable-metrics-agent.adoc
@@ -4,24 +4,28 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="zero-trust-manager-enable-metrics-agent_{context}"]
-= Configuring metrics collection for SPIRE agent by using a Service Monitor
+= Configuring metrics collection for SPIRE Agent by using a Service Monitor
 
-The SPIRE Agent operand exposes metrics by default on port `9402` at the `/metrics` endpoint. You can configure metrics collection for the SPIRE Agent by creating a `ServiceMonitor` custom resource (CR), which enables Prometheus Operator to collect custom metrics.
+The SPIRE Agent Operand exposes metrics by default on port `9402` at the `/metrics` endpoint. You can configure metrics collection for the SPIRE Agent by creating a `ServiceMonitor` custom resource (CR), which enables the Prometheus Operator to collect custom metrics.
 
 .Prerequisites
 
 * You have access to the cluster as a user with the `cluster-admin` cluster role.
+
 * You have installed the {zero-trust-full}.
-* You have deployed the SPIRE Agent operand in the cluster.
+
+* You have deployed the SPIRE Agent Operand in the cluster.
+
 * You have enabled the user workload monitoring.
 
 .Procedure
 
 . Create the `ServiceMonitor` CR:
 
-.. Create the YAML file that defines `ServiceMonitor` CR:
+.. Create the YAML file that defines the `ServiceMonitor` CR:
 +
 .Example `servicemonitor-spire-agent.yaml` file
++
 [source,yaml]
 ----
 apiVersion: monitoring.coreos.com/v1
@@ -58,7 +62,6 @@ After the `ServiceMonitor` CR is created, the user workload Prometheus instance 
 .Verification
 
 . In the {product-title} web console, navigate to *Observe* → *Targets*.
-
 
 . In the *Label* filter field, enter the following label to filter the metrics targets:
 +

--- a/modules/zero-trust-manager-enable-metrics-operator.adoc
+++ b/modules/zero-trust-manager-enable-metrics-operator.adoc
@@ -1,0 +1,203 @@
+// Module included in the following assemblies:
+//
+// * security/zer_trust_workload_identity_manager/zero-trust-manager-monitoring.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="zero-trust-manager-enable-metrics-operator_{context}"]
+= Configuring metrics collection for the Operator by using a ServiceMonitor
+
+[role="_abstract"]
+The {zero-trust-full} exposes metrics by default on port 8443 at the `/metrics` service endpoint. You can configure metrics collection for the Operator by creating a `ServiceMonitor` custom resource (CR) that enables the Prometheus Operator to collect custom metrics. For more information, see "Configuring user workload monitoring".
+
+
+The SPIRE Server operand exposes metrics by default on port `9402` at the `/metrics` endpoint. You can configure metrics collection for the SPIRE Server by creating a `ServiceMonitor` custom resource (CR) that enables the Prometheus Operator to collect custom metrics.
+
+
+.Prerequisites
+
+* You have access to the cluster as a user with the `cluster-admin` cluster role.
+
+* You have installed the {zero-trust-full}.
+
+* You have enabled the user workload monitoring.
+
+.Procedure
+
+. Configure the Operator to use HTTP or HTTPS protocols for the metrics server.
+
+.. Update the subscription object for {zero-trust-full} to configure the HTTP protocol by running the following command:
++
+[source,terminal]
+----
+$ oc -n zero-trust-workload-identity-manager patch subscription zero-trust-workload-identity-manager-subscription --type='merge' -p '{"spec":{"config":{"env":[{"name":"METRICS_BIND_ADDRESS","value":":8080"}, {"name": "METRICS_SECURE", "value": "false"}]}}}'
+----
+
+.. Verify the {zero-trust-full} pod is redeployed and that the configured values for `METRICS_BIND_ADDRESS` and `METRICS_SECURE` is updated by running the following command:
++
+[source,terminal]
+----
+$ oc set env --list deployment/zero-trust-workload-identity-manager-controller-manager -n zero-trust-workload-identity-manager | grep -e METRICS_BIND_ADDRESS -e METRICS_SECURE -e container
+----
++
+.Example output
++
+[source,text]
+----
+deployments/zero-trust-workload-identity-manager-controller-manager, container manager
+METRICS_BIND_ADDRESS=:8080
+METRICS_SECURE=false
+----
+
+. Create the `Secret` resource with `kubernetes.io/service-account.name` annotation to inject the token required for authenticating with the metrics server.
+
+..  Create the `secret-zero-trust-workload-identity-manager.yaml` file:
++
+[source,yaml]
+----
+apiVersion: v1
+kind: Secret
+metadata:
+ labels:
+   name: zero-trust-workload-identity-manager
+ name: zero-trust-workload-identity-manager-metrics-auth
+ namespace: zero-trust-workload-identity-manager
+ annotations:
+   kubernetes.io/service-account.name: zero-trust-workload-identity-manager-controller-manager
+type: kubernetes.io/service-account-token
+----
+
+.. Apply the `Secret` resource by running the following command:
++
+[source,terminal]
+----
+$ oc apply -f secret-zero-trust-workload-identity-manager.yaml
+----
+
+. Create the `ClusterRoleBinding` resource required for granting permissions to access the metrics.
+
+.. Create the `clusterrolebinding-zero-trust-workload-identity-manager.yaml` file:
++
+[source,yaml]
+----
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+ labels:
+   name: zero-trust-workload-identity-manager
+ name: zero-trust-workload-identity-manager-allow-metrics-access
+roleRef:
+ apiGroup: rbac.authorization.k8s.io
+ kind: ClusterRole
+ name: zero-trust-workload-identity-manager-metrics-reader
+subjects:
+- kind: ServiceAccount
+  name: zero-trust-workload-identity-manager-controller-manager
+  namespace: zero-trust-workload-identity-manager
+----
+
+.. Apply the `ClusterRoleBinding` resource by running the following command:
++
+[source,terminal]
+----
+$ oc apply -f clusterrolebinding-zero-trust-workload-identity-manager.yaml
+----
+
+. Create the following `ServiceMonitor` CR if the metrics server is configured to use `http`.
+
+.. Create the `servicemonitor-zero-trust-workload-identity-manager-http.yaml` file:
++
+[source,yaml]
+----
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    name: zero-trust-workload-identity-manager
+  name: zero-trust-workload-identity-manager-metrics-monitor
+  namespace: zero-trust-workload-identity-manager
+spec:
+  endpoints:
+    - authorization:
+        credentials:
+          name: zero-trust-workload-identity-manager-metrics-auth
+          key: token
+        type: Bearer
+      interval: 60s
+      path: /metrics
+      port: metrics-http
+      scheme: http
+      scrapeTimeout: 30s
+  namespaceSelector:
+    matchNames:
+      - zero-trust-workload-identity-manager
+  selector:
+    matchLabels:
+      name: zero-trust-workload-identity-manager
+----
+
+.. Apply the `ServiceMonitor` CR by running the following command:
++
+[source,terminal]
+----
+$ oc apply -f servicemonitor-zero-trust-workload-identity-manager-http.yaml
+----
+. Create the following `ServiceMonitor` CR if the metrics server is configured to use `https`.
+
+.. Create the `servicemonitor-zero-trust-workload-identity-manager-https.yaml` file:
++
+[source,yaml]
+----
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    name: zero-trust-workload-identity-manager
+  name: zero-trust-workload-identity-manager-metrics-monitor
+  namespace: zero-trust-workload-identity-manager
+spec:
+  endpoints:
+    - authorization:
+        credentials:
+          name: zero-trust-workload-identity-manager-metrics-auth
+          key: token
+        type: Bearer
+      interval: 60s
+      path: /metrics
+      port: metrics-https
+      scheme: https
+      scrapeTimeout: 30s
+      tlsConfig:
+        ca:
+          configMap:
+            name: openshift-service-ca.crt
+            key: service-ca.crt
+        serverName: zero-trust-workload-identity-manager-metrics-service.zero-trust-workload-identity-manager.svc.cluster.local
+  namespaceSelector:
+    matchNames:
+      - zero-trust-workload-identity-manager
+  selector:
+    matchLabels:
+      name: zero-trust-workload-identity-manager
+----
+
+.. Apply the `ServiceMonitor` CR by running the following command:
++
+[source,terminal]
+----
+$ oc apply -f servicemonitor-zero-trust-workload-identity-manager-https.yaml
+----
++
+After the `ServiceMonitor` CR is created, the user workload Prometheus instance begins metrics collection from the SPIRE Server. The collected metrics are labeled with `job="zero-trust-workload-identity-manager-metrics-service"`.
+
+.Verification
+
+. In the {product-title} web console, navigate to *Observe* → *Targets*.
+
+. In the *Label* filter field, enter the following label to filter the metrics targets:
++
+[source,terminal]
+----
+$ service=zero-trust-workload-identity-manager-metrics-service
+----
+
+. Confirm that the *Status* column shows `Up` for the `zero-trust-workload-identity-manager` entry.

--- a/modules/zero-trust-manager-enable-metrics-server.adoc
+++ b/modules/zero-trust-manager-enable-metrics-server.adoc
@@ -4,46 +4,53 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="zero-trust-manager-enable-metrics-server_{context}"]
-= Configuring metrics collection for SPIRE server by using a Service Monitor
+= Configuring metrics collection for SPIRE Server by using a ServiceMonitor
 
-The SPIRE Server operand exposes metrics by default on port `9402` at the `/metrics` endpoint. You can configure metrics collection for the SPIRE Server by creating a `ServiceMonitor` custom resource (CR) that enables Prometheus Operator to collect custom metrics.
+[role="_abstract"]
+To collect custom metrics from the SPIRE Server, create a ServiceMonitor custom resource (CR). This configuration enables the Prometheus Operator to scrape metrics from the default endpoint, which helps you monitor your SPIRE deployment.
+
+The SPIRE Server Operand exposes metrics by default on port `9402` at the `/metrics` endpoint. You can configure metrics collection for the SPIRE Server by creating a `ServiceMonitor` custom resource (CR) that enables the Prometheus Operator to collect custom metrics.
 
 .Prerequisites
 
 * You have access to the cluster as a user with the `cluster-admin` cluster role.
+
 * You have installed the {zero-trust-full}.
-* You have deployed the SPIRE Server operand in the cluster.
+
+* You have deployed the SPIRE Server Operand in the cluster.
+
 * You have enabled the user workload monitoring.
 
 .Procedure
 
 . Create the `ServiceMonitor` CR:
 
-.. Create the YAML file that defines `ServiceMonitor` CR:
+.. Create the YAML file that defines the `ServiceMonitor` CR:
 +
 .Example `servicemonitor-spire-server` file
++
 [source,yaml]
 ----
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  labels:
+labels:
+  app.kubernetes.io/name: server
+  app.kubernetes.io/instance: spire
+name: spire-server-metrics
+namespace: zero-trust-workload-identity-manager
+spec:
+endpoints:
+- port: metrics
+  interval: 30s
+  path: /metrics
+selector:
+  matchLabels:
     app.kubernetes.io/name: server
     app.kubernetes.io/instance: spire
-  name: spire-server-metrics
-  namespace: zero-trust-workload-identity-manager
-spec:
-  endpoints:
-  - port: metrics
-    interval: 30s
-    path: /metrics
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: server
-      app.kubernetes.io/instance: spire
-  namespaceSelector:
-    matchNames:
-    - zero-trust-workload-identity-manager
+namespaceSelector:
+  matchNames:
+  - zero-trust-workload-identity-manager
 ----
 
 .. Create the `ServiceMonitor` CR by running the following command:
@@ -57,14 +64,13 @@ After the `ServiceMonitor` CR is created, the user workload Prometheus instance 
 
 .Verification
 
-. In the {product-title} web console, navigate to *Observe* → *Targets*.
-
+. In the {product-title} web console, navigate to *Observe* -> *Targets*.
 
 . In the *Label* filter field, enter the following label to filter the metrics targets:
 +
 [source,terminal]
 ----
-$ service=spire-server
+$ service=zero-trust-workload-identity-manager-metrics-service
 ----
 
 . Confirm that the *Status* column shows `Up` for the `spire-server-metrics` entry.

--- a/modules/zero-trust-manager-install-cli.adoc
+++ b/modules/zero-trust-manager-install-cli.adoc
@@ -1,4 +1,4 @@
-/ Module included in the following assemblies:
+// Module included in the following assemblies:
 //
 // * security/zero_trust_workload_identity_manageer/zero-trust-manager-install.adoc
 
@@ -9,6 +9,12 @@
 .Prerequisites
 
 * You have access to the cluster with `cluster-admin` privileges.
+
+[NOTE]
+====
+A minimum of 1Gi persistent volume is required to install the SPIRE Server.
+====
+
 .Procedure
 
 . Create a new project named `zero-trust-workload-identity-manager` by running the following command:
@@ -56,7 +62,7 @@ metadata:
   name: openshift-zero-trust-workload-identity-manager
   namespace: zero-trust-workload-identity-manager
 spec:
-  channel: tech-preview-v0.1
+  channel: stable-v1
   name: openshift-zero-trust-workload-identity-manager
   source: redhat-operators
   sourceNamespace: openshift-marketplace
@@ -72,7 +78,7 @@ $ oc create -f subscription.yaml
 
 .Verification
 
-. Verify that the OLM subscription is created by running the following command:
+* Verify that the OLM subscription is created by running the following command:
 +
 [source, terminal]
 ----
@@ -83,10 +89,10 @@ $ oc get subscription -n zero-trust-workload-identity-manager
 [source, terminal]
 ----
 NAME                                             PACKAGE                                SOURCE             CHANNEL
-openshift-zero-trust-workload-identity-manager   zero-trust-workload-identity-manager   redhat-operators   tech-preview-v0.1
+openshift-zero-trust-workload-identity-manager   zero-trust-workload-identity-manager   redhat-operators   stable-v1
 ----
 
-. Verify whether the Operator is successfully installed by running the following command:
+* Verify whether the Operator is successfully installed by running the following command:
 +
 [source, terminal]
 ----
@@ -97,10 +103,10 @@ $ oc get csv -n zero-trust-workload-identity-manager
 [source, terminal]
 ----
 NAME                                         DISPLAY                                VERSION  PHASE
-zero-trust-workload-identity-manager.v0.1.0   Zero Trust Workload Identity Manager   0.1.0    Succeeded
+zero-trust-workload-identity-manager.v1.0.0   Zero Trust Workload Identity Manager   1.0.0    Succeeded
 ----
 
-. Verify that the {zero-trust-full} controller manager is ready by running the following command:
+* Verify that the {zero-trust-full} controller manager is ready by running the following command:
 +
 [source, terminal]
 ----

--- a/modules/zero-trust-manager-install-console.adoc
+++ b/modules/zero-trust-manager-install-console.adoc
@@ -6,44 +6,55 @@
 [id="zero-trust-manager-install-console_{context}"]
 = Installing the {zero-trust-full} by using the web console
 
-You can use the web console to install the {zero-trust-full}.
+Use the OperatorHub in the {product-title} web console to install the {zero-trust-full}. This process streamlines deployment and helps ensure the Operator is installed in the correct namespace with the appropriate installation mode.
+
+[NOTE]
+====
+A minimum of 1Gi persistent volume is required to install the SPIRE Server.
+====
 
 .Prerequisites
 
 * You have access to the cluster with `cluster-admin` privileges.
+
 * You have access to the {product-title} web console.
+
 .Procedure
 
 . Log in to the {product-title} web console.
 
-. Go to *Operators* -> *OperatorHub*.
+. Go to *Ecosystem* -> *Software Catalog*.
 
-. Enter *{zero-trust-full}* into the filter box.
-
-. Select the *{zero-trust-full}*
-
-. Select the {zero-trust-full} version from *Version* drop-down list, and click *Install*.
+. Search for *{zero-trust-full}*.
 
 . On the *Install Operator* page:
-.. Update the *Update channel*, if necessary. The channel defaults to *tech-preview-v0.1*, which installs the latest Technology Preview v0.1 release of the {zero-trust-full}.
+
+.. Update the *Update channel*, if necessary. The channel defaults to `stable-v1`, which installs the latest `stable-v1` release of the {zero-trust-full}.
+
 .. Choose the *Installed Namespace* for the Operator. The default Operator namespace is `zero-trust-workload-identity-manager`.
 +
 If the `zero-trust-workload-identity-manager` namespace does not exist, it is created for you.
++
+[NOTE]
+====
+The Operator and operands are deployed in the same namespace.
+====
 
-.. Select an *Update approval* strategy.
-+
-* The *Automatic* strategy allows Operator Lifecycle Manager (OLM) to automatically update the Operator when a new version is available.
-+
-* The *Manual* strategy requires a user with appropriate credentials to approve the Operator update.
-.. Click *Install*.
+.. Select an *Update Approval* strategy
+
+* The *Automatic strategy* allows Operator Lifecycle Manager (OLM) to automatically update the Operator when a new version is available.
+
+* The *Manual strategy* requires a user with appropriate credentials to approve the Operator update.
+
+. Click *Install*.
 
 .Verification
 
-. Navigate to *Operators* -> *Installed Operators*.
+. Navigate to *Ecosystem* -> *Installed Operators*.
 
-. Verify that *{zero-trust-full}* is listed with a *Status* of *Succeeded* in the `zero-trust-workload-identity-manager` namespace.
+.. Verify that *Zero Trust Workload Identity Manager* is listed with a *Status* of *Succeeded* in the `zero-trust-workload-identity-manager` namespace.
 
-. Verify that {zero-trust-full} controller manager deployment is ready and available by running the following command:
+.. Verify that Zero Trust Workload Identity Manager controller manager deployment is ready and available by running the following command:
 +
 [source,terminal]
 ----
@@ -53,6 +64,13 @@ $ oc get deployment -l name=zero-trust-workload-identity-manager -n zero-trust-w
 .Example output
 [source,terminal]
 ----
-NAME                                                            READY   UP-TO-DATE    AVAILABLE  AGE
-zero-trust-workload-identity-manager-controller-manager-6c4djb  1/1     1             1          43m
+NAME                                                           READY UP-TO-DATE AVAILABLE AGE
+zero-trust-workload-identity-manager-controller-manager-6c4djb 1/1   1          1         43m
+----
+
+. To check the Operator logs, run the following command:
++
+[source,terminal]
+----
+$ oc logs -f deployment/zero-trust-workload-identity-manager -n zero-trust-workload-identity-manager
 ----

--- a/modules/zero-trust-manager-query-metrics.adoc
+++ b/modules/zero-trust-manager-query-metrics.adoc
@@ -11,8 +11,11 @@ As a cluster administrator, or as a user with view access to all namespaces, you
 .Prerequisites
 
 * You have access to the cluster as a user with the `cluster-admin` role.
+
 * You have installed the {zero-trust-full}.
+
 * You have deployed the SPIRE Server and SPIRE Agent operands in the cluster.
+
 * You have enabled monitoring and metrics collection by creating `ServiceMonitor` objects.
 
 .Procedure
@@ -26,7 +29,7 @@ As a cluster administrator, or as a user with view access to all namespaces, you
 {job="spire-server"}
 ----
 
-. In the query field, enter the following PromQL expression to query SPIRE Agent metrics.
+. In the query field, enter the following PromQL expression to query SPIRE Agent metrics:
 +
 [source,promql]
 ----

--- a/security/zero_trust_workload_identity_manager/zero-trust-manager-install.adoc
+++ b/security/zero_trust_workload_identity_manager/zero-trust-manager-install.adoc
@@ -1,5 +1,5 @@
 :_mod-docs-content-type: ASSEMBLY
-[id="zero-trust-manager-install"]
+[id="zero-trust-manager-install_{context}"]
 = Installing the {zero-trust-full}
 include::_attributes/common-attributes.adoc[]
 :context: zero-trust-manager-install
@@ -7,14 +7,16 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-:FeatureName: Zero Trust Workload Identity Manager for Red{nbsp}Hat OpenShift
+[role="_abstract"]
+Install {zero-trust-full} to help ensure secure communication between your workloads. You can install the {zero-trust-full} by using either the web console or CLI.
 
-include::snippets/technology-preview.adoc[]
+If you install the Operator into a custom namespace (for example, `my-custom-namespace`), all managed operand resources are deployed within that same namespace. All secrets and ConfigMaps referenced by the custom resources (CRs) must also exist in that custom namespace.
 
-The {zero-trust-full} is not installed in {product-title} by default. You can install the {zero-trust-full} by using either the web console or CLI.
+[IMPORTANT]
+====
+The Operator installation is not supported in the `openshift-*` namespaces and the `default` namespace.
+====
 
-
-== Installing the {zero-trust-full}
 // Installing the {zero-trust-full} using the web console
 include::modules/zero-trust-manager-install-console.adoc[leveloffset=+1]
 

--- a/security/zero_trust_workload_identity_manager/zero-trust-manager-monitoring.adoc
+++ b/security/zero_trust_workload_identity_manager/zero-trust-manager-monitoring.adoc
@@ -1,12 +1,13 @@
 :_mod-docs-content-type: ASSEMBLY
-[id="zero-trust-manager-monitoring"]
+[id="zero-trust-manager-monitoring_{context}"]
 = Monitoring {zero-trust-full}
 include::_attributes/common-attributes.adoc[]
 :context: zero-trust-manager-monitoring
 
 toc::[]
 
-By default, the SPIRE Server and SPIRE Agent components of the {zero-trust-full} emit metrics. You can configure OpenShift Monitoring to collect these metrics by using the Prometheus Operator format.
+[role="_abstract"]
+You can configure OpenShift Monitoring to collect these metrics by using the Prometheus Operator format. By default, the SPIRE Server and SPIRE Agent components of the {zero-trust-full} emit metrics.
 
 // Enabling metrics for the {zero-trust-full}
 
@@ -15,22 +16,23 @@ include::modules/zero-trust-manager-enable-monitoring.adoc[leveloffset=+1]
 [role="_additional-resources"]
 .Additional resources
 
-* link:https://docs.redhat.com/en/documentation/monitoring_stack_for_red_hat_openshift/4.18/html/configuring_user_workload_monitoring/configuring-metrics-uwm#setting-up-metrics-collection-for-user-defined-projects_configuring-metrics-uwm[Setting up metrics collection for user-defined projects]
+* link:https://docs.redhat.com/en/documentation/monitoring_stack_for_red_hat_openshift/4.21/html/configuring_user_workload_monitoring/configuring-metrics-uwm#setting-up-metrics-collection-for-user-defined-projects_configuring-metrics-uwm[Setting up metrics collection for user-defined projects]
 
 include::modules/zero-trust-manager-enable-metrics-server.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources
 
-* link:https://docs.redhat.com/en/documentation/monitoring_stack_for_red_hat_openshift/4.18/html/configuring_user_workload_monitoring/preparing-to-configure-the-monitoring-stack-uwm[Configuring user workload monitoring]
-
+* link:https://docs.redhat.com/en/documentation/monitoring_stack_for_red_hat_openshift/4.21/html/configuring_user_workload_monitoring/preparing-to-configure-the-monitoring-stack-uwm[Configuring user workload monitoring]
 
 include::modules/zero-trust-manager-enable-metrics-agent.adoc[leveloffset=+1]
+
+include::modules/zero-trust-manager-enable-metrics-operator.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources
 
-* link:https://docs.redhat.com/en/documentation/monitoring_stack_for_red_hat_openshift/4.18/html/configuring_user_workload_monitoring/preparing-to-configure-the-monitoring-stack-uwm[Configuring user workload monitoring]
+* link:https://docs.redhat.com/en/documentation/monitoring_stack_for_red_hat_openshift/4.21/html/configuring_user_workload_monitoring/preparing-to-configure-the-monitoring-stack-uwm[Configuring user workload monitoring]
 
 // Querying metrics for the {zero-trust-full}
 include::modules/zero-trust-manager-query-metrics.adoc[leveloffset=+1]
@@ -38,4 +40,7 @@ include::modules/zero-trust-manager-query-metrics.adoc[leveloffset=+1]
 [role="_additional-resources"]
 .Additional resources
 
-* link:https://docs.redhat.com/en/documentation/monitoring_stack_for_red_hat_openshift/4.18/html/accessing_metrics/index[Accessing metrics]
+* link:https://docs.redhat.com/en/documentation/monitoring_stack_for_red_hat_openshift/4.21/html/accessing_metrics/index[Accessing metrics]
+
+// available metrics
+include::modules/zero-trust-manager-available-metrics.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s):
4.18

Issue:
https://redhat.atlassian.net/browse/OSDOCS-19410

Link to docs preview:
https://110927--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/zero_trust_workload_identity_manager/zero-trust-manager-install.html
https://110927--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/zero_trust_workload_identity_manager/zero-trust-manager-monitoring.html

QE review:
- [ ] QE has approved this change.


Additional information:
The 4.18 documentation in this PR is a copy and paste from the most recent zero-trust documentation.

This PR contains the following assemblies:

- zero-trust-manager-install.adoc
- zero-trust-manager-monitoring.adoc

This is PR #2. This is related to the following PRs:

-  https://github.com/openshift/openshift-docs/pull/110828
- https://github.com/openshift/openshift-docs/pull/110932
- https://github.com/openshift/openshift-docs/pull/110952
- https://github.com/openshift/openshift-docs/pull/110970
- https://github.com/openshift/openshift-docs/pull/110988


The PRs were put into smaller PRs instead of having one large PR. This makes it easier for the merge reviewers.