### PR TITLE
OSDOCS-19149 [NETOBSERV] 1.12 Release Notes

### DIFF
--- a/modules/network-observability-operator-release-notes-1-12-advisory.adoc
+++ b/modules/network-observability-operator-release-notes-1-12-advisory.adoc
@@ -1,0 +1,11 @@
+// Module included in the following assemblies:
+// * network_observability/network-observability-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="network-observability-operator-release-notes_{context}"]
+= Network Observability Operator 1.12 advisory
+
+[role="_abstract"]
+You can review the advisory for Network Observability Operator 1.12 release.
+
+* link:https://access.redhat.com/errata/RHSA-2026:24473[RHSA-2026:24473 Network Observability Operator 1.12]

--- a/modules/network-observability-operator-release-notes-1-12-advisory.adoc
+++ b/modules/network-observability-operator-release-notes-1-12-advisory.adoc
@@ -1,0 +1,11 @@
+// Module included in the following assemblies:
+// * network_observability/network-observability-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="network-observability-operator-release-notes_{context}"]
+= Network Observability Operator 1.12 advisory
+
+[role="_abstract"]
+You can review the advisory for Network Observability Operator 1.12 release.
+
+* link:https://access.redhat.com/errata/RHSA-2026:<insert>[RHSA-2026:<insert> Network Observability Operator 1.12]

