### PR TITLE
OSDOCS-18308: Created Autonode documentation for ROSA

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ commercial_package
 !.vale/templates
 !.vale/config/vocabularies
 
+# Agent workspace
+.agent_workspace/

--- a/_attributes/attributes-openshift-dedicated.adoc
+++ b/_attributes/attributes-openshift-dedicated.adoc
@@ -35,6 +35,7 @@
 :sts-short: STS
 :insights-operator: Insights Operator
 :red-hat-lightspeed: Red{nbsp}Hat Lightspeed
+:autonode: Red{nbsp}Hat build of Karpenter
 //logging
 :logging-title: logging for Red Hat OpenShift
 :logging-title-uc: Logging for Red Hat OpenShift

--- a/_topic_maps/_topic_map_rosa_hcp.yml
+++ b/_topic_maps/_topic_map_rosa_hcp.yml
@@ -458,6 +458,7 @@ Topics:
   File: rosa-cluster-autoscaling-hcp
 - Name: Managing compute nodes using machine pools
   Dir: rosa_nodes
+  Distro: openshift-rosa-hcp
   Topics:
   - Name: About machine pools
     File: rosa-nodes-machinepools-about
@@ -470,6 +471,8 @@ Topics:
     File: rosa-nodes-about-autoscaling-nodes
   - Name: Configuring cluster memory to meet container memory and risk requirements
     File: nodes-cluster-resource-configure
+- Name: Managing compute nodes using Red Hat build of Karpenter
+  File: rosa-nodes-managing-karpenter
 - Name: Configuring PID limits
   File: rosa-configuring-pid-limits
 - Name: Managing multi-architecture clusters

--- a/modules/rosa-hcp-upgrade-options.adoc
+++ b/modules/rosa-hcp-upgrade-options.adoc
@@ -1,17 +1,23 @@
+// Module included in the following assemblies:
+//
+// * upgrading/rosa-hcp-upgrading.adoc
+
 :_mod-docs-content-type: CONCEPT
 [id="rosa-upgrade-options_{context}"]
-= Update options for {product-title} clusters
+= Update options for {product-title} clusters configured with {autonode}
 
 [role="_abstract"]
-You can control the impact of updates to your workload by controlling which parts of the cluster are updated, for example:
+You can control the impact of updates to your workload by controlling which parts of the cluster are updated. 
 
-Update only the hosted control plane:: This initiates update of the hosted control plane. It does not impact your worker nodes.
+Update only the hosted control plane:: This initiates update of the hosted control plane. When the cluster is not configured with {autonode}, it does not impact your worker nodes. When the cluster is configured with {autonode}, worker nodes that are part of the default `EC2NodeClass` resource managed by Karpenter are updated along with the {hcp}.
 
 Update nodes in a machine pool:: {product-title} machine pool updates are designed to fully replace each node in a machine pool during the update process. This provides additional security and stability benefits over performing an in-place update. Updating the nodes in a machine pool initiates a rolling replacement of nodes in the specified machine pool, and temporarily impacts the worker nodes on that machine pool. You can also update multiple machine pools concurrently.
 
+Update nodes in a Karpenter-managed `EC2NodeClass`:: When {autonode} is enabled, `OpenshiftEC2NodeClass` resource created in the cluster can be upgraded.  
+
 [IMPORTANT]
 ====
-You cannot update the hosted control plane at the same time as any machine pool update. You will need to update the hosted control plane first, and then update machine pools.
+You cannot update the hosted control plane at the same time as any machine pool update. You must update the hosted control plane first, and then update machine pools.
 ====
 
 [IMPORTANT]

