### PR TITLE
[enterprise-4.12] OSDOCS#15735: 4.12 - Mentioning how many etcd encryption keys are kep…

### DIFF
--- a/modules/about-etcd-encryption.adoc
+++ b/modules/about-etcd-encryption.adoc
@@ -17,7 +17,9 @@ When you enable etcd encryption, the following OpenShift API server and Kubernet
 * OAuth access tokens
 * OAuth authorize tokens
 
-When you enable etcd encryption, encryption keys are created. These keys are rotated on a weekly basis. You must have these keys to restore from an etcd backup.
+When you enable etcd encryption, encryption keys are created. You must have these keys to restore from an etcd backup.
+
+The etcd encryption keys are rotated every 7 days. Up to 10 historical encryption keys are preserved after rotation to facilitate the decryption of older backups and provide an extra layer of data recovery safety.
 
 [NOTE]
 ====


### PR DESCRIPTION
…t after rotation#111613

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.12

Issue:
https://redhat.atlassian.net/browse/OSDOCS-15735

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
4.12 CP/update for #111613