### PR TITLE
OSDOCS NODES 7: Scheduling Configuration (Scheduler, Affinity) III

### DIFF
--- a/modules/nodes-scheduler-default-about.adoc
+++ b/modules/nodes-scheduler-default-about.adoc
@@ -6,8 +6,11 @@
 [id="nodes-scheduler-default-about_{context}"]
 = Understanding default scheduling
 
+[role="_abstract"]
 The existing generic scheduler is the default platform-provided scheduler
-_engine_ that selects a node to host the pod in a three-step operation:
+_engine_ that selects a node to host the pod.
+
+The default scheduler selects the node in a three-step operation:
 
 Filters the nodes::
 The available nodes are filtered based on the constraints or requirements

--- a/modules/nodes-scheduler-node-selectors-about.adoc
+++ b/modules/nodes-scheduler-node-selectors-about.adoc
@@ -7,6 +7,7 @@
 [id="nodes-scheduler-node-selectors-about_{context}"]
 = About node selectors
 
+[role="_abstract"]
 You can use node selectors on pods and labels on nodes to control where the pod is scheduled. With node selectors, {product-title} schedules the pods on nodes that contain matching labels.
 
 You can use a node selector to place specific pods on specific nodes, cluster-wide node selectors to place new pods on specific nodes anywhere in the cluster, and project node selectors to place new pods in a project on specific nodes.
@@ -61,11 +62,12 @@ metadata:
     node.kubernetes.io/instance-type: m4.large
     kubernetes.io/hostname: ip-10-0-131-14
     kubernetes.io/arch: amd64
-    region: east <1>
+    region: east
     type: user-node
 #...
 ----
-<1> Labels to match the pod node selector.
++
+In this example, the `region: east` and `type: user-node` labels must match the pod node selector.
 endif::openshift-origin[]
 ifdef::openshift-origin[]
 .Sample `Node` object with a label
@@ -89,11 +91,12 @@ metadata:
     node.kubernetes.io/instance-type: m4.large
     kubernetes.io/hostname: ip-10-0-131-14
     kubernetes.io/arch: amd64
-    region: east <1>
+    region: east
     type: user-node
 #...
 ----
-<1> Labels to match the pod node selector.
++
+In this example, the `region: east` and `type: user-node` labels must match the pod node selector.
 endif::openshift-origin[]
 +
 A pod has the `type: user-node,region: east` node selector:
@@ -107,12 +110,16 @@ metadata:
   name: s1
 #...
 spec:
-  nodeSelector: <1>
+  nodeSelector:
     region: east
     type: user-node
 #...
 ----
-<1> Node selectors to match the node label. The node must have a label for each node selector.
+where:
++
+--
+`spec.nodeSelector`:: Specifies the node selectors to match the node label. The node must have a label for each node selector.
+--
 +
 When you create the pod using the example pod spec, it can be scheduled on the example node.
 

--- a/modules/nodes-scheduler-node-selectors-cluster.adoc
+++ b/modules/nodes-scheduler-node-selectors-cluster.adoc
@@ -6,6 +6,7 @@
 [id="nodes-scheduler-node-selectors-cluster_{context}"]
 = Creating default cluster-wide node selectors
 
+[role="_abstract"]
 You can use default cluster-wide node selectors on pods together with labels on nodes to constrain all pods created in a cluster to specific nodes.
 
 With cluster-wide node selectors, when you create a pod in that cluster, {product-title} adds the default node selectors to the pod and schedules
@@ -18,9 +19,9 @@ You configure cluster-wide node selectors by editing the Scheduler Operator cust
 You can add additional key/value pairs to a pod. But you cannot add a different value for a default key.
 ====
 
-.Procedure
+The following procedure adds a default cluster-wide node selector.
 
-To add a default cluster-wide node selector:
+.Procedure
 
 . Edit the Scheduler Operator CR to add the default cluster-wide node selectors:
 +
@@ -38,10 +39,14 @@ metadata:
   name: cluster
 ...
 spec:
-  defaultNodeSelector: type=user-node,region=east <1>
+  defaultNodeSelector: type=user-node,region=east
   mastersSchedulable: false
 ----
-<1> Add a node selector with the appropriate `<key>:<value>` pairs.
+where:
++
+--
+`spec.defaultNodeSelector`:: Specifies a node selector with the appropriate `<key>:<value>` pairs.
+--
 +
 After making this change, wait for the pods in the `openshift-kube-apiserver` project to redeploy. This can take several minutes. The default cluster-wide node selector does not take effect until the pods redeploy.
 
@@ -53,9 +58,10 @@ After making this change, wait for the pods in the `openshift-kube-apiserver` pr
 +
 [source,terminal]
 ----
-$ oc patch MachineSet <name> --type='json' -p='[{"op":"add","path":"/spec/template/spec/metadata/labels", "value":{"<key>"="<value>","<key>"="<value>"}}]'  -n openshift-machine-api <1>
+$ oc patch MachineSet <name> --type='json' -p='[{"op":"add","path":"/spec/template/spec/metadata/labels", "value":{"<key>"="<value>","<key>"="<value>"}}]'  -n openshift-machine-api
 ----
-<1> Add a `<key>/<value>` pair for each label.
++
+Add a `<key>/<value>` pair for each label.
 +
 For example:
 +

--- a/modules/nodes-scheduler-node-selectors-pod.adoc
+++ b/modules/nodes-scheduler-node-selectors-pod.adoc
@@ -6,6 +6,7 @@
 [id="nodes-scheduler-node-selectors-pod_{context}"]
 = Using node selectors to control pod placement
 
+[role="_abstract"]
 You can use node selectors on pods and labels on nodes to control where the pod is scheduled. With node selectors, {product-title} schedules the pods on nodes that contain matching labels.
 
 You add labels to a node, a compute machine set, or a machine config. Adding the label to the compute machine set ensures that if the node or machine goes down, new nodes have the label. Labels added to a node or machine config do not persist if the node or machine goes down.
@@ -29,7 +30,8 @@ replica set:
 $ oc describe pod router-default-66d5cf9464-7pwkc
 ----
 
-.Example output
+The output appears similar to the following example:
+
 [source,terminal]
 ----
 kind: Pod
@@ -114,7 +116,7 @@ For example:
 $ oc edit MachineSet abc612-msrtw-worker-us-east-1c -n openshift-machine-api
 ----
 +
-.Example `MachineSet` object
+The output appears similar to the following example:
 +
 [source,yaml]
 ----
@@ -207,10 +209,12 @@ spec:
       nodeSelector:
         kubernetes.io/os: linux
         node-role.kubernetes.io/worker: ''
-        type: user-node <1>
+        type: user-node
 # ...
 ----
-<1> Add the node selector.
+where:
+
+`spec.template.spec.nodeSelector`:: Specifies the node selectors .
 
 * To add a node selector to a specific, new pod, add the selector to the `Pod` object directly:
 +
@@ -259,10 +263,12 @@ spec:
       nodeSelector:
         kubernetes.io/os: linux
         node-role.kubernetes.io/worker: ''
-        type: user-node <1>
+        type: user-node
 # ...
 ----
-<1> Add the node selector.
+where:
+
+`spec.template.spec.nodeSelector`:: Specifies the node selectors.
 
 ** To add a node selector to a specific, new pod, add the selector to the `Pod` object directly:
 +

--- a/modules/nodes-scheduler-node-selectors-project.adoc
+++ b/modules/nodes-scheduler-node-selectors-project.adoc
@@ -6,6 +6,7 @@
 [id="nodes-scheduler-node-selectors-project_{context}"]
 = Creating project-wide node selectors
 
+[role="_abstract"]
 You can use node selectors in a project together with labels on nodes to constrain all pods created in that project to the labeled nodes.
 
 When you create a pod in this project, {product-title} adds the node selectors to the pods in the project and schedules the pods on a node with matching labels in the project. If there is a cluster-wide default node selector, a project node selector takes preference.
