### PR TITLE
OSDOCS-18179 kube storage version migrator RNs: wgabor bug batch

### DIFF
--- a/modules/rn-ocp-release-notes-fixed-issues.adoc
+++ b/modules/rn-ocp-release-notes-fixed-issues.adoc
@@ -90,6 +90,11 @@ Instructions: Add entries in the following format under the appropriate heading:
 [id="rn-ocp-release-note-kube-scheduler-fixed-issues_{context}"]
 == Kube Scheduler
 
+[id="rn-ocp-release-note-kube-storage-version-migrator-fixed-issues_{context}"]
+== Kube Storage Version Migrator
+
+* Before this update, the storage version migrator pod did not have a node selector configured, causing it to run on worker nodes instead of control plane nodes. As a consequence, this {product-title} component did not follow the standard placement pattern for platform components. With this release, the migrator pod includes a node selector to schedule on control plane nodes. As a result, the storage version migrator pod runs on control plane nodes alongside other {product-title} components. (link:https://redhat.atlassian.net/browse/OCPBUGS-84312[OCPBUGS-84312])
+
 
 // [id="rn-ocp-release-note-kube-api-server-fixed-issues_{context}"]
 // == Kubernetes API Server


### PR DESCRIPTION
Version(s):
4.22

Issue:
https://redhat.atlassian.net/browse/OSDOCS-18179

Link to docs preview:
https://112459--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-22-release-notes.html#rn-ocp-release-notes-fixed-issues_release-notes


QE review:
- [ ] QE has approved this change.


Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
