### PR TITLE
TELCODOCS-2687: DITA rewrite for ibi-edge-image-based-install-standalone

### DIFF
--- a/modules/ibi-create-standalone-config-iso.adoc
+++ b/modules/ibi-create-standalone-config-iso.adoc
@@ -6,6 +6,7 @@
 [id="create-standalone-config-iso_{context}"]
 = Deploying a {sno} cluster using the openshift-install program
 
+[role="_abstract"]
 You can use the `openshift-install` program to configure and deploy a host that you preinstalled with an image-based installation. To configure the target host with site-specific details, you must create the following resources:
 
 * The `install-config.yaml` installation manifest
@@ -30,16 +31,16 @@ For more information about the specifications for the `image-based-config.yaml` 
 +
 [source,terminal]
 ----
-$ mkdir ibi-config-iso-workdir <1>
+$ mkdir <working_directory>
 ----
-<1> Replace `ibi-config-iso-workdir` with the name of your working directory.
++
+where `<working_directory>` is the name of your working directory, for example `ibi-config-iso-workdir`.
 
 . Create the installation manifest:
 
-.. Create a YAML file that defines the `install-config` manifest:
+.. Create a YAML file that defines the `install-config` manifest, as in the following example:
 +
 --
-.Example `install-config.yaml` file
 [source,yaml]
 ----
 apiVersion: v1
@@ -57,7 +58,7 @@ controlPlane:
   name: master
   replicas: 1
 networking:
-  machineNetwork: <1>
+  machineNetwork:
   - cidr: 192.168.200.0/24
   #- cidr: fd01::/64
 platform:
@@ -67,7 +68,8 @@ cpuPartitioningMode: "AllNodes"
 pullSecret: '{"auths":{"<your_pull_secret>"}}}'
 sshKey: 'ssh-rsa <your_ssh_pub_key>'
 ----
-<1> For dual-stack networking, you can specify both IPv4 and IPv6 CIDRs using a list format. The first CIDR in the list is the primary address family and must match the primary address family of the seed cluster.
++
+For dual-stack networking, you can specify both IPv4 and IPv6 CIDRs using a list format in the `machineNetwork` field. The first CIDR in the list is the primary address family and must match the primary address family of the seed cluster.
 
 [IMPORTANT]
 ====
@@ -87,7 +89,8 @@ If your cluster deployment requires a proxy configuration, you must do the follo
 $ openshift-install image-based create config-template --dir ibi-config-iso-workdir/
 ----
 +
-.Example output
+Example output:
++
 [source,terminal]
 ----
 INFO Config-Template created in: ibi-config-iso-workdir
@@ -129,7 +132,8 @@ networkConfig:
 
 . Edit your configuration file:
 +
-.Example `image-based-config.yaml` file
+Example `image-based-config.yaml` file:
++
 [source,yaml]
 ----
 #
@@ -182,7 +186,8 @@ networkConfig:
 $ openshift-install image-based create config-image --dir ibi-config-iso-workdir/
 ----
 +
-.Example output
+Example output:
++
 [source,terminal]
 ----
 INFO Adding NMConnection file <ens1f0.nmconnection> 
@@ -193,7 +198,8 @@ INFO Config-Image created in: ibi-config-iso-workdir/auth
 +
 View the output in the working directory:
 +
-.Example output
+Example output:
++
 [source,terminal]
 ----
 ibi-config-iso-workdir/
@@ -222,7 +228,8 @@ $ export KUBECONFIG=ibi-config-iso-workdir/auth/kubeconfig
 $ oc get nodes
 ----
 +
-.Example output
+Example output:
++
 [source,terminal]
 ----
 NAME                                         STATUS   ROLES                  AGE     VERSION

--- a/modules/ibi-extra-manifests-standalone.adoc
+++ b/modules/ibi-extra-manifests-standalone.adoc
@@ -6,20 +6,17 @@
 [id="ibi-extra-manifest-standalone_{context}"]
 = Configuring resources for extra manifests
 
+[role="_abstract"]
 You can optionally define additional resources in an image-based deployment for {sno} clusters.
 
 Create the additional resources in an `extra-manifests` folder in the same working directory that has the `install-config.yaml` and `image-based-config.yaml` manifests.
 
 [NOTE]
 ====
-Filenames for additional resources in the `extra-manifests` directory must not exceed 30 characters. Longer filenames might cause deployment failures. 
+Filenames for additional resources in the `extra-manifests` directory must not exceed 30 characters. Longer filenames might cause deployment failures.
 ====
 
-== Creating a resource in the extra-manifests folder
-
-You can create a resource in the `extra-manifests` folder of your working directory to add extra manifests to the image-based deployment for {sno} clusters.
-
-The following example adds an single-root I/O virtualization (SR-IOV) network to the deployment.
+The following example shows how to create a resource in the `extra-manifests` folder of your working directory to add an single-root I/O virtualization (SR-IOV) network to the deployment.
 
 [NOTE]
 ====

--- a/modules/ibi-installer-configuration-config.adoc
+++ b/modules/ibi-installer-configuration-config.adoc
@@ -6,6 +6,7 @@
 [id="ibi-installer-configuration-config_{context}"]
 = Reference specifications for the image-based-config.yaml manifest
 
+[role="_abstract"]
 The following content describes the specifications for the `image-based-config.yaml` manifest. 
 
 The `openshift-install` program uses the `image-based-config.yaml` manifest to create a site-specific configuration ISO for image-based deployments of {sno}. 


### PR DESCRIPTION
## Summary

Consolidates the DITA rewrite from PR #106508 with additional DITA compliance fixes.

### Changes from original PR #106508
- Added [role="_abstract"] to ibi-create-standalone-config-iso.adoc, ibi-extra-manifests-standalone.adoc, ibi-installer-configuration-config.adoc
- Removed callout explanation from ibi-extra-manifests-standalone.adoc

### Additional DITA compliance fixes (pre-existing)
- Converted 5 block titles before source blocks to inline text in ibi-create-standalone-config-iso.adoc (.Example output, .Example image-based-config.yaml file)

All files pass the full 14-check DITA validation suite.

## Test plan
- [x] Verify all .adoc files build without errors
- [ ] Confirm no regressions in rendered output