### PR TITLE
[RHDEVDOCS-7635] Release notes for Pipelines 1.22.2

### DIFF
--- a/modules/op-release-notes-1-22-2.adoc
+++ b/modules/op-release-notes-1-22-2.adoc
@@ -1,0 +1,28 @@
+// This module is included in the following assemblies:
+// * release_notes/op-release-notes-1-22.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="op-release-notes-1-22-2_{context}"]
+= Release notes for {pipelines-title} 1.22.2
+
+[role="_abstract"]
+With this update, {pipelines-title} General Availability (GA) 1.22.2 is available on {OCP} 4.14, 4.16, and later versions.
+
+[id="new-features-1-22-2_{context}"]
+== New features and enhancements
+
+In addition to fixes and stability improvements, the following section highlights what is new in {pipelines-title} 1.22.2:
+
+.{pac}
+
+Webhook signature validation for Forgejo and Gitea providers::
+With this update, {pac} enforces webhook signature validation for Forgejo and Gitea providers. Previously, the provider implementation skipped validation, which could allow unauthenticated or spoofed requests to trigger pipelines. With this release, the system verifies that incoming requests originate from trusted sources.
++
+link:https://issues.redhat.com/browse/SRVKP-10609[SRVKP-10609]
+
+.User interface
+
+Console plugin upgraded to React 18 and PatternFly 6 for {OCP} 4.22 compatibility::
+With this update, the {pipelines-shortname} console plugin is upgraded to use React 18 and PatternFly 6. This upgrade helps ensure compatibility with {OCP} 4.22 and later versions as part of ongoing platform alignment efforts. The upgrade includes migrating all UI components from PatternFly 5 to PatternFly 6 and updating the React framework from version 17 to version 18. These changes are primarily technical and framework-related, with no functional changes to your workflows.
++
+link:https://issues.redhat.com/browse/SRVKP-9276[SRVKP-9276], link:https://issues.redhat.com/browse/SRVKP-9273[SRVKP-9273]

--- a/modules/op-tkn-pipelines-compatibility-support-matrix.adoc
+++ b/modules/op-tkn-pipelines-compatibility-support-matrix.adoc
@@ -22,7 +22,7 @@ GA:: General Availability
 
 | Operator | Pipelines | Triggers | CLI | Chains | Hub | {pac} | Results | Manual Approval Gate | Pruner | Cache | |
 
-|1.22 | 1.9.x | 0.35.x | 0.44.x | 0.26.x (GA) | 1.23.x (TP) | 0.42.x (GA) | 0.18.x (GA) | 0.8.x (TP) | 0.3.x (GA) | 0.3.x (GA) | 4.14, 4.16, 4.17, 4.18, 4.19, 4.20, 4.21 | GA
+|1.22 | 1.9.x | 0.35.x | 0.44.x | 0.26.x (GA) | 1.23.x (TP) | 0.42.x (GA) | 0.18.x (GA) | 0.8.x (TP) | 0.3.x (GA) | 0.3.x (GA) | 4.14, 4.16, 4.17, 4.18, 4.19, 4.20, 4.21, 4.22 | GA
 
 |1.21 | 1.6.x | 0.34.x | 0.43.x | 0.26.x (GA) | 1.23.x (TP) | 0.39.x (GA) | 0.17.x (GA) | 0.7.x (TP) | 0.3.x (GA) |0.3.x (GA) | 4.14, 4.16, 4.17, 4.18, 4.19, 4.20, 4.21 | GA
 

--- a/release_notes/op-release-notes-1-22.adoc
+++ b/release_notes/op-release-notes-1-22.adoc
@@ -28,6 +28,9 @@ For an overview of {pipelines-title}, see xref:../about/understanding-openshift-
 // Compatibility and support matrix 1.22
 include::modules/op-tkn-pipelines-compatibility-support-matrix.adoc[leveloffset=+1]
 
+// Release notes for Red Hat OpenShift Pipelines 1.22.2
+include::modules/op-release-notes-1-22-2.adoc[leveloffset=+1]
+
 // Release notes for Red Hat OpenShift Pipelines 1.22.1
 include::modules/op-release-notes-1-22-1.adoc[leveloffset=+1]
 


### PR DESCRIPTION
Version(s):
- none for CP

Issue:
- https://redhat.atlassian.net/browse/RHDEVDOCS-7635

Link to docs preview:
- [1.22.2 RNs](https://112767--ocpdocs-pr.netlify.app/openshift-pipelines/latest/release_notes/op-release-notes-1-22.html#op-release-notes-1-22-2_op-release-notes-1-22)

QE review:
- [x] QE has approved this change.
