### PR TITLE
 OSDOCS#19442: Correct TLS configuration content - MicroShift

### DIFF
--- a/microshift_configuring/microshift-ingress-controller.adoc
+++ b/microshift_configuring/microshift-ingress-controller.adoc
@@ -7,7 +7,7 @@ include::_attributes/attributes-microshift.adoc[]
 toc::[]
 
 [role="_abstract"]
-Use the ingress controller options in the {microshift-short} configuration file to make pods and services accessible outside the node.
+To make pods and services accessible outside the node, you must configure the ingress controller options in the {microshift-short} configuration file.
 
 include::modules/microshift-ingress-controller-conc.adoc[leveloffset=+1]
 
@@ -16,6 +16,11 @@ include::modules/microshift-ingress-controller-config.adoc[leveloffset=+1]
 include::modules/microshift-ingress-control-config-fields.adoc[leveloffset=+2]
 
 include::modules/microshift-ingress-controller-create-cert-secret.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../microshift_networking/microshift-configuring-routes.adoc#nw-ingress-creating-a-route-via-an-ingress_microshift-configuring-routes[Creating a route through an Ingress object]
 
 include::modules/microshift-ingress-controller-tls-config.adoc[leveloffset=+2]
 

--- a/modules/microshift-ingress-controller-create-cert-secret.adoc
+++ b/modules/microshift-ingress-controller-create-cert-secret.adoc
@@ -8,18 +8,27 @@
 = Creating a secret for the ingress controller certificateSecret
 
 [role="_abstract"]
-To serve a custom default certificate through the ingress controller in {microshift-short}, you can create a TLS secret containing your certificate chain and private key, then set the `certificateSecret` value in the configuration file to that secret name.
+To secure network traffic with your own certificate, you must create a TLS secret and update the configuration file. This process configures a custom default certificate for the {microshift-short} ingress router.
 
 [NOTE]
 ====
-Any in-use certificates is automatically integrated with the {microshift-short} built-in OAuth server.
+Any in-use certificates automatically integrate with the {microshift-short} built-in OAuth server.
 ====
+
+To configure application-level certificates for a Kubernetes Ingress object by using the `spec.tls` field, follow the procedure in "Creating a route through an Ingress object".
 
 .Prerequisites
 
-* You have root access to {microshift-short}.
-* You installed the {oc-first}.
-* Your private key is not encrypted or you have decrypted it for importing into {microshift-short}.
+* Root access to the {microshift-short} host.
+* Installation of the {oc-first}.
+* A decrypted, non-password-protected TLS private key in Privacy-Enhanced Mail (PEM) format.
+* A PEM-encoded TLS certificate.
+* A valid certificate for the {microshift-short} apps wildcard where the `subjectAltName` extension includes DNS names covering `*.apps.<nodename>.<domain>`.
+
+[NOTE]
+====
+This procedure only applies to the default ingress router certificate, `ingress.certificateSecret`.
+====
 
 .Procedure
 
