### PR TITLE
Improve declarative auth provider docs for GitOps workflows

### DIFF
--- a/configuration/declarative-configuration-using.adoc
+++ b/configuration/declarative-configuration-using.adoc
@@ -10,9 +10,9 @@ toc::[]
 
 With declarative configuration, you can update configurations by storing them in files in repositories and apply them to the system. Declarative configuration is useful, for example, if you are using a GitOps workflow. You can currently use declarative configuration in {rh-rhacs-first} for authentication and authorization resources such as authentication providers, roles, permission sets, and access scopes.
 
-To use declarative configuration, you create YAML files that contain configuration information about authentication and authorization resources. These files, or configurations, are added to {product-title-short} by using a mount point during Central installation. See the installation documentation in the "Additional resources" section for more information on configuring mount points when installing {product-title-short}.
+To use declarative configuration, you create YAML files that contain configuration information about authentication and authorization resources. You can write these YAML files manually or generate them by using the `roxctl declarative-config create` command. These files, or configurations, are added to {product-title-short} by using a mount point during Central installation. See the installation documentation in the "Additional resources" section for more information on configuring mount points when installing {product-title-short}.
 
-The configuration files used with declarative configuration are stored in config maps or secrets, depending on the type of resource. Store configurations for authentication providers in a secret for greater security. You can store other configurations in config maps.
+The configuration files used with declarative configuration are stored in config maps or secrets, depending on the type of resource. Store configurations for authentication providers in a secret for greater security, because they can contain sensitive values such as client secrets or certificates. You can store other configurations such as roles, permission sets, and access scopes in config maps.
 
 A single config map or secret can contain more than one configuration of multiple resource types. This allows you to limit the number of volume mounts for the Central instance.
 
