### PR TITLE
OSDOCS-18784-10 created assembly/modules for uninstall

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -1324,6 +1324,8 @@ Topics:
   Topics:
   - Name: Customizing the External Secrets Operator for Red Hat OpenShift
     File: external-secrets-log-levels
+  - Name: Uninstalling the External Secrets Operator
+    File: external-secrets-operator-uninstall
 - Name: Viewing audit logs
   File: audit-log-view
 - Name: Configuring the audit log policy

--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -1314,6 +1314,8 @@ Topics:
   Topics:
   - Name: Customizing the External Secrets Operator for Red Hat OpenShift
     File: external-secrets-log-levels
+  - Name: Uninstalling the External Secrets Operator
+    File: external-secrets-operator-uninstall
 - Name: Viewing audit logs
   File: audit-log-view
 - Name: Configuring the audit log policy

--- a/modules/external-secrets-operator-uninstall-console.adoc
+++ b/modules/external-secrets-operator-uninstall-console.adoc
@@ -1,0 +1,28 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-operator-uninstall.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="external-secrets-operator-uninstall-console_{context}"]
+= Uninstalling the {external-secrets-operator} using the web console
+
+[role="_abstract"]
+You can uninstall the {external-secrets-operator} from your cluster using the {product-title} web console. Uninstalling the Operator does not automatically delete the `ExternalSecrets` custom resources or the running `external-secrets` application workload. These resources remain in the cluster to prevent accidental data loss and must be removed manually if they are no longer needed.
+
+.Prerequisites
+
+* You have access to the cluster with `cluster-admin` privileges.
+* You have access to the {product-title} web console.
+* The {external-secrets-operator-short} is installed.
+
+.Procedure
+
+. Log in to the {product-title} web console.
+
+. Uninstall the {external-secrets-operator} using the following steps:
+
+.. Navigate to *Ecosystem* -> *Installed Operators*.
+
+.. Click the Options menu {kebab} next to the *{external-secrets-operator}* entry and click *Uninstall Operator*.
+
+.. In the confirmation dialog, click *Uninstall*.

--- a/modules/external-secrets-operator-uninstall-console.adoc
+++ b/modules/external-secrets-operator-uninstall-console.adoc
@@ -1,0 +1,30 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-operator-uninstall.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="external-secrets-operator-uninstall-console_{context}"]
+= Uninstalling the {external-secrets-operator} using the web console
+
+[role="_abstract"]
+You can uninstall the {external-secrets-operator} from your cluster by using the {product-title} web console. This action does not automatically delete the `ExternalSecrets` custom resources (CRs) or the running `external-secrets` workload.
+
+These resources remain in the cluster to prevent accidental data loss. If you no longer need them, remove them manually.
+
+.Prerequisites
+
+* You have access to the cluster with `cluster-admin` privileges.
+* You have access to the {product-title} web console.
+* The {external-secrets-operator-short} is installed.
+
+.Procedure
+
+. Log in to the {product-title} web console.
+
+. Uninstall the {external-secrets-operator} using the following steps:
+
+.. Navigate to *Ecosystem* -> *Installed Operators*.
+
+.. Click the Options menu {kebab} next to the *{external-secrets-operator}* entry and click *Uninstall Operator*.
+
+.. In the confirmation dialog, click *Uninstall*.

--- a/modules/external-secrets-remove-resources-cli.adoc
+++ b/modules/external-secrets-remove-resources-cli.adoc
@@ -1,0 +1,36 @@
+// Module included in the following assemblies:
+//
+// * security/external-secrets-operator-uninstall.adoc
+:_mod-docs-content-type: PROCEDURE
+[id="external-secrets-remove-resources-cli_{context}"]
+= Removing {external-secrets-operator} resources by using the CLI
+
+[role="_abstract"]
+After you have uninstalled the {external-secrets-operator}, you can optionally eliminate its associated resources from your cluster by using the command-line interface (CLI).
+
+.Prerequisites
+
+* You have access to the cluster with `cluster-admin` privileges.
+
+.Procedure
+
+. Delete the deployments of the `external-secrets` application components in the `external-secrets` namespace by running the following command:
++
+[source,terminal]
+----
+$ oc delete deployment -n external-secrets -l app=external-secrets
+----
+
+. Delete the custom resource definitions (CRDs) that were installed by the {external-secrets-operator-short} by running the following command:
++
+[source,terminal]
+----
+$ oc delete customresourcedefinitions.apiextensions.k8s.io -l external-secrets.io/component=controller
+----
+
+. Delete the `external-secrets-operator` namespace by running the following command:
++
+[source,terminal]
+----
+$ oc delete project external-secrets-operator
+----

--- a/modules/external-secrets-remove-resources-cli.adoc
+++ b/modules/external-secrets-remove-resources-cli.adoc
@@ -1,0 +1,36 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-operator-uninstall.adoc
+:_mod-docs-content-type: PROCEDURE
+[id="external-secrets-remove-resources-cli_{context}"]
+= Removing {external-secrets-operator} resources by using the CLI
+
+[role="_abstract"]
+After you uninstall the {external-secrets-operator}, you can remove the resources associated with the Operator from your cluster by using the command-line interface (CLI).
+
+.Prerequisites
+
+* You have access to the cluster with `cluster-admin` privileges.
+
+.Procedure
+
+. Delete the deployments of the `external-secrets` application components in the `external-secrets` namespace by running the following command:
++
+[source,terminal]
+----
+$ oc delete deployment -n external-secrets -l app=external-secrets
+----
+
+. Delete the custom resource definitions (CRDs) that were installed by the {external-secrets-operator-short} by running the following command:
++
+[source,terminal]
+----
+$ oc delete customresourcedefinitions.apiextensions.k8s.io -l external-secrets.io/component=controller
+----
+
+. Delete the `external-secrets-operator` namespace by running the following command:
++
+[source,terminal]
+----
+$ oc delete project external-secrets-operator
+----

--- a/modules/external-secrets-remove-resources.adoc
+++ b/modules/external-secrets-remove-resources.adoc
@@ -1,0 +1,68 @@
+// Module included in the following assemblies:
+//
+// * security/external-secrets-operator-uninstall.adoc
+:_mod-docs-content-type: PROCEDURE
+[id="external-secrets-remove-resources_{context}"]
+= Removing {external-secrets-operator} resources by using the web console
+
+[role="_abstract"]
+After you have uninstalled the {external-secrets-operator}, you have the option to eliminate its associated resources from your cluster.
+
+.Prerequisites
+
+* You have access to the cluster with `cluster-admin` privileges.
+* You have access to the {product-title} web console.
+
+.Procedure
+
+. Log in to the {product-title} web console.
+
+. Remove the deployments of the `external-secrets` application components in the `external-secrets` namespace:
+
+.. Click the *Project* drop-down menu to see a list of all available projects, and select the *external-secrets* project.
+
+.. Navigate to *Workloads* -> *Deployments*.
+
+.. Select the deployment that you want to delete.
+
+.. Click the *Actions* drop-down menu, and select *Delete Deployment* to see a confirmation dialog box.
+
+.. Click *Delete* to delete the deployment.
+
+. Remove the custom resource definitions (CRDs) that were installed by the {external-secrets-operator-short} using the following steps:
+
+.. Navigate to *Administration* -> *CustomResourceDefinitions*.
+
+.. Choose `external-secrets.io/component: controller` from the suggestions in the *Label* field to filter the CRDs.
+
+.. Click the Options menu {kebab} next to each of the following CRDs, and select *Delete Custom Resource Definition*:
+
+*** ACRAccessToken
+*** ClusterExternalSecret
+*** ClusterGenerator
+*** ClusterPushSecret
+*** ClusterSecretStore
+*** ECRAuthorizationToken
+*** ExternalSecret
+*** GCRAccessToken
+*** GeneratorState
+*** GithubAccessToken
+*** Grafana
+*** MFA
+*** Password
+*** PushSecret
+*** QuayAccessToken
+*** SecretStore
+*** SSHKey
+*** STSSessionToken
+*** UUID
+*** VaultDynamicSecret
+*** Webhook
+
+. Remove the `external-secrets-operator` namespace using the following steps:
+
+.. Navigate to *Administration* -> *Namespaces*.
+
+.. Click the Options menu {kebab} next to the *{external-secrets-operator-short}* and select *Delete Namespace*.
+
+.. In the confirmation dialog, enter `external-secrets-operator` in the field and click *Delete*.

--- a/modules/external-secrets-remove-resources.adoc
+++ b/modules/external-secrets-remove-resources.adoc
@@ -1,0 +1,68 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-operator-uninstall.adoc
+:_mod-docs-content-type: PROCEDURE
+[id="external-secrets-remove-resources_{context}"]
+= Removing {external-secrets-operator} resources by using the web console
+
+[role="_abstract"]
+After you uninstall the {external-secrets-operator}, you can remove the resources associated with the Operator from your cluster.
+
+.Prerequisites
+
+* You have access to the cluster with `cluster-admin` privileges.
+* You have access to the {product-title} web console.
+
+.Procedure
+
+. Log in to the {product-title} web console.
+
+. Remove the deployments of the `external-secrets` application components in the `external-secrets` namespace:
+
+.. Click the *Project* drop-down menu to see a list of all available projects, and select the *external-secrets* project.
+
+.. Navigate to *Workloads* -> *Deployments*.
+
+.. Select the deployment that you want to delete.
+
+.. Click the *Actions* drop-down menu, and select *Delete Deployment* to see a confirmation dialog box.
+
+.. Click *Delete* to delete the deployment.
+
+. Remove the custom resource definitions (CRDs) that were installed by the {external-secrets-operator-short} using the following steps:
+
+.. Navigate to *Administration* -> *CustomResourceDefinitions*.
+
+.. Choose `external-secrets.io/component: controller` from the suggestions in the *Label* field to filter the CRDs.
+
+.. Click the Options menu {kebab} next to each of the following CRDs, and select *Delete Custom Resource Definition*:
+
+*** ACRAccessToken
+*** ClusterExternalSecret
+*** ClusterGenerator
+*** ClusterPushSecret
+*** ClusterSecretStore
+*** ECRAuthorizationToken
+*** ExternalSecret
+*** GCRAccessToken
+*** GeneratorState
+*** GithubAccessToken
+*** Grafana
+*** MFA
+*** Password
+*** PushSecret
+*** QuayAccessToken
+*** SecretStore
+*** SSHKey
+*** STSSessionToken
+*** UUID
+*** VaultDynamicSecret
+*** Webhook
+
+. Remove the `external-secrets-operator` namespace using the following steps:
+
+.. Navigate to *Administration* -> *Namespaces*.
+
+.. Click the Options menu {kebab} next to the *{external-secrets-operator-short}* and select *Delete Namespace*.
+
+.. In the confirmation dialog, enter `external-secrets-operator` in the field and click *Delete*.

--- a/security/external_secrets_operator/external-secrets-operator-uninstall.adoc
+++ b/security/external_secrets_operator/external-secrets-operator-uninstall.adoc
@@ -1,0 +1,19 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="external-secrets-operator-uninstall"]
+= Uninstalling the External Secrets Operator for Red Hat OpenShift
+include::_attributes/common-attributes.adoc[]
+:context: external-secrets-operator-uninstall
+
+toc::[]
+
+[role="_abstract"]
+You can remove the {external-secrets-operator} from {product-title} by uninstalling the Operator and removing its related resources.
+
+// Uninstalling the {external-secrets-operator-short}
+include::modules/external-secrets-operator-uninstall-console.adoc[leveloffset=+1]
+
+// Removing {external-secrets-operator-short}
+include::modules/external-secrets-remove-resources.adoc[leveloffset=+1]
+
+// Removing {external-secrets-operator-short} using CLI
+include::modules/external-secrets-remove-resources-cli.adoc[leveloffset=+1]

--- a/security/external_secrets_operator/external-secrets-operator-uninstall.adoc
+++ b/security/external_secrets_operator/external-secrets-operator-uninstall.adoc
@@ -1,0 +1,19 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="external-secrets-operator-uninstall"]
+= Uninstalling the External Secrets Operator for Red Hat OpenShift
+include::_attributes/common-attributes.adoc[]
+:context: external-secrets-operator-uninstall
+
+toc::[]
+
+[role="_abstract"]
+You can remove the {external-secrets-operator} from {product-title} by uninstalling the Operator and removing the related resources.
+
+// Uninstalling the {external-secrets-operator-short}
+include::modules/external-secrets-operator-uninstall-console.adoc[leveloffset=+1]
+
+// Removing {external-secrets-operator-short}
+include::modules/external-secrets-remove-resources.adoc[leveloffset=+1]
+
+// Removing {external-secrets-operator-short} using CLI
+include::modules/external-secrets-remove-resources-cli.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s):
4.18

Issue:
https://redhat.atlassian.net/browse/OSDOCS-18784

Link to docs preview:
https://111950--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/external_secrets_operator/external-secrets-operator-uninstall.html


QE review:
- [x] QE has approved this change.


Additional information:
Merge-reviewer: The information in this PR was copied from the most recent ESO repo here https://github.com/openshift/openshift-docs/tree/main/modules. Most of the  text was reviewed in earlier PRs. Just thought you would want to know.
