### PR TITLE
OSDOCS CQA NODES-9: Autoscaling and Miscellaneous I

### DIFF
--- a/modules/nodes-pods-adjust-resources-in-place-about.adoc
+++ b/modules/nodes-pods-adjust-resources-in-place-about.adoc
@@ -6,7 +6,10 @@
 [id="nodes-pods-adjust-resources-in-place-about_{context}"]
 = About in-place pod resizing
 
-In-place pod resizing allows you to change the CPU and memory resources for containers within a running pod without application disruption. The standard methods for changing pod CPU and memory resources cause the pod to be re-created, potentially causing disruption. In-place pod resizing allows you to scale pod resources up or down without suffering the downtime or state loss associated with a pod restart.
+[role="_abstract"]
+You can use in-place pod resizing to change the CPU and memory resources for containers within a running pod without suffering the downtime or state loss associated with a pod restart.
+
+The standard methods for changing pod CPU and memory resources cause the pod to be re-created, potentially causing disruption. You can use in-place pod resizing to scale pod resources up or down without application disruption. 
 
 When using in-place pod resizing to change CPU or memory resources, you can control whether a pod is restarted by configuring a resize policy in the pod specification. The following example resize policy requires a pod restart upon changing the memory resources, but prevents a restart for CPU resource changes.
 
@@ -25,13 +28,15 @@ spec:
   containers:
   - name: pause
 # ...
-    resizePolicy: <1>
+    resizePolicy:
     - resourceName: cpu
       restartPolicy: NotRequired
     - resourceName: memory
       restartPolicy: RestartContainer
 ----
-<1> Specifies a resize policy. 
+where:
+
+`spec.containers.resizePolicy`:: Specifies a resize policy. 
 
 [NOTE]
 ====

--- a/modules/nodes-pods-adjust-resources-in-place-configuring.adoc
+++ b/modules/nodes-pods-adjust-resources-in-place-configuring.adoc
@@ -6,7 +6,8 @@
 [id="nodes-pods-adjust-resources-in-place-configuring_{context}"]
 = Configuring in-place pod resizing
 
-In-place pod resizing requires that you add a resize policy to a pod specification. 
+[role="_abstract"]
+You can use in-place pod resizing to scale pod resources up or down without application disruption by adding a resize policy to a pod specification. 
 
 You cannot add or modify a resize policy in an existing pod, but you can add or edit the policy in the pod's owner object, such as a deployment, if the pod has an owner object. 
 
@@ -26,14 +27,16 @@ spec:
 # ...
   containers:
   - name: pause
-    resizePolicy: <1>
+    resizePolicy:
     - resourceName: cpu
       restartPolicy: NotRequired
     - resourceName: memory
       restartPolicy: RestartContainer
 # ...
 ----
-<1> Specifies a resize policy. For CPU and/or memory resources specify one of the following values:
+where:
+
+`spec.containers.resizePolicy`:: Specifies a resize policy. For CPU and/or memory resources specify one of the following values:
 +
 * `NotRequired`: Apply any resource changes without restarting the pod. This is the default when using a resize policy.
 * `RestartContainer`: Apply any resource changes and restart the pod.

--- a/modules/nodes-pods-image-volume-about.adoc
+++ b/modules/nodes-pods-image-volume-about.adoc
@@ -7,7 +7,9 @@
 = Understanding image volumes
 
 [role="_abstract"]
-You can you use an _image volume_ to mount an Open Container Initiative (OCI)-compliant container image or artifact directly into a pod as a native volume source, making the OCI object accessible to the containers without the need to include them in the base image. OCI objects enable users to store and distribute arbitrary files and metadata through OCI-compliant container registries.
+You can you use an _image volume_ to mount an Open Container Initiative (OCI)-compliant container image or artifact directly into a pod as a native volume source, making the OCI object accessible to the containers without the need to include them in the base image. 
+
+OCI objects enable users to store and distribute arbitrary files and metadata through OCI-compliant container registries.
 
 By using an image volume in a pod, you can take advantage of the OCI image and distribution specification standards to accomplish several tasks including the following use cases: 
 

--- a/modules/nodes-pods-image-volume-adding.adoc
+++ b/modules/nodes-pods-image-volume-adding.adoc
@@ -7,7 +7,9 @@
 = Adding an image volume to a pod
 
 [role="_abstract"]
-To mount an Open Container Initiative (OCI)-compliant container image or artifact, use the `volume` parameter in your pod spec to include a path to the image or artifact, along with an optional pull policy. You can create the pod directly or use a controlling object, such as a deployment or replica set. 
+To mount an Open Container Initiative (OCI)-compliant container image or artifact, use the `volume` parameter in your pod spec to include a path to the image or artifact, along with an optional pull policy. 
+
+You can create the pod directly or use a controlling object, such as a deployment or replica set. 
 
 .Procedure
 

--- a/modules/nodes-sigstore-configure-cluster-policy.adoc
+++ b/modules/nodes-sigstore-configure-cluster-policy.adoc
@@ -7,7 +7,9 @@
 = Creating a cluster image policy CR
 
 [role="_abstract"]
-A `ClusterImagePolicy` custom resource (CR) enables a cluster administrator to configure a sigstore signature verification policy for the entire cluster. When enabled, the Machine Config Operator (MCO) watches the `ClusterImagePolicy` object and updates the `/etc/containers/policy.json` and `/etc/containers/registries.d/sigstore-registries.yaml` files on all the nodes in the cluster.
+A cluster administrator can use a `ClusterImagePolicy` custom resource (CR) to configure a sigstore signature verification policy for the entire cluster. 
+
+When enabled, the Machine Config Operator (MCO) watches the `ClusterImagePolicy` object and updates the `/etc/containers/policy.json` and `/etc/containers/registries.d/sigstore-registries.yaml` files on all the nodes in the cluster.
 
 The following example shows general guidelines on how to configure a `ClusterImagePolicy` object. For more details on the parameters, see "About cluster and image policy parameters."
 
@@ -35,117 +37,126 @@ mirror.com/image/repo:sha256-1234567890abcdef1234567890abcdef1234567890abcdef123
 
 . Create a cluster image policy object similar to the following examples. See "About image policy parameters" for specific details on these parameters.
 +
---
-.Example cluster image policy object with a public key policy and the `MatchRepoDigestOrExact` match policy
+The following example cluster image policy object uses a public key policy and the `MatchRepoDigestOrExact` match policy:
++
 [source,yaml]
 ----
 apiVersion: config.openshift.io/v1
-kind: ClusterImagePolicy <1>
+kind: ClusterImagePolicy
 metadata:
   name: p1
 spec:
-  scopes: <2>
+  scopes:
     - example.com
-  policy: <3>
-    rootOfTrust: <4>
-      policyType: PublicKey <5>
+  policy:
+    rootOfTrust:
+      policyType: PublicKey
       publicKey:
-        keyData: a2V5RGF0YQ== <6>
-        rekorKeyData: cmVrb3JLZXlEYXRh <7>
-    signedIdentity: <8>
+        keyData: a2V5RGF0YQ==
+        rekorKeyData: cmVrb3JLZXlEYXRh
+    signedIdentity:
       matchPolicy: MatchRepoDigestOrExact
 ----
-<1> Creates a `ClusterImagePolicy` object.
-<2> Defines a list of repositories or images assigned to this policy. In a cluster image policy, make sure that the policy does not block the deployment of the {product-title} images in the `quay.io/openshift-release-dev/ocp-release` and `quay.io/openshift-release-dev/ocp-v4.0-art-dev` repositories. Images in these repositories are required for cluster operation.
-<3> Specifies the parameters that define how the images are verified.
-<4> Defines a root of trust for the policy.
-<5> Specifies the policy types that define the root of trust, either a public key, a BYOPKI certificate, or a link:https://docs.sigstore.dev/certificate_authority/overview/[Fulcio certificate]. This example uses a public key with Rekor verification.
-<6> For a public key policy, specifies a base64-encoded public key in the PEM format. The maximum length is 8192 characters.
-<7> Optional: Specifies a base64-encoded Rekor public key in the PEM format. The maximum length is 8192 characters.
-<8> Optional: Specifies one of the following processes to verify the identity in the signature and the actual image identity:
+where:
++
+--
+`kind`:: Specifies that the configuration is for a `ClusterImagePolicy` object.
+`spec.scopes`:: Specifies a list of repositories or images assigned to this policy. In a cluster image policy, make sure that the policy does not block the deployment of the {product-title} images in the `quay.io/openshift-release-dev/ocp-release` and `quay.io/openshift-release-dev/ocp-v4.0-art-dev` repositories. Images in these repositories are required for cluster operation.
+`spec.policy`:: Specifies the parameters that define how the images are verified.
+`spec.policy.rootOfTrust`:: Specifies a root of trust for the policy.
+`spec.policy.rootOfTrust.policyType`:: Specifies the policy types that define the root of trust, either a public key, a BYOPKI certificate, or a link:https://docs.sigstore.dev/certificate_authority/overview/[Fulcio certificate]. This example uses a public key with Rekor verification.
+`spec.policy.rootOfTrust.publicKey.keyData`:: For a public key policy, specifies a base64-encoded public key in the PEM format. The maximum length is 8192 characters.
+`spec.policy.rootOfTrust.publicKey.rekorKeyData`:: Specifies a base64-encoded Rekor public key in the PEM format. The maximum length is 8192 characters. This parameter is optional.
+`spec.policy.signedIdentity`:: Specifies the process to verify the identity in the signature and the actual image identity. This parameter is optional. Specify one of the following processes:
 * `MatchRepoDigestOrExact`.
 * `MatchRepository`.
 * `ExactRepository`. The `exactRepository` parameter must be specified.
 * `RemapIdentity`. The `prefix` and `signedPrefix` parameters must be specified.
 --
 +
---
-.Example cluster image policy object for a BYOPKI policy and the `MatchRepository` match policy
+The following example cluster image policy object uses a BYOPKI policy and the `MatchRepository` match policy:
++
 [source,yaml]
 ----
 apiVersion: config.openshift.io/v1alpha1
-kind: ClusterImagePolicy <1>
+kind: ClusterImagePolicy
 metadata:
   name: pki-policy
 spec:
   scopes:
-  - example.io <2>
-  policy: <3>
-    rootOfTrust: <4>
-      policyType: PKI <5>
-      pki: <6>
+  - example.io
+  policy:
+    rootOfTrust:
+      policyType: PKI
+      pki:
         caRootsData: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk....URS0tLS0t
         caIntermediatesData: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1J....lDQVRFLS0tLS0=
-        pkiCertificateSubject: <7>
+        pkiCertificateSubject:
           email: email@example.com
           hostname: myhost.example.com
     signedIdentity:
-      matchPolicy: MatchRepository <8>
+      matchPolicy: MatchRepository
 ----
-<1> Creates a `ClusterImagePolicy` object.
-<2> Defines a list of repositories or images assigned to this policy. In a cluster image policy, make sure that the policy does not block the deployment of the {product-title} images in the `quay.io/openshift-release-dev/ocp-release` and `quay.io/openshift-release-dev/ocp-v4.0-art-dev` repositories. Images in these repositories are required for cluster operation.
-<3> Specifies the parameters that define how the images are verified.
-<4> Defines a root of trust for the policy.
-<5> Specifies the policy types that define the root of trust, either a public key, a BYOPKI certificate, or a link:https://docs.sigstore.dev/certificate_authority/overview/[Fulcio certificate]. This example uses a BYOPKI certificate.
-<6> For a BYOPKI certificate, specify `caRootsData`. This parameter specifies a base64-encoded CA root certificate in the PEM format. The maximum length is 8192 characters. Optionally with `caIntermediatesData`, specifies a base64-encoded intermediate CA root certificate in the PEM format. The maximum length is 8192 characters.
-<7> Specifies a subject alternative name (SAN) to authenticate the user’s identity by using a hostname and an email address: 
-* `email`. Specifies the email address specified when the certificate was generated.
-* `hostname`. Specifies the hostname specified when the certificate was generated.
-<8> For a BYOPKI certificate, specify the `MatchRepository` parameter to verify the identity in the signature and the actual image identity. The default signed identity is `matchRepoDigestOrExact`, which requires a digest reference in the signature identity for verification. The signature identity in this case uses a repository reference, and does not include the image digest.
---
+where:
 +
 --
