### PR TITLE
[WIP]OSDOCS-18468: Provide an option to trigger an image rebuild

### DIFF
--- a/hardware_enablement/kmm-kernel-module-management.adoc
+++ b/hardware_enablement/kmm-kernel-module-management.adoc
@@ -119,6 +119,13 @@ include::modules/kmm-checking-the-keys.adoc[leveloffset=+2]
 
 include::modules/kmm-signing-kmods-in-a-prebuilt-image.adoc[leveloffset=+1]
 
+// Added for OSDOCS-18465
+include::modules/kmm-specifying-files-to-sign.adoc[leveloffset=+1]
+
+include::modules/kmm-defining-full-paths.adoc[leveloffset=+2]
+
+include::modules/kmm-using-wildcard-and-glob-patterns.adoc[leveloffset=+2]
+
 include::modules/kmm-building-and-signing-a-kmod-image.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
@@ -193,6 +200,9 @@ include::modules/kmm-day1-machineconfigpool.adoc[leveloffset=+2]
 
 // Added TELCODOCS-2595
 include::modules/kmm-managing-day1-kmod-images.adoc[leveloffset=+1]
+
+// Added OSDOCS-18468
+include::modules/kmm-forcing-module-image-rebuilds.adoc[leveloffset=+1]
 
 include::modules/kmm-debugging-and-troubleshooting.adoc[leveloffset=+1]
 

--- a/modules/kmm-forcing-module-image-rebuilds.adoc
+++ b/modules/kmm-forcing-module-image-rebuilds.adoc
@@ -1,0 +1,74 @@
+// Module included in the following assemblies:
+//
+// * hardware_enablement/kmm-kernel-module-management.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="kmm-forcing-module-image-rebuilds_{context}"]
+= Forcing module image rebuilds
+
+[role="_abstract"]
+When using ephemeral image registries, such as those with temporary storage, Kernel Module Management (KMM) can get out of sync and it can appear that images exist in the registry when they've actually been deleted, causing node failures. You can mitigate this issue by using the optional `imageRebuildTriggerGeneration` counter field.
+
+When KMM builds a kmod image in-cluster, it first checks if the target image already exists in the registry. If the image exists, KMM skips the build. However, when using an image registry with ephemeral storage, a restart, node drain, or rollout can delete the registry contents.
+
+You can force Kernel Module Management (KMM) to reverify and rebuild module images when using ephemeral image registries by using the `imageRebuildTriggerGeneration` counter field in the `Module` and `ManagedClusterModule` CRs. This is useful when images no longer exist in the registry even though KMM assumes they do. When this counter's value changes, the system automatically clears cached image statuses and reverifies the image existence, potentially triggering rebuilds.
+
+.Procedure
+
+. If the `spec.imageRebuildTriggerGeneration` isn't set, you can set it to reverify and rebuild the image, as shown in the following `Module` example.
++
+[source,yaml]
+----
+apiVersion: kmm.sigs.x-k8s.io/v1beta1
+kind: Module
+metadata:
+  name: my-kmod
+spec:
+  imageRebuildTriggerGeneration: 1
+  moduleLoader:
+    container:
+      modprobe:
+        moduleName: my-kmod
+      kernelMappings:
+        - regexp: '^.+$'
+          containerImage: my-registry/my-kmod:${KERNEL_FULL_VERSION}
+          build:
+            dockerfileConfigMap:
+              name: my-kmod-dockerfile
+  selector:
+    node-role.kubernetes.io/worker: ""
+----
+
+. If needed, you can change this value to trigger KMM to compare it against the value stored in `status`. If KMM detects that the value differs from the `status` value, it clears all cached image statuses and reverifies that images actually exist in the registry. If the images are missing, KMM rebuilds them. 
++
+To change the value, increment the counter value for `spec.imageRebuildTriggerGeneration`, for example, from `1` to `2`, as shown in the following `Module` example. 
++
+[source,yaml]
+----
+apiVersion: kmm.sigs.x-k8s.io/v1beta1
+kind: Module
+metadata:
+  name: my-kmod
+spec:
+  imageRebuildTriggerGeneration: 2
+  moduleLoader:
+    container:
+      modprobe:
+        moduleName: my-kmod
+      kernelMappings:
+        - regexp: '^.+$'
+          containerImage: my-registry/my-kmod:${KERNEL_FULL_VERSION}
+          build:
+            dockerfileConfigMap:
+              name: my-kmod-dockerfile
+  selector:
+    node-role.kubernetes.io/worker: ""
+----
+
+
+
+
+
+
+
+


### PR DESCRIPTION
[MGMT-22332] KMM 2.6 Provide an option to trigger an image rebuild

Version(s):
4.21, 4.22

Issue:
https://redhat.atlassian.net/browse/OSDOCS-18468

Link to docs preview:
https://111103--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hardware_enablement/kmm-kernel-module-management.html#kmm-forcing-module-image-rebuilds_kernel-module-management-operator

Dev: @TomerNewman 
SME: @ybettan
QE review: @ybrodsky-rh 

    QE has approved this change.
