### PR TITLE
OCPBUGS-55773: Add link to OpenShift AI RDMA documentation

### DIFF
--- a/networking/hardware_networks/using-dpdk-and-rdma.adoc
+++ b/networking/hardware_networks/using-dpdk-and-rdma.adoc
@@ -62,6 +62,8 @@ include::modules/nw-openstack-ovs-dpdk-testpmd-pod.adoc[leveloffset=+1]
 
 * link:https://catalog.redhat.com/en/hardware[Red Hat certified hardware (Red Hat Ecosystem Catalog)]
 
+* link:https://docs.redhat.com/en/documentation/red_hat_openshift_ai_self-managed/latest/html/managing_openshift_ai/managing-distributed-workloads_managing-rhoai#configuring-a-cluster-for-rdma_managing-rhoai[Configuring a cluster for RDMA in {rhoai-full}]
+
 * xref:../../scalability_and_performance/cnf-tuning-low-latency-nodes-with-perf-profile.adoc#cnf-create-performance-profiles_cnf-tuning-low-latency-nodes-with-perf-profile[Creating a performance profile]
 
 * xref:../../scalability_and_performance/cnf-tuning-low-latency-nodes-with-perf-profile.adoc#adjusting-nic-queues-with-the-performance-profile_cnf-tuning-low-latency-nodes-with-perf-profile[Adjusting the NIC queues with the performance profile]


### PR DESCRIPTION
## Description
This PR adds a link to the Red Hat OpenShift AI RDMA configuration documentation in the Additional resources section of the OpenShift RDMA documentation.

## Problem
Customers searching for NVIDIA GPUDirect RDMA documentation for AI workloads often land on the OpenShift RDMA documentation but are actually looking for the OpenShift AI-specific RDMA configuration guide.

## Solution
Added a link to the OpenShift AI RDMA configuration guide in the Additional resources section to help direct customers to the appropriate documentation for AI/GPU workloads.

## VERSIONS
4.16+

## JIRA
https://redhat.atlassian.net/browse/OCPBUGS-55773

## REVIEWERS

Ben Schmaus (dev engineer)
Guy Gordani (Quality engineer)