### PR TITLE
OCPBUGS-86644: Fix incorrect object names in registry mirror project secret procedure

### DIFF
--- a/modules/images-configuration-registry-mirror-project-secret.adoc
+++ b/modules/images-configuration-registry-mirror-project-secret.adoc
@@ -124,7 +124,7 @@ Replace `<pull_secret_name>` with a name for your secret and `<path/to/.config/c
 
 .. Create a YAML file similar to the following example:
 +
-.Example `CRIOCredentialProviderConfig` object
+.Example `Role` and `RoleBinding` objects
 [source,terminal]
 ----
 apiVersion: rbac.authorization.k8s.io/v1
@@ -154,7 +154,7 @@ subjects:
 +
 Replace `<namespace_name>` with a name for your namespace and `<role_name>` with a name for the role.
 
-.. Create the `CRIOCredentialProviderConfig` object:
+.. Create the `Role` and `RoleBinding` objects:
 +
 [source,terminal]
 ----


### PR DESCRIPTION
## Summary

- Fix step 3.a: Change `.Example CRIOCredentialProviderConfig object` to `.Example Role and RoleBinding objects` since the YAML defines RBAC resources, not a CRIOCredentialProviderConfig
- Fix step 3.b: Change `Create the CRIOCredentialProviderConfig object` to `Create the Role and RoleBinding objects` since the `oc create` command creates the RBAC objects from the previous step

## Test plan

- [x] Verified the YAML in the example contains `kind: Role` and `kind: RoleBinding`, confirming the labels should reference RBAC objects
- [x] Verified step 3.c (`Edit the CRIOCredentialProviderConfig object`) is correct and unchanged, as it edits the actual CRIOCredentialProviderConfig

Bug: https://issues.redhat.com/browse/OCPBUGS-86644