### PR TITLE
OSDOCS-18103#updating TP table

### DIFF
--- a/modules/rn-ocp-release-notes-deprecated-features.adoc
+++ b/modules/rn-ocp-release-notes-deprecated-features.adoc
@@ -23,3 +23,7 @@ Deprecation of the `oc adm release mirror` command::
 As of {product-title} 4.22, using the `oc adm release mirror` command to mirror release images has been deprecated and will be removed in a future release.
 +
 As an alternative, use the xref:../disconnected/about-installing-oc-mirror-v2.adoc#about-installing-oc-mirror-v2[oc-mirror plugin v2].
+
+Deprecation of adding kernel modules to nodes with KVC::
++
+As of {product-title} 4.22, support for adding kernel modules to nodes with kmods-via-containers software (KVC) has been deprecated and will be removed in a future release.

--- a/modules/rn-ocp-release-notes-deprecated-removed-tables.adoc
+++ b/modules/rn-ocp-release-notes-deprecated-removed-tables.adoc
@@ -28,47 +28,47 @@
 |`--cloud` parameter for `oc adm release extract`
 |Deprecated
 |Deprecated
-|
+|Deprecated
 
 |CoreDNS wildcard queries for the `cluster.local` domain
 |Deprecated
 |Deprecated
-|
+|Deprecated
 
 |`compute.platform.openstack.rootVolume.type` for {rh-openstack}
 |Deprecated
 |Deprecated
-|
+|Deprecated
 
 |`controlPlane.platform.openstack.rootVolume.type` for {rh-openstack}
 |Deprecated
 |Deprecated
-|
+|Deprecated
 
 |`ingressVIP` and `apiVIP` settings in the `install-config.yaml` file for installer-provisioned infrastructure clusters
 |Deprecated
 |Deprecated
-|
+|Deprecated
 
 |`platform.aws.preserveBootstrapIgnition` parameter for {aws-first}
 |Deprecated
 |Deprecated
-|
+|Deprecated
 
 |Installing a cluster on {aws-short} with compute nodes in {aws-short} Outposts
 |Deprecated
 |Deprecated
-|
-
-|Deploying managed clusters using `SiteConfig` and the {ztp} workflow
 |Deprecated
-|Removed
-|
+
+|Adding kernel modules to nodes with kvc
+|General Availability
+|General Availability
+|Deprecated
 
 |Installing a cluster using Fujitsu iRMC drivers on bare-metal machines
 |General Availability
 |Deprecated
-|
+|Deprecated
 |====
 
 [id="ocp-release-note-machine-manage-dep-rem_{context}"]

--- a/modules/rn-ocp-release-notes-technology-preview.adoc
+++ b/modules/rn-ocp-release-notes-technology-preview.adoc
@@ -126,7 +126,7 @@ In the following tables, features are marked with the following statuses:
 |Mount shared entitlements in BuildConfigs in RHEL
 |Technology Preview
 |Technology Preview
-|General Availability
+|General Availability (through Builds for OpenShift Operator)
 
 |OpenShift zones support for vSphere host groups
 |Technology Preview
@@ -134,9 +134,9 @@ In the following tables, features are marked with the following statuses:
 |Technology Preview
 
 |Selectable Cluster Inventory
-|Technology Preview
-|Technology Preview
-|Technology Preview
+|
+|
+|
 
 |Enabling a user-provisioned DNS on {gcp-short}
 |Technology Preview
@@ -189,6 +189,10 @@ In the following tables, features are marked with the following statuses:
 |Technology Preview
 |====
 
+[NOTE]
+====
+Fleet Management supersedes Selectable Cluster Inventory in {product-title} 4.20 and later releases. For more information see, the {rh-rhacm-title} for Kubernetes documentation for link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.15/html-single/release_notes/index#console-new-features[Fleet Management].
+====
 
 [id="ocp-release-notes-mco-tech-preview_{context}"]
 == Machine Config Operator Technology Preview features


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version:
4.22

Issue:
https://redhat.atlassian.net/browse/OSDOCS-18103

Link to docs preview:
- [Installation Technology Preview features](https://111705--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-22-release-notes.html#ocp-release-notes-installing-tech-preview_release-notes)

- [Installation deprecated and removed features](https://111705--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-22-release-notes.html#ocp-release-note-install-dep-rem_release-notes)

- [Deprecation of adding kernel modules to nodes with KVC](https://111705--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-22-release-notes.html#rn-ocp-release-notes-deprecated-features_release-notes)



QE review:
- [] QE has approved this change. The PR has been approved by the SMEs.

Additional information:
