### PR TITLE
OSDOCS-19056# Bare metal nodes on vSphere GA documentation.

### DIFF
--- a/machine_management/user_infra/adding-bare-metal-compute-vsphere-user-infra.adoc
+++ b/machine_management/user_infra/adding-bare-metal-compute-vsphere-user-infra.adoc
@@ -11,31 +11,12 @@ To support workloads requiring direct hardware access, extend your existing {vmw
 
 This procedure supports clusters installed using installer-provisioned infrastructure, user-provisioned infrastructure, or the Assisted Installer.
 
-:FeatureName: Bare-metal nodes on vSphere clusters
-include::snippets/technology-preview.adoc[]
-
 [IMPORTANT]
 ====
 Bare-metal compute machines added to a {vmw-short} cluster are unmanaged by the Machine API. You cannot use compute machine sets or the cluster autoscaler to manage these compute machines. Lifecycle tasks such as provisioning and replacement must be performed manually.
 ====
 
-== Prerequisites
-
-* You have an existing {product-title} cluster installed on {vmw-short}.
-* You have bare-metal hardware with network connectivity to the existing cluster's machine network.
-* You have configured the network for the new bare-metal compute machines, including:
-** DHCP: Persistent IP addresses and hostname reservations.
-** DNS: Forward and reverse DNS resolution for the new hostnames.
-* You have obtained the {op-system-first} ISO image that matches your cluster version. You can download this from the *Cluster Details* page on the {hybrid-console} or extract it from the cluster payload.
-
-[WARNING]
-====
-To use this feature, you must explicitly disable the native {vmw-short} Container Storage Interface (CSI) driver for the entire cluster. This means existing {vmw-short} virtual machines will lose the ability to provision or attach {vmw-short} volumes. You must ensure that all workloads (virtual and physical) are migrated to an alternative storage solution before proceeding.
-====
-
-[role="_additional-resources"]
-.Additional resources
-* xref:../../storage/container_storage_interface/persistent-storage-csi-vsphere.adoc#persistent-storage-csi-vsphere-disable-storage-procedure_persistent-storage-csi-vsphere[Disabling and enabling storage on vSphere]
+include::modules/bare-metal-vsphere-prerequisites.adoc[leveloffset=+1]
 
 include::modules/bare-metal-vsphere-iso.adoc[leveloffset=+1]
 

--- a/machine_management/user_infra/adding-bare-metal-compute-vsphere-user-infra.adoc
+++ b/machine_management/user_infra/adding-bare-metal-compute-vsphere-user-infra.adoc
@@ -11,27 +11,12 @@ To support workloads requiring direct hardware access, extend your existing {vmw
 
 This procedure supports clusters installed using installer-provisioned infrastructure, user-provisioned infrastructure, or the Assisted Installer.
 
-:FeatureName: Bare-metal nodes on vSphere clusters
-include::snippets/technology-preview.adoc[]
-
 [IMPORTANT]
 ====
 Bare-metal compute machines added to a {vmw-short} cluster are unmanaged by the Machine API. You cannot use compute machine sets or the cluster autoscaler to manage these compute machines. Lifecycle tasks such as provisioning and replacement must be performed manually.
 ====
 
-== Prerequisites
-
-* You have an existing {product-title} cluster installed on {vmw-short}.
-* You have bare-metal hardware with network connectivity to the existing cluster's machine network.
-* You have configured the network for the new bare-metal compute machines, including:
-** DHCP: Persistent IP addresses and hostname reservations.
-** DNS: Forward and reverse DNS resolution for the new hostnames.
-* You have obtained the {op-system-first} ISO image that matches your cluster version. You can download this from the *Cluster Details* page on the {hybrid-console} or extract it from the cluster payload.
-
-[WARNING]
-====
-To use this feature, you must explicitly disable the native {vmw-short} Container Storage Interface (CSI) driver for the entire cluster. This means existing {vmw-short} virtual machines will lose the ability to provision or attach {vmw-short} volumes. You must ensure that all workloads (virtual and physical) are migrated to an alternative storage solution before proceeding.
-====
+include::modules/bare-metal-vsphere-prerequisites.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources

--- a/machine_management/user_infra/adding-compute-user-infra-general.adoc
+++ b/machine_management/user_infra/adding-compute-user-infra-general.adoc
@@ -38,9 +38,6 @@ To manually add more compute machines to your cluster, see xref:../../machine_ma
 
 To add bare-metal compute machines to your cluster, see xref:../../machine_management/user_infra/adding-bare-metal-compute-vsphere-user-infra.adoc#adding-bare-metal-compute-vsphere-user-infra[Adding bare-metal compute machines to a vSphere cluster].
 
-:FeatureName: Bare-metal nodes on vSphere clusters
-include::snippets/technology-preview.adoc[]
-
 [id="upi-adding-compute-bare-metal"]
 == Adding compute machines to bare metal
 

--- a/modules/bare-metal-vsphere-iso.adoc
+++ b/modules/bare-metal-vsphere-iso.adoc
@@ -9,9 +9,6 @@
 [role="_abstract"]
 To add bare-metal compute machines to your {vmw-first} cluster, you must manually provision them using an {op-system} ISO image and the `coreos-installer` utility.
 
-:FeatureName: Bare-metal nodes on vSphere clusters
-include::snippets/technology-preview.adoc[]
-
 .Prerequisites
 
 * You have access to the {op-system} ISO image that matches your cluster version.

--- a/modules/bare-metal-vsphere-prerequisites.adoc
+++ b/modules/bare-metal-vsphere-prerequisites.adoc
@@ -1,0 +1,26 @@
+// Module included in the following assemblies:
+//
+// * machine_management/user_infra/adding-bare-metal-compute-vsphere-user-infra.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="bare-metal-vsphere-prerequisites_{context}"]
+= Prerequisites for adding bare-metal compute machines to a vSphere cluster
+
+[role="_abstract"]
+Before you add bare-metal compute machines to your {vmw-first} cluster, you must meet the following infrastructure and network requirements.
+
+* You have an existing {product-title} cluster installed on {vmw-short}.
+* You have bare-metal hardware with network connectivity to the existing cluster's machine network.
+* You have configured the network for the new bare-metal compute machines, including:
+** DHCP: Persistent IP addresses and hostname reservations.
+** DNS: Forward and reverse DNS resolution for the new hostnames.
+* You have obtained the {op-system-first} ISO image that matches your cluster version. You can download this from the *Cluster Details* page on the {hybrid-console} or extract it from the cluster payload.
+
+[WARNING]
+====
+To use this feature, you must explicitly disable the native {vmw-short} Container Storage Interface (CSI) driver for the entire cluster. This means existing {vmw-short} virtual machines will lose the ability to provision or attach {vmw-short} volumes. You must ensure that all workloads (virtual and physical) are migrated to an alternative storage solution before proceeding.
+====
+
+[role="_additional-resources"]
+.Additional resources
+* xref:../../storage/container_storage_interface/persistent-storage-csi-vsphere.adoc#persistent-storage-csi-vsphere-disable-storage-procedure_persistent-storage-csi-vsphere[Disabling and enabling storage on vSphere]

--- a/modules/bare-metal-vsphere-prerequisites.adoc
+++ b/modules/bare-metal-vsphere-prerequisites.adoc
@@ -1,0 +1,22 @@
+// Module included in the following assemblies:
+//
+// * machine_management/user_infra/adding-bare-metal-compute-vsphere-user-infra.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="bare-metal-vsphere-prerequisites_{context}"]
+= Prerequisites for adding bare-metal compute machines to a vSphere cluster
+
+[role="_abstract"]
+Before you add bare-metal compute machines to your {vmw-first} cluster, you must meet the following infrastructure and network requirements.
+
+* You have an existing {product-title} cluster installed on {vmw-short}.
+* You have bare-metal hardware with network connectivity to the existing cluster's machine network.
+* You have configured the network for the new bare-metal compute machines, including:
+** DHCP: Persistent IP addresses and hostname reservations.
+** DNS: Forward and reverse DNS resolution for the new hostnames.
+* You have obtained the {op-system-first} ISO image that matches your cluster version. You can download this from the *Cluster Details* page on the {hybrid-console} or extract it from the cluster payload.
+
+[WARNING]
+====
+To use this feature, you must explicitly disable the native {vmw-short} Container Storage Interface (CSI) driver for the entire cluster. This means existing {vmw-short} virtual machines will lose the ability to provision or attach {vmw-short} volumes. You must ensure that all workloads (virtual and physical) are migrated to an alternative storage solution before proceeding.
+====

--- a/modules/upi-adding-compute-vsphere.adoc
+++ b/modules/upi-adding-compute-vsphere.adoc
@@ -19,5 +19,3 @@ You can add bare-metal compute machines to your cluster.
 
 See xref:../../machine_management/user_infra/adding-bare-metal-compute-vsphere-user-infra.adoc#adding-bare-metal-compute-vsphere-user-infra[Adding bare-metal compute machines to a vSphere cluster] for more information.
 
-:FeatureName: Bare-metal nodes on vSphere clusters
-include::snippets/technology-preview.adoc[]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.22.13+

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://redhat.atlassian.net/browse/OSDOCS-19056

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
* Feature introduction and procedure -- https://111626--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/user_infra/adding-bare-metal-compute-vsphere-user-infra.html
* Entry in add compute machines by platform -- https://111626--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/user_infra/adding-compute-user-infra-general.html#upi-adding-compute-vsphere

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

The 4.22 cherrypick of this PR will include the following additional note in place of the removed tech preview snippets to clarify the z-stream release scope:

[IMPORTANT]
====
Bare-metal nodes on VMware vSphere clusters is generally available for {product-title} 4.22.13 and later. However, this feature is Technology Preview for 4.21 through 4.22.12.
====

PR also includes minor restructure for improved DITA compatibility.

Change management checklist:
* PX: Chris Fields
* Engineering manager: Richard Vanderpool
* Engineering: Neil Girard
* PM: Linh Nguyen
* DPM: Kathryn Alexander
* CS: Avani Bhatt

Related PRs:
* Release note PR: https://github.com/openshift/openshift-docs/pull/119626/
* Storage PR: https://github.com/openshift/openshift-docs/pull/119733/

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->