### PR TITLE
OSDOCS-1680-fix# Remove limitation re datastore migration

### DIFF
--- a/modules/persistent-storage-csi-vsphere-limitations.adoc
+++ b/modules/persistent-storage-csi-vsphere-limitations.adoc
@@ -11,6 +11,4 @@ The following limitations apply to the vSphere Container Storage Interface (CSI)
 
 * The vSphere CSI Driver supports dynamic and static provisioning. However, when using static provisioning in the PV specifications, do not use the key `storage.kubernetes.io/csiProvisionerIdentity` in `csi.volumeAttributes` because this key indicates dynamically provisioned PVs.
 
-* Migrating persistent container volumes between datastores using the vSphere client interface is not supported with {product-title}.
-
 * {product-title} does not support restoring volume snapshots in a topology domain that does not have access to the datastore where the snapshot resides. You must manually schedule pods that use a persistent volume claim (PVC) that restore a snapshot to a region and zone with the snapshot. Using a shared datastore across all regions and zones meets this requirement.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.19+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: Fix for this vSphere datastore migration feature
https://redhat.atlassian.net/browse/OSDOCS-12143
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

The main branch **removes** the datastore limitation and **adds** the snapshot limitation specific to 4.22. When I cherry-pick back to 4.21–4.19, I will remove the 4.22 snapshot limitation during conflict resolution, so those legacy branches only reflect the datastore limitation removal.

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->

**PTAL**:  @gnufied @gcharot @jsafrane 
