### PR TITLE
OBSDOCS-3363: Log forwarding configuration improvements (6.4 backport)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,12 @@ commercial_package
 .vale/styles/RedHat
 dita/
 vale.log
+.claude/
+.vale/styles/AsciiDocDITA/IntrinsicAttribute.yml
+LOGGING_DOCS_RESTRUCTURE_PLAN.md
+LOGGING_DOCS_SUMMARY.md
+JIRA_HOTSPOTS.md
+OBSDOCS-*_PLAN.md
+jira-token
+pull-jira-backlog.sh
+.jira-backlog/

--- a/configuring/configuring-log-forwarding.adoc
+++ b/configuring/configuring-log-forwarding.adoc
@@ -94,6 +94,8 @@ include::modules/troubleshooting-log-collection.adoc[leveloffset=+1]
 [id="forwarding-to-third-party-destinations_{context}"]
 == Forwarding to third-party destinations
 
+include::modules/logging-external-destination-compatibility.adoc[leveloffset=+2]
+
 include::modules/cluster-logging-collector-log-forwarding-about.adoc[leveloffset=+2]
 
 include::modules/cluster-logging-collector-log-forward-gcp.adoc[leveloffset=+2]
@@ -145,3 +147,8 @@ include::modules/configuring-aws-iam-for-cross-account-access.adoc[leveloffset=+
 include::modules/example-clusterlogforwarder-configuration-for-cross-account-forwarding.adoc[leveloffset=+3]
 
 include::modules/cross-account-log-forwarding-troubleshooting.adoc[leveloffset=+3]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../configuring/opentelemetry-data-model.adoc#opentelemetry-data-model[OpenTelemetry data model]

--- a/modules/clf-outputs-reference.adoc
+++ b/modules/clf-outputs-reference.adoc
@@ -43,7 +43,14 @@ The following fields are required as default stream labels for LokiStack and can
 If these fields are not present in the log record, they will be set to the empty string.
 ====
 
-`otlp`:: Forwards logs by using the OpenTelemetry Protocol (OTLP) with {product-title} semantic conventions. This output sends logs in OTLP format over HTTP or HTTPS, compatible with OpenTelemetry collectors and observability backends that support OTLP ingestion.
+`otlp`:: Forwards logs by using the OpenTelemetry Protocol (OTLP) with {product-title} semantic conventions. This output sends logs in OTLP format over HTTP or HTTPS to OpenTelemetry collectors and observability backends that support OTLP ingestion.
++
+**Use case**: Platform teams can forward logs to any observability platform that supports the OTLP protocol. Organizations can also use OpenTelemetry Collector as a central gateway to aggregate logs from multiple clusters before routing to final destinations. This approach provides vendor-neutral log forwarding and simplified multi-destination routing.
++
+[NOTE]
+====
+The `otlp` output uses the OpenTelemetry data model, which differs from the ViaQ data model used by other output types. Field names and structure vary between these models.
+====
 
 `s3`:: Forwards logs to Amazon S3 or S3-compatible object storage. This output supports the same authentication methods as CloudWatch (AWS access keys or IAM roles). You must specify the AWS region, bucket name, and key prefix pattern for organizing log objects. Use this output for long-term archival, compliance retention, or integration with data lake pipelines.
 +

--- a/modules/configuring-otlp-output.adoc
+++ b/modules/configuring-otlp-output.adoc
@@ -61,6 +61,30 @@ spec:
 The OTLP output uses the OpenTelemetry data model, which is different from the ViaQ data model that is used by other output types. For more information, see OpenTelemetry Semantic Conventions.
 ====
 
+. Apply the `ClusterLogForwarder` custom resource:
++
+[source,terminal]
+----
+$ oc apply -f <filename>.yaml
+----
+
+.Verification
+
+. Verify that the `ClusterLogForwarder` status shows `Ready`:
++
+[source,terminal]
+----
+$ oc get clusterlogforwarder clf-otlp -n openshift-logging \
+  -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}'
+----
++
+The output should show `True`.
+
+. Verify that OTLP is functioning correctly by checking the LokiStack metrics dashboard:
+.. In the {ocp-product-title} web console, navigate to *Observe* -> *Dashboards*.
+.. From the *Dashboard* dropdown, select *OpenShift Logging / LokiStack / Writes*.
+.. Check the *Distributor - structured metadata* panel for incoming OTLP log records.
+
 [role="_additional-resources"]
 .Additional resources
 

--- a/modules/logging-external-destination-compatibility.adoc
+++ b/modules/logging-external-destination-compatibility.adoc
@@ -1,0 +1,95 @@
+// Module included in the following assemblies:
+//
+// * configuring/configuring-log-forwarding.adoc
+
+:_mod-docs-content-type: REFERENCE
+
+[id="logging-external-destination-compatibility_{context}"]
+= External log forwarding destination compatibility
+
+[role="_abstract"]
+The following table lists external log forwarding destinations tested and validated with {product-title}.
+
+.Tested and validated external log forwarding destinations
+[cols="4",options="header"]
+|===
+|Output type
+|Protocol
+|Tested versions
+|Logging versions
+
+|Elasticsearch v6
+|HTTP 1.1
+|6.8.1
+|6.0+
+
+|Elasticsearch v7
+|HTTP 1.1
+|7.12.2
+|6.0+
+
+|Elasticsearch v8
+|HTTP 1.1
+|8.6.1
+|6.0+
+
+|Elasticsearch v9
+|HTTP 1.1
+|9.3.3
+|6.0+
+
+|Google Cloud Logging
+|REST over HTTPS
+|Latest
+|6.0+
+
+|HTTP (Generic)
+|HTTP 1.1
+|Vector 0.28-1, 0.34-1
+|6.0+
+
+|Kafka
+|Kafka 0.11
+|2.4.1, 2.7.0
+|6.0+
+
+|Loki (External)
+|REST over HTTP/HTTPS
+|2.3.0
+|6.0+
+
+|OTLP
+|HTTP/HTTPS
+|OpenTelemetry Collector 0.88+
+|6.1+
+
+|Splunk
+|HEC
+|9.0.0
+|6.0+
+
+|Syslog
+|RFC3164, RFC5424
+|rsyslog 8.39.0
+|6.0+
+
+|Amazon CloudWatch
+|REST over HTTPS
+|Latest
+|6.0+
+
+|Amazon S3
+|REST over HTTPS
+|Latest
+|6.0+
+
+|Azure Monitor Logs
+|REST over HTTPS
+|Latest
+|6.0+
+|===
+
+[NOTE]
+====
+This table lists versions that Red Hat has tested. Other versions might work but Red Hat has not validated them. For {product-title} managed destinations (LokiStack), version compatibility is managed automatically.
+====


### PR DESCRIPTION
Cherry-pick of #111162 to standalone-logging-docs-6.4.

## Changes
- Added `.gitignore` entries
- Updated log forwarding configuration documentation
- Added external destination compatibility reference
- Updated CLF outputs reference
- Updated OTLP output configuration (preserved tech preview status for 6.4)

## Conflict Resolution
- Preserved the technology preview snippet for OTLP in 6.4 (OTLP is not yet GA in this version)

This PR contains a single squashed commit as required.