### PR TITLE
OSDOCS-18784-5 added assembly/modules install ESO

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -1312,6 +1312,8 @@ Topics:
   Dir: external_secrets_operator
   Distros: openshift-enterprise
   Topics:
+  - Name: Installing the External Secrets Operator
+    File: external-secrets-operator-install
   - Name: Customizing the External Secrets Operator for Red Hat OpenShift
     File: external-secrets-log-levels
 - Name: Viewing audit logs

--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -1324,6 +1324,8 @@ Topics:
   Topics:
   - Name: External Secrets Operator release notes
     File: external-secrets-operator-release-notes
+  - Name: Installing the External Secrets Operator
+    File: external-secrets-operator-install
   - Name: Customizing the External Secrets Operator for Red Hat OpenShift
     File: external-secrets-log-levels
   - Name: Uninstalling the External Secrets Operator

--- a/modules/external-secrets-operand-install-cli.adoc
+++ b/modules/external-secrets-operand-install-cli.adoc
@@ -1,0 +1,101 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-operator-install.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="external-secrets-operand-install-cli_{context}"]
+= Installing the External Secrets operand by using the CLI
+
+[role="_abstract"]
+To install the External Secrets operand, create an instance of the `ExternalSecrets` custom resource by using the command-line interface (CLI) which deploys necessary operand components such as the core controller, webhook, and certificate controller into the `external-secrets` namespace.
+
+.Prerequisites
+
+* You have access to the cluster with `cluster-admin` privileges.
+
+.Procedure
+
+. Create an `externalsecretsconfig.openshift.operator.io` object by defining a YAML file with the following content:
++
+.Example `externalsecretsconfig.yaml` file.
++
+[source,yaml]
+----
+apiVersion: operator.openshift.io/v1alpha1
+kind: ExternalSecretsConfig
+metadata:
+  labels:
+    app: external-secrets-operator
+    app.kubernetes.io/name: cluster
+  name: cluster
+spec:
+  controllerConfig:
+    networkPolicies:
+    - componentName: ExternalSecretsCoreController
+      egress:
+      - {}
+      name: allow-external-secrets-egress
+----
++
+For more information on spec configuration, see "External Secrets Operator for Red Hat OpenShift APIs".
+
+. Create the `externalsecretsconfigs.openshift.operator.io` object by running the following command:
++
+[source,terminal]
+----
+$ oc create -f externalsecretsconfig.yaml
+----
+
+.Verification
+
+. Verify that the `external-secrets` pods are running by entering the following command:
++
+[source,terminal]
+----
+$ oc get pods -n external-secrets
+----
++
+.Example output
++
+[source,terminal]
+----
+NAME                                                READY   STATUS    RESTARTS   AGE
+external-secrets-75d47cb9c8-6p4n2                   1/1     Running   0          4h5m
+external-secrets-cert-controller-676444b897-qb6ft   1/1     Running   0          4h5m
+external-secrets-webhook-b566658ff-7m4d5            1/1     Running   0          4h5m
+----
+
+. Verify that the `external-secrets-operator` deployment object reports a successful status by running the following command:
++
+[source,terminal]
+----
+$ oc get externalsecretsconfig.operator.openshift.io cluster -n external-secrets-operator -o jsonpath='{.status.conditions}' | jq .
+----
++
+.Example output
++
+[source,terminal]
+----
+[
+  {
+    "lastTransitionTime": "2025-06-17T14:57:04Z",
+    "message": "",
+    "observedGeneration": 2,
+    "reason": "Ready",
+    "status": "False",
+    "type": "Degraded"
+  },
+  {
+    "lastTransitionTime": "2025-11-27T05:58:38Z,
+    "message": "reconciliation successful",
+    "observedGeneration": 2,
+    "reason": "Ready",
+    "status": "True",
+    "type": "Ready"
+  }
+]
+----
+
+.Next step
+
+* Configure the network policies of the operand as described in "Configuring network policy for the operand".

