### PR TITLE
OSDOCS-19860: Remove DAS from topic map

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -3632,8 +3632,6 @@ Topics:
   File: gaudi-ai-accelerator
 - Name: Remote Direct Memory Access (RDMA)
   File: rdma-remote-direct-memory-access
-- Name: Dynamic Accelerator Slicer (DAS) Operator
-  File: das-about-dynamic-accelerator-slicer-operator
 ---
 Name: Backup and restore
 Dir: backup_and_restore


### PR DESCRIPTION
[OCPSTRAT-2891]Deprecation and Removal of Dynamic Accelerator Slicer (DAS) in OCP 4.22

Version: 4.22
[Planned for 4.22 GA](https://github.com/openshift/openshift-docs/milestone/212)

Jira: https://redhat.atlassian.net/browse/OSDOCS-19860

Preview:

**Note to reviewers:** No new documentation. Dynamic Accelerator Slicer (DAS) topics removed from the topic map.