### PR TITLE
OSDOCS-18152 updating AWS AMIs for 4.22

### DIFF
--- a/modules/installation-aws-user-infra-rhcos-ami.adoc
+++ b/modules/installation-aws-user-infra-rhcos-ami.adoc
@@ -8,247 +8,305 @@
 = {op-system} AMIs for the AWS infrastructure
 
 [role="_abstract"]
-Red{nbsp}Hat provides {op-system-first} AMIs that are valid for the various AWS regions and instance architectures that you can manually specify for your {product-title} nodes.
+Red{nbsp}Hat provides {op-system-first} AMIs that are valid for the various AWS regions and instance architectures that you can manually specify for your {product-title} nodes. {op-system} AMIs are available based on RHEL 9 and RHEL 10.
 
 [NOTE]
 ====
-By importing your own AMI, you can also install to regions that do not have a published {op-system} AMI.
+By importing your own AMI, you can also install to regions that do not have published {op-system} AMIs.
 ====
 
 ifndef::openshift-origin[]
 .x86_64 {op-system} AMIs
 
-[cols="2a,2a",options="header"]
+[cols="2a,2a,2a",options="header"]
 |===
 
 |AWS zone
-|AWS AMI
+|RHEL 9 AMI
+|RHEL 10 AMI
 
 |`af-south-1`
-|`ami-0a3b22174319ad66e`
+|`ami-0e09db1a117f89982`
+|`ami-00b9419956a1b8301`
 
 |`ap-east-1`
-|`ami-09cde51703738523d`
+|`ami-0f3883046e2b590c4`
+|`ami-093ce74a7831d5796`
 
 |`ap-east-2`
-|`ami-05478426f756db81c`
+|`ami-05fda30c28d357b97`
+|`ami-0f1f5f78fad6126f3`
 
 |`ap-northeast-1`
-|`ami-0d6f0c1a044b6848f`
+|`ami-0acebf7451fbed435`
+|`ami-0b1305ab18da2b503`
 
 |`ap-northeast-2`
-|`ami-0d19d79e52ad365c8`
+|`ami-07e85fe3474ab6f53`
+|`ami-089d5b21fb5472656`
 
 |`ap-northeast-3`
-|`ami-0a0391de700b812ae`
+|`ami-0bf06ecbd16316390`
+|`ami-08b988fa11f0772c3`
 
 |`ap-south-1`
-|`ami-097ffb6f644b7bad1`
+|`ami-001b087fae6b102a2`
+|`ami-030c986c15d7d21fe`
 
 |`ap-south-2`
-|`ami-08f1c0c6caafcf2c5`
+|`ami-02e59bb73395086de`
+|`ami-0baf89a420726a0c9`
 
 |`ap-southeast-1`
-|`ami-09b223a7c699ecde8`
+|`ami-07e0e4d66f0276e33`
+|`ami-07db2a2569bf635d5`
 
 |`ap-southeast-2`
-|`ami-0a44bb6d4903a93a1`
+|`ami-0656ee074d43ebeb9`
+|`ami-0c66ca97b4cb72a96`
 
 |`ap-southeast-3`
-|`ami-01469b817e364700f`
+|`ami-0b8ac3107bf7b8091`
+|`ami-0ea4633b5accce1cc`
 
 |`ap-southeast-4`
-|`ami-086cc002b6d450301`
+|`ami-06a85e79ca82e97d3`
+|`ami-0b9a19c6d404ebe82`
 
 |`ap-southeast-5`
-|`ami-0b5b9be3ea6fc17de`
+|`ami-068e811f466ce5eec`
+|`ami-0860196faab6d36f5`
 
 |`ap-southeast-6`
-|`ami-03a6ddee59246ab62`
+|`ami-01801dc800c336d1f`
+|`ami-05391d944831d449c`
 
 |`ap-southeast-7`
-|`ami-03ce4d4bb4f67e777`
+|`ami-01b449b1bf9c95caf`
+|`ami-0ea7c99fe14478e31`
 
 |`ca-central-1`
-|`ami-0b23054e68ef5ec3b`
+|`ami-016a214bc34aed24c`
+|`ami-01a1c5433b11c6040`
 
 |`ca-west-1`
-|`ami-0541a60892c677593`
+|`ami-0279542db8d76fe7c`
+|`ami-0aaec38c9c3c18973`
 
 |`eu-central-1`
-|`ami-006a33223c87af648`
+|`ami-02b4be39da643ac06`
+|`ami-050a2036417aa85c9`
 
 |`eu-central-2`
-|`ami-05ddf59e283155ea1`
+|`ami-09e9173753792f284`
+|`ami-0dc1cab1a5a382089`
 
 |`eu-north-1`
-|`ami-054f384036093db98`
+|`ami-0b4a484d5db49d4a5`
+|`ami-0ebb900e33852ac20`
 
 |`eu-south-1`
