### PR TITLE
OSDOCS CQA NODES-9: Autoscaling and Miscellaneous IV

### DIFF
--- a/modules/nodes-pods-vertical-autoscaler-about.adoc
+++ b/modules/nodes-pods-vertical-autoscaler-about.adoc
@@ -6,7 +6,10 @@
 [id="nodes-pods-vertical-autoscaler-about_{context}"]
 = About the Vertical Pod Autoscaler Operator
 
-The Vertical Pod Autoscaler Operator (VPA) is implemented as an API resource and a custom resource (CR). The CR determines the actions for the VPA to take with the pods associated with a specific workload object, such as a daemon set, replication controller, and so forth, in a project.
+[role="_abstract"]
+To help you maintain the optimal CPU and memory usage for your pods, you can use the {product-title} Vertical Pod Autoscaler Operator (VPA).
+
+The VPA is implemented as an API resource and a custom resource (CR). The CR determines the actions for the VPA to take with the pods associated with a specific workload object, such as a daemon set, replication controller, and so forth, in a project.
 
 The VPA consists of three components, each of which has its own pod in the VPA namespace:
 

--- a/modules/nodes-pods-vertical-autoscaler-configuring.adoc
+++ b/modules/nodes-pods-vertical-autoscaler-configuring.adoc
@@ -6,9 +6,12 @@
 [id="nodes-pods-vertical-autoscaler-configuring_{context}"]
 = Using the Vertical Pod Autoscaler Operator
 
-You can use the Vertical Pod Autoscaler Operator (VPA) by creating a VPA custom resource (CR). The CR indicates the pods to analyze and determines the actions for the VPA to take with those pods.
+[role="_abstract"]
+You can use the Vertical Pod Autoscaler Operator (VPA) to help you maintain the optimal CPU and memory usage for your pods by creating a VPA custom resource (CR). The CR indicates the pods to analyze and determines the actions for the VPA to take with those pods.
 
 You can use the VPA to scale built-in resources such as deployments or stateful sets, and custom resources that manage pods. For more information, see "About using the Vertical Pod Autoscaler Operator".
+
+The following procedure creates a VPA CR for a specific workload object.
 
 .Prerequisites
 
@@ -17,8 +20,6 @@ You can use the VPA to scale built-in resources such as deployments or stateful 
 * Ensure that if you want to use an alternative recommender, a deployment including that recommender exists.
 
 .Procedure
-
-To create a VPA CR for a specific workload object:
 
 . Change to the location of the project for the workload object you want to scale.
 
@@ -33,26 +34,28 @@ metadata:
 spec:
   targetRef:
     apiVersion: "apps/v1"
-    kind:       Deployment <1>
-    name:       frontend <2>
+    kind:       Deployment
+    name:       frontend
   updatePolicy:
-    updateMode: "InPlaceOrRecreate" <3>
-  resourcePolicy: <4>
+    updateMode: "InPlaceOrRecreate"
+  resourcePolicy:
     containerPolicies:
     - containerName: my-opt-sidecar
       mode: "Off"
-  recommenders: <5>
+  recommenders:
     - name: my-recommender
 ----
-<1> Specify the type of workload object you want this VPA to manage: `Deployment`, `StatefulSet`, `Job`, `DaemonSet`, `ReplicaSet`, or `ReplicationController`.
-<2> Specify the name of an existing workload object you want this VPA to manage.
-<3> Specify the VPA mode:
+where:
+
+`spec.targetRef.kind`:: Specifies the type of workload object you want this VPA to manage: `Deployment`, `StatefulSet`, `Job`, `DaemonSet`, `ReplicaSet`, or `ReplicationController`.
+`spec.targetRef.name`:: Specifies the name of an existing workload object you want this VPA to manage.
+`spec.updatePolicy.updateMode`:: Specifies the VPA mode:
 * `InPlaceOrRecreate` to automatically apply the recommended resources on pods associated with the workload object. The VPA attempts to update the workload object with the new resources without re-creating the pod. If the VPA is unable to update the object in place, the VPA re-creates it.
 * `Recreate` to automatically apply the recommended resources on pods associated with the workload object. The VPA terminates existing pods and creates new pods with the recommended resource limits and requests. Use the `Recreate` mode only if you need to ensure that the pods restart whenever the resource request changes.
 * `Initial` to automatically apply the recommended resources to newly-created pods associated with the workload object. The VPA does not update the pods as it learns new resource recommendations.
 * `Off` to only generate resource recommendations for the pods associated with the workload object. The VPA does not update the pods as it learns new resource recommendations and does not apply the recommendations to new pods.
-<4> Optional. Specify the containers you want to opt-out and set the mode to `Off`.
-<5> Optional. Specify an alternative recommender.
+`spec.resourcePolicy`:: Specifies the containers you want to opt-out and set the mode to `Off`. This parameter is optional.
+`spec.recommenders`:: Specifies an alternative recommender. This parameter is optional.
 
 .. Create the VPA CR:
 +
@@ -85,16 +88,16 @@ status:
   recommendation:
     containerRecommendations:
     - containerName: frontend
-      lowerBound: <1>
+      lowerBound:
         cpu: 25m
         memory: 262144k
-      target: <2>
+      target:
         cpu: 25m
         memory: 262144k
-      uncappedTarget: <3>
+      uncappedTarget:
         cpu: 25m
         memory: 262144k
