### PR TITLE
OSDOCS-20042: adds OIDC authentication RHCL

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -70,6 +70,8 @@ Topics:
   File: coredns
 - Name: Using X.509 cryptographic identity verification
   File: rhcl-using-x509-crypt-id-verify
+- Name: Using OpenID Connect authentication
+  File: rhcl-oidc-authentication
 ---
 Name: Registering MCP servers and creating policies
 Dir: mcp_gateway_config

--- a/deployment/rhcl-oidc-authentication.adoc
+++ b/deployment/rhcl-oidc-authentication.adoc
@@ -1,0 +1,20 @@
+:_mod-docs-content-type: ASSEMBLY
+include::_attributes/attributes.adoc[]
+[id="rhcl-oidc-authentication"]
+= Using OpenID Connect authentication
+:context: rhcl-oidc-authentication
+
+toc::[]
+
+[role="_abstract"]
+You can use OpenID Connect (OIDC) authentication with {prodname} to connect and secure an API exposed by a `Gateway` object.
+
+include::modules/proc-rhcl-oidc-authpolicy.adoc[leveloffset=+1]
+
+include::modules/proc-rhcl-oidc-authpolicy-verify.adoc[leveloffset=+2]
+
+include::modules/proc-rhcl-oidc-get-token.adoc[leveloffset=+1]
+
+include::modules/proc-rhcl-oidc-rbac-policy.adoc[leveloffset=+1]
+
+include::modules/proc-rhcl-oidc-rbac-verify.adoc[leveloffset=+2]

--- a/modules/con-about-config-gateway-policies.adoc
+++ b/modules/con-about-config-gateway-policies.adoc
@@ -18,6 +18,12 @@ To complete your deployment, take the following steps:
 
 * Create and apply  a `TLSPolicy` custom resource (CR) that uses your `CertificateIssuer` object to set up your HTTPS listener certificates.
 * Create and apply an `HTTPRoute` or `GRPCRoute` CR for your `Gateway` object to communicate with your backend application API.
-* Create and apply an `AuthPolicy` CR to set up a default HTTP `403` response for any unprotected endpoints
+* Create and apply an `AuthPolicy` CR to set up a default HTTP `403` response for any unprotected endpoints.
++
+[TIP]
+====
+Use the `oc explain authpolicies` command to understand which authentication methods are supported when you use {prodname} on {ocp}. The in-cluster API documentation lists all supported authentication mechanisms.
+====
 * Create and apply a `RateLimitPolicy` CR to set up a default artificially low global limit to further protect any endpoints exposed by the `Gateway` object.
 * Create and apply a `DNSPolicy` CR with a load balancing strategy for your `Gateway` object.
+

--- a/modules/proc-rhcl-oidc-authpolicy-verify.adoc
+++ b/modules/proc-rhcl-oidc-authpolicy-verify.adoc
@@ -1,0 +1,80 @@
+// Module included in the following assemblies:
+//
+// *deployment/rhcl-oidc-authentication.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="proc-set-oidc-auth-policy-verify_{context}"]
+= Verifying the OIDC AuthPolicy custom resource
+
+[role="_abstract"]
+You can verify a {prodname} `AuthPolicy` custom resource (CR) after you applied the policy to ensure that it is working as intended.
+
+.Prerequisites
+
+* You completed the "Setting the OIDC AuthPolicy custom resource" procedure.
+
+.Procedure
+
+. Check that your `AuthPolicy` has `Accepted` and `Enforced` status by running the following command:
++
+[source,terminal,subs="+quotes"]
+----
+$ oc describe authpolicy _<api_oidc_auth>_ -n _<user_apps>_
+----
++
+--
+* Replace `_<api_oidc_auth>_` with the name of your `AuthPolicy` CR.
+* Replace `_<user_apps>_` with the namespace where your `AuthPolicy` CR is applied.
+--
++
+.Example output
+[source,terminal]
+----
+Status:
+  Conditions:
+    Last Transition Time:  2026-06-12T12:00:00Z
+    Message:               AuthPolicy has been accepted
+    Reason:                Accepted
+    Status:                True
+    Type:                  Accepted
+    Last Transition Time:  2026-06-12T12:00:01Z
+    Message:               AuthPolicy has been enforced
+    Reason:                Enforced
+    Status:                True
+    Type:                  Enforced
+----
+
+. Send an unauthenticated request to your route to verify that it is blocked by running the following command:
++
+[source,terminal,subs="+quotes"]
+----
+$ curl -v -s -o /dev/null -w "%{http_code}\n" http://_<route_hostname>_
+----
++
+--
+* Replace `_<route_hostname>_` with the exposed hostname of your application route.
+--
++
+.Expected output
+[source,text]
+----
+HTTP/1.1 401 Unauthorized
+----
+
+. Send an authenticated request containing a valid OIDC access token to verify that access is granted by running the following command:
++
+[source,terminal,subs="+quotes"]
+----
+$ curl -H "Authorization: Bearer _<access_token>_" -v -s -o /dev/null -w "%{http_code}\n" http://_<route_hostname>_
+----
++
+--
+* Replace `_<access_token>_` with a valid JWT string issued by your OIDC provider.
+* Replace `_<route_hostname>_` with the exposed hostname of your application route.
+--
++
+.Expected output
+[source,text]
+----
+HTTP/1.1 200 OK
+----

