### PR TITLE
OSDOCS-19431: fix toc elements RHCL docs

### DIFF
--- a/deployment/coredns.adoc
+++ b/deployment/coredns.adoc
@@ -1,10 +1,10 @@
 :_mod-docs-content-type: ASSEMBLY
+include::_attributes/attributes.adoc[]
 [id="rhcl-using-on-prem-dns-coredns"]
 = Using on-premise DNS with CoreDNS
-include::_attributes/attributes.adoc[]
 :context: rhcl-using-on-prem-dns-coredns
 
-//toc::[]
+toc::[]
 
 [role="_abstract"]
 You can secure, protect, and connect an API exposed by a gateway that uses Gateway API by using {prodname}.

--- a/deployment/deployment.adoc
+++ b/deployment/deployment.adoc
@@ -1,8 +1,10 @@
 :_mod-docs-content-type: ASSEMBLY
+include::_attributes/attributes.adoc[]
 [id="rhcl-config-deploy-gateway-policies"]
 = Configuring and deploying gateway policies
-include::_attributes/attributes.adoc[]
 :context: rhcl-config-deploy-gateway-policies
+
+toc::[]
 
 [role="_abstract"]
 You can use {prodname} to connect and secure an API exposed by a `Gateway` object.

--- a/install-guide/install-guide.adoc
+++ b/install-guide/install-guide.adoc
@@ -4,7 +4,7 @@ include::_attributes/attributes.adoc[]
 = Installing on {ocp}
 :context: installing-rhcl-on-ocp
 
-//toc:[]
+toc::[]
 
 [role="_abstract"]
 As a platform engineer, you can install {prodname} on {ocp} clusters.

--- a/introduction/introduction.adoc
+++ b/introduction/introduction.adoc
@@ -4,6 +4,8 @@ include::_attributes/attributes.adoc[]
 = About {prodname}
 :context: rhcl-introduction
 
+toc::[]
+
 [role="_abstract"]
 {product-title} is a control plane for configuring the Gateway API data plane in {ocp} clusters. You can use it to apply authentication, rate limiting, and DNS policies to gateway resources.
 

--- a/mcp_gateway_config/mcp-gateway-authentication.adoc
+++ b/mcp_gateway_config/mcp-gateway-authentication.adoc
@@ -4,6 +4,8 @@ include::_attributes/attributes.adoc[]
 = Using authentication with {mcpg}
 :context: mcp-gateway-authentication
 
+toc::[]
+
 [role="_abstract"]
 You can configure authentication for {mcpg} by using an `AuthPolicy` custom resource (CR) with an identity provider, or any Istio or Gateway API compatible mechanism.
 

--- a/mcp_gateway_config/mcp-gateway-authorization.adoc
+++ b/mcp_gateway_config/mcp-gateway-authorization.adoc
@@ -4,6 +4,8 @@ include::_attributes/attributes.adoc[]
 = Using authorization with {mcpg}
 :context: mcp-gateway-authorization
 
+toc::[]
+
 [role="_abstract"]
 You can configure authorization for the {mcpg} by using an additional `AuthPolicy` custom resource (CR) that adds access control for servers, data, and tools.
 

--- a/mcp_gateway_config/mcp-gateway-creating-virtual-mcp-servers.adoc
+++ b/mcp_gateway_config/mcp-gateway-creating-virtual-mcp-servers.adoc
@@ -1,8 +1,10 @@
 :_mod-docs-content-type: ASSEMBLY
+include::_attributes/attributes.adoc[]
 [id="mcp-gateway-create-virtual-mcp-servers"]
 = Creating virtual MCP servers
-include::_attributes/attributes.adoc[]
 :context: mcp-gateway-register-virtual-mcp-servers
+
+toc::[]
 
 [role="_abstract"]
 Create focused, curated tool collections from your aggregated internal and external MCP servers by creating virtual MCP servers from any of your registered MCP servers.

--- a/mcp_gateway_config/mcp-gateway-register-ext-mcp-servers.adoc
+++ b/mcp_gateway_config/mcp-gateway-register-ext-mcp-servers.adoc
@@ -1,8 +1,10 @@
 :_mod-docs-content-type: ASSEMBLY
+include::_attributes/attributes.adoc[]
 [id="mcp-gateway-register-ext-mcp-servers"]
 = Registering external MCP servers
-include::_attributes/attributes.adoc[]
 :context: mcp-gateway-register-ext-mcp-servers
+
+toc::[]
 
 [role="_abstract"]
 To use external MCP servers with your MCP gateway, you must configure ingress, create routing resources, and register the server with the MCP gateway. As a best practice, you must also configure security rules.

--- a/mcp_gateway_config/mcp-gateway-register-on-prem-mcp-servers.adoc
+++ b/mcp_gateway_config/mcp-gateway-register-on-prem-mcp-servers.adoc
@@ -1,8 +1,10 @@
 :_mod-docs-content-type: ASSEMBLY
+include::_attributes/attributes.adoc[]
 [id="mcp-gateway-register-on-prem-mcp-servers"]
 = Registering on-prem MCP servers
-include::_attributes/attributes.adoc[]
 :context: mcp-gateway-register-on-prem-servers
+
+toc::[]
 
 [role="_abstract"]
 To begin using MCP servers with your {mcpg}, you must register each server by creating an `HTTPRoute` custom resource (CR) and a corresponding `MCPServerRegistration` CR that references the route.

--- a/mcp_gateway_config/mcp-gateway-revoke-tool-access.adoc
+++ b/mcp_gateway_config/mcp-gateway-revoke-tool-access.adoc
@@ -1,8 +1,10 @@
 :_mod-docs-content-type: ASSEMBLY
