### PR TITLE
OSDOCS-19749: adds audit trail docs MCP gateway

### DIFF
--- a/mcp_gateway_install/mcp-gateway-install.adoc
+++ b/mcp_gateway_install/mcp-gateway-install.adoc
@@ -21,11 +21,13 @@ include::modules/proc-config-mcp-gateway-listener.adoc[leveloffset=+1]
 
 include::modules/con-mcp-gateway-install-olm-ext-cr.adoc[leveloffset=+1]
 
+include::modules/proc-mcp-gateway-install-olm-ext-cr.adoc[leveloffset=+1]
+
+include::modules/ref-mcp-gateway-install-gateway-ext-api.adoc[leveloffset=+2]
+
 include::modules/ref-mcp-gateway-auto-route.adoc[leveloffset=+2]
 
 include::modules/proc-mcp-gateway-referencegrant.adoc[leveloffset=+1]
-
-include::modules/proc-mcp-gateway-install-olm-ext-cr.adoc[leveloffset=+1]
 
 include::modules/con-mcp-gateway-dns-management.adoc[leveloffset=+1]
 

--- a/modules/con-mcp-gateway-audit-trail-no-auth.adoc
+++ b/modules/con-mcp-gateway-audit-trail-no-auth.adoc
@@ -1,0 +1,44 @@
+// Module included in the following assemblies:
+//
+// *mcp_gateway_config/mcp-gateway-observe.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="con-mcp-gateway-audit-trail-no-auth_{context}"]
+= Using an audit trail without authentication
+
+[role="_abstract"]
+If you do not have an authentication layer, the routing headers still offer useful audit context. The `mcp_user_id` field is empty (`-`), but you can still see what tool was called, on which server, in which session, at what time, and how long the interaction lasted.
+
+You can configure the `x-auth-identity` header name and the JWT claim in the `AuthPolicy` CR. Adjust the `spec.defaults.rules.response.success.headers` section to match your identity provider according to the following list:
+
+* {keycloak}: `auth.identity.preferred_username` or `auth.identity.email`.
+* Generic OIDC: `auth.identity.sub`; this is the subject claim, always present in JWTs.
+* Custom claims: `auth.identity.<claim_name>` for any claim in the JWT payload.
+
+[IMPORTANT]
+====
+If you change the header name, you must also update the `mcp_user_id` field in your `MeshConfig` extension provider to match the `%REQ(_<HEADER_NAME>_)%` format.
+====
+
+.Generic OIDC `AuthPolicy` CR header configuration example
+[source,yaml,subs="+quotes"]
+----
+apiVersion: kuadrant.io/v1
+kind: AuthPolicy
+metadata:
+  name: _<audit_no_auth_client_listener>_
+  namespace: _<gateway_namespace>_
+spec:
+#...
+  defaults:
+#...
+    rules:
+#...
+      response:
+        success:
+          headers:
+            "x-auth-identity":
+              plain:
+                selector: auth.identity.sub
+#...
+----

--- a/modules/con-mcp-gateway-audit-trail.adoc
+++ b/modules/con-mcp-gateway-audit-trail.adoc
@@ -1,0 +1,26 @@
+// Module included in the following assemblies:
+//
+// *mcp_gateway_config/mcp-gateway-observe.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="con-mcp-gateway-audit-trail_{context}"]
+= Understanding an MCP gateway audit trail
+
+[role="_abstract"]
+You can use an audit trail for compliance and accountability that captures caller identity, tool names, and MCP session context through the MCP gateway.
+
+Users connect to backend MCP servers and run functions, for example, reading a database, running a script, or editing files. By configuring an audit trail that comes from your `AuthPolicy` objects and the Istio Telemetry API, you can configure JSON access logging on your `Gateway` object and discover who did what and when.
+
+MCP Gateway sets the following routing headers on every request:
+
+* `x-mcp-method`
+* `x-mcp-toolname`
+* `x-mcp-servername`
+* `mcp-session-id`
+
+These headers are available to any Envoy access log through `%REQ(...)%` format strings. With configuration, you can add the following username header and structured access logs:
+
+* `x-auth-identity`: Adds caller identity. After you configure the header, the `AuthPolicy` object validates JWT tokens and injects the authenticated username as the request header.
+* With an Istio Telemetry resource, you can configure JSON access logging on the `Gateway` object, capturing MCP routing headers and the identity header.
+
+The result is a JSON access log on the MCP `Gateway` object pod's standard output (`stdout`) that tells you who called what tool, on which server, during which session, and at what time.

