### PR TITLE
OSDOCS-19414 [NETOBSERV] 1.12 Health Rules recording

### DIFF
--- a/modules/network-observability-custom-health-rule-configuration.adoc
+++ b/modules/network-observability-custom-health-rule-configuration.adoc
@@ -3,22 +3,27 @@
 // * network_observability/network-observability-alerts.adoc
 
 :_mod-docs-content-type: PROCEDURE
-[id="network-observability-custom-health-rule-configuration_{context}"]
-= Custom health rule configuration
+[id="network-observability-configuring-custom-health-rules_{context}"]
+= Configuring custom health rules
 
 [role="_abstract"]
-Use the Prometheus Query Language (`PromQL`) to define a custom `AlertingRule` resource to trigger alerts based on specific network metrics (e.g., traffic surges).
+Create custom health rules by using Prometheus Query Language (PromQL) to define an `AlertingRule` resource. These rules trigger alerts based on specific network metrics, such as traffic surges.
 
 .Prerequisites
 
-* Familiarity with `PromQL`.
-* You have installed {product-title} 4.16 or later.
-* You have access to the cluster as a user with the `cluster-admin` role.
-* You have installed the Network Observability Operator.
+* Access to the cluster with `cluster-admin` privileges.
+* The Network Observability Operator is installed.
+* {product-title} 4.16 or later is installed.
+* Familiarity with PromQL.
+
+[IMPORTANT]
+====
+Custom `PrometheusRule` resources are not owned by the `FlowCollector` resource. Custom rules created in the `netobserv` namespace might be deleted if the Network Observability Operator is uninstalled. To prevent data loss, create custom rules in a different namespace, such as `openshift-monitoring`, and maintain a backup in version control.
+====
 
 .Procedure
 
-. Create a YAML file named `custom-alert.yaml` that contains your `AlertingRule` resource.
+. Define an `AlertingRule` resource in a YAML file, for example, `custom-alert.yaml`.
 . Apply the custom alert rule by running the following command:
 +
 [source,terminal]
@@ -28,13 +33,13 @@ $ oc apply -f custom-alert.yaml
 
 .Verification
 
-. Verify that the `PrometheusRule` resource was created in the `netobserv` namespace by running the following command:
+. Confirm the `PrometheusRule` resource was created in the target namespace by running the following command:
 +
 [source,terminal]
 ----
-$ oc get prometheusrules -n netobserv -oyaml
+$ oc get prometheusrules -n <namespace> -o yaml
 ----
-+
-The output should include the `netobserv-alerts` rule you just created, confirming that the resource was generated correctly.
 
-. Confirm the rule is active by checking the *Network Health* dashboard in the {product-title} web console → *Observe*.
+. Confirm the rule is active in the {product-title} web console:
+.. Navigate to *Observe* → *Alerting* to see the firing status.
+.. Navigate to *Observe* → *Network Health* to view the dashboard integration.

--- a/modules/network-observability-disable-predefined-rules.adoc
+++ b/modules/network-observability-disable-predefined-rules.adoc
@@ -4,9 +4,11 @@
 
 :_mod-docs-content-type: REFERENCE
 [id="network-observability-disable-predefined-rules_{context}"]
-= Disable predefined rules
+= Disabling default rules
 
 [role="_abstract"]
 Rule templates can be disabled in the `spec.processor.metrics.disableAlerts` field of the `FlowCollector` custom resource (CR). This setting accepts a list of rule template names. For a list of alert template names, see "List of default rules".
 
-If a template is disabled and overridden in the `spec.processor.metrics.healthRules` field, the disable setting takes precedence and the alert rule is not created.
+If a rule template is included in the `disableAlerts` list, it is not created, even if a custom override exists in the `spec.processor.metrics.healthRules` field. The `disableAlerts` configuration takes precedence over all other health rule settings.
+
+For a list of alert template names, see "List of default rules".

--- a/modules/network-observability-health-rule-structure-customization.adoc
+++ b/modules/network-observability-health-rule-structure-customization.adoc
@@ -3,15 +3,15 @@
 // network_observability/network-observability-alerts.adoc
 
 :_mod-docs-content-type: CONCEPT
-[id="network-observability-health-rule-structure-customization_{context}"]
-= Network observability health rule structure and customization
+[id="network-observability-health-rule-customization_{context}"]
+= Health rule threshold and grouping customization
 
 [role="_abstract"]
-Health rules in the Network Observability Operator are defined using rule templates and variants in the `spec.processor.metrics.healthRules` object of the `FlowCollector` custom resource (CR). You can customize the default templates and variants for flexible, fine-grained alerting.
+Health rules in the Network Observability Operator are defined by using rule templates and variants in the `spec.processor.metrics.healthRules` field of the `FlowCollector` custom resource (CR). Customizing these templates allows for flexible, fine-grained alerting tailored to specific environment needs.
 
