### PR TITLE
Fix en dash to double hyphen in CloudWatch create-log-group command

### DIFF
--- a/modules/rosa-set-up-cloudwatch-log-group.adoc
+++ b/modules/rosa-set-up-cloudwatch-log-group.adoc
@@ -19,7 +19,7 @@ If you have logs that require immediate action or organization, set up an Amazon
 +
 [source,terminal]
 ----
-$ aws logs create-log-group –log-group-name <your_log_group_name>
+$ aws logs create-log-group --log-group-name <your_log_group_name>
 ----
 +
 . In your {product-title} cluster, configure the log forwarder to use the CloudWatch log group by applying the following JSON sample:


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->
An AWS command had single hyphen instead of '--' that was failing for those who copy and paste the command. This PR fixes the typo. 
<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
- 4.21+

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
[OSDOCS-19998](https://redhat.atlassian.net/browse/OSDOCS-19998) 

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://112762--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/observability/logging/rosa-forwarding-control-plane-logs.html

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
