### PR TITLE
[SRVCOM-4272] Add OTel breaking changes for Tracing

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -505,6 +505,8 @@ Topics:
     File: serverless-tracing-open-telemetry
   - Name: Using Jaeger distributed tracing
     File: serverless-tracing-jaeger
+  - Name: Migrating from B3 to W3C Trace Context propagation
+    File: serverless-tracing-b3-w3c-migration
 
 ---
 # Integrations

--- a/modules/serverless-config-request-log.adoc
+++ b/modules/serverless-config-request-log.adoc
@@ -7,13 +7,13 @@
 = Configuring request log settings
 
 [role="_abstract"]
-You can configure request logging for your service in the `observability` field of your `KnativeServing` custom resource (CR).
+You can configure request logging for your service in the `observability` field of the `KnativeServing` custom resource (CR).
 
 For information about the available parameters for configuring request logging, see "Parameters of request logging".
 
 .Procedure
 
-* Configure request logging for your service by modifying the `observability` field in your `KnativeServing` CR:
+* Configure request logging for your service by modifying the `observability` field in the `KnativeServing` CR:
 +
 You get an output similar to the following example:
 +
@@ -30,6 +30,13 @@ spec:
     observability:
         logging.enable-request-log: true
         logging.enable-probe-request-log: true
-        logging.request-log-template: '{"httpRequest": {"requestMethod": "{{.Request.Method}}", "requestUrl": "{{js .Request.RequestURI}}", "requestSize": "{{.Request.ContentLength}}", "status": {{.Response.Code}}, "responseSize": "{{.Response.Size}}", "userAgent": "{{js .Request.UserAgent}}", "remoteIp": "{{js .Request.RemoteAddr}}", "serverIp": "{{.Revision.PodIP}}", "referer": "{{js .Request.Referer}}", "latency": "{{.Response.Latency}}s", "protocol": "{{.Request.Proto}}"}, "traceId": "{{index .Request.Header "X-B3-Traceid"}}"}'
+        logging.request-log-template: '{"httpRequest": {"requestMethod": "{{.Request.Method}}", "requestUrl": "{{js .Request.RequestURI}}", "requestSize": "{{.Request.ContentLength}}", "status": {{.Response.Code}}, "responseSize": "{{.Response.Size}}", "userAgent": "{{js .Request.UserAgent}}", "remoteIp": "{{js .Request.RemoteAddr}}", "serverIp": "{{.Revision.PodIP}}", "referer": "{{js .Request.Referer}}", "latency": "{{.Response.Latency}}s", "protocol": "{{.Request.Proto}}"}, "traceId": "{{index .Request.Header "Traceparent"}}"}'
 # ...
 ----
++
+[IMPORTANT]
+====
+The request log template uses the `traceparent` header to capture trace context information. {ServerlessProductName} uses the W3C Trace Context standard for distributed tracing.
+
+If you previously configured logging to use the B3 trace header format (`X-B3-Traceid`), you must update your configuration to use `traceparent` instead. Note that while the JSON field name remains `traceId` for backward compatibility, the value format changes from a simple trace ID to the full W3C Trace Context `traceparent` header format (for example, `00-80f198ee56343ba864fe8b2a57d3eff7-e457b5a2e4d86bd1-01`). If your log parsers expect only the trace ID, update them to extract the trace ID from the `traceparent` value.
+====

--- a/modules/serverless-config-request-log.adoc
+++ b/modules/serverless-config-request-log.adoc
@@ -30,6 +30,11 @@ spec:
     observability:
         logging.enable-request-log: true
         logging.enable-probe-request-log: true
-        logging.request-log-template: '{"httpRequest": {"requestMethod": "{{.Request.Method}}", "requestUrl": "{{js .Request.RequestURI}}", "requestSize": "{{.Request.ContentLength}}", "status": {{.Response.Code}}, "responseSize": "{{.Response.Size}}", "userAgent": "{{js .Request.UserAgent}}", "remoteIp": "{{js .Request.RemoteAddr}}", "serverIp": "{{.Revision.PodIP}}", "referer": "{{js .Request.Referer}}", "latency": "{{.Response.Latency}}s", "protocol": "{{.Request.Proto}}"}, "traceId": "{{index .Request.Header "X-B3-Traceid"}}"}'
+        logging.request-log-template: '{"httpRequest": {"requestMethod": "{{.Request.Method}}", "requestUrl": "{{js .Request.RequestURI}}", "requestSize": "{{.Request.ContentLength}}", "status": {{.Response.Code}}, "responseSize": "{{.Response.Size}}", "userAgent": "{{js .Request.UserAgent}}", "remoteIp": "{{js .Request.RemoteAddr}}", "serverIp": "{{.Revision.PodIP}}", "referer": "{{js .Request.Referer}}", "latency": "{{.Response.Latency}}s", "protocol": "{{.Request.Proto}}"}, "traceparent": "{{index .Request.Header "Traceparent"}}"}'
 # ...
 ----