--- a/modules/network-observability-operator-release-notes-1-12-fixed-issues.adoc
+++ b/modules/network-observability-operator-release-notes-1-12-fixed-issues.adoc
@@ -1,0 +1,86 @@
+// Module included in the following assemblies:
+// * network_observability/network-observability-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="network-observability-operator-release-notes-1-12-fixed-issues_{context}"]
+= Network Observability Operator 1.12 fixed issues
+
+[role="_abstract"]
+The Network Observability Operator 1.12 release contains several fixed issues that improve performance, system status reporting, and user experience.
+
+Consistent FlowCollector pipeline status::
+Before this update, changes to the sampling field caused an inconsistency in the `FlowCollector` resource status. As a consequence, you could see conflicting statuses across pipeline components.
++
+With this release, status reporting is made consistent across all components. As a result, the reliability of the pipeline status indicator is improved.
++
+link:https://issues.redhat.com/browse/NETOBSERV-2375[NETOBSERV-2375]
+
+Fixed `--help` flag processing in netobserv-cli::
+Before this update, the `--help` flag was ignored when placed after other command flags in the Network Observability CLI. As a consequence, running commands such as `oc netobserv flows --interfaces=br-ex --max-time=10s --help` executed the flow collection instead of displaying the help page.
++
+With this release, the `--help` flag is recognized regardless of its position in the command. As a result, you can now display help information by placing the `--help` flag anywhere in your command arguments.
++
+link:https://issues.redhat.com/browse/NETOBSERV-2617[NETOBSERV-2617]
+
+Improved visibility of DNS names warning messages::
+Before this update, the **DNS names** graph repeatedly displayed a warning message on every refresh when running in a Prometheus-only configuration. As a consequence, the persistent warning message covered other dashboard elements.
++
+With this release, the warning message is only displayed during the initial data load and does not overlay other content. As a result, interface clarity is improved when navigating the dashboard.
++
+link:https://issues.redhat.com/browse/NETOBSERV-2618[NETOBSERV-2618]
+
+Prometheus enabled by default in FlowCollector configurations::
+Before this update, the default setting for Prometheus metrics was unassigned during `FlowCollector` custom resource creation. As a consequence, you had to manually ensure that metrics collection was active to query accurate flow data.
++
+With this release, the default value for Prometheus metrics collection in the `FlowCollector` configuration is set to `true`. As a result, the deployment process is simplified and flow metrics are collected automatically.
++
+link:https://issues.redhat.com/browse/NETOBSERV-2620[NETOBSERV-2620]
+
+Usage examples added to CLI subcommand help text::
+Before this update, the `help` subcommands for the Network Observability CLI lacked syntax examples. As a consequence, understanding how to construct complex filtering and capture commands required additional research.
++
+With this release, clear examples are included in the subcommand help outputs. As a result, the usability and discoverability of the CLI features are enhanced.
++
+link:https://issues.redhat.com/browse/NETOBSERV-2646[NETOBSERV-2646]
+
+Corrected latency formatting for values above one second::
+Before this update, flow durations and network latencies greater than one second were improperly formatted as milliseconds. As a consequence, donut graphs and latency metrics displayed confusing or inaccurate time designations.
++
+With this release, the duration formatting function handles values greater than one millisecond accurately using decimal seconds. As a result, you can view precise network latency values in console charts.
++
+link:https://issues.redhat.com/browse/NETOBSERV-2669[NETOBSERV-2669]
+
+Improved FlowCollector status reporting when eBPF pods are absent::
+Before this update, the `FlowCollector` resource reported a status of `Ready` even when a restrictive `nodeSelector` prevented any eBPF agent pods from deploying. As a consequence, the system status misrepresented the health of the agent layer.
++
+With this release, the Operator checks for a zero-pod deployment count. As a result, the `FlowCollector` CR now correctly identifies when zero eBPF pods are active, improving cluster error diagnostics.
++
+link:https://issues.redhat.com/browse/NETOBSERV-2674[NETOBSERV-2674]
+
+Optimized field exports for OpenTelemetry exporters::
+Before this update, the OpenTelemetry exporter processed missing or null keys as non-null data. As a consequence, unpopulated `metadata` fields were exported to log streams, which increased storage usage and cluttered telemetry files.
++
+With this release, the OpenTelemetry exporter filters out null or unrelated fields, exporting only keys that belong to explicitly enabled features. As a result, exported log sizes are reduced and data efficiency is improved.
++
+link:https://issues.redhat.com/browse/NETOBSERV-2705[NETOBSERV-2705]
+
+Added sampling probability fields to IPFIX exports::
+Before this update, Internet Protocol Flow Information Export (IPFIX) record exports omitted per-flow sampling information. As a consequence, data exports failed to comply with the standard IPFIX specifications for `samplingProbability` usage.
++
+With this release, the exporter includes sampling probability details within the IPFIX packet metadata. As a result, exported OpenTelemetry data matches industry compliance standards.
++
+link:https://issues.redhat.com/browse/NETOBSERV-2706[NETOBSERV-2706]
+
+Fixed TLS volume name conflicts on OpenTelemetry exporters::
+Before this update, configuring TLS certificates on OpenTelemetry exporters generated an invalid volume name format. As a consequence, the `apiserver` rejected the underlying Flow-logs Pipeline deployment specification, causing the pipeline pod to fail during initialization.
++
+With this release, the Operator ensures valid volume names are generated when handling TLS attributes. As a result, enabling TLS on your OpenTelemetry exporters no longer interferes with pipeline pod lifecycles.
++
+link:https://issues.redhat.com/browse/NETOBSERV-2707[NETOBSERV-2707]
+
+Improved pod-to-pod flow filter rule matching for asymmetric CIDR rules::
+Before this update, the default flow filter action was not enforced when a network flow failed to match both a CIDR rule and its corresponding `peerCIDR` rule identically. As a consequence, unexpected acknowledgment-only, `ACK`, flows bypass filtering restrictions inside the pod network.
++
+With this release, when a network flow matches a designated CIDR rule but fails the `peerCIDR` pairing, the default filtering action is correctly applied. As a result, traffic blocking and network rule isolation are handled more securely.
++
+link:https://issues.redhat.com/browse/NETOBSERV-2755[NETOBSERV-2755]

