### PR TITLE
OCPBUGS-85514: Added parent interface MTU to br-ex docs

### DIFF
--- a/modules/creating-manifest-file-customized-br-ex-bridge-post.adoc
+++ b/modules/creating-manifest-file-customized-br-ex-bridge-post.adoc
@@ -69,11 +69,12 @@ metadata:
 spec:
   nodeSelector:
     kubernetes.io/hostname: worker-0
-    desiredState:
+  desiredState:
     interfaces:
     - name: enp2s0
       type: ethernet
       state: up
+      mtu: 9000
       ipv4:
         enabled: false
       ipv6:
@@ -97,6 +98,7 @@ spec:
       type: ovs-interface
       state: up
       copy-mac-from: enp2s0
+      mtu: 9000
       ipv4:
         enabled: true
         dhcp: true
@@ -120,6 +122,7 @@ where:
 `interfaces.name`:: Specifies the name of the interface.
 `interfaces.type`:: Specifies the type of ethernet.
 `interfaces.state`:: Specifies the requested state for the interface after creation.
+`mtu`:: To ensure network stability and performance, you must explicitly declare the MTU in the manifest for every interface. Do not rely on automatic MTU configuration. The MTU configured on a bridge port or VLAN-tagged interface must not exceed the maximum frame size supported by the attached physical medium. A mismatch causes packet fragmentation or connectivity loss.
 `ipv4.enabled`:: Disables IPv4 and IPv6 in this example.
 `port.name`:: Specifies the node NIC to which the bridge is attached.
 `address.ip`:: Shows the default IPv4 and IPv6 IP addresses. Ensure that you set the masquerade IPv4 and IPv6 IP addresses of your network. 

--- a/modules/creating-manifest-file-customized-br-ex-bridge.adoc
+++ b/modules/creating-manifest-file-customized-br-ex-bridge.adoc
@@ -84,6 +84,7 @@ interfaces:
 - name: enp2s0
   type: ethernet
   state: up
+  mtu: 9000
   ipv4:
     enabled: false
   ipv6:
@@ -107,6 +108,7 @@ interfaces:
   type: ovs-interface
   state: up
   copy-mac-from: enp2s0
+  mtu: 9000
   ipv4:
     enabled: true
     dhcp: true
@@ -120,12 +122,13 @@ interfaces:
 +
 where:
 +
-`interfaces.name`:: Name of the interface.
-`interfaces.type`:: The type of ethernet.
-`interfaces.state`:: The requested state for the interface after creation.
+`interfaces.name`:: Specifies the name of the interface.
+`interfaces.type`:: Specifies the type of ethernet.
+`interfaces.state`:: Specifies the requested state for the interface after creation.
+`mtu`:: To ensure network stability and performance, you must explicitly declare the MTU in the manifest for every interface. Do not rely on automatic MTU configuration. The MTU configured on a bridge port or VLAN-tagged interface must not exceed the maximum frame size supported by the attached physical medium. A mismatch causes packet fragmentation or connectivity loss.
 `ipv4.enabled`:: Disables IPv4 and IPv6 in this example.
-`port.name`:: The node NIC to which the bridge attaches.
-`auto-route-metric`:: Set the parameter to `48` to ensure the `br-ex` default route always has the highest precedence (lowest metric). This configuration prevents routing conflicts with any other interfaces automatically configured by the `NetworkManager` service.
+`port.name`:: Specifies the node NIC to which the bridge attaches.
+`auto-route-metric`:: Sets the parameter to `48` to ensure the `br-ex` default route always has the highest precedence (lowest metric). This configuration prevents routing conflicts with any other interfaces that are automatically configured by the `NetworkManager` service.
 
 . Use the `cat` command to base64-encode the contents of the NMState configuration:
 +
@@ -177,9 +180,9 @@ where:
 +
 `metadata.name`:: Specifies the name of the policy.
 `contents.source`:: Writes the encoded base64 information to the specified path.
-`path`:: For each node in your cluster, specify the hostname path to your node and the base-64 encoded Ignition configuration file data for the machine type. The `worker` role is the default role for nodes in your cluster. Use the `.yml` extension for configuration files. For example, use `$(hostname -s).yml` when specifying the short hostname path for each node or all nodes in the `MachineConfig` manifest file.
+`path`:: For each node in your cluster, specify the hostname path to your node and the base-64 encoded Ignition configuration file data for the machine type. The `worker` role is the default role for nodes in your cluster. You must use the `.yml` extension for configuration files. For example, use `$(hostname -s).yml` when specifying the short hostname path for each node or all nodes in the `MachineConfig` manifest file.
 +
