### PR TITLE
OSDOCS-19064: ROSA and OSD with OCP 4.22

### DIFF
--- a/modules/life-cycle-dates.adoc
+++ b/modules/life-cycle-dates.adoc
@@ -14,13 +14,13 @@ The following table lists the general availability, maintenance support end date
 [options="header"]
 |===
 |Version    |General availability   |Maintenance support ends  |Extended Update Support Add-On - Term 1 ends
+|4.22       |Jun  9, 2026           |Dec 31, 2027              |Jun 30, 2028
 |4.21       |Feb  4, 2026           |Aug  3, 2027              |
 |4.20       |Oct 21, 2025           |Apr 21, 2027              |Oct 21, 2027
 |4.19       |Jun 17, 2025           |Dec 17, 2026              |
 |4.18       |Feb 25, 2025           |Aug 25, 2026              |Feb 25, 2027
-|4.17       |Oct  1, 2024           |Apr  1, 2026               |
+|4.17       |Oct  1, 2024           |Apr  1, 2026              |
 |4.16       |Jun 27, 2024           |Dec 27, 2025              |Jun 27, 2026
-|4.15       |Feb 27, 2024           |Aug 27, 2025              |
 |===
 
 The Extended Update Support Add-On - Term 1 is available for {product-title} customers using even-numbered versions, starting with 4.16, and is included with your {product-title} subscription.

--- a/modules/osd-release-notes-Q2-2026.adoc
+++ b/modules/osd-release-notes-Q2-2026.adoc
@@ -8,6 +8,10 @@
 [role="_abstract"]
 The following items were added during the second quarter of 2026.
 
+New version of {product-title} available::
++
+{product-title} on {gcp} and {product-title} on {aws} versions 4.22 are available for new clusters.
+
 Upgrade channels are available::
 +
 You can choose the new channels option for more precise, version-specific control over your cluster updates. You can target exact minor version paths, such as `stable-4.20` or `fast-4.21`, instead of relying on broader channel groups, which are being deprecated. For more information, see link:https://docs.redhat.com/en/documentation/openshift_dedicated/4/html/upgrading/osd-upgrades#osd-upgrading-channels_osd-upgrades[Channels in {product-title} clusters].

--- a/modules/rosa-release-notes-Q2-2026.adoc
+++ b/modules/rosa-release-notes-Q2-2026.adoc
@@ -11,10 +11,14 @@ The following items were added during the second quarter of 2026.
 ifdef::openshift-rosa-hcp[]
 {autonode} based on Karpenter v1.9 is available for managing compute nodes::
 +
-With this update, you can use {autonode} to automatically provision compute nodes based on workload demand. {autonode} is based on the open-source Karpenter project and provides dynamic node provisioning that matches workload requirements without requiring pre-configured node pools. When pods no longer require a node, {autonode} removes the node to reduce costs. 
+With this update, you can use {autonode} to automatically provision compute nodes based on workload demand. {autonode} is based on the open-source Karpenter project and provides dynamic node provisioning that matches workload requirements without requiring pre-configured node pools. When pods no longer require a node, {autonode} removes the node to reduce costs.
 
 //For more information, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html/cluster_administration/rosa_cluster_admin/rosa-nodes-managing-karpenter#rosa-nodes-autonode-managing[Managing compute nodes using {autonode}].
 endif::openshift-rosa-hcp[]
+
+New version of {product-title} available::
++
+{product-title} version 4.22 is available for new clusters.
 
 Upgrade channels are available::
 +


### PR DESCRIPTION
Version(s):
4.22+

Issue:
https://redhat.atlassian.net/browse/OSDOCS-19064

Link to docs preview:
**Release notes:**
https://112759--ocpdocs-pr.netlify.app/openshift-dedicated/latest/osd_whats_new/osd-whats-new.html
https://112759--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/rosa_release_notes/rosa-release-notes.html
https://112759--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_release_notes/rosa-release-notes.html

**Life cycle dates** are reused in all 3 docs and thus look identical:

- [OSD life cycle](https://112759--ocpdocs-pr.netlify.app/openshift-dedicated/latest/osd_architecture/osd_policy/osd-life-cycle.html#sd-life-cycle-dates_osd-life-cycle)
- [ROSA life cycle](https://112759--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/rosa_architecture/rosa_policy_service_definition/rosa-hcp-life-cycle.html#sd-life-cycle-dates_rosa-hcp-life-cycle)
- [ROSA Classic life cycle](https://112759--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_architecture/rosa_policy_service_definition/rosa-life-cycle.html#sd-life-cycle-dates_rosa-life-cycle)

QE review:
N/A

Additional information:
