### PR TITLE
OSDOCS-19420: Updating ROSA and OSD release notes

### DIFF
--- a/modules/osd-release-notes-Q1-2026.adoc
+++ b/modules/osd-release-notes-Q1-2026.adoc
@@ -10,14 +10,16 @@ The following items were added during the first quarter of 2026.
 
 Virtualization support for {product-title} on {GCP}::
 +
-{product-title} on {GCP} version 4.21.5 now supports running virtualized workloads using the {VirtProductName} Operator version 4.21.1, leveraging {GCP} C3 bare-metal instances and {GCP} Hyperdisk. This enables you to migrate and modernize virtual machines (VMs) from existing platforms directly onto {product-title}, managing them alongside containerized workloads on a single, unified application platform.
+{product-title} on {GCP} version 4.21.5 supports running virtualized workloads using the {VirtProductName} Operator version 4.21.1, leveraging {GCP} C3 bare-metal instances and {GCP} Hyperdisk. This enables you to migrate and modernize virtual machines (VMs) from existing platforms directly onto {product-title}, managing them alongside containerized workloads on a single, unified application platform.
 +
-For more information about using {VirtProductName} on {product-title} on {gcp}, see link:https://docs.redhat.com/en/documentation/openshift_dedicated/4/html/virtualization/index[Virtualization].
-//link to Virtualization 4.21.z release note documentation to be added when available
+For more information about using {VirtProductName} on {product-title} on {gcp}, see:
 
-{product-title} now available in {GCP} console::
+* link:https://docs.redhat.com/en/documentation/openshift_dedicated/4/html/virtualization/index[Virtualization]
+* link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.21/html/virtualization/release-notes[OpenShift Virtualization release notes]
+
+{product-title} is available in {GCP} console::
 +
-{product-title} is now available directly within the link:https://console.cloud.google.com/redhat-openshift/landing[{GCP} console], making it easier to find and deploy alongside native {GCP} services. This integration simplifies the initial setup by allowing you to validate environment prerequisites for {product-title} cluster deployment.
+{product-title} is available directly within the link:https://console.cloud.google.com/redhat-openshift/landing[{GCP} console], making it easier to find and deploy alongside native {GCP} services. This integration simplifies the initial setup by allowing you to validate environment prerequisites for {product-title} cluster deployment.
 +
 **Key improvements:**
 
@@ -28,10 +30,10 @@ For more information about using {VirtProductName} on {product-title} on {gcp}, 
 +
 For more information about deploying {product-title} on {GCP}, see link:https://docs.redhat.com/en/documentation/openshift_dedicated/4/html/planning_your_environment/gcp-ccs#ccs-gcp-understand_gcp-ccs[Understanding Customer Cloud Subscriptions on Google Cloud].
 
-Cluster admins can now create multiple users with htpasswd identity providers::
+Cluster admins can create multiple users with htpasswd identity providers::
 +
-Cluster administrators can now add multiple users to an htpasswd identity providers (IDPs) for {product-title} clusters using the command-line interface (CLI). You can add multiple users to a single htpasswd IDP, streamlining managing user identities. Using the CLI, administrators can add multiple users interactively and noninteractively. For more information, see link:https://docs.redhat.com/en/documentation/openshift_dedicated/4/html/authentication_and_authorization/sd-configuring-identity-providers#config-htpasswd-idp_sd-configuring-identity-providers[Configuring an htpasswd identity provider].
+Cluster administrators can add multiple users to an htpasswd identity providers (IDPs) for {product-title} clusters using the command-line interface (CLI). You can add multiple users to a single htpasswd IDP, streamlining managing user identities. Using the CLI, administrators can add multiple users interactively and noninteractively. For more information, see link:https://docs.redhat.com/en/documentation/openshift_dedicated/4/html/authentication_and_authorization/sd-configuring-identity-providers#config-htpasswd-idp_sd-configuring-identity-providers[Configuring an htpasswd identity provider].
 
 New version of {product-title} available::
 +
