### PR TITLE
TELCODOCS-2703 DITA migration cleanup for troubleshooting-mco.adoc

### DIFF
--- a/modules/troubleshooting-mco-apply-several-mcs.adoc
+++ b/modules/troubleshooting-mco-apply-several-mcs.adoc
@@ -6,6 +6,7 @@
 [id="troubleshooting-mco-apply-several-mcs_{context}"]
 = Applying several machine config files at the same time
 
+[role="_abstract"]
 When you need to change the machine config for a group of nodes in the cluster, also known as machine config pools (MCPs), sometimes the changes must be applied with several different machine config files.
 The nodes need to restart for the machine config file to be applied.
 After each machine config file is applied to the cluster, all nodes restart that are affected by the machine config file.
@@ -27,5 +28,5 @@ $ oc patch mcp/<mcp_name> --type merge --patch '{"spec":{"paused":true}}'
 ----
 $ oc patch mcp/<mcp_name> --type merge --patch '{"spec":{"paused":false}}'
 ----
-
++
 This allows the nodes in your MCP to reboot into the new configurations.

--- a/modules/troubleshooting-mco-purpose.adoc
+++ b/modules/troubleshooting-mco-purpose.adoc
@@ -6,6 +6,7 @@
 [id="troubleshooting-mco-purpose_{context}"]
 = Purpose of the Machine Config Operator
 
+[role="_abstract"]
 The Machine Config Operator (MCO) manages and applies configuration and updates of {op-system-first} and container runtime, including everything between the kernel and kubelet.
 Managing {op-system} is important since most telecommunications companies run on bare-metal hardware and use some sort of hardware accelerator or kernel modification.
 Applying machine configuration to {op-system} manually can cause problems because the MCO monitors each node and what is applied to it.


### PR DESCRIPTION
## Summary
- Add `[role="_abstract"]` to 2 troubleshooting-mco modules
- Fix `+` list continuation in `troubleshooting-mco-apply-several-mcs.adoc`
- Add missing newline at EOF in `troubleshooting-mco-apply-several-mcs.adoc`

Follows up on #106564.

## JIRA
https://issues.redhat.com/browse/TELCODOCS-2703

## Test plan
- [x] Vale AsciiDocDITA validation passes with 0 errors and 0 warnings
- [x] Review content changes for accuracy
- [ ] Build documentation locally


Made with [Cursor](https://cursor.com)