### PR TITLE
[SRVLOGIC-933] Release notes for OSL 1.38.0

### DIFF
--- a/about/serverless-release-notes.adoc
+++ b/about/serverless-release-notes.adoc
@@ -15,7 +15,9 @@ include::modules/serverless-tech-preview-features.adoc[leveloffset=+1]
 
 include::modules/serverless-deprecated-removed-features.adoc[leveloffset=+1]
 
-include::modules/serverless-rn-1-37-2.adoc[leveloffset=+1]
+include::modules/serverless-logic-rn-1.38.adoc[leveloffset=+1]
+
+include::modules/serverless-logic-rn-1-37-2.adoc[leveloffset=+1]
 
 include::modules/serverless-rn-1-37-1.adoc[leveloffset=+1]
 
@@ -31,12 +33,3 @@ include::modules/serverless-rn-1-36-0.adoc[leveloffset=+1]
 * link:https://access.redhat.com/support/policy/updates/openshift_operators[OpenShift Operator Life Cycles]
 
 * link:https://knative.dev/blog/[Knative blog]
-
-
-
-
-
-
-
-
-

--- a/modules/serverless-logic-rn-1-37-2.adoc
+++ b/modules/serverless-logic-rn-1-37-2.adoc
@@ -3,8 +3,8 @@
 // * about/serverless-release-notes.adoc
 
 :_mod-docs-content-type: REFERENCE
-[id="serverless-rn-1-37-2_{context}"]
-= Red{nbsp}Hat {ServerlessProductName} 1.37.2
+[id="serverless-logic-rn-1-37-2_{context}"]
+= Red{nbsp}Hat {ServerlessLogicProductName} 1.37.2
 
 [role="_abstract"]
 {ServerlessLogicProductName} 1.37.2 is now available. This release addresses identified Common Vulnerabilities and Exposures (CVEs) to enhance security and reliability. The following notes describe fixed issues that affect {ServerlessLogicProductName} on {ocp-product-title}.

--- a/modules/serverless-logic-rn-1.38.adoc
+++ b/modules/serverless-logic-rn-1.38.adoc
@@ -1,0 +1,71 @@
+// Module included in the following assemblies
+//
+// * about/serverless-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="serverless-logic-rn-1-38-0_{context}"]
+= Red{nbsp}Hat {ServerlessLogicProductName} 1.38
+
+[role="_abstract"]
+{ServerlessLogicProductName} 1.38 is now available. New features, updates, fixed issues, and known issues that pertain to {ServerlessLogicProductName} on {ocp-product-title} are included in the following notes:
+
+[IMPORTANT]
+====
+The following features apply to {ServerlessLogicProductName} 1.38.
+{ServerlessLogicProductName} and {ServerlessProductName} follow different release cadences. This release introduces features for OpenShift Serverless Logic 1.38.
+====
+
+[id="new-features-osl-1-38-0_{context}"]
+== New features
+
+Workflows runtime configuration aligned with Quarkus 3.20.1 format::
+
+This release aligns the workflow runtime configuration with the Quarkus 3.20.1 format. This helps eliminate configuration format warnings from service logs at startup.
++
+link:https://issues.redhat.com/browse/SRVLOGIC-674[SRVLOGIC-674]
+
+Configurable leader lease parameters for the operator::
+
+{ServerlessLogicProductName} supports configuring leader lease parameters for the operator. This enhancement addresses operator pod restarts that can occur in busy clusters due to leader lease timeout issues. The operator includes improved default values and provides configuration options for fine-tuning in specific environments. As a result, the operator helps maintain more stable operation in high-load cluster conditions.
++
+link:https://issues.redhat.com/browse/SRVLOGIC-745[SRVLOGIC-745]
+
+Horizontal Pod Autoscaling support for workflows and Data Index deployments::
+
+{ServerlessLogicProductName} supports configuring Horizontal Pod Autoscaling (HPA) for both SonataFlow workflows and Data Index service deployments. This enhancement enables automatic scaling of these services based on resource utilization. As a result, workflows and Data Index services can scale automatically in response to workload demands.
++
+link:https://issues.redhat.com/browse/SRVLOGIC-764[SRVLOGIC-764]
+
+Pod Disruption Budget support for workflows and Data Index deployments::
+
+{ServerlessLogicProductName} supports configuring Pod Disruption Budgets (PDB) for both SonataFlow workflows and Data Index service deployments. This enhancement protects services from unintended disruptions during voluntary cluster operations such as node reboots or upgrades. As a result, workflows and Data Index services can help maintain availability during planned cluster maintenance activities.
++
+link:https://issues.redhat.com/browse/SRVLOGIC-769[SRVLOGIC-769]
+
+Updated OpenJDK base container images::
+
+This release updates all {ServerlessLogicProductName} container images to use `ubi9/openjdk` version `1.24` as the parent base image. This update addresses identified Common Vulnerabilities and Exposures (CVEs) in the previous version. As a result, container images include the latest security fixes.
++
+link:https://issues.redhat.com/browse/SRVLOGIC-793[SRVLOGIC-793]
+
+
+[id="fixed-issues-osl-1-38-0_{context}"]
+== Fixed issues
+
+Retrying jobs no longer cancel during periodic job loading::
+
+Before this update, periodic job loading cancelled jobs in a retrying state. As a consequence, retrying jobs could terminate unexpectedly. With this release, the Jobs Service no longer cancels retrying jobs during periodic loading. As a result, retrying jobs can complete successfully.
++
+link:https://issues.redhat.com/browse/SRVLOGIC-894[SRVLOGIC-894]
+
+Large schemas with multi-byte characters no longer fail compilation::
+
+Before this update, large schemas containing multi-byte characters exceeded Java compilation byte-size limits. As a consequence, workflows using large schemas with special characters, such as emojis, failed to compile. With this release, the build process splits large schema strings into smaller chunks. As a result, large schemas with multi-byte characters compile successfully.
++
+link:https://issues.redhat.com/browse/SRVLOGIC-914[SRVLOGIC-914]
+
+Subflows no longer remain active after parent workflow cancellation::
+
+Before this update, cancelling a parent workflow did not cancel its active subflows. As a consequence, subflows continued to run after the parent workflow was aborted. With this release, cancelling a parent workflow cancels all associated subflows. As a result, aborting a parent workflow terminates all subflow instances.
++
+link:https://issues.redhat.com/browse/SRVLOGIC-953[SRVLOGIC-953]


### PR DESCRIPTION
Version(s):
- `serverless-docs-1.37`
- `serverless-docs-1.38`

Issue:
- https://redhat.atlassian.net/browse/SRVLOGIC-933

Link to docs preview:
- [OSL 1.38 release notes](https://111531--ocpdocs-pr.netlify.app/openshift-serverless/latest/about/serverless-release-notes.html#serverless-logic-rn-1-38-0_serverless-release-notes)

QE review:
- [ ] QE has approved this change.