### PR TITLE
OSDOCS-18784-6 create assembly/modules for confg net policy

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -1312,6 +1312,8 @@ Topics:
   Dir: external_secrets_operator
   Distros: openshift-enterprise
   Topics:
+  - Name: Configuring Network Policy for the Operand
+    File: external-secrets-operator-config-net-policy
   - Name: Customizing the External Secrets Operator for Red Hat OpenShift
     File: external-secrets-log-levels
 - Name: Viewing audit logs

--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -1322,6 +1322,8 @@ Topics:
   Dir: external_secrets_operator
   Distros: openshift-enterprise
   Topics:
+  - Name: Configuring Network Policy for the Operand
+    File: external-secrets-operator-config-net-policy
   - Name: Customizing the External Secrets Operator for Red Hat OpenShift
     File: external-secrets-log-levels
 - Name: Viewing audit logs

--- a/modules/external-secrets-operator-egress-allow-all-traffic.adoc
+++ b/modules/external-secrets-operator-egress-allow-all-traffic.adoc
@@ -1,0 +1,41 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-operator-install.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="external-secrets-operator-egress-allow-all-traffic_{context}"]
+= Adding a custom network policy to allow egress to all external providers
+
+[role="_abstract"]
+You must configure custom policies through the `ExternalSecretsConfig` custom resource to allow all egress to all external providers.
+
+.Prerequisites
+
+* An `ExternalSecretsConfig` must be predefined.
+
+* You must be able to define specific egress rules, including destination ports and protocols.
+
+.Procedure
+
+. Edit the `ExternalSecretsConfig` CR by running the following command:
++
+[source,terminal]
+----
+$ oc edit externalsecretsconfigs.operator.openshift.io cluster
+----
+
+. Set the policy by editing the `networkPolicies` section:
++
+[source,yaml]
+----
+apiVersion: operator.openshift.io/v1alpha1
+kind: ExternalSecretsConfig
+metadata:
+  name: cluster
+spec:
+  controllerConfig:
+    networkPolicies:
+      - name: allow-external-secrets-egress
+        componentName: CoreController
+        egress: # Allow all egress traffic
+----

--- a/modules/external-secrets-operator-egress-allow-all-traffic.adoc
+++ b/modules/external-secrets-operator-egress-allow-all-traffic.adoc
@@ -1,0 +1,40 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-operator-config-net-policy.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="external-secrets-operator-egress-allow-all-traffic_{context}"]
+= Adding a custom network policy to allow egress to all external providers
+
+[role="_abstract"]
+You must configure custom policies through the `ExternalSecretsConfig` custom resource (CR) to allow all egress to all external providers.
+
+.Prerequisites
+
+* An `ExternalSecretsConfig` must be predefined.
+
+.Procedure
+
+. Edit the `ExternalSecretsConfig` CR by running the following command:
++
+[source,terminal]
+----
+$ oc edit externalsecretsconfigs.operator.openshift.io cluster
+----
+
+. Set the policy by editing the `networkPolicies` section:
++
+[source,yaml]
+----
+apiVersion: operator.openshift.io/v1alpha1
+kind: ExternalSecretsConfig
+metadata:
+  name: cluster
+spec:
+  controllerConfig:
+    networkPolicies:
+      - name: allow-external-secrets-egress
+        componentName: CoreController
+        egress:
+        - {}
+----

