### PR TITLE
OSDOCS#18178: Remove unused sections from 4.22 RN files 

### DIFF
--- a/modules/rn-ocp-release-notes-fixed-issues.adoc
+++ b/modules/rn-ocp-release-notes-fixed-issues.adoc
@@ -94,7 +94,6 @@ The following issues are fixed for this release:
 // [id="rn-ocp-release-note-dev-console-fixed-issues_{context}"]
 // == Dev Console
 
-
 [id="rn-ocp-release-note-etcd-fixed-issues_{context}"]
 == etcd
 
@@ -143,12 +142,6 @@ The following issues are fixed for this release:
 
 * Before this update, certificate files for the Kube APi server were not flushed to disk immediately after being written, and data could remain in memory without being persisted to storage. As a consequence, on {sno} clusters, an ungraceful shutdown could cause all Kube API server certificates to be lost, leaving the cluster unable to start. With this release, certificate writes are flushed to disk before any previous data is removed, ensuring crash durability. As a result, {sno} clusters that experience an unexpected shutdown no longer risk losing their Kube API server certificates. (link:https://redhat.atlassian.net/browse/OCPBUGS-85269[OCPBUGS-85269])
 
-[id="rn-ocp-release-note-kube-controller-manager-fixed-issues_{context}"]
-== Kube Controller Manager
-
-[id="rn-ocp-release-note-kube-scheduler-fixed-issues_{context}"]
-== Kube Scheduler
-
 [id="rn-ocp-release-note-kube-storage-version-migrator-fixed-issues_{context}"]
 == Kube Storage Version Migrator
 
@@ -168,9 +161,6 @@ The following issues are fixed for this release:
 * Before this update, faulty `vCenter` matching logic caused boot image update failures in multi center vSphere clusters. As a consequence, the Machine Config Operator (MCO) degraded when boot image updates were enabled for this scenario. With this update, the matching `vCenter` logic is fixed. As a result, boot image updates work as expected in 4.21 for multi center vSphere clusters. (link:https://redhat.atlassian.net/browse/OCPBUGS-77498[OCPBUGS-77498])
 
 * Before this update, the Machine Config Operator (MCO) only enabled `systemd` units that contained explicit content, filtering out those without it. This prevented `systemd` units provided by extensions from being enabled when a `MachineConfig` object with `enabled: true` was applied after the extension was installed. With this release, the MCO has been modified to enable any `systemd` unit that either has content or an existing unit file, ensuring that extension-provided `systemd` units are correctly detected and enabled regardless of whether they are currently loaded. (link:[https://redhat.atlassian.net/browse/OCPBUGS-83874](https://redhat.atlassian.net/browse/OCPBUGS-83577)[OCPBUGS-83577])
-
-
-
 
 // [id="rn-ocp-release-note-management-console-fixed-issues_{context}"]
 // == Management Console
@@ -278,15 +268,8 @@ The following issues are fixed for this release:
 
 * Before this update, when Prometheus was configured to scrape targets using client Transport Layer Socket (TLS) certificates without a certificate authority (CA), rotating the client certificates caused Prometheus to permanently stop scraping the affected targets. Prometheus continued running but no metrics were collected from those targets until a manual restart. With this release, Prometheus correctly handles client certificate rotation when no CA is configured, and scraping continues uninterrupted after rotation. (link:https://issues.redhat.com/browse/OCPBUGS-86248[OCPBUGS-86248])
 
-
-[id="rn-ocp-release-note-networking-fixed-issues_{context}"]
-== Networking
-
-
-
-[id="clock-state-metrics_{context}"]
-== Clock state metrics degrade correctly after upstream clock loss
-
+// [id="rn-ocp-release-note-networking-fixed-issues_{context}"]
+// == Networking
 
 [id="rn-ocp-release-note-node-fixed-issues_{context}"]
 == Node
@@ -296,7 +279,6 @@ The following issues are fixed for this release:
 * Before this update, a race condition in the container stop path could have caused CRI-O to panic with a "send on closed channel" message when a second `StopContainer` call arrived after the first had already completed and closed the internal stop channel. As a consequence, the CRI-O process crashed, potentially leaving pods stuck in a terminating state. With this release, a `stopDone` guard is added to the `WaitOnStopTimeout` method so that it returns early after the stop life cycle is complete. As a result, concurrent `StopContainer` calls do not cause a panic by sending on a closed channel. (link:https://redhat.atlassian.net/browse/OCPBUGS-76415[OCPBUGS-76415])
 
 * Before this update, init containers in Tekton Pipelines finished too quickly for CRI-O to capture exit codes, causing intermittent failures in high-performance environments. As a consequence, these non-deterministic pipeline failures occurred. With this release, there is an improvement in the exit code handling of CRI-O for fast-completing init containers. As a result, high-performance Tekton Pipelines no longer intermittently fail due to non-deterministic exit code issues in init containers. (link:https://issues.redhat.com/browse/OCPBUGS-82162[OCPBUGS-82162])
-
 
 //[id="rn-ocp-release-note-node-tuning-operator-fixed-issues_{context}"]
 //== Node Tuning Operator
@@ -321,7 +303,6 @@ The following issues are fixed for this release:
 
 * Before this update, the `oc adm inspect` command failed to collect resources when both the API group and resource name were specified. As a consequence, resources could only be collected by specifying the resource name without the API group. With this release, `oc adm inspect` correctly resolves resource types when both the API group and resource name are specified and resources can be collected using explicit API group specifications. (link:https://redhat.atlassian.net/browse/OCPBUGS-76958[OCPBUGS-76958])
 
-
 [id="rn-ocp-release-note-oc-mirror-fixed-issues_{context}"]
 == oc-mirror
 
@@ -335,12 +316,10 @@ The following issues are fixed for this release:
 
 * Before this update, when performing disk-to-mirror operations, `oc-mirror` generated cluster resource manifests with empty status fields for `ClusterCatalog`, `CatalogSource`, and `UpdateService` resources. As a consequence, the generated YAML files contained unnecessary `status: {}` entries. With this release, `oc-mirror` no longer includes empty status fields in generated cluster resource manifests. As a result, the generated YAML files are cleaner and do not contain empty status fields. (link:https://redhat.atlassian.net/browse/OCPBUGS-77146[OCPBUGS-77146])
 
-
 [id="rn-ocp-release-note-ocp-api-server-fixed-issues_{context}"]
 == OpenShift API Server
 
 * Before this update, Security Context Constraints (SCCs) did not include `image` as a supported volume type. As a consequence, pods using image volumes failed to be created with the error `image volumes are not allowed to be used`. With this release, `image` is added as a supported volume type in SCCs. As a result, pods can use image volumes without security context constraint errors. (link:https://redhat.atlassian.net/browse/OCPBUGS-65807[OCPBUGS-65807])
-
 
 [id="ocp-release-notes-web-console-fixed-issues_{context}"]
 == Web console
@@ -350,18 +329,14 @@ The following issues are fixed for this release:
 // [id="rn-ocp-release-note-ocp-cli-fixed-issues_{context}"]
 // == OpenShift CLI (oc)
 
-
 // [id="rn-ocp-release-note-ocp-controller-fixed-issues_{context}"]
 // == OpenShift Controller
-
 
 // [id="rn-ocp-release-note-olm-classic-fixed-issues_{context}"]
 // == {olmv0-first}
 
-
 // [id="rn-ocp-release-note-service-catalog-fixed-issues_{context}"]
 // == Service Catalog
-
 
 [id="rn-ocp-release-note-storage-fixed-issues_{context}"]
 == Storage

--- a/modules/rn-ocp-release-notes-new-features.adoc
+++ b/modules/rn-ocp-release-notes-new-features.adoc
@@ -15,8 +15,8 @@ When a problem occurs on your {product-title} cluster, you want to determine exa
 
 For more information, see xref:../ai_applications/mcp_server/mcp-server-overview.adoc[MCP server for Red Hat {product-title}].
 
-[id="ocp-release-notes-api_{context}"]
-== API server
+// [id="ocp-release-notes-api_{context}"]
+// == API server
 
 ////
 Instructions: Add entries in the following format:
@@ -35,8 +35,8 @@ You can configure advanced OIDC authentication scenarios using structured authen
 +
 For more information, see xref:../authentication/structured-auth-config-fields.adoc#structured-auth-config-about[About advanced direct authentication fields].
 
-[id="ocp-release-notes-auto_{context}"]
-== Autoscaling
+// [id="ocp-release-notes-auto_{context}"]
+// == Autoscaling
 
 [id="ocp-release-notes-CVO_{context}"]
 == Cluster Version Operator
@@ -45,8 +45,8 @@ New `NetworkPolicy` parameter denies traffic for pods that are not host-networke
 
 A new `NetworkPolicy` parameter for the `openshift-cluster-version` namespace denies all ingress and egress traffic for pods that are not host-networked.
 
-[id="ocp-release-notes-edge-computing_{context}"]
-== Edge computing
+// [id="ocp-release-notes-edge-computing_{context}"]
+// == Edge computing
 
 ////
 Instructions: Add entries in the following format:
@@ -65,8 +65,8 @@ You can change network properties such as node IP addresses, machine network CID
 For more information, see xref:../edge_computing/sno_ip_configuration/cnf-understanding-sno-ip-configuration.adoc#cnf-understanding-sno-ip-configuration[Understand {sno} network reconfiguration].
 
 
-[id="ocp-release-notes-etcd_{context}"]
-== etcd
+// [id="ocp-release-notes-etcd_{context}"]
+// == etcd
 
 ////
 Instructions: Add entries in the following format:
@@ -283,12 +283,11 @@ With this update, the `AppliedFilesAndOS` condition reported by the machine conf
 +
 For more information, see xref:../machine_configuration/index.html#checking-mco-node-status_machine-config-overview[About node status during updates].
 
-[id="ocp-release-notes-machine-management_{context}"]
-== Machine management
+// [id="ocp-release-notes-machine-management_{context}"]
+// == Machine management
 
-
-[id="ocp-release-notes-monitoring_{context}"]
-== Monitoring
+// id="ocp-release-notes-monitoring_{context}"]
+// == Monitoring
 
 // This should be left for a little while to get users used to the fact that they will find release notes at a new place.
 
@@ -450,8 +449,8 @@ Availability of the `oc mirror list` command in oc-mirror v2 plugin::
 +
 With this update, you can use the list support feature with the oc-mirror v2 plugin. You can run the `oc mirror list` command to explore available platform and Operator content, including their specific versions, from remote and local registries. For more information, see xref:../disconnected/about-installing-oc-mirror-v2.adoc#oc-mirror-building-image-set-config-v2_about-installing-oc-mirror-v2[Creating the image set configuration].
 
-[id="ocp-release-notes-operator-development_{context}"]
-== Operator development
+// [id="ocp-release-notes-operator-development_{context}"]
+// == Operator development
 
 ////
 This section applies to the removed Operator SDK and the Operator base images that are still supported.

--- a/modules/rn-ocp-release-notes-technology-preview.adoc
+++ b/modules/rn-ocp-release-notes-technology-preview.adoc
@@ -575,7 +575,6 @@ Fleet Management supersedes Selectable Cluster Inventory in {product-title} 4.20
 |
 |====
 
-
 //[id="ocp-release-notes-special-hardware-tech-preview_{context}"]
 //== Specialized hardware and driver enablement Technology Preview features
 
@@ -584,7 +583,6 @@ Fleet Management supersedes Selectable Cluster Inventory in {product-title} 4.20
 //|====
 //|Feature |4.19 |4.20 |4.21
 //|====
-
 
 [id="ocp-release-notes-storage-tech-preview_{context}"]
 == Storage Technology Preview features


### PR DESCRIPTION
Version(s):
4.22

Issue:
[OSDOCS-18178](https://redhat.atlassian.net/browse/OSDOCS-18178)

Link to docs preview:
[Release notes](https://112610--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-22-release-notes.html)

QE review:
- [ ] QE has approved this change.
N/A