-For each template, you can define a list of variants, each with their own thresholds and grouping configurations. For more information, see "List of default alert templates".
+For each template, a list of variants can be defined, each with distinct thresholds and grouping configurations.
 
-The following example shows an alert:
+The following example shows a `FlowCollector` configuration with custom health rules:
 
 [source,yaml]
 ----
@@ -26,10 +26,10 @@ spec:
       - template: PacketDropsByKernel
         mode: Alert # or Recording
         variants:
-        # triggered when the whole cluster traffic (no grouping) reaches 10% of drops
+        # Triggered when aggregate cluster traffic reaches 10% drops
         - thresholds:
             critical: "10"
-        # triggered when per-node traffic reaches 5% of drops, with gradual severity
+        # Triggered per-node with increasing severity levels
         - thresholds:
             critical: "15"
             warning: "10"
@@ -37,15 +37,12 @@ spec:
           groupBy: Node
 ----
 
-where:
-
 `spec.processor.metrics.healthRules.template`:: Specifies the name of the predefined rule template.
-`spec.processor.metrics.healthRules.mode`:: Specifies whether the rule functions as an `Alert` or a `Recording` rule. This setting can either be defined per variant, or for the whole template.
-`spec.processor.metrics.healthRules.variants.thresholds`:: Specifies the numerical values that trigger the rule. You can define multiple severity levels, such as `critical`, `warning`, or `info`, within a single variant.
-`cluster-wide variant`:: Specifies a variant defined without a `groupBy` setting. In the provided example, this variant triggers when the total cluster traffic reaches 10% drops.
-`spec.processor.metrics.healthRules.variants.groupBy`:: Specifies the dimension used to aggregate the metric. In the provided example, the alert is evaluated independently for each *Node8.
+`spec.processor.metrics.healthRules.mode`:: Specifies whether the rule functions as an `Alert` or a `Recording` rule.
+`spec.processor.metrics.healthRules.variants.thresholds`:: Specifies the numerical values that trigger the rule. Multiple severity levels, such as `critical`, `warning`, or `info`, can be defined within a single variant.
+`spec.processor.metrics.healthRules.variants.groupBy`:: Specifies the dimension used to aggregate the metric, such as `Node` or `Namespace`.
 
 [NOTE]
 ====
-Customizing a rule replaces the default configuration for that template. If you want to keep the default configurations, you must manually replicate them.
+Customizing a rule replaces the default configuration for that template. To retain default configurations, the default settings must be manually included in the custom resource.
 ====

--- a/modules/network-observability-health-rules-and-performance.adoc
+++ b/modules/network-observability-health-rules-and-performance.adoc
@@ -4,17 +4,53 @@
 
 :_mod-docs-content-type: CONCEPT
 [id="network-observability-health-rules-and-performance_{context}"]
-= Network observability rules for health and performance
+= Identifying network issues with automated health rules
 
 [role="_abstract"]
-Network observability includes a system for managing Prometheus-based rules. Use these rules to monitor the health and performance of {product-title} applications and infrastructure.
+Network observability identifies network issues by using automated health rules to monitor metrics. These rules trigger alerts when anomalies occur, which assists in maintaining connectivity and responding to network degradation.
 
-The Network Observability Operator converts these rules into a `PrometheusRule` resource. The Network Observability Operator supports the following rule types:
+The Network Observability Operator manages a system of Prometheus-based rules that detect network problems, and converts these rules into `PrometheusRule` resources. It supports the following rule types:
 
-* Alerting rules: Specifies rules managed by the Prometheus `AlertManager` to provide notification of network anomalies or infrastructure failures.
-* Recording rules: Specifies pre-compute complex Prometheus Query Language (PromQL) expressions into new time series to improve dashboard performance and visualization.
+Alerting rules:: Trigger notifications through the Prometheus `Alertmanager` when network anomalies or infrastructure failures are detected.
 
-View the `PrometheusRule` resource in the `netobserv` namespace by running the following command:
+Recording rules:: Pre-compute complex Prometheus Query Language (PromQL) expressions into new time series to improve dashboard performance.
+
+[id="importance-of-network-health-monitoring_{context}"]
+== Importance of network health monitoring
+
+Maintaining reliable and secure network connectivity is critical for cluster administrators and security teams. Unresolved network issues can result in the following consequences:
+
+* Application downtime caused by packet drops or DNS failures.
+* Security risks from undetected network policy violations.
+* Performance degradation caused by latency spikes or bandwidth saturation.
+* Compliance issues from unmonitored network traffic.
+
+Early detection of these issues allows for resolution before service level objectives (SLOs) are affected.
+
+[id="detection-of-network-issues_{context}"]
+== Automated health monitoring
+
+The Network Observability Operator provides automated health monitoring through the following features:
+
+* Pre-configured health rules: Detect common network problems by using default thresholds.
+* Automated alerting: Integrates with the {product-title} monitoring stack.
+* Health dashboards: Displays health status for clusters, nodes, namespaces, and workloads.
+* Custom rules: Supports the creation of organization-specific monitoring rules.
+
+Health rules monitor network flow metrics and trigger alerts when defined thresholds are exceeded. For example, the `PacketDropsByKernel` rule reports an alert when kernel packet drop rates exceed defined levels.
+
+[id="network-health-monitoring-workflow_{context}"]
+== Network health monitoring workflow
+
+Monitoring network health involves the following phases:
+
+* Configuring the Network Observability Operator to collect required network health data for monitoring, such as packet drops or DNS tracking.
+* Reviewing and customizing default health rules and thresholds in the `FlowCollector` custom resource.
+* Monitoring alerts in the {product-title} web console in the *Observe* → *Alerting* and *Observe* → *Network Health* views.
+* Creating custom health rules for specific requirements.
+* Configuring recording rules to optimize performance for large-scale deployments.
+
+The `PrometheusRule` resource in the `netobserv` namespace can be viewed by running the following command:
 
 [source,terminal]
 ----

