### PR TITLE
OSDOCS-18910: Document OLM v1 deployment configuration API

### DIFF
--- a/extensions/ce/olmv1-configuring-extensions.adoc
+++ b/extensions/ce/olmv1-configuring-extensions.adoc
@@ -7,9 +7,9 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 [role="_abstract"]
-In {olmv1-first}, extensions watch all namespaces by default. Some Operators support only namespace-scoped watching based on {olmv0} install modes. To install these Operators, configure the watch namespace for the extension. For more information, see "Discovering bundle install modes".
+You can customize Operator installations to control namespace scope and manage deployment behavior including resource allocation, node placement, and pod scheduling.
 
-:FeatureName: Configuring a watch namespace for a cluster extension
+:FeatureName: Configuring cluster extensions
 include::snippets/technology-preview.adoc[]
 
 include::modules/olmv1-config-api.adoc[leveloffset=+1]
@@ -29,8 +29,24 @@ include::modules/olmv1-config-api-watch-namespace-examples.adoc[leveloffset=+2]
 
 include::modules/olmv1-clusterextension-watchnamespace-validation-errors.adoc[leveloffset=+2]
 
+include::modules/olmv1-deployment-config-api.adoc[leveloffset=+1]
+
+include::modules/olmv1-clusterobjectsets-deployment-mechanism.adoc[leveloffset=+1]
+
+include::modules/olmv1-inspecting-clusterobjectsets.adoc[leveloffset=+1]
+
+include::modules/olmv1-customizing-operator-deployments.adoc[leveloffset=+1]
+
+include::modules/olmv1-deployment-config-examples.adoc[leveloffset=+1]
+
+include::modules/olmv1-deployment-config-reference.adoc[leveloffset=+1]
+
+include::modules/olmv1-deployment-config-troubleshooting.adoc[leveloffset=+1]
+
 [id="olmv1-configuring-extensions_additional-resources"]
 [role="_additional-resources"]
 == Additional resources
 
 * xref:../../extensions/ce/managing-ce.adoc#olmv1-installing-an-operator_managing-ce[Installing a cluster extension in all namespaces]
+* link:https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/[Assigning Pods to Nodes (Kubernetes)]
+* link:https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/[Taints and Tolerations (Kubernetes)]

--- a/modules/olmv1-clusterobjectsets-deployment-mechanism.adoc
+++ b/modules/olmv1-clusterobjectsets-deployment-mechanism.adoc
@@ -1,0 +1,69 @@
+// Module included in the following assemblies:
+//
+// * extensions/ce/olmv1-configuring-extensions.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="olmv1-clusterobjectsets-deployment-mechanism_{context}"]
+= ClusterObjectSets deployment mechanism
+
+[role="_abstract"]
+`ClusterObjectSets` deploy cluster extensions through ordered phases, enabling safe upgrades by maintaining both old and new revisions until the new version succeeds.
+
+:FeatureName: {olmv1} ClusterObjectSets
+include::snippets/technology-preview.adoc[]
+
+`ClusterObjectSets` are cluster-scoped APIs representing versioned resource sets organized into ordered phases. {olmv1} uses `ClusterObjectSets` to deploy Operator resources sequentially.
+
+[id="olmv1-clusterobjectsets-benefits_{context}"]
+== Benefits
+
+Phased rollouts:: Resources deploy in a defined order by kind. For example, Custom Resource Definitions (CRDs) are created before deployments that use them.
+
+Safe upgrades:: Both old and new revisions remain active until the new version succeeds, mitigating service disruption.
+
+Immutable revision records:: Immutable revisions provide a clear deployment record.
+
+Large bundle support:: References externalized secrets to bypass the etcd 1.5 MiB size limit, enabling large bundle deployments.
+
+[id="olmv1-clusterobjectsets-relationship_{context}"]
+== Relationship to the deploymentConfig API
+
+{olmv1} applies `deploymentConfig` settings during the `ClusterObjectSet` process, modifying Operator manifests before organizing them into phases.
+
+[id="olmv1-clusterobjectsets-phases_{context}"]
+== Deployment phases
+
+Phases are system-determined groups that organize resources into ordered deployment stages based on their API group and kind. Objects are automatically assigned to well-known phases.
+
+[NOTE]
+====
+All objects within a phase are applied in no particular order. The next phase begins only after all objects in the current phase pass their readiness probes.
+====
+
+The system assigns resources to the following phases in order:
+
+`namespaces`:: `Namespace` objects.
+
+`policies`:: `NetworkPolicy`, `PodDisruptionBudget`, and `PriorityClass` objects.
+
+`identity`:: `ServiceAccount` objects.
+
+`configuration`:: `Secret` and `ConfigMap` objects.
+
+`storage`:: `PersistentVolume`, `PersistentVolumeClaim`, and `StorageClass` objects.
+
+`crds`:: `CustomResourceDefinition` objects.
+
+`roles`:: `ClusterRole` and `Role` objects.
+
+`bindings`:: `ClusterRoleBinding` and `RoleBinding` objects.
+
+`infrastructure`:: `Service`, `Issuer`, and `Certificate` objects.
+
+`deploy`:: `Deployment` objects.
+
+`scaling`:: `VerticalPodAutoscaler` objects.
+
+`publish`:: `PrometheusRule`, `ServiceMonitor`, `PodMonitor`, `Ingress`, `Route`, and console resources.
+
+`admission`:: `ValidatingWebhookConfiguration` and `MutatingWebhookConfiguration` objects.