--- a/modules/external-secrets-operator-egress-specific-provider.adoc
+++ b/modules/external-secrets-operator-egress-specific-provider.adoc
@@ -1,0 +1,49 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-operator-install.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="external-secrets-operator-egress-specific-provider_{context}"]
+= Adding a custom network policy to allow egress to a specific provider
+
+[role="_abstract"]
+You must configure custom policies through the `ExternalSecretsConfig` custom resource to allow all egress to a specific provider.
+
+.Prerequisites
+
+* An `ExternalSecretsConfig` must be predefined.
+
+* You must be able to define specific egress rules, including destination ports and protocols
+
+.Procedure
+
+. Edit the `ExternalSecretsConfig` CR by running the following command:
++
+[source,terminal]
+----
+$ oc edit externalsecretsconfigs.operator.openshift.io cluster
+----
+
+. Set the policy by editing the `networkPolicies` section. The following example shows how to allow egress to {aws-first} endpoints.
++
+[source,yaml]
+----
+apiVersion: operator.openshift.io/v1alpha1
+kind: ExternalSecretsConfig
+metadata:
+  name: cluster
+spec:
+  controllerConfig:
+    networkPolicies:
+      - componentName: ExternalSecretsCoreController
+        egress:
+          # Allow egress to Kubernetes API server, AWS endpoints, and DNS
+          - ports:
+              - port: 443   # HTTPS (AWS Secrets Manager)
+                protocol: TCP
+      - name: allow-external-secrets-egress
+----
++
+where:
+
+componentName:: Specifies the name for the core controller which is `ExternalSecretsCoreController`. Egress rules must specify the required ports, such as Transmission Control Protocol (TCP) port 443, for services such as the {aws-short} Secrets Manager.

--- a/modules/external-secrets-operator-egress-specific-provider.adoc
+++ b/modules/external-secrets-operator-egress-specific-provider.adoc
@@ -1,0 +1,50 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-operator-config-net-policy.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="external-secrets-operator-egress-specific-provider_{context}"]
+= Adding a custom network policy to allow egress to a specific provider
+
+[role="_abstract"]
+You must configure custom policies through the `ExternalSecretsConfig` custom resource (CR) to allow egress to a specific provider.
+
+.Prerequisites
+
+* An `ExternalSecretsConfig` must be predefined.
+
+* You must be able to define specific egress rules, including destination ports and protocols
+
+.Procedure
+
+. Edit the `ExternalSecretsConfig` CR by running the following command:
++
+[source,terminal]
+----
+$ oc edit externalsecretsconfigs.operator.openshift.io cluster
+----
+
+. Set the policy by editing the `networkPolicies` section. The following example shows how to allow egress to {aws-first} endpoints.
++
+[source,yaml]
+----
+apiVersion: operator.openshift.io/v1alpha1
+kind: ExternalSecretsConfig
+metadata:
+  name: cluster
+spec:
+  controllerConfig:
+    networkPolicies:
+      - name: allow-external-secrets-egress-aws
+        componentName: CoreController
+        egress:
+          - ports:
+              - port: 443
+                protocol: TCP
+----
++
+where:
+
+`spec.controllerConfig.networkPolicies.name:: Specifies the name of the network policy object.
+
+`spec.controllerConfig.networkPolicies.componentName:: Specifies the name for the core controller that is `CoreController`. Egress rules must specify the required ports, such as Transmission Control Protocol (TCP) port 443, for services such as the {aws-short} Secrets Manager.

--- a/modules/external-secrets-operator-ingress-egress-rules.adoc
+++ b/modules/external-secrets-operator-ingress-egress-rules.adoc
@@ -1,0 +1,45 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-operator-install.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="external-secrets-operator-ingress-egress-rules_{context}"]
+= Default ingress and egress rules
+
+[role="_abstract"]
+The ingress and egress rules are necessary to build a secure setup where every component acts with the least amount of privilege necessary. These rules protect your cluster by strictly blocking unnecessary traffic and only allowing the outbound connections needed to fetch secrets. They also permit the specific inbound connections required to validate webhooks and observe system performance.
+
+The following table summarizes the specific ports and protocols used by each component.
+
+[cols="1,1,1,1",options="header"]
+|===
+| Component
+| Ingress ports
+| Egress ports
+| Description
+
+| `external-secrets`
+| 8080
+| 6443
+| Allows retrieving metrics and interacting with the API server
+
+| `external-secrets-webhook`
+| 8080/10250
+| 6443
+| Allows retrieving metrics, handling webhook requests, and interacting with the API server
+
+| `external-secrets-cert-controller`
+| 8080
+| 6443
+| Allows retrieving metrics and interacting with the API server
+
+| `external-secrets-bitwarden-server`
+| 9998
+| 6443
+| Handles Bitwarden server connections and interacts with the API server
+
+| `external-secrets-allow-dns`
+|
+| 5353
+| Enables DNS lookups to find external secret providers.
+|===

