### PR TITLE
OCPBUGS-77930: Add known issue for topo-aware-scheduler preemption

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ commercial_package
 .vale/styles/OpenShiftAsciiDoc
 .vale/styles/RedHat
 .vale/styles/AsciiDocDITA/
+.claude

--- a/release_notes/ocp-4-13-release-notes.adoc
+++ b/release_notes/ocp-4-13-release-notes.adoc
@@ -2749,6 +2749,8 @@ In the following tables, features are marked with the following statuses:
 [id="ocp-4-13-known-issues_{context}"]
 == Known issues
 
+* Currently, the `topo-aware-scheduler` provided by the NUMA Resources Operator (NRO) does not support Kubernetes priority-based preemption. When all NUMA zones on available nodes are fully consumed by lower-priority pods, a high-priority pod with a `PreemptLowerPriority` policy remains in `Pending` state indefinitely instead of preempting the lower-priority pods. As a consequence, workloads that depend on priority-based preemption for scheduling recovery do not function correctly when using the `topo-aware-scheduler`. (link:https://issues.redhat.com/browse/OCPBUGS-77930[OCPBUGS-77930])
+
 * For a cloud controller manager (CCM) with the `--cloud-provider=external` option set to `cloud-provider-vsphere`, a known issue exists for a cluster that operates in a networking environment with multiple subnets.
 +
 When you upgrade your cluster from {product-title} 4.12 to {product-title} {product-version}, the CCM selects a wrong node IP address and this operation generates an error message in the `namespaces/openshift-cloud-controller-manager/pods/vsphere-cloud-controller-manager` logs. The error message indicates a mismatch with the node IP address and the `vsphere-cloud-controller-manager` pod IP address in your cluster.


### PR DESCRIPTION
## Summary
- Adds a known issue entry for OCPBUGS-77930 to the 4.13 release notes
- The `topo-aware-scheduler` (NRO) does not support Kubernetes priority-based preemption, causing high-priority pods to remain `Pending` indefinitely when NUMA zones are fully consumed by lower-priority pods

## JIRA
https://issues.redhat.com/browse/OCPBUGS-77930

🤖 Generated with [Claude Code](https://claude.com/claude-code)