### PR TITLE
OSDOCS#19772: Update the z-stream RNs for 4.21.15

### DIFF
--- a/modules/zstream-4-21-15.adoc
+++ b/modules/zstream-4-21-15.adoc
@@ -1,0 +1,32 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-21-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-21-15_{context}"]
+= RHBA-2026:16162 - {product-title} {product-version}.15 fixed issues advisory
+
+Issued: 13 May 2026
+
+[role="_abstract"]
+{product-title} release {product-version}.15 is now available. The list of fixed issues that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2026:16162[RHBA-2026:16162] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2026:16154[RHBA-2026:16154] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.21.15 --pullspecs
+----
+
+[id="zstream-4-21-15-fixed-issues_{context}"]
+== Fixed issues
+
+There are no notable fixed issues in this release.
+
+
+[id="zstream-4-21-15-updating_{context}"]
+== Updating
+
+To update an {product-title} 4.21 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].

--- a/release_notes/ocp-4-21-release-notes.adoc
+++ b/release_notes/ocp-4-21-release-notes.adoc
@@ -44,6 +44,9 @@ include::modules/rn-ocp-release-notes-known-issues.adoc[leveloffset=+1]
 // Asynchronous errata updates
 include::modules/rn-async-errata.adoc[leveloffset=+1]
 
+// 4.21.15 RNs and updating
+include::modules/zstream-4-21-15.adoc[leveloffset=+2]
+
 // 4.21.14 RNs and updating
 include::modules/zstream-4-21-14.adoc[leveloffset=+2]
 


### PR DESCRIPTION
Version(s):
4.21

Issue:
[OSDOCS-19772](https://redhat.atlassian.net/browse/OSDOCS-19772)

Link to docs preview:
[4.21.15](https://111609--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-21-release-notes.html#zstream-4-21-15_release-notes)

QE review:
- [ ] QE has approved this change.
N/A for RNs.

Additional information:
Shipment [MR](https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/522)
ART [Dashboard](https://art-dash.engineering.redhat.com/dashboard/release/openshift-4.21)
