### PR TITLE
[OSSM 3.2] Fix broken link for OVN-K gateway mode

### DIFF
--- a/install/ossm-istio-ambient-mode.adoc
+++ b/install/ossm-istio-ambient-mode.adoc
@@ -38,7 +38,7 @@ include::modules/ossm-adding-authorization-policy.adoc[leveloffset=+1]
 [id="additional-resources_{context}"]
 == Additional resources
 
-* link:https://docs.redhat.com/en/documentation/openshift_container_platform/latest/html/ovn-kubernetes_network_plugin/configuring-gateway-mode[Configuring gateway mode]
+* link:https://docs.redhat.com/en/documentation/openshift_container_platform/latest/html/ovn-kubernetes_network_plugin/configuring-gateway[Configuring gateway mode]
 
 * xref:../install/ossm-installing-openshift-service-mesh.adoc#ossm-scoping-service-mesh-with-discoveryselectors_ossm-installing-openshift-service-mesh[Scoping the mesh with discovery selectors]
 


### PR DESCRIPTION
This PR fixes a broken link in the Ambient mode prerequisites section.
