### PR TITLE
OSDOCS-16837: Standard Network Policy CQA2

### DIFF
--- a/modules/modifying-template-for-new-projects.adoc
+++ b/modules/modifying-template-for-new-projects.adoc
@@ -7,6 +7,9 @@
 [id="modifying-template-for-new-projects_{context}"]
 = Modifying the template for new projects
 
+[role="_abstract"]
+To modify the default project template to customize the resources and settings applied when users create new projects, you can create a custom project template.
+
 As a cluster administrator, you can modify the default project template so that new projects are created using your custom requirements.
 
 To create your own custom project template:

--- a/modules/nw-networkpolicy-about.adoc
+++ b/modules/nw-networkpolicy-about.adoc
@@ -6,6 +6,9 @@
 [id="nw-networkpolicy-about_{context}"]
 = About network policy
 
+[role="_abstract"]
+To control traffic between workloads and improve network isolation, configure `NetworkPolicy` objects for your projects. Network policies define the allowed ingress and egress connections for selected pods and help secure applications in your cluster.
+
 By default, all pods in a project are accessible from other pods and network endpoints. To isolate one or more pods in a project, you can create `NetworkPolicy` objects in that project to indicate the allowed incoming connections. Project administrators can create and delete `NetworkPolicy` objects within their own project.
 
 If a pod is matched by selectors in one or more `NetworkPolicy` objects, then the pod will accept only connections that are allowed by at least one of those `NetworkPolicy` objects. A pod that is not selected by any `NetworkPolicy` objects is fully accessible.
@@ -152,12 +155,15 @@ spec:
   - from:
     - namespaceSelector:
         matchLabels:
-          policy-group.network.openshift.io/ingress: ""<1>
+          policy-group.network.openshift.io/ingress: ""
   podSelector: {}
   policyTypes:
   - Ingress
 ----
-<1> `policy-group.network.openshift.io/ingress:""` label supports OVN-Kubernetes.
+
+where:
+
+* The `policy-group.network.openshift.io/ingress:""` label supports OVN-Kubernetes.
 
 [id="nw-networkpolicy-allow-from-hostnetwork_{context}"]
 == Using the allow-from-hostnetwork network policy

--- a/modules/nw-networkpolicy-about.adoc
+++ b/modules/nw-networkpolicy-about.adoc
@@ -7,7 +7,9 @@
 = About network policy
 
 [role="_abstract"]
-To isolate workloads, project administrators can create `NetworkPolicy` objects to define and manage allowed incoming connections.
+To control traffic between workloads and improve network isolation, configure `NetworkPolicy` objects for your projects. Network policies define the allowed ingress and egress connections for selected pods and help secure applications in your cluster.
+
+By default, all pods in a project are accessible from other pods and network endpoints. To isolate one or more pods in a project, you can create `NetworkPolicy` objects in that project to indicate the allowed incoming connections. Project administrators can create and delete `NetworkPolicy` objects within their own project.
 
 By default, all pods in a project are accessible from any network endpoint.
 
@@ -25,8 +27,24 @@ This means the pods accept:
 * Connections on any port from pods in the same namespace.
 * Connections on ports `80` and `443` from pods in any namespace.
 
-[id="nw-networkpolicy-default-core-components_{context}"]
-== Default network policies for core {product-title}  components
+[source,yaml]
+----
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-from-router
+spec:
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          policy-group.network.openshift.io/ingress: ""
+  podSelector: {}
+  policyTypes:
+  - Ingress
+----
+
+The `policy-group.network.openshift.io/ingress:""` label supports OVN-Kubernetes.
 
 To reduce the cluster attack surface and ensure predictable network behavior, {product-title} enforces least-privilege network policies on critical networking components.
 

--- a/modules/nw-networkpolicy-create-ocm.adoc
+++ b/modules/nw-networkpolicy-create-ocm.adoc
@@ -8,6 +8,9 @@
 [id="nw-networkpolicy-create-ocm_{context}"]
 = Creating a network policy using {cluster-manager}
 
+[role="_abstract"]
+To control ingress and egress traffic for workloads in your cluster, create a network policy by using {cluster-manager}. Network policies help enforce namespace-level network isolation and improve application security.
+
 To define granular rules describing the ingress or egress network traffic allowed for namespaces in your cluster, you can create a network policy.
 
 .Prerequisites

--- a/modules/nw-networkpolicy-multitenant-isolation.adoc
+++ b/modules/nw-networkpolicy-multitenant-isolation.adoc
@@ -6,8 +6,8 @@
 [id="nw-networkpolicy-multitenant-isolation_{context}"]
 = Configuring multitenant isolation by using network policy
 
