### PR TITLE
Fix incorrect field name in multi-line exception detection procedure

### DIFF
--- a/modules/enabling-multi-line-exception-detection.adoc
+++ b/modules/enabling-multi-line-exception-detection.adoc
@@ -17,7 +17,7 @@ Enabling this feature could have performance implications and might require addi
 
 .Procedure
 
-. To enable logging to detect multi-line exceptions and reassemble them into a single log entry, ensure that the `ClusterLogForwarder` Custom Resource (CR) has a `detectMultilineErrors` field under the `.spec.filters`.
+. To enable logging to detect multi-line exceptions and reassemble them into a single log entry, ensure that the `ClusterLogForwarder` Custom Resource (CR) has a `detectMultilineException` filter type under the `.spec.filters`.
 +
 *Example `ClusterLogForwarder` CR*
 +


### PR DESCRIPTION
## Summary

- Fixes incorrect reference to `detectMultilineErrors` (old v5 terminology) in the procedure text of the "Enabling multi-line exception detection" section
- The correct v6 filter type is `detectMultilineException`, which the YAML example already used correctly

## Bug Details

**File:** `modules/enabling-multi-line-exception-detection.adoc`

The procedure step text said:
> ensure that the `ClusterLogForwarder` Custom Resource (CR) has a `detectMultilineErrors` field under the `.spec.filters`.

But should say:
> ensure that the `ClusterLogForwarder` Custom Resource (CR) has a `detectMultilineException` filter type under the `.spec.filters`.

The YAML example directly below was already correct (`type: detectMultilineException`), so only the prose needed to be fixed.

## Jira

Resolves: [OBSDOCS-3476](https://redhat.atlassian.net/browse/OBSDOCS-3476)

## Cherry-pick Required

This bug exists on all standalone logging docs branches and needs cherry-picking to:
- `standalone-logging-docs-6.6`
- `standalone-logging-docs-6.5`
- `standalone-logging-docs-6.4`
- `standalone-logging-docs-6.3`
- `standalone-logging-docs-6.2`
- `standalone-logging-docs-6.1`
- `standalone-logging-docs-6.0`

## Test Plan

- [x] Verified the YAML example uses `type: detectMultilineException` (unchanged)
- [x] Verified the procedure text now matches the YAML example
- [x] Confirmed the bug exists on all branches listed above


Made with [Cursor](https://cursor.com)