### PR TITLE
OCPBUGS-85374: Add note about ipForwarding Global behavior (4.17)

### DIFF
--- a/modules/nw-metallb-configure-secondary-interface.adoc
+++ b/modules/nw-metallb-configure-secondary-interface.adoc
@@ -2,10 +2,11 @@
 [id="nw-metallb-configure-secondary-interface_{context}"]
 = Configuring MetalLB with secondary networks
 
-From {product-title} 4.14 the default network behavior is to not allow forwarding of IP packets between network interfaces. Therefore, when MetalLB is configured on a secondary interface, you need to add a machine configuration to enable IP forwarding for only the required interfaces. 
+From {product-title} 4.14 the default network behavior is to not allow forwarding of IP packets between network interfaces. Therefore, when MetalLB is configured on a secondary interface, you need to add a machine configuration to enable IP forwarding for only the required interfaces.
+
 [NOTE]
 ====
-{product-title} clusters upgraded from 4.13 are not affected because a global parameter is set during upgrade to enable global IP forwarding. 
+{product-title} clusters upgraded from 4.13 are not affected because a global parameter is set during upgrade to enable global IP forwarding.
 ====
 
 To enable IP forwarding for the secondary interface, you have two options:
@@ -22,7 +23,7 @@ Enabling IP forwarding for a specific interface provides more granular control, 
 == Enabling IP forwarding for a specific interface
 .Procedure
 
-. Patch the Cluster Network Operator, setting the parameter `routingViaHost` to `true`, by running the following command: 
+. Patch the Cluster Network Operator, setting the parameter `routingViaHost` to `true`, by running the following command:
 +
 [source,terminal]
 ----
@@ -55,7 +56,7 @@ apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig
 metadata:
   labels:
-    machineconfiguration.openshift.io/role: <node_role> <1> 
+    machineconfiguration.openshift.io/role: <node_role> <1>
   name: 81-enable-global-forwarding
 spec:
   config:
@@ -73,7 +74,7 @@ spec:
 ----
 +
 <1> Node role where you want to enable IP forwarding, for example, `worker`
-<2> Populate with the generated base64 string 
+<2> Populate with the generated base64 string
 
 .. Apply the configuration by running the following command:
 +
@@ -84,9 +85,9 @@ $ oc apply -f enable-ip-forward.yaml
 
 .Verification
 
-.  After you apply the machine config, verify the changes by following this procedure: 
+.  After you apply the machine config, verify the changes by following this procedure:
 
-.. Enter into a debug session on the target node by running the following command: 
+.. Enter into a debug session on the target node by running the following command:
 +
 [source,terminal]
 ----
@@ -102,7 +103,7 @@ $ chroot /host
 ----
 The debug pod mounts the host’s root file system in `/host` within the pod. By changing the root directory to `/host`, you can run binaries contained in the host’s executable paths.
 
-.. Verify that IP forwarding is enabled by running the following command: 
+.. Verify that IP forwarding is enabled by running the following command:
 +
 [source,terminal]
 ----
@@ -113,13 +114,13 @@ $ cat /etc/sysctl.d/enable-global-forwarding.conf
 
 [source,terminal]
 ----
-net.ipv4.conf.bridge-net.forwarding = 1 
+net.ipv4.conf.bridge-net.forwarding = 1
 ----
 +
 The output indicates that IPv4 forwarding is enabled on the `bridge-net` interface.
 
 [id="nw-enabling-ip-forwarding-globally_{context}"]
-== Enabling IP forwarding globally 
+== Enabling IP forwarding globally
 
 * Enable IP forwarding globally by running the following command:
 +
@@ -127,3 +128,8 @@ The output indicates that IPv4 forwarding is enabled on the `bridge-net` interfa
 ----
 $ oc patch network.operator cluster -p '{"spec":{"defaultNetwork":{"ovnKubernetesConfig":{"gatewayConfig":{"ipForwarding": "Global"}}}}}' --type=merge
 ----
++
+[NOTE]
+====
+Setting `ipForwarding` to `Global` sets `net.ipv4.conf.default.forwarding = 1`. All interfaces on the node inherit this, resulting in settings like `net.ipv4.conf.tun0.forwarding = 1`. This configuration also skips installing the default drop firewall rules, allowing the node to act as a router that forwards traffic between interfaces.
+====


### PR DESCRIPTION
[OCPBUGS-85374]: Edit optional note about ipForwarding Global

Version(s): 4.17

Issue: https://redhat.atlassian.net/browse/OCPBUGS-85374

Link to docs preview: https://112776--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ingress_load_balancing/metallb/about-advertising-ipaddresspool.html

QE review:
- [x] QE has approved this change.

Additional information: Port of #111710 (enterprise-4.21) to enterprise-4.17.

## Summary
- Add NOTE block explaining that setting `ipForwarding` to `Global` enables forwarding on all interfaces and skips default drop firewall rules
- Fix trailing whitespace throughout the file

## Test plan
- [x] Changes are a direct port of merged PR #111710

🤖 Generated with [Claude Code](https://claude.com/claude-code)