### PR TITLE
OSDOCS-19034 adding BMaaS OCI support

### DIFF
--- a/modules/bmaas-prerequisites.adoc
+++ b/modules/bmaas-prerequisites.adoc
@@ -19,11 +19,15 @@ Cluster Privileges::
 You must have `cluster-admin` privileges on the {product-title} cluster to perform configuration tasks.
 
 Web server with images::
-{bmaas-first} does not provide images for deployment on hardware. You must configure a web server with the images and checksums you want to use. The `image` field of the `BareMetalHost` spec references these images during deployment. Ensure that the bare-metal hosts can reach the web server URL. The following is an example of an image and checksum you might include:
+{bmaas-first} does not provide images for deployment on hardware. You must configure a web server with the images and checksums you want to use. The `image` field of the `BareMetalHost` spec references these images during deployment. Ensure that the bare-metal hosts can reach the web server URL. Alternatively, you can access images from an OCI registry as a Technology Preview. This can be done by accessing a public registry such as Quay.io, or by hosting OCI images from the built-in registry in your cluster. The following is an example of images and checksums you might include:
 
   * `http://example.com/rhel9.qcow2`
   * `http://example.com/rhel9.qcow2.sha512sum`
   * `http://example.com/stream9.qcow2`
   * `http://example.com/stream9.qcow2.sha512sum`
+  * `oci://quay.io/example/image:version`
 
-These prerequisites ensure that you can provision and manage bare-metal hosts effectively.
+These prerequisites ensure that {bmaas-first} can provision and manage bare-metal hosts effectively.
+
+:FeatureName: Accessing images from an OCI registry
+include::snippets/technology-preview.adoc[]

--- a/modules/bmo-deploying-an-image-to-the-bare-metal-host.adoc
+++ b/modules/bmo-deploying-an-image-to-the-bare-metal-host.adoc
@@ -23,6 +23,6 @@ $ oc patch baremetalhost <hostname> \
 `<hostname>`::
 The name of your `BareMetalHost` resource.
 `<image_url>`::
-The URL of the image to deploy.
+The URL of the image to deploy. You can access images using the HTTP and OCI protocols. Accessing images using the OCI protocol is available as a Technology Preview.
 `<checksum_url>`::
 The URL of the checksum file for the image.


### PR DESCRIPTION
Version(s):
4.22

Issue:
https://redhat.atlassian.net/browse/OSDOCS-19034

Link to docs preview:
[BMaaS prerequisites](https://111612--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/bare-metal-using-bare-metal-as-a-service.html#bmaas-prerequisites_bare-metal-using-bmaas)

QE review:
- [x] QE has approved this change.
