### PR TITLE
OBSDOCS-3359 [DOC] Add support to enable the ethtool collector in node-exporter via Cluster Monitoring Operator

### DIFF
--- a/modules/monitoring-cluster-monitoring-operator-configuration-reference.adoc
+++ b/modules/monitoring-cluster-monitoring-operator-configuration-reference.adoc
@@ -245,7 +245,9 @@ Appears in: link:#nodeexporterconfig[NodeExporterConfig]
 
 |tcpstat|link:#nodeexportercollectortcpstatconfig[NodeExporterCollectorTcpStatConfig]|Defines the configuration of the `tcpstat` collector, which collects TCP connection statistics. Disabled by default.
 
-|netdev|link:#nodeexportercollectornetdevconfig[NodeExporterCollectorNetDevConfig]|Defines the configuration of the `netdev` collector, which collects network devices statistics. Enabled by default.
+|ethtool|link:#nodeexportercollectorethtoolconfig[NodeExporterCollectorEthtoolConfig]|Defines the configuration of the `ethtool` collector, which collects Ethernet device statistics. Disabled by default.
+
+|netdev|link:#nodeexportercollectornetdevconfig[NodeExporterCollectorNetDevConfig]|Defines the configuration of the `netdev` collector, which collects network device statistics. Enabled by default.
 
 |netclass|link:#nodeexportercollectornetclassconfig[NodeExporterCollectorNetClassConfig]|Defines the configuration of the `netclass` collector, which collects information about network devices. Enabled by default.
 
@@ -374,6 +376,20 @@ Appears in: link:#nodeexportercollectorconfig[NodeExporterCollectorConfig]
 |===
 | Property | Type | Description
 |enabled|bool|A Boolean flag that enables or disables the `tcpstat` collector.
+
+|===
+
+== NodeExporterCollectorEthtoolConfig
+
+Description::
+The `NodeExporterCollectorEthtoolConfig` resource works as an on/off switch for the `ethtool` collector of the `node-exporter` agent. By default, the `ethtool` collector is disabled.
+
+Appears in: link:#nodeexportercollectorconfig[NodeExporterCollectorConfig]
+
+[options="header"]
+|===
+| Property | Type | Description
+|enabled|bool|A Boolean flag that enables or disables the `ethtool` collector.
 
 |===
 


### PR DESCRIPTION
Change type: Doc update; Add support to enable the ethtool collector in node-exporter via Cluster Monitoring Operator

Doc JIRA: https://redhat.atlassian.net/browse/OBSDOCS-3359

Also merge to: monitoring-docs-4.22

Doc Preview: https://112157--ocpdocs-pr.netlify.app/openshift-monitoring/latest/config-map-reference/config-map-reference-for-the-cluster-monitoring-operator.html

SME/QE Review: @jan--f @simonpasquier 
Peer review: @kaldesai 