### PR TITLE
[OCPBUGS-86820] Add cluster-proxy impact warning for ClusterNetwork expansion

### DIFF
--- a/modules/nw-cluster-network-range-edit.adoc
+++ b/modules/nw-cluster-network-range-edit.adoc
@@ -12,6 +12,8 @@ To expand the cluster network IP address range in {product-title} to support mor
 [NOTE]
 ====
 This change requires rolling out a new Operator configuration across the cluster, and can take up to 30 minutes to take effect.
+
+For clusters configured with cluster proxy, expanding the cluster network range also triggers a MachineConfigPool update that reboots all nodes. Plan this operation during a maintenance window to avoid service disruption.
 ====
 
 .Prerequisites


### PR DESCRIPTION
Combine the existing NOTE with new cluster-proxy warning into a single NOTE admonition. This provides clearer guidance to users about:
- Standard operation takes up to 30 minutes
- Clusters with cluster-proxy will experience node reboots due to MachineConfigPool updates when the cluster network range is expanded

The warning helps users plan maintenance windows appropriately to avoid unexpected service disruption.

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.18+


Issue: https://redhat.atlassian.net/browse/OCPBUGS-86820

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
