### PR TITLE
OSDOCS-16851-2: Second CQA for OVNK-2: Egress Traffic and Gateway Conf

### DIFF
--- a/modules/nw-egress-router-about.adoc
+++ b/modules/nw-egress-router-about.adoc
@@ -20,6 +20,7 @@ endif::[]
 [id="nw-egress-router-about_{context}"]
 = About an egress router pod
 
+[role="_abstract"]
 The {product-title} egress router pod redirects traffic to a specified remote server from a private source IP address that is not used for any other purpose. An egress router pod can send network traffic to servers that are set up to allow access only from specific IP addresses.
 
 [NOTE]
@@ -29,7 +30,7 @@ The egress router pod is not intended for every outgoing connection. Creating la
 
 [IMPORTANT]
 ====
-The egress router image is not compatible with Amazon AWS, Azure Cloud, or any other cloud platform that does not support layer 2 manipulations due to their incompatibility with macvlan traffic.
+The egress router image is not compatible with {aws-first}, {azure-first}, or any other cloud platform that does not support layer 2 manipulations due to their incompatibility with macvlan traffic.
 ====
 
 [id="nw-egress-router-about-modes_{context}"]
@@ -57,8 +58,7 @@ The egress router implementation uses the egress router Container Network Interf
 
 An egress router is a pod that has two network interfaces. For example, the pod can have `eth0` and `net1` network interfaces. The `eth0` interface is on the cluster network and the pod continues to use the interface for ordinary cluster-related network traffic. The `net1` interface is on a secondary network and has an IP address and gateway for that network. Other pods in the {product-title} cluster can access the egress router service and the service enables the pods to access external services. The egress router acts as a bridge between pods and an external system.
 
-Traffic that leaves the egress router exits through a node, but the packets
-have the MAC address of the `net1` interface from the egress router pod.
+Traffic that leaves the egress router exits through a node, but the packets have the MAC address of the `net1` interface from the egress router pod.
 
 When you add an egress router custom resource, the Cluster Network Operator creates the following objects:
 
@@ -76,7 +76,7 @@ An egress router pod adds an additional IP address and MAC address to the primar
 
 {rh-openstack-first}::
 
-If you deploy {product-title} on {rh-openstack}, you must allow traffic from the IP and MAC addresses of the egress router pod on your OpenStack environment. If you do not allow the traffic, then link:https://access.redhat.com/solutions/2803331[communication will fail]:
+If you deploy {product-title} on {rh-openstack}, you must allow traffic from the IP and MAC addresses of the egress router pod on your OpenStack environment. If you do not allow the traffic, see "OpenShift on OpenStack: Egress router not working" Knowledgebase article in the _Additional resources_ section.
 +
 [source,terminal]
 ----
@@ -86,13 +86,13 @@ $ openstack port set --allowed-address \
 
 VMware vSphere::
 
-If you are using VMware vSphere, see the link:https://docs.vmware.com/en/VMware-vSphere/6.0/com.vmware.vsphere.security.doc/GUID-3507432E-AFEA-4B6B-B404-17A020575358.html[VMware documentation for securing vSphere standard switches]. View and change VMware vSphere default settings by selecting the host virtual switch from the vSphere Web Client.
+If you are using {vmw-full}, see the VMware documentation for securing {vmw-short} standard switches. View and change {vmw-full} default settings by selecting the host virtual switch from the {vmw-short} Web Client. Specifically, ensure that you enable the following components:
 
-Specifically, ensure that the following are enabled:
+* MAC address changes
+* Forged transits
+* Promiscuous Mode Operation
 
-* https://docs.vmware.com/en/VMware-vSphere/6.0/com.vmware.vsphere.security.doc/GUID-942BD3AA-731B-4A05-8196-66F2B4BF1ACB.html[MAC Address Changes]
-* https://docs.vmware.com/en/VMware-vSphere/6.0/com.vmware.vsphere.security.doc/GUID-7DC6486F-5400-44DF-8A62-6273798A2F80.html[Forged Transits]
-* https://docs.vmware.com/en/VMware-vSphere/6.0/com.vmware.vsphere.security.doc/GUID-92F3AB1F-B4C5-4F25-A010-8820D7250350.html[Promiscuous Mode Operation]
+For more information on these components, see the _Additional resources_ section.
 
 [id="nw-egress-router-about-failover_{context}"]
 == Failover configuration
