### PR TITLE
OCPBUGS-86312: Nutanix docs for preloadedOSImageName and OS disk storage

### DIFF
--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -4353,6 +4353,15 @@ The name of one or more failures domains.
 |compute:
   platform:
     nutanix:
+      osDisk:
+        diskSizeGiB:
+|Configures the size of the compute machine VM system disk in GiB only. This parameter does not include `storageContainer`. To specify a storage container for additional disks, use `dataDisks[].storageConfig.storageContainer`.
+
+*Value:* Integer
+
+|compute:
+  platform:
+    nutanix:
       dataDisks:
         dataSourceImage:
           name:
@@ -4511,6 +4520,15 @@ The name of one or more failures domains.
 
 *Value:* String
 
+|controlPlane:
+  platform:
+    nutanix:
+      osDisk:
+        diskSizeGiB:
+|Configures the size of the control plane machine VM system disk in GiB only. This parameter does not include `storageContainer`. To specify a storage container for additional disks, use `dataDisks[].storageConfig.storageContainer`.
+
+*Value:* Integer
+
 |platform:
   nutanix:
     defaultMachinePlatform:
@@ -4566,6 +4584,15 @@ The name of one or more failures domains.
 |The boot type for all machines. You must use the `Legacy` boot type in {product-title} {product-version}. For more information on boot types, see link:https://portal.nutanix.com/page/documents/kbs/details?targetId=kA07V000000H3K9SAK[Understanding UEFI, Secure Boot, and TPM in the Virtualized Environment].
 
 *Value:* `Legacy`, `SecureBoot` or `UEFI`. The default is `Legacy`.
+
+|platform:
+  nutanix:
+    defaultMachinePlatform:
+      osDisk:
+        diskSizeGiB:
+|Configures the size of the VM system disk in GiB for all machine pools that do not override `osDisk` in their platform configuration. This parameter does not include `storageContainer`. To specify a storage container for additional disks, use `dataDisks[].storageConfig.storageContainer`.
+
+*Value:* Integer
 
 |platform:
   nutanix:
@@ -4630,6 +4657,10 @@ For more information on usage, see "Configuring a failure domain" in "Installing
     preloadedOSImageName:
 |Instead of creating and uploading a {op-system} image object for each {product-title} cluster, this parameter uses the named, preloaded {op-system} image object from the Prism Elements to which the {product-title} cluster is deployed.
 
+This parameter specifies the name of an existing {op-system} image in Prism Central. It does not configure the Nutanix storage container for cluster VM system disks. During installation, {product-title} creates each VM system disk from that image. Nutanix typically places the disk on the storage container where the image resides. If you upload the preloaded image to a non-default storage container (for example, instead of `SelfServiceContainer`), system disks may appear on that container. This placement follows from image location and Nutanix behavior, not from an OpenShift storage-container setting.
+
+{product-title} does not support changing the system disk storage container after installation via a MachineSet. To place additional disks on specific storage containers, configure `compute[].platform.nutanix.dataDisks` with `storageConfig.storageContainer` (and failure domain `referenceName` values when using failure domains).
+
 *Value:* String
 
 |platform:
@@ -4685,6 +4716,24 @@ For more information on usage, see "Configuring a failure domain" in "Installing
 1. The `prismElements` section holds a list of Prism Elements (clusters). A Prism Element encompasses all of the Nutanix resources, for example virtual machines and subnets, that are used to host the {product-title} cluster.
 2. A maximum of 32 subnets for each Prism Element in an {product-title} cluster is supported. All `subnetUUID` values must be unique.
 --
+
+[[nutanix-storage-placement_{context}]]
+=== Storage placement for Nutanix VMs
+
+Use the following summary when planning disk storage for Nutanix clusters:
+
+.Storage placement summary
+[cols="1,2",options="header"]
+|====
+|Disk | install-config control
+
+|System / OS disk
+|`osDisk.diskSizeGiB` only (under `controlPlane.platform.nutanix`, `compute.platform.nutanix`, or `platform.nutanix.defaultMachinePlatform`)
+
+|Additional data disks
+|`dataDisks` with `storageConfig.storageContainer` (and optional failure domain `referenceName`)
+|====
+
 endif::nutanix[]
 
 ifeval::["{context}" == "installation-config-parameters-vsphere"]


### PR DESCRIPTION
## Summary

- Clarify that `platform.nutanix.preloadedOSImageName` selects a preloaded RHCOS **image name** in Prism Central, not a Nutanix storage container for VM system disks.
- Document that system disks are created from the referenced image and Nutanix typically places them on the image's storage container (implicit placement, not an OpenShift storage-container API).
- Add `osDisk.diskSizeGiB` parameter rows for compute, control plane, and `defaultMachinePlatform` (size only; no `storageContainer`).
- Add "Storage placement for Nutanix VMs" summary table distinguishing system/OS disks vs additional data disks.

Jira: https://redhat.atlassian.net/browse/OCPBUGS-86312

## Files changed

- `modules/installation-configuration-parameters.adoc` (Nutanix `ifdef` block only)

## Test plan

- [ ] Nutanix install-config parameters page renders updated `preloadedOSImageName` text without implying storage-container selection
- [ ] New `osDisk.diskSizeGiB` rows appear under Additional Nutanix configuration parameters
- [ ] Storage placement summary table renders correctly
- [ ] Existing `dataDisks` / `storageContainer` documentation unchanged except cross-references in new text
- [ ] AsciiDoc builds cleanly (CI)

## Backport

Docs team: please advise on cherry-pick to `enterprise-4.18` through `enterprise-4.22` branches if required for supported releases.


Made with [Cursor](https://cursor.com)