### PR TITLE
CQA fixes for Creating pipeline Runs in Pipeline as Code

### DIFF
--- a/modules/op-creating-pipeline-run-pac.adoc
+++ b/modules/op-creating-pipeline-run-pac.adoc
@@ -22,7 +22,7 @@ You can create a pipeline run definition for {pac} in your repository and match 
 
 . In the file that you created, create a YAML specification for a `PipelineRun` CR. This specification can use all features of {pipelines-shortname}.
 
-. Depending on the requirements of your pipeline run definition, complete any of the following optional steps:
+. Optional: Complete any of the following configuration steps based on your pipeline run requirements:
 
 ** Create other files with a `.yaml` or `.yml` extension in the `.tekton` directory. In these files, give definitions of resources that your pipeline run definition references, such as `Pipeline`, `Task`, or `StepAction` CRs. The {pac} resolver automatically resolves these resources and includes them in the  `PipelineRun` CR that uses your definition.
 
@@ -55,7 +55,7 @@ If your Git repository provider uses merge requests and not pull requests, a `pu
 
 ** The event matches a `pipelinesascode.tekton.dev/on-label` annotation if the pull request or push event has one of the specified labels.
 
-. Optional: Add the `pipelinesascode.tekton.dev/cancel-in-progress: "true"` annotation to enable automatic cancellation of the pipeline run in certain cases. For example, if a pull request triggers a pipeline run and then the user pushes new commits into the pull request source branch, each push triggers a new copy of the pipeline run. if you enable automatic cancellation-in-progress, after a new copy of the pipeline run starts, {pac} cancels the older run to avoid running many copies of the pipeline run at the same time. For more information about this annotation, see the "Annotations for specifying automatic cancellation-in-progress for a pipeline run" section.
+. Optional: Add the `pipelinesascode.tekton.dev/cancel-in-progress: "true"` annotation to enable automatic cancellation of the pipeline run in certain cases. For example, if a pull request triggers a pipeline run and then the user pushes new commits into the pull request source branch, each push triggers a new copy of the pipeline run. If you enable automatic cancellation-in-progress, {pac} cancels the older run after a new copy starts. This prevents many copies of the pipeline run from consuming cluster resources simultaneously. For more information about this annotation, see the "Annotations for specifying automatic cancellation-in-progress for a pipeline run" section.
 +
 .Example {pac} pipeline run definition
 [source,yaml]
@@ -108,3 +108,58 @@ spec:
 `tasks.name`:: The pipeline run specification references the `git-clone` task by name. Because of the `pipelinesascode.tekton.dev/task` annotation, the {pac} resolver resolves this reference to the `git-clone` task from {tekton-hub}.
 `params.repo_url`:: {pac} replaces the `{{ repo_url }}` dynamic variable with the URL for the Git repository.
 `params.revision`:: {pac} replaces the `{{ revision }}` dynamic variable with the revision of the branch for which {pac} started the pipeline run.
+
+.Verification
+
+. Verify that your pipeline run definition files exist in the `.tekton` directory:
++
+[source,terminal]
+----
+$ ls .tekton/
+----
++
+The output shows your `.yaml` or `.yml` files and any subdirectories containing additional pipeline resources.
++
+.Example output
+[source,terminal]
+----
+maven-build.yaml  pull-request.yml  shared-tasks/
+----
+
+. After committing and pushing the pipeline run definition to your repository, trigger a matching event such as opening a pull request or pushing to a branch that matches your annotations.
+
+. Verify that {pac} created a `PipelineRun` resource:
++
+[source,terminal]
+----
+$ oc get pipelinerun -n <namespace>
+----
++
+Replace `<namespace>` with the namespace where your `Repository` CR is configured.
++
+The output shows the `PipelineRun` resources that {pac} created from your definition.
+
+.Troubleshooting
+
+* If {pac} does not trigger the pipeline run, verify the following:
+** The webhook is correctly configured for the Git repository.
+** The secret is correctly created in your cluster.
+** The `Repository` CR exists and is correctly configured.
+** The pipeline run definition file is in the `.tekton` directory.
+** The file has a `.yaml` or `.yml` extension.
+** The event annotations match the Git event type (pull_request, push, or comment).
+** The target branch annotation matches the actual branch.
+
+* If the pipeline run fails to start, check the {pac} controller logs by using the following command with the appropriate pod name:
++
+[source,terminal]
+----
+$ oc logs pipelines-as-code-controller-<pod_id> -n openshift-pipelines
+----
++
+Replace `<pod_id>` with the unique identifier of the {pac} controller pod. To find the pod name, use `oc get pods -n openshift-pipelines`.
+
+[role="_additional-resources"]
+.Additional resources
+
+* link:https://tekton.dev/docs/pipelines/pipelineruns/[Tekton PipelineRun documentation]

--- a/modules/op-filtering-pipeline-run-using-pipelines-as-code.adoc
+++ b/modules/op-filtering-pipeline-run-using-pipelines-as-code.adoc
@@ -89,3 +89,8 @@ annotations:
 ====
 The current version of {pac} supports matching events to pull request labels only for the GitHub, Gitea, and GitLab repository hosting service providers.
 ====
+
+[role="_additional-resources"]
+.Additional resources
+
+* link:https://cel.dev/[Common Expression Language (CEL)]

--- a/modules/op-matching-pipeline-run-using-pipelines-as-code.adoc
+++ b/modules/op-matching-pipeline-run-using-pipelines-as-code.adoc
@@ -5,7 +5,6 @@
 [id="matching-pipeline-run-using-pipelines-as-code_{context}"]
 = Annotations for matching events to a pipeline run
 
-You can match different Git provider events with each pipeline run by using annotations on the pipeline run. If there are many pipeline runs matching an event, {pac} runs them in parallel and posts the results to the Git provider as soon as a pipeline run finishes.
 [role="_abstract"]
 You can match different Git provider events with each pipeline run by using annotations on the pipeline run. If there are many pipeline runs matching an event, {pac} runs them in parallel and posts the results to the Git provider as soon as a pipeline run finishes.
 
@@ -190,3 +189,9 @@ If you want to trigger the pipeline run again when using the `body` field for ev
 $ git commit --amend --no-edit && git push --force-with-lease
 ----
 ====
+
+[role="_additional-resources"]
+.Additional resources
+
+* link:https://cel.dev/[Common Expression Language (CEL)]
+* link:https://www.kubernetes.dev/docs/guide/owners/[Kubernetes OWNERS file specification]

--- a/modules/op-parameters-pipeline-run-using-pipelines-as-code.adoc
+++ b/modules/op-parameters-pipeline-run-using-pipelines-as-code.adoc
@@ -5,7 +5,6 @@
 [id="parameters-pipeline-run-using-pipelines-as-code_{context}"]
 = Dynamic variables in a pipeline run specification
 
-You can use dynamic variables in a pipeline run specification to give information about the triggering commit. You can also use these variables with the temporary GitHub App token for GitHub API operations.
 [role="_abstract"]
 You can use dynamic variables in a pipeline run specification to give information about the triggering commit. You can also use these variables with the temporary GitHub App token for GitHub API operations.
 
@@ -66,3 +65,8 @@ spec:
 ====
 On GitHub Apps, the generated installation token is available for 8 hours and scoped to the repository from where the events originate. You can configure the scope differently, but GitHub determines the expiration time.
 ====
+
+[role="_additional-resources"]
+.Additional resources
+
+* link:https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/about-authentication-with-a-github-app[GitHub App authentication]

--- a/modules/op-pipelines-as-code-resolver-annotations.adoc
+++ b/modules/op-pipelines-as-code-resolver-annotations.adoc
@@ -6,7 +6,7 @@
 = {pac} resolver annotations
 
 [role="_abstract"]
-You can use {pac} resolver annotations to reference `Task` and `Pipeline` custom resource (CR) definitions. The {pac} resolver fetches the definitions from the locations that you specify in the annotations. If there is any error while fetching the remote tasks or parsing them, {pac} stops processing the tasks.
+You can use {pac} resolver annotations to reference `Task` and `Pipeline` custom resource (CR) definitions. The {pac} resolver fetches the definitions from the locations that you specify in the annotations.
 
 If you reference a remote task in a pipeline run, or a pipeline in a `PipelineRun` or a `PipelineSpec` object, the {pac} resolver automatically resolves the referenced resource and includes it in the resulting `PipelineRun` CR.
 
@@ -14,9 +14,14 @@ If you reference a remote task in a pipeline run, or a pipeline in a `PipelineRu
 ====
 Red Hat deprecated the public instance of {tekton-hub} (`hub.tekton.dev`) and will remove it in a future release. Use link:https://artifacthub.io[{artifact-hub}] as an alternative for Tekton `Pipeline` and `Task` resources:
 
