### PR TITLE
OSDOCS#19367: Note runc container runtime deprecation

### DIFF
--- a/modules/config-container-runtime.adoc
+++ b/modules/config-container-runtime.adoc
@@ -7,13 +7,18 @@
 = Configuring the container runtime
 
 [role="_abstract"]
-You can configure the container runtime used with new workloads on your nodes, based on which runtime you or your organization prefers. You can use either crun, which is considered a faster and more lightweight runtime, or runc, which is more widely used than crun. 
+You can configure the container runtime used with new workloads on your nodes, based on which runtime you or your organization prefers. You can use either crun, which is considered a faster and more lightweight runtime, or runC, which is more widely used than crun. 
 
-For information on crun and runc, see "About the container engine and container runtime".
+For information on crun and runC, see "About the container engine and container runtime".
+
+[WARNING]
+====
+Starting in {product-title} 4.22, the runC container runtime is deprecated.
+====
 
 Starting in {product-title} 4.18, crun is the default container runtime for new installations. You can change between the runtimes by using a `ContainerRuntimeConfig` object, as described in the following procedure. Changing the container runtime affects new workloads only. Existing workloads continue to use their existing container runtime. 
 
-If you updated your cluster from {product-title} 4.17, the runc container runtime remains unchanged as the default. During the upgrade, two `MachineConfig` objects, one for the control plane nodes and one for the worker nodes, were created to override the new default runtime. You can migrate the container runtime to crun, on a schedule of your choosing, by removing either or both of the `MachineConfig` objects.
+If you updated your cluster from {product-title} 4.17, the runC container runtime remains unchanged as the default. During the upgrade, two `MachineConfig` objects, one for the control plane nodes and one for the worker nodes, were created to override the new default runtime. You can migrate the container runtime to crun, on a schedule of your choosing, by removing either or both of the `MachineConfig` objects.
 
 .Procedure
 
@@ -33,7 +38,7 @@ $ oc delete machineconfig 00-override-worker-generated-crio-default-container-ru
 $ oc delete machineconfig 00-override-master-generated-crio-default-container-runtime
 ----
 
-* For any {product-title} 4.18 or greater cluster, you can configure crun or runc as the container runtime for specific nodes by creating a container runtime configuration:
+* For any {product-title} 4.18 or greater cluster, you can configure crun or runC as the container runtime for specific nodes by creating a container runtime configuration:
 
 . Create a YAML file for the `ContainerRuntimeConfig` CR:
 +

--- a/nodes/containers/nodes-containers-using.adoc
+++ b/nodes/containers/nodes-containers-using.adoc
@@ -53,6 +53,11 @@ The {product-title} documentation uses the term _container runtime_ to refer to 
 ifndef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 {product-title} uses CRI-O as the container engine and runC or crun as the container runtime. The default container runtime is crun. Both container runtimes adhere to the link:https://www.opencontainers.org/[Open Container Initiative (OCI)] runtime specifications.
 
+[WARNING]
+====
+Starting in {product-title} 4.22, the runC container runtime is deprecated.
+====
+
 include::snippets/about-crio-snippet.adoc[]
 
 crun, developed by Red Hat, is a fast and low-memory container runtime fully written in C. runC, developed by Docker and maintained by the Open Container Project, is a lightweight, portable container runtime written in Go.
@@ -74,6 +79,11 @@ endif::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 
 ifdef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 {product-title} uses CRI-O as the container engine and crun or runC as the container runtime. The default container runtime is crun.
+
+[WARNING]
+====
+Starting in {product-title} 4.22, the runC container runtime is deprecated.
+====
 endif::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 
 ifndef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]


### PR DESCRIPTION
Version(s):
4.22

Issue:
[OSDOCS-19367](https://redhat.atlassian.net/browse/OSDOCS-19367)

Link to docs preview:
1. [Configuring the container runtime](https://112351--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_configuration/machine-configs-custom.html#config-container-runtime_machine-configs-custom)
2. About the container engine and container runtime
    - [OpenShift Container Platform](https://112351--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/containers/nodes-containers-using.html#nodes-containers-runtimes)
    - [OpenShift Dedicated](https://112351--ocpdocs-pr.netlify.app/openshift-dedicated/latest/nodes/containers/nodes-containers-using.html#nodes-containers-runtimes)
    - [ROSA](https://112351--ocpdocs-pr.netlify.app/openshift-rosa/latest/nodes/containers/nodes-containers-using.html#nodes-containers-runtimes)

QE review:
- [x] QE has approved this change.

Additional information:
N/A