### PR TITLE
TELCODOCS-2821: Update RAN RDS for 4.22

### DIFF
--- a/modules/telco-ran-cert-manager-operator.adoc
+++ b/modules/telco-ran-cert-manager-operator.adoc
@@ -1,0 +1,26 @@
+// Module included in the following assemblies:
+//
+// * scalability_and_performance/telco-ran-du-rds.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="telco-ran-cert-manager-operator_{context}"]
+= cert-manager Operator
+
+[role="_abstract"]
+The cert-manager Operator for {product-title} manages the lifecycle of TLS certificates for cluster components and workloads.
+
+Description::
++
+--
+The cert-manager Operator for {product-title} manages the lifecycle of TLS certificates for cluster components and workloads.
+cert-manager Operator automates certificate issuance, renewal, and rotation, eliminating manual certificate management.
+The reference configuration includes cert-manager Operator to optionally manage certificates for the API server and ingress controller endpoints.
+--
+
+Limits and requirements::
+
+* The reference configuration includes only the `ACME DNS01` challenge type for platform certificate issuance.
+
+Engineering considerations::
+
+* Use {rh-rhacm} `CertificatePolicy` resources on the hub cluster to monitor certificate expiration and compliance across managed RAN DU clusters.

--- a/modules/telco-ran-cert-manager-operator.adoc
+++ b/modules/telco-ran-cert-manager-operator.adoc
@@ -1,0 +1,28 @@
+// Module included in the following assemblies:
+//
+// * scalability_and_performance/telco-ran-du-rds.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="telco-ran-cert-manager-operator_{context}"]
+= cert-manager Operator
+
+[role="_abstract"]
+The cert-manager Operator for {product-title} manages the lifecycle of TLS certificates for cluster components and workloads.
+
+Description::
++
+--
+The cert-manager Operator for {product-title} manages the lifecycle of TLS certificates for cluster components and workloads.
+cert-manager Operator automates certificate issuance, renewal, and rotation, eliminating manual certificate management.
+The reference configuration includes cert-manager Operator to optionally manage certificates for the API server and ingress controller endpoints.
+--
+
+Limits and requirements::
+
+* You must enable the console capability to use the cert-manager Operator.
+* EUS-to-EUS image-based upgrades are not supported on clusters with the cert-manager Operator installed. Remove the cert-manager Operator before performing the upgrade and reinstall it after the upgrade completes.
+* The reference configuration includes only the `ACME DNS01` challenge type for platform certificate issuance.
+
+Engineering considerations::
+
+* Use {rh-rhacm} `CertificatePolicy` resources on the hub cluster to monitor certificate expiration and compliance across managed RAN DU clusters.

--- a/modules/telco-ran-cluster-tuning.adoc
+++ b/modules/telco-ran-cluster-tuning.adoc
@@ -10,7 +10,7 @@
 Configure cluster tuning settings including cluster capabilities and monitoring for the telco RAN DU reference design.
 
 New in this release::
-* No reference design updates in this release
+* OLM profile collection is removed in {product-title} 4.22. The `DisableOLMPprof` CR compliance type is now set to `mustnothave` to remove the previously applied configuration from clusters.
 
 Description::
 For a full list of components that you can disable using the cluster capabilities feature, see "Cluster capabilities".

--- a/modules/telco-ran-crs-cluster-tuning.adoc
+++ b/modules/telco-ran-crs-cluster-tuning.adoc
@@ -17,7 +17,7 @@ Cluster capabilities,`example-sno.yaml`,Representative ClusterInstance CR to ins
 Console disable,`cluster-tuning/console-disable/ConsoleOperatorDisable.yaml`,Disables the Console Operator.,No
 Disconnected registry,`extra-manifest/09-openshift-marketplace-ns.yaml`,Defines a dedicated namespace for managing the OpenShift Operator Marketplace.,No
 Disconnected registry,`disconnected-registry/DefaultCatsrc.yaml`,Configures the catalog source for the disconnected registry.,No
-Disconnected registry,`cluster-tuning/DisableOLMPprof.yaml`,Disables performance profiling for OLM.,No
+Disconnected registry,`cluster-tuning/DisableOLMPprof.yaml`,Removes the obsolete `ConfigMap` CR that disabled OLM performance profiling in earlier releases. OLM performance profiling collection is removed in {product-title} 4.22.,No
 Disconnected registry,`disconnected-registry/DisconnectedIDMS.yaml`,Configures disconnected registry image content source policy.,No
 Disconnected registry,`cluster-tuning/operator-hub/OperatorHub.yaml`,"Optional, for multi-node clusters only. Configures the OperatorHub in OpenShift, disabling all default Operator sources. Not required for single-node OpenShift installs with marketplace capability disabled.",No
 Monitoring configuration,`cluster-tuning/monitoring-configuration/ReduceMonitoringFootprint.yaml`,"Reduces the monitoring footprint by disabling Alertmanager and Telemeter, and sets Prometheus retention to 24 hours",No

