### PR TITLE
TELCODOCS-2685: DITA rewrite for ibi-understanding-image-based-install

### DIFF
--- a/edge_computing/image_base_install/ibi-understanding-image-based-install.adoc
+++ b/edge_computing/image_base_install/ibi-understanding-image-based-install.adoc
@@ -6,13 +6,14 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 Image-based installations significantly reduce the deployment time of {sno} clusters by streamlining the installation process.
 
 This approach enables the preinstallation of configured and validated instances of {sno} on target hosts. These preinstalled hosts can be rapidly reconfigured and deployed at the far edge of the network, including in disconnected environments, with minimal intervention.
 
 [NOTE]
 ====
-To deploy a managed cluster using an imaged-based approach in combination with {ztp-first}, you can use the SiteConfig operator. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.12/html-single/multicluster_engine_operator_with_red_hat_advanced_cluster_management/index#siteconfig-intro[SiteConfig operator].
+To deploy a managed cluster using an imaged-based approach in combination with {ztp-first}, you can use the SiteConfig operator.
 ====
 
 [id="ibi-installation-deployment-overview_{context}"]
@@ -39,75 +40,13 @@ Using the `openshift-install` program::
 For a {sno} cluster, use the `openshift-install` program only to manually create the live installation ISO that is common to all hosts. Then, use the program again to create the configuration ISO which ensures that the host is unique. For more information, see “Deploying managed {sno} using the openshift-install program”.
 
 Using the IBI Operator::
-For managed {sno} clusters, you can use the `openshift-install` with the Image Based Install (IBI) Operator to scale up the operations. The program creates the live installation ISO and then the IBI Operator creates one configuration ISO for each host. For more information, see “Deploying {sno} using the IBI Operator”.
+For managed {sno} clusters, you can use the `openshift-install` with the Image Based Install (IBI) Operator to scale up the operations. The program creates the live installation ISO and then the IBI Operator creates one configuration ISO for each host. For more information, see "Deploying {sno} using the IBI Operator".
 
-[id="ibi-installation-overview_{context}"]
-=== Image-based installation for {sno} clusters
+include::modules/ibi-image-based-installation-overview.adoc[leveloffset=+2]
 
-Using the {lcao}, you can generate an OCI container image that encapsulates an instance of a {sno} cluster. This image is derived from a dedicated cluster that you can configure with the target {product-title} version.  
+include::modules/ibi-image-based-deployment-overview.adoc[leveloffset=+2]
 
