### PR TITLE
OSDOCS-18179-bug-batch-machine-config-4-22

### DIFF
--- a/modules/rn-ocp-release-notes-fixed-issues.adoc
+++ b/modules/rn-ocp-release-notes-fixed-issues.adoc
@@ -113,6 +113,20 @@ The following issues are fixed for this release:
 // [id="rn-ocp-release-note-kube-api-server-fixed-issues_{context}"]
 // == Kubernetes API Server* 
 
+[id="rn-ocp-release-note-machine-config-operator-fixed-issues_{context}"]
+== Machine Config Operator
+
+* Before this update, the Machine Config Operator (MCO) would default to the control plane architecture if the annotation was missing while performing boot images. For multi-arch clusters, this was causing incorrect updates. With this release, the multi-arch clusters are skipped when the arch annotation is not found. (link:https://issues.redhat.com/browse/OCPBUGS-69674[OCPBUGS-69674])
+
+* Before this update, the Machine Config Operator (MCO) failed to log into vCenter during installation, which resulted in the vSphere credentials being erroneously recorded as part of the login error message. With this release, the error message has been updated to exclude sensitive details, ensuring that the MCO no longer logs credentials on login failure. (link:https://issues.redhat.com/browse/OCPBUGS-77318[OCPBUGS-77318])
+
+* Before this update, faulty `vCenter` matching logic caused boot image update failures in multi center vSphere clusters. As a consequence, the Machine Config Operator (MCO) degraded when boot image updates were enabled for this scenario. With this update, the matching `vCenter` logic is fixed. As a result, boot image updates work as expected in 4.21 for multi center vSphere clusters. (link:https://redhat.atlassian.net/browse/OCPBUGS-77498[OCPBUGS-77498])
+
+* Before this update, the Machine Config Operator (MCO) only enabled `systemd` units that contained explicit content, filtering out those without it. This prevented `systemd` units provided by extensions from being enabled when a `MachineConfig` object with `enabled: true` was applied after the extension was installed. With this release, the MCO has been modified to enable any `systemd` unit that either has content or an existing unit file, ensuring that extension-provided `systemd` units are correctly detected and enabled regardless of whether they are currently loaded. (link:[https://redhat.atlassian.net/browse/OCPBUGS-83874](https://redhat.atlassian.net/browse/OCPBUGS-83577)[OCPBUGS-83577])
+
+
+
+
 // [id="rn-ocp-release-note-management-console-fixed-issues_{context}"]
 // == Management Console
 


### PR DESCRIPTION
Version(s):
4.22

Issue:
https://redhat.atlassian.net/browse/OSDOCS-18179

Link to docs preview:
https://112587--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-22-release-notes.html#rn-ocp-release-note-machine-config-operator-fixed-issues_release-notes


QE review:
- [ ] QE has approved this change.


Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
