### PR TITLE
OSDOCS NODES 7: Scheduling Configuration (Scheduler, Affinity) II

### DIFF
--- a/modules/nodes-cluster-overcommit-about.adoc
+++ b/modules/nodes-cluster-overcommit-about.adoc
@@ -6,9 +6,10 @@
 [id="nodes-cluster-overcommit-about_{context}"]
 = Understanding overcommitment
 
-Requests and limits enable administrators to allow and manage the overcommitment of resources on a node. The scheduler uses requests for scheduling your container and providing a minimum service guarantee. Limits constrain the amount of compute resource that may be consumed on your node.
+[role="_abstract"]
+{product-title} administrators can control the level of overcommit and manage container density on nodes by configuring masters to override the ratio between the container compute resource requests and limits set on developer containers.
 
-{product-title} administrators can control the level of overcommit and manage container density on nodes by configuring masters to override the ratio between request and limit set on developer containers. In conjunction with a per-project `LimitRange` object specifying limits and defaults, this adjusts the container limit and request to achieve the desired level of overcommit.
+Requests and limits enable administrators to allow and manage the overcommitment of resources on a node. The scheduler uses requests for scheduling your container and providing a minimum service guarantee. Limits constrain the amount of compute resource that may be consumed on your node. In conjunction with a per-project `LimitRange` object specifying limits and defaults, this adjusts the container limit and request to achieve the desired level of overcommit.
 
 [NOTE]
 ====

--- a/modules/nodes-scheduler-taints-tolerations-about.adoc
+++ b/modules/nodes-scheduler-taints-tolerations-about.adoc
@@ -16,7 +16,8 @@ endif::[]
 [id="nodes-scheduler-taints-tolerations-about_{context}"]
 = Understanding taints and tolerations
 
-A _taint_ allows a node to refuse a pod to be scheduled unless that pod has a matching _toleration_.
+[role="_abstract"]
+You can use a _taint_ on a node to allow that node to refuse a pod to be scheduled unless that pod has a matching _toleration_.
 
 You apply taints to a node through the `Node` specification (`NodeSpec`) and apply tolerations to a pod through the `Pod` specification (`PodSpec`). When you apply a taint to a node, the scheduler cannot place a pod on that node unless the pod can tolerate the taint.
 
@@ -276,7 +277,7 @@ If you use the `tolerationSeconds` parameter with no value, pods are never evict
 
 By default, if more than 55% of nodes in a given zone are unhealthy, the node lifecycle controller changes that zone's state to `PartialDisruption` and the rate of pod evictions is reduced. For small clusters (by default, 50 nodes or less) in this state, nodes in this zone are not tainted and evictions are stopped.
 
-For more information, see link:https://kubernetes.io/docs/concepts/architecture/nodes/#rate-limits-on-eviction[Rate limits on eviction] in the Kubernetes documentation.
+For more information, see "Rate limits on eviction" in the Kubernetes documentation.
 ====
 
 {product-title} automatically adds a toleration for `node.kubernetes.io/not-ready` and `node.kubernetes.io/unreachable` with `tolerationSeconds=300`, unless the `Pod` configuration specifies either toleration.
@@ -293,7 +294,7 @@ spec:
   - key: node.kubernetes.io/not-ready
     operator: Exists
     effect: NoExecute
-    tolerationSeconds: 300 <1>
+    tolerationSeconds: 300
   - key: node.kubernetes.io/unreachable
     operator: Exists
     effect: NoExecute
@@ -301,7 +302,7 @@ spec:
 #...
 ----
 
-<1> These tolerations ensure that the default pod behavior is to remain bound for five minutes after one of these node conditions problems is detected.
+These tolerations ensure that the default pod behavior is to remain bound for five minutes after one of these node conditions problems is detected.
 
 You can configure these tolerations as needed. For example, if you have an application with a lot of local state, you might want to keep the pods bound to node for a longer time in the event of network partition, allowing for the partition to recover and avoiding pod eviction.
 

--- a/modules/nodes-scheduler-taints-tolerations-adding-machineset.adoc
+++ b/modules/nodes-scheduler-taints-tolerations-adding-machineset.adoc
@@ -7,7 +7,10 @@
 [id="nodes-scheduler-taints-tolerations-adding-machineset_{context}"]
 = Adding taints and tolerations using a compute machine set
 
