### PR TITLE
Mentioning how many etcd encryption keys are kept after rotation

### DIFF
--- a/modules/etcd-encryption-types.adoc
+++ b/modules/etcd-encryption-types.adoc
@@ -9,6 +9,8 @@
 
 The following encryption types are supported for encrypting etcd data in {product-title}:
 
-AES-CBC:: Uses AES-CBC with PKCS#7 padding and a 32 byte key to perform the encryption. The encryption keys are rotated weekly.
+AES-CBC:: Uses AES-CBC with PKCS#7 padding and a 32 byte key to perform the encryption.
 
-AES-GCM:: Uses AES-GCM with a random nonce and a 32 byte key to perform the encryption. The encryption keys are rotated weekly.
+AES-GCM:: Uses AES-GCM with a random nonce and a 32 byte key to perform the encryption.
+
+The etcd encryption keys are rotated every 7 days. Up to 10 historical encryption keys are preserved after rotation to facilitate the decryption of older backups and provide an extra layer of data recovery safety.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.13+ 
(Applies to 4.12 too, but it's in a different location in the docs and will need to be submitted separately)

Issue:
https://redhat.atlassian.net/browse/OSDOCS-15735

Link to docs preview:
https://111613--ocpdocs-pr.netlify.app/openshift-enterprise/latest/etcd/etcd-encrypt.html#etcd-encryption-types_etcd-encrypt

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
