### PR TITLE
[SRVCOM-4271a] Add OTel metric changes

### DIFF
--- a/modules/serverless-activator-metrics.adoc
+++ b/modules/serverless-activator-metrics.adoc
@@ -17,20 +17,35 @@ You can use the following metrics to understand how applications respond when tr
 |Tags
 |Unit
 
-|`request_concurrency`
+|`kn_revision_request_concurrency`
 |The number of concurrent requests that routes to the activator, or average concurrency over a reporting period.
 |Gauge
-|`configuration_name`, `container_name`, `namespace_name`, `pod_name`, `revision_name`, `service_name`
-|Integer (no units)
+a|
+`kn_configuration_name`:: configuration name
+`k8s_namespace_name`:: namespace
+`kn_revision_name`:: revision name
+`kn_service_name`:: service name
+|Dimensionless
 
-|`request_count`
+|`http_server_request_duration_seconds_count{job="activator-sm-service"}`
 |The number of requests that route to the activator. The activator handler processes these requests.
 |Counter
-|`configuration_name`, `container_name`, `namespace_name`, `pod_name`, `response_code`, `response_code_class`, `revision_name`, `service_name`, |Integer (no units)
+a|
+`kn_configuration_name`:: configuration name
+`k8s_namespace_name`:: namespace
+`http_response_status_code`:: HTTP response code
+`kn_revision_name`:: revision name
+`kn_service_name`:: service name
+|Dimensionless
 
-|`request_latencies`
-|The response time in milliseconds for a fulfilled, routed request.
+|`http_server_request_duration_seconds_bucket{job="activator-sm-service"}`
+|The response time for a fulfilled, routed request.
 |Histogram
-|`configuration_name`, `container_name`, `namespace_name`, `pod_name`, `response_code`, `response_code_class`, `revision_name`, `service_name`
-|Milliseconds
+a|
+`kn_configuration_name`:: configuration name
+`k8s_namespace_name`:: namespace
+`http_response_status_code`:: HTTP response code
+`kn_revision_name`:: revision name
+`kn_service_name`:: service name
+|Seconds
 |===

--- a/modules/serverless-autoscaler-metrics.adoc
+++ b/modules/serverless-autoscaler-metrics.adoc
@@ -17,87 +17,153 @@ The autoscaler component exposes several metrics related to autoscaler behavior 
 |Tags
 |Unit
 
-|`desired_pods`
+|`kn_revision_pods_desired`
 |The number of pods the autoscaler tries to assign for a service.
 |Gauge
-|`configuration_name`, `namespace_name`, `revision_name`, `service_name`
-|Integer (no units)
+a|
+`kn_configuration_name`:: configuration name
+`k8s_namespace_name`:: namespace
+`kn_revision_name`:: revision name
+`kn_service_name`:: service name
+|Dimensionless
 
-|`excess_burst_capacity`
+|`kn_revision_capacity_excess`
 |The excess burst capacity served over the stable window.
 |Gauge
-|`configuration_name`, `namespace_name`, `revision_name`, `service_name`
-|Integer (no units)
+a|
+`kn_configuration_name`:: configuration name
+`k8s_namespace_name`:: namespace
+`kn_revision_name`:: revision name
+`kn_service_name`:: service name
+|Dimensionless
 
-|`stable_request_concurrency`
+|`kn_revision_concurrency_stable`
 |The average number of requests for each observed pod over the stable window.
 |Gauge
-|`configuration_name`, `namespace_name`, `revision_name`, `service_name`
-|Integer (no units)
+a|
+`kn_configuration_name`:: configuration name
+`k8s_namespace_name`:: namespace
+`kn_revision_name`:: revision name
+`kn_service_name`:: service name
+|Dimensionless
 
-|`panic_request_concurrency`
+|`kn_revision_concurrency_panic`
 |The average number of requests for each observed pod over the panic window.
 |Gauge
-|`configuration_name`, `namespace_name`, `revision_name`, `service_name`
-|Integer (no units)
+a|
+`kn_configuration_name`:: configuration name
+`k8s_namespace_name`:: namespace
+`kn_revision_name`:: revision name
+`kn_service_name`:: service name
+|Dimensionless
 
-|`target_concurrency_per_pod`
+|`kn_revision_concurrency_target`
 |The number of concurrent requests that the autoscaler tries to send to each pod.
 |Gauge
-|`configuration_name`, `namespace_name`, `revision_name`, `service_name`
-|Integer (no units)
+a|
+`kn_configuration_name`:: configuration name
+`k8s_namespace_name`:: namespace
+`kn_revision_name`:: revision name
+`kn_service_name`:: service name
+|Dimensionless
 
-|`stable_requests_per_second`
+|`kn_revision_rps_stable_per_second`
 |The average number of requests-per-second for each observed pod over the stable window.
 |Gauge
-|`configuration_name`, `namespace_name`, `revision_name`, `service_name`
-|Integer (no units)
+a|
+`kn_configuration_name`:: configuration name
+`k8s_namespace_name`:: namespace
+`kn_revision_name`:: revision name
+`kn_service_name`:: service name
+|Dimensionless
 
-|`panic_requests_per_second`
+|`kn_revision_rps_panic_per_second`
 |The average number of requests-per-second for each observed pod over the panic window.
 |Gauge
-|`configuration_name`, `namespace_name`, `revision_name`, `service_name`
-|Integer (no units)
+a|
+`kn_configuration_name`:: configuration name
+`k8s_namespace_name`:: namespace
+`kn_revision_name`:: revision name
+`kn_service_name`:: service name
+|Dimensionless
 
-|`target_requests_per_second`
+|`kn_revision_rps_target_per_second`
 |The number of requests-per-second that the autoscaler targets for each pod.
 |Gauge
-|`configuration_name`, `namespace_name`, `revision_name`, `service_name`
-|Integer (no units)
+a|
+`kn_configuration_name`:: configuration name
+`k8s_namespace_name`:: namespace
+`kn_revision_name`:: revision name
+`kn_service_name`:: service name
+|Dimensionless
 
-|`panic_mode`
+|`kn_revision_panic_mode`
 |This value is `1` if the autoscaler is in panic mode, or `0` if the autoscaler is not in panic mode.
 |Gauge
-|`configuration_name`, `namespace_name`, `revision_name`, `service_name`
-|Integer (no units)
+a|
+`kn_configuration_name`:: configuration name
+`k8s_namespace_name`:: namespace
+`kn_revision_name`:: revision name
+`kn_service_name`:: service name
+|Dimensionless
 