-You can configure your project to isolate it from pods and services in other
-project namespaces.
+[role="_abstract"]
+You can configure network policies to isolate workloads in a project from pods and services in other namespaces. This isolation helps control network traffic between projects and improves multitenant security in your cluster.
 
 .Prerequisites
 

--- a/modules/nw-networkpolicy-multitenant-isolation.adoc
+++ b/modules/nw-networkpolicy-multitenant-isolation.adoc
@@ -6,6 +6,9 @@
 [id="nw-networkpolicy-multitenant-isolation_{context}"]
 = Configuring multitenant isolation by using network policy
 
+[role="_abstract"]
+You can configure network policies to isolate workloads in a project from pods and services in other namespaces. This isolation helps control network traffic between projects and improves multitenant security in your cluster.
+
 You can configure your project to isolate it from pods and services in other
 project namespaces.
 

--- a/modules/nw-networkpolicy-project-defaults.adoc
+++ b/modules/nw-networkpolicy-project-defaults.adoc
@@ -8,8 +8,8 @@
 [id="nw-networkpolicy-project-defaults_{context}"]
 = Adding network policies to the new project template
 
-As a cluster administrator, you can add network policies to the default template for new projects.
-{product-title} will automatically create all the `NetworkPolicy` objects specified in the template in the project.
+[role="_abstract"]
+You can add `NetworkPolicy` objects to the default project template so that new projects automatically include predefined network isolation rules. Applying network policies through templates helps enforce consistent network security controls across projects.
 
 .Prerequisites
 
@@ -82,9 +82,10 @@ objects:
 +
 [source,terminal]
 ----
-$ oc new-project <project> <1>
+$ oc new-project <project>
 ----
-<1> Replace `<project>` with the name for the project you are creating.
++
+Replace `<project>` with the name of the project you want to create.
 
 .. Confirm that the network policy objects in the new project template exist in the new project:
 +

--- a/modules/nw-networkpolicy-project-defaults.adoc
+++ b/modules/nw-networkpolicy-project-defaults.adoc
@@ -8,6 +8,9 @@
 [id="nw-networkpolicy-project-defaults_{context}"]
 = Adding network policies to the new project template
 
+[role="_abstract"]
+You can add `NetworkPolicy` objects to the default project template so that new projects automatically include predefined network isolation rules. Applying network policies through templates helps enforce consistent network security controls across projects.
+
 As a cluster administrator, you can add network policies to the default template for new projects.
 {product-title} will automatically create all the `NetworkPolicy` objects specified in the template in the project.
 
@@ -82,9 +85,14 @@ objects:
 +
 [source,terminal]
 ----
-$ oc new-project <project> <1>
+$ oc new-project <project>
 ----
-<1> Replace `<project>` with the name for the project you are creating.
++
+--
+where:
+
+* `<project>` is the name of the project you want to create.
+--
 
 .. Confirm that the network policy objects in the new project template exist in the new project:
 +

--- a/networking/network_security/network_policy/about-network-policy.adoc
+++ b/networking/network_security/network_policy/about-network-policy.adoc
@@ -9,23 +9,22 @@ endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 
 toc::[]
 
+[role="_abstract"]
+To restrict traffic between workloads and improve application security, configure `NetworkPolicy` objects for your cluster. Network policies define the allowed ingress and egress connections for selected pods and help isolate applications within namespaces.
+
 As a developer, you can define network policies that restrict traffic to pods in your cluster.
 
 include::modules/nw-networkpolicy-about.adoc[leveloffset=+1]
 
 include::modules/nw-networkpolicy-optimize-ovn.adoc[leveloffset=+1]
 
-[id="about-network-policy-next-steps"]
-== Next steps
-
-* xref:../../../networking/network_security/network_policy/creating-network-policy.adoc#creating-network-policy[Creating a network policy]
-ifndef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
-* Optional: xref:../../../networking/network_security/network_policy/default-network-policy.adoc#default-network-policy[Defining a default network policy for projects]
-
 [role="_additional-resources"]
 [id="about-network-policy-additional-resources"]
 == Additional resources
 
+* xref:../../../networking/network_security/network_policy/creating-network-policy.adoc#creating-network-policy[Creating a network policy]
+ifndef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
+* xref:../../../networking/network_security/network_policy/default-network-policy.adoc#default-network-policy[Defining a default network policy for projects]
 * xref:../../../authentication/using-rbac.adoc#rbac-projects-namespaces_using-rbac[Projects and namespaces]
 * xref:../../../networking/network_security/network_policy/multitenant-network-policy.adoc#multitenant-network-policy[Configuring multitenant isolation with network policy]
 * xref:../../../rest_api/network_apis/networkpolicy-networking-k8s-io-v1.adoc#networkpolicy-networking-k8s-io-v1[NetworkPolicy API]