-You can apply a single global configuration to all nodes by using the `/etc/nmstate/openshift/cluster.yml` configuration file. In this case, you do not need to specify individual hostname paths for each node, such as `/etc/nmstate/openshift/<node_hostname>.yml`.
+You can apply a single global configuration to all nodes in your cluster by using the `/etc/nmstate/openshift/cluster.yml` configuration file. In this case, you do not need to specify the short hostname path for each node, such as `/etc/nmstate/openshift/<node_hostname>.yml`. For example:
 +
 .Example /etc/nmstate/openshift/cluster.yml configuration file
 [source,yaml]

--- a/modules/creating-manifest-file-customized-br-ex-bridge.adoc
+++ b/modules/creating-manifest-file-customized-br-ex-bridge.adoc
@@ -16,7 +16,7 @@ endif::[]
 
 [role="_abstract"]
 ifndef::postinstall-bare-metal[]
-By default, {product-title} automatically configures the Open vSwitch (OVS) `br-ex` bridge. For advanced networking requirements, on a bare-metal platform you can override the default behavior by creating a `MachineConfig` object that includes an NMState configuration file. 
+By default, {product-title} automatically configures the Open vSwitch (OVS) `br-ex` bridge. For advanced networking requirements on a bare-metal platform, you can override the default behavior. Create a `MachineConfig` object that includes an NMState configuration file. 
 
 Consider using the customized `br-ex` bridge configuration for any of the following tasks:
 
@@ -30,7 +30,7 @@ endif::postinstall-bare-metal[]
 Consider using the default OVS br-ex bridge configuration if you require a standard environment with a single network interface controller (NIC) and standard OVS settings.
 
 ifdef::postinstall-bare-metal[]
-By default, {product-title} automatically configures the Open vSwitch (OVS) `br-ex` bridge on bare-metal nodes. For advanced networking requirements, you can override the default behavior by creating a `NodeNetworkConfigurationPolicy` (NNCP) custom resource (CR) that includes an NMState configuration file. 
+By default, {product-title} automatically configures the Open vSwitch (OVS) `br-ex` bridge on bare-metal nodes. For advanced networking requirements, you can override the default behavior. Create a `NodeNetworkConfigurationPolicy` (NNCP) custom resource (CR) that includes an NMState configuration file. 
 
 The Kubernetes NMState Operator uses the NMState configuration file to create a customized `br-ex` bridge network configuration on each node in your cluster.
 
@@ -120,6 +120,7 @@ interfaces:
   type: ovs-interface
   state: up
   copy-mac-from: enp2s0
+  mtu: 9000
   ipv4:
     enabled: true
     dhcp: true
@@ -133,12 +134,13 @@ interfaces:
 +
 where:
 +
-`interfaces.name`:: Name of the interface.
-`interfaces.type`:: The type of ethernet.
-`interfaces.state`:: The requested state for the interface after creation.
+`interfaces.name`:: Specifies the name of the interface.
+`interfaces.type`:: Specifies the type of ethernet.
+`interfaces.state`:: Specifies the requested state for the interface after creation.
+`mtu`:: To ensure network stability and performance, you must explicitly declare the MTU in a manifest for both physical and virtual interfaces. Do not rely on automatic inheritance. This ensures that the MTU of a child interface, such as a VLAN or bridge, remains synchronized with its parent interface. Synchronization prevents packet fragmentation or connectivity loss.
 `ipv4.enabled`:: Disables IPv4 and IPv6 in this example.
-`port.name`:: The node NIC to which the bridge attaches.
-`auto-route-metric`:: Set the parameter to `48` to ensure the `br-ex` default route always has the highest precedence (lowest metric). This configuration prevents routing conflicts with any other interfaces that are automatically configured by the `NetworkManager` service.
+`port.name`:: Specifies the node NIC to which the bridge attaches.
+`auto-route-metric`:: Sets the parameter to `48` to ensure the `br-ex` default route always has the highest precedence (lowest metric). This configuration prevents routing conflicts with any other interfaces that are automatically configured by the `NetworkManager` service.
 
 . Use the `cat` command to base64-encode the contents of the NMState configuration:
 +
