### PR TITLE
OSDOCS-18179-storage-bug-batch-4-22 RNs

### DIFF
--- a/modules/rn-ocp-release-notes-fixed-issues.adoc
+++ b/modules/rn-ocp-release-notes-fixed-issues.adoc
@@ -277,25 +277,12 @@ The following issues are fixed for this release:
 [id="rn-ocp-release-note-storage-fixed-issues_{context}"]
 == Storage
 
-vSphere CSI driver operator metrics endpoint incorrectly returns 500 error::
-Previously, the vSphere container storage interface (CSI) driver operator's metrics endpoint (port 8445) returned "HTTP 500" (Internal Server Error) when accessed without authentication, instead of the expected "HTTP 401" (Unauthorized/Forbidden).
-+
-This occurred because the service account lacked permission to create `subjectaccessreviews` resources, causing the authorization check itself to fail, rather than properly rejecting the unauthorized request. This issue has been resolved by adding the missing RBAC permissions to the vSphere CSI driver operator's `ClusterRole`.
-+
-link:https://redhat.atlassian.net/browse/OCPBUGS-60159[OCPBUGS-60159]
+* Before this update, the vSphere container storage interface (CSI) driver Operator's metrics endpoint (port 8445) returned a _HTTP 500 Internal Server Error_ message when accessed without authentication, instead of the expected _HTTP 401 Unauthorized_ message. As a consequence, the service account lacked permission to create the `subjectaccessreviews` resources, causing the authorization check itself to fail, rather than properly rejecting the unauthorized request. With this release, the missing role-based access control (RBAC) permissions have been added to the vSphere CSI driver operator's `ClusterRole` object. (link:https://redhat.atlassian.net/browse/OCPBUGS-60159[OCPBUGS-60159])
 
-Azure CSI stray volume attachment prevents pod starts::
-Previously, after a node reboot, a pod may fail to start with "Multi-Attach" error, even though the volume is not attached to any node.
-+
-This was fixed by adding LUN verification to prevent race conditions during disk attachment.
-+
-Now, pods start successfully after a node reboot.
-+
-link:https://redhat.atlassian.net/browse/OCPBUGS-74936[OCPBUGS-74936]
+* Before this update, the storage operator did not create the required `RoleBinding` object for Prometheus in the `openshift-cluster-csi-drivers` namespace, which caused the monitoring of the CSI driver namespace to fail and prevented metric collection. With this release, the storage operator creates the `RoleBinding` object for the Prometheus Service Account in the `openshift-cluster-csi-drivers` namespace. As a result, CSI drivers are successfully monitored during hosted control planes AKS runs. (link:https://redhat.atlassian.net/browse/OCPBUGS-70339[OCPBUGS-70339])
 
-Azure CSI driver indefinite hang during volume detach after node deletion::
-Previously, a fix for dangling volumes (OCPBUGS-67165) introduced a regression where the `ControllerUnpublish` operation could continue indefinitely when waiting for a disk's `ManagedBy` field to clear. This occurred if the disk was reassigned to another node during the detach operation, causing the wait loop to never exit since `ManagedBy` pointed to the new node instead of becoming NULL.
-+
-This issue has been resolved by checking whether the disk's `ManagedBy` field points to a different node than the one being detached from. If so,the detach operation is considered complete, allowing volumes to properly clear the "detaching" state and be scheduled on new nodes.
-+
-link:https://redhat.atlassian.net/browse/OCPBUGS-85193[OCPBUGS-85193]
+* Before this update, after a node reboot, a pod might fail to start displaying the "Multi-Attach" error, even though the volume is not attached to any node. With this release, LUN verification was added to prevent race conditions during disk attachment. As a result, pods start successfully after a node reboot. (link:https://redhat.atlassian.net/browse/OCPBUGS-74936[OCPBUGS-74936])
+
+* Before this update, creating snapshots of large {azure-first} UltraSSD_LRS or PremiumV2_LRS persistent volumes could fail due to a hard coded 10-minute timeout in the Container Storage Interface (CSI) driver, which was insufficient for Azure's background copy process on large disks. With this release, the {azure-short} Disk CSI driver supports instant access snapshots, configurable with the `instantAccessDurationMinutes` parameter in the `VolumeSnapshotClass`, allowing snapshot operations on large volumes to complete successfully. (link:https://issues.redhat.com/browse/OCPBUGS-77248[OCPBUGS-77248])
+
+* Before this update, a fix for dangling volumes introduced a regression where the `ControllerUnpublish` operation could continue indefinitely when waiting for a disk's `ManagedBy` field to clear. This occurred if the disk was reassigned to another node during the detach operation, causing the wait loop to never exit because the `ManagedBy` field pointed to the new node instead of becoming NULL. With this release, the disk's `ManagedBy` field is checked to see if it points to a different node rather than the one being detached from. If so,the detach operation is considered complete, allowing volumes to properly clear the "detaching" state and be scheduled on new nodes. (link:https://redhat.atlassian.net/browse/OCPBUGS-85193[OCPBUGS-85193])


### PR DESCRIPTION
Version(s):
4.22

Issue:
https://redhat.atlassian.net/browse/OSDOCS-18179

Link to docs preview:
https://112566--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-22-release-notes.html#rn-ocp-release-note-storage-fixed-issues_release-notes


QE review:
- [ ] QE has approved this change.


Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
