### PR TITLE
OSDOCS-19034-RN BMaaS OCI Release note

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -434,3 +434,4 @@ endif::openshift-origin[]
 :attribute-based-short: Attribute-Based GPU Allocation
 //Support log gather operator
 :support-log-gather: Support Log Gather
+:bmaas-first: Red{nbsp}Hat Bare Metal as a Service for OpenShift

--- a/modules/rn-ocp-release-notes-new-features.adoc
+++ b/modules/rn-ocp-release-notes-new-features.adoc
@@ -265,6 +265,9 @@ With this release, the Peripheral Component Interconnect (PCI) address for each 
 +
 For more information, see xref:../installing/installing_bare_metal/bare-metal-postinstallation-configuration.adoc#bmo-about-the-baremetalhost-resource_bare-metal-postinstallation-configuration[About the BareMetalHost resource] and xref:../installing/installing_bare_metal/bare-metal-postinstallation-configuration.adoc#the-baremetalhost-status[The BareMetalHost status].
 
+Expanding bare-metal clusters using OCI images and {bmaas-first} (Technology Preview)::
++
+With this update, you can expand your bare-metal cluster using {bmaas-first} with images from an OCI registry as a Technology Preview. You can use images from public OCI registries or from the built-in cluster registry. For more information, see xref:../installing/installing_bare_metal/bare-metal-using-bare-metal-as-a-service.adoc[Using Red Hat Bare Metal as a Service for OpenShift].
 
 [id="ocp-release-notes-scale-and-perform_{context}"]
 == Scalability and performance

--- a/modules/rn-ocp-release-notes-technology-preview.adoc
+++ b/modules/rn-ocp-release-notes-technology-preview.adoc
@@ -456,6 +456,19 @@ In the following tables, features are marked with the following statuses:
 //|Feature |4.20 |4.21 |4.22
 //|====
 
+[id="ocp-release-notes-post-installation_{context}"]
+== Postinstallation configuration Technology Preview features
+
+.Postinstallation configuration Technology Preview tracker
+[cols="4,1,1,1",options="header"]
+|====
+|Feature |4.20 |4.21 |4.22
+
+|Expanding a bare metal cluster using images from OCI registries
+|Not Available
+|Not Available
+|Technology Preview
+|====
 
 [id="ocp-release-notes-rhcos-tech-preview_{context}"]
 == {rh-openstack-first} Technology Preview features


### PR DESCRIPTION
Version(s):
4.22

Issue:
https://redhat.atlassian.net/browse/OSDOCS-19034

Link to docs preview:
https://111614--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-22-release-notes#ocp-release-notes-post-install-configuration_release-notes

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Attribute change is temporary until https://github.com/openshift/openshift-docs/pull/111238 merges