### PR TITLE
TELCODOCS#2607: Configuring a boundary clock without holdover on GNR-D

### DIFF
--- a/modules/nw-ptp-granite-rapids-boundary-clock-overview.adoc
+++ b/modules/nw-ptp-granite-rapids-boundary-clock-overview.adoc
@@ -1,0 +1,31 @@
+// Module included in the following assemblies:
+//
+// * networking/advanced_networking/ptp/configuring-ptp.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="nw-ptp-granite-rapids-boundary-clock-overview_{context}"]
+= Boundary clocks without holdover on Intel Granite Rapids-D hardware
+
+[role="_abstract"]
+Intel Granite Rapids-D (GNR-D) server platforms support Precision Time Protocol (PTP) boundary clock (BC) deployments without holdover for high-density Radio Access Network (RAN) sites that use onboard Network Acceleration Complex (NAC) ports and optional Carter Flat expansion network interface cards (NICs).
+
+In a BC deployment, one time receiver (TR) port synchronizes to an upstream timing source while time transmitter (TT) ports distribute synchronized time to downstream devices. GNR-D platforms use platform-specific `PtpConfig` plugin configurations and internal timing paths.
+
+Before you configure a BC profile on GNR-D hardware, verify that your qualified hardware layout, interface naming, and plugin configuration align with your deployment requirements.
+
+GNR-D BC deployments use onboard NAC ports as the primary timing controller and can extend timing distribution by using optional Carter Flat expansion NICs. 
+
+GNR-D platforms route synchronization internally instead of using external timing cabling. 
+
+Your qualified hardware layout determines the available TR and TT port roles across NAC ports and optional Carter Flat expansion cards.
+
+[id="nw-ptp-granite-rapids-boundary-clock-overview-without-holdover_{context}"]
+== Boundary clock without holdover behavior
+
+GNR-D boundary clock deployments on Carter Flat hardware do not maintain time synchronization if the upstream timing source becomes unavailable. This deployment model operates without monitored holdover because Carter Flat hardware does not expose sufficient follower digital phase-locked loop (DPLL) accuracy information for holdover support.
+
+To maintain synchronization, keep a continuous connection to a qualified upstream PTP source.
+
+Red Hat tools can detect follower DPLL lock state, but they cannot monitor the detailed follower DPLL accuracy that holdover support requires.
+
+When you configure a BC profile on GNR-D hardware that uses Carter Flat NICs, disable holdover.

