### PR TITLE
[enterprise-4.16] OSDOCS-18730 [NETOBSERV] Fix new Vale rule: ConceptLink

### DIFF
--- a/modules/network-observability-health-rules-monitoring-and-alerting.adoc
+++ b/modules/network-observability-health-rules-monitoring-and-alerting.adoc
@@ -2,7 +2,7 @@
 //
 // * network_observability/network-observability-health-rules.adoc
 
-:_mod-docs-content-type: CONCEPT
+:_mod-docs-content-type: REFERENCE
 [id="network-observability-health-rules-monitoring-and-alerting_{context}"]
 = Network health monitoring and alerting rules
 

--- a/modules/network-observability-important-flowcollector-considerations.adoc
+++ b/modules/network-observability-important-flowcollector-considerations.adoc
@@ -1,15 +1,15 @@
 // Module included in the following assemblies:
 //
-// network_observability/installing-operators.adoc
+// * network_observability/installing-operators.adoc
 
 :_mod-docs-content-type: REFERENCE
-[id="additional-resources_configuring-flow-collector-considerations_{context}"]
-= Important Flow Collector configuration considerations
+[id="network-observability-important-flowcollector-configuration-considerations_{context}"]
+= Important FlowCollector configuration considerations
 
 [role="_abstract"]
 Review essential `FlowCollector` configuration options before initial deployment to avoid pod disruptions caused by later reconfiguration. Key settings include Kafka integration, enriched flow data exports, SR-IOV traffic monitoring, and advanced tracking for DNS and packet drops.
 
-When you create the `FlowCollector` instance, you can reconfigure it, but the pods are terminated and recreated again, which can be disruptive.
+Once you create the `FlowCollector` instance, you can reconfigure it, but the pods are terminated and recreated again, which can be disruptive.
 
 Therefore, you can consider configuring the following options when creating the `FlowCollector` for the first time.
 

--- a/modules/network-observability-kafka-option.adoc
+++ b/modules/network-observability-kafka-option.adoc
@@ -9,7 +9,7 @@
 [role="_abstract"]
 The Kafka Operator is supported for large-scale environments. Kafka provides high-throughput and low-latency data feeds for forwarding network flow data in a more resilient, scalable way.
 
-You can install the Kafka Operator as link:https://access.redhat.com/documentation/en-us/red_hat_amq_streams/2.2[Red Hat AMQ Streams] from the Operator Hub, just as the {loki-op} and Network Observability Operator were installed. Refer to "Configuring the FlowCollector resource with Kafka" to configure Kafka as a storage option.
+You can install the Kafka Operator as Red Hat AMQ Streams from the Operator Hub, just as the {loki-op} and Network Observability Operator were installed. Refer to "Configuring the FlowCollector resource with Kafka" to configure Kafka as a storage option.
 
 [NOTE]
 ====

--- a/modules/network-observability-lokistack-ingestion-query.adoc
+++ b/modules/network-observability-lokistack-ingestion-query.adoc
@@ -1,7 +1,7 @@
 // Module included in the following assemblies:
 
 // * networking/network_observability/installing-operators.adoc
-:_mod-docs-content-type: CONCEPT
+:_mod-docs-content-type: REFERENCE
 [id="network-observability-lokistack-configuring-ingestion_{context}"]
 = LokiStack ingestion limits and health alerts
 
@@ -29,4 +29,5 @@ spec:
         maxEntriesLimitPerQuery: 10000
         maxQuerySeries: 3000
 ----
-For more information about these settings, see the link:https://loki-operator.dev/docs/api.md/#loki-grafana-com-v1-IngestionLimitSpec[LokiStack API reference].
+
+For more information about these settings, see "LokiStack API reference".

--- a/modules/network-observability-packet-translation-overview.adoc
+++ b/modules/network-observability-packet-translation-overview.adoc
@@ -22,5 +22,4 @@ As network packets are processed, the eBPF hook enriches flow logs with metadata
 - Source Port
 - Destination Pod IP
 - Destination Port
-- link:https://lwn.net/Articles/370152/#:~:text=A%20zone%20is%20simply%20a,to%20seperate%20conntrack%20defragmentation%20queues.[Conntrack Zone ID]
-
+- Conntrack Zone ID

--- a/observability/network_observability/configuring-operator.adoc
+++ b/observability/network_observability/configuring-operator.adoc
@@ -9,7 +9,7 @@ toc::[]
 [role="_abstract"]
 Configure the Network Observability Operator by updating the cluster-wide `FlowCollector` API resource (cluster) to manage component configurations and flow collection settings.
 
-The `FlowCollector` is explicitly created during installation. Since this resource operates cluster-wide, only a single `FlowCollector` is allowed, and it must be named `cluster`. For more information, see the xref:../../observability/network_observability/flowcollector-api.adoc#network-observability-flowcollector-api-specifications_network_observability[FlowCollector API reference].
+The `FlowCollector` is explicitly created during installation. Since this resource operates cluster-wide, only a single `FlowCollector` is allowed, and it must be named `cluster`. For more information, see the "FlowCollector API reference".
 
 include::modules/network-observability-flowcollector-view.adoc[leveloffset=+1]
 

--- a/observability/network_observability/installing-operators.adoc
+++ b/observability/network_observability/installing-operators.adoc
@@ -50,11 +50,13 @@ include::modules/loki-deployment-sizing.adoc[leveloffset=+2]
 
 include::modules/network-observability-lokistack-ingestion-query.adoc[leveloffset=+2]
 
+[role="_additional-resources"]
+.Additional resources
+* link:https://loki-operator.dev/docs/api.md/#loki-grafana-com-v1-IngestionLimitSpec[LokiStack API reference]
+
 include::modules/network-observability-operator-install.adoc[leveloffset=+1]
 
-include::modules/network-observability-multitenancy.adoc[leveloffset=+1]
-
-include::modules/network-observability-important-flowcollector-considerations.adoc[leveloffset=+1]
+include::modules/network-observability-important-flowcollector-considerations.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
 .Additional resources
@@ -72,6 +74,8 @@ include::modules/network-observability-important-flowcollector-considerations.ad
 
 include::modules/network-observability-updating-migrating.adoc[leveloffset=+2]
 
+include::modules/network-observability-multitenancy.adoc[leveloffset=+1]
+
 [role="_additional-resources"]
 .Additional resources
 * xref:../../operators/operator-reference.adoc#cluster-kube-storage-version-migrator-operator_operator-reference[Kubernetes Storage Version Migrator Operator]
@@ -80,6 +84,7 @@ include::modules/network-observability-kafka-option.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources
+* link:https://docs.redhat.com/en/documentation/red_hat_streams_for_apache_kafka/2.2[Red Hat AMQ Streams]
 * xref:../../observability/network_observability/configuring-operator.adoc#network-observability-flowcollector-kafka-config_network_observability[Configuring the FlowCollector resource with Kafka]
 
 include::modules/network-observability-operator-uninstall.adoc[leveloffset=+1]

--- a/observability/network_observability/network-observability-health-rules.adoc
+++ b/observability/network_observability/network-observability-health-rules.adoc
@@ -30,7 +30,6 @@ include::modules/network-observability-custom-health-rule-configuration.adoc[lev
 
 include::modules/network-observability-disable-predefined-rules.adoc[leveloffset=+1]
 
-
 [role="_additional-resources"]
 == Additional resources
 * xref:../../observability/network_observability/network-observability-health-rules.adoc#network-observability-default-rules_network-observability-health-rules[List of default rules]

--- a/observability/network_observability/network-observability-operator-release-notes.adoc
+++ b/observability/network_observability/network-observability-operator-release-notes.adoc
@@ -8,7 +8,7 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 [role="_abstract"]
-Review new features, enhancements, fixed issues, and known issues for the Network Observability Operator. These release notes provide information to help you understand changes and security advisories in the latest operator release.
+Find information about new features, security advisories, fixed issues, and known issues for the Network Observability Operator, and stay informed about changes and performance enhancements in the latest version of the operator for {product-title}.
 
 The Network Observability Operator enables administrators to observe and analyze network traffic flows for {product-title} clusters.
 


### PR DESCRIPTION
Manual cherry-pick

Original PR: https://github.com/openshift/openshift-docs/pull/108337
Original commit: b4074d93144166adfcf958c948f37531584bdbb4

Version(s):
4.16

QE review:
QE is not required for this PR.

Additional information:
* `modules/network-observability-creating-metrics-network-events.adoc` does not apply to 4.16. 
* The assembly files for `metrics-alerts-dashboards.adoc` and `observing-network-traffic.adoc` have no change since network events do not apply.
* 9 files instead of 12 because 1 file does not apply and the other 2 have no changes as a result.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
