### PR TITLE
OBSDOCS-3473: Fix ClusterLogForwarder service account name in install guide

### DIFF
--- a/modules/creating-the-clusterlogforwarder.adoc
+++ b/modules/creating-the-clusterlogforwarder.adoc
@@ -22,7 +22,7 @@ metadata:
   namespace: openshift-logging
 spec:
   serviceAccount:
-    name: collector
+    name: logging-collector
   outputs:
   - name: lokistack-out
     type: lokiStack


### PR DESCRIPTION
Recreated https://github.com/openshift/openshift-docs/pull/112627 PR on standalone-logging-docs-main to ensure the change carries forward to 6.6+.

Version(s): 6.6, 6.5
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://redhat.atlassian.net/browse/OBSDOCS-3473
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
