### PR TITLE
OSSM 13838: version 2.6.16 release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,7 @@ commercial_package
 .vale/styles/RedHat
 .vale/styles/AsciiDocDITA
 .claude
+artifacts/
+modules/ossm-migrate-to-nftables-rhel10-ambient.adoc
+modules/ossm-migrate-to-nftables-rhel10-sidecar.adoc
+update/ossm-preparing-for-rhel-10-migration.adoc

--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -209,7 +209,7 @@ endif::[]
 :product-rosa: Red{nbsp}Hat OpenShift Service on AWS
 :SMProductName: Red{nbsp}Hat OpenShift Service Mesh
 :SMProductShortName: Service Mesh
-:SMProductVersion: 2.6.15
+:SMProductVersion: 2.6.16
 :MaistraVersion: 2.6
 :KialiProduct: Kiali Operator provided by Red Hat
 :SMPlugin: OpenShift Service Mesh Console (OSSMC) plugin

--- a/modules/ossm-release-2-6-15.adoc
+++ b/modules/ossm-release-2-6-15.adoc
@@ -11,8 +11,6 @@ This release of {SMProductName} updates the {SMProductName} Operator version to 
 
 This release addresses Common Vulnerabilities and Exposures (CVEs) and is supported on {product-title} 4.14 through 4.19.
 
-include::snippets/ossm-current-version-support-snippet.adoc[]
-
 You can use the most current version of the {KialiProduct} with all supported versions of {SMProductName}. The version of {SMProductShortName} automatically ensures a compatible version of Kiali.
 
 [id="ossm-release-2-6-15-components_{context}"]

--- a/modules/ossm-release-2-6-16.adoc
+++ b/modules/ossm-release-2-6-16.adoc
@@ -1,0 +1,32 @@
+// Module included in the following assemblies:
+//
+// * service_mesh/v2x/servicemesh-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="ossm-release-2-6-16_{context}"]
+= {SMProductName} version 2.6.16
+
+[role="_abstract"]
+This release of {SMProductName} updates the {SMProductName} Operator version to 2.6.16, and includes the `ServiceMeshControlPlane` resource version updates for 2.6.16.
+
+This release addresses Common Vulnerabilities and Exposures (CVEs) and is supported on {product-title} 4.14, 4.16, 4.18, and 4.19.
+
+include::snippets/ossm-current-version-support-snippet.adoc[]
+
+You can use the most current version of the {KialiProduct} with all supported versions of {SMProductName}. The version of {SMProductShortName} automatically ensures a compatible version of Kiali.
+
+[id="ossm-release-2-6-16-components_{context}"]
+== Component updates
+
+|===
+|Component |Version
+
+|Istio
+|1.20.8
+
+|Envoy Proxy
+|1.28.8
+
+|Kiali Server
+|1.73
+|===

--- a/service_mesh/v2x/servicemesh-release-notes.adoc
+++ b/service_mesh/v2x/servicemesh-release-notes.adoc
@@ -8,6 +8,8 @@ toc::[]
 
 // The following include statements pull in the module files that comprise 2.x release notes.
 
+include::modules/ossm-release-2-6-16.adoc[leveloffset=+1]
+
 include::modules/ossm-release-2-6-15.adoc[leveloffset=+1]
 
 include::modules/ossm-release-2-6-14.adoc[leveloffset=+1]


### PR DESCRIPTION
OSSM 2.6.16 At ReleaseCandidate Documentation Tasks

Version(s):
enterprise-4.19, enterprise-4.18, enterprise-4.16, enterprise-4.14

Issue:
https://redhat.atlassian.net/browse/OSSM-13836

Link to docs preview:
https://112275--ocpdocs-pr.netlify.app/openshift-enterprise/latest/service_mesh/v2x/servicemesh-release-notes

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
