### PR TITLE
CNV-80383: Add 3 CNV release notes for 4.22

### DIFF
--- a/virt/release_notes/virt-4-22-release-notes.adoc
+++ b/virt/release_notes/virt-4-22-release-notes.adoc
@@ -40,6 +40,12 @@ To view the supported guest operating systems for {VirtProductName}, see link:ht
 
 // Infrastructure
 
+Monitor node memory overcommit level for virtual machines::
++
+Cluster administrators can balance workloads using the VM memory overcommit and utilization dashboard. The dashboard allows you to monitor whether the clusters are underutilized or at risk due to memory overcommit to decide whether to expand the cluster.
++
+link:https://redhat.atlassian.net/browse/CNV-44026[CNV-44026]
+
 KubeVirt Redfish for VM management through the Redfish API (Technology Preview)::
 +
 KubeVirt Redfish exposes {VirtProductName} virtual machines through the standard Redfish API. Using KubeVirt Redfish, administrators can manage VM power states, boot configuration, and virtual media attachments. This feature is available as a Technology Preview.
@@ -73,6 +79,12 @@ link:https://redhat.atlassian.net/browse/CNV-72621[CNV-72621]
 
 
 // Storage
+
+Native storage migration support for virtual machines::
++
+{VirtProductName} supports native storage migration in {product-title} 4.20 and later. Before this update, you installed Migration Toolkit for Containers (MTC) to migrate virtual machine (VM) disks to different storage classes. You need not install MTC since the VM disk storage class migration is native to {VirtProductName}. Additionally, it is no longer a requirement that the VMs you select for each bulk migration be in the same namespace.
++
+link:https://redhat.atlassian.net/browse/CNV-73518[CNV-73518]
 
 Configure predictable PVC and DV names when cloning VMs::
 +
@@ -201,6 +213,13 @@ Convert an existing VM to a template from the user interface (Technology Preview
 Virtual machine (VM) owners can create, filter, and delete a user-generated template. You can create a template from an existing VM in the same project as the running VM or a different project from the OpenShift Virtualization user interface. To make sure that the data is consistent, stop the VM before you create a template. This capability is a Technology Preview feature.
 +
 link:https://redhat.atlassian.net/browse/CNV-81577[CNV-81577]
+
+//CNV-73392
+Create virtual machines from in-cluster native templates (Technology Preview)::
++
+Virtual machine (VM) owners can create VMs from {VirtProductName} cluster native template custom resource. The VM template tracks a golden image that is updated periodically, while reducing errors, and ensuring uniformity in the virtualized environment. You can host the template in all namespaces that you can control. This capability is a Technology Preview feature.
++
+link:https://redhat.atlassian.net/browse/CNV-73392[CNV-73392]
 
 //[id="virt-4-22-bug-fixes_{context}"]
 //== Fixed issues


### PR DESCRIPTION
Version(s):
4.22

Issue:
https://redhat.atlassian.net/browse/CNV-44026
https://redhat.atlassian.net/browse/CNV-73518
https://redhat.atlassian.net/browse/CNV-73392

Link to docs preview:
_Will add after preview build completes_

QE review:
- [ ] QE has approved this change.

Additional information:
Adds 3 CNV release notes for OpenShift Virtualization 4.22 covering infrastructure monitoring, storage migration, and VM template enhancements.

---

🤖 Generated with Claude Code