### PR TITLE
OSDOCS-18179-etcd-tavery:Bug Batching

### DIFF
--- a/modules/rn-ocp-release-notes-fixed-issues.adoc
+++ b/modules/rn-ocp-release-notes-fixed-issues.adoc
@@ -68,9 +68,12 @@ The following issues are fixed for this release:
 // == Dev Console
 
 
-// [id="rn-ocp-release-note-etcd-fixed-issues_{context}"]
-// == etcd
+[id="rn-ocp-release-note-etcd-fixed-issues_{context}"]
+== etcd
 
+* Before this update, the etcd Operator randomly removed control plane nodes, which caused duplication and potential cluster downtime. As a consequence, service disruptions might have caused the loss of control plane nodes in the etcd cluster. With this release, the etcd Operator prioritizes removing members in the same failure domain index, which reduces potential duplication and improves cluster stability. As a result, the etcd Operator ensures that the control plane remains stable with three nodes, which prevents potential service disruptions. (link:https://issues.redhat.com/browse/OCPBUGS-73857[OCPBUGS-73857])
+
+* Before this update, the etcd Operator allowed member deletion and removed pre-drain hooks during a revision rollout. As a consequence, cluster degradation occurred during simultaneous machine deletion, causing API unavailability. With this release, the Cluster Member Removal Controller logic is updated to prevent deletion during a revision rollout. As a result, cluster degradation during the `OnDelete` rollout is fixed, ensuring smooth vertical scaling. (link:https://issues.redhat.com/browse/OCPBUGS-74151[OCPBUGS-74151])
 
 // [id="rn-ocp-release-note-extensions-olmv1-fixed-issues_{context}"]
 // == Extensions ({olmv1})


### PR DESCRIPTION
Version(s):
4.22

Issue:
https://redhat.atlassian.net/browse/OSDOCS-18179

Link to docs preview:
https://112517--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-22-release-notes.html#rn-ocp-release-note-etcd-fixed-issues_release-notes