### PR TITLE
OSDOCS-18784-12 created assembly/modules for migration to upstream

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -1314,6 +1314,8 @@ Topics:
   Topics:
   - Name: Customizing the External Secrets Operator for Red Hat OpenShift
     File: external-secrets-log-levels
+  - Name: Migrating from the community External Secret Operator to the External Secret Operator For Red Hat OpenShift
+    File: external-secrets-operator-migrate-downstream-upstream
 - Name: Viewing audit logs
   File: audit-log-view
 - Name: Configuring the audit log policy

--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -1326,6 +1326,8 @@ Topics:
     File: external-secrets-log-levels
   - Name: Uninstalling the External Secrets Operator
     File: external-secrets-operator-uninstall
+  - Name: Migrating from the community External Secret Operator to the External Secret Operator For Red Hat OpenShift
+    File: external-secrets-operator-migrate-downstream-upstream
 - Name: Viewing audit logs
   File: audit-log-view
 - Name: Configuring the audit log policy

--- a/modules/external-secrets-operator-create-externalsecretsconfig.adoc
+++ b/modules/external-secrets-operator-create-externalsecretsconfig.adoc
@@ -1,0 +1,175 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-operator-migrate-downstream-upstream.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="external-secrets-operator-create-externalsecretsconfig_{context}"]
+= Creating the ExternalSecretsConfig Operator
+
+[role="_abstract"]
+Create the `ExternalSecretsConfig` resource to install and configure the core `external-secrets` component. This setup helps ensure that features like Bitwarden and cert-manager support are correctly enabled.
+
+.Prerequisites
+
+* {external-secrets-operator} is installed.
+
+* {cert-manager-operator} is installed.
+
+* You have access to the cluster with `cluster-admin` privileges.
+
+.Procedure
+
+. Create an `externalsecretsconfig` file by defining a YAML file with the following content:
++
+[source,yml]
+----
+apiVersion: operator.openshift.io/v1alpha1
+kind: ExternalSecretsConfig
+metadata:
+  labels:
+    app.kubernetes.io/name: cluster
+  name: cluster
+spec:
+  appConfig:
+    logLevel: 1
+  controllerConfig:
+    networkPolicies:
+      - componentName: ExternalSecretsCoreController
+        egress:
+          - {}
+        name: allow-external-secrets-egress
+  plugins: {}
+----
+
+. Create the `ExternalSecretsConfig` object by running the following command:
++
+[source,terminal]
+----
+$ oc create -f externalsecretsconfig.yaml
+----
+
+.Verification
+
+Verify that all custom resources (CRs) are present and that the APIs are using `v1` instead of `v1beta1`. There CRs are retained and automatically converted by the new Operator.
+
+. To verify that the `external-secrets` pods are in a `running` state, run the following command:
++
+[source,terminal]
+----
+$ oc get pods -n external-secret
+----
++
+The following is example output that the `external-secrets` pods are in a `running` state.
++
+[source,terminal]
+----
+NAME                                          READY        STATUS        RESTARTS     AGE
+bitwarden-sdk-server-5b4cf48766-w7zp7         1/1          Running       0            5m
+external-secrets-5854b85dd5-m6zf9             1/1          Running       0            5m
+external-secrets-webhook-5cb85b8fdb-6jtqb     1/1          Running       0            5m
+----
+
+. To verify that the `SecretStore` CR is present, run the following command:
++
+[source,terminal]
+----
+$ oc get secretstores.external-secrets.io -A
+----
++
+The following is example output from validating that the `SecretStore` is present:
++
+[source,terminal]
+----
+NAMESPACE               NAME                         AGE         STATUS      CAPABILITIES    READY
+external-secrets-1      gcp-store                    18min       Valid       ReadWrite       True
+external-secrets-2      aws-secretstore              11min       Valid       ReadWrite       True
+external-secrets        bitwarden-secretsmanager     20min       Valid       Readwrite       True
+----
+
+. To verify that the `ExternalSecret` CR is present, run the following command:
++
+[source,terminal]
+----
+$ oc get externalsecrets.external-secrets.io -A
+----
++
+The following is example output from validating that the `SecretStore` is present:
++
+[source,terminal]
+----
+NAMESPACE             NAME                    STORE                      REFRESH INTERVAL    STATUS          READY
+external-secrets-1    gcp-externalsecret      gcp-store                  1hr                 SecretSynced    True
+external-secrets-2    aws-external-secret     aws-secret-store           1hr                 SecretSynced    True
+external-secrets      bitwarden               bitwarden-secretsmanager   1hr                 SecretSynced    True
+----
+
+. To verify that the `SecretStore` is `apiVersion: external-secrets.io/v1`, run the following command:
++
+[source,terminal]
+----
+$ oc get secretstores.external-secrets.io -n external-secrets-1 gcp-store -o yaml
+----
++
+The following is example output that the `SecretStore` is `apiVersion: external-secrets.io/v1`.
++
+[source,yml]
+----
+apiVersion: external-secrets.io/v1
+kind: SecretStore
+metadata:
+  creationTimestamp: "2025-10-27T11:38:19Z"
+  generation: 1
+  name: gcp-store
+  namespace: external-secrets-1
+  resourceVersion: "104519"
+  uid: 7bccb0cc-2557-4f4a-9caa-1577f0108f4b
+spec:
+.
+.
+.
+status:
+  capabilities: ReadWrite
+  conditions:
+  - lastTransitionTime: "2025-10-27T11:38:19Z"
+    message: store validated
+    reason: Valid
+    status: "True"
+    type: Ready
+----
+
+. To verify that the `ExternalSecret` is `apiVersion: external-secrets.io/v1`, run the following command:
++
+[source,terminal]
+----
+$ oc get externalsecrets.external-secrets.io -n external-secrets-1 gcp-externalsecret -o yaml
+----
++
+The following is example output that the `ExternalSecret` is `apiVersion: external-secrets.io/v1`.
++
+[source,yml]
+----
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  creationTimestamp: "2025-10-27T11:39:03Z"
+  generation: 1
+  name: gcp-externalsecret
+  namespace: external-secrets-1
+  resourceVersion: "104532"
+  uid: 93a3295a-a3ad-4304-90e1-1328d951e5fb
+spec:
+.
+.
+.
+status:
+  binding:
+    name: k8s-secret-gcp
+  conditions:
+  - lastTransitionTime: "2025-10-27T11:39:03Z"
+    message: secret synced
+    reason: SecretSynced
+    status: "True"
+    type: Ready
+  refreshTime: "2025-10-27T12:13:15Z"
+  syncedResourceVersion: 1-f47fe3c0b255b6dd8047cdffa772587bb829efe7a1cb70febeda2eb2
+----