--- a/modules/rosa-hcp-upgrading-autonode-clusters.adoc
+++ b/modules/rosa-hcp-upgrading-autonode-clusters.adoc
@@ -1,0 +1,24 @@
+// Module included in the following assemblies:
+//
+// * upgrading/rosa-hcp-upgrading.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="rosa-nodes-autonode-upgrading-autonode_{context}"]
+= Understanding upgrades for {product-title} clusters configured with {autonode}
+
+[role="_abstract"]
+You can upgrade clusters that are configured with {autonode}. 
+
+[id="rosa-nodes-autonode-upgrading-autonode-openshiftec2nodeclass_{context}"]
+*Default `OpenshiftEC2NodeClass`*
+
+When you enable {autonode}, a default `OpenshiftEC2NodeClass` resource is created with the same version as that of the hosted control plane. All node pools that reference the default `EC2NodeClass` are automatically upgraded as part of the hosted control plane upgrade.
+
+[id="rosa-nodes-autonode-upgrading-autonode-secondary-openshiftec2nodeclass_{context}"]
+*Optional `OpenshiftEC2NodeClass`*
+
+Upgrade behavior depends on whether or not the `OpenshiftEC2NodeClass` is pinned to a version by using the `spec.version` field.  
+
+Unpinned `OpenshiftEC2NodeClass`:: By default, `OpenshiftEC2NodeClass` resources have the same version of the hosted control plane. When the hosted control plane is upgraded, unpinned `OpenshiftEC2NodeClass` resources are automatically upgraded.  
+
+Pinned `OpenshiftEC2NodeClass`:: In the `OpenshiftEC2NodeClass` resource, you can specify a valid {ocp-short} version in `spec.version`. Specifying this version pins the cluster's node pools to a specific version. Any pinned `OpenshiftEC2NodeClass` resources are not upgraded as part of the hosted control plane upgrade. You can update the `spec.version` of pinned `OpenshiftEC2NodeClass` resources to a valid version. Updating this `spec.version` field initiates the upgrade of all of the node pools that reference its corresponding `OpenshiftEC2NodeClass` resource. 

--- a/modules/rosa-nodes-autonode-about.adoc
+++ b/modules/rosa-nodes-autonode-about.adoc
@@ -1,0 +1,12 @@
+// Module included in the following assemblies:
+//
+// * rosa_cluster_admin/rosa-nodes-managing-karpenter.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="rosa-nodes-autonode-about_{context}"]
+= About {autonode}
+
+[role="_abstract"]
+{autonode} builds on the open source Karpenter project and provides automatic node provisioning for {product-title} clusters. Karpenter watches for pods that the Kubernetes scheduler marks as unschedulable and evaluates their scheduling constraints, including resource requests, node selectors, affinities, tolerations, and topology spread constraints. Karpenter then provisions nodes that meet the specific requirements of those waiting pods.
+
+Karpenter improves cluster efficiency by provisioning nodes that match workload requirements instead of requiring pre-configured node pools. When nodes are no longer needed, Karpenter removes them to reduce costs. For more information about Karpenter capabilities and architecture, see _Karpenter project documentation_ in the Additional resources.

--- a/modules/rosa-nodes-autonode-managing-create-nodepool.adoc
+++ b/modules/rosa-nodes-autonode-managing-create-nodepool.adoc
@@ -1,0 +1,74 @@
+// Module included in the following assemblies:
+//
+// * rosa_cluster_admin/rosa-nodes-managing-karpenter.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="rosa-nodes-autonode-managing-nodepool_{context}"]
+= Create a node pool
+
+[role="_abstract"]
+Create a node pool to define the compute capacity that {autonode} can provision.
+
+.Procedure
+
+. Create a node pool manifest:
++
+[source,terminal]
+----
+$ cat > nodepool.yaml <<'EOF'
+apiVersion: karpenter.sh/v1
+kind: NodePool
+metadata:
+  name: default-np
+spec:
+  template:
+    metadata:
+      labels:
+        autonode: "true"
+    spec:
+      requirements:
+      - key: node.kubernetes.io/instance-type
+        operator: In
+        values:
+        - c5.xlarge
+      - key: karpenter.sh/capacity-type
+        operator: In
+        values: ["on-demand"]
+      nodeClassRef:
+        group: karpenter.k8s.aws
+        kind: EC2NodeClass
+        name: default
+EOF
+----
+where:
+`nodeClassRef.kind`::
+Required field that must use the `EC2NodeClass` type.
+`spec.labels`::
+Optional field that you can use to place pods by using labels.
++
+[NOTE]
+====
+For a list of all requirements available under `spec.requirements`, see the _Additional resources_.
+====
+
+. Apply the node pool:
++
+[source,terminal]
+----
+$ oc apply -f nodepool.yaml
+----
+
+. Verify the node pool is ready:
++
+[source,terminal]
+----
+$ oc get nodepool
+----
++
+*Example output*
++
+[source,terminal]
+----
+NAME         NODECLASS   NODES   READY   AGE
+default-np   default     0       True    3s
+----

