### PR TITLE
OSDOCS-19333: deprecating oc adm release mirror

### DIFF
--- a/disconnected/installing-mirroring-installation-images.adoc
+++ b/disconnected/installing-mirroring-installation-images.adoc
@@ -8,22 +8,27 @@ toc::[]
 
 You can ensure your clusters only use container images that satisfy your organizational controls on external content. Before you install a cluster on infrastructure that you provision in a restricted network, you must mirror the required container images into that environment. By using the `oc adm` command, you can mirror release and catalog images in OpenShift. To mirror container images, you must have a registry for mirroring.
 
+
+// Note to CQA assignee: this deprecation notice is in 4.22+ docs, this should not be backported to 4.20 and 4.21 docs while cherry picking CQAs.
+[IMPORTANT]
+====
+* The `oc adm release mirror` command is deprecated as of {product-title} 4.22 and will be removed in a future release.
+As an alternative, use the oc-mirror plugin v2.
+
+* You must have access to the internet to obtain the necessary container images.
+In this procedure, you place your mirror registry on a mirror host
+that has access to both your network and the internet. If you do not have access
+to a mirror host, use the xref:../disconnected/installing-mirroring-installation-images.adoc#olm-mirror-catalog_installing-mirroring-installation-images[Mirroring Operator catalogs for use with disconnected clusters] procedure to copy images to a device you can move across network boundaries with.
+====
+
 [NOTE]
 ====
-The `oc adm release mirror` command is planned for deprecation in a future release. Additionally, when using this command, release image signatures are not automatically mirrored to the disconnected registry. Missing release signatures prevent cluster upgrades, as `ClusterImagePolicy` requires all release images to be verified. To ensure image signatures are correctly mirrored, it is recommended to use the oc-mirror v2 plugin.
+When using the `oc adm release mirror` command, release image signatures are not automatically mirrored to the disconnected registry. Missing release signatures prevent cluster upgrades, as `ClusterImagePolicy` requires all release images to be verified. To ensure image signatures are correctly mirrored, it is recommended to use the oc-mirror v2 plugin.
 ====
 
 // TODO: Is this procedure going to be marked deprecated for 4.10 so that it could be removed in the future?
 // TODO: Add a link to the TP procedure?
 // TODO: Consider updating the title of this one to indicate the difference? Or wait to make any changes like that til GA, til we know if it'll stick around or be completely replaced by the oc-mirror one?
-
-[IMPORTANT]
-====
-You must have access to the internet to obtain the necessary container images.
-In this procedure, you place your mirror registry on a mirror host
-that has access to both your network and the internet. If you do not have access
-to a mirror host, use the xref:../disconnected/installing-mirroring-installation-images.adoc#olm-mirror-catalog_installing-mirroring-installation-images[Mirroring Operator catalogs for use with disconnected clusters] procedure to copy images to a device you can move across network boundaries with.
-====
 
 [id="prerequisites_installing-mirroring-installation-images"]
 == Prerequisites

--- a/disconnected/updating/mirroring-image-repository.adoc
+++ b/disconnected/updating/mirroring-image-repository.adoc
@@ -39,6 +39,9 @@ The following steps outline the high-level workflow on how to mirror images to a
 
 .. Repeat these steps as needed to update your mirror registry.
 
+// Note to CQA assignee: this deprecation notice is in 4.22+ docs, this should not be backported to 4.20 and 4.21 docs while cherry picking CQAs.
+include::snippets/oc-adm-release-mirror-depr.adoc[]
+
 Compared to using the `oc adm release mirror` command, the oc-mirror plugin has the following advantages:
 
 * It can mirror content other than container images.
@@ -58,6 +61,9 @@ See xref:../../disconnected/about-installing-oc-mirror-v2.adoc#about-installing-
 == Mirroring images using the oc adm release mirror command
 
 You can use the `oc adm release mirror` command to mirror images to your mirror registry.
+
+// Note to CQA assignee: this deprecation notice is in 4.22+ docs, this should not be backported to 4.20 and 4.21 docs while cherry picking CQAs.
+include::snippets/oc-adm-release-mirror-depr.adoc[]
 
 [id="prerequisites_updating-mirroring-disconnected_{context}"]
 === Prerequisites

--- a/modules/agent-install-about-mirroring-for-disconnected-registry.adoc
+++ b/modules/agent-install-about-mirroring-for-disconnected-registry.adoc
@@ -13,6 +13,9 @@ To use mirror images for a disconnected installation with the Agent-based Instal
 You can mirror the release image by using the output of either the `oc adm release mirror` or `oc mirror` command.
 This is dependent on which command you used to set up the mirror registry.
 
