### PR TITLE
DOCPLAN-368: Fix AsciiDocDITA.ConceptLink warnings in virt-*.adoc files

### DIFF
--- a/modules/virt-about-control-plane-only-updates.adoc
+++ b/modules/virt-about-control-plane-only-updates.adoc
@@ -18,4 +18,4 @@ To move between EUS versions, first update {VirtProductName} to the latest z-str
 You can update {VirtProductName} directly to the latest z-stream release of your current minor version without applying each intermediate z-stream update.
 ====
 
-For more information about EUS versions, see the link:https://access.redhat.com/support/policy/updates/openshift[{product-title} Life Cycle Policy].
+For more information about EUS versions, see the "{product-title} Life Cycle Policy".

--- a/modules/virt-about-dr-methods.adoc
+++ b/modules/virt-about-dr-methods.adoc
@@ -9,7 +9,7 @@
 [role="_abstract"]
 The two primary DR methods for {VirtProductName} are Metropolitan Disaster Recovery (Metro-DR) and Regional-DR.
 
-For an overview of disaster recovery (DR) concepts, architecture, and planning considerations, see the link:https://access.redhat.com/articles/7041594[Red{nbsp}Hat {VirtProductName} disaster recovery guide] in the Red{nbsp}Hat Knowledgebase.
+For an overview of disaster recovery (DR) concepts, architecture, and planning considerations, see the "Red{nbsp}Hat {VirtProductName} disaster recovery guide" in the Red{nbsp}Hat Knowledgebase.
 
 [id="metro-dr_{context}"]
 == Metro-DR

--- a/modules/virt-what-you-can-do-with-virt.adoc
+++ b/modules/virt-what-you-can-do-with-virt.adoc
@@ -20,7 +20,7 @@ You can use it to manage virtual machines (VMs) exclusively or alongside contain
 ifndef::openshift-origin,openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
 [NOTE]
 ====
-If you have a {ove-first} subscription, you can run unlimited VMs on subscribed hosts, but you cannot run application instances in containers. For more information, see the subscription guide section about link:https://www.redhat.com/en/resources/self-managed-openshift-subscription-guide#section-8[{ove-first} and related products].
+If you have a {ove-first} subscription, you can run unlimited VMs on subscribed hosts, but you cannot run application instances in containers. For more information, see the subscription guide section about "{ove-first} and related products".
 ====
 endif::[]
 
@@ -45,7 +45,7 @@ ifndef::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
 
 [IMPORTANT]
 ====
-When you deploy {VirtProductName} with {rh-storage}, you must create a dedicated storage class for Windows virtual machine disks. See link:https://access.redhat.com/articles/6978371[Optimizing ODF PersistentVolumes for Windows VMs] for details.
+When you deploy {VirtProductName} with {rh-storage}, you must create a dedicated storage class for Windows virtual machine disks. See "Optimizing ODF PersistentVolumes for Windows VMs" for details.
 ====
 endif::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
 

--- a/virt/about_virt/about-virt.adoc
+++ b/virt/about_virt/about-virt.adoc
@@ -26,7 +26,11 @@ endif::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
 [id="additional-resources_{context}"]
 == Additional resources
 
+ifndef::openshift-origin,openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
+* link:https://www.redhat.com/en/resources/self-managed-openshift-subscription-guide#section-8[{ove-first} and related products]
+endif::openshift-origin,openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
 ifndef::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
+* link:https://access.redhat.com/articles/6978371[Optimizing ODF PersistentVolumes for Windows VMs]
 * xref:../../networking/ovn_kubernetes_network_provider/about-ovn-kubernetes.adoc#about-ovn-kubernetes[OVN-Kubernetes]
 * xref:../../security/compliance_operator/co-concepts/compliance-operator-understanding.adoc#understanding-compliance[Compliance Operator]
 * xref:../../security/compliance_operator/co-scans/compliance-operator-supported-profiles.adoc#compliance-operator-supported-profiles[Supported compliance profiles]

--- a/virt/about_virt/virt-security-policies.adoc
+++ b/virt/about_virt/virt-security-policies.adoc
@@ -11,7 +11,7 @@ toc::[]
 
 *Key points*
 
