### PR TITLE
OSDOCS-16851-3: Third CQA PR for OVNK2 Egress Traffic and Gateway config

### DIFF
--- a/modules/nw-egress-ips-about.adoc
+++ b/modules/nw-egress-ips-about.adoc
@@ -6,10 +6,10 @@
 [id="nw-egress-ips-about_{context}"]
 = Egress IP address architectural design and implementation
 
+[role="_abstract"]
 By using the {product-title} egress IP address functionality, you can ensure that the traffic from one or more pods in one or more namespaces has a consistent source IP address for services outside the cluster network.
 
-For example, you might have a pod that periodically queries a database that is hosted on a server outside of your cluster. To enforce access requirements for the server, a packet filtering device is configured to allow traffic only from specific IP addresses.
-To ensure that you can reliably allow access to the server from only that specific pod, you can configure a specific egress IP address for the pod that makes the requests to the server.
+For example, you might have a pod that periodically queries a database that is hosted on a server outside of your cluster. To enforce access requirements for the server, a packet filtering device is configured to allow traffic only from specific IP addresses. To ensure that you can reliably allow access to the server from only that specific pod, you can configure a specific egress IP address for the pod that makes the requests to the server.
 
 An egress IP address assigned to a namespace is different from an egress router, which is used to send traffic to specific destinations.
 
@@ -28,43 +28,6 @@ Egress IP addresses must not be configured in any Linux network configuration fi
 ====
 endif::openshift-rosa[]
 
-ifndef::openshift-rosa[]
-[id="nw-egress-ips-platform-support_{context}"]
-== Platform support
-
-The Egress IP address feature that runs on a primary host network is supported on the following platforms:
-
-[cols="1,1",options="header"]
-|===
-| Platform | Supported
-
-| Bare metal | Yes
-| VMware vSphere | Yes
-| {rh-openstack-first} | Yes
-| Amazon Web Services (AWS) | Yes
-| {gcp-first} | Yes
-| Microsoft Azure | Yes
-| {ibm-z-name} and {ibm-linuxone-name} | Yes
-| {ibm-z-name} and {ibm-linuxone-name} for {op-system-base-full} KVM | Yes
-| {ibm-power-name} | Yes
-| Nutanix | Yes
-|===
-
-[IMPORTANT]
-====
-Support for egress IP addresses in Microsoft Azure is restricted to the infra subnet. As a workaround for this limitation, you can use a Network Address Translation (NAT) gateway instead of a general purpose public load balancer.
-====
-// If platform support increases, ensure to update the lead-in sentence to the plural form.
-The Egress IP address feature that runs on secondary host networks is supported on the following platform:
-
-[cols="1,1",options="header"]
-|===
-| Platform | Supported
-
-| Bare metal | Yes
-|===
-endif::openshift-rosa[]
-
 [IMPORTANT]
 ====
 The assignment of egress IP addresses to control plane nodes with the EgressIP feature is
@@ -72,39 +35,11 @@ ifdef::openshift-rosa[]
 not supported.
 endif::openshift-rosa[]
 ifndef::openshift-rosa[]
