### PR TITLE
OSDOCS#19469: Update the z-stream RNs for 4.12.88

### DIFF
--- a/modules/zstream-4-12-88-about.adoc
+++ b/modules/zstream-4-12-88-about.adoc
@@ -1,0 +1,24 @@
+// Module included in the following assembly:
+//
+// * release_notes/ocp-4-12-release-notes.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="zstream-4-12-88-about_{context}"]
+= RHSA-2026:12282 - {product-title} {product-version}.88 bug fix and security update
+
+[role="_abstract"]
+Issued: 7 May 2026
+
+{product-title} release {product-version}.88, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2026:12282[RHSA-2026:12282] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2026:12273[RHSA-2026:12273] advisory.
+
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+
+You can view the container images in this release by running the following command:
+
+
+[source,terminal]
+----
+$ oc adm release info 4.12.88 --pullspecs
+----

--- a/modules/zstream-4-12-88-fixed-issues.adoc
+++ b/modules/zstream-4-12-88-fixed-issues.adoc
@@ -1,0 +1,12 @@
+// Module included in the following assembly:
+//
+// * release_notes/ocp-4-12-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-12-88-fixed-issues_{context}"]
+= Fixed issues
+
+[role="_abstract"]
+The following issue is fixed with this release:
+
+* Before this update, the user-provisioned infrastructure advanced RISC machine (ARM) template had an invalid parameter in the `storageProfile.osDiskImage.source.id` field and caused installation failures on {azure-first}. With this release, the issue with the {azure-short} user-provisioned infrastructure ARM template's `storageProfile.osDiskImage.source.id` property is correct. As a result, the user-provisioned infrastructure ARM template installation on {azure-first} succeeds. (link:https://issues.redhat.com/browse/OCPBUGS-83750[OCPBUGS-83750])

--- a/modules/zstream-4-12-88-updating.adoc
+++ b/modules/zstream-4-12-88-updating.adoc
@@ -1,0 +1,10 @@
+// Module included in the following assembly:
+//
+// * release_notes/ocp-4-12-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-12-88-updating_{context}"]
+= Updating
+
+[role="_abstract"]
+To update an existing {product-title} 4.12 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].

--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -5384,3 +5384,12 @@ include::modules/zstream-4-12-87-fixed-issues.adoc[leveloffset=+3]
 
 // 4.12.87 updating
 include::modules/zstream-4-12-87-updating.adoc[leveloffset=+3]
+
+// 4.12.88 about
+include::modules/zstream-4-12-88-about.adoc[leveloffset=+2]
+
+// 4.12.88 fixes
+include::modules/zstream-4-12-88-fixed-issues.adoc[leveloffset=+3]
+
+// 4.12.8 updating
+include::modules/zstream-4-12-88-updating.adoc[leveloffset=+3]


### PR DESCRIPTION
Version(s):
4.12

Issue:
[OSDOCS-19469](https://redhat.atlassian.net/browse/OSDOCS-19469)

Link to docs preview:
[4.12.88](https://111315--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-12-release-notes.html#zstream-4-12-88-about_release-notes)

QE review:
- [ ] QE has approved this change.
N/A for z-stream RNs.

Additional information:
Shipment [MR](https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/492)
ART [Dashboard](https://art-dash.engineering.redhat.com/dashboard/release/openshift-4.12)