-.Example cluster image policy object with a Fulcio certificate policy and the `remapIdentity` match policy
+`kind`:: Specifies that the configuration is for a `ClusterImagePolicy` object.
+`spec.scopes`:: Specifies a list of repositories or images assigned to this policy. In a cluster image policy, make sure that the policy does not block the deployment of the {product-title} images in the `quay.io/openshift-release-dev/ocp-release` and `quay.io/openshift-release-dev/ocp-v4.0-art-dev` repositories. Images in these repositories are required for cluster operation.
+`spec.policy`:: Specifies the parameters that define how the images are verified.
+`spec.policy.rootOfTrust`:: Specifies a root of trust for the policy.
+`spec.policy.rootOfTrust.policyType`:: Specifies the policy types that define the root of trust, either a public key, a BYOPKI certificate, or a Fulcio certificate. This example uses a BYOPKI certificate.
+`spec.policy.rootOfTrust.pki`:: For a BYOPKI certificate, specifies `caRootsData`. This parameter specifies a base64-encoded CA root certificate in the PEM format. The maximum length is 8192 characters. Optionally with `caIntermediatesData`, specifies a base64-encoded intermediate CA root certificate in the PEM format. The maximum length is 8192 characters.
+`spec.policy.rootOfTrust.pki.pkiCertificateSubject`:: Specifies a subject alternative name (SAN) to authenticate the user’s identity by using a hostname and an email address: 
+* `email`. Specifies the email address specified when the certificate was generated.
+* `hostname`. Specifies the hostname specified when the certificate was generated.
+`spec.policy.signedIdentity.matchPolicy`:: For a BYOPKI certificate, specifies the `MatchRepository` parameter to verify the identity in the signature and the actual image identity. The default signed identity is `matchRepoDigestOrExact`, which requires a digest reference in the signature identity for verification. The signature identity in this case uses a repository reference, and does not include the image digest.
+--
++
+The following example cluster image policy object uses a Fulcio certificate policy and the `remapIdentity` match policy:
++
 [source,yaml]
 ----
 apiVersion: config.openshift.io/v1
-kind: ClusterImagePolicy <1>
+kind: ClusterImagePolicy
 metadata:
   name: p1
 spec:
-  scopes: <2>
+  scopes:
     - example.com
-  policy: <3>
-    rootOfTrust: <4>
-      policyType: FulcioCAWithRekor <5>
-      fulcioCAWithRekor: <6>
+  policy:
+    rootOfTrust:
+      policyType: FulcioCAWithRekor
+      fulcioCAWithRekor:
         fulcioCAData: a2V5RGF0YQ==
         fulcioSubject:
           oidcIssuer: "https://expected.OIDC.issuer/"
           signedEmail: "expected-signing-user@example.com"
-        rekorKeyData: cmVrb3JLZXlEYXRh <7>
+        rekorKeyData: cmVrb3JLZXlEYXRh
     signedIdentity:
-      matchPolicy: RemapIdentity <8>
+      matchPolicy: RemapIdentity
       remapIdentity:
-        prefix: example.com <9>
-        signedPrefix: mirror-example.com <10>
+        prefix: example.com
+        signedPrefix: mirror-example.com
 ----
-<1> Creates a `ClusterImagePolicy` object.
-<2> Defines a list of repositories or images assigned to this policy. In a cluster image policy, make sure that the policy does not block the deployment of the {product-title} images in the `quay.io/openshift-release-dev/ocp-release` and `quay.io/openshift-release-dev/ocp-v4.0-art-dev` repositories. Images in these repositories are required for cluster operation.
-<3> Specifies the parameters that define how the images are verified.
-<4> Defines a root of trust for the policy.
-<5> Specifies the policy types that define the root of trust, either a public key, a BYOPKI certificate, or a link:https://docs.sigstore.dev/certificate_authority/overview/[Fulcio certificate]. This example uses a Fulcio certificate with required Rekor verification.
-<6> For a Fulcio certificate policy, the following parameters are required:
+where:
++
+--
+`kind`:: Specifies that the configuration is for a `ClusterImagePolicy` object.
+`spec.scopes`:: Specifies a list of repositories or images assigned to this policy. In a cluster image policy, make sure that the policy does not block the deployment of the {product-title} images in the `quay.io/openshift-release-dev/ocp-release` and `quay.io/openshift-release-dev/ocp-v4.0-art-dev` repositories. Images in these repositories are required for cluster operation.
+`spec.policy`:: Specifies the parameters that define how the images are verified.
+`spec.policy.rootOfTrust`:: Specifies a root of trust for the policy.
+`spec.policy.rootOfTrust.policyType`:: Specifies the policy types that define the root of trust, either a public key, a BYOPKI certificate, or a Fulcio certificate. This example uses a Fulcio certificate with required Rekor verification.
+`spec.policy.rootOfTrust.fulcioCAWithRekor`:: For a Fulcio certificate policy, the following parameters are required:
 * `fulcioCAData`: Specifies a base64-encoded Fulcio certificate in the PEM format. The maximum length is 8192 characters.
 * `fulcioSubject`: Specifies the OIDC issuer and the email of the Fulcio authentication configuration.
