### PR TITLE
OSDOCS-16607 [ROSA]: Vale and Dita work for Networking

### DIFF
--- a/modules/albo-deleting.adoc
+++ b/modules/albo-deleting.adoc
@@ -21,19 +21,19 @@ $ oc delete subscription aws-load-balancer-operator -n aws-load-balancer-operato
 [source,terminal]
 ----
 $ aws iam detach-role-policy \
-  --role-name "<cluster-id>-alb-operator" \
-  --policy-arn <operator-policy-arn>
+  --role-name "<cluster_id>-alb-operator" \
+  --policy-arn <operator_policy_arn>
 ----
 +
 [source,terminal]
 ----
 $ aws iam delete-role \
-  --role-name "<cluster-id>-alb-operator"
+  --role-name "<cluster_id>-alb-operator"
 ----
 
 . Delete the AWS IAM policy:
 +
 [source,terminal]
 ----
-$ aws iam delete-policy --policy-arn <operator-policy-arn>
+$ aws iam delete-policy --policy-arn <operator_policy_arn>
 ----

--- a/modules/albo-installation.adoc
+++ b/modules/albo-installation.adoc
@@ -36,7 +36,7 @@ $ aws iam create-policy \
         --region ${REGION}
 ----
 +
-Take note of the Operator policy ARN in the output. This is referred to as the `$OPERATOR_POLICY_ARN` for the remainder of this process.
+Take note of the Operator policy Amazon Resource Name (ARN) in the output. The remainder of this process refers to this as `$OPERATOR_POLICY_ARN`.
 
 . Create an AWS IAM role for the AWS Load Balancer Operator:
 +
@@ -73,7 +73,7 @@ $ aws iam create-role --role-name "${CLUSTER_NAME}-alb-operator" \
     --assume-role-policy-document "file://${SCRATCH}/operator-trust-policy.json"
 ----
 +
-Take note of the Operator role ARN in the output. This is referred to as the `$OPERATOR_ROLE_ARN` for the remainder of this process.
+Take note of the Operator role ARN in the output. The remainder of this process refers to this as `$OPERATOR_ROLE_ARN`.
 +
 .. Associate the Operator role and policy:
 +
@@ -132,7 +132,7 @@ $ aws iam create-policy \
     --policy-document file://${SCRATCH}/controller-permission-policy.json
 ----
 +
-Take note of the Controller policy ARN in the output. This is referred to as the `$CONTROLLER_POLICY_ARN` for the remainder of this process.
+Take note of the Controller policy ARN in the output. The remainder of this process refers to this as `$CONTROLLER_POLICY_ARN`.
 
 . Create an AWS IAM role for the AWS Load Balancer Controller:
 +
@@ -168,7 +168,7 @@ EOF
 CONTROLLER_ROLE_ARN=$(aws iam create-role --role-name "${CLUSTER_NAME}-albo-controller" \ --assume-role-policy-document "file://${SCRATCH}/controller-trust-policy.json" \ --query Role.Arn --output text) echo ${CONTROLLER_ROLE_ARN}
 ----
 +
-Take note of the Controller role ARN in the output. This is referred to as the `$CONTROLLER_ROLE_ARN` for the remainder of this process.
+Take note of the Controller role ARN in the output. The remainder of this process refers to this as `$CONTROLLER_ROLE_ARN`.
 +
 .. Associate the Controller role and policy:
 +

--- a/modules/albo-prerequisites.adoc
+++ b/modules/albo-prerequisites.adoc
@@ -7,13 +7,13 @@
 = Prepare to install the AWS Load Balancer Operator
 
 [role="_abstract"]
-Before you install the AWS Load Balancer Operator, ensure that your cluster fulfills requirements and that your AWS VPC resources are appropriately tagged. You also have the option to configure some helpful environment variables.
+Before you install the AWS Load Balancer Operator, ensure that your cluster fulfills requirements and that your AWS Virtual Private Cloud (VPC) resources are appropriately tagged. You also have the option to configure some helpful environment variables.
 
 Cluster requirements::
 
-Your cluster must be deployed across three availability zones and use a pre-existing VPC that has three public subnets.
+Your cluster must deploy across three availability zones and use a pre-existing VPC that has three public subnets.
 
 [IMPORTANT]
 ====
-These requirements mean that the AWS Load Balancer Operator may not be suitable for some PrivateLink clusters. AWS NLBs may be a better choice for such clusters.
+These requirements mean that the AWS Load Balancer Operator might not be suitable for some PrivateLink clusters. AWS Network Load Balancers (NLBs) might be a better choice for such clusters.
 ====

--- a/modules/albo-validate-install.adoc
+++ b/modules/albo-validate-install.adoc
@@ -7,7 +7,7 @@
 = Validating Operator installation
 
 [role="_abstract"]
-To confirm that the AWS Load Balancer Operator and Controller are installed correctly, deploy a basic sample application. This validation process involves creating ingress and load balancing services to test the deployment.
+To confirm that the AWS Load Balancer Operator and Controller have installed correctly, deploy a basic sample application. This validation process involves creating ingress and load balancing services to test the deployment.
 
 .Procedure
 
@@ -77,7 +77,7 @@ EOF
 +
 [NOTE]
 ====
-ALB provisioning takes a few minutes. If you receive an error that says `curl: (6) Could not resolve host`, please wait and try again.
+ALB provisioning takes a few minutes. If you receive an error that says `curl: (6) Could not resolve host`, wait and try again.
 ====
 +
 [source,terminal]
@@ -126,7 +126,7 @@ EOF
 +
 [NOTE]
 ====
-NLB provisioning takes a few minutes. If you receive an error that says `curl: (6) Could not resolve host`, please wait and try again.
+NLB provisioning takes a few minutes. If you receive an error that says `curl: (6) Could not resolve host`, wait and try again.
 ====
 +
 [source,terminal]

--- a/modules/automatic-network-verification-bypassing.adoc
+++ b/modules/automatic-network-verification-bypassing.adoc
@@ -6,6 +6,7 @@
 [id="automatic-network-verification-bypassing_{context}"]
 = Automatic network verification bypassing
 
+[role="_abstract"]
 You can bypass the automatic network verification if you want to deploy
 ifdef::openshift-dedicated[]
 an {product-title}
@@ -15,12 +16,8 @@ a {product-title} (ROSA)
 endif::openshift-rosa[]
 cluster with known network configuration issues into an existing Virtual Private Cloud (VPC).
 
-If you bypass the network verification when you create a cluster, the cluster has a limited support status. After installation, you can resolve the issues and then manually run the network verification. The limited support status is removed after the verification succeeds.
+If you bypass the network verification when you create a cluster, the cluster has a limited support status. After installation, you can resolve the issues and then manually run the network verification. The verification removes the limited support status after it succeeds.
 
-ifdef::openshift-rosa[]
-.Bypassing automatic network verification by using {cluster-manager}
-
-endif::openshift-rosa[]
 When you install a cluster into an existing VPC by using {cluster-manager-first}, you can bypass the automatic verification by selecting *Bypass network verification* on the *Virtual Private Cloud (VPC) subnet settings* page.
 
 //Commented out due to updates made in OSDOCS-7033

--- a/modules/aws-load-balancer-operator-environment.adoc
+++ b/modules/aws-load-balancer-operator-environment.adoc
@@ -59,7 +59,7 @@ $ mkdir -p ${SCRATCH}
 +
 These commands create environment variables that you can use in this terminal session to pass their values to the command line interface.
 
-. Verify that the variable values are set correctly by running the following command:
+. Verify that the environment variables have correct values by running the following command:
 +
 [source,terminal]
 ----

--- a/modules/cluster-wide-proxy-preqs.adoc
+++ b/modules/cluster-wide-proxy-preqs.adoc
@@ -6,6 +6,7 @@
 [id="cluster-wide-proxy-prereqs_{context}"]
 = Prerequisites for configuring a cluster-wide proxy
 
+[role="_abstract"]
 To configure a cluster-wide proxy, you must meet the following requirements. These requirements are valid when you configure a proxy during installation or postinstallation.
 
 
@@ -13,12 +14,12 @@ To configure a cluster-wide proxy, you must meet the following requirements. The
 == General requirements
 
 * You are the cluster owner.
-* Your account has sufficient privileges.
+* Your account has enough privileges.
 ifdef::openshift-rosa,openshift-rosa-hcp[]
 * You have an existing Virtual Private Cloud (VPC) for your cluster.
 endif::openshift-rosa,openshift-rosa-hcp[]
 ifdef::openshift-dedicated[]
-* You have an existing Virtual Private Cloud (VPC) for your cluster.
+* You have an existing VPC for your cluster.
 * You are using the Customer Cloud Subscription (CCS) model for your cluster.
 endif::openshift-dedicated[]
 * The proxy can access the VPC for the cluster and the private subnets of the VPC. The proxy must also be accessible from the VPC for the cluster and from the private subnets of the VPC.
@@ -52,6 +53,6 @@ Your proxy must exclude re-encrypting the following OpenShift URLs:
 
 |`sso.redhat.com`
 |https/443