--- a/modules/telco-ran-crs-day-2-operators.adoc
+++ b/modules/telco-ran-crs-day-2-operators.adoc
@@ -20,7 +20,7 @@ Cluster Logging Operator,`cluster-logging/ClusterLogServiceAccount.yaml`,New in 
 Cluster Logging Operator,`cluster-logging/ClusterLogServiceAccountAuditBinding.yaml`,New in 4.18. Configures the cluster logging service account.,No
 Cluster Logging Operator,`cluster-logging/ClusterLogServiceAccountInfrastructureBinding.yaml`,New in 4.18. Configures the cluster logging service account.,No
 Cluster Logging Operator,`cluster-logging/ClusterLogSubscription.yaml`,Manages installation and updates for the Cluster Logging Operator.,No
-Lifecycle Agent,`ibu/ImageBasedUpgrade.yaml`,Manage the image-based upgrade process in OpenShift.,Yes
+Lifecycle Agent,`ibu/ImageBasedUpgrade.yaml`,Manage the image-based upgrade process in {product-title}.,Yes
 Lifecycle Agent,`lca/LcaSubscription.yaml`,Manages installation and updates for the LCA Operator.,Yes
 Lifecycle Agent,`lca/LcaSubscriptionNS.yaml`,Configures namespace for LCA subscription.,Yes
 Lifecycle Agent,`lca/LcaSubscriptionOperGroup.yaml`,Configures the Operator group for the LCA subscription.,Yes
@@ -34,8 +34,8 @@ LVM Operator,`storage-lvm/StorageLVMCluster.yaml`,"Defines an LVM cluster config
 LVM Operator,`storage-lvm/StorageLVMSubscription.yaml`,Manages installation and updates of the LVMS Operator. Optional substitute for the Local Storage Operator.,No
 LVM Operator,`storage-lvm/StorageLVMSubscriptionNS.yaml`,Creates the namespace for the LVMS Operator with labels and annotations for cluster monitoring and workload management. Optional substitute for the Local Storage Operator.,No
 LVM Operator,`storage-lvm/StorageLVMSubscriptionOperGroup.yaml`,Defines the target namespace for the LVMS Operator. Optional substitute for the Local Storage Operator.,No
-Node Tuning Operator,`node-tuning-operator/aarch64/PerformanceProfile.yaml`,"Configures node performance settings in an OpenShift cluster, optimizing for low latency and real-time workloads for aarch64 CPUs.",No
-Node Tuning Operator,`node-tuning-operator/x86_64/PerformanceProfile.yaml`,"Configures node performance settings in an OpenShift cluster, optimizing for low latency and real-time workloads for x86_64 CPUs.",No
+Node Tuning Operator,`node-tuning-operator/aarch64/PerformanceProfile.yaml`,"Configures node performance settings in an {product-title} cluster, optimizing for low latency and real-time workloads for aarch64 CPUs.",No
+Node Tuning Operator,`node-tuning-operator/x86_64/PerformanceProfile.yaml`,"Configures node performance settings in an {product-title} cluster, optimizing for low latency and real-time workloads for x86_64 CPUs.",No
 Node Tuning Operator,`node-tuning-operator/TunedPerformancePatch.yaml`,"Applies performance tuning settings, including scheduler groups and service configurations for nodes in the specific namespace.",No
 Node Tuning Operator,`node-tuning-operator/TunedPowerCustom.yaml`,"Applies additional powersave mode tuning as an overlay on top of TunedPerformancePatch.",No
 PTP fast event notifications,`ptp-operator/configuration/PtpConfigBoundaryForEvent.yaml`,Configures PTP settings for PTP boundary clocks with additional options for event synchronization. Dependent on cluster role.,No
@@ -53,6 +53,7 @@ PTP Operator,`ptp-operator/configuration/PtpConfigTBCWpc.yaml`,Configures PTP as
 PTP Operator,`ptp-operator/configuration/PtpConfigDualCardTBCWpc.yaml`,Configures PTP as a Telecom boundary clock for hosts that have dual NICs. Dependent on cluster role.,No
 PTP Operator,`ptp-operator/configuration/PtpConfigThreeCardTBCWpc.yaml`,Configures PTP as a Telecom boundary clock for hosts that have 3 NICs. Dependent on cluster role.,No
 PTP Operator,`ptp-operator/configuration/PtpConfigTTSCWpc.yaml`,Configures PTP settings for a PTP Telecom Time Slave Clock with single interface. Dependent on cluster role.,N