--- a/modules/network-observability-health-rules-monitoring-and-alerting.adoc
+++ b/modules/network-observability-health-rules-monitoring-and-alerting.adoc
@@ -4,21 +4,21 @@
 
 :_mod-docs-content-type: CONCEPT
 [id="network-observability-health-rules-monitoring-and-alerting_{context}"]
-= Network health monitoring and alerting rules
+= Detecting network issues with automated health rules
 
 [role="_abstract"]
-The Network Observability Operator includes a rule-based system to detect network anomalies and infrastructure failures. By converting configurations into alerting rules, the Operator enables automated monitoring and troubleshooting through the {product-title} web console.
+The Network Observability Operator includes a rule-based system to detect network anomalies and infrastructure failures. By converting configurations into alerting rules, the Operator provides automated monitoring and troubleshooting through the {product-title} web console.
 
 [id="network-observability-health-outcomes_{context}"]
 == Monitoring outcomes
-The Network Observability Operator surfaces network status in the following areas:
+The Network Observability Operator displays network status in the following views:
 
-*Alerting* UI:: Specific alerts appear in *Observe* → *Alerting*, where notifications are managed through the Prometheus `AlertManager`.
-*Network Health* dashboard:: A specialized dashboard in *Observe* → *Network Health* provides a high-level summary of cluster network status.
+*Alerting* UI:: Specific alerts appear in *Observe* → *Alerting*. Notifications are managed through the Prometheus `Alertmanager`.
+*Network Health* dashboard:: A specialized dashboard in *Observe* → *Network Health* provides a summary of cluster network status.
 
 The *Network Health* dashboard categorizes violations into tabs to isolate the scope of an issue:
 
-* *Global*: Aggregate health of the entire cluster.
+* *Global*: Aggregate health of the cluster.
 * *Nodes*: Violations specific to infrastructure nodes.
 * *Namespaces*: Violations specific to individual namespaces.
 * *Workloads*: Violations specific to resources, such as `Deployments` or `DaemonSets`.
@@ -29,22 +29,22 @@ The Network Observability Operator provides default rules for common networking 
 
 The following list contains a subset of available default rules:
 
-`PacketDropsByDevice`:: Triggers on a high percentage of packet drops from network devices. It is based on standard node-exporter metrics and does not require the `PacketDrop` agent feature.
-`PacketDropsByKernel`:: Triggers on a high percentage of packet drops by the kernel. Requires the `PacketDrop` agent feature.
-`IPsecErrors`:: Triggers when IPsec encryption errors are detected. Requires the `IPSec` agent feature.
-`NetpolDenied`:: Triggers when traffic denied by network policies is detected. Requires the `NetworkEvents` agent feature.
-`LatencyHighTrend`:: Triggers when a significant increase in TCP latency is detected. Requires the `FlowRTT` agent feature.
-`DNSErrors`:: Triggers when DNS errors are detected. Requires the `DNSTracking` agent feature.
+`PacketDropsByDevice`:: Reports a high percentage of packet drops from network devices. This rule is based on node-exporter metrics and does not require the `PacketDrop` agent feature.
+`PacketDropsByKernel`:: Reports a high percentage of packet drops by the kernel. This rule requires the `PacketDrop` agent feature.
+`IPsecErrors`:: Reports IPsec encryption errors. This rule requires the `IPSec` agent feature.
+`NetpolDenied`:: Reports traffic denied by network policies. This rule requires the `NetworkEvents` agent feature.
+`LatencyHighTrend`:: Reports a significant increase in TCP latency. This rule requires the `FlowRTT` agent feature.
+`DNSErrors`:: Reports DNS errors. This rule requires the `DNSTracking` agent feature.
 
-Operational alerts for the Network Observability Operator:
+The following operational alerts apply to the Network Observability Operator:
 
-`NetObservNoFlows`:: Triggers when the pipeline is active but no flows are observed.
-`NetObservLokiError`:: Triggers when flows are dropped because of Loki errors.
+`NetObservNoFlows`:: Reports when the pipeline is active but no flows are observed.
+`NetObservLokiError`:: Reports when flows are dropped because of Loki errors.
 
 For a complete list of rules and runbooks, see the link:https://github.com/openshift/runbooks/tree/master/alerts/network-observability-operator[Network Observability Operator runbooks].
 
-[id="network-observability-rule-dependencies_{context}"]
-== Rule dependencies and feature requirements
-The Network Observability Operator creates rules based on the features enabled in the `FlowCollector` custom resource (CR).
+[id="network-observability-enabling-features-for-health-monitoring_{context}"]
+== Enabling features for health monitoring
+The Network Observability Operator creates rules based on the features enabled in the `FlowCollector` CR.
 
-For example, packet drop-related rules are created only if the `PacketDrop` agent feature is enabled. Rules are built on metrics; if the required metrics are missing, configuration warnings might appear. Configure metrics in the `spec.processor.metrics.includeList` object of the `FlowCollector` resource.
+For example, packet drop rules are created only if the `PacketDrop` agent feature is enabled. Rules depend on metrics; if the required metrics are unavailable, configuration warnings might appear. Configure metrics in the `spec.processor.metrics.includeList` field of the `FlowCollector` resource.

--- a/modules/network-observability-health-rules-promql-expressions-metadata.adoc
+++ b/modules/network-observability-health-rules-promql-expressions-metadata.adoc
@@ -4,69 +4,63 @@
 
 :_mod-docs-content-type: REFERENCE
 [id="network-observability-health-rules-promql-expressions-metadata_{context}"]
-= PromQL expressions and metadata for health rules
+= Health rule query and metadata reference
 
 [role="_abstract"]
-Learn about the base query for Prometheus Query Language (`PromQL`), and how to customize it so you can configure network observability alerts for your specific needs.
+The `FlowCollector` health rule API maps to the Prometheus Operator to generate `PrometheusRule` objects. Use these base Prometheus Query Language (PromQL) patterns and metadata configurations to create custom health rules for network observability.
 
-The health rule API in the network observability `FlowCollector` custom resource (`CR`) is mapped to the Prometheus Operator API, generating a `PrometheusRule`. You can see the `PrometheusRule` in the default `netobserv` namespace by running the following command:
+The `PrometheusRule` resource in the `netobserv` namespace can be viewed by running the following command:
 
 [source,terminal]
 ----
-$ oc get prometheusrules -n netobserv -oyaml
+$ oc get prometheusrules -n netobserv -o yaml
 ----
 
-[id="example-example-query-alert-for-surge-in-incoming-traffic_{context}"]
-== An example query for an alert in a surge of incoming traffic
+[id="example-query-surge-incoming-traffic_{context}"]
+== Customizing alert logic with PromQL: Incoming traffic surge
 
-This example provides the base `PromQL` query pattern for an alert about a surge in incoming traffic:
+The following PromQL query calculates the byte rate from the `openshift-ingress` namespace to any workload namespace over a 30-minute interval:
 
 [source,promql]
 ----
 sum(rate(netobserv_workload_ingress_bytes_total{SrcK8S_Namespace="openshift-ingress"}[30m])) by (DstK8S_Namespace)
 ----
 
-This query calculates the byte rate coming from the `openshift-ingress` namespace to any of your workloads' namespaces over the past 30 minutes.
+Queries can be customized to filter low-bandwidth data, compare time periods, and establish thresholds.
 
-You can customize the query, including retaining only some rates, running the query for specific time periods, and setting a final threshold.
-
-Filtering noise:: Appending `> 1000` to this query retains only the rates observed that are greater than `1 KB/s`, which eliminates noise from low-bandwidth consumers.
+Data filtering:: Appending `> 1000` to the query removes rates lower than `1 KB/s` to filter low-bandwidth traffic.
 +
 `(sum(rate(netobserv_workload_ingress_bytes_total{SrcK8S_Namespace="openshift-ingress"}[30m])) by (DstK8S_Namespace) > 1000)`
 +
-The byte rate is relative to the sampling interval defined in the `FlowCollector` custom resource (`CR`) configuration. If the sampling interval is `1:100`, the actual traffic might be approximately 100 times higher than the reported metrics.
+[NOTE]
+====
+The byte rate is relative to the sampling interval in the `FlowCollector` CR. Normalizing byte rates with the `netobserv_agent_sampling_rate` metric decouples the PromQL expression from the sampling configuration.
+====
 
-Time comparison:: You can run the same query for a particular period of time using the `offset` modifier. For example, a query for one day earlier can be run using `offset 1d`, and a query for five hours ago can be run using `offset 5h`.
+Time comparison:: The `offset` modifier compares data across different time periods. For example, `offset 1d` retrieves data from the previous day.
 +
 `sum(rate(netobserv_workload_ingress_bytes_total{SrcK8S_Namespace="openshift-ingress"}[30m] offset 1d)) by (DstK8S_Namespace))`
