### PR TITLE
OCPBUGS-38140 - Composable openshift : cluster capabilities mismatch

### DIFF
--- a/modules/telco-ran-cluster-tuning.adoc
+++ b/modules/telco-ran-cluster-tuning.adoc
@@ -7,7 +7,7 @@
 = Cluster tuning
 
 New in this release::
-* No reference design updates in this release
+* Documented version-specific cluster capabilities required when using `baselineCapabilitySet: None`
 
 Description::
 The cluster capabilities feature includes a `MachineAPI` component which, when excluded, disables the following Operators and their resources in the cluster:
@@ -38,7 +38,14 @@ The following table lists the required platform tuning configurations:
 |Remove optional cluster capabilities
 a|Reduce the {product-title} footprint by disabling optional cluster Operators on {sno} clusters only.
 
-* Remove all optional Operators except the Marketplace and Node Tuning Operators.
+When you deploy managed clusters with {ztp}, configure cluster capabilities in the `installConfigOverrides` field of the `SiteConfig` CR.
+Set `baselineCapabilitySet` to `None` and enable only the required capabilities in `additionalEnabledCapabilities`.
+
+The following capabilities must be enabled when using `baselineCapabilitySet: None`:
+
+* `NodeTuning` - Required for {product-title} 4.13 and later.
+* `OperatorLifecycleManager` - Required for {product-title} 4.15 and later.
+* `Ingress` - Required for {product-title} 4.16 and later.
 
 |Configure cluster monitoring
 a|Configure the monitoring stack for reduced footprint by doing the following:

--- a/modules/ztp-sno-du-removing-the-console-operator.adoc
+++ b/modules/ztp-sno-du-removing-the-console-operator.adoc
@@ -6,14 +6,30 @@
 [id="ztp-sno-du-removing-the-console-operator_{context}"]
 = Console Operator
 
-Use the cluster capabilities feature to prevent the Console Operator from being installed.
-When the node is centrally managed it is not needed.
-Removing the Operator provides additional space and capacity for application workloads.
+Use the cluster capabilities feature to prevent the Console Operator and other optional Operators from being installed.
+When the node is centrally managed, the console is not needed.
+Removing optional Operators provides additional space and capacity for application workloads.
 
-
-To disable the Console Operator during the installation of the managed cluster, set the following in the `spec.clusters.0.installConfigOverrides` field of the `SiteConfig` custom resource (CR):
+To disable optional cluster capabilities during installation, set `baselineCapabilitySet` to `None` in the `spec.clusters[].installConfigOverrides` field of the `SiteConfig` CR.
+You must also enable the capabilities required for your {product-title} version in `additionalEnabledCapabilities`.
 
 [source,yaml]
 ----
-installConfigOverrides:  "{\"capabilities\":{\"baselineCapabilitySet\": \"None\" }}"
+installConfigOverrides: |
+  {
+    "capabilities": {
+      "baselineCapabilitySet": "None",
+      "additionalEnabledCapabilities": [
+        "NodeTuning",
+        "OperatorLifecycleManager",
+        "Ingress"
+      ]
+    }
+  }
 ----
+
+where:
+
+* `NodeTuning` - Required for {product-title} 4.13 and later.
+* `OperatorLifecycleManager` - Required for {product-title} 4.15 and later.
+* `Ingress` - Required for {product-title} 4.16 and later.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->
OCPBUGS-38140 - Composable openshift : cluster capabilities mismatch between RAN RDS and ZTP
<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.16, 4.17
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://redhat.atlassian.net/browse/OCPBUGS-38140
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
