### PR TITLE
OSDOCS-18784-8 created assembly/modules for monitoring

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -1322,6 +1322,8 @@ Topics:
   Dir: external_secrets_operator
   Distros: openshift-enterprise
   Topics:
+  - Name: Monitoring the External Secrets Operator for Red Hat OpenShift
+    File: external-secrets-monitoring
   - Name: Customizing the External Secrets Operator for Red Hat OpenShift
     File: external-secrets-log-levels
 - Name: Viewing audit logs

--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -1312,6 +1312,8 @@ Topics:
   Dir: external_secrets_operator
   Distros: openshift-enterprise
   Topics:
+  - Name: Monitoring the External Secrets Operator for Red Hat OpenShift
+    File: external-secrets-monitoring
   - Name: Customizing the External Secrets Operator for Red Hat OpenShift
     File: external-secrets-log-levels
 - Name: Viewing audit logs

--- a/modules/external-secrets-enable-metrics.adoc
+++ b/modules/external-secrets-enable-metrics.adoc
@@ -1,0 +1,129 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/exteernal-secrets-monitoring.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="external-secrets-enable-metrics_{context}"]
+= Configuring metrics collection for {external-secrets-operator} operands by using a ServiceMonitor
+
+[role="_abstract"]
+The {external-secrets-operator} operands exposes metrics by default on port `8080` at the `/metrics` service endpoint for all three components (`external-secrets`, `external-secrets-cert-controll`, and `external-secrets-webhook`). You can configure metrics collection for the external-secrets operands by creating a `ServiceMonitor` custom resource (CR) that enables the Prometheus Operator to collect custom metrics. For more information, see "Configuring user workload monitoring".
+
+.Prerequisites
+
+* You have access to the cluster as a user with the `cluster-admin` role.
+* You have installed the {external-secrets-operator}.
+* You have enabled the user workload monitoring.
+
+.Procedure
+
+. Create the `ClusterRoleBinding` resource required for granting permissions to access metrics:
+
+.. Create the `clusterrolebinding-external-secrets.yaml` YAML file:
++
+The following example shows a `clusterrolebinding-external-secrets.yaml` file.
++
+[source,yaml]
+----
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app: external-secrets
+  name: external-secrets-allow-metrics-access
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: external-secrets-operator-metrics-reader
+subjects:
+  - kind: ServiceAccount
+    name: external-secrets
+    namespace: external-secrets
+  - kind: ServiceAccount
+    name: external-secrets-cert-controller
+    namespace: external-secrets
+  - kind: ServiceAccount
+    name: external-secrets-webhook
+    namespace: external-secrets
+----
+
+.. Create the `ClusterRoldeBinding` custom resource by running the following command:
++
+[source,terminal]
+----
+$ oc apply -f clusterrolebinding-external-secrets.yaml
+----
+
+. Create the `ServiceMonitor` CR:
+
+.. Create the `servicemonitor-external-secrets.yaml` YAML file:
++
+[source,yaml]
+----
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    app: external-secrets
+  name: external-secrets-metrics-monitor
+  namespace: external-secrets
+spec:
+  endpoints:
+    - interval: 60s
+      path: /metrics
+      port: metrics
+      scheme: http
+      scrapeTimeout: 30s
+  namespaceSelector:
+    matchNames:
+      - external-secrets
+  selector:
+    matchExpressions:
+      - key: app.kubernetes.io/name
+        operator: In
+        values:
+          - external-secrets
+          - external-secrets-cert-controller
+          - external-secrets-webhook
+      - key: app.kubernetes.io/instance
+        operator: In
+        values:
+          - external-secrets
+      - key: app.kubernetes.io/managed-by
+        operator: In
+        values:
+          - external-secrets-operator
+----
+
+.. Create the `ServiceMonitor` CR by running the following command:
++
+[source,terminal]
+----
+$ oc apply -f servicemonitor-external-secrets.yaml
+----
++
+After the `ServiceMonitor` CR is created, the user workload Prometheus instance begins metrics collection from the {external-secrets-operator} operands. The collected metrics are labeled with `job="external-secrets"`,`job="external-secrets-cainjector"`, and `job="external-secrets-webhook"`.
+
+.Verification
+
+. In the {product-title} web console, navigate to *Observe* -> *Targets*.
+
+. In the Label filter field, enter the following labels to filter the metrics targets for each operand:
++
+[source,terminal]
+----
+$ service=external-secrets
+----
++
+[source,terminal]
+----
+$ service=external-secrets-cert-controller-metrics
+----
++
+[source,terminal]
+----
+$ service=external-secrets-webhook
+----
+
+. Confirm that the *Status* column shows `Up` for the `external-secrets`, `external-secrets-cert-controller` and `external-secrets-webhook`.
+

