### PR TITLE
OSDOCS-19494: fixes version attribute

### DIFF
--- a/_attributes/attributes-openshift-dedicated.adoc
+++ b/_attributes/attributes-openshift-dedicated.adoc
@@ -8,7 +8,7 @@
 :imagesdir: images
 :OCP: OpenShift Container Platform
 :OCP-short: OpenShift
-:ocp-version: 4.18
+:ocp-version: 4.16
 :op-system-first: Red Hat Enterprise Linux CoreOS (RHCOS)
 :oc-first: pass:quotes[OpenShift CLI (`oc`)]
 :cluster-manager-first: Red Hat OpenShift Cluster Manager


### PR DESCRIPTION
Version(s):
4.16 only

Issue:
[OSDOCS-19494](https://redhat.atlassian.net/browse/OSDOCS-19494)

Link to docs preview:
N/A

Additional information:
fixes wrong-version attribute update in https://github.com/openshift/openshift-docs/pull/103368
<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