-|The https://console.redhat.com/openshift site uses authentication from `sso.redhat.com` to download the cluster pull secret and use Red Hat SaaS solutions to facilitate monitoring of your subscriptions, cluster inventory, and chargeback reporting.
+|The `console.redhat.com/openshift` site uses authentication from `sso.redhat.com` to download the cluster pull secret and use Red Hat SaaS solutions to ease monitoring of your subscriptions, cluster inventory, and chargeback reporting.
 |===
 

--- a/modules/configmap-removing-ca.adoc
+++ b/modules/configmap-removing-ca.adoc
@@ -6,6 +6,7 @@
 [id="configmap-removing-ca_{context}"]
 = Removing certificate authorities on a {product-title} cluster
 
+[role="_abstract"]
 You can remove certificate authorities (CA) from your cluster with the ROSA CLI, `rosa`.
 
 .Prerequisites
@@ -16,14 +17,14 @@ You can remove certificate authorities (CA) from your cluster with the ROSA CLI,
 
 .Procedure
 
-* Use the `rosa edit` command to modify the CA trust bundle. You must pass empty strings to the `--additional-trust-bundle-file` argument to clear the trust bundle from the cluster:
+* Use the `rosa edit` command to change the CA trust bundle. You must pass empty strings to the `--additional-trust-bundle-file` argument to clear the trust bundle from the cluster:
 +
 [source,terminal]
 ----
 $ rosa edit cluster -c <cluster_name> --additional-trust-bundle-file ""
 ----
 +
-.Example Output
+*Example output*
 +
 [source,yaml]
 ----
@@ -32,14 +33,14 @@ I: Updated cluster <cluster_name>
 
 .Verification
 
-* You can verify that the trust bundle has been removed from the cluster by using the `rosa describe` command:
+* To verify that you removed the trust bundle from the cluster, use the `rosa describe` command:
 +
 [source,yaml]
 ----
 $ rosa describe cluster -c <cluster_name>
 ----
 +
-Before removal, the Additional trust bundle section appears, redacting its value for security purposes:
+Before removal, the Additional trust bundle section is displayed, redacting its value for security purposes:
 +
 [source,yaml,subs="attributes+"]
 ----
@@ -69,7 +70,7 @@ Proxy:
 Additional trust bundle:    REDACTED
 ----
 +
-After removing the proxy, the Additional trust bundle section is removed:
+After you remove the proxy, the Additional trust bundle section no longer displays:
 +
 [source,yaml,subs="attributes+"]
 ----

--- a/modules/configuring-a-proxy-after-installation-cli.adoc
+++ b/modules/configuring-a-proxy-after-installation-cli.adoc
@@ -6,19 +6,20 @@
 [id="configuring-a-proxy-after-installation-cli_{context}"]
 = Configuring a proxy after installation using the CLI
 
+[role="_abstract"]
 You can use the ROSA CLI (`rosa`) to add a cluster-wide proxy configuration to an existing ROSA cluster in a Virtual Private Cloud (VPC).
 
 You can also use `rosa` to update an existing cluster-wide proxy configuration. For example, you might need to update the network address for the proxy or replace the additional trust bundle if any of the certificate authorities for the proxy expire.
 
 [IMPORTANT]
 ====
-The cluster applies the proxy configuration to the control plane and compute nodes. While applying the configuration, each cluster node is temporarily placed in an unschedulable state and drained of its workloads. Each node is restarted as part of the process.
+The cluster applies the proxy configuration to the control plane and compute nodes. While applying the configuration, each cluster node is temporarily placed in an unschedulable state and drained of its workloads. The process restarts each node.
 ====
 
 .Prerequisites
 
-* You have installed and configured the latest ROSA (`rosa`) and OpenShift (`oc`) CLIs on your installation host.
-* You have a {product-title} cluster that is deployed in a VPC.
+* You have installed and configured the latest ROSA (`rosa`) and OpenShift (`oc`) command-line interfaces (CLIs) on your installation host.
+* You have deployed your {product-title} cluster in a VPC.
 
 .Procedure
 
@@ -28,28 +29,31 @@ The cluster applies the proxy configuration to the control plane and compute nod
 ----
 $ rosa edit cluster \
  --cluster $CLUSTER_NAME \
- --additional-trust-bundle-file <path_to_ca_bundle_file> \ <1> <2> <3>
- --http-proxy http://<username>:<password>@<ip>:<port> \ <1> <3>
- --https-proxy https://<username>:<password>@<ip>:<port> \ <1> <3>
-  --no-proxy example.com <4>
+ --additional-trust-bundle-file <path_to_ca_bundle_file> \
+ --http-proxy http://<username>:<password>@<ip>:<port> \
+ --https-proxy https://<username>:<password>@<ip>:<port> \
+  --no-proxy example.com
 ----
 +
 --
-<1> The `additional-trust-bundle-file`, `http-proxy`, and `https-proxy` arguments are all optional.
-<2> The `additional-trust-bundle-file` argument is a file path pointing to a bundle of PEM-encoded X.509 certificates, which are all concatenated together. The additional-trust-bundle-file argument is a file path pointing to a bundle of PEM-encoded X.509 certificates, which are all concatenated together. The additional-trust-bundle-file argument is required for users who use a TLS-inspecting proxy unless the identity certificate for the proxy is signed by an authority from the {op-system-first} trust bundle. This applies regardless of whether the proxy is transparent or requires explicit configuration using the `http-proxy` and `https-proxy` arguments.
+
+where:
+
+** The `additional-trust-bundle-file`, `http-proxy`, and `https-proxy` arguments are all optional.
+** The `additional-trust-bundle-file` argument is a file path pointing to a bundle of PEM-encoded X.509 certificates, which are all concatenated together. The additional-trust-bundle-file argument is a file path pointing to a bundle of PEM-encoded X.509 certificates, which are all concatenated together. The additional-trust-bundle-file argument is required for users who use a TLS-inspecting proxy unless the identity certificate for the proxy is signed by an authority from the {op-system-first} trust bundle. This applies regardless of whether the proxy is transparent or requires explicit configuration using the `http-proxy` and `https-proxy` arguments.
 +
 [IMPORTANT]
 ====
 Do not attempt to change the proxy or additional trust bundle configuration on the cluster directly. Any changes must be applied by using the ROSA CLI (`rosa`) or {cluster-manager-first}. Any changes made directly to managed resources on the cluster are reverted automatically.
 ====
-<3> The `http-proxy` and `https-proxy` arguments must point to a valid URL.
-<4> A comma-separated list of destination domain names, IP addresses, or network CIDRs to exclude proxying.
+** The `http-proxy` and `https-proxy` arguments must point to a valid URL.
+** A comma-separated list of destination domain names, IP addresses, or network CIDRs to exclude proxying.
 +
-Preface a domain with `.` to match subdomains only. For example, `.y.com` matches `x.y.com`, but not `y.com`. Use `*` to bypass proxy for all destinations.
+** Preface a domain with `.` to match subdomains only. For example, `.y.com` matches `x.y.com`, but not `y.com`. Use `*` to bypass proxy for all destinations.
 +
-If you scale up workers that are not included in the network defined by the `networking.machineNetwork[].cidr` field from the installation configuration, you must add them to this list to prevent connection issues.
+** If you scale up workers that are not included in the network defined by the `networking.machineNetwork[].cidr` field from the installation configuration, you must add them to this list to prevent connection issues.
 +
-This field is ignored if neither the `httpProxy` or `httpsProxy` fields are set.
+** This field is ignored if the `httpProxy` or `httpsProxy` fields are not set.
 --
 
 .Verification

--- a/modules/configuring-a-proxy-after-installation-ocm.adoc
+++ b/modules/configuring-a-proxy-after-installation-ocm.adoc
@@ -6,6 +6,7 @@
 [id="configuring-a-proxy-after-installation-ocm_{context}"]
 = Configuring a proxy after installation using {cluster-manager}
 
+[role="_abstract"]
 You can use {cluster-manager-first} to add a cluster-wide proxy configuration to an existing {product-title} cluster in a Virtual Private Cloud (VPC).
 ifdef::openshift-dedicated[]
 You can enable a proxy only for clusters that use the Customer Cloud Subscription (CCS) model.
@@ -15,7 +16,7 @@ You can also use {cluster-manager} to update an existing cluster-wide proxy conf
 
 [IMPORTANT]
 ====
-The cluster applies the proxy configuration to the control plane and compute nodes. While applying the configuration, each cluster node is temporarily placed in an unschedulable state and drained of its workloads. Each node is restarted as part of the process.
+The cluster applies the proxy configuration to the control plane and compute nodes. While applying the configuration, each cluster node is temporarily placed in an unschedulable state and drained of its workloads. The process restarts each node.
 ====
 
 .Prerequisites
@@ -26,7 +27,7 @@ endif::openshift-dedicated[]
 ifdef::openshift-dedicated[]
 * You have an {product-title} cluster that uses the Customer Cloud Subscription (CCS) model.
 endif::openshift-dedicated[]
-* Your cluster is deployed in a VPC.
+* You deploy your cluster in a VPC.
 
 .Procedure
 
@@ -34,13 +35,13 @@ endif::openshift-dedicated[]
 
 . Under the *Virtual Private Cloud (VPC)* section on the *Networking* page, click *Edit cluster-wide proxy*.
 
-. On the *Edit cluster-wide proxy* page, provide your proxy configuration details:
+. On the *Edit cluster-wide proxy* page, give your proxy configuration details:
 .. Enter a value in at least one of the following fields:
 *** Specify a valid *HTTP proxy URL*.
 *** Specify a valid *HTTPS proxy URL*.
-*** In the *Additional trust bundle* field, provide a PEM encoded X.509 certificate bundle.
+*** In the *Additional trust bundle* field, give a Privacy Enhanced Mail (PEM) encoded X.509 certificate bundle.
 +
-If you are replacing an existing trust bundle file, select *Replace file* to view the field. The bundle is added to the trusted certificate store for the cluster nodes. An additional trust bundle file is required if you use a TLS-inspecting proxy unless the identity certificate for the proxy is signed by an authority from the {op-system-first} trust bundle. This requirement applies regardless of whether the proxy is transparent or requires explicit configuration using the `http-proxy` and `https-proxy` arguments.
+If you are replacing an existing trust bundle file, select *Replace file* to view the field. The system adds the bundle to the trusted certificate store for the cluster nodes. You must use an additional trust bundle file if you use a TLS-inspecting proxy unless an authority from the {op-system-first} trust bundle signs the identity certificate for the proxy. This requirement applies regardless of whether the proxy is transparent or requires explicit configuration by using the `http-proxy` and `https-proxy` arguments.
 
 .. Click *Confirm*.
 

--- a/modules/configuring-a-proxy-during-installation-cli.adoc
+++ b/modules/configuring-a-proxy-during-installation-cli.adoc
@@ -6,9 +6,10 @@
 [id="configuring-a-proxy-during-installation-cli_{context}"]
 = Configuring a proxy during installation using the CLI
 
+[role="_abstract"]
 If you are installing a {product-title} cluster into an existing Virtual Private Cloud (VPC), you can use the ROSA CLI (`rosa`) to enable a cluster-wide HTTP or HTTPS proxy during installation.
 
-The following procedure provides details about the ROSA CLI (`rosa`) arguments that are used to configure a cluster-wide proxy during installation.
+The following procedure provides details about the ROSA CLI (`rosa`) arguments that you use to configure a cluster-wide proxy during installation.
 
 ifdef::openshift-rosa[]
 For general installation steps using the ROSA CLI, see _Creating a cluster with customizations using the CLI_.
@@ -16,7 +17,7 @@ endif::openshift-rosa[]
 
 .Prerequisites
 
-* You have verified that the proxy is accessible from the VPC that the cluster is being installed into. The proxy must also be accessible from the private subnets of the VPC.
+* You have verified that the proxy is accessible from the VPC that you install the cluster into. The proxy must also be accessible from the private subnets of the VPC.
 
 
 .Procedure
@@ -26,20 +27,23 @@ endif::openshift-rosa[]
 ----
 $ rosa create cluster \
  <other_arguments_here> \
- --additional-trust-bundle-file <path_to_ca_bundle_file> \ <1> <2> <3>
- --http-proxy http://<username>:<password>@<ip>:<port> \ <1> <3>
- --https-proxy https://<username>:<password>@<ip>:<port> \ <1> <3>
- --no-proxy example.com <4>
+ --additional-trust-bundle-file <path_to_ca_bundle_file> \
+ --http-proxy http://<username>:<password>@<ip>:<port> \
+ --https-proxy https://<username>:<password>@<ip>:<port> \
+ --no-proxy example.com
 ----
 +
 --
-<1> The `additional-trust-bundle-file`, `http-proxy`, and `https-proxy` arguments are all optional.
-<2> The `additional-trust-bundle-file` argument is a file path pointing to a bundle of PEM-encoded X.509 certificates, which are all concatenated together. The additional-trust-bundle-file argument is required for users who use a TLS-inspecting proxy unless the identity certificate for the proxy is signed by an authority from the {op-system-first} trust bundle. This applies regardless of whether the proxy is transparent or requires explicit configuration using the http-proxy and https-proxy arguments.
-<3> The `http-proxy` and `https-proxy` arguments must point to a valid URL.
-<4> A comma-separated list of destination domain names, IP addresses, or network CIDRs to exclude proxying.
+
+where:
+
+** The `additional-trust-bundle-file`, `http-proxy`, and `https-proxy` arguments are all optional.
+** The `additional-trust-bundle-file` argument is a file path pointing to a bundle of PEM-encoded X.509 certificates, which are all concatenated together. The additional-trust-bundle-file argument is required for users who use a TLS-inspecting proxy unless the identity certificate for the proxy is signed by an authority from the {op-system-first} trust bundle. This applies regardless of whether the proxy is transparent or requires explicit configuration using the http-proxy and https-proxy arguments.
+** The `http-proxy` and `https-proxy` arguments must point to a valid URL.
+** A comma-separated lis of destination domain names, IP addresses, or network CIDRs to exclude proxying.
 +
-Preface a domain with `.` to match subdomains only. For example, `.y.com` matches `x.y.com`, but not `y.com`. Use `*` to bypass proxy for all destinations.
-If you scale up workers that are not included in the network defined by the `networking.machineNetwork[].cidr` field from the installation configuration, you must add them to this list to prevent connection issues.
+** Preface a domain with `.` to match subdomains only. For example, `.y.com` matches `x.y.com`, but not `y.com`. Use `*` to bypass proxy for all destinations.
+** If you scale up workers that are not included in the network defined by the `networking.machineNetwork[].cidr` field from the installation configuration, you must add them to this list to prevent connection issues.
 +
-This field is ignored if neither the `httpProxy` or `httpsProxy` fields are set.
+** This field is ignored if the `httpProxy` or `httpsProxy` fields are not set.
 --

--- a/modules/configuring-a-proxy-during-installation-ocm.adoc
+++ b/modules/configuring-a-proxy-during-installation-ocm.adoc
@@ -6,6 +6,7 @@
 [id="configuring-a-proxy-during-installation-ocm_{context}"]
 = Configuring a proxy during installation using {cluster-manager}
 
+[role="_abstract"]
 If you are installing
 ifdef::openshift-dedicated[]
 an {product-title}
@@ -18,7 +19,7 @@ ifdef::openshift-dedicated[]
 You can enable a proxy only for clusters that use the Customer Cloud Subscription (CCS) model.
 endif::openshift-dedicated[]
 
-Prior to the installation, you must verify that the proxy is accessible from the VPC that the cluster is being installed into. The proxy must also be accessible from the private subnets of the VPC.
+Before the installation, you must verify that the proxy is accessible from the VPC that you install the cluster into. The proxy must also be accessible from the private subnets of the VPC.
 
 ifdef::openshift-dedicated[]
 For detailed steps to configure a cluster-wide proxy during installation by using {cluster-manager}, see _Creating a cluster on AWS_ or _Creating a cluster on {gcp-short}_.

--- a/modules/configuring-a-proxy-trust-bundle-responsibilities.adoc
+++ b/modules/configuring-a-proxy-trust-bundle-responsibilities.adoc
@@ -6,6 +6,7 @@
 [id="configuring-a-proxy-trust-bundle-responsibilities_{context}"]
 = Responsibilities for additional trust bundles
 
+[role="_abstract"]
 If you supply an additional trust bundle, you are responsible for the following requirements:
 
 * Ensuring that the contents of the additional trust bundle are valid

--- a/modules/configuring-proxy-after-install-intro.adoc
+++ b/modules/configuring-proxy-after-install-intro.adoc
@@ -1,0 +1,15 @@
+// Module included in the following assemblies:
+//
+// * networking/ovn_kubernetes_network_provider/configuring-cluster-wide-proxy.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="configuring-a-proxy-after-installation_{context}"]
+= Configuring a proxy after installation
+
+[role="_abstract"]
+ifdef::openshift-dedicated[]
+You can configure an HTTP or HTTPS proxy after you install an {product-title} with Customer Cloud Subscription (CCS) cluster into an existing Virtual Private Cloud (VPC). You can configure the proxy after installation by using {cluster-manager-first}.
+endif::openshift-dedicated[]
+ifdef::openshift-rosa,openshift-rosa-hcp[]
+You can configure an HTTP or HTTPS proxy after you install a {product-title} cluster into an existing Virtual Private Cloud (VPC). You can configure the proxy after installation by using {cluster-manager-first} or the ROSA CLI (`rosa`).
+endif::openshift-rosa,openshift-rosa-hcp[]

--- a/modules/configuring-proxy-during-install-intro.adoc
+++ b/modules/configuring-proxy-during-install-intro.adoc
@@ -1,0 +1,15 @@
+// Module included in the following assemblies:
+//
+// * networking/ovn_kubernetes_network_provider/configuring-cluster-wide-proxy.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="configuring-a-proxy-during-installation_{context}"]
+= Configuring a proxy during installation
+
+[role="_abstract"]
+ifdef::openshift-dedicated[]
+You can configure an HTTP or HTTPS proxy when you install an {product-title} with Customer Cloud Subscription (CCS) cluster into an existing Virtual Private Cloud (VPC). You can configure the proxy during installation by using {cluster-manager-first}.
+endif::openshift-dedicated[]
+ifdef::openshift-rosa,openshift-rosa-hcp[]
+You can configure an HTTP or HTTPS proxy when you install a {product-title} cluster into an existing Virtual Private Cloud (VPC). You can configure the proxy during installation by using {cluster-manager-first} or the ROSA CLI (`rosa`).
+endif::openshift-rosa,openshift-rosa-hcp[]

--- a/modules/migrate-sdn-ovn-osd.adoc
+++ b/modules/migrate-sdn-ovn-osd.adoc
@@ -3,21 +3,24 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="migrate-sdn-ovn-ocm-cli_{context}"]
-= Initiating migration using the OpenShift Cluster Manager API command-line interface (ocm) CLI
+= Starting migration by using the {cluster-manager} CLI
+
+[role="_abstract"]
+You can start the migration from the OpenShift Software-Defined Networking (SDN) network plugin to the OVN-Kubernetes network plugin by using the {rosa-cli-first}.
 
 [WARNING]
 ====
-You can only initiate migration on clusters that are version 4.16.43 and above.
+You can only start migration on clusters that are version 4.16.43 and above.
 ====
 
 .Prerequisites
 
-*  You installed the link:https://console.redhat.com/openshift/downloads[OpenShift Cluster Manager API command-line interface (`ocm`)].
+*  You installed the link:https://console.redhat.com/openshift/downloads[{cluster-manager} CLI (`ocm`)].
 
 [IMPORTANT]
 ====
 [subs="attributes+"]
-OpenShift Cluster Manager API command-line interface (`ocm`) is a Developer Preview feature only.
+The {cluster-manager} CLI (`ocm`) is a Developer Preview feature only.
 For more information about the support scope of Red Hat Developer Preview features, see link:https://access.redhat.com/support/offerings/devpreview/[Developer Preview Support Scope].
 ====
 
@@ -52,26 +55,23 @@ For more information about the support scope of Red Hat Developer Preview featur
 ====
 OVN-Kubernetes reserves the following IP address ranges:
 
-`100.64.0.0/16`. This IP address range is used for the `internalJoinSubnet` parameter of OVN-Kubernetes by default.
+`100.64.0.0/16`. OVN-Kubernetes uses this IP address range for the `internalJoinSubnet` parameter by default.
 
-`100.88.0.0/16`. This IP address range is used for the `internalTransSwitchSubnet` parameter of OVN-Kubernetes by default.
+`100.88.0.0/16`. OVN-Kubernetes uses this IP address range for the `internalTransSwitchSubnet` parameter by default.
 
-If these IP addresses have been used by OpenShift SDN or any external networks that might communicate with this cluster, you must patch them to use a different IP address range before initiating the limited live migration. For more information, see _Patching OVN-Kubernetes address ranges_ in the _Additional resources_ section.
+If OpenShift SDN or any external networks that might communicate with this cluster use these IP addresses, you must patch them to use a different IP address range before starting the limited live migration. For more information, see _Patching OVN-Kubernetes address ranges_ in the _Additional resources_ section.
 ====
 +
 
-. To initiate the migration, run the following post request in a terminal window:
-
+. To start the migration, run the following post request in a terminal window.
 +
 [source,terminal]
 ----
-$ ocm post /api/clusters_mgmt/v1/clusters/{cluster_id}/migrations <1>
-  --body=myjsonfile.json <2>
+$ ocm post /api/clusters_mgmt/v1/clusters/{cluster_id}/migrations
+  --body=myjsonfile.json
 ----
-<1> Replace `{cluster_id}` with the ID of the cluster you want to migrate to the OVN-Kubernetes network plugin.
-<2> Replace `myjsonfile.json` with the name of the JSON file you created in the previous step.
 +
-.Example output
+*Example output*
 +
 [source,json]
 ----
@@ -93,6 +93,13 @@ $ ocm post /api/clusters_mgmt/v1/clusters/{cluster_id}/migrations <1>
   "updated_timestamp": "2025-02-05T14:56:34.878467542Z"
 }
 ----
++
+--
+where:
+
+`{cluster_id}`:: Specifies the ID of the cluster you want to migrate to the OVN-Kubernetes network plugin.
+`myjsonfile.json`:: Specifies the name of the JSON file you created in the previous step.
+--
 
 // :_mod-docs-content-type: PROCEDURE
 // [id="verify-sdn-ovn-ocm_{context}"]
@@ -100,12 +107,9 @@ $ ocm post /api/clusters_mgmt/v1/clusters/{cluster_id}/migrations <1>
 
 .Verification
 
-* To check the status of the migration, run the following command:
-
+* To check the status of the migration, run the following command. Replace `<cluster_id>` with the ID of the cluster to which you applied the migration:
 +
-
 [source,terminal]
 ----
-$ ocm get cluster <cluster_id>/migrations <1>
+$ ocm get cluster <cluster_id>/migrations
 ----
-<1> Replace `<cluster_id>` with the ID of the cluster that the migration was applied to.

--- a/modules/migrate-sdn-ovn.adoc
+++ b/modules/migrate-sdn-ovn.adoc
@@ -3,23 +3,29 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="migrate-sdn-ovn-cli_{context}"]
-= Initiating migration using the ROSA CLI
+= Starting migration by using the ROSA CLI
+
+[role="_abstract"]
+You can start the migration from the OpenShift SDN network plugin to the OVN-Kubernetes network plugin by using the ROSA CLI.
 
 [WARNING]
 ====
-You can only initiate migration on clusters that are version 4.16.43 and above.
+You can only start migration on clusters that are version 4.16.43 and above.
 ====
 
-To initiate the migration, run the following command:
+.Procedure
+
+* Start the migration by running the following command. Replace `<cluster_id>` with the ID of the cluster you want to migrate to the OVN-Kubernetes network plugin:
++
 [source,terminal]
 ----
-$ rosa edit cluster -c <cluster_id> <1>
+$ rosa edit cluster -c <cluster_id>
   --network-type OVNKubernetes
-  --ovn-internal-subnets <configuration> <2>
+  --ovn-internal-subnets <configuration>
 ----
-<1> Replace `<cluster_id>` with the ID of the cluster you want to migrate to the OVN-Kubernetes network plugin.
-<2> Optional: Users can create key-value pairs to configure internal subnets using any or all of the options `join, masquerade, transit` along with a single CIDR per option. For example, `--ovn-internal-subnets="join=0.0.0.0/24,transit=0.0.0.0/24,masquerade=0.0.0.0/24"`.
-
++
+Optional: You can create key-value pairs to configure internal subnets by using any or all of the options `join, masquerade, transit` along with a single CIDR per option. For example, `--ovn-internal-subnets="join=0.0.0.0/24,transit=0.0.0.0/24,masquerade=0.0.0.0/24"`.
++
 [IMPORTANT]
 ====
 You cannot include the optional flag `--ovn-internal-subnets` in the command unless you define a value for the flag `--network-type`.
@@ -27,12 +33,9 @@ You cannot include the optional flag `--ovn-internal-subnets` in the command unl
 
 .Verification
 
-* To check the status of the migration, run the following command:
-
+* To check the status of the migration, run the following command. Replace `<cluster_id>` with the ID of the cluster to check the migration status:
 +
-
 [source,terminal]
 ----
-$ rosa describe cluster -c <cluster_id> <1>
+$ rosa describe cluster -c <cluster_id>
 ----
-<1> Replace `<cluster_id>` with the ID of the cluster to check the migration status.

--- a/modules/nv-scope-network-verification-checks.adoc
+++ b/modules/nv-scope-network-verification-checks.adoc
@@ -1,0 +1,24 @@
+// Module included in the following assemblies:
+//
+// * networking/network_security/network-verification.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="scope-of-the-network-verification-checks_{context}"]
+= Scope of the network verification checks
+
+[role="_abstract"]
+The network verification includes checks for each of the following requirements:
+
+* The parent Virtual Private Cloud (VPC) exists.
+* All specified subnets belong to the VPC.
+* The VPC has `enableDnsSupport` enabled.
+* The VPC has `enableDnsHostnames` enabled.
+ifdef::openshift-dedicated[]
+* Egress is available to the required domain and port combinations.
+endif::openshift-dedicated[]
+
+ifdef::openshift-dedicated[]
+[role="_additional-resources"]
+.Additional resources
+* link:https://docs.openshift.com/dedicated/osd_planning/aws-ccs.html#osd-aws-privatelink-firewall-prerequisites_aws-ccs[AWS firewall prerequisites]
+endif::openshift-dedicated[]

--- a/modules/nw-networkpolicy-create-ocm.adoc
+++ b/modules/nw-networkpolicy-create-ocm.adoc
@@ -1,13 +1,12 @@
 // Module included in the following assemblies:
 //
 // * networking/network_security/network_policy/creating-network-policy.adoc
