### PR TITLE
updating headings for node-iso assembly

### DIFF
--- a/nodes/nodes/nodes-nodes-adding-node-iso.adoc
+++ b/nodes/nodes/nodes-nodes-adding-node-iso.adoc
@@ -49,14 +49,14 @@ This is useful if you want to add more than one node at a time, or if you are sp
 You can add a node by running the `oc adm node-image create` command with flags to specify your configurations.
 This is useful if you want to add only a single node at a time, and have only simple configurations to specify for that node.
 
-// Cluster configuration reference
-include::modules/adding-node-iso-configs.adoc[leveloffset=+1]
-
 // Adding one or more nodes using a configuration file
-include::modules/adding-node-iso-yaml.adoc[leveloffset=+2]
+include::modules/adding-node-iso-yaml.adoc[leveloffset=+1]
 
 // Adding a single node with command flags
-include::modules/adding-node-iso-flags.adoc[leveloffset=+2]
+include::modules/adding-node-iso-flags.adoc[leveloffset=+1]
+
+// Cluster configuration reference
+include::modules/adding-node-iso-configs.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 [id="additional-resources_{context}"]


### PR DESCRIPTION
Versions: 4.17+

Updating the heading structure of the "adding worker nodes to an on premise cluster" page, so that it more closely resembles the original structure (while still being DITA compliant)

No QE, only formatting changes (let me know if you feel differently)

Preview: [Adding worker nodes to an on-premise cluster](https://111095--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/nodes/nodes-nodes-adding-node-iso)