### PR TITLE
CNV-80383: Add 7 CNV release notes for 4.22

### DIFF
--- a/virt/release_notes/virt-4-22-release-notes.adoc
+++ b/virt/release_notes/virt-4-22-release-notes.adoc
@@ -74,15 +74,57 @@ link:https://redhat.atlassian.net/browse/CNV-72621[CNV-72621]
 
 // Storage
 
+Configure predictable PVC and DV names when cloning VMs::
++
+Virtual machine (VM) owners and cluster administrators can configure predictable persistent volume claim (PVC) and data volume (DV) names when cloning a VM. Use the `volumeNamePolicy` to include the target VM name in the restored PVC names to maintain consistency and manageability of the storage resources. This improves compatibility with orchestrators that rely on the original DV name after restoration.
++
+link:https://redhat.atlassian.net/browse/CNV-76230[CNV-76230]
+
+Keep original PVC names when restoring a virtual machine from a VM snapshot::
++
+Virtual machine (VM) owners who restore a VM from a snapshot can retain the original names of persistent volume claims (PVCs). You can use the *In place Volume Restore Policy* section of the *Restore Snapshot* dialog in the web console to preserve the PVC names. This sets the `spec.volumeRestorePolicy` field on the `VirtualMachineRestore` resource. If users opt not to keep the original PVC name, {VirtProductName} assigns a randomized PVC name.
++
+link:https://redhat.atlassian.net/browse/CNV-71612[CNV-71612]
+
 New default for PVC naming during VM restore and clone requests::
 +
 With this update, the `volumeRestorePolicy` default setting has been changed to `PrefixTargetName`. This means that the name of the target virtual machine (VM) is now used as a prefix for new PVC names created with VM restore and clone requests.
 +
 link:https://redhat.atlassian.net/browse/CNV-77397[CNV-77397]
 
+Insert and eject CD-ROMs in a live VM::
++
+{VirtProductName} support for declarative hot plug of CD-ROM storage devices in live virtual machines (VMs) is generally available. You can insert and eject CD-ROM storage in running VMs by enabling the `DeclarativeHotplugVolumes` feature gate in the `HyperConverged` custom resource (CR) without restarting the VM.
++
+link:https://redhat.atlassian.net/browse/CNV-68916[CNV-68916]
+
 
 
 // Web console
+
+Configure AAQ to track resource utilization for VMs and mixed workloads::
++
+Cluster administrators can use the Application-Aware Quota (AAQ) Operator in the {product-title} web console as the primary mechanism for defining and managing resource limits for virtual machines (VMs) and mixed workloads. You can configure AAQ to track resource utilization for VMs only, for both pods and VMs together, or for VMs and pods separately with dedicated quotas for each.
++
+link:https://redhat.atlassian.net/browse/CNV-61720[CNV-61720]
+
+Configure a run strategy for virtual machines in the web console::
++
+Virtual machine (VM) owners can configure and edit a run strategy that models how the VMs behave after a shutdown, restart, or a failure. You can choose a run strategy from `Rerun on failure`, `Always`, `Halted`, and `Manual` in the *Scheduling* tab of the {VirtProductName} user interface. You can edit the run strategy across all VM creation flows and the details view for a streamlined experience when customizing VMs.
++
+link:https://redhat.atlassian.net/browse/CNV-82452[CNV-82452]
+
+Export virtual machine data in CSV format for inventory management::
++
+You can export virtual machine (VM) information such as hostname, IP address, node name, namespace, memory, disk, operating system version, and more in CSV format to efficiently manage the inventory. You can also customize the view of VM tables by using automated sorting and built-in column filtering capabilities.
++
+link:https://redhat.atlassian.net/browse/CNV-74276[CNV-74276]
+
+Hide YAML tab on virtual machines::
++
+Administrators can hide the YAML tab on virtual machines (VM) and other resources to prevent users from directly editing the YAML from the user interface, enhancing security and reducing potential errors. As a result, you can ensure that configuration changes are made through approved channels, maintaining consistency and compliance across the system.
++
+link:https://redhat.atlassian.net/browse/CNV-74216[CNV-74216]
 
 Removed deprecated label from localnet network attachment definition type::
 The web console no longer displays a *Deprecated* label next to the localnet `NetworkAttachmentDefinition` (NAD) type. This change clarifies that localnet NAD functionality is not deprecated and remains fully supported. You can use either the NAD-based approach or the VM network wizard to create localnet networks for connecting virtual machines to physical networks.


### PR DESCRIPTION
Version(s):
4.22

Issue:
https://redhat.atlassian.net/browse/CNV-76230
https://redhat.atlassian.net/browse/CNV-71612
https://redhat.atlassian.net/browse/CNV-68916
https://redhat.atlassian.net/browse/CNV-61720
https://redhat.atlassian.net/browse/CNV-82452
https://redhat.atlassian.net/browse/CNV-74276
https://redhat.atlassian.net/browse/CNV-74216

Link to docs preview:
https://112502--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/release_notes/virt-4-22-release-notes.html

QE review:
- [x] QE has approved this change.

Additional information:
Adds 7 CNV release notes for OpenShift Virtualization 4.22 covering enhancements in storage, networking, and web console functionality.

---

🤖 Generated with Claude Code