### PR TITLE
RHDEVDOCS-7523-new: Minor changes to GitOps 1.20.3 RN

### DIFF
--- a/modules/gitops-release-notes-1-20-3.adoc
+++ b/modules/gitops-release-notes-1-20-3.adoc
@@ -13,13 +13,13 @@
 [id="errata-updates-1-20-3_{context}"]
 == Errata updates
 
-[id="RHSA-XXXX:NNNN-gitops-1-20-3-security-update-advisory_{context}"]
-RHSA-XXXX:NNNN - {gitops-title} 1.20.3 security update advisory::
+[id="RHBA-2026:12433-gitops-1-20-3-enhancement-update-advisory_{context}"]
+RHBA-2026:12433 - {gitops-title} 1.20.3 enhancement update advisory::
 Issued: 2026-04-28
 +
 The list of enhancements that are included in this release is documented in the following advisory:
 +
-* link:https://access.redhat.com/errata/RHSA-XXXX:NNNN[RHSA-XXXX:NNNN]
+* link:https://access.redhat.com/errata/RHBA-2026:12433[RHBA-2026:12433]
 
 If you have installed the {gitops-title} Operator in the default namespace, run the following command to view the container images in this release:
 


### PR DESCRIPTION
This PR is for updating the GitOps 1.20.3 RN with the missing errata information.