### PR TITLE
[OSDOCS#16167]: Added new module for Installing CSI driver using CLI

### DIFF
--- a/modules/persistent-storage-csi-secrets-store-driver-install-cli.adoc
+++ b/modules/persistent-storage-csi-secrets-store-driver-install-cli.adoc
@@ -1,0 +1,107 @@
+// Module included in the following assemblies:
+//
+// * storage/container_storage_interface/persistent-storage-csi-secrets-store.adoc
+//
+
+:_mod-docs-content-type: PROCEDURE
+[id="persistent-storage-csi-secrets-store-driver-install-cli_{context}"]
+= Installing the {secrets-store-driver} by using the CLI
+
+[role="_abstract"]
+The {secrets-store-driver} is typically installed in the namespace `openshift-cluster-csi-drivers`. This namespace is present in the cluster as part of the installation of the Cluster Storage Operator.
+
+.Procedure
+
+. Create an `OperatorGroup` object by running the following command:
++
+[source,terminal]
+----
+$ oc apply -f - <<EOF
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: openshift-cluster-csi-drivers
+  namespace: openshift-cluster-csi-drivers
+spec: {}
+EOF
+----
+
+. Create a `Subscription` object by running the following command:
++
+[source,terminal]
+----
+$ oc apply -f - <<EOF
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: secrets-store-csi-driver-operator
+  namespace: openshift-cluster-csi-drivers
+spec:
+  channel: stable
+  installPlanApproval: Automatic
+  name: secrets-store-csi-driver-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+EOF
+----
+
+. Wait for the Operator to be up and running. You can check the Operator status by running the following command:
++
+[source,terminal]
+----
+$ oc get csv -n openshift-cluster-csi-drivers
+----
++
+.Example output
+[source,terminal]
+----
+NAME    DISPLAY     VERSION         RELEASE   REPLACES   PHASE
+secrets-store-csi-driver-operator.v4.22.0-202607151755   Secrets Store CSI Driver Operator   4.22.0-202607151755                        Succeeded
+----
+
+. Create the Cluster CSI driver by running the following command:
++
+[source,terminal]
+----
+$ oc apply -f - <<EOF
+apiVersion: operator.openshift.io/v1
+kind: ClusterCSIDriver
+metadata:
+  name: secrets-store.csi.k8s.io
+spec:
+  managementState: Managed
+EOF
+----
+
+.Verification
+
+* Verify that the Operator is running:
++
+[source,terminal]
+----
+$ oc get operator -n openshift-cluster-csi-drivers
+----
++
+.Example output
+[source,terminal]
+----
+NAME                                                             AGE
+secrets-store-csi-driver-operator.openshift-cluster-csi-drivers   7m55s
+----
+
+* Verify that the pods are running:
++
+[source,terminal]
+----
+$ oc get pods -n openshift-cluster-csi-drivers
+----
++
+.Example output
+[source,terminal]
+----
+NAME                                                 READY   STATUS    RESTARTS   AGE
+....
+....
+secrets-store-csi-driver-node-bhp2d                  3/3     Running   0          45s
+secrets-store-csi-driver-operator-74696fc7bc-qjrl8   1/1     Running   0          7m40s
+----

--- a/storage/container_storage_interface/persistent-storage-csi-secrets-store.adoc
+++ b/storage/container_storage_interface/persistent-storage-csi-secrets-store.adoc
@@ -22,6 +22,7 @@ include::modules/secrets-store-providers.adoc[leveloffset=+2]
 include::modules/persistent-storage-csi-about.adoc[leveloffset=+1]
 
 include::modules/persistent-storage-csi-secrets-store-disconnect-environment.adoc[leveloffset=+1]
+
 [role="_additional-resources"]
 .Additional resources
 * xref:../../disconnected/about.adoc#about[About disconnected environments]
@@ -29,9 +30,13 @@ include::modules/persistent-storage-csi-secrets-store-disconnect-environment.ado
 include::modules/persistent-storage-csi-secrets-store-network-policies.adoc[leveloffset=+1]
 
 include::modules/persistent-storage-csi-secrets-store-driver-install.adoc[leveloffset=+1]
-[role="_additional-resources"]
-.Additional resources
-* xref:../../nodes/pods/nodes-pods-secrets-store.adoc#nodes-pods-secrets-store[Providing sensitive data to pods by using an external secrets store]
+
+include::modules/persistent-storage-csi-secrets-store-driver-install-cli.adoc[leveloffset=+1]
+
+.Next steps
+
+* xref:../../nodes/pods/nodes-pods-secrets-store.adoc#mounting-secrets-external-secrets-store[Mounting secrets from an external secrets store to a CSI volume]
+
 
 include::modules/persistent-storage-csi-secrets-store-driver-uninstall.adoc[leveloffset=+1]
 


### PR DESCRIPTION

Version(s):
4.22

Issue:
https://redhat.atlassian.net/browse/OSDOCS-16167

Link to docs preview:
https://112469--ocpdocs-pr.netlify.app/openshift-enterprise/latest/storage/container_storage_interface/persistent-storage-csi-secrets-store.html#persistent-storage-csi-secrets-store-driver-install-cli_persistent-storage-csi-secrets-store

https://112469--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/pods/nodes-pods-secrets-store#mounting-secrets-external-secrets-store

QE review:
- [x] QE has approved this change.
