### PR TITLE
OSDOCS-17178: SEC-10: CQA 2.0 - Security Profile Operator

### DIFF
--- a/modules/spo-base-syscalls.adoc
+++ b/modules/spo-base-syscalls.adoc
@@ -6,6 +6,7 @@
 [id="spo-base-syscalls_{context}"]
 = Base syscalls for a container runtime
 
+[role="_abstract"]
 You can use the `baseProfileName` attribute to establish the minimum required `syscalls` for a given runtime to start a container.
 
 .Procedure

--- a/modules/spo-binding-workloads.adoc
+++ b/modules/spo-binding-workloads.adoc
@@ -18,6 +18,7 @@ endif::[]
 [id="spo-binding-workloads_{context}"]
 = Binding workloads to profiles with ProfileBindings
 
+[role="_abstract"]
 You can use the `ProfileBinding` resource to bind a security profile to the `SecurityContext` of a container.
 
 .Procedure
@@ -33,13 +34,17 @@ metadata:
   name: nginx-binding
 spec:
   profileRef:
-    kind: {kind} <1>
-    name: profile <2>
-  image: quay.io/security-profiles-operator/test-nginx-unprivileged:1.21 <3>
+    kind: {kind}
+    name: profile
+  image: quay.io/security-profiles-operator/test-nginx-unprivileged:1.21
 ----
-<1> The `kind:` variable refers to the kind of the profile.
-<2> The `name:` variable refers to the name of the profile.
-<3> You can enable a default security profile by using a wildcard in the image attribute: `image: "*"`
++
+where:
+
+`spec.profileRef.kind`:: Specifies the kind of the profile.
+`spec.profileRef.name`:: Specifies the name of the profile.
+`spec.image`:: Allows you to enable a default security profile by using a wildcard in the image attribute: `image: "*"`
+
 +
 [IMPORTANT]
 ====

--- a/modules/spo-create-seccomp-profile.adoc
+++ b/modules/spo-create-seccomp-profile.adoc
@@ -1,0 +1,37 @@
+// Module included in the following assemblies:
+//
+// * security/security_profiles_operator/spo-seccomp.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="spo-create-seccomp-profile_{context}"]
+= Creating seccomp profiles
+
+[role="_abstract"]
+Use the `SeccompProfile` object to create seccomp profiles.
+
+`SeccompProfile` objects can restrict syscalls within a container, limiting the access of your application.
+
+.Procedure
+
+. Create a project by running the following command:
++
+[source,terminal]
+----
+$ oc new-project my-namespace
+----
+
+. Create the `SeccompProfile` object:
++
+[source,yaml]
+----
+apiVersion: security-profiles-operator.x-k8s.io/v1beta1
+kind: SeccompProfile
+metadata:
+  name: profile1
+spec:
+  defaultAction: SCMP_ACT_LOG
+----
++
+The seccomp profile will be saved in `/var/lib/kubelet/seccomp/operator/<namespace>/<name>.json`.
++
+An `init` container creates the root directory of the Security Profiles Operator to run the Operator without `root` group or user ID privileges. A symbolic link is created from the rootless profile storage `/var/lib/openshift-security-profiles` to the default `seccomp` root path inside of the kubelet root `/var/lib/kubelet/seccomp/operator`.

--- a/modules/spo-create-selinux-profile.adoc
+++ b/modules/spo-create-selinux-profile.adoc
@@ -1,57 +1,15 @@
 // Module included in the following assemblies:
 //
-// * security/security_profiles_operator/spo-seccomp.adoc
 // * security/security_profiles_operator/spo-selinux.adoc
 
-ifeval::["{context}" == "spo-seccomp"]
-:seccomp:
-:type: seccomp
-:kind: SeccompProfile
-endif::[]
-ifeval::["{context}" == "spo-selinux"]
-:selinux:
-:type: SELinux
-:kind: SelinuxProfile
-endif::[]
-
 :_mod-docs-content-type: PROCEDURE
-[id="spo-creating-profiles_{context}"]
-= Creating {type} profiles
+[id="spo-create-selinux-profile_{context}"]
+= Creating SELinux profiles
 
-Use the `{kind}` object to create profiles.
+[role="_abstract"]
+Use the `SelinuxProfile` object to create SELinux profiles.
 
