### PR TITLE
Fix ConceptLink warnings in virt/backup_restore documentation

### DIFF
--- a/modules/install-and-configure-oadp-kubevirt.adoc
+++ b/modules/install-and-configure-oadp-kubevirt.adoc
@@ -9,7 +9,7 @@
 [role="_abstract"]
 As a cluster administrator, you install {oadp-short} by installing the {oadp-short} Operator.
 
-The latest version of the {oadp-short} Operator installs link:https://velero.io/docs/v{velero-version}[Velero {velero-version}].
+The latest version of the {oadp-short} Operator installs Velero {velero-version}.
 
 .Prerequisites
 

--- a/modules/oadp-installing-dpa-1-3.adoc
+++ b/modules/oadp-installing-dpa-1-3.adoc
@@ -382,7 +382,7 @@ where:
 `namespace`:: Specifies the default namespace for OADP which is `openshift-adp`. The namespace is a variable and is configurable.
 `aws`:: Specifies that an object store plugin corresponding to your storage locations is required. For all S3 providers, the required plugin is `aws`. For {azure-short} and {gcp-short} object stores, the `azure` or `gcp` plugin is required.
 `kubevirt`:: Optional: The `kubevirt` plugin is used with {VirtProductName}.
-`csi`:: Specifies the `csi` default plugin if you use CSI snapshots to back up PVs. The `csi` plugin uses the link:https://{velero-domain}/docs/main/csi/[Velero CSI beta snapshot APIs]. You do not need to configure a snapshot location.
+`csi`:: Specifies the `csi` default plugin if you use CSI snapshots to back up PVs. The `csi` plugin uses the Velero CSI beta snapshot APIs. You do not need to configure a snapshot location.
 `openshift`:: Specifies that the `openshift` plugin is mandatory.
 `resourceTimeout`:: Specifies how many minutes to wait for several Velero resources such as Velero CRD availability, volumeSnapshot deletion, and backup repository availability, before timeout occurs. The default is 10m.
 `nodeAgent`:: Specifies the administrative agent that routes the administrative requests to servers.
@@ -435,7 +435,7 @@ where:
 `namespace`:: Specifies the default namespace for OADP which is `openshift-adp`. The namespace is a variable and is configurable.
 `kubevirt`:: Specifies that the `kubevirt` plugin is mandatory for {VirtProductName}.
 `gcp`:: Specifies the plugin for the backup provider, for example, `gcp`, if it exists.
-`csi`:: Specifies that the `csi` plugin is mandatory for backing up PVs with CSI snapshots. The `csi` plugin uses the link:https://{velero-domain}/docs/main/csi/[Velero CSI beta snapshot APIs]. You do not need to configure a snapshot location.
+`csi`:: Specifies that the `csi` plugin is mandatory for backing up PVs with CSI snapshots. The `csi` plugin uses the Velero CSI beta snapshot APIs. You do not need to configure a snapshot location.
 `openshift`:: Specifies that the `openshift` plugin is mandatory.
 `resourceTimeout`:: Specifies how many minutes to wait for several Velero resources such as Velero CRD availability, volumeSnapshot deletion, and backup repository availability, before timeout occurs. The default is 10m.
 `nodeAgent`:: Specifies the administrative agent that routes the administrative requests to servers.

--- a/modules/virt-about-dr-methods.adoc
+++ b/modules/virt-about-dr-methods.adoc
@@ -9,7 +9,7 @@
 [role="_abstract"]
 The two primary DR methods for {VirtProductName} are Metropolitan Disaster Recovery (Metro-DR) and Regional-DR.
 
-For an overview of disaster recovery (DR) concepts, architecture, and planning considerations, see the link:https://access.redhat.com/articles/7041594[Red{nbsp}Hat {VirtProductName} disaster recovery guide] in the Red{nbsp}Hat Knowledgebase.
+For an overview of disaster recovery (DR) concepts, architecture, and planning considerations, see the "Red{nbsp}Hat {VirtProductName} disaster recovery guide" in the Red{nbsp}Hat Knowledgebase.
 
 [id="metro-dr_{context}"]
 == Metro-DR

--- a/virt/backup_restore/virt-backup-restore-overview.adoc
+++ b/virt/backup_restore/virt-backup-restore-overview.adoc
@@ -54,16 +54,6 @@ endif::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
 
 include::modules/install-and-configure-oadp-kubevirt.adoc[leveloffset=+1]
 
-ifndef::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
-[role="_additional-resources"]
-.Additional resources
-
-* xref:../../backup_and_restore/application_backup_and_restore/oadp-features-plugins.adoc#oadp-plugins_oadp-features-plugins[{oadp-short} plugins]
-* xref:../../backup_and_restore/application_backup_and_restore/backing_up_and_restoring/backing-up-applications.adoc#backing-up-applications[`Backup` custom resource (CR)]
-* xref:../../backup_and_restore/application_backup_and_restore/backing_up_and_restoring/restoring-applications.adoc#restoring-applications[`Restore` CR]
-* xref:../../disconnected/using-olm.adoc#olm-restricted-networks[Using Operator Lifecycle Manager in disconnected environments]
-endif::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
-
 include::modules/oadp-installing-dpa-1-3.adoc[leveloffset=+1]
 
 :!provider:
@@ -71,9 +61,13 @@ include::modules/oadp-installing-dpa-1-3.adoc[leveloffset=+1]
 :!virt-backup-restore-overview:
 
 [role="_additional-resources"]
-[id="additional-resources_{virt-backup-restore-overview}"]
+[id="additional-resources_{context}"]
 == Additional resources
-
 * xref:../../backup_and_restore/index.adoc#application-backup-restore-operations-overview[{oadp-full}]
+ifndef::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
+* xref:../../backup_and_restore/application_backup_and_restore/oadp-features-plugins.adoc#oadp-plugins_oadp-features-plugins[{oadp-short} plugins]
+* xref:../../backup_and_restore/application_backup_and_restore/backing_up_and_restoring/backing-up-applications.adoc#backing-up-applications[`Backup` custom resource (CR)]
+* xref:../../backup_and_restore/application_backup_and_restore/backing_up_and_restoring/restoring-applications.adoc#restoring-applications[`Restore` CR]
 * xref:../../backup_and_restore/application_backup_and_restore/backing_up_and_restoring/oadp-backing-up-applications-restic-doc.adoc#oadp-backing-up-applications-restic-doc[Backing up applications with File System Backup: Kopia or Restic]
 * xref:../../disconnected/using-olm.adoc#olm-restricted-networks[Using Operator Lifecycle Manager in disconnected environments]
+endif::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]

--- a/virt/backup_restore/virt-backup-restore-overview.adoc
+++ b/virt/backup_restore/virt-backup-restore-overview.adoc
@@ -17,7 +17,7 @@ Red Hat supports using {VirtProductName} 4.14 or later with {oadp-short} 1.3.x o
 ====
 
 ifndef::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
-Back up and restore virtual machines by using the xref:../../backup_and_restore/index.adoc#application-backup-restore-operations-overview[{oadp-full}].
+Back up and restore virtual machines by using the {oadp-full}.
 endif::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
 
 ifdef::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
@@ -42,14 +42,14 @@ The following storage options are excluded:
 * Volume snapshot backup and restore
 
 ifndef::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
-For more information, see xref:../../backup_and_restore/application_backup_and_restore/backing_up_and_restoring/oadp-backing-up-applications-restic-doc.adoc#oadp-backing-up-applications-restic-doc[Backing up applications with File System Backup: Kopia or Restic].
+For more information, see "Backing up applications with File System Backup: Kopia or Restic".
 endif::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
 ====
 
 To install the {oadp-short} Operator in a restricted network environment, you must first disable the default software catalog sources and mirror the Operator catalog.
 
 ifndef::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
-See xref:../../disconnected/using-olm.adoc#olm-restricted-networks[Using Operator Lifecycle Manager in disconnected environments] for details.
+See "Using Operator Lifecycle Manager in disconnected environments" for details.
 endif::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
 
 include::modules/install-and-configure-oadp-kubevirt.adoc[leveloffset=+1]
@@ -69,3 +69,11 @@ include::modules/oadp-installing-dpa-1-3.adoc[leveloffset=+1]
 :!provider:
 :!credentials:
 :!virt-backup-restore-overview:
+
+[role="_additional-resources"]
+[id="additional-resources_{virt-backup-restore-overview}"]
+== Additional resources
+
+* xref:../../backup_and_restore/index.adoc#application-backup-restore-operations-overview[{oadp-full}]
+* xref:../../backup_and_restore/application_backup_and_restore/backing_up_and_restoring/oadp-backing-up-applications-restic-doc.adoc#oadp-backing-up-applications-restic-doc[Backing up applications with File System Backup: Kopia or Restic]
+* xref:../../disconnected/using-olm.adoc#olm-restricted-networks[Using Operator Lifecycle Manager in disconnected environments]


### PR DESCRIPTION
## Summary
This PR fixes AsciiDocDITA.ConceptLink warnings in the virt/backup_restore documentation by:
- Moving links and cross-references to Additional resources sections in assembly files
- Removing links from module and snippet files to comply with documentation standards
- Applying proper formatting when replacing links in text

## Related
Part of splitting PR #111736 into smaller, subdirectory-focused PRs for easier review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)