### PR TITLE
OSDOCS-19366: Warn against wildcard DNS A-records for cluster base domain

### DIFF
--- a/modules/nw-dns-wildcard-warning.adoc
+++ b/modules/nw-dns-wildcard-warning.adoc
@@ -1,0 +1,28 @@
+// Module included in the following assemblies:
+// * networking/networking_operators/dns-operator.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="nw-dns-wildcard-warning_{context}"]
+= Wildcard DNS records and cluster DNS resolution
+
+[role="_abstract"]
+Configuring wildcard DNS A-records for the cluster's base domain can break in-cluster name resolution. Avoid creating wildcard records such as `*._<cluster_name>_._<base_domain>_` in your DNS zone.
+
+[IMPORTANT]
+====
+Wildcard DNS A-records for the cluster's base domain are unsupported and are known to cause in-cluster name resolution failures.
+
+By default, Kubernetes configures pod DNS with `ndots:5`, which means that any DNS name with fewer than five dots is treated as an unqualified name. The resolver appends each search domain from `/etc/resolv.conf` before querying. Internal service names such as `_<service>_._<namespace>_.svc.cluster.local` contain only four dots and are therefore subject to search domain expansion.
+
+If a search domain has a wildcard DNS A-record, the appended query resolves to the wildcard IP address instead of the correct cluster-internal address. This can cause widespread connectivity failures, including the web console becoming unreachable.
+
+To avoid this issue:
+
+* Do not configure wildcard DNS A-records for the cluster's base domain.
+* If you require wildcard records for other purposes, ensure they do not overlap with any domain in the pod search path.
+====
+
+[role="_additional-resources"]
+.Additional resources
+
+* link:https://access.redhat.com/solutions/7024856[Avoiding unnecessary wildcard DNS A-records for your OpenShift 4 cluster]

--- a/networking/networking_operators/dns-operator.adoc
+++ b/networking/networking_operators/dns-operator.adoc
@@ -9,6 +9,8 @@ toc::[]
 [role="_abstract"]
 In {product-title}, the DNS Operator deploys and manages a CoreDNS instance to provide a name resolution service to pods inside the cluster, enables DNS-based Kubernetes Service discovery, and resolves internal `cluster.local` names.
 
+include::modules/nw-dns-wildcard-warning.adoc[leveloffset=+1]
+
 ifdef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 This Operator is installed on {product-title} clusters by default.
 endif::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]


### PR DESCRIPTION
## Summary

Adds documentation warning that wildcard DNS A-records for the cluster's base domain are unsupported and cause in-cluster name resolution failures.

### Changes

- **New module:** `modules/nw-dns-wildcard-warning.adoc` — A CONCEPT module explaining:
  - Wildcard DNS A-records on the cluster base domain break internal service resolution
  - The `ndots:5` default causes service names (with <5 dots) to have search domains appended
  - If those search domains have wildcard records, queries resolve to incorrect external IPs
  - Actionable recommendations to avoid the issue
  - Link to [KB 7024856](https://access.redhat.com/solutions/7024856)

- **Assembly update:** `networking/networking_operators/dns-operator.adoc` — Includes the new module near the top of the page (visible for all product variants)

### Jira References

- **[OSDOCS-19366](https://redhat.atlassian.net/browse/OSDOCS-19366):** Document that wildcard DNS A-records for cluster base domain are unsupported / cause issues
- **OCPBUGS-65769:** Search domains with wild-card from `/etc/resolv.conf` gets appended to DNS queries of any internal service URL within Pod

### Acceptance Criteria (from [OSDOCS-19366](https://redhat.atlassian.net/browse/OSDOCS-19366))

- [x] Documentation includes a clear statement warning against wildcard DNS records for the cluster base domain
- [x] Documentation links to the KB solution for additional context