### PR TITLE
OCPBUGS-86496 Remove TP associated with spec.featureGates.mellanoxFirmwareReset

### DIFF
--- a/modules/nw-sriov-operator-cr.adoc
+++ b/modules/nw-sriov-operator-cr.adoc
@@ -56,7 +56,4 @@ The following table describes the `sriovoperatorconfig` CR fields:
 |`boolean`
 |Specifies whether to reset the firmware on virtual function (VF) changes in the SR-IOV Network Operator. Some chipsets, such as the Intel C740 Series, do not completely power off the PCI-E devices, which is required to configure VFs on NVIDIA/Mellanox NICs. By default, this field is set to `false`.
 
-:FeatureName: The `spec.featureGates.mellanoxFirmwareReset` parameter
-include::snippets/technology-preview.adoc[]
-
 |====


### PR DESCRIPTION
[OCPBUGS-86496]: Remove TP note from https://docs.redhat.com/en/documentation/openshift_container_platform/4.21/html/networking_operators/sr-iov-operator#nw-sriov-operator-cr_configuring-sriov-operator

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.22 and main
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:https://redhat.atlassian.net/browse/OCPBUGS-86496
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:https://112201--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/networking_operators/sr-iov-operator/configuring-sriov-operator.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
