### PR TITLE
[OSSMDOCS] OSSM-12507: Adding Ambient-Sidecar Coexistence for OSSM

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -74,6 +74,8 @@ Topics:
   File: ossm-sidecar-injection
 - Name: Istio ambient mode
   File: ossm-istio-ambient-mode
+- Name: Ambient and sidecar mode coexistence
+  File: ossm-ambient-sidecar-coexistence
 - Name: Red Hat OpenShift Service Mesh and cert-manager
   File: ossm-cert-manager
 - Name: Multi-Cluster topologies

--- a/install/ossm-ambient-sidecar-coexistence.adoc
+++ b/install/ossm-ambient-sidecar-coexistence.adoc
@@ -7,7 +7,7 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 [role="_abstract"]
-{SMProductName} supports running sidecar and ambient workloads in the same {istio} mesh. Use this capability to migrate workloads incrementally or to keep specific workloads in sidecar mode when they depend on features that ambient mode does not yet support.
+{SMProductName} supports running sidecar and ambient workloads in the same {istio} mesh. Use this capability to migrate workloads incrementally or to keep specific workloads in sidecar mode when they depend on features that ambient mode does not yet support (as described in the Limitations section).
 
 include::modules/ossm-about-ambient-sidecar-coexistence.adoc[leveloffset=+1]
 

--- a/install/ossm-ambient-sidecar-coexistence.adoc
+++ b/install/ossm-ambient-sidecar-coexistence.adoc
@@ -1,0 +1,28 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="ossm-ambient-sidecar-coexistence"]
+= Ambient and sidecar mode coexistence
+include::_attributes/common-attributes.adoc[]
+:context: ossm-ambient-sidecar-coexistence
+
+toc::[]
+
+[role="_abstract"]
+{SMProductName} supports running sidecar and ambient workloads in the same {istio} mesh. Use this capability to migrate workloads incrementally or to keep specific workloads in sidecar mode when they depend on features that ambient mode does not yet support.
+
+include::modules/ossm-about-ambient-sidecar-coexistence.adoc[leveloffset=+1]
+
+include::modules/ossm-enabling-ambient-on-existing-sidecar-mesh.adoc[leveloffset=+1]
+
+include::modules/ossm-enabling-sidecar-on-existing-ambient-mesh.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+[id="additional-resources-ossm-ambient-sidecar-coexistence_{context}"]
+== Additional resources
+
+* xref:ossm-istio-ambient-mode.adoc#ossm-istio-ambient-mode[Istio ambient mode]
+
+* xref:ossm-sidecar-injection.adoc#ossm-sidecar-injection[Sidecar injection]
+
+* link:https://docs.redhat.com/en/documentation/openshift_container_platform/latest/html/ovn-kubernetes_network_plugin/configuring-gateway-mode[Configuring gateway mode]
+
+* link:https://istio.io/latest/docs/ambient/usage/add-workloads/[Adding workloads to a mesh in ambient mode (Istio documentation)]

--- a/modules/ossm-about-ambient-sidecar-coexistence.adoc
+++ b/modules/ossm-about-ambient-sidecar-coexistence.adoc
@@ -7,7 +7,7 @@
 = About ambient and sidecar coexistence
 
 [role="_abstract"]
-Sidecar-injected pods and ambient pods share a single control plane. The `{istio}` CR must use `profile: ambient`. Workloads in different modes must be in separate namespaces. A namespace must not carry both the `istio-injection: enabled` label and the `istio.io/dataplane-mode: ambient` label; if both are present, sidecar injection takes precedence.
+Sidecar-injected pods and ambient pods share a single control plane. The `{istio}` CR must use `profile: ambient`. Red Hat recommends keeping workloads in different modes in separate namespaces to make the data plane mode of each workload explicit and to avoid label conflicts. A namespace must not carry both the `istio-injection: enabled` label and the `istio.io/dataplane-mode: ambient` label; if both are present, sidecar injection takes precedence.
 
 [NOTE]
 ====
@@ -56,6 +56,16 @@ The following features work when sidecar and ambient workloads coexist in the sa
 [id="ossm-about-ambient-sidecar-coexistence-limitations_{context}"]
 == Limitations
 
+*VirtualService features not supported in ambient mode*
+
+Some `VirtualService` features have no equivalent in the Gateway API that ambient mode uses for L7 policy. Workloads that depend on any of the following features must remain in sidecar mode.
+
+* `HTTPFaultInjection`
+* JWT claim-based routing
+* Delegate rules
+* Rate limiting
+* `ignoreCase` for path matching
+
 *L7 policy enforcement from sidecar to ambient workloads*
 
 When a sidecar pod sends traffic to an ambient pod that has a waypoint proxy configured, the traffic bypasses the waypoint proxy. Only L4 authorization policies are enforced in this direction; L7 policies, such as HTTP-based `AuthorizationPolicy` rules and `VirtualService` routing, do not apply to that traffic path. Routing decisions are made by the client-side sidecar proxy, not the waypoint.
@@ -68,16 +78,6 @@ Traffic from an ingress gateway to an ambient service does not traverse the wayp
 
 * The `ENABLE_INGRESS_WAYPOINT_ROUTING` environment variable is set to `true` in the `spec.values.pilot.env` field of the `{istio}` CR. This setting defaults to `false`. For more information, see link:https://istio.io/latest/docs/reference/commands/pilot-discovery/#enable-ingress-waypoint-routing[ENABLE_INGRESS_WAYPOINT_ROUTING (Istio documentation)].
 * The service or namespace has the `istio.io/ingress-use-waypoint: "true"` label applied.
-
-*VirtualService features with no Gateway API counterpart*
-
-Some `VirtualService` features have no equivalent in the Gateway API that ambient mode uses for L7 policy. Workloads that depend on any of the following features must remain in sidecar mode.
-
-* `HTTPFaultInjection`
-* JWT claim-based routing
-* Delegate rules
-* Rate limiting
-* `ignoreCase` for path matching
 
 [id="ossm-about-ambient-sidecar-coexistence-best-practices_{context}"]
 == Best practices

