### PR TITLE
OBSDOCS-3250: Fix typo in RBAC service account name

### DIFF
--- a/modules/otel-creating-required-RBAC-resources-automatically.adoc
+++ b/modules/otel-creating-required-RBAC-resources-automatically.adoc
@@ -11,7 +11,7 @@ Some Collector components require configuring the RBAC resources.
 
 .Procedure
 
-* Add the following permissions to the `opentelemetry-operator-controller-manage` service account so that the {OTelOperator} can create them automatically:
+* Add the following permissions to the `opentelemetry-operator-controller-manager` service account so that the {OTelOperator} can create them automatically:
 +
 [source,yaml]
 ----


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): main, 3.9
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://redhat.atlassian.net/browse/OBSDOCS-3250
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://111271--ocpdocs-pr.netlify.app/openshift-otel/latest/otel-collector/otel-collector-configuration-intro.html#otel-creating-required-RBAC-resources-automatically_otel-configuration-of-otel-intro
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review: N/A (typo)
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: Based on https://github.com/openshift/openshift-docs/pull/108848
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