@@ -182,11 +184,11 @@ spec:
 +
 where:
 +
-`metadata.name`:: The name of the policy.
+`metadata.name`:: Specifies the name of the policy.
 `contents.source`:: Writes the encoded base64 information to the specified path.
-`path`:: For each node in your cluster, specify the hostname path to your node and the base-64 encoded Ignition configuration file data for the machine type. The `worker` role is the default role for nodes in your cluster. You must use the `.yml` extension for configuration files, such as `$(hostname -s).yml` when specifying the short hostname path for each node or all nodes in the `MachineConfig` manifest file.
+`path`:: For each node in your cluster, specify the hostname path to your node and the base-64 encoded Ignition configuration file data for the machine type. The `worker` role is the default role for nodes in your cluster. You must use the `.yml` extension for configuration files. For example, use `$(hostname -s).yml` when specifying the short hostname path for each node or all nodes in the `MachineConfig` manifest file.
 +
-If you have a single global configuration specified in an `/etc/nmstate/openshift/cluster.yml` configuration file that you want to apply to all nodes in your cluster, you do not need to specify the short hostname path for each node, such as `/etc/nmstate/openshift/<node_hostname>.yml`. For example:
+You can apply a single global configuration to all nodes in your cluster by using the `/etc/nmstate/openshift/cluster.yml` configuration file. In this case, you do not need to specify the short hostname path for each node, such as `/etc/nmstate/openshift/<node_hostname>.yml`. For example:
 +
 [source,yaml]
 ----
@@ -252,6 +254,7 @@ spec:
       type: ovs-interface
       state: up
       copy-mac-from: enp2s0
+      mtu: 9000
       ipv4:
         enabled: true
         dhcp: true
@@ -271,12 +274,13 @@ spec:
 +
 where:
 +
-`metadata.name`:: Name of the policy.
-`interfaces.name`:: Name of the interface.
-`interfaces.type`:: The type of ethernet.
-`interfaces.state`:: The requested state for the interface after creation.
+`metadata.name`:: Specifies the name of the policy.
+`interfaces.name`:: Specifies the name of the interface.
+`interfaces.type`:: Specifies the type of ethernet.
+`interfaces.state`:: Specifies the requested state for the interface after creation.
+`mtu`:: To ensure network stability and performance, you must explicitly declare the MTU in a manifest for both physical and virtual interfaces. Do not rely on automatic inheritance. This ensures that the MTU of a child interface, such as a VLAN or bridge, remains synchronized with its parent interface. Synchronization prevents packet fragmentation or connectivity loss.
 `ipv4.enabled`:: Disables IPv4 and IPv6 in this example.
-`port.name`:: The node NIC to which the bridge is attached.
+`port.name`:: Specifies the node NIC to which the bridge is attached.
 `address.ip`:: Shows the default IPv4 and IPv6 IP addresses. Ensure that you set the masquerade IPv4 and IPv6 IP addresses of your network. 
 `auto-route-metric`:: Set the parameter to `48` to ensure the `br-ex` default route always has the highest precedence (lowest metric). This configuration prevents routing conflicts with any other interfaces that are automatically configured by the `NetworkManager` service.
 endif::postinstall-bare-metal[]

--- a/modules/making-disruptive-changes-br-ex-bridge.adoc
+++ b/modules/making-disruptive-changes-br-ex-bridge.adoc
@@ -6,15 +6,16 @@
 [id="making-disruptive-changes-br-ex-bridge.adoc_{context}"]
 = Making disruptive changes to a customized br-ex bridge
 
-For certain situations, you might need to make disruptive changes to a `br-ex` bridge for planned maintenance or network configuration updates. A `br-ex` bridge is a gateway for all external network traffic from your workloads, so any change to the bridge might temporarily disconnect pods and virtual machines (VMs) from an external network.
+[role="_abstract"]
+You might need to make disruptive changes to a `br-ex` bridge for planned maintenance or network configuration updates. A `br-ex` bridge is a gateway for all external network traffic from your workloads. Any change to the bridge might temporarily disconnect pods and virtual machines (VMs) from an external network.
 
