### PR TITLE
[OSDOCS#19774]: Added files for 4.16.62 z-stream release notes

### DIFF
--- a/modules/zstream-4-16-62.adoc
+++ b/modules/zstream-4-16-62.adoc
@@ -1,0 +1,32 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-16-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-16-62_{context}"]
+= RHBA-2026:16172 - {product-title} {product-version}.62 fixed issues and security updates
+
+Issued: 13 May 2026
+
+[role="_abstract"]
+{product-title} release {product-version}.62 is now available. The list of fixed issues that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2026:16172[RHBA-2026:16172] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2026:16170[RHBA-2026:16170] advisory.
+
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.16.62 --pullspecs
+----
+
+[id="zstream-4-16-62-fixed-issues_{context}"]
+== Fixed issues
+
+There are no notable fixed issues for this release.
+
+[id="zstream-4-16-62-updating_{context}"]
+== Updating
+
+To update an {product-title} 4.16 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].

--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -3390,6 +3390,10 @@ Testing has shown that wake up latencies are under 20μs for over 99.99999% of t
 // 4.16 about async
 include::modules/rn-async-errata.adoc[leveloffset=+1]
 
+// 4.16.62 Rns and updating
+include::modules/zstream-4-16-62.adoc[leveloffset=+2]
+
+
 // 4.16.61 Rns and updating
 include::modules/zstream-4-16-61.adoc[leveloffset=+2]
 


### PR DESCRIPTION

Version(s):
4.16

Issue:
https://redhat.atlassian.net/browse/OSDOCS-19774

Link to docs preview:
https://111579--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html#zstream-4-16-62_release-notes

QE review:
N/A


