### PR TITLE
CQA updates for the Using Pipelines as Code with a Git repository hosting service provider chapter

### DIFF
--- a/modules/op-creating-a-github-application-in-administrator-perspective.adoc
+++ b/modules/op-creating-a-github-application-in-administrator-perspective.adoc
@@ -3,11 +3,10 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="creating-a-github-application-in-administrator-perspective_{context}"]
-
-= Creating a GitHub App in administrator perspective
+= Create a GitHub App in administrator perspective
 
 [role="_abstract"]
-As a cluster administrator, you can configure your GitHub App with the {OCP} cluster to use {pac}. You can then run a set of tasks required for build deployment.
+As a cluster administrator, you can configure your GitHub App with the {ocp} cluster to use {pac}. You can then run a set of tasks required for build deployment.
 
 [IMPORTANT]
 ====
@@ -33,3 +32,9 @@ image::Github-app-details.png[GitHub app details]
 {pac} saves the details of the GitHub App as a secret in the `openShift-pipelines` namespace.
 
 To view details such as name, link, and secret associated with the GitHub applications, go to *Pipelines* and click *View GitHub App*.
+
+[role="_additional-resources"]
+.Additional resources
+
+* link:https://docs.github.com/en/apps/creating-github-apps/about-creating-github-apps/about-creating-github-apps[About creating GitHub Apps on GitHub] (GitHub)
+

--- a/modules/op-interfacing-pipelines-as-code-with-custom-certificates.adoc
+++ b/modules/op-interfacing-pipelines-as-code-with-custom-certificates.adoc
@@ -1,12 +1,12 @@
 // This module is included in the following assemblies:
 // * pac/using-pipelines-as-code-repos.adoc
 
-:_mod-docs-content-type: REFERENCE
+:_mod-docs-content-type: PROCEDURE
 [id="interfacing-pipelines-as-code-with-custom-certificates_{context}"]
-= Interfacing {pac} with custom certificates 
+= Configure custom certificates for {pac}
 
 [role="_abstract"]
-To configure {pac} with a Git repository that is accessible with a privately signed or custom certificate, you can expose the certificate to {pac}.
+To configure {pac} with a Git repository that uses a privately signed or custom certificate, expose the certificate to {pac}.
 
 .Procedure
 

--- a/modules/op-pac-configuring-github-app-cli.adoc
+++ b/modules/op-pac-configuring-github-app-cli.adoc
@@ -3,9 +3,8 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="pac-configuring-github-app-cli_{context}"]
-= Configuring a GitHub App using the command line interface
+= Configure a GitHub App using the command line interface
 
-You can use the `tkn` command line utility to create a GitHub app and configure the {pac} controller for the GitHub app.
 [role="_abstract"]
 You can use the `tkn` command line utility to create a GitHub app and configure the {pac} controller for the GitHub app.
 
@@ -35,3 +34,13 @@ This command assumes that your account uses a standard github.com API endpoint. 
 ----
 $ tkn pac bootstrap github-app --github-api-url https://github.com/enterprises/example-enterprise
 ----
+
+.Verification
+
+* Navigate to your GitHub account or organization settings to verify that the new GitHub App is displayed in the *GitHub Apps* section.
+
+[role="_additional-resources"]
+.Additional resources
+
+* link:https://docs.github.com/en/developers/apps/getting-started-with-apps/about-apps[About GitHub Apps on GitHub] (GitHub)
+

--- a/modules/op-pac-configuring-github-app-manually.adoc
+++ b/modules/op-pac-configuring-github-app-manually.adoc
@@ -3,12 +3,18 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="pac-configuring-github-app-manually_{context}"]
-= Configuring a GitHub App manually and creating a secret for {pac}
+= Configure a GitHub App manually and create a secret for {pac}
 
 [role="_abstract"]
 You can use the GitHub user interface to create a GitHub app. Then you must create a secret that configures {pac} to connect to GitHub app.
 
 If you created additional {pac} controllers to support additional GitHub apps, you must use this procedure for the additional controllers.
+
+.Prerequisites
+
+* You have installed the {pipelines-title} {pipelines-ver} Operator from the OperatorHub.
+* You have a GitHub account with permissions to create GitHub Apps for your personal account or organization.
+* You are logged on to the {OCP} cluster as a cluster administrator.
 
 .Procedure
 . Sign in to your GitHub account.
@@ -26,7 +32,7 @@ If you created additional {pac} controllers to support additional GitHub apps, y
 $ echo https://$(oc get route -n openshift-pipelines pipelines-as-code-controller -o jsonpath='{.spec.host}')
 ----
 +
-Or, to configure the GitHub app for an additional {pac} controller, replace `pipelines-as-code-controller` with the name of the controller that you configured, as in the following example:
+Alternatively, to configure the GitHub app for an additional {pac} controller, replace `pipelines-as-code-controller` with the name of the controller that you configured, as in the following example:
 +
 .Example command
 [source,terminal]
@@ -88,3 +94,12 @@ $ oc -n openshift-pipelines create secret generic pipelines-as-code-secret \
 ====
 {pac} works automatically with GitHub Enterprise by detecting the header set from GitHub Enterprise and using it for the GitHub Enterprise API authorization URL.
 ====
+
+.Verification
+
+. Navigate to your GitHub account or organization settings to verify that the GitHub App is installed and displayed in the *Installed GitHub Apps* section.
+
+[role="_additional-resources"]
+.Additional resources
+
+* link:https://docs.github.com/en/developers/apps/getting-started-with-apps/about-apps[About GitHub Apps on GitHub] (GitHub)

--- a/modules/op-scoping-github-token.adoc
+++ b/modules/op-scoping-github-token.adoc
@@ -3,16 +3,24 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="scoping-github-token_{context}"]
-= Scoping the GitHub token to additional repositories
+= Scope the GitHub token to additional repositories
 
 [role="_abstract"]
-{pac} uses the GitHub app to generate an access token. {pac} uses this token to retrieve the pipeline payload and to interact with GitHub repositories.
+{pac} uses the GitHub App to generate an access token. {pac} uses this token to retrieve the pipeline payload and to interact with GitHub repositories.
+
 By default, {pac} scopes the access token to the repository with the pipeline definition. You might need the token to access additional repositories. For example, the `.tekton/pr.yaml` file might reside in a CI repository, but the build process in `pr.yaml` fetches tasks from a separate private CD repository.
 
 You can extend the scope of the GitHub token in two ways:
 
 * _Global configuration_: You can extend the GitHub token to a list of repositories in different namespaces. You must have administrative permissions to set this configuration.
 * _Repository level configuration_: You can extend the GitHub token to a list of repositories that exist in the same namespace as the original repository. You do not need administrative permissions to set this configuration.
+
+.Prerequisites
+
+* You have administrator access to the {OCP} cluster, or you have repository administrator access for repository-level configuration.
+* You have a {pac} GitHub App configured for your {OCP} cluster.
+* You know the names of the additional repositories that you want to scope the token to.
+* The additional repositories must already exist in your GitHub organization or account.
 
 .Procedure
 
@@ -68,7 +76,7 @@ failed to scope GitHub token as repo owner1/project1 does not exist in namespace
 ----
 ====
 
-.Result
+.Verification
 
 The generated GitHub token enables access to the additional repositories that you configured in the global and repository level configuration, and the original repository where the {pac} payload files reside.
 
@@ -108,3 +116,8 @@ spec:
 ----
 
 {pac} scopes the GitHub token to the `owner/project`, `owner1/project1`, `owner2/project2`, `owner3/project3`, and `linda/project` repositories.
+
+[role="_additional-resources"]
+.Additional resources
+
+* link:https://docs.openshift.com/container-platform/latest/architecture/control-plane.html[Understanding the control plane]

--- a/modules/op-using-pipelines-as-code-with-a-github-app.adoc
+++ b/modules/op-using-pipelines-as-code-with-a-github-app.adoc
@@ -3,10 +3,11 @@
 
 :_mod-docs-content-type: CONCEPT
 [id="using-pipelines-as-code-with-a-github-app_{context}"]
-= Using {pac} with a GitHub App
+= GitHub App integration with {pac}
 
 [role="_abstract"]
-GitHub Apps act as a point of integration with {pipelines-title} and bring the advantage of Git-based workflows to {pipelines-shortname}. Cluster administrators can configure a single GitHub App for all cluster users. For GitHub Apps to work with {pac}, ensure that the webhook of the GitHub App points to the {pac} controller route (or ingress endpoint) that listens for GitHub events.
+GitHub Apps integrate {pipelines-title} with Git-based workflows. Cluster administrators configure a single GitHub App for all users, with webhooks pointing to the {pac} controller endpoint to trigger pipeline runs.
+
 
 There are three ways to set up a GitHub app for {pac}:
 
