### PR TITLE
OSDOCS-19924:Update the z-stream RNs for 4.18.43

### DIFF
--- a/modules/zstream-4-18-43.adoc
+++ b/modules/zstream-4-18-43.adoc
@@ -1,0 +1,46 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-18-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-18-43_{context}"]
+= RHSA-2026:21657 - {product-title} {product-version}.43 fixed issues and security update
+
+Issued: 03 June 2026
+
+[role="_abstract"]
+{product-title} release {product-version}.43 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2026:21657[RHSA-2026:21657] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2026:21655[RHSA-2026:21655] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.18.43 --pullspecs
+----
+[id="zstream-4-18-43-enhancements_{context}"]
+== Enhancements
+
+* With this enhancement, the must-gather diagnostic tool will collect the total size of every type of resource in etcd to assist with many control plane troubleshooting scenarios. (link:https://redhat.atlassian.net/browse/OCPBUGS-86019[OCPBUGS-86109])
+
+[id="zstream-4-18-43-known-issues_{context}"]
+== Known issues
+
+* On certain Telecom Grandmaster (T-GM) systems, an {product-title} node reboot can trigger a change in the Global Navigation Satellite System (GNSS) device name. This issue prevents the T-GM system from achieving a locked state because the configuration points to a static, stale device path. To work around this problem, omit the `ts2phc.nmea_serialport` setting from the `ts2phcConf` section of the `PtpConfig` resource. (link:https://redhat.atlassian.net/browse/OCPBUGS-77517[OCPBUGS-77517])
+
+[id="zstream-4-18-43-fixed-issues_{context}"]
+== Fixed issues
+
+* Before this update, the `Modern` Transport Layer Security (TLS) security profile did not work. With this release, support for TLS 1.3 and the proper handling of the `Modern` profile is added, which ensures that the `Modern` TLS security profile works as expected. (link:https://redhat.atlassian.net/browse/OCPBUGS-56834[OCPBUGS-56834])
+
+* Before this update, enabling the `routingViaHost: true` and `ipForwarding: Global` parameters on a {hcp} KubeVirt guest cluster caused the console and ingress Cluster Operators to become degraded. As a consequence, route health checks from within the cluster would fail, even though ingress routes remained accessible from external clients. This issue occurred due to a routing conflict when both the management cluster and the {hcp} guest cluster had the `routingViaHost: true` parameter enabled. With this release, the fix ensures that {hcp} KubeVirt guest clusters use the subnet gateway IP as the default gateway. As a result, the routing conflict is resolved and the console and ingress Cluster Operators are allowed to remain healthy when these networking features are enabled. (link:https://redhat.atlassian.net/browse/OCPBUGS-74399[OCPBUGS-74399])
+
+* Before this update, the `oauth` pods in the `openshift-authentication` namespace could get stuck while rolling out changes when one of the respective nodes these pods were running on was not ready or not available. As a consequence, authentication completely stopped until the blocked rollout concluded. With this release, the pods can proceed with the rolling update even when a node is down or unavailable (link:https://redhat.atlassian.net/browse/OCPBUGS-75897[OCPBUGS-75897])
+
+* Before this update, the egress IP address was incorrectly assigned to the `br-ex` bridge when you configured additional interfaces. This issue caused egress IP address assignment conflicts and routing issues with unexpected traffic paths. With this release, the egress IP address is not assigned to the `br-ex` bridge. As a result, the egress IP address is correctly assigned to the secondary interface, which resolves routing conflicts. (link:https://redhat.atlassian.net/browse/OCPBUGS-85434[OCPBUGS-85434])
+
+[id="zstream-4-18-43-updating_{context}"]
+== Updating
+
+To update an {product-title} 4.18 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].

--- a/release_notes/ocp-4-18-release-notes.adoc
+++ b/release_notes/ocp-4-18-release-notes.adoc
@@ -3064,6 +3064,9 @@ As a workaround, you must manually reboot the failed host from the disk. (link:h
 // 4.18 about async
 include::modules/rn-async-errata.adoc[leveloffset=+1]
 
+// 4.18.43 RNs and updating
+include::modules/zstream-4-18-43.adoc[leveloffset=+2]
+
 // 4.18.42 RNs and updating
 include::modules/zstream-4-18-42.adoc[leveloffset=+2]
 


### PR DESCRIPTION
Version(s):
4.18

Issue:
https://redhat.atlassian.net/browse/OSDOCS-19924

Link to docs preview:
https://112561--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-18-release-notes.html#zstream-4-18-43_release-notes

Additional information:
4.18.43 MR: https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/550
ART Dashboard: https://art-dash.engineering.redhat.com/dashboard/release/openshift-4.18