### PR TITLE
OSDOCS-18784-9 created assembly/moules for log levels

### DIFF
--- a/modules/external-secrets-bit-warden-config.adoc
+++ b/modules/external-secrets-bit-warden-config.adoc
@@ -1,0 +1,67 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-log-levels.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="external-secrets-bit-warden-config_{context}"]
+= Configuring the bitwardenSecretManagerProvider plugin
+
+[role="_abstract"]
+You must configure the `bitwardenSecretManagerProvider` plugin to enable communication with the Bitwarden API. This configuration enables the Operator to authenticate and fetch secrets for synchronization.
+
+.Prerequisites
+
+* You have access to the cluster with `cluster-admin` privileges.
+* You have created the `ExternalSecretsConfig` custom resource.
+
+.Procedure
+
+. Edit the `ExternalSecretsConfig` custom resource by running the following command:
++
+[source,terminal]
+----
+$  oc edit externalsecretsconfigs.operator.openshift.io cluster
+----
+
+. Edit the `spec.plugins.bitwardenSecretManagerProvider` section as follows to enable the Bitwarden Secrets Manager:
++
+[source,yaml]
+----
+apiVersion: operator.openshift.io/v1alpha1
+kind: ExternalSecretsConfig
+...
+spec:
+  plugins:
+    bitwardenSecretManagerProvider:
+      mode: Enabled
+      secretRef:
+        name: <secret_object_name>
+----
++
+where:
+
+name:: The name of the secret containing the certificate key pair for the plugin. The key name in the secret for the certificate must be `tls.crt`. The key name for the private key must be `tls.key`. The key name for the Certificate Authority (CA) certificate key name must be `ca.crt`. Configuring the secret is optional when the cert-manager certificate provider is configured.
+
+. Save your changes and exit the editor.
+
+. If you disable the plugin the following resources must be deleted manually by running the following commands:
++
+[source,terminal]
+----
+$ oc delete deployments.apps bitwarden-sdk-server -n external-secrets
+----
++
+[source,terminal]
+----
+$ oc delete certificates.cert-manager.io bitwarden-tls-certs -n external-secrets
+----
++
+[source,terminal]
+----
+$ oc delete service bitwarden-sdk-server -n external-secrets
+----
++
+[source,terminal]
+----
+$ oc delete serviceaccounts bitwarden-sdk-server -n external-secrets
+----

--- a/modules/external-secrets-bit-warden-config.adoc
+++ b/modules/external-secrets-bit-warden-config.adoc
@@ -1,0 +1,67 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-log-levels.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="external-secrets-bit-warden-config_{context}"]
+= Configuring the bitwardenSecretManagerProvider plugin
+
+[role="_abstract"]
+You must configure the `bitwardenSecretManagerProvider` plugin to enable communication with the Bitwarden API. With this configuration, the Operator authenticates and fetches secrets for synchronization.
+
+.Prerequisites
+
+* You have access to the cluster with `cluster-admin` privileges.
+* You have created the `ExternalSecretsConfig` custom resource (CR).
+
+.Procedure
+
+. Edit the `ExternalSecretsConfig` CR by running the following command:
++
+[source,terminal]
+----
+$ oc edit externalsecretsconfigs.operator.openshift.io cluster
+----
+
+. Edit the `spec.plugins.bitwardenSecretManagerProvider` section as follows to enable the Bitwarden Secrets Manager:
++
+[source,yaml]
+----
+apiVersion: operator.openshift.io/v1alpha1
+kind: ExternalSecretsConfig
+# ...
+spec:
+  plugins:
+    bitwardenSecretManagerProvider:
+      mode: Enabled
+      secretRef:
+        name: <secret_object_name>
+----
++
+where:
+
+`spec.plugins.bitwardenSecretManagerProvider.secretRef.name`:: Specifies the name of the secret containing the certificate key pair for the plugin. The key name in the secret for the certificate must be `tls.crt`. The key name for the private key must be `tls.key`. The key name for the Certificate Authority (CA) certificate key must be `ca.crt`. Configuring the secret is optional when the cert-manager certificate provider is configured.
+
+. Save your changes and exit the editor.
+
+. Optional: If you disable the plugin, the following resources must be deleted manually by running the following commands:
++
+[source,terminal]
+----
+$ oc delete deployments.apps bitwarden-sdk-server -n external-secrets
+----
++
+[source,terminal]
+----
+$ oc delete certificates.cert-manager.io bitwarden-tls-certs -n external-secrets
+----
++
+[source,terminal]
+----
+$ oc delete service bitwarden-sdk-server -n external-secrets
+----
++
+[source,terminal]
+----
+$ oc delete serviceaccounts bitwarden-sdk-server -n external-secrets
+----

