### PR TITLE
TELCODOCS 2614 Extend the BGP/L2 Advertisements with ServiceSelectors

### DIFF
--- a/modules/nw-metallb-advertise-address-pool-with-bgp-advanced.adoc
+++ b/modules/nw-metallb-advertise-address-pool-with-bgp-advanced.adoc
@@ -7,7 +7,7 @@
 = Advertising an advanced address pool configuration with BGP
 
 [role="_abstract"]
-Configure MetalLB to advertise an advanced address pool by using the BGP.
+Configure MetalLB to advertise an advanced address pool by using BGP attributes such as BGP communities, route aggregation, and local preference.
 
 .Prerequisites
 

--- a/modules/nw-metallb-bgpadvertisement-cr.adoc
+++ b/modules/nw-metallb-bgpadvertisement-cr.adoc
@@ -29,11 +29,11 @@ The following table describes the parameters for the `BGPAdvertisements` CR:
 
 |`spec.aggregationLength`
 |`integer`
-|Optional: Specifies the number of bits to include in a 32-bit CIDR mask. To aggregate the routes that the speaker advertises to BGP peers, the mask is applied to the routes for several service IP addresses and the speaker advertises the aggregated route. For example, with an aggregation length of `24`, the speaker can aggregate several `10.0.1.x/32` service IP addresses and advertise a single `10.0.1.0/24` route.
+|Optional: Specifies the number of bits to include in a 32-bit CIDR mask. To aggregate the routes that the speaker advertises to BGP peers, the mask is applied to the routes for several service IP addresses and the speaker advertises the aggregated route. For example, with an aggregation length of `24`, the speaker can aggregate several `10.0.1.x/32` service IP addresses and advertise a single `10.0.1.0/24` route. If this `BGPAdvertisement` resource uses `spec.serviceSelectors` to limit the advertisement to labeled services, you must omit `aggregationLength` or set it to `32`; you cannot set another aggregation length on this same resource together with labeled service selection.
 
 |`spec.aggregationLengthV6`
 |`integer`
-|Optional: Specifies the number of bits to include in a 128-bit CIDR mask. For example, with an aggregation length of `124`, the speaker can aggregate several `fc00:f853:0ccd:e799::x/128` service IP addresses and advertise a single `fc00:f853:0ccd:e799::0/124` route.
+|Optional: Specifies the number of bits to include in a 128-bit CIDR mask. For example, with an aggregation length of `124`, the speaker can aggregate several `fc00:f853:0ccd:e799::x/128` service IP addresses and advertise a single `fc00:f853:0ccd:e799::0/124` route. If this `BGPAdvertisement` resource uses `spec.serviceSelectors` to limit the advertisement to labeled services, you must omit `aggregationLengthV6` or set it to `128`; you cannot set another aggregation length on this same resource together with labeled service selection.
 
 |`spec.communities`
 |`string`
@@ -42,11 +42,8 @@ The following table describes the parameters for the `BGPAdvertisements` CR:
 * `NO_EXPORT`: `65535:65281`
 * `NO_ADVERTISE`: `65535:65282`
 * `NO_EXPORT_SUBCONFED`: `65535:65283`
-+
-[NOTE]
-====
+
 You can also use community objects that are created along with the strings.
-====
 
 |`spec.localPref`
 |`integer`
@@ -59,6 +56,10 @@ You can also use community objects that are created along with the strings.
 |`spec.ipAddressPoolSelectors`
 |`string`
 |Optional: A selector for the `IPAddressPools` that gets advertised with this advertisement. This is for associating the `IPAddressPool` to the advertisement based on the label assigned to the `IPAddressPool` instead of the name itself. If no `IPAddressPool` is selected by this or by the list, the advertisement is applied to all the `IPAddressPools`.
