### PR TITLE
OSDOCS#19900: Update the MicroShift z-stream RNs for 4.19.32

### DIFF
--- a/microshift_release_notes/microshift-4-19-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-19-release-notes.adoc
@@ -28,8 +28,10 @@ include::modules/microshift-4-19-additional-release-notes.adoc[leveloffset=+1]
 
 include::modules/microshift-4-19-asynchronous-errata-updates.adoc[leveloffset=+1]
 
-include::modules/microshift-4-19-0-dp.adoc[leveloffset=+2]
+include::modules/microshift-4-19-32-dp.adoc[leveloffset=+2]
+
+include::modules/microshift-4-19-25-dp.adoc[leveloffset=+2]
 
 include::modules/microshift-4-19-7-dp.adoc[leveloffset=+2]
 
-include::modules/microshift-4-19-25-dp.adoc[leveloffset=+2]
+include::modules/microshift-4-19-0-dp.adoc[leveloffset=+2]

--- a/modules/microshift-4-19-25-dp.adoc
+++ b/modules/microshift-4-19-25-dp.adoc
@@ -4,12 +4,12 @@
 
 :_mod-docs-content-type: CONCEPT
 [id="microshift-4-19-25-dp_{context}"]
-= RHBA-2026:3508 - {microshift-short} 4.19.25 bug fix and update advisory
+= RHBA-2026:3508 - {microshift-short} 4.19.25 fixed issue advisory
 
 Issued: 04 March 2026
 
 [role="_abstract"]
-{product-title} release 4.19.25 is now available. Bug fixes and enhancements are listed in the link:https://access.redhat.com/errata/RHBA-2026:3508[RHBA-2026:3508] advisory. Release notes for bug fixes and enhancements are provided in this documentation. The images that are included in the update are provided by the {OCP} link:https://access.redhat.com/errata/RHBA-2026:3394[RHBA-2026:3394] advisory.
+{product-title} release 4.19.25 is now available. Fixed issues are listed in the link:https://access.redhat.com/errata/RHBA-2026:3508[RHBA-2026:3508] advisory. Release notes for fixed issues are provided in this documentation. The images that are included in the update are provided by the {OCP} link:https://access.redhat.com/errata/RHBA-2026:3394[RHBA-2026:3394] advisory.
 
 See the latest images included with {microshift-short} by using the following instructions:
 

--- a/modules/microshift-4-19-32-dp.adoc
+++ b/modules/microshift-4-19-32-dp.adoc
@@ -1,0 +1,22 @@
+// Module included in the following assemblies:
+//
+//microshift_release_notes/microshift-4-19-release-notes.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="microshift-4-19-32-dp_{context}"]
+= RHSA-2026:20322 - {microshift-short} 4.19.32 fixed issue and security update advisory
+
+Issued: 27 May 2026
+
+[role="_abstract"]
+{product-title} release 4.19.32 is now available. Bug fixes and enhancements are listed in the link:https://access.redhat.com/errata/RHSA-2026:20322[RHSA-2026:20322] advisory. Release notes for fixed issues are provided in this documentation. The images that are included in the update are provided by the {OCP} link:https://access.redhat.com/errata/RHSA-2026:20041[RHSA-2026:20041] advisory.
+
+See the latest images included with {microshift-short} by using the following instructions:
+
+* xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[Listing the contents of the {microshift-short} RPM release package]
+* xref:../microshift_install_bootc/microshift-install-bootc-image.adoc#microshift-install-bootc-get-published-image_microshift-install-rhel-bootc-image[Getting the published bootc image for MicroShift]
+
+[id="microshift-4-19-32-dp-bug-fixes_{context}"]
+== Fixed issues
+
+There are no notable fixed issues for this release.

--- a/modules/microshift-4-19-7-dp.adoc
+++ b/modules/microshift-4-19-7-dp.adoc
@@ -4,20 +4,20 @@
 
 :_mod-docs-content-type: CONCEPT
 [id="microshift-4-19-7-dp_{context}"]
-= RHBA-2025:12745 - {microshift-short} 4.19.7 bug fix and update advisory
+= RHBA-2025:12745 - {microshift-short} 4.19.7 fixed issues advisory
 
 [role="_abstract"]
 Issued: 11 August 2025
 
-{product-title} release 4.19.7 is now available. Bug fixes and enhancements are listed in the link:https://access.redhat.com/errata/RHBA-2025:12745[RHBA-2025:12745] advisory. Release notes for bug fixes and enhancements are provided in this documentation. The images that are included in the update are provided by the {OCP} link:https://access.redhat.com/errata/RHSA-2025:12341[RHSA-2025:12341] advisory.
+{product-title} release 4.19.7 is now available. Fixed issues are listed in the link:https://access.redhat.com/errata/RHBA-2025:12745[RHBA-2025:12745] advisory. Release notes for fixed issues are provided in this documentation. The images that are included in the update are provided by the {OCP} link:https://access.redhat.com/errata/RHSA-2025:12341[RHSA-2025:12341] advisory.
 
 See the latest images included with {microshift-short} by using the following instructions:
 
 * xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[Listing the contents of the {microshift-short} RPM release package]
-* xref:../microshift_install_bootc/microshift-install-bootc-image.adoc#microshift-install-bootc-get-published-image_microshift-install-publish-bootc-image[Getting the published bootc image for MicroShift]
+* xref:../microshift_install_bootc/microshift-install-bootc-image.adoc#microshift-install-bootc-get-published-image_microshift-install-rhel-bootc-image[Getting the published bootc image for MicroShift]
 
 [id="microshift-4-19-7-dp-bug-fixes_{context}"]
-== Bug fixes
+== Fixed issues
 
 * Before this update, a bare-metal node reboot caused the deployment progress deadline to be surpassed. This resulted in the greenboot health check failing with a false-positive error. With this release, the full timeout duration is provided for the deployment to become ready, reducing false-positive greenboot health check errors. (https://issues.redhat.com/browse/OCPBUGS-59301[OCPBUGS-59301])
 


### PR DESCRIPTION
Version(s):
4.19

Issue:
[OSDOCS-19900](https://redhat.atlassian.net/browse/OSDOCS-19900)

Link to docs preview:
[4.19.32](https://112328--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-19-release-notes.html#microshift-4-19-32-dp_release-notes)

QE review:
- [ ] QE has approved this change.
N/A for z-stream RNs.

Additional information:
Shipment [MR](https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/548)
ART [Dashboard](https://art-dash.engineering.redhat.com/dashboard/release/openshift-4.19?page=1)
