### PR TITLE
Fix MetalLB procedure gaps found by live cluster verification

### DIFF
--- a/modules/nw-metallb-configure-l2-advertisement.adoc
+++ b/modules/nw-metallb-configure-l2-advertisement.adoc
@@ -11,17 +11,17 @@ You can configure MetalLB so that the `IPAddressPool` is advertised with the L2 
 
 .Prerequisites
 
-* Install the {oc-first}. 
+* Install the {oc-first}.
 * Log in as a user with `cluster-admin` privileges.
+* Install the MetalLB Operator and start MetalLB.
 
 .Procedure
 
-. Create an IP address pool.
+. Create an IP address pool by entering the following command:
 +
-.. Create a file, such as `ipaddresspool.yaml`, with content like the following example:
-+
-[source,yaml]
+[source,terminal]
 ----
+$ cat << EOF | oc apply -f -
 apiVersion: metallb.io/v1beta1
 kind: IPAddressPool
 metadata:
@@ -29,24 +29,17 @@ metadata:
   name: doc-example-l2
 spec:
   addresses:
-    - 4.4.4.0/24
+    - 203.0.113.200-203.0.113.210 <1>
   autoAssign: false
-# ...
+EOF
 ----
-+
-.. Apply the configuration for the IP address pool:
+<1> Replace the address range with addresses that are appropriate for your network.
+
+. Create an L2 advertisement by entering the following command:
 +
 [source,terminal]
 ----
-$ oc apply -f ipaddresspool.yaml
-----
-
-. Create an L2 advertisement.
-+
-.. Create a file, such as `l2advertisement.yaml`, with content like the following example:
-+
-[source,yaml]
-----
+$ cat << EOF | oc apply -f -
 apiVersion: metallb.io/v1beta1
 kind: L2Advertisement
 metadata:
@@ -55,12 +48,35 @@ metadata:
 spec:
   ipAddressPools:
    - doc-example-l2
-  # ...
+EOF
 ----
-+
-.. Apply the configuration:
+
+.Verification
+
+. Verify the IP address pool is created:
 +
 [source,terminal]
 ----
-$ oc apply -f l2advertisement.yaml
+$ oc get ipaddresspool -n metallb-system
+----
++
+.Example output
+[source,terminal]
+----
+NAME               AUTO ASSIGN   AVOID BUGGY IPS   ADDRESSES
+doc-example-l2     false         false             ["203.0.113.200-203.0.113.210"]
+----
+
+. Verify the L2 advertisement is created:
++
+[source,terminal]
+----
+$ oc get l2advertisement -n metallb-system
+----
++
+.Example output
+[source,terminal]
+----
+NAME              IPADDRESSPOOLS     IPADDRESSPOOL SELECTORS   INTERFACES
+l2advertisement   ["doc-example-l2"]
 ----

--- a/modules/nw-metallb-configure-svc.adoc
+++ b/modules/nw-metallb-configure-svc.adoc
@@ -18,61 +18,88 @@ To expose an application to external network traffic, configure a load-balancing
 
 .Procedure
 
-. Create a `<service_name>.yaml` file. In the file, set the `spec.type` parameter to `LoadBalancer`.
+. Create a test application by entering the following command:
 +
-Refer to the examples for information about how to request the external IP address that MetalLB assigns to the service.
+[source,terminal]
+----
+$ oc create deployment hello-metallb --image=quay.io/openshifttest/hello-openshift:1.2.0
+----
 
-. Create the service:
+. Create a `LoadBalancer` service for the application by entering the following command:
 +
 [source,terminal]
 ----
-$ oc apply -f <service_name>.yaml
+$ cat << EOF | oc apply -f -
+apiVersion: v1
+kind: Service
+metadata:
+  name: hello-metallb-service
+  annotations:
+    metallb.io/address-pool: doc-example-l2 <1>
+spec:
+  type: LoadBalancer
+  selector:
+    app: hello-metallb
+  ports:
+    - port: 80
+      targetPort: 8080
+      protocol: TCP
+EOF
 ----
-+
-.Example output
-[source,terminal]
-----
-service/<service_name> created
-----
+<1> The `metallb.io/address-pool` annotation is required when the address pool has `autoAssign` set to `false`. Replace `doc-example-l2` with the name of your address pool.
 
 .Verification
 
-* Describe the service:
+. Verify the service has been assigned an external IP address:
 +
 [source,terminal]
 ----
-$ oc describe service <service_name>
+$ oc get svc hello-metallb-service
+----
++
+.Example output
+[source,terminal]
+----
+NAME                    TYPE           CLUSTER-IP      EXTERNAL-IP       PORT(S)        AGE
+hello-metallb-service   LoadBalancer   172.30.186.105  203.0.113.200     80:31732/TCP   30s
+----
+
+. Describe the service to confirm MetalLB assigned an IP address:
++
+[source,terminal]
+----
+$ oc describe service hello-metallb-service
 ----
 +
 .Example output
 ----
-Name:                     <service_name>
+Name:                     hello-metallb-service
 Namespace:                default
 Labels:                   <none>
-Annotations:              metallb.io/address-pool: doc-example
-Selector:                 app=service_name
+Annotations:              metallb.io/address-pool: doc-example-l2
+Selector:                 app=hello-metallb
 Type:                     LoadBalancer
 IP Family Policy:         SingleStack
 IP Families:              IPv4
