### PR TITLE
OSDOCS-19448: oc adm upgrade recommend custom alert RN

### DIFF
--- a/modules/rn-ocp-release-notes-new-features.adoc
+++ b/modules/rn-ocp-release-notes-new-features.adoc
@@ -144,6 +144,12 @@ With this update, you can install a cluster using {op-system-base} version 10 as
 +
 For more information, see xref:../installing/install_config/installation-config-parameters-generic.adoc#installation-config-parameters-generic[Installation configuration parameters].
 
+Adding custom alerts to `oc adm upgrade recommend` command output::
++
+With this update, you can add the `openShiftUpdatePrecheck` label to alerts in a `PrometheusRule` custom resource (CR) so that, when you run the `oc adm upgrade recommend` command, any firing alerts with this label appear in the command output.
++
+For more information, see xref:../updating/preparing_for_updates/updating-cluster-prepare.adoc#oc-adm-upgrade-recommend-custom-alert_updating-cluster-prepare[Adding custom alerts to `oc adm upgrade recommend` command output].
+
 [id="ocp-release-notes-machine-config-operator_{context}"]
 == Machine Config Operator
 
@@ -320,7 +326,7 @@ Support for integrated OCI chart interaction::
 +
 The {product-title} web console now fully supports browsing, inspecting, and installing Open Container Initiative (OCI)-based Helm charts directly from configured repositories to provide functional parity with traditional HTTP(S) Helm charts. This enhancement removes the previous discovery-only limitation, enabling users to interact with and deploy OCI-based charts seamlessly within the console's repository views.
 +
-For more information, see xref:../applications/working_with_helm_charts/configuring-custom-helm-chart-repositories.adoc#configuring-custom-helm-chart-repositories[Configuring custom Helm chart repositories]. 
+For more information, see xref:../applications/working_with_helm_charts/configuring-custom-helm-chart-repositories.adoc#configuring-custom-helm-chart-repositories[Configuring custom Helm chart repositories].
 
 Azure Resource Group field for operator installations on Azure WIF clusters::
 +


### PR DESCRIPTION
[OSDOCS-19448](https://redhat.atlassian.net/browse/OSDOCS-19448)

Version(s): 4.22

This PR adds a release note for functionality relating to the `openShiftUpdatePrecheck` label and the `oc adm upgrade recommend` command.

QE review:
- [x] QE has approved this change.

Preview: [Release note](https://111680--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-22-release-notes.html#ocp-release-notes-install-update_release-notes:~:text=Adding%20custom%20alerts)