-      upperBound: <4>
+      upperBound:
         cpu: 262m
         memory: "274357142"
     - containerName: backend
@@ -113,7 +116,11 @@ status:
 
 ...
 ----
-<1> `lowerBound` is the minimum recommended resource levels.
-<2> `target` is the recommended resource levels.
-<3> `upperBound` is the highest recommended resource levels.
-<4> `uncappedTarget` is the most recent resource recommendations.
+where:
+
+`status.recommendation.containerRecommendations`:: Specifies the minimum and maximum recommended resource levels for the container:
+* `containerName` is the container for the recommended resource levels.
+* `lowerBound` is the minimum recommended resource levels.
+* `target` is the recommended resource levels.
+* `upperBound` is the highest recommended resource levels.
+* `uncappedTarget` is the most recent resource recommendations.

--- a/modules/nodes-pods-vertical-autoscaler-custom-resource.adoc
+++ b/modules/nodes-pods-vertical-autoscaler-custom-resource.adoc
@@ -6,7 +6,8 @@
 [id="nodes-pods-vertical-autoscaler-custom-resource_{context}"]
 = Example custom resources for the Vertical Pod Autoscaler
 
-The Vertical Pod Autoscaler Operator (VPA) can update not only built-in resources such as deployments or stateful sets, but also custom resources that manage pods.
+[role="_abstract"]
+You can use the Vertical Pod Autoscaler Operator (VPA) to update custom resources that manage pods, not just built-in resources such as deployments or stateful sets.
 
 To use the VPA with a custom resource when you create the `CustomResourceDefinition` (CRD) object, you must configure the `labelSelectorPath` field in the `/scale` subresource. The `/scale` subresource creates a `Scale` object. The `labelSelectorPath` field defines the JSON path inside the custom resource that corresponds to `status.selector` in the `Scale` object and in the custom resource. The following is an example of a `CustomResourceDefinition` and a `CustomResource` that fulfills these requirements, along with a `VerticalPodAutoscaler` definition that targets the custom resource. The following example shows the `/scale` subresource contract.
 
@@ -50,7 +51,7 @@ spec:
       scale:
         specReplicasPath: .spec.replicas
         statusReplicasPath: .status.replicas
-        labelSelectorPath: .spec.selector <1>
+        labelSelectorPath: .spec.selector
   scope: Namespaced
   names:
     plural: scalablepods
@@ -59,7 +60,9 @@ spec:
     shortNames:
     - spod
 ----
-<1> Specifies the JSON path that corresponds to `status.selector` field of the custom resource object.
+where:
+
+`spec.subresources.scale.labelSelectorPath`:: Specifies the JSON path that corresponds to `status.selector` field of the custom resource object.
 
 .Example custom CR
 [source,yaml]
@@ -70,10 +73,12 @@ metadata:
   name: scalable-cr
   namespace: default
 spec:
-  selector: "app=scalable-cr" <1>
+  selector: "app=scalable-cr"
   replicas: 1
 ----
-<1> Specify the label type to apply to managed pods. This is the field that the `labelSelectorPath` references in the custom resource definition object.
+where:
+
+`spec.selector`:: Specifies the label type to apply to managed pods. This is the field that the `labelSelectorPath` references in the custom resource definition object.
 
 .Example VPA object
 [source,yaml]

--- a/modules/nodes-pods-vertical-autoscaler-custom.adoc
+++ b/modules/nodes-pods-vertical-autoscaler-custom.adoc
@@ -6,7 +6,10 @@
 [id="nodes-pods-vertical-autoscaler-custom_{context}"]
 = Using an alternative recommender
 
-You can use your own recommender to autoscale based on your own algorithms. If you do not specify an alternative recommender, {product-title} uses the default recommender, which suggests CPU and memory requests based on historical usage. Because there is no universal recommendation policy that applies to all types of workloads, you might want to create and deploy different recommenders for specific workloads.
+[role="_abstract"]
+You can use your own recommender to autoscale based on your own algorithms. If you do not specify an alternative recommender, {product-title} uses the default recommender, which suggests CPU and memory requests based on historical usage. 
+
+Because there is no universal recommendation policy that applies to all types of workloads, you might want to create and deploy different recommenders for specific workloads.
 
 For example, the default recommender might not accurately predict future resource usage when containers exhibit certain resource behaviors. Examples are cyclical patterns that alternate between usage spikes and idling as used by monitoring applications, or recurring and repeating patterns used with deep learning applications. Using the default recommender with these usage behaviors might result in significant over-provisioning and Out of Memory (OOM) kills for your applications.
 
@@ -17,21 +20,21 @@ For example, the default recommender might not accurately predict future resourc
 Instructions for how to create a recommender are beyond the scope of this documentation.
 ====
 
-.Procedure
+The following procedure shows how to use an alternative recommender for your pods.
 
-To use an alternative recommender for your pods:
+.Procedure
 
 . Create a service account for the alternative recommender and bind that service account to the required cluster role:
 +
 [source,yaml]
 ----
-apiVersion: v1 <1>
+apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: alt-vpa-recommender-sa
   namespace: <namespace_name>
 ---
-apiVersion: rbac.authorization.k8s.io/v1 <2>
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: system:example-metrics-reader
@@ -44,7 +47,7 @@ subjects:
   name: alt-vpa-recommender-sa
   namespace: <namespace_name>
 ---
