### PR TITLE
CNV-80160: Live migration dual stream support

### DIFF
--- a/modules/virt-vm-migration-dual-stream.adoc
+++ b/modules/virt-vm-migration-dual-stream.adoc
@@ -1,0 +1,21 @@
+
+// Module included in the following assemblies:
+//
+// * virt/live_migration/virt-about-live-migration.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="virt-vm-migration-dual-stream_{context}"]
+= VM migration support for {op-system} 10.x
+
+[role="_abstract"]
+
+:FeatureName: Live migration support for {op-system} 10.x
+include::snippets/technology-preview.adoc[]
+
+{VirtProductName} 4.22 and later versions supports live migration with {op-system} 10.x worker nodes as a Technology Preview feature.
+
+For information on configuring your cluster to use {op-system} 10.x, refer to the {product-title} documentation.
+
+When performing live migration on a cluster using {op-system} 10.x, the migration does not complete successfully when the migration policy uses the attribute `allowPostCopy: true`. This is a known limitation.
+
+Live migration is supported across both {op-system} 9.x and 10.x worker nodes when both versions are present in a cluster. Any VM live migration from {op-system} 10.x to {op-system} 9.x and from {op-system} 9.x to {op-system} 10.x worker nodes, is a Technology Preview feature in {product-title} 4.22.

--- a/modules/virt-vm-migration-dual-stream.adoc
+++ b/modules/virt-vm-migration-dual-stream.adoc
@@ -12,10 +12,10 @@
 :FeatureName: Live migration support for {op-system} 10.x
 include::snippets/technology-preview.adoc[]
 
-{product-title} 4.21.2 and greater supports the use of {op-system-first} 10.x in a cluster as a Technology Preview feature. {VirtProductTitle} 4.22 and greater live migration supports {op-system} 10.x worker nodes as a Technology Preview feature.
+{product-title} 4.21.2 and greater supports the use of {op-system-first} 10.x in a cluster as a Technology Preview feature. {VirtProductName} 4.22 and greater live migration supports {op-system} 10.x worker nodes as a Technology Preview feature.
 
 For information on configuring your cluster to use {op-system} 10.x, refer to the {product-title} documentation.
 
-When performing live migration on a cluster using {op-system} 10.x, the migration does not complete successfully when the migration policy uses the attribute `allowPostCopy=True`. If your cluster uses {op-first} 10.x, adjust your migration policies to not use this attribute.
+When performing live migration on a cluster using {op-system} 10.x, the migration does not complete successfully when the migration policy uses the attribute `allowPostCopy=True`. If your cluster uses {op-system} 10.x, adjust your migration policies to not use this attribute.
 
 Live migration is supported across both {op-system} 9.x and 10.x worker nodes when both versions are present in a cluster.

--- a/modules/virt-vm-migration-dual-stream.adoc
+++ b/modules/virt-vm-migration-dual-stream.adoc
@@ -16,6 +16,6 @@ include::snippets/technology-preview.adoc[]
 
 For information on configuring your cluster to use {op-system} 10.x, refer to the {product-title} documentation.
 
-When performing live migration on a cluster using {op-system} 10.x, the migration does not complete successfully when the migration policy uses the attribute `allowPostCopy=True`. If your cluster uses {op-system} 10.x, adjust your migration policies to not use this attribute.
+When performing live migration on a cluster using {op-system} 10.x, the migration does not complete successfully when the migration policy uses the attribute `allowPostCopy=True`. This is a known limitation.
 
 Live migration is supported across both {op-system} 9.x and 10.x worker nodes when both versions are present in a cluster.

--- a/modules/virt-vm-migration-dual-stream.adoc
+++ b/modules/virt-vm-migration-dual-stream.adoc
@@ -1,0 +1,21 @@
+
+// Module included in the following assemblies:
+//
+// * virt/live_migration/virt-about-live-migration.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="virt-vm-migration-dual-stream_{context}"]
+= VM migration support for {op-system} 10.x
+
+[role="_abstract"]
+
+:FeatureName: Live migration support for {op-system} 10.x
+include::snippets/technology-preview.adoc[]
+
+{product-title} 4.21.2 and greater supports the use of {op-system-first} 10.x in a cluster as a Technology Preview feature. {VirtProductTitle} 4.22 and greater live migration supports {op-system} 10.x worker nodes as a Technology Preview feature.
+
+For information on configuring your cluster to use {op-system} 10.x, refer to the {product-title} documentation.
+
+When performing live migration on a cluster using {op-system} 10.x, the migration does not complete successfully when the migration policy uses the attribute `allowPostCopy=True`. If your cluster uses {op-first} 10.x, adjust your migration policies to not use this attribute.
+
+Live migration is supported across both {op-system} 9.x and 10.x worker nodes when both versions are present in a cluster.

--- a/virt/live_migration/virt-about-live-migration.adoc
+++ b/virt/live_migration/virt-about-live-migration.adoc
@@ -21,6 +21,8 @@ include::modules/virt-granting-live-migration-permissions.adoc[leveloffset=+1]
 
 include::modules/virt-vm-migration-tuning.adoc[leveloffset=+1]
 
+include::modules/virt-vm-migration-dual-stream.adoc[leveloffset=+1]
+
 [role="_additional-resources"]
 [id="additional-resources_{context}"]
 == Additional resources


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->
Documentation on live migration support for dual stream RCOS in a cluster.
<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.22+

Issue:
[CNV-80160](https://redhat.atlassian.net/browse/CNV-80160)

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
[VM migration support for RHCOS 10.x](https://111685--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/live_migration/virt-about-live-migration.html#virt-vm-migration-dual-stream_virt-about-live-migration)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
