### PR TITLE
CNV-74060: RN 4.22 removing SVVP cert

### DIFF
--- a/virt/release_notes/virt-4-22-release-notes.adoc
+++ b/virt/release_notes/virt-4-22-release-notes.adoc
@@ -15,15 +15,15 @@ toc::[]
 To view the supported guest operating systems for {VirtProductName}, see link:https://access.redhat.com/articles/973163#ocpvirt[Certified Guest Operating Systems in Red Hat OpenStack Platform, Red Hat Virtualization, OpenShift Virtualization and Red Hat Enterprise Linux with KVM].
 
 //Ensure platform passes Windows Server Virtualization Validation Program. Otherwise, comment out the section below.
-[id="virt-svvp-certification_{context}"]
-== Microsoft Windows SVVP certification
-
-{VirtProductName} is certified in Microsoft's Windows Server Virtualization Validation Program (SVVP) to run Windows Server workloads.
-
-The SVVP certification applies to:
-
-* Red Hat Enterprise Linux CoreOS workers. In the Microsoft SVVP Catalog, they are named __Red{nbsp}Hat {product-title} 4.20__.
-* Intel and AMD CPUs.
+//[id="virt-svvp-certification_{context}"]
+//== Microsoft Windows SVVP certification
+//
+//{VirtProductName} is certified in Microsoft's Windows Server Virtualization Validation Program (SVVP) to run Windows Server workloads.
+//
+//The SVVP certification applies to:
+//
+//* Red Hat Enterprise Linux CoreOS workers. In the Microsoft SVVP Catalog, they are named __Red{nbsp}Hat {product-title} 4.20__.
+//* Intel and AMD CPUs.
 
 [id="virt-4-22-new_{context}"]
 == New features and enhancements
@@ -48,7 +48,7 @@ The SVVP certification applies to:
 
 // Networking
 Support for IPv6 single-stack clusters is generally available::
-With this release, support for IPv6 single-stack clusters is Generally Available (GA). {VirtProductName} supports single-stack IPv6 clusters for VMs that are connected to an OVN-Kubernetes localnet network, Linux bridge Container Network Interface (CNI) plugin, and Single Root I/O Virtualization (SR-IOV) network devices. 
+With this release, support for IPv6 single-stack clusters is Generally Available (GA). {VirtProductName} supports single-stack IPv6 clusters for VMs that are connected to an OVN-Kubernetes localnet network, Linux bridge Container Network Interface (CNI) plugin, and Single Root I/O Virtualization (SR-IOV) network devices.
 +
 link:https://redhat.atlassian.net/browse/CNV-28924[CNV-28924]
 


### PR DESCRIPTION
Version(s):
4.22

Issue:
https://redhat.atlassian.net/browse/CNV-74060

Link to docs preview:
https://111939--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/release_notes/virt-4-22-release-notes.html

QE review:
- [x] QE has approved this change.


Additional information:
> Per discussions in Leads meeting, we're not getting SVVP cert. Please remove this section from the release notes for 4.22 only