### PR TITLE
[TELCODOCS-2375]: Improve MetalLB Operator supported platforms documentation

### DIFF
--- a/modules/nw-metallb-infra-considerations.adoc
+++ b/modules/nw-metallb-infra-considerations.adoc
@@ -7,9 +7,18 @@
 = Infrastructure considerations for MetalLB
 
 [role="_abstract"]
-You can use MetalLB for bare metal and on-premise installations that lack a native load balancer.
+MetalLB is designed for bare metal and on-premise environments where no native cloud load balancer is available. Before you deploy MetalLB, verify that your infrastructure meets the networking requirements for your chosen mode.
 
-In addition to bare-metal installations, installations of {product-title} on some infrastructures might not include a native load-balancer capability. For example, the following infrastructures can benefit from adding the MetalLB Operator:
+[IMPORTANT]
+====
+MetalLB is not supported on cloud provider platforms such as AWS, Azure, or Google Cloud. Cloud platforms virtualize the network layer and expose proprietary APIs instead of standard network protocols. As a result, MetalLB cannot function correctly on these platforms.
+
+Use the load balancing service that the platform provides if your cluster runs on a cloud platform.
+====
+
+== Supported platforms
+
+The following infrastructure platforms support MetalLB:
 
 * Bare metal
 
@@ -20,3 +29,18 @@ In addition to bare-metal installations, installations of {product-title} on som
 * {ibm-z-name} and {ibm-linuxone-name} for {op-system-base-full} KVM
 
 * {ibm-power-name}
+
+== Network prerequisites
+
+MetalLB requires the following network capabilities, depending on the operating mode:
+
+For Layer 2 mode::
+* Standard ARP (IPv4) or NDP (IPv6) must function on the network. The network must not block or emulate ARP/NDP traffic.
+* Anti-ARP-spoofing protections, if present, must be disabled on nodes running MetalLB speakers. Some virtualization platforms, such as {rh-openstack-first}, enable this protection by default.
+
+For BGP mode::
+* An external BGP-capable router must be available and reachable from the cluster nodes.
+* The network must allow BGP sessions (TCP port 179) between the cluster nodes and the upstream router.
+
+For both modes::
+* Configure external network infrastructure to route traffic destined for the external IP addresses to the cluster nodes.

--- a/modules/nw-metallb-when-metallb.adoc
+++ b/modules/nw-metallb-when-metallb.adoc
@@ -9,11 +9,11 @@
 [role="_abstract"]
 To get fault-tolerant access to applications through an external IP on bare metal in {product-title}, you can use MetalLB.
 
-Using MetalLB is valuable when you have a bare-metal cluster, or an infrastructure that is like bare metal, and you want fault-tolerant access to an application through an external IP address.
+MetalLB is useful when you have a bare-metal cluster, or an on-premise infrastructure without a native load balancer, and you need to expose services through external IP addresses.
 
-You must configure your networking infrastructure to ensure that network traffic for the external IP address is routed from clients to the host network for the cluster.
+You must configure your networking infrastructure to route network traffic for the external IP address from clients to the host network for the cluster.
 
-After deploying MetalLB with the MetalLB Operator, when you add a service of type `LoadBalancer`, MetalLB provides a platform-native load balancer. 
+When you deploy MetalLB with the MetalLB Operator, and add a service of type `LoadBalancer`, MetalLB provides a platform-native load balancer.
 
 When external traffic enters your {product-title} cluster through a MetalLB `LoadBalancer` service, the return traffic to the client has the external IP address of the load balancer as the source IP.
 


### PR DESCRIPTION
Version(s): 4.18

Issue: https://redhat.atlassian.net/browse/TELCODOCS-2375

Cherry-pick of https://github.com/openshift/openshift-docs/pull/110765 to enterprise-4.18.

Files excluded (not on branch):
- `networking/ingress_load_balancing/metallb/monitoring-metallb-status.adoc`