### PR TITLE
Remove MS attribute from reused networking module

### DIFF
--- a/modules/nw-ovn-kubernetes-limitations.adoc
+++ b/modules/nw-ovn-kubernetes-limitations.adoc
@@ -8,7 +8,7 @@
 = OVN-Kubernetes IPv6 and dual-stack limitations
 
 [role="abstract"]
-IPv6 and dual-stack networking for the OVN-Kubernetes network plugin in {microshift-short} have specific limitations that affect gateway configuration, routing, and cluster stability.
+IPv6 and dual-stack networking for the OVN-Kubernetes network plugin have limitations that affect gateway configuration, routing, and cluster stability.
 
 // The foll limitation is also recorded in the installation section.
 ifndef::microshift[]


### PR DESCRIPTION
Attribute doesn't render in OCP enterprise docs. 

Version(s):
4.20+

Issue:
N/A

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
