### PR TITLE
[TELCODOCS#2633]: SNO agent base installation (4.16 cherry-pick)

### DIFF
--- a/installing/installing_sno/install-sno-installing-sno.adoc
+++ b/installing/installing_sno/install-sno-installing-sno.adoc
@@ -97,6 +97,20 @@ endif::openshift-origin[]
 ifndef::openshift-origin[]
 * xref:../../nodes/nodes/nodes-sno-worker-nodes.adoc#nodes-sno-worker-nodes[Adding worker nodes to {sno} clusters]
 
+[id="install-sno-installing-sno-with-agent-based-installer"]
+== Installing {sno} with the Agent-based Installer
+
+You can use the Agent-based Installer to deploy {sno} on bare-metal servers running ARM (`aarch64`) architecture. The Agent-based Installer generates a self-contained bootable ISO image by using the {product-title} installer for offline and automated deployments.
+
+The following procedure describes how to create the required configuration files, generate the agent ISO image, and boot the target ARM server to install {sno}.
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../installing/installing_with_agent_based_installer/preparing-to-install-with-agent-based-installer.adoc#preparing-to-install-with-agent-based-installer[Preparing to install with the Agent-based Installer]
+
+include::modules/install-sno-installing-with-agent-based-installer.adoc[leveloffset=+2]
+
 [id="install-sno-installing-sno-on-cloud-providers"]
 == Installing {sno} on cloud providers
 endif::openshift-origin[]

--- a/modules/install-sno-generating-the-install-iso-manually.adoc
+++ b/modules/install-sno-generating-the-install-iso-manually.adoc
@@ -40,7 +40,7 @@ $ OKD_VERSION=<okd_version> <1>
 <1> Replace `<okd_version>` with the current version, for example, `4.14.0-0.okd-2024-01-26-175629`
 endif::openshift-origin[]
 
-. Set the host architecture:
+. Set the target cluster architecture:
 +
 [source,terminal]
 ----
@@ -48,12 +48,21 @@ $ export ARCH=<architecture> <1>
 ----
 <1> Replace `<architecture>` with the target host architecture, for example, `aarch64` or `x86_64`.
 
+. Set the installation host architecture:
++
+[source,terminal]
+----
+$ export HOST_ARCH=$(uname -m)
+----
++
+This command detects the architecture of the installation host. If the installation host architecture differs from the target cluster architecture, the downloaded binaries must match the installation host. For example, if you are installing an `aarch64` cluster from an `x86_64` bastion host, `HOST_ARCH` is `x86_64`.
+
 ifndef::openshift-origin[]
 . Download the {product-title} client (`oc`) and make it available for use by entering the following commands:
 +
 [source,terminal]
 ----
-$ curl -k https://mirror.openshift.com/pub/openshift-v4/clients/ocp/$OCP_VERSION/openshift-client-linux.tar.gz -o oc.tar.gz
+$ curl -k https://mirror.openshift.com/pub/openshift-v4/$HOST_ARCH/clients/ocp/$OCP_VERSION/openshift-client-linux.tar.gz -o oc.tar.gz
 ----
 +
 [source,terminal]
@@ -90,7 +99,7 @@ ifndef::openshift-origin[]
 +
 [source,terminal]
 ----
-$ curl -k https://mirror.openshift.com/pub/openshift-v4/clients/ocp/$OCP_VERSION/openshift-install-linux.tar.gz -o openshift-install-linux.tar.gz
+$ curl -k https://mirror.openshift.com/pub/openshift-v4/$HOST_ARCH/clients/ocp/$OCP_VERSION/openshift-install-linux.tar.gz -o openshift-install-linux.tar.gz
 ----
 endif::openshift-origin[]
 ifdef::openshift-origin[]

--- a/modules/install-sno-installing-with-agent-based-installer.adoc
+++ b/modules/install-sno-installing-with-agent-based-installer.adoc
@@ -1,0 +1,173 @@
+// This is included in the following assemblies:
+//
+// installing_sno/install-sno-installing-sno.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="install-sno-installing-with-agent-based-installer_{context}"]
+= Installing {sno} with the Agent-based Installer on ARM architecture
+
+[role="_abstract"]
+You can use the Agent-based Installer to install {sno} on an `aarch64` (ARM) server. The Agent-based Installer generates a bootable ISO image that you use to boot the target machine and deploy the cluster.
+
+.Prerequisites
+
+* You downloaded the `openshift-install` binary for your installation host architecture from the {hybrid-console-url}. When you select the architecture on the console, ensure that it matches your installation host and that you select `ARM64` (`aarch64`) as the target cluster architecture.
+* You have a valid pull secret from the {hybrid-console-url}.
+* You have an SSH public key on the administration host.
+* You configured DNS records for `api.<cluster_name>.<base_domain>` and `*.apps.<cluster_name>.<base_domain>` to point to the node IP address.
+
+[NOTE]
+====
+See "Requirements for installing OpenShift on a single node" for networking requirements, including DNS records.
+====
+
+.Procedure
+
+. Create a directory to store the installation configuration by running the following command:
++
+[source,terminal]
+----
+$ mkdir ~/<install_directory>
+----
+
+. Create the `install-config.yaml` file in the installation directory as in the following example:
++
+[source,yaml]
+----
+apiVersion: v1
+baseDomain: <domain>
+compute:
+- architecture: arm64
+  hyperthreading: Enabled
+  name: worker
+  replicas: 0
+controlPlane:
+  architecture: arm64
+  hyperthreading: Enabled
+  name: master
+  replicas: 1
+metadata:
+  name: <cluster_name>
+networking:
+  clusterNetwork:
+  - cidr: 10.128.0.0/14
+    hostPrefix: 23
+  machineNetwork:
+  - cidr: <machine_network_cidr>
+  networkType: OVNKubernetes
+  serviceNetwork:
+  - 172.30.0.0/16
+platform:
+  none: {}
+pullSecret: '<pull_secret>'
+sshKey: '<ssh_pub_key>'
+----
++
+The following table describes the required parameters:
++
+.Required `install-config.yaml` parameters
+[cols="2,3",options="header"]
+|===
+|Parameter |Description
+
+|`baseDomain`
+|Specify the cluster base domain name.
+
+|`compute[].architecture`
+|Set to `arm64` for ARM-based deployments. Must match the `controlPlane` architecture.
+
+|`compute[].replicas`
+|Set to `0` to make the control plane node schedulable.
+
+|`controlPlane.architecture`
+|Set to `arm64` for ARM-based deployments. Must match the `compute` architecture.
+
+|`controlPlane.replicas`
+|Set to `1` to ensure the cluster runs on a single node.
+
+|`metadata.name`
+|Specify the cluster name.
+
+|`machineNetwork[].cidr`
+|Set the CIDR value to match the subnet of the {sno} cluster.
+
+|`networkType`
+|Set to `OVNKubernetes`. This is the only supported network plugin for single-node clusters.
+
+|`pullSecret`
+|Copy the {cluster-manager-url-pull} and add the contents to this configuration setting.
+
+|`sshKey`
+|Provide the public SSH key from the administration host so that you can log in to the cluster after installation.
+|===
+
+. Create the `agent-config.yaml` file in the same installation directory as in the following example:
++
+[source,yaml]
+----
+apiVersion: v1beta1
+kind: AgentConfig
+metadata:
+  name: <cluster_name>
+rendezvousIP: <node_ip>
+----
++
+Replace `<cluster_name>` with the cluster name. This value must match the `metadata.name` value in `install-config.yaml`. Replace `<node_ip>` with the IP address of the node. For {sno}, this is the IP address of the single node.
+
+. Generate the agent ISO image by running the following command:
++
+[source,terminal]
+----
+$ openshift-install --dir ~/<install_directory> agent create image
+----
++
+The command creates the `agent.aarch64.iso` image in the installation directory.
+
+. Transfer the `agent.aarch64.iso` image to the target ARM server and boot from it. You can use one of the following methods:
++
+--
+* Attach the ISO image by using a virtual media interface such as Redfish or a BMC console.
+* Write the ISO image to a USB drive and boot from it.
+* Host the ISO image on an HTTP server and boot from it by using the Redfish API.
+--
++
+The ISO image writes the system configuration to the target installation disk and installs {product-title}.
+
+. Monitor the installation progress from the administration host by running the following command:
++
+[source,terminal]
+----
+$ openshift-install --dir ~/<install_directory> agent wait-for install-complete --log-level=info
+----
++
+.Example output
+[source,terminal]
+----
+...................................................................
+INFO Cluster is installed
+INFO Install complete!
+INFO To access the cluster as the system:admin user when using 'oc', run
+INFO     export KUBECONFIG=~/<install_directory>/auth/kubeconfig
+INFO Access the OpenShift web-console here: https://console-openshift-console.apps.<cluster_name>.<domain>
+----
+
+.Verification
+
+* After the installation is complete, verify the cluster by running the following commands:
++
+[source,terminal]
+----
+$ export KUBECONFIG=~/<install_directory>/auth/kubeconfig
+----
++
+[source,terminal]
+----
+$ oc get nodes
+----
++
+.Example output
+[source,terminal]
+----
+NAME                    STATUS   ROLES                         AGE     VERSION
+<node_name>             Ready    control-plane,master,worker   10m     v1.34.2
+----


### PR DESCRIPTION
Cherry-pick of https://github.com/openshift/openshift-docs/pull/110672 onto `enterprise-4.16`.

Version(s): 4.16

Issue: [TELCODOCS-2633](https://redhat.atlassian.net/browse/TELCODOCS-2633)

This PR adds documentation for single-node OpenShift Agent-Based Installation on ARM (new procedure module, assembly update, and `$HOST_ARCH` download URLs in the manual ISO generation module).

QE review:
- [x] QE has approved this change on the original PR for main.

Made with [Cursor](https://cursor.com)