-{product-title} on {gcp} and {product-title} on {aws} versions 4.21 are now available for new clusters.
+{product-title} on {gcp} and {product-title} on {aws} versions 4.21 are available for new clusters.

--- a/modules/osd-release-notes-Q2-2026.adoc
+++ b/modules/osd-release-notes-Q2-2026.adoc
@@ -16,10 +16,9 @@ The `fast` upgrade channel is available as an update option::
 +
 You can choose `fast` as an upgrade channel when creating or updating your {product-title} clusters. The `fast` channel is updated with new versions of {product-title} as soon as Red{nbsp}Hat declares the version as a general availability (GA) release.
 
-
-{GCP} NetApp Volumes (GCNV) for {VirtProductName} on {GCP}::
+GCNV for {VirtProductName} on {GCP}::
 +
-{VirtProductName} on {product-title} on {GCP} 4.21 and later now supports link:https://cloud.google.com/netapp/volumes/docs[Google Cloud NetApp Volumes] (GCNV) as a certified NFS storage backend when you use the NetApp Trident CSI Operator version 26.02.0 or later together with {VirtProductName} 4.21.2 or later.
+{VirtProductName} on {product-title} on {GCP} 4.21 and later adds support for link:https://cloud.google.com/netapp/volumes/docs[{GCP} NetApp Volumes] (GCNV) as a certified NFS storage backend when you use the NetApp Trident CSI Operator version 26.02.0 or later together with {VirtProductName} 4.21.2 or later.
 +
 GCNV provides NFS-based shared storage that supports ReadWriteMany (RWX) access in `Filesystem` mode. The NetApp Trident CSI driver provisions GCNV storage volumes.
 +
@@ -31,15 +30,15 @@ For more information about using GCNV with {VirtProductName} on {GCP}, see the f
 
 Support for excluding namespaces from default ingress load controller using label selectors::
 +
-You can now use the `ocm` CLI to configure default ingress namespace exclusions for your cluster. For more information, see link:https://docs.redhat.com/en/documentation/openshift_dedicated/4/html/networking_operators/configuring-ingress#osd-ingress-excluded-namespaces-ocm-cli_configuring-ingress[Configure excluded namespaces for the default ingress controller].
+With this update, you can use the `ocm` CLI to configure default ingress namespace exclusions for your cluster. For more information, see link:https://docs.redhat.com/en/documentation/openshift_dedicated/4/html/networking_operators/configuring-ingress#osd-ingress-excluded-namespaces-ocm-cli_configuring-ingress[Configure excluded namespaces for the default ingress controller].
 
 Support for new {gcp-short} instances::
 +
-You can now create clusters with `g2` and `g4` instance types on {product-title} version 4.21 and later. For more information, see link:https://docs.redhat.com/en/documentation/openshift_dedicated/4/html/introduction_to_openshift_dedicated/policies-and-service-definition#gcp-compute-types_osd-service-definition[{gcp-full} instance types].
+With this update, you can create clusters with `g2` and `g4` instance types on {product-title} version 4.21 and later. For more information, see link:https://docs.redhat.com/en/documentation/openshift_dedicated/4/html/introduction_to_openshift_dedicated/policies-and-service-definition#gcp-compute-types_osd-service-definition[{gcp-full} instance types].
 
-{product-title} managed DNS zones now available::
+{product-title} managed DNS zones are available::
 +
-You can now create and manage your own DNS zones for Shared VPC deployments on {GCP}, giving you greater control over your {product-title} cluster's network configuration and security. This new capability allows you to maintain ownership of your DNS infrastructure while still leveraging the powerful features of {product-title}.
+You can create and manage your own DNS zones for Shared VPC deployments on {GCP}, giving you greater control over your {product-title} cluster's network configuration and security. This new capability allows you to maintain ownership of your DNS infrastructure while still leveraging the powerful features of {product-title}.
 +
 By using managed DNS zones, you can ensure that your cluster's DNS records are managed according to your organization's policies and compliance requirements, without granting broad administrative access to your host projects. This improvement enhances security and provides a more flexible deployment option for customers with strict governance needs.
 +
@@ -49,4 +48,4 @@ For more information about managed DNS zones for {product-title} on {GCP}, see l
 
 Support for new {gcp-short} instances::
 +
-{product-title} version 4.18 and later now supports `c2d`, `c3d`, `n2d` and `t2d` instance types on {gcp-full}. For more information, see link:https://docs.redhat.com/en/documentation/openshift_dedicated/4/html/introduction_to_openshift_dedicated/policies-and-service-definition#gcp-compute-types_osd-service-definition[{gcp-full} compute types].
+{product-title} version 4.18 and later adds support for `c2d`, `c3d`, `n2d` and `t2d` instance types on {gcp-full}. For more information, see link:https://docs.redhat.com/en/documentation/openshift_dedicated/4/html/introduction_to_openshift_dedicated/policies-and-service-definition#gcp-compute-types_osd-service-definition[{gcp-full} compute types].

--- a/modules/osd-release-notes-Q4-2025.adoc
+++ b/modules/osd-release-notes-Q4-2025.adoc
@@ -10,8 +10,7 @@ The following items were added during the fourth quarter of 2025.
 
 Support for managing workload identity pools and providers in a dedicated {GCP} project::
 +
-{product-title} on {GCP} now lets you update an existing Workload Identity Federation (WIF) configuration to use a dedicated project for managing workload identity pools and providers.
-For more information, see link:http://docs.redhat.com/en/documentation/openshift_dedicated/4/html-single/openshift_dedicated_clusters_on_google_cloud/index#wif-configuration-update_osd-creating-a-cluster-on-gcp-with-workload-identity-federation[Updating a Workload Identity Federation configuration].
+You can update an existing Workload Identity Federation (WIF) configuration on {product-title} on {GCP} to use a dedicated project for managing workload identity pools and providers. For more information, see link:http://docs.redhat.com/en/documentation/openshift_dedicated/4/html-single/openshift_dedicated_clusters_on_google_cloud/index#wif-configuration-update_osd-creating-a-cluster-on-gcp-with-workload-identity-federation[Updating a Workload Identity Federation configuration].
 
 Required API services table updated::
 +
@@ -27,10 +26,10 @@ For more information, see the _Required API services_ table in the link:https://
 
 New version of {product-title} available::
 +
-{product-title} on {gcp} and {product-title} on {aws} versions 4.20 are now available for new clusters.
+{product-title} on {gcp} and {product-title} on {aws} versions 4.20 are available for new clusters.
 
-Extended Update Support (EUS) channel group now available::
+The EUS channel group is available::
 +
-You can now select the EUS channel group when creating or editing your {product-title} cluster. The EUS channel group allows you to extend the life cycle of your even-numbered version {product-title} cluster, giving you additional time to plan and budget for future upgrades. This channel group also provides continued security patches and critical bug fixes.
+You can select the Extended Update Support (EUS) channel group when creating or editing your {product-title} cluster. The EUS channel group allows you to extend the life cycle of your even-numbered version {product-title} cluster, giving you additional time to plan and budget for future upgrades. This channel group also provides continued security patches and critical bug fixes.
 +
 For additional information, see link:https://docs.redhat.com/en/documentation/openshift_dedicated/4/html/introduction_to_openshift_dedicated/policies-and-service-definition#sd-life-cycle-dates_osd-life-cycle[Life cycle dates].

--- a/modules/rosa-release-notes-Q1-2026.adoc
+++ b/modules/rosa-release-notes-Q1-2026.adoc
@@ -8,30 +8,30 @@
 [role="_abstract"]
 The following items were added during the first quarter of 2026.
 
-Cluster admins can now create multiple users with htpasswd identity providers::
+Cluster admins can create multiple users with htpasswd identity providers::
 +
-Cluster administrators can now add multiple users to an htpasswd identity providers (IDPs) for {product-title} clusters using the command-line interface (CLI). You can add multiple users to a single htpasswd IDP, streamlining managing user identities. Using the CLI or Terraform, administrators can add users interactively and noninteractively. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html/authentication_and_authorization/sd-configuring-identity-providers#config-htpasswd-idp_sd-configuring-identity-providers[Configuring an htpasswd identity provider].
+Cluster administrators can add multiple users to an htpasswd identity providers (IDPs) for {product-title} clusters using the command-line interface (CLI). You can add multiple users to a single htpasswd IDP, streamlining managing user identities. Using the CLI or Terraform, administrators can add users interactively and noninteractively. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html/authentication_and_authorization/sd-configuring-identity-providers#config-htpasswd-idp_sd-configuring-identity-providers[Configuring an htpasswd identity provider].
 
 ifdef::openshift-rosa-hcp[]
 Platform monitoring using the Cluster Monitoring Operator::
 +
-You can now configure the in-cluster monitoring stack components, metrics, and alerts to monitor both core platform components and user-defined projects. Previously, you could only monitor user-defined projects. This change applies to both new and existing {product-title} clusters. However, it affects them differently.
+With this update, you can configure the in-cluster monitoring stack components, metrics, and alerts to monitor both core platform components and user-defined projects. Previously, you could only monitor user-defined projects. This change applies to both new and existing {product-title} clusters. However, it affects them differently.
 
 * For new clusters created after this change, the default, in-cluster monitoring stack is installed during cluster installation and immediately begins collecting metrics. After installation, you can use the default configuration, or you can modify the monitoring components to suit your needs.
 * For existing clusters created prior to this change, no changes will be made to the cluster's monitoring configuration. However, you can begin to use the core platform monitoring components, and modify them to suit your needs.
 
 +
-For more information, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html-single/monitoring/index[Monitoring].
+For more information, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html-single/monitoring/index[Monitoring projects on {product-title}].
 
-AWS Windows License Included now available for {product-title}::
+AWS Windows License Included is available for {product-title}::
 +
-You can now add a Windows License Included enabled machine pool to a {product-title} cluster. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html/cluster_administration/managing-compute-nodes-using-machine-pools#creating_a_machine_pools_cli_win_li_rosa-managing-worker-nodes[Creating a machine pool with AWS Windows License Included enabled using the {rosa-cli}].
+You can add a Windows License Included enabled machine pool to a {product-title} cluster. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html/cluster_administration/managing-compute-nodes-using-machine-pools#creating_a_machine_pools_cli_win_li_rosa-managing-worker-nodes[Creating a machine pool with AWS Windows License Included enabled using the {rosa-cli}].
 
-Updating the global pull secret now available for {product-title} clusters::
+Updating the global pull secret is available for {product-title} clusters::
 +
-You can now modify the global pull secret to include additional pull secrets for accessing container images from private registries. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html/images/managing-images#images-update-global-pull-secret_using-image-pull-secrets[Updating the global cluster pull secret].
+You can modify the global pull secret to include additional pull secrets for accessing container images from private registries. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html/images/managing-images#images-update-global-pull-secret_using-image-pull-secrets[Updating the global cluster pull secret].
 endif::openshift-rosa-hcp[]
 
 New version of {product-title} available::
 +
-{product-title} version 4.21 is now available for new clusters.
+{product-title} version 4.21 is available for new clusters.

--- a/modules/rosa-release-notes-Q2-2026.adoc
+++ b/modules/rosa-release-notes-Q2-2026.adoc
@@ -23,15 +23,15 @@ The `fast` upgrade channel is available as an update option::
 You can choose `fast` as an upgrade channel when creating or updating your {product-title} clusters. The `fast` channel is updated with new versions of {product-title} as soon as Red{nbsp}Hat declares the version as a general availability (GA) release.
 
 ifdef::openshift-rosa-hcp[]
-Users can create FIPS-encrypted Red Hat OpenShift Service on AWS clusters::
+FIPS-encrypted {product-title} clusters::
 +
