### PR TITLE
OSDOCS-18179-apiserver-auth-tavery:Bug Batching

### DIFF
--- a/modules/rn-ocp-release-notes-fixed-issues.adoc
+++ b/modules/rn-ocp-release-notes-fixed-issues.adoc
@@ -35,8 +35,10 @@ Instructions: Add entries in the following format under the appropriate heading:
 //Telco Edge / ZTP
 
 
-//[id="rn-ocp-release-note-api-auth-bug-fixes_{context}"]
-//== API Server and Authentication
+[id="rn-ocp-release-note-api-auth-bug-fixes_{context}"]
+== API Server and Authentication
+
+* Before this update, the `oc explain authentication` command displayed incorrect descriptions for the OpenID Connect (OIDC) provider fields. With this release, all field descriptions are corrected. As a result, the multiline comments are combined into a single line for improved YAML generation which provides better `oc explain` output. (link:https://redhat.atlassian.net/browse/OCPBUGS-56851[OCPBUGS-56851])
 
 // [id="rn-ocp-release-note-bare-metal-hardware-fixed-issues_{context}"]
 // == Bare Metal Hardware Provisioning


### PR DESCRIPTION
Version(s):
4.22

Issue:
https://redhat.atlassian.net/browse/OSDOCS-18179

Link to docs preview:
https://112436--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-22-release-notes.html#rn-ocp-release-note-api-auth-bug-fixes_release-notes