--- a/modules/external-secrets-operator-ingress-egress-rules.adoc
+++ b/modules/external-secrets-operator-ingress-egress-rules.adoc
@@ -1,0 +1,45 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-operator-config-net-policy.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="external-secrets-operator-ingress-egress-rules_{context}"]
+= Default ingress and egress rules
+
+[role="_abstract"]
+You can review the default ingress and egress ports and protocols for each {external-secrets-operator} operand component.
+
+The table lists ingress and egress ports for each operand component. These default rules block unnecessary traffic and allow only the connections required for metrics, webhooks, API server access, and DNS lookups.
+
+[cols="1,1,1,1",options="header"]
+|===
+| Component
+| Ingress ports
+| Egress ports
+| Description
+
+| `external-secrets`
+| 8080
+| 6443
+| Allows retrieving metrics and interacting with the API server
+
+| `external-secrets-webhook`
+| 8080/10250
+| 6443
+| Allows retrieving metrics, handling webhook requests, and interacting with the API server
+
+| `external-secrets-cert-controller`
+| 8080
+| 6443
+| Allows retrieving metrics and interacting with the API server
+
+| `external-secrets-bitwarden-server`
+| 9998
+| 6443
+| Handles Bitwarden server connections and interacts with the API server
+
+| `external-secrets-allow-dns`
+|
+| 5353
+| Enables DNS lookups to find external secret providers.
+|===

--- a/security/external_secrets_operator/external-secrets-operator-config-net-policy.adoc
+++ b/security/external_secrets_operator/external-secrets-operator-config-net-policy.adoc
@@ -1,0 +1,19 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="external-secrets-operator-config-net-policy"]
+= Configuring network policy for the operand
+include::_attributes/common-attributes.adoc[]
+:context: external-secrets-operator-config-net-policy
+
+toc::[]
+
+[role="_abstract"]
+The {external-secrets-operator} for {product-title} includes pre-defined `NetworkPolicies` for security that rejects all egress traffic and allows traffic towards services that are required for the operand functionality. You must configure additional custom policies to allow the `external-secrets` controller to egress traffic towards external providers. These configurable policies are set through the `ExternalSecretsConfig` custom resource to establish the egress allow policy.
+
+// Adding network policy to connect to permit all egress traffic
+include::modules/external-secrets-operator-egress-allow-all-traffic.adoc[leveloffset=+1]
+
+// Adding network policy to connect to a specific provider
+include::modules/external-secrets-operator-egress-specific-provider.adoc[leveloffset=+1]
+
+// Default ingress and egress rules
+include::modules/external-secrets-operator-ingress-egress-rules.adoc[leveloffset=+1]

--- a/security/external_secrets_operator/external-secrets-operator-config-net-policy.adoc
+++ b/security/external_secrets_operator/external-secrets-operator-config-net-policy.adoc
@@ -1,0 +1,21 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="external-secrets-operator-config-net-policy"]
+= Configuring network policy for the operand
+include::_attributes/common-attributes.adoc[]
+:context: external-secrets-operator-config-net-policy
+
+toc::[]
+
+[role="_abstract"]
+The {external-secrets-operator} for {product-title} applies default `NetworkPolicy` resources that block egress traffic except for operand services. Configure additional egress allow policies in the `ExternalSecretsConfig` custom resource so the controller can reach external secret providers.
+
+The default operand `NetworkPolicy` resources reject all other egress traffic and permit only the connections required for core operand functionality.
+
+// Adding network policy to connect to permit all egress traffic
+include::modules/external-secrets-operator-egress-allow-all-traffic.adoc[leveloffset=+1]
+
+// Adding network policy to connect to a specific provider
+include::modules/external-secrets-operator-egress-specific-provider.adoc[leveloffset=+1]
+
+// Default ingress and egress rules
+include::modules/external-secrets-operator-ingress-egress-rules.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s):
4.18

Issue:
https://redhat.atlassian.net/browse/OSDOCS-18784

Link to docs preview:
https://111850--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/external_secrets_operator/external-secrets-operator-config-net-policy.html


QE review:
- [ ] QE has approved this change.


Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
