### PR TITLE
Fix MetalLB procedures based on live cluster verification

### DIFF
--- a/modules/nw-metallb-configure-l2-advertisement.adoc
+++ b/modules/nw-metallb-configure-l2-advertisement.adoc
@@ -11,17 +11,17 @@ You can configure MetalLB so that the `IPAddressPool` is advertised with the L2 
 
 .Prerequisites
 
-* Install the {oc-first}. 
+* Install the {oc-first}.
 * Log in as a user with `cluster-admin` privileges.
+* Install the MetalLB Operator and start MetalLB on your cluster.
 
 .Procedure
 
-. Create an IP address pool.
+. Create an IP address pool by entering the following command:
 +
-.. Create a file, such as `ipaddresspool.yaml`, with content like the following example:
-+
-[source,yaml]
+[source,terminal]
 ----
+$ cat << EOF | oc apply -f -
 apiVersion: metallb.io/v1beta1
 kind: IPAddressPool
 metadata:
@@ -29,24 +29,15 @@ metadata:
   name: doc-example-l2
 spec:
   addresses:
-    - 4.4.4.0/24
-  autoAssign: false
-# ...
+    - 192.168.122.200-192.168.122.210
+EOF
 ----
-+
-.. Apply the configuration for the IP address pool:
+
+. Create an L2 advertisement by entering the following command:
 +
 [source,terminal]
 ----
-$ oc apply -f ipaddresspool.yaml
-----
-
-. Create an L2 advertisement.
-+
-.. Create a file, such as `l2advertisement.yaml`, with content like the following example:
-+
-[source,yaml]
-----
+$ cat << EOF | oc apply -f -
 apiVersion: metallb.io/v1beta1
 kind: L2Advertisement
 metadata:
@@ -55,12 +46,35 @@ metadata:
 spec:
   ipAddressPools:
    - doc-example-l2
-  # ...
+EOF
 ----
-+
-.. Apply the configuration:
+
+.Verification
+
+. Verify that the IP address pool is created:
 +
 [source,terminal]
 ----
-$ oc apply -f l2advertisement.yaml
+$ oc get ipaddresspool -n metallb-system
+----
++
+.Example output
+[source,terminal]
+----
+NAMESPACE        NAME             AUTO ASSIGN   AVOID BUGGY IPS   ADDRESSES
+metallb-system   doc-example-l2   true          false             ["192.168.122.200-192.168.122.210"]
+----
+
+. Verify that the L2 advertisement is created:
++
+[source,terminal]
+----
+$ oc get l2advertisement -n metallb-system
+----
++
+.Example output
+[source,terminal]
+----
+NAMESPACE        NAME              IPADDRESSPOOLS       IPADDRESSPOOL SELECTORS   INTERFACES
+metallb-system   l2advertisement   ["doc-example-l2"]
 ----

--- a/modules/nw-metallb-configure-svc.adoc
+++ b/modules/nw-metallb-configure-svc.adoc
@@ -18,61 +18,92 @@ To expose an application to external network traffic, configure a load-balancing
 
 .Procedure
 
-. Create a `<service_name>.yaml` file. In the file, set the `spec.type` parameter to `LoadBalancer`.
+. Create a project for the application by entering the following command:
 +
-Refer to the examples for information about how to request the external IP address that MetalLB assigns to the service.
+[source,terminal]
+----
+$ oc new-project metallb-test
+----
 
-. Create the service:
+. Create a test application deployment by entering the following command:
 +
 [source,terminal]
 ----
-$ oc apply -f <service_name>.yaml
+$ oc create deployment hello-web --image=quay.io/openshifttest/hello-openshift:1.2.0 --port=8080
 ----
+
+. Wait for the deployment to be available by entering the following command:
 +
-.Example output
 [source,terminal]
 ----
-service/<service_name> created
+$ oc wait deployment/hello-web --for=condition=Available --timeout=60s
 ----
+
+. Create a `LoadBalancer` service to expose the application by entering the following command:
++
+[source,terminal]
+----
+$ cat << EOF | oc apply -f -
+apiVersion: v1
+kind: Service
+metadata:
+  name: hello-web-lb
+  namespace: metallb-test
+  annotations:
+    metallb.universe.tf/address-pool: doc-example-l2 <1>
+spec:
+  type: LoadBalancer
+  selector:
+    app: hello-web
+  ports:
+    - port: 80
+      targetPort: 8080
+      protocol: TCP
+EOF
+----
+<1> Replace `doc-example-l2` with the name of your `IPAddressPool`.
 
 .Verification
 
-* Describe the service:
+. Verify that MetalLB assigned an external IP address to the service:
 +
 [source,terminal]
 ----
-$ oc describe service <service_name>
+$ oc get svc hello-web-lb -n metallb-test
 ----
 +
 .Example output
+[source,terminal]
 ----
-Name:                     <service_name>
-Namespace:                default
-Labels:                   <none>
-Annotations:              metallb.io/address-pool: doc-example
-Selector:                 app=service_name
-Type:                     LoadBalancer
-IP Family Policy:         SingleStack
-IP Families:              IPv4
-IP:                       10.105.237.254
-IPs:                      10.105.237.254
-LoadBalancer Ingress:     192.168.100.5
-Port:                     <unset>  80/TCP
-TargetPort:               8080/TCP
-NodePort:                 <unset>  30550/TCP
-Endpoints:                10.244.0.50:8080
-Session Affinity:         None
-External Traffic Policy:  Cluster
-Events:
-  Type    Reason        Age                From             Message
-  ----    ------        ----               ----             -------
-  Normal  nodeAssigned  32m (x2 over 32m)  metallb-speaker  announcing from node "<node_name>"
+NAME           TYPE           CLUSTER-IP      EXTERNAL-IP       PORT(S)        AGE
+hello-web-lb   LoadBalancer   172.30.10.155   192.168.122.200   80:31506/TCP   4s
+----
+
+. Describe the service to verify the MetalLB annotations and events:
++
+[source,terminal]
+----
+$ oc describe service hello-web-lb -n metallb-test
 ----
 +
 where:
 +
 `Annotations`:: Specifies the annotation that is present if you request an IP address from a specific pool.
 `Type`:: Specifies the service type that must indicate `LoadBalancer`.
-`LoadBalancer Ingress`:: Specifies the indicates the external IP address if the service is assigned correctly.
+`LoadBalancer Ingress`:: Specifies the external IP address if the service is assigned correctly.
 `Events`:: Specifies the events parameter that indicates the node name that is assigned to announce the external IP address. If you experience an error, the events parameter indicates the reason for the error.
 
+. Verify that the application is reachable from outside the cluster by entering the following command:
++
+[source,terminal]
+----
+$ curl http://<external_ip_address>
+----
++
+Replace `<external_ip_address>` with the `EXTERNAL-IP` value from the output of the `oc get svc` command.
++
+.Example output
+[source,terminal]
+----
+Hello OpenShift!
+----

--- a/modules/nw-metallb-configure-svc.adoc
+++ b/modules/nw-metallb-configure-svc.adoc
@@ -50,7 +50,7 @@ metadata:
   name: hello-web-lb
   namespace: metallb-test
   annotations:
-    metallb.universe.tf/address-pool: doc-example-l2 <1>
+    metallb.universe.tf/address-pool: doc-example-l2
 spec:
   type: LoadBalancer
   selector:
@@ -61,7 +61,8 @@ spec:
       protocol: TCP
 EOF
 ----
-<1> Replace `doc-example-l2` with the name of your `IPAddressPool`.
++
+Replace `doc-example-l2` in the `metallb.universe.tf/address-pool` annotation with the name of your `IPAddressPool`.
 
 .Verification
 

--- a/modules/nw-metallb-installing-operator-cli.adoc
+++ b/modules/nw-metallb-installing-operator-cli.adoc
@@ -58,11 +58,11 @@ NAME               AGE
 metallb-operator   14m
 ----
 
-. Create a `Subscription` CR:
-.. Define the `Subscription` CR and save the YAML file, for example, `metallb-sub.yaml`:
+. Create a `Subscription` CR by entering the following command:
 +
-[source,yaml]
+[source,terminal]
 ----
+$ cat << EOF | oc apply -f -
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
@@ -73,15 +73,7 @@ spec:
   name: metallb-operator
   source: redhat-operators
   sourceNamespace: openshift-marketplace
-----
-+
-** For the `spec.source` parameter, must specify the `redhat-operators` value.
-
-.. To create the `Subscription` CR, run the following command:
-+
-[source,terminal]
-----
-$ oc create -f metallb-sub.yaml
+EOF
 ----
 
 . Optional: To ensure BGP and BFD metrics appear in Prometheus, you can label the namespace as in the following command:
@@ -111,7 +103,7 @@ install-wzg94   metallb-operator.{product-version}.0-nnnnnnnnnnnn   Automatic   
 +
 [NOTE]
 ====
-Installation of the Operator might take a few seconds.
+Installation of the Operator might take up to a minute or more.
 ====
 
 . To verify that the Operator is installed, enter the following command and then check that output shows `Succeeded` for the Operator:

--- a/modules/nw-metallb-operator-initial-config.adoc
+++ b/modules/nw-metallb-operator-initial-config.adoc
@@ -32,11 +32,16 @@ metadata:
 EOF
 ----
 +
-** For the `metdata.namespace` parameter, substitute `metallb-system` with `openshift-operators` if you installed the MetalLB Operator using the web console.
+** For the `metadata.namespace` parameter, substitute `metallb-system` with `openshift-operators` if you installed the MetalLB Operator using the web console.
 
 .Verification
 
 Confirm that the deployment for the MetalLB controller and the daemon set for the MetalLB speaker are running.
+
+[NOTE]
+====
+After creating the MetalLB custom resource, it might take up to a minute for the controller deployment and speaker daemon set to become available.
+====
 
 . Verify that the deployment for the controller is running:
 +


### PR DESCRIPTION
## Summary
   - **Install procedure**: Replaced magic step (save YAML file + `oc create`) with inline heredoc pattern consistent with earlier steps; fixed
   misleading "few seconds" wait time
   - **Initial config**: Fixed `metdata.namespace` typo, added wait note before verification steps
   - **L2 advertisement**: Replaced file-based magic steps with inline heredocs, added missing MetalLB prerequisite, used realistic IP range
   (`192.168.122.200-192.168.122.210`), removed unexplained `autoAssign: false`, added verification section
   - **Service config**: Replaced placeholder-only procedure with concrete working example including test deployment (`hello-openshift`), LoadBalancer
   service with MetalLB annotation, and `curl` verification

   ## Test plan
   - [x] All four procedures tested end-to-end against a live OCP 4.18 single-node cluster
   - [x] MetalLB Operator installed, MetalLB started, IPAddressPool and L2Advertisement created, LoadBalancer service assigned external IP
   - [x] Application reachable via external IP in browser (`http://192.168.122.200`)
   - [x] Gaps identified using the verify-procedure skill (Ruby-based AsciiDoc parser + executor)

   🤖 Generated with [Claude Code](https://claude.com/claude-code)
   EOF
   )"
   Create pull request to upstream

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
