### PR TITLE
Adding karpenter support for CP log forwarding

### DIFF
--- a/modules/rosa-determine-log-groups.adoc
+++ b/modules/rosa-determine-log-groups.adoc
@@ -77,6 +77,7 @@ a|
 * `cluster-api`
 * `community-operators-catalog`
 * `etcd`
+* `karpenter`
 * `private-router`
 * `redhat-marketplace-catalog`
 * `redhat-operators-catalog`


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->
As part of introducing Red Hat build of Karpenter on ROSA, log forwarding from Control Plane now includes karpenter controller. This PR adds karpenter to the list of available applications for forwarding logs.

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.22+

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
[OSDOCS-19817](https://redhat.atlassian.net/browse/OSDOCS-19817)

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
