### PR TITLE
OSSM_v_3.1.8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,7 @@ commercial_package
 .vale/styles/AsciiDocDITA
 .vale/styles/OpenShiftAsciiDoc
 .vale/styles/RedHat
+artifacts/
+modules/ossm-migrate-to-nftables-rhel10-ambient.adoc
+modules/ossm-migrate-to-nftables-rhel10-sidecar.adoc
+update/ossm-preparing-for-rhel-10-migration.adoc

--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -17,10 +17,10 @@
 :SMProductName: Red{nbsp}Hat OpenShift Service Mesh
 :SMProduct: OpenShift Service Mesh
 :SMProductShortName: Service Mesh
-:SMProductVersion: 3.1.7
+:SMProductVersion: 3.1.8
 //service mesh v2
 //Update when there is a new 2.6.z release
-:SMv2Version: 2.6.14
+:SMv2Version: 2.6.15
 //SMv2Version must be updated with each 2.x release because users can only migrate from the latest 2.x.z version. Update 02/24/2025 for service-mesh-docs-3.0
 //Istio
 :istio: Istio

--- a/modules/ossm-release-notes-3-1-8.adoc
+++ b/modules/ossm-release-notes-3-1-8.adoc
@@ -1,0 +1,20 @@
+// Module included in the following assemblies:
+//
+// * service-mesh-docs-main/ossm-release-notes/ossm-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="ossm-release-3-1-8_{context}"]
+= {SMProductName} version 3.1.8
+
+[role="_abstract"]
+This release of {SMProductName} is included with the {SMProductName} Operator 3.1.8 and is supported on {ocp-product-title} 4.16-4.20. This release addresses enhancements, fixed issues, and Common Vulnerabilities and Exposures (CVEs).
+
+For supported component versions for 3.1.8, see "Service Mesh version support tables".
+
+[id="ossm-fixed-issues-3-1-8_{context}"]
+== Fixed issues
+
+Icons restored to OperatorHub catalog cards in the {ocp-product-title} web console::
+This fix restores icons to OperatorHub catalog cards for Sail Operator and {SMProductShortName} Operator, enhancing visibility and ease of use. 
++
+link:https://redhat.atlassian.net/browse/OSSM-13028[OSSM-13028]

--- a/modules/ossm-release-notes-supported-versions.adoc
+++ b/modules/ossm-release-notes-supported-versions.adoc
@@ -7,6 +7,35 @@
 = {SMProduct} supported versions
 
 [role="_abstract"]
+See the following table for information about {SMProduct} 3.1.8 supported versions.
+
+== {SMProduct} 3.1.8 supported versions
+[cols="1,1"]
+|===
+| Feature | Supported versions
+
+|{SMProduct} 3 Operator
+|3.1.8
+
+|{SMProduct} `Istio` control plane resource
+|1.26.8
+
+|{ocp-product-title}
+|4.16-4.20
+
+| Envoy proxy
+| 1.34.14
+
+| `IstioCNI` resource
+| 1.26.8
+
+|Kiali Operator
+|2.22.3
+
+|Kiali server
+|2.11.10
+
+|===
 
 See the following table for information about {SMProduct} 3.1.7 supported versions.
 

--- a/ossm-release-notes/ossm-release-notes.adoc
+++ b/ossm-release-notes/ossm-release-notes.adoc
@@ -16,6 +16,8 @@ The {SMProductName} release notes provide details about new features and enhance
 For additional information about the {SMProductName} life cycle and supported platforms, refer to the "{ocp-short-name} Operator Life Cycles".
 ====
 
+include::modules/ossm-release-notes-3-1-8.adoc[leveloffset=+1]
+
 include::modules/ossm-release-notes-3-1-7.adoc[leveloffset=+1]
 
 include::modules/ossm-release-notes-3-1-6.adoc[leveloffset=+1]


### PR DESCRIPTION
[OSSM-13659](https://redhat.atlassian.net/browse/OSSM-13659): OSSM 3.3.3 & 3.2.5 & 3.1.8 & 3.0.11 At ReleaseCandidate Documentation Tasks

Version(s):
service-mesh-docs-3.1

Issue:
https://redhat.atlassian.net/browse/OSSM-13659

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