--- a/modules/external-secrets-cert-manager-config.adoc
+++ b/modules/external-secrets-cert-manager-config.adoc
@@ -1,0 +1,83 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-log-levels.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="external-secrets-cert-manager-config_{context}"]
+= Configuring cert-manager for the external-secrets certificate requirements
+
+[role="_abstract"]
+You can optionally configure cert-manager to manage certificates for the {external-secrets-operator} webhook and plugins. If you do not use cert-manager, the Operator automatically generates webhook certificates, but you must manually configure certificates for any plugins.
+
+.Prerequisites
+
+* You have access to the cluster with `cluster-admin` privileges.
+* You have created the `ExternalSecretsConfig` custom resource.
+* You have installed the {cert-manager-operator}. For more information, see "Installing the {cert-manager-operator}"
+
+.Procedure
+
+. Edit the `ExternalSecretsConfig` custom resource by running the following command:
++
+[source,terminal]
+----
+$  oc edit externalsecretsconfigs.operator.openshift.io cluster
+----
+
+. Configure `cert-manager` by editing the `spec.controllerConfig.certProvider.certManager` section as follows:
++
+[source,yaml]
+----
+apiVersion: operator.openshift.io/v1alpha1
+kind: ExternalSecretsConfig
+...
+spec:
+  controllerConfig:
+    certProvider:
+      certManager:
+        injectAnnotations: "true"
+        issuerRef:
+          name: <issuer_name>
+          kind: <issuer_kind>
+          group: <issuer_group>
+        mode: Enabled
+----
++
+where:
+
+injectAnnotation:: Must be set to `true` when enabled.
+name:: Specifies the name of the issuer object referenced in `ExternalSecretsConfig`.
+kind:: Specifies the API issuer. Can be set to either `Issuer` or `ClusterIssuer`.
+group:: Specifies the API issuer group. The group name must be `cert-manager.io`.
+mode:: Must be set to `Enabled`. This is an immutable field and cannot be modified once it is configured.
+
+. Save your changes.
+
+. After you update the `cert-manager` configurations in the `externalsecretsconfig.operator.openshift.io` object, you must manually delete `external-secrets-cert-controller` deployment by running the following command. This prevents performance degradation of the `external-secrets` application.
++
+[source,terminal]
+----
+$ oc delete deployments.apps external-secrets-cert-controller -n external-secrets
+----
+
+. Optionally, you can delete other resources created for the `cert-controller` by running the following commands:
++
+[source,terminal]
+----
+$ oc delete clusterrolebindings.rbac.authorization.k8s.io external-secrets-cert-controller
+----
++
+[source,terminal]
+----
+$ oc delete clusterroles.rbac.authorization.k8s.io external-secrets-cert-controller
+----
++
+[source,terminal]
+----
+$ oc delete serviceaccounts external-secrets-cert-controller -n external-secrets
+----
++
+[source,terminal]
+----
+$ oc delete secrets external-secrets-webhook -n external-secrets
+----

--- a/modules/external-secrets-cert-manager-config.adoc
+++ b/modules/external-secrets-cert-manager-config.adoc
@@ -1,0 +1,83 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-log-levels.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="external-secrets-cert-manager-config_{context}"]
+= Configuring cert-manager for the external-secrets certificate requirements
+
+[role="_abstract"]
+You can configure cert-manager to manage certificates for the {external-secrets-operator} webhook and plugins. If you do not use cert-manager, the Operator automatically generates webhook certificates, but you must manually configure certificates for any plugins.
+
+.Prerequisites
+
+* You have access to the cluster with `cluster-admin` privileges.
+* You have created the `ExternalSecretsConfig` custom resource (CR).
+* You have installed the {cert-manager-operator}. For more information, see "Installing the {cert-manager-operator}".
+
+.Procedure
+
+. Edit the `ExternalSecretsConfig` CR by running the following command:
++
+[source,terminal]
+----
+$ oc edit externalsecretsconfigs.operator.openshift.io cluster
+----
+
+. Configure `cert-manager` by editing the `spec.controllerConfig.certProvider.certManager` section as follows:
++
+[source,yaml]
+----
+apiVersion: operator.openshift.io/v1alpha1
+kind: ExternalSecretsConfig
+# ...
+spec:
+  controllerConfig:
+    certProvider:
+      certManager:
+        injectAnnotations: "true"
+        issuerRef:
+          name: <issuer_name>
+          kind: <issuer_kind>
+          group: <issuer_group>
+        mode: Enabled
+----
++
+where:
+
+injectAnnotations:: Must be set to `true` when enabled.
+name:: Specifies the name of the issuer object referenced in `ExternalSecretsConfig`.
+kind:: Specifies the API issuer. Can be set to either `Issuer` or `ClusterIssuer`.
+group:: Specifies the API issuer group. The group name must be `cert-manager.io`.
+mode:: Must be set to `Enabled`. This is an immutable field and cannot be modified after it is configured.
+
+. Save your changes.
+
+. After you update the `cert-manager` configurations in the `externalsecretsconfigs.operator.openshift.io` object, you must manually delete the `external-secrets-cert-controller` deployment by running the following command. This prevents performance degradation of the `external-secrets` application.
++
+[source,terminal]
+----
+$ oc delete deployments.apps external-secrets-cert-controller -n external-secrets
+----
+
+. Optional: You can delete other resources created for the `cert-controller` by running the following commands:
++
+[source,terminal]
+----
+$ oc delete clusterrolebindings.rbac.authorization.k8s.io external-secrets-cert-controller
+----
++
+[source,terminal]
+----
+$ oc delete clusterroles.rbac.authorization.k8s.io external-secrets-cert-controller
+----
++
+[source,terminal]
+----
+$ oc delete serviceaccounts external-secrets-cert-controller -n external-secrets
+----
++
+[source,terminal]
+----
+$ oc delete secrets external-secrets-webhook -n external-secrets
+----

--- a/modules/external-secrets-enable-operand-log-level.adoc
+++ b/modules/external-secrets-enable-operand-log-level.adoc
@@ -1,0 +1,46 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-log-levels.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="external-secrets-enable-operand-log-level_{context}"]
+= Setting a log level for the {external-secrets-operator} operand
+
+[role="_abstract"]
+You can troubleshoot common issues, such as secret synchronization failures, provider authentication errors, or data formatting problems, by configuring the log verbosity for the core controller.
+
+.Prerequisites
+
+* You have access to the cluster with `cluster-admin` privileges.
+* You have created the `ExternalSecretsConfig` custom resource.
+
+.Procedure
+
+. Edit the `ExternalSecretsConfig` CR by running the following command:
++
+[source,terminal]
+----
+$ oc edit externalsecretsconfigs.operator.openshift.io cluster
+----
+
+. Set the log level value by editing the `spec.appConfig.logLevel` section:
++
+[source,yaml]
+----
+apiVersion: operator.openshift.io/v1alpha1
+kind: ExternalSecretsConfig
+...
+spec:
+  appConfig:
+    logLevel: <log_level>
+----
++
+where:
+
+log_level:: Supports the value range of 1-5. The log level gets mapped to the following operand support levels:
+ * 1 - warnings
+ * 2 - error logs
+ * 3 - info logs
+ * 4 and 5 - debug logs
+
+. Save your changes and exit the editor.

--- a/modules/external-secrets-enable-operand-log-level.adoc
+++ b/modules/external-secrets-enable-operand-log-level.adoc
@@ -1,0 +1,46 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-log-levels.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="external-secrets-enable-operand-log-level_{context}"]
+= Setting a log level for the {external-secrets-operator} operand
+
+[role="_abstract"]
+You can troubleshoot common issues, such as secret synchronization failures, provider authentication errors, or data formatting problems, by configuring the log verbosity for the core controller.
+
+.Prerequisites
+
+* You have access to the cluster with `cluster-admin` privileges.
+* You have created the `ExternalSecretsConfig` custom resource (CR).
+
+.Procedure
+
+. Edit the `ExternalSecretsConfig` CR by running the following command:
++
+[source,terminal]
+----
+$ oc edit externalsecretsconfigs.operator.openshift.io cluster
+----
+
+. Set the log level value by editing the `spec.appConfig.logLevel` section:
++
+[source,yaml]
+----
+apiVersion: operator.openshift.io/v1alpha1
+kind: ExternalSecretsConfig
+# ...
+spec:
+  appConfig:
+    logLevel: <log_level>
+----
++
+where:
+
+log_level:: Supports the value range of 1-5. The log level gets mapped to the following operand support levels:
+ * 1 - warnings
+ * 2 - error logs
+ * 3 - info logs
+ * 4 and 5 - debug logs
+
+. Save your changes and exit the editor.

--- a/modules/external-secrets-enable-operator-log-level.adoc
+++ b/modules/external-secrets-enable-operator-log-level.adoc
@@ -1,0 +1,54 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-log-levels.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="external-secrets-enable-operator-log-level_{context}"]
+= Setting a log level for the {external-secrets-operator}
+
+[role="_abstract"]
+You can configure the log verbosity for the lifecycle manager. You must adjust this setting to troubleshoot issues related to the installation, upgrade, or configuration of the operator itself, rather than secret synchronization.
+
+.Prerequisites
+
+* You have access to the cluster with `cluster-admin` privileges.
+* You have created the `ExternalSecretsConfig` custom resource.
+
+.Procedure
+
+* Update the subscription object for the {external-secrets-operator} to provide the verbosity level for the operator logs by running the following command:
++
+[source,terminal]
+----
+$ oc -n <external_secrets_operator_namespace> patch subscription openshift-external-secrets-operator --type='merge' -p '{"spec":{"config":{"env":[{"name":"OPERATOR_LOG_LEVEL","value":"<log_level>"}]}}}'
+----
++
+where:
+
+external_secrets_operator_namespace:: Specifies the namespace where the Operator is installed.
+
+log_level:: Specifies the level of log detail. Values range from 1-5. The default is 2.
+
+.Verification
+
+. The External Secrets Operator pod is redeployed. Verify that the log level of the {external-secrets-operator} is updated by running the following command:
++
+[source,terminal]
+----
+$ oc set env deploy/external-secrets-operator-controller-manager -n external-secrets-operator --list | grep -e OPERATOR_LOG_LEVEL -e container
+----
++
+The following example verifies that the log level of the {external-secrets-operator} is updated.
++
+[source,terminal]
+----
+# deployments/external-secrets-operator-controller-manager, container manager
+OPERATOR_LOG_LEVEL=2
+----
+
+. Verify that the log level of the {external-secrets-operator} is updated by running the `oc logs` command:
++
+[source,terminal]
+----
+$ oc logs -n external-secrets-operator -f deployments/external-secrets-operator-controller-manager -c manager
+----

