### PR TITLE
OCPBUGS-86705: Fix symmetric routing procedure for MetalLB+VRF (4.16)

### DIFF
--- a/modules/nw-metallb-configure-return-traffic-proc.adoc
+++ b/modules/nw-metallb-configure-return-traffic-proc.adoc
@@ -12,7 +12,7 @@ This example associates a VRF routing table with MetalLB and an egress service t
 
 [NOTE]
 ====
-* If you use the `sourceIPBy: "LoadBalancerIP"` setting in the `EgressService` CR, you must specify the load-balancer node in the `BGPAdvertisement` custom resource (CR).
+* If you use the `sourceIPBy: "LoadBalancerIP"` setting in the `EgressService` CR, you must specify the `LoadBalancer` node in the `BGPAdvertisement` custom resource (CR).
 
 * You can use the `sourceIPBy: "Network"` setting on clusters that use OVN-Kubernetes configured with the `gatewayConfig.routingViaHost` specification set to `true` only. Additionally, if you use the `sourceIPBy: "Network"` setting, you must schedule the application workload on nodes configured with the network VRF instance.
 ====
@@ -23,8 +23,19 @@ This example associates a VRF routing table with MetalLB and an egress service t
 * Log in as a user with `cluster-admin` privileges.
 * Install the Kubernetes NMState Operator.
 * Install the MetalLB Operator.
+* Create a namespace for your application workload. The examples in this procedure use a namespace called `test`.
 
 .Procedure
+
+. Label the nodes that you want to participate in the VRF configuration by running the following command:
++
+[source,terminal]
+----
+$ oc label node <node_name> vrf=true
+----
++
+The examples in this procedure use the label `vrf: "true"`.
+
 
 . Create a `NodeNetworkConfigurationPolicy` CR to define the VRF instance:
 
@@ -70,10 +81,10 @@ spec:
       - ip-to: 172.30.0.0/16
         priority: 998
         route-table: 254 <10>
-      - ip-to: 10.132.0.0/14
+      - ip-to: 10.128.0.0/14
         priority: 998
         route-table: 254
-      - ip-to: 169.254.169.0/29
+      - ip-to: 169.254.0.0/17
         priority: 998
         route-table: 254
 ----
@@ -83,7 +94,7 @@ spec:
 <4> The type of interface. This example creates a VRF instance.
 <5> The node interface that the VRF attaches to.
 <6> The name of the route table ID for the VRF.
-<7> The IPv4 address of the interface associated with the VRF. 
+<7> The IPv4 address of the interface associated with the VRF.
 <8> Defines the configuration for network routes. The `next-hop-address` field defines the IP address of the next hop for the route. The `next-hop-interface` field defines the outgoing interface for the route. In this example, the VRF routing table is `2`, which references the ID that you define in the `EgressService` CR.
 <9> Defines additional route rules. The `ip-to` fields must match the `Cluster Network` CIDR, `Service Network` CIDR, and `Internal Masquerade` subnet CIDR. You can view the values for these CIDR address specifications by running the following command: `oc describe network.operator/cluster`.
 <10> The main routing table that the Linux kernel uses when calculating routes has the ID `254`.
@@ -94,6 +105,15 @@ spec:
 ----
 $ oc apply -f node-network-vrf.yaml
 ----
++
+.. Verify that the policy is applied by running the following command:
++
+[source,terminal]
+----
+$ oc get nncp vrfpolicy
+----
++
+The output must show `Available` in the `STATUS` column before you continue to the next step.
 
 . Create a `BGPPeer` custom resource (CR):
 
@@ -165,7 +185,7 @@ spec:
         egress-service.k8s.ovn.org/test-server1: "" <2>
 ----
 <1> In this example, MetalLB advertises a range of IP addresses from the `first-pool` IP address pool to the `frrviavrf` BGP peer.
-<2> In this example, the `EgressService` CR configures the source IP address for egress traffic to use the load-balancer service IP address. Therefore, you must specify the load-balancer node for return traffic to use the same return path for the traffic originating from the pod.
+<2> In this example, the `EgressService` CR configures the source IP address for egress traffic to use the `LoadBalancer` service IP address. Therefore, you must specify the `LoadBalancer` node for return traffic to use the same return path for the traffic originating from the pod.
 
 .. Apply the configuration for the BGP advertisement by running the following command:
 +