--- a/modules/olmv1-customizing-operator-deployments.adoc
+++ b/modules/olmv1-customizing-operator-deployments.adoc
@@ -1,0 +1,92 @@
+// Module included in the following assemblies:
+//
+// * extensions/ce/olmv1-configuring-extensions.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="olmv1-customizing-operator-deployments_{context}"]
+= Customize operator deployments
+
+[role="_abstract"]
+Customize Operator pod deployments to meet production requirements by configuring resource allocation, node placement, and pod tolerations through the `ClusterExtension` resource.
+
+:FeatureName: {olmv1} `deploymentConfig` API
+include::snippets/technology-preview.adoc[]
+
+.Prerequisites
+
+* You have access to an {product-title} cluster using an account with `cluster-admin` permissions.
+* You have enabled the `TechPreviewNoUpgrade` feature set on the cluster.
+* You have created a service account and assigned enough role-based access controls (RBAC) to install, update, and manage the extension. For more information, see "Cluster extension permissions".
+* You have installed the {oc-first}.
+* You have identified the operator you want to install and customize.
+
+.Procedure
+
+. Create a `ClusterExtension` resource with `deploymentConfig` customizations:
++
+[source,yaml]
+----
+apiVersion: olm.operatorframework.io/v1
+kind: ClusterExtension
+metadata:
+  name: my-operator
+spec:
+  namespace: my-operator-ns
+  serviceAccount:
+    name: my-operator-installer
+  config:
+    configType: Inline
+    inline:
+      deploymentConfig:
+        resources:
+          requests:
+            cpu: 100m
+            memory: 128Mi
+          limits:
+            cpu: 500m
+            memory: 512Mi
+        nodeSelector:
+          node-role.kubernetes.io/infra: ""
+        tolerations:
+        - key: node-role.kubernetes.io/infra
+          operator: Exists
+          effect: NoSchedule
+  source:
+    sourceType: Catalog
+    catalog:
+      packageName: my-operator
+      version: 1.0.0
+----
++
+where:
++
+--
+`resources:`:: Specifies CPU and memory resource requests and limits for the Operator pod.
+`nodeSelector:`:: Specifies pod scheduling restrictions to infrastructure nodes.
+`tolerations:`:: Specifies pod tolerations that allow scheduling on nodes with the specified taint.
+--
+
+. Apply the `ClusterExtension` resource:
++
+[source,terminal]
+----
+$ oc apply -f my-operator.yaml
+----
+
+. Verify the installation:
++
+[source,terminal]
+----
+$ oc get clusterextension my-operator -o yaml
+----
+
+.Verification
+
+* Verify that the `deploymentConfig` settings were applied:
++
+[source,terminal]
+----
+$ oc get deployment -n my-operator-ns -l olm.operatorframework.io/owner-name=my-operator -o yaml
+----
++
+Check the deployment specification for your configured settings such as resource limits, node selectors, tolerations, and volumes.

--- a/modules/olmv1-deployment-config-api.adoc
+++ b/modules/olmv1-deployment-config-api.adoc
@@ -1,0 +1,154 @@
+// Module included in the following assemblies:
+//
+// * extensions/ce/olmv1-configuring-extensions.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="olmv1-deployment-config-api_{context}"]
+= deploymentConfig API
+
+[role="_abstract"]
+The `deploymentConfig` API controls Operator pod runtime settings such as resources, node placement, and environment variables, providing feature parity with {olmv0} Subscription configuration.
+
+:FeatureName: {olmv1} `deploymentConfig` API
+include::snippets/technology-preview.adoc[]
+
+Provides feature parity with the `Subscription.spec.config` configuration of the {olmv0}. Configure resources, node placement, storage, environment variables, and other deployment settings.
+
+[id="olmv1-deployment-config-structure_{context}"]
+== deploymentConfig structure
+
+Configure how the Operator deploys in the `spec.config.inline.deploymentConfig` field as a JSON object.
+
+.Example `deploymentConfig` object
+[source,yaml]
+----
+apiVersion: olm.operatorframework.io/v1
+kind: ClusterExtension
+metadata:
+  name: <extension_name>
+spec:
+  namespace: <installation_namespace>
+  serviceAccount:
+    name: <service_account_name>
+  source:
+    sourceType: Catalog
+    catalog:
+      packageName: <package_name>
+  config:
+    configType: Inline
+    inline:
+      deploymentConfig:
+        resources:
+          requests:
+            cpu: 100m
+            memory: 128Mi
+          limits:
+            cpu: 500m
+            memory: 512Mi
+        nodeSelector:
+          node-role.kubernetes.io/infra: ""
+        tolerations:
+        - key: node-role.kubernetes.io/infra
+          operator: Exists
+          effect: NoSchedule
+----
+where:
+--
+`serviceAccount:`:: Specifies the service account name for the Operator.
+`source:`:: Specifies the package source configuration.
+`deploymentConfig:`:: Specifies the object for customizing the deployment.
+`resources:`:: Specifies the CPU and memory requests and limits.
+`nodeSelector:`:: Specifies the node placement selector.
+`tolerations:`:: Specifies the node taint tolerations.
+--
+
+[id="olmv1-deployment-config-fields_{context}"]
+== Supported configuration fields
+
+Environment variables:: Add or override environment variables with `env`. Values are merged with existing container environment variables, with `deploymentConfig` values taking precedence.
+
+Environment variable sources:: Add environment variable sources with `envFrom`. Sources are appended to existing sources; duplicates are skipped.
+
+Resource requirements:: Specify CPU and memory requests and limits with `resources`. Replaces existing resource requirements.
+
+Node selector:: Control pod node placement with `nodeSelector`. Replaces existing node selector.
+
+Tolerations:: Schedule pods on nodes with taints by using `tolerations`. Appended to existing tolerations.
+
+Affinity rules:: Define pod affinity and anti-affinity rules with `affinity`. Non-nil fields replace corresponding bundle fields.
+
+Volumes and volume mounts:: Add volumes and volume mounts. Volumes with the same name as existing bundle volumes are overridden; new volumes are appended.
+
+Annotations:: Add custom pod annotations. Merged with existing annotations. Annotations already set by the bundle cannot be overridden.
+
+[id="olmv1-deployment-config-validation_{context}"]
+== Configuration validation
+
+{olmv1} validates configuration against a JSON schema generated from Kubernetes API definitions. The schema derives from the `SubscriptionConfig` type used in {olmv0}, providing consistent validation across versions.
+
+Invalid configurations prevent installation and report errors in the `ClusterExtension` resource's `Progressing` condition. Common validation errors include:
+
+* Unknown field errors when using unsupported configuration options
+* Type mismatch errors when field values do not match the expected type
+* Required field errors when mandatory nested fields are missing
+
+[NOTE]
+====
+{olmv1} applies configurations during the `ClusterObjectSet` deployment process, modifying Operator manifests before organizing them into phases.
+====
+
+[id="olmv1-deployment-config-migration_{context}"]
+== Converting from {olmv0}
+
+Transfer existing `Subscription.spec.config` settings to the `deploymentConfig` object. The YAML structure is the same, but some merge behaviors differ from {olmv0}.
+
+[NOTE]
+====
+`volumes` and `volumeMounts` with the same name override existing entries in {olmv1} rather than appending as in {olmv0}.
+====
+
+.Example {olmv0} subscription configuration
+[source,yaml]
+----
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: my-operator
+spec:
+  name: my-operator
+  channel: stable
+  config:
+    nodeSelector:
+      node-role.kubernetes.io/infra: ""
+    tolerations:
+    - key: node-role.kubernetes.io/infra
+      operator: Exists
+      effect: NoSchedule
+----
+
+.Equivalent {olmv1} cluster extension configuration
+[source,yaml]
+----
+apiVersion: olm.operatorframework.io/v1
+kind: ClusterExtension
+metadata:
+  name: my-operator
+spec:
+  namespace: my-operator-ns
+  serviceAccount:
+    name: my-operator-sa
+  config:
+    configType: Inline
+    inline:
+      deploymentConfig:
+        nodeSelector:
+          node-role.kubernetes.io/infra: ""
+        tolerations:
+        - key: node-role.kubernetes.io/infra
+          operator: Exists
+          effect: NoSchedule
+  source:
+    sourceType: Catalog
+    catalog:
+      packageName: my-operator
+----

--- a/modules/olmv1-deployment-config-examples.adoc
+++ b/modules/olmv1-deployment-config-examples.adoc
@@ -1,0 +1,189 @@
+// Module included in the following assemblies:
+//
+// * extensions/ce/olmv1-configuring-extensions.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="olmv1-deployment-config-examples_{context}"]
+= `deploymentConfig` examples
+
+[role="_abstract"]
+Customize Operator deployments using resource limits, node placement, custom volumes, environment variables, and combined configurations.
+
+:FeatureName: {olmv1} `deploymentConfig` API
+include::snippets/technology-preview.adoc[]
+
+[id="olmv1-deployment-config-env-vars_{context}"]
+== Environment variables
+
+Add environment variables for runtime configuration.
+
+.Adding environment variables
+[source,yaml]
+----
+apiVersion: olm.operatorframework.io/v1
+kind: ClusterExtension
+metadata:
+  name: kmm-operator
+spec:
+  namespace: openshift-kmm
+  serviceAccount:
+    name: kmm-operator-sa
+  config:
+    configType: Inline
+    inline:
+      deploymentConfig:
+        env:
+        - name: KMM_MANAGED
+          value: "1"
+  source:
+    sourceType: Catalog
+    catalog:
+      packageName: kernel-module-management
+----
+where:
+--
+`KMM_MANAGED`:: Specifies the environment variable used when deploying the Kernel Module Management Operator in a hub-and-spoke configuration.
+--
+
+[id="olmv1-deployment-config-volumes_{context}"]
+== Custom volumes
+
+Mount a custom CA certificate for HTTPS communication through a proxy.
+
+.Mounting a custom CA certificate
+[source,yaml]
+----
+apiVersion: olm.operatorframework.io/v1
+kind: ClusterExtension
+metadata:
+  name: my-operator
+spec:
+  namespace: my-operator-ns
+  serviceAccount:
+    name: my-operator-sa
+  config:
+    configType: Inline
+    inline:
+      deploymentConfig:
+        volumes:
+        - name: trusted-ca
+          configMap:
+            name: trusted-ca
+            items:
+            - key: ca-bundle.crt
+              path: tls-ca-bundle.pem
+        volumeMounts:
+        - name: trusted-ca
+          mountPath: /etc/pki/ca-trust/extracted/pem
+          readOnly: true
+  source:
+    sourceType: Catalog
+    catalog:
+      packageName: my-operator
+----
+where:
+--
+`volumes:`:: Specifies a volume created from the `trusted-ca` config map.
+`volumeMounts:`:: Specifies the volume mount to the Operator container at the specified path.
+`mountPath:`:: Specifies the path where the certificate bundle is available inside the container.
+--
+
+[id="olmv1-deployment-config-affinity_{context}"]
+== Pod anti-affinity
+
+Spread Operator pods across nodes for high availability.
+
+.Pod anti-affinity for high availability
+[source,yaml]
+----
+apiVersion: olm.operatorframework.io/v1
+kind: ClusterExtension
+metadata:
+  name: my-operator
+spec:
+  namespace: my-operator-ns
+  serviceAccount:
+    name: my-operator-sa
+  config:
+    configType: Inline
+    inline:
+      deploymentConfig:
+        affinity:
+          podAntiAffinity:
+            preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                  - key: app.kubernetes.io/name
+                    operator: In
+                    values:
+                    - my-operator
+                topologyKey: kubernetes.io/hostname
+  source:
+    sourceType: Catalog
+    catalog:
+      packageName: my-operator
+----
+where:
+--
+`podAntiAffinity:`:: Specifies anti-affinity rules for the Operator pod.
+`preferredDuringSchedulingIgnoredDuringExecution:`:: Specifies soft constraints that the scheduler tries to enforce but does not guarantee.
+`topologyKey`:: Specifies the topology key that groups nodes by hostname to ensure pods are spread across different nodes.
+--
+
+[id="olmv1-deployment-config-combined_{context}"]
+== Multiple customizations
+
+Combine multiple deployment customizations.
+
+.Production Operator with combined customizations
+[source,yaml]
+----
+apiVersion: olm.operatorframework.io/v1
+kind: ClusterExtension
+metadata:
+  name: production-operator
+spec:
+  namespace: production-operators
+  serviceAccount:
+    name: production-operator-installer
+  config:
+    configType: Inline
+    inline:
+      deploymentConfig:
+        resources:
+          requests:
+            cpu: 200m
+            memory: 256Mi
+          limits:
+            cpu: 1000m
+            memory: 1Gi
+        env:
+        - name: LOG_LEVEL
+          value: info
+        - name: ENABLE_METRICS
+          value: "true"
+        nodeSelector:
+          node-role.kubernetes.io/infra: ""
+        tolerations:
+        - key: node-role.kubernetes.io/infra
+          operator: Exists
+          effect: NoSchedule
+        annotations:
+          monitoring.openshift.io/scrape: "true"
+          monitoring.openshift.io/port: "8080"
+  source:
+    sourceType: Catalog
+    catalog:
+      packageName: production-operator
+      version: 2.1.0
+----
+where:
+--
+`resources:`:: Specifies memory and CPU requests and limits for the Operator pod.
+`env:`:: Specifies environment variables for the Operator.
+`nodeSelector:`:: Specifies that the pod runs on infrastructure nodes.
+`tolerations:`:: Specifies pod tolerations that allow scheduling on nodes with the specified taint.
+`annotations:`:: Specifies Prometheus monitoring annotations for the pod.
+--

--- a/modules/olmv1-deployment-config-reference.adoc
+++ b/modules/olmv1-deployment-config-reference.adoc
@@ -1,0 +1,162 @@
+// Module included in the following assemblies:
+//
+// * extensions/ce/olmv1-configuring-extensions.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="olmv1-deployment-config-reference_{context}"]
+= `deploymentConfig` field reference
+
+[role="_abstract"]
+Field reference for the `deploymentConfig` API including {olmv0} to {olmv1} field mappings and merge behavior for each configuration option.
+
+:FeatureName: {olmv1} `deploymentConfig` API
+include::snippets/technology-preview.adoc[]
+
+[id="olmv1-deployment-config-field-mapping_{context}"]
+== Field mapping from {olmv0} to {olmv1}
+
+Field conversion from {olmv0} to {olmv1}:
+
+.{olmv0} to {olmv1} configuration field mapping
+[cols="1,1,2",options="header"]
+|===
+|{olmv0} field path
+|{olmv1} field path
+|Notes
+
+|`spec.config.env`
+|`spec.config.inline.deploymentConfig.env`
+|Environment variables are merged. {olmv1} values take precedence over bundle values.
+
+|`spec.config.envFrom`
+|`spec.config.inline.deploymentConfig.envFrom`
+|Environment variable sources are appended to bundle sources. Duplicates are skipped.
+
+|`spec.config.resources`
+|`spec.config.inline.deploymentConfig.resources`
+|Resource specifications completely replace bundle resource requirements.
+
+|`spec.config.nodeSelector`
+|`spec.config.inline.deploymentConfig.nodeSelector`
+|Node selectors completely replace bundle node selectors.
+
+|`spec.config.tolerations`
+|`spec.config.inline.deploymentConfig.tolerations`
+|Tolerations are appended to bundle tolerations.
+
+|`spec.config.affinity`
+|`spec.config.inline.deploymentConfig.affinity`
+|Affinity rules selectively override bundle affinity. Non-nil fields replace corresponding bundle fields.
+
+|`spec.config.volumes`
+|`spec.config.inline.deploymentConfig.volumes`
+|Volumes override existing bundle volumes with the same name; new volumes are appended.
+
+|`spec.config.volumeMounts`
+|`spec.config.inline.deploymentConfig.volumeMounts`
+|Volume mounts override existing bundle volume mounts with the same name; new mounts are appended.
+
+|`spec.config.annotations`
+|`spec.config.inline.deploymentConfig.annotations`
+|Annotations are merged with bundle annotations. Bundle annotations take precedence on conflicts.
+
+|`spec.config.selector`
+|Not supported
+|The `selector` field from {olmv0} is not supported in {olmv1}. This field was never used in {olmv0}.
+
+|===
+
+[id="olmv1-deployment-config-merge-behavior_{context}"]
+== Merge and override behavior
+
+Configuration fields have different merge behaviors:
+
+Replace:: Completely replaces bundle values. Applies to: `resources`, `nodeSelector`
+
+Append:: Adds to existing bundle values. Applies to: `tolerations`, `envFrom`
+
+Override and append:: Overrides existing values with the same name; new values are appended. Applies to: `volumes`, `volumeMounts`
+
+Merge with precedence:: Merges with bundle values. `deploymentConfig` values take precedence on conflicts. Applies to: `env`
+
+Merge with bundle precedence:: Merges with bundle values. Bundle takes precedence on conflicts. Applies to: `annotations`
+
+Selective override:: Non-nil fields replace corresponding bundle fields. Applies to: `affinity`
+
+[id="olmv1-deployment-config-env-reference_{context}"]
+== Environment variable fields
+
+`env`:: Specifies an array of environment variable objects. Merged with existing container environment variables, with `deploymentConfig` values taking precedence. Each object has:
++
+* `name`: Environment variable name (string, required).
+* `value`: Environment variable value (string, optional).
+* `valueFrom`: Reference to a secret or config map key (object, optional).
+
+`envFrom`:: Specifies an array of environment variable source objects merged with existing sources. Each object can reference:
++
+* `configMapRef`: Config map containing environment variables.
+* `secretRef`: Secret containing environment variables.
+
+[id="olmv1-deployment-config-resources-reference_{context}"]
+== Resource requirements fields
+
+`resources`:: Specifies compute resource requirements that completely replace existing bundle resource requirements. Contains:
++
+* `requests`: Minimum resources required.
+** `cpu`: CPU request (string, for example, `"100m"`, `"0.5"`).
+** `memory`: Memory request (string, for example, `"128Mi"`, `"1Gi"`).
+* `limits`: Maximum resources allowed.
+** `cpu`: CPU limit (string).
+** `memory`: Memory limit (string).
+
+[id="olmv1-deployment-config-node-placement-reference_{context}"]
+== Node placement fields
+
+`nodeSelector`:: Specifies a map of key-value pairs for node selection. Completely replaces any existing node selector. Pods schedule only on nodes with all specified labels.
++
+.Example node selector
+[source,yaml]
+----
+nodeSelector:
+  node-role.kubernetes.io/infra: ""
+  disktype: ssd
+----
+
+`tolerations`:: Specifies an array of toleration objects appended to existing bundle tolerations. Each toleration has:
++
+* `key`: Taint key (string).
+* `operator`: Operator (string: `Exists`, `Equal`).
+* `value`: Taint value (string, required if `operator` is `Equal`).
+* `effect`: Taint effect (string: `NoSchedule`, `PreferNoSchedule`, `NoExecute`).
+* `tolerationSeconds`: Time before pod eviction for `NoExecute` effect (integer).
+
+`affinity`:: Specifies an affinity rules object. Non-nil fields replace corresponding bundle fields. Contains:
++
+* `nodeAffinity`: Node label-based scheduling rules.
+* `podAffinity`: Pod label-based scheduling rules.
+* `podAntiAffinity`: Pod spreading rules across nodes.
+
+[id="olmv1-deployment-config-storage-reference_{context}"]
+== Storage fields
+
+`volumes`:: Specifies an array of volume objects. Volumes with the same name as existing bundle volumes are overridden; new volumes are appended. All Kubernetes volume types are supported. Each volume requires a `name` field (string).
+
+`volumeMounts`:: Specifies an array of volume mount objects. Volume mounts with the same name as existing bundle volume mounts are overridden; new mounts are appended. Each mount has:
++
+* `name`: Volume name to mount (string, required).
+* `mountPath`: The path within the container (string, required).
+* `readOnly`: Whether the volume is read-only (boolean, optional).
+* `subPath`: A path within the volume (string, optional).
+
+[id="olmv1-deployment-config-metadata-reference_{context}"]
+== Metadata fields
+
+`annotations`:: Specifies a map of key-value pairs for deployment and pod annotations. Annotations are applied to both the deployment metadata and the pod template metadata. Annotations from `deploymentConfig` are merged with bundle annotations. When keys conflict, bundle annotations take precedence.
++
+.Example annotations
+[source,yaml]
+----
+annotations:
+  monitoring.openshift.io/scrape: "true"
+  monitoring.openshift.io/port: "8080"
+----