--- a/modules/network-observability-operator-release-notes-1-12-fixed-issues.adoc
+++ b/modules/network-observability-operator-release-notes-1-12-fixed-issues.adoc
@@ -1,0 +1,51 @@
+// Module included in the following assemblies:
+// * network_observability/network-observability-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="network-observability-operator-release-notes-1-12-fixed-issues_{context}"]
+= Network Observability Operator 1.12 fixed issues
+
+[role="_abstract"]
+The Network Observability Operator 1.12 release contains several fixed issues that improve performance and the user experience.
+
+Consistent FlowCollector pipeline status::
+The `FlowCollector` pipeline status now reports consistently after configuration updates. Previously, changing settings such as sampling caused the status to fluctuate between `Ready` and `Unused`.
++
+link:https://issues.redhat.com/browse/NETOBSERV-2375[NETOBSERV-2375]
+
+Standard labels in DSCP filter autocomplete::
+The Differentiated Services Code Point (DSCP) filter in the web console now applies the selected standard label. Previously, the autocomplete feature occasionally applied a numeric value instead of the label.
++
+link:https://issues.redhat.com/browse/NETOBSERV-2599[NETOBSERV-2599]
+
+CLI plug-in subcommand help examples::
+Usage examples are now included in the help output for all subcommands in the Network Observability CLI plug-in, such as `oc netobserv flows --help`.
++
+link:https://issues.redhat.com/browse/NETOBSERV-2646[NETOBSERV-2646]
+
+FlowCollector error reporting for node selector mismatches::
+The `FlowCollector` status now reports an error when eBPF pods cannot be scheduled due to `nodeSelector` configurations. This ensures visibility when no agents are active.
++
+link:https://issues.redhat.com/browse/NETOBSERV-2674[NETOBSERV-2674]
+
+Optimized OpenTelemetry log exports::
+OpenTelemetry log exports now omit empty fields and fields for disabled features. This optimization reduces the payload size for downstream systems.
++
+link:https://issues.redhat.com/browse/NETOBSERV-2705[NETOBSERV-2705]
+
+Sampling probability in IPFIX exports::
+IPFIX exports now include the `samplingProbability` field. This field provides the sampling probability based on the random sampling interval, which allows collectors to interpret sampled records accurately.
++
+link:https://issues.redhat.com/browse/NETOBSERV-2706[NETOBSERV-2706]
+
+////
+Follow this format:
+
+MetricName and Remap fields are validated::
++
+Before this update, users could create a `FlowMetric` custom resource (CR) with an invalid metric name. Although the `FlowMetric` CR was successfully created, the underlying metric would fail silently without providing any error feedback to the user.
++
+With this release, the `FlowMetric`, `metricName`, and `remap` fields are now validated before creation, so users are immediately notified if they enter an invalid name.
++
+link:https://issues.redhat.com/browse/NETOBSERV-2348[NETOBSERV-2348]
+////

--- a/modules/network-observability-operator-release-notes-1-12-known-issues.adoc
+++ b/modules/network-observability-operator-release-notes-1-12-known-issues.adoc
@@ -1,0 +1,16 @@
+// Module included in the following assemblies:
+// * network_observability/network-observability-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="network-observability-operator-release-notes-1-12-known-issues_{context}"]
+= Network Observability Operator 1.12 known issues
+
+[role="_abstract"]
+The following known issues affect the Network Observability Operator 1.12 release.
+
+Operator fails to start when custom web console logos are configured::
+When you configure custom product logos in the `Console.operator.openshift.io` resource using the `spec.customization.logos` field, the Network Observability Operator pod fails to start during installation. The Operator incorrectly reports a validation error indicating that both `logos` and the deprecated `customLogoFile` fields are set, even though only `logos` is configured.
++
+To work around this problem, manually enable the Network Observability Operator {product-title} web console plugin by adding `netobserv-plugin-static` to the `spec.plugins` list in the `Console` cluster resource, or by enabling the plugin through the web console under *Administration* -> *Cluster Settings* -> *Configuration* -> *Console* -> *Console plugins*.
++
+link:https://issues.redhat.com/browse/NETOBSERV-2767[NETOBSERV-2767]

