### PR TITLE
GPU autoscaler improperly referenced in docs for IPI PowerVS

### DIFF
--- a/machine_management/creating_machinesets/creating-machineset-ibm-power-vs.adoc
+++ b/machine_management/creating_machinesets/creating-machineset-ibm-power-vs.adoc
@@ -4,6 +4,8 @@ include::_attributes/common-attributes.adoc[]
 = Creating a compute machine set on {ibm-power-server-title}
 :context: creating-machineset-ibm-power-vs
 
+toc::[]
+
 [role="_abstract"]
 Create compute machine sets in your {product-title} cluster on {ibm-power-server-name} to perform specific tasks. For example, you might create infrastructure machine sets and related machines so that you can move supporting workloads to the new machines. Moving supporting workloads to dedicated machines helps ensure that your cluster resources are allocated efficiently.
 
@@ -20,9 +22,6 @@ include::modules/machineset-yaml-ibm-power-vs.adoc[leveloffset=+1]
 
 //Creating a compute machine set
 include::modules/machineset-creating.adoc[leveloffset=+1]
-
-//Labeling GPU machine sets for the cluster autoscaler
-include::modules/machineset-label-gpu-autoscaler.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.17+ versions

Issue: https://redhat.atlassian.net/browse/OCPBUGS-50632

Link to docs preview:
https://112619--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/creating_machinesets/creating-machineset-ibm-power-vs.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
https://docs.redhat.com/en/documentation/openshift_container_platform/4.21/html/machine_management/managing-compute-machines-with-the-machine-api#machineset-label-gpu-autoscaler_creating-machineset-ibm-cloud
