### PR TITLE
[OSDOCS-17114] resolves ADV errors for third set of MS Networking docs

### DIFF
--- a/microshift_networking/microshift-firewall.adoc
+++ b/microshift_networking/microshift-firewall.adoc
@@ -6,6 +6,7 @@ include::_attributes/attributes-microshift.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 Firewalls are not required in {microshift-short}, but using a firewall can prevent undesired access to the {microshift-short} API.
 
 include::modules/microshift-firewall-about.adoc[leveloffset=+1]
@@ -21,6 +22,8 @@ include::modules/microshift-firewalld-install.adoc[leveloffset=+1]
 include::modules/microshift-firewall-req-settings.adoc[leveloffset=+1]
 
 include::modules/microshift-firewall-opt-settings.adoc[leveloffset=+1]
+
+include::modules/microshift-firewall-optional-ports.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
 .Additional resources

--- a/modules/microshift-firewall-about.adoc
+++ b/modules/microshift-firewall-about.adoc
@@ -6,7 +6,10 @@
 [id="microshift-firewall-about_{context}"]
 = About network traffic through the firewall
 
-Firewalld is a networking service that runs in the background and responds to connection requests, creating a dynamic customizable host-based firewall. If you are using {op-system-ostree-first} with {microshift-short}, firewalld should already be installed and you just need to configure it. Details are provided in procedures that follow. Overall, you must explicitly allow the following OVN-Kubernetes traffic when the `firewalld` service is running:
+[role="_abstract"]
+Firewalld is a networking service that runs in the background and responds to connection requests, creating a dynamic customizable host-based firewall. If you are using {op-system-ostree-first} with {microshift-short}, firewalld should be installed and you only need to configure it. 
+
+Details are provided in procedures that follow. Overall, you must explicitly allow the following OVN-Kubernetes traffic when the `firewalld` service is running.
 
 CNI pod to CNI pod::
 CNI pod to Host-Network pod

--- a/modules/microshift-firewall-add-services.adoc
+++ b/modules/microshift-firewall-add-services.adoc
@@ -6,9 +6,10 @@
 [id="microshift-firewall-add-services_{context}"]
 = Adding services to open ports
 
-On a {microshift-short} instance, you can open services on ports by using the `firewall-cmd` command. 
+[role="_abstract"]
+To open default ports for predefined services through firewalld on your {microshift-short} instance, you can use the `firewall-cmd` command. Add each service with the `--add-service` option.
 
-.Procedure 
+.Procedure
 
 . Optional: You can view all predefined services in firewalld by running the following command
 +

--- a/modules/microshift-firewall-allow-traffic.adoc
+++ b/modules/microshift-firewall-allow-traffic.adoc
@@ -6,6 +6,7 @@
 [id="microshift-firewall-allow-traffic_{context}"]
 = Allowing network traffic through the firewall
 
+[role="_abstract"]
 You can allow network traffic through the firewall by configuring the IP address range and inserting the DNS server to allow internal traffic from pods through the network gateway.
 
 .Procedure

--- a/modules/microshift-firewall-apply-settings.adoc
+++ b/modules/microshift-firewall-apply-settings.adoc
@@ -4,13 +4,14 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="microshift-firewall-applying-settings_{context}"]
-== Applying firewall settings
+= Applying firewall settings
 
-To apply firewall settings, use the following one-step procedure:
+[role="_abstract"]
+To apply firewall settings after you have finished configuring network access through the firewall, you can reload the firewall service.
 
 .Procedure
 
-* After you have finished configuring network access through the firewall, run the following command to restart the firewall and apply the settings:
+* Restart the firewall and apply the settings by running the following command:
 +
 [source,terminal]
 ----

--- a/modules/microshift-firewall-known-issue.adoc
+++ b/modules/microshift-firewall-known-issue.adoc
@@ -6,4 +6,7 @@
 [id="microshift-firewall-known-issue_{context}"]
 = Known firewall issue
 