-|`requested_pods`
+|`kn_revision_pods_requested`
 |The number of pods that the autoscaler has requested from the Kubernetes cluster.
 |Gauge
-|`configuration_name`, `namespace_name`, `revision_name`, `service_name`
-|Integer (no units)
+a|
+`kn_configuration_name`:: configuration name
+`k8s_namespace_name`:: namespace
+`kn_revision_name`:: revision name
+`kn_service_name`:: service name
+|Dimensionless
 
-|`actual_pods`
+|`kn_revision_pods_count`
 |The number of pods the system allocates that are currently ready.
 |Gauge
-|`configuration_name`, `namespace_name`, `revision_name`, `service_name`
-|Integer (no units)
+a|
+`kn_configuration_name`:: configuration name
+`k8s_namespace_name`:: namespace
+`kn_revision_name`:: revision name
+`kn_service_name`:: service name
+|Dimensionless
 
-|`not_ready_pods`
+|`kn_revision_pods_not_ready_count`
 |The number of pods that have a not ready state.
 |Gauge
-|`configuration_name`, `namespace_name`, `revision_name`, `service_name`
-|Integer (no units)
+a|
+`kn_configuration_name`:: configuration name
+`k8s_namespace_name`:: namespace
+`kn_revision_name`:: revision name
+`kn_service_name`:: service name
+|Dimensionless
 
-|`pending_pods`
+|`kn_revision_pods_pending_count`
 |The number of pods that are currently pending.
 |Gauge
-|`configuration_name`, `namespace_name`, `revision_name`, `service_name`
-|Integer (no units)
+a|
+`kn_configuration_name`:: configuration name
+`k8s_namespace_name`:: namespace
+`kn_revision_name`:: revision name
+`kn_service_name`:: service name
+|Dimensionless
 
-|`terminating_pods`
+|`kn_revision_pods_terminating_count`
 |The number of pods that are currently terminating.
 |Gauge
-|`configuration_name`, `namespace_name`, `revision_name`, `service_name`
-|Integer (no units)
+a|
+`kn_configuration_name`:: configuration name
+`k8s_namespace_name`:: namespace
+`kn_revision_name`:: revision name
+`kn_service_name`:: service name
+|Dimensionless
+
+|`kn_autoscaler_scrape_duration_seconds_bucket`
+|The time taken to scrape metrics from a revision.
+|Histogram
+a|
+`kn_configuration_name`:: configuration name
+`k8s_namespace_name`:: namespace
+`kn_revision_name`:: revision name
+`kn_service_name`:: service name
+|Seconds
 |===

--- a/modules/serverless-broker-filter-metrics.adoc
+++ b/modules/serverless-broker-filter-metrics.adoc
@@ -17,21 +17,35 @@ You can use the following metrics to debug broker filters, evaluate their perfor
 |Tags
 |Unit
 
-|`event_count`
-|Number of events received by a broker.
+|`kn_eventing_dispatch_duration_seconds_count{job="mt-broker-filter-sm-service"}`
+|Number of events dispatched by a broker filter.
 |Counter
-|`broker_name`, `container_name`, `filter_type`, `namespace_name`, `response_code`, `response_code_class`, `trigger_name`, `unique_name`
-|Integer (no units)
+a|
+`kn_broker_name`:: broker name
+`kn_broker_namespace`:: broker namespace
+`kn_trigger_name`:: trigger name
+`cloudevents_type`:: CloudEvents type
+`http_response_status_code`:: HTTP response code returned by the subscriber
+|Dimensionless
 
-|`event_dispatch_latencies`
-|The time taken to dispatch an event to a channel.
+|`kn_eventing_dispatch_duration_seconds_bucket{job="mt-broker-filter-sm-service"}`
+|The time taken to dispatch an event to a trigger subscriber.
 |Histogram
-|`broker_name`, `container_name`, `filter_type`, `namespace_name`, `response_code`, `response_code_class`, `trigger_name`, `unique_name`
-|Milliseconds
+a|
+`kn_broker_name`:: broker name
+`kn_broker_namespace`:: broker namespace
+`kn_trigger_name`:: trigger name
+`cloudevents_type`:: CloudEvents type
+`http_response_status_code`:: HTTP response code returned by the subscriber
+|Seconds
 
-|`event_processing_latencies`
+|`kn_eventing_process_duration_seconds_bucket{job="mt-broker-filter-sm-service"}`
 |The time required to process an event before dispatching it to a trigger subscriber.
 |Histogram
-|`broker_name`, `container_name`, `filter_type`, `namespace_name`, `trigger_name`, `unique_name`
-|Milliseconds
+a|
+`kn_broker_name`:: broker name
+`kn_broker_namespace`:: broker namespace
+`kn_trigger_name`:: trigger name
+`cloudevents_type`:: CloudEvents type
+|Seconds
 |===

--- a/modules/serverless-broker-filter-metrics.adoc
+++ b/modules/serverless-broker-filter-metrics.adoc
@@ -17,21 +17,32 @@ You can use the following metrics to debug broker filters, evaluate their perfor
 |Tags
 |Unit
 
-|`event_count`
-|Number of events received by a broker.
+|`kn_eventing_dispatch_duration_seconds_count{job="mt-broker-filter-sm-service"}`
+|Number of events dispatched by a broker filter.
 |Counter
-|`broker_name`, `container_name`, `filter_type`, `namespace_name`, `response_code`, `response_code_class`, `trigger_name`, `unique_name`
-|Integer (no units)
+a|
+`kn_broker_name`:: broker name
+`kn_broker_namespace`:: broker namespace
+`cloudevents_type`:: CloudEvents type
+`http_response_status_code`:: HTTP response code returned by the subscriber
+|Dimensionless
 
-|`event_dispatch_latencies`
-|The time taken to dispatch an event to a channel.
+|`kn_eventing_dispatch_duration_seconds_bucket{job="mt-broker-filter-sm-service"}`
+|The time taken to dispatch an event to a trigger subscriber.
 |Histogram
-|`broker_name`, `container_name`, `filter_type`, `namespace_name`, `response_code`, `response_code_class`, `trigger_name`, `unique_name`
-|Milliseconds
+a|
+`kn_broker_name`:: broker name
+`kn_broker_namespace`:: broker namespace
+`cloudevents_type`:: CloudEvents type
+`http_response_status_code`:: HTTP response code returned by the subscriber
+|Seconds
 