@@ -15,3 +16,8 @@ There are three ways to set up a GitHub app for {pac}:
 * Set up the app manually in GitHub and then create a secret for {pac}.
 
 By default, {pac} can communicate with one GitHub app. If you configured additional {pac} controllers to communicate with additional GitHub apps, configure each of the GitHub apps separately. You must set up GitHub apps for any additional controllers manually.
+
+[role="_additional-resources"]
+.Additional resources
+
+* link:https://docs.github.com/en/developers/apps/getting-started-with-apps/about-apps[About GitHub Apps on GitHub] (GitHub)

--- a/modules/op-using-pipelines-as-code-with-bitbucket-cloud.adoc
+++ b/modules/op-using-pipelines-as-code-with-bitbucket-cloud.adoc
@@ -3,7 +3,7 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="using-pipelines-as-code-with-bitbucket-cloud_{context}"]
-= Using {pac} with Bitbucket Cloud
+= Use {pac} with Bitbucket Cloud
 
 [role="_abstract"]
 If your organization or project uses Bitbucket Cloud as the preferred platform, you can use {pac} for your repository with a webhook on Bitbucket Cloud.
@@ -62,7 +62,7 @@ $ tkn pac create repo
 
 ** To configure a webhook and create a `Repository` CR _manually_, perform the following steps:
 
-... On your OpenShift cluster, extract the public URL of the {pac} controller.
+... On your {ocp} cluster, extract the public URL of the {pac} controller.
 +
 [source,terminal]
 ----
@@ -81,7 +81,7 @@ $ echo https://$(oc get route -n openshift-pipelines pipelines-as-code-controlle
 
 .... Click *Save*.
 
-... On your OpenShift cluster, create a `Secret` object with the app password in the target namespace.
+... On your {ocp} cluster, create a `Secret` object with the app password in the target namespace.
 +
 [source,terminal]
 ----
@@ -147,7 +147,7 @@ $ tkn pac webhook add -n repo-pipelines
 Use the `[-n <namespace>]` option with the `tkn pac webhook add` command only when the `Repository` CR exists in a namespace other than the default namespace.
 ====
 
-.. Update the `webhook.secret` key in the existing OpenShift `Secret` object.
+.. Update the `webhook.secret` key in the existing OpenShift Secret object.
 
 . Optional: For an existing `Repository` CR, update the personal access token.
 
@@ -193,3 +193,53 @@ spec:
 ----
 $ oc -n $target_namespace patch secret bitbucket-cloud-token -p "{\"data\": {\"provider.token\": \"$(echo -n $NEW_TOKEN|base64 -w0)\"}}"
 ----
+
+.Verification
+
+. Verify that the Repository custom resource is created:
++
+[source,terminal]
+----
+$ oc get repository -n <namespace>
+----
++
+.Example output
+[source,terminal]
+----
+NAME              URL                                      NAMESPACE           SUCCEEDED   REASON
+workspace-repo    https://bitbucket.org/workspace/repo     repo-pipelines      True        Succeeded
+----
+
+. Verify the webhook configuration in your Bitbucket Cloud repository:
+.. Navigate to your Bitbucket Cloud repository in a web browser.
+.. Go to *Repository settings* → *Webhooks*.
+.. Verify that the webhook is displayed with the {pac} controller URL.
+.. Check the webhook history for successful deliveries after you trigger an event.
+
+. Trigger a test event by pushing a commit to your repository or creating a pull request.
+
+. Verify that the pipeline run is created in response to the event:
++
+[source,terminal]
+----
+$ oc get pipelinerun -n <namespace>
+----
++
+.Example output
+[source,terminal]
+----
+NAME                          SUCCEEDED   REASON      STARTTIME   COMPLETIONTIME
+workspace-repo-run-abc123     True        Succeeded   5m          2m
+----
+
+. Verify that the pipeline status is reported back to Bitbucket Cloud:
+.. Navigate to your pull request or commit in Bitbucket Cloud.
+.. Verify that the pipeline status displays as a build status indicator.
+.. Verify that the status shows the correct state (running, succeeded, or failed).
+
+[role="_additional-resources"]
+.Additional resources
+
+* link:https://support.atlassian.com/bitbucket-cloud/docs/app-passwords/[Creating app password on Bitbucket Cloud] (Bitbucket Cloud)
+* link:https://developer.atlassian.com/cloud/bitbucket/bitbucket-api-changes-gdpr/#introducing-atlassian-account-id-and-nicknames[Introducing Atlassian Account ID and Nicknames] (Atlassian Developer)
+