-The following procedure uses an example to show making disruptive changes to a `br-ex` bridge that minimizes any impact to running cluster workloads. 
+The following procedure shows how to make disruptive changes to a `br-ex` bridge while minimizing the impact to running cluster workloads. 
 
-For all the nodes in your cluster to receive the `br-ex` bridge changes, you must reboot your cluster. Editing the existing `MachineConfig` object does not force a reboot operation, so you must create an additional `MachineConfig` object to force a reboot operation for the cluster.
+For all the nodes in your cluster to receive the `br-ex` bridge changes, you must reboot your cluster. Editing the existing `MachineConfig` object does not force a reboot operation. You must create an additional `MachineConfig` object to force a cluster reboot.
 
 [IMPORTANT]
 ====
-Red Hat does not support changing IP addresses for nodes as a postintallation task.
+Red Hat does not support changing IP addresses for nodes as a postinstallation task.
 ====
 
 .Prerequisites
@@ -24,20 +25,22 @@ Red Hat does not support changing IP addresses for nodes as a postintallation ta
 
 .Procedure
 
-. Make changes to the NMState configuration file that you created during cluster installation for customizing your `br-ex` bridge network interface.
+. Make changes to the NMState configuration file you created during cluster installation to customize your br-ex bridge network interface.
 +
 [IMPORTANT]
 ====
-Before you save the `MachineConfig` object, check the changed parameter values. If you enter wrong values and save the file, you cannot recover the file to its original state and this impacts networking functionality for your cluster. 
+Before you save the `MachineConfig` object, check the changed parameter values. If you enter wrong values and save the file, you cannot recover the file to its original state and this impacts networking functionality for your cluster.
+
+To ensure network stability and performance, you must explicitly declare the MTU in a manifest for both physical and virtual interfaces. Do not rely on automatic inheritance. This ensures that the MTU of a child interface, such as a VLAN or bridge, remains synchronized with its parent interface. Synchronization prevents packet fragmentation or connectivity loss.
 ====
 
 . Use the `base64` command to re-encode the contents of the NMState configuration by entering the following command:
 +
 [source,terminal]
 ----
-$ base64 -w0 <nmstate_configuration>.yml <1>
+$ base64 -w0 <nmstate_configuration>.yml
 ----
-<1> Replace `<nmstate_configuration>` with the name of your NMState resource YAML file.
+* Replace `<nmstate_configuration>` with the name of your NMState resource YAML file.
 
 . Update the `MachineConfig` manifest file that you created during cluster installation and re-define the customized `br-ex` bridge network interface. 
 
@@ -113,7 +116,7 @@ $ oc delete machineconfig <machine_config_name>
 
 .Verification
 
-* Use the `nmstatectl` tool to check the configuration for the `br-ex` bridge interface by running the following command. The tool checks a node that runs the `br-ex` bridge interface and not the location where you deployed the `MachineConfig` objects.
+* Use the `nmstatectl` tool to check the `br-ex` bridge interface configuration by running the following command. The tool checks a node that runs the `br-ex` bridge interface. The tool does not check the location where you deployed the `MachineConfig` objects.
 +
 [source,terminal]
 ----

--- a/modules/making-disruptive-changes-br-ex-bridge.adoc
+++ b/modules/making-disruptive-changes-br-ex-bridge.adoc
@@ -9,9 +9,9 @@
 [role="_abstract"]
 For certain situations, you might need to make disruptive changes to a `br-ex` bridge for planned maintenance or network configuration updates. A `br-ex` bridge is a gateway for all external network traffic from your workloads, so any change to the bridge might temporarily disconnect pods and virtual machines (VMs) from an external network.
 
-The following procedure uses an example to show making disruptive changes to a `br-ex` bridge that minimizes any impact to running cluster workloads. 
+The following procedure shows how to make disruptive changes to a `br-ex` bridge while minimizing the impact to running cluster workloads. 
 
-For all the nodes in your cluster to receive the `br-ex` bridge changes, you must reboot your cluster. Editing the existing `MachineConfig` object does not force a reboot operation, so you must create an additional `MachineConfig` object to force a reboot operation for the cluster.
+For all the nodes in your cluster to receive the `br-ex` bridge changes, you must reboot your cluster. Editing the existing `MachineConfig` object does not force a reboot operation. You must create an additional `MachineConfig` object to force a cluster reboot.
 
 [IMPORTANT]
 ====
