### PR TITLE
[OSDOCS#18851]: Removed Ingress LB installer related statement

### DIFF
--- a/installing/installing_two_node_cluster/installing_tnf/installing-two-node-fencing.adoc
+++ b/installing/installing_two_node_cluster/installing_tnf/installing-two-node-fencing.adoc
@@ -6,10 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-:FeatureName: Two-node OpenShift cluster with fencing
-include::snippets/technology-preview.adoc[leveloffset=+1]
-
-A two-node OpenShift cluster with fencing provides high availability (HA) with a reduced hardware footprint. This configuration is designed for distributed or edge environments where deploying a full three-node control plane cluster is not practical.
+[role="_abstract"]
+A two-node {product-title} cluster with fencing provides high availability (HA) with a reduced hardware footprint. This configuration is designed for distributed or edge environments where deploying a full three-node control plane cluster is not practical.
 
 A two-node cluster does not include compute nodes. The two control plane machines run user workloads in addition to managing the cluster.
 
@@ -17,7 +15,7 @@ Fencing is managed by Pacemaker, which can isolate an unresponsive node by using
 
 [NOTE]
 ====
-You can deploy a two-node OpenShift cluster with fencing by using either the user-provisioned infrastructure  method or the installer-provisioned infrastructure method.
+You can deploy a two-node {product-title} cluster with fencing by using either the user-provisioned infrastructure method or the installer-provisioned infrastructure method.
 ====
 
 The two-node OpenShift cluster with fencing requires the following hosts:
@@ -52,9 +50,6 @@ include::modules/installation-dns-user-infra-example.adoc[leveloffset=+2]
 
 // Two-node-dns-requirements - installer-provisioned infrastructure
 include::modules/installation-dns-installer-infra.adoc[leveloffset=+1]
-
-// Cofiguration for Ingress LB to get it to work with Pacemaker
-include::modules/installation-two-node-ingress-lb-configuration.adoc[leveloffset=+1]
 
 //  Creating a manifest object that includes a customized br-ex bridge
 include::modules/installation-two-node-creating-manifest-custom-br-ex.adoc[leveloffset=+1]

--- a/modules/sample-install-config-two-node-fencing-ipi.adoc
+++ b/modules/sample-install-config-two-node-fencing-ipi.adoc
@@ -35,7 +35,6 @@ controlPlane:
         certificateVerification: Enabled
 metadata:
   name: <cluster_name>
-featureSet: TechPreviewNoUpgrade
 platform:
   baremetal:
     apiVIPs:
@@ -66,7 +65,6 @@ sshKey: '<ssh_public_key>'
 * `fencing.credentials.hostname`: Provide the Baseboard Management Console (BMC) credentials for each control plane node. These credentials are required for node fencing and prevent split-brain scenarios. 
 * `fencing.credentials.certificateVerification`: Set this field to `Disabled` if your Redfish URL uses self-signed certificates, which is common for internally-hosted endpoints. Set this field to `Enabled` for URLs with valid CA-signed certificates.
 * `metadata.name`: The cluster name is used as a prefix for hostnames and DNS records.  
-* `featureSet`: Set this field to `TechPreviewNoUpgrade` to enable two-node OpenShift cluster deployments.  
 * `platform.baremetal.apiVIPs` and `platform.baremetal.ingressVIPs` : Virtual IPs for the API and Ingress endpoints. Ensure they are reachable by all nodes and external clients.  
 * `pullSecret`: Contains credentials required to pull container images for the cluster components.  
 * `sshKey`: The SSH public key for accessing cluster nodes after installation.

--- a/modules/sample-install-config-two-node-fencing-upi.adoc
+++ b/modules/sample-install-config-two-node-fencing-upi.adoc
@@ -33,7 +33,6 @@ controlPlane:
         password: <password>
 metadata:
   name: <cluster_name>
-featureSet: TechPreviewNoUpgrade
 platform:
   none: {}
 pullSecret: '<pull_secret>'
@@ -44,7 +43,6 @@ sshKey: '<ssh_public_key>'
 * `controlPlane.replicas`: Set this field to `2` for a two-node fencing deployment.  
 * `fencing.credentials.hostname`: Provide BMC credentials for each control plane node.  
 * `metadata.name`: Cluster name is used as a prefix for hostnames and DNS records.  
-* `featureSet`: Enables a two-node {product-title} cluster with fencing deployments.  
 * `platform.none` Set the platform to `none` for user-provisioned infrastructure deployments. Bare-metal hosts are pre-provisioned outside of the installation program.
 * `pullSecret`: Contains credentials required to pull container images for the cluster components.  
 * `sshKey`: The SSH public key for accessing cluster nodes after installation.


### PR DESCRIPTION

Version(s):
4.22

Issue:
https://redhat.atlassian.net/browse/OSDOCS-18851

Link to docs preview:


QE review:
- [x] QE has approved this change.


Additional information:
Made changes specific to the 4.22 feature and reverted all CQA or other editorial changes. The scope of this PR is to remove the module related to the Ingress LB installer. 
