### PR TITLE
OADP-6673: Add parallel backup

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -3724,6 +3724,10 @@ Topics:
       File: backing-up-applications
     - Name: Creating a Backup CR
       File: oadp-creating-backup-cr
+    - Name: Parallel backup processing in OADP
+      File: oadp-parallel-backup-processing-in-oadp
+    - Name: Enabling parallel backup processing
+      File: oadp-enabling-parallel-backup-processing
     - Name: Backing up persistent volumes with CSI snapshots
       File: oadp-backing-up-pvs-csi-doc
     - Name: Backing up applications with File System Backup

--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -3773,6 +3773,10 @@ Topics:
       File: backing-up-applications
     - Name: Creating a Backup CR
       File: oadp-creating-backup-cr
+    - Name: Parallel backup processing in OADP
+      File: oadp-parallel-backup-processing-in-oadp
+    - Name: Enabling parallel backup processing
+      File: oadp-enabling-parallel-backup-processing
     - Name: Backing up persistent volumes with CSI snapshots
       File: oadp-backing-up-pvs-csi-doc
     - Name: Backing up applications with File System Backup

--- a/_topic_maps/_topic_map_rosa.yml
+++ b/_topic_maps/_topic_map_rosa.yml
@@ -1156,6 +1156,10 @@ Topics:
       File: backing-up-applications
     - Name: Creating a Backup CR
       File: oadp-creating-backup-cr
+    - Name: Parallel backup processing in OADP
+      File: oadp-parallel-backup-processing-in-oadp
+    - Name: Enabling parallel backup processing
+      File: oadp-enabling-parallel-backup-processing
 # ROSA docs do not include CSI snapshots
 #    - Name: Backing up persistent volumes with CSI snapshots
 #      File: oadp-backing-up-pvs-csi-doc

--- a/_topic_maps/_topic_map_rosa_hcp.yml
+++ b/_topic_maps/_topic_map_rosa_hcp.yml
@@ -939,6 +939,10 @@ Topics:
       File: backing-up-applications
     - Name: Creating a Backup CR
       File: oadp-creating-backup-cr
+    - Name: Parallel backup processing in OADP
+      File: oadp-parallel-backup-processing-in-oadp
+    - Name: Enabling parallel backup processing
+      File: oadp-enabling-parallel-backup-processing
 # ROSA docs do not include CSI snapshots
 #    - Name: Backing up persistent volumes with CSI snapshots
 #      File: oadp-backing-up-pvs-csi-doc

--- a/backup_and_restore/application_backup_and_restore/backing_up_and_restoring/oadp-enabling-parallel-backup-processing.adoc
+++ b/backup_and_restore/application_backup_and_restore/backing_up_and_restoring/oadp-enabling-parallel-backup-processing.adoc
@@ -1,0 +1,59 @@
+// Module included in the following assemblies:
+//
+// * backup_and_restore/application_backup_and_restore/backing_up_and_restoring/backing-up-applications.adoc
+include::_attributes/common-attributes.adoc[]
+
+:_mod-docs-content-type: PROCEDURE
+[id="oadp-enabling-parallel-backup-processing_{context}"]
+= Enabling parallel backup processing
+
+[role="_abstract"]
+By default, {oadp-full} processes only one backup in the `InProgress` phase at a time. Configure the `DataProtectionApplication` (DPA) custom resource (CR) to run several backups simultaneously to prevent smaller backups from being queued behind larger operations.
+
+
+.Prerequisites
+* You must be logged in as a user with `cluster-admin` privileges.
+* You must have a DPA CR configured and deployed in your cluster.
+
+
+.Procedure
+
+. Edit your DPA CR:
++
+[source,terminal,subs="+quotes"]
+----
+$ oc edit dpa <dpa_name> -n openshift-adp
+----
+
+. Add the `concurrentBackups` field in the `spec.configuration.velero` section of your DPA CR:
++
+[source,yaml]
+----
+  configuration:
+    velero:
+      concurrentBackups: <integer_limit>
+      defaultPlugins:
+        - openshift
+        - aws
+        - csi
+----
++
+Replace `<integer_limit>` with the maximum number of backups you want {oadp-short} to process simultaneously. The default value is `1`. Backups that target overlapping namespaces are automatically serialized.
+
+
+.Verification
+
+* Verify that all backups are in the `InProgress` phase simultaneously:
++
+[source,terminal]
+----
+$ oc get backups.velero.io -n openshift-adp
+----
++
+.Example output
+[source,terminal]
+----
+NAME                STATUS       CREATED                        EXPIRES
+backup-namespace1   InProgress   2026-04-28 10:00:00 +0000 UTC  29d
+backup-namespace2   InProgress   2026-04-28 10:00:05 +0000 UTC  29d
+----