--- a/modules/network-observability-operator-release-notes-1-12-new-features-enhancements.adoc
+++ b/modules/network-observability-operator-release-notes-1-12-new-features-enhancements.adoc
@@ -1,0 +1,40 @@
+// Module included in the following assemblies:
+// * network_observability/network-observability-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="network-observability-operator-release-notes-1-12-new-features-enhancements_{context}"]
+= Network Observability Operator 1.12 new features and enhancements
+
+[role="_abstract"]
+The Network Observability Operator 1.12 release introduces non-decrypting TLS metadata tracking, Kafka message compression options, automated secondary network indexing, and expanded web console compatibility for {product-title} clusters.
+
+Transport Layer Security traffic metadata tracking::
+The Network Observability Operator can now capture and analyze Transport Layer Security (TLS) metadata from network flows without decrypting traffic. By extracting handshake details from `ClientHello` and `ServerHello` messages, the Operator provides visibility into encryption protocols while maintaining data privacy.
++
+The following key benefits include:
++
+* Security risk detection: Identify workloads using deprecated TLS versions (1.0, 1.1) or weak cipher suites.
+* Compliance auditing: Audit TLS configurations to meet regulatory requirements through metric aggregation and dashboard visualization.
+* Security posture assessment: Visualize encrypted network traffic with lock icons in the *Topology* view and identify unencrypted communications across your cluster.
+* Configure Prometheus alerts to automatically report insecure or non-compliant TLS configurations.
++
+To use this feature, enable `TLSTracking` in the `spec.agent.ebpf.features` list of the `FlowCollector` custom resource (CR).
+
+Support for Kafka compression::
+Message compression configuration is now available when using Kafka to scale network flow collection. Enabling compression reduces the network bandwidth required to transport flows and decreases the storage footprint on Kafka brokers.
++
+The following key benefits include:
++
+* Reduced network load: Compressing flow data minimizes the traffic volume between the eBPF agent or flowlogs-pipeline and your Kafka cluster.
+* Storage efficiency: Smaller message sizes lead to improved disk space utilization on Kafka brokers.
+* Tunable performance: Choose from several compression algorithms, such as `gzip`, `snappy`, `lz4`, or `zstd`, to balance CPU usage with compression ratios.
++
+To enable this feature, configure the `spec.kafka.compression` and `spec.exporters.kafka.compression` fields in the `FlowCollector` custom resource.
+
+Simplified secondary network indexing::
+The configuration process for secondary network indexing is now simplified.
++
+The `name` field in the `spec.processor.advanced.secondaryNetworks` list is deprecated and ignored. The Network Observability Operator automatically evaluates all secondary networks regardless of their assigned names, removing the requirement for manual name-matching entries in the `FlowCollector` CR.
+
+{product-title} web console compatibility::
+The Network Observability web console plugin is updated to support {product-title} 4.22 and later. Backward compatibility is maintained for {product-title} versions 4.14 through 4.21.

