### PR TITLE
docs: Document CustomNoUpgrade featureSet in the feature gates user guide

### DIFF
--- a/modules/nodes-cluster-enabling-features-about.adoc
+++ b/modules/nodes-cluster-enabling-features-about.adoc
@@ -11,13 +11,20 @@ You can use the `FeatureGate` custom resource (CR) to enable specific feature se
 
 A feature set is a collection of {product-title} features that are not enabled by default.
 
-You can activate the following feature set by using the `FeatureGate` CR:
+You can activate the following feature sets by using the `FeatureGate` CR:
 
 * `TechPreviewNoUpgrade`. This feature set is a subset of the current Technology Preview features. This feature set allows you to enable these Technology Preview features on test clusters, where you can fully test them, while leaving the features disabled on production clusters.
 +
 [WARNING]
 ====
 Enabling the `TechPreviewNoUpgrade` feature set on your cluster cannot be undone and prevents minor version updates. You should not enable this feature set on production clusters.
+====
+
+* `CustomNoUpgrade`. This feature set allows you to enable or disable individual feature gates without activating the entire Technology Preview suite. Use this feature set when you need granular control over specific feature gates.
++
+[WARNING]
+====
+Enabling the `CustomNoUpgrade` feature set on your cluster cannot be undone and prevents minor version updates. This feature set is not supported, cannot be validated, and should not be enabled on production clusters. If you apply incorrect feature gate names or invalid combinations, your cluster may fail in an unrecoverable way.
 ====
 +
 The following Technology Preview features are enabled by this feature set:
@@ -128,20 +135,12 @@ The following Technology Preview features are enabled by this feature set:
 
 See the _Additional resources_ sections for information on some of these features.
 
-////
-Do not document per Derek Carr: https://github.com/openshift/api/pull/370#issuecomment-510632939
-|`CustomNoUpgrade` ^[2]^
-|Allows the enabling or disabling of any feature. Turning on this feature set on is not supported, cannot be undone, and prevents upgrades.
-
-[.small]
---
-1.
-2. If you use the `CustomNoUpgrade` feature set to disable a feature that appears in the web console, you might see that feature, but
-no objects are listed. For example, if you disable builds, you can see the *Builds* tab in the web console, but there are no builds present. If you attempt to use commands associated with a disabled feature, such as `oc start-build`, {product-title} displays an error.
-
-[NOTE]
-====
-If you disable a feature that any application in the cluster relies on, the application might not
-function properly, depending upon the feature disabled and how the application uses that feature.
-====
-////
+// Historical note: CustomNoUpgrade was previously excluded from documentation per
+// https://github.com/openshift/api/pull/370#issuecomment-510632939 (July 2019).
+// Since then, CustomNoUpgrade has become widely used across the ecosystem:
+// - OCP 4.16 release notes reference it for Cluster API on GCP
+// - Red Hat KCS articles 7065352 and 7074157 address customer usage
+// - OCPSTRAT-2485 (4.22) relies on it for CVO manifest gating
+// - Multiple OpenShift component teams use it in their documentation
+// The decision to document it was made to address documented customer confusion
+// and to align with current usage patterns.

--- a/modules/nodes-cluster-enabling-features-cli-custom.adoc
+++ b/modules/nodes-cluster-enabling-features-cli-custom.adoc
@@ -31,12 +31,7 @@ $ oc patch featuregate cluster --type=merge -p \
   '{"spec":{"featureSet":"CustomNoUpgrade","customNoUpgrade":{"enabled":["<feature_gate_name>"]}}}'
 ----
 +