--- a/backup_and_restore/application_backup_and_restore/backing_up_and_restoring/oadp-enabling-parallel-backup-processing.adoc
+++ b/backup_and_restore/application_backup_and_restore/backing_up_and_restoring/oadp-enabling-parallel-backup-processing.adoc
@@ -1,18 +1,31 @@
 // Module included in the following assemblies:
 //
 // * backup_and_restore/application_backup_and_restore/backing_up_and_restoring/backing-up-applications.adoc
+include::_attributes/common-attributes.adoc[]
 
 :_mod-docs-content-type: PROCEDURE
-include::_attributes/common-attributes.adoc[]
 [id="oadp-enabling-parallel-backup-processing_{context}"]
 = Enabling parallel backup processing
 
 [role="_abstract"]
 By default, {oadp-full} processes only one backup in the `InProgress` phase at a time. Configure the `DataProtectionApplication` (DPA) custom resource (CR) to run several backups simultaneously to prevent smaller backups from being queued behind larger operations.
 
+
+.Prerequisites
+* You must be logged in as a user with `cluster-admin` privileges.
+* You must have a DPA CR configured and deployed in your cluster.
+
+
 .Procedure
 
-* Add the `concurrentBackups` field in the `spec.configuration.velero` section of your DPA CP:
+. Edit your DPA CR:
++
+[source,terminal,subs="+quotes"]
+----
+$ oc edit dpa <dpa_name> -n openshift-adp
+----
+
+. Add the `concurrentBackups` field in the `spec.configuration.velero` section of your DPA CP:
 +
 [source,yaml]
 ----
@@ -27,7 +40,6 @@ By default, {oadp-full} processes only one backup in the `InProgress` phase at a
 +
 Replace `<integer_limit>` with the maximum number of backups you want {oadp-short} to process simultaneously. The default value is `1`. Backups that target overlapping namespaces are automatically serialized.
 
-//TODO: Is this procedure complete?
 
 .Verification
 
@@ -41,7 +53,7 @@ $ oc get backups.velero.io -n openshift-adp
 .Example output
 [source,terminal]
 ----
-NAME         STATUS       CREATED                        EXPIRES
-backup-ns1   InProgress   2026-04-28 10:00:00 +0000 UTC  29d
-backup-ns2   InProgress   2026-04-28 10:00:05 +0000 UTC  29d
+NAME                STATUS       CREATED                        EXPIRES
+backup-namespace1   InProgress   2026-04-28 10:00:00 +0000 UTC  29d
+backup-namespace2   InProgress   2026-04-28 10:00:05 +0000 UTC  29d
 ----

