### PR TITLE
add the overprovisionRatio parameter in LVMCluster examples to avoid …

### DIFF
--- a/modules/lvm-cluster-custom-resource-examples.adoc
+++ b/modules/lvm-cluster-custom-resource-examples.adoc
@@ -28,6 +28,7 @@ spec:
       thinPoolConfig:
         name: thin-pool-1
         sizePercent: 90
+        overprovisionRatio: 10
 ----
 +
 The discovery policy is not relevant here. Explicit paths always define the device set.
@@ -48,6 +49,7 @@ spec:
       thinPoolConfig:
         name: thin-pool-1
         sizePercent: 90
+        overprovisionRatio: 10
 ----
 +
 The Operator discovers and adds all available devices to the volume group during the initial reconciliation. After the Operator creates the volume group, it adds no new devices.
@@ -68,6 +70,7 @@ spec:
       thinPoolConfig:
         name: thin-pool-1
         sizePercent: 90
+        overprovisionRatio: 10
 ----
 +
 The Operator continuously discovers and adds devices to the volume group every 30 seconds. This setting is useful for development and testing. However, it might introduce operational risks in production environments.


### PR DESCRIPTION
…invalid LVMCluster CR during creation

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.22

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

https://redhat.atlassian.net/browse/OSDOCS-19914

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

If example contents are taken as they are in the documentation, the LVMCluster CR fails to be created with the following:

```
> oc create -f lvms/LVMCluster.static.yaml
The LVMCluster "my-lvmcluster" is invalid:
* spec.storage.deviceClasses[0].thinPoolConfig.overprovisionRatio: Required value
* <nil>: Invalid value: null: some validation rules were not checked because the object was invalid; correct the existing errors to complete validation

```

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