--- a/modules/proc-mcp-gateway-add-custom-audit-log-provider.adoc
+++ b/modules/proc-mcp-gateway-add-custom-audit-log-provider.adoc
@@ -1,0 +1,66 @@
+// Module included in the following assemblies:
+//
+// *mcp_gateway_config/mcp-gateway-observe.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="proc-mcp-gateway-add-custom-audit-log-provider_{context}"]
+= Adding a custom audit log provider
+
+[role="_abstract"]
+Define the JSON format for the audit logs by adding a custom access log provider to Istio's `MeshConfig` structure that dictates all the global settings for the mesh. Istio acts as the controller that translates your resources into Envoy configurations.
+
+[IMPORTANT]
+====
+The approach used in the following procedures only works if you are using {service-mesh}. If you are using the {ocp} default Ingress Operator to manage `Istio` objects, changes are reconciled back to the previous settings.
+====
+
+.Prerequisites
+
+* You installed the MCP gateway.
+* You installed {prodname}.
+* You created a `Gateway` object.
+* You set up an identity provider.
+* You configured Istio as the Gateway API provider.
+* You created `AuthPolicy` audit CRs for both MCP gateway listeners.
+
+.Procedure
+
+* Edit the Istio object by using the following example:
++
+.Example Istio custom access log provider
+[source,yaml]
+----
+apiVersion: operator.istio.io/v1alpha1
+kind: Istio
+metadata:
+  name: default
+  namespace: istio-system
+spec:
+  meshConfig:
+    extensionProviders:
+      - name: mcp-json-access-log
+        file:
+          path: /dev/stdout
+          jsonFormat:
+            timestamp: "%START_TIME%"
+            method: "%REQ(:METHOD)%"
+            path: "%REQ(:PATH)%"
+            response_code: "%RESPONSE_CODE%"
+            request_id: "%REQ(X-REQUEST-ID)%"
+            traceparent: "%REQ(TRACEPARENT)%"
+            mcp_method: "%REQ(X-MCP-METHOD)%"
+            mcp_tool_name: "%REQ(X-MCP-TOOLNAME)%"
+            mcp_server_name: "%REQ(X-MCP-SERVERNAME)%"
+            mcp_session_id: "%REQ(MCP-SESSION-ID)%"
+            mcp_user_id: "%REQ(X-AUTH-IDENTITY)%"
+            duration_ms: "%DURATION%"
+            upstream_host: "%UPSTREAM_HOST%"
+            bytes_sent: "%BYTES_SENT%"
+            bytes_received: "%BYTES_RECEIVED%"
+#...
+----
++
+[IMPORTANT]
+====
+If you have other extension providers configured, for example, OpenTelemetry tracing, include them in the `extensionProviders` array with the access log provider. The merge of the resources replaces the array.
+====

