### PR TITLE
OBSDOCS-3473: Fix ClusterLogForwarder service account name in install guide

### DIFF
--- a/modules/creating-the-clusterlogforwarder.adoc
+++ b/modules/creating-the-clusterlogforwarder.adoc
@@ -22,7 +22,7 @@ metadata:
   namespace: openshift-logging
 spec:
   serviceAccount:
-    name: collector
+    name: logging-collector
   outputs:
   - name: lokistack-out
     type: lokiStack


### PR DESCRIPTION
## Summary
- Fixes a service account name mismatch in the Installing Logging guide (sections 6.2 and 6.3).
- Section 6.2 (`creating-collector-rbac`) creates SA `logging-collector`, but section 6.3 (`creating-the-clusterlogforwarder`) incorrectly used `collector` in `spec.serviceAccount.name`.
- Updates `modules/creating-the-clusterlogforwarder.adoc` to use `logging-collector`, matching the RBAC step and the web console procedure in the same assembly.

## Jira
https://redhat.atlassian.net/browse/OBSDOCS-3473

## Test plan
- [ ] Confirm Installing Logging guide section 6.3 shows `name: logging-collector` in the ClusterLogForwarder YAML
- [ ] Verify section 6.2 still documents `logging-collector` SA creation
- [ ] Confirm configuring-log-forwarding modules (which intentionally use SA `collector`) are unchanged