### PR TITLE
OSDOCS-18784-2 added ESO assemblies and modules index

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -1312,6 +1312,8 @@ Topics:
   Dir: external_secrets_operator
   Distros: openshift-enterprise
   Topics:
+  - Name: External Secrets Operator overview
+    File: index
   - Name: Customizing the External Secrets Operator for Red Hat OpenShift
     File: external-secrets-log-levels
 - Name: Viewing audit logs

--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -1322,6 +1322,8 @@ Topics:
   Dir: external_secrets_operator
   Distros: openshift-enterprise
   Topics:
+  - Name: External Secrets Operator overview
+    File: index
   - Name: Customizing the External Secrets Operator for Red Hat OpenShift
     File: external-secrets-log-levels
 - Name: Viewing audit logs

--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -1322,6 +1322,8 @@ Topics:
   Dir: external_secrets_operator
   Distros: openshift-enterprise
   Topics:
+  - Name: External Secrets Operator overview
+    File: index
   - Name: Customizing the External Secrets Operator for Red Hat OpenShift
     File: external-secrets-log-levels
   - Name: Uninstalling the External Secrets Operator

--- a/modules/external-secrets-about.adoc
+++ b/modules/external-secrets-about.adoc
@@ -1,0 +1,38 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/index.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="external-secrets-about_{context}"]
+= About the {external-secrets-operator}
+
+[role="_abstract"]
+Use the {external-secrets-operator} to integrate the external-secrets application with the {product-title} cluster. The `external-secrets` application fetches secrets stored in the external providers such as the AWS Secrets Manager, HashiCorp Vault, Google Secret Manager, Azure Key Vault, {ibm-cloud-title} Secrets Manager, and AWS Systems Manager Parameter Store and integrates them with Kubernetes in a secure manner.
+
+Using the {external-secrets-operator-short} ensures the following:
+
+* Decouples applications from the secret-lifecycle management.
+* Centralizes secret storage to support compliance requirements.
+* Enables secure and automated secret rotation.
+* Supports multi-cloud secret sourcing with fine-grained access control.
+* Centralizes and audits access control.
+
+[IMPORTANT]
+====
+Do not attempt to use more than one {external-secrets-operator-short} in your cluster. If you have a community {external-secrets-operator-short} installed in your cluster, you must uninstall it before installing the {external-secrets-operator}.
+====
+
+For more information about `external-secrets` application, see link:https://external-secrets.io/latest/[external-secrets].
+
+Use the {external-secrets-operator-short} to authenticate with the external secrets store, retrieve secrets, and inject the retrieved secrets into a native Kubernetes secret. This method removes the need for applications to directly access or manage external secrets.
+
+[role="_additional-resources"]
+.Additional resources
+
+* link:https://external-secrets.io/latest/[external-secrets]
+* link:https://aws.amazon.com/secrets-manager/[AWS Secrets Manager]
+* link:https://developer.hashicorp.com/vault[HashiCorp Vault]
+* link:https://cloud.google.com/security/products/secret-manager[Google Secret Manager]
+* link:https://azure.microsoft.com/en-us/products/key-vault/[Azure Key Vault]
+* link:https://www.ibm.com/products/secrets-manager[{ibm-cloud-title} Secrets Manager]
+* link:https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-parameter-store.html[AWS Systems Manager Parameter Store]

--- a/modules/external-secrets-about.adoc
+++ b/modules/external-secrets-about.adoc
@@ -1,0 +1,27 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/index.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="external-secrets-about_{context}"]
+= About the {external-secrets-operator}
+
+[role="_abstract"]
+Use the {external-secrets-operator} to integrate an external secrets repository with the external-secrets application with the {product-title} cluster. The `external-secrets` application fetches secrets such as the AWS Secrets Manager, HashiCorp Vault, Google Secret Manager, Azure Key Vault, {ibm-cloud-title} Secrets Manager, and AWS Systems Manager Parameter Store. The secrets are stored in the external secrets repository and then integrated with Kubernetes in a secure manner.
+
+Using the {external-secrets-operator-short} ensures the following:
+
+* Decouples applications from the secret-lifecycle management.
+* Centralizes secret storage to support compliance requirements.
+* Enables secure and automated secret rotation.
+* Supports multi-cloud secret sourcing with fine-grained access control.
+* Centralizes and audits access control.
+
+[IMPORTANT]
+====
+Do not attempt to use more than one {external-secrets-operator-short} in your cluster. If you have a community {external-secrets-operator-short} installed in your cluster, you must uninstall it before installing the {external-secrets-operator}.
+====
+
+Use the {external-secrets-operator-short} to authenticate with an external secrets repository, retrieve secrets, and inject the retrieved secrets into a native Kubernetes secret. This method removes the need for applications to directly access or manage external secrets.
+
+

--- a/modules/external-secrets-about.adoc
+++ b/modules/external-secrets-about.adoc
@@ -1,0 +1,29 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/index.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="external-secrets-about_{context}"]
+= About the {external-secrets-operator}
+
+[role="_abstract"]
+Use the {external-secrets-operator} to integrate an external secrets repository with the external-secrets application with the {product-title} cluster. The `external-secrets` application fetches secrets such as the AWS Secrets Manager, HashiCorp Vault, Google Secret Manager, Azure Key Vault, {ibm-cloud-title} Secrets Manager, and AWS Systems Manager Parameter Store. The secrets are stored in the external secrets repository and then integrated with Kubernetes in a secure manner.
+
+Using the {external-secrets-operator-short} ensures the following security benefits:
+
+* Decouples applications from the secret-lifecycle management.
+* Centralizes secret storage to support compliance requirements.
+* Enables secure and automated secret rotation.
+* Supports multi-cloud secret sourcing with fine-grained access control.
+* Centralizes and audits access control.
+
+[IMPORTANT]
+====
+Do not attempt to use more than one {external-secrets-operator-short} in your cluster. If you have a community {external-secrets-operator-short} installed in your cluster, you must uninstall it before installing the {external-secrets-operator}.
+====
+
+Use the {external-secrets-operator-short} to authenticate with an external secrets repository, retrieve secrets, and inject the retrieved secrets into a native Kubernetes secret. This method removes the need for applications to directly access or manage external secrets.
+
+For more information about the `external-secrets` application, see link:https://external-secrets.io/latest/[external-secrets].
+
+

--- a/modules/external-secrets-fips-support.adoc
+++ b/modules/external-secrets-fips-support.adoc
@@ -1,0 +1,18 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/index.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="external-secrets-fips-support_{context}"]
+= About FIPS compliance for {external-secrets-operator}
+
+[role="_abstract"]
+The {external-secrets-operator} supports FIPS compliance. When running on {product-title} in FIPS mode, {external-secrets-operator-short} uses the RHEL cryptographic libraries submitted to NIST for FIPS validation on the x86_64, ppc64le, and s390X architectures.
+
+To enable FIPS mode, install the {external-secrets-operator-short} on an {product-title} cluster that runs in FIPS mode. For more information, see "Do you need extra security for your cluster?".
+
+[role="_additional-resources"]
+.Additional resources
+
+* link:https://csrc.nist.gov/Projects/cryptographic-module-validation-program/validated-modules[Cryptographic module validation program]
+* link:https://access.redhat.com/articles/2918071#fips-140-2-and-fips-140-3-2[Compliance activities and government standards]

--- a/modules/external-secrets-operator-proxy-considerations.adoc
+++ b/modules/external-secrets-operator-proxy-considerations.adoc
@@ -1,0 +1,21 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/index.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="external-secrets-operator-proxy-considerations_{context}"]
+= Security considerations
+
+[role="_abstract"]
+When using the {external-secrets-operator}, there are some security concerns you should consider:
+
+* The `external-secrets` operand fetches the secrets from the configured external secrets repository and stores it in a Kubernetes native `Secrets` resource. This results in a secret zero problem. It is recommended to secure the secret objects using additional encryption. 
+
+* When configuring `SecretStore` and `ClusterSecretStore` resources, consider using short-term credential-based authorization. This approach enhances security by limiting the window of opportunity for unauthorized access, even if credentials are compromised.
+
+* To enhance the security of the {external-secrets-operator}, it is crucial to implement role-based access controls (RBACs). These RBACs should define and limit access to the custom resources provided by the {external-secrets-operator-short}.
+
+[role="_additional-resources"]
+.Additional resources
+
+* link:https://docs.redhat.com/en/documentation/red_hat_openshift_data_foundation/4.9/html/planning_your_deployment/security-considerations_rhodf#data-encryption-options_rhodf[Data encryption options].

--- a/modules/external-secrets-operator-proxy-considerations.adoc
+++ b/modules/external-secrets-operator-proxy-considerations.adoc
@@ -1,0 +1,21 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/index.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="external-secrets-operator-proxy-considerations_{context}"]
+= Security considerations
+
+[role="_abstract"]
+When using the {external-secrets-operator}, there are some security concerns you should consider:
+
+* The `external-secrets` operand fetches the secrets from the configured external providers and stores it in a Kubernetes native `Secrets` resource. This results in a secret zero problem. It is recommended to secure the secret objects using additional encryption. 
+
+* When configuring `SecretStore` and `ClusterSecretStore` resources, consider using short-term credential-based authorization. This approach enhances security by limiting the window of opportunity for unauthorized access, even if credentials are compromised.
+
+* To enhance the security of the {external-secrets-operator}, it is crucial to implement role-based access controls (RBACs). These RBACs should define and limit access to the custom resources provided by the {external-secrets-operator-short}.
+
+[role="_additional-resources"]
+.Additional resources
+
+* link:https://docs.redhat.com/en/documentation/red_hat_openshift_data_foundation/4.9/html/planning_your_deployment/security-considerations_rhodf#data-encryption-options_rhodf[Data encryption options].

--- a/modules/external-secrets-operator-proxy-considerations.adoc
+++ b/modules/external-secrets-operator-proxy-considerations.adoc
@@ -1,0 +1,21 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/index.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="external-secrets-operator-proxy-considerations_{context}"]
+= Security considerations
+
+[role="_abstract"]
+When using the {external-secrets-operator}, there are some security concerns you should consider:
+
+* The `external-secrets` operand fetches the secrets from the configured external secrets repository and stores it in a Kubernetes native `Secrets` resource. This results in a secret zero problem. It is recommended to secure the secret objects using additional encryption. 
+
+* When configuring `SecretStore` and `ClusterSecretStore` resources, consider using short-term credential-based authorization. This approach enhances security by limiting the window of opportunity for unauthorized access, even if credentials are compromised.
+
+* To enhance the security of the {external-secrets-operator}, it is crucial to implement role-based access controls (RBACs). These RBACs should define and limit access to the custom resources provided by the {external-secrets-operator-short}.
+
+[role="_additional-resources"]
+.Additional resources
+
+* link:https://docs.redhat.com/en/documentation/red_hat_openshift_data_foundation/4.9/html/planning_your_deployment/security-considerations_rhodf#data-encryption-options_rhodf[Data encryption options]

--- a/modules/external-secrets-provider-types.adoc
+++ b/modules/external-secrets-provider-types.adoc
@@ -1,0 +1,31 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/index.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="external-secrets-provider-types_{context}"]
+= External secrets providers for the {external-secrets-operator}
+
+[role="_abstract"]
+The {external-secrets-operator} is tested with the following external secrets provider types:
+
+* AWS Secrets Manager
+* HashiCorp Vault
+* Google Secret Manager
+* Azure Key Vault
+* {ibm-cloud-title} Secrets Manager
+
+[NOTE]
+====
+Red Hat does not test all factors associated with third-party secrets store provider functionality.
+====
+
+[role="_additional-resources"]
+.Additional resources
+
+* link:https://aws.amazon.com/secrets-manager/[AWS Secrets Manager]
+* link:https://developer.hashicorp.com/vault[HashiCorp Vault]
+* link:https://cloud.google.com/security/products/secret-manager[Google Secret Manager]
+* link:https://azure.microsoft.com/en-us/products/key-vault/[Azure Key Vault]
+* link:https://www.ibm.com/products/secrets-manager[{ibm-cloud-title} Secrets Manager]
+* link:https://access.redhat.com/third-party-software-support[Red{nbsp}Hat third-party support policy]

--- a/modules/external-secrets-provider-types.adoc
+++ b/modules/external-secrets-provider-types.adoc
@@ -1,0 +1,26 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/index.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="external-secrets-provider-types_{context}"]
+= External secrets providers for the {external-secrets-operator}
+
+[role="_abstract"]
+The {external-secrets-operator} is tested with the following external secrets provider types:
+
+* link:https://aws.amazon.com/secrets-manager/[AWS Secrets Manager]
+* link:https://developer.hashicorp.com/vault[HashiCorp Vault]
+* link:https://cloud.google.com/security/products/secret-manager[Google Secret Manager]
+* link:https://azure.microsoft.com/en-us/products/key-vault/[Azure Key Vault]
+* link:https://www.ibm.com/products/secrets-manager[{ibm-cloud-title} Secrets Manager]
+
+[NOTE]
+====
+Red Hat does not test all factors associated with third-party secrets store provider functionality.
+====
+
+[role="_additional-resources"]
+.Additional resources
+
+* link:https://access.redhat.com/third-party-software-support[Red{nbsp}Hat third-party support policy]

--- a/security/external_secrets_operator/index.adoc
+++ b/security/external_secrets_operator/index.adoc
@@ -1,0 +1,35 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="external-secrets-operator-about"]
+= {external-secrets-operator} overview
+include::_attributes/common-attributes.adoc[]
+:context: external-secrets-operator-about
+
+toc::[]
+
+[role="_abstract"]
+The {external-secrets-operator} operates as a cluster-wide service to deploy and manage the `external-secrets` application. The `external-secrets` application integrates with external secrets management systems and performs secret fetching, refreshing, and provisioning within the cluster.
+
+//About the {external-secrets-operator}
+include::modules/external-secrets-about.adoc[leveloffset=+1]
+
+
+//About the external secrets provide types
+include::modules/external-secrets-provider-types.adoc[leveloffset=+1]
+
+//FIPS compliant support
+include::modules/external-secrets-fips-support.adoc[leveloffset=+1]
+
+//egress proxy security considerations
+include::modules/external-secrets-operator-proxy-considerations.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+[id="external-secrets-operator-about_additional-resources"]
+== Additional resources
+
+* link:https://external-secrets.io/latest/[external-secrets]
+* link:https://external-secrets.io/latest/[external-secrets application]
+* xref:../../security/container_security/security-compliance.adoc#security-compliance[Understanding compliance]
+* xref:../../installing/overview/installing-fips.adoc#installing-fips-mode_installing-fips[Installing a cluster in FIPS mode]
+* xref:../../installing/overview/installing-preparing.adoc#installing-preparing-security[Do you need extra security for your cluster?]
+* link:https://docs.redhat.com/en/documentation/red_hat_openshift_data_foundation/4.19/html/planning_your_deployment/security-considerations_rhodf[Security considerations]
+* link:https://external-secrets.io/latest/guides/security-best-practices/[Security Best Practices]

--- a/security/external_secrets_operator/index.adoc
+++ b/security/external_secrets_operator/index.adoc
@@ -1,0 +1,33 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="external-secrets-operator-about"]
+= {external-secrets-operator} overview
+include::_attributes/common-attributes.adoc[]
+:context: external-secrets-operator-about
+
+toc::[]
+
+[role="_abstract"]
+The {external-secrets-operator} operates as a cluster-wide service to deploy and manage the `external-secrets` application. The `external-secrets` application integrates with external secrets management systems and performs secret fetching, refreshing, and provisioning within the cluster.
+
+//About the {external-secrets-operator}
+include::modules/external-secrets-about.adoc[leveloffset=+1]
+
+//About the external secrets provide types
+include::modules/external-secrets-provider-types.adoc[leveloffset=+1]
+
+//FIPS compliant support
+include::modules/external-secrets-fips-support.adoc[leveloffset=+1]
+
+//egress proxy security considerations
+include::modules/external-secrets-operator-proxy-considerations.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+[id="external-secrets-operator-about_additional-resources"]
+== Additional resources
+
+* link:https://external-secrets.io/latest/[external-secrets application]
+* xref:../../security/container_security/security-compliance.adoc#security-compliance[Understanding compliance]
+* xref:../../installing/overview/installing-fips.adoc#installing-fips-mode_installing-fips[Installing a cluster in FIPS mode]
+* xref:../../installing/overview/installing-preparing.adoc#installing-preparing-security[Do you need extra security for your cluster?]
+* link:https://docs.redhat.com/en/documentation/red_hat_openshift_data_foundation/4.19/html/planning_your_deployment/security-considerations_rhodf[Security considerations]
+* link:https://external-secrets.io/latest/guides/security-best-practices/[Security Best Practices]

--- a/security/external_secrets_operator/index.adoc
+++ b/security/external_secrets_operator/index.adoc
@@ -1,0 +1,32 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="external-secrets-operator-about"]
+= {external-secrets-operator} overview
+include::_attributes/common-attributes.adoc[]
+:context: external-secrets-operator-about
+
+toc::[]
+
+[role="_abstract"]
+The {external-secrets-operator} operates as a cluster-wide service to deploy and manage the `external-secrets` application. The `external-secrets` application integrates with external secrets management systems and performs secret fetching, refreshing, and provisioning within the cluster.
+
+//About the {external-secrets-operator}
+include::modules/external-secrets-about.adoc[leveloffset=+1]
+
+//About the external secrets provider types
+include::modules/external-secrets-provider-types.adoc[leveloffset=+1]
+
+//FIPS compliant support
+include::modules/external-secrets-fips-support.adoc[leveloffset=+1]
+
+//egress proxy security considerations
+include::modules/external-secrets-operator-proxy-considerations.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+[id="additional-resources_{context}"]
+== Additional resources
+
+* xref:../../security/container_security/security-compliance.adoc#security-compliance[Understanding compliance]
+* xref:../../installing/overview/installing-fips.adoc#installing-fips-mode_installing-fips[Installing a cluster in FIPS mode]
+* xref:../../installing/overview/installing-preparing.adoc#installing-preparing-security[Do you need extra security for your cluster?]
+* link:https://docs.redhat.com/en/documentation/red_hat_openshift_data_foundation/4.19/html/planning_your_deployment/security-considerations_rhodf[Security considerations]
+* link:https://external-secrets.io/latest/guides/security-best-practices/[Security Best Practices]


### PR DESCRIPTION
Version(s):
4.18

Issue:
https://redhat.atlassian.net/browse/OSDOCS-18784

Link to docs preview:
https://111734--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/external_secrets_operator/index.html


QE review:
- [ ] QE has approved this change.


Additional information:
This is the second PR. This is related to the following PRs:

- https://github.com/openshift/openshift-docs/pull/111755
- https://github.com/openshift/openshift-docs/pull/111824
- https://github.com/openshift/openshift-docs/pull/111850
- https://github.com/openshift/openshift-docs/pull/111857
- https://github.com/openshift/openshift-docs/pull/111862
- https://github.com/openshift/openshift-docs/pull/111911
- https://github.com/openshift/openshift-docs/pull/111950
- https://github.com/openshift/openshift-docs/pull/111965
- https://github.com/openshift/openshift-docs/pull/111998

