### PR TITLE
OSDOCS-19448: oc adm upgrade recommend docs

### DIFF
--- a/modules/oc-adm-upgrade-recommend-custom-alert.adoc
+++ b/modules/oc-adm-upgrade-recommend-custom-alert.adoc
@@ -1,0 +1,55 @@
+:_mod-docs-content-type: PROCEDURE
+[id="oc-adm-upgrade-recommend-custom-alert_{context}"]
+= Adding custom alerts to oc adm upgrade recommend command output
+
+[role="_abstract"]
+You can configure specific alerts to be checked by the `oc adm upgrade recommend` command, so that if they are firing they appear in the output of the command.
+To do this, add the `openShiftUpdatePrecheck` label to an alert and set it to true.
+
+.Procedure
+
+. Edit a `PrometheusRule` custom resource (CR) by running the following command:
++
+[source,terminal]
+----
+$ oc edit prometheusrule <rule_name> -n <namespace>
+----
++
+where:
+
+`<rule_name>`:: Specifies the name of the `PrometheusRule` CR.
+
+`<namespace>`:: Specifies the namespace that contains the CR.
+
+. Add the following snippet to the `labels` section of the alert you want to be checked by the `oc adm upgrade recommend` command:
++
+[source,yaml]
+----
+# ...
+     labels:
+       openShiftUpdatePrecheck: "true"
+# ...
+----
++
+.Example `PrometheusRule` CR with precheck label
+[source,yaml]
+----
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: storage-warning-alerts
+  namespace: openshift-monitoring
+spec:
+  groups:
+  - name: disk-usage-warnings
+    rules:
+    - alert: VolumeNearingCapacity
+      expr: (kubelet_volume_stats_used_bytes / kubelet_volume_stats_capacity_bytes) > 0.85
+      for: 15m
+      labels:
+        severity: warning
+        openShiftUpdatePrecheck: "true"
+      annotations:
+        summary: "Storage volume is over 85% full"
+        description: "The volume {{ $labels.persistentvolumeclaim }} in namespace {{ $labels.namespace }} is currently {{ $value | humanizePercentage }} full. This may cause issues during pod restarts or cluster updates."
+----

--- a/modules/oc-adm-upgrade-recommend.adoc
+++ b/modules/oc-adm-upgrade-recommend.adoc
@@ -1,0 +1,47 @@
+:_mod-docs-content-type: PROCEDURE
+[id="oc-adm-upgrade-recommend_{context}"]
+= Using the oc adm upgrade recommend command to identify update risks
+
+[role="_abstract"]
+To identify potential update risks before initiating a cluster update, you can use the `oc adm upgrade recommend` command.
+
+When you run the `oc adm upgrade recommend` command, the output displays the following information:
+
+* Any issues that cause the Cluster Version Operator to have a status of `Failing=True`
+* Any firing alerts that might be a cause for concern about a cluster update
+* Information about your current update channel and your cluster's update service
+* Recommended target versions and any relevant known issues associated with each version
+
+You can use the information provided by the output to make informed decisions about the state of your cluster. Examples include whether any critical cluster issues should be addressed before attempting an update, or which specific target version would have less risk for your cluster.
+
+.Prerequisites
+
+* You installed the latest version of {oc-first}.
+
+.Procedure
+
+* Identify potential update risks and view recommended update versions by running the following command:
++
+[source,terminal]
+----
+$ oc adm upgrade recommend
+----
++
+.Example output
+[source,terminal]
+----
+The following conditions found no cause for concern in updating this cluster to later releases: recommended/CriticalAlerts (AsExpected), recommended/NodeAlerts (AsExpected), recommended/PodDisruptionBudgetAlerts (AsExpected), recommended/PodImagePullAlerts (AsExpected), recommended/UpdatePrecheckAlerts (AsExpected)
+
+Upstream update service is unset, so the cluster will use an appropriate default.
+Channel: stable-4.21 (available channels: candidate-4.20, candidate-4.21, candidate-4.22, eus-4.20, fast-4.20, fast-4.21, stable-4.20, stable-4.21)
+
+Updates to 4.21:
+  VERSION     ISSUES
+  4.21.14     no known issues relevant to this cluster
+  4.21.13     no known issues relevant to this cluster
+And 2 older 4.21 updates you can see with '--show-outdated-releases' or '--version VERSION'.
+
+Updates to 4.20:
+  VERSION     ISSUES
+  4.20.20     no known issues relevant to this cluster
+----

