### PR TITLE
OCPBUGS-87223: Add token-based auth prerequisite for oc adm upgrade recommend

### DIFF
--- a/modules/oc-adm-upgrade-recommend.adoc
+++ b/modules/oc-adm-upgrade-recommend.adoc
@@ -17,6 +17,17 @@ You can use the information provided by the output to make informed decisions ab
 .Prerequisites
 
 * You installed the latest version of {oc-first}.
+* You are logged in with a token-based identity, such as `kubeadmin`, by using the `oc login` command.
++
+[NOTE]
+====
+The `oc adm upgrade recommend` command requires a bearer token to query the cluster's Thanos monitoring service for firing alerts. Certificate-based authentication, such as the `system:admin` identity provided in the default `kubeconfig` file from the installation program, does not satisfy this requirement. If you use certificate-based authentication, the command output displays the following message and skips all alert-based precondition checks:
+
+[source,terminal]
+----
+Failed to check for at least some preconditions: no token is currently in use for this session
+----
+====
 
 .Procedure
 

--- a/modules/oc-adm-upgrade-recommend.adoc
+++ b/modules/oc-adm-upgrade-recommend.adoc
@@ -17,6 +17,14 @@ You can use the information provided by the output to make informed decisions ab
 .Prerequisites
 
 * You installed the latest version of {oc-first}.
+* You are logged in with a token-based identity, such as `kubeadmin`, by using the `oc login` command.
++
+[NOTE]
+====
+The `oc adm upgrade recommend` command requires a bearer token to query the cluster's Thanos monitoring service for firing alerts. Certificate-based authentication, such as the `system:admin` identity provided in the default `kubeconfig` file from the installer, does not satisfy this requirement. If you use certificate-based authentication, the command output displays the following message and skips all alert-based precondition checks:
+
+`Failed to check for at least some preconditions: no token is currently in use for this session`
+====
 
 .Procedure
 


### PR DESCRIPTION
## Summary

- Adds a prerequisite to the `oc adm upgrade recommend` documentation noting that token-based authentication (e.g., `oc login -u kubeadmin`) is required
- Documents that certificate-based auth (`system:admin` from the installer kubeconfig) causes the command to silently skip all alert-based precondition checks
- Includes the exact error message users see so it is searchable

## Context

Found during OCP 4.22 pre-GA hackathon testing of OCPSTRAT-2781. The Thanos monitoring route uses `kube-rbac-proxy` with TokenReview-based auth only (no `--client-ca-file` on port 9091), so certificate-based authentication is structurally impossible ([source](https://github.com/openshift/oc/blob/master/pkg/cli/admin/inspectalerts/inspectalerts.go#L97-L104)).

**Root cause discussed with OTA maintainer (W Trevor King):** The real fix belongs to the monitoring team — either providing a dedicated Thanos-access SA or adding `--client-ca-file` to kube-rbac-proxy-web. OTA should not hardcode SA assumptions. This doc PR is a band-aid documenting the current token requirement.

- Monitoring docs reference: [Accessing monitoring APIs by using the CLI](https://docs.redhat.com/en/documentation/monitoring_stack_for_red_hat_openshift/4.21/html/accessing_metrics/accessing-monitoring-apis-by-using-the-cli)

## Test plan

- [x] Verified on OCP 4.22.0-rc.4 that `system:admin` produces `Failed to check for at least some preconditions: no token is currently in use for this session`
- [x] Verified that `oc login -u kubeadmin` resolves the issue and all precheck categories are displayed
- [x] Verified API server proxy to thanos-querier returns 401 (kube-rbac-proxy-web has no `--client-ca-file`)
- [x] Verified `oc create token <SA>` works from cert auth but choosing the right SA is a monitoring team decision

Fixes: https://redhat.atlassian.net/browse/OCPBUGS-87223