### PR TITLE
TELCODOCS-2891: Fix DITA conversion issues in MicroShift workload partitioning

### DIFF
--- a/microshift_configuring/microshift_low_latency/microshift-workload-partitioning.adoc
+++ b/microshift_configuring/microshift_low_latency/microshift-workload-partitioning.adoc
@@ -6,7 +6,8 @@ include::_attributes/attributes-microshift.adoc[]
 
 toc::[]
 
-Workload partitioning divides the node CPU resources into distinct CPU sets. The primary objective is to limit the amount of CPU usage for all control plane components which reserves rest of the device CPU resources for workloads of the user.
+[role="_abstract"]
+Workload partitioning divides the node CPU resources into distinct CPU sets. The primary objective is to limit the amount of CPU usage for all control plane components, which reserves the rest of the device CPU resources for workloads of the user.
 
 Workload partitioning allocates reserved set of CPUs to {microshift-short} services, cluster management workloads, and infrastructure pods, ensuring that the remaining CPUs in the cluster deployment are untouched and available exclusively for non-platform workloads.
 

--- a/modules/microshift-enabling-workload-partitioning.adoc
+++ b/modules/microshift-enabling-workload-partitioning.adoc
@@ -6,50 +6,60 @@
 [id="microshift-enabling-workload-partitioning_{context}"]
 = Enabling workload partitioning
 
+[role="_abstract"]
 To enable workload partitioning on {microshift-short}, make the following configuration changes:
 
 * Update the {microshift-short} `config.yaml` file to include the kubelet configuration file.
 * Create the CRI-O systemd and configuration files.
-* Create and update the systemd configuration file for the {microshift-short} and CRI-O services respectively.
+* Create and update the systemd configuration file for the {microshift-short} and CRI-O services.
 
 .Procedure
 
 . Update the {microshift-short} `config.yaml` file to include the kubelet configuration file to enable and configure CPU Manager for the workloads:
 * Create the kubelet configuration file in the path `/etc/kubernetes/openshift-workload-pinning`. The kubelet configuration directs the kubelet to modify the node resources based on the capacity and allocatable CPUs.
 +
-.kubelet configuration example
+The following is an example kubelet configuration:
++
 [source,yaml]
 ----
 # ...
 {
   "management": {
-    "cpuset": "0,6,7" <1>
+    "cpuset": "<cpuset_value>"
   }
 }
 # ...
 ----
-<1> The `cpuset` applies to a machine with 8 VCPUs (4 cores) and is valid throughout the document.
++
+--
+* `<cpuset_value>` specifies the CPU set for the management workload. For example, `"0,6,7"` applies to a machine with 8 VCPUs (4 cores). This value is valid throughout the document.
+--
 * Update the {microshift-short} config.yaml file in the path `/etc/microshift/config.yaml`. Embed the kubelet configuration in the {microshift-short} `config.yaml` file to enable and configure CPU Manager for the workloads.
 +
-.{microshift-short} `config.yaml` example
+The following is an example {microshift-short} `config.yaml` configuration:
++
 [source,yaml]
 ----
 # ...
 kubelet:
-  reservedSystemCPUs: 0,6,7 <1>
+  reservedSystemCPUs: <reserved_cpus>
   cpuManagerPolicy: static
   cpuManagerPolicyOptions:
-    full-pcpus-only: "true" <2>
+    full-pcpus-only: "<full_pcpus_only>"
   cpuManagerReconcilePeriod: 5s
 # ...
 ----
-<1> Exclusive cpuset for the system daemons and the interrupts/timers.
-<2> kubelet configuration sets the `CPUManagerPolicyOptions` option to `full-pcpus-only` to ensure allocation of whole cores to the containers workload.
++
+--
+* `<reserved_cpus>` specifies the exclusive CPU set for the system daemons and the interrupts/timers, for example `0,6,7`.
+* `<full_pcpus_only>` specifies whether to allocate whole cores to the containers workload. Set to `"true"` to ensure allocation of whole cores.
+--
 
 . Create the CRI-O systemd and configuration files:
 * Create the CRI-O configuration file in the path `/etc/crio/crio.conf.d/20-microshift-workload-partition.conf` which overrides the default configuration that already exists in the `11-microshift-ovn.conf` file.
 +
-.CRI-O configuration example
+The following is an example CRI-O configuration:
++
 [source,yaml]
 ----
 # ...
@@ -64,7 +74,8 @@ resources = { "cpushares" = 0, "cpuset" = "0,6,7" }
 ----
 * Create the systemd file for CRI-O in the path `/etc/systemd/system/crio.service.d/microshift-cpuaffinity.conf`.
 +
-.CRI-O systemd configuration example
+The following is an example CRI-O systemd configuration:
++
 [source,yaml]
 ----
 # ...
@@ -76,7 +87,8 @@ CPUAffinity=0,6,7
 . Create and update the systemd configuration file with `CPUAffinity` value for the {microshift-short} and CRI-O services:
 * Create the {microshift-short} services systemd file in the path `/etc/systemd/system/microshift.service.d/microshift-cpuaffinity.conf`. {microshift-short} will be pinned using the systemd `CPUAffinity` value.
 +
-.{microshift-short} services systemd configuration example
+The following is an example {microshift-short} services systemd configuration:
++
 [source,yaml]
 ----
 # ...
@@ -86,7 +98,8 @@ CPUAffinity=0,6,7
 ----
 * Update the `CPUAffinity` value in the {microshift-short} ovs-vswitchd systemd file in the path `/etc/systemd/system/ovs-vswitchd.service.d/microshift-cpuaffinity.conf`.
 +
-.{microshift-short} ovs-vswitchd systemd configuration example
+The following is an example {microshift-short} ovs-vswitchd systemd configuration:
++
 [source,yaml]
 ----
 # ...
@@ -94,9 +107,10 @@ CPUAffinity=0,6,7
 CPUAffinity=0,6,7
 # ...
 ----
-* Update the `CPUAffinity` value in the {microshift-short} ovsdb-server systemd file in the path `/etc/systemd/system/ovsdb-server.service.d/microshift-cpuaffinity.conf`
+* Update the `CPUAffinity` value in the {microshift-short} ovsdb-server systemd file in the path `/etc/systemd/system/ovsdb-server.service.d/microshift-cpuaffinity.conf`.
 +
-.{microshift-short} ovsdb-server systemd configuration example
+The following is an example {microshift-short} ovsdb-server systemd configuration:
++
 [source,yaml]
 ----
 # ...


### PR DESCRIPTION
## Summary
- Add `[role="_abstract"]` short descriptions to the assembly and module for DITA `<shortdesc>` conversion
- Replace callout markers with user-replaceable placeholders and bullet lists (callouts are unsupported in DITA)
- Convert `.block title` annotations on code blocks to inline text using the "Following Rule"
- Remove "respectively" per Red Hat style guide (DoNotUseTerms)

## Test plan
- [x] Vale AsciiDocDITA linting passes with 0 errors and 0 warnings
- [ ] Verify rendered output in preview build

🤖 Generated with [Claude Code](https://claude.com/claude-code)