### PR TITLE
OCPBUGS-55773-attribute: Remove link based on unrendered attribute

### DIFF
--- a/networking/hardware_networks/using-dpdk-and-rdma.adoc
+++ b/networking/hardware_networks/using-dpdk-and-rdma.adoc
@@ -62,8 +62,6 @@ include::modules/nw-openstack-ovs-dpdk-testpmd-pod.adoc[leveloffset=+1]
 
 * link:https://catalog.redhat.com/en/hardware[Red Hat certified hardware (Red Hat Ecosystem Catalog)]
 
-* link:https://docs.redhat.com/en/documentation/red_hat_openshift_ai_self-managed/latest/html/managing_openshift_ai/managing-distributed-workloads_managing-rhoai#configuring-a-cluster-for-rdma_managing-rhoai[Configuring a cluster for RDMA in {rhoai-full}]
-
 * xref:../../scalability_and_performance/cnf-tuning-low-latency-nodes-with-perf-profile.adoc#cnf-create-performance-profiles_cnf-tuning-low-latency-nodes-with-perf-profile[Creating a performance profile]
 
 * xref:../../scalability_and_performance/cnf-tuning-low-latency-nodes-with-perf-profile.adoc#adjusting-nic-queues-with-the-performance-profile_cnf-tuning-low-latency-nodes-with-perf-profile[Adjusting the NIC queues with the performance profile]


### PR DESCRIPTION
The PM confirmed that the link is not relevant for 4.18 to 4.16.


## VERSIONS
4.16 to 4.18

## JIRA
[OCPBUGS-55773](https://redhat.atlassian.net/browse/OCPBUGS-55773)

## REVIEWERS

Ben Schmaus (dev engineer)
Guy Gordani (Quality engineer)

Asked Taneem Ibrahim about versioning support. 