### PR TITLE
OCPBUGS-84366: Added note to nw-egress-ips-multi-nic-considerations

### DIFF
--- a/modules/nw-egress-ips-multi-nic-considerations.adoc
+++ b/modules/nw-egress-ips-multi-nic-considerations.adoc
@@ -6,7 +6,7 @@
 [id="nw-egress-ips-multi-nic-considerations_{context}"]
 = Considerations for using an egress IP address on additional network interfaces
 
-In {product-title}, egress IP addresses provide administrators a way to control network traffic. Egress IP addresses can be used with a `br-ex` Open vSwitch (OVS) bridge interface and any physical interface that has IP connectivity enabled.
+In {product-title}, egress IP addresses provide administrators a way to control network traffic. You can use egress IP addresses with a `br-ex` Open vSwitch (OVS) bridge interface. You can also use any physical interface that has IP connectivity enabled.
 
 You can inspect your network interface type by running the following command:
 
@@ -15,9 +15,9 @@ You can inspect your network interface type by running the following command:
 $ ip -details link show
 ----
 
-The primary network interface is assigned a node IP address which also contains a subnet mask. Information for this node IP address can be retrieved from the Kubernetes node object for each node within your cluster by inspecting the `k8s.ovn.org/node-primary-ifaddr` annotation. In an IPv4 cluster, this annotation is similar to the following example: `"k8s.ovn.org/node-primary-ifaddr: {"ipv4":"192.168.111.23/24"}"`.
+The primary network interface is assigned a node IP address which also contains a subnet mask. You can retrieve this node IP address information from the Kubnernetes node object. Inspect the `k8s.ovn.org/node-primary-ifaddr` annotation for each node in your cluster. In an IPv4 cluster, this annotation is similar to the following example: `"k8s.ovn.org/node-primary-ifaddr: {"ipv4":"192.168.111.23/24"}"`.
 
-If the egress IP address is not within the subnet of the primary network interface subnet, you can use an egress IP address on another Linux network interface that is not of the primary network interface type. By doing so, {product-title} administrators are provided with a greater level of control over networking aspects such as routing, addressing, segmentation, and security policies. This feature provides users with the option to route workload traffic over specific network interfaces for purposes such as traffic segmentation or meeting specialized requirements.
+If the egress IP address is not within the subnet of the primary network interface subnet, use another Linux network interface. This interface must not be of the primary network interface type. With this approach, an administrator can provide a greater level of control over networking aspects such as routing, addressing, segmentation, and security policies. With this feature, you can route workload traffic over specific network interfaces for purposes such as traffic segmentation or meeting specialized requirements.
 
 If the egress IP address is not within the subnet of the primary network interface, then the selection of another network interface for egress traffic might occur if they are present on a node.
 
@@ -36,8 +36,13 @@ As an administrator who wants an egress IP address and traffic to route over a p
 
 * You understand that if a network interface is removed or if the IP address and subnet mask which allows the egress IP address to be hosted on the interface is removed, reconfiguration of the egress IP address occurs. Consequently, the egress IP address might get assigned to another node and interface.
 
-* If you use an Egress IP address on a secondary network interface card (NIC), you must use the Node Tuning Operator to enable IP forwarding on the secondary NIC.
-
 * You configured a NIC with routes by ensuring a gateway exists in the main routing table. As a postinstallation task, Red Hat does not support configuring a NIC on a cluster that uses OVN-Kubernetes.
 
 * Routes associated with an egress interface get copied from the main routing table to the routing table that was created to support the Egress IP object. 
+
+* You can use an Egress IP address on a secondary network interface card (NIC). However, you must use the Node Tuning Operator to enable IP forwarding on the secondary NIC.
++
+[IMPORTANT]
+====
+Red{nbsp}Hat does not support EgressIP multi-NIC configurations when the target network interface is bound to a VRF instance.
+====

--- a/modules/nw-egress-ips-multi-nic-considerations.adoc
+++ b/modules/nw-egress-ips-multi-nic-considerations.adoc
@@ -7,7 +7,7 @@
 = Considerations for using an egress IP address on additional network interfaces
 
 [role="_abstract"]
-In {product-title}, egress IP addresses provide administrators a way to control network traffic. Egress IP addresses can be used with a `br-ex` Open vSwitch (OVS) bridge interface and any physical interface that has IP connectivity enabled.
+In {product-title}, egress IP addresses provide administrators a way to control network traffic. You can use egress IP addresses with a `br-ex` Open vSwitch (OVS) bridge interface. You can also use any physical interface that has IP connectivity enabled.
 
 You can inspect your network interface type by running the following command:
 
@@ -16,9 +16,9 @@ You can inspect your network interface type by running the following command:
 $ ip -details link show
 ----
 
