### PR TITLE
OCPBUGS-85374 Edit optional note

### DIFF
--- a/modules/nw-metallb-configure-secondary-interface.adoc
+++ b/modules/nw-metallb-configure-secondary-interface.adoc
@@ -3,11 +3,11 @@
 = Configuring MetalLB with secondary networks
 
 [role="_abstract"]
-From {product-title} 4.14 the default network behavior is to not allow forwarding of IP packets between network interfaces. Therefore, when MetalLB is configured on a secondary interface, you need to add a machine configuration to enable IP forwarding for only the required interfaces. 
+From {product-title} 4.14 the default network behavior is to not allow forwarding of IP packets between network interfaces. Therefore, when MetalLB is configured on a secondary interface, you need to add a machine configuration to enable IP forwarding for only the required interfaces.
 
 [NOTE]
 ====
-{product-title} clusters upgraded from 4.13 are not affected because a global parameter is set during upgrade to enable global IP forwarding. 
+{product-title} clusters upgraded from 4.13 are not affected because a global parameter is set during upgrade to enable global IP forwarding.
 ====
 
 To enable IP forwarding for the secondary interface, you have two options:
@@ -22,7 +22,7 @@ Enabling IP forwarding for a specific interface provides more granular control, 
 
 .Procedure
 
-. Patch the Cluster Network Operator, setting the parameter `routingViaHost` to `true` by running the following command: 
+. Patch the Cluster Network Operator, setting the parameter `routingViaHost` to `true` by running the following command:
 +
 [source,terminal]
 ----
@@ -90,10 +90,15 @@ $ oc apply -f enable-ip-forward.yaml
 ----
 $ oc patch network.operator cluster -p '{"spec":{"defaultNetwork":{"ovnKubernetesConfig":{"gatewayConfig":{"ipForwarding": "Global"}}}}}' --type=merge
 ----
++
+[NOTE]
+====
+Setting `ipForwarding` to `Global` sets `net.ipv4.conf.default.forwarding = 1`. All interfaces on the node inherit this, resulting in settings like `net.ipv4.conf.tun0.forwarding = 1`. This configuration also skips installing the default drop firewall rules, allowing the node to act as a router that forwards traffic between interfaces.
+====
 
 .Verification
 
-.  After you apply the machine config, verify the changes by completing the following steps: 
+.  After you apply the machine config, verify the changes by completing the following steps:
 +
 .. Enter into a debug session on the target node by running the following command. This command instantiates a debug pod called `<node-name>-debug`.
 +
@@ -109,7 +114,7 @@ $ oc debug node/<node-name>
 $ chroot /host
 ----
 +
-.. Verify that IP forwarding is enabled by running the following command: 
+.. Verify that IP forwarding is enabled by running the following command:
 +
 [source,terminal]
 ----
@@ -119,7 +124,7 @@ $ cat /etc/sysctl.d/enable-global-forwarding.conf
 .Example output
 [source,terminal]
 ----
-net.ipv4.conf.bridge-net.forwarding = 1 
+net.ipv4.conf.bridge-net.forwarding = 1
 ----
 +
 The output indicates that IPv4 forwarding is enabled on the `bridge-net` interface.

--- a/modules/nw-metallb-configure-secondary-interface.adoc
+++ b/modules/nw-metallb-configure-secondary-interface.adoc
@@ -3,11 +3,11 @@
 = Configuring MetalLB with secondary networks
 
 [role="_abstract"]
-From {product-title} 4.14 the default network behavior is to not allow forwarding of IP packets between network interfaces. Therefore, when MetalLB is configured on a secondary interface, you need to add a machine configuration to enable IP forwarding for only the required interfaces. 
+From {product-title} 4.14 the default network behavior is to not allow forwarding of IP packets between network interfaces. Therefore, when MetalLB is configured on a secondary interface, you need to add a machine configuration to enable IP forwarding for only the required interfaces.
 
 [NOTE]
 ====
-{product-title} clusters upgraded from 4.13 are not affected because a global parameter is set during upgrade to enable global IP forwarding. 
+{product-title} clusters upgraded from 4.13 are not affected because a global parameter is set during upgrade to enable global IP forwarding.
 ====
 
 To enable IP forwarding for the secondary interface, you have two options:
@@ -22,7 +22,7 @@ Enabling IP forwarding for a specific interface provides more granular control, 
 
 .Procedure
 
-. Patch the Cluster Network Operator, setting the parameter `routingViaHost` to `true` by running the following command: 
+. Patch the Cluster Network Operator, setting the parameter `routingViaHost` to `true` by running the following command:
 +
 [source,terminal]
 ----
@@ -90,10 +90,15 @@ $ oc apply -f enable-ip-forward.yaml
 ----
 $ oc patch network.operator cluster -p '{"spec":{"defaultNetwork":{"ovnKubernetesConfig":{"gatewayConfig":{"ipForwarding": "Global"}}}}}' --type=merge
 ----
++
+[NOTE]
+====
+Setting `ipForwarding` to `Global` enables the IPv4 forwarding `sysctl` for all interfaces on the node and skips installing the default drop firewall rules. This means the node can act as a router, forwarding traffic between interfaces.
+====
 
 .Verification
 
-.  After you apply the machine config, verify the changes by completing the following steps: 
+.  After you apply the machine config, verify the changes by completing the following steps:
 +
 .. Enter into a debug session on the target node by running the following command. This command instantiates a debug pod called `<node-name>-debug`.
 +
@@ -109,7 +114,7 @@ $ oc debug node/<node-name>
 $ chroot /host
 ----
 +
-.. Verify that IP forwarding is enabled by running the following command: 
+.. Verify that IP forwarding is enabled by running the following command:
 +
 [source,terminal]
 ----
@@ -119,7 +124,7 @@ $ cat /etc/sysctl.d/enable-global-forwarding.conf
 .Example output
 [source,terminal]
 ----
-net.ipv4.conf.bridge-net.forwarding = 1 
+net.ipv4.conf.bridge-net.forwarding = 1
 ----
 +
 The output indicates that IPv4 forwarding is enabled on the `bridge-net` interface.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OCPBUGS-85374]: Edit Optional in remove Optional from https://docs.redhat.com/en/documentation/openshift_container_platform/4.21/html/ingress_and_load_balancing/load-balancing-with-metallb#nw-metallb-configure-secondary-interface_about-advertising-ip-address-pool 

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.17+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:https://redhat.atlassian.net/browse/OCPBUGS-85374
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:https://111710--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ingress_load_balancing/metallb/about-advertising-ipaddresspool.html#nw-metallb-configure-secondary-interface_about-advertising-ip-address-pool
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: In different location prior to 4.17 need to check 
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