--- a/modules/ptp-configuring-linuxptp-services-as-boundary-clock-gnrd.adoc
+++ b/modules/ptp-configuring-linuxptp-services-as-boundary-clock-gnrd.adoc
@@ -1,0 +1,446 @@
+// Module included in the following assemblies:
+//
+// * networking/advanced_networking/ptp/configuring-ptp.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="ptp-configuring-linuxptp-services-as-boundary-clock-gnrd_{context}"]
+= Configuring linuxptp services as a boundary clock without holdover on Intel Granite Rapids-D hardware
+
+[role="_abstract"]
+Use this procedure to configure a Precision Time Protocol (PTP) boundary clock (BC) profile without holdover on Intel Granite Rapids-D (GNR-D) hardware that uses onboard Network Acceleration Complex (NAC) ports and optional Carter Flat expansion network interface cards (NICs).
+
+In this deployment, one time receiver (TR) port synchronizes to an upstream timing source and time transmitter (TT) ports distribute synchronized time downstream.
+
+[IMPORTANT]
+====
+GNR-D BC deployments that use Carter Flat NICs operate without monitored holdover. Disable holdover in your `PtpConfig` profile.
+====
+
+.Prerequisites
+
+* You have installed the OpenShift CLI (`oc`).
+* You are logged in as a user with `cluster-admin` privileges.
+* You have installed the PTP Operator.
+* You have verified your qualified GNR-D hardware layout, including NAC ports, Carter Flat ports, and TR/TT role assignments.
+* You have verified interface naming and plugin device alignment for your hardware layout.
+
+.Procedure
+
+. Create a `PtpConfig` custom resource (CR) that matches your qualified GNR-D BC without holdover hardware layout:
++
+[source,yaml]
+----
+apiVersion: ptp.openshift.io/v1
+kind: PtpConfig
+metadata:
+  name: gnrd-bc
+  namespace: openshift-ptp
+  annotations:
+    ran.openshift.io/ztp-deploy-wave: "10"
+spec:
+  profile:
+    - name: 00-bc-tt
+      ptp4lConf: |
+        # All TimeTransmitter ports should be outlined here with 'masterOnly 1'
+        #[eno8303]
+        # ** Host management interface
+        [eno8403]
+        masterOnly 1
+        #[eno8503]
+        # ** TR port (see 01-bc-tr profile)
+        [eno8603]
+        masterOnly 1
+        [eno8703]
+        masterOnly 1
+        [eno8803]
+        masterOnly 1
+        [eno8903]
+        masterOnly 1
+        [eno9003]
+        masterOnly 1
+        [enp108s0f0]
+        masterOnly 1
+        [enp108s0f1]
+        masterOnly 1
+        [enp108s0f2]
+        masterOnly 1
+        [enp108s0f3]
+        masterOnly 1
+        [enp108s0f4]
+        masterOnly 1
+        [enp108s0f5]
+        masterOnly 1
+        [enp108s0f6]
+        masterOnly 1
+        [enp108s0f7]
+        masterOnly 1
+        [enp110s0f0]
+        masterOnly 1
+        [enp110s0f1]
+        masterOnly 1
+        [enp110s0f2]
+        masterOnly 1
+        [enp110s0f3]
+        masterOnly 1
+        [enp110s0f4]
+        masterOnly 1
+        [enp110s0f5]
+        masterOnly 1
+        [enp110s0f6]
+        masterOnly 1
+        [enp110s0f7]
+        masterOnly 1
+        [global]
+        #
+        # Default Data Set
+        #
+        twoStepFlag 1
+        slaveOnly 0
+        priority1 128
+        priority2 128
+        domainNumber 24
+        #utc_offset 37
+        clockClass 248
+        clockAccuracy 0xFE
+        offsetScaledLogVariance 0xFFFF
+        free_running 0
+        freq_est_interval 1
+        dscp_event 0
+        dscp_general 0
+        dataset_comparison G.8275.x
+        G.8275.defaultDS.localPriority 128
+        #
+        # Port Data Set
+        #
+        logAnnounceInterval -3
+        logSyncInterval -4
+        logMinDelayReqInterval -4
+        logMinPdelayReqInterval -4
+        announceReceiptTimeout 3
+        syncReceiptTimeout 0
+        delayAsymmetry 0
+        fault_reset_interval -4
+        neighborPropDelayThresh 20000000
+        masterOnly 0
+        G.8275.portDS.localPriority 128
+        #
+        # Run time options
+        #
+        assume_two_step 0
+        logging_level 6
+        path_trace_enabled 0
+        follow_up_info 0
+        hybrid_e2e 0
+        inhibit_multicast_service 0
+        net_sync_monitor 0
+        tc_spanning_tree 0
+        tx_timestamp_timeout 50
+        unicast_listen 0
+        unicast_master_table 0
+        unicast_req_duration 3600
+        use_syslog 1
+        verbose 0
+        summary_interval 0
+        kernel_leap 1
+        check_fup_sync 0
+        clock_class_threshold 135
+        #
+        # Servo Options
+        #
+
+        # NGEN TEST MODIFIED
+        # New:
+        # pi_proportional_const 0.60
+        # pi_integral_const 0.0003
+        # Old:
+        # pi_proportional_const 0.0
+        # pi_integral_const 0.0
+        # END TEST MOD
+
+        pi_proportional_const 0.60
+        pi_integral_const 0.001
+        pi_proportional_scale 0.0
+        pi_proportional_exponent -0.3
+        pi_proportional_norm_max 0.7
+        pi_integral_scale 0.0
+        pi_integral_exponent 0.4
+        pi_integral_norm_max 0.3
+        step_threshold 2.0
+        # end T-BC experiment
+        first_step_threshold 0.00002
+        max_frequency 900000000
+        clock_servo pi
+        sanity_freq_limit 200000000
+        ntpshm_segment 0
+        #
+        # Transport options
+        #
+        transportSpecific 0x0
+        ptp_dst_mac 01:1B:19:00:00:00
+        p2p_dst_mac 01:80:C2:00:00:0E
+        udp_ttl 1
+        udp6_scope 0x0E
+        uds_address /var/run/ptp4l
+        #
+        # Default interface options
+        #
+        clock_type BC
+        network_transport L2
+        delay_mechanism E2E
+        time_stamping hardware
+        tsproc_mode filter
+        delay_filter moving_median
+        delay_filter_length 10
+        egressLatency 0
+        ingressLatency 0
+        boundary_clock_jbod 1
+        #
+        # Clock description
+        #
+        productDescription ;;
+        revisionData ;;
+        manufacturerIdentity 00:00:00
+        userDescription ;
+        timeSource 0xA0
+      ptp4lOpts: -2 --summary_interval -4
+      ptpSchedulingPolicy: SCHED_FIFO
+      ptpSchedulingPriority: 10
+      ptpSettings:
+        controllingProfile: 01-bc-tr
+        logReduce: "true"
+    - name: 01-bc-tr
+      phc2sysOpts: -r -n 24 -N 8 -R 16 -u 0 -m -s $upstreamInterface
+      ptp4lConf: |
+        [$upstreamInterface]
+        masterOnly 0
+        [global]
+        #
+        # Default Data Set
+        #
+        twoStepFlag 1
+        slaveOnly 0
+        priority1 128
+        priority2 128
+        domainNumber 24
+        #utc_offset 37
+        clockClass 248
+        clockAccuracy 0xFE
+        offsetScaledLogVariance 0xFFFF
+        free_running 0
+        freq_est_interval 1
+        dscp_event 0
+        dscp_general 0
+        dataset_comparison G.8275.x
+        G.8275.defaultDS.localPriority 128
+        #
+        # Port Data Set
+        #
+        logAnnounceInterval -3
+        logSyncInterval -4
+        logMinDelayReqInterval -4
+        logMinPdelayReqInterval -4
+        announceReceiptTimeout 3
+        syncReceiptTimeout 0
+        delayAsymmetry 0
+        fault_reset_interval -4
+        neighborPropDelayThresh 20000000
+        masterOnly 0
+        G.8275.portDS.localPriority 128
+        #
+        # Run time options
+        #
+        assume_two_step 0
+        logging_level 6
+        path_trace_enabled 0
+        follow_up_info 0
+        hybrid_e2e 0
+        inhibit_multicast_service 0
+        net_sync_monitor 0
+        tc_spanning_tree 0
+        tx_timestamp_timeout 50
+        unicast_listen 0
+        unicast_master_table 0
+        unicast_req_duration 3600
+        use_syslog 1
+        verbose 0
+        summary_interval 0
+        kernel_leap 1
+        check_fup_sync 0
+        clock_class_threshold 135
+        #
+        # Servo Options
+        #
+
+        # NGEN TEST MODIFIED
+        # New:
+        # pi_proportional_const 0.60
+        # pi_integral_const 0.0003
+        # Old:
+        # pi_proportional_const 0.0
+        # pi_integral_const 0.0
+        # END TEST MOD
+
+        pi_proportional_const 0.60
+        pi_integral_const 0.001
+        pi_proportional_scale 0.0
+        pi_proportional_exponent -0.3
+        pi_proportional_norm_max 0.7
+        pi_integral_scale 0.0
+        pi_integral_exponent 0.4
+        pi_integral_norm_max 0.3
+        step_threshold 2.0
+        # end T-BC experiment
+        first_step_threshold 0.00002
+        max_frequency 900000000
+        clock_servo pi
+        sanity_freq_limit 200000000
+        ntpshm_segment 0
+        #
+        # Transport options
+        #
+        transportSpecific 0x0
+        ptp_dst_mac 01:1B:19:00:00:00
+        p2p_dst_mac 01:80:C2:00:00:0E
+        udp_ttl 1
+        udp6_scope 0x0E
+        uds_address /var/run/ptp4l
+        #
+        # Default interface options
+        #
+        clock_type OC
+        network_transport L2
+        delay_mechanism E2E
+        time_stamping hardware
+        tsproc_mode filter
+        delay_filter moving_median
+        delay_filter_length 10
+        egressLatency 0
+        ingressLatency 0
+        boundary_clock_jbod 1
+        #
+        # Clock description
+        #
+        productDescription ;;
+        revisionData ;;
+        manufacturerIdentity 00:00:00
+        userDescription ;
+        timeSource 0xA0
+      ptp4lOpts: -2 --summary_interval -4
+      ptpSchedulingPolicy: SCHED_FIFO
+      ptpSchedulingPriority: 10
+      ptpSettings:
+        clockType: T-BC
+        inSyncConditionThreshold: "10"
+        inSyncConditionTimes: "12"
+        logReduce: "true"
+        leadingInterface: eno8703
+        upstreamPort: $upstreamInterface
+      plugins:
+        e825:
+          devices:
+            - eno8703
+          settings:
+            LocalMaxHoldoverOffSet: 500
+            LocalHoldoverTimeout: 0
+            MaxInSpecOffset: 100
+        e830:
+          devices:
+            - enp108s0f0
+            - enp110s0f0
+      ts2phcConf: |
+        [global]
+        use_syslog  0
+        verbose 1
+        logging_level 7
+        ts2phc.pulsewidth 500000000
+        leapfile  /usr/share/zoneinfo/leap-seconds.list
+        domainNumber 24
+        uds_address /var/run/ptp4l.1.socket
+        [eno8703]
+        ts2phc.extts_correction 0
+        ts2phc.master 0
+        ts2phc.channel 0
+        ts2phc.pin_index 1
+        # This should be one section per Carter Flats (e830) card:
+        [enp108s0f0]
+        ts2phc.extts_polarity rising
+        ts2phc.extts_correction 0
+        ts2phc.master 0
+        ts2phc.channel 0
+        ts2phc.pin_index 1
+        [enp110s0f0]
+        ts2phc.extts_polarity rising
+        ts2phc.extts_correction 0
+        ts2phc.master 0
+        ts2phc.channel 0
+        ts2phc.pin_index 1
+      ts2phcOpts: -s generic -a --ts2phc.rh_external_pps 1
+  recommend:
+    - match:
+      - nodeLabel: node-role.kubernetes.io/$mcp
+      priority: 4
+      profile: 00-bc-tt
+    - match:
+      - nodeLabel: node-role.kubernetes.io/$mcp
+      priority: 4
+      profile: 01-bc-tr
+----
++
+where:
+
+TR interface::
+Specifies the interface that synchronizes to the upstream timing source. Replace this value with the qualified TR interface from your site bill of materials.
+
+TT interfaces::
+Specify the interfaces that distribute synchronized time downstream. Replace these values with the qualified TT interfaces for your deployment.
+
+`plugins.e825.devices`::
+Specifies the qualified NAC interfaces for your hardware layout.
+
+`plugins.e830.devices`::
+Specifies the qualified Carter Flat interfaces for your hardware layout, if installed.
+
+`ptp4lConf`::
+Defines BC timing behavior, including TR and TT interface roles.
+
+`ts2phcConf`::
+Defines timing synchronization behavior for qualified hardware devices.
+
+`recommend`::
+Specifies the machine config pool that selects the target DU nodes. Replace placeholder values with the machine config pool label for your deployment.
+
+. Apply the `PtpConfig` CR:
++
+[source,terminal]
+----
+$ oc apply -f <name_of_the_ptpconfig_yaml_file>
+----
+
+.Verification
+
+. Verify that the `PtpConfig` profile is applied:
++
+[source,terminal]
+----
+$ oc get ptpconfig -n openshift-ptp
+----
+
+. Verify that the `linuxptp` daemon is running on the target node:
++
+[source,terminal]
+----
+$ oc get pods -n openshift-ptp -o wide
+----
+
+. Review `linuxptp` daemon logs for BC status:
++
+[source,terminal]
+----
+$ oc logs <linuxptp_daemon_pod> -n openshift-ptp -c linuxptp-daemon-container
+----
+
+. Verify the following:
++
+* The TR port synchronizes successfully to the upstream timing source.
+* TT ports distribute timing downstream.
+* The deployed BC profile operates without holdover.