--- a/modules/proc-rhcl-oidc-authpolicy.adoc
+++ b/modules/proc-rhcl-oidc-authpolicy.adoc
@@ -1,0 +1,61 @@
+// Module included in the following assemblies:
+//
+// *deployment/rhcl-oidc-authentication.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="proc-set-oidc-auth-policy_{context}"]
+= Setting the OIDC AuthPolicy custom resource
+
+[role="_abstract"]
+You can configure a {prodname} `AuthPolicy` custom resource (CR) to use an OIDC provider. The same API deployed to multiple clusters can authenticate with the same identity provider.
+
+In a zero-trust environment, every application with an `HTTPRoute` or `GRPCRoute` CR exposed by an application developer must also have an attached route-level `AuthPolicy` CR. You can target either a `Gateway` or a `route` object with an `AuthPolicy` CR.
+
+.Prerequisites
+
+* You installed {prodname} on one or more clusters.
+* You installed the {oc-first}.
+* You have write access to the {ocp} namespaces you need to work with.
+* You created a `Gateway` object.
+* You created an `HTTPRoute` or `GRPCRoute` object.
+* You have a trusted OIDC provider configured to issue tokens for your API clients.
+* If your OIDC server is using a self-signed or internal cluster certificate, you injected the trusted CA bundle into your {prodname} installation.
+
+.Procedure
+
+. Create an `AuthPolicy` CR that targets an `HTTPRoute` CR and configures OIDC authentication by using the following example:
++
+.Example `AuthPolicy` CR
+[source,yaml,subs="+quotes"]
+----
+apiVersion: kuadrant.io/v1
+kind: AuthPolicy
+metadata:
+  name: _<api_oidc_auth>_
+  namespace: _<user_apps>_
+spec:
+  targetRef:
+    group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    name: _<api_route>_
+  rules:
+    authentication:
+      "oidc-idp-auth":
+        jwt:
+          issuerUrl: "https://rhbk.apps.cluster.example.com/realms/realm"
+----
++
+* The `AuthPolicy` CR must exist in the same namespace where the `HTTPRoute` object is applied.
+* Replace the `spec.metadata.name` parameter value with the name you want to use for your `AuthPolicy` CR.
+* Replace the `spec.metadata.namespace` parameter value with the namespace where you want your `AuthPolicy` CR applied.
+* The value of the `spec.targetRef.name` parameter must match the name of your `HTTPRoute` object.
+* The URL, `"https://rhbk.apps.cluster.example.com/realms/realm"`, is the base URL of your OIDC issuer, for example, {keycloak}.
+
+. Apply your `AuthPolicy` CR by running the following command:
++
+[source,terminal,subs="+quotes"]
+----
+$ oc apply -f _<api_oidc_auth.yaml>_
+----
++
+Replace `_<api_oidc_auth.yaml>_` with your `AuthPolicy` YAML filename.

