### PR TITLE
OBSDOCS-3292: Release notes for 6.2.10

### DIFF
--- a/modules/logging-release-notes-6-2-10.adoc
+++ b/modules/logging-release-notes-6-2-10.adoc
@@ -1,0 +1,25 @@
+// Module included in the following assemblies:
+//
+// * release_notes/logging-release-notes-6.2.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="logging-release-notes-6-2-10_{context}"]
+= Logging 6.2.10 Release Notes
+
+[role="_abstract"]
+This release includes link:https://access.redhat.com/errata/RHSA-2026:11800[RHSA-2026:11800].
+
+[id="logging-release-notes-6-2-10-bug-fixes_{context}"]
+== Bug fixes
+
+* Previously, Vector was unable to authenticate to Kafka 4.0.0 (and newer KRaft-based clusters) when using the SASL/SCRAM-SHA-512 mechanism, resulting in authentication failure errors even when valid credentials were provided. This was due to a compatibility issue in how the underlying `librdkafka` client handled SCRAM authentication with certain Kafka versions. With this release, the Vector component has been updated to include fixes that resolve these authentication failures, allowing logs to be forwarded successfully to Kafka 4.0.0 clusters using SCRAM-SHA-512.
+(https://redhat.atlassian.net/browse/LOG-9339[LOG-9339])
+
+[id="logging-release-notes-6-2-10-cves_{context}"]
+== CVEs
+
+* link:https://access.redhat.com/security/cve/CVE-2026-27137[CVE-2026-27137]
+
+* link:https://access.redhat.com/security/cve/CVE-2026-25679[CVE-2026-25679]
+
+* link:https://access.redhat.com/security/cve/CVE-2026-32829[CVE-2026-32829]

--- a/release_notes/logging-release-notes-6.2.adoc
+++ b/release_notes/logging-release-notes-6.2.adoc
@@ -9,6 +9,8 @@ toc::[]
 [role="_abstract"]
 The following release notes describe the updates in {LoggingProductName} 6.2. They include new features and enhancements, bug fixes, security updates (CVEs), known issues, and Technology Preview features.
 
+include::modules/logging-release-notes-6-2-10.adoc[leveloffset=+1]
+
 include::modules/logging-release-notes-6-2-9.adoc[leveloffset=+1]
 
 include::modules/logging-release-notes-6-2-8.adoc[leveloffset=+1]


### PR DESCRIPTION
This PR contains Z-stream release notes for OpenShift Logging 6.2.10

Version(s): 6.2
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://redhat.atlassian.net/browse/OBSDOCS-3292
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
