### PR TITLE
OSDOCS-19084: Updated documentation about ingress namespace exclusions.

### DIFF
--- a/modules/create-wif-cluster-ocm.adoc
+++ b/modules/create-wif-cluster-ocm.adoc
@@ -127,12 +127,19 @@ Private Service Connect is supported only with *Install into an existing VPC*.
 +
 .. If you are installing into an existing VPC and you want to enable an HTTP or HTTPS proxy for your cluster, select *Configure a cluster-wide proxy*.
 +
-. Accept the default application ingress settings, or to create your own custom settings, select *Custom Settings*.
-
-.. Optional: Provide route selector.
-.. Optional: Provide excluded namespaces.
-.. Select a namespace ownership policy.
-.. Select a wildcard policy.
+. Accept the default application ingress settings, or to create your own custom settings, select *Custom Settings*. All of the custom settings are optional.
+.. In *Route selector*, enter a comma-separated list of `key=value` pairs to limit which routes this ingress exposes.
+Leave the field empty if all routes should remain eligible based on your other choices.
+.. In *Excluded namespaces*, enter a comma-separated list of namespace names whose routes must not use this ingress.
+.. In *Exclude namespace selectors*, specify one or more label selectors. For each selector, provide a label key and a comma-separated list of label values. The default Ingress Controller does not apply to namespaces whose labels satisfy any of the configured selectors.
++
+[IMPORTANT]
+====
+Do not include spaces around commas, for example, use `finance,HR,legal`, and not `finance, HR, legal`.
+====
++
+.. Set *Namespace ownership policy* for route admission when namespaces share hostnames, for example, select *Strict* for restrictive admission.
+.. Set *Wildcard policy* to allow or disallow wildcard patterns in route hostnames, for example, select *Disallowed* to block wildcard host routes.
 +
 For more information about custom application ingress settings, click on the information icon provided for each setting.
 
@@ -188,7 +195,22 @@ If you are installing a cluster into a Shared VPC, the VPC name and subnets are 
 +
 For more information about configuring a proxy with {product-title}, see _Configuring a cluster-wide proxy_.
 
+. Accept the default application ingress settings, or to create your own custom settings, select *Custom Settings*. All of the custom settings are optional.
+.. In *Route selector*, enter a comma-separated list of `key=value` pairs to limit which routes this ingress exposes.
+Leave the field empty if all routes should remain eligible based on your other choices.
+.. In *Excluded namespaces*, enter a comma-separated list of namespace names whose routes must not use this ingress.
+.. In *Exclude namespace selectors*, specify one or more label selectors. For each selector, provide a label key and a comma-separated list of label values. The default Ingress Controller does not apply to namespaces whose labels satisfy any of the configured selectors.
 +
+[IMPORTANT]
+====
+Do not include spaces around commas, for example, use `finance,HR,legal`, and not `finance, HR, legal`.
+====
++
+.. Set *Namespace ownership policy* for route admission when namespaces share hostnames, for example, select *Strict* for restrictive admission.
+.. Set *Wildcard policy* to allow or disallow wildcard patterns in route hostnames, for example, select *Disallowed* to block wildcard host routes.
++
+For more information about custom application ingress settings, click the information icon provided for each setting.
+
 . In the *CIDR ranges* dialog, configure custom classless inter-domain routing (CIDR) ranges or use the defaults that are provided.
 +
 [IMPORTANT]

--- a/modules/osd-cluster-create-application-ingress-selector-day1-ui.adoc
+++ b/modules/osd-cluster-create-application-ingress-selector-day1-ui.adoc
@@ -1,0 +1,34 @@
+// Module included in the following assemblies:
+//
+// * networking/networking_operators/ingress-operator.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="osd-create-cluster-exclude-namespace-selector-day1-ui_{context}"]
+= Set namespace exclusions for the default ingress when creating a cluster in {cluster-manager-first}
+
+[role="_abstract"]
+Specify a namespace label selector so that namespaces matching those labels are excluded from the default `application ingress` when creating an {product-title} cluster in {cluster-manager-url}.
+
+.Procedure
+
+. On the *Networking* screen, select *Custom Settings* under *Application ingress settings*. 
++
+[NOTE]
+====
+All of the custom settings are optional.
+====
++
+. In *Route selector*, enter a comma-separated list of `key=value` pairs to limit which routes this ingress exposes.
+Leave the field empty if all routes should remain eligible based on your other choices.
+. In *Excluded namespaces*, enter a comma-separated list of namespace names whose routes must not use this ingress.
+. In *Exclude namespace selectors*, specify one or more label selectors. For each selector, provide a label key and a comma-separated list of label values. The default Ingress Controller does not apply to namespaces whose labels satisfy any of the configured selectors.
++
+[IMPORTANT]
+====
+Do not include spaces around commas, for example, use `finance,HR,legal`, and not `finance, HR, legal`.
+====
++
+. Set *Namespace ownership policy* for route admission when namespaces share hostnames, for example, select *Strict* for restrictive admission.
+. Set *Wildcard policy* to allow or disallow wildcard patterns in route hostnames, for example, select *Disallowed* to block wildcard host routes.
++
+For more information about custom application ingress settings, click the information icon provided for each setting.