-// * networking/multiple_networks/configuring-multi-network-policy.adoc
-// * post_installation_configuration/network-configuration.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="nw-networkpolicy-create-ocm_{context}"]
 = Creating a network policy using {cluster-manager}
 
+[role="_abstract"]
 To define granular rules describing the ingress or egress network traffic allowed for namespaces in your cluster, you can create a network policy.
 
 .Prerequisites
@@ -20,19 +19,19 @@ To define granular rules describing the ingress or egress network traffic allowe
 
 .Procedure
 
-. From {cluster-manager-url}, click on the cluster you want to access.
+. From {cluster-manager-url}, click the cluster you want to access.
 
 . Click *Open console* to navigate to the OpenShift web console.
 
-. Click on your identity provider and provide your credentials to log in to the cluster.
+. Click your identity provider and give your credentials to log in to the cluster.
 
 . From the administrator perspective, under *Networking*, click *NetworkPolicies*.
 
 . Click *Create NetworkPolicy*.
 
-. Provide a name for the policy in the *Policy name* field.
+. Give a name for the policy in the *Policy name* field.
 
-. Optional: You can provide the label and selector for a specific pod if this policy applies only to one or more specific pods. If you do not select a specific pod, then this policy will be applicable to all pods on the cluster.
+. Optional: You can give the label and selector for a specific pod if this policy applies only to one or more specific pods. If you do not select a specific pod, then this policy will be applicable to all pods on the cluster.
 
 . Optional: You can block all ingress and egress traffic by using the *Deny all ingress traffic* or *Deny all egress traffic* checkboxes.
 
@@ -40,7 +39,7 @@ To define granular rules describing the ingress or egress network traffic allowe
 
 . Add ingress rules to your policy:
 
-.. Select *Add ingress rule* to configure a new rule. This action creates a new *Ingress rule* row with an *Add allowed source* drop-down menu that enables you to specify how you want to limit inbound traffic. The drop-down menu offers three options to limit your ingress traffic:
+.. Select *Add ingress rule* to configure a new rule. This action creates a new *Ingress rule* row with an *Add allowed source* drop-down menu where you specify how to limit inbound traffic. The drop-down menu offers three options to limit your ingress traffic:
 +
 *** *Allow pods from the same namespace* limits traffic to pods within the same namespace. You can specify the pods in a namespace, but leaving this option blank allows all of the traffic from pods in the namespace.
 
@@ -52,7 +51,7 @@ To define granular rules describing the ingress or egress network traffic allowe
 
 . Add egress rules to your network policy:
 
-.. Select *Add egress rule* to configure a new rule. This action creates a new *Egress rule* row with an *Add allowed destination*"* drop-down menu that enables you to specify how you want to limit outbound traffic. The drop-down menu offers three options to limit your egress traffic:
+.. Select *Add egress rule* to configure a new rule. This action creates a new *Egress rule* row with an *Add allowed destination*"* drop-down menu where you specify how to limit outbound traffic. The drop-down menu offers three options to limit your egress traffic:
 +
 *** *Allow pods from the same namespace* limits outbound traffic to pods within the same namespace. You can specify the pods in a namespace, but leaving this option blank allows all of the traffic from pods in the namespace.
 

--- a/modules/nw-networkpolicy-delete-ocm.adoc
+++ b/modules/nw-networkpolicy-delete-ocm.adoc
@@ -1,7 +1,6 @@
 // Module included in the following assemblies:
 //
 // * networking/network_security/network_policy/deleting-network-policy.adoc
-// * post_installation_configuration/network-configuration.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="nw-networkpolicy-delete-ocm_{context}"]
@@ -34,6 +33,6 @@ endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 +
 .. Delete the policy using the *Actions* drop-down menu from the individual network policy details:
 +
-... Click on *Actions* drop-down menu for your network policy.
+... Click *Actions* drop-down menu for your network policy.
 +
 ... Select *Delete NetworkPolicy* from the menu.

--- a/modules/nw-networkpolicy-view-ocm.adoc
+++ b/modules/nw-networkpolicy-view-ocm.adoc
@@ -1,7 +1,6 @@
 // Module included in the following assemblies:
 //
 // * networking/network_security/network_policy/viewing-network-policy.adoc
-// * post_installation_configuration/network-configuration.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="nw-networkpolicy-view-ocm_{context}"]
@@ -25,9 +24,9 @@ endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 
 .Procedure
 
-. From the *Administrator* perspective in the {cluster-manager} web console, under *Networking*, click *NetworkPolicies*.
+. From the *Administrator* perspective in the {cluster-manager} web console, under *Networking*, click *`NetworkPolicies`*.
 
-. Select the desired network policy to view.
+. Select the required network policy to view.
 
 . In the *Network Policy* details page, you can view all of the associated ingress and egress rules.
 

--- a/modules/nw-rosa-proxy-remove-cli.adoc
+++ b/modules/nw-rosa-proxy-remove-cli.adoc
@@ -6,6 +6,7 @@
 [id="nw-rosa-proxy-remove-cli_{context}"]
 = Removing the cluster-wide proxy using CLI
 
+[role="_abstract"]
 You must use the ROSA CLI, `rosa`, to remove the proxy's address from your cluster.
 
 .Prerequisites
@@ -15,7 +16,7 @@ You must use the ROSA CLI, `rosa`, to remove the proxy's address from your clust
 
 .Procedure
 
-* Use the `rosa edit` command to modify the proxy. You must pass empty strings to the `--http-proxy` and `--https-proxy` arguments to clear the proxy from the cluster:
+* Use the `rosa edit` command to change the proxy. You must pass empty strings to the `--http-proxy` and `--https-proxy` arguments to clear the proxy from the cluster:
 +
 [source,terminal]
 ----
@@ -24,10 +25,10 @@ $ rosa edit cluster -c <cluster_name> --http-proxy "" --https-proxy ""
 +
 [NOTE]
 ====
-While your proxy might only use one of the proxy arguments, the empty fields are ignored, so passing empty strings to both the `--http-proxy` and `--https-proxy` arguments does not cause any issues.
+While your proxy might only use one of the proxy arguments, the system ignores the empty fields, so passing empty strings to both the `--http-proxy` and `--https-proxy` arguments does not cause any issues.
 ====
 +
-.Example Output
+*Example output*
 +
 [source,yaml]
 ----
@@ -36,7 +37,7 @@ I: Updated cluster <cluster_name>
 
 .Verification
 
-* You can verify that the proxy has been removed from the cluster by using the `rosa describe` command:
+* You can verify that you removed the proxy from the cluster by using the `rosa describe` command:
 +
 [source,yaml]
 ----

--- a/modules/osd-create-cluster-exclude-namespace-selector-cli.adoc
+++ b/modules/osd-create-cluster-exclude-namespace-selector-cli.adoc
@@ -7,7 +7,7 @@
 = Set namespace exclusions for the default ingress when creating a cluster
 
 [role="_abstract"]
-When you create an {product-title} cluster in noninteractive mode, you can pass a namespace label selector so that namespaces matching those labels are excluded from the default `application ingress`. This allows you to exclude namespaces that host workloads through the default ingress, such as namespaces with sensitive data or internal services.
+When you create an {product-title} cluster in noninteractive mode, pass a namespace label selector to exclude matching namespaces from the default `application ingress`. For example, exclude namespaces that host sensitive data or internal services.
 
 .Prerequisites
 
@@ -41,9 +41,9 @@ where:
 
 `--provider=<aws_or_gcp>`:: Specifies the cloud provider.
 
-`<other_required_flags>`:: Required parameters such as region, version, CCS settings, or billing flags, as described in the cluster creation documentation for your platform.
+`<other_required_flags>`:: Required parameters such as region, version, Customer Cloud Subscription (CCS) settings, or billing flags, as described in the cluster creation documentation for your platform.
 
-`--default-ingress-excluded-namespace-selectors`:: Specifies label selectors; namespaces whose labels match are excluded from the default application ingress, subject to validation by the service. Replace `<key>=<value>` with your labels. Do not include spaces around the `=` sign.
+`--default-ingress-excluded-namespace-selectors`:: Specifies label selectors that exclude matching namespaces from the default application ingress. The service validates these exclusions. Replace `<key>=<value>` with your labels. Do not include spaces around the `=` sign.
 
 .Verification
 

--- a/modules/osd-ingress-excluded-namespaces-ocm-cli.adoc
+++ b/modules/osd-ingress-excluded-namespaces-ocm-cli.adoc
@@ -7,11 +7,11 @@
 = Configure excluded namespaces for the default ingress controller
 
 [role="_abstract"]
-As a cluster administrator, you can use the {cluster-manager} CLI (`ocm`) to set which namespaces are excluded from the default application ingress on an existing cluster. Excluded namespaces do not have routes served by that ingress.
+As a cluster administrator, you can use the {cluster-manager} CLI (`ocm`) to exclude namespaces from the default application ingress on an existing cluster. Excluded namespaces do not have routes served by that ingress.
 
 .Prerequisites
 
