### PR TITLE
OSDOCS-14906 Updating install docs for AWS Dual Stack

### DIFF
--- a/modules/installation-aws-permissions.adoc
+++ b/modules/installation-aws-permissions.adoc
@@ -330,3 +330,16 @@ If you are managing your cloud provider credentials with mint mode, the IAM user
 * `ec2:DescribePublicIpv4Pools`
 * `ec2:DisassociateAddress`
 ====
+
+.Required permissions to install a cluster with dual-stack networking
+[%collapsible]
+====
+* `ec2:DescribeEgressOnlyInternetGateways`
+* `ec2:CreateEgressOnlyInternetGateway`
+====
+
+.Required permissions to delete a cluster with dual-stack networking
+[%collapsible]
+====
+* `ec2:DeleteEgressOnlyInternetGateway`
+====

--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -325,11 +325,11 @@ endif::ibm-power-vc[]
 
 You can customize your installation configuration based on the requirements of your existing network infrastructure. For example, you can expand the IP address block for the cluster network or configure different IP address blocks than the defaults.
 
-ifndef::agent,bare,ibm-power,ibm-z,vsphere,osp[]
+ifndef::agent,aws,bare,ibm-power,ibm-z,vsphere,osp[]
 Only IPv4 addresses are supported.
-endif::agent,bare,ibm-power,ibm-z,vsphere,osp[]
+endif::agent,aws,bare,ibm-power,ibm-z,vsphere,osp[]
 
-ifdef::agent,bare,ibm-power,ibm-z,vsphere,osp[]
+ifdef::agent,aws,bare,ibm-power,ibm-z,vsphere,osp[]
 Consider the following information before you configure network parameters for your cluster:
 
 * If you use the {openshift-networking} OVN-Kubernetes network plugin, both IPv4 and IPv6 address families are supported.
@@ -371,7 +371,9 @@ networking:
   - 172.30.0.0/16
   - fd00:172:16::/112
 ----
-endif::agent,bare,ibm-power,ibm-z,vsphere,osp[]
+If you are installing your cluster on {aws-short}, the order of address families must match the `platform.aws.ipFamily` parameter. For example, if you specified the `DualStackIPv6Primary` parameter, you must list the IPv6 address first.
+
+endif::agent,aws,bare,ibm-power,ibm-z,vsphere,osp[]
 
 ifdef::osp[]
 [NOTE]
@@ -424,20 +426,20 @@ If you specify multiple IP address blocks, the blocks must not overlap.
 
 [source,yaml]
 ----
-ifndef::agent,bare[]
+ifndef::agent,aws,bare[]
 networking:
   clusterNetwork:
   - cidr: 10.128.0.0/14
     hostPrefix: 23
-endif::agent,bare[]
-ifdef::agent,bare[]
+endif::agent,aws,bare[]
+ifdef::agent,aws,bare[]
 networking:
   clusterNetwork:
   - cidr: 10.128.0.0/14
     hostPrefix: 23
   - cidr: fd01::/48
     hostPrefix: 64
-endif::agent,bare[]
+endif::agent,aws,bare[]
 ----
 
 |networking:
@@ -449,14 +451,12 @@ ifndef::agent,bare[]
 An IPv4 network.
 endif::agent,bare[]
 
-ifdef::agent,bare[]
+ifdef::agent,aws,bare[]
 If you use the OVN-Kubernetes network plugin, you can specify IPv4 and IPv6 networks.
-endif::agent,bare[]
 
 *Value:* An IP address block in Classless Inter-Domain Routing (CIDR) notation. The prefix length for an IPv4 block is between `0` and `32`.
-ifdef::agent,bare[]
 The prefix length for an IPv6 block is between `0` and `128`. For example, `10.128.0.0/14` or `fd01::/48`.
-endif::agent,bare[]
+endif::agent,aws,bare[]
 
 |networking:
   clusterNetwork:
@@ -469,35 +469,33 @@ ifndef::agent,bare[]
 The default value is `23`.
 endif::agent,bare[]
 
-ifdef::agent,bare[]
-For an IPv4 network the default value is `23`. For an IPv6 network the default value is `64`. The default value is also the minimum value for IPv6.
-endif::agent,bare[]
+ifdef::agent,aws,bare[]
+For an IPv4 network the default value is `23`. For an IPv6 network `hostPrefix` must be set to `64`, which is the default value.
+endif::agent,aws,bare[]
 
 |networking:
   serviceNetwork:
 |The IP address block for services. The default value is `172.30.0.0/16`.
 
