### PR TITLE
OKD-365: Update oc client download links to new mirror location

### DIFF
--- a/modules/cli-installing-cli-linux.adoc
+++ b/modules/cli-installing-cli-linux.adoc
@@ -79,9 +79,11 @@ endif::microshift[]
 .Procedure
 
 ifdef::openshift-origin[]
-. Navigate to link:https://mirror.openshift.com/pub/openshift-v4/clients/oc/latest/[https://mirror.openshift.com/pub/openshift-v4/clients/oc/latest/] and choose the folder for your operating system and architecture.
+. Navigate to the link:https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/stable/[OpenShift Client Tools] page.
++
+For other architectures, replace `x86_64` in the URL with your architecture (`aarch64`, `ppc64le`, or `s390x`).
 
-. Download `oc.tar.gz`.
+. Download `openshift-client-linux.tar.gz`.
 endif::[]
 ifndef::openshift-origin,microshift,openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 . Navigate to the link:https://access.redhat.com/downloads/content/290[Download {product-title}] page on the Red{nbsp}Hat Customer Portal.

--- a/modules/cli-installing-cli-macos.adoc
+++ b/modules/cli-installing-cli-macos.adoc
@@ -79,8 +79,9 @@ endif::microshift[]
 .Procedure
 
 ifdef::openshift-origin[]
-. Navigate to link:https://mirror.openshift.com/pub/openshift-v4/clients/oc/latest/[https://mirror.openshift.com/pub/openshift-v4/clients/oc/latest/] and choose the folder for your operating system and architecture.
-. Download `oc.tar.gz`.
+. Navigate to the link:https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/stable/[OpenShift Client Tools] page for Intel-based Macs, or link:https://mirror.openshift.com/pub/openshift-v4/aarch64/clients/ocp/stable/[OpenShift Client Tools for Apple Silicon] for ARM-based Macs.
+
+. Download `openshift-client-mac.tar.gz` for Intel Macs, or `openshift-client-mac-arm64.tar.gz` for Apple Silicon Macs.
 endif::[]
 ifndef::openshift-origin,microshift,openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 . Navigate to the link:https://access.redhat.com/downloads/content/290[Download {product-title}] page on the Red{nbsp}Hat Customer Portal.

--- a/modules/cli-installing-cli-windows.adoc
+++ b/modules/cli-installing-cli-windows.adoc
@@ -79,8 +79,9 @@ endif::microshift[]
 .Procedure
 
 ifdef::openshift-origin[]
-. Navigate to link:https://mirror.openshift.com/pub/openshift-v4/clients/oc/latest/[https://mirror.openshift.com/pub/openshift-v4/clients/oc/latest/] and choose the folder for your operating system and architecture.
-. Download `oc.zip`.
+. Navigate to the link:https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/stable/[OpenShift Client Tools] page.
+
+. Download `openshift-client-windows.zip`.
 endif::[]
 ifndef::openshift-origin,microshift,openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 . Navigate to the link:https://access.redhat.com/downloads/content/290[Download {product-title}] page on the Red{nbsp}Hat Customer Portal.


### PR DESCRIPTION
Version(s):
4.9+


Link to docs preview:


QE review:
- [ ] QE has approved this change.

Additional information:
Updated OpenShift Client (oc) download links for OKD to point to the new mirror location structure. The changes include:
- Updated URLs from `/pub/openshift-v4/clients/oc/latest/` to architecture-specific paths `/pub/openshift-v4/{arch}/clients/ocp/stable/`
- Updated file names to match new naming conventions
- Added guidance for multiple architectures (x86_64, aarch64, ppc64le, s390x)
- Platform-specific instructions for Linux, macOS (Intel and Apple Silicon), and Windows