@@ -14,7 +15,6 @@ You add node selectors to a project by editing the `Namespace` object to add the
 
 A pod is not scheduled if the `Pod` object contains a node selector, but no project has a matching node selector. When you create a pod from that spec, you receive an error similar to the following message:
 
-.Example error message
 [source,terminal]
 ----
 Error from server (Forbidden): error when creating "pod.yaml": pods "pod-4" is forbidden: pod node label selector conflicts with its project node label selector
@@ -25,9 +25,9 @@ Error from server (Forbidden): error when creating "pod.yaml": pods "pod-4" is f
 You can add additional key/value pairs to a pod. But you cannot add a different value for a project key.
 ====
 
-.Procedure
+The following procedure adds a default project node selector.
 
-To add a default project node selector:
+.Procedure
 
 . Create a namespace or edit an existing namespace to add the `openshift.io/node-selector` parameter:
 +
@@ -43,7 +43,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   annotations:
-    openshift.io/node-selector: "type=user-node,region=east" <1>
+    openshift.io/node-selector: "type=user-node,region=east"
     openshift.io/description: ""
     openshift.io/display-name: ""
     openshift.io/requester: kube:admin
@@ -60,7 +60,8 @@ spec:
   finalizers:
   - kubernetes
 ----
-<1> Add the `openshift.io/node-selector` with the appropriate `<key>:<value>` pairs.
++
+Add the `openshift.io/node-selector` annotation with the appropriate `<key>:<value>` pairs.
 
 . Add labels to a node by using a compute machine set or editing the node directly:
 

--- a/modules/nodes-scheduler-pod-topology-spread-constraints-examples.adoc
+++ b/modules/nodes-scheduler-pod-topology-spread-constraints-examples.adoc
@@ -6,7 +6,8 @@
 [id="nodes-scheduler-pod-topology-spread-constraints-examples_{context}"]
 = Example configurations for pod topology spread constraints
 
-You can specify which pods to group together, which topology domains they are spread among, and the acceptable skew.
+[role="_abstract"]
+When configuring topology spread constraints, you can specify which pods to group together, which topology domains they are spread among, and the acceptable skew.
 
 The following examples demonstrate pod topology spread constraint configurations.
 
@@ -25,14 +26,14 @@ spec:
     seccompProfile:
       type: RuntimeDefault
   topologySpreadConstraints:
-  - maxSkew: 1 <1>
-    topologyKey: topology.kubernetes.io/zone <2>
-    whenUnsatisfiable: DoNotSchedule <3>
-    labelSelector: <4>
+  - maxSkew: 1
+    topologyKey: topology.kubernetes.io/zone
+    whenUnsatisfiable: DoNotSchedule
+    labelSelector:
       matchLabels:
-        region: us-east <5>
+        region: us-east
     matchLabelKeys:
-      - my-pod-label <6>
+      - my-pod-label
   containers:
   - image: "docker.io/ocpqe/hello-pod"
     name: hello-pod
@@ -41,12 +42,13 @@ spec:
       capabilities:
         drop: [ALL]
 ----
