### PR TITLE
TELCODOCS-2701 DITA migration cleanup for troubleshooting-general-troubleshooting.adoc

### DIFF
--- a/modules/troubleshooting-general-check-logs.adoc
+++ b/modules/troubleshooting-general-check-logs.adoc
@@ -6,6 +6,7 @@
 [id="troubleshooting-general-check-logs_{context}"]
 = Checking pod logs
 
+[role="_abstract"]
 Get logs from the pod so that you can review the logs for issues.
 
 .Procedure
@@ -18,7 +19,6 @@ Get logs from the pod so that you can review the logs for issues.
 $ oc get pod
 ----
 
-.Example output
 [source,terminal]
 ----
 NAME        READY   STATUS    RESTARTS          AGE
@@ -29,11 +29,11 @@ busybox-4   1/1     Running   168 (43m ago)     7d
 ----
 --
 
-. Check pod log files by running the following command: 
+. Check pod log files by running the following command:
 +
 [source,terminal]
 ----
 $ oc logs -n <namespace> busybox-1
 ----
-
++
 For more information, see "oc logs", "Logging", and "Inspecting pod and container logs".

--- a/modules/troubleshooting-general-connect-to-pod.adoc
+++ b/modules/troubleshooting-general-connect-to-pod.adoc
@@ -6,6 +6,7 @@
 [id="troubleshooting-general-connect-to-pod_{context}"]
 = Connecting to a pod
 
+[role="_abstract"]
 You can directly connect to a currently running pod with the `oc rsh` command, which provides you with a shell on that pod.
 
 [WARNING]
@@ -22,5 +23,5 @@ Use the `oc rsh` command only if you cannot connect to the node by using the `oc
 ----
 $ oc rsh -n <namespace> busybox-1
 ----
-
++
 For more information, see "oc rsh" and "Accessing running pods".

--- a/modules/troubleshooting-general-debug-pod.adoc
+++ b/modules/troubleshooting-general-debug-pod.adoc
@@ -6,6 +6,7 @@
 [id="troubleshooting-general-debug-pod_{context}"]
 = Debugging a pod
 
+[role="_abstract"]
 In certain cases, you do not want to directly interact with your pod that is in production.
 
 To avoid interfering with running traffic, you can use a secondary pod that is a copy of your original pod.
@@ -21,7 +22,6 @@ The secondary pod uses the same components as that of the original pod but does 
 $ oc get pod
 ----
 
-.Example output
 [source,terminal]
 ----
 NAME        READY   STATUS    RESTARTS          AGE
@@ -40,7 +40,6 @@ busybox-4   1/1     Running   168 (43m ago)     7d
 $ oc debug -n <namespace> busybox-1
 ----
 
-.Example output
 [source,terminal]
 ----
 Starting pod/busybox-1-debug, command was: sleep 3600
@@ -49,5 +48,5 @@ Pod IP: 10.133.2.11
 
 If you do not see a shell prompt, press Enter.
 --
-
++
 For more information, see "oc debug" and "Starting debug pods with root access".

--- a/modules/troubleshooting-general-query-cluster.adoc
+++ b/modules/troubleshooting-general-query-cluster.adoc
@@ -6,6 +6,7 @@
 [id="troubleshooting-general-query-cluster_{context}"]
 = Querying your cluster
 
+[role="_abstract"]
 Get information about your cluster so that you can more accurately find potential problems.
 
 .Procedure
@@ -25,7 +26,6 @@ $ oc project <project_name>
 $ oc get clusterversion,clusteroperator,node
 ----
 
-.Example output
 [source,terminal]
 ----
 NAME                                         VERSION   AVAILABLE   PROGRESSING   SINCE   STATUS
@@ -72,5 +72,5 @@ node/ctrl-plane-1   Ready    control-plane,master,worker   62d   v1.29.7
 node/ctrl-plane-2   Ready    control-plane,master,worker   62d   v1.29.7
 ----
 --
-
++
 For more information, see "oc get" and "Reviewing pod status".

--- a/modules/troubleshooting-general-review-events.adoc
+++ b/modules/troubleshooting-general-review-events.adoc
@@ -6,6 +6,7 @@
 [id="troubleshooting-general-review-events_{context}"]
 = Reviewing events
 
+[role="_abstract"]
 You can review the events in a given namespace to find potential issues.
 
 .Procedure
@@ -14,17 +15,19 @@ You can review the events in a given namespace to find potential issues.
 +
 [source,terminal]
 ----
-$ oc get events -n <namespace> --sort-by=".metadata.creationTimestamp" <1>
+$ oc get events -n <namespace> --sort-by=".metadata.creationTimestamp"
 ----
-<1> Adding the `--sort-by=".metadata.creationTimestamp"` flag places the most recent events at the end of the output.
++
+The `--sort-by=".metadata.creationTimestamp"` flag places the most recent events at the end of the output.
 
 . Optional: If the events within your specified namespace do not provide enough information, expand your query to all namespaces by running the following command:
 +
 [source,terminal]
 ----
-$ oc get events -A --sort-by=".metadata.creationTimestamp" <1>
+$ oc get events -A --sort-by=".metadata.creationTimestamp"
 ----
-<1> The `--sort-by=".metadata.creationTimestamp"` flag places the most recent events at the end of the output.
++
+The `--sort-by=".metadata.creationTimestamp"` flag places the most recent events at the end of the output.
 +
 To filter the results of all events from a cluster, you can use the `grep` command.
 For example, if you are looking for errors, the errors can appear in two different sections of the output: the `TYPE` or `MESSAGE` sections.
@@ -38,7 +41,6 @@ With the `grep` command, you can search for keywords, such as `error` or `failed
 $ oc get events -A | grep -Ei "warning|error"
 ----
 
-.Example output
 [source,terminal]
 ----
 NAMESPACE    LAST SEEN   TYPE      REASON          OBJECT              MESSAGE
@@ -52,5 +54,5 @@ openshift    59s         Warning   FailedMount     pod/openshift-1     MountVolu
 ----
 $ oc delete events -n <namespace> --all
 ----
-
++
 For more information, see "Watching cluster events".

--- a/modules/troubleshooting-general-run-command-on-pod.adoc
+++ b/modules/troubleshooting-general-run-command-on-pod.adoc
@@ -6,6 +6,7 @@
 [id="troubleshooting-run-command-on-pod_{context}"]
 = Running a command on a pod
 
+[role="_abstract"]
 If you want to run a command or set of commands on a pod without directly logging into it, you can use the `oc exec -it` command.
 You can interact with the pod quickly to get process or output information from the pod.
 A common use case is to run the `oc exec -it` command inside a script to run the same command on multiple pods in a replica set or deployment.
@@ -23,5 +24,5 @@ In pods that run a low-latency application, the `oc exec` command can cause late
 ----
 $ oc exec -it <pod> -- <command>
 ----
-
++
 For more information, see "oc exec" and "Executing remote commands in containers".


### PR DESCRIPTION
## Summary
- Replace `[NOTE]` callout conversions with simple continuation sentences in `troubleshooting-general-review-events.adoc` (explaining a flag is not a note/caveat)
- Remove `.Example output` block titles (DITA-incompatible)
- Fix `+` list continuations for "For more information" references
- Add `[role="_abstract"]` to all 6 modules
- Add missing newline at EOF in all 6 files

Follows up on #106562.

## JIRA
https://issues.redhat.com/browse/TELCODOCS-2701

## Test plan
- [x] Vale AsciiDocDITA validation passes with 0 errors and 0 warnings
- [x] Review content changes for accuracy
- [ ] Build documentation locally


Made with [Cursor](https://cursor.com)