### PR TITLE
Add troubleshooting doc for pvc delay binding

### DIFF
--- a/backup_and_restore/application_backup_and_restore/troubleshooting/backup-and-restore-cr-issues.adoc
+++ b/backup_and_restore/application_backup_and_restore/troubleshooting/backup-and-restore-cr-issues.adoc
@@ -20,3 +20,5 @@ include::modules/troubleshooting-backup-cr-cannot-retrieve-volume-issue.adoc[lev
 include::modules/troubleshooting-backup-cr-status-remains-in-progress-issue.adoc[leveloffset=+1]
 
 include::modules/troubleshooting-backup-cr-status-remains-in-partiallyfailed-issue.adoc[leveloffset=+1]
+
+include::modules/oadp-troubleshooting-pvc-binding-delay.adoc[leveloffset=+1]

--- a/modules/oadp-troubleshooting-pvc-binding-delay.adoc
+++ b/modules/oadp-troubleshooting-pvc-binding-delay.adoc
@@ -1,0 +1,35 @@
+// Module included in the following assemblies:
+//
+// * backup_and_restore/application_backup_and_restore/troubleshooting/backup-and-restore-cr-issues.adoc
+
+:_mod-docs-content-type: PROCEDURE
+
+[id="oadp-troubleshooting-pvc-binding-delay_{context}"]
+= Troubleshooting PVC binding failures with the waitForFirstConsumer storage class
+
+[role="_abstract"]
+To ensure that restored persistent volume claims (PVCs) successfully bind to PVs when node affinity is configured, adjust the storage class binding mode settings during restore operations.
+
+PVCs that use a storage class with `bindingMode: WaitForFirstConsumer` might fail to bind to a PV when node affinity is configured. This issue can occur during restore operations, including virtual machine file restore (VMFR) workflows.
+
+.Procedure
+
+* Set the `ignoreDelayBinding` field to `true` in the `restorePVC` section of the `nodeAgent` configuration in the `DataProtectionApplication` CR, as shown in the following example:
++
+[source,yaml,subs="+quotes"]
+----
+apiVersion: oadp.openshift.io/v1alpha1
+kind: DataProtectionApplication
+metadata:
+  name: dpa-test
+  namespace: openshift-adp
+spec:
+# ...
+  configuration:
+    nodeAgent:
+      enable: true
+      restorePVC:
+        ignoreDelayBinding: true
+      uploaderType: kopia
+----
+

--- a/modules/oadp-troubleshooting-pvc-binding-delay.adoc
+++ b/modules/oadp-troubleshooting-pvc-binding-delay.adoc
@@ -1,0 +1,35 @@
+// Module included in the following assemblies:
+//
+// * backup_and_restore/application_backup_and_restore/troubleshooting/backup-and-restore-cr-issues.adoc
+
+:_mod-docs-content-type: PROCEDURE
+
+[id="oadp-troubleshooting-pvc-binding-delay_{context}"]
+= PVC binding failure with waitForFirstConsumer storage class
+
+[role="_abstract"]
+Resolve a persistent volume claim (PVC) binding failure that occurs during restore operations when the storage class uses `waitForFirstConsumer` binding mode. This helps you ensure that restored PVCs bind to persistent volumes (PVs) successfully.
+
+PVCs that use a storage class with `bindingMode: WaitForFirstConsumer` might fail to bind to a PV when node affinity is configured. This issue can occur during restore operations, including virtual machine file restore (VMFR) workflows.
+
+.Procedure
+
+* Set the `ignoreDelayBinding` field to `true` in the `restorePVC` section of the `nodeAgent` configuration in the `DataProtectionApplication` CR, as shown in the following example:
++
+[source,yaml,subs="+quotes"]
+----
+apiVersion: oadp.openshift.io/v1alpha1
+kind: DataProtectionApplication
+metadata:
+  name: dpa-test
+  namespace: openshift-adp
+spec:
+# ...
+  configuration:
+    nodeAgent:
+      enable: true
+      restorePVC:
+        ignoreDelayBinding: true
+      uploaderType: kopia
+----
+


### PR DESCRIPTION
## Jira 

* [OADP-7880](https://redhat.atlassian.net/browse/OADP-7880)

Add troubleshooting doc for pvc delay binding

##  Version

* OCP 4.19 -> 4.22 and 5.0

## Preview

* [PVC binding failure with waitForFirstConsumer storage class](https://111893--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/troubleshooting/backup-and-restore-cr-issues.html#oadp-troubleshooting-pvc-binding-delay_backup-and-restore-cr-issues)


## QE Review

* [x] QE has approved this change.
