### PR TITLE
OSDOCS-18179-bug-batch-olm-4-22

### DIFF
--- a/modules/rn-ocp-release-notes-fixed-issues.adoc
+++ b/modules/rn-ocp-release-notes-fixed-issues.adoc
@@ -316,6 +316,21 @@ The following issues are fixed for this release:
 
 * Before this update, when performing disk-to-mirror operations, `oc-mirror` generated cluster resource manifests with empty status fields for `ClusterCatalog`, `CatalogSource`, and `UpdateService` resources. As a consequence, the generated YAML files contained unnecessary `status: {}` entries. With this release, `oc-mirror` no longer includes empty status fields in generated cluster resource manifests. As a result, the generated YAML files are cleaner and do not contain empty status fields. (link:https://redhat.atlassian.net/browse/OCPBUGS-77146[OCPBUGS-77146])
 
+[id="rn-ocp-release-note-olm-fixed-issues_{context}"]
+== OLM
+
+* Before this update, the `collect-profiles` job was affected by maintenance difficulties, causing confusion for customers and support engineers during troubleshooting. With this release, the `collect-profiles` job is removed, improving user experience and reducing maintenance effort. (link:https://issues.redhat.com/browse/OCPBUGS-31547[OCPBUGS-31547])
+
+* Before this update, the `cluster-olm-operator` did not detect version changes during cluster upgrades. As a consequence, the Operator failed to report the `Progressing=True` status during upgrades, which prevented accurate upgrade monitoring. With this release, version detection logic was added that compares `RELEASE_VERSION` against the stored Operator version and sets the `Progressing=True` status when an upgrade is detected. As a result, the Operator correctly reports the `Progressing` status during upgrades, which improves upgrade observability. (link:https://redhat.atlassian.net/browse/OCPBUGS-65623[OCPBUGS-65623])
+
+* Before this update, `NetworkPolicy` egress rules hardcoded port 6443 for `kube-apiserver` access. Because {hcp} allows custom API server ports via the `hostedcluster.spec.networking.apiServer.port` parameter, OLM Operators failed to communicate with `kube-apiserver` in hosted clusters that used non-default API ports. As a consequence, the Operator functionality and catalog operations were broken. With this release, the hardcoded port 6443 is replaced with wildcard egress (`egress: [{}]`) for `kube-apiserver` traffic. Explicit DNS rules (ports 53, 5353) were also added for documentation and future policy refinements. As a result, OLM now supports deploying {hcp} with any configured API server port. (link:https://redhat.atlassian.net/browse/OCPBUGS-66980[OCPBUGS-66980])
+
+* Before this update, `NetworkPolicy` egress rules in OLM v0 hardcoded port 6443 for `kube-apiserver` access across static manifests and generated policies. Because {hcp} allows custom API server ports that differ from 6443, OLM v0 components (`olm-operator`, `catalog-operator`, `packageserver`) did not communicate with `kube-apiserver` in {hcp} clusters that used custom API ports. As a consequence, Operator installation and catalog operations were prevented. With this update, `NetworkPolicy` egress rules are updated to use a wildcard (egress: [{}]) for `kube-apiserver` traffic in both static manifests and dynamic policy generation code. Explicit DNS rules (ports 53, 5353) are also added for future policy refinements. As a result, OLM v0 supports {hcp} deployments with any configured API server port. (link:https://redhat.atlassian.net/browse/OCPBUGS-76971[OCPBUGS-76971])
+
+* Before this update, the `catalog-operator` pod failed during the {sno} cluster install. With this release, the nil pointer dereference in the `sortUnpackJobs` parameter when sorting non-failed jobs is fixed. As a result, the `catalog-operator` pod does not fail during the cluster install. (link:https://issues.redhat.com/browse/OCPBUGS-77179[OCPBUGS-77179])
+
+
+
 [id="rn-ocp-release-note-ocp-api-server-fixed-issues_{context}"]
 == OpenShift API Server
 


### PR DESCRIPTION
Version(s):
4.22

Issue:
https://redhat.atlassian.net/browse/OSDOCS-18179

Link to docs preview:
https://112594--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-22-release-notes.html#rn-ocp-release-note-olm-fixed-issues_release-notes


QE review:
- [ ] QE has approved this change.


Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
