### PR TITLE
ROX-34778: Release notes for RHACS 4.9.7

### DIFF
--- a/modules/common-attributes.adoc
+++ b/modules/common-attributes.adoc
@@ -62,7 +62,7 @@ endif::[]
 :product-registry: OpenShift image registry
 :olm-first: Operator Lifecycle Manager (OLM)
 :olm: OLM
-:rhacs-version: 4.9.6
+:rhacs-version: 4.9.7
 :ga-date-490: 30 October 2025
 :ga-date-491: 24 November 2025
 :ga-date-492: 16 December 2025
@@ -70,6 +70,7 @@ endif::[]
 :ga-date-494: 16 March 2026
 :ga-date-495: 8 April 2026
 :ga-date-496: 6 May 2026
+:ga-date-497: 2 June 2026
 :ocp-supported-version: 4.12
 :ocp-latest-version: 4.21
 :pipelines-shortname: OpenShift Pipelines

--- a/release_notes/49-release-notes.adoc
+++ b/release_notes/49-release-notes.adoc
@@ -22,6 +22,9 @@ toc::[]
 |`4.9.4` | {ga-date-494}
 |`4.9.5` | {ga-date-495}
 |`4.9.6` | {ga-date-496}
+|`4.9.7` | {ga-date-497}
+
+
 
 |====
 
@@ -701,5 +704,43 @@ This release addresses the following security vulnerabilities:
 * gRPC-Go: Authorization bypass due to improper HTTP/2 path validation (link:https://access.redhat.com/security/cve/CVE-2026-33186[CVE-2026-33186])
 //ROX-33773
 * Immutable.js: Improperly controlled modification of object prototype attributes (prototype pollution) in immutable (link:https://access.redhat.com/security/cve/CVE-2026-29063[CVE-2026-29063])
+
+[id="about-this-release-497_{context}"]
+== About release 4.9.7
+
+*Release date*: {ga-date-497}
+
+This release provides the following bug fixes:
+
+//ROX-33153
+* Before this update, CVE severity ratings displayed inconsistent values in the {product-title-short} portal. When users viewed the same CVE on different pages, the severity level could appear as "Critical" on the image page but "Important" on the CVE page. With this release, Red{nbsp}Hat has corrected the severity calculation logic. As a result, CVE severity ratings now display consistently across all pages.
+
+This release addresses the following security vulnerabilities:
+
+//ROX-34518
+*  gosaml2:
+** CBC padding panic: Unauthenticated process crash (link:https://github.com/advisories/GHSA-hwqm-qvj9-4jr2[GHSA-hwqm-qvj9-4jr2])
+** Unsigned SAML `LogoutRequest` acceptance (link:https://github.com/advisories/GHSA-pcgw-qcv5-h8ch[GHSA-pcgw-qcv5-h8ch])
+* Axios:
+//ROX-34622
+** Invisible JSON response tampering via prototype pollution gadget (link:https://access.redhat.com/security/cve/CVE-2026-42044[CVE-2026-42044])
+//ROX-34547
+** Authentication bypass due to prototype pollution of HTTP error handling (link:https://access.redhat.com/security/cve/CVE-2026-42041[CVE-2026-42041])
+//ROX-34543
+** Denial of service via unbounded recursion in `toFormData` with deeply nested request data (link:https://access.redhat.com/security/cve/CVE-2026-42039[CVE-2026-42039])
+//ROX-34540
+** NO_PROXY bypass via crafted URL (link:https://access.redhat.com/security/cve/CVE-2026-42043[CVE-2026-42043])
+//ROX-34508
+** HTTP transport hijacking via prototype pollution (link:https://access.redhat.com/security/cve/CVE-2026-42033[CVE-2026-42033])
+//ROX-34462
+** Arbitrary HTTP header injection via prototype pollution (link:https://access.redhat.com/security/cve/CVE-2026-42035[CVE-2026-42035])
+//ROX-34129
+** Remote code execution via prototype pollution escalation (link:https://access.redhat.com/security/cve/cve-2026-40175[CVE-2026-40175])
+//ROX-34108
+** Server-side request forgery and proxy bypass due to improper hostname normalization (link:https://access.redhat.com/security/cve/CVE-2025-62718[CVE-2025-62718])
+//ROX-34421
+* follow-redirects: Information disclosure via cross-domain redirects (link:https://access.redhat.com/security/cve/CVE-2026-40895[CVE-2026-40895])
+//ROX-34736
+* Go crypto/x509: Denial of service via inefficient certificate chain validation (link:https://access.redhat.com/security/cve/CVE-2026-32281[CVE-2026-32281])
 
 include::modules/image-versions.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s): 4.9.7

Issue: [ROX-34778](https://redhat.atlassian.net/browse/ROX-34778)

Link to docs preview:
https://112650--ocpdocs-pr.netlify.app/openshift-acs/latest/release_notes/49-release-notes#about-this-release-497_release-notes-49

QE review: ACS has no formal QE process, approved by SME
- [x] QE has approved this change.

Additional information:

