### PR TITLE
OSDOCS-19915: adds RHCL 1.4.0 main release note

### DIFF
--- a/_attributes/attributes.adoc
+++ b/_attributes/attributes.adoc
@@ -11,6 +11,7 @@
 :prodnamefull: {rh} {prodname}
 :productpkg: red_hat_connectivity_link
 :mcpg: MCP gateway
+:mcpg-version: 0.7.0
 
 :version: 1.4
 :version-1: 1.3.x

--- a/modules/ref-relnotes-about.adoc
+++ b/modules/ref-relnotes-about.adoc
@@ -1,0 +1,12 @@
+// Module used in the following assemblies
+//
+// *release_notes/release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="rhcl-relnotes-about_{context}"]
+= About this release
+
+[role="_abstract"]
+{prodname} {version} (RHEA-2026:XXXXX) is now available. This release includes the {mcpg} {mcpg-version} as a Technology Preview feature. New features, changes, and known issues that pertain to {prodname} {version} are included in this topic.
+
+Starting from {prodname} {version}, full support begins at the GA/release of the minor version and ends with the release of the superseding minor release (typically 4 months after the GA date). See the link:https://access.redhat.com/RedHatConnectivityLink[Red Hat Connectivity Link Life Cycle Policy] for details about version support and {ocp} compatibility.

--- a/modules/ref-relnotes-intro.adoc
+++ b/modules/ref-relnotes-intro.adoc
@@ -3,12 +3,10 @@
 // *release_notes/release-notes.adoc
 
 :_mod-docs-content-type: REFERENCE
-[id="prodname-relnotes_{context}"]
+[id="rhcl-release-notes_{context}"]
 = {product-title} {version} release notes
 
 [role="_abstract"]
-{product-title} is a modular and flexible solution for application connectivity, policy management, and API management in multicloud and hybrid cloud environments. You can use {prodname} to secure, protect, connect, and observe your APIs, applications, and infrastructure.
+{prodname} is a modular and flexible solution for application connectivity, policy management, and API management in multicloud and hybrid cloud environments. You can use {prodname} to secure, protect, connect, and observe your APIs, applications, and infrastructure.
 
-{prodname} is based on the link:https://kuadrant.io/[Kuadrant] community project. {prodname} provides a control plane for configuring and deploying ingress gateways and policies based on the link:https://gateway-api.sigs.k8s.io/[Kubernetes Gateway API] standard. {prodname} supports link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_mesh/{service-mesh-version}/html-single/about/index[{service-mesh} {service-mesh-version}] as the Gateway API provider, which is based on the link:https://istio.io/[Istio] community project.
-
-See the link:https://access.redhat.com/RedHatConnectivityLink[Red Hat Connectivity Link Life Cycle Policy] for details about version support and {ocp} compatibility.
+{prodname} is based on the link:https://kuadrant.io/[Kuadrant] community project, providing a control plane for you to configure and deploy ingress gateways and policies based on the link:https://gateway-api.sigs.k8s.io/[Kubernetes Gateway API] standard. {prodname} supports link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_mesh/{service-mesh-version}/html-single/about/index[{service-mesh} {service-mesh-version}] as the Gateway API provider, which is based on the link:https://istio.io/[Istio] community project.

--- a/modules/ref-relnotes-new-features.adoc
+++ b/modules/ref-relnotes-new-features.adoc
@@ -33,4 +33,14 @@ MCP gateway audit trail documentation is now available::
 
 The {mcpg} documentation now includes configuration instructions for creating an audit trail for compliance and accountability that captures caller identity, tool names, and MCP session context through the MCP gateway.
 
-//For more information, see xref:../observe/mcp-gateway-observe.adoc#con-mcp-gateway-audit-trail_mcp-gateway-observe[Understanding an MCP gateway audit trail].
+For more information, see xref:../observe/mcp-gateway-observe.adoc#con-mcp-gateway-audit-trail_mcp-gateway-observe[Understanding an MCP gateway audit trail].
+
+Notable technical changes::
+
+*{prodname}*: The gateway integration has been migrated from an Istio `WasmPlugin` to `EnvoyFilter` custom resources (CRs). WASM injection now uses `EnvoyFilter` patches. This enables native support for image pull secrets and allows for embedded plugin configurations directly within the patches. This is an internal Operator change. No user action is required during an update. Existing CRs might remain in your cluster as orphans.
++
+*{prodname}*: To improve performance and scalability, the Kuadrant CR lookup is cached within the reconciliation state. This internal optimization reduces redundant `get` requests to the Kubernetes API server during reconciliation loops. This change reduces control plane utilization and consumption, reduces Operator resource usage, and makes policy reconciliation times faster.
++
+*MCP gateway*: The `toolPrefix` field on the `MCPServerRegistration` CR is renamed `prefix`. This field has always been a server-level namespace, not tool-specific, and the rename aligns the API with its actual semantics now that it applies to both tools and prompts.
++
+Migration: You must replace `toolPrefix` with `prefix` in your `MCPServerRegistration` CRs. Existing CRs must be deleted and recreated, not patched in-place. For bulk updates, you can use a `sed` one-liner or `yq edit` on these manifest files before you run the `oc apply` command.

