### PR TITLE
OSDOCS#19905: Add Red Hat Marketplace to deprecation tables

### DIFF
--- a/modules/rn-ocp-release-notes-deprecated-removed-tables.adoc
+++ b/modules/rn-ocp-release-notes-deprecated-removed-tables.adoc
@@ -171,6 +171,11 @@
 |====
 |Feature |4.20 |4.21 |4.22
 
+|Red Hat Marketplace
+|Deprecated
+|Deprecated
+|Removed
+
 // Do not remove the SQLite database... entry until otherwise directed by the Operator Framework PM
 |SQLite database format for Operator catalogs
 |Deprecated


### PR DESCRIPTION
Version(s):
4.22

Issue:
[OSDOCS-19905](https://redhat.atlassian.net/browse/OSDOCS-19905)

Link to docs preview:
[Operator lifecycle and development deprecated and removed features](https://112353--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-22-release-notes.html#ocp-release-note-operators-dep-rem_release-notes)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:

See #112284 for the removal of this content from the docs for 4.22.

SME confirmed that the Marketplace is deprecated in 4.21 and removed in 4.22, but could not confirm deprecation in 4.20. Deprecation in 4.20 is noted here due to the timing of the Marketplace removal: the Marketplace was removed in April 2025, and OpenShift 4.20 was released in October 2025.

SME approved this change.