--- a/modules/op-using-pipelines-as-code-with-bitbucket-server.adoc
+++ b/modules/op-using-pipelines-as-code-with-bitbucket-server.adoc
@@ -3,7 +3,7 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="using-pipelines-as-code-with-bitbucket-server_{context}"]
-= Using {pac} with Bitbucket Data Center
+= Use {pac} with Bitbucket Data Center
 
 [role="_abstract"]
 If your organization or project uses Bitbucket Data Center as the preferred platform, you can use {pac} for your repository with a webhook on Bitbucket Data Center.
@@ -22,7 +22,7 @@ If your organization or project uses Bitbucket Data Center as the preferred plat
 
 .Procedure
 
-. On your OpenShift cluster, extract the public URL of the {pac} controller.
+. On your {ocp} cluster, extract the public URL of the {pac} controller.
 +
 [source,terminal]
 ----
@@ -53,7 +53,7 @@ $ openssl rand -hex 20
 
 .. Click *Save*.
 
-. On your OpenShift cluster, create a `Secret` object with the app password in the target namespace.
+. On your {ocp} cluster, create a `Secret` object with the app password in the target namespace.
 +
 [source,terminal]
 ----
@@ -92,3 +92,53 @@ spec:
 ====
 The `tkn pac create` and `tkn pac bootstrap` commands are not supported on Bitbucket Data Center.
 ====
+
+.Verification
+
+. Verify that the Repository custom resource is created:
++
+[source,terminal]
+----
+$ oc get repository -n <namespace>
+----
++
+.Example output
+[source,terminal]
+----
+NAME      URL                                       NAMESPACE           SUCCEEDED   REASON
+my-repo   https://bitbucket.com/workspace/repo      target-namespace    True        Succeeded
+----
+
+. Verify the webhook configuration in your Bitbucket Data Center repository:
+.. Navigate to your Bitbucket Data Center repository in a web browser.
+.. Go to *Repository settings* → *Webhooks*.
+.. Verify that the webhook is displayed with the {pac} controller URL.
+.. Check the webhook history for successful deliveries after you trigger an event.
+
+. Trigger a test event by pushing a commit to your repository or creating a pull request.
+
+. Verify that the pipeline run is created in response to the event:
++
+[source,terminal]
+----
+$ oc get pipelinerun -n <namespace>
+----
++
+.Example output
+[source,terminal]
+----
+NAME                   SUCCEEDED   REASON      STARTTIME   COMPLETIONTIME
+my-repo-run-xyz456     True        Succeeded   4m          1m
+----
+
+. Verify that the pipeline status is reported back to Bitbucket Data Center:
+.. Navigate to your pull request or commit in Bitbucket Data Center.
+.. Verify that the pipeline status displays as a build status indicator.
+.. Verify that the status shows the correct state (running, succeeded, or failed).
+
+[role="_additional-resources"]
+.Additional resources
+
+* link:https://pipelinesascode.com/docs/guides/repository-crd/[Using the Repository custom resource]
+* link:https://confluence.atlassian.com/bitbucketserver/personal-access-tokens-939515499.html[Creating personal tokens on Bitbucket Data Center] (Bitbucket Data Center)
+* link:https://confluence.atlassian.com/bitbucketserver/manage-webhooks-938025878.html[Managing webhooks on Bitbucket Data Center] (Bitbucket Data Center)

--- a/modules/op-using-pipelines-as-code-with-github-webhook.adoc
+++ b/modules/op-using-pipelines-as-code-with-github-webhook.adoc
@@ -3,10 +3,10 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="using-pipelines-as-code-with-github-webhook_{context}"]
-= Using {pac} with GitHub Webhook
+= Use {pac} with GitHub Webhook
 
 [role="_abstract"]
-Use {pac} with GitHub Webhook on your repository if you cannot create a GitHub App. However, using {pac} with GitHub Webhook does not give you access to the GitHub Check Runs API. {pac} adds the status of the tasks as comments on the pull request and is unavailable under the *Checks* tab.
+Use {pac} with GitHub Webhook if you cannot create a GitHub App. However, GitHub Webhook does not give access to the GitHub Check Runs API. {pac} reports task status as pull request comments instead of the *Checks* tab.
 
 [NOTE]
 ====
@@ -88,7 +88,7 @@ $ tkn pac create repo
 
 ** To configure a webhook and create a `Repository` CR _manually_, perform the following steps:
 
-... On your OpenShift cluster, extract the public URL of the {pac} controller.
+... On your {ocp} cluster, extract the public URL of the {pac} controller.
 +
 [source,terminal]
 ----
@@ -114,7 +114,7 @@ $ openssl rand -hex 20
 
 .... Click *Add webhook*.
 
-... On your OpenShift cluster, create a `Secret` object with the personal access token and webhook secret.
+... On your {ocp} cluster, create a `Secret` object with the personal access token and webhook secret.
 +
 [source,terminal]
 ----
@@ -146,10 +146,10 @@ spec:
 +
 [NOTE]
 ====
-{pac} assumes that the OpenShift `Secret` object and the `Repository` CR are in the same namespace.
+{pac} assumes that the OpenShift Secret object and the Repository CR are in the same namespace.
 ====
 
-. Optional: For an existing `Repository` CR, add many GitHub Webhook secrets or give a substitute for a deleted secret.
+. Optional: For an existing Repository CR, add many GitHub Webhook secrets or give a substitute for a deleted secret.
 
 .. Add a webhook by using the `tkn pac` CLI tool.
 +
@@ -167,10 +167,10 @@ $ tkn pac webhook add -n repo-pipelines
 ? Do you want me to use it? Yes
 ? Please enter the secret to configure the webhook for payload validation (default: AeHdHTJVfAeH):  AeHdHTJVfAeH
 ✓ Webhook has been created on repository owner/repo
-🔑 Secret owner-repo has been updated with webhook secert in the repo-pipelines namespace.
+🔑 Secret owner-repo has been updated with webhook secret in the repo-pipelines namespace.
 ----
 
-.. Update the `webhook.secret` key in the existing OpenShift `Secret` object.
+.. Update the `webhook.secret` key in the existing OpenShift Secret object.
 
 . Optional: For an existing `Repository` CR, update the personal access token.
 
@@ -214,3 +214,19 @@ spec:
 ----
 $ oc -n $target_namespace patch secret github-webhook-config -p "{\"data\": {\"provider.token\": \"$(echo -n $NEW_TOKEN|base64 -w0)\"}}"
 ----
+
+.Verification
+
+Verify the webhook configuration in your GitHub repository.
+
+. Go to your GitHub repository *Settings* -> *Webhooks*.
+
+. Verify that the webhook is displayed in the list with the {pac} controller URL.
+
+.. Check that the recent deliveries show successful responses with a checkmark.
+
+[role="_additional-resources"]
+.Additional resources
+
+* link:https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token[Creating a personal access token] (GitHub)
+* link:https://docs.github.com/en/developers/webhooks-and-events/webhooks/about-webhooks[About webhooks] (GitHub)

--- a/modules/op-using-pipelines-as-code-with-gitlab.adoc
+++ b/modules/op-using-pipelines-as-code-with-gitlab.adoc
@@ -3,10 +3,10 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="using-pipelines-as-code-with-gitlab_{context}"]
-= Using {pac} with GitLab 
+= Use {pac} with GitLab
 
 [role="_abstract"]
-If your organization or project uses GitLab as the preferred platform, you can use {pac} for your repository with a webhook on GitLab. 
+If your organization or project uses GitLab as the preferred platform, you can use {pac} for your repository with a webhook on GitLab.
 
 .Prerequisites
 
@@ -59,7 +59,7 @@ $ tkn pac create repo
 
 ** To configure a webhook and create a `Repository` CR _manually_, perform the following steps:
 
-... On your OpenShift cluster, extract the public URL of the {pac} controller.
+... On your {ocp} cluster, extract the public URL of the {pac} controller.
 +
 [source,terminal]
 ----
@@ -77,13 +77,13 @@ $ echo https://$(oc get route -n openshift-pipelines pipelines-as-code-controlle
 [source,terminal]
 ----
 $ openssl rand -hex 20
----- 
+----
 
-.... Click *Let me select individual events* and select these events: *Commit comments*, *Issue comments*, *Pull request*, and *Pushes*. 
+.... Click *Let me select individual events* and select these events: *Commit comments*, *Issue comments*, *Pull request*, and *Pushes*.
 
 .... Click *Save changes*.
 
