### PR TITLE
Improve visibility of architecture-specific kdump settings

### DIFF
--- a/modules/troubleshooting-enabling-kdump-day-one.adoc
+++ b/modules/troubleshooting-enabling-kdump-day-one.adoc
@@ -15,6 +15,19 @@ The `kdump` service is intended to be enabled per node to debug kernel problems.
 
 If you are aware of the downsides and trade-offs of having the `kdump` service enabled, it is possible to enable kdump in a cluster-wide fashion. Although machine-specific machine configs are not yet supported, you can use a `systemd` unit in a `MachineConfig` object as a day-1 customization and have kdump enabled on all nodes in the cluster. You can create a `MachineConfig` object and inject that object into the set of manifest files used by Ignition during cluster setup.
 
+[IMPORTANT]
+====
+Architecture-specific kernel arguments must be considered when enabling kdump.
+
+For the ppc64le platform:
+
+* Use the following recommended value for the `crashkernel` parameter:
++
+`crashkernel=2G-4G:384M,4G-16G:512M,16G-64G:1G,64G-128G:2G,128G-:4G`
+
+* In the `KDUMP_COMMANDLINE_APPEND` setting, replace `nr_cpus=1` with `maxcpus=1` because the `nr_cpus` parameter is not supported on this platform. Ensure that these adjustments are applied when configuring kdump on ppc64le systems.
+====
+
 [NOTE]
 ====
 See "Customizing nodes" in the _Installing -> Installation configuration_ section for more information and examples on how to use Ignition configs.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.18 and above
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
https://redhat.atlassian.net/browse/OCPBUGS-53029

Link to docs preview:
https://112848--ocpdocs-pr.netlify.app/openshift-enterprise/latest/support/troubleshooting/troubleshooting-operating-system-issues.html#enabling-kdump-day-one

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