-With this update, you can create Red Hat OpenShift Service on AWS clusters with Federal Information Processing Standards (FIPS) encryption that adhere to the highest data security levels. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html-single/install_clusters/index#rosa-hcp-creating-cluster-with-fips-encryption[Deploying {product-title} clusters using FIPS encryption].
+With this update, you can create {product-title} clusters with Federal Information Processing Standards (FIPS) encryption that adhere to the highest data security levels. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html-single/install_clusters/index#rosa-hcp-creating-cluster-with-fips-encryption[Deploying {product-title} clusters using FIPS encryption].
 
-Users can implement the Modern TLS 1.3 security profile for {product-title} clusters::
+The Modern TLS 1.3 security profile for {product-title} clusters::
 +
 With this update, you can enhance the security of your managed endpoints by enforcing the Modern Transport Layer Security (TLS) 1.3 security profile. This profile ensures that all communications with the API server and OAuth endpoints comply with the latest security standards.
 
-Users can scale machine pools to zero nodes::
+Machine pools can be scaled to zero nodes::
 +
 With this update, you can optimize infrastructure costs for {product-title} by configuring machine pools to autoscale to zero nodes. By setting a minimum replica count of 0, use the cluster autoscaler to decommission all idle nodes in a pool. By doing this, you eliminate subscription and infrastructure expenses for high-cost resources, like GPU nodes or specialized on-demand workloads. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html/cluster_administration/managing-compute-nodes-using-machine-pools#creating_a_machine_pool_rosa-managing-worker-nodes[Creating a machine pool].
 endif::openshift-rosa-hcp[]

--- a/modules/rosa-release-notes-Q4-2025.adoc
+++ b/modules/rosa-release-notes-Q4-2025.adoc
@@ -10,7 +10,7 @@ The following items were added during the fourth quarter of 2025.
 
 AWS GovCloud::
 +
-The Amazon Web Services (AWS) GovCloud service is now available and for use by federal and government agencies, or by commercial organizations and Federal Information Security Modernization Act (FISMA) R&D Universities supporting a government contract or in the process of bidding on a government contract such as a request for proposal (RFP) or request for information (RFI) pre-bid stage. For more information, see
+The Amazon Web Services (AWS) GovCloud service is now available for federal and government agencies. Commercial organizations and Federal Information Security Modernization Act (FISMA) R&D Universities may also use the service if they support a current government contract or are in the process of bidding on a government contract such as a request for proposal (RFP) or request for information (RFI) pre-bid stage. For more information, see
 ifdef::openshift-rosa-hcp[]
 link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html-single/getting_started_with_red_hat_openshift_service_on_aws_in_aws_govcloud[Getting started with ROSA GovCloud].
 endif::openshift-rosa-hcp[]
@@ -18,28 +18,22 @@ ifdef::openshift-rosa[]
 link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws_classic_architecture/4/html-single/getting_started_with_red_hat_openshift_service_on_aws_in_aws_govcloud[Getting started with ROSA GovCloud].
 endif::openshift-rosa[]
 
-ifdef::openshift-rosa-hcp[]
-ImageDigestMirrorSets (IDMS) now supported::
-+
-{product-title} now supports ImageDigestMirrorSets (IDMS), enabling clusters to redirect image pulls to a private, mirrored registry. This critical enhancement means customers in air-gapped or restricted networks can host their own mirrors for third-party images while satisfying strict security and compliance requirements. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html-single/images/index#images-registry-mirroring_image-configuration-hcp[Image registry mirroring for {product-title}].
-endif::openshift-rosa-hcp[]
-
 New version of {product-title} available::
 +
-{product-title} version 4.20 is now available for new clusters.
+{product-title} version 4.20 is available for new clusters.
 
 ifdef::openshift-rosa-hcp[]
-On-Demand Capacity Reservations and Capacity Blocks for ML now supported::
+On-Demand Capacity Reservations and Capacity Blocks for ML are supported::
 +
-You can now use pre-purchased Capacity Reservations when creating new machine pools on {product-title} clusters. For more information, see link:https://docs.redhat.com/documentation/red_hat_openshift_service_on_aws/4/html-single/cluster_administration/index#rosa-managing-worker-nodes[Managing compute nodes].
+With this update, you can use pre-purchased Capacity Reservations when creating new machine pools on {product-title} clusters. For more information, see link:https://docs.redhat.com/documentation/red_hat_openshift_service_on_aws/4/html-single/cluster_administration/index#rosa-managing-worker-nodes[Managing compute nodes].
 
-ImageDigestMirrorSets (IDMS) now supported::
+ImageDigestMirrorSets (IDMS) is supported::
 +
-{product-title} now supports ImageDigestMirrorSets (IDMS), enabling clusters to redirect image pulls to a private, mirrored registry. This critical enhancement means customers in restricted networks can host their own mirrors for third-party images while satisfying strict security and compliance requirements. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html-single/images/index#images-registry-mirroring_image-configuration-hcp[Image registry mirroring for {product-title}].
+{product-title} adds support for ImageDigestMirrorSets (IDMS), enabling clusters to redirect image pulls to a private, mirrored registry. This critical enhancement means customers in restricted networks can host their own mirrors for third-party images while satisfying strict security and compliance requirements. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html-single/images/index#images-registry-mirroring_image-configuration-hcp[Image registry mirroring for {product-title}].
 
 {product-title} regions added::
 +
-{product-title} is now available in the following regions:
+{product-title} is available in the following regions:
 
 ** Mexico (`mx-central-1`)
 ** Thailand (`ap-southeast-7`)
@@ -48,11 +42,11 @@ ImageDigestMirrorSets (IDMS) now supported::
 For more information on region availabilities, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html-single/introduction_to_rosa/index#rosa-sdpolicy-regions-az_rosa-hcp-service-definition[Regions and availability zones].
 endif::openshift-rosa-hcp[]
 
-Extended Update Support (EUS) channel group now available::
+The EUS channel group is available::
 +
-You can now select the EUS channel group when creating or editing your {product-title} cluster. The EUS channel group allows you to extend the life cycle of your even-numbered version {product-title} cluster, giving you additional time to plan and budget for future upgrades as well as providing continued security patches and critical bug fixes. For additional information, see
+You can select the Extended Update Support (EUS) channel group when creating or editing your {product-title} cluster. The EUS channel group allows you to extend the life cycle of your even-numbered version {product-title} cluster, giving you additional time to plan and budget for future upgrades as well as providing continued security patches and critical bug fixes. For more information, see
 ifdef::openshift-rosa-hcp[]
- link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html/introduction_to_rosa/policies-and-service-definition#sd-life-cycle-dates_rosa-hcp-life-cycle[Life cycle dates].
+link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html/introduction_to_rosa/policies-and-service-definition#sd-life-cycle-dates_rosa-hcp-life-cycle[Life cycle dates].
 endif::openshift-rosa-hcp[]
 ifdef::openshift-rosa[]
 link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws_classic_architecture/4/html/introduction_to_rosa/policies-and-service-definition#sd-life-cycle-dates_rosa-life-cycle[Life cycle dates].


### PR DESCRIPTION
Version(s):
4.21+

Issue:
https://redhat.atlassian.net/browse/OSDOCS-19420

Link to docs preview:

- [OSD RNs](https://112451--ocpdocs-pr.netlify.app/openshift-dedicated/latest/osd_whats_new/osd-whats-new.html)
- [ROSA HCP RNs](https://112451--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/rosa_release_notes/rosa-release-notes.html)
- [ROSA Classic RNs](https://112451--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_release_notes/rosa-release-notes.html) are all included in the ROSA HCP RNs, so there's not much need to check the content, but rather that syntax isn't broken.

QE review:
N/A

Additional information:

Apart from implementing the SSG requirements, this PR also:

- Removes a duplicate ROSA RN "ImageDigestMirrorSets (IDMS) now supported". See the Jira issue for details if needed.
- Adds a link to the Virtualization RNs. Kept the hard-coded 4.21 version since the RN is talking about v.4.21.  