+
+|`spec.serviceSelectors`
+|`array (LabelSelector)`
+|Optional: Kubernetes label selectors that determine which `LoadBalancer` services receive this advertisement's BGP policy for routes from the selected pools. If you omit `spec.serviceSelectors` or specify an empty list, MetalLB applies this advertisement to every `LoadBalancer` service that draws an IP address from the pools listed in `spec.ipAddressPools` or matched by `spec.ipAddressPoolSelectors`. You can use selectors to limit the advertisement to labeled services. On this `BGPAdvertisement` resource, if you use `spec.serviceSelectors` to limit the advertisement to labeled services, labeled service selection and custom BGP route aggregation are mutually exclusive: omit `spec.aggregationLength` and `spec.aggregationLengthV6` or set them to `32` (IPv4) and `128` (IPv6). You cannot set other aggregation lengths on this same resource together with labeled service selection.
 
 |`spec.nodeSelectors`
 |`string`

--- a/modules/nw-metallb-configure-l2-advertisement-label.adoc
+++ b/modules/nw-metallb-configure-l2-advertisement-label.adoc
@@ -7,9 +7,8 @@
 = Configuring MetalLB with an L2 advertisement and labels
 
 [role="_abstract"]
-You can use the `ipAddressPoolSelectors` field in the `BGPAdvertisement` and `L2Advertisement` custom resource definitions to associate the `IPAddressPool` to the advertisement. This association is based on the label assigned to the `IPAddressPool` instead of the name itself.
-
-The example in the procedure shows how to configure MetalLB so that the `IPAddressPool` is advertised with the L2 protocol by configuring the `ipAddressPoolSelectors` field.
+You can use the `ipAddressPoolSelectors` field in the `L2Advertisement` custom resource definition to associate the `IPAddressPool` with the advertisement based on the label assigned to the pool instead of the pool name.
+The example configures MetalLB to advertise the pool over Layer 2 by using `ipAddressPoolSelectors`.
 
 .Prerequisites
 

--- a/modules/nw-metallb-l2padvertisement-cr.adoc
+++ b/modules/nw-metallb-l2padvertisement-cr.adoc
@@ -7,7 +7,7 @@
 = About the L2Advertisement custom resource
 
 [role="_abstract"]
-To configure how application services are announced over a Layer 2 network, define the properties in the `L2Advertisement` custom resource (CR). Establishing these parameters ensures that MetalLB correctly manages routing for your load-balancer IP addresses within the local network infrastructure
+To configure how application services are announced over a Layer 2 network, define the properties in the `L2Advertisement` custom resource (CR). Establishing these parameters ensures that MetalLB correctly manages routing for your load-balancer IP addresses within the local network infrastructure.
 
 The following table details parameters for the `l2Advertisements` CR:
 
@@ -34,6 +34,10 @@ The following table details parameters for the `l2Advertisements` CR:
 |`spec.ipAddressPoolSelectors`
 |`string`
 |Optional: A selector for the `IPAddressPools` to advertise with this advertisement. This is for associating the `IPAddressPool` to the advertisement based on the label assigned to the `IPAddressPool` instead of the name itself. If no `IPAddressPool` is selected by this or by the list, the advertisement is applied to all the `IPAddressPools`.
+
+|`spec.serviceSelectors`
+|`array (LabelSelector)`
+|Optional: Kubernetes label selectors that determine which `LoadBalancer` services receive this advertisement's Layer 2 settings for addresses from the selected pools. If you omit `spec.serviceSelectors` or specify an empty list, MetalLB applies this advertisement to every `LoadBalancer` service that draws an IP address from the pools listed in `spec.ipAddressPools` or matched by `spec.ipAddressPoolSelectors`. You can use selectors to limit the advertisement to labeled services. On this `L2Advertisement` resource, if you use `spec.serviceSelectors` to limit the advertisement to labeled services, `LoadBalancer` services that use the `metallb.io/allow-shared-ip` annotation are not announced on Layer 2 when this advertisement matches those services. Do not combine that annotation with `serviceSelectors` for Layer 2.
 
 |`spec.nodeSelectors`
 |`string`

