### PR TITLE
RHDEVDOCS-7571: Changes for round robin sharding and making it GA

### DIFF
--- a/modules/gitops-argo-cd-round-robin-sharding-algorithm.adoc
+++ b/modules/gitops-argo-cd-round-robin-sharding-algorithm.adoc
@@ -7,7 +7,7 @@
 = Round-robin sharding algorithm
 
 [role="_abstract"]
-:FeatureName: The `round-robin` sharding algorithm
+:FeatureName: `round-robin` sharding algorithm
 include::snippets/technology-preview.adoc[]
 
 By default, the Argo CD Application Controller uses the non-uniform `legacy` hash-based sharding algorithm. This can result in an uneven distribution of clusters across shards. You can enable the `round-robin` sharding algorithm to achieve more equal cluster distribution across all shards.

--- a/modules/gitops-enabling-the-round-robin-sharding-algorithm-in-web-console.adoc
+++ b/modules/gitops-enabling-the-round-robin-sharding-algorithm-in-web-console.adoc
@@ -38,9 +38,7 @@ spec:
     sharding:
       enabled: true
       replicas: 3
-    env:
-      - name: ARGOCD_CONTROLLER_SHARDING_ALGORITHM 
-        value: round-robin
+      algorithm: round-robin
     logLevel: debug
 ----
 --
@@ -50,7 +48,7 @@ where:
 
 `spec.controller.sharding.enabled`:: Specifies the value of the `sharding.enabled` parameter to enable sharding.
 `spec.controller.sharding.replicas`:: Specifies the number of controller replicas, for example, `3`.
-`spec.controller.env.name`:: Specifies the environment variable `ARGOCD_CONTROLLER_SHARDING_ALGORITHM`.
+`spec.controller.sharding.algorithm`:: Specifies the cluster distribution algorithm, for example, round-robin.
 `spec.controller.env.value`:: Specifies the sharding algorithm to `round-robin`.
 `spec.controller.logLevel`:: Specifies the log level as `debug` so that you can verify to which shard each cluster is attached.
 --

--- a/modules/gitops-enabling-the-round-robin-sharding-algorithm-using-cli.adoc
+++ b/modules/gitops-enabling-the-round-robin-sharding-algorithm-using-cli.adoc
@@ -19,22 +19,7 @@ You can enable the `round-robin` sharding algorithm by using the command-line in
 +
 [source,terminal]
 ----
-$ oc patch argocd <argocd_instance> -n <namespace> --patch='{"spec":{"controller":{"sharding":{"enabled":true,"replicas":<value>}}}}' --type=merge
-----
-+
---
-*Example output:*
-[source,terminal]
-----
-argocd.argoproj.io/<argocd_instance> patched
-----
---
-
-. Configure the sharding algorithm to `round-robin` by running the following command:
-+
-[source,terminal]
-----
-$ oc patch argocd <argocd_instance> -n <namespace> --patch='{"spec":{"controller":{"env":[{"name":"ARGOCD_CONTROLLER_SHARDING_ALGORITHM","value":"round-robin"}]}}}' --type=merge
+$ oc patch argocd <argocd_instance> -n --patch='{"spec":{"controller":{"sharding":{"enabled":true,"replicas":,"algorithm":"round-robin"}}}}' --type=merge
 ----
 +
 --


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

gitops-docs-1.21

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

https://redhat.atlassian.net/browse/RHDEVDOCS-7571

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

Updated The round-robin cluster sharding algorithm row in the [Technology Preview features](https://112706--ocpdocs-pr.netlify.app/openshift-gitops/latest/release_notes/gitops-release-notes-1-20#GitOps-technology-preview_gitops-release-notes) table.

Removed the Tech Preview note from the following sections:

[Round-robin sharding algorithm](https://112706--ocpdocs-pr.netlify.app/openshift-gitops/latest/declarative_clusterconfig/sharding-clusters-across-argo-cd-application-controller-replicas#gitops-argo-cd-round-robin-sharding-algorithm_sharding-clusters-across-argo-cd-application-controller-replicas)
[- Dynamic scaling of shards for the Argo CD Application Controller](https://112706--ocpdocs-pr.netlify.app/openshift-gitops/latest/declarative_clusterconfig/sharding-clusters-across-argo-cd-application-controller-replicas#gitops-argo-cd-dynamic-scaling_sharding-clusters-across-argo-cd-application-controller-replicas)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

SME review: ccoco@redhat.com @jgwest 
QE review: @varshab1210 
Peer review: @shivanisathe25 

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
