### PR TITLE
[service-mesh-docs-3.3] Nftables support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,9 @@ artifacts/
 modules/ossm-migrate-to-nftables-rhel10-ambient.adoc
 modules/ossm-migrate-to-nftables-rhel10-sidecar.adoc
 update/ossm-preparing-for-rhel-10-migration.adoc
+migrating/JIRA-9894-dns-capture-documentation-plan.md
+migrating/modules/ossm-migrating-a-multitenant-deployment.html
+artifacts/
+update/ossm-preparing-for-rhel-10-migration.adoc
+modules/ossm-migrate-to-nftables-rhel10-ambient.adoc
+modules/ossm-migrate-to-nftables-rhel10-sidecar.adoc

--- a/install/ossm-installing-openshift-service-mesh.adoc
+++ b/install/ossm-installing-openshift-service-mesh.adoc
@@ -4,6 +4,12 @@
 include::_attributes/common-attributes.adoc[]
 :context: ossm-installing-openshift-service-mesh
 
+include::_attributes/attributes-microshift.adoc[]
+:context: ossm-installing-openshift-service-mesh
+
+include::_attributes/attributes-openshift-dedicated.adoc[]
+:context: ossm-installing-openshift-service-mesh
+
 toc::[]
 
 [role="_abstract"]

--- a/install/ossm-istio-ambient-mode.adoc
+++ b/install/ossm-istio-ambient-mode.adoc
@@ -4,6 +4,12 @@
 include::_attributes/common-attributes.adoc[]
 :context: ossm-istio-ambient-mode
 
+include::_attributes/attributes-microshift.adoc[]
+:context: ossm-istio-ambient-mode
+
+include::_attributes/attributes-openshift-dedicated.adoc[]
+:context: ossm-istio-ambient-mode
+
 toc::[]
 
 [role="_abstract"]

--- a/modules/ossm-creating-istio-resource-using-console.adoc
+++ b/modules/ossm-creating-istio-resource-using-console.adoc
@@ -7,8 +7,7 @@
 = Creating the Istio resource using the web console
 
 [role="_abstract"]
-
-Create the {istio} resource that will contain the YAML configuration file for your {istio} deployment. The {SMProductName} Operator uses information in the YAML file to create an instance of the {istio} control plane.
+Create the {istio} resource to define the YAML configuration for your {istio} deployment. The {SMProductName} Operator uses information in the YAML file to create an instance of the {istio} control plane.
 
 .Prerequisites
 
@@ -29,6 +28,23 @@ Create the {istio} resource that will contain the YAML configuration file for yo
 . Click *Create Istio*.
 
 . Select the `istio-system` project from the *Namespace* drop-down menu.
+
+. Click *YAML* to view the configuration.
+
+. If your cluster includes {op-system-base-full} 10 or {op-system-first} 10 nodes, you must enable native `nftables` support. In the YAML configuration, set the `nativeNftables` field to `true` within the `spec.values.global` section, as shown in the following example: 
++
+[source,yaml]
+----
+apiVersion: sailoperator.io/v1
+kind: Istio
+metadata:
+  name: default
+spec:
+  namespace: istio-system
+  values:
+    global:
+      nativeNftables: true
+----
 
 . Click *Create*. This action deploys the {istio} control plane.
 +

--- a/modules/ossm-creating-istiocni-resource-using-console.adoc
+++ b/modules/ossm-creating-istiocni-resource-using-console.adoc
@@ -7,7 +7,6 @@
 = Creating the IstioCNI resource using the web console
 
 [role="_abstract"]
-
 Create an {istio} Container Network Interface (CNI) resource, which has the configuration file for the Istio CNI plugin. The {SMProductShortName} Operator uses the configuration specified by this resource to deploy the CNI pod.
 
 .Prerequisites
@@ -29,6 +28,23 @@ Create an {istio} Container Network Interface (CNI) resource, which has the conf
 . Click *Create IstioCNI*.
 
 . Ensure that the name is `default`.
