### PR TITLE
OSDOCS-19446-1:Updated z-stream RN for 4.18.40

### DIFF
--- a/modules/zstream-4-18-40.adoc
+++ b/modules/zstream-4-18-40.adoc
@@ -4,12 +4,12 @@
 
 :_mod-docs-content-type: REFERENCE
 [id="zstream-4-18-40_{context}"]
-= RHSA-2026:13736 - {product-title} {product-version}.40 fixed issues and security update
+= RHSA-2026:13727 and RHSA-2026:13736 - {product-title} {product-version}.40 fixed issues and security update
 
 Issued: 06 May 2026
 
 [role="_abstract"]
-{product-title} release {product-version}.40 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2026:13736[RHSA-2026:13736] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2026:13726[RHBA-2026:13726] advisory.
+{product-title} release {product-version}.40 is now available. The lists of bug fixes that are included in the update are documented in the link:https://access.redhat.com/errata/RHSA-2026:13727[RHSA-2026:13727] and link:https://access.redhat.com/errata/RHSA-2026:13736[RHSA-2026:13736] advisories. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2026:13726[RHBA-2026:13726] advisory.
 
 Space precluded documenting all of the container images for this release in the advisory.
 


### PR DESCRIPTION
Version(s):
4.18

Issue:
https://redhat.atlassian.net/browse/OSDOCS-19446

Link to docs preview:
https://111657--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-18-release-notes.html#zstream-4-18-40_release-notes

Additional information:
4.18.40 MR: https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/503
ART Dashboard: https://art-dash.engineering.redhat.com/dashboard/release/openshift-4.18