+PTP Operator,`ptp-operator/configuration/PtpConfigGnrdBcNoHoldover.yaml`,Configures PTP settings for a PTP Boundary Clock without holdover on GNR-D hardware. Dependent on cluster role.,N
 PTP Operator,`ptp-operator/PtpOperatorConfig.yaml`,"Configures the PTP Operator settings, specifying node selection criteria for running PTP daemons in the openshift-ptp namespace.",No
 PTP Operator,`ptp-operator/PtpSubscription.yaml`,Manages installation and updates of the PTP Operator in the openshift-ptp namespace.,No
 PTP Operator,`ptp-operator/PtpSubscriptionNS.yaml`,Configures the namespace for the PTP Operator.,No
@@ -66,8 +67,17 @@ SR-IOV FEC Operator,`sriov-fec-operator/SriovFecClusterConfig.yaml`,"Configures 
 SR-IOV Operator,`sriov-operator/SriovNetwork.yaml`,"Defines an SR-IOV network configuration, with placeholders for various network settings.",No
 SR-IOV Operator,`sriov-operator/SriovNetworkNodePolicy.yaml`,"Configures SR-IOV network settings for specific nodes, including device type, RDMA support, physical function names, and the number of virtual functions.",No
 SR-IOV Operator,`sriov-operator/SriovOperatorConfig.yaml`,"Configures SR-IOV Network Operator settings, including node selection, injector, and webhook options.",No
-SR-IOV Operator,`sriov-operator/SriovOperatorConfigForSNO.yaml`,"Configures the SR-IOV Network Operator settings for Single Node OpenShift (SNO), including node selection, injector, webhook options, and disabling node drain, in the openshift-sriov-network-operator namespace.",No
+SR-IOV Operator,`sriov-operator/SriovOperatorConfigForSNO.yaml`,"Configures the SR-IOV Network Operator settings for {sno}, including node selection, injector, webhook options, and disabling node drain, in the openshift-sriov-network-operator namespace.",No
 SR-IOV Operator,`sriov-operator/SriovSubscription.yaml`,Manages the installation and updates of the SR-IOV Network Operator.,No
 SR-IOV Operator,`sriov-operator/SriovSubscriptionNS.yaml`,Creates the namespace for the SR-IOV Network Operator with specific annotations for workload management and deployment waves.,No
 SR-IOV Operator,`sriov-operator/SriovSubscriptionOperGroup.yaml`,"Defines the target namespace for the SR-IOV Network Operators, enabling their management and deployment within this namespace.",No
+cert-nanager Operator,`optional/cert-manager/certManagerNS.yaml`,Defines the cert-manager-operator namespace.,Yes
+cert-nanager Operator,`optional/cert-manager/certManagerOperatorgroup.yaml`,Defines the OperatorGroup for cert-nanager Operator.,Yes
+cert-nanager Operator,`optional/cert-manager/certManagerSubscription.yaml`,Installs the cert-manager Operator.,Yes
+cert-nanager Operator,`optional/cert-manager/certManagerOperatorStatus.yaml`,Verifies the installation or upgrade of the cert-manager Operator.,Yes
+cert-nanager Operator,`optional/cert-manager/certManagerClusterIssuer.yaml`,Configures an ACME ClusterIssuer using Let's Encrypt with DNS-01 challenge.,Yes
+cert-nanager Operator,`optional/cert-manager/apiServerCertificate.yaml`,Creates a certificate for the API Server endpoint.,Yes
+cert-nanager Operator,`optional/cert-manager/ingressCertificate.yaml`,Creates a wildcard certificate for the Ingress/Router.,Yes
+cert-nanager Operator,`optional/cert-manager/apiServerConfig.yaml`,Configures {product-title} to use the cert-manager generated API Server certificate.,Yes
+cert-nanager Operator,`optional/cert-manager/ingressControllerConfig.yaml`,Configures {product-title} to use the cert-manager generated Ingress certificate.,Yes
 |====

--- a/modules/telco-ran-crs-day-2-operators.adoc
+++ b/modules/telco-ran-crs-day-2-operators.adoc
@@ -53,6 +53,7 @@ PTP Operator,`ptp-operator/configuration/PtpConfigTBCWpc.yaml`,Configures PTP as
 PTP Operator,`ptp-operator/configuration/PtpConfigDualCardTBCWpc.yaml`,Configures PTP as a Telecom boundary clock for hosts that have dual NICs. Dependent on cluster role.,No
 PTP Operator,`ptp-operator/configuration/PtpConfigThreeCardTBCWpc.yaml`,Configures PTP as a Telecom boundary clock for hosts that have 3 NICs. Dependent on cluster role.,No
 PTP Operator,`ptp-operator/configuration/PtpConfigTTSCWpc.yaml`,Configures PTP settings for a PTP Telecom Time Slave Clock with single interface. Dependent on cluster role.,N
