### PR TITLE
OCPBUGS-77930: Add known issue for topo-aware-scheduler preemption

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ commercial_package
 .vale/styles/OpenShiftAsciiDoc
 .vale/styles/RedHat
 .vale/styles/AsciiDocDITA/
+.claude

--- a/release_notes/ocp-4-15-release-notes.adoc
+++ b/release_notes/ocp-4-15-release-notes.adoc
@@ -2622,6 +2622,8 @@ In the following tables, features are marked with the following statuses:
 [id="ocp-4-15-known-issues"]
 == Known issues
 
+* Currently, the `topo-aware-scheduler` provided by the NUMA Resources Operator (NRO) does not support Kubernetes priority-based preemption. When all NUMA zones on available nodes are fully consumed by lower-priority pods, a high-priority pod with a `PreemptLowerPriority` policy remains in `Pending` state indefinitely instead of preempting the lower-priority pods. As a consequence, workloads that depend on priority-based preemption for scheduling recovery do not function correctly when using the `topo-aware-scheduler`. (link:https://issues.redhat.com/browse/OCPBUGS-77930[OCPBUGS-77930])
+
 // TODO: This known issue should carry forward to 4.9 and beyond!
 * The `oc annotate` command does not work for LDAP group names that contain an equal sign (`=`), because the command uses the equal sign as a delimiter between the annotation name and value. As a workaround, use `oc patch` or `oc edit` to add the annotation. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1917280[*BZ#1917280*])
 


### PR DESCRIPTION
## Summary
- Adds a known issue entry for OCPBUGS-77930 to the 4.15 release notes
- The `topo-aware-scheduler` (NRO) does not support Kubernetes priority-based preemption, causing high-priority pods to remain `Pending` indefinitely when NUMA zones are fully consumed by lower-priority pods

## JIRA
https://issues.redhat.com/browse/OCPBUGS-77930

🤖 Generated with [Claude Code](https://claude.com/claude-code)