### PR TITLE
[OCPBUGS#16758]: Add sections for Openshift 4 custom TLS Certificate update process

### DIFF
--- a/modules/customize-certificates-api-add-named.adoc
+++ b/modules/customize-certificates-api-add-named.adoc
@@ -4,119 +4,98 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="customize-certificates-api-add-named_{context}"]
-= Add an API server named certificate
+= Adding an API server named certificate for the first time
 
-The default API server certificate is issued by an internal {product-title}
-cluster CA. You can add one or more alternative certificates that the API
-server will return based on the fully qualified domain name (FQDN) requested by
-the client, for example when a reverse proxy or load balancer is used.
+[role="_abstract"]
+The default API server certificate is issued by an internal {product-title} cluster Certificate Authority (CA). You can add alternative certificates that the API server will return based on the fully qualified domain name (FQDN) requested by the client, for example when a reverse proxy or load balancer is used.
+
+[NOTE]
+====
+Adding a custom API server named certificate for the first time triggers the `kube-apiserver-operator` to roll out a new revision of the API server pods. Node reboots are not required.
+====
 
 .Prerequisites
 
 * You must have a certificate for the FQDN and its corresponding private key. Each should be in a separate PEM format file.
-* The private key must be unencrypted. If your key is encrypted, decrypt it
-before importing it into {product-title}.
+* The private key must be unencrypted.
 * The certificate must include the `subjectAltName` extension showing the FQDN.
-* The certificate file can contain one or more certificates in a chain. The
-certificate for the API server FQDN must be the first certificate in the file.
-It can then be followed with any intermediate certificates, and the file should
-end with the root CA certificate.
+* The certificate file can contain one or more certificates in a chain. The certificate for the API server FQDN must be the first certificate in the file, followed by intermediate certificates, and ending with the root CA certificate.
 
 [WARNING]
 ====
-Do not provide a named certificate for the internal load balancer (host
-name `api-int.<cluster_name>.<base_domain>`). Doing so will leave your
-cluster in a degraded state.
+Do not provide a named certificate for the internal load balancer (host name `api-int.<cluster_name>.<base_domain>`). Doing so will leave your cluster in a degraded state.
 ====
 
 .Procedure
 
-. Login to the new API as the `kubeadmin` user.
+. Log in to the CLI as the `kubeadmin` user:
 +
 [source,terminal]
 ----
-$ oc login -u kubeadmin -p <password> https://FQDN:6443
+$ oc login -u kubeadmin -p <password> https://<fqdn>:6443
 ----
++
+where:
++
+--
+`<password>`:: Specifies your cluster administrative password.
+`<fqdn>`:: Specifies the fully qualified domain name of the internal cluster API endpoint.
+--
 
-. Get the `kubeconfig` file.
+. Create a secret that contains the certificate chain and private key in the `openshift-config` namespace:
 +
 [source,terminal]
 ----
-$ oc config view --flatten > kubeconfig-newapi
-----
-
-. Create a secret that contains the certificate chain and private key in the
-`openshift-config` namespace.
-+
-[source,terminal]
-----
-$ oc create secret tls <secret> \//<1>
-     --cert=</path/to/cert.crt> \//<2>
-     --key=</path/to/cert.key> \//<3>
+$ oc create secret tls <secret_name> \
+     --cert=<path_to_certificate_file> \
+     --key=<path_to_private_key_file> \
      -n openshift-config
 ----
-<1> `<secret>` is the name of the secret that will contain the certificate chain and private key.
-<2> `</path/to/cert.crt>` is the path to the certificate chain on your local file system.
-<3> `</path/to/cert.key>` is the path to the private key associated with this certificate.
-
-. Update the API server to reference the created secret.
 +
-[source,terminal]
-----
-$ oc patch apiserver cluster \
-     --type=merge -p \
-     '{"spec":{"servingCerts": {"namedCertificates":
-     [{"names": ["<FQDN>"],
-     "servingCertificate": {"name": "<secret>"}}]}}}'
-----
 where:
++
+--
+`<secret_name>`:: Specifies the name of the new secret resource that will contain the cryptographic key pair.
+`<path_to_certificate_file>`:: Specifies the absolute local path to your custom certificate chain file.
+`<path_to_private_key_file>`:: Specifies the absolute local path to the unencrypted private key file associated with the certificate.
+--
 
-<FQDN>:: Replace `<FQDN>` with the FQDN that the API server should provide the certificate for. Do not include the port number.
-<secret>:: Replace `<secret>` with the name used for the secret in the previous step.
-
-. Examine the `apiserver/cluster` object and confirm the secret is now
-referenced.
+. Update the API server to reference the created secret resource:
 +
 [source,terminal]
 ----
-$ oc get apiserver cluster -o yaml
+$ oc patch apiserver cluster --type=merge -p '
+{
+  "spec": {
+    "servingCerts": {
+      "namedCertificates": [
+        {
+          "names": ["<fqdn>"],
+          "servingCertificate": {
+            "name": "<secret_name>"
+          }
+        }
+      ]
+    }
+  }
+}'
 ----
 +