-* link:https://artifacthub.io/packages/search?repo=tekton-catalog-tasks[Tekton Catalog Tasks]  
+* link:https://artifacthub.io/packages/search?repo=tekton-catalog-tasks[Tekton Catalog Tasks]
 * link:https://artifacthub.io/packages/search?repo=tekton-catalog-pipelines[Tekton Catalog Pipelines]
 
 {artifact-hub} is open source and supports self-hosting, providing greater flexibility for managing your Tekton `Pipeline` and `Task` resources.
 ====
+
+[role="_additional-resources"]
+.Additional resources
+
+* link:https://artifacthub.io/packages/search?repo=tekton-catalog-tasks[Tekton Catalog Tasks on Artifact Hub]
 

--- a/modules/op-speccancel-pipeline-run-using-pipelines-as-code.adoc
+++ b/modules/op-speccancel-pipeline-run-using-pipelines-as-code.adoc
@@ -6,7 +6,7 @@
 = Annotations for specifying automatic cancellation-in-progress for a pipeline run
 
 [role="_abstract"]
-By default, {pac} does not cancel pipeline runs automatically. Every pipeline run that {pac} creates and starts executes until it completes. However, events that trigger pipeline runs can come in quick succession.
+Configure automatic cancellation-in-progress for pipeline runs to prevent many copies from consuming excessive cluster resources when rapid Git events occur. Use the `cancel-in-progress` annotation to automatically cancel older pipeline runs when a new copy starts for the same pull request or branch.
 
 For example, if a pull request triggers a pipeline run and then the user pushes new commits into the pull request source branch, each push triggers a new copy of the pipeline run. If several pushes happen, several copies can run, which can consume excessive cluster resources.
 
