### PR TITLE
[enterprise-4.14] OSDOCS-19635 [NETOBSERV] Release notes 1.11.2

### DIFF
--- a/modules/network-observability-operator-release-notes-1-11-2-advisory.adoc
+++ b/modules/network-observability-operator-release-notes-1-11-2-advisory.adoc
@@ -1,0 +1,11 @@
+// Module included in the following assemblies:
+// * network_observability/network-observability-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="network-observability-operator-release-notes-1-11-2-advisory_{context}"]
+= Network Observability Operator 1.11.2 advisory
+
+[role="_abstract"]
+You can review the advisory for Network Observability Operator 1.11.2 release.
+
+* https://access.redhat.com/errata/RHSA-2026:16874[RHSA-2026:16874 Network Observability Operator 1.11.2]

--- a/observability/network_observability/network-observability-operator-release-notes.adoc
+++ b/observability/network_observability/network-observability-operator-release-notes.adoc
@@ -11,7 +11,7 @@ The Network Observability Operator enables administrators to observe and analyze
 
 These release notes track the development of the Network Observability Operator in the {product-title}.
 
-For an overview of the Network Observability Operator, see xref:../../observability/network_observability/network-observability-overview.adoc#network-observability-overview[About network observability].
+include::modules/network-observability-operator-release-notes-1-11-2-advisory.adoc[leveloffset=+1]
 
 include::modules/network-observability-operator-release-notes-1-11-1-advisory.adoc[leveloffset=+1]
 


### PR DESCRIPTION
Manual cherry-pick

Original commit: 2752198dc9194b3f6e75ab70cb13917f8310b851

Original PR: https://github.com/openshift/openshift-docs/pull/111350

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.14


QE review:
QE is not required for this PR.

Additional information:
* Links are not allowed in assembly files unless in an "Additional resources" section. That change was not cherry-picked back to 4.14 as CQA updates stopped being cherry-picked back that far when that update was made.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
