### PR TITLE
[OSDOCS-14646]: Network isolation docs for HCP

### DIFF
--- a/hosted_control_planes/hcp-networking.adoc
+++ b/hosted_control_planes/hcp-networking.adoc
@@ -9,6 +9,17 @@ toc::[]
 [role="_abstract"]
 Ensure optimal performance with {hcp} by configuring network settings. Those settings include internal subnets and proxy support for control-plane workloads, compute nodes, management clusters, and hosted clusters.
 
+//hcp isolation overview
+include::modules/hcp-isolation-overview.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+ * xref:../hosted_control_planes/hcp-networking.adoc#hcp-isolation_hcp-networking[Control plane isolation]
+ * xref:../hosted_control_planes/hcp-prepare/hcp-distribute-workloads.adoc#hcp-node-labeling_hcp-distribute-workloads[Node labeling for {hcp}]
+
+//control plane isolation
+include::modules/hcp-isolation.adoc[leveloffset=+2]
+
 //ingress and egress for hcp
 include::modules/hcp-ingress-egress-reqs.adoc[leveloffset=+1]
 

--- a/hosted_control_planes/hcp-prepare/hcp-distribute-workloads.adoc
+++ b/hosted_control_planes/hcp-prepare/hcp-distribute-workloads.adoc
@@ -6,22 +6,21 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-Before you get started with {hcp} for {product-title}, you must properly label nodes so that the pods of hosted clusters can be scheduled into infrastructure nodes. Node labeling is also important for the following reasons:
-
-* To ensure high availability and proper workload deployment. For example, to avoid having the control plane workload count toward your {product-title} subscription, you can set the `node-role.kubernetes.io/infra` label.
-* To ensure that control plane workloads are separate from other workloads in the management cluster.
-* To ensure that control plane workloads are configured at the correct multi-tenancy distribution level for your deployment. The distribution levels are as follows:
-
-** Everything shared: Control planes for hosted clusters can run on any node that is designated for control planes.
-** Request serving isolation: Serving pods are requested in their own dedicated nodes.
-** Nothing shared: Every control plane has its own dedicated nodes.
-
-For more information about dedicating a node to a single hosted cluster, see "Labeling management cluster nodes".
+[role="_abstract"]
+In {hcp} for {product-title}, cluster management is separate from cluster workload. As you prepare your deployment, ensure you know how you want to distribute your hosted cluster workloads.
 
 [IMPORTANT]
 ====
 Do not use the management cluster for your workload. Workloads must not run on nodes where control planes run.
 ====
+
+include::modules/hcp-node-labeling.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../hosted_control_planes/hcp-prepare/hcp-distribute-workloads.adoc#hcp-labels-taints_hcp-distribute-workloads[Labeling management cluster nodes]
+* xref:../../hosted_control_planes/hcp-networking.adoc#hcp-isolation-overview_hcp-networking[Network isolation for hosted clusters]
 
 include::modules/hcp-labels-taints.adoc[leveloffset=+1]
 

--- a/modules/hcp-isolation-overview.adoc
+++ b/modules/hcp-isolation-overview.adoc
@@ -1,0 +1,22 @@
+// Module included in the following assemblies:
+//
+// * hosted_control_planes/hcp-networking.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="hcp-isolation-overview_{context}"]
+= Network isolation for hosted clusters
+
+[role="_abstract"]
+To provide distinct, secure environments for multiple hosted clusters that share the same management cluster, you can configure hosted clusters with specific network and virtual machine (VM) isolation levels.
+
+For hosted clusters, network isolation levels include container-based isolation, VM-based isolation, and physical isolation:
+
+Container-based isolation:: With container-based isolation, you use shared compute nodes, and isolation is enforced by policy, namespaces, and control group or SELinux boundaries. Control-plane components run as pods on the management cluster, isolated mainly by Kubernetes or Linux mechanisms, not by giving each hosted cluster its own VM or server. Each control plane runs in a dedicated namespace, with default-deny networking and a network policy that allows only defined traffic. Pods use the restricted security context constraint, with unique identifiers (UIDs) scoped for each namespace.
+
+VM-based isolation:: With VM-based isolation, you run hosted control plane pods inside VMs; for example, on {VirtProductName}. This type of isolation is useful if you require VM-based isolation over container-based isolation for a multitenant management cluster. You add a hypervisor boundary between hosted clusters that share a management cluster. Control plane pods are pinned to dedicated VMs.
+
+Physical isolation:: With physical isolation, you follow a "shared-nothing" approach, where each control plane has its own dedicated node. Nodes for a specific hosted cluster are tainted and labeled with a specific `hypershift.openshift.io/hosted-cluster` value. Security involves the use of a network policy and physical network access control lists (ACLs) across hosted clusters.  
+
+For more information, see "Control plane isolation" and "Distributing hosted cluster workloads".
+
+

