### PR TITLE
OBSDOCS-3392: HOTSPOT 3 Log Collection Setup & Permissions

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -36,6 +36,8 @@ Topics:
   File: cluster-logging-collector
 - Name: Configuring log forwarding
   File: configuring-log-forwarding
+- Name: Collecting Kubernetes events
+  File: collecting-kubernetes-events
 - Name: Configuring the log store
   File: configuring-the-log-store
 - Name: Configuring LokiStack for OTLP

--- a/configuring/collecting-kubernetes-events.adoc
+++ b/configuring/collecting-kubernetes-events.adoc
@@ -1,0 +1,19 @@
+:_mod-docs-content-type: ASSEMBLY
+:context: collecting-kubernetes-events
+[id="collecting-kubernetes-events"]
+= Collecting Kubernetes events
+include::_attributes/common-attributes.adoc[]
+
+toc::[]
+
+[role="_abstract"]
+Collect Kubernetes events and forward them through the {logging} pipeline for storage and analysis. Events provide valuable insight into cluster activity, resource state changes, and system operations.
+
+include::modules/cluster-logging-eventrouter-about.adoc[leveloffset=+1]
+
+include::modules/cluster-logging-eventrouter-deploy.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../configuring/configuring-log-forwarding.adoc#configuring-log-forwarding[Configuring log forwarding]

--- a/modules/cluster-logging-collecting-storing-kubernetes-events.adoc
+++ b/modules/cluster-logging-collecting-storing-kubernetes-events.adoc
@@ -1,9 +1,0 @@
-// Module included in the following assemblies:
-//
-// * observability/logging/cluster-logging.adoc
-
-:_mod-docs-content-type: CONCEPT
-[id="cluster-logging-collecting-storing-kubernetes-events-about_{context}"]
-= About collecting and storing Kubernetes events
-
-The {ocp-product-title} Event Router is a pod that watches Kubernetes events and logs them for collection by {ocp-product-title} Logging. You must manually deploy the Event Router.

--- a/modules/cluster-logging-eventrouter-about.adoc
+++ b/modules/cluster-logging-eventrouter-about.adoc
@@ -6,7 +6,7 @@
 [id="cluster-logging-eventrouter-about_{context}"]
 = About event routing
 
-The Event Router is a pod that watches {ocp-product-title} events so they can be collected by {logging}.
-The Event Router collects events from all projects and writes them to `STDOUT`. Fluentd collects those events and forwards them into the {ocp-product-title} Elasticsearch instance. Elasticsearch indexes the events to the `infra` index.
+[role="_abstract"]
+The Event Router is a pod that watches {ocp-product-title} events and makes them available to {logging}. The Event Router collects events from all projects and writes them to STDOUT. The collector gathers those events and forwards them to your configured log storage.
 
 You must manually deploy the Event Router.

--- a/modules/cluster-logging-eventrouter-deploy.adoc
+++ b/modules/cluster-logging-eventrouter-deploy.adoc
@@ -1,16 +1,17 @@
 // Module included in the following assemblies:
 //
-// * observability/logging/log_collection_forwarding/cluster-logging-eventrouter.adoc
+// * configuring/collecting-kubernetes-events.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="cluster-logging-eventrouter-deploy_{context}"]
 = Deploying and configuring the Event Router
 
-Use the following steps to deploy the Event Router into your cluster. You should always deploy the Event Router to the `openshift-logging` project to ensure it collects events from across the cluster.
+[role="_abstract"]
+Deploy the Event Router into your cluster. Red Hat recommends deploying the Event Router to the `openshift-logging` project to ensure it collects events from across the cluster.
 
 [NOTE]
 ====
-The Event Router image is not a part of the {clo} and must be downloaded separately.
+The Event Router image is not included in the {clo}. You must download it separately.
 ====
 
 The following `Template` object creates the service account, cluster role, and cluster role binding required for the Event Router. The template also configures and deploys the Event Router pod. You can either use this template without making changes or edit the template to change the deployment object CPU and memory requests.
@@ -19,7 +20,7 @@ The following `Template` object creates the service account, cluster role, and c
 
 * You need proper permissions to create service accounts and update cluster role bindings. For example, you can run the following template with a user that has the *cluster-admin* role.
 
-* The {clo} must be installed.
+* You have installed the {clo}.
 
 .Procedure
 