+include::_attributes/attributes.adoc[]
 [id="mcp-gateway-revoke-mcp-server-tool-access"]
 = Revoking MCP server tool access
-include::_attributes/attributes.adoc[]
 :context: mcp-gateway-revoke-mcp-server-tool-access
+
+toc::[]
 
 [role="_abstract"]
 You can revoke tool access for users and groups. Tool revocation prevents a user or group from calling specific MCP tools.

--- a/mcp_gateway_discover/mcp-gateway-introduction.adoc
+++ b/mcp_gateway_discover/mcp-gateway-introduction.adoc
@@ -4,6 +4,8 @@ include::_attributes/attributes.adoc[]
 = Introduction to the {mcpg}
 :context: mcp-gateway-introduction
 
+toc::[]
+
 [role="_abstract"]
 You can centralize and manage the connectivity for your agentic AI applications that access your Model Context Protocol (MCP) servers by using the MCP gateway.
 

--- a/mcp_gateway_install/mcp-gateway-install.adoc
+++ b/mcp_gateway_install/mcp-gateway-install.adoc
@@ -4,6 +4,8 @@ include::_attributes/attributes.adoc[]
 = Installing and configuring {mcpg}
 :context: mcp-gateway-get-install
 
+toc::[]
+
 [role="_abstract"]
 You can get started with the MCP gateway by installing the Operator by using Operator Lifecycle Manager (OLM), and then continuing to set up connections by applying the custom resources that you require.
 

--- a/observe_troubleshoot/mcp-gateway-observe.adoc
+++ b/observe_troubleshoot/mcp-gateway-observe.adoc
@@ -4,6 +4,8 @@ include::_attributes/attributes.adoc[]
 = Observing {mcpg} connections
 :context: mcp-gateway-observe
 
+toc::[]
+
 [role="_abstract"]
 You can use observability in {mcpg} to debug things such as silent failures, track destructive annotations, track latencies, and make an audit trail.
 

--- a/observe_troubleshoot/mcp-gateway-troubleshooting.adoc
+++ b/observe_troubleshoot/mcp-gateway-troubleshooting.adoc
@@ -4,6 +4,8 @@ include::_attributes/attributes.adoc[]
 = Troubleshooting and support for {mcpg}
 :context: mcp-gateway-troubleshooting
 
+toc::[]
+
 [role="_abstract"]
 You can troubleshoot common issues with solutions when working with the {mcpg} across installation, configuration, and operation.
 

--- a/observe_troubleshoot/observability.adoc
+++ b/observe_troubleshoot/observability.adoc
@@ -4,6 +4,8 @@ include::_attributes/attributes.adoc[]
 = {prodname} observability
 :context: rhcl-observability
 
+toc::[]
+
 [role="_abstract"]
 You can use the {prodname} observability features to observe and monitor your gateways, applications, and APIs on {ocp}.
 

--- a/updating/updating-rhcl.adoc
+++ b/updating/updating-rhcl.adoc
@@ -3,7 +3,8 @@ include::_attributes/attributes.adoc[]
 [id="updating-rhcl"]
 = Updating {prodname} {version}
 :context: updating-rhcl
-//toc:[]
+
+toc::[]
 
 [role="_abstract"]
 You can update your {product-title} from one version to the next if your supported configuration meets the requirements of the version you want to update to.


### PR DESCRIPTION
Version(s):
rhcl-docs-1.4
rhcl-docs-1.3
rhcl-docs-1.2
rhcl-docs-1.1

Issue:
[OSDOCS-19431](https://redhat.atlassian.net/browse/OSDOCS-19431)

Link to docs preview (fixing/generating the right-hand nav only):
https://110949--ocpdocs-pr.netlify.app/rhcl/latest/deployment/coredns.html
https://110949--ocpdocs-pr.netlify.app/rhcl/latest/deployment/deployment.html
https://110949--ocpdocs-pr.netlify.app/rhcl/latest/install-guide/install-guide.html
https://110949--ocpdocs-pr.netlify.app/rhcl/latest/introduction/introduction.html
https://110949--ocpdocs-pr.netlify.app/rhcl/latest/mcp_gateway_config/mcp-gateway-authentication.html
https://110949--ocpdocs-pr.netlify.app/rhcl/latest/mcp_gateway_config/mcp-gateway-authorization.html
https://110949--ocpdocs-pr.netlify.app/rhcl/latest/mcp_gateway_config/mcp-gateway-creating-virtual-mcp-servers.html
https://110949--ocpdocs-pr.netlify.app/rhcl/latest/mcp_gateway_config/mcp-gateway-register-ext-mcp-servers.html
https://110949--ocpdocs-pr.netlify.app/rhcl/latest/mcp_gateway_config/mcp-gateway-register-on-prem-mcp-servers.html
https://110949--ocpdocs-pr.netlify.app/rhcl/latest/mcp_gateway_config/mcp-gateway-revoke-tool-access.html
https://110949--ocpdocs-pr.netlify.app/rhcl/latest/mcp_gateway_discover/mcp-gateway-introduction.html
https://110949--ocpdocs-pr.netlify.app/rhcl/latest/mcp_gateway_install/mcp-gateway-install.html
https://110949--ocpdocs-pr.netlify.app/rhcl/latest/observe_troubleshoot/mcp-gateway-observe.html
https://110949--ocpdocs-pr.netlify.app/rhcl/latest/observe_troubleshoot/mcp-gateway-troubleshooting.html
https://110949--ocpdocs-pr.netlify.app/rhcl/latest/observe_troubleshoot/observability.html
https://110949--ocpdocs-pr.netlify.app/rhcl/latest/updating/updating-rhcl.html

QE review:
- N/A backend docs build only

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
