### PR TITLE
DOCPLAN-106: Add context and use cases to guest system logs documentation

### DIFF
--- a/modules/virt-view-guest-system-logs-cli.adoc
+++ b/modules/virt-view-guest-system-logs-cli.adoc
@@ -7,7 +7,9 @@
 = Viewing guest system logs with the CLI
 
 [role="_abstract"]
-To diagnose and troubleshoot issues with a virtual machine (VM) guest, you can view the serial console logs by running the `oc logs` command.
+To diagnose and troubleshoot issues with a virtual machine (VM) guest operating system, you can view the guest system logs by running the `oc logs` command.
+
+include::snippets/virt-guest-system-logs-about.adoc[]
 
 .Prerequisites
 

--- a/modules/virt-view-guest-system-logs-web.adoc
+++ b/modules/virt-view-guest-system-logs-web.adoc
@@ -7,7 +7,9 @@
 = Viewing guest system logs with the web console
 
 [role="_abstract"]
-To diagnose and troubleshoot issues with a virtual machine (VM) guest, you can view the serial console logs by using the web console. 
+To diagnose and troubleshoot issues with a virtual machine (VM) guest operating system, you can view the guest system logs by using the web console.
+
+include::snippets/virt-guest-system-logs-about.adoc[]
 
 .Prerequisites
 

--- a/snippets/virt-guest-system-logs-about.adoc
+++ b/snippets/virt-guest-system-logs-about.adoc
@@ -1,0 +1,8 @@
+// Text snippet included in the following modules:
+//
+// * modules/virt-view-guest-system-logs-cli.adoc
+// * modules/virt-view-guest-system-logs-web.adoc
+
+:_mod-docs-content-type: SNIPPET
+
+Guest system logs capture serial console output from the VM's boot process, kernel messages, and system-level events, which is useful when troubleshooting boot failures, kernel panics, or configuration issues that prevent standard access methods.


### PR DESCRIPTION
Version(s):
4.20+

Issue:
https://redhat.atlassian.net/browse/DOCPLAN-106

Link to docs preview:
- https://111498--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/support/virt-troubleshooting.html#virt-view-guest-system-logs-web_virt-troubleshooting
- https://111498--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/support/virt-troubleshooting.html#virt-view-guest-system-logs-cli_virt-troubleshooting

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