-where `<feature_gate_name>` is the name of the feature gate you want to enable, for example `ClusterAPIMachineManagement`.
-+
-[NOTE]
-====
-The `spec.customNoUpgrade.enabled` field accepts a string array. Each element is a feature gate name as a plain string. Do not use the object format `{"name": "FeatureGateName"}`. The object format is used in `status.featureGates` but is not valid for the spec.
-====
+where `<feature_gate_name>` is the name of the feature gate you want to enable, for example `ClusterAPIMachineManagement`. The `spec.customNoUpgrade.enabled` field accepts a string array. Each element is a feature gate name as a plain string. Do not use the object format `{"name": "FeatureGateName"}`, which appears in `status.featureGates` but is not valid for the spec.
 
 . To enable multiple feature gates at once:
 +
@@ -74,18 +69,19 @@ kind: FeatureGate
 metadata:
   name: cluster
 spec:
-  featureSet: CustomNoUpgrade <1>
+  featureSet: CustomNoUpgrade
   customNoUpgrade:
-    enabled: <2>
+    enabled:
       - <feature_gate_name>
-    disabled: <3>
+    disabled:
       - <feature_gate_name>
 ----
+where:
 +
 --
-<1> Must be set to `CustomNoUpgrade` to use the `customNoUpgrade` field.
-<2> A list of feature gate names to enable, specified as plain strings.
-<3> Optional. A list of feature gate names to explicitly disable.
+`spec.featureSet`:: Must be set to `CustomNoUpgrade` to use the `customNoUpgrade` field.
+`spec.customNoUpgrade.enabled`:: A list of feature gate names to enable, specified as plain strings.
+`spec.customNoUpgrade.disabled`:: Optional. A list of feature gate names to explicitly disable.
 --
 +
 After you save the changes, new machine configs are created, the machine config pools are updated, and scheduling on each node is disabled while the change is being applied.

--- a/modules/nodes-cluster-enabling-features-cli-custom.adoc
+++ b/modules/nodes-cluster-enabling-features-cli-custom.adoc
@@ -1,0 +1,110 @@
+// Module included in the following assemblies:
+//
+// * nodes/cluster/nodes-cluster-enabling-features.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="nodes-cluster-enabling-features-cli-custom_{context}"]
+= Enabling individual feature gates using the CustomNoUpgrade feature set
+
+[role="_abstract"]
+You can use the {oc-first} to enable or disable individual feature gates on your cluster by setting the `CustomNoUpgrade` feature set on the `FeatureGate` custom resource (CR). Unlike `TechPreviewNoUpgrade`, which enables all Technology Preview features, `CustomNoUpgrade` gives you granular control over individual feature gates.
+
+[WARNING]
+====
+Enabling the `CustomNoUpgrade` feature set on your cluster cannot be undone and prevents minor version updates. Once applied, you cannot revert the `featureSet` field back to its default value. You can continue to modify the individual gates within `customNoUpgrade.enabled` and `customNoUpgrade.disabled`, but the `CustomNoUpgrade` feature set itself is permanent.
+
+This feature set is not supported for production clusters. Because of its nature, this setting cannot be validated. If you have any typos or accidentally apply invalid combinations, your cluster may fail in an unrecoverable way.
+====
+
+.Prerequisites
+
+* You have installed the {oc-first}.
+* You have cluster administrator privileges.
+
+.Procedure
+
+. Enable a specific feature gate by patching the `FeatureGate` CR:
++
+[source,terminal]
+----
+$ oc patch featuregate cluster --type=merge -p \
+  '{"spec":{"featureSet":"CustomNoUpgrade","customNoUpgrade":{"enabled":["<feature_gate_name>"]}}}'
+----
++
+where `<feature_gate_name>` is the name of the feature gate you want to enable, for example `ClusterAPIMachineManagement`.
++
+[NOTE]
+====
+The `spec.customNoUpgrade.enabled` field accepts a string array. Each element is a feature gate name as a plain string. Do not use the object format `{"name": "FeatureGateName"}`. The object format is used in `status.featureGates` but is not valid for the spec.
+====
+
+. To enable multiple feature gates at once:
++
+[source,terminal]
+----
+$ oc patch featuregate cluster --type=merge -p \
+  '{"spec":{"featureSet":"CustomNoUpgrade","customNoUpgrade":{"enabled":["<feature_gate_1>","<feature_gate_2>"]}}}'
+----
+
+. To remove a previously enabled feature gate from the enabled list:
++
+[source,terminal]
+----
+$ oc patch featuregate cluster --type=merge -p \
+  '{"spec":{"customNoUpgrade":{"enabled":[]}}}'
+----
++
+[NOTE]
+====
+This removes all individually enabled gates but does not revert the `CustomNoUpgrade` feature set. The cluster remains on `CustomNoUpgrade` and minor version upgrades remain blocked.
+====
+
+. Alternatively, you can enable the feature set by editing the `FeatureGate` CR directly:
++
+[source,terminal]
+----
+$ oc edit featuregate cluster
+----
++
+.Sample FeatureGate custom resource with CustomNoUpgrade
+[source,yaml]
+----
+apiVersion: config.openshift.io/v1
+kind: FeatureGate
+metadata:
+  name: cluster
+spec:
+  featureSet: CustomNoUpgrade <1>
+  customNoUpgrade:
+    enabled: <2>
+      - <feature_gate_name>
+    disabled: <3>
+      - <feature_gate_name>
+----
++
+--
+<1> Must be set to `CustomNoUpgrade` to use the `customNoUpgrade` field.
+<2> A list of feature gate names to enable, specified as plain strings.
+<3> Optional. A list of feature gate names to explicitly disable.
+--
++
+After you save the changes, new machine configs are created, the machine config pools are updated, and scheduling on each node is disabled while the change is being applied.
+
+[NOTE]
+====
+The syntax for enabling feature gates differs between the `install-config.yaml` file and the `FeatureGate` CR:
+
+* In `install-config.yaml`, use `featureGates: ["<feature_gate_name>=true"]`
+* In the `FeatureGate` CR at runtime, use `customNoUpgrade.enabled: ["<feature_gate_name>"]`
+====
+
+.Verification
+
+include::snippets/nodes-cluster-enabling-features-verification.adoc[]
+
+You can also verify the enabled feature gates by checking the `FeatureGate` CR status:
+
+[source,terminal]
+----
+$ oc get featuregate cluster -o jsonpath='{.status.featureGates[0].enabled[*].name}' | tr ' ' '\n'
+----

