### PR TITLE
[WIP] Add OpenShift Virtualization 4.22.1 dummy release notes file

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -121,9 +121,9 @@ endif::[]
 :opp: OpenShift Platform Plus
 //openshift virtualization (cnv)
 :VirtProductName: OpenShift Virtualization
-:VirtVersion: 4.21
-:HCOVersion: 4.21.0
-:HCOVersionPrev: 4.20.0
+:VirtVersion: 4.22.1
+:HCOVersion: 4.22.1
+:HCOVersionPrev: 4.22.0
 :HCOCliKind: hyperconvergeds.v1beta1.hco.kubevirt.io
 :CNVNamespace: openshift-cnv
 :CNVOperatorDisplayName: OpenShift Virtualization Operator

--- a/virt/release_notes/virt-4-22-1-release-notes.adoc
+++ b/virt/release_notes/virt-4-22-1-release-notes.adoc
@@ -1,0 +1,12 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="virt-4-22-1-release-notes"]
+= {VirtProductName} release notes
+include::_attributes/common-attributes.adoc[]
+:context: virt-4-22-1-release-notes
+
+toc::[]
+
+Do not add or edit release notes here. Edit release notes directly in the branch
+that they are relevant for.
+
+This file is here to allow builds to work.


### PR DESCRIPTION
## Summary
- Add dummy release notes file for OpenShift Virtualization 4.22.1
- Update version attributes to 4.22.1

## Description
This PR adds the necessary files for OpenShift Virtualization 4.22.1 on the main branch:

1. **Dummy release notes file**: Required for builds to pass on main before actual release notes are available in the enterprise branch
2. **Version attribute updates**: Increments versions for the 4.22.1 z-stream release

Changes:
- Created `virt/release_notes/virt-4-22-1-release-notes.adoc` with dummy placeholder content
- Updated `_attributes/common-attributes.adoc`:
  - `:VirtVersion: 4.21` → `4.22.1`
  - `:HCOVersion: 4.21.0` → `4.22.1`
  - `:HCOVersionPrev: 4.20.0` → `4.22.0`

This follows the same pattern as previous dummy files (e.g., PR #50754).

## Test plan
- [ ] Verify builds pass with dummy file and updated attributes on main branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)