### PR TITLE
OSDOCS-18615: SNO vCPU requirement update

### DIFF
--- a/installing/installing_sno/install-sno-installing-sno.adoc
+++ b/installing/installing_sno/install-sno-installing-sno.adoc
@@ -124,6 +124,11 @@ endif::openshift-origin[]
 
 include::modules/install-sno-additional-requirements-for-installing-sno-on-a-cloud-provider.adoc[leveloffset=+2]
 
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../installing/overview/cluster-capabilities.adoc#cluster-capabilities[Cluster capabilities]
+
 include::modules/install-sno-supported-cloud-providers-for-single-node-openshift.adoc[leveloffset=+2]
 
 include::modules/installation-aws_con_installing-sno-on-aws.adoc[leveloffset=+2]

--- a/installing/installing_sno/install-sno-preparing-to-install-sno.adoc
+++ b/installing/installing_sno/install-sno-preparing-to-install-sno.adoc
@@ -15,3 +15,8 @@ toc::[]
 include::modules/install-sno-about-installing-on-a-single-node.adoc[leveloffset=+1]
 
 include::modules/install-sno-requirements-for-installing-on-a-single-node.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../installing/overview/cluster-capabilities.adoc#cluster-capabilities[Cluster capabilities]

--- a/installing/installing_with_agent_based_installer/preparing-to-install-with-agent-based-installer.adoc
+++ b/installing/installing_with_agent_based_installer/preparing-to-install-with-agent-based-installer.adoc
@@ -43,6 +43,8 @@ include::modules/understanding-agent-install.adoc[leveloffset=+1]
 [role="_additional-resources"]
 .Additional resources
 
+* xref:../../installing/overview/cluster-capabilities.adoc#cluster-capabilities[Cluster capabilities]
+
 * xref:../../installing/installing_with_agent_based_installer/preparing-to-install-with-agent-based-installer.adoc#installation-requirements-platform-none_preparing-to-install-with-agent-based-installer[Requirements for a cluster using the platform "none" option]
 
 * xref:../installing_bare_metal/ipi/ipi-install-prerequisites.adoc#network-requirements-increase-mtu_ipi-install-prerequisites[Increase the network MTU]

--- a/modules/install-sno-additional-requirements-for-installing-sno-on-a-cloud-provider.adoc
+++ b/modules/install-sno-additional-requirements-for-installing-sno-on-a-cloud-provider.adoc
@@ -11,7 +11,17 @@ The documentation for installer-provisioned installation on cloud providers is b
 
 * A high availability cluster requires a temporary bootstrap machine, three control plane machines, and at least two compute machines. For a {sno} cluster, you need only a temporary bootstrap machine and one cloud instance for the control plane node and no compute nodes.
 
-* The minimum resource requirements for high availability cluster installation include a control plane node with 4 vCPUs and 100GB of storage. For a {sno} cluster, you must have a minimum of 8 vCPUs and 120GB of storage.
+* The minimum resource requirements for high availability cluster installation include a control plane node with 4 vCPUs and 100GB of storage. For a {sno} cluster, you must have a minimum of 4 vCPUs and 120GB of storage.
++
+[IMPORTANT]
+====
+Running {sno} on 4 vCPUs leaves very little "headroom" for user applications, and creates a high risk of resource contention and performance degradation.
+
+To ensure cluster stability at this threshold, you must take steps to minimize the total resource footprint of the cluster, such as limiting the amount of workloads running on the cluster or limiting cluster capabilities.
+For more information, see "Cluster capabilities".
+
+Otherwise, it is recommended to provide more compute resources to the cluster.
+====
 endif::openshift-origin[]
 ifdef::openshift-origin[]
 = Additional requirements for installing {sno-okd} on a cloud provider
@@ -20,7 +30,17 @@ The documentation for installer-provisioned installation on cloud providers is b
 
 * A high availability cluster requires a temporary bootstrap machine, three control plane machines, and at least two compute machines. For a {sno-okd} cluster, you need only a temporary bootstrap machine and one cloud instance for the control plane node and no worker nodes.
 