--- a/modules/nodes-cluster-enabling-features-cli.adoc
+++ b/modules/nodes-cluster-enabling-features-cli.adoc
@@ -45,7 +45,7 @@ where:
 
 `spec.featureSet`:: Specifies the feature set that you want to enable:
 * `TechPreviewNoUpgrade` enables specific Technology Preview features.
-* `CustomNoUpgrade` enables granular control over individual feature gates. See xref:../../nodes/clusters/nodes-cluster-enabling-features.adoc#nodes-cluster-enabling-features-cli-custom_nodes-cluster-enabling[Enabling individual feature gates using the CustomNoUpgrade feature set].
+* `CustomNoUpgrade` enables granular control over individual feature gates.
 --
 +
 After you save the changes, new machine configs are created, the machine config pools are updated, and scheduling on each node is disabled while the change is being applied.

--- a/modules/nodes-cluster-enabling-features-cli.adoc
+++ b/modules/nodes-cluster-enabling-features-cli.adoc
@@ -45,6 +45,7 @@ where:
 
 `spec.featureSet`:: Specifies the feature set that you want to enable:
 * `TechPreviewNoUpgrade` enables specific Technology Preview features.
+* `CustomNoUpgrade` enables granular control over individual feature gates. See xref:../../nodes/clusters/nodes-cluster-enabling-features.adoc#nodes-cluster-enabling-features-cli-custom_nodes-cluster-enabling[Enabling individual feature gates using the CustomNoUpgrade feature set].
 --
 +
 After you save the changes, new machine configs are created, the machine config pools are updated, and scheduling on each node is disabled while the change is being applied.

