### PR TITLE
[SRVCOM-4271b] Add OTel metric migration reference

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -468,6 +468,8 @@ Topics:
   Topics:
   - Name: Administrator metrics overview
     File: serverless-admin-metrics
+  - Name: OpenTelemetry metrics migration reference
+    File: serverless-opentelemetry-metrics-migration
   - Name: Controller metrics
     File: serverless-controller-metrics
   - Name: Webhook metrics

--- a/observability/admin-metrics/serverless-admin-metrics-eventing.adoc
+++ b/observability/admin-metrics/serverless-admin-metrics-eventing.adoc
@@ -28,3 +28,9 @@ include::modules/serverless-knative-kafka-subscription-metrics.adoc[leveloffset=
 include::modules/serverless-knative-kafka-source-metrics.adoc[leveloffset=+1]
 
 include::modules/serverless-knative-kafka-sink-metrics.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+[id="additional-resources_{context}"]
+== Additional resources
+
+* xref:../../observability/admin-metrics/serverless-opentelemetry-metrics-migration.adoc#serverless-opentelemetry-metrics-migration[OpenTelemetry metrics migration reference]

--- a/observability/admin-metrics/serverless-admin-metrics-serving.adoc
+++ b/observability/admin-metrics/serverless-admin-metrics-serving.adoc
@@ -16,6 +16,9 @@ include::modules/serverless-autoscaler-metrics.adoc[leveloffset=+1]
 include::modules/serverless-go-metrics.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
+[id="additional-resources_{context}"]
 == Additional resources
+
+* xref:../../observability/admin-metrics/serverless-opentelemetry-metrics-migration.adoc#serverless-opentelemetry-metrics-migration[OpenTelemetry metrics migration reference]
 
 * link:https://golang.org/pkg/runtime/#MemStats[MemStats]

--- a/observability/admin-metrics/serverless-admin-metrics.adoc
+++ b/observability/admin-metrics/serverless-admin-metrics.adoc
@@ -14,7 +14,10 @@ To view different metrics for {ServerlessProductName}, you can check the {ocp-pr
 include::modules/serverless-prereqs-for-admin-metrics.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
+[id="additional-resources_{context}"]
 == Additional resources
+
+* xref:../../observability/admin-metrics/serverless-opentelemetry-metrics-migration.adoc#serverless-opentelemetry-metrics-migration[OpenTelemetry metrics migration reference]
 
 * link:https://docs.openshift.com/container-platform/latest/observability/monitoring/managing-metrics.html[Managing metrics]
 

--- a/observability/admin-metrics/serverless-opentelemetry-metrics-migration.adoc
+++ b/observability/admin-metrics/serverless-opentelemetry-metrics-migration.adoc
@@ -1,0 +1,294 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="serverless-opentelemetry-metrics-migration"]
+= OpenTelemetry metrics migration reference
+include::_attributes/common-attributes.adoc[]
+:context: serverless-opentelemetry-metrics-migration
+
+toc::[]
+
+[role="_abstract"]
+In {ServerlessProductName} 1.38.0, Knative migrates from OpenCensus to OpenTelemetry for metrics collection. This affects metric names, label names, and units. If you have custom dashboards, alerting rules, or monitoring queries that use Knative metrics, you must update them.
+
+For complete metric reference tables showing the new metric names and labels, see the individual component metric reference pages listed in the "Additional resources" section.
+
+[id="metric-naming-patterns_{context}"]
+== Metric naming patterns
+
+OpenTelemetry metrics use semantic prefixes:
+
+* *Eventing metrics:*
+** MT Broker and InMemoryChannel use `+kn_eventing_dispatch_duration_seconds+` or `+kn_eventing_process_duration_seconds+`
+** Kafka-based components use `+kn_eventing_dispatch_latency_ms+` or `+kn_eventing_process_latency_ms+`
+** Event sources use Knative-specific metrics or standard `+http_client_request_duration_seconds+`
+
+* *Serving metrics:*
+** Queue Proxy uses `+kn_serving_invocation_duration_seconds+`
+** Activator uses `+http_server_request_duration_seconds+` for HTTP requests and `+kn_revision_request_concurrency+` for concurrency
+** Autoscaler uses `+kn_revision_*+` or `+kn_autoscaler_*+` prefixes
+
+* *Metric type suffixes:*
+** Counter metrics end with `+_count+`
+** Histogram metrics end with `+_bucket+`
+** Gauge metrics have no suffix
+
+[id="label-naming-patterns_{context}"]
+== Label naming patterns
+
+Labels follow OpenTelemetry and Kubernetes semantic conventions:
+
+* *Kubernetes labels:*
+** `+namespace_name+` becomes `+k8s_namespace_name+`
+** `+pod_name+` becomes `+k8s_pod_name+`
+
+* *Knative labels:*
+** Serving uses `+kn_configuration_name+`, `+kn_revision_name+`, `+kn_service_name+`
+** Eventing uses resource-specific labels that vary by component type
+
+* *HTTP labels:*
+** `+response_code+` and `+response_code_class+` become `+http_response_status_code+`
+
+* *CloudEvents labels:*
+** `+event_type+` becomes `+cloudevents_type+`
+
+[IMPORTANT]
+====
+Different Eventing components use different namespace labels. MT Broker uses `+kn_broker_namespace+`, InMemoryChannel uses `+kn_channel_namespace+`, KafkaChannel uses `+kn_kafkachannel_namespace+`, and Kafka Broker Dispatcher uses `+kn_trigger_namespace+` instead of `+kn_broker_namespace+`.
+====
+
+[id="unit-changes_{context}"]
+== Unit changes
+
+[IMPORTANT]
+====
+Kafka-based components, such as Kafka Broker, Kafka Channel, Kafka Source, and Kafka Sink, still use millisecond-based metrics with `+_ms+` suffix. MT Broker, InMemoryChannel, and Serving components use second-based metrics with `+_seconds+` suffix.
+====
+
+When you update queries for components that changed to seconds:
+
+* *Old threshold:* `+> 100+` (100 milliseconds) becomes `+> 0.1+` (0.1 seconds)
+* *Histogram quantile results:* Results are in seconds instead of milliseconds
+* *Display units:* Update dashboard panel display units
+
+[id="response-code-filtering_{context}"]
+== Response code filtering
+
+Response code filtering uses regex patterns instead of exact string matches:
+
+* *Success (2xx):* `+http_response_status_code=~"2.."+`
+* *Client errors (4xx):* `+http_response_status_code=~"4.."+`
+* *Server errors (5xx):* `+http_response_status_code=~"5.."+`
+* *All errors (non-2xx):* `+http_response_status_code!~"2.."+`
+
+[id="job-labels_{context}"]
+== Job labels for Eventing components
+
+Eventing components require `+job+` label filters to distinguish between components that share metric names:
+
+[cols="2,3",options="header"]
+|===
+|Component
+|Job label value
+
+|MT Broker Ingress
+|`mt-broker-ingress-sm-service`
+
+|MT Broker Filter
+|`mt-broker-filter-sm-service`
+
+|InMemoryChannel Dispatcher
+|`imc-dispatcher-sm-service`
+
+|Kafka Broker Receiver
+|`kafka-broker-receiver-sm-service`
+
+|Kafka Broker Dispatcher
+|`kafka-broker-dispatcher-sm-service`
+
+|KafkaChannel Receiver
+|`kafka-channel-receiver-sm-service`
+
+|KafkaSink Receiver
+|`kafka-sink-receiver-sm-service`
+
+|PingSource
+|`pingsource-mt-adapter-sm-service`
+
+|KafkaSource
+|`kafka-source-dispatcher-sm-service`
+
+|ApiServerSource
+|`+apiserversource-.*+` (use regex: `+job=~"apiserversource-.*"+`)
+
+|===
+
+[id="migration-examples_{context}"]
+== Migration examples
+
+The following examples show how to update common monitoring queries.
+
+.Example: MT Broker event rate
+[cols="1,1",options="header"]
+|===
+|Before
+|After
+
+a|
+[source,promql]
+----
+sum(rate(mt_broker_ingress_event_count{namespace_name="my-namespace"}[1m]))
+----
+
+a|
+[source,promql]
+----
+sum(rate(kn_eventing_dispatch_duration_seconds_count{job="mt-broker-ingress-sm-service", kn_broker_namespace="my-namespace"}[1m]))
+----
+|===
+
+.Example: MT Broker P99 latency
+[cols="1,1",options="header"]
+|===
+|Before
+|After
+
+a|
+[source,promql]
+----
+histogram_quantile(0.99,
+  sum(rate(mt_broker_ingress_event_dispatch_latencies_bucket{namespace_name="my-namespace"}[1m])) by (le)
+)
+----
+
+a|
+[source,promql]
+----
+histogram_quantile(0.99,
+  sum(rate(kn_eventing_dispatch_duration_seconds_bucket{job="mt-broker-ingress-sm-service", kn_broker_namespace="my-namespace"}[1m])) by (le)
+)
+----
+|===
+
+[NOTE]
+====
+The unit changed from milliseconds to seconds. Adjust dashboard panel display units and alert thresholds.
+====
+
+.Example: Kafka Broker Receiver event rate
+[cols="1,1",options="header"]
+|===
+|Before
+|After
+
+a|
+[source,promql]
+----
+sum(rate(event_count_1_total{job="kafka-broker-receiver-sm-service", namespace_name="my-namespace"}[1m]))
+----
+
+a|
+[source,promql]
+----
+sum(rate(kn_eventing_dispatch_latency_ms_count{job="kafka-broker-receiver-sm-service", kn_broker_namespace="my-namespace"}[1m]))
+----
+|===
+
+[NOTE]
+====
+Kafka Broker metrics still use milliseconds.
+====
+
+.Example: Kafka Broker Dispatcher event rate
+[cols="1,1",options="header"]
+|===
+|Before
+|After
+
+a|
+[source,promql]
+----
+sum(rate(event_count_1_total{job="kafka-broker-dispatcher-sm-service", namespace_name="my-namespace"}[1m]))
+----
+
+a|
+[source,promql]
+----
+sum(rate(kn_eventing_dispatch_latency_ms_count{job="kafka-broker-dispatcher-sm-service", kn_trigger_namespace="my-namespace"}[1m]))
+----
+|===
+
+[NOTE]
+====
+The Kafka Broker Dispatcher uses `+kn_trigger_namespace+`, which is different from the Kafka Broker Receiver's `+kn_broker_namespace+`.
+====
+
+.Example: Success rate with response code filtering
+[cols="1,1",options="header"]
+|===
+|Before
+|After
+
+a|
+[source,promql]
+----
+sum(rate(mt_broker_ingress_event_count{response_code_class="2xx", namespace_name="my-namespace"}[1m])) /
+sum(rate(mt_broker_ingress_event_count{namespace_name="my-namespace"}[1m]))
+----
+
+a|
+[source,promql]
+----
+sum(rate(kn_eventing_dispatch_duration_seconds_count{http_response_status_code=~"2..", job="mt-broker-ingress-sm-service", kn_broker_namespace="my-namespace"}[1m])) /
+sum(rate(kn_eventing_dispatch_duration_seconds_count{job="mt-broker-ingress-sm-service", kn_broker_namespace="my-namespace"}[1m]))
+----
+|===
+
+[NOTE]
+====
+Response code filtering uses regex patterns: `+=~"2.."+` for success and `+!~"2.."+` for errors.
+====
+
+.Example: Serving revision request count
+[cols="1,1",options="header"]
+|===
+|Before
+|After
+
+a|
+[source,promql]
+----
+sum(rate(revision_app_request_count{namespace="my-namespace", revision_name=~"my-app.*"}[1m]))
+----
+
+a|
+[source,promql]
+----
+sum(rate(kn_serving_invocation_duration_seconds_count{k8s_namespace_name="my-namespace", kn_revision_name=~"my-app.*"}[1m]))
+----
+|===
+
+.Example: Autoscaler actual pods
+[cols="1,1",options="header"]
+|===
+|Before
+|After
+
+a|
+[source,promql]
+----
+sum(autoscaler_actual_pods{namespace_name="my-namespace", revision_name="my-app-00001"})
+----
+
+a|
+[source,promql]
+----
+sum(kn_revision_pods_count{k8s_namespace_name="my-namespace", kn_revision_name="my-app-00001"})
+----
+|===
+
+[role="_additional-resources"]
+[id="additional-resources_{context}"]
+== Additional resources
+
+* xref:../../observability/admin-metrics/serverless-admin-metrics-eventing.adoc#serverless-admin-metrics-eventing[Knative Eventing metrics]
+* xref:../../observability/admin-metrics/serverless-admin-metrics-serving.adoc#serverless-admin-metrics-serving[Knative Serving metrics]
+* link:https://opentelemetry.io/docs/specs/semconv/[OpenTelemetry Semantic Conventions]


### PR DESCRIPTION
Version(s):
- `serverless-docs-1.38`

Issue:
- https://redhat.atlassian.net/browse/SRVCOM-4271

Link to docs preview:
- [OpenTelemetry metrics migration reference](https://111339--ocpdocs-pr.netlify.app/openshift-serverless/latest/observability/admin-metrics/serverless-opentelemetry-metrics-migration.html)

QE review:
- [x] QE has approved this change.
