### PR TITLE
[RHDEVDOC-7540] Remove Repository CR status field documentation

### DIFF
--- a/modules/op-monitoring-pipeline-run-status-using-pipelines-as-code.adoc
+++ b/modules/op-monitoring-pipeline-run-status-using-pipelines-as-code.adoc
@@ -54,22 +54,5 @@ If {pac} matches a namespace to a `Repository` custom resource definition (CRD),
 
 These error scenarios do not halt the execution of valid pipeline runs. The system continues to process validated and matched pipeline runs, preventing a single validation problem from disrupting the entire workflow.
 
-*Status associated with Repository CRD*
-{pac} stores the last 5 status messages for a pipeline run inside the `Repository` custom resource.
-
-[source,terminal]
-----
-$ oc get repo -n <pipelines_as_code_ci>
-----
-
-.Example output
-[source,terminal]
-----
-NAME                  URL                                                        NAMESPACE             SUCCEEDED   REASON      STARTTIME   COMPLETIONTIME
-pipelines-as-code-ci   https://github.com/openshift-pipelines/pipelines-as-code   pipelines-as-code-ci   True        Succeeded   59m         56m
-----
-
-Using the `tkn pac describe` command, you can extract the status of the runs associated with your repository and its metadata.
-
 *Notifications*
 {pac} does not manage notifications. If you need to have notifications, use the `finally` feature of pipelines.


### PR DESCRIPTION
Version(s):
- `pipelines-docs-1.24`

Issue:
- https://redhat.atlassian.net/browse/RHDEVDOCS-7540

Link to docs preview:
- [Monitoring pipeline run status using PaC](https://112326--ocpdocs-pr.netlify.app/openshift-pipelines/latest/pac/managing-pipeline-runs-pac.html#monitoring-pipeline-run-status-using-pipelines-as-code_managing-pipeline-runs-pac)

SME review:
- [x] SME has approved this change.
