### PR TITLE
[enterprise-4.19] Fixing MetalLB docs bug

### DIFF
--- a/modules/nw-metallb-frr-configurations.adoc
+++ b/modules/nw-metallb-frr-configurations.adoc
@@ -6,11 +6,10 @@
 [id="nw-metallb-configuring-frr-k8s-configuratons_{context}"]
 = FRR configurations
 
-You can create multiple `FRRConfiguration` CRs to use `FRR` services in `MetalLB`. 
+You can create multiple `FRRConfiguration` CRs to use `FRR` services in `MetalLB`.
 `MetalLB` generates an `FRRConfiguration` object which `FRR-K8s` merges with all other configurations that all users have created.
 
-For example, you can configure `FRR-K8s` to receive all of the prefixes advertised by a given neighbor.
-The following example configures `FRR-K8s` to receive all of the prefixes advertised by a `BGPPeer` with host `172.18.0.5`: 
+`MetalLB` generates an `FRRConfiguration` object which `FRR-K8s` merges with all other configurations that all users have created. For example, you can configure `FRR-K8s` to receive all of the prefixes advertised by a given neighbor. The following example configures `FRR-K8s` to receive all of the prefixes advertised by a `BGPPeer` with host `172.18.0.5`:
 
 .Example FRRConfiguration CR
 [source,yaml]
@@ -32,9 +31,9 @@ spec:
             mode: all
 ----
 
-You can also configure FRR-K8s to always block a set of prefixes, regardless of the configuration applied. 
-This can be useful to avoid routes towards the pods or `ClusterIPs` CIDRs that might result in cluster malfunctions. 
-The following example blocks the set of prefixes `192.168.1.0/24`:
+You can also configure FRR-K8s to always block a set of prefixes, regardless of the configuration applied. This is useful to prevent routes to pod or `ClusterIPs` CIDRs that might cause cluster malfunctions. For example, you might block the `clusterNetwork` and `serviceNetwork` CIDRs. Run `oc describe network.config/cluster` to find these values.
+
+The following example blocks the prefix `192.168.1.0/24`:
 
 .Example MetalLB CR
 [source,yaml]
@@ -45,15 +44,7 @@ metadata:
   name: metallb
   namespace: metallb-system
 spec:
-  bgpBackend: frr-k8s
   frrk8sConfig:
     alwaysBlock:
     - 192.168.1.0/24
-----
-You can set `FRR-K8s` to block the `Cluster Network` CIDR and `Service Network` CIDR. 
-You can view the values for these CIDR address specifications by running the following command: 
-
-[source,terminal]
-----
-$ oc describe network.config/cluster
 ----

--- a/modules/nw-metallb-loglevel.adoc
+++ b/modules/nw-metallb-loglevel.adoc
@@ -33,6 +33,11 @@ spec:
   nodeSelector:
     node-role.kubernetes.io/worker: ""
 ----
++
+[NOTE]
+====
+While other fields like `speakerConfig` can be configured here, the `bgpBackend` field must be omitted. It is reserved for internal use by MetalLB to manage the active BGP implementation.
+====
 
 . Apply the configuration:
 +


### PR DESCRIPTION
[OCPBUGS-82120]: Fixing MetalLB docs bug

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.19 (CP from https://github.com/openshift/openshift-docs/pull/109978)
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:https://redhat.atlassian.net/browse/OCPBUGS-82120
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://109978--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ingress_load_balancing/metallb/metallb-frr-k8s.html
https://109978--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ingress_load_balancing/metallb/metallb-troubleshoot-support.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
