### PR TITLE
[enterprise-4.20] DOCPLAN-99: Vale updates for /virt/support/virt-support-overview.adoc

### DIFF
--- a/modules/virt-support-collect-data.adoc
+++ b/modules/virt-support-collect-data.adoc
@@ -1,0 +1,21 @@
+// Module included in the following assemblies:
+//
+// * virt/support/virt-support-overview.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="virt-support-collect-data_{context}"]
+= Collecting data for Red{nbsp}Hat Support
+
+[role="_abstract"]
+Gather information about the issue affecting your environment to submit with your support case. This aids Red{nbsp}Hat Support in effectively diagnosing your issue.
+
+Gather troubleshooting information by using the following tools:
+
+* Configure Prometheus and Alertmanager.
+
+// must-gather not supported for ROSA/OSD, per Dustin Row
+ifndef::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
+* Configure and use the `must-gather` tool.
+* Collect `must-gather` data and memory dumps from VMs.
+* Collect `must-gather` data for {product-title} and {VirtProductName}
+endif::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]

--- a/modules/virt-support-create-jira-issue.adoc
+++ b/modules/virt-support-create-jira-issue.adoc
@@ -1,0 +1,35 @@
+// Module included in the following assemblies:
+//
+// * virt/support/virt-support-overview.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="virt-creating-jira-issue_{context}"]
+= Creating a Jira issue
+
+[role="_abstract"]
+To report an issue with your environment to Red{nbsp}Hat Support, create a Jira issue in the {VirtProductName} (CNV) Jira project.
+
+.Procedure
+
+. Log in to Red Hat Atlassian Jira.
+
+. Click the following link to open a *Create Issue* page: link:https://redhat.atlassian.net/secure/CreateIssue.jspa[Create issue].
+
+. Select {VirtProductName} (CNV) as the *Project*.
+
+. Select *Bug* as the *Issue Type*.
+
+. Click *Next*.
+
+. Complete the *Summary* and *Description* fields. In the *Description* field, include a detailed description of the issue.
+
+. Submit any collected troubleshooting information. 
+
+.. Add any textual troubleshooting information, such as command outputs, in the *Description* field.
+.. Add troubleshooting files using the *Attachment* field.
+
+. Select the appropriate component from *Components*.
+
+. Click *Create*.
+
+. Review the details of the bug you created.

--- a/modules/virt-support-opening-case.adoc
+++ b/modules/virt-support-opening-case.adoc
@@ -1,0 +1,10 @@
+// Module included in the following assemblies:
+//
+// * virt/support/virt-support-overview.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="virt-support-opening-case_{context}"]
+= Opening a support case
+
+[role="_abstract"]
+Open a support case with Red{nbsp}Hat Support when you encounter an issue that requires immediate assistance.

--- a/modules/virt-support-submit-support-case.adoc
+++ b/modules/virt-support-submit-support-case.adoc
@@ -1,0 +1,12 @@
+// Module included in the following assemblies:
+//
+// * virt/support/virt-support-overview.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="virt-support-submit-support-case_{context}"]
+= Submitting a support case
+
+[role="_abstract"]
+Submit a support case to resolve a cluster issue that is affecting the ability of {VirtProductName} to function properly in your environment. 
+
+You can submit a support case to Red{nbsp}Hat Support by using the link:https://access.redhat.com/support/cases/#/case/list[Customer Support] page. Include data that you collected about your issue with your support request.

--- a/modules/virt-support-web-console-monitoring.adoc
+++ b/modules/virt-support-web-console-monitoring.adoc
@@ -1,0 +1,42 @@
+// Module included in the following assemblies:
+//
+// * virt/support/virt-support-overview.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="virt-support-web-console-monitoring_{context}"]
+= Web console monitoring
+
+[role="_abstract"]
+Monitor cluster and virtual machine (VM) health with the {product-title} web console.
+
+The {product-title} web console displays resource usage, alerts, events, and trends for your cluster and for {VirtProductName} components and resources.
+
+.Web console pages for monitoring and troubleshooting
+[options="header"]
+|====
+|Page |Description
+
+|*Overview* page
+|Cluster details, status, alerts, inventory, and resource usage
+
+|*Virtualization* -> *Overview* tab
+|{VirtProductName} resources, usage, alerts, and status
+
+|*Virtualization* -> *Top consumers* tab
+|Top consumers of CPU, memory, and storage
+
+|*Virtualization* -> *Migrations* tab
+|Progress of live migrations
+
+|*Virtualization* -> *VirtualMachines* tab
+|CPU, memory, and storage usage summary
+
+|*Virtualization* -> *VirtualMachines* -> *VirtualMachine details* -> *Metrics* tab
+|VM resource usage, storage, network, and migration
+
+|*Virtualization* -> *VirtualMachines* -> *VirtualMachine details* -> *Events* tab
+|List of VM events
+
+|*Virtualization* -> *VirtualMachines* -> *VirtualMachine details* -> *Diagnostics* tab
+|VM status conditions and volume snapshot status
+|====