-* The minimum resource requirements for high availability cluster installation include a control plane node with 4 vCPUs and 100GB of storage. For a {sno-okd} cluster, you must have a minimum of 8 vCPU cores and 120GB of storage.
+* The minimum resource requirements for high availability cluster installation include a control plane node with 4 vCPUs and 100GB of storage. For a {sno-okd} cluster, you must have a minimum of 4 vCPU cores and 120GB of storage.
++
+[IMPORTANT]
+====
+Running {sno-okd} on 4 vCPUs leaves very little "headroom" for user applications, and creates a high risk of resource contention and performance degradation.
+
+To ensure cluster stability at this threshold, you must take steps to minimize the total resource footprint of the cluster, such as limiting the amount of workloads running on the cluster or limiting cluster capabilities.
+For more information, see "Cluster capabilities".
+
+Otherwise, it is recommended to provide more compute resources to the cluster.
+====
 endif::openshift-origin[]
 
 * The `controlPlane.replicas` setting in the `install-config.yaml` file should be set to `1`.

--- a/modules/install-sno-requirements-for-installing-on-a-single-node.adoc
+++ b/modules/install-sno-requirements-for-installing-on-a-single-node.adoc
@@ -33,8 +33,18 @@ Installing {product-title} on a single node is supported on bare metal and link:
 [options="header"]
 |====
 |Profile|Compute|Memory|Storage
-|Minimum|8 vCPUs|16 GB of RAM| 120 GB
+|Minimum|4 vCPUs|16 GB of RAM| 120 GB
 |====
++
+[IMPORTANT]
+====
+Running {sno} on 4 vCPUs leaves very little "headroom" for user applications, and creates a high risk of resource contention and performance degradation.
+
+To ensure cluster stability at this threshold, you must take steps to minimize the total resource footprint of the cluster, such as limiting the amount of workloads running on the cluster or limiting cluster capabilities.
+For more information, see "Cluster capabilities".
+
+Otherwise, it is recommended to provide more compute resources to the cluster.
+====
 +
 [NOTE]
 ====

--- a/modules/understanding-agent-install.adoc
+++ b/modules/understanding-agent-install.adoc
@@ -62,6 +62,20 @@ Recommended cluster resources for the following topologies:
 |HA cluster|3 to 5|2 and above |8 vCPUs|16 GB of RAM|120 GB
 |====
 
+[NOTE]
+====
+You can use as few as 4 vCPUs for an {sno} cluster.
+
+However, running {sno} on 4 vCPUs leaves very little "headroom" for user applications, and creates a high risk of resource contention and performance degradation.
+
+To ensure cluster stability at this threshold, you must take steps to minimize the total resource footprint of the cluster, such as limiting the amount of workloads running on the cluster or limiting cluster capabilities.
+For more information, see "Cluster capabilities".
+
+Otherwise, it is recommended to provide more compute resources to the cluster.
+====
+
+// Note to CQA assignee, the previous note about 4 vCPUs is for 4.22+ and shouldn't be cherry picked to earlier versions
+
 // These supported platforms are also documented in nodes/nodes/nodes-nodes-adding-node-iso.adoc and installation-configuration-parameters.adoc
 
 In the `install-config.yaml`, specify the platform on which to perform the installation. The following platforms are supported:


### PR DESCRIPTION
[OSDOCS-18615](https://redhat.atlassian.net/browse/OSDOCS-18615)

Version: 4.22+

This PR updates the vCPU requirements for SNO, with admonitions warning about the implications of running such a limited cluster

QE review:
- [x] QE has approved this change.

Previews:
- [Recommended resources for topologies](https://111566--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_with_agent_based_installer/preparing-to-install-with-agent-based-installer.html#agent-based-installer-recommended-resources_preparing-to-install-with-agent-based-installer) (Agent)
- [Additional requirements for installing single-node OpenShift on a cloud provider](https://111566--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_sno/install-sno-installing-sno.html#additional-requirements-for-installing-sno-on-a-cloud-provider_install-sno-installing-sno-with-the-assisted-installer)
- [Requirements for installing OpenShift on a single node](https://111566--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_sno/install-sno-preparing-to-install-sno.html#install-sno-requirements-for-installing-on-a-single-node_install-sno-preparing)