### PR TITLE
OCPBUGS-85437: Added subnet collision information to hcp-custom-ovn-s…

### DIFF
--- a/modules/hcp-custom-ovn-subnets.adoc
+++ b/modules/hcp-custom-ovn-subnets.adoc
@@ -9,7 +9,7 @@
 [role="_abstract"]
 In hosted clusters, you can configure internal OVN subnets to avoid routing conflicts, customize network architecture, or enable virtual private cloud (VPC) peering.
 
-Avoid CIDR conflicts:: Connect VPCs that host {product-rosa} clusters with other VPCs that use the default OVN internal subnets of 100.88.0.0/16 and 100.64.0.0/16.
+Avoid CIDR conflicts:: Connect VPCs that host {product-rosa} clusters with other VPCs that use the default OVN internal subnets of 100.88.0.0/16 and 100.64.0.0/16. To avoid a conflict on a `kubevirt` hosted cluster, the HyperShift Operator sets the OVN join subnet to `100.66.0.0/16` instead of `100.64.0.0/16` or `100.65.0.0/16`. The default CIDR for the OVN gateway router is `100.64.0.0/16`. The default CIDR for the user-defined network (UDN) join subnet is `100.65.0.0/16`.
 Customize network architecture:: Configure internal OVN subnets to align with your corporate network policies.
 Enable VPC peering:: Deploy hosted clusters in environments where default subnets conflict with peered networks.
 

--- a/modules/hcp-custom-ovn-subnets.adoc
+++ b/modules/hcp-custom-ovn-subnets.adoc
@@ -9,7 +9,7 @@
 [role="_abstract"]
 In hosted clusters, you can configure internal OVN subnets to avoid routing conflicts, customize network architecture, or enable virtual private cloud (VPC) peering.
 
-Avoid CIDR conflicts:: Connect VPCs that host {product-rosa} clusters with other VPCs that use the default OVN internal subnets of 100.88.0.0/16 and 100.64.0.0/16.
+Avoid CIDR conflicts:: Connect VPCs that host {product-rosa} clusters with other VPCs that use the default OVN internal subnets of 100.88.0.0/16 and 100.64.0.0/16. To avoid a conflict on a `kubevirt` hosted cluster, the HyperShift Operator sets the OVN join subnet to `100.66.0.0./16` instead of `100.64.0.0./16` or `100.65.0.0/16`. The default CIDR for the OVN gateway router is `100.64.0.0./16`. The default CIDR for the user-defined network (UDN) join subnet is `100.65.0.0/16`.
 Customize network architecture:: Configure internal OVN subnets to align with your corporate network policies.
 Enable VPC peering:: Deploy hosted clusters in environments where default subnets conflict with peered networks.
 


### PR DESCRIPTION
Version(s):
4.20+

Issue:
[OCPBUGS-85437](https://redhat.atlassian.net/browse/OCPBUGS-85437)

Link to docs preview:

* [Configuring internal OVN IPv4 subnets for hosted clusters](https://111658--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-networking.html#hcp-custom-ovn-subnets_hcp-networking)


- [x] SME has approved this change (Enrique P).
- [x] QE has approved this change (Jie Zhao).
