### PR TITLE
OSDOCS-19436# Add documentation for enabling JWKs in GCP workload identity pool OIDC providers.

### DIFF
--- a/modules/cco-ccoctl-creating-at-once.adoc
+++ b/modules/cco-ccoctl-creating-at-once.adoc
@@ -205,12 +205,14 @@ $ ccoctl gcp create-all \
   --name=<name> \// <1>
   --region=<gcp_region> \// <2>
   --project=<gcp_project_id> \// <3>
-  --credentials-requests-dir=<path_to_credentials_requests_directory> <4>
+  --credentials-requests-dir=<path_to_credentials_requests_directory> \// <4>
+  --key-storage-method=<key_storage_method> <5>
 ----
 <1> Specify the user-defined name for all created {gcp-short} resources used for tracking. If you plan to install the {gcp-short} Filestore Container Storage Interface (CSI) Driver Operator, retain this value.
 <2> Specify the {gcp-short} region in which cloud resources will be created.
 <3> Specify the {gcp-short} project ID in which cloud resources will be created.
 <4> Specify the directory containing the files of `CredentialsRequest` manifests to create {gcp-short} service accounts.
+<5> Optional: Specify the method for storing OIDC JWK files. Accepted values are `public-bucket` and `pool-jwk-file`. The default value `public-bucket` creates a public GCS bucket to host the OIDC configuration and JWK files. The `pool-jwk-file` value attaches the JWK directly to the workload identity pool provider without creating a public bucket.
 +
 [NOTE]
 ====

--- a/modules/cco-ccoctl-upgrading.adoc
+++ b/modules/cco-ccoctl-upgrading.adoc
@@ -78,6 +78,7 @@ $ ccoctl gcp create-all \
   --credentials-requests-dir=<path_to_credentials_requests_directory> \// <4>
   --output-dir=<path_to_ccoctl_output_dir> \// <5>
   --public-key-file=<path_to_ccoctl_output_dir>/serviceaccount-signer.public \// <6>
+  --key-storage-method=<key_storage_method> <7>
 ----
 <1> Specify the user-defined name for all created {gcp-short} resources used for tracking.
 <2> Specify the {gcp-short} region in which cloud resources will be created.
@@ -85,6 +86,12 @@ $ ccoctl gcp create-all \
 <4> Specify the directory containing the files of `CredentialsRequest` manifests to create {gcp-short} service accounts.
 <5> Specify the path to the output directory.
 <6> Specify the path to the `serviceaccount-signer.public` file that you extracted from the cluster.
+<7> Optional: Specify the method for storing OIDC JWK files. Accepted values are `public-bucket` and `pool-jwk-file`. The default value `public-bucket` creates a public GCS bucket to host the OIDC configuration and JWK files. The `pool-jwk-file` value attaches the JWK directly to the workload identity pool provider without creating a public bucket.
++
+[NOTE]
+=====
+If your cluster was previously configured with the `public-bucket` method and you switch to `pool-jwk-file`, the existing GCS bucket is no longer used. You can delete the old `<name>-oidc` bucket from your {gcp-short} project to avoid retaining an unnecessary public resource.
+=====
 ====
 +
 .{ibm-cloud-title}

--- a/modules/rotating-bound-service-keys.adoc
+++ b/modules/rotating-bound-service-keys.adoc
@@ -18,15 +18,15 @@ ifdef::rotate-aws[= Rotating {aws-short} OIDC bound service account signer keys]
 ifdef::rotate-gcp[= Rotating {gcp-short} OIDC bound service account signer keys]
 ifdef::rotate-azure[= Rotating {azure-short} OIDC bound service account signer keys]
 
-If the Cloud Credential Operator (CCO) for your {product-title} cluster
+[role="_abstract"]
+You can rotate the bound service account signer key for an {product-title} cluster
 ifdef::rotate-aws[on {aws-first}]
 ifdef::rotate-gcp[on {gcp-first}]
 ifdef::rotate-azure[on {azure-first}]