--- a/modules/ossm-about-ambient-sidecar-coexistence.adoc
+++ b/modules/ossm-about-ambient-sidecar-coexistence.adoc
@@ -1,0 +1,125 @@
+// Module included in the following assemblies:
+//
+// * service-mesh-docs-main/install/ossm-ambient-sidecar-coexistence.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="ossm-about-ambient-sidecar-coexistence_{context}"]
+= About ambient and sidecar mode coexistence
+
+[role="_abstract"]
+{SMProductName} supports running sidecar and ambient workloads in the same {istio} mesh. You can use this capability to migrate workloads from sidecar mode to ambient mode incrementally, or to keep specific workloads in sidecar mode when they depend on features that ambient mode does not yet support.
+
+:FeatureName: Ambient and sidecar mode coexistence
+include::snippets/technology-preview.adoc[]
+:!FeatureName:
+
+In coexistence mode, sidecar-injected pods and ambient pods share a single control plane. The `{istio}` CR must use `profile: ambient`. Workloads in different modes must be in separate namespaces. A namespace must not carry both the `istio-injection: enabled` label and the `istio.io/dataplane-mode: ambient` label; if both are present, sidecar injection takes precedence.
+
+[NOTE]
+====
+Ambient and sidecar mode coexistence applies to {istio} version 1.27.x and later.
+====
+
+[id="ossm-about-ambient-sidecar-coexistence-supported-features_{context}"]
+== Supported features
+
+The following features work when sidecar and ambient workloads coexist in the same mesh.
+
+[options="header"]
+[cols="1,1,2"]
+|===
+|Category |Functionality |Description
+
+|Connectivity
+|East-west traffic
+|Sidecar pods and ambient pods communicate bidirectionally across namespace boundaries.
+
+|Security
+|mTLS
+|Sidecar proxies automatically detect HBONE endpoints and use HBONE for outbound connections to ambient pods. Ztunnel uses HBONE to reach sidecar proxies. Traffic between both modes is encrypted with mutual TLS.
+
+|Security
+|L4 `AuthorizationPolicy`
+|Authorization policies based on principals, source IPs, and ports are enforced in both directions across modes.
+
+|Security
+|`PeerAuthentication` with `STRICT` mTLS
+|A `PeerAuthentication` policy set to `STRICT` mode accepts traffic from both sidecar and ambient workloads.
+
+|Gateways
+|Egress gateways
+|Ambient pods interoperate with egress gateways.
+
+|Gateways
+|Ingress gateways
+|Ingress gateways deployed in non-ambient namespaces expose services in both sidecar and ambient namespaces.
+
+|Observability
+|L4 TCP metrics
+|Basic Layer 4 TCP metrics and telemetry are available for traffic between sidecar and ambient workloads.
+|===
+
+[id="ossm-about-ambient-sidecar-coexistence-limitations_{context}"]
+== Limitations
+
+[id="ossm-about-ambient-sidecar-coexistence-limitations-l7_{context}"]
+=== L7 policy enforcement from sidecar to ambient workloads
+
+When a sidecar pod sends traffic to an ambient pod that has a waypoint proxy configured, the traffic bypasses the waypoint proxy. Only L4 authorization policies are enforced in this direction; L7 policies, such as HTTP-based `AuthorizationPolicy` rules and `VirtualService` routing, do not apply to that traffic path. Routing decisions are made by the client-side sidecar proxy, not the waypoint.
+
+Ambient pods communicating with sidecar pods are not affected by this limitation. When an ambient pod sends traffic to a sidecar pod, L7 enforcement is handled by the destination sidecar proxy and works as expected.
+
+[id="ossm-about-ambient-sidecar-coexistence-limitations-ingress_{context}"]
+=== Ingress gateway to ambient services
+
+Traffic from an ingress gateway to an ambient service does not traverse the waypoint proxy unless the service or namespace has the `istio.io/ingress-use-waypoint: "true"` label applied.
+
+[id="ossm-about-ambient-sidecar-coexistence-limitations-virtualservice_{context}"]
+=== VirtualService features with no Gateway API counterpart
+
+Some `VirtualService` features have no equivalent in the Gateway API that ambient mode uses for L7 policy. Workloads that depend on any of the following features must remain in sidecar mode.
+
+[options="header"]
+[cols="1,2"]
+|===
+|Feature |Status
+
+|`HTTPFaultInjection`
+|No Gateway API proposal; no implementation planned.
+
+|JWT claim-based routing
+|Proposed and experimental in the Gateway API; no Istio or Envoy implementation.
+
+|Delegate rules
+|Abandoned in the Gateway API.
+
+|Rate limiting
+|Withdrawn from the Gateway API.
+
+|`ignoreCase` for path matching
+|No Gateway API proposal; no work in progress.
+|===
+
+[id="ossm-about-ambient-sidecar-coexistence-best-practices_{context}"]
+== Best practices
+
+* Keep ambient and sidecar workloads in separate namespaces to make the data plane mode of each workload explicit and to avoid label conflicts.
+
+* Do not label a namespace or pod with both `istio-injection: enabled` and `istio.io/dataplane-mode: ambient`. If both labels are present, sidecar injection takes precedence, but the resulting configuration is ambiguous and difficult to maintain.
+
+* Restart existing sidecar pods after enabling ambient mode on the control plane so that the pods are reinjected with the `ISTIO_META_ENABLE_HBONE` setting. Without this setting, sidecar pods cannot communicate with ambient pods. You can validate this also by using the following command to check for HBONE support:
+
+[source,shell]
+----
+istioctl ztunnel-config workloads --namespace ztunnel
+----
+The output shows the ambient workloads registered with the control plane and confirms that HBONE is enabled for those workloads.
++.Example output
+[source,terminal]
+----
+NAMESPACE          POD NAME                                IP          NODE                  WAYPOINT PROTOCOL
+example            example-gateway-istio-59dd7c96db-q9k6v 10.244.1.11 ambient-worker        None     TCP
+example            example-app-cf74bb974-5sqkp            10.244.1.5  ambient-worker        None     HBONE
+----
+    
+* Label services or namespaces with `istio.io/ingress-use-waypoint: "true"` when you require ingress gateway traffic to traverse a waypoint proxy for L7 policy enforcement.

--- a/modules/ossm-about-ambient-sidecar-coexistence.adoc
+++ b/modules/ossm-about-ambient-sidecar-coexistence.adoc
@@ -62,6 +62,7 @@ The following features work when sidecar and ambient workloads coexist in the sa
 [id="ossm-about-ambient-sidecar-coexistence-limitations_{context}"]
 == Limitations
 
+[discrete]
 [id="ossm-about-ambient-sidecar-coexistence-limitations-l7_{context}"]
 === L7 policy enforcement from sidecar to ambient workloads
 
@@ -69,11 +70,13 @@ When a sidecar pod sends traffic to an ambient pod that has a waypoint proxy con
 
 Ambient pods communicating with sidecar pods are not affected by this limitation. When an ambient pod sends traffic to a sidecar pod, L7 enforcement is handled by the destination sidecar proxy and works as expected.
 
+[discrete]
 [id="ossm-about-ambient-sidecar-coexistence-limitations-ingress_{context}"]
 === Ingress gateway to ambient services
 
 Traffic from an ingress gateway to an ambient service does not traverse the waypoint proxy unless the service or namespace has the `istio.io/ingress-use-waypoint: "true"` label applied.
 
+[discrete]
 [id="ossm-about-ambient-sidecar-coexistence-limitations-virtualservice_{context}"]
 === VirtualService features with no Gateway API counterpart
 

--- a/modules/ossm-about-ambient-sidecar-coexistence.adoc
+++ b/modules/ossm-about-ambient-sidecar-coexistence.adoc
@@ -7,9 +7,7 @@
 = About ambient and sidecar mode coexistence
 
 [role="_abstract"]
-{SMProductName} supports running sidecar and ambient workloads in the same {istio} mesh. You can use this capability to migrate workloads from sidecar mode to ambient mode incrementally, or to keep specific workloads in sidecar mode when they depend on features that ambient mode does not yet support.
-
-:FeatureName: Ambient and sidecar mode coexistence
+FeatureName: Ambient and sidecar mode coexistence
 include::snippets/technology-preview.adoc[]
 :!FeatureName:
 
@@ -17,7 +15,7 @@ In coexistence mode, sidecar-injected pods and ambient pods share a single contr
 
 [NOTE]
 ====
-Ambient and sidecar mode coexistence applies to {istio} version 1.27.x and later.
+Ambient and sidecar mode coexistence applies to {istio} version 1.30.x and later.
 ====
 
 [id="ossm-about-ambient-sidecar-coexistence-supported-features_{context}"]
@@ -108,10 +106,11 @@ Some `VirtualService` features have no equivalent in the Gateway API that ambien
 
 [source,shell]
 ----
-istioctl ztunnel-config workloads --namespace ztunnel
+$ istioctl ztunnel-config workloads --namespace ztunnel
 ----
 The output shows the ambient workloads registered with the control plane and confirms that HBONE is enabled for those workloads.
-+.Example output
++
+.Example output
 [source,terminal]
 ----
 NAMESPACE          POD NAME                                IP          NODE                  WAYPOINT PROTOCOL

--- a/modules/ossm-about-ambient-sidecar-coexistence.adoc
+++ b/modules/ossm-about-ambient-sidecar-coexistence.adoc
@@ -4,18 +4,14 @@
 
 :_mod-docs-content-type: CONCEPT
 [id="ossm-about-ambient-sidecar-coexistence_{context}"]
-= About ambient and sidecar mode coexistence
+= About ambient and sidecar coexistence
 
 [role="_abstract"]
-FeatureName: Ambient and sidecar mode coexistence
-include::snippets/technology-preview.adoc[]
-:!FeatureName:
-
-In coexistence mode, sidecar-injected pods and ambient pods share a single control plane. The `{istio}` CR must use `profile: ambient`. Workloads in different modes must be in separate namespaces. A namespace must not carry both the `istio-injection: enabled` label and the `istio.io/dataplane-mode: ambient` label; if both are present, sidecar injection takes precedence.
+Sidecar-injected pods and ambient pods share a single control plane. The `{istio}` CR must use `profile: ambient`. Workloads in different modes must be in separate namespaces. A namespace must not carry both the `istio-injection: enabled` label and the `istio.io/dataplane-mode: ambient` label; if both are present, sidecar injection takes precedence.
 
 [NOTE]
 ====
-Ambient and sidecar mode coexistence applies to {istio} version 1.30.x and later.
+Ambient and sidecar coexistence is available in {SMProductName} 3.2 and later.
 ====
 
 [id="ossm-about-ambient-sidecar-coexistence-supported-features_{context}"]
@@ -68,32 +64,20 @@ Ambient pods communicating with sidecar pods are not affected by this limitation
 
 *Ingress gateway to ambient services*
 
-Traffic from an ingress gateway to an ambient service does not traverse the waypoint proxy unless the service or namespace has the `istio.io/ingress-use-waypoint: "true"` label applied.
+Traffic from an ingress gateway to an ambient service does not traverse the waypoint proxy unless both of the following conditions are met:
+
+* The `ENABLE_INGRESS_WAYPOINT_ROUTING` environment variable is set to `true` in the `spec.values.pilot.env` field of the `{istio}` CR. This setting defaults to `false`. For more information, see link:https://istio.io/latest/docs/reference/commands/pilot-discovery/#enable-ingress-waypoint-routing[ENABLE_INGRESS_WAYPOINT_ROUTING (Istio documentation)].
+* The service or namespace has the `istio.io/ingress-use-waypoint: "true"` label applied.
 
 *VirtualService features with no Gateway API counterpart*
 
 Some `VirtualService` features have no equivalent in the Gateway API that ambient mode uses for L7 policy. Workloads that depend on any of the following features must remain in sidecar mode.
 
-[options="header"]
-[cols="1,2"]
-|===
-|Feature |Status
-
-|`HTTPFaultInjection`
-|No Gateway API proposal; no implementation planned.
-
-|JWT claim-based routing
-|Proposed and experimental in the Gateway API; no Istio or Envoy implementation.
-
-|Delegate rules
-|Abandoned in the Gateway API.
-
-|Rate limiting
-|Withdrawn from the Gateway API.
-
-|`ignoreCase` for path matching
-|No Gateway API proposal; no work in progress.
-|===
+* `HTTPFaultInjection`
+* JWT claim-based routing
+* Delegate rules
+* Rate limiting
+* `ignoreCase` for path matching
 
 [id="ossm-about-ambient-sidecar-coexistence-best-practices_{context}"]
 == Best practices
@@ -103,11 +87,12 @@ Some `VirtualService` features have no equivalent in the Gateway API that ambien
 * Do not label a namespace or pod with both `istio-injection: enabled` and `istio.io/dataplane-mode: ambient`. If both labels are present, sidecar injection takes precedence, but the resulting configuration is ambiguous and difficult to maintain.
 
 * Restart existing sidecar pods after enabling ambient mode on the control plane so that the pods are reinjected with the `ISTIO_META_ENABLE_HBONE` setting. Without this setting, sidecar pods cannot communicate with ambient pods. You can validate this also by using the following command to check for HBONE support:
-
++
 [source,shell]
 ----
 $ istioctl ztunnel-config workloads --namespace ztunnel
 ----
++
 The output shows the ambient workloads registered with the control plane and confirms that HBONE is enabled for those workloads.
 +
 .Example output

--- a/modules/ossm-about-ambient-sidecar-coexistence.adoc
+++ b/modules/ossm-about-ambient-sidecar-coexistence.adoc
@@ -62,23 +62,17 @@ The following features work when sidecar and ambient workloads coexist in the sa
 [id="ossm-about-ambient-sidecar-coexistence-limitations_{context}"]
 == Limitations
 
-[discrete]
-[id="ossm-about-ambient-sidecar-coexistence-limitations-l7_{context}"]
-=== L7 policy enforcement from sidecar to ambient workloads
+*L7 policy enforcement from sidecar to ambient workloads*
 
 When a sidecar pod sends traffic to an ambient pod that has a waypoint proxy configured, the traffic bypasses the waypoint proxy. Only L4 authorization policies are enforced in this direction; L7 policies, such as HTTP-based `AuthorizationPolicy` rules and `VirtualService` routing, do not apply to that traffic path. Routing decisions are made by the client-side sidecar proxy, not the waypoint.
 
 Ambient pods communicating with sidecar pods are not affected by this limitation. When an ambient pod sends traffic to a sidecar pod, L7 enforcement is handled by the destination sidecar proxy and works as expected.
 
-[discrete]
-[id="ossm-about-ambient-sidecar-coexistence-limitations-ingress_{context}"]
-=== Ingress gateway to ambient services
+*Ingress gateway to ambient services*
 
 Traffic from an ingress gateway to an ambient service does not traverse the waypoint proxy unless the service or namespace has the `istio.io/ingress-use-waypoint: "true"` label applied.
 
-[discrete]
-[id="ossm-about-ambient-sidecar-coexistence-limitations-virtualservice_{context}"]
-=== VirtualService features with no Gateway API counterpart
+*VirtualService features with no Gateway API counterpart*
 
 Some `VirtualService` features have no equivalent in the Gateway API that ambient mode uses for L7 policy. Workloads that depend on any of the following features must remain in sidecar mode.
 

--- a/modules/ossm-enabling-ambient-on-existing-sidecar-mesh.adoc
+++ b/modules/ossm-enabling-ambient-on-existing-sidecar-mesh.adoc
@@ -132,7 +132,8 @@ $ istioctl ztunnel-config workloads --namespace ztunnel
 ----
 +
 The output shows the ambient workloads registered with the control plane and confirms that HBONE is enabled for those workloads.
-+.Example output
++
+.Example output
 [source,terminal]
 ----
 $ istioctl ztunnel-config workloads
@@ -140,7 +141,7 @@ NAMESPACE          POD NAME                                IP          NODE     
 example            example-gateway-istio-59dd7c96db-q9k6v 10.244.1.11 ambient-worker        None     TCP
 example            example-app-cf74bb974-5sqkp            10.244.1.5  ambient-worker        None     HBONE
 ----
-+
+
 [NOTE]
 ====
 Traffic from sidecar pods to ambient pods bypasses waypoint proxies. Only L4 authorization policies apply in this direction. For more information about this limitation, see the "About ambient and sidecar mode coexistence" section.