-apiVersion: rbac.authorization.k8s.io/v1 <3>
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: system:example-vpa-actor
@@ -57,7 +60,7 @@ subjects:
   name: alt-vpa-recommender-sa
   namespace: <namespace_name>
 ---
-apiVersion: rbac.authorization.k8s.io/v1 <4>
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: system:example-vpa-target-reader-binding
@@ -70,10 +73,13 @@ subjects:
   name: alt-vpa-recommender-sa
   namespace: <namespace_name>
 ----
-<1> Creates a service account for the recommender in the namespace that displays the recommender.
-<2> Binds the recommender service account to the `metrics-reader` role. Specify the namespace for where to deploy the recommender.
-<3> Binds the recommender service account to the `vpa-actor` role. Specify the namespace for where to deploy the recommender.
-<4> Binds the recommender service account to the `vpa-target-reader` role. Specify the namespace for where to display the recommender.
++
+--
+* The `alt-vpa-recommender-sa` object creates a service account for the recommender in the namespace that displays the recommender.
+* The `system:metrics-reader` object binds the recommender service account to the `metrics-reader` role. Specify the namespace for where to deploy the recommender.
+* The `system:example-vpa-actor` object binds the recommender service account to the `vpa-actor` role. Specify the namespace for where to deploy the recommender.
+* The `system:example-vpa-target-reader-binding` object binds the recommender service account to the `vpa-target-reader` role. Specify the namespace for where to display the recommender.
+--
 
 . To add the alternative recommender to the cluster, create a `Deployment` object similar to the following:
 +
@@ -94,9 +100,9 @@ spec:
       labels:
         app: alt-vpa-recommender
     spec:
-      containers: <1>
+      containers:
       - name: recommender
-        image: quay.io/example/alt-recommender:latest <2>
+        image: quay.io/example/alt-recommender:latest
         imagePullPolicy: Always
         resources:
           limits:
@@ -115,15 +121,16 @@ spec:
               - ALL
           seccompProfile:
             type: RuntimeDefault
-      serviceAccountName: alt-vpa-recommender-sa <3>
+      serviceAccountName: alt-vpa-recommender-sa
       securityContext:
         runAsNonRoot: true
 ----
+where:
 +
 --
-<1> Creates a container for your alternative recommender.
-<2> Specifies your recommender image.
-<3> Associates the service account that you created for the recommender.
+`spec.template.spec.containers`:: Specifies a container for your alternative recommender.
+`spec.template.spec.containers.image`:: Specifies your recommender image.
+`spec.template.spec.serviceAccountName`:: Specifies the service account that you created for the recommender.
 --
 +
 A new pod is created for the alternative recommender in the same namespace.
@@ -155,11 +162,13 @@ metadata:
   namespace: <namespace_name>
 spec:
   recommenders:
-    - name: alt-vpa-recommender <1>
+    - name: alt-vpa-recommender
   targetRef:
     apiVersion: "apps/v1"
-    kind:       Deployment <2>
+    kind:       Deployment
     name:       frontend
 ----
-<1> Specifies the name of the alternative recommender deployment.
-<2> Specifies the name of an existing workload object you want this VPA to manage.
+where:
+
+`spec.recommenders.name`:: Specifies the name of the alternative recommender deployment.
+`spec.targetRef.kind`:: Specifies the name of an existing workload object you want this VPA to manage.

--- a/modules/nodes-pods-vertical-autoscaler-install.adoc
+++ b/modules/nodes-pods-vertical-autoscaler-install.adoc
@@ -6,7 +6,8 @@
 [id="nodes-pods-vertical-autoscaler-install_{context}"]
 = Installing the Vertical Pod Autoscaler Operator
 
-You can use the {product-title} web console to install the Vertical Pod Autoscaler Operator (VPA).
+[role="_abstract"]
+You can install the Vertical Pod Autoscaler Operator (VPA) by using the {product-title} web console.
 
 ifdef::openshift-origin[]
 .Prerequisites

--- a/modules/nodes-pods-vertical-autoscaler-moving-vpa.adoc
+++ b/modules/nodes-pods-vertical-autoscaler-moving-vpa.adoc
@@ -14,11 +14,19 @@ endif::[]
 [id="infrastructure-moving-vpa_{context}"]
 = Moving the Vertical Pod Autoscaler Operator components
 
+[role="_abstract"]
 ifdef::machinemgmt[]
-The Vertical Pod Autoscaler Operator (VPA) consists of three components: the recommender, updater, and admission controller. The Operator and each component has its own pod in the VPA namespace on the control plane nodes. You can move the VPA Operator and component pods to infrastructure nodes by adding a node selector to the VPA subscription and the `VerticalPodAutoscalerController` CR.
+You can move the VPA Operator and component pods to infrastructure nodes by adding a node selector to the VPA subscription and the `VerticalPodAutoscalerController` CR.
 endif::machinemgmt[]
 ifdef::vpa[]
