### PR TITLE
OSDOCS-18075 Updating K8s version in 4.22 RNs

### DIFF
--- a/modules/rn-ocp-about-this-release.adoc
+++ b/modules/rn-ocp-about-this-release.adoc
@@ -4,7 +4,7 @@
 
 [role=”_abstract”]
 // TODO: Update with the relevant information closer to release.
-{product-title} (link:https://access.redhat.com/errata/RHBA-2026:1481[RHBA-2026:1481]) is now available. This release uses link:https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.34.md[Kubernetes 1.34] with CRI-O runtime. New features, changes, and known issues that pertain to {product-title} {product-version} are included in this topic.
+{product-title} (link:https://access.redhat.com/errata/RHBA-2026:1481[RHBA-2026:1481]) is now available. This release uses link:https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.35.md[Kubernetes 1.35] with CRI-O runtime. New features, changes, and known issues that pertain to {product-title} {product-version} are included in this topic.
 
 {product-title} {product-version} clusters are available at https://console.redhat.com/openshift. From the {hybrid-console}, you can deploy {product-title} clusters to either on-premises or cloud environments.
 


### PR DESCRIPTION

Version(s): 4.22
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [OSDOCS-18075](https://redhat.atlassian.net/browse/OSDOCS-18075)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://111561--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-22-release-notes.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [X] Acting QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