@@ -35,12 +36,12 @@ metadata:
     description: "A pod forwarding kubernetes events to OpenShift Logging stack."
     tags: "events,EFK,logging,cluster-logging"
 objects:
-  - kind: ServiceAccount <1>
+  - kind: ServiceAccount
     apiVersion: v1
     metadata:
       name: eventrouter
       namespace: ${NAMESPACE}
-  - kind: ClusterRole <2>
+  - kind: ClusterRole
     apiVersion: rbac.authorization.k8s.io/v1
     metadata:
       name: event-reader
@@ -48,7 +49,7 @@ objects:
     - apiGroups: [""]
       resources: ["events"]
       verbs: ["get", "watch", "list"]
-  - kind: ClusterRoleBinding <3>
+  - kind: ClusterRoleBinding
     apiVersion: rbac.authorization.k8s.io/v1
     metadata:
       name: event-reader-binding
@@ -59,7 +60,7 @@ objects:
     roleRef:
       kind: ClusterRole
       name: event-reader
-  - kind: ConfigMap <4>
+  - kind: ConfigMap
     apiVersion: v1
     metadata:
       name: eventrouter
@@ -69,7 +70,7 @@ objects:
         {
           "sink": "stdout"
         }
-  - kind: Deployment <5>
+  - kind: Deployment
     apiVersion: apps/v1
     metadata:
       name: eventrouter
@@ -118,28 +119,37 @@ objects:
             configMap:
               name: eventrouter
 parameters:
-  - name: IMAGE <6>
+  - name: IMAGE
     displayName: Image
     value: "registry.redhat.io/openshift-logging/eventrouter-rhel9:v0.4"
-  - name: CPU <7>
+  - name: CPU
     displayName: CPU
     value: "100m"
-  - name: MEMORY <8>
+  - name: MEMORY
     displayName: Memory
     value: "128Mi"
   - name: NAMESPACE
     displayName: Namespace
-    value: "openshift-logging" <9>
+    value: "openshift-logging"
 ----
-<1> Creates a Service Account in the `openshift-logging` project for the Event Router.
-<2> Creates a ClusterRole to monitor for events in the cluster.
-<3> Creates a ClusterRoleBinding to bind the ClusterRole to the service account.
-<4> Creates a config map in the `openshift-logging` project to generate the required `config.json` file.
-<5> Creates a deployment in the `openshift-logging` project to generate and configure the Event Router pod.
-<6> Specifies the image, identified by a tag such as `v0.4`.
-<7> Specifies the minimum amount of CPU to allocate to the Event Router pod. Defaults to `100m`.
-<8> Specifies the minimum amount of memory to allocate to the Event Router pod. Defaults to `128Mi`.
-<9> Specifies the `openshift-logging` project to install objects in.
+
+`ServiceAccount`:: Creates a Service Account in the `openshift-logging` project for the Event Router.
++
+`ClusterRole`:: Creates a ClusterRole to monitor for events in the cluster.
++
+`ClusterRoleBinding`:: Creates a ClusterRoleBinding to bind the ClusterRole to the service account.
++
+`ConfigMap`:: Creates a config map in the `openshift-logging` project to generate the required `config.json` file.
++
+`Deployment`:: Creates a deployment in the `openshift-logging` project to generate and configure the Event Router pod.
++
+`IMAGE`:: Specifies the image, identified by a tag such as `v0.4`.
++
+`CPU`:: Specifies the minimum amount of CPU to allocate to the Event Router pod. Defaults to `100m`.
++
+`MEMORY`:: Specifies the minimum amount of memory to allocate to the Event Router pod. Defaults to `128Mi`.
++
+`NAMESPACE`:: Specifies the project to install objects in. Defaults to `openshift-logging`. Red Hat recommends using the default value to ensure cluster-wide event collection.
 
 . Use the following command to process and apply the template:
 +