-You can add taints to nodes using a compute machine set. All nodes associated with the `MachineSet` object are updated with the taint. Tolerations respond to taints added by a compute machine set in the same manner as taints added directly to the nodes.
+[role="_abstract"]
+You can add taints to groups of nodes by using a compute machine set. All nodes associated with the `MachineSet` object are updated with the taint. 
+
+Tolerations respond to taints added by a compute machine set in the same manner as taints added directly to the nodes.
 
 .Procedure
 
@@ -23,15 +26,19 @@ metadata:
 #...
 spec:
   tolerations:
-  - key: "key1" <1>
+  - key: "key1"
     value: "value1"
     operator: "Equal"
     effect: "NoExecute"
-    tolerationSeconds: 3600 <2>
+    tolerationSeconds: 3600
 #...
 ----
-<1> The toleration parameters, as described in the *Taint and toleration components* table.
-<2> The `tolerationSeconds` parameter specifies how long a pod is bound to a node before being evicted.
+where:
++
+--
+`spec.tolerations`:: Specifies the toleration parameters, as described in the *Taint and toleration components* table.
+`spec.tolerations.tolerationSeconds`:: Specifies how long a pod can remain bound to a node before being evicted.
+--
 +
 For example:
 +

--- a/modules/nodes-scheduler-taints-tolerations-adding.adoc
+++ b/modules/nodes-scheduler-taints-tolerations-adding.adoc
@@ -7,7 +7,10 @@
 [id="nodes-scheduler-taints-tolerations-adding_{context}"]
 = Adding taints and tolerations
 
-You add tolerations to pods and taints to nodes to allow the node to control which pods should or should not be scheduled on them. For existing pods and nodes, you should add the toleration to the pod first, then add the taint to the node to avoid pods being removed from the node before you can add the toleration.
+[role="_abstract"]
+You can add tolerations to pods and taints to nodes to allow the node to control which pods should or should not be scheduled on that node. 
+
+For existing pods and nodes, you should add the toleration to the pod first, then add the taint to the node to avoid pods being removed from the node before you can add the toleration.
 
 .Procedure
 
@@ -23,15 +26,19 @@ metadata:
 #...
 spec:
   tolerations:
-  - key: "key1" <1>
+  - key: "key1"
     value: "value1"
     operator: "Equal"
     effect: "NoExecute"
-    tolerationSeconds: 3600 <2>
+    tolerationSeconds: 3600
 #...
 ----
