### PR TITLE
OSDOCS-19410-4 back porting most recent zero-trust docs to 4.18 PR#4

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -1301,6 +1301,10 @@ Topics:
     File: zero-trust-manager-install
   - Name: Deploying Zero Trust Workload Identity Manager operands
     File: zero-trust-manager-configuration
+  - Name: Configuring the egress proxy
+    File: zero-trust-manager-proxy
+  - Name: Enabling create-only mode for the Zero Trust Workload Identity Manager
+    File: zero-trust-manager-reconciliation
   - Name: Monitoring Zero Trust Workload Identity Manager
     File: zero-trust-manager-monitoring
   - Name: Uninstalling Zero Trust Workload Identity Manager

--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -1308,6 +1308,10 @@ Topics:
     File: zero-trust-manager-configuration
   - Name: Configuring Zero Trust Workload Identity Manager OIDC Federation
     File: zero-trust-manager-oidc-federation
+  - Name: Configuring the egress proxy
+    File: zero-trust-manager-proxy
+  - Name: Enabling create-only mode for the Zero Trust Workload Identity Manager
+    File: zero-trust-manager-reconciliation
   - Name: Monitoring Zero Trust Workload Identity Manager
     File: zero-trust-manager-monitoring
   - Name: Uninstalling Zero Trust Workload Identity Manager

--- a/modules/zero-trust-manager-pause-reconciliation.adoc
+++ b/modules/zero-trust-manager-pause-reconciliation.adoc
@@ -1,0 +1,66 @@
+// Module included in the following assemblies:
+//
+// * security/zero_trust_workload_identity_manager/zero-trust-manager-reconciliation.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="zero-trust-manager-pause-reconciliation_{context}"]
+= Pausing Operator reconciliation
+
+[role="_abstract"]
+Pause reconciliation of the Operands by enabling `create-only` mode. This setting prevents the Operator from automatically reverting your manual changes to the desired state. You can enable this mode by updating the Operator `Subscription` object.
+
+[IMPORTANT]
+====
+When `create-only` mode is disabled, the Operator overwrites the resources if any conflicts exist.
+====
+
+.Prerequisites
+
+* You have installed {zero-trust-full} on your machine.
+* You have installed the SPIRE Servers, Agents, SPIFFE Container Storage Interface (CSI), and an OpenID Connect (OIDC) Discovery Provider and are in running status.
+
+.Procedure
+
+* To pause reconciling the Operands resources managed by the Operator, add the environment variable `CREATE_ONLY_MODE`: `true` in the subscription object by running the following command:
++
+[source,terminal]
+----
+$ oc -n $OPERATOR_NAMESPACE patch subscription openshift-zero-trust-workload-identity-manager --type='merge' -p '{"spec":{"config":{"env":[{"name":"CREATE_ONLY_MODE","value":"true"}]}}}'
+----
+
+.Verification
+
+* Check the status of the `SpireServer` resource to confirm that the `create-only` mode is active. The `status` must be `true` and the `reason` must be `CreateOnlyModeEnabled`.
++
+[source,terminal]
+----
+$ oc get SpireServer cluster -o yaml
+----
++
+.Example output
++
+[source,yaml]
+----
+status:
+  conditions:
+  - lastTransitionTime: "2025-12-23T11:36:58Z"
+    message: All components are ready
+    reason: Ready
+    status: "True"
+    type: Ready
+  - lastTransitionTime: "2025-12-23T11:36:58Z"
+    message: All operand CRs are ready
+    reason: Ready
+    status: "True"
+    type: OperandsAvailable
+  - lastTransitionTime: "2025-12-23T11:36:58Z"
+    message: create-only mode enabled
+    reason: CreateOnlyModeEnabled
+    status: "True"
+    type: CreateOnlyMode
+----
+
+[IMPORTANT]
+====
+The Operator updates the upgradeable condition to `false` in the `operatorCondition` resource. You might not be able to upgrade the Operator when in `create-only` mode.
+====

--- a/modules/zero-trust-manager-pause-reconciliation.adoc
+++ b/modules/zero-trust-manager-pause-reconciliation.adoc
@@ -1,0 +1,66 @@
+// Module included in the following assemblies:
+//
+// * security/zero_trust_workload_identity_manager/zero-trust-manager-reconciliation.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="zero-trust-manager-pause-reconciliation_{context}"]
+= Pausing Operator reconciliation
+
+[role="_abstract"]
+Pause reconciliation of the Operands by enabling `create-only` mode. This setting prevents the Operator from automatically reverting your manual changes to the desired state. You can enable this mode by updating the Operator's subscription object.
+
+[IMPORTANT]
+====
+When `create-only` mode is disabled, the Operator overwrites the resources if any conflicts exist.
+====
+
+.Prerequisites
+
+* You have installed {zero-trust-full} on your machine.
+
+* You have installed the SPIRE Servers, Agents, SPIFFE Container Storage Interface (CSI), and an OpenID Connect (OIDC) Discovery Provider and are in running status.
+
+.Procedure
+
+* To pause reconciling the Operands resources managed by the Operator, add the environment variable `CREATE_ONLY_MODE`: `true` in the subscription object by running the following command:
++
+[source,terminal]
+----
+$ oc -n $OPERATOR_NAMESPACE patch subscription openshift-zero-trust-workload-identity-manager --type='merge' -p '{"spec":{"config":{"env":[{"name":"CREATE_ONLY_MODE","value":"true"}]}}}'
+----
+
+.Verification
+* Check the status of the `SpireServer` resource to confirm that the `create-only` mode is active. The `status` must be `true` and the `reason` must be `CreateOnlyModeEnabled`.
++
+[source,terminal]
+----
+$ oc get SpireServer cluster -o yaml
+----
++
+.Example output
++
+[source,yaml]
+----
+status:
+  conditions:
+  - lastTransitionTime: "2025-12-23T11:36:58Z"
+    message: All components are ready
+    reason: Ready
+    status: "True"
+    type: Ready
+  - lastTransitionTime: "2025-12-23T11:36:58Z"
+    message: All operand CRs are ready
+    reason: Ready
+    status: "True"
+    type: OperandsAvailable
+  - lastTransitionTime: "2025-12-23T11:36:58Z"
+    message: create-only mode enabled
+    reason: CreateOnlyModeEnabled
+    status: "True"
+    type: CreateOnlyMode
+----
+
+[IMPORTANT]
+====
+The Operator updates the upgradeable condition to `false` in the `operatorCondition` resource. You might not be able to upgrade the Operator when in `create-only` mode.
+====

