### PR TITLE
Add upgrade behavior for autonode

### DIFF
--- a/modules/rosa-hcp-upgrade-options.adoc
+++ b/modules/rosa-hcp-upgrade-options.adoc
@@ -3,11 +3,13 @@
 = Update options for {product-title} clusters
 
 [role="_abstract"]
-You can control the impact of updates to your workload by controlling which parts of the cluster are updated, for example:
+You can control the impact of updates to your workload by controlling which parts of the cluster are updated. 
 
-Update only the hosted control plane:: This initiates update of the hosted control plane. It does not impact your worker nodes.
+Update only the hosted control plane:: This initiates update of the hosted control plane. When the cluster is not configured with Red Hat build of Karpenter, it does not impact your worker nodes. When the cluster is configued with Red Hat build of Karpenter, worker nodes that are part of the default EC2NodeClass resource managed by Karpenter will be updated along with the hosted control plane.
 
 Update nodes in a machine pool:: {product-title} machine pool updates are designed to fully replace each node in a machine pool during the update process. This provides additional security and stability benefits over performing an in-place update. Updating the nodes in a machine pool initiates a rolling replacement of nodes in the specified machine pool, and temporarily impacts the worker nodes on that machine pool. You can also update multiple machine pools concurrently.
+
+Update nodes in a Karpenter-managed EC2NodeClass:: When {autonode} is enabled, OpenshiftEC2NodeClass created in the cluster can be upgraded.  
 
 [IMPORTANT]
 ====

--- a/modules/rosa-hcp-upgrading-autonode-clusters.adoc
+++ b/modules/rosa-hcp-upgrading-autonode-clusters.adoc
@@ -1,0 +1,17 @@
+:_mod-docs-content-type: CONCEPT
+[id="rosa-upgrading-autonode_{context}"]
+= upgrading {product-title} clusters configured with {autonode}
+
+[role="_abstract"]
+
+This section outlines the behavior when the {product-title} cluster is configured with the {autonode} and the instructions for upgrading the cluster.  You can view cluster properties to confirm whether autonode is enabled.
+
+== Default OpenshiftEC2NodeClass
+When you enable autonode, a default OpenshiftEC2NodeClass is created with the same version as that of the hosted control plane. All NodePools that reference the default EC2NodeClass will be automatically upgraded as part of the hosted control plane upgrade.
+
+== Optional OpenshiftEC2NodeClass
+Upgrade behavior depends on whether or not the OpenshiftEC2NodeClass is pinned to a version using the `spec.version` field.  
+
+* `Unpinned OpenshiftEC2NodeClass`: OpenshiftEC2NodeClass by default has the same version of the hosted control plane. When the hosted control plane is upgraded, such unpinned OpenshiftEC2NodeClass will be automatically upgraded.  
+
+* `Pinned OpenshiftEC2NodeClass' : In the OpenshiftEC2NodeClass, you can specify a valide version in `spec.version` to pin its NodePools to a specific version. Such pinned OpenshiftEC2NodeClasses will not be upgraded as part of the hosted control plane upgrade. `spec.version` of such pinned OpenshiftEC2NodeClass can be updated to a valid version to initiate the upgrade of all the NodePools that reference its corresponding OpenshiftEC2NodeClass. 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->
[ROSA-17](https://redhat.atlassian.net/browse/ROSA-17) introduces Red Hat build of Karpenter for ROSA with hosted control planes cluster. This PR adds the cluster upgrade behavior section and adjust the existing wording to accommodate the new behavior.

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.22+

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
[OSDOCS-20045](https://redhat.atlassian.net/browse/OSDOCS-20045)

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