-<1> The toleration parameters, as described in the *Taint and toleration components* table.
-<2> The `tolerationSeconds` parameter specifies how long a pod can remain bound to a node before being evicted.
+where:
++
+--
+`spec.tolerations`:: Specifies the toleration parameters, as described in the *Taint and toleration components* table.
+`spec.tolerations.tolerationSeconds``:: Specifies how long a pod can remain bound to a node before being evicted.
+--
 +
 For example:
 +
@@ -46,12 +53,13 @@ metadata:
 spec:
    tolerations:
     - key: "key1"
-      operator: "Exists" <1>
+      operator: "Exists"
       effect: "NoExecute"
       tolerationSeconds: 3600
 #...
 ----
-<1> The `Exists` operator does not take a `value`.
++
+The `Exists` operator does not take a `value`.
 +
 This example places a taint on `node1` that has key `key1`, value `value1`, and taint effect `NoExecute`.
 

--- a/modules/nodes-scheduler-taints-tolerations-binding.adoc
+++ b/modules/nodes-scheduler-taints-tolerations-binding.adoc
@@ -7,13 +7,16 @@
 [id="nodes-scheduler-taints-tolerations-bindings_{context}"]
 = Binding a user to a node using taints and tolerations
 
-If you want to dedicate a set of nodes for exclusive use by a particular set of users, add a toleration to their pods. Then, add a corresponding taint to those nodes.  The pods with the tolerations are allowed to use the tainted nodes or any other nodes in the cluster.
+[role="_abstract"]
+You can use taints and tolerations to dedicate a set of nodes for exclusive use by a particular set of users. 
+
+First, add a toleration to their pods. Then, add a corresponding taint to those nodes. The pods with the tolerations are allowed to use the tainted nodes or any other nodes in the cluster.
 
 If you want ensure the pods are scheduled to only those tainted nodes, also add a label to the same set of nodes and add a node affinity to the pods so that the pods can only be scheduled onto nodes with that label.
 
-.Procedure
+Use the following procedure to configure a node so that users can use only that node.
 
-To configure a node so that users can use only that node:
+.Procedure
 
 . Add a corresponding taint to those nodes:
 +

--- a/modules/nodes-scheduler-taints-tolerations-projects.adoc
+++ b/modules/nodes-scheduler-taints-tolerations-projects.adoc
@@ -7,6 +7,7 @@
 [id="nodes-scheduler-taints-tolerations-projects_{context}"]
 = Creating a project with a node selector and toleration
 
+[role="_abstract"]
 You can create a project that uses a node selector and toleration, which are set as annotations, to control the placement of pods onto specific nodes. Any subsequent resources created in the project are then scheduled on nodes that have a taint matching the toleration.
 
 .Prerequisites
@@ -24,17 +25,19 @@ You can create a project that uses a node selector and toleration, which are set
 kind: Project
 apiVersion: project.openshift.io/v1
 metadata:
-  name: <project_name> <1>
+  name: <project_name>
   annotations:
-    openshift.io/node-selector: '<label>' <2>
+    openshift.io/node-selector: '<label>'
     scheduler.alpha.kubernetes.io/defaultTolerations: >-
       [{"operator": "Exists", "effect": "NoSchedule", "key":
-      "<key_name>"} <3>
+      "<key_name>"}
       ]
 ----
-<1> The project name.
-<2> The default node selector label.
-<3> The toleration parameters, as described in the *Taint and toleration components* table. This example uses the `NoSchedule` effect, which allows existing pods on the node to remain, and the `Exists` operator, which does not take a value.
+where:
+
+`metadata.name`:: Specifies the project name.
+`metadata.annotations.openshift.io/node-selector`:: Specifies the default node selector label.
+`metadata.annotations.scheduler.alpha.kubernetes.io/defaultTolerations`:: Specifies the toleration parameters, as described in the *Taint and toleration components* table. This example uses the `NoSchedule` effect, which allows existing pods on the node to remain, and the `Exists` operator, which does not take a value.
 
 . Use the `oc apply` command to create the project:
 +
@@ -42,5 +45,5 @@ metadata:
 ----
 $ oc apply -f project.yaml
 ----
-
++
 Any subsequent resources created in the `<project_name>` namespace should now be scheduled on the specified nodes.

--- a/modules/nodes-scheduler-taints-tolerations-removing.adoc
+++ b/modules/nodes-scheduler-taints-tolerations-removing.adoc
@@ -7,11 +7,14 @@
 [id="nodes-scheduler-taints-tolerations-removing_{context}"]
 = Removing taints and tolerations
 
-You can remove taints from nodes and tolerations from pods as needed. You should add the toleration to the pod first, then add the taint to the node to avoid pods being removed from the node before you can add the toleration.
+[role="_abstract"]
+You can remove taints from nodes and tolerations from pods as needed if you no longer want the scheduling behavior. 
+
+You should add the toleration to the pod first, then add the taint to the node to avoid pods being removed from the node before you can add the toleration.
+
+Use the following procedure to remove taints and tolerations.
 
 .Procedure
-
-To remove taints and tolerations:
 
 . To remove a taint from a node:
 +

--- a/modules/nodes-scheduler-taints-tolerations-special.adoc
+++ b/modules/nodes-scheduler-taints-tolerations-special.adoc
@@ -7,13 +7,14 @@
 [id="nodes-scheduler-taints-tolerations-special_{context}"]
 = Controlling nodes with special hardware using taints and tolerations
 
-In a cluster where a small subset of nodes have specialized hardware, you can use taints and tolerations to keep pods that do not need the specialized hardware off of those nodes, leaving the nodes for pods that do need the specialized hardware. You can also require pods that need specialized hardware to use specific nodes.
+[role="_abstract"]
+In a cluster that has specialized hardware, you can use taints and tolerations to either keep pods that do not need the specialized hardware off of those nodes or require pods that need specialized hardware to use specific nodes.
 
 You can achieve this by adding a toleration to pods that need the special hardware and tainting the nodes that have the specialized hardware.
 
-.Procedure
+Use the following procedure to ensure nodes with specialized hardware are reserved for specific pods. 
 
-To ensure nodes with specialized hardware are reserved for specific pods:
+.Procedure
 
 . Add a toleration to pods that need the special hardware.
 +

--- a/nodes/scheduling/nodes-scheduler-overcommit.adoc
+++ b/nodes/scheduling/nodes-scheduler-overcommit.adoc
@@ -7,9 +7,8 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 
-
-
-
+[role="_abstract"]
+{product-title} administrators can use container compute resource requests and limits to allow and manage the overcommitment of resources on a node, which enables pods to use additional resources when available, without guaranteeing those resources.
 
 In an _overcommited_ state, the sum of the container compute resource requests and limits exceeds the resources available on the system.
 Overcommitment might be desirable in development environments where a trade-off of guaranteed performance for capacity is acceptable.

--- a/nodes/scheduling/nodes-scheduler-taints-tolerations.adoc
+++ b/nodes/scheduling/nodes-scheduler-taints-tolerations.adoc
@@ -6,7 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-Taints and tolerations allow the node to control which pods should (or should not) be scheduled on them.
+[role="_abstract"]
+You can use taints and tolerations to allow the scheduler to control which pods should or should not be scheduled on a node.
 
 // The following include statements pull in the module files that comprise
 // the assembly. Include any combination of concept, procedure, or reference
@@ -23,17 +24,20 @@ include::modules/nodes-scheduler-taints-tolerations-binding.adoc[leveloffset=+2]
 
 include::modules/nodes-scheduler-taints-tolerations-projects.adoc[leveloffset=+2]
 
-[role="_additional-resources"]
-.Additional resources
+include::modules/nodes-scheduler-taints-tolerations-special.adoc[leveloffset=+2]
 
-* Adding taints and tolerations xref:../../nodes/scheduling/nodes-scheduler-taints-tolerations.adoc#nodes-scheduler-taints-tolerations-adding_nodes-scheduler-taints-tolerations[manually to nodes] or xref:../../nodes/scheduling/nodes-scheduler-taints-tolerations.adoc#nodes-scheduler-taints-tolerations-adding-machineset_nodes-scheduler-taints-tolerations[with compute machine sets]
+include::modules/nodes-scheduler-taints-tolerations-removing.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+[id="additional-resources_{context}"]
+== Additional resources
+
+* xref:../../nodes/scheduling/nodes-scheduler-taints-tolerations.adoc#nodes-scheduler-taints-tolerations-adding_nodes-scheduler-taints-tolerations[Adding taints and tolerations]
+* xref:../../nodes/scheduling/nodes-scheduler-taints-tolerations.adoc#nodes-scheduler-taints-tolerations-adding-machineset_nodes-scheduler-taints-tolerations[Adding taints and tolerations using a compute machine set]
 ifndef::openshift-rosa,openshift-dedicated[]
 * xref:../../nodes/scheduling/nodes-scheduler-node-selectors.adoc#nodes-scheduler-node-selectors-project_nodes-scheduler-node-selectors[Creating project-wide node selectors]
 * xref:../../operators/admin/olm-adding-operators-to-cluster.adoc#olm-pod-placement_olm-adding-operators-to-a-cluster[Pod placement of Operator workloads]
 endif::openshift-rosa,openshift-dedicated[]
-
-include::modules/nodes-scheduler-taints-tolerations-special.adoc[leveloffset=+2]
-
-include::modules/nodes-scheduler-taints-tolerations-removing.adoc[leveloffset=+1]
+* link:https://kubernetes.io/docs/concepts/architecture/nodes/#rate-limits-on-eviction[Rate limits on eviction (Kubernetes documentation)]
 
 //Removed per upstream docs modules/nodes-scheduler-taints-tolerations-evictions.adoc[leveloffset=+1]


### PR DESCRIPTION
https://redhat.atlassian.net/browse/OSDOCS-16935

Nodes -> Controlling pod placement onto nodes (scheduling) -> [Placing pods onto overcommited nodes](https://112367--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/scheduling/nodes-scheduler-overcommit.html)
Nodes -> Controlling pod placement onto nodes (scheduling) -> [Controlling pod placement using node taints](https://112367--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/scheduling/nodes-scheduler-taints-tolerations)
Postinstallation configuration ->  Node tasks -> [Taints and tolerations](https://112367--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/node-tasks.html#post-install-taints-tolerations) -- Same files as in Nodes book.

'openshift-docs/nodes/scheduling/nodes-scheduler-taints-tolerations.adoc'
'openshift-docs/nodes/scheduling/nodes-scheduler-overcommit.adoc'