### PR TITLE
OSDOCS-19868 created zstream RNs for 4-16-63

### DIFF
--- a/modules/zstream-4-16-63.adoc
+++ b/modules/zstream-4-16-63.adoc
@@ -1,0 +1,32 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-16-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-16-63_{context}"]
+= RHSA-2026:20088 - {product-title} {product-version}.63 fixed issues and security updates
+
+Issued: 28 May 2026
+
+[role="_abstract"]
+{product-title} release {product-version}.63 is now available. The list of fixed issues that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2026:20088[RHSA-2026:20088] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2026:20086[RHBA-2026:20086] advisory.
+
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.16.63 --pullspecs
+----
+
+[id="zstream-4-16-63-fixed-issues_{context}"]
+== Fixed issues
+
+There are no notable fixed issues for this release.
+
+[id="zstream-4-16-63-updating_{context}"]
+== Updating
+
+To update an {product-title} 4.16 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].

--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -3390,6 +3390,9 @@ Testing has shown that wake up latencies are under 20μs for over 99.99999% of t
 // 4.16 about async
 include::modules/rn-async-errata.adoc[leveloffset=+1]
 
+// 4.16.63 Rns and updating
+include::modules/zstream-4-16-63.adoc[leveloffset=+2]
+
 // 4.16.62 Rns and updating
 include::modules/zstream-4-16-62.adoc[leveloffset=+2]
 


### PR DESCRIPTION
Version(s):
4.16

Issue:
https://redhat.atlassian.net/browse/OSDOCS-19868

Link to docs preview:
https://112229--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html#zstream-4-16-63_release-notes


QE review:
- [ ] QE has approved this change.


Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
