### PR TITLE
nw-network-policy-create-cli-fix

### DIFF
--- a/modules/nw-networkpolicy-create-cli.adoc
+++ b/modules/nw-networkpolicy-create-cli.adoc
@@ -71,7 +71,6 @@ ifdef::multi[]
 ----
 apiVersion: k8s.cni.cncf.io/v1beta1
 kind: MultiNetworkPolicy
-endif:: multi[]
 metadata:
   name: deny-by-default
   annotations:


### PR DESCRIPTION
Fixes a floating conditional that was [added here.](https://github.com/openshift/openshift-docs/pull/102739/changes#diff-130b5e7d179a593c067ffbc70b290cfe7e9e76e0a3f77d2577d2eb95b0ca696e)


Version(s):
4.17+

4.16 is fine and does not have the floating conditional.

Issue:
N/A (Internal fix)

Link to docs preview:

* https://111875--ocpdocs-pr.netlify.app/microshift/latest/microshift_networking/microshift_network_policy/microshift-creating-network-policy.html
* https://111875--ocpdocs-pr.netlify.app/openshift-dedicated/latest/networking/network_security/network_policy/creating-network-policy.html
* https://111875--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/multiple_networks/secondary_networks/configuring-multi-network-policy.html
* https://111875--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/network_security/network_policy/creating-network-policy.html
* https://111875--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/networking/network_security/network_policy/creating-network-policy.html
* https://111875--ocpdocs-pr.netlify.app/openshift-rosa/latest/networking/network_security/network_policy/creating-network-policy.html
