### PR TITLE
TELCODOCS-2696 DITA migration cleanup for security-host-sec.adoc

### DIFF
--- a/modules/security-linux-capabilities-overview.adoc
+++ b/modules/security-linux-capabilities-overview.adoc
@@ -6,6 +6,7 @@
 [id="security-linux-capabilities-overview_{context}"]
 = Linux capabilities
 
+[role="_abstract"]
 Linux capabilities define the actions a process can perform on the host system. By default, pods are granted several capabilities unless security measures are applied. These default capabilities are as follows:
 
 * `CHOWN`

--- a/modules/security-rhcos-overview.adoc
+++ b/modules/security-rhcos-overview.adoc
@@ -6,6 +6,7 @@
 [id="security-rhcos-overview_{context}"]
 = {op-system-first}
 
+[role="_abstract"]
 {op-system-first} is different from {op-system-base-full} in key areas. For more information, see "About {op-system}".
 
 A major distinction is the control of `rpm-ostree`, which is updated through the Machine Config Operator. 
@@ -15,7 +16,7 @@ A major distinction is the control of `rpm-ostree`, which is updated through the
 To manage hosts effectively while maintaining security, avoid direct access whenever possible. Instead, you can use the following methods for host management:
 
 * Debug pod
-* Direct SSHs
+* Direct SSH
 * Console access
 
 Review the following {op-system} security mechanisms that are integral to maintaining host security: 


### PR DESCRIPTION
## Summary
- Add `[role="_abstract"]` to 3 security-host-sec modules
- Fix typo: "Direct SSHs" → "Direct SSH" in `security-rhcos-overview.adoc`

Follows up on #106558.

## JIRA
https://issues.redhat.com/browse/TELCODOCS-2696

## Test plan
- [x] Vale AsciiDocDITA validation passes with 0 errors
- [x] Review content changes for accuracy
- [ ] Build documentation locally


Made with [Cursor](https://cursor.com)