-* You installed the `ocm` CLI and logged in with credentials that can modify cluster ingress settings in {cluster-manager-first}.
+* You installed the `ocm` CLI and logged in with credentials that can change cluster ingress settings in {cluster-manager-first}.
 * You have the cluster name, cluster ID, or external ID of your cluster.
 
 [IMPORTANT]

--- a/modules/removing-cluster-wide-proxy-intro.adoc
+++ b/modules/removing-cluster-wide-proxy-intro.adoc
@@ -1,0 +1,10 @@
+// Module included in the following assemblies:
+//
+// * networking/ovn_kubernetes_network_provider/configuring-cluster-wide-proxy.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="removing-cluster-wide-proxy_{context}"]
+= Removing a cluster-wide proxy
+
+[role="_abstract"]
+You can remove your cluster-wide proxy by using the ROSA CLI. After removing the cluster, you should also remove any trust bundles that you added to the cluster.

--- a/modules/running-network-verification-manually-cli.adoc
+++ b/modules/running-network-verification-manually-cli.adoc
@@ -7,9 +7,10 @@
 [id="running-network-verification-manually-cli_{context}"]
 = Running the network verification manually using the CLI
 
+[role="_abstract"]
 You can manually run the network verification checks for an existing {product-title} cluster by using the ROSA CLI (`rosa`).
 
-When you run the network verification, you can specify a set of VPC subnet IDs or a cluster name.
+To run the network verification, you can specify either a cluster name or a set of Virtual Private Cloud (VPC) subnet IDs.
 
 .Prerequisites
 
@@ -19,14 +20,12 @@ When you run the network verification, you can specify a set of VPC subnet IDs o
 
 .Procedure
 
-* Verify the network configuration by using one of the following methods:
-** Verify the network configuration by specifying the cluster name. The subnet IDs are automatically detected:
+* Option 1: Verify the network configuration by specifying the cluster name. The subnet IDs are automatically detected. Replace `<cluster_name>` with the name of your cluster:
 +
 [source,terminal]
 ----
-$ rosa verify network --cluster <cluster_name> <1>
+$ rosa verify network --cluster <cluster_name>
 ----
-<1> Replace `<cluster_name>` with the name of your cluster.
 +
 .Example output
 [source,terminal]
@@ -37,19 +36,20 @@ I: subnet-03146b9b52b2034cc: passed
 I: Run the following command to wait for verification to all subnets to complete:
 rosa verify network --watch --status-only --region us-east-1 --subnet-ids subnet-03146b9b52b6024cb,subnet-03146b9b52b2034cc
 ----
-*** Ensure that verification to all subnets has been completed:
+** Ensure that verification to all subnets completes:
 +
 [source,terminal]
 ----
-$ rosa verify network --watch \ <1>
-                      --status-only \ <2>
-                      --region <region_name> \ <3>
-                      --subnet-ids subnet-03146b9b52b6024cb,subnet-03146b9b52b2034cc <4>
+$ rosa verify network --watch \
+                      --status-only \
+                      --region <region_name> \
+                      --subnet-ids subnet-03146b9b52b6024cb,subnet-03146b9b52b2034cc
 ----
-<1> The `watch` flag causes the command to complete after all the subnets under test are in a failed or passed state.
-<2> The `status-only` flag does not trigger a run of network verification but returns the current state, for example, `subnet-123 (verification still in-progress)`. By default, without this option, a call to this command always triggers a verification of the specified subnets.
-<3> Use a specific AWS region that overrides the _AWS_REGION_ environment variable.
-<4> Enter a list of subnet IDs separated by commas to verify. If any of the subnets do not exist, the error message `Network verification for subnet 'subnet-<subnet_number> not found` displays and no subnets are checked.
++
+*** The `watch` flag causes the command to complete after all the subnets under test are in a failed or passed state.
+*** The `status-only` flag does not trigger a run of network verification but returns the current state, for example, `subnet-123 (verification still in-progress)`. By default, without this option, a call to this command always triggers a verification of the specified subnets.
+*** Use the `region` flag to provide a specific AWS region that overrides the `_AWS_REGION_` environment variable.
+*** Use the `subnet-ids` flag to enter a list of subnet IDs separated by commas to verify. If any of the subnets do not exist, the error message `Network verification for subnet 'subnet-<subnet_number> not found` displays and the system does not check subnets.
 +
 .Example output
 [source,terminal]
@@ -64,7 +64,7 @@ I: subnet-03146b9b52b2034cc: passed
 To output the full list of verification tests, you can include the `--debug` argument when you run the `rosa verify network` command.
 ====
 +
-** Verify the network configuration by specifying the VPC subnets IDs. Replace `<region_name>` with your AWS region and `<AWS_account_ID>` with your AWS account ID:
+* Option 2: Verify the network configuration by specifying the VPC subnets IDs. Replace `<region_name>` with your AWS region and `<AWS_account_ID>` with your AWS account ID:
 +
 [source,terminal]
 ----
@@ -80,7 +80,7 @@ I: subnet-03146b9b52b2034cc: passed
 I: Run the following command to wait for verification to all subnets to complete:
 rosa verify network --watch --status-only --region us-east-1 --subnet-ids subnet-03146b9b52b6024cb,subnet-03146b9b52b2034cc
 ----
-*** Ensure that verification to all subnets has been completed:
+** Ensure that verification to all subnets completes:
 +
 [source,terminal]
 ----

--- a/modules/running-network-verification-manually-ocm.adoc
+++ b/modules/running-network-verification-manually-ocm.adoc
@@ -15,6 +15,7 @@ ifdef::openshift-rosa[]
 
 endif::openshift-rosa[]
 
+[role="_abstract"]
 You can manually run the network verification checks for an existing {product-title} cluster by using {cluster-manager-first}.
 
 .Prerequisites

--- a/modules/running-network-verification-manually.adoc
+++ b/modules/running-network-verification-manually.adoc
@@ -6,4 +6,5 @@
 [id="running-network-verification-manually_{context}"]
 = Running the network verification manually
 
+[role="_abstract"]
 After installing a {product-title} cluster, you can run the network verification checks manually by using {cluster-manager-first} or the ROSA CLI (`rosa`).

--- a/modules/sd-ingress-responsibilities.adoc
+++ b/modules/sd-ingress-responsibilities.adoc
@@ -3,8 +3,9 @@
 
 :_mod-docs-content-type: REFERENCE
 [id="sd-ingress-responsibility-matrix_{context}"]
-= Management of `default` Ingress Controller functions
+= Management of default Ingress Controller functions
 
+[role="_abstract"]
 The following table details the components of the `default` Ingress Controller managed by the Ingress Operator and whether Red Hat Site Reliability Engineering (SRE) maintains this component on {product-title} clusters.
 
 .Ingress Operator Responsibility Chart

--- a/modules/tagging-aws-vpc-subnets.adoc
+++ b/modules/tagging-aws-vpc-subnets.adoc
@@ -7,7 +7,7 @@
 = Tag the AWS VPC and subnets
 
 [role="_abstract"]
-To prepare your environment for the AWS Load Balancer Operator, tag your AWS VPC resources. This configuration ensures that the Operator can correctly identify and manage your network resources.
+To prepare your environment for the AWS Load Balancer Operator, tag your AWS Virtual Private Cloud (VPC) resources. This configuration ensures that the Operator can correctly identify and manage your network resources.
 
 .Prerequisites
 
@@ -20,17 +20,17 @@ To prepare your environment for the AWS Load Balancer Operator, tag your AWS VPC
 +
 [source,terminal]
 ----
-$ export VPC_ID=<vpc-id>
+$ export VPC_ID=<vpc_id>
 ----
 +
 [source,terminal]
 ----
-$ export PUBLIC_SUBNET_IDS="<public-subnet-a-id> <public-subnet-b-id> <public-subnet-c-id>"
+$ export PUBLIC_SUBNET_IDS="<public_subnet_a_id> <public_subnet_b_id> <public_subnet_c_id>"
 ----
 +
 [source,terminal]
 ----
-$ export PRIVATE_SUBNET_IDS="<private-subnet-a-id> <private-subnet-b-id> <private-subnet-c-id>"
+$ export PRIVATE_SUBNET_IDS="<private_subnet_a_id> <private_subnet_b_id> <private_subnet_c_id>"
 ----
 
 . Tag your VPC to associate it with your cluster:

--- a/modules/understanding-network-verification.adoc
+++ b/modules/understanding-network-verification.adoc
@@ -6,6 +6,7 @@
 [id="osd-understanding-network-verification_{context}"]
 = Understanding network verification for {product-title} clusters
 
+[role="_abstract"]
 When you deploy
 ifdef::openshift-dedicated[]
 an {product-title}
@@ -22,8 +23,8 @@ ifdef::openshift-rosa,openshift-rosa-hcp[]
 When you prepare to install your cluster by using {cluster-manager-first}, the automatic checks run after you input a subnet into a subnet ID field on the *Virtual Private Cloud (VPC) subnet settings* page. If you create your cluster by using the ROSA CLI (`rosa`) with the interactive mode, the checks run after you provide the required VPC network information. If you use the CLI without the interactive mode, the checks begin immediately before cluster creation.
 endif::openshift-rosa,openshift-rosa-hcp[]
 