-To avoid breaking traffic flows with a firewall reload or restart, run firewall commands before starting {op-system-base-full}. The CNI driver in {microshift-short} makes use of iptable rules for some traffic flows, such as those using the NodePort service. The iptable rules are generated and inserted by the CNI driver, but are deleted when the firewall reloads or restarts. The absence of the iptable rules breaks traffic flows. If firewall commands have to run after {microshift-short} is started, manually restart `ovnkube-master` pod in the `openshift-ovn-kubernetes` namespace to reset the rules controlled by the CNI driver.
+[role="_abstract"]
+To avoid traffic failures after a firewalld reload or restart on {microshift-short}, run firewall commands before you start {op-system-base-full}. If you must run firewall commands later, restart the `ovnkube-master` pod in `openshift-ovn-kubernetes` to restore iptable rules that OVN-Kubernetes manages.
+
+The CNI driver in {microshift-short} makes use of iptable rules for some traffic flows, such as those using the NodePort service. The iptable rules are generated and inserted by the CNI driver, but are deleted when the firewall reloads or restarts. The absence of the iptable rules breaks traffic flows.

--- a/modules/microshift-firewall-opt-settings.adoc
+++ b/modules/microshift-firewall-opt-settings.adoc
@@ -6,7 +6,12 @@
 [id="microshift-firewall-optional-settings_{context}"]
 = Using optional port settings
 
-The {microshift-short} firewall service allows optional port settings.
+[role="_abstract"]
+To allow external access to services and APIs in {microshift-short}, you can add custom ports to your firewall configuration. Use the listed ports and protocols as a guide for HTTP, HTTPS, NodePort, mDNS, and API access.
+
+For a complete list of ports and protocols, see "Optional ports".
+
+The following examples show commands to open firewall access for services running on {microshift-short}.
 
 .Procedure
 
@@ -17,45 +22,11 @@ The {microshift-short} firewall service allows optional port settings.
 $ sudo firewall-cmd --permanent --zone=public --add-port=<port number>/<port protocol>
 ----
 +
-.Optional ports
-[option="header"]
-|===
-|Port(s)|Protocol(s)|Description
-
-|80
-|TCP
-|HTTP port used to serve applications through the {ocp} router.
-
-|443
-|TCP
-|HTTPS port used to serve applications through the {ocp} router.
-
-|5353
-|UDP
-|mDNS service to respond for {ocp} route mDNS hosts.
-
-|30000-32767
-|TCP
-|Port range reserved for NodePort services; can be used to expose applications on the LAN.
-
-|30000-32767
-|UDP
-|Port range reserved for NodePort services; can be used to expose applications on the LAN.
-
-|6443
-|TCP
-|HTTPS API port for the {product-title} API.
-|===
-
-The following are examples of commands used when requiring external access through the firewall to services running on {microshift-short}, such as port 6443 for the API server, for example, ports 80 and 443 for applications exposed through the router.
-
-.Example command
-
-* Configuring a port for the {microshift-short} API server:
+For example, to configure a port for the {microshift-short} API server, enter the following command:
 +
 [source,terminal]
 ----
 $ sudo firewall-cmd --permanent --zone=public --add-port=6443/tcp
 ----
-
-To close unnecessary ports in your {microshift-short} instance, follow the procedure in "Closing unused or unnecessary ports to enhance network security". 
++
+To close unnecessary ports in your {microshift-short} instance, follow the procedure in "Closing unused or unnecessary ports to enhance network security".

--- a/modules/microshift-firewall-optional-ports.adoc
+++ b/modules/microshift-firewall-optional-ports.adoc
@@ -1,0 +1,41 @@
+// Module included in the following assemblies:
+//
+// * microshift_networking/microshift-firewall.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="microshift-firewall-optional-ports_{context}"]
+= Optional ports
+
+[role="_abstract"]
+The following table lists the optional ports that are available for use with the {microshift-short} firewall service.
+
+.Optional ports
+[option="header"]
+|===
+|Port(s)|Protocol(s)|Description
+
+|80
+|TCP
+|HTTP port used to serve applications through the {ocp} router.
+
+|443
+|TCP
+|HTTPS port used to serve applications through the {ocp} router.
+
+|5353
+|UDP
+|mDNS service to respond for {ocp} route mDNS hosts.
+
+|30000-32767
+|TCP
+|Port range reserved for NodePort services; can be used to expose applications on the LAN.
+
+|30000-32767
+|UDP
+|Port range reserved for NodePort services; can be used to expose applications on the LAN.
+
+|6443
+|TCP
+|HTTPS API port for the {product-title} API.
+|===
+

