### PR TITLE
OCPBUGS-85045: Updated nw-using-cookies-keep-route-statefulness.adoc …

### DIFF
--- a/modules/nw-using-cookies-keep-route-statefulness.adoc
+++ b/modules/nw-using-cookies-keep-route-statefulness.adoc
@@ -12,7 +12,14 @@
 = Using cookies to keep route statefulness
 
 [role="_abstract"]
-To maintain stateful application traffic during pod restarts or scaling events, configure sticky sessions by using cookies. By using this method, you ensure that all incoming traffic reaches the same endpoint, preventing state loss even if the specific endpoint pod changes.
+To maintain stateful application traffic during pod restarts or scaling events, configure sticky sessions by using cookies. By using this method, you ensure that all incoming traffic reaches the same endpoint. This method helps prevent state loss even if the specific endpoint pod changes.
+
+[IMPORTANT]
+====
+The persistence cookie is enabled by default. For a response that contains the persistence cookie, the OpenShift router automatically appends the `Cache-Control: private` header to the response. This configuration prevents the cookie from being cached. If the persistence cookie was not in place, clients receiving the cached response would be routed to the same pod, resulting in performance and reliability issues.
+
+Applications that need control on `Cache-Control` headers, such as those that serve static content, can experience performance issues. This issues happen if the application cannot properly rely on external caching. For such applications that require full control over caching behavior, consider disabling the persistence cookie.
+====
 
 {product-title} can use cookies to configure session persistence. The Ingress Controller selects an endpoint to handle any user requests, and creates a cookie for the session. The cookie is passed back in the response to the request and the user sends the cookie back with the next request in the session. The cookie tells the Ingress Controller which endpoint is handling the session, ensuring that client requests use the cookie so that they are routed to the same pod.
 

--- a/modules/nw-using-cookies-keep-route-statefulness.adoc
+++ b/modules/nw-using-cookies-keep-route-statefulness.adoc
@@ -12,7 +12,16 @@
 = Using cookies to keep route statefulness
 
 [role="_abstract"]
-To maintain stateful application traffic during pod restarts or scaling events, configure sticky sessions by using cookies. By using this method, you ensure that all incoming traffic reaches the same endpoint, preventing state loss even if the specific endpoint pod changes.
+To maintain stateful application traffic during pod restarts or scaling events, configure sticky sessions by using cookies. By using this method, you ensure that all incoming traffic reaches the same endpoint. This method helps prevent state loss even if the specific endpoint pod changes.
+
+[IMPORTANT]
+====
+The persistence cookie is enabled by default. For a response that contains the persistence cookie, the OpenShift router automatically appends the `Cache-Control: private` header to the response. This configuration prevents the cookie from being cached. 
+
+Missing the header causes intermediate caches to store persistence cookies, routing multiple clients to the same pod. This situation can cause performance and reliability issues.
+
+Applications that need control on `Cache-Control` headers, such as those that serve static content, can experience performance issues. This issues happen if the application cannot properly rely on external caching. For such applications that require full control over caching behavior, consider disabling the persistence cookie.
+====
 
 {product-title} can use cookies to configure session persistence. The Ingress Controller selects an endpoint to handle any user requests, and creates a cookie for the session. The cookie is passed back in the response to the request and the user sends the cookie back with the next request in the session. The cookie tells the Ingress Controller which endpoint is handling the session, ensuring that client requests use the cookie so that they are routed to the same pod.
 

--- a/modules/nw-using-cookies-keep-route-statefulness.adoc
+++ b/modules/nw-using-cookies-keep-route-statefulness.adoc
@@ -12,7 +12,16 @@
 = Use cookies to keep route statefulness
 
 [role="_abstract"]
-To maintain stateful application traffic during pod restarts or scaling events, configure sticky sessions by using cookies. By using this method, you ensure that all incoming traffic reaches the same endpoint, preventing state loss even if the specific endpoint pod changes.
+To maintain stateful application traffic during pod restarts or scaling events, configure sticky sessions by using cookies. By using this method, you ensure that all incoming traffic reaches the same endpoint. This method helps prevent state loss even if the specific endpoint pod changes.
+
+[IMPORTANT]
+====
+The persistence cookie is enabled by default. For a response that contains the persistence cookie, the OpenShift router automatically appends the `Cache-Control: private` header to the response. This configuration prevents the cookie from being cached. 
+
+If the header is not added, intermediate caches store persistence cookies and this routes multiple clients to the same pod. This situation can cause performance and reliability issues.
+
+Applications that need control on `Cache-Control` headers, such as those that serve static content, can experience performance issues. This issues happen if the application cannot properly rely on external caching. For such applications that require full control over caching behavior, consider disabling the persistence cookie.
+====
 
 {product-title} can use cookies to configure session persistence. The Ingress Controller selects an endpoint to handle any user requests, and creates a cookie for the session. The cookie is passed back in the response to the request and the user sends the cookie back with the next request in the session. The cookie tells the Ingress Controller which endpoint is handling the session, ensuring that client requests use the cookie so that they are routed to the same pod.
 


### PR DESCRIPTION
CANNOT PROGRESS THIS WORK UNTIL POST 5.0 AND AEM MIGRATION AS MICROSHIFT MODULES ARE UNDERGOING CONVERSION FROM ASCIIDOC TO DITA.

Version(s):
4.16+

Issue:
[OCPBUGS-85045](https://redhat.atlassian.net/browse/OCPBUGS-85045)

Link to docs preview:

* https://111549--ocpdocs-pr.netlify.app/microshift/latest/microshift_networking/microshift-configuring-routes.html
* https://111549--ocpdocs-pr.netlify.app/openshift-dedicated/latest/networking/ingress_load_balancing/routes/nw-configuring-routes.html
* https://111549--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ingress_load_balancing/routes/nw-configuring-routes.html
* https://111549--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/networking/ingress_load_balancing/routes/nw-configuring-routes.html
* https://111549--ocpdocs-pr.netlify.app/openshift-rosa/latest/networking/ingress_load_balancing/routes/nw-configuring-routes.html


- [x] SME has approved this change (Pablo).
- [x] QE has approved this change (Aashish Radhakrishnan).

If MS update in scope, message into https://redhat-internal.slack.com/archives/C0A88NJ3TC4/p1788553578188229 so module can be re-converted to DITA.