--- a/modules/external-secrets-operand-install-cli.adoc
+++ b/modules/external-secrets-operand-install-cli.adoc
@@ -1,0 +1,98 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-operator-install.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="external-secrets-operand-install-cli_{context}"]
+= Installing the External Secrets operand by using the CLI
+
+[role="_abstract"]
+To install the External Secrets operand, create an instance of the `ExternalSecrets` custom resource by using the command-line interface (CLI) which deploys necessary operand components such as the core controller, webhook, and certificate controller into the `external-secrets` namespace.
+
+.Prerequisites
+
+* You have access to the cluster with `cluster-admin` privileges.
+
+.Procedure
+
+. Create an `externalsecretsconfig.openshift.operator.io` object by defining a YAML file with the following content:
++
+.Example `externalsecretsconfig.yaml` file.
+[source,yaml]
+----
+apiVersion: operator.openshift.io/v1alpha1
+kind: ExternalSecretsConfig
+metadata:
+  labels:
+    app: external-secrets-operator
+    app.kubernetes.io/name: cluster
+  name: cluster
+spec:
+  controllerConfig:
+    networkPolicies:
+    - componentName: ExternalSecretsCoreController
+      egress:
+      - {}
+      name: allow-external-secrets-egress
+----
++
+For more information on spec configuration, see "{external-secrets-operator} APIs".
+
+. Create the `externalsecretsconfig.openshift.operator.io` object by running the following command:
++
+[source,terminal]
+----
+$ oc create -f externalsecretsconfig.yaml
+----
+
+.Verification
+
+. Verify that the `external-secrets` pods are running by entering the following command:
++
+[source,terminal]
+----
+$ oc get pods -n external-secrets
+----
++
+.Example output
+[source,terminal]
+----
+NAME                                                READY   STATUS    RESTARTS   AGE
+external-secrets-75d47cb9c8-6p4n2                   1/1     Running   0          4h5m
+external-secrets-cert-controller-676444b897-qb6ft   1/1     Running   0          4h5m
+external-secrets-webhook-b566658ff-7m4d5            1/1     Running   0          4h5m
+----
+
+. Verify that the `external-secrets-operator` deployment object reports a successful status by running the following command:
++
+[source,terminal]
+----
+$ oc get externalsecretsconfig.operator.openshift.io cluster -n external-secrets-operator -o jsonpath='{.status.conditions}' | jq .
+----
++
+.Example output
+[source,terminal]
+----
+[
+  {
+    "lastTransitionTime": "2025-06-17T14:57:04Z",
+    "message": "",
+    "observedGeneration": 2,
+    "reason": "Ready",
+    "status": "False",
+    "type": "Degraded"
+  },
+  {
+    "lastTransitionTime": "2025-11-27T05:58:38Z",
+    "message": "reconciliation successful",
+    "observedGeneration": 2,
+    "reason": "Ready",
+    "status": "True",
+    "type": "Ready"
+  }
+]
+----
+
+.Next step
+
+* Configure the network policies of the operand as described in "Configuring network policy for the operand".

