### PR TITLE
OSDOCS#18243: Deprecate Red Hat Marketplace content

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -2457,8 +2457,8 @@ Topics:
   Distros: openshift-origin,openshift-enterprise
 - Name: Deleting applications
   File: odc-deleting-applications
-- Name: Using the Red Hat Marketplace
-  File: red-hat-marketplace
+#- Name: Using the Red Hat Marketplace
+#  File: red-hat-marketplace
   Distros: openshift-origin,openshift-enterprise
 ---
 Name: Serverless


### PR DESCRIPTION
Version(s):
4.22

Issue:
[OSDOCS-18243](https://redhat.atlassian.net/browse/OSDOCS-18243)

Link to docs preview:
[Welcome](https://112284--ocpdocs-pr.netlify.app/openshift-enterprise/latest/welcome/)

QE review:
- [x] QE has approved this change.

Additional information:
Removing deprecated Red Hat Marketplace content. Ensure that the Red Hat Marketplace is not mentioned anywhere in the documentation.

To confirm, [this is the removed area of documentation in the 4.21 docs](https://docs.redhat.com/en/documentation/openshift_container_platform/4.21/html/building_applications/red-hat-marketplace).

SME approved this change.