### PR TITLE
OCPBUGS-87224: Fix grammar in Route 53 zone ID parameter description

### DIFF
--- a/modules/installation-creating-aws-dns.adoc
+++ b/modules/installation-creating-aws-dns.adoc
@@ -90,7 +90,7 @@ config files for the cluster.
 <4> Specify the infrastructure name that you extracted from the Ignition config
 file metadata, which has the format `<cluster-name>-<random-string>`.
 <5> The Route 53 public zone ID to register the targets with.
-<6> Specify the Route 53 public zone ID, which as a format similar to
+<6> Specify the Route 53 public zone ID, which has a format similar to
 `Z21IXYZABCZ2A4`. You can obtain this value from the AWS console.
 <7> The Route 53 zone to register the targets with.
 <8> Specify the Route 53 base domain that you used when you generated the


### PR DESCRIPTION
## Summary

- Fix "which as a format" to "which has a format" in the Route 53 public zone ID parameter description

One-word typo in `modules/installation-creating-aws-dns.adoc` line 93. This module is used by both the standard AWS UPI and the restricted-network AWS UPI installation procedures.

Bug: https://issues.redhat.com/browse/OCPBUGS-87224