--- a/modules/external-secrets-enable-metrics.adoc
+++ b/modules/external-secrets-enable-metrics.adoc
@@ -1,0 +1,116 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-monitoring.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="external-secrets-enable-metrics_{context}"]
+= Configuring metrics collection for {external-secrets-operator} operands by using a ServiceMonitor CR
+
+[role="_abstract"]
+The {external-secrets-operator} operands expose metrics by default on port `8080` at the `/metrics` service endpoint. You can configure metrics collection for the operands by creating a `ServiceMonitor` custom resource (CR) that enables the Prometheus Operator to collect custom metrics.
+
+.Prerequisites
+
+* You have access to the cluster as a user with the `cluster-admin` role.
+* You have installed the {external-secrets-operator}.
+* You have enabled the user workload monitoring.
+
+.Procedure
+
+. Create the `ClusterRoleBinding` resource required for granting permissions to access metrics:
+
+.. Create the `clusterrolebinding-external-secrets.yaml` YAML file:
++
+[source,yaml]
+----
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app: external-secrets
+  name: external-secrets-allow-metrics-access
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: external-secrets-operator-metrics-reader
+subjects:
+  - kind: ServiceAccount
+    name: external-secrets
+    namespace: external-secrets
+  - kind: ServiceAccount
+    name: external-secrets-cert-controller
+    namespace: external-secrets
+  - kind: ServiceAccount
+    name: external-secrets-webhook
+    namespace: external-secrets
+----
+
+.. Create the `ClusterRoleBinding` resource by running the following command:
++
+[source,terminal]
+----
+$ oc apply -f clusterrolebinding-external-secrets.yaml
+----
+
+. Create the `ServiceMonitor` CR:
+
+.. Create the `servicemonitor-external-secrets.yaml` YAML file:
++
+[source,yaml]
+----
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    app: external-secrets
+  name: external-secrets-metrics-monitor
+  namespace: external-secrets
+spec:
+  endpoints:
+    - interval: 60s
+      path: /metrics
+      port: metrics
+      scheme: http
+      scrapeTimeout: 30s
+  namespaceSelector:
+    matchNames:
+      - external-secrets
+  selector:
+    matchExpressions:
+      - key: app.kubernetes.io/name
+        operator: In
+        values:
+          - external-secrets
+          - external-secrets-cert-controller
+          - external-secrets-webhook
+      - key: app.kubernetes.io/instance
+        operator: In
+        values:
+          - external-secrets
+      - key: app.kubernetes.io/managed-by
+        operator: In
+        values:
+          - external-secrets-operator
+----
+
+.. Create the `ServiceMonitor` CR by running the following command:
++
+[source,terminal]
+----
+$ oc apply -f servicemonitor-external-secrets.yaml
+----
++
+After the `ServiceMonitor` CR is created, the user workload Prometheus instance begins metrics collection from the {external-secrets-operator} operands. The collected metrics are labeled with `job="external-secrets"`, `job="external-secrets-cert-controller-metrics"`, and `job="external-secrets-webhook"`.
+
+.Verification
+
+. In the {product-title} web console, navigate to *Observe* -> *Targets*.
+
+. In the *Label filter* field, enter one of the following labels to filter the metrics targets for each operand:
++
+* `service=external-secrets`
+* `service=external-secrets-cert-controller-metrics`
+* `service=external-secrets-webhook`
+
+. Confirm that the *Status* column shows `Up` for the `external-secrets`, `external-secrets-cert-controller`, and `external-secrets-webhook`.
+