--- a/modules/proc-mcp-gateway-config-authpolicy-with-id-injection.adoc
+++ b/modules/proc-mcp-gateway-config-authpolicy-with-id-injection.adoc
@@ -1,0 +1,146 @@
+// Module included in the following assemblies:
+//
+// *mcp_gateway_config/mcp-gateway-observe.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="proc-mcp-gateway-config-authpolicy-with-id-injection_{context}"]
+= Configuring an AuthPolicy with identity injection
+
+[role="_abstract"]
+To capture authenticated user identities in access logs for all request types, you must create an `AuthPolicy` custom resource (CR) for each of the MCP gateway's two listeners.
+
+The MCP gateway uses the two following listeners:
+
+* `mcp`: This listener handles client requests such as `initialize` and `tools/list`.
+* `mcps`: This listener handles tool call routing to the backend MCP servers.
+
+When you have configured the `AuthPolicy` CRs, after Authorino validates the JWT, it extracts the `preferred_username` field value from the token claims and injects it as the `x-auth-identity` request header. This header is trustworthy because Authorino strips any client-supplied value and sets it from the validated token. With both policies in place, the `mcp_user_id` field is displayed in access log entries for all MCP request types.
+
+.Prerequisites
+
+* You installed the MCP gateway.
+* You installed {prodname}.
+* You created a `Gateway` object.
+* You set up an identity provider.
+* You configured Istio as the Gateway API provider.
+//Q: I thought Istio is automatic? what does an openshift customer need to do here?
+
+.Procedure
+
+. Create an `AuthPolicy` CR for the client-facing listener, `mcp`, by using the following example:
++
+.Client-facing listener AuthPolicy CR
+[source,yaml,subs="+quotes"]
+----
+apiVersion: kuadrant.io/v1
+kind: AuthPolicy
+metadata:
+  name: _<audit_auth_client_listener>_
+  namespace: _<gateway_namespace>_
+spec:
+  targetRef:
+    group: gateway.networking.k8s.io
+    kind: Gateway
+    name: _<mcp_gateway>_
+    sectionName: mcp
+  defaults:
+    when:
+      - predicate: "!request.path.contains('/.well-known')"
+    rules:
+      authentication:
+        'keycloak':
+          jwt:
+            issuerUrl: https://keycloak.example.com:8002/realms/mcp
+      response:
+        success:
+          headers:
+            "x-auth-identity":
+              plain:
+                selector: auth.identity.preferred_username
+        unauthenticated:
+          code: 401
+          headers:
+            'WWW-Authenticate':
+              value: Bearer resource_metadata=http://mcp.example.com:8001/.well-known/oauth-protected-resource/mcp
+          body:
+            value: |
+              {
+                "error": "Unauthorized",
+                "message": "Authentication required."
+              }
+----
++
+* Replace `_<mcp_gateway>_` with the name of your MCP gateway deployment.
+* Replace `_<gateway_namespace>_` with the namespace where you applied your `Gateway` object.
++
+[NOTE]
+====
+This `mcp` listener `AuthPolicy` CR validates JSON web tokens (JWTs) on client requests and injects the authenticated username as a request header.
+====
+
+. Apply the client-listener `AuthPolicy` CR by running the following command:
++
+[source,terminal,subs="+quotes"]
+----
+$ oc apply -f _<audit_auth_client_listener.yaml>_
+----
++
+Replace `_<audit_auth_client_listener.yaml>_` with the filename that you used.
+
+. Create an `AuthPolicy` CR for the backend-facing listener, `mcps`, by using the following example:
++
+.Client-facing listener AuthPolicy CR
+[source,yaml,subs="+quotes"]
+----
+apiVersion: kuadrant.io/v1
+kind: AuthPolicy
+metadata:
+  name: _<audit_auth_backend_listener>_
+  namespace: _<gateway_namespace>_
+spec:
+  targetRef:
+    group: gateway.networking.k8s.io
+    kind: Gateway
+    name: _<mcp_gateway>_
+    sectionName: mcps
+  defaults:
+    rules:
+      authentication:
+        'keycloak':
+          jwt:
+            issuerUrl: https://keycloak.example.com:8002/realms/mcp
+      response:
+        success:
+          headers:
+            "x-auth-identity":
+              plain:
+                selector: auth.identity.preferred_username
+        unauthenticated:
+          code: 401
+          headers:
+            'WWW-Authenticate':
+              value: Bearer resource_metadata=http://mcp.example.com:8001/.well-known/oauth-protected-resource/mcp
+          body:
+            value: |
+              {
+                "error": "Unauthorized",
+                "message": "Authentication required."
+              }
+----
+* Replace `_<mcp_gateway>_` with the name of your MCP gateway deployment.
+* Replace `_<gateway_namespace>_` with the namespace where you applied your `Gateway` object.
+* Replace the `preferred_username` field value with `sub` or another claim depending on both your identity provider and what you want as the audit identity. For {keycloak}, the `preferred_username` field value gives a human-readable username but requires the `profile` scope in the token request.
++
+[NOTE]
+====
+This `mcps` listener policy validates the same JWT on tool call requests routed to backend servers and injects the identity header there, too.
+====
+
+. Apply the backend-listener `AuthPolicy` CR by running the following command:
++
+[source,terminal,subs="+quotes"]
+----
+$ oc apply -f _<audit_auth_backend_listener.yaml>_
+----
++
+Replace `_<audit_auth_backend_listener.yaml>_` with the filename that you used.