--- a/modules/hcp-isolation.adoc
+++ b/modules/hcp-isolation.adoc
@@ -1,14 +1,14 @@
 // Module included in the following assemblies:
 //
 // * hosted_control_planes/hcp-prepare/hcp-distribute-workloads.adoc
+// * hosted_control_planes/hcp-networking.adoc
 
 :_mod-docs-content-type: CONCEPT
 [id="hcp-isolation_{context}"]
 = Control plane isolation
 
+[role="_abstract"]
 You can configure {hcp} to isolate network traffic or control plane pods.
-
-== Network policy isolation
 
 Each hosted control plane is assigned to run in a dedicated Kubernetes namespace. By default, the Kubernetes namespace denies all network traffic.
 
@@ -18,16 +18,17 @@ The following network traffic is allowed through the network policy that is enfo
 * Ingress on port 6443 to the hosted `kube-apiserver` pod for the tenant
 * Metric scraping from the management cluster Kubernetes namespace with the `network.openshift.io/policy-group: monitoring` label is allowed for monitoring
 
+[id="hcp-cp-pod-isolation_{context}"]
 == Control plane pod isolation
 
-In addition to network policies, each hosted control plane pod is run with the `restricted` security context constraint. This policy denies access to all host features and requires pods to be run with a UID and with SELinux context that is allocated uniquely to each namespace that hosts a customer control plane.  
+In addition to network policies, each hosted control plane pod is run with the `restricted` security context constraint. This policy denies access to all host features and requires pods to be run with a unique identifier (UID) and with SELinux context that is allocated uniquely to each namespace that hosts a customer control plane.  
 
 The policy ensures the following constraints:
 
 * Pods cannot run as privileged.
 * Pods cannot mount host directory volumes.
 * Pods must run as a user in a pre-allocated range of UIDs.  
-* Pods must run with a pre-allocated MCS label.
+* Pods must run with a pre-allocated Multi-Category Security (MCS) label.
 * Pods cannot access the host network namespace.
 * Pods cannot expose host network ports.
 * Pods cannot access the host PID namespace.  
@@ -37,7 +38,7 @@ The management components, such as `kubelet` and `crio`, on each management clus
 
 The following SELinux labels are used for key processes and sockets:
 
-* *kubelet*: `system_u:system_r:unconfined_service_t:s0`
-* *crio*: `system_u:system_r:container_runtime_t:s0`
-* *crio.sock*: `system_u:object_r:container_var_run_t:s0` 
-* *<example user container processes>*: `system_u:system_r:container_t:s0:c14,c24`
+`kubelet`:: `system_u:system_r:unconfined_service_t:s0`
+`crio`:: `system_u:system_r:container_runtime_t:s0`
+`crio.sock`:: `system_u:object_r:container_var_run_t:s0` 
+`<example user container processes>`:: `system_u:system_r:container_t:s0:c14,c24`

--- a/modules/hcp-node-labeling.adoc
+++ b/modules/hcp-node-labeling.adoc
@@ -1,0 +1,21 @@
+// Module included in the following assemblies:
+//
+// * hosted_control_planes/hcp-prepare/hcp-distribute-workloads.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="hcp-node-labeling_{context}"]
+= Node labeling for {hcp}
+
+[role="_abstract"]
+Before you get started with {hcp}, you must properly label nodes so that the pods of hosted clusters can be scheduled into infrastructure nodes. 
+
+Node labeling is also important for the following reasons:
+
+* To ensure high availability and proper workload deployment. For example, to avoid having the control plane workload count toward your {product-title} subscription, you can set the `node-role.kubernetes.io/infra` label.
+* To ensure that control plane workloads are separate from other workloads in the management cluster.
+* To ensure that control plane workloads are configured at the correct multi-tenancy distribution level for your deployment. The distribution levels are as follows:
+
+** Everything shared: Control planes for hosted clusters can run on any node that is designated for control planes.
+** Nothing shared: Every control plane has its own dedicated nodes.
+
+For more information about dedicating a node to a single hosted cluster, see "Labeling management cluster nodes".


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.22+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://redhat.atlassian.net/browse/OSDOCS-14646
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
- HCP network isolation: https://111556--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-networking.html#hcp-isolation-overview_hcp-networking
- Distributing cluster workload: https://111556--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-prepare/hcp-distribute-workloads.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
