### PR TITLE
OSDOCS-19630 removing stale ifevals

### DIFF
--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -926,15 +926,6 @@ ifndef::aws,azure,gcp,ibm-cloud[]
 `Internal` or `External`. The default value is `External`.
 
 Setting this field to `Internal` is not supported on non-cloud platforms.
-ifndef::ibm-power-vs[]
-ifeval::[{product-version} <= 4.7]
-[IMPORTANT]
-====
-If the value of the field is set to `Internal`, the cluster becomes non-functional. For more information, refer to link:https://bugzilla.redhat.com/show_bug.cgi?id=1953035[BZ#1953035].
-====
-
-endif::[]
-endif::ibm-power-vs[]
 endif::[]
 
 |sshKey:

--- a/modules/nw-multus-add-pod.adoc
+++ b/modules/nw-multus-add-pod.adoc
@@ -8,16 +8,6 @@ ifeval::["{context}" == "configuring-sr-iov"]
 :sriov:
 endif::[]
 
-ifeval::["{product-version}" == "4.3"]
-:bz:
-endif::[]
-ifeval::["{product-version}" == "4.4"]
-:bz:
-endif::[]
-ifeval::["{product-version}" == "4.5"]
-:bz:
-endif::[]
-
 :_mod-docs-content-type: PROCEDURE
 [id="nw-multus-add-pod_{context}"]
 = Adding a pod to a secondary network
@@ -38,13 +28,6 @@ If you are using an Intel network interface controller (NIC) in Data Plane Devel
 
 You can work around this issue by either ensuring that the container that needs access to the NIC is the first container defined in the `Pod` object or by disabling the Network Resource Injector. For more information, see link:https://bugzilla.redhat.com/show_bug.cgi?id=1990953[BZ#1990953].
 =====
-
-ifdef::bz[]
-[IMPORTANT]
-====
-When specifying an SR-IOV hardware network for a `Deployment` object or a `ReplicationController` object, you must specify the namespace of the `NetworkAttachmentDefinition` object. For more information, see the following bugs: link:https://bugzilla.redhat.com/show_bug.cgi?id=1846333[BZ#1846333] and link:https://bugzilla.redhat.com/show_bug.cgi?id=1840962[BZ#1840962].
-====
-endif::bz[]
 endif::sriov[]
 
 .Prerequisites
@@ -156,7 +139,3 @@ to the pod. The annotation value is stored as a plain text value.
 ifeval::["{context}" == "configuring-sr-iov"]
 :!sriov:
 endif::[]
-
-ifdef::bz[]
-:!bz:
-endif::bz[]

--- a/networking/ovn_kubernetes_network_provider/enabling-multicast.adoc
+++ b/networking/ovn_kubernetes_network_provider/enabling-multicast.adoc
@@ -4,29 +4,8 @@
 include::_attributes/common-attributes.adoc[]
 :context: ovn-kubernetes-enabling-multicast
 
-ifeval::["{product-version}" == "4.3"]
-:bz:
-endif::[]
-ifeval::["{product-version}" == "4.4"]
-:bz:
-endif::[]
-ifeval::["{product-version}" == "4.5"]
-:bz:
-endif::[]
-
 toc::[]
-
-ifdef::bz[]
-[NOTE]
-====
-In {product-title} {product-version}, a bug prevents pods in the same namespace, but assigned to different nodes, from communicating over multicast. For more information, see link:https://bugzilla.redhat.com/show_bug.cgi?id=1843695[BZ#1843695].
-====
-endif::bz[]
 
 include::modules/nw-about-multicast.adoc[leveloffset=+1]
 
 include::modules/nw-enabling-multicast.adoc[leveloffset=+1]
-
-ifdef::bz[]
-:!bz:
-endif::bz[]


### PR DESCRIPTION
Version(s):
~~4.12+~~ 4.14+
Not worth doing manual cherrypicks in 4.12-4.13

Issue:
[OSDOCS-19630](https://redhat.atlassian.net/browse/OSDOCS-19630)

Link to docs preview:

- https://111328--ocpdocs-pr.netlify.app/openshift-dedicated/latest/networking/ovn_kubernetes_network_provider/enabling-multicast.html
- https://111328--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/install_config/installation-config-parameters-generic.html
- https://111328--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/installation-config-parameters-aws.html
- https://111328--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_azure/installation-config-parameters-azure.html
- https://111328--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_azure_stack_hub/installation-config-parameters-ash.html
- https://111328--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/upi/installation-config-parameters-bare-metal.html
- https://111328--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installation-config-parameters-gcp.html
- https://111328--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_ibm_cloud/installation-config-parameters-ibm-cloud-vpc.html
- https://111328--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_ibm_power/installation-config-parameters-ibm-power.html
- https://111328--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_ibm_powervc/installation-config-parameters-ibm-powervc.html
- https://111328--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_ibm_powervs/installation-config-parameters-ibm-power-vs.html
- https://111328--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_ibm_z/installation-config-parameters-ibm-z.html
- https://111328--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_nutanix/installation-config-parameters-nutanix.html
- https://111328--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_openstack/installation-config-parameters-openstack.html
- https://111328--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installation-config-parameters-vsphere.html
- https://111328--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_with_agent_based_installer/installation-config-parameters-agent.html
- https://111328--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/hardware_networks/configuring-sriov-ib-attach.html
- https://111328--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/hardware_networks/configuring-sriov-net-attach.html
- https://111328--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/multiple_networks/secondary_networks/attaching-pod.html
- https://111328--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/enabling-multicast.html
- https://111328--ocpdocs-pr.netlify.app/openshift-rosa/latest/networking/ovn_kubernetes_network_provider/enabling-multicast.html

QE review:
N/A

Additional information:
Removes ifevals that keyed off product versions older than we support.