### PR TITLE
OLS-3110: Minor updates to release notes 1.0.13

### DIFF
--- a/configure/ols-configuring-openshift-lightspeed.adoc
+++ b/configure/ols-configuring-openshift-lightspeed.adoc
@@ -66,7 +66,7 @@ include::modules/ols-disabling-ocp-documentation-rag-database.adoc[leveloffset=+
 
 include::modules/ols-about-cluster-interaction.adoc[leveloffset=+1]
 
-include::modules/ols-enabling-cluster-interaction.adoc[leveloffset=+2]
+include::modules/ols-disabling-cluster-interaction.adoc[leveloffset=+2]
 
 include::modules/ols-enabling-custom-mcp-server.adoc[leveloffset=+2]
 
@@ -83,3 +83,7 @@ include::modules/ols-overriding-default-persistent-volume-claim-specifications.a
 include::modules/ols-about-query-based-tool-filtering.adoc[leveloffset=+1]
 
 include::modules/ols-enabling-query-based-tool-filtering.adoc[leveloffset=+2]
+
+include::modules/ols-about-operation-approvals.adoc[leveloffset=+2]
+
+include::modules/ols-ref-tools-approval-configuration.adoc[leveloffset=+2]

--- a/modules/ols-1-0-13-release-notes.adoc
+++ b/modules/ols-1-0-13-release-notes.adoc
@@ -24,7 +24,7 @@
 
 * With this update, the `introspectionEnabled` field in the `OLSConfig` custom resource (CR) is `true` by default. You do not have to specify this field to use the Kubernetes Model Context Protocol (MCP) server. To disable the Kubernetes MCP server, you must set this field to `false`.
 
-* With this update, the Kubernetes MCP server supports both read and write operations. Because human-in-the-loop (HITL) support is automatically enabled, you must approve any non-read operation, such as an update or delete, in the user interface before {ols-long} executes the action.
+* With this update, the Kubernetes MCP server supports both read and write operations. Because human-in-the-loop (HITL) support is enabled by default, you must approve any non-read operation, such as an update or delete, in the user interface before {ols-long} executes the action. This behavior is controlled by the `toolsApprovalConfig.approvalType` field in the `OLSConfig` custom resource (CR), which defaults to `tool_annotations`.
 
 //OLS-2565
 
@@ -33,3 +33,7 @@
 //OLS-2460
 
 * With this update, {ols-long} supports only the strong ciphers and Transport Layer Security (TLS) profiles recommended by Red Hat Product Security. This enhancement prevents the use of weak signature algorithms to ensure that your cluster remains protected and compliant with security standards.
+
+//OLS-1188
+
+* With this update, you can attach Prometheus alerting rules and `Alertmanager` silences to a prompt directly from their details pages. 

--- a/modules/ols-about-cluster-interaction.adoc
+++ b/modules/ols-about-cluster-interaction.adoc
@@ -6,22 +6,24 @@
 = About cluster interaction
 
 [role="_abstract"]
-Enable the cluster interaction feature to supply the large language model (LLM) with additional context about your {ocp-product-title} cluster.
+Enable the cluster interaction feature to provide the large language model (LLM) with additional context about your {ocp-product-title} cluster.
 
-{ols-long} uses a large language model (LLM) to answer your questions. When you share details about your cluster objects, the LLM can give specific answers for your environment.
+{ols-long} uses an LLM to answer your questions. When you share details about your cluster objects, the LLM provides specific answers for your environment.
 
-The Model Context Protocol (MCP) is an open protocol. It creates a standard way for applications to give context to an LLM. Using the protocol, an MCP server offers a standardized way for an LLM to increase context by requesting and receiving real-time information from external resources.
+The Model Context Protocol (MCP) is an open protocol that creates a standard way for applications to provide context to an LLM. Using this protocol, an MCP server enables an LLM to increase context by requesting and receiving real-time information from external resources.
 
-[NOTE]
-====
-If you configure filtering or redacting in the `OLSConfig` CR file, and you configure `introspectionEnabled` to enable a Model Context Protocol (MCP) server, any content that the tools return is not filtered and is visible to the LLM.
-====
-
-When you enable cluster interaction, the {ols-long} Operator installs an MCP server. The MCP server provides the {ols-long} Service with access to the {ocp-short-name} API. Through this access, the Service performs read operations to gather more context for the LLM, enabling the Service to generate answers to questions about the Kubernetes objects that reside in your {ocp-short-name} cluster.
+The `introspectionEnabled` field in the `OLSConfig` custom resource (CR) is `true` by default. You do not need to specify this field to use the Observability MCP server. To disable this MCP server, you must set this field to `false`.
 
 [NOTE]
 ====
-The ability of {ols-long} to choose and use a tool effectively is very sensitive to the large language (LLM) model. In general, a larger model with more parameters performs better, and the best performance comes from an extremely large frontier model that represents the latest AI capabilities. When using a small model, you might notice poor performance in tool selection or other aspects of cluster interaction.
+If you configure filtering or redacting in the `OLSConfig` CR file and enable an MCP server, any content that the tools return is not filtered and remains visible to the LLM.
+====
+
+When you enable cluster interaction, the {ols-long} Operator installs the Observability MCP server. This MCP server provides the {ols-long} Service with access to the {ocp-short-name} API. Through this access, the Service performs read operations to gather cluster context for the LLM. This context enables the Service to generate answers to questions about the {k8s} objects that reside in your {ocp-short-name} cluster.
+
+[NOTE]
+====
+The ability of {ols-long} to choose and use a tool effectively depends on the LLM model. In general, a larger model with more parameters performs better. The best performance comes from an extremely large frontier model that represents the latest AI capabilities. When using a small model, you might notice poor performance in tool selection or other aspects of cluster interaction.
 ====
 
 You must enable tool calling in the LLM provider to activate the cluster interaction feature in the {ols-long} Service.

--- a/modules/ols-about-operation-approvals.adoc
+++ b/modules/ols-about-operation-approvals.adoc
@@ -1,0 +1,16 @@
+// Module included in the following assemblies:
+// * lightspeed-docs-main/configure/ols-configuring-openshift-lightspeed.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="ols-about-operation-approvals_{context}"]
+= About operation approvals
+
+[role="_abstract"]
+To manage sensitive cluster changes, you can use the operation approvals feature. This feature requires human validation before {ols-long} executes a selected tool.
+
+The Observability MCP server supports both read and write operations. The Service automatically enables Human-In-The-Loop (HITL) support for non-read operations. Any non-read operation triggers an approval request in the user interface (UI).
+
+The `toolsApprovalConfig` object in the custom resource (CR) defines these validation policies. This object supports configuration options to set the tool approval level.
+
+An administrator must review and clear the pending request before the service can execute the underlying cluster changes. This mechanism prevents unintended or unauthorized alterations to your environment.
+

--- a/modules/ols-about-query-based-tool-filtering.adoc
+++ b/modules/ols-about-query-based-tool-filtering.adoc
@@ -11,3 +11,4 @@ Query-based filtering uses a hybrid retrieval-augmented generation (RAG) system 
 When a large language model (LLM) application has access to hundreds of tools, sending the full list in one prompt slows performance and raises costs. Query-based filtering finds and retrieves the most relevant set of tools for a request in milliseconds. This pre-processing step removes selection interference, and ensures that the LLM focuses its reasoning capabilities on a small, high-quality subset of functions.
 
 Restricting the set of tools available reduces token use, prevents model confusion, and maintains high execution accuracy. This approach transforms a massive tool library into a fast, lean interface.
+

--- a/modules/ols-disabling-cluster-interaction.adoc
+++ b/modules/ols-disabling-cluster-interaction.adoc
@@ -2,11 +2,11 @@
 // * lightspeed-docs-main/configure/ols-configuring-openshift-lightspeed.adoc
 
 :_mod-docs-content-type: PROCEDURE
-[id="enabling-cluster-interaction_{context}"]
-= Enabling cluster interaction
+[id="disabling-cluster-interaction_{context}"]
+= Disabling cluster interaction
 
 [role="_abstract"]
-Enable the cluster interaction feature by modifying the `OLSConfig` custom resource (CR) to give {ols-long} cluster-specific context.
+Disable the cluster interaction feature by modifying the `OLSConfig` custom resource (CR) if you do not want {ols-long} to access cluster-specific context.
 
 :FeatureName: The cluster interaction feature
 include::snippets/technology-preview.adoc[]
@@ -30,7 +30,7 @@ include::snippets/technology-preview.adoc[]
 
 . Click the *YAML* tab.
 
-. Set the `spec.ols.introspectionEnabled` parameter to `true` to enable cluster interaction: 
+. Set the `spec.ols.introspectionEnabled` parameter to `false` to disable cluster interaction: 
 +
 [source,yaml,subs="attributes,verbatim"]
 ----
@@ -40,13 +40,12 @@ metadata:
   name: cluster
 spec:
   ols:
-    introspectionEnabled: true  
+    introspectionEnabled: false  
 ----
 
 . Click *Save*.
 
 .Verification
 
-* Access the {ols-long} virtual assistant and submit a question associated with your cluster.
-+
-The {ols-long} virtual assistant generates a highly refined response specific to your environment.
+* Access the {ols-long} virtual assistant and submit a question about your cluster objects. The {ols-long} virtual assistant responds generally without using cluster-specific resource details.
+

--- a/modules/ols-enabling-custom-mcp-server.adoc
+++ b/modules/ols-enabling-custom-mcp-server.adoc
@@ -22,7 +22,7 @@ include::snippets/technology-preview.adoc[]
 
 .Procedure
 
-. Open the {ols-long} `OLSconfig` custom resource (CR) file by running the following command:
+. Edit the {ols-long} `OLSConfig` custom resource (CR) file by running the following command:
 +
 [source,terminal]
 ----
@@ -43,7 +43,7 @@ spec:
   mcpServers:
   - name: mcp-server-1
     url: https://mcp.example.com 
-    timeout: 30 
+    timeout: 30
     headers: 
       - name: Authorization
         valueFrom:
@@ -71,10 +71,15 @@ spec:
 
 * `spec.mcpServers.headers.name` specifies the name of the header that gets sent to the MCP server.
 
-* `spec.mcpServers.headers.valueFrom.type` specify the string `kubernetes` to provide the user's bearer token
+* `spec.mcpServers.headers.valueFrom.type`: Specifies the authentication source type. Valid values are `secret`, `kubernetes` (to provide the user's bearer token), or `client`.
 
 * `spec.mcpServers.headers.valueFrom.secretRef.name` specifies the name of the secret that contains the header value. Ensure that the secret has the key name `header`. 
-
-. Click *Save*. 
 +
-The save operation saves the file and applies the changes so that the MCP server is available to the {ols-long} service.
+[NOTE]
+====
+If your custom MCP server handles sensitive operations, ensure that these operations do not have `read-only` annotations to enforce human-in-the-loop (HITL) approvals.
+====
+
+. Save and close the text editor to apply the changes. 
++
+The save operation applies the updates and makes the custom MCP server available to the {ols-long} service.

--- a/modules/ols-enabling-query-based-tool-filtering.adoc
+++ b/modules/ols-enabling-query-based-tool-filtering.adoc
@@ -42,9 +42,9 @@ spec:
   olsConfig:
     maxIterations: 5
     toolFilteringConfig:
-      alpha: 0.8     
-      topK: 10        
-      threshold: 0.01 
+      alpha: 0.8
+      topK: 10
+      threshold: 0.01
 ----
 +
 * `spec.featureGates.ToolFilter` specifies the feature gate.
@@ -55,11 +55,11 @@ spec:
 
 * `spec.olsConfig.toolFilteringConfig.topk` specifies the maximum number of tools available for the LLM.
 
-* `spec.olsConfig.toolFilteringConfig.threshold` specifies the minimum score for the tool to be considered as a candidate. Tools with a value of the score lower then the threshold value are discarded. Increasing the value discards more tools. The valid range of values is `0.01` to `0.1`.
+* `spec.olsConfig.toolFilteringConfig.threshold` specifies the minimum score for the tool to be considered as a candidate. Tools with a value of the score lower than the threshold value are discarded. Increasing the value discards more tools. The valid range of values is `0.01` to `0.1`.
 +
 [NOTE]
 ====
-This example uses the default values for the `maxIterations`, `alpha`, `tpok` and `threshold` fields. If you use the default values in your configuration, you do not have to specify them.
+This example uses the default values for the `maxIterations`, `alpha`, `tpok` and `threshold` fields. If you use the default values in your configuration, you do not have to specify them in your file.
 ====
 
 . Click *Save*.

--- a/modules/ols-olsconfig-api-specifications.adoc
+++ b/modules/ols-olsconfig-api-specifications.adoc
@@ -94,6 +94,10 @@ possible values: MCPServer
 | `object`
 | OLSDataCollectorSpec defines allowed OLS data collector configuration.
 
+| `toolsApprovalConfig`
+| `object`
+| ToolsApprovalConfig defines the configuration for tool execution approvals.
+
 |===
 == .spec.llm
 Description::
@@ -466,6 +470,10 @@ Description::
 +
 --
 MCP Server settings
+[NOTE]
+====
+The `introspectionEnabled` field in the `OLSConfig` custom resource (CR) is `true` by default. You do not need to specify this field to use the built-in {k8s} MCP server. To disable the built-in {k8s} MCP server, you must set `introspectionEnabled` to `false`.
+====
 --
 
 Type::
@@ -493,6 +501,10 @@ Required::
 |===
 | Property | Type | Description
 
+| `args`
+| `array (string)`
+| Custom arguments passed to the MCP server during initialization.
+
 | `name`
 | `string`
 | Name of the MCP server
@@ -502,46 +514,16 @@ Required::
 | Streamable HTTP Transport settings
 
 |===
-== .spec.mcpServers[].streamableHTTP
+== .spec.mcpServers[].args
 Description::
 +
 --
-Streamable HTTP Transport settings
+Custom arguments passed directly to the MCP server process initialization command.
 --
 
 Type::
-  `object`
+  `array (string)`
 
-Required::
-  - `url`
-
-
-
-[cols="1,1,1",options="header"]
-|===
-| Property | Type | Description
-
-| `enableSSE`
-| `boolean`
-| Enable Server Sent Events
-
-| `headers`
-| `object (string)`
-| Headers to send to the MCP server
-
-| `sseReadTimeout`
-| `integer`
-| SSE Read Timeout, default is 10 seconds
-
-| `timeout`
-| `integer`
-| Timeout for the MCP server, default is 5 seconds
-
-| `url`
-| `string`
-| URL of the MCP server
-
-|===
 == .spec.ols
 Description::
 +

--- a/modules/ols-ref-tools-approval-configuration.adoc
+++ b/modules/ols-ref-tools-approval-configuration.adoc
@@ -1,0 +1,41 @@
+// Module included in the following assemblies:
+// * lightspeed-docs-main/configure/ols-configuring-openshift-lightspeed.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="ols-ref-tools-approval-configuration_{context}"]
+= Tools approval configuration
+
+[role="_abstract"]
+The `toolsApprovalConfig` object controls whether tool calls require user approval before execution.
+
+[cols="2,1,1,4",options="header"]
+|===
+| Field | Type | Default | Description
+
+| `approvalType`
+| string (enum)
+| `tool_annotations`
+| Approval strategy for tool execution. Support values: `never`, `always`, `tool_annotations`.
+
+| `approvalTimeout`
+| int
+| `600`
+| Timeout in seconds for waiting for user approval. The minimum value is `1`.
+|===
+
+The following table depicts the `approvalType` values:
+
+[cols="1,3",options="header"]
+|===
+| Value | Description
+
+| `never`
+| All tools execute without requiring user approval.
+
+| `always`
+| All tool calls require user approval before execution.
+
+| `tool_annotations`
+| Per-tool annotations determine approval. Each tool can individually declare whether it needs approval.
+|===
+


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
lightspeed-docs-main, lightspeed-docs-1.0

Issue:
[OLS-3110](https://redhat.atlassian.net/browse/OLS-3110)

Link to docs preview:
- [Release Notes 1.0.13](https://111982--ocpdocs-pr.netlify.app/openshift-lightspeed/latest/release_notes/ols-release-notes.html)
- [OLSConfig API reference](https://111982--ocpdocs-pr.netlify.app/openshift-lightspeed/latest/configure/olsconfigure-api.html)
- [About cluster interaction](https://111982--ocpdocs-pr.netlify.app/openshift-lightspeed/latest/configure/ols-configuring-openshift-lightspeed.html#about-cluster-interaction_ols-configuring-openshift-lightspeed)
- [About query-based tool filtering](https://111982--ocpdocs-pr.netlify.app/openshift-lightspeed/latest/configure/ols-configuring-openshift-lightspeed.html#ols-about-query-based-tools-filtering_ols-configuring-openshift-lightspeed)
- [About operation approvals](https://111982--ocpdocs-pr.netlify.app/openshift-lightspeed/latest/configure/ols-configuring-openshift-lightspeed.html#ols-about-operation-approvals_ols-configuring-openshift-lightspeed)
- [Disabling cluster interaction](https://111982--ocpdocs-pr.netlify.app/openshift-lightspeed/latest/configure/ols-configuring-openshift-lightspeed.html#disabling-cluster-interaction_ols-configuring-openshift-lightspeed)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
