### PR TITLE
OSDOCS#19111: Adding warning on using default SAs and mentioning that…

### DIFF
--- a/modules/service-accounts-default.adoc
+++ b/modules/service-accounts-default.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * authentication/using-service-accounts.adoc
+// * authentication/using-service-accounts-in-applications.adoc
 
 :_mod-docs-content-type: REFERENCE
 [id="service-accounts-default_{context}"]
@@ -77,6 +77,16 @@ The `deployer` service account is not created if the `DeploymentConfig` cluster 
 
 |`default`
 |Used to run all other pods unless they specify a different service account.
+
+[IMPORTANT]
+====
+Access rights and security privileges tied to the `default` service account apply to every pod in the project that does not specify a different service account. To implement the principle of least privilege and improve auditability, create dedicated service accounts for your workloads instead of using the `default` service account.
+
+While most {product-title} platform components and Operators use dedicated service accounts, the following dynamic tools continue to use the `default` service account to ensure operational efficiency:
+
+* `oc debug`: Uses the `default` service account to avoid the performance overhead of creating and removing unique service accounts for short-lived troubleshooting sessions.
+* `oc adm must-gather`: Uses the `default` service account to collect diagnostic data across the cluster without requiring extensive manual RBAC modifications.
+====
 |===
 
 All service accounts in a project are given the `system:image-puller` role,


### PR DESCRIPTION
… platform components don't use it by default

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.22

Issue:
https://redhat.atlassian.net/browse/OSDOCS-19111

Link to docs preview:
https://111555--ocpdocs-pr.netlify.app/openshift-enterprise/latest/authentication/using-service-accounts-in-applications.html#default-service-accounts-and-roles_using-service-accounts

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
