### PR TITLE
OSDOCS Obsolete package-based RHEL references should be removed

### DIFF
--- a/modules/mirror-registry-introduction.adoc
+++ b/modules/mirror-registry-introduction.adoc
@@ -23,7 +23,7 @@ The following limitations apply to the _mirror registry for Red{nbsp}Hat OpenShi
 
 * The _mirror registry for Red{nbsp}Hat OpenShift_ is not intended to be a substitute for a production deployment of {quay}.
 
-* The _mirror registry for Red{nbsp}Hat OpenShift_ is only supported for hosting images that are required to install a disconnected {product-title} cluster, such as Release images or Red{nbsp}Hat Operator images. It uses local storage on your {op-system-base-full} machine, and storage supported by {op-system-base} is supported by the _mirror registry for Red{nbsp}Hat OpenShift_.
+* The _mirror registry for Red{nbsp}Hat OpenShift_ is only supported for hosting images that are required to install a disconnected {product-title} cluster, such as Release images or Red{nbsp}Hat Operator images. It uses local storage on your machine, and storage supported by {op-system-base} is supported by the _mirror registry for Red{nbsp}Hat OpenShift_.
 +
 [NOTE]
 ====

--- a/modules/update-canary-about.adoc
+++ b/modules/update-canary-about.adoc
@@ -48,5 +48,5 @@ However, you must determine whether the available nodes in the remaining MCPs ca
 
 [NOTE]
 ====
-You can use this update process with all documented {product-title} update processes. However, the process does not work with {op-system-base-full} machines, which are updated using Ansible playbooks.
+You can use this update process with all documented {product-title} update processes.
 ====

--- a/modules/update-service-overview.adoc
+++ b/modules/update-service-overview.adoc
@@ -39,8 +39,6 @@ During the update process, the Machine Config Operator (MCO) applies the new con
 The default setting for `maxUnavailable` is `1` for all the machine config pools in {product-title}. It is recommended to not change this value and update one control plane node at a time. Do not change this value to `3` for the control plane pool.
 ====
 
-If you use {op-system-base-full} machines as workers, the MCO does not update the kubelet because you must update the OpenShift API on the machines first.
-
 With the specification for the new version applied to the old kubelet, the {op-system-base} machine cannot return to the `Ready` state. You cannot complete the update until the machines are available. However, the maximum number of unavailable nodes is set to ensure that normal cluster operations can continue with that number of machines out of service.
 
 The OpenShift Update Service is composed of an Operator and one or more application instances.


### PR DESCRIPTION
https://redhat.atlassian.net/browse/OSDOCS-18256

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