--- a/modules/zero-trust-manager-proxy-support.adoc
+++ b/modules/zero-trust-manager-proxy-support.adoc
@@ -1,0 +1,129 @@
+// Module included in the following assemblies:
+//
+// * security/cert_manager_operator/cert-manager-operator-proxy.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="zero-trust-manager-proxy-support_{context}"]
+= Injecting a custom CA certificate for the {zero-trust-full}
+
+[role="_abstract"]
+Inject certificate authority (CA) certificates into the {zero-trust-full} to support proxying HTTPS connections. This configuration helps ensure that the Identity Manager can communicate securely when you enable a cluster-wide proxy.
+
+.Prerequisites
+
+* You have access to the cluster as a user with the `cluster-admin` role.
+* You have enabled the cluster-wide proxy for {product-title}.
+* You have installed {zero-trust-full} 1.0.0 or later.
+* You have deployed the SPIRE Server, SPIRE Agent, SPIFFEE CSI Driver, and the SPIRE OIDC Discovery Provider operands in the cluster.
+
+.Procedure
+
+. Create a ConfigMap in the `zero-trust-workload-identity-manager` namespace by running the following command:
++
+[source,terminal]
+----
+$ oc create configmap trusted-ca -n zero-trust-workload-identity-manager
+----
+
+. Inject the CA bundle that is trusted by {product-title} into the config map by running the following command:
++
+[source,terminal]
+----
+$ oc label cm trusted-ca config.openshift.io/inject-trusted-cabundle=true -n zero-trust-workload-identity-manager
+----
+
+. Update the subscription for the {zero-trust-full} to use the config map by running the following command:
++
+[source,terminal]
+----
+$ oc -n zero-trust-workload-identity-manager patch subscription openshift-zero-trust-workload-identity-manager --type='merge' -p '{"spec":{"config":{"env":[{"name":"TRUSTED_CA_BUNDLE_CONFIGMAP","value":"trusted-ca"}]}}}'
+----
+
+.Verification
+
+. Verify that the Operands have finished rolling out by running the following command:
++
+[source,terminal]
+----
+$ oc rollout status deployment/zero-trust-workload-identity-manager-controller-manager -n zero-trust-workload-identity-manager && \
+$ oc rollout status statefulset/spireserver -n zero-trust-workload-identity-manager && \
+$ oc rollout status daemonset/spire-agent -n zero-trust-workload-identity-manager && \
+$ oc rollout status deployment/spire-spiffe-oidc-discovery-provider -n zero-trust-workload-identity-manager
+----
++
+.Example output
+[source,terminal]
+----
+deployment "zero-trust-workload-identity-manager-controller-manager" successfully rolled out
+statefulset "spire-server" successfully rolled out
+daemonset "spire-agent" successfully rolled out
+deployment "spire-spiffe-oidc-discovery-provider" successfully rolled out
+----
+
+. Verify that the CA bundle was mounted as a volume by running the following commands:
++
+[source,terminal]
+----
+$ oc get deployment zero-trust-workload-identity-manager -n zero-trust-workload-identity-manager -o=jsonpath={.spec.template.spec.'containers[0].volumeMounts'}
+----
++
+[source,terminal]
+----
+$ oc get statefulset spire-server -n zero-trust-workload-identity-manager -o jsonpath='{.spec.template.spec.containers[*].volumeMounts[?(@.name=="trusted-ca-bundle")]}'
+----
++
+[source,terminal]
+----
+$ oc get daemonset spire-agent -n zero-trust-workload-identity-manager -o jsonpath='{.spec.template.spec.containers[*].volumeMounts[?(@.name=="trusted-ca-bundle")]}'
+----
++
+[source,terminal]
+----
+$ oc get daemonset spire-spiffe-csi-driver -n zero-trust-workload-identity-manager -o jsonpath='{.spec.template.spec.containers[*].volumeMounts[?(@.name=="trusted-ca-bundle")]}'
+----
++
+.Example output
+[source,terminal]
+----
+[{{"mountPath":"/etc/pki/ca-trust/extracted/pem","name":"trusted-ca-bundle","readOnly":true}]
+----
+
+. Verify that the source of the CA bundle is the `trusted-ca` config map by running the following commands:
++
+[source,terminal]
+----
+$ oc get deployment zero-trust-workload-identity-manager -n zero-trust-workload-identity-manager -o=jsonpath={.spec.template.spec.volumes}
+----
++
+[source,terminal]
+----
+$ oc get statefulset spire-server -n zero-trust-workload-identity-manager -o=jsonpath='{.spec.template.spec.volumes}' | jq '.[] | select(.name=="trusted-ca-bundle")'
+----
++
+[source,terminal]
+----
+$ oc get daemonset spire-agent -n zero-trust-workload-identity-manager -o=jsonpath='{.spec.template.spec.volumes}' | jq '.[] | select(.name=="trusted-ca-bundle")'
+----
++
+[source,terminal]
+----
+$ oc get deployment spire-spiffe-oidc-discovery-provider -n zero-trust-workload-identity-manager -o=jsonpath='{.spec.template.spec.volumes}' | jq '.[] | select(.name=="trusted-ca-bundle")'
+----
++
+.Example output
+[source,terminal]
+----
+{
+  "configMap": {
+    "defaultMode": 420,
+    "items": [
+      {
+        "key": "ca-bundle.crt",
+        "path": "tls-ca-bundle.pem"
+      }
+    ],
+    "name": "trusted-ca"
+  },
+  "name": "trusted-ca-bundle"
+}
+----

--- a/modules/zero-trust-manager-proxy-support.adoc
+++ b/modules/zero-trust-manager-proxy-support.adoc
@@ -1,0 +1,132 @@
+// Module included in the following assemblies:
+//
+// * security/cert_manager_operator/cert-manager-operator-proxy.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="zero-trust-manager-proxy-support_{context}"]
+= Injecting a custom CA certificate for the {zero-trust-full}
+
+[role="_abstract"]
+Inject certificate authority (CA) certificates into the {zero-trust-full} to support proxying HTTPS connections. This configuration helps ensure that the Identity Manager can communicate securely when you enable a cluster-wide proxy.
+
+.Prerequisites
+
+* You have access to the cluster as a user with the `cluster-admin` role.
+
+* You have enabled the cluster-wide proxy for {product-title}.
+
+* You have installed {zero-trust-full} 1.0.0 or later.
+
+* You have deployed the SPIRE Server, SPIRE Agent, SPIFFEE CSI Driver, and the SPIRE OIDC Discovery Provider operands in the cluster.
+
+.Procedure
+
+. Create a config map in the `zero-trust-workload-identity-manager` namespace by running the following command:
++
+[source,terminal]
+----
+$ oc create configmap trusted-ca -n zero-trust-workload-identity-manager
+----
+
+. Inject the CA bundle that is trusted by {product-title} into the config map by running the following command:
++
+[source,terminal]
+----
+$ oc label cm trusted-ca config.openshift.io/inject-trusted-cabundle=true -n zero-trust-workload-identity-manager
+----
+
+. Update the subscription for the {zero-trust-full} to use the config map by running the following command:
++
+[source,terminal]
+----
+$ oc -n zero-trust-workload-identity-manager patch subscription openshift-zero-trust-workload-identity-manager --type='merge' -p '{"spec":{"config":{"env":[{"name":"TRUSTED_CA_BUNDLE_CONFIGMAP","value":"trusted-ca"}]}}}'
+----
+
+.Verification
+
+. Verify that the Operands have finished rolling out by running the following command:
++
+[source,terminal]
+----
+$ oc rollout status deployment/zero-trust-workload-identity-manager-controller-manager -n zero-trust-workload-identity-manager && \
+$ oc rollout status statefulset/spireserver -n zero-trust-workload-identity-manager && \
+$ oc rollout status daemonset/spire-agent -n zero-trust-workload-identity-manager && \
+$ oc rollout status deployment/spire-spiffe-oidc-discovery-provider -n zero-trust-workload-identity-manager
+----
++
+.Example output
+[source,terminal]
+----
+deployment "zero-trust-workload-identity-manager-controller-manager" successfully rolled out
+statefulset "spire-server" successfully rolled out
+daemonset "spire-agent" successfully rolled out
+deployment "spire-spiffe-oidc-discovery-provider" successfully rolled out
+----
+
+. Verify that the CA bundle was mounted as a volume by running the following commands:
++
+[source,terminal]
+----
+$ oc get deployment zero-trust-workload-identity-manager -n zero-trust-workload-identity-manager -o=jsonpath={.spec.template.spec.'containers[0].volumeMounts'}
+----
++
+[source,terminal]
+----
+$ oc get statefulset spire-server -n zero-trust-workload-identity-manager -o jsonpath='{.spec.template.spec.containers[*].volumeMounts[?(@.name=="trusted-ca-bundle")]}'
+----
++
+[source,terminal]
+----
+$ oc get daemonset spire-agent -n zero-trust-workload-identity-manager -o jsonpath='{.spec.template.spec.containers[*].volumeMounts[?(@.name=="trusted-ca-bundle")]}'
+----
++
+[source,terminal]
+----
+$ oc get daemonset spire-spiffe-csi-driver -n zero-trust-workload-identity-manager -o jsonpath='{.spec.template.spec.containers[*].volumeMounts[?(@.name=="trusted-ca-bundle")]}'
+----
++
+.Example output
+[source,terminal]
+----
+[{{"mountPath":"/etc/pki/ca-trust/extracted/pem","name":"trusted-ca-bundle","readOnly":true}]
+----
+
+. Verify that the source of the CA bundle is the `trusted-ca` config map by running the following commands:
++
+[source,terminal]
+----
+$ oc get deployment zero-trust-workload-identity-manager -n zero-trust-workload-identity-manager -o=jsonpath={.spec.template.spec.volumes}
+----
++
+[source,terminal]
+----
+$ oc get statefulset spire-server -n zero-trust-workload-identity-manager -o=jsonpath='{.spec.template.spec.volumes}' | jq '.[] | select(.name=="trusted-ca-bundle")'
+----
++
+[source,terminal]
+----
+$ oc get daemonset spire-agent -n zero-trust-workload-identity-manager -o=jsonpath='{.spec.template.spec.volumes}' | jq '.[] | select(.name=="trusted-ca-bundle")'
+----
++
+[source,terminal]
+----
+$ oc get deployment spire-spiffe-oidc-discovery-provider -n zero-trust-workload-identity-manager -o=jsonpath='{.spec.template.spec.volumes}' | jq '.[] | select(.name=="trusted-ca-bundle")'
+----
++
+.Example output
+[source,terminal]
+----
+{
+  "configMap": {
+    "defaultMode": 420,
+    "items": [
+      {
+        "key": "ca-bundle.crt",
+        "path": "tls-ca-bundle.pem"
+      }
+    ],
+    "name": "trusted-ca"
+  },
+  "name": "trusted-ca-bundle"
+}
+----

--- a/modules/zero-trust-manager-restart-reconciliation.adoc
+++ b/modules/zero-trust-manager-restart-reconciliation.adoc
@@ -1,0 +1,48 @@
+// Module included in the following assemblies:
+//
+// * security/zero_trust_workload_identity_manager/zero-trust-manager-reconciliation.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="zero-trust-manager-restart-reconciliation_{context}"]
+
+= Resuming Operator reconciliation
+
+[role="_abstract"]
+To resume Operator reconciliation after manual configuration or debugging, disable the `create-only` mode. This allows the controller to resume managing resources and applying the desired state. You can disable this mode by setting the environment variable in the subscription object.
+
+.Prerequisites
+
+* You have enabled `create-only` mode on the {zero-trust-full}.
+
+* You have completed your manual configuration or debugging tasks.
+
+.Procedure
+
+* To restart reconciling the Operator-managed resources, add the environment variable `CREATE_ONLY_MODE`: `false` in the subscription object by running the following command:
++
+[source,terminal]
+----
+$ oc -n $OPERATOR_NAMESPACE patch subscription openshift-zero-trust-workload-identity-manager --type='merge' -p '{"spec":{"config":{"env":[{"name":"CREATE_ONLY_MODE","value":"false"}]}}}'
+----
+
+.Verification
+
+* Check the status of the `SpireServer` resource to confirm that `create-only` mode is disabled by running the following command:
++
+[source,terminal]
+----
+$ oc get SpireServer cluster -o yaml
+----
++
+.Example output
++
+[source,yaml]
+----
+status:
+ conditions:
+ - lastTransitionTime: "2025-12-23T11:40:00Z"
+   message: create-only mode disabled
+   reason: CreateOnlyModeDisabled
+   status: "False"
+   type: CreateOnlyMode
+----

--- a/security/zero_trust_workload_identity_manager/zero-trust-manager-proxy.adoc
+++ b/security/zero_trust_workload_identity_manager/zero-trust-manager-proxy.adoc
@@ -1,0 +1,17 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="zero-trust-manager-proxy_{context}"]
+= Configuring the egress proxy for the {zero-trust-full}
+include::_attributes/common-attributes.adoc[]
+:context: zero-trust-manager-proxy
+
+[role="_abstract"]
+Operator Lifecycle Manager (OLM) automatically configures managed Operators with proxy settings when you use a cluster-wide egress proxy. To support proxying HTTPS connections, you can inject certificate authority (CA) certificates into the {zero-trust-full}.
+
+// Injecting a custom CA certificate for the {cert-manager-operator}
+include::modules/zero-trust-manager-proxy-support.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+[id="zero-trust-manager-proxy_additional-resources"]
+== Additional resources
+
+* xref:../../operators/admin/olm-configuring-proxy-support.adoc#olm-configuring-proxy-support[Configuring proxy support in Operator Lifecycle Manager]

--- a/security/zero_trust_workload_identity_manager/zero-trust-manager-reconciliation.adoc
+++ b/security/zero_trust_workload_identity_manager/zero-trust-manager-reconciliation.adoc
@@ -1,0 +1,24 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="zero-trust-manager-reconciliation_{context}"]
+= Enabling create-only mode for the Zero Trust Workload Identity Manager
+include::_attributes/common-attributes.adoc[]
+:context: zero-trust-manager-reconciliation
+
+toc::[]
+
+[role="_abstract"]
+To pause Operator reconciliation, enable `create-only` mode by setting an environment variable in the subscription object. By setting this value, you can perform manual configurations or debug the Operator without the controller overwriting your changes.
+
+The following scenarios are examples of when the `create-only` mode might be of use:
+
+**Manual Customization Required**: You need to customize operator-managed resources, such as ConfigMaps, Deployments, DaemonSets, and so on, with specific configurations that differ from the Operator defaults.
+
+**Day 2 Operations**: After initial deployment, you want to prevent the Operator from overwriting their manual changes during subsequent reconciliation cycles.
+
+**Configuration Drift Prevention**: You want to maintain control over certain resource configurations while still benefiting from the Operator lifecycle management.
+
+// Pause reconciliation
+include::modules/zero-trust-manager-pause-reconciliation.adoc[leveloffset=+1]
+
+// Removing {zero-trust-full} resources
+include::modules/zero-trust-manager-restart-reconciliation.adoc[leveloffset=+1]