-|`event_processing_latencies`
+|`kn_eventing_process_duration_seconds_bucket{job="mt-broker-filter-sm-service"}`
 |The time required to process an event before dispatching it to a trigger subscriber.
 |Histogram
-|`broker_name`, `container_name`, `filter_type`, `namespace_name`, `trigger_name`, `unique_name`
-|Milliseconds
+a|
+`kn_broker_name`:: broker name
+`kn_broker_namespace`:: broker namespace
+`cloudevents_type`:: CloudEvents type
+|Seconds
 |===

--- a/modules/serverless-broker-ingress-metrics.adoc
+++ b/modules/serverless-broker-ingress-metrics.adoc
@@ -17,15 +17,23 @@ You can use the following metrics to debug the broker ingress, evaluate its perf
 |Tags
 |Unit
 
-|`event_count`
+|`kn_eventing_dispatch_duration_seconds_count{job="mt-broker-ingress-sm-service"}`
 |Number of events received by a broker.
 |Counter
-|`broker_name`, `event_type`, `namespace_name`, `response_code`, `response_code_class`, `unique_name`
-|Integer (no units)
+a|
+`kn_broker_name`:: broker name
+`cloudevents_type`:: CloudEvents type
+`kn_broker_namespace`:: broker namespace
+`http_response_status_code`:: HTTP response code returned by the broker
+|Dimensionless
 
-|`event_dispatch_latencies`
+|`kn_eventing_dispatch_duration_seconds_bucket{job="mt-broker-ingress-sm-service"}`
 |The time taken to dispatch an event to a channel.
 |Histogram
-|`broker_name`, `event_type`, `namespace_name`, `response_code`, `response_code_class`, `unique_name`
-|Milliseconds
+a|
+`kn_broker_name`:: broker name
+`cloudevents_type`:: CloudEvents type
+`kn_broker_namespace`:: broker namespace
+`http_response_status_code`:: HTTP response code returned by the broker
+|Seconds
 |===

--- a/modules/serverless-event-source-metrics.adoc
+++ b/modules/serverless-event-source-metrics.adoc
@@ -9,6 +9,8 @@
 [role="_abstract"]
 You can use the following metrics to verify that the event source delivered events to the connected event sink.
 
+== ApiServerSource metrics
+
 [cols=5*,options="header"]
 |===
 |Metric name
@@ -17,14 +19,46 @@ You can use the following metrics to verify that the event source delivered even
 |Tags
 |Unit
 
-|`event_count`
-|Number of events sent by the event source.
+|`+http_client_request_duration_seconds_count{job=~"apiserversource-.*"}+`
+|Number of events sent by ApiServerSource.
 |Counter
-|`broker_name`, `container_name`, `filter_type`, `namespace_name`, `response_code`, `response_code_class`, `trigger_name`, `unique_name`
-|Integer (no units)
+a|
+`kn_source_namespace`:: source namespace
+`http_response_status_code`:: HTTP response code returned by the sink
+|Dimensionless
 
-|`retry_event_count`
-|The event source retries and sends events that failed during the initial delivery trial.
+|`+http_client_request_duration_seconds_bucket{job=~"apiserversource-.*"}+`
+|The time taken to send events to the sink.
+|Histogram
+a|
+`kn_source_namespace`:: source namespace
+`http_response_status_code`:: HTTP response code returned by the sink
+|Seconds
+|===
+
+== PingSource metrics
+
+[cols=5*,options="header"]
+|===
+|Metric name
+|Description
+|Type
+|Tags
+|Unit
+
+|`http_client_request_duration_seconds_count{job="pingsource-mt-adapter-sm-service"}`
+|Number of events sent by PingSource.
 |Counter
-|`event_source`, `event_type`, `name`, `namespace_name`, `resource_group`, `response_code`, `response_code_class`, `response_error`, `response_timeout` |Integer (no units)
+a|
+`kn_source_namespace`:: source namespace
+`http_response_status_code`:: HTTP response code returned by the sink
+|Dimensionless
+
+|`http_client_request_duration_seconds_bucket{job="pingsource-mt-adapter-sm-service"}`
+|The time taken to send events to the sink.
+|Histogram
+a|
+`kn_source_namespace`:: source namespace
+`http_response_status_code`:: HTTP response code returned by the sink
+|Seconds
 |===

--- a/modules/serverless-inmemory-dispatch-metrics.adoc
+++ b/modules/serverless-inmemory-dispatch-metrics.adoc
@@ -17,15 +17,23 @@ You can use the following metrics to debug `InMemoryChannel` channels, evaluate 
 |Tags
 |Unit
 
-|`event_count`
+|`kn_eventing_dispatch_duration_seconds_count{job="imc-dispatcher-sm-service"}`
 |Number of events dispatched by `InMemoryChannel` channels.
 |Counter
-|`broker_name`, `container_name`, `filter_type`, `namespace_name`, `response_code`, `response_code_class`, `trigger_name`, `unique_name`
-|Integer (no units)
+a|
+`kn_channel_name`:: channel name
+`kn_channel_namespace`:: channel namespace
+`cloudevents_type`:: CloudEvents type
+`http_response_status_code`:: HTTP response code returned by the subscriber
+|Dimensionless
 
-|`event_dispatch_latencies`
+|`kn_eventing_dispatch_duration_seconds_bucket{job="imc-dispatcher-sm-service"}`
 |The time taken to dispatch an event from an `InMemoryChannel` channel.
 |Histogram
-|`broker_name`, `container_name`, `filter_type`, `namespace_name`, `response_code`, `response_code_class`, `trigger_name`, `unique_name`
-|Milliseconds
+a|
+`kn_channel_name`:: channel name
+`kn_channel_namespace`:: channel namespace
+`cloudevents_type`:: CloudEvents type
+`http_response_status_code`:: HTTP response code returned by the subscriber
+|Seconds
 |===

--- a/modules/serverless-knative-kafka-broker-metrics.adoc
+++ b/modules/serverless-knative-kafka-broker-metrics.adoc
@@ -17,26 +17,53 @@ You can use the following metrics to debug and visualize the performance of Kafk
 |Tags
 |Unit
 
-|`event_count_1_total{job="kafka-broker-receiver-sm-service", namespace="knative-eventing"}`
-|Number of events received by a broker
+|`kn_eventing_dispatch_latency_ms_count{job="kafka-broker-receiver-sm-service", namespace="knative-eventing"}`
+|Number of events received by a Kafka broker
 |Counter
 a|
