### PR TITLE
OSDOCS-19410-6 back porting most recent zert-trust docs to 4.18 PR#6

### DIFF
--- a/modules/zero-trust-manager-uninstall-console.adoc
+++ b/modules/zero-trust-manager-uninstall-console.adoc
@@ -15,13 +15,14 @@ You can uninstall the {zero-trust-full} by using the web console.
 * You have access to the {product-title} web console.
 
 * The {zero-trust-full} is installed.
+
 .Procedure
 
 . Log in to the {product-title} web console.
 
 . Uninstall the {zero-trust-full}.
 
-.. Go to *Operators* -> *Installed Operators*.
+.. Go to *Ecosystem* -> *Installed Operators*.
 
 .. Click the *Options* menu next to the *{zero-trust-full}* entry, and then click *Uninstall Operator*.
 

--- a/modules/zero-trust-manager-uninstall-resources.adoc
+++ b/modules/zero-trust-manager-uninstall-resources.adoc
@@ -6,70 +6,145 @@
 [id="zero-trust-manager-uninstall-resources-console_{context}"]
 = Uninstalling {zero-trust-full} resources by using the CLI
 
-After you have uninstalled the {zero-trust-full}, you have the option to delete its associated resources from your cluster.
+[role="_abstract"]
+Clean up your cluster by removing remaining {zero-trust-full} resources, such as Operands and custom resource definitions (CRDs), after you uninstall the Operator.
 
 .Prerequisites
 
-* You have access to the cluster with `cluster-admin` privileges.
+* You have access to the cluster with the `cluster-admin` role.
 
 .Procedure
 
-. Uninstall the operand objects by running each of the following commands:
+. Uninstall the Operands by running each of the following commands:
+
+.. Delete the `SpireOIDCDiscoveryProvider` cluster by running the following command:
++
+[source,terminal]
+----
+$ oc delete SpireOIDCDiscoveryProvider cluster
+----
+
+.. Delete the `SpiffeCSIDriver` cluster by running the following command:
++
+[source,terminal]
+----
+$ oc delete SpiffeCSIDriver cluster -l
+----
+
+.. Delete the `SpireAgent` cluster by running the following command:
++
+[source,terminal]
+----
+$ oc delete SpireAgent cluster
+----
+
+.. Delete the `SpireServer` cluster by running the following command:
++
+[source,terminal]
+----
+$ oc delete SpireServer cluster
+----
+
+.. Delete the `ZeroTrustWorkloadIdentityManager` cluster by running the following command:
 +
 [source,terminal]
 ----
 $ oc delete ZeroTrustWorkloadIdentityManager cluster
-$ oc delete SpireOIDCDiscoveryProvider cluster
-$ oc delete SpiffeCSIDriver cluster
-$ oc delete SpireAgent cluster
-$ oc delete SpireServer cluster
 ----
 
-. Delete the Persistent Volume Claim (PVC) and services by running each of the following commands:
+.. Delete the persistent volume claim (PVC) by running the following command:
 +
 [source,terminal]
 ----
-$ oc delete pvc -l=app.kubernetes.io/managed-by=zero-trust-workload-identity-manager
-$ oc delete csidriver -l=app.kubernetes.io/managed-by=zero-trust-workload-identity-manager
-$ oc delete service -l=app.kubernetes.io/managed-by=zero-trust-workload-identity-manager
+$ oc delete pvc -l=app.kubernetes.io/name=spire-server
 ----
 
-. Delete the namespace by running the following command:
+.. Delete the service by running the following command:
++
+[source,terminal]
+----
+$ oc delete service -l=app.kubernetes.io/name=zero-trust-workload-identity-manager -n zero-trust-workload-identity-manager
+----
+
+.. Delete the namespace by running the following command:
 +
 [source,terminal]
 ----
 $ oc delete ns zero-trust-workload-identity-manager
 ----
 
-. Delete the cluster-wide role-based access control (RBAC) by running each of the following commands:
+.. Delete the cluster role by running the following command:
 +
 [source,terminal]
 ----
-$ oc delete clusterrolebinding -l=app.kubernetes.io/managed-by=zero-trust-workload-identity-manager
-$ oc delete clusterrole -l=app.kubernetes.io/managed-by=zero-trust-workload-identity-manager
+$ oc delete clusterrole -l=app.kubernetes.io/name=zero-trust-workload-identity-manager
 ----
 
