### PR TITLE
OCPBUGS-84675: Updated installation-initializing.adoc to remove state…

### DIFF
--- a/modules/installation-initializing.adoc
+++ b/modules/installation-initializing.adoc
@@ -708,6 +708,7 @@ Only one VPE can be specified per service.
 ====
 endif::ibm-cloud[]
 ifdef::restricted[]
+ifndef::vsphere,osp,nutanix[]
 +
 .. Optionally, set the publishing strategy to `Internal`:
 +
@@ -717,6 +718,7 @@ publish: Internal
 ----
 +
 By setting this option, you create an internal Ingress Controller and a private load balancer.
+endif::vsphere,osp,nutanix[]
 ifdef::azure[]
 +
 [IMPORTANT]


### PR DESCRIPTION
Check non-cloud platforms if parameter should be excluded. 

Version(s):
4.16+

Issue:
[OCPBUGS-84675](https://redhat.atlassian.net/browse/OCPBUGS-84675)

Link to docs preview:

**vSphere files:**

* https://111015--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/ipi/installing-restricted-networks-installer-provisioned-vsphere.html#installation-initializing_installing-restricted-networks-installer-provisioned-vsphere
* https://111015--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/ipi/installing-vsphere-installer-provisioned-customizations.html#installation-initializing_installing-vsphere-installer-provisioned-customizations

**Nutanix files:**

* https://111015--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_nutanix/installing-restricted-networks-nutanix-installer-provisioned.html

**OpenStack files:**

* https://111015--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_openstack/installing-openstack-installer-restricted.html

**Other platforms (Cloud platforms that keep the statement):**

* https://111015--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/ipi/installing-restricted-networks-aws-installer-provisioned.html
* https://111015--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_azure/ipi/installing-restricted-networks-azure-installer-provisioned.html
* https://111015--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_azure/upi/installing-restricted-networks-azure-user-provisioned.html
* https://111015--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-restricted-networks-gcp.html
* https://111015--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-restricted-networks-gcp-installer-provisioned.html
* https://111015--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_ibm_powervs/installing-restricted-networks-ibm-power-vs.html



- [x] SME has approved this change (Joe Callen).
- [x] QE has approved this change (Neil Girard).

The Optional configuration parameters document mentions https://bugzilla.redhat.com/show_bug.cgi?id=1953035. The Installer does automatic checks for supported platforms:https://github.com/openshift/installer/blob/main/pkg/types/validation/installconfig.go#L196-L202:

On the listed public clouds, OpenShift can automatically provision private load balancers and internal DNS. On other platforms, the installer lacks the native automation to guarantee a strictly "internal" setup, so it prevents the user from selecting that configuration option to avoid a broken or insecure deployment.