--- a/modules/olmv1-deployment-config-troubleshooting.adoc
+++ b/modules/olmv1-deployment-config-troubleshooting.adoc
@@ -1,0 +1,70 @@
+// Module included in the following assemblies:
+//
+// * extensions/ce/olmv1-configuring-extensions.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="olmv1-deployment-config-troubleshooting_{context}"]
+= Troubleshooting `deploymentConfig`
+
+[role="_abstract"]
+Common `deploymentConfig` issues include validation errors, configuration verification problems, and annotation conflicts that can prevent successful Operator installation.
+
+:FeatureName: {olmv1} `deploymentConfig` API
+include::snippets/technology-preview.adoc[]
+
+[id="olmv1-deployment-config-troubleshooting-validation_{context}"]
+== Validation errors
+
+Check the `Progressing` condition for validation errors when installation fails:
+
+[source,terminal]
+----
+$ oc get clusterextension <extension_name> -o jsonpath='{.status.conditions[?(@.type=="Progressing")].message}'
+----
+
+Common validation errors and resolutions:
+
+Unknown field:: Configuration includes an unsupported field. Remove unsupported fields.
+
+Type mismatch:: Field value does not match the expected type. Verify field types match Kubernetes specifications.
+
+Required field missing:: Mandatory nested field is missing. Complete all required fields in nested structures.
+
+[id="olmv1-deployment-config-troubleshooting-applied_{context}"]
+== Verifying applied configuration
+
+Inspect the Operator deployment to verify applied configurations:
+
+[source,terminal]
+----
+$ oc get deployment -n <namespace> -l olm.operatorframework.io/owner-name=<extension_name> -o yaml
+----
+
+Configuration locations in the deployment specification:
+
+* **Environment variables**: `spec.template.spec.containers[].env` and `spec.template.spec.containers[].envFrom`
+* **Resources**: `spec.template.spec.containers[].resources`
+* **Node selector**: `spec.template.spec.nodeSelector`
+* **Tolerations**: `spec.template.spec.tolerations`
+* **Affinity**: `spec.template.spec.affinity`
+* **Volumes**: `spec.template.spec.volumes` and `spec.template.spec.containers[].volumeMounts`
+* **Annotations**: `metadata.annotations` and `spec.template.metadata.annotations`
+
+[id="olmv1-deployment-config-troubleshooting-conflicts_{context}"]
+== Annotation conflicts
+
+Bundle annotations take precedence over `deploymentConfig` annotations when keys conflict. View the installed bundle information:
+
+[source,terminal]
+----
+$ oc get clusterextension <extension_name> -o jsonpath='{.status.install.bundle}'
+----
+
+This returns the bundle name and version. To see the annotations applied to the Operator pod template:
+
+[source,terminal]
+----
+$ oc get deployment -n <namespace> -l olm.operatorframework.io/owner-name=<extension_name> -o jsonpath='{.items[0].spec.template.metadata.annotations}'
+----
+
+To override a bundle annotation, modify the bundle or accept the bundle value.

--- a/modules/olmv1-inspecting-clusterobjectsets.adoc
+++ b/modules/olmv1-inspecting-clusterobjectsets.adoc
@@ -1,0 +1,46 @@
+// Module included in the following assemblies:
+//
+// * extensions/ce/olmv1-configuring-extensions.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="olmv1-inspecting-clusterobjectsets_{context}"]
+= Inspecting ClusterObjectSets
+
+[role="_abstract"]
+Monitor and troubleshoot cluster extension deployments by viewing ClusterObjectSet phases, resource status, and revision history.
+
+.Procedure
+
+. List all `ClusterObjectSets` in the cluster by entering the following command:
++
+[source,terminal]
+----
+$ oc get clusterobjectsets
+----
+
+. List `ClusterObjectSets` for a specific extension by running the following command:
++
+[source,terminal]
+----
+$ oc get clusterobjectsets -l olm.operatorframework.io/owner-name=<extension_name>
+----
++
+Replace `<extension_name>` with your `ClusterExtension` name.
+
+. View the details of a specific `ClusterObjectSet` by running the following command:
++
+[source,terminal]
+----
+$ oc get clusterobjectset <clusterobjectset_name> -o yaml
+----
++
+Shows deployment phases, resource status, and conditions.
+
+. Check the `ClusterExtension` status to see active revisions by running the following command:
++
+[source,terminal]
+----
+$ oc get clusterextension <extension_name> -o jsonpath='{.status.activeRevisions}{"\n"}'
+----
++
+Shows the active revisions currently deployed.


### PR DESCRIPTION
Version(s): 4.22+

Issue:[OSDOCS-18910](https://redhat.atlassian.net/browse/OSDOCS-18910)

Link to docs preview: https://111495--ocpdocs-pr.netlify.app/openshift-enterprise/latest/extensions/ce/olmv1-configuring-extensions.html

QE review:

[X] QE has approved this change.

Additional information:

## Overview

Documents the deployment configuration API for OLM v1, providing feature parity with OLM v0's `SubscriptionConfig`. Expands the cluster extensions assembly to cover both watch namespace configuration and deployment customization with resource limits and node placement.

## Related Issues
- JIRA: [OSDOCS-18910](https://redhat.atlassian.net/browse/OSDOCS-18910)
- Upstream Feature: [OCPSTRAT-2305](https://redhat.atlassian.net/browse/OCPSTRAT-2305)
- Enhancement Proposal: https://github.com/openshift/enhancements/pull/1915

## Content Added

6 new documentation modules (25.1K):
- olmv1-deployment-config-api.adoc (5.2K) - Core concepts
- olmv1-clusterobjectsets-deployment-mechanism.adoc (3.6K) - Deployment mechanism
- olmv1-customizing-operator-deployments.adoc (2.5K) - Procedures
- olmv1-deployment-config-examples.adoc (4.9K) - Examples
- olmv1-deployment-config-reference.adoc (6.4K) - Field reference
- olmv1-deployment-config-troubleshooting.adoc (2.5K) - Troubleshooting

## Quality Assurance
✅ **DITA compliant** (0 errors)  
✅ **Style guide compliant** (0 errors, 0 warnings)  
✅ **Validated against upstream documentation**  
✅ **Tested on live cluster** (OpenShift 4.22 nightly)
- All commands and jsonpaths verified working
- Label selectors for finding operator deployments confirmed
- Condition paths and status queries tested with cert-manager operator
- Deployment specification paths validated

## Technical Improvements
- Corrected ClusterObjectSet phase names and resource assignments to match upstream implementation
- Fixed ClusterObjectSet phase description for accuracy
- Improved short descriptions for better clarity and DITA compliance
- Updated assembly abstract to reflect expanded scope (watch namespaces + deployment customization)
- Fixed bundle status documentation to clarify output format and added command for retrieving full bundle annotations
- All troubleshooting commands verified against running ClusterExtension resources

**Target**: OpenShift 4.22 (Tech Preview)