-The Vertical Pod Autoscaler Operator (VPA) and each component has its own pod in the VPA namespace on the control plane nodes. You can move the VPA Operator and component pods to infrastructure or worker nodes by adding a node selector to the VPA subscription and the `VerticalPodAutoscalerController` CR.
+You can move the VPA Operator and component pods to infrastructure or worker nodes by adding a node selector to the VPA subscription and the `VerticalPodAutoscalerController` CR.
+endif::vpa[]
+
+ifdef::machinemgmt[]
+The Vertical Pod Autoscaler Operator (VPA) consists of three components: the recommender, updater, and admission controller. The Operator and each component has its own pod in the VPA namespace on the control plane nodes.
+endif::machinemgmt[]
+ifdef::vpa[]
+The Vertical Pod Autoscaler Operator (VPA) and each component has its own pod in the VPA namespace on the control plane nodes.
 
 You can create and use infrastructure nodes to host only infrastructure components. For example, the default router, the integrated container image registry, and the components for cluster metrics and monitoring. These infrastructure nodes are not counted toward the total number of subscriptions that are required to run the environment. For more information, see _Creating infrastructure machine sets_.
 
@@ -27,7 +35,6 @@ endif::vpa[]
 
 The following example shows the default deployment of the VPA pods to the control plane nodes.
 
-.Example output
 [source,terminal]
 ----
 NAME                                                READY   STATUS    RESTARTS   AGE     IP            NODE                  NOMINATED NODE   READINESS GATES
@@ -63,9 +70,13 @@ metadata:
 spec:
   config:
     nodeSelector:
-      node-role.kubernetes.io/infra: "" <1>
+      node-role.kubernetes.io/infra: ""
 ----
-<1> Specifies the node role of an infra node.
+where:
++
+--
+`spec.config.nodeSelector.node-role.kubernetes.io/infra`:: Specifies the node role of an infra node.
+--
 +
 [NOTE]
 ====
@@ -86,13 +97,15 @@ spec:
   config:
     nodeSelector:
       node-role.kubernetes.io/infra: ""
-    tolerations: <1>
+    tolerations:
     - key: "node-role.kubernetes.io/infra"
       operator: "Exists"
       effect: "NoSchedule"
 ----
+where:
+
+`spec.config.tolerations`:: Specifies a toleration for a taint on the infra node.
 ====
-<1> Specifies a toleration for a taint on the infra node.
 
 . Move each VPA component by adding node selectors to the `VerticalPodAutoscaler` custom resource (CR):
 
@@ -119,21 +132,25 @@ spec:
       container:
         resources: {}
       nodeSelector:
-        node-role.kubernetes.io/infra: "" <1>
+        node-role.kubernetes.io/infra: ""
     recommender:
       container:
         resources: {}
       nodeSelector:
-        node-role.kubernetes.io/infra: "" <2>
+        node-role.kubernetes.io/infra: ""
     updater:
       container:
         resources: {}
       nodeSelector:
-        node-role.kubernetes.io/infra: "" <3>
+        node-role.kubernetes.io/infra: ""
 ----
-<1> Optional: Specifies the node role for the VPA admission pod.
-<2> Optional: Specifies the node role for the VPA recommender pod.
-<3> Optional: Specifies the node role for the VPA updater pod.
+where:
++
+--
+`spec.deploymentOverrides.admission.nodeselector`:: Optional: Specifies the node role for the VPA admission pod.
+`spec.deploymentOverrides.recommender.nodeselector`:: Optional: Specifies the node role for the VPA recommender pod.
+`spec.deploymentOverrides.updater.nodeselector`:: Optional: Specifies the node role for the VPA updater pod.
+--
 +
 [NOTE]
 ====
@@ -179,10 +196,12 @@ spec:
         operator: "Exists"
         effect: "NoSchedule"
 ----
+where:
+
+`spec.deploymentOverrides.admission.tolerations`:: Specifies a toleration for the admission controller pod for a taint on the infra node.
+`spec.deploymentOverrides.recommender.tolerations`:: Specifies a toleration for the recommender pod for a taint on the infra node.
+`spec.deploymentOverrides.updater.tolerations`:: Specifies a toleration for the updater pod for a taint on the infra node.
 ====
-<1> Specifies a toleration for the admission controller pod for a taint on the infra node.
-<2> Specifies a toleration for the recommender pod for a taint on the infra node.
-<3> Specifies a toleration for the updater pod for a taint on the infra node.
 endif::machinemgmt[]
 
 ifdef::vpa[]
@@ -211,7 +230,11 @@ spec:
     nodeSelector:
       node-role.kubernetes.io/<node_role>: "" <1>
 ----
-<1> Specifies the node role of the node where you want to move the VPA Operator pod.
+where:
++
+--
+`spec.config.nodeSelector.node-role.kubernetes.io/infra`:: Specifies the node role of an infra node. Specifies the node role of the node where you want to move the VPA Operator pod.
+--
 +
 [NOTE]
 ====
@@ -238,7 +261,9 @@ spec:
       effect: "NoSchedule"
 ----
 ====
-<1> Specifies a toleration for a taint on the node where you want to move the VPA Operator pod.
+where:
+
+`spec.config.tolerations`:: Specifies a toleration for a taint on the node where you want to move the VPA Operator pod.
 
 . Move each VPA component by adding node selectors to the `VerticalPodAutoscaler` custom resource (CR):
 
@@ -277,9 +302,13 @@ spec:
       nodeSelector:
         node-role.kubernetes.io/<node_role>: "" <3>
 ----