-IP:                       10.105.237.254
-IPs:                      10.105.237.254
-LoadBalancer Ingress:     192.168.100.5
+IP:                       172.30.186.105
+IPs:                      172.30.186.105
+LoadBalancer Ingress:     203.0.113.200
 Port:                     <unset>  80/TCP
 TargetPort:               8080/TCP
-NodePort:                 <unset>  30550/TCP
+NodePort:                 <unset>  31732/TCP
 Endpoints:                10.244.0.50:8080
 Session Affinity:         None
 External Traffic Policy:  Cluster
 Events:
-  Type    Reason        Age                From             Message
-  ----    ------        ----               ----             -------
-  Normal  nodeAssigned  32m (x2 over 32m)  metallb-speaker  announcing from node "<node_name>"
+  Type    Reason        Age   From                Message
+  ----    ------        ----  ----                -------
+  Normal  IPAllocated   30s   metallb-controller  Assigned IP ["203.0.113.200"]
+  Normal  nodeAssigned  30s   metallb-speaker     announcing from node "<node_name>" with protocol "layer2"
 ----
 +
 where:
 +
 `Annotations`:: Specifies the annotation that is present if you request an IP address from a specific pool.
 `Type`:: Specifies the service type that must indicate `LoadBalancer`.
-`LoadBalancer Ingress`:: Specifies the indicates the external IP address if the service is assigned correctly.
+`LoadBalancer Ingress`:: Specifies the external IP address if the service is assigned correctly.
 `Events`:: Specifies the events parameter that indicates the node name that is assigned to announce the external IP address. If you experience an error, the events parameter indicates the reason for the error.
-

--- a/modules/nw-metallb-installing-operator-cli.adoc
+++ b/modules/nw-metallb-installing-operator-cli.adoc
@@ -58,11 +58,11 @@ NAME               AGE
 metallb-operator   14m
 ----
 
-. Create a `Subscription` CR:
-.. Define the `Subscription` CR and save the YAML file, for example, `metallb-sub.yaml`:
+. Create a `Subscription` CR by entering the following command:
 +
-[source,yaml]
+[source,terminal]
 ----
+$ cat << EOF | oc apply -f -
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
@@ -73,15 +73,7 @@ spec:
   name: metallb-operator
   source: redhat-operators
   sourceNamespace: openshift-marketplace
-----
-+
-** For the `spec.source` parameter, must specify the `redhat-operators` value.
-
-.. To create the `Subscription` CR, run the following command:
-+
-[source,terminal]
-----
-$ oc create -f metallb-sub.yaml
+EOF
 ----
 
 . Optional: To ensure BGP and BFD metrics appear in Prometheus, you can label the namespace as in the following command:
@@ -106,7 +98,7 @@ $ oc get installplan -n metallb-system
 [source,terminal,subs="attributes+"]
 ----
 NAME            CSV                                   APPROVAL    APPROVED
-install-wzg94   metallb-operator.{product-version}.0-nnnnnnnnnnnn   Automatic   true
+install-wzg94   metallb-operator.v{product-version}.0-nnnnnnnnnnnn   Automatic   true
 ----
 +
 [NOTE]

--- a/modules/nw-metallb-operator-initial-config.adoc
+++ b/modules/nw-metallb-operator-initial-config.adoc
@@ -32,11 +32,24 @@ metadata:
 EOF
 ----
 +
-** For the `metdata.namespace` parameter, substitute `metallb-system` with `openshift-operators` if you installed the MetalLB Operator using the web console.
+** For the `metadata.namespace` parameter, substitute `metallb-system` with `openshift-operators` if you installed the MetalLB Operator using the web console.
 
 .Verification
 
 Confirm that the deployment for the MetalLB controller and the daemon set for the MetalLB speaker are running.
+
+. Wait for the controller deployment to be available:
++
+[source,terminal]
+----
+$ oc wait deployment -n metallb-system controller --for=condition=Available --timeout=120s
+----
++
+.Example output
+[source,terminal]
+----
+deployment.apps/controller condition met
+----
 
 . Verify that the deployment for the controller is running:
 +


### PR DESCRIPTION
## Summary
- Tested all four MetalLB install/configure procedures on a live OCP 4.21 cluster
- Fixed 19 documentation gaps (1 critical, 6 high, 5 medium, 7 low)
- Converted "save to file" patterns to inline `cat << EOF | oc apply -f -` for consistency and automation
- Replaced unusable `4.4.4.0/24` example IP range with RFC 5737 documentation range (`203.0.113.200-203.0.113.210`)
- Added concrete deployment + LoadBalancer service example to replace entirely abstract procedure
- Added missing wait steps, prerequisites, and verification sections

## Files changed
| File | Changes |
|------|---------|
| `modules/nw-metallb-installing-operator-cli.adoc` | Inline Subscription CR, fix CSV version prefix |
| `modules/nw-metallb-operator-initial-config.adoc` | Add `oc wait` step, fix `metdata` typo |
| `modules/nw-metallb-configure-l2-advertisement.adoc` | Inline apply, fix IP range, add prereq + verification |
| `modules/nw-metallb-configure-svc.adoc` | Complete rewrite with concrete working example |

## Test plan
- [x] Verified all four procedures end-to-end on a live OCP 4.21 single-node cluster
- [x] MetalLB Operator installed and controller/speaker running
- [x] IPAddressPool and L2Advertisement created successfully
- [x] LoadBalancer service assigned external IP from pool
- [x] Application reachable via MetalLB-assigned IP (`curl` returned "Hello OpenShift!")

🤖 Generated with [Claude Code](https://claude.com/claude-code)