### PR TITLE
OSDOCS-19763 RODOO 1.4.1 release notes GA June 17th

### DIFF
--- a/modules/rodoo-rn-1-4-1.adoc
+++ b/modules/rodoo-rn-1-4-1.adoc
@@ -1,0 +1,26 @@
+// Module included in the following assemblies:
+//
+// * nodes/pods/run_once_duration_override/run-once-duration-override-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="rodoo-rn-1-4-1_{context}"]
+= {run-once-operator} 1.4.1
+
+[role="_abstract"]
+Review the features, enhancements, and advisory for the release of {run-once-operator} 1.4.1.
+
+Issued: 17 June 2026
+
+The following advisory is available for the {run-once-operator} 1.4.1:
+
+* link:https://access.redhat.com/errata/RHBA-2026:26526[RHBA-2026:26526]
+
+[id="rodoo-1-4-1-new-features-and-enhancements_{context}"]
+== New features and enhancements
+
+* This release of the {run-once-operator} updates the Kubernetes version to 1.35.
+
+[id="rodoo-rn-1-4-1-bug-fixes_{context}"]
+== Bug fixes
+
+* This release of the {run-once-operator} addresses several Common Vulnerabilities and Exposures (CVEs).

--- a/nodes/pods/run_once_duration_override/run-once-duration-override-release-notes.adoc
+++ b/nodes/pods/run_once_duration_override/run-once-duration-override-release-notes.adoc
@@ -15,5 +15,8 @@ These release notes track the development of the {run-once-operator} for {produc
 
 For an overview of the {run-once-operator}, see xref:../../../nodes/pods/run_once_duration_override/index.adoc#run-once-about_run-once-duration-override-about[About the {run-once-operator}].
 
+//1.4.1 release notes
+include::modules/rodoo-rn-1-4-1.adoc[leveloffset=+1]
+
 //1.4.0 release notes
 include::modules/rodoo-rn-1-4-0.adoc[leveloffset=+1]


### PR DESCRIPTION

Version(s): 4.21, 4.22
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:[OSDOCS-19763](https://redhat.atlassian.net/browse/OSDOCS-19763)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to [docs preview](https://112658--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/pods/run_once_duration_override/run-once-duration-override-release-notes.html):
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [X] QE has approved this change. (Jan acting as QE)
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: Advisory link not yet available. 
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
