### PR TITLE
CNV-76433: Add release note for localnet NAD deprecated label removal

### DIFF
--- a/virt/release_notes/virt-4-22-release-notes.adoc
+++ b/virt/release_notes/virt-4-22-release-notes.adoc
@@ -59,6 +59,11 @@ link:https://redhat.atlassian.net/browse/CNV-28924[CNV-28924]
 
 // Web console
 
+Removed deprecated label from localnet network attachment definition type::
+The web console no longer displays a *Deprecated* label next to the localnet `NetworkAttachmentDefinition` (NAD) type. This change clarifies that localnet NAD functionality is not deprecated and remains fully supported. You can use either the NAD-based approach or the VM network wizard to create localnet networks for connecting virtual machines to physical networks.
++
+link:https://redhat.atlassian.net/browse/OCPBUGS-83809[OCPBUGS-83809]
+
 
 
 // Monitoring


### PR DESCRIPTION
Version(s):
4.22

Issue:
https://redhat.atlassian.net/browse/CNV-76433

Link to docs preview:
https://112133--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/release_notes/virt-4-22-release-notes.html#virt-4-22-new_virt-4-22-release-notes

QE review:
- [x] QE has approved this change.

Additional information:
Added release note to the Web console section of the OpenShift Virtualization 4.22 release notes explaining that the "Deprecated" label has been removed from the localnet NetworkAttachmentDefinition type in the web console. This clarifies that localnet NAD functionality is not deprecated and remains fully supported.

The release note references OCPBUGS-83809 (the bug that reported the misleading UI label).

---

🤖 Generated with Claude Code