### PR TITLE
OSDOCS#19913: Update the MicroShift RNs for 4.16.63

### DIFF
--- a/microshift_release_notes/microshift-4-16-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-16-release-notes.adoc
@@ -84,3 +84,5 @@ include::modules/microshift-4-16-40-dp.adoc[leveloffset=+2]
 include::modules/microshift-4-16-47-dp.adoc[leveloffset=+2]
 
 include::modules/microshift-4-16-58-dp.adoc[leveloffset=+2]
+
+include::modules/microshift-4-16-63-dp.adoc[leveloffset=+2]

--- a/modules/microshift-4-16-63-dp.adoc
+++ b/modules/microshift-4-16-63-dp.adoc
@@ -1,0 +1,19 @@
+// Module included in the following assemblies:
+//
+//microshift_release_notes/microshift-4-16-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="microshift-4-16-63-dp_{context}"]
+= RHSA-2026:20436 - {microshift-short} 4.16.63 bug fix advisory
+
+Issued: 29 May 2026
+
+[role="_abstract"]
+{product-title} release 4.16.63 is now available. The list of fixed issues that are included in the update is attached to the link:https://access.redhat.com/errata/RHSA-2026:20436[RHSA-2026:20436] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2026:20088[RHSA-2026:20088] advisory.
+
+See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].
+
+[id="microshift-4-16-63-bug-fixes_{context}"]
+== Fixed issues
+
+There are no notable fixed issues in this release.


### PR DESCRIPTION
Version(s):
4.16

Issue:
[OSDOCS-19913](https://redhat.atlassian.net/browse/OSDOCS-19913)

Link to docs preview:
[4.16.63](https://112435--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-16-release-notes.html#microshift-4-16-63-dp_release-notes)

QE review:
- [ ] QE has approved this change.
N/A for RNs.

Additional information:
Shipment [MR](https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/547)
ART [Dashboard](https://art-dash.engineering.redhat.com/dashboard/release/openshift-4.16?page=1)
