### PR TITLE
Fix ConceptLink warnings in virt/about_virt documentation

### DIFF
--- a/modules/virt-about-storage-volumes-for-vm-disks.adoc
+++ b/modules/virt-about-storage-volumes-for-vm-disks.adoc
@@ -11,7 +11,7 @@
 If you use the storage API with known storage providers, the volume and access modes are selected automatically. However, if you use a storage class that does not have a storage profile, you must configure the volume and access mode.
 
 ifndef::openshift-dedicated[]
-For a list of known storage providers for {VirtProductName}, see the link:https://catalog.redhat.com/search?searchType=software&badges_and_features=OpenShift+Virtualization&subcategories=Storage[ Red Hat Ecosystem Catalog].
+For a list of known storage providers for {VirtProductName}, see the Red Hat Ecosystem Catalog.
 endif::openshift-dedicated[]
 
 For best results, use the `ReadWriteMany` (RWX) access mode and the `Block` volume mode. This is important for the following reasons:

--- a/modules/virt-tested-maximums.adoc
+++ b/modules/virt-tested-maximums.adoc
@@ -12,7 +12,7 @@ The following limits apply to a large-scale {VirtProductName} 4.x environment. T
 [id="vm-maximums_{context}"]
 == Virtual machine maximums
 
-The following maximums apply to virtual machines (VMs) running on {VirtProductName}. These values are subject to the limits specified in link:https://access.redhat.com/articles/rhel-kvm-limits[Virtualization limits for Red Hat{nbsp}Enterprise Linux with KVM].
+The following maximums apply to virtual machines (VMs) running on {VirtProductName}. These values are subject to the limits specified in "Virtualization limits for Red Hat{nbsp}Enterprise Linux with KVM".
 
 [cols="1,1,1",subs="attributes+"]
 |===

--- a/modules/virt-what-you-can-do-with-virt.adoc
+++ b/modules/virt-what-you-can-do-with-virt.adoc
@@ -20,7 +20,7 @@ You can use it to manage virtual machines (VMs) exclusively or alongside contain
 ifndef::openshift-origin,openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
 [NOTE]
 ====
-If you have a {ove-first} subscription, you can run unlimited VMs on subscribed hosts, but you cannot run application instances in containers. For more information, see the subscription guide section about link:https://www.redhat.com/en/resources/self-managed-openshift-subscription-guide#section-8[{ove-first} and related products].
+If you have a {ove-first} subscription, you can run unlimited VMs on subscribed hosts, but you cannot run application instances in containers. For more information, see the subscription guide section about {ove-first} and related products.
 ====
 endif::[]
 
@@ -45,9 +45,27 @@ ifndef::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
 
 [IMPORTANT]
 ====
-When you deploy {VirtProductName} with {rh-storage}, you must create a dedicated storage class for Windows virtual machine disks. See link:https://access.redhat.com/articles/6978371[Optimizing ODF PersistentVolumes for Windows VMs] for details.
+When you deploy {VirtProductName} with {rh-storage}, you must create a dedicated storage class for Windows virtual machine disks. See "Optimizing ODF PersistentVolumes for Windows VMs" for details.
 ====
 endif::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
 
-// A line about support for OVN and OpenShiftSDN network providers has been moved to the `about-virt` assembly due to xrefs.
-// If you are re-using this module, you might also want to include that line in your assembly.
+ifndef::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
+You can use {VirtProductName} with OVN-Kubernetes or one of the other certified network plugins listed in "Certified OpenShift CNI Plug-ins".
+endif::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
+
+ifdef::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
+You can use {VirtProductName} with OVN-Kubernetes.
+endif::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
+
+// Hiding links in ROSA/OSD until PR 62384 merges
+ifndef::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
+You can check your {VirtProductName} cluster for compliance issues by installing the Compliance Operator and running a scan with the `ocp4-moderate` and `ocp4-moderate-node` profiles. The Compliance Operator uses OpenSCAP, a NIST-certified tool, to scan and enforce security policies.
+endif::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
+
+ifdef::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
+You can check your {VirtProductName} cluster for compliance issues by installing the Compliance Operator and running a scan with the `ocp4-moderate` and `ocp4-moderate-node` profiles. The Compliance Operator uses OpenSCAP, a NIST-certified tool, to scan and enforce security policies.
+endif::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
+
+ifndef::openshift-dedicated[]
+For information about partnering with Independent Software Vendors (ISVs) and Services partners for specialized storage, networking, backup, and additional functionality, see the Red Hat Ecosystem Catalog.
+endif::openshift-dedicated[]

