### PR TITLE
[OSDOCS-17114] Fixes a few nits in MS short descriptions

### DIFF
--- a/modules/microshift-cri-o-container-runtime.adoc
+++ b/modules/microshift-cri-o-container-runtime.adoc
@@ -7,7 +7,7 @@
 = Using a proxy in the CRI-O container runtime
 
 [role="_abstract"]
-To use an HTTP or HTTPS proxy in a CRI-O container runtime on a {product-title} node, you can add a systemd `Service` drop-in file that defines the `HTTP_PROXY`, `HTTPS_PROXY`, and optional `NO_PROXY` environment variables. You can reload systemd, restart `crio`, and restart the {microshift-short} service so the proxy settings apply.
+To use an HTTP or HTTPS proxy in CRI-O, you can add a systemd `Service` drop-in file that defines the `HTTP_PROXY`, `HTTPS_PROXY`, and optional `NO_PROXY` environment variables. You can reload systemd, restart `crio`, and restart the {microshift-short} service so the proxy settings apply.
 
 .Procedure
 

--- a/modules/microshift-restart-ovnkube-master.adoc
+++ b/modules/microshift-restart-ovnkube-master.adoc
@@ -7,7 +7,7 @@
 = Restarting the ovnkube-master pod
 
 [role="_abstract"]
-To restart the `ovnkube-master` pod on {product-title}, you can delete the `ovnkube-master` pod in the `openshift-ovn-kubernetes` namespace.
+To restart the `ovnkube-master` pod on {microshift-short}, you can delete the `ovnkube-master` pod in the `openshift-ovn-kubernetes` namespace.
 
 .Prerequisites
 


### PR DESCRIPTION
I want to revert the short description in the CRI-O file to a closer state to its original. Original state can be found here: https://github.com/openshift/openshift-docs/pull/110884/changes

Version(s):
4.20+

Issue:
https://redhat.atlassian.net/browse/OSDOCS-17114

Follow up to https://github.com/openshift/openshift-docs/pull/110884

Preview: 
https://111137--ocpdocs-pr.netlify.app/microshift/latest/microshift_networking/microshift-networking-settings.html