### PR TITLE
[enterprise-4.21] OSDOCS-19771: CQA FIO Release Note Modularization

### DIFF
--- a/modules/fio-rn-0-1-21.adoc
+++ b/modules/fio-rn-0-1-21.adoc
@@ -1,0 +1,35 @@
+// Module included in the following assemblies:
+//
+// * security/file_integrity_operator/file-integrity-operator-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="file-integrity-operator-release-notes-0-1-21_{context}"]
+= Release notes for OpenShift File Integrity Operator 0.1.21
+
+[role="_abstract"]
+Release notes for OpenShift File Integrity Operator 0.1.21.
+
+
+The following Red Hat Bug Fix Advisory (RHBA) is available for the OpenShift File Integrity Operator 0.1.21:
+
+* link:https://access.redhat.com/errata/RHBA-2021:4631[RHBA-2021:4631 OpenShift File Integrity Operator Bug Fix and Enhancement Update]
+
+[id="file-integrity-operator-0-1-21-new-features-and-enhancements_{context}"]
+== New features and enhancements
+
+* The metrics related to `FileIntegrity` scan results and processing metrics are displayed on the monitoring dashboard on the web console. The results are labeled with the prefix of `file_integrity_operator_`.
++
+* If a node has an integrity failure for more than 1 second, the default `PrometheusRule` provided in the operator namespace alerts with a warning.
++
+* The following dynamic Machine Config Operator and Cluster Version Operator related filepaths are excluded from the default AIDE policy to help prevent false positives during node updates:
+ - /etc/machine-config-daemon/currentconfig
+ - /etc/pki/ca-trust/extracted/java/cacerts
+ - /etc/cvo/updatepayloads
+ - /root/.kube
++
+* The AIDE daemon process has stability improvements over v0.1.16, and is more resilient to errors that might occur when the AIDE database is initialized.
+
+[id="openshift-file-integrity-operator-0-1-21-bug-fixes_{context}"]
+== Bug fixes
+
+* Before this update, when the Operator automatically upgraded, outdated daemon sets were not removed. With this release, outdated daemon sets are removed during the automatic upgrade.

