### PR TITLE
OSDOCS-19948: Fix incorrect SNO terminology in install guide

### DIFF
--- a/installing/installing_sno/install-sno-installing-sno.adoc
+++ b/installing/installing_sno/install-sno-installing-sno.adoc
@@ -7,7 +7,7 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 ifndef::openshift-origin[]
-You can install {sno} by using either the web-based Assisted Installer or the `coreos-installer` tool to generate a discovery ISO image. The discovery ISO image writes the {op-system-first} system configuration to the target installation disk, so that you can run a single-cluster node to meet your needs.
+You can install {sno} by using either the web-based Assisted Installer or the `coreos-installer` tool to generate a discovery ISO image. The discovery ISO image writes the {op-system-first} system configuration to the target installation disk, so that you can run a single-node cluster to meet your needs.
 
 Consider using {sno} when you want to run a cluster in a low-resource or an isolated environment for testing, troubleshooting, training, or small-scale project purposes.
 


### PR DESCRIPTION
## Summary
- Replace incorrect phrase "single-cluster node" with "single-node cluster" in the SNO installation guide.

## Jira
https://redhat.atlassian.net/browse/OSDOCS-19948

## Affected doc
https://content-preview.docs.redhat.com/en/documentation/openshift_container_platform/4.22/html/installing_on_a_single_node/index

## Test plan
- [ ] Build/preview `installing/installing_sno/install-sno-installing-sno.adoc`
- [ ] Confirm rendered text reads "...run a single-node cluster to meet your needs."

