### PR TITLE
Add Logging 6.4.5 release notes

### DIFF
--- a/modules/logging-release-notes-6-4-5.adoc
+++ b/modules/logging-release-notes-6-4-5.adoc
@@ -1,0 +1,31 @@
+// Module included in the following assemblies:
+//
+// * release_notes/logging-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="logging-release-notes-6-4-5_{context}"]
+= Logging 6.4.5 release notes
+
+[role="_abstract"]
+
+This release includes link:https://access.redhat.com/errata/RHSA-2026:22862[RHSA-2026:22862].
+
+[id="logging-release-notes-6-4-5-bug-fixes_{context}"]
+== Bug fixes
+
+* Before this update, Vector could not authenticate to Kafka version 4.0.0 with the SASL mechanism SCRAM-SHA-512. When you configured a `ClusterLogForwarder` to forward logs to a KRaft-based Kafka cluster by using SCRAM-SHA-512 authentication, Vector continuously raised authentication failure errors even when credentials were valid. This issue affected deployments that used AMQ Streams 3.0.0 or later. Vector now correctly handles SCRAM-SHA-512 authentication with Kafka version 4.0.0. Logs are now successfully forwarded to KRaft-based Kafka clusters without authentication errors.
+(link:https://issues.redhat.com/browse/LOG-9338[LOG-9338])
+
+* Before this update, collector memory and CPU usage grew continuously over time in a ladder-like pattern, even when log volume remained uniform. This behavior resembled a memory leak, causing collectors to eventually reach their memory limits and crash with `OOMKilled` errors. In deployments without memory limits, collector memory usage could exceed 40 GB. The memory leak is now resolved. Collector memory and CPU usage now remain stable and proportional to the actual log workload.
+(link:https://issues.redhat.com/browse/LOG-9347[LOG-9347])
+
+[id="logging-release-notes-6-4-5-cves_{context}"]
+== CVEs
+
+* link:https://access.redhat.com/security/cve/CVE-2026-25679[CVE-2026-25679]
+
+* link:https://access.redhat.com/security/cve/CVE-2026-27137[CVE-2026-27137]
+
+* link:https://access.redhat.com/security/cve/CVE-2026-31812[CVE-2026-31812]
+
+* link:https://access.redhat.com/security/cve/CVE-2026-32829[CVE-2026-32829]

--- a/release_notes/logging-release-notes.adoc
+++ b/release_notes/logging-release-notes.adoc
@@ -10,6 +10,8 @@ toc::[]
 [role="_abstract"]
 The following release notes describe the updates in {LoggingProductName} 6.4. They include new features and enhancements, bug fixes, security updates (CVEs), known issues, and Technology Preview features.
 
+include::modules/logging-release-notes-6-4-5.adoc[leveloffset=+1]
+
 include::modules/logging-release-notes-6-4-4.adoc[leveloffset=+1]
 
 include::modules/logging-release-notes-6-4-3.adoc[leveloffset=+1]


### PR DESCRIPTION
## Summary
- Add release notes for Logging 6.4.5
- Fix Vector authentication to Kafka 4.0.0 with SCRAM-SHA-512 ([LOG-9338](https://redhat.atlassian.net/browse/LOG-9338))
- Fix collector memory and CPU leak ([LOG-9347](https://redhat.atlassian.net/browse/LOG-9347))
- Add CVEs: CVE-2026-31812, CVE-2026-27137, CVE-2026-25679, CVE-2026-32829

## Issue

https://redhat.atlassian.net/browse/OBSDOCS-3444

## Test plan
- [x] Verify AsciiDoc syntax
- [x] Verify links to Jira issues work
- [x] Verify CVE links work
- [x] Verify include statement in logging-release-notes.adoc

## Preview

https://112657--ocpdocs-pr.netlify.app/openshift-logging/latest/release_notes/logging-release-notes.html#logging-release-notes-6-4-5_logging-release-notes

Signed-off-by: John Wilkins <jowilkin@redhat.com>