-<1> Optional: Specifies the node role for the VPA admission pod.
-<2> Optional: Specifies the node role for the VPA recommender pod.
-<3> Optional: Specifies the node role for the VPA updater pod.
+where:
++
+--
+`spec.deploymentOverrides.admission.nodeselector`:: Optional: Specifies the node role for the VPA admission pod.
+`spec.deploymentOverrides.recommender.nodeselector`:: Optional: Specifies the node role for the VPA recommender pod.
+`spec.deploymentOverrides.updater.nodeselector`:: Optional: Specifies the node role for the VPA updater pod.
+--
 +
 [NOTE]
 ====
@@ -302,7 +331,7 @@ spec:
         resources: {}
       nodeSelector:
         node-role.kubernetes.io/worker: ""
-      tolerations: <1>
+      tolerations:
       - key: "my-example-node-taint-key"
         operator: "Exists"
         effect: "NoSchedule"
@@ -311,7 +340,7 @@ spec:
         resources: {}
       nodeSelector:
         node-role.kubernetes.io/worker: ""
-      tolerations: <2>
+      tolerations:
       - key: "my-example-node-taint-key"
         operator: "Exists"
         effect: "NoSchedule"
@@ -320,15 +349,17 @@ spec:
         resources: {}
       nodeSelector:
         node-role.kubernetes.io/worker: ""
-      tolerations: <3>
+      tolerations:
       - key: "my-example-node-taint-key"
         operator: "Exists"
         effect: "NoSchedule"
 ----
 ====
-<1> Specifies a toleration for the admission controller pod for a taint on the node where you want to install the pod.
-<2> Specifies a toleration for the recommender pod for a taint on the node where you want to install the pod.
-<3> Specifies a toleration for the updater pod for a taint on the node where you want to install the pod.
+where:
+
+`spec.deploymentOverrides.admission.tolerations`:: Specifies a toleration for the admission controller pod for a taint on the node where you want to install the pod.
+`spec.deploymentOverrides.recommender.tolerations`:: Specifies a toleration for the recommender pod for a taint on the node where you want to install the pod.
+`spec.deploymentOverrides.updater.tolerations`:: Specifies a toleration for the updater pod for a taint on the node where you want to install the pod.
 endif::vpa[]
 
 .Verification

--- a/modules/nodes-pods-vertical-autoscaler-oom.adoc
+++ b/modules/nodes-pods-vertical-autoscaler-oom.adoc
@@ -6,7 +6,8 @@
 [id="nodes-pods-vertical-autoscaler-oom_{context}"]
 = Custom memory bump-up after OOM event
 
-If your cluster experiences an OOM (out of memory) event, the Vertical Pod Autoscaler Operator (VPA) increases the memory recommendation. The basis for the recommendation is the memory consumption observed during the OOM event and a specified multiplier value to prevent future crashes due to insufficient memory.
+[role="_abstract"]
+If your cluster experiences an OOM (out of memory) event, you can use the Vertical Pod Autoscaler Operator (VPA) to increase the memory recommendation based on the memory consumption observed during the OOM event and a specified multiplier value to prevent future crashes due to insufficient memory.
 
 The recommendation is the higher of two calculations: the memory in use by the pod when the OOM event happened multiplied by a specified number of bytes or a specified percentage. The following formula represents the calculation:
 

--- a/modules/nodes-pods-vertical-autoscaler-tuning.adoc
+++ b/modules/nodes-pods-vertical-autoscaler-tuning.adoc
@@ -6,7 +6,8 @@
 [id="nodes-pods-vertical-autoscaler-tuning_{context}"]
 = Performance tuning the VPA Operator
 
-As a cluster administrator, you can tune the performance of your Vertical Pod Autoscaler Operator (VPA) to limit the rate at which the VPA makes requests of the Kubernetes API server and to specify the CPU and memory resources for the VPA recommender, updater, and admission controller component pods.
+[role="_abstract"]
+As a cluster administrator, you can tune the performance of your Vertical Pod Autoscaler Operator (VPA) to limit the rate at which the VPA makes requests of the Kubernetes API server and to specify the CPU and memory resources for the VPA component pods.
 
 You can also configure the VPA to monitor only those workloads a VPA custom resource (CR) manages. By default, the VPA monitors every workload in the cluster. As a result, the VPA accrues and stores 8 days of historical data for all workloads. The can be used by the VPA if a new VPA CR is created for a workload. However, this causes the VPA to use significant CPU and memory. This can cause the VPA to fail, particularly on larger clusters. By configuring the VPA to monitor only workloads with a VPA CR, you can save on CPU and memory resources. One tradeoff is that where you have a running workload and you create a VPA CR to manage that workload. The VPA does not have any historical data for that workload. As a result, the initial recommendations are not as useful as those after the workload is running for some time.
 
@@ -192,30 +193,30 @@ metadata:
   namespace: openshift-vertical-pod-autoscaler
 spec:
   deploymentOverrides:
-    admission: <1>
+    admission:
       container:
-        args: <2>
+        args:
           - '--kube-api-qps=50.0'
           - '--kube-api-burst=100.0'
         resources:
-          requests: <3>
+          requests:
             cpu: 40m
             memory: 150Mi
           limits:
             memory: 300Mi
-    recommender: <4>
+    recommender:
       container:
         args:
           - '--kube-api-qps=60.0'
           - '--kube-api-burst=120.0'
-          - '--memory-saver=true' <5>
+          - '--memory-saver=true'
         resources:
           requests:
             cpu: 75m
             memory: 275Mi
           limits:
             memory: 550Mi
