### PR TITLE
OCPBUGS-87177: Improve BMaaS docs for cloud-config header and RBAC roles

### DIFF
--- a/modules/bmaas-setting-up-a-dedicated-namespace.adoc
+++ b/modules/bmaas-setting-up-a-dedicated-namespace.adoc
@@ -152,18 +152,48 @@ $ oc adm policy add-role-to-user edit <username> -n bmaas
 $ git clone -b release-{product-version} https://github.com/openshift/baremetal-operator.git
 ----
 
-. For each role you want to add, apply the appropriate RBAC role YAML file from the repository by running the following command:
+. Apply the RBAC roles that grant the user permission to manage bare-metal host resources. At minimum, apply the `baremetalhost-editor-role` by running the following command:
 +
 [source,terminal]
 ----
-$ oc apply -f baremetal-operator/config/base/rbac/<role_filename>.yaml
+$ oc apply -f baremetal-operator/config/base/rbac/baremetalhost_editor_role.yaml
 ----
++
+The following table lists the available user-facing roles and their purpose:
++
+[cols="1,1",options="header"]
+|===
+|Role file |Purpose
 
-. Assign the custom RBAC roles to the `bmadmin` user in the `bmaas` namespace by running the following command:
+|`baremetalhost_editor_role.yaml`
+|Create, update, and delete `BareMetalHost` resources. Required for provisioning.
+
+|`baremetalhost_viewer_role.yaml`
+|View-only access to `BareMetalHost` resources.
+
+|`hostfirmwaresettings_editor_role.yaml`
+|Manage firmware settings on bare-metal hosts.
+
+|`hostfirmwarecomponents_editor_role.yaml`
+|Manage firmware component updates on bare-metal hosts.
+
+|`preprovisioningimage_editor_role.yaml`
+|Manage pre-provisioning images.
+
+|`dataimage_editor_role.yaml`
+|Manage data images attached to bare-metal hosts.
+|===
++
+[NOTE]
+====
+The controller roles (`role.yaml`, `role_binding.yaml`, `leader_election_role.yaml`) are managed by the Cluster Baremetal Operator and do not need to be applied manually.
+====
+
+. Assign the applied RBAC roles to the `bmadmin` user in the `bmaas` namespace by running the following command:
 +
 [source,terminal]
 ----
-$ oc adm policy add-role-to-user <role_name> bmadmin -n bmaas
+$ oc adm policy add-role-to-user baremetalhost-editor-role bmadmin -n bmaas
 ----
 
 . Login as the `bmadmin` user by running the following command:

--- a/modules/bmo-configuring-users-for-bmaas-hosts.adoc
+++ b/modules/bmo-configuring-users-for-bmaas-hosts.adoc
@@ -15,6 +15,7 @@ Configure bare-metal host users and add them to a Kubernetes secret. Then, creat
 +
 [source,yaml]
 ----
+#cloud-config
 users:
   - name: <name>
     sudo: [<sudo_config>]
@@ -25,6 +26,11 @@ users:
     groups: [<groups>]
     lock_passwd: true|false
 ----
++
+[IMPORTANT]
+====
+The `#cloud-config` header on the first line is required. Without it, `cloud-init` does not recognize the file as a cloud-config and silently ignores the user configuration.
+====
 `users.name`::
 The user name.
 `users.sudo`::
@@ -44,6 +50,7 @@ Whether the user password is locked. If `true`, the user cannot log in by using 
 .Example user
 [source,yaml]
 ----
+#cloud-config
 users:
   - name: sysadmin
     sudo: ["ALL=(ALL) NOPASSWD:ALL"]


### PR DESCRIPTION
## Summary

- Add required `#cloud-config` header to BMaaS userData examples
- List minimum required RBAC roles for BMaaS namespace setup with a role/purpose table

## Why this change

Both issues reported in OCPBUGS-87177:

1. The userData example for configuring users on RHEL 9 hosts does not include the `#cloud-config` header. Without it, cloud-init does not process the userData and user creation silently fails.

2. The RBAC step says "apply the appropriate RBAC role" with a generic `<role_filename>` placeholder but does not explain which roles are needed. Users apply all 28 files because they cannot tell which are required. Added a table listing each user-facing role (editor/viewer for BMH, firmware, images) and clarified that controller roles are managed by the operator automatically.

## Test plan

- [x] Verified `#cloud-config` header is required for cloud-init on RHEL 9 (tested with RHEL 9 qcow2 on baremetal lab)
- [x] Verified RBAC role names match the ClusterRole names in baremetal-operator `config/base/rbac/`
- [x] Verified controller roles (role.yaml, role_binding.yaml) are listed in kustomization.yaml and applied by the operator

Bug: https://issues.redhat.com/browse/OCPBUGS-87177