### PR TITLE
[enterprise-4.15] networking: improve verification steps for limited live migration

### DIFF
--- a/modules/initiating-limited-live-migration.adoc
+++ b/modules/initiating-limited-live-migration.adoc
@@ -46,21 +46,60 @@ After running this command, the migration process begins. During this process, t
 This `oc patch` command checks for overlapping CIDRs in use by OpenShift SDN. If overlapping CIDRs are detected, you must patch them before the limited live migration process can start. For more information, see "Patching OVN-Kubernetes address ranges".
 ====
 
-. Optional: To ensure that the migration process has completed, and to check the status of the `network.config`, you can enter the following commands:
+. Verify that the migration has completed successfully before proceeding to any cleanup steps. Check that the network type has changed to `OVNKubernetes` by entering the following command:
 +
 [source,terminal]
 ----
 $ oc get network.config.openshift.io cluster -o jsonpath='{.status.networkType}'
 ----
 +
+The expected output is `OVNKubernetes`. If the output still shows `OpenShiftSDN`, the migration is not yet complete.
+
+. Verify that the migration status condition indicates completion by entering the following command:
++
 [source,terminal]
 ----
 $ oc get network.config cluster -o=jsonpath='{.status.conditions}' | jq .
 ----
 +
+In the output, find the condition with `"type": "NetworkTypeMigrationInProgress"`. The `status` field must be `"False"` and the `reason` field must be `"NetworkTypeMigrationCompleted"`. If the `status` is `"True"`, the migration is still in progress.
++
 You can check limited live migration metrics for troubleshooting issues. For more information, see "Checking limited live migration metrics".
 
-. After a successful migration operation, remove the `network.openshift.io/network-type-migration-` annotation from the `network.config` custom resource by entering the following command:
+. Verify that all machine config pools have finished updating by entering the following command:
++
+[source,terminal]
+----
+$ oc get mcp
+----
++
+For each machine config pool, the `UPDATED` column must show `True`, the `UPDATING` column must show `False`, and the `DEGRADED` column must show `False`. If any pool shows `UPDATING` as `True`, the Machine Config Operator is still applying changes and you must wait for it to finish.
+
+. Verify that all nodes are in the `Ready` state and that each node has applied the expected machine configuration by entering the following command:
++
+[source,terminal]
+----
+$ oc get nodes -o json | jq -r '.items[] | select(.metadata.annotations["machineconfiguration.openshift.io/currentConfig"] != .metadata.annotations["machineconfiguration.openshift.io/desiredConfig"] or .metadata.annotations["machineconfiguration.openshift.io/state"] != "Done") | .metadata.name'
+----
++
+This command must produce no output. If any node names are returned, those nodes have not yet completed the machine config rollout. Wait for them to finish before proceeding.
+
+. Verify that all cluster Operators are available by entering the following command:
++
+[source,terminal]
+----
+$ oc get co
+----
++
+For each cluster Operator, the `AVAILABLE` column must show `True`, the `PROGRESSING` column must show `False`, and the `DEGRADED` column must show `False`.
+
++
+[WARNING]
+====
+Do not proceed to the next step until all of the previous verification checks pass. Running the cleanup step before the migration has fully completed can leave the cluster in an unrecoverable state. If any verification check fails, wait and re-check, or see "Checking limited live migration metrics" for troubleshooting.
+====
+
+. After all of the previous verification checks pass, remove the `network.openshift.io/network-type-migration-` annotation from the `network.config` custom resource by entering the following command:
 +
 [source,terminal]
 ----


### PR DESCRIPTION
Version(s):
4.15

Issue:
N/A — cherry-pick of https://github.com/openshift/openshift-docs/pull/112643 (enterprise-4.16)

Link to docs preview:
N/A

QE review:
- [ ] QE has approved this change.

## Context

Cherry-pick of enterprise-4.16 PR #112643 to enterprise-4.15. The `initiating-limited-live-migration.adoc` module is identical on both branches and has the same problem — verification marked "Optional", no gate before cleanup.

This is a common pitfall where users are falling. They run the cleanup annotation removal before the migration has fully completed, leaving the cluster in a half-SDN, half-OVN hybrid state that is difficult or impossible to recover from.

See PR #112643 for full details on the problem and changes.