-ifdef::seccomp[]
-
-`{kind}` objects can restrict syscalls within a container, limiting the access of your application.
-
-.Procedure
-
-. Create a project by running the following command:
-+
-[source,terminal]
-----
-$ oc new-project my-namespace
-----
-
-. Create the `{kind}` object:
-+
-[source,yaml,subs="attributes+"]
-----
-apiVersion: security-profiles-operator.x-k8s.io/v1beta1
-kind: {kind}
-metadata:
-  name: profile1
-spec:
-  defaultAction: SCMP_ACT_LOG
-----
-
-The {type} profile will be saved in `/var/lib/kubelet/{type}/operator/<namespace>/<name>.json`.
-
-An `init` container creates the root directory of the Security Profiles Operator to run the Operator without `root` group or user ID privileges. A symbolic link is created from the rootless profile storage `/var/lib/openshift-security-profiles` to the default `seccomp` root path inside of the kubelet root `/var/lib/kubelet/{type}/operator`.
-endif::[]
-
-ifdef::selinux[]
-The `{kind}` object has several features that allow for better security hardening and readability:
+The `SelinuxProfile` object has several features that allow for better security hardening and readability:
 
 * Restricts the profiles to inherit from to the current namespace or a system-wide profile. Because there are typically many profiles installed on the system, but only a subset should be used by cluster workloads, the inheritable system profiles are listed in the `spod` instance in `spec.selinuxOptions.allowedSystemProfiles`.
 * Performs basic validation of the permissions, classes and labels.
@@ -67,12 +25,12 @@ The `{kind}` object has several features that allow for better security hardenin
 $ oc new-project nginx-deploy
 ----
 
-. Create a policy that can be used with a non-privileged workload by creating the following `{kind}` object:
+. Create a policy that can be used with a non-privileged workload by creating the following `SelinuxProfile` object:
 +
-[source,yaml,subs="attributes+"]
+[source,yaml]
 ----
 apiVersion: security-profiles-operator.x-k8s.io/v1alpha2
-kind: {kind}
+kind: SelinuxProfile
 metadata:
   name: nginx-secure
 spec:
@@ -145,15 +103,3 @@ $ semodule -l | grep nginx-secure
 ----
 nginx-secure
 ----
-endif::[]
-
-ifeval::["{context}" == "spo-seccomp"]
-:!seccomp:
-:!type:
-:!kind:
-endif::[]
-ifeval::["{context}" == "spo-selinux"]
-:!selinux:
-:!type:
-:!kind:
-endif::[]

--- a/modules/spo-custom-priority-class.adoc
+++ b/modules/spo-custom-priority-class.adoc
@@ -6,6 +6,7 @@
 [id="spo-custom-priority-class_{context}"]
 = Setting a custom priority class name for the spod daemon pod
 
+[role="_abstract"]
 The default priority class name of the `spod` daemon pod is set to `system-node-critical`. A custom priority class name can be configured in the `spod` configuration by setting a value in the `priorityClassName` field.
 
 .Procedure

--- a/modules/spo-daemon-requirements.adoc
+++ b/modules/spo-daemon-requirements.adoc
@@ -6,8 +6,8 @@
 [id="spo-daemon-requirements_{context}"]
 = Customizing daemon resource requirements
 
-The default resource requirements of the daemon container can be adjusted by using the field `daemonResourceRequirements`
-from the `spod` configuration.
+[role="_abstract"]
+The default resource requirements of the daemon container can be adjusted by using the field `daemonResourceRequirements` from the `spod` configuration.
 
 .Procedure
 

--- a/modules/spo-inspecting-seccomp-profiles.adoc
+++ b/modules/spo-inspecting-seccomp-profiles.adoc
@@ -6,6 +6,7 @@
 [id="spo-inspecting-seccomp-profiles_{context}"]
 = Inspecting seccomp profiles
 
+[role="_abstract"]
 Corrupted `seccomp` profiles can disrupt your workloads. Ensure that the user cannot abuse the system by not allowing other workloads to map any part of the path `/var/lib/kubelet/seccomp/operator`.
 
 .Procedure
@@ -18,8 +19,6 @@ $ oc -n openshift-security-profiles logs openshift-security-profiles-<id>
 ----
 +
 .Example output
-[%collapsible]
-====
 [source,terminal]
 ----
 I1019 19:34:14.942464       1 main.go:90] setup "msg"="starting openshift-security-profiles"  "buildDate"="2020-10-19T19:31:24Z" "compiler"="gc" "gitCommit"="a3ef0e1ea6405092268c18f240b62015c247dd9d" "gitTreeState"="dirty" "goVersion"="go1.15.1" "platform"="linux/amd64" "version"="0.2.0-dev"