--- a/modules/external-secrets-enable-operator-log-level.adoc
+++ b/modules/external-secrets-enable-operator-log-level.adoc
@@ -1,0 +1,54 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-log-levels.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="external-secrets-enable-operator-log-level_{context}"]
+= Setting a log level for the {external-secrets-operator}
+
+[role="_abstract"]
+You can configure the log verbosity for the lifecycle manager. You must adjust this setting to troubleshoot issues related to the installation, upgrade, or configuration of the Operator itself, rather than secret synchronization.
+
+.Prerequisites
+
+* You have access to the cluster with `cluster-admin` privileges.
+* You have created the `ExternalSecretsConfig` custom resource (CR).
+
+.Procedure
+
+* Update the subscription object for the {external-secrets-operator} to provide the verbosity level for the Operator logs by running the following command:
++
+[source,terminal]
+----
+$ oc -n <external_secrets_operator_namespace> patch subscription openshift-external-secrets-operator --type='merge' -p '{"spec":{"config":{"env":[{"name":"OPERATOR_LOG_LEVEL","value":"<log_level>"}]}}}'
+----
++
+where:
+
+external_secrets_operator_namespace:: Specifies the namespace where the Operator is installed.
+
+log_level:: Specifies the level of log detail. Values range from 1-5. The default is 2.
+
+.Verification
+
+. Verify that the log level of the {external-secrets-operator} is updated by running the following command:
++
+[source,terminal]
+----
+$ oc set env deploy/external-secrets-operator-controller-manager -n external-secrets-operator --list | grep -e OPERATOR_LOG_LEVEL -e container
+----
++
+The following example verifies that the log level of the {external-secrets-operator} is updated.
++
+[source,terminal]
+----
+# deployments/external-secrets-operator-controller-manager, container manager
+OPERATOR_LOG_LEVEL=2
+----
+
+. Verify that the log level of the {external-secrets-operator} is updated by running the `oc logs` command:
++
+[source,terminal]
+----
+$ oc logs -n external-secrets-operator -f deployments/external-secrets-operator-controller-manager -c manager
+----

--- a/modules/external-secrets-operator-adding-custom-annotations.adoc
+++ b/modules/external-secrets-operator-adding-custom-annotations.adoc
@@ -1,0 +1,81 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-log-levels.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="external-secrets-enable-operator-adding-custom-annotations_{context}"]
+= Adding custom annotations to external-secrets resources
+
+[role="_abstract"]
+To customize your resources, you can define up to 20 custom annotations in the custom resource (CR). The Operator merges the annotations with the defaults, prioritizes them, and safely preserves annotations set by external systems.
+
+When an annotation is removed from the CR, the Operator automatically removes it from all managed resources during the next reconciliation. Annotations set by external sources, such as Kubernetes system annotations or annotations added by other controllers, are preserved and are not affected by the Operator.
+
+Annotation keys containing the following reserved domain prefixes are not allowed and are rejected by validation if applied:
+
+* `kubernetes.io/` (including subdomains such as `*.kubernetes.io/`)
+
+* `k8s.io/` (including subdomains such as `*.k8s.io/`)
+
+* `openshift.io/` (including subdomains such as `*.openshift.io/`)
+
+* `cert-manager.io/`
+
+.Prerequisites
+
+* You have access to the cluster with `cluster-admin` privileges.
+
+* You have created the `ExternalSecretsConfig` custom resource.
+
+.Procedure
+
+. Edit the `ExternalSecretsConfig` CR by running the following command:
++
+[source,terminal]
+----
+$ oc edit externalsecretsconfigs.operator.openshift.io cluster
+----
+
+. Add the `annotations` field under `spec.controllerConfig` as follows:
++
+[source,yaml]
+----
+apiVersion: operator.openshift.io/v1alpha1
+kind: ExternalSecretsConfig
+metadata:
+  name: cluster
+spec:
+  controllerConfig:
+    annotations:
+      prometheus.io/scrape: "true"
+      example.com/environment: "production"
+----
+
+.Verification
+
+. Verify that annotations are applied to the external-secrets deployment by running the following command:
++
+[source,terminal]
+----
+$ oc get deployment external-secrets -n external-secrets -o jsonpath='{.metadata.annotations}' | jq .
+----
++
+The output should include the custom annotations you specified.
+
+. Verify that annotations are applied to the pod template by running the following command:
++
+[source,terminal]
+----
+$ oc get deployment external-secrets -n external-secrets -o jsonpath='{.spec.template.metadata.annotations}' | jq .
+----
++
+The output should include the custom annotations you specified.
+
+. Verify that annotations are applied to other managed resources such as Services by running the following command:
++
+[source,terminal]
+----
+$ oc get service external-secrets-webhook -n external-secrets -o jsonpath='{.metadata.annotations}' | jq .
+----
++
+The output should include the custom annotations you specified.

