### PR TITLE
[OSDOCS#18861]: For 4.22, added hyperlink to sos report

### DIFF
--- a/installing/installing_two_node_cluster/installing_tnf/install-post-tnf.adoc
+++ b/installing/installing_two_node_cluster/installing_tnf/install-post-tnf.adoc
@@ -19,6 +19,8 @@ include::modules/installation-manual-recovering-when-auto-recovery-is-unavail.ad
 
 * xref:../installing_tnf/install-post-tnf.adoc#installation-verifying-etcd-health_install-post-tnf[Verifying etcd health in a two-node OpenShift cluster with fencing]
 
+* xref:../../../support/gathering-cluster-data.adoc#about-sosreport_gathering-cluster-data[Gathering an sosreport for {product-title}]
+
 // Replacing control plane nodes
 include::modules/installation-replacing-control-plane-nodes.adoc[leveloffset=+1]
 


### PR DESCRIPTION
Version(s):
4.22

Issue:
https://redhat.atlassian.net/browse/OSDOCS-18861

Link to docs preview:
https://112821--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_two_node_cluster/installing_tnf/install-post-tnf.html#installation-manual-recovering-when-auto-recovery-is-unavail_install-post-tnf

QE review:
- [x] QE has approved this change.


Additional information:
This PR consists only of a hyperlink to an SOS report section. All other doc restructuring-related feedback from https://github.com/openshift/openshift-docs/pull/110821 will be implemented in 5.0
