### PR TITLE
OSDOCS-18784-7 created assembly/modules for proxy

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -1312,6 +1312,8 @@ Topics:
   Dir: external_secrets_operator
   Distros: openshift-enterprise
   Topics:
+  - Name: Configuring the egress proxy
+    File: external-secrets-operator-proxy
   - Name: Customizing the External Secrets Operator for Red Hat OpenShift
     File: external-secrets-log-levels
 - Name: Viewing audit logs

--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -1322,6 +1322,8 @@ Topics:
   Dir: external_secrets_operator
   Distros: openshift-enterprise
   Topics:
+  - Name: Configuring the egress proxy
+    File: external-secrets-operator-proxy
   - Name: Customizing the External Secrets Operator for Red Hat OpenShift
     File: external-secrets-log-levels
 - Name: Viewing audit logs

--- a/modules/external-secrets-operator-configure-proxy.adoc
+++ b/modules/external-secrets-operator-configure-proxy.adoc
@@ -1,0 +1,82 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-operator-proxy.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="external-secrets-operator-configure-proxy_{context}"]
+= Configuring the egress proxy for the {external-secrets-operator}
+
+[role="_abstract"]
+The egress proxy can be configured in the `ExternalSecretsConfig` or the `ExternalSecretsManager` custom resource (CR). The Operator and the operand make use of the {product-title} supported certificate authority (CA) bundle for the proxy validations.
+
+.Prerequisites
+
+* You have access to the cluster as a user with the `cluster-admin` role.
+
+* You have created the `ExternalSecretsConfig` custom CR.
+
+.Procedure
+
+. To set the proxy in the `ExternalSecretsConfig` resource, perform the following steps:
+
+.. Edit the `ExternalSecretsConfig` resource by running the following command:
++
+[source,terminal]
+----
+$ oc edit externalsecretsconfigs.operator.openshift.io cluster
+----
+
+.. Edit the `spec.appConfig.proxy` section to set the proxy values as follows:
++
+[source,yaml]
+----
+apiVersion: operator.openshift.io/v1alpha1
+kind: ExternalSecretsConfig
+...
+spec:
+  appConfig:
+    proxy:
+      httpProxy: <http_proxy>
+      httpsProxy: <https_proxy>
+      noProxy: <no_proxy>
+----
++
+where:
+
+<http_proxy>:: Specifies the proxy URL for the http requests.
+
+<https_proxy>:: Specifies the proxy URL for the https requests.
+
+<no_proxy>:: Specifies a comma-separated list of hostnames, CIDRs, IPs or a combination of these, for which the proxy should not be used.
+
+. To set the proxy in the `ExternalSecretsManager` CR, perform the following steps.
+
+.. Edit the `ExternalSecretsManager` CR by running the following command:
++
+[source,terminal]
+----
+$ oc edit externalsecretsmanagers.operator.openshift.io cluster
+----
+
+.. Edit the `spec.globalConfig.proxy` section to set the proxy values as follows:
++
+[source,yaml]
+----
+apiVersion: operator.openshift.io/v1alpha1
+kind: ExternalSecretsManager
+...
+spec:
+  globalConfig:
+    proxy:
+      httpProxy: <http_proxy>
+      httpsProxy: <https_proxy>
+      noProxy: <no_proxy>
+----
++
+where:
+
+<http_proxy>:: Specifies the proxy URL for the http requests.
+
+<https_proxy>:: Proxy URL for the https requests.
+
+<no_proxy>:: Comma-separated list of hostnames, CIDRs, IPs or a combination of these for which the proxy should not be used.