+PTP Operator,`ptp-operator/configuration/PtpConfigGnrdBcNoHoldover.yaml`,Configures PTP settings for a PTP Boundary Clock without holdover on GNR-D hardware. Dependent on cluster role.,N
 PTP Operator,`ptp-operator/PtpOperatorConfig.yaml`,"Configures the PTP Operator settings, specifying node selection criteria for running PTP daemons in the openshift-ptp namespace.",No
 PTP Operator,`ptp-operator/PtpSubscription.yaml`,Manages installation and updates of the PTP Operator in the openshift-ptp namespace.,No
 PTP Operator,`ptp-operator/PtpSubscriptionNS.yaml`,Configures the namespace for the PTP Operator.,No
@@ -70,4 +71,12 @@ SR-IOV Operator,`sriov-operator/SriovOperatorConfigForSNO.yaml`,"Configures the 
 SR-IOV Operator,`sriov-operator/SriovSubscription.yaml`,Manages the installation and updates of the SR-IOV Network Operator.,No
 SR-IOV Operator,`sriov-operator/SriovSubscriptionNS.yaml`,Creates the namespace for the SR-IOV Network Operator with specific annotations for workload management and deployment waves.,No
 SR-IOV Operator,`sriov-operator/SriovSubscriptionOperGroup.yaml`,"Defines the target namespace for the SR-IOV Network Operators, enabling their management and deployment within this namespace.",No
+Cert-Manager,`optional/cert-manager/certManagerNS.yaml`,Defines the cert-manager-operator namespace.,Yes
+Cert-Manager,`optional/cert-manager/certManagerOperatorgroup.yaml`,Defines the OperatorGroup for cert-manager.,Yes
+Cert-Manager,`optional/cert-manager/certManagerSubscription.yaml`,Installs the OpenShift cert-manager operator.,Yes
+Cert-Manager,`optional/cert-manager/certManagerClusterIssuer.yaml`,Configures an ACME ClusterIssuer using Let's Encrypt with DNS-01 challenge.,Yes
+Cert-Manager,`optional/cert-manager/apiServerCertificate.yaml`,Creates a certificate for the API Server endpoint.,Yes
+Cert-Manager,`optional/cert-manager/ingressCertificate.yaml`,Creates a wildcard certificate for the Ingress/Router.,Yes
+Cert-Manager,`optional/cert-manager/apiServerConfig.yaml`,Configures OpenShift to use the cert-manager generated API Server certificate.,Yes
+Cert-Manager,`optional/cert-manager/ingressControllerConfig.yaml`,Configures OpenShift to use the cert-manager generated Ingress certificate.,Yes
 |====

--- a/modules/telco-ran-engineering-considerations-for-the-ran-du-use-model.adoc
+++ b/modules/telco-ran-engineering-considerations-for-the-ran-du-use-model.adoc
@@ -13,7 +13,7 @@ Specific limits, requirements and engineering considerations for individual comp
 
 [NOTE]
 ====
-For details of the telco RAN DU RDS KPI test results, see the link:https://access.redhat.com/articles/7107302[telco RAN DU {product-version} reference design specification KPI test results].
+For details of the telco RAN DU RDS KPI test results, see the link:https://access.redhat.com/articles/7143490[telco RAN DU {product-version} reference design specification KPI test results].
 This information is only available to customers and partners.
 ====
 
@@ -75,10 +75,12 @@ Supported cluster topologies for RAN DU::
 |No
 
 |===
++
+* The standard mixed-architecture topology uses `x86_64` control plane nodes and `AArch64` worker nodes.
 
 Workloads::
 . DU workloads are described in xref:../scalability_and_performance/telco-ran-du-rds.adoc#telco-ran-du-application-workloads_telco-ran-du[Telco RAN DU application workloads].
-. DU worker nodes are Intel 3rd Generation Xeon (IceLake) 2.20 GHz or newer with host firmware tuned for maximum performance.
+. DU worker nodes are Intel 3rd Generation Xeon (Ice Lake) 2.20 GHz or newer with host firmware tuned for maximum performance.
 
 Resources::
 The maximum number of running pods in the system, inclusive of application workload and {product-title} pods, is 160.
@@ -111,7 +113,12 @@ You might need to allocate additional cluster resources to meet these requiremen
 
 Reference application workload characteristics::
 . Uses 75 pods across 5 namespaces with 4 containers per pod for the vRAN application including its management and control functions
