### PR TITLE
DOCPLAN-368: Fix ConceptLink warnings in virt SSH docs

### DIFF
--- a/modules/virt-defining-watchdog-device-vm.adoc
+++ b/modules/virt-defining-watchdog-device-vm.adoc
@@ -58,12 +58,12 @@ $ oc apply -f <file_name>.yaml
 
 .Verification
 
+. Run the following command to verify that the VM is connected to the watchdog device:
++
 [IMPORTANT]
 ====
-This procedure is provided for testing watchdog functionality only and must not be run on production machines.
+Verification steps are provided for testing watchdog functionality only and must not be run on production machines.
 ====
-
-. Run the following command to verify that the VM is connected to the watchdog device:
 +
 [source,terminal]
 ----

--- a/virt/managing_vms/virt-accessing-vm-ssh.adoc
+++ b/virt/managing_vms/virt-accessing-vm-ssh.adoc
@@ -84,7 +84,6 @@ include::modules/virt-editing-vm-dynamic-key-injection.adoc[leveloffset=+3]
 
 include::modules/virt-enabling-dynamic-key-injection-cli.adoc[leveloffset=+3]
 
-
 :context: virt-accessing-vm-ssh
 :virt-accessing-vm-ssh:
 include::modules/virt-using-virtctl-ssh-command.adoc[leveloffset=+2]
@@ -141,16 +140,16 @@ You can configure a secondary network, attach a virtual machine (VM) to the seco
 Secondary networks provide excellent performance because the traffic is not handled by the cluster network stack. However, the VMs are exposed directly to the secondary network and are not protected by firewalls. If a VM is compromised, an intruder could gain access to the secondary network. You must configure appropriate security within the operating system of the VM if you use this method.
 ====
 
-See the link:https://access.redhat.com/articles/6994974#networking-multus[Multus] and link:https://access.redhat.com/articles/6994974#networking-sriov[SR-IOV] documentation in the link:https://access.redhat.com/articles/6994974[{VirtProductName} Tuning & Scaling Guide] for additional information about networking options.
+For additional information about networking options, see the Multus and SR-IOV documentation in the "{VirtProductName} Tuning & Scaling Guide".
 
 .Prerequisites
 
 ifndef::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
-* You configured a secondary network such as xref:../../virt/vm_networking/virt-connecting-vm-to-linux-bridge.adoc#virt-connecting-vm-to-linux-bridge[Linux bridge] or xref:../../virt/vm_networking/virt-connecting-vm-to-sriov.adoc#virt-connecting-vm-to-sriov[SR-IOV].
-* You created a network attachment definition for a xref:../../virt/vm_networking/virt-connecting-vm-to-linux-bridge.adoc#virt-creating-linux-bridge-nad-web_virt-connecting-vm-to-linux-bridge[Linux bridge network] or the SR-IOV Network Operator created a xref:../../virt/vm_networking/virt-connecting-vm-to-sriov.adoc#nw-sriov-additional-network_virt-connecting-vm-to-sriov[network attachment definition] when you created an `SriovNetwork` object.
+* You configured a secondary network such as Linux bridge or SR-IOV.
+* You created a network attachment definition for a Linux bridge network or the SR-IOV Network Operator created a network attachment definition when you created an `SriovNetwork` object.
 endif::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
 ifdef::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
-* You configured a xref:../../virt/vm_networking/virt-connecting-vm-to-ovn-secondary-network.adoc#virt-connecting-vm-to-ovn-secondary-network[secondary network].
+* You configured a secondary network.
 * You created a network attachment definition.
 endif::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
 
@@ -161,6 +160,21 @@ include::modules/virt-connecting-secondary-network-ssh.adoc[leveloffset=+2]
 ifndef::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
 [NOTE]
 ====
-You can also xref:../../virt/vm_networking/virt-accessing-vm-secondary-network-fqdn.adoc#virt-accessing-vm-secondary-network-fqdn[access a VM attached to a secondary network interface by using the cluster FQDN].
+You can also access a VM attached to a secondary network interface by using the cluster FQDN.
 ====
+endif::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
+
+[role="_additional-resources"]
+[id="additional-resources_{context}"]
+== Additional resources
+* link:https://access.redhat.com/articles/6994974[{VirtProductName} Tuning & Scaling Guide]
+ifndef::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
+* xref:../../virt/vm_networking/virt-connecting-vm-to-linux-bridge.adoc#virt-connecting-vm-to-linux-bridge[Connecting a virtual machine to a Linux bridge network]
+* xref:../../virt/vm_networking/virt-connecting-vm-to-sriov.adoc#virt-connecting-vm-to-sriov[Connecting a virtual machine to an SR-IOV network]
+* xref:../../virt/vm_networking/virt-connecting-vm-to-linux-bridge.adoc#virt-creating-linux-bridge-nad-web_virt-connecting-vm-to-linux-bridge[Creating a Linux bridge NAD by using the web console]
+* xref:../../virt/vm_networking/virt-connecting-vm-to-sriov.adoc#nw-sriov-additional-network_virt-connecting-vm-to-sriov[Configuring SR-IOV additional network]
+* xref:../../virt/vm_networking/virt-accessing-vm-secondary-network-fqdn.adoc#virt-accessing-vm-secondary-network-fqdn[Accessing a virtual machine by using its external FQDN]
+endif::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
+ifdef::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
+* xref:../../virt/vm_networking/virt-connecting-vm-to-ovn-secondary-network.adoc#virt-connecting-vm-to-ovn-secondary-network[Connecting a virtual machine to an OVN-Kubernetes layer 2 secondary network]
 endif::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]


### PR DESCRIPTION
## Summary
- Fixes AsciiDocDITA.ConceptLink warnings by moving links and xrefs to Additional resources section in virt-accessing-vm-ssh.adoc
- Fixes verification step ordering in virt-defining-watchdog-device-vm.adoc to place important warning before the verification command

https://redhat.atlassian.net/browse/DOCPLAN-368
4.20+

## Preview links
* https://112119--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/monitoring/virt-monitoring-vm-health.html#virt-defining-watchdog-device-vm
* https://112119--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/managing_vms/virt-accessing-vm-ssh#additional-resources_virt-accessing-vm-ssh
* https://112119--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/managing_vms/virt-accessing-vm-ssh#using-secondary-networks-ssh_virt-accessing-vm-ssh

🤖 Generated with [Claude Code](https://claude.com/claude-code)