### PR TITLE
OSDOCS-18784-11 created assembly/modules for api

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -1324,6 +1324,8 @@ Topics:
   Topics:
   - Name: Customizing the External Secrets Operator for Red Hat OpenShift
     File: external-secrets-log-levels
+  - Name: External Secrets Operator APIs
+    File: external-secrets-operator-api
 - Name: Viewing audit logs
   File: audit-log-view
 - Name: Configuring the audit log policy

--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -1314,6 +1314,8 @@ Topics:
   Topics:
   - Name: Customizing the External Secrets Operator for Red Hat OpenShift
     File: external-secrets-log-levels
+  - Name: External Secrets Operator APIs
+    File: external-secrets-operator-api
 - Name: Viewing audit logs
   File: audit-log-view
 - Name: Configuring the audit log policy

--- a/modules/eso-bitwarden-secret.adoc
+++ b/modules/eso-bitwarden-secret.adoc
@@ -1,0 +1,33 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-operator-api.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="eso-bitwarden-secret_{context}"]
+= bitwardenSecretManagerProvider
+
+[role="_abstract"]
+To enable the Bitwarden secrets manager provider and set up the additional service required to connect to the Bitwarden server, you can configure the `bitwardenSecretManagerProvider` field.
+
+[cols="1,1,1,1,1",options="header"]
+|===
+| Field
+| Type
+| Description
+| Default
+| Validation
+
+| `mode`
+| _string_
+| `mode` field enables the `bitwardenSecretManagerProvider` provider state, which can be set to `Enabled` or `Disabled`. If set to `Enabled`, the Operator ensures the plugin is deployed and synchronized. If set to `Disabled`, the Bitwarden provider plugin reconciliation is disabled. The plugin and resources remain in their current state, and are not managed by the Operator.
+| `Disabled`
+| enum: [Enabled Disabled]
+
+Optional
+
+| `secretRef`
+| _SecretReference_
+| `SecretRef` specifies the Kubernetes secret that contains the TLS key pair for the Bitwarden server. If this reference is not provided and the `certManagerConfig` field is configured, the issuer defined in `certManagerConfig` generates the required certificate. The secret must use `tls.crt` for certificate, `tls.key` for the private key, and `ca.crt` for CA certificate.
+|
+| Optional
+|===

--- a/modules/eso-bitwarden-secret.adoc
+++ b/modules/eso-bitwarden-secret.adoc
@@ -1,0 +1,33 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-operator-api.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="eso-bitwarden-secret_{context}"]
+= bitwardenSecretManagerProvider
+
+[role="_abstract"]
+To enable the Bitwarden secrets manager provider and set up the additional service required to connect to the Bitwarden server, you can configure the `bitwardenSecretManagerProvider` field.
+
+[cols="1,1,1,1,1",options="header"]
+|===
+| Field
+| Type
+| Description
+| Default
+| Validation
+
+| `mode`
+| _string_
+| `mode` field enables the `bitwardenSecretManagerProvider` provider state, which can be set to `Enabled` or `Disabled`. If set to `Enabled`, the Operator ensures the plugin is deployed and synchronized. If set to `Disabled`, the Bitwarden provider plugin reconciliation is disabled. The plugin and resources remain in their current state, and are not managed by the Operator.
+| `Disabled`
+| enum: [Enabled Disabled]
+
+Optional
+
+| `secretRef`
+| _SecretReference_
+| `secretRef` specifies the Kubernetes secret that contains the TLS key pair for the Bitwarden server. If this reference is not provided and the `certManagerConfig` field is configured, the issuer defined in `certManagerConfig` generates the required certificate. The secret must use `tls.crt` for certificate, `tls.key` for the private key, and `ca.crt` for CA certificate.
+|
+| Optional
+|===

--- a/modules/eso-cert-manager-config.adoc
+++ b/modules/eso-cert-manager-config.adoc
@@ -1,0 +1,53 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-operator-api.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="eso-cert-manager-config_{context}"]
+= certManagerConfig
+
+[role="_abstract"]
+You can integrate the {external-secrets-operator} with cert-manager to secure internal webhooks. Use these settings to replace the default internal certificate management with cert-manager, specify custom issuers, and define certificate lifecycle and renewal policies.
+
+[cols="1,1,1,1,1",options="header"]
+|===
+| Field
+| Type
+| Description
+| Default
+| Validation
+
+| `mode`
+| _string_
+| `mode` specifies whether to use cert-manager for certificate management instead of the built-in `cert-controller` which can be indicated by setting either `Enabled` or `Disabled`. If set to `Enabled`, uses `cert-manager` for obtaining the certificates for the webhook server and other components. If set to `Disabled`, uses the `cert-controller` for obtaining the certificates for the webhook server. `Disabled` is the default behavior.
+| false
+| enum: [true false]
+
+Required
+
+| `injectAnnotations`
+| _string_
+| `injectAnnotations` adds the `cert-manager.io/inject-ca-from` annotation to the webhooks and custom resource definitions (CRDs) to automatically configure the webhook with the `cert-manager` Operator certificate authority (CA). This requires CA Injector to be enabled in `cert-manager` Operator. Set this field to `true` or `false`. When set, this field cannot be changed.
+| false
+| enum: [true false]
+
+Optional
+
+| `issuerRef`
+| _ObjectReference_
+| `issuerRef` contains details of the referenced object used for obtaining certificates. The object must exist in the `external-secrets` namespace unless a cluster-scoped `cert-manager` Operator issuer is used.
+|
+| Required
+
+| `certificateDuration`
+| link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#duration-v1-meta[_Duration_]
+| `certificateDuration` sets the validity period of the webhook certificate.
+| 8760h
+| Optional
+
+| `certificateRenewBefore`
+| link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#duration-v1-meta[_Duration_]
+| `certificateRenewBefore` sets the ahead time to renew the webhook certificate before expiry.
+| 30m
+| Optional
+|===

--- a/modules/eso-cert-manager-config.adoc
+++ b/modules/eso-cert-manager-config.adoc
@@ -1,0 +1,49 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-operator-api.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="eso-cert-manager-config_{context}"]
+= certManagerConfig
+
+[role="_abstract"]
+You can configure the `certManagerConfig` field to integrate cert-manager with the {external-secrets-operator} for securing internal webhooks, replacing the default certificate management, specifying custom issuers, and defining certificate lifecycle and renewal policies.
+
+[cols="1,1,1,1,1",options="header"]
+|===
+| Field
+| Type
+| Description
+| Default
+| Validation
+
+| `mode`
+| _string_
+| `mode` specifies whether to use cert-manager for certificate management instead of the built-in `cert-controller` which can be indicated by setting either `Enabled` or `Disabled`. If set to `Enabled`, uses `cert-manager` for obtaining the certificates for the webhook server and other components. If set to `Disabled`, uses the `cert-controller` for obtaining the certificates for the webhook server. `Disabled` is the default behavior.
+| 
+| enum: [Enabled Disabled]
+
+| `injectAnnotations`
+| _string_
+| `injectAnnotations` adds the `cert-manager.io/inject-ca-from` annotation to the webhooks and custom resource definitions (CRDs) to automatically configure the webhook with the `cert-manager` Operator certificate authority (CA). This requires CA Injector to be enabled in `cert-manager` Operator. Set this field to `true` or `false`. When set, this field cannot be changed.
+| false
+| enum: [true false]
+
+| `issuerRef`
+| _ObjectReference_
+| `issuerRef` contains details of the referenced object used for obtaining certificates. The object must exist in the `external-secrets` namespace unless a cluster-scoped `cert-manager` Operator issuer is used.
+|
+| 
+
+| `certificateDuration`
+| link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#duration-v1-meta[_Duration_]
+| `certificateDuration` sets the validity period of the webhook certificate.
+| 8760h
+| 
+
+| `certificateRenewBefore`
+| link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#duration-v1-meta[_Duration_]
+| `certificateRenewBefore` sets the ahead time to renew the webhook certificate before expiry.
+| 30m
+| 
+|===

--- a/modules/eso-cert-providers-config.adoc
+++ b/modules/eso-cert-providers-config.adoc
@@ -1,0 +1,23 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-operator-api.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="eso-cert-providers-config_{context}"]
+= certProvidersConfig
+
+[role="_abstract"]
+The `certProvidersConfig` defines the configuration for the certificate providers used to manage TLS certificates for webhook and plugins.
+
+[cols="1,1,1,1",options="header"]
+|===
+| Field
+| Type
+| Description
+| Validation
+
+| `certManager`
+| _object_
+| `certManager` defines the configuration for `cert-manager` provider specifics.
+| Optional
+|===

--- a/modules/eso-cert-providers-config.adoc
+++ b/modules/eso-cert-providers-config.adoc
@@ -1,0 +1,25 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-operator-api.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="eso-cert-providers-config_{context}"]
+= certProvidersConfig
+
+[role="_abstract"]
+The `certProvidersConfig` defines the configuration for the certificate providers used to manage TLS certificates for webhook and plugins.
+
+[cols="1,1,1,1,1",options="header"]
+|===
+| Field
+| Type
+| Description
+| Default
+| Validation
+
+| `certManager`
+| _object_
+| `certManager` defines the configuration for `cert-manager` provider specifics.
+|
+| 
+|===

--- a/modules/eso-common-configs.adoc
+++ b/modules/eso-common-configs.adoc
@@ -1,0 +1,62 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-operator-api.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="eso-common-configs_{context}"]
+= commonConfigs
+
+[role="_abstract"]
+The `commonConfigs` specifies the common configurations available for all operands managed by the Operator.
+
+[cols="1,1,1,1,1",options="header"]
+|===
+| Field
+| Type
+| Description
+| Default
+| Validation
+
+| `logLevel`
+| _integer_
+| `logLevel` supports the value range as defined in the link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#time-v1-meta[_Time_].
+| 1
+a| The maximum number of log levels is 5.
+
+The minimum number of log levels is 1.
+
+| `resources`
+| link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#resourcerequirements-v1-core[_ResourceRequirements_].
+| `resources` defines the resource requirements. This cannot be updated. See link:https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/[Resource Management for Pods and Containers].
+|
+| 
+
+| `affinity`
+| link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#affinity-v1-core[_affinity_].
+| `affinity` is used for setting scheduling affinity rules. See See link:https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/[Assigning Pods to Nodes].
+|
+| 
+
+| `tolerations`
+| link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#toleration-v1-core[_toleration array_]
+| `tolerations` sets the pod tolerations.
+|
+a| The maximum number of items is 50.
+
+The minimum number of items is 0.
+
+| `nodeSelector`
+| _object (keys:string, values:string)_
+| `nodeSelector` defines the scheduling criteria using node labels.
+|
+a| The maximum number of properties is 50.
+
+The minimum number of properties is 0.
+
+| `proxy`
+| _proxyConfig_
+| `proxy` sets the proxy configurations which are made avaiable in operand containers managed by the Operator as environment variables.
+|
+| 
+
+|===

--- a/modules/eso-component-config.adoc
+++ b/modules/eso-component-config.adoc
@@ -1,0 +1,39 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-operator-api.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="eso-comoponent-config_{context}"]
+= componentConfig
+
+[role="_abstract"]
+The `componentConfig` field defines configuration overrides for a specific `external-secrets` component.
+
+[cols="1,1,1,1",options="header"]
+|===
+| Field
+| Type
+| Description
+| Validation
+
+| `componentName`
+| _string_
+| `componentName` identifies which `external-secrets` component this configuration applies to. Valid values are `ExternalSecretsCoreController`, `Webhook`, `CertController`, and `BitwardenSDKServer`.
+a| Enum: [`ExternalSecretsCoreController`, `Webhook`, `CertController`, `BitwardenSDKServer`]
+
+Required
+
+| `deploymentConfigs`
+| _object_
+| `deploymentConfigs` specifies overrides for the Kubernetes Deployment resource of this component.
+|Optional
+
+| `overrideEnv`
+a| *EnvVar*
+
+_array_
+| `overrideEnv` specifies custom environment variables for this component's container. These are merged with operator-managed environment variables, with user-defined values taking precedence. Environment variable names starting with `HOSTNAME`, `KUBERNETES_` or `EXTERNAL_SECRETS_` are reserved and are not allowed.
+a| The maximum number of items is 50.
+
+Optional
+|===

--- a/modules/eso-component-config.adoc
+++ b/modules/eso-component-config.adoc
@@ -1,0 +1,42 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-operator-api.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="eso-component-config_{context}"]
+= componentConfig
+
+[role="_abstract"]
+The `componentConfig` field defines configuration overrides for a specific `external-secrets` component.
+
+[cols="1,1,1,1,1",options="header"]
+|===
+| Field
+| Type
+| Description
+| Default
+| Validation
+
+| `componentName`
+| _string_
+| `componentName` identifies which `external-secrets` component this configuration applies to. Valid values are `ExternalSecretsCoreController`, `Webhook`, `CertController`, and `BitwardenSDKServer`.
+|
+a| Enum: [`ExternalSecretsCoreController`, `Webhook`, `CertController`, `BitwardenSDKServer`]
+
+Required
+
+| `deploymentConfigs`
+| _object_
+| `deploymentConfigs` specifies overrides for the Kubernetes Deployment resource of this component.
+|
+|
+
+| `overrideEnv`
+a| *EnvVar*
+
+_array_
+| `overrideEnv` specifies custom environment variables for the container of this component. These are merged with operator-managed environment variables, with user-defined values taking precedence. Environment variable names starting with `HOSTNAME`, `KUBERNETES_` or `EXTERNAL_SECRETS_` are reserved and are not allowed.
+|
+| The maximum number of items is 50.
+
+|===

--- a/modules/eso-component-name.adoc
+++ b/modules/eso-component-name.adoc
@@ -1,0 +1,34 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-operator-api.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="eso-component-name_{context}"]
+= componentName
+
+[role="_abstract"]
+The `componentName` field represents the `external-secrets` components that can have network policies applied.
+
+[cols="1,1,1",options="header"]
+|===
+| Field
+| Type
+| Description
+
+| `ExternalSecretsCoreController`
+| _object_
+| `ExternalSecretsCoreController` represents the `external-secrets` component.
+
+| `BitwardenSDKServer`
+| _object_
+| `BitwardenSDKServer` represents the `bitwarden-sdk-server` component.
+
+| `Webhook`
+| _object_
+| `Webhook` represents the `external-secrets` webhook component.
+
+| `CertController`
+| _object_
+| `CertController` represents the `cert-controller` component.
+
+|===

--- a/modules/eso-condition.adoc
+++ b/modules/eso-condition.adoc
@@ -1,0 +1,33 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-operator-api.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="eso-condition_{context}"]
+= condition
+
+[role="_abstract"]
+The `condition` object reports the current health and operational state of the {external-secrets-operator} deployment. It provides a standardized status check by detailing the specific type of condition, its current status, and a message to verify deployment success or troubleshooting errors.
+
+[cols="1,1,1,1",options="header"]
+|===
+| Field
+| Type
+| Description
+| Validation
+
+| `type`
+| _string_
+| `type` contains the condition of the deployment.
+| Required
+
+| `status`
+| link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#conditionstatus-v1-meta[_ConditionStatus_]
+| `status` contains the status of the condition of the deployment
+|
+
+| `message`
+| _string_
+| `message` provides details on the state of the deployment
+|
+|===

--- a/modules/eso-condition.adoc
+++ b/modules/eso-condition.adoc
@@ -1,0 +1,30 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-operator-api.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="eso-condition_{context}"]
+= condition
+
+[role="_abstract"]
+The `condition` object reports the current health and operational state of the {external-secrets-operator} deployment. It provides a standardized status check by detailing the specific type of condition, its current status, and a message to help verify deployment success or troubleshoot errors.
+
+[cols="1,1,1",options="header"]
+|===
+| Field
+| Type
+| Description
+
+| `type`
+| _string_
+| `type` contains the condition of the deployment.
+
+| `status`
+| link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#conditionstatus-v1-meta[_ConditionStatus_]
+| `status` contains the status of the condition of the deployment
+
+| `message`
+| _string_
+| `message` provides details on the state of the deployment
+
+|===

--- a/modules/eso-conditional-status.adoc
+++ b/modules/eso-conditional-status.adoc
@@ -1,0 +1,21 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-operator-api.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="eso-conditional-status_{context}"]
+= conditionalStatus
+
+[role="_abstract"]
+The `conditionalStatus` field holds information about the current state of the `external-secrets` deployment.
+
+[cols="1,1,1",options="header"]
+|===
+| Field
+| Type
+| Description
+
+| `conditions`
+| _array_
+| `conditions` contains information on the current state of the deployment.
+|===

--- a/modules/eso-controller-config.adoc
+++ b/modules/eso-controller-config.adoc
@@ -1,0 +1,51 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-operator-api.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="eso-controller-config_{context}"]
+= controllerConfig
+
+[role="_abstract"]
+The `controllerConfig` specifies the configurations used by the controller when installing the `external-secrets` operand and the plugins.
+
+[cols="1,1,1,1",options="header"]
+|===
+| Field
+| Type
+| Description
+| Validation
+
+| `certProvider`
+| _string_
+| `certProvider` defines the configuration for the certificate providers used to manage TLS certificates for webhook and plugins.
+| Optional
+
+| `labels`
+| _object (keys:string, values:string)_
+| `labels` field applies labels to all resources created for the `external-secrets` operand deployment.
+a| The maximum number of properties is 20.
+
+The minimum number of properties is 0.
+
+Optional
+
+| `annotations`
+| _object (keys:string, values:string)_
+| `annotations` add custom annotations to all the resources created for the `external-secrets` deployment. The annotations are merged with any default annotations set by the Operator. User-specified annotations take precedence over defaults in case of conflicts. Annotation keys containing the reserved domains `kubernetes.io/`, `openshift.io/`, `k8s.io/`, or `cert-manager.io/` (including subdomains like `*.kubernetes.io/`) are not allowed.
+a| The maximum number of properties is 20.
+
+The minimum number of properties is 0.
+
+Optional
+
+| `componentConfigs`
+| _ComponentConfig array_
+| `componentConfigs` allows specifying deployment-level configuration overrides for individual `external-secrets` components. Each component can have only one configuration entry.
+a| The maximum number of items is 4.
+
+The minimum number of items is 0.
+
+Optional
+
+|===

--- a/modules/eso-controller-config.adoc
+++ b/modules/eso-controller-config.adoc
@@ -1,0 +1,60 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-operator-api.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="eso-controller-config_{context}"]
+= controllerConfig
+
+[role="_abstract"]
+The `controllerConfig` specifies the configurations used by the controller when installing the `external-secrets` operand and the plugins.
+
+[cols="1,1,1,1,1",options="header"]
+|===
+| Field
+| Type
+| Description
+| Default
+| Validation
+
+| `certProvider`
+| _certProviderConfig_
+| `certProvider` defines the configuration for the certificate providers used to manage TLS certificates for webhook and plugins.
+|
+| 
+
+| `labels`
+| _object (keys:string, values:string)_
+| `labels` field applies labels to all resources created for the `external-secrets` operand deployment.
+|
+a| The maximum number of properties is 20.
+
+The minimum number of properties is 0.
+
+| `annotations`
+| _object (keys:string, values:string)_
+| `annotations` add custom annotations to all the resources created for the `external-secrets` deployment. The annotations are merged with any default annotations set by the Operator. User-specified annotations take precedence over defaults in case of conflicts. Annotation keys containing the reserved domains `kubernetes.io/`, `openshift.io/`, `k8s.io/`, or `cert-manager.io/` (including subdomains like `*.kubernetes.io/`) are not allowed.
+|
+a| The maximum number of annotations is 20.
+
+The minimum number of annotations is 0.
+
+| `networkPolicies`
+| _networkPolicy array_
+| `networkPolicies` specifies the list of network policy configurations
+to be applied to `external-secrets` pods. Each entry allows specifying a name for the generated `NetworkPolicy` object, along with its full Kubernetes `NetworkPolicy` definition. If this field is not provided, external-secrets components are isolated with deny-all network policies, which prevents proper operation.
+|
+a| The maximum number of items is 50.
+
+The minimum number of items is 0.
+
+| `componentConfigs`
+| _ComponentConfig array_
+| `componentConfigs` allows specifying deployment-level configuration overrides for individual `external-secrets` components. This field enables fine-grained control over deployment settings for each component independently.
+Each component can have only one configuration entry.
+|
+| The maximum number of items is 4.
+
+The minimum number of items is 0.
+
+|===

--- a/modules/eso-controller-status.adoc
+++ b/modules/eso-controller-status.adoc
@@ -1,0 +1,33 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-operator-api.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="eso-controller-status_{context}"]
+= controllerStatus
+
+[role="_abstract"]
+The `controllerStatus` field tracks the health and synchronization state of the individual controllers managed by the Operator. It identifies each controller by name, details its current operational conditions, and verifies that the controller is processing the latest configuration version.
+
+[cols="1,1,1,1",options="header"]
+|===
+| Field
+| Type
+| Description
+| Validation
+
+| `name`
+| _string_
+| `name` specifies the name of the controller for which the observed condition is recorded.
+| Required
+
+| `conditions`
+| _array_
+| `conditions` contains information about the current state of the {external-secrets-operator-short} controllers.
+|
+
+| `observedGeneration`
+| _integer_
+| `observedGeneration` represents the `.metadata.generation` on the observed resource.
+| The minimum number of observed resources is 0.
+|===

--- a/modules/eso-deployment-config.adoc
+++ b/modules/eso-deployment-config.adoc
@@ -1,0 +1,29 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-operator-api.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="eso-deployment-config_{context}"]
+= deploymentConfig
+
+[role="_abstract"]
+The `deploymentConfig` field defines configuration overrides for a Kubernetes Deployment resource.
+
+[cols="1,1,1,1,1",options="header"]
+|===
+| Field
+| Type
+| Description
+| Default
+| Validation
+
+| `revisionHistoryLimit`
+| _integer_
+| `revisionHistoryLimit` specifies the number of old `ReplicaSets` to retain for rollback purposes. This allows rolling back to previous deployment versions using the command `oc rollout undo`. Must be at least 1 to ensure rollback capability.
+| 10
+a| The minimum value is 1.
+
+The maximum value is 50.
+
+Optional
+|===

--- a/modules/eso-deployment-config.adoc
+++ b/modules/eso-deployment-config.adoc
@@ -1,0 +1,28 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-operator-api.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="eso-deployment-config_{context}"]
+= deploymentConfig
+
+[role="_abstract"]
+The `deploymentConfig` field defines configuration overrides for a Kubernetes Deployment resource.
+
+[cols="1,1,1,1,1",options="header"]
+|===
+| Field
+| Type
+| Description
+| Default
+| Validation
+
+| `revisionHistoryLimit`
+| _integer_
+| `revisionHistoryLimit` specifies the number of old `ReplicaSets` to retain for rollback purposes. This allows rolling back to previous deployment versions using the command `oc rollout undo`. Set this field to at least 1 to ensure rollback capability.
+| 10
+a| The maximum value is 50.
+
+The minimum value is 1.
+
+|===