-* {VirtProductName} adheres to the `restricted` link:https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted[Kubernetes pod security standards] profile, which aims to enforce the current best practices for pod security.
+* {VirtProductName} adheres to the `restricted` Kubernetes pod security standards profile, which aims to enforce the current best practices for pod security.
 * Virtual machine (VM) workloads run as unprivileged pods.
 * Security context constraints (SCCs) are defined for the `kubevirt-controller` service account. For more information about SSCs, see "Additional resources".
 * TLS certificates for {VirtProductName} components are renewed and rotated automatically.
@@ -35,10 +35,10 @@ include::modules/virt-additional-scc-for-kubevirt-controller.adoc[leveloffset=+2
 [role="_additional-resources"]
 [id="additional-resources_{context}"]
 == Additional resources
-* xref:../../authentication/managing-security-context-constraints.adoc#security-context-constraints-about_configuring-internal-oauth[About Security context constraints] 
+* link:https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted[Pod Security Standards]
+* xref:../../authentication/managing-security-context-constraints.adoc#security-context-constraints-about_configuring-internal-oauth[About Security context constraints]
 * xref:../../authentication/using-rbac.adoc#using-rbac[Using RBAC to define and apply permissions]
 * xref:../../authentication/managing-security-context-constraints.adoc#security-context-constraints-about_configuring-internal-oauth[Managing security context constraints]
-* xref:../../authentication/using-rbac.adoc#using-rbac[Using RBAC to define and apply permissions]
 * xref:../../authentication/using-rbac.adoc#creating-cluster-role_using-rbac[Creating a cluster role]
 * xref:../../authentication/using-rbac.adoc#cluster-role-binding-commands_using-rbac[Cluster role binding commands]
 * xref:../../virt/storage/virt-enabling-user-permissions-to-clone-datavolumes.adoc#virt-enabling-user-permissions-to-clone-datavolumes[Enabling user permissions to clone data volumes across namespaces]

--- a/virt/about_virt/virt-supported-limits.adoc
+++ b/virt/about_virt/virt-supported-limits.adoc
@@ -9,7 +9,7 @@ toc::[]
 [role="_abstract"]
 You can refer to tested object maximums when planning your {product-title} environment for {VirtProductName}. However, approaching the maximum values can reduce performance and increase latency. Ensure that you plan for your specific use case and consider all factors that can impact cluster scaling.
 
-For more information about cluster configuration and options that impact performance, see the link:https://access.redhat.com/articles/6994974[{VirtProductName} - Tuning & Scaling Guide] in the Red{nbsp}Hat Knowledgebase.
+For more information about cluster configuration and options that impact performance, see the "{VirtProductName} - Tuning & Scaling Guide" in the Red{nbsp}Hat Knowledgebase.
 
 include::modules/virt-tested-maximums.adoc[leveloffset=+1]
 

--- a/virt/backup_restore/virt-disaster-recovery.adoc
+++ b/virt/backup_restore/virt-disaster-recovery.adoc
@@ -20,6 +20,7 @@ include::modules/virt-dr-solutions-rh-managed-clusters.adoc[leveloffset=+1]
 [role="_additional-resources"]
 [id="additional-resources_{context}"]
 == Additional resources
+* link:https://access.redhat.com/articles/7041594[Red{nbsp}Hat {VirtProductName} disaster recovery guide]
 * link:https://docs.redhat.com/en/documentation/red_hat_openshift_data_foundation/latest/html/configuring_openshift_data_foundation_disaster_recovery_for_openshift_workloads/index[Configuring {rh-storage} Disaster Recovery for OpenShift Workloads]
 * link:https://access.redhat.com/articles/7053115[Use {rh-storage} Disaster Recovery to Protect Virtual Machines (in the Red{nbsp}Hat Knowledgebase)]
 * link:https://docs.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.10[Red{nbsp}Hat Advanced Cluster Management for Kubernetes 2.10]

--- a/virt/creating_vm/virt-creating-vms-from-templates.adoc
+++ b/virt/creating_vm/virt-creating-vms-from-templates.adoc
@@ -17,7 +17,7 @@ You can use VM templates to help you easily create VMs.
 Expedite creation with boot sources::
 You can expedite VM creation by using templates that have an available boot source. Templates with a boot source are labeled *Available boot source* if they do not have a custom label.
 +
-Templates without a boot source are labeled *Boot source required*. See xref:../../virt/storage/virt-automatic-bootsource-updates.adoc#virt-automatic-bootsource-updates[Managing automatic boot source updates] for details.
+Templates without a boot source are labeled *Boot source required*. See "Managing automatic boot source updates" for details.
 
 Customize before starting the VM::
 You can customize the disk source and VM parameters before you start the VM.
@@ -25,7 +25,7 @@ You can customize the disk source and VM parameters before you start the VM.
 +
 [NOTE]
 ====
-If you copy a VM template with all its labels and annotations, your version of the template is marked as deprecated when a new version of the Scheduling, Scale, and Performance (SSP) Operator is deployed. You can remove this designation. See xref:../../virt/creating_vm/virt-creating-vms-from-templates.adoc#virt-customizing-vm-template-web_virt-creating-vms-from-templates[Removing a deprecated designation from a customized VM template by using the web console].
+If you copy a VM template with all its labels and annotations, your version of the template is marked as deprecated when a new version of the Scheduling, Scale, and Performance (SSP) Operator is deployed. You can remove this designation. See "Removing a deprecated designation from a customized VM template by using the web console".
 ====
 
 {sno-caps}::
@@ -38,3 +38,8 @@ include::modules/virt-customizing-vm-template-web.adoc[leveloffset=+1]
 include::modules/virt-creating-template.adoc[leveloffset=+2]
 
 include::modules/virt-dedicated-resources-vm-template.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+[id="additional-resources_{context}"]
+== Additional resources
+* xref:../../virt/storage/virt-automatic-bootsource-updates.adoc#virt-automatic-bootsource-updates[Managing automatic boot source updates]

--- a/virt/managing_vms/advanced_vm_management/virt-assigning-compute-resources.adoc
+++ b/virt/managing_vms/advanced_vm_management/virt-assigning-compute-resources.adoc
@@ -9,7 +9,7 @@ toc::[]
 [role="_abstract"]
 In {VirtProductName}, compute resources assigned to virtual machines (VMs) are backed by either guaranteed CPUs or time-sliced CPU shares.
 
-Guaranteed CPUs, also known as CPU reservation, dedicate CPU cores or threads to a specific workload, which makes them unavailable to any other workload. Assigning guaranteed CPUs to a VM ensures that the VM will have sole access to a reserved physical CPU. xref:../../../virt/managing_vms/advanced_vm_management/virt-dedicated-resources-vm.adoc#virt-dedicated-resources-vm[Enable dedicated resources for VMs] to use a guaranteed CPU.
+Guaranteed CPUs, also known as CPU reservation, dedicate CPU cores or threads to a specific workload, which makes them unavailable to any other workload. Assigning guaranteed CPUs to a VM ensures that the VM will have sole access to a reserved physical CPU. Enable dedicated resources for VMs to use a guaranteed CPU.
 
 Time-sliced CPUs dedicate a slice of time on a shared physical CPU to each workload. You can specify the size of the slice during VM creation, or when the VM is offline. By default, each vCPU receives 100 milliseconds, or 1/10 of a second, of physical CPU time.
 
@@ -28,4 +28,5 @@ include::modules/virt-setting-cpu-allocation-ratio.adoc[leveloffset=+1]
 [role="_additional-resources"]
 [id="additional-resources_{context}"]
 == Additional resources
+* xref:../../../virt/managing_vms/advanced_vm_management/virt-dedicated-resources-vm.adoc#virt-dedicated-resources-vm[Enabling dedicated resources for virtual machines]
 * link:https://kubernetes.io/docs/concepts/workloads/pods/pod-qos/[Pod Quality of Service Classes]

--- a/virt/managing_vms/advanced_vm_management/virt-high-availability-for-vms.adoc
+++ b/virt/managing_vms/advanced_vm_management/virt-high-availability-for-vms.adoc
@@ -21,11 +21,12 @@ endif::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
 
 You can configure remediating nodes by installing the Self Node Remediation Operator or the Fence Agents Remediation Operator from the software catalog and enabling machine health checks or node remediation checks.
 
-For more information on remediation, fencing, and maintaining nodes, see the link:https://docs.redhat.com/en/documentation/workload_availability_for_red_hat_openshift/24.3[Workload Availability for Red Hat OpenShift] documentation.
+For more information on remediation, fencing, and maintaining nodes, see the "Workload Availability for Red Hat OpenShift" documentation.
 
-ifndef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 [role="_additional-resources"]
 [id="additional-resources_{context}"]
 == Additional resources
+* link:https://docs.redhat.com/en/documentation/workload_availability_for_red_hat_openshift/24.3[Workload Availability for Red Hat OpenShift]
+ifndef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 * xref:../../../virt/nodes/virt-eviction-strategies.adoc#virt-delete-failed-node-vm-failover_virt-eviction-strategies[Delete a failed node to trigger virtual machine failover]
 endif::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]

