### PR TITLE
OSDOCS-16264_RN: adding AWS EUSC RN

### DIFF
--- a/modules/rn-ocp-release-notes-new-features.adoc
+++ b/modules/rn-ocp-release-notes-new-features.adoc
@@ -124,6 +124,13 @@ Installing a cluster on {azure-short} with a user-provisioned DNS was introduced
 +
 For more information, see xref:../installing/installing_azure/ipi/installing-azure-customizations.adoc#installation-azure-enabling-user-managed-DNS_installing-azure-customizations[Enabling a user-managed DNS] and xref:../installing/installing_azure/ipi/installing-azure-customizations.adoc#installation-azure-provisioning-own-dns-records_installing-azure-customizations[Provisioning your own DNS records].
 
+Installing a cluster on {aws-short} European Sovereign Cloud (Technology Preview)::
++
+You can now install {product-title} on {aws-first} in the European Sovereign Cloud (EUSC) region (`eusc-de-east-1`). The {aws-short} EUSC region is separate and independent from other {aws-short} regions, with all the infrastructure located within the European Union (EU). You must specify a custom Amazon Machine Image (AMI) in the `platform.aws.defaultMachinePlatform.amiID` field of your `install-config.yaml` file. Other limitations also apply. The {aws-short} EUSC region is available as a Technology Preview feature.
++
+For more information, see xref:../installing/installing_aws/installing-aws-account.adoc#installation-aws-eusc_region_installing-aws-account[{aws-short} EUSC].
+
+
 [id="ocp-release-notes-machine-config-operator_{context}"]
 == Machine Config Operator
 
@@ -143,7 +150,7 @@ For more information, see xref:../installing/installing_azure/ipi/installing-azu
 
 Network policy enhancement::
 +
-{product-title} now includes `NetworkPolicy` objects in some of its own namespaces by default. This inclusion improves overall security and better protects control plane components. 
+{product-title} now includes `NetworkPolicy` objects in some of its own namespaces by default. This inclusion improves overall security and better protects control plane components.
 +
 Do not modify the `NetworkPolicy` objects that {product-title} includes in its own namespaces by default. To check the namespaces that include the objects by default, you can run the following command:
 +


### PR DESCRIPTION
Version:
4.22

Issue:
https://redhat.atlassian.net/browse/OSDOCS-16264

Link to docs preview:
[Installing a cluster on AWS European Sovereign Cloud (Technology Preview)
](https://111216--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-22-release-notes.html#ocp-release-notes-install-update_release-notes)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
https://github.com/openshift/openshift-docs/pull/110585 is the corresponding PR (where the feature will be documented). 