--- a/modules/external-secrets-operator-install-cli.adoc
+++ b/modules/external-secrets-operator-install-cli.adoc
@@ -1,0 +1,117 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-operator-install.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="external-secrets-operator-install-cli_{context}"]
+= Installing the {external-secrets-operator} by using the CLI
+
+[role="_abstract"]
+You can install the {external-secrets-operator} by manually configuring the Operator Lifecycle Manager (OLM) resources using the OpenShift CLI. You can create a dedicated namespace, define the Operator's scope, and install the Operator from the catalog.
+
+.Prerequisites
+
+* You have access to the cluster with `cluster-admin` privileges.
+
+.Procedure
+
+. Create a new project named `external-secrets-operator` by running the following command:
++
+[source,terminal]
+----
+$ oc new-project external-secrets-operator
+----
+
+. Create an `OperatorGroup` object by defining a YAML file with the following content:
++
+[source,yaml]
+----
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: openshift-external-secrets-operator
+  namespace: external-secrets-operator
+spec:
+  targetNamespaces: []
+----
+
+. Create the `OperatorGroup` object by running the following command:
++
+[source,terminal]
+----
+$ oc create -f operatorGroup.yaml
+----
+
+. Create a `Subscription` object by defining a YAML file with the following content:
++
+The following is an example of a `subscription.yaml` file.
++
+[source,yaml]
+----
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: openshift-external-secrets-operator
+  namespace: external-secrets-operator
+spec:
+  channel: stable-v1
+  name: openshift-external-secrets-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+  installPlanApproval: Automatic
+  startingCSV: external-secrets-operator.v1.0.0
+----
+
+. Create the `Subscription` object by running the following command:
++
+[source,terminal]
+----
+$ oc create -f subscription.yaml
+----
+
+.Verification
+
+. Verify that the {olm} subscription is created by running the following command:
++
+[source,terminal]
+----
+$ oc get subscription -n external-secrets-operator
+----
++
+The following is example output verifying the {olm} subscription is created.
++
+[source,terminal]
+----
+NAME                                  PACKAGE                               SOURCE             CHANNEL
+openshift-external-secrets-operator   openshift-external-secrets-operator   redhat-operators   stable-v1
+----
+
+. Verify whether the Operator is successfully installed by running the following command:
++
+[source,terminal]
+----
+$ oc get csv -n external-secrets-operator
+----
++
+The following is example output verifying that the Operator is installed.
++
+[source,terminal]
+----
+NAME                               DISPLAY                                           VERSION   REPLACES   PHASE
+external-secrets-operator.v1.0.0   External Secrets Operator for Red Hat OpenShift   1.0.0                Succeeded
+----
+
+. Verify that the status of the {external-secrets-operator-short} is `Running` by entering the following command:
++
+[source,terminal]
+----
+$ oc get pods -n external-secrets-operator
+----
++
+The following is example output verifying the {external-secrets-operator-short} is `Running`.
++
+[source,terminal]
+----
+NAME                                                            READY   STATUS    RESTARTS   AGE
+external-secrets-operator-controller-manager-5699f4bc54-kbsmn   1/1     Running   0          25h
+----

--- a/modules/external-secrets-operator-install-cli.adoc
+++ b/modules/external-secrets-operator-install-cli.adoc
@@ -1,0 +1,113 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-operator-install.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="external-secrets-operator-install-cli_{context}"]
+= Installing the {external-secrets-operator} by using the CLI
+
+[role="_abstract"]
+You can install the {external-secrets-operator} by manually configuring the Operator Lifecycle Manager (OLM) resources using the {product-title} CLI. You can create a dedicated namespace, define the scope of the Operator, and install the Operator from the catalog.
+
+.Prerequisites
+
+* You have access to the cluster with `cluster-admin` privileges.
+
+.Procedure
+
+. Create a new project named `external-secrets-operator` by running the following command:
++
+[source,terminal]
+----
+$ oc new-project external-secrets-operator
+----
+
+. Create an `OperatorGroup` object by defining a YAML file with the following content:
++
+[source,yaml]
+----
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: openshift-external-secrets-operator
+  namespace: external-secrets-operator
+spec:
+  targetNamespaces: []
+----
+
+. Create the `OperatorGroup` object by running the following command:
++
+[source,terminal]
+----
+$ oc create -f operatorGroup.yaml
+----
+
+. Create a `Subscription` object by defining a YAML file with the following content:
++
+.Example `subscription.yaml` file
+[source,yaml]
+----
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: openshift-external-secrets-operator
+  namespace: external-secrets-operator
+spec:
+  channel: stable-v1
+  name: openshift-external-secrets-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+  installPlanApproval: Automatic
+  startingCSV: external-secrets-operator.v1.1.0
+----
+
+. Create the `Subscription` object by running the following command:
++
+[source,terminal]
+----
+$ oc create -f subscription.yaml
+----
+
+.Verification
+
+. Verify that the {olm} subscription is created by running the following command:
++
+[source,terminal]
+----
+$ oc get subscription -n external-secrets-operator
+----
++
+.Example output
+[source,terminal]
+----
+NAME                                  PACKAGE                               SOURCE             CHANNEL
+openshift-external-secrets-operator   openshift-external-secrets-operator   redhat-operators   stable-v1
+----
+
+. Verify whether the Operator is successfully installed by running the following command:
++
+[source,terminal]
+----
+$ oc get csv -n external-secrets-operator
+----
++
+.Example output
+[source,terminal]
+----
+NAME                               DISPLAY                                           VERSION   REPLACES   PHASE
+external-secrets-operator.v1.1.0   External Secrets Operator for Red Hat OpenShift   1.0.0                Succeeded
+----
+
+. Verify that the status of the {external-secrets-operator-short} is `Running` by entering the following command:
++
+[source,terminal]
+----
+$ oc get pods -n external-secrets-operator
+----
++
+.Example output
+[source,terminal]
+----
+NAME                                                            READY   STATUS    RESTARTS   AGE
+external-secrets-operator-controller-manager-5699f4bc54-kbsmn   1/1     Running   0          25h
+----