-    updater: <6>
+    updater:
       container:
         args:
           - '--kube-api-qps=60.0'
@@ -232,17 +233,19 @@ spec:
   recommendationOnly: false
   safetyMarginFraction: 0.15
 ----
-<1> Specifies the tuning parameters for the VPA admission controller.
-<2> Specifies the API QPS and burst rates for the VPA admission controller.
+where:
+
+`spec.deploymentOverrides.admission`:: Specifies the tuning parameters for the VPA admission controller.
+`spec.deploymentOverrides.admission.container.args`:: Specifies the API QPS and burst rates for the VPA admission controller.
 +
 --
 * `kube-api-qps`: Specifies the queries per second (QPS) limit when making requests to Kubernetes API server. The default is `5.0`.
 * `kube-api-burst`: Specifies the burst limit when making requests to Kubernetes API server. The default is `10.0`.
 --
-<3> Specifies the resource requests and limits for the VPA admission controller pod.
-<4> Specifies the tuning parameters for the VPA recommender.
-<5> Specifies that the VPA Operator monitors only workloads with a VPA CR. The default is `false`.
-<6> Specifies the tuning parameters for the VPA updater.
+`spec.deploymentOverrides.admission.container.resources.requests`:: Specifies the resource requests and limits for the VPA admission controller pod.
+`spec.deploymentOverrides.recommender`:: Specifies the tuning parameters for the VPA recommender.
+`spec.deploymentOverrides.recommender.container.args.memory-saver`:: When `true`, specifies that the VPA Operator monitors only workloads with a VPA CR. The default is `false`.
+`spec.deploymentOverrides.updater`:: Specifies the tuning parameters for the VPA updater.
 
 ////
 Hiding these three callouts as not supported

--- a/modules/nodes-pods-vertical-autoscaler-uninstall.adoc
+++ b/modules/nodes-pods-vertical-autoscaler-uninstall.adoc
@@ -6,7 +6,10 @@
 [id="nodes-pods-vertical-autoscaler-uninstall_{context}"]
 = Uninstalling the Vertical Pod Autoscaler Operator
 
-You can remove the Vertical Pod Autoscaler Operator (VPA) from your {product-title} cluster. After uninstalling, the resource requests for the pods that are already modified by an existing VPA custom resource (CR) do not change. The resources defined in the workload object, not the previous recommendations made by the VPA, are allocated to any new pods.
+[role="_abstract"]
+You can remove the Vertical Pod Autoscaler Operator (VPA) from your {product-title} cluster. 
+
+After uninstalling, the resource requests for the pods that are already modified by an existing VPA custom resource (CR) do not change. The resources defined in the workload object, not the previous recommendations made by the VPA, are allocated to any new pods.
 
 [NOTE]
 ====

--- a/modules/nodes-pods-vertical-autoscaler-using-about.adoc
+++ b/modules/nodes-pods-vertical-autoscaler-using-about.adoc
@@ -6,7 +6,10 @@
 [id="nodes-pods-vertical-autoscaler-using-about_{context}"]
 = About using the Vertical Pod Autoscaler Operator
 
-To use the Vertical Pod Autoscaler Operator (VPA), you create a VPA custom resource (CR) for a workload object in your cluster. The VPA learns and applies the optimal CPU and memory resources for the pods associated with that workload object. You can use a VPA with a deployment, stateful set, job, daemon set, replica set, or replication controller workload object. The VPA CR must be in the same project as the pods that you want to check.
+[role="_abstract"]
+To use the {product-title} Vertical Pod Autoscaler Operator (VPA) to help you maintain the optimal CPU and memory usage for your pods, you create a VPA custom resource (CR) for a workload object in your cluster. 
+
+The VPA learns and applies the optimal CPU and memory resources for the pods associated with that workload object. You can use a VPA with a deployment, stateful set, job, daemon set, replica set, or replication controller workload object. The VPA CR must be in the same project as the pods that you want to check.
 
 You use the VPA CR to associate a workload object and specify the mode that the VPA operates in. You can also use the CR to opt-out certain containers from VPA evaluation and updates.
 
@@ -86,11 +89,6 @@ The output shows the recommended resources, `target`, the minimum recommended re
 
 The VPA uses the `lowerBound` and `upperBound` values to determine if a pod needs updating. If a pod has resource requests less than the `lowerBound` values or more than the `upperBound` values, the VPA terminates and recreates the pod with the `target` values.
 
-[role="_additional-resources"]
-.Additional resources
-
-* xref:../../nodes/pods/nodes-pods-adjust-resources-in-place.adoc#nodes-pods-adjust-resources-in-place-about_nodes-pods-adjust-resources-in-place[Adjust pod resource levels without pod disruption]
-
 [id="nodes-pods-vertical-autoscaler-using-one-pod_{context}"]
 == Changing the VPA minimum value
 
@@ -116,14 +114,15 @@ metadata:
   resourceVersion: "142172"
   uid: 180e17e9-03cc-427f-9955-3b4d7aeb2d59
 spec:
-  minReplicas: 3 <1>
+  minReplicas: 3
   podMinCPUMillicores: 25
   podMinMemoryMb: 250
   recommendationOnly: false
   safetyMarginFraction: 0.15
 ----
+where:
 
