### PR TITLE
OCPBUGS-77930: Add known issue for topo-aware-scheduler preemption

### DIFF
--- a/release_notes/ocp-4-18-release-notes.adoc
+++ b/release_notes/ocp-4-18-release-notes.adoc
@@ -2942,6 +2942,8 @@ In the following tables, features are marked with the following statuses:
 [id="ocp-4-18-known-issues_{context}"]
 == Known issues
 
+* Currently, the `topo-aware-scheduler` provided by the NUMA Resources Operator (NRO) does not support Kubernetes priority-based preemption. When all NUMA zones on available nodes are fully consumed by lower-priority pods, a high-priority pod with a `PreemptLowerPriority` policy remains in `Pending` state indefinitely instead of preempting the lower-priority pods. As a consequence, workloads that depend on priority-based preemption for scheduling recovery do not function correctly when using the `topo-aware-scheduler`. (link:https://issues.redhat.com/browse/OCPBUGS-77930[OCPBUGS-77930])
+
 * Previously, when you attempted to set the policy for a {gcp-first} service account, the API reported a `400: Bad Request` validation error. When you create a service account, it might take up to 60 seconds for the account to become active, and this causes the validation error. If this error occurs, create a service account with a true exponential backoff that lasts at least 60 seconds. (link:https://issues.redhat.com/browse/OCPBUGS-48187[OCPBUGS-48187])
 
 * An installation can succeed when installing a cluster on a {gcp-full} shared virtual private network (VPC) using the minimum permissions and without specifying the`controlPlane.platform.gcp.serviceAccount` in the `install-config.yaml` file. Firewall rules in Kubernetes (K8s) are created in the shared VPC, but destroying the cluster will not delete these firewall rules in K8s because the host project lacks the permissions. (link:https://issues.redhat.com/browse/OCPBUGS-38689[OCPBUGS-38689])


### PR DESCRIPTION
## Summary
- Adds a known issue entry for OCPBUGS-77930 to the 4.18 release notes
- The `topo-aware-scheduler` (NRO) does not support Kubernetes priority-based preemption, causing high-priority pods to remain `Pending` indefinitely when NUMA zones are fully consumed by lower-priority pods

## JIRA
https://issues.redhat.com/browse/OCPBUGS-77930

🤖 Generated with [Claude Code](https://claude.com/claude-code)