### PR TITLE
TELCODOCS-2609: Release notes for kubevirt redish

### DIFF
--- a/modules/rn-ocp-release-notes-new-features.adoc
+++ b/modules/rn-ocp-release-notes-new-features.adoc
@@ -155,6 +155,12 @@ With this update, you can add the `openShiftUpdatePrecheck` label to alerts in a
 +
 For more information, see xref:../updating/preparing_for_updates/updating-cluster-prepare.adoc#oc-adm-upgrade-recommend-custom-alert_updating-cluster-prepare[Adding custom alerts to `oc adm upgrade recommend` command output].
 
+Deploying virtualized control planes with KubeVirt Redfish (Technology Preview)::
++
+You can use KubeVirt Redfish to deploy {product-title} clusters with control plane nodes running as virtual machines on a hosting cluster with {VirtProductName}. Running control plane nodes as VMs provides VM-level isolation for control plane components. KubeVirt Redfish exposes VMs through the standard Redfish API, enabling existing installation methods such as installer-provisioned infrastructure, Agent-based Installer, and {ztp-first} to manage VM power states and boot media. The feature is available as a Technology Preview.
++
+For more information, see xref:../vcp/vcp-overview.adoc#vcp-overview[Understanding virtualized control planes].
+
 [id="ocp-release-notes-machine-config-operator_{context}"]
 == Machine Config Operator
 

--- a/modules/rn-ocp-release-notes-technology-preview.adoc
+++ b/modules/rn-ocp-release-notes-technology-preview.adoc
@@ -187,6 +187,11 @@ In the following tables, features are marked with the following statuses:
 |Technology Preview
 |Technology Preview
 |Technology Preview
+
+|Deploying virtualized control planes with KubeVirt Redfish
+|Not Available
+|Not Available
+|Technology Preview
 |====
 
 [NOTE]

--- a/virt/release_notes/virt-4-22-release-notes.adoc
+++ b/virt/release_notes/virt-4-22-release-notes.adoc
@@ -40,7 +40,11 @@ The SVVP certification applies to:
 
 // Infrastructure
 
-
+KubeVirt Redfish for VM management through the Redfish API (Technology Preview)::
++
+KubeVirt Redfish exposes {VirtProductName} virtual machines through the standard Redfish API. Using KubeVirt Redfish, administrators can manage VM power states, boot configuration, and virtual media attachments. This feature is available as a Technology Preview.
++
+For more information, see xref:../post_installation_configuration/virt-kubevirt-redfish.adoc#proc_virt-installing-kubevirt-redfish_virt-kubevirt-redfish[Install KubeVirt Redfish].
 
 // Virtualization
 


### PR DESCRIPTION
[TELCODOCS-2609](https://redhat.atlassian.net/browse/TELCODOCS-2609): Release notes for kubevirt redish

Version(s):
4.22

Issue:
https://redhat.atlassian.net/browse/TELCODOCS-2609

Link to docs preview:

OCP core RN:
https://111890--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-22-release-notes.html#ocp-release-notes-install-update_release-notes

Virt RN:
https://111890--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/release_notes/virt-4-22-release-notes.html#virt-4-22-new_virt-4-22-release-notes

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
One RN for Virt
One RN for OCP core