### PR TITLE
[OSDOCS#17443]Update intros_short descriptions_CQA fixes

### DIFF
--- a/modules/rosa-sts-operator-roles.adoc
+++ b/modules/rosa-sts-operator-roles.adoc
@@ -8,7 +8,7 @@
 = Cluster-specific Operator IAM role reference
 
 [role="_abstract"]
-Some cluster capabilities, including several capabilities provided by default, are managed using Operators. Cluster-specific Operator roles  use the OpenID Connect (OIDC) provider for the cluster to temporarily authenticate Operator access to AWS resources. Use Operator roles to obtain the temporary permissions forcluster operations, such as managing back-end storage, cloud ingress controller, and external access to a cluster.
+Use Operator roles to authenticate to your AWS resources through an OpenID Connect (OIDC) provider, and obtain temporary permissions for cluster operations. Securing these permissions helps you successfully manage capabilities like back-end storage, cloud ingress controllers, and external cluster access.
 
 When you create the Operator roles, the account-wide Operator policies for the matching cluster version are attached to the roles.
 ifdef::openshift-rosa[]

--- a/modules/sd-planning-cluster-maximums-environment.adoc
+++ b/modules/sd-planning-cluster-maximums-environment.adoc
@@ -8,7 +8,7 @@
 = OpenShift Container Platform testing environment and configuration
 
 [role="_abstract"]
-The following table lists the OpenShift Container Platform environment and configuration on which the cluster maximums are tested for the AWS cloud platform.
+To successfully plan your deployment on the AWS cloud platform, review the tested {product-title} environment and configuration settings. Adhering to these cluster maximums ensures your environment is fully supported and optimized for scale.
 
 [options="header",cols="8*"]
 |===

--- a/modules/sd-planning-cluster-maximums.adoc
+++ b/modules/sd-planning-cluster-maximums.adoc
@@ -8,21 +8,14 @@
 = Cluster maximums
 
 [role="_abstract"]
-Consider the following tested object maximums when you plan
+Review the tested object maximums when planning
 ifdef::openshift-rosa[]
 a {product-title}
 endif::[]
 ifdef::openshift-dedicated[]
 an {product-title}
 endif::[]
-cluster installation. The table specifies the maximum limits for each tested type in
-ifdef::openshift-rosa[]
-a {product-title}
-endif::[]
-ifdef::openshift-dedicated[]
-an {product-title}
-endif::[]
-cluster.
+cluster installation. Adhering to these supported limits helps you successfully architect and deploy a scalable, reliable environment.
 
 These guidelines are based on a cluster of 249 compute (also known as worker) nodes in a multiple availability zone configuration. For smaller clusters, the maximums are lower.
 

--- a/modules/sd-planning-considerations.adoc
+++ b/modules/sd-planning-considerations.adoc
@@ -15,9 +15,7 @@ endif::[]
 ifdef::openshift-dedicated[]
 an {product-title}
 endif::[]
-cluster, the sizing of the control plane and infrastructure nodes are automatically determined by the compute node count.
-
-If you change the number of compute nodes in your cluster after installation, the Red{nbsp}Hat Site Reliability Engineering (SRE) team scales the control plane and infrastructure nodes as required to maintain cluster stability.
+cluster, the sizing of the control plane and infrastructure nodes are automatically determined by the compute node count. To maintain cluster stability, the Red{nbsp}Hat Site Reliability Engineering (SRE) team automatically adjusts your control plane and infrastructure nodes whenever you change your compute node count.
 
 [id="node-sizing-during-installation_{context}"]
 == Node sizing during installation

--- a/osd_planning/osd-limits-scalability.adoc
+++ b/osd_planning/osd-limits-scalability.adoc
@@ -8,7 +8,7 @@ include::_attributes/attributes-openshift-dedicated.adoc[]
 toc::[]
 
 [role="_abstract"]
-This document details the tested cluster maximums for {product-title} clusters, along with information about the test environment and configuration used to test the maximums. Information about control plane and infrastructure node sizing and scaling is also provided.
+To architect a stable and fully supported {product-title} cluster, review the information about tested cluster maximums, the test environment, and configuration. Understanding these cluster maximums and the recommended control plane and infrastructure node sizing ensures your environment is optimized for scale.
 
 include::modules/sd-planning-cluster-maximums.adoc[leveloffset=+1]
 include::modules/sd-planning-cluster-maximums-environment.adoc[leveloffset=+1]

--- a/rosa_planning/rosa-planning-environment.adoc
+++ b/rosa_planning/rosa-planning-environment.adoc
@@ -7,7 +7,7 @@ include::_attributes/attributes-openshift-dedicated.adoc[]
 toc::[]
 
 [role="_abstract"]
-This document describes how to plan your {product-title} environment based on tested cluster maximums.
+Plan your {product-title} environment by reviewing the tested cluster maximums. Adhering to these supported limits ensures that your deployment is reliable and optimized for scale.
 
 include::modules/rosa-planning-environment-cluster-max-overview.adoc[leveloffset=+1]
 ifdef::openshift-rosa[]


### PR DESCRIPTION
Version(s):
4.21+

Issue:
https://redhat.atlassian.net/browse/OSDOCS-17443

Link to docs preview:
[Limits and scalability](https://112277--ocpdocs-pr.netlify.app/openshift-dedicated/latest/osd_planning/osd-limits-scalability.html)
[Cluster-specific Operator IAM role reference](https://112277--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/rosa_architecture/rosa-sts-about-iam-resources.html#rosa-sts-operator-roles_rosa-sts-about-iam-resources)
[Planning resource usage in your cluster](https://112277--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/rosa_planning/rosa-planning-environment.html)
[Cluster-specific Operator IAM role reference (Classic)](https://112277--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_architecture/rosa-sts-about-iam-resources.html#rosa-sts-operator-roles_rosa-sts-about-iam-resources)

Peer review:
- [ ] Peer reviewer has approved this change.

QE review:
- QE approval is not required as no procedural changes.

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
