### PR TITLE
[OCPBUGS-86292]: Adding known limitation to HCP disconnected docs

### DIFF
--- a/hosted_control_planes/hcp-disconnected/hcp-deploy-dc-virt.adoc
+++ b/hosted_control_planes/hcp-disconnected/hcp-deploy-dc-virt.adoc
@@ -1,18 +1,28 @@
 :_mod-docs-content-type: ASSEMBLY
-[id="hcp-deploy-dc-virt"]
 include::_attributes/common-attributes.adoc[]
+[id="hcp-deploy-dc-virt"]
 = Deploying {hcp} on {VirtProductName} in a disconnected environment
 :context: hcp-deploy-dc-virt
 
 toc::[]
 
-When you deploy {hcp} in a disconnected environment, some of the steps differ depending on the platform you use. The following procedures are specific to deployments on {VirtProductName}.
+[role="_abstract"]
+When you deploy {hcp} in a disconnected environment, some of the steps differ depending on whether you use bare metal or {VirtProductName}.
 
-[id="prerequisites_{context}"]
-== Prerequisites
+To get started, you must meet the following requirements:
 
 * You have a disconnected {product-title} environment serving as your management cluster.
-* You have an internal registry to mirror images on. For more information, see xref:../../disconnected/index.adoc#installing-mirroring-disconnected-about[About disconnected installation mirroring].
+* You have an internal registry to mirror images on. For more information, see "About disconnected installation mirroring".
+
+[NOTE]
+====
+A known limitation exists for hosted clusters on an {product-title} management cluster that is version 4.21 or later. To avoid issues, you must mirror the 4.20.10 release payload from the `quay.io/openshift-release-dev/ocp-release:4.20.10-multi` image to the target mirror registry. This temporary limitation is expected to be resolved in a later release.
+====
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../disconnected/index.adoc#installing-mirroring-disconnected-about[About disconnected installation mirroring]
 
 include::modules/hcp-dc-image-mirror.adoc[leveloffset=+1]
 
@@ -27,27 +37,21 @@ include::modules/hcp-dc-apply-objects.adoc[leveloffset=+1]
 .Additional resources
 * xref:../../disconnected/about-installing-oc-mirror-v2.adoc#about-installing-oc-mirror-v2[Mirroring images for a disconnected installation by using the oc-mirror plugin v2]
 
-[id="hcp-dc-mce-virt"]
-== Deploying {mce-short} for a disconnected installation of {hcp}
+include::modules/hcp-dc-mce-virt.adoc[leveloffset=+1]
 
-The {mce} plays a crucial role in deploying clusters across providers. If you do not have {mce-short} installed, review the following documentation to understand the prerequisites and steps to install it:
+[role="_additional-resources"]
+.Additional resources
 
 * link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.16/html/clusters/cluster_mce_overview#mce-intro[About cluster lifecycle with multicluster engine operator]
 * link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.16/html/clusters/cluster_mce_overview#mce-install-intro[Installing and upgrading multicluster engine operator]
 
-[id="hcp-dc-tls-virt"]
-== Configuring TLS certificates for a disconnected installation of {hcp}
-
-To ensure proper function in a disconnected deployment, you need to configure the registry CA certificates in the management cluster and the worker nodes for the hosted cluster.
+include::modules/hcp-dc-tls-virt.adoc[leveloffset=+1]
 
 include::modules/hcp-dc-tls-mgmt.adoc[leveloffset=+2]
 
 include::modules/hcp-dc-tls-hosted.adoc[leveloffset=+2]
 
-[id="hcp-dc-virt-hosted"]
-== Creating a hosted cluster on {VirtProductName}
-
-A hosted cluster is an {product-title} cluster with its control plane and API endpoint hosted on a management cluster. The hosted cluster includes the control plane and its corresponding data plane.
+include::modules/hcp-dc-virt-hosted.adoc[leveloffset=+1]
 
 include::modules/hcp-virt-reqs.adoc[leveloffset=+2]
 
@@ -57,23 +61,17 @@ include::modules/hcp-virt-create-hc-cli.adoc[leveloffset=+2]
 .Additional resources
 * xref:../../hosted_control_planes/hcp-prepare/hcp-distribute-workloads.adoc#hcp-labels-taints_hcp-distribute-workloads[Labeling management cluster nodes]
 
-include::modules/hcp-virt-ingress-dns.adoc[leveloffset=+2]
+include::modules/hcp-virt-ingress-dns.adoc[leveloffset=+1]
 
-[id="hcp-dc-virt-ingress-dns-custom"]
-=== Customizing ingress and DNS behavior
+include::modules/hcp-dc-virt-ingress-dns-custom.adoc[leveloffset=+1]
 
