### PR TITLE
[RHDEVDOCS-7612] Release notes for Pipelines 1.22.1

### DIFF
--- a/modules/op-release-notes-1-22-1.adoc
+++ b/modules/op-release-notes-1-22-1.adoc
@@ -1,0 +1,9 @@
+// This module is included in the following assemblies:
+// * release_notes/op-release-notes-1-22.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="op-release-notes-1-22-1_{context}"]
+= Release notes for {pipelines-title} 1.22.1
+
+[role="_abstract"]
+With this update, {pipelines-title} General Availability (GA) 1.22.1 is available on {OCP} 4.14, 4.16, and later versions.

--- a/release_notes/op-release-notes-1-22.adoc
+++ b/release_notes/op-release-notes-1-22.adoc
@@ -28,6 +28,9 @@ For an overview of {pipelines-title}, see xref:../about/understanding-openshift-
 // Compatibility and support matrix 1.22
 include::modules/op-tkn-pipelines-compatibility-support-matrix.adoc[leveloffset=+1]
 
+// Release notes for Red Hat OpenShift Pipelines 1.22.1
+include::modules/op-release-notes-1-22-1.adoc[leveloffset=+1]
+
 // Release notes for Red Hat OpenShift Pipelines 1.22.0
 include::modules/op-release-notes-1-22-0.adoc[leveloffset=+1]
 


### PR DESCRIPTION
Version(s):
- none for cherry-picking

Issue:
- https://redhat.atlassian.net/browse/RHDEVDOCS-7612

Link to docs preview:
- [OpenShift Pipelines 1.22.1 release notes](https://112032--ocpdocs-pr.netlify.app/openshift-pipelines/latest/release_notes/op-release-notes-1-22.html#op-release-notes-1-22-1_op-release-notes-1-22)

QE review:
- [x] QE has approved this change.
