### PR TITLE
TELCODOCS-2735 DITA migration cleanup for update-completing-the-z-stream-update.adoc

### DIFF
--- a/modules/update-starting-the-cluster-update.adoc
+++ b/modules/update-starting-the-cluster-update.adoc
@@ -32,10 +32,10 @@ $ oc adm upgrade --to=4.15.33
 * **Z-stream update** - Verify that there are no problems moving to that specific release
 ====
 
-.Example output
 [source,terminal]
 ----
-Requested update to 4.15.33 <1>
+Requested update to 4.15.33
 ----
-<1> The `Requested update` value changes depending on your particular update.
+
+The `Requested update` value changes depending on your particular update.
 --

--- a/modules/update-updating-the-worker-nodes.adoc
+++ b/modules/update-updating-the-worker-nodes.adoc
@@ -19,6 +19,8 @@ This is a potential holding point.
 You can have a cluster version that is fully supported to run in production with the control plane that is updated to a new EUS release while the worker nodes are at a <y-2>-release. This allows large clusters to upgrade in steps across several maintenance windows.
 ====
 
+.Procedure
+
 . You can check how many nodes are managed in an `mcp` group.
 Run the following command to get the list of `mcp` groups:
 +


### PR DESCRIPTION
## Summary
- Replace single bullet callout conversion with plain sentence in `update-starting-the-cluster-update.adoc`
- Remove `.Example output` block title
- Add `.Procedure` marker to `update-updating-the-worker-nodes.adoc`

Follows up on #106631.

## JIRA
https://issues.redhat.com/browse/TELCODOCS-2735

## Test plan
- [x] Vale AsciiDocDITA validation passes with 0 errors and 0 warnings
- [ ] Review content changes for accuracy
- [ ] Build documentation locally


Made with [Cursor](https://cursor.com)