-<1> Specify the minimum number of replicas in a workload object for the VPA to act on. Any objects with replicas fewer than the minimum are not automatically deleted by the VPA.
+`spec.minReplicas`:: Specifies the minimum number of replicas in a workload object for the VPA to act on. Any objects with replicas fewer than the minimum are not automatically deleted by the VPA.
 
 [id="nodes-pods-vertical-autoscaler-using-auto_{context}"]
 == Automatically applying VPA recommendations
@@ -146,17 +145,20 @@ metadata:
 spec:
   targetRef:
     apiVersion: "apps/v1"
-    kind:       Deployment <1>
-    name:       frontend <2>
+    kind:       Deployment
+    name:       frontend
   updatePolicy:
-    updateMode: "InPlaceOrRecreate" <3>
+    updateMode: "InPlaceOrRecreate"
 ----
-<1> The type of workload object you want this VPA CR to manage.
-<2> The name of the workload object you want this VPA CR to manage.
-<3> Set the mode to `InPlaceOrRecreate` or `Recreate`: 
-+
+where:
+
+`spec.targetRef.kind`:: Specifies the type of workload object you want this VPA CR to manage.
+`spec.targetRef.name`:: Specifies the name of the workload object you want this VPA CR to manage.
+`spec.updatePolicy.updateMode`:: Specifies the mode, either `InPlaceOrRecreate` or `Recreate`: 
+--
 * `InPlaceOrRecreate`. The VPA attempts to update the workload object with the new resource requests without re-creating the pod. If the VPA is unable to update the object in place, the VPA re-creates it.
 * `Recreate`. The VPA assigns resource requests on pod creation and updates the existing pods by terminating them. Use this mode rarely, only if you need to ensure that when the resource request changes the pods restart.
+--
 
 [NOTE]
 ====
@@ -181,14 +183,16 @@ metadata:
 spec:
   targetRef:
     apiVersion: "apps/v1"
-    kind:       Deployment <1>
-    name:       frontend <2>
+    kind:       Deployment
+    name:       frontend
   updatePolicy:
-    updateMode: "Initial" <3>
+    updateMode: "Initial"
 ----
-<1> The type of workload object you want this VPA CR to manage.
-<2> The name of the workload object you want this VPA CR to manage.
-<3> Set the mode to `Initial`. The VPA assigns resources when pods are created and does not change the resources during the lifetime of the pod.
+where:
+
+`spec.targetRef.kind`:: Specifies the type of workload object you want this VPA CR to manage.
+`spec.targetRef.name`:: Specifies the name of the workload object you want this VPA CR to manage.
+`spec.updatePolicy.updateMode`:: Specifies the mode as `Initial`. The VPA assigns resources when pods are created and does not change the resources during the lifetime of the pod.
 
 [NOTE]
 ====
@@ -214,14 +218,16 @@ metadata:
 spec:
   targetRef:
     apiVersion: "apps/v1"
-    kind:       Deployment <1>
-    name:       frontend <2>
+    kind:       Deployment
+    name:       frontend
   updatePolicy:
-    updateMode: "Off" <3>
+    updateMode: "Off"
 ----
-<1> The type of workload object you want this VPA CR to manage.
-<2> The name of the workload object you want this VPA CR to manage.
-<3> Set the mode to `Off`.
+where:
+
+`spec.targetRef.kind`:: Specifies the type of workload object you want this VPA CR to manage.
+`spec.targetRef.name`:: Specifies the name of the workload object you want this VPA CR to manage.
+`spec.updatePolicy.updateMode`:: Specifies the mode as `Off`.
 
 You can view the recommendations by using the following command.
 
@@ -255,19 +261,21 @@ metadata:
 spec:
   targetRef:
     apiVersion: "apps/v1"
-    kind:       Deployment <1>
-    name:       frontend <2>
+    kind:       Deployment
+    name:       frontend
   updatePolicy:
-    updateMode: "InPlaceOrRecreate" <3>
-  resourcePolicy: <4>
+    updateMode: "InPlaceOrRecreate"
+  resourcePolicy:
     containerPolicies:
     - containerName: my-opt-sidecar
       mode: "Off"
 ----
-<1> The type of workload object you want this VPA CR to manage.
-<2> The name of the workload object you want this VPA CR to manage.
-<3> Set the mode to `InPlaceOrRecreate`, `Recreate`, `Initial`, or `Off`. Use the `Recreate` mode rarely. For example, use this mode to ensure that the pods restart when the resources are updated.
-<4> Specify the containers that you do not want updated by the VPA and set the `mode` to `Off`.
+where:
+
+`spec.targetRef.kind`:: Specifies the type of workload object you want this VPA CR to manage.
+`spec.targetRef.name`:: Specifies the name of the workload object you want this VPA CR to manage.
+`spec.updatePolicy.updateMode`:: Specifies the mode as `InPlaceOrRecreate`, `Recreate`, `Initial`, or `Off`. Use the `Recreate` mode rarely. For example, use this mode to ensure that the pods restart when the resources are updated.
+`spec.resourcePolicy`:: Specifies the containers that you do not want updated by the VPA and set the `mode` to `Off`.
 
 For example, a pod has two containers, the same resource requests and limits:
 

