### PR TITLE
[RHDEVDOCS-7633] Release notes for Pipelines 1.21.2

### DIFF
--- a/modules/op-release-notes-1-21-2.adoc
+++ b/modules/op-release-notes-1-21-2.adoc
@@ -1,0 +1,71 @@
+// This module is included in the following assemblies:
+// * release_notes/op-release-notes-1-21.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="op-release-notes-1-21-2_{context}"]
+= Release notes for {pipelines-title} 1.21.2
+
+[role="_abstract"]
+With this update, {pipelines-title} General Availability (GA) 1.21.2 is available on {OCP} 4.14 and later supported versions.
+
+[id="new-features-1-21-2_{context}"]
+== New features and enhancements
+
+.Pipelines
+
+//SRVKP-9726
+Support for hostUsers field in PodTemplate enables user namespace isolation::
+With this update, {pipelines-shortname} supports the Kubernetes-native `hostUsers` field in the `PodTemplate` specification. This field enables user namespace isolation for tasks and pipelines, allowing workloads to run with remapped user IDs for enhanced security. This capability is essential for container build tasks that use `buildah` and require user namespace support on {OCP} 4.20 and later versions, replacing the need for legacy CRI-O-specific annotations with a standard Kubernetes approach.
++
+link:https://issues.redhat.com/browse/SRVKP-9726[SRVKP-9726]
+
+[id="pipelines-fixed-issues-1-21-2_{context}"]
+== Fixed issues
+
+.Operator
+
+//SRVKP-10509
+ServiceMonitor works correctly when Operator is installed in non-default namespace::
+Before this update, the Operator `ServiceMonitor` had a hardcoded namespace reference to `openshift-operators` in its `namespaceSelector` field. As a consequence, when the Operator was installed in a different namespace, Prometheus scrape attempts failed with permission errors, triggering the `PrometheusKubernetesListWatchFailures` alert. With this update, hardcoded namespace references are removed from the `ServiceMonitor` configuration, allowing the namespace to be dynamically injected based on the Operator installation location. As a result, the `ServiceMonitor` functions correctly regardless of which namespace the Operator is installed in.
++
+link:https://issues.redhat.com/browse/SRVKP-10509[SRVKP-10509]
+
+.{pac}
+
+//SRVKP-9474
+pull_request_number variable is correctly populated for merge commit events::
+Before this update, {pac} occasionally failed to identify pull request numbers when using the Merge Commit strategy due to GitHub API indexing delays. As a consequence, the `pull_request_number` variable was not populated, causing related tasks to fail. With this update, an exponential backoff retry mechanism detects merge commits and retries the API call over several seconds if the association is not found immediately. As a result, the `pull_request_number` variable is correctly populated even when there is minor provider latency.
++
+link:https://issues.redhat.com/browse/SRVKP-9474[SRVKP-9474]
+
+//SRVKP-11295
+Admission controller prevents duplicate Repository resources with URL variations::
+Before this update, the {pac} admission webhook did not normalize repository URLs before checking for duplicates, allowing repositories with URLs differing only by trailing slashes or other minor variations to bypass validation. As a consequence, multiple `Repository` custom resources could be created for the same repository, causing configuration conflicts and unpredictable pipeline run behavior. With this update, the admission controller normalizes URLs by treating variations with and without trailing slashes as identical. As a result, duplicate repository configurations are correctly rejected, helping prevent multiple resources for the same repository URL.
++
+link:https://issues.redhat.com/browse/SRVKP-11295[SRVKP-11295]
+
+//SRVKP-9636
+Bitbucket Cloud commit statuses track multiple pipeline runs individually::
+Before this update, when multiple pipeline runs were triggered from a Bitbucket Cloud push event, {pac} used a static application name as the commit status key. As a consequence, each pipeline run overwrote the previous status, and the Bitbucket Cloud UI showed only one build entry for the commit, preventing you from seeing individual pipeline run results. With this update, commit statuses use a unique key formatted as `ApplicationName / PipelineRunName` for each pipeline run. As a result, Bitbucket Cloud displays separate build status entries for each pipeline run, allowing you to distinguish between multiple pipeline executions for the same application.
++
+link:https://issues.redhat.com/browse/SRVKP-9636[SRVKP-9636]
+
+//SRVKP-10880
+Custom hub catalog references with version specifiers no longer cause parse errors::
+Before this update, when using custom hub catalog annotations with version specifiers in the format `catalog://resource:version`, {pac} incorrectly parsed the version portion as a URL port number. As a consequence, pipeline runs failed with an "invalid port" error when using versioned hub catalog references. With this update, the URL parsing logic skips non-HTTP(S) schemes and handles hub catalog references gracefully. As a result, custom hub catalog references with version specifiers work correctly without producing parse errors.
++
+link:https://issues.redhat.com/browse/SRVKP-10880[SRVKP-10880]
+
+.User interface
+
+//SRVKP-11533
+TaskSidebar displays correctly in Pipeline Builder on {OCP} 4.21 and later versions::
+Before this update, the `TaskSidebar` component in the Pipeline Builder lacked a z-index style property. This issue became visible on {OCP} 4.21 and later versions when static plugin fallback code was removed from the console. As a consequence, the sidebar rendered behind other page elements, and only the sidebar header was visible. With this update, the component includes the missing z-index property. As a result, the `TaskSidebar` correctly overlays other components and remains visible and accessible.
++
+link:https://issues.redhat.com/browse/SRVKP-11533[SRVKP-11533]
+
+//SRVKP-9276, SRVKP-9273
+Console plugin upgraded to React 18 and PatternFly 6 for {OCP} 4.22 compatibility::
+With this update, the {pipelines-shortname} console plugin is upgraded to use React 18 and PatternFly 6. This upgrade helps ensure compatibility with {OCP} 4.22 and later versions as part of ongoing platform alignment efforts. The upgrade includes migrating all UI components from PatternFly 5 to PatternFly 6 and updating the React framework from version 17 to version 18. These changes are primarily technical and framework-related, with no functional changes to your workflows.
++
+link:https://issues.redhat.com/browse/SRVKP-9276[SRVKP-9276], link:https://issues.redhat.com/browse/SRVKP-9273[SRVKP-9273]

--- a/release_notes/op-release-notes-1-21.adoc
+++ b/release_notes/op-release-notes-1-21.adoc
@@ -29,6 +29,9 @@ For an overview of {pipelines-title}, see xref:../about/understanding-openshift-
 // Compatibility and support matrix 1.21
 include::modules/op-tkn-pipelines-compatibility-support-matrix.adoc[leveloffset=+1]
 
+// Release notes for Red Hat OpenShift Pipelines 1.21.2
+include::modules/op-release-notes-1-21-2.adoc[leveloffset=+1]
+
 // Release notes for Red Hat Openshift Pipelines 1.21.1
 include::modules/op-release-notes-1-21-1.adoc[leveloffset=+1]
 


### PR DESCRIPTION
Version(s):
- none for CP

Issue:
 - https://redhat.atlassian.net/browse/RHDEVDOCS-7633

Link to docs preview:
- [Release notes for Red Hat OpenShift Pipelines 1.21.2](https://112554--ocpdocs-pr.netlify.app/openshift-pipelines/latest/release_notes/op-release-notes-1-21.html#op-release-notes-1-21-2_op-release-notes-1-21)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->