### PR TITLE
OSDOCS-18157: Update OCP n+1 and n-1 attributes

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -11,8 +11,8 @@
 :imagesdir: images
 :prewrap!:
 // n-1 and n+1 OCP versions relative to the current branch's {product-version} attr
-:ocp-nminus1: 4.20
-:ocp-nplus1: 4.22
+:ocp-nminus1: 4.21
+:ocp-nplus1: 4.23
 // Operating system attributes
 :op-system-first: Red{nbsp}Hat Enterprise Linux CoreOS (RHCOS)
 :op-system: RHCOS


### PR DESCRIPTION
:point_right: Merge reviewer: Please merge this upon approval

Version(s): 
4.22

Issue:
[OSDOCS-18157](https://redhat.atlassian.net/browse/OSDOCS-18157)

Link to docs preview:
`ocp-nplus1`
- https://112439--ocpdocs-pr.netlify.app/openshift-enterprise/latest/extensions/ce/update-paths#olmv1-ocp-compat_update-paths

`ocp-nminus1`
- https://112439--ocpdocs-pr.netlify.app/openshift-enterprise/latest/authentication/managing_cloud_provider_credentials/cco-mode-mint#mint-mode
- https://112439--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/changing-cloud-credentials-configuration#manually-removing-cloud-creds_changing-cloud-credentials-configuration
- https://112439--ocpdocs-pr.netlify.app/openshift-enterprise/latest/operators/understanding/olm/olm-understanding-olm#olm-catalogsource-image-template_olm-understanding-olm

QE review:
- N/A ~[ ] QE has approved this change.~

Additional information:
Copied from #105513

:point_right: Merge reviewer: Please merge this upon approval