### PR TITLE
nw-multus-bridge-object: fix field types and improve isDefaultGateway description

### DIFF
--- a/modules/nw-multus-bridge-object.adoc
+++ b/modules/nw-multus-bridge-object.adoc
@@ -53,7 +53,7 @@ endif::microshift[]
 
 |`isDefaultGateway`
 |`boolean`
-|Optional: Set to `true` to configure the bridge as the default gateway for the virtual network. The default value is `false`. If `isDefaultGateway` is set to `true`, then `isGateway` is also set to `true` automatically.
+|Optional: Set to `true` to configure the bridge as the default gateway for the virtual network. The bridge's assigned IP address is used as the default route. The default value is `false`. If `isDefaultGateway` is set to `true`, then `isGateway` is also set to `true` automatically.
 
 |`forceAddress`
 |`boolean`
@@ -69,11 +69,11 @@ endif::microshift[]
 
 ifndef::microshift[]
 |`vlan`
-|`string`
+|`integer`
 |Optional: Specify a virtual LAN (VLAN) tag as an integer value. By default, no VLAN tag is assigned.
 
 |`preserveDefaultVlan`
-|`string`
+|`boolean`
 |Optional: Indicates whether the default VLAN must be preserved on the `veth` end connected to the bridge. Defaults to `false`.
 
 |`vlanTrunk`


### PR DESCRIPTION
## Summary

Fixes discrepancies found when comparing the table against the upstream
[CNI bridge plugin network configuration reference](https://www.cni.dev/plugins/current/main/bridge/#network-configuration-reference):

- Fix `vlan` field type from `string` to `integer`
- Fix `preserveDefaultVlan` field type from `string` to `boolean`
- Clarify `isDefaultGateway` description to note that the bridge's assigned IP address is used as the default route

## Test plan

- [ ] Verify rendered table shows correct types for `vlan` and `preserveDefaultVlan`
- [ ] Verify `isDefaultGateway` description accurately reflects upstream CNI bridge plugin behaviour