### PR TITLE
OSDOCS-19958:Update the z-stream RNs for 4.21.18

### DIFF
--- a/modules/zstream-4-21-18.adoc
+++ b/modules/zstream-4-21-18.adoc
@@ -1,0 +1,39 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-21-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-21-18_{context}"]
+= RHSA-2026:21709 - {product-title} {product-version}.18 fixed issues advisory
+
+Issued: 02 June 2026
+
+[role="_abstract"]
+{product-title} release {product-version}.18 is now available. The list of fixed issues that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2026:21709[RHSA-2026:21709] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2026:21707[RHBA-2026:21707] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.21.18 --pullspecs
+----
+
+[id="zstream-4-21-18-fixed-issues_{context}"]
+== Fixed issues
+
+* Before this update, the lack of leader election on the hosted control plane ignition server controllers might have caused excessive resource requests during node pool reconciliation. As a consequence, excessive resource requests might have increased load on the registry hosting the image payload which increased the likelihood of errors processing the image payload. These errors might have caused excessive patching to the node pool token secrets. With this release, the image payload download errors were generalized to minimize patching of node pool token secrets. As a result, excessive resource requests do not occur. (link:https://issues.redhat.com/browse/OCPBUGS-81671[OCPBUGS-81671])
+
+* Before this update, shared key access was enabled on the cluster storage account, preventing it from being migrated to identity-based access to {azure-first} Storage. As a consequence, shared key access caused security concerns and prevented migration. With this release, shared key access is automatically disabled when using a managed identity, facilitating a seamless transition to identity-based access. As a result, disabling shared key access improves security. (link:https://issues.redhat.com/browse/OCPBUGS-82068[OCPBUGS-82068])
+
+* Before this update, the `HostFirmwareSetting` (HFS) resource was not applied when pre-provisioning {sno} while inspection was disabled. As a consequence, the HFS resource settings were not applied to {sno} in pre-provisioning scenarios where inspection was disabled. With this release, the Bare Metal Operator (BMO) correctly skips registration of the bare-metal host (BMH) when inspection is disabled. As a result, when you pre-provision {sno}, the HFS resource settings are properly applied when inspection is disabled. (link:https://issues.redhat.com/browse/OCPBUGS-82068[OCPBUGS-82141])
+
+* Before this update, when you configured networking with the `agent-tui` parameter during an Assisted Installer workflow, the `NetworkManager` keyfiles created in that session were not automatically passed to the CoreOS installation program. As a consequence, the installation program could not identify the keyfiles as manually created configurations and the network configurations set up through the `agent-tui` parameter during installation did not persist into the installed OS. This issue caused nodes to have missing or incorrect network settings after the cluster was deployed. With this release, the agent detects manually-created `NetworkManager` keyfiles by comparing their modification times against the `agent-tui` start time (derived from the birth time of the `/var/log/agent` parameter). When these keyfiles are found, the `--copy-network` command is automatically appended to the CoreOS installation program arguments, which ensures the configurations are passed on to the installed system. (link:https://issues.redhat.com/browse/OCPBUGS-85041[OCPBUGS-85041])
+
+* Before this update, when Prometheus was configured to scrape targets using client Transport Layer Security (TLS) certificates without a certificate authority (CA), rotating the client certificates caused Prometheus to crash with a `SIGSEGV` panic. Kubernetes restarted the pod, but Prometheus was down during that time. With this update, Prometheus correctly handles client certificate rotation when no CA is configured, preventing the crash and ensuring continuous metric collection. (link:https://issues.redhat.com/browse/OCPBUGS-86250[OCPBUGS-86250])
+
+[id="zstream-4-21-18-updating_{context}"]
+== Updating
+
+To update an {product-title} 4.21 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].

--- a/release_notes/ocp-4-21-release-notes.adoc
+++ b/release_notes/ocp-4-21-release-notes.adoc
@@ -44,6 +44,9 @@ include::modules/rn-ocp-release-notes-known-issues.adoc[leveloffset=+1]
 // Asynchronous errata updates
 include::modules/rn-async-errata.adoc[leveloffset=+1]
 
+// 4.21.18 RNs and updating
+include::modules/zstream-4-21-18.adoc[leveloffset=+2]
+
 // 4.21.17 RNs and updating
 include::modules/zstream-4-21-17.adoc[leveloffset=+2]
 


### PR DESCRIPTION
Version(s):
4.21

Issue:
https://redhat.atlassian.net/browse/OSDOCS-19958

Link to docs preview:
https://112681--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-21-release-notes.html#zstream-4-21-18_release-notes

Additional information:
4.21.18 MR: https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/555
ART Dashboard: https://art-dash.engineering.redhat.com/dashboard/release/openshift-4.21?page=1