### PR TITLE
TELCODOCS-2894: Update SNO vDU minimum to 4 vCPU with headroom guidance

### DIFF
--- a/edge_computing/ztp-reference-cluster-configuration-for-vdu.adoc
+++ b/edge_computing/ztp-reference-cluster-configuration-for-vdu.adoc
@@ -19,6 +19,12 @@ include::modules/ztp-low-latency.adoc[leveloffset=+1]
 
 include::modules/ztp-install-sno-hardware-reqs.adoc[leveloffset=+1]
 
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../installing/overview/cluster-capabilities.adoc#cluster-capabilities[Cluster capabilities]
+* xref:../scalability_and_performance/cnf-tuning-low-latency-nodes-with-perf-profile.adoc#cnf-tuning-low-latency-nodes-with-perf-profile[Tuning nodes for low latency with the performance profile]
+
 include::modules/ztp-du-host-firmware-requirements.adoc[leveloffset=+1]
 
 include::modules/ztp-managed-cluster-network-prereqs.adoc[leveloffset=+1]

--- a/modules/ztp-install-sno-hardware-reqs.adoc
+++ b/modules/ztp-install-sno-hardware-reqs.adoc
@@ -1,18 +1,35 @@
 // Module included in the following assemblies:
 //
-// * scalability_and_performance/ztp_far_edge/ztp-reference-cluster-configuration-for-vdu.adoc
+// * edge_computing/ztp-reference-cluster-configuration-for-vdu.adoc
 
+:_mod-docs-content-type: CONCEPT
 [id="ztp-install-sno-hardware-reqs_{context}"]
 = Recommended cluster host requirements for vDU application workloads
 
+[role="_abstract"]
 Running vDU application workloads requires a bare-metal host with sufficient resources to run {product-title} services and production workloads.
 
 .Minimum resource requirements
 [options="header"]
 |====
 |Profile|vCPU|Memory|Storage
-|Minimum|4 to 8 vCPU|32GB of RAM| 120GB
+|Minimum|4 vCPU|32 GB of RAM|120 GB
+|Recommended|8 vCPU|32 GB of RAM|120 GB
 |====
+
+[IMPORTANT]
+====
+Running {sno} on 4 vCPUs leaves very little headroom for vDU application workloads.
+With all cluster capabilities enabled, the platform alone can request over 2.5 vCPUs and consume over 2 vCPUs at idle, leaving minimal capacity for application workloads.
+====
+
+To run on 4 vCPUs, you must minimize the cluster resource footprint:
+
+* Set `baselineCapabilitySet` to `None` in the `install-config.yaml` file and use `additionalEnabledCapabilities` to enable only the capabilities that your workload requires, such as `Storage`, `Console`, and `Ingress`. For more information, see "Cluster capabilities".
+
+* Use a performance profile to partition CPU resources between cluster housekeeping duties and application workloads, ensuring that your vDU containers run on isolated CPUs with minimal interruption. For more information, see "Tuning nodes for low latency with the performance profile".
+
+If your deployment does not require these optimizations, it is recommended to use at least 8 vCPUs..
 
 [NOTE]
 ====


### PR DESCRIPTION
[TELCODOCS-2894]: Update SNO vDU minimum to 4 vCPU with headroom guidance.

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.22 and main
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:https://redhat.atlassian.net/browse/Update SNO vDU minimum to 4 vCPU with headroom guidance
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://112543--ocpdocs-pr.netlify.app/openshift-enterprise/latest/edge_computing/ztp-reference-cluster-configuration-for-vdu.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->

## Summary
- Updates the vDU SNO hardware requirements table to show 4 vCPU as the minimum and 8 vCPU as recommended
- Adds an IMPORTANT admonition explaining the resource constraints at 4 vCPU, with specific guidance on:
  - Disabling optional cluster capabilities via `baselineCapabilitySet: None` to reduce platform overhead
  - Using performance profiles to partition CPUs between cluster housekeeping and application workloads
- Includes approximate resource consumption figures from SNO resource usage testing (OCP 4.20) — SME to decide whether these specific numbers should be retained or generalized

## References
- [TELCODOCS-2894](https://redhat.atlassian.net/browse/TELCODOCS-2894): Update SNO Minimum to reflect support for 4vCPU
- [OCPSTRAT-1936](https://redhat.atlassian.net/browse/OCPSTRAT-1936): Support SNO with 4 Threads compute capacity
- Resource data sourced from OCP V4.20 SNO Resource Usage Comparison testing

## Test plan
- [ ] Verify AsciiDoc renders correctly with `asciibinder build`
- [ ] SME review: confirm whether specific resource consumption numbers (2.5 vCPU requested, 2.2 vCPU with minimal capabilities) should be kept or generalized
- [ ] Verify cross-references to "Cluster capabilities" and "Tuning nodes for low latency with the performance profile" resolve correctly in the published docs