### PR TITLE
OSDOCS#19773: Update the z-stream RNs for 4.12.90 

### DIFF
--- a/modules/zstream-4-12-90-about.adoc
+++ b/modules/zstream-4-12-90-about.adoc
@@ -1,0 +1,24 @@
+// Module included in the following assembly:
+//
+// * release_notes/ocp-4-12-release-notes.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="zstream-4-12-90-about_{context}"]
+= RHBA-2026:16181 - {product-title} {product-version}.90 bug fix and security update
+
+[role="_abstract"]
+Issued: 14 May 2026
+
+{product-title} release {product-version}.90, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2026:16181[RHBA-2026:16181] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2026:16179[RHBA-2026:16179] advisory.
+
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+
+You can view the container images in this release by running the following command:
+
+
+[source,terminal]
+----
+$ oc adm release info 4.12.90 --pullspecs
+----

--- a/modules/zstream-4-12-90-fixed-issues.adoc
+++ b/modules/zstream-4-12-90-fixed-issues.adoc
@@ -1,0 +1,10 @@
+// Module included in the following assembly:
+//
+// * release_notes/ocp-4-12-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-12-90-fixed-issues_{context}"]
+= Fixed issues
+
+[role="_abstract"]
+There are no notable fixed issues in this release.

--- a/modules/zstream-4-12-90-updating.adoc
+++ b/modules/zstream-4-12-90-updating.adoc
@@ -1,0 +1,10 @@
+// Module included in the following assembly:
+//
+// * release_notes/ocp-4-12-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-12-90-updating_{context}"]
+= Updating
+
+[role="_abstract"]
+To update an existing {product-title} 4.12 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].

--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -5404,3 +5404,12 @@ include::modules/zstream-4-12-89-fixed-issues.adoc[leveloffset=+3]
 
 // 4.12.89 updating
 include::modules/zstream-4-12-89-updating.adoc[leveloffset=+3]
+
+// 4.12.90 about
+include::modules/zstream-4-12-90-about.adoc[leveloffset=+2]
+
+// 4.12.90 fixes
+include::modules/zstream-4-12-90-fixed-issues.adoc[leveloffset=+3]
+
+// 4.12.90 updating
+include::modules/zstream-4-12-90-updating.adoc[leveloffset=+3]


### PR DESCRIPTION
Version(s):
4.12

Issue:
[OSDOCS-19773](https://redhat.atlassian.net/browse/OSDOCS-19773)

Link to docs preview:
4.12.90

QE review:
- [ ] QE has approved this change.
N/A for RNs.

Additional information:

**Mergers - This is one of the CVE z-streams for this week. There are no notable bugs, but there are CVEs (security fixes).
Shipment [MR](https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/528)
ART [Dashboard](https://art-dash.engineering.redhat.com/dashboard/release/openshift-4.12)
