### PR TITLE
OCPBUGS-87229,OCPBUGS-87230,OCPBUGS-87231: Fix bare-metal on vSphere node addition docs

### DIFF
--- a/machine_management/user_infra/adding-bare-metal-compute-vsphere-user-infra.adoc
+++ b/machine_management/user_infra/adding-bare-metal-compute-vsphere-user-infra.adoc
@@ -26,7 +26,20 @@ Bare-metal compute machines added to a {vmw-short} cluster are unmanaged by the 
 * You have configured the network for the new bare-metal compute machines, including:
 ** DHCP: Persistent IP addresses and hostname reservations.
 ** DNS: Forward and reverse DNS resolution for the new hostnames.
-* You have obtained the {op-system-first} ISO image that matches your cluster version. You can download this from the *Cluster Details* page on the {hybrid-console} or extract it from the cluster payload.
+* You have obtained the {op-system-first} ISO image that matches your cluster version. You can download this from the *Cluster Details* page on the {hybrid-console} or extract it from the cluster payload by running the following command:
++
+[source,terminal]
+----
+$ oc -n openshift-machine-config-operator get configmap/coreos-bootimages \
+    -o jsonpath='{.data.stream}' | jq -r '.architectures.x86_64.artifacts.metal.formats.iso.disk.location'
+----
+* If the bare-metal node is on a different subnet than the {vmw-short} cluster's machine network, you must add the bare-metal subnet to the cluster's machine networks:
++
+[source,terminal,subs="+quotes"]
+----
+$ oc patch infrastructure/cluster --type=json \
+    -p '[{"op":"add","path":"/spec/platformSpec/vsphere/machineNetworks/-","value":"__<bare-metal-subnet-cidr>__"}]'
+----
 
 [WARNING]
 ====

--- a/machine_management/user_infra/adding-bare-metal-compute-vsphere-user-infra.adoc
+++ b/machine_management/user_infra/adding-bare-metal-compute-vsphere-user-infra.adoc
@@ -26,7 +26,20 @@ Bare-metal compute machines added to a {vmw-short} cluster are unmanaged by the 
 * You have configured the network for the new bare-metal compute machines, including:
 ** DHCP: Persistent IP addresses and hostname reservations.
 ** DNS: Forward and reverse DNS resolution for the new hostnames.
-* You have obtained the {op-system-first} ISO image that matches your cluster version. You can download this from the *Cluster Details* page on the {hybrid-console} or extract it from the cluster payload.
+* You have obtained the {op-system-first} ISO image that matches your cluster version. You can download this from the *Cluster Details* page on the {hybrid-console} or extract it from the cluster payload by running the following command:
++
+[source,terminal]
+----
+$ oc -n openshift-machine-config-operator get configmap/coreos-bootimages \
+    -o jsonpath='{.data.stream}' | jq -r '.architectures.x86_64.artifacts.metal.formats.iso.disk.location'
+----
+* If the bare-metal node is on a different subnet than the {vmw-short} cluster's machine network, you must add the bare metal subnet to the cluster's machine networks:
++
+[source,terminal,subs="+quotes"]
+----
+$ oc patch infrastructure/cluster --type=json \
+    -p '[{"op":"add","path":"/spec/platformSpec/vsphere/machineNetworks/-","value":"__<bare-metal-subnet-cidr>__"}]'
+----
 
 [WARNING]
 ====

--- a/modules/bare-metal-vsphere-iso.adoc
+++ b/modules/bare-metal-vsphere-iso.adoc
@@ -14,7 +14,14 @@ include::snippets/technology-preview.adoc[]
 
 .Prerequisites
 
-* You have access to the {op-system} ISO image that matches your cluster version.
+* You have obtained the {op-system} ISO image that matches your cluster version by running the following command:
++
+[source,terminal]
+----
+$ RHCOS_ISO=$(oc -n openshift-machine-config-operator get configmap/coreos-bootimages -o jsonpath='{.data.stream}' | jq -r '.architectures.x86_64.artifacts.metal.formats.iso.disk.location')
+----
++
+Download the ISO from the URL stored in `$RHCOS_ISO`.
 * You have an HTTP server accessible to the bare-metal machine to host the Ignition config file.
 * You have disabled the {vmw-short} CSI driver.
 * The OpenShift CLI (`oc`) is installed.
@@ -46,7 +53,7 @@ $ curl -I http://<http_server>/worker.ign
 $ sudo coreos-installer install /dev/sda \
     --ignition-url=http://<http_server>/worker.ign \
     --insecure-ignition \
-    --platform=none
+    --platform=metal
 ----
 +
 where:


### PR DESCRIPTION
## Summary

Fixes three issues in the bare-metal nodes on vSphere documentation (Section 9.4), found during OCP 4.22 pre-GA hackathon testing:

- **[OCPBUGS-87229](https://redhat.atlassian.net/browse/OCPBUGS-87229) (Critical):** `--platform=none` is invalid — changed to `--platform=metal`. RHCOS Ignition rejects `none` with: `invalid value "none" for flag -platform: none is not a valid platform`. This makes the documented procedure completely non-functional.
- **[OCPBUGS-87230](https://redhat.atlassian.net/browse/OCPBUGS-87230):** Added command to extract the correct RHCOS ISO URL from the cluster payload (`oc get configmap/coreos-bootimages`). Without this, customers may use a mismatched ISO causing cryptic Ignition failures.
- **[OCPBUGS-87231](https://redhat.atlassian.net/browse/OCPBUGS-87231):** Added prerequisite for adding the bare-metal subnet to `machineNetworks` when the bare-metal node is on a different subnet than the vSphere cluster.

## Files changed

- `modules/bare-metal-vsphere-iso.adoc` — fix `--platform=metal`, add ISO extraction command
- `machine_management/user_infra/adding-bare-metal-compute-vsphere-user-infra.adoc` — add ISO extraction command, add machineNetwork prerequisite

## Test plan

- [x] Tested on OCP 4.22.0-rc.4 vSphere IPI cluster with bare-metal Dell R660 worker node
- [x] Verified `--platform=metal` results in successful node addition
- [x] Verified `--platform=none` causes Ignition failure
- [x] Verified machineNetwork patch required for cross-subnet bare-metal nodes
- [x] Bare-metal node joined cluster as Ready worker with all 34 operators healthy

**Related feature:** [OCPSTRAT-2650](https://redhat.atlassian.net/browse/OCPSTRAT-2650) — [GA] Support Adding Bare Metal Nodes to OpenShift clusters in platform vSphere