--- a/virt/managing_vms/virt-accessing-vm-ssh.adoc
+++ b/virt/managing_vms/virt-accessing-vm-ssh.adoc
@@ -10,22 +10,18 @@ toc::[]
 [role="_abstract"]
 You can use SSH to securely access your virtual machines (VMs) from the command line. To set up your SSH configuration, use one of the following methods:
 
-* xref:../../virt/managing_vms/virt-accessing-vm-ssh.adoc#using-virtctl-ssh_virt-accessing-vm-ssh[`virtctl ssh` command]
-+
+`virtctl ssh` command::
 You create an SSH key pair, add the public key to a VM, and connect to the VM by running the `virtctl ssh` command with the private key.
 +
 You can add public SSH keys to {op-system-base-full} 9 VMs at runtime or at first boot to VMs with guest operating systems that can be configured by using a cloud-init data source.
 
-* xref:../../virt/managing_vms/virt-accessing-vm-ssh.adoc#virt-using-virtctl-port-forward-command_virt-accessing-vm-ssh[`virtctl port-forward` command]
-+
+`virtctl port-forward` command::
 You add the `virtctl port-foward` command to your `.ssh/config` file and connect to the VM by using OpenSSH.
 
-* xref:../../virt/managing_vms/virt-accessing-vm-ssh.adoc#using-services-ssh_virt-accessing-vm-ssh[Service]
-+
+Service::
 You create a service, associate the service with the VM, and connect to the IP address and port exposed by the service.
 
