### PR TITLE
[OSDOCS#18858]: Document process for updating stale BMC credentials for 4.22

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -443,10 +443,8 @@ Topics:
       File: installing-two-node-fencing
     - Name: Installing a two-node OpenShift cluster with fencing
       File: install-tnf
-    - Name: Operating a degraded two-node OpenShift cluster with fencing
-      File: operating-a-degraded-tnf
-    - Name: Post-installation troubleshooting and recovery
-      File: install-post-tnf
+    - Name: Recover a two-node OpenShift cluster with fencing from disruption events
+      File: recover-tnf-from-disruption-events
 - Name: Installing on bare metal
   Dir: installing_bare_metal
   Distros: openshift-origin,openshift-enterprise
@@ -3875,7 +3873,7 @@ Topics:
   Dir: control_plane_backup_and_restore
   Topics:
   - Name: Backing up etcd data
-    File: backing-up-etcd
+    File: backing-up-etcd-data
   - Name: Replacing an unhealthy etcd member
     File: replacing-unhealthy-etcd-member
   - Name: Disaster recovery

--- a/backup_and_restore/control_plane_backup_and_restore/backing-up-etcd-data.adoc
+++ b/backup_and_restore/control_plane_backup_and_restore/backing-up-etcd-data.adoc
@@ -3,13 +3,14 @@
 //If you update any of the content in this assembly file, be sure to also make the same changes in the assemblies in the following file: backup_and_restore/control_plane_backup_and_restore/etcd-backup.adoc.
 
 :_mod-docs-content-type: ASSEMBLY
-[id="backup-etcd"]
-= Backing up etcd
+[id="backing-up-etcd-data"]
+= Backing up etcd data
 include::_attributes/common-attributes.adoc[]
 :context: backup-etcd
 
 toc::[]
 
+[role="_abstract"]
 etcd is the key-value store for {product-title}, which persists the state of all resource objects.
 
 Back up your cluster's etcd data regularly and store in a secure location ideally outside the {product-title} environment. Do not take an etcd backup before the first certificate rotation completes, which occurs 24 hours after installation, otherwise the backup will contain expired certificates. It is also recommended to take etcd backups during non-peak usage hours because the etcd snapshot has a high I/O cost.
@@ -21,14 +22,13 @@ Be sure to take an etcd backup before you update your cluster. Taking a backup b
 Back up your cluster's etcd data by performing a single invocation of the backup script on a control plane host. Do not take a backup for each control plane host.
 ====
 
-After you have an etcd backup, you can xref:../../backup_and_restore/control_plane_backup_and_restore/disaster_recovery/scenario-2-restoring-cluster-state.adoc#dr-restoring-cluster-state[restore to a previous cluster state].
+After you have an etcd backup, you can xref:../../backup_and_restore/control_plane_backup_and_restore/disaster_recovery/scenario-2-restoring-cluster-state.adoc#dr-restoring-cluster-state[Restoring to a previous cluster state].
 
 // Backing up etcd data
 include::modules/backup-etcd.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
-[id="additional-resources_backup-etcd"]
-== Additional resources
+.Additional resources
 * xref:../../hosted_control_planes/hcp_high_availability/hcp-recovering-etcd-cluster.adoc#hcp-recovering-etcd-cluster[Recovering an unhealthy etcd cluster]
 
 // Creating automated etcd backups

--- a/installing/installing_two_node_cluster/installing_tnf/recover-tnf-from-disruption-events.adoc
+++ b/installing/installing_two_node_cluster/installing_tnf/recover-tnf-from-disruption-events.adoc
@@ -1,0 +1,29 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="recover-tnf-from-disruption-events"]
+= Recover a two-node OpenShift cluster with fencing from disruption events
+include::_attributes/common-attributes.adoc[]
+:context: recover-tnf-from-disruption-events
+
+toc::[]
+
+[role="_abstract"]
+Learn how to manually recover from disruption events, replace control plane nodes, and verify etcd health in a two-node {product-title} cluster with fencing (TNF).
+
+// Manually recovering from a disruption event when automated recovery is unavailable
+include::modules/recovering-from-disruption-event-manually-when-auto-recovery-is-unavailable.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../../backup_and_restore/control_plane_backup_and_restore/backing-up-etcd-data.adoc#backup-etcd-restoring_backing-up-etcd[Backing up etcd data]
+
+// Replacing control plane nodes
+include::modules/replacing-a-failed-control-plane-node-in-tnf.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../../backup_and_restore/control_plane_backup_and_restore/backing-up-etcd-data.adoc#backup-etcd-restoring_backing-up-etcd[Backing up etcd data]
+
+// Verifying etcd health in a two-node OpenShift cluster with fencing
+include::modules/verifying-etcd-health-in-tnf.adoc[leveloffset=+1]

--- a/modules/config-container-runtime.adoc
+++ b/modules/config-container-runtime.adoc
@@ -7,13 +7,18 @@
 = Configuring the container runtime
 
 [role="_abstract"]
-You can configure the container runtime used with new workloads on your nodes, based on which runtime you or your organization prefers. You can use either crun, which is considered a faster and more lightweight runtime, or runc, which is more widely used than crun. 
+You can configure the container runtime used with new workloads on your nodes, based on which runtime you or your organization prefers. You can use either crun, which is considered a faster and more lightweight runtime, or runC, which is more widely used than crun. 
 
-For information on crun and runc, see "About the container engine and container runtime".
+For information on crun and runC, see "About the container engine and container runtime".
+
+[WARNING]
+====
+Starting in {product-title} 4.22, the runC container runtime is deprecated.
+====
 
 Starting in {product-title} 4.18, crun is the default container runtime for new installations. You can change between the runtimes by using a `ContainerRuntimeConfig` object, as described in the following procedure. Changing the container runtime affects new workloads only. Existing workloads continue to use their existing container runtime. 
 
-If you updated your cluster from {product-title} 4.17, the runc container runtime remains unchanged as the default. During the upgrade, two `MachineConfig` objects, one for the control plane nodes and one for the worker nodes, were created to override the new default runtime. You can migrate the container runtime to crun, on a schedule of your choosing, by removing either or both of the `MachineConfig` objects.
+If you updated your cluster from {product-title} 4.17, the runC container runtime remains unchanged as the default. During the upgrade, two `MachineConfig` objects, one for the control plane nodes and one for the worker nodes, were created to override the new default runtime. You can migrate the container runtime to crun, on a schedule of your choosing, by removing either or both of the `MachineConfig` objects.
 
 .Procedure
 
@@ -33,7 +38,7 @@ $ oc delete machineconfig 00-override-worker-generated-crio-default-container-ru
 $ oc delete machineconfig 00-override-master-generated-crio-default-container-runtime
 ----
 
-* For any {product-title} 4.18 or greater cluster, you can configure crun or runc as the container runtime for specific nodes by creating a container runtime configuration:
+* For any {product-title} 4.18 or greater cluster, you can configure crun or runC as the container runtime for specific nodes by creating a container runtime configuration:
 
 . Create a YAML file for the `ContainerRuntimeConfig` CR:
 +

--- a/modules/recovering-from-disruption-event-manually-when-auto-recovery-is-unavailable.adoc
+++ b/modules/recovering-from-disruption-event-manually-when-auto-recovery-is-unavailable.adoc
@@ -1,11 +1,12 @@
-//Module included in the following assemblies:
+//modules included in the following assembly 
 //
-// *installing/installing_two_node_cluster/installing_tnf/install-post-tnf.adoc
+// *installing_tnf/recover-tnf-from-disruption-events.adoc
 
 :_mod-docs-content-type: PROCEDURE
-[id="installation-manual-recovering-when-auto-recovery-is-unavail_{context}"]
-= Manually recovering from a disruption event when automated recovery is unavailable
+[id="recovering-from-disruption-event-manually-when-auto-recovery-is-unavailable_{context}"]
+= Recovering from a disruption event manually when automated recovery is unavailable
 
+[role="_abstract"]
 You might need to perform manual recovery steps if a disruption event prevents fencing from functioning correctly. In this case, you can run commands directly on the control plane nodes to recover the cluster. There are four main recovery scenarios, which should be attempted in the following order:
 
 . Update fencing secrets:  Refresh the Baseboard Management Console (BMC) credentials if they are incorrect or outdated.
@@ -27,7 +28,7 @@ Do an etcd backup before proceeding to ensure that you can restore the cluster i
 
 . Update the fencing secrets:
 
-.. If the Cluster API is unavilable, update fencing secret by running the following command on one of the cluster nodes:
+.. If the Cluster API is unavailable, update the fencing secrets by running the following command on one of the cluster nodes:
 +
 [source,terminal]
 ----
@@ -36,7 +37,7 @@ $ sudo pcs stonith update <node_name>_redfish username=<user_name> password=<pas
 +
 After the Cluster API recovers, or the Cluster API is already available, update fencing secret in the cluster to ensure it stays in sync, as described in the following step.
 
-.. Edit the username and password for the existing fencing secret for the control plane node by running the following commads:
+.. Edit the username and password for the existing fencing secret for the control plane node by running the following commands:
 +
 [source,terminal]
 ----
@@ -45,7 +46,72 @@ $ oc project openshift-etcd
 +
 [source,terminal]
 ----
