### PR TITLE
OSDOCS 18571 [Docs] Explain admin-ack remediation in 4.21 bootimage update docs MAIN

### DIFF
--- a/modules/mco-update-boot-images-disable.adoc
+++ b/modules/mco-update-boot-images-disable.adoc
@@ -10,6 +10,22 @@
 [role="_abstract"]
 You can disable the boot image management feature so that the Machine Config Operator (MCO) no longer manages or updates the boot image in the affected machine sets. For example, you could disable this feature for the worker nodes in order to use a custom boot image that you do not want changed.
 
+[NOTE]
+====
+If you are updating an {azure-first} or {vmw-first} cluster from {product-title} 4.21 to 4.22, and you have not configured the `managedBootImages` parameter, the update is blocked with the message: `This cluster is Azure or vSphere but lacks a boot image configuration`. The update is intentionally blocked on {azure-short} or {vmw-short} clusters in order to alert you that the default boot image management behavior is changing between version 4.21 and 4.22 in order to enable boot images management by default on those platforms.
+
+To allow the update, perform one of the following tasks:
+
+* If you want to allow the feature to be enabled, acknowledge that you are aware of the change in the default behavior by patching the `admin-acks` config map by running the following command:
++
+[source,terminal]
+----
+$ oc -n openshift-config patch cm admin-acks --patch '{"data":{"ack-4.21-boot-image-opt-out-in-4.22":"true"}}' --type=merge
+----
+
+* If you do not want the boot image management feature enabled, explicitly disable the feature for worker machine sets by using the following procedure.
+====
+
 You disable the boot image management feature for the control plane or worker machine sets in your cluster by editing the `MachineConfiguration` object.
 
 [NOTE]
@@ -32,7 +48,9 @@ After disabling the feature, you can re-enable the feature at any time. For more
 $ oc edit MachineConfiguration cluster
 ----
 
-. Disable the feature for some or all of your machine sets:
+. Disable the feature for some or all of your machine sets by making one or both of the following changes:
+
+* Disable the feature for nodes in the worker machine sets by adding the following parameters:
 +
 [source,yaml]
 ----
@@ -48,6 +66,32 @@ spec:
       resource: machinesets
       selection:
         mode: None
+----
++
+--
+where:
+
+`spec.managedBootImages`:: Specifies the parameters for the boot image management feature.
+
+`spec.managedBootImages.machineManagers.apiGroup`:: Specifies the API group. This must be `machine.openshift.io`. 
+
+`spec.managedBootImages.machineManagers.resource`:: Specifies that the `selection.mode` parameter applies to worker nodes when a value of `machinesets` is set.
+
+`spec.managedBootImages.machineManagers.selection.mode`:: When `None`, specifies that the feature is disabled for the specified machine sets.
+--
+
+* Disable the feature for nodes in the control plane machine sets by adding the following parameters:
++
+[source,yaml]
+----
+apiVersion: operator.openshift.io/v1
+kind: MachineConfiguration
+metadata:
+  name: cluster
+spec:
+# ...
+  managedBootImages:
+    machineManagers:
     - apiGroup: machine.openshift.io
       resource: controlplanemachinesets
       selection:
@@ -57,13 +101,13 @@ spec:
 --
 where:
 
-`spec.managedBootImages`:: Configures the boot image management feature.
+`spec.managedBootImages`:: Specifies the parameters for the boot image management feature.
 
-`spec.managedBootImages.machineManagers.selection.mode.None`:: Specifies that the feature is disabled for all machine sets in the cluster. Set the selection mode to `None` for one or both of the following resources to disable the feature for that resource.
+`spec.managedBootImages.machineManagers.apiGroup`:: Specifies the API group. This must be `machine.openshift.io`. 
 
-* `controlplanemachinesets`: Disable boot image management for control plane machine sets.
+`spec.managedBootImages.machineManagers.resource`:: Specifies that the `selection.mode` parameter applies to control plane nodes when a value of `controlplanemachinesets` is set.
 
-* `machinesets`: Disables boot image management for worker machine sets.
+`spec.managedBootImages.machineManagers.selection.mode`:: When `None`, specifies that the feature is disabled for the specified machine sets.
 --
 
 ////


### PR DESCRIPTION
New PR to implement https://github.com/openshift/openshift-docs/pull/108279 so that we can get the relevant information into both 4.21 and 4.22. 

Dev requested that we add the information on a 4.18 - 4.19 admin ack into the 4.21 docs, so I created https://github.com/openshift/openshift-docs/pull/108279. In the process, I noticed that I missed some TP notifications when I added the related files in the 4.21 release. So I added them in 108279. 
In the merge review, it was pointed out to me that the admin ack info should have gone into 4.22. This PR adds the info to both 4.21 and 4.22. 

In this PR, I added the Note about the admin ack from 108279 and split the procedure into one step to disable boot image management for workers and another for control plane to make it more clear. 

Dev, QE, and merge review details in previous PR.

I will add the missing TO notifications to the 4.21 files after. 