--- a/modules/external-secrets-operator-adding-custom-annotations.adoc
+++ b/modules/external-secrets-operator-adding-custom-annotations.adoc
@@ -1,0 +1,81 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-log-levels.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="external-secrets-enable-operator-adding-custom-annotations_{context}"]
+= Adding custom annotations to external-secrets resources
+
+[role="_abstract"]
+To customize your resources, you can define up to 20 custom annotations in the custom resource (CR). The Operator merges the annotations with the defaults, prioritizes them, and safely preserves annotations set by external systems.
+
+When an annotation is removed from the CR, the Operator automatically removes it from all managed resources during the next reconciliation. Annotations set by external sources, such as Kubernetes system annotations or annotations added by other controllers, are preserved and are not affected by the Operator.
+
+Annotation keys containing the following reserved domain prefixes are not allowed and are rejected by validation if applied:
+
+* `kubernetes.io/`, including subdomains such as `*.kubernetes.io/`
+
+* `k8s.io/`, including subdomains such as `*.k8s.io/`
+
+* `openshift.io/`, including subdomains such as `*.openshift.io/`
+
+* `cert-manager.io/`
+
+.Prerequisites
+
+* You have access to the cluster with `cluster-admin` privileges.
+
+* You have created the `ExternalSecretsConfig` CR.
+
+.Procedure
+
+. Edit the `ExternalSecretsConfig` CR by running the following command:
++
+[source,terminal]
+----
+$ oc edit externalsecretsconfigs.operator.openshift.io cluster
+----
+
+. Add the `annotations` field under `spec.controllerConfig` as follows:
++
+[source,yaml]
+----
+apiVersion: operator.openshift.io/v1alpha1
+kind: ExternalSecretsConfig
+metadata:
+  name: cluster
+spec:
+  controllerConfig:
+    annotations:
+      prometheus.io/scrape: "true"
+      example.com/environment: "production"
+----
+
+.Verification
+
+. Verify that annotations are applied to the external-secrets deployment by running the following command:
++
+[source,terminal]
+----
+$ oc get deployment external-secrets -n external-secrets -o jsonpath='{.metadata.annotations}' | jq .
+----
++
+The output should include the custom annotations you specified.
+
+. Verify that annotations are applied to the pod template by running the following command:
++
+[source,terminal]
+----
+$ oc get deployment external-secrets -n external-secrets -o jsonpath='{.spec.template.metadata.annotations}' | jq .
+----
++
+The output should include the custom annotations you specified.
+
+. Verify that annotations are applied to other managed resources such as Services by running the following command:
++
+[source,terminal]
+----
+$ oc get service external-secrets-webhook -n external-secrets -o jsonpath='{.metadata.annotations}' | jq .
+----
++
+The output should include the custom annotations you specified.

--- a/modules/external-secrets-operator-configure-history-limit.adoc
+++ b/modules/external-secrets-operator-configure-history-limit.adoc
@@ -1,0 +1,81 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-log-levels.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="external-secrets-enable-operator-configure-history-limit_{context}"]
+= Configuring the revisionHistoryLimit for external-secrets components
+
+[role="_abstract"]
+Configure the number of old `ReplicaSet` objects retained for rollback by setting the `revisionHistoryLimit` parameter for `external-secrets` components.
+
+The following components can be configured:
+
+[cols="1,1",options="header"]
+|===
+| Component name
+| Description
+
+| `ExternalSecretsCoreController`
+| The main `external-secrets` controller.
+
+| `Webhook`
+| The `external-secrets` webhook server.
+
+| `CertController`
+| The certificate controller for webhook TLS.
+
+| `BitwardenSDKServer`
+| The Bitwarden SDK server plugin.
+|===
+
+Each component can only have one configuration entry. A maximum of 4 component configuration entries are allowed, one per component.
+
+.Prerequisites
+
+* You have access to the cluster with `cluster-admin` privileges.
+
+* You have created the `ExternalSecretsConfig` custom resource.
+
+.Procedure
+
+. Edit the `ExternalSecretsConfig` CR by running the following command:
++
+[source,terminal]
+----
+$ oc edit externalsecretsconfigs.operator.openshift.io cluster
+----
+
+. Add the `componentConfigs` field under `spec.controllerConfig` as follows:
++
+[source,yaml]
+----
+apiVersion: operator.openshift.io/v1alpha1
+kind: ExternalSecretsConfig
+metadata:
+  name: cluster
+spec:
+  controllerConfig:
+    componentConfigs:
+      - componentName: ExternalSecretsCoreController
+        deploymentConfigs:
+          revisionHistoryLimit: 5
+      - componentName: Webhook
+        deploymentConfigs:
+          revisionHistoryLimit: 3
+----
++
+where
+
+`spec.controllerConfig.componentConfigs.componentName.deploymentConfigs.revisionHistoryLimit`:: Specifies the number of old `ReplicaSet` objects to retain for rollback. The value must be at least 1 to ensure rollback capability. The maximum value is 50. If not specified, the default is 10.
+
+.Verification
+
+* Verify that the `revisionHistoryLimit` parameter is applied to the deployment by running the following command:
++
+[source,terminal]
+----
+$ oc get deployment external-secrets -n external-secrets -o jsonpath='{.spec.revisionHistoryLimit}'
+----
++
+The output should display the value you configured.