--- a/modules/osd-cluster-create-application-ingress-selector-day2-ui.adoc
+++ b/modules/osd-cluster-create-application-ingress-selector-day2-ui.adoc
@@ -1,0 +1,40 @@
+// Module included in the following assemblies:
+//
+// * networking/networking_operators/ingress-operator.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="osd-create-cluster-exclude-namespace-selector-day2-ui_{context}"]
+= Change namespace exclusions for the ingress on a cluster in {cluster-manager-first}
+
+[role="_abstract"]
+Specify a namespace label selector so that namespaces matching those labels are excluded from the default `application ingress` on your configured {product-title} cluster in {cluster-manager}.
+
+.Procedure
+
+. From {cluster-manager-url}, navigate to the *Cluster List* page and select the cluster that you want to set namespace exclusions for.
+
+. On the selected cluster, select the *Networking* tab.
+
+. Select *Edit application ingress*. 
++
+[NOTE]
+====
+All of the custom settings are optional.
+====
++
+. In *Route selector*, enter a comma-separated list of `key=value` pairs to limit which routes this ingress exposes.
+Leave the field empty if all routes should remain eligible based on your other choices.
+. In *Excluded namespaces*, enter a comma-separated list of namespace names whose routes must not use this ingress.
+. In *Exclude namespace selectors*, specify one or more label selectors. For each selector, provide a label key and a comma-separated list of label values. The default Ingress Controller does not apply to namespaces whose labels satisfy any of the configured selectors.
++
+[IMPORTANT]
+====
+Do not include spaces around commas, for example, use `finance,HR,legal`, and not `finance, HR, legal`.
+====
++
+. Set *Namespace ownership policy* for route admission when namespaces share hostnames, for example, select *Strict* for restrictive admission.
+. Set *Wildcard policy* to allow or disallow wildcard patterns in route hostnames, for example, select *Disallowed* to block wildcard host routes.
++
+For more information about custom application ingress settings, click the information icon provided for each setting.
+
+. Select *Save* to configure the ingress with your changes.

--- a/modules/osd-cluster-create-application-ingress-settings.adoc
+++ b/modules/osd-cluster-create-application-ingress-settings.adoc
@@ -1,0 +1,15 @@
+// Module included in the following assemblies:
+//
+// * networking/networking_operators/ingress-operator.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="osd-create-cluster-exclude-namespace-selector-settings_{context}"]
+= Set namespace exclusions for the default ingress when creating a cluster
+
+[role="_abstract"]
+When you create an {product-title} cluster, you can specify a namespace label selector so that namespaces matching those labels are excluded from the default `application ingress`. This allows you to exclude namespaces that host workloads through the default ingress, such as namespaces with sensitive data or internal services.
+
+[NOTE]
+====
+Do not exclude namespaces that host required platform routes (for example, `openshift-console` or `openshift-authentication`). Excluding them can break the web console, downloads, or OAuth flows.
+====

--- a/modules/osd-create-cluster-ccs.adoc
+++ b/modules/osd-create-cluster-ccs.adoc
@@ -177,12 +177,19 @@ Private Service Connect is supported only with *Install into an existing VPC*.
 In order to configure a cluster-wide proxy for your cluster, you must first create the Cloud network address translation (NAT) and a Cloud router. See the _Additional resources_ section for more information.
 ====
 --
-. Accept the default application ingress settings, or to create your own custom settings, select *Custom Settings*.
-
-.. Optional: Provide route selector.
-.. Optional: Provide excluded namespaces.
-.. Select a namespace ownership policy.
-.. Select a wildcard policy.
+. Accept the default application ingress settings, or to create your own custom settings, select *Custom Settings*. All of the custom settings are optional.
+.. In *Route selector*, enter a comma-separated list of `key=value` pairs to limit which routes this ingress exposes.
+Leave the field empty if all routes should remain eligible based on your other choices.
+.. In *Excluded namespaces*, enter a comma-separated list of namespace names whose routes must not use this ingress.
+.. In *Exclude namespace selectors*, specify one or more label selectors. For each selector, provide a label key and a comma-separated list of label values. The default Ingress Controller does not apply to namespaces whose labels satisfy any of the configured selectors.
++
+[IMPORTANT]
+====
+Do not include spaces around commas, for example, use `finance,HR,legal`, and not `finance, HR, legal`.
+====
++
+.. Set *Namespace ownership policy* for route admission when namespaces share hostnames, for example, select *Strict* for restrictive admission.
+.. Set *Wildcard policy* to allow or disallow wildcard patterns in route hostnames, for example, select *Disallowed* to block wildcard host routes.
 +
 For more information about custom application ingress settings, click on the information icon provided for each setting.
 

