### PR TITLE
Fix MetalLB web console install procedure gaps

### DIFF
--- a/modules/metallb-installing-using-web-console.adoc
+++ b/modules/metallb-installing-using-web-console.adoc
@@ -17,11 +17,15 @@ As a cluster administrator, you can install the MetalLB Operator by using the {p
 
 . In the {product-title} web console, navigate to *Ecosystem* -> *Software Catalog*.
 
-. Type a keyword into the *Filter by keyword* box or scroll to find the Operator you want. For example, type `metallb` to find the MetalLB Operator.
+. Type `metallb` in the *Filter by keyword* box to find the MetalLB Operator.
 +
 You can also filter options by *Infrastructure Features*. For example, select *Disconnected* if you want to see Operators that work in disconnected environments, also known as restricted network environments.
 
+. Click the *MetalLB Operator* tile, and then click *Install*.
+
 . On the *Install Operator* page, accept the defaults and click *Install*.
+
+. The web console displays the install progress. When the installation is complete, click *View installed Operators*.
 
 .Verification
 
@@ -29,10 +33,10 @@ You can also filter options by *Infrastructure Features*. For example, select *D
 
 .. Navigate to the *Ecosystem* -> *Installed Operators* page.
 
-.. Check that the Operator is installed in the `openshift-operators` namespace and that its status is `Succeeded`.
+.. Check that the Operator is installed in the `metallb-system` namespace and that its status is `Succeeded`.
 
 . If the Operator is not installed successfully, check the status of the Operator and review the logs:
 
 .. Navigate to the *Ecosystem* -> *Installed Operators* page and inspect the `Status` column for any errors or failures.
 
-.. Navigate to the *Workloads* -> *Pods* page and check the logs in any pods in the `openshift-operators` project that are reporting issues.
+.. Navigate to the *Workloads* -> *Pods* page and check the logs in any pods in the `metallb-system` project that are reporting issues.

--- a/modules/metallb-installing-using-web-console.adoc
+++ b/modules/metallb-installing-using-web-console.adoc
@@ -17,11 +17,15 @@ As a cluster administrator, you can install the MetalLB Operator by using the {p
 
 . In the {product-title} web console, navigate to *Ecosystem* -> *Software Catalog*.
 
-. Type a keyword into the *Filter by keyword* box or scroll to find the Operator you want. For example, type `metallb` to find the MetalLB Operator.
+. Type `metallb` in the *Filter by keyword* box to find the MetalLB Operator.
 +
 You can also filter options by *Infrastructure Features*. For example, select *Disconnected* if you want to see Operators that work in disconnected environments, also known as restricted network environments.
 
+. Click the *MetalLB Operator* tile, and then click *Install*.
+
 . On the *Install Operator* page, accept the defaults and click *Install*.
+
+. The web console displays the progress of the installation. When the installation is complete, click *View installed Operators*.
 
 .Verification
 
@@ -29,10 +33,10 @@ You can also filter options by *Infrastructure Features*. For example, select *D
 
 .. Navigate to the *Ecosystem* -> *Installed Operators* page.
 
-.. Check that the Operator is installed in the `openshift-operators` namespace and that its status is `Succeeded`.
+.. Check that the Operator is installed in the `metallb-system` namespace and that its status is `Succeeded`.
 
 . If the Operator is not installed successfully, check the status of the Operator and review the logs:
 
 .. Navigate to the *Ecosystem* -> *Installed Operators* page and inspect the `Status` column for any errors or failures.
 
-.. Navigate to the *Workloads* -> *Pods* page and check the logs in any pods in the `openshift-operators` project that are reporting issues.
+.. Navigate to the *Workloads* -> *Pods* page and check the logs in any pods in the `metallb-system` project that are reporting issues.


### PR DESCRIPTION
[OCPBUGS-86566]: Fix MetalLB web console install procedure gaps

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.20+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:https://redhat.atlassian.net/browse/OCPBUGS-86566
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:https://112269--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/networking_operators/metallb-operator/metallb-operator-install.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->



## Summary
- Add missing step to click the MetalLB Operator tile before clicking Install
- Add install progress page step with "View installed Operators" link
- Fix namespace from `openshift-operators` to `metallb-system` in verification and troubleshooting steps

## How it was found
Validated the documented procedure against a live OCP 4.21 cluster using Playwright browser automation. The test drove a real browser through each documented step and identified where the docs diverged from the actual UI behavior.

## Test plan
- [ ] Verify procedure renders correctly with AsciiBinder
- [ ] Confirm steps match OCP 4.21 web console flow

🤖 Generated with [Claude Code](https://claude.ai/claude-code)