--- a/modules/eso-external-secrets-config.adoc
+++ b/modules/eso-external-secrets-config.adoc
@@ -1,0 +1,83 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-operator-api.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="eso-external-secrets-config_{context}"]
+= applicationConfig
+
+[role="_abstract"]
+The `applicationConfig` object customizes the runtime behavior and deployment constraints of the operand. Use this section to control observability, define the operational scope, and configure webhook specifics. Additionally, you can tailor the deployment to your infrastructure requirements.
+
+[cols="1,1,1,1,1",options="header"]
+|===
+| Field
+| Type
+| Description
+| Default
+| Validation
+
+| `logLevel`
+| _integer_
+| `logLevel` supports a range of values as defined in the link:https://github.com/kubernetes/community/blob/master/contributors/devel/sig-instrumentation/logging.md#what-method-to-use[kubernetes logging guidelines].
+| 1
+| The maximum range value is 5
+
+The minimum range value is 1
+
+Optional
+
+| `operatingNamespace`
+| _string_
+| `operatingNamespace` restricts the `external-secrets` operand operations to the provided namespace. Enabling this field disables `ClusterSecretStore` and `ClusterExternalSecret`.
+|
+| The maximum length is 63
+
+The minimum length is 1
+
+Optional
+
+| `webhookConfig`
+| _object_
+| `webhookConfig` configures webhook specifics of the `external-secrets` operand.
+|
+|
+
+| `resources`
+| link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#resourcerequirements-v1-core[_ResourceRequirements_]
+| `resources` defines the resource requirements. You cannot change the value of this field after setting it initially. For more information, see link:https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/[]
+|
+| Optional
+
+| `affinity`
+| link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#affinity-v1-core[_Affinity_]
+| `affinity` sets the scheduling affinity rules. For more information, see link:https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/[]
+|
+| Optional
+
+| `tolerations`
+| link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#toleration-v1-core[_Toleration_] _array_
+| `tolerations` sets the pod tolerations. For more information, see link:https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/[]
+|
+| The maximum number of items is 50
+
+The minimum number of items is 0
+
+Optional
+
+| `nodeSelector`
+| _object (keys:string, values:string)_
+| `nodeSelector` defines the scheduling criteria by using node labels. For more information, see link:https://kubernetes.io/docs/concepts/configuration/assign-pod-node/[]
+|
+| The maximum number of properties is 50
+
+The minimum number of properties is 0
+
+Optional
+
+| `proxy`
+| _object (keys:string, values:string)_
+| `proxy` sets the proxy configurations available in operand containers managed by the Operator as environment variables.
+|
+| Optional
+|===

--- a/modules/eso-external-secrets-config.adoc
+++ b/modules/eso-external-secrets-config.adoc
@@ -1,0 +1,83 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-operator-api.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="eso-external-secrets-config_{context}"]
+= applicationConfig
+
+[role="_abstract"]
+You can use the `applicationConfig` object to customize the runtime behavior, observability, operational scope, and webhook and infrastructure settings of the operand.
+
+[cols="1,1,1,1,1",options="header"]
+|===
+| Field
+| Type
+| Description
+| Default
+| Validation
+
+| `logLevel`
+| _integer_
+| `logLevel` supports a range of values as defined in the link:https://github.com/kubernetes/community/blob/master/contributors/devel/sig-instrumentation/logging.md#what-method-to-use[kubernetes logging guidelines].
+| 1
+| The maximum range value is 5
+
+The minimum range value is 1
+
+Optional
+
+| `operatingNamespace`
+| _string_
+| `operatingNamespace` restricts the `external-secrets` operand operations to the provided namespace. Enabling this field disables `ClusterSecretStore` and `ClusterExternalSecret`.
+|
+| The maximum length is 63
+
+The minimum length is 1
+
+Optional
+
+| `webhookConfig`
+| _object_
+| `webhookConfig` configures webhook specifics of the `external-secrets` operand.
+|
+|
+
+| `resources`
+| link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#resourcerequirements-v1-core[_ResourceRequirements_]
+| `resources` defines the resource requirements. You cannot change the value of this field after setting it initially. For more information, see link:https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/[]
+|
+| Optional
+
+| `affinity`
+| link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#affinity-v1-core[_Affinity_]
+| `affinity` sets the scheduling affinity rules. For more information, see link:https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/[]
+|
+| Optional
+
+| `tolerations`
+| link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#toleration-v1-core[_Toleration_] _array_
+| `tolerations` sets the pod tolerations. For more information, see link:https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/[]
+|
+| The maximum number of items is 50
+
+The minimum number of items is 0
+
+Optional
+
+| `nodeSelector`
+| _object (keys:string, values:string)_
+| `nodeSelector` defines the scheduling criteria by using node labels. For more information, see link:https://kubernetes.io/docs/concepts/configuration/assign-pod-node/[]
+|
+| The maximum number of properties is 50
+
+The minimum number of properties is 0
+
+Optional
+
+| `proxy`
+| _proxyConfig_
+| `proxy` sets the proxy configurations available in operand containers managed by the Operator as environment variables.
+|
+| Optional
+|===

--- a/modules/eso-external-secrets-list.adoc
+++ b/modules/eso-external-secrets-list.adoc
@@ -1,0 +1,33 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-operator-api.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="eso-external-secrets-list_{context}"]
+= externalSecretsConfigList
+
+[role="_abstract"]
+The `externalSecretsConfigList` object fetches the list of `externalSecretsConfig` objects.
+
+[cols="1,1,1",options="header"]
+|===
+| Field
+| Type
+| Description
+
+| `apiVersion`
+| _string_
+| The `apiVersion` specifies the version of the schema in use, which is `operator.openshift.io/v1alpha1`
+
+| `kind`
+| _string_
+| `kind` specifies the type of the object, which is `externalSecretsList` for this API.
+
+| `metadata`
+| link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#listmeta-v1-meta[_ListMeta_]
+| Refer to Kubernetes API documentation for details about the `metadata` fields.
+
+| `items`
+| _array_
+| `Items` contains a list of `externalSecrets` objects.
+|===

--- a/modules/eso-external-secrets-list.adoc
+++ b/modules/eso-external-secrets-list.adoc
@@ -1,0 +1,33 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-operator-api.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="eso-external-secrets-list_{context}"]
+= externalSecretsConfigList
+
+[role="_abstract"]
+The `externalSecretsConfigList` object fetches the list of `externalSecretsConfig` objects.
+
+[cols="1,1,1",options="header"]
+|===
+| Field
+| Type
+| Description
+
+| `apiVersion`
+| _string_
+| The `apiVersion` specifies the version of the schema in use, which is `operator.openshift.io/v1alpha1`
+
+| `kind`
+| _string_
+| `kind` specifies the type of the object, which is `externalSecretsConfigList` for this API.
+
+| `metadata`
+| link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#listmeta-v1-meta[_ListMeta_]
+| Refer to Kubernetes API documentation for details about the `metadata` fields.
+
+| `items`
+| _array_
+| `Items` contains a list of `externalSecretsConfig` objects.
+|===

--- a/modules/eso-external-secrets-manager-list.adoc
+++ b/modules/eso-external-secrets-manager-list.adoc
@@ -1,0 +1,34 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-operator-api.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="eso-external-secrets-manager-list_{context}"]
+= externalSecretsManagerList
+
+[role="_abstract"]
+The `externalSecretsManagerList` object fetches the list of `externalSecretsManager` objects.
+
+
+[cols="1,1,1",options="header"]
+|===
+| Field
+| Type
+| Description
+
+| `apiVersion`
+| _string_
+| The `apiVersion` specifies the version of the schema in use, which is `operator.openshift.io/v1alpha1`.
+
+| `kind`
+| _string_
+| `kind` specifies the type of the object, which is `externalSecretsManagerList` for this API.
+
+| `metadata`
+| link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#listmeta-v1-meta[_ListMeta_]
+| Refer to Kubernetes API documentation for details about the `metadata` fields.
+
+| `items`
+| _array_
+|
+|===

--- a/modules/eso-external-secrets-manager-spec.adoc
+++ b/modules/eso-external-secrets-manager-spec.adoc
@@ -1,0 +1,23 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-operator-api.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="eso-external-secrets-manager-spec_{context}"]
+= externalSecretsManagerSpec
+
+[role="_abstract"]
+The `externalSecretsManagerSpec` field defines the desired behavior of the `externalSecretsManager` object.
+
+[cols="1,1,1,1",options="header"]
+|===
+| Field
+| type
+| Description
+| Validation
+
+| `globalConfig`
+| _object_
+| `globalConfig` configures the behavior of deployments that {external-secrets-operator-short} manages.
+| Optional
+|===

--- a/modules/eso-external-secrets-manager-spec.adoc
+++ b/modules/eso-external-secrets-manager-spec.adoc
@@ -1,0 +1,23 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-operator-api.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="eso-external-secrets-manager-spec_{context}"]
+= externalSecretsManagerSpec
+
+[role="_abstract"]
+The `externalSecretsManagerSpec` field defines the desired behavior of the `externalSecretsConfig` object.
+
+[cols="1,1,1,1",options="header"]
+|===
+| Field
+| type
+| Description
+| Validation
+
+| `globalConfig`
+| _object_
+| `globalConfig` configures the behavior of deployments that {external-secrets-operator-short} manages.
+| Optional
+|===

--- a/modules/eso-external-secrets-manager-status.adoc
+++ b/modules/eso-external-secrets-manager-status.adoc
@@ -1,0 +1,30 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-operator-api.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="eso-external-secrets-manager-status_{context}"]
+= externalSecretsManagerStatus
+
+[role="_abstract"]
+The `externalSecretsManagerStatus` field shows the most recently observed status of the `externalSecretsManager` object.
+
+[cols="1,1,1,1",options="header"]
+|===
+| Field
+| Type
+| Description
+| Validation
+
+| `controllerStatuses`
+|  _array_
+| `controllerStatuses` holds the observed conditions of the controllers used by the Operator.
+|
+
+| `lastTransitionTime`
+| link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#time-v1-meta[_Time_]
+| `lastTransitionTime` records the most recent time the status of the condition changed.
+| Format: date-time
+
+Type: string
+|===

--- a/modules/eso-external-secrets-manager.adoc
+++ b/modules/eso-external-secrets-manager.adoc
@@ -1,0 +1,37 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-operator-api.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="eso-external-secrets-manager_{context}"]
+= externalSecretsManager
+
+[role="_abstract"]
+The `externalSecretsManager` object defines the configuration and information of deployments managed by the {external-secrets-operator-short}. Set the name to `cluster` as this allows only one instance of `externalSecretsManager` per cluster. You can configure global options by using `externalSecretsManager`. This serves as a centralized configuration for managing multiple controllers of the Operator. The Operator automatically creates the `externalSecretsManager` object during installation.
+
+[cols="1,1,1",options="header"]
+|===
+| Field
+| Type
+| Description
+
+| `apiVersion`
+| _string_
+| The `apiVersion` specifies the version of the schema in use, which is `operator.openshift.io/v1alpha1`.
+
+| `kind`
+| _string_
+| `kind` specifies the type of the object, which is `externalSecretsManager` for this Object.
+
+| `metadata`
+| link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#objectmeta-v1-meta[_ObjectMeta_]
+| Refer to Kubernetes API documentation for details about the `metadata` fields.
+
+| `spec`
+| _object_
+| `spec` contains specifications of the desired behavior.
+
+| `status`
+| _object_
+| `status` displays the most recently observed state of the controllers in the {external-secrets-operator-short}.
+|===

--- a/modules/eso-external-secrets-manager.adoc
+++ b/modules/eso-external-secrets-manager.adoc
@@ -1,0 +1,39 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-operator-api.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="eso-external-secrets-manager_{context}"]
+= externalSecretsManager
+
+[role="_abstract"]
+You can configure global options by using `externalSecretsManager`, which serves as a centralized configuration for managing multiple controllers of the Operator. The Operator automatically creates this object during installation.
+
+The `externalSecretsManager` object defines the configuration and information of deployments managed by the {external-secrets-operator-short}. Set the name to `cluster` as this allows only one instance of `externalSecretsManager` per cluster. 
+
+[cols="1,1,1",options="header"]
+|===
+| Field
+| Type
+| Description
+
+| `apiVersion`
+| _string_
+| The `apiVersion` specifies the version of the schema in use, which is `operator.openshift.io/v1alpha1`.
+
+| `kind`
+| _string_
+| `kind` specifies the type of the object, which is `externalSecretsManager` for this object.
+
+| `metadata`
+| link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#objectmeta-v1-meta[_ObjectMeta_]
+| Refer to Kubernetes API documentation for details about the `metadata` fields.
+
+| `spec`
+| _object_
+| `spec` contains specifications of the desired behavior.
+
+| `status`
+| _object_
+| `status` displays the most recently observed state of the controllers in the {external-secrets-operator-short}.
+|===

--- a/modules/eso-external-secrets-spec.adoc
+++ b/modules/eso-external-secrets-spec.adoc
@@ -1,0 +1,33 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-operator-api.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="eso-external-secrets-spec_{context}"]
+= externalSecretsConfigSpec
+
+[role="_abstract"]
+The `externalSecretsConfigSpec` field defines the desired behavior of the `externalSecrets` object.
+
+[cols="1,1,1,1",options="header"]
+|===
+| Field
+| Type
+| Description
+| Validation
+
+| `appConfig`
+| _object_
+| `appConfig` configures the behavior of the `external-secrets` operand.
+| Optional
+
+| `plugins`
+| _object_
+| `plugins` configures the optional provider plugins.
+| Optional
+
+| `controllerConfig`
+| _object_
+| `controllerConfig` configures the controller to set up defaults that enable `external-secrets` operand.
+| Optional
+|===

--- a/modules/eso-external-secrets-spec.adoc
+++ b/modules/eso-external-secrets-spec.adoc
@@ -1,0 +1,32 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-operator-api.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="eso-external-secrets-spec_{context}"]
+= externalSecretsConfigSpec
+
+[role="_abstract"]
+The `externalSecretsConfigSpec` field defines the desired behavior of the `externalSecrets` object.
+
+[cols="1,1,1",options="header"]
+|===
+| Field
+| Type
+| Description
+
+| `appConfig`
+| _object_
+| `appConfig` configures the behavior of the `external-secrets` operand.
+
+
+| `plugins`
+| _object_
+| `plugins` configures the optional provider plugins.
+
+
+| `controllerConfig`
+| _object_
+| `controllerConfig` configures the controller to set up defaults that enable `external-secrets` operand.
+
+|===

--- a/modules/eso-external-secrets-status.adoc
+++ b/modules/eso-external-secrets-status.adoc
@@ -1,0 +1,29 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-operator-api.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="eso-external-secrets-status_{context}"]
+= externalSecretsConfigStatus
+
+[role="_abstract"]
+The `externalSecretsConfigStatus` field shows the most recently observed status of the `externalSecretsConfig` Object.
+
+[cols="1,1,1",options="header"]
+|===
+| Field
+| Type
+| Description
+
+| `conditions`
+| link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#condition-v1-meta[_Condition_] _array_
+| `conditions` contains information about the current state of deployment.
+
+| `externalSecretsImage`
+| _string_
+| `externalSecretsImage` specifies the image name and tag used for deploy `external-secrets` operand.
+
+| `bitwardenSDKServerImage`
+| _string_
+| `bitwardenSDKServerImage` specifies the name of the image and tag used for deploying the `bitwarden-sdk-server`.
+|===

--- a/modules/eso-external-secrets-status.adoc
+++ b/modules/eso-external-secrets-status.adoc
@@ -1,0 +1,29 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-operator-api.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="eso-external-secrets-status_{context}"]
+= externalSecretsConfigStatus
+
+[role="_abstract"]
+The `externalSecretsConfigStatus` field shows the most recently observed status of the `externalSecretsConfig` object.
+
+[cols="1,1,1",options="header"]
+|===
+| Field
+| Type
+| Description
+
+| `conditions`
+| link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#condition-v1-meta[_Condition_] _array_
+| `conditions` contains information about the current state of deployment.
+
+| `externalSecretsImage`
+| _string_
+| `externalSecretsImage` specifies the image name and tag used to deploy the `external-secrets` operand.
+
+| `bitwardenSDKServerImage`
+| _string_
+| `bitwardenSDKServerImage` specifies the name of the image and tag used for deploying the `bitwarden-sdk-server`.
+|===

--- a/modules/eso-external-secrets.adoc
+++ b/modules/eso-external-secrets.adoc
@@ -1,0 +1,39 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-operator-api.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="eso-external-secrets_{context}"]
+= externalSecretsConfig
+
+[role="_abstract"]
+The `externalSecretsConfig` object defines the configuration and information for the managed `external-secrets` operand deployment. Set the name to `cluster` as `externalSecretsConfig` object allows only one instance per cluster.
+
+Creating an `externalSecretsConfig` object triggers the deployment of the `external-secrets` operand and maintains the desired state.
+
+[cols="1,1,1",options="header"]
+|===
+| Field
+| Type
+| Description
+
+| `apiVersion`
+| _string_
+| The `apiVersion` specifies the version of the schema in use, which is `operator.openshift.io/v1alpha1`.
+
+| `kind`
+| _string_
+| `kind` specifies the type of the object, which is `externalSecrets` for this object.
+
+| `metadata`
+| link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#objectmeta-v1-meta[_ObjectMeta_]
+| Refer to Kubernetes API documentation for details about the `metadata` fields.
+
+| `spec`
+| _object_
+| `spec` contains the specifications of the desired behavior of the `externalSecrets` object.
+
+| `status`
+| _object_
+| `status` displays the most recently observed status of the `externalSecrets` object.
+|===

--- a/modules/eso-external-secrets.adoc
+++ b/modules/eso-external-secrets.adoc
@@ -1,0 +1,39 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-operator-api.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="eso-external-secrets_{context}"]
+= externalSecretsConfig
+
+[role="_abstract"]
+The `externalSecretsConfig` object defines the configuration and information for the managed `external-secrets` operand deployment. Set the name to `cluster` as the `externalSecretsConfig` object allows only one instance per cluster.
+
+Creating an `externalSecretsConfig` object triggers the deployment of the `external-secrets` operand and maintains the desired state.
+
+[cols="1,1,1",options="header"]
+|===
+| Field
+| Type
+| Description
+
+| `apiVersion`
+| _string_
+| The `apiVersion` specifies the version of the schema in use, which is `operator.openshift.io/v1alpha1`.
+
+| `kind`
+| _string_
+| `kind` specifies the type of the object, which is `externalSecretsConfig` for this object.
+
+| `metadata`
+| link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#objectmeta-v1-meta[_ObjectMeta_]
+| Refer to Kubernetes API documentation for details about the `metadata` fields.
+
+| `spec`
+| _object_
+| `spec` contains the specifications of the desired behavior of the `externalSecrets` object.
+
+| `status`
+| _object_
+| `status` displays the most recently observed status of the `externalSecrets` object.
+|===

--- a/modules/eso-global-config.adoc
+++ b/modules/eso-global-config.adoc
@@ -1,0 +1,77 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-operator-api.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="eso-global-config_{context}"]
+= globalConfig
+
+[role="_abstract"]
+The `globalConfig` field defines the baseline behavior and deployment parameters for the {external-secrets-operator}. Use this section to apply labels to all managed resources and configure the logging verbosity. It also provides infrastructure-level controls to govern where and how the Operator is scheduled, alongside proxy settings for network compatibility.
+
+[cols="1,1,1,1,1",options="header"]
+|===
+| Field
+| Type
+| Description
+| Default
+| Validation
+
+| `labels`
+| _integer_
+| `labels` applies to all resources created by the Operator. This field can have a maximum of 20 entries
+| 1
+| The maximum number of properties is 20
+
+The minimum number of properties is 0
+
+Optional
+
+| `logLevel`
+| _integer_
+| `logLevel` supports a range of values as defined in the link:https://github.com/kubernetes/community/blob/master/contributors/devel/sig-instrumentation/logging.md#what-method-to-use[kubernetes logging guidelines].
+| 1
+| The maximum range value is 5
+
+The minimum range value is 1
+
+Optional
+
+| `resources`
+| link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#resourcerequirements-v1-core[_ResourceRequirements_]
+| `resources` defines the resource requirements. You cannot change the value of this field after setting it initially. For more information, see link:https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/[]
+|
+| Optional
+
+| `affinity`
+| link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#affinity-v1-core[_Affinity_]
+| `affinity` sets the scheduling affinity rules. For more information, see link:https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/[]
+|
+| Optional
+
+| `tolerations`
+| link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#toleration-v1-core[_Toleration_] _array_
+| `tolerations` sets the pod tolerations. For more information, see link:https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/[]
+|
+| The maximum number of items is 50
+
+The minimum number of items is 0
+
+Optional
+
+| `nodeSelector`
+| _object (keys:string, values:string)_
+| `nodeSelector` defines the scheduling criteria by using the node labels. For more information, see link:https://kubernetes.io/docs/concepts/configuration/assign-pod-node/[]
+|
+| The maximum number of properties is 50
+
+The minimum number of properties is 0
+
+Optional
+
+| `proxy`
+| _object_
+| `proxy` sets the proxy configurations available in the operand containers managed by the Operator as environment variables.
+|
+| Optional
+|===

--- a/modules/eso-global-config.adoc
+++ b/modules/eso-global-config.adoc
@@ -1,0 +1,72 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-operator-api.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="eso-global-config_{context}"]
+= globalConfig
+
+[role="_abstract"]
+You can use the `globalConfig` field to configure baseline behavior and deployment parameters for the {external-secrets-operator}, including resource labels, logging verbosity, scheduling controls, and proxy settings.
+
+Apply labels to all managed resources and configure the logging verbosity by using this field. It also provides infrastructure-level controls to govern where and how the Operator is scheduled, alongside proxy settings for network compatibility.
+
+[cols="1,1,1,1,1",options="header"]
+|===
+| Field
+| Type
+| Description
+| Default
+| Validation
+
+| `logLevel`
+| _integer_
+| `logLevel` supports a range of values as defined in the link:https://github.com/kubernetes/community/blob/master/contributors/devel/sig-instrumentation/logging.md#what-method-to-use[kubernetes logging guidelines].
+| 1
+| The maximum range value is 5
+
+The minimum range value is 1
+
+| `resources`
+| link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#resourcerequirements-v1-core[_ResourceRequirements_]
+| `resources` defines the resource requirements. You cannot change the value of this field after setting it initially. For more information, see link:https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/[]
+|
+| 
+
+| `affinity`
+| link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#affinity-v1-core[_Affinity_]
+| `affinity` sets the scheduling affinity rules. For more information, see link:https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/[]
+|
+| 
+
+| `tolerations`
+| link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#toleration-v1-core[_Toleration_] _array_
+| `tolerations` sets the pod tolerations. For more information, see link:https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/[]
+|
+| The maximum number of items is 50
+
+The minimum number of items is 0
+
+| `nodeSelector`
+| _object (keys:string, values:string)_
+| `nodeSelector` defines the scheduling criteria by using the node labels. For more information, see link:https://kubernetes.io/docs/concepts/configuration/assign-pod-node/[]
+|
+| The maximum number of properties is 50
+
+The minimum number of properties is 0
+
+| `proxy`
+| _proxyConfig_
+| `proxy` sets the proxy configurations available in the operand containers managed by the Operator as environment variables.
+|
+| 
+
+| `labels`
+| _object (keys:string, values:string)_
+| `labels` applies to all resources created by the Operator. This field can have a maximum of 20 entries
+| 
+| The maximum number of properties is 20
+
+The minimum number of properties is 0
+
+|===

--- a/modules/eso-mode.adoc
+++ b/modules/eso-mode.adoc
@@ -1,0 +1,22 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-operator-api.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="eso-mode_{context}"]
+= mode
+
+[role="_abstract"]
+The `mode` field indicates the operational state of the optional features.
+
+[cols="1,1",options="header"]
+|===
+| Field
+| Description
+
+| `Enabled`
+| `Enabled` indicates the optional configuration is enabled.
+
+| `Disabled`
+| `Disabled` indicates the optional configuration is disabled.
+|===

--- a/modules/eso-network-policy.adoc
+++ b/modules/eso-network-policy.adoc
@@ -1,0 +1,41 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-operator-api.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="eso-network-policy_{context}"]
+= networkPolicy
+
+[role="_abstract"]
+The `networkPolicy` field represents a custom network policy configuration for operator-managed components. The field includes a name for identification and the network policy rules to be enforced.
+
+[cols="1,1,1,1,1",options="header"]
+|===
+| Field
+| Type
+| Description
+| Default
+| Validation
+
+| `name`
+| _string_
+| `name` is a unique identifier for this network policy configuration. This name is used as part of the generated `NetworkPolicy` resource name.
+|
+a| The maximum length is 253 characters.
+
+The minimum length is 1 character.
+
+| `componentName`
+| _string_
+| `componentName` specifies which external-secrets component this network policy applies to.
+|
+| Enum:[`ExternalSecretsCoreController` `BitwardenSDKServer`]
+
+| `egress`
+  *NetworkPolicyegressRule*
+|_array_
+| `egress` is a list of egress rules to be applied to the selected pods. Outgoing traffic is allowed if there are no `NetworkPolicies` selecting the pod, and cluster policy otherwise allows the traffic, or if the traffic matches at least one egress rule across all the `NetworkPolicy` objects whose `podSelector` matches the pod. If this field is empty, then this `NetworkPolicy` limits all outgoing traffic and serves solely to ensure that the pods it selects are isolated by default. The Operator automatically handles ingress rules based on the current running ports.
+|
+| 
+
+|===

--- a/modules/eso-object-reference.adoc
+++ b/modules/eso-object-reference.adoc
@@ -1,0 +1,45 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-operator-api.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="eso-object-reference_{context}"]
+= objectReference
+
+[role="_abstract"]
+The `ObjectReference` object acts as a pointer to a specific Kubernetes resource. It uniquely identifies the target by requiring its name, and optionally, helps scope the reference to a specific resource type and API group.
+
+[cols="1,1,1,1",options="header"]
+|===
+| Field
+| Type
+| Description
+| Validation
+
+| `name`
+| _string_
+| `name` specifies the name of the resource being referred to.
+| The maximum length is 253 characters.
+
+The minimum length is 1 character.
+
+Required
+
+| `kind`
+| _string_
+| `kind` specifies the kind of the resource being referred to.
+| The maximum length is 253 characters.
+
+The minimum length is 1 character.
+
+Optional
+
+| `group`
+| _string_
+| `group` specifies the group of the resource being referred to.
+| The maximum length is 253 characters.
+
+The minimum length is 1 character.
+
+Optional
+|===

--- a/modules/eso-object-reference.adoc
+++ b/modules/eso-object-reference.adoc
@@ -1,0 +1,45 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-operator-api.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="eso-object-reference_{context}"]
+= objectReference
+
+[role="_abstract"]
+The `objectReference` object acts as a pointer to a specific Kubernetes resource. It uniquely identifies the target by requiring its name, and optionally, helps scope the reference to a specific resource type and API group.
+
+[cols="1,1,1,1",options="header"]
+|===
+| Field
+| Type
+| Description
+| Validation
+
+| `name`
+| _string_
+| `name` specifies the name of the resource being referred to.
+| The maximum length is 253 characters.
+
+The minimum length is 1 character.
+
+Required
+
+| `kind`
+| _string_
+| `kind` specifies the kind of the resource being referred to.
+| The maximum length is 253 characters.
+
+The minimum length is 1 character.
+
+Optional
+
+| `group`
+| _string_
+| `group` specifies the group of the resource being referred to.
+| The maximum length is 253 characters.
+
+The minimum length is 1 character.
+
+Optional
+|===

--- a/modules/eso-plugins-config.adoc
+++ b/modules/eso-plugins-config.adoc
@@ -1,0 +1,23 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-operator-api.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="eso-plugiins-config_{context}"]
+= pluginsConfig
+
+[role="_abstract"]
+The `pluginsConfig` configures the optional plugins.
+
+[cols="1,1,1,1",options="header"]
+|===
+| Field
+| Type
+| Description
+| Validation
+
+| `bitwardenSecretManagerProvider`
+| _object_
+| `bitwardenSecretManagerProvider` enables the `bitwarden-secrets-manager` provider plugin for connecting with the 'bitwarden-secrets-manager'.
+| Optional
+|===

--- a/modules/eso-plugins-config.adoc
+++ b/modules/eso-plugins-config.adoc
@@ -1,0 +1,23 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-operator-api.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="eso-plugins-config_{context}"]
+= pluginsConfig
+
+[role="_abstract"]
+The `pluginsConfig` configures the optional plugins.
+
+[cols="1,1,1,1",options="header"]
+|===
+| Field
+| Type
+| Description
+| Validation
+
+| `bitwardenSecretManagerProvider`
+| _object_
+| `bitwardenSecretManagerProvider` enables the `bitwarden-secrets-manager` provider plugin for connecting with the `bitwarden-secrets-manager`.
+| Optional
+|===

--- a/modules/eso-proxy-config.adoc
+++ b/modules/eso-proxy-config.adoc
@@ -1,0 +1,45 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-operator-api.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="eso-proxy-config_{context}"]
+= proxyConfig
+
+[role="_abstract"]
+The `proxyConfig` object defines the network proxy settings that the Operator injects into managed containers as environment variables. Use this configuration to ensure proper connectivity in restricted network environments, or to bypass the proxy and connect directly.
+
+[cols="1,1,1,1",options="header"]
+|===
+| Field
+| Type
+| Description
+| Validation
+
+| `httpProxy`
+| _string_
+| The `httpProxy` field contains the URL of the proxy for HTTP requests. This field can have a maximum of 2048 characters.
+| The maximum length is 2048 characters.
+
+The minimum length is 0 characters.
+
+Optional
+
+| `httpsProxy`
+| _string_
+| The `httpsProxy` field contains the URL of the proxy for HTTPS requests. This field can have a maximum of 2048 characters.
+| The maximum length is 2048 characters.
+
+The minimum length is 0 characters.
+
+Optional
+
+| `noProxy`
+| _string_
+| The `noProxy` field is a comma-separated list of hostnames, classless inter-domain routings (CIDRs), and IP addresses or a combination of the three for which the proxy should not be used. This field can have a maximum of 4096 characters.
+| The maximum length is 4096 characters.
+
+The minimum length is 0 characters.
+
+Optional
+|===

--- a/modules/eso-proxy-config.adoc
+++ b/modules/eso-proxy-config.adoc
@@ -1,0 +1,44 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-operator-api.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="eso-proxy-config_{context}"]
+= proxyConfig
+
+[role="_abstract"]
+You can use the `proxyConfig` object to define network proxy settings that the Operator injects into managed containers as environment variables, ensuring proper connectivity in restricted network environments or allowing you to bypass the proxy entirely.
+
+[cols="1,1,1,1,1",options="header"]
+|===
+| Field
+| Type
+| Description
+| Default
+| Validation
+
+| `httpProxy`
+| _string_
+| The `httpProxy` field contains the URL of the proxy for HTTP requests. This field can have a maximum of 2048 characters.
+|
+| The maximum length is 2048 characters.
+
+The minimum length is 0 characters.
+
+| `httpsProxy`
+| _string_
+| The `httpsProxy` field contains the URL of the proxy for HTTPS requests. This field can have a maximum of 2048 characters.
+|
+| The maximum length is 2048 characters.
+
+The minimum length is 0 characters.
+
+| `noProxy`
+| _string_
+| The `noProxy` field is a comma-separated list of hostnames, classless inter-domain routings (CIDRs), and IP addresses or a combination of the three for which the proxy should not be used. This field can have a maximum of 4096 characters.
+|
+| The maximum length is 4096 characters.
+
+The minimum length is 0 characters.
+
+|===

--- a/modules/eso-secret-reference.adoc
+++ b/modules/eso-secret-reference.adoc
@@ -1,0 +1,27 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-operator-api.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="eso-secret-reference_{context}"]
+= secretReference
+
+[role="_abstract"]
+The `secretReference` field refers to a secret with the given name in the same namespace where it used.
+
+[cols="1,1,1,1",options="header"]
+|===
+| Field
+| Type
+| Description
+| Validation
+
+| `name`
+| _string_
+| `name` specifies the name of the secret resource being referred to.
+| The maximum length is 253.
+
+The minimum length is 1.
+
+Required
+|===

--- a/modules/eso-secret-reference.adoc
+++ b/modules/eso-secret-reference.adoc
@@ -1,0 +1,26 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-operator-api.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="eso-secret-reference_{context}"]
+= secretReference
+
+[role="_abstract"]
+The `secretReference` field refers to a secret with the given name in the same namespace where it is used.
+
+[cols="1,1,1,1",options="header"]
+|===
+| Field
+| Type
+| Description
+| Validation
+
+| `name`
+| _string_
+| `name` specifies the name of the secret resource being referred to.
+| The maximum length is 253.
+
+The minimum length is 1.
+
+|===

--- a/modules/eso-web-hook-config.adoc
+++ b/modules/eso-web-hook-config.adoc
@@ -1,0 +1,25 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-operator-api.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="eso-web-hook-config_{context}"]
+= webhookConfig
+
+[role="_abstract"]
+The `webhookConfig` field configures the specifics of the `external-secrets` application webhook.
+
+[cols="1,1,1,1,1",options="header"]
+|===
+| Field
+| Type
+| Description
+| Default
+| Validation
+
+| `certificateCheckInterval`
+| link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#duration-v1-meta[_Duration_]
+| `certificateCheckInterval` configures the polling interval to check certificate validity.
+| 5m
+| Optional
+|===

--- a/security/external_secrets_operator/external-secrets-operator-api.adoc
+++ b/security/external_secrets_operator/external-secrets-operator-api.adoc
@@ -1,0 +1,108 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="external-secrets-operator-api"]
+= External Secrets Operator for Red Hat OpenShift APIs
+include::_attributes/common-attributes.adoc[]
+:context: external-secrets-operator-api
+
+toc::[]
+
+[role="_abstract"]
+{external-secrets-operator} uses the following two APIs to configure the `external-secrets` application deployment.
+
+//:FeatureName: The {external-secrets-operator}
+//include::snippets/technology-preview.adoc[leveloffset=+1]
+
+[cols="1,1,1",options="header"]
+|===
+| Group
+| Version
+| Kind
+
+| `operator.openshift.io`
+| `v1alpha1`
+| `externalsecretsConfig`
+
+| `operator.openshift.io`
+| `v1alpha1`
+| `externalsecretsmanager`
+|===
+
+The following list contains the {external-secrets-operator} APIs:
+
+* ExternalSecretsConfig
+* ExternalSecretsManager
+
+//ExternalSecretsManagerList
+include::modules/eso-external-secrets-manager-list.adoc[leveloffset=+1]
+
+//ExternalSecretsManager
+include::modules/eso-external-secrets-manager.adoc[leveloffset=+1]
+
+//ExternalSecretsConfigList
+include::modules/eso-external-secrets-list.adoc[leveloffset=+1]
+
+//ExternalSecretsConfig
+include::modules/eso-external-secrets.adoc[leveloffset=+1]
+
+//ExternalSecretsManagerSpec
+include::modules/eso-external-secrets-manager-spec.adoc[leveloffset=+1]
+
+//externalSecretsManagerStatus
+include::modules/eso-external-secrets-manager-status.adoc[leveloffset=+1]
+
+//ExternalSecretsConfigSpec
+include::modules/eso-external-secrets-spec.adoc[leveloffset=+1]
+
+//externalSecretsConfigStatus
+include::modules/eso-external-secrets-status.adoc[leveloffset=+1]
+
+//GlobalConfig
+include::modules/eso-global-config.adoc[leveloffset=+1]
+
+//ControllerConfig
+include::modules/eso-controller-config.adoc[leveloffset=+1]
+
+//controllerStatus
+include::modules/eso-controller-status.adoc[leveloffset=+1]
+
+//ApplicationConfig
+include::modules/eso-external-secrets-config.adoc[leveloffset=+1]
+
+//bitwardenSecretManagerProvider
+include::modules/eso-bitwarden-secret.adoc[leveloffset=+1]
+
+//WebhookConfig
+include::modules/eso-web-hook-config.adoc[leveloffset=+1]
+
+//CertManagerConfig
+include::modules/eso-cert-manager-config.adoc[leveloffset=+1]
+
+//CertProvidersConfig
+include::modules/eso-cert-providers-config.adoc[leveloffset=+1]
+
+//ObjectReference
+include::modules/eso-object-reference.adoc[leveloffset=+1]
+
+//secretReference
+include::modules/eso-secret-reference.adoc[leveloffset=+1]
+
+//condition
+include::modules/eso-condition.adoc[leveloffset=+1]
+
+//conditionalStatus
+include::modules/eso-conditional-status.adoc[leveloffset=+1]
+
+//mode
+include::modules/eso-mode.adoc[leveloffset=+1]
+
+//pluginsConfig
+include::modules/eso-plugins-config.adoc[leveloffset=+1]
+
+//ProxyConfig
+include::modules/eso-proxy-config.adoc[leveloffset=+1]
+
+//componentConfig
+include::modules/eso-component-config.adoc[leveloffset=+1]
+
+//deploymentConfig
+include::modules/eso-deployment-config.adoc[leveloffset=+1]

--- a/security/external_secrets_operator/external-secrets-operator-api.adoc
+++ b/security/external_secrets_operator/external-secrets-operator-api.adoc
@@ -1,0 +1,117 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="external-secrets-operator-api"]
+= External Secrets Operator for Red Hat OpenShift APIs
+include::_attributes/common-attributes.adoc[]
+:context: external-secrets-operator-api
+
+toc::[]
+
+[role="_abstract"]
+{external-secrets-operator} uses the following two APIs to configure the `external-secrets` application deployment.
+
+//:FeatureName: The {external-secrets-operator}
+//include::snippets/technology-preview.adoc[leveloffset=+1]
+
+[cols="1,1,1",options="header"]
+|===
+| Group
+| Version
+| Kind
+
+| `operator.openshift.io`
+| `v1alpha1`
+| `ExternalSecretsConfig`
+
+| `operator.openshift.io`
+| `v1alpha1`
+| `ExternalSecretsManager`
+|===
+
+The following list contains the {external-secrets-operator} APIs:
+
+* ExternalSecretsConfig
+* ExternalSecretsManager
+
+//ApplicationConfig
+include::modules/eso-external-secrets-config.adoc[leveloffset=+1]
+
+//bitwardenSecretManagerProvider
+include::modules/eso-bitwarden-secret.adoc[leveloffset=+1]
+
+//CertManagerConfig
+include::modules/eso-cert-manager-config.adoc[leveloffset=+1]
+
+//CertProvidersConfig
+include::modules/eso-cert-providers-config.adoc[leveloffset=+1]
+
+//CommonConfigs
+include::modules/eso-common-configs.adoc[leveloffset=+1]
+
+//componentConfig
+include::modules/eso-component-config.adoc[leveloffset=+1]
+
+//componentName
+include::modules/eso-component-name.adoc[leveloffset=+1]
+
+//condition
+include::modules/eso-condition.adoc[leveloffset=+1]
+
+//conditionalStatus
+include::modules/eso-conditional-status.adoc[leveloffset=+1]
+
+//ControllerConfig
+include::modules/eso-controller-config.adoc[leveloffset=+1]
+
+//controllerStatus
+include::modules/eso-controller-status.adoc[leveloffset=+1]
+
+//deploymentConfig
+include::modules/eso-deployment-config.adoc[leveloffset=+1]
+
+//ExternalSecretsConfig
+include::modules/eso-external-secrets.adoc[leveloffset=+1]
+
+//ExternalSecretsConfigList
+include::modules/eso-external-secrets-list.adoc[leveloffset=+1]
+
+//ExternalSecretsConfigSpec
+include::modules/eso-external-secrets-spec.adoc[leveloffset=+1]
+
+//externalSecretsConfigStatus
+include::modules/eso-external-secrets-status.adoc[leveloffset=+1]
+
+//ExternalSecretsManager
+include::modules/eso-external-secrets-manager.adoc[leveloffset=+1]
+
+//ExternalSecretsManagerList
+include::modules/eso-external-secrets-manager-list.adoc[leveloffset=+1]
+
+//ExternalSecretsManagerSpec
+include::modules/eso-external-secrets-manager-spec.adoc[leveloffset=+1]
+
+//externalSecretsManagerStatus
+include::modules/eso-external-secrets-manager-status.adoc[leveloffset=+1]
+
+//GlobalConfig
+include::modules/eso-global-config.adoc[leveloffset=+1]
+
+//mode
+include::modules/eso-mode.adoc[leveloffset=+1]
+
+//networkPolicy
+include::modules/eso-network-policy.adoc[leveloffset=+1]
+
+//ObjectReference
+include::modules/eso-object-reference.adoc[leveloffset=+1]
+
+//pluginsConfig
+include::modules/eso-plugins-config.adoc[leveloffset=+1]
+
+//ProxyConfig
+include::modules/eso-proxy-config.adoc[leveloffset=+1]
+
+//secretReference
+include::modules/eso-secret-reference.adoc[leveloffset=+1]
+
+//WebhookConfig
+include::modules/eso-web-hook-config.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s):
4.18

Issue:
https://redhat.atlassian.net/browse/OSDOCS-18784

Link to docs preview:
https://111965--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/external_secrets_operator/external-secrets-operator-api.html


QE review:
- [x] QE has approved this change.


Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