-<1> The maximum difference in number of pods between any two topology domains. The default is `1`, and you cannot specify a value of `0`.
-<2> The key of a node label. Nodes with this key and identical value are considered to be in the same topology.
-<3> How to handle a pod if it does not satisfy the spread constraint. The default is `DoNotSchedule`, which tells the scheduler not to schedule the pod. Set to `ScheduleAnyway` to still schedule the pod, but the scheduler prioritizes honoring the skew to not make the cluster more imbalanced.
-<4> Pods that match this label selector are counted and recognized as a group when spreading to satisfy the constraint. Be sure to specify a label selector, otherwise no pods can be matched.
-<5> Be sure that this `Pod` spec also sets its labels to match this label selector if you want it to be counted properly in the future.
-<6> A list of pod label keys to select which pods to calculate spreading over.
+where:
+
+`spec.topologySpreadConstraints.maxSkew`:: Specifies the maximum difference in number of pods between any two topology domains. The default is `1`, and you cannot specify a value of `0`.
+`spec.topologySpreadConstraints.topologyKey`:: Specifies the key of a node label. Nodes with this key and identical value are considered to be in the same topology.
+`spec.topologySpreadConstraints.whenUnsatisfiable`:: Specifies how to handle a pod if it does not satisfy the spread constraint. The default is `DoNotSchedule`, which tells the scheduler not to schedule the pod. Set to `ScheduleAnyway` to still schedule the pod, but the scheduler prioritizes honoring the skew to not make the cluster more imbalanced.
+`spec.topologySpreadConstraints.labelSelector.matchLabels`:: Specifies {key,value} pairs for matching. Pods that match this label selector are counted and recognized as a group when spreading to satisfy the constraint. Be sure to specify a label selector, otherwise no pods can be matched. Be sure that this `Pod` spec also sets its labels to match this label selector if you want it to be counted properly in the future.
+`spec.topologySpreadConstraints.matchLabelKeys`:: Specifies a list of pod label keys to select which pods to calculate spreading over.
 
 .Example demonstrating a single pod topology spread constraint
 [source,yaml]

--- a/modules/nodes-scheduler-use-cases.adoc
+++ b/modules/nodes-scheduler-use-cases.adoc
@@ -1,0 +1,54 @@
+// Module included in the following assemblies:
+//
+// * nodes/nodes-scheduler-default.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="nodes-scheduler-use-cases_{context}"]
+= Scheduler use cases
+
+[role="_abstract"]
+You can configure the cluster scheduler to apply affinity and anti-affinity policies across customizable infrastructure topological levels to meet application latency and high-availability requirements.
+
+ifdef::openshift-enterprise,openshift-webscale,openshift-origin[]
+
+Infrastructure topological levels::
+Administrators can define multiple topological levels for their infrastructure
+(nodes) by specifying labels on nodes. For example: `region=r1`, `zone=z1`, `rack=s1`.
++
+These label names have no particular meaning and
+administrators are free to name their infrastructure levels anything, such as
+city/building/room. Also, administrators can define any number of levels
+for their infrastructure topology, with three levels usually being adequate
+(such as: `regions` -> `zones` -> `racks`).  Administrators can specify affinity
+and anti-affinity rules at each of these levels in any combination.
+endif::openshift-enterprise,openshift-webscale,openshift-origin[]
+
+Affinity::
+Administrators should be able to configure the scheduler to specify affinity at
+any topological level, or even at multiple levels. Affinity at a particular
+level indicates that all pods that belong to the same service are scheduled
+onto nodes that belong to the same level. This handles any latency requirements
+of applications by allowing administrators to ensure that peer pods do not end
+up being too geographically separated. If no node is available within the same
+affinity group to host the pod, then the pod is not scheduled.
++
+If you need greater control over where the pods are scheduled, see "Controlling pod placement on nodes using node affinity rules" and "Placing pods relative to other pods using affinity and anti-affinity rules".
++
+These advanced scheduling features allow administrators
+to specify which node a pod can be scheduled on and to force or reject scheduling relative to other pods.
+
+Anti-affinity::
+
+Administrators should be able to configure the scheduler to specify
+anti-affinity at any topological level, or even at multiple levels.
+Anti-affinity (or 'spread') at a particular level indicates that all pods that
+belong to the same service are spread across nodes that belong to that
+level. This ensures that the application is well spread for high availability
+purposes. The scheduler tries to balance the service pods across all
+applicable nodes as evenly as possible.
++
+If you need greater control over where the pods are scheduled, see "Controlling pod placement on nodes using node affinity rules" and "Placing pods relative to other pods using affinity and anti-affinity rules".
++
+These advanced scheduling features allow administrators
+to specify which node a pod can be scheduled on and to force or reject scheduling relative to other pods.
+

--- a/modules/pod-topology-spread-constraints-max-skew.adoc
+++ b/modules/pod-topology-spread-constraints-max-skew.adoc
@@ -6,6 +6,9 @@
 [id="pod-topology-spread-constraints-max-skew_{context}"]
 = Understanding skew and maxSkew
 
+[role="_abstract"]
+You can configure skew to control the uneven distribution of pods across topology domains.
+
 Skew refers to the difference in the number of pods that match a specified label selector across different topology domains, such as zones or nodes.
 
 The skew is calculated for each domain by taking the absolute difference between the number of pods in that domain and the number of pods in the domain with the lowest amount of pods scheduled. Setting a `maxSkew` value guides the scheduler to maintain a balanced pod distribution.

--- a/nodes/scheduling/nodes-scheduler-about.adoc
+++ b/nodes/scheduling/nodes-scheduler-about.adoc
@@ -6,8 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-Pod scheduling is an internal process that determines placement of new
-pods onto nodes within the cluster.
+[role="_abstract"]
+You can rely on the default pod scheduling or use the advanced pod scheduling tool for greater control over pod scheduling. Pod scheduling is an internal process that determines placement of new pods onto nodes within the cluster. 
 
 The scheduler code has a clean separation that watches new pods
 as they get created and identifies the most suitable node to host them. It then
@@ -22,6 +22,30 @@ In situations where you might want more control over where new pods are placed, 
 You can control pod placement by using the following scheduling features:
 
 ifndef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
+* Scheduler profiles
+endif::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
+* Pod affinity and anti-affinity rules
+* Node affinity
+* Node selectors
+ifndef::openshift-dedicated,openshift-rosa-hcp,openshift-rosa[]
+* Taints and tolerations
+endif::openshift-dedicated,openshift-rosa-hcp,openshift-rosa[]
+* Node overcommitment
+
+[id="about-default-scheduler"]
+== About the default scheduler
+
+The default {product-title} pod scheduler is responsible for determining the placement of new pods onto nodes within the cluster. It reads data from the pod and finds a node that is a good fit based on configured profiles. It is completely independent and exists as a standalone solution. It does not modify the pod; it creates a binding for the pod that ties the pod to the particular node.
+
+// Understanding default scheduling
+include::modules/nodes-scheduler-default-about.adoc[leveloffset=+2]
+include::modules/nodes-scheduler-use-cases.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+[id="additional-resources_{context}"]
+== Additional resources
+
+ifndef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 * xref:../../nodes/scheduling/nodes-scheduler-profiles.adoc#nodes-scheduler-profiles[Scheduler profiles]
 endif::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 * xref:../../nodes/scheduling/nodes-scheduler-pod-affinity.adoc#nodes-scheduler-pod-affinity[Pod affinity and anti-affinity rules]
@@ -31,67 +55,5 @@ ifndef::openshift-dedicated,openshift-rosa-hcp,openshift-rosa[]
 * xref:../../nodes/scheduling/nodes-scheduler-taints-tolerations.adoc#nodes-scheduler-taints-tolerations[Taints and tolerations]
 endif::openshift-dedicated,openshift-rosa-hcp,openshift-rosa[]
 * xref:../../nodes/scheduling/nodes-scheduler-overcommit.adoc#nodes-scheduler-overcommit[Node overcommitment]
-
-[id="about-default-scheduler"]
-== About the default scheduler
-
-The default {product-title} pod scheduler is responsible for determining the placement of new pods onto nodes within the cluster. It reads data from the pod and finds a node that is a good fit based on configured profiles. It is completely independent and exists as a standalone solution. It does not modify the pod; it creates a binding for the pod that ties the pod to the particular node.
-
-// Understanding default scheduling
-include::modules/nodes-scheduler-default-about.adoc[leveloffset=+2]
-
-[id="nodes-scheduler-about-use-cases_{context}"]
-== Scheduler use cases
-
-One of the important use cases for scheduling within {product-title} is to
-support flexible affinity and anti-affinity policies.
-ifdef::openshift-enterprise,openshift-webscale,openshift-origin[]
-
-[id="infrastructure-topological-levels_{context}"]
-=== Infrastructure topological levels
-
-Administrators can define multiple topological levels for their infrastructure
-(nodes) by specifying labels on nodes. For example: `region=r1`, `zone=z1`, `rack=s1`.
-
-These label names have no particular meaning and
-administrators are free to name their infrastructure levels anything, such as
-city/building/room. Also, administrators can define any number of levels
-for their infrastructure topology, with three levels usually being adequate
-(such as: `regions` -> `zones` -> `racks`).  Administrators can specify affinity
-and anti-affinity rules at each of these levels in any combination.
-endif::openshift-enterprise,openshift-webscale,openshift-origin[]
-
-[id="affinity_{context}"]
-=== Affinity
-
-Administrators should be able to configure the scheduler to specify affinity at
-any topological level, or even at multiple levels. Affinity at a particular
-level indicates that all pods that belong to the same service are scheduled
-onto nodes that belong to the same level. This handles any latency requirements
-of applications by allowing administrators to ensure that peer pods do not end
-up being too geographically separated. If no node is available within the same
-affinity group to host the pod, then the pod is not scheduled.
-
-If you need greater control over where the pods are scheduled, see xref:../../nodes/scheduling/nodes-scheduler-node-affinity.adoc#nodes-scheduler-node-affinity[Controlling pod placement on nodes using node affinity rules] and
-xref:../../nodes/scheduling/nodes-scheduler-pod-affinity.adoc#nodes-scheduler-pod-affinity[Placing pods relative to other pods using affinity and anti-affinity rules].
-
-These advanced scheduling features allow administrators
-to specify which node a pod can be scheduled on and to force or reject scheduling relative to other pods.
-
-
-[id="anti-affinity_{context}"]
-=== Anti-affinity
-
-Administrators should be able to configure the scheduler to specify
-anti-affinity at any topological level, or even at multiple levels.
-Anti-affinity (or 'spread') at a particular level indicates that all pods that
-belong to the same service are spread across nodes that belong to that
-level. This ensures that the application is well spread for high availability
-purposes. The scheduler tries to balance the service pods across all
-applicable nodes as evenly as possible.
-
-If you need greater control over where the pods are scheduled, see xref:../../nodes/scheduling/nodes-scheduler-node-affinity.adoc#nodes-scheduler-node-affinity[Controlling pod placement on nodes using node affinity rules] and
-xref:../../nodes/scheduling/nodes-scheduler-pod-affinity.adoc#nodes-scheduler-pod-affinity[Placing pods relative to other pods using affinity and anti-affinity rules].
-
-These advanced scheduling features allow administrators
-to specify which node a pod can be scheduled on and to force or reject scheduling relative to other pods.
+* xref:../../nodes/scheduling/nodes-scheduler-node-affinity.adoc#nodes-scheduler-node-affinity[Controlling pod placement on nodes using node affinity rules]
+* xref:../../nodes/scheduling/nodes-scheduler-pod-affinity.adoc#nodes-scheduler-pod-affinity[Placing pods relative to other pods using affinity and anti-affinity rules]

--- a/nodes/scheduling/nodes-scheduler-node-selectors.adoc
+++ b/nodes/scheduling/nodes-scheduler-node-selectors.adoc
@@ -6,6 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 include::snippets/about-node-selectors.adoc[]
 
 include::modules/nodes-scheduler-node-selectors-about.adoc[leveloffset=+1]