--- a/modules/update-upgrading-cli.adoc
+++ b/modules/update-upgrading-cli.adoc
@@ -36,19 +36,20 @@ ifndef::openshift-origin[]
 .Example output
 [source,terminal]
 ----
-Failing=True:
+The following conditions found no cause for concern in updating this cluster to later releases: recommended/CriticalAlerts (AsExpected), recommended/NodeAlerts (AsExpected), recommended/PodDisruptionBudgetAlerts (AsExpected), recommended/PodImagePullAlerts (AsExpected), recommended/UpdatePrecheckAlerts (AsExpected)
 
-  Reason: ClusterOperatorNotAvailable
-  Message: Cluster operator monitoring is not available
-...
-Upstream update service: https://api.integration.openshift.com/api/upgrades_info/graph
-Channel: candidate-4.16 (available channels: candidate-4.16, candidate-4.17, candidate-4.18, eus-4.16, fast-4.16, fast-4.17, stable-4.16, stable-4.17)
+Upstream update service is unset, so the cluster will use an appropriate default.
+Channel: stable-4.21 (available channels: candidate-4.20, candidate-4.21, candidate-4.22, eus-4.20, fast-4.20, fast-4.21, stable-4.20, stable-4.21)
 
-Updates to 4.16:
+Updates to 4.21:
   VERSION     ISSUES
-  4.16.32     no known issues relevant to this cluster
-  4.16.30     no known issues relevant to this cluster
-And 2 older 4.16 updates you can see with '--show-outdated-releases' or '--version VERSION'.
+  4.21.14     no known issues relevant to this cluster
+  4.21.13     no known issues relevant to this cluster
+And 2 older 4.21 updates you can see with '--show-outdated-releases' or '--version VERSION'.
+
+Updates to 4.20:
+  VERSION     ISSUES
+  4.20.20     no known issues relevant to this cluster
 ----
 endif::openshift-origin[]
 ifdef::openshift-origin[]

--- a/updating/preparing_for_updates/updating-cluster-prepare.adoc
+++ b/updating/preparing_for_updates/updating-cluster-prepare.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="updating-cluster-prepare"]
-= Preparing to update to {product-title} 4.21
+= Preparing to update to {product-title} {product-version}
 include::_attributes/common-attributes.adoc[]
 :context: updating-cluster-prepare
 
@@ -35,6 +35,10 @@ include::modules/update-etcd-backup.adoc[leveloffset=+1]
 * xref:../../backup_and_restore/control_plane_backup_and_restore/backing-up-etcd.adoc#backup-etcd[Backing up etcd]
 
 * xref:../../backup_and_restore/control_plane_backup_and_restore/disaster_recovery/scenario-2-restoring-cluster-state.adoc#dr-restoring-cluster-state[Restoring to a previous cluster state]
+
+include::modules/oc-adm-upgrade-recommend.adoc[leveloffset=+1]
+
+include::modules/oc-adm-upgrade-recommend-custom-alert.adoc[leveloffset=+2]
 
 // Gateway API management succession
 include::modules/nw-ingress-gateway-api-manage-succession.adoc[leveloffset=+1]


### PR DESCRIPTION
[OSDOCS-19448](https://redhat.atlassian.net/browse/OSDOCS-19448)

Version(s): 4.22+

This PR adds docs for the `oc adm upgrade recommend` command to the "preparing to update" docs, including new functionality for the `openShiftUpdatePrecheck` label.

QE review:
- [x] QE has approved this change.

Preview: 

- [Using the oc adm upgrade recommend command to identify update risks](https://111110--ocpdocs-pr.netlify.app/openshift-enterprise/latest/updating/preparing_for_updates/updating-cluster-prepare.html#oc-adm-upgrade-recommend_updating-cluster-prepare)
- [Updating a cluster by using the CLI](https://111110--ocpdocs-pr.netlify.app/openshift-enterprise/latest/updating/updating_a_cluster/updating-cluster-cli.html#update-upgrading-cli_updating-cluster-cli) (Example output of step 1)