### PR TITLE
TELCODOCS-2736 DITA migration cleanup for update-ocp-update-prep.adoc

### DIFF
--- a/modules/update-applying-mcp-labels-to-nodes-before-the-update.adoc
+++ b/modules/update-applying-mcp-labels-to-nodes-before-the-update.adoc
@@ -12,16 +12,14 @@ With MCP groups, you can reboot groups of nodes independently from the rest of t
 
 You use the MCP node labels to pause and unpause the set of nodes during the update process so that you can do the update and reboot at a time of your choosing.
 
-[id="update-staggering-the-cluster-update_{context}"]
-== Staggering the cluster update
+*Staggering the cluster update*
 
 Sometimes there are problems during the update.
 Often the problem is related to hardware failure or nodes needing to be reset.
 Using MCP node labels, you can update nodes in stages by pausing the update at critical moments, tracking paused and unpaused nodes as you proceed.
 When a problem occurs, you use the nodes that are in an unpaused state to ensure that there are enough nodes running to keep all applications pods running.
 
-[id="update-dividing-worker-nodes-into-mcp-groups_{context}"]
-== Dividing worker nodes into MachineConfigPool groups
+*Dividing worker nodes into MachineConfigPool groups*
 
 How you divide worker nodes into MCPs can vary depending on how many nodes are in the cluster or how many nodes you assign to a node role.
 By default, the two roles in a cluster are control plane and worker roles.
@@ -61,3 +59,5 @@ The process and pace at which you unpause the MCP groups is determined by your a
 
 If your pod can handle being scheduled across nodes in a cluster, you can unpause several MCP groups at a time and set the `MaxUnavailable` field in the MCP custom resource (CR) to as high as 50%. This allows up to half of the nodes in an MCP group to restart and get updated.
 ====
+
+.Procedure

--- a/modules/update-ensuring-the-host-firmware-is-compatible.adoc
+++ b/modules/update-ensuring-the-host-firmware-is-compatible.adoc
@@ -20,3 +20,5 @@ For example, workloads with high throughput requirements can be negatively affec
 You should thoroughly test new firmware updates to ensure that they work as expected with the current version of {product-title}.
 For best results, test the latest firmware version with the target {product-title} update version.
 ====
+
+.Procedure

--- a/post_installation_configuration/day_2_core_cnf_clusters/updating/update-ocp-update-prep.adoc
+++ b/post_installation_configuration/day_2_core_cnf_clusters/updating/update-ocp-update-prep.adoc
@@ -9,6 +9,18 @@ toc::[]
 [role="_abstract"]
 On bare-metal hardware, you often must update the firmware to take on important security fixes, take on new functionality, or maintain compatibility with the new release of {product-title}.
 
+[id="update-environment-considerations_{context}"]
+== Disconnected environment considerations
+
+To update clusters in disconnected environments, you must update your offline image repository.
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../../rest_api/overview/understanding-compatibility-guidelines.adoc#api-compatibility-guidelines_compatibility-guidelines[API compatibility guidelines]
+
+* xref:../../../disconnected/about-installing-oc-mirror-v2.adoc#about-installing-oc-mirror-v2[Mirroring images for a disconnected installation by using the oc-mirror plugin v2]
+
 include::modules/update-ensuring-the-host-firmware-is-compatible.adoc[leveloffset=+1]
 
 include::modules/update-ensuring-that-layered-products-are-compatible.adoc[leveloffset=+1]
@@ -41,18 +53,6 @@ include::modules/update-creating-mcp-groups-for-the-cluster.adoc[leveloffset=+2]
 * xref:../../../post_installation_configuration/day_2_core_cnf_clusters/updating/update-cnf-update-prep.adoc#update-pdb_update-cnf-update-prep[Ensuring that CNF workloads run uninterrupted with pod disruption budgets]
 
 * xref:../../../post_installation_configuration/day_2_core_cnf_clusters/updating/update-cnf-update-prep.adoc#update-pod-anti-affinity_update-cnf-update-prep[Ensuring that pods do not run on the same cluster node]
-
-[id="update-environment-considerations_{context}"]
-== Disconnected environment considerations
-
-To update clusters in disconnected environments, you must update your offline image repository.
-
-[role="_additional-resources"]
-.Additional resources
-
-* xref:../../../rest_api/overview/understanding-compatibility-guidelines.adoc#api-compatibility-guidelines_compatibility-guidelines[API compatibility guidelines]
-
-* xref:../../../disconnected/about-installing-oc-mirror-v2.adoc#about-installing-oc-mirror-v2[Mirroring images for a disconnected installation by using the oc-mirror plugin v2]
 
 include::modules/update-preparing-the-platform-for-update.adoc[leveloffset=+1]
 


### PR DESCRIPTION
## Summary
- Add missing newline at EOF in `update-applying-mcp-labels-to-nodes-before-the-update.adoc`
- Replace `==` subsection headings with bold text for DITA compatibility
- Add `.Procedure` markers
- Move "Disconnected environment considerations" section in assembly

Follows up on #106632.

## JIRA
https://issues.redhat.com/browse/TELCODOCS-2736

## Test plan
- [x] Vale AsciiDocDITA validation passes with 0 errors and 0 warnings
- [ ] Review content changes for accuracy
- [ ] Build documentation locally


Made with [Cursor](https://cursor.com)