--- a/backup_and_restore/application_backup_and_restore/backing_up_and_restoring/oadp-enabling-parallel-backup-processing.adoc
+++ b/backup_and_restore/application_backup_and_restore/backing_up_and_restoring/oadp-enabling-parallel-backup-processing.adoc
@@ -1,0 +1,47 @@
+// Module included in the following assemblies:
+//
+// * backup_and_restore/application_backup_and_restore/backing_up_and_restoring/backing-up-applications.adoc
+
+:_mod-docs-content-type: PROCEDURE
+include::_attributes/common-attributes.adoc[]
+[id="oadp-enabling-parallel-backup-processing_{context}"]
+= Enabling parallel backup processing
+
+[role="_abstract"]
+By default, {oadp-full} processes only one backup in the `InProgress` phase at a time. Configure the `DataProtectionApplication` (DPA) custom resource (CR) to run several backups simultaneously to prevent smaller backups from being queued behind larger operations.
+
+.Procedure
+
+* Add the `concurrentBackups` field in the `spec.configuration.velero` section of your DPA CP:
++
+[source,yaml]
+----
+  configuration:
+    velero:
+      concurrentBackups: <integer_limit>
+      defaultPlugins:
+        - openshift
+        - aws
+        - csi
+----
++
+Replace `<integer_limit>` with the maximum number of backups you want {oadp-short} to process simultaneously. The default value is `1`. Backups that target overlapping namespaces are automatically serialized.
+
+//TODO: Is this procedure complete?
+
+.Verification
+
+* Verify that all backups are in the `InProgress` phase simultaneously:
++
+[source,terminal]
+----
+$ oc get backups.velero.io -n openshift-adp
+----
++
+.Example output
+[source,terminal]
+----
+NAME         STATUS       CREATED                        EXPIRES
+backup-ns1   InProgress   2026-04-28 10:00:00 +0000 UTC  29d
+backup-ns2   InProgress   2026-04-28 10:00:05 +0000 UTC  29d
+----

--- a/backup_and_restore/application_backup_and_restore/backing_up_and_restoring/oadp-parallel-backup-processing-in-oadp.adoc
+++ b/backup_and_restore/application_backup_and_restore/backing_up_and_restoring/oadp-parallel-backup-processing-in-oadp.adoc
@@ -1,0 +1,30 @@
+// Module included in the following assemblies:
+//
+// * backup_and_restore/application_backup_and_restore/backing_up_and_restoring/backing-up-applications.adoc
+include::_attributes/common-attributes.adoc[]
+
+:_mod-docs-content-type: CONCEPT
+[id="oadp-parallel-backup-processing-in-oadp_{context}"]
+= Parallel backup processing in {oadp-short}
+
+[role="_abstract"]
+With parallel backup processing in {oadp-full}, you can back up several applications from different namespaces simultaneously. This concurrent processing ensures that a single large backup task does not delay the backups for other applications in your cluster.
+
+By default, Velero processes backup resources sequentially - one resource in the `InProgress` phase at a time. Parallel backup changes this behavior to handle backups concurrently. 
+
+The following considerations apply for enabling parallel backups in {oadp-short}:
+
+* Resource allocation: Increasing the concurrency settings requires additional CPU and memory for the Velero container. Monitor resource consumption to ensure cluster stability.
+
+* Backup scope: Parallel processing provides the most benefit for backups that contain a large number of Kubernetes resources or many smaller volumes. Backups dominated by a few large volumes see less benefit because most time is spent waiting for asynchronous data movement to complete.
+
+* Namespace partitioning: To keep data integrity, {oadp-short} uses namespace-level isolation when processing parallel backups. Two backups cannot run simultaneously if they share any included namespaces.
++
+.Parallel backup execution examples
+[options="header"]
+|====
+|Scenario|Included namespaces|Processing behavior
+|Backup A and Backup B|`namespace1` and `namespace2`|Parallel: The namespaces are isolated.
+|Backup A and Backup B|`namespace1` and `namespace1`|Serialized: The shared namespace creates a lock.
+|Full cluster and Backup A|All namespaces and `namespace1`|Serialized: A cluster-wide backup includes all namespaces and locks the entire cluster.
+|====

--- a/backup_and_restore/application_backup_and_restore/backing_up_and_restoring/oadp-parallel-backup-processing-in-oadp.adoc
+++ b/backup_and_restore/application_backup_and_restore/backing_up_and_restoring/oadp-parallel-backup-processing-in-oadp.adoc
@@ -1,16 +1,14 @@
 // Module included in the following assemblies:
 //
 // * backup_and_restore/application_backup_and_restore/backing_up_and_restoring/backing-up-applications.adoc
+include::_attributes/common-attributes.adoc[]
 
 :_mod-docs-content-type: CONCEPT
-include::_attributes/common-attributes.adoc[]
 [id="oadp-parallel-backup-processing-in-oadp_{context}"]
 = Parallel backup processing in {oadp-short}
 
 [role="_abstract"]