-<7> Specifies a base64-encoded Rekor public key in the PEM format. This parameter is required when the `policyType` is `FulcioCAWithRekor`. The maximum length is 8192 characters.
-<8> Optional: Specifies one of the following processes to verify the identity in the signature and the actual image identity.
+* `rekorKeyData`: Specifies a base64-encoded Rekor public key in the PEM format. This parameter is required when the `policyType` is `FulcioCAWithRekor`. The maximum length is 8192 characters.
+`spec.policy.signedIdentity.matchPolicy`:: Specifies one of the following processes to verify the identity in the signature and the actual image identity. This parameter is optional.
 * `MatchRepoDigestOrExact`.
 * `MatchRepository`.
 * `ExactRepository`. The `exactRepository` parameter must be specified.
 * `RemapIdentity`. The `prefix` and `signedPrefix` parameters must be specified.
-<9> For the `remapIdentity` match policy, specifies the prefix that should be matched against the scoped image prefix. If the two match, the scoped image prefix is replaced with the value of `signedPrefix`. The maximum length is 512 characters.
-<10> For the `remapIdentity` match policy, specifies the image prefix to be remapped, if needed. The maximum length is 512 characters.
+`spec.policy.signedIdentity.remapIdentity.prefix`:: For the `remapIdentity` match policy, specifies the prefix that should be matched against the scoped image prefix. If the two match, the scoped image prefix is replaced with the value of `signedPrefix`. The maximum length is 512 characters.
+`spec.policy.signedIdentity.remapIdentity.signedPrefix`:: For the `remapIdentity` match policy, specifies the image prefix to be remapped, if needed. The maximum length is 512 characters.
 --
 
 . Create the cluster image policy object:
@@ -263,9 +274,11 @@ sh-5.1# cat /etc/containers/registries.d/sigstore-registries.yaml
 ----
 docker:
   example.com:
-    use-sigstore-attachments: true <1>
+    use-sigstore-attachments: true
   quay.io/openshift-release-dev/ocp-release:
     use-sigstore-attachments: true
 ----
-<1> When `true`, specifies that sigstore signatures are going to be read along with the image.
+where:
+
+`docker.example.com.use-sigstore-attachments`:: When `true`, specifies that sigstore signatures are going to be read along with the image.
 // https://github.com/openshift/api/blob/master/config/v1alpha1/zz_generated.crd-manifests/0000_10_config-operator_01_clusterimagepolicies-TechPreviewNoUpgrade.crd.yaml

--- a/modules/nodes-sigstore-configure-image-policy.adoc
+++ b/modules/nodes-sigstore-configure-image-policy.adoc
@@ -6,7 +6,10 @@
 [id="nodes-sigstore-configure-image-policy_{context}"]
 = Creating an image policy CR
 
-An `ImagePolicy` custom resource (CR) enables a cluster administrator or application developer to configure a sigstore signature verification policy for a specific namespace. The MCO watches `ImagePolicy` instances in different namespaces and updates the `/etc/crio/policies/<namespace>.json` and `/etc/containers/registries.d/sigstore-registries.yaml` files on all the nodes in the cluster.
+[role="_abstract"]
+A cluster administrator or application developer can use an `ImagePolicy` custom resource (CR) to configure a sigstore signature verification policy for a specific namespace. 
+
+The MCO watches `ImagePolicy` instances in different namespaces and updates the `/etc/crio/policies/<namespace>.json` and `/etc/containers/registries.d/sigstore-registries.yaml` files on all the nodes in the cluster.
 
 [NOTE]
 ====
@@ -17,7 +20,7 @@ The following example shows general guidelines on how to configure an `ImagePoli
 
 .Prerequisites
 // Taken from https://issues.redhat.com/browse/OCPSTRAT-918
-* You have a sigstore-supported public key infrastructure (PKI) key, a Bring Your Own Public Key Infrastructure (BYOPKI) certificate, or provide a link:https://docs.sigstore.dev/cosign/signing/overview/[Cosign public and private key pair] for signing operations.
+* You have a sigstore-supported public key infrastructure (PKI) key, a Bring Your Own Public Key Infrastructure (BYOPKI) certificate, or provide a Cosign public and private key pair for signing operations.
 * You have a signing process in place to sign your images.
 * You have access to a registry that supports Cosign signatures, if you are using Cosign signatures.
 
@@ -26,35 +29,35 @@ The following example shows general guidelines on how to configure an `ImagePoli
 . Create an image policy object similar to the following examples. See "About cluster and image policy parameters" for specific details on these parameters.
 +
 --
-.Example image policy object with a public key policy and the `MatchRepository` match policy
+The following example image policy object uses a public key policy and the `MatchRepository` match policy:
 [source,yaml]
 ----
 apiVersion: config.openshift.io/v1
-kind: ImagePolicy <1>
+kind: ImagePolicy
 metadata:
   name: p0
-  namespace: mynamespace <2>
+  namespace: mynamespace
 spec:
-  scopes: <3>
+  scopes:
     - example.io/crio/signed
-  policy: <4>
-    rootOfTrust: <5>
-      policyType: PublicKey <6>
+  policy:
+    rootOfTrust:
+      policyType: PublicKey
       publicKey:
-        keyData: a2V5RGF0YQ== <7>
-        rekorKeyData: cmVrb3JLZXlEYXRh <8>
+        keyData: a2V5RGF0YQ==
+        rekorKeyData: cmVrb3JLZXlEYXRh
     signedIdentity:
-      matchPolicy: MatchRepository <9>
+      matchPolicy: MatchRepository
 ----