+
+. Click *YAML* to view the configuration.
+
+. If your cluster includes {op-system-base-full} 10 or {op-system-first} 10 nodes, you must enable native `nftables` support. In the YAML configuration, set the `nativeNftables` field to `true` within the `spec.values.global` section, as shown in the following example: 
++
+[source,yaml]
+----
+apiVersion: sailoperator.io/v1
+kind: IstioCNI
+metadata:
+  name: default
+spec:
+  namespace: istio-cni
+  values:
+    global:
+      nativeNftables: true
+----
 
 . Click *Create*. This action deploys the Istio CNI plugin.
 +

--- a/modules/ossm-installing-istio-ambient-mode.adoc
+++ b/modules/ossm-installing-istio-ambient-mode.adoc
@@ -35,6 +35,11 @@ $ oc create namespace istio-system
 +
 You can see the following example configuration for reference:
 +
+[NOTE]
+====
+If your cluster includes {op-system-base-full} 10 or {op-system-first} 10 nodes, you must enable native `nftables` support by setting the `nativeNftables` field to `true` within the `spec.values.global` section.
+====
++
 [source,yaml]
 ----
 apiVersion: sailoperator.io/v1
@@ -45,6 +50,8 @@ spec:
   namespace: istio-system
   profile: ambient
   values:
+    global:
+      nativeNftables: true  # Add this line if deploying on RHEL 10 or RHCOS 10 nodes
     pilot:
       trustedZtunnelNamespace: ztunnel
 ----
@@ -81,6 +88,11 @@ $ oc create namespace istio-cni
 +
 You can see the following example configuration for reference:
 +
+[NOTE]
+====
+If your cluster includes {op-system-base-full} 10 or {op-system-first} 10 nodes, you must enable native `nftables` support by setting the `nativeNftables` field to `true` within the `spec.values.global` section.
+====
++
 [source,yaml]
 ----
 apiVersion: sailoperator.io/v1
@@ -90,6 +102,9 @@ metadata:
 spec:
   namespace: istio-cni
   profile: ambient
+  values:
+    global:
+      nativeNftables: true  # Add this line if deploying on RHEL 10 or RHCOS 10 nodes
 ----
 +
 Set the `profile` field to `ambient`.

--- a/modules/ossm-nftables-migration-ambient.adoc
+++ b/modules/ossm-nftables-migration-ambient.adoc
@@ -1,0 +1,27 @@
+// Module included in the following assemblies:
+//
+// update/ossm-updating-openshift-service-mesh-in-ambient-mode.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="ossm-nftables-migration-ambient_{context}"]
+= Nftables migration in ambient mode
+
+[role="_abstract"]
+When you enable support for the `nftables` network backend, which is required for clusters that use {op-system-base-full} 10 nodes, the {istio} CNI initialization process manages existing networking artifacts. In ambient mode, existing `iptables` rules on the host determine the migration behavior.
+
+== Enabling `nftables` support
+To enable `nftables` support, set the `spec.values.global.nativeNftables` field to `true` in both the `{istio}` and `IstioCNI` resources. This configuration is compatible with earlier versions of {op-system-base-full} and allows for mixed-version clusters during migration.
+
+== How {SMProductShortName} initializes with `nftables` enabled
+The {istio} CNI agent checks for existing `iptables` artifacts on the host during startup. The result of this check determines the networking backend configuration based on environment:
+
+* **Clean environments:** On nodes with no existing `iptables` artifacts, such as new {op-system-base-full} 10 hosts, the CNI agent automatically uses the `nftables` backend.
+* **Existing environments:** On nodes where `iptables` was active, the CNI agent might detect existing artifacts. To prevent networking conflicts, the agent overrides the `nftables` setting and continues to use the `iptables` backend.
+
+== Final migration step for existing nodes
+To migrate existing nodes from `iptables` to `nftables`, reboot the nodes to ensure a clean networking state. 
+
+[NOTE]
+====
+If the CNI agent detects existing artifacts and reverts to `iptables`, it logs a message indicating that a node reboot is required to complete the migration to the `nftables` backend.
+====