@@ -27,7 +27,17 @@ Because resources can reference other resources (for example, a role can referen
 
 include::modules/declarative-configuration-resource-create.adoc[leveloffset=+1]
 
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../configuration/declarative-configuration-using.adoc#declarative-configuration-examples_declarative-configuration-using[Declarative configuration examples]
+
 include::modules/declarative-configuration-examples.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../configuration/declarative-configuration-using.adoc#declarative-configuration-resource-create_declarative-configuration-using[Creating declarative configurations]
 
 include::modules/declarative-configuration-troubleshooting.adoc[leveloffset=+1]
 

--- a/modules/declarative-configuration-examples.adoc
+++ b/modules/declarative-configuration-examples.adoc
@@ -9,74 +9,192 @@
 [role="_abstract"]
 You can create declarative configurations by using the following examples as a guide. Use the `roxctl declarative-config lint` command to verify that your configurations are valid.
 
-[id="declarative-config-example-auth-provider"]
-== Declarative configuration authentication provider example
+You can also write the configuration YAML directly without using `roxctl`. For more information, see "Creating declarative configurations".
+
+[id="declarative-config-example-auth-provider_{context}"]
+== Declarative configuration authentication provider examples
+
+Each authentication provider configuration must specify exactly one provider type: `oidc`, `saml`, `iap`, `userpki`, or `openshift`. The following examples show valid configurations for each type.
+
+[IMPORTANT]
+====
+Store authentication provider configurations in Kubernetes secrets rather than config maps, because they can contain sensitive values such as client secrets or certificates.
+====
+
+[id="declarative-config-example-auth-provider-oidc_{context}"]
+=== OpenID Connect (OIDC) authentication provider
+
+The following example configures an OIDC authentication provider with a client secret. This is the most common configuration for identity providers such as Keycloak, Okta, or Azure AD.
 
 [source,yaml]
 ----
-name: A sample auth provider
-minimumRole: Analyst
-uiEndpoint: central.custom-domain.com:443
-extraUIEndpoints:
-    - central-alt.custom-domain.com:443
+name: my-oidc-provider
+minimumRole: None
+uiEndpoint: central.example.com:443
 groups:
-    - key: email
-      value: example@example.com
-      role: Admin
-    - key: groups
-      value: reviewers
-      role: Analyst
+  - key: groups
+    value: cluster-admins
+    role: Admin
+  - key: email
+    value: analyst@example.com
+    role: Analyst
 requiredAttributes:
-    - key: org_id
-      value: "12345"
+  - key: org_id
+    value: "12345"
 claimMappings:
-    - path: org_id
-      value: my_org_id
+  - path: realm_access.roles
+    name: groups
 oidc:
-    issuer: sample.issuer.com
-    mode: auto
-    clientID: CLIENT_ID
-    clientSecret: CLIENT_SECRET
-clientSecret: CLIENT_SECRET
-iap:
-    audience: audience
-saml:
-    spIssuer: sample.issuer.com
-    metadataURL: sample.provider.com/metadata
-saml:
-    spIssuer: sample.issuer.com
-    cert: |
-    ssoURL: saml.provider.com
-    idpIssuer: idp.issuer.com
-userpki:
-    certificateAuthorities: |
-    certificate
-openshift:
-    enable: true
+  issuer: sso.example.com/realms/my-realm
+  mode: post
+  clientID: my-client-id
+  clientSecret: my-client-secret
 ----
 
-where:
+To configure an OIDC provider without a client secret (a public client), omit the `clientSecret` field and set `doNotUseClientSecret` to `true`:
+
+[source,yaml]
+----
+name: my-oidc-public-provider
+minimumRole: None
+uiEndpoint: central.example.com:443
+oidc:
+  issuer: sso.example.com/realms/my-realm
+  mode: fragment
+  clientID: my-public-client-id
+  doNotUseClientSecret: true
+----
+
+[id="declarative-config-example-auth-provider-saml_{context}"]
+=== SAML 2.0 authentication provider
+
+You can configure SAML 2.0 by using either dynamic configuration, with a metadata URL, or by using static configuration, with an IdP certificate and SSO URL.
+
+.Dynamic SAML configuration
+
+[source,yaml]
+----
+name: my-saml-provider
+minimumRole: None
+uiEndpoint: central.example.com:443
+groups:
+  - key: email
+    value: admin@example.com
+    role: Admin
+saml:
+  spIssuer: https://central.example.com
+  metadataURL: https://idp.example.com/metadata
+----
+
+.Static SAML configuration
+
+[source,yaml]
+----
+name: my-saml-static-provider
+minimumRole: None
+uiEndpoint: central.example.com:443
+saml:
+  spIssuer: https://central.example.com
+  cert: |
+    -----BEGIN CERTIFICATE-----
+    ...
+    -----END CERTIFICATE-----
+  ssoURL: https://idp.example.com/sso
+  idpIssuer: https://idp.example.com
+  nameIdFormat: urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress
+----
+
+[id="declarative-config-example-auth-provider-openshift_{context}"]
+=== OpenShift Auth authentication provider
+
+[source,yaml]
+----
+name: my-openshift-auth
+minimumRole: None
+uiEndpoint: central.example.com:443
+openshift:
+  enable: true
+----
+
+[id="declarative-config-example-auth-provider-iap_{context}"]
+=== Google IAP authentication provider
+
+[source,yaml]
+----
+name: my-iap-provider
+minimumRole: None
+uiEndpoint: central.example.com:443
+iap:
+  audience: /projects/123456/apps/my-app
+----
+
+[id="declarative-config-example-auth-provider-userpki_{context}"]
+=== User PKI authentication provider
+
+[source,yaml]
+----
+name: my-userpki-provider
+minimumRole: None
+uiEndpoint: central.example.com:443
+userpki:
+  certificateAuthorities: |
+    -----BEGIN CERTIFICATE-----
+    ...
+    -----END CERTIFICATE-----
+----
+
+[id="declarative-config-auth-provider-field-reference_{context}"]
+=== Authentication provider field reference
 
 --
-`minimumRole`:: Specifies the minimum role that will be assigned by default to any user logging in. If left blank, the value is `None`.
-`uiEndpoint`:: Specifies the user interface endpoint of your Central instance.
-`extraUIEndpoints`:: Specifies whether your Central instance is exposed to different endpoints.
-`groups`:: Specifies the specific roles to map users based on their attributes.
-`groups.key`:: Specifies the key that can be any claim returned from the authentication provider.
-`groups.role`:: Specifies the role that the users are given. You can use a default role or a declaratively-created role.
-`requiredAttributes`:: Specifies whether the attributes returned from the authentication provider are required, for example, if the audience is limited to a specific organization or group. This is optional.
-`claimMappings`:: Specifies whether the claims returned from the identity provider should be mapped to custom claims. This is optional.
-`oidc`:: Specifies whether the system is configured to use OpenID Connect (OIDC) as an authentication method.
-`oidc.issuer`:: Specifies the expected issuer for the token.
-`oidc.mode`:: Specifies the OIDC callback mode. Possible values are `auto`, `post`, `query`, and `fragment`. The preferred value is `auto`.
-`iap`:: Specifies whether the system is configured to use Google Identity-Aware Proxy (IAP) as an authentication method.
-`saml`:: Specifies whether the system is configured to use Security Assertion Markup Language (SAML) 2.0 dynamic or static configuration as an authentication method.
-`saml.cert`:: Specifies the certificate in Privacy Enhanced Mail (PEM) format.
-`userpki.certificateAuthorities`:: Specifies whether the system is configured for authentication with user certificates.
-`userpki.certificate`:: Specifies the certificate in PEM format.
-`openshift`:: Specifies whether the system is configured for OpenShift Auth authentication providers.
+`name`:: Required. The name of the authentication provider. This name is displayed in the {product-title-short} login page.
+`minimumRole`:: Specifies the minimum role that is assigned by default to any user logging in through this provider. If left blank, the value is `None`.
+`uiEndpoint`:: Required. The user interface endpoint of your Central instance, specified without scheme (`http://` or `https://`) but including the port; for example, `central.example.com:443`.
+`extraUIEndpoints`:: Specifies additional endpoints if your Central instance is exposed on multiple URLs.
+`groups`:: Specifies role mappings for users based on their identity provider attributes.
+`groups.key`:: The identity provider attribute key to match; for example, `email`, `groups`, `userid`, or any claim returned by the provider.
+`groups.value`:: The attribute value to match.
+`groups.role`:: The {product-title-short} role to assign to matching users. You can use a default system role or a declaratively created role.
+`requiredAttributes`:: Optional. Specifies attributes that must be present in the identity provider response for authentication to succeed.
+`requiredAttributes.key`:: The required attribute key.
+`requiredAttributes.value`:: The required attribute value.
+`claimMappings`:: Optional. Maps claims from the identity provider to custom attribute names in {product-title-short}.
+`claimMappings.path`:: The claim path in the identity provider token; for example, `realm_access.roles`.
+`claimMappings.name`:: The attribute name to map the claim to in {product-title-short}; for example, `groups`.
 --
-[id="declarative-config-example-short-lived-token"]
+
+==== OIDC fields
+
+--
+`oidc.issuer`:: Required. The OIDC issuer URL according to the OpenID Connect specification. Specify without scheme; for example, `sso.example.com/realms/my-realm`.
+`oidc.mode`:: Required. The OIDC callback mode. Possible values are `auto`, `post`, `query`, and `fragment`. The recommended value is `post` when using a client secret, or `fragment` for public clients.
+`oidc.clientID`:: Required. The OAuth 2.0 client ID.
+`oidc.clientSecret`:: The OAuth 2.0 client secret. Required unless `doNotUseClientSecret` is set to `true`. Store configurations containing this field in a Kubernetes secret.
+`oidc.doNotUseClientSecret`:: Set to `true` to configure a public client without a client secret. Default is `false`.
+`oidc.disableOfflineAccessScope`:: Set to `true` to prevent requesting the `offline_access` scope from the identity provider. Default is `false`.
+`oidc.extraScopes`:: A space-delimited string of additional OAuth 2.0 scopes to request in addition to the default `openid profile email` scopes.
+--
+
+==== SAML fields
+
+--
+`saml.spIssuer`:: Required. The service provider issuer URI; for example, `https://central.example.com`.
+`saml.metadataURL`:: The metadata URL for dynamic SAML configuration. If specified, the `cert`, `ssoURL`, `idpIssuer`, and `nameIdFormat` fields are not required.
+`saml.cert`:: The IdP certificate in PEM format. Required for static SAML configuration.
+`saml.ssoURL`:: The IdP single sign-on URL. Required for static SAML configuration.
+`saml.idpIssuer`:: The IdP issuer URI. Used with static SAML configuration.
+`saml.nameIdFormat`:: The SAML NameID format; for example, `urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress`. Used with static SAML configuration.
+--
+
+==== Other provider type fields
+
+--
+`openshift.enable`:: Set to `true` to enable OpenShift Auth as the authentication provider.
+`iap.audience`:: Required. The Google IAP audience string.
+`userpki.certificateAuthorities`:: Required. One or more certificate authority certificates in PEM format.
+--
+
+[id="declarative-config-example-short-lived-token_{context}"]
 == Declarative configuration short-lived token example
 
 [source,yaml]

--- a/modules/declarative-configuration-resource-create.adoc
+++ b/modules/declarative-configuration-resource-create.adoc
@@ -5,7 +5,7 @@
 [id="declarative-configuration-resource-create_{context}"]
 = Creating declarative configurations
 
-Use `roxctl` to create the YAML files that store the configurations, create a config map from the files, and apply the config map.
+You can create declarative configuration YAML files either manually or by using the `roxctl` CLI. After creating the files, store them in a Kubernetes config map or secret and mount them into Central.
 
 [NOTE]
 ====
@@ -13,7 +13,105 @@ For {ocp}, use `oc` instead of `kubectl`.
 ====
 
 .Prerequisites
-* You have added the mount for the config map or secret during the installation of Central. In this example, the config map is called "declarative-configs". See the installation documentation listed in the "Additional resources" section for more information.
+* You have added the mount for the config map or secret during the installation of Central. See the installation documentation listed in the "Additional resources" section for more information.
+
+[id="declarative-configuration-resource-create-manual_{context}"]
+== Creating declarative configurations manually
+
+You can write declarative configuration YAML files directly, without using the `roxctl` CLI. This approach is useful for GitOps workflows where you manage configuration as code in a repository.
+
+.Procedure
+
+. Create a YAML file containing the authentication provider configuration. The following example configures an OIDC provider:
++
+[source,yaml]
+----
+name: my-oidc-provider
+minimumRole: None
+uiEndpoint: central.example.com:443
+groups:
+  - key: groups
+    value: cluster-admins
+    role: Admin
+oidc:
+  issuer: sso.example.com/realms/my-realm
+  mode: post
+  clientID: my-client-id
+  clientSecret: my-client-secret
+----
++
+For examples of all supported authentication provider types and other resource types, see "Declarative configuration examples".
++
+[TIP]
+====
+You can include multiple configurations of different resource types in a single YAML file by separating them with `---`. This allows you to limit the number of volume mounts for the Central instance.
+====
+
+. Create a Kubernetes secret from the YAML file. Use a secret rather than a config map when the configuration contains sensitive values such as client secrets or certificates:
++
+[NOTE]
+====
+The following commands use `--namespace=stackrox`, which assumes Central is installed in the `stackrox` namespace. If your Central instance is in a different namespace, replace `stackrox` with your namespace.
+====
++
+[source,terminal]
+----
+$ kubectl create secret generic my-auth-provider-config \
+    --from-file=auth-provider.yaml \
+    --namespace=stackrox
+----
++
+Alternatively, for non-sensitive configurations such as roles, permission sets, and access scopes, you can use a config map:
++
+[source,terminal]
+----
+$ kubectl create configmap my-declarative-configs \
+    --from-file=role.yaml --from-file=permission-set.yaml \
+    --namespace=stackrox
+----
+
+. Reference the secret or config map in your Central custom resource or Helm values.
++
+If you are using the Operator, add the reference to the `Central` custom resource:
++
+[source,yaml]
+----
+apiVersion: platform.stackrox.io/v1alpha1
+kind: Central
+metadata:
+  name: stackrox-central-services
+  namespace: stackrox
+spec:
+  central:
+    declarativeConfiguration:
+      secrets:
+        - name: my-auth-provider-config
+      configMaps:
+        - name: my-declarative-configs
+----
++
+If you are using Helm, add the reference to your values file:
++
+[source,yaml]
+----
+central:
+  declarativeConfiguration:
+    mounts:
+      secrets:
+        - my-auth-provider-config
+      configMaps:
+        - my-declarative-configs
+----
+
+. After Central starts or reconciles the configuration, verify that the resources were created successfully:
++
+* Navigate to *Platform Configuration* -> *System Health* and scroll to the *Declarative configuration* section. Verify that the status shows as healthy.
+* Navigate to *Access Control* to verify that the authentication provider appears. The *Origin* column shows `Declarative` for resources created from declarative configuration.
+
+[id="declarative-configuration-resource-create-roxctl_{context}"]
+== Creating declarative configurations by using the roxctl CLI
+
+Use `roxctl` to generate the YAML files that store the configurations, create a config map from the files, and apply the config map.
 
 .Procedure
 


### PR DESCRIPTION
Version: 4.9+
Issue: none
Preview: https://112037--ocpdocs-pr.netlify.app/openshift-acs/latest/configuration/declarative-configuration-using.html
Approval: Approved by ACS SME 👍 

## Summary

- Replace invalid combined auth provider YAML example (which showed all provider types in one block with duplicate keys) with separate, valid per-provider-type examples: OIDC with/without client secret, SAML dynamic/static, OpenShift Auth, Google IAP, User PKI
- Add a complete field reference section covering previously undocumented fields (`oidc.clientID`, `oidc.clientSecret`, `oidc.doNotUseClientSecret`, `oidc.disableOfflineAccessScope`, `oidc.extraScopes`, static SAML fields)
- Fix `claimMappings` field name from `value` to `name` to match the actual YAML schema in the [stackrox source](https://github.com/stackrox/stackrox/blob/master/pkg/declarativeconfig/auth_provider.go)
- Add a new "Creating declarative configurations manually" procedure showing the end-to-end workflow without `roxctl`: write YAML by hand, create a Kubernetes Secret, reference in Central CR (Operator) or Helm values, verify in the UI
- Update the assembly overview to mention manual YAML authoring and clarify when to use Secrets vs ConfigMaps

## Test plan

- [ ] All YAML examples validated with `yaml.safe_load()` — no parse errors
- [ ] All field names cross-checked against Go struct yaml tags in `pkg/declarativeconfig/auth_provider.go`
- [ ] Verify AsciiDoc renders correctly
- [ ] Verify examples work against a running ACS Central instance with declarative configuration enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)