@@ -199,5 +209,3 @@ $ oc logs cluster-logging-eventrouter-d649f97c8-qvv8r -n openshift-logging
 ----
 {"verb":"ADDED","event":{"metadata":{"name":"openshift-service-catalog-controller-manager-remover.1632d931e88fcd8f","namespace":"openshift-service-catalog-removed","selfLink":"/api/v1/namespaces/openshift-service-catalog-removed/events/openshift-service-catalog-controller-manager-remover.1632d931e88fcd8f","uid":"787d7b26-3d2f-4017-b0b0-420db4ae62c0","resourceVersion":"21399","creationTimestamp":"2020-09-08T15:40:26Z"},"involvedObject":{"kind":"Job","namespace":"openshift-service-catalog-removed","name":"openshift-service-catalog-controller-manager-remover","uid":"fac9f479-4ad5-4a57-8adc-cb25d3d9cf8f","apiVersion":"batch/v1","resourceVersion":"21280"},"reason":"Completed","message":"Job completed","source":{"component":"job-controller"},"firstTimestamp":"2020-09-08T15:40:26Z","lastTimestamp":"2020-09-08T15:40:26Z","count":1,"type":"Normal"}}
 ----
-+
-You can also use Kibana to view events by creating an index pattern using the Elasticsearch `infra` index.

--- a/modules/logging-loki-log-access.adoc
+++ b/modules/logging-loki-log-access.adoc
@@ -6,7 +6,8 @@
 [id="logging-loki-log-access_{context}"]
 = Fine grained access for Loki logs
 
-The {clo} does not grant all users access to logs by default. As an administrator, you must configure your users' access unless the Operator was upgraded and prior configurations are in place. Depending on your configuration and need, you can configure fine grain access to logs using the following:
+[role="_abstract"]
+The {clo} does not grant all users access to logs by default. As an administrator, configure your users' access unless you upgraded the Operator and prior configurations are in place. Depending on your configuration and need, configure fine-grained access to logs by using the following:
 
 * Cluster wide policies
 * Namespace scoped policies
@@ -38,27 +39,29 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: cluster-logging-application-view # <1>
-subjects: # <2>
+  name: cluster-logging-application-view
+subjects:
 - kind: Group
   name: system:authenticated
   apiGroup: rbac.authorization.k8s.io
 ----
-<1> Additional `ClusterRoles` are `cluster-logging-infrastructure-view`, and `cluster-logging-audit-view`.
-<2> Specifies the users or groups this object applies to.
+
+`name`:: Additional `ClusterRoles` are `cluster-logging-infrastructure-view`, and `cluster-logging-audit-view`.
++
+`subjects`:: Specifies the users or groups this object applies to.
 
 == Namespaced access
 
-`RoleBinding` resources can be used with `ClusterRole` objects to define the namespace a user or group has access to logs for.
+Use `RoleBinding` resources with `ClusterRole` objects to define the namespaces for which a user or group can access logs.
 
-.Example RoleBinding
+.Example RoleBinding for a User
 [source,yaml]
 ----
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: allow-read-logs
-  namespace: log-test-0 # <1>
+  namespace: log-test-0
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -68,21 +71,54 @@ subjects:
   apiGroup: rbac.authorization.k8s.io
   name: testuser-0
 ----
-<1> Specifies the namespace this `RoleBinding` applies to.
+
+`namespace`:: Specifies the namespace this `RoleBinding` applies to.
+
+.Example RoleBinding for a ServiceAccount
+[source,yaml]
+----
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: allow-sa-read-logs
+  namespace: log-test-0
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-logging-application-view
+subjects:
+- kind: ServiceAccount
+  name: log-reader-sa
+  namespace: log-test-0
+----
+
+`namespace`:: Specifies the namespace this `RoleBinding` applies to.
++
+`name`:: The `ServiceAccount` must have permission to list projects for namespace-scoped log access.
+
+[NOTE]
+====
+When granting namespace-scoped access to a `ServiceAccount`, also grant the service account permission to list projects. Create a `ClusterRoleBinding` that binds the service account to the `self-provisioner` cluster role or create a custom `ClusterRole` with project list permissions.
+====
 
 // tag::CustomAdmin[]
 == Custom admin group access
 
 // tag::LokiMode[]
-If you have a large deployment with several users who require broader permissions, you can create a custom group using the `adminGroup` field. Users who are members of any group specified in the `adminGroups` field of the `LokiStack` CR are considered administrators. 
+For large deployments with several users who require broader permissions, create a custom group by using the `adminGroup` field. Users who are members of any group specified in the `adminGroups` field of the `LokiStack` CR have administrator permissions.
 // end::LokiMode[]
 
 // tag::NetObservMode[]