-. Creates 30 `ConfigMap` CRs and 30 `Secret` CRs per namespace
+. Creates 30 `ConfigMap` CRs and 30 `Secret` CRs for each namespace
++
+[NOTE]
+====
+The RDS validates mutable `ConfigMap` CRs. However, use immutable `ConfigMap` CRs where possible. Immutable resources significantly reduce the load on the API server by eliminating resource watches. A high volume of `ConfigMap` CRs, up to the validated 30 for vDU, might increase node recovery time during reboots, as volume mount points are recreated. The maximum size for each `ConfigMap` CR is limited to 1 MB.
+====
 . Uses no exec probes
 . Uses a secondary network
 +

--- a/modules/telco-ran-engineering-considerations-for-the-ran-du-use-model.adoc
+++ b/modules/telco-ran-engineering-considerations-for-the-ran-du-use-model.adoc
@@ -75,10 +75,12 @@ Supported cluster topologies for RAN DU::
 |No
 
 |===
++
+* The standard mixed-architecture topology uses `x86_64` control plane nodes and `AArch64` worker nodes.
 
 Workloads::
 . DU workloads are described in xref:../scalability_and_performance/telco-ran-du-rds.adoc#telco-ran-du-application-workloads_telco-ran-du[Telco RAN DU application workloads].
-. DU worker nodes are Intel 3rd Generation Xeon (IceLake) 2.20 GHz or newer with host firmware tuned for maximum performance.
+. DU worker nodes are Intel 3rd Generation Xeon (Ice Lake) 2.20 GHz or newer with host firmware tuned for maximum performance.
 
 Resources::
 The maximum number of running pods in the system, inclusive of application workload and {product-title} pods, is 160.
@@ -111,7 +113,12 @@ You might need to allocate additional cluster resources to meet these requiremen
 
 Reference application workload characteristics::
 . Uses 75 pods across 5 namespaces with 4 containers per pod for the vRAN application including its management and control functions
-. Creates 30 `ConfigMap` CRs and 30 `Secret` CRs per namespace
+. Creates 30 `ConfigMap` CRs and 30 `Secret` CRs for each namespace
++
+[NOTE]
+====
+The RDS validates mutable `ConfigMap` CRs. However, use immutable `ConfigMap` CRs where possible. Immutable resources significantly reduce the load on the API server by eliminating resource watches. A high volume of `ConfigMap` CRs, up to the validated 30 for vDU, might increase node recovery time during reboots, as volume mount points are recreated. The maximum size for each `ConfigMap` CR is limited to 1MB.
+====
 . Uses no exec probes
 . Uses a secondary network
 +

--- a/modules/telco-ran-gitops-operator-and-ztp-plugins.adoc
+++ b/modules/telco-ran-gitops-operator-and-ztp-plugins.adoc
@@ -31,7 +31,7 @@ To maintain multiple per-version policies simultaneously, use Git to manage the 
 
 Limits and requirements::
 // Scale results ACM-17868
-* 1000 `ClusterInstance` CRs per ArgoCD application.
+* 1000 `ClusterInstance` CRs per ArgoCD application on a hub cluster conforming to the Hub RDS.
 Multiple applications can be used to achieve the maximum number of clusters supported by a single hub cluster
 * Content in the `source-crs/` directory in Git overrides content provided in the ZTP plugin container, as Git takes precedence in the search path.
 * The `source-crs/` directory must be located in the same directory as the `kustomization.yaml` file, which includes `PolicyGenerator` CRs as a generator.

--- a/modules/telco-ran-machine-configuration.adoc
+++ b/modules/telco-ran-machine-configuration.adoc
@@ -36,9 +36,6 @@ Limits and requirements::
 Enables kdump to capture debug information when a kernel panic occurs.
 The reference CRs that enable kdump have an increased memory reservation based on the set of drivers and kernel modules included in the reference configuration.
 
-|CRI-O wipe disable
-|Disables automatic wiping of the CRI-O image cache after unclean shutdown
-
 |SR-IOV-related kernel arguments
 |Include additional SR-IOV-related arguments in the kernel command line
 

--- a/modules/telco-ran-node-tuning-operator.adoc
+++ b/modules/telco-ran-node-tuning-operator.adoc
@@ -10,10 +10,7 @@
 The RAN DU use model includes cluster performance tuning using `PerformanceProfile` CRs for low-latency performance, and a `TunedPerformancePatch` CR that adds additional RAN-specific tuning.
 
 New in this release::