-not supported on a cluster provisioned on Amazon Web Services (AWS). (link:https://bugzilla.redhat.com/show_bug.cgi?id=2039656[*BZ#2039656*]).
+not supported on a cluster provisioned on {aws-first}. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2039656[BZ#2039656]).
 endif::openshift-rosa[]
 ====
 
-ifndef::openshift-rosa[]
-[id="nw-egress-ips-public-cloud-platform-considerations_{context}"]
-== Public cloud platform considerations
-
-Typically, public cloud providers place a limit on egress IP addresses. This means that there is a constraint on the absolute number of assignable IP addresses per node for clusters provisioned on public cloud infrastructure. The maximum number of assignable IP addresses per node, or the _IP capacity_, can be described in the following formula:
-
-[source,text]
-----
-IP capacity = public cloud default capacity - sum(current IP assignments)
-----
-
-While the Egress IP addresses capability manages the IP address capacity per node, it is important to plan for this constraint in your deployments. For example, if a public cloud provider limits IP address capacity to 10 IP addresses per node, and you have 8 nodes, the total number of assignable IP addresses is only 80. To achieve a higher IP address capacity, you would need to allocate additional nodes. For example, if you needed 150 assignable IP addresses, you would need to allocate 7 additional nodes.
-
-To confirm the IP capacity and subnets for any node in your public cloud environment, you can enter the `oc get node <node_name> -o yaml` command. The `cloud.network.openshift.io/egress-ipconfig` annotation includes capacity and subnet information for the node.
-
-The annotation value is an array with a single object with fields that provide the following information for the primary network interface:
-
-* `interface`: Specifies the interface ID on AWS and Azure and the interface name on {gcp-short}.
-* `ifaddr`: Specifies the subnet mask for one or both IP address families.
-* `capacity`: Specifies the IP address capacity for the node. On AWS, the IP address capacity is provided per IP address family. On Azure and {gcp-short}, the IP address capacity includes both IPv4 and IPv6 addresses.
-
-Automatic attachment and detachment of egress IP addresses for traffic between nodes are available. This allows for traffic from many pods in namespaces to have a consistent source IP address to locations outside of the cluster.
-
-[NOTE]
-====
-When an {rh-openstack} cluster administrator assigns a floating IP to the reservation port, {product-title} cannot delete the reservation port. The `CloudPrivateIPConfig` object cannot perform delete and move operations until an {rh-openstack} cluster administrator unassigns the floating IP from the reservation port.
-====
-endif::openshift-rosa[]
-
+ifdef::openshift-rosa[]
 The following examples illustrate the annotation from nodes on several public cloud providers. The annotations are indented for readability.
 
 .Example `cloud.network.openshift.io/egress-ipconfig` annotation on AWS
@@ -119,111 +54,9 @@ cloud.network.openshift.io/egress-ipconfig: [
 ]
 ----
 
-ifndef::openshift-rosa[]
-.Example `cloud.network.openshift.io/egress-ipconfig` annotation on {gcp-short}
-[source,yaml]
-----
-cloud.network.openshift.io/egress-ipconfig: [
-  {
-    "interface":"nic0",
-    "ifaddr":{"ipv4":"10.0.128.0/18"},
-    "capacity":{"ip":14}
-  }
-]
-----
+The following section describes the IP address capacity for supported public cloud environments for use in your capacity calculation.
+
+{aws-first} IP address capacity limits::
+
+On {aws-short}, constraints on IP address assignments depend on the instance type configured. For more information, see link:https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-eni.html#AvailableIpPerENI[IP addresses per network interface per instance type]
 endif::openshift-rosa[]
-
-The following sections describe the IP address capacity for supported public cloud environments for use in your capacity calculation.
-
-[id="nw-egress-ips-capacity-aws_{context}"]
-ifndef::openshift-rosa[]
-=== Amazon Web Services (AWS) IP address capacity limits
-endif::openshift-rosa[]
-ifdef::openshift-rosa[]
-== Amazon Web Services (AWS) IP address capacity limits
-endif::openshift-rosa[]
-
-On AWS, constraints on IP address assignments depend on the instance type configured. For more information, see link:https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-eni.html#AvailableIpPerENI[IP addresses per network interface per instance type]
-
-ifndef::openshift-rosa[]
-[id="nw-egress-ips-capacity-gcp_{context}"]
-=== {gcp-first} IP address capacity limits
-
-On {gcp-short}, the networking model implements additional node IP addresses through IP address aliasing, rather than IP address assignments. However, IP address capacity maps directly to IP aliasing capacity.
-
-The following capacity limits exist for IP aliasing assignment:
-
-- Per node, the maximum number of IP aliases, both IPv4 and IPv6, is 100.
-- Per VPC, the maximum number of IP aliases is unspecified, but {product-title} scalability testing reveals the maximum to be approximately 15,000.
-
-For more information, see link:https://cloud.google.com/vpc/docs/quota#per_instance[Per instance] quotas and link:https://cloud.google.com/vpc/docs/alias-ip[Alias IP ranges overview].
-
-[id="nw-egress-ips-capacity-azure_{context}"]
-=== Microsoft Azure IP address capacity limits
-
-On Azure, the following capacity limits exist for IP address assignment:
-
-- Per NIC, the maximum number of assignable IP addresses, for both IPv4 and IPv6, is 256.
-- Per virtual network, the maximum number of assigned IP addresses cannot exceed 65,536.
-
-For more information, see link:https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/azure-subscription-service-limits?toc=/azure/virtual-network/toc.json#networking-limits[Networking limits].
-
-endif::openshift-rosa[]
-
-[id="nw-egress-ips-node-architecture_{context}"]
-== Architectural diagram of an egress IP address configuration
-
-The following diagram depicts an egress IP address configuration. The diagram describes four pods in two different namespaces running on three nodes in a cluster. The nodes are assigned IP addresses from the `192.168.126.0/18` CIDR block on the host network.
-
-// Source: https://github.com/redhataccess/documentation-svg-assets/blob/master/for-web/121_OpenShift/121_OpenShift_engress_IP_Topology_1020.svg
-image::nw-egress-ips-diagram.svg[Architectural diagram for the egress IP feature.]
-
-Both Node 1 and Node 3 are labeled with `k8s.ovn.org/egress-assignable: ""` and thus available for the assignment of egress IP addresses.
-
-The dashed lines in the diagram depict the traffic flow from pod1, pod2, and pod3 traveling through the pod network to egress the cluster from Node 1 and Node 3. When an external service receives traffic from any of the pods selected by the example `EgressIP` object, the source IP address is either `192.168.126.10` or `192.168.126.102`. The traffic is balanced roughly equally between these two nodes.
-
-Based on the diagram, the following manifest file defines namespaces:
-
-.Namespace objects
-[source,yaml]
-----
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: namespace1
-  labels:
-    env: prod
----
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: namespace2
-  labels:
-    env: prod
-----
-
-Based on the diagram, the following `EgressIP` object describes a configuration that selects all pods in any namespace with the `env` label set to `prod`. The egress IP addresses for the selected pods are `192.168.126.10` and `192.168.126.102`.
-
-.`EgressIP` object
-[source,yaml]
-----
-apiVersion: k8s.ovn.org/v1
-kind: EgressIP
-metadata:
-  name: egressips-prod
-spec:
-  egressIPs:
-  - 192.168.126.10
-  - 192.168.126.102
-  namespaceSelector:
-    matchLabels:
-      env: prod
-status:
-  items:
-  - node: node1
-    egressIP: 192.168.126.10
-  - node: node3
-    egressIP: 192.168.126.102
-----
-
-For the configuration in the previous example, {product-title} assigns both egress IP addresses to the available nodes. The `status` field reflects whether and where the egress IP addresses are assigned.

--- a/modules/nw-egress-ips-node-architecture.adoc
+++ b/modules/nw-egress-ips-node-architecture.adoc
@@ -1,0 +1,62 @@
+// Module included in the following assemblies:
+//
+// * networking/ovn_kubernetes_network_provider/configuring-egress-ips-ovn.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="nw-egress-ips-node-architecture_{context}"]
+= Architectural diagram of an egress IP address configuration
+
+The following diagram depicts an egress IP address configuration. The diagram describes four pods in two different namespaces running on three nodes in a cluster. The nodes are assigned IP addresses from the `192.168.126.0/18` CIDR block on the host network.
+
+// Source: https://github.com/redhataccess/documentation-svg-assets/blob/master/for-web/121_OpenShift/121_OpenShift_engress_IP_Topology_1020.svg
+image::nw-egress-ips-diagram.svg[Architectural diagram for the egress IP feature.]
+
+Both Node 1 and Node 3 are labeled with `k8s.ovn.org/egress-assignable: ""` and thus available for the assignment of egress IP addresses.
+
+The dashed lines in the diagram depict the traffic flow from pod1, pod2, and pod3 traveling through the pod network to egress the cluster from Node 1 and Node 3. When an external service receives traffic from any of the pods selected by the example `EgressIP` object, the source IP address is either `192.168.126.10` or `192.168.126.102`. The traffic is balanced roughly equally between these two nodes.
+
+Based on the diagram, the following manifest file defines namespaces:
+
+.Namespace objects
+[source,yaml]
+----
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: namespace1
+  labels:
+    env: prod
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: namespace2
+  labels:
+    env: prod
+----
+
+Based on the diagram, the following `EgressIP` object describes a configuration that selects all pods in any namespace with the `env` label set to `prod`. The egress IP addresses for the selected pods are `192.168.126.10` and `192.168.126.102`.
+
+.`EgressIP` object
+[source,yaml]
+----
+apiVersion: k8s.ovn.org/v1
+kind: EgressIP
+metadata:
+  name: egressips-prod
+spec:
+  egressIPs:
+  - 192.168.126.10
+  - 192.168.126.102
+  namespaceSelector:
+    matchLabels:
+      env: prod
+status:
+  items:
+  - node: node1
+    egressIP: 192.168.126.10
+  - node: node3
+    egressIP: 192.168.126.102
+----
+
+For the configuration in the previous example, {product-title} assigns both egress IP addresses to the available nodes. The `status` field reflects whether and where the egress IP addresses are assigned.

--- a/modules/nw-egress-ips-platform-support.adoc
+++ b/modules/nw-egress-ips-platform-support.adoc
@@ -1,0 +1,43 @@
+// Module included in the following assemblies:
+//
+// * networking/ovn_kubernetes_network_provider/configuring-egress-ips-ovn.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="nw-egress-ips-platform-support_{context}"]
+= Platform support
+
+[role="_abstract"]
+The Egress IP address feature that runs on a primary host network is supported on the specific platforms.
+
+The following table outlines the platforms that support the Egress IP address feature:
+
+[cols="1,1",options="header"]
+|===
+| Platform | Supported
+
+| Bare metal | Yes
+| VMware vSphere | Yes
+| {rh-openstack-first} | Yes
+| Amazon Web Services (AWS) | Yes
+| {gcp-first} | Yes
+| Microsoft Azure | Yes
+| {ibm-z-name} and {ibm-linuxone-name} | Yes
+| {ibm-z-name} and {ibm-linuxone-name} for {op-system-base-full} KVM | Yes
+| {ibm-power-name} | Yes
+| Nutanix | Yes
+|===
+
+[IMPORTANT]
+====
+Support for egress IP addresses in Microsoft Azure is restricted to the infra subnet. As a workaround for this limitation, you can use a Network Address Translation (NAT) gateway instead of a general purpose public load balancer.
+====
+
+The Egress IP address feature that runs on secondary host networks is supported on the following platform:
+
+[cols="1,1",options="header"]
+|===
+| Platform | Supported
+
+| Bare metal | Yes
+|===
+

--- a/modules/nw-egress-ips-public-cloud-platform-considerations.adoc
+++ b/modules/nw-egress-ips-public-cloud-platform-considerations.adoc
@@ -1,0 +1,87 @@
+// Module included in the following assemblies:
+//
+// * networking/ovn_kubernetes_network_provider/configuring-egress-ips-ovn.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="nw-egress-ips-public-cloud-platform-considerations_{context}"]
+= Public cloud platform considerations
+
+[role="_abstract"]
+Typically, public cloud providers place a limit on egress IP addresses. You must understand that there is a constraint on the absolute number of assignable IP addresses per node for clusters provisioned on public cloud infrastructure. 
+
+The maximum number of assignable IP addresses per node, or the _IP capacity_, can be described in the following formula:
+
+[source,text]
+----
+IP capacity = public cloud default capacity - sum(current IP assignments)
+----
+
+While the Egress IP addresses capability manages the IP address capacity per node, ensure you plan for this constraint in your deployments. For example, if a public cloud provider limits IP address capacity to 10 IP addresses per node, and you have 8 nodes, the total number of assignable IP addresses is only 80. To achieve a higher IP address capacity, you would need to allocate additional nodes. For example, if you needed 150 assignable IP addresses, you would need to allocate 7 additional nodes.
+
+To confirm the IP capacity and subnets for any node in your public cloud environment, you can enter the `oc get node <node_name> -o yaml` command. The `cloud.network.openshift.io/egress-ipconfig` annotation includes capacity and subnet information for the node.
+
+The annotation value is an array with a single object with fields that provide the following information for the primary network interface:
+
+* `interface`: Specifies the interface ID on {aws-short} and {azure-short} and the interface name on {gcp-short}.
+* `ifaddr`: Specifies the subnet mask for one or both IP address families.
+* `capacity`: Specifies the IP address capacity for the node. On {aws-short}, the IP address capacity is provided per IP address family. On {azure-short} and {gcp-short}, the IP address capacity includes both IPv4 and IPv6 addresses.
+
+Automatic attachment and detachment of egress IP addresses for traffic between nodes are available. This allows for traffic from many pods in namespaces to have a consistent source IP address to locations outside of the cluster.
+
+[NOTE]
+====
+When an {rh-openstack} cluster administrator assigns a floating IP to the reservation port, {product-title} cannot delete the reservation port. The `CloudPrivateIPConfig` object cannot perform delete and move operations until an {rh-openstack} cluster administrator unassigns the floating IP from the reservation port.
+====
+
+The following examples illustrate the annotation from nodes on several public cloud providers. The annotations are indented for readability.
+
+.Example `cloud.network.openshift.io/egress-ipconfig` annotation on {aws-short}
+[source,yaml]
+----
+cloud.network.openshift.io/egress-ipconfig: [
+  {
+    "interface":"eni-078d267045138e436",
+    "ifaddr":{"ipv4":"10.0.128.0/18"},
+    "capacity":{"ipv4":14,"ipv6":15}
+  }
+]
+----
+
+.Example `cloud.network.openshift.io/egress-ipconfig` annotation on {gcp-short}
+[source,yaml]
+----
+cloud.network.openshift.io/egress-ipconfig: [
+  {
+    "interface":"nic0",
+    "ifaddr":{"ipv4":"10.0.128.0/18"},
+    "capacity":{"ip":14}
+  }
+]
+----
+
+The following sections describe the IP address capacity for supported public cloud environments for use in your capacity calculation.
+
+{aws-first} IP address capacity limits::
+
+On {azure-short}, constraints on IP address assignments depend on the instance type configured. For more information, see "IP addresses per network interface per instance type" in the _Additional resources_ section.
+
+{gcp-first} IP address capacity limits::
+
+On {gcp-short}, the networking model implements additional node IP addresses through IP address aliasing, rather than IP address assignments. However, IP address capacity maps directly to IP aliasing capacity.
+
+The following capacity limits exist for IP aliasing assignment:
+
+- Per node, the maximum number of IP aliases, both IPv4 and IPv6, is 100.
+- Per VPC, the maximum number of IP aliases is unspecified, but {product-title} scalability testing reveals the maximum to be approximately 15,000.
+
+For more information, see "Per instance" quotas and "Alias IP ranges overview" in the _Additional resources_ section.
+
+{azure-full} IP address capacity limits::
+
+On {azure-short}, the following capacity limits exist for IP address assignment:
+
+- Per NIC, the maximum number of assignable IP addresses, for both IPv4 and IPv6, is 256.
+- Per virtual network, the maximum number of assigned IP addresses cannot exceed 65,536.
+
+For more information, see "Networking limits" in the _Additional resources_ section.
+

--- a/networking/ovn_kubernetes_network_provider/configuring-egress-ips-ovn.adoc
+++ b/networking/ovn_kubernetes_network_provider/configuring-egress-ips-ovn.adoc
@@ -7,19 +7,46 @@ include::_attributes/attributes-openshift-dedicated.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 As a cluster administrator, you can configure the OVN-Kubernetes Container Network Interface (CNI) network plugin to assign one or more egress IP addresses to a namespace, or to specific pods in a namespace.
 
 // Egress IP address architectural design and implementation
 include::modules/nw-egress-ips-about.adoc[leveloffset=+1]
 
+// Architectural diagram of an egress IP address configuration
+include::modules/nw-egress-ips-node-architecture.adoc[leveloffset=+2]
+
 ifndef::openshift-rosa[]
 // Considerations for using an egress IP address on additional network interfaces
 include::modules/nw-egress-ips-multi-nic-considerations.adoc[leveloffset=+2]
-
 endif::openshift-rosa[]
 
 // EgressIP object
 include::modules/nw-egress-ips-object.adoc[leveloffset=+1]
+
+// Platform support
+ifndef::openshift-rosa[]
+include::modules/nw-egress-ips-platform-support.adoc[leveloffset=+2]
+endif::openshift-rosa[]
+
+// Public cloud platform considerations
+ifndef::openshift-rosa[]
+include::modules/nw-egress-ips-public-cloud-platform-considerations.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+[id="configuring-egress-ips-additional-resources"]
+== Additional resources
+
+* link:https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-eni.html#AvailableIpPerENI[IP addresses per network interface per instance type]
+* link:https://cloud.google.com/vpc/docs/quota#per_instance[Per instance] 
+* link:https://cloud.google.com/vpc/docs/alias-ip[Alias IP ranges overview]
+* link:https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/azure-subscription-service-limits?toc=/azure/virtual-network/toc.json#networking-limits[Networking limits]
+endif::openshift-rosa[]
+
+
+
+
+
 
 // Assignment of egress IPs to a namespace, nodes, and pods
 include::modules/nw-egress-ips-considerations.adoc[leveloffset=+1]
@@ -37,7 +64,6 @@ include::modules/egressip_configure_failover_task.adoc[leveloffset=+2]
 
 // REFERENCE: Describes the parameters (The table of values)
 include::modules/egressip_failover_reference.adoc[leveloffset=+2]
-
 endif::openshift-rosa,openshift-rosa-hcp[]
 
 // Labeling a node to host egress IP addresses
@@ -50,7 +76,6 @@ include::modules/nw-egress-ips-object-dual-stack.adoc[leveloffset=+1]
 endif::openshift-rosa[]
 
 [role="_additional-resources"]
-[id="configuring-egress-ips-additional-resources"]
 == Additional resources
 
 ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]


### PR DESCRIPTION
Version(s):
4.20+

Issue:
[OSDOCS-16851](https://redhat.atlassian.net/browse/OSDOCS-16851)

Link to docs preview:

* https://112778--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/configuring-egress-ips-ovn.html
* https://112778--ocpdocs-pr.netlify.app/openshift-rosa/latest/networking/ovn_kubernetes_network_provider/configuring-egress-ips-ovn.html