--- a/modules/rosa-nodes-autonode-managing-enable-cli.adoc
+++ b/modules/rosa-nodes-autonode-managing-enable-cli.adoc
@@ -1,0 +1,103 @@
+// Module included in the following assemblies:
+//
+// * rosa_cluster_admin/rosa-nodes-managing-karpenter.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="rosa-nodes-autonode-managing-enable-cli_{context}"]
+= Enable {autonode} using {rosa-cli}
+
+[role="_abstract"]
+Enable {autonode} on your cluster by using {rosa-cli-first} after it finishes installing.
+
+.Procedure
+
+. Export your cluster name and ID to environment variables:
++
+[source,terminal,subs="+quotes"]
+----
+$ export CLUSTER_NAME=<cluster_name>
+$ export CLUSTER_ID=$(rosa describe cluster -c "$CLUSTER_NAME" -o json | jq -r '.id')
+$ echo $CLUSTER_NAME $CLUSTER_ID
+----
+
+. Wait for the cluster to become ready:
++
+[source,terminal]
+----
+$ rosa describe cluster -c $CLUSTER_ID | grep -i State
+----
++
+*Example output*
++
+[source,terminal]
+----
+State:                      ready
+----
+
+. Ensure that your {autonode} IAM role is correctly set:
++
+[source,terminal]
+----
+$ ROLE_ARN=$(aws iam get-role --role-name rosa-karpenter-controller-role-${CLUSTER_NAME} --query 'Role.Arn' --output text)
+----
+
+. Enable {autonode}:
++
+[source,terminal]
+----
+$ rosa edit cluster -c $CLUSTER_ID \
+  --autonode=enabled \
+  --autonode-iam-role-arn=$ROLE_ARN
+----
+
+. If you do not already have cluster admin access, create a cluster admin user:
++
+[source,terminal]
+----
+$ rosa create admin -c $CLUSTER_ID
+----
+
+. Log in to the cluster using the credentials from the previous command:
++
+[source,terminal]
+----
+$ oc login <api_url> --username cluster-admin --password <password>
+----
+
+. Verify that the {autonode} custom resource definitions (CRDs) are present:
++
+[source,terminal]
+----
+$ oc get ec2nodeclass
+----
++
+[NOTE]
+====
+The node pool manifest uses the `EC2NodeClass` resource.
+====
++
+*Example output*
++
+[source,terminal]
+----
+NAME      READY   AGE
+default   True    5m
+----
++
+[source,terminal]
+----
+$ oc get openshiftec2nodeclass
+----
++
+[NOTE]
+====
+The `OpenShiftEC2NodeClass` resource is Red{nbsp}Hat's wrapper to communicate with the `EC2NodeClass` resource.
+====
++
+*Example output*
++
+[source,terminal]
+----
+NAME      READY
+default   True
+----

--- a/modules/rosa-nodes-autonode-managing-enable-ui.adoc
+++ b/modules/rosa-nodes-autonode-managing-enable-ui.adoc
@@ -1,0 +1,77 @@
+// Module included in the following assemblies:
+//
+// * rosa_cluster_admin/rosa-nodes-managing-karpenter.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="rosa-nodes-autonode-managing-enable-ui_{context}"]
+= Enable {autonode} using {cluster-manager}
+
+[role="_abstract"]
+Enable {autonode} on your cluster by using {cluster-manager} after it finishes installing.
+
+.Prerequisites
+* You have created a {product-title} cluster, version 4.22.0 or later.
+* You have created an AWS Identity and Access Management (IAM) role to be configured for {autonode}.
+* You have your cluster's Open ID Connect (OIDC) Endpoint URL.
++ 
+[NOTE]
+====
+Run `rosa describe cluster -c $CLUSTER_NAME | grep "OIDC Endpoint URL"` to see this URL. Do not include the `https://` prefix from the OIDC Endpoint URL. For example, use  `example-oidc-endpoint.cloudfront.net/abcd1234examplehash5678` instead of `https://example-oidc-endpoint.cloudfront.net/abcd1234examplehash5678`.
+====
+* You have the proper credentials to access the AWS console.
+
+
+.Procedure
+
+. Export your AWS ID:
++
+[source,terminal]
+----
+$ export AWS_ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
+----
+
+. Log in to the link:https://console.aws.amazon.com/[AWS console]. 
+. In the AWS console, navigate to **IAM > Roles**.
+. On your {autonode} Amazon Resource Name (ARN), update the trust policy to include the following policy specifications:
++
+[NOTE]
+====
+To access this ARN, run:
+
+[source,terminal]
+----
+$ echo $ROLE_ARN
+----
+====
++
+[source,json]
+----
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Principal": {
+                "Federated": "arn:aws:iam::<aws_account_id>:oidc-provider/<oidc-endpoint-url>"
+            },
+            "Action": "sts:AssumeRoleWithWebIdentity",
+            "Condition": {
+                "StringEquals": {
+                    "<oidc-endpoint-url>:sub": "system:serviceaccount:kube-system:karpenter"
+                }
+            }
+        }
+    ]
+}
+----
+where:
+<aws_account_id>::
+Specifies your AWS Account ID. 
+<oidc-endpoint-url>::
+Specifies the OIDC endpoint URL that you acquired.
+
+. In {cluster-manager-url}, select your cluster from the cluster list.
+. On the cluster details screen, select the *Edit* button next to the status for {autonode}. 
+. On the *Edit Autonode settings* dialog box, toggle *Enable Autonode*.
+. Add your {autonode} IAM role ARN to the field in this dialog box.
+. Select *Save* to save your configurations and close the *Edit Autonode settings* box.