--- a/modules/external-secrets-operator-configure-history-limit.adoc
+++ b/modules/external-secrets-operator-configure-history-limit.adoc
@@ -1,0 +1,80 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-log-levels.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="external-secrets-enable-operator-configure-history-limit_{context}"]
+= Configuring the revisionHistoryLimit for external-secrets components
+
+[role="_abstract"]
+You can set the `revisionHistoryLimit` parameter for `external-secrets` components in the `ExternalSecretsConfig` custom resource (CR) to specify how many old `ReplicaSet` objects to retain for rollback.
+
+.Configurable `external-secrets` components
+[cols="1,1",options="header"]
+|===
+| Component name
+| Description
+
+| `ExternalSecretsCoreController`
+| The main `external-secrets` controller.
+
+| `Webhook`
+| The `external-secrets` webhook server.
+
+| `CertController`
+| The certificate controller for webhook TLS.
+
+| `BitwardenSDKServer`
+| The Bitwarden SDK server plugin.
+|===
+
+Each component can have only one configuration entry. A maximum of 4 component configuration entries are allowed, one per component.
+
+.Prerequisites
+
+* You have access to the cluster with `cluster-admin` privileges.
+
+* You have created the `ExternalSecretsConfig` custom resource (CR).
+
+.Procedure
+
+. Edit the `ExternalSecretsConfig` CR by running the following command:
++
+[source,terminal]
+----
+$ oc edit externalsecretsconfigs.operator.openshift.io cluster
+----
+
+. Add the `componentConfigs` field under `spec.controllerConfig` as follows:
++
+[source,yaml]
+----
+apiVersion: operator.openshift.io/v1alpha1
+kind: ExternalSecretsConfig
+metadata:
+  name: cluster
+spec:
+  controllerConfig:
+    componentConfigs:
+      - componentName: ExternalSecretsCoreController
+        deploymentConfigs:
+          revisionHistoryLimit: 5
+      - componentName: Webhook
+        deploymentConfigs:
+          revisionHistoryLimit: 3
+----
++
+where:
+
+`spec.controllerConfig.componentConfigs.componentName.deploymentConfigs.revisionHistoryLimit`:: Specifies the number of old `ReplicaSet` objects to retain for rollback. The value must be at least 1 to ensure rollback capability. The maximum value is 50. If not specified, the default is 10.
+
+.Verification
+
+* Verify that the `revisionHistoryLimit` parameter is applied to the deployment by running the following command:
++
+[source,terminal]
+----
+$ oc get deployment external-secrets -n external-secrets -o jsonpath='{.spec.revisionHistoryLimit}'
+----
++
+The output should display the value you configured.

--- a/modules/external-secrets-operator-overriding-operand-arguments.adoc
+++ b/modules/external-secrets-operator-overriding-operand-arguments.adoc
@@ -1,0 +1,69 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-log-levels.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="external-secrets-operator-overriding-operand-arguments_{context}"]
+= Overriding operand container arguments for the {external-secrets-operator}
+
+[role="_abstract"]
+You can override container arguments for the `external-secrets` operand deployments by setting environment variables on the {external-secrets-operator} subscription. Use this method when you need to pass additional or replacement `--key=value` flags to operand containers.
+
+[NOTE]
+====
+This is a temporary feature available only in the {external-secrets-operator} 1.1 and 1.2 z-streams. {external-secrets-operator} 1.3.0 adds support in the `ExternalSecretsConfig` API to configure the same behavior. Consider migrating to the `ExternalSecretsConfig` API when upgrading to {external-secrets-operator-short} 1.3.0. This subscription-based method is scheduled to be deprecated and removed in {external-secrets-operator} 1.4.0.
+====
+
+.Prerequisites
+
+* Your installed {external-secrets-operator} version is 1.1 or 1.2.
+* You have access to the cluster as a user with the `cluster-admin` role.
+
+.Procedure
+
+* Update the Subscription for the {external-secrets-operator-short} to set the operand argument overrides by running the following command:
++
+[source,terminal]
+----
+$ oc -n <external_secrets_operator_namespace> patch subscription openshift-external-secrets-operator --type='merge' -p '{"spec":{"config":{"env":[{"name":"OPERAND_EXTERNAL_SECRETS_ARGS","value":"<controller_args>"},{"name":"OPERAND_WEBHOOK_ARGS","value":"<webhook_args>"},{"name":"OPERAND_CERT_CONTROLLER_ARGS","value":"<cert_controller_args>"},{"name":"OPERAND_BITWARDEN_SDK_SERVER_ARGS","value":"<bitwarden_args>"}]}}}'
+----
++
+where:
+
+`<external_secrets_operator_namespace>`:: Specifies the namespace where the Operator is installed.
+`<controller_args>`:: Specifies a comma-separated list of `--key` or `--key=value` flags for the `external-secrets` core controller. For example, `--concurrent=2,--loglevel=debug`.
+`<webhook_args>`:: Specifies a comma-separated list of flags for the webhook. Commas inside a flag value are preserved when the next flag begins with `--`. For example, `--tls-ciphers=TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,--loglevel=debug`.
+`<cert_controller_args>`:: Specifies a comma-separated list of flags for the `cert-controller`. For example, `--crd-requeue-interval=10m,--loglevel=debug`.
+`<bitwarden_args>`:: Specifies a comma-separated list of flags for the `bitwarden-sdk-server`. For example, `--key-file=/certs/key.pem,--cert-file=/certs/cert.pem`.
++
+Set only the environment variables you need. Omit any unused entries from the `env` list.
+
+.Verification
+
+. Verify that the environment variables are set on the Operator by running the following command:
++
+[source,terminal]
+----
+$ oc set env deploy/external-secrets-operator-controller-manager -n <external_secrets_operator_namespace> --list | grep -e OPERAND_ -e container
+----
++
+.Example output
+[source,terminal]
+----
+$ deployments/external-secrets-operator-controller-manager, container manager
+OPERAND_EXTERNAL_SECRETS_ARGS=--concurrent=2,--loglevel=debug
+OPERAND_WEBHOOK_ARGS=--tls-ciphers=TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,--loglevel=debug
+----
+
+. Verify that the operand `Deployment` container arguments were updated by running the following command:
++
+[source,terminal]
+----
+$ oc get deploy/external-secrets-webhook -n <operand_namespace> -o jsonpath='{.spec.template.spec.containers[0].args}'
+----
++
+.Example output
+[source,terminal]
+----
+$ ["webhook","--dns-name=external-secrets-webhook.external-secrets.svc","--port=10250","--cert-dir=/tmp/certs","--check-interval=15m0s","--metrics-addr=:8080","--healthz-addr=:8081","--loglevel=debug","--zap-time-encoding=epoch","--tls-ciphers=TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256"]
+----

