### PR TITLE
Fixing step ordering bug

### DIFF
--- a/modules/installation-creating-gcp-lb.adoc
+++ b/modules/installation-creating-gcp-lb.adoc
@@ -23,8 +23,6 @@ If your cluster does not initialize correctly, you might have to contact Red Hat
 
 .Procedure
 
-. Copy the template from the *Infrastructure Manager template for the internal load balancer* section of this topic and save it as `02_lb_int.tf` in a directory called `02_lb_int` on your computer. This template describes the internal load balancing objects that your cluster requires.
-
 . If you are installing a cluster into a shared VPC, set environment variables for the cluster network and control plane subnet.
 
 .. Determine the shared VPC network name by running the following command:
@@ -59,6 +57,8 @@ $ export CONTROL_SUBNET=<control_subnet>
 ----
 +
 `<control_subnet>` specifies the name of the subnet you selected from the list of subnets.
+
+. Copy the template from the *Infrastructure Manager template for the internal load balancer* section of this topic and save it as `02_lb_int.tf` in a directory called `02_lb_int` on your computer. This template describes the internal load balancing objects that your cluster requires.
 
 .. Create an internal load balancer by running the following command:
 +


### PR DESCRIPTION
Version(s):
4.22

Issue:
https://redhat.atlassian.net/browse/OSDOCS-15002

Link to docs preview:
https://111951--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-user-infra.html#installation-creating-gcp-lb_installing-gcp-user-infra

No QE review needed - docs only bug with the indentation of steps.