### PR TITLE
Fix IstioCNI readiness cmd and Service Mesh install step

### DIFF
--- a/modules/ossm-installing-istio-ambient-mode.adoc
+++ b/modules/ossm-installing-istio-ambient-mode.adoc
@@ -102,7 +102,7 @@ $ oc apply -f istio-cni.yaml
 +
 [source,terminal]
 ----
-$ oc wait --for=condition=Ready istios/default --timeout=3m
+$ oc wait --for=condition=Ready IstioCNI/default --timeout=3m
 ----
 
 . Install the Ztunnel proxy:

--- a/modules/ossm-installing-operator.adoc
+++ b/modules/ossm-installing-operator.adoc
@@ -18,7 +18,7 @@ For clusters without {SMProduct} instances, install the {SMProductShortName} Ope
 
 .Procedure
 
-. In the {ocp-product-title} web console, navigate to the *Operators* -> *OperatorHub* page.
+. In the {ocp-product-title} web console, navigate to the *Ecosystem* -> *Software Catalog* page.
 
 . Search for the {SMProductName} 3 Operator.
 


### PR DESCRIPTION
This PR fixes the following issues.
1. Fix the command used to wait for IstioCNI readiness
2. Correct a step in the Service Mesh Operator installation doc

Fixes: https://redhat.atlassian.net/browse/OSSM-12705