++
+[NOTE]
+====
+The request log template uses the `traceparent` header to capture trace context information. {ServerlessProductName} uses the W3C Trace Context standard for distributed tracing. If you previously configured logging to use the B3 trace header format (`X-B3-Traceid`), you must update your configuration to use `traceparent` instead.
+====

--- a/modules/serverless-tracing-context-migration.adoc
+++ b/modules/serverless-tracing-context-migration.adoc
@@ -1,0 +1,158 @@
+// Module included in the following assemblies:
+//
+// * serverless/observability/serverless-tracing.adoc
+// * serverless/observability/serverless-tracing-jaeger.adoc
+// * serverless/observability/serverless-tracing-open-telemetry.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="serverless-tracing-context-migration_{context}"]
+= Migrating from B3 to W3C Trace Context propagation
+
+[role="_abstract"]
+{ServerlessProductName} has migrated from OpenCensus to OpenTelemetry for distributed tracing. As part of this migration, the trace context propagation format has changed from B3 (Zipkin) headers to the W3C Trace Context standard.
+
+[IMPORTANT]
+====
+This is a breaking change. If your applications expect or produce B3 headers, they will not propagate trace context correctly and distributed traces will be incomplete. You must update your applications to use W3C Trace Context headers.
+====
+
+== Understanding the header format changes
+
+The following table shows the trace context header changes:
+
+[cols="2,3,3",options="header"]
+|===
+|Purpose
+|Old format (B3)
+|New format (W3C Trace Context)
+
+|Trace ID and span ID
+|`X-B3-TraceId: 80f198ee56343ba864fe8b2a57d3eff7`
+
+`X-B3-SpanId: e457b5a2e4d86bd1`
+|`traceparent: 00-80f198ee56343ba864fe8b2a57d3eff7-e457b5a2e4d86bd1-01`
+
+|Sampling decision
+|`X-B3-Sampled: 1`
+|Included in `traceparent` flags field (last two digits)
+
+|Additional vendor-specific data
+|`X-B3-Flags` (rarely used)
+|`tracestate: vendor1=value1,vendor2=value2`
+|===
+
+== W3C Trace Context format
+
+The `traceparent` header uses the format: `version-trace-id-parent-id-trace-flags`
+
+For example:
+----
+traceparent: 00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01
+----
+
+where:
+
+`00`::
+Specifies the version field.
+
+`0af7651916cd43dd8448eb211c80319c`::
+Specifies the trace ID (32 hexadecimal digits).
+
+`b7ad6b7169203331`::
+Specifies the parent ID or span ID (16 hexadecimal digits).
+
+`01`::
+Specifies the trace flags field indicating the trace is sampled.
+
+== Updating your applications
+
+To maintain distributed tracing across your services, you must update applications that:
+
+* **Read trace headers**: Change code that extracts `X-B3-TraceId`, `X-B3-SpanId`, or `X-B3-Sampled` headers to extract and parse the `traceparent` header instead.
+
+* **Write trace headers**: Change code that sets B3 headers on outgoing requests to set the `traceparent` header instead.
+
+* **Log trace IDs**: Update log configurations that reference `X-B3-TraceId` to extract the trace ID from the `traceparent` header.
+
+[NOTE]
+====
+Most modern OpenTelemetry SDKs and instrumentation libraries handle W3C Trace Context propagation automatically. If you are using an OpenTelemetry SDK in your application, you may not need to manually handle trace headers.
+====
+
+.Example: Extracting trace ID from traceparent header in Go
+
+The trace ID is the second field in the `traceparent` header:
+
+[source,go]
+----
+traceparent := r.Header.Get("traceparent")
+parts := strings.Split(traceparent, "-")
+if len(parts) == 4 {
+    traceID := parts[1]
+}
+----
+
+where:
+
+`traceparent`::
+Specifies the W3C Trace Context header containing trace information in the format `version-trace-id-span-id-flags`.
+
+`parts[1]`::
+Specifies the trace ID extracted from the second field of the traceparent header.
+
+.Example: Extracting trace ID from traceparent header in Python
+
+[source,python]
+----
+traceparent = request.headers.get('traceparent')
+parts = traceparent.split('-')
+if len(parts) == 4:
+    trace_id = parts[1]
+----
+
+where:
+
+`traceparent`::
+Specifies the W3C Trace Context header containing trace information in the format `version-trace-id-span-id-flags`.
+
+`parts[1]`::
+Specifies the trace ID extracted from the second field of the traceparent header.
+
+.Example: Extracting trace ID from traceparent header in Java
+
+[source,java]
+----
+String traceparent = request.getHeader("traceparent");
+String[] parts = traceparent.split("-");
+if (parts.length == 4) {
+    String traceId = parts[1];
+}
+----
+
+where:
+
+`traceparent`::
+Specifies the W3C Trace Context header containing trace information in the format `version-trace-id-span-id-flags`.
+
+`parts[1]`::
+Specifies the trace ID extracted from the second field of the traceparent header.
+
+== Temporary migration options
+
+If you cannot immediately update all applications in your distributed system, you have the following options:
+
+* **Use an OpenTelemetry Collector** to translate between trace formats as a temporary bridge. However, this only delays the migration problem, as Zipkin exporter support in OpenTelemetry will be removed in December 2026.
+
+* **Update applications incrementally** and accept incomplete traces during the migration period.
+
+[WARNING]
+====
+Do not rely on B3 header support as a long-term solution. The Zipkin exporter is deprecated and will be removed from the OpenTelemetry specification in December 2026.
+====
+
+[role="_additional-resources"]
+== Additional resources
+
+* link:https://www.w3.org/TR/trace-context/[W3C Trace Context specification]
+* link:https://opentelemetry.io/docs/specs/otel/trace/api/#traceparent-header[OpenTelemetry Trace Context documentation]
+* link:https://opentelemetry.io/docs/specs/otel/trace/sdk_exporters/zipkin/[OpenTelemetry Zipkin exporter deprecation notice]

