### PR TITLE
[OSDOCS#17878]Remove url for requestInit to fix broken link_CQA jobs

### DIFF
--- a/modules/dynamic-plugin-api.adoc
+++ b/modules/dynamic-plugin-api.adoc
@@ -721,7 +721,8 @@ for cluster-scoped resources.
 URL.
 
 |`options.requestInit` |The fetch init object to use. This can have
-request headers, method, redirect, etc. See link:{power-bi-url}[Interface RequestInit] for more.
+request headers, method, redirect, etc. 
+// See link:{power-bi-url}[Interface RequestInit] for more.
 |===
 
 


### PR DESCRIPTION
Version(s):
4.21+

Issue:
https://redhat.atlassian.net/browse/OSDOCS-17878

Link to docs preview:
[Dynamic plugin reference > k8sGetResource_ROSA HCP](https://112499--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/web_console/dynamic-plugin/dynamic-plugins-reference.html#k8sgetresource)
[Dynamic plugin reference > k8sGetResource_Classic](https://112499--ocpdocs-pr.netlify.app/openshift-rosa/latest/web_console/dynamic-plugin/dynamic-plugins-reference.html#k8sgetresource)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
