### PR TITLE
CNV-62146: Boot source garbage collection configuration

### DIFF
--- a/modules/virt-configuring-bootsource-garbage-collection.adoc
+++ b/modules/virt-configuring-bootsource-garbage-collection.adoc
@@ -1,0 +1,48 @@
+// Module included in the following assemblies:
+//
+// * virt/storage/virt-automatic-bootsource-updates.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="virt-configuring-bootsource-garbage-collection_{context}"]
+= Configuring boot source garbage collection and retention
+
+[role="_abstract"]
+You can configure garbage collection and image retention settings to limit the number of older operating system image versions preserved on the cluster.
+
+When automatic boot source updates are enabled, the Containerized Data Importer (CDI) tracks and downloads the latest versions of operating system images. By default, the system retains older versions of these imported images as a safety mechanism, allowing you to roll back if a newly imported version introduces issues. However, in environments with limited storage capacity, such as single-node OpenShift (SNO) environments, lowering the retention count helps conserve disk space.
+
+[NOTE]
+====
+Manually deleting older `PersistentVolumeClaim` or `DataVolume` objects associated with historic boot source imports does not impact cluster stability or future updates.
+====
+
+.Procedure
+
+. Open the `HyperConverged` custom resource (CR) in your default editor:
++
+[source,terminal]
+----
+$ oc edit hyperconverged kubevirt-hyperconverged -n openshift-cnv
+----
+
+. Edit the `spec.dataImportCronTemplates` field to add or adjust the `garbageCollect` and `importsToKeep` parameters:
++
+[source,yaml]
+----
+apiVersion: hco.kubevirt.io/v1beta1
+kind: HyperConverged
+metadata:
+  name: kubevirt-hyperconverged
+spec:
+  dataImportCronTemplates:
+    - metadata:
+        name: rhel9-image-cron
+      spec:
+        garbageCollect: Outdated <1>
+        importsToKeep: 1 <2>
+        schedule: "0 */12 * * *"
+        managedDataSource: rhel9
+----
+. Specifies the garbage collection policy. Valid values are `Outdated` to automatically delete older resource versions after a successful import, or `Never` to retain all previous versions.
+. Specifies the number of older image versions to retain. The default value is `3`.
+. Save and exit the editor to apply the changes.

--- a/modules/virt-increasing-bootsource-disk-image-retention.adoc
+++ b/modules/virt-increasing-bootsource-disk-image-retention.adoc
@@ -1,0 +1,45 @@
+// Module included in the following assemblies:
+//
+// * virt-increasing-bootsource-disk-image-retention.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="virt-increasing-bootsource-disk-image-retention_{context}"]
+= Increasing boot source disk image retention
+
+[role="_abstract"]
+You can configure image retention settings to increase the number of older operating system image versions preserved on the cluster.
+
+When automatic boot source updates are enabled, the Containerized Data Importer (CDI) tracks and downloads the latest versions of operating system images. By default, the system aggressively minimizes the retention of older versions to conserve disk space. However, if you require a safety mechanism that allows you to roll back if a newly imported version introduces issues, you can increase the retention count.
+
+[NOTE]
+====
+Manually deleting older `PersistentVolumeClaim` or `DataVolume` objects associated with historic boot source imports does not impact cluster stability or future updates.
+====
+
+.Procedure
+
+. Open the `HyperConverged` custom resource (CR) in your default editor:
++
+[source,terminal]
+----
+$ oc edit hyperconverged kubevirt-hyperconverged -n openshift-cnv
+----
+
+. Edit the `spec.dataImportCronTemplates` field to adjust the `importsToKeep` parameter to your preferred retention threshold:
++
+[source,yaml]
+----
+apiVersion: hco.kubevirt.io/v1beta1
+kind: HyperConverged
+metadata:
+  name: kubevirt-hyperconverged
+spec:
+  dataImportCronTemplates:
+    - metadata:
+        name: rhel9-image-cron
+      spec:
+        garbageCollect: Outdated <1>
+        importsToKeep: 3
+        schedule: "0 */12 * * *"
+        managedDataSource: rhel9
+----

--- a/virt/storage/virt-automatic-bootsource-updates.adoc
+++ b/virt/storage/virt-automatic-bootsource-updates.adoc
@@ -21,6 +21,8 @@ include::modules/virt-enabling-volume-snapshot-boot-source.adoc[leveloffset=+1]
 
 include::modules/virt-disable-auto-updates-single-boot-source.adoc[leveloffset=+1]
 
+include::modules/virt-increasing-bootsource-disk-image-retention.adoc[leveloffset=+1]
+
 include::modules/virt-verify-status-bootsource-update.adoc[leveloffset=+1]
 
 [role="_additional-resources"]

--- a/virt/storage/virt-automatic-bootsource-updates.adoc
+++ b/virt/storage/virt-automatic-bootsource-updates.adoc
@@ -21,6 +21,8 @@ include::modules/virt-enabling-volume-snapshot-boot-source.adoc[leveloffset=+1]
 
 include::modules/virt-disable-auto-updates-single-boot-source.adoc[leveloffset=+1]
 
+include::modules/virt-configuring-bootsource-garbage-collection.adoc[leveloffset=+1]
+
 include::modules/virt-verify-status-bootsource-update.adoc[leveloffset=+1]
 
 [role="_additional-resources"]


### PR DESCRIPTION
Version(s):
4.22+

Issue:
https://redhat.atlassian.net/browse/CNV-62146

Link to docs preview:
https://112212--ocpdocs-pr.netlify.app/openshift-dedicated/latest/virt/storage/virt-automatic-bootsource-updates.html#virt-configuring-bootsource-garbage-collection_virt-automatic-bootsource-updates

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Note:
I've re-framed the content to address the inverse use case as requested by the SME.
