### PR TITLE
ROX-34505: Adds 4.22 to baseline support range

### DIFF
--- a/modules/enabling-the-plugin.adoc
+++ b/modules/enabling-the-plugin.adoc
@@ -13,7 +13,7 @@ For a fresh installation of {rh-rhacs-first} 4.10, the {rh-rhacs-console-plugin}
 To review enablement status during Operator installation, or to enable the {rh-rhacs-console-plugin} plugin after Operator installation, use the following steps.
 
 .Prerequisites
-* You are running {ocp} version 4.19, 4.20, or 4.21.
+* You are running {ocp} version 4.19, 4.20, 4.21, or 4.22.
 * You are running the {product-title-short} version 4.10 code base for both secured cluster services and Central services.
 * You have access to an {ocp} cluster using an account with Operator installation permissions.
 * As part of the installation process for the {product-title-short} Operator, you will install secured cluster services on the cluster. 


### PR DESCRIPTION
Updates OCP version compatibility for RHACS dynamic plugin as per conversation in https://redhat-internal.slack.com/archives/C08E4UMCWAG/p1777901363803539. New version support range starting in RHACS 4.11

Version(s):
RHACS 4.11

Issue:
https://redhat.atlassian.net/browse/ROX-34505

Link to docs preview:
https://111516--ocpdocs-pr.netlify.app/openshift-acs/latest/configuration/accessing-vulnerability-information-in-web-console.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
