### PR TITLE
OBSDOCS-3467: Use OCP product name for schema feature version gate

### DIFF
--- a/modules/installing-the-logging-ui-plug-in-cli.adoc
+++ b/modules/installing-the-logging-ui-plug-in-cli.adoc
@@ -48,7 +48,7 @@ where:
 ====
 These are the known issues for the logging UI plugin. For more information, see link:https://issues.redhat.com/browse/OU-587[OU-587].
 
-* The `schema` feature is only supported in {product-title} 4.15 and later. In earlier versions of {product-title}, the logging UI plugin will only use the `viaq` attribute, ignoring any other values that might be set.
+* The `schema` feature is only supported in {ocp-product-title} 4.15 and later. In earlier versions of {ocp-product-title}, the logging UI plugin will only use the `viaq` attribute, ignoring any other values that might be set.
 * Non-administrator users cannot query logs using the `otel` attribute with {logging} {for} versions 5.8 to 6.2. This issue will be fixed in a future {logging} release. (link:https://issues.redhat.com/browse/LOG-6589[LOG-6589])
 * In {logging} {for} version 5.9, the `severity_text` Otel attribute is not set.
 ====


### PR DESCRIPTION
## Summary
- Fix incorrect product name in the CLI UI plugin known-issues note for the `schema` feature.
- Replace `{product-title}` with `{ocp-product-title}` in the CLI install module so the version gate references OpenShift Container Platform 4.15+, not Red Hat OpenShift Logging 4.15+.
- Aligns the CLI section with the web console module, which already uses `{ocp-product-title}`.

## Jira
https://redhat.atlassian.net/browse/OBSDOCS-3467

## Test plan
- [ ] Build/review Installing logging 6.5
- [ ] Confirm the CLI UI plugin section (§1.2.3) and web console section (§1.3.3) both render "OpenShift Container Platform 4.15"