### PR TITLE
OCPBUGS-85716: Updated the YAML in Adding a single NodePort service t…

### DIFF
--- a/modules/nw-ingress-controller-nodeportservice-projects.adoc
+++ b/modules/nw-ingress-controller-nodeportservice-projects.adoc
@@ -31,25 +31,23 @@ Before you set a `NodePort`-type `Service` for each project, read the following 
 .Example of a CR file that defines information for the `IngressController` object
 [source,yaml]
 ----
-apiVersion: v1
-items:
-- apiVersion: operator.openshift.io/v1
-  kind: IngressController
-  metadata:
-    name: <custom_ic_name>
-    namespace: openshift-ingress-operator
-  spec:
-    replicas: 1
-    domain: <custom_ic_domain_name>
-    nodePlacement:
-      nodeSelector:
-        matchLabels:
-          <key>: <value>
-    namespaceSelector:
-     matchLabels:
-       <key>: <value>
-    endpointPublishingStrategy:
-      type: NodePortService 
+apiVersion: operator.openshift.io/v1
+kind: IngressController
+metadata:
+  name: <custom_ic_name>
+  namespace: openshift-ingress-operator
+spec:
+  replicas: 1
+  domain: <custom_ic_domain_name>
+  nodePlacement:
+    nodeSelector:
+      matchLabels:
+        <key>: <value>
+  namespaceSelector:
+    matchLabels:
+      <key>: <value>
+  endpointPublishingStrategy:
+    type: NodePortService 
 # ...
 ----
 +


### PR DESCRIPTION
Version(s):
4.16+

Issue:
[OCPBUGS-85716](https://redhat.atlassian.net/browse/OCPBUGS-85716)

Link to docs preview:

* [Adding a single NodePort service to an Ingress Controller](https://111787--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ingress_load_balancing/configuring_ingress_cluster_traffic/nw-configuring-ingress-controller-endpoint-publishing-strategy.html#nw-ingress-controller-nodeportservice-projects_nw-configuring-ingress-controller-endpoint-publishing-strategy)

- [x] SME has approved this change (Chris Fields).
- [x] QE has approved this change (Melvin Joseph).
