### PR TITLE
OSDOCS-19866:Update the z-stream RNs for 4.19.32

### DIFF
--- a/modules/zstream-4-19-31.adoc
+++ b/modules/zstream-4-19-31.adoc
@@ -31,4 +31,3 @@ There are no notable fixed issues in this release.
 To update an {product-title} 4.19 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
 
 
-

--- a/modules/zstream-4-19-32.adoc
+++ b/modules/zstream-4-19-32.adoc
@@ -1,0 +1,58 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-19-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-19-32_{context}"]
+= RHSA-2026:20041 - {product-title} {product-version}.32 fixed issues and security update
+
+Issued: 27 May 2026
+
+[role="_abstract"]
+{product-title} release {product-version}.32 is now available. The list of fixed issues that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2026:20041[RHSA-2026:20041] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2026:20039[RHBA-2026:20039] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.19.32 --pullspecs
+----
+
+[id="zstream-4-19-32-enhancements_{context}"]
+== Enhancements
+
+* With this release, the must-gather will now collect the total size of every kind of resources in etcd. This enhancement helps address many control plane troubleshooting scenarios. (link:https://redhat.atlassian.net/browse/OCPBUGS-85578[OCPBUGS-85578])
+
+[id="zstream-4-19-32-known-issues_{context}"]
+== Known issues
+
+* On certain Telecom Grandmaster (T-GM) systems, an {product-title} node reboot can trigger a change in the Global Navigation Satellite System (GNSS) device name. This prevents the T-GM from achieving a locked state because the configuration points to a static, stale device path. To workaround this problem, omit the `ts2phc.nmea_serialport` setting from the `ts2phcConf` section of the `PtpConfig` resource. (link:https://redhat.atlassian.net/browse/OCPBUGS-77747[OCPBUGS-77747])
+
+[id="zstream-4-19-32-fixed-issues_{context}"]
+== Fixed issues
+
+* Before this update, enabling the `routingViaHost: true` and `ipForwarding: Global` parameters on a {hcp} Kubevirt guest cluster caused the console and ingress Cluster Operators to become degraded. As a consequence, route health checks from within the cluster would fail, even though ingress routes remained accessible from external clients. This issue occurred due to a routing conflict when both the management cluster and the {hcp} guest cluster had the `routingViaHost: true` parameter enabled. With this release, the fix ensures that {hcp} Kubevirt guest clusters use the subnet gateway IP as the default gateway. As a result, the routing conflict is resolved and the console and ingress Cluster Operators are allowed to remain healthy when these networking features are enabled. (link:https://redhat.atlassian.net/browse/OCPBUGS-74397[OCPBUGS-74397])
+
+* Before this update, creating snapshots of large {azure-first} `UltraSSD_LRS` or `PremiumV2_LRS` persistent volumes could fail due to a hard coded 10-minute timeout in the Container Storage Interface (CSI) driver, which was insufficient for the {azure-short} background copy process on large disks. With this release, the {azure-short} Disk CSI driver supports instant access snapshots which are configurable via the `instantAccessDurationMinutes` parameter in the `VolumeSnapshotClass`. As a result, snapshot operations on large volumes are successfully completed. (link:https://redhat.atlassian.net/browse/OCPBUGS-78035[OCPBUGS-78035])
+
+* Before this update, secrets containing a mix of text and binary values would trigger a runtime error in the edit form because the `stringData` initialization logic returned null when encountering any binary data. With this release, the system is updated to retain string data as it iterates over fields, even if a binary field is encountered. As a result, mixed-type secrets can be edited seamlessly without causing application crashes. (link:https://redhat.atlassian.net/browse/OCPBUGS-81738[OCPBUGS-81738])
+
+* Before this update, when the cluster `Authentication` resource was configured with the `type: None` parameter, any OAuth metadata specified by the `spec.oauthMetadata` field was silently ignored. As a consequence, the Console Operator would unconditionally delete the OAuth metadata `ConfigMap` object and unset the `oauthMetadataFile` field, even if a valid `ConfigMap` object reference was provided. This issue could have caused the Console Operator to become degraded, because console pods could not build the OAuth cache due to missing OAuth metadata from the Kubernetes API. With this release, the `spec.oauthMetadata` field is respected when the `type: None` parameter is set. If the field references a `ConfigMap` object, it syncs and is served by the kube-apiserver. If the field is left empty, the existing behavior is unchanged. (link:https://redhat.atlassian.net/browse/OCPBUGS-83857[OCPBUGS-83857])
+
+* Before this update, the Cluster Network Operator (CNO) waited indefinitely for the compute node rollout. As a consequence, the `ovnkube-control-plane` pod was blocked from updating even when no compute nodes were present. With this release, control-plane upgrades can complete successfully in zero-worker {hcp} clusters. (link:https://redhat.atlassian.net/browse/OCPBUGS-84177[OCPBUGS-84177])
+
+* Before this update, when you clicked the *Status*, *Size*, or *Source* column headings in the `VolumeSnapshot` and `VolumeSnapshotContent` tables, the sort order did not change. With this release, these columns now sort correctly when you click their headings. (link:https://redhat.atlassian.net/browse/OCPBUGS-84271[OCPBUGS-84271])
+
+* Before this update, the web console did not serve a `robots.txt` file, which meant search engine crawlers had no explicit instruction to avoid indexing console pages. With this release, the web console serves a `robots.txt` file that disallows all crawlers. As a result, search engines are instructed not to index any web console pages. (link:https://redhat.atlassian.net/browse/OCPBUGS-84772[OCPBUGS-84772])
+
+* Before this update, the egress IP address was incorrectly assigned to the `br-ex` bridge when you configured additional interfaces. This issue caused egress IP address assignment conflicts and routing issues with unexpected traffic paths. With this release, the egress IP address is not assigned to the `br-ex` bridge. As a result, the egress IP address is correctly assigned to the secondary interface, which resolves routing conflicts. (link:https://redhat.atlassian.net/browse/OCPBUGS-85355[OCPBUGS-85355])
+
+[id="zstream-4-19-32-updating_{context}"]
+== Updating
+
+To update an {product-title} 4.19 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
+
+

--- a/release_notes/ocp-4-19-release-notes.adoc
+++ b/release_notes/ocp-4-19-release-notes.adoc
@@ -2977,6 +2977,9 @@ To save the `vmcore` file, use the `crashkernel` setting to reserve 1024 MB of m
 // 4.19.z about errata updates
 include::modules/ocp-release-asynch-errata-updates.adoc[leveloffset=+1]
 
+// 4.19.32 z-stream RNs full document
+include::modules/zstream-4-19-32.adoc[leveloffset=+2]
+
 // 4.19.31 z-stream RNs full document
 include::modules/zstream-4-19-31.adoc[leveloffset=+2]
 


### PR DESCRIPTION
Version(s):
4.19

Issue:
https://redhat.atlassian.net/browse/OSDOCS-19866

Link to docs preview:
https://112108--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-19-release-notes.html#zstream-4-19-32_release-notes

Additional information:
4.19.32 MR: https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/546
ART Dashboard: https://art-dash.engineering.redhat.com/dashboard/release/openshift-4.19