--- a/modules/rosa-nodes-autonode-managing-iam-setup.adoc
+++ b/modules/rosa-nodes-autonode-managing-iam-setup.adoc
@@ -1,0 +1,104 @@
+// Module included in the following assemblies:
+//
+// * rosa_cluster_admin/rosa-nodes-managing-karpenter.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="rosa-nodes-autonode-managing-setup_{context}"]
+= Prepare an AWS IAM role for {autonode}
+
+[role="_abstract"]
+Create the IAM policy and role that {autonode} requires to provision Amazon Elastic Compute Cloud (Amazon EC2) instances.
+
+This policy grants {autonode} the following permissions:
+
+* Create and terminate EC2 instances and fleets
+* Create and manage launch templates
+* Tag resources with Karpenter-specific tags
+* Describe EC2 resources such as instances, instance types, and subnets
+* Access Systems Manager (SSM) parameters for Amazon Machine Image (AMI) information
+* Query EC2 pricing information
+* Manage Simple Queue Service (SQS) interruption queues for Spot instance handling
+* Create and manage IAM instance profiles
++
+[NOTE]
+====
+All permissions are restricted to resources tagged with Karpenter-specific tags to ensure {autonode} manages only nodes that it provisions.
+====
+
+.Procedure
+
+. Download the latest {autonode} IAM policy:
++
+[source,terminal]
+----
+$ curl -o autonode-policy.json https://raw.githubusercontent.com/openshift/managed-cluster-config/refs/heads/master/resources/sts/hypershift/openshift_hcp_karpenter_controller_credentials_policy.json
+----
+
+. Export your cluster name and ID to environment variables:
++
+[source,terminal,subs="+quotes"]
+----
+$ export CLUSTER_NAME=<cluster_name>
+$ export CLUSTER_ID=$(rosa describe cluster -c "$CLUSTER_NAME" -o json | jq -r '.id')
+$ echo $CLUSTER_NAME $CLUSTER_ID
+----
+
+. Create the IAM policy:
++
+[source,terminal]
+----
+$ POLICY_ARN=$(aws iam create-policy \
+  --policy-name rosa-karpenter-controller-role-${CLUSTER_NAME} \
+  --policy-document file://autonode-policy.json \
+  --query 'Policy.Arn' \
+  --output text)
+----
+
+. Create the trust policy for the Karpenter service account:
++
+[source,terminal]
+----
+$ cat > trust-policy.json <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Principal": {
+                "Federated": "arn:aws:iam::$(aws sts get-caller-identity --query Account --output text):oidc-provider/$(rosa describe cluster -c $CLUSTER_NAME -o json | jq -r .aws.sts.oidc_endpoint_url | sed 's|https://||')"
+            },
+            "Action": "sts:AssumeRoleWithWebIdentity",
+            "Condition": {
+                "StringEquals": {
+                    "$(rosa describe cluster -c $CLUSTER_NAME -o json | jq -r .aws.sts.oidc_endpoint_url | sed 's|https://||'):sub": "system:serviceaccount:kube-system:karpenter"
+                }
+            }
+        }
+    ]
+}
+EOF
+----
+
+. Create the IAM role and attach the policy:
++
+[source,terminal]
+----
+$ ROLE_ARN=$(aws iam create-role \
+  --role-name rosa-karpenter-controller-role-${CLUSTER_NAME} \
+  --assume-role-policy-document file://trust-policy.json \
+  --query 'Role.Arn' \
+  --output text)
+
+$ aws iam attach-role-policy \
+  --role-name rosa-karpenter-controller-role-${CLUSTER_NAME} \
+  --policy-arn $POLICY_ARN
+----
++
+
+.Verification 
+
+Verify that policies are present by running:
+[source,terminal]
+----
+$ aws iam list-attached-role-policies --role-name rosa-karpenter-controller-role-${CLUSTER_NAME}
+----

