### PR TITLE
OSDOCS-19974: Add --cloud flag to credential extraction across platforms

### DIFF
--- a/modules/cco-ccoctl-creating-at-once.adoc
+++ b/modules/cco-ccoctl-creating-at-once.adoc
@@ -150,12 +150,14 @@ $ oc adm release extract \
   --from=$RELEASE_IMAGE \
   --credentials-requests \
   --included \// <1>
-  --install-config=<path_to_directory_with_installation_configuration>/install-config.yaml \// <2>
-  --to=<path_to_directory_for_credentials_requests> <3>
+  --cloud=aws \// <2>
+  --install-config=<path_to_directory_with_installation_configuration>/install-config.yaml \// <3>
+  --to=<path_to_directory_for_credentials_requests> <4>
 ----
 <1> The `--included` parameter includes only the manifests that your specific cluster configuration requires.
-<2> Specify the location of the `install-config.yaml` file.
-<3> Specify the path to the directory where you want to store the `CredentialsRequest` objects. If the specified directory does not exist, this command creates it.
+<2> The `--cloud` parameter filters credential requests to only AWS provider specs.
+<3> Specify the location of the `install-config.yaml` file.
+<4> Specify the path to the directory where you want to store the `CredentialsRequest` objects. If the specified directory does not exist, this command creates it.
 +
 [NOTE]
 ====

--- a/modules/cco-ccoctl-creating-individually.adoc
+++ b/modules/cco-ccoctl-creating-individually.adoc
@@ -95,12 +95,14 @@ $ oc adm release extract \
   --from=$RELEASE_IMAGE \
   --credentials-requests \
   --included \// <1>
-  --install-config=<path_to_directory_with_installation_configuration>/install-config.yaml \// <2>
-  --to=<path_to_directory_for_credentials_requests> <3>
+  --cloud=aws \// <2>
+  --install-config=<path_to_directory_with_installation_configuration>/install-config.yaml \// <3>
+  --to=<path_to_directory_for_credentials_requests> <4>
 ----
 <1> The `--included` parameter includes only the manifests that your specific cluster configuration requires.
-<2> Specify the location of the `install-config.yaml` file.
-<3> Specify the path to the directory where you want to store the `CredentialsRequest` objects. If the specified directory does not exist, this command creates it.
+<2> The `--cloud` parameter filters credential requests to only AWS provider specs.
+<3> Specify the location of the `install-config.yaml` file.
+<4> Specify the path to the directory where you want to store the `CredentialsRequest` objects. If the specified directory does not exist, this command creates it.
 
 .. Use the `ccoctl` tool to process all `CredentialsRequest` objects by running the following command:
 +

--- a/modules/enabling-entra-workload-id-existing-cluster.adoc
+++ b/modules/enabling-entra-workload-id-existing-cluster.adoc
@@ -155,6 +155,7 @@ $ oc patch cloudcredential cluster \
 $ oc adm release extract \
   --credentials-requests \
   --included \
+  --cloud=azure \
   --to <path_to_directory_for_credentials_requests> \
   --registry-config ~/.pull-secret
 ----

--- a/modules/manually-configure-iam-nutanix.adoc
+++ b/modules/manually-configure-iam-nutanix.adoc
@@ -52,12 +52,14 @@ $ oc adm release extract \
   --from=$RELEASE_IMAGE \
   --credentials-requests \
   --included \// <1>
-  --install-config=<path_to_directory_with_installation_configuration>/install-config.yaml \// <2>
-  --to=<path_to_directory_for_credentials_requests> <3>
+  --cloud=nutanix \// <2>
+  --install-config=<path_to_directory_with_installation_configuration>/install-config.yaml \// <3>
+  --to=<path_to_directory_for_credentials_requests> <4>
 ----
 <1> The `--included` parameter includes only the manifests that your specific cluster configuration requires.
-<2> Specify the location of the `install-config.yaml` file.
-<3> Specify the path to the directory where you want to store the `CredentialsRequest` objects. If the specified directory does not exist, this command creates it.
+<2> The `--cloud` parameter filters credential requests to only Nutanix provider specs.
+<3> Specify the location of the `install-config.yaml` file.
+<4> Specify the path to the directory where you want to store the `CredentialsRequest` objects. If the specified directory does not exist, this command creates it.
 +
 .Sample `CredentialsRequest` object
 [source,yaml]

--- a/modules/manually-create-iam-ibm-cloud.adoc
+++ b/modules/manually-create-iam-ibm-cloud.adoc
@@ -101,10 +101,12 @@ $ oc adm release extract \
   --from=$RELEASE_IMAGE \
   --credentials-requests \
   --included \
+  --cloud=ibmcloud \
   --install-config=<path_to_directory_with_installation_configuration>/install-config.yaml \
   --to=<path_to_directory_for_credentials_requests>
 ----
 * `--included`: Includes only the manifests that your specific cluster configuration requires.
