### PR TITLE
Fix ConceptLink warnings in virt/post_installation_configuration documentation

### DIFF
--- a/modules/virt-creating-secondary-localnet-udn.adoc
+++ b/modules/virt-creating-secondary-localnet-udn.adoc
@@ -45,7 +45,7 @@ spec:
 +
 [IMPORTANT]
 ====
-{VirtProductName} does not support Linux bridge bonding modes 0, 5, and 6. For more information, see link:https://access.redhat.com/solutions/67546[Which bonding modes work when used with a bridge that virtual machine guests or containers connect to?].
+{VirtProductName} does not support Linux bridge bonding modes 0, 5, and 6. For more information, see "Which bonding modes work when used with a bridge that virtual machine guests or containers connect to?".
 ====
 
 . Apply the `NodeNetworkConfigurationPolicy` manifest by running the following command:

--- a/virt/post_installation_configuration/virt-post-install-config.adoc
+++ b/virt/post_installation_configuration/virt-post-install-config.adoc
@@ -17,9 +17,9 @@ endif::openshift-enterprise[]
 
 * The hostpath provisioner is a local storage provisioner designed for {VirtProductName}. If you want to configure local storage for virtual machines, you must enable the hostpath provisioner first.
 
-* xref:../../virt/post_installation_configuration/virt-node-placement-virt-components.adoc#virt-node-placement-virt-components[Node placement rules for {VirtProductName} Operators, workloads, and controllers]
+* Node placement rules for {VirtProductName} Operators, workloads, and controllers
 
-* xref:../../virt/post_installation_configuration/virt-post-install-network-config.adoc#virt-post-install-network-config[Network configuration]:
+* Network configuration:
 
 ifndef::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
 ** Installing the Kubernetes NMState and SR-IOV Operators
@@ -32,9 +32,17 @@ ifdef::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
 ** Enabling the creation of load balancer services by using the {product-title} web console
 endif::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
 
-* xref:../../virt/post_installation_configuration/virt-post-install-storage-config.adoc#virt-post-install-storage-config[Storage configuration]:
+* "Storage configuration":
 ** Defining a default storage class for the Container Storage Interface (CSI)
 ** Configuring local storage by using the Hostpath Provisioner (HPP)
 
 // * Users
 // * Alerts and notifications
+
+[role="_additional-resources"]
+[id="additional-resources_{virt-post-install-config}"]
+== Additional resources
+
+* xref:../../virt/post_installation_configuration/virt-node-placement-virt-components.adoc#virt-node-placement-virt-components[Node placement rules for {VirtProductName} Operators, workloads, and controllers]
+* xref:../../virt/post_installation_configuration/virt-post-install-network-config.adoc#virt-post-install-network-config[Network configuration]
+* xref:../../virt/post_installation_configuration/virt-post-install-storage-config.adoc#virt-post-install-storage-config[Storage configuration]


### PR DESCRIPTION
## Summary
This PR fixes AsciiDocDITA.ConceptLink warnings in the virt/post_installation_configuration documentation by:
- Moving links and cross-references to Additional resources sections in assembly files
- Removing links from module and snippet files to comply with documentation standards
- Applying proper formatting when replacing links in text

## Related
Part of splitting PR #111736 into smaller, subdirectory-focused PRs for easier review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)