### PR TITLE
OSDOCS-19403: Added the RFC-1035 requirement around names and namespaces

### DIFF
--- a/modules/nw-ingress-gateway-api-enable.adoc
+++ b/modules/nw-ingress-gateway-api-enable.adoc
@@ -7,15 +7,15 @@
 = Getting started with Gateway API for the Ingress Operator
 
 [role="_abstract"]
-After you create a `GatewayClass` resource, the resource configures Gateway API for use on your cluster.
+You can enable Gateway API on your cluster by creating a `GatewayClass` resource. This resource configures the Cluster Ingress Operator to manage Gateway API resources for routing traffic to your applications.
 
 [IMPORTANT]
 ====
-The {product-title} Gateway API implementation relies on the Cluster Ingress Operator (CIO) to install and manage a specific version of OpenShift Service Mesh (OSSM v3.x) in the `openshift-ingress` namespace.
+The {product-title} Gateway API implementation relies on the Cluster Ingress Operator (CIO). The CIO installs and manages a specific version of OpenShift Service Mesh (OSSM v3.x) in the `openshift-ingress` namespace.
 
 A conflict occurs if your cluster already has an active OpenShift Service Mesh (OSSM v2.x) subscription in any namespace. OSSM v2.x and OSSM v3.x cannot coexist on the same cluster.
 
-If a conflicting OSSM v2.x subscription is present when you create a `GatewayClass` resource, the Cluster Ingress Operator attempts to install the required OSSM v3.x components but fails this installation operation. As a result, Gateway API resources, such as Gateway or HTTPRoute, have no effect and no proxy gets configured to route traffic. In {product-title} 4.19, this failure is silent. For {product-title} 4.20 and later, this conflict causes the ingress ClusterOperator to report a Degraded status.
+If a conflicting OSSM v2.x subscription exists when you create a `GatewayClass` resource, the installation fails. The Cluster Ingress Operator attempts to install OSSM v3.x components but cannot complete the operation. As a result, Gateway API resources, such as Gateway or HTTPRoute, have no effect. No proxy gets configured to route traffic. In {product-title} 4.19, this failure is silent. For {product-title} 4.20 and later, this conflict causes the ingress ClusterOperator to report a Degraded status.
 
 Before enabling Gateway API by creating a `GatewayClass`, verify that you do not have an active OSSM v2.x subscription on the cluster.
 ====
@@ -37,14 +37,15 @@ spec:
   controllerName: openshift.io/gateway-controller/v1
 ----
 +
+* `name`: The name of your `GatewayClass` object. The name must be compliant with the link:https://datatracker.ietf.org/doc/html/rfc1035[RFC 1035] specification. The name must not exceed the 63 lowercase alphanumeric characters limit.
 * `controllerName`: The controller name.
 +
 [IMPORTANT]
 ====
-The controller name must be exactly as shown for the Ingress Operator to manage it. If you set this field to anything else, the Ingress Operator ignores the `GatewayClass` object and all associated `Gateway`, `GRPCRoute`, and `HTTPRoute` objects. The controller name is tied to the implementation of Gateway API in {product-title}, and `openshift.io/gateway-controller/v1` is the only controller name allowed.
+The controller name must be exactly as shown for the Ingress Operator to manage it. If you set this field to any other value, the Ingress Operator ignores the `GatewayClass` object. The Operator also ignores all associated `Gateway`, `GRPCRoute`, and `HTTPRoute` objects. The controller name is tied to the implementation of Gateway API in {product-title}, and `openshift.io/gateway-controller/v1` is the only controller name allowed.
 ====
 +
-.. Run the following command to create the `GatewayClass` resource:
+.. Run the following command to create the `GatewayClass` resource. During the creation of the `GatewayClass` resource, the Ingress Operator installs a lightweight version of {SMProductName}, an Istio custom resource, and a new deployment in the `openshift-ingress` namespace.
 +
 [source,terminal]
 ----
@@ -56,8 +57,6 @@ $ oc create -f openshift-default.yaml
 ----
 gatewayclass.gateway.networking.k8s.io/openshift-default created
 ----
-+
-During the creation of the `GatewayClass` resource, the Ingress Operator installs a lightweight version of {SMProductName}, an Istio custom resource, and a new deployment in the `openshift-ingress` namespace.
 +
 .. Optional: Verify that the new deployment, `istiod-openshift-gateway`, is ready and available:
 +
@@ -118,9 +117,10 @@ spec:
 +
 where:
 +
+`metadata.name`:: The name of your `Gateway` object. The name must be compliant with the link:https://datatracker.ietf.org/doc/html/rfc1035[RFC 1035] specification. The name must not exceed the 63 lowercase alphanumeric characters limit.
 `metadata.namespace`:: The `Gateway` object must be created in the `openshift-ingress` namespace.
 `gatewayClassName`:: The `Gateway` object must reference the name of the previously created `GatewayClass` object.
-`listeners.name`:: The HTTPS listener listens for HTTPS requests that match a subdomain of the cluster domain. You use this listener to configure ingress to your applications by using Gateway API `HTTPRoute` resources.
+`listeners.name`:: The HTTPS listener listens for HTTPS requests matching a cluster subdomain. Use this listener to configure ingress by using Gateway API `HTTPRoute` resources.
 `listeners.hostname`::  The hostname must be a subdomain of the Ingress Operator domain. If you use a domain, the listener tries to serve all traffic in that domain.
 `tls.name`:: The name of the previously created secret.
 
@@ -156,7 +156,7 @@ $ oc get service -n openshift-ingress example-gateway-openshift-default
 [source,terminal]
 ----
 NAME                                TYPE           CLUSTER-IP   EXTERNAL-IP         PORT(S)      AGE
-example-gateway-openshift-default   LoadBalancer   10.1.2.3     <external_ipname>   <port_info>  47s
+example-gateway-openshift-default   LoadBalancer   10.1.2.3     <external_ip_name>   <port_info>  47s
 ----
 
 .. Optional: The Ingress Operator automatically creates a `DNSRecord` CR using the hostname from the listeners, and adds the label `gateway.networking.k8s.io/gateway-name=example-gateway`. Verify the status of the DNS record by running the following command:
@@ -215,7 +215,7 @@ spec:
   hostnames: ["example.gwapi.${DOMAIN}"]
   rules:
   - backendRefs:
-    - name: example-app <5>
+    - name: example-app
       port: 8443
 ----
 +


### PR DESCRIPTION
Version(s):
4.19+

Issue:
[OSDOCS-19403](https://redhat.atlassian.net/browse/OSDOCS-19403)

Link to docs preview:

* https://111721--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ingress_load_balancing/configuring_ingress_cluster_traffic/ingress-gateway-api.html

Asked in the forum-k8s-gateway-api group and tagged [@network-edge-team](https://redhat.enterprise.slack.com/admin/user_groups) team.

- [ ] SME has approved this change ().
- [ ] QE has approved this change.