@@ -36,5 +36,10 @@ include::snippets/technology-preview.adoc[]
 ====
 * {pac} cancels a pipeline run _after_ starting a new copy of this pipeline run successfully. The `pipelinesascode.tekton.dev/cancel-in-progress` setting does _not_ ensure that only one copy of the pipeline run is executing at any time.
 
-* To enable `cancellation-in-progress` for all default pipeline runs, use the `enable-cancel-in-progress-on-pull-requests` and the `enable-cancel-in-progress-on-push` settings. These settings are available in the `platforms.openshift.pipelinesAsCode.settings` spec of the `TektonConfig` custom resource (CR) configure {pac}. 
+* To enable `cancellation-in-progress` for all default pipeline runs, use the `enable-cancel-in-progress-on-pull-requests` and the `enable-cancel-in-progress-on-push` settings. These settings are available in the `platforms.openshift.pipelinesAsCode.settings` spec of the `TektonConfig` custom resource (CR) configure {pac}.
 ====
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../pac/install-config-pipelines-as-code.adoc#customizing-pipelines-as-code-configuration_install-config-pipelines-as-code[Customizing {pac} configuration]

--- a/modules/op-using-remote-pipeline-annotations-with-pipelines-as-code.adoc
+++ b/modules/op-using-remote-pipeline-annotations-with-pipelines-as-code.adoc
@@ -44,3 +44,9 @@ metadata:
 For this example, assume the remote task found at `\https://git.provider/raw/pipeline.yaml` includes a task named `git-clone` and the task that the `my-git-clone-task.yaml` file defines is also named `git-clone`.
 
 In this case, the pipeline run executes the remote pipeline, but replaces the task named `git-clone` in the pipeline with the task you defined.
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../pac/creating-pipeline-runs-pac.adoc#pipelines-as-code-resolver-annotations_creating-pipeline-runs-pac[{pac} resolver annotations]
+* xref:../pac/creating-pipeline-runs-pac.adoc#using-remote-task-annotations-with-pipelines-as-code_creating-pipeline-runs-pac[Remote task annotations]

