### PR TITLE
[OSDOCS#19775]: Added files for 4.20.22 z-stream release notes

### DIFF
--- a/modules/zstream-4-20-22.adoc
+++ b/modules/zstream-4-20-22.adoc
@@ -1,0 +1,31 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-20-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-20-22_{context}"]
+= RHBA-2026:16163 - {product-title} {product-version}.22 fixed issues
+
+Issued: 13 May 2026
+
+[role="_abstract"]
+{product-title} release {product-version}.22 is now available. The list of fixed issues that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2026:16163[RHBA-2026:16163] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2026:16156[RHBA-2026:16156] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.20.22 --pullspecs
+----
+
+[id="zstream-4-20-22-fixed-issues_{context}"]
+== Fixed issues
+
+There are no notable fixed issues for this release.
+
+[id="zstream-4-20-22-updating_{context}"]
+== Updating
+
+To update an {product-title} 4.20 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].

--- a/release_notes/ocp-4-20-release-notes.adoc
+++ b/release_notes/ocp-4-20-release-notes.adoc
@@ -3021,7 +3021,10 @@ In both cases, the installation program generates a user-assigned identity. (lin
 
 include::modules/rn-async-errata.adoc[leveloffset=+1]
 
-// 4.20.20 release notes
+// 4.20.22 release notes
+include::modules/zstream-4-20-22.adoc[leveloffset=+2]
+
+// 4.20.21 release notes
 include::modules/zstream-4-20-21.adoc[leveloffset=+2]
 
 // 4.20.20 release notes


### PR DESCRIPTION
Version(s):
4.20

Issue:
https://redhat.atlassian.net/browse/OSDOCS-19775

Link to docs preview:
https://111577--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-20-release-notes.html#zstream-4-20-22_release-notes

QE review:
N/A