--- a/modules/ref-relnotes-tech-preview.adoc
+++ b/modules/ref-relnotes-tech-preview.adoc
@@ -20,4 +20,4 @@ Support for `GRPCRoute` policy attachment::
 
 Beginning with {prodname} 1.4.0, `GRPCRoute` policy attachment support is available as a Technology Preview feature. You can attach `AuthPolicy` and `RateLimitPolicy` custom resources (CRs) to `GRPCRoute` CRs, enabling authentication and rate-limiting controls for gRPC services with native `service` and `method` matching.
 
-//For more information, see xref:../deployment/deployment.adoc#con-about-grpc-support_rhcl-config-deploy-gateway-policies[About GRPCRoute policy attachment support]
+For more information, see xref:../deployment/deployment.adoc#con-about-grpc-support_rhcl-config-deploy-gateway-policies[About GRPCRoute policy attachment support].

--- a/modules/rhcl-relnotes-z-stream.adoc
+++ b/modules/rhcl-relnotes-z-stream.adoc
@@ -1,0 +1,14 @@
+// Module used in the following assemblies
+//
+// *release_notes/release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="rhcl-relnotes-z-stream_{context}"]
+= Asynchronous releases
+
+[role="_abstract"]
+Security, bug fix, and enhancement updates for {product-title} {version} are released asynchronously through the Red{nbsp}Hat Network. All {product-title} {version} updates are available on the Red{nbsp}Hat Customer Portal. For more information about asynchronous updates, read the link:https://access.redhat.com/RedHatConnectivityLink[Red Hat Connectivity Link Life Cycle Policy].
+
+Red{nbsp}Hat Customer Portal users can enable update notifications in the account settings for Red{nbsp}Hat Subscription Management (RHSM). When notifications are enabled, you are notified through email whenever new updates relevant to your registered systems are released.
+
+This section is updated over time to provide notes on enhancements and bug fixes for future asynchronous releases of {product-title} {version}. Versioned asynchronous releases, for example with the {product-title} 1.4.z, are detailed in the following subsections.

--- a/release_notes/rhcl-release-notes.adoc
+++ b/release_notes/rhcl-release-notes.adoc
@@ -1,15 +1,15 @@
 :_mod-docs-content-type: ASSEMBLY
 include::_attributes/attributes.adoc[]
 [id="rhcl-release-notes"]
-= {prodname} {version} release notes
+= {product-title} {version} release notes
 :context: rhcl-release-notes
-
-//toc:[]
 
 [role="_abstract"]
 Welcome to the {product-title} release notes, where you can learn about what is new and what is fixed.
 
 include::modules/ref-relnotes-intro.adoc[leveloffset=+1]
+
+include::modules/ref-relnotes-about.adoc[leveloffset=+1]
 
 include::modules/ref-relnotes-new-features.adoc[leveloffset=+2]
 
@@ -18,3 +18,5 @@ include::modules/ref-relnotes-tech-preview.adoc[leveloffset=+2]
 //include::modules/ref-relnotes-bug-fixes.adoc[leveloffset=+2]
 
 include::modules/ref-relnotes-known-issues.adoc[leveloffset=+2]
+
+//include::modules/rhcl-relnotes-z-stream.adoc[leveloffset=+2]


### PR DESCRIPTION
Version(s):
rhcl-docs-1.4
(and main)

Issue:
[OSDOCS-19915](https://redhat.atlassian.net/browse/OSDOCS-19915)

Link to docs preview:
https://112414--ocpdocs-pr.netlify.app/rhcl/latest/release_notes/rhcl-release-notes.html

SME review:
- [x] SME approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
QE approved the individual notes already; this is boilerplate approval (does not require QE as it is not technical information).

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
