### PR TITLE
Fix LimitRange minimum constraint descriptions

### DIFF
--- a/modules/admin-quota-limits.adoc
+++ b/modules/admin-quota-limits.adoc
@@ -11,7 +11,7 @@ To define compute resource constraints at the object level, create a `LimitRange
 
 All requests to create and modify resources are evaluated against each `LimitRange` object in the project. If the resource violates any of the enumerated constraints, the resource is rejected. If the resource does not set an explicit value, and if the constraint supports a default value, the default value is applied to the resource.
 
-For CPU and memory limits, if you specify a maximum value but do not specify a minimum limit, the resource can consume more CPU and memory resources than the maximum value.
+For CPU and memory limits, if you specify a maximum value but do not specify a `min` value, no minimum constraint is enforced. Any configured maximum value is still enforced.
 
 ifdef::openshift-online[]
 [IMPORTANT]
@@ -64,17 +64,17 @@ where:
 
 `max.memory`:: Specifies the maximum amount of memory that a pod can request on a node across all containers.
 
-`min.cpu`:: Specifies the minimum amount of CPU that a pod can request on a node across all containers. If you do not set a `min` value or you set `min` to `0`, the result is no limit and the pod can consume more than the `max` CPU value.
+`min.cpu`:: Specifies the minimum amount of CPU that a pod can request on a node across all containers. If you do not set a `min` value or you set `min` to `0`, no minimum constraint is enforced.
 
-`min.memory`:: Specifies the minimum amount of memory that a pod can request on a node across all containers. If you do not set a `min` value or you set `min` to `0`, the result is no limit and the pod can consume more than the `max` memory value.
+`min.memory`:: Specifies the minimum amount of memory that a pod can request on a node across all containers. If you do not set a `min` value or you set `min` to `0`, no minimum constraint is enforced.
 
 `max.cpu`:: Specifies the maximum amount of CPU that a single container in a pod can request.
 
 `max.memory`:: Specifies the maximum amount of memory that a single container in a pod can request.
 
-`min.cpu`:: Specifies the minimum amount of CPU that a single container in a pod can request. If you do not set a `min` value or you set `min` to `0`, the result is no limit and the pod can consume more than the `max` CPU value.
+`min.cpu`:: Specifies the minimum amount of CPU that a single container in a pod can request. If you do not set a `min` value or you set `min` to `0`, no minimum constraint is enforced.
 
-`max.memory`:: Specifies the minimum amount of memory that a single container in a pod can request. If you do not set a `min` value or you set `min` to `0`, the result is no limit and the pod can consume more than the `max` memory value.
+`min.memory`:: Specifies the minimum amount of memory that a single container in a pod can request. If you do not set a `min` value or you set `min` to `0`, no minimum constraint is enforced.
 
 `default.cpu`:: Specifies the default CPU limit for a container if you do not specify a limit in the pod specification.
 
@@ -129,6 +129,6 @@ where:
 
 `min.cpu`:: Specifies the minimum amount of CPU that a pod can request on a node across all containers. See the Supported Constraints table for important information.
 
-`min.memory`:: Specifies the minimum amount of memory that a pod can request on a node across all containers. If you do not set a `min` value or you set `min` to `0`, the result is no limit and the pod can consume more than the `max` memory value.
+`min.memory`:: Specifies the minimum amount of memory that a pod can request on a node across all containers. If you do not set a `min` value or you set `min` to `0`, no minimum constraint is enforced.
 
 You can specify both core and {product-title} resources in one limit range object.


### PR DESCRIPTION
## Summary

Fixes incorrect `LimitRange` wording in the compute resource quotas docs.

The current text says that when `min` is not set, a pod or container can consume more than the configured `max` value. That is incorrect: missing `min` means no minimum constraint is enforced; it does not disable `max`.

Also fixes a copy/paste error where a container memory entry is labeled `max.memory` but describes `min.memory`.

## Verification

Tested on CRC with `LimitRange` objects that set `max` without `min`, and with `min: 0`.

`oc create --dry-run=server` confirmed that resources above `max` are still rejected.