### PR TITLE
Fix indents for parameter descriptions

### DIFF
--- a/modules/nw-metallb-frr-k8s-configuration-crd.adoc
+++ b/modules/nw-metallb-frr-k8s-configuration-crd.adoc
@@ -12,7 +12,8 @@ To customize routing behavior beyond standard MetalLB capabilities, configure th
 The following reference examples demonstrate how to define specific FRRouting (FRR) parameters to enable advanced services, such as receiving routes:
 
 The `routers` parameter::
-
++
+--
 You can use the `routers` parameter to configure multiple routers, one for each Virtual Routing and Forwarding (VRF) resource. For each router, you must define the Autonomous System Number (ASN).
 
 You can also define a list of Border Gateway Protocol (BGP) neighbors to connect to, as in the following example:
@@ -39,9 +40,11 @@ spec:
         port: 179
 # ...
 ----
+--
 
 The `toAdvertise` parameter::
-
++
+--
 By default, `FRR-K8s` does not advertise the prefixes configured as part of a router configuration. To advertise the prefixes, you use the `toAdvertise` parameter.
 
 You can advertise a subset of the prefixes, as in the following example:
@@ -102,9 +105,11 @@ spec:
 # ...
 ----
 * `allowed.mode`: Advertises all prefixes.
+--
 
 The `toReceive` parameter::
-
++
+--
 By default, `FRR-K8s` does not process any prefixes advertised by a neighbor. You can use the `toReceive` parameter to process such addresses.
 
 You can configure for a subset of the prefixes, as in this example:
@@ -159,9 +164,11 @@ spec:
               mode: all
 # ...
 ----
+--
 
 The `bgp` parameter::
-
++
+--
 You can use the `bgp` parameter to define various `BFD` profiles and associate them with a neighbor. In the following example, `BFD` backs up the `BGP` session and `FRR` can detect link failures:
 
 .Example FRRConfiguration CR
@@ -185,9 +192,11 @@ spec:
       - name: defaultprofile
 # ...
 ----
+--
 
 The `nodeSelector` parameter::
-
++
+--
 By default, `FRR-K8s` applies the configuration to all nodes where the daemon is running.
 You can use the `nodeSelector` parameter to specify the nodes to which you want to apply the configuration. For example:
 
@@ -208,9 +217,11 @@ spec:
     foo: "bar"
 # ...
 ----
+--
 
 The `interface` parameter::
-
++
+--
 You can use the `interface` parameter to configure unnumbered BGP peering by using the following example configuration:
 
 .Example `FRRConfiguration` CR
@@ -255,6 +266,7 @@ To use the `interface` parameter, you must establish a point-to-point, layer 2 c
 
 If you use this parameter, you cannot specify a value in the `spec.bgp.routers.neighbors.address` parameter.
 ====
+--
 
 The parameters for the `FRRConfiguration` custom resource are described in the following table:
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

Refs https://github.com/openshift/openshift-docs/pull/109988/changes#diff-c5f030b01cd2cd8d254ea7a67f6ef031f37539b2fc8802b062be726c7782bb23L14

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