--- a/modules/nw-metallb-service-selectors-shared-pool-bgp.adoc
+++ b/modules/nw-metallb-service-selectors-shared-pool-bgp.adoc
@@ -1,0 +1,123 @@
+// Module included in the following assemblies:
+//
+// * networking/ingress_load_balancing/metallb/about-advertising-ipaddresspool.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="nw-metallb-service-selectors-shared-pool-bgp_{context}"]
+= Apply different BGP advertisement policies on a shared IP address pool
+
+[role="_abstract"]
+Use this procedure when many `BGPAdvertisement` resources reference the same `IPAddressPool` and each advertisement must apply different BGP settings to a different group of `LoadBalancer` services.
+You match services with `spec.serviceSelectors` so each advertisement applies only where its selectors match.
+
+.Prerequisites
+
+* You created the `IPAddressPool` that your advertisements reference (for example, `doc-example-bgp-adv`).
+
+.Procedure
+
+. Create two `BGPAdvertisement` resources that reference the same `IPAddressPool` but use different `serviceSelectors` and `localPref` values.
++
+The following example uses two `LoadBalancer` services that share one pool and use the labels `app: web` and `app: api`.
+It does not include a catch-all `BGPAdvertisement` with no `serviceSelectors`; for that behavior, see the description of `spec.serviceSelectors` in "About the BGPAdvertisement custom resource".
++
+[NOTE]
+====
+The label keys and values you set under `spec.serviceSelectors` must match the labels on each `LoadBalancer` service that should use this advertisement, and you must use the same keys and values consistently across both advertisement manifests in this procedure (for example, `app: web` and `app: api`).
+This procedure shows those selectors in the manifests first; add matching labels on your services in the next step.
+For how `spec.serviceSelectors` interacts with `spec.aggregationLength` on a `BGPAdvertisement` resource, see "About the BGPAdvertisement custom resource".
+====
++
+.. Create a file, such as `bgpadvertisement-web.yaml`, with content similar to the following example:
++
+[source,yaml]
+----
+apiVersion: metallb.io/v1beta1
+kind: BGPAdvertisement
+metadata:
+  name: bgpadvertisement-web
+  namespace: metallb-system
+spec:
+  ipAddressPools:
+  - doc-example-bgp-adv
+  localPref: 200
+  serviceSelectors:
+  - matchLabels:
+      app: web
+----
++
+where:
++
+`doc-example-bgp-adv`:: Specifies the name of the `IPAddressPool` that both advertisements share.
+`localPref`:: Specifies the BGP local preference for routes that this advertisement controls for matching services.
+`serviceSelectors`:: Specifies label selectors so MetalLB applies this advertisement only to `LoadBalancer` services whose labels include `app: web`.
++
+.. Apply the configuration by running the following command:
++
+[source,terminal]
+----
+$ oc apply -f bgpadvertisement-web.yaml
+----
++
+.. Create a file, such as `bgpadvertisement-api.yaml`, with content similar to the following example:
++
+[source,yaml]
+----
+apiVersion: metallb.io/v1beta1
+kind: BGPAdvertisement
+metadata:
+  name: bgpadvertisement-api
+  namespace: metallb-system
+spec:
+  ipAddressPools:
+  - doc-example-bgp-adv
+  localPref: 300
+  serviceSelectors:
+  - matchLabels:
+      app: api
+----
++
+where:
++
+`doc-example-bgp-adv`:: Specifies the same shared `IPAddressPool` name as the first advertisement.
+`localPref`:: Specifies the BGP local preference for routes that this advertisement controls for matching services.
+`serviceSelectors`:: Specifies label selectors so MetalLB applies this advertisement only to `LoadBalancer` services whose labels include `app: api`.
++
+.. Apply the configuration by running the following command:
++
+[source,terminal]
+----
+$ oc apply -f bgpadvertisement-api.yaml
+----
++
+A `LoadBalancer` service whose labels include `app: web` receives the BGP policy from `bgpadvertisement-web`, including `localPref` `200`.
+A service whose labels include `app: api` receives the BGP policy from `bgpadvertisement-api`, including `localPref` `300`.
+Each advertisement applies only to services that satisfy its `serviceSelectors`.
++
+For the same pattern for Layer 2 advertisements on a shared pool, see *Apply different Layer 2 advertisement policies on a shared IP address pool*.
+
+. Add labels to each `LoadBalancer` service that must match the advertisements.
++
+.. Label the service that should match `app: web` by running the following command:
++
+[source,terminal]
+----
+$ oc label service <service_web_name> app=web -n <project>
+----
++
+where:
++
+`<service_web_name>`:: Specifies the name of the `LoadBalancer` service.
+`<project>`:: Specifies the namespace that contains the service.
++
+.. Label the service that should match `app: api` by running the following command:
++
+[source,terminal]
+----
+$ oc label service <service_api_name> app=api -n <project>
+----
++
+where:
++
+`<service_api_name>`:: Specifies the name of the `LoadBalancer` service.
+`<project>`:: Specifies the namespace that contains the service.