-You can reference this image in a live installation ISO to consistently preinstall configured and validated instances of {sno} to multiple hosts. This approach enables the preparation of hosts at a central location, for example in a factory or service depot, before shipping the preinstalled hosts to a remote site for rapid reconfiguration and deployment. The instructions for preinstalling a host are the same whether you deploy the host by using only the `openshift-install` program or using the program with the IBI Operator.
-
-The following is a high-level overview of the image-based installation process:
-
-. Generate an image from a {sno} cluster.
-. Use the `openshift-install` program to embed the seed image URL, and other installation artifacts, in a live installation ISO.
-. Start the host using the live installation ISO to preinstall the host. 
-+
-During this process, the `openshift-install` program installs {op-system-first} to the disk, pulls the image you generated, and precaches release container images to the disk.
-
-. When the installation completes, the host is ready to ship to the remote site for rapid reconfiguration and deployment.
-
-[id="ibi-deployment-overview_{context}"]
-=== Image-based deployment for {sno} clusters
-
-You can use the `openshift-install` program or the IBI Operator to configure and deploy a host that you preinstalled with an image-based installation.
-
-{sno-caps} cluster deployment::
-
-To configure the target host with site-specific details by using the `openshift-install` program, you must create the following resources:
-+
---
-* The `install-config.yaml` installation manifest
-
-* The `image-based-config.yaml` manifest
---
-+
-The `openshift-install` program uses these resources to generate a configuration ISO that you attach to the preinstalled target host to complete the deployment.
-
-Managed {sno} cluster deployment::
-
-{rh-rhacm-first} and the {mce} (MCE) use a hub-and-spoke architecture to manage and deploy {sno} clusters across multiple sites. Using this approach, the hub cluster serves as a central control plane that manages the spoke clusters, which are often remote {sno} clusters deployed at the far edge of the network.
-+
-You can define the site-specific configuration resources for an image-based deployment in the hub cluster. The IBI Operator uses these configuration resources to reconfigure the preinstalled host at the remote site and deploy the host as a managed {sno} cluster. This approach is especially beneficial for telecommunications providers and other service providers with extensive, distributed infrastructures, where an end-to-end installation at the remote site would be time-consuming and costly.
-+
-The following is a high-level overview of the image-based deployment process for hosts preinstalled with an imaged-based installation:
-+
---
-* Define the site-specific configuration resources for the preinstalled host in the hub cluster.
-* Apply these resources in the hub cluster. This initiates the deployment process.
-* The IBI Operator creates a configuration ISO.
-* The IBI Operator boots the target preinstalled host with the configuration ISO attached.
-* The host mounts the configuration ISO and begins the reconfiguration process.
-* When the reconfiguration completes, the {sno} cluster is ready.
---
-+
-As the host is already preinstalled using an image-based installation, a technician can reconfigure and deploy the host in a matter of minutes.
-
-[id="ibi-installation-deployment-components_{context}"]
-== Image-based installation and deployment components
-
-The following content describes the components in an image-based installation and deployment.
-
-Seed image:: OCI container image generated from a dedicated cluster with the target {product-title} version.
-
-Seed cluster:: Dedicated {sno} cluster that you use to create a seed image and is deployed with the target {product-title} version.
-
-{lcao}:: Generates the seed image.
-
-Image Based Install (IBI) Operator:: When you deploy managed clusters, the IBI Operator creates a configuration ISO from the site-specific resources you define in the hub cluster, and attaches the configuration ISO to the preinstalled host by using a bare-metal provisioning service.
-
-`openshift-install` program:: Creates the installation and configuration ISO, and embeds the seed image URL in the live installation ISO. If the IBI Operator is not used, you must manually attach the configuration ISO to a preinstalled host to complete the deployment.
+include::modules/ibi-installation-deployment-components.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources
@@ -129,3 +68,5 @@ include::modules/ibi-validated-software-versions.adoc[leveloffset=+1]
 * link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.12/html/about/welcome-to-red-hat-advanced-cluster-management-for-kubernetes#multicluster-architecture[Multicluster architecture]
 
 * xref:../../edge_computing/image_based_upgrade/cnf-understanding-image-based-upgrade.adoc#cnf-understanding-image-based-upgrade[Understanding the image-based upgrade for {sno} clusters]
+
+* link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.12/html-single/multicluster_engine_operator_with_red_hat_advanced_cluster_management/index#siteconfig-intro[SiteConfig operator]

--- a/modules/ibi-image-based-deployment-overview.adoc
+++ b/modules/ibi-image-based-deployment-overview.adoc
@@ -1,0 +1,40 @@
+// Module included in the following assemblies:
+// * edge_computing/image_base_install/ibi-understanding-image-based-install.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="ibi-image-based-deployment-overview_{context}"]
+= Image-based deployment for {sno} clusters
+
+[role="_abstract"]
+You can use the `openshift-install` program or the IBI Operator to configure and deploy a host that you preinstalled with an image-based installation.
+
+{sno-caps} cluster deployment::
+
+To configure the target host with site-specific details by using the `openshift-install` program, you must create the following resources:
++
+--
+* The `install-config.yaml` installation manifest
+
+* The `image-based-config.yaml` manifest
+--
++
+The `openshift-install` program uses these resources to generate a configuration ISO that you attach to the preinstalled target host to complete the deployment.
+
+Managed {sno} cluster deployment::
+
+{rh-rhacm-first} and the {mce} (MCE) use a hub-and-spoke architecture to manage and deploy {sno} clusters across multiple sites. Using this approach, the hub cluster serves as a central control plane that manages the spoke clusters, which are often remote {sno} clusters deployed at the far edge of the network.
++
+You can define the site-specific configuration resources for an image-based deployment in the hub cluster. The IBI Operator uses these configuration resources to reconfigure the preinstalled host at the remote site and deploy the host as a managed {sno} cluster. This approach is especially beneficial for telecommunications providers and other service providers with extensive, distributed infrastructures, where an end-to-end installation at the remote site would be time-consuming and costly.
++
+The following is a high-level overview of the image-based deployment process for hosts preinstalled with an imaged-based installation:
++
+--
+* Define the site-specific configuration resources for the preinstalled host in the hub cluster.
+* Apply these resources in the hub cluster. This initiates the deployment process.
+* The IBI Operator creates a configuration ISO.
+* The IBI Operator boots the target preinstalled host with the configuration ISO attached.
+* The host mounts the configuration ISO and begins the reconfiguration process.
+* When the reconfiguration completes, the {sno} cluster is ready.
+--
++
+As the host is already preinstalled using an image-based installation, a technician can reconfigure and deploy the host in a matter of minutes.