--- a/modules/rosa-nodes-autonode-managing-tagging-setup.adoc
+++ b/modules/rosa-nodes-autonode-managing-tagging-setup.adoc
@@ -1,0 +1,41 @@
+// Module included in the following assemblies:
+//
+// * rosa_cluster_admin/rosa-nodes-managing-karpenter.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="rosa-nodes-autonode-managing-tagging-setup_{context}"]
+= Tag your AWS resources for {autonode}
+
+[role="_abstract"]
+Create the necessary AWS tags so that {autonode} discovers the security group to use when provisioning nodes. Tag the security group for the cluster that was created during cluster installation. 
+
+.Procedure
+
+. Export your cluster name and ID to environment variables:
++
+[source,terminal,subs="+quotes"]
+----
+$ export CLUSTER_NAME=<cluster_name>
+$ export AWS_REGION=us-east-2
+$ export CLUSTER_ID=$(rosa describe cluster -c "$CLUSTER_NAME" -o json | jq -r '.id')
+$ echo $CLUSTER_NAME $CLUSTER_ID
+----
++
+[IMPORTANT]
+====
+Ensure that your AWS client is using the region where your cluster is deployed. In this example, `us-east-2` is used.
+====
+
+. Find your cluster's security group by running the following command:
++
+[source,terminal]
+----
+$ SECURITY_GROUP_ID=$(aws ec2 describe-security-groups --filters "Name=tag:Name,Values=$CLUSTER_ID-default-sg" | jq -r .SecurityGroups[0].GroupId)
+----
+
+. Tag the security group with the {autonode} auto-discovery tags by running the following command:
++
+[source,terminal]
+----
+$ aws ec2 create-tags --resources "$SECURITY_GROUP_ID" --tags Key="karpenter.sh/discovery",Value="$CLUSTER_ID"
+----

--- a/modules/rosa-release-notes-Q2-2026.adoc
+++ b/modules/rosa-release-notes-Q2-2026.adoc
@@ -8,9 +8,17 @@
 [role="_abstract"]
 The following items were added during the second quarter of 2026.
 
+ifdef::openshift-rosa-hcp[]
+{autonode} based on Karpenter v1.9 is available for managing compute nodes::
++
+With this update, you can use {autonode} to automatically provision compute nodes based on workload demand. {autonode} is based on the open-source Karpenter project and provides dynamic node provisioning that matches workload requirements without requiring pre-configured node pools. When pods no longer require a node, {autonode} removes the node to reduce costs. 
+
+//For more information, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html/cluster_administration/rosa_cluster_admin/rosa-nodes-managing-karpenter#rosa-nodes-autonode-managing[Managing compute nodes using {autonode}].
+endif::openshift-rosa-hcp[]
+
 Upgrade channels are available::
 +
-You can choose the new channels option for more precise, version-specific control over your cluster updates. You can target exact minor version paths, such as `stable-4.20` or `fast-4.21`, instead of relying on broader channel groups, which are being deprecated. For more information, see
+You can select the new channels option for more precise, version-specific control over your cluster updates. You can target exact minor version paths, such as `stable-4.20` or `fast-4.21`, instead of relying on broader channel groups, which are being deprecated. For more information, see
 ifdef::openshift-rosa-hcp[]
  link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html/upgrading/index#rosa-hcp-upgrading-channels_rosa-hcp-upgrading[Channels in {product-title} clusters].
 endif::openshift-rosa-hcp[]
