### PR TITLE
[OSDOCS#19911]Add concept topic for Channels and channel groups to Classic

### DIFF
--- a/modules/rosa-upgrading-channels.adoc
+++ b/modules/rosa-upgrading-channels.adoc
@@ -1,0 +1,45 @@
+:_mod-docs-content-type: CONCEPT
+[id="rosa-upgrading-channels_{context}"]
+= Channels in {product-title} clusters
+
+[role="_abstract"]
+You can use {product-title} channels to view available cluster update options and apply patches or z-stream updates in your existing channel. You can also view the update path to newer y-stream versions if available.
+
+== Channel groups and channels
+Channel groups in {product-title} are similar to channels, but there is no specific version with channel groups. When you select a channel group, your {product-title} cluster receives z-stream updates for your current channel group. These channel groups typically include:
+
+* `fast`: cluster receives the latest updates as soon as they are available.
+* `stable`: cluster receives updates after they have been thoroughly tested.
+* `eus`: Extended Update Support channel, allowing for extended support for even-numbered versions, for example, 4.16, 4.18, or 4.20.
+
+By moving from channel groups to channels, you can have more control over your cluster updates. Instead of receiving patch/z-stream updates only for a particular channel group, by using channels you can view the available updates associated with a minor release version, and determine if there is a path available to that minor/y+1/y+2 version.
+
+[IMPORTANT]
+====
+The channel group option is being deprecated. If you set a channel group only, {product-title} will default to preserving the current channel's target version. For example, a `stable-4.20` cluster moving to the `eus` channel group will use the `eus-4.20` channel by default, if the current cluster version is a member of the `eus-4.20` channel.
+====
+
+== Cluster update options
+The process for updating your cluster is based on the updates that are available for your current version, and what level of release you are interested in, such as z-stream or y-stream updates.
+
+* *Patch (z-stream) updates*: You do not need to change the channel when performing a patch update within your current minor version. For example, if you have your cluster at version 4.19.12, you can stay within your current `stable-4.19` channel, and decide to update your cluster when there are updates available, such as 4.19.13, 4.19.14, 4.19.17, 4.19.20 until you have the latest updates for that minor version.
+
+* *Minor version (y-stream) updates*: To update to a new minor release, you must change the channel to the next release channel. 
++
+For example, if you have your cluster at version 4.19.12, you can switch the channel to `stable-4.20` or `stable-4.21` and check if there is an update path available for those versions. 
++
+If `stable-4.20` has an update path available, it shows you the z-stream updates for your current version, as well as the updates to the y+1 version, such as 4.19.14, 4.19.17, 4.19.20, 4.19.23, 4.19.27, 4.20.0. 
++
+If you select `stable-4.21`, the available updates might be 4.19.14, 4.19.17, 4.19.20, 4.19.23, 4.19.27, 4.20.0, 4.20.3, 4.20.4, 4.20.6, 4.20.7, with all the z-stream/patch updates displayed right through to the y+2 version of 4.21.0.
+
+You can change your cluster's channel either through the Cluster Overview → Details page in the web console or by using the `rosa edit cluster` command in {rosa-cli}.
+
+When you have set the channel and an update is initiated, the Cluster Version Operator (CVO) retrieves the target release image and begins applying the changes to the cluster.
+
+////
+[NOTE]
+====
+The *Channel groups* option is now deprecated in {product-title}. Channel groups allowed you to upgrade through the available patch/z-stream updates for a particular channel group, such as stabe or eus. 
+There was the possibility of inadvertently upgrading to the next minor version/Y+1 version if it appeared in the available updates.
+====
+////

--- a/upgrading/rosa-upgrading-sts.adoc
+++ b/upgrading/rosa-upgrading-sts.adoc
@@ -14,6 +14,8 @@ Use one of the following methods to upgrade {product-title} clusters:
 
 include::modules/rosa-upgrading-lifecycle-policy.adoc[leveloffset=+1]
 
+include::modules/rosa-upgrading-channels.adoc[leveloffset=+1]
+
 include::modules/rosa-sts-upgrading-a-cluster-with-sts.adoc[leveloffset=+1]
 
 include::modules/rosa-how-upgrades-work.adoc[leveloffset=+2]


### PR DESCRIPTION
Version(s):
4.21+

Issue:
https://redhat.atlassian.net/browse/OSDOCS-19911

Link to docs preview:
[Channels in Red Hat OpenShift Service on AWS (classic architecture) clusters](https://112366--ocpdocs-pr.netlify.app/openshift-rosa/latest/upgrading/rosa-upgrading-sts.html#rosa-upgrading-channels_rosa-upgrading-sts)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
