### PR TITLE
DOCPLAN-368: Fix ConceptLink warnings in virt/post_installation_configuration

### DIFF
--- a/virt/post_installation_configuration/virt-post-install-config.adoc
+++ b/virt/post_installation_configuration/virt-post-install-config.adoc
@@ -17,9 +17,9 @@ endif::openshift-enterprise[]
 
 * The hostpath provisioner is a local storage provisioner designed for {VirtProductName}. If you want to configure local storage for virtual machines, you must enable the hostpath provisioner first.
 
-* xref:../../virt/post_installation_configuration/virt-node-placement-virt-components.adoc#virt-node-placement-virt-components[Node placement rules for {VirtProductName} Operators, workloads, and controllers]
+* Node placement rules for {VirtProductName} Operators, workloads, and controllers.
 
-* xref:../../virt/post_installation_configuration/virt-post-install-network-config.adoc#virt-post-install-network-config[Network configuration]:
+* Network configuration:
 
 ifndef::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
 ** Installing the Kubernetes NMState and SR-IOV Operators
@@ -32,9 +32,16 @@ ifdef::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
 ** Enabling the creation of load balancer services by using the {product-title} web console
 endif::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
 
-* xref:../../virt/post_installation_configuration/virt-post-install-storage-config.adoc#virt-post-install-storage-config[Storage configuration]:
+* Storage configuration:
 ** Defining a default storage class for the Container Storage Interface (CSI)
 ** Configuring local storage by using the Hostpath Provisioner (HPP)
 
 // * Users
 // * Alerts and notifications
+
+[role="_additional-resources"]
+[id="additional-resources_{context}"]
+== Additional resources
+* xref:../../virt/post_installation_configuration/virt-node-placement-virt-components.adoc#virt-node-placement-virt-components[Specifying nodes for {VirtProductName} components]
+* xref:../../virt/post_installation_configuration/virt-post-install-network-config.adoc#virt-post-install-network-config[Postinstallation network configuration]
+* xref:../../virt/post_installation_configuration/virt-post-install-storage-config.adoc#virt-post-install-storage-config[Postinstallation storage configuration]


### PR DESCRIPTION
Move links and cross-references to Additional resources sections.

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.20+

Issue:
https://redhat.atlassian.net/browse/DOCPLAN-368

Link to docs preview:
https://111386--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/post_installation_configuration/virt-post-install-config.html

QE review:
n/a