@@ -32,7 +31,6 @@ I1019 19:34:15.450757       1 controller.go:176] controller "msg"="Starting work
 I1019 19:34:15.453102       1 profile.go:148] profile "msg"="Reconciled profile from SeccompProfile" "namespace"="openshift-security-profiles" "profile"="nginx-1.19.1" "name"="nginx-1.19.1" "resource version"="728"
 I1019 19:34:15.453618       1 profile.go:148] profile "msg"="Reconciled profile from SeccompProfile" "namespace"="openshift-security-profiles" "profile"="openshift-security-profiles" "name"="openshift-security-profiles" "resource version"="729"
 ----
-====
 
 . Confirm that the `seccomp` profiles are saved into the correct path by running the following command:
 +

--- a/modules/spo-installing-cli.adoc
+++ b/modules/spo-installing-cli.adoc
@@ -6,6 +6,10 @@
 [id="spo-installing-cli_{context}"]
 = Installing the Security Profiles Operator using the CLI
 
+[role="_abstract"]
+You can install the {product-title} Security Profiles Operator by using the command line interface. 
+
+
 .Prerequisites
 
 * You must have `cluster-admin` privileges.
@@ -75,7 +79,7 @@ spec:
 ----
 $ oc create -f subscription-object.yaml
 ----
-
++
 [NOTE]
 ====
 If you are setting the global scheduler feature and enable `defaultNodeSelector`, you must create the namespace manually and update the annotations of the `openshift-security-profiles` namespace, or the namespace where the Security Profiles Operator was installed, with `openshift.io/node-selector: “”`. This removes the default node selector and prevents deployment failures.

--- a/modules/spo-installing.adoc
+++ b/modules/spo-installing.adoc
@@ -6,6 +6,9 @@
 [id="spo-installing_{context}"]
 = Installing the Security Profiles Operator
 
+[role="_abstract"]
+You can use the {product-title} web console to install the Security Profiles Operator. This installs the Security Profiles Operator into the `openshift-security-profiles` namespace by default. You can also verify correct installation by using the {product-title} web console.
+
 .Prerequisites
 
 * You must have access to the web console as a user with `cluster-admin` privileges.

--- a/modules/spo-log-enricher-app-trace.adoc
+++ b/modules/spo-log-enricher-app-trace.adoc
@@ -6,6 +6,7 @@
 [id="spo-log-enricher-app-trace_{context}"]
 = Using the log enricher to trace an application
 
+[role="_abstract"]
 You can use the Security Profiles Operator log enricher to trace an application.
 
 .Procedure
@@ -54,8 +55,7 @@ $ oc -n openshift-security-profiles logs -f ds/spod log-enricher
 ----
 +
 .Example output
-[%collapsible]
-====
+
 [source,terminal]
 ----
 …
@@ -72,4 +72,3 @@ I0623 12:59:20.454127 1854764 enricher.go:111] log-enricher "msg"="audit"  "cont
 I0623 12:59:20.458654 1854764 enricher.go:111] log-enricher "msg"="audit"  "container"="log-container" "executable"="/usr/sbin/nginx" "namespace"="default" "node"="127.0.0.1" "pid"=1905792 "pod"="log-pod" "syscallID"=257 "syscallName"="openat" "timestamp"="1624453150.235:2879" "type"="seccomp"
 …
 ----
-====

--- a/modules/spo-logging-verbosity.adoc
+++ b/modules/spo-logging-verbosity.adoc
@@ -6,7 +6,8 @@
 [id="logging-verbosity_{context}"]
 = Configuring logging verbosity
 
-The Security Profiles Operator supports the default logging verbosity of `0` and an enhanced verbosity of `1`.
+[role="_abstract"]
+The Security Profiles Operator supports the default logging verbosity of `0` and an enhanced verbosity of `1`. 
 
 .Procedure
 

--- a/modules/spo-memory-optimzation.adoc
+++ b/modules/spo-memory-optimzation.adoc
@@ -6,6 +6,7 @@
 [id="spo-memory-optimization_{context}"]
 = Enabling memory optimization in the spod daemon
 
+[role="_abstract"]
 The controller running inside of `spod` daemon process watches all pods available in the cluster when profile recording is enabled. This can lead to very high memory usage in large clusters, resulting in the `spod` daemon running out of memory or crashing.
 
 To prevent crashes, the `spod` daemon can be configured to only load the pods labeled for profile recording into the cache memory.

--- a/modules/spo-replicating-controllers.adoc
+++ b/modules/spo-replicating-controllers.adoc
@@ -6,7 +6,10 @@
 [id="spo-replicating-controllers_{context}"]
 = Replicating controllers and SecurityContextConstraints
 
-When you deploy SELinux policies for replicating controllers, such as deployments or daemon sets, note that the `Pod` objects spawned by the controllers are not running with the identity of the user who creates the workload. Unless a `ServiceAccount` is selected, the pods might revert to using a restricted `SecurityContextConstraints` (SCC) which does not allow use of custom security policies.
+[role="_abstract"]
+You can deploy SELinux policies for replicating controllers, such as deployments or daemon sets. 
+
+Note that the `Pod` objects spawned by the controllers are not running with the identity of the user who creates the workload. Unless a `ServiceAccount` is selected, the pods might revert to using a restricted `SecurityContextConstraints` (SCC) which does not allow use of custom security policies.
 
 .Procedure
 
@@ -93,18 +96,19 @@ spec:
       serviceAccountName: spo-deploy-test
       securityContext:
         seLinuxOptions:
-          type: nginx-secure.process <1>
+          type: nginx-secure.process
       containers:
       - name: nginx-unpriv
         image: quay.io/security-profiles-operator/test-nginx-unprivileged:1.21
         ports:
         - containerPort: 8080
 ----
-<1> The `.seLinuxOptions.type` must exist before the Deployment is created.
++
+The `spec.template.spec.securityContext.seLinuxOptions.type` must exist before the Deployment is created.
 +
 [NOTE]
 ====
 The SELinux type is not specified in the workload and is handled by the SCC. When the pods are created by the deployment and the `ReplicaSet`, the pods will run with the appropriate profile.
 ====
-
++
 Ensure that your SCC is usable by only the correct service account. Refer to _Additional resources_ for more information.

--- a/modules/spo-restrict-syscalls.adoc
+++ b/modules/spo-restrict-syscalls.adoc
@@ -6,7 +6,15 @@
 [id="spo-restrict-syscalls_{context}"]
 = Restrict the allowed syscalls in seccomp profiles
 
+[role="_abstract"]
 The Security Profiles Operator does not restrict `syscalls` in `seccomp` profiles by default. You can define the list of allowed `syscalls` in the `spod` configuration.
+
+[IMPORTANT]
+====
+The Operator will install only the `seccomp` profiles, which have a subset of `syscalls` defined into the allowed list. All profiles not complying with this ruleset are rejected.
+
+When the list of allowed `syscalls` is modified in the `spod` configuration, the Operator will identify the already installed profiles which are noncompliant and remove them automatically.
+====
 
 .Procedure
 
@@ -17,10 +25,3 @@ The Security Profiles Operator does not restrict `syscalls` in `seccomp` profile
 $ oc -n openshift-security-profiles patch spod spod --type merge \
     -p '{"spec":{"allowedSyscalls": ["exit", "exit_group", "futex", "nanosleep"]}}'
 ----
-
-[IMPORTANT]
-====
-The Operator will install only the `seccomp` profiles, which have a subset of `syscalls` defined into the allowed list. All profiles not complying with this ruleset are rejected.
-
-When the list of allowed `syscalls` is modified in the `spod` configuration, the Operator will identify the already installed profiles which are non-compliant and remove them automatically.
-====

--- a/modules/spo-runtime-metrics.adoc
+++ b/modules/spo-runtime-metrics.adoc
@@ -6,6 +6,7 @@
 [id="spo-runtime-metrics_{context}"]
 = controller-runtime metrics
 
+[role="_abstract"]
 The controller-runtime `metrics` and the DaemonSet endpoint `metrics-spod` provide a set of default metrics. Additional metrics are provided by the daemon, which are always prefixed with `security_profiles_operator_`.
 
 .Available controller-runtime metrics
@@ -28,13 +29,13 @@ The controller-runtime `metrics` and the DaemonSet endpoint `metrics-spod` provi
 | Amount of seccomp profile bpf operations. Requires the bpf recorder to be enabled.
 
 | `seccomp_profile_error_total`