-<1> Creates an `ImagePolicy` object.
-<2> Specifies the namespace where the image policy is applied.
-<3> Defines a list of repositories or images assigned to this policy.
-<4> Specifies the parameters that define how the images are verified.
-<5> Defines a root of trust for the policy.
-<6> Specifies the policy types that define the root of trust, either a public key, a BYOPKI certificate, or a link:https://docs.sigstore.dev/certificate_authority/overview/[Fulcio certificate]. Here, a public key with Rekor verification.
-<7> For a public key policy, specifies a base64-encoded public key in the PEM format. The maximum length is 8192 characters.
-<8> Optional: Specifies a base64-encoded Rekor public key in the PEM format. The maximum length is 8192 characters.
-<9> Optional: Specifies one of the following processes to verify the identity in the signature and the actual image identity:
+`kind`:: Specifies that the configuration is for a `ImagePolicy` object.
+`metadata.namespace`:: Specifies the namespace where the image policy is applied.
+`spec.scopes`:: Specifies a list of repositories or images assigned to this policy.
+`spec.policy`:: Specifies the parameters that define how the images are verified.
+`spec.policy.rootOfTrust`:: Specifies a root of trust for the policy.
+`spec.policy.rootOfTrust.policyType`:: Specifies the policy types that define the root of trust, either a public key, a BYOPKI certificate, or a Fulcio certificate. Here, a public key with Rekor verification.
+`spec.policy.rootOfTrust.publicKey.keyData`:: For a public key policy, specifies a base64-encoded public key in the PEM format. The maximum length is 8192 characters.
+`spec.policy.rootOfTrust.publicKey.rekorKeyData`:: Optional: Specifies a base64-encoded Rekor public key in the PEM format. The maximum length is 8192 characters.
+`spec.policy.signedIdentity.matchPolicy`:: Optional: Specifies one of the following processes to verify the identity in the signature and the actual image identity:
 * `MatchRepoDigestOrExact`.
 * `MatchRepository`.
 * `ExactRepository`. The `exactRepository` parameter must be specified.
@@ -62,85 +65,84 @@ spec:
 --
 +
 --
-.Example image policy object for a BYOPKI policy and the `MatchRepository` match policy
+The following example image policy object uses a BYOPKI policy and the `MatchRepository` match policy:
 [source,yaml]
 ----
 apiVersion: config.openshift.io/v1alpha1
-kind: ImagePolicy <1>
+kind: ImagePolicy
 metadata:
   name: pki-policy
-  namespace: mynamespace <2>
+  namespace: mynamespace
 spec:
   scopes:
-  - example.io <3>
-  policy: <4>
-    rootOfTrust: <5>
-      policyType: PKI <6>
+  - example.io
+  policy:
+    rootOfTrust:
+      policyType: PKI
       pki: <7>
         caRootsData: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk....RVJUSUZJQ0FURS0tLS0t
         caIntermediatesData: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURkVENDQ....0QT09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0=
-        pkiCertificateSubject: <8>
+        pkiCertificateSubject:
           email: email@example.com
           hostname: myhost.example.com
     signedIdentity:
-      matchPolicy: MatchRepository <9>
+      matchPolicy: MatchRepository
 ----
-<1> Creates an `ImagePolicy` object.
-<2> Specifies the namespace where the image policy is applied.
-<3> Defines a list of repositories or images assigned to this policy.
-<4> Specifies the parameters that define how the images are verified.
-<5> Defines a root of trust for the policy.
-<6> Specifies the policy types that define the root of trust, either a public key, a BYOPKI certificate, or a link:https://docs.sigstore.dev/certificate_authority/overview/[Fulcio certificate]. Here, a BYOPKI certificate.
-<7> For a BYOPKI certificate, specify `caRootsData`. This parameter specifies a base64-encoded CA root certificate in the PEM format. The maximum length is 8192 characters. Optionally with `caIntermediatesData`, specifies a base64-encoded intermediate CA root certificate in the PEM format. The maximum length is 8192 characters.
-<8> Specifies a subject alternative name (SAN) to authenticate the user’s identity by using a hostname and an email address:
+`kind`:: Specifies that the configuration is for a `ImagePolicy` object.
+`metadata.namespace`:: Specifies the namespace where the image policy is applied.
+`spec.scopes`:: Specifies a list of repositories or images assigned to this policy.
+`spec.policy`:: Specifies the parameters that define how the images are verified.
+`spec.policy.rootOfTrust`:: Specifies a root of trust for the policy.
+`spec.policy.rootOfTrust.policyType`:: Specifies the policy types that define the root of trust, either a public key, a BYOPKI certificate, or a Fulcio certificate. Here, a BYOPKI certificate.
+`spec.policy.rootOfTrust.pki`:: For a BYOPKI certificate, specifies `caRootsData`. This parameter specifies a base64-encoded CA root certificate in the PEM format. The maximum length is 8192 characters. Optionally with `caIntermediatesData`, specifies a base64-encoded intermediate CA root certificate in the PEM format. The maximum length is 8192 characters.
+`spec.policy.rootOfTrust.pki.pkiCertificateSubject`:: Specifies a subject alternative name (SAN) to authenticate the user’s identity by using a hostname and an email address:
 * `email`. Specifies the email address specified when the certificate was generated.
 * `hostname`. Specifies the hostname specified when the certificate was generated.
-<9> For a BYOPKI certificate, specify `MatchRepository` to verify the identity in the signature and the actual image identity. The default signed identity is `matchRepoDigestOrExact`, which requires digest specification. The signature in this case was not created for digested image.
+`spec.policy.signedIdentity.matchPolicy`:: For a BYOPKI certificate, specify `MatchRepository` to verify the identity in the signature and the actual image identity. The default signed identity is `matchRepoDigestOrExact`, which requires digest specification. The signature in this case was not created for digested image.
 --
-// <9> is from the test case: https://polarion.engineering.redhat.com/polarion/#/project/OSE/workitem?id=OCP-83752
 +
 --
-.Example image policy object with a Fulcio certificate policy and the `ExactRepository` match policy
+The following example image policy object uses a Fulcio certificate policy and the `ExactRepository` match policy:
 [source,yaml]
 ----
 apiVersion: config.openshift.io/v1