--- a/modules/ossm-release-notes-istio-deployment-lifecycle.adoc
+++ b/modules/ossm-release-notes-istio-deployment-lifecycle.adoc
@@ -51,9 +51,14 @@
 
 | ProxyConfig
 | GA ^[3]^
+
+|Native `nftables` support
+|GA ^[5]^
+
 |===
 
 . For more information, see "Support for Istioctl".
 . Installation is only supported by using the {SMProduct} 3 Operator, which uses the Istio Helm chart values for managing configuration.
 . The `ProxyConfig` API is supported with the exception of the image field, which is not supported.
 . Dual-Stack IPv4/IPv6 is supported on x86 environments only. On non-x86 environments, this feature remains a Technology Preview.
+. To deploy {SMProduct} on nodes running {op-system-base-full} 10 or {op-system-first} 10, you must enable native `nftables` support. In the {istio} resource, set the `spec.values.global.nativeNftables` parameter to `true`.

--- a/ossm-release-notes/ossm-release-notes-feature-support-tables.adoc
+++ b/ossm-release-notes/ossm-release-notes-feature-support-tables.adoc
@@ -5,6 +5,12 @@
 include::_attributes/common-attributes.adoc[]
 :context: ossm-release-notes-support-tables
 
+include::_attributes/attributes-microshift.adoc[]
+:context: ossm-release-notes-support-tables
+
+include::_attributes/attributes-openshift-dedicated.adoc[]
+:context: ossm-release-notes-support-tables
+
 toc::[]
 
 [role="_abstract"]

--- a/update/ossm-updating-openshift-service-mesh-in-ambient-mode.adoc
+++ b/update/ossm-updating-openshift-service-mesh-in-ambient-mode.adoc
@@ -4,6 +4,12 @@
 include::_attributes/common-attributes.adoc[]
 :context: ossm-updating-openshift-service-mesh-in-ambient-mode
 
+include::_attributes/attributes-microshift.adoc[]
+:context: ossm-updating-openshift-service-mesh-in-ambient-mode
+
+include::_attributes/attributes-openshift-dedicated.adoc[]
+:context: ossm-updating-openshift-service-mesh-in-ambient-mode
+
 toc::[]
 
 [role="_abstract"]
@@ -11,6 +17,8 @@ toc::[]
 Update {SMProductName} in ambient mode by transitioning the control plane and waypoint proxies to new revisions while maintaining Layer 7 (L7) functionality and resource compatibility.
 
 include::modules/ossm-about-update-strategies-in-ambient-mode.adoc[leveloffset=+1]
+
+include::modules/ossm-nftables-migration-ambient.adoc[leveloffset=+1]
 
 include::modules/ossm-updating-waypoint-proxies-with-inplace-strategy.adoc[leveloffset=+1]
 


### PR DESCRIPTION
Cherry Picked from e8934df318fd53225ca93d9d48b407ecd2bdc914 xref: https://github.com/openshift/openshift-docs/pull/111267


This commit includes the following changes:
- Add nftables support note to Istio deployment and lifecycle table
- Add nftables enablement steps to Creating Istio and IstioCNI resource procedures
- Add nftables configuration to ambient installation guide
- Create migration guide module for nftables in ambient mode
- Add migration documentation to Updating guide
- Include attribute files in assemblies for proper variable rendering
- Add attribute includes to feature support table assembly
- Minor edits for clarity

[OSSM-13620](https://redhat.atlassian.net/browse/OSSM-13620): Support Native nftables in Istio (RHEL 10)
https://redhat.atlassian.net/browse/OSSM-13620

Version(s):
service-mesh-docs-3.3