--- a/modules/nw-metallb-service-selectors-shared-pool-l2.adoc
+++ b/modules/nw-metallb-service-selectors-shared-pool-l2.adoc
@@ -1,0 +1,120 @@
+// Module included in the following assemblies:
+//
+// * networking/ingress_load_balancing/metallb/about-advertising-ipaddresspool.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="nw-metallb-service-selectors-shared-pool-l2_{context}"]
+= Apply different Layer 2 advertisement policies on a shared IP address pool
+
+[role="_abstract"]
+Use this procedure when many `L2Advertisement` resources reference the same `IPAddressPool` and each advertisement must apply different Layer 2 settings to a different group of `LoadBalancer` services.
+You match services with `spec.serviceSelectors` so each advertisement applies only where its selectors match.
+
+.Prerequisites
+
+* You created the `IPAddressPool` that your advertisements reference (for example, `doc-example-l2-label`).
+
+.Procedure
+
+. Create two `L2Advertisement` resources that reference the same `IPAddressPool` but use different `serviceSelectors` so that each advertisement applies Layer 2 settings to a different group of services.
++
+The following example uses two `LoadBalancer` services that share one pool and use the labels `app: web` and `app: api`.
+It does not include a catch-all `L2Advertisement` with no `serviceSelectors`; for that behavior, see the description of `spec.serviceSelectors` in "About the L2Advertisement custom resource".
+Each manifest lists `ipAddressPools` and `serviceSelectors`; add other fields such as `interfaces` or `nodeSelectors` when your deployment requires them.
++
+[NOTE]
+====
+The label keys and values you set under `spec.serviceSelectors` must match the labels on each `LoadBalancer` service that should use this advertisement, and you must use the same keys and values consistently across both advertisement manifests in this procedure (for example, `app: web` and `app: api`).
+This procedure shows those selectors in the manifests first; add matching labels on your services in the next step.
+For how `spec.serviceSelectors` interacts with the `metallb.io/allow-shared-ip` annotation, see "About the L2Advertisement custom resource".
+====
++
+.. Create a file, such as `l2advertisement-web.yaml`, with content similar to the following example:
++
+[source,yaml]
+----
+apiVersion: metallb.io/v1beta1
+kind: L2Advertisement
+metadata:
+  name: l2advertisement-web
+  namespace: metallb-system
+spec:
+  ipAddressPools:
+  - doc-example-l2-label
+  serviceSelectors:
+  - matchLabels:
+      app: web
+----
++
+where:
++
+`doc-example-l2-label`:: Specifies the name of the `IPAddressPool` that both Layer 2 advertisements share.
+`serviceSelectors`:: Specifies label selectors so MetalLB applies this advertisement only to `LoadBalancer` services whose labels include `app: web`.
++
+.. Apply the configuration by running the following command:
++
+[source,terminal]
+----
+$ oc apply -f l2advertisement-web.yaml
+----
++
+.. Create a file, such as `l2advertisement-api.yaml`, with content similar to the following example:
++
+[source,yaml]
+----
+apiVersion: metallb.io/v1beta1
+kind: L2Advertisement
+metadata:
+  name: l2advertisement-api
+  namespace: metallb-system
+spec:
+  ipAddressPools:
+  - doc-example-l2-label
+  serviceSelectors:
+  - matchLabels:
+      app: api
+----
++
+where:
++
+`doc-example-l2-label`:: Specifies the same shared `IPAddressPool` name as the first Layer 2 advertisement.
+`serviceSelectors`:: Specifies label selectors so MetalLB applies this advertisement only to `LoadBalancer` services whose labels include `app: api`.
++
+.. Apply the configuration by running the following command:
++
+[source,terminal]
+----
+$ oc apply -f l2advertisement-api.yaml
+----
++
+A `LoadBalancer` service whose labels include `app: web` receives the Layer 2 settings from `l2advertisement-web`.
+A service whose labels include `app: api` receives the Layer 2 settings from `l2advertisement-api`.
+Each advertisement applies only to services that satisfy its `serviceSelectors`.
++
+For the same pattern for BGP on a shared pool, see *Apply different BGP advertisement policies on a shared IP address pool*.
+
+. Add labels to each `LoadBalancer` service that must match the advertisements.
++
+.. Label the service that should match `app: web` by running the following command:
++
+[source,terminal]
+----
+$ oc label service <service_web_name> app=web -n <project>
+----
++
+where:
++
+`<service_web_name>`:: Specifies the name of the `LoadBalancer` service.
+`<project>`:: Specifies the namespace that contains the service.
++
+.. Label the service that should match `app: api` by running the following command:
++
+[source,terminal]
+----
+$ oc label service <service_api_name> app=api -n <project>
+----
++
+where:
++
+`<service_api_name>`:: Specifies the name of the `LoadBalancer` service.
+`<project>`:: Specifies the namespace that contains the service.