--- a/virt/about_virt/about-virt.adoc
+++ b/virt/about_virt/about-virt.adoc
@@ -11,30 +11,6 @@ Learn about {VirtProductName}'s capabilities and support scope.
 
 include::modules/virt-what-you-can-do-with-virt.adoc[leveloffset=+1]
 
-// This line is attached to the above `virt-what-you-can-do-with-virt` module.
-// It is included here in the assembly because of the xref ban.
-
-ifndef::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
-You can use {VirtProductName} with xref:../../networking/ovn_kubernetes_network_provider/about-ovn-kubernetes.adoc#about-ovn-kubernetes[OVN-Kubernetes] or one of the other certified network plugins listed in link:https://access.redhat.com/articles/5436171[Certified OpenShift CNI Plug-ins].
-endif::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
-
-ifdef::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
-You can use {VirtProductName} with OVN-Kubernetes.
-endif::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
-
-// Hiding links in ROSA/OSD until PR 62384 merges
-ifndef::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
-You can check your {VirtProductName} cluster for compliance issues by installing the xref:../../security/compliance_operator/co-concepts/compliance-operator-understanding.adoc#understanding-compliance[Compliance Operator] and running a scan with the `ocp4-moderate` and `ocp4-moderate-node` xref:../../security/compliance_operator/co-scans/compliance-operator-supported-profiles.adoc#compliance-operator-supported-profiles[profiles]. The Compliance Operator uses OpenSCAP, a link:https://www.nist.gov/[NIST-certified tool], to scan and enforce security policies.
-endif::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
-
-ifdef::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
-You can check your {VirtProductName} cluster for compliance issues by installing the Compliance Operator and running a scan with the `ocp4-moderate` and `ocp4-moderate-node` profiles. The Compliance Operator uses OpenSCAP, a link:https://www.nist.gov/[NIST-certified tool], to scan and enforce security policies.
-endif::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
-
-ifndef::openshift-dedicated[]
-For information about partnering with Independent Software Vendors (ISVs) and Services partners for specialized storage, networking, backup, and additional functionality, see link:https://red.ht/workswithvirt[the Red Hat Ecosystem Catalog].
-endif::openshift-dedicated[]
-
 include::modules/virt-vmware-comparison.adoc[leveloffset=+1]
 
 include::modules/virt-supported-cluster-version.adoc[leveloffset=+1]
@@ -47,9 +23,18 @@ include::modules/virt-sno-differences.adoc[leveloffset=+1]
 endif::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
 
 [role="_additional-resources"]
-[id="additional-resources_about-virt"]
+[id="additional-resources_{context}"]
 == Additional resources
-
+ifndef::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
+* link:https://access.redhat.com/articles/5436171[Certified OpenShift CNI Plug-ins]
+* xref:../../networking/ovn_kubernetes_network_provider/about-ovn-kubernetes.adoc#about-ovn-kubernetes[About the OVN-Kubernetes network plugin]
+* link:https://www.nist.gov/[NIST-certified tool]
+* xref:../../security/compliance_operator/co-concepts/compliance-operator-understanding.adoc#understanding-compliance[Understanding the Compliance Operator]
+* xref:../../security/compliance_operator/co-scans/compliance-operator-supported-profiles.adoc#compliance-operator-supported-profiles[Supported compliance profiles]
+endif::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
+ifndef::openshift-dedicated[]
+* link:https://red.ht/workswithvirt[Red Hat Ecosystem Catalog]
+endif::openshift-dedicated[]
 ifndef::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
 * xref:../../virt/about_virt/virt-supported-limits.adoc#virt-supported-limits[{VirtProductName} supported limits]
 * xref:../../networking/ovn_kubernetes_network_provider/about-ovn-kubernetes.adoc#nw-ovn-kubernetes-purpose_about-ovn-kubernetes[OVN-Kubernetes purpose]

--- a/virt/about_virt/virt-security-policies.adoc
+++ b/virt/about_virt/virt-security-policies.adoc
@@ -10,9 +10,9 @@ toc::[]
 Learn about {VirtProductName} security and authorization.
 
 .Key points
-* {VirtProductName} adheres to the `restricted` link:https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted[Kubernetes pod security standards] profile, which aims to enforce the current best practices for pod security.
+* {VirtProductName} adheres to the `restricted` Kubernetes pod security standards profile, which aims to enforce the current best practices for pod security.
 * Virtual machine (VM) workloads run as unprivileged pods.