@@ -25,11 +25,13 @@ Red Hat does not support changing IP addresses for nodes as a postinstallation t
 
 .Procedure
 
-. Make changes to the NMState configuration file that you created during cluster installation for customizing your `br-ex` bridge network interface.
+. Make changes to the NMState configuration file you created during cluster installation to customize your br-ex bridge network interface.
 +
 [IMPORTANT]
 ====
-Before you save the `MachineConfig` object, check the changed parameter values. If you enter wrong values and save the file, you cannot recover the file to its original state and this impacts networking functionality for your cluster. 
+Before you save the `MachineConfig` object, check the changed parameter values. If you enter wrong values and save the file, you cannot recover the file to its original state and this impacts networking functionality for your cluster.
+
+To ensure network stability and performance, you must explicitly declare the MTU in the manifest for every interface. Do not rely on automatic MTU configuration. The MTU configured on a bridge port or VLAN-tagged interface must not exceed the maximum frame size supported by the attached physical medium. A mismatch causes packet fragmentation or connectivity loss.
 ====
 
 . Use the `base64` command to re-encode the contents of the NMState configuration by entering the following command:
@@ -115,7 +117,7 @@ $ oc delete machineconfig <machine_config_name>
 
 .Verification
 
-* Use the `nmstatectl` tool to check the configuration for the `br-ex` bridge interface by running the following command. The tool checks a node that runs the `br-ex` bridge interface and not the location where you deployed the `MachineConfig` objects.
+* Use the `nmstatectl` tool to check the `br-ex` bridge interface configuration by running the following command. The tool checks a node that runs the `br-ex` bridge interface. The tool does not check the location where you deployed the `MachineConfig` objects.
 +
 [source,terminal]
 ----

--- a/modules/migrating-br-ex-bridge-nmstate.adoc
+++ b/modules/migrating-br-ex-bridge-nmstate.adoc
@@ -6,7 +6,10 @@
 [id="migrating-br-ex-bridge-nmstate_{context}"]
 = Migrating a configured br-ex bridge to NMState
 
-If you used the `configure-ovs.sh` shell script to set a `br-ex` bridge during cluster installation, you can migrate the `br-ex` bridge to NMState as a postinstallation task. NMState provides a declarative and idempotent way to handle configuring the `br-ex` bridge.
+[role="_abstract"]
+You can migrate a `br-ex` bridge to NMState as a postinstallation task. This applies if you used the `configure-ovs.sh` shell script to set a `br-ex` bridge during cluster installation.
+
+NMState provides a declarative and idempotent way to handle configuring the `br-ex` bridge.
 
 [NOTE]
 ====
@@ -20,7 +23,7 @@ After you migrate your configured `br-ex` bridge to NMState, you cannot reverse 
 Misconfiguring any files that form part of the migration operation can cause disruptive changes to your cluster. Reverting these changes might not always be possible. 
 ====
 
-.Prerequisties 
+.Prerequisites
 
 * You used the `configure-ovs.sh` shell script to set a `br-ex` bridge for your cluster.
 
@@ -41,7 +44,29 @@ where:
 `<nmstate_configuration>`:: Specifies `<nmstate_configuration>` with the name of your NMState resource YAML file.
 --
 
-. Create a `MachineConfig` manifest file and define a customized `br-ex` bridge network configuration in the file. Additionally, ensure that you specify the path to the base64-encoded NMState configuration file so that the contents of this file get embedded in the `MachineConfig` manifest file.
+. Create a `MachineConfig` manifest file and define a customized `br-ex` bridge network configuration in the file. Specify the path to the `base64-encoded` NMState configuration file. This embeds the file contents in the `MachineConfig` manifest file.
++
+[IMPORTANT]
+====
+To ensure network stability and performance, you must explicitly declare the MTU in a manifest for both physical and virtual interfaces. Do not rely on automatic inheritance. This ensures that the MTU of a child interface, such as a VLAN or bridge, remains synchronized with its parent interface. Synchronization prevents packet fragmentation or connectivity loss.
+
+The following example sets the MTU to `9000`, which is from the parent interface, in the `MachineConfig` manifest file:
+
+[source,terminal]
+----
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+# ...
+ - name: br-ex
+      type: ovs-interface
+      state: up
+      copy-mac-from: enp2s0
+      mtu: 9000
+      ipv4:
+# ...
+----
+====
 
 . Apply the updates from the `MachineConfig` object to your cluster by entering the following command:
 +