-With parallel backup processing, {oadp-full} can handle several backup requests simultaneously. Reviewing key considerations for resource allocation, backup scope, and namespace isolation helps to ensure your applications are not delayed by large backup tasks.
-
-//TODO: Shortdesc can be better!
+With parallel backup processing in {oadp-full}, you can back up several applications from different namespaces simultaneously. This concurrent processing ensures that a single large backup task does not delay the backups for other applications in your cluster.
 
 By default, Velero processes backup resources sequentially - one resource in the `InProgress` phase at a time. Parallel backup changes this behavior to handle backups concurrently. 
 
@@ -20,7 +18,7 @@ The following considerations apply for enabling parallel backups in OADP:
 
 * Backup scope: Parallel processing provides the most benefit for backups that contain a large number of Kubernetes resources or many smaller volumes. Backups dominated by a few large volumes see less benefit because most time is spent waiting for asynchronous data movement to complete.
 
-* Namespace partitioning: To keep data integrity, {oadp-full} uses namespace-level isolation when processing parallel backups. Two backups cannot run simultaneously if they share any included namespaces.
+* Namespace partitioning: To keep data integrity, {oadp-short} uses namespace-level isolation when processing parallel backups. Two backups cannot run simultaneously if they share any included namespaces.
 +
 .Parallel backup execution examples
 [options="header"]

--- a/backup_and_restore/application_backup_and_restore/backing_up_and_restoring/oadp-parallel-backup-processing-in-oadp.adoc
+++ b/backup_and_restore/application_backup_and_restore/backing_up_and_restoring/oadp-parallel-backup-processing-in-oadp.adoc
@@ -1,0 +1,32 @@
+// Module included in the following assemblies:
+//
+// * backup_and_restore/application_backup_and_restore/backing_up_and_restoring/backing-up-applications.adoc
+
+:_mod-docs-content-type: CONCEPT
+include::_attributes/common-attributes.adoc[]
+[id="oadp-parallel-backup-processing-in-oadp_{context}"]
+= Parallel backup processing in {oadp-short}
+
+[role="_abstract"]
+With parallel backup processing, {oadp-full} can handle several backup requests simultaneously. Reviewing key considerations for resource allocation, backup scope, and namespace isolation helps to ensure your applications are not delayed by large backup tasks.
+
+//TODO: Shortdesc can be better!
+
+By default, Velero processes backup resources sequentially - one resource in the `InProgress` phase at a time. Parallel backup changes this behavior to handle backups concurrently. 
+
+The following considerations apply for enabling parallel backups in OADP:
+
+* Resource allocation: Increasing the concurrency settings requires additional CPU and memory for the Velero container. Monitor resource consumption to ensure cluster stability.
+
+* Backup scope: Parallel processing provides the most benefit for backups that contain a large number of Kubernetes resources or many smaller volumes. Backups dominated by a few large volumes see less benefit because most time is spent waiting for asynchronous data movement to complete.
+
+* Namespace partitioning: To keep data integrity, {oadp-full} uses namespace-level isolation when processing parallel backups. Two backups cannot run simultaneously if they share any included namespaces.
++
+.Parallel backup execution examples
+[options="header"]
+|====
+|Scenario|Included namespaces|Processing behavior
+|Backup A and Backup B|`namespace1` and `namespace2`|Parallel: The namespaces are isolated.
+|Backup A and Backup B|`namespace1` and `namespace1`|Serialized: The shared namespace creates a lock.
+|Full cluster and Backup A|All namespaces and `namespace1`|Serialized: A cluster-wide backup includes all namespaces and locks the entire cluster.
+|====


### PR DESCRIPTION
Summary of changes:
- Add a concept and a procedure on parallel backups.

Version(s):
OCP 4.22+

Issue:
[OADP-6673](https://redhat.atlassian.net/browse/OADP-6673)

Link to docs preview (same content added to OCP, ROSA and ROSA with HCP):
- [Parallel backup processing in OADP](https://111001--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/backing_up_and_restoring/oadp-parallel-backup-processing-in-oadp.html)
- [Enabling parallel backup processing](https://111001--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/backing_up_and_restoring/oadp-enabling-parallel-backup-processing.html)

QE review:
- [x] QE has approved this change.