--- a/modules/serverless-tracing-context-migration.adoc
+++ b/modules/serverless-tracing-context-migration.adoc
@@ -1,0 +1,137 @@
+// Module included in the following assemblies:
+//
+// * serverless/observability/tracing/serverless-tracing-b3-w3c-migration.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="serverless-tracing-context-migration_{context}"]
+= Migrating from B3 to W3C Trace Context propagation
+
+[role="_abstract"]
+{ServerlessProductName} 1.38 and later use OpenTelemetry instead of OpenCensus for distributed tracing. This migration changes the trace context propagation format from B3 Zipkin headers to the W3C Trace Context standard.
+
+[IMPORTANT]
+====
+This is a breaking change. Your applications must use W3C Trace Context headers to propagate trace context correctly. Applications that expect or produce B3 headers will create incomplete distributed traces.
+====
+
+== Understanding the header format changes
+
+The following table shows the trace context header changes:
+
+[cols="2,3,3",options="header"]
+|===
+|Purpose
+|B3 format
+|W3C Trace Context format
+
+|Trace ID and span ID
+|`X-B3-TraceId: 80f198ee56343ba864fe8b2a57d3eff7`
+
+`X-B3-SpanId: e457b5a2e4d86bd1`
+|`traceparent: 00-80f198ee56343ba864fe8b2a57d3eff7-e457b5a2e4d86bd1-01`
+
+|Sampling decision
+|`X-B3-Sampled: 1` (sampled) or `X-B3-Sampled: 0` (not sampled)
+|Included in the `traceparent` flags field as the last two digits: `01` (sampled) or `00` (not sampled)
+
+|Additional vendor-specific data
+|`X-B3-Flags`
+|`tracestate: vendor1=value1,vendor2=value2`
+|===
+
+[NOTE]
+====
+Beyond header format changes, the migration to OpenTelemetry introduces standardized naming conventions for traces. Service names, operation names, and span attributes differ from what OpenCensus previously generated, reflecting the consistent approach to instrumentation in OpenTelemetry.
+====
+
+== W3C Trace Context format
+
+The `traceparent` header uses the format: `version-trace-id-parent-id-trace-flags`
+
+For example:
+----
+traceparent: 00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01
+----
+
+where:
+
+`00`::
+Specifies the version field.
+
+`0af7651916cd43dd8448eb211c80319c`::
+Specifies the trace ID as 32 hexadecimal digits.
+
+`b7ad6b7169203331`::
+Specifies the parent ID or span ID as 16 hexadecimal digits.
+
+`01`::
+Specifies the trace flags field that indicates whether the trace is sampled. A value of `01` means the trace is sampled, while `00` means it is not sampled.
+
+== Updating your applications
+
+You must update your applications to maintain distributed tracing across your services. Update applications that perform the following tasks:
+
+* Read trace headers: Change code that extracts `X-B3-TraceId`, `X-B3-SpanId`, or `X-B3-Sampled` headers to extract and parse the `traceparent` header instead.
+
+* Write trace headers: Change code that sets B3 headers on outgoing requests to set the `traceparent` header instead.
+
+* Log trace IDs: Update log configurations that reference `X-B3-TraceId` to extract the trace ID from the `traceparent` header.
+
+[NOTE]
+====
+Modern OpenTelemetry SDKs and instrumentation libraries handle W3C Trace Context propagation automatically. If you use an OpenTelemetry SDK in your application, you might not need to manually handle trace headers.
+====
+
+The trace ID is the second field in the `traceparent` header (format: `version-trace-id-span-id-flags`).
+
+The following example shows how to extract the trace ID from the `traceparent` header in Go:
+
+[source,go]
+----
+traceparent := r.Header.Get("traceparent")
+parts := strings.Split(traceparent, "-")
+if len(parts) == 4 {
+    traceID := parts[1]
+}
+----
+
+The following example shows how to extract the trace ID from the `traceparent` header in Python:
+
+[source,python]
+----
+traceparent = request.headers.get('traceparent')
+parts = traceparent.split('-')
+if len(parts) == 4:
+    trace_id = parts[1]
+----
+
+The following example shows how to extract the trace ID from the `traceparent` header in Java:
+
+[source,java]
+----
+String traceparent = request.getHeader("traceparent");
+String[] parts = traceparent.split("-");
+if (parts.length == 4) {
+    String traceId = parts[1];
+}
+----
+
+== Temporary migration options
+
+If you cannot immediately update all applications in your distributed system, consider the following options:
+
+* Use an OpenTelemetry Collector to translate between trace formats as a temporary bridge. However, this approach only delays the migration because OpenTelemetry will remove Zipkin exporter support in December 2026.
+
+* Update applications incrementally and accept incomplete traces during the migration period.
+
+[WARNING]
+====
+Do not rely on B3 header support as a long-term solution. OpenTelemetry will remove the deprecated Zipkin exporter from the specification in December 2026.
+====
+
+[role="_additional-resources"]
+== Additional resources
+
+* link:https://www.w3.org/TR/trace-context/[W3C Trace Context specification]
+* link:https://opentelemetry.io/docs/specs/otel/trace/api/#traceparent-header[OpenTelemetry Trace Context documentation]
+* link:https://opentelemetry.io/docs/specs/otel/trace/sdk_exporters/zipkin/[OpenTelemetry Zipkin exporter deprecation notice]

