### PR TITLE
OSDOCS-18179-Cluster-Autoscaler-tavery:Bug Batching

### DIFF
--- a/modules/rn-ocp-release-notes-fixed-issues.adoc
+++ b/modules/rn-ocp-release-notes-fixed-issues.adoc
@@ -49,9 +49,10 @@ Instructions: Add entries in the following format under the appropriate heading:
 // == Cloud Credential Operator
 
 
-// [id="rn-ocp-release-note-cluster-autoscaler-fixed-issues_{context}"]
-// == Cluster Autoscaler
+[id="rn-ocp-release-note-cluster-autoscaler-fixed-issues_{context}"]
+== Cluster Autoscaler
 
+* Before this update, the cluster autoscaler processed paused node groups as if they were active, which could lead to the wrong nodes being deleted. With this release, the cluster autoscaler identifies paused node groups and does not act upon them, preventing incorrect node deletion. (link:https://redhat.atlassian.net/browse/OCPBUGS-78152[OCPBUGS-78152])
 
 // [id="ocp-release-note-cluster-override-admin-operator-bug-fixes_{context}"]
 // == Cluster Resource Override Admission Operator


### PR DESCRIPTION
Version(s):
4.22

Issue:
https://redhat.atlassian.net/browse/OSDOCS-18179

Link to docs preview:
https://112461--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-22-release-notes.html#rn-ocp-release-note-cluster-autoscaler-fixed-issues_release-notes
