### PR TITLE
OBSDOCS-2961 [DOC] Logging 6.2 Console plugin disabled when Console is GitOps-managed; missing documentation

### DIFF
--- a/modules/coo-logging-ui-plugin-about.adoc
+++ b/modules/coo-logging-ui-plugin-about.adoc
@@ -1,0 +1,20 @@
+// Module included in the following assemblies:
+
+// * observability/cluster_observability_operator/ui_plugins/logging-ui-plugin.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="coo-about-logging-ui-plugin_{context}"]
+= About the {coo-full} logging UI plugin
+
+[role="_abstract"]
+The logging UI plugin surfaces logging data in the {ocp-product-title} web console on the *Observe* -> *Logs* page.
+
+You can specify filters, queries, time ranges, and refresh rates, with the results displayed as a list of collapsed logs, which you can expand to show more detailed information for each log.
+
+If you also deploy the Troubleshooting UI plugin on {ocp-product-title} version 4.19+, it connects to the Korrel8r service and enables navigation between the *Observe* -> *Logs*, *Observe* -> *Metrics*, and *Observe* -> *Alerting* pages. You can navigate between these pages by opening the Troubleshooting panel.
+
+Additional features of the plugin based on {ocp-product-title} version are categorized as:
+
+dev-console::	Adds the logging view to the developer perspective of the web console.
+alerts::	Merges the web console alerts in the admin or core platform perspective with log-based alerts defined in the Loki ruler. Adds a log-based metrics chart in the alert detail view.
+dev-alerts::	Merges the web console alerts in the developer perspective with log-based alerts defined in the Loki ruler. Adds a log-based metrics chart in the alert detail view for the web console.

--- a/modules/coo-logging-ui-plugin-install-gitops-and-automation.adoc
+++ b/modules/coo-logging-ui-plugin-install-gitops-and-automation.adoc
@@ -1,0 +1,39 @@
+// Module included in the following assemblies:
+
+// * observability/cluster_observability_operator/ui_plugins/logging-ui-plugin.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="coo-logging-ui-plugin-install-gitops-and-automation_{context}"]
+= Installing the {coo-full} logging UI plugin with GitOps and automation
+
+[role="_abstract"]
+[IMPORTANT]
+====
+If your {ocp-product-title} cluster configuration, specifically the Console Operator, is managed via GitOps tools like ArgoCD, the `logging-view-plugin` may automatically disable itself after a sync or redeployment. This happens because the GitOps controller overwrites the cluster's `Console` resource to match its git repository state.
+====
+
+To prevent the plugin from being disabled after an automated sync, you must explicitly define the plugin within your GitOps-managed `Console` configuration.
+
+.Procedure
+
+* Update your GitOps repository configuration for the `Console` resource to include `logging-view-plugin` under the `spec.plugins` block, similar to the following example:
++
+[source,yaml]
+----
+apiVersion: operator.openshift.io/v1
+kind: Console
+metadata:
+  name: cluster
+spec:
+  plugins:
+    - logging-view-plugin
+----
+
+.Verification
+
+* Verify that the configuration has been correctly applied on the cluster by running the following command:
++
+[source,terminal]
+----
+$ oc get consoles.operator.openshift.io cluster -o jsonpath="{.spec.plugins}"
+----

--- a/ui_plugins/logging-ui-plugin.adoc
+++ b/ui_plugins/logging-ui-plugin.adoc
@@ -7,27 +7,11 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 [role="_abstract"]
-The logging UI plugin surfaces logging data in the {ocp-product-title} web console on the *Observe* -> *Logs* page.
-You can specify filters, queries, time ranges and refresh rates, with the results displayed as a list of collapsed logs, which can then be expanded to show more detailed information for each log.
 
-If you also deploy the Troubleshooting UI plugin on {ocp-product-title} version 4.16+, it connects to the Korrel8r service and adds direct links to the web console, from the **Observe** -> **Logs** page, to the **Observe** -> **Metrics** page with a correlated PromQL query. The plugin also adds a **See Related Logs** link from the web console alerting detail page, at **Observe** -> **Alerting**,  to the **Observe** -> **Logs** page with a correlated filter set selected.
+Analyze and query cluster log data with the {coo-full} logging UI plugin to monitor workload health and accelerate system troubleshooting.
 
-The features of the plugin are categorized as:
-
-dev-console::	Adds the logging view to web console.
-alerts::	Merges the web console alerts with log-based alerts defined in the Loki ruler. Adds a log-based metrics chart in the alert detail view.
-dev-alerts::	Merges the web console alerts with log-based alerts defined in the Loki ruler. Adds a log-based metrics chart in the alert detail view for the web console.
-
-
-For {coo-first} versions, the support for these features in {ocp-product-title} versions is shown in the following table:
-
-[cols="1,1,3", options="header"]
-|===
-| COO version   | OCP versions   | Features
-
-| 0.3.0+        | 4.12           | `dev-console`
-| 0.3.0+        | 4.13           | `dev-console`, `alerts`
-| 0.3.0+        | 4.14+          | `dev-console`, `alerts`, `dev-alerts`
-|===
+include::modules/coo-logging-ui-plugin-about.adoc[leveloffset=+1]
 
 include::modules/coo-logging-ui-plugin-install.adoc[leveloffset=+1]
+
+include::modules/coo-logging-ui-plugin-install-gitops-and-automation.adoc[leveloffset=+2]


### PR DESCRIPTION
Change type: Doc update; Logging 6.2 Console plugin disabled when Console is GitOps-managed; missing documentation

Doc JIRA: https://redhat.atlassian.net/browse/OBSDOCS-2961

Also merge to: standalone-coo-docs-1-latest

NOTE to the Reviewer: I have also fixed the Assembly structure for Logging UI Plugin with this PR according to DITA migration rules, as it might get flagged in Doc reviews.

Doc Preview: https://112470--ocpdocs-pr.netlify.app/openshift-coo/latest/ui_plugins/logging-ui-plugin.html#coo-logging-ui-plugin-install_logging-ui-plugin

SME/QE Review: @PeterYurkovich @etmurasaki 
Peer review: @kaldesai 