### PR TITLE
OSDOCS-19446:Update the z-stream RNs for 4.18.39 and 4.18.40

### DIFF
--- a/modules/zstream-4-18-39.adoc
+++ b/modules/zstream-4-18-39.adoc
@@ -1,0 +1,37 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-18-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-18-39_{context}"]
+= RHSA-2026:12118 - {product-title} {product-version}.39 fixed issues and security update
+
+Issued: 06 May 2026
+
+[role="_abstract"]
+{product-title} release {product-version}.39 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2026:12118[RHSA-2026:12118] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-12069[RHBA-2026:12069] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.18.39 --pullspecs
+----
+
+[id="zstream-4-18-39-fixed-issues_{context}"]
+== Fixed issues
+
+* Before this update, the Baseboard Management Controller (BMC) firmware lacked a structured error response for `UserName` and `Password` parameters, which caused the BMC to reject ISO mounting during NVIDIA Deep GPU Xceleration (DGX) B200 node provisioning. As a consequence, automated provisioning failed. With this release, the firmware handling of credentials is updated, which adds handling for missing `UserName` and `Password` parameters in the Redfish `InsertMedia` response. As a result, Bare Metal Operator (BMO) and Ironic mounting failures are resolved and automated provisioning of NVIDIA DGX B200 nodes is enabled. (link:https://redhat.atlassian.net/browse/OCPBUGS-74407[OCPBUGS-74407])
+
+* Before this update, the etcd Operator randomly removed control plane nodes, which caused duplication and potential cluster downtime. As a consequence, service disruptions might have caused the loss of control plane nodes in the etcd cluster. With this release, the etcd Operator prioritizes removing members in the same failure domain index, which reduces potential duplication and improves cluster stability. As a result, the etcd Operator ensures that the control plane remains stable with three nodes, which prevents potential service disruptions. (link:https://issues.redhat.com/browse/OCPBUGS-78776[OCPBUGS-78776])
+
+* Before this update, Kube API server rollouts in clusters that had encrypted etcd caused transmission control protocol (TCP) reset (RST) storms. This behavior resulted in application pod traffic drops. With this release, the Kube API server rollouts do not cause traffic drops in encrypted clusters, which improves service stability.(link:https://redhat.atlassian.net/browse/OCPBUGS-81479[OCPBUGS-81479])
+
+* Before this update, DNS name rules in the `EgressFirewall` custom resource (CR) were not working correctly when an error was encountered during DNS name resolution or a zero TTL value was returned by the DNS name server. For both scenarios, the next lookup occurred only after 30 minutes. However, these scenarios could be transient and might have gotten resolved well before the next lookup. With this release, the lookup occurs every five seconds when an error is encountered during DNS name resolution or a zero TTL value is returned by the DNS name server. When an error is encountered during the DNS lookup, the lookup occurs with an exponential backoff after 10 retries, with the maximum backoff time capped at two minutes. (link:https://redhat.atlassian.net/browse/OCPBUGS-83567[OCPBUGS-83567])
+
+[id="zstream-4-18-39-updating_{context}"]
+== Updating
+
+To update an {product-title} 4.18 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].

--- a/modules/zstream-4-18-40.adoc
+++ b/modules/zstream-4-18-40.adoc
@@ -1,0 +1,31 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-18-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-18-40_{context}"]
+= RHSA-2026:13736 - {product-title} {product-version}.40 fixed issues and security update
+
+Issued: 06 May 2026
+
+[role="_abstract"]
+{product-title} release {product-version}.40 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2026:13736[RHSA-2026:13736] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2026:13726[RHBA-2026:13726] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.18.40 --pullspecs
+----
+
+[id="zstream-4-18-40-fixed-issues_{context}"]
+== Fixed issues
+
+There are no notable fixed issues in this release.
+
+[id="zstream-4-18-40-updating_{context}"]
+== Updating
+
+To update an {product-title} 4.18 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].

--- a/release_notes/ocp-4-18-release-notes.adoc
+++ b/release_notes/ocp-4-18-release-notes.adoc
@@ -3062,6 +3062,12 @@ As a workaround, you must manually reboot the failed host from the disk. (link:h
 // 4.18 about async
 include::modules/rn-async-errata.adoc[leveloffset=+1]
 
+// 4.18.40 RNs and updating
+include::modules/zstream-4-18-40.adoc[leveloffset=+2]
+
+// 4.18.39 RNs and updating
+include::modules/zstream-4-18-39.adoc[leveloffset=+2]
+
 // 4.18.38 RNs and updating
 include::modules/zstream-4-18-38.adoc[leveloffset=+2]
 


### PR DESCRIPTION
Version(s):
4.18

Issue:
https://redhat.atlassian.net/browse/OSDOCS-19446

Link to docs preview:

https://111073--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-18-release-notes.html#zstream-4-18-39_release-notes
https://111073--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-18-release-notes.html#zstream-4-18-40_release-notes

Additional information:
4.18.39 MR: https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/490
ART Dashboard: https://art-dash.engineering.redhat.com/dashboard/release/openshift-4.18

4.18.40 MR: https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/503
ART Dashboard: https://art-dash.engineering.redhat.com/dashboard/release/openshift-4.18

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->