### PR TITLE
OCPBUGS-77930: Add known issue for topo-aware-scheduler preemption

### DIFF
--- a/modules/rn-ocp-release-notes-known-issues.adoc
+++ b/modules/rn-ocp-release-notes-known-issues.adoc
@@ -4,4 +4,4 @@
 
 This section includes several known issues for {product-title} {product-version}.
 
-
+* Currently, the `topo-aware-scheduler` provided by the NUMA Resources Operator (NRO) does not support Kubernetes priority-based preemption. When all NUMA zones on available nodes are fully consumed by lower-priority pods, a high-priority pod with a `PreemptLowerPriority` policy remains in `Pending` state indefinitely instead of preempting the lower-priority pods. As a consequence, workloads that depend on priority-based preemption for scheduling recovery do not function correctly when using the `topo-aware-scheduler`. (link:https://issues.redhat.com/browse/OCPBUGS-77930[OCPBUGS-77930])


### PR DESCRIPTION
## Summary
- Adds a known issue entry for OCPBUGS-77930 to the 4.22 release notes
- The `topo-aware-scheduler` (NRO) does not support Kubernetes priority-based preemption, causing high-priority pods to remain `Pending` indefinitely when NUMA zones are fully consumed by lower-priority pods

## JIRA
https://issues.redhat.com/browse/OCPBUGS-77930

🤖 Generated with [Claude Code](https://claude.com/claude-code)