### PR TITLE
OSDOCS  WMCO 4.22/10.22 update docs for Windows Server 2025

### DIFF
--- a/modules/creating-runtimeclass.adoc
+++ b/modules/creating-runtimeclass.adoc
@@ -17,13 +17,13 @@ Using a `RuntimeClass` object simplifies the use of scheduling mechanisms like t
 apiVersion: node.k8s.io/v1
 kind: RuntimeClass
 metadata:
-  name: windows2019 <1>
+  name: windows2025 <1>
 handler: 'runhcs-wcow-process'
 scheduling:
   nodeSelector: <2>
     kubernetes.io/os: 'windows'
     kubernetes.io/arch: 'amd64'
-    node.kubernetes.io/windows-build: '10.0.17763'
+    node.kubernetes.io/windows-build: '10.0.26100'
   tolerations: <3>
   - effect: NoSchedule
     key: os
@@ -36,8 +36,9 @@ scheduling:
 ----
 <1> Specify the `RuntimeClass` object name, which is defined in the pods you want to be managed by this runtime class.
 <2> Specify labels that must be present on nodes that support this runtime class. Pods using this runtime class can only be scheduled to a node matched by this selector. The node selector of the runtime class is merged with the existing node selector of the pod. Any conflicts prevent the pod from being scheduled to the node.
-* For Windows 2019, specify the `node.kubernetes.io/windows-build: '10.0.17763'` label.
+* For Windows 2025, specify the `node.kubernetes.io/windows-build: '10.0.26100'` label.
 * For Windows 2022, specify the `node.kubernetes.io/windows-build: '10.0.20348'` label.
+* For Windows 2019, specify the `node.kubernetes.io/windows-build: '10.0.17763'` label.
 <3> Specify tolerations to append to pods, excluding duplicates, running with this runtime class during admission. This combines the set of nodes tolerated by the pod and the runtime class.
 
 . Create the `RuntimeClass` object:
@@ -63,7 +64,7 @@ kind: Pod
 metadata:
   name: my-windows-pod
 spec:
-  runtimeClassName: windows2019 <1>
+  runtimeClassName: windows2025 <1>
 # ...
 ----
 <1> Specify the runtime class to manage the scheduling of your pod.

--- a/modules/creating-the-vsphere-windows-vm-golden-image.adoc
+++ b/modules/creating-the-vsphere-windows-vm-golden-image.adoc
@@ -25,7 +25,12 @@ You must use link:https://docs.microsoft.com/en-us/powershell/scripting/install/
 
 .Procedure
 
-.  Select a compatible Windows Server version. Currently, the Windows Machine Config Operator (WMCO) stable version supports Windows Server 2022 Long-Term Servicing Channel with the OS-level container networking patch link:https://support.microsoft.com/en-us/topic/april-25-2022-kb5012637-os-build-20348-681-preview-2233d69c-d4a5-4be9-8c24-04a450861a8d[KB5012637].
+.  Select a compatible Windows Server version. Currently, the Windows Machine Config Operator (WMCO) stable version supports the following versions: 
++
+--
+* Windows Server 2025 Long-Term Servicing Channel
+* Windows Server 2022 Long-Term Servicing Channel with the OS-level container networking patch link:https://support.microsoft.com/en-us/topic/april-25-2022-kb5012637-os-build-20348-681-preview-2233d69c-d4a5-4be9-8c24-04a450861a8d[KB5012637, Microsoft Windows documentation].
+--
 
 . Create a new VM in the vSphere client using the VM golden image with a compatible Windows Server version. For more information about compatible versions, see the "Windows Machine Config Operator prerequisites" section of the "Red Hat OpenShift support for Windows Containers release notes."
 +

--- a/modules/sample-windows-workload-deployment.adoc
+++ b/modules/sample-windows-workload-deployment.adoc
@@ -54,7 +54,7 @@ spec:
     spec:
       containers:
       - name: windowswebserver
