### PR TITLE
DOCPLAN-364: Fix ConceptLink warnings in virt/support and included modules

### DIFF
--- a/modules/virt-collecting-data-about-vms.adoc
+++ b/modules/virt-collecting-data-about-vms.adoc
@@ -14,7 +14,7 @@ Collecting data about malfunctioning virtual machines (VMs) minimizes the time r
 * For Linux VMs, you have installed the latest QEMU guest agent.
 * For Windows VMs, you have:
 ** Recorded the Windows patch update details.
-** link:https://access.redhat.com/solutions/6957701[Installed the latest VirtIO drivers].
+** Installed the latest VirtIO drivers.
 ** Installed the latest QEMU guest agent.
 ** If Remote Desktop Protocol (RDP) is enabled, you have connected by using the desktop viewer to determine whether there is a problem with the connection software.
 

--- a/modules/virt-collecting-data-about-your-environment.adoc
+++ b/modules/virt-collecting-data-about-your-environment.adoc
@@ -12,13 +12,13 @@ Collecting data about your environment minimizes the time required to analyze an
 .Prerequisites
 //link needs to be added for HCP when available
 ifdef::openshift-dedicated,openshift-rosa[]
-* You have link:https://docs.redhat.com/en/documentation/monitoring_stack_for_red_hat_openshift/4.21/html/configuring_user_workload_monitoring/storing-and-recording-data-uwm#modifying-retention-time-and-size-for-prometheus-metrics-data_storing-and-recording-data-uwm[set the retention time for Prometheus metrics data] to a minimum of seven days.
-* You have link:https://docs.redhat.com/en/documentation/monitoring_stack_for_red_hat_openshift/4.21/html/configuring_user_workload_monitoring/storing-and-recording-data-uwm#modifying-retention-time-and-size-for-prometheus-metrics-data_storing-and-recording-data-uwm[configured the Alertmanager to capture relevant alerts and to send alert notifications to a dedicated mailbox] so that they can be viewed and persisted outside the cluster.
+* You have set the retention time for Prometheus metrics data to a minimum of seven days.
+* You have configured the Alertmanager to capture relevant alerts and to send alert notifications to a dedicated mailbox so that they can be viewed and persisted outside the cluster.
 endif::openshift-dedicated,openshift-rosa[]
 
 ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
-* You have link:https://docs.redhat.com/en/documentation/monitoring_stack_for_red_hat_openshift/4.21/html/configuring_core_platform_monitoring/storing-and-recording-data#modifying-retention-time-and-size-for-prometheus-metrics-data_storing-and-recording-data[set the retention time for Prometheus metrics data] to a minimum of seven days.
-* You have link:https://docs.redhat.com/en/documentation/monitoring_stack_for_red_hat_openshift/4.21/html/configuring_core_platform_monitoring/configuring-alerts-and-notifications[configured the Alertmanager to capture relevant alerts and to send alert notifications to a dedicated mailbox] so that they can be viewed and persisted outside the cluster.
+* You have set the retention time for Prometheus metrics data to a minimum of seven days.
+* You have configured the Alertmanager to capture relevant alerts and to send alert notifications to a dedicated mailbox so that they can be viewed and persisted outside the cluster.
 endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 * You have recorded the exact number of affected nodes and virtual machines.
 
@@ -27,10 +27,10 @@ endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 // must-gather not supported for ROSA/OSD, per Dustin Row
 ifndef::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
 . Collect must-gather data for the cluster.
-. link:https://access.redhat.com/documentation/en-us/red_hat_openshift_data_foundation/latest/html-single/troubleshooting_openshift_data_foundation/index#downloading-log-files-and-diagnostic-information_rhodf[Collect must-gather data for {rh-storage-first}], if necessary.
+. Collect must-gather data for {rh-storage-first}, if necessary.
 . Collect must-gather data for {VirtProductName}.
 endif::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
 ifndef::openshift-rosa-hcp[]
-. link:https://docs.redhat.com/en/documentation/monitoring_stack_for_red_hat_openshift/4.21/html/accessing_metrics/accessing-metrics-as-an-administrator#querying-metrics-for-all-projects-with-mon-dashboard_accessing-metrics-as-an-administrator[Collect Prometheus metrics for the cluster].
+. Collect Prometheus metrics for the cluster.
 endif::openshift-rosa-hcp[]
 //link needs to be added for HCP when available

--- a/modules/virt-generating-a-vm-memory-dump.adoc
+++ b/modules/virt-generating-a-vm-memory-dump.adoc
@@ -44,7 +44,7 @@ $ virtctl memory-dump download <vm_name> --output=<output_file>
 
 . Attach the memory dump to a Red Hat Support case.
 +
-Alternatively, you can inspect the memory dump, for example by using link:https://github.com/volatilityfoundation/volatility3[the volatility3 tool].
+Alternatively, you can inspect the memory dump, for example by using the volatility3 tool.
 
 . Optional: Remove the memory dump:
 +

--- a/modules/virt-support-create-jira-issue.adoc
+++ b/modules/virt-support-create-jira-issue.adoc
@@ -13,7 +13,7 @@ To report an issue with your environment to Red{nbsp}Hat Support, create a Jira 
 
 . Log in to Red Hat Atlassian Jira.
 
-. Click the following link to open a *Create Issue* page: link:https://redhat.atlassian.net/secure/CreateIssue.jspa[Create issue].
+. Access the *Create Issue* page.
 
 . Select {VirtProductName} (CNV) as the *Project*.
 

