### PR TITLE
OCPBUGS-62277 Adding RN for PerformanceProfile degraded after master nodes reboot in MNO

### DIFF
--- a/modules/rn-ocp-release-notes-fixed-issues.adoc
+++ b/modules/rn-ocp-release-notes-fixed-issues.adoc
@@ -119,6 +119,7 @@ Instructions: Add entries in the following format under the appropriate heading:
 [id="rn-ocp-release-note-node-tuning-operator-fixed-issues_{context}"]
 == Node Tuning Operator
 
+* Before this update, a failure to update the `PerformanceProfile` status due to a temporarily unavailable API server during an upgrade or under network load could leave the profile in a `Degraded` condition. As a consequence, the degraded condition might get stuck and never resolve, even after the cluster returned to a healthy state, because the operator did not retry until the next reconcile event. With this update, the operator schedules a retry of the status update until it succeeds, retrying approximately every 30 seconds. As a result, the stuck degraded condition is temporary and resolves automatically during the next retry. (link:https://issues.redhat.com/browse/OCPBUGS-62277[OCPBUGS-62277])
 
 // [id="rn-ocp-release-note-observability-fixed-issues_{context}"]
 // == Observability


### PR DESCRIPTION
[OCPBUGS-62277]: Adding RN for PerformanceProfile degraded after master nodes reboot in MNO

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.22 RN bug fix
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:https://redhat.atlassian.net/browse/OCPBUGS-62277
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