--- a/observability/tracing/serverless-tracing-b3-w3c-migration.adoc
+++ b/observability/tracing/serverless-tracing-b3-w3c-migration.adoc
@@ -1,0 +1,9 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="serverless-tracing-b3-w3c-migration"]
+= Migrating from B3 to W3C Trace Context propagation
+include::_attributes/common-attributes.adoc[]
+:context: serverless-tracing-b3-w3c-migration
+
+toc::[]
+
+include::modules/serverless-tracing-context-migration.adoc[leveloffset=+1]

--- a/observability/tracing/serverless-tracing-jaeger.adoc
+++ b/observability/tracing/serverless-tracing-jaeger.adoc
@@ -5,6 +5,8 @@ include::_attributes/common-attributes.adoc[]
 :context: serverless-tracing-jaeger
 
 [role="_abstract"]
-If you do not want to install all of the components of {DTProductName}, you can still use {DTShortName} on {ocp-product-title} with {ServerlessProductName}. 
+If you do not want to install all of the components of {DTProductName}, you can still use {DTShortName} on {ocp-product-title} with {ServerlessProductName}.
+
+include::modules/serverless-tracing-context-migration.adoc[leveloffset=+1]
 
 include::modules/serverless-jaeger-config.adoc[leveloffset=+1]

--- a/observability/tracing/serverless-tracing-jaeger.adoc
+++ b/observability/tracing/serverless-tracing-jaeger.adoc
@@ -5,6 +5,11 @@ include::_attributes/common-attributes.adoc[]
 :context: serverless-tracing-jaeger
 
 [role="_abstract"]
-If you do not want to install all of the components of {DTProductName}, you can still use {DTShortName} on {ocp-product-title} with {ServerlessProductName}. 
+If you do not want to install all of the components of {DTProductName}, you can still use {DTShortName} on {ocp-product-title} with {ServerlessProductName}.
+
+[IMPORTANT]
+====
+{ServerlessProductName} 1.38 and later use the W3C Trace Context standard instead of B3 headers. For migration guidance, see xref:../../observability/tracing/serverless-tracing-b3-w3c-migration.adoc#serverless-tracing-b3-w3c-migration[Migrating from B3 to W3C Trace Context propagation].
+====
 
 include::modules/serverless-jaeger-config.adoc[leveloffset=+1]

--- a/observability/tracing/serverless-tracing-open-telemetry.adoc
+++ b/observability/tracing/serverless-tracing-open-telemetry.adoc
@@ -7,4 +7,6 @@ include::_attributes/common-attributes.adoc[]
 [role="_abstract"]
 You can use {DTProductName} with {ServerlessProductName} to monitor and troubleshoot serverless applications.
 
+include::modules/serverless-tracing-context-migration.adoc[leveloffset=+1]
+
 include::modules/serverless-open-telemetry.adoc[leveloffset=+1]

--- a/observability/tracing/serverless-tracing-open-telemetry.adoc
+++ b/observability/tracing/serverless-tracing-open-telemetry.adoc
@@ -7,4 +7,9 @@ include::_attributes/common-attributes.adoc[]
 [role="_abstract"]
 You can use {DTProductName} with {ServerlessProductName} to monitor and troubleshoot serverless applications.
 
+[IMPORTANT]
+====
+{ServerlessProductName} 1.38 and later use the W3C Trace Context standard instead of B3 headers. For migration guidance, see xref:../../observability/tracing/serverless-tracing-b3-w3c-migration.adoc#serverless-tracing-b3-w3c-migration[Migrating from B3 to W3C Trace Context propagation].
+====
+
 include::modules/serverless-open-telemetry.adoc[leveloffset=+1]

--- a/observability/tracing/serverless-tracing.adoc
+++ b/observability/tracing/serverless-tracing.adoc
@@ -11,6 +11,8 @@ Distributed tracing records the path of a request through the various services t
 
 include::modules/distr-tracing-product-overview.adoc[leveloffset=+1]
 
+include::modules/serverless-tracing-context-migration.adoc[leveloffset=+1]
+
 [role="_additional-resources"]
 == Additional resources
 

--- a/observability/tracing/serverless-tracing.adoc
+++ b/observability/tracing/serverless-tracing.adoc
@@ -11,6 +11,11 @@ Distributed tracing records the path of a request through the various services t
 
 include::modules/distr-tracing-product-overview.adoc[leveloffset=+1]
 
+[IMPORTANT]
+====
+{ServerlessProductName} 1.38 and later use the W3C Trace Context standard instead of B3 headers. For migration guidance, see xref:../../observability/tracing/serverless-tracing-b3-w3c-migration.adoc#serverless-tracing-b3-w3c-migration[Migrating from B3 to W3C Trace Context propagation].
+====
+
 [role="_additional-resources"]
 == Additional resources
 


### PR DESCRIPTION
Version(s):
-`serverless-docs-1.38`

Issue:
- https://redhat.atlassian.net/browse/SRVCOM-4272

Link to docs preview:
- [Migrating from B3 to W3C Trace Context propagation](https://112148--ocpdocs-pr.netlify.app/openshift-serverless/latest/observability/tracing/serverless-tracing-b3-w3c-migration#serverless-tracing-context-migration_serverless-tracing-b3-w3c-migration)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