-| `reason={` +
-`SeccompNotSupportedOnNode,` +
-`InvalidSeccompProfile,` +
-`CannotSaveSeccompProfile,` +
-`CannotRemoveSeccompProfile,` +
-`CannotUpdateSeccompProfile,` +
-`CannotUpdateNodeStatus` +
+| `reason={`
+`SeccompNotSupportedOnNode,`
+`InvalidSeccompProfile,`
+`CannotSaveSeccompProfile,`
+`CannotRemoveSeccompProfile,`
+`CannotUpdateSeccompProfile,`
+`CannotUpdateNodeStatus`
 `}`
 | Counter
 | Amount of seccomp profile errors.
@@ -50,13 +51,13 @@ The controller-runtime `metrics` and the DaemonSet endpoint `metrics-spod` provi
 | Amount of SELinux profile audit operations. Requires the log enricher to be enabled.
 
 | `selinux_profile_error_total`
-| `reason={` +
-`CannotSaveSelinuxPolicy,` +
-`CannotUpdatePolicyStatus,` +
-`CannotRemoveSelinuxPolicy,` +
-`CannotContactSelinuxd,` +
-`CannotWritePolicyFile,` +
-`CannotGetPolicyStatus` +
+| `reason={`
+`CannotSaveSelinuxPolicy,`
+`CannotUpdatePolicyStatus,`
+`CannotRemoveSelinuxPolicy,`
+`CannotContactSelinuxd,`
+`CannotWritePolicyFile,`
+`CannotGetPolicyStatus`
 `}`
 | Counter
 | Amount of SELinux profile errors.

--- a/modules/spo-using-metrics.adoc
+++ b/modules/spo-using-metrics.adoc
@@ -6,7 +6,8 @@
 [id="spo-using-metrics_{context}"]
 = Using metrics
 
-The `openshift-security-profiles` namespace provides metrics endpoints, which are secured by the link:https://github.com/brancz/kube-rbac-proxy[kube-rbac-proxy] container. All metrics are exposed by the `metrics` service within the `openshift-security-profiles` namespace.
+[role="_abstract"]
+The `openshift-security-profiles` namespace provides metrics endpoints, which are secured by the `kube-rbac-proxy` container. All metrics are exposed by the `metrics` service within the `openshift-security-profiles` namespace.
 
 The Security Profiles Operator includes a cluster role and corresponding binding `spo-metrics-client` to retrieve the metrics from within the cluster. There are two metrics paths available:
 

--- a/security/security_profiles_operator/spo-advanced.adoc
+++ b/security/security_profiles_operator/spo-advanced.adoc
@@ -6,7 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-Use advanced tasks to enable metrics, configure webhooks, or restrict syscalls.
+[role="_abstract"]
+You can use advanced Security Profiles Operator tasks to enable metrics, configure webhooks, or restrict syscalls.
 
 include::modules/spo-restrict-syscalls.adoc[leveloffset=+1]
 

--- a/security/security_profiles_operator/spo-enabling.adoc
+++ b/security/security_profiles_operator/spo-enabling.adoc
@@ -6,6 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 Before you can use the Security Profiles Operator, you must ensure the Operator is deployed in the cluster.
 
 [IMPORTANT]

--- a/security/security_profiles_operator/spo-seccomp.adoc
+++ b/security/security_profiles_operator/spo-seccomp.adoc
@@ -6,6 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 Create and manage seccomp profiles and bind them to workloads.
 
 [IMPORTANT]
@@ -13,7 +14,7 @@ Create and manage seccomp profiles and bind them to workloads.
 The Security Profiles Operator supports only Red Hat Enterprise Linux CoreOS (RHCOS) worker nodes. Red Hat Enterprise Linux (RHEL) nodes are not supported.
 ====
 
-include::modules/spo-creating-profiles.adoc[leveloffset=+1]
+include::modules/spo-create-seccomp-profile.adoc[leveloffset=+1]
 
 include::modules/spo-applying-profiles.adoc[leveloffset=+1]
 
@@ -28,7 +29,7 @@ include::modules/spo-container-profile-instances.adoc[leveloffset=+2]
 [id="additional-resources_spo-seccomp"]
 == Additional resources
 
-* xref:../../authentication/managing-security-context-constraints.adoc[Managing security context constraints]
+* xref:../../authentication/managing-security-context-constraints.adoc#managing-pod-security-policies[Managing security context constraints]
 * link:https://cloud.redhat.com/blog/managing-sccs-in-openshift[Managing SCCs in OpenShift]
 * xref:../../security/security_profiles_operator/spo-advanced.adoc#spo-log-enricher_spo-advanced[Using the log enricher]
 * xref:../../security/security_profiles_operator/spo-understanding.adoc#spo-about_spo-understanding[About security profiles]