@@ -192,11 +212,11 @@ spec:
       vrf: "true" <4>
   network: "2" <5>
 ----
-<1> Specify the name for the egress service. The name of the `EgressService` resource must match the name of the load-balancer service that you want to modify.
-<2> Specify the namespace for the egress service. The namespace for the `EgressService` must match the namespace of the load-balancer service that you want to modify. The egress service is namespace-scoped.
+<1> Specify the name for the egress service. The name of the `EgressService` resource must match the name of the `LoadBalancer` service that you want to modify.
+<2> Specify the namespace for the egress service. The namespace for the `EgressService` must match the namespace of the `LoadBalancer` service that you want to modify. The egress service is namespace-scoped.
 <3> This example assigns the `LoadBalancer` service ingress IP address as the source IP address for egress traffic.
 <4> If you specify `LoadBalancer` for the `sourceIPBy` specification, a single node handles the `LoadBalancer` service traffic. In this example, only a node with the label `vrf: "true"` can handle the service traffic. If you do not specify a node, OVN-Kubernetes selects a worker node to handle the service traffic. When a node is selected, OVN-Kubernetes labels the node in the following format: `egress-service.k8s.ovn.org/<svc_namespace>-<svc_name>: ""`.
-<5> Specify the routing table ID for egress traffic. Ensure that the value matches the `route-table-id` ID defined in the `NodeNetworkConfigurationPolicy` resource, for example, `route-table-id: 2`. 
+<5> Specifies the routing table ID for egress traffic. Ensure that the value matches the `route-table-id` ID defined in the `NodeNetworkConfigurationPolicy` resource, for example, `route-table-id: 2`.
 
 .. Apply the configuration for the egress service by running the following command:
 +
@@ -207,12 +227,22 @@ $ oc apply -f egress-service.yaml
 
 .Verification
 
+. Get the external IP address for the `LoadBalancer` service by running the following command:
++
+[source,terminal]
+----
+$ oc get svc <service_name> -n <namespace>
+----
++
+where `<service_name>` is the name of your `LoadBalancer` service and `<namespace>` is the namespace where the service is deployed. Note the `EXTERNAL-IP` value from the output.
+
 . Verify that you can access the application endpoint of the pods running behind the MetalLB service by running the following command:
 +
 [source,terminal]
 ----
-$ curl <external_ip_address>:<port_number> <1>
+$ curl <external_ip_address>:<port_number>
 ----
-<1> Update the external IP address and port number to suit your application endpoint.
++
+where `<external_ip_address>` is the `EXTERNAL-IP` value from the previous step, and `<port_number>` is the port number of your application endpoint.
 
 . Optional: If you assigned the `LoadBalancer` service ingress IP address as the source IP address for egress traffic, verify this configuration by using tools such as `tcpdump` to analyze packets received at the external client.

--- a/modules/nw-metallb-configure-return-traffic-proc.adoc
+++ b/modules/nw-metallb-configure-return-traffic-proc.adoc
@@ -6,6 +6,7 @@
 [id="nw-metallb-configure-return-traffic-proc_{context}"]
 = Configuring symmetric routing by using VRFs with MetalLB
 
+[role="_abstract"]
 You can configure symmetric network routing for applications behind a MetalLB service that require the same ingress and egress network paths.
 
 This example associates a VRF routing table with MetalLB and an egress service to enable symmetric routing for ingress and egress traffic for pods behind a `LoadBalancer` service.
@@ -46,21 +47,21 @@ The examples in this procedure use the label `vrf: "true"`.
 apiVersion: nmstate.io/v1
 kind: NodeNetworkConfigurationPolicy
 metadata:
-  name: vrfpolicy <1>
+  name: <policy_name>
 spec:
   nodeSelector:
-    vrf: "true" <2>
+    vrf: "true"
   maxUnavailable: 3
   desiredState:
     interfaces:
-    - name: ens4vrf <3>
-      type: vrf <4>
+    - name: <vrf_interface_name>
+      type: vrf
       state: up
       vrf:
         port:
-        - ens4 <5>
-        route-table-id: 2 <6>
-    - name: ens4 <7>
+        - <node_interface>
+        route-table-id: <route_table_id>
+    - name: <node_interface>
       type: ethernet
       state: up
       ipv4:
@@ -69,18 +70,18 @@ spec:
           prefix-length: 24
         dhcp: false
         enabled: true