-. Delete the admission wehhook configuration by running each of the following command:
+.. Delete the admission wehhook configuration by running the following command:
 +
 [source,terminal]
 ----
-$ oc delete validatingwebhookconfigurations -l=app.kubernetes.io/managed-by=zero-trust-workload-identity-manager
+$ oc delete validatingwebhookconfigurations -l=app.kubernetes.io/name=zero-trust-workload-identity-manager
 ----
 
-. Delete the Custom Resource Definitions (CRDs) by running each of the following commands:
+. Delete the custom resource definitions (CRDs) by running each of the following commands:
+
+.. Delete the SPIRE Server CRD by running the following command:
 +
 [source,terminal]
 ----
 $ oc delete crd spireservers.operator.openshift.io
+----
+
+.. Delete the SPIRE Agent CRD by running the following command:
++
+[source,terminal]
+----
 $ oc delete crd spireagents.operator.openshift.io
+----
+
+.. Delete the SPIFFEE CSI Drivers CRD by running the following command:
++
+[source,terminal]
+----
 $ oc delete crd spiffecsidrivers.operator.openshift.io
+----
+
+.. Delete the SPIRE OIDC Discovery Provider CRD by running the following command:
++
+[source,terminal]
+----
 $ oc delete crd spireoidcdiscoveryproviders.operator.openshift.io
+----
+
+.. Delete the SPIRE and SPIFFE cluster federated trust domains CRD by running the following command:
++
+[source,terminal]
+----
 $ oc delete crd clusterfederatedtrustdomains.spire.spiffe.io
+----
+
+.. Delete the cluster SPIFFE IDs CRD by running the following command:
++
+[source,terminal]
+----
 $ oc delete crd clusterspiffeids.spire.spiffe.io
+----
+
+.. Delete the SPIRE and SPIFFE cluster static entries CRD by running the following command:
++
+[source,terminal]
+----
 $ oc delete crd clusterstaticentries.spire.spiffe.io
+----
+
+.. Delete the {zero-trust-full} CRD by running the following command:
++
+[source,terminal]
+----
 $ oc delete crd zerotrustworkloadidentitymanagers.operator.openshift.io
 ----
 
 .Verification
 
-* To verify that the resources have been deleted, replace each `oc delete` command with `oc get`, and then run the command. If no resources are returned, the deletion was successful.
+To verify that the resources have been deleted, replace each `oc delete` command with `oc get`, and then run the command. If no resources are returned, the deletion was successful.

--- a/security/zero_trust_workload_identity_manager/zero-trust-manager-uninstall.adoc
+++ b/security/zero_trust_workload_identity_manager/zero-trust-manager-uninstall.adoc
@@ -1,16 +1,14 @@
 :_mod-docs-content-type: ASSEMBLY
-[id="zero-trust-manager-uninstall"]
+[id="zero-trust-manager-uninstall_{context}"]
 = Uninstalling the {zero-trust-full}
 include::_attributes/common-attributes.adoc[]
 :context: zero-trust-manager-uninstall
 
 toc::[]
 
-:FeatureName: Zero Trust Workload Identity Manager
-
-include::snippets/technology-preview.adoc[]
-
+[role="_abstract"]
 You can remove the {zero-trust-full} from {product-title} by uninstalling the Operator and removing its related resources.
+
 
 // Uninstalling the {zero-trust-full}
 include::modules/zero-trust-manager-uninstall-console.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s):
4.18

Issue:
https://redhat.atlassian.net/browse/OSDOCS-19410

Link to docs preview:


QE review:
- [ ] QE has approved this change.


Additional information:
The 4.18 documentation in this PR is a copy and paste from the most recent zero-trust documentation.

This PR contains the following assembly:

- zero-trust-manager-uninstall.adoc

This is PR #6. This is related to the following PRs:

- https://github.com/openshift/openshift-docs/pull/110828
- https://github.com/openshift/openshift-docs/pull/110927
- https://github.com/openshift/openshift-docs/pull/110932
- https://github.com/openshift/openshift-docs/pull/110952
- https://github.com/openshift/openshift-docs/pull/110970

The PRs were put into smaller PRs instead of having one large PR. This makes it easier for the merge reviewers.