--- a/modules/external-secrets-enable-operator-metrics.adoc
+++ b/modules/external-secrets-enable-operator-metrics.adoc
@@ -1,0 +1,202 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/exteernal-secrets-monitoring.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="external-secrets-enable-operator-metrics_{context}"]
+= Configuring metrics collection for {external-secrets-operator} by using a ServiceMonitor
+
+[role="_abstract"]
+The {external-secrets-operator} exposes metrics by default on port `8443` at the `/metrics` service endpoint. You can configure metrics collection for the Operator by creating a `ServiceMonitor` custom resource (CR) that enables the Prometheus Operator to collect custom metrics. For more information, see "Configuring user workload monitoring".
+
+.Prerequisites
+
+* You have access to the cluster as a user with the `cluster-admin` role.
+* You have installed the {external-secrets-operator}.
+* You have enabled the user workload monitoring.
+
+.Procedure
+
+. Configure the Operator to use `HTTP` for the metrics server. `HTTPS` is enabled by default.
+
+.. Update the subscription object for {external-secrets-operator} to configure the `HTTP` protocol by running the following command:
++
+[source,terminal]
+----
+$ oc -n external-secrets-operator patch subscription openshift-external-secrets-operator --type='merge' -p '{"spec":{"config":{"env":[{"name":"METRICS_BIND_ADDRESS","value":":8080"}, {"name": "METRICS_SECURE", "value": "false"}]}}}'
+----
+
+.. To verify that the {external-secrets-operator-short} pod is redeployed and that the configured values for `METRICS_BIND_ADDRESS` and `METRICS_SECURE` are updated, run the following command:
++
+[source,terminal]
+----
+$ oc set env --list deployment/external-secrets-operator-controller-manager -n external-secrets-operator | grep -e METRICS_BIND_ADDRESS -e METRICS_SECURE -e container
+----
++
+The following example shows that the `METRICS_BIND_ADDRESS` and `METRICS_SECURE` have been updated:
++
+[source,terminal]
+----
+# deployments/external-secrets-operator-controller-manager, container manager
+METRICS_BIND_ADDRESS=:8080
+METRICS_SECURE=false
+----
+
+. Create the `Secret` resource with the `kubernetes.io/service-account.name` annotation to inject the token required for authenticating with the metrics server.
+
+.. Create the `secret-external-secrets-operator.yaml` YAML file:
++
+[source,yaml]
+----
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    app: external-secrets-operator
+  name: external-secrets-operator-metrics-auth
+  namespace: external-secrets-operator
+  annotations:
+    kubernetes.io/service-account.name: external-secrets-operator-controller-manager
+type: kubernetes.io/service-account-token
+----
+
+.. Create the `Secret` resource by running the following command:
++
+[source,terminal]
+----
+$ oc apply -f secret-external-secrets-operator.yaml
+----
+
+. Create the `ClusterRoleBinding` resource required for granting permissions to access metrics:
+
+.. Create the `clusterrolebinding-external-secrets.yaml` YAML file:
++
+The following example shows a `clusterrolebinding-external-secrets.yaml` file.
++
+[source,yaml]
+----
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app: external-secrets-operator
+  name: external-secrets-allow-metrics-access
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: external-secrets-operator-metrics-reader
+subjects:
+  - kind: ServiceAccount
+    name: external-secrets-operator-controller-manager
+    namespace: external-secrets-operator
+----
+
+.. Create the `ClusterRoldeBinding` custom resource by running the following command:
++
+[source,terminal]
+----
+$ oc apply -f clusterrolebinding-external-secrets.yaml
+----
+
+. Create the `ServiceMonitor` CR if using the default `HTTPS`:
+
+.. Create the `servicemonitor-external-secrets-operator-https.yaml` YAML file:
++
+[source,yaml]
+----
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    app: external-secrets-operator
+  name: external-secrets-operator-metrics-monitor
+  namespace: external-secrets-operator
+spec:
+  endpoints:
+    - authorization:
+        credentials:
+          name: external-secrets-operator-metrics-auth
+          key: token
+        type: Bearer
+      interval: 60s
+      path: /metrics
+      port: metrics-https
+      scheme: https
+      scrapeTimeout: 30s
+      tlsConfig:
+        ca:
+          configMap:
+            name: openshift-service-ca.crt
+            key: service-ca.crt
+        serverName: external-secrets-operator-controller-manager-metrics-service.external-secrets-operator.svc.cluster.local
+  namespaceSelector:
+    matchNames:
+      - external-secrets-operator
+  selector:
+    matchLabels:
+      app: external-secrets-operator
+      svc: external-secrets-operator-controller-manager-metrics-service
+----
+
+.. Create the `ServiceMonitor` CR by running the following command:
++
+[source,terminal]
+----
+$ oc apply -f servicemonitor-external-secrets-operator-https.yaml
+----
+
+. Create the `ServiceMonitor` CR if configured to use `HTTP`:
+
+.. Create the `servicemonitor-external-secrets-operator-http.yaml` YAML file:
++
+[source,yaml]
+----
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    app: external-secrets-operator
+  name: external-secrets-operator-metrics-monitor
+  namespace: external-secrets-operator
+spec:
+  endpoints:
+    - authorization:
+        credentials:
+          name: external-secrets-operator-metrics-auth
+          key: token
+        type: Bearer
+      interval: 60s
+      path: /metrics
+      port: metrics-http
+      scheme: http
+      scrapeTimeout: 30s
+  namespaceSelector:
+    matchNames:
+      - external-secrets-operator
+  selector:
+    matchLabels:
+      app: external-secrets-operator
+      svc: external-secrets-operator-controller-manager-metrics-service
+----
+
+.. Create the `ServiceMonitor` CR by running the following command:
++
+[source,terminal]
+----
+$ oc apply -f servicemonitor-external-secrets-operator-http.yaml
+----
++
+After the `ServiceMonitor` CR is created, the user workload Prometheus instance begins metrics collection from the Operator. The collected metrics are labeled with `job="external-secrets-operator-controller-manager-metrics-service"`.
+
+.Verification
+
+. In the {product-title} web console, navigate to *Observe* -> *Targets*.
+
+. In the Label filter field, enter the following labels to filter the metrics targets for each operand:
++
+[source,terminal]
+----
+$ service=external-secrets-operator-controller-manager-metrics-service
+----
+
+. Confirm that the *Status* column shows `Up` for the `external-secrets-operator`.

