### PR TITLE
TELCODOCS-2695 DITA migration cleanup for security-basics.adoc

### DIFF
--- a/modules/security-identity-prov-config.adoc
+++ b/modules/security-identity-prov-config.adoc
@@ -6,6 +6,7 @@
 [id="security-identity-prov-config_{context}"]
 = Identity provider configuration
 
+[role="_abstract"]
 Configuring an identity provider is the first step in setting up users on the cluster. You can manage groups at the organizational level by using an identity provider. 
 
 The identity provider can pull in specific user groups that are maintained at the organizational level, rather than the cluster level. This allows you to add and remove users from groups that follow your organization’s established practices.

--- a/modules/security-infra.adoc
+++ b/modules/security-infra.adoc
@@ -6,6 +6,9 @@
 [id="security-infra_{context}"]
 = Bare-metal infrastructure
 
-Hardware requirements:: In several industries, such as telco and finance, clusters are primarily built on bare-metal hardware. This means that the (op-system-first) operating system is installed directly on the physical machines, without using virtual machines. This reduces network connectivity complexity, minimizes latency, and optimizes CPU usage for applications.
+[role="_abstract"]
+Bare-metal infrastructure for {product-title} clusters in telco and finance industries requires specific hardware and network configurations.
+
+Hardware requirements:: In several industries, such as telco and finance, clusters are primarily built on bare-metal hardware. This means that the {op-system-first} operating system is installed directly on the physical machines, without using virtual machines. This reduces network connectivity complexity, minimizes latency, and optimizes CPU usage for applications.
 
 Network requirements:: Networks in these industries sometimes require much higher bandwidth compared to standard IT networks. For example, Telco networks commonly use dual-port 25 GB connections or 100 GB network interface cards (NICs) to handle massive data throughput. Security is critical, requiring encrypted connections and secure endpoints to protect sensitive personal data.

--- a/modules/security-lifecycle-mgmnt.adoc
+++ b/modules/security-lifecycle-mgmnt.adoc
@@ -6,6 +6,7 @@
 [id="security-lifecycle-mgmnt_{context}"]
 = Lifecycle management
 
+[role="_abstract"]
 Upgrades are critical for security. When a vulnerability is discovered, it is patched in the latest z-stream release. This fix is then rolled back through each lower y-stream release until all supported versions are patched. Releases that are no longer supported do not receive patches. Therefore, it is important to upgrade {product-title} clusters regularly to stay within a supported release and ensure they remain protected against vulnerabilities.
 
 For more information about lifecycle management and upgrades, see "Upgrading {product-title} clusters".

--- a/modules/security-pod-sec-in-kub-and-ocp.adoc
+++ b/modules/security-pod-sec-in-kub-and-ocp.adoc
@@ -6,6 +6,7 @@
 [id="security-pod-sec-in-kub-and-ocp_{context}"]
 = Advancement of pod security in Kubernetes and {product-title}
 
+[role="_abstract"]
 Kubernetes initially had limited pod security. When {product-title} integrated Kubernetes, Red Hat added pod security through Security Context Constraints (SCCs). In Kubernetes version 1.3, `PodSecurityPolicy` (PSP) was introduced as a similar feature. However, Pod Security Admission (PSA) was introduced in Kubernetes version 1.21, which resulted in the deprecation of PSP in Kubernetes version 1.25.
 
 PSA also became available in {product-title} version 4.11. While PSA improves pod security, it lacks features provided by SCCs that are still necessary for certain use cases. Therefore, {product-title} continues to support both PSA and SCCs.

--- a/modules/security-rbac-overview.adoc
+++ b/modules/security-rbac-overview.adoc
@@ -6,6 +6,7 @@
 [id="security-rbac-overview_{context}"]
 = RBAC overview
 
+[role="_abstract"]
 Role-based access control (RBAC) objects determine whether a user is allowed to perform a given action within a project. 
 
 Cluster administrators can use the cluster roles and bindings to control who has various access levels to the {product-title} platform itself and all projects.
@@ -32,7 +33,6 @@ You can bind more than one role to a user or group.
 
 For more information on RBAC, see "Using RBAC to define and apply permissions".
 
-[discrete]
 [id="security-operational-rbac-considerations_{context}"]
 == Operational RBAC considerations
 

--- a/modules/security-replacing-kubeadmin-user.adoc
+++ b/modules/security-replacing-kubeadmin-user.adoc
@@ -6,7 +6,8 @@
 [id="security-replacing-kubeadmin-user_{context}"]
 = Replacing the kubeadmin user with a cluster-admin user
 
-The `kubeadmin` user with the `cluster-admin` privileges is created on every cluster by default. To enhance the cluster security, you can replace the`kubeadmin` user with a `cluster-admin` user and then disable or remove the `kubeadmin` user.
+[role="_abstract"]
+The `kubeadmin` user with the `cluster-admin` privileges is created on every cluster by default. To enhance the cluster security, you can replace the `kubeadmin` user with a `cluster-admin` user and then disable or remove the `kubeadmin` user.
 
 .Prerequisites
 

--- a/modules/security-sec-accounts-overview.adoc
+++ b/modules/security-sec-accounts-overview.adoc
@@ -6,6 +6,7 @@
 [id="security-sec-accounts-overview_{context}"]
 = Security accounts overview
 
+[role="_abstract"]
 A service account is an {product-title} account that allows a component to directly access the API. Service accounts are API objects that exist within each project.
 Service accounts provide a flexible way to control API access without sharing a regular user's credentials. 
 

--- a/modules/security-sec-considerations-telco.adoc
+++ b/modules/security-sec-considerations-telco.adoc
@@ -6,6 +6,7 @@
 [id="security-sec-considerations-{context}"]
 = Security considerations
 
+[role="_abstract"]
 Workloads might handle sensitive data and demand high reliability. A single security vulnerability might lead to broader, cluster-wide compromises. With numerous components running on an {product-title} cluster, you must secure each component to prevent any breach from escalating. Ensuring security across the entire infrastructure, including all components, is essential to maintaining the integrity of the network and avoiding vulnerabilities.
 
 The following key security features are essential for all industries that handle sensitive data:


### PR DESCRIPTION
## Summary
- Fix `(op-system-first)` → `{op-system-first}` attribute syntax in `security-infra.adoc`
- Fix missing space before backtick in `security-replacing-kubeadmin-user.adoc`
- Add missing newline at EOF in `security-infra.adoc` and `security-pod-sec-in-kub-and-ocp.adoc`

Follows up on #106557.

## JIRA
https://issues.redhat.com/browse/TELCODOCS-2695

## Test plan
- [x] Vale AsciiDocDITA validation passes with 0 errors and 0 warnings
- [x] Review content changes for accuracy
- [ ] Build documentation locally


Made with [Cursor](https://cursor.com)