-`name`:: broker name
-`namespace_name`:: broker namespace
-`event_type`:: event type
-`response_code`:: HTTP response code returned by the broker
-`response_code_class`:: HTTP response code class returned by the broker: 2xx, 3xx, 4xx, 5xx
+`kn_broker_name`:: broker name
+`kn_broker_namespace`:: broker namespace
+`cloudevents_type`:: CloudEvents type
+`http_response_status_code`:: HTTP response code returned by the Kafka cluster
 |Dimensionless
 
-|`event_dispatch_latencies_ms_bucket{job="kafka-broker-receiver-sm-service", namespace="knative-eventing"}`
+|`kn_eventing_dispatch_latency_ms_bucket{job="kafka-broker-receiver-sm-service", namespace="knative-eventing"}`
 |The time spent dispatching an event to a Kafka cluster
 |Histogram
 a|
-`name`:: broker name
-`namespace_name`:: broker namespace
-`event_type`:: event type
-`response_code`:: HTTP response code returned by the broker
-`response_code_class`:: HTTP response code class returned by the broker: 2xx, 3xx, 4xx, 5xx
+`kn_broker_name`:: broker name
+`kn_broker_namespace`:: broker namespace
+`cloudevents_type`:: CloudEvents type
+`http_response_status_code`:: HTTP response code returned by the Kafka cluster
+|Milliseconds
+
+|`kn_eventing_dispatch_latency_ms_count{job="kafka-broker-dispatcher-sm-service", namespace="knative-eventing"}`
+|Number of events dispatched from a Kafka broker to trigger subscribers
+|Counter
+a|
+`kn_trigger_name`:: trigger name
+`kn_trigger_namespace`:: trigger namespace
+`cloudevents_type`:: CloudEvents type
+`http_response_status_code`:: HTTP response code returned by the subscriber
+|Dimensionless
+
+|`kn_eventing_dispatch_latency_ms_bucket{job="kafka-broker-dispatcher-sm-service", namespace="knative-eventing"}`
+|The time spent dispatching an event from a Kafka broker to a trigger subscriber
+|Histogram
+a|
+`kn_trigger_name`:: trigger name
+`kn_trigger_namespace`:: trigger namespace
+`cloudevents_type`:: CloudEvents type
+`http_response_status_code`:: HTTP response code returned by the subscriber
+|Milliseconds
+
+|`kn_eventing_process_latency_ms_bucket{job="kafka-broker-dispatcher-sm-service", namespace="knative-eventing"}`
+|The time spent processing an event before dispatching to a trigger subscriber
+|Histogram
+a|
+`kn_trigger_name`:: trigger name
+`kn_trigger_namespace`:: trigger namespace
+`cloudevents_type`:: CloudEvents type
 |Milliseconds
 
 |`kafka_broker_controller_consumer_group_expected_replicas`
@@ -70,3 +97,8 @@ In this context, resources refer to user facing entities such as Kafka source, t
 |Dimensionless
 
 |===
+
+[IMPORTANT]
+====
+Kafka broker metrics continue to use milliseconds (not seconds) for duration measurements.
+====

--- a/modules/serverless-knative-kafka-channel-metrics.adoc
+++ b/modules/serverless-knative-kafka-channel-metrics.adoc
@@ -17,26 +17,29 @@ You can use the following metrics to debug and visualize the performance of Kafk
 |Tags
 |Unit
 
-|`event_count_1_total{job="kafka-channel-receiver-sm-service", namespace="knative-eventing"}`
+|`kn_eventing_dispatch_latency_ms_count{job="kafka-channel-receiver-sm-service", namespace="knative-eventing"}`
 |Number of events received by a Kafka channel
 |Counter
 a|
-`name`:: Kafka channel name
-`namespace_name`:: Kafka channel namespace
-`event_type`:: event type
-`response_code`:: HTTP response code returned by the Kafka channel
-`response_code_class`:: HTTP response code class returned by the Kafka channel: 2xx, 3xx, 4xx, 5xx
+`kn_kafkachannel_name`:: Kafka channel name
+`kn_kafkachannel_namespace`:: Kafka channel namespace
+`cloudevents_type`:: CloudEvents type
+`http_response_status_code`:: HTTP response code returned by the Kafka cluster
 |Dimensionless
 
-|`event_dispatch_latencies_ms_bucket{job="kafka-channel-receiver-sm-service", namespace="knative-eventing"}`
+|`kn_eventing_dispatch_latency_ms_bucket{job="kafka-channel-receiver-sm-service", namespace="knative-eventing"}`
 |The time spent dispatching an event to a Kafka cluster
 |Histogram
 a|
-`name`:: Kafka channel name
-`namespace_name`:: Kafka channel namespace
-`event_type`:: event type
-`response_code`:: HTTP response code returned by the Kafka channel
-`response_code_class`:: HTTP response code class returned by the Kafka channel: 2xx, 3xx, 4xx, 5xx
+`kn_kafkachannel_name`:: Kafka channel name
+`kn_kafkachannel_namespace`:: Kafka channel namespace
+`cloudevents_type`:: CloudEvents type
+`http_response_status_code`:: HTTP response code returned by the Kafka cluster
 |Milliseconds
 
 |===
+
+[IMPORTANT]
+====
+Kafka channel metrics continue to use milliseconds (not seconds) for duration measurements.
+====

--- a/modules/serverless-knative-kafka-sink-metrics.adoc
+++ b/modules/serverless-knative-kafka-sink-metrics.adoc
@@ -17,26 +17,29 @@ You can use the following metrics to debug and visualize the performance of Kafk
 |Tags
 |Unit
 
-|`event_count_1_total{job="kafka-sink-receiver-sm-service", namespace="knative-eventing"}`
-|Number of events received by a broker
+|`kn_eventing_dispatch_latency_ms_count{job="kafka-sink-receiver-sm-service", namespace="knative-eventing"}`
+|Number of events received by a Kafka sink
 |Counter
 a|
-`name`:: Kafka sink name
-`namespace_name`:: Kafka sink namespace
-`event_type`:: event type
-`response_code`:: HTTP response code returned by the Kafka sink
-`response_code_class`:: HTTP response code class returned by the Kafka sink: 2xx, 3xx, 4xx, 5xx
+`kn_kafkasink_name`:: Kafka sink name
+`kn_kafkasink_namespace`:: Kafka sink namespace
+`cloudevents_type`:: CloudEvents type
+`http_response_status_code`:: HTTP response code returned by the Kafka cluster
 |Dimensionless
 
-|`event_dispatch_latencies_ms_bucket{job="kafka-sink-receiver-sm-service", namespace="knative-eventing"}`
+|`kn_eventing_dispatch_latency_ms_bucket{job="kafka-sink-receiver-sm-service", namespace="knative-eventing"}`
 |The time spent dispatching an event to a Kafka cluster
 |Histogram
 a|
-`name`:: Kafka sink name
-`namespace_name`:: Kafka sink namespace
-`event_type`:: event type
-`response_code`:: HTTP response code returned by the Kafka sink
-`response_code_class`:: HTTP response code class returned by the Kafka sink: 2xx, 3xx, 4xx, 5xx
+`kn_kafkasink_name`:: Kafka sink name
+`kn_kafkasink_namespace`:: Kafka sink namespace
+`cloudevents_type`:: CloudEvents type
+`http_response_status_code`:: HTTP response code returned by the Kafka cluster
 |Milliseconds
 
 |===
+
+[IMPORTANT]
+====
+Kafka sink metrics continue to use milliseconds (not seconds) for duration measurements.
+====

--- a/modules/serverless-knative-kafka-source-metrics.adoc
+++ b/modules/serverless-knative-kafka-source-metrics.adoc
@@ -17,38 +17,33 @@ You can use the following metrics to debug and visualize the performance of Kafk
 |Tags
 |Unit
 
-|`event_count_1_total{job="kafka-source-dispatcher-sm-service", namespace="knative-eventing"}`
+|`kn_eventing_dispatch_latency_ms_count{job="kafka-source-dispatcher-sm-service", namespace="knative-eventing"}`
 |Number of events dispatched by a Kafka source
 |Counter
 a|
-`consumer_name`:: Kafka source name
-`namespace_name`:: Kafka source namespace
-`name`:: Kafka source name
-`event_type`:: event type
-`response_code`:: HTTP response code returned by the Kafka source sink service
-`response_code_class`:: HTTP response code class returned by the Kafka source sink service: 2xx, 3xx, 4xx, 5xx
+`kn_kafkasource_name`:: Kafka source name
+`kn_kafkasource_namespace`:: Kafka source namespace
+`cloudevents_type`:: CloudEvents type
+`http_response_status_code`:: HTTP response code returned by the sink
 |Dimensionless
 
-|`event_dispatch_latencies_ms_bucket{job="kafka-source-dispatcher-sm-service", namespace="knative-eventing"}`
+|`kn_eventing_dispatch_latency_ms_bucket{job="kafka-source-dispatcher-sm-service", namespace="knative-eventing"}`
 |The time spent dispatching an event to a sink
 |Histogram
 a|
-`consumer_name`:: Kafka source name
-`namespace_name`:: Kafka source namespace
-`name`:: Kafka source name
-`event_type`:: event type
-`response_code`:: HTTP response code returned by the Kafka source sink service
-`response_code_class`:: HTTP response code class returned by the Kafka source sink service: 2xx, 3xx, 4xx, 5xx
+`kn_kafkasource_name`:: Kafka source name
+`kn_kafkasource_namespace`:: Kafka source namespace
+`cloudevents_type`:: CloudEvents type
+`http_response_status_code`:: HTTP response code returned by the sink
 |Milliseconds
 
-|`event_processing_latencies_ms_bucket{job="kafka-source-dispatcher-sm-service", namespace="knative-eventing"}`
-|The time spent processing an event
+|`kn_eventing_process_latency_ms_bucket{job="kafka-source-dispatcher-sm-service", namespace="knative-eventing"}`
+|The time spent processing an event before dispatching
 |Histogram
 a|
-`consumer_name`:: Kafka source name
-`namespace_name`:: Kafka source namespace
-`name`:: Kafka source name
-`event_type`:: event type
+`kn_kafkasource_name`:: Kafka source name
+`kn_kafkasource_namespace`:: Kafka source namespace
+`cloudevents_type`:: CloudEvents type
 |Milliseconds
 
 |`kafka_broker_controller_consumer_group_expected_replicas`
@@ -82,3 +77,8 @@ In this context, resources refer to user facing entities such as Kafka source,tr
 |Dimensionless
 
 |===
+
+[IMPORTANT]
+====
+Kafka source metrics continue to use milliseconds (not seconds) for duration measurements.
+====

--- a/modules/serverless-knative-kafka-source-metrics.adoc
+++ b/modules/serverless-knative-kafka-source-metrics.adoc
@@ -17,68 +17,84 @@ You can use the following metrics to debug and visualize the performance of Kafk
 |Tags
 |Unit
 
-|`event_count_1_total{job="kafka-source-dispatcher-sm-service", namespace="knative-eventing"}`
+|`kn_eventing_dispatch_latency_ms_count{job="kafka-source-dispatcher-sm-service", namespace="knative-eventing"}`
 |Number of events dispatched by a Kafka source
 |Counter
 a|
-`consumer_name`:: Kafka source name
-`namespace_name`:: Kafka source namespace
-`name`:: Kafka source name
-`event_type`:: event type
-`response_code`:: HTTP response code returned by the Kafka source sink service
-`response_code_class`:: HTTP response code class returned by the Kafka source sink service: 2xx, 3xx, 4xx, 5xx
+`kn_kafkasource_name`:: Kafka source name
+`kn_kafkasource_namespace`:: Kafka source namespace
+`cloudevents_type`:: CloudEvents type
+`http_response_status_code`:: HTTP response code returned by the sink
 |Dimensionless
 
-|`event_dispatch_latencies_ms_bucket{job="kafka-source-dispatcher-sm-service", namespace="knative-eventing"}`
+|`kn_eventing_dispatch_latency_ms_bucket{job="kafka-source-dispatcher-sm-service", namespace="knative-eventing"}`
 |The time spent dispatching an event to a sink
 |Histogram
 a|
-`consumer_name`:: Kafka source name
-`namespace_name`:: Kafka source namespace
-`name`:: Kafka source name
-`event_type`:: event type
-`response_code`:: HTTP response code returned by the Kafka source sink service
-`response_code_class`:: HTTP response code class returned by the Kafka source sink service: 2xx, 3xx, 4xx, 5xx
+`kn_kafkasource_name`:: Kafka source name
+`kn_kafkasource_namespace`:: Kafka source namespace
+`cloudevents_type`:: CloudEvents type
+`http_response_status_code`:: HTTP response code returned by the sink
 |Milliseconds
 
