### PR TITLE
OSDOCS-19549: Instructions to enable plugins sans UI

### DIFF
--- a/modules/proc_enabling-dynamic-plugin-using-cli.adoc
+++ b/modules/proc_enabling-dynamic-plugin-using-cli.adoc
@@ -1,0 +1,101 @@
+//Used in assembly deploy-plugin-cluster.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="enabling-a-dynamic-plugin-by-using-the-cli_{context}"]
+= Enabling a dynamic plugin with the CLI
+
+[role="_abstract"]
+You can enable a dynamic plugin to extend the core web console with more features, such as additional pages, perspectives, or dashboard items. Use the {oc-first} after a scripted installation, such as an Operator or Helm-based install. Add the `ConsolePlugin` name to `spec.plugins` in the console Operator configuration (`console.operator.openshift.io/cluster`) so the web console loads it.
+
+.Prerequisites
+* You logged in to the cluster as a user with `cluster-admin` privileges.
+* You installed the dynamic plugin using a scripted installation, such as an Operator or Helm chart.
+* A `ConsolePlugin` custom resource (CR) exists on the cluster.
+
+.Procedure
+. Confirm the name of the `ConsolePlugin` resource by running the following command:
++
+[source,terminal]
+----
+$ oc get consoleplugin
+----
++
+. Optional: View details for a specific `ConsolePlugin` resource by running the following commands:
+
+.. Set the plugin name as an environment variable:
++
+[source,terminal]
+----
+$ PLUGIN_NAME="<plugin_name>"
+----
++
+where `<plugin_name>` is the name of the `ConsolePlugin` resource.
+.. Verify the plugin details:
++
+[source,terminal]
+----
+$ oc get consoleplugin "${PLUGIN_NAME}" -o yaml
+----
++
+The following example shows a `ConsolePlugin` YAML with the plugin listed in `spec.plugins`:
++
+[source,yaml]
+----
+apiVersion: operator.openshift.io/v1
+kind: Console
+metadata:
+  name: cluster
+spec:
+  plugins:
+    - <plugin_name> 
+    # ...
+----
++
+Replace `<plugin_name>` with the name of your plugin.
+
+. Enable the dynamic plugin by adding the `ConsolePlugin` name to the console Operator configuration. 
++
+[NOTE]
+====
+Make sure the Operator finishes installing the dynamic plugin before you run the following patch command.
+====
++
+.. Set the plugin patch as an environment variable:
++
+[source,terminal]
+----
+$ PLUGIN_PATCH=$(cat <<EOF
+[
+  {
+    "op": "add",
+    "path": "/spec/plugins/-",
+    "value": "<plugin_name>"
+  }
+]
+EOF
+)
+----
+
+.. Patch the console Operator configuration:
++
+[source,terminal]
+----
+$ oc patch consoles.operator.openshift.io cluster --type=json -p "${PLUGIN_PATCH}"
+----
+
+.Verification
+. Confirm that the console Operator configuration includes the `ConsolePlugin` name by running the following command:
++
+[source,terminal]
+----
+$ oc get console.operator.openshift.io cluster -o jsonpath='{.spec.plugins}{"\n"}'
+----
+
+. Refresh the {product-title} web console.
++
+The console can take a few minutes to apply the updated configuration.
+
+[role="_additional-resources"]
+.Additional resources
+* https://github.com/openshift/console/tree/main/dynamic-demo-plugin#enabling-the-plugin[Upstream demo instructions for enabling a plugin]
+* https://github.com/openshift/console-plugin-template/blob/3a06152cffdd10ad9654b6b607cb00a055f29733/charts/openshift-console-plugin/templates/patch-consoles-job.yaml[Helm template that patches the console Operator configuration]

--- a/web_console/dynamic-plugin/deploy-plugin-cluster.adoc
+++ b/web_console/dynamic-plugin/deploy-plugin-cluster.adoc
@@ -24,6 +24,8 @@ include::modules/deployment-plug-in-cluster.adoc[leveloffset=+1]
 
 include::modules/dynamic-plugin-proxy-service.adoc[leveloffset=+1]
 
+include::modules/proc_enabling-dynamic-plugin-using-cli.adoc[leveloffset=+1]
+
 ifndef::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
 [role="_additional-resources"]
 .Additional resources


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.22
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://redhat.atlassian.net/browse/OSDOCS-19549
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://111266--ocpdocs-pr.netlify.app/openshift-rosa/latest/web_console/dynamic-plugin/deploy-plugin-cluster.html#enabling-a-dynamic-plugin-by-using-the-cli_deploy-plugin-cluster
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