--- a/networking/network_security/network_policy/about-network-policy.adoc
+++ b/networking/network_security/network_policy/about-network-policy.adoc
@@ -10,25 +10,21 @@ endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 toc::[]
 
 [role="_abstract"]
+To restrict traffic between workloads and improve application security, configure `NetworkPolicy` objects for your cluster. Network policies define the allowed ingress and egress connections for selected pods and help isolate applications within namespaces.
+
 As a developer, you can define network policies that restrict traffic to pods in your cluster.
 
 include::modules/nw-networkpolicy-about.adoc[leveloffset=+1]
 
 include::modules/nw-networkpolicy-optimize-ovn.adoc[leveloffset=+1]
 
-include::modules/nw-network-policy-examples.adoc[leveloffset=+1]
-
-[id="about-network-policy-next-steps"]
-== Next steps
-
-* xref:../../../networking/network_security/network_policy/creating-network-policy.adoc#creating-network-policy[Creating a network policy]
-ifndef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
-* Optional: xref:../../../networking/network_security/network_policy/default-network-policy.adoc#default-network-policy[Defining a default network policy for projects]
-
 [role="_additional-resources"]
 [id="about-network-policy-additional-resources"]
 == Additional resources
 
+* xref:../../../networking/network_security/network_policy/creating-network-policy.adoc#creating-network-policy[Creating a network policy]
+ifndef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
+* xref:../../../networking/network_security/network_policy/default-network-policy.adoc#default-network-policy[Defining a default network policy for projects]
 * xref:../../../authentication/using-rbac.adoc#rbac-projects-namespaces_using-rbac[Projects and namespaces]
 * xref:../../../networking/network_security/network_policy/multitenant-network-policy.adoc#multitenant-network-policy[Configuring multitenant isolation with network policy]
 * xref:../../../rest_api/network_apis/networkpolicy-networking-k8s-io-v1.adoc#networkpolicy-networking-k8s-io-v1[NetworkPolicy API]

--- a/networking/network_security/network_policy/default-network-policy.adoc
+++ b/networking/network_security/network_policy/default-network-policy.adoc
@@ -6,6 +6,9 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
+To enforce consistent network isolation and security controls across projects, configure a default project template to automatically apply network policies to newly created projects.
+
 // TODO OSDOCS-11830 or namespace administrator?
 As a cluster administrator, you can modify the new project template to automatically include network policies when you create a new project. If you do not yet have a customized template for new projects, you must first create one.
 

--- a/networking/network_security/network_policy/multitenant-network-policy.adoc
+++ b/networking/network_security/network_policy/multitenant-network-policy.adoc
@@ -9,6 +9,9 @@ endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 
 toc::[]
 
+[role="_abstract"]
+You can configure network policies to isolate network traffic between projects in a multitenant cluster. This isolation helps prevent unauthorized communication between workloads in different namespaces.
+
 //TODO OSDOCS-11830 should this not be done with adminnetworkpolicy now?
 As a cluster administrator, you can configure your network policies to provide multitenant network isolation.
 
@@ -20,8 +23,8 @@ Configuring network policies as described in this section provides network isola
 include::modules/nw-networkpolicy-multitenant-isolation.adoc[leveloffset=+1]
 
 ifndef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
-[id="multitenant-network-policy-next-steps"]
-== Next steps
+[id="multitenant-network-policy-additional-resources"]
+== Additional resources
 
 * xref:../../../networking/network_security/network_policy/default-network-policy.adoc#default-network-policy[Defining a default network policy for a project]
 endif::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]


### PR DESCRIPTION
- https://redhat.atlassian.net/browse/OSDOCS-16837

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

- [Configuring project creation](https://111308--ocpdocs-pr.netlify.app/openshift-enterprise/latest/applications/projects/configuring-project-creation.html)

- [About network policy](https://111308--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/network_security/network_policy/about-network-policy.html)

- [Creating a network policy](https://111308--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/network_security/network_policy/creating-network-policy.html)

- [Defining a default network policy for projects](https://111308--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/network_security/network_policy/default-network-policy.html)

- [Configuring multitenant isolation with network policy](https://111308--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/network_security/network_policy/multitenant-network-policy.html)

- [Postinstallation network configuration](https://111308--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/post-install-network-configuration.html)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
