### PR TITLE
OCPBUGS#84959 vSphere UUID admonition should only apply to vSphere

### DIFF
--- a/modules/installation-network-user-infra.adoc
+++ b/modules/installation-network-user-infra.adoc
@@ -77,10 +77,12 @@ endif::[]
 [role="_abstract"]
 You must configure networking for all the {op-system-first} machines in `initramfs` during boot, so that they can fetch their Ignition config files.
 
+ifdef::vsphere[]
 [IMPORTANT]
 ====
 Ensure you enable the `disk.EnableUUID` parameter on all virtual machines in your cluster.
 ====
+endif::[]
 
 ifndef::azure,gcp[]
 ifdef::ibm-z[]


### PR DESCRIPTION
Version(s):
4.16+

Issue:
https://redhat.atlassian.net/browse/OCPBUGS-84959

Link to docs preview:
[Bare metal UPI (note is gone)](https://111192--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/upi/installing-bare-metal-network-customizations#installation-network-user-infra_installing-bare-metal-network-customizations)
[vSphere install req's (note is present)](https://111192--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/upi/upi-vsphere-installation-reqs#installation-network-user-infra_upi-vsphere-installation-reqs)

QE review:
Not needed, fixing a docs bug introduced by https://github.com/openshift/openshift-docs/pull/103618/changes#diff-53fa868750ffa662daf17f6998ed96291d066e63cb6c79f19a19632ac083ed75L63-L66

