### PR TITLE
[WIP] Add OpenShift Virtualization 4.22.1 release notes placeholder

### DIFF
--- a/virt/release_notes/virt-4-22-1-release-notes.adoc
+++ b/virt/release_notes/virt-4-22-1-release-notes.adoc
@@ -1,0 +1,12 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="virt-4-22-1-release-notes"]
+= {VirtProductName} release notes
+include::_attributes/common-attributes.adoc[]
+:context: virt-4-22-1-release-notes
+
+toc::[]
+
+Do not add or edit release notes here. Edit release notes directly in the branch
+that they are relevant for.
+
+This file is here to allow builds to work.


### PR DESCRIPTION
## Summary
Add placeholder release notes file for OpenShift Virtualization 4.22.1 to the enterprise-4.22 branch.

## Description
This PR adds a placeholder release notes file for OpenShift Virtualization 4.22.1 (z-stream) to the enterprise-4.22 branch. This file is copied from the dummy file on main (PR #111565) and will be populated with actual release notes content.

Changes:
- Created `virt/release_notes/virt-4-22-1-release-notes.adoc`

**Note**: Version attribute updates are handled separately in PR #111565 on the main branch.

## Test plan
- [ ] Verify placeholder file structure is correct
- [ ] Confirm builds pass on enterprise-4.22 branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)