-kind: ImagePolicy <1>
+kind: ImagePolicy
 metadata:
   name: p1
-  namespace: mynamespace <2>
+  namespace: mynamespace
 spec:
-  scopes: <3>
+  scopes:
     - example.io/crio/signed
-  policy: <4>
-    rootOfTrust: <5>
-      policyType: FulcioCAWithRekor <6>
-      fulcioCAWithRekor: <7>
+  policy:
+    rootOfTrust:
+      policyType: FulcioCAWithRekor
+      fulcioCAWithRekor:
         fulcioCAData: a2V5RGF0YQ==
         fulcioSubject:
           oidcIssuer: "https://expected.OIDC.issuer/"
           signedEmail: "expected-signing-user@example.com"
-        rekorKeyData: cmVrb3JLZXlEYXRh <8>
+        rekorKeyData: cmVrb3JLZXlEYXRh
     signedIdentity:
-      matchPolicy: ExactRepository <9>
+      matchPolicy: ExactRepository
       exactRepository:
-        repository: quay.io/crio/signed <10>
+        repository: quay.io/crio/signed
 ----
-<1> Creates an `ImagePolicy` object.
-<2> Specifies the namespace where the image policy is applied.
-<3> Defines a list of repositories or images assigned to this policy.
-<4> Specifies the parameters that define how the images are verified.
-<5> Defines a root of trust for the policy.
-<6> Specifies the policy types that define the root of trust, either a public key, a BYOPKI certificate, or a link:https://docs.sigstore.dev/certificate_authority/overview/[Fulcio certificate]. Here, a Fulcio certificate with required Rekor verification.
-<7> For a Fulcio certificate policy, the following parameters are required:
+`kind`:: Specifies that the configuration is for a `ImagePolicy` object.
+`metadata.namespace`:: Specifies the namespace where the image policy is applied.
+`spec.scopes`:: Specifies a list of repositories or images assigned to this policy.
+`spec.policy`:: Specifies the parameters that define how the images are verified.
+`spec.policy.rootOfTrust`:: Specifies a root of trust for the policy.
+`spec.policy.rootOfTrust.policyType`:: Specifies the policy types that define the root of trust, either a public key, a BYOPKI certificate, or a link:https://docs.sigstore.dev/certificate_authority/overview/[Fulcio certificate]. Here, a Fulcio certificate with required Rekor verification.
+`spec.policy.rootOfTrust.fulcioCAWithRekor`:: For a Fulcio certificate policy, the following parameters are required:
 * `fulcioCAData`: Specifies a base64-encoded Fulcio certificate in the PEM format. The maximum length is 8192 characters.
 * `fulcioSubject`: Specifies the OIDC issuer and the email of the Fulcio authentication configuration.
-<8> Specifies a base64-encoded Rekor public key in the PEM format. This parameter is required when the `policyType` is `FulcioCAWithRekor`. The maximum length is 8192 characters.
-<9> Optional: Specifies one of the following processes to verify the identity in the signature and the actual image identity:
+* `rekorKeyData`: Specifies a base64-encoded Rekor public key in the PEM format. This parameter is required when the `policyType` is `FulcioCAWithRekor`. The maximum length is 8192 characters.
+`spec.policy.signedIdentity.matchPolicy`:: Optional: Specifies one of the following processes to verify the identity in the signature and the actual image identity:
 * `MatchRepoDigestOrExact`.
 * `MatchRepository`.
 * `ExactRepository`. The `exactRepository` parameter must be specified.
 * `RemapIdentity`. The `prefix` and `signedPrefix` parameters must be specified.
-<10> For the `exactRepository` match policy, specifies the repository that contains the image identity and signature.
+`spec.policy.signedIdentity.exactRepository.repository`:: For the `exactRepository` match policy, specifies the repository that contains the image identity and signature.
 --
 
 . Create the image policy object:
@@ -256,11 +258,13 @@ sh-5.1# cat /etc/containers/registries.d/sigstore-registries.yaml
 ----
 docker:
   example.io/crio/signed:
-    use-sigstore-attachments: true <1>
+    use-sigstore-attachments: true
   quay.io/openshift-release-dev/ocp-release:
     use-sigstore-attachments: true
 ----
-<1> When `true`, specifies that sigstore signatures are going to be read along with the image.
+where:
+
+`docker.example.com.use-sigstore-attachments`:: When `true`, specifies that sigstore signatures are going to be read along with the image.
 
 ..  Check the crio log for sigstore signature verification by running the following command:
 +
@@ -273,8 +277,8 @@ sh-5.1#  journalctl -u crio | grep -A 100 "Pulling image: example.io/crio"
 [source,terminal]
 ----
 # ...
-msg="IsRunningImageAllowed for image docker:example.io/crio/signed:latest" file="signature/policy_eval.go:274" <1>
-msg="Using transport \"docker\" specific policy section \"example.io/crio/signed\"" file="signature/policy_eval.go:150" <2>
+msg="IsRunningImageAllowed for image docker:example.io/crio/signed:latest" file="signature/policy_eval.go:274"
+msg="Using transport \"docker\" specific policy section \"example.io/crio/signed\"" file="signature/policy_eval.go:150"
 msg="Reading /var/lib/containers/sigstore/crio/signed@sha256=18b42e8ea347780f35d979a829affa178593a8e31d90644466396e1187a07f3a/signature-1" file="docker/docker_image_src.go:545"
 msg="Looking for Sigstore attachments in quay.io/crio/signed:sha256-18b42e8ea347780f35d979a829affa178593a8e31d90644466396e1187a07f3a.sig" file="docker/docker_client.go:1138"
 msg="GET https://quay.io/v2/crio/signed/manifests/sha256-18b42e8ea347780f35d979a829affa178593a8e31d90644466396e1187a07f3a.sig" file="docker/docker_client.go:617"