@@ -124,8 +124,6 @@ spec:
     app: egress-router-cni
 ----
 endif::ovn[]
-
-// Clear temporary attributes
 
 ifdef::ovn[]
 :!ovn:

--- a/modules/nw-egress-service-cr.adoc
+++ b/modules/nw-egress-service-cr.adoc
@@ -6,27 +6,33 @@
 [id="nw-egress-service-ovn-cr_{context}"]
 = Egress service custom resource
 
-Define the configuration for an egress service in an `EgressService` custom resource. The following YAML describes the fields for the configuration of an egress service:
+[role="_abstract"]
+You can define the configuration for an egress service in an `EgressService` custom resource.
+
+The following YAML describes the fields for the configuration of an egress service:
 
 [source,yaml]
 ----
 apiVersion: k8s.ovn.org/v1
 kind: EgressService
 metadata:
-  name: <egress_service_name> <1>
-  namespace: <namespace> <2>
+  name: <egress_service_name>
+  namespace: <namespace>
 spec:
-  sourceIPBy: <egress_traffic_ip> <3>
-  nodeSelector: <4>
+  sourceIPBy: <egress_traffic_ip>
+  nodeSelector:
     matchLabels:
       node-role.kubernetes.io/<role>: ""
-  network: <egress_traffic_network> <5>
+  network: <egress_traffic_network>
 ----
-<1> Specify the name for the egress service. The name of the `EgressService` resource must match the name of the load-balancer service that you want to modify.
-<2> Specify the namespace for the egress service. The namespace for the `EgressService` must match the namespace of the load-balancer service that you want to modify. The egress service is namespace-scoped.
-<3> Specify the source IP address of egress traffic for pods behind a service. Valid values are `LoadBalancerIP` or `Network`. Use the `LoadBalancerIP` value to assign the `LoadBalancer` service ingress IP address as the source IP address for egress traffic. Specify `Network` to assign the network interface IP address as the source IP address for egress traffic.
-<4> Optional: If you use the `LoadBalancerIP` value for the `sourceIPBy` specification, a single node handles the `LoadBalancer` service traffic. Use the `nodeSelector` field to limit which node can be assigned this task. When a node is selected to handle the service traffic, OVN-Kubernetes labels the node in the following format: `egress-service.k8s.ovn.org/<svc-namespace>-<svc-name>: ""`. When the `nodeSelector` field is not specified, any node can manage the `LoadBalancer` service traffic.
-<5> Optional: Specify the routing table ID for egress traffic. Ensure that the value matches the `route-table-id` ID defined in the `NodeNetworkConfigurationPolicy` resource. If you do not include the `network` specification, the egress service uses the default host network.
+
+where:
+
+`metadata.name`:: Specifies the name for the egress service. The name of the `EgressService` resource must match the name of the load-balancer service that you want to modify.
+`metadata.namespace`:: Specifies the namespace for the egress service. The namespace for the `EgressService` must match the namespace of the load-balancer service that you want to modify. The egress service is namespace-scoped.
+`spec.sourceIPBy`:: Specifies the source IP address of egress traffic for pods behind a service. Valid values are `LoadBalancerIP` or `Network`. Use the `LoadBalancerIP` value to assign the `LoadBalancer` service ingress IP address as the source IP address for egress traffic. Specify `Network` to assign the network interface IP address as the source IP address for egress traffic.
+`spec.nodeSelector`:: Optional parameter. If you use the `LoadBalancerIP` value for the `sourceIPBy` specification, a single node handles the `LoadBalancer` service traffic. Use the `nodeSelector` field to limit which node can be assigned this task. When a node is selected to handle the service traffic, OVN-Kubernetes labels the node in the following format: `egress-service.k8s.ovn.org/<svc-namespace>-<svc-name>: ""`. When the `nodeSelector` field is not specified, any node can manage the `LoadBalancer` service traffic.
+`spec.network`:: Optional parameter. Specifies the routing table ID for egress traffic. Ensure that the value matches the `route-table-id` ID defined in the `NodeNetworkConfigurationPolicy` resource. If you do not include the `network` specification, the egress service uses the default host network.
 
 .Example egress service specification
 [source,yaml]