-+
-You can use the formula `100 * (<query now> - <query from the previous day>) / <query from the previous day>` to calculate the percentage of increase compared to the previous day. This value can be negative if the byte rate today is lower than the previous day.
 
-Final threshold:: You can apply a final threshold to filter increases that are lower than the desired percentage. For example, `> 100` eliminates increases that are lower than 100%.
+Threshold application:: A final threshold filters increases below a specific percentage. For example, `> 100` removes increases lower than 100%.
 
-Together, the complete expression for the `PrometheusRule` looks like the following:
+The following example shows a complete PromQL expression for a `PrometheusRule`:
 
 [source,promql]
 ----
-...
-      expr: |-
-        (100 *
-          (
-            (sum(rate(netobserv_workload_ingress_bytes_total{SrcK8S_Namespace="openshift-ingress"}[30m])) by (DstK8S_Namespace) > 1000)
-            - sum(rate(netobserv_workload_ingress_bytes_total{SrcK8S_Namespace="openshift-ingress"}[30m] offset 1d)) by (DstK8S_Namespace)
-          )
-          / sum(rate(netobserv_workload_ingress_bytes_total{SrcK8S_Namespace="openshift-ingress"}[30m] offset 1d)) by (DstK8S_Namespace))
-        > 100
+expr: |-
+  (100 *
+    (
+      (sum(rate(netobserv_workload_ingress_bytes_total{SrcK8S_Namespace="openshift-ingress"}[30m])) by (DstK8S_Namespace) > 1000)
+      - sum(rate(netobserv_workload_ingress_bytes_total{SrcK8S_Namespace="openshift-ingress"}[30m] offset 1d)) by (DstK8S_Namespace)
+    )
+    / sum(rate(netobserv_workload_ingress_bytes_total{SrcK8S_Namespace="openshift-ingress"}[30m] offset 1d)) by (DstK8S_Namespace))
+  > 100
 ----
 
 [id="alert-metadata-fields_{context}"]
 == Alert metadata fields
 
-The Network Observability Operator uses components from other {product-title} features, such as the monitoring stack, to enhance visibility into network traffic. For more information, see: "Monitoring stack architecture".
-
-Some metadata must be configured for the rule definitions. This metadata is used by Prometheus and the `Alertmanager` service from the monitoring stack, or by the *Network Health* dashboard.
-
-The following example shows an `AlertingRule` resource with the configured metadata:
+Rule definitions require specific metadata for the Prometheus `Alertmanager` service and the *Network Health* dashboard. The following example shows an `AlertingRule` resource with configured metadata:
 
 [source,yaml]
 ----
@@ -83,16 +77,10 @@ spec:
       annotations:
         netobserv_io_network_health: '{"namespaceLabels":["DstK8S_Namespace"],"threshold":"100","unit":"%","upperBound":"500"}'
         message: |-
-          NetObserv is detecting a surge of incoming traffic: current traffic to {{ $labels.DstK8S_Namespace }} has increased by more than 100% since yesterday.
+          Surge of incoming traffic detected: current traffic to {{ $labels.DstK8S_Namespace }} increased by more than 100% since yesterday.
         summary: "Surge in incoming traffic"
       expr: |-
-        (100 *
-          (
-            (sum(rate(netobserv_workload_ingress_bytes_total{SrcK8S_Namespace="openshift-ingress"}[30m])) by (DstK8S_Namespace) > 1000)
-            - sum(rate(netobserv_workload_ingress_bytes_total{SrcK8S_Namespace="openshift-ingress"}[30m] offset 1d)) by (DstK8S_Namespace)
-          )
-          / sum(rate(netobserv_workload_ingress_bytes_total{SrcK8S_Namespace="openshift-ingress"}[30m] offset 1d)) by (DstK8S_Namespace))
-        > 100
+        # ... (PromQL expression)
       for: 1m
       labels:
         app: netobserv
@@ -100,20 +88,17 @@ spec:
         severity: warning
 ----
 
-where:
-
 `spec.groups.rules.alert.labels.netobserv`::
-Specifies the alert for the *Network Health* dashboard to detect when set to `true`.
+Specifies that the *Network Health* dashboard must detect the alert when set to `true`.
 `spec.groups.rules.alert.labels.severity`::
-Specifies the severity of the alert. The following values are valid: `critical`, `warning`, or `info`.
+Specifies the alert severity. Valid values are `critical`, `warning`, or `info`.
 
-You can leverage the output labels from the defined `PromQL` expression in the `message` annotation. In the example, since results are grouped per `DstK8S_Namespace`, the expression `{{ $labels.DstK8S_Namespace }}` is used in the message text.
+[id="netobserv-io-network-health-annotation_{context}"]
+== netobserv_io_network_health annotation fields
 
