### PR TITLE
OSDOCS-19645: admin acks for azure and vsphere updates

### DIFF
--- a/modules/update-preparing-azure-vsphere-ack.adoc
+++ b/modules/update-preparing-azure-vsphere-ack.adoc
@@ -1,0 +1,33 @@
+// Module included in the following assemblies:
+//
+// * updating/preparing_for_updates/updating-cluster-prepare.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="update-preparing-azure-vsphere-ack_{context}"]
+= Providing an administrator acknowledgment for Microsoft Azure or VMware vSphere clusters
+
+[role="_abstract"]
+If you are updating a {azure-first} or {vmw-first} cluster from {product-title} 4.21 to 4.22, and you have not configured the `managedBootImages` parameter, the update is blocked with a "_This cluster is Azure or vSphere but lacks a boot image configuration._" message.
+
+The update is blocked intentionally on {azure-short} or {vmw-short} clusters in order to alert you that the default updated boot image behavior is changing between version 4.21 and 4.22 to enable updated boot images by default on those platforms.
+
+To allow the update, you must perform one of the following tasks:
+
+* If you want to allow the feature to be enabled, you must provide an administrator acknowledgment as described in the following procedure before you can update your cluster.
+
+* If you do not want the updated boot image feature enabled, you must explicitly disable the feature for compute nodes and then update your cluster.
+For more information, see "Disabling boot image management".
+
+
+.Prerequisite
+
+* You must have access to the cluster as a user with the `cluster-admin` role.
+
+.Procedure
+
+* Acknowledge that you are aware of the change in the default behavior by running the following command:
++
+[source,terminal]
+----
+$ oc -n openshift-config patch cm admin-acks --patch '{"data":{"ack-4.21-boot-image-opt-out-in-4.22":"true"}}' --type=merge
+----

--- a/updating/preparing_for_updates/updating-cluster-prepare.adoc
+++ b/updating/preparing_for_updates/updating-cluster-prepare.adoc
@@ -19,6 +19,12 @@ Learn more about administrative tasks that cluster admins must perform to succes
 
 There are no Kubernetes API removals in this release.
 
+include::modules/update-preparing-azure-vsphere-ack.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+* xref:../../nodes/nodes/nodes-update-boot-images.adoc#mco-update-boot-images-disable_nodes-update-boot-images[Disabling boot image management]
+
 // Assessing the risk of conditional updates
 include::modules/update-preparing-conditional.adoc[leveloffset=+1]
 


### PR DESCRIPTION
[OSDOCS-19645](https://redhat.atlassian.net/browse/OSDOCS-19645)

Version(s): 4.22 only

This PR adds info about admin acks for vsphere and azure clusters to the "Preparing to update" docs. Relates to #108279

QE review:
- [x] QE has approved this change.

Preview: [Providing an administrator acknowledgement for Microsoft Azure or VMware vSphere clusters](https://111550--ocpdocs-pr.netlify.app/openshift-enterprise/latest/updating/preparing_for_updates/updating-cluster-prepare.html#update-preparing-azure-vsphere-ack_updating-cluster-prepare)
