### PR TITLE
CNV#81479: USB device bugfix

### DIFF
--- a/modules/virt-configuring-vm-use-usb-device.adoc
+++ b/modules/virt-configuring-vm-use-usb-device.adoc
@@ -23,12 +23,12 @@ You can configure virtual machine (VM) access to a USB device. This configuratio
 $ oc get {HCOCliKind} kubevirt-hyperconverged -n {CNVNamespace}
 ----
 +
-*Example output*
+Example output:
 +
 [source, yaml]
 ----
 # ...
-  spec:  
+  spec:
     permittedHostDevices:
       usbHostDevices:
         - resourceName: kubevirt.io/peripherals
@@ -41,42 +41,43 @@ $ oc get {HCOCliKind} kubevirt-hyperconverged -n {CNVNamespace}
               product: "b100"
 ----
 
-. Open the VM instance CR:
+. Open the VM CR:
 +
 [source,terminal]
 ----
-$ oc edit vmi <vmi_usb>
+$ oc edit vm <vm_name>
 ----
 +
 where:
 +
-`<vmi_usb>`:: Specifies the name of the `VirtualMachineInstance` CR.
-
+`<vm_name>`:: Specifies the name of the `VirtualMachine` CR.
 
 . Edit the CR by adding the USB device, as shown in the following example:
 +
-*Example configuration*
+Example configuration:
 +
 [source, yaml]
 ----
 apiVersion: kubevirt.io/v1
-kind: VirtualMachineInstance
+kind: VirtualMachine
 metadata:
-  labels:
-    special: vmi-usb
-  name: vmi-usb
+  name: example-vm
 spec:
-  domain:
-    devices:
-      hostDevices:
-      - deviceName: kubevirt.io/peripherals
-        name: local-peripherals
+  template:
+    spec:
+      architecture: amd64
+      domain:
+        devices:
+          hostDevices:
+          - deviceName: kubevirt.io/peripherals
+            name: local-peripherals
 # ...
 ----
 +
-* `spec.domain.devices.hostDevices.name` defines the name of the USB device.
+* `spec.template.spec.domain.devices.hostDevices.deviceName` specifies the resource name from the `HyperConverged` CR.
+* `spec.template.spec.domain.devices.hostDevices.name` defines the name of the USB device.
 
-. Apply the modifications to the VM configurations:
+. Save and apply your changes:
 +
 [source,terminal]
 ----
@@ -85,4 +86,4 @@ $ oc apply -f <filename>.yaml
 +
 where:
 +
-<filename>:: Specifies the name of the `VirtualMachineInstance` manifest YAML file.
+`<filename>`:: Specifies the name of the `VirtualMachine` manifest YAML file.

--- a/modules/virt-configuring-vm-use-usb-device.adoc
+++ b/modules/virt-configuring-vm-use-usb-device.adoc
@@ -41,17 +41,16 @@ $ oc get {HCOCliKind} kubevirt-hyperconverged -n {CNVNamespace}
               product: "b100"
 ----
 
-. Open the VM instance CR:
+. Open the VM CR:
 +
 [source,terminal]
 ----
-$ oc edit vmi <vmi_usb>
+$ oc edit vm <vm_name>
 ----
 +
 where:
 +
-`<vmi_usb>`:: Specifies the name of the `VirtualMachineInstance` CR.
-
+`<vm_name>`:: Specifies the name of the `VirtualMachine` CR.
 
 . Edit the CR by adding the USB device, as shown in the following example:
 +
@@ -60,23 +59,25 @@ where:
 [source, yaml]
 ----
 apiVersion: kubevirt.io/v1
-kind: VirtualMachineInstance
+kind: VirtualMachine
 metadata:
-  labels:
-    special: vmi-usb
-  name: vmi-usb
+  name: example-vm
 spec:
-  domain:
-    devices:
-      hostDevices:
-      - deviceName: kubevirt.io/peripherals
-        name: local-peripherals
+  template:
+    spec:
+      architecture: amd64
+      domain:
+        devices:
+          hostDevices:
+          - deviceName: kubevirt.io/peripherals
+            name: local-peripherals
 # ...
 ----
 +
-* `spec.domain.devices.hostDevices.name` defines the name of the USB device.
+* `spec.template.spec.domain.devices.hostDevices.deviceName` specifies the resource name from the `HyperConverged` CR.
+* `spec.template.spec.domain.devices.hostDevices.name` defines the name of the USB device.
 
-. Apply the modifications to the VM configurations:
+. Save and apply your changes:
 +
 [source,terminal]
 ----
@@ -85,4 +86,4 @@ $ oc apply -f <filename>.yaml
 +
 where:
 +
-<filename>:: Specifies the name of the `VirtualMachineInstance` manifest YAML file.
+<filename>:: Specifies the name of the `VirtualMachine` manifest YAML file.

--- a/modules/virt-enabling-usb-host-passthrough.adoc
+++ b/modules/virt-enabling-usb-host-passthrough.adoc
@@ -18,23 +18,6 @@ To do this, specify a resource name and USB device name for each device you want
 
 .Procedure
 
-. Ensure that the `HostDevices` feature gate is enabled:
-+
-[source,terminal]
-----
-$ oc get featuregate cluster -o yaml
-----
-+
-*Successful output*
-+
-[source,yaml]
-----
-  featureGates:
-# ...
-    enabled:
-    - name: HostDevices
-----
-
 . Identify the USB device vendor and product:
 +
 [source,terminal]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.17+ (need to confirm)
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [CNV-81479](https://redhat.atlassian.net/browse/CNV-81479)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://111399--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/managing_vms/advanced_vm_management/virt-configuring-usb-host-passthrough.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: One part of this bug (unsupported jsonpatch -> editing HCO) was already fixed in main and at least some versions of the docs. Will confirm if the bug is still there in any versions.
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
