### PR TITLE
[OSDOCS-19880]Change nodeSelector key/pair in postgres deployment example

### DIFF
--- a/modules/persistent-storage-csi-gcp-hyperdisk-storage-pools-procedure.adoc
+++ b/modules/persistent-storage-csi-gcp-hyperdisk-storage-pools-procedure.adoc
@@ -206,7 +206,7 @@ spec:
         app: postgres
     spec:
       nodeSelector:
-        cloud.google.com/machine-family: n4 <1>
+        node.kubernetes.io/instance-type: n4-standard-4 <1>
       containers:
       - name: postgres
         image: postgres:14-alpine

--- a/modules/persistent-storage-csi-gcp-hyperdisk-storage-pools-procedure.adoc
+++ b/modules/persistent-storage-csi-gcp-hyperdisk-storage-pools-procedure.adoc
@@ -219,7 +219,7 @@ spec:
         persistentVolumeClaim:
           claimName: my-pvc <2>
 ----
-<1> Specifies the machine family. In this example, it is `n4`.
+<1> Specifies the instance type. In this example, it is `n4-standard-4`.
 <2> Specifies the name of the PVC created in the preceding step. In this example, it is `my-pfc`.
 
 .. Confirm that the deployment was successfully created by running the following command:


### PR DESCRIPTION
Change nodeSelector key/pair in postgres deployment example. machine-family label doesn't exists in a fresh ocp 4.22 install on gcp

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
OpenShift 4.22-rc4

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://redhat.atlassian.net/browse/OSDOCS-19880

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->
The "Example deployment YAML file" mentioned in https://content-preview.docs.redhat.com/en/documentation/openshift_container_platform/4.22/html/storage/using-container-storage-interface-csi#persistent-storage-csi-gcp-hyperdisk-storage-pools-procedure_persistent-storage-csi-gcp-pd for the postgres deployment ask the user to use the 'cloud.google.com/machine-family: n4' as the label for the nodeSelector field. In a fresh OCP 4.22-rc4 install , there is no label.

In this case, we can use the label 'node.kubernetes.io/instance-type' with value 'n4-standard-4'.
This allows the deployment to start, otherwise it will get stuck in pending waiting for a node with that specific label.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
