### PR TITLE
OSDOCS-19434: adds advisory and xref to release note RHCL 1.3.3

### DIFF
--- a/modules/con-connectivity-link-supported-configs.adoc
+++ b/modules/con-connectivity-link-supported-configs.adoc
@@ -91,7 +91,8 @@ For more information, see the documentation for your chosen cloud DNS provider.
 == Supported on-premise DNS providers
 
 You can use CoreDNS can to configure an on-cluster DNS zone.
-//For more information, see xref:../deployment/coredns.adoc#con-about-using-onprem-dns-coredns_rhcl-using-on-prem-dns-coredns[About using on-premise DNS with CoreDNS].
+
+For more information, see xref:../deployment/coredns.adoc#con-about-using-onprem-dns-coredns_rhcl-using-on-prem-dns-coredns[About using on-premise DNS with CoreDNS].
 
 [id="rhcl-supported-data-stores-for-rate-limiting_{context}"]
 == Supported data stores for rate limiting

--- a/modules/ref-relnotes-1.3.3-z-stream.adoc
+++ b/modules/ref-relnotes-1.3.3-z-stream.adoc
@@ -9,12 +9,12 @@
 Issued: 30 April 2026
 
 [role="_abstract"]
-{product-title} release 1.3.3 is now available. {product-title} uses the `stable` update channel to track and receive updates for the {product-title} Operator. You can manage how your updates are applied through your Operator Lifecycle Manager (OLM) subscription resource. For more information, see xref:../updating/updating-rhcl.adoc#proc-update-rhcl-with-web-console_updating-rhcl[Updating Red Hat Connectivity Link].
+{product-title} release 1.3.3 is now available. A description is available in the link:https://access.redhat.com/errata/RHEA-2026:10743[RHEA-2026:10743] advisory. {product-title} uses the `stable` update channel to track and receive updates for the {product-title} Operator. You can manage how your updates are applied through your Operator Lifecycle Manager (OLM) subscription resource. For more information, see xref:../updating/updating-rhcl.adoc#proc-update-rhcl-with-web-console_updating-rhcl[Updating Red Hat Connectivity Link].
 
 [id="rhcl-relnotes-1.3.3-z-stream-enhancements_{context}"]
 == New features and enhancements
 
-With this release, the Model Context Protocol (MCP) gateway is now available as a Technology Preview feature. This experimental feature is not intended for production use. Note the following scope of support on the Red Hat Customer Portal for this feature: link:https://access.redhat.com/support/offerings/techpreview[Technology Preview Features - Scope of Support].
+With this release, the Model Context Protocol (MCP) gateway is now available as a Technology Preview feature. This experimental feature is not intended for production use. The {mcpg} is available on the `preview` update channel. Note the following scope of support on the Red Hat Customer Portal for this feature: link:https://access.redhat.com/support/offerings/techpreview[Technology Preview Features - Scope of Support].
 
 The MCP gateway aggregates in-cluster and remote MCP servers behind a single endpoint. The MCP gateway discovers every tool available to you on registered MCP servers. You can achieve the following goals by using the MCP gateway:
 
@@ -23,7 +23,7 @@ The MCP gateway aggregates in-cluster and remote MCP servers behind a single end
 * Add and remove MCP servers without restarting your systems because the MCP gateway system state updates dynamically.
 * Curate your MCP server tools by creating virtual MCP servers.
 
-//For more information, see xref:../mcp_gateway_discover/mcp-gateway-introduction.adoc#mcp-gateway-introduction[Introduction to the MCP gateway]
+For more information, see xref:../mcp_gateway_discover/mcp-gateway-introduction.adoc#con-about-mcp-gateway_mcp-gateway-introduction[Introduction to the MCP gateway]
 
 * With this release, elicitation support is available with the MCP gateway if your client supports them. MCP servers can implement interactive workflows by enabling user input requests. For more information, see the link:https://modelcontextprotocol.io/specification/2025-11-25/client/elicitation[Elicitation documentation (MCP specification)].
 
@@ -34,4 +34,4 @@ When the default setting `httpRouteManagement: Enabled` is set on an `MCPGateway
 
 The workaround is to set `httpRouteManagement: Disabled` in the `MCPGatewayExtension` CR in the `config/mcp-gateway/` with a manually managed `HTTPRoute` CR.
 
-//See xref:../mcp_gateway_install/mcp-gateway-install.adoc#proc-mcp-gateway-custom-route_mcp-gateway-install[Applying a customized HTTPRoute object] for instructions.
+See xref:../mcp_gateway_install/mcp-gateway-install.adoc#proc-mcp-gateway-custom-route_mcp-gateway-get-install[Applying a customized HTTPRoute object] for instructions.

--- a/modules/ref-relnotes-new-features.adoc
+++ b/modules/ref-relnotes-new-features.adoc
@@ -12,7 +12,8 @@ You can use the new features and enhancements that are available with {product-t
 CoreDNS integration for on-premise DNS is Generally Available::
 
 {prodname} {version} provides integration with https://coredns.io/[CoreDNS] for on-premise DNS as a Generally Available feature.
-//For more information, see xref:../deployment/coredns.adoc#con-about-using-onprem-dns-coredns_rhcl-using-on-prem-dns-coredns[About using on-premise DNS with CoreDNS].
+
+For more information, see xref:../deployment/coredns.adoc#con-about-using-onprem-dns-coredns_rhcl-using-on-prem-dns-coredns[About using on-premise DNS with CoreDNS].
 
 Updated Observability documentation is now available::
 

--- a/release_notes/rhcl-release-notes.adoc
+++ b/release_notes/rhcl-release-notes.adoc
@@ -4,6 +4,8 @@ include::_attributes/attributes.adoc[]
 = {prodname} {version} release notes
 :context: rhcl-release-notes
 
+toc::[]
+
 [role="_abstract"]
 Welcome to the {product-title} release notes, where you can learn about what is new and what is fixed.
 


### PR DESCRIPTION
Version(s):
rhcl-docs-1.3

Issue:
[OSDOCS-19434](https://redhat.atlassian.net/browse/OSDOCS-19434)

Link to docs preview:
https://110963--ocpdocs-pr.netlify.app/rhcl/latest/release_notes/rhcl-release-notes.html#rhcl-relnotes-1.3.3-z-stream_rhcl-release-notes

QE review:
- N/A adding known links, no technical changes

Additional information:
For release 30 April 2026. OK to merge (docs are not syncing prior to release).

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