-When you add a machine pool with a subnet that is new to your cluster, the automatic network verification checks the subnet to ensure that network connectivity is available before the machine pool is provisioned.
+When you add a machine pool with a subnet that is new to your cluster, the automatic network verification checks the subnet to ensure that network connectivity is available before provisioning the machine pool.
 
-After automatic network verification completes, a record is sent to the service log. The record provides the results of the verification check, including any network configuration errors. You can resolve the identified issues before a deployment and the deployment has a greater chance of success.
+After automatic network verification completes, the system sends a record to the service log. The record provides the results of the verification check, including any network configuration errors. You can resolve the identified issues before a deployment and the deployment has a greater chance of success.
 
-You can also run the network verification manually for an existing cluster. This enables you to verify the network configuration for your cluster after making configuration changes. For steps to run the network verification checks manually, see _Running the network verification manually_.
+You can also run the network verification manually for an existing cluster to verify the network configuration after making configuration changes. For steps to run the network verification checks manually, see _Running the network verification manually_.

--- a/networking/network_security/network-verification.adoc
+++ b/networking/network_security/network-verification.adoc
@@ -7,6 +7,7 @@ include::_attributes/attributes-openshift-dedicated.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 Network verification checks run automatically when you deploy
 ifdef::openshift-dedicated[]
 an {product-title}
@@ -14,24 +15,11 @@ endif::openshift-dedicated[]
 ifdef::openshift-rosa,openshift-rosa-hcp[]
 a {product-title}
 endif::openshift-rosa,openshift-rosa-hcp[]
-cluster into an existing Virtual Private Cloud (VPC) or create an additional machine pool with a subnet that is new to your cluster. The checks validate your network configuration and highlight errors, enabling you to resolve configuration issues before cluster deployment.
-
-You can also run the network verification checks manually to validate the configuration for an existing cluster.
+cluster into an existing Virtual Private Cloud (VPC) or create an additional machine pool with a subnet that is new to your cluster. The checks validate your network configuration and highlight errors, enabling you to resolve configuration issues before cluster deployment. You can also run the network verification checks manually to validate the configuration for an existing cluster.
 
 include::modules/understanding-network-verification.adoc[leveloffset=+1]
 
-[id="scope-of-the-network-verification-checks_{context}"]
-== Scope of the network verification checks
-
-The network verification includes checks for each of the following requirements:
-
-* The parent Virtual Private Cloud (VPC) exists.
-* All specified subnets belong to the VPC.
-* The VPC has `enableDnsSupport` enabled.
-* The VPC has `enableDnsHostnames` enabled.
-ifdef::openshift-dedicated[]
-* Egress is available to the required domain and port combinations that are specified in the xref:../../osd_planning/aws-ccs.adoc#osd-aws-privatelink-firewall-prerequisites_aws-ccs[AWS firewall prerequisites] section.
-endif::openshift-dedicated[]
+include::modules/nv-scope-network-verification-checks.adoc[leveloffset=+1]
 //ifdef::openshift-rosa[]
 //Commenting out the following xref because it's breaking the networking and potentially other PRs. Pre- or post-publish HCP pruning task. 
 //ifdef::openshift-rosa,openshift-rosa-hcp[]

--- a/networking/networking_operators/aws-load-balancer-operator.adoc
+++ b/networking/networking_operators/aws-load-balancer-operator.adoc
@@ -7,22 +7,22 @@ include::_attributes/attributes-openshift-dedicated.adoc[]
 toc::[]
 
 [role="_abstract"]
-The AWS Load Balancer Operator is an Operator supported by Red{nbsp}Hat that you can optionally install on SRE-managed {product-title} clusters.
+The AWS Load Balancer Operator is an Operator supported by Red{nbsp}Hat that you can optionally install on Site Reliability Engineering (SRE)-managed {product-title} clusters.
 
 [IMPORTANT]
 ====
-Load Balancers created by the AWS Load Balancer Operator cannot be used for xref:../../networking/ingress_load_balancing/routes/creating-basic-routes.adoc#creating-basic-routes[OpenShift Routes], and should only be used for individual services or ingress resources that do not need the full layer 7 capabilities of an OpenShift Route.
+Load balancers created by the AWS Load Balancer Operator cannot serve OpenShift Routes, and should only serve individual services or ingress resources that do not need the full layer 7 capabilities of an OpenShift Route.
 ====
 
-The link:https://github.com/openshift/aws-load-balancer-operator[AWS Load Balancer Operator] is used to install, manage, and configure the link:https://kubernetes-sigs.github.io/aws-load-balancer-controller/[AWS Load Balancer Controller] in a {product-title} cluster.
+The AWS Load Balancer Operator installs, manages, and configures the AWS Load Balancer Controller in a {product-title} cluster.
 
-The AWS Load Balancer Controller provisions link:https://docs.aws.amazon.com/elasticloadbalancing/latest/application/introduction.html[AWS Application Load Balancers (ALB)] when you create Kubernetes Ingress resources and link:https://docs.aws.amazon.com/elasticloadbalancing/latest/network/introduction.html[AWS Network Load Balancers (NLB)] when you create a Kubernetes Service resource with a type of LoadBalancer.
+The AWS Load Balancer Controller provisions AWS Application Load Balancers (ALBs) when you create Kubernetes Ingress resources and AWS Network Load Balancers (NLBs) when you create a Kubernetes Service resource with a type of `LoadBalancer`.
 
-Compared with the default AWS in-tree load balancer provider, this controller is developed with advanced annotations for both ALBs and NLBs. Some advanced use cases are:
+Compared with the default AWS in-tree load balancer provider, this controller provides advanced annotations for both ALBs and NLBs. Some advanced use cases are:
 
 * Using native Kubernetes Ingress objects with ALBs
 * Integrate ALBs with the AWS Web Application Firewall (WAF) service
-* Specify custom NLB source IP ranges
+* Specify custom Network Load Balancer (NLB) source IP ranges
 * Specify custom NLB internal IP addresses
 
 include::modules/albo-prerequisites.adoc[leveloffset=+1]
@@ -31,7 +31,7 @@ include::modules/aws-load-balancer-operator-environment.adoc[leveloffset=+2]
 
 include::modules/tagging-aws-vpc-subnets.adoc[leveloffset=+2]
 
-[role="additional_resources"]
+[role="_additional-resources"]
 .Additional resources
 ifdef::openshift-rosa[]
 * xref:../../rosa_install_access_delete_clusters/rosa-sts-creating-a-cluster-quickly.adoc#rosa-sts-creating-a-cluster-quickly[Creating a {product-title} cluster with STS using the default options]
@@ -39,13 +39,18 @@ endif::openshift-rosa[]
 ifdef::openshift-rosa-hcp[]
 * xref:../../rosa_hcp/rosa-hcp-sts-creating-a-cluster-quickly.adoc#rosa-hcp-sts-creating-a-cluster-quickly_rosa-hcp-sts-creating-a-cluster-quickly[Creating {product-title} clusters using the default options]
 endif::openshift-rosa-hcp[]
+* link:https://github.com/openshift/aws-load-balancer-operator[AWS Load Balancer Operator on GitHub]
+* link:https://kubernetes-sigs.github.io/aws-load-balancer-controller/[AWS Load Balancer Controller documentation]
+* link:https://docs.aws.amazon.com/elasticloadbalancing/latest/application/introduction.html[AWS Application Load Balancers]
+* link:https://docs.aws.amazon.com/elasticloadbalancing/latest/network/introduction.html[AWS Network Load Balancers]
+* xref:../../networking/ingress_load_balancing/routes/creating-basic-routes.adoc#creating-basic-routes[Creating basic routes]
 
 include::modules/albo-installation.adoc[leveloffset=+1]
 
-[role="additional_resources"]
+[role="_additional-resources"]
 .Additional resources
 ifndef::openshift-rosa-hcp[]
-* link:https://docs.redhat.com/en/documentation/openshift_container_platform/{ocp-version}/html/networking_operators/aws-load-balancer-operator-1#nw-multiple-ingress-through-single-alb[Creating multiple ingresses through a single AWS Load Balancer]
+* link:https://docs.redhat.com/en/documentation/openshift_container_platform/{ocp-version}/html/networking_operators/aws-load-balancer-operator-1#nw-multiple-ingress-through-single-alb[Creating many ingresses through a single AWS Load Balancer]
 * link:https://docs.redhat.com/en/documentation/openshift_container_platform/{ocp-version}/html/networking_operators/aws-load-balancer-operator-1#nw-multiple-ingress-through-single-alb#nw-adding-tls-termination_adding-tls-termination[Adding TLS termination]
 * link:https://docs.openshift.com/container-platform/4.13/networking/aws_load_balancer_operator/create-instance-aws-load-balancer-controller.html[Creating an instance of AWS Load Balancer Controller]
 endif::openshift-rosa-hcp[]