-* xref:../../virt/managing_vms/virt-accessing-vm-ssh.adoc#using-secondary-networks-ssh_virt-accessing-vm-ssh[Secondary network]
-+
+Secondary network::
 You configure a secondary network, attach a virtual machine (VM) to the secondary network interface, and connect to the DHCP-allocated IP address.
 
 include::modules/virt-access-configuration-considerations.adoc[leveloffset=+1]
@@ -124,7 +120,7 @@ include::modules/virt-creating-service-virtctl.adoc[leveloffset=+3]
 
 .Next steps
 
-After you create a service with `virtctl`, you must add `special: key` to the `spec.template.metadata.labels` stanza of the `VirtualMachine` manifest. See xref:../../virt/managing_vms/virt-accessing-vm-ssh.adoc#virt-creating-service-cli_virt-accessing-vm-ssh[Creating a service by using the command line].
+After you create a service with `virtctl`, you must add `special: key` to the `spec.template.metadata.labels` stanza of the `VirtualMachine` manifest. See "Creating a service by using the command line".
 
 include::modules/virt-creating-service-cli.adoc[leveloffset=+3]
 

--- a/virt/managing_vms/virt-controlling-vm-states.adoc
+++ b/virt/managing_vms/virt-controlling-vm-states.adoc
@@ -7,7 +7,7 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 [role="_abstract"]
-You can use xref:../../virt/getting_started/virt-using-the-cli-tools.adoc#virt-using-the-cli-tools[`virtctl`] to manage virtual machine states and perform other actions from the CLI. For example, you can use `virtctl` to force stop a VM or expose a port.
+You can use `virtctl` to manage virtual machine states and perform other actions from the CLI. For example, you can use `virtctl` to force stop a VM or expose a port.
 
 You can stop, start, restart, reset, pause, and unpause virtual machines from the web console.
 
