### PR TITLE
RHDEVDOCS-7543: Content creation for using API tokens

### DIFF
--- a/modules/op-authenticating-pipelines-repos-using-secrets.adoc
+++ b/modules/op-authenticating-pipelines-repos-using-secrets.adoc
@@ -1,0 +1,54 @@
+// This module is included in the following assemblies:
+// * secure/authenticating-pipelines-repos-using-secrets.adoc
+:_mod-docs-content-type: PROCEDURE
+[id="op-authenticating-pipelines-repos-using-secrets_{context}"]
+= Authenticating to Bitbucket Cloud using API tokens
+
+[role="_abstract"]
+If you use private repositories hosted on Bitbucket Cloud, you can authenticate repository access in {pipelines-title} by using a Bitbucket Cloud API token stored in a Kubernetes secret.
+
+Bitbucket Cloud API tokens are recommended for CI/CD automation and can be scoped with limited permissions for repository access.
+
+.Procedure
+
+. Create a Bitbucket Cloud API token with `Repositories: Read` permission scope.
+
+. Create a secret in your OpenShift cluster by running the following command:
++
+[source,terminal]
+----
+$ oc create secret generic bitbucket-auth \
+  --type=kubernetes.io/basic-auth \
+  --from-literal=username=<bitbucket_username> \
+  --from-literal=password=<bitbucket_api_token>
+----
++
+[NOTE]
+====
+You can use either your Bitbucket username or the static username `x-bitbucket-api-token-auth` as the username value when authenticating with a Bitbucket Cloud API token.
+====
++
+. Annotate the secret to enable {pipelines-shortname} to use it for Bitbucket Cloud repositories.
++
+[source,terminal]
+----
+$ oc annotate secret bitbucket-auth tekton.dev/git-0=https://bitbucket.org
+----
+
+. Attach the secret to the service account used by your pipeline by running the following command:
++
+[source,terminal]
+----
+$ oc secrets link <service_account_name> bitbucket-auth
+----
+
+. Reference the repository in your `git-clone` task:
++
+[source,yaml]
+----
+params:
+  - name: url
+    value: https://bitbucket.org/<workspace>/<repository>.git
+----
+
+At runtime, the `git-clone` task uses credentials from the `bitbucket-auth` secret when accessing HTTPS Git URLs matching `https://bitbucket.org`.

--- a/secure/authenticating-pipelines-repos-using-secrets.adoc
+++ b/secure/authenticating-pipelines-repos-using-secrets.adoc
@@ -18,6 +18,8 @@ include::modules/op-providing-secrets-service-accounts-about.adoc[leveloffset=+1
 
 include::modules/op-types-annotation-secrets.adoc[leveloffset=+2]
 
+include::modules/op-authenticating-pipelines-repos-using-secrets.adoc[leveloffset=+2]
+
 include::modules/op-configuring-basic-authentication-for-git.adoc[leveloffset=+2]
 
 include::modules/op-configuring-ssh-authentication-for-git.adoc[leveloffset=+2]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

pipelines-docs-1.23

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

https://redhat.atlassian.net/browse/RHDEVDOCS-7543

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

[Authenticating to Bitbucket Cloud using API tokens](https://112162--ocpdocs-pr.netlify.app/openshift-pipelines/latest/secure/authenticating-pipelines-repos-using-secrets.html#op-authenticating-pipelines-repos-using-secrets_authenticating-pipelines-repos-using-secrets)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

SME review: @waveywaves 
QE review: NA
Peer review: @ochromy 

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