--- a/modules/ptp-configuring-linuxptp-services-as-boundary-clock-gnrd.adoc
+++ b/modules/ptp-configuring-linuxptp-services-as-boundary-clock-gnrd.adoc
@@ -1,0 +1,446 @@
+// Module included in the following assemblies:
+//
+// * networking/advanced_networking/ptp/configuring-ptp.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="ptp-configuring-linuxptp-services-as-boundary-clock-gnrd_{context}"]
+= Configuring linuxptp services as a boundary clock without holdover on Intel Granite Rapids-D hardware
+
+[role="_abstract"]
+Use this procedure to configure a Precision Time Protocol (PTP) boundary clock (BC) profile without holdover on Intel Granite Rapids-D (GNR-D) hardware that uses onboard Network Acceleration Complex (NAC) ports and optional Carter Flat expansion network interface cards (NICs).
+
+In this deployment, one time receiver (TR) port synchronizes to an upstream timing source and time transmitter (TT) ports distribute synchronized time downstream.
+
+[IMPORTANT]
+====
+GNR-D BC deployments that use Carter Flat NICs operate without monitored holdover. Disable holdover in your `PtpConfig` profile.
+====
+
+.Prerequisites
+
+* You have installed the OpenShift CLI (`oc`).
+* You are logged in as a user with `cluster-admin` privileges.
+* You have installed the PTP Operator.
+* You have verified your qualified GNR-D hardware layout, including NAC ports, Carter Flat ports, and TR/TT role assignments.
+* You have verified interface naming and plugin device alignment for your hardware layout.
+
+.Procedure
+
+. Create a `PtpConfig` custom resource (CR) that matches your qualified GNR-D BC without holdover hardware layout:
++
+[source,yaml]
+----
+apiVersion: ptp.openshift.io/v1
+kind: PtpConfig
+metadata:
+  name: gnrd-bc
+  namespace: openshift-ptp
+  annotations:
+    ran.openshift.io/ztp-deploy-wave: "10"
+spec:
+  profile:
+    - name: 00-bc-tt
+      ptp4lConf: |
+        # All TimeTransmitter ports should be outlined here with 'masterOnly 1'
+        #[eno8303]
+        # ** Host management interface
+        [eno8403]
+        masterOnly 1
+        #[eno8503]
+        # ** TR port (see 01-bc-tr profile)
+        [eno8603]
+        masterOnly 1
+        [eno8703]
+        masterOnly 1
+        [eno8803]
+        masterOnly 1
+        [eno8903]
+        masterOnly 1
+        [eno9003]
+        masterOnly 1
+        [enp108s0f0]
+        masterOnly 1
+        [enp108s0f1]
+        masterOnly 1
+        [enp108s0f2]
+        masterOnly 1
+        [enp108s0f3]
+        masterOnly 1
+        [enp108s0f4]
+        masterOnly 1
+        [enp108s0f5]
+        masterOnly 1
+        [enp108s0f6]
+        masterOnly 1
+        [enp108s0f7]
+        masterOnly 1
+        [enp110s0f0]
+        masterOnly 1
+        [enp110s0f1]
+        masterOnly 1
+        [enp110s0f2]
+        masterOnly 1
+        [enp110s0f3]
+        masterOnly 1
+        [enp110s0f4]
+        masterOnly 1
+        [enp110s0f5]
+        masterOnly 1
+        [enp110s0f6]
+        masterOnly 1
+        [enp110s0f7]
+        masterOnly 1
+        [global]
+        #
+        # Default Data Set
+        #
+        twoStepFlag 1
+        slaveOnly 0
+        priority1 128
+        priority2 128
+        domainNumber 24
+        #utc_offset 37
+        clockClass 248
+        clockAccuracy 0xFE
+        offsetScaledLogVariance 0xFFFF
+        free_running 0
+        freq_est_interval 1
+        dscp_event 0
+        dscp_general 0
+        dataset_comparison G.8275.x
+        G.8275.defaultDS.localPriority 128
+        #
+        # Port Data Set
+        #
+        logAnnounceInterval -3
+        logSyncInterval -4
+        logMinDelayReqInterval -4
+        logMinPdelayReqInterval -4
+        announceReceiptTimeout 3
+        syncReceiptTimeout 0
+        delayAsymmetry 0
+        fault_reset_interval -4
+        neighborPropDelayThresh 20000000
+        masterOnly 0
+        G.8275.portDS.localPriority 128
+        #
+        # Run time options
+        #
+        assume_two_step 0
+        logging_level 6
+        path_trace_enabled 0
+        follow_up_info 0
+        hybrid_e2e 0
+        inhibit_multicast_service 0
+        net_sync_monitor 0
+        tc_spanning_tree 0
+        tx_timestamp_timeout 50
+        unicast_listen 0
+        unicast_master_table 0
+        unicast_req_duration 3600
+        use_syslog 1
+        verbose 0
+        summary_interval 0
+        kernel_leap 1
+        check_fup_sync 0
+        clock_class_threshold 135
+        #
+        # Servo Options
+        #
+
+        # NGEN TEST MODIFIED
+        # New:
+        # pi_proportional_const 0.60
+        # pi_integral_const 0.0003
+        # Old:
+        # pi_proportional_const 0.0
+        # pi_integral_const 0.0
+        # END TEST MOD
+
+        pi_proportional_const 0.60
+        pi_integral_const 0.001
+        pi_proportional_scale 0.0
+        pi_proportional_exponent -0.3
+        pi_proportional_norm_max 0.7
+        pi_integral_scale 0.0
+        pi_integral_exponent 0.4
+        pi_integral_norm_max 0.3
+        step_threshold 2.0
+        # end T-BC experiment
+        first_step_threshold 0.00002
+        max_frequency 900000000
+        clock_servo pi
+        sanity_freq_limit 200000000
+        ntpshm_segment 0
+        #
+        # Transport options
+        #
+        transportSpecific 0x0
+        ptp_dst_mac 01:1B:19:00:00:00
+        p2p_dst_mac 01:80:C2:00:00:0E
+        udp_ttl 1
+        udp6_scope 0x0E
+        uds_address /var/run/ptp4l
+        #
+        # Default interface options
+        #
+        clock_type BC
+        network_transport L2
+        delay_mechanism E2E
+        time_stamping hardware
+        tsproc_mode filter
+        delay_filter moving_median
+        delay_filter_length 10
+        egressLatency 0
+        ingressLatency 0
+        boundary_clock_jbod 1
+        #
+        # Clock description
+        #
+        productDescription ;;
+        revisionData ;;
+        manufacturerIdentity 00:00:00
+        userDescription ;
+        timeSource 0xA0
+      ptp4lOpts: -2 --summary_interval -4
+      ptpSchedulingPolicy: SCHED_FIFO
+      ptpSchedulingPriority: 10
+      ptpSettings:
+        controllingProfile: 01-bc-tr
+        logReduce: "true"
+    - name: 01-bc-tr
+      phc2sysOpts: -r -n 24 -N 8 -R 16 -u 0 -m -s $upstreamInterface
+      ptp4lConf: |
+        [$upstreamInterface]
+        masterOnly 0
+        [global]
+        #
+        # Default Data Set
+        #
+        twoStepFlag 1
+        slaveOnly 0
+        priority1 128
+        priority2 128
+        domainNumber 24
+        #utc_offset 37
+        clockClass 248
+        clockAccuracy 0xFE
+        offsetScaledLogVariance 0xFFFF
+        free_running 0
+        freq_est_interval 1
+        dscp_event 0
+        dscp_general 0
+        dataset_comparison G.8275.x
+        G.8275.defaultDS.localPriority 128
+        #
+        # Port Data Set
+        #
+        logAnnounceInterval -3
+        logSyncInterval -4
+        logMinDelayReqInterval -4
+        logMinPdelayReqInterval -4
+        announceReceiptTimeout 3
+        syncReceiptTimeout 0
+        delayAsymmetry 0
+        fault_reset_interval -4
+        neighborPropDelayThresh 20000000
+        masterOnly 0
+        G.8275.portDS.localPriority 128
+        #
+        # Run time options
+        #
+        assume_two_step 0
+        logging_level 6
+        path_trace_enabled 0
+        follow_up_info 0
+        hybrid_e2e 0
+        inhibit_multicast_service 0
+        net_sync_monitor 0
+        tc_spanning_tree 0
+        tx_timestamp_timeout 50
+        unicast_listen 0
+        unicast_master_table 0
+        unicast_req_duration 3600
+        use_syslog 1
+        verbose 0
+        summary_interval 0
+        kernel_leap 1
+        check_fup_sync 0
+        clock_class_threshold 135
+        #
+        # Servo Options
+        #
+
+        # NGEN TEST MODIFIED
+        # New:
+        # pi_proportional_const 0.60
+        # pi_integral_const 0.0003
+        # Old:
+        # pi_proportional_const 0.0
+        # pi_integral_const 0.0
+        # END TEST MOD
+
+        pi_proportional_const 0.60
+        pi_integral_const 0.001
+        pi_proportional_scale 0.0
+        pi_proportional_exponent -0.3
+        pi_proportional_norm_max 0.7
+        pi_integral_scale 0.0
+        pi_integral_exponent 0.4
+        pi_integral_norm_max 0.3
+        step_threshold 2.0
+        # end T-BC experiment
+        first_step_threshold 0.00002
+        max_frequency 900000000
+        clock_servo pi
+        sanity_freq_limit 200000000
+        ntpshm_segment 0
+        #
+        # Transport options
+        #
+        transportSpecific 0x0
+        ptp_dst_mac 01:1B:19:00:00:00
+        p2p_dst_mac 01:80:C2:00:00:0E
+        udp_ttl 1
+        udp6_scope 0x0E
+        uds_address /var/run/ptp4l
+        #
+        # Default interface options
+        #
+        clock_type OC
+        network_transport L2
+        delay_mechanism E2E
+        time_stamping hardware
+        tsproc_mode filter
+        delay_filter moving_median
+        delay_filter_length 10
+        egressLatency 0
+        ingressLatency 0
+        boundary_clock_jbod 1
+        #
+        # Clock description
+        #
+        productDescription ;;
+        revisionData ;;
+        manufacturerIdentity 00:00:00
+        userDescription ;
+        timeSource 0xA0
+      ptp4lOpts: -2 --summary_interval -4
+      ptpSchedulingPolicy: SCHED_FIFO
+      ptpSchedulingPriority: 10
+      ptpSettings:
+        clockType: T-BC
+        inSyncConditionThreshold: "10"
+        inSyncConditionTimes: "12"
+        logReduce: "true"
+        leadingInterface: eno8703
+        upstreamPort: $upstreamInterface
+      plugins:
+        e825:
+          devices:
+            - eno8703
+          settings:
+            LocalMaxHoldoverOffSet: 500
+            LocalHoldoverTimeout: 0
+            MaxInSpecOffset: 100
+        e830:
+          devices:
+            - enp108s0f0
+            - enp110s0f0
+      ts2phcConf: |
+        [global]
+        use_syslog  0
+        verbose 1
+        logging_level 7
+        ts2phc.pulsewidth 500000000
+        leapfile  /usr/share/zoneinfo/leap-seconds.list
+        domainNumber 24
+        uds_address /var/run/ptp4l.1.socket
+        [eno8703]
+        ts2phc.extts_correction 0
+        ts2phc.master 0
+        ts2phc.channel 0
+        ts2phc.pin_index 1
+        # This should be one section per Carter Flats (e830) card:
+        [enp108s0f0]
+        ts2phc.extts_polarity rising
+        ts2phc.extts_correction 0
+        ts2phc.master 0
+        ts2phc.channel 0
+        ts2phc.pin_index 1
+        [enp110s0f0]
+        ts2phc.extts_polarity rising
+        ts2phc.extts_correction 0
+        ts2phc.master 0
+        ts2phc.channel 0
+        ts2phc.pin_index 1
+      ts2phcOpts: -s generic -a --ts2phc.rh_external_pps 1
+  recommend:
+    - match:
+      - nodeLabel: node-role.kubernetes.io/$mcp
+      priority: 4
+      profile: 00-bc-tt
+    - match:
+      - nodeLabel: node-role.kubernetes.io/$mcp
+      priority: 4
+      profile: 01-bc-tr
+----
++
+where:
+
+TR interface::
+Specifies the interface that synchronizes to the upstream timing source. Replace this value with the qualified TR interface from your site bill of materials.
+
+TT interfaces::
+Specify the interfaces that distribute synchronized time downstream. Replace these values with the qualified TT interfaces for your deployment.
+
+`plugins.e825.devices`::
+Specifies the qualified NAC interfaces for your hardware layout.
+
+`plugins.e830.devices`::
+Specifies the qualified Carter Flat interfaces for your hardware layout, if installed.
+
+`ptp4lConf`::
+Defines BC timing behavior, including TR and TT interface roles.
+
+`ts2phcConf`::
+Defines timing synchronization behavior for qualified hardware devices.
+
+`recommend`::
+Specifies the machine config pool that selects the target DU nodes. Replace placeholder values with the machine config pool label for your deployment.
+
+. Apply the `PtpConfig` CR:
++
+[source,terminal]
+----
+$ oc apply -f <name_of_the_ptpconfig_yaml_file>
+----
+
+.Verification
+
+. Verify that the `PtpConfig` profile is applied:
++
+[source,terminal]
+----
+$ oc get ptpconfig -n openshift-ptp
+----
+
+. Verify that the `linuxptp` daemon is running on the target node:
++
+[source,terminal]
+----
+$ oc get pods -n openshift-ptp -o wide
+----
+
+. Review `linuxptp` daemon logs for BC status:
++
+[source,terminal]
+----
+$ oc logs <linuxptp_daemon_pod> -n openshift-ptp -c linuxptp-daemon-container
+----
+
+. Verify the following:
++
+* The TR port synchronizes successfully to the upstream timing source
+* TT ports distribute timing downstream
+* The deployed BC profile operates without holdover