+// Note to CQA assignee: this deprecation notice is in 4.22+ docs, this should not be backported to 4.20 and 4.21 docs while cherry picking CQAs.
+include::snippets/oc-adm-release-mirror-depr.adoc[]
+
 The following example shows the output of the `oc adm release mirror` command.
 
 [source,terminal]

--- a/modules/connected-to-disconnected-mirror-images.adoc
+++ b/modules/connected-to-disconnected-mirror-images.adoc
@@ -8,6 +8,9 @@
 
 After the cluster is properly configured, you can mirror the images from your external repositories to the mirror repository.
 
+// Note to CQA assignee: this deprecation notice is in 4.22+ docs, this should not be backported to 4.20 and 4.21 docs while cherry picking CQAs.
+include::snippets/oc-adm-release-mirror-depr.adoc[]
+
 .Procedure
 
 . Mirror the Operator Lifecycle Manager (OLM) images:

--- a/modules/installation-mirror-repository.adoc
+++ b/modules/installation-mirror-repository.adoc
@@ -10,6 +10,9 @@
 [role="_abstract"]
 Mirror the {product-title} image repository to your registry to use during cluster installation or upgrade. Complete the following steps on the mirror host.
 
+// Note to CQA assignee: this deprecation notice is in 4.22+ docs, this should not be backported to 4.20 and 4.21 docs while cherry picking CQAs.
+include::snippets/oc-adm-release-mirror-depr.adoc[]
+
 .Prerequisites
 
 * Your mirror host has access to the internet.

--- a/modules/ipi-install-mirroring-for-disconnected-registry.adoc
+++ b/modules/ipi-install-mirroring-for-disconnected-registry.adoc
@@ -9,6 +9,9 @@
 
 Complete the following steps to mirror the {product-title} image repository for a disconnected registry.
 
+// Note to CQA assignee: this deprecation notice is in 4.22+ docs, this should not be backported to 4.20 and 4.21 docs while cherry picking CQAs.
+include::snippets/oc-adm-release-mirror-depr.adoc[]
+
 .Prerequisites
 
 * Your mirror host has access to the internet.

--- a/snippets/oc-adm-release-mirror-depr.adoc
+++ b/snippets/oc-adm-release-mirror-depr.adoc
@@ -1,0 +1,19 @@
+// Text snippet included in the following assemblies:
+//
+// * disconnected/updating/mirroring-image-repository.adoc
+// * disconnected/installing-mirroring-installation-images.adoc (the snippet itself isn't actually there, but the deprecation notice is in this assembly in plain text)
+//
+// Text snippet included in the following modules:
+//
+// * modules/agent-install-about-mirroring-for-disconnected-registry.adoc
+// * modules/connected-to-disconnected-mirror-images.adoc
+// * modules/installation-mirror-repository.adoc
+// * modules/ipi-install-mirroring-for-disconnected-registry.adoc
+
+:_mod-docs-content-type: SNIPPET
+[IMPORTANT]
+====
+The `oc adm release mirror` command is deprecated as of {product-title} 4.22 and will be removed in a future release.
+
+As an alternative, use the oc-mirror plugin v2.
+====


### PR DESCRIPTION
[OSDOCS-19333](https://redhat.atlassian.net/browse/OSDOCS-19333)

Version(s): 4.22+

This PR adds deprecation notices for the `oc adm release mirror` command.

QE review:
- [x] QE has approved this change.

Previews:

- [Mirroring images using the oc adm release mirror command](https://111518--ocpdocs-pr.netlify.app/openshift-enterprise/latest/disconnected/updating/mirroring-image-repository.html#update-mirror-repository-adm-release-mirror_mirroring-ocp-image-repository) 
- [Mirroring images for a disconnected installation by using the oc adm command](https://111518--ocpdocs-pr.netlify.app/openshift-enterprise/latest/disconnected/installing-mirroring-installation-images)
- [About mirroring the OpenShift Container Platform image repository for a disconnected registry](https://111518--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_with_agent_based_installer/understanding-disconnected-installation-mirroring.html#agent-install-about-mirroring-for-disconnected-registry_understanding-disconnected-installation-mirroring)
- [Mirroring the images](https://111518--ocpdocs-pr.netlify.app/openshift-enterprise/latest/disconnected/connected-to-disconnected.html#connected-to-disconnected-mirror-images_connected-to-disconnected) (disconnected conversion doc)
- [Mirroring the OpenShift Dedicated image repository](https://111518--ocpdocs-pr.netlify.app/openshift-dedicated/latest/openshift_images/samples-operator-alt-registry.html#installation-mirror-repository_samples-operator-alt-registry) (OpenShift Dedicated doc, preview links below for same page in other distros)