-The OVN-Kubernetes network plugins supports only a single IP address block for the service network.
-
-ifdef::agent,bare[]
+ifdef::agent,aws,bare[]
 If you use the OVN-Kubernetes network plugin, you can specify an IP address block for both of the IPv4 and IPv6 address families.
-endif::agent,bare[]
+endif::agent,aws,bare[]
 
 *Value:* An array with an IP address block in CIDR format. For example:
 
 [source,yaml]
 ----
-ifndef::agent,bare[]
+ifndef::agent,aws,bare[]
 networking:
   serviceNetwork:
    - 172.30.0.0/16
-endif::agent,bare[]
-ifdef::agent,bare[]
+endif::agent,aws,bare[]
+ifdef::agent,aws,bare[]
 networking:
   serviceNetwork:
    - 172.30.0.0/16
    - fd02::/112
-endif::agent,bare[]
+endif::agent,aws,bare[]
 ----
 
 |networking:
@@ -545,6 +543,13 @@ endif::ibm-power-vs[]
 [NOTE]
 ====
 Set the `networking.machineNetwork` to match the CIDR that the preferred NIC resides in.
+
+If you are installing a cluster on {aws-short} with dual-stack networking, consider the following distinction:
+
+* If the installation program creates the VPC, do not specify an IPv6 entry in `networking.machineNetwork`. The installation program will assign an IPv6 address to the VPC.
+* If you provide existing dual-stack subnets using the `platform.aws.vpc.subnets` parameter, you must specify IPv6 entries corresponding to either the VPC CIDR or the CIDR of the subnets.
+* In both cases, you must provide an IPv4 CIDR entry.
+
 ====
 
 |networking:
@@ -911,9 +916,11 @@ ifdef::aws[]
 |platform:
   aws:
     lbType:
-|Required to set the NLB load balancer type in AWS. Valid values are `Classic` or `NLB`. If no value is specified, the installation program defaults to `Classic`. The installation program sets the value provided here in the ingress cluster configuration object. If you do not specify a load balancer type for other Ingress Controllers, they use the type set in this parameter.
+|Required to set the NLB load balancer type in {aws-short}. Valid values are `Classic` or `NLB`. If no value is specified, the installation program defaults to `Classic`. The installation program sets the value provided here in the ingress cluster configuration object. If you do not specify a load balancer type for other Ingress Controllers, they use the type set in this parameter.
 
-*Value:* `Classic` or `NLB`. The default value is `Classic`.
+If you installed your cluster using the `DualStackIPv4Primary` or `DualStackIPv6Primary` values for the `platform.aws.ipFamily` parameter, any services that have IPv6 addresses must use the NLB load balancer type. The classic load balancer (CLB) does not support IPv6.
+
+*Value:* `Classic` or `NLB`. If you do not set the `platform.aws.ipFamily` parameter or set it to `IPv4`, the default value is `Classic`. If you set the `platform.aws.ipFamily` parameter to `DualStackIPv4Primary` or `DualStackIPv6Primary`, the default value is `NLB`.
 endif::aws[]
 endif::openshift-origin[]
 
@@ -1309,11 +1316,32 @@ You can enable BYOIP only for customized installations that do not have any netw
 
 |platform:
   aws:
+    ipFamily:
+|The IP address family for networks used by the cluster. Specify `IPv4`` for IPv4-only networking, `DualStackIPv4Primary` for dual-stack networking with IPv4 as the primary address family, or `DualStackIPv6Primary` for dual-stack networking with IPv6 as the primary address family. When using dual-stack, the VPC and subnets must be configured with both IPv4 and IPv6 CIDR blocks.
+
+Consider the following requirements if you use dual-stack networking:
+
+* All API and Ingress load balancers must be Network Load Balancers (NLB). Classic Load Balancers (CLB) do not support IPv6 addressing.
+* All machines in a dual-stack cluster must be Nitro-based and support IPv6 addressing.
+* If you are installing a cluster using existing subnets, all provided subnets must be configured with dual-stack address pools.
+* If you are installing a cluster using Local Zones, you must provide dual-stack subnets. The installation program cannot automatically provision dual-stack subnets in Local Zones.
+* Installing a cluster using dual-stack networking is not supported in Wavelength Zones.
+
+[IMPORTANT]
+====
+Dual-stack networking on {aws-short} is a Technology Preview feature only. Technology Preview features are not supported with Red Hat production service level agreements (SLAs) and might not be functionally complete. Red Hat does not recommend using them in production. These features provide early access to upcoming product features, enabling customers to test functionality and provide feedback during the development process.
+For more information about the support scope of Red Hat Technology Preview features, see link:https://access.redhat.com/support/offerings/techpreview/[Technology Preview Features Support Scope].
+====
+
+*Value:* "IPv4", "DualStackIPv4Primary", or "DualStackIPv6Primary". The default value is "IPv4".
+
+|platform:
+  aws:
     vpc:
       subnets:
 |A list of subnets in an existing VPC to be used in place of automatically created subnets. You specify a subnet by providing the subnet ID and an optional list of roles that apply to that subnet. If you specify subnet IDs but do not specify roles for any subnet, the subnets' roles are decided automatically. If you do not specify any roles, you must ensure that any other subnets in your VPC have the `kubernetes.io/cluster/.*: .*` or `kubernetes.io/cluster/unmanaged: true` tags.
 
-The subnets must be part of the same `machineNetwork[].cidr` ranges that you specify.
+The subnets must be part of the same `networking.machineNetwork[].cidr` ranges that you specify. If you provide dual-stack subnets using this parameter, you must specify IPv6 entries in the `networking.machineNetwork[].cidr` parameter.
 
 For a public cluster, specify a public and a private subnet for each availability zone.
 

--- a/modules/nw-operator-cr.adoc
+++ b/modules/nw-operator-cr.adoc
@@ -72,8 +72,7 @@ The fields for the Cluster Network Operator (CNO) are described in the following
 
 |`spec.clusterNetwork`
 |`array`
-|A list specifying the blocks of IP addresses from which pod IP addresses are
-allocated and the subnet prefix length assigned to each individual node in the cluster. For example:
+|A list specifying the blocks of IP addresses from which pod IP addresses are allocated and the subnet prefix length assigned to each individual node in the cluster. If you use dual-stack networking, specify IPv4 and IPv6 address families. For example:
 
 [source,yaml]
 ----
@@ -81,20 +80,25 @@ spec:
   clusterNetwork:
   - cidr: 10.128.0.0/19
     hostPrefix: 23
-  - cidr: 10.128.32.0/19
-    hostPrefix: 23
+  - cidr: fd01::/48
+    hostPrefix: 64
 ----
+
+If you install a cluster on {aws-short} with dual-stack networking, the order of addresses must match the dual-stack configuration you selected. For example, if you specified the `DualStackIPv4Primary`, list the IPv4 address first.
 
 |`spec.serviceNetwork`
 |`array`
-|A block of IP addresses for services. The OVN-Kubernetes network plugin supports only a single IP address block for the service network. For example:
+|A block of IP addresses for services. If you use dual-stack networking, specify IPv4 and IPv6 address families. For example:
 
 [source,yaml]
 ----
 spec:
   serviceNetwork:
   - 172.30.0.0/14
+  - fd02::/112
 ----
+
+If you install a cluster on {aws-short} with dual-stack networking, the order of addresses must match the dual-stack configuration you selected. For example, if you specified the `DualStackIPv4Primary`, list the IPv4 address first.
 
 ifdef::operator[]
 This value is ready-only and inherited from the `Network.config.openshift.io` object named `cluster` during cluster installation.


### PR DESCRIPTION
Version(s):
4.22

Issue:
https://redhat.atlassian.net/browse/OSDOCS-14906

Link to docs preview:
[Cluster Network Operator config object](https://111527--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/ipi/installing-aws-customizations#nw-operator-cr-cno-object_installing-aws-customizations)
[Required permissions (bottom of the list)](https://111527--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-aws-account#installation-aws-permissions_installing-aws-account)
[Network configuration parameters (introductory paragraph and network parameters)](https://111527--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/installation-config-parameters-aws#installation-configuration-parameters-network_installation-config-parameters-aws)
[Optional configuration parameters (`lbType` parameter update)](https://111527--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/installation-config-parameters-aws#installation-configuration-parameters-optional_installation-config-parameters-aws)
[Optional AWS parameters (`ipFamily` parameter)](https://111527--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/installation-config-parameters-aws#installation-configuration-parameters-optional-aws_installation-config-parameters-aws)

QE review:
- [x] QE has approved this change.
