### PR TITLE
TELCODOCS-2802: Configure firewall rules in Butane format - RN

### DIFF
--- a/modules/rn-ocp-release-notes-new-features.adoc
+++ b/modules/rn-ocp-release-notes-new-features.adoc
@@ -183,6 +183,12 @@ Assign alternative names to network interfaces by using the Kubernetes NMState O
 +
 For more information, see xref:../networking/k8s_nmstate/k8s-nmstate-updating-node-network-config.adoc#k8s-nmstate-alternative-interface-names_k8s-nmstate-updating-node-network-config[Configure alternative network interface names].
 
+Ingress firewall configuration with the `commatrix` plugin::
++
+The `commatrix` plugin generates `nftables` firewall rules in Butane format for deployment to cluster nodes. These rules restrict ingress traffic to only the flows required by deployed services, promoting a zero-trust security posture. The plugin also generates a `NodeDisruptionPolicy` patch to apply rule updates without node reboots.
++
+For more information, see xref:../installing/install_config/configuring-firewall.adoc#commatrix-generate-butane_configuring-firewall[Generate nftables firewall rules in Butane format].
+
 [id="ocp-release-notes-nodes_{context}"]
 == Nodes
 


### PR DESCRIPTION
[TELCODOCS-2802](https://redhat.atlassian.net/browse/TELCODOCS-2802): RN to configure firewall rules in Butant format

Version(s):
4.22+

Issue:
https://redhat.atlassian.net/browse/TELCODOCS-2802

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
