### PR TITLE
OCPBUGS-84690: Add release note for RTE pods CrashLoopBackOff fix during canary upgrade

### DIFF
--- a/modules/rn-ocp-release-notes-fixed-issues.adoc
+++ b/modules/rn-ocp-release-notes-fixed-issues.adoc
@@ -356,6 +356,8 @@ The following issues are fixed for this release:
 
 * Before this update, a failure to update the `PerformanceProfile` status due to a temporarily unavailable API server during an upgrade or under network load could leave the profile in a `Degraded` condition. As a consequence, the degraded condition might get stuck and never resolve, even after the cluster returned to a healthy state, because the operator did not retry until the next reconcile event. With this update, the operator schedules a retry of the status update until it succeeds, retrying approximately every 30 seconds. As a result, the stuck degraded condition is temporary and resolves automatically during the next retry. (link:https://issues.redhat.com/browse/OCPBUGS-62277[OCPBUGS-62277])
 
+* Previously, when a `MachineConfigPool` resource was paused, the NUMA Resources Operator could enter an infinite reconciliation loop. This prevented all node groups from completing their updates, including those not associated with the paused pool. With this update, paused `MachineConfigPool` resources no longer block the operator, and node groups backed by non-paused pools continue to reconcile normally. Additionally, the `NUMAResourcesOperator` custom resource status now reports a `MachineConfigPoolPaused` condition, providing visibility into which pools are paused and might require attention. As a result, workflows that involve paused `MachineConfigPool` resources, such as canary upgrades, no longer cause the NUMA Resources Operator to stall. (link:https://issues.redhat.com/browse/OCPBUGS-84690[OCPBUGS-84690])
+
 [id="rn-ocp-release-note-observability-fixed-issues_{context}"]
 == Observability
 


### PR DESCRIPTION
Version(s):
4.22

Issue:
https://redhat.atlassian.net/browse/OCPBUGS-84690

Link to docs preview:


QE review:
- [ ] QE has approved this change.

Additional information:
