### PR TITLE
Fix MetalLB procedures based on live cluster verification

### DIFF
--- a/modules/nw-metallb-configure-svc.adoc
+++ b/modules/nw-metallb-configure-svc.adoc
@@ -18,21 +18,38 @@ To expose an application to external network traffic, configure a load-balancing
 
 .Procedure
 
-. Create a `<service_name>.yaml` file. In the file, set the `spec.type` parameter to `LoadBalancer`.
+. Create a service YAML file, such as `metallb-service.yaml`, with content like the following example:
 +
-Refer to the examples for information about how to request the external IP address that MetalLB assigns to the service.
+[source,yaml]
+----
+apiVersion: v1
+kind: Service
+metadata:
+  name: metallb-service
+  annotations:
+    metallb.io/address-pool: doc-example <1>
+spec:
+  selector:
+    app: <application_name> <2>
+  ports:
+  - port: 80
+    targetPort: 8080
+  type: LoadBalancer
+----
+<1> Specifies the address pool to use. If you do not set the annotation, MetalLB automatically assigns an IP address from any available pool that has `autoAssign` set to `true`.
+<2> Specifies the label selector of the pods that the service targets. Replace `<application_name>` with the label of your application.
 
 . Create the service:
 +
 [source,terminal]
 ----
-$ oc apply -f <service_name>.yaml
+$ oc apply -f metallb-service.yaml
 ----
 +
 .Example output
 [source,terminal]
 ----
-service/<service_name> created
+service/metallb-service created
 ----
 
 .Verification
@@ -41,16 +58,16 @@ service/<service_name> created
 +
 [source,terminal]
 ----
-$ oc describe service <service_name>
+$ oc describe service metallb-service
 ----
 +
 .Example output
 ----
-Name:                     <service_name>
+Name:                     metallb-service
 Namespace:                default
 Labels:                   <none>
 Annotations:              metallb.io/address-pool: doc-example
-Selector:                 app=service_name
+Selector:                 app=<application_name>
 Type:                     LoadBalancer
 IP Family Policy:         SingleStack
 IP Families:              IPv4

--- a/modules/nw-metallb-installing-operator-cli.adoc
+++ b/modules/nw-metallb-installing-operator-cli.adoc
@@ -84,6 +84,18 @@ spec:
 $ oc create -f metallb-sub.yaml
 ----
 
+. Verify that the Operator is installed by entering the following command:
++
+[source,terminal]
+----
+$ oc wait --for=jsonpath='{.status.phase}'=Succeeded csv -n metallb-system -l operators.coreos.com/metallb-operator.metallb-system --timeout=300s
+----
++
+[NOTE]
+====
+Installation of the Operator might take a few minutes.
+====
+
 . Optional: To ensure BGP and BFD metrics appear in Prometheus, you can label the namespace as in the following command:
 +
 [source,terminal]

--- a/modules/nw-metallb-operator-initial-config.adoc
+++ b/modules/nw-metallb-operator-initial-config.adoc
@@ -32,11 +32,24 @@ metadata:
 EOF
 ----
 +
-** For the `metdata.namespace` parameter, substitute `metallb-system` with `openshift-operators` if you installed the MetalLB Operator using the web console.
+** For the `metadata.namespace` parameter, substitute `metallb-system` with `openshift-operators` if you installed the MetalLB Operator using the web console.
 
 .Verification
 
 Confirm that the deployment for the MetalLB controller and the daemon set for the MetalLB speaker are running.
+
+. Wait for the MetalLB controller deployment to be available:
++
+[source,terminal]
+----
+$ oc wait deployment/controller -n metallb-system --for=condition=Available --timeout=120s
+----
++
+.Example output
+[source,terminal]
+----
+deployment.apps/controller condition met
+----
 
 . Verify that the deployment for the controller is running:
 +


### PR DESCRIPTION
## Summary
- **nw-metallb-installing-operator-cli.adoc**: Added `oc wait` polling step after Subscription creation so users can confirm the Operator reaches `Succeeded` before proceeding. During live verification the Operator took ~70s to install — without this step users hit race conditions on the verification commands.
- **nw-metallb-operator-initial-config.adoc**: Fixed typo (`metdata` → `metadata`) and added `oc wait` step for the controller deployment before verification checks.
- **nw-metallb-configure-svc.adoc**: Replaced placeholder-only service instructions (`<service_name>.yaml`) with a concrete YAML example including `metallb.io/address-pool` annotation and callout explanations. The original procedure was not executable without users already knowing how to write a LoadBalancer Service manifest.

## Test plan
- [x] All four MetalLB procedures verified end-to-end on a live SNO cluster (mysno.demo.lab, OCP 4.21)
- [x] `oc wait` commands confirmed working with correct label selectors
- [x] Service received LoadBalancer Ingress IP from MetalLB pool and was accessible via browser
- [x] All YAML blocks passed syntax validation and `oc apply --dry-run=client`

🤖 Generated with [Claude Code](https://claude.com/claude-code)