### PR TITLE
OSDOCS-18179-bug-batch-monitoring-4-22 RNs

### DIFF
--- a/modules/rn-ocp-release-notes-fixed-issues.adoc
+++ b/modules/rn-ocp-release-notes-fixed-issues.adoc
@@ -155,6 +155,21 @@ The following issues are fixed for this release:
 // [id="rn-ocp-release-note-management-console-fixed-issues_{context}"]
 // == Management Console
 
+[id="rn-ocp-release-note-monitoring-fixed-issues_{context}"]
+== Monitoring
+
+* Before this update, a regression introduced in {product-title} version 4.15 impacted the `AlertingRule` logic, leading to inaccurate processing of alert definitions. This regression caused the system to generate duplicate alerts for the same event, causing it to misinterpret alert definitions and cluttered monitoring dashboards. With this release, the underlying regression has been resolved, restoring the intended behavior and logic to the `AlertingRule` component. (link:https://issues.redhat.com/browse/OCPBUGS-61262[OCPBUGS-61262])
+
+* Before this update, the use of deprecated Kubernetes APIs generated significant unnecessary log noise within Prometheus, cluttering monitoring dashboards with redundant warnings. With this release, these deprecated API calls have been mitigated to reduce the log output to only one error. (link:https://redhat.atlassian.net/browse/OCPBUGS-65568[OCPBUGS-65568])
+
+* Before this update, the minimal collection profile did not have the `kube_pod_labels` metric included, which affected the *Control Plane* panel in the Console dashboard. With this release, the panel works as expected. (link:https://issues.redhat.com/browse/OCPBUGS-66069[OCPBUGS-66069])
+
+* Before this update, the user workload Prometheus Operator did not validate the `webhookURL` secret reference in the MSTeams receiver configuration of the `AlertmanagerConfig` custom resource. As a consequence, an invalid or missing `webhookURL` secret could be accepted, causing the user workload `Alertmanager` to crash at runtime. With this release, the user workload Prometheus Operator validates the `webhookURL` secret for MSTeams receivers, rejecting invalid configurations before they can affect the `Alertmanager`. (link:https://issues.redhat.com/browse/OCPBUGS-67303[OCPBUGS-67303])
+
+* Before this update, the `StatefulSet` controller did not automatically repair pods when the `StatefulSet` definition got reverted to a valid  configuration after a roll-out brought the pods into a broken state. With this release, the Prometheus Operator has been configured to evict unready pods when it detects that there is a more recent revision of the `StatefulSet` controller. (link:https://issues.redhat.com/browse/OCPBUGS-78976[OCPBUGS-78976])
+
+* Before this update, when Prometheus was configured to scrape targets using client Transport Layer Socket (TLS) certificates without a certificate authority (CA), rotating the client certificates caused Prometheus to permanently stop scraping the affected targets. Prometheus continued running but no metrics were collected from those targets until a manual restart. With this release, Prometheus correctly handles client certificate rotation when no CA is configured, and scraping continues uninterrupted after rotation. (link:https://issues.redhat.com/browse/OCPBUGS-86248[OCPBUGS-86248])
+
 
 [id="rn-ocp-release-note-networking-fixed-issues_{context}"]
 == Networking


### PR DESCRIPTION
Version(s):
4.22

Issue:
https://redhat.atlassian.net/browse/OSDOCS-18179

Link to docs preview:
https://112583--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-22-release-notes.html#rn-ocp-release-note-monitoring-fixed-issues_release-notes


QE review:
- [ ] QE has approved this change.
- [ ] 

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