--- a/modules/external-secrets-operator-create-externalsecretsconfig.adoc
+++ b/modules/external-secrets-operator-create-externalsecretsconfig.adoc
@@ -1,0 +1,166 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-operator-migrate-downstream-upstream.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="external-secrets-operator-create-externalsecretsconfig_{context}"]
+= Creating the ExternalSecretsConfig custom resource
+
+[role="_abstract"]
+You can create an `ExternalSecretsConfig` custom resource (CR) to install and configure the core `external-secrets` component after the Operator is installed.
+
+.Prerequisites
+
+* {external-secrets-operator} is installed.
+
+* {cert-manager-operator} is installed.
+
+* You have access to the cluster with `cluster-admin` privileges.
+
+.Procedure
+
+. Create an `externalsecretsconfig.yaml` file with the following content:
++
+[source,yaml]
+----
+apiVersion: operator.openshift.io/v1alpha1
+kind: ExternalSecretsConfig
+metadata:
+  labels:
+    app.kubernetes.io/name: cluster
+  name: cluster
+spec:
+  appConfig:
+    logLevel: 1
+  controllerConfig:
+    networkPolicies:
+      - componentName: ExternalSecretsCoreController
+        egress:
+          - {}
+        name: allow-external-secrets-egress
+  plugins: {}
+----
+
+. Create the `ExternalSecretsConfig` object by running the following command:
++
+[source,terminal]
+----
+$ oc create -f externalsecretsconfig.yaml
+----
+
+.Verification
+
+Verify that all CRs are present and that the APIs are using `v1` instead of `v1beta1`. These CRs are retained and automatically converted by the new Operator.
+
+. To verify that the `external-secrets` pods are in a `running` state, run the following command:
++
+[source,terminal]
+----
+$ oc get pods -n external-secrets
+----
++
+.Example output
+[source,terminal]
+----
+NAME                                          READY        STATUS        RESTARTS     AGE
+bitwarden-sdk-server-5b4cf48766-w7zp7         1/1          Running       0            5m
+external-secrets-5854b85dd5-m6zf9             1/1          Running       0            5m
+external-secrets-webhook-5cb85b8fdb-6jtqb     1/1          Running       0            5m
+----
+
+. To verify that the `SecretStore` CR is present, run the following command:
++
+[source,terminal]
+----
+$ oc get secretstores.external-secrets.io -A
+----
++
+.Example output
+[source,terminal]
+----
+NAMESPACE               NAME                         AGE         STATUS      CAPABILITIES    READY
+external-secrets-1      gcp-store                    18min       Valid       ReadWrite       True
+external-secrets-2      aws-secretstore              11min       Valid       ReadWrite       True
+external-secrets        bitwarden-secretsmanager     20min       Valid       ReadWrite       True
+----
+
+. To verify that the `ExternalSecret` CR is present, run the following command:
++
+[source,terminal]
+----
+$ oc get externalsecrets.external-secrets.io -A
+----
++
+.Example output
+[source,terminal]
+----
+NAMESPACE             NAME                    STORE                      REFRESH INTERVAL    STATUS          READY
+external-secrets-1    gcp-externalsecret      gcp-store                  1hr                 SecretSynced    True
+external-secrets-2    aws-external-secret     aws-secret-store           1hr                 SecretSynced    True
+external-secrets      bitwarden               bitwarden-secretsmanager   1hr                 SecretSynced    True
+----
+
+. To verify that the `SecretStore` is `apiVersion: external-secrets.io/v1`, run the following command:
++
+[source,terminal]
+----
+$ oc get secretstores.external-secrets.io -n external-secrets-1 gcp-store -o yaml
+----
++
+.Example output
+[source,yaml]
+----
+apiVersion: external-secrets.io/v1
+kind: SecretStore
+metadata:
+  creationTimestamp: "2025-10-27T11:38:19Z"
+  generation: 1
+  name: gcp-store
+  namespace: external-secrets-1
+  resourceVersion: "104519"
+  uid: 7bccb0cc-2557-4f4a-9caa-1577f0108f4b
+spec:
+# ...
+status:
+  capabilities: ReadWrite
+  conditions:
+  - lastTransitionTime: "2025-10-27T11:38:19Z"
+    message: store validated
+    reason: Valid
+    status: "True"
+    type: Ready
+----
+
+. To verify that the `ExternalSecret` is `apiVersion: external-secrets.io/v1`, run the following command:
++
+[source,terminal]
+----
+$ oc get externalsecrets.external-secrets.io -n external-secrets-1 gcp-externalsecret -o yaml
+----
++
+.Example output
+[source,yaml]
+----
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  creationTimestamp: "2025-10-27T11:39:03Z"
+  generation: 1
+  name: gcp-externalsecret
+  namespace: external-secrets-1
+  resourceVersion: "104532"
+  uid: 93a3295a-a3ad-4304-90e1-1328d951e5fb
+spec:
+# ...
+status:
+  binding:
+    name: k8s-secret-gcp
+  conditions:
+  - lastTransitionTime: "2025-10-27T11:39:03Z"
+    message: secret synced
+    reason: SecretSynced
+    status: "True"
+    type: Ready
+  refreshTime: "2025-10-27T12:13:15Z"
+  syncedResourceVersion: 1-f47fe3c0b255b6dd8047cdffa772587bb829efe7a1cb70febeda2eb2
+----