-The `netobserv_io_network_health` annotation is optional, and controls how the alert is rendered on the *Network Health* page.
+The optional `netobserv_io_network_health` annotation is a JSON string that controls how the alert renders on the *Network Health* page.
 
-The `netobserv_io_network_health` annotation is a JSON string consisting of the following fields:
-
-.Fields for the netobserv_io_network_health annotation
+.Fields for the `netobserv_io_network_health` annotation
 [cols="2,2,6",options="header"]
 |===
 | Field
@@ -122,55 +107,30 @@ The `netobserv_io_network_health` annotation is a JSON string consisting of the 
 
 | `namespaceLabels`
 | List of strings
-| One or more labels that hold namespaces. When provided, the alert appears under the *Namespaces* tab.
+| One or more labels containing namespaces. Alerts appear under the *Namespaces* tab.
 
 | `nodeLabels`
 | List of strings
-| One or more labels that hold node names. When provided, the alert appears under the *Nodes* tab.
+| One or more labels containing node names. Alerts appear under the *Nodes* tab.
 
-|`workloadLabels`
+| `workloadLabels`
 | List of strings
-| One or more labels that hold owner/workload names. When provided alongside with `kindLabels`, the alert will show up under the "Owners" tab.
-
-|`kindLabels`
-| List of strings
-| One or more labels that hold owner/workload kinds. When provided alongside with `workloadLabels`, the alert will show up under the "Owners" tab.
+| One or more labels containing owner or workload names. Alerts appear under the *Owners* tab when `kindLabels` is also provided.
 
 | `threshold`
 | String
-| The alert threshold, expected to match the threshold defined in the `PromQL` expression.
+| The alert threshold. This value should match the threshold in the PromQL expression.
 
 | `unit`
 | String
-| The data unit, used only for display purposes.
+| The data unit for display purposes.
 
 | `upperBound`
 | String
-| An upper bound value used to compute the score on a closed scale. Metric values exceeding this bound are clamped.
-
-| `links`
-| List of objects
-| A list of links to display contextually with the alert. Each link requires a `name` (display name) and `url`.
-
-| `trafficLink`
-| String
-| Information related to the link to the *Network Traffic* page, for URL building. Some filters will be set automatically, such as the `node` or `namespace` filter.
+| An upper bound value used to calculate scores on a closed scale. Metric values exceeding this bound are clamped.
 |===
 
-The `namespaceLabels` and `nodeLabels` are mutually exclusive. If neither is provided, the alert appears under the *Global* tab.
-
-.`trafficLink` fields
-[cols="1,3",options="header"]
-|===
-| Field
-| Description
-
-| `extraFilter`
-| Additional filter to inject (for example, a DNS response code for DNS-related alerts).
-
-| `backAndForth`
-| Whether the filter should include return traffic (`true` or `false`).
-
-| `filterDestination`
-| Whether the filter should target the destination of the traffic instead of the source (`true` or `false`).
-|===
+[NOTE]
+====
+The `namespaceLabels` and `nodeLabels` fields are mutually exclusive. If neither is provided, the alert appears under the *Global* tab.
+====

--- a/modules/network-observability-health-rules-recording-rules-performance-optimization.adoc
+++ b/modules/network-observability-health-rules-recording-rules-performance-optimization.adoc
@@ -3,11 +3,11 @@
 // * network_observability/network-observability-health-rules.adoc
 
 :_mod-docs-content-type: CONCEPT
-[id="network-observability-health-rules-recording-rules-performance-optimization_{context}"]
+[id="network-observability-recording-rules-performance-optimization_{context}"]
 = Performance optimization with recording rules
 
 [role="_abstract"]
-For large-scale clusters, recording rules optimize how Prometheus handles network data. Recording rules improve dashboard responsiveness and reduce the computational overhead of complex queries.
+In large-scale clusters, recording rules optimize how Prometheus handles network data. Recording rules improve dashboard responsiveness and reduce the computational overhead of complex queries.
 
 [id="network-observability-recording-rules-benefits_{context}"]
 == Optimization benefits
@@ -19,29 +19,46 @@ Improved performance:: Pre-computing Prometheus queries allows dashboards to loa
 Resource efficiency:: Calculating data at fixed intervals reduces CPU load on the Prometheus server compared to recalculating data on every dashboard refresh.
 Simplified queries:: Using short metric names, such as `cluster:network_traffic:rate_5m`, simplifies complex aggregate calculations in custom dashboards.
 
+
+
 [id="network-observability-alert-vs-recording-comparison_{context}"]
 == Comparison of rule modes
 The following table compares rule modes based on the expected outcome:
 
 [cols="1,2,2",options="header"]
 |===
-| Description
+| Feature
 | Alerting rules
 | Recording rules
 
-| Goal
+| Primary goal
 | Issue notification.
-| Save history of high level metrics.
+| Persistent metric history.
 
-| Data result
-| Generates an alerting state.
-| Creates a persistent metric.
+| Data output
+| Alerting state.
+| New time series metric.
 
