### PR TITLE
OSDOCS#19839: Update the z-stream RNs for 4.18.42

### DIFF
--- a/microshift_release_notes/microshift-4-18-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-18-release-notes.adoc
@@ -26,12 +26,14 @@ include::modules/microshift-4-18-additional-release-notes.adoc[leveloffset=+1]
 
 include::modules/microshift-4-18-asynch-errata-updates.adoc[leveloffset=+1]
 
-include::modules/microshift-4-18-1-dp.adoc[leveloffset=+2]
+include::modules/microshift-4-18-42-dp.adoc[leveloffset=+2]
 
-include::modules/microshift-4-18-2-dp.adoc[leveloffset=+2]
-
-include::modules/microshift-4-18-11-dp.adoc[leveloffset=+2]
+include::modules/microshift-4-18-36-dp.adoc[leveloffset=+2]
 
 include::modules/microshift-4-18-26-dp.adoc[leveloffset=+2]
 
-include::modules/microshift-4-18-36-dp.adoc[leveloffset=+2]
+include::modules/microshift-4-18-11-dp.adoc[leveloffset=+2]
+
+include::modules/microshift-4-18-2-dp.adoc[leveloffset=+2]
+
+include::modules/microshift-4-18-1-dp.adoc[leveloffset=+2]

--- a/modules/microshift-4-18-11-dp.adoc
+++ b/modules/microshift-4-18-11-dp.adoc
@@ -5,12 +5,12 @@
 
 :_mod-docs-content-type: REFERENCE
 [id="microshift-4-18-11-dp_{context}"]
-= RHBA-2025:4249 - {microshift-short} 4.18.11 bug fix and enhancement advisory
+= RHBA-2025:4249 - {microshift-short} 4.18.11 fixed issues and enhancement advisory
 
 [role="_abstract"]
 Issued: 1 May 2025
 
-{product-title} release 4.18.11 is now available, see the link:https://access.redhat.com/errata/RHBA-2025:4249[RHBA-2025:4249] advisory. Release notes for bug fixes and enhancements are provided in this documentation. The images that are included in the update are provided by the {OCP} link:https://access.redhat.com/errata/RHSA-2025:4211[RHSA-2025:4211] advisory.
+{product-title} release 4.18.11 is now available, see the link:https://access.redhat.com/errata/RHBA-2025:4249[RHBA-2025:4249] advisory. Release notes for fixed issues and enhancements are provided in this documentation. The images that are included in the update are provided by the {OCP} link:https://access.redhat.com/errata/RHSA-2025:4211[RHSA-2025:4211] advisory.
 
 See the latest images included with {microshift-short} by using the following instructions:
 
@@ -18,7 +18,7 @@ See the latest images included with {microshift-short} by using the following in
 * xref:../microshift_install_bootc/microshift-install-bootc-image.adoc#microshift-install-bootc-get-published-image_microshift-install-publish-bootc-image[Getting the published bootc image for MicroShift]
 
 [id="microshift-4-18-11-bugs_{context}"]
-== Bug fixes
+== Fixed issues
 
 * Previously, {microshift-short} could fail to start on a host without the hostname RPM package installed. With this release, the hostname RPM package is pulled as a dependency during installation. This change means that the hostname RPM package is now required when building the {microshift-short} system, preventing this type of startup failure.  (link:https://issues.redhat.com/browse/OCPBUGS-54448[OCPBUGS-54448])
 

--- a/modules/microshift-4-18-2-dp.adoc
+++ b/modules/microshift-4-18-2-dp.adoc
@@ -5,16 +5,16 @@
 
 :_mod-docs-content-type: REFERENCE
 [id="microshift-4-18-2-dp_{context}"]
-= RHBA-2025:1953 - {microshift-short} 4.18.2 bug fix and enhancement advisory
+= RHBA-2025:1953 - {microshift-short} 4.18.2 fixed issues and enhancement advisory
 
 [role="_abstract"]
 Issued: 4 March 2025
 
-{product-title} release 4.18.2 is now available. Bug fixes and enhancements are listed in the link:https://access.redhat.com/errata/RHBA-2025:1953[RHBA-2025:1953] advisory. Release notes for bug fixes and enhancements are provided in this documentation. The images that are included in the update are provided by the {OCP} link:https://access.redhat.com/errata/RHBA-2025:1904[RHBA-2025:1904] advisory.
+{product-title} release 4.18.2 is now available. Fixed issues and enhancements are listed in the link:https://access.redhat.com/errata/RHBA-2025:1953[RHBA-2025:1953] advisory. Release notes for fixed issues and enhancements are provided in this documentation. The images that are included in the update are provided by the {OCP} link:https://access.redhat.com/errata/RHBA-2025:1904[RHBA-2025:1904] advisory.
 
 See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].
 
 [id="microshift-4-18-2-bugs_{context}"]
-== Bug fix
+== Fixed issues
 
 * Previously, a failed greenboot health check flag did not clear when an RPM-install-based {microshift-short} service was updated without rebooting the system. As a consequence, greenboot health checks for optional components continue to fail because the `systemctl restart greenboot-healthcheck.service` command fails while the flag is present. With this release, the primary {microshift-short} greenboot health check clears the condition that causes optional component health checks to continue to fail. (link:https://issues.redhat.com/browse/OCPBUGS-51198[OCPBUGS-51198])

--- a/modules/microshift-4-18-26-dp.adoc
+++ b/modules/microshift-4-18-26-dp.adoc
@@ -5,12 +5,12 @@
 
 :_mod-docs-content-type: REFERENCE
 [id="microshift-4-18-26-dp_{context}"]
-= RHBA-2025:17912 - {microshift-short} 4.18.26 bug fix and enhancement advisory
+= RHBA-2025:17912 - {microshift-short} 4.18.26 fixed issues and enhancement advisory
 
 [role="_abstract"]
 Issued: 16 October 2026
 
-{product-title} release 4.18.26 is now available, see the link:https://access.redhat.com/errata/RHBA-2025:17912[RHBA-2025:17912] advisory. Release notes for bug fixes and enhancements are provided in this documentation. The images that are included in the update are provided by the {OCP} link:https://access.redhat.com/errata/RHSA-2025:17657[RHSA-2025:17657] advisory.
+{product-title} release 4.18.26 is now available, see the link:https://access.redhat.com/errata/RHBA-2025:17912[RHBA-2025:17912] advisory. Release notes for fixed issues and enhancements are provided in this documentation. The images that are included in the update are provided by the {OCP} link:https://access.redhat.com/errata/RHSA-2025:17657[RHSA-2025:17657] advisory.
 
 See the latest images included with {microshift-short} by using the following instructions:
 
@@ -18,7 +18,7 @@ See the latest images included with {microshift-short} by using the following in
 * xref:../microshift_install_bootc/microshift-install-bootc-image.adoc#microshift-install-bootc-get-published-image_microshift-install-publish-bootc-image[Getting the published bootc image for MicroShift]
 
 [id="microshift-4-18-26-bugs_{context}"]
-== Bug fix
+== Fixed issues
 
 * Before this update, embedding container images into a bootc build could fail because HTTP proxy environment variables were defined in the bootc image. Proxy errors occurred during container image embedding and prevented successful builds. With this release, the bootc image no longer sets HTTP proxy environment variables, thereby eliminating the issue. As a result, you can now embed container images without encountering proxy errors. (link:https://issues.redhat.com/browse/OCPBUGS-61433[OCPBUGS-61433])
 

--- a/modules/microshift-4-18-36-dp.adoc
+++ b/modules/microshift-4-18-36-dp.adoc
@@ -5,12 +5,12 @@
 
 :_mod-docs-content-type: REFERENCE
 [id="microshift-4-18-36-dp_{context}"]
-= RHBA-2026:5750 - {microshift-short} 4.18.36 bug fix and enhancement advisory
+= RHBA-2026:5750 - {microshift-short} 4.18.36 fixed issue and enhancement advisory
 
 Issued: 25 March 2026
 
 [role="_abstract"]
-{product-title} release 4.18.36 is now available. Bug fixes and enhancements are listed in the link:https://access.redhat.com/errata/RHBA-2026:5750[RHBA-2026:5750] advisory. Release notes for bug fixes and enhancements are provided in this documentation. The images that are included in the update are provided by the {OCP} link:https://access.redhat.com/errata/RHSA-2026:5133[RHSA-2026:5133] advisory.
+{product-title} release 4.18.36 is now available. Fixed issues and enhancements are listed in the link:https://access.redhat.com/errata/RHBA-2026:5750[RHBA-2026:5750] advisory. Release notes for fixed issues and enhancements are provided in this documentation. The images that are included in the update are provided by the {OCP} link:https://access.redhat.com/errata/RHSA-2026:5133[RHSA-2026:5133] advisory.
 
 See the latest images included with {microshift-short} by using the following instructions:
 

--- a/modules/microshift-4-18-42-dp.adoc
+++ b/modules/microshift-4-18-42-dp.adoc
@@ -1,0 +1,23 @@
+
+// Module included in the following assemblies:
+//
+//microshift_release_notes/microshift-4-18-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="microshift-4-18-42-dp_{context}"]
+= RHSA-2026:18068 - {microshift-short} 4.18.42 fixed issue and security advisory
+
+Issued: 20 May 2026
+
+[role="_abstract"]
+{product-title} release 4.18.42 is now available. Fixed issues are listed in the link:https://access.redhat.com/errata/RHSA-2026:18068[RHSA-2026:18068] advisory. Release notes for fixed issues are provided in this documentation. The images that are included in the update are provided by the {OCP} link:https://access.redhat.com/errata/RHSA-2026:17448[RHSA-2026:17448] advisory.
+
+See the latest images included with {microshift-short} by using the following instructions:
+
+* xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[Listing the contents of the {microshift-short} RPM release package]
+* xref:../microshift_install_bootc/microshift-install-bootc-image.adoc#microshift-install-bootc-get-published-image_microshift-install-rhel-bootc-image[Getting the published bootc image for {microshift-short}]
+
+[id="microshift-4-18-42-bugs_{context}"]
+== Fixed issues
+
+There are no notable fixed issues in this release.


### PR DESCRIPTION
Version(s):
4.18

Issue:
[OSDOCS-19839](https://redhat.atlassian.net/browse/OSDOCS-19839)

Link to docs preview:
[4.18.42](https://111960--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-18-release-notes.html#microshift-4-18-42-dp_release-notes)

QE review:
- [ ] QE has approved this change.
N/A for RNs.

Additional information:
Shipment [MR](https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/538/diffs)
ART [Dashboard](https://art-dash.engineering.redhat.com/dashboard/release/openshift-4.21)