--- a/modules/external-secrets-enable-operator-metrics.adoc
+++ b/modules/external-secrets-enable-operator-metrics.adoc
@@ -1,0 +1,195 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-monitoring.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="external-secrets-enable-operator-metrics_{context}"]
+= Configuring metrics collection for {external-secrets-operator} by using a ServiceMonitor
+
+[role="_abstract"]
+The {external-secrets-operator} exposes metrics by default on port `8443` at the `/metrics` service endpoint. You can configure metrics collection for the Operator by creating a `ServiceMonitor` custom resource (CR) that enables the Prometheus Operator to collect custom metrics.
+
+.Prerequisites
+
+* You have access to the cluster as a user with the `cluster-admin` role.
+* You have installed the {external-secrets-operator}.
+* You have enabled the user workload monitoring.
+
+.Procedure
+
+. Configure the Operator to use `HTTP` for the metrics server. `HTTPS` is enabled by default.
+
+.. Update the subscription object for {external-secrets-operator} to configure the `HTTP` protocol by running the following command:
++
+[source,terminal]
+----
+$ oc -n external-secrets-operator patch subscription openshift-external-secrets-operator --type='merge' -p '{"spec":{"config":{"env":[{"name":"METRICS_BIND_ADDRESS","value":":8080"}, {"name": "METRICS_SECURE", "value": "false"}]}}}'
+----
+
+.. To verify that the {external-secrets-operator-short} pod is redeployed and that the configured values for `METRICS_BIND_ADDRESS` and `METRICS_SECURE` are updated, run the following command:
++
+[source,terminal]
+----
+$ oc set env --list deployment/external-secrets-operator-controller-manager -n external-secrets-operator | grep -e METRICS_BIND_ADDRESS -e METRICS_SECURE -e container
+----
++
+The following example shows that the `METRICS_BIND_ADDRESS` and `METRICS_SECURE` have been updated:
++
+[source,terminal]
+----
+# deployments/external-secrets-operator-controller-manager, container manager
+METRICS_BIND_ADDRESS=:8080
+METRICS_SECURE=false
+----
+
+. Create the `Secret` resource with the `kubernetes.io/service-account.name` annotation to inject the token required for authenticating with the metrics server.
+
+.. Create the `secret-external-secrets-operator.yaml` YAML file:
++
+[source,yaml]
+----
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    app: external-secrets-operator
+  name: external-secrets-operator-metrics-auth
+  namespace: external-secrets-operator
+  annotations:
+    kubernetes.io/service-account.name: external-secrets-operator-controller-manager
+type: kubernetes.io/service-account-token
+----
+
+.. Create the `Secret` resource by running the following command:
++
+[source,terminal]
+----
+$ oc apply -f secret-external-secrets-operator.yaml
+----
+
+. Create the `ClusterRoleBinding` resource required for granting permissions to access metrics.
+
+.. Create the `clusterrolebinding-external-secrets.yaml` YAML file:
++
+[source,yaml]
+----
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app: external-secrets-operator
+  name: external-secrets-allow-metrics-access
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: external-secrets-operator-metrics-reader
+subjects:
+  - kind: ServiceAccount
+    name: external-secrets-operator-controller-manager
+    namespace: external-secrets-operator
+----
+
+.. Create the `ClusterRoleBinding` resource by running the following command:
++
+[source,terminal]
+----
+$ oc apply -f clusterrolebinding-external-secrets.yaml
+----
+
+. If using the default `HTTPS`, create the `ServiceMonitor` CR.
+
+.. Create the `servicemonitor-external-secrets-operator-https.yaml` YAML file:
++
+[source,yaml]
+----
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    app: external-secrets-operator
+  name: external-secrets-operator-metrics-monitor
+  namespace: external-secrets-operator
+spec:
+  endpoints:
+    - authorization:
+        credentials:
+          name: external-secrets-operator-metrics-auth
+          key: token
+        type: Bearer
+      interval: 60s
+      path: /metrics
+      port: metrics-https
+      scheme: https
+      scrapeTimeout: 30s
+      tlsConfig:
+        ca:
+          configMap:
+            name: openshift-service-ca.crt
+            key: service-ca.crt
+        serverName: external-secrets-operator-controller-manager-metrics-service.external-secrets-operator.svc.cluster.local
+  namespaceSelector:
+    matchNames:
+      - external-secrets-operator
+  selector:
+    matchLabels:
+      app: external-secrets-operator
+      svc: external-secrets-operator-controller-manager-metrics-service
+----
+
+.. Create the `ServiceMonitor` CR by running the following command:
++
+[source,terminal]
+----
+$ oc apply -f servicemonitor-external-secrets-operator-https.yaml
+----
+
+. If configured to use `HTTP`, create the `ServiceMonitor` CR.
+
+.. Create the `servicemonitor-external-secrets-operator-http.yaml` YAML file:
++
+[source,yaml]
+----
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    app: external-secrets-operator
+  name: external-secrets-operator-metrics-monitor
+  namespace: external-secrets-operator
+spec:
+  endpoints:
+    - authorization:
+        credentials:
+          name: external-secrets-operator-metrics-auth
+          key: token
+        type: Bearer
+      interval: 60s
+      path: /metrics
+      port: metrics-http
+      scheme: http
+      scrapeTimeout: 30s
+  namespaceSelector:
+    matchNames:
+      - external-secrets-operator
+  selector:
+    matchLabels:
+      app: external-secrets-operator
+      svc: external-secrets-operator-controller-manager-metrics-service
+----
+
+.. Create the `ServiceMonitor` CR by running the following command:
++
+[source,terminal]
+----
+$ oc apply -f servicemonitor-external-secrets-operator-http.yaml
+----
++
+After the `ServiceMonitor` CR is created, the user workload Prometheus instance begins metrics collection from the Operator. The collected metrics are labeled with `job="external-secrets-operator-controller-manager-metrics-service"`.
+
+.Verification
+
+. In the {product-title} web console, navigate to *Observe* -> *Targets*.
+
+. In the *Label filter* field, enter the `service=external-secrets-operator-controller-manager-metrics-service` label to filter the metrics targets.
+
+. Confirm that the *Status* column shows `Up` for the `external-secrets-operator`.

