### PR TITLE
OSDOCS-19488 adding osImageStream parameter

### DIFF
--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -890,6 +890,11 @@ endif::openshift-origin,ibm-power-vs[]
 
 *Value:* Array of strings
 
+|osImageStream:
+|Specifies the image stream that will be used for all machines in the cluster. `osImageStream` is a Technology Preview feature. Technology Preview features are not supported with Red Hat production service level agreements (SLAs) and might not be functionally complete. Red Hat does not recommend using them in production. These features provide early access to upcoming product features, enabling customers to test functionality and provide feedback during the development process.
+
+*Value:* String. Valid values are `rhel-9` or `rhel-10`.
+
 ifndef::openshift-origin[]
 ifdef::aws[]
 |platform:


### PR DESCRIPTION
Version(s):
4.22+

Issue:
https://redhat.atlassian.net/browse/OSDOCS-19488

Link to docs preview:
https://111145--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/installation-config-parameters-aws#installation-configuration-parameters-optional_installation-config-parameters-aws

QE review:
- [x] QE has approved this change.