-|`event_processing_latencies_ms_bucket{job="kafka-source-dispatcher-sm-service", namespace="knative-eventing"}`
-|The time spent processing an event
+|`kn_eventing_process_latency_ms_bucket{job="kafka-source-dispatcher-sm-service", namespace="knative-eventing"}`
+|The time spent processing an event before dispatching
 |Histogram
 a|
-`consumer_name`:: Kafka source name
-`namespace_name`:: Kafka source namespace
-`name`:: Kafka source name
-`event_type`:: event type
+`kn_kafkasource_name`:: Kafka source name
+`kn_kafkasource_namespace`:: Kafka source namespace
+`cloudevents_type`:: CloudEvents type
 |Milliseconds
 
-|`kafka_broker_controller_consumer_group_expected_replicas`
+|`kn_eventing_replicas_expected`
 |Number of expected replicas for a given Kafka consumer group resource
 |Gauge
 a|
-`consumer_name`:: resource name
-`namespace_name`:: resource namespace
-`consumer_kind`:: resource Kind, enum: `KafkaSource`, `Trigger`, `Subscription`
+Labels depend on the resource kind:
 
-[NOTE]
-====
-In this context, resources refer to user facing entities such as Kafka source,trigger, and subscription. Avoid using internal or generated names when using these resources.
-====
+For KafkaChannels:
+
+`kn_channel_name`:: Kafka channel name
+`kn_channel_namespace`:: Kafka channel namespace
+
+For Kafka Broker Triggers:
+
+`kn_trigger_name`:: Trigger name
+`kn_trigger_namespace`:: Trigger namespace
+
+For KafkaSources:
+
+`kn_source_name`:: Kafka source name
+`kn_source_namespace`:: Kafka source namespace
 
 |Dimensionless
 
-|`kafka_broker_controller_consumer_group_ready_replicas`
+|`kn_eventing_replicas_ready`
 |Number of ready replicas for a given Kafka consumer group resource
 |Gauge
 a|
-`consumer_name`:: resource name
-`namespace_name`:: resource namespace
-`consumer_kind`:: resource Kind, enum: `KafkaSource`, `Trigger`, `Subscription`
+Labels depend on the resource kind:
 
-[NOTE]
-====
-In this context, resources refer to user facing entities such as Kafka source,trigger, and subscription. Avoid using internal or generated names when using these resources.
-====
+For KafkaChannels:
+
+`kn_channel_name`:: Kafka channel name
+`kn_channel_namespace`:: Kafka channel namespace
+
+For Kafka Broker Triggers:
+
+`kn_trigger_name`:: Trigger name
+`kn_trigger_namespace`:: Trigger namespace
+
+For KafkaSources:
+
+`kn_source_name`:: Kafka source name
+`kn_source_namespace`:: Kafka source namespace
 
 |Dimensionless
 
 |===
+
+[IMPORTANT]
+====
+Kafka source metrics continue to use milliseconds (not seconds) for duration measurements.
+====

--- a/modules/serverless-knative-kafka-subscription-metrics.adoc
+++ b/modules/serverless-knative-kafka-subscription-metrics.adoc
@@ -17,38 +17,38 @@ You can use the following metrics to debug and visualize the performance of subs
 |Tags
 |Unit
 
-|`event_count_1_total{job="kafka-channel-dispatcher-sm-service", namespace="knative-eventing"}`
+|`kn_eventing_dispatch_latency_ms_count{job="kafka-channel-dispatcher-sm-service", namespace="knative-eventing"}`
 |Number of events dispatched by a subscription to a subscriber
 |Counter
 a|
-`consumer_name`:: Subscription name
-`namespace_name`:: Subscription namespace
-`name`:: `KafkaChannel` name
-`event_type`:: event type
-`response_code`:: HTTP response code returned by the `Subscription` subscriber service
-`response_code_class`:: HTTP response code class returned by the `Subscription` subscriber service: 2xx, 3xx, 4xx, 5xx
+`kn_kafkachannel_name`:: Kafka channel name
+`kn_kafkachannel_namespace`:: Kafka channel namespace
+`cloudevents_type`:: CloudEvents type
+`http_response_status_code`:: HTTP response code returned by the subscriber
 |Dimensionless
 
-|`event_dispatch_latencies_ms_bucket{job="kafka-channel-dispatcher-sm-service", namespace="knative-eventing"}`
+|`kn_eventing_dispatch_latency_ms_bucket{job="kafka-channel-dispatcher-sm-service", namespace="knative-eventing"}`
 |The time spent dispatching an event to a subscriber
 |Histogram
 a|
-`consumer_name`:: Subscription name
-`namespace_name`:: Subscription namespace
-`name`:: `KafkaChannel` name
-`event_type`:: event type
-`response_code`:: HTTP response code returned by the `Subscription` subscriber service
-`response_code_class`:: HTTP response code class returned by the `Subscription` subscriber service: 2xx, 3xx, 4xx, 5xx
+`kn_kafkachannel_name`:: Kafka channel name
+`kn_kafkachannel_namespace`:: Kafka channel namespace
+`cloudevents_type`:: CloudEvents type
+`http_response_status_code`:: HTTP response code returned by the subscriber
 |Milliseconds
 
-|`event_processing_latencies_ms_bucket{job="kafka-channel-dispatcher-sm-service", namespace="knative-eventing"}`
+|`kn_eventing_process_latency_ms_bucket{job="kafka-channel-dispatcher-sm-service", namespace="knative-eventing"}`
 |The time spent processing an event
 |Histogram
 a|
-`consumer_name`:: Subscription name
-`namespace_name`:: Subscription namespace
-`name`:: `KafkaChannel` name
-`event_type`:: event type
-|Dimensionless
+`kn_kafkachannel_name`:: Kafka channel name
+`kn_kafkachannel_namespace`:: Kafka channel namespace
+`cloudevents_type`:: CloudEvents type
+|Milliseconds
 
 |===
+
+[IMPORTANT]
+====
+Kafka subscription metrics continue to use milliseconds (not seconds) for duration measurements.
+====

--- a/modules/serverless-knative-kafka-subscription-metrics.adoc
+++ b/modules/serverless-knative-kafka-subscription-metrics.adoc
@@ -17,38 +17,41 @@ You can use the following metrics to debug and visualize the performance of subs
 |Tags
 |Unit
 
