### PR TITLE
OSDOCS#19442: Add the RNs for MicroShift TLS configuration 

### DIFF
--- a/modules/microshift-4-22-new-features-enhancements.adoc
+++ b/modules/microshift-4-22-new-features-enhancements.adoc
@@ -15,6 +15,15 @@ This release adds improvements related to the following components and concepts.
 With this release, {microshift-short} is supported on {op-system-base-full} {op-system-version}.
 
 //TODO add new features and enhancements as neededGeneric Device Plugin feature
+
+[id="microshift-4-22-ingress-tls-doc_{context}"]
+== Ingress TLS configuration documentation
+
+With this release, {microshift-short} documentation adds procedures and prerequisites for the default ingress router certificate (`ingress.certificateSecret`) and for TLS on Kubernetes `Ingress` objects.
+
+* xref:../microshift_configuring/microshift-ingress-controller.adoc#microshift-ingress-controller[Using ingress control for a {microshift-short} node]
+
+//TODO add new features and enhancements as needed
 //[id="microshift-4-22-placeholder-feature2_{context}"]
 //== placeholder feature 2
 


### PR DESCRIPTION
Version(s):
4.22

Issue:
[OSDOCS-19442](https://redhat.atlassian.net/browse/OSDOCS-19442)

Link to docs preview:
[Ingress TLS configuration documentation](https://112444--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-22-release-notes.html#microshift-4-22-ingress-tls-doc_release-notes)

QE review:
- [ x] QE has approved this change.

Additional information:
Feature [PR](https://github.com/openshift/openshift-docs/pull/111698)
