### PR TITLE
[enterprise-4.17] OSDOCS-19635 [NETOBSERV] Release notes 1.11.2

### DIFF
--- a/modules/network-observability-operator-release-notes-1-11-2-advisory.adoc
+++ b/modules/network-observability-operator-release-notes-1-11-2-advisory.adoc
@@ -1,0 +1,11 @@
+// Module included in the following assemblies:
+// * network_observability/network-observability-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="network-observability-operator-release-notes-1-11-2-advisory_{context}"]
+= Network Observability Operator 1.11.2 advisory
+
+[role="_abstract"]
+You can review the advisory for Network Observability Operator 1.11.2 release.
+
+* https://access.redhat.com/errata/RHSA-2026:16874[RHSA-2026:16874 Network Observability Operator 1.11.2]

--- a/observability/network_observability/network-observability-operator-release-notes.adoc
+++ b/observability/network_observability/network-observability-operator-release-notes.adoc
@@ -11,7 +11,7 @@ The Network Observability Operator enables administrators to observe and analyze
 
 These release notes track the development of the Network Observability Operator in the {product-title}.
 
-For an overview of the Network Observability Operator, see xref:../../observability/network_observability/network-observability-overview.adoc#network-observability-overview[About network observability].
+include::modules/network-observability-operator-release-notes-1-11-2-advisory.adoc[leveloffset=+1]
 
 include::modules/network-observability-operator-release-notes-1-11-1-advisory.adoc[leveloffset=+1]
 


### PR DESCRIPTION
Manual cherry-pick

Original commit: https://github.com/openshift/openshift-docs/commit/2752198dc9194b3f6e75ab70cb13917f8310b851

Original PR: https://github.com/openshift/openshift-docs/pull/111350

Version(s):
4.17

QE review:
QE is not required for this PR.

Additional information:
* Links are not allowed in assembly files unless in an "Additional resources" section. That change was not cherry-picked back to 4.17 as CQA updates stopped being cherry-picked back that far when that update was made.