--- a/modules/external-secrets-operator-delete-upstream-operatorconfig.adoc
+++ b/modules/external-secrets-operator-delete-upstream-operatorconfig.adoc
@@ -1,0 +1,65 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-operator-migrate-downstream-upstream.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="external-secrets-operator-delete-upstream-operatorconfig_{context}"]
+= Deleting the community {external-secrets-operator-short}
+
+[role="_abstract"]
+Delete the configuration resource for the community Operator so that the legacy application is fully removed. This action prevents conflicts before installing the {external-secrets-operator}.
+
+.Prerequisites
+
+* You must be logged in as a user with the `cluster-admin` role.
+
+* You must have the `oc` command-line tool installed and configured.
+
+.Procedure
+
+. Find your community Operator's `namespace` by running the following command:
++
+[source,terminal]
+----
+$ oc get operatorconfigs.operator.external-secrets.io -A
+----
++
+The following is an example of finding the `namespace`:
++
+[source,terminal]
+----
+NAMESPACE             NAME        AGE
+external-secrets      cluster     9m18s
+----
+
+. Delete the `operatorconfig` custom resrouce (CR) by running the following command:
++
+[source,terminal]
+----
+$ oc delete operatorconfig <config_name> -n <operator_namespace>
+----
+
+.Verification
+
+. To verify that the `operatorconfig` CR is deleted, run the following command:
++
+[source,terminal]
+----
+$ oc get operatorconfig -n <operator_namespace>
+----
++
+The command must return `no resource found`.
+
+. To verify that the old webhooks are deleted, run the following commands:
++
+[source,terminal]
+----
+$ oc get validatingwebhookconfigurations | grep external-secrets
+----
++
+[source,terminal]
+----
+$ oc get mutatingwebhookconfigurations | grep external-secrets
+----
++
+The commands must return no results.

