### PR TITLE
TELCODOCS-2097: RN for IPv4 forwarding on specific interface

### DIFF
--- a/modules/rn-ocp-release-notes-new-features.adoc
+++ b/modules/rn-ocp-release-notes-new-features.adoc
@@ -154,6 +154,12 @@ $ oc get networkpolicies --all-namespaces
 +
 The {product-title} {product-version} release did not include these objects in all {product-title} namespaces; later {product-title} releases might include the objects in additional namespaces.
 
+IPv4 forwarding for specific network interfaces::
++
+You can enable IPv4 forwarding on specific network interfaces by using the Kubernetes NMState Operator. By setting the `forwarding: true` field in a `NodeNetworkConfigurationPolicy` custom resource, you can configure individual interfaces to forward IP packets without enabling global IP forwarding on the cluster. This approach improves security by keeping global forwarding disabled while allowing forwarding only on the interfaces that require it, such as secondary interfaces used by MetalLB load balancers.
++
+For more information, see xref:../networking/k8s_nmstate/k8s-nmstate-updating-node-network-config.adoc#nw-nmstate-enable-per-interface-ip-forwarding_k8s-nmstate-updating-node-network-config[Enable IP forwarding on specific interfaces].
+
 [id="ocp-release-notes-nodes_{context}"]
 == Nodes
 


### PR DESCRIPTION
[TELCODOCS-2097](https://redhat.atlassian.net/browse/TELCODOCS-2097): RN for IPv4 forwarding on specific interface

Version(s):
4.22+

Issue:
https://redhat.atlassian.net/browse/TELCODOCS-2097

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

