### PR TITLE
OSDOCS-19333: deprecating oc adm release mirror RN

### DIFF
--- a/modules/rn-ocp-release-notes-deprecated-features.adoc
+++ b/modules/rn-ocp-release-notes-deprecated-features.adoc
@@ -17,3 +17,9 @@ If a `BareMetalHost` resource contains a BMC address with `irmc://` as its URI s
 Once support for this driver is removed, hosts that use `irmc://` URI schemes will become unmanageable.
 +
 For information about updating the `BareMetalHost` resource, see xref:../installing/installing_bare_metal/bare-metal-postinstallation-configuration.adoc#bmo-editing-a-baremetalhost-resource_bare-metal-postinstallation-configuration[Editing a BareMetalHost resource].
+
+Deprecation of the `oc adm release mirror` command::
++
+As of {product-title} 4.22, using the `oc adm release mirror` command to mirror release images has been deprecated and will be removed in a future release.
++
+As an alternative, use the xref:../disconnected/about-installing-oc-mirror-v2.adoc#about-installing-oc-mirror-v2[oc-mirror plugin v2].

--- a/modules/rn-ocp-release-notes-deprecated-removed-tables.adoc
+++ b/modules/rn-ocp-release-notes-deprecated-removed-tables.adoc
@@ -148,6 +148,11 @@
 |Deprecated
 |Deprecated
 |
+
+|`oc adm release mirror` command
+|General Availability
+|General Availability
+|Deprecated
 |====
 
 


### PR DESCRIPTION
[OSDOCS-19333](https://redhat.atlassian.net/browse/OSDOCS-19333)

Version(s): 4.22

This PR adds deprecation notices for the oc adm release mirror command in the release notes.

QE review:
- [x] QE has approved this change.

Previews:
- [OpenShift CLI (oc) deprecated and removed features](https://111528--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-22-release-notes.html#ocp-release-note-cli-dep-rem_release-notes)
- [Deprecated features](https://111528--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-22-release-notes.html#rn-ocp-release-notes-deprecated-features_release-notes)