--- a/modules/external-secrets-operator-delete-upstream-operatorconfig.adoc
+++ b/modules/external-secrets-operator-delete-upstream-operatorconfig.adoc
@@ -1,0 +1,68 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-operator-migrate-downstream-upstream.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="external-secrets-operator-delete-upstream-operatorconfig_{context}"]
+= Deleting the community {external-secrets-operator-short}
+
+[role="_abstract"]
+Delete the configuration resource for the community Operator so that the legacy application is fully removed before you install the {external-secrets-operator}.
+
+.Prerequisites
+
+* You must be logged in as a user with the `cluster-admin` role.
+
+* You must have the {oc-first} installed and configured.
+
+.Procedure
+
+. Find the namespace of the community Operator by running the following command:
++
+[source,terminal]
+----
+$ oc get operatorconfigs.operator.external-secrets.io -A
+----
++
+.Example output
+[source,terminal]
+----
+NAMESPACE             NAME        AGE
+external-secrets      cluster     9m18s
+----
+
+. Delete the `operatorconfig` custom resource (CR) by running the following command:
++
+[source,terminal]
+----
+$ oc delete operatorconfig <config_name> -n <operator_namespace>
+----
+
+.Verification
+
+. Verify that the `operatorconfig` CR is deleted by running the following command:
++
+[source,terminal]
+----
+$ oc get operatorconfig -n <operator_namespace>
+----
++
+The command must return `No resources found`.
+
+. Verify that the validating webhook is deleted by running the following command:
++
+[source,terminal]
+----
+$ oc get validatingwebhookconfigurations | grep external-secrets
+----
++
+The command must return no results.
+
+. Verify that the mutating webhook is deleted by running the following command:
++
+[source,terminal]
+----
+$ oc get mutatingwebhookconfigurations | grep external-secrets
+----
++
+The command must return no results.

--- a/modules/external-secrets-operator-eso-install.adoc
+++ b/modules/external-secrets-operator-eso-install.adoc
@@ -1,0 +1,10 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-operator-migrate-downstream-upstream.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="external-secrets-operator-eso-install_{context}"]
+= Installing the {external-secrets-operator}
+
+[role="_abstract"]
+Install the {external-secrets-operator} after cleaning up the community version. This establishes the officially supported service for managing secrets in your cluster.

--- a/modules/external-secrets-operator-eso-install.adoc
+++ b/modules/external-secrets-operator-eso-install.adoc
@@ -1,0 +1,15 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-operator-migrate-downstream-upstream.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="external-secrets-operator-eso-install_{context}"]
+= Installing the {external-secrets-operator}
+
+[role="_abstract"]
+Install the {external-secrets-operator} after cleaning up the community version. This establishes the officially supported service for managing secrets in your cluster. For more information, see "Installing the External Secrets Operator for Red Hat OpenShift".
+
+[role="_additional-resources"]
+.Additional resources
+
+* link:https://docs.redhat.com/en/documentation/openshift_container_platform/latest/html-single/security_and_compliance/index#external-secrets-operator-install[Installing the External Secrets Operator for Red Hat OpenShift]

--- a/modules/external-secrets-operator-uninstall-helm.adoc
+++ b/modules/external-secrets-operator-uninstall-helm.adoc
@@ -1,0 +1,32 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-operator-migrate-downstream-upstream.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="external-secrets-operator-uninstall-helm_{context}"]
+= Uninstalling a helm installed community {external-secrets-operator-short}
+
+[role="_abstract"]
+Remove the community {external-secrets-operator-short} that was installed using Helm. This helps you free up resources and maintain a clean environment for your cluster.
+
+.Prerequisites
+
+* You must be logged in as a user with the `cluster-admin` role.
+
+* You must have deleted the `operatorconfig` custom resource (CR).
+
+.Procedure
+
+. Install the {external-secrets-operator}. The `external-secrets-operator` namespace must be null.
+
+. Delete the {external-secrets-operator-short} by running the following command:
++
+[source,terminal]
+----
+$ oc helm delete <release_name> -n <operator_namespace>
+----
++
+[NOTE]
+====
+Using `helm delete` might delete all custom resource definitions (CRDs) and CRs. It is recommended to install the downstream Operator first if the namespace `external-secrets-operator` is empty.
+====

--- a/modules/external-secrets-operator-uninstall-helm.adoc
+++ b/modules/external-secrets-operator-uninstall-helm.adoc
@@ -1,0 +1,35 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-operator-migrate-downstream-upstream.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="external-secrets-operator-uninstall-helm_{context}"]
+= Uninstalling the community {external-secrets-operator-short} installed by Helm
+
+[role="_abstract"]
+Remove the community {external-secrets-operator-short} that was installed by using Helm. Removing it prevents a conflict with {external-secrets-operator}.
+
+[NOTE]
+====
+Using `helm delete` might delete all custom resource definitions (CRDs) and CRs. If the `external-secrets-operator` namespace is empty, install the downstream Operator first.
+====
+
+.Prerequisites
+
+* You must be logged in as a user with the `cluster-admin` role.
+
+* You must have deleted the `operatorconfig` custom resource (CR).
+
+* The `external-secrets-operator` namespace does not exist or is empty.
+
+.Procedure
+
+. Install the {external-secrets-operator}.
+
+. Delete the community {external-secrets-operator-short} by running the following command:
++
+[source,terminal]
+----
+$ oc helm delete <release_name> -n <operator_namespace>
+----
+

--- a/modules/external-secrets-operator-uninstall-olm.adoc
+++ b/modules/external-secrets-operator-uninstall-olm.adoc
@@ -1,0 +1,40 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-operator-migrate-downstream-upstream.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="external-secrets-operator-uninstall-olm_{context}"]
+= Uninstalling an Operator Lifecylce Manager installed community {external-secrets-operator-short}
+
+
+[role="_abstract"]
+Remove the community {external-secrets-operator-short} that was installed by an Operator Lifecycle Manager (OLM) subscription. This helps you free up resources and maintain a clean environment for your cluster.
+
+.Prerequisites
+
+* You must be logged in as a user with the `cluster-admin` role.
+
+* You must have deleted the `operatorconfig` CR.
+
+.Procedure
+
+. Find the subscription name by running the following command:
++
+[source,terminal]
+----
+$ oc get subscription -n <operator_namespace> | grep external-secrets
+----
+
+. Delete the subscription by running the following command:
++
+[source,terminal]
+----
+$ oc delete subscription <subscription_name> -n <operator_namespace>
+----
+
+. Delete the `ClusterServiceVersion` by running the following command:
++
+[source,terminal]
+----
+$ oc delete csv <csv_name> -n <operator_namespace>
+----

--- a/modules/external-secrets-operator-uninstall-olm.adoc
+++ b/modules/external-secrets-operator-uninstall-olm.adoc
@@ -1,0 +1,39 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-operator-migrate-downstream-upstream.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="external-secrets-operator-uninstall-olm_{context}"]
+= Uninstalling the community {external-secrets-operator-short} installed by Operator Lifecycle Manager
+
+[role="_abstract"]
+Remove the community {external-secrets-operator-short} that was installed by an Operator Lifecycle Manager (OLM) subscription. Removing it prevents a conflict with {external-secrets-operator}.
+
+.Prerequisites
+
+* You must be logged in as a user with the `cluster-admin` role.
+
+* You must have deleted the `operatorconfig` custom resource (CR).
+
+.Procedure
+
+. Find the subscription name by running the following command:
++
+[source,terminal]
+----
+$ oc get subscription -n <operator_namespace> | grep external-secrets
+----
+
+. Delete the subscription by running the following command:
++
+[source,terminal]
+----
+$ oc delete subscription <subscription_name> -n <operator_namespace>
+----
+
+. Delete the `ClusterServiceVersion` by running the following command:
++
+[source,terminal]
+----
+$ oc delete csv <csv_name> -n <operator_namespace>
+----

--- a/modules/external-secrets-operator-uninstall-raw-manifests.adoc
+++ b/modules/external-secrets-operator-uninstall-raw-manifests.adoc
@@ -1,0 +1,25 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-operator-migrate-downstream-upstream.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="external-secrets-operator-uninstall-raw-manifests_{context}"]
+= Uninstalling a raw manifest installed community {external-secrets-operator-short}
+
+[role="_abstract"]
+Remove the community {external-secrets-operator-short} that was installed by raw manifests. This helps you free up resources and maintain a clean environment for your cluster.
+
+.Prerequisites
+
+* You must be logged in as a user with the `cluster-admin` role.
+
+* You must have deleted the `operatorconfig` CR.
+
+.Procedure
+
+* To remove the communiity {external-secrets-operator-short} that was installed by raw manifests, run the following command:
++
+[source,terminal]
+----
+$ oc delete -f /path/to/your/old/manifests.yaml -n <operator_namespace>
+----

--- a/modules/external-secrets-operator-uninstall-raw-manifests.adoc
+++ b/modules/external-secrets-operator-uninstall-raw-manifests.adoc
@@ -1,0 +1,25 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-operator-migrate-downstream-upstream.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="external-secrets-operator-uninstall-raw-manifests_{context}"]
+= Uninstalling the community {external-secrets-operator-short} installed by raw manifests
+
+[role="_abstract"]
+Remove the community {external-secrets-operator-short} that was installed by raw manifests. Removing it prevents a conflict with {external-secrets-operator}.
+
+.Prerequisites
+
+* You must be logged in as a user with the `cluster-admin` role.
+
+* You must have deleted the `operatorconfig` custom resource (CR).
+
+.Procedure
+
+* To remove the community {external-secrets-operator-short} that was installed by raw manifests, run the following command:
++
+[source,terminal]
+----
+$ oc delete -f /path/to/your/old/manifests.yaml -n <operator_namespace>
+----

--- a/modules/external-secrets-operator-uninstall-upstream-eso.adoc
+++ b/modules/external-secrets-operator-uninstall-upstream-eso.adoc
@@ -1,0 +1,12 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-operator-migrate-downstream-upstream.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="external-secrets-operator-uninstall-upstream-eso_{context}"]
+= Uninstalling the community {external-secrets-operator-short}
+
+[role="_abstract"]
+Uninstall the community {external-secrets-operator-short} to prevent conflicts or accidental recreation after you migrate to {external-secrets-operator}.
+
+You must uninstall the community {external-secrets-operator-short} to prevent it from being recreated or conflicting with the new one. The steps to uninstall are different based on how the community {external-secrets-operator-short} was installed but the prerequisites are the same for each.

--- a/modules/external-secrets-operator-uninstall-upstream-eso.adoc
+++ b/modules/external-secrets-operator-uninstall-upstream-eso.adoc
@@ -1,0 +1,12 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-operator-migrate-downstream-upstream.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="external-secrets-operator-uninstall-upstream-eso_{context}"]
+= Uninstalling the community {external-secrets-operator-short}
+
+[role="_abstract"]
+Uninstall the community {external-secrets-operator-short} to prevent conflicts or accidental recreation after you migrate to {external-secrets-operator}.
+
+Uninstall steps depend on whether the community {external-secrets-operator-short} was installed by Helm, Operator Lifecycle Manager (OLM), or raw manifests. The prerequisites are the same for each method.

--- a/security/external_secrets_operator/external-secrets-operator-migrate-downstream-upstream.adoc
+++ b/security/external_secrets_operator/external-secrets-operator-migrate-downstream-upstream.adoc
@@ -1,0 +1,58 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="external-secrets-operator-migrate-downstream-upstream"]
+= Migrating from the community External Secrets Operator to the External Secrets Operator for Red Hat OpenShift
+include::_attributes/common-attributes.adoc[]
+:context: external-secrets-operator-migrate-downstream-upstream
+
+toc::[]
+
+[role="_abstract"]
+You can migrate from the community version of the {external-secrets-operator-short}. Migrating to {external-secrets-operator} provides you with an officially supported product giving you access to enterprise-grade support. It also provides you with seamless integration from installation to upgrades.
+
+The following migration versions have been fully tested.
+
+[cols="1,1,1",options="header"]
+|===
+| Upstream version
+| Installation method
+| Downstream version
+
+| 0.11.0
+| OLM
+| v1.0.0 GA
+
+| 0.19.0
+| Helm
+| v1.0.0 GA
+|===
+
+[NOTE]
+====
+The migration does not support rollbacks.
+====
+
+[NOTE]
+====
+{external-secrets-operator} is based on the upstream version 0.19.0. Do not try to migrate from a higher version of the {external-secrets-operator-short}.
+====
+
+// Deleting the operatorconfig
+include::modules/external-secrets-operator-delete-upstream-operatorconfig.adoc[leveloffset=+1]
+
+// Uninstalling the upstream {external-secrets-operator}
+include::modules/external-secrets-operator-uninstall-upstream-eso.adoc[leveloffset=+1]
+
+// Uninstalling the upstream {external-secrets-operator} installed by helm
+include::modules/external-secrets-operator-uninstall-helm.adoc[leveloffset=+2]
+
+// Uninstalling the upstream {external-secrets-operator} installed by OLM
+include::modules/external-secrets-operator-uninstall-olm.adoc[leveloffset=+2]
+
+// Uninstalling the upstream {external-secrets-operator} installed by raw manifests
+include::modules/external-secrets-operator-uninstall-raw-manifests.adoc[leveloffset=+2]
+
+// Removing {external-secrets-operator-short} using CLI
+include::modules/external-secrets-operator-eso-install.adoc[leveloffset=+1]
+
+// Create externalsecretsconfig and verify everything is running
+include::modules/external-secrets-operator-create-externalsecretsconfig.adoc[leveloffset=+1]

--- a/security/external_secrets_operator/external-secrets-operator-migrate-downstream-upstream.adoc
+++ b/security/external_secrets_operator/external-secrets-operator-migrate-downstream-upstream.adoc
@@ -1,0 +1,56 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="external-secrets-operator-migrate-downstream-upstream"]
+= Migrating from the community External Secrets Operator to the External Secrets Operator for Red Hat OpenShift
+include::_attributes/common-attributes.adoc[]
+:context: external-secrets-operator-migrate-downstream-upstream
+
+toc::[]
+
+[role="_abstract"]
+You can migrate from the community {external-secrets-operator-short} to the {external-secrets-operator} by uninstalling the community Operator and creating an `ExternalSecretsConfig` custom resource (CR).
+
+The following migration versions have been fully tested.
+
+[cols="1,1,1",options="header"]
+|===
+| Upstream version
+| Installation method
+| Downstream version
+
+| 0.11.0
+| OLM
+| v1.0.0 GA
+
+| 0.19.0
+| Helm
+| v1.0.0 GA
+|===
+
+[NOTE]
+====
+The migration does not support rollbacks. {external-secrets-operator} is based on upstream version 0.19.0. Do not migrate from a higher community Operator version.
+====
+
+// Deleting the operatorconfig
+include::modules/external-secrets-operator-delete-upstream-operatorconfig.adoc[leveloffset=+1]
+
+// Uninstalling the upstream {external-secrets-operator}
+include::modules/external-secrets-operator-uninstall-upstream-eso.adoc[leveloffset=+1]
+
+// Uninstalling the upstream {external-secrets-operator} installed by helm
+include::modules/external-secrets-operator-uninstall-helm.adoc[leveloffset=+2]
+
+// Uninstalling the upstream {external-secrets-operator} installed by OLM
+include::modules/external-secrets-operator-uninstall-olm.adoc[leveloffset=+2]
+
+// Uninstalling the upstream {external-secrets-operator} installed by raw manifests
+include::modules/external-secrets-operator-uninstall-raw-manifests.adoc[leveloffset=+2]
+
+// Install {external-secrets-operator-short} after community cleanup
+include::modules/external-secrets-operator-eso-install.adoc[leveloffset=+1]
+
+// Create externalsecretsconfig and verify everything is running
+include::modules/external-secrets-operator-create-externalsecretsconfig.adoc[leveloffset=+1]
+
+
+


### PR DESCRIPTION
Version(s):
4.18

Issue:
https://redhat.atlassian.net/browse/OSDOCS-19410

Link to docs preview:
https://111998--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/external_secrets_operator/external-secrets-operator-migrate-downstream-upstream.html


QE review:
- [x] QE has approved this change.


Additional information:
Merge-reviewer: The information in this PR was copied from the most recent ESO repo here https://github.com/openshift/openshift-docs/tree/main/modules. Most of the  text was reviewed in earlier PRs. Just thought you would want to know.
