### PR TITLE
OSDOCS-19637:Update the z-stream RNs for 4.14.65

### DIFF
--- a/modules/zstream-4-14-65.adoc
+++ b/modules/zstream-4-14-65.adoc
@@ -1,0 +1,36 @@
+// Module included in the following assembly:
+//
+// * release_notes/ocp-4-14-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-14-65-bug-fixes_{context}"]
+= RHSA-2026:15091 - {product-title} {product-version}.65 image release, fixed issues, and security update
+
+Issued: 13 May 2026
+
+[role="_abstract"]
+{product-title} release {product-version}.65 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2026:15091[RHSA-2026:15091] advisory. There are no RPM packages for this release.
+
+[NOTE]
+====
+{product-title} release {product-version}.64 was not issued.
+====
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.14.65 --pullspecs
+----
+
+[id="zstream-4-14-65-fixed_issues_{context}"]
+== Fixed issues
+
+* Before this update, the `osDiskImage.source.id` property in the user-provisioned infrastructure ARM template was incorrectly placed. As a consequence, installation on {azure-first} failed. With this release, the `storageProfile.osDiskImage.source.id` property location in the user-provisioned infrastructure ARM template is corrected. As a result, the user-provisioned infrastructure ARM template on {azure-first} installation succeeds. (link:https://redhat.atlassian.net/browse/OCPBUGS-79654[OCPBUGS-79654])
+
+[id="zstream-4-14-65-updating_{context}"]
+== Updating
+
+To update an {product-title} 4.14 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].

--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -3413,6 +3413,9 @@ The impact is on East/West traffic in local gateway mode with `routingViaHost` s
 // 4.14 about async
 include::modules/rn-async-errata.adoc[leveloffset=+1]
 
+// 4.14.65 Rns and updating
+include::modules/zstream-4-14-65.adoc[leveloffset=+2]
+
 // 4.14.63 Rns and updating
 include::modules/zstream-4-14-63.adoc[leveloffset=+2]
 


### PR DESCRIPTION
Version(s):
4.14

Issue:
https://redhat.atlassian.net/browse/OSDOCS-19637

Link to docs preview:
https://111467--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes.html#zstream-4-14-65-bug-fixes_release-notes

Additional information:
4.14.65 MR: https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/520
ART Dashboard: https://art-dash.engineering.redhat.com/dashboard/release/openshift-4.14