+* `--cloud=ibmcloud`: Filters credential requests to only {ibm-cloud-name} provider specs.
 * `<path_to_directory_with_installation_configuration>`: Specify the location of the `install-config.yaml` file.
 * `<path_to_directory_for_credentials_requests>`: Specify the path to the directory where you want to store the `CredentialsRequest` objects. If the specified directory does not exist, this command creates it.
 +

--- a/modules/manually-create-identity-access-management.adoc
+++ b/modules/manually-create-identity-access-management.adoc
@@ -220,12 +220,25 @@ $ oc adm release extract \
   --from=$RELEASE_IMAGE \
   --credentials-requests \
   --included \// <1>
-  --install-config=<path_to_directory_with_installation_configuration>/install-config.yaml \// <2>
-  --to=<path_to_directory_for_credentials_requests> <3>
+ifdef::aws[]
+  --cloud=aws \// <2>
+endif::aws[]
+ifdef::azure[]
+  --cloud=azure \// <2>
+endif::azure[]
+ifdef::ash[]
+  --cloud=azure \// <2>
+endif::ash[]
+ifdef::google-cloud-platform[]
+  --cloud=gcp \// <2>
+endif::google-cloud-platform[]
+  --install-config=<path_to_directory_with_installation_configuration>/install-config.yaml \// <3>
+  --to=<path_to_directory_for_credentials_requests> <4>
 ----
 <1> The `--included` parameter includes only the manifests that your specific cluster configuration requires.
-<2> Specify the location of the `install-config.yaml` file.
-<3> Specify the path to the directory where you want to store the `CredentialsRequest` objects. If the specified directory does not exist, this command creates it.
+<2> The `--cloud` parameter filters credential requests to only the provider specs for your platform.
+<3> Specify the location of the `install-config.yaml` file.
+<4> Specify the path to the directory where you want to store the `CredentialsRequest` objects. If the specified directory does not exist, this command creates it.
 +
 This command creates a YAML file for each `CredentialsRequest` object.
 +

--- a/modules/manually-maintained-credentials-upgrade-extract.adoc
+++ b/modules/manually-maintained-credentials-upgrade-extract.adoc
@@ -63,6 +63,11 @@ $ oc adm release extract \
 <1> The `--included` parameter includes only the manifests that your specific cluster configuration requires for the target release.
 <2> Specify the path to the directory where you want to store the `CredentialsRequest` objects. If the specified directory does not exist, this command creates it.
 +
+[TIP]
+====
+You can add the `--cloud` parameter to filter credential requests by cloud provider. Valid values are `alibabacloud`, `aws`, `azure`, `gcp`, `ibmcloud`, `nutanix`, `openstack`, `powervs`, and `vsphere`.
+====
++
 This command creates a YAML file for each `CredentialsRequest` object.
 
 . For each `CredentialsRequest` CR in the release image, ensure that a namespace that matches the text in the `spec.secretRef.namespace` field exists in the cluster. This field is where the generated secrets that hold the credentials configuration are stored.


### PR DESCRIPTION
## Summary

- Add `--cloud=<platform>` to `oc adm release extract --credentials-requests` commands across all platform-specific credential extraction procedures
- Aligns IBM Cloud, Azure, GCP, Nutanix, and the shared IAM module with the pattern AWS STS already uses
- Adds a tip about `--cloud` to the manual credentials upgrade extraction procedure

## Why

The `--included` flag alone does not reliably filter multi-provider `CredentialsRequest` objects. The ingress operator credential request ships with `providerSpec` blocks for multiple clouds in a single file. When extracted without `--cloud`, the file may contain specs for providers other than the target platform, causing the platform-specific `ccoctl` tool to fail.

On IBM Cloud, this manifests as `ccoctl ibmcloud create-service-id` failing with an `AWSProviderSpec` error. The `--cloud` flag explicitly filters to the target provider and prevents this failure.

AWS STS docs (`enabling-aws-sts-existing-cluster.adoc`) already use `--cloud=aws`. This PR brings consistency across all platforms.

## Changes

| File | Change |
|------|--------|
| `modules/manually-create-iam-ibm-cloud.adoc` | Add `--cloud=ibmcloud` |
| `modules/manually-configure-iam-nutanix.adoc` | Add `--cloud=nutanix` |
| `modules/enabling-entra-workload-id-existing-cluster.adoc` | Add `--cloud=azure` |
| `modules/cco-ccoctl-creating-individually.adoc` (AWS) | Add `--cloud=aws` |
| `modules/cco-ccoctl-creating-at-once.adoc` (AWS) | Add `--cloud=aws` |
| `modules/manually-create-identity-access-management.adoc` | Add platform-conditional `--cloud` via existing `ifdef` |
| `modules/manually-maintained-credentials-upgrade-extract.adoc` | Add tip about `--cloud` parameter |

## Related

- Bug: [OSDOCS-19974](https://issues.redhat.com/browse/OSDOCS-19974)
- Product bug: [OCPBUGS-36723](https://issues.redhat.com/browse/OCPBUGS-36723) (`--included` does not extract ingress credential)
- `oc adm release extract --help` documents `--cloud` with valid values: alibabacloud, aws, azure, gcp, ibmcloud, nutanix, openstack, ovirt, powervs, vsphere