### PR TITLE
OSDOCS-18105 [ROSA]: New Feature Log Forwarding in UI 

### DIFF
--- a/modules/rosa-create-cluster-log-forwarding-ui-day1.adoc
+++ b/modules/rosa-create-cluster-log-forwarding-ui-day1.adoc
@@ -32,7 +32,7 @@ In about 20 minutes after you complete this information, your cluster is ready t
 .. If you enable Amazon `S3`, complete the following fields:
 +
 * *Bucket name*: Give it a unique identifier across all of {AWS}.
-* *Bucket prefix*: Give it an optional path to organize your data
+* *Bucket prefix*: Give it an optional path to organize your data.
 * *Select groups and applications* (optional): When you select a group, the log forwarder collects all the applications and related services from that group
 .. If you enable `CloudWatch`, complete the following fields:
 +

--- a/modules/rosa-create-cluster-log-forwarding-ui-day1.adoc
+++ b/modules/rosa-create-cluster-log-forwarding-ui-day1.adoc
@@ -12,7 +12,7 @@ You can set up control plane log forwarding when you create your {product-title}
 
 . In the {hybrid-console}, go to *Clusters* -> *Cluster List*, then click the *Create cluster* button.
 . On the *Managed services* offerings page, go to the offering, *Red Hat OpenShift Service on AWS (ROSA)*, and click the *Create cluster* button, then select *With web interface*.
-. For the *Create a ROSA Cluster* -> *Control plane*,  select your *ROSA hosted architecture*.
+. For *Create a ROSA Cluster* -> *Control plane*, select your *ROSA hosted architecture*.
 . For *Accounts and roles*, select your *Associated AWS infrastructure account* and *AWS billing account*.
 . For the *Cluster settings* -> *Cluster details*, complete the following text boxes:
 +

--- a/modules/rosa-create-cluster-log-forwarding-ui-day1.adoc
+++ b/modules/rosa-create-cluster-log-forwarding-ui-day1.adoc
@@ -31,7 +31,7 @@ In about 20 minutes after you complete this information, your cluster is ready t
 .. On the *Control plane log forwarding (optional)* page, click *Enable Amazon S3*, or *Enable CloudWatch*, or both.
 .. If you enable Amazon `S3`, complete the following fields:
 +
-* *Bucket name*: Give it a unique identifier across all of {AWS}
+* *Bucket name*: Give it a unique identifier across all of {AWS}.
 * *Bucket prefix*: Give it an optional path to organize your data
 * *Select groups and applications* (optional): When you select a group, the log forwarder collects all the applications and related services from that group
 .. If you enable `CloudWatch`, complete the following fields:

--- a/modules/rosa-create-cluster-log-forwarding-ui-day1.adoc
+++ b/modules/rosa-create-cluster-log-forwarding-ui-day1.adoc
@@ -25,7 +25,7 @@ You can set up control plane log forwarding when you create your {product-title}
 
 + 
 In about 20 minutes after you complete this information, your cluster is ready to install and you can continue to configure it.
-. For *Machine pool* -> *Networking* -> *Configuration* -> *CIDR ranges* -> *Cluster roles and policies*, complete all the required text boxes with the specifications that you want for your cluster.
+. For *Machine pool* -> *Networking* -> *Configuration* -> *CIDR ranges* -> *Cluster roles and policies*, complete all of the required text boxes with the specifications that you want for your cluster.
 . On the *Review and create* -> *Review your ROSA cluster* page, verify that all the information and details are what you want your cluster to include.
 . *Optional*: If you want to forward your control plane logs fo an Amazon `S3` bucket or `CloudWatch` log group, complete the following instructions:
 .. On the *Control plane log forwarding (optional)* page, click *Enable Amazon S3*, or *Enable CloudWatch*, or both.