--- a/modules/ossm-enabling-ambient-on-existing-sidecar-mesh.adoc
+++ b/modules/ossm-enabling-ambient-on-existing-sidecar-mesh.adoc
@@ -45,6 +45,33 @@ You must set `spec.profile` to `ambient` and configure `spec.values.pilot.truste
 $ oc apply -f istio_ambient.yaml
 ----
 
+. Update the `IstioCNI` resource to enable the ambient profile. Save the following to a file named `istiocni_ambient.yaml`:
++
+.Example `IstioCNI` resource
+[source,yaml]
+----
+apiVersion: sailoperator.io/v1
+kind: IstioCNI
+metadata:
+  name: default
+spec:
+  profile: ambient
+----
+
+. Apply the updated `IstioCNI` resource by running the following command:
++
+[source,terminal]
+----
+$ oc apply -f istiocni_ambient.yaml
+----
+
+. Wait for the `IstioCNI` resource to be ready by running the following command:
++
+[source,terminal]
+----
+$ oc wait --for=condition=Ready istiocnis/default --timeout=3m
+----
+
 . Create the `ztunnel` namespace by running the following command:
 +
 [source,terminal]
@@ -57,19 +84,34 @@ $ oc create project ztunnel
 .Example `ZTunnel` resource
 [source,yaml]
 ----
-apiVersion: sailoperator.io/v1alpha1
+apiVersion: sailoperator.io/v1
 kind: ZTunnel
 metadata:
   name: default
 spec:
   namespace: ztunnel
+  targetRef:
+    kind: Istio
+    name: default
 ----
++
+[NOTE]
+====
+The `spec.targetRef` field associates the `ZTunnel` instance with an {istio} control plane. When set, values relevant for `ZTunnel`, such as `global`, `meshConfig`, and `revision`, are automatically copied from the referenced `Istio` or `IstioRevision` resource. Any values explicitly set in the `ZTunnel` `spec.values` field take precedence over inherited values.
+====
 
 . Apply the `ZTunnel` CR by running the following command:
 +
 [source,terminal]
 ----
 $ oc apply -f ztunnel.yaml
+----
+
+. Wait for the `ZTunnel` resource to be ready by running the following command:
++
+[source,terminal]
+----
+$ oc wait --for=condition=Ready ztunnels/default --timeout=3m
 ----
 
 . Wait for the {istio} control plane to be ready by running the following command:
@@ -144,5 +186,5 @@ example            example-app-cf74bb974-5sqkp            10.244.1.5  ambient-wo
 
 [NOTE]
 ====
-Traffic from sidecar pods to ambient pods bypasses waypoint proxies. Only L4 authorization policies apply in this direction. For more information about this limitation, see the "About ambient and sidecar mode coexistence" section.
+Traffic from sidecar pods to ambient pods bypasses waypoint proxies. Only L4 authorization policies apply in this direction. For more information about this limitation, see the "About ambient and sidecar coexistence" section.
 ====

--- a/modules/ossm-enabling-ambient-on-existing-sidecar-mesh.adoc
+++ b/modules/ossm-enabling-ambient-on-existing-sidecar-mesh.adoc
@@ -143,5 +143,5 @@ example            example-app-cf74bb974-5sqkp            10.244.1.5  ambient-wo
 +
 [NOTE]
 ====
-Traffic from sidecar pods to ambient pods bypasses waypoint proxies. Only L4 authorization policies apply in this direction. For details, see xref:ossm-about-ambient-sidecar-coexistence.adoc#ossm-about-ambient-sidecar-coexistence-limitations-l7_{context}[L7 policy enforcement from sidecar to ambient workloads].
+Traffic from sidecar pods to ambient pods bypasses waypoint proxies. Only L4 authorization policies apply in this direction. For more information about this limitation, see the "About ambient and sidecar mode coexistence" section.
 ====

--- a/modules/ossm-enabling-ambient-on-existing-sidecar-mesh.adoc
+++ b/modules/ossm-enabling-ambient-on-existing-sidecar-mesh.adoc
@@ -166,19 +166,19 @@ Pods in an ambient namespace show `1/1` containers in the `READY` column, confir
 NAME                        READY   STATUS    RESTARTS   AGE
 my-app-6d8f94b7c9-xk2pj    1/1     Running   0          45s
 ----
+
 . Verify the ambient workloads are registered with the control plane and that HBONE is enabled by using `istioctl`:
 +
 [source,terminal]
 ----
 $ istioctl ztunnel-config workloads --namespace ztunnel --workload-namespace <ambient-namespace>
 ----
-
++
 The output shows the ambient workloads registered with the control plane and confirms that HBONE is enabled for those workloads.
 +
 .Example output
 [source,terminal]
 ----
-$ istioctl ztunnel-config workloads
 NAMESPACE          POD NAME                                IP          NODE                  WAYPOINT PROTOCOL
 example            example-gateway-istio-59dd7c96db-q9k6v 10.244.1.11 ambient-worker        None     TCP
 example            example-app-cf74bb974-5sqkp            10.244.1.5  ambient-worker        None     HBONE

--- a/modules/ossm-enabling-ambient-on-existing-sidecar-mesh.adoc
+++ b/modules/ossm-enabling-ambient-on-existing-sidecar-mesh.adoc
@@ -130,7 +130,7 @@ my-app-6d8f94b7c9-xk2pj    1/1     Running   0          45s
 ----
 $ istioctl ztunnel-config workloads --namespace ztunnel
 ----
-+
+
 The output shows the ambient workloads registered with the control plane and confirms that HBONE is enabled for those workloads.
 +
 .Example output

--- a/modules/ossm-enabling-ambient-on-existing-sidecar-mesh.adoc
+++ b/modules/ossm-enabling-ambient-on-existing-sidecar-mesh.adoc
@@ -76,7 +76,7 @@ $ oc wait --for=condition=Ready istiocnis/default --timeout=3m
 +
 [source,terminal]
 ----
-$ oc create project ztunnel
+$ oc create namespace ztunnel
 ----
 
 . Create a file named `ztunnel.yaml` that contains the `ZTunnel` resource:
@@ -166,11 +166,11 @@ Pods in an ambient namespace show `1/1` containers in the `READY` column, confir
 NAME                        READY   STATUS    RESTARTS   AGE
 my-app-6d8f94b7c9-xk2pj    1/1     Running   0          45s
 ----
-. Alternatively, you can verify the ambient workloads by using `istioctl` to check that they are registered with the control plane and that HBONE is enabled:
+. Verify the ambient workloads are registered with the control plane and that HBONE is enabled by using `istioctl`:
 +
 [source,terminal]
 ----
-$ istioctl ztunnel-config workloads --namespace ztunnel
+$ istioctl ztunnel-config workloads --namespace ztunnel --workload-namespace <ambient-namespace>
 ----
 
 The output shows the ambient workloads registered with the control plane and confirms that HBONE is enabled for those workloads.

--- a/modules/ossm-enabling-ambient-on-existing-sidecar-mesh.adoc
+++ b/modules/ossm-enabling-ambient-on-existing-sidecar-mesh.adoc
@@ -1,0 +1,147 @@
+// Module included in the following assemblies:
+//
+// * service-mesh-docs-main/install/ossm-ambient-sidecar-coexistence.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="ossm-enabling-ambient-on-existing-sidecar-mesh_{context}"]
+= Enabling ambient mode on an existing sidecar mesh
+
+[role="_abstract"]
+Add ambient workloads to an existing sidecar-mode {istio} installation by updating the control plane configuration and deploying the ztunnel proxy. After completing this procedure, you can run sidecar and ambient workloads in separate namespaces within the same mesh.
+
+.Prerequisites
+
+* You have an existing {istio} installation in sidecar mode on {ocp-product-title}.
+* You are logged in to the {ocp-product-title} cluster as a user with the `cluster-admin` role.
+
+.Procedure
+
+. Update the existing `{istio}` CR to set `profile: ambient` and configure the trusted ztunnel namespace. Save the following to a file named `istio_ambient.yaml`:
++
+.Example `Istio` resource
+[source,yaml]
+----
+apiVersion: sailoperator.io/v1
+kind: Istio
+metadata:
+  name: default
+spec:
+  namespace: istio-system
+  profile: ambient
+  values:
+    pilot:
+      trustedZtunnelNamespace: ztunnel
+----
++
+[IMPORTANT]
+====
+You must set `spec.profile` to `ambient` and configure `spec.values.pilot.trustedZtunnelNamespace` to `ztunnel`, which is the namespace where the `ZTunnel` resource will be installed.
+====
+
+. Apply the updated `{istio}` CR by running the following command:
++
+[source,terminal]
+----
+$ oc apply -f istio_ambient.yaml
+----
+
+. Create the `ztunnel` namespace by running the following command:
++
+[source,terminal]
+----
+$ oc create project ztunnel
+----
+
+. Create a file named `ztunnel.yaml` that contains the `ZTunnel` resource:
++
+.Example `ZTunnel` resource
+[source,yaml]
+----
+apiVersion: sailoperator.io/v1alpha1
+kind: ZTunnel
+metadata:
+  name: default
+spec:
+  namespace: ztunnel
+----
+
+. Apply the `ZTunnel` CR by running the following command:
++
+[source,terminal]
+----
+$ oc apply -f ztunnel.yaml
+----
+
+. Wait for the {istio} control plane to be ready by running the following command:
++
+[source,terminal]
+----
+$ oc wait --for=condition=Ready istios/default --timeout=3m
+----
+
+. Restart existing sidecar pods in each namespace that contains sidecar workloads by running the following command for each namespace:
++
+[source,terminal]
+----
+$ oc rollout restart deployment -n <sidecar-namespace>
+----
++
+[NOTE]
+====
+This restart is required so that the pods are reinjected with the `ISTIO_META_ENABLE_HBONE` setting. Without this setting, the sidecar proxies cannot communicate with workloads in the ambient data plane. Note that if you have a large number of sidecar pods, you may want to restart them in batches or individually to avoid disruption.
+====
+
+. Create a namespace for your ambient workloads by running the following command:
++
+[source,terminal]
+----
+$ oc create namespace <ambient-namespace>
+----
+
+. Label the namespace to enable ambient mode by running the following command:
++
+[source,terminal]
+----
+$ oc label namespace <ambient-namespace> istio.io/dataplane-mode=ambient
+----
+
+. Deploy your application workloads to `<ambient-namespace>`. The mesh automatically intercepts traffic for pods in this namespace using the ztunnel proxy, no changes to your workload manifests are required.
+
+.Verification
+
+. Verify that the ambient workloads are running without a sidecar proxy by running the following command:
++
+[source,terminal]
+----
+$ oc get pods -n <ambient-namespace>
+----
++
+Pods in an ambient namespace show `1/1` containers in the `READY` column, confirming that no sidecar proxy was injected.
++
+.Example output
+[source,terminal]
+----
+NAME                        READY   STATUS    RESTARTS   AGE
+my-app-6d8f94b7c9-xk2pj    1/1     Running   0          45s
+----
+. Alternatively, you can verify the ambient workloads by using `istioctl` to check that they are registered with the control plane and that HBONE is enabled:
++
+[source,terminal]
+----
+$ istioctl ztunnel-config workloads --namespace ztunnel
+----
++
+The output shows the ambient workloads registered with the control plane and confirms that HBONE is enabled for those workloads.
++.Example output
+[source,terminal]
+----
+$ istioctl ztunnel-config workloads
+NAMESPACE          POD NAME                                IP          NODE                  WAYPOINT PROTOCOL
+example            example-gateway-istio-59dd7c96db-q9k6v 10.244.1.11 ambient-worker        None     TCP
+example            example-app-cf74bb974-5sqkp            10.244.1.5  ambient-worker        None     HBONE
+----
++
+[NOTE]
+====
+Traffic from sidecar pods to ambient pods bypasses waypoint proxies. Only L4 authorization policies apply in this direction. For details, see xref:ossm-about-ambient-sidecar-coexistence.adoc#ossm-about-ambient-sidecar-coexistence-limitations-l7_{context}[L7 policy enforcement from sidecar to ambient workloads].
+====

--- a/modules/ossm-enabling-sidecar-on-existing-ambient-mesh.adoc
+++ b/modules/ossm-enabling-sidecar-on-existing-ambient-mesh.adoc
@@ -90,12 +90,14 @@ my-app-7f8b9c6d5-lnr4q       2/2     Running   0          38s
 +
 
 . Alternatively, you can verify the sidecar workloads by using `istioctl` to check that they are registered with the control plane and that HBONE is enabled:
-+[source,terminal]
++
+[source,terminal]
 ----
 $ istioctl ztunnel-config workloads --namespace ztunnel
 ----
 +The output shows the sidecar workloads registered with the control plane and confirms that HBONE is enabled for those workloads.
-+.Example output
++
+.Example output
 [source,terminal]
 ----
 $ istioctl ztunnel-config workloads --namespace ztunnel
@@ -103,7 +105,7 @@ NAMESPACE          POD NAME                                IP          NODE     
 example            example-gateway-istio-59dd7c96db-q9k6v 10.244.1.11 ambient-worker        None     TCP
 example            example-app-cf74bb974-5sqkp            10.244.1.5  ambient-worker        None     HBONE
 ----
-+
+
 [NOTE]
 ====
 Traffic from sidecar pods to ambient pods bypasses waypoint proxies. Only L4 authorization policies apply in this direction. For more information about this limitation, see the "About ambient and sidecar mode coexistence" section.

--- a/modules/ossm-enabling-sidecar-on-existing-ambient-mesh.adoc
+++ b/modules/ossm-enabling-sidecar-on-existing-ambient-mesh.adoc
@@ -1,0 +1,110 @@
+// Module included in the following assemblies:
+//
+// * service-mesh-docs-main/install/ossm-ambient-sidecar-coexistence.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="ossm-enabling-sidecar-on-existing-ambient-mesh_{context}"]
+= Enabling sidecar mode on an existing ambient mesh
+
+[role="_abstract"]
+Add sidecar workloads to an existing ambient-mode {istio} installation by creating a dedicated namespace and labeling it for sidecar injection. Use this procedure when you need to run workloads that require features supported only in sidecar mode, such as `VirtualService` fault injection or delegate rules.
+
+.Prerequisites
+
+* You have an existing {istio} installation in ambient mode on {ocp-product-title} with the `{istio}` CR set to `profile: ambient`.
+* A `ZTunnel` resource is deployed and healthy in the cluster.
+* You are logged in to the {ocp-product-title} cluster as a user with the `cluster-admin` role.
+
+.Procedure
+
+. Retrieve the revision name of the {istio} control plane by running the following command:
++
+[source,terminal]
+----
+$ oc get istiorevisions
+----
++
+.Example output
+[source,terminal]
+----
+NAME      TYPE    READY   STATUS    IN USE   VERSION   AGE
+default   Local   True    Healthy   True     v1.27.0   12m
+----
++
+The value in the `NAME` column is the revision name. Use it in the next step to label the namespace for sidecar injection.
+
+. Create a namespace for your sidecar workloads by running the following command:
++
+[source,terminal]
+----
+$ oc create namespace <sidecar-namespace>
+----
+
+. Label the namespace to enable sidecar injection.
++
+* If the revision name from the previous step is `default`, run the following command:
++
+[source,terminal]
+----
+$ oc label namespace <sidecar-namespace> istio-injection=enabled
+----
++
+* If the revision name is not `default`, run the following command:
++
+[source,terminal]
+----
+$ oc label namespace <sidecar-namespace> istio.io/rev=<revision-name>
+----
++
+[NOTE]
+====
+Do not add the `istio.io/dataplane-mode: ambient` label to this namespace. A namespace that carries both the sidecar injection label and the `istio.io/dataplane-mode: ambient` label will have sidecar injection applied, but the configuration is ambiguous and difficult to maintain. To confirm the namespace has no ambient label, run:
+
+[source,terminal]
+----
+$ oc get namespace <sidecar-namespace> --show-labels
+----
+
+Confirm that `istio.io/dataplane-mode=ambient` does not appear in the output.
+====
+
+. Deploy your application workloads to `<sidecar-namespace>`. The mesh automatically injects the sidecar proxy into pods in this namespace.
+
+.Verification
+
+. Verify that the sidecar proxy was injected by running the following command:
++
+[source,terminal]
+----
+$ oc get pods -n <sidecar-namespace>
+----
++
+Pods in a sidecar-injected namespace show `2/2` containers in the `READY` column, confirming that both the application container and the sidecar proxy are running.
++
+.Example output
+[source,terminal]
+----
+NAME                         READY   STATUS    RESTARTS   AGE
+my-app-7f8b9c6d5-lnr4q       2/2     Running   0          38s
+----
++
+
+. Alternatively, you can verify the sidecar workloads by using `istioctl` to check that they are registered with the control plane and that HBONE is enabled:
++[source,terminal]
+----
+$ istioctl ztunnel-config workloads --namespace ztunnel
+----
++The output shows the sidecar workloads registered with the control plane and confirms that HBONE is enabled for those workloads.
++.Example output
+[source,terminal]
+----
+$ istioctl ztunnel-config workloads --namespace ztunnel
+NAMESPACE          POD NAME                                IP          NODE                  WAYPOINT PROTOCOL
+example            example-gateway-istio-59dd7c96db-q9k6v 10.244.1.11 ambient-worker        None     TCP
+example            example-app-cf74bb974-5sqkp            10.244.1.5  ambient-worker        None     HBONE
+----
++
+[NOTE]
+====
+Traffic from sidecar pods to ambient pods bypasses waypoint proxies. Only L4 authorization policies apply in this direction. For details, see xref:ossm-about-ambient-sidecar-coexistence.adoc#ossm-about-ambient-sidecar-coexistence-limitations-l7_{context}[L7 policy enforcement from sidecar to ambient workloads].
+====

--- a/modules/ossm-enabling-sidecar-on-existing-ambient-mesh.adoc
+++ b/modules/ossm-enabling-sidecar-on-existing-ambient-mesh.adoc
@@ -7,57 +7,15 @@
 = Enabling sidecar mode on an existing ambient mesh
 
 [role="_abstract"]
-Add sidecar workloads to an existing ambient-mode {istio} installation by creating a dedicated namespace and labeling it for sidecar injection. Use this procedure when you need to run workloads that require features supported only in sidecar mode, such as `VirtualService` fault injection or delegate rules.
+Add sidecar workloads to an existing ambient-mode {istio} installation by creating a dedicated namespace and labeling it for sidecar injection. Follow the standard procedure for enabling sidecar injection by using namespace labels. The only additional requirement is that you must not apply both a sidecar injection label and the `istio.io/dataplane-mode: ambient` label to the same namespace.
 
-.Prerequisites
+For the full procedure, see xref:ossm-sidecar-injection.adoc#ossm-enabling-sidecar-injection-namespace-labels_ossm-sidecar-injection[Enabling sidecar injection using namespace labels].
 
-* You have an existing {istio} installation in ambient mode on {ocp-product-title} with the `{istio}` CR set to `profile: ambient`.
-* A `ZTunnel` resource is deployed and healthy in the cluster.
-* You are logged in to the {ocp-product-title} cluster as a user with the `cluster-admin` role.
-
-.Procedure
-
-. Retrieve the active revision name of the {istio} control plane by running the following command:
-+
-[source,terminal]
-----
-$ oc get istios default -o jsonpath='{.status.activeRevisionName}'
-----
-+
-.Example output
-[source,terminal]
-----
-default
-----
-+
-Use this value in the next step to label the namespace for sidecar injection.
-
-. Create a namespace for your sidecar workloads by running the following command:
-+
-[source,terminal]
-----
-$ oc create namespace <sidecar-namespace>
-----
-
-. Label the namespace to enable sidecar injection.
-+
-* If the revision name from the previous step is `default`, run the following command:
-+
-[source,terminal]
-----
-$ oc label namespace <sidecar-namespace> istio-injection=enabled
-----
-+
-* If the revision name is not `default`, run the following command:
-+
-[source,terminal]
-----
-$ oc label namespace <sidecar-namespace> istio.io/rev=<revision-name>
-----
-+
-[NOTE]
+[IMPORTANT]
 ====
-Do not add the `istio.io/dataplane-mode: ambient` label to this namespace. A namespace that carries both the sidecar injection label and the `istio.io/dataplane-mode: ambient` label will have sidecar injection applied, but the configuration is ambiguous and difficult to maintain. To confirm the namespace has no ambient label, run:
+Do not label a sidecar namespace with `istio.io/dataplane-mode: ambient`. If a namespace carries both a sidecar injection label (`istio-injection: enabled` or `istio.io/rev: <revision>`) and the `istio.io/dataplane-mode: ambient` label, sidecar injection takes precedence, but the configuration is ambiguous and difficult to maintain.
+
+To confirm the namespace has no ambient label applied, run the following command:
 
 [source,terminal]
 ----
@@ -67,44 +25,7 @@ $ oc get namespace <sidecar-namespace> --show-labels
 Confirm that `istio.io/dataplane-mode=ambient` does not appear in the output.
 ====
 
-. Deploy your application workloads to `<sidecar-namespace>`. The mesh automatically injects the sidecar proxy into pods in this namespace.
-
-.Verification
-
-. Verify that the sidecar proxy was injected by running the following command:
-+
-[source,terminal]
-----
-$ oc get pods -n <sidecar-namespace>
-----
-+
-Pods in a sidecar-injected namespace show `2/2` containers in the `READY` column, confirming that both the application container and the sidecar proxy are running.
-+
-.Example output
-[source,terminal]
-----
-NAME                         READY   STATUS    RESTARTS   AGE
-my-app-7f8b9c6d5-lnr4q       2/2     Running   0          38s
-----
-
-. Verify the sidecar workloads are registered with the control plane and that HBONE is enabled by using `istioctl`:
-+
-[source,terminal]
-----
-$ istioctl ztunnel-config workloads --namespace ztunnel --workload-namespace <sidecar-namespace>
-----
-+
-The output shows the sidecar workloads registered with the control plane and confirms that HBONE is enabled for those workloads.
-+
-.Example output
-[source,terminal]
-----
-NAMESPACE          POD NAME                                IP          NODE                  WAYPOINT PROTOCOL
-example            example-gateway-istio-59dd7c96db-q9k6v 10.244.1.11 ambient-worker        None     TCP
-example            example-app-cf74bb974-5sqkp            10.244.1.5  ambient-worker        None     HBONE
-----
-
 [NOTE]
 ====
-Traffic from sidecar pods to ambient pods bypasses waypoint proxies. Only L4 authorization policies apply in this direction. For more information about this limitation, see the "About ambient and sidecar coexistence" section.
+Traffic from sidecar pods to ambient pods bypasses waypoint proxies. Only L4 authorization policies apply in this direction. For more information, see the "About ambient and sidecar coexistence" section.
 ====

--- a/modules/ossm-enabling-sidecar-on-existing-ambient-mesh.adoc
+++ b/modules/ossm-enabling-sidecar-on-existing-ambient-mesh.adoc
@@ -87,7 +87,6 @@ Pods in a sidecar-injected namespace show `2/2` containers in the `READY` column
 NAME                         READY   STATUS    RESTARTS   AGE
 my-app-7f8b9c6d5-lnr4q       2/2     Running   0          38s
 ----
-+
 
 . Alternatively, you can verify the sidecar workloads by using `istioctl` to check that they are registered with the control plane and that HBONE is enabled:
 +
@@ -95,7 +94,7 @@ my-app-7f8b9c6d5-lnr4q       2/2     Running   0          38s
 ----
 $ istioctl ztunnel-config workloads --namespace ztunnel
 ----
-
++
 The output shows the sidecar workloads registered with the control plane and confirms that HBONE is enabled for those workloads.
 +
 .Example output
@@ -109,5 +108,5 @@ example            example-app-cf74bb974-5sqkp            10.244.1.5  ambient-wo
 
 [NOTE]
 ====
-Traffic from sidecar pods to ambient pods bypasses waypoint proxies. Only L4 authorization policies apply in this direction. For more information about this limitation, see the "About ambient and sidecar mode coexistence" section.
+Traffic from sidecar pods to ambient pods bypasses waypoint proxies. Only L4 authorization policies apply in this direction. For more information about this limitation, see the "About ambient and sidecar coexistence" section.
 ====

--- a/modules/ossm-enabling-sidecar-on-existing-ambient-mesh.adoc
+++ b/modules/ossm-enabling-sidecar-on-existing-ambient-mesh.adoc
@@ -17,21 +17,20 @@ Add sidecar workloads to an existing ambient-mode {istio} installation by creati
 
 .Procedure
 
-. Retrieve the revision name of the {istio} control plane by running the following command:
+. Retrieve the active revision name of the {istio} control plane by running the following command:
 +
 [source,terminal]
 ----
-$ oc get istiorevisions
+$ oc get istios default -o jsonpath='{.status.activeRevisionName}'
 ----
 +
 .Example output
 [source,terminal]
 ----
-NAME      TYPE    READY   STATUS    IN USE   VERSION   AGE
-default   Local   True    Healthy   True     v1.27.0   12m
+default
 ----
 +
-The value in the `NAME` column is the revision name. Use it in the next step to label the namespace for sidecar injection.
+Use this value in the next step to label the namespace for sidecar injection.
 
 . Create a namespace for your sidecar workloads by running the following command:
 +
@@ -88,11 +87,11 @@ NAME                         READY   STATUS    RESTARTS   AGE
 my-app-7f8b9c6d5-lnr4q       2/2     Running   0          38s
 ----
 
-. Alternatively, you can verify the sidecar workloads by using `istioctl` to check that they are registered with the control plane and that HBONE is enabled:
+. Verify the sidecar workloads are registered with the control plane and that HBONE is enabled by using `istioctl`:
 +
 [source,terminal]
 ----
-$ istioctl ztunnel-config workloads --namespace ztunnel
+$ istioctl ztunnel-config workloads --namespace ztunnel --workload-namespace <sidecar-namespace>
 ----
 +
 The output shows the sidecar workloads registered with the control plane and confirms that HBONE is enabled for those workloads.
@@ -100,7 +99,6 @@ The output shows the sidecar workloads registered with the control plane and con
 .Example output
 [source,terminal]
 ----
-$ istioctl ztunnel-config workloads --namespace ztunnel
 NAMESPACE          POD NAME                                IP          NODE                  WAYPOINT PROTOCOL
 example            example-gateway-istio-59dd7c96db-q9k6v 10.244.1.11 ambient-worker        None     TCP
 example            example-app-cf74bb974-5sqkp            10.244.1.5  ambient-worker        None     HBONE

--- a/modules/ossm-enabling-sidecar-on-existing-ambient-mesh.adoc
+++ b/modules/ossm-enabling-sidecar-on-existing-ambient-mesh.adoc
@@ -106,5 +106,5 @@ example            example-app-cf74bb974-5sqkp            10.244.1.5  ambient-wo
 +
 [NOTE]
 ====
-Traffic from sidecar pods to ambient pods bypasses waypoint proxies. Only L4 authorization policies apply in this direction. For details, see xref:ossm-about-ambient-sidecar-coexistence.adoc#ossm-about-ambient-sidecar-coexistence-limitations-l7_{context}[L7 policy enforcement from sidecar to ambient workloads].
+Traffic from sidecar pods to ambient pods bypasses waypoint proxies. Only L4 authorization policies apply in this direction. For more information about this limitation, see the "About ambient and sidecar mode coexistence" section.
 ====

--- a/modules/ossm-enabling-sidecar-on-existing-ambient-mesh.adoc
+++ b/modules/ossm-enabling-sidecar-on-existing-ambient-mesh.adoc
@@ -95,7 +95,8 @@ my-app-7f8b9c6d5-lnr4q       2/2     Running   0          38s
 ----
 $ istioctl ztunnel-config workloads --namespace ztunnel
 ----
-+The output shows the sidecar workloads registered with the control plane and confirms that HBONE is enabled for those workloads.
+
+The output shows the sidecar workloads registered with the control plane and confirms that HBONE is enabled for those workloads.
 +
 .Example output
 [source,terminal]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: 

Adding specific OSSM sidecar and ambient coexistence

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
Jira: 
https://redhat.atlassian.net/browse/OSSM-12507

Link to docs preview:
https://111191--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/install/ossm-ambient-sidecar-coexistence.html

QE review:
- [ ] @pbajjuri20  QE has approved this change.
- [x] @nrfox Dev has approved this change
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
