### PR TITLE
OSDOCS-19760 created zstream RNs for 4-19-31

### DIFF
--- a/modules/zstream-4-19-31.adoc
+++ b/modules/zstream-4-19-31.adoc
@@ -1,0 +1,34 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-19-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-19-31_{context}"]
+= RHBA-2026:16165 - {product-title} {product-version}.31 fixed issues advisory
+
+Issued: 13 May 2026
+
+[role="_abstract"]
+{product-title} release {product-version}.31 is now available. The list of fixed issues that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2026:16165[RHBA-2026:16165] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2026:16159[RHBA-2026:16159] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.19.31 --pullspecs
+----
+
+[id="zstream-4-19-31-fixed-issues_{context}"]
+== Fixed issues
+
+There are no notable fixed issues in this release.
+
+[id="zstream-4-19-31-updating_{context}"]
+== Updating
+
+To update an {product-title} 4.19 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
+
+

--- a/release_notes/ocp-4-19-release-notes.adoc
+++ b/release_notes/ocp-4-19-release-notes.adoc
@@ -2977,6 +2977,9 @@ To save the `vmcore` file, use the `crashkernel` setting to reserve 1024 MB of m
 // 4.19.z about errata updates
 include::modules/ocp-release-asynch-errata-updates.adoc[leveloffset=+1]
 
+// 4.19.31 z-stream RNs full document
+include::modules/zstream-4-19-31.adoc[leveloffset=+2]
+
 // 4.19.30 z-stream RNs full document
 include::modules/zstream-4-19-30.adoc[leveloffset=+2]
 


### PR DESCRIPTION
Version(s):
4.19

Issue:
https://redhat.atlassian.net/browse/OSDOCS-19760

Link to docs preview:
https://111544--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-19-release-notes.html#zstream-4-19-31_release-notes

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
