### PR TITLE
OSDOCS-19787:Update the z-stream RNs for 4.14.66

### DIFF
--- a/modules/zstream-4-14-66.adoc
+++ b/modules/zstream-4-14-66.adoc
@@ -1,0 +1,31 @@
+// Module included in the following assembly:
+//
+// * release_notes/ocp-4-14-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-14-66-bug-fixes_{context}"]
+= RHBA-2026:16177 - {product-title} {product-version}.66 image release, fixed issues, and security update
+
+Issued: 14 May 2026
+
+[role="_abstract"]
+{product-title} release {product-version}.66 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2026:16177[RHBA-2026:16177] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2026:16175[RHBA-2026:16175] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.14.66 --pullspecs
+----
+
+[id="zstream-4-14-66-fixed_issues_{context}"]
+== Fixed issues
+
+There are no notable fixed issues in this release.
+
+[id="zstream-4-14-66-updating_{context}"]
+== Updating
+
+To update an {product-title} 4.14 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].

--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -3413,6 +3413,9 @@ The impact is on East/West traffic in local gateway mode with `routingViaHost` s
 // 4.14 about async
 include::modules/rn-async-errata.adoc[leveloffset=+1]
 
+// 4.14.66 Rns and updating
+include::modules/zstream-4-14-66.adoc[leveloffset=+2]
+
 // 4.14.65 Rns and updating
 include::modules/zstream-4-14-65.adoc[leveloffset=+2]
 


### PR DESCRIPTION
Version(s):
4.14

Issue:
https://redhat.atlassian.net/browse/OSDOCS-19787

Link to docs preview:
https://111684--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes.html#zstream-4-14-66-bug-fixes_release-notes

Additional information:
4.14.66 MR:  https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/527
ART Dashboard:  https://art-dash.engineering.redhat.com/dashboard/release/openshift-4.14