--- a/modules/ibi-image-based-install-cluster-guide.adoc
+++ b/modules/ibi-image-based-install-cluster-guide.adoc
@@ -5,6 +5,7 @@
 [id="ibi-image-based-install-cluster-guide_{context}"]
 = Cluster guidelines for image-based installation and deployment
 
+[role="_abstract"]
 For a successful image-based installation and deployment, see the following guidelines.
 
 [id="ibi-cluster-guidelines_{context}"]

--- a/modules/ibi-image-based-installation-overview.adoc
+++ b/modules/ibi-image-based-installation-overview.adoc
@@ -1,0 +1,23 @@
+// Module included in the following assemblies:
+// * edge_computing/image_base_install/ibi-understanding-image-based-install.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="ibi-image-based-installation-overview_{context}"]
+= Image-based installation for {sno} clusters
+
+[role="_abstract"]
+Using the {lcao}, you can generate an OCI container image that encapsulates an instance of a {sno} cluster.
+
+This image is derived from a dedicated cluster that you can configure with the target {product-title} version.
+
+You can reference this image in a live installation ISO to consistently preinstall configured and validated instances of {sno} to multiple hosts. This approach enables the preparation of hosts at a central location, for example in a factory or service depot, before shipping the preinstalled hosts to a remote site for rapid reconfiguration and deployment. The instructions for preinstalling a host are the same whether you deploy the host by using only the `openshift-install` program or using the program with the IBI Operator.
+
+The following is a high-level overview of the image-based installation process:
+
+. Generate an image from a {sno} cluster.
+. Use the `openshift-install` program to embed the seed image URL, and other installation artifacts, in a live installation ISO.
+. Start the host using the live installation ISO to preinstall the host.
++
+During this process, the `openshift-install` program installs {op-system-first} to the disk, pulls the image you generated, and precaches release container images to the disk.
+
+. When the installation completes, the host is ready to ship to the remote site for rapid reconfiguration and deployment.

--- a/modules/ibi-installation-deployment-components.adoc
+++ b/modules/ibi-installation-deployment-components.adoc
@@ -1,0 +1,19 @@
+// Module included in the following assemblies:
+// * edge_computing/image_base_install/ibi-understanding-image-based-install.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="ibi-installation-deployment-components_{context}"]
+= Image-based installation and deployment components
+
+[role="_abstract"]
+The following content describes the components in an image-based installation and deployment.
+
+Seed image:: OCI container image generated from a dedicated cluster with the target {product-title} version.
+
+Seed cluster:: Dedicated {sno} cluster that you use to create a seed image and is deployed with the target {product-title} version.
+
+{lcao}:: Generates the seed image.
+
+Image Based Install (IBI) Operator:: When you deploy managed clusters, the IBI Operator creates a configuration ISO from the site-specific resources you define in the hub cluster, and attaches the configuration ISO to the preinstalled host by using a bare-metal provisioning service.
+
+`openshift-install` program:: Creates the installation and configuration ISO, and embeds the seed image URL in the live installation ISO. If the IBI Operator is not used, you must manually attach the configuration ISO to a preinstalled host to complete the deployment.

--- a/modules/ibi-validated-software-versions.adoc
+++ b/modules/ibi-validated-software-versions.adoc
@@ -5,6 +5,7 @@
 [id="ztp-image-based-upgrade-prereqs_{context}"]
 = Software prerequisites for an image-based installation and deployment
 
+[role="_abstract"]
 An image-based installation and deployment requires the following minimum software versions for these required components.
 
 .Minimum software requirements


### PR DESCRIPTION
## Summary

Consolidates the DITA rewrite from PR #106504 with additional pre-existing DITA compliance fixes for the assembly file.

### Changes from original PR #106504
- Restructured ibi-understanding-image-based-install.adoc assembly into modular components
- Created new concept modules: ibi-image-based-installation-overview.adoc, ibi-image-based-deployment-overview.adoc
- Created new reference module: ibi-installation-deployment-components.adoc
- Updated ibi-image-based-install-cluster-guide.adoc and ibi-validated-software-versions.adoc

### Additional DITA compliance fixes (pre-existing)
- Added [role="_abstract"] to assembly for DITA shortdesc mapping
- Moved inline link from NOTE body to Additional resources section (DITA related-links compliance)

All files pass the full 14-check DITA validation suite.

## Test plan
- [x] Verify all .adoc files build without errors
- [ ] Verify Additional resources links resolve correctly
- [ ] Confirm no regressions in rendered output