### PR TITLE
4.22 RN - TELCODOCS-2483 -  Telecom Grandmaster clocks on Intel Grani…

### DIFF
--- a/modules/rn-ocp-release-notes-new-features.adoc
+++ b/modules/rn-ocp-release-notes-new-features.adoc
@@ -309,6 +309,14 @@ For more information, see xref:../networking/ingress_load_balancing/metallb/abou
 Immutable AWS Network Load Balancer for a service::
 With this release, when deploying a service with the AWS Load Balancer the `service.beta.kubernetes.io/aws-load-balancer-type` annotation is immutable for existing services. To change the load balancer type, you must recreate the service.
 
+PTP Telecom Grandmaster on Intel Granite Rapids-D (Technology Preview)::
++
+You can run a Precision Time Protocol (PTP) Telecom Grandmaster (T-GM) on Intel Granite Rapids-D (GNR-D) servers so a single Global Navigation Satellite System (GNSS) feed synchronizes timing across onboard Network Acceleration Complex (NAC) ports and optional Carter Flat expansion NICs. 
+The PTP Operator drives the `e830` and `e825` hardware plugins for your qualified layout, with Zero Touch Provisioning (ZTP) RAN profiles supplying interface renaming and an example `PtpConfig` aligned to the telco reference manifest.
+PTP T-GM on GNR-D is available as a Technology Preview feature.
++
+For more information, see xref:../networking/advanced_networking/ptp/configuring-ptp.adoc#nw-ptp-granite-rapids-telecom-grandmaster-clock-overview_configuring-ptp[Understand Telecom Grandmaster clocks on Intel Granite Rapids-D hardware].
+
 [id="ocp-release-notes-nodes_{context}"]
 == Nodes
 

--- a/modules/rn-ocp-release-notes-new-features.adoc
+++ b/modules/rn-ocp-release-notes-new-features.adoc
@@ -422,6 +422,14 @@ In this configuration, one time receiver (TR) port synchronizes to an upstream t
 +
 For more information, see xref:../networking/advanced_networking/ptp/configuring-ptp.adoc#nw-ptp-gnrd-t-bc-holdover_configuring-ptp[Configuring GNR-D T-BC holdover on a GNR-D platform].
 
+PTP Telecom Grandmaster on Intel Granite Rapids-D (Technology Preview)::
++
+You can configure a Precision Time Protocol (PTP) Telecom Grandmaster (T-GM) on Intel Granite Rapids-D (GNR-D) servers so a single Global Navigation Satellite System (GNSS) feed synchronizes timing across onboard Network Acceleration Complex (NAC) ports and optional Carter Flat expansion network interface cards (NICs).
+The PTP Operator supports GNR-D deployments with the `e830` and `e825` hardware plugins and an example `PtpConfig` custom resource (CR) that you customize for your qualified hardware layout.
+PTP T-GM on GNR-D is available as a Technology Preview feature.
++
+For more information, see xref:../networking/advanced_networking/ptp/configuring-ptp.adoc#nw-ptp-granite-rapids-telecom-grandmaster-clock-overview_configuring-ptp[Telecom Grandmaster clocks on Intel Granite Rapids-D hardware].
+
 [id="ocp-release-notes-nodes_{context}"]
 == Nodes
 

--- a/modules/rn-ocp-release-notes-technology-preview.adoc
+++ b/modules/rn-ocp-release-notes-technology-preview.adoc
@@ -416,6 +416,11 @@ Fleet Management supersedes Selectable Cluster Inventory in {product-title} 4.20
 |Technology Preview
 |General Availability
 |
+
+|PTP Telecom Grandmaster (T-GM) on Intel Granite Rapids-D (GNR-D)
+|Not Available
+|Not Available
+|Technology Preview
 |====
 
 

--- a/modules/rn-ocp-release-notes-technology-preview.adoc
+++ b/modules/rn-ocp-release-notes-technology-preview.adoc
@@ -444,6 +444,11 @@ Fleet Management supersedes Selectable Cluster Inventory in {product-title} 4.20
 |Not Available
 |Not Available
 |Technology Preview
+
+|PTP Telecom Grandmaster (T-GM) on Intel Granite Rapids-D (GNR-D)
+|Not Available
+|Not Available
+|Technology Preview
 |====
 
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> ---> [TELCODOCS-2483](https://redhat.atlassian.net/browse/TELCODOCS-2483) - Telecom Grandmaster clocks on Intel Granite Rapids-D hardware

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.22
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://redhat.atlassian.net/browse/TELCODOCS-2483
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: [Networking](https://111540--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-22-release-notes.html#ocp-release-notes-networking_release-notes) -> PTP Telecom Grandmaster (T-GM) on Intel Granite Rapids-D (GNR-D)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
