### PR TITLE
OSDOCS Fix numbering issues in Configuring credentials that allow images to be mirrored

### DIFF
--- a/modules/installation-adding-registry-pull-secret.adoc
+++ b/modules/installation-adding-registry-pull-secret.adoc
@@ -92,11 +92,10 @@ Specify the path to the directory to store the pull secret in and a name for the
 }
 ----
 +
---
-// An additional step for following this procedure when using oc-mirror as part of the disconnected install process.
 ifdef::oc-mirror[]
---
 . Save the file as either `~/.docker/config.json` or `$XDG_RUNTIME_DIR/containers/auth.json`:
++
+// An additional step for following this procedure when using oc-mirror as part of the disconnected install process.
 
 .. If the `.docker` or `$XDG_RUNTIME_DIR/containers` directories do not exist, create one by entering the following command:
 +
@@ -115,13 +114,13 @@ $ cp <path>/<pull_secret_file_in_json> <directory_name>/<auth_file>
 ----
 +
 The `<directory_name>` is either `~/.docker` or `$XDG_RUNTIME_DIR/containers`, and `<auth_file>` is either `config.json` or `auth.json`
---
 endif::oc-mirror[]
-// Similar to the additional step above, except it is framed as optional because it is included in a disconnected update page (where users may or may not use oc-mirror for their process)
 ifdef::update-oc-mirror[]
 
 . Optional: If using the oc-mirror plugin, save the file as either `~/.docker/config.json` or `$XDG_RUNTIME_DIR/containers/auth.json`:
-
++
+// Similar to the additional step above, except it is framed as optional because it is included in a disconnected update page (where users may or may not use oc-mirror for their process)
+	
 ** If the `.docker` or `$XDG_RUNTIME_DIR/containers` directories do not exist, create one by entering the following command:
 +
 [source,terminal]
@@ -141,8 +140,6 @@ $ cp <path>/<pull_secret_file_in_json> <directory_name>/<auth_file>
 Where `<directory_name>` is either `~/.docker` or `$XDG_RUNTIME_DIR/containers`, and `<auth_file>` is either `config.json` or `auth.json`.
 
 endif::update-oc-mirror[]
-// Additional step for allowing this procedure for oc-mirror-v2
-// Should this step below also have the "if you don't have this directory, create it using this command" substeps?
 ifdef::oc-mirror-v2[]
 
 . If the `$XDG_RUNTIME_DIR/containers` directory does not exist, create one by entering the following command:
@@ -151,11 +148,14 @@ ifdef::oc-mirror-v2[]
 ----
 $ mkdir -p $XDG_RUNTIME_DIR/containers
 ----
++
+// Additional step for allowing this procedure for oc-mirror-v2
++
+// Should this step below also have the "if you don't have this directory, create it using this command" substeps?
 
 . Save the pull secret file as `$XDG_RUNTIME_DIR/containers/auth.json`.
 endif::oc-mirror-v2[]
 endif::openshift-origin[]
---
 
 . Generate the base64-encoded user name and password or token for your mirror registry by running the following command:
 +


### PR DESCRIPTION
In fixing another issue, I saw that the numbering in this procedure is incorrect. Apparently, the comments in the steps were breaking the procedure. I see that adding the comments with `+` character is a fix. 

Disconnected environments -> Mirroring images for a disconnected installation by using the oc-mirror plugin v2 -> [Configuring credentials that allow images to be mirrored](https://112576--ocpdocs-pr.netlify.app/openshift-enterprise/latest/disconnected/about-installing-oc-mirror-v2#installation-adding-registry-pull-secret_about-installing-oc-mirror-v2)  [Current docs](https://docs.redhat.com/en/documentation/openshift_container_platform/4.21/html/disconnected_environments/about-installing-oc-mirror-v2#installation-adding-registry-pull-secret_about-installing-oc-mirror-v2)

Disconnected environments -> Mirroring images for a disconnected installation using the oc-mirror plugin -> [Configuring credentials that allow images to be mirrored](https://112576--ocpdocs-pr.netlify.app/openshift-enterprise/latest/disconnected/installing-mirroring-disconnected#installation-adding-registry-pull-secret_installing-mirroring-disconnected)  [Current docs](https://docs.redhat.com/en/documentation/openshift_container_platform/4.21/html/disconnected_environments/installing-mirroring-disconnected#installation-adding-registry-pull-secret_installing-mirroring-disconnected)

Disconnected environments -> Mirroring images for a disconnected installation by using the oc adm command -> [Configuring credentials that allow images to be mirrored](https://112576--ocpdocs-pr.netlify.app/openshift-enterprise/latest/disconnected/installing-mirroring-installation-images#installation-adding-registry-pull-secret_installing-mirroring-installation-images)  [Current docs](https://docs.redhat.com/en/documentation/openshift_container_platform/4.21/html/disconnected_environments/installing-mirroring-installation-images#installation-adding-registry-pull-secret_installing-mirroring-installation-images)

Disconnected environments -> Updating a cluster in a disconnected environment -> Mirroring OpenShift Container Platform images -> Preparing your mirror host -> [Configuring credentials that allow images to be mirrored](https://112576--ocpdocs-pr.netlify.app/openshift-enterprise/latest/disconnected/updating/mirroring-image-repository#installation-adding-registry-pull-secret_mirroring-ocp-image-repository) [Current docs](https://docs.redhat.com/en/documentation/openshift_container_platform/4.21/html/disconnected_environments/updating-a-cluster-in-a-disconnected-environment#installation-adding-registry-pull-secret_mirroring-ocp-image-repository)

Images -> Using the Cluster Samples Operator with an alternate registry -> [Configuring credentials that allow images to be mirrored](https://docs.redhat.com/en/documentation/openshift_container_platform/4.21/html/images/samples-operator-alt-registry#installation-adding-registry-pull-secret_samples-operator-alt-registry) -- This one looks OK in the [Current docs](https://docs.redhat.com/en/documentation/openshift_container_platform/4.21/html/images/samples-operator-alt-registry#installation-adding-registry-pull-secret_samples-operator-alt-registry).

There is no OKD preview, but the errors in the file caused formatting issues. Look in the [current docs](https://docs.okd.io/latest/disconnected/about-installing-oc-mirror-v2.html#installation-adding-registry-pull-secret_about-installing-oc-mirror-v2) for _Mirroring an image set to a mirror registry_ after this section as an example. 
Here is a screenshot of the fix in a local preview:
<img width="1649" height="656" alt="image" src="https://github.com/user-attachments/assets/93246bc9-a478-438b-90d4-215c6cd80aca" />

