### PR TITLE
[enterprise-4.22] OSDOCS-14819: Added Scaling Limits to the product documentation

### DIFF
--- a/modules/rosa-planning-environment-cluster-max-classic.adoc
+++ b/modules/rosa-planning-environment-cluster-max-classic.adoc
@@ -1,0 +1,51 @@
+// Module included in the following assemblies:
+//
+// * rosa_planning/rosa-planning-environment.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="planning-environment-tested-maximums-classic_{context}"]
+= Tested cluster maximums for {product-title}
+
+[role="_abstract"]
+These tested maximums apply to {product-title} clusters. Use the table to plan worker nodes, namespaces, pods, and related objects within validated scale ranges.
+
+[options="header",cols="2,1"]
+|===
+|Maximum type |{product-title} tested maximum
+
+|Number of compute (worker) nodes
+|249
+
+|Number of pods
+|60,000
+
+|Number of pods per node
+|250
+
+|Number of deployments
+|11,200
+
+|Number of namespaces
+|2,250
+
+|Number of routes
+|4,500
+
+|Number of secrets
+|29,000
+
+|Number of config maps
+|34,000
+
+|Number of services
+|22,000
+
+|Number of pods per namespace
+|2,000
+
+|Number of services per namespace
+|1,000
+
+|Number of deployments per namespace
+|2,000
+|===

--- a/modules/rosa-planning-environment-cluster-max-considerations.adoc
+++ b/modules/rosa-planning-environment-cluster-max-considerations.adoc
@@ -1,0 +1,16 @@
+// Module included in the following assemblies:
+//
+// * rosa_planning/rosa-planning-environment.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="planning-environment-cluster-maximums-considerations_{context}"]
+= Considerations for cluster maximum tests
+
+[role="_abstract"]
+These tests measure individual OpenShift resource limits with dedicated workloads. The following considerations describe factors that can change the limits you observe in production compared with the published tested maximums.
+
+* *Idle pod baselines:* Metrics include `pause` pods and default cluster control plane pods on control plane nodes. Results use the `node-density` workload and change with active application load.
+* *Resource and I/O limitations:* Observed limits depend on workload intensity. For example, high-density I/O workloads (for example, PostgreSQL) or hitting the PVC-per-node ceiling can reduce the maximum stable pod count.
+* *Namespace composition:* Tests include default cluster operator namespaces. Each test namespace has idle pods, config maps, and secrets to model routine operational load.
+* *Service scalability:* Data reflects tested `ClusterIP` services with a single endpoint using the `cni-density` workload. Other service types can scale differently.
+* *Infrastructure and routing:* The test environment used two routers with default settings on dedicated {product-title} infrastructure nodes. Limits used the `cluster-density` workload.

--- a/modules/rosa-planning-environment-cluster-max-hcp.adoc
+++ b/modules/rosa-planning-environment-cluster-max-hcp.adoc
@@ -1,0 +1,51 @@
+// Module included in the following assemblies:
+//
+// * rosa_planning/rosa-planning-environment.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="planning-environment-tested-maximums-hcp_{context}"]
+= Tested cluster maximums for {product-title}
+
+[role="_abstract"]
+These tested maximums apply to {product-title} clusters. Use the table to plan worker nodes, namespaces, pods, and related objects within validated scale ranges.
+
+[options="header",cols="2,1"]
+|===
+|Maximum type |{product-title} tested maximum
+
+|Number of compute (worker) nodes
+|501
+
+|Number of pods
+|105,205
+
+|Number of pods per node
+|250
+
+|Number of deployments
+|22,600
+
+|Number of namespaces
+|4,500
+
+|Number of routes
+|9,000
+
+|Number of secrets
+|59,000
+
+|Number of config maps
+|68,000
+
+|Number of services
+|38,000
+
+|Number of pods per namespace
+|2,000
+
+|Number of services per namespace
+|1,000
+
+|Number of deployments per namespace
+|2,000
+|===

--- a/modules/rosa-planning-environment-cluster-max-overview.adoc
+++ b/modules/rosa-planning-environment-cluster-max-overview.adoc
@@ -1,0 +1,19 @@
+// Module included in the following assemblies:
+//
+// * rosa_planning/rosa-planning-environment.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="planning-environment-cluster-maximums_{context}"]
+= Planning your environment based on tested cluster maximums
+
+[role="_abstract"]
+You can use tested cluster maximums when you size {product-title} clusters and namespaces. These values are not hard limits or Red{nbsp}Hat supported ceilings for production.
+
+The following tables summarize the latest published tested maximums for your architecture.
+
+[NOTE]
+====
+These numbers come from internal Red{nbsp}Hat tests on the latest {product-title} clusters using default cluster tunings. Reaching or exceeding a number does not mean the cluster fails or degrade immediately.
+
+Each value reflects limits for individual OpenShift resources measured with separate workloads that target a few resource types at a time. The workloads do not reproduce every production load, but they target patterns that stay close to common customer use cases. Tests used the Cloud Native Computing Foundation (CNCF) workload orchestrator. For more information, see link:https://www.cncf.io/projects/kube-burner/[the project page for this orchestrator].
+====

--- a/rosa_planning/rosa-planning-environment.adoc
+++ b/rosa_planning/rosa-planning-environment.adoc
@@ -1,6 +1,5 @@
 :_mod-docs-content-type: ASSEMBLY
 include::_attributes/attributes-openshift-dedicated.adoc[]
-
 [id="rosa-planning-environment"]
 = Planning resource usage in your cluster
 :context: rosa-planning-environment
@@ -8,7 +7,15 @@ include::_attributes/attributes-openshift-dedicated.adoc[]
 toc::[]
 
 [role="_abstract"]
-This document describes how to plan your {product-title} environment based on the tested cluster maximums.
+This document describes how to plan your {product-title} environment based on tested cluster maximums.
 
-include::modules/rosa-planning-environment-cluster-max.adoc[leveloffset=+1]
+include::modules/rosa-planning-environment-cluster-max-overview.adoc[leveloffset=+1]
+ifdef::openshift-rosa[]
+include::modules/rosa-planning-environment-cluster-max-classic.adoc[leveloffset=+2]
+include::modules/rosa-planning-environment-cluster-max-considerations.adoc[leveloffset=+2]
+endif::openshift-rosa[]
+ifdef::openshift-rosa-hcp[]
+include::modules/rosa-planning-environment-cluster-max-hcp.adoc[leveloffset=+2]
+include::modules/rosa-planning-environment-cluster-max-considerations.adoc[leveloffset=+2]
+endif::openshift-rosa-hcp[]
 include::modules/rosa-planning-environment-application-reqs.adoc[leveloffset=+1]


### PR DESCRIPTION
This is a manual cherrypick of #111697 for `enterprise-4.22`