### PR TITLE
[OSDOCS#18858]: For 4.22, updated the steps for updating stale BMC credentials

### DIFF
--- a/modules/installation-manual-recovering-when-auto-recovery-is-unavail.adoc
+++ b/modules/installation-manual-recovering-when-auto-recovery-is-unavail.adoc
@@ -1,4 +1,4 @@
-//Module included in the following assemblies:
+/Module included in the following assemblies:
 //
 // *installing/installing_two_node_cluster/installing_tnf/install-post-tnf.adoc
 
@@ -6,9 +6,10 @@
 [id="installation-manual-recovering-when-auto-recovery-is-unavail_{context}"]
 = Manually recovering from a disruption event when automated recovery is unavailable
 
+[role="_abstract"]
 You might need to perform manual recovery steps if a disruption event prevents fencing from functioning correctly. In this case, you can run commands directly on the control plane nodes to recover the cluster. There are four main recovery scenarios, which should be attempted in the following order:
 
-. Update fencing secrets:  Refresh the Baseboard Management Console (BMC) credentials if they are incorrect or outdated.
+. Update fencing secrets: Refresh the Baseboard Management Console (BMC) credentials if they are incorrect or outdated.
 . Recover from a single-node failure: Restore functionality when only one control plane node is down.
 . Recover from a complete node failure: Restore functionality when both control plane nodes are down.
 . Replace a control plane node that cannot be recovered: Replace the node to restore cluster functionality.
@@ -26,17 +27,18 @@ Do an etcd backup before proceeding to ensure that you can restore the cluster i
 .Procedure
 
 . Update the fencing secrets:
-
-.. If the Cluster API is unavilable, update fencing secret by running the following command on one of the cluster nodes:
++
+--
+.. If the Cluster API is unavailable, update the fencing secret by running the following command on one of the cluster nodes:
 +
 [source,terminal]
 ----
 $ sudo pcs stonith update <node_name>_redfish username=<user_name> password=<password>
 ----
 +
-After the Cluster API recovers, or the Cluster API is already available, update fencing secret in the cluster to ensure it stays in sync, as described in the following step.
+After the Cluster API recovers, or if the Cluster API is already available, update the fencing secret in the cluster to ensure it stays in sync, as described in the following step.
 
-.. Edit the username and password for the existing fencing secret for the control plane node by running the following commads:
+.. Edit the username and password for the existing fencing secret for the control plane node by running the following commands:
 +
 [source,terminal]
 ----
@@ -46,12 +48,67 @@ $ oc project openshift-etcd
 [source,terminal]
 ----
 $ oc edit secret <node_name>-fencing
+$ oc edit secret fencing-credentials-<node_name>
+----
++
+The secret contains the following data keys:
++
+[cols="1,1,2",options="header"]
+.Data keys
+|===
+| Key | Description | Changes during credential rotation?
+| `username` | BMC username | Yes
+| `password` | BMC password | Yes
+| `address` | Full Redfish URL (for example, `redfish+https://192.168.1.10:443/redfish/v1/Systems/1`) | Only if BMC address changed
+| `certificateVerification` | `Disabled` or `Enabled` | Only if TLS settings changed
+|===
++
+[NOTE]
+====
+The `oc edit secret` command displays base64-encoded values. If you modify any of the values, the new values must also be base64-encoded.
+====
++
+Alternatively, you can use the following command to create or update the secret with literal strings:
++
+[source,terminal]
+----
+$ oc create secret generic fencing-credentials-<node_name> \
+  --from-literal=address='<redfish_address>' \
+  --from-literal=username='<new_username>' \
+  --from-literal=password='<new_password>' \
+  --from-literal=certificateVerification='<Disabled_or_Enabled>' \
+  --dry-run=client -o yaml | oc apply -f -
+----
++
+All four keys must be present. The cluster etcd Operator rejects secrets with missing keys.
+
+.. Verify that the new credentials can reach the BMC by running the following command:
++
+[source,terminal]
+----
+$ sudo pcs stonith config <node_name>_redfish
+----
+
+.. Verify that no STONITH resources are blocked by running the following command:
++
+[source,terminal]
+----
+$ sudo pcs status --full
+----
++
+The cluster etcd Operator performs this validation automatically when it applies credentials from the secret by using the following command:
++
+[source,terminal]
+----
+$ fence_redfish --action status
 ----
 +
 If the cluster recovers after updating the fencing secrets, no further action is required. If the issue persists, proceed to the next step.
+--
 
 . Recover from a single-node failure:
-
++
+--
 .. Gather initial diagnostics by running the following command:
 +
 [source,terminal]
@@ -106,9 +163,11 @@ $ sudo chown -R etcd:etcd /var/lib/etcd
 ----
 +
 If the recovery is successful, no further action is required. If the issue persists, proceed to the next step.
+--
 
 . Recover from a complete node failure:
-
++
+--
 .. Power on both control plane nodes.
 +
 Pacemaker starts automatically and begins the recovery operation when it detects both nodes are online. If the recovery does not start as expected, use the diagnostic commands described in the previous step to investigate the issue.
@@ -139,7 +198,7 @@ $ sudo journalctl -u pacemaker
 $ sudo journalctl -u kubelet
 ----
 
-.. Handle out-of-sync etcd. 
+.. Handle out-of-sync etcd.
 +
 If one node has a more up-to-date etcd, Pacemaker attempts to fence the lagging node and start it as a learner. If this process stalls, verify the Redfish fencing endpoint and credentials by running the following command:
 +
@@ -149,6 +208,7 @@ $ sudo pcs stonith config
 ----
 +
 If the recovery is successful, no further action is required. If the issue persists, perform manual recovery as described in the next step.
+--
 
 . If you need to manually recover from an event when one of the nodes is not recoverable, follow the procedure in "Replacing control plane nodes in a two-node OpenShift cluster".
 +


### PR DESCRIPTION

Version(s):
4.22

Issue:
https://redhat.atlassian.net/browse/OSDOCS-18858

Link to docs preview:
https://112560--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_two_node_cluster/installing_tnf/install-post-tnf.html#installation-manual-recovering-when-auto-recovery-is-unavail_install-post-tnf

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
I have not modified any other content other than the sub-steps in the  "Manually recovering from a disruption event when automated recovery is unavailable."  
