### PR TITLE
DOCPLAN-368: Add [role="_abstract"] attribute to fix AsciiDocDITA.ShortDescription warnings

### DIFF
--- a/virt/release_notes/virt-4-11-release-notes.adoc
+++ b/virt/release_notes/virt-4-11-release-notes.adoc
@@ -5,6 +5,7 @@ include::_attributes/common-attributes.adoc[]
 :context: virt-4-11-release-notes
 toc::[]
 
+[role="_abstract"]
 Do not add or edit release notes here. Edit release notes directly in the branch
 that they are relevant for.
 

--- a/virt/release_notes/virt-4-12-release-notes.adoc
+++ b/virt/release_notes/virt-4-12-release-notes.adoc
@@ -5,6 +5,7 @@ include::_attributes/common-attributes.adoc[]
 :context: virt-4-12-release-notes
 toc::[]
 
+[role="_abstract"]
 Do not add or edit release notes here. Edit release notes directly in the branch
 that they are relevant for.
 

--- a/virt/release_notes/virt-4-13-release-notes.adoc
+++ b/virt/release_notes/virt-4-13-release-notes.adoc
@@ -5,6 +5,7 @@ include::_attributes/common-attributes.adoc[]
 :context: virt-4-13-release-notes
 toc::[]
 
+[role="_abstract"]
 Do not add or edit release notes here. Edit release notes directly in the branch
 that they are relevant for.
 

--- a/virt/release_notes/virt-4-14-release-notes.adoc
+++ b/virt/release_notes/virt-4-14-release-notes.adoc
@@ -5,6 +5,7 @@ include::_attributes/common-attributes.adoc[]
 :context: virt-4-14-release-notes
 toc::[]
 
+[role="_abstract"]
 Do not add or edit release notes here. Edit release notes directly in the branch
 that they are relevant for.
 

--- a/virt/release_notes/virt-4-15-release-notes.adoc
+++ b/virt/release_notes/virt-4-15-release-notes.adoc
@@ -5,6 +5,7 @@ include::_attributes/common-attributes.adoc[]
 :context: virt-4-15-release-notes
 toc::[]
 
+[role="_abstract"]
 Do not add or edit release notes here. Edit release notes directly in the branch
 that they are relevant for.
 

--- a/virt/release_notes/virt-4-16-release-notes.adoc
+++ b/virt/release_notes/virt-4-16-release-notes.adoc
@@ -5,6 +5,7 @@ include::_attributes/common-attributes.adoc[]
 :context: virt-4-16-release-notes
 toc::[]
 
+[role="_abstract"]
 Do not add or edit release notes here. Edit release notes directly in the branch
 that they are relevant for.
 


### PR DESCRIPTION
## Summary
Fix 6 virt release notes files that were missing the `[role="_abstract"]` attribute before their abstract paragraphs. This resolves 6 of 7 AsciiDocDITA.ShortDescription warnings identified in the virt documentation.

## Files Modified
- virt/release_notes/virt-4-11-release-notes.adoc
- virt/release_notes/virt-4-12-release-notes.adoc
- virt/release_notes/virt-4-13-release-notes.adoc
- virt/release_notes/virt-4-14-release-notes.adoc
- virt/release_notes/virt-4-15-release-notes.adoc
- virt/release_notes/virt-4-16-release-notes.adoc

## File Skipped
- virt/backup_restore/virt-backup-restore-overview.adoc - First content is an IMPORTANT admonition block, not a proper abstract paragraph. Per the abstract skill guidelines, files where the first content is inside an admonition block should be skipped.

## Changes
Added `[role="_abstract"]` attribute immediately before the abstract paragraph in each release notes file, following the AsciiDoc DITA conversion requirements.

## Validation
- Verified all files have main title (single `=`) before the abstract - ✅
- Verified abstracts are paragraphs, not section headings - ✅
- Verified no abstract added to files with admonition blocks as first content - ✅
- Verified 6 AsciiDocDITA.ShortDescription warnings resolved - ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)