### PR TITLE
[OSDOCS#18914]: Release Notes for SSCSI Driver

### DIFF
--- a/modules/rn-ocp-release-notes-new-features.adoc
+++ b/modules/rn-ocp-release-notes-new-features.adoc
@@ -585,6 +585,10 @@ This feature is only supported on AWS Elastic Block Storage (EBS).
 
 Mutable CSI node allocatable property was introduced in {product-title} 4.21 as a Technical Preview feature. In {product-title} 4.22, it is supported as generally available.
 
+[id="release-notes-storage-secrets-store-csi-driver-operator_{context}"]
+=== Updated release of the Secrets Store CSI Driver Operator
+The Secrets Store CSI Driver Operator version v4.22 is now based on the upstream version v1.5.6 release of secrets-store-csi-driver. {product-title} 4.22 enables Secrets Store CSI Driver on {ibm-z-name}.
+
 [id="release-notes-storage-sovereign-cloud_{context}"]
 === European Sovereign Cloud (EUSC) region (Technology Preview)
 European Sovereign Cloud (EUSC) region acts as a "digital fortress" built within a specific country’s borders. Sovereign Clouds are specifically designed to meet strict legal, jurisdictional, and security requirements of a particular nation or entity.
@@ -596,6 +600,8 @@ For {product-title} 4.22, only AWS Elastic Block Storage supports EUSC. AWS Elas
 EUSC is supported as a Technology Preview feature.
 
 For more information about EUSC, see xref:../storage/container_storage_interface/persistent-storage-csi-ebs.adoc#support-for-european-sovereign-cloud-eusc-region[Support for European Sovereign Cloud (EUSC) region].
+
+
 
 [id="ocp-release-notes-web-console_{context}"]
 == Web console


### PR DESCRIPTION

Version(s):
4.22

Issue:
https://redhat.atlassian.net/browse/OSDOCS-18914

Link to docs preview:
For IBM Z platform: https://112568--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-22-release-notes.html#ocp-release-notes-ibm-z-linux-one_release-notes

Storage: https://112568--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-22-release-notes.html#release-notes-storage-secrets-store-csi-driver-operator_release-notes



QE review:
- [x] QE has approved this change.

