### PR TITLE
[RHACS] [DOCS] ROX-34578: Release notes for RHACS 4.9.6

### DIFF
--- a/modules/common-attributes.adoc
+++ b/modules/common-attributes.adoc
@@ -62,13 +62,14 @@ endif::[]
 :product-registry: OpenShift image registry
 :olm-first: Operator Lifecycle Manager (OLM)
 :olm: OLM
-:rhacs-version: 4.9.5
+:rhacs-version: 4.9.6
 :ga-date-490: 30 October 2025
 :ga-date-491: 24 November 2025
 :ga-date-492: 16 December 2025
 :ga-date-493: 17 February 2026
 :ga-date-494: 16 March 2026
 :ga-date-495: 8 April 2026
+:ga-date-496: 6 May 2026
 :ocp-supported-version: 4.12
 :ocp-latest-version: 4.21
 :pipelines-shortname: OpenShift Pipelines

--- a/release_notes/49-release-notes.adoc
+++ b/release_notes/49-release-notes.adoc
@@ -21,6 +21,7 @@ toc::[]
 |`4.9.3` | {ga-date-493}
 |`4.9.4` | {ga-date-494}
 |`4.9.5` | {ga-date-495}
+|`4.9.6` | {ga-date-496}
 
 |====
 
@@ -669,5 +670,36 @@ This release addresses the following security vulnerabilities:
 ====
 This CVE is not addressed in Scanner V2 images in this release.
 ====
+
+[id="about-this-release-496_{context}"]
+== About release 4.9.6
+
+*Release date*: {ga-date-496}
+
+This release provides the following bug fixes:
+
+//ROX-34000
+* Before this update, the documentation for Central exposure route reencrypt TLS certificate and key configuration requirements was unclear. Users attempting to configure these fields encountered Operator failures with the following error message:
++
+`FATAL ERROR: The reencrypt route must specify either both, certificate and key, or neither.`
++
+With this release, Red{nbsp}Hat has clarified the documentation to specify that users must configure the certificate and key fields together or omit both. As a result, users can now correctly configure reencrypt routes.
+
+This release addresses the following security vulnerabilities:
+
+//ROX-34144
+* Security vulnerability in OpenTelemetry components (link:https://access.redhat.com/security/cve/CVE-2026-24051[CVE-2026-24051])
+//ROX-34143
+* Security vulnerability in Docker components (link:https://access.redhat.com/security/cve/CVE-2025-15558[CVE-2025-15558])
+//ROX-34121
+* Kubelet, CRI-O, kube-apiserver: Denial of service via SPDY streaming code (link:https://access.redhat.com/security/cve/CVE-2026-35469[CVE-2026-35469])
+// ROX-34053, ROX-34056, ROX-34057, ROX-34048, ROX-34052, ROX-34054
+* `github.com/jackc/pgx`: Memory-safety vulnerability (link:https://access.redhat.com/security/cve/CVE-2026-33815[CVE-2026-33815], link:https://access.redhat.com/security/cve/CVE-2026-33816[CVE-2026-33816])
+// ROX-33987, ROX-33989, ROX-33992
+* Go JOSE: Denial of service via crafted JSON Web Encryption (JWE) object (link:https://access.redhat.com/security/cve/CVE-2026-34986[CVE-2026-34986])
+//ROX-33810, ROX-33811
+* gRPC-Go: Authorization bypass due to improper HTTP/2 path validation (link:https://access.redhat.com/security/cve/CVE-2026-33186[CVE-2026-33186])
+//ROX-33773
+* Immutable.js: Improperly controlled modification of object prototype attributes (prototype pollution) in immutable (link:https://access.redhat.com/security/cve/CVE-2026-29063[CVE-2026-29063])
 
 include::modules/image-versions.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s):
RHACS 4.9.6

Official release date of 4.9.6:
6 May 2026

Issue:
https://redhat.atlassian.net/browse/ROX-34578

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
QE review: RHACS has no QE review, approved by SMEs

Additional information:
RHACS 4.9.6 issue report: 
https://redhat.atlassian.net/projects/ROX/versions/104033/tab/release-report-all-issues