--- a/modules/fio-rn-0-1-22.adoc
+++ b/modules/fio-rn-0-1-22.adoc
@@ -1,0 +1,21 @@
+// Module included in the following assemblies:
+//
+// * security/file_integrity_operator/file-integrity-operator-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="file-integrity-operator-release-notes-0-1-22_{context}"]
+= Release notes for OpenShift File Integrity Operator 0.1.22
+
+[role="_abstract"]
+Release notes for OpenShift File Integrity Operator 0.1.22.
+
+
+The following Red Hat Bug Fix Advisory (RHBA) is available for the OpenShift File Integrity Operator 0.1.22:
+
+* link:https://access.redhat.com/errata/RHBA-2022:0142[RHBA-2022:0142 OpenShift File Integrity Operator Bug Fix]
+
+[id="openshift-file-integrity-operator-0-1-22-bug-fixes_{context}"]
+== Bug fixes
+
+* Before this update, a system with a File Integrity Operator installed might interrupt the {product-title} update, due to the  `/etc/kubernetes/aide.reinit` file. This occurred if the `/etc/kubernetes/aide.reinit` file was present, but later removed before the `ostree` validation. With this update, `/etc/kubernetes/aide.reinit` is moved to the `/run` directory so that it does not conflict with the {product-title} update. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2033311[*BZ#2033311*])
+

--- a/modules/fio-rn-0-1-24.adoc
+++ b/modules/fio-rn-0-1-24.adoc
@@ -1,0 +1,28 @@
+// Module included in the following assemblies:
+//
+// * security/file_integrity_operator/file-integrity-operator-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="file-integrity-operator-release-notes-0-1-24_{context}"]
+= Release notes for OpenShift File Integrity Operator 0.1.24
+
+[role="_abstract"]
+Release notes for OpenShift File Integrity Operator 0.1.24.
+
+
+The following Red Hat Bug Fix Advisory (RHBA) is available for the OpenShift File Integrity Operator 0.1.24:
+
+* link:https://access.redhat.com/errata/RHBA-2022:1331[RHBA-2022:1331 OpenShift File Integrity Operator Bug Fix]
+
+[id="file-integrity-operator-0-1-24-new-features-and-enhancements_{context}"]
+== New features and enhancements
+
+* You can now configure the maximum number of backups stored in the `FileIntegrity` Custom Resource (CR) with the `config.maxBackups` attribute. This attribute specifies the number of AIDE database and log backups left over from the `re-init` process to keep on the node. Older backups beyond the configured number are automatically pruned. The default is set to five backups.
+
+[id="openshift-file-integrity-operator-0-1-24-bug-fixes_{context}"]
+== Bug fixes
+
+* Before this update, upgrading the Operator from versions older than 0.1.21 to 0.1.22 could cause the `re-init` feature to fail. This was a result of the Operator failing to update `configMap` resource labels. Now, upgrading to the latest version fixes the resource labels. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2049206[*BZ#2049206*])
+
+* Before this update, when enforcing the default `configMap` script contents, the wrong data keys were compared. This resulted in the `aide-reinit` script not being updated properly after an Operator upgrade, and caused the `re-init` process to fail. Now,`daemonSets` run to completion and the AIDE database `re-init` process executes successfully. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2072058[*BZ#2072058*])
+

--- a/modules/fio-rn-0-1-30.adoc
+++ b/modules/fio-rn-0-1-30.adoc
@@ -1,0 +1,29 @@
+// Module included in the following assemblies:
+//
+// * security/file_integrity_operator/file-integrity-operator-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="file-integrity-operator-release-notes-0-1-30_{context}"]
+= Release notes for OpenShift File Integrity Operator 0.1.30
+
+[role="_abstract"]
+Release notes for OpenShift File Integrity Operator 0.1.30.
+
+
+The following Red Hat Bug Fix Advisory (RHBA) is available for the OpenShift File Integrity Operator 0.1.30:
+
+* link:https://access.redhat.com/errata/RHBA-2022:5538[RHBA-2022:5538 OpenShift File Integrity Operator Bug Fix and Enhancement Update]
+
+[id="file-integrity-operator-0-1-30-new-features-and-enhancements_{context}"]
+== New features and enhancements
+
+* The File Integrity Operator is now supported on the following architectures:
++
+** {ibm-power-name}
+** {ibm-z-name} and {ibm-linuxone-name}
+
+[id="file-integrity-operator-0-1-30-bug-fixes_{context}"]
+== Bug fixes
+
+* Before this update, alerts issued by the File Integrity Operator did not set a namespace, making it difficult to understand where the alert originated. Now, the Operator sets the appropriate namespace, increasing understanding of the alert. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2101393[*BZ#2101393*])
+

--- a/modules/fio-rn-0-1-32.adoc
+++ b/modules/fio-rn-0-1-32.adoc
@@ -1,0 +1,23 @@
+// Module included in the following assemblies:
+//
+// * security/file_integrity_operator/file-integrity-operator-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="file-integrity-operator-release-notes-0-1-32_{context}"]
+= Release notes for OpenShift File Integrity Operator 0.1.32
+
+[role="_abstract"]
+Release notes for OpenShift File Integrity Operator 0.1.32.
+
+
+The following Red Hat Bug Fix Advisory (RHBA) is available for the OpenShift File Integrity Operator 0.1.32:
+
+* link:https://access.redhat.com/errata/RHBA-2022:7095[RHBA-2022:7095 OpenShift File Integrity Operator Bug Fix Update]
+
+[id="file-integrity-operator-0-1-32-bug-fixes_{context}"]
+== Bug fixes
+
+* Before this update, alerts issued by the File Integrity Operator did not set a namespace, making it difficult to understand from which namespace the alert originated. Now, the Operator sets the appropriate namespace, providing more information about the alert. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2112394[*BZ#2112394*])
+
+* Before this update, The File Integrity Operator did not update the metrics service on Operator startup, causing the metrics targets to be unreachable. With this release, the File Integrity Operator now ensures the metrics service is updated on Operator startup. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2115821[*BZ#2115821*])
+

--- a/modules/fio-rn-1-0-0.adoc
+++ b/modules/fio-rn-1-0-0.adoc
@@ -1,0 +1,16 @@
+// Module included in the following assemblies:
+//
+// * security/file_integrity_operator/file-integrity-operator-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="file-integrity-operator-release-notes-1-0-0_{context}"]
+= Release notes for OpenShift File Integrity Operator 1.0.0
+
+[role="_abstract"]
+Release notes for OpenShift File Integrity Operator 1.0.0.
+
+
+The following Red Hat Bug Fix Advisory (RHBA) is available for the OpenShift File Integrity Operator 1.0.0:
+
+* link:https://access.redhat.com/errata/RHBA-2023:0037[RHBA-2023:0037 OpenShift File Integrity Operator Bug Fix Update]
+

--- a/modules/fio-rn-1-2-0.adoc
+++ b/modules/fio-rn-1-2-0.adoc
@@ -1,0 +1,23 @@
+// Module included in the following assemblies:
+//
+// * security/file_integrity_operator/file-integrity-operator-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="file-integrity-operator-release-notes-1-2-0_{context}"]
+= Release notes for OpenShift File Integrity Operator 1.2.0
+
+[role="_abstract"]
+Release notes for OpenShift File Integrity Operator 1.2.0.
+
+
+The following Red Hat Bug Fix Advisory (RHBA) is available for the OpenShift File Integrity Operator 1.2.0:
+
+* link:https://access.redhat.com/errata/RHBA-2023:1273[RHBA-2023:1273 OpenShift File Integrity Operator Enhancement Update]
+
+[id="file-integrity-operator-1-2-0-new-features-and-enhancements_{context}"]
+== New features and enhancements
+
+* The File Integrity Operator Custom Resource (CR) now contains an `initialDelay` feature that specifies the number of seconds to wait before starting the first AIDE integrity check. For more information, see xref:../../security/file_integrity_operator/file-integrity-operator-understanding.adoc#understanding-file-integrity-custom-resource_file-integrity-operator[Creating the FileIntegrity custom resource].
+
+* The File Integrity Operator is now stable and the release channel is upgraded to `stable`. Future releases will follow link:https://semver.org/[Semantic Versioning]. To access the latest release, see xref:../../security/file_integrity_operator/file-integrity-operator-updating.adoc#olm-preparing-upgrade_file-integrity-operator-updating[Updating the File Integrity Operator].
+

--- a/modules/fio-rn-1-2-1.adoc
+++ b/modules/fio-rn-1-2-1.adoc
@@ -1,0 +1,18 @@
+// Module included in the following assemblies:
+//
+// * security/file_integrity_operator/file-integrity-operator-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="file-integrity-operator-release-notes-1-2-1_{context}"]
+= Release notes for OpenShift File Integrity Operator 1.2.1
+
+[role="_abstract"]
+Release notes for OpenShift File Integrity Operator 1.2.1.
+
+
+The following Red Hat Bug Fix Advisory (RHBA) is available for the OpenShift File Integrity Operator 1.2.1:
+
+* link:https://access.redhat.com/errata/RHBA-2023:1684[RHBA-2023:1684 OpenShift File Integrity Operator Bug Fix Update]
+
+* This release includes updated container dependencies.
+

--- a/modules/fio-rn-1-3-1.adoc
+++ b/modules/fio-rn-1-3-1.adoc
@@ -1,0 +1,37 @@
+// Module included in the following assemblies:
+//
+// * security/file_integrity_operator/file-integrity-operator-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="file-integrity-operator-release-notes-1-3-1_{context}"]
+= Release notes for OpenShift File Integrity Operator 1.3.1
+
+[role="_abstract"]
+Release notes for OpenShift File Integrity Operator 1.3.1.
+
+
+The following Red Hat Bug Fix Advisory (RHBA) is available for the OpenShift File Integrity Operator 1.3.1:
+
+* link:https://access.redhat.com/errata/RHBA-2023:3600[RHBA-2023:3600 OpenShift File Integrity Operator Bug Fix Update]
+
+[id="file-integrity-operator-1-3-1-new-features-and-enhancements_{context}"]
+== New features and enhancements
+
+* FIO now includes kubelet certificates as default files, excluding them from issuing warnings when they're managed by {product-title}. (link:https://issues.redhat.com/browse/OCPBUGS-14348[*OCPBUGS-14348*])
+
+* FIO now correctly directs email to the address for Red Hat Technical Support. (link:https://issues.redhat.com/browse/OCPBUGS-5023[*OCPBUGS-5023*])
+
+[id="file-integrity-operator-1-3-1-bug-fixes_{context}"]
+== Bug fixes
+
+* Before this update, the File Integrity Operator (FIO) would not clean up `FileIntegrityNodeStatus` CRDs when nodes are removed from the cluster. FIO now correctly cleans up node status CRDs on node removal.  (link:https://issues.redhat.com/browse/OCPBUGS-4321[*OCPBUGS-4321*])
+
+* Before this update, FIO would also erroneously indicate that new nodes failed integrity checks. FIO now correctly shows node status CRDs when adding new nodes to the cluster. This provides correct node status notifications. (link:https://issues.redhat.com/browse/OCPBUGS-8502[*OCPBUGS-8502*])
+
+* Before this update, when FIO was reconciling `FileIntegrity` CRDs, it would pause scanning until the reconciliation was done. This caused an overly aggressive re-initiatization process on nodes not impacted by the reconciliation. This problem also resulted in unnecessary daemonsets for machine config pools which are unrelated to the `FileIntegrity` being changed. FIO correctly handles these cases and only pauses AIDE scanning for nodes that are affected by file integrity changes. (link:https://issues.redhat.com/browse/CMP-1097[*CMP-1097*])
+
+[id="file-integrity-operator-1-3-1-known-issues_{context}"]
+== Known Issues
+
+In FIO 1.3.1, increasing nodes in {ibm-z-name} clusters might result in `Failed` File Integrity node status. For more information, see link:https://access.redhat.com/solutions/7028861[Adding nodes in {ibm-power-name} clusters can result in failed File Integrity node status].
+

--- a/modules/fio-rn-1-3-2.adoc
+++ b/modules/fio-rn-1-3-2.adoc
@@ -1,0 +1,18 @@
+// Module included in the following assemblies:
+//
+// * security/file_integrity_operator/file-integrity-operator-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="file-integrity-operator-release-notes-1-3-2_{context}"]
+= Release notes for OpenShift File Integrity Operator 1.3.2
+
+[role="_abstract"]
+Release notes for OpenShift File Integrity Operator 1.3.2.
+
+
+The following Red Hat Bug Fix Advisory (RHBA) is available for the OpenShift File Integrity Operator 1.3.2:
+
+* link:https://access.redhat.com/errata/RHBA-2023:5107[RHBA-2023:5107 OpenShift File Integrity Operator Bug Fix Update]
+
+This update addresses a CVE in an underlying dependency.
+

--- a/modules/fio-rn-1-3-3.adoc
+++ b/modules/fio-rn-1-3-3.adoc
@@ -1,0 +1,35 @@
+// Module included in the following assemblies:
+//
+// * security/file_integrity_operator/file-integrity-operator-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="file-integrity-operator-release-notes-1-3-3_{context}"]
+= Release notes for OpenShift File Integrity Operator 1.3.3
+
+[role="_abstract"]
+Release notes for OpenShift File Integrity Operator 1.3.3.
+
+
+The following Red Hat Bug Fix Advisory (RHBA) is available for the OpenShift File Integrity Operator 1.3.3:
+
+* link:https://access.redhat.com/errata/RHBA-2023:5652[RHBA-2023:5652 OpenShift File Integrity Operator Bug Fix and Enhancement Update]
+
+This update addresses a CVE in an underlying dependency.
+
+[id="file-integrity-operator-1-3-3-new-features-and-enhancements_{context}"]
+== New features and enhancements
+
+* You can install and use the File Integrity Operator in an {product-title} cluster running in FIPS mode.
++
+--
+include::snippets/fips-snippet.adoc[]
+
+--
+
+[id="file-integrity-operator-1-3-3-bug-fixes_{context}"]
+== Bug fixes
+
+* Before this update, some FIO pods with private default mount propagation in combination with `hostPath: path: /` volume mounts would break the CSI driver relying on multipath. This problem has been fixed and the CSI driver works correctly. (link:https://access.redhat.com/solutions/7017081[Some OpenShift Operator pods blocking unmounting of CSI volumes when multipath is in use])
+
+* This update resolves CVE-2023-39325. (link:https://access.redhat.com/security/cve/CVE-2023-39325[*CVE-2023-39325*])
+

--- a/modules/fio-rn-1-3-4.adoc
+++ b/modules/fio-rn-1-3-4.adoc
@@ -1,0 +1,21 @@
+// Module included in the following assemblies:
+//
+// * security/file_integrity_operator/file-integrity-operator-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="file-integrity-operator-release-notes-1-3-4_{context}"]
+= Release notes for OpenShift File Integrity Operator 1.3.4
+
+[role="_abstract"]
+Release notes for OpenShift File Integrity Operator 1.3.4.
+
+
+The following Red Hat Bug Fix Advisory (RHBA) is available for the OpenShift File Integrity Operator 1.3.4:
+
+* link:https://access.redhat.com/errata/RHBA-2024:2946[RHBA-2024:2946 OpenShift File Integrity Operator Bug Fix and Enhancement Update]
+
+[id="file-integrity-operator-1-3-4-bug-fixes_{context}"]
+== Bug fixes
+
+* Before this update, File Integrity Operator would issue a `NodeHasIntegrityFailure` alert due to multus certificate rotation. With this release, the alert and failing status are now correctly triggered. (link:https://issues.redhat.com/browse/OCPBUGS-31257[*OCPBUGS-31257*])
+

--- a/modules/fio-rn-1-3-5.adoc
+++ b/modules/fio-rn-1-3-5.adoc
@@ -1,0 +1,18 @@
+// Module included in the following assemblies:
+//
+// * security/file_integrity_operator/file-integrity-operator-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="file-integrity-operator-release-notes-1-3-5_{context}"]
+= Release notes for OpenShift File Integrity Operator 1.3.5
+
+[role="_abstract"]
+Release notes for OpenShift File Integrity Operator 1.3.5.
+
+
+The following Red Hat Bug Fix Advisory (RHBA) is available for the OpenShift File Integrity Operator 1.3.5:
+
+* link:https://access.redhat.com/errata/RHBA-2024:10366[RHBA-2024:10366 OpenShift File Integrity Operator Update]
+
+This update includes upgraded dependencies in underlying base images.
+

--- a/modules/fio-rn-1-3-6.adoc
+++ b/modules/fio-rn-1-3-6.adoc
@@ -1,0 +1,29 @@
+// Module included in the following assemblies:
+//
+// * security/file_integrity_operator/file-integrity-operator-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="file-integrity-operator-release-notes-1-3-6_{context}"]
+= Release notes for OpenShift File Integrity Operator 1.3.6
+
+[role="_abstract"]
+Release notes for OpenShift File Integrity Operator 1.3.6.
+
+
+The following Red Hat Bug Fix Advisory (RHBA) is available for the OpenShift File Integrity Operator 1.3.6:
+
+* link:https://access.redhat.com/errata/RHBA-2025:11535[RHBA-2025:11535 OpenShift File Integrity Operator Bug Fix Update]
+
+[id="file-integrity-operator-1-3-6-bug-fixes_{context}"]
+== Bug fixes
+
+* Before this update, running the `oc annotate fileintegrities/<fileintegrity-name> file-integrity.openshift.io/re-init-on-failed=` command would trigger a reinitialization on all nodes. Now, it only reinitializes the nodes where failures occurred. (link:https://issues.redhat.com/browse/OCPBUGS-18933[*OCPBUGS-18933*])
+
+* Before this update, resetting FIO cleared the `NodeHasIntegrityFailure` alert. This occurred because the `metric file_integrity_operator_node_failed` setting was also reset. With this release, restarting FIO does not affect the `NodeHasIntegrityFailure` alert. (link:https://issues.redhat.com/browse/OCPBUGS-42807[*OCPBUGS-42807*])
+
+* Before this update, when a new node was added to a cluster by scaling up the `machineset` object, FIO marked the new node as `Failed` before the node was ready. With this release FIO waits until the new node is ready. (link:https://issues.redhat.com/browse/OCPBUGS-36483[*OCPBUGS-36483*])
+
+* Before this update, the Advanced Intrusion Detection Environment (AIDE) daemonset pods would constantly force-initialize the AIDE database. With this release, FIO initializes the AIDE database only once. (link:https://issues.redhat.com/browse/OCPBUGS-37300[*OCPBUGS-37300*])
+
+* Before this update, some link paths in the Machine Config Operator (MCO) configuration, such as `/hostroot/etc/ipsec.d/openshift.conf` and `hostroot/etc/mco/internal-registry-pull-secret.json`, changed during an MCO update. This led to failed file integrity checks on nodes after the update, which disrupted user experience. With this update, the File Integrity Operator (FIO) uses the updated file link paths in the MCO configuration. File integrity checks now pass after an update, helping to ensure a stable cluster. (link:https://issues.redhat.com/browse/OCPBUGS-41628[*OCPBUGS-41628*])
+

--- a/modules/fio-rn-1-3-7.adoc
+++ b/modules/fio-rn-1-3-7.adoc
@@ -1,0 +1,18 @@
+// Module included in the following assemblies:
+//
+// * security/file_integrity_operator/file-integrity-operator-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="file-integrity-operator-release-notes-1-3-7_{context}"]
+= Release notes for OpenShift File Integrity Operator 1.3.7
+
+[role="_abstract"]
+Release notes for OpenShift File Integrity Operator 1.3.7.
+
+
+The following Red Hat Security Advisory (RHSA) is available for the OpenShift File Integrity Operator 1.3.7:
+
+* link:https://access.redhat.com/errata/RHSA-2025:21913[RHSA-2025:21913 OpenShift File Integrity Operator Update]
+
+This update includes upgraded dependencies in underlying base images.
+

--- a/modules/fio-rn-1-3-8.adoc
+++ b/modules/fio-rn-1-3-8.adoc
@@ -1,0 +1,23 @@
+// Module included in the following assemblies:
+//
+// * security/file_integrity_operator/file-integrity-operator-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="file-integrity-operator-release-notes-1-3-8_{context}"]
+= Release notes for OpenShift File Integrity Operator 1.3.8
+
+[role="_abstract"]
+Release notes for OpenShift File Integrity Operator 1.3.8.
+
+
+The following Red Hat Security Advisory (RHSA) is available for the OpenShift File Integrity Operator 1.3.8:
+
+* link:https://access.redhat.com/errata/RHSA-2025:23542[RHSA-2025:23542 OpenShift File Integrity Operator Update]
+
+[id="file-integrity-operator-1-3-8-bug-fixes_{context}"]
+== Bug fixes
+
+* Before this update, the file-integrity-operator pods and the aide pods running the database used by a recently installed File Integrity Operator (FIO) would go into a terminating state, adding error log entries that were not useful. With this release, the pods needed by FIO do not go into terminating state unless a relevant error occurred or they completed their work.  (link:https://issues.redhat.com/browse/CMP-3757[*CMP-3757*])
+
+* This update includes upgraded dependencies in the underlying base images.
+

--- a/security/file_integrity_operator/file-integrity-operator-release-notes.adoc
+++ b/security/file_integrity_operator/file-integrity-operator-release-notes.adoc
@@ -1,271 +1,53 @@
 //OpenShift File Integrity Operator Release Notes
 :_mod-docs-content-type: ASSEMBLY
 [id="file-integrity-operator-release-notes"]
-= File Integrity Operator release notes
+= Release notes for the File Integrity Operator
 :context: file-integrity-operator-release-notes-v0
 include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 The File Integrity Operator for {product-title} continually runs file integrity checks on {op-system} nodes.
 
 These release notes track the development of the File Integrity Operator in the {product-title}.
 
-For an overview of the File Integrity Operator, see xref:../../security/file_integrity_operator/file-integrity-operator-understanding.adoc#understanding-file-integrity-operator[Understanding the File Integrity Operator].
+// Release note modules (most recent first)
+include::modules/fio-rn-1-3-8.adoc[leveloffset=+1]
 
-To access the latest release, see xref:../../security/file_integrity_operator/file-integrity-operator-updating.adoc#olm-preparing-upgrade_file-integrity-operator-updating[Updating the File Integrity Operator].
+include::modules/fio-rn-1-3-7.adoc[leveloffset=+1]
 
+include::modules/fio-rn-1-3-6.adoc[leveloffset=+1]
 
-[id="file-integrity-operator-release-notes-1-3-8"]
-== OpenShift File Integrity Operator 1.3.8
+include::modules/fio-rn-1-3-5.adoc[leveloffset=+1]
 
-The following advisory is available for the OpenShift File Integrity Operator 1.3.8:
+include::modules/fio-rn-1-3-4.adoc[leveloffset=+1]
 
-* link:https://access.redhat.com/errata/RHSA-2025:23542[RHSA-2025:23542 OpenShift File Integrity Operator Update]
+include::modules/fio-rn-1-3-3.adoc[leveloffset=+1]
 
-[id="file-integrity-operator-1-3-8-bug-fixes"]
-=== Bug fixes
+include::modules/fio-rn-1-3-2.adoc[leveloffset=+1]
 
-* Previously, the file-integrity-operator pods and the aide pods running the database used by recently installed FIO would go into a terminating state, adding error log entries that were not useful. With this release, the pods needed by FIO do not go into terminating state unless a relevant error occurred or they completed their work.  (link:https://issues.redhat.com/browse/CMP-3757[*CMP-3757*])
+include::modules/fio-rn-1-3-1.adoc[leveloffset=+1]
 
-* This update includes upgraded dependencies in the underlying base images.
+include::modules/fio-rn-1-2-1.adoc[leveloffset=+1]
 
-[id="file-integrity-operator-release-notes-1-3-7"]
-== OpenShift File Integrity Operator 1.3.7
+include::modules/fio-rn-1-2-0.adoc[leveloffset=+1]
 
-The following advisory is available for the OpenShift File Integrity Operator 1.3.7:
+include::modules/fio-rn-1-0-0.adoc[leveloffset=+1]
 
-* link:https://access.redhat.com/errata/RHSA-2025:21913[RHSA-2025:21913 OpenShift File Integrity Operator Update]
+include::modules/fio-rn-0-1-32.adoc[leveloffset=+1]
 
-This update includes upgraded dependencies in underlying base images.
+include::modules/fio-rn-0-1-30.adoc[leveloffset=+1]
 
-[id="file-integrity-operator-release-notes-1-3-6"]
-== OpenShift File Integrity Operator 1.3.6
+include::modules/fio-rn-0-1-24.adoc[leveloffset=+1]
 
-The following advisory is available for the OpenShift File Integrity Operator 1.3.6:
+include::modules/fio-rn-0-1-22.adoc[leveloffset=+1]
 
-* link:https://access.redhat.com/errata/RHBA-2025:11535[RHBA-2025:11535 OpenShift File Integrity Operator Bug Fix Update]
-
-[id="file-integrity-operator-1-3-6-bug-fixes"]
-=== Bug fixes
-
-* Previously, running the `oc annotate fileintegrities/<fileintegrity-name> file-integrity.openshift.io/re-init-on-failed=` command would trigger a reinitialization on all nodes. Now, it only reinitializes the nodes where failures occurred. (link:https://issues.redhat.com/browse/OCPBUGS-18933[*OCPBUGS-18933*])
-
-* Previously, resetting FIO cleared the `NodeHasIntegrityFailure` alert. This occurred because the `metric file_integrity_operator_node_failed` setting was also reset. With this release, restarting FIO does not affect the `NodeHasIntegrityFailure` alert. (link:https://issues.redhat.com/browse/OCPBUGS-42807[*OCPBUGS-42807*])
-
-* Previously, when a new node was added to a cluster by scaling up the `machineset` object, FIO marked the new node as `Failed` before the node was ready. With this release FIO waits until the new node is ready. (link:https://issues.redhat.com/browse/OCPBUGS-36483[*OCPBUGS-36483*])
-
-* Previously, the Advanced Intrusion Detection Environment (AIDE) daemonset pods would constantly force-initialize the AIDE database. With this release, FIO initializes the AIDE database only once. (link:https://issues.redhat.com/browse/OCPBUGS-37300[*OCPBUGS-37300*])
-
-* Previously, some link paths in the Machine Config Operator (MCO) configuration, such as `/hostroot/etc/ipsec.d/openshift.conf` and `hostroot/etc/mco/internal-registry-pull-secret.json`, were modified during an MCO update. This led to failed file integrity checks on nodes after the update, which disrupted user experience. With this update, the modified file link paths in the MCO configuration have been updated. File integrity checks now pass after an update, helping to ensure a stable cluster. (link:https://issues.redhat.com/browse/OCPBUGS-41628[*OCPBUGS-41628*])
-
-[id="file-integrity-operator-release-notes-1-3-5"]
-== OpenShift File Integrity Operator 1.3.5
-
-The following advisory is available for the OpenShift File Integrity Operator 1.3.5:
-
-* link:https://access.redhat.com/errata/RHBA-2024:10366[RHBA-2024:10366 OpenShift File Integrity Operator Update]
-
-This update includes upgraded dependencies in underlying base images.
-
-[id="file-integrity-operator-release-notes-1-3-4"]
-== OpenShift File Integrity Operator 1.3.4
-
-The following advisory is available for the OpenShift File Integrity Operator 1.3.4:
-
-* link:https://access.redhat.com/errata/RHBA-2024:2946[RHBA-2024:2946 OpenShift File Integrity Operator Bug Fix and Enhancement Update]
-
-[id="file-integrity-operator-1-3-4-bug-fixes"]
-=== Bug fixes
-
-Previously, File Integrity Operator would issue a `NodeHasIntegrityFailure` alert due to multus certificate rotation. With this release, the alert and failing status are now correctly triggered. (link:https://issues.redhat.com/browse/OCPBUGS-31257[*OCPBUGS-31257*])
-
-[id="file-integrity-operator-release-notes-1-3-3"]
-== OpenShift File Integrity Operator 1.3.3
-
-The following advisory is available for the OpenShift File Integrity Operator 1.3.3:
-
-* link:https://access.redhat.com/errata/RHBA-2023:5652[RHBA-2023:5652 OpenShift File Integrity Operator Bug Fix and Enhancement Update]
-
-This update addresses a CVE in an underlying dependency.
-
-[id="file-integrity-operator-1-3-3-new-features-and-enhancements"]
-=== New features and enhancements
-
-* You can install and use the File Integrity Operator in an {product-title} cluster running in FIPS mode.
-+
---
-include::snippets/fips-snippet.adoc[]
-
---
-
-[id="file-integrity-operator-1-3-3-bug-fixes"]
-=== Bug fixes
-
-* Previously, some FIO pods with private default mount propagation in combination with `hostPath: path: /` volume mounts would break the CSI driver relying on multipath. This problem has been fixed and the CSI driver works correctly. (link:https://access.redhat.com/solutions/7017081[Some OpenShift Operator pods blocking unmounting of CSI volumes when multipath is in use])
-
-* This update resolves CVE-2023-39325. (link:https://access.redhat.com/security/cve/CVE-2023-39325[*CVE-2023-39325*])
-
-[id="file-integrity-operator-release-notes-1-3-2"]
-== OpenShift File Integrity Operator 1.3.2
-
-The following advisory is available for the OpenShift File Integrity Operator 1.3.2:
-
-* link:https://access.redhat.com/errata/RHBA-2023:5107[RHBA-2023:5107 OpenShift File Integrity Operator Bug Fix Update]
-
-This update addresses a CVE in an underlying dependency.
-
-[id="file-integrity-operator-release-notes-1-3-1"]
-== OpenShift File Integrity Operator 1.3.1
-
-The following advisory is available for the OpenShift File Integrity Operator 1.3.1:
-
-* link:https://access.redhat.com/errata/RHBA-2023:3600[RHBA-2023:3600 OpenShift File Integrity Operator Bug Fix Update]
-
-[id="file-integrity-operator-1-3-1-new-features-and-enhancements"]
-=== New features and enhancements
-
-* FIO now includes kubelet certificates as default files, excluding them from issuing warnings when they're managed by {product-title}. (link:https://issues.redhat.com/browse/OCPBUGS-14348[*OCPBUGS-14348*])
-
-* FIO now correctly directs email to the address for Red Hat Technical Support. (link:https://issues.redhat.com/browse/OCPBUGS-5023[*OCPBUGS-5023*])
-
-[id="file-integrity-operator-1-3-1-bug-fixes"]
-=== Bug fixes
-
-* Previously, FIO would not clean up `FileIntegrityNodeStatus` CRDs when nodes are removed from the cluster. FIO has been updated to correctly clean up node status CRDs on node removal.  (link:https://issues.redhat.com/browse/OCPBUGS-4321[*OCPBUGS-4321*])
-
-* Previously, FIO would also erroneously indicate that new nodes failed integrity checks. FIO has been updated to correctly show node status CRDs when adding new nodes to the cluster. This provides correct node status notifications. (link:https://issues.redhat.com/browse/OCPBUGS-8502[*OCPBUGS-8502*])
-
-* Previously, when FIO was reconciling `FileIntegrity` CRDs, it would pause scanning until the reconciliation was done. This caused an overly aggressive re-initiatization process on nodes not impacted by the reconciliation. This problem also resulted in unnecessary daemonsets for machine config pools which are unrelated to the `FileIntegrity` being changed. FIO correctly handles these cases and only pauses AIDE scanning for nodes that are affected by file integrity changes. (link:https://issues.redhat.com/browse/CMP-1097[*CMP-1097*])
-
-[id="file-integrity-operator-1-3-1-known-issues"]
-=== Known Issues
-
-In FIO 1.3.1, increasing nodes in {ibm-z-name} clusters might result in `Failed` File Integrity node status. For more information, see link:https://access.redhat.com/solutions/7028861[Adding nodes in {ibm-power-name} clusters can result in failed File Integrity node status].
-
-[id="file-integrity-operator-release-notes-1-2-1"]
-== OpenShift File Integrity Operator 1.2.1
-
-The following advisory is available for the OpenShift File Integrity Operator 1.2.1:
-
-* link:https://access.redhat.com/errata/RHBA-2023:1684[RHBA-2023:1684 OpenShift File Integrity Operator Bug Fix Update]
-
-* This release includes updated container dependencies.
-
-[id="file-integrity-operator-release-notes-1-2-0"]
-== OpenShift File Integrity Operator 1.2.0
-
-The following advisory is available for the OpenShift File Integrity Operator 1.2.0:
-
-* link:https://access.redhat.com/errata/RHBA-2023:1273[RHBA-2023:1273 OpenShift File Integrity Operator Enhancement Update]
-
-[id="file-integrity-operator-1-2-0-new-features-and-enhancements"]
-=== New features and enhancements
-
-* The File Integrity Operator Custom Resource (CR) now contains an `initialDelay` feature that specifies the number of seconds to wait before starting the first AIDE integrity check. For more information, see xref:../../security/file_integrity_operator/file-integrity-operator-understanding.adoc#understanding-file-integrity-custom-resource_file-integrity-operator[Creating the FileIntegrity custom resource].
-
-* The File Integrity Operator is now stable and the release channel is upgraded to `stable`. Future releases will follow link:https://semver.org/[Semantic Versioning]. To access the latest release, see xref:../../security/file_integrity_operator/file-integrity-operator-updating.adoc#olm-preparing-upgrade_file-integrity-operator-updating[Updating the File Integrity Operator].
-
-[id="file-integrity-operator-release-notes-1-0-0"]
-== OpenShift File Integrity Operator 1.0.0
-
-The following advisory is available for the OpenShift File Integrity Operator 1.0.0:
-
-* link:https://access.redhat.com/errata/RHBA-2023:0037[RHBA-2023:0037 OpenShift File Integrity Operator Bug Fix Update]
-
-[id="file-integrity-operator-release-notes-0-1-32"]
-== OpenShift File Integrity Operator 0.1.32
-
-The following advisory is available for the OpenShift File Integrity Operator 0.1.32:
-
-* link:https://access.redhat.com/errata/RHBA-2022:7095[RHBA-2022:7095 OpenShift File Integrity Operator Bug Fix Update]
-
-[id="file-integrity-operator-0-1-32-bug-fixes"]
-=== Bug fixes
-
-* Previously, alerts issued by the File Integrity Operator did not set a namespace, making it difficult to understand from which namespace the alert originated. Now, the Operator sets the appropriate namespace, providing more information about the alert. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2112394[*BZ#2112394*])
-
-* Previously, The File Integrity Operator did not update the metrics service on Operator startup, causing the metrics targets to be unreachable. With this release, the File Integrity Operator now ensures the metrics service is updated on Operator startup. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2115821[*BZ#2115821*])
-
-[id="file-integrity-operator-release-notes-0-1-30"]
-== OpenShift File Integrity Operator 0.1.30
-
-The following advisory is available for the OpenShift File Integrity Operator 0.1.30:
-
-* link:https://access.redhat.com/errata/RHBA-2022:5538[RHBA-2022:5538 OpenShift File Integrity Operator Bug Fix and Enhancement Update]
-
-[id="file-integrity-operator-0-1-30-new-features-and-enhancements"]
-=== New features and enhancements
-
-* The File Integrity Operator is now supported on the following architectures:
-+
-** {ibm-power-name}
-** {ibm-z-name} and {ibm-linuxone-name}
-
-[id="file-integrity-operator-0-1-30-bug-fixes"]
-=== Bug fixes
-
-* Previously, alerts issued by the File Integrity Operator did not set a namespace, making it difficult to understand where the alert originated. Now, the Operator sets the appropriate namespace, increasing understanding of the alert. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2101393[*BZ#2101393*])
-
-[id="file-integrity-operator-release-notes-0-1-24"]
-== OpenShift File Integrity Operator 0.1.24
-
-The following advisory is available for the OpenShift File Integrity Operator 0.1.24:
-
-* link:https://access.redhat.com/errata/RHBA-2022:1331[RHBA-2022:1331 OpenShift File Integrity Operator Bug Fix]
-
-[id="file-integrity-operator-0-1-24-new-features-and-enhancements"]
-=== New features and enhancements
-
-* You can now configure the maximum number of backups stored in the `FileIntegrity` Custom Resource (CR) with the `config.maxBackups` attribute. This attribute specifies the number of AIDE database and log backups left over from the `re-init` process to keep on the node. Older backups beyond the configured number are automatically pruned. The default is set to five backups.
-
-[id="openshift-file-integrity-operator-0-1-24-bug-fixes"]
-=== Bug fixes
-
-* Previously, upgrading the Operator from versions older than 0.1.21 to 0.1.22 could cause the `re-init` feature to fail. This was a result of the Operator failing to update `configMap` resource labels. Now, upgrading to the latest version fixes the resource labels. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2049206[*BZ#2049206*])
-
-* Previously, when enforcing the default `configMap` script contents, the wrong data keys were compared. This resulted in the `aide-reinit` script not being updated properly after an Operator upgrade, and caused the `re-init` process to fail. Now,`daemonSets` run to completion and the AIDE database `re-init` process executes successfully. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2072058[*BZ#2072058*])
-
-[id="file-integrity-operator-release-notes-0-1-22"]
-== OpenShift File Integrity Operator 0.1.22
-
-The following advisory is available for the OpenShift File Integrity Operator 0.1.22:
-
-* link:https://access.redhat.com/errata/RHBA-2022:0142[RHBA-2022:0142 OpenShift File Integrity Operator Bug Fix]
-
-[id="openshift-file-integrity-operator-0-1-22-bug-fixes"]
-=== Bug fixes
-
-* Previously, a system with a File Integrity Operator installed might interrupt the {product-title} update, due to the  `/etc/kubernetes/aide.reinit` file. This occurred if the `/etc/kubernetes/aide.reinit` file was present, but later removed prior to the `ostree` validation. With this update, `/etc/kubernetes/aide.reinit` is moved to the `/run` directory so that it does not conflict with the {product-title} update. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2033311[*BZ#2033311*])
-
-[id="file-integrity-operator-release-notes-0-1-21"]
-== OpenShift File Integrity Operator 0.1.21
-
-The following advisory is available for the OpenShift File Integrity Operator 0.1.21:
-
-* link:https://access.redhat.com/errata/RHBA-2021:4631[RHBA-2021:4631 OpenShift File Integrity Operator Bug Fix and Enhancement Update]
-
-[id="file-integrity-operator-0-1-21-new-features-and-enhancements"]
-=== New features and enhancements
-
-* The metrics related to `FileIntegrity` scan results and processing metrics are displayed on the monitoring dashboard on the web console. The results are labeled with the prefix of `file_integrity_operator_`.
-+
-* If a node has an integrity failure for more than 1 second, the default `PrometheusRule` provided in the operator namespace alerts with a warning.
-+
-* The following dynamic Machine Config Operator and Cluster Version Operator related filepaths are excluded from the default AIDE policy to help prevent false positives during node updates:
- - /etc/machine-config-daemon/currentconfig
- - /etc/pki/ca-trust/extracted/java/cacerts
- - /etc/cvo/updatepayloads
- - /root/.kube
-+
-* The AIDE daemon process has stability improvements over v0.1.16, and is more resilient to errors that might occur when the AIDE database is initialized.
-
-[id="openshift-file-integrity-operator-0-1-21-bug-fixes"]
-=== Bug fixes
-
-* Previously, when the Operator automatically upgraded, outdated daemon sets were not removed. With this release, outdated daemon sets are removed during the automatic upgrade.
+include::modules/fio-rn-0-1-21.adoc[leveloffset=+1]
 
 [id="file-integrity-operator-release-notes_additional-resources"]
 [role="_additional-resources"]
 == Additional resources
+
 * xref:../../security/file_integrity_operator/file-integrity-operator-understanding.adoc#understanding-file-integrity-operator[Understanding the File Integrity Operator]
+* xref:../../security/file_integrity_operator/file-integrity-operator-updating.adoc#olm-preparing-upgrade_file-integrity-operator-updating[Updating the File Integrity Operator]

--- a/snippets/fips-snippet.adoc
+++ b/snippets/fips-snippet.adoc
@@ -23,6 +23,7 @@
 //
 // * security/compliance_operator/compliance-operator-release-notes.adoc
 // * security/file_integrity_operator/file-integrity-operator-release-notes.adoc
+// * modules/fio-rn-1-3-3.adoc
 
 :_mod-docs-content-type: SNIPPET
 


### PR DESCRIPTION
Version(s): 4.21 ONLY

Issue: https://redhat.atlassian.net/browse/OSDOCS-19771

Manual backport of FIO release note modularization from https://github.com/openshift/openshift-docs/pull/111567 (merged to main). /cherrypick failed due to a merge conflict in file-integrity-operator-release-notes.adoc.

Changes:

Adds 15 modules/fio-rn-*.adoc release note modules
Replaces monolithic file-integrity-operator-release-notes.adoc with modular assembly includes
Updates snippets/fips-snippet.adoc include list
Additional information: Modularization and DITA/CQA alignment only; no new release note content.