### PR TITLE
OSDOCS-19710: adds prompt federation MCP gateway

### DIFF
--- a/mcp_gateway_config/mcp-gateway-authorization.adoc
+++ b/mcp_gateway_config/mcp-gateway-authorization.adoc
@@ -7,8 +7,10 @@ include::_attributes/attributes.adoc[]
 toc::[]
 
 [role="_abstract"]
-You can configure authorization for the {mcpg} by using an additional `AuthPolicy` custom resource (CR) that adds access control for servers, data, and tools.
+You can configure authorization for the {mcpg} by using an additional `AuthPolicy` custom resource (CR) that adds access control for servers, data, tools, and prompts.
 
 include::modules/con-understanding-mcp-gateway-authorization.adoc[leveloffset=+1]
 
 include::modules/proc-mcp-gateway-authorization.adoc[leveloffset=+1]
+
+//TODO create authpolicy reference modules

--- a/mcp_gateway_config/mcp-gateway-creating-virtual-mcp-servers.adoc
+++ b/mcp_gateway_config/mcp-gateway-creating-virtual-mcp-servers.adoc
@@ -7,7 +7,7 @@ include::_attributes/attributes.adoc[]
 toc::[]
 
 [role="_abstract"]
-Create focused, curated tool collections from your aggregated internal and external MCP servers by creating virtual MCP servers from any of your registered MCP servers.
+Create focused, curated tool and prompt collections from your aggregated internal and external MCP servers by creating virtual MCP servers from any of your registered MCP servers.
 
 include::modules/con-register-virt-mcp-server.adoc[leveloffset=+1]
 

--- a/mcp_gateway_config/mcp-gateway-register-on-prem-mcp-servers.adoc
+++ b/mcp_gateway_config/mcp-gateway-register-on-prem-mcp-servers.adoc
@@ -9,6 +9,8 @@ toc::[]
 [role="_abstract"]
 To begin using MCP servers with your {mcpg}, you must register each server by creating an `HTTPRoute` custom resource (CR) and a corresponding `MCPServerRegistration` CR that references the route.
 
+include::modules/con-mcp-gateway-register-mcp-server.adoc[leveloffset=+1]
+
 include::modules/proc-mcp-gateway-register-mcp-server.adoc[leveloffset=+1]
 
 include::modules/ref-mcp-gateway-mcpserverregistration-cr.adoc[leveloffset=+2]

--- a/mcp_gateway_config/mcp-gateway-revoke-tool-access.adoc
+++ b/mcp_gateway_config/mcp-gateway-revoke-tool-access.adoc
@@ -8,6 +8,7 @@ toc::[]
 
 [role="_abstract"]
 You can revoke tool access for users and groups. Tool revocation prevents a user or group from calling specific MCP tools.
+//Q: can we revoke prompt access as well? If yes, is the process the same?
 
 include::modules/con-mcp-gateway-understand-tool-access-revocation.adoc[leveloffset=+1]
 

--- a/modules/con-mcp-gateway-register-mcp-server.adoc
+++ b/modules/con-mcp-gateway-register-mcp-server.adoc
@@ -1,0 +1,18 @@
+// Module included in the following assemblies:
+//
+// *mcp_gateway_config/mcp-gateway-register-servers.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="con-mcp-gateway-register-mcp-server_{context}"]
+= Understanding MCP server registration
+
+[role="_abstract"]
+You must register your MCP servers so that each server can be discovered and routed to by the MCP gateway.
+
+When you register a backend MCP server, you must define a `prefix` in the `MCPServerRegistration` custom resource (CR) for each tool and prompt name. Prefixing each MCP server's listed capabilities avoids name collisions with other MCP servers.
+
+The MCP gateway then automatically federates the MCP server's tools and prompts.
+
+To connect an MCP server to the MCP gateway, you must first create an `HTTPRoute` CR, and then create an `MCPServerRegistration` CR for the server that references the route.
+
+When a client calls a tool or requests a prompt, the MCP gateway identifies the target upstream server by the `prefix`, strips the `prefix`, then routes the request to the correct MCP server with authentication and authorization through an `AuthPolicy` CR.

--- a/modules/con-mcp-gateway-register-mcp-server.adoc
+++ b/modules/con-mcp-gateway-register-mcp-server.adoc
@@ -1,0 +1,18 @@
+// Module included in the following assemblies:
+//
+// *mcp_gateway_config/mcp-gateway-register-servers.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="con-register-mcp-server_{context}"]
+= Understanding MCP server registration
+
+[role="_abstract"]
+You must register your MCP servers so that each server can be discovered and routed to by the MCP gateway.
+
+When you register a backend MCP server, you must define a `prefix` in the `MCPServerRegistration` custom resource (CR) for each tool and prompt name. Prefixing each MCP server's listed capabilities avoids name collisions with other MCP servers.
+
+The MCP gateway then automatically federates the MCP server's tools and prompts.
+
+To connect an MCP server to MCP gateway, you must first create an `HTTPRoute` CR, then create an `MCPServerRegistration` CR for the server that references the route.
+
+When a client calls a tool or requests a prompt, the MCP gateway identifies the target upstream server by the `prefix`, strips the `prefix`, then routes the request to the correct MCP server with authentication and authorization through an `AuthPolicy` CR.

--- a/modules/con-mcp-gateway-understand-tool-access-revocation.adoc
+++ b/modules/con-mcp-gateway-understand-tool-access-revocation.adoc
@@ -17,7 +17,7 @@ You cannot revoke a specific in-flight token or revoke access instantly. JWT tok
 The following two enforcement points apply:
 
 * `tools/call`: The `AuthPolicy` custom resource (CR) CEL expression checks the `x-mcp-toolname` header against the user's `resource_access` roles. A revoked tool returns a `failed to create session for mcp server: failed to create client: transport error: server returned 4xx for initialize POST, likely a legacy SSE server` error.
-* `tools/list`: The broker filters the tools list using the signed `x-authorized-tools` header. A revoked tool is no longer displayed in the list.
+* `tools/list`: The broker filters the tools list by using the signed `x-mcp-authorized` header. A revoked tool is no longer displayed in the list.
 
 The timing of tool revocation depends on the following session events:
 

--- a/modules/con-register-virt-mcp-server.adoc
+++ b/modules/con-register-virt-mcp-server.adoc
@@ -8,14 +8,14 @@
 = About virtual MCP servers
 
 [role="_abstract"]
-When you aggregate all your MCP servers centrally, you solve for authentication, authorization, and configuration management. At the same time, this aggregation can overwhelm large-language models (LLMs) and AI agents with too many tool choices. You can create virtual MCP servers to curate tools for each situation.
+When you aggregate all your MCP servers centrally, you solve for authentication, authorization, and configuration management. At the same time, this aggregation can overwhelm large-language models (LLMs) and AI agents with too many tool and prompt choices. You can create virtual MCP servers to curate tools and prompts for each situation.
 
-You can narrow the scope for your agentic services and applications by creating virtual MCP servers that filter the complete tool list based on a curated selection and access only the relevant tools with HTTP headers. You can use virtual MCP servers to accomplish the following efficiencies:
+You can narrow the scope for your agentic services and applications by creating virtual MCP servers that filter the complete capabilities based on a curated selection and access only the relevant capabilities with HTTP headers. You can use virtual MCP servers to do the following:
 
 * Create specialized collections of tools for specific use cases.
-* Reduce the load on LLMs by presenting fewer, more relevant tools.
-* Group tools by function, for example, development tools, data analysis tools, and so on.
-* Make it easier for users and agents to find the right tools.
+* Reduce the load on LLMs by presenting fewer, more relevant tools and prompts.
+* Group tools and prompts by function, for example, development tools, data analysis tools, and so on.
+* Make it easier for users and agents to find the right tools and prompts.
 * Combine with authorization policies for fine-grained access management.
 
-Virtual MCP servers only filter which tools a client can discover by using the `tools/list` concept. Virtual MCP servers do not change `tools/call` routing or authorization.
+Virtual MCP servers only filter which tools and prompts a client can discover by using the `tools/list` and `prompts/list` concepts. Virtual MCP servers do not change call routing or authorization.

--- a/modules/con-understanding-mcp-gateway-authorization.adoc
+++ b/modules/con-understanding-mcp-gateway-authorization.adoc
@@ -7,20 +7,20 @@
 = Understanding authorization in {mcpg}
 
 [role="_abstract"]
-By setting up authorization in the MCP gateway, you can control which authenticated users can access specific MCP server tools. The MCP gateway supports authorization approaches including other policy engines and Gateway API policy extensions.
+By setting up authorization in the MCP gateway, you can control which authenticated users can access specific MCP server tools and prompts. The MCP gateway supports authorization approaches including other policy engines and Gateway API policy extensions.
 
 The following steps represent what happens during an authorization evaluation:
 
 * Authentication: A user authenticates and receives a JSON Web Token (JWT) with permissions.
 * Tool request: The client makes an MCP tool call, such as `tools/call`.
 * Request identity check: An `AuthPolicy` object verifies the JWT and extracts authorization claims.
-* Authorization check: A Common Expression Language (CEL) expression evaluates the requested tool against the user's permissions that were extracted from the JWT.
-* Access decision: `Allow` or `deny` based on the authorization check result.
+* Authorization check: A Common Expression Language (CEL) expression evaluates the requested tool against the user permissions extracted from the JWT.
+* Access decision: The final step is to `allow` or `deny` based on the authorization check result.
 
 To create an authorization evaluation, you must set up authentication, define permissions, and specify access control roles. For example, take the following steps if using {keycloak}:
 
 * Define your permissions and user claims. If you are using {keycloak}, you can add groups or attributes to the default JWT.
-* Provide tool-level authorization to control access to individual MCP tools.
+* Provide authorization to control access to individual MCP tools and prompts.
 * Define role-based access by using {keycloak} client roles and group bindings for permission decisions.
 * Configure your identity provider to include Access Control List (ACL) claims in the tokens it issues.
 * Define complex authorization logic using Common Expression Language expressions that evaluate the claims and decide whether to let them through.

--- a/modules/con-understanding-mcp-gateway-authorization.adoc
+++ b/modules/con-understanding-mcp-gateway-authorization.adoc
@@ -7,20 +7,20 @@
 = Understanding authorization in {mcpg}
 
 [role="_abstract"]
-By setting up authorization in the MCP gateway, you can control which authenticated users can access specific MCP server tools. The MCP gateway supports authorization approaches including other policy engines and Gateway API policy extensions.
+By setting up authorization in the MCP gateway, you can control which authenticated users can access specific MCP server tools and prompts. The MCP gateway supports authorization approaches including other policy engines and Gateway API policy extensions.
 
 The following steps represent what happens during an authorization evaluation:
 
 * Authentication: A user authenticates and receives a JSON Web Token (JWT) with permissions.
 * Tool request: The client makes an MCP tool call, such as `tools/call`.
 * Request identity check: An `AuthPolicy` object verifies the JWT and extracts authorization claims.
-* Authorization check: A Common Expression Language (CEL) expression evaluates the requested tool against the user's permissions that were extracted from the JWT.
+* Authorization check: A Common Expression Language (CEL) expression evaluates the requested tool against the user permissions extracted from the JWT.
 * Access decision: `Allow` or `deny` based on the authorization check result.
 
 To create an authorization evaluation, you must set up authentication, define permissions, and specify access control roles. For example, take the following steps if using {keycloak}:
 
 * Define your permissions and user claims. If you are using {keycloak}, you can add groups or attributes to the default JWT.
-* Provide tool-level authorization to control access to individual MCP tools.
+* Provide authorization to control access to individual MCP tools and prompts.
 * Define role-based access by using {keycloak} client roles and group bindings for permission decisions.
 * Configure your identity provider to include Access Control List (ACL) claims in the tokens it issues.
 * Define complex authorization logic using Common Expression Language expressions that evaluate the claims and decide whether to let them through.

--- a/modules/con-virt-mcp-server-auth-tool-filtering.adoc
+++ b/modules/con-virt-mcp-server-auth-tool-filtering.adoc
@@ -4,16 +4,16 @@
 
 :_mod-docs-content-type: CONCEPT
 [id="con-virt-mcp-server-auth-tool-filtering_{context}"]
-= About virtual MCP servers authorization and tool filtering
+= About virtual MCP servers authorization and filtering
 
 [role="_abstract"]
-If you have authentication and user-based tool filtering configured on your MCP servers, and then set up virtual MCP servers, the resulting tool list is the intersection of two filters.
+If you have authentication and user-based tool or prompt filtering configured on your MCP servers, and then set up virtual MCP servers, the resulting capabilities list is the intersection of the authentication and the filters.
 
 The `AuthPolicy` custom resource (CR) configurations you applied when you registered the MCP servers are used. You do not need to make additional configurations when creating virtual MCP servers.
 
-The MCP gateway broker component applies filters sequentially when handling a `tools/list` request with a virtual MCP server header. The following are the applied filters in order:
+The MCP gateway broker component applies filters sequentially when handling `tools/list` and `prompts/list` request` with a virtual MCP server header. The following are the applied filters in order:
 
-. Identity-based filtering: The `x-authorized-tools` header, injected by the `AuthPolicy` CR, reduces the tool list to only the tools that the user has `resource_access` roles configured for.
-. Virtual MCP server filtering: The `X-Mcp-Virtualserver` header further reduces the available-tools list to only those tools that are defined in the `MCPVirtualServer` CR.
+. Identity-based filtering: The `x-authorized-tools` header, injected by the `AuthPolicy` CR, reduces the tools and prompts list to only the capabilities that the user has `resource_access` roles configured for.
+. Virtual MCP server filtering: The `X-Mcp-Virtualserver` header further reduces the available-capabilities list to only those that you defined in the `MCPVirtualServer` CR.
 
 For example, if the `accounting` virtual server lists `test1_greet` and `test3_add`, but the user only has the `greet` role on `mcp-test/test-server1`, that user only sees the tool, `test1_greet`.

--- a/modules/con-virt-mcp-server-auth-tool-filtering.adoc
+++ b/modules/con-virt-mcp-server-auth-tool-filtering.adoc
@@ -4,16 +4,16 @@
 
 :_mod-docs-content-type: CONCEPT
 [id="con-virt-mcp-server-auth-tool-filtering_{context}"]
-= About virtual MCP servers authorization and tool filtering
+= About virtual MCP servers authorization and filtering
 
 [role="_abstract"]
-If you have authentication and user-based tool filtering configured on your MCP servers, and then set up virtual MCP servers, the resulting tool list is the intersection of two filters.
+If you have authentication and user-based tool or prompt filtering configured on your MCP servers, and then set up virtual MCP servers, the resulting capabilities list is the intersection of the authentication and the filters.
 
 The `AuthPolicy` custom resource (CR) configurations you applied when you registered the MCP servers are used. You do not need to make additional configurations when creating virtual MCP servers.
 
-The MCP gateway broker component applies filters sequentially when handling a `tools/list` request with a virtual MCP server header. The following are the applied filters in order:
+The MCP gateway broker component applies filters sequentially when handling `tools/list` and `prompts/list` requests with a virtual MCP server header. The following are the applied filters in order:
 
-. Identity-based filtering: The `x-authorized-tools` header, injected by the `AuthPolicy` CR, reduces the tool list to only the tools that the user has `resource_access` roles configured for.
-. Virtual MCP server filtering: The `X-Mcp-Virtualserver` header further reduces the available-tools list to only those tools that are defined in the `MCPVirtualServer` CR.
+. Identity-based filtering: The `x-mcp-authorized` header, injected by the `AuthPolicy` CR, reduces the tools and prompts list to only the capabilities that the user has `resource_access` roles configured for.
+. Virtual MCP server filtering: The `X-Mcp-Virtualserver` header further reduces the available-capabilities list to only those that you defined in the `MCPVirtualServer` CR.
 
 For example, if the `accounting` virtual server lists `test1_greet` and `test3_add`, but the user only has the `greet` role on `mcp-test/test-server1`, that user only sees the tool, `test1_greet`.

--- a/modules/proc-mcp-gateway-authorization.adoc
+++ b/modules/proc-mcp-gateway-authorization.adoc
@@ -28,26 +28,26 @@ The following example demonstrates using a Kuadrant `AuthPolicy` custom resource
 {
   "resource_access": {
     "mcp-ns/arithmetic-mcp-server": {
-      "roles": ["add", "sum", "multiply", "divide"]
+      "roles": ["add", "sum", "multiply", "divide", "prompt:math_tutor"]
     },
     "mcp-ns/geometry-mcp-server": {
-      "roles": ["area", "distance", "volume"]
+      "roles": ["area", "distance", "volume", "prompt:calculate_area"]
     }
   }
 }
 ----
 +
 * The `"mcp-ns/arithmetic-mcp-server"` specification must match the namespaced name of the `MCPServerRegistration` CR in the format `{namespace}/{name}`. For example, if your `MCPServerRegistration` CR is named `arithmetic-mcp-server` and is applied in the `mcp-ns` namespace, the {keycloak} client ID must be `mcp-ns/arithmetic-mcp-server`.
-* The `"roles": ["add", "sum", "multiply", "divide"]` parameter and values specify the roles representing the allowed tools.
+* The `"roles": ["add", "sum", "multiply", "divide", "prompt:<value>"]` parameter and values specify the roles representing the allowed tools and prompts.
 
-. Configure tool-level authorization by creating an `AuthPolicy` CR that enforces tool-level access control on the `mcps` listener, as shown in the following example:
+. Configure authorization by creating an `AuthPolicy` CR that enforces access control on the `mcps` listener, as shown in the following example:
 +
 [IMPORTANT]
 ====
 The authorization `AuthPolicy` CR must target the `mcps` listener, not the `mcp` listener. The `mcp` listener only handles public traffic and has an authentication-only `AuthPolicy` CR.
 ====
 +
-.Example tool-level access control AuthPolicy
+.Example tool and prompt access control AuthPolicy
 [source,yaml,subs="+quotes"]
 ----
 apiVersion: kuadrant.io/v1
@@ -68,10 +68,19 @@ spec:
           issuerUrl: https://_<keycloak.example.com>_/realms/mcp
     authorization:
       'tool-access-check':
+        when:
+          - predicate: "request.headers.exists(h, h == 'x-mcp-toolname')"
         patternMatching:
           patterns:
             - predicate: |
                 request.headers['x-mcp-toolname'] in (has(auth.identity.resource_access) && auth.identity.resource_access.exists(p, p == request.headers['x-mcp-servername']) ? auth.identity.resource_access[request.headers['x-mcp-servername']].roles : [])
+        'prompt-access-check':
+        when:
+          - predicate: "request.headers.exists(h, h == 'x-mcp-promptname')"
+        patternMatching:
+          patterns:
+            - predicate: |
+                ('prompt:' + request.headers['x-mcp-promptname']) in (has(auth.identity.resource_access) && auth.identity.resource_access.exists(p, p == request.headers['x-mcp-servername']) ? auth.identity.resource_access[request.headers['x-mcp-servername']].roles : [])
     response:
       unauthenticated:
         headers:
@@ -81,6 +90,7 @@ spec:
           value: |
             {
               "error": "Unauthorized",
+              "message": "MCP Access denied: Authentication required."
               "message": "MCP Tool Access denied: Authentication required."
             }
       unauthorized:
@@ -88,7 +98,7 @@ spec:
           value: |
             {
               "error": "Forbidden",
-              "message": "MCP Tool Access denied: Insufficient permissions for this tool."
+              "message": "MCP Access denied: Insufficient permissions."
             }
 ----
 +
@@ -97,20 +107,77 @@ spec:
 * Replace `spec.targetRef.name:` with the name of the `Gateway` CR.
 * The `spec.targetRef.sectionName:` value must be `mcps`, which is the internal listener for `tool/call` authorization. This listener must exist on your `Gateway` object.
 * Authentication: Validates the JWT token using the configured issuer URL. Replace `_<keycloak.example.com>_` with your identity provider hostname.
-* Authorization Logic: CEL expression checks if user's roles allow access to the requested tool
+* Authorization Logic: CEL expressions check if the user role allows access to the requested tool or prompt. The appropriate check is triggered based on the presence of the `x-mcp-toolname` or `x-mcp-promptname` header.
 * CEL Breakdown:
-** `request.headers['x-mcp-toolname']`: The name of the requested MCP tool, stripped from prefix.
+** `request.headers['x-mcp-toolname']`: The name of the requested MCP tool.
 ** `request.headers['x-mcp-servername']`: The namespaced name of the MCP server matching the `MCPServerRegistration` CR.
-** `auth.identity.resource_access`: The JWT claim containing all roles representing each allowed tool the user can access, grouped by MCP server.
+** `request.headers['x-mcp-promptname']`: The name of the requested MCP prompt.
+** `auth.identity.resource_access`: The JWT claim containing all roles representing each allowed capability, tool or prompt, that the user can access, grouped by MCP server.
 * Response handling: Custom `401` and `403` responses for unauthenticated and unauthorized access attempts.
 
-. Apply the AuthPolicy CR by running the following command:
+. Apply the `AuthPolicy` CR by running the following command:
 +
 [source,terminal,subs="+quotes"]
 ----
 $ oc apply -f _<mcp_tool_auth_policy.yaml>_
 ----
-* Replace `_<mcp_tool_auth_policy.yaml>_` with the name of the `AuthPolicy` YAML filename.
++
+Replace `_<mcp_tool_auth_policy.yaml>_` with the name of the `AuthPolicy` YAML filename.
+
+. Optional. Configure authorization by creating an `AuthPolicy` CR using an Open Policy Agent (OPA) rule, as shown in the following example:
++
+.Example `AuthPolicy` with an OPA rule
+[source,yaml,subs="+quotes"]
+----
+apiVersion: kuadrant.io/v1
+kind: AuthPolicy
+metadata:
+  name: _<mcp_tool_auth_policy>_
+  namespace: _<gateway_system>_
+spec:
+  targetRef:
+    group: gateway.networking.k8s.io
+    kind: Gateway
+    name: _<mcp_gateway>_
+    sectionName: _<mcps>_
+  rules:
+    authentication:
+      'sso-server':
+        jwt:
+          issuerUrl: https://_<keycloak.example.com>_/realms/mcp
+    authorization:
+      'authorized-capabilities':
+        opa:
+          rego: |
+            allow = true
+            capabilities = {
+              "tools": { server: tools |
+                server := object.keys(input.auth.identity.resource_access)[_]
+                tools := [substring(r, count("tool:"), -1) |
+                  r := input.auth.identity.resource_access[server].roles[_]
+                  startswith(r, "tool:")
+                ]
+              },
+              "prompts": { server: prompts |
+                server := object.keys(input.auth.identity.resource_access)[_]
+                prompts := [substring(r, count("prompt:"), -1) |
+                  r := input.auth.identity.resource_access[server].roles[_]
+                  startswith(r, "prompt:")
+                ]
+              }
+            }
+          allValues: true
+#...
+----
+
+. Apply the OPA `AuthPolicy` CR by running the following command:
++
+[source,terminal,subs="+quotes"]
+----
+$ oc apply -f _<mcp_tool_auth_policy.yaml>_
+----
++
+Replace `_<mcp_tool_auth_policy.yaml>_` with the name of the `AuthPolicy` YAML filename.
 
 .Verification
 

--- a/modules/proc-mcp-gateway-authorization.adoc
+++ b/modules/proc-mcp-gateway-authorization.adoc
@@ -28,26 +28,26 @@ The following example demonstrates using a Kuadrant `AuthPolicy` custom resource
 {
   "resource_access": {
     "mcp-ns/arithmetic-mcp-server": {
-      "roles": ["add", "sum", "multiply", "divide"]
+      "roles": ["add", "sum", "multiply", "divide", "prompt:math_tutor"]
     },
     "mcp-ns/geometry-mcp-server": {
-      "roles": ["area", "distance", "volume"]
+      "roles": ["area", "distance", "volume", "prompt:calculate_area"]
     }
   }
 }
 ----
 +
 * The `"mcp-ns/arithmetic-mcp-server"` specification must match the namespaced name of the `MCPServerRegistration` CR in the format `{namespace}/{name}`. For example, if your `MCPServerRegistration` CR is named `arithmetic-mcp-server` and is applied in the `mcp-ns` namespace, the {keycloak} client ID must be `mcp-ns/arithmetic-mcp-server`.
-* The `"roles": ["add", "sum", "multiply", "divide"]` parameter and values specify the roles representing the allowed tools.
+* The `"roles": ["add", "sum", "multiply", "divide", "prompt:<value>"]` parameter and values specify the roles representing the allowed tools and prompts.
 
-. Configure tool-level authorization by creating an `AuthPolicy` CR that enforces tool-level access control on the `mcps` listener, as shown in the following example:
+. Configure authorization by creating an `AuthPolicy` CR that enforces access control on the `mcps` listener, as shown in the following example:
 +
 [IMPORTANT]
 ====
 The authorization `AuthPolicy` CR must target the `mcps` listener, not the `mcp` listener. The `mcp` listener only handles public traffic and has an authentication-only `AuthPolicy` CR.
 ====
 +
-.Example tool-level access control AuthPolicy
+.Example tool and prompt access control AuthPolicy
 [source,yaml,subs="+quotes"]
 ----
 apiVersion: kuadrant.io/v1
@@ -68,10 +68,19 @@ spec:
           issuerUrl: https://_<keycloak.example.com>_/realms/mcp
     authorization:
       'tool-access-check':
+        when:
+          - predicate: "request.headers.exists(h, h == 'x-mcp-toolname')"
         patternMatching:
           patterns:
             - predicate: |
-                request.headers['x-mcp-toolname'] in (has(auth.identity.resource_access) && auth.identity.resource_access.exists(p, p == request.headers['x-mcp-servername']) ? auth.identity.resource_access[request.headers['x-mcp-servername']].roles : [])
+                ('tool:' + request.headers['x-mcp-toolname']) in (has(auth.identity.resource_access) && auth.identity.resource_access.exists(p, p == request.headers['x-mcp-servername']) ? auth.identity.resource_access[request.headers['x-mcp-servername']].roles : [])
+      'prompt-access-check':
+        when:
+          - predicate: "request.headers.exists(h, h == 'x-mcp-promptname')"
+        patternMatching:
+          patterns:
+            - predicate: |
+                ('prompt:' + request.headers['x-mcp-promptname']) in (has(auth.identity.resource_access) && auth.identity.resource_access.exists(p, p == request.headers['x-mcp-servername']) ? auth.identity.resource_access[request.headers['x-mcp-servername']].roles : [])
     response:
       unauthenticated:
         headers:
@@ -81,14 +90,14 @@ spec:
           value: |
             {
               "error": "Unauthorized",
-              "message": "MCP Tool Access denied: Authentication required."
+              "message": "MCP Access denied: Authentication required."
             }
       unauthorized:
         body:
           value: |
             {
               "error": "Forbidden",
-              "message": "MCP Tool Access denied: Insufficient permissions for this tool."
+              "message": "MCP Access denied: Insufficient permissions."
             }
 ----
 +
@@ -97,20 +106,77 @@ spec:
 * Replace `spec.targetRef.name:` with the name of the `Gateway` CR.
 * The `spec.targetRef.sectionName:` value must be `mcps`, which is the internal listener for `tool/call` authorization. This listener must exist on your `Gateway` object.
 * Authentication: Validates the JWT token using the configured issuer URL. Replace `_<keycloak.example.com>_` with your identity provider hostname.
-* Authorization Logic: CEL expression checks if user's roles allow access to the requested tool
+* Authorization Logic: CEL expressions check if the user role allows access to the requested tool or prompt. The appropriate check is triggered based on the presence of the `x-mcp-toolname` or `x-mcp-promptname` header.
 * CEL Breakdown:
-** `request.headers['x-mcp-toolname']`: The name of the requested MCP tool, stripped from prefix.
+** `request.headers['x-mcp-toolname']`: The name of the requested MCP tool.
 ** `request.headers['x-mcp-servername']`: The namespaced name of the MCP server matching the `MCPServerRegistration` CR.
-** `auth.identity.resource_access`: The JWT claim containing all roles representing each allowed tool the user can access, grouped by MCP server.
+** `request.headers['x-mcp-promptname']`: The name of the requested MCP prompt.
+** `auth.identity.resource_access`: The JWT claim containing all roles representing each allowed capability, tool or prompt, that the user can access, grouped by MCP server.
 * Response handling: Custom `401` and `403` responses for unauthenticated and unauthorized access attempts.
 
-. Apply the AuthPolicy CR by running the following command:
+. Apply the `AuthPolicy` CR by running the following command:
 +
 [source,terminal,subs="+quotes"]
 ----
 $ oc apply -f _<mcp_tool_auth_policy.yaml>_
 ----
-* Replace `_<mcp_tool_auth_policy.yaml>_` with the name of the `AuthPolicy` YAML filename.
++
+Replace `_<mcp_tool_auth_policy.yaml>_` with the name of the `AuthPolicy` YAML filename.
+
+. Optional. Configure authorization by creating an `AuthPolicy` CR using an Open Policy Agent (OPA) rule, as shown in the following example:
++
+.Example `AuthPolicy` with an OPA rule
+[source,yaml,subs="+quotes"]
+----
+apiVersion: kuadrant.io/v1
+kind: AuthPolicy
+metadata:
+  name: _<mcp_tool_auth_policy>_
+  namespace: _<gateway_system>_
+spec:
+  targetRef:
+    group: gateway.networking.k8s.io
+    kind: Gateway
+    name: _<mcp_gateway>_
+    sectionName: _<mcps>_
+  rules:
+    authentication:
+      'sso-server':
+        jwt:
+          issuerUrl: https://_<keycloak.example.com>_/realms/mcp
+    authorization:
+      'authorized-capabilities':
+        opa:
+          rego: |
+            allow = true
+            capabilities = {
+              "tools": { server: tools |
+                server := object.keys(input.auth.identity.resource_access)[_]
+                tools := [substring(r, count("tool:"), -1) |
+                  r := input.auth.identity.resource_access[server].roles[_]
+                  startswith(r, "tool:")
+                ]
+              },
+              "prompts": { server: prompts |
+                server := object.keys(input.auth.identity.resource_access)[_]
+                prompts := [substring(r, count("prompt:"), -1) |
+                  r := input.auth.identity.resource_access[server].roles[_]
+                  startswith(r, "prompt:")
+                ]
+              }
+            }
+          allValues: true
+#...
+----
+
+. Apply the OPA `AuthPolicy` CR by running the following command:
++
+[source,terminal,subs="+quotes"]
+----
+$ oc apply -f _<mcp_tool_auth_policy.yaml>_
+----
++
+Replace `_<mcp_tool_auth_policy.yaml>_` with the name of the `AuthPolicy` YAML filename.
 
 .Verification
 

--- a/modules/proc-mcp-gateway-create-virt-mcp-server.adoc
+++ b/modules/proc-mcp-gateway-create-virt-mcp-server.adoc
@@ -15,6 +15,11 @@ An `MCPVirtualServer` CR must contain the following information:
 * Description: A human-readable description of the virtual MCP server's purpose.
 * Access method: Tools are accessed by the `X-Mcp-Virtualserver` header with the `namespace/name` format.
 
+[NOTE]
+====
+Prompt selection is optional. Specify which prompts from the aggregated pool to expose. Prompts are accessed by the `X-Mcp-Virtualserver` header with the `namespace/name` format.
+====
+
 .Prerequisites
 
 * You completed all of the installation and configuration steps for {mcpg}.
@@ -54,7 +59,7 @@ $ oc apply -f _<mcpvs_devtools.yaml>_
 +
 Replace `_<mcpvs_devtools.yaml>_` with the name of your CR.
 
-. Create an `MCPVirtualServer` CR for a virtual server that curates data analysis tools by using the following example:
+. Create an `MCPVirtualServer` CR for a virtual server that curates data analysis tools and prompts by using the following example:
 +
 .Example data analysis tools MCPVirtualServer CR
 [source,yaml,subs="+quotes"]
@@ -70,11 +75,14 @@ spec:
   - mcpserver2_time
   - mcpserver2_dozen
   - mcpserver1_get_stats
+  prompts:
+  - test2_data_summary
 ----
 +
 * Replace the `metadata.name:` value with the name you want to use.
 * Replace the `metadata.namespace:` value with the namespace you want to use. The `metadata.namespace:` value can be any namespace where you have permission to create resources.
 * Replace the list values in `spec.tools:` with the names of the tools you want to curate to this CR.
+* Replace the list values in `spec.prompts:` with the names of the prompts you want to curate to this CR.
 
 . Apply the CR by running the following command:
 +
@@ -87,4 +95,4 @@ Replace `_<mcpvs_datatools.yaml>_` with the name of your CR.
 
 .Next step
 
-* Verify that your virtual MCP servers are returning the tools you expect to see by following the instructions in "Verifying virtual MCP servers".
+* Verify that your virtual MCP servers are returning the tools and prompts that you expect to see by following the instructions in "Verifying virtual MCP servers".

--- a/modules/proc-mcp-gateway-filter-revoked-tools-display.adoc
+++ b/modules/proc-mcp-gateway-filter-revoked-tools-display.adoc
@@ -4,10 +4,10 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="proc-mcp-gateway-filter-revoked-tools-display_{context}"]
-= Filtering revoked tools from tools/list display
+= Filtering revoked tools and prompts from display
 
 [role="_abstract"]
-After you revoke a tool by using your identity provider, `tools/call` requests are blocked. However, the revoked tool is still displayed in `tools/list` responses. To filter revoked tools from the displayed list, you must give the MCP broker component a signed header that carries the user's authorized tools.
+After you revoke a tool or prompt by using your identity provider, requests are blocked. However, the revoked capability is still displayed in responses. To filter revoked tools and prompts from the displayed list, you must give the MCP broker component a signed header that carries the user's authorized capabilities.
 
 You can remove blocked tools from responses by configuring the Authorino Operator to generate the header by using a wristband JWT signed with an ECDSA key pair.
 
@@ -49,7 +49,7 @@ $ oc create secret generic trusted-headers-private-key \
   --dry-run=client -o yaml | oc apply -f -
 ----
 +
-Replace `_<kuadrant_system>_` with the namespace where {prodname} is installed.
+Replace `_<kuadrant_system>_` with the namespace where you installed {prodname}.
 
 . Create a Kubernetes `Secret` object in the MCP broker component namespace by adding the public key with the following command:
 +
@@ -78,7 +78,7 @@ $ oc delete authpolicy _<mcp_authn_policy>_ -n _<authn_namespace>_ --ignore-not-
 You must delete the `AuthPolicy` CR and create a new one. Using `$ oc apply` merges both the new and old policies.
 ====
 
-. Generate a new `x-authorized-tools` header by creating and applying a new `AuthPolicy` CR. Use the following example:
+. Generate a new `x-mcp-authorized` header by creating and applying a new `AuthPolicy` CR. Use the following example:
 +
 .Example AuthPolicy CR
 [source,yaml]
@@ -107,22 +107,37 @@ spec:
         patternMatching:
           patterns:
           - predicate: |
-              !request.headers.exists(h, h == 'x-mcp-method') || (request.headers['x-mcp-method'] in ["tools/list","initialize","notifications/initialized"])
-      'authorized-tools':
+              !request.headers.exists(h, h == 'x-mcp-method') || (request.headers['x-mcp-method'] in ["tools/list","prompts/list","initialize","notifications/initialized"])
+      'authorized-capabilities':
         opa:
           rego: |
             allow = true
-            tools = { server: roles | server := object.keys(input.auth.identity.resource_access)[_]; roles := object.get(input.auth.identity.resource_access, server, {}).roles }
+            capabilities = {
+              "tools": { server: tools |
+                server := object.keys(input.auth.identity.resource_access)[_]
+                tools := [substring(r, count("tool:"), -1) |
+                  r := input.auth.identity.resource_access[server].roles[_]
+                  startswith(r, "tool:")
+                ]
+              },
+              "prompts": { server: prompts |
+                server := object.keys(input.auth.identity.resource_access)[_]
+                prompts := [substring(r, count("prompt:"), -1) |
+                  r := input.auth.identity.resource_access[server].roles[_]
+                  startswith(r, "prompt:")
+                ]
+              }
+            }
           allValues: true
     response:
       success:
         headers:
-          x-authorized-tools:
+          x-mcp-authorized:
             wristband:
               issuer: 'authorino'
               customClaims:
-                'allowed-tools':
-                  selector: auth.authorization.authorized-tools.tools.@tostr
+                'allowed-capabilities':
+                  selector: auth.authorization.authorized-capabilities.capabilities.@tostr
               tokenDuration: 300
               signingKeyRefs:
                 - name: trusted-headers-private-key

--- a/modules/proc-mcp-gateway-register-mcp-server.adoc
+++ b/modules/proc-mcp-gateway-register-mcp-server.adoc
@@ -60,10 +60,10 @@ spec:
 +
 [source,terminal,subs="+quotes"]
 ----
-$ oc apply -f _<mcp_api_key_server_route>_
+$ oc apply -f _<mcp_api_key_server_route.yaml>_
 ----
 +
-Replace `_<mcp_api_key_server_route>_` with the name of the http route you created.
+Replace `_<mcp_api_key_server_route.yaml>_` with the name of the http route you created.
 
 . Create an `MCPServerRegistration` CR that references your `HTTPRoute` CR by using the following template:
 +
@@ -76,7 +76,7 @@ metadata:
   name: _<mcp_server_one>_
   namespace: _<mcp_test>_
 spec:
-  toolPrefix: _<serverone_>_
+  prefix: _<serverone_>_
   targetRef:
     group: "gateway.networking.k8s.io"
     kind: "HTTPRoute"
@@ -88,7 +88,7 @@ spec:
 ----
 +
 * Replace the `metadata.name:` and `metadata.namespace:` field values with the ones you want to use. If you did not use a `ReferenceGrant` CR, the value of `metadata.namespace:` must be the same as specified in the `HTTPRoute` object.
-* Replace the `spec.toolPrefix:` field with the value that you want to prefix the tools available with this MCP server.
+* Replace the `spec.prefix:` field with the value that you want to prefix the tools available with this MCP server.
 * Replace the `spec.targetRef.name field` value with the name of the `HTTPRoute` CR you applied. In this example, `_<mcp_api_key_server_route>_` is used.
 * Replace the `spec.targetRef.namespace:` field value with the namespace where your `HTTPRoute` CR is applied. In this example, `_<mcp_test>_` is used.
 * Replace the `credentialRef.name:` field value with the name of your `Secret` CR. In this example, `_<mcp_server_one_secret>_` is used. You can omit this parameter if your MCP server does not require authentication or authorization.
@@ -96,17 +96,17 @@ spec:
 +
 [IMPORTANT]
 ====
-A `toolPrefix` value can only contain alphanumeric characters, hyphens (-), and underscores (_).
+A `prefix` value can only contain alphanumeric characters, hyphens (-), and underscores (_).
 ====
 
 . Apply the CR by running the following command:
 +
 [source,terminal,subs="+quotes"]
 ----
-$ oc apply -f _<mcp_server_one>_
+$ oc apply -f _<mcp_server_one.yaml>_
 ----
 +
-Replace `_<mcp_server_one>_` with the `name` of your `MCPServerRegistration` CR.
+Replace `_<mcp_server_one.yaml>_` with your `MCPServerRegistration` CR.
 
 . Check the status of your current `MCPServerRegistration` CR by running the following command:
 +
@@ -157,7 +157,7 @@ items:
   metadata:
     annotations:
       kubectl.kubernetes.io/last-applied-configuration: |
-        {"apiVersion":"mcp.kuadrant.io/v1alpha1","kind":"MCPServerRegistration","metadata":{"annotations":{},"labels":{"mcp.kuadrant.io/managed":"true"},"name":"test-server1","namespace":"mcp-test"},"spec":{"targetRef":{"group":"gateway.networking.k8s.io","kind":"HTTPRoute","name":"mcp-server1-route"},"toolPrefix":"test1_"}}
+        {"apiVersion":"mcp.kuadrant.io/v1alpha1","kind":"MCPServerRegistration","metadata":{"annotations":{},"labels":{"mcp.kuadrant.io/managed":"true"},"name":"test-server1","namespace":"mcp-test"},"spec":{"targetRef":{"group":"gateway.networking.k8s.io","kind":"HTTPRoute","name":"mcp-server1-route"},"prefix":"test1_"}}
     creationTimestamp: "2026-03-31T09:50:26Z"
     finalizers:
     - mcp.kuadrant.io/finalizer
@@ -174,7 +174,7 @@ items:
       group: gateway.networking.k8s.io
       kind: HTTPRoute
       name: mcp-server1-route
-    toolPrefix: test1_
+    prefix: test1_
   status:
     conditions:
     - lastTransitionTime: "2026-04-07T08:49:53Z"

--- a/modules/proc-mcp-gateway-register-mcp-server.adoc
+++ b/modules/proc-mcp-gateway-register-mcp-server.adoc
@@ -60,10 +60,10 @@ spec:
 +
 [source,terminal,subs="+quotes"]
 ----
-$ oc apply -f _<mcp_api_key_server_route>_
+$ oc apply -f _<mcp_api_key_server_route.yaml>_
 ----
 +
-Replace `_<mcp_api_key_server_route>_` with the name of the http route you created.
+Replace `_<mcp_api_key_server_route.yaml>_` with the name of the http route you created.
 
 . Create an `MCPServerRegistration` CR that references your `HTTPRoute` CR by using the following template:
 +
@@ -76,7 +76,7 @@ metadata:
   name: _<mcp_server_one>_
   namespace: _<mcp_test>_
 spec:
-  toolPrefix: _<serverone_>_
+  prefix: _<serverone_>_
   targetRef:
     group: "gateway.networking.k8s.io"
     kind: "HTTPRoute"
@@ -88,7 +88,7 @@ spec:
 ----
 +
 * Replace the `metadata.name:` and `metadata.namespace:` field values with the ones you want to use. If you did not use a `ReferenceGrant` CR, the value of `metadata.namespace:` must be the same as specified in the `HTTPRoute` object.
-* Replace the `spec.toolPrefix:` field with the value that you want to prefix the tools available with this MCP server.
+* Replace the `spec.prefix:` field with the value that you want to prefix the tools available with this MCP server.
 * Replace the `spec.targetRef.name field` value with the name of the `HTTPRoute` CR you applied. In this example, `_<mcp_api_key_server_route>_` is used.
 * Replace the `spec.targetRef.namespace:` field value with the namespace where your `HTTPRoute` CR is applied. In this example, `_<mcp_test>_` is used.
 * Replace the `credentialRef.name:` field value with the name of your `Secret` CR. In this example, `_<mcp_server_one_secret>_` is used. You can omit this parameter if your MCP server does not require authentication or authorization.
@@ -96,17 +96,19 @@ spec:
 +
 [IMPORTANT]
 ====
-A `toolPrefix` value can only contain alphanumeric characters, hyphens (-), and underscores (_).
+The `prefix` field only accepts lowercase letters (`a-z`), digits (`0-9`), and underscores (`_`). The value must start with a letter or digit. This is enforced at the CRD schema level.
+
+Existing `MCPServerRegistration` CRs with non-conforming prefixes continue to function but cannot be updated. To update such resources, delete and re-create them with a conforming prefix.
 ====
 
 . Apply the CR by running the following command:
 +
 [source,terminal,subs="+quotes"]
 ----
-$ oc apply -f _<mcp_server_one>_
+$ oc apply -f _<mcp_server_one.yaml>_
 ----
 +
-Replace `_<mcp_server_one>_` with the `name` of your `MCPServerRegistration` CR.
+Replace `_<mcp_server_one.yaml>_` with your `MCPServerRegistration` CR.
 
 . Check the status of your current `MCPServerRegistration` CR by running the following command:
 +
@@ -157,7 +159,7 @@ items:
   metadata:
     annotations:
       kubectl.kubernetes.io/last-applied-configuration: |
-        {"apiVersion":"mcp.kuadrant.io/v1alpha1","kind":"MCPServerRegistration","metadata":{"annotations":{},"labels":{"mcp.kuadrant.io/managed":"true"},"name":"test-server1","namespace":"mcp-test"},"spec":{"targetRef":{"group":"gateway.networking.k8s.io","kind":"HTTPRoute","name":"mcp-server1-route"},"toolPrefix":"test1_"}}
+        {"apiVersion":"mcp.kuadrant.io/v1alpha1","kind":"MCPServerRegistration","metadata":{"annotations":{},"labels":{"mcp.kuadrant.io/managed":"true"},"name":"test-server1","namespace":"mcp-test"},"spec":{"targetRef":{"group":"gateway.networking.k8s.io","kind":"HTTPRoute","name":"mcp-server1-route"},"prefix":"test1_"}}
     creationTimestamp: "2026-03-31T09:50:26Z"
     finalizers:
     - mcp.kuadrant.io/finalizer
@@ -174,7 +176,7 @@ items:
       group: gateway.networking.k8s.io
       kind: HTTPRoute
       name: mcp-server1-route
-    toolPrefix: test1_
+    prefix: test1_
   status:
     conditions:
     - lastTransitionTime: "2026-04-07T08:49:53Z"

--- a/modules/proc-mcp-gateway-revoking-tools-call-requests.adoc
+++ b/modules/proc-mcp-gateway-revoking-tools-call-requests.adoc
@@ -4,12 +4,12 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="proc-mcp-gateway-revoking-tool-call-requests_{context}"]
-= Revoking tools/call requests
+= Revoking tool and prompt call requests
 
 [role="_abstract"]
-Use your existing authorization setup to revoke `tools/call` requests for individual users and groups by removing the tool role from the user or group in your identity provider.
+Use your existing authorization setup to revoke tool and prompt requests for individual users and groups by removing either role from the user or group in your identity provider.
 
-In this example, {keycloak} is used. Remove the client-role mapping. The client name corresponds to the namespaced MCPServerRegistration custom resource (CR), such as `mcp-test/test-server1`. Each role represents a tool name, such as `greet`, or `headers`.
+In this example, {keycloak} is used. Remove the client-role mapping. The client name corresponds to the namespaced MCPServerRegistration custom resource (CR), such as `mcp-test/test-server1`. Each role represents a tool name, such as `greet`, or `headers`. Use the same process for prompts.
 
 .Prerequisites
 

--- a/modules/proc-mcp-gateway-revoking-tools-call-requests.adoc
+++ b/modules/proc-mcp-gateway-revoking-tools-call-requests.adoc
@@ -4,10 +4,15 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="proc-mcp-gateway-revoking-tool-call-requests_{context}"]
-= Revoking tools/call requests
+= Revoking tool and prompt call requests
 
 [role="_abstract"]
 Use your existing authorization setup to revoke `tools/call` requests for individual users and groups by removing the tool role from the user or group in your identity provider.
+
+[TIP]
+====
+Use the same method to revoke `prompts/call` requests for individual users and groups by removing the prompt role from the user or group in your identity provider.
+====
 
 In this example, {keycloak} is used. Remove the client-role mapping. The client name corresponds to the namespaced MCPServerRegistration custom resource (CR), such as `mcp-test/test-server1`. Each role represents a tool name, such as `greet`, or `headers`.
 

--- a/modules/proc-mcp-gateway-ts-on-prem-mcp-server.adoc
+++ b/modules/proc-mcp-gateway-ts-on-prem-mcp-server.adoc
@@ -172,19 +172,19 @@ $ oc logs -n _<mcp_system>_ -l app.kubernetes.io/name=_<mcp_gateway>_
 
 . Ensure that your backend MCP server is returning valid MCP protocol responses. Using the MCP Conformance Test Framework is the easiest way to catch protocol errors.
 
-. Verify that the `toolPrefix` entry in the `MCPServerRegistration` CR is valid, meaning that there are no spaces or special characters.
+. Verify that the `prefix` entry in the `MCPServerRegistration` CR is valid, meaning that there are no spaces or special characters.
 
 . If tools appear without the configured prefix, check the `MCPServerRegistration` CR by running the following command:
 +
 [source,terminal,subs="+quotes"]
 ----
-$ oc get mcpsr _<mcpsr_name>_ -n _<mcpsr_namespace>_ -o yaml | grep toolPrefix
+$ oc get mcpsr _<mcpsr_name>_ -n _<mcpsr_namespace>_ -o yaml | grep prefix
 ----
 +
 * Replace `_<mcpsr_name>_` with the name of your MCP server.
 * Replace `_<mcpsr_namespace>_` with the namespace where your `MCPServerRegistration` CR is applied.
 
-.. Ensure that a `toolPrefix` is set correctly in `MCPServerRegistration` CR.
+.. Ensure that a `prefix` is set correctly in `MCPServerRegistration` CR.
 
 . Check the MCP gateway controller component logs for problems with your `MCPServerRegistration` CR by running the following command:
 +

--- a/modules/proc-mcp-gateway-verify-mcp-server-registration.adoc
+++ b/modules/proc-mcp-gateway-verify-mcp-server-registration.adoc
@@ -8,12 +8,12 @@
 = Verifying an MCP server registration
 
 [role="_abstract"]
-You can test that your MCP server tools are available through the MCP gateway by starting a session and listing available tools.
+You can test that your MCP server tools are available through the MCP gateway by starting a session and listing available tools and prompts.
 
 .Prerequisites
 
-* You registered the MCP server you want to verify.
 * You completed all {mcpg} installation and configuration steps.
+* You registered the MCP server you want to verify.
 
 .Procedure
 
@@ -26,7 +26,7 @@ $ curl -s -D /tmp/mcp_headers -X POST http://_<example.com>_/mcp \
   -d '{"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {"protocolVersion": "2025-11-25", "capabilities": {}, "clientInfo": {"name": "test-client", "version": "1.0.0"}}}'
 ----
 +
-Replace _<example.com>_ with your URL and port.
+Replace `_<example.com>_` with your URL and port.
 
 . Extract the MCP session ID from the dumped response headers by running the following command:
 +
@@ -46,8 +46,46 @@ $ curl -X POST http://_<example.com>_/mcp \
   -d '{"jsonrpc": "2.0", "id": 2, "method": "tools/list"}'
 ----
 +
-Replace _<example.com>_ with your URL and port.
-Your MCP server tools are listed in the response, prefixed with the `toolPrefix` value you configured in the `MCPServerRegistration` CR.
+Replace `_<example.com>_` with your URL and port.
+
+. Expected output: Your MCP server tools are listed in the response, prefixed with the `prefix` value you configured in the `MCPServerRegistration` CR.
+
+. Verify that your MCP server prompts are also available by running the following command:
++
+[source,terminal]
+----
+# Use the same SESSION_ID from the previous step
+curl -X POST http://_<example.com>_/mcp \
+  -H "Content-Type: application/json" \
+  -H "mcp-session-id: $SESSION_ID" \
+  -d '{"jsonrpc": "2.0", "id": 3, "method": "prompts/list"}'
+----
++
+Replace `_<example.com>_` with your URL and port.
+
+. Expected output: Your MCP server prompts are listed in the response, prefixed with the `prefix` value you configured in the `MCPServerRegistration` CR.
+
+. Retrieve a specific prompt by using the `prompts/get` method with the prefixed name as shown in the following command:
++
+[source,terminal]
+----
+$ curl -X POST http://_<example.com>_/mcp \
+  -H "Content-Type: application/json" \
+  -H "mcp-session-id: $SESSION_ID" \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": 4,
+    "method": "prompts/get",
+    "params": {
+      "name": "myserver_gh_pr_review",
+      "arguments": {
+        "pr_number": "42"
+      }
+    }
+  }'
+----
++
+Replace `_<example.com>_` with your URL and port.
 
 . Clean up by running the following command:
 +

--- a/modules/proc-register-ext-mcp-server-mcpserverregistration.adoc
+++ b/modules/proc-register-ext-mcp-server-mcpserverregistration.adoc
@@ -31,7 +31,7 @@ metadata:
   name: _<external_mcp_server>_
   namespace: _<mcp_test>_
 spec:
-  toolPrefix: _<"extserver_">_
+  prefix: _<"extserver_">_
   targetRef:
     group: "gateway.networking.k8s.io"
     kind: "HTTPRoute"
@@ -44,14 +44,14 @@ spec:
 +
 * Replace the `metadata.name:` field value with the name you want to use.
 * Replace the `metadata.namespace:` field value with the namespace you need to use. If you did not use a `ReferenceGrant` CR, the value of `metadata.namespace:` must be the same as the namepsace specified in the `HTTPRoute` object.
-* Replace the `spec.toolPrefix:` field with the value that you want to use to prefix the tools available with this MCP server.
+* Replace the `spec.prefix:` field with the value that you want to use to prefix the tools available with this MCP server.
 * Replace the `spec.targetRef.name:` field value with the name of the `HTTPRoute` CR you applied.
 * Replace the value of `spec.targetRef.namespace:` with the namespace where your `HTTPRoute` CR is applied.
 * The `spec.credentialRef:` field points to the `Secret` CR that has credentials for the external MCP server.
 +
 [IMPORTANT]
 ====
-A `toolPrefix` value cannot include spaces or special characters.
+A `prefix` value cannot include spaces or special characters.
 ====
 
 . Apply the CR by running the following command:

--- a/modules/proc-register-ext-mcp-server-mcpserverregistration.adoc
+++ b/modules/proc-register-ext-mcp-server-mcpserverregistration.adoc
@@ -31,7 +31,7 @@ metadata:
   name: _<external_mcp_server>_
   namespace: _<mcp_test>_
 spec:
-  toolPrefix: _<"extserver_">_
+  prefix: _<"extserver_">_
   targetRef:
     group: "gateway.networking.k8s.io"
     kind: "HTTPRoute"
@@ -43,15 +43,15 @@ spec:
 ----
 +
 * Replace the `metadata.name:` field value with the name you want to use.
-* Replace the `metadata.namespace:` field value with the namespace you need to use. If you did not use a `ReferenceGrant` CR, the value of `metadata.namespace:` must be the same as the namepsace specified in the `HTTPRoute` object.
-* Replace the `spec.toolPrefix:` field with the value that you want to use to prefix the tools available with this MCP server.
+* Replace the `metadata.namespace:` field value with the namespace you need to use. If you did not use a `ReferenceGrant` CR, the value of `metadata.namespace:` must be the same as the namespace specified in the `HTTPRoute` object.
+* Replace the `spec.prefix:` field with the value that you want to use to prefix the tools available with this MCP server.
 * Replace the `spec.targetRef.name:` field value with the name of the `HTTPRoute` CR you applied.
 * Replace the value of `spec.targetRef.namespace:` with the namespace where your `HTTPRoute` CR is applied.
 * The `spec.credentialRef:` field points to the `Secret` CR that has credentials for the external MCP server.
 +
 [IMPORTANT]
 ====
-A `toolPrefix` value cannot include spaces or special characters.
+A `prefix` value cannot include spaces or special characters.
 ====
 
 . Apply the CR by running the following command:

--- a/modules/proc-verify-virt-mcp-server.adoc
+++ b/modules/proc-verify-virt-mcp-server.adoc
@@ -7,7 +7,7 @@
 = Verifying virtual MCP servers
 
 [role="_abstract"]
-After you create your virtual MCP servers, you can check that they are returning the tool lists that you want.
+After you create your virtual MCP servers, you can check that they are returning the tool and prompt lists that you want.
 
 .Prerequisites
 
@@ -37,7 +37,7 @@ $ curl -s -D /tmp/mcp_headers -X POST _<http:example.com:port/mcp>_ \
   -d '{"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {"protocolVersion": "2025-11-25", "capabilities": {}, "clientInfo": {"name": "test-client", "version": "1.0.0"}}}'
 ----
 +
-* Replace `_<http:example.com:port/mcp>_` with the target URL and MCP gateway endpoint.
+Replace `_<http:example.com:port/mcp>_` with the target URL and MCP gateway endpoint.
 +
 .Example output
 [source,json]
@@ -116,4 +116,21 @@ $ curl -X POST _<http:example.com:port/mcp>_ \
   -d '{"jsonrpc": "2.0", "id": 1, "method": "tools/list"}' | jq '.result.tools[].name'
 ----
 +
-The expected response is a list of all tools from all registered MCP servers.
+* Replace `_<http:example.com:port/mcp>_` with the target URL and MCP gateway endpoint.
+* The expected response is a list of all tools from all registered MCP servers.
+
+. Request prompts from the `data_tools` MCP virtual server by running the following command:
++
+[source,terminal,subs="+quotes"]
+----
+$ curl -X POST _<http:example.com:port/mcp>_ \
+  -H "Content-Type: application/json" \
+  -H "mcp-session-id: $SESSION_ID" \
+  -H "X-Mcp-Virtualserver: _<mcp_system/data_tools>_" \
+  -d '{"jsonrpc": "2.0", "id": 1, "method": "prompts/list"}' | jq '.result.prompts[].name'
+----
++
+* Replace `_<http:example.com:port/mcp>_` with the target URL and MCP gateway endpoint.
+* Replace `_<mcp_system>_` with the namespace of the MCP gateway.
+* Replace `_<data_tools>_` with the tool headers that you want to request.
+* The expected response is a list of only those prompts specified in the `data_tools` virtual server.

--- a/modules/ref-mcp-gateway-mcpserverregistration-cr.adoc
+++ b/modules/ref-mcp-gateway-mcpserverregistration-cr.adoc
@@ -28,7 +28,7 @@ You can explore the required parts and values for an `MCPServerRegistration` cus
 |*Field* |*Type* |*Required* |*Description*
 |`targetRef` |TargetReference |Yes |An `HTTPRoute` object that points to a backend MCP server. The controller discovers the backend service from this `HTTPRoute` CR and configures the broker to consolidate the MCP server's tools.
 
-|`toolPrefix` |String |No |The prefix added to all consolidated tools from referenced servers. Avoids naming conflicts when aggregating tools from multiple sources, such as `server1++_++search` and `server2++_++search`. Immutable setting.
+|`prefix` |String |No |The prefix added to all consolidated tools from referenced servers. Avoids naming conflicts when aggregating tools from multiple sources, such as `server1++_++search` and `server2++_++search`. Immutable setting.
 
 |`path` |String |No |The URL path where the MCP server endpoint is exposed. Default value is `/mcp`.
 

--- a/modules/ref-relnotes-new-features.adoc
+++ b/modules/ref-relnotes-new-features.adoc
@@ -9,11 +9,10 @@
 [role="_abstract"]
 You can use the new features and enhancements that are available with {product-title} {version}.
 
-CoreDNS integration for on-premise DNS is Generally Available::
+MCP gateway: MCP prompt federation is now available::
 
-{prodname} {version} provides integration with https://coredns.io/[CoreDNS] for on-premise DNS as a Generally Available feature.
-//For more information, see xref:../deployment/coredns.adoc#con-about-using-onprem-dns-coredns_rhcl-using-on-prem-dns-coredns[About using on-premise DNS with CoreDNS].
+{mcpg} adds support for federating MCP prompts through the `Gateway` object as a Generally Available feature. MCP prompt federation makes it much easier to supply your large language models (LLMs) with the exact context and steering instructions they need, no matter which server originally hosted the template.
++
+With this update, you can now access and run prompt templates from your upstream MCP servers through a single, central `Gateway` connection. Instead of managing separate connections to multiple backend servers, you can query the `Gateway` object to see a unified, prefixed list of every available prompt across your network. When you find the prompt template that you need, you can plug in your custom variables. The `Gateway` object automatically routes the request to the right place.
 
-Updated Observability documentation is now available::
-
-{prodname} {version} includes enhanced Observability documentation, including configuring access logs, tracing, and request correlation. For more information, see xref:../observe/observability.adoc#rhcl-observability[Red{nbsp}Hat Connectivity Link observability].
+//For more information, see xref:../mcp_gateway_config/mcp-gateway-register-on-prem-mcp-servers.adoc#mcp-gateway-register-on-prem-mcp-servers[Registering on-prem MCP servers]

--- a/modules/ref-relnotes-new-features.adoc
+++ b/modules/ref-relnotes-new-features.adoc
@@ -9,11 +9,10 @@
 [role="_abstract"]
 You can use the new features and enhancements that are available with {product-title} {version}.
 
-CoreDNS integration for on-premise DNS is Generally Available::
+MCP gateway: MCP prompt federation is now available::
 
-{prodname} {version} provides integration with https://coredns.io/[CoreDNS] for on-premise DNS as a Generally Available feature.
-//For more information, see xref:../deployment/coredns.adoc#con-about-using-onprem-dns-coredns_rhcl-using-on-prem-dns-coredns[About using on-premise DNS with CoreDNS].
+{mcpg} adds support for federating MCP prompts through the `Gateway` object as a Generally Available feature. MCP prompt federation makes it much easier to supply your large language models (LLMs) with the exact context and steering instructions they need, no matter which server originally hosted the template.
 
-Updated Observability documentation is now available::
+With this update, you can now access and run prompt templates from your upstream MCP servers through a single, central `Gateway` connection. Instead of managing separate connections to multiple backend servers, you can query the `Gateway` object to see a unified, prefixed list of every available prompt across your network. When you find the prompt template that you need, you can plug in your custom variables. The `Gateway` object automatically routes the request to the right place.
 
-{prodname} {version} includes enhanced Observability documentation, including configuring access logs, tracing, and request correlation. For more information, see xref:../observe/observability.adoc#rhcl-observability[Red{nbsp}Hat Connectivity Link observability].
+//For more information, see xref:../


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
rhcl-docs-1.4

Issue:
[OSDOCS-19710](https://redhat.atlassian.net/browse/OSDOCS-19710)

Link to docs preview:
https://111936--ocpdocs-pr.netlify.app/rhcl/latest/mcp_gateway_config/mcp-gateway-authorization.html
https://111936--ocpdocs-pr.netlify.app/rhcl/latest/mcp_gateway_config/mcp-gateway-creating-virtual-mcp-servers.html
https://111936--ocpdocs-pr.netlify.app/rhcl/latest/mcp_gateway_config/mcp-gateway-register-ext-mcp-servers.html
https://111936--ocpdocs-pr.netlify.app/rhcl/latest/mcp_gateway_config/mcp-gateway-register-on-prem-mcp-servers.html
https://111936--ocpdocs-pr.netlify.app/rhcl/latest/mcp_gateway_config/mcp-gateway-revoke-tool-access.html
https://111936--ocpdocs-pr.netlify.app/rhcl/latest/release_notes/rhcl-release-notes.html

QE review:
- [x] SME approved this change.
- [x] QE approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->


<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