--- a/modules/external-secrets-operator-set-custom-variables.adoc
+++ b/modules/external-secrets-operator-set-custom-variables.adoc
@@ -1,0 +1,69 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-log-levels.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="external-secrets-operator-set-custom-variables_{context}"]
+=  Setting custom environment variables for external-secrets components
+
+[role="_abstract"]
+To configure component behavior at runtime or integrate with external services, set custom environment variables for individual `external-secrets` components.
+
+Custom environment variables are merged with the default environment variables set by the Operator. User-specified variables take precedence in case of conflicts with the Operator defaults. A maximum of 50 custom environment variables can be specified per component.
+
+The environment variable names starting with the following prefixes are reserved:
+
+* `HOSTNAME`
+
+* `KUBERNETES_`
+
+* `EXTERNAL_SECRETS_`
+
+.Prerequisites
+
+* You have access to the cluster with `cluster-admin` privileges.
+
+* You have created the `ExternalSecretsConfig` custom resource.
+
+.Procedure
+
+. Edit the `ExternalSecretsConfig` CR by running the following command:
++
+[source,terminal]
+----
+$ oc edit externalsecretsconfigs.operator.openshift.io cluster
+----
+
+. Add the `overrideEnv` field under the desired component in the `spec.controllerConfig.componentConfigs` stanza as follows:
++
+[source,yaml]
+----
+apiVersion: operator.openshift.io/v1alpha1
+kind: ExternalSecretsConfig
+metadata:
+  name: cluster
+spec:
+  controllerConfig:
+    componentConfigs:
+      - componentName: ExternalSecretsCoreController
+        overrideEnv:
+          - name: Example
+            value: "4"
+----
++
+where
+
+`spec.controllerConfig.componentConfigs.overrideEnv.name`:: Specifies the name of the environment variable. Environment variable names starting with `HOSTNAME`, `KUBERNETES_`, or `EXTERNAL_SECRETS_` are reserved and are not allowed.
+
+`spec.controllerConfig.componentConfigs.overrideEnv.value`:: Specifies the value of the environment variable.
+
+.Verification
+
+* Verify that the environment variable is set on the deployment by running the following command:
++
+[source,terminal]
+----
+$ oc set env deployment/external-secrets -n external-secrets --list
+----
++
+The output should include the custom environment variable you specified.

--- a/modules/external-secrets-operator-set-custom-variables.adoc
+++ b/modules/external-secrets-operator-set-custom-variables.adoc
@@ -1,0 +1,69 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-log-levels.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="external-secrets-operator-set-custom-variables_{context}"]
+= Setting custom environment variables for external-secrets components
+
+[role="_abstract"]
+To configure component behavior at runtime or integrate with external services, set custom environment variables for individual `external-secrets` components.
+
+Custom environment variables are merged with the default environment variables set by the Operator. User-specified variables take precedence in case of conflicts with the Operator defaults. A maximum of 50 custom environment variables can be specified per component.
+
+The environment variable names starting with the following prefixes are reserved:
+
+* `HOSTNAME`
+
+* `KUBERNETES_`
+
+* `EXTERNAL_SECRETS_`
+
+.Prerequisites
+
+* You have access to the cluster with `cluster-admin` privileges.
+
+* You have created the `ExternalSecretsConfig` custom resource (CR).
+
+.Procedure
+
+. Edit the `ExternalSecretsConfig` CR by running the following command:
++
+[source,terminal]
+----
+$ oc edit externalsecretsconfigs.operator.openshift.io cluster
+----
+
+. Add the `overrideEnv` field under the desired component in the `spec.controllerConfig.componentConfigs` stanza as follows:
++
+[source,yaml]
+----
+apiVersion: operator.openshift.io/v1alpha1
+kind: ExternalSecretsConfig
+metadata:
+  name: cluster
+spec:
+  controllerConfig:
+    componentConfigs:
+      - componentName: ExternalSecretsCoreController
+        overrideEnv:
+          - name: Example
+            value: "4"
+----
++
+where:
+
+`spec.controllerConfig.componentConfigs.overrideEnv.name`:: Specifies the name of the environment variable. Environment variable names starting with `HOSTNAME`, `KUBERNETES_`, or `EXTERNAL_SECRETS_` are reserved and are not allowed.
+
+`spec.controllerConfig.componentConfigs.overrideEnv.value`:: Specifies the value of the environment variable.
+
+.Verification
+
+* Verify that the environment variable is set on the deployment by running the following command:
++
+[source,terminal]
+----
+$ oc set env deployment/external-secrets -n external-secrets --list
+----
++
+The output should include the custom environment variable you specified.

--- a/security/external_secrets_operator/external-secrets-log-levels.adoc
+++ b/security/external_secrets_operator/external-secrets-log-levels.adoc
@@ -15,4 +15,29 @@ The Operator reconciles operand resources from the `ExternalSecretsConfig` CR. C
 
 For the complete list of fields and allowed values, see the `ExternalSecretsConfig` API reference in the {external-secrets-operator} documentation.
 
+include::modules/external-secrets-enable-operator-log-level.adoc[leveloffset=+1]
 
+// enable operand log level
+include::modules/external-secrets-enable-operand-log-level.adoc[leveloffset=+1]
+
+// configure cert-manager certificate requirements
+include::modules/external-secrets-cert-manager-config.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+[id="external-secrets-log-levels_additional-resources"]
+.Additional resources
+
+* xref:../cert_manager_operator/index.adoc#cert-manager-operator-about[cert-manager Operator for Red Hat Openshift]
+* xref:../cert_manager_operator/cert-manager-operator-install#cert-manager-operator-install[Installing the cert-manager-Operator for Red Hat Openshift]
+
+// configuring bitwarden
+include::modules/external-secrets-bit-warden-config.adoc[leveloffset=+1]
+
+// add custom annotations
+include::modules/external-secrets-operator-adding-custom-annotations.adoc[leveloffset=+1]
+
+// configure history limit
+include::modules/external-secrets-operator-configure-history-limit.adoc[leveloffset=+1]
+
+// Set custom environment variables
+include::modules/external-secrets-operator-set-custom-variables.adoc[leveloffset=+1]

--- a/security/external_secrets_operator/external-secrets-log-levels.adoc
+++ b/security/external_secrets_operator/external-secrets-log-levels.adoc
@@ -15,4 +15,33 @@ The Operator reconciles operand resources from the `ExternalSecretsConfig` CR. C
 
 For the complete list of fields and allowed values, see the `ExternalSecretsConfig` API reference in the {external-secrets-operator} documentation.
 
+include::modules/external-secrets-enable-operator-log-level.adoc[leveloffset=+1]
+
+// enable operand log level
+include::modules/external-secrets-enable-operand-log-level.adoc[leveloffset=+1]
+
+// configure cert-manager certificate requirements
+include::modules/external-secrets-cert-manager-config.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+[id="external-secrets-log-levels_additional-resources"]
+.Additional resources
+
+* xref:../cert_manager_operator/index.adoc#cert-manager-operator-about[cert-manager Operator for Red Hat OpenShift]
+* xref:../cert_manager_operator/cert-manager-operator-install#cert-manager-operator-install[Installing the cert-manager Operator for Red Hat OpenShift]
+
+// configuring bitwarden
+include::modules/external-secrets-bit-warden-config.adoc[leveloffset=+1]
+
+// add custom annotations
+include::modules/external-secrets-operator-adding-custom-annotations.adoc[leveloffset=+1]
+
+// configure history limit
+include::modules/external-secrets-operator-configure-history-limit.adoc[leveloffset=+1]
+
+// Set custom environment variables
+include::modules/external-secrets-operator-set-custom-variables.adoc[leveloffset=+1]
+
+// overriding operand arguments
+include::modules/external-secrets-operator-overriding-operand-arguments.adoc[leveloffset=+1]
 


### PR DESCRIPTION
Version(s):
4.18

Issue:
https://redhat.atlassian.net/browse/OSDOCS-18784

Link to docs preview:
https://111911--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/external_secrets_operator/external-secrets-log-levels.html


QE review:
- [ ] QE has approved this change.


Additional information:

