### PR TITLE
OCPBUGS inconsistent cgroup v2 description

### DIFF
--- a/modules/nodes-clusters-cgroups-2.adoc
+++ b/modules/nodes-clusters-cgroups-2.adoc
@@ -35,6 +35,10 @@ ifdef::nodes[]
 You can enable link:https://www.kernel.org/doc/html/latest/admin-guide/cgroup-v1/index.html[Linux control group version 1] (cgroup v1) or link:https://www.kernel.org/doc/html/latest/admin-guide/cgroup-v2.html[Linux control group version 2] (cgroup v2)  by editing the `node.config` object. The default is cgroup v2.
 endif::nodes[]
 
+ifdef::post[]
+The following procedure configures cgroupv1 on all the nodes in a cluster.
+endif::post[]
+
 :FeatureName: cgroup v1
 include::snippets/deprecated-feature.adoc[]
 
@@ -226,7 +230,7 @@ sh-4.4# chroot /host
 ----
 
 ifdef::post[]
-. Check that the `sys/fs/cgroup/cgroup2fs` file is present on your nodes. This file is created by cgroup v1:
+. Check the cgroup file system on your nodes. This file is created by cgroup v1:
 +
 [source,terminal]
 ----
@@ -236,11 +240,11 @@ $ stat -c %T -f /sys/fs/cgroup
 .Example output
 [source,terminal]
 ----
-cgroup2fs
+tmpfs
 ----
 endif::post[]
 ifdef::nodes[]
-. Check that the `sys/fs/cgroup/cgroup2fs` or `sys/fs/cgroup/tmpfs` file is present on your nodes:
+. Check the cgroup file system on your nodes:
 +
 [source,terminal]
 ----


### PR DESCRIPTION
https://redhat.atlassian.net/browse/OCPBUGS-86632

Version(s):
The file involved appears in this format in 4.14 to 4.18 only. It was [removed in 4.19](https://github.com/openshift/openshift-docs/pull/96853) and is a completely different use case in [4.13 and earlier](https://github.com/openshift/openshift-docs/blob/enterprise-4.13/modules/nodes-clusters-cgroups-2.adoc).

Link to docs preview:
Nodes -> Working with clusters -> [Configuring the Linux cgroup](https://112447--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/clusters/nodes-cluster-cgroups-2.html#nodes-clusters-cgroups-2_nodes-cluster-cgroups-2) -- Verification Step 6. Fixed the output for the cgroupv1 example. Added a specific command to examine the cgroup or cgroup2fs file for clarity. Fixed the file name for cgroupv1.
Postinstallation configuration -> Cluster tasks -> [Configuring Linux cgroup](https://112447--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/cluster-tasks#nodes-clusters-cgroups-2_post-install-cluster-tasks) - Added a sentence before Important note clarifying that the procedure is to set cgroupv1. Fixed Verification Step 6.

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
