### PR TITLE
OSSM_13621_multi-network ingress gateway variables

### DIFF
--- a/modules/ossm-installing-multi-primary-multi-network-mesh-ambient.adoc
+++ b/modules/ossm-installing-multi-primary-multi-network-mesh-ambient.adoc
@@ -7,7 +7,6 @@
 = Installing a multi-primary multi-network mesh in ambient mode
 
 [role="_abstract"]
-
 Install {istio} and configure it for ambient mode in the multi-primary multi-network topology on two {ocp-product-title} clusters.
 
 [NOTE]
@@ -19,7 +18,7 @@ You can adapt these instructions for a mesh spanning more than two clusters.
 
 .Prerequisites
 
-* You have {istio} version 1.27.3 or later.
+* You have {istio} version 1.29.2 or later.
 
 * You have installed the {SMProduct} 3 Operator on all of the clusters that include the mesh.
 
@@ -33,7 +32,7 @@ You can adapt these instructions for a mesh spanning more than two clusters.
 
 * You have installed and configured the MetalLB Operator *if* your environment is on-premise.
 +
-In on-premise environments, such as those running on bare metal, {ocp-product-title} clusters often do not include a native load-balancer capability. As a result, a service of type `LoadBalancer`, such as the `istio-eastwestgateway`, does not automatically assign an external IP address. To ensure the required external IP assignment for cross-cluster communication, cluster administrators must install and configure the MetalLB Operator.
+In on-site environments, such as those running on bare metal, {ocp-product-title} clusters often do not include a native load-balancer capability. As a result, a service of type `LoadBalancer`, such as the `istio-eastwestgateway`, does not automatically assign an external IP address. To ensure the required external IP assignment for cross-cluster communication, cluster administrators must install and configure the MetalLB Operator.
 +
 Once deployed, MetalLB provides a platform-native load balancer. For more information, see link:https://docs.redhat.com/en/documentation/openshift_container_platform/latest/html/networking_operators/metallb-operator[MetalLB Operator].
 
@@ -56,7 +55,7 @@ In addition to bare metal, the MetalLB Operator can offer load balancing for ins
 +
 [source,terminal]
 ----
-$ export ISTIO_VERSION=1.27.3
+$ export ISTIO_VERSION=1.29.2
 ----
 
 . Install {istio} on the East cluster:
@@ -84,8 +83,14 @@ spec:
       trustedZtunnelNamespace: ztunnel
       env:
         AMBIENT_ENABLE_MULTI_NETWORK: "true"
+        AMBIENT_ENABLE_MULTI_NETWORK_INGRESS: "true"
+        AMBIENT_ENABLE_BAGGAGE: "true"
 EOF
 ----
++
+* By setting the `AMBIENT_ENABLE_MULTI_NETWORK` and `AMBIENT_ENABLE_MULTI_NETWORK_INGRESS` environment variables to `true` (as shown in the YAML example), you enable ingress gateways to route requests to clusters on remote networks. Without this configuration, ingress gateways keep traffic local.
+
+* Optional: Set `AMBIENT_ENABLE_BAGGAGE` to `true` to let your waypoint proxies use HTTP headers to automatically find and share information about connected services.
 
 .. Create a project called ztunnel by running the following command:
 +
@@ -94,7 +99,7 @@ EOF
 $ oc get project ztunnel --context "${CTX_CLUSTER1}" || oc new-project ztunnel --context "${CTX_CLUSTER1}"
 ----
 
-.. Create a ztunnel custom resource as shown in the following example: 
+.. Create a ztunnel custom resource as shown in the following example:
 +
 [source,terminal]
 ----
@@ -145,7 +150,7 @@ spec:
 EOF
 ----
 
-.. To ensure the gateway is fully programmed before it begins receiving requests, run the following command. This process includes a three-minute timeout; if the gateway is not ready by then, the command will exit with an error.  
+.. To ensure the gateway is fully programmed before receiving requests, run the following command. If the process exceeds three minutes, the command exits with an error.
 +
 [source,terminal]
 ----
@@ -177,6 +182,8 @@ spec:
       trustedZtunnelNamespace: ztunnel
       env:
         AMBIENT_ENABLE_MULTI_NETWORK: "true"
+        AMBIENT_ENABLE_MULTI_NETWORK_INGRESS: "true"
+        AMBIENT_ENABLE_BAGGAGE: "true"
 EOF
 ----
 
@@ -218,8 +225,8 @@ $ oc --context "${CTX_CLUSTER2}" wait --for condition=Ready istio/default --time
 [source,terminal]
 ----
 $ cat <<EOF | oc --context "${CTX_CLUSTER2}" apply -f -
-kind: Gateway
 apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
 metadata:
   name: istio-eastwestgateway
   namespace: istio-system
@@ -238,7 +245,7 @@ spec:
 EOF
 ----
 
-.. To ensure the gateway is fully programmed before it begins receiving requests, run the following command. This process includes a three-minute timeout; if the gateway is not ready by then, the command will exit with an error.  
+.. To ensure the gateway is fully programmed before receiving requests, run the following command. If the process exceeds three minutes, the command exits with an error.
 +
 [source,terminal]
 ----
@@ -292,5 +299,5 @@ $ istioctl create-remote-secret \
   --context="${CTX_CLUSTER1}" \
   --name=cluster1 \
   --create-service-account=false | \
-  oc --context="${CTX_CLUSTER2}" apply -f -  
+  oc --context="${CTX_CLUSTER2}" apply -f -
 ----

--- a/modules/ossm-installing-multi-primary-multi-network-mesh-ambient.adoc
+++ b/modules/ossm-installing-multi-primary-multi-network-mesh-ambient.adoc
@@ -7,7 +7,6 @@
 = Installing a multi-primary multi-network mesh in ambient mode
 
 [role="_abstract"]
-
 Install {istio} and configure it for ambient mode in the multi-primary multi-network topology on two {ocp-product-title} clusters.
 
 [NOTE]
@@ -19,7 +18,7 @@ You can adapt these instructions for a mesh spanning more than two clusters.
 
 .Prerequisites
 
-* You have {istio} version 1.27.3 or later.
+* You have {istio} version 1.29.2 or later.
 
 * You have installed the {SMProduct} 3 Operator on all of the clusters that include the mesh.
 
@@ -33,7 +32,7 @@ You can adapt these instructions for a mesh spanning more than two clusters.
 
 * You have installed and configured the MetalLB Operator *if* your environment is on-premise.
 +
-In on-premise environments, such as those running on bare metal, {ocp-product-title} clusters often do not include a native load-balancer capability. As a result, a service of type `LoadBalancer`, such as the `istio-eastwestgateway`, does not automatically assign an external IP address. To ensure the required external IP assignment for cross-cluster communication, cluster administrators must install and configure the MetalLB Operator.
+In on-site environments, such as those running on bare metal, {ocp-product-title} clusters often do not include a native load-balancer capability. As a result, a service of type `LoadBalancer`, such as the `istio-eastwestgateway`, does not automatically assign an external IP address. To ensure the required external IP assignment for cross-cluster communication, cluster administrators must install and configure the MetalLB Operator.
 +
 Once deployed, MetalLB provides a platform-native load balancer. For more information, see link:https://docs.redhat.com/en/documentation/openshift_container_platform/latest/html/networking_operators/metallb-operator[MetalLB Operator].
 
@@ -56,7 +55,7 @@ In addition to bare metal, the MetalLB Operator can offer load balancing for ins
 +
 [source,terminal]
 ----
-$ export ISTIO_VERSION=1.27.3
+$ export ISTIO_VERSION=1.29.2
 ----
 
 . Install {istio} on the East cluster:
@@ -80,12 +79,20 @@ spec:
       multiCluster:
         clusterName: cluster1
       network: network1
+    meshConfig:
+      trustDomain: mesh1  
     pilot:
       trustedZtunnelNamespace: ztunnel
       env:
         AMBIENT_ENABLE_MULTI_NETWORK: "true"
+        AMBIENT_ENABLE_MULTI_NETWORK_INGRESS: "true"
+        AMBIENT_ENABLE_BAGGAGE: "true"
 EOF
 ----
++
+* By setting the `AMBIENT_ENABLE_MULTI_NETWORK` and `AMBIENT_ENABLE_MULTI_NETWORK_INGRESS` environment variables to `true` (as shown in the YAML example), you enable ingress gateways to route requests to clusters on remote networks. Without this configuration, ingress gateways keep traffic local.
+
+* Optional: Set `AMBIENT_ENABLE_BAGGAGE` to `true` to let your waypoint proxies use HTTP headers to automatically find and share information about connected services.
 
 .. Create a project called ztunnel by running the following command:
 +
@@ -173,10 +180,14 @@ spec:
       multiCluster:
         clusterName: cluster2
       network: network2
+    meshConfig:
+      trustDomain: mesh1  
     pilot:
       trustedZtunnelNamespace: ztunnel
       env:
         AMBIENT_ENABLE_MULTI_NETWORK: "true"
+        AMBIENT_ENABLE_MULTI_NETWORK_INGRESS: "true"
+        AMBIENT_ENABLE_BAGGAGE: "true"
 EOF
 ----
 
@@ -238,7 +249,7 @@ spec:
 EOF
 ----
 
-.. To ensure the gateway is fully programmed before it begins receiving requests, run the following command. This process includes a three-minute timeout; if the gateway is not ready by then, the command will exit with an error.  
+.. To ensure the gateway is fully programmed before it begins receiving requests, run the following command:   
 +
 [source,terminal]
 ----


### PR DESCRIPTION
[OSSM-13621](https://redhat.atlassian.net/browse/OSSM-13621): [DOC] [GA] Ambient multi-cluster (multi-primary) support (OSSM 3.4)

Version(s):
service-mesh-docs-main, service-mesh-docs-3.4

Issue:
https://redhat.atlassian.net/browse/OSSM-13621

Link to docs preview:
https://111605--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/install/ossm-multi-cluster-topologies.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->