-    routes: <8>
+    routes:
       config:
       - destination: 0.0.0.0/0
         metric: 150
         next-hop-address: 192.168.130.1
-        next-hop-interface: ens4
-        table-id: 2
-    route-rules: <9>
+        next-hop-interface: <node_interface>
+        table-id: <route_table_id>
+    route-rules:
       config:
       - ip-to: 172.30.0.0/16
         priority: 998
-        route-table: 254 <10>
+        route-table: 254
       - ip-to: 10.128.0.0/14
         priority: 998
         route-table: 254
@@ -88,16 +89,15 @@ spec:
         priority: 998
         route-table: 254
 ----
-<1> The name of the policy.
-<2> This example applies the policy to all nodes with the label `vrf:true`.
-<3> The name of the interface.
-<4> The type of interface. This example creates a VRF instance.
-<5> The node interface that the VRF attaches to.
-<6> The name of the route table ID for the VRF.
-<7> The IPv4 address of the interface associated with the VRF.
-<8> Defines the configuration for network routes. The `next-hop-address` field defines the IP address of the next hop for the route. The `next-hop-interface` field defines the outgoing interface for the route. In this example, the VRF routing table is `2`, which references the ID that you define in the `EgressService` CR.
-<9> Defines additional route rules. The `ip-to` fields must match the `Cluster Network` CIDR, `Service Network` CIDR, and `Internal Masquerade` subnet CIDR. You can view the values for these CIDR address specifications by running the following command: `oc describe network.operator/cluster`.
-<10> The main routing table that the Linux kernel uses when calculating routes has the ID `254`.
++
+--
+* `<policy_name>` specifies the name of the policy. The `nodeSelector` applies the policy to all nodes with the label `vrf: "true"`.
+* `<vrf_interface_name>` specifies the name of the VRF interface.
+* `<node_interface>` specifies the node interface that the VRF attaches to.
+* `<route_table_id>` specifies the route table ID for the VRF. In this example, the VRF routing table is `2`, which references the ID that you define in the `EgressService` CR.
+* `routes` defines the configuration for network routes. The `next-hop-address` field defines the IP address of the next hop for the route. The `next-hop-interface` field defines the outgoing interface for the route.
+* `route-rules` defines additional route rules. The `ip-to` fields must match the `Cluster Network` CIDR, `Service Network` CIDR, and `Internal Masquerade` subnet CIDR. You can view the values for these CIDR address specifications by running the following command: `oc describe network.operator/cluster`. The `route-table` value of `254` is the main routing table that the Linux kernel uses when calculating routes.
+--
 
 .. Apply the policy by running the following command:
 +
@@ -130,9 +130,12 @@ spec:
   myASN: 100
   peerASN: 200
   peerAddress: 192.168.130.1
-  vrf: ens4vrf <1>
+  vrf: <vrf_interface_name>
 ----
-<1> Specifies the VRF instance to associate with the BGP peer. MetalLB can advertise services and make routing decisions based on the routing information in the VRF.
++
+--
+* `<vrf_interface_name>` specifies the VRF instance to associate with the BGP peer. MetalLB can advertise services and make routing decisions based on the routing information in the VRF.
+--
 
 .. Apply the configuration for the BGP peer by running the following command:
 +
@@ -179,13 +182,16 @@ spec:
   ipAddressPools:
     - first-pool
   peers:
-    - frrviavrf <1>
+    - <bgp_peer_name>
   nodeSelectors:
     - matchLabels:
-        egress-service.k8s.ovn.org/test-server1: "" <2>
+        egress-service.k8s.ovn.org/<namespace>-<service_name>: ""
 ----
-<1> In this example, MetalLB advertises a range of IP addresses from the `first-pool` IP address pool to the `frrviavrf` BGP peer.
-<2> In this example, the `EgressService` CR configures the source IP address for egress traffic to use the `LoadBalancer` service IP address. Therefore, you must specify the `LoadBalancer` node for return traffic to use the same return path for the traffic originating from the pod.
++
+--
+* `<bgp_peer_name>` specifies the BGP peer. In this example, MetalLB advertises a range of IP addresses from the `first-pool` IP address pool to the BGP peer.
+* `nodeSelectors` specifies the node that handles the `LoadBalancer` service traffic. The `EgressService` CR configures the source IP address for egress traffic to use the `LoadBalancer` service IP address. Therefore, you must specify the `LoadBalancer` node for return traffic to use the same return path for the traffic originating from the pod.
+--
 
 .. Apply the configuration for the BGP advertisement by running the following command:
 +
