### PR TITLE
[OCPBUGS#16869]: Add warning message to create an SCC with a high priority that can block upgrades and cause instability 

### DIFF
--- a/modules/security-context-constraints-about.adoc
+++ b/modules/security-context-constraints-about.adoc
@@ -460,6 +460,11 @@ pod to fail.
 
 Security context constraints (SCCs) have a priority field that affects the ordering when attempting to validate a request by the admission controller.
 
+[WARNING]
+====
+Setting an SCC priority greater than 0 for the default {product-title} SCCs can cause critical cluster instability.
+====
+
 A priority value of `0` is the lowest possible priority. A nil priority is considered a `0`, or lowest, priority. Higher priority SCCs are moved to the front of the set when sorting.
 
 When the complete set of available SCCs is determined, the SCCs are ordered in the following manner:

--- a/modules/security-context-constraints-creating.adoc
+++ b/modules/security-context-constraints-creating.adoc
@@ -21,6 +21,11 @@ If the default security context constraints (SCCs) do not satisfy your applicati
 Creating and modifying your own SCCs are advanced operations that might cause instability to your cluster. If you have questions about using your own SCCs, contact Red{nbsp}Hat Support. For information about contacting Red{nbsp}Hat support, see _Getting support_.
 ====
 
+[WARNING]
+====
+Setting an SCC priority greater than 0 for the default {product-title} SCCs can cause critical cluster instability.
+====
+
 ifdef::openshift-dedicated[]
 [NOTE]
 ====


### PR DESCRIPTION
Version(s):
4.16+

Issue:
[OCPBUGS-16869](https://redhat.atlassian.net/browse/OCPBUGS-16869?actionerId=63c10c428a7d2f693bf779a3&sourceType=assign)

Link to docs preview:
https://111316--ocpdocs-pr.netlify.app/openshift-dedicated/latest/authentication/managing-security-context-constraints.html
https://111316--ocpdocs-pr.netlify.app/openshift-enterprise/latest/authentication/managing-security-context-constraints.html
https://111316--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/authentication/managing-security-context-constraints.html
https://111316--ocpdocs-pr.netlify.app/openshift-rosa/latest/authentication/managing-security-context-constraints.html

QE review:
- [x] QE has approved this change.
QE review performed in #110432