-If you need to see cluster-wide logs without necessarily being an administrator, or if you already have any group defined that you want to use here, you can specify a custom group using the `adminGroup` field. Users who are members of any group specified in the `adminGroups` field of the `LokiStack` custom resource (CR) have the same read access to logs as administrators. 
+To see cluster-wide logs without administrator privileges, or to use an existing group, specify a custom group by using the `adminGroup` field. Users who are members of any group specified in the `adminGroups` field of the `LokiStack` custom resource (CR) have the same read access to logs as administrators.
 // end::NetObservMode[]
 
-// tag::LokiMode[] 
+// tag::LokiMode[]
 Administrator users have access to all application logs in all namespaces, if they also get assigned the `cluster-logging-application-view` role.
+
+[NOTE]
+====
+To grant cluster-wide log access to a `ServiceAccount`, add the service account's group to the `adminGroups` field in the `LokiStack` CR. The service account group follows the format `system:serviceaccounts:<namespace>` for all service accounts in a namespace, or `system:serviceaccount:<namespace>:<name>` for a specific service account.
+====
 // end::LokiMode[]
 
 // tag::NetObservMode[]
@@ -106,17 +142,23 @@ metadata:
 spec:
   tenants:
 # tag::LokiMode[]
-    mode: openshift-logging # <1>
+    mode: openshift-logging
 # end::LokiMode[]
 # tag::NetObservMode[]
-    mode: openshift-network # <1>
+    mode: openshift-network
 # end::NetObservMode[]
     openshift:
-      adminGroups: # <2>
+      adminGroups:
       - cluster-admin
-      - custom-admin-group # <3>
+      - custom-admin-group
+      - system:serviceaccount:openshift-logging:log-reader-sa
 ----
-<1> Custom admin groups are only available in this mode.
-<2> Entering an empty list `[]` value for this field disables admin groups.
-<3> Overrides the default groups (`system:cluster-admins`, `cluster-admin`, `dedicated-admin`)
+
+`mode`:: Custom admin groups are only available in this mode.
++
+`adminGroups`:: Entering an empty list `[]` value for this field disables admin groups.
++
+`custom-admin-group`:: Overrides the default groups (`system:cluster-admins`, `cluster-admin`, `dedicated-admin`)
++
+`system:serviceaccount:openshift-logging:log-reader-sa`:: Grants cluster-wide log access to a specific `ServiceAccount`.
 // end::CustomAdmin[]

--- a/modules/logging-upgrading-clo.adoc
+++ b/modules/logging-upgrading-clo.adoc
@@ -6,19 +6,20 @@
 [id="logging-upgrading-clo_{context}"]
 = Updating the {clo}
 
-The {clo} does not provide an automated upgrade from Logging 5.x to Logging 6.x because of the different combinations in which Logging can be configured. You must install all the different operators for managing logging separately.
+[role="_abstract"]
+The {clo} does not provide an automated upgrade from Logging 5.x to Logging 6.x due to the different configuration combinations. You must install all the different operators for managing logging separately.
 
 You can update {clo} by either changing the subscription channel in the {ocp-product-title} web console, or by uninstalling it. The following procedure demonstrates updating {clo} by changing the subscription channel in the {ocp-product-title} web console.
 
 [IMPORTANT]
 ====
-When you migrate, all the logs that have not been compressed will be reprocessed by Vector. The reprocessing might lead to the following issues:
+When you migrate, Vector will reprocess all uncompressed logs. The reprocessing might lead to the following issues:
 
 * Duplicated logs during migration.
 * Too many requests in the Log storage receiving the logs, or requests reaching the rate limit.
 * Impact on the disk and performance because of reading and processing of all old logs in the collector.
 * Impact on the Kube API.
-* A peak in memory and CPU use by Vector until all the old logs are processed. The logs can be several GB per node. 
+* A peak in memory and CPU use by Vector until Vector processes all the old logs. The logs can be several gigabytes per node.
 ====
 
 .Prerequisites
@@ -30,11 +31,6 @@ When you migrate, all the logs that have not been compressed will be reprocessed
 .Procedure
 
 . Create a service account by running the following command:
-+
-[NOTE]
-====
-If your previous log forwarder is deployed in the namespace `openshift-logging` and named `instance`, the earlier versions of the operator created a `logcollector` service account. This service account gets removed when you delete cluster logging. Therefore, you need to create a new service account. Any other service account will be preserved. and can be used in Logging 6.x.
-====
 +
 [source,terminal]
 ----
@@ -79,7 +75,7 @@ For more information, see link:[Changes to Cluster logging and forwarding in Log
 
 . Move Vector checkpoints to the new path.
 +
-The Vector checkpoints in Logging v5 are located at the path `/var/lib/vector/input*/checkpoints.json`. Move these checkpoints to the path `/var/lib/vector/<namespace>/<clusterlogforwarder cr name>/*`. The following example uses `openshift-logging` as the namespace and `collector` as the ClusterForwarder custom resource name. 
+In Logging v5, Vector stores checkpoints at the path `/var/lib/vector/input*/checkpoints.json`. Move these checkpoints to the path `/var/lib/vector/<namespace>/<clusterlogforwarder cr name>/*`. The following example uses `openshift-logging` as the namespace and `collector` as the ClusterForwarder custom resource name. 
 +
 [source,terminal]
 ----
@@ -110,4 +106,4 @@ Only update to an N+2 version, where N is your current version. For example, if 
 
 .. On the *Operators* -> *Installed Operators* page, wait for the *Status* field to report *Succeeded*.
 +
-Your existing Logging v5 resources will continue to run, but are no longer managed by your operator. These unmanaged resources can be removed once your new resources are ready to be created. 
+Your existing Logging v5 resources will continue to run, but your operator no longer manages them. You can remove these unmanaged resources once you create your new resources. 


### PR DESCRIPTION
Aggregating multiple tickets by "Hotspot" to streamline the workflow.

## 🔥 HOTSPOT 3: Log Collection Setup & Permissions
**Assembly:** `configuring/configuring-log-forwarding.adoc` (permissions section)  
**Impact:** 3 tickets, Normal/Major priority  
**Effort Estimate:** Medium  
**Status:** ✅ COMPLETE ([OBSDOCS-3392](https://redhat.atlassian.net/browse/OBSDOCS-3392)) - 3/3 tickets complete

### Tickets:
1. **OBSDOCS-2886** (Normal) ✅ COMPLETE - Expand fine-grained access section to cover ServiceAccounts
   - ✅ Added ServiceAccount example to namespace-scoped access section in `modules/logging-loki-log-access.adoc`
   - ✅ Documented requirement for ServiceAccounts to list projects for namespace-scoped access
   - ✅ Added note about using `adminGroups` in LokiStack for cluster-wide ServiceAccount access
   - ✅ Added ServiceAccount group example to LokiStack CR showing format `system:serviceaccount:<namespace>:<name>`
   - Related to [LOG-6894](https://redhat.atlassian.net/browse/LOG-6894)

2. **OBSDOCS-1668** (Normal) ✅ COMPLETE - Legacy service accounts deletion behavior
   - ✅ Removed confusing NOTE about `logcollector` service account from `modules/logging-upgrading-clo.adoc`
   - ✅ The note implied service accounts could be reused but was misleading about deletion behavior
   - ✅ Simplified upgrade instructions by removing legacy service account discussion
   - Legacy service accounts are deleted when old ClusterLogging CR is removed
   - Current docs imply they can be reused, but they're actually deleted during upgrade
   - Proposal: Remove legacy service account section (causes confusion, little benefit)

3. **[OBSDOCS-2213](https://redhat.atlassian.net/browse/OBSDOCS-2213)** (Major) ✅ COMPLETE - Missing Event Router steps
   - ✅ Updated `modules/cluster-logging-eventrouter-about.adoc` to remove Fluentd/Elasticsearch references
   - ✅ Updated `modules/cluster-logging-eventrouter-deploy.adoc` to remove Kibana reference
   - ✅ Updated `modules/cluster-logging-collecting-storing-kubernetes-events.adoc` with abstract
   - ✅ Created new assembly `configuring/collecting-kubernetes-events.adoc`
   - ✅ Added assembly to `_topic_maps/_topic_map.yml` in Configuring logging section
   - ✅ Confirmed with KB article that EventRouter is fully supported in Logging 6

### Why this is a hotspot:
All relate to collector permissions, service accounts, and log collection setup. Could consolidate the entire permissions/RBAC story in one effort.

### Dependencies:
- [OBSDOCS-2213](https://redhat.atlassian.net/browse/OBSDOCS-2213): Need to locate old Event Router content or get engineering input

Version(s): 6.5, 6.6

Issue: https://redhat.atlassian.net/browse/OBSDOCS-3392https://redhat.atlassian.net/browse/OBSDOCS-3392
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