-If you do not want to use the default ingress and DNS behavior, you can configure a KubeVirt hosted cluster with a unique base domain at creation time. This option requires manual configuration steps during creation and involves three main steps: cluster creation, load balancer creation, and wildcard DNS configuration.
+include::modules/hcp-virt-hc-base-domain.adoc[leveloffset=+1]
 
-include::modules/hcp-virt-hc-base-domain.adoc[leveloffset=+3]
+include::modules/hcp-virt-load-balancer.adoc[leveloffset=+1]
 
-include::modules/hcp-virt-load-balancer.adoc[leveloffset=+3]
+include::modules/hcp-virt-wildcard-dns.adoc[leveloffset=+1]
 
-include::modules/hcp-virt-wildcard-dns.adoc[leveloffset=+3]
-
-[id="hcp-dc-finish"]
-== Finishing the deployment
-
-You can monitor the deployment of a hosted cluster from two perspectives: the control plane and the data plane.
+include::modules/hcp-dc-finish.adoc[leveloffset=+1]
 
 include::modules/hcp-monitor-cp.adoc[leveloffset=+2]
 

--- a/modules/hcp-dc-finish.adoc
+++ b/modules/hcp-dc-finish.adoc
@@ -1,0 +1,10 @@
+// Module included in the following assemblies:
+//
+// * hosted_control_planes/hcp-disconnected/hcp-deploy-dc-virt.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="hcp-dc-finish_{context}"]
+= Finishing the deployment
+
+[role="_abstract"]
+You can monitor the deployment of a hosted cluster from two perspectives: the control plane and the data plane.

--- a/modules/hcp-dc-mce-virt.adoc
+++ b/modules/hcp-dc-mce-virt.adoc
@@ -1,0 +1,15 @@
+// Module included in the following assemblies:
+//
+// * hosted_control_planes/hcp-disconnected/hcp-deploy-dc-virt.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="hcp-dc-mce-virt_{context}"]
+= Deploying {mce-short} for a disconnected installation of {hcp}
+
+[role="_abstract"]
+The {mce} is crucial in deploying clusters across providers. Ensure that you have {mce-short} installed and configured for your deployment.
+
+If you do not have {mce-short} installed, review the following documentation to understand the prerequisites and steps to install it:
+
+* "About cluster lifecycle with multicluster engine operator"
+* "Installing and upgrading multicluster engine operator"

--- a/modules/hcp-dc-tls-virt.adoc
+++ b/modules/hcp-dc-tls-virt.adoc
@@ -1,0 +1,10 @@
+// Module included in the following assemblies:
+//
+// * hosted_control_planes/hcp-disconnected/hcp-deploy-dc-virt.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="hcp-dc-tls-virt_{context}"]
+= Configuring TLS certificates for a disconnected installation of {hcp}
+
+[role="_abstract"]
+To ensure proper function in a disconnected deployment, you need to configure the registry CA certificates in the management cluster and the compute nodes for the hosted cluster.

--- a/modules/hcp-dc-virt-hosted.adoc
+++ b/modules/hcp-dc-virt-hosted.adoc
@@ -1,0 +1,10 @@
+// Module included in the following assemblies:
+//
+// * hosted_control_planes/hcp-disconnected/hcp-deploy-dc-virt.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="hcp-dc-virt-hosted_{context}"]
+= Creating a hosted cluster on {VirtProductName} in a disconnected environment
+
+[role="_abstract"]
+As part of the process to deploy {hcp} on {VirtProductName} in a disconnected environment, you need to create a hosted cluster. A hosted cluster is an {product-title} cluster with its control plane and API endpoint hosted on a management cluster. The hosted cluster includes the control plane and its corresponding data plane.

--- a/modules/hcp-dc-virt-ingress-dns-custom.adoc
+++ b/modules/hcp-dc-virt-ingress-dns-custom.adoc
@@ -1,0 +1,12 @@
+// Module included in the following assemblies:
+//
+// * hosted_control_planes/hcp-disconnected/hcp-deploy-dc-virt.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="hcp-dc-virt-ingress-dns-custom_{context}"]
+= Customize ingress and DNS behavior
+
+[role="_abstract"]
+If you do not want to use the default ingress and DNS behavior, you can configure a hosted cluster on {VirtProductName} with a unique base domain at creation time. 
+
+This option requires manual configuration steps during creation and involves three main steps: cluster creation, load balancer creation, and wildcard DNS configuration.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.21+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://redhat.atlassian.net/browse/OCPBUGS-86292
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: The main purpose of this PR is to add a known limitation to the docs about deploying HCP on OpenShift Virtualization in a disconnected environment. I also modularized some of the content that was failing Vale checks. The modularization changes did not affect any technical content.
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
