### PR TITLE
Fix ConceptLink warnings in virt/updating documentation

### DIFF
--- a/modules/virt-about-control-plane-only-updates.adoc
+++ b/modules/virt-about-control-plane-only-updates.adoc
@@ -18,4 +18,4 @@ To move between EUS versions, first update {VirtProductName} to the latest z-str
 You can update {VirtProductName} directly to the latest z-stream release of your current minor version without applying each intermediate z-stream update.
 ====
 
-For more information about EUS versions, see the link:https://access.redhat.com/support/policy/updates/openshift[{product-title} Life Cycle Policy].
+For more information about EUS versions, see the "{product-title} Life Cycle Policy".


### PR DESCRIPTION
## Summary
This PR fixes AsciiDocDITA.ConceptLink warnings in the virt/updating documentation by:
- Moving links and cross-references to Additional resources sections in assembly files
- Removing links from module and snippet files to comply with documentation standards
- Applying proper formatting when replacing links in text

## Related
Part of splitting PR #111736 into smaller, subdirectory-focused PRs for easier review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)