### PR TITLE
OSDOCS-19786: accept flag for recommend command

### DIFF
--- a/modules/oc-adm-upgrade-recommend-accept.adoc
+++ b/modules/oc-adm-upgrade-recommend-accept.adoc
@@ -1,0 +1,83 @@
+:_mod-docs-content-type: PROCEDURE
+[id="oc-adm-upgrade-recommend-accept_{context}"]
+= Accepting risks with the oc adm upgrade recommend command
+
+[role="_abstract"]
+You can use a command flag to explicitly accept update risks that are shown in the output of the `oc adm upgrade recommend` command.
+
+// Not sure what else to add to the intro, since the "why" behind this seems to be that in 5.0, it will be necessary for upgrades to versions with risks. Right now, this feature kind of seems to just exist.
+
+.Procedure
+
+. Check for update risks by running the following command:
++
+[source,terminal]
+----
+$ oc adm upgrade recommend
+----
++
+.Example output
+[source,terminal]
+----
+The following conditions found no cause for concern in updating this cluster to later releases: recommended/CriticalAlerts (AsExpected), recommended/NodeAlerts (AsExpected), recommended/PodDisruptionBudgetAlerts (AsExpected), recommended/PodImagePullAlerts (AsExpected)
+
+The following conditions found cause for concern in updating this cluster to later releases: recommended/UpdatePrecheckAlerts/TestAlert/0
+
+recommended/UpdatePrecheckAlerts/TestAlert/0=False:
+
+  Reason: Alert:firing
+  Message: warning alert TestAlert firing, suggesting issues worth investigating before updating the cluster. Test alert for updates. The alert description is: Test alert for updates <alert does not have a runbook_url annotation>
+
+Upstream update service is unset, so the cluster will use an appropriate default.
+Channel: stable-4.21 (available channels: candidate-4.20, candidate-4.21, candidate-4.22, eus-4.20, fast-4.20, fast-4.21, stable-4.20, stable-4.21)
+
+Updates to 4.21:
+  VERSION     ISSUES
+  4.21.14     no known issues relevant to this cluster
+  4.21.13     no known issues relevant to this cluster
+And 2 older 4.21 updates you can see with '--show-outdated-releases' or '--version VERSION'.
+
+Updates to 4.20:
+  VERSION     ISSUES
+  4.20.20     no known issues relevant to this cluster
+----
++
+In this example, `TestAlert` is the name of the alert that is firing on the cluster and is considered a risk to a cluster update.
+Alerts that are identified as update risks might be changed over time.
+
+. Accept update risks by running the following command:
++
+[source,terminal]
+----
+$ oc adm upgrade recommend --accept <risk_name>
+----
++
+Replace `<risk_name>` with the name of the risk you want to accept.
+You can accept multiple risks at once by separating each risk by a comma, for example `risk1,risk2,risk3`.
++
+.Example command
+[source,terminal]
+----
+$ oc adm upgrade recommend --accept TestAlert
+----
++
+.Example output
+[source,terminal]
+----
+The following conditions found no cause for concern in updating this cluster to later releases: recommended/CriticalAlerts (AsExpected), recommended/NodeAlerts (AsExpected), recommended/PodDisruptionBudgetAlerts (AsExpected), recommended/PodImagePullAlerts (AsExpected)
+
+The following conditions found cause for concern in updating this cluster to later releases, but were explicitly accepted via --accept: recommended/UpdatePrecheckAlerts/TestAlert/0
+
+Upstream update service is unset, so the cluster will use an appropriate default.
+Channel: stable-4.21 (available channels: candidate-4.20, candidate-4.21, candidate-4.22, eus-4.20, fast-4.20, fast-4.21, stable-4.20, stable-4.21)
+
+Updates to 4.21:
+  VERSION     ISSUES
+  4.21.14     no known issues relevant to this cluster
+  4.21.13     no known issues relevant to this cluster
+And 2 older 4.21 updates you can see with '--show-outdated-releases' or '--version VERSION'.
+
+Updates to 4.20:
+  VERSION     ISSUES
+  4.20.20     no known issues relevant to this cluster
+----

--- a/modules/oc-adm-upgrade-recommend.adoc
+++ b/modules/oc-adm-upgrade-recommend.adoc
@@ -14,6 +14,11 @@ When you run the `oc adm upgrade recommend` command, the output displays the fol
 
 You can use the information provided by the output to make informed decisions about the state of your cluster. Examples include whether any critical cluster issues should be addressed before attempting an update, or which specific target version would have less risk for your cluster.
 
+[NOTE]
+====
+The `oc adm upgrade recommend` command is read-only and does not affect the state of the cluster. To request an update, use the `oc adm upgrade` command.
+====
+
 .Prerequisites
 
 * You installed the latest version of {oc-first}.

--- a/updating/preparing_for_updates/updating-cluster-prepare.adoc
+++ b/updating/preparing_for_updates/updating-cluster-prepare.adoc
@@ -40,6 +40,8 @@ include::modules/oc-adm-upgrade-recommend.adoc[leveloffset=+1]
 
 include::modules/oc-adm-upgrade-recommend-custom-alert.adoc[leveloffset=+2]
 
+include::modules/oc-adm-upgrade-recommend-accept.adoc[leveloffset=+2]
+
 // Gateway API management succession
 include::modules/nw-ingress-gateway-api-manage-succession.adoc[leveloffset=+1]
 


### PR DESCRIPTION
[OSDOCS-19786](https://redhat.atlassian.net/browse/OSDOCS-19786)

Version(s): 4.22+

This PR adds docs for using the `--accept` flag with the `oc adm upgrade recommend` command.

QE review:
- [x] QE has approved this change.

Preview: [Accepting risks with the oc adm upgrade recommend command](https://112007--ocpdocs-pr.netlify.app/openshift-enterprise/latest/updating/preparing_for_updates/updating-cluster-prepare.html#oc-adm-upgrade-recommend-accept_updating-cluster-prepare)