### PR TITLE
OSDOCS-18289:Update RHDE page for MicroShift 4.22

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -11,11 +11,13 @@
 :op-system-ostree-first: Red{nbsp}Hat Enterprise Linux (RHEL) for Edge
 :op-system-ostree: RHEL for Edge
 :op-system-bootc: image mode for RHEL
-:op-system-version: 9.6
-:op-system-version-major: 9
+:op-system-version-9: 9.8
+:op-system-version-major-9: 9
+:op-system-version-10: 10.2
+:op-system-version-major: 10
 :microshift-first: Red{nbsp}Hat build of MicroShift (MicroShift)
 :microshift-short: MicroShift
-:microshift-version: 4.21
+:microshift-version: 4.22
 :rhde: Red{nbsp}Hat Device Edge
 :ansible: Red{nbsp}Hat Ansible Automation Platform
 :ansible-version: 2.5

--- a/modules/about-rhde.adoc
+++ b/modules/about-rhde.adoc
@@ -21,12 +21,14 @@ For a non-technical description of {product-title}, see link:https://www.redhat.
 
 The latest release notes for each product that is part of {product-title} are available at the following links:
 
-* link:https://docs.redhat.com/en/documentation/red_hat_build_of_microshift/{microshift-version}/html/red_hat_build_of_microshift_release_notes/index[{microshift-first}]
+* link:https://docs.redhat.com/en/documentation/red_hat_build_of_microshift/4.22/html/red_hat_build_of_microshift_release_notes[{microshift-first} release notes]
 
-* link:https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/{op-system-version-major}/html/9.2_release_notes/index[{op-system-first}] 9.2 release notes.
+* link:https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9/html/9.2_release_notes[9.2 release notes]
 
-* link:https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/{op-system-version-major}/html/9.4_release_notes/index[{op-system-first}] 9.4 release notes.
+* link:https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9/html/9.4_release_notes[9.4 release notes]
 
-* link:https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/{op-system-version-major}/html/9.6_release_notes/index[{op-system-first}] 9.6 release notes.
+* link:https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9/html/9.6_release_notes[9.6 release notes]
 
-* link:https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/{ansible-version}/html/red_hat_ansible_automation_platform_release_notes/index[{ansible} Release Notes]
+* link:https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9/html/9.8_release_notes[9.8 release notes]
+
+* link:https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.7/whats_new-overview_of_redhat_ansible_intro[{ansible} release notes]

--- a/modules/microshift-rhde-compatibility-table-ref.adoc
+++ b/modules/microshift-rhde-compatibility-table-ref.adoc
@@ -24,17 +24,29 @@ Be sure to check the support status of a release on the product lifecycle page.
 ^|*{microshift-short} Version*
 ^|*Supported {microshift-short} Version{nbsp}->{nbsp}Version Updates*
 
-^|10.0
+^|10.2
+^|4.22
+^|4.22.0{nbsp}->{nbsp}4.22.z (Technology Preview)
+
+^|9.8
+^|4.22
+^|4.22.0{nbsp}->{nbsp}4.22.z
+
+^|9.8
 ^|4.21
-^|4.21.0{nbsp}->{nbsp}4.21.z (Technology Preview)
+^|4.21.0{nbsp}->{nbsp}4.21.z, 4.21{nbsp}->{nbsp}4.22
+
+^|9.8
+^|4.20
+^|4.22.0{nbsp}->{nbsp}4.22.z, 4.22 on {op-system-base} 9.8{nbsp}->{nbsp}4.22 on {op-system-base} 10.2 (Technology Preview)
 
 ^|9.6
 ^|4.21
-^|4.21.0{nbsp}->{nbsp}4.21.z
+^|4.21.0{nbsp}->{nbsp}4.21.z, 4.21{nbsp}->{nbsp}4.22, 4.21{nbsp}->{nbsp}4.22 on {op-system-base} 9.8, 4.21{nbsp}->{nbsp}4.22 on {op-system-base} 10.2 (Technology Preview)
 
 ^|9.6
 ^|4.20
-^|4.20.0{nbsp}->{nbsp}4.20.z, 4.20{nbsp}->{nbsp}4.21
+^|4.20.0{nbsp}->{nbsp}4.20.z, 4.20{nbsp}->{nbsp}4.21, 4.20{nbsp}->{nbsp}4.22 on {op-system-base} 10.2 (Technology Preview)
 
 ^|9.6
 ^|4.19
@@ -51,8 +63,4 @@ Be sure to check the support status of a release on the product lifecycle page.
 ^|9.4
 ^|4.16
 ^|4.16.0{nbsp}->{nbsp}4.16.z, 4.16{nbsp}->4.17, 4.16{nbsp}->{nbsp}4.18
-
-^|9.2
-^|4.14
-^|4.14.0{nbsp}->{nbsp}4.14.z, 4.14{nbsp}->{nbsp}4.16 on {op-system-base} 9.4
 |===


### PR DESCRIPTION
Issue:
https://redhat.atlassian.net/browse/OSDOCS-18289

Link to docs preview:
https://112489--ocpdocs-pr.netlify.app/openshift-rhde/latest/overview/rhde-overview.html

Approvals can be found at https://github.com/openshift/openshift-docs/pull/111809

Additional information:
NOTE: RHDE is not planned for migration so errors can be ignored.