-is configured to operate in manual mode with
-ifdef::rotate-aws[{sts-short},]
-ifdef::rotate-gcp[{gcp-wid-short},]
-ifdef::rotate-azure[{entra-first},]
-you can rotate the bound service account signer key.
+that uses the Cloud Credential Operator (CCO) in manual mode with
+ifdef::rotate-aws[{sts-short}.]
+ifdef::rotate-gcp[{gcp-wid-short}.]
+ifdef::rotate-azure[{entra-first}.]
 
 To rotate the key, you delete the existing key on your cluster, which causes the Kubernetes API server to create a new key.
 To reduce authentication failures during this process, you must immediately add the new public key to the existing issuer file.
@@ -78,6 +78,7 @@ endif::rotate-aws[]
 ifdef::rotate-gcp[]
 CURRENT_ISSUER=$(oc get authentication cluster -o jsonpath='{.spec.serviceAccountIssuer}')
 GCP_BUCKET=$(echo ${CURRENT_ISSUER} | cut -d "/" -f4)
+CLUSTER_NAME=${GCP_BUCKET%-*}
 endif::rotate-gcp[]
 ifdef::rotate-azure[]
 CURRENT_ISSUER=$(oc get authentication cluster -o jsonpath='{.spec.serviceAccountIssuer}')
@@ -257,10 +258,22 @@ $ aws s3api get-object \
 ----
 endif::rotate-aws[]
 ifdef::rotate-gcp[]
+** For {gcp-short} clusters that store OIDC keys in a public bucket, run the following command:
 +
 [source,terminal]
 ----
 $ gcloud storage cp gs://${GCP_BUCKET}/keys.json ${TEMPDIR}/jwks.current.json
+----
+
+** For {gcp-short} clusters that attach OIDC keys directly to the workload identity pool, run the following command:
++
+[source,terminal]
+----
+$ gcloud iam workload-identity-pools providers describe \
+  --format json \
+  --location global \
+  --workload-identity-pool ${CLUSTER_NAME} ${CLUSTER_NAME} \
+  | jq -r ".oidc.jwksJson" > ${TEMPDIR}/jwks.current.json
 ----
 endif::rotate-gcp[]
 ifdef::rotate-azure[]
@@ -295,10 +308,21 @@ $ aws s3api put-object \
 ----
 endif::rotate-aws[]
 ifdef::rotate-gcp[]
+** For {gcp-short} clusters that store OIDC keys in a public bucket, run the following command:
 +
 [source,terminal]
 ----
 $ gcloud storage cp ${TEMPDIR}/jwks.combined.json gs://${GCP_BUCKET}/keys.json
+----
+
+** For {gcp-short} clusters that attach OIDC keys directly to the workload identity pool, run the following command:
++
+[source,terminal]
+----
+$ gcloud iam workload-identity-pools providers update-oidc ${CLUSTER_NAME} \
+  --location=global \
+  --workload-identity-pool=${CLUSTER_NAME} \
+  --jwk-json-path=${TEMPDIR}/jwks.combined.json
 ----
 endif::rotate-gcp[]
 ifdef::rotate-azure[]
@@ -387,10 +411,21 @@ $ aws s3api put-object \
 ----
 endif::rotate-aws[]
 ifdef::rotate-gcp[]
+** For {gcp-short} clusters that store OIDC keys in a public bucket, run the following command:
 +
 [source,terminal]
 ----
 $ gcloud storage cp ${TEMPDIR}/jwks.new.json gs://${GCP_BUCKET}/keys.json
+----
+
+** For {gcp-short} clusters that attach OIDC keys directly to the workload identity pool, run the following command:
++
+[source,terminal]
+----
+$ gcloud iam workload-identity-pools providers update-oidc ${CLUSTER_NAME} \
+  --location=global \
+  --workload-identity-pool=${CLUSTER_NAME} \
+  --jwk-json-path=${TEMPDIR}/jwks.new.json
 ----
 endif::rotate-gcp[]
 ifdef::rotate-azure[]

--- a/modules/rotating-bound-service-keys.adoc
+++ b/modules/rotating-bound-service-keys.adoc
@@ -78,6 +78,7 @@ endif::rotate-aws[]
 ifdef::rotate-gcp[]
 CURRENT_ISSUER=$(oc get authentication cluster -o jsonpath='{.spec.serviceAccountIssuer}')
 GCP_BUCKET=$(echo ${CURRENT_ISSUER} | cut -d "/" -f4)
+CLUSTER_NAME=${GCP_BUCKET%-*}
 endif::rotate-gcp[]
 ifdef::rotate-azure[]
 CURRENT_ISSUER=$(oc get authentication cluster -o jsonpath='{.spec.serviceAccountIssuer}')
@@ -257,10 +258,22 @@ $ aws s3api get-object \
 ----
 endif::rotate-aws[]
 ifdef::rotate-gcp[]
+** For {gcp-short} clusters that store OIDC keys in a public bucket, run the following command:
 +
 [source,terminal]
 ----
 $ gcloud storage cp gs://${GCP_BUCKET}/keys.json ${TEMPDIR}/jwks.current.json
+----
+
+** For {gcp-short} clusters that attach OIDC keys directly to the workload identity pool, run the following command:
++
+[source,terminal]
+----
+$ gcloud iam workload-identity-pools providers describe \
+  --format json \
+  --location global \
+  --workload-identity-pool ${CLUSTER_NAME} ${CLUSTER_NAME} \
+  | jq -r ".oidc.jwksJson" > ${TEMPDIR}/jwks.current.json
 ----
 endif::rotate-gcp[]
 ifdef::rotate-azure[]
@@ -295,10 +308,21 @@ $ aws s3api put-object \
 ----
 endif::rotate-aws[]
 ifdef::rotate-gcp[]
+** For {gcp-short} clusters that store OIDC keys in a public bucket, run the following command:
 +
 [source,terminal]
 ----
 $ gcloud storage cp ${TEMPDIR}/jwks.combined.json gs://${GCP_BUCKET}/keys.json
+----
+
+** For {gcp-short} clusters that attach OIDC keys directly to the workload identity pool, run the following command:
++
+[source,terminal]
+----
+$ gcloud iam workload-identity-pools providers update-oidc ${CLUSTER_NAME} \
+  --location=global \
+  --workload-identity-pool=${CLUSTER_NAME} \
+  --jwk-json-path=${TEMPDIR}/jwks.combined.json
 ----
 endif::rotate-gcp[]
 ifdef::rotate-azure[]
@@ -387,10 +411,21 @@ $ aws s3api put-object \
 ----
 endif::rotate-aws[]
 ifdef::rotate-gcp[]
+** For {gcp-short} clusters that store OIDC keys in a public bucket, run the following command:
 +
 [source,terminal]
 ----
 $ gcloud storage cp ${TEMPDIR}/jwks.new.json gs://${GCP_BUCKET}/keys.json
+----
+
+** For {gcp-short} clusters that attach OIDC keys directly to the workload identity pool, run the following command:
++
+[source,terminal]
+----
+$ gcloud iam workload-identity-pools providers update-oidc ${CLUSTER_NAME} \
+  --location=global \
+  --workload-identity-pool=${CLUSTER_NAME} \
+  --jwk-json-path=${TEMPDIR}/jwks.new.json
 ----
 endif::rotate-gcp[]
 ifdef::rotate-azure[]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.22+

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://redhat.atlassian.net/browse/OSDOCS-19436

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

* (install) Creating Google Cloud resources with the Cloud Credential Operator utility -- https://111570--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-customizations.html#cco-ccoctl-creating-at-once_installing-gcp-customizations
* Updating cloud provider resources with the Cloud Credential Operator utility -- https://111570--ocpdocs-pr.netlify.app/openshift-enterprise/latest/updating/preparing_for_updates/preparing-manual-creds-update.html#cco-ccoctl-upgrading_preparing-manual-creds-update
* Rotating Google Cloud OIDC bound service account signer keys -- https://111570--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/changing-cloud-credentials-configuration#rotating-bound-service-keys_key-rotation-gcp

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->
Release note PR: https://github.com/openshift/openshift-docs/pull/111891

Note to merge reviewer: Due to time constraints, the numerated callouts in these files will need to be reformatted for DITA compliance post-release. Work will be tracked in this card https://redhat.atlassian.net/browse/OSDOCS-19931

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