--- a/modules/microshift-firewall-req-settings.adoc
+++ b/modules/microshift-firewall-req-settings.adoc
@@ -6,6 +6,7 @@
 [id="microshift-firewall-req-settings_{context}"]
 = Required firewall settings
 
+[role="_abstract"]
 An IP address range for the node network must be enabled during firewall configuration. You can use the default values or customize the IP address range. If you choose to customize the node network IP address range from the default `10.42.0.0/16` setting, you must also use the same custom range in the firewall configuration.
 
 .Firewall IP address settings
@@ -24,9 +25,10 @@ An IP address range for the node network must be enabled during firewall configu
 |Host network pod access to {product-title} API server
 |===
 
-The following are examples of commands for settings that are mandatory for firewall configuration:
+[id="microshift-firewall-req-settings-example-commands_{context}"]
+== Example commands
 
-.Example commands
+The following are examples of commands for settings that are mandatory for firewall configuration:
 
 * Configure host network pod access to other pods:
 +

--- a/modules/microshift-firewall-update-for-service.adoc
+++ b/modules/microshift-firewall-update-for-service.adoc
@@ -6,7 +6,10 @@
 [id="microshift-firewall-update-for-service_{context}"]
 = Overview of firewall ports when a service is exposed
 
-Firewalld is often active when you run services on {microshift-short}. This can disrupt certain services on {microshift-short} because traffic to the ports might be blocked by the firewall. You must ensure that the necessary firewall ports are open if you want certain services to be accessible from outside the host. There are several options for opening your ports:
+[role="_abstract"]
+Firewalld is often active when you run services on {microshift-short}. This can disrupt certain services on {microshift-short} because traffic to the ports might be blocked by the firewall. You must ensure that the necessary firewall ports are open if you want certain services to be accessible from outside the host. 
+
+There are several options for opening your ports:
 
 * Services of the `NodePort` and `LoadBalancer` type are automatically available with OVN-Kubernetes.
 +

--- a/modules/microshift-firewall-verify-settings.adoc
+++ b/modules/microshift-firewall-verify-settings.adoc
@@ -6,11 +6,12 @@
 [id="microshift-firewall-verifying-settings_{context}"]
 = Verifying firewall settings
 
-After you have restarted the firewall, you can verify your settings by listing them.
+[role="_abstract"]
+After you have restarted the firewall, you can verify your settings by listing them with the `firewall-cmd` command.
 
 .Procedure
 
-* To verify rules added in the default public zone, such as ports-related rules, run the following command:
+* To verify rules added in the default public zone, such as ports-related rules, run the following command:  
 +
 [source,terminal]
 ----

--- a/modules/microshift-firewalld-install.adoc
+++ b/modules/microshift-firewalld-install.adoc
@@ -6,9 +6,8 @@
 [id="microshift-firewall-install_{context}"]
 = Installing the firewalld service
 
-If you are using {op-system-ostree}, firewalld should be installed. To use the service, you can simply configure it. The following procedure can be used if you do not have firewalld, but want to use it.
-
-Install and run the `firewalld` service for {microshift-short} by using the following steps.
+[role="_abstract"]
+To install and enable firewalld on your {op-system-ostree} host when the package is missing, you can use `dnf` to install the package and `systemctl` to enable and start the service. Optionally check for the package with `rpm -q firewalld` before you install.
 
 .Procedure
 


### PR DESCRIPTION
PR 3 of ?

Version(s):
4.20+

Issue:
https://redhat.atlassian.net/browse/OSDOCS-17114

Link to docs preview:
https://110990--ocpdocs-pr.netlify.app/microshift/latest/microshift_networking/microshift-firewall.html

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