@@ -203,20 +209,23 @@ $ oc apply -f first-adv.yaml
 apiVersion: k8s.ovn.org/v1
 kind: EgressService
 metadata:
-  name: server1 <1>
-  namespace: test <2>
+  name: <service_name>
+  namespace: <namespace>
 spec:
-  sourceIPBy: "LoadBalancerIP" <3>
+  sourceIPBy: "LoadBalancerIP"
   nodeSelector:
     matchLabels:
-      vrf: "true" <4>
-  network: "2" <5>
+      vrf: "true"
+  network: "<route_table_id>"
 ----
-<1> Specify the name for the egress service. The name of the `EgressService` resource must match the name of the `LoadBalancer` service that you want to modify.
-<2> Specify the namespace for the egress service. The namespace for the `EgressService` must match the namespace of the `LoadBalancer` service that you want to modify. The egress service is namespace-scoped.
-<3> This example assigns the `LoadBalancer` service ingress IP address as the source IP address for egress traffic.
-<4> If you specify `LoadBalancer` for the `sourceIPBy` specification, a single node handles the `LoadBalancer` service traffic. In this example, only a node with the label `vrf: "true"` can handle the service traffic. If you do not specify a node, OVN-Kubernetes selects a worker node to handle the service traffic. When a node is selected, OVN-Kubernetes labels the node in the following format: `egress-service.k8s.ovn.org/<svc_namespace>-<svc_name>: ""`.
-<5> Specifies the routing table ID for egress traffic. Ensure that the value matches the `route-table-id` ID defined in the `NodeNetworkConfigurationPolicy` resource, for example, `route-table-id: 2`.
++
+--
+* `<service_name>` specifies the name for the egress service. The name of the `EgressService` resource must match the name of the `LoadBalancer` service that you want to modify.
+* `<namespace>` specifies the namespace for the egress service. The namespace for the `EgressService` must match the namespace of the `LoadBalancer` service that you want to modify. The egress service is namespace-scoped.
+* `sourceIPBy: "LoadBalancerIP"` assigns the `LoadBalancer` service ingress IP address as the source IP address for egress traffic.
+* `nodeSelector` specifies the node that handles the `LoadBalancer` service traffic. In this example, only a node with the label `vrf: "true"` can handle the service traffic. If you do not specify a node, OVN-Kubernetes selects a worker node to handle the service traffic. When a node is selected, OVN-Kubernetes labels the node in the following format: `egress-service.k8s.ovn.org/<svc_namespace>-<svc_name>: ""`.
+* `<route_table_id>` specifies the routing table ID for egress traffic. Ensure that the value matches the `route-table-id` ID defined in the `NodeNetworkConfigurationPolicy` resource, for example, `route-table-id: 2`.
+--
 
 .. Apply the configuration for the egress service by running the following command:
 +


### PR DESCRIPTION
[OCPBUGS-86705]: Hybrid cluster network cited instead of cluster network for metallb+vrf symmetric NNCP config

Version(s): 4.16

Issue: https://redhat.atlassian.net/browse/OCPBUGS-86705

Link to docs preview: https://112772--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/metallb/metallb-configure-return-traffic.html

QE review:
- [x] QE has approved this change.

Additional information: Port of #112391 (main) to enterprise-4.16. The content lives in a different assembly on 4.16 (`networking/ovn_kubernetes_network_provider/configuring-egress-traffic-for-vrf-loadbalancer-services.adoc`) but uses the same module.

## Summary
- Fix Cluster Network CIDR from `10.132.0.0/14` to `10.128.0.0/14`
- Fix Internal Masquerade subnet CIDR from `169.254.169.0/29` to `169.254.0.0/17`
- Add namespace creation (`test`) as a prerequisite
- Move node labeling (`vrf=true`) from implicit prereq to explicit procedure step
- Add NMState policy readiness check (`oc get nncp`) after applying the policy
- Add `oc get svc` step to retrieve external IP before curl verification
- Fix `load-balancer` → `LoadBalancer` terminology throughout
- Fix trailing whitespace and typo in EgressService callout

## Test plan
- [x] Verified end-to-end on a live OCP 4.21 SNO cluster (via main branch PR)
- [x] Changes are a direct port of approved PR #112391

🤖 Generated with [Claude Code](https://claude.com/claude-code)