### PR TITLE
[OSDOCS#19843]: Added z-stream release notes for 4.18.42

### DIFF
--- a/modules/zstream-4-18-42.adoc
+++ b/modules/zstream-4-18-42.adoc
@@ -1,0 +1,31 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-18-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-18-42_{context}"]
+= RHSA-2026:17448 - {product-title} {product-version}.42 fixed issues and security update
+
+Issued: 20 May 2026
+
+[role="_abstract"]
+{product-title} release {product-version}.42 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2026:17448[RHSA-2026:17448] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2026:17446[RHSA-2026:17446] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.18.42 --pullspecs
+----
+
+[id="zstream-4-18-42-fixed-issues_{context}"]
+== Fixed issues
+
+* Before this update, the CSI driver failed due to a password serialization issue that incorrectly handled special characters. This led to storage degradation. With this release, the password serialization issue is fixed, ensuring correct handling of special characters. As a result, storage degradation does not occur. (link:https://redhat.atlassian.net/browse/OCPBUGS-81673[OCPBUGS-81673])
+
+[id="zstream-4-18-42-updating_{context}"]
+== Updating
+
+To update an {product-title} 4.18 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].

--- a/release_notes/ocp-4-18-release-notes.adoc
+++ b/release_notes/ocp-4-18-release-notes.adoc
@@ -3064,6 +3064,9 @@ As a workaround, you must manually reboot the failed host from the disk. (link:h
 // 4.18 about async
 include::modules/rn-async-errata.adoc[leveloffset=+1]
 
+// 4.18.42 RNs and updating
+include::modules/zstream-4-18-42.adoc[leveloffset=+2]
+
 // 4.18.41 RNs and updating
 include::modules/zstream-4-18-41.adoc[leveloffset=+2]
 


### PR DESCRIPTION

Version(s):
4.18

Issue:
https://redhat.atlassian.net/browse/OSDOCS-19843

Link to docs preview:
https://111969--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-18-release-notes.html#zstream-4-18-42_release-notes

QE review:
N/A