--- a/modules/external-secrets-enable-user-workload-monitor.adoc
+++ b/modules/external-secrets-enable-user-workload-monitor.adoc
@@ -1,0 +1,57 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-monitoring.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="external-secrets-enable-user-workload-monitor_{context}"]
+= Enabling user workload monitoring
+
+[role="_abstract"]
+By default, the {product-title} monitoring stack does not scrape metrics from user-installed applications like the External Secrets Operator. Enabling user workload monitoring is necessary to collect critical operational data, such as synchronization status, API error rates, and controller performance. This helps you to configure custom alerts for secret sync failures and create dashboards to monitor the overall health of your secret management system. You can enable monitoring for user-defined projects by configuring user workload monitoring in the cluster. For more information, see "Setting up metrics collection for user-defined projects".
+
+.Prerequisites
+
+* You have access to the cluster as a user with the `cluster-admin` role.
+
+.Procedure
+
+. Create the `cluster-monitoring-config.yaml` YAML file:
++
+[source,yaml]
+----
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cluster-monitoring-config
+  namespace: openshift-monitoring
+data:
+  config.yaml: |
+    enableUserWorkload: true
+----
+
+. Apply the `ConfigMap` by running the following command:
++
+[source,terminal]
+----
+$ oc apply -f cluster-monitoring-config.yaml
+----
+
+.Verification
+
+* Verify that the monitoring components for user workloads are running in the `openshift-user-workload-monitoring` namespace by running the following command:
++
+[source,terminal]
+----
+$ oc -n openshift-user-workload-monitoring get pod
+----
++
+.Example output
+[source,terminal]
+----
+NAME                                   READY   STATUS    RESTARTS   AGE
+prometheus-operator-5f79cff9c9-67pjb   2/2     Running   0          25h
+prometheus-user-workload-0             6/6     Running   0          25h
+thanos-ruler-user-workload-0           4/4     Running   0          25h
+----
++
+The status of the pods such as `prometheus-operator`, `prometheus-user-workload`, and `thanos-ruler-user-workload` must be `Running`.