--- a/modules/network-observability-operator-release-notes-1-12-new-features-enhancements.adoc
+++ b/modules/network-observability-operator-release-notes-1-12-new-features-enhancements.adoc
@@ -1,0 +1,76 @@
+// Module included in the following assemblies:
+// * network_observability/network-observability-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="network-observability-operator-release-notes-1-12-new-features-enhancements_{context}"]
+= Network Observability Operator 1.12 new features and enhancements
+
+[role="_abstract"]
+Learn about the new features and enhancements in the Network Observability Operator 1.12 release, including
+
+Monitoring TLS traffic::
+This release introduces the ability to monitor Transport Layer Security (TLS) traffic metadata without decrypting network flows. By capturing metadata from TLS handshake messages, such as `ClientHello` and `ServerHello`, the Network Observability Operator provides visibility into encryption protocols while maintaining data privacy.
++
+Key capabilities include:
++
+* Security risk detection: Identify workloads using deprecated TLS versions (1.0, 1.1) or weak cipher suites.
+* Compliance auditing: Audit TLS configurations to meet regulatory requirements through metric aggregation and dashboard visualization.
+* Security posture assessment: Visualize encrypted network traffic with lock icons in the *Topology* view and identify unencrypted communications across your cluster.
+* Proactive alerting: Configure Prometheus alerts to automatically report insecure or non-compliant TLS configurations.
++
+To use this feature, you must enable `TLSTracking` in the `spec.agent.ebpf.features` list of the `FlowCollector` custom resource.
+
+Support for Kafka compression::
+This release introduces the ability to configure message compression when using Kafka to scale network flow collection. By enabling compression, you can reduce the network bandwidth required to transport flows and decrease the storage footprint on your Kafka brokers.
++
+Key benefits include:
++
+* Reduced network load: Compressing flow data minimizes the traffic volume between the eBPF agent or flowlogs-pipeline and your Kafka cluster.
+* **Storage efficiency: Smaller message sizes lead to improved disk space utilization on Kafka brokers.
+* Tunable performance: You can choose from several compression algorithms, such as `gzip`, `snappy`, `lz4`, or `zstd`, to balance CPU usage with compression ratios.
++
+To enable this feature, configure the `spec.exporters.kafka.compression` field in the `FlowCollector` custom resource.
+
+Shared cache architecture for Flow-logs Pipeline::
+This release introduces a shared cache architecture for the Flow-logs Pipeline (FLP) to reduce Kubernetes API server load and optimize resource consumption in large clusters.
++
+Previously, each FLP instance independently queried the API server for metadata enrichment, leading to redundant requests and high memory usage at scale. With this release, you can enable a centralized shared cache that retrieves metadata once and distributes it to all FLP instances via gRPC.
++
+Key benefits include:
++
+* Improved cluster stability: Reduces the cumulative load on the Kubernetes API server by centralizing resource watches and notifications.
+* Resource optimization: Decreases the memory and CPU footprint of individual FLP pods by eliminating redundant in-memory caches.
+* High availability: Uses leader election across multiple shared cache replicas to ensure continuous metadata availability without a single point of failure.
++
+To enable this feature, set `spec.processor.informers.enabled` to `true` in the `FlowCollector` custom resource.
+
+Secondary network indexing simplification::
+This release simplifies the configuration for secondary network indexing. Previously, you had to manually configure the `name` field for every secondary network in the `spec.processor.advanced.secondaryNetworks` list to ensure pods were correctly enriched.
++
+With this release, the `name` configuration is deprecated and ignored. The Network Observability Operator now automatically checks all secondary networks regardless of their assigned name. As a result, you can simplify your `FlowCollector` configuration by removing redundant secondary network entries that were previously required for name matching.
+
+TLS tracking support::
+With this release, you can gather Transport Layer Security (TLS) information for network flows by enabling TLS tracking. This feature provides visibility into the TLS versions and cipher suites used within your cluster, helping you identify insecure connections and ensure compliance with security policies.
++
+To enable this feature, configure the `spec.agent.ebpf.features` field in the `FlowCollector` custom resource to include `TLSTracking`.
++
+.Example FlowCollector configuration
+[source,yaml]
+----
+apiVersion: flows.netobserv.io/v1alpha1
+kind: FlowCollector
+metadata:
+  name: cluster
+spec:
+  agent:
+    type: eBPF
+    ebpf:
+      features:
+        - TLSTracking
+----
++
+When enabled, the following information is enriched in the flow records and available for visualization in the web console:
++
+* TLS Version: Identifies the version of the TLS protocol (for example, TLS 1.2 or TLS 1.3).
+* Cipher Suite: Displays the specific cryptographic algorithms used for the connection.
+* TLS Metrics: Provides Prometheus metrics for monitoring TLS usage patterns across namespaces and workloads.

--- a/modules/network-observability-operator-release-notes-1-12-technology-preview.adoc
+++ b/modules/network-observability-operator-release-notes-1-12-technology-preview.adoc
@@ -1,0 +1,11 @@
+// Module included in the following assemblies:
+// * network_observability/network-observability-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="network-observability-operator-release-notes-1-12-technology-preview_{context}"]
+= Network Observability Operator 1.12 Technology Preview features
+
+[role="_abstract"]
+The Network Observability Operator is included by default as a Technology Preview feature in 1.12 and {product-title} 4.22. You can explore network traffic visualization and monitoring capabilities without performing a separate installation.
+
+To use this Technology Preview feature, you must enable the `NetworkObservabilityInstall` feature gate through a manifest file during cluster installation.

--- a/modules/network-observability-operator-release-notes-1-12-technology-preview.adoc
+++ b/modules/network-observability-operator-release-notes-1-12-technology-preview.adoc
@@ -14,6 +14,4 @@ The Network Observability Operator is included with {product-title}, so you can 
 +
 This capability provides earlier access to visibility into cluster networking and network traffic when you build observability workflows. These capabilities are a Technology Preview feature.
 +
-For more information about network observability, see
-
-//Still needs work; may also be influenced by how Networking IA shakes out.
+To use this Technology Preview feature on a Technology Preview cluster, you must enable the `NetworkObservabilityInstall` feature gate through a manifest file during cluster installation.

