### PR TITLE
Fix ConceptLink warnings in virt/creating_vm documentation

### DIFF
--- a/virt/creating_vm/virt-creating-vms-from-templates.adoc
+++ b/virt/creating_vm/virt-creating-vms-from-templates.adoc
@@ -6,7 +6,6 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-[role="_abstract"]
 You can create virtual machines (VMs) from Red Hat templates by using the {product-title} web console.
 
 [id="virt-about-templates"]
@@ -43,3 +42,4 @@ include::modules/virt-dedicated-resources-vm-template.adoc[leveloffset=+2]
 [id="additional-resources_{context}"]
 == Additional resources
 * xref:../../virt/storage/virt-automatic-bootsource-updates.adoc#virt-automatic-bootsource-updates[Managing automatic boot source updates]
+* xref:../../virt/creating_vm/virt-creating-vms-from-templates.adoc#virt-customizing-vm-template-web_virt-creating-vms-from-templates[Removing a deprecated designation from a customized VM template by using the web console]

--- a/virt/creating_vm/virt-creating-vms-from-templates.adoc
+++ b/virt/creating_vm/virt-creating-vms-from-templates.adoc
@@ -6,7 +6,6 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-[role="_abstract"]
 You can create virtual machines (VMs) from Red Hat templates by using the {product-title} web console.
 
 [id="virt-about-templates"]
@@ -17,7 +16,7 @@ You can use VM templates to help you easily create VMs.
 Expedite creation with boot sources::
 You can expedite VM creation by using templates that have an available boot source. Templates with a boot source are labeled *Available boot source* if they do not have a custom label.
 +
-Templates without a boot source are labeled *Boot source required*. See xref:../../virt/storage/virt-automatic-bootsource-updates.adoc#virt-automatic-bootsource-updates[Managing automatic boot source updates] for details.
+Templates without a boot source are labeled *Boot source required*. See "Managing automatic boot source updates" for details.
 
 Customize before starting the VM::
 You can customize the disk source and VM parameters before you start the VM.
@@ -25,7 +24,7 @@ You can customize the disk source and VM parameters before you start the VM.
 +
 [NOTE]
 ====
-If you copy a VM template with all its labels and annotations, your version of the template is marked as deprecated when a new version of the Scheduling, Scale, and Performance (SSP) Operator is deployed. You can remove this designation. See xref:../../virt/creating_vm/virt-creating-vms-from-templates.adoc#virt-customizing-vm-template-web_virt-creating-vms-from-templates[Removing a deprecated designation from a customized VM template by using the web console].
+If you copy a VM template with all its labels and annotations, your version of the template is marked as deprecated when a new version of the Scheduling, Scale, and Performance (SSP) Operator is deployed. You can remove this designation. See "Removing a deprecated designation from a customized VM template by using the web console".
 ====
 
 {sno-caps}::
@@ -38,3 +37,10 @@ include::modules/virt-customizing-vm-template-web.adoc[leveloffset=+1]
 include::modules/virt-creating-template.adoc[leveloffset=+2]
 
 include::modules/virt-dedicated-resources-vm-template.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+[id="additional-resources_{virt-creating-vms-from-templates}"]
+== Additional resources
+
+* xref:../../virt/storage/virt-automatic-bootsource-updates.adoc#virt-automatic-bootsource-updates[Managing automatic boot source updates]
+* xref:../../virt/creating_vm/virt-creating-vms-from-templates.adoc#virt-customizing-vm-template-web_virt-creating-vms-from-templates[Removing a deprecated designation from a customized VM template by using the web console]


### PR DESCRIPTION
## Summary
This PR fixes AsciiDocDITA.ConceptLink warnings in the virt/creating_vm documentation by:
- Moving links and cross-references to Additional resources sections in assembly files
- Removing links from module and snippet files to comply with documentation standards
- Applying proper formatting when replacing links in text

## Related
Part of splitting PR #111736 into smaller, subdirectory-focused PRs for easier review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)