### PR TITLE
OSSM_v3.0.11_Kiali_updates

### DIFF
--- a/modules/ossm-release-notes-supported-versions.adoc
+++ b/modules/ossm-release-notes-supported-versions.adoc
@@ -31,10 +31,10 @@ See the following table for information about {SMProduct} 3.0.11 supported versi
 | 1.24.6
 
 |Kiali Operator
-|2.22.3
+|2.22.4
 
 |Kiali server
-|2.4.16
+|2.4.17
 
 |===
 


### PR DESCRIPTION
[OSSM-13937](https://redhat.atlassian.net/browse/OSSM-13937): [DOC] Kiali updates for OSSM 3.3.3 & 3.2.5 & 3.1.8 & 3.0.11

Version(s):
service-mesh-docs-3.0

Jira link:
https://redhat.atlassian.net/browse/OSSM-13937

Link to docs preview:
https://112224--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/ossm-release-notes/ossm-release-notes-version-support-tables.html#openshift-service-mesh-3-0-11-supported-versions