--- a/modules/op-using-remote-task-annotations-with-pipelines-as-code.adoc
+++ b/modules/op-using-remote-task-annotations-with-pipelines-as-code.adoc
@@ -5,9 +5,8 @@
 [id="using-remote-task-annotations-with-pipelines-as-code_{context}"]
 = Remote task annotations
 
-To include remote tasks, see the following examples of annotation:
 [role="_abstract"]
-You can include remote tasks in your pipeline runs by using specific annotations. Refer to the following examples to configure your tasks.
+Include remote tasks in your pipeline runs by using {pac} resolver annotations to reference tasks from {tekton-hub}, Artifact Hub, HTTP URLs, or local repository files. This enables task reuse across repositories without duplicating task definitions.
 
 *Reference remote tasks in {tekton-hub}*
 
@@ -90,3 +89,8 @@ pipelinesascode.tekton.dev/task: "<share/tasks/git-clone.yaml>"
 ...
 ----
 `pipelinesascode.tekton.dev/task`:: Relative path to the local file containing the task definition.
+
+[role="_additional-resources"]
+.Additional resources
+
+* link:https://artifacthub.io/packages/search?repo=tekton-catalog-tasks[Tekton Catalog Tasks on Artifact Hub]

--- a/pac/creating-pipeline-runs-pac.adoc
+++ b/pac/creating-pipeline-runs-pac.adoc
@@ -7,16 +7,11 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 [role="_abstract"]
-To create pipeline run definitions, first integrate {pac} with your repository provider and define your repository by using the `Repository` custom resource (CR).
+Automate pipeline execution triggered by Git events. Integrate {pac} with your repository provider and define your repository using the `Repository` custom resource (CR).
 
 include::modules/op-creating-pipeline-run-pac.adoc[leveloffset=+1]
 
 include::modules/op-parameters-pipeline-run-using-pipelines-as-code.adoc[leveloffset=+1]
-
-[role="_additional-resources"]
-.Additional resources
-
-* xref:../pac/using-pipelines-as-code-repos.adoc#scoping-github-token_using-pipelines-as-code-repos[Scoping the GitHub token to additional repositories]
 
 include::modules/op-pipelines-as-code-resolver-annotations.adoc[leveloffset=+1]
 
@@ -28,15 +23,13 @@ include::modules/op-matching-pipeline-run-using-pipelines-as-code.adoc[leveloffs
 
 include::modules/op-filtering-pipeline-run-using-pipelines-as-code.adoc[leveloffset=+1]
 
-
-[role="_additional-resources"]
-.Additional resources
-
-* link:https://cel.dev/[Common Expression Language (CEL)]
-
 include::modules/op-speccancel-pipeline-run-using-pipelines-as-code.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources
+
+* xref:../pac/using-pipelines-as-code-repos.adoc#scoping-github-token_using-pipelines-as-code-repos[Scoping the GitHub token to additional repositories]
+
+* link:https://cel.dev/[Common Expression Language (CEL)]
 
 * xref:../pac/install-config-pipelines-as-code.adoc#customizing-pipelines-as-code-configuration_install-config-pipelines-as-code[Customizing {pac} configuration]


### PR DESCRIPTION
[RHDEVDOCS-7229](https://redhat.atlassian.net/browse/RHDEVDOCS-7229): CQA updates for the Creating pipeline runs in  Pipelines as Code chapter

The changes primarily include:
- Added Verification and Additional Resources sections
- Updated the short description (abstracts) to fit into the recommended word count limits

Version(s): 1.22, 1.21, 1.20

Issue: [RHDEVDOCS-7229](https://redhat.atlassian.net/browse/RHDEVDOCS-7229)

Link to docs preview: https://112547--ocpdocs-pr.netlify.app/openshift-pipelines/latest/pac/creating-pipeline-runs-pac.html

QE review:
- [x] SME has approved this change.

Additional information: N/A