### PR TITLE
CNV-80383: Add 5 CNV release notes for 4.22

### DIFF
--- a/virt/release_notes/virt-4-22-release-notes.adoc
+++ b/virt/release_notes/virt-4-22-release-notes.adoc
@@ -40,6 +40,12 @@ To view the supported guest operating systems for {VirtProductName}, see link:ht
 
 // Infrastructure
 
+Monitor node memory overcommit level for virtual machines::
++
+Cluster administrators can balance workloads using the VM memory overcommit and utilization dashboard. The dashboard allows you to monitor whether clusters are underutilized or at risk due to memory overcommit, or to decide whether to expand a cluster.
++
+link:https://redhat.atlassian.net/browse/CNV-44026[CNV-44026]
+
 KubeVirt Redfish for VM management through the Redfish API (Technology Preview)::
 +
 KubeVirt Redfish exposes {VirtProductName} virtual machines through the standard Redfish API. Using KubeVirt Redfish, administrators can manage VM power states, boot configuration, and virtual media attachments. This feature is available as a Technology Preview.
@@ -73,6 +79,12 @@ link:https://redhat.atlassian.net/browse/CNV-72621[CNV-72621]
 
 
 // Storage
+
+Option to automatically clean up source PVCs after storage migration::
++
+Virtual machine (VM) owners can now automatically clean up source persistent volume claims (PVCs) after a storage migration, reducing manual cleanup tasks. By default, {VirtProductName} retains the source PVCs so you can manually clean them up. You can deselect the option to keep source PVCs in the user interface to enable automatic cleanup after the migration completes.
++
+link:https://redhat.atlassian.net/browse/CNV-73509[CNV-73509]
 
 Configure predictable PVC and DV names when cloning VMs::
 +
@@ -130,6 +142,12 @@ Removed deprecated label from localnet network attachment definition type::
 The web console no longer displays a *Deprecated* label next to the localnet `NetworkAttachmentDefinition` (NAD) type. This change clarifies that localnet NAD functionality is not deprecated and remains fully supported. You can use either the NAD-based approach or the VM network wizard to create localnet networks for connecting virtual machines to physical networks.
 +
 link:https://redhat.atlassian.net/browse/OCPBUGS-83809[OCPBUGS-83809]
+
+Overview tab displays dynamic hierarchical view of VM data::
++
+The *Overview* tab displays a dynamic, hierarchical view of VM data that adapts to your tree view selection, supporting both cluster and multi-cluster levels.
++
+link:https://redhat.atlassian.net/browse/CNV-79560[CNV-79560]
 
 Add an internal certificate authority or a self-signed certificate for virtual machine images::
 Cluster administrators can create a custom certificate authority (CA) or a self-signed certificate for URL images in a cluster in the Add Volume dialog. As a result, you can secure access to HTTPS sources to be used to create a virtual machine (VM) in a streamlined user workflow, without switching to the command line interface (CLI) for manual patching.
@@ -202,6 +220,13 @@ Virtual machine (VM) owners can create, filter, and delete a user-generated temp
 +
 link:https://redhat.atlassian.net/browse/CNV-81577[CNV-81577]
 
+//CNV-73392
+Create virtual machines from in-cluster native templates (Technology Preview)::
++
+Virtual machine (VM) owners can create VMs from the {VirtProductName} cluster native template custom resource. The VM template tracks a golden image that is updated periodically, reducing errors and ensuring uniformity in the virtualized environment. You can host the template in all namespaces that you can control.
++
+link:https://redhat.atlassian.net/browse/CNV-73392[CNV-73392]
+
 //[id="virt-4-22-bug-fixes_{context}"]
 //== Fixed issues
 
@@ -210,6 +235,14 @@ link:https://redhat.atlassian.net/browse/CNV-81577[CNV-81577]
 
 [role="_abstract"]
 Some linked Jira tickets are accessible only with Red Hat credentials.
+
+//CNV-78892
+Non-versioned HyperConverged commands default to v1 API::
+In this release, the v1 API for the `HyperConverged` custom resource (CR) is introduced, in preparation for a future migration from v1beta1 to v1. Due to the way Kubernetes selects default API versions, non-versioned commands such as `oc get hco`, `oc edit hyperconverged`, and `oc patch hyperconverged` now default to the v1 API. As a consequence, these commands can behave unexpectedly or fail because the v1 API is not yet ready for production use.
++
+To work around this problem, use the fully versioned type name `hyperconvergeds.v1beta1.hco.kubevirt.io` when running commands against the `HyperConverged` CR. For example, use `oc get hyperconvergeds.v1beta1.hco.kubevirt.io` instead of `oc get hco`. For the `oc explain` command, use the `--api-version` flag: `oc explain --api-version=hco.kubevirt.io/v1beta1 hco.spec`. As a result, commands target the v1beta1 API as intended.
++
+link:https://redhat.atlassian.net/browse/CNV-78892[CNV-78892]
 
 //CNV-38746: According to Petr, this will remain relevant as long as 4.12 is available. Anyone upgrading from 4.12 could be affected. Version 4.12 is supported until January 2026
 [id="virt-4-22-ki-networking_{context}"]


### PR DESCRIPTION
Version(s):
4.22

Issue:
https://redhat.atlassian.net/browse/CNV-44026
https://redhat.atlassian.net/browse/CNV-73509
https://redhat.atlassian.net/browse/CNV-73392
https://redhat.atlassian.net/browse/CNV-78892
https://redhat.atlassian.net/browse/CNV-79560

Link to docs preview:
https://112604--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/release_notes/virt-4-22-release-notes.html

QE review:
- [x] QE has approved this change.

Additional information:
Adds 5 CNV release notes for OpenShift Virtualization 4.22 covering infrastructure monitoring, storage PVC cleanup, VM template enhancements, HyperConverged API versioning, and web console Overview tab improvements.

---

🤖 Generated with Claude Code