### PR TITLE
[RHDEVDOCS-7544] Add support for multiple URLs in hub resolver

### DIFF
--- a/modules/op-resolver-hub-config.adoc
+++ b/modules/op-resolver-hub-config.adoc
@@ -29,25 +29,42 @@ metadata:
 spec:
   pipeline:
     hub-resolver-config:
-      default-tekton-hub-catalog: Tekton
+      default-tekton-hub-catalog: tekton-catalog
       default-artifact-hub-task-catalog: tekton-catalog-tasks
       default-artifact-hub-pipeline-catalog: tekton-catalog-pipelines
-      defailt-kind: pipeline
-      default-type: tekton
-      tekton-hub-api: "https://my-custom-tekton-hub.example.com"
-      artifact-hub-api: "https://my-custom-artifact-hub.example.com"
+      default-kind: task
+      default-type: artifact
+      artifact-hub-urls: |
+        - https://internal-artifact-hub.example.com/
+        - https://artifacthub.io/
 ----
 `default-tekton-hub-catalog`:: The default {tekton-hub} catalog for pulling a resource.
 `default-artifact-hub-task-catalog`:: The default {artifact-hub} catalog for pulling a task resource.
 `default-artifact-hub-pipeline-catalog`:: The default {artifact-hub} catalog for pulling a pipeline resource.
-`defailt-kind`:: The default object kind for references.
+`default-kind`:: The default object kind for references.
 `default-type`:: The default hub for pulling a resource, either `artifact` for {artifact-hub} or `tekton` for {tekton-hub}.
-`tekton-hub-api`:: The {tekton-hub} API used, if you set the `default-type` option to `tekton`.
-`artifact-hub-api`:: Optional: The {artifact-hub} API used, if you set the `default-type` option to `artifact`.
+`tekton-hub-api`:: The self-hosted {tekton-hub} API URL, if you set the `default-type` option to `tekton`. The public {tekton-hub} instance (hub.tekton.dev) is no longer available. You must configure your own self-hosted instance.
+`artifact-hub-api`:: Optional: The {artifact-hub} API URL, if you set the `default-type` option to `artifact`.
+`artifact-hub-urls`:: Optional: An ordered YAML list of {artifact-hub} API URLs. The resolver tries each URL in sequence and returns the first successful response. URLs must use the `http` or `https` scheme. If not set, the resolver uses the `artifact-hub-api` value or the default URL `\https://artifacthub.io`.
+`tekton-hub-urls`:: Optional: An ordered YAML list of self-hosted {tekton-hub} API URLs. The resolver tries each URL in sequence and returns the first successful response. URLs must use the `http` or `https` scheme. If not set, the resolver uses the `tekton-hub-api` value. The public {tekton-hub} instance is no longer available.
 +
 [IMPORTANT]
 ====
-If you set the `default-type` option to `tekton`, you must configure your own instance of the {tekton-hub} by setting the `tekton-hub-api` value.
+If you set the `default-type` option to `artifact`, the resolver uses the public {artifact-hub} API at \https://artifacthub.io/ by default. You can configure your own {artifact-hub} instance by setting the `artifact-hub-api` value or the `artifact-hub-urls` list.
 
-If you set the `default-type` option to `artifact` then the resolver uses the public hub API at https://artifacthub.io/ by default. You can configure your own {artifact-hub} API by setting the `artifact-hub-api` value.
+If you set the `default-type` option to `tekton`, you must configure your own self-hosted instance of {tekton-hub} by setting the `tekton-hub-api` value or the `tekton-hub-urls` list. The public {tekton-hub} instance (hub.tekton.dev) is no longer available.
+
+Use {artifact-hub} as the primary hub for Tekton resources.
+====
++
+[NOTE]
+====
+The hub resolver determines which URL to use based on the following precedence (from highest to lowest):
+
+. The `url` parameter set in the pipeline run, task run, or task specification
+. The `artifact-hub-urls` or `tekton-hub-urls` configuration field, tried in order
+. The `artifact-hub-api` or `tekton-hub-api` configuration field
+. The default URL for {artifact-hub}: `\https://artifacthub.io`
+
+If you specify multiple URLs in the `artifact-hub-urls` or `tekton-hub-urls` fields, the resolver tries each URL in sequence and returns the first successful response. This is useful for configuring fallback hubs or for environments with multiple hub instances.
 ====

--- a/modules/op-resolver-hub.adoc
+++ b/modules/op-resolver-hub.adoc
@@ -56,6 +56,10 @@ When creating a pipeline run, you can specify a remote pipeline from {artifact-h
 | `version`
 | The version of the task or pipeline to fetch from the hub. You must use quotes (`"`) around the number.
 | `"0.5.0"`
+
+| `url`
+| Optional. A custom hub API endpoint to query instead of the cluster-configured default. The URL must be an absolute HTTP or HTTPS URL. When you specify this parameter, it overrides all other URL configuration, including ConfigMap URL lists, environment variables, and defaults.
+| `https://internal-hub.example.com`
 |===
 +
 If the pipeline or task requires additional parameters, specify values for these parameters in the `params` section of the specification of the pipeline, pipeline run, or task run. The `params` section of the `pipelineRef` or `taskRef` specification must contain only the parameters that the resolver supports.
@@ -171,3 +175,37 @@ spec:
     - name: sample-stepaction-parameter
       value: test
 ----
+
+The following example task run references a remote task from a private hub instance by using the `url` parameter:
+
+[source,yaml]
+----
+apiVersion: tekton.dev/v1
+kind: TaskRun
+metadata:
+  name: private-hub-task-reference
+spec:
+  taskRef:
+    resolver: hub
+    params:
+    - name: url
+      value: https://internal-hub.example.com
+    - name: catalog
+      value: my-team-catalog
+    - name: type
+      value: artifact
+    - name: kind
+      value: task
+    - name: name
+      value: my-task
+    - name: version
+      value: "1.0.0"
+  params:
+  - name: sample-task-parameter
+    value: test
+----
++
+[NOTE]
+====
+The `url` parameter overrides all cluster-configured hub URLs. Use this parameter to access resources from a private hub instance, test resources from a different hub, or support air-gapped deployments. If you do not specify the `url` parameter, the resolver uses the cluster-configured default values.
+====


### PR DESCRIPTION
Version(s):
- `pipelines-docs-1.23`

Issue:
- https://redhat.atlassian.net/browse/RHDEVDOCS-7544

Link to docs preview:
- [Configuring the hub resolver](https://112333--ocpdocs-pr.netlify.app/openshift-pipelines/latest/create/remote-pipelines-tasks-resolvers.html#resolver-hub-config_remote-pipelines-tasks-resolvers)

SME review:
- [x] SME has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional info: 
RN done as a part of the 1.23.0 RNs PR.