-... On your OpenShift cluster, create a `Secret` object with the personal access token and webhook secret.
+... On your {ocp} cluster, create a `Secret` object with the personal access token and webhook secret.
 +
 [source,terminal]
 ----
@@ -118,10 +118,10 @@ spec:
 +
 [NOTE]
 ====
-* {pac} assumes that the OpenShift `Secret` object and the `Repository` CR are in the same namespace.
+* {pac} assumes that the OpenShift Secret object and the Repository CR are in the same namespace.
 ====
 
-. Optional: For an existing `Repository` CR, add many GitLab Webhook secrets or give a substitute for a deleted secret.
+. Optional: For an existing Repository CR, add many GitLab Webhook secrets or give a substitute for a deleted secret.
 
 .. Add a webhook by using the `tkn pac` CLI tool.
 +
@@ -139,10 +139,10 @@ $ tkn pac webhook add -n repo-pipelines
 ? Do you want me to use it? Yes
 ? Please enter the secret to configure the webhook for payload validation (default: AeHdHTJVfAeH):  AeHdHTJVfAeH
 ✓ Webhook has been created on repository owner/repo
-🔑 Secret owner-repo has been updated with webhook secert in the repo-pipelines namespace.
+🔑 Secret owner-repo has been updated with webhook secret in the repo-pipelines namespace.
 ----
 
-.. Update the `webhook.secret` key in the existing OpenShift `Secret` object.
+.. Update the `webhook.secret` key in the existing OpenShift Secret object.
 
 . Optional: For an existing `Repository` CR, update the personal access token.
 
@@ -181,4 +181,22 @@ spec:
 ----
 $ oc -n $target_namespace patch secret gitlab-webhook-config -p "{\"data\": {\"provider.token\": \"$(echo -n $NEW_TOKEN|base64 -w0)\"}}"
 ----
+
+.Verification
+
+* Check the webhook configuration in your GitLab project:
+.. Navigate to *Settings* -> *Webhooks*.
+.. Verify that the webhook URL points to {pac} controller.
+.. Click *Test* and select *Push events* to verify connectivity.
+
+* Trigger a pipeline run by pushing a commit to your repository or creating a merge request.
+
+* Check that the pipeline status is reported back to GitLab in the merge request or commit status.
+
+[role="_additional-resources"]
+.Additional resources
+
+* link:https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html[Personal access tokens] (GitLab)
+* link:https://docs.gitlab.com/ee/user/project/integrations/webhooks.html[Webhooks] (GitLab)
+
 

--- a/modules/op-using-private-repositories-with-pipelines-as-code.adoc
+++ b/modules/op-using-private-repositories-with-pipelines-as-code.adoc
@@ -3,7 +3,7 @@
 
 :_mod-docs-content-type: REFERENCE
 [id="using-private-repositories-with-pipelines-as-code_{context}"]
-= Using private repositories with {pac}
+= Private repository support in {pac}
 
 [role="_abstract"]
 {pac} supports private repositories by creating or updating a secret in the target namespace with the user token. The `git-clone` task from {tekton-hub} uses the user token to clone private repositories.
@@ -52,3 +52,8 @@ tasks:
 `name`:: The `git-clone` task picks up the `basic-auth` workspace and uses it to clone the private repository.
 
 You can change this configuration by setting the `secret-auto-create` parameter to either a `false` or `true` value, as required, in the `TektonConfig` custom resource, in the `pipelinesAsCode.settings` spec.
+
+[role="_additional-resources"]
+.Additional resources
+
+* link:https://hub.tekton.dev/tekton/task/git-clone[git-clone task on {tekton-hub}]

--- a/pac/using-pipelines-as-code-repos.adoc
+++ b/pac/using-pipelines-as-code-repos.adoc
@@ -6,7 +6,9 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 [role="_abstract"]
-After installing {pac}, cluster administrators can configure a Git repository hosting service provider. Currently, the following services are supported:
+After installing {pac}, cluster administrators can configure a Git repository hosting service provider.
+
+The following services are supported:
 
 * GitHub App
 * GitHub Webhook
@@ -27,56 +29,26 @@ include::modules/op-creating-a-github-application-in-administrator-perspective.a
 
 include::modules/op-pac-configuring-github-app-manually.adoc[leveloffset=+2]
 
