### PR TITLE
[OCPBUGS-84109]: Fixing broken links in etcd docs

### DIFF
--- a/backup_and_restore/control_plane_backup_and_restore/replacing-unhealthy-etcd-member.adoc
+++ b/backup_and_restore/control_plane_backup_and_restore/replacing-unhealthy-etcd-member.adoc
@@ -38,7 +38,7 @@ include::modules/restore-determine-state-etcd-member.adoc[leveloffset=+1]
 Depending on the state of your unhealthy etcd member, use one of the following procedures:
 
 * xref:../../backup_and_restore/control_plane_backup_and_restore/replacing-unhealthy-etcd-member.adoc#restore-replace-stopped-etcd-member_replacing-unhealthy-etcd-member[Replacing an unhealthy etcd member whose machine is not running or whose node is not ready]
-* link:https://docs.redhat.com/en/documentation/assisted_installer_for_openshift_container_platform/2024/html/installing_openshift_container_platform_with_the_assisted_installer/expanding-the-cluster#installing-primary-control-plane-node-unhealthy-cluster_expanding-the-cluster[Installing a primary control plane node on an unhealthy cluster]
+* link:https://docs.redhat.com/en/documentation/assisted_installer_for_openshift_container_platform/2026/html/installing_openshift_container_platform_with_the_assisted_installer/expanding-the-cluster#installing-control-plane-node-unhealthy-cluster_expanding-the-cluster[Replacing a control plane node in an unhealthy cluster]
 * xref:../../backup_and_restore/control_plane_backup_and_restore/replacing-unhealthy-etcd-member.adoc#restore-replace-crashlooping-etcd-member_replacing-unhealthy-etcd-member[Replacing an unhealthy etcd member whose etcd pod is crashlooping]
 * xref:../../backup_and_restore/control_plane_backup_and_restore/replacing-unhealthy-etcd-member.adoc#restore-replace-stopped-baremetal-etcd-member_replacing-unhealthy-etcd-member[Replacing an unhealthy stopped baremetal etcd member]
 
@@ -48,7 +48,7 @@ include::modules/restore-replace-stopped-etcd-member.adoc[leveloffset=+2]
 [role="_additional-resources"]
 .Additional resources
 * xref:../../machine_management/control_plane_machine_management/cpmso-troubleshooting.adoc#cpmso-ts-etcd-degraded_cpmso-troubleshooting[Recovering a degraded etcd Operator]
-* link:https://docs.redhat.com/en/documentation/assisted_installer_for_openshift_container_platform/2024/html/installing_openshift_container_platform_with_the_assisted_installer/expanding-the-cluster#installing-primary-control-plane-node-unhealthy-cluster_expanding-the-cluster[Installing a primary control plane node on an unhealthy cluster]
+* link:https://docs.redhat.com/en/documentation/assisted_installer_for_openshift_container_platform/2026/html/installing_openshift_container_platform_with_the_assisted_installer/expanding-the-cluster#installing-control-plane-node-unhealthy-cluster_expanding-the-cluster[Replacing a control plane node on an unhealthy cluster]
 
 // Replacing an unhealthy etcd member whose etcd pod is crashlooping
 include::modules/restore-replace-crashlooping-etcd-member.adoc[leveloffset=+2]

--- a/etcd/etcd-backup-restore/replace-unhealthy-etcd-member.adoc
+++ b/etcd/etcd-backup-restore/replace-unhealthy-etcd-member.adoc
@@ -32,7 +32,7 @@ include::modules/restore-determine-state-etcd-member.adoc[leveloffset=+1]
 Depending on the state of your unhealthy etcd member, use one of the following procedures:
 
 * Replacing an unhealthy etcd member whose machine is not running or whose node is not ready
-* Installing a primary control plane node on an unhealthy cluster
+* Replacing a control plane node on an unhealthy cluster
 * Replacing an unhealthy etcd member whose etcd pod is crashlooping
 * Replacing an unhealthy stopped baremetal etcd member
 
@@ -42,7 +42,7 @@ include::modules/restore-replace-stopped-etcd-member.adoc[leveloffset=+2]
 [role="_additional-resources"]
 .Additional resources
 * xref:../../machine_management/control_plane_machine_management/cpmso-troubleshooting.adoc#cpmso-ts-etcd-degraded_cpmso-troubleshooting[Recovering a degraded etcd Operator]
-* link:https://docs.redhat.com/en/documentation/assisted_installer_for_openshift_container_platform/2024/html/installing_openshift_container_platform_with_the_assisted_installer/expanding-the-cluster#installing-primary-control-plane-node-unhealthy-cluster_expanding-the-cluster[Installing a primary control plane node on an unhealthy cluster]
+* link:https://docs.redhat.com/en/documentation/assisted_installer_for_openshift_container_platform/2026/html/installing_openshift_container_platform_with_the_assisted_installer/expanding-the-cluster#installing-control-plane-node-unhealthy-cluster_expanding-the-cluster[Replacing a control plane node on an unhealthy cluster]
 
 // Replacing an unhealthy etcd member whose etcd pod is crashlooping
 include::modules/restore-replace-crashlooping-etcd-member.adoc[leveloffset=+2]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.20+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://redhat.atlassian.net/browse/OCPBUGS-84109
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
- https://110992--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/control_plane_backup_and_restore/replacing-unhealthy-etcd-member.html#replacing-the-unhealthy-etcd-member
- https://110992--ocpdocs-pr.netlify.app/openshift-enterprise/latest/etcd/etcd-backup-restore/replace-unhealthy-etcd-member.html#replacing-the-unhealthy-etcd-member
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
