### PR TITLE
OBSDOCS-3294: Added release notes for OpenShift Logging 6.5.1.

### DIFF
--- a/modules/logging-release-notes-6-5-0.adoc
+++ b/modules/logging-release-notes-6-5-0.adoc
@@ -7,6 +7,5 @@
 = Logging 6.5.0 release notes
 
 [role="_abstract"]
-This release of {LoggingProductName} is supported on {ocp-product-title} 4.19 and later.
 
 This release includes link:https://access.redhat.com/errata/RHBA-2026:6393[RHBA-2026:6393].

--- a/modules/logging-release-notes-6-5-1-cves.adoc
+++ b/modules/logging-release-notes-6-5-1-cves.adoc
@@ -1,0 +1,12 @@
+// Module included in the following assemblies:
+//
+// * about/logging-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="logging-release-notes-6-5-1-cves_{context}"]
+= CVEs
+
+[role="_abstract"]
+The following CVEs are included in this release of {LoggingProductName}.
+
+* https://access.redhat.com/security/cve/cve-2026-32829[CVE-2026-32829]

--- a/modules/logging-release-notes-6-5-1-fixed-issues.adoc
+++ b/modules/logging-release-notes-6-5-1-fixed-issues.adoc
@@ -1,0 +1,40 @@
+// Module included in the following assemblies:
+//
+// * about/logging-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="logging-release-notes-6-5-1-fixed-issues_{context}"]
+= Fixed issues
+
+[role="_abstract"]
+The following issues are fixed in this release of {LoggingProductName}.
+
+Vector cannot authenticate to Kafka 4.0.0 with SASL mechanism SCRAM-SHA-512::
+Previously, Vector could fail to authenticate to Kafka 4.0.0 when using the SCRAM-SHA-512 SASL mechanism, which could lead to connection issues and stalled producers. With this update, the `rdkafka` library has been upgraded to 0.38.0, resolving these authentication issues and ensuring stable connectivity to Kafka 4.0.0 clusters. 
++
+https://redhat.atlassian.net/browse/LOG-7506[LOG-7506]
+
+Duplicate case-variant 'Accept' and 'accept' headers in CLF lead to `media_type_header_exception` in Elasticsearch output::
+Previously, duplicate case-variant headers (such as Accept and accept) in the `ClusterLogForwarder` could cause a `media_type_header_exception` when sending logs to the Elasticsearch output. With this update, header names are normalized using `CanonicalHeaderKey`, which prevents duplicate case-variant headers and resolves the exception. 
++
+https://redhat.atlassian.net/browse/LOG-8581[LOG-8581]
+
+Eventrouter timestamp logic for updates causes Loki ingestion rejection::
+Previously, the Eventrouter used `metadata.creationTimestamp` as the log timestamp for Kubernetes Events, which could be weeks or months old for repeated events, causing Loki to reject the logs with a `greater_than_max_sample_age` error. With this update, `Eventrouter` now uses `event.lastTimestamp` as the primary log timestamp, falling back to `firstTimestamp`, `eventTime`, and then `creationTimestamp` only if necessary, ensuring that events are correctly accepted by Loki.
++
+https://redhat.atlassian.net/browse/LOG-8697[LOG-8697]
+
+S3 Log Forwarding: `compression: none` ignored; defaults to GZIP::
+Previously, setting `compression: none` for S3 log forwarding was ignored, and logs were always compressed using GZIP by default. With this update, specifying `compression: none` is correctly respected, allowing logs to be forwarded to S3 without compression as intended. 
++
+https://redhat.atlassian.net/browse/LOG-8769[LOG-8769]
+
+Unsupported cipher suite error messages on LFME pods::
+Previously, Log File Metric Exporter (LFME) pods would log "unsupported cipher suite" error messages during startup when encountering certain TLS configurations. This update ensures that all required cipher suites are properly recognized and supported, eliminating these error messages and ensuring consistent TLS behavior. 
++
+https://redhat.atlassian.net/browse/LOG-8893[LOG-8893]
+
+Collector memory and cpu usage always growing::
+Previously, collectors configured to use the `detect_exceptions` transform would create separate instances of the state machine for each log stream, leading to increased memory consumption. With this update, the behavior has been modified to share a single state machine instance across all log streams, significantly reducing the memory usage of the collector. 
++
+https://redhat.atlassian.net/browse/LOG-9314[LOG-9314]

--- a/modules/logging-release-notes-6-5-1.adoc
+++ b/modules/logging-release-notes-6-5-1.adoc
@@ -1,0 +1,10 @@
+// Module included in the following assemblies:
+//
+// * release_notes/logging-release-notes-6.2.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="logging-release-notes-6-5-1_{context}"]
+= Logging 6.5.1 Release Notes
+
+[role="_abstract"]
+This release includes https://access.redhat.com/errata/RHSA-2026:16354[RHSA-2026:16354].

--- a/release_notes/logging-release-notes.adoc
+++ b/release_notes/logging-release-notes.adoc
@@ -10,10 +10,14 @@ toc::[]
 [role="_abstract"]
 This release of {LoggingProductName} is supported on {ocp-product-title} 4.19 and later.
 
-This release includes link:https://access.redhat.com/errata/RHBA-2026:6393[RHBA-2026:6393].
+include::modules/logging-release-notes-6-5-1.adoc[leveloffset=+1]
 
-//include::modules/logging-release-notes-6-5-0.adoc[leveloffset=+1]
+include::modules/logging-release-notes-6-5-1-fixed-issues.adoc[leveloffset=+2]
 
-include::modules/logging-release-notes-6-5-0-enhancement.adoc[leveloffset=+1]
+include::modules/logging-release-notes-6-5-1-cves.adoc[leveloffset=+2]
 
-include::modules/logging-release-notes-6-5-0-fixed-issues.adoc[leveloffset=+1]
+include::modules/logging-release-notes-6-5-0.adoc[leveloffset=+1]
+
+include::modules/logging-release-notes-6-5-0-enhancement.adoc[leveloffset=+2]
+
+include::modules/logging-release-notes-6-5-0-fixed-issues.adoc[leveloffset=+2]


### PR DESCRIPTION
This PR contains release notes for OpenShift Logging 6.5.1.

Version(s): 6.5


Issue: https://redhat.atlassian.net/browse/OBSDOCS-3294
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://111263--ocpdocs-pr.netlify.app/openshift-logging/latest/release_notes/logging-release-notes.html#logging-release-notes-6-5-1_logging-release-notes
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
