### PR TITLE
Revert "OSDOCS-18432#Adding BM nodes to vSphere clusters TP -> GA"

### DIFF
--- a/modules/persistent-storage-csi-vsphere-adding-bm-nodes.adoc
+++ b/modules/persistent-storage-csi-vsphere-adding-bm-nodes.adoc
@@ -8,6 +8,8 @@
 = Adding bare-metal nodes
 
 [role="_abstract"]
-Adding bare-metal nodes to an {product-title} cluster on vSphere is supported. However, if you add bare-metal nodes, you must remove the vSphere CSI Driver, otherwise the cluster is marked as degraded. For information about how to remove the driver and the consequences of doing this, see Section _Disabling and enabling storage on vSphere_. 
+Adding bare-metal nodes to an {product-title} cluster on vSphere is supported as a Technology Preview feature. 
+
+However, if you add bare-metal nodes, you must remove the vSphere CSI Driver, otherwise the cluster is marked as degraded. For information about how to remove the driver and the consequences of doing this, see Section _Disabling and enabling storage on vSphere_. 
 
 For information about how to add bare-metal nodes, under _Additional resources_, see Section _Adding bare-metal compute machines to a vSphere cluster_.

--- a/storage/container_storage_interface/persistent-storage-csi-vsphere.adoc
+++ b/storage/container_storage_interface/persistent-storage-csi-vsphere.adoc
@@ -129,6 +129,9 @@ include::modules/persistent-storage-csi-vsphere-disable-storage-procedure.adoc[l
 
 include::modules/persistent-storage-csi-vsphere-adding-bm-nodes.adoc[leveloffset=+1]
 
+:FeatureName: Adding bare-metal nodes
+include::snippets/technology-preview.adoc[leveloffset=+2]
+
 [role="_additional-resources"]
 .Additional resources
 * xref:../../machine_management/user_infra/adding-bare-metal-compute-vsphere-user-infra.adoc[Adding bare-metal compute machines to a vSphere cluster]


### PR DESCRIPTION
Reverts openshift/openshift-docs#107216

From @sslocket and confirmed by @gcharot BM for vSphere TP -> GA is not going in 4.22 (moved to z-stream) and needs to be reverted.

PTAL: @gcharot 