--- a/modules/nodes-cluster-enabling-features-console.adoc
+++ b/modules/nodes-cluster-enabling-features-console.adoc
@@ -45,7 +45,7 @@ where:
 
 `spec.featureSet`:: Specifies the feature set that you want to enable:
 * `TechPreviewNoUpgrade` enables specific Technology Preview features.
-* `CustomNoUpgrade` enables granular control over individual feature gates. See xref:../../nodes/clusters/nodes-cluster-enabling-features.adoc#nodes-cluster-enabling-features-cli-custom_nodes-cluster-enabling[Enabling individual feature gates using the CustomNoUpgrade feature set].
+* `CustomNoUpgrade` enables granular control over individual feature gates.
 --
 +
 After you save the changes, new machine configs are created, the machine config pools are updated, and scheduling on each node is disabled while the change is being applied.

--- a/modules/nodes-cluster-enabling-features-console.adoc
+++ b/modules/nodes-cluster-enabling-features-console.adoc
@@ -45,6 +45,7 @@ where:
 
 `spec.featureSet`:: Specifies the feature set that you want to enable:
 * `TechPreviewNoUpgrade` enables specific Technology Preview features.
+* `CustomNoUpgrade` enables granular control over individual feature gates. See xref:../../nodes/clusters/nodes-cluster-enabling-features.adoc#nodes-cluster-enabling-features-cli-custom_nodes-cluster-enabling[Enabling individual feature gates using the CustomNoUpgrade feature set].
 --
 +
 After you save the changes, new machine configs are created, the machine config pools are updated, and scheduling on each node is disabled while the change is being applied.

--- a/nodes/clusters/nodes-cluster-enabling-features.adoc
+++ b/nodes/clusters/nodes-cluster-enabling-features.adoc
@@ -17,6 +17,8 @@ include::modules/nodes-cluster-enabling-features-console.adoc[leveloffset=+1]
 
 include::modules/nodes-cluster-enabling-features-cli.adoc[leveloffset=+1]
 
+include::modules/nodes-cluster-enabling-features-cli-custom.adoc[leveloffset=+1]
+
 [role="_additional-resources"]
 [id="additional-resources_nodes-cluster-enabling"]
 == Additional resources

--- a/nodes/clusters/nodes-cluster-enabling-features.adoc
+++ b/nodes/clusters/nodes-cluster-enabling-features.adoc
@@ -38,3 +38,5 @@ include::modules/nodes-cluster-enabling-features-cli-custom.adoc[leveloffset=+1]
 * xref:../../storage/container_storage_interface/persistent-storage-csi-sc-manage.adoc#persistent-storage-csi-sc-manage[Managing the default storage class]
 
 * xref:../../authentication/understanding-and-managing-pod-security-admission.adoc#understanding-and-managing-pod-security-admission[Pod security admission enforcement]
+
+* xref:../../nodes/clusters/nodes-cluster-enabling-features.adoc#nodes-cluster-enabling-features-cli-custom_nodes-cluster-enabling[Enabling individual feature gates using the CustomNoUpgrade feature set]


### PR DESCRIPTION
## Summary

Add documentation for the `CustomNoUpgrade` featureSet to the "Enabling features using feature gates"
section of the Nodes guide. Currently, only `TechPreviewNoUpgrade` is documented. `CustomNoUpgrade` is
actively used by customers, operators, and upstream projects to enable individual feature gates, but
has no user-facing guidance.

## Changes

- Added `CustomNoUpgrade` description and WARNING callout to the "Understanding feature gates" module
  (`nodes-cluster-enabling-features-about.adoc`)
- Created new procedure module `nodes-cluster-enabling-features-cli-custom.adoc` covering:
  - `oc patch` CLI examples for enabling/disabling individual gates at runtime
  - FeatureGate CR YAML example with correct `customNoUpgrade.enabled` (`[]string`) syntax
  - NOTE clarifying that `[{"name": "..."}]` object format is invalid for the spec
  - NOTE clarifying syntax difference between `install-config.yaml` (`Name=true`) and the runtime CR (`["Name"]`)
  - Verification steps using `oc get featuregate`