@@ -20,7 +28,7 @@ endif::openshift-rosa[]
 
 The `fast` upgrade channel is available as an update option::
 +
-You can choose `fast` as an upgrade channel when creating or updating your {product-title} clusters. The `fast` channel is updated with new versions of {product-title} as soon as Red{nbsp}Hat declares the version as a general availability (GA) release.
+You can select `fast` as an upgrade channel when creating or updating your {product-title} clusters. Red{nbsp}Hat updates the `fast` channel with new versions of {product-title} as soon as Red{nbsp}Hat declares the version as a general availability (GA) release.
 
 ifdef::openshift-rosa-hcp[]
 FIPS-encrypted {product-title} clusters::

--- a/rosa_cluster_admin/rosa-nodes-managing-karpenter.adoc
+++ b/rosa_cluster_admin/rosa-nodes-managing-karpenter.adoc
@@ -1,0 +1,38 @@
+:_mod-docs-content-type: ASSEMBLY
+include::_attributes/attributes-openshift-dedicated.adoc[]
+[id="rosa-nodes-autonode-managing"]
+= Manage compute nodes using {autonode}
+:context: rosa-nodes-autonode-managing
+
+toc::[]
+
+[role="_abstract"]
+{autonode} provisions compute nodes automatically based on workload demand. By automatically provisioning your nodes, {autonode} helps improve cluster efficiency and reduce costs.
+
+== Prerequisites
+
+* You have installed the {rosa-cli-first} version 1.2.61 or later.
+* You have an {ocp-short} cluster version 4.22.0 or later.
+* You have installed the `jq` CLI tool.
+* You have installed the `curl` CLI tool.
+* You have the required AWS Identity and Access Management (IAM) permissions to create policies and roles.
+
+include::modules/rosa-nodes-autonode-about.adoc[leveloffset=+1]
+
+include::modules/rosa-nodes-autonode-managing-iam-setup.adoc[leveloffset=+1]
+
+include::modules/rosa-nodes-autonode-managing-tagging-setup.adoc[leveloffset=+1]
+
+include::modules/rosa-nodes-autonode-managing-enable-cli.adoc[leveloffset=+1]
+
+include::modules/rosa-nodes-autonode-managing-enable-ui.adoc[leveloffset=+1]
+
+include::modules/rosa-nodes-autonode-managing-create-nodepool.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* link:https://karpenter.sh/docs/[Karpenter project documentation]
+* link:https://karpenter.sh/docs/concepts/nodepools/[`NodePools` reference]
+* xref:../authentication/sd-configuring-identity-providers.adoc#sd-configuring-identity-providers[Identity providers overview]
+* xref:../upgrading/rosa-hcp-upgrading.adoc#rosa-upgrade-options_rosa-hcp-upgrading[Update options for {product-title} clusters configured with {autonode}]

--- a/upgrading/rosa-hcp-upgrading.adoc
+++ b/upgrading/rosa-hcp-upgrading.adoc
@@ -11,6 +11,8 @@ In {product-title}, updating provisions a new component with updated software an
 
 include::modules/rosa-hcp-upgrade-options.adoc[leveloffset=+1]
 
+include::modules/rosa-hcp-upgrading-autonode-clusters.adoc[leveloffset=+1]
+
 include::modules/rosa-upgrading-lifecycle-policy.adoc[leveloffset=+1]
 
 include::modules/rosa-hcp-upgrading-channels.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s):
`enterprise-4.21+`

Issue:
**[OSDOCS-19805](https://redhat.atlassian.net/browse/OSDOCS-19805)**
**[OSDOCS-20072](https://redhat.atlassian.net/browse/OSDOCS-20072)**

Link to docs preview:

1. [Manage compute nodes by using the Red Hat build of Karpenter](https://110935--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/rosa_cluster_admin/rosa-nodes-managing-karpenter)
2. [Understanding upgrades for Red Hat OpenShift Service on AWS clusters configured with Red Hat build of Karpenter
](https://110935--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/upgrading/rosa-hcp-upgrading#rosa-nodes-autonode-upgrading-autonode_rosa-hcp-upgrading)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
This PR adds documentation to ROSA and ROSA (classic) about creating clusters with AutoNode scaling enabled.