### PR TITLE
Fix issues in the VPA OOM bump-up example

### DIFF
--- a/modules/nodes-pods-vertical-autoscaler-oom.adoc
+++ b/modules/nodes-pods-vertical-autoscaler-oom.adoc
@@ -7,9 +7,9 @@
 = Custom memory bump-up after OOM event
 
 [role="_abstract"]
-If your cluster experiences an OOM (out of memory) event, you can use the Vertical Pod Autoscaler Operator (VPA) to increase the memory recommendation based on the memory consumption observed during the OOM event and a specified multiplier value to prevent future crashes due to insufficient memory.
+If your cluster experiences an OOM (out of memory) event, you can use the Vertical Pod Autoscaler Operator (VPA) to increase the memory recommendation based on the memory consumption observed during the OOM event and configured bump-up values to prevent future crashes due to insufficient memory.
 
-The recommendation is the higher of two calculations: the memory in use by the pod when the OOM event happened multiplied by a specified number of bytes or a specified percentage. The following formula represents the calculation:
+The recommendation is the higher of two calculations: the memory in use by the pod when the OOM event happened plus a specified number of bytes, or the memory in use multiplied by a specified ratio. The following formula represents the calculation:
 
 [source,text]
 ----
@@ -18,10 +18,10 @@ recommendation = max(memory-usage-in-oom-event + oom-min-bump-up-bytes, memory-u
 
 You can configure the memory increase by specifying the following values in the recommender pod:
 
-* `oom-min-bump-up-bytes`. This value, in bytes, is a specific increase in memory after an OOM event occurs. The default is `100MiB`.
-* `oom-bump-up-ratio`. This value is a percentage increase in memory when the OOM event occurred. The default value is `1.2`.
+* `oom-min-bump-up-bytes`. This value, in bytes, is a fixed increase added to the observed memory usage after an OOM event occurs. The default is `100MiB`.
+* `oom-bump-up-ratio`. This value is a multiplier applied to the pod memory usage at the time of the OOM event. The default value is `1.2`.
 
-For example, if the pod memory usage during an OOM event is 100 MB, and `oom-min-bump-up-bytes` is set to 150 MB with a `oom-min-bump-ratio` of 1.2. After an OOM event, the VPA recommends increasing the memory request for that pod to 150 MB, as it is higher than at 120 MB (100 MB * 1.2).
+For example, if the pod memory usage during an OOM event is 100 MiB, and `oom-min-bump-up-bytes` is set to 150 MiB with an `oom-bump-up-ratio` of 1.2, the VPA recommends a memory request of 250 MiB for that pod. The additive calculation (100 MiB + 150 MiB = 250 MiB) is higher than the ratio calculation (100 MiB * 1.2 = 120 MiB), so 250 MiB is recommended.
 
 .Example recommender deployment object
 
@@ -37,7 +37,7 @@ spec:
 # ...
   template:
 # ...
-    spec
+    spec:
       containers:
       - name: recommender
         args:


### PR DESCRIPTION
Correct four issues in the `nodes-pods-vertical-autoscaler-oom` module:

- Fix incorrect parameter name: `oom-min-bump-ratio` does not exist in the
  VPA recommender. The correct flag is `oom-bump-up-ratio`, which is also
  defined in the bullet list above the example and used in the YAML at the
  bottom of the module.

- Fix incorrect worked example result. Applying the formula shown in the
  module to the stated values (100 MiB memory, 150 MiB for
  `oom-min-bump-up-bytes`, ratio 1.2) yields max(250, 120) = 250 MiB,
  not 150 MB as previously stated.

- Standardize memory units to MiB throughout the example paragraph.
  The default for `oom-min-bump-up-bytes` is 100 * 1024 * 1024 bytes
  (100 MiB). Using MB (decimal) is inconsistent with the binary unit
  system used by Kubernetes and with the bullet list in the same module.

- Fix YAML syntax: add missing colon to `spec:` in the example Deployment.