--- a/modules/external-secrets-enable-user-workload-monitor.adoc
+++ b/modules/external-secrets-enable-user-workload-monitor.adoc
@@ -1,0 +1,57 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-monitoring.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="external-secrets-enable-user-workload-monitor_{context}"]
+= Enabling user workload monitoring
+
+[role="_abstract"]
+By default, the {product-title} monitoring stack does not scrape metrics from user-installed applications like the {external-secrets-operator-short}. You can enable user workload monitoring to collect Operator metrics such as synchronization status, API error rates, and controller performance.
+
+.Prerequisites
+
+* You have access to the cluster as a user with the `cluster-admin` role.
+
+.Procedure
+
+. Create the `cluster-monitoring-config.yaml` YAML file:
++
+[source,yaml]
+----
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cluster-monitoring-config
+  namespace: openshift-monitoring
+data:
+  config.yaml: |
+    enableUserWorkload: true
+----
+
+. Apply the `ConfigMap` object by running the following command:
++
+[source,terminal]
+----
+$ oc apply -f cluster-monitoring-config.yaml
+----
+
+.Verification
+
+* Verify that the monitoring components for user workloads are running in the `openshift-user-workload-monitoring` namespace by running the following command:
++
+[source,terminal]
+----
+$ oc -n openshift-user-workload-monitoring get pod
+----
++
+.Example output
+[source,terminal]
+----
+NAME                                   READY   STATUS    RESTARTS   AGE
+prometheus-operator-5f79cff9c9-67pjb   2/2     Running   0          25h
+prometheus-user-workload-0             6/6     Running   0          25h
+thanos-ruler-user-workload-0           4/4     Running   0          25h
+----
++
+The status of the pods such as `prometheus-operator`, `prometheus-user-workload`, and `thanos-ruler-user-workload` must be `Running`.

--- a/modules/external-secrets-query-metrics.adoc
+++ b/modules/external-secrets-query-metrics.adoc
@@ -1,0 +1,38 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-monitoring.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="external-secrets-query-metrics_{context}"]
+= Querying metrics for the external-secrets operand
+
+[role="_abstract"]
+As a cluster administrator, or as a user with view access to all namespaces, you can query `external-secrets` operand metrics by using the {product-title} web console or the command-line interface (CLI). For more information, see "Accessing metrics".
+
+.Prerequisites
+
+* You have access to the cluster as a user with the `cluster-admin` role.
+* You have installed the {external-secrets-operator}.
+* You have enabled monitoring and metrics collection by creating a `ServiceMonitor` object.
+
+.Procedure
+
+. In the {product-title} web console, navigate to *Observe* -> *Metrics*.
+
+. In the query field, enter the following PromQL expressions to query the {external-secrets-operator} operands metric for each operand:
++
+[source,promql]
+----
+{job="external-secrets"}
+----
++
+[source,promql]
+----
+{job="external-secrets-webhook"}
+----
++
+[source,promql]
+----
+{job="external-secrets-cert-controller-metrics"}
+----
+