@@ -28,3 +28,8 @@ include::modules/virt-pausing-vm-web.adoc[leveloffset=+1]
 include::modules/virt-unpausing-vm-web.adoc[leveloffset=+1]
 
 include::modules/virt-controlling-multiple-vms.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+[id="additional-resources_{context}"]
+== Additional resources
+* xref:../../virt/getting_started/virt-using-the-cli-tools.adoc#virt-using-the-cli-tools[Using the CLI tools]

--- a/virt/managing_vms/virt-customize-web-console.adoc
+++ b/virt/managing_vms/virt-customize-web-console.adoc
@@ -7,12 +7,14 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 [role="_abstract"]
-As a cluster administrator, you can customize the {product-title} web console by integrating xref:../../web_console/dynamic-plugin/overview-dynamic-plugin.adoc#overview-dynamic-plugin[dynamic plugins]. Virtual machine (VM) owners can then use the actions provided by these plugins from different tabs on the *Virtualization* page.
+As a cluster administrator, you can customize the {product-title} web console by integrating dynamic plugins. Virtual machine (VM) owners can then use the actions provided by these plugins from different tabs on the *Virtualization* page.
 
 include::modules/virt-enable-bulk-operations-web-console.adoc[leveloffset=+1]
 
 include::modules/virt-create-custom-console-tabs.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
+[id="additional-resources_{context}"]
 == Additional resources
+* xref:../../web_console/dynamic-plugin/overview-dynamic-plugin.adoc#overview-dynamic-plugin[Dynamic plugins overview]
 * xref:../../web_console/dynamic-plugin/dynamic-plugins-get-started.adoc#dynamic-plugins-get-started[Getting started with dynamic plugins]

--- a/virt/managing_vms/virt-edit-vms.adoc
+++ b/virt/managing_vms/virt-edit-vms.adoc
@@ -11,7 +11,7 @@ You can update virtual machine (VM) configuration details like CPU, memory, and 
 
 
 ifndef::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
-To edit a VM to configure disk sharing by using virtual disks or LUN, see xref:../../virt/managing_vms/virtual_disks/virt-configuring-shared-volumes-for-vms.adoc#virt-configuring-shared-volumes-for-vms[Configuring shared volumes for virtual machines].
+To edit a VM to configure disk sharing by using virtual disks or LUN, see "Configuring shared volumes for virtual machines".
 endif::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
 
 include::modules/virt-change-vm-instance-type.adoc[leveloffset=+1]
@@ -39,6 +39,9 @@ include::modules/virt-configure-multiple-iothreads.adoc[leveloffset=+1]
 [role="_additional-resources"]
 [id="additional-resources_{context}"]
 == Additional resources
+ifndef::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
+* xref:../../virt/managing_vms/virtual_disks/virt-configuring-shared-volumes-for-vms.adoc#virt-configuring-shared-volumes-for-vms[Configuring shared volumes for virtual machines]
+endif::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
 * xref:../../nodes/pods/nodes-pods-configmaps.adoc#nodes-pods-configmap-overview_builds-configmaps[Understanding config maps]
 * xref:../../nodes/pods/nodes-pods-secrets.adoc#nodes-pods-secrets-about[Providing sensitive data to pods]
 * xref:../../authentication/understanding-and-creating-service-accounts.adoc#service-accounts-overview[Understanding and creating service accounts]

--- a/virt/managing_vms/virt-exporting-vms.adoc
+++ b/virt/managing_vms/virt-exporting-vms.adoc
@@ -11,14 +11,19 @@ Export a virtual machine (VM) and its associated disks to import it into another
 
 You create a `VirtualMachineExport` custom resource (CR) by using the command-line interface.
 
-Alternatively, you can use the xref:../../virt/getting_started/virt-using-the-cli-tools.adoc#vm-export-commands_virt-using-the-cli-tools[`virtctl vmexport` command] to create a `VirtualMachineExport` CR and to download exported volumes.
+Alternatively, you can use the `virtctl vmexport` command to create a `VirtualMachineExport` CR and to download exported volumes.
 
 [NOTE]
 ====