--- a/modules/external-secrets-operator-install-console.adoc
+++ b/modules/external-secrets-operator-install-console.adoc
@@ -1,0 +1,53 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-operator-install.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="external-secrets-operator-install-console_{context}"]
+= Installing the {external-secrets-operator} by using the web console
+
+[role="_abstract"]
+You can install the {external-secrets-operator} by using the {product-title} web console. You can select the desired update channel and approval strategy, and deploy the Operator into the recommended namespace without manually defining YAML resources.
+
+.Prerequisites
+
+* You have access to the cluster with `cluster-admin` privileges.
+* You have access to the {product-title} web console.
+
+.Procedure
+
+. Log in to the {product-title} web console.
+
+. Navigate to *Ecosystem* -> *Software Catalog*.
+
+. Enter *{external-secrets-operator-short}* in the search box.
+
+. Select the *{external-secrets-operator}* from the generated list and click *Install*.
+
+. On the *Install Operator* page:
+
+.. Update the *Update channel*, if necessary. The channel defaults to *stable-v1*, which installs the latest stable release of the {external-secrets-operator-short}.
+
+.. Select the version from *Version* drop-down list.
+
+.. Choose the *Installed Namespace* for the Operator.
++
+* To use the default Operator namespace, select the *Operator recommended Namespace* option.
++
+* To use the namespace that you created, select the *Select a Namespace* option, and then select the namespace from the drop-down list.
++
+* If the default `external-secrets-operator` namespace does not exist, it is created for you by the {olm-first}.
++
+.. Select an *Update approval* strategy.
++
+* The *Automatic* strategy enables {olm} to automatically update the Operator when a new version is available.
++
+* The *Manual* strategy requires a user with appropriate credentials to approve the Operator update.
+
+.. Click *Install*.
+
+.Verification
+
+. Navigate to *Ecosystem* -> *Installed Operators*.
+
+. Verify that *{external-secrets-operator-short}* is listed with a *Status* of *Succeeded* in the `external-secrets-operator` namespace.

--- a/modules/external-secrets-operator-install-console.adoc
+++ b/modules/external-secrets-operator-install-console.adoc
@@ -1,0 +1,53 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-operator-install.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="external-secrets-operator-install-console_{context}"]
+= Installing the {external-secrets-operator} by using the web console
+
+[role="_abstract"]
+You can install the {external-secrets-operator} by using the {product-title} web console. You can select the desired update channel and approval strategy, and deploy the Operator into the recommended namespace without manually defining YAML resources.
+
+.Prerequisites
+
+* You have access to the cluster with `cluster-admin` privileges.
+* You have access to the {product-title} web console.
+
+.Procedure
+
+. Log in to the {product-title} web console.
+
+. Navigate to *Ecosystem* -> *Software Catalog*.
+
+. Enter *{external-secrets-operator-short}* in the search box.
+
+. Select the *{external-secrets-operator}* from the generated list and click *Install*.
+
+. On the *Install Operator* page:
+
+.. Update the *Update channel*, if necessary. The channel defaults to *stable-v1*, which installs the latest stable release of the {external-secrets-operator-short}.
+
+.. Select the version from the *Version* drop-down list.
+
+.. Choose the *Installed Namespace* for the Operator.
++
+* To use the default Operator namespace, select the *Operator recommended Namespace* option.
++
+* To use the namespace that you created, select the *Select a Namespace* option, and then select the namespace from the drop-down list.
++
+* If the default `external-secrets-operator` namespace does not exist, it is created for you by the {olm-first}.
++
+.. Select an *Update approval* strategy.
++
+* The *Automatic* strategy enables {olm} to automatically update the Operator when a new version is available.
++
+* The *Manual* strategy requires a user with appropriate credentials to approve the Operator update.
+
+.. Click *Install*.
+
+.Verification
+
+. Navigate to *Ecosystem* -> *Installed Operators*.
+
+. Verify that *{external-secrets-operator-short}* is listed with a *Status* of *Succeeded* in the `external-secrets-operator` namespace.

