### PR TITLE
OSDOCS-18169 Removing unsupported version of CLI Manager for 4.22

### DIFF
--- a/cli_reference/cli_manager/cli-manager-release-notes.adoc
+++ b/cli_reference/cli_manager/cli-manager-release-notes.adoc
@@ -18,9 +18,6 @@ include::modules/cli-manager-rn-0-2-0.adoc[leveloffset=+1]
 //cli manager 0.1.1 (Technology Preview)
 include::modules/cli-manager-rn-0-1-1.adoc[leveloffset=+1]
 
-//{cli-manager} 0.1.0 (Technology Preview)
-include::modules/cli-manager-initial-release.adoc[leveloffset=+1]
-
 .Additional resources
 
 * xref:../../cli_reference/cli_manager/index.adoc#cli-manager-overview[About the {cli-manager}]


### PR DESCRIPTION


Version(s):main, 4.22
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:https://redhat.atlassian.net/browse/OSDOCS-18169
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
