### PR TITLE
[OSDOCS#19044]: Approve CSRs during graceful cluster restart

### DIFF
--- a/modules/graceful-restart.adoc
+++ b/modules/graceful-restart.adoc
@@ -58,9 +58,9 @@ The control plane nodes are ready if the status is `Ready`, as shown in the foll
 [source,terminal]
 ----
 NAME                           STATUS   ROLES                  AGE   VERSION
-ip-10-0-168-251.ec2.internal   Ready    control-plane,master   75m   v1.35.4
-ip-10-0-170-223.ec2.internal   Ready    control-plane,master   75m   v1.35.4
-ip-10-0-211-16.ec2.internal    Ready    control-plane,master   75m   v1.35.4
+ip-10-0-168-251.ec2.internal   Ready    control-plane,master   75m   v1.35.0
+ip-10-0-170-223.ec2.internal   Ready    control-plane,master   75m   v1.35.0
+ip-10-0-211-16.ec2.internal    Ready    control-plane,master   75m   v1.35.0
 ----
 
 . If the control plane nodes are _not_ ready, then check whether there are any pending certificate signing requests (CSRs) that must be approved.
@@ -72,13 +72,36 @@ ip-10-0-211-16.ec2.internal    Ready    control-plane,master   75m   v1.35.4
 $ oc get csr
 ----
 
-.. Review the details of a CSR to verify that it is valid:
+.. Review the details of each CSR to verify that it is valid by running:
 +
 [source,terminal]
 ----
-$ oc describe csr <csr_name> <1>
+$ oc get csr <csr_name> -o jsonpath='{.spec.request}' | base64 -d | openssl req -text -noout
 ----
-<1> `<csr_name>` is the name of a CSR from the list of current CSRs.
++
+When validating the CSR, verify that the following fields match your infrastructure expectations:
++
+* Subject / Common Name (CN): Must follow the format `system:node:<node_name>`, such as `system:node:control-plane-0.example.com`.
+* Organization (O): Must be exactly `system:nodes`.
+* Requested Extensions (Extended Key Usage): Must list `TLS Web Client Authentication`.
++
+.Example Output of a Valid Control Plane Client CSR
+[source,terminal]
+----
+Certificate Request:
+    Data:
+        Version: 1 (0x0)
+        Subject: O = system:nodes, CN = system:node:control-plane-0.example.com
+        Subject Public Key Info:
+            Public Key Algorithm: id-ecPublicKey
+                Public-Key: (256 bit)
+        Attributes:
+            Requested Extensions:
+                X509v3 Extended Key Usage: 
+                    TLS Web Client Authentication
+----
++
+The process verifies that the certificate is allowed to be used as a client credential for the node.
 
 .. Approve each valid CSR:
 +
@@ -87,24 +110,24 @@ $ oc describe csr <csr_name> <1>
 $ oc adm certificate approve <csr_name>
 ----
 
-. After the control plane nodes are ready, verify that all worker nodes are ready.
+. After the control plane nodes are ready, verify that all compute nodes are ready.
 +
 [source,terminal]
 ----
 $ oc get nodes -l node-role.kubernetes.io/worker
 ----
 +
-The worker nodes are ready if the status is `Ready`, as shown in the following output:
+The compute nodes are ready if the status is `Ready`, as shown in the following output:
 +
 [source,terminal]
 ----
 NAME                           STATUS   ROLES    AGE   VERSION
-ip-10-0-179-95.ec2.internal    Ready    worker   64m   v1.35.4
-ip-10-0-182-134.ec2.internal   Ready    worker   64m   v1.35.4
-ip-10-0-250-100.ec2.internal   Ready    worker   64m   v1.35.4
+ip-10-0-179-95.ec2.internal    Ready    worker   64m   v1.35.0
+ip-10-0-182-134.ec2.internal   Ready    worker   64m   v1.35.0
+ip-10-0-250-100.ec2.internal   Ready    worker   64m   v1.35.0
 ----
 
-. If the worker nodes are _not_ ready, then check whether there are any pending certificate signing requests (CSRs) that must be approved.
+. If the compute nodes are _not_ ready, then check whether there are any pending certificate signing requests (CSRs) that must be approved.
 
 .. Get the list of current CSRs:
 +
@@ -113,13 +136,39 @@ ip-10-0-250-100.ec2.internal   Ready    worker   64m   v1.35.4
 $ oc get csr
 ----
 
-.. Review the details of a CSR to verify that it is valid:
+.. Review the details of each CSR to verify its validity by running:
 +
 [source,terminal]
 ----
-$ oc describe csr <csr_name> <1>
+$ oc get csr <csr_name> -o jsonpath='{.spec.request}' | base64 -d | openssl req -text -noout
 ----
-<1> `<csr_name>` is the name of a CSR from the list of current CSRs.
++
+Compute node CSRs can be for client certificates (kubelet to API) or serving certificates (API to kubelet). Verify that the following fields match your infrastructure expectations:
++
+* Subject / Common Name (CN): Must follow the format `system:node:<compute_node_name>`.
+* Organization (O): Must be exactly `system:nodes`.
+* Extended Key Usage (EKU): Must list `TLS Web Client Authentication` (for client requests) or `TLS Web Server Authentication` (for serving requests).
+* Subject Alternative Name (SAN): For serving certificates, this field must contain the correct internal DNS hostname and the internal IP address of the respective compute node.
++
+.Example Output of a Valid Worker Serving CSR
+[source,terminal]
+----
+Certificate Request:
+    Data:
+        Version: 1 (0x0)
+        Subject: O = system:nodes, CN = system:node:worker-0.example.com
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                Public-Key: (2048 bit)
+        Attributes:
+            Requested Extensions:
+                X509v3 Extended Key Usage: 
+                    TLS Web Server Authentication
+                X509v3 Subject Alternative Name: 
+                    DNS:worker-0.example.com, IP Address:10.0.12.34
+----
++
+This process verifies the validity of the certificate as a server credential for cluster communication.
 
 .. Approve each valid CSR:
 +
@@ -172,12 +221,12 @@ Check that the status for all nodes is `Ready`.
 [source,terminal]
 ----
 NAME                           STATUS   ROLES                  AGE   VERSION
-ip-10-0-168-251.ec2.internal   Ready    control-plane,master   82m   v1.35.4
-ip-10-0-170-223.ec2.internal   Ready    control-plane,master   82m   v1.35.4
-ip-10-0-179-95.ec2.internal    Ready    worker                 70m   v1.35.4
-ip-10-0-182-134.ec2.internal   Ready    worker                 70m   v1.35.4
-ip-10-0-211-16.ec2.internal    Ready    control-plane,master   82m   v1.35.4
-ip-10-0-250-100.ec2.internal   Ready    worker                 69m   v1.35.4
+ip-10-0-168-251.ec2.internal   Ready    control-plane,master   82m   v1.35.0
+ip-10-0-170-223.ec2.internal   Ready    control-plane,master   82m   v1.35.0
+ip-10-0-179-95.ec2.internal    Ready    worker                 70m   v1.35.0
+ip-10-0-182-134.ec2.internal   Ready    worker                 70m   v1.35.0
+ip-10-0-211-16.ec2.internal    Ready    control-plane,master   82m   v1.35.0
+ip-10-0-250-100.ec2.internal   Ready    worker                 69m   v1.35.0
 ----
 +
 If the cluster did not start properly, you might need to restore your cluster using an etcd backup. For more information, see "Restoring to a previous cluster state".


### PR DESCRIPTION
Version(s):
4.21+

Issue:
[OSDOCS-19044](https://redhat.atlassian.net/browse/OSDOCS-19044)

Link to docs preview:
https://112034--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/graceful-cluster-restart.html

QE review:
- [x] QE has approved this change.