-| Visibility
-| *Alerting* UI and *Network Health* view.
-| *Metrics Explorer* and *Network Health* view.
+| UI visibility
+| *Alerting* and *Network Health* views.
+| *Metrics Explorer* and *Network Health* views.
 
 | Notifications
-| Triggers `AlertManager` notifications.
+| Triggers `Alertmanager` notifications.
 | Does not trigger notifications.
 |===
+
+[id="network-observability-integrating-recording-rules-with-health-dashboard_{context}"]
+== Integrating recording rules with the health dashboard
+
+Custom recording rules that contribute to the *Network Health* dashboard must meet specific metadata requirements.
+
+Label requirements::
+Include the `netobserv: "true"` label in the `labels` field of the rule and the `PrometheusRule` metadata. The Network Observability Operator identifies `PrometheusRule` resources cluster-wide by using this label.
+
+Annotation requirements::
+Include the `netobserv.io/network-health` annotation in the `PrometheusRule` metadata. This annotation is required for recording rules to appear in the *Network Health* dashboard. The value is a JSON object where keys are the metric names (the `record` field of each rule). Each value consists of the following fields:
++
+* `summary`: An optional short title. This field supports Prometheus template syntax, such as `{{ $labels.namespace }}`.
+* `description`: An optional description. This field supports Prometheus template syntax.
+* `netobserv_io_network_health`: A required JSON string. For recording rules, use the `recordingThresholds` field instead of `threshold`. This field determines the health score and UI coloring, such as `{"info":"10","warning":"25","critical":"50"}`.

--- a/modules/network-observability-recording-rule-custom-configuration.adoc
+++ b/modules/network-observability-recording-rule-custom-configuration.adoc
@@ -1,0 +1,73 @@
+// Module included in the following assemblies:
+//
+// * network_observability/network-observability-health-rules.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="network-observability-configuring-custom-recording-rules_{context}"]
+= Optimizing dashboard metrics with recording rules
+
+[role="_abstract"]
+Create custom recording rules to pre-compute metrics for the *Network Health* dashboard. Recording rules require specific annotations and labels to integrate with the Network Observability Operator.
+
+.Prerequisites
+
+* Access to the cluster with `cluster-admin` privileges.
+* The Network Observability Operator is installed.
+* {product-title} 4.16 or later is installed.
+* Familiarity with PromQL.
+
+[IMPORTANT]
+====
+Custom `PrometheusRule` resources are not owned by the `FlowCollector` resource. Custom rules created in the `netobserv` namespace might be deleted if the Network Observability Operator is uninstalled. To prevent data loss, create custom rules in a different namespace, such as `openshift-monitoring`, and maintain a backup in version control.
+====
+
+.Procedure
+
+. Define a `PrometheusRule` resource in a YAML file, such as `custom-recording-rule.yaml`, ensuring the `netobserv: "true"` label and `netobserv.io/network-health` annotation are included:
++
+[source,yaml]
+----
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: my-recording-rules
+  namespace: openshift-monitoring
+  labels:
+    netobserv: "true"
+  annotations:
+    netobserv.io/network-health: |
+      {
+        "my_metric_per_namespace": {
+          "summary": "Custom metric is {{ $value }} in the namespace {{ $labels.namespace }}",
+          "description": "Custom metric is {{ $value }} in the namespace {{ $labels.namespace }}",
+          "netobserv_io_network_health": "{\"unit\":\"%\",\"upperBound\":\"100\",\"namespaceLabels\":[\"namespace\"],\"recordingThresholds\":{\"info\":\"10\",\"warning\":\"25\",\"critical\":\"50\"}}"
+        }
+      }
+spec:
+  groups:
+    - name: MyRecordingRules
+      interval: 30s
+      rules:
+        - record: my_metric_per_namespace
+          expr: (count by (namespace) (kube_pod_info) * 0 + 20)
+          labels:
+            netobserv: "true"
+----
+
+. Apply the custom recording rule by running the following command:
++
+[source,terminal]
+----
+$ oc apply -f custom-recording-rule.yaml
+----
+
+.Verification
+
+. Confirm the `PrometheusRule` resource exists by running the following command:
++
+[source,terminal]
+----
+$ oc get prometheusrules my-recording-rules -n openshift-monitoring -o yaml
+----
+
+. Confirm the recording rule appears in the {product-title} web console by navigating to *Observe* → *Network Health*.

--- a/observability/network_observability/network-observability-health-rules.adoc
+++ b/observability/network_observability/network-observability-health-rules.adoc
@@ -20,13 +20,15 @@ include::modules/network-observability-health-rules-and-performance.adoc[levelof
 
 include::modules/network-observability-health-rules-monitoring-and-alerting.adoc[leveloffset=+2]
 
-include::modules/network-observability-health-rules-recording-rules-performance-optimization.adoc[leveloffset=+1]
-
 include::modules/network-observability-health-rule-structure-customization.adoc[leveloffset=+1]
 
 include::modules/network-observability-health-rules-promql-expressions-metadata.adoc[leveloffset=+2]
 
 include::modules/network-observability-custom-health-rule-configuration.adoc[leveloffset=+2]
+
+include::modules/network-observability-health-rules-recording-rules-performance-optimization.adoc[leveloffset=+1]
+
+include::modules/network-observability-recording-rule-custom-configuration.adoc[leveloffset=+2]
 
 include::modules/network-observability-disable-predefined-rules.adoc[leveloffset=+1]
 

--- a/observability/network_observability/network-observability-health-rules.adoc
+++ b/observability/network_observability/network-observability-health-rules.adoc
@@ -1,6 +1,6 @@
 
 :_mod-docs-content-type: ASSEMBLY
-[id="network-observability-health-rules_{context}"]
+[id="network-observability-health-rules"]
 = Network observability health rules
 :context: network-observability-health-rules
 :toc:

--- a/observability/network_observability/network-observability-health-rules.adoc
+++ b/observability/network_observability/network-observability-health-rules.adoc
@@ -1,6 +1,6 @@
 
 :_mod-docs-content-type: ASSEMBLY
-[id="network-observability-health-rules_{context}"]
+[id="network-observability-health-rules"]
 = Network observability health rules
 :context: network-observability-health-rules
 :toc:
@@ -20,13 +20,15 @@ include::modules/network-observability-health-rules-and-performance.adoc[levelof
 
 include::modules/network-observability-health-rules-monitoring-and-alerting.adoc[leveloffset=+2]
 
-include::modules/network-observability-health-rules-recording-rules-performance-optimization.adoc[leveloffset=+1]
-
 include::modules/network-observability-health-rule-structure-customization.adoc[leveloffset=+1]
 
 include::modules/network-observability-health-rules-promql-expressions-metadata.adoc[leveloffset=+2]
 
 include::modules/network-observability-custom-health-rule-configuration.adoc[leveloffset=+2]
+
+include::modules/network-observability-health-rules-recording-rules-performance-optimization.adoc[leveloffset=+1]
+
+include::modules/network-observability-recording-rule-custom-configuration.adoc[leveloffset=+2]
 
 include::modules/network-observability-disable-predefined-rules.adoc[leveloffset=+1]
 


### PR DESCRIPTION
[OSDOCS-19414](https://redhat.atlassian.net/browse/OSDOCS-19414) [NETOBSERV] 1.12 Health Rules recording

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
Merge into `no-1.12` only. No cherry picks.

Issue:
https://redhat.atlassian.net/browse/OSDOCS-19414

Link to docs preview:
* Network observability health rules: https://111207--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/network-observability-health-rules
* Identifying network issues with automated health rules: https://111207--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/network-observability-health-rules#network-observability-health-rules-and-performance_network-observability-health-rules
* Importance of network healt monitoring: https://111207--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/network-observability-health-rules#importance-of-network-health-monitoring_network-observability-health-rules
* Automated health monitoring: https://111207--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/network-observability-health-rules#detection-of-network-issues_network-observability-health-rules
* Network health monitoring workflow: https://111207--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/network-observability-health-rules#network-health-monitoring-workflow_network-observability-health-rules
* Detecting network issues with automated health rules: https://111207--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/network-observability-health-rules#network-observability-health-rules-monitoring-and-alerting_network-observability-health-rules
* Health rules threshold and grouping customization: https://111207--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/network-observability-health-rules#network-observability-health-rule-customization_network-observability-health-rules
* Query and meta data reference: https://111207--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/network-observability-health-rules#network-observability-health-rules-promql-expressions-metadata_network-observability-health-rules
* Configuring custom health rules: https://111207--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/network-observability-health-rules#network-observability-configuring-custom-health-rules_network-observability-health-rules
* Performance optimization with recording rules: https://111207--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/network-observability-health-rules#network-observability-recording-rules-performance-optimization_network-observability-health-rules
* Benefits: https://111207--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/network-observability-health-rules#network-observability-recording-rules-benefits_network-observability-health-rules
* Comparison of rule modes: https://111207--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/network-observability-health-rules#network-observability-alert-vs-recording-comparison_network-observability-health-rules
* Integrating recording rules with health dashboard: https://111207--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/network-observability-health-rules#network-observability-integrating-recording-rules-with-health-dashboard_network-observability-health-rules
* Optimizing dashboard metrics with recording rules: https://111207--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/network-observability-health-rules#network-observability-configuring-custom-recording-rules_network-observability-health-rules
* Disabling default alerts: https://111207--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/network-observability-health-rules#network-observability-disable-predefined-rules_network-observability-health-rules
* Additional resources: https://111207--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/network-observability-health-rules#additional-resources

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
* I will open one PR against `main` to incorporate all of the `no-1.12` content just before its GA.
* Follows JTBD to be in line with Observability Docs.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