@@ -283,5 +287,9 @@ msg="Found a Sigstore attachment manifest with 1 layers" file="docker/docker_ima
 msg="Fetching Sigstore attachment 1/1: sha256:8276724a208087e73ae5d9d6e8f872f67808c08b0acdfdc73019278807197c45" file="docker/docker_image_src.go:644"
 # ...
 ----
-<1> The `IsRunningImageAllowed` line confirms that image is allowed by the configured sigstore verification policy.
-<2> The `Using transport \"docker\" specific policy section \"example.io/crio/signed\"" file="signature/policy_eval.go:150` line confirms that the image policy has been applied.
++
+--
+The `IsRunningImageAllowed` line confirms that image is allowed by the configured sigstore verification policy.
+
+The `Using transport \"docker\" specific policy section \"example.io/crio/signed\"" file="signature/policy_eval.go:150` line confirms that the image policy has been applied.
+--

--- a/modules/nodes-sigstore-configure.adoc
+++ b/modules/nodes-sigstore-configure.adoc
@@ -6,7 +6,10 @@
 [id="nodes-sigstore-configure_{context}"]
 = About configuring sigstore support
 
-You can use the `ClusterImagePolicy` and `ImagePolicy` custom resource (CR) objects to enable and configure sigstore support for the entire cluster or a specific namespace. These objects contain a policy that specifies the images and repositories to be verified by using sigstore tooling and how the signatures must be verified.
+[role="_abstract"]
+You can use the `ClusterImagePolicy` and `ImagePolicy` custom resource (CR) objects to enable and configure sigstore support for the entire cluster or a specific namespace. 
+
+The `ClusterImagePolicy` and `ImagePolicy` objects contain a policy that specifies the images and repositories to be verified by using sigstore tooling and how the signatures must be verified.
 
 * Cluster image policy. A cluster image policy object enables a cluster administrator to configure a sigstore signature verification policy for the entire cluster. When enabled, the Machine Config Operator (MCO) watches the `ClusterImagePolicy` object and updates the `/etc/containers/policy.json` and `/etc/containers/registries.d/sigstore-registries.yaml` files on all nodes in the cluster.
 +
@@ -39,8 +42,6 @@ Status:
 
 The following parameters apply to cluster and image policies. For information on using these parameters, see "Creating a cluster image policy CR" and "Creating an image policy CR."
 
-// Based on https://github.com/openshift/api/blob/master/config/v1alpha1/zz_generated.crd-manifests/0000_10_config-operator_01_imagepolicies-TechPreviewNoUpgrade.crd.yaml
-
 `scopes`:: Defines a list of repositories and images assigned to a policy. You must list at least one of the following scopes:
 +
 --
@@ -55,14 +56,14 @@ If multiple scopes match a single scope in the same a cluster or image policy, t
 If a scoped image or repository in an image policy is nested under one of the scoped images or repositories in a cluster image policy, only the policy from cluster image policy is applied. However, the image policy object is created. For example, if an image policy specifies `example.com/global/image`, and the cluster image policy specifies `example.com/global`, the namespace inherits the policy from the cluster image policy.
 
 `policy`:: Contains configuration to allow images from the sources listed in `scopes` to be verified, and defines how images not matching the verification policy are treated. You must configure a `rootOfTrust` and optionally, a `signedIdentity`.
-* `rootOfTrust`: Specifies the root of trust for the policy. Configure either a public key, a Bring Your Own Public Key Infrastructure (BYOPKI) certificate, or a link:https://docs.sigstore.dev/certificate_authority/overview/[Fulcio certificate].
-** `publicKey`: Indicates that the policy relies on a sigstore public key. You must specify a base64-encoded PEM format public key. You can optionally include link:https://docs.sigstore.dev/logging/overview/[Rekor verification].
+* `rootOfTrust`: Specifies the root of trust for the policy. Configure either a public key, a Bring Your Own Public Key Infrastructure (BYOPKI) certificate, or a Fulcio certificate.
+** `publicKey`: Indicates that the policy relies on a sigstore public key. You must specify a base64-encoded PEM format public key. You can optionally include Rekor verification.
 ** `PKI` Indicates that the policy relies on a certificate from your own public key infrastructure (PKI) that is compatible with Cosign Bring Your Own Public Key Infrastructure (BYOPKI) verification. You must specify a base64-encoded PEM format public key. BYOPKI enables you to validate container images using an existing X.509 certificate while aligning with Cosign's bring-your-own PKI signing workflow.
 ** `FulcioCAWithRekor`: Indicates that the policy is based on a Fulcio certificate. You must specify the following parameters:
 *** A base64-encoded PEM-format Fulcio CA
 *** An OpenID Connect (OIDC) issuer
 *** The email of the Fulcio authentication configuration
-*** The link:https://docs.sigstore.dev/logging/overview/[Rekor verification]
+*** The Rekor verification
 * `signedIdentity`: Specifies the approach used to verify the image in the signature and the actual image itself. To configure a signed identity, you must specify one of the following parameters as the match policy:
 ** `MatchRepoDigestOrExact`. The image referenced in the signature must be in the same repository as the image itself. If the image carries a tag, the image referenced in the signature must match exactly. This is the default.
 ** `MatchRepository`. The image referenced in the signature must be in the same repository as the image itself. If the image carries a tag, the image referenced in the signature does not need to match exactly. This is useful to pull an image that contains the `latest` tag if the image is signed with a tag specifying an exact image version.

--- a/modules/nodes-sigstore-using-about.adoc
+++ b/modules/nodes-sigstore-using-about.adoc
@@ -6,7 +6,10 @@
 [id="nodes-sigstore-using-about_{context}"]
 = About sigstore
 
