### PR TITLE
DOCPLAN-368: Add [role="_abstract"] attributes to virt documentation

### DIFF
--- a/virt/release_notes/virt-4-11-release-notes.adoc
+++ b/virt/release_notes/virt-4-11-release-notes.adoc
@@ -1,10 +1,12 @@
-:_content-type: ASSEMBLY
+:_mod-docs-content-type: ASSEMBLY
+include::_attributes/common-attributes.adoc[]
 [id="virt-4-11-release-notes"]
 = {VirtProductName} release notes
-include::_attributes/common-attributes.adoc[]
 :context: virt-4-11-release-notes
+
 toc::[]
 
+[role="_abstract"]
 Do not add or edit release notes here. Edit release notes directly in the branch
 that they are relevant for.
 

--- a/virt/release_notes/virt-4-12-release-notes.adoc
+++ b/virt/release_notes/virt-4-12-release-notes.adoc
@@ -1,10 +1,12 @@
-:_content-type: ASSEMBLY
+:_mod-docs-content-type: ASSEMBLY
+include::_attributes/common-attributes.adoc[]
 [id="virt-4-12-release-notes"]
 = {VirtProductName} release notes
-include::_attributes/common-attributes.adoc[]
 :context: virt-4-12-release-notes
+
 toc::[]
 
+[role="_abstract"]
 Do not add or edit release notes here. Edit release notes directly in the branch
 that they are relevant for.
 

--- a/virt/release_notes/virt-4-13-release-notes.adoc
+++ b/virt/release_notes/virt-4-13-release-notes.adoc
@@ -1,10 +1,12 @@
-:_content-type: ASSEMBLY
+:_mod-docs-content-type: ASSEMBLY
+include::_attributes/common-attributes.adoc[]
 [id="virt-4-13-release-notes"]
 = {VirtProductName} release notes
-include::_attributes/common-attributes.adoc[]
 :context: virt-4-13-release-notes
+
 toc::[]
 
+[role="_abstract"]
 Do not add or edit release notes here. Edit release notes directly in the branch
 that they are relevant for.
 

--- a/virt/release_notes/virt-4-14-release-notes.adoc
+++ b/virt/release_notes/virt-4-14-release-notes.adoc
@@ -1,10 +1,12 @@
-:_content-type: ASSEMBLY
+:_mod-docs-content-type: ASSEMBLY
+include::_attributes/common-attributes.adoc[]
 [id="virt-4-14-release-notes"]
 = {VirtProductName} release notes
-include::_attributes/common-attributes.adoc[]
 :context: virt-4-14-release-notes
+
 toc::[]
 
+[role="_abstract"]
 Do not add or edit release notes here. Edit release notes directly in the branch
 that they are relevant for.
 

--- a/virt/release_notes/virt-4-15-release-notes.adoc
+++ b/virt/release_notes/virt-4-15-release-notes.adoc
@@ -1,10 +1,12 @@
-:_content-type: ASSEMBLY
+:_mod-docs-content-type: ASSEMBLY
+include::_attributes/common-attributes.adoc[]
 [id="virt-4-15-release-notes"]
 = {VirtProductName} release notes
-include::_attributes/common-attributes.adoc[]
 :context: virt-4-15-release-notes
+
 toc::[]
 
+[role="_abstract"]
 Do not add or edit release notes here. Edit release notes directly in the branch
 that they are relevant for.
 

--- a/virt/release_notes/virt-4-16-release-notes.adoc
+++ b/virt/release_notes/virt-4-16-release-notes.adoc
@@ -1,10 +1,12 @@
-:_content-type: ASSEMBLY
+:_mod-docs-content-type: ASSEMBLY
+include::_attributes/common-attributes.adoc[]
 [id="virt-4-16-release-notes"]
 = {VirtProductName} release notes
-include::_attributes/common-attributes.adoc[]
 :context: virt-4-16-release-notes
+
 toc::[]
 
+[role="_abstract"]
 Do not add or edit release notes here. Edit release notes directly in the branch
 that they are relevant for.
 


### PR DESCRIPTION
## Summary
Add `[role="_abstract"]` attributes to fix AsciiDocDITA.ShortDescription warnings in virt release notes files.

## Changes
- Modified 6 files: Added `[role="_abstract"]` attribute to virt release notes files (4.11-4.16)
- Only adds abstracts to paragraphs immediately following the main document title, not section headings

## Files Modified
- `virt/release_notes/virt-4-11-release-notes.adoc`
- `virt/release_notes/virt-4-12-release-notes.adoc`
- `virt/release_notes/virt-4-13-release-notes.adoc`
- `virt/release_notes/virt-4-14-release-notes.adoc`
- `virt/release_notes/virt-4-15-release-notes.adoc`
- `virt/release_notes/virt-4-16-release-notes.adoc`

Branch: main