### PR TITLE
MIG-1912: Add MTC 1.8.15 RNs

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -90,7 +90,7 @@ endif::[]
 :mtc-short: MTC
 :mtc-full: Migration Toolkit for Containers
 :mtc-version: 1.8
-:mtc-version-z: 1.8.14
+:mtc-version-z: 1.8.15
 :mtc-legacy-image: 1.7
 :mtv-first: Migration Toolkit for Virtualization (MTV)
 :mtv-short: MTV

--- a/migration_toolkit_for_containers/release_notes/mtc-release-notes.adoc
+++ b/migration_toolkit_for_containers/release_notes/mtc-release-notes.adoc
@@ -15,6 +15,8 @@ The {mtc-short} enables you to migrate application workloads between {product-ti
 
 For information on the support policy for {mtc-short}, see link:https://access.redhat.com/support/policy/updates/openshift#app_migration[OpenShift Application and Cluster Migration Solutions], part of the _Red Hat {product-title} Life Cycle Policy_.
 
+include::modules/migration-mtc-release-notes-1-8-15.adoc[leveloffset=+1]
+
 include::modules/migration-mtc-release-notes-1-8-14.adoc[leveloffset=+1]
 
 include::modules/migration-mtc-release-notes-1-8-13.adoc[leveloffset=+1]

--- a/modules/migration-mtc-release-notes-1-8-15.adoc
+++ b/modules/migration-mtc-release-notes-1-8-15.adoc
@@ -1,0 +1,25 @@
+// Module included in the following assemblies:
+//
+// * migration_toolkit_for_containers/mtc-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="migration-mtc-release-notes-1-8-15_{context}"]
+= {mtc-full} 1.8.15 release notes
+
+[role="_abstract"]
+{mtc-first} 1.8.15 is a Container Grade Only (CGO) release, which is released to refresh the health grades of the containers. No code was changed in the product itself compared to that of {mtc-short} 1.8.14. {mtc-short} 1.8.15 fixes several Common Vulnerabilities and Exposures (CVEs).
+
+
+[id="resolved-issues-1-8-15_{context}"]
+== Resolved issues
+
+{mtc-first} 1.8.15 fixes the following CVEs::
++
+* link:https://access.redhat.com/security/cve/cve-2026-25639[CVE-2026-25639]
+* link:https://access.redhat.com/security/cve/cve-2026-40175[CVE-2026-40175]
+* link:https://access.redhat.com/security/cve/cve-2026-42033[CVE-2026-42033]
+* link:https://access.redhat.com/security/cve/cve-2026-42035[CVE-2026-42035]
+* link:https://access.redhat.com/security/cve/cve-2026-42039[CVE-2026-42039]
+* link:https://access.redhat.com/security/cve/cve-2026-42041[CVE-2026-42041]
+* link:https://access.redhat.com/security/cve/cve-2026-42043[CVE-2026-42043]
+* link:https://access.redhat.com/security/cve/cve-2026-42044[CVE-2026-42044]


### PR DESCRIPTION
Summary of changes: Update MTC attribute and add a new module for MTC 1.8.15 release.

Version(s):
OCP 4.14-4.20

Issue:
[MIG-1912](https://redhat.atlassian.net/browse/MIG-1912)

Link to docs preview:
[Migration Toolkit for Containers 1.8.15 release notes](https://112410--ocpdocs-pr.netlify.app/openshift-enterprise/latest/migration_toolkit_for_containers/release_notes/mtc-release-notes#migration-mtc-release-notes-1-8-15_mtc-release-notes)

QE review:
- [x] QE has approved this change.