-|`event_count_1_total{job="kafka-channel-dispatcher-sm-service", namespace="knative-eventing"}`
+|`kn_eventing_dispatch_latency_ms_count{job="kafka-channel-dispatcher-sm-service", namespace="knative-eventing"}`
 |Number of events dispatched by a subscription to a subscriber
 |Counter
 a|
-`consumer_name`:: Subscription name
-`namespace_name`:: Subscription namespace
-`name`:: `KafkaChannel` name
-`event_type`:: event type
-`response_code`:: HTTP response code returned by the `Subscription` subscriber service
-`response_code_class`:: HTTP response code class returned by the `Subscription` subscriber service: 2xx, 3xx, 4xx, 5xx
+`kn_subscription_name`:: Subscription name
+`kn_subscription_namespace`:: Subscription namespace
+`kn_kafkachannel_name`:: Kafka channel name
+`cloudevents_type`:: CloudEvents type
+`http_response_status_code`:: HTTP response code returned by the subscriber
 |Dimensionless
 
-|`event_dispatch_latencies_ms_bucket{job="kafka-channel-dispatcher-sm-service", namespace="knative-eventing"}`
+|`kn_eventing_dispatch_latency_ms_bucket{job="kafka-channel-dispatcher-sm-service", namespace="knative-eventing"}`
 |The time spent dispatching an event to a subscriber
 |Histogram
 a|
-`consumer_name`:: Subscription name
-`namespace_name`:: Subscription namespace
-`name`:: `KafkaChannel` name
-`event_type`:: event type
-`response_code`:: HTTP response code returned by the `Subscription` subscriber service
-`response_code_class`:: HTTP response code class returned by the `Subscription` subscriber service: 2xx, 3xx, 4xx, 5xx
+`kn_subscription_name`:: Subscription name
+`kn_subscription_namespace`:: Subscription namespace
+`kn_kafkachannel_name`:: Kafka channel name
+`cloudevents_type`:: CloudEvents type
+`http_response_status_code`:: HTTP response code returned by the subscriber
 |Milliseconds
 
-|`event_processing_latencies_ms_bucket{job="kafka-channel-dispatcher-sm-service", namespace="knative-eventing"}`
+|`kn_eventing_process_latency_ms_bucket{job="kafka-channel-dispatcher-sm-service", namespace="knative-eventing"}`
 |The time spent processing an event
 |Histogram
 a|
-`consumer_name`:: Subscription name
-`namespace_name`:: Subscription namespace
-`name`:: `KafkaChannel` name
-`event_type`:: event type
-|Dimensionless
+`kn_subscription_name`:: Subscription name
+`kn_subscription_namespace`:: Subscription namespace
+`kn_kafkachannel_name`:: Kafka channel name
+`cloudevents_type`:: CloudEvents type
+|Milliseconds
 
 |===
+
+[IMPORTANT]
+====
+Kafka subscription metrics continue to use milliseconds (not seconds) for duration measurements.
+====

--- a/modules/serverless-knative-kafka-trigger-metrics.adoc
+++ b/modules/serverless-knative-kafka-trigger-metrics.adoc
@@ -17,38 +17,38 @@ You can use the following metrics to debug and visualize the performance of Kafk
 |Tags
 |Unit
 
-|`event_count_1_total{job="kafka-broker-dispatcher-sm-service", namespace="knative-eventing"}`
+|`kn_eventing_dispatch_latency_ms_count{job="kafka-broker-dispatcher-sm-service", namespace="knative-eventing"}`
 |Number of events dispatched by a trigger to a subscriber
 |Counter
 a|
-`consumer_name`:: trigger name
-`namespace_name`:: trigger namespace
-`name`:: broker name
-`event_type`:: event type
-`response_code`:: HTTP response code returned by the trigger subscriber service
-`response_code_class`:: HTTP response code class returned by the trigger subscriber service: 2xx, 3xx, 4xx, 5xx
+`kn_trigger_name`:: trigger name
+`kn_trigger_namespace`:: trigger namespace
+`cloudevents_type`:: CloudEvents type
+`http_response_status_code`:: HTTP response code returned by the subscriber
 |Dimensionless
 
-|`event_dispatch_latencies_ms_bucket{job="kafka-broker-dispatcher-sm-service", namespace="knative-eventing"}`
+|`kn_eventing_dispatch_latency_ms_bucket{job="kafka-broker-dispatcher-sm-service", namespace="knative-eventing"}`
 |The time spent dispatching an event to a subscriber
 |Histogram
 a|
-`consumer_name`:: trigger name
-`namespace_name`:: trigger namespace
-`name`:: broker name
-`event_type`:: event type
-`response_code`:: HTTP response code returned by the trigger subscriber service
-`response_code_class`:: HTTP response code class returned by the trigger subscriber service: 2xx, 3xx, 4xx, 5xx
+`kn_trigger_name`:: trigger name
+`kn_trigger_namespace`:: trigger namespace
+`cloudevents_type`:: CloudEvents type
+`http_response_status_code`:: HTTP response code returned by the subscriber
 |Milliseconds
 
-|`event_processing_latencies_ms_bucket{job="kafka-broker-dispatcher-sm-service", namespace="knative-eventing"}`
+|`kn_eventing_process_latency_ms_bucket{job="kafka-broker-dispatcher-sm-service", namespace="knative-eventing"}`
 |The time spent processing and filtering an event
 |Histogram
 a|
-`consumer_name`:: trigger name
-`namespace_name`:: trigger namespace
-`name`:: broker name
-`event_type`:: event type
+`kn_trigger_name`:: trigger name
+`kn_trigger_namespace`:: trigger namespace
+`cloudevents_type`:: CloudEvents type
 |Milliseconds
 
 |===
+
+[IMPORTANT]
+====
+Kafka trigger metrics continue to use milliseconds (not seconds) for duration measurements.
+====

--- a/modules/serverless-queue-proxy-metrics.adoc
+++ b/modules/serverless-queue-proxy-metrics.adoc
@@ -19,33 +19,62 @@ You can use the following metrics to measure if requests are queued at the proxy
 |Tags
 |Unit
 
-|`revision_request_count`
+|`kn_serving_request_duration_seconds_count`
 |The number of requests that are routed to `queue-proxy` pod.
 |Counter
-|`configuration_name`, `container_name`, `namespace_name`, `pod_name`, `response_code`, `response_code_class`, `revision_name`, `service_name`
-|Integer (no units)
+a|
+`kn_configuration_name`:: configuration name
+`k8s_namespace_name`:: namespace
+`k8s_pod_name`:: pod name
+`http_response_status_code`:: HTTP response code
+`kn_revision_name`:: revision name
+`kn_service_name`:: service name
+|Dimensionless
 
