### PR TITLE
OSDOCS-17814-RN BMaaS GA release note

### DIFF
--- a/modules/rn-ocp-release-notes-new-features.adoc
+++ b/modules/rn-ocp-release-notes-new-features.adoc
@@ -312,7 +312,7 @@ For more information, see xref:../machine_configuration/machine-configs-custom.a
 
 CPU resource enforcement is now enabled by default::
 +
-With this update, the `system-reserved-compressible` parameter is enabled for all clusters that do not use the reserved CPU feature. This addresses previous issues where the system reserved CPU exceeded the desired limit. This default can be overridden by configuring the `systemReservedCPU: ""` parameter in a kubelet configuration. 
+With this update, the `system-reserved-compressible` parameter is enabled for all clusters that do not use the reserved CPU feature. This addresses previous issues where the system reserved CPU exceeded the desired limit. This default can be overridden by configuring the `systemReservedCPU: ""` parameter in a kubelet configuration.
 +
 For more information, see xref:../nodes/nodes/nodes-nodes-resources-configuring.adoc#system-reserved-compressible_nodes-nodes-resources-configuring[How {product-title} enforces system-reserved CPU].
 
@@ -330,7 +330,7 @@ For more information, see xref:../nodes/nodes/nodes-nodes-additional-crio-storag
 
 Project-scoped image pull secrets for mirrored registries (Technology Preview)::
 +
-With this update, you can pull images from mirrored registries by using project-scoped pull secrets as a technology preview feature. Before this update, you needed to use node-level secrets when pulling from a mirrored registry because the kublet does not recognize the mirror configuration, which is configured at the container-runtime level. 
+With this update, you can pull images from mirrored registries by using project-scoped pull secrets as a technology preview feature. Before this update, you needed to use node-level secrets when pulling from a mirrored registry because the kublet does not recognize the mirror configuration, which is configured at the container-runtime level.
 +
 For more information, see xref:../openshift_images/image-configuration.adoc#images-configuration-registry-mirror-project-secret_image-configuration[Configuring project-scoped image pull secrets for mirrored registries].
 
@@ -376,6 +376,10 @@ With this release, the Peripheral Component Interconnect (PCI) address for each 
 +
 For more information, see xref:../installing/installing_bare_metal/bare-metal-postinstallation-configuration.adoc#bmo-about-the-baremetalhost-resource_bare-metal-postinstallation-configuration[About the BareMetalHost resource] and xref:../installing/installing_bare_metal/bare-metal-postinstallation-configuration.adoc#the-baremetalhost-status[The BareMetalHost status].
 
+{bmaas-first} is generally available::
++
+With this update, {bmaas-first}, formerly known as Bare Metal as a Service (BMaaS), is generally available. You can provision and manage bare-metal hosts by using the Metal^3^ API and the Bare Metal Operator (BMO). These hosts, external to the {product-title} cluster, can run workloads that might not be suitable for containerization or virtualization, such as legacy applications or applications that require direct hardware access. For more information, see xref:../installing/installing_bare_metal/bare-metal-using-bare-metal-as-a-service.adoc#bare-metal-using-bare-metal-as-a-service[Using {bmaas-first}].
+
 Expanding bare-metal clusters using OCI images and {bmaas-first} (Technology Preview)::
 +
 With this update, you can expand your bare-metal cluster using {bmaas-first} with images from an OCI registry as a Technology Preview feature. You can use images from public OCI registries or from the built-in cluster registry. For more information, see xref:../installing/installing_bare_metal/bare-metal-using-bare-metal-as-a-service.adoc[Using Red Hat Bare Metal as a Service for OpenShift].
@@ -412,11 +416,11 @@ Support for the numad package::
 With this update, the numad package is supported. numad is an automatic NUMA affinity management daemon. It monitors NUMA topology and resource usage within a system that dynamically improves NUMA resource allocation, management, and system performance.
 //https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9/html/monitoring_and_managing_system_status_and_performance/overview-of-performance-monitoring-options
 
-//// 
+////
 Not documenting per Mark Russell via Ashley Hardin
 Support for Fibre Channel over Ethernet (FCoE)::
 +
-With this update, the Fibre Channel over Ethernet (FCoE) protocol is supported for clusters running the x86_64 architecture. FCoE in {op-system} consists of the following packages: 
+With this update, the Fibre Channel over Ethernet (FCoE) protocol is supported for clusters running the x86_64 architecture. FCoE in {op-system} consists of the following packages:
 +
 --
 // From https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/6/html/6.4_technical_notes/fcoe-utils

--- a/modules/rn-ocp-release-notes-technology-preview.adoc
+++ b/modules/rn-ocp-release-notes-technology-preview.adoc
@@ -163,7 +163,7 @@ In the following tables, features are marked with the following statuses:
 |General Availability
 |General Availability
 
-|Using bare metal as a service
+|{bmaas-first} (formerly known as bare metal as a service)
 |Technology Preview
 |Technology Preview
 |General Availability


### PR DESCRIPTION
Version(s):
4.22

Issue:
https://redhat.atlassian.net/browse/OSDOCS-17814

Link to docs preview:
https://112115--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-22-release-notes.html#ocp-release-notes-post-install-configuration_release-notes
https://112115--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-22-release-notes.html#ocp-release-notes-installing-tech-preview_release-notes

QE review:
- [x] QE has approved this change.

This PR also fixed the link to the other bare metal as a service release note.