### PR TITLE
OSDOCS-17325: Update descheduler profile default to PrometheusCPUMemoryCombinedProfile

### DIFF
--- a/modules/nodes-descheduler-profiles.adoc
+++ b/modules/nodes-descheduler-profiles.adoc
@@ -111,10 +111,15 @@ The `KubeVirtRelieveAndMigrate` profile evicts pods from high-cost nodes to redu
 * **Node maintenance**: A higher number of containers on a node increases resource consumption and maintenance costs.
 --
 +
-The profile enables the `LowNodeUtilization` strategy with the `EvictionsInBackground` alpha feature. The profile also exposes the following customization fields:
+The profile enables the `LowNodeUtilization` strategy with the alpha-level `EvictionsInBackground` feature. By default, the profile uses the `PrometheusCPUMemoryCombinedProfile` utilization metric. This metric combines CPU and memory utilization with pressure stall information (PSI) for both dimensions for comprehensive node load balancing.
++
+The profile also exposes the following customization fields:
 +
 --
-* `devActualUtilizationProfile`: Enables load-aware descheduling.
+* `devActualUtilizationProfile`: Enables load-aware descheduling. You can configure the following utilization profiles:
++
+** `PrometheusCPUMemoryCombinedProfile` (default): Balances nodes based on CPU utilization, CPU PSI pressure, memory utilization, and memory PSI pressure. This profile is ideal for environments with memory overcommit enabled, as it spreads the load and prevents resource contention.
+** `PrometheusCPUCombined`: Balances nodes based on CPU utilization and CPU PSI pressure only. Use this profile in environments without memory overcommit, where memory allocations are strictly guaranteed and CPU pressure is the primary driver for workload distribution.
 * `devLowNodeUtilizationThresholds`: Sets experimental thresholds for the `LowNodeUtilization` strategy. Do not use this field with `devDeviationThresholds`.
 * `devDeviationThresholds`: Treats nodes with below-average resource usage as underutilized to help redistribute workloads from overutilized nodes. Do not use this field with `devLowNodeUtilizationThresholds`. Supported values are: `Low` (10%:10%), `Medium` (20%:20%), `High` (30%:30%), `AsymmetricLow` (0%:10%), `AsymmetricMedium` (0%:20%), `AsymmetricHigh` (0%:30%).
 * `devEnableSoftTainter`: Enables the soft-tainting component to dynamically apply or remove soft taints as scheduling hints.
@@ -137,7 +142,7 @@ spec:
   profileCustomizations:
     devEnableSoftTainter: true
     devDeviationThresholds: AsymmetricLow
-    devActualUtilizationProfile: PrometheusCPUCombined
+    devActualUtilizationProfile: PrometheusCPUMemoryCombinedProfile
 ----
 +
 The `KubeVirtRelieveAndMigrate` profile requires PSI metrics to be enabled on all worker nodes. You can enable this by applying the following `MachineConfig` custom resource (CR):


### PR DESCRIPTION
Version(s):
4.22+

Issue:
https://redhat.atlassian.net/browse/OSDOCS-17325

Link to docs preview:
https://112623--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/scheduling/descheduler/index.html#nodes-descheduler-profiles_nodes-descheduler-about

QE review:
- [x] QE has approved this change.

Additional information:
Updated the KubeVirtRelieveAndMigrate descheduler profile documentation to reflect the new default utilization metric. The profile now uses PrometheusCPUMemoryCombinedProfile by default, which combines CPU and memory utilization with PSI pressure for both dimensions, providing more comprehensive node load balancing for virtual machines.