### PR TITLE
Fix secret name mismatch in Splunk HEC forwarding procedure

### DIFF
--- a/modules/logging-forward-splunk.adoc
+++ b/modules/logging-forward-splunk.adoc
@@ -42,7 +42,7 @@ spec:
         url: '<http://your.splunk.hec.url:8088>'
         authentication:
           token:
-            secretName: splunk-secret
+            secretName: vector-splunk-secret
             key: hecToken
         index: '{.log_type||"undefined"}'
         source: '{.log_source||"undefined"}'


### PR DESCRIPTION
## Summary

- Fixes secret name mismatch between procedure step 1 and the YAML example in step 2
- Step 1 creates `vector-splunk-secret` but the YAML referenced `splunk-secret`
- Updated YAML `secretName` to `vector-splunk-secret` to match the secret created in step 1

## Bug Details

**File:** `modules/logging-forward-splunk.adoc`

Users following the procedure step-by-step would:
1. Create a secret named `vector-splunk-secret`
2. Apply a ClusterLogForwarder CR that looks for `splunk-secret`
3. Log forwarding fails because `splunk-secret` doesn't exist

## Jira

Resolves: [OBSDOCS-3478](https://redhat.atlassian.net/browse/OBSDOCS-3478)

## Cherry-pick Required

This bug exists on all standalone logging docs branches and needs cherry-picking to:
- `standalone-logging-docs-6.6`
- `standalone-logging-docs-6.5`
- `standalone-logging-docs-6.4`
- `standalone-logging-docs-6.3`
- `standalone-logging-docs-6.2`
- `standalone-logging-docs-6.1`
- `standalone-logging-docs-6.0`

## Test Plan

- [x] Verified the secret name in step 1 is `vector-splunk-secret`
- [x] Verified the YAML `secretName` now matches: `vector-splunk-secret`
- [x] Confirmed the bug exists on all branches listed above


Made with [Cursor](https://cursor.com)