-The primary network interface is assigned a node IP address which also contains a subnet mask. Information for this node IP address can be retrieved from the Kubernetes node object for each node within your cluster by inspecting the `k8s.ovn.org/node-primary-ifaddr` annotation. In an IPv4 cluster, this annotation is similar to the following example: `"k8s.ovn.org/node-primary-ifaddr: {"ipv4":"192.168.111.23/24"}"`.
+The primary network interface is assigned a node IP address which also contains a subnet mask. You can retrieve this node IP address information from the Kubnernetes node object. Inspect the `k8s.ovn.org/node-primary-ifaddr` annotation for each node in your cluster. In an IPv4 cluster, this annotation is similar to the following example: `"k8s.ovn.org/node-primary-ifaddr: {"ipv4":"192.168.111.23/24"}"`.
 
-If the egress IP address is not within the subnet of the primary network interface subnet, you can use an egress IP address on another Linux network interface that is not of the primary network interface type. By doing so, {product-title} administrators are provided with a greater level of control over networking aspects such as routing, addressing, segmentation, and security policies. This feature provides users with the option to route workload traffic over specific network interfaces for purposes such as traffic segmentation or meeting specialized requirements.
+If the egress IP address is not within the subnet of the primary network interface subnet, use another Linux network interface. This interface must not be of the primary network interface type. With this approach, an administrator can provide a greater level of control over networking aspects such as routing, addressing, segmentation, and security policies. With this feature, you can route workload traffic over specific network interfaces for purposes such as traffic segmentation or meeting specialized requirements.
 
 If the egress IP address is not within the subnet of the primary network interface, then the selection of another network interface for egress traffic might occur if they are present on a node.
 
@@ -26,7 +26,7 @@ You can determine which other network interfaces might support egress IP address
 
 [NOTE]
 ====
-OVN-Kubernetes provides a mechanism to control and direct outbound network traffic from specific namespaces and pods. This ensures that it exits the cluster through a particular network interface and with a specific egress IP address.
+By using OVN-Kubernetes, you can control how outbound traffic leaves the cluster. You can configure traffic from specific namespaces or pods to exit through a chosen network interface and use a designated egress IP address. This configuration routes application traffic over specific network paths, providing better network isolation and traffic management.
 ====
 
 As an administrator who wants an egress IP address and traffic to route over a particular interface that is not the primary network interface, you must meet the following conditions:
@@ -37,8 +37,13 @@ As an administrator who wants an egress IP address and traffic to route over a p
 
 * You understand that if a network interface is removed or if the IP address and subnet mask which allows the egress IP address to be hosted on the interface is removed, reconfiguration of the egress IP address occurs. Consequently, the egress IP address might get assigned to another node and interface.
 
-* If you use an Egress IP address on a secondary network interface card (NIC), you must use the Node Tuning Operator to enable IP forwarding on the secondary NIC.
-
 * You configured a NIC with routes by ensuring a gateway exists in the main routing table. As a postinstallation task, Red Hat does not support configuring a NIC on a cluster that uses OVN-Kubernetes.
 
 * Routes associated with an egress interface get copied from the main routing table to the routing table that was created to support the Egress IP object. 
+
+* You can use an Egress IP address on a secondary network interface card (NIC). However, you must use the Node Tuning Operator to enable IP forwarding on the secondary NIC.
++
+[IMPORTANT]
+====
+Red{nbsp}Hat does not support EgressIP multi-NIC configurations when the target network interface is bound to a VRF instance.
+====


### PR DESCRIPTION
## Version(s):
4.18+

## Issue:
[OCPBUGS-84366](https://redhat.atlassian.net/browse/OCPBUGS-84366)

## Link to docs preview:
* [Considerations for using an egress IP address on additional network interfaces](https://111122--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/configuring-egress-ips-ovn.html#nw-egress-ips-multi-nic-considerations_configuring-egress-ips-ovn)
* [Configuring an egress IP address ](https://111122--ocpdocs-pr.netlify.app/openshift-rosa/latest/networking/ovn_kubernetes_network_provider/configuring-egress-ips-ovn.html)

- [x] SME has approved this change (Ramesh Sahoo).
- [x] QE has approved this change (Ramesh Sahoo).

## Additional information:

Summary of changes:

File: modules/nw-egress-ips-multi-nic-considerations.adoc (+11/-6)
    - Clarity improvements: Rewrote several sentences for better readability, breaking up complex statements and using more direct language
    - Note enhancement: Expanded the OVN-Kubernetes note to better explain how administrators can control outbound traffic routing through specific network interfaces
    - Content reorganization: Moved the Node Tuning Operator requirement to the end of the list and converted it to a bullet with attached block
    - New important admonition: Added a critical limitation stating Red Hat does not support EgressIP multi-NIC configurations when the target network interface is bound to a VRF instance
    - Typo fix: Corrected "Kubnernetes" to "Kubernetes"