--- a/networking/advanced_networking/ptp/configuring-ptp.adoc
+++ b/networking/advanced_networking/ptp/configuring-ptp.adoc
@@ -69,6 +69,12 @@ include::modules/ptp-configuring-linuxptp-services-as-boundary-clock-dual-nic.ad
 
 include::modules/ptp-configuring-linuxptp-services-as-ha-bc-for-dual-nic.adoc[leveloffset=+2]
 
+//Boundary clocks on Intel Granite Rapids-D hardware
+include::modules/nw-ptp-granite-rapids-boundary-clock-overview.adoc[leveloffset=+2]
+
+// Configuring linuxptp services as a boundary clock on Intel Granite Rapids-D hardware
+include::modules/ptp-configuring-linuxptp-services-as-boundary-clock-gnrd.adoc[leveloffset=+2]
+
 include::modules/nw-ptp-configuring-linuxptp-services-as-ordinary-clock.adoc[leveloffset=+1]
 
 [role="_additional-resources"]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.21+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
https://redhat.atlassian.net/browse/TELCODOCS-2607
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
- [Boundary clocks without holdover on Intel Granite Rapids-D hardware](https://111692--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/advanced_networking/ptp/configuring-ptp.html#nw-ptp-granite-rapids-boundary-clock-overview_configuring-ptp)
- [Configuring linuxptp services as a boundary clock without holdover on Intel Granite Rapids-D hardware](https://111692--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/advanced_networking/ptp/configuring-ptp.html#ptp-configuring-linuxptp-services-as-boundary-clock-gnrd_configuring-ptp)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->main` branch.