--- a/modules/nw-egress-service-ovn.adoc
+++ b/modules/nw-egress-service-ovn.adoc
@@ -6,20 +6,21 @@
 [id="nw-egress-service-ovn_{context}"]
 = Deploying an egress service
 
+[role="_abstract"]
 You can deploy an egress service to manage egress traffic for pods behind a `LoadBalancer` service.
 
 The following example configures the egress traffic to have the same source IP address as the ingress IP address of the `LoadBalancer` service.
 
 .Prerequisites
 
-* Install the OpenShift CLI (`oc`).
+* Install the {oc-first}.
 * Log in as a user with `cluster-admin` privileges.
 * You configured MetalLB `BGPPeer` resources.
 
 .Procedure
 
 . Create an `IPAddressPool` CR with the desired IP for the service:
-
++
 .. Create a file, such as `ip-addr-pool.yaml`, with content like the following example:
 +
 [source,yaml]
@@ -33,7 +34,7 @@ spec:
   addresses:
   - 172.19.0.100/32
 ----
-
++
 .. Apply the configuration for the IP address pool by running the following command:
 +
 [source,terminal]
@@ -42,7 +43,7 @@ $ oc apply -f ip-addr-pool.yaml
 ----
 
 . Create `Service` and `EgressService` CRs:
-
++
 .. Create a file, such as `service-egress-service.yaml`, with content like the following example:
 +
 [source,yaml,subs="+quotes,+macros"]
@@ -53,7 +54,7 @@ metadata:
   name: example-service
   namespace: example-namespace
   annotations:
-    metallb.io/address-pool: example-pool <1>
+    metallb.io/address-pool: example-pool
 spec:
   selector:
     app: example
@@ -70,20 +71,23 @@ metadata:
   name: example-service
   namespace: example-namespace
 spec:
-  sourceIPBy: "LoadBalancerIP" <2>
-  nodeSelector: <3>
+  sourceIPBy: "LoadBalancerIP"
+  nodeSelector:
     matchLabels:
       node-role.kubernetes.io/worker: ""
 ----
-<1> The `LoadBalancer` service uses the IP address assigned by MetalLB from the `example-pool` IP address pool.
-<2> This example uses the `LoadBalancerIP` value to assign the ingress IP address of the `LoadBalancer` service as the source IP address of egress traffic.
-<3> When you specify the `LoadBalancerIP` value, a single node handles the `LoadBalancer` service's traffic. In this example, only nodes with the `worker` label can be selected to handle the traffic. When a node is selected, OVN-Kubernetes labels the node in the following format `egress-service.k8s.ovn.org/<svc-namespace>-<svc-name>: ""`.
++
+where:
+
+`metadata.annotations.metallb.io/address-pool`:: Specifies the `LoadBalancer` service uses the IP address assigned by MetalLB from the `example-pool` IP address pool.
+`spec.sourceIPBy`:: This example uses the `LoadBalancerIP` value to assign the ingress IP address of the `LoadBalancer` service as the source IP address of egress traffic.
+`spec.nodeSelector`:: When you specify the `LoadBalancerIP` value, a single node handles the `LoadBalancer` service's traffic. In this example, only nodes with the `worker` label can be selected to handle the traffic. When a node is selected, OVN-Kubernetes labels the node in the following format `egress-service.k8s.ovn.org/<svc-namespace>-<svc-name>: ""`.
 +
 [NOTE]
 ====
 If you use the `sourceIPBy: "LoadBalancerIP"` setting, you must specify the load-balancer node in the `BGPAdvertisement` custom resource (CR).
 ====
-
++
 .. Apply the configuration for the service and egress service by running the following command:
 +
 [source,terminal]
@@ -92,7 +96,7 @@ $ oc apply -f service-egress-service.yaml
 ----
 
 . Create a `BGPAdvertisement` CR to advertise the service:
-
++
 .. Create a file, such as `service-bgp-advertisement.yaml`, with content like the following example:
 +
 [source,yaml]