--- a/nodes/pods/nodes-pods-vertical-autoscaler.adoc
+++ b/nodes/pods/nodes-pods-vertical-autoscaler.adoc
@@ -7,8 +7,10 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 
+[role="_abstract"]
+You can use the {product-title} Vertical Pod Autoscaler Operator (VPA) to help you understand the optimal CPU and memory usage for your pods and automatically maintain pod resources through the pod lifecycle.
 
-The {product-title} Vertical Pod Autoscaler Operator (VPA) automatically reviews the historic and current CPU and memory resources for containers in pods. The VPA can update the resource limits and requests based on the usage values it learns. By using individual custom resources (CR), the VPA updates all the pods in a project associated with any built-in workload objects. This includes the following list of object types:
+The VPA automatically reviews the historic and current CPU and memory resources for containers in pods. The VPA can update the resource limits and requests based on the usage values it learns. By using individual custom resources (CR), the VPA updates all the pods in a project associated with any built-in workload objects. This includes the following list of object types:
 
 * `Deployment`
 * `DeploymentConfig`
@@ -18,24 +20,16 @@ The {product-title} Vertical Pod Autoscaler Operator (VPA) automatically reviews
 * `ReplicaSet`
 * `ReplicationController`
 
-The VPA can also update certain custom resource object that manage pods. For more information, see xref:../../nodes/pods/nodes-pods-vertical-autoscaler.adoc#nodes-pods-vertical-autoscaler-custom-resource_nodes-pods-vertical-autoscaler[Example custom resources for the Vertical Pod Autoscaler].
-
-The VPA helps you to understand the optimal CPU and memory usage for your pods and can automatically maintain pod resources through the pod lifecycle.
+The VPA can also update certain custom resource object that manage pods. For more information, see "Example custom resources for the Vertical Pod Autoscaler".
 
 // The following include statements pull in the module files that comprise
 // the assembly. Include any combination of concept, procedure, or reference
 // modules required to cover the user story. You can also include other
 // assemblies.
 
-
 include::modules/nodes-pods-vertical-autoscaler-about.adoc[leveloffset=+1]
 
 include::modules/nodes-pods-vertical-autoscaler-in-place.adoc[leveloffset=+2]
-
-[role="_additional-resources"]
-.Additional resources
-* xref:../../nodes/pods/nodes-pods-vertical-autoscaler.adoc#nodes-pods-vertical-autoscaler-using-about_nodes-pods-vertical-autoscaler[About using the Vertical Pod Autoscaler Operator]
-* xref:../../nodes/pods/nodes-pods-adjust-resources-in-place.adoc#nodes-pods-adjust-resources-in-place[Adjust pod resource levels without pod disruption]
 
 include::modules/nodes-pods-vertical-autoscaler-install.adoc[leveloffset=+1]
 
@@ -47,9 +41,6 @@ include::modules/nodes-pods-vertical-autoscaler-tuning.adoc[leveloffset=+2]
 
 include::modules/nodes-pods-vertical-autoscaler-oom.adoc[leveloffset=+2]
 
-.Additional resources
-* xref:../../nodes/clusters/nodes-cluster-resource-configure.adoc#nodes-cluster-resource-configure-oom_nodes-cluster-resource-configure[Understanding OOM kill policy]
-
 include::modules/nodes-pods-vertical-autoscaler-custom.adoc[leveloffset=+2]
 
 include::modules/nodes-pods-vertical-autoscaler-configuring.adoc[leveloffset=+1]
@@ -57,3 +48,11 @@ include::modules/nodes-pods-vertical-autoscaler-configuring.adoc[leveloffset=+1]
 include::modules/nodes-pods-vertical-autoscaler-custom-resource.adoc[leveloffset=+2]
 
 include::modules/nodes-pods-vertical-autoscaler-uninstall.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+[id="additional-resources_{context}"]
+== Additional resources
+* xref:../../nodes/pods/nodes-pods-vertical-autoscaler.adoc#nodes-pods-vertical-autoscaler-custom-resource_nodes-pods-vertical-autoscaler[Example custom resources for the Vertical Pod Autoscaler]
+* xref:../../nodes/pods/nodes-pods-vertical-autoscaler.adoc#nodes-pods-vertical-autoscaler-using-about_nodes-pods-vertical-autoscaler[About using the Vertical Pod Autoscaler Operator]
+* xref:../../nodes/pods/nodes-pods-adjust-resources-in-place.adoc#nodes-pods-adjust-resources-in-place[Adjust pod resource levels without pod disruption]
+* xref:../../nodes/clusters/nodes-cluster-resource-configure.adoc#nodes-cluster-resource-configure-oom_nodes-cluster-resource-configure[Understanding OOM kill policy]


### PR DESCRIPTION
https://redhat.atlassian.net/browse/OSDOCS-16937

Preview:
Nodes -> Working with pods -> [Automatically adjust pod resource levels with the vertical pod autoscaler
](https://112863--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/pods/nodes-pods-vertical-autoscaler.html)
Machine management -> Creating infrastructure machine sets -> Moving the Vertical Pod Autoscaler Operator components -- The short desc and intro paragraphs are slight different from the [VPA Moving the Vertical Pod Autoscaler Operator components](https://112863--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/pods/nodes-pods-vertical-autoscaler.html#infrastructure-moving-vpa_nodes-pods-vertical-autoscaler).

Assembly:
'openshift-docs/nodes/pods/nodes-pods-vertical-autoscaler.adoc'