- Added `CustomNoUpgrade` cross-references to CLI and web console modules
- Included the new module in the assembly (`nodes-cluster-enabling-features.adoc`)

## Why this matters

- `CustomNoUpgrade` is the **only** way to enable individual feature gates without the full TechPreview suite
- It is **irreversible** — once set, it cannot be reverted, permanently blocking minor version upgrades
- The API reference mentions the warning but it is buried — the user-facing guide where administrators
  look for instructions has **zero coverage**
- Real-world customer issues exist:
  [KCS 7074157](https://access.redhat.com/solutions/7074157) ("CustomNoUpgrade featureSet blocks the
  RHOCP 4 upgrade between minor version")
- Third-party projects document it independently with varying quality
  ([CNCF blog](https://www.cncf.io/blog/2026/03/16/registry-mirror-authentication-with-kubernetes-secrets-2/),
  [kata-containers#12864](https://github.com/kata-containers/kata-containers/issues/12864))
- [OCPSTRAT-2485](https://redhat.atlassian.net/browse/OCPSTRAT-2485) (4.22) relies on `CustomNoUpgrade` for CVO feature-gate-based manifest gating

## Historical context

A [2019 comment](https://github.com/openshift/api/pull/370#issuecomment-510632939) by @derekwaynecarr
originally categorized `CustomNoUpgrade` as "not documented". Since then, the landscape has changed:
- OCP 4.16 release notes reference `CustomNoUpgrade` for Cluster API on GCP
- Red Hat KCS articles (7065352, 7074157) address customer questions about it
- [OCPSTRAT-2485](https://redhat.atlassian.net/browse/OCPSTRAT-2485) makes it foundational for CVO manifest gating in 4.22
- OpenShift component teams (network-edge-tools, cluster-api) document it in their own repos
- The 4.10 CSI Storage docs included a `CustomNoUpgrade` YAML example

The old commented-out section in `nodes-cluster-enabling-features-about.adoc` has been replaced with a
historical note explaining why documentation is now appropriate.

## Technical detail

The `CustomNoUpgrade` featureSet is enforced via a CEL validation rule in
[openshift/api](https://github.com/openshift/api/blob/master/config/v1/types_feature.go):

```go
// +kubebuilder:validation:XValidation:rule="oldSelf == 'CustomNoUpgrade'
//   ? self == 'CustomNoUpgrade' : true",
//   message="CustomNoUpgrade may not be changed"
```

The `spec.customNoUpgrade.enabled` field is `[]string` (not `[]object`), which differs from the
`status.featureGates[].enabled` format (`[{name: "..."}]`). This type mismatch is the root cause
of user confusion and is explicitly addressed in the new documentation.

## Testing

Verified on OCP 4.22.0-rc.4 (AWS us-east-2):
- `CustomNoUpgrade` correctly enables individual feature gates
- Irreversibility confirmed (CEL validation rejects reversion)
- `oc patch` with `["GateName"]` syntax confirmed working
- `oc patch` with `[{"name":"GateName"}]` confirmed rejected with type error

## Duplicate check

No existing PR or doc bug found:
- No `openshift/openshift-docs` PR adds `CustomNoUpgrade` to the feature gates user guide
- No `OCPDOCS-*` Jira ticket references this gap

Related code PRs (not documentation):
- [openshift/cluster-version-operator#1273](https://github.com/openshift/cluster-version-operator/pull/1273) — [OCPSTRAT-2485](https://redhat.atlassian.net/browse/OCPSTRAT-2485) implementation
- [openshift/installer#7246](https://github.com/openshift/installer/pull/7246) — CustomNoUpgrade in install-config

Related: [OCPSTRAT-2485](https://redhat.atlassian.net/browse/OCPSTRAT-2485)

Made with [Cursor](https://cursor.com)