--- a/modules/network-observability-operator-release-notes-1-12-technology-preview.adoc
+++ b/modules/network-observability-operator-release-notes-1-12-technology-preview.adoc
@@ -1,0 +1,19 @@
+// Module included in the following assemblies:
+// * network_observability/network-observability-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="network-observability-operator-release-notes-1-12-technology-preview_{context}"]
+= Network Observability Operator 1.12 Technology Preview features
+
+[role="_abstract"]
+The Network Observability Operator is included by default as a Technology Preview feature in 1.12 and {product-title} 4.22. This integration allows you to explore network traffic visualization and monitoring capabilities without performing a separate installation.
+
+Network Observability Operator included with {product-title} clusters (Technology Preview)::
+
+The Network Observability Operator is included with {product-title}, so you can enable network observability without installing the Network Observability Operator from OperatorHub.
++
+This capability provides earlier access to visibility into cluster networking and network traffic when you build observability workflows. These capabilities are a Technology Preview feature.
++
+For more information about network observability, see
+
+//Still needs work; may also be influenced by how Networking IA shakes out.

--- a/observability/network_observability/network-observability-operator-release-notes.adoc
+++ b/observability/network_observability/network-observability-operator-release-notes.adoc
@@ -17,13 +17,10 @@ These release notes track the development of the Network Observability Operator 
 include::modules/network-observability-operator-release-notes-1-11-2-advisory.adoc[leveloffset=+1]
 
 include::modules/network-observability-operator-release-notes-1-11-1-advisory.adoc[leveloffset=+1]
+include::modules/network-observability-operator-release-notes-1-12-advisory.adoc[leveloffset=+1]
 
-include::modules/network-observability-operator-release-notes-1-11-1-fixed-issues.adoc[leveloffset=+1]
+include::modules/network-observability-operator-release-notes-1-12-new-features-enhancements.adoc[leveloffset=+1]
 
-include::modules/network-observability-operator-release-notes-1-11-advisory.adoc[leveloffset=+1]
+include::modules/network-observability-operator-release-notes-1-12-technology-preview.adoc[leveloffset=+1]
 
-include::modules/network-observability-operator-release-notes-1-11-new-features-enhancements.adoc[leveloffset=+1]
-
-include::modules/network-observability-operator-release-notes-1-11-known-issues.adoc[leveloffset=+1]
-
-include::modules/network-observability-operator-release-notes-1-11-fixed-issues.adoc[leveloffset=+1]
+include::modules/network-observability-operator-release-notes-1-12-fixed-issues.adoc[leveloffset=+1]

--- a/observability/network_observability/network-observability-operator-release-notes.adoc
+++ b/observability/network_observability/network-observability-operator-release-notes.adoc
@@ -8,22 +8,18 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 [role="_abstract"]
-Review new features, enhancements, fixed issues, and known issues for the Network Observability Operator. These release notes provide information to help you understand changes and security advisories in the latest operator release.
+Review new features, enhancements, fixed issues, and known issues for the Network Observability Operator. These release notes provide information to help you understand changes and security advisories in the latest Operator release.
 
 The Network Observability Operator enables administrators to observe and analyze network traffic flows for {product-title} clusters.
 
 These release notes track the development of the Network Observability Operator in the {product-title}.
 
-include::modules/network-observability-operator-release-notes-1-11-2-advisory.adoc[leveloffset=+1]
+include::modules/network-observability-operator-release-notes-1-12-advisory.adoc[leveloffset=+1]
 
-include::modules/network-observability-operator-release-notes-1-11-1-advisory.adoc[leveloffset=+1]
+include::modules/network-observability-operator-release-notes-1-12-new-features-enhancements.adoc[leveloffset=+1]
 
-include::modules/network-observability-operator-release-notes-1-11-1-fixed-issues.adoc[leveloffset=+1]
+include::modules/network-observability-operator-release-notes-1-12-technology-preview.adoc[leveloffset=+1]
 
-include::modules/network-observability-operator-release-notes-1-11-advisory.adoc[leveloffset=+1]
+include::modules/network-observability-operator-release-notes-1-12-fixed-issues.adoc[leveloffset=+1]
 
-include::modules/network-observability-operator-release-notes-1-11-new-features-enhancements.adoc[leveloffset=+1]
-
-include::modules/network-observability-operator-release-notes-1-11-known-issues.adoc[leveloffset=+1]
-
-include::modules/network-observability-operator-release-notes-1-11-fixed-issues.adoc[leveloffset=+1]
+include::modules/network-observability-operator-release-notes-1-12-known-issues.adoc[leveloffset=+1]

--- a/observability/network_observability/release_notes_archive/network-observability-operator-release-notes-archive.adoc
+++ b/observability/network_observability/release_notes_archive/network-observability-operator-release-notes-archive.adoc
@@ -13,6 +13,21 @@ These release notes track past developments of the Network Observability Operato
 
 The Network Observability Operator enables administrators to observe and analyze network traffic flows for {product-title} clusters.
 
+
+include::modules/network-observability-operator-release-notes-1-11-2-advisory.adoc[leveloffset=+1]
+
+include::modules/network-observability-operator-release-notes-1-11-1-advisory.adoc[leveloffset=+1]
+
+include::modules/network-observability-operator-release-notes-1-11-1-fixed-issues.adoc[leveloffset=+1]
+
+include::modules/network-observability-operator-release-notes-1-11-advisory.adoc[leveloffset=+1]
+
+include::modules/network-observability-operator-release-notes-1-11-new-features-enhancements.adoc[leveloffset=+1]
+
+include::modules/network-observability-operator-release-notes-1-11-known-issues.adoc[leveloffset=+1]
+
+include::modules/network-observability-operator-release-notes-1-11-fixed-issues.adoc[leveloffset=+1]
+
 include::modules/network-observability-operator-release-notes-1-10-1.adoc[leveloffset=+1]
 
 include::modules/network-observability-operator-release-notes-1-10-1-cves.adoc[leveloffset=+1]

--- a/observability/network_observability/release_notes_archive/network-observability-operator-release-notes-archive.adoc
+++ b/observability/network_observability/release_notes_archive/network-observability-operator-release-notes-archive.adoc
@@ -13,6 +13,18 @@ These release notes track past developments of the Network Observability Operato
 
 The Network Observability Operator enables administrators to observe and analyze network traffic flows for {product-title} clusters.
 
+include::modules/network-observability-operator-release-notes-1-11-1-advisory.adoc[leveloffset=+1]
+
+include::modules/network-observability-operator-release-notes-1-11-1-fixed-issues.adoc[leveloffset=+1]
+
+include::modules/network-observability-operator-release-notes-1-11-advisory.adoc[leveloffset=+1]
+
+include::modules/network-observability-operator-release-notes-1-11-new-features-enhancements.adoc[leveloffset=+1]
+
+include::modules/network-observability-operator-release-notes-1-11-known-issues.adoc[leveloffset=+1]
+
+include::modules/network-observability-operator-release-notes-1-11-fixed-issues.adoc[leveloffset=+1]
+
 include::modules/network-observability-operator-release-notes-1-10-1.adoc[leveloffset=+1]
 
 include::modules/network-observability-operator-release-notes-1-10-1-cves.adoc[leveloffset=+1]


### PR DESCRIPTION
[OSDOCS-19149](https://redhat.atlassian.net/browse/OSDOCS-19149) [NETOBSERV] 1.12 Release Notes

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
Merge into `no-1.12` only. No cherry picks.

Issue:
https://redhat.atlassian.net/browse/OSDOCS-19149

Link to docs preview:
* 1.12 advisory: https://111255--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/network-observability-operator-release-notes#network-observability-operator-release-notes_network-observability-operator-release-notes
* 1.12 New features: https://111255--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/network-observability-operator-release-notes#network-observability-operator-release-notes-1-11-new-features-enhancements_network-observability-operator-release-notes
* 1.12 Technology Preview: https://111255--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/network-observability-operator-release-notes#network-observability-operator-release-notes-1-12-technology-preview_network-observability-operator-release-notes
* 1.12 Fixed issues: https://111255--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/network-observability-operator-release-notes#network-observability-operator-release-notes-1-12-fixed-issues_network-observability-operator-release-notes
* 1.12 Known issues: https://111255--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/network-observability-operator-release-notes#network-observability-operator-release-notes-1-12-known-issues_network-observability-operator-release-notes

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
* Can be merged into `no-1.12` as Advisory is generally added via a separate PR.
* I will open one PR against main to incorporate all of the no-1.12 content just before its GA.
* Follows JTBD to be in line with Observability Docs.
* PRs were failing. Approval on Known Issue copy was provided via Slack.


<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
