### PR TITLE
[OSDOCS#17047] CPMSO CQA follow-up - MACH-5

### DIFF
--- a/machine_management/control_plane_machine_management/cpmso-troubleshooting.adoc
+++ b/machine_management/control_plane_machine_management/cpmso-troubleshooting.adoc
@@ -7,7 +7,7 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 [role="_abstract"]
-Use the information in this section to understand and recover from issues you might encounter.
+Use the following information to understand and recover from issues you might encounter.
 
 //Checking the control plane machine set custom resource status
 include::modules/cpmso-checking-status.adoc[leveloffset=+1]


### PR DESCRIPTION
Tweak to remove self-referential language in a troubleshooting module.

Version(s): 4.20+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [OSDOCS-17047](https://redhat.atlassian.net/browse/OSDOCS-17047)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] ~~QE has approved this change.~~
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