--- a/modules/proc-mcp-gateway-create-telemetry-cr-audit-logs.adoc
+++ b/modules/proc-mcp-gateway-create-telemetry-cr-audit-logs.adoc
@@ -1,0 +1,67 @@
+// Module included in the following assemblies:
+//
+// *mcp_gateway_config/mcp-gateway-observe.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="proc-mcp-gateway-create-telemetry-cr-audit-logs_{context}"]
+= Create a Telemetry custom resource for audit logs
+
+[role="_abstract"]
+After you updated your Istio custom resource (CR), you must create a Telemetry CR in the namespace where your `Gateway` object is applied to enable the access log on the Gateway workload.
+
+The resource created in this example scopes the access log to the `_<mcp_gateway>_` Gateway pods only. Other workloads in the mesh are not affected.
+
+.Prerequisites
+
+* You installed the MCP gateway.
+* You installed {prodname}.
+* You created a `Gateway` object.
+* You set up an identity provider.
+* You configured Istio as the Gateway API provider.
+* You created `AuthPolicy` audit CRs for both MCP gateway listeners.
+* You added your custom log provider.
+
+.Procedure
+
+. Create a `Telemetry` CR in the namespace where your `Gateway` object is applied by using the following example:
++
+.Example Telemetry CR for audit logs
+[source,yaml,subs="+quotes"]
+----
+apiVersion: telemetry.istio.io/v1
+kind: Telemetry
+metadata:
+  name: _<mcp_audit_logging>_
+  namespace: _<gateway_namespace>_
+spec:
+  selector:
+    matchLabels:
+      gateway.networking.k8s.io/gateway-name: _<mcp_gateway>_
+  accessLogging:
+    - providers:
+        - name: mcp-json-access-log
+----
++
+* Replace `_<mcp_audit_logging>_` with the name of your audit logging Telemetry CR.
+* Replace `_<gateway_namespace>_` with the namespace where you applied your `Gateway` object.
+* Replace `_<mcp_gateway>_` with the name of your MCP gateway deployment.
+
+. Apply the `Telemetry` CR by running the following command:
++
+[source,terminal,subs="+quotes"]
+----
+$ oc apply -f _<mcp_audit_logging.yaml>_
+----
++
+Replace `_<mcp_audit_logging.yaml>_` with the name of your audit logging Telemetry YAML.
+
+.Verification
+
+. Verify that your `Telemetry` CR is applied by running the following command:
++
+[source,terminal,subs="+quotes"]
+----
+$ oc get telemetry -n _<gateway_namespace>_
+----
++
+Replace `_<gateway_namespace>_` with the namespace where you applied your `Gateway` object.

--- a/modules/proc-mcp-gateway-verify-audit-trail.adoc
+++ b/modules/proc-mcp-gateway-verify-audit-trail.adoc
@@ -1,0 +1,69 @@
+// Module included in the following assemblies:
+//
+// *mcp_gateway_config/mcp-gateway-observe.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="proc-mcp-gateway-verify-audit-trail_{context}"]
+= Verifying your audit trail
+
+[role="_abstract"]
+After you updated your Istio custom resource (CR), you must create a Telemetry CR in the namespace where your `Gateway` object is applied to enable the access log on the Gateway workload.
+
+The resource created in this example scopes the access log to the `_<mcp_gateway>_` Gateway pods only. Other workloads in the mesh are not affected.
+
+.Prerequisites
+
+* You installed the MCP gateway.
+* You installed {prodname}.
+* You created a `Gateway` object.
+* You set up an identity provider.
+* You configured Istio as the Gateway API provider.
+* You created `AuthPolicy` audit custom resources (CRs) for both MCP gateway listeners.
+* You added your custom log provider.
+* You created your Telemetry CR.
+
+.Procedure
+
+. Make an authenticated tool call by reusing both the token and session ID from the earlier step by running the following command:
++
+[source,terminal]
+----
+$ curl -s http://mcp.example.com:8001/mcp \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -H "Mcp-Session-Id: $SESSION_ID" \
+  -d '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"test1_greet","arguments":{"name":"audit-test"}}}'
+----
+
+. Check the `Gateway` object pod logs for the JSON access log entry by running the following command:
++
+[source,terminal,subs="+quotes"]
+----
+$ oc logs -n _<gateway_namespace>_ -l gateway.networking.k8s.io/gateway-name=_<mcp_gateway>_ --since=30s \
+  | grep '"mcp_method"' | tail -1 | jq .
+----
++
+* Replace `_<gateway_namespace>_` with the namespace where you applied your `Gateway` object.
+* Replace `_<mcp_gateway>_` with the name of your MCP gateway deployment.
++
+.Expected output
+[source,json]
+----
+{
+  "timestamp": "2026-05-21T14:23:01.123Z",
+  "method": "POST",
+  "path": "/mcp",
+  "response_code": 200,
+  "request_id": "abc-111",
+  "traceparent": null,
+  "mcp_method": "tools/call",
+  "mcp_tool_name": "greet",
+  "mcp_server_name": "mcp-test/test-server1",
+  "mcp_session_id": "sess-7a3b",
+  "mcp_user_id": "mcp",
+  "duration_ms": 342,
+  "upstream_host": "10.0.1.5:8080",
+  "bytes_sent": 1024,
+  "bytes_received": 512
+}
+----

--- a/modules/proc-mcp-gateway-verify-authpolicy-id-inject.adoc
+++ b/modules/proc-mcp-gateway-verify-authpolicy-id-inject.adoc
@@ -1,0 +1,59 @@
+// Module included in the following assemblies:
+//
+// *mcp_gateway_config/mcp-gateway-observe.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="proc-mcp-gateway-verify-authpolicy-with-id-inject_{context}"]
+= Verifying AuthPolicy identity injection
+
+[role="_abstract"]
+Verify that the identity header you created in your audit `AuthPolicy` custom resource (CR) is being injected by calling a tool and checking what the backend receives.
+
+.Prerequisites
+
+* You installed the MCP gateway.
+* You installed {prodname}.
+* You created a `Gateway` object.
+* You set up an identity provider.
+* You configured Istio as the Gateway API provider.
+* You created `AuthPolicy` audit CRs for both MCP gateway listeners.
+
+.Procedure
+
+. Get a token by running the following command:
++
+[source,terminal]
+----
+$ TOKEN=$(curl -s -X POST "https://keycloak.example.com:8002/realms/mcp/protocol/openid-connect/token" \
+  -d "grant_type=password&client_id=mcp-gateway&client_secret=secret&username=mcp&password=mcp&scope=openid+profile" \
+  | jq -r '.access_token')
+----
++
+Adjust this command for your identity provider.
+
+. Initialize a session by running the following command:
++
+[source,terminal]
+----
+$ SESSION_ID=$(curl -si http://mcp.example.com:8001/mcp \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"audit-test","version":"0.0.1"}}}' \
+  | grep -i 'mcp-session-id:' | awk '{print $2}' | tr -d '\r')
+----
++
+The expected output is the session ID returned in the response header.
+
+. Call the headers tool to see which headers reach the backend by running the following command:
++
+[source,terminal]
+----
+$ curl -s http://mcp.example.com:8001/mcp \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -H "Mcp-Session-Id: $SESSION_ID" \
+  -d '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"test1_headers","arguments":{}}}' \
+  | jq '.result.content[0].text' | grep -i "x-auth-identity"
+----
++
+The expected output is the `x-auth-identity` header that lists the Keycloak username in the response.

--- a/modules/ref-mcp-gateway-audit-log-fields.adoc
+++ b/modules/ref-mcp-gateway-audit-log-fields.adoc
@@ -1,0 +1,79 @@
+// Module included in the following assemblies:
+//
+// *mcp_gateway_config/mcp-gateway-observe.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="ref-mcp-gateway-custom-audit-log-provider-fields_{context}"]
+= Custom audit log provider fields
+
+[role="_abstract"]
+Understand the MCP gateway audit log fields by using the reference table for descriptions of each field and the source and type of information that each provides.
+
+.Audit log fields
+[cols="25,25,50", options="header"]
+|===
+
+|*Field*
+|*Source*
+|*Description*
+
+|`timestamp`
+|`%START_TIME%`
+|The start time of the session
+
+|`method`
+|`%REQ(:METHOD)%`
+|The HTTP method of the request, for example, `GET`, `POST`
+
+|`path`
+|`%REQ(:PATH)%`
+|The HTTP request path, including any query parameters
+
+|`response_code`
+|`%RESPONSE_CODE%`
+|The HTTP response status code returned to the client
+
+|`request_id`
+|`%REQ(X-REQUEST-ID)%`
+|Unique string identifier for tracking the end-to-end request lifecycle
+
+|`traceparent`
+|`%REQ(TRACEPARENT)%`
+|W3C Trace Context for cross-system correlation
+
+|`mcp_method`
+|`%REQ(X-MCP-METHOD)%`
+|MCP method, such as `tools/call`, `tools/list`, `initialize`, and so on
+
+|`mcp_tool_name`
+|`%REQ(X-MCP-TOOLNAME)%`
+|Tool name after prefix stripping
+
+|`mcp_server_name`
+|`%REQ(X-MCP-SERVERNAME)%`
+|Backend MCP server name
+
+|`mcp_session_id`
+|`%REQ(MCP-SESSION-ID)%`
+|MCP session identifier
+
+|`mcp_user_id`
+|`%REQ(X-AUTH-IDENTITY)%`
+|Authenticated user identity, injected by an `AuthPolicy` custom resource
+
+|`duration_ms`
+|`%DURATION%`
+|Total duration of the request in milliseconds, from the start time to the last byte sent
+
+|`upstream_host`
+|`%UPSTREAM_HOST%`
+|The upstream host IP address and port that handled the request
+
+|`bytes_sent`
+|`%BYTES_SENT%`
+|Body bytes sent downstream to the client
+
+|`bytes_received`
+|`%BYTES_RECEIVED%`
+|Body bytes received upstream from the client
+|===

--- a/modules/ref-mcp-gateway-install-gateway-ext-api.adoc
+++ b/modules/ref-mcp-gateway-install-gateway-ext-api.adoc
@@ -1,0 +1,202 @@
+// Module included in the following assemblies:
+//
+// *mcp_gateway_install/mcp-gateway-install.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="ref-mcp-gateway-install-ext-api_{context}"]
+= The MCPGatewayExtension custom resource API reference
+
+[role="_abstract"]
+You can use the following API reference information for each MCP gateway `MCPGatewayExtension` custom resource (CR).
+
+.MCPGatewayExtension
+[cols="1,1,1,2", options="header"]
+|===
+
+|*Field*
+|*Type*
+|*Required*
+|*Description*
+
+|`spec`
+|link:https://github.com/Kuadrant/mcp-gateway/blob/main/docs/reference/mcpgatewayextension.md#mcpgatewayextensiontargetreference[MCPGatewayExtensionSpec]
+|Yes
+|The specification for MCPGatewayExtension custom resource
+
+|`status`
+|link:https://github.com/Kuadrant/mcp-gateway/blob/main/docs/reference/mcpgatewayextension.md#mcpgatewayextensionstatus[MCPGatewayExtensionStatus]
+|No
+|The status for the custom resource
+|===
+
+.MCPGatewayExtensionSpec
+[cols="1,1,1,2", options="header"]
+|===
+
+|*Field*
+|*Type*
+|*Required*
+|*Description*
+
+|`targetRef`
+|link:https://github.com/Kuadrant/mcp-gateway/blob/main/docs/reference/mcpgatewayextension.md#mcpgatewayextensiontargetreference[MCPGatewayExtensionTargetReference]
+|Yes
+|The Gateway listener to extend with MCP protocol support
+
+|`publicHost`
+|String
+|No
+|Overrides the public host derived from the listener hostname. Use when the listener has a wildcard and you need a specific host
+
+|`privateHost`
+|String
+|No
+|Overrides the internal host used for hair-pinning requests back through the gateway. Defaults to `<gateway>-istio.<ns>.svc.cluster.local:<port>`, with an `https://` scheme prefix when the targeted Gateway listener uses the HTTPS protocol. The supplied value is honoured verbatim, so an operator can include a scheme, for example, `https://my-gw:443`, or pin to a different port.
+
+|`backendPingIntervalSeconds`
+|Integer
+|No
+|How often (in seconds) the broker pings upstream MCP servers. Min: 10, Max: 7200, Default: 60
+
+|`trustedHeadersKey`
+|link:https://github.com/Kuadrant/mcp-gateway/blob/main/docs/reference/mcpgatewayextension.md#trustedheaderskey[TrustedHeadersKey]
+|No
+|Configures trusted-header key pair for JWT-based tool filtering. When set, the public key secret is injected into the broker deployment with the `TRUSTED_HEADER_PUBLIC_KEY` environment variable.
+
+|`httpRouteManagement`
+|String
+|No
+|Controls whether the operator manages the gateway `HTTPRoute` CR. The default value is `Enabled`: creates and manages the `HTTPRoute` CR. `Disabled`: does not create an `HTTPRoute` CR. Disabling does not delete a previously created route.
+
+|`sessionStore`
+|link:https://github.com/Kuadrant/mcp-gateway/blob/main/docs/reference/mcpgatewayextension.md#sessionstore[SessionStore]
+|No
+|References a secret for redis-based session storage. When not set, in-memory session storage is used.
+
+|`urlElicitation`
+|String
+|No
+|Controls URL-based token elicitation. `Enabled`: creates a separate `/tokens` HTTPRoute and passes `--enable-url-elicitation` to the broker. `Disabled` (default): no `/tokens` route is created.
+|===
+
+.MCPGatewayExtensionTargetReference
+[cols="1,1,1,2", options="header"]
+|===
+
+|*Field*
+|*Type*
+|*Required*
+|*Description*
+
+|`group`
+|String
+|Yes
+|Group of the target resource. Default: `gateway.networking.k8s.io`
+
+|`kind`
+|String
+|Yes
+|Kind of the target resource. Default: `Gateway`
+
+|`name`
+|String
+|Yes
+|Name of the target Gateway
+
+|`namespace`
+|String
+|No
+|Namespace of the target Gateway. Defaults to the MCPGatewayExtension namespace. Cross-namespace references require a ReferenceGrant
+
+|`sectionName`
+|String
+|Yes
+|Name of a listener on the target Gateway. The controller reads the listener's port and hostname to configure the MCP Gateway instance
+|===
+
+.TrustedHeadersKey
+[cols="1,1,1,2", options="header"]
+|===
+
+|*Field*
+|*Type*
+|*Required*
+|*Description*
+
+|`secretName`
+|String
+|Yes
+|Name of the secret containing the PEM-encoded public key used by the broker to verify trusted-header JWTs. The secret must have a data entry with key `key`. When `generate` is `Enabled`, the operator creates this secret
+
+|`generate`
+|String
+|No
+|Controls whether the operator generates an ECDSA P-256 key pair. `Enabled`: creates `<secretName>` (public key) and `<secretName>-private` (private key) with owner references. `Disabled` (default): the secret must already exist. Changing this field requires deleting the existing secrets first to ensure the keys are a matching pair
+|===
+
+.SessionStore
+[cols="1,1,1,2", options="header"]
+|===
+
+|*Field*
+|*Type*
+|*Required*
+|*Description*
+
+|`secretName`
+|String
+|Yes
+|Name of the secret containing a `CACHE_CONNECTION_STRING` data entry. The value should be a Redis connection string  such as `redis://<user>:<pass>@<host>:<port>/<db>`. The secret must exist in the same namespace as the `MCPGatewayExtension` CR and must have the label `mcp.kuadrant.io/secret: "true"`. Injected as `CACHE_CONNECTION_STRING` environment variable into the MCP broker-router component deployment.
+|===
+
+.MCPGatewayExtensionStatus
+[cols="1,1,1,2", options="header"]
+|===
+
+|*Field*
+|*Type*
+|*Required*
+|*Description*
+
+|`conditions`
+|link:https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Condition[Kubernetes meta/v1.Condition]
+|Yes
+|List of conditions that define the status of the resource
+|===
+
+.Conditions
+[cols="1,2", options="header"]
+|===
+
+|*Type*
+|*Description*
+
+|`Ready`
+|Indicates whether the `MCPGatewayExtension` is fully configured as follows: the broker-router deployment is running, the EnvoyFilter is applied, and trusted headers, if configured, are valid.
+|===
+
+.Condition reasons
+[cols="1,2", options="header"]
+|===
+
+|*Reason*
+|*Description*
+
+|`ValidMCPGatewayExtension`
+|The `MCPGatewayExtension` is valid and ready.
+
+|`InvalidMCPGatewayExtension`
+|Invalid configuration detected.
+
+|`ReferenceGrantRequired`
+|A `ReferenceGrant` is missing for a cross-namespace `Gateway` reference.
+
+|`DeploymentNotReady`
+|The broker-router deployment is not ready.
+
+|`SecretNotFound`
+|A referenced secret is missing, specifically the trusted headers or session store.
+
+|`SecretInvalid`
+|A referenced secret lacks the required data entry: `key` for trusted headers, `CACHE_CONNECTION_STRING` for session store.
+|===

--- a/modules/ref-relnotes-new-features.adoc
+++ b/modules/ref-relnotes-new-features.adoc
@@ -13,7 +13,7 @@ X.509 cryptographic identity verification now available::
 
 With this {prodname} release, you can use X.509 client certificate authentication with for strong cryptographic identity verification. The X.509 format creates a two-layer authentication process that requires both cryptographic proof and context-aware validation before a request authenticates.
 
-//For more information, see xref:../deployment/rhcl-using-x509-crypt-id-verify.adoc#rhcl-using-x509-crypt-id-verify[Using X.509 cryptographic identity verification]
+For more information, see xref:../deployment/rhcl-using-x509-crypt-id-verify.adoc#rhcl-using-x509-crypt-id-verify[Using X.509 cryptographic identity verification].
 
 MCP gateway: MCP prompt federation is now available::
 
@@ -21,10 +21,16 @@ MCP gateway: MCP prompt federation is now available::
 +
 With this update, you can now access and run prompt templates from your upstream MCP servers through a single, central `Gateway` connection. Instead of managing separate connections to multiple backend servers, you can query the `Gateway` object to see a unified, prefixed list of every available prompt across your network. When you find the prompt template that you need, you can plug in your custom variables. The `Gateway` object automatically routes the request to the right place.
 
-//For more information, see xref:../mcp_gateway_config/mcp-gateway-register-on-prem-mcp-servers.adoc#mcp-gateway-register-on-prem-mcp-servers[Registering on-prem MCP servers]
+For more information, see xref:../mcp_gateway_config/mcp-gateway-register-on-prem-mcp-servers.adoc#mcp-gateway-register-on-prem-mcp-servers[Registering on-prem MCP servers].
 
 MCP gateway: Vault documentation now included::
 
 Now you can learn how to use HashiCorp Vault (Vault) to retrieve and inject authentication credentials into your MCP server request flow with the MCP gateway.
 
-//For more information see xref:../mcp_gateway_config/mcp-gateway-vault.adoc#mcp-gateway-vault[Using credentials to access external APIs with Vault]
+For more information see xref:../mcp_gateway_config/mcp-gateway-vault.adoc#mcp-gateway-vault[Using credentials to access external APIs with Vault].
+
+MCP gateway audit trail documentation is now available::
+
+The {mcpg} documentation now includes configuration instructions for creating an audit trail for compliance and accountability that captures caller identity, tool names, and MCP session context through the MCP gateway.
+
+//For more information, see xref:../observe/mcp-gateway-observe.adoc#con-mcp-gateway-audit-trail_mcp-gateway-observe[Understanding an MCP gateway audit trail].

--- a/observe/mcp-gateway-observe.adoc
+++ b/observe/mcp-gateway-observe.adoc
@@ -7,11 +7,27 @@ include::_attributes/attributes.adoc[]
 toc::[]
 
 [role="_abstract"]
-You can use observability in {mcpg} to debug things such as silent failures, track destructive annotations, track latencies, and make an audit trail.
+You can use observability in {mcpg} to debug things such as silent failures, track destructive annotations, track latencies, and configure an audit trail.
 
 include::modules/proc-mcp-gateway-otel.adoc[leveloffset=+1]
 
 include::modules/ref-mcp-gateway-router-spans.adoc[leveloffset=+2]
+
+include::modules/con-mcp-gateway-audit-trail.adoc[leveloffset=+1]
+
+include::modules/proc-mcp-gateway-config-authpolicy-with-id-injection.adoc[leveloffset=+2]
+
+include::modules/proc-mcp-gateway-verify-authpolicy-id-inject.adoc[leveloffset=+2]
+
+include::modules/proc-mcp-gateway-add-custom-audit-log-provider.adoc[leveloffset=+2]
+
+include::modules/ref-mcp-gateway-audit-log-fields.adoc[leveloffset=+3]
+
+include::modules/proc-mcp-gateway-create-telemetry-cr-audit-logs.adoc[leveloffset=+2]
+
+include::modules/proc-mcp-gateway-verify-audit-trail.adoc[leveloffset=+2]
+
+include::modules/con-mcp-gateway-audit-trail-no-auth.adoc[leveloffset=+2]
 
 [id="additional-resources_mcp-gateway-observe"]
 [role="_additional-resources"]


### PR DESCRIPTION
Version(s):
rhcl-docs-1.4

Issue:
[OSDOCS-19749](https://redhat.atlassian.net/browse/OSDOCS-19749)

Link to docs preview:
https://112003--ocpdocs-pr.netlify.app/rhcl/latest/observe/mcp-gateway-observe.html#con-mcp-gateway-audit-trail_mcp-gateway-observe (audit trail--docs only scope)
https://112003--ocpdocs-pr.netlify.app/rhcl/latest/mcp_gateway_install/mcp-gateway-install.html#ref-mcp-gateway-install-ext-api_mcp-gateway-get-install (adds the extension's API reference)
https://112003--ocpdocs-pr.netlify.app/rhcl/latest/release_notes/rhcl-release-notes.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->


<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
