### PR TITLE
OSDOCS MCO boot image skew enforcement add not in SNO note

### DIFF
--- a/machine_configuration/mco-update-boot-skew-mgmt.adoc
+++ b/machine_configuration/mco-update-boot-skew-mgmt.adoc
@@ -9,6 +9,11 @@ toc::[]
 [role="_abstract"]
 You can use boot image skew enforcement to help ensure that the boot images in a cluster are up-to-date with the {product-title} and {op-system} version being used in the cluster. Using an older boot image could cause issues when scaling new nodes. If the images are older than a predetermined version, the MCO disables cluster upgrades until it deems the boot images to be compliant.
 
+[NOTE]
+====
+Boot image skew enforcement is not supported for {sno} clusters.
+====
+
 include::modules/mco-update-boot-skew-mgmt-about.adoc[leveloffset=+1]
 
 include::modules/mco-update-boot-skew-mgmt-modes.adoc[leveloffset=+2]


### PR DESCRIPTION
Documenting https://redhat.atlassian.net/browse/MCO-2145. Enhancement to https://issues.redhat.com/browse/OSDOCS-18143

Preview:
[Boot image skew enforcement](https://112093--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_configuration/mco-update-boot-skew-mgmt.html) -- Added note after first paragraph

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