@@ -107,18 +111,22 @@ spec:
   - example-pool
   nodeSelectors:
   - matchLabels:
-      egress-service.k8s.ovn.org/example-namespace-example-service: "" <1>
+      egress-service.k8s.ovn.org/example-namespace-example-service: ""
 ----
-<1> In this example, the `EgressService` CR configures the source IP address for egress traffic to use the load-balancer service IP address. Therefore, you must specify the load-balancer node for return traffic to use the same return path for the traffic originating from the pod.
++
+where:
+
+`spec.nodeSelectors.matchLabels`:: In the example, the `EgressService` CR configures the source IP address for egress traffic to use the load-balancer service IP address. Therefore, you must specify the load-balancer node for return traffic to use the same return path for the traffic originating from the pod.
 
 .Verification
 
- . Verify that you can access the application endpoint of the pods running behind the MetalLB service by running the following command:
+. Verify that you can access the application endpoint of the pods running behind the MetalLB service by running the following command:
 +
 [source,terminal]
 ----
-$ curl <external_ip_address>:<port_number> <1>
+$ curl <external_ip_address>:<port_number>
 ----
-<1> Update the external IP address and port number to suit your application endpoint.
++
+`<external_ip_address>:<port_number`:: Update the external IP address and port number to suit your application endpoint.
 
 . If you assigned the `LoadBalancer` service's ingress IP address as the source IP address for egress traffic, verify this configuration by using tools such as `tcpdump` to analyze packets received at the external client.

--- a/networking/ovn_kubernetes_network_provider/configuring-egress-traffic-for-vrf-loadbalancer-services.adoc
+++ b/networking/ovn_kubernetes_network_provider/configuring-egress-traffic-for-vrf-loadbalancer-services.adoc
@@ -6,6 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 As a cluster administrator, you can configure egress traffic for pods behind a load balancer service by using an egress service.
 
 :FeatureName: Egress service

--- a/networking/ovn_kubernetes_network_provider/using-an-egress-router-ovn.adoc
+++ b/networking/ovn_kubernetes_network_provider/using-an-egress-router-ovn.adoc
@@ -6,6 +6,9 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
+Before you use the egress router pod, you must understand how the pod works. Doing so can prevent situations such as creating large numbers of egress router pods that exceed the limits of your network hardware.
+
 // About an egress router pod
 include::modules/nw-egress-router-about.adoc[leveloffset=+1]
 
@@ -14,3 +17,13 @@ include::modules/nw-egress-router-about.adoc[leveloffset=+1]
 == Additional resources
 
 * xref:../../networking/ovn_kubernetes_network_provider/deploying-egress-router-ovn-redirection.adoc#deploying-egress-router-ovn-redirection[Deploying an egress router in redirection mode]
+
+* link:https://access.redhat.com/solutions/2803331[OpenShift on OpenStack: Egress router not working]
+
+* https://docs.vmware.com/en/VMware-vSphere/6.0/com.vmware.vsphere.security.doc/GUID-942BD3AA-731B-4A05-8196-66F2B4BF1ACB.html[MAC Address Changes]
+
+* https://docs.vmware.com/en/VMware-vSphere/6.0/com.vmware.vsphere.security.doc/GUID-7DC6486F-5400-44DF-8A62-6273798A2F80.html[Forged Transits]
+
+* https://docs.vmware.com/en/VMware-vSphere/6.0/com.vmware.vsphere.security.doc/GUID-92F3AB1F-B4C5-4F25-A010-8820D7250350.html[Promiscuous Mode Operation]
+
+* link:https://docs.vmware.com/en/VMware-vSphere/6.0/com.vmware.vsphere.security.doc/GUID-3507432E-AFEA-4B6B-B404-17A020575358.html[VMware documentation for securing vSphere standard switches]


### PR DESCRIPTION
Version(s):
4.20+

Issue:
[OSDOCS-16851](https://redhat.atlassian.net/browse/OSDOCS-16851)

Link to docs preview:

* https://112730--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/configuring-egress-traffic-for-vrf-loadbalancer-services.html
* https://112730--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/using-an-egress-router-ovn.html