-* xref:../../authentication/managing-security-context-constraints.adoc#security-context-constraints-about_configuring-internal-oauth[Security context constraints] (SCCs) are defined for the `kubevirt-controller` service account.
+* Security context constraints (SCCs) are defined for the `kubevirt-controller` service account.
 * TLS certificates for {VirtProductName} components are renewed and rotated automatically.
 
 include::modules/virt-about-workload-security.adoc[leveloffset=+1]
@@ -22,7 +22,7 @@ include::modules/virt-automatic-certificates-renewal.adoc[leveloffset=+1]
 [id="authorization_virt-security-policies"]
 == Authorization
 
-{VirtProductName} uses xref:../../authentication/using-rbac.adoc#using-rbac[role-based access control] (RBAC) to define permissions for human users and service accounts. The permissions defined for service accounts control the actions that {VirtProductName} components can perform.
+{VirtProductName} uses role-based access control (RBAC) to define permissions for human users and service accounts. The permissions defined for service accounts control the actions that {VirtProductName} components can perform.
 
 You can also use RBAC roles to manage user access to virtualization features. For example, an administrator can create an RBAC role that provides the permissions required to launch a virtual machine. The administrator can then restrict access by binding the role to specific users.
 
@@ -35,6 +35,8 @@ include::modules/virt-additional-scc-for-kubevirt-controller.adoc[leveloffset=+2
 [role="_additional-resources"]
 [id="additional-resources_{context}"]
 == Additional resources
+* link:https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted[Kubernetes pod security standards]
+* xref:../../authentication/managing-security-context-constraints.adoc#security-context-constraints-about_configuring-internal-oauth[Security context constraints]
 * xref:../../authentication/managing-security-context-constraints.adoc#security-context-constraints-about_configuring-internal-oauth[Managing security context constraints]
 * xref:../../authentication/using-rbac.adoc#using-rbac[Using RBAC to define and apply permissions]
 * xref:../../authentication/using-rbac.adoc#creating-cluster-role_using-rbac[Creating a cluster role]

--- a/virt/about_virt/virt-supported-limits.adoc
+++ b/virt/about_virt/virt-supported-limits.adoc
@@ -9,13 +9,14 @@ toc::[]
 [role="_abstract"]
 You can refer to tested object maximums when planning your {product-title} environment for {VirtProductName}. However, approaching the maximum values can reduce performance and increase latency. Ensure that you plan for your specific use case and consider all factors that can impact cluster scaling.
 
-For more information about cluster configuration and options that impact performance, see the link:https://access.redhat.com/articles/6994974[{VirtProductName} - Tuning & Scaling Guide] in the Red{nbsp}Hat Knowledgebase.
+For more information about cluster configuration and options that impact performance, see the "{VirtProductName} - Tuning & Scaling Guide" in the Red{nbsp}Hat Knowledgebase.
 
 include::modules/virt-tested-maximums.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 [id="additional-resources_{context}"]
 == Additional resources
+* link:https://access.redhat.com/articles/rhel-kvm-limits[Virtualization limits for Red Hat{nbsp}Enterprise Linux with KVM]
 * link:https://access.redhat.com/articles/6994974[{VirtProductName} - Tuning & Scaling Guide]
 * xref:../../scalability_and_performance/planning-your-environment-according-to-object-maximums.adoc#planning-your-environment-according-to-object-maximums[Planning your environment according to object maximums]
 * xref:../../nodes/nodes/nodes-nodes-managing-max-pods.adoc#nodes-nodes-managing-max-pods[Managing the maximum number of pods per node]


### PR DESCRIPTION
## Summary
This PR fixes AsciiDocDITA.ConceptLink warnings in the virt/about_virt documentation by:
- Moving links and cross-references to Additional resources sections in assembly files
- Removing links from module and snippet files to comply with documentation standards
- Applying proper formatting when replacing links in text

Preview links:

- https://111741--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/about_virt/about-virt.html
- https://111741--ocpdocs-pr.netlify.app/openshift-dedicated/latest/virt/about_virt/about-virt.html#additional-resources_about-virt
- https://111741--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/about_virt/virt-security-policies.html
- https://111741--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/about_virt/virt-supported-limits.html
- https://111741--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/install/virt-requirements.html

Version:
4.20+

Jira:
TBA

## Related
Part of splitting PR #111736 into smaller, subdirectory-focused PRs for easier review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)