--- a/nodes/scheduling/nodes-scheduler-pod-topology-spread-constraints.adoc
+++ b/nodes/scheduling/nodes-scheduler-pod-topology-spread-constraints.adoc
@@ -6,7 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-You can use pod topology spread constraints to provide fine-grained control over the placement of your pods across nodes, zones, regions, or other user-defined topology domains. Distributing pods across failure domains can help to achieve high availability and more efficient resource utilization.
+[role="_abstract"]
+To achieve high availability and more efficient resource utilization, you can use pod topology spread constraints to control the placement of your pods across nodes, zones, regions, or other user-defined topology domains.
 
 [id="nodes-scheduler-pod-topology-spread-constraints-example-use-cases"]
 == Example use cases

--- a/snippets/about-node-selectors.adoc
+++ b/snippets/about-node-selectors.adoc
@@ -5,6 +5,4 @@
 
 :_mod-docs-content-type: SNIPPET
 
-A _node selector_ specifies a map of key/value pairs that are defined using custom labels on nodes and selectors specified in pods.
-
-For the pod to be eligible to run on a node, the pod must have the same key/value node selector as the label on the node.
+You can use a _node selector_ to specify a map of key/value pairs that you define by using custom labels on nodes and selectors specified in pods. For the pod to be eligible to run on a node, the pod must have the same key/value node selector as the label on the node.


### PR DESCRIPTION
https://redhat.atlassian.net/browse/OSDOCS-16935


Link to docs preview. I don't think there are many differences between the platforms, but here are all the links:
OCP:
Nodes -> Controlling pod placement onto nodes (scheduling) -> [Controlling pod placement using the scheduler](https://112454--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/scheduling/nodes-scheduler-about)
Nodes -> Controlling pod placement onto nodes (scheduling) -> [Placing pods on specific nodes using node selectors](https://112454--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/scheduling/nodes-scheduler-node-selectors)
Nodes -> Controlling pod placement onto nodes (scheduling) -> [Controlling pod placement by using pod topology spread constraints](https://112454--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/scheduling/nodes-scheduler-pod-topology-spread-constraints)

OSD:
Nodes -> Controlling pod placement onto nodes (scheduling) -> [Controlling pod placement using the scheduler](https://112454--ocpdocs-pr.netlify.app/openshift-dedicated/latest/nodes/scheduling/nodes-scheduler-about)
Nodes -> Controlling pod placement onto nodes (scheduling) -> [Placing pods on specific nodes using node selectors](https://112454--ocpdocs-pr.netlify.app/openshift-dedicated/latest/nodes/scheduling/nodes-scheduler-node-selectors)
Nodes -> Controlling pod placement onto nodes (scheduling) -> [Controlling pod placement by using pod topology spread constraints](https://112454--ocpdocs-pr.netlify.app/openshift-dedicated/latest/nodes/scheduling/nodes-scheduler-pod-topology-spread-constraints)

ROSA
Nodes -> Controlling pod placement onto nodes (scheduling) -> [Controlling pod placement using the scheduler](https://112454--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/nodes/scheduling/nodes-scheduler-about)
Nodes -> Controlling pod placement onto nodes (scheduling) -> [Placing pods on specific nodes using node selectors](https://112454--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/nodes/scheduling/nodes-scheduler-node-selectors)
Nodes -> Controlling pod placement onto nodes (scheduling) -> [Controlling pod placement by using pod topology spread constraints](https://112454--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/nodes/scheduling/nodes-scheduler-pod-topology-spread-constraints)

ROSA classic
Nodes -> Controlling pod placement onto nodes (scheduling) -> [Controlling pod placement using the scheduler](https://112454--ocpdocs-pr.netlify.app/openshift-rosa/latest/nodes/scheduling/nodes-scheduler-about)
Nodes -> Controlling pod placement onto nodes (scheduling) -> [Placing pods on specific nodes using node selectors](https://112454--ocpdocs-pr.netlify.app/openshift-rosa/latest/nodes/scheduling/nodes-scheduler-node-selectors)
Nodes -> Controlling pod placement onto nodes (scheduling) -> [Controlling pod placement by using pod topology spread constraints](https://112454--ocpdocs-pr.netlify.app/openshift-rosa/latest/nodes/scheduling/nodes-scheduler-pod-topology-spread-constraints)