-$ oc edit secret <node_name>-fencing
+$ oc edit secret fencing-credentials-<node_name>
+----
++
+The secret contains the following data keys:
++
+.Data keys
+[cols="1,1,2",options="header"]
+|===
+| Key | Description | Changes during credential rotation?
+
+| `username`
+| BMC username
+| Yes
+
+| `password`
+| BMC password
+| Yes
+
+| `address`
+| Full Redfish URL (e.g., `redfish+https://192.168.1.10:443/redfish/v1/Systems/1`)
+| Only if BMC address changed
+
+| `certificateVerification`
+| `Disabled` or `Enabled`
+| Only if TLS settings changed
+
+|===
++
+[NOTE]
+====
+The `oc edit secret` command displays base64-encoded values, and any new values must also be base64-encoded before editing. 
+====
++
+The following command avoids manual encoding:
++
+[source,terminal]
+----
+$ oc create secret generic fencing-credentials-<node_name> \
+      --from-literal=address='<redfish_address>' \
+      --from-literal=username='<new_username>' \
+      --from-literal=password='<new_password>' \
+      --from-literal=certificateVerification='<Disabled_or_Enabled>' \
+      --dry-run=client -o yaml | oc apply -f -
+----
++
+All four keys must be present. The cluster etcd Operator rejects secrets with missing keys.
+
+.. Verify that the new credentials can reach the BMC by running the following command:
++
+[source,terminal]
+----
+$ sudo pcs stonith config <node_name>_redfish
+----
++
+.. Verify that no STONITH resources are blocked by running the following command:
++
+[source,terminal]
+----
+$ sudo pcs status --full
+----
++
+The cluster etcd Operator performs this validation automatically when it applies credentials from the secret by using the following command:
++
+[source,terminal]
+----
+`fence_redfish --action status`
 ----
 +
 If the cluster recovers after updating the fencing secrets, no further action is required. If the issue persists, proceed to the next step.

--- a/modules/replacing-a-failed-control-plane-node-in-tnf.adoc
+++ b/modules/replacing-a-failed-control-plane-node-in-tnf.adoc
@@ -1,12 +1,13 @@
-//Module included in the following assemblies:
+//modules included in the following assembly 
 //
-// *installing/installing_two_node_cluster/installing_tnf/install-post-tnf.adoc
+// *installing_tnf/recover-tnf-from-disruption-events.adoc
 
 :_mod-docs-content-type: PROCEDURE
-[id="installation-replacing-control-plane-nodes_{context}"]
-= Replacing control plane nodes in a two-node OpenShift cluster with fencing
+[id="replacing-a-failed-control-plane-node-in-tnf_{context}"]
+= Replacing a failed control plane node in a two-node OpenShift cluster with fencing
 
-You can replace a failed control plane node in a two-node OpenShift cluster. The replacement node must use the same host name and IP address as the failed node.
+[role="_abstract"]
+To ensure a seamless recovery, your replacement control plane node must reuse the hostname and IP address of the failed node. This allows the cluster to correctly identify and integrate the new hardware.
 
 .Prerequisites
 

--- a/modules/verifying-etcd-health-in-tnf.adoc
+++ b/modules/verifying-etcd-health-in-tnf.adoc
@@ -1,8 +1,13 @@
+//modules included in the following assembly 
+//
+// *installing_tnf/recover-tnf-from-disruption-events.adoc
+
 :_mod-docs-content-type: PROCEDURE
-[id="installation-verifying-etcd-health_{context}"]
+[id="verifying-etcd-health-in-tnf_{context}"]
 = Verifying etcd health in a two-node OpenShift cluster with fencing
 
-After completing node recovery or maintenance procedures, verify that both control plane nodes and etcd are operating correctly.
+[role="_abstract"]
+After you complete node recovery or maintenance, verify the health of your control plane nodes and etcd to ensure your cluster is fully functional and resilient.
 
 .Prerequisites
 
@@ -45,7 +50,7 @@ This command shows the current etcd members and their roles. Look for any nodes 
 $ sudo pcs status --full
 ----
 +
-This command provides a detailed overview of all resources managed by Pacemaker. You must ensure that the following conditions are met:
+This command provides a detailed overview of all resources managed by Pacemaker. You must ensure that the cluster meets the following conditions:
 +
 ** Both nodes are online.
 ** The `kubelet` and `etcd` resources are running.

--- a/nodes/containers/nodes-containers-using.adoc
+++ b/nodes/containers/nodes-containers-using.adoc
@@ -53,6 +53,11 @@ The {product-title} documentation uses the term _container runtime_ to refer to 
 ifndef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 {product-title} uses CRI-O as the container engine and runC or crun as the container runtime. The default container runtime is crun. Both container runtimes adhere to the link:https://www.opencontainers.org/[Open Container Initiative (OCI)] runtime specifications.
 
+[WARNING]
+====
+Starting in {product-title} 4.22, the runC container runtime is deprecated.
+====
+
 include::snippets/about-crio-snippet.adoc[]
 
 crun, developed by Red Hat, is a fast and low-memory container runtime fully written in C. runC, developed by Docker and maintained by the Open Container Project, is a lightweight, portable container runtime written in Go.
@@ -74,6 +79,11 @@ endif::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 
 ifdef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 {product-title} uses CRI-O as the container engine and crun or runC as the container runtime. The default container runtime is crun.
+
+[WARNING]
+====
+Starting in {product-title} 4.22, the runC container runtime is deprecated.
+====
 endif::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 
 ifndef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]


### PR DESCRIPTION
Version(s):
4.22

Issue:
https://redhat.atlassian.net/browse/OSDOCS-18858

Link to docs preview:
https://112124--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_two_node_cluster/installing_tnf/recover-tnf-from-disruption-events.html

QE review:
- [x] QE has approved this change.