@@ -44,7 +53,7 @@ The certificate must include the `subjectAltName` extension showing `*.apps.<nod
 
 . Update the `certificateSecret` parameter value in the {microshift-short} configuration YAML with the newly created secret.
 
-. Complete any other configurations you require, then start or restart {microshift-short} by running one the following commands:
+. Complete any other configurations you require, then start or restart {microshift-short} by running one of the following commands:
 +
 [source,terminal]
 ----

--- a/modules/microshift-ingress-controller-create-cert-secret.adoc
+++ b/modules/microshift-ingress-controller-create-cert-secret.adoc
@@ -21,7 +21,6 @@ To configure application-level certificates for a Kubernetes Ingress object by u
 
 * Root access to the {microshift-short} host.
 * Installation of the {oc-first}.
-* Confirmation that this task applies only to the default ingress router certificate, `ingress.certificateSecret`.
 * A decrypted, non-password-protected TLS private key in Privacy-Enhanced Mail (PEM) format.
 * A PEM-encoded TLS certificate.
 * A valid certificate for the {microshift-short} apps wildcard where the `subjectAltName` extension includes DNS names covering `*.apps.<nodename>.<domain>`.

--- a/modules/microshift-ingress-controller-create-cert-secret.adoc
+++ b/modules/microshift-ingress-controller-create-cert-secret.adoc
@@ -8,18 +8,28 @@
 = Creating a secret for the ingress controller certificateSecret
 
 [role="_abstract"]
-To serve a custom default certificate through the ingress controller in {microshift-short}, you can create a TLS secret containing your certificate chain and private key, then set the `certificateSecret` value in the configuration file to that secret name.
+To secure network traffic with your own certificate, you must create a TLS secret and update the configuration file. This process configures a custom default certificate for the {microshift-short} ingress router.
 
 [NOTE]
 ====
-Any in-use certificates is automatically integrated with the {microshift-short} built-in OAuth server.
+Any in-use certificates automatically integrate with the {microshift-short} built-in OAuth server.
 ====
+
+To configure application-level certificates for a Kubernetes Ingress object by using the `spec.tls` field, follow the procedure in *Creating a route through an Ingress object*.
 
 .Prerequisites
 
-* You have root access to {microshift-short}.
-* You installed the {oc-first}.
-* Your private key is not encrypted or you have decrypted it for importing into {microshift-short}.
+* Root access to the {microshift-short} host.
+* Installation of the {oc-first}.
+* Confirmation that this task applies only to the default ingress router certificate, `ingress.certificateSecret`.
+* A decrypted, non-password-protected TLS private key in Privacy-Enhanced Mail (PEM) format.
+* A PEM-encoded TLS certificate.
+* A valid certificate for the {microshift-short} apps wildcard where the `subjectAltName` extension includes DNS names covering `*.apps.<nodename>.<domain>`.
+
+[NOTE]
+====
+This procedure only applies to the default ingress router certificate, `ingress.certificateSecret`.
+====
 
 .Procedure
 
@@ -44,7 +54,7 @@ The certificate must include the `subjectAltName` extension showing `*.apps.<nod
 
 . Update the `certificateSecret` parameter value in the {microshift-short} configuration YAML with the newly created secret.
 
-. Complete any other configurations you require, then start or restart {microshift-short} by running one the following commands:
+. Complete any other configurations you require, then start or restart {microshift-short} by running one of the following commands:
 +
 [source,terminal]
 ----

--- a/modules/nw-ingress-creating-a-route-via-an-ingress.adoc
+++ b/modules/nw-ingress-creating-a-route-via-an-ingress.adoc
@@ -10,6 +10,15 @@
 [role="_abstract"]
 To integrate ecosystem components that require Ingress resources, configure an Ingress object. {product-title} automatically manages the lifecycle of the corresponding route objects, creating and deleting them to ensure seamless connectivity.
 
+.Prerequisites
+
+* If clients must receive a full certificate chain, you must combine the PEM-encoded leaf certificate and intermediates into a single file. Place the leaf certificate first, followed by each issuer in chain order.
+* You confirmed the private key matches the leaf certificate in the `tls.crt` key.
+* You confirmed the `tls.key` key has only the private key for the leaf certificate.
+* The certificate Subject Alternative Name (SAN), or the subject CN if no SAN is present, covers every hostname set in `spec.rules[].host` and `spec.tls[].hosts`. These values must match for the same host.
+* The private key is not password-encrypted. You must decrypt the key before you create the TLS secret so that {product-title} can read the key material.
+* You created a `Secret` of type `kubernetes.io/tls` in the same namespace as the `Ingress`. The `secretName` must match the `spec.tls[].secretName` field. If you have not created the secret, you must do so before you apply the `Ingress` object.
+
 .Procedure
 
 . Define an Ingress object in the {product-title} console or by entering the `oc create` command:


### PR DESCRIPTION
Version(s):
4.22+

Issue:
[OSDOCS-19442](https://redhat.atlassian.net/browse/OSDOCS-19442)

Link to docs preview:
[Creating a secret for the ingress controller certificateSecret](https://111698--ocpdocs-pr.netlify.app/microshift/latest/microshift_configuring/microshift-ingress-controller.html#microshift-ingress-controller-create-cert-secret_microshift-ingress-controller)
[Creating a route through an Ingress object](https://111698--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ingress_load_balancing/routes/creating-basic-routes.html#nw-ingress-creating-a-route-via-an-ingress_creating-basic-routes)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
none