--- a/virt/support/virt-support-overview.adoc
+++ b/virt/support/virt-support-overview.adoc
@@ -6,75 +6,25 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-You can request assistance from Red{nbsp}Hat Support, report bugs, collect data about your environment, and monitor the health of your cluster and virtual machines (VMs) with the following tools.
+[role="_abstract"]
+Accelerate the resolution of cluster and virtual machine (VM) issues by using the integrated diagnostic tools and support provided by {VirtProductName}.
 
-[id="opening-support-tickets_{context}"]
-== Opening support tickets
+include::modules/virt-support-opening-case.adoc[leveloffset=+1] 
 
-If you have encountered an issue that requires immediate assistance from Red{nbsp}Hat Support, you can submit a support case.
+include::modules/virt-support-collect-data.adoc[leveloffset=+2]
 
-To report a bug, you can create a Jira issue directly.
+include::modules/virt-support-submit-support-case.adoc[leveloffset=+2]
 
-[id="submitting-support-case_{context}"]
-=== Submitting a support case
+include::modules/virt-support-create-jira-issue.adoc[leveloffset=+2]
 
-To request support from Red{nbsp}Hat Support, follow xref:../../support/getting-support.adoc#support-submitting-a-case_getting-support[the instructions for submitting a support case].
+include::modules/virt-support-web-console-monitoring.adoc[leveloffset=+1]
 
-It is helpful to collect debugging data to include with your support request.
+[role="_additional-resources"]
+== Additional resources
+* xref:../../support/getting-support.adoc#support-submitting-a-case_getting-support[Submitting a support case]
+* xref:../../virt/support/virt-collecting-virt-data.adoc#virt-collecting-data-about-your-environment_virt-collecting-virt-data[Collecting data about your environment]
 
-[id="collecting-data-for-red-hat-support_{context}"]
-==== Collecting data for Red{nbsp}Hat Support
-
-You can gather debugging information by performing the following steps:
-
-xref:../../virt/support/virt-collecting-virt-data.adoc#virt-collecting-data-about-your-environment_virt-collecting-virt-data[Collecting data about your environment]::
-Configure Prometheus and Alertmanager and collect `must-gather` data for {product-title} and {VirtProductName}.
-
-// must-gather not supported for ROSA/OSD, per Dustin Row
 ifndef::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
-xref:../../virt/support/virt-collecting-virt-data.adoc#virt-using-virt-must-gather_virt-collecting-virt-data[`must-gather` tool for {VirtProductName}]::
-Configure and use the `must-gather` tool.
-
-xref:../../virt/support/virt-collecting-virt-data.adoc#virt-collecting-data-about-vms_virt-collecting-virt-data[Collecting data about VMs]::
-Collect `must-gather` data and memory dumps from VMs.
+* xref:../../virt/support/virt-collecting-virt-data.adoc#virt-using-virt-must-gather_virt-collecting-virt-data[Using the `must-gather` tool for {VirtProductName}]
+* xref:../../virt/support/virt-collecting-virt-data.adoc#virt-collecting-data-about-vms_virt-collecting-virt-data[Collecting data about virtual machines]
 endif::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
-
-[id="virt-creating-jira-issue_{context}"]
-=== Creating a Jira issue
-
-To report a bug, you can create a Jira issue directly by filling out the form on the link:https://issues.redhat.com/secure/CreateIssueDetails!init.jspa?pid=12323181&issuetype=1&priority=10200[*Create Issue*] page.
-
-[id="virt-web-console_{context}"]
-== Web console monitoring
-
-You can monitor the health of your cluster and VMs by using the {product-title} web console. The web console displays resource usage, alerts, events, and trends for your cluster and for {VirtProductName} components and resources.
-
-.Web console pages for monitoring and troubleshooting
-[options="header"]
-|====
-|Page |Description
-
-|*Overview* page
-|Cluster details, status, alerts, inventory, and resource usage
-
-|*Virtualization* -> *Overview* tab
-|{VirtProductName} resources, usage, alerts, and status
-
-|*Virtualization* -> *Top consumers* tab
-|Top consumers of CPU, memory, and storage
-
-|*Virtualization* -> *Migrations* tab
-|Progress of live migrations
-
-|*Virtualization* -> *VirtualMachines* tab
-|CPU, memory, and storage usage summary
-
-|*Virtualization* -> *VirtualMachines* -> *VirtualMachine details* -> *Metrics* tab
-|VM resource usage, storage, network, and migration
-
-|*Virtualization* -> *VirtualMachines* -> *VirtualMachine details* -> *Events* tab
-|List of VM events
-
-|*Virtualization* -> *VirtualMachines* -> *VirtualMachine details* -> *Diagnostics* tab
-|VM status conditions and volume snapshot status
-|====


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->
Manual cherry pick of content to enterprise-4.20 branch. Original PR: https://github.com/openshift/openshift-docs/pull/108320.
<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.20

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
[DOCPLAN-99](https://issues.redhat.com/browse/DOCPLAN-99)

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
