### PR TITLE
OSDOCS#19640: Update the z-stream RNs for 4.16.61

### DIFF
--- a/modules/zstream-4-16-61.adoc
+++ b/modules/zstream-4-16-61.adoc
@@ -1,0 +1,32 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-16-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-16-61_{context}"]
+= RHBA-2026:13735 - {product-title} {product-version}.61 fixed issues and security updates
+
+Issued: 7 May 2026
+
+[role="_abstract"]
+{product-title} release {product-version}.61 is now available. The list of fixed issues that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2026:13735[RHBA-2026:13735] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2026:13728[RHBA-2026:13728] advisory.
+
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.16.61 --pullspecs
+----
+
+[id="zstream-4-16-61-fixed-issues_{context}"]
+== Fixed issues
+
+There are no notable fixed issues for this release.
+
+[id="zstream-4-16-61-updating_{context}"]
+== Updating
+
+To update an {product-title} 4.16 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].

--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -3390,6 +3390,9 @@ Testing has shown that wake up latencies are under 20μs for over 99.99999% of t
 // 4.16 about async
 include::modules/rn-async-errata.adoc[leveloffset=+1]
 
+// 4.16.61 Rns and updating
+include::modules/zstream-4-16-61.adoc[leveloffset=+2]
+
 // 4.16.60 Rns and updating
 include::modules/zstream-4-16-60.adoc[leveloffset=+2]
 


### PR DESCRIPTION
Version(s):
4.16

Issue:
[OSDOCS-19640](https://redhat.atlassian.net/browse/OSDOCS-19640)

Link to docs preview:
[4.16.61](https://111393--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html#zstream-4-16-61_release-notes)

QE review:
- [ ] QE has approved this change.
N/A

Additional information:
Shipment [MR](https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/502)
ART [Dashboard](https://art-dash.engineering.redhat.com/dashboard/release/openshift-4.16)