--- a/modules/external-secrets-operator-configure-proxy.adoc
+++ b/modules/external-secrets-operator-configure-proxy.adoc
@@ -1,0 +1,82 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-operator-proxy.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="external-secrets-operator-configure-proxy_{context}"]
+= Configuring the egress proxy for the {external-secrets-operator}
+
+[role="_abstract"]
+You can configure the egress proxy in the `ExternalSecretsConfig` or `ExternalSecretsManager` custom resource (CR). The Operator and the operand use the {product-title} supported certificate authority (CA) bundle for the proxy validations.
+
+.Prerequisites
+
+* You have access to the cluster as a user with the `cluster-admin` role.
+
+* You have created the `ExternalSecretsConfig` CR.
+
+.Procedure
+
+. To set the proxy in the `ExternalSecretsConfig` resource, perform the following steps:
+
+.. Edit the `ExternalSecretsConfig` resource by running the following command:
++
+[source,terminal]
+----
+$ oc edit externalsecretsconfigs.operator.openshift.io cluster
+----
+
+.. Edit the `spec.appConfig.proxy` section to set the proxy values as follows:
++
+[source,yaml]
+----
+apiVersion: operator.openshift.io/v1alpha1
+kind: ExternalSecretsConfig
+...
+spec:
+  appConfig:
+    proxy:
+      httpProxy: <http_proxy>
+      httpsProxy: <https_proxy>
+      noProxy: <no_proxy>
+----
++
+where:
+
+`<http_proxy>`:: Specifies the proxy URL for the http requests.
+
+`<https_proxy>`:: Specifies the proxy URL for the https requests.
+
+`<no_proxy>`:: Specifies a comma-separated list of hostnames, CIDRs, IPs or a combination of these, for which the proxy should not be used.
+
+. To set the proxy in the `ExternalSecretsManager` CR, perform the following steps:
+
+.. Edit the `ExternalSecretsManager` CR by running the following command:
++
+[source,terminal]
+----
+$ oc edit externalsecretsmanagers.operator.openshift.io cluster
+----
+
+.. Edit the `spec.globalConfig.proxy` section to set the proxy values as follows:
++
+[source,yaml]
+----
+apiVersion: operator.openshift.io/v1alpha1
+kind: ExternalSecretsManager
+...
+spec:
+  globalConfig:
+    proxy:
+      httpProxy: <http_proxy>
+      httpsProxy: <https_proxy>
+      noProxy: <no_proxy>
+----
++
+where:
+
+`<http_proxy>`:: Specifies the proxy URL for the http requests.
+
+`<https_proxy>`:: Specifies the proxy URL for the https requests.
+
+`<no_proxy>`:: Specifies a comma-separated list of hostnames, CIDRs, IPs or a combination of these, for which the proxy should not be used.

--- a/security/external_secrets_operator/external-secrets-operator-proxy.adoc
+++ b/security/external_secrets_operator/external-secrets-operator-proxy.adoc
@@ -1,0 +1,19 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="external-secrets-operator-proxy"]
+= About the egress proxy for the External Secrets Operator for Red Hat OpenShift
+include::_attributes/common-attributes.adoc[]
+:context: external-secrets-operator-proxy
+
+toc::[]
+
+[role="_abstract"]
+If a cluster-wide egress proxy is configured in {product-title}, Operator Lifecycle Manager (OLM) automatically configures Operators that it manages with the cluster-wide proxy. OLM automatically updates all of the Operators deployments with the `HTTP_PROXY`, `HTTPS_PROXY`, `NO_PROXY` environment variables.
+
+// Configure egress proxy
+include::modules/external-secrets-operator-configure-proxy.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+[id="external-resources-operator-proxy_additional-resources"]
+== Additional resources
+
+* xref:../../operators/admin/olm-configuring-proxy-support.adoc#olm-configuring-proxy-support[Configuring proxy support in Operator Lifecycle Manager]

--- a/security/external_secrets_operator/external-secrets-operator-proxy.adoc
+++ b/security/external_secrets_operator/external-secrets-operator-proxy.adoc
@@ -1,0 +1,19 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="external-secrets-operator-proxy"]
+= About the egress proxy for the External Secrets Operator for Red Hat OpenShift
+include::_attributes/common-attributes.adoc[]
+:context: external-secrets-operator-proxy
+
+toc::[]
+
+[role="_abstract"]
+If a cluster-wide egress proxy is configured in {product-title}, Operator Lifecycle Manager (OLM) automatically configures the Operators it manages with the proxy and updates the Operator deployments with the `HTTP_PROXY`, `HTTPS_PROXY`, and `NO_PROXY` environment variables.
+
+// Configure egress proxy
+include::modules/external-secrets-operator-configure-proxy.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+[id="external-secrets-operator-proxy_additional-resources"]
+== Additional resources
+
+* xref:../../operators/admin/olm-configuring-proxy-support.adoc#olm-configuring-proxy-support[Configuring proxy support in Operator Lifecycle Manager]


### PR DESCRIPTION
Version(s):
4.18

Issue:
https://redhat.atlassian.net/browse/OSDOCS-18784

Link to docs preview:
https://111857--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/external_secrets_operator/external-secrets-operator-proxy.html


QE review:
- [x] QE has approved this change.


Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