--- a/modules/virt-support-submit-support-case.adoc
+++ b/modules/virt-support-submit-support-case.adoc
@@ -9,4 +9,4 @@
 [role="_abstract"]
 Submit a support case to resolve a cluster issue that is affecting the ability of {VirtProductName} to function properly in your environment. 
 
-You can submit a support case to Red{nbsp}Hat Support by using the link:https://access.redhat.com/support/cases/#/case/list[Customer Support] page. Include data that you collected about your issue with your support request.
+You can submit a support case to Red{nbsp}Hat Support by using the Customer Support page. Include data that you collected about your issue with your support request.

--- a/virt/support/virt-collecting-virt-data.adoc
+++ b/virt/support/virt-collecting-virt-data.adoc
@@ -7,7 +7,7 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 [role="_abstract"]
-When you submit a xref:../../support/getting-support.adoc#support-submitting-a-case_getting-support[support case] to Red{nbsp}Hat Support, it is helpful to provide debugging information for {product-title} and {VirtProductName} by using the following tools:
+When you submit a support case to Red{nbsp}Hat Support, it is helpful to provide debugging information for {product-title} and {VirtProductName} by using the following tools:
 
 // must-gather not supported for ROSA/OSD, per Dustin Row
 ifndef::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
@@ -51,4 +51,15 @@ endif::openshift-dedicated,openshift-rosa[]
 * xref:../../virt/managing_vms/virt-install-virtio-drivers-on-windows-vms.adoc#virt-installing-virtio-drivers-existing-windows_virt-install-virtio-drivers-on-windows-vms[Installing VirtIO drivers from a SATA CD drive on an existing Windows VM]
 * xref:../../virt/managing_vms/virt-accessing-vm-consoles.adoc#virt-connecting-desktop-viewer-web_virt-accessing-vm-consoles[Connect to the desktop viewer by using the web console]
 * xref:../../virt/support/virt-collecting-virt-data.adoc#virt-generating-a-vm-memory-dump_virt-collecting-virt-data[Collect memory dumps from VMs]
+* xref:../../support/getting-support.adoc#support-submitting-a-case_getting-support[Submitting a support case]
+* link:https://docs.redhat.com/en/documentation/monitoring_stack_for_red_hat_openshift/4.21/html/configuring_user_workload_monitoring/storing-and-recording-data-uwm#modifying-retention-time-and-size-for-prometheus-metrics-data_storing-and-recording-data-uwm[Modifying retention time and size for Prometheus metrics data]
+* link:https://docs.redhat.com/en/documentation/monitoring_stack_for_red_hat_openshift/4.21/html/configuring_user_workload_monitoring/storing-and-recording-data-uwm#modifying-retention-time-and-size-for-prometheus-metrics-data_storing-and-recording-data-uwm[Configuring the Alertmanager to capture relevant alerts and to send alert notifications to a dedicated mailbox]
+* link:https://docs.redhat.com/en/documentation/monitoring_stack_for_red_hat_openshift/4.21/html/configuring_core_platform_monitoring/storing-and-recording-data#modifying-retention-time-and-size-for-prometheus-metrics-data_storing-and-recording-data[Modifying retention time and size for Prometheus metrics data]
+* link:https://docs.redhat.com/en/documentation/monitoring_stack_for_red_hat_openshift/4.21/html/configuring_core_platform_monitoring/configuring-alerts-and-notifications[Configuring alerts and notifications]
+* link:https://access.redhat.com/documentation/en-us/red_hat_openshift_data_foundation/latest/html-single/troubleshooting_openshift_data_foundation/index#downloading-log-files-and-diagnostic-information_rhodf[Downloading log files and diagnostic information]
+* link:https://docs.redhat.com/en/documentation/monitoring_stack_for_red_hat_openshift/4.21/html/accessing_metrics/accessing-metrics-as-an-administrator#querying-metrics-for-all-projects-with-mon-dashboard_accessing-metrics-as-an-administrator[Querying metrics for all projects with the monitoring dashboard]
+* link:https://access.redhat.com/solutions/6957701[Installing the latest VirtIO drivers]
+* link:https://github.com/volatilityfoundation/volatility3[Volatility3 tool]
+* link:https://access.redhat.com/support/cases/#/case/list[Customer Support]
+* link:https://redhat.atlassian.net/secure/CreateIssue.jspa[Create issue]
 


### PR DESCRIPTION
Move cross-references and links to Additional resources sections to resolve ConceptLink warnings in virt-collecting-virt-data.adoc and all module files included in virt/support assemblies.

Changes:
- Moved 12 links/xrefs across 6 files (1 assembly + 5 modules)
- Replaced links/xrefs with plain text in main content
- Added links/xrefs to Additional resources sections
- Preserved all empty lines and formatting

Link text improvements:
- Used exact heading titles for xrefs (e.g., "Submitting a support case")
- Capitalized and formatted external link text appropriately
- Used gerund forms for procedure titles (e.g., "Modifying retention time...")
- Matched link text to actual document section headings where possible

Files modified:
- virt/support/virt-collecting-virt-data.adoc
- modules/virt-collecting-data-about-your-environment.adoc (6 links)
- modules/virt-collecting-data-about-vms.adoc (1 link)
- modules/virt-generating-a-vm-memory-dump.adoc (1 link)
- modules/virt-support-create-jira-issue.adoc (1 link)
- modules/virt-support-submit-support-case.adoc (1 link)

Version(s):
4.20+

Issue:
https://redhat.atlassian.net/browse/DOCPLAN-364

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
n/a
