### PR TITLE
OBSDOCS-3472: Fix article before OperatorGroup in CLI install module

### DIFF
--- a/modules/installing-logging-operator-cli.adoc
+++ b/modules/installing-logging-operator-cli.adoc
@@ -19,7 +19,7 @@ Install {clo} on your {ocp-product-title} cluster to collect and forward logs to
 
 . Create an `OperatorGroup` object:
 +
-The following example displays a `OperatorGroup` object:
+The following example displays an `OperatorGroup` object:
 +
 [source,yaml]
 ----


### PR DESCRIPTION
## Summary
- Fixes grammar in section 1.2.2 of the Installing Logging 6.5 guide: changes "displays a OperatorGroup" to "displays an OperatorGroup" in `modules/installing-logging-operator-cli.adoc`.

## Jira
https://redhat.atlassian.net/browse/OBSDOCS-3472

## Test plan
- [ ] Confirm rendered text in Installing Logging → Installing {clo} by using the CLI shows "displays an `OperatorGroup` object"
- [ ] Vale/lint passes on the modified `.adoc` file (if run locally or via CI)