### PR TITLE
OSSM_v3.1.8_Kiali_updates

### DIFF
--- a/modules/ossm-exposing-a-service-by-using-the-kubernetes-gateway-api.adoc
+++ b/modules/ossm-exposing-a-service-by-using-the-kubernetes-gateway-api.adoc
@@ -188,7 +188,7 @@ $ oc patch service <gateway_name>-istio -n <gateway_namespace> -p '{"spec": {"ty
 +
 [NOTE]
 ====
-{ocp-short-name} Routes can also expose a gateway to traffic outside the cluster. For more information, see "Exposing a gateway to traffic outside the cluster using {ocp-short-name} Routes".
+{ocp-short-name} Routes can also expose a gateway to traffic outside the cluster. For more information, see "Exposing a gateway to traffic outside the cluster by using {ocp-short-name} Routes".
 ====
 
 . Verify that you can access the `httpbin` service from outside the cluster when using the external hostname or IP address of the gateway Service resource. Ensure that you set the `INGRESS_HOST` variable appropriately for the environment in which your cluster is running.

--- a/modules/ossm-exposing-service-using-istio-gateway-and-virtualservice.adoc
+++ b/modules/ossm-exposing-service-using-istio-gateway-and-virtualservice.adoc
@@ -209,7 +209,7 @@ $ oc patch service <gateway_name> -n <gateway_namespace> -p '{"spec": {"type": "
 +
 [NOTE]
 ====
-{ocp-short-name} Routes can also expose a gateway to traffic outside the cluster. For more information, see "Exposing a gateway to traffic outside the cluster using {ocp-short-name} Routes".
+{ocp-short-name} Routes can also expose a gateway to traffic outside the cluster. For more information, see "Exposing a gateway to traffic outside the cluster by using {ocp-short-name} Routes".
 ====
 
 . Verify that you can access the `httpbin` service from outside the cluster when using the external hostname or IP address of the gateway `Service` resource. Ensure that you set the `INGRESS_HOST` variable appropriately for the environment that your cluster is running in.

--- a/modules/ossm-release-notes-supported-versions.adoc
+++ b/modules/ossm-release-notes-supported-versions.adoc
@@ -30,10 +30,10 @@ See the following table for information about {SMProduct} 3.1.8 supported versio
 | 1.26.8
 
 |Kiali Operator
-|2.22.3
+|2.22.4
 
 |Kiali server
-|2.11.10
+|2.11.11
 
 |===
 


### PR DESCRIPTION
[OSSM-13937](https://redhat.atlassian.net/browse/OSSM-13937): [DOC] Kiali updates for OSSM 3.3.3 & 3.2.5 & 3.1.8 & 3.0.11
This PR also resolves the very minor doc bug OSSM-13528.

Version(s):
service-mesh-docs-3.1

Jira link:
https://redhat.atlassian.net/browse/OSSM-13937

Link to docs preview:
https://112285--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/ossm-release-notes/ossm-release-notes-version-support-tables.html

QE review:
- [ ] QE has approved this change.