--- a/modules/proc-rhcl-oidc-get-token.adoc
+++ b/modules/proc-rhcl-oidc-get-token.adoc
@@ -1,0 +1,40 @@
+// Module included in the following assemblies:
+//
+// *deployment/rhcl-oidc-authentication.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="proc-set-oidc-get-token_{context}"]
+= Getting a token to use with an OIDC AuthPolicy custom resource
+
+[role="_abstract"]
+After you configured a {prodname} `AuthPolicy` custom resource (CR) to use an OIDC provider, you must get a token.
+
+The following example assumes the following facts:
+
+* You have a {keycloak} instance running in the `keycloak` namespace that is listening at port `8080`.
+* You have a `kuadrant` Keycloak realm.
+* You have a demonstration OAuth2 client with a Direct Access grant enabled.
+* You have a user `john` with the password `p`.
+
+.Prerequisites
+
+* You installed {prodname} on one or more clusters.
+* You installed the {oc-first}.
+* You have write access to the {ocp} namespaces you need to work with.
+* You created a `Gateway` object.
+* You created an `HTTPRoute` or `GRPCRoute` object.
+* You created an `AuthPolicy` CR.
+
+.Procedure
+
+* Get an access token from within the cluster for the user John, who is assigned to the `member` role, by running the following command:
++
+[source,terminal]
+----
+$ ACCESS_TOKEN=$(oc run token --attach --rm --restart=Never -q --image=curlimages/curl -- http://keycloak.keycloak.svc.cluster.local:8080/realms/kuadrant/protocol/openid-connect/token -s -d 'grant_type=password' -d 'client_id=demo' -d 'username=john' -d 'password=p' -d 'scope=openid' | jq -r .access_token)
+----
++
+[NOTE]
+====
+If your {keycloak} server is reachable from outside the cluster, you can get the token directly. Make sure that the `hostname` set in the OIDC issuer endpoint configured in the `AuthPolicy` CR matches the one used to get the token and is reachable from within the cluster.
+====

--- a/modules/proc-rhcl-oidc-rbac-policy.adoc
+++ b/modules/proc-rhcl-oidc-rbac-policy.adoc
@@ -1,0 +1,70 @@
+// Module included in the following assemblies:
+//
+// *deployment/rhcl-oidc-authentication.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="proc-rhcl-oidc-rbac-policy_{context}"]
+= Using RBAC with an OIDC AuthPolicy custom resource
+
+[role="_abstract"]
+You can configure role-based-access to use with your OpenID Connect (OIDC) authentication by adding the roles to your `AuthPolicy` custom resource (CR).
+
+.Prerequisites
+
+* You installed {prodname} on one or more clusters.
+* You installed the {oc-first}.
+* You have write access to the {ocp} namespaces you need to work with.
+* You created a `Gateway` object.
+* You created an `HTTPRoute` or `GRPCRoute` object.
+* You created an `AuthPolicy` CR.
+* You got a token from your OIDC provider.
+
+.Procedure
+
+* Add the following roles to your `AuthPolicy` CR by using the following example:
++
+.Example AuthPolicy with RBAC definitions
+[source,yaml,subs="+quotes"]
+----
+apiVersion: kuadrant.io/v1
+kind: AuthPolicy
+metadata:
+  name: _<api_oidc_rbac_auth>_
+  namespace: _<user_apps>_
+spec:
+#...
+  patterns:
+    "member-role":
+    - selector: auth.identity.realm_access.roles
+      operator: incl
+      value: member
+    "admin-role":
+    - selector: auth.identity.realm_access.roles
+      operator: incl
+      value: admin
+  authorization:
+    "rbac-resources-api":
+      when:
+      - cel: "http.path.matches('^/resources(/.*)?$')"
+      patternMatching:
+        patterns:
+        - patternRef: member-role
+    "rbac-delete-resource":
+      when:
+      - cel: "http.path.matches('^/resources/\\\\d+$') && http.method == 'DELETE'"
+      patternMatching:
+        patterns:
+        - patternRef: admin-role
+    "rbac-admin-api":
+      when:
+      - cel: "http.path.matches('^/admin(/.*)?$')"
+      patternMatching:
+        patterns:
+        - patternRef: admin-role
+----
++
+* Replace the `spec.metadata.name` parameter value with the name you want to use for your `AuthPolicy` CR.
+* Replace the `spec.metadata.namespace` parameter value with the namespace where you want your `AuthPolicy` CR applied.
+* Requests to `/resources[/*]` require the `member` role.
+* `DELETE` requests to `^/resources/\\\\d+$` require the `admin` role.
+* Requests to `^/admin(/.*)?$` require the `admin` role.

--- a/modules/proc-rhcl-oidc-rbac-verify.adoc
+++ b/modules/proc-rhcl-oidc-rbac-verify.adoc
@@ -1,0 +1,133 @@
+// Module included in the following assemblies:
+//
+// *deployment/rhcl-oidc-authentication.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="proc-rhcl-oidc-rbac-verify_{context}"]
+= Verifying RBAC with OIDC
+
+[role="_abstract"]
+You can verify that the role-based-access you configured is working your OpenID Connect (OIDC) authentication by conducting tests with different user roles.
+
+The following example assumes the following setup:
+
+* A {keycloak} instance running in the keycloak namespace listening at port 8080.
+* A `kuadrant` {keycloak} realm.
+* An OAuth2 client with Direct Access grant enabled.
+* A user `john` who is assigned the `member` role and has the password `p`.
+* A user `jane` who is assigned the `member` and `admin` roles and has the  password `p`.
+
+.Prerequisites
+
+* You installed {prodname} on one or more clusters.
+* You installed the {oc-first}.
+* You have write access to the {ocp} namespaces you need to work with.
+* You created a `Gateway` object.
+* You created an `HTTPRoute` or `GRPCRoute` object.
+* You configured an `AuthPolicy` CR with role-based-access.
+
+.Procedure
+
+. Get an access token from within the cluster for the user John, who is assigned to the `member` role, by running the following command:
++
+[source,terminal]
+----
+$ ACCESS_TOKEN=$(oc run token --attach --rm --restart=Never -q --image=curlimages/curl -- https://keycloak.keycloak.svc.cluster.local:8080/realms/kuadrant/protocol/openid-connect/token -s -d 'grant_type=password' -d 'client_id=demo' -d 'username=john' -d 'password=p' -d 'scope=openid' | jq -r .access_token)
+----
++
+[NOTE]
+====
+If your {keycloak} server is reachable from outside the cluster, you can get the token directly. Make sure that the `hostname` set in the OIDC issuer endpoint configured in the `AuthPolicy` CR matches the one used to get the token and is reachable from within the cluster.
+====
+
+. Retrieve your cluster base domain and assign it to an environment variable by running the following command:
++
+[source,terminal]
+----
+$ export CLUSTER_DOMAIN=$(oc get ingress.config/cluster -o jsonpath='{.spec.domain}')
+----
+
+. As John, send a `GET` request to **/resources** by running the following command:
++
+[source,terminal,subs="+quotes"]
+----
+$ curl -H "Authorization: Bearer $ACCESS_TOKEN" https://api.$CLUSTER_DOMAIN/resources -i
+----
++
+.Example output
+[source,text]
+----
+HTTP/1.1 200 OK
+----
+
+. As John, send a `DELETE` request to `/resources/123` by running the following command:
++
+[source,terminal,subs="+quotes"]
+----
+$ curl -H "Authorization: Bearer $ACCESS_TOKEN" -X DELETE https://api.$CLUSTER_DOMAIN/resources/123 -i
+----
++
+.Example output
+[source,text]
+----
+HTTP/1.1 403 Forbidden
+----
+
+. As John, send a `GET` request to `/admin/settings` by running the following command:
++
+[source,terminal,subs="+quotes"]
+----
+$ curl -H "Authorization: Bearer $ACCESS_TOKEN" https://api.$CLUSTER_DOMAIN/admin/settings -i
+----
++
+.Example output
+[source,text]
+----
+HTTP/1.1 403 Forbidden
+----
+
+. Get an access token from within the cluster for the user Jane, who is assigned to the `member` and `admin` roles by running the following command:
++
+[source,terminal]
+----
+$ ACCESS_TOKEN=$(oc run token --attach --rm --restart=Never -q --image=curlimages/curl -- http://keycloak.keycloak.svc.cluster.local:8080/realms/kuadrant/protocol/openid-connect/token -s -d 'grant_type=password' -d 'client_id=demo' -d 'username=jane' -d 'password=p' -d 'scope=openid' | jq -r .access_token)
+----
+
+. As Jane, send a `GET` request to `/resources` by running the following command:
++
+[source,terminal,subs="+quotes"]
+----
+$ curl -H "Authorization: Bearer $ACCESS_TOKEN" https://api.$CLUSTER_DOMAIN/resources -i
+----
++
+.Example output
+[source,text]
+----
+HTTP/1.1 200 OK
+----
+
+. As Jane, send a `DELETE` request to **/resources/123** by running the following command:
++
+[source,terminal,subs="+quotes"]
+----
+$ curl -H "Authorization: Bearer $ACCESS_TOKEN" -X DELETE https://api.$CLUSTER_DOMAIN/resources/123 -i
+----
++
+.Example output
+[source,text]
+----
+HTTP/1.1 200 OK
+----
+
+. As Jane, send a `GET` request to `/admin/settings` by running the following command:
++
+[source,terminal,subs="+quotes"]
+----
+$ curl -H "Authorization: Bearer $ACCESS_TOKEN" https://api.$CLUSTER_DOMAIN/admin/settings -i
+----
++
+.Example output
+[source,text]
+----
+HTTP/1.1 200 OK
+----

--- a/modules/proc-rhcl-oidc-verify.adoc
+++ b/modules/proc-rhcl-oidc-verify.adoc
@@ -1,0 +1,53 @@
+// Module included in the following assemblies:
+//
+// *deployment/rhcl-oidc-authentication.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="proc-rhcl-oidc-verify_{context}"]
+= Verifying an OIDC authentication layer
+
+[role="_abstract"]
+You can verify that your OIDC authentication layer is working in two steps.
+
+.Prerequisites
+
+* You installed {prodname} on one or more clusters.
+* You installed the {oc-first}.
+* You have write access to the {ocp} namespaces you need to work with.
+* You created a `Gateway` object.
+* You created an `HTTPRoute` or `GRPCRoute` object.
+* You created an `AuthPolicy` CR.
+* You have a token from your OIDC provider.
+
+.Procedure
+
+. Send a `GET` request to your API while attaching the JSON Web Token (JWT) that you got from {keycloak} inside the `Authorization` header by running the following command:
++
+[source,terminal,subs="+quotes"]
+----
+$ curl -H "Authorization: Bearer $ACCESS_TOKEN" _<https://api.example.com:port/hello>_
+----
++
+Replace `_<http://api.example.com:port/hello>_` with the path and port to your API.
++
+.Example output
+[source,text]
+----
+HTTP/1.1 200 OK
+----
+
+. Send the exact same request to your API, but omit the `Authorization` header by running the following command:
++
+[source,terminal,subs="+quotes"]
+----
+$ curl _<https://api.example.com:port/hello>_ -i
+----
++
+Replace `_<https://api.example.com:port/hello>_` with the path and port to your API.
++
+.Example output
+[source,text]
+----
+HTTP/1.1 401 Unauthorized
+x-ext-auth-reason: credential not found
+----

--- a/modules/proc-set-default-auth-policy.adoc
+++ b/modules/proc-set-default-auth-policy.adoc
@@ -93,7 +93,7 @@ AuthPolicy has been successfully enforced
 +
 [source,terminal]
 ----
-$ curl -H 'Authorization: APIKEY ndyBzreUzF4zqDQsqSPMHkRhriEOtcRx' http://talker-api.127.0.0.1.nip.io:8000/hello
+$ curl -H 'Authorization: APIKEY ndyBzreUzF4zqDQsqSPMHkRhriEOtcRx' http://api.example.com:8000/hello
 ----
 +
 .Example output

--- a/modules/ref-about-service-deployment-objects-for-app.adoc
+++ b/modules/ref-about-service-deployment-objects-for-app.adoc
@@ -31,7 +31,7 @@ spec:
     spec:
       containers:
         - name: toystore
-          image: quay.io/kuadrant/authorino-examples:talker-api
+          image: quay.io/kuadrant/authorino-examples:api
           env:
             - name: LOG_LEVEL
               value: "debug"


### PR DESCRIPTION
Version(s):
rhcl-docs-1.4
rhcl-docs-1.5

Issue:
[OSDOCS-20042](https://redhat.atlassian.net/browse/OSDOCS-20042)

Link to docs preview:
https://112868--ocpdocs-pr.netlify.app/rhcl/latest/deployment/rhcl-oidc-authentication.html
https://112868--ocpdocs-pr.netlify.app/rhcl/latest/deployment/deployment#con-about-config-gateway-policies_rhcl-config-deploy-gateway-policies

QE review:
- [x] QE has approved this change.
- [x] SME has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Docs reviewer, please do not merge (awaiting QE).
<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