-[role="_additional-resources"]
-.Additional resources
-
-* xref:../pac/install-config-pipelines-as-code.adoc#pac-additional-controller_install-config-pipelines-as-code[Configuring additional {pac} controllers to support additional GitHub apps]
-
 include::modules/op-scoping-github-token.adoc[leveloffset=+2]
 
 include::modules/op-using-pipelines-as-code-with-github-webhook.adoc[leveloffset=+1]
 
-[role="_additional-resources"]
-.Additional resources
-
-* link:https://docs.github.com/en/developers/webhooks-and-events/webhooks/creating-webhooks[GitHub Webhook documentation on GitHub]
-
-* link:https://docs.github.com/en/rest/guides/getting-started-with-the-checks-api[GitHub Check Runs documentation on GitHub]
-
-* link:https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token[Creating a personal access token on GitHub]
-
-* link:https://github.com/settings/tokens/new?description=pipelines-as-code-token&scopes=repo[Classic tokens with pre-filled permissions]
-
 include::modules/op-using-pipelines-as-code-with-gitlab.adoc[leveloffset=+1]
-
-[role="_additional-resources"]
-.Additional resources
-
-* link:https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html[GitLab Webhook documentation on GitLab]
 
 include::modules/op-using-pipelines-as-code-with-bitbucket-cloud.adoc[leveloffset=+1]
 
-[role="_additional-resources"]
-.Additional resources
-
-* link:https://support.atlassian.com/bitbucket-cloud/docs/app-passwords/[Creating app password on Bitbucket Cloud]
-
-* link:https://developer.atlassian.com/cloud/bitbucket/bitbucket-api-changes-gdpr/#introducing-atlassian-account-id-and-nicknames[Introducing Atlassian Account ID and Nicknames]
-
 include::modules/op-using-pipelines-as-code-with-bitbucket-server.adoc[leveloffset=+1]
-
-[role="_additional-resources"]
-.Additional resources
-
-* link:https://confluence.atlassian.com/bitbucketserver/personal-access-tokens-939515499.html[Creating personal tokens on Bitbucket Data Center]
-
-* link:https://confluence.atlassian.com/bitbucketserver/manage-webhooks-938025878.html[Managing webhooks on Bitbucket Data Center]
 
 include::modules/op-interfacing-pipelines-as-code-with-custom-certificates.adoc[leveloffset=+1]
 
+include::modules/op-using-private-repositories-with-pipelines-as-code.adoc[leveloffset=+1]
+
 [role="_additional-resources"]
 .Additional resources
-
+* link:https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html[GitLab Webhook documentation on GitLab]
+* link:https://support.atlassian.com/bitbucket-cloud/docs/app-passwords/[Creating app password on Bitbucket Cloud]
+* link:https://developer.atlassian.com/cloud/bitbucket/bitbucket-api-changes-gdpr/#introducing-atlassian-account-id-and-nicknames[Introducing Atlassian Account ID and Nicknames]
+* link:https://confluence.atlassian.com/bitbucketserver/personal-access-tokens-939515499.html[Creating personal tokens on Bitbucket Data Center]
+* link:https://confluence.atlassian.com/bitbucketserver/manage-webhooks-938025878.html[Managing webhooks on Bitbucket Data Center]
+* xref:../pac/install-config-pipelines-as-code.adoc#pac-additional-controller_install-config-pipelines-as-code[Configuring additional {pac} controllers to support additional GitHub apps]
 * link:https://docs.openshift.com/container-platform/latest/networking/enable-cluster-wide-proxy.html[Enabling the cluster-wide proxy]
-
-include::modules/op-using-private-repositories-with-pipelines-as-code.adoc[leveloffset=+1]


### PR DESCRIPTION
[RHDEVDOCS-7225](https://redhat.atlassian.net/browse/RHDEVDOCS-7225): CQA updates for the Using Pipelines as Code with a Git repository hosting service provider chapter

The changes primarily include:
- Added Verification and Additional Resources section to procedures
- Updated to Titles (from gerund form to imperative or noun form as the case may be)

Version(s): 1.22, 1.21, 1.20

Issue: [RHDEVDOCS-7225](https://redhat.atlassian.net/browse/RHDEVDOCS-7225)

Link to docs preview: https://112474--ocpdocs-pr.netlify.app/openshift-pipelines/latest/pac/using-pipelines-as-code-repos.html

QE review: 
- [x] SME has approved this change.

Additional information: N/A