### PR TITLE
OSDOCS-18637: updates abstract per CP review

### DIFF
--- a/modules/nw-additional-network-considerations.adoc
+++ b/modules/nw-additional-network-considerations.adoc
@@ -14,6 +14,6 @@ Isolating network traffic is useful for the following performance and security r
 Performance:: You can send traffic on two different planes to manage how much traffic is along each plane.
 Security:: You can send sensitive traffic onto a network plane that is managed specifically for security considerations, and you can separate private data that must not be shared between tenants or customers.
 
-All of the pods in the cluster still use the cluster-wide default network to maintain connectivity across the cluster. Every pod has an `eth0` interface that is attached to the cluster-wide pod network. You can view the interfaces for a pod by using the `oc exec -it <pod_name> \-- ip a` command. If you add additional network interfaces that use Multus CNI, they are named `net1`, `net2`, ..., `netN`.
+All of the pods in the cluster still use the cluster-wide default network to maintain connectivity across the cluster. Every pod has an `eth0` interface that is attached to the cluster-wide pod network. You can view the interfaces for a pod by using the `oc exec -it <pod_name> \-- ip a` command. If you add additional network interfaces that use Multus CNI, they are named `net1`, `net2`, and so on.
 
 To attach additional network interfaces to a pod, you must create configurations that define how the interfaces are attached. You specify each interface by using a `NetworkAttachmentDefinition` custom resource (CR). A CNI configuration inside each of these CRs defines how that interface is created.

--- a/networking/multiple_networks/understanding-multiple-networks.adoc
+++ b/networking/multiple_networks/understanding-multiple-networks.adoc
@@ -7,7 +7,7 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 [role="_abstract"]
-{product-title} administrators and users can use user-defined networks (UDNs) or `NetworkAttachmentDefinition` (NADs) to define the networks that handle all of the ordinary network traffic of the cluster.
+{product-title} administrators and users can use `NetworkAttachmentDefinition` (NADs) to define the networks that handle all of the ordinary network traffic of the cluster.
 
 include::modules/nw-multus-understanding-con.adoc[leveloffset=+1]
 


### PR DESCRIPTION
Version(s):
enterprise-4.16

Issue:
[OSDOCS-18637](https://redhat.atlassian.net/browse/OSDOCS-18637)

Link to docs preview:
https://111179--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/multiple_networks/understanding-multiple-networks.html

QE review:
- N/A

Additional information:
Removes mention of UDN from the manual 4.16 CP of https://github.com/openshift/openshift-docs/pull/103471
UDN was TP in 4.17 and GA in 4.18.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
