### PR TITLE
OSDOCS#19910: Remove 4.14 from Compatibility table

### DIFF
--- a/modules/microshift-rhde-compatibility-table.adoc
+++ b/modules/microshift-rhde-compatibility-table.adoc
@@ -63,8 +63,4 @@ Be sure to check the support status of a release on the product lifecycle page.
 ^|9.4
 ^|4.16
 ^|4.16.0{nbsp}&#8594;{nbsp}4.16.z, 4.16{nbsp}&#8594;{nbsp}4.17, 4.16{nbsp}&#8594;{nbsp}4.18
-
-^|9.2
-^|4.14
-^|4.14.0{nbsp}&#8594;{nbsp}4.14.z, 4.14{nbsp}&#8594;{nbsp}4.16 on {op-system-base} 9.4
 |===


### PR DESCRIPTION
Version(s):
4.22+

Issue:
[OSDOCS-19910](https://redhat.atlassian.net/browse/OSDOCS-19910)

Link to docs preview:
[RHDE Compatibility table](https://112354--ocpdocs-pr.netlify.app/microshift/latest/microshift_install_get_ready/microshift-install-get-ready.html#microshift-rhde-compatibility-table_microshift-install-get-ready)

QE review:
- [ ] QE has approved this change.

Additional information:
This PR removes 4.14 support from the MicroShift compatibility table for RHEL 10.2 support. This is the original RHEL 10.2 [PR](https://github.com/openshift/openshift-docs/pull/110814).