-* There is now optional support for `acpi_idle` CPUIdle driver.
-* Updates to `TunedPerformancePatch` to enable the triggering a kernel panic for system recovery and diagnostic purposes when x86_64 architecture nodes become unresponsive. The `TunedPerformancePatch` configures the `kernel.panic_on_unrecovered_nmi` sysctl parameter to enable triggering a kernel panic through BMC Non-Maskable Interrupt (NMI) on x86_64 architectures.
-
-
+* No reference design updates in this release
 
 Description::
 The RAN DU use model includes cluster performance tuning using `PerformanceProfile` CRs for low-latency performance, and a `TunedPerformancePatch` CR that adds additional RAN-specific tuning.
@@ -68,7 +65,7 @@ To ensure that pods with guaranteed whole CPU QoS have full use of allocated CPU
 * Tailor `systemReserved` memory for each cluster based on its size and application workload. The minimum recommended value is 11Gi.
 * Under x86_64, the `PerformanceProfile` may be customized with the following optional arguments in the `additionalKernelargs` list:
 ** The `vcio_pci` arguments support devices such as the FEC accelerator. You can omit them if they are not required for your workload.
-** To enable the `acpi_idle`` CPUIdle driver, for example, for Intel FlexRAN, add `intel_idle.max_cstate=0`
+** To enable the `acpi_idle` CPUIdle driver, for example, for Intel FlexRAN, add `intel_idle.max_cstate=0`
 * Under aarch64, the `PerformanceProfile` must be adjusted depending on the needs of the platform:
 ** For Grace Hopper systems, the following kernel commandline arguments are required:
 *** `acpi_power_meter.force_cap_on=y`

--- a/modules/telco-ran-ptp-operator.adoc
+++ b/modules/telco-ran-ptp-operator.adoc
@@ -10,10 +10,10 @@
 Configure Precision Time Protocol (PTP) in cluster nodes to ensure precise timing and reliability in the RAN environment.
 
 New in this release::
-* {product-title} 4.20 introduced unassisted holdover for boundary clocks and time synchronous clocks as a Technology Preview feature. This feature is now Generally Available (GA).
+* Support for PTP boundary clock without holdover on GNR-D hardware.
 
 Description::
-Configure Precision Time Protocol (PTP) in cluster nodes.
+Configure PTP in cluster nodes.
 PTP ensures precise timing and reliability in the RAN environment, compared to other clock synchronization protocols, like NTP.
 Support includes::
 * Grandmaster clock (T-GM): use GPS to sync the local clock and provide time synchronization to other devices
@@ -23,24 +23,32 @@ Support includes::
 Configuration variations allow for multiple NIC configurations for greater time distribution and high availability (HA), and optional fast event notification over HTTP.
 
 Limits and requirements::
-
 * Supports the PTP G.8275.1 profile for the following telco use-cases:
 ** T-GM use-case:
 *** Limited to a maximum of 3 Westport channel NICs
-*** Requires GNSS input to one NIC card, with SMA connections to synchronize additional NICs
+**** Requires GNSS input to one NIC card, with SMA connections to synchronize additional NICs
 *** HA support N/A
+*** GNR-D is not supported for T-GM.
 ** T-BC use-case:
 *** Limited to a maximum of 2 NICs
 *** System clock HA support is optional in 2-NIC configuration.
+*** GNR-D is not supported for T-BC.
 ** T-TSC use-case:
 *** Limited to single NIC only
 *** System clock HA support is optional in active/standby 2-port configuration.
+*** GNR-D is not supported for T-TSC.
+** T-BC without holdover use-case:
+*** GNR-D hardware with 0, 1, or 2 additional Carter Flats, e830 NICs
+*** Time receiver port must be one of the onboard NAC ports.
+*** Time transmitters may be configured to any combination of NAC and Carter Flats ports, up to a total of 23.
+*** Holdover is not enabled, so any failure of the Time receiver will enter `FREERUN` state immediately.
 * Log reduction must be enabled with `true` or `enhanced`.
 
 Engineering considerations::
 * Example RAN DU RDS configurations are provided for:
-** T-GM, T-BC, and T-TSC
+** T-GM, T-BC, T-TSC, and BC-without-holdover
 ** Variations with and without HA
+** Variations with and without fast event notification
 * PTP fast event notifications use `ConfigMap` CRs to persist subscriber details.
 * Hierarchical event subscription as described in the O-RAN specification is not supported for PTP events.
-* Cluster Node(s) must have proper NTP configuration to ensure correct time prior to PTP operator taking ownership of node timing.
+* Cluster nodes must have proper NTP configuration to ensure correct time prior to PTP operator taking ownership of node timing.

--- a/modules/telco-ran-ptp-operator.adoc
+++ b/modules/telco-ran-ptp-operator.adoc
@@ -10,10 +10,10 @@
 Configure Precision Time Protocol (PTP) in cluster nodes to ensure precise timing and reliability in the RAN environment.
 
 New in this release::
-* {product-title} 4.20 introduced unassisted holdover for boundary clocks and time synchronous clocks as a Technology Preview feature. This feature is now Generally Available (GA).
+* Configure PTP boundary clock without holdover on Granite Rapids (GNR-D) hardware.
 
 Description::
-Configure Precision Time Protocol (PTP) in cluster nodes.
+Configure PTP in cluster nodes.
 PTP ensures precise timing and reliability in the RAN environment, compared to other clock synchronization protocols, like NTP.
 Support includes::
 * Grandmaster clock (T-GM): use GPS to sync the local clock and provide time synchronization to other devices
@@ -23,24 +23,32 @@ Support includes::
 Configuration variations allow for multiple NIC configurations for greater time distribution and high availability (HA), and optional fast event notification over HTTP.
 
 Limits and requirements::
-
 * Supports the PTP G.8275.1 profile for the following telco use-cases:
 ** T-GM use-case:
 *** Limited to a maximum of 3 Westport channel NICs
-*** Requires GNSS input to one NIC card, with SMA connections to synchronize additional NICs
+**** Requires GNSS input to one NIC card, with SMA connections to synchronize additional NICs
 *** HA support N/A
+*** GNR-D is not supported for T-GM.
 ** T-BC use-case:
 *** Limited to a maximum of 2 NICs
 *** System clock HA support is optional in 2-NIC configuration.
+*** GNR-D is not supported for T-BC.
 ** T-TSC use-case:
 *** Limited to single NIC only
 *** System clock HA support is optional in active/standby 2-port configuration.
+*** GNR-D is not supported for T-TSC.
+** T-BC without holdover use-case:
+*** GNR-D hardware with 0, 1, or 2 additional Carter Flats, e830 NICs
+*** Time receiver port must be one of the on board NAC ports.
+*** Time transmitters may be configured to any combination of NAC and Carter Flats ports, up to a total of 23.
+*** Holdover is not enabled, so any failure of the Time receiver will enter `FREERUN` state immediately.
 * Log reduction must be enabled with `true` or `enhanced`.
 
 Engineering considerations::
 * Example RAN DU RDS configurations are provided for:
-** T-GM, T-BC, and T-TSC
+** T-GM, T-BC, T-TSC, and BC-without-holdover
 ** Variations with and without HA
+** Variations with and without fast event notification
 * PTP fast event notifications use `ConfigMap` CRs to persist subscriber details.
 * Hierarchical event subscription as described in the O-RAN specification is not supported for PTP events.
-* Cluster Node(s) must have proper NTP configuration to ensure correct time prior to PTP operator taking ownership of node timing.
+* Cluster nodes must have proper NTP configuration to ensure correct time prior to PTP operator taking ownership of node timing.

--- a/modules/telco-ran-red-hat-advanced-cluster-management-rhacm.adoc
+++ b/modules/telco-ran-red-hat-advanced-cluster-management-rhacm.adoc
@@ -10,7 +10,7 @@
 {rh-rhacm} provides Multi Cluster Engine (MCE) installation and ongoing lifecycle management functionality for deployed clusters.
 
 New in this release::
-* The CRI-O wipe disable `MachineConfig` CR is no longer needed as cri-o now handles unclean shutdowns by performing a quick check and repair.
+* No reference design updates in this release
 
 Description::
 +

--- a/modules/telco-ran-sysctls.adoc
+++ b/modules/telco-ran-sysctls.adoc
@@ -4,20 +4,20 @@
 
 :_mod-docs-content-type: REFERENCE
 [id="telco-ran-sysctls_{context}"]
-= Kubelet Settings
+= Kubelet settings
 
 [role="_abstract"]
 Configure kubelet settings and sysctls for the telco RAN DU use model, including `systemReserved` and unsafe sysctl parameters.
 
 New in this release::
-Support for configuring `systemReserved` settings (cpu and memory).
+* No reference design updates in this release
 
 Some CNF workloads make use of sysctls which are not in the list of system-wide safe sysctls.
 Generally, network sysctls are namespaced and you can enable them using the `kubeletconfig.experimental` annotation in the `PerformanceProfile` Custom Resource (CR).
 
-Additionally, the `systemReserved` memory can be configured through the same `kubeletconfig.experimental` annotation to reserve memory for system daemons and kernel processes. An example setting of these parameters as a string of JSON is shown here:
-.Example snippet showing allowedUnsafeSysctls and systemReserved
+Additionally, the `systemReserved` memory can be configured through the same `kubeletconfig.experimental` annotation to reserve memory for system daemons and kernel processes.
 
+An example setting of these parameters as a string of JSON is shown here:
 
 .Example snippet showing allowedUnsafeSysctls and systemReserved
 [source,yaml]

--- a/modules/telco-ref-design-overview.adoc
+++ b/modules/telco-ref-design-overview.adoc
@@ -33,8 +33,8 @@ image::474_OpenShift_OpenShift_RAN_RDS_arch_updates_1023.png[A diagram showing t
 |===
 
 |Architecture
-|Real-time Kernel
-|Non-Realtime Kernel
+|Real-time kernel
+|Non-real-time kernel
 
 |x86_64
 |Yes
@@ -44,4 +44,6 @@ image::474_OpenShift_OpenShift_RAN_RDS_arch_updates_1023.png[A diagram showing t
 |No
 |Yes
 |===
++
+* For `aarch64` architecture CPUs, the non-real-time configuration uses the standard kernel with a 64k page size.
 

--- a/modules/ztp-telco-ran-software-versions.adoc
+++ b/modules/ztp-telco-ran-software-versions.adoc
@@ -16,26 +16,32 @@ The Red Hat telco RAN DU {product-version} solution has been validated using the
 |Software version
 
 |{product-title}
-|4.21
+|4.22
+
+|cert-manager Operator
+|1.19
 
 |Cluster Logging Operator
-|6.2
+|6.5
 
 |Local Storage Operator
-|4.21
+|4.22
 
 |OpenShift API for Data Protection (OADP)
-|1.5
+|1.6
 
 |PTP Operator
-|4.21
+|4.22
 
 |SR-IOV Operator
-|4.21
+|4.22
 
 |SRIOV-FEC Operator
-|2.11
+|2.12
 
 |Lifecycle Agent Operator
-|4.21
+|4.22
 |====
+
+* The cert-manager Operator is a platform agnostic Operator. The support lifecycle for the cert-manager Operator is independent from the support lifecycle for {product-title}. You might need to update to a newer minor version of this Operator at the end of an Operator lifecycle, or when planning to update the {product-title} cluster to continue support. For support lifecycle details for platform agnostic operators, see link:https://access.redhat.com/support/policy/updates/openshift_operators[OpenShift Operator Life Cycles].
+* Cluster Logging Operator will be updated to 6.6 when the aligned Cluster Logging Operator version is released.

--- a/modules/ztp-telco-ran-software-versions.adoc
+++ b/modules/ztp-telco-ran-software-versions.adoc
@@ -16,26 +16,32 @@ The Red Hat telco RAN DU {product-version} solution has been validated using the
 |Software version
 
 |{product-title}
-|4.21
+|4.22
+
+|cert-manager Operator
+|1.19
 
 |Cluster Logging Operator
-|6.2
+|6.5
 
 |Local Storage Operator
-|4.21
+|4.22
 
 |OpenShift API for Data Protection (OADP)
-|1.5
+|1.6
 
 |PTP Operator
-|4.21
+|4.22
 
 |SR-IOV Operator
-|4.21
+|4.22
 
 |SRIOV-FEC Operator
-|2.11
+|2.12
 
 |Lifecycle Agent Operator
-|4.21
+|4.22
 |====
+
+* The cert-manager Operator is a platform-agnostic Operator. The support lifecycle for the cert-manager Operator is independent from the support lifecycle for {product-title}. You might need to update to a newer minor version of this Operator at the end of an Operator lifecycle, or when planning to update the {product-title} cluster to continue support. For support lifecycle details for platform agnostic operators, see link:https://access.redhat.com/support/policy/updates/openshift_operators[OpenShift Operator Life Cycles].
+* Cluster Logging Operator will be updated to 6.6 when the aligned Cluster Logging Operator version is released.

--- a/scalability_and_performance/telco-ran-du-rds.adoc
+++ b/scalability_and_performance/telco-ran-du-rds.adoc
@@ -153,7 +153,7 @@ include::modules/telco-ran-agent-based-installer-abi.adoc[leveloffset=+2]
 
 * xref:../installing/installing_with_agent_based_installer/installing-with-agent-based-installer.adoc#installing-with-agent-based-installer[Installing a cluster with customizations]
 
-// include::modules/telco-ran-additional-components.adoc[leveloffset=+2]
+include::modules/telco-ran-cert-manager-operator.adoc[leveloffset=+2]
 
 include::modules/telco-ran-du-reference-configuration-crs.adoc[leveloffset=+1]
 


### PR DESCRIPTION
[TELCODOCS-2821](https://redhat.atlassian.net/browse/TELCODOCS-2821): Update RAN RDS for 4.22

Version(s):
4.22+

Issue:
https://redhat.atlassian.net/browse/TELCODOCS-2821

Link to docs preview:
https://112156--ocpdocs-pr.netlify.app/openshift-enterprise/latest/scalability_and_performance/telco-ran-du-rds.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