--- a/modules/external-secrets-operator-limitations.adoc
+++ b/modules/external-secrets-operator-limitations.adoc
@@ -1,0 +1,17 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-operator-install.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="external-secrets-operator-limitations_{context}"]
+= Limitations of {external-secrets-operator}
+
+[role="_abstract"]
+There are specific operational constraints to consider when deploying or removing the {external-secrets-operator}, that might require manual intervention or strict dependency ordering.
+
+The following are the limitations of {external-secrets-operator} during the installation and uninstallation of the `external-secrets` application.
+
+* Uninstalling the {external-secrets-operator} does not delete the resources created for `external-secrets` application. you must clean up the resources manually.
+* When you add `cert-manager` Operator configurations in `externalsecrets.operator.openshift.io` object after creation, delete the `external-secrets-cert-controller` deployment resource manually to prevent degradation of the `external-secrets` application.
+* Enable the `BitwardenSecretManagerProvider` field in `externalsecrets.operator.openshift.io` object only when installed on OpenShift Cluster running on x86_64 and arm64 architectures .
+* Ensure `cert-manager` Operator is installed and operational before deploying the {external-secrets-operator} for seamless functioning. If you install the `cert-manager` Operator later, manually restart the `external-secrets-operator` pod to apply cert-manager configurations in `externalsecrets.operator.openshift.io` object.

--- a/modules/external-secrets-operator-limitations.adoc
+++ b/modules/external-secrets-operator-limitations.adoc
@@ -1,0 +1,17 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-operator-install.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="external-secrets-operator-limitations_{context}"]
+= Limitations of {external-secrets-operator}
+
+[role="_abstract"]
+There are specific operational constraints to consider when deploying or removing the {external-secrets-operator}, which might require manual intervention or strict dependency ordering.
+
+The following are the limitations of {external-secrets-operator} during the installation and uninstallation of the `external-secrets` application.
+
+* Uninstalling the {external-secrets-operator} does not delete the resources created for `external-secrets` application. You must clean up the resources manually.
+* When you add `cert-manager` Operator configurations in `externalsecrets.operator.openshift.io` object after creation, delete the `external-secrets-cert-controller` deployment resource manually to prevent degradation of the `external-secrets` application.
+* Enable the `BitwardenSecretManagerProvider` field in `externalsecrets.operator.openshift.io` object only when installed on OpenShift Cluster running on x86_64 and arm64 architectures.
+* Ensure that the `cert-manager` Operator is installed and operational before deploying the {external-secrets-operator} for seamless functioning. If you install the `cert-manager` Operator later, manually restart the `external-secrets-operator` pod to apply cert-manager configurations in `externalsecrets.operator.openshift.io` object.

--- a/modules/external-secrets-operator-stablev1-channel.adoc
+++ b/modules/external-secrets-operator-stablev1-channel.adoc
@@ -1,0 +1,21 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-operator-install.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="external-secrets-operator-stablev1-channel_{context}"]
+= About the {external-secrets-operator} stable-v1 channel
+
+[role="_abstract"]
+Select the `stable-v1` channel to install and update the latest release of the {external-secrets-operator}. By selecting this channel, you can use the most recent stable release for your Operator.
+
+[NOTE]
+====
+The `stable-v1` channel is the default and suggested channel while installing the {external-secrets-operator}.
+====
+
+The `stable-v1` channel offers the following update approval strategies:
+
+Automatic:: If you choose automatic updates for an installed {external-secrets-operator}, a new version of the {external-secrets-operator} is available in the `stable-v1` channel. The Operator Lifecycle Manager (OLM) automatically upgrades the running instance of your Operator without human intervention.
+
+Manual:: If you select manual updates, when a newer version of the {external-secrets-operator} is available, OLM creates an update request. As a cluster administrator, you must then manually approve that update request to have the {cert-manager-operator} updated to the new version.