-|`revision_request_latencies`
+|`kn_serving_request_duration_seconds_bucket`
 |The response time of revision requests.
 |Histogram
-|`configuration_name`, `container_name`, `namespace_name`, `pod_name`, `response_code`, `response_code_class`, `revision_name`, `service_name`
-|Milliseconds
+a|
+`kn_configuration_name`:: configuration name
+`k8s_namespace_name`:: namespace
+`k8s_pod_name`:: pod name
+`http_response_status_code`:: HTTP response code
+`kn_revision_name`:: revision name
+`kn_service_name`:: service name
+|Seconds
 
-|`revision_app_request_count`
+|`kn_serving_invocation_duration_seconds_count`
 |The number of requests that are routed to the `user-container` pod.
 |Counter
-|`configuration_name`, `container_name`, `namespace_name`, `pod_name`, `response_code`, `response_code_class`, `revision_name`, `service_name`
-|Integer (no units)
+a|
+`kn_configuration_name`:: configuration name
+`k8s_namespace_name`:: namespace
+`k8s_pod_name`:: pod name
+`http_response_status_code`:: HTTP response code
+`kn_revision_name`:: revision name
+`kn_service_name`:: service name
+|Dimensionless
 
-|`revision_app_request_latencies`
+|`kn_serving_invocation_duration_seconds_bucket`
 |The response time of revision app requests.
 |Histogram
-|`configuration_name`, `namespace_name`, `pod_name`, `response_code`, `response_code_class`, `revision_name`, `service_name`
-|Milliseconds
+a|
+`kn_configuration_name`:: configuration name
+`k8s_namespace_name`:: namespace
+`k8s_pod_name`:: pod name
+`http_response_status_code`:: HTTP response code
+`kn_revision_name`:: revision name
+`kn_service_name`:: service name
+|Seconds
 
-|`revision_queue_depth`
+|`kn_serving_queue_depth`
 | The current number of items in the `serving` and `waiting` queues. This metric is not reported if unlimited concurrency is configured.
 |Gauge
-|`configuration_name`, `event-display`, `container_name`, `namespace_name`, `pod_name`, `response_code_class`, `revision_name`, `service_name`
-|Integer (no units)
+a|
+`kn_configuration_name`:: configuration name
+`k8s_namespace_name`:: namespace
+`k8s_pod_name`:: pod name
+`kn_revision_name`:: revision name
+`kn_service_name`:: service name
+|Dimensionless
 |===

--- a/modules/serverless-queue-proxy-metrics.adoc
+++ b/modules/serverless-queue-proxy-metrics.adoc
@@ -19,33 +19,38 @@ You can use the following metrics to measure if requests are queued at the proxy
 |Tags
 |Unit
 
-|`revision_request_count`
-|The number of requests that are routed to `queue-proxy` pod.
-|Counter
-|`configuration_name`, `container_name`, `namespace_name`, `pod_name`, `response_code`, `response_code_class`, `revision_name`, `service_name`
-|Integer (no units)
-
-|`revision_request_latencies`
-|The response time of revision requests.
-|Histogram
-|`configuration_name`, `container_name`, `namespace_name`, `pod_name`, `response_code`, `response_code_class`, `revision_name`, `service_name`
-|Milliseconds
-
-|`revision_app_request_count`
+|`kn_serving_invocation_duration_seconds_count`
 |The number of requests that are routed to the `user-container` pod.
 |Counter
-|`configuration_name`, `container_name`, `namespace_name`, `pod_name`, `response_code`, `response_code_class`, `revision_name`, `service_name`
-|Integer (no units)
+a|
+`kn_configuration_name`:: configuration name
+`k8s_namespace_name`:: namespace
+`k8s_pod_name`:: pod name
+`http_response_status_code`:: HTTP response code
+`kn_revision_name`:: revision name
+`kn_service_name`:: service name
+|Dimensionless
 
-|`revision_app_request_latencies`
+|`kn_serving_invocation_duration_seconds_bucket`
 |The response time of revision app requests.
 |Histogram
-|`configuration_name`, `namespace_name`, `pod_name`, `response_code`, `response_code_class`, `revision_name`, `service_name`
-|Milliseconds
+a|
+`kn_configuration_name`:: configuration name
+`k8s_namespace_name`:: namespace
+`k8s_pod_name`:: pod name
+`http_response_status_code`:: HTTP response code
+`kn_revision_name`:: revision name
+`kn_service_name`:: service name
+|Seconds
 
-|`revision_queue_depth`
+|`kn_serving_queue_depth`
 | The current number of items in the `serving` and `waiting` queues. This metric is not reported if unlimited concurrency is configured.
 |Gauge
-|`configuration_name`, `event-display`, `container_name`, `namespace_name`, `pod_name`, `response_code_class`, `revision_name`, `service_name`
-|Integer (no units)
+a|
+`kn_configuration_name`:: configuration name
+`k8s_namespace_name`:: namespace
+`k8s_pod_name`:: pod name
+`kn_revision_name`:: revision name
+`kn_service_name`:: service name
+|Dimensionless
 |===

--- a/modules/serverless-viewing-knative-service-metrics-web-console.adoc
+++ b/modules/serverless-viewing-knative-service-metrics-web-console.adoc
@@ -37,7 +37,7 @@ Hello Go Sample v1!
 +
 [source]
 ----
-revision_app_request_count{namespace="ns1", job="helloworld-go-sm"}
+kn_serving_invocation_duration_seconds_count{k8s_namespace_name="ns1", job="helloworld-go-sm"}
 ----
 +
 Another example:


### PR DESCRIPTION
Version(s):
- `serverless-docs-1.38`

Issue:
- https://redhat.atlassian.net/browse/SRVCOM-4271

Link to docs preview:
- [Knative Eventing metrics](https://111029--ocpdocs-pr.netlify.app/openshift-serverless/latest/observability/admin-metrics/serverless-admin-metrics-eventing.html)
- [Knative Serving metrics](https://111029--ocpdocs-pr.netlify.app/openshift-serverless/latest/observability/admin-metrics/serverless-admin-metrics-serving.html)
- [Examining metrics of a service](https://111029--ocpdocs-pr.netlify.app/openshift-serverless/latest/observability/developer-metrics/serverless-monitoring-services-examining-metrics.html)

QE review:
- [ ] QE has approved this change.

Additional information:
