### PR TITLE
CNV-81288: Add D series instancetype

### DIFF
--- a/modules/virt-common-instancetypes.adoc
+++ b/modules/virt-common-instancetypes.adoc
@@ -69,4 +69,14 @@ a|
 .^a|`m1.large`::
 * 2 vCPUs
 * 16GiB Memory
+
+^.^|Dedicated
+^.^|D
+a|
+* Dedicated CPU
+* Isolated emulator threads
+^.^|1:4
+.^a|`d1.medium`::
+* 1 vCPUs
+* 4GiB Memory
 |===


### PR DESCRIPTION
Version(s):
4.19+

Issue:
https://redhat.atlassian.net/browse/CNV-81288

Link to docs preview:
https://111262--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/creating_vm/virt-creating-vms-from-instance-types.html#virt-common-instancetypes_virt-creating-vms-from-instance-types

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Based on https://github.com/kubevirt/common-instancetypes
