### PR TITLE
ROX-34571: Release notes for 4.10.3

### DIFF
--- a/modules/bug-fixes-in-version-4103.adoc
+++ b/modules/bug-fixes-in-version-4103.adoc
@@ -1,0 +1,40 @@
+// Module included in the following assemblies:
+//
+// * release_notes/410-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="bug-fixes_4103_{context}"]
+= Bug fixes in version 4.10.3
+
+[role="_abstract"]
+This release provides the following bug fixes:
+
+//ROX-34654
+* Before this update, deployments without generated risk information caused the Risk detail page to crash in the {product-title-short} portal. With this release, Red{nbsp}Hat has corrected the handling of deployments without risk data. As a result, the Risk detail page now displays properly for all deployments.
+
+//ROX-33153
+* Before this update, CVE severity ratings displayed inconsistent values in the {product-title-short} portal. When users viewed the same CVE on different pages, the severity level could appear as "Critical" on the image page but "Important" on the CVE page. With this release, Red{nbsp}Hat has corrected the severity calculation logic. As a result, CVE severity ratings now display consistently across all pages.
+
+This release also addresses the following security vulnerabilities:
+
+//ROX-34518
+* gosaml2:
+** CBC padding panic: Unauthenticated process crash (link:https://github.com/advisories/GHSA-hwqm-qvj9-4jr2[GHSA-hwqm-qvj9-4jr2])
+** Unsigned SAML `LogoutRequest` acceptance (link:https://github.com/advisories/GHSA-pcgw-qcv5-h8ch[GHSA-pcgw-qcv5-h8ch])
+* Axios:
+//ROX-34620
+** Invisible JSON response tampering via prototype pollution gadget (link:https://access.redhat.com/security/cve/CVE-2026-42044[CVE-2026-42044])
+//ROX-34548
+** Authentication bypass due to prototype pollution of HTTP error handling (link:https://access.redhat.com/security/cve/CVE-2026-42041[CVE-2026-42041])
+//ROX-34544
+** Denial of service via unbounded recursion in `toFormData` with deeply nested request data (link:https://access.redhat.com/security/cve/CVE-2026-42039[CVE-2026-42039])
+//ROX-34541
+** NO_PROXY bypass via crafted URL (link:https://access.redhat.com/security/cve/CVE-2026-42043[CVE-2026-42043])
+//ROX-34509
+** HTTP transport hijacking via prototype pollution (link:https://access.redhat.com/security/cve/CVE-2026-42033[CVE-2026-42033])
+//ROX-34460
+** Arbitrary HTTP header injection via prototype pollution (link:https://access.redhat.com/security/cve/CVE-2026-42035[CVE-2026-42035])
+//ROX-34106
+** Server-side request forgery and proxy bypass due to improper hostname normalization (link:https://access.redhat.com/security/cve/CVE-2025-62718[CVE-2025-62718])
+//ROX-34422
+* follow-redirects: Information disclosure via cross-domain redirects (link:https://access.redhat.com/security/cve/CVE-2026-40895[CVE-2026-40895])

--- a/modules/common-attributes.adoc
+++ b/modules/common-attributes.adoc
@@ -64,10 +64,11 @@ endif::[]
 :product-registry: OpenShift image registry
 :olm-first: Operator Lifecycle Manager (OLM)
 :olm: OLM
-:rhacs-version: 4.10.2
+:rhacs-version: 4.10.3
 :ga-date-410: 3 March 2026
 :ga-date-4101: 8 April 2026
 :ga-date-4102: 4 May 2026
+:ga-date-4103: 2 June 2026
 :ocp-supported-version: 4.12
 :ocp-latest-version: 4.21
 :pipelines-shortname: OpenShift Pipelines

--- a/modules/common-attributes.adoc
+++ b/modules/common-attributes.adoc
@@ -64,10 +64,11 @@ endif::[]
 :product-registry: OpenShift image registry
 :olm-first: Operator Lifecycle Manager (OLM)
 :olm: OLM
-:rhacs-version: 4.10.2
+:rhacs-version: 4.10.3
 :ga-date-410: 3 March 2026
 :ga-date-4101: 8 April 2026
 :ga-date-4102: 4 May 2026
+:ga-date-4103: 26 May 2026
 :ocp-supported-version: 4.12
 :ocp-latest-version: 4.21
 :pipelines-shortname: OpenShift Pipelines

--- a/modules/release-dates-410.adoc
+++ b/modules/release-dates-410.adoc
@@ -18,5 +18,6 @@ Review the official release dates and update schedule for {product-title-short} 
 |`4.10.0` | {ga-date-410}
 |`4.10.1` | {ga-date-4101}
 |`4.10.2` | {ga-date-4102}
+|`4.10.3` | {ga-date-4103}
 
 |====

--- a/release_notes/410-release-notes.adoc
+++ b/release_notes/410-release-notes.adoc
@@ -83,6 +83,8 @@ include::modules/bug-fixes-in-version-4101.adoc[leveloffset=+1]
 
 include::modules/bug-fixes-in-version-4102.adoc[leveloffset=+1]
 
+include::modules/bug-fixes-in-version-4103.adoc[leveloffset=+1]
+
 include::modules/known-issues-in-version-4101.adoc[leveloffset=+1]
 
 include::modules/image-versions.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s): 4.10

Issue: [ROX-34571](https://redhat.atlassian.net/browse/ROX-34571)

Link to docs preview: https://111599--ocpdocs-pr.netlify.app/openshift-acs/latest/release_notes/410-release-notes#bug-fixes_4103_release-notes-410

QE review: **ACS has no QE, approved by SME**
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
