### PR TITLE
OCPBUGS-84720: Added missing steps to nw-aws-switching-clb-with-nlb.adoc

### DIFF
--- a/modules/nw-aws-replacing-clb-with-nlb.adoc
+++ b/modules/nw-aws-replacing-clb-with-nlb.adoc
@@ -11,11 +11,7 @@ To improve performance and reduce latency for traffic in {product-title} on {aws
 
 [WARNING]
 ====
-This procedure might cause the following issues:
-
-* An outage that can last several minutes due to new DNS records propagation, new load balancers provisioning, and other factors. IP addresses and canonical names of the Ingress Controller load balancer might change after applying this procedure.
-
-* Leaked load balancer resources due to a change in the annotation of the service.
+This procedure might cause an outage that can last several minutes due to new DNS records propagation, new load balancers provisioning, and other factors. IP addresses and canonical names of the Ingress Controller load balancer might change after applying this procedure.
 ====
 
 .Procedure

--- a/modules/nw-aws-switching-clb-with-nlb.adoc
+++ b/modules/nw-aws-switching-clb-with-nlb.adoc
@@ -13,11 +13,7 @@ Switching between these load balancers does not delete the `IngressController` o
 
 [WARNING]
 ====
-This procedure might cause the following issues:
-
-* An outage that can last several minutes due to new DNS records propagation, new load balancers provisioning, and other factors. IP addresses and canonical names of the Ingress Controller load balancer might change after applying this procedure.
-
-* Leaked load balancer resources due to a change in the annotation of the service.
+This procedure might cause an outage that can last several minutes due to new DNS records propagation, new load balancers provisioning, and other factors. IP addresses and canonical names of the Ingress Controller load balancer might change after applying this procedure.
 ====
 
 .Procedure
@@ -60,5 +56,29 @@ If your Ingress Controller has other customizations that you want to update, suc
 ----
 $ oc apply -f ingresscontroller.yaml
 ----
+
+. Check that the `Progressing` condition of the Ingress Controller is set to `True` by running the following command:
++
+[source,terminal]
+----
+$ oc get ingresscontroller default -n openshift-ingress-operator -o jsonpath='{.status.conditions[?(@.type=="Progressing")]}'
+----
+
+. Delete the service associated with the Ingress Controller by running the following command:
++
+[source,terminal]
+----
+$ oc -n openshift-ingress delete svc/router-<name>
+----
+* Replace `<name>` with the specific instance name of your Ingress Controller.
 +
 Expect several minutes of outages while the Ingress Controller updates.
+
+.Verification
+
+* Confirm that the Ingress Controller updated successfully by running the following command:
++
+[source,terminal]
+----
+$ oc get ingresscontroller -n openshift-ingress-operator default -o jsonpath="{.status.conditions}" | yq -PC
+----

--- a/modules/nw-aws-switching-nlb-with-clb.adoc
+++ b/modules/nw-aws-switching-nlb-with-clb.adoc
@@ -56,5 +56,29 @@ If your Ingress Controller has other customizations that you want to update, suc
 ----
 $ oc apply -f ingresscontroller.yaml
 ----
+
+. Check that the `Progressing` condition of the Ingress Controller is set to `True` by running the following command:
++
+[source,terminal]
+----
+$ oc get ingresscontroller default -n openshift-ingress-operator -o jsonpath='{.status.conditions[?(@.type=="Progressing")]}'
+----
+
+. Delete the service associated with the Ingress Controller by running the following command:
++
+[source,terminal]
+----
+$ oc -n openshift-ingress delete svc/router-<name>
+----
+* Replace `<name>` with the specific instance name of your Ingress Controller.
 +
 Expect several minutes of outages while the Ingress Controller updates.
+
+.Verification
+
+* Confirm that the Ingress Controller updated successfully by running the following command:
++
+[source,terminal]
+----
+$ oc get ingresscontroller -n openshift-ingress-operator default -o jsonpath="{.status.conditions}" | yq -PC
+----


### PR DESCRIPTION
Version(s):
4.22+

Issue:
[OCPBUGS-84720](https://redhat.atlassian.net/browse/OCPBUGS-84720)

Link to docs preview:
[Switching the Ingress Controller from using a Classic Load Balancer to a Network Load Balancer](https://111065--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ingress_load_balancing/configuring_ingress_cluster_traffic/configuring-ingress-cluster-traffic-aws.html#nw-aws-switching-clb-with-nlb_configuring-ingress-cluster-traffic-aws)

- [x] SME has approved this change (Grant Spence).
- [x] QE has approved this change (Melvin Joseph).