--- a/security/security_profiles_operator/spo-selinux.adoc
+++ b/security/security_profiles_operator/spo-selinux.adoc
@@ -6,6 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 Create and manage SELinux profiles and bind them to workloads.
 
 [IMPORTANT]
@@ -13,7 +14,7 @@ Create and manage SELinux profiles and bind them to workloads.
 The Security Profiles Operator supports only Red Hat Enterprise Linux CoreOS (RHCOS) worker nodes. Red Hat Enterprise Linux (RHEL) nodes are not supported.
 ====
 
-include::modules/spo-creating-profiles.adoc[leveloffset=+1]
+include::modules/spo-create-selinux-profile.adoc[leveloffset=+1]
 
 include::modules/spo-applying-profiles.adoc[leveloffset=+1]
 
@@ -34,7 +35,7 @@ include::modules/spo-selinux-runasany.adoc[leveloffset=+2]
 [id="additional-resources_spo-selinux"]
 == Additional resources
 
-* xref:../../authentication/managing-security-context-constraints.adoc[Managing security context constraints]
+* xref:../../authentication/managing-security-context-constraints.adoc#managing-pod-security-policies[Managing security context constraints]
 * link:https://cloud.redhat.com/blog/managing-sccs-in-openshift[Managing SCCs in OpenShift]
 * xref:../../security/security_profiles_operator/spo-advanced.adoc#spo-log-enricher_spo-advanced[Using the log enricher]
 * xref:../../security/security_profiles_operator/spo-understanding.adoc#spo-about_spo-understanding[About security profiles]

--- a/security/security_profiles_operator/spo-support.adoc
+++ b/security/security_profiles_operator/spo-support.adoc
@@ -7,18 +7,16 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-[id="spo-lifecycle_{context}"]
-== Security Profiles Operator lifecycle
-
-The Security Profiles Operator is a "Rolling Stream" Operator, meaning updates are available asynchronously of {product-title} releases. For more information, see link:https://access.redhat.com/support/policy/updates/openshift_operators[OpenShift Operator Life Cycles] on the Red Hat Customer Portal.
+[role="_abstract"]
+The Security Profiles Operator is a "Rolling Stream" Operator, meaning updates are available asynchronously of {product-title} releases.
 
 include::modules/support.adoc[leveloffset=+1]
 
 //If we ever add a must-gather for SPO:
 //include modules/spo-must-gather.adoc[leveloffset=+1]
 
-//[role="_additional-resources"]
-//[id="additional-resources_{context}"]
-//== Additional resources
-//
-//* xref:../../support/gathering-cluster-data.adoc#about-must-gather_gathering-cluster-data[About the must-gather tool]
+[role="_additional-resources"]
+[id="additional-resources_{context}"]
+== Additional resources
+
+* link:https://access.redhat.com/support/policy/updates/openshift_operators[OpenShift Operator Life Cycles on the Red Hat Customer Portal]

--- a/security/security_profiles_operator/spo-troubleshooting.adoc
+++ b/security/security_profiles_operator/spo-troubleshooting.adoc
@@ -6,6 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 Troubleshoot the Security Profiles Operator to diagnose a problem or provide information in a bug report.
 
 include::modules/spo-inspecting-seccomp-profiles.adoc[leveloffset=+1]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.20+ This is a new PR, correctly opened against MAIN. It is a duplicate of an incorrectly-opened PR, https://github.com/openshift/openshift-docs/pull/106260 .  That PR is now closed and superceded by this one.

<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OSDOCS-17178
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs previews:
https://112027--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/security_profiles_operator/spo-advanced.html
https://112027--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/security_profiles_operator/spo-enabling.html
https://112027--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/security_profiles_operator/spo-seccomp.html
https://112027--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/security_profiles_operator/spo-selinux.html
https://112027--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/security_profiles_operator/spo-support.html
https://112027--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/security_profiles_operator/spo-troubleshooting.html

<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review: None needed, no new technical content.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: This PR turns out to be a :size-L: but that is because github counts the creation of modules from the release note assembly as entirely new text. There has been no new information added, the text that makes up the modules comes from the main assembly, excepting for the new module created to avoid the two ".Procedure" blocks in one module. 

This PR only adds needed DITA information and changes to deal with the one conditional. No new content is added, therefore QE review has not been requested. 

<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
