### PR TITLE
OSDOCS-19488 adding RHEL10 install release note

### DIFF
--- a/modules/rn-ocp-release-notes-new-features.adoc
+++ b/modules/rn-ocp-release-notes-new-features.adoc
@@ -138,6 +138,12 @@ N4A Virtual Machines (VMs) use highly efficient Arm-based processors. N4A machin
 +
 For more information, see xref:../installing/installing_gcp/installing-gcp-customizations.adoc#installation-gcp-tested-machine-types_installing-gcp-customizations[Tested instance types for {gcp-full}] and link:https://docs.cloud.google.com/compute/docs/general-purpose-machines#n4a_series[N4A machine series (Google documentation)].
 
+Installing a cluster using {op-system-base-full} 10::
++
+With this update, you can install a cluster using {op-system-base} version 10 as the base image for all machines in the cluster. This feature is available as a Technology Preview. To enable this feature, enable the `TechPreviewNoUpgrade` feature set and set the `osImageStream` parameter to `rhel-10` in your `install-config.yaml` file.
++
+For more information, see xref:../installing/install_config/installation-config-parameters-generic.adoc#installation-config-parameters-generic[Installation configuration parameters].
+
 [id="ocp-release-notes-machine-config-operator_{context}"]
 == Machine Config Operator
 

--- a/modules/rn-ocp-release-notes-technology-preview.adoc
+++ b/modules/rn-ocp-release-notes-technology-preview.adoc
@@ -118,6 +118,11 @@ In the following tables, features are marked with the following statuses:
 |Technology Preview
 |
 
+|Installing a cluster using {op-system-base-full} 10
+|Not Available
+|Not Available
+|Technology Preview
+
 |Dedicated disk for etcd on {azure-full}
 |Technology Preview
 |Technology Preview


### PR DESCRIPTION
Version(s):
4.22

Issue:
https://redhat.atlassian.net/browse/OSDOCS-19488

Link to docs preview:
[Release note](https://111146--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-22-release-notes#ocp-release-notes-install-update_release-notes)
[Tech preview table](https://111146--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-22-release-notes#ocp-release-notes-installing-tech-preview_release-notes)

QE review:
- [x] QE has approved this change.