### PR TITLE
Fix index field fallback value in description text

### DIFF
--- a/modules/cluster-logging-collector-log-forwarding-about.adoc
+++ b/modules/cluster-logging-collector-log-forwarding-about.adoc
@@ -80,7 +80,7 @@ spec:
         - external-es
 ----
 `version`:: Forwarding to an external Elasticsearch of version 8.x or greater requires you to specify the `version` field.
-`index`:: The `index` field reads the `.log_type` field value and falls back to "unknown" if not found.
+`index`:: The `index` field reads the `.log_type` field value and falls back to "undefined" if not found.
 `secretName`:: Use username and password to authenticate to the server
 `ca`:: Enable Mutual Transport Layer Security (mTLS) between collector and Elasticsearch. The spec identifies the keys and secret for the certificates that they represent.
 


### PR DESCRIPTION
## Summary

- Fixes mismatch between the `index` field description text and the YAML example in the "About forwarding logs to third-party systems" section
- The YAML example uses `'{.log_type||"undefined"}'` but the description text incorrectly said "unknown"
- Updated the text to say "undefined" to match the YAML

## Bug Details

**File:** `modules/cluster-logging-collector-log-forwarding-about.adoc`

The description said:
> The `index` field reads the `.log_type` field value and falls back to "unknown" if not found.

But the YAML example uses:
```yaml
index: '{.log_type||"undefined"}'
```

Fixed the text to say "undefined" to match the YAML.

## Jira

Resolves: [OBSDOCS-3487](https://redhat.atlassian.net/browse/OBSDOCS-3487)

## Cherry-pick Required

This bug exists on all standalone logging docs branches:
- `standalone-logging-docs-6.6`
- `standalone-logging-docs-6.5`
- `standalone-logging-docs-6.4`
- `standalone-logging-docs-6.3`
- `standalone-logging-docs-6.2`
- `standalone-logging-docs-6.1`
- `standalone-logging-docs-6.0`

Note: On 6.3-6.0 branches the text is in a callout annotation format (`<2>`) rather than a definition list, but the same "unknown" → "undefined" fix applies.

## Test Plan

- [x] Verified the YAML example uses "undefined" as the fallback value
- [x] Confirmed the description text now matches the YAML example
- [x] No other content modified


Made with [Cursor](https://cursor.com)