### PR TITLE
OCPBUGS-86005: Update the note in nw-egress-ips-considerations.adoc

### DIFF
--- a/modules/nw-egress-ips-considerations.adoc
+++ b/modules/nw-egress-ips-considerations.adoc
@@ -7,9 +7,7 @@
 = Assignment of egress IPs to a namespace, nodes, and pods
 
 [role="_abstract"]
-To assign one or more egress IPs to a namespace or specific pods in a namespace, you must meet certain conditions.
-
-These conditions are listed as follows:
+To assign one or more egress IPs to a namespace or specific pods in a namespace, you must meet specific conditions.
 
 - At least one node in your cluster must have the `k8s.ovn.org/egress-assignable: ""` label.
 - An `EgressIP` object exists that defines one or more egress IP addresses to use as the source IP address for traffic leaving the cluster from pods in a namespace.
@@ -29,6 +27,11 @@ When creating an `EgressIP` object, the following conditions apply to nodes that
 * No node will ever host more than one of the specified IP addresses.
 * Traffic is balanced roughly equally between the specified IP addresses for a given namespace.
 - If a node becomes unavailable, any egress IP addresses assigned to it are automatically reassigned, subject to the previously described conditions.
+
+[IMPORTANT]
+====
+If the number of nodes labeled with `k8s.ovn.org/egress-assignable` is less than the number of egress IP addresses specified in the `EgressIP` object, the additional egress IP addresses remain unassigned. To ensure all specified egress IP addresses are active and traffic is balanced as expected, verify that the number of egress-assignable nodes is equal to or greater than the number of egress IP addresses defined in the `EgressIP` object.
+====
 
 When a pod matches the selector for multiple `EgressIP` objects, there is no guarantee which of the egress IP addresses that are specified in the `EgressIP` objects is assigned as the egress IP address for the pod.
 

--- a/modules/nw-egress-ips-considerations.adoc
+++ b/modules/nw-egress-ips-considerations.adoc
@@ -6,7 +6,10 @@
 [id="nw-egress-ips-considerations_{context}"]
 = Assignment of egress IPs to a namespace, nodes, and pods
 
-To assign one or more egress IPs to a namespace or specific pods in a namespace, the following conditions must be satisfied:
+[role="_abstract"]
+When assigning egress IPs to a namespace, nodes, or pods, specific conditions must be met. These conditions help route outbound network traffic through predictable source addresses and help maintain secure cluster communications.
+
+Before assigning one or more egress IPs to a namespace or specific pods in a namespace, ensure you meet the following conditions:
 
 - At least one node in your cluster must have the `k8s.ovn.org/egress-assignable: ""` label.
 - An `EgressIP` object exists that defines one or more egress IP addresses to use as the source IP address for traffic leaving the cluster from pods in a namespace.
@@ -15,7 +18,7 @@ To assign one or more egress IPs to a namespace or specific pods in a namespace,
 ====
 If you create `EgressIP` objects prior to labeling any nodes in your cluster for egress IP assignment, {product-title} might assign every egress IP address to the first node with the `k8s.ovn.org/egress-assignable: ""` label.
 
-To ensure that egress IP addresses are widely distributed across nodes in the cluster, always apply the label to the nodes you intent to host the egress IP addresses before creating any `EgressIP` objects.
+To help ensure that egress IP addresses are widely distributed across nodes in the cluster, always apply the label to the nodes you intent to host the egress IP addresses before creating any `EgressIP` objects.
 ====
 
 When creating an `EgressIP` object, the following conditions apply to nodes that are labeled with the `k8s.ovn.org/egress-assignable: ""` label:
@@ -26,6 +29,11 @@ When creating an `EgressIP` object, the following conditions apply to nodes that
 * No node will ever host more than one of the specified IP addresses.
 * Traffic is balanced roughly equally between the specified IP addresses for a given namespace.
 - If a node becomes unavailable, any egress IP addresses assigned to it are automatically reassigned, subject to the previously described conditions.
+
+[IMPORTANT]
+====
+If the number of nodes labeled with `k8s.ovn.org/egress-assignable` is less than the number of egress IP addresses specified in the `EgressIP` object, the additional egress IP addresses remain unassigned. To ensure all specified egress IP addresses are active and traffic is balanced as expected, verify that the number of egress-assignable nodes is equal to or greater than the number of egress IP addresses defined in the `EgressIP` object.
+====
 
 When a pod matches the selector for multiple `EgressIP` objects, there is no guarantee which of the egress IP addresses that are specified in the `EgressIP` objects is assigned as the egress IP address for the pod.
 


### PR DESCRIPTION
Version(s):
4.18+

Issue:
[OCPBUGS-86005](https://redhat.atlassian.net/browse/OCPBUGS-86005)

Link to docs preview:

* [Assignment of egress IPs to a namespace, nodes, and pods - core OCP](https://112046--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/configuring-egress-ips-ovn.html)
* [Assignment of egress IPs to a namespace, nodes, and pods - ROSA](https://112046--ocpdocs-pr.netlify.app/openshift-rosa/latest/networking/ovn_kubernetes_network_provider/configuring-egress-ips-ovn.html#nw-egress-ips-considerations_configuring-egress-ips-ovn)

- [x] SME has approved this change (Atharva Patil).
- [x] QE has approved this change (Jean Chen).