--- a/security/zero_trust_workload_identity_manager/zero-trust-manager-reconciliation.adoc
+++ b/security/zero_trust_workload_identity_manager/zero-trust-manager-reconciliation.adoc
@@ -1,0 +1,24 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="zero-trust-manager-reconciliation_{context}"]
+= Enabling create-only mode for the Zero Trust Workload Identity Manager
+include::_attributes/common-attributes.adoc[]
+:context: zero-trust-manager-reconciliation
+
+toc::[]
+
+[role="_abstract"]
+To pause Operator reconciliation, enable `create-only` mode by setting an environment variable in the subscription object. By setting this value, you can perform manual configurations or debug the Operator without the controller overwriting your changes.
+
+The following scenarios are examples of when the `create-only` mode might be of use:
+
+**Manual Customization Required**: You need to customize operator-managed resources (ConfigMaps, Deployments, DaemonSets, etc.) with specific configurations that differ from the Operator's defaults
+
+**Day 2 Operations**: After initial deployment, you want to prevent the Operator from overwriting their manual changes during subsequent reconciliation cycles
+
+**Configuration Drift Prevention**: You want to maintain control over certain resource configurations while still benefiting from the Operator's lifecycle management
+
+// Pause reconciliation
+include::modules/zero-trust-manager-pause-reconciliation.adoc[leveloffset=+1]
+
+// Removing {zero-trust-full} resources
+include::modules/zero-trust-manager-restart-reconciliation.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s):
4.18

Issue:
https://redhat.atlassian.net/browse/OSDOCS-19410

Link to docs preview:
https://110952--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/zero_trust_workload_identity_manager/zero-trust-manager-proxy.html
https://110952--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/zero_trust_workload_identity_manager/zero-trust-manager-reconciliation.html

QE review:
- [ ] QE has approved this change.


Additional information:
The 4.18 documentation in this PR is a copy and paste from the most recent zero-trust documentation.

This PR contains the following assemblies:

- zero-trust-manager-proxy.adoc (new assembly and modules)
- zero-trust-manager-reconciliation.adoc (new assembly and modules)

This is PR #4. This is related to the following PRs:

-  https://github.com/openshift/openshift-docs/pull/110828
- https://github.com/openshift/openshift-docs/pull/110927
- https://github.com/openshift/openshift-docs/pull/110932
- https://github.com/openshift/openshift-docs/pull/110970
- https://github.com/openshift/openshift-docs/pull/110988

The PRs were put into smaller PRs instead of having one large PR. This makes it easier for the merge reviewers.
