### PR TITLE
OSDOCS#19824: Update the MicroShift RNs for 4.21.16

### DIFF
--- a/microshift_release_notes/microshift-4-21-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-21-release-notes.adoc
@@ -23,6 +23,8 @@ include::modules/microshift-4-21-additional-release-notes.adoc[leveloffset=+1]
 
 include::modules/microshift-4-21-asynch-updates.adoc[leveloffset=+1]
 
+include::modules/microshift-4-21-16-async.adoc[leveloffset=+2]
+
 include::modules/microshift-4-21-11-async.adoc[leveloffset=+2]
 
 include::modules/microshift-4-21-7-async.adoc[leveloffset=+2]

--- a/modules/microshift-4-21-16-async.adoc
+++ b/modules/microshift-4-21-16-async.adoc
@@ -1,0 +1,23 @@
+// Module included in the following assemblies:
+//
+//microshift_release_notes/microshift-4-21-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="microshift-4-21-16-async_{context}"]
+= RHBA-2026:18007 - {microshift-short} 4.21.16 fixed issue update
+
+Issued: 19 May 2026
+
+[role="_abstract"]
+{product-title} release 4.21.16 is now available. Fixed issues are listed in the link:https://access.redhat.com/errata/RHBA-2026:18007[RHBA-2026:18007] advisory. The images that are included in the update are provided by the {OCP} link:https://access.redhat.com/errata/RHSA-2026:17474[RHSA-2026:17474] advisory.
+
+See the latest images included with {microshift-short} by using the following instructions:
+
+* xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[Listing the contents of the {microshift-short} RPM release package]
+* xref:../microshift_install_bootc/microshift-install-bootc-image.adoc#microshift-install-bootc-get-published-image_microshift-install-rhel-bootc-image[Getting the published bootc image for MicroShift]
+
+[id="microshift-4-21-16-fixed-issues_{context}"]
+== Fixed issues
+
+There are no notable fixed issues in this release.
+


### PR DESCRIPTION
Version(s):
4.21

Issue:
[OSDOCS-19824](https://redhat.atlassian.net/browse/OSDOCS-19824)

Link to docs preview:
[4.21.16](https://111842--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-21-release-notes.html#microshift-4-21-16-async_release-notes)

QE review:
- [ ] QE has approved this change.
N/A for z-stream RNs

Additional information:
Shipment [MR](https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/537/diffs)
ART [Dashboard](https://art-dash.engineering.redhat.com/dashboard/release/openshift-4.21)
