### PR TITLE
OSDOCS#19842: Update the z-stream RNs for 4.17.54

### DIFF
--- a/modules/zstream-4-17-54.adoc
+++ b/modules/zstream-4-17-54.adoc
@@ -1,0 +1,31 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-17-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-17-54-about_{context}"]
+= RHSA-2026:17598 - {product-title} {product-version}.54 fixed issues and security update
+
+Issued: 20 May 2026
+
+[role="_abstract"]
+{product-title} release {product-version}.54 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2026:17598[RHSA-2026:17598] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2026:17595[RHSA-2026:17595] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.17.54--pullspecs
+----
+
+[id="zstream-4-17-54-fixed-issues_{context}"]
+== Fixed issues
+
+There are no notable fixed issues for this release.
+
+[id="zstream-4-17-54-updating_{context}"]
+== Updating
+
+To update an {product-title} 4.17 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].

--- a/release_notes/ocp-4-17-release-notes.adoc
+++ b/release_notes/ocp-4-17-release-notes.adoc
@@ -2948,6 +2948,9 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+// 4.17.54
+include::modules/zstream-4-17-54.adoc[leveloffset=+2]
+
 // 4.17.53
 include::modules/zstream-4-17-53.adoc[leveloffset=+2]
 


### PR DESCRIPTION
Version(s):
4.17

Issue:
[OSDOCS-19842](https://redhat.atlassian.net/browse/OSDOCS-19842)

Link to docs preview:
[4.17.54](https://111993--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-17-release-notes.html#zstream-4-17-54-about_release-notes)

QE review:
- [ ] QE has approved this change.
N/A for RNs.

Additional information:
Shipment [MR](https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/534/diffs#218b3c80d1aa2c67aef0d53bfc97d9558c598a06)
ART [Dashboard](https://art-dash.engineering.redhat.com/dashboard/release/openshift-4.17)
