### PR TITLE
TELCODOCS-2683 DITA rewrite for ibi-factory-image-based-install.adoc

### DIFF
--- a/modules/ibi-create-iso-for-bmh.adoc
+++ b/modules/ibi-create-iso-for-bmh.adoc
@@ -6,6 +6,7 @@
 [id="ibi-create-iso-for-bmh_{context}"]
 = Creating a live installation ISO for a {sno} image-based installation
 
+[role="_abstract"]
 You can embed your {sno} seed image URL, and other installation artifacts, in a live installation ISO by using the `openshift-install` program.
 
 [NOTE]
@@ -27,19 +28,21 @@ For more information about the specification for the `image-based-installation-c
 +
 [source,terminal]
 ----
-$ mkdir ibi-iso-workdir <1>
+$ mkdir <working_directory>
 ----
-<1> Replace `ibi-iso-workdir` with the name of your working directory.
++
+where `<working_directory>` is the name of your working directory, for example `ibi-iso-workdir`.
 
 .. Optional. Create an installation configuration template to use as a reference when configuring the `ImageBasedInstallationConfig` resource:
 +
 [source,terminal]
 ----
-$ openshift-install image-based create image-config-template --dir ibi-iso-workdir <1>
+$ openshift-install image-based create image-config-template --dir <working_directory>
 ----
-<1> If you do not specify a working directory, the command uses the current directory.
 +
-.Example output
+where `<working_directory>` is the name of your working directory, for example `ibi-iso-workdir`. If you do not specify a working directory, the command uses the current directory.
++
+Example output:
 [source,terminal]
 ----
 INFO Image-Config-Template created in: ibi-iso-workdir
@@ -81,7 +84,7 @@ pullSecret: '<your_pull_secret>'
 
 .. Edit your installation configuration file:
 +
-.Example `image-based-installation-config.yaml` file
+Example `image-based-installation-config.yaml` file:
 [source,yaml]
 ----
 apiVersion: v1beta1
@@ -129,7 +132,7 @@ networkConfig:
 $ openshift-install image-based create image --dir ibi-iso-workdir
 ----
 +
-.Example output
+Example output:
 [source,terminal]
 ----
 INFO Consuming Image-based Installation ISO Config from target directory

--- a/modules/ibi-extra-partition-ibi-install-iso.adoc
+++ b/modules/ibi-extra-partition-ibi-install-iso.adoc
@@ -6,6 +6,7 @@
 [id="ibi-extra-partition-ibi-install-iso_{context}"]
 = Configuring additional partitions on the target host
 
+[role="_abstract"]
 The installation ISO creates a partition for the `/var/lib/containers` directory as part of the image-based installation process.
 
 You can create additional partitions by using the `coreosInstallerArgs` specification. For example, in hard disks with adequate storage, you might need an additional partition for storage options, such as {lvms-first}.
@@ -19,7 +20,7 @@ The `/var/lib/containers` partition requires at least 500 GB to ensure adequate 
 
 . Edit the `image-based-installation-config.yaml` file to configure additional partitions:
 +
-.Example `image-based-installation-config.yaml` file
+Example `image-based-installation-config.yaml` file:
 [source,yaml]
 ----
 apiVersion: v1beta1
@@ -31,10 +32,10 @@ seedVersion: "4.21.0"
 installationDisk: /dev/sda
 pullSecret: '{"auths": ...}'
 # ...
-skipDiskCleanup: true <1>
+skipDiskCleanup: <skip_disk_cleanup>
 coreosInstallerArgs:
-   - "--save-partindex" <2>
-   - "6" <3>
+   - "--save-partindex"
+   - "<partition_index>"
 ignitionConfigOverride: |
   {
     "ignition": {
@@ -43,13 +44,13 @@ ignitionConfigOverride: |
     "storage": {
       "disks": [
         {
-          "device": "/dev/sda", <4>
+          "device": "<installation_disk>",
           "partitions": [
             {
-              "label": "storage", <5>
-              "number": 6, <6>
-              "sizeMiB": 380000, <7>
-              "startMiB": 500000 <8>
+              "label": "<partition_label>",
+              "number": <partition_number>,
+              "sizeMiB": <partition_size>,
+              "startMiB": <starting_position>
             }
           ]
         }
@@ -58,14 +59,17 @@ ignitionConfigOverride: |
   }
 
 ----
-<1> Specify `true` to skip disk formatting during the installation process.
-<2> Specify this argument to preserve a partition.
-<3> The live installation ISO requires five partitions. Specify a number greater than five to identify the additional partition to preserve.
-<4> Specify the installation disk on the target host.
-<5> Specify the label for the partition.
-<6> Specify the number for the partition.
-<7> Specify the size of parition in MiB.
-<8> Specify the starting position on the disk in MiB for the additional partition. You must specify a starting point larger that the partition for `var/lib/containers`.
++
+where:
++
+`<skip_disk_cleanup>`:: Specifies whether to skip disk formatting during the installation process. Set to `true` to skip.
+`"--save-partindex"`:: Specifies the argument to preserve a partition.
+`<partition_index>`:: Specifies the additional partition to preserve. The live installation ISO requires five partitions. Set a number greater than five, for example `6`.
+`<installation_disk>`:: Specifies the installation disk on the target host, for example `/dev/sda`.
+`<partition_label>`:: Specifies the label for the partition, for example `storage`.
+`<partition_number>`:: Specifies the number for the partition, for example `6`.
+`<partition_size>`:: Specifies the size of partition in MiB, for example `380000`.
+`<starting_position>`:: Specifies the starting position on the disk in MiB for the additional partition. You must specify a starting point larger than the partition for `/var/lib/containers`, for example `500000`.
 
 .Verification
 
@@ -76,7 +80,7 @@ ignitionConfigOverride: |
 $ lsblk
 ----
 +
-.Example output
+Example output:
 [source,terminal]
 ----
 sda    8:0    0  140G  0 disk

--- a/modules/ibi-installer-installation-config.adoc
+++ b/modules/ibi-installer-installation-config.adoc
@@ -6,6 +6,7 @@
 [id="ibi-installer-installation-config_{context}"]
 = Reference specifications for the image-based-installation-config.yaml manifest
 
+[role="_abstract"]
 The following content describes the specifications for the `image-based-installation-config.yaml` manifest. 
 
 The `openshift-install` program uses the `image-based-installation-config.yaml` manifest to create a live installation ISO for image-based installations of {sno}. 

--- a/modules/ibi-provision-install-iso-to-bmh.adoc
+++ b/modules/ibi-provision-install-iso-to-bmh.adoc
@@ -4,9 +4,14 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="ibi-provision-install-iso-to-bmh_{context}"]
-= Provisioning the live installation ISO to a host 
+= Provisioning the live installation ISO to a host
 
-Using your preferred method, boot the target bare-metal host from the `rhcos-ibi.iso` live installation ISO to preinstall {sno}.
+[role="_abstract"]
+You can provision a live installation ISO to a bare-metal host to preinstall {sno}.
+
+.Procedure
+
+* Using your preferred method, boot the target bare-metal host from the `rhcos-ibi.iso` live installation ISO to preinstall {sno}.
 
 .Verification
 
@@ -19,7 +24,7 @@ Using your preferred method, boot the target bare-metal host from the `rhcos-ibi
 $ journalctl -b
 ----
 +
-.Example output
+Example output:
 [source,terminal]
 ----
 Aug 13 17:01:44 10.46.26.129 install-rhcos-and-restore-seed.sh[2876]: time="2024-08-13T17:01:44Z" level=info msg="All the precaching threads have finished."


### PR DESCRIPTION
## Summary
- Fix Vale AsciiDocDITA rule violations in ibi-factory-image-based-install.adoc modules
- Remove callouts and replace with DITA-compatible definition lists and inline explanations
- Add `[role="_abstract"]` to all modules for DITA `<shortdesc>` mapping
- Fix procedure structure in `ibi-provision-install-iso-to-bmh.adoc`
- Convert unsupported block titles (`.Example output`, `.Example ...file`) before source blocks to inline text for DITA compatibility

## JIRA
https://issues.redhat.com/browse/TELCODOCS-2683

## Test plan
- [x] Vale AsciiDocDITA lint — 0 errors, 0 warnings on all 4 files
- [x] dita-block-title — all unsupported block titles fixed
- [x] dita-callouts — no callouts remaining
- [x] dita-line-break — no hard line breaks
- [x] dita-entity-reference — no HTML entities
- [x] dita-content-type — all files have `:_mod-docs-content-type:`
- [x] dita-document-id — all files have document IDs
- [x] dita-add-shortdesc-abstract — all files have `[role="_abstract"]`
- [x] dita-task-contents — all procedures have `.Procedure` title
- [x] dita-task-step — no missing list continuations
- [x] dita-task-title — no unsupported task titles
- [x] dita-related-links — no issues in Additional resources
- [x] dita-check-asciidoctor — all files build without errors
- [x] Review content changes for accuracy
- [ ] Build documentation locally

Based on work from https://github.com/openshift/openshift-docs/pull/106499 with additional DITA block title fixes.