--- a/networking/ingress_load_balancing/metallb/about-advertising-ipaddresspool.adoc
+++ b/networking/ingress_load_balancing/metallb/about-advertising-ipaddresspool.adoc
@@ -30,6 +30,9 @@ include::modules/nw-metallb-configure-bgp-advertisement-advanced.adoc[leveloffse
 // Advertising MetalLB with a BGP advertisement
 include::modules/nw-metallb-advertise-address-pool-with-bgp-advanced.adoc[leveloffset=+2]
 
+// BGP: service selectors when several advertisements share a pool
+include::modules/nw-metallb-service-selectors-shared-pool-bgp.adoc[leveloffset=+2]
+
 // Advertising IP address pools from a subset of nodes
 include::modules/nw-metallb-advertise-ip-pools-from-node-subset.adoc[leveloffset=+1]
 
@@ -41,6 +44,9 @@ include::modules/nw-metallb-configure-l2-advertisement.adoc[leveloffset=+1]
 
 // Configuring MetalLB with an L2 advertisement and labels
 include::modules/nw-metallb-configure-l2-advertisement-label.adoc[leveloffset=+1]
+
+// L2: service selectors when several advertisements share a pool
+include::modules/nw-metallb-service-selectors-shared-pool-l2.adoc[leveloffset=+1]
 
 // Configure MetalLB with an L2 advertisement using interface
 include::modules/nw-metallb-configure-l2-advertisement-interface.adoc[leveloffset=+1]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.22
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://redhat.atlassian.net/browse/TELCODOCS-2614
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
[About the BGPAdvertisement CR](https://111086--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ingress_load_balancing/metallb/about-advertising-ipaddresspool.html)
[Configuring MetalLB with an L2 advertisement and labels](https://111086--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ingress_load_balancing/metallb/about-advertising-ipaddresspool.html#nw-metallb-configure-with-L2-advertisement-label_about-advertising-ip-address-pool)
[About the L2Advertisement CR](https://111086--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ingress_load_balancing/metallb/about-advertising-ipaddresspool.html#nw-metallb-l2padvertisement-cr_about-advertising-ip-address-pool)
[Apply different advertisement policies on a shared IP address pool](https://111086--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ingress_load_balancing/metallb/about-advertising-ipaddresspool.html#nw-metallb-service-selectors-shared-pool_about-advertising-ip-address-pool)


<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
