### PR TITLE
DOCPLAN-234: Restructure the `virt/monitoring/virt-runbooks.adoc` module as a reference module

### DIFF
--- a/virt/monitoring/virt-runbooks.adoc
+++ b/virt/monitoring/virt-runbooks.adoc
@@ -15,408 +15,274 @@ To diagnose and resolve {VirtProductName} alerts, you can use the {VirtProductNa
 Runbooks for the {VirtProductName} Operator are maintained in the link:https://github.com/openshift/runbooks/tree/master/alerts/openshift-virtualization-operator[openshift/runbooks] Git repository, and you can view them on GitHub. 
 ====
 
-// IMPORTANT: these IDs are meant to exactly mirror the original module IDs //
-// changing them will break links in the actual alerts //
+[id="virt-runbooks-supported-table"]
+[cols="1m,1"]
+.Runbooks for {VirtProductName} alerts
+|===
+| Alert | GitHub link
 
-[id="virt-runbook-cdidataimportcronoutdated_{context}"]
-== CDIDataImportCronOutdated
+| CDIDataImportCronOutdated
+| link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/CDIDataImportCronOutdated.md[Runbook]
 
-* link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/CDIDataImportCronOutdated.md[View the runbook] for the `CDIDataImportCronOutdated` alert.
+| CDIDataVolumeUnusualRestartCount
+| link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/CDIDataVolumeUnusualRestartCount.md[Runbook]
 
-[id="virt-runbook-cdidatavolumeunusualrestartcount_{context}"]
-== CDIDataVolumeUnusualRestartCount
+| CDIDefaultStorageClassDegraded
+| link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/CDIDefaultStorageClassDegraded.md[Runbook]
 
-* link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/CDIDataVolumeUnusualRestartCount.md[View the runbook] for the `CDIDataVolumeUnusualRestartCount` alert.
+| CDIMultipleDefaultVirtStorageClasses
+| link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/CDIMultipleDefaultVirtStorageClasses.md[Runbook]
 
-[id="virt-runbook-cdidefaultstorageclassdegraded_{context}"]
-== CDIDefaultStorageClassDegraded
+| CDINoDefaultStorageClass
+| link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/CDINoDefaultStorageClass.md[Runbook]
 
-* link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/CDIDefaultStorageClassDegraded.md[View the runbook] for the `CDIDefaultStorageClassDegraded` alert.
+| CDINotReady
+| link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/CDINotReady.md[Runbook]
 
-[id="virt-runbook-cdimultipledefaultvirtstorageclasses_{context}"]
-== CDIMultipleDefaultVirtStorageClasses
+| CDIOperatorDown
+| link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/CDIOperatorDown.md[Runbook]
 
-* link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/CDIMultipleDefaultVirtStorageClasses.md[View the runbook] for the `CDIMultipleDefaultVirtStorageClasses` alert.
+| CDIStorageProfilesIncomplete
+| link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/CDIStorageProfilesIncomplete.md[Runbook]
 
-[id="virt-runbook-cdinodefaultstorageclass_{context}"]
-== CDINoDefaultStorageClass
+| CnaoDown
+| link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/CnaoDown.md[Runbook]
 
-* link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/CDINoDefaultStorageClass.md[View the runbook] for the `CDINoDefaultStorageClass` alert.
+| CnaoNMstateMigration
+| link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/CnaoNmstateMigration.md[Runbook]
 
-[id="virt-runbook-cdinotready_{context}"]
-== CDINotReady
+| DeprecatedMachineType
+| link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/DeprecatedMachineType.md[Runbook]
 
-* link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/CDINotReady.md[View the runbook] for the `CDINotReady` alert.
+| GuestFilesystemAlmostOutOfSpace
+| link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/GuestFilesystemAlmostOutOfSpace.md[Runbook]
 
-[id="virt-runbook-cdioperatordown_{context}"]
-== CDIOperatorDown
+| GuestVCPUQueueHighCritical
+| link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/GuestVCPUQueueHighCritical.md[Runbook]
 
-* link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/CDIOperatorDown.md[View the runbook] for the `CDIOperatorDown` alert.
+| GuestVCPUQueueHighWarning
+| link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/GuestVCPUQueueHighWarning.md[Runbook]
 
-[id="virt-runbook-cdistorageprofilesincomplete_{context}"]
-== CDIStorageProfilesIncomplete
+| HAControlPlaneDown
+| link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/HAControlPlaneDown.md[Runbook]
 
-* link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/CDIStorageProfilesIncomplete.md[View the runbook] for the `CDIStorageProfilesIncomplete` alert.
+| HCOGoldenImageWithNoArchitectureAnnotation
+| link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/HCOGoldenImageWithNoArchitectureAnnotation.md[Runbook]
 
-[id="virt-runbook-cnaodown_{context}"]
-== CnaoDown
+| HCOGoldenImageWithNoSupportedArchitecture
+| link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/HCOGoldenImageWithNoSupportedArchitecture.md[Runbook]
 
-* link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/CnaoDown.md[View the runbook] for the `CnaoDown` alert.
+| HCOInstallationIncomplete
+| link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/HCOInstallationIncomplete.md[Runbook]
 
-[id="virt-runbook-cnaonmstatemigration_{context}"]
-== CnaoNMstateMigration
+| HCOMisconfiguredDescheduler
+| link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/HCOMisconfiguredDescheduler.md[Runbook]
 
-* link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/CnaoNmstateMigration.md[View the runbook] for the `CnaoNMstateMigration` alert.
+| HCOMultiArchGoldenImagesDisabled
+| link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/HCOMultiArchGoldenImagesDisabled.md[Runbook]
 
-[id="virt-runbook-deprecatedmachinetype_{context}"]
-== DeprecatedMachineType
+| HCOOperatorConditionsUnhealthy
+| link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/HCOOperatorConditionsUnhealthy.md[Runbook]
 
-* link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/DeprecatedMachineType.md[View the runbook] for the `DeprecatedMachineType` alert.
+| HighNodeCPUFrequency
+| link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/HighNodeCPUFrequency.md[Runbook]
 
-[id="virt-runbook-duplicatewaspagentdsdetected_{context}"]
-== DuplicateWaspAgentDSDetected
+| HPPNotReady
+| link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/HPPNotReady.md[Runbook]
 
-* The `DuplicateWaspAgentDSDetected` alert is link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/DuplicateWaspAgentDSDetected.md[deprecated].
+| HPPOperatorDown
+| link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/HPPOperatorDown.md[Runbook]
 
-[id="virt-runbook-guestfilesystemalmostoutofspace_{context}"]
-== GuestFilesystemAlmostOutOfSpace
+| HPPSharingPoolPathWithOS
+| link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/HPPSharingPoolPathWithOS.md[Runbook]
 
-* link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/GuestFilesystemAlmostOutOfSpace.md[View the runbook] for the `GuestFilesystemAlmostOutOfSpace` alert.
+| HighCPUWorkload
+| link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/HighCPUWorkload.md[Runbook]
 
-[id="virt-runbook-guestvcpuqueuehighcritical_{context}"]
-== GuestVCPUQueueHighCritical
+| KubemacpoolDown
+| link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/KubemacpoolDown.md[Runbook]
 
-* link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/GuestVCPUQueueHighCritical.md[View the runbook] for the `GuestVCPUQueueHighCritical` alert.
+| KubeVirtCRModified
+| link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/KubeVirtCRModified.md[Runbook]
 
-[id="virt-runbook-guestvcpuqueuehighwarning_{context}"]
-== GuestVCPUQueueHighWarning
+| KubeVirtDeprecatedAPIRequested
+| link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/KubeVirtDeprecatedAPIRequested.md[Runbook]
 
-* link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/GuestVCPUQueueHighWarning.md[View the runbook] for the `GuestVCPUQueueHighWarning` alert.
+| KubeVirtVMGuestMemoryAvailableLow
+| link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/KubeVirtVMGuestMemoryAvailableLow.md[Runbook]
 
-[id="virt-runbook-hacontrolplanedown_{context}"]
-== HAControlPlaneDown
+| KubeVirtVMGuestMemoryPressure
+| link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/KubeVirtVMGuestMemoryPressure.md[Runbook]
 
-* link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/HAControlPlaneDown.md[View the runbook] for the `HAControlPlaneDown` alert.
+| KubeVirtNoAvailableNodesToRunVMs
+| link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/KubeVirtNoAvailableNodesToRunVMs.md[Runbook]
 
-[id="virt-runbook-hcogoldenimagewithnoarchitectureannotation_{context}"]
-== HCOGoldenImageWithNoArchitectureAnnotation
+| KubeVirtVMIExcessiveMigrations
+| link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/KubeVirtVMIExcessiveMigrations.md[Runbook]
 
-* link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/HCOGoldenImageWithNoArchitectureAnnotation.md[View the runbook] for the `HCOGoldenImageWithNoArchitectureAnnotation` alert.
+| LowKVMNodesCount
+| link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/LowKVMNodesCount.md[Runbook]
 
-[id="virt-runbook-hcogoldenimagewithnosupportedarchitecture_{context}"]
-== HCOGoldenImageWithNoSupportedArchitecture
+| LowReadyVirtControllersCount
+| link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/LowReadyVirtControllersCount.md[Runbook]
 
-* link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/HCOGoldenImageWithNoSupportedArchitecture.md[View the runbook] for the `HCOGoldenImageWithNoSupportedArchitecture` alert.
+| LowReadyVirtOperatorsCount
+| link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/LowReadyVirtOperatorsCount.md[Runbook]
 
-[id="virt-runbook-hcoinstallationincomplete_{context}"]
-== HCOInstallationIncomplete
+| LowVirtAPICount
+| link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/LowVirtAPICount.md[Runbook]
 
-* link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/HCOInstallationIncomplete.md[View the runbook] for the `HCOInstallationIncomplete` alert.
+| LowVirtControllersCount
+| link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/LowVirtControllersCount.md[Runbook]
 
-[id="virt-runbook-hcomisconfigureddescheduler_{context}"]
-== HCOMisconfiguredDescheduler
+| LowVirtOperatorCount
+| link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/LowVirtOperatorCount.md[Runbook]
 
-* link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/HCOMisconfiguredDescheduler.md[View the runbook] for the `HCOMisconfiguredDescheduler` alert.
+| NetworkAddonsConfigNotReady
+| link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/NetworkAddonsConfigNotReady.md[Runbook]
 
-[id="virt-runbook-hcomultiarchgoldenimagesdisabled_{context}"]
-== HCOMultiArchGoldenImagesDisabled
+| NoLeadingVirtOperator
+| link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/NoLeadingVirtOperator.md[Runbook]
 
-* link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/HCOMultiArchGoldenImagesDisabled.md[View the runbook] for the `HCOMultiArchGoldenImagesDisabled` alert.
+| NoReadyVirtController
+| link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/NoReadyVirtController.md[Runbook]
 
-[id="virt-runbook-hcooperatorconditionsunhealthy_{context}"]
-== HCOOperatorConditionsUnhealthy
+| NoReadyVirtOperator
+| link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/NoReadyVirtOperator.md[Runbook]
 
-* link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/HCOOperatorConditionsUnhealthy.md[View the runbook] for the `HCOOperatorConditionsUnhealthy` alert.
+| NodeNetworkInterfaceDown
+| link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/NodeNetworkInterfaceDown.md[Runbook]
 
-[id="virt-runbook-highnodecpufrequency_{context}"]
-== HighNodeCPUFrequency
+| OrphanedVirtualMachineInstances
+| link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/OrphanedVirtualMachineInstances.md[Runbook]
 
-* link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/HighNodeCPUFrequency.md[View the runbook] for the `HighNodeCPUFrequency` alert.
+| OutdatedVirtualMachineInstanceWorkloads
+| link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/OutdatedVirtualMachineInstanceWorkloads.md[Runbook]
 
-[id="virt-runbook-hppnotready_{context}"]
-== HPPNotReady
+| PersistentVolumeFillingUp
+| link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/PersistentVolumeFillingUp.md[Runbook]
 
-* link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/HPPNotReady.md[View the runbook] for the `HPPNotReady` alert.
+| SSPCommonTemplatesModificationReverted
+| link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/SSPCommonTemplatesModificationReverted.md[Runbook]
 
-[id="virt-runbook-hppoperatordown_{context}"]
-== HPPOperatorDown
+| SSPDown
+| link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/SSPDown.md[Runbook]
 
-* link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/HPPOperatorDown.md[View the runbook] for the `HPPOperatorDown` alert.
+| SSPFailingToReconcile
+| link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/SSPFailingToReconcile.md[Runbook]
 
-[id="virt-runbook-hppsharingpoolpathwithos_{context}"]
-== HPPSharingPoolPathWithOS
+| SSPHighRateRejectedVms
+| link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/SSPHighRateRejectedVms.md[Runbook]
 
-* link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/HPPSharingPoolPathWithOS.md[View the runbook] for the `HPPSharingPoolPathWithOS` alert.
+| SSPTemplateValidatorDown
+| link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/SSPTemplateValidatorDown.md[Runbook]
 
-[id="virt-runbook-highcpuworkload_{context}"]
-== HighCPUWorkload
+| UnsupportedHCOModification
+| link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/UnsupportedHCOModification.md[Runbook]
 
-* link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/HighCPUWorkload.md[View the runbook] for the `HighCPUWorkload` alert.
+| VirtAPIDown
+| link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/VirtAPIDown.md[Runbook]
 
-[id="virt-runbook-kubemacpooldown_{context}"]
-== KubemacpoolDown
+| VirtApiRESTErrorsBurst
+| link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/VirtApiRESTErrorsBurst.md[Runbook]
 
-* link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/KubemacpoolDown.md[View the runbook] for the `KubemacpoolDown` alert.
+| VirtControllerDown
+| link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/VirtControllerDown.md[Runbook]
 
-[id="virt-runbook-KubeMacPoolDuplicateMacsfound_{context}"]
-== KubeMacPoolDuplicateMacsFound
+| VirtControllerRESTErrorsBurst
+| link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/VirtControllerRESTErrorsBurst.md[Runbook]
 
-*The `KubeMacPoolDuplicateMacsFound` alert is link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/KubeMacPoolDuplicateMacsFound.md[deprecated].
+| VirtHandlerDaemonSetRolloutFailing
+| link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/VirtHandlerDaemonSetRolloutFailing.md[Runbook]
 
-[id="virt-runbook-kubevirtcomponentexceedsrequestedcpu_{context}"]
-== KubeVirtComponentExceedsRequestedCPU
+| VirtHandlerRESTErrorsBurst
+| link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/VirtHandlerRESTErrorsBurst.md[Runbook]
 
-* The `KubeVirtComponentExceedsRequestedCPU` alert is link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/KubeVirtComponentExceedsRequestedCPU.md[deprecated].
+| VirtLauncherPodsStuckFailed
+| link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/VirtLauncherPodsStuckFailed.md[Runbook]
 
-[id="virt-runbook-kubevirtcomponentexceedsrequestedmemory_{context}"]
-== KubeVirtComponentExceedsRequestedMemory
+| VirtOperatorDown
+| link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/VirtOperatorDown.md[Runbook]
 
-* The `KubeVirtComponentExceedsRequestedMemory` alert is link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/KubeVirtComponentExceedsRequestedMemory.md[deprecated].
+| VirtOperatorRESTErrorsBurst
+| link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/VirtOperatorRESTErrorsBurst.md[Runbook]
 
-[id="virt-runbook-kubevirtcrmodified_{context}"]
-== KubeVirtCRModified
+| VirtualMachineInstanceHasEphemeralHotplugVolume
+| link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/VirtualMachineInstanceHasEphemeralHotplugVolume.md[Runbook]
 
-* link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/KubeVirtCRModified.md[View the runbook] for the `KubeVirtCRModified` alert.
+| VirtualMachineStuckInUnhealthyState
+| link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/VirtualMachineStuckInUnhealthyState.md[Runbook]
 
-[id="virt-runbook-kubevirtdeprecatedapirequested_{context}"]
-== KubeVirtDeprecatedAPIRequested
+| VirtualMachineStuckOnNode
+| link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/VirtualMachineStuckOnNode.md[Runbook]
 
-* link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/KubeVirtDeprecatedAPIRequested.md[View the runbook] for the `KubeVirtDeprecatedAPIRequested` alert.
+| VMCannotBeEvicted
+| link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/VMCannotBeEvicted.md[Runbook]
 
-[id="virt-runbook-kubevirtguestmemoryavailablelow_{context}"]
-== KubeVirtVMGuestMemoryAvailableLow
+| VMStorageClassWarning
+| link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/VMStorageClassWarning.md[Runbook]
+|===
 
-* link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/KubeVirtVMGuestMemoryAvailableLow.md[View the runbook] for the `KubeVirtVMGuestMemoryAvailableLow` alert.
+[id="virt-runbooks-deprecated"]
+== Runbooks for deprecated alerts
 
-[id="virt-runbook-kubevirtguestmemorypressure_{context}"]
-== KubeVirtVMGuestMemoryPressure
+Deprecated alerts no longer report actual issues and you can safely ignore them.
 
-* link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/KubeVirtVMGuestMemoryPressure.md[View the runbook] for the `KubeVirtVMGuestMemoryPressure` alert.
+.Runbooks for deprecated {VirtProductName} alerts
+[id="virt-runbooks-deprecated-table"]
+[cols="2m,1,1"]
+|===
+| Alert | GitHub link | Notes
 
+| DuplicateWaspAgentDSDetected
+| link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/DuplicateWaspAgentDSDetected.md[Runbook]
+| -
 
-[id="virt-runbook-kubevirtnoavailablenodestorunvms_{context}"]
-== KubeVirtNoAvailableNodesToRunVMs
+| KubeMacPoolDuplicateMacsFound
+| link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/KubeMacPoolDuplicateMacsFound.md[Runbook]
+| -
 
-* link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/KubeVirtNoAvailableNodesToRunVMs.md[View the runbook] for the `KubeVirtNoAvailableNodesToRunVMs` alert.
+| KubeVirtComponentExceedsRequestedCPU
+| link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/KubeVirtComponentExceedsRequestedCPU.md[Runbook]
+| -
 
-[id="virt-runbook-kubevirtvmhighmemoryusage_{context}"]
-== KubevirtVmHighMemoryUsage
+| KubeVirtComponentExceedsRequestedMemory
+| link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/KubeVirtComponentExceedsRequestedMemory.md[Runbook]
+| -
 
-* The `KubevirtVmHighMemoryUsage` alert is link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/KubevirtVmHighMemoryUsage.md[deprecated].
+| KubevirtVmHighMemoryUsage
+| link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/KubevirtVmHighMemoryUsage.md[Runbook]
+| -
 
-[id="virt-runbook-kubevirtvmiexcessivemigrations_{context}"]
-== KubeVirtVMIExcessiveMigrations
+| OperatorConditionsUnhealthy
+| link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/OperatorConditionsUnhealthy.md[Runbook]
+| -
 
-* link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/KubeVirtVMIExcessiveMigrations.md[View the runbook] for the `KubeVirtVMIExcessiveMigrations` alert.
+| SingleStackIPv6Unsupported
+| link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/SingleStackIPv6Unsupported.md[Runbook]
+| -
 
-[id="virt-runbook-lowkvmnodescount_{context}"]
-== LowKVMNodesCount
+| SSPOperatorDown
+| link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/SSPOperatorDown.md[Runbook]
+| -
 
-* link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/LowKVMNodesCount.md[View the runbook] for the `LowKVMNodesCount` alert.
+| VirtApiRESTErrorsHigh
+| link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/VirtApiRESTErrorsHigh.md[Runbook]
+| -
 
-[id="virt-runbook-lowreadyvirtcontrollerscount_{context}"]
-== LowReadyVirtControllersCount
+| VirtControllerRESTErrorsHigh
+| link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/VirtControllerRESTErrorsHigh.md[Runbook]
+| -
 
-* link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/LowReadyVirtControllersCount.md[View the runbook] for the `LowReadyVirtControllersCount` alert.
+| VirtHandlerRESTErrorsHigh
+| link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/VirtHandlerRESTErrorsHigh.md[Runbook]
+| -
 
-[id="virt-runbook-lowreadyvirtoperatorscount_{context}"]
-== LowReadyVirtOperatorsCount
+| VirtOperatorRESTErrorsHigh
+| link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/VirtOperatorRESTErrorsHigh.md[Runbook]
+| -
 
-* link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/LowReadyVirtOperatorsCount.md[View the runbook] for the `LowReadyVirtOperatorsCount` alert.
-
-[id="virt-runbook-lowvirtapicount_{context}"]
-== LowVirtAPICount
-
-* link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/LowVirtAPICount.md[View the runbook] for the `LowVirtAPICount` alert.
-
-[id="virt-runbook-lowvirtcontrollerscount_{context}"]
-== LowVirtControllersCount
-
-* link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/LowVirtControllersCount.md[View the runbook] for the `LowVirtControllersCount` alert.
-
-[id="virt-runbook-lowvirtoperatorcount_{context}"]
-== LowVirtOperatorCount
-
-* link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/LowVirtOperatorCount.md[View the runbook] for the `LowVirtOperatorCount` alert.
-
-[id="virt-runbook-networkaddonsconfignotready_{context}"]
-== NetworkAddonsConfigNotReady
-
-* link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/NetworkAddonsConfigNotReady.md[View the runbook] for the `NetworkAddonsConfigNotReady` alert.
-
-[id="virt-runbook-noleadingvirtoperator_{context}"]
-== NoLeadingVirtOperator
-
-* link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/NoLeadingVirtOperator.md[View the runbook] for the `NoLeadingVirtOperator` alert.
-
-[id="virt-runbook-noreadyvirtcontroller_{context}"]
-== NoReadyVirtController
-
-* link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/NoReadyVirtController.md[View the runbook] for the `NoReadyVirtController` alert.
-
-[id="virt-runbook-noreadyvirtoperator_{context}"]
-== NoReadyVirtOperator
-
-* link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/NoReadyVirtOperator.md[View the runbook] for the `NoReadyVirtOperator` alert.
-
-[id="virt-runbook-nodenetworkinterfacedown_{context}"]
-== NodeNetworkInterfaceDown
-
-* link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/NodeNetworkInterfaceDown.md[View the runbook] for the `NodeNetworkInterfaceDown` alert.
-
-[id="virt-runbook-operatorconditionsunhealthy_{context}"]
-== OperatorConditionsUnhealthy
-
-* The `OperatorConditionsUnhealthy` alert is link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/OperatorConditionsUnhealthy.md[deprecated].
-
-[id="virt-runbook-orphanedvirtualmachineinstances_{context}"]
-== OrphanedVirtualMachineInstances
-
-* link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/OrphanedVirtualMachineInstances.md[View the runbook] for the `OrphanedVirtualMachineInstances` alert.
-
-[id="virt-runbook-outdatedvirtualmachineinstanceWorkloads_{context}"]
-== OutdatedVirtualMachineInstanceWorkloads
-
-* link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/OutdatedVirtualMachineInstanceWorkloads.md[View the runbook] for the `OutdatedVirtualMachineInstanceWorkloads` alert.
-
-[id="virt-runbook-persistentvolumefillingup_{context}"]
-== PersistentVolumeFillingUp
-
-* link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/PersistentVolumeFillingUp.md[View the runbook] for the `PersistentVolumeFillingUp` alert.
-
-[id="virt-runbook-singlestackipv6unsupported_{context}"]
-== SingleStackIPv6Unsupported
-
-* The `SingleStackIPv6Unsupported` alert is link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/SingleStackIPv6Unsupported.md[deprecated].
-
-[id="virt-runbook-sspcommontemplatesmodificationreverted_{context}"]
-== SSPCommonTemplatesModificationReverted
-
-* link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/SSPCommonTemplatesModificationReverted.md[View the runbook] for the `SSPCommonTemplatesModificationReverted` alert.
-
-[id="virt-runbook-sspdown_{context}"]
-== SSPDown
-
-* link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/SSPDown.md[View the runbook] for the `SSPDown` alert.
-
-[id="virt-runbook-sspfailingtoreconcile_{context}"]
-== SSPFailingToReconcile
-
-* link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/SSPFailingToReconcile.md[View the runbook] for the `SSPFailingToReconcile` alert.
-
-[id="virt-runbook-ssphighraterejectedvms_{context}"]
-== SSPHighRateRejectedVms
-
-* link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/SSPHighRateRejectedVms.md[View the runbook] for the `SSPHighRateRejectedVms` alert.
-
-[id="virt-runbook-sspoperatordown_{context}"]
-== SSPOperatorDown
-
-* The `SSPOperatorDown` alert is link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/SSPOperatorDown.md[deprecated].
-
-[id="virt-runbook-ssptemplatevalidatordown_{context}"]
-== SSPTemplateValidatorDown
-
-* link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/SSPTemplateValidatorDown.md[View the runbook] for the `SSPTemplateValidatorDown` alert.
-
-[id="virt-runbook-unsupportedhcomodification_{context}"]
-== UnsupportedHCOModification
-
-* link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/UnsupportedHCOModification.md[View the runbook] for the `UnsupportedHCOModification` alert.
-
-[id="virt-runbook-virtapidown_{context}"]
-== VirtAPIDown
-
-* link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/VirtAPIDown.md[View the runbook] for the `VirtAPIDown` alert.
-
-[id="virt-runbook-virtapiresterrorsburst_{context}"]
-== VirtApiRESTErrorsBurst
-
-* link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/VirtApiRESTErrorsBurst.md[View the runbook] for the `VirtApiRESTErrorsBurst` alert.
-
-[id="virt-runbook-virtapiresterrorshigh_{context}"]
-== VirtApiRESTErrorsHigh
-
-* The `VirtApiRESTErrorsHigh` alert is link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/VirtApiRESTErrorsHigh.md[deprecated].
-
-[id="virt-runbook-virtcontrollerdown_{context}"]
-== VirtControllerDown
-
-* link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/VirtControllerDown.md[View the runbook] for the `VirtControllerDown` alert.
-
-[id="virt-runbook-virtcontrollerresterrorsburst_{context}"]
-== VirtControllerRESTErrorsBurst
-
-* link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/VirtControllerRESTErrorsBurst.md[View the runbook] for the `VirtControllerRESTErrorsBurst` alert.
-
-[id="virt-runbook-virtcontrollerresterrorshigh_{context}"]
-== VirtControllerRESTErrorsHigh
-
-* The `VirtControllerRESTErrorsHigh` alert is link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/VirtControllerRESTErrorsHigh.md[deprecated].
-
-[id="virt-runbook-virthandlerdaemonsetrolloutfailing_{context}"]
-== VirtHandlerDaemonSetRolloutFailing
-
-* link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/VirtHandlerDaemonSetRolloutFailing.md[View the runbook] for the `VirtHandlerDaemonSetRolloutFailing` alert.
-
-[id="virt-runbook-virthandlerresterrorsburst_{context}"]
-== VirtHandlerRESTErrorsBurst
-
-* link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/VirtHandlerRESTErrorsBurst.md[View the runbook] for the `VirtHandlerRESTErrorsBurst` alert.
-
-[id="virt-runbook-virthandlerresterrorshigh_{context}"]
-== VirtHandlerRESTErrorsHigh
-
-* The `VirtHandlerRESTErrorsHigh` alert is link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/VirtHandlerRESTErrorsHigh.md[deprecated].
-
-[id="virt-runbook-virtlauncherpodsstuckfailed_{context}"]
-== VirtLauncherPodsStuckFailed
-
-* link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/VirtLauncherPodsStuckFailed.md[View the runbook] for the `VirtLauncherPodsStuckFailed` alert.
-
-[id="virt-runbook-virtoperatordown_{context}"]
-== VirtOperatorDown
-
-* link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/VirtOperatorDown.md[View the runbook] for the `VirtOperatorDown` alert.
-
-[id="virt-runbook-virtoperatorresterrorsburst_{context}"]
-== VirtOperatorRESTErrorsBurst
-
-* link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/VirtOperatorRESTErrorsBurst.md[View the runbook] for the `VirtOperatorRESTErrorsBurst` alert.
-
-[id="virt-runbook-virtoperatorresterrorshigh_{context}"]
-== VirtOperatorRESTErrorsHigh
-
-* The `VirtOperatorRESTErrorsHigh` alert is link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/VirtOperatorRESTErrorsHigh.md[deprecated].
-
-[id="virt-runbook-virtualmachinecrcerrors_{context}"]
-== VirtualMachineCRCErrors
-
-* The `VirtualMachineCRCErrors` alert is link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/VirtualMachineCRCErrors.md[deprecated].
-+
-The alert is now called `VMStorageClassWarning`.
-
-[id="virt-runbook-virtualmachineinstancehasephemeralhotplugvolume_{context}"]
-== VirtualMachineInstanceHasEphemeralHotplugVolume
-
-* link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/VirtualMachineInstanceHasEphemeralHotplugVolume.md[View the runbook] for the `VirtualMachineInstanceHasEphemeralHotplugVolume` alert.
-
-[id="virt-runbook-virtualmachinestuckinunhealthystate_{context}"]
-== VirtualMachineStuckInUnhealthyState
-
-* link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/VirtualMachineStuckInUnhealthyState.md[View the runbook] for the `VirtualMachineStuckInUnhealthyState` alert.
-
-[id="virt-runbook-virtualmachinestuckonnode_{context}"]
-== VirtualMachineStuckOnNode
-
-* link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/VirtualMachineStuckOnNode.md[View the runbook] for the `VirtualMachineStuckOnNode` alert.
-
-[id="virt-runbook-vmcannotbeevicted_{context}"]
-== VMCannotBeEvicted
-
-* link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/VMCannotBeEvicted.md[View the runbook] for the `VMCannotBeEvicted` alert.
-
-[id="virt-runbook-vmstorageclasswarning_{context}"]
-== VMStorageClassWarning
-
-* link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/VMStorageClassWarning.md[View the runbook] for the `VMStorageClassWarning` alert.
+| VirtualMachineCRCErrors
+| link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/VirtualMachineCRCErrors.md[Runbook]
+| Renamed to `VMStorageClassWarning`.
+|===


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.20+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [DOCPLAN-234](https://redhat.atlassian.net/browse/DOCPLAN-234)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
- https://110991--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/monitoring/virt-runbooks.html

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->
Resolves 70 `RedHat.Headings` suggestions which initially motivated me to look into this module.


<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
