### PR TITLE
OSDOCS-19804:Update the z-stream RNs for 4.21.16

### DIFF
--- a/modules/zstream-4-21-16.adoc
+++ b/modules/zstream-4-21-16.adoc
@@ -1,0 +1,42 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-21-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-21-16_{context}"]
+= RHSA-2026:17474 - {product-title} {product-version}.16 fixed issues advisory
+
+Issued: 19 May 2026
+
+[role="_abstract"]
+{product-title} release {product-version}.16 is now available. The list of fixed issues that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2026:17474[RHSA-2026:17474] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2026:17472[RHBA-2026:17472] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.21.16 --pullspecs
+----
+
+[id="zstream-4-21-16-known-issues_{context}"]
+== Known issues
+
+* Booting the `Baremetalhost` object into the correct operating system repeatedly fails on certain Baseboard Management Controller (BMC) firmware versions because the SuperMicro ARS-111GL-NHR server boots into an existing hard drive instead of virtual media. This issue is caused by an unusual change of boot device names between `CD` and `USB CD` across firmware versions. As a consequence, the node inspection might fail. In this situation, try updating to the latest BMC and BIOS firmware or manually setting the `BootSourceOverrideTarget` parameter to `USB CD` instead of `CD` to successfully boot the node from the correct virtual media. (link:https://issues.redhat.com/browse/OCPBUGS-82298[OCPBUGS-82298])
+
+[id="zstream-4-21-16-fixed-issues_{context}"]
+== Fixed issues
+
+* Before this update, when going into holdover a new data set was defined for the `ts2phc` command as it started reporting offsets, which did not meet the minimum number of samples. As a consequence, the PTP Operator  incorrectly reported a `FREERUN` clock state immediately. With this release, when going into holdover the offset is calculated based on the slope defined by the holdover thresholds. As a result, the offset steadily increases until it goes over the threshold. The clock state correctly transitions from `HOLDOVER` to `HOLDOVER OUT-OF-SPEC` and finally to `FREERUN`. (link:https://issues.redhat.com/browse/OCPBUGS-77473[OCPBUGS-77473])
+
+* Before this update, {ibm-cloud-title} was unable to process new `SecurityGroup` rule types such as `any` and older versions of the Software Development Kit (SDK) for the Virtual Private Cloud (VPC) could not unmarshal a VPC with these new types. As a consequence, the installation program could not set up a new VPC or use an existing VPC with the `any` protocol type. With this release, the SDK for the VPC is updated to support the unmarshalling of the new types. As a result, the `SecurityGroup` rule bug is resolved and the installation program can create or use a VPC with the new `SecurityGroup` rule types. (link:https://redhat.atlassian.net/browse/OCPBUGS-84225[OCPBUGS-84225])
+
+* Before this update, a race condition in the container stop path could have caused CRI-O to panic with a "send on closed channel" message when a second `StopContainer` call arrived after the first had already completed and closed the internal stop channel. As a consequence, the CRI-O process crashed, potentially leaving pods stuck in a terminating state. With this release, a `stopDone` guard is added to the `WaitOnStopTimeout` method so that it returns early after the stop life cycle is complete. As a result, concurrent `StopContainer` calls do not cause a panic by sending on a closed channel. (link:https://redhat.atlassian.net/browse/OCPBUGS-84922[OCPBUGS-84922])
+
+* Before this update, pagination controls were not present at mobile resolutions because PatternFly expected both top and bottom pagination controls to be used. With this release, pagination controls are present regardless of the mobile resolution. (link:https://redhat.atlassian.net/browse/OCPBUGS-84967[OCPBUGS-84967])
+
+[id="zstream-4-21-16-updating_{context}"]
+== Updating
+
+To update an {product-title} 4.21 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].

--- a/release_notes/ocp-4-21-release-notes.adoc
+++ b/release_notes/ocp-4-21-release-notes.adoc
@@ -44,6 +44,9 @@ include::modules/rn-ocp-release-notes-known-issues.adoc[leveloffset=+1]
 // Asynchronous errata updates
 include::modules/rn-async-errata.adoc[leveloffset=+1]
 
+// 4.21.16 RNs and updating
+include::modules/zstream-4-21-16.adoc[leveloffset=+2]
+
 // 4.21.15 RNs and updating
 include::modules/zstream-4-21-15.adoc[leveloffset=+2]
 


### PR DESCRIPTION
Version(s):
4.21

Issue:
https://redhat.atlassian.net/browse/OSDOCS-19804

Link to docs preview:
https://111681--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-21-release-notes.html#zstream-4-21-16_release-notes

Additional information:
4.21.16 MR: https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/533
ART Dashboard: https://art-dash.engineering.redhat.com/dashboard/release/openshift-4.21