--- a/networking/ovn_kubernetes_network_provider/configuring-cluster-wide-proxy.adoc
+++ b/networking/ovn_kubernetes_network_provider/configuring-cluster-wide-proxy.adoc
@@ -7,6 +7,7 @@ include::_attributes/attributes-openshift-dedicated.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 If you are using an existing Virtual Private Cloud (VPC), you can configure a cluster-wide proxy during
 ifdef::openshift-rosa,openshift-rosa-hcp[]
 a {product-title}
@@ -18,7 +19,7 @@ cluster installation or after the cluster is installed. When you enable a proxy,
 
 [NOTE]
 ====
-Only cluster system egress traffic is proxied, including calls to the cloud provider API.
+The system proxies only cluster system egress traffic, including calls to the cloud provider API.
 ====
 
 ifdef::openshift-dedicated[]
@@ -48,15 +49,7 @@ endif::openshift-dedicated[]
 
 include::modules/configuring-a-proxy-trust-bundle-responsibilities.adoc[leveloffset=+1]
 
-[id="configuring-a-proxy-during-installation_{context}"]
-== Configuring a proxy during installation
-
-ifdef::openshift-dedicated[]
-You can configure an HTTP or HTTPS proxy when you install an {product-title} with Customer Cloud Subscription (CCS) cluster into an existing Virtual Private Cloud (VPC). You can configure the proxy during installation by using {cluster-manager-first}.
-endif::openshift-dedicated[]
-ifdef::openshift-rosa,openshift-rosa-hcp[]
-You can configure an HTTP or HTTPS proxy when you install a {product-title} cluster into an existing Virtual Private Cloud (VPC). You can configure the proxy during installation by using {cluster-manager-first} or the ROSA CLI (`rosa`).
-endif::openshift-rosa,openshift-rosa-hcp[]
+include::modules/configuring-proxy-during-install-intro.adoc[leveloffset=+1]
 
 ifdef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 include::modules/configuring-a-proxy-during-installation-ocm.adoc[leveloffset=+2]
@@ -85,29 +78,22 @@ ifdef::openshift-dedicated[]
 endif::openshift-dedicated[]
 endif::openshift-rosa,openshift-dedicated[]
 
-[id="configuring-a-proxy-after-installation_{context}"]
-== Configuring a proxy after installation
+include::modules/configuring-proxy-after-install-intro.adoc[leveloffset=+1]
 
 ifdef::openshift-dedicated[]
-You can configure an HTTP or HTTPS proxy after you install an {product-title} with Customer Cloud Subscription (CCS) cluster into an existing Virtual Private Cloud (VPC). You can configure the proxy after installation by using {cluster-manager-first}.
-
-include::modules/configuring-a-proxy-after-installation-ocm.adoc[leveloffset=+1]
+include::modules/configuring-a-proxy-after-installation-ocm.adoc[leveloffset=+2]
 
 endif::openshift-dedicated[]
 
 ifdef::openshift-rosa,openshift-rosa-hcp[]
-You can configure an HTTP or HTTPS proxy after you install a {product-title} cluster into an existing Virtual Private Cloud (VPC). You can configure the proxy after installation by using {cluster-manager-first} or the ROSA CLI (`rosa`).
 
 include::modules/configuring-a-proxy-after-installation-ocm.adoc[leveloffset=+2]
 
 include::modules/configuring-a-proxy-after-installation-cli.adoc[leveloffset=+2]
 
-[id="removing-cluster-wide-proxy_{context}"]
-== Removing a cluster-wide proxy
+include::modules/removing-cluster-wide-proxy-intro.adoc[leveloffset=+2]
 
-You can remove your cluster-wide proxy by using the ROSA CLI. After removing the cluster, you should also remove any trust bundles that are added to the cluster.
-
-include::modules/nw-rosa-proxy-remove-cli.adoc[leveloffset=+2]
+include::modules/nw-rosa-proxy-remove-cli.adoc[leveloffset=+3]
 
 include::modules/configmap-removing-ca.adoc[leveloffset=+2]
 

--- a/networking/ovn_kubernetes_network_provider/migrate-from-openshift-sdn-osd.adoc
+++ b/networking/ovn_kubernetes_network_provider/migrate-from-openshift-sdn-osd.adoc
@@ -7,18 +7,21 @@ include::_attributes/attributes-openshift-dedicated.adoc[]
 
 toc::[]
 
-As an {product-title} cluster administrator, you can initiate the migration from the OpenShift SDN network plugin to the OVN-Kubernetes network plugin and verify the migration status using the OCM CLI.
+[role="_abstract"]
+As an {product-title} cluster administrator, you can start the migration from the OpenShift Software-Defined Networking (SDN) network plugin to the OVN-Kubernetes network plugin and verify the migration status by using the {cluster-manager} CLI (`ocm`).
 
-Some considerations before starting migration initiation are:
+Consider the following before starting migration:
 
 * The cluster version must be 4.16.43 and above.
-* The migration process cannot be interrupted.
+* You cannot interrupt the migration process.
 * Migrating back to the SDN network plugin is not possible.
-* Cluster nodes will be rebooted during migration.
+* The migration process reboots cluster nodes.
 * There will be no impact to workloads that are resilient to node disruptions.
 * Migration time can vary between several minutes and hours, depending on the cluster size and workload configurations.
 
 include::modules/migrate-sdn-ovn-osd.adoc[leveloffset=+1]
 
-.Additional resources
+[role="_additional-resources"]
+[id="additional-resources_{context}"]
+== Additional resources
 * link:https://docs.openshift.com/container-platform/4.16/networking/ovn_kubernetes_network_provider/migrate-from-openshift-sdn.html#patching-ovnk-address-ranges_migrate-from-openshift-sdn[Patching OVN-Kubernetes address ranges]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.21+

Issue:
https://redhat.atlassian.net/browse/OSDOCS-16607

Link to docs preview:

- https://110996--ocpdocs-pr.netlify.app/openshift-dedicated/latest/networking/networking_operators/ingress-operator.html
- https://110996--ocpdocs-pr.netlify.app/openshift-dedicated/latest/networking/networking_overview/about-managed-networking.html
- https://110996--ocpdocs-pr.netlify.app/openshift-dedicated/latest/networking/network_security/network_policy/creating-network-policy.html
- https://110996--ocpdocs-pr.netlify.app/openshift-dedicated/latest/networking/network_security/network_policy/deleting-network-policy.html
- https://110996--ocpdocs-pr.netlify.app/openshift-dedicated/latest/networking/network_security/network_policy/viewing-network-policy.html
- https://110996--ocpdocs-pr.netlify.app/openshift-dedicated/latest/networking/network_security/network-verification.html
- https://110996--ocpdocs-pr.netlify.app/openshift-dedicated/latest/networking/ovn_kubernetes_network_provider/configuring-cluster-wide-proxy.html
- https://110996--ocpdocs-pr.netlify.app/openshift-dedicated/latest/networking/ovn_kubernetes_network_provider/migrate-from-openshift-sdn-osd.html
- https://110996--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/networking_operators/ingress-operator.html
- https://110996--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/network_security/network_policy/creating-network-policy.html
- https://110996--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/network_security/network_policy/deleting-network-policy.html
- https://110996--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/network_security/network_policy/viewing-network-policy.html
- https://110996--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/networking/networking_operators/aws-load-balancer-operator.html
- https://110996--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/networking/networking_operators/ingress-operator.html
- https://110996--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/networking/networking_overview/about-managed-networking.html
- https://110996--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/networking/network_security/network_policy/creating-network-policy.html
- https://110996--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/networking/network_security/network_policy/deleting-network-policy.html
- https://110996--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/networking/network_security/network_policy/viewing-network-policy.html
- https://110996--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/networking/network_security/network-verification.html
- https://110996--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/networking/ovn_kubernetes_network_provider/configuring-cluster-wide-proxy.html
- https://110996--ocpdocs-pr.netlify.app/openshift-rosa/latest/networking/networking_operators/aws-load-balancer-operator.html
- https://110996--ocpdocs-pr.netlify.app/openshift-rosa/latest/networking/networking_operators/ingress-operator.html
- https://110996--ocpdocs-pr.netlify.app/openshift-rosa/latest/networking/networking_overview/about-managed-networking.html
- https://110996--ocpdocs-pr.netlify.app/openshift-rosa/latest/networking/network_security/network_policy/creating-network-policy.html
- https://110996--ocpdocs-pr.netlify.app/openshift-rosa/latest/networking/network_security/network_policy/deleting-network-policy.html
- https://110996--ocpdocs-pr.netlify.app/openshift-rosa/latest/networking/network_security/network_policy/viewing-network-policy.html
- https://110996--ocpdocs-pr.netlify.app/openshift-rosa/latest/networking/network_security/network-verification.html
- https://110996--ocpdocs-pr.netlify.app/openshift-rosa/latest/networking/ovn_kubernetes_network_provider/configuring-cluster-wide-proxy.html
- https://110996--ocpdocs-pr.netlify.app/openshift-rosa/latest/networking/ovn_kubernetes_network_provider/migrate-from-openshift-sdn.html

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
