### PR TITLE
[OSDOCS#18175]: Updated 4.22 image advisory

### DIFF
--- a/modules/rn-ocp-about-this-release.adoc
+++ b/modules/rn-ocp-about-this-release.adoc
@@ -4,7 +4,7 @@
 
 [role=”_abstract”]
 // TODO: Update with the relevant information closer to release.
-{product-title} (link:https://access.redhat.com/errata/RHBA-2026:1481[RHBA-2026:1481]) is now available. This release uses link:https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.35.md[Kubernetes 1.35] with CRI-O runtime. New features, changes, and known issues that pertain to {product-title} {product-version} are included in this topic.
+{product-title} (link:https://access.redhat.com/errata/RHBA-2026:449[RHBA-2026:449]) is now available. This release uses link:https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.35.md[Kubernetes 1.35] with CRI-O runtime. New features, changes, and known issues that pertain to {product-title} {product-version} are included in this topic.
 
 {product-title} {product-version} clusters are available at https://console.redhat.com/openshift. From the {hybrid-console}, you can deploy {product-title} clusters to either on-premises or cloud environments.
 


### PR DESCRIPTION

Version(s):
4.22

Issue:
https://redhat.atlassian.net/browse/OSDOCS-18175

Link to docs preview:
https://112425--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-22-release-notes.html#rn-ocp-about-this-release_release-notes

QE review:
N/A
