### PR TITLE
[enterprise-4.15] OSDOCS-19635 [NETOBSERV] Release notes 1.11.2

### DIFF
--- a/modules/network-observability-operator-release-notes-1-11-1-advisory.adoc
+++ b/modules/network-observability-operator-release-notes-1-11-1-advisory.adoc
@@ -1,0 +1,11 @@
+// Module included in the following assemblies:
+// * network_observability/network-observability-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="network-observability-operator-release-notes-1-11-1-advisory_{context}"]
+= Network Observability Operator 1.11.1 advisory
+
+[role="_abstract"]
+You can review the advisory for Network Observability Operator 1.11.1 release.
+
+* link:https://access.redhat.com/errata/RHSA-2026:6428[RHSA-2026:6428 Network Observability Operator 1.11.1]

--- a/modules/network-observability-operator-release-notes-1-11-1-fixed-issues.adoc
+++ b/modules/network-observability-operator-release-notes-1-11-1-fixed-issues.adoc
@@ -1,0 +1,42 @@
+// Module included in the following assemblies:
+// * network_observability/network-observability-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="network-observability-operator-release-notes-1-11-1-fixed-issues_{context}"]
+= Network Observability Operator 1.11.1 fixed issues
+
+[role="_abstract"]
+The Network Observability Operator 1.11.1 release contains several fixed issues that improve eBPF agent performance and the user experience in the {product-title} web console.
+
+eBPF agent memory usage optimization::
+Before this update, a regression in the eBPF agent caused kernel memory to be reserved unintentionally for disabled features. This resulted in higher than expected memory usage for the agent.
++
+With this update, the eBPF agent ensures that reserved kernel memory is kept to a minimum when features are disabled. As a result, the agent's memory footprint is reduced and resource allocation is more efficient.
++
+link:https://issues.redhat.com/browse/NETOBSERV-2656[NETOBSERV-2656]
+
+Improved DNS graph availability in Prometheus-only mode::
+Before this update, when Loki was disabled and DNS tracking was enabled, the {product-title} console plugin failed to display any DNS graphs. Instead, it displayed an error stating the request could not be performed with Prometheus metrics, even for graphs that had valid Prometheus data.
++
+With this update, the error is only displayed for specific graphs that lack configured metrics. As a result, all valid DNS graphs are now correctly displayed in the web console.
++
+link:https://issues.redhat.com/browse/NETOBSERV-2621[NETOBSERV-2621]
+
+Improved error handling in Topology view::
+Before this update, in installations without Loki, certain queries in the *Topology* view could result in errors due to missing Prometheus metrics. These errors sometimes persisted until you cleared the browser cache.
++
+With this update, the console no longer displays invalid scopes caused by missing metrics. Additionally, error handling in the console has been updated to provide more actionable information, eliminating the need for manual cache clears in these scenarios.
++
+link:https://issues.redhat.com/browse/NETOBSERV-2477[NETOBSERV-2477]
+
+////
+Follow this format:
+
+MetricName and Remap fields are validated::
++
+Before this update, users could create a `FlowMetric` custom resource (CR) with an invalid metric name. Although the `FlowMetric` CR was successfully created, the underlying metric would fail silently without providing any error feedback to the user.
++
+With this release, the `FlowMetric`, `metricName`, and `remap` fields are now validated before creation, so users are immediately notified if they enter an invalid name.
++
+link:https://issues.redhat.com/browse/NETOBSERV-2348[NETOBSERV-2348]
+////

--- a/modules/network-observability-operator-release-notes-1-11-2-advisory.adoc
+++ b/modules/network-observability-operator-release-notes-1-11-2-advisory.adoc
@@ -1,0 +1,11 @@
+// Module included in the following assemblies:
+// * network_observability/network-observability-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="network-observability-operator-release-notes-1-11-2-advisory_{context}"]
+= Network Observability Operator 1.11.2 advisory
+
+[role="_abstract"]
+You can review the advisory for Network Observability Operator 1.11.2 release.
+
+* https://access.redhat.com/errata/RHSA-2026:16874[RHSA-2026:16874 Network Observability Operator 1.11.2]

--- a/observability/network_observability/network-observability-operator-release-notes.adoc
+++ b/observability/network_observability/network-observability-operator-release-notes.adoc
@@ -11,7 +11,11 @@ The Network Observability Operator enables administrators to observe and analyze
 
 These release notes track the development of the Network Observability Operator in the {product-title}.
 
-For an overview of the Network Observability Operator, see xref:../../observability/network_observability/network-observability-overview.adoc#network-observability-overview[About network observability].
+include::modules/network-observability-operator-release-notes-1-11-2-advisory.adoc[leveloffset=+1]
+
+include::modules/network-observability-operator-release-notes-1-11-1-advisory.adoc[leveloffset=+1]
+
+include::modules/network-observability-operator-release-notes-1-11-1-fixed-issues.adoc[leveloffset=+1]
 
 include::modules/network-observability-operator-release-notes-1-11-advisory.adoc[leveloffset=+1]
 


### PR DESCRIPTION
Manual cherry-pick

Original commit: https://github.com/openshift/openshift-docs/commit/2752198dc9194b3f6e75ab70cb13917f8310b851

Original PR: https://github.com/openshift/openshift-docs/pull/111350

Version(s):
4.15

QE review:
QE is not required for this PR.

Additional information:
* Links are not allowed in assembly files unless in an "Additional resources" section. That change was not cherry-picked back to 4.15 as CQA updates stopped being cherry-picked back that far when that update was made.
* 4 files instead of 2 because 1.11.1 advisory and fixed issue modules were missing.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
