### PR TITLE
DOCPLAN-368: Fix CQA 2.0 violations in about-virt.adoc

### DIFF
--- a/modules/virt-what-you-can-do-with-virt.adoc
+++ b/modules/virt-what-you-can-do-with-virt.adoc
@@ -37,7 +37,7 @@ You can manage your cluster and virtualization resources by using the *Virtualiz
 
 [IMPORTANT]
 ====
-For supported and unsupported OVN-Kubernetes network plugin use cases, see "OVN-Kubernetes purpose". 
+For supported and unsupported OVN-Kubernetes network plug-in use cases, see "OVN-Kubernetes purpose". 
 ====
 
 ifndef::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
@@ -49,5 +49,21 @@ When you deploy {VirtProductName} with {rh-storage}, you must create a dedicated
 ====
 endif::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
 
-// A line about support for OVN and OpenShiftSDN network providers has been moved to the `about-virt` assembly due to xrefs.
-// If you are re-using this module, you might also want to include that line in your assembly.
+You can use {VirtProductName} with OVN-Kubernetes or one of the other certified network plug-ins listed in "Certified OpenShift CNI Plug-ins".
+
+ifdef::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
+You can use {VirtProductName} with OVN-Kubernetes.
+endif::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
+
+// Hiding links in ROSA/OSD until PR 62384 merges
+ifndef::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
+You can check your {VirtProductName} cluster for compliance issues by installing the Compliance Operator and running a scan with the `ocp4-moderate` and `ocp4-moderate-node` profiles. The Compliance Operator uses OpenSCAP, a NIST-certified tool, to scan and enforce security policies.
+endif::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
+
+ifdef::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
+You can check your {VirtProductName} cluster for compliance issues by installing the Compliance Operator and running a scan with the `ocp4-moderate` and `ocp4-moderate-node` profiles. The Compliance Operator uses OpenSCAP, a NIST-certified tool, to scan and enforce security policies.
+endif::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
+
+ifndef::openshift-dedicated[]
+For information about partnering with Independent Software Vendors (ISVs) and Services partners for specialized storage, networking, backup, and additional functionality, see the Red Hat Ecosystem Catalog.
+endif::openshift-dedicated[]

--- a/virt/about_virt/about-virt.adoc
+++ b/virt/about_virt/about-virt.adoc
@@ -11,28 +11,6 @@ toc::[]
 
 include::modules/virt-what-you-can-do-with-virt.adoc[leveloffset=+1]
 
-// This line is attached to the above `virt-what-you-can-do-with-virt` module.
-// It is included here in the assembly because of the xref ban.
-
-You can use {VirtProductName} with OVN-Kubernetes or one of the other certified network plugins listed in Certified OpenShift CNI Plug-ins.
-
-ifdef::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
-You can use {VirtProductName} with OVN-Kubernetes.
-endif::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
-
-// Hiding links in ROSA/OSD until PR 62384 merges
-ifndef::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
-You can check your {VirtProductName} cluster for compliance issues by installing the Compliance Operator and running a scan with the `ocp4-moderate` and `ocp4-moderate-node` profiles. The Compliance Operator uses OpenSCAP, a NIST-certified tool, to scan and enforce security policies.
-endif::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
-
-ifdef::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
-You can check your {VirtProductName} cluster for compliance issues by installing the Compliance Operator and running a scan with the `ocp4-moderate` and `ocp4-moderate-node` profiles. The Compliance Operator uses OpenSCAP, a NIST-certified tool, to scan and enforce security policies.
-endif::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
-
-ifndef::openshift-dedicated[]
-For information about partnering with Independent Software Vendors (ISVs) and Services partners for specialized storage, networking, backup, and additional functionality, see the Red Hat Ecosystem Catalog.
-endif::openshift-dedicated[]
-
 include::modules/virt-vmware-comparison.adoc[leveloffset=+1]
 
 include::modules/virt-supported-cluster-version.adoc[leveloffset=+1]
@@ -59,7 +37,7 @@ endif::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
 ifndef::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
 * xref:../../installing/installing_sno/install-sno-preparing-to-install-sno.adoc#install-sno-about-installing-on-a-single-node_install-sno-preparing[About {sno}]
 endif::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
-* link:https://cloud.redhat.com/blog/using-the-openshift-assisted-installer-service-to-deploy-an-openshift-cluster-on-metal-and-vsphere[Assisted installer]
+* link:https://cloud.redhat.com/blog/using-the-openshift-assisted-installer-service-to-deploy-an-openshift-cluster-on-metal-and-vsphere[Using the OpenShift Assisted Installer Service to Deploy an OpenShift Cluster on Bare Metal and vSphere]
 * link:https://access.redhat.com/articles/5436171[Certified OpenShift CNI Plug-ins]
 * link:https://www.nist.gov/[NIST-certified tool]
 * link:https://red.ht/workswithvirt[Red Hat Ecosystem Catalog]


### PR DESCRIPTION
## Summary
- Remove prose content after module includes to comply with DITA assembly structure

CQA 2.0 Violations Fixed, as well as other RH style issues

Version:
4.20+

Preview link:
https://111930--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/about_virt/about-virt.html

🤖 Generated with [Claude Code](https://claude.com/claude-code)