### PR TITLE
[OSDOCS#17295]: Configuring image pull credential verification in multi-tenant clusters release notes

### DIFF
--- a/modules/rn-ocp-release-notes-new-features.adoc
+++ b/modules/rn-ocp-release-notes-new-features.adoc
@@ -215,13 +215,23 @@ For more information, see xref:../networking/multiple_networks/secondary_network
 [id="ocp-release-notes-nodes_{context}"]
 == Nodes
 
-////
-Instructions: Add entries in the following format:
-
-Item description::
+Image pull credential verification in multi-tenant clusters::
 +
-Detailed information.
-////
+With this release, administrators can use the `imagePullCredentialsVerificationPolicy` parameter in a `KubeletConfig` custom resource to enforce credential verification for cached images. This parameter forces the kubelet to re-authenticate with the container registry before it deploys a pod, ensuring that the requesting namespace has valid access rights to the image.
++
+The underlying `KubeletEnsureSecretPulledImages` feature gate is enabled by default. Administrators can configure specific credential provider policies to balance security and stability:
++
+* `AlwaysVerify`: Enforces credential checks for all image pull requests.
+* `NeverVerifyAllowlistedImages`: Enforces credential checks for user workloads while exempting essential infrastructure images on an allowlist.
++
+Before this release, multi-tenant {product-title} clusters had a security vulnerability where the kubelet did not re-verify credentials for cached images. If one tenant pulled a private image, another tenant could deploy a pod by using that same cache without providing image pull secrets. To mitigate this previously, administrators relied on unsupported configurations. However, these workarounds caused cluster instability, risked control plane failures during registry outages, and blocked crucial cluster upgrades.
++
+[NOTE]
+====
+Do not use the `NeverVerifyPreloadedImages` policy when the default `KubeletEnsureSecretPulledImages` feature gate is active, as the policy might not function as expected. Use the `NeverVerifyAllowlistedImages` policy instead.
+====
++
+For more information, see xref:../machine_configuration/machine-configs-custom.adoc#create-a-kubeletconfig-crd-to-edit-kubelet-parameters_machine-configs-custom[Creating a KubeletConfig CRD to edit kubelet parameters].
 
 [id="ocp-release-notes-operator-development_{context}"]
 == Operator development


### PR DESCRIPTION
Version(s):
4.22

Issue:
[OSDOCS-17295](https://redhat.atlassian.net/browse/OSDOCS-17295)

Link to docs preview:
https://111786--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-22-release-notes.html

QE review:
- [x] QE has approved this change.