### PR TITLE
fix(microshift-enabling-workload-partitioning): DITA compatibility fixes

### DIFF
--- a/modules/microshift-enabling-workload-partitioning.adoc
+++ b/modules/microshift-enabling-workload-partitioning.adoc
@@ -6,6 +6,7 @@
 [id="microshift-enabling-workload-partitioning_{context}"]
 = Enabling workload partitioning
 
+[role="_abstract"]
 To enable workload partitioning on {microshift-short}, make the following configuration changes:
 
 * Update the {microshift-short} `config.yaml` file to include the kubelet configuration file.
@@ -23,12 +24,15 @@ To enable workload partitioning on {microshift-short}, make the following config
 # ...
 {
   "management": {
-    "cpuset": "0,6,7" <1>
+    "cpuset": "<cpuset_value>"
   }
 }
 # ...
 ----
-<1> The `cpuset` applies to a machine with 8 VCPUs (4 cores) and is valid throughout the document.
++
+--
+* `<cpuset_value>` specifies the cpuset that applies to a machine with 8 VCPUs (4 cores) and is valid throughout the document. For example, `0,6,7`.
+--
 * Update the {microshift-short} config.yaml file in the path `/etc/microshift/config.yaml`. Embed the kubelet configuration in the {microshift-short} `config.yaml` file to enable and configure CPU Manager for the workloads.
 +
 .{microshift-short} `config.yaml` example
@@ -36,15 +40,18 @@ To enable workload partitioning on {microshift-short}, make the following config
 ----
 # ...
 kubelet:
-  reservedSystemCPUs: 0,6,7 <1>
+  reservedSystemCPUs: <reserved_cpus>
   cpuManagerPolicy: static
   cpuManagerPolicyOptions:
-    full-pcpus-only: "true" <2>
+    full-pcpus-only: "<full_pcpus_only>"
   cpuManagerReconcilePeriod: 5s
 # ...
 ----
-<1> Exclusive cpuset for the system daemons and the interrupts/timers.
-<2> kubelet configuration sets the `CPUManagerPolicyOptions` option to `full-pcpus-only` to ensure allocation of whole cores to the containers workload.
++
+--
+* `<reserved_cpus>` specifies the exclusive cpuset for the system daemons and the interrupts/timers. For example, `0,6,7`.
+* `<full_pcpus_only>` specifies the `CPUManagerPolicyOptions` option. Set to `true` to ensure allocation of whole cores to the containers workload.
+--
 
 . Create the CRI-O systemd and configuration files:
 * Create the CRI-O configuration file in the path `/etc/crio/crio.conf.d/20-microshift-workload-partition.conf` which overrides the default configuration that already exists in the `11-microshift-ovn.conf` file.


### PR DESCRIPTION
- Added [role="_abstract"] for short description
- Replaced callout markers with user-replaceable placeholders and bullet lists

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
