### PR TITLE
RHDEVDOCS-7532: [DOCS] Implement stepResources override in Build and BuildRuns

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -64,6 +64,8 @@ Topics:
   File: creating-container-images
 - Name: Creating container images in a network-restricted environment
   File: creating-container-images-in-a-network-restricted-environment
+- Name: Optimize build performance
+  File: optimize-build-performance
 - Name: Managing builds
   File: managing-builds
 ---

--- a/modules/adjust-resource-limits-for-a-build-configuration.adoc
+++ b/modules/adjust-resource-limits-for-a-build-configuration.adoc
@@ -1,0 +1,68 @@
+// Module included in the following assembly:
+//
+// * work_with_builds/optimize-build-performance.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="adjust-resource-limits-for-a-build-configuration_{context}"]
+= Adjust resource limits for a build configuration
+
+[role="_abstract"]
+Adjust the CPU and memory limits for specific steps in a build configuration by adding resource requirements to the Build resource YAML file.
+
+.Prerequisites
+* You have installed the Builds for Red Hat OpenShift Operator and the oc CLI.
+* You have identified the exact names of the steps in your strategy.
+
+.Procedure
+
+. Open your Build resource YAML file.
+
+. In the `spec.strategy` section, add the `stepResources` field and define the requirements for your steps. Ensure your configuration meets these criteria:
+* The name field must match the strategy step name exactly. The step names are case-sensitive.
+* Every entry in the `stepResources` list must include both the name and the resources object.
+* To tune many steps at once, add additional entries to the `stepResources` list. Any step not explicitly listed will continue to use the strategy's default resource settings.
+
+. Use the following example configuration to assign specific CPU and memory limits for your build steps:
++
+[source,yaml]
+----
+apiVersion: shipwright.io/v1beta1
+kind: Build
+metadata:
+  name: my-app-build
+spec:
+  strategy:
+    name: buildah
+    kind: ClusterBuildStrategy
+    stepResources:
+      - name: build-and-push
+        resources:
+          requests:
+            cpu: 500m
+            memory: 512Mi
+          limits:
+            cpu: "1"
+            memory: 1Gi
+  # ... source and output configuration
+----
+
+. Apply the configuration to your cluster:
++
+[source,terminal]
+----
+$ oc apply -f build.yaml
+----
+
+. Create a BuildRun to test the configuration:
++
+[source,terminal]
+----
+$ oc create -f buildrun.yaml
+----
++
+Or trigger a build:
++
+[source,terminal]
+----
+$ oc start-build my-app-build
+----

--- a/modules/override-resources-for-a-specific-build-run.adoc
+++ b/modules/override-resources-for-a-specific-build-run.adoc
@@ -1,0 +1,53 @@
+// Module included in the following assembly:
+//
+// * work_with_builds/optimize-build-performance.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="override-resources-for-a-specific-build-run_{context}"]
+= Override resources for a specific build run
+
+[role="_abstract"]
+Override resource limits for a single build execution by defining temporary CPU and memory requirements in the BuildRun resource YAML file.
+
+.Procedure
+
+. Create a BuildRun resource YAML file that references your existing Build.
+
+. Define the temporary resource boost in the spec.stepResources field. When configuring this file, ensure it meets the following requirements:
+* Constraint for Embedded Builds: If you are defining a build using an embedded spec.build.spec, you must place your resource overrides inside spec.build.spec.strategy.stepResources. You cannot use the top-level spec.stepResources for embedded builds.
+* Case Sensitivity: Ensure the step name (for example, build-and-push) matches the casing used in the BuildStrategy exactly.
+* Resource Pairings: Each entry in the list must contain both a name and a resources object.
+
+. Apply a temporary resource increase for a specific run as shown in this example:
++
+[source,yaml]
+----
+apiVersion: shipwright.io/v1beta1
+kind: BuildRun
+metadata:
+  name: release-v1-run
+spec:
+  build:
+    name: my-app-build
+  stepResources:
+    - name: build-and-push
+      resources:
+        requests:
+          cpu: "1"
+          memory: 1Gi
+        limits:
+          cpu: "2"
+          memory: 2Gi
+----
++
+where:
+
+`spec.stepResources`:: Specifies that the `BuildRun` step resource overrides take precedence over `Build` step resource overrides for the same step.
+
+
+. Start the build run by applying the file:
++
+[source,terminal]
+----
+$ oc apply -f buildrun.yaml
+----

--- a/modules/verify-build-resource-limits.adoc
+++ b/modules/verify-build-resource-limits.adoc
@@ -1,0 +1,65 @@
+// Module included in the following assembly:
+//
+// * work_with_builds/optimize-build-performance.adoc
+//
+// This module describes how to verify that resource limits for a build configuration are correctly applied.
+
+:_mod-docs-content-type: PROCEDURE
+[id="verify-build-resource-limits_{context}"]
+= Verify build resource limits
+
+[role="_abstract"]
+Verify that the CPU and memory resource limits applied to your build configuration are working correctly by checking the BuildRun status.
+
+.Prerequisites
+* You have installed the {builds-operator} and the `oc` CLI.
+* You have created a `BuildRun`.
+* You have configured resource limits for a build configuration.
+
+.Procedure
+
+. Run the following command to check the status of the `Build` resource:
++
+[source,terminal]
+----
+$ oc get buildrun <buildrun_name>
+----
++
+--
+where:
+
+`<buildrun_name>`:: Specifies the name of the BuildRun resource.
+--
++
+Example:
++
+[source,terminal]
+----
+$ oc get buildrun buildah-buildrun-with-resources
+----
++
+Example output:
++
+[source,yaml]
+----
+  NAME                              SUCCEEDED   REASON      STARTTIME   COMPLETIONTIME
+  buildah-buildrun-with-resources   True        Succeeded   2m          45s
+----
++
+Verify that the SUCCEEDED column displays status as True.
+
+. If the SUCCEEDED column shows an error, run the following command to check `UndefinedStepResource` reason:
++
+[source,terminal]
+----
+$ oc describe buildrun <buildrun_name>
+----
++
+where:
+
+`<buildrun_name>`:: Specifies the name of the BuildRun resource.
+
++ 
+--
+This command generates a detailed report that identifies which specific step name in your YAML fails to match the names defined in the strategy.
+--

--- a/work_with_builds/optimize-build-performance.adoc
+++ b/work_with_builds/optimize-build-performance.adoc
@@ -1,0 +1,28 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="optimize-build-performance"]
+= Optimize build performance
+
+include::_attributes/common-attributes.adoc[]
+:context: optimize-build-performance
+
+toc::[]
+
+[role="_abstract"]
+
+By default, build strategies give standard resource allocations. However, heavy workloads, such as compiling large binaries or pushing massive images, often require more memory than the default strategy allows.
+You can override the step resources to tune your builds at two levels:
+
+* Build configuration level: For permanent resource adjustments to a specific application.
+* BuildRun level: For one-time large builds (e.g., a major release).
+
+When multiple overrides exist, the system applies them in the following order of priority:
+
+* BuildRun overrides
+* Build configuration overrides
+* Strategy defaults
+
+include::modules/adjust-resource-limits-for-a-build-configuration.adoc[leveloffset=+1]
+
+include::modules/override-resources-for-a-specific-build-run.adoc[leveloffset=+1]
+
+include::modules/verify-build-resource-limits.adoc[leveloffset=+1]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): build-docs-1.8
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://redhat.atlassian.net/browse/RHDEVDOCS-7532
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://111485--ocpdocs-pr.netlify.app/openshift-builds/latest/work_with_builds/optimize-build-performance.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
