### PR TITLE
Fix MetalLB web console install procedure based on Playwright validation

### DIFF
--- a/modules/metallb-installing-using-web-console.adoc
+++ b/modules/metallb-installing-using-web-console.adoc
@@ -21,7 +21,11 @@ As a cluster administrator, you can install the MetalLB Operator by using the {p
 +
 You can also filter options by *Infrastructure Features*. For example, select *Disconnected* if you want to see Operators that work in disconnected environments, also known as restricted network environments.
 
+. Click the *MetalLB Operator* tile and click *Install*.
+
 . On the *Install Operator* page, accept the defaults and click *Install*.
++
+The web console displays the *Installing Operator* page with a status update. Wait until the Operator installs before continuing.
 
 .Verification
 
@@ -29,10 +33,10 @@ You can also filter options by *Infrastructure Features*. For example, select *D
 
 .. Navigate to the *Ecosystem* -> *Installed Operators* page.
 
-.. Check that the Operator is installed in the `openshift-operators` namespace and that its status is `Succeeded`.
+.. Check that the Operator is installed in the `metallb-system` namespace and that its status is `Succeeded`.
 
 . If the Operator is not installed successfully, check the status of the Operator and review the logs:
 
 .. Navigate to the *Ecosystem* -> *Installed Operators* page and inspect the `Status` column for any errors or failures.
 
-.. Navigate to the *Workloads* -> *Pods* page and check the logs in any pods in the `openshift-operators` project that are reporting issues.
+.. Navigate to the *Workloads* -> *Pods* page and check the logs in any pods in the `metallb-system` project that are reporting issues.

--- a/modules/metallb-installing-using-web-console.adoc
+++ b/modules/metallb-installing-using-web-console.adoc
@@ -21,9 +21,11 @@ As a cluster administrator, you can install the MetalLB Operator by using the {p
 +
 You can also filter options by *Infrastructure Features*. For example, select *Disconnected* if you want to see Operators that work in disconnected environments, also known as restricted network environments.
 
-. Click the *MetalLB Operator* tile, and then click *Install*.
+. Click the *MetalLB Operator* tile and click *Install*.
 
 . On the *Install Operator* page, accept the defaults and click *Install*.
++
+The web console displays the *Installing Operator* page with a status update. Wait until the Operator installs before continuing.
 
 . The web console displays the progress of the installation. When the installation is complete, click *View installed Operators*.
 


### PR DESCRIPTION
Playwright-driven testing against a live OCP 4.21 cluster identified three gaps in the documented procedure: a missing tile-click step, incorrect namespace references (openshift-operators vs metallb-system), and no mention of the install progress page users see after clicking Install.

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.20+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:https://redhat.atlassian.net/browse/OCPBUGS-86566
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:https://112233--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/networking_operators/metallb-operator/metallb-operator-install.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
