### PR TITLE
OBSDOCS-3400: Fix OpenTelemetry Kubernetes Events Receiver RBAC

### DIFF
--- a/modules/otel-receivers-kubernetesevents-receiver.adoc
+++ b/modules/otel-receivers-kubernetesevents-receiver.adoc
@@ -9,7 +9,7 @@
 [role="_abstract"]
 The Kubernetes Events Receiver collects events from the Kubernetes API server. The collected events are converted into logs.
 
-The following {ocp-product-title} permissions are required for the Kubernetes Events Receiver:
+The following {ocp-product-title} permissions are required for the Kubernetes Events Receiver. Alternatively, you can use a namespace-scoped `Role` object and `RoleBinding` object when you configure the receiver to watch specific namespaces by using the `namespaces` option.
 
 [source,yaml]
 ----
@@ -20,63 +20,9 @@ metadata:
   labels:
     app: otel-collector
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - events
-  - namespaces
-  - namespaces/status
-  - nodes
-  - nodes/spec
-  - pods
-  - pods/status
-  - replicationcontrollers
-  - replicationcontrollers/status
-  - resourcequotas
-  - services
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - apps
-  resources:
-  - daemonsets
-  - deployments
-  - replicasets
-  - statefulsets
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - extensions
-  resources:
-  - daemonsets
-  - deployments
-  - replicasets
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - batch
-  resources:
-  - jobs
-  - cronjobs
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-    - autoscaling
-  resources:
-    - horizontalpodautoscalers
-  verbs:
-    - get
-    - list
-    - watch
-# ...
+- apiGroups: [""]
+  resources: ["events"]
+  verbs: ["get", "list", "watch"]
 ----
 
 The following `OpenTelemetryCollector` custom resource configures the Kubernetes Event Receiver:


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): main, 3.9, 3.10
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://redhat.atlassian.net/browse/OBSDOCS-3400
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://111860--ocpdocs-pr.netlify.app/openshift-otel/latest/otel-collector/otel-collector-receivers.html#otel-receivers-kubernetesevents-receiver_otel-collector-receivers
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: Based on https://github.com/openshift/openshift-docs/pull/111543
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
