### PR TITLE
TELCODOCS-2610: RN for alt names feature

### DIFF
--- a/modules/rn-ocp-release-notes-new-features.adoc
+++ b/modules/rn-ocp-release-notes-new-features.adoc
@@ -177,6 +177,12 @@ The Kubernetes NMState Operator can now collect metrics from the following Kuber
 +
 For more information, see xref:../networking/networking_operators/k8s-nmstate-about-the-k8s-nmstate-operator.adoc#viewing-stats-collected-kubernetes-nmstate-op_k8s-nmstate-about-the-k8s-nmstate-operator[Viewing metrics collected by the Kubernetes NMState Operator].
 
+Alternative interface names for network interfaces with the Kubernetes NMState Operator::
++
+Assign alternative names to network interfaces by using the Kubernetes NMState Operator. Alternative names provide consistent, descriptive labels for interfaces across cluster nodes, simplifying automation in environments where interface names vary across nodes.
++
+For more information, see xref:../networking/k8s_nmstate/k8s-nmstate-updating-node-network-config.adoc#k8s-nmstate-alternative-interface-names_k8s-nmstate-updating-node-network-config[Configure alternative network interface names].
+
 [id="ocp-release-notes-nodes_{context}"]
 == Nodes
 


### PR DESCRIPTION
[TELCODOCS-2610](https://redhat.atlassian.net/browse/TELCODOCS-2610): RN for alt names feature

Version(s):
4.22+

Issue:
https://redhat.atlassian.net/browse/TELCODOCS-2610

Link to docs preview:
https://111287--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-22-release-notes.html#ocp-release-notes-networking_release-notes

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