-|`ami-0a1cc6a65238669f3`
+|`ami-02f2692568ca70d48`
+|`ami-06794550da69b4d4f`
 
 |`eu-south-2`
-|`ami-0fe02b801fea5edf6`
+|`ami-0777de9170dd480a0`
+|`ami-09b9b2363f8b9bf79`
 
 |`eu-west-1`
-|`ami-0632ffa330e30aea1`
+|`ami-0754b5979bce4f62f`
+|`ami-00277e2896ce030cd`
 
 |`eu-west-2`
-|`ami-05829d8d5c031e4a8`
+|`ami-05a2b3abb8cf0cc92`
+|`ami-06c08d05f6a1085e5`
 
 |`eu-west-3`
-|`ami-00be64f508df27900`
+|`ami-01ba91ba1e67b52fa`
+|`ami-0c94bd2324f9a7dc4`
 
 |`il-central-1`
-|`ami-0eeea15b1c070e051`
-
-|`me-central-1`
-|`ami-090084b481adf23e9`
-
-|`me-south-1`
-|`ami-0569abe19529c8b10`
+|`ami-0be1e841b9475abc2`
+|`ami-090c5d273c266bcb1`
 
 |`mx-central-1`
-|`ami-05ab0cf33b0e946a7`
+|`ami-04e5e190abb398aef`
+|`ami-0127400b1a4f4d8a8`
 
 |`sa-east-1`
-|`ami-04dd4c56b43a23fb5`
+|`ami-09b6c03d247ba3007`
+|`ami-0d636038b33e48e74`
 
 |`us-east-1`
-|`ami-04018496b0a1da2d2`
+|`ami-09a04cae40b5df1b1`
+|`ami-06c799e44545e8040`
 
 |`us-east-2`
-|`ami-0b264801b0e00009c`
+|`ami-008f91aec6651d818`
+|`ami-0b56c6461b8dfea32`
 
 |`us-gov-east-1`
-|`ami-042feba6717887157`
+|`ami-083a079a4e93810d0`
+|`ami-00a5a8f684bfe21a4`
 
 |`us-gov-west-1`
-|`ami-0b05862564ac8353d`
+|`ami-03c270b5f712d93c5`
+|`ami-0ee3e9e7a587954c3`
 
 |`us-west-1`
-|`ami-08f548f5be577ce2d`
+|`ami-000065c53330c76d2`
+|`ami-0ceb35adb65ceb3ee`
 
 |`us-west-2`
-|`ami-04941543f3e575579`
+|`ami-0106a1d635d4a36c0`
+|`ami-0a8a99e4004c7938d`
 
 |===
 
 .aarch64 {op-system} AMIs
 
-[cols="2a,2a",options="header"]
+[cols="2a,2a,2a",options="header"]
 |===
 
 |AWS zone
-|AWS AMI
+|RHEL 9 AMI
+|RHEL 10 AMI
 
 |`af-south-1`
-|`ami-0265ec024c31e7603`
+|`ami-09b3b126662fe7a18`
+|`ami-07c2492a6e610eb29`
 
 |`ap-east-1`
-|`ami-01d0891e1fa7c28fe`
+|`ami-009fe8f4f06381d2e`
+|`ami-0c081ca051d9066c3`
 
 |`ap-east-2`
-|`ami-0de88496066d7428e`
+|`ami-0403657dcda8a5e9c`
+|`ami-016834812d68d485e`
 
 |`ap-northeast-1`
-|`ami-0d7c8859dc8f2ac02`
+|`ami-0f9d02af671b8f84e`
+|`ami-0a93317cde971c817`
 
 |`ap-northeast-2`
-|`ami-00377959ff7cf0ed6`
+|`ami-09fb79703d81dad43`
+|`ami-008d018630379e1eb`
 
 |`ap-northeast-3`
-|`ami-095386042a7673286`
+|`ami-038a507ec93b04ce1`
+|`ami-016bf4359ca8f9ea2`
 
 |`ap-south-1`
-|`ami-09f0f012b2c626f59`
+|`ami-0eb4f5b5dbaa33c62`
+|`ami-01c3da87c9088e490`
 
 |`ap-south-2`
-|`ami-01c8221c9a56e0c74`
+|`ami-0d0f18aae857f459b`
+|`ami-089e3dc824dfc53cc`
 
 |`ap-southeast-1`
-|`ami-0c27520bfa297e78a`
+|`ami-0519530b4a949ac79`
+|`ami-047501898db0e6004`
 
 |`ap-southeast-2`
-|`ami-0af72833671d615f1`
+|`ami-029b0ef4d6d0872e6`
+|`ami-00aa2f8c59143b0ae`
 
 |`ap-southeast-3`
-|`ami-085607af8f322e956`
+|`ami-0e04bab1932cc8079`
+|`ami-001bd2512362e7b35`
 
 |`ap-southeast-4`
-|`ami-03d8bfd58de713367`
+|`ami-03b0fdc3fbc4a0fa4`
+|`ami-0c3a562ba17fcc7fe`
 
 |`ap-southeast-5`
-|`ami-0f6479fb82d8108d1`
+|`ami-046fecd472297b7c4`
+|`ami-0abc0ee6a009667b2`
 
 |`ap-southeast-6`
-|`ami-0a6a284e74f2e9afd`
+|`ami-088024b57838dfd53`
+|`ami-0c8b6c104987a0fc3`
 
 |`ap-southeast-7`
-|`ami-054eb3c4286f4dbca`
+|`ami-00c84a187abf62194`
+|`ami-0fbf9de5c1828e872`
 
 |`ca-central-1`
-|`ami-032e08fde31f0a6cc`
+|`ami-0f65ba965f0cdf25b`
+|`ami-06be00da14f45f988`
 
 |`ca-west-1`
-|`ami-07d83e72beff3eb6c`
+|`ami-0ce3bfdc385214b60`
+|`ami-0260b4a668a59a922`
 
 |`eu-central-1`
-|`ami-0a62c879da82e8f99`
+|`ami-077c9e69aa2a7442b`
+|`ami-001fdc3025ce50006`
 
 |`eu-central-2`
-|`ami-09c91e670678ce2c1`
+|`ami-0843ce8434ed947e0`
+|`ami-0443b053f6e845524`
 
 |`eu-north-1`
-|`ami-0e896b8e4e7de42be`
+|`ami-047f81c57b0567e80`
+|`ami-06bc091c0435adf6f`
 
 |`eu-south-1`
-|`ami-01718000bd7650956`
+|`ami-048742ddf9599b9a3`
+|`ami-02ee91218bdc1bb3a`
 
 |`eu-south-2`
-|`ami-02c48b6c8488542b2`
+|`ami-0385fbca30108a3a9`
+|`ami-0b8943a7a26627b01`
 
 |`eu-west-1`
-|`ami-06ea845fe728a8891`
+|`ami-04631bbd6c1be5b55`
+|`ami-064942d9b57521cf3`
 
 |`eu-west-2`
-|`ami-0e6c67a8674179e1b`
+|`ami-0915a41744ba40397`
+|`ami-0e13b80ab624fc7d3`
 
 |`eu-west-3`
-|`ami-0c4cb83cc7e4ec057`
+|`ami-09fd8d0e79f45b71a`
+|`ami-0b1bd601d3ecde37d`
 
 |`il-central-1`
-|`ami-00a88a6e634ac6676`
-
-|`me-central-1`
-|`ami-09aff5ac8bd25e9b8`
-
-|`me-south-1`
-|`ami-043e9d5894e68426d`
+|`ami-0853f94ef8841751a`
+|`ami-0073de64ca6a1189b`
 
 |`mx-central-1`
-|`ami-00c0f1b2fc7ab92d4`
+|`ami-039d2c56cbe869df0`
+|`ami-03bf73795d8dfac51`
 
 |`sa-east-1`
-|`ami-0af3988f6b0fbee7f`
+|`ami-0915393860fee75df`
+|`ami-0f8e239c3eb87df2b`
 
 |`us-east-1`
-|`ami-02ffd1d5ed7351ceb`
+|`ami-0e3af3b58f5710e43`
+|`ami-04ec52f48c28d001d`
 
 |`us-east-2`
-|`ami-0d08ccc7bcf77433d`
+|`ami-017020cb8aeeda203`
+|`ami-0469df626c198243e`
 
 |`us-gov-east-1`
-|`ami-0b183fafd7eeae965`
+|`ami-014a147dae2cf3359`
+|`ami-03557a94deb16be46`
 
 |`us-gov-west-1`
-|`ami-0411a4dd8cbf726db`
+|`ami-07113f5ee8cde6fb3`
+|`ami-06460c1920305cf08`
 
 |`us-west-1`
-|`ami-06149aec55f3e1d6c`
+|`ami-09ca10147735afd05`
+|`ami-0cd45be3140b38916`
 
 |`us-west-2`
-|`ami-0c2bafedf2fc1dfc3`
+|`ami-00e116f16409da3de`
+|`ami-03206cc79683aa1a6`
 
 |===
 endif::openshift-origin[]


### PR DESCRIPTION
Version(s):
4.22

Issue:
https://redhat.atlassian.net/browse/OSDOCS-18152

Link to docs preview:
https://112264--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/upi/installing-aws-user-infra.html#installation-aws-user-infra-rhcos-ami_installing-aws-user-infra

QE review:
- [x] QE has approved this change.

4.22 appears to have split the rhcos.json file into [RHEL 9](https://github.com/openshift/installer/blob/release-4.22/data/data/coreos/coreos-rhel-9.json) and [RHEL 10](https://github.com/openshift/installer/blob/release-4.22/data/data/coreos/coreos-rhel-10.json) files, so I have updated the tables to have separate columns for each OS.