-.Example output
-[source,terminal]
-----
-...
-spec:
-  servingCerts:
-    namedCertificates:
-    - names:
-      - <FQDN>
-      servingCertificate:
-        name: <secret>
-...
-----
+where:
++
+--
+`<fqdn>`:: Specifies the fully qualified domain name for which the API server serves this custom certificate. Do not include a port number.
+`<secret_name>`:: Specifies the name of the secret you created in the previous step.
+--
 
-. Check the `kube-apiserver` operator, and verify that a new revision of the Kubernetes API server rolls out.
-It may take a minute for the operator to detect the configuration change and trigger a new deployment.
-While the new revision is rolling out, `PROGRESSING` will report `True`.
+. Verify that a new revision of the Kubernetes API server rolls out by checking the operator status:
 +
 [source,terminal]
 ----
 $ oc get clusteroperators kube-apiserver
 ----
 +
-Do not continue to the next step until `PROGRESSING` is listed as `False`, as shown in the following output:
-+
-.Example output
-[source,terminal,subs="attributes+"]
-----
-NAME             VERSION   AVAILABLE   PROGRESSING   DEGRADED   SINCE
-kube-apiserver   {product-version}.0     True        False         False      145m
-----
-+
-If `PROGRESSING` is showing `True`, wait a few minutes and try again.
-+
 [NOTE]
 ====
-A new revision of the Kubernetes API server only rolls out if the API server named certificate is added for the first time. When the API server named certificate is renewed, a new revision of the Kubernetes API server does not roll out because the `kube-apiserver` pods dynamically reload the updated certificate.
+The `PROGRESSING` status column will change to `True` while the API server operator deploys the new pod revision configured with your custom certificate. Do not interrupt the process or apply additional configuration updates while the rollout is underway. Continue only after the status returns to `False` and `AVAILABLE` reads `True`.
 ====

--- a/modules/customize-certificates-api-renew-named.adoc
+++ b/modules/customize-certificates-api-renew-named.adoc
@@ -1,0 +1,57 @@
+// Module included in the following assemblies:
+//
+// * security/certificates/api-server.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="customize-certificates-api-renew-named_{context}"]
+= Updating or renewing an existing API server named certificate
+
+[role="_abstract"]
+Update or renew an expired or expiring named certificate that has already been configured in your cluster to avoid API availability issues. The API server pods dynamically detect and reload the updated certificate asset without disruption.
+
+[NOTE]
+====
+When an existing API server named certificate is renewed by updating its corresponding secret, a new revision of the Kubernetes API server pods does not roll out. Node reboots are not required.
+====
+
+[WARNING]
+====
+If the renewed certificate is signed by a different root CA than the previous certificate, internal applications or custom pods that communicate with the API server might encounter X509 certificate validation errors. If these client workloads do not automatically hot-reload their truststores, you must manually restart them to force them to pick up the new certificate chain.
+====
+
+.Prerequisites
+
+* You have the renewed certificate chain and private key files in PEM format.
+* The secret containing the old certificate already exists in the `openshift-config` namespace and is actively referenced by the `apiserver/cluster` configuration.
+
+.Procedure
+
+. Log in to the CLI as the `kubeadmin` user.
+
+. Update the existing secret resource in the `openshift-config` namespace with the newly issued certificate and private key:
++
+[source,terminal]
+----
+$ oc create secret tls <existing_secret_name> \
+     --cert=<path_to_new_cert>.crt \
+     --key=<path_to_new_key>.key \
+     -n openshift-config \
+     --dry-run=client -o yaml | oc replace -f -
+----
++
+where:
++
+--
+`<existing_secret_name>`:: Specifies the target name of the existing active secret that you are replacing.
+`<path_to_new_cert>.crt`:: Specifies the absolute local file system path to the renewed certificate chain file.
+`<path_to_new_key>.key`:: Specifies the absolute local file system path to the corresponding unencrypted private key file.
+--
+
+. Verify that the `kube-apiserver` pods successfully hot-reload the updated assets without initiating a new cluster deployment revision:
++
+[source,terminal]
+----
+$ oc get clusteroperators kube-apiserver
+----
++
+Confirm that the `PROGRESSING` status column remains `False`. If the status changes to `True`, verify that your underlying `apiserver/cluster` resource parameters were not modified structural layout changes during the substitution.

--- a/security/certificates/api-server.adoc
+++ b/security/certificates/api-server.adoc
@@ -17,3 +17,4 @@ In hosted control plane clusters, you can add as many custom certificates to you
 ====
 
 include::modules/customize-certificates-api-add-named.adoc[leveloffset=+1]
+include::modules/customize-certificates-api-renew-named.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s):
4.16+

Issue:
https://redhat.atlassian.net/browse/OCPBUGS-16758actionerId=63c10c428a7d2f693bf779a3&sourceType=assign

Link to docs preview:
https://110943--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/certificates/api-server.html

QE review:
- [x] QE has approved this change.