### PR TITLE
OSDOCS-19962: Add Claude skill for porting docs to downstream

### DIFF
--- a/claude-skills/doc-verification/doc-verification.md
+++ b/claude-skills/doc-verification/doc-verification.md
@@ -1,0 +1,224 @@
+---
+name: doc-verification
+description: Verify project documentation accuracy and quality against the actual codebase. Use this skill when asked to "check documentation", "verify docs", "review documentation", or when you need to ensure documented information matches the current implementation. Also use when reviewing PRs that contain documentation changes (.md files) — invoke alongside the PR review skill to catch both code and documentation issues. Focuses on finding inaccuracies and quality problems in existing docs, not flagging missing documentation.
+---
+
+# Documentation Verification
+
+Verify that existing project documentation accurately reflects the current codebase and serves users effectively.
+
+## Philosophy: Accuracy and Quality
+
+This skill checks two things:
+1. **Accuracy**: What IS documented is correct against the codebase.
+2. **Quality**: What IS documented is usable, well-structured, and serves the target audience.
+
+It does NOT flag what ISN'T documented (completeness).
+
+**Check (accuracy):**
+- Documented make targets actually exist
+- Documented constants match actual values
+- YAML examples have valid fields and syntax
+- Tool versions match actual requirements
+- Documented file paths exist
+- Default values match implementation
+- Enum values match API types
+- Code examples are syntactically correct
+
+**Check (quality):**
+- Document fits its type in the doc hierarchy (overview vs user guide vs reference)
+- Information flows logically without requiring readers to jump back and forth
+- Related information is grouped together (not split across distant sections)
+- Claims are specific and match reality (absolute statements like "must be" are accurate)
+- Users can act on the guidance (no dead ends, missing examples, or unexplained concepts)
+- Cross-references connect docs into a navigable whole
+
+**Do NOT check (completeness):**
+- Whether all make targets are documented
+- Whether all API fields have examples
+- Whether new features are documented
+- Whether all constants are in docs
+
+**Rationale**: Completeness is subjective and context-dependent. Accuracy and quality are objective and actionable.
+
+## Core Principles
+
+1. **Zero assumptions** - Never conclude that a documented statement is correct or incorrect based on what you expect, infer, or "know" from training data. Every factual claim requires a verified source:
+   - If the doc references a file or path, check that it exists.
+   - If the doc contains a command, run it (or dry-run it) and compare the output to what the doc claims.
+   - If the doc describes code behavior, read the actual implementation at the relevant file:line.
+   - If the doc states a default value, constant, or version, find the source of truth in code or config and confirm it.
+   - If you haven't read the file, run the command, or checked the source, you don't know — and must do so before forming any judgment.
+2. **Code evidence is mandatory** - Every claim of inaccuracy must have specific file:line references from both docs and code. No guessing.
+3. **Verify before reporting** - Research independently. Read the code, check official docs for syntax/conventions, trace execution. Only report issues you've confirmed.
+4. **Quality over quantity** - 3 confirmed issues with evidence are worth more than 30 unverified claims. False positives damage trust.
+
+## Step 1: Discover Documentation Files
+
+Use Glob to find all `.md` files in the repository root and `doc/` or `docs/` directories:
+- `CLAUDE.md` - Project documentation and AI context
+- `README.md` - User-facing README
+- `RELEASE.md` - Release procedures
+- `CONTRIBUTING.md` - Contributor guide
+- `doc/*.md` / `docs/*.md` - All documentation files
+
+**Exclude**: `CHANGELOG.md` (historical archive, not current documentation).
+
+## Step 2: Verify Each File Using These Patterns
+
+For each discovered file, extract and verify factual claims:
+
+### Pattern 1: Make Targets
+- **Extract**: Any mention of `make <target>` or `` `make <target>` ``
+- **Verify**: Test with `make -n <target>` to confirm it exists
+- **Check**: Command examples show correct flag names and values
+- **Check**: Documented defaults for Makefile variables match actual defaults
+- **Detect typos**: If target doesn't exist, suggest similar names from Makefile
+
+### Pattern 2: Constants and Default Values
+- **Extract**: Documented constant names, default values, configuration values
+- **Verify**: Cross-check against source code (API types, config files, main packages)
+- **Check**: Referenced constants actually exist in the stated files
+- **Sources**: Port numbers, default replicas, resource limits, enum values in type definitions
+
+### Pattern 3: YAML/JSON Examples
+- **Extract**: All YAML/JSON code blocks
+- **Verify syntax**: Properly formatted, no stray markers
+- **Verify fields**: All fields exist in the corresponding API/CRD spec
+- **Verify types**: Field types match API (string vs int vs object)
+- **Verify enums**: Enum fields use valid values from API type definitions
+
+### Pattern 4: Tool Versions
+- **Extract**: References to tool versions (e.g., "operator-sdk version 1.32.0")
+- **Verify consistency**: Same tool versions across all documentation files
+- **Verify accuracy**: Versions match Makefile, go.mod, or build configuration
+
+### Pattern 5: File Paths and Directory References
+- **Extract**: Any mention of file paths
+- **Verify existence**: Use Glob or Bash to confirm paths exist
+- **Verify links**: Internal markdown links point to existing files
+
+### Pattern 6: Code References and Behavior
+- **Extract**: Descriptions of how code works, function names, execution order
+- **Verify**: Cross-reference with actual implementation
+- **Check**: Function names, environment variables, reconciliation steps, behavior descriptions
+
+## Step 3: Assess Documentation Quality
+
+After verifying accuracy, evaluate the documentation quality using these patterns. Evidence is still required — cite specific sections, headings, or line ranges to support each finding.
+
+### Pattern 7: Document Type Fit
+- **Identify**: What type of document is this? (overview, user guide, reference, tutorial, design doc)
+- **Check**: Does the level of detail match the type?
+  - Overviews should explain concepts and help users make decisions, not provide step-by-step instructions
+  - User guides should be actionable with working examples, not abstract explanations
+  - References should document structure and fields, not use cases
+- **Check**: Is content that belongs in another doc type leaking in? (e.g., a full tutorial inside a reference doc)
+
+### Pattern 8: Structure and Flow
+- **Check**: Does the document progress logically? (concept → decision → configuration → troubleshooting)
+- **Check**: Can a reader follow the document top-to-bottom without needing to jump back to earlier sections?
+- **Check**: Is related information grouped together? Flag cases where information needed to use a feature is split across distant sections (e.g., encoding requirements 100 lines away from the examples that need them)
+- **Check**: Are there sections that describe a concept but leave the reader with no next step? (dead ends)
+
+### Pattern 9: Audience and Accessibility
+- **Check**: Is the assumed knowledge level consistent throughout? (don't explain Kubernetes basics then assume deep Envoy internals knowledge)
+- **Check**: Are decision points clear? When users need to choose between options, is there enough guidance? (tables, "when to use" framing, trade-off comparisons)
+- **Check**: Are examples realistic and self-contained? Can a user copy an example and adapt it without hunting for missing context?
+
+### Pattern 10: Claim Specificity
+- **Check**: Do absolute statements ("must be", "always", "only") match reality? Look for CRD fields or configuration options that provide alternatives the doc doesn't mention.
+- **Check**: Are descriptions of fields or concepts consistent with their actual semantics? (e.g., a field described as "certificate serial number" that actually contains a Subject DN serial number)
+- **Check**: Do examples use realistic values that won't mislead? (e.g., example values that look like a different concept than what the field actually contains)
+
+### Pattern 11: Cross-Reference Integrity
+- **Check**: Do related documents reference each other appropriately? (overview links to user guide, user guide links back to overview)
+- **Check**: Is terminology consistent across related documents? (same concept shouldn't have different names in different docs)
+- **Check**: When multiple docs cover related topics, is the division of responsibility clear? (no significant overlap that could diverge, no gaps between docs)
+
+## Step 4: Avoiding False Positives
+
+Before reporting any issue, verify it is NOT one of these common false positives:
+
+**Accuracy false positives:**
+- **Valid alternative syntax**: The doc uses a different but correct syntax. Check official docs first.
+- **Intentionally out of scope**: The document type doesn't require this level of detail.
+- **Standard conventions**: Industry-standard patterns don't need explicit documentation.
+- **Architecture differences**: The code works differently than you assumed. Read more carefully.
+- **Basic docs linking to detailed docs**: An overview doc referencing a detailed guide is not "incomplete."
+
+**Quality false positives:**
+- **Appropriate simplification**: An overview doc omitting advanced options is fine if it links to the reference. Not every field needs to be mentioned everywhere.
+- **Audience-appropriate depth**: A user guide for beginners explaining basics isn't "too simple" — it's serving its audience.
+- **Style preferences**: Don't flag writing style choices (active vs passive voice, heading conventions) unless they harm clarity. Focus on structural and informational issues.
+- **Transitional content**: A section that describes a deprecated/fallback approach briefly without full examples may be intentional if the doc recommends users move to the preferred approach.
+
+**When uncertain**: Research independently first. Check official docs, read related code, trace execution. Only ask the user about scope clarification, priority questions, or ambiguous requirements.
+
+## Step 5: Generate Report
+
+```markdown
+## Documentation Verification Report
+
+### Verified Accurate
+
+List all checked documentation areas that are accurate:
+- {file}: {section} - all values verified correct
+- {file}: {section} - examples match API spec
+
+### Inaccuracies Found
+
+#### [{File name}] - [{Section}]
+**Issue**: {Clear description}
+**Location**: {File:line}
+**Current docs say**: {Exact quote}
+**Actual implementation**: {What the code actually says, with file:line}
+**Suggested fix**: {Specific correction}
+
+### Quality Issues Found
+
+#### [{File name}] - [{Section}]
+**Issue**: {Clear description}
+**Location**: {File:line or section range}
+**Pattern**: {Which quality pattern this violates: type fit, structure, audience, claim specificity, or cross-reference}
+**Impact**: {How this affects users — what will they struggle with or misunderstand?}
+**Suggested fix**: {Specific improvement}
+
+### Summary
+
+- Documentation files checked: {N}
+- Inaccuracies found: {N}
+- Quality issues found: {N}
+- Severity breakdown:
+  - Critical (wrong values/broken examples/misleading claims): {N}
+  - Minor (typos/structure improvements/usability nits): {N}
+
+### Assessment
+
+If no issues: "Documentation is accurate and well-structured."
+If issues found: "Found {N} inaccuracies and {N} quality issues."
+```
+
+## What to Flag vs What to Skip
+
+**Flag these (inaccuracies):**
+- "DefaultPort: 8080" but code says 8081
+- "make verify-manifets" but Makefile has "verify-manifests"
+- YAML example uses `spec.storage.redis.url` but API field is `configSecretRef`
+- "version 1.32.0" in one doc but "1.30.0" in another
+- Link to `doc/storage.yaml` but file doesn't exist
+
+**Flag these (quality):**
+- A field described as "certificate serial number" but the code returns the Subject DN serial number (misleading claim)
+- Doc says "secrets must be in namespace X" but the API has an option to use all namespaces (absolute statement contradicted by reality)
+- An option is described with "use EnvoyFilter resources" but no examples, no links, and no further guidance (dead end)
+- Encoding requirements documented in a "requirements" section but not near the examples that need them (split information)
+- An overview doc containing step-by-step kubectl commands that belong in a user guide (type mismatch)
+
+**Skip these (completeness/opinions):**
+- Make target exists but not documented
+- New API field added but no example in docs
+- Config directory exists but not listed
+- Feature works but behavior not fully explained
+- Writing style preferences that don't affect clarity
+- An overview linking to a detailed guide instead of repeating the content

--- a/claude-skills/jtbd/JTBD-Skill.md
+++ b/claude-skills/jtbd/JTBD-Skill.md
@@ -1,0 +1,133 @@
+---
+name: jtbd-docs
+description: Apply Jobs-to-be-Done principles to documentation writing
+---
+
+# Jobs to be Done (JTBD) Documentation Strategy
+
+Apply Jobs to be Done principles to all documentation work, focusing on user goals rather than feature descriptions.
+
+## Core JTBD Framework
+
+When creating or updating documentation:
+
+1. **Frame around user goals** using the pattern: "When [situation], I want to [action], so that [outcome]"
+2. **Focus on jobs** users are trying to accomplish, not just features
+3. **Organize by use cases** rather than capabilities
+4. **Make it timeless** by addressing underlying needs, not implementation details
+
+## JTBD Principles for Technical Documentation
+
+### Start with the Job Statement
+Before documenting any feature, identify:
+- **Situation**: What context or trigger prompts the user?
+- **Motivation**: What does the user want to accomplish?
+- **Outcome**: What success looks like for the user?
+
+Example: "When deploying a multi-tenant API, I want to authenticate clients using their X.509 certificates, so that I can ensure only authorized organizations access specific resources."
+
+### Structure Documentation Around Jobs
+
+**Instead of feature-first:**
+```
+Authentication
+├── Overview
+├── API Key Authentication
+├── JWT Authentication
+├── X.509 Certificate Authentication
+└── OAuth2 Authentication
+```
+
+**Use job-first:**
+```
+Secure API Access
+├── Verify client identity with enterprise certificates
+│   ├── Understanding X.509 client certificate authentication
+│   ├── Configure certificate validation
+│   └── Extract claims from certificates
+├── Enable partner integration with API keys
+└── Support user login with OAuth2
+```
+
+### Content Guidelines
+
+**DO:**
+- Lead with the user's goal or problem
+- Provide complete workflows from job start to finish
+- Include context about when to use this approach
+- Show related capabilities in context of the job
+- Use concrete, real-world scenarios
+
+**DON'T:**
+- Start with feature definitions or capability lists
+- Document features in isolation
+- Use abstract examples
+- Organize solely by API or product structure
+- Focus on "how the feature works" before "what job it solves"
+
+### Documentation Patterns
+
+#### Job-Focused Guide Structure
+1. **Job statement**: When/want/so that
+2. **Before you begin**: Prerequisites in context of the job
+3. **Guided workflow**: Step-by-step path to job completion
+4. **Verification**: How to confirm the job is done
+5. **Related jobs**: What users might do next
+6. **Reference**: Feature details for those who need them
+
+#### Navigation Organization
+Group by:
+- User roles and responsibilities
+- Workflow stages or lifecycle phases
+- Problem domains or scenarios
+- Business outcomes
+
+Avoid grouping by:
+- API resources or CRDs
+- Product components
+- Alphabetical feature lists
+
+### Quality Checks
+
+Before publishing documentation, verify:
+- [ ] Title describes a job, not a feature ("Authenticate microservices with mTLS" not "X.509 AuthPolicy Configuration")
+- [ ] Introduction states the user's goal and outcome
+- [ ] Content follows a job workflow, not a feature tour
+- [ ] Examples show realistic scenarios, not toy cases
+- [ ] Related capabilities appear in context, not as isolated topics
+- [ ] Structure remains stable even if feature implementation changes
+
+## Application to Current Work
+
+When working on documentation tasks:
+
+1. **Identify the job**: Ask "What is the user really trying to accomplish?"
+2. **Reframe the title**: Convert feature names to job statements
+3. **Restructure content**: Lead with scenario, follow with solution path
+4. **Add context**: Explain when and why to use this approach
+5. **Connect jobs**: Show how this fits into larger workflows
+
+## Examples from Kuadrant Context
+
+**Feature-based** ❌
+"Configuring X.509 Client Certificate Authentication in AuthPolicy"
+
+**Job-based** ✅
+"Authenticate API clients using enterprise X.509 certificates"
+
+**Feature-based navigation** ❌
+- AuthPolicy
+  - Authentication methods
+  - X.509 configuration
+  - JWT validation
+  - API key setup
+
+**Job-based navigation** ✅
+- Secure API access for different client types
+  - Verify enterprise clients with X.509 certificates
+  - Enable partner integration with API keys
+  - Support user sessions with JWT tokens
+
+---
+
+**Usage**: Invoke this skill at the start of any documentation task to apply JTBD principles throughout the work.

--- a/claude-skills/port-docs-to-downstream/SKILL.md
+++ b/claude-skills/port-docs-to-downstream/SKILL.md
@@ -1,0 +1,516 @@
+---
+name: port-docs-to-downstream
+description: Convert Kuadrant upstream documentation to Red Hat Connectivity Link (RHCL) downstream docs
+argument-hint: "<upstream-doc-url-or-path> [scope-notes]"
+---
+
+# Port Documentation to Downstream
+
+Convert Kuadrant upstream documentation into Red Hat Connectivity Link (RHCL) downstream documentation suitable for Red Hat product documentation.
+
+## Scope and Philosophy
+
+This skill transforms upstream Kuadrant docs (published at https://docs.kuadrant.io) into downstream RHCL docs following Red Hat documentation standards, OpenShift platform requirements, and IBM Style Guide conventions.
+
+**Key transformation principle**: Not everything upstream belongs downstream. Filter, adapt, and contextualize based on what Red Hat supports and what downstream users need.
+
+**CRITICAL: Procedural integrity**: Under no circumstance add or skip a procedural step (command-line instruction, configuration change, or any direct instruction to the reader) unless you are certain it will not break the procedure. When in doubt about whether a step is needed or can be safely omitted, ask the user for clarification. It is better to include a potentially redundant step than to create a broken procedure.
+
+## Input
+
+The user provides `$ARGUMENTS` which should be:
+1. **Required**: Upstream documentation URL or file path (GitHub URL, local path, or docs.kuadrant.io URL)
+2. **Optional**: Scope notes (features to include/exclude, specific use cases to cover, version information)
+
+Example invocations:
+```
+/port-docs-to-downstream https://github.com/Kuadrant/kuadrant-operator/blob/main/doc/auth-x509.md "Only Tier 2 use case"
+/port-docs-to-downstream docs/rate-limiting.md "OLM installation only, OSSM and CIO gateways"
+```
+
+## Prerequisites
+
+- Access to upstream documentation (GitHub, local files, or docs.kuadrant.io)
+- Understanding of downstream platform (OpenShift) and supported features
+- Access to current downstream docs structure: https://github.com/openshift/openshift-docs/tree/rhcl-docs-main
+- Knowledge of Red Hat documentation standards (IBM Style Guide + Red Hat Supplementary Style Guide)
+
+## Step 1: Fetch and Analyze Upstream Content
+
+1. **Retrieve the upstream doc**:
+   - For GitHub URLs: Use Github MCP server (if configured) or alternatives such as `gh api` or WebFetch to get the raw content
+   - For local paths: Use Read tool
+   - For docs.kuadrant.io URLs: Use WebFetch
+
+2. **Parse user scope notes** to identify:
+   - Features/capabilities to include vs exclude
+   - Specific use cases or tiers to document
+   - Installation methods (assume OLM only unless specified)
+   - Gateway providers (default to CIO; use OSSM only if mentioned in upstream or by user)
+   - Version/release information
+
+3. **Ask clarifying questions** if scope is ambiguous:
+   - Which features from the upstream are supported downstream?
+   - Are there specific use cases or tiers to focus on?
+   - What should be excluded entirely?
+   - Are there new constraints or requirements to apply?
+
+## Step 2: Apply Downstream Transformation Rules
+
+### Rule 1: Platform and Installation Differences
+
+**Upstream → Downstream transformations:**
+
+| Upstream | Downstream | Notes |
+|----------|-----------|-------|
+| Helm installation | OLM installation | Skip Helm procedures; assume operator installed via OLM |
+| Kubernetes generic | OpenShift specific | Apply OpenShift security context constraints, use `oc` not `kubectl` |
+| Istio, Envoy Gateway | CIO (primary), OSSM (secondary) | Prefer CIO unless upstream/user specifies OSSM |
+| `kubectl` commands | `oc` commands | Convert all kubectl to oc |
+| Kind, minikube, k3s | OpenShift clusters | Remove local dev cluster references |
+| `make` targets | Inline procedures | Expand make targets into explicit steps |
+
+**OpenShift-specific requirements:**
+- All pod templates must include `securityContext` configuration
+- Use OpenShift Routes for ingress (CIO) or OSSM ServiceEntry/VirtualService
+- Reference OpenShift documentation for platform features
+- Use OpenShift's RBAC and security model
+- Apply namespace restrictions and project conventions
+
+**Gateway provider priorities:**
+- **Primary (default)**: OpenShift Cluster Ingress Operator (CIO)
+  - Use `gatewayClassName: openshift-default` in Gateway objects
+  - Assume CIO unless upstream doc or user specifically mentions OSSM
+- **Secondary**: OpenShift Service Mesh (OSSM)
+  - Use `gatewayClassName: istio` in Gateway objects
+  - Only use when explicitly mentioned in upstream or by user
+
+### Rule 2: Product Naming
+
+**Find and replace (case-sensitive where appropriate):**
+- "Kuadrant" → "Red Hat Connectivity Link (RHCL)" (first mention in each doc)
+- "Kuadrant" → "Red Hat Connectivity Link" or "RHCL" (subsequent mentions)
+- Keep "Kuadrant" only when explicitly referencing the upstream project as the basis (e.g., "based on the upstream Kuadrant project")
+
+**Component naming:**
+- Upstream component names remain the same (Authorino, Limitador, etc.) but context should indicate they're part of RHCL
+- Use product attributes where possible: `{prodname}`, `{product-version}`
+
+### Rule 3: Content Inclusion/Exclusion
+
+**Exclude from downstream:**
+- Helm installation procedures
+- Unsupported gateway providers (vanilla Istio, Envoy Gateway)
+- Development/testing tools (Kind, minikube)
+- Upstream-only features not in the RHCL release
+- GitHub-specific workflows (clone repos, use make targets)
+- Alpha/experimental features
+- Contributor-focused content
+
+**Include in downstream:**
+- User-facing procedures and use cases
+- Supported API references and configurations
+- Architecture and concepts (adapted for supported platforms)
+- Prerequisites and verification steps
+- Troubleshooting for supported scenarios
+
+**Transform (don't exclude):**
+- Installation steps: OLM-based installation
+- Platform setup: OpenShift-specific configuration
+- Examples: Real hostnames, production-like scenarios
+
+**Procedural step preservation:**
+- NEVER skip or add procedural steps unless certain it won't break the procedure
+- Transform commands (kubectl → oc, etc.) but preserve the complete sequence
+- If uncertain whether a step is necessary, ask the user before omitting it
+- Expand abbreviated instructions (like make targets) into full steps, don't condense them
+
+### Rule 4: YAML and Code Examples
+
+**All referenced files must be inline:**
+- No links to GitHub repositories for YAML files
+- No instructions to "clone the repo and run..."
+- Embed complete YAML examples directly in the doc
+- Show full command sequences inline
+
+**Example transformations:**
+
+❌ Upstream:
+```
+See example-policy.yaml in the examples/ directory.
+Run: make deploy-example
+```
+
+✅ Downstream:
+```yaml
+apiVersion: kuadrant.io/v1
+kind: AuthPolicy
+metadata:
+  name: example-policy
+  namespace: my-namespace
+spec:
+  # ... complete inline example
+```
+
+**Variables and placeholders:**
+- Use clear placeholder syntax: `export HOSTNAME=<replace-with-gateway-hostname>`
+- Avoid `localhost` and `nip.io` - use real hostname variables
+- Prefer environment variables for values users must customize
+
+**YAML ellipses:**
+- Use commented ellipses: `# ...` (not bare `...` which means document end)
+
+### Rule 5: Links and References
+
+**Link policy:**
+- **Avoid external links** where possible (GitHub, Wikipedia often not allowed)
+- **Use internal cross-references** to other RHCL docs
+- **Check current downstream structure**: https://github.com/openshift/openshift-docs/tree/rhcl-docs-main
+- Replace upstream doc links with downstream equivalents
+- Remove or inline content instead of linking to external sources
+
+**When you must link:**
+- Link to Red Hat documentation
+- Link to OpenShift documentation
+- Link to top-level pages, not deep links
+- Never use bare URLs or URL shorteners
+
+### Rule 6: DNS and Hostnames
+
+**Hostname policy:**
+
+❌ Upstream style:
+```
+curl http://localhost:8080/api
+kubectl port-forward svc/api 8080:8080
+export GATEWAY_URL=$(kubectl get svc -n istio-system -o jsonpath='{.status.loadBalancer.ingress[0].ip}').nip.io
+```
+
+✅ Downstream style:
+```bash
+# Get the gateway hostname
+export GATEWAY_HOSTNAME=$(oc get route api-gateway -n gateway-namespace -o jsonpath='{.spec.host}')
+
+# Test the endpoint
+curl https://${GATEWAY_HOSTNAME}/api
+```
+
+**Principles:**
+- Assume cloud or on-premises with real DNS
+- Use variables and placeholders for hostnames
+- Show how to retrieve actual hostnames from OpenShift resources
+- Prefer production-like examples over localhost
+
+### Rule 7: Avoid Repetition via Cross-References
+
+**Reference existing procedures instead of duplicating:**
+- Check current downstream structure for existing content
+- Link to existing installation, configuration, or prerequisite docs
+- Only duplicate if the existing doc is insufficient or wrong context
+
+**Downstream doc structure** (release branch): https://github.com/openshift/openshift-docs/tree/rhcl-docs-main
+
+Current published version: https://docs.redhat.com/en/documentation/red_hat_connectivity_link/latest/html/red_hat_connectivity_link/index
+
+**Common cross-references:**
+- Installation procedures
+- Gateway setup
+- Common prerequisites (oc login, project setup)
+- Verification steps
+- Troubleshooting sections
+
+## Step 3: Apply IBM Style Guide and Red Hat Conventions
+
+The downstream docs must follow IBM Style Guide (primary) and Red Hat Supplementary Style Guide (secondary). This skill inherits all style rules from the `review-downstream-docs` skill.
+
+**Key rules to apply during conversion:**
+
+### Voice and tense
+- Active voice, present tense
+- Second person ("you")
+- No anthropomorphism
+
+### Contractions
+- Avoid in formal docs (don't → do not, can't → cannot)
+
+### Clarity
+- Include "that" in subordinate clauses: "Verify that the pod is running"
+- Use "because" not "since" for causation
+- Use "whether" not "if" for alternatives
+- Place "only" immediately before what it modifies
+
+### Headings
+- Sentence-style capitalization (not headline-style)
+- Gerunds for procedures: "Installing the operator" (not "Install the operator")
+- Nouns for concepts: "Authentication overview"
+- 3-11 words; no terminal periods
+- Do not use Level 2 (H3) headings (`===`) or lower in any files
+
+### Banned words
+- Filler: simply, just, basically, easily, obviously
+- Vague verbs: utilize, leverage, performant
+- Politeness: please, thank you
+- "Easy", "simple"
+- Negative connotation: execute, kill – prefer "run", "stop"
+
+### Word forms
+- back end (n), back-end (adj)
+- command line (n), command-line (adj)
+- One word: cannot, download, email, hostname, upstream, downstream
+- Verb/noun: log in (v), login (n); set up (v), setup (n)
+
+### Red Hat specifics
+- Short descriptions required: 50-300 chars, active voice, user intent
+- Prerequisites as completed checks (not imperatives)
+- One command per code block
+- User-replaced values: `_<value_name>_` (italicized, angle brackets)
+- Include `$` prompt sign for terminal commands, use `#` for root commands
+- Use `sudo` not `su -`
+- Product attributes: `{prodname}`, `{product-version}`
+- No cost references, no future promises
+- `{nbsp}` between "Red" and "Hat"
+
+### OpenShift module conventions
+- Module files: `con-` (concept), `proc-` (procedure), `ref-` (reference)
+- Module IDs with context suffix: `[id="proc-install-operator_{context}"]`
+- Files end with newline
+- US English spelling
+
+## Step 4: Generate Downstream Document
+
+Create the downstream version with this structure:
+
+### AsciiDoc format (standard for RHCL docs)
+
+```asciidoc
+[id="module-id-here_{context}"]
+= Module title (sentence-style capitalization, use gerunds for procedures)
+
+[role="_abstract"]
+Short description here (50-300 chars, active voice, states what and why).
+
+== Prerequisites
+
+* Prerequisite as completed check
+* Another prerequisite as completed check
+
+== Procedure
+
+. First step with inline YAML or command
++
+[source,terminal,subs="+quotes"]
+----
+$ oc apply -f - <<EOF
+apiVersion: example.io/v1
+kind: Example
+metadata:
+  name: example
+  namespace: my-namespace
+# ...
+EOF
+----
+
+. Second step with verification
++
+[source,terminal,subs="+quotes"]
+----
+$ oc get example -n my-namespace
+----
+
+. Final step
+
+== Verification
+
+. Check that the resource exists
++
+[source,terminal,subs="+quotes"]
+----
+$ oc get example example -n my-namespace
+----
+
+. Verify the expected behavior
+
+== Additional resources
+
+* Link to related RHCL doc
+* Link to OpenShift doc
+```
+
+### Content organization
+
+1. **Module header**: ID with context variable, title
+2. **Abstract**: Short description with role tag
+3. **Prerequisites**: Completed checks, not imperatives
+4. **Procedure/Content**: Step-by-step or concept explanation
+5. **Verification**: How to confirm success (for procedures)
+6. **Additional resources**: Internal cross-references
+
+### YAML/Code examples
+- One command per code block within procedure steps
+- Separate input and output into different blocks
+- Use `[source,yaml]` or `[source,terminal,subs="+quotes"]` tags – **never use `[source,bash]`**
+- Quote substitution is **required** for all terminal blocks: `[source,terminal,subs="+quotes"]`
+- Include prompt signs: `$` for regular user commands, `#` for root commands
+- Comment ellipses: `# ...`
+- No syntax highlighting for plain terminal output
+
+### DITA compliance
+
+Apply DITA 1.3 validation rules for OpenShift documentation:
+
+- **Validation config**: https://raw.githubusercontent.com/openshift/openshift-docs/refs/heads/main/modules/.vale.ini
+- **Accepted terms**: https://raw.githubusercontent.com/openshift/openshift-docs/refs/heads/main/.vale/styles/config/vocabularies/OpenShiftDocs/accept.txt (in addition to RHCL-specific terms such as Authorino, Limitador, Kuadrant, etc.)
+- **Rejected terms**: https://raw.githubusercontent.com/openshift/openshift-docs/refs/heads/main/.vale/styles/config/vocabularies/OpenShiftDocs/reject.txt
+
+If uncertain about a term or style choice, consult these vocabulary lists. Prefer accepted terms and avoid rejected terms entirely. RHCL-specific component names (Authorino, Limitador, DNS Operator, Cert-manager) are implicitly accepted even if not in the OpenShift vocabulary list.
+
+## Step 5: Quality Checks
+
+Before presenting the downstream doc, verify:
+
+- [ ] No mentions of "Kuadrant" except when referencing upstream project
+- [ ] No Helm installation procedures
+- [ ] No unsupported gateway providers (vanilla Istio, Envoy Gateway)
+- [ ] Gateway provider priority: CIO (default) with `gatewayClassName: openshift-default`, OSSM only if specified
+- [ ] No `kubectl` commands (use `oc`)
+- [ ] No `localhost` or `nip.io` hostnames (use variables)
+- [ ] No links to GitHub files or repos
+- [ ] All YAML examples are inline and complete
+- [ ] All make targets expanded into explicit steps
+- [ ] OpenShift security context constraints applied
+- [ ] Product attributes used: `{prodname}`, `{product-version}`
+- [ ] IBM Style compliance: active voice, present tense, "that" in clauses
+- [ ] Red Hat conventions: short description, proper module ID, prerequisites
+- [ ] Heading style: gerunds for procedures, nouns for concepts, L2 only (no L3+)
+- [ ] Terminal commands: `$` prompt for user, `#` for root, `sudo` not `su -`
+- [ ] Code blocks: `[source,terminal,subs="+quotes"]` for terminal output (not `bash`)
+- [ ] Banned words avoided: execute/kill (use run/stop), simply, just, easily, etc.
+- [ ] DITA 1.3 compliance: OpenShiftDocs vocabulary, no rejected terms
+- [ ] Cross-references to existing downstream docs instead of duplication
+- [ ] Real hostnames or clear placeholders (no trivial DNS tools)
+- [ ] **All procedural steps preserved**: No steps added or removed without user confirmation
+- [ ] Command sequences complete and in correct order
+
+## Step 6: Output Format
+
+Present the converted downstream documentation as:
+
+1. **Summary of changes**: What was excluded, what was adapted, what was added
+2. **Scope confirmation**: Features/use cases covered in this downstream version
+3. **The downstream document**: Complete AsciiDoc module(s)
+4. **Integration notes**: Where this fits in the current downstream structure, suggested cross-references
+5. **Follow-up recommendations**: Suggest running `/review-downstream-docs` on the generated content
+
+## Integration with Documentation Workflow
+
+This skill is typically used in sequence:
+
+1. `/jtbd-docs` - Frame the documentation around user jobs
+2. `/doc-verification` - Verify upstream doc accuracy (optional, if working from existing upstream)
+3. `/port-docs-to-downstream` - Convert to downstream format (this skill)
+4. `/review-downstream-docs` - Review the downstream doc for technical accuracy and style compliance
+
+## Common Scenarios
+
+### Scenario 1: Feature guide with limited use cases
+User: "Port the X.509 authentication doc but only Tier 2 use case"
+- Read upstream doc
+- Identify Tier 2 content
+- Exclude Tier 1 and Tier 3 explanations and procedures
+- Simplify branching logic
+- Generate focused downstream procedure
+
+### Scenario 2: API reference
+User: "Port the RateLimitPolicy API reference"
+- Read upstream API doc
+- Filter out unsupported fields or options
+- Convert examples to OpenShift context
+- Replace Kubernetes-generic examples with OpenShift-specific ones
+- Add RHCL context
+
+### Scenario 3: Tutorial or walkthrough
+User: "Port the getting started guide"
+- Replace Helm with OLM installation (or skip, reference existing install doc)
+- Convert kubectl to oc
+- Replace Kind/local cluster with OpenShift cluster assumption
+- Convert all hostnames to production-style variables
+- Inline all YAML files referenced
+- Remove make targets, show explicit commands
+
+## Error Handling and Edge Cases
+
+**If upstream doc not found:**
+- Try alternate URLs (main vs specific branch)
+- Ask user for correct path or URL
+
+**If scope is ambiguous:**
+- List features found in upstream
+- Ask which to include/exclude
+- Clarify use cases and tiers
+
+**If downstream structure unclear:**
+- Check current downstream docs: https://github.com/openshift/openshift-docs/tree/rhcl-docs-main
+- Ask user where this should fit
+- Suggest possible integration points
+
+**If unsupported features referenced:**
+- Flag them clearly in the summary
+- Ask user whether to exclude or adapt
+- Provide alternatives where possible
+
+## Verification Before Finalizing
+
+Run these checks on the generated downstream doc:
+
+1. **Grep for upstream-only terms:**
+   ```bash
+   grep -i "kuadrant\|helm install\|kubectl\|kind create\|localhost\|nip\.io\|github\.com.*\.yaml" downstream-doc.adoc
+   ```
+
+2. **Check for inline YAML:**
+   Ensure no "see example.yaml" or "clone the repo" instructions
+
+3. **Verify OpenShift specifics:**
+   ```bash
+   grep -i "oc \|openshift\|securityContext\|route\|project" downstream-doc.adoc
+   ```
+
+4. **Style compliance:**
+   ```bash
+   grep -i "don't\|can't\|won't\|simply\|just\|easily\|please\|execute\|kill" downstream-doc.adoc
+   ```
+
+5. **Code block format:**
+   ```bash
+   grep "\[source,bash\]" downstream-doc.adoc
+   ```
+   Should return no results (use `[source,terminal,subs="+quotes"]` instead)
+
+6. **Heading levels:**
+   ```bash
+   grep "^===" downstream-doc.adoc
+   ```
+   Should return no results (Level 2/H3 headings prohibited)
+
+7. **Product attributes:**
+   ```bash
+   grep "{product-title}" downstream-doc.adoc
+   ```
+   Should return no results (use `{prodname}` instead)
+
+Report any violations before presenting final output.
+
+## Notes for Reviewers
+
+When this skill completes:
+- The generated downstream doc is a first draft requiring human review
+- Technical accuracy must be verified against actual RHCL release capabilities
+- Integration with existing downstream structure may need adjustment
+- IBM Style and Red Hat conventions are applied but may need refinement
+- Always run `/review-downstream-docs` as a follow-up quality check
+
+## Related Skills
+
+- **jtbd-docs**: Apply before this skill to ensure job-focused framing
+- **doc-verification**: Verify upstream doc accuracy before conversion
+- **review-downstream-docs**: Review generated downstream doc for quality and compliance

--- a/claude-skills/review-downstream-docs/review-downstream-docs.md
+++ b/claude-skills/review-downstream-docs/review-downstream-docs.md
@@ -1,0 +1,386 @@
+---
+name: review-downstream-docs
+description: "Review downstream (OpenShift/RHCL) documentation PRs for technical accuracy and style compliance"
+argument-hint: "<PR-URL>"
+---
+
+# Downstream Documentation Review
+
+Review a documentation PR for technical accuracy against the upstream codebase and compliance with IBM Style and the Red Hat supplementary style guide.
+
+## Style authority
+
+Priority order: IBM Style Guide (primary), then Red Hat Supplementary Style Guide (secondary, adds Red Hat-specific conventions on top of IBM). The substantive rules from both are baked into this skill below so that reviews do not require fetching external docs.
+
+- IBM Style: https://www.ibm.com/docs/en/ibm-style
+- Red Hat Supplementary Style Guide: https://redhat-documentation.github.io/supplementary-style-guide/
+
+## Input
+
+The user provides `$ARGUMENTS` which should be a GitHub PR URL (e.g. `https://github.com/openshift/openshift-docs/pull/109317`).
+
+## Step 1: Fetch the PR
+
+Requires `gh` CLI installed and authenticated (`gh auth status` to check).
+
+Parse the PR URL to extract `<owner>/<repo>` and `<number>`, then run:
+
+1. `gh pr view <number> --repo <owner>/<repo> --json title,body,files,additions,deletions` -- PR metadata and changed files
+2. `gh pr diff <number> --repo <owner>/<repo>` -- full diff (this is the source of truth for all content)
+3. `gh api repos/<owner>/<repo>/pulls/<number>/comments` -- existing review comments with threading
+4. `gh api repos/<owner>/<repo>/pulls/<number>/reviews` -- review states (approved, changes requested)
+
+Identify all changed `.adoc` files from the metadata. Focus the review on new and modified module files (`modules/con-*.adoc`, `modules/proc-*.adoc`, `modules/ref-*.adoc`) and assembly files.
+
+## Step 2: Technical accuracy review
+
+This is the most important step. Every technical claim in the documentation must be verified against the actual codebase.
+
+### Verification methodology
+
+For each technical claim in the docs, follow this process:
+
+1. **Identify the claim type**: Is it about a header name, API field, component behaviour, architecture, configuration, or workflow?
+2. **Locate the source of truth**: Find the code that implements the claimed behaviour. Use Grep/Read on the upstream repo.
+3. **Verify precisely**: Don't assume -- check exact strings, field names, header values, config formats. A header called `x-mcp-tool` vs `x-mcp-toolname` is wrong even though it's close.
+4. **Check scope claims**: Statements like "all traffic", "every request", "always" are frequently overstated. Verify the actual scope.
+5. **Check component boundaries**: Which component does what? Don't let docs attribute behaviour to the wrong component.
+
+### What to verify
+
+- **Header names**: Grep for exact header string literals in the code. Header names in docs are frequently wrong or outdated.
+- **Config types**: Is it a ConfigMap or Secret? Check the controller/operator code.
+- **Component responsibilities**: Which component does what? Read the handler code.
+- **API resource names**: CRD names, field names, status conditions. Check the API type definitions.
+- **Architecture claims**: Data flow, what talks to what, what intercepts what. Check the actual wiring.
+- **Feature claims**: Does the described feature actually exist? Is it implemented or just planned?
+- **Default values**: Are claimed defaults correct? Check flag definitions and constants.
+- **Shell commands**: Do grep patterns match actual log messages? Do deployment names match? Do protocol versions match current code?
+
+### Upstream codebase location
+
+The skill needs access to the upstream codebase to verify claims. To find it:
+
+1. Check the current working directory -- it may already be the upstream repo.
+2. Check sibling directories (e.g. `../project-name`).
+3. If not found, ask the user for the path.
+
+Once located, read the project's `CLAUDE.md` (if it exists) to understand the codebase structure, key files, architecture, and conventions. This replaces hardcoded file lists -- the CLAUDE.md is the source of truth for where to find things in the codebase.
+
+## Step 3: Style review
+
+Apply IBM Style (primary) and the Red Hat Supplementary Style Guide (secondary). Focus on obvious mistakes and issues that affect clarity, not pedantic nitpicks. The key rules from both guides are listed here for reference.
+
+### Voice, tense, and person (IBM Style)
+
+- **Active voice**: Use active voice. Passive is acceptable when the subject matters more than the actor.
+- **Present tense**: Use present tense. Avoid future tense ("will") except when describing something that genuinely occurs later.
+- **Second person**: Use "you" to address the reader. Avoid first person (I, we, our, us) in technical docs.
+- **No anthropomorphism**: Systems do not "think", "want", "complain", "refuse", or "know".
+
+### Contractions (IBM Style + RH override)
+
+IBM Style permits contractions in context. However, Red Hat product documentation avoids contractions except in content with a conversational tone. Flag contractions in formal procedure/reference docs: don't, can't, won't, it's, that's, you'll, isn't, aren't, doesn't, hasn't, haven't, shouldn't, couldn't, wouldn't.
+
+### Conjunctions and clarity (IBM Style)
+
+- Use *since* only for time, not as a synonym for *because*.
+- Use *while* only for simultaneous actions, not as a synonym for *although*.
+- Use *once* only for "one time", not as a synonym for *after* or *when*.
+- Use *as* only for simultaneous actions, not as a synonym for *because*.
+- Use *if* for conditions, *whether* for alternatives.
+- Use *if...then*: avoid using *then* to introduce an independent clause after *if*.
+- Use *that* (no comma) for restrictive clauses. Use *which* (with comma) for nonrestrictive clauses.
+- Include *that* in subordinate clauses for translation clarity ("verify that the pod is running" not "verify the pod is running"). This is one of the most common issues in doc PRs; IBM is emphatic about it. Always include "that" after verbs like verify, ensure, confirm, specify, check, note.
+- Place *only* immediately before the word or phrase it modifies ("the gateway processes only HTTP requests" not "the gateway only processes HTTP requests").
+
+### Inclusive language (IBM Style + RH)
+
+Flag these if found:
+- blacklist/whitelist: use denylist/allowlist, blocklist/passlist
+- master/slave: use primary/secondary, source/replica, controller/device
+- Do not use "white" or "black" in contexts where white is good and black is bad
+- Avoid gender-specific pronouns; use "you" or rephrase with plural nouns
+
+### Banned words and filler (IBM Style + RH)
+
+- **Filler**: simply, basically, essentially, actually, really, very, totally, obviously, just, easily
+- **Vague/inflated verbs**: leverage (use "use"), utilize (use "use"), architect as verb (use "design"), performant
+- **Informal**: gonna, admin (spell out on first use), info (spell out)
+- **Politeness terms**: please, thank you (avoid in technical information; terms of politeness convey wrong tone)
+- **Never state things are "easy" or "simple"**
+
+### Preferred terms (IBM Style)
+
+- "because" not "since/as" (for reason)
+- "for example" not "e.g."
+- "that is" not "i.e."
+- "such as" not "like" (for examples)
+- "whether" not "if" (for choices)
+- "click" not "click on"
+- "start" not "start up"
+- "print" not "print out"
+- "use" not "utilize/leverage"
+- "ensure" not "make sure" (but note: "ensure" can imply a guarantee; in contexts with legal or SLA implications, consider "verify" or "confirm" instead)
+
+### Possessives (IBM Style)
+
+- Do not use possessive 's with inanimate objects ("the server labels" not "the server's labels")
+- Do not use possessive 's with abbreviations or product names ("the layout of the GUI" not "the GUI's layout", "IBM Cloud solutions" not "IBM Cloud's solutions")
+
+### Headings (IBM Style + RH override)
+
+IBM Style says do not use question-style headings in concept/reference/procedure topics. Red Hat supplementary guide adds:
+
+- Use **sentence-style capitalisation**, not headline-style
+- Use **gerunds** for procedures: "Installing the CLI" not "Install the CLI"
+- Use **nouns or noun phrases** for concept/reference topics
+- Do not start with "Understanding", "Introducing"
+- Keep between 3-11 words; no one-word titles
+- Do not use Level 2 (H3) headings (`===`) or lower in any files
+- No terminal periods (IBM Style); no file/command names in titles (IBM Style)
+
+### Abbreviations (IBM Style)
+
+- Spell out on first use, then abbreviation in parentheses, unless well known (HTML, API, HTTP, DNS, TCP/IP)
+- Do not use abbreviations as verbs ("use the FTP command" not "FTP the files")
+- Do not use possessive 's on abbreviations ("the properties of HTML" not "HTML's properties")
+- Plural: add lowercase *s* (CRDs, APIs, LLMs)
+- Do not use Latin abbreviations: use "for example" (not e.g.), "that is" (not i.e.), use "and so on" (not etc.)
+
+### Punctuation (IBM Style)
+
+- **Serial comma**: Use a serial comma before a conjunction that precedes the final item in a series of three or more.
+- **Em dashes**: Do not use em dashes in technical information. Use commas, parentheses, colons, or rewrite.
+- **Exclamation points**: Never in docs.
+- **Ellipses**: Avoid in technical information.
+- **Slashes**: Do not use for "or". Write "enable or disable" not "enable/disable".
+- **Parenthetical (s)**: Do not use. Write the plural form, or "one or more".
+
+### Numbers (IBM Style)
+
+- Use numerals to represent all numbers in most cases. For numbers below 10 in text, it is also acceptable to use words.
+- Use commas to separate groups of three numerals, including 4-digit numbers (1,000 not 1000).
+- Non-breaking space between value and unit (2 GB, 100 MHz).
+
+### Lists (IBM Style)
+
+- Lead-in must be a complete sentence (for translation clarity). Use complete sentences, not phrases, to introduce lists.
+- Complete sentence items get periods. Fragment items get no punctuation.
+- Items must be grammatically parallel.
+- Do not break a sentence across a list.
+
+### Word forms (IBM Style)
+
+Two-word nouns, hyphenated adjectives:
+- back end (n), back-end (adj) -- not "backend"
+- front end (n), front-end (adj) -- not "frontend"
+- command line (n), command-line (adj)
+- real time (n), real-time (adj)
+- on premise (adverb), on-premise (adj)
+
+Two words always: bug fix, code base, data center, data source, data store, data type, file name, file system, file type, health check, home page, web page, web UI
+
+One word always: cannot, download, downstream, email, hostname, lifecycle, offline, online, screenshot, troubleshoot, upstream, uptime, username
+
+Verb/noun splits:
+- backup (n/adj), back up (v)
+- login (n/adj), log in (v), log in to (3 words, never "log into")
+- setup (n/adj), set up (v)
+- shut down (v), shutdown (only for the command)
+
+Other:
+- open source -- two words, lowercase, never hyphenated
+- double-click -- hyphenated
+- built-in (adj) -- hyphenated
+- dialog box -- not "dialog" or "dialogue"
+
+### Spelling (IBM Style)
+
+US English spelling in all publications: labeled (not labelled), color (not colour), analyze (not analyse), center (not centre), license (not licence), program (not programme), canceled (not cancelled), gray (not grey), fulfill (not fulfil), recognize (not recognise).
+
+### Red Hat supplementary conventions (RH overrides/additions)
+
+These apply on top of IBM Style for Red Hat product docs:
+
+**Admonitions**: Use NOTE, IMPORTANT, WARNING, TIP only. Use singular form (NOTE not NOTES). Keep brief; do not include procedures. Minimize use; avoid placing multiple admonitions near each other.
+
+**Short descriptions (abstracts)**: Required for every module and assembly. Length: 50-300 characters. Use active voice, present tense, plain English. Include user intent (what and why). Avoid "This topic covers..." self-references. Tag: `[role="_abstract"]`.
+
+**Prerequisites**: Write as checks that are true or completed before procedure. Use passive voice if needed. Do not use imperative formations.
+
+**Single-step procedures**: Use an unnumbered bullet, not a numbered list.
+
+**Code blocks**: One command per code block per procedure step. Separate command input and output into individual code blocks. Do not use `bash` for syntax highlighting of terminal commands (incorrectly interprets `#` as comment).
+
+**User-replaced values**: Format as `_<value_name>_` (angle brackets, underscores for multi-word, lowercase, italicised). In XML, use `_${value_name}_`.
+
+**Commands requiring root**: Use `sudo` for temporary elevation, not `su -`. When using `sudo`, display `$` prompt, not `#`.
+
+**Product names and versions**: Use attributes (`{product-title}`, `{product-version}`) not hardcoded names.
+
+**Date formats**: Preferred: _day Month year_ (3 October 2019).
+
+**YAML ellipses**: Use `# ...` (commented) instead of bare `...` which indicates document end in YAML.
+
+**IP addresses in examples**: Use documentation-reserved ranges: IPv4 192.0.2.0/24, 198.51.100.0/24, 203.0.113.0/24. IPv6 2001:0DB8::/32.
+
+**Developer Preview features**: Include the Developer Preview admonition template at the content beginning. Developer Preview is a distinct category from Technology Preview with its own required wording.
+
+**Technology Preview features**: Include the Technology Preview admonition template at the content beginning. Technology Preview has its own distinct required wording, separate from Developer Preview. Do not conflate the two.
+
+For both: avoid the word "support"; use "available", "provide", "capability".
+
+**No cost references**: Avoid all references to product costs or charges.
+
+**No future release promises**: Do not mention specific future release numbers or dates. Exception: deprecation/removal notices.
+
+**CAUTION admonition banned**: Do not use CAUTION admonition type. It is not fully supported by the Red Hat Customer Portal.
+
+**Non-breaking space for "Red Hat"**: Use `{nbsp}` between "Red" and "Hat" to prevent line breaks splitting the company name.
+
+**"enter" not "type"**: Use "enter" instead of "type" or "input" when instructing users to provide text in a GUI field.
+
+**Short description before admonitions**: Never start a module or assembly with an admonition. Always provide a short description first.
+
+**External links**: Avoid deep links into external sites (link to top-level pages). Do not use bare URLs or URL shorteners.
+
+**MAC addresses in examples**: Use RFC 7042 documentation-reserved ranges: unicast 00:00:5E:00:53:00-FF, multicast 01:00:5E:90:10:00-FF.
+
+### OpenShift/RHCL module conventions
+
+- Module files: `con-` (concept), `proc-` (procedure), `ref-` (reference)
+- Module IDs must include `_{context}` suffix: `[id="con-about-feature-name_{context}"]`
+- Assembly files include modules with `include::modules/con-foo.adoc[leveloffset=+1]`
+- Files must end with a newline
+- US English spelling (labeled not labelled, color not colour, capitalize not capitalise)
+
+## Step 3b: Run style checks (MANDATORY -- do not skip)
+
+After completing the technical review, run these grep-based checks against the diff. Do not skip this step even if the technical review found many issues. Requires `gh` CLI installed and authenticated.
+
+```bash
+# Extract only added content lines (no diff metadata, no comments)
+gh pr diff <number> --repo <owner>/<repo> | grep '^+' | grep -v '^+++' | grep -v '^+//' > /tmp/pr-content.txt
+
+# 1. Banned words, filler, and contractions
+grep -i -E "\bsimply\b|\bjust\b|\bbasically\b|\beasily\b|\beasy\b|\bsimple\b|\bobviously\b|\bplease\b|\bdon't\b|\bcan't\b|\bwon't\b|\bit's\b|\bthat's\b|\byou'll\b|\butilize\b|\bleverage\b|\bperformant\b|\band/or\b|\bgot\b|\bwish\b" /tmp/pr-content.txt
+
+# 2. Ambiguous/incorrect terms
+grep -i -E "\bshould\b|\bmay\b|\bonce\b|\bsince\b|\ballows\b|\bwhile\b|\bclick on\b|\blog into\b|\bnavigate to\b|\be\.g\.\b|\bi\.e\.\b" /tmp/pr-content.txt
+
+# 3. Future tense and first person
+grep -i -E "\bwill be\b|\bwill have\b|\bwill not\b|\bwe \b|\bour \b" /tmp/pr-content.txt
+
+# 4. Exclusionary language
+grep -i -E "\bblacklist\b|\bwhitelist\b|\bmaster\b|\bslave\b|\bsanity\b" /tmp/pr-content.txt
+
+# 5. Vague heading verbs
+gh pr diff <number> --repo <owner>/<repo> | grep '^+=' | grep -i -E "Understanding|Introducing"
+
+# 6. Possessives on product names
+grep -i -E "MCP gateway's|Envoy's|Kubernetes's|OpenShift's|Istio's|Authorino's" /tmp/pr-content.txt
+
+# 7. Anthropomorphism
+grep -i -E "\bthinks\b|\bwants\b|\bknows\b|\brefuses\b|\bcomplains\b|\btries to\b" /tmp/pr-content.txt
+
+# 8. Common word form errors
+grep -i -E "\bbackend\b|\bfrontend\b|\bopen-source\b|\bsetup\b.*verb-context|\blog into\b" /tmp/pr-content.txt
+
+# 9. Em dashes (should not appear in technical docs per IBM Style)
+grep -E "\xE2\x80\x94|--[^-]" /tmp/pr-content.txt
+
+# 10. Latin abbreviations
+grep -i -E "\be\.g\.|\bi\.e\.|\betc\." /tmp/pr-content.txt
+```
+
+Report only findings that affect clarity or violate IBM/RH rules. If the checks come back clean, state that explicitly -- don't manufacture issues. Context matters: "should" in a YAML comment is fine, "backend" as part of `backendRef` (a Kubernetes API field) is fine.
+
+## Step 4: Check existing review comments
+
+Use `gh` to fetch all review comments and their context:
+
+```bash
+# Get all review comments with reply threading
+gh api repos/<owner>/<repo>/pulls/<number>/comments \
+  --jq '.[] | {id, user: .user.login, path: .path, line: .line, body: .body, in_reply_to_id: .in_reply_to_id, created_at: .created_at}'
+
+# Get review states (approved, changes requested, commented)
+gh api repos/<owner>/<repo>/pulls/<number>/reviews \
+  --jq '.[] | {user: .user.login, state: .state}'
+```
+
+For each comment from a human reviewer (ignore bots unless they flag real errors):
+
+1. **Check if addressed**: A comment is considered addressed if ANY of:
+   - The suggested change appears in the current diff (compare suggestion text against current file content)
+   - A reply exists from the author acknowledging it
+   - The comment has emoji reactions (the API doesn't always show these -- note this limitation)
+   - The `in_reply_to_id` field shows a thread with resolution
+
+2. **Check if technically correct**: Reviewer suggestions can be wrong. Verify every `suggestion` block against the codebase before endorsing it. If a reviewer suggests wrong header names, flag that too.
+
+3. **Check if still relevant**: The file or section may have been rewritten since the comment was posted. Compare the comment's `path` and `line` against the current diff.
+
+4. **Author `//Q:` comments**: These are inline questions from the doc author asking for technical input. Answer each one based on the codebase. Use `gh pr diff` to find them:
+   ```bash
+   gh pr diff <number> --repo <owner>/<repo> | grep -n '//Q:'
+   ```
+   Then get the correct file line number using the per-file extraction method.
+
+Only flag unaddressed comments that contain valid technical corrections or unanswered questions. Do not flag resolved threads or style-only suggestions from bots.
+
+## Step 5: Output format
+
+The output is a single numbered list of comments to post on the PR. Every finding (technical accuracy, style, author questions, unaddressed reviewer comments) becomes a comment in this list. Do not split findings into separate sections -- the user needs one consolidated list of actions.
+
+Structure each comment as:
+
+```
+**N. `file path`, line NN**
+
+Comment text explaining the issue. Include ```suggestion blocks where appropriate.
+```
+
+Group related issues on the same file/line into a single comment where it makes sense (e.g. a typo and a technical error on the same line).
+
+For author `//Q:` comments, the comment should answer the question based on the codebase. Frame it as a helpful response, not a finding.
+
+### Priority ordering
+
+Order comments by priority within the list:
+
+1. Technical inaccuracies (wrong header names, wrong component, wrong config type) -- always include
+2. Misleading scope claims ("all traffic", "every request") -- always include
+3. Unaddressed reviewer comments with valid corrections -- always include
+4. Author `//Q:` questions -- always answer
+5. Grammar errors that change meaning -- include
+6. Style violations -- include only if egregious or frequent
+7. Minor style nits -- skip entirely
+
+### No nitpicking
+
+Do not include:
+- Minor style preferences that don't affect clarity (serial comma placement, minor word choice)
+- Formatting inconsistencies that don't affect rendering
+- AsciiDoc conventions that are clearly just the author's style
+- Anything you'd label "minor" or "nit" -- skip it entirely
+
+Only include issues that would cause user confusion, technical errors, or broken workflows.
+
+### Verification before reporting (MANDATORY)
+
+Every finding must be triple-checked before inclusion. False positives destroy reviewer credibility.
+
+For each finding, complete ALL of these steps:
+
+1. **Re-read the exact text in the PR diff** -- not a paraphrase, not from memory. Run `gh pr diff` and grep for the exact string.
+2. **Re-verify against the code** -- grep for exact string literals (header names, log messages, config types, field names). If you claim something "doesn't exist in the codebase", prove it with a zero-match grep.
+3. **Confirm the line number** -- GitHub PR reviews use file line numbers (right-side in the diff view), NOT diff output line numbers. To get the correct line number for a finding in a new file, extract just the file content from the diff and number it:
+   ```
+   gh pr diff <number> --repo <owner>/<repo> | sed -n '/^+++ b\/path\/to\/file/,/^diff --git/p' | grep '^+' | grep -v '^+++' | cat -n | grep 'search term'
+   ```
+   This strips the diff metadata and gives you the true file line numbers. NEVER use raw `gh pr diff | cat -n` line numbers -- they include diff headers, hunk markers, and context lines that throw off the count. NEVER estimate line numbers from memory.
+4. **Verify reviewer suggestions** -- if a finding is about another reviewer's suggestion, check that the suggestion itself is correct. Reviewers can be wrong too.
+5. **Check for stale upstream docs** -- API type comments, CLAUDE.md, AGENTS.md can contain stale information. If the doc repeats a claim from an API comment, verify the claim matches the actual implementation, not just the comment.
+6. **Test commands** -- if the doc includes shell commands (grep patterns, curl commands, oc commands), verify: (a) the exact string/pattern would produce results, (b) deployment names and namespaces match the actual deployment, (c) protocol versions and API paths are current.


### PR DESCRIPTION
Version(s):
main only

Issue:
[OSDOCS-19962](https://redhat.atlassian.net/browse/OSDOCS-19962)

Link to docs preview:
N/A

QE review:
N/A

Additional information:
Internal Claude skills for testing with RHCL documentation. These skills are being ported in from the private Kuadrant developer tools repository. The review is a sanity check (that I won't break the repo; that the folder structure looks reasonable, etc.). Reviewing the skills themselves is out of scope.

can be updated according to https://github.com/Kuadrant/dev-team-plugin/pull/44#event-26274565944

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
