### PR TITLE
OSDOCS-20005:Update the z-stream RNs for 4.21.19

### DIFF
--- a/modules/zstream-4-21-19.adoc
+++ b/modules/zstream-4-21-19.adoc
@@ -1,0 +1,39 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-21-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-21-19_{context}"]
+= RHSA-2026:23241 - {product-title} {product-version}.19 fixed issues advisory
+
+Issued: 11 June 2026
+
+[role="_abstract"]
+{product-title} release {product-version}.19 is now available. The list of fixed issues that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2026:23241[RHSA-2026:23241] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2026:23239[RHBA-2026:23239] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.21.19 --pullspecs
+----
+
+[id="zstream-4-21-19-fixed-issues_{context}"]
+== Fixed issues
+
+* Before this update, pagination controls were not present at mobile resolutions because PatternFly expected both top and bottom pagination controls to be used. With this release, pagination controls are present regardless of the mobile resolution. (link:https://redhat.atlassian.net/browse/OCPBUGS-84967[OCPBUGS-84967])
+
+* Before this update, the manila container storage interface (CSI) driver node plugin sometimes crashed on startup if the Network File System (NFS) CSI plugin socket was not yet available. For example, this issue sometimes occurred after a node reboot. With this release, the manila CSI node DaemonSet waits for the NFS plugin socket to be ready before starting the driver, which prevents crash loops due to transient startup ordering. (link:https://redhat.atlassian.net/browse/OCPBUGS-85572[OCPBUGS-85572])
+
+* Before this update, a change in the `controller-runtime` library in {product-title} 4.21 caused logging to not be initialized for some of the controllers for the Operator. As a consequence, the Cluster Ingress Operator did not log controller initialization or reconciliation errors for the `gateway-labeler`,  `gateway-service-dns`, and `gatewayclass` controllers. With this release, the Operator is updated to initialize logging for these controllers. As a result, the Operator logs initialization and reconciliation errors for these controllers. (link:https://issues.redhat.com/browse/OCPBUGS-86027[OCPBUGS-86027])
+
+* Before this update, the `python3-perf` RPM package was incorrectly pinned to an old version. As a result, the RPM package was being flagged by security scanners for including more than 400 outstanding CVEs because the `python-3-perf` RPM package was built from the kernel RPM package. With this release, the pinning issue is resolved. As a result, the scanning result is clean. (link:https://issues.redhat.com/browse/OCPBUGS-86513[OCPBUGS-86513])
+
+* Before this update, if an API server was temporarily unavailable because of an upgrade or network load, the `PerformanceProfile` status was not updated. As a consequence, the degraded condition might get stuck and never resolve, even after the cluster returned to a healthy state, because the Operator did not retry until the next reconcile event. With this release, the Operator schedules a retry of the status update until it succeeds, retrying approximately every 30 seconds. As a result, the stuck degraded status is temporary and is resolved automatically during the next retry. (link:https://issues.redhat.com/browse/OCPBUGS-86809[OCPBUGS-86809])
+
+[id="zstream-4-21-19-updating_{context}"]
+== Updating
+
+To update an {product-title} 4.21 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].

--- a/release_notes/ocp-4-21-release-notes.adoc
+++ b/release_notes/ocp-4-21-release-notes.adoc
@@ -44,6 +44,9 @@ include::modules/rn-ocp-release-notes-known-issues.adoc[leveloffset=+1]
 // Asynchronous errata updates
 include::modules/rn-async-errata.adoc[leveloffset=+1]
 
+// 4.21.19 RNs and updating
+include::modules/zstream-4-21-19.adoc[leveloffset=+2]
+
 // 4.21.18 RNs and updating
 include::modules/zstream-4-21-18.adoc[leveloffset=+2]
 


### PR DESCRIPTION
Version(s):
4.21

Issue:
https://redhat.atlassian.net/browse/OSDOCS-20005

Link to docs preview:
https://112842--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-21-release-notes.html#zstream-4-21-19_release-notes

Additional information:
4.21.19 MR: https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/564
ART Dashboard: https://art-dash.engineering.redhat.com/dashboard/release/openshift-4.21?page=1