--- a/modules/osd-create-cluster-exclude-namespace-selector-day1-cli.adoc
+++ b/modules/osd-create-cluster-exclude-namespace-selector-day1-cli.adoc
@@ -3,21 +3,16 @@
 // * networking/networking_operators/ingress-operator.adoc
 
 :_mod-docs-content-type: PROCEDURE
-[id="osd-create-cluster-exclude-namespace-selector-cli_{context}"]
-= Set namespace exclusions for the default ingress when creating a cluster
+[id="osd-create-cluster-exclude-namespace-selector-day1-cli_{context}"]
+= Set namespace exclusions for the default ingress when creating a cluster in the CLI
 
 [role="_abstract"]
-When you create an {product-title} cluster in noninteractive mode, pass a namespace label selector to exclude matching namespaces from the default `application ingress`. For example, exclude namespaces that host sensitive data or internal services.
+Use the `ocm` CLI to pass namespace exclusions for the default ingress while creating your cluster.
 
 .Prerequisites
 
 * You installed the `ocm` CLI and logged in with credentials that can create clusters in {cluster-manager-first}.
 * You are using the noninteractive mode for `ocm create cluster`. For interactive mode, use the prompts for ingress settings when they are available for your `ocm` version.
-
-[NOTE]
-====
-Do not exclude namespaces that host required platform routes (for example, `openshift-console` or `openshift-authentication`). Excluding them can break the web console, downloads, or OAuth flows.
-====
 
 .Procedure
 

--- a/modules/osd-create-cluster-exclude-namespace-selector-day2-cli.adoc
+++ b/modules/osd-create-cluster-exclude-namespace-selector-day2-cli.adoc
@@ -1,0 +1,36 @@
+// Module included in the following assemblies:
+//
+// * networking/networking_operators/ingress-operator.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="osd-create-cluster-exclude-namespace-selector-day2-cli_{context}"]
+= Changing namespace exclusions for the default ingress on your cluster in the CLI
+
+[role="_abstract"]
+Use the `ocm` CLI to pass namespace exclusions for the default ingress to your {product-title} cluster.
+
+.Prerequisites
+
+* You installed the `ocm` CLI and logged in with credentials that can modify clusters in {cluster-manager-first}.
+* You have configured a {product-title} cluster.
+
+.Procedure
+
+. Run the following command to pass the namespace exclusions to your cluster:
++
+[source,terminal]
+----
+$ ocm edit ingress <ingress_name> -c <cluster_id> \ 
+  --excluded-namespace-selectors "key1=val1,key2=val2,key1=val3,foo=bar" \
+  <cluster_name>
+----
++
+where:
+
+`<ingress_name>`:: Specifies your ingress name.
+
+`<cluster_id>`:: Specifies your cluster ID.
+
+`--excluded-namespace-selectors "key1=val1,key2=val2,key1=val3,foo=bar"`:: Specifies label selectors that exclude matching namespaces from the default application ingress. The service validates these exclusions. Replace `<key>=<value>` with your labels. Do not include spaces around the `=` sign.
+
+`<cluster_name>`:: Specifies the cluster name.

--- a/modules/osd-create-cluster-red-hat-account.adoc
+++ b/modules/osd-create-cluster-red-hat-account.adoc
@@ -88,6 +88,22 @@ After your cluster is created, you can change the number of compute nodes, but y
 
 . In the *Cluster privacy* dialog, select *Public* or *Private* to use either public or private API endpoints and application routes for your cluster.
 
+. Accept the default application ingress settings, or to create your own custom settings, select *Custom Settings*. All of the custom settings are optional.
+.. In *Route selector*, enter a comma-separated list of `key=value` pairs to limit which routes this ingress exposes.
+Leave the field empty if all routes should remain eligible based on your other choices.
+.. In *Excluded namespaces*, enter a comma-separated list of namespace names whose routes must not use this ingress.
+.. In *Exclude namespace selectors*, specify one or more label selectors. For each selector, provide a label key and a comma-separated list of label values. The default Ingress Controller does not apply to namespaces whose labels satisfy any of the configured selectors.
++
+[IMPORTANT]
+====
+Do not include spaces around commas, for example, use `finance,HR,legal`, and not `finance, HR, legal`.
+====
++
+.. Set *Namespace ownership policy* for route admission when namespaces share hostnames, for example, select *Strict* for restrictive admission.
+.. Set *Wildcard policy* to allow or disallow wildcard patterns in route hostnames, for example, select *Disallowed* to block wildcard host routes.
++
+For more information about custom application ingress settings, click the information icon provided for each setting.
+
 . Click *Next*.
 
 . In the *CIDR ranges* dialog, configure custom classless inter-domain routing (CIDR) ranges or use the defaults that are provided.