--- a/modules/external-secrets-operator-stablev1-channel.adoc
+++ b/modules/external-secrets-operator-stablev1-channel.adoc
@@ -1,0 +1,21 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-operator-install.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="external-secrets-operator-stablev1-channel_{context}"]
+= About the {external-secrets-operator} stable-v1 channel
+
+[role="_abstract"]
+Select the `stable-v1` channel to install and update the latest release of the {external-secrets-operator}. By selecting this channel, you can use the most recent stable release for your Operator.
+
+[NOTE]
+====
+The `stable-v1` channel is the default and suggested channel while installing the {external-secrets-operator}.
+====
+
+The `stable-v1` channel offers the following update approval strategies:
+
+Automatic:: If you choose automatic updates for an installed {external-secrets-operator}, a new version of the {external-secrets-operator} is available in the `stable-v1` channel. The Operator Lifecycle Manager (OLM) automatically upgrades the running instance of your Operator without human intervention.
+
+Manual:: If you select manual updates, when a newer version of the {external-secrets-operator} is available, OLM creates an update request. As a cluster administrator, you must then manually approve that update request to have the {external-secrets-operator} updated to the new version.

--- a/modules/external-secrets-operator-stablev1-y-channel.adoc
+++ b/modules/external-secrets-operator-stablev1-y-channel.adoc
@@ -1,0 +1,18 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-operator-install.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="external-secrets-operator-stablev1-y-channel_{context}"]
+= About the {external-secrets-operator} stable-v1.y channel
+
+[role="_abstract"]
+Select the stable-v1 channel to install and update the latest release of the {external-secrets-operator}. By selecting this channel, you can use the latest stable release and allows you to choose between automatic and manual updates.
+
+The y-stream version of the {external-secrets-operator} installs updates from the `stable-v1.y` channels such as `stable-v1.0`, `stable-v1.1`, and `stable-v1.2`. Select the `stable-v1.y` channel if you want to use the y-stream version and stay updated to the z-stream version of the {external-secrets-operator}.
+
+The `stable-v1.y` channel offers the following update approval strategies:
+
+Automatic:: If you choose automatic updates for an installed {external-secrets-operator}, a new z-stream version of the {external-secrets-operator} is available in the `stable-v1.y` channel. OLM automatically upgrades the running instance of your Operator without human intervention.
+
+Manual:: If you select manual updates, when a newer version of the {external-secrets-operator} is available, OLM creates an update request. As a cluster administrator, you must then manually approve that update request to have the {external-secrets-operator} updated to the new version of the z-stream releases.

--- a/modules/external-secrets-operator-stablev1-y-channel.adoc
+++ b/modules/external-secrets-operator-stablev1-y-channel.adoc
@@ -1,0 +1,18 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-operator-install.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="external-secrets-operator-stablev1-y-channel_{context}"]
+= About the {external-secrets-operator} stable-v1.y channel
+
+[role="_abstract"]
+Select the `stable-v1.y` channel to install and update the latest release of the {external-secrets-operator}. By selecting this channel, you can use the latest stable release and allows you to choose between automatic and manual updates.
+
+The y-stream version of the {external-secrets-operator} installs updates from the `stable-v1.y` channels such as `stable-v1.0`, `stable-v1.1`, and `stable-v1.2`. Select the `stable-v1.y` channel if you want to use the y-stream version and stay updated to the z-stream version of the {external-secrets-operator}.
+
+The `stable-v1.y` channel offers the following update approval strategies:
+
+Automatic:: If you choose automatic updates for an installed {external-secrets-operator}, a new z-stream version of the {external-secrets-operator} is available in the `stable-v1.y` channel. OLM automatically upgrades the running instance of your Operator without human intervention.
+
+Manual:: If you select manual updates, when a newer version of the {external-secrets-operator} is available, OLM creates an update request. As a cluster administrator, you must then manually approve that update request to have the {external-secrets-operator} updated to the new version of the z-stream releases.

--- a/modules/external-secrets-operator-update-channels.adoc
+++ b/modules/external-secrets-operator-update-channels.adoc
@@ -1,0 +1,15 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-operator-install.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="external-secrets-operator-update-channels_{context}"]
+= Understanding update channels of the {external-secrets-operator}
+
+[role="_abstract"]
+Control the version of the {external-secrets-operator} in your cluster by selecting an update channel. By using this mechanism, you can declare a specific version track, ensuring your environment receives only the updates you require for stability.
+
+The {external-secrets-operator} offers the following update channels:
+
+* `stable-v1`
+* `stable-v1.y`

--- a/security/external_secrets_operator/external-secrets-operator-install.adoc
+++ b/security/external_secrets_operator/external-secrets-operator-install.adoc
@@ -1,0 +1,44 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="external-secrets-operator-install"]
+= Installing the External Secrets Operator for Red Hat OpenShift
+include::_attributes/common-attributes.adoc[]
+:context: external-secrets-operator-install
+
+toc::[]
+
+[role="_abstract"]
+The {external-secrets-operator} is not installed on the {product-title} by default. Install the {external-secrets-operator-short} by using either the web console or the command-line interface (CLI).
+
+//Limitations of application installation and uninstallation
+include::modules/external-secrets-operator-limitations.adoc[leveloffset=+1]
+
+//Installing the {external-secrets-operator} using the web console
+include::modules/external-secrets-operator-install-console.adoc[leveloffset=+1]
+
+//Installing using CLI
+include::modules/external-secrets-operator-install-cli.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+[id="external-secrets-operator-install_additional-resources"]
+== Additional resources
+
+* xref:../../operators/admin/olm-adding-operators-to-cluster.adoc#olm-adding-operators-to-a-cluster[Adding Operators to a cluster]
+
+//== Installing the external secrets operand using CLI
+include::modules/external-secrets-operand-install-cli.adoc[leveloffset=+1]
+
+//== updating external secrets channels
+include::modules/external-secrets-operator-update-channels.adoc[leveloffset=+1]
+
+//== updating external secrets stable v1 channels
+include::modules/external-secrets-operator-stablev1-channel.adoc[leveloffset=+2]
+
+//== updating external secrets stable v1.y channels
+include::modules/external-secrets-operator-stablev1-y-channel.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+[id="external-secrets-operator-update-channels_additional-resources"]
+== Additional resources
+
+* xref:../../operators/admin/olm-adding-operators-to-cluster.adoc#olm-adding-operators-to-a-cluster[Adding Operators to a cluster]
+* xref:../../operators/admin/olm-upgrading-operators.adoc#olm-upgrading-operators[Updating installed Operators]

--- a/security/external_secrets_operator/external-secrets-operator-install.adoc
+++ b/security/external_secrets_operator/external-secrets-operator-install.adoc
@@ -1,0 +1,38 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="external-secrets-operator-install"]
+= Installing the External Secrets Operator for Red Hat OpenShift
+include::_attributes/common-attributes.adoc[]
+:context: external-secrets-operator-install
+
+toc::[]
+
+[role="_abstract"]
+The {external-secrets-operator} is not installed on the {product-title} by default. Install the {external-secrets-operator-short} by using either the web console or the command-line interface (CLI).
+
+//Limitations of application installation and uninstallation
+include::modules/external-secrets-operator-limitations.adoc[leveloffset=+1]
+
+//Installing the {external-secrets-operator} using the web console
+include::modules/external-secrets-operator-install-console.adoc[leveloffset=+1]
+
+//Installing using CLI
+include::modules/external-secrets-operator-install-cli.adoc[leveloffset=+1]
+
+//== Installing the external secrets operand using CLI
+include::modules/external-secrets-operand-install-cli.adoc[leveloffset=+1]
+
+//== updating external secrets channels
+include::modules/external-secrets-operator-update-channels.adoc[leveloffset=+1]
+
+//== updating external secrets stable v1 channels
+include::modules/external-secrets-operator-stablev1-channel.adoc[leveloffset=+2]
+
+//== updating external secrets stable v1.y channels
+include::modules/external-secrets-operator-stablev1-y-channel.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+[id="external-secrets-operator-install_additional-resources"]
+== Additional resources
+
+* xref:../../operators/admin/olm-adding-operators-to-cluster.adoc#olm-adding-operators-to-a-cluster[Adding Operators to a cluster]
+* xref:../../operators/admin/olm-upgrading-operators.adoc#olm-upgrading-operators[Updating installed Operators]


### PR DESCRIPTION
Version(s):
4.18

Issue:
https://redhat.atlassian.net/browse/OSDOCS-18784

Link to docs preview:
https://111824--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/external_secrets_operator/external-secrets-operator-install.html


QE review:
- [ ] QE has approved this change.


Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
