### PR TITLE
OSDOCS#19909: Add runC container runtime to deprecation tables

### DIFF
--- a/modules/rn-ocp-release-notes-deprecated-features.adoc
+++ b/modules/rn-ocp-release-notes-deprecated-features.adoc
@@ -25,3 +25,7 @@ As an alternative, use the xref:../disconnected/about-installing-oc-mirror-v2.ad
 Deprecation of adding kernel modules to nodes with KVC::
 +
 As of {product-title} 4.22, support for adding kernel modules to nodes with kmods-via-containers software (KVC) has been deprecated and will be removed in a future release.
+
+Deprecation of the runC container runtime::
++
+As of {product-title} 4.22, support for using the runC container runtime is deprecated and will be removed in a future release.

--- a/modules/rn-ocp-release-notes-deprecated-removed-tables.adoc
+++ b/modules/rn-ocp-release-notes-deprecated-removed-tables.adoc
@@ -132,6 +132,11 @@
 |Technology Preview
 |Technology Preview
 |Removed
+
+|runC container runtime
+|General Availability
+|General Availability
+|Deprecated
 |====
 
 


### PR DESCRIPTION
Version(s):
4.22

Issue:
[OSDOCS-19909](https://redhat.atlassian.net/browse/OSDOCS-19909)

Link to docs preview:
TBD

QE review:
- [ ] QE has approved this change.

Additional information:

N/A