### PR TITLE
OCPBUGS-87227,OCPBUGS-87228: Add disableCertificateVerification and fix BMC address format in BMaaS BMH example

### DIFF
--- a/modules/bmo-creating-a-bare-metal-host-resource.adoc
+++ b/modules/bmo-creating-a-bare-metal-host-resource.adoc
@@ -21,7 +21,7 @@ $ vim bmaas-<name>-bmh.yaml
 <name>::
     Replace `<name>` with the name of the bare-metal host.
 
-. Edit the CR: 
+. Edit the CR:
 +
 [source,yaml]
 ----
@@ -34,14 +34,17 @@ spec:
   online: true
   bootMACAddress: <mac_addr>
   bmc:
-    address: redfish-virtualmedia+<address>/redfish/v1/Systems/System.Embedded.1 
-    credentialsName: bmaas-<num>-bmc-secret
+    address: redfish-virtualmedia://<address>/redfish/v1/Systems/System.Embedded.1
+    credentialsName: bmaas-<name>-bmc-secret
+    disableCertificateVerification: true
 ----
 +
 <mac_addr>::
     Replace `<mac_addr>` with the MAC address of the first NIC on the bare-metal host.
 <address>::
-    Replace `<address>` with IP address or FQDN of the host.
+    Replace `<address>` with the IP address or FQDN of the baseboard management controller (BMC). The BMC address format depends on the protocol supported by the BMC. Use `redfish-virtualmedia://` for Redfish with virtual media.
+`disableCertificateVerification`::
+    Set to `true` to skip TLS certificate verification when the BMC uses a self-signed certificate. If the BMC has a valid certificate from a trusted certificate authority, set this field to `false` or omit it.
 
 . Apply the CR by running the following command:
 +


### PR DESCRIPTION
## Summary

- Add `disableCertificateVerification: true` to the BareMetalHost YAML example in the BMaaS "Creating a bare-metal host resource" procedure
- Fix BMC address format from `redfish-virtualmedia+<address>` to `redfish-virtualmedia://<address>` to match the format used in other bare-metal documentation (e.g., hosted control planes BMH examples)
- Add callout annotations explaining when to use `disableCertificateVerification` and a cross-reference to the BMC addressing documentation

## Why this change

During BMaaS testing on OCP 4.22.0-rc.5 with Dell iDRAC (self-signed certs), the BMO failed to connect to the BMC without `disableCertificateVerification: true`. The node stayed stuck in the registering state. Most enterprise and lab BMC deployments (iDRAC, iLO) use self-signed certificates by default.

The BMC address format `redfish-virtualmedia+<address>` was also inconsistent with the format used in `modules/hcp-bm-hosts.adoc` (`redfish-virtualmedia://`) and the IPI install docs. The `://` format worked during testing; the `+` format was ambiguous about whether to include `https://`.

Also fixed `credentialsName: bmaas-<num>-bmc-secret` to `bmaas-<name>-bmc-secret` to match the secret naming used in the preceding "Creating a BMC secret" section.

## Test plan

- [x] Verified BareMetalHost creation with the updated YAML on a baremetal IPI cluster (OCP 4.22.0-rc.5)
- [x] Node progressed through registering -> inspecting -> available -> provisioning -> provisioned

Bug: https://issues.redhat.com/browse/OCPBUGS-87227
Bug: https://issues.redhat.com/browse/OCPBUGS-87228