-You can migrate virtual machines between OpenShift Virtualization clusters by using the link:https://access.redhat.com/products/migration-toolkits-virtualization[Migration Toolkit for Virtualization].
+You can migrate virtual machines between OpenShift Virtualization clusters by using the Migration Toolkit for Virtualization.
 ====
 
 include::modules/virt-creating-virtualmachineexport.adoc[leveloffset=+1]
 
 include::modules/virt-accessing-exported-vm-manifests.adoc[leveloffset=+1]
 
+[role="_additional-resources"]
+[id="additional-resources_{context}"]
+== Additional resources
+* link:https://access.redhat.com/products/migration-toolkits-virtualization[Migration Toolkit for Virtualization]
+* xref:../../virt/getting_started/virt-using-the-cli-tools.adoc#vm-export-commands_virt-using-the-cli-tools[virtctl vmexport command]

--- a/virt/managing_vms/virt-manage-vmis.adoc
+++ b/virt/managing_vms/virt-manage-vmis.adoc
@@ -7,7 +7,7 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 [role="_abstract"]
-Manage standalone virtual machine instances (VMIs) that were created independently outside of the {VirtProductName} environment through the web console by using `oc` or xref:../../virt/getting_started/virt-using-the-cli-tools.adoc#virt-using-the-cli-tools[`virtctl`] commands from the command-line interface (CLI).
+Manage standalone virtual machine instances (VMIs) that were created independently outside of the {VirtProductName} environment through the web console by using `oc` or `virtctl` commands from the command-line interface (CLI).
 
 The `virtctl` command provides more virtualization options than the `oc` command. For example, you can use `virtctl` to pause a VM or expose a port.
 
@@ -24,3 +24,8 @@ include::modules/virt-editing-vmis-web.adoc[leveloffset=+1]
 include::modules/virt-deleting-vmis-cli.adoc[leveloffset=+1]
 
 include::modules/virt-deleting-vmis-web.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+[id="additional-resources_{context}"]
+== Additional resources
+* xref:../../virt/getting_started/virt-using-the-cli-tools.adoc#virt-using-the-cli-tools[Using the CLI tools]

--- a/virt/managing_vms/virt-managing-vms-openshift-pipelines.adoc
+++ b/virt/managing_vms/virt-managing-vms-openshift-pipelines.adoc
@@ -9,7 +9,7 @@ toc::[]
 [role="_abstract"]
 Automate virtual machine (VM) provisioning and management in your CI/CD workflows with {pipelines-shortname} tasks designed for virtualization. These tasks allow you to create, configure, and manipulate VMs and their disks as part of your automated deployment pipelines, streamlining VM lifecycle management.
 
-link:https://docs.openshift.com/pipelines/latest/about/understanding-openshift-pipelines.html[{pipelines-title}] is a Kubernetes-native CI/CD framework that allows developers to design and run each step of the CI/CD pipeline in its own container.
+{pipelines-title} is a Kubernetes-native CI/CD framework that allows developers to design and run each step of the CI/CD pipeline in its own container.
 
 By using {pipelines-shortname} tasks and the example pipeline, you can do the following:
 
@@ -17,23 +17,23 @@ By using {pipelines-shortname} tasks and the example pipeline, you can do the fo
 * Run commands in VMs.
 * Manipulate disk images with `libguestfs` tools.
 
-The tasks are located in link:https://artifacthub.io/packages/search?repo=redhat-tekton-tasks&sort=relevance&page=1[the task catalog (ArtifactHub)].
+The tasks are located in the task catalog (ArtifactHub).
 
-The example Windows pipeline is located in link:https://artifacthub.io/packages/tekton-pipeline/redhat-pipelines/windows-efi-installer[the pipeline catalog (ArtifactHub)].
+The example Windows pipeline is located in the pipeline catalog (ArtifactHub).
 
 [id="prerequisites_virt-managing-vms-openshift-pipelines"]
 == Prerequisites
 
 * You have access to an {product-title} cluster with `cluster-admin` permissions.
 * You have installed the OpenShift CLI (`oc`).
