### PR TITLE
OSDOCS-19152 [NETOBSERV] 1.12 API updates

### DIFF
--- a/modules/network-observability-flowcollector-api-specifications.adoc
+++ b/modules/network-observability-flowcollector-api-specifications.adoc
@@ -104,6 +104,10 @@ Kafka can provide better scalability, resiliency, and high availability (for mor
 
 `Direct` is not recommended on large clusters as it is less memory efficient.
 
+| `execution`
+| `object`
+| `execution` defines configuration related to the execution of the flow collection process.
+
 | `exporters`
 | `array`
 | `exporters` defines additional optional exporters for custom consumption or storage.
@@ -231,6 +235,8 @@ This feature requires mounting the kernel debug filesystem, so the eBPF agent po
 It requires using the OVN-Kubernetes network plugin with the Observability feature.  +
 
 - `IPSec`, to track flows between nodes with IPsec encryption.  +
+
+- `TLSTracking`, to track TLS usage.  +
 
 
 | `flowFilter`
@@ -1082,6 +1088,31 @@ otherwise to an implementation-defined value. Requests cannot exceed Limits.
 More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
 
 |===
+== .spec.execution
+Description::
++
+--
+`execution` defines configuration related to the execution of the flow collection process.
+--
+
+Type::
+  `object`
+
+
+
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `mode`
+| `string`
+| `mode` is the flow collection process execution desired mode: `Running` or `OnHold`.
+When `OnHold`, the operator deletes all managed services and workloads, with the exception
+of the static console plugin, and the operator itself.
+It allows to use minimal cluster resources without losing configuration.
+
+|===
 == .spec.exporters
 Description::
 +
@@ -1195,13 +1226,19 @@ Required::
 | `string`
 | Address of the Kafka server
 
+| `compression`
+| `string`
+| Compression codec to use when producing messages to Kafka.
+Accepted values are: `none` (default), `gzip`, `snappy`, `lz4`, `zstd`.
+
 | `sasl`
 | `object`
 | SASL authentication configuration. [Unsupported (*)].
 
 | `tls`
 | `object`
-| TLS client configuration. When using TLS, verify that the address matches the Kafka port used for TLS, generally 9093.
+| TLS and mTLS client configuration. When using TLS, verify that the address matches the Kafka port used for TLS, generally 9093.
+We recommend the use of mTLS for higher security standards.
 
 | `topic`
 | `string`
@@ -1312,7 +1349,8 @@ If the namespace is different, the config map or the secret is copied so that it
 Description::
 +
 --
-TLS client configuration. When using TLS, verify that the address matches the Kafka port used for TLS, generally 9093.
+TLS and mTLS client configuration. When using TLS, verify that the address matches the Kafka port used for TLS, generally 9093.
+We recommend the use of mTLS for higher security standards.
 --
 
 Type::
@@ -1706,13 +1744,19 @@ Required::
 | `string`
 | Address of the Kafka server
 
+| `compression`
+| `string`
+| Compression codec to use when producing messages to Kafka.
+Accepted values are: `none` (default), `gzip`, `snappy`, `lz4`, `zstd`.
+
 | `sasl`
 | `object`
 | SASL authentication configuration. [Unsupported (*)].
 
 | `tls`
 | `object`
-| TLS client configuration. When using TLS, verify that the address matches the Kafka port used for TLS, generally 9093.
+| TLS and mTLS client configuration. When using TLS, verify that the address matches the Kafka port used for TLS, generally 9093.
+We recommend the use of mTLS for higher security standards.
 
 | `topic`
 | `string`
@@ -1823,7 +1867,8 @@ If the namespace is different, the config map or the secret is copied so that it
 Description::
 +
 --
-TLS client configuration. When using TLS, verify that the address matches the Kafka port used for TLS, generally 9093.
+TLS and mTLS client configuration. When using TLS, verify that the address matches the Kafka port used for TLS, generally 9093.
+We recommend the use of mTLS for higher security standards.
 --
 
 Type::
@@ -2705,8 +2750,10 @@ configuration, you can disable it and install your own instead.
 | `boolean`
 | Deploys network policies on the namespaces used by Network Observability (main and privileged).
 These network policies better isolate the Network Observability components to prevent undesired connections from and to them.
-This option is enabled by default when using with OVNKubernetes, and disabled otherwise (it has not been tested with other CNIs).
-When disabled, you can manually create the network policies for the Network Observability components.
+Because it cannot be tested with all CNIs, this option is only enabled by default when Network Observability runs in a known
+supported environment, and it is disabled by default otherwise.
+When disabled, it is highly recommended to create network policies manually, to prevent undesired accesses.
+More information: https://github.com/netobserv/netobserv-operator/blob/main/docs/NetworkPolicy.md.
 
 |===
 == .spec.processor
@@ -2811,6 +2858,10 @@ Deprecation notice: use `spec.processor.consumerReplicas` instead.
 | `resources` are the compute resources required by this container.
 For more information, see https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
 
+| `service`
+| `object`
+| Service configuration, only used when `spec.deploymentModel` is `Service`.
+
 | `slicesConfig`
 | `object`
 | Global configuration managing FlowCollectorSlices custom resources.
@@ -2895,6 +2946,7 @@ By convention, some values are forbidden. It must be greater than 1024 and diffe
 | Defines secondary networks to be checked for resources identification.
 To guarantee a correct identification, indexed values must form an unique identifier across the cluster.
 If the same index is used by several resources, those resources might be incorrectly labeled.
+If not provided and `spec.agent.ebpf.privileged` is `true`, secondary networks are detected automatically.
 
 |===
 == .spec.processor.advanced.scheduling
@@ -2988,7 +3040,6 @@ Type::
 
 Required::
   - `index`
-  - `name`
 
 
 
@@ -3004,7 +3055,7 @@ Fields absent from the 'k8s.v1.cni.cncf.io/network-status' annotation must not b
 
 | `name`
 | `string`
-| `name` should match the network name as visible in the pods annotation 'k8s.v1.cni.cncf.io/network-status'.
+| Deprecated: `name` is unused.
 
 |===
 == .spec.processor.deduper
@@ -3116,6 +3167,16 @@ Type::
 [cols="1,1,1",options="header"]
 |===
 | Property | Type | Description
+
+| `additionalIncludeList`
+| `array (string)`
+| `additionalIncludeList` is a list of metric names to include in addition to the default metrics.
+Unlike `includeList`, this appends to the default list rather than replacing it.
+This field is mutually exclusive with `includeList`. If `includeList` is set, `additionalIncludeList` is ignored.
+The names correspond to the names in Prometheus without the prefix. For example,
+`namespace_egress_packets_total` shows up as `netobserv_namespace_egress_packets_total` in Prometheus.
+Note that the more metrics you add, the bigger is the impact on Prometheus workload resources.
+More information, with full list of available metrics: https://github.com/netobserv/network-observability-operator/blob/main/docs/Metrics.md
 
 | `disableAlerts`
 | `array (string)`
@@ -3471,6 +3532,187 @@ otherwise to an implementation-defined value. Requests cannot exceed Limits.
 More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
 
 |===
+== .spec.processor.service
+Description::
++
+--
+Service configuration, only used when `spec.deploymentModel` is `Service`.
+--
+
+Type::
+  `object`
+
+Required::
+  - `tlsType`
+
+
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `providedCertificates`
+| `object`
+| TLS or mTLS configuration when `type` is set to `Provided`.
+
+| `tlsType`
+| `string`
+| Select the type of TLS configuration: +
+
+- `Disabled` to not configure TLS for the endpoint. Disabling TLS results in a less secure deployment model. +
+
+- `Provided` to manually provide the key and certificate references. +
+
+- `Auto` (default) to enable automatically based on the running environment. +
+
+- `Auto-mTLS` to preconfigure mTLS. [Unsupported (*)]. +
+
+See also: https://github.com/netobserv/netobserv-operator/blob/main/docs/TLS.md.
+
+|===
+== .spec.processor.service.providedCertificates
+Description::
++
+--
+TLS or mTLS configuration when `type` is set to `Provided`.
+--
+
+Type::
+  `object`
+
+
+
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `caFile`
+| `object`
+| Reference to the CA file.
+
+| `clientCert`
+| `object`
+| TLS client certificate reference, used for mTLS. Leave unset for simple TLS.
+
+| `serverCert`
+| `object`
+| TLS server certificate reference.
+
+|===
+== .spec.processor.service.providedCertificates.caFile
+Description::
++
+--
+Reference to the CA file.
+--
+
+Type::
+  `object`
+
+
+
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `file`
+| `string`
+| File name within the config map or secret.
+
+| `name`
+| `string`
+| Name of the config map or secret containing the file.
+
+| `namespace`
+| `string`
+| Namespace of the config map or secret containing the file. If omitted, the default is to use the same namespace as where Network Observability is deployed.
+If the namespace is different, the config map or the secret is copied so that it can be mounted as required.
+
+| `type`
+| `string`
+| Type for the file reference: `configmap` or `secret`.
+
+|===
+== .spec.processor.service.providedCertificates.clientCert
+Description::
++
+--
+TLS client certificate reference, used for mTLS. Leave unset for simple TLS.
+--
+
+Type::
+  `object`
+
+
+
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `certFile`
+| `string`
+| `certFile` defines the path to the certificate file name within the config map or secret.
+
+| `certKey`
+| `string`
+| `certKey` defines the path to the certificate private key file name within the config map or secret. Omit when the key is not necessary.
+
+| `name`
+| `string`
+| Name of the config map or secret containing certificates.
+
+| `namespace`
+| `string`
+| Namespace of the config map or secret containing certificates. If omitted, the default is to use the same namespace as where Network Observability is deployed.
+If the namespace is different, the config map or the secret is copied so that it can be mounted as required.
+
+| `type`
+| `string`
+| Type for the certificate reference: `configmap` or `secret`.
+
+|===
+== .spec.processor.service.providedCertificates.serverCert
+Description::
++
+--
+TLS server certificate reference.
+--
+
+Type::
+  `object`
+
+
+
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `certFile`
+| `string`
+| `certFile` defines the path to the certificate file name within the config map or secret.
+
+| `certKey`
+| `string`
+| `certKey` defines the path to the certificate private key file name within the config map or secret. Omit when the key is not necessary.
+
+| `name`
+| `string`
+| Name of the config map or secret containing certificates.
+
+| `namespace`
+| `string`
+| Namespace of the config map or secret containing certificates. If omitted, the default is to use the same namespace as where Network Observability is deployed.
+If the namespace is different, the config map or the secret is copied so that it can be mounted as required.
+
+| `type`
+| `string`
+| Type for the certificate reference: `configmap` or `secret`.
+
+|===
 == .spec.processor.slicesConfig
 Description::
 +
@@ -3639,7 +3881,7 @@ Required::
 | `enable`
 | `boolean`
 | When `enable` is `true`, the Console plugin queries flow metrics from Prometheus instead of Loki whenever possible.
-It is enbaled by default: set it to `false` to disable this feature.
+It is enabled by default: set it to `false` to disable this feature.
 The Console plugin can use either Loki or Prometheus as a data source for metrics (see also `spec.loki`), or both.
 Not all queries are transposable from Loki to Prometheus. Hence, if Loki is disabled, some features of the plugin are disabled as well,
 such as getting per-pod information or viewing raw flows.

--- a/modules/network-observability-flows-format.adoc
+++ b/modules/network-observability-flows-format.adoc
@@ -63,7 +63,7 @@ The "Cardinality" column gives information about the implied metric cardinality 
 | `dns_name`
 | no
 | careful
-| n/a
+| dns.name
 | `Dscp`
 | number
 | Differentiated Services Code Point (DSCP) value
@@ -112,7 +112,7 @@ The "Cardinality" column gives information about the implied metric cardinality 
 | `dst_network`
 | no
 | fine
-| n/a
+| destination.network.name
 | `DstK8S_OwnerName`
 | string
 | Name of the destination owner, such as Deployment name, StatefulSet name, etc.
@@ -188,7 +188,7 @@ The "Cardinality" column gives information about the implied metric cardinality 
 | `ipsec_status`
 | no
 | fine
-| n/a
+| ipsec.status
 | `IcmpCode`
 | number
 | ICMP code
@@ -343,7 +343,7 @@ The "Cardinality" column gives information about the implied metric cardinality 
 | `src_network`
 | no
 | fine
-| n/a
+| source.network.name
 | `SrcK8S_OwnerName`
 | string
 | Name of the source owner, such as Deployment name, StatefulSet name, etc.
@@ -393,6 +393,34 @@ The "Cardinality" column gives information about the implied metric cardinality 
 | no
 | fine
 | source.subnet.label
+| `TLSCipherSuite`
+| string
+| TLS cipher suite
+| `tls_cipher_suite`
+| no
+| fine
+| tls.ciphersuite
+| `TLSGroup`
+| string
+| TLS group name
+| `tls_group`
+| no
+| fine
+| tls.group
+| `TLSTypes`
+| string[]
+| TLS message types (bitfield)
+| `tls_types`
+| no
+| careful
+| tls.types
+| `TLSVersion`
+| string
+| TLS version
+| `tls_version`
+| no
+| fine
+| tls.version
 | `TimeFlowEndMs`
 | number
 | End timestamp of this flow, in milliseconds


### PR DESCRIPTION
[OSDOCS-19152](https://redhat.atlassian.net/browse/OSDOCS-19152) [NETOBSERV] 1.12 API updates

Automatically generated API docs.

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
Merge into `no-1.12` only. No cherry picks.

Issue:
https://redhat.atlassian.net/browse/OSDOCS-19152

Link to docs preview:
* FlowCollector API reference: https://112437--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/flowcollector-api.html
* Network flows format reference: https://112437--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/json-flows-format-reference.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
* I will open one PR against main to incorporate all of the no-1.12 content just before its GA.
* Automatically generated API docs. Per https://redhat.atlassian.net/wiki/spaces/OSDOCS/pages/265912624/Content+updates+in+preparation+for+migrating+to+DITA , "Still Pending Discussion".

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
