### PR TITLE
OSDOCS-19888: adds RHCL 1.3.4 release notes

### DIFF
--- a/modules/ref-relnotes-1.3.4-z-stream.adoc
+++ b/modules/ref-relnotes-1.3.4-z-stream.adoc
@@ -1,0 +1,25 @@
+// Module used in the following assemblies
+//
+// *release_notes/release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="rhcl-relnotes-1.3.4-z-stream_{context}"]
+= {product-title} 1.3.4 bug fix and security update
+
+Issued: 2 June 2026
+
+[role="_abstract"]
+{product-title} release 1.3.4 is now available. A description is available in the link:https://access.redhat.com/errata/RHBA-2026:22741[RHBA-2026:22741] advisory. {product-title} uses the `stable` update channel to track and receive updates for the {product-title} Operator. You can manage how your updates are applied through your Operator Lifecycle Manager (OLM) subscription resource. For more information, see xref:../updating/updating-rhcl.adoc#proc-update-rhcl-with-web-console_updating-rhcl[Updating Red Hat Connectivity Link].
+
+[id="rhcl-relnotes-1.3.4-z-stream-bug-fixes_{context}"]
+== Bug fixes
+
+* Previously, when the disk storage option was enabled in the `Limitador` custom resource (CR), both the initial `Limitador` deployment and the Limitador Operator update got stuck on a `Multi-Attach` error because of the persistent volume claim (PVC) volume. Now, the `DeploymentStrategy` is `Recreate` by default in all storage options and the reconciliation process works as expected. As a result, the initial `Limitador` deployment and Operator update can proceed. (link:https://issues.redhat.com/browse/CONNLINK-855[CONNLINK-855])
+
+* Previously, the Limitador Operator did not correctly handle transitions when changing the underlying data storage type, such as switching from in-memory to disk storage or vice versa, within the Custom Resource (CR) specification. Because of this, modifying the storage configuration caused the Operator to fail during the migration process, preventing successful redeployment, update, or application of the new storage backend. Now, the reconciliation logic is updated to properly manage lifecycle transitions between different storage types, ensuring that existing CRs are correctly reconfigured or replaced during a backend switch. You can now switch between in-memory and disk storage types without encountering deployment failures or blocking configuration updates. (link:https://github.com/Kuadrant/limitador-operator/pull/251[Kuadrant-251])
+
+* Before this release, the {prodname} DNS Operator silently discarded wildcard replacement. The `strings.Replace` function handled wildcard DNS record replacements. However, the `strings.Replace` function returned a copy of the modified string rather than altering the original variable in place. The returned result was never assigned back to the target variable and the intended wildcard replacements were silently discarded. With this release, the return value of the string function is properly captured and assigned back to the appropriate variable wildcard. DNS records are now accurately processed, resolved, and handled by the DNS Operator without silent failures. (link:https://github.com/Kuadrant/dns-operator/issues/750[Kuadrant-750])
+
+* Previously, the {prodname} DNS Operator zone-matching process validation was too restrictive, causing all public suffixes to be rejected. Hostnames under valid private registry suffixes such as `httpbin.org`, `github.io`, and `s3.amazonaws.com`, were incorrectly rejected during the zone-matching process, preventing the creation or management of DNS records for these widely used domains. Now, the DNS Operator uses a strict check that differentiates between standard ICANN-managed Top-Level Domains (TLDs) and private registry suffixes. The DNS Operator now only triggers a rejection if the domain is a true ICANN-managed TLD. Hostnames using private suffixes are now successfully recognized, validated, and matched. (link:https://github.com/Kuadrant/dns-operator/pull/765[Kuadrant-765])
+
+* Previously, the Authorino Operator TLS preflight validation logic only checked if the `CertSecret.Name` field was empty. Cases where the field was initialized but contained an empty string ("") were not validated. Because the validation bypassed empty strings, the invalid configuration skipped the preflight check. This triggered confusing, misleading error messages much later in the reconciliation loop, making it difficult for users to diagnose the actual configuration issue. Now, the preflight check is hardened to explicitly validate against both empty values and empty strings for the certificate secret name. Invalid, empty certificate secret names are now caught immediately during the initial TLS preflight check, providing clear and actionable error feedback. (link:https://github.com/Kuadrant/authorino-operator/pull/309[Kuadrant-309])

--- a/release_notes/rhcl-release-notes.adoc
+++ b/release_notes/rhcl-release-notes.adoc
@@ -17,6 +17,8 @@ include::modules/ref-relnotes-known-issues.adoc[leveloffset=+2]
 
 include::modules/ref-relnotes-z-streams.adoc[leveloffset=+1]
 
+include::modules/ref-relnotes-1.3.4-z-stream.adoc[leveloffset=+2]
+
 include::modules/ref-relnotes-1.3.3-z-stream.adoc[leveloffset=+2]
 
 include::modules/ref-relnotes-1.3.2-z-stream.adoc[leveloffset=+2]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
rhcl-docs-1.3

Issue:
[OSDOCS-19888](https://redhat.atlassian.net/browse/OSDOCS-19888)

Link to docs preview:
https://112219--ocpdocs-pr.netlify.app/rhcl/latest/release_notes/rhcl-release-notes.html#rhcl-relnotes-1.3.4-z-stream_rhcl-release-notes

QE review:
- N/A async release note; SME approved
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
