### PR TITLE
OCPBUGS-85153 AWS custom security groups should address SG quotas

### DIFF
--- a/installing/installing_aws/installing-aws-account.adoc
+++ b/installing/installing_aws/installing-aws-account.adoc
@@ -17,6 +17,15 @@ include::modules/nw-endpoint-route53.adoc[leveloffset=+2]
 
 include::modules/installation-aws-limits.adoc[leveloffset=+1]
 
+[role="_additional-resources"]
+.Additional resources
+* link:https://docs.aws.amazon.com/general/latest/gr/aws_service_limits.html[Service Limits ({aws-short} documentation)]
+* link:https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html[Regions and Zones ({aws-short} documentation)]
+* link:https://docs.aws.amazon.com/vpc/latest/userguide/vpc-nat-gateway.html[NAT Gateways ({aws-short} documentation)]
+* link:https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/elastic-ip-addresses-eip.html[Elastic IP Addresses ({aws-short} documentation)]
+* link:https://aws.amazon.com/about-aws/global-infrastructure[Region map ({aws-short} documentation)]
+* link:https://aws.amazon.com/elasticloadbalancing[Elastic load balancing ({aws-short} documentation)]
+
 include::modules/installation-aws-permissions.adoc[leveloffset=+1]
 
 include::modules/installation-aws-iam-user.adoc[leveloffset=+1]

--- a/modules/installation-aws-limits.adoc
+++ b/modules/installation-aws-limits.adoc
@@ -7,9 +7,7 @@
 = {aws-short} account limits
 
 [role="_abstract"]
-The {product-title} cluster uses several {aws-first}
-components, and the default
-link:https://docs.aws.amazon.com/general/latest/gr/aws_service_limits.html[Service Limits] affect your ability to install {product-title} clusters.
+The {product-title} cluster uses several {aws-first} components, and the default service limits affect your ability to install {product-title} clusters.
 
 If you use certain cluster configurations, deploy your cluster in certain {aws-short} regions, or run multiple clusters from your account, you might need
 to request additional resources for your {aws-short} account.
@@ -37,16 +35,10 @@ and the bootstrap and control plane machines use `m6i.xlarge` instances. In some
 |Elastic IPs (EIPs)
 |0 to 1
 |5 EIPs per account
-|To provision the cluster in a highly available configuration, the installation program
-creates a public and private subnet for each
-link:https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html[availability zone within a region].
-Each private subnet requires a
-link:https://docs.aws.amazon.com/vpc/latest/userguide/vpc-nat-gateway.html[NAT Gateway],
-and each NAT gateway requires a separate
-link:https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/elastic-ip-addresses-eip.html[elastic IP].
-Review the
-link:https://aws.amazon.com/about-aws/global-infrastructure/[AWS region map] to
-determine how many availability zones are in each region. To take advantage of the default high availability, install the cluster in a region with at least three availability zones. To install a cluster in a region with more than five availability zones, you must increase the EIP limit.
+|To provision the cluster in a highly available configuration, the installation program creates a public and private subnet for each availability zone within a region.
+Each private subnet requires a NAT gateway, and each NAT gateway requires a separate elastic IP.
+Review the AWS region map to determine how many availability zones are in each region. To take advantage of the default high availability, install the cluster in a region with at least three availability zones. To install a cluster in a region with more than five availability zones, you must increase the EIP limit.
+
 [IMPORTANT]
 ====
 To use the `us-east-1` region, you must increase the EIP limit for your account.
@@ -61,8 +53,7 @@ To use the `us-east-1` region, you must increase the EIP limit for your account.
 |3
 |20 per region
 |By default, each cluster creates internal and external network load balancers for the master
-API server and a single Classic Load Balancer for the router. Deploying more Kubernetes `Service` objects with type `LoadBalancer` will create additional
-link:https://aws.amazon.com/elasticloadbalancing/[load balancers].
+API server and a single Classic Load Balancer for the router. Deploying more Kubernetes `Service` objects with type `LoadBalancer` will create additional load balancers.
 
 
 |NAT Gateways
@@ -74,9 +65,7 @@ link:https://aws.amazon.com/elasticloadbalancing/[load balancers].
 |At least 12
 |350 per region
 |The default installation creates 21 ENIs and an ENI for each availability zone
-in your region. For example, the `us-east-1` region contains six availability zones, so a cluster that is deployed in that zone uses 27 ENIs. Review the
-link:https://aws.amazon.com/about-aws/global-infrastructure/[AWS region map] to
-determine how many availability zones are in each region.
+in your region. For example, the `us-east-1` region contains six availability zones, so a cluster that is deployed in that zone uses 27 ENIs. Review the AWS region map to determine how many availability zones are in each region.
 
 Additional ENIs are created for additional machines and ELB load balancers that are created by cluster usage and deployed workloads.
 
@@ -95,5 +84,15 @@ Additional ENIs are created for additional machines and ELB load balancers that 
 |250
 |2,500 per account
 |Each cluster creates 10 distinct security groups.
-                                                                                                                                        | Fail, optionally surfacing response body to the user
+
+|Security Groups on network interfaces
+|Varies
+|5 per network interface
+|By default, {aws-short} allows 5 security groups per network interface. The installation program creates 2 security groups for compute machines and 3 security groups for control plane machines. If you are installing a cluster into a shared VPC, there are three scenarios in which you must increase this quota:
+
+* You specified 4 or more custom security groups for compute machines using the `compute.platform.aws.additionalSecurityGroupIDs` parameter in the `install-config.yaml` file.
+* You specified 3 or more custom security groups for control plane machines using the `controlPlane.platform.aws.additionalSecurityGroupIDs` parameter in the `install-config.yaml` file.
+* You specified 3 or more custom security groups for all machines using the `platform.aws.defaultMachinePlatform` parameter in the `install-config.yaml` file.
+
+You must increase the quota of security groups per network interface to a number greater than or equal to `3 + (number of control plane custom security groups OR number of default machine platform custom security groups)`, or `2 + (number of compute custom security groups OR number of default machine platform custom security groups)`, whichever is higher. If you do not specify a sufficient quota, the installation will succeed, but it will generate `SecurityGroupsPerInterfaceLimitExceeded` errors in the installation log, and the additional security groups will not be applied. The maximum allowed quota is 16 and the maximum number of user-specified security groups is 10.
 |===

--- a/modules/installation-aws-security-groups.adoc
+++ b/modules/installation-aws-security-groups.adoc
@@ -16,6 +16,7 @@ endif::[]
 [id="installation-aws-security-groups_{context}"]
 = Optional: AWS security groups
 
+[role="_abstract"]
 By default, the installation program creates and attaches security groups to control plane and compute machines. The rules associated with the default security groups cannot be modified.
 
 However, you can apply additional existing AWS security groups, which are associated with your existing VPC, to control plane and compute machines. Applying custom security groups can help you meet the security needs of your organization, in such cases where you need to control the incoming or outgoing traffic of these machines.
@@ -28,6 +29,17 @@ endif::localzone[]
 ifdef::localzone[]
 For more information, see "Edge compute pools and AWS Local Zones".
 endif::localzone[]
+
+[IMPORTANT]
+====
+By default, {aws-short} allows 5 security groups per network interface. The installation program creates 2 security groups for compute machines and 3 security groups for control plane machines. If you are installing a cluster into a shared VPC, there are three scenarios in which you must increase this quota:
+
+* You specified 4 or more custom security groups for compute machines using the `compute.platform.aws.additionalSecurityGroupIDs` parameter in the `install-config.yaml` file.
+* You specified 3 or more custom security groups for control plane machines using the `controlPlane.platform.aws.additionalSecurityGroupIDs` parameter in the `install-config.yaml` file.
+* You specified 3 or more custom security groups for all machines using the `platform.aws.defaultMachinePlatform` parameter in the `install-config.yaml` file.
+
+You must increase the quota of security groups per network interface to a number greater than or equal to `3 + (number of control plane custom security groups OR number of default machine platform custom security groups)`, or `2 + (number of compute custom security groups OR number of default machine platform custom security groups)`, whichever is higher. If you do not specify a sufficient quota, the installation will succeed, but it will generate `SecurityGroupsPerInterfaceLimitExceeded` errors in the installation log, and the additional security groups will not be applied. The maximum allowed quota is 16 and the maximum number of user-specified security groups is 10.
+====
 
 ifeval::["{context}" == "installing-aws-localzone"]
 :!localzone:


### PR DESCRIPTION
Version(s):
4.22

Issue:
https://redhat.atlassian.net/browse/OCPBUGS-85153

Link to docs preview:
[Account limits](https://111466--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-aws-account.html#installation-aws-limits_installing-aws-account)
[Optional: Security groups](https://111466--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/ipi/installing-aws-vpc.html#installation-aws-security-groups_installing-aws-vpc)

QE review:
- [x] QE has approved this change.

This PR also moves some links to Additional Resources to satisfy Vale.