### PR TITLE
Fix typo in 'Microsoft' in documentation

### DIFF
--- a/modules/identity-provider-about-request-header.adoc
+++ b/modules/identity-provider-about-request-header.adoc
@@ -64,7 +64,7 @@ include::snippets/technology-preview.adoc[leveloffset=+1]
 endif::[]
 
 The OpenShift CLI (`oc`) supports the Security Support Provider Interface (SSPI) to allow for SSO
-flows on Microsft Windows. If you use the request header identity provider with a
+flows on Microsoft Windows. If you use the request header identity provider with a
 GSSAPI-enabled proxy to connect an Active Directory server to {product-title},
 users can automatically authenticate to {product-title} by using the `oc`  command
 line interface from a domain-joined Microsoft Windows computer.


### PR DESCRIPTION
There is a spelling error in the section discussing Security Support Provider Interface (SSPI) support for Windows. "Microsoft" is misspelled as "Microsft".

Current Text:
> The OpenShift CLI (oc) supports the Security Support Provider Interface (SSPI) to allow for SSO
> flows on Microsft Windows.

Suggested Correction:
> The OpenShift CLI (oc) supports the Security Support Provider Interface (SSPI) to allow for SSO
> flows on Microsoft Windows.

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.21.z, 4.22.z
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://redhat.atlassian.net/browse/OSDOCS-19844
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: 
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
