### PR TITLE
PR for SRVLOGIC-976: Add a section about explaining the workflow id naming and versioning recommended practices and limitations in the OSL product docs

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -374,6 +374,8 @@ Topics:
 - Name: Getting started
   Dir: serverless-logic-getting-started
   Topics:
+  - Name: Managing Workflow identifiers and versioning
+    File: serverless-logic-workflow-identifiers-versioning
   - Name: Creating and running workflows with Knative Workflow plugin
     File: serverless-logic-creating-managing-workflows
   - Name: Deploying workflows

--- a/modules/serverless-logic-workflow-configuration-consistency.adoc
+++ b/modules/serverless-logic-workflow-configuration-consistency.adoc
@@ -1,0 +1,91 @@
+// Module included in the following assemblies:
+//
+// * serverless-logic/serverless-logic-getting-started/serverless-logic-workflow-identifiers-versioning.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="serverless-logic-workflow-configuration-consistency_{context}"]
+= Workflow configuration consistency
+
+[role="_abstract"]
+The workflow identifier must be consistent across all configurations, especially for {ServerlessLogicOperatorName} deployments by using the `gitops` profile.
+
+The following example displays YAML workflow definition:
+
+[source,yaml]
+----
+id: hello-world
+version: "1.0"
+specVersion: 0.8.0
+name: Hello World
+description: An example workflow to say Hello World
+start: HelloWorld
+# rest of workflow definition omitted
+----
+
+The following table displays Key fields in workflow definition:
+
+[cols="1,3",options="header"]
+|===
+|Field
+|Description
+
+|`id`
+|Must be a valid RFC 1123 DNS label
+
+|`version`
+|Workflow version
+
+|`specVersion`
+|CNCF Serverless Workflow specification version
+
+|`name`
+|(Optional) human-readable name
+
+|`description`
+|(Optional) workflow description
+|===
+
+The following example displays `gitops` profile configuration:
+
+[source,yaml]
+----
+apiVersion: sonataflow.org/v1alpha08
+kind: SonataFlow
+metadata:
+  name: hello-world
+  annotations:
+    sonataflow.org/name: Hello World
+    sonataflow.org/description: An example workflow to say Hello World
+    sonataflow.org/version: 1.0
+    sonataflow.org/profile: gitops
+spec:
+  podTemplate:
+    container:
+      image: "quay.io/my-workflows/hello-world:1.0"
+  flow:
+    start: HelloWorld
+    # rest of workflow definition omitted
+----
+
+The following table displays configuration mapping for `gitops` profile:
+
+[cols="1,3",options="header"]
+|===
+|Configuration field
+|Description
+
+|`metadata.name`
+|Represents the workflow `id` from YAML
+
+|`sonataflow.org/name`
+|Optional human-readable name annotation
+
+|`sonataflow.org/description`
+|Optional description annotation
+
+|`sonataflow.org/version`
+|Must match version from workflow YAML
+
+|`apiVersion`
+|Infers CNCF specification version (currently only 0.8.0 supported)
+|===

--- a/modules/serverless-logic-workflow-identifier-requirements.adoc
+++ b/modules/serverless-logic-workflow-identifier-requirements.adoc
@@ -1,0 +1,34 @@
+// Module included in the following assemblies:
+//
+// * serverless-logic/serverless-logic-getting-started/serverless-logic-workflow-identifiers-versioning.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="serverless-logic-workflow-identifier-requirements_{context}"]
+= Workflow identifier requirements
+
+[role="_abstract"]
+Workflow identifiers must comply with RFC 1123 DNS label standards to ensure proper functionality across all deployment variants.
+
+A workflow identifier must:
+
+* Contain only lowercase letters (a-z), digits (0-9), and hyphens (-)
+* Start with a lowercase letter or digit
+* End with a lowercase letter or digit
+
+You can see the following valid examples for reference:
+[source,text]
+----
+order-processing
+invoice123
+customer-onboarding-flow
+flow-01
+----
+
+You can see the following invalid examples for reference:
+[source,text]
+----
+OrderProcessing (uppercase not allowed)
+order_processing (underscores not allowed)
+-orderflow (cannot start with hyphen)
+orderflow- (cannot end with hyphen)
+----

--- a/modules/serverless-logic-workflow-versioning-limitations.adoc
+++ b/modules/serverless-logic-workflow-versioning-limitations.adoc
@@ -1,0 +1,41 @@
+// Module included in the following assemblies:
+//
+// * serverless-logic/serverless-logic-getting-started/serverless-logic-workflow-identifiers-versioning.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="serverless-logic-workflow-versioning-limitations_{context}"]
+= Workflow versioning limitations
+
+[role="_abstract"]
+The {ServerlessLogicProductName} ecosystem does not support multiple versions of a workflow sharing the same `id`. Each workflow `id` must be unique across deployments regardless of the configured `version`. Deploying multiple workflows with same `id` but different versions is unsupported and causes unexpected behavior.
+
+When introducing a new version, assign a new workflow `id` by using a consistent naming convention:
+
+* `hello-world-v1` for version 1.0
+* `hello-world-v2` for version 2.0
+
+This approach ensures clarity and avoids conflicts when managing multiple workflow iterations.
+
+The following example displays Version 1.0 workflow:
+[source,yaml]
+----
+id: hello-world-v1
+version: "1.0"
+specVersion: 0.8.0
+name: Hello World V1
+description: First version of Hello World workflow
+start: HelloWorld
+# rest of workflow definition
+----
+
+The following example displays Version 2.0 workflow:
+[source,yaml]
+----
+id: hello-world-v2
+version: "2.0"
+specVersion: 0.8.0
+name: Hello World V2
+description: Second version of Hello World workflow
+start: HelloWorld
+# rest of workflow definition
+----

--- a/serverless-logic/serverless-logic-getting-started/serverless-logic-workflow-identifiers-versioning.adoc
+++ b/serverless-logic/serverless-logic-getting-started/serverless-logic-workflow-identifiers-versioning.adoc
@@ -1,0 +1,16 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="serverless-logic-workflow-identifiers-versioning"]
+= Managing Workflow identifiers and versioning
+include::_attributes/common-attributes.adoc[]
+:context: serverless-logic-workflow-identifiers-versioning
+
+toc::[]
+
+[role="_abstract"]
+Workflow identifiers in {ServerlessLogicProductName} must comply with specific naming standards to ensure proper functionality across all deployment variants. Understanding the versioning limitations and best practices helps you manage workflow evolution effectively.
+
+include::modules/serverless-logic-workflow-identifier-requirements.adoc[leveloffset=+1]
+
+include::modules/serverless-logic-workflow-configuration-consistency.adoc[leveloffset=+1]
+
+include::modules/serverless-logic-workflow-versioning-limitations.adoc[leveloffset=+1]


### PR DESCRIPTION
**You can cherry-pick for the following branches:** 

- `serverless-docs-1.38`
- `serverless-docs-1.37`

**Tracking JIRA:** https://redhat.atlassian.net/browse/SRVLOGIC-976

**Changes:** 
Added a "[Managing Workflow identifiers and versioning](https://112874--ocpdocs-pr.netlify.app/openshift-serverless/latest/serverless-logic/serverless-logic-getting-started/serverless-logic-workflow-identifiers-versioning)" section under the Getting started directory. 

**Reviews:**
- [ ] SME has approved this change
- [ ] QE has approved this change
- [ ] Peer has approved this change