### PR TITLE
OCPBUGS-77930: Add known issue for topo-aware-scheduler preemption

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ commercial_package
 .vale/styles/OpenShiftAsciiDoc
 .vale/styles/RedHat
 .vale/styles/AsciiDocDITA/
+.claude

--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -3005,6 +3005,8 @@ In the following tables, features are marked with the following statuses:
 [id="ocp-4-12-known-issues_{context}"]
 == Known issues
 
+* Currently, the `topo-aware-scheduler` provided by the NUMA Resources Operator (NRO) does not support Kubernetes priority-based preemption. When all NUMA zones on available nodes are fully consumed by lower-priority pods, a high-priority pod with a `PreemptLowerPriority` policy remains in `Pending` state indefinitely instead of preempting the lower-priority pods. As a consequence, workloads that depend on priority-based preemption for scheduling recovery do not function correctly when using the `topo-aware-scheduler`. (link:https://issues.redhat.com/browse/OCPBUGS-77930[OCPBUGS-77930])
+
 // TODO: This known issue should carry forward to 4.8 and beyond! This needs some SME/QE review before being updated for 4.11. Need to check if KI should be removed or should stay.
 * In {product-title} 4.1, anonymous users could access discovery endpoints. Later releases revoked this access to reduce the possible attack surface for security exploits because some discovery endpoints are forwarded to aggregated API servers. However, unauthenticated access is preserved in upgraded clusters so that existing use cases are not broken.
 +
@@ -5200,7 +5202,7 @@ ERROR Error: Plugin did not respond
 ERROR
 ERROR   with module.cis.ibm_cis_dns_record.kubernetes_api_internal[0],
 ERROR   on cis/main.tf line 27, in resource "ibm_cis_dns_record" "kubernetes_api_internal":
-ERROR   27: resource "ibm_cis_dns_record" "kubernetes_api_internal" 
+ERROR   27: resource "ibm_cis_dns_record" "kubernetes_api_internal"
 ----
 +
 With this release, you can use the installation program to create an external cluster on {product-title} without the plugin issue. (link:https://issues.redhat.com/browse/OCPBUGS-53453[OCPBUGS-53453])


### PR DESCRIPTION
## Summary
- Adds a known issue entry for OCPBUGS-77930 to the 4.12 release notes
- The `topo-aware-scheduler` (NRO) does not support Kubernetes priority-based preemption, causing high-priority pods to remain `Pending` indefinitely when NUMA zones are fully consumed by lower-priority pods

## JIRA
https://issues.redhat.com/browse/OCPBUGS-77930

🤖 Generated with [Claude Code](https://claude.com/claude-code)