-* You have link:https://docs.openshift.com/pipelines/latest/install_config/installing-pipelines.html[installed {pipelines-shortname}].
+* You have installed {pipelines-shortname}.
 
 include::modules/virt-supported-ssp-tasks.adoc[leveloffset=+1]
 
 [id="windows-efi-installer-pipeline_{context}"]
 == Windows EFI installer pipeline
 
-You can run the link:https://artifacthub.io/packages/tekton-pipeline/redhat-pipelines/windows-efi-installer[Windows EFI installer pipeline] by using the web console or CLI.
+You can run the Windows EFI installer pipeline by using the web console or CLI.
 
 The Windows EFI installer pipeline installs Windows 10, Windows 11, or Windows Server 2022 into a new data volume from a Windows installation image (ISO file). A custom answer file is used to run the installation process.
 
@@ -52,5 +52,9 @@ include::modules/virt-deprecated-tasks-web.adoc[leveloffset=+1]
 [role="_additional-resources"]
 [id="additional-resources_{context}"]
 == Additional resources
+* link:https://docs.openshift.com/pipelines/latest/about/understanding-openshift-pipelines.html[Understanding {pipelines-shortname}]
+* link:https://artifacthub.io/packages/search?repo=redhat-tekton-tasks&sort=relevance&page=1[Task catalog (ArtifactHub)]
+* link:https://artifacthub.io/packages/tekton-pipeline/redhat-pipelines/windows-efi-installer[Windows EFI installer pipeline (ArtifactHub)]
+* link:https://docs.openshift.com/pipelines/latest/install_config/installing-pipelines.html[Installing {pipelines-shortname}]
 * link:https://docs.openshift.com/pipelines/latest/create/creating-applications-with-cicd-pipelines.html[Creating CI/CD solutions for applications using {pipelines-title}]
 * xref:../../virt/creating_vms_advanced/virt-creating-vms-uploading-images.adoc#virt-creating-windows-vm_virt-creating-vms-uploading-images[Creating a Windows VM]

--- a/virt/managing_vms/virt-using-vtpm-devices.adoc
+++ b/virt/managing_vms/virt-using-vtpm-devices.adoc
@@ -11,9 +11,16 @@ To run Windows 11 or other workloads that require a Trusted Platform Module, you
 
 [IMPORTANT]
 ====
-With {VirtProductName} 4.18 and newer, you can xref:../../virt/managing_vms/virt-exporting-vms.adoc#virt-exporting-vms[export virtual machines] (VMs) with attached vTPM devices, xref:../../virt/backup_restore/virt-backup-restore-snapshots.adoc#virt-creating-vm-snapshot-cli_virt-backup-restore-snapshots[create snapshots of these VMs], and xref:../../virt/backup_restore/virt-backup-restore-snapshots.adoc#virt-restoring-vm-from-snapshot-cli_virt-backup-restore-snapshots[restore VMs from these snapshots]. However, cloning a VM with a vTPM device attached to it or creating a new VM from its snapshot is not supported.
+With {VirtProductName} 4.18 and newer, you can export virtual machines (VMs) with attached vTPM devices, create snapshots of these VMs, and restore VMs from these snapshots. However, cloning a VM with a vTPM device attached to it or creating a new VM from its snapshot is not supported.
 ====
 
 include::modules/virt-about-vtpm-devices.adoc[leveloffset=+1]
 
 include::modules/virt-adding-vtpm-to-vm.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+[id="additional-resources_{context}"]
+== Additional resources
+* xref:../../virt/managing_vms/virt-exporting-vms.adoc#virt-exporting-vms[Exporting virtual machines]
+* xref:../../virt/backup_restore/virt-backup-restore-snapshots.adoc#virt-creating-vm-snapshot-cli_virt-backup-restore-snapshots[Creating a snapshot by using the CLI]
+* xref:../../virt/backup_restore/virt-backup-restore-snapshots.adoc#virt-restoring-vm-from-snapshot-cli_virt-backup-restore-snapshots[Restoring a virtual machine from a snapshot by using the CLI]