-        image: mcr.microsoft.com/windows/servercore:ltsc2019 <1>
+        image: mcr.microsoft.com/windows/servercore:ltsc2025 <1>
         imagePullPolicy: IfNotPresent
         command:
         - powershell.exe <2>
@@ -66,11 +66,12 @@ spec:
             runAsUserName: "ContainerAdministrator"
       os:
         name: "windows"
-      runtimeClassName: windows2019 <3>
+      runtimeClassName: windows2025 <3>
 ----
 <1> Specify the container image to use: `mcr.microsoft.com/powershell:<tag>` or `mcr.microsoft.com/windows/servercore:<tag>`. The container image must match the Windows version running on the node.
-* For Windows 2019, use the `ltsc2019` tag.
+* For Windows 2025, use the `ltsc2025` tag.
 * For Windows 2022, use the `ltsc2022` tag. 
+* For Windows 2019, use the `ltsc2019` tag.
 <2> Specify the commands to execute on the container. 
 * For the `mcr.microsoft.com/powershell:<tag>` container image, you must define the command as `pwsh.exe`. 
 * For the `mcr.microsoft.com/windows/servercore:<tag>` container image, you must define the command as `powershell.exe`. 

--- a/modules/windows-machineset-nutanix.adoc
+++ b/modules/windows-machineset-nutanix.adoc
@@ -78,7 +78,12 @@ You must use the `Legacy` boot type in {product-title} {product-version}.
 ====
 <6> Specifies a Nutanix Prism Element cluster configuration. In this example, the cluster type is `uuid`, so there is a `uuid` stanza.
 <7> Specifies the secret name for the cluster. Do not change this value.
-<8> Specifies the image to use. Use an image from an existing default compute machine set for the cluster.
+<8> Specifies the image to use. Use an image from an existing default compute machine set for the cluster, one of the following options: 
++
+--
+* `nutanix-windows-server-2022` for Windows Server 2022
+* `nutanix-windows-server-2025` for Windows Server 2025
+--
 <9> Specifies the cloud provider platform type. Do not change this value.
 <10> Specifies the amount of memory for the cluster in Gi.
 <11> Specifies a subnet configuration. In this example, the subnet type is `uuid`, so there is a `uuid` stanza.

--- a/modules/windows-pod-placement.adoc
+++ b/modules/windows-pod-placement.adoc
@@ -10,7 +10,7 @@ Before deploying your Windows workloads to the cluster, you must configure your 
 
 With multiple operating systems, and the ability to run multiple Windows OS variants in the same cluster, you must map your Windows pods to a base Windows OS variant by using a `RuntimeClass` object. For example, if you have multiple Windows nodes running on different Windows Server container versions, the cluster could schedule your Windows pods to an incompatible Windows OS variant. You must have `RuntimeClass` objects configured for each Windows OS variant on your cluster. Using a `RuntimeClass` object is also recommended if you have only one Windows OS variant available in your cluster.
 
-For more information, see Microsoft's documentation on link:https://docs.microsoft.com/en-us/virtualization/windowscontainers/deploy-containers/update-containers#host-and-container-version-compatibility[Host and container version compatibility].
+For more information, see Microsoft's documentation on link:https://docs.microsoft.com/en-us/virtualization/windowscontainers/deploy-containers/update-containers#host-and-container-version-compatibility[Host and container version compatibility, Microsoft Windows documentation].
 
 Also, it is recommended that you set the `spec.os.name.windows` parameter in your workload pods. The Windows Machine Config Operator (WMCO) uses this field to authoritatively identify the pod operating system for validation and is used to enforce Windows-specific pod security context constraints (SCCs). Currently, this parameter has no effect on pod scheduling. For more information about this parameter, see the link:https://kubernetes.io/docs/concepts/workloads/pods/#pod-os[Kubernetes Pods documentation].
 
@@ -18,6 +18,6 @@ Also, it is recommended that you set the `spec.os.name.windows` parameter in you
 ====
 The container base image must be the same Windows OS version and build number that is running on the node where the conainer is to be scheduled. 
 
-Also, if you upgrade the Windows nodes from one version to another, for example going from 20H2 to 2022, you must upgrade your container base image to match the new version. For more information, see link:https://learn.microsoft.com/en-us/virtualization/windowscontainers/deploy-containers/version-compatibility?tabs=windows-server-2022%2Cwindows-11-21H2[Windows container version compatibility].
+Also, if you upgrade the Windows nodes from one version to another, for example going from 2022 to 2025, you must upgrade your container base image to match the new version. For more information, see link:https://learn.microsoft.com/en-us/virtualization/windowscontainers/deploy-containers/version-compatibility?tabs=windows-server-2022%2Cwindows-11-21H2[Windows container version compatibility, Microsoft Windows documentation].
 ====
 

--- a/windows_containers/creating_windows_machinesets/creating-windows-machineset-aws.adoc
+++ b/windows_containers/creating_windows_machinesets/creating-windows-machineset-aws.adoc
@@ -16,6 +16,13 @@ You can create a Windows `MachineSet` object to serve a specific purpose in your
 +
 Use one of the following `aws` commands, as appropriate for your Windows Server release, to query valid AMI images:
 +
+.Example Windows Server 2025 command
++
+[source,terminal]
+----
+$ aws ec2 describe-images --region <aws_region_name> --filters "Name=name,Values=Windows_Server-2025*English*Core*Base*" "Name=is-public,Values=true" --query "reverse(sort_by(Images, &CreationDate))[*].{name: Name, id: ImageId}" --output table
+----
++
 .Example Windows Server 2022 command
 +
 [source,terminal]
@@ -23,7 +30,7 @@ Use one of the following `aws` commands, as appropriate for your Windows Server 
 $ aws ec2 describe-images --region <aws_region_name> --filters "Name=name,Values=Windows_Server-2022*English*Core*Base*" "Name=is-public,Values=true" --query "reverse(sort_by(Images, &CreationDate))[*].{name: Name, id: ImageId}" --output table
 ----
 +
-.Example Windows Server 2019 command
+.Example Windows Server 2025 command
 +
 [source,terminal]
 ----


### PR DESCRIPTION
https://redhat.atlassian.net/browse/OSDOCS-17787

[Creating a RuntimeClass object to encapsulate scheduling mechanisms](https://111691--ocpdocs-pr.netlify.app/openshift-enterprise/latest/windows_containers/scheduling-windows-workloads#creating-runtimeclass_scheduling-windows-workloads) -- Updated RuntimeClass to 2025 values; added 2025 to label options.
[Creating the vSphere Windows VM golden image](https://111691--ocpdocs-pr.netlify.app/openshift-enterprise/latest/windows_containers/creating_windows_machinesets/creating-windows-machineset-vsphere#creating-the-vsphere-windows-vm-golden-image_creating-windows-machineset-vsphere) -- Added Windows Server 2025 Long-Term Servicing Channel to procedure
[Scheduling Windows container workloads](https://111691--ocpdocs-pr.netlify.app/openshift-enterprise/latest/windows_containers/scheduling-windows-workloads) -- Updated Deployment to Windows 2025 values; added Windows 2025 as an option.
[Sample YAML for a Windows MachineSet object on Nutanix](https://111691--ocpdocs-pr.netlify.app/openshift-enterprise/latest/windows_containers/creating_windows_machinesets/creating-windows-machineset-nutanix#windows-machineset-nutanix_creating-windows-machineset-nutanix) -- Added image ID strings for Windows 2022 and 2025. 
[Windows pod placement](https://111691--ocpdocs-pr.netlify.app/openshift-enterprise/latest/windows_containers/scheduling-windows-workloads#windows-pod-placement_scheduling-windows-workloads) -- Updated Important note to remove reference to an unsupported Windows version. 
Creating a Windows machine set on AWS -> [Prerequisites](https://111691--ocpdocs-pr.netlify.app/openshift-enterprise/latest/windows_containers/creating_windows_machinesets/creating-windows-machineset-aws#prerequisites) -- Added example command for Windows 2025.