@@ -108,7 +133,7 @@ $ oc delete machineconfig <machine_config_name>
 
 .Verification
 
-* Use the `nmstatectl` tool to check the configuration for the `br-ex` bridge interface by running the following command. The tool checks a node that runs the `br-ex` bridge interface and not the location where you deployed the `MachineConfig` objects.
+* Use the `nmstatectl` tool to check the configuration for the `br-ex` bridge interface by running the following command. The tool checks a node that runs the `br-ex` bridge interface. The tool does not check the location where you deployed the `MachineConfig` objects.
 +
 [source,terminal]
 ----

--- a/modules/migrating-br-ex-bridge-nmstate.adoc
+++ b/modules/migrating-br-ex-bridge-nmstate.adoc
@@ -38,7 +38,52 @@ $ cat <nmstate_configuration>.yaml | base64
 +
 Replace `<nmstate_configuration>` with the name of your NMState resource YAML file.
 
-. Create a `MachineConfig` manifest file and define a customized `br-ex` bridge network configuration in the file. Additionally, ensure that you specify the path to the base64-encoded NMState configuration file so that the contents of this file get embedded in the `MachineConfig` manifest file.
+. Create a `MachineConfig` manifest file and define a customized `br-ex` bridge network configuration in the file. Specify the path to the `base64-encoded` NMState configuration file. This embeds the file contents in the `MachineConfig` manifest file.
++
+[IMPORTANT]
+====
+To ensure network stability and performance, you must explicitly declare the MTU in the manifest for every interface. Do not rely on automatic MTU configuration. The MTU configured on a bridge port or VLAN-tagged interface must not exceed the maximum frame size supported by the attached physical medium. A mismatch causes packet fragmentation or connectivity loss.
+
+The following example sets the MTU to `9000` for both the physical device and the bridge interface in the NMState configuration file. You must base64-encode the file and then embed the output in a `MachineConfig` manifest file. The `MachineConfig` manifest file writes to `/etc/nmstate/openshift/cluster.yml` or a per-node path under `/etc/nmstate/openshift/`.
+
+.NMState file before encoding
+[source,yaml]
+----
+# ...
+interfaces:
+# ...
+- name: enp2s0
+  type: ethernet
+  state: up
+  mtu: 9000
+# ...
+- name: br-ex
+  type: ovs-interface
+  state: up
+  copy-mac-from: enp2s0
+  mtu: 9000
+# ...
+----
+
+.MachineConfig embeds the encoded file
+[source,yaml]
+----
+# ...
+  kind: MachineConfig
+  metadata:
+# ...
+spec:
+  config:
+# ...
+    storage:
+      files:
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,<base64_encoded_nmstate_configuration>
+# ...
+        path: /etc/nmstate/openshift/cluster.yml
+# ...
+----
+====
 
 . Apply the updates from the `MachineConfig` object to your cluster by entering the following command:
 +
@@ -105,7 +150,7 @@ $ oc delete machineconfig <machine_config_name>
 
 .Verification
 
-* Use the `nmstatectl` tool to check the configuration for the `br-ex` bridge interface by running the following command. The tool checks a node that runs the `br-ex` bridge interface and not the location where you deployed the `MachineConfig` objects.
+* Use the `nmstatectl` tool to check the configuration for the `br-ex` bridge interface by running the following command. The tool checks a node that runs the `br-ex` bridge interface. The tool does not check the location where you deployed the `MachineConfig` objects.
 +
 [source,terminal]
 ----


### PR DESCRIPTION
Version(s):
4.16+

Issue:
[OCPBUGS-85514](https://redhat.atlassian.net/browse/OCPBUGS-85514)

Link to docs preview:

* https://111581--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/bare-metal-postinstallation-configuration.html
* https://111581--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/ipi/ipi-install-installation-workflow.html
* https://111581--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/upi/installing-bare-metal.html
* https://111581--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/upi/installing-bare-metal-network-customizations.html
* https://111581--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/upi/installing-restricted-networks-bare-metal.html

- [x] SME has approved this change.
- [x] QE has approved this change.