--- a/networking/networking_operators/ingress-operator.adoc
+++ b/networking/networking_operators/ingress-operator.adoc
@@ -141,15 +141,27 @@ include::modules/sd-ingress-responsibilities.adoc[leveloffset=+1]
 endif::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 
 ifdef::openshift-dedicated[]
-include::modules/osd-create-cluster-exclude-namespace-selector-cli.adoc[leveloffset=+1]
+include::modules/osd-cluster-create-application-ingress-settings.adoc[leveloffset=+1]
 
-include::modules/osd-ingress-excluded-namespaces-ocm-cli.adoc[leveloffset=+1]
+include::modules/osd-create-cluster-exclude-namespace-selector-day1-cli.adoc[leveloffset=+2]
 
+include::modules/osd-create-cluster-exclude-namespace-selector-day2-cli.adoc[leveloffset=+2]
+
+include::modules/osd-cluster-create-application-ingress-selector-day1-ui.adoc[leveloffset=+2]
+
+include::modules/osd-cluster-create-application-ingress-selector-day2-ui.adoc[leveloffset=+2]
 endif::openshift-dedicated[]
 
-ifndef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
+ifndef::openshift-rosa,openshift-rosa-hcp[]
 [role="_additional-resources"]
 == Additional resources
 
+ifndef::openshift-dedicated[]
 * xref:../../networking/configuring_network_settings/configuring-a-custom-pki.adoc#configuring-a-custom-pki[Configuring a custom PKI]
-endif::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
+endif::openshift-dedicated[]
+ifdef::openshift-dedicated[]
+* xref:../../osd_gcp_clusters/creating-a-gcp-cluster-with-workload-identity-federation.adoc#osd-creating-a-cluster-on-gcp-with-workload-identity-federation[Creating a Workload Identity Federation cluster using {cluster-manager}]
+* xref:../../osd_gcp_clusters/creating-a-gcp-cluster-redhat-account.adoc#osd-creating-a-gcp-cluster-rh-account[Creating a cluster on Google Cloud with a Red Hat cloud account using {cluster-manager}]
+* xref:../../osd_gcp_clusters/creating-a-gcp-cluster-sa.adoc#osd-creating-a-cluster-on-gcp-sa[Creating a cluster with Service Account authentication using {cluster-manager}]
+endif::openshift-dedicated[]
+endif::openshift-rosa,openshift-rosa-hcp[]


### PR DESCRIPTION
Version(s):
`enterprise-4.21+`

Issue:
**[OSDOCS-19552](https://redhat.atlassian.net/browse/OSDOCS-19552)**

Link to docs preview:
- [Set namespace exclusions for the default ingress when creating a cluster
](https://111210--ocpdocs-pr.netlify.app/openshift-dedicated/latest/networking/networking_operators/ingress-operator.html#osd-create-cluster-exclude-namespace-selector-cli_configuring-ingress)

The following sections also added:
<img width="876" height="790" alt="image" src="https://github.com/user-attachments/assets/a19fd852-17f4-4a0e-a13f-5e323847b766" />
 
- [Creating a Workload Identity Federation cluster using OpenShift Cluster Manager](https://111210--ocpdocs-pr.netlify.app/openshift-dedicated/latest/osd_gcp_clusters/creating-a-gcp-cluster-with-workload-identity-federation#create-wif-cluster-ocm_osd-creating-a-cluster-on-gcp-with-workload-identity-federation)
- [Creating a cluster on Google Cloud with a Red Hat cloud account using OpenShift Cluster Manager](https://111210--ocpdocs-pr.netlify.app/openshift-dedicated/latest/osd_gcp_clusters/creating-a-gcp-cluster-redhat-account#osd-create-gcp-cluster-ccs_osd-creating-a-gcp-cluster-rh-account)
- [Creating a cluster with Service Account authentication using OpenShift Cluster Manager](https://111210--ocpdocs-pr.netlify.app/openshift-dedicated/latest/osd_gcp_clusters/creating-a-gcp-cluster-sa#osd-create-gcp-cluster-ccs1_osd-creating-a-cluster-on-gcp-sa)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
This PR adds instructions for editing the ingress within the Web UI.
