### PR TITLE
TELCODOCS-2706 DITA migration cleanup for update-before-the-update.adoc

### DIFF
--- a/modules/backup-etcd.adoc
+++ b/modules/backup-etcd.adoc
@@ -7,6 +7,7 @@
 [id="backing-up-etcd-data_{context}"]
 = Backing up etcd data
 
+[role="_abstract"]
 Follow these steps to back up etcd data by creating an etcd snapshot and backing up the resources for the static pods. This backup can be saved and used at a later time if you need to restore etcd.
 
 [IMPORTANT]

--- a/modules/creating-single-etcd-backup.adoc
+++ b/modules/creating-single-etcd-backup.adoc
@@ -7,6 +7,7 @@
 [id="creating-single-etcd-backup_{context}"]
 = Creating a single automated etcd backup
 
+[role="_abstract"]
 Follow these steps to create a single etcd backup by creating and applying a custom resource (CR).
 
 .Prerequisites
@@ -32,10 +33,11 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: 200Gi <1>
+      storage: 200Gi
   volumeMode: Filesystem
 ----
-<1> The amount of storage available to the PVC. Adjust this value for your requirements.
++
+Adjust the `storage` value for your requirements.
 +
 .. Apply the PVC by running the following command:
 +
@@ -73,9 +75,10 @@ metadata:
   name: etcd-single-backup
   namespace: openshift-etcd
 spec:
-  pvcName: etcd-backup-pvc <1>
+  pvcName: etcd-backup-pvc
 ----
-<1> The name of the PVC to save the backup to. Adjust this value according to your environment.
++
+Adjust the `pvcName` value according to your environment.
 +
 .. Apply the CR to start a single backup:
 +
@@ -115,7 +118,7 @@ metadata:
   name: etcd-backup-pv-fs
 spec:
   capacity:
-    storage: 100Gi <1>
+    storage: 100Gi
   volumeMode: Filesystem
   accessModes:
   - ReadWriteOnce
@@ -130,10 +133,15 @@ spec:
       - key: kubernetes.io/hostname
          operator: In
          values:
-         - <example_master_node> <2>
+         - <example_master_node>
 ----
-<1> The amount of storage available to the PV. Adjust this value for your requirements.
-<2> Replace this value with the node to attach this PV to.
++
+where:
++
+--
+`100Gi`:: Specifies the amount of storage available to the PV. Adjust this value for your requirements.
+`<example_master_node>`:: Specifies the node to attach this PV to.
+--
 +
 .. Verify the creation of the PV by running the following command:
 +
@@ -164,9 +172,10 @@ spec:
   volumeMode: Filesystem
   resources:
     requests:
-      storage: 10Gi <1>
+      storage: 10Gi
 ----
-<1> The amount of storage available to the PVC. Adjust this value for your requirements.
++
+Adjust the `storage` value for your requirements.
 +
 .. Apply the PVC by running the following command:
 +
@@ -185,9 +194,10 @@ metadata:
   name: etcd-single-backup
   namespace: openshift-etcd
 spec:
-  pvcName: etcd-backup-pvc <1>
+  pvcName: etcd-backup-pvc
 ----
-<1> The name of the persistent volume claim (PVC) to save the backup to. Adjust this value according to your environment.
++
+Adjust the `pvcName` value according to your environment.
 +
 .. Apply the CR to start a single backup:
 +

--- a/modules/update-backup-etcd-database-before-update.adoc
+++ b/modules/update-backup-etcd-database-before-update.adoc
@@ -1,0 +1,10 @@
+// Module included in the following assemblies:
+//
+// * edge_computing/day_2_core_cnf_clusters/updating/update-before-the-update.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="update-backup-etcd-database-before-update_{context}"]
+= Backup the etcd database before you proceed with the update
+
+[role="_abstract"]
+You must backup the etcd database before you proceed with the update.

--- a/modules/update-pause-worker-nodes-before-the-update.adoc
+++ b/modules/update-pause-worker-nodes-before-the-update.adoc
@@ -41,7 +41,7 @@ master  false
 mcp-1   true
 mcp-2   true
 ----
-
++
 [NOTE]
 ====
 The default control plane and worker `mcp` groups are not changed during an update.

--- a/post_installation_configuration/day_2_core_cnf_clusters/updating/update-before-the-update.adoc
+++ b/post_installation_configuration/day_2_core_cnf_clusters/updating/update-before-the-update.adoc
@@ -11,10 +11,7 @@ Before you start the cluster update, you must pause worker nodes, back up the et
 
 include::modules/update-pause-worker-nodes-before-the-update.adoc[leveloffset=+1]
 
-[id="update-backup-etcd-database-before-update_{context}"]
-== Backup the etcd database before you proceed with the update
-
-You must backup the etcd database before you proceed with the update.
+include::modules/update-backup-etcd-database-before-update.adoc[leveloffset=+1]
 
 include::modules/backup-etcd.adoc[leveloffset=+2]
 


### PR DESCRIPTION
## Summary
- Replace 5 `[NOTE]` callout conversions with DITA-compliant patterns in `creating-single-etcd-backup.adoc`:
  - Single-value explanations → simple continuation sentences
  - Multi-value placeholders → "where:" definition list
- Add `[role="_abstract"]` to modules
- Extract inline assembly content to new module
- Fix `+` list continuation in `update-pause-worker-nodes-before-the-update.adoc`

Follows up on #106567.

## JIRA
https://issues.redhat.com/browse/TELCODOCS-2706

## Test plan
- [x] Vale AsciiDocDITA validation passes with 0 errors and 0 warnings
- [x] Review content changes for accuracy
- [ ] Build documentation locally


Made with [Cursor](https://cursor.com)