--- a/modules/external-secrets-query-metrics.adoc
+++ b/modules/external-secrets-query-metrics.adoc
@@ -1,0 +1,40 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-monitoring.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="external-secrets-query-metrics_{context}"]
+= Querying metrics for the external-secrets operand
+
+[role="_abstract"]
+As a cluster administrator, or as a user with view access to all namespaces, you can query `external-secrets` operand metrics by using the {product-title} web console or the command-line interface (CLI).
+
+For more information, see "Accessing metrics".
+
+.Prerequisites
+
+* You have access to the cluster as a user with the `cluster-admin` role.
+* You have installed the {external-secrets-operator}.
+* You have enabled monitoring and metrics collection by creating a `ServiceMonitor` object.
+
+.Procedure
+
+. In the {product-title} web console, navigate to *Observe* -> *Metrics*.
+
+. In the query field, enter the following PromQL expressions to query the {external-secrets-operator} operands metric for each operand:
++
+[source,promql]
+----
+{job="external-secrets"}
+----
++
+[source,promql]
+----
+{job="external-secrets-webhook"}
+----
++
+[source,promql]
+----
+{job="external-secrets-cert-controller-metrics"}
+----
+

--- a/modules/external-secrets-query-operator-metrics.adoc
+++ b/modules/external-secrets-query-operator-metrics.adoc
@@ -1,0 +1,27 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-monitoring.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="external-secrets-query-operator-metrics_{context}"]
+= Querying metrics for the {external-secrets-operator}
+
+[role="_abstract"]
+As a cluster administrator, or as a user with view access to all namespaces, you can query the Operator metrics by using the {product-title} web console or the command-line interface (CLI). For more information, see "Accessing metrics".
+
+.Prerequisites
+
+* You have access to the cluster as a user with the `cluster-admin` role.
+* You have installed the {external-secrets-operator}.
+* You have enabled monitoring and metrics collection by creating a `ServiceMonitor` object.
+
+.Procedure
+
+. In the {product-title} web console, navigate to *Observe* -> *Metrics*.
+
+. In the query field, enter the following PromQL expressions to query the {external-secrets-operator} metric:
++
+[source,promql]
+----
+{job="external-secrets-operator-controller-manager-metrics-service"}
+----

--- a/modules/external-secrets-query-operator-metrics.adoc
+++ b/modules/external-secrets-query-operator-metrics.adoc
@@ -1,0 +1,29 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-monitoring.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="external-secrets-query-operator-metrics_{context}"]
+= Querying metrics for the {external-secrets-operator}
+
+[role="_abstract"]
+As a cluster administrator, or as a user with view access to all namespaces, you can query the Operator metrics by using the {product-title} web console or the command-line interface (CLI).
+
+For more information, see "Accessing metrics".
+
+.Prerequisites
+
+* You have access to the cluster as a user with the `cluster-admin` role.
+* You have installed the {external-secrets-operator}.
+* You have enabled monitoring and metrics collection by creating a `ServiceMonitor` object.
+
+.Procedure
+
+. In the {product-title} web console, navigate to *Observe* -> *Metrics*.
+
+. In the query field, enter the following PromQL expressions to query the {external-secrets-operator} metric:
++
+[source,promql]
+----
+{job="external-secrets-operator-controller-manager-metrics-service"}
+----

--- a/security/external_secrets_operator/external-secrets-monitoring.adoc
+++ b/security/external_secrets_operator/external-secrets-monitoring.adoc
@@ -1,0 +1,50 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="external-secrets-monitoring"]
+= Monitoring the External Secrets Operator for Red Hat OpenShift
+include::_attributes/common-attributes.adoc[]
+:context: external-secrets-monitoring
+
+toc::[]
+
+[role="_abstract"]
+By default, the {external-secrets-operator} exposes metrics for the Operator and the operands. You can configure OpenShift Monitoring to collect these metrics by using the Prometheus Operator format.
+
+// Enabling user workload monitoring for the external-secrets-operator operand
+include::modules/external-secrets-enable-user-workload-monitor.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+* link:https://docs.redhat.com/en/documentation/monitoring_stack_for_red_hat_openshift/4.21/html/configuring_user_workload_monitoring/configuring-metrics-uwm#setting-up-metrics-collection-for-user-defined-projects_configuring-metrics-uwm[Setting up metrics collection for user-defined projects]
+
+// Metrics scraping for external-secrets-operator
+include::modules/external-secrets-enable-operator-metrics.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* link:https://docs.redhat.com/en/documentation/monitoring_stack_for_red_hat_openshift/4.21/html/configuring_user_workload_monitoring/preparing-to-configure-the-monitoring-stack-uwm#configurable-monitoring-components_preparing-to-configure-the-monitoring-stack-uwm[Configurable monitoring components]
+
+// Querying metrics for the external-secrets operator
+include::modules/external-secrets-query-operator-metrics.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* link:https://docs.redhat.com/en/documentation/monitoring_stack_for_red_hat_openshift/4.21/html/accessing_metrics/index[Accessing metrics]
+
+
+// Metrics scraping for external-secrets operands by using a ServiceMonitor
+include::modules/external-secrets-enable-metrics.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* link:https://docs.redhat.com/en/documentation/monitoring_stack_for_red_hat_openshift/4.21/html/configuring_user_workload_monitoring/preparing-to-configure-the-monitoring-stack-uwm[Configuring user workload monitoring]
+
+// Querying metrics for the external-secrets operands
+include::modules/external-secrets-query-metrics.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* link:https://docs.redhat.com/en/documentation/monitoring_stack_for_red_hat_openshift/4.21/html/accessing_metrics/index[Accessing metrics]

--- a/security/external_secrets_operator/external-secrets-monitoring.adoc
+++ b/security/external_secrets_operator/external-secrets-monitoring.adoc
@@ -1,0 +1,50 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="external-secrets-monitoring"]
+= Monitoring the External Secrets Operator for Red Hat OpenShift
+include::_attributes/common-attributes.adoc[]
+:context: external-secrets-monitoring
+
+toc::[]
+
+[role="_abstract"]
+By default, the {external-secrets-operator} exposes metrics for the Operator and the operands. You can configure the {product-title} monitoring stack to collect these metrics by using the Prometheus Operator format.
+
+// Enabling user workload monitoring for the external-secrets-operator operand
+include::modules/external-secrets-enable-user-workload-monitor.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+* link:https://docs.redhat.com/en/documentation/monitoring_stack_for_red_hat_openshift/4.21/html/configuring_user_workload_monitoring/configuring-metrics-uwm#setting-up-metrics-collection-for-user-defined-projects_configuring-metrics-uwm[Setting up metrics collection for user-defined projects]
+
+// Metrics scraping for external-secrets-operator
+include::modules/external-secrets-enable-operator-metrics.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* link:https://docs.redhat.com/en/documentation/monitoring_stack_for_red_hat_openshift/4.21/html/configuring_user_workload_monitoring/preparing-to-configure-the-monitoring-stack-uwm#configurable-monitoring-components_preparing-to-configure-the-monitoring-stack-uwm[Configurable monitoring components]
+
+// Querying metrics for the external-secrets operator
+include::modules/external-secrets-query-operator-metrics.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* link:https://docs.redhat.com/en/documentation/monitoring_stack_for_red_hat_openshift/4.21/html/accessing_metrics/index[Accessing metrics]
+
+
+// Metrics scraping for external-secrets operands by using a ServiceMonitor
+include::modules/external-secrets-enable-metrics.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* link:https://docs.redhat.com/en/documentation/monitoring_stack_for_red_hat_openshift/4.21/html/configuring_user_workload_monitoring/preparing-to-configure-the-monitoring-stack-uwm[Configuring user workload monitoring]
+
+// Querying metrics for the external-secrets operands
+include::modules/external-secrets-query-metrics.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* link:https://docs.redhat.com/en/documentation/monitoring_stack_for_red_hat_openshift/4.21/html/accessing_metrics/index[Accessing metrics]


### PR DESCRIPTION
Version(s):
4.18

Issue:
https://redhat.atlassian.net/browse/OSDOCS-18784

Link to docs preview:
https://111862--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/external_secrets_operator/external-secrets-monitoring.html


QE review:
- [x] QE has approved this change.


Additional information:
Merge-reviewer: The information in this PR was copied from the most recent ESO repo here https://github.com/openshift/openshift-docs/tree/main/modules. Most of the  text was reviewed in earlier PRs. Just thought you would want to know.