-The sigstore project enables developers to sign-off on what they build and administrators to verify signatures and monitor workflows at scale. With the sigstore project, signatures can be stored in the same registry as the build images. A second server is not needed. The identity piece of a signature is tied to the OpenID Connect (OIDC) identity through the Fulcio certificate authority, which simplifies the signature process by allowing key-less signing. Additionally, sigstore includes Rekor, which records signature metadata to an immutable, tamper-resistant ledger.
+[role="_abstract"]
+Cluster administrators or application developers can use the sigstore project to improve supply chain security. Developers can sign-off on what they build and administrators can verify those signatures and monitor workflows at scale. 
+
+With the sigstore project, signatures can be stored in the same registry as the build images. A second server is not needed. The identity piece of a signature is tied to the OpenID Connect (OIDC) identity through the Fulcio certificate authority, which simplifies the signature process by allowing key-less signing. Additionally, sigstore includes Rekor, which records signature metadata to an immutable, tamper-resistant ledger.
 
 You can use the `ClusterImagePolicy` and `ImagePolicy` custom resource (CR) objects to enable and configure sigstore support at the cluster or namespace scope. These objects specify the images and repositories to be verified and how the signatures must be verified.
 

--- a/nodes/index.adoc
+++ b/nodes/index.adoc
@@ -6,7 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-// TODO: Need some help with an intro blurb
+[role="_abstract"]
+In an {product-title} cluster, nodes, pods, and application containers are foundational components that you use to create and manage workloads.
 
 [id="nodes-overview"]
 == About nodes

--- a/nodes/nodes-sigstore-using.adoc
+++ b/nodes/nodes-sigstore-using.adoc
@@ -6,7 +6,10 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-You can use link:https://www.sigstore.dev/[sigstore] with {product-title} to improve supply chain security.
+[role="_abstract"]
+To improve supply chain security, cluster administrators or application developers can use the sigstore framework with {product-title}.
+
+Sigstore is a collection of open source tools that you can use individually or together to improve your software supply chain security by securely signing and verifying software artifacts.
 
 // The following include statements pull in the module files that comprise
 // the assembly. Include any combination of concept, procedure, or reference
@@ -20,14 +23,13 @@ include::modules/nodes-sigstore-configure.adoc[leveloffset=+1]
 
 include::modules/nodes-sigstore-configure-cluster-policy.adoc[leveloffset=+1]
 
-[role="_additional-resources"]
-.Additional resources
-* xref:../nodes/nodes-sigstore-using.adoc#nodes-sigstore-configure-parameters_nodes-sigstore-using[About cluster and image policy parameters]
-
 include::modules/nodes-sigstore-configure-image-policy.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
-.Additional resources
-
+[id="additional-resources_{context}"]
+== Additional resources
+* link:https://www.sigstore.dev/[Sigstore]
+* link:https://docs.sigstore.dev/certificate_authority/overview/[Fulcio certificate (Sigstore documentation)]
+* link:https://docs.sigstore.dev/logging/overview/[Rekor verification in the Sigstore documentation]
+* link:https://docs.sigstore.dev/cosign/signing/overview/[Cosign public and private key pair (Sigstore documentation)]
 * xref:../nodes/nodes-sigstore-using.adoc#nodes-sigstore-configure-parameters_nodes-sigstore-using[About cluster and image policy parameters]
-

--- a/nodes/pods/nodes-pods-adjust-resources-in-place.adoc
+++ b/nodes/pods/nodes-pods-adjust-resources-in-place.adoc
@@ -6,6 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 You can change the CPU or memory resource requests and limits assigned to a container without re-creating or restarting the pod by using _in-place pod resizing_.
 
 include::modules/nodes-pods-adjust-resources-in-place-about.adoc[leveloffset=+1]

--- a/nodes/pods/nodes-pods-node-selectors.adoc
+++ b/nodes/pods/nodes-pods-node-selectors.adoc
@@ -7,10 +7,10 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 
+[role="_abstract"]
+For a pod to be eligible to run on a specific node, you can include a _node selector_ in the pod spec that has the indicated key-value pairs as the label on that node.
 
 A _node selector_ specifies a map of key-value pairs. The rules are defined using custom labels on nodes and selectors specified in pods.
-
-For the pod to be eligible to run on a node, the pod must have the indicated key-value pairs as the label on the node.
 
 If you are using node affinity and node selectors in the same pod configuration, see the important considerations below.
 


### PR DESCRIPTION
https://redhat.atlassian.net/browse/OSDOCS-16937

**REVIEWER: Use caution when CPing this PR to 4.20. For the `nodes-pods-image-volume-*` files remove _(OCI)-compliant artifact_ references. Only _(OCI)-compliant container images_ were supported in 4.20. See https://github.com/openshift/openshift-docs/pull/102039**

Previews:
Nodes -> [Overview of Nodes](https://112757--ocpdocs-pr.netlify.app/openshift-dedicated/latest/nodes/index.html)
Nodes -> Working with pods -> [Adjust pod resource levels without pod disruption](https://112757--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/pods/nodes-pods-adjust-resources-in-place)
Nodes -> Working with pods -> [Placing pods on specific nodes using node selectors](https://112757--ocpdocs-pr.netlify.app/openshift-dedicated/latest/nodes/pods/nodes-pods-node-selectors)
Nodes -> [Manage secure signatures with sigstore](https://112757--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/nodes-sigstore-using)
Nodes -> Working with pods -> Mounting OCI images and artifacts into a pod -> [Understanding image volumes](https://112757--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/pods/nodes-pods-image-volume#nodes-pods-image-volume-about_nodes-pods-node-selectors)
Nodes -> Working with pods -> Mounting OCI images and artifacts into a pod -> [Adding an image volume to a pod](https://112757--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/pods/nodes-pods-image-volume#nodes-pods-image-volume-adding_nodes-pods-node-selectors)

Assemblies:
nodes-sigstore-using.adoc
index.adoc
nodes-pods-node-selectors.adoc
nodes-pods-adjust-resources-in-place.adoc
nodes-pods-image-volume.adoc
nodes-pods-allocate-dra.adoc (no changes)