### PR TITLE
Fix ConceptLink warnings in virt/getting_started documentation

### DIFF
--- a/modules/virt-arm-compatibility.adoc
+++ b/modules/virt-arm-compatibility.adoc
@@ -13,7 +13,7 @@ Before using {VirtProductName} on an ARM64-based system, consider the following 
 
 Operating system::
 * Only Linux-based guest operating systems are supported.
-* All virtualization limitations for {op-system-base} also apply to {VirtProductName}. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9/html/configuring_and_managing_virtualization/assembly_feature-support-and-limitations-in-rhel-9-virtualization_configuring-and-managing-virtualization#how-virtualization-on-arm-64-differs-from-amd64-and-intel64_feature-support-and-limitations-in-rhel-9-virtualization[How virtualization on ARM64 differs from AMD64 and Intel 64] in the {op-system-base} documentation.
+* All virtualization limitations for {op-system-base} also apply to {VirtProductName}. For more information, see "How virtualization on ARM64 differs from AMD64 and Intel 64" in the {op-system-base} documentation.
 
 Live migration::
 * Live migration is *not supported* on ARM64-based {product-title} clusters.


### PR DESCRIPTION
## Summary
This PR fixes AsciiDocDITA.ConceptLink warnings in the virt/getting_started documentation by:
- Moving links and cross-references to Additional resources sections in assembly files
- Removing links from module and snippet files to comply with documentation standards
- Applying proper formatting when replacing links in text

## Related
Part of splitting PR #111736 into smaller, subdirectory-focused PRs for easier review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)