--- a/modules/rosa-create-cluster-log-forwarding-ui-day1.adoc
+++ b/modules/rosa-create-cluster-log-forwarding-ui-day1.adoc
@@ -1,0 +1,41 @@
+// Module included in the following assemblies:
+//
+// * observability/logging/rosa-forwarding-control-plane-logs.adoc
+:_mod-docs-content-type: PROCEDURE
+[id="rosa-create-cluster-log-forwarding-ui-day1_{context}"]
+= Creating a {product-title} cluster with log forwarding for Day 1
+
+[role="_abstract"]
+On Day 1, you create your {product-title} cluster in the {hybrid-console} and you can set up control plane log forwarding. As you create your {product-title} cluster, you have the option to forward your control plan logs to an Amazon `S3` bucket, `CloudWatch` log group, or both. If you do not want to forward your control plan logs to an Amazon `S3` bucket or a `CloudWatch` log group, you do not need to complete those instructions.
+
+.Procedure
+
+. In the {hybrid-console}, go to *Clusters* -> *Cluster List*, then click the *Create cluster* button.
+. On the *Managed services* offerings page, go to the offering, *Red Hat OpenShift Service on AWS (ROSA)*, and click the *Create cluster* button, then select *With web interface*.
+. For the *Create a ROSA Cluster* -> *Control plane*,  select your *ROSA hosted architecture*.
+. For *Accounts and roles*, select your *Associated AWS infrastructure account* and *AWS billing account*.
+. For the *Cluster settings* -> *Cluster details*, complete the following text boxes:
++
+* *Region*
+* *Cluster name*
+* *Version*
+* *Channel*
+* In about 20 minutes after you complete this information, your cluster is ready to build and you are taken to all the other necessary pages.
+. For *Machine pool* -> *Networking* -> *Configuration* -> *CIDR ranges* -> *Cluster roles and policies*, complete all the required text boxes with the specifications that you want for your cluster.
+. On the *Review and create* -> *Review your ROSA cluster* page, verify that all the information and details are what you want your cluster to include.
+. *Optional*: If you want to forward your control plane logs fo an Amazon `S3` bucket or `CloudWatch` log group, complete the following instructions:
+.. On the *Control plane log forwarding (optional)* page, click *Enable Amazon S3*, or *Enable CloudWatch*, or both.
+.. If you enable Amazon `S3`, complete the following fields:
++
+* *Bucket name*: Give it a unique identifier across all of {AWS}
+* *Bucket prefix*: Give it an optional path to organize your data
+* *Select groups and applications* (optional): When you select a group, the log forwarder collects all the applications and related services from that group
+.. If you enable `CloudWatch`, complete the following fields:
++
+* *Prerequisite*: Verify that you have created an `IAM` role and policy, then click the box stating that you have
+* *Log group name*: Give it a unique identifier
+* *Role ARN*: Give the `IAM` role ARN. For example, `arn:aws:iam::<12-digit-account-id>:role/<role-name>`
+* *Select groups and applications*: When you select a group, the log forwarder collects all the applications and related services from that group
+.. On the *Review and create* -> *Review your ROSA cluster* page, verify that all the information and details are what you want your cluster to include.
+.. Click the *Create cluster* button.
+. If you want to finish completing your cluster with no designated log forwarding destination, click the *Create cluster* button.

--- a/modules/rosa-create-cluster-log-forwarding-ui-day1.adoc
+++ b/modules/rosa-create-cluster-log-forwarding-ui-day1.adoc
@@ -20,7 +20,11 @@ You can set up control plane log forwarding when you create your {product-title}
 * *Cluster name*
 * *Version*
 * *Channel*
-* In about 20 minutes after you complete this information, your cluster is ready to build and you are taken to all the other necessary pages.
+...
+* *Channel*
+
++ 
+In about 20 minutes after you complete this information, your cluster is ready to install and you can continue to configure it.
 . For *Machine pool* -> *Networking* -> *Configuration* -> *CIDR ranges* -> *Cluster roles and policies*, complete all the required text boxes with the specifications that you want for your cluster.
 . On the *Review and create* -> *Review your ROSA cluster* page, verify that all the information and details are what you want your cluster to include.
 . *Optional*: If you want to forward your control plane logs fo an Amazon `S3` bucket or `CloudWatch` log group, complete the following instructions:

--- a/modules/rosa-create-cluster-log-forwarding-ui-day1.adoc
+++ b/modules/rosa-create-cluster-log-forwarding-ui-day1.adoc
@@ -33,7 +33,7 @@ In about 20 minutes after you complete this information, your cluster is ready t
 +
 * *Bucket name*: Give it a unique identifier across all of {AWS}.
 * *Bucket prefix*: Give it an optional path to organize your data.
-* *Select groups and applications* (optional): When you select a group, the log forwarder collects all the applications and related services from that group
+* *Select groups and applications* (optional): When you select a group, the log forwarder collects all of the applications and related services from that group
 .. If you enable `CloudWatch`, complete the following fields:
 +
 * *Prerequisite*: Verify that you have created an `IAM` role and policy, then click the box stating that you have

--- a/modules/rosa-create-cluster-log-forwarding-ui-day1.adoc
+++ b/modules/rosa-create-cluster-log-forwarding-ui-day1.adoc
@@ -6,7 +6,7 @@
 = Creating a {product-title} cluster with log forwarding for Day 1
 
 [role="_abstract"]
-On Day 1, you create your {product-title} cluster in the {hybrid-console} and you can set up control plane log forwarding. As you create your {product-title} cluster, you have the option to forward your control plan logs to an Amazon `S3` bucket, `CloudWatch` log group, or both. If you do not want to forward your control plan logs to an Amazon `S3` bucket or a `CloudWatch` log group, you do not need to complete those instructions.
+You can set up control plane log forwarding when you create your {product-title} cluster in the {hybrid-console}. As you create your {product-title} cluster, you have the option to forward your control plane logs to an Amazon `S3` bucket, `CloudWatch` log group, or both. If you do not want to forward your control plan logs to an Amazon `S3` bucket or a `CloudWatch` log group, you do not need to complete those instructions.
 
 .Procedure
 

--- a/modules/rosa-create-cluster-log-forwarding-ui-day1.adoc
+++ b/modules/rosa-create-cluster-log-forwarding-ui-day1.adoc
@@ -27,7 +27,7 @@ You can set up control plane log forwarding when you create your {product-title}
 In about 20 minutes after you complete this information, your cluster is ready to install and you can continue to configure it.
 . For *Machine pool* -> *Networking* -> *Configuration* -> *CIDR ranges* -> *Cluster roles and policies*, complete all of the required text boxes with the specifications that you want for your cluster.
 . On the *Review and create* -> *Review your ROSA cluster* page, verify that the cluster details are correct.
-. *Optional*: If you want to forward your control plane logs fo an Amazon `S3` bucket or `CloudWatch` log group, complete the following instructions:
+. *Optional*: If you want to forward your control plane logs to an Amazon `S3` bucket or `CloudWatch` log group, complete the following instructions:
 .. On the *Control plane log forwarding (optional)* page, click *Enable Amazon S3*, or *Enable CloudWatch*, or both.
 .. If you enable Amazon `S3`, complete the following fields:
 +

--- a/modules/rosa-create-cluster-log-forwarding-ui-day1.adoc
+++ b/modules/rosa-create-cluster-log-forwarding-ui-day1.adoc
@@ -26,7 +26,7 @@ You can set up control plane log forwarding when you create your {product-title}
 + 
 In about 20 minutes after you complete this information, your cluster is ready to install and you can continue to configure it.
 . For *Machine pool* -> *Networking* -> *Configuration* -> *CIDR ranges* -> *Cluster roles and policies*, complete all of the required text boxes with the specifications that you want for your cluster.
-. On the *Review and create* -> *Review your ROSA cluster* page, verify that all the information and details are what you want your cluster to include.
+. On the *Review and create* -> *Review your ROSA cluster* page, verify that the cluster details are correct.
 . *Optional*: If you want to forward your control plane logs fo an Amazon `S3` bucket or `CloudWatch` log group, complete the following instructions:
 .. On the *Control plane log forwarding (optional)* page, click *Enable Amazon S3*, or *Enable CloudWatch*, or both.
 .. If you enable Amazon `S3`, complete the following fields:

--- a/modules/rosa-create-cluster-log-forwarding-ui-day1.adoc
+++ b/modules/rosa-create-cluster-log-forwarding-ui-day1.adoc
@@ -40,6 +40,6 @@ In about 20 minutes after you complete this information, your cluster is ready t
 * *Log group name*: Give it a unique identifier
 * *Role ARN*: Give the `IAM` role ARN. For example, `arn:aws:iam::<12-digit-account-id>:role/<role-name>`
 * *Select groups and applications*: When you select a group, the log forwarder collects all the applications and related services from that group
-.. On the *Review and create* -> *Review your ROSA cluster* page, verify that all the information and details are what you want your cluster to include.
+.. On the *Review and create* -> *Review your ROSA cluster* page, verify that the cluster details are correct.
 .. Click the *Create cluster* button.
 . If you want to finish completing your cluster with no designated log forwarding destination, click the *Create cluster* button.

--- a/modules/rosa-create-cluster-log-forwarding-ui-day1.adoc
+++ b/modules/rosa-create-cluster-log-forwarding-ui-day1.adoc
@@ -3,7 +3,7 @@
 // * observability/logging/rosa-forwarding-control-plane-logs.adoc
 :_mod-docs-content-type: PROCEDURE
 [id="rosa-create-cluster-log-forwarding-ui-day1_{context}"]
-= Creating a {product-title} cluster with log forwarding for Day 1
+= Creating a {product-title} cluster with log forwarding
 
 [role="_abstract"]
 You can set up control plane log forwarding when you create your {product-title} cluster in the {hybrid-console}. As you create your {product-title} cluster, you have the option to forward your control plane logs to an Amazon `S3` bucket, `CloudWatch` log group, or both. If you do not want to forward your control plan logs to an Amazon `S3` bucket or a `CloudWatch` log group, you do not need to complete those instructions.

--- a/modules/rosa-create-cluster-ui-log-forwarding.adoc
+++ b/modules/rosa-create-cluster-ui-log-forwarding.adoc
@@ -1,0 +1,13 @@
+// Module included in the following assemblies:
+//
+// * observability/logging/rosa-configuring-the-log-forwarder.adoc
+:_mod-docs-content-type: CONCEPT
+[id="rosa-create-cluster-ui-log-groups_{context}"]
+= Creating a {product-title} cluster in the {hybrid-console}
+
+[role="_abstract"]
+You can forward logs from your {product-title} cluster to `CloudWatch`, `S3`, or both. When you forward your control plane logs, you can store them in the infrastructure that you designated, helping you meet compliance and audit requirements and workflows. 
+
+In the {hybrid-console}, you set up your {product-title} cluster to forward control plane logs on Day 1. Then, you can continue to use the web user interface (UI) for all your control plane logs forwarding needs. 
+
+*Note*: For full audit visibility, it is recommended that you enable the control plane log forwarding  feature on Day 1. On Day 2, you can still enable the control plane log forwarding feature but you have the limitations. The log forwarding feature cannot retrieve logs created before you enabled this feature, resulting in data and audit gaps among logs created before and after you enabled the forwarding feature. 

--- a/modules/rosa-create-cluster-ui-log-forwarding.adoc
+++ b/modules/rosa-create-cluster-ui-log-forwarding.adoc
@@ -8,6 +8,6 @@
 [role="_abstract"]
 You can forward logs from your {product-title} cluster to `CloudWatch`, `S3`, or both. When you forward your control plane logs, you can store them in the infrastructure that you designated, helping you meet compliance and audit requirements and workflows. 
 
-In the {hybrid-console}, you set up your {product-title} cluster to forward control plane logs on Day 1. Then, you can continue to use the web user interface (UI) for all your control plane logs forwarding needs. 
+In the {hybrid-console}, you set up your {product-title} cluster to forward control plane logs when you create the cluster. Then, you can continue to use the web user interface (UI) to forward your control plane logs.
 
 *Note*: For full audit visibility, it is recommended that you enable the control plane log forwarding  feature on Day 1. On Day 2, you can still enable the control plane log forwarding feature but you have the limitations. The log forwarding feature cannot retrieve logs created before you enabled this feature, resulting in data and audit gaps among logs created before and after you enabled the forwarding feature. 

--- a/modules/rosa-create-cluster-ui-log-forwarding.adoc
+++ b/modules/rosa-create-cluster-ui-log-forwarding.adoc
@@ -10,4 +10,4 @@ You can forward logs from your {product-title} cluster to `CloudWatch`, `S3`, or
 
 In the {hybrid-console}, you set up your {product-title} cluster to forward control plane logs when you create the cluster. Then, you can continue to use the web user interface (UI) to forward your control plane logs.
 
-*Note*: For full audit visibility, it is recommended that you enable the control plane log forwarding  feature on Day 1. On Day 2, you can still enable the control plane log forwarding feature but you have the limitations. The log forwarding feature cannot retrieve logs created before you enabled this feature, resulting in data and audit gaps among logs created before and after you enabled the forwarding feature. 
+Enable control plane log forwarding when you create the cluster to ensure a complete audit trail. If enabled later, the feature cannot capture logs generated prior to activation, leaving gaps in your data.

--- a/modules/rosa-view-cluster-log-forwarding-ui-day2.adoc
+++ b/modules/rosa-view-cluster-log-forwarding-ui-day2.adoc
@@ -6,7 +6,7 @@
 = Viewing a {product-title} cluster with log forwarding
 
 [role="_abstract"]
-On Day 2, you can view the statuses of log forwarding for clusters that you created on Day 1.
+You can verify the status of log forwarding for a cluster.
 
 .Procedure
 

--- a/modules/rosa-view-cluster-log-forwarding-ui-day2.adoc
+++ b/modules/rosa-view-cluster-log-forwarding-ui-day2.adoc
@@ -3,7 +3,7 @@
 // * observability/logging/rosa-forwarding-control-plane-logs.adoc
 :_mod-docs-content-type: PROCEDURE
 [id="rosa-view-cluster-log-forwarding-ui-day2_{context}"]
-= Viewing a {product-title} cluster with log forwarding for Day 2
+= Viewing a {product-title} cluster with log forwarding
 
 [role="_abstract"]
 On Day 2, you can view the statuses of log forwarding for clusters that you created on Day 1.

--- a/modules/rosa-view-cluster-log-forwarding-ui-day2.adoc
+++ b/modules/rosa-view-cluster-log-forwarding-ui-day2.adoc
@@ -12,5 +12,5 @@ You can verify the status of log forwarding for a cluster.
 
 . In the {hybrid-console}, go to *Clusters* -> *Cluster List*. You can see the name and status of your cluster.
 . Verify that the status of your clusters is “Ready” and then click the name of your cluster.
-. Go to the *Overview* tab and verify that the details of your cluster are what you provided and specified on Day 1.
+. Go to the *Overview* tab and verify that the details of your cluster are what you provided and specified when you created the cluster.
 . If you enabled *Amazon S3* or *CloudWatch*, go to the *Settings* -> *Control plane log forwarding* tab, and verify that the listed information is what you provided and specified on Day 1. 

--- a/modules/rosa-view-cluster-log-forwarding-ui-day2.adoc
+++ b/modules/rosa-view-cluster-log-forwarding-ui-day2.adoc
@@ -11,6 +11,6 @@ You can verify the status of log forwarding for a cluster.
 .Procedure
 
 . In the {hybrid-console}, go to *Clusters* -> *Cluster List*. You can see the name and status of your cluster.
-. Verify that the status of your clusters is “Ready” and click on the name of your cluster.
+. Verify that the status of your clusters is “Ready” and then click the name of your cluster.
 . Go to the *Overview* tab and verify that the details of your cluster are what you provided and specified on Day 1.
 . If you enabled *Amazon S3* or *CloudWatch*, go to the *Settings* -> *Control plane log forwarding* tab, and verify that the listed information is what you provided and specified on Day 1. 

--- a/modules/rosa-view-cluster-log-forwarding-ui-day2.adoc
+++ b/modules/rosa-view-cluster-log-forwarding-ui-day2.adoc
@@ -1,0 +1,16 @@
+// Module included in the following assemblies:
+//
+// * observability/logging/rosa-forwarding-control-plane-logs.adoc
+:_mod-docs-content-type: PROCEDURE
+[id="rosa-view-cluster-log-forwarding-ui-day2_{context}"]
+= Viewing a {product-title} cluster with log forwarding for Day 2
+
+[role="_abstract"]
+On Day 2, you can view the statuses of log forwarding for clusters that you created on Day 1.
+
+.Procedure
+
+. In the {hybrid-console}, go to *Clusters* -> *Cluster List*. You can see the name and status of your cluster.
+. Verify that the status of your clusters is “Ready” and click on the name of your cluster.
+. Go to the *Overview* tab and verify that the details of your cluster are what you provided and specified on Day 1.
+. If you enabled *Amazon S3* or *CloudWatch*, go to the *Settings* -> *Control plane log forwarding* tab, and verify that the listed information is what you provided and specified on Day 1. 

--- a/modules/rosa-view-cluster-log-forwarding-ui-day2.adoc
+++ b/modules/rosa-view-cluster-log-forwarding-ui-day2.adoc
@@ -13,4 +13,4 @@ You can verify the status of log forwarding for a cluster.
 . In the {hybrid-console}, go to *Clusters* -> *Cluster List*. You can see the name and status of your cluster.
 . Verify that the status of your clusters is “Ready” and then click the name of your cluster.
 . Go to the *Overview* tab and verify that the details of your cluster are what you provided and specified when you created the cluster.
-. If you enabled *Amazon S3* or *CloudWatch*, go to the *Settings* -> *Control plane log forwarding* tab, and verify that the listed information is what you provided and specified on Day 1. 
+. If you enabled *Amazon S3* or *CloudWatch*, go to the *Settings* -> *Control plane log forwarding* tab, and verify that the listed information is what you specified when you created the cluster.

--- a/observability/logging/rosa-forwarding-control-plane-logs.adoc
+++ b/observability/logging/rosa-forwarding-control-plane-logs.adoc
@@ -22,3 +22,9 @@ include::modules/rosa-set-up-cloudwatch-log-group.adoc[leveloffset=+1]
 include::modules/rosa-set-up-s3-bucket.adoc[leveloffset=+1]
 
 include::modules/rosa-manage-control-plane-log-forwarding.adoc[leveloffset=+1]
+
+include::modules/rosa-create-cluster-ui-log-forwarding.adoc[leveloffset=+1]
+
+include::modules/rosa-create-cluster-log-forwarding-ui-day1.adoc[leveloffset=+1]
+
+include::modules/rosa-view-cluster-log-forwarding-ui-day2.adoc[leveloffset=+1]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.21+

Issue:
https://redhat.atlassian.net/browse/OSDOCS-18105

Link to docs preview:
https://112116--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/observability/logging/rosa-forwarding-control-plane-logs#rosa-create-cluster-ui-log-groups_rosa-configuring-the-log-forwarder

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
