### PR TITLE
[OSDOCS#20000]: Added files for 4.12.91 z-stream release notes

### DIFF
--- a/modules/zstream-4-12-91-about.adoc
+++ b/modules/zstream-4-12-91-about.adoc
@@ -1,0 +1,24 @@
+// Module included in the following assembly:
+//
+// * release_notes/ocp-4-12-release-notes.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="zstream-4-12-91-about_{context}"]
+= RHSA-2026:21696 - {product-title} {product-version}.91 bug fix and security update
+
+[role="_abstract"]
+Issued: 04 June 2026
+
+{product-title} release {product-version}.91, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2026:21696[RHSA-2026:21696] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2026:21694[RHBA-2026:21694] advisory.
+
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+
+You can view the container images in this release by running the following command:
+
+
+[source,terminal]
+----
+$ oc adm release info 4.12.91 --pullspecs
+----

--- a/modules/zstream-4-12-91-fixed-issues.adoc
+++ b/modules/zstream-4-12-91-fixed-issues.adoc
@@ -1,0 +1,10 @@
+// Module included in the following assembly:
+//
+// * release_notes/ocp-4-12-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-12-91-fixed-issues_{context}"]
+= Fixed issues
+
+[role="_abstract"]
+There are no notable fixed issues in this release.

--- a/modules/zstream-4-12-91-updating.adoc
+++ b/modules/zstream-4-12-91-updating.adoc
@@ -1,0 +1,10 @@
+// Module included in the following assembly:
+//
+// * release_notes/ocp-4-12-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-12-91-updating_{context}"]
+= Updating
+
+[role="_abstract"]
+To update an existing {product-title} 4.12 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].

--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -5413,3 +5413,12 @@ include::modules/zstream-4-12-90-fixed-issues.adoc[leveloffset=+3]
 
 // 4.12.90 updating
 include::modules/zstream-4-12-90-updating.adoc[leveloffset=+3]
+
+// 4.12.91 about
+include::modules/zstream-4-12-91-about.adoc[leveloffset=+2]
+
+// 4.12.91 fixes
+include::modules/zstream-4-12-91-fixed-issues.adoc[leveloffset=+3]
+
+// 4.12.91 updating
+include::modules/zstream-4-12-91-updating.adoc[leveloffset=+3]


### PR DESCRIPTION

Version(s):
4.12

Issue:
https://redhat.atlassian.net/browse/OSDOCS-20000

Link to docs preview:
https://112766--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-12-release-notes.html#zstream-4-12-91-about_release-notes

QE review:
N/A

