### PR TITLE
[RHDEVDOCS-7614] Release notes for Pipelines 1.20.5

### DIFF
--- a/modules/op-release-notes-1-20-5.adoc
+++ b/modules/op-release-notes-1-20-5.adoc
@@ -1,0 +1,48 @@
+// This module is included in the following assemblies:
+// * release_notes/op-release-notes-1-20.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="op-release-notes-1-20-5_{context}"]
+= Release notes for {pipelines-title} 1.20.5
+
+[role="_abstract"]
+With this update, {pipelines-title} General Availability (GA) 1.20.5 is available on {OCP} 4.14, 4.16, and later versions.
+
+[id="known-issues-1-20-5_{context}"]
+== Known issues
+
+maven-ecosystem task fails with rate limiting errors on multiple architectures::
+On x86/amd64, IBM Power, and IBM Z architecture clusters, the `maven-ecosystem` task fails when downloading plugins from Maven Central with the following error message:
++
+[source,terminal]
+----
+Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1
+from/to central (https://repo.maven.apache.org/maven2):
+status code: 429, reason phrase: Too Many Requests (429)
+----
++
+This issue is specific to {pipelines-shortname} 1.20.5 and does not occur on ARM64 architecture clusters or earlier versions of {pipelines-shortname}. As a consequence, Maven builds cannot complete successfully.
++
+link:https://redhat.atlassian.net/browse/SRVKP-12186[SRVKP-12186]
+
+[id="fixed-issues-1-20-5_{context}"]
+== Fixed issues
+
+.Operator
+
+TektonResult nodeSelector and tolerations configurations correctly propagate to pods::
+Before this update, the Operator did not propagate `nodeSelector` and `tolerations` configurations from the `TektonConfig` custom resource (CR) to the `TektonResult` CR and its `TektonInstallerSet` resource. As a consequence, `TektonResult` deployments, including the API, watcher, and retention policy agent, ignored scheduling configurations and landed on worker nodes instead of the intended control plane or infrastructure nodes. With this update, the Operator correctly cascades configuration from the `TektonConfig` CR to the `TektonResult` CR. As a result, `TektonResult` deployments respect `nodeSelector` and `tolerations` settings and schedule according to the specified configuration.
++
+link:https://issues.redhat.com/browse/SRVKP-9205[SRVKP-9205]
+
+.User interface
+
+TaskSidebar displays correctly in Pipeline Builder on {OCP} 4.21 and later versions::
+Before this update, the `TaskSidebar` component in the Pipeline Builder lacked a z-index style property. This issue became visible on {OCP} 4.21 and later versions when static plugin fallback code was removed from the console. As a consequence, the sidebar rendered behind other page elements, and only the sidebar header was visible. With this update, the component includes the missing z-index property. As a result, the `TaskSidebar` correctly overlays other components and remains visible and accessible.
++
+link:https://issues.redhat.com/browse/SRVKP-11533[SRVKP-11533]
+
+Pipeline run logs preserve whitespace and formatting in the console::
+Before this update, pipeline run logs in the {OCP} console did not preserve whitespace, and long lines wrapped automatically. As a consequence, structured log output and tabular data appeared misaligned, reducing readability. With this update, the log viewer preserves whitespace and provides horizontal scrolling for long lines. As a result, pipeline run logs maintain their original formatting.
++
+link:https://issues.redhat.com/browse/SRVKP-11608[SRVKP-11608]

--- a/release_notes/op-release-notes-1-20.adoc
+++ b/release_notes/op-release-notes-1-20.adoc
@@ -44,6 +44,9 @@ include::modules/op-release-notes-1-20-3.adoc[leveloffset=+1]
 // Release notes for Red Hat OpenShift Pipelines 1.20.4
 include::modules/op-release-notes-1-20-4.adoc[leveloffset=+1]
 
+// Release notes for Red Hat OpenShift Pipelines 1.20.5
+include::modules/op-release-notes-1-20-5.adoc[leveloffset=+1]
+
 //Additional resources 1.20
 [role="_additional-resources"]
 .Additional resources


### PR DESCRIPTION
Version(s):
- none for cherry-picking

Issue:
- https://redhat.atlassian.net/browse/RHDEVDOCS-7614

Link to docs preview:
- [OpenShift Pipelines 1.20.5 release notes](https://111886--ocpdocs-pr.netlify.app/openshift-pipelines/latest/release_notes/op-release-notes-1-20.html#op-release-notes-1-20-5_op-release-notes-1-20)

Reviews:
- [x] peer reviewed by @Dhruv-Soni11 
- [x] QE has approved this change.