--- a/virt/managing_vms/virtual_disks/virt-hot-plugging-virtual-disks.adoc
+++ b/virt/managing_vms/virtual_disks/virt-hot-plugging-virtual-disks.adoc
@@ -17,10 +17,14 @@ A hot plugged disk remains attached to the VM even after reboot. You must unplug
 ====
 Each VM has a `virtio-scsi` controller so that hot plugged disks can use the SCSI bus. The `virtio-scsi` controller overcomes the limitations of VirtIO while retaining its performance advantages. It is highly scalable and supports hot plugging over 4 million disks.
 
-When you hot plug disks to the VirtIO (`virtio-blk`) bus, each disk uses a PCI Express (PCIe) slot in the VM. The number of PCIe slots is limited and pre-set automatically at the VM creation as specified in the link:https://kubevirt.io/user-guide/storage/hotplug_volumes/#available-virtio-ports[Available VirtIO Ports] table. Therefore, you can use `virtio-blk` for a small number of disks that does not exceed the number of available slots.
+When you hot plug disks to the VirtIO (`virtio-blk`) bus, each disk uses a PCI Express (PCIe) slot in the VM. The number of PCIe slots is limited and pre-set automatically at the VM creation as specified in the "Available VirtIO Ports" table. Therefore, you can use `virtio-blk` for a small number of disks that does not exceed the number of available slots.
 ====
 
 include::modules/virt-hot-plugging-disks-ui.adoc[leveloffset=+1]
 
 include::modules/virt-hot-plugging-disk-cli.adoc[leveloffset=+1]
 
+[role="_additional-resources"]
+[id="additional-resources_{context}"]
+== Additional resources
+* link:https://kubevirt.io/user-guide/storage/hotplug_volumes/#available-virtio-ports[Available VirtIO Ports]

--- a/virt/updating/upgrading-virt.adoc
+++ b/virt/updating/upgrading-virt.adoc
@@ -49,6 +49,7 @@ endif::openshift-origin[]
 [role="_additional-resources"]
 == Additional resources
 ifndef::openshift-rosa,openshift-dedicated,openshift-origin,openshift-rosa-hcp[]
+* link:https://access.redhat.com/support/policy/updates/openshift[{product-title} Life Cycle Policy]
 * xref:../../updating/updating_a_cluster/control-plane-only-update.adoc#control-plane-only-update[Performing a Control Plane Only update]
 endif::openshift-rosa,openshift-dedicated,openshift-origin,openshift-rosa-hcp[]
 * xref:../../operators/understanding/olm-what-operators-are.adoc#olm-what-operators-are[What are Operators?]


### PR DESCRIPTION
## Summary
Fixed AsciiDocDITA.ConceptLink warnings in 18 virt documentation files by moving links and cross-references to Additional resources sections or replacing them with properly formatted text.

https://redhat.atlassian.net/browse/DOCPLAN-368
OCP 4.20+

## Changes
- **Module files**: Removed links/xrefs and replaced with quoted text where appropriate
- **Assembly files**: Moved links to Additional resources sections with proper formatting and conditional blocks
- Removed self-referential xrefs that were only navigational
- Reduced ConceptLink warnings from 40 to 0

## Preview links
- https://112283--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/updating/upgrading-virt.html#virt-about-control-plane-only-updates_upgrading-virt
- https://112283--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/updating/upgrading-virt.html#additional-resources_upgrading-virt
- https://112283--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/backup_restore/virt-disaster-recovery.html#virt-about-dr-methods_virt-disaster-recovery
- https://112283--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/about_virt/about-virt.html#virt-what-you-can-do-with-virt_about-virt
- https://112283--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/about_virt/virt-security-policies
- https://112283--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/creating_vm/virt-creating-vms-from-templates
- https://112283--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/managing_vms/virtual_disks/virt-hot-plugging-virtual-disks
- https://112283--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/managing_vms/virt-accessing-vm-ssh
- https://112283--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/managing_vms/virt-controlling-vm-states
- https://112283--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/managing_vms/virt-customize-web-console
- https://112283--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/managing_vms/virt-managing-vms-openshift-pipelines

## Validation
Ran dita-vale on all virt-*.adoc files to verify ConceptLink warnings were resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)