### PR TITLE
OCPBUGS-86563: Add securityContext to image volume pod YAML example

### DIFF
--- a/modules/nodes-pods-image-volume-adding.adoc
+++ b/modules/nodes-pods-image-volume-adding.adoc
@@ -24,6 +24,13 @@ spec:
   - name: image-volume-container
     command: ["sleep", "infinity"]
     image: debian
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop: ["ALL"]
+      runAsNonRoot: true
+      seccompProfile:
+        type: RuntimeDefault
     volumeMounts:
     - name: image
       mountPath: /image
@@ -33,6 +40,13 @@ spec:
     args:
     - -c
     - trap 'exit 0' TERM INT; sleep infinity & wait
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop: ["ALL"]
+      runAsNonRoot: true
+      seccompProfile:
+        type: RuntimeDefault
     volumeMounts:
     - name: artifact
       mountPath: /artifact


### PR DESCRIPTION
## Summary

- Add required `securityContext` fields to both containers in the image volume pod YAML example
- Without these fields, creating the pod as documented fails with a PodSecurity violation under the default `restricted` profile
- Added fields: `allowPrivilegeEscalation: false`, `capabilities.drop: ["ALL"]`, `runAsNonRoot: true`, `seccompProfile.type: RuntimeDefault`

### Error without fix
```
Error from server (Forbidden): pods "image-volume" is forbidden: violates PodSecurity
"restricted:latest": allowPrivilegeEscalation != false, unrestricted capabilities,
runAsNonRoot != true, seccompProfile
```

## Test plan

- [x] Verified the pod YAML example creates successfully under the default restricted PodSecurity profile with the added securityContext

Bug: https://issues.redhat.com/browse/OCPBUGS-86563