### PR TITLE
DOCPLAN-365: Fix ConceptLink warnings in virt/about_virt

### DIFF
--- a/modules/virt-tested-maximums.adoc
+++ b/modules/virt-tested-maximums.adoc
@@ -12,7 +12,7 @@ The following limits apply to a large-scale {VirtProductName} 4.x environment. T
 [id="vm-maximums_{context}"]
 == Virtual machine maximums
 
-The following maximums apply to virtual machines (VMs) running on {VirtProductName}. These values are subject to the limits specified in link:https://access.redhat.com/articles/rhel-kvm-limits[Virtualization limits for Red Hat{nbsp}Enterprise Linux with KVM].
+The following maximums apply to virtual machines (VMs) running on {VirtProductName}. These values are subject to the limits specified in "Virtualization limits for Red Hat Enterprise Linux with KVM".
 
 [cols="1,1,1",subs="attributes+"]
 |===

--- a/virt/about_virt/about-virt.adoc
+++ b/virt/about_virt/about-virt.adoc
@@ -27,7 +27,7 @@ You can check your {VirtProductName} cluster for compliance issues by installing
 endif::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
 
 ifdef::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
-You can check your {VirtProductName} cluster for compliance issues by installing the Compliance Operator and running a scan with the `ocp4-moderate` and `ocp4-moderate-node` profiles. The Compliance Operator uses OpenSCAP, a link:https://www.nist.gov/[NIST-certified tool], to scan and enforce security policies.
+You can check your {VirtProductName} cluster for compliance issues by installing the Compliance Operator and running a scan with the `ocp4-moderate` and `ocp4-moderate-node` profiles. The Compliance Operator uses OpenSCAP, a NIST-certified tool, to scan and enforce security policies.
 endif::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
 
 ifndef::openshift-dedicated[]

--- a/virt/about_virt/about-virt.adoc
+++ b/virt/about_virt/about-virt.adoc
@@ -14,7 +14,7 @@ include::modules/virt-what-you-can-do-with-virt.adoc[leveloffset=+1]
 // It is included here in the assembly because of the xref ban.
 
 ifndef::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
-You can use {VirtProductName} with xref:../../networking/ovn_kubernetes_network_provider/about-ovn-kubernetes.adoc#about-ovn-kubernetes[OVN-Kubernetes] or one of the other certified network plugins listed in link:https://access.redhat.com/articles/5436171[Certified OpenShift CNI Plug-ins].
+You can use {VirtProductName} with OVN-Kubernetes or one of the other certified network plugins listed in "Certified OpenShift CNI Plug-ins".
 endif::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
 
 ifdef::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
@@ -23,7 +23,7 @@ endif::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
 
 // Hiding links in ROSA/OSD until PR 62384 merges
 ifndef::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
-You can check your {VirtProductName} cluster for compliance issues by installing the xref:../../security/compliance_operator/co-concepts/compliance-operator-understanding.adoc#understanding-compliance[Compliance Operator] and running a scan with the `ocp4-moderate` and `ocp4-moderate-node` xref:../../security/compliance_operator/co-scans/compliance-operator-supported-profiles.adoc#compliance-operator-supported-profiles[profiles]. The Compliance Operator uses OpenSCAP, a link:https://www.nist.gov/[NIST-certified tool], to scan and enforce security policies.
+You can check your {VirtProductName} cluster for compliance issues by installing the Compliance Operator and running a scan with the `ocp4-moderate` and `ocp4-moderate-node` profiles. The Compliance Operator uses OpenSCAP, a NIST-certified tool, to scan and enforce security policies.
 endif::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
 
 ifdef::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
@@ -31,7 +31,7 @@ You can check your {VirtProductName} cluster for compliance issues by installing
 endif::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
 
 ifndef::openshift-dedicated[]
-For information about partnering with Independent Software Vendors (ISVs) and Services partners for specialized storage, networking, backup, and additional functionality, see link:https://red.ht/workswithvirt[the Red Hat Ecosystem Catalog].
+For information about partnering with Independent Software Vendors (ISVs) and Services partners for specialized storage, networking, backup, and additional functionality, see the Red Hat Ecosystem Catalog.
 endif::openshift-dedicated[]
 
 include::modules/virt-vmware-comparison.adoc[leveloffset=+1]
@@ -48,7 +48,12 @@ endif::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
 [role="_additional-resources"]
 [id="additional-resources_about-virt"]
 == Additional resources
-
+* link:https://access.redhat.com/articles/5436171[Certified OpenShift CNI Plug-ins]
+* xref:../../networking/ovn_kubernetes_network_provider/about-ovn-kubernetes.adoc#about-ovn-kubernetes[About the OVN-Kubernetes network plugin]
+* link:https://www.nist.gov/[National Institute of Standards and Technology]
+* xref:../../security/compliance_operator/co-concepts/compliance-operator-understanding.adoc#understanding-compliance[Understanding the Compliance Operator]
+* xref:../../security/compliance_operator/co-scans/compliance-operator-supported-profiles.adoc#compliance-operator-supported-profiles[Supported compliance profiles]
+* link:https://red.ht/workswithvirt[Red Hat Ecosystem Catalog]
 ifndef::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
 * xref:../../virt/about_virt/virt-supported-limits.adoc#virt-supported-limits[{VirtProductName} supported limits]
 * xref:../../networking/ovn_kubernetes_network_provider/about-ovn-kubernetes.adoc#nw-ovn-kubernetes-purpose_about-ovn-kubernetes[OVN-Kubernetes purpose]

--- a/virt/about_virt/virt-security-policies.adoc
+++ b/virt/about_virt/virt-security-policies.adoc
@@ -9,9 +9,9 @@ toc::[]
 Learn about {VirtProductName} security and authorization.
 
 .Key points
-* {VirtProductName} adheres to the `restricted` link:https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted[Kubernetes pod security standards] profile, which aims to enforce the current best practices for pod security.
+* {VirtProductName} adheres to the `restricted` Kubernetes pod security standards profile, which aims to enforce the current best practices for pod security.
 * Virtual machine (VM) workloads run as unprivileged pods.
-* xref:../../authentication/managing-security-context-constraints.adoc#security-context-constraints-about_configuring-internal-oauth[Security context constraints] (SCCs) are defined for the `kubevirt-controller` service account.
+* Security context constraints (SCCs) are defined for the `kubevirt-controller` service account.
 * TLS certificates for {VirtProductName} components are renewed and rotated automatically.
 
 include::modules/virt-about-workload-security.adoc[leveloffset=+1]
@@ -21,7 +21,7 @@ include::modules/virt-automatic-certificates-renewal.adoc[leveloffset=+1]
 [id="authorization_virt-security-policies"]
 == Authorization
 
-{VirtProductName} uses xref:../../authentication/using-rbac.adoc#using-rbac[role-based access control] (RBAC) to define permissions for human users and service accounts. The permissions defined for service accounts control the actions that {VirtProductName} components can perform.
+{VirtProductName} uses role-based access control (RBAC) to define permissions for human users and service accounts. The permissions defined for service accounts control the actions that {VirtProductName} components can perform.
 
 You can also use RBAC roles to manage user access to virtualization features. For example, an administrator can create an RBAC role that provides the permissions required to launch a virtual machine. The administrator can then restrict access by binding the role to specific users.
 
@@ -34,7 +34,8 @@ include::modules/virt-additional-scc-for-kubevirt-controller.adoc[leveloffset=+2
 [role="_additional-resources"]
 [id="additional-resources_{context}"]
 == Additional resources
-* xref:../../authentication/managing-security-context-constraints.adoc#security-context-constraints-about_configuring-internal-oauth[Managing security context constraints]
+* link:https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted[Pod Security Standards]
+* xref:../../authentication/managing-security-context-constraints.adoc#security-context-constraints-about_configuring-internal-oauth[About security context constraints]
 * xref:../../authentication/using-rbac.adoc#using-rbac[Using RBAC to define and apply permissions]
 * xref:../../authentication/using-rbac.adoc#creating-cluster-role_using-rbac[Creating a cluster role]
 * xref:../../authentication/using-rbac.adoc#cluster-role-binding-commands_using-rbac[Cluster role binding commands]

--- a/virt/about_virt/virt-supported-limits.adoc
+++ b/virt/about_virt/virt-supported-limits.adoc
@@ -16,6 +16,7 @@ include::modules/virt-tested-maximums.adoc[leveloffset=+1]
 [id="additional-resources_{context}"]
 == Additional resources
 * link:https://access.redhat.com/articles/6994974[{VirtProductName} - Tuning & Scaling Guide]
+* link:https://access.redhat.com/articles/rhel-kvm-limits[Virtualization limits for Red Hat Enterprise Linux with KVM]
 * xref:../../scalability_and_performance/planning-your-environment-according-to-object-maximums.adoc#planning-your-environment-according-to-object-maximums[Planning your environment according to object maximums]
 * xref:../../nodes/nodes/nodes-nodes-managing-max-pods.adoc#nodes-nodes-managing-max-pods[Managing the maximum number of pods per node]
 * link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes[{rh-rhacm-title} documentation]

--- a/virt/about_virt/virt-supported-limits.adoc
+++ b/virt/about_virt/virt-supported-limits.adoc
@@ -8,7 +8,7 @@ toc::[]
 
 You can refer to tested object maximums when planning your {product-title} environment for {VirtProductName}. However, approaching the maximum values can reduce performance and increase latency. Ensure that you plan for your specific use case and consider all factors that can impact cluster scaling.
 
-For more information about cluster configuration and options that impact performance, see the link:https://access.redhat.com/articles/6994974[{VirtProductName} - Tuning & Scaling Guide] in the Red{nbsp}Hat Knowledgebase.
+For more information about cluster configuration and options that impact performance, see the "{VirtProductName} - Tuning & Scaling Guide" in the Red{nbsp}Hat Knowledgebase.
 
 include::modules/virt-tested-maximums.adoc[leveloffset=+1]
 


### PR DESCRIPTION
Move links and cross-references to Additional resources sections. Update link text for proper capitalization and formatting.

Version(s):
4.20+

Issue:
https://redhat.atlassian.net/browse/DOCPLAN-365

Link to docs preview:

- https://111387--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/about_virt/about-virt.html
- https://111387--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/about_virt/virt-security-policies.html
- https://111387--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/about_virt/virt-supported-limits.html

QE review:
n/a