### PR TITLE
OSDOCS-19422: Updated ipi-install-network-requirements.adoc with tool…

### DIFF
--- a/modules/ipi-install-network-requirements.adoc
+++ b/modules/ipi-install-network-requirements.adoc
@@ -6,9 +6,18 @@
 [id="network-requirements_{context}"]
 = Network requirements
 
+[role="_abstract"]
 Installer-provisioned installation of {product-title} involves multiple network requirements. First, installer-provisioned installation involves an optional non-routable `provisioning` network for provisioning the operating system on each bare-metal node. Second, installer-provisioned installation involves a routable `baremetal` network.
 
 image::210_OpenShift_Baremetal_IPI_Deployment_updates_0122_2.png[Installer-provisioned networking]
+
+[IMPORTANT]
+====
+Red Hat supports any valid host network configuration that meets the documented requirements, regardless of how that configuration is applied. However, Red Hat provides support only for the process of applying the configuration that use approved tools. The following list details examples of these tools:
+
+* A documented tool, such as NMState or Kubernetes-NMState.
+* Other tools might be supported to perform a specific task. Red Hat does not support these other tools for general network configuration.
+====
 
 [id="network-requirements-ensuring-required-ports-are-open_{context}"]
 == Ensuring required ports are open
@@ -98,14 +107,16 @@ For the `baremetal` network, a network administrator must reserve several IP add
 . One IP address for each worker node, if applicable.
 
 [IMPORTANT]
-.Reserving IP addresses so they become static IP addresses
 ====
+Reserving IP addresses so they become static IP addresses example:
+
 Some administrators prefer to use static IP addresses so that each node's IP address remains constant in the absence of a DHCP server. To configure static IP addresses with NMState, see "(Optional) Configuring node network interfaces" in the "Setting up the environment for an OpenShift installation" section.
 ====
 
 [IMPORTANT]
-.Networking between external load balancers and control plane nodes
 ====
+Networking between external load balancers and control plane nodes example:
+
 External load balancing services and the control plane nodes must run on the same L2 network, and on the same VLAN when using VLANs to route traffic between the load balancing services and the control plane nodes.
 ====
 

--- a/modules/ipi-install-network-requirements.adoc
+++ b/modules/ipi-install-network-requirements.adoc
@@ -6,9 +6,18 @@
 [id="network-requirements_{context}"]
 = Network requirements
 
+[role="_abstract"]
 Installer-provisioned installation of {product-title} involves multiple network requirements. First, installer-provisioned installation involves an optional non-routable `provisioning` network for provisioning the operating system on each bare-metal node. Second, installer-provisioned installation involves a routable `baremetal` network.
 
 image::210_OpenShift_Baremetal_IPI_Deployment_updates_0122_2.png[Installer-provisioned networking]
+
+[IMPORTANT]
+====
+Red Hat supports any valid host network configuration that meets the documented requirements, regardless of how that configuration is applied. However, Red Hat only supports the configuration application process when approved tools are used. The following list details examples of these tools:
+
+* A documented tool, such as NMState or Kubernetes-NMState.
+* Other tools might be supported to perform a specific task. Red Hat does not support these other tools for general network configurations.
+====
 
 [id="network-requirements-ensuring-required-ports-are-open_{context}"]
 == Ensuring required ports are open
@@ -98,14 +107,16 @@ For the `baremetal` network, a network administrator must reserve several IP add
 . One IP address for each worker node, if applicable.
 
 [IMPORTANT]
-.Reserving IP addresses so they become static IP addresses
 ====
+Reserving IP addresses so they become static IP addresses example:
+
 Some administrators prefer to use static IP addresses so that each node's IP address remains constant in the absence of a DHCP server. To configure static IP addresses with NMState, see "(Optional) Configuring node network interfaces" in the "Setting up the environment for an OpenShift installation" section.
 ====
 
 [IMPORTANT]
-.Networking between external load balancers and control plane nodes
 ====
+Networking between external load balancers and control plane nodes example:
+
 External load balancing services and the control plane nodes must run on the same L2 network, and on the same VLAN when using VLANs to route traffic between the load balancing services and the control plane nodes.
 ====
 

--- a/modules/nw-cluster-mtu-preparing.adoc
+++ b/modules/nw-cluster-mtu-preparing.adoc
@@ -11,7 +11,7 @@ To maintain network stability during an MTU change, you must prepare the configu
 
 .Procedure
 
-. Prepare your configuration for the hardware MTU:
+* Prepare your configuration for the hardware MTU:
 +
 ** If your hardware MTU is specified with DHCP, update your DHCP configuration such as with the following dnsmasq configuration:
 +
@@ -29,8 +29,8 @@ where:
 ** If your hardware MTU is specified with a kernel command line with PXE, update that configuration accordingly.
 +
 ** If your hardware MTU is specified in a NetworkManager connection configuration, complete the following steps. This approach is the default for {product-title} if you do not explicitly specify your network configuration with DHCP, a kernel command line, or some other method. Your cluster nodes must all use the same underlying network configuration for the following procedure to work unmodified.
-
-. Find the primary network interface by entering the following command:
++
+Find the primary network interface by entering the following command:
 +
 [source,terminal]
 ----
@@ -42,8 +42,8 @@ where:
 
 `<node_name>`:: Specifies the name of a node in your cluster.
 --
-
-. Create the following `NetworkManager` configuration in the `<interface>-mtu.conf` file:
++
+Create the following `NetworkManager` configuration in the `<interface>-mtu.conf` file:
 +
 [source,ini]
 ----
@@ -59,4 +59,4 @@ where:
 `<mtu>`:: Specifies the new hardware MTU value.
 --
 +
-** If you used Kubernetes NMState to configure the `br-ex` bridge, use the Kubernetes NMState Operator to update the MTU for the `br-ex` bridge. Changing the MTU for this bridge in a `.nmconnection` file could lead to persistence issues as the Machine Config Operator (MCO) might overwrite the file.
+If you used Kubernetes NMState to configure the `br-ex` bridge, use the Kubernetes NMState Operator to update the MTU for the `br-ex` bridge. Changing the MTU for this bridge in a `.nmconnection` file could lead to persistence issues as the Machine Config Operator (MCO) might overwrite the file.


### PR DESCRIPTION
Version(s):
4.16+

Issue:
[OSDOCS-19422](https://redhat.atlassian.net/browse/OSDOCS-19422)

Link to docs preview:

* https://111582--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/ipi/ipi-install-prerequisites.html#network-requirements_ipi-install-prerequisites
* https://111582--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/advanced_networking/changing-cluster-network-mtu.html#nw-cluster-mtu-preparing_changing-cluster-network-mtu

- [x] SME has approved this change.
- [x] QE has approved this change.
