### PR TITLE
OBSDOCS-3314 [DOC] COO 1.5.0 GA Release Notes

### DIFF
--- a/modules/coo-features.adoc
+++ b/modules/coo-features.adoc
@@ -1,0 +1,22 @@
+//Module included in the following assemblies:
+//
+// * release-notes/cluster-observability-operator-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="coo-release-notes-abstract"]
+= {coo-full} features
+
+The {coo-short} complements the built-in monitoring capabilities of {ocp-product-title}. You can deploy it in parallel with the default platform and user workload monitoring stacks managed by the {cmo-first}.
+
+These release notes track the development of the {coo-full} in {ocp-product-title}.
+
+The following table provides information about which features are available depending on the version of {coo-full} and {ocp-product-title}:
+
+[cols="1,1,1,1,1,1,1", options="header"]
+|===
+| COO Version   | OCP Versions       | Distributed tracing   | Logging   | Troubleshooting panel | ACM alerts | Incident detection
+| 1.1+          | 4.12 - 4.14        | ✔                     | ✔         | ✘                     | ✘          | ✘
+| 1.1+          | 4.15               | ✔                     | ✔         | ✘                     | ✔          | ✘
+| 1.1+          | 4.16 - 4.18        | ✔                     | ✔         | ✘                     | ✔          | ✘
+| 1.2+          | 4.19+              | ✔                     | ✔         | ✔                     | ✔          | ✔
+|===

--- a/modules/coo-rel-notes-150.adoc
+++ b/modules/coo-rel-notes-150.adoc
@@ -1,0 +1,138 @@
+//Module included in the following assemblies:
+//
+// * release-notes/cluster-observability-operator-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+
+[id="cluster-observability-operator-release-notes-1-5_{context}"]
+= {coo-full} 1.5
+
+[role="_abstract"]
+Review the release notes for {coo-full} version 1.5, including new features, enhancements, bug fixes, and security advisories for each minor release.
+
+The following advisory is available for {coo-full} 1.5:
+
+* link:https://access.redhat.com/errata/RHSA-2026:26010[RHSA-2026:26010] {coo-full} 1.5
+
+[id="cluster-observability-operator-1-5-new-features-enhancements_{context}"]
+== New features and enhancements
+
+Red Hat build of Perses dashboarding tool::
+With this update, the Red{nbsp}Hat build of Perses dashboarding tool is generally available. This tool displays observability data and supports native Kubernetes role-based access control (RBAC). This feature includes a dashboard management user interface (UI) with create, edit, and delete capabilities directly in the {ocp-product-title} web console. This component also provides an integrated import tool to migrate existing dashboards from Grafana, configurable data sources for metrics, logging, and tracing, and built-in RBAC roles for secure access control. Users can manage observability dashboards without switching to external platforms.
++
+For more information, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_cluster_observability_operator/1-latest/html/ui_plugins_for_red_hat_openshift_cluster_observability_operator/perses-dashboard[Perses dashboards documentation].
+
+Stable and fast release channels for file-based catalogs::
+With this update, the single stable channel is replaced with two distinct release channels for component output optimization file-based catalogs:  
+* fast: Ships the latest bundle across all {ocp-product-title} versions. This matches the previous channel behavior.
+* stable: Pins different bundle versions per {ocp-product-title} version, controlled by the `config/channels.yaml` file.
+
++
+This change enhances the update process by allowing version-specific control, streamlining Konflux component updates with per-version update scripts, and improving organization with separate rendered catalog directories for each OCP version.
+
++
+[IMPORTANT]
+====
+If you are currently on the stable channel and want to continue receiving rolling releases, you must switch to the fast channel.
+====
+
++
+link:https://issues.redhat.com/browse/COO-1840[COO-1840]
+
+OTEL semantic convention support in Perses dashboards::
+With this update, monitoring UI plugin supports OpenTelemetry (OTEL) semantic convention metric naming in dashboards for Perses. Users can toggle between the OTEL semantic convention and the Prometheus naming schema to utilize normalized Prometheus metric names in the application performance monitoring (APM) dashboard. For example, the dashboard supports the `traces_span_metrics_calls_total` metric name for the `traces.span.metrics.calls` OTEL metric.  
++
+The dashboard metrics will now be named according to the OTEL standard, improving consistency and compatibility with other OTEL tools. As a result, users will benefit from a more seamless experience when using Perses dashboards with OTLP metrics.
++
+link:https://issues.redhat.com/browse/COO-1614[COO-1614]
+
+API server TLS configuration watch controller for {coo-full}::
+With this update, the {coo-first} includes a new controller that watches the cluster API server TLS configuration. When the configuration changes, the controller automatically exits or reconciles all managed resources. The controller can also convert the cluster TLS configuration into a Go TLS configuration.
++
+Before this update, the Operator lacked a dedicated controller to monitor and automatically reconcile changes in the cluster API server TLS configuration. This enhancement ensures that {coo-short} can manage and support the API server TLS configuration in the cluster, preventing potential issues and maintaining a secure deployment.
++
+link:https://issues.redhat.com/browse/COO-1548[COO-1548]
+
+[id="cluster-observability-operator-1-5-fixed-issues_{context}"]
+== Fixed issues
+
+Monitoring stack reconciler no longer encounters precondition errors::
+Before this update, the monitoring stack reconciler used an update API method to add finalizers. If a resource was removed concurrently during end-to-end test runs, the process failed with a `Precondition failed: UID in precondition` log error because the resource unique identifier (UID) was no longer present in etcd. 
++
+With this release, the reconciler uses a patch method to add finalizers, and the required patch permissions are added for monitoring stacks. This change ensures that the Operator does not attempt to update missing resources, which eliminates the precondition errors from the logs.
++
+link:https://issues.redhat.com/browse/COO-1690[COO-1690]
+
+Resolved issue with Prometheus and Alertmanager pods failing to deploy::
+Before this update, configuring a `MonitoringStack` with `createClusterRoleBindings: NoClusterRoleBindings` and a `namespaceSelector` prevented the creation of both `ClusterRoleBinding` and `RoleBinding` objects. As a result, `ServiceAccounts` lacked the necessary permissions, which prevented `StatefulSet` creation and stopped pods from deploying. 
++
+With this release, the required role bindings are correctly created under these configuration conditions, enabling successful `StatefulSet` creation and pod deployment.
++
+link:https://issues.redhat.com/browse/COO-1493[COO-1493]
+
+`MonitoringStack` CRD marked as generally available::
+Before this update, the `MonitoringStack` custom resource definition (CRD) for the {coo-full} displayed as a Technology Preview feature, which caused confusion among users.
++
+With this release, the `MonitoringStack` CRD is marked as generally available.
++
+link:https://issues.redhat.com/browse/COO-1742[COO-1742]
+
+Enhanced Perses Operator memory limit in large environments::
+Before this update, Perses Operator memory consumption increased, causing exceeded memory limits and requiring user adjustments in large environments.
++
+With this release, Perses Operator memory limit has been increased. As a result, potential overwrites are reduced, and user experience is improved.
++
+link:https://issues.redhat.com/browse/COO-1741[COO-1741]
+
+Distributed tracing plugin rebuilt against {ocp-product-title} 4.22::
+Before this update, the distributed tracing plugin was built against older module versions, causing version mismatch warnings on {ocp-product-title} 4.22. As a consequence, users experienced multiple `Unsatisfied version` warnings in the browser console due to version discrepancies between the plugin and console. 
++
+With this release, the distributed tracing plugin has been rebuilt against {ocp-product-title} 4.22 shared module versions. As a result, the plugin is updated to eliminate the warnings, ensuring compatibility.
++
+link:https://issues.redhat.com/browse/COO-1740[COO-1740]
+
+{coo-first} Go images aligned with FIPS requirements::
+Before this update, the build configuration for the {coo-short} Go images did not enable the cryptographic settings required for full compliance with FIPS standards. As a result, the admission webhook binaries failed validation.
++
+With this release, the build process enables the strict FIPS runtime and CGO compilation across all Operator components. These updates ensure that the binaries successfully pass payload validation requirements.
++
+link:https://issues.redhat.com/browse/COO-1739[COO-1739]
+
+Perses operator no longer panics when Perses instances are missing::
+Before this update, creating a `PersesDatasource` custom resource when no Perses instances were found caused the Operator to panic due to a nil pointer dereference during status reconciliation.
++
+With this release, the Operator status update logic safely sets the degraded status when instances are missing, which resolves the issue and ensures that the Operator continues running.
++
+link:https://issues.redhat.com/browse/COO-1735[COO-1735]
+
+[id="cluster-observability-operator-1-5-known-issues_{context}"]
+== Known issues
+
+Tempo fails to connect over HTTPS when the `ObservabilityInstaller` S3 endpoint lacks explicit TLS configuration::
+There is currently a known issue where Tempo connects to the object storage endpoint over plain HTTP even when an HTTPS URL is specified. This issue occurs when you create an `ObservabilityInstaller` custom resource (CR) with a `https://` S3 endpoint but do not provide an explicit tls configuration section, which causes the {coo-first} to disable storage TLS on the generated `TempoStack` CR. As a result, the connection to the S3 endpoint fails with an I/O timeout because the endpoint only accepts HTTPS connections.
++
+Workaround: You must add a `tls` section to the `ObservabilityInstaller` CR. You can specify either an empty configuration block (`tls: {}`) or a minimum version, such as `minVersion: "VersionTLS12"`. This forces COO to enable TLS on the `TempoStack` CR.
++
+link:https://issues.redhat.com/browse/COO-1749[COO-1749]
+
+Logging view plugin fails to render in {ocp-product-title} 4.22::
+There is currently a known issue where the logging view plugin included with {coo-first} 1.4 does not render correctly under {ocp-product-title} 4.22. This problem occurs because the web console PatternFly updates conflict with the specific plugin version deployed by the Operator.
++
+Workaround: Depending on your environment, perform one of the following tasks:
++
+* If you use {ocp-product-title} version 4.21 or earlier, upgrade to {coo-short} 1.5 before upgrading the cluster to version 4.22.
+* If you already use {ocp-product-title} version 4.22, upgrade to {coo-short} 1.5.
+
++
+link:https://issues.redhat.com/browse/OU-1395[OU-1395]
+
+[id="cluster-observability-operator-1-5-CVEs"]
+== CVEs
+
+* link:https://access.redhat.com/security/cve/cve-2026-42035[CVE-2026-42035]
+
+* link:https://access.redhat.com/security/cve/cve-2026-40895[CVE-2026-40895]
+
+* link:https://access.redhat.com/security/cve/cve-2026-32282[CVE-2026-32282]
+
+* link:https://access.redhat.com/security/cve/cve-2025-62718[CVE-2025-62718]

--- a/release-notes/cluster-observability-operator-release-notes.adoc
+++ b/release-notes/cluster-observability-operator-release-notes.adoc
@@ -9,22 +9,12 @@ toc::[]
 
 [role="_abstract"]
 Release notes for the {coo-first}, an optional {ocp-product-title} Operator that enables administrators to create standalone monitoring stacks that are independently configurable for use by different services and users.
-The {coo-short} complements the built-in monitoring capabilities of {ocp-product-title}. You can deploy it in parallel with the default platform and user workload monitoring stacks managed by the {cmo-first}.
 
-These release notes track the development of the {coo-full} in {ocp-product-title}.
-
-The following table provides information about which features are available depending on the version of {coo-full} and {ocp-product-title}:
-
-[cols="1,1,1,1,1,1,1", options="header"]
-|===
-| COO Version   | OCP Versions       | Distributed tracing   | Logging   | Troubleshooting panel | ACM alerts | Incident detection
-| 1.1+          | 4.12 - 4.14        | ✔                     | ✔         | ✘                     | ✘          | ✘
-| 1.1+          | 4.15               | ✔                     | ✔         | ✘                     | ✔          | ✘
-| 1.1+          | 4.16 - 4.18        | ✔                     | ✔         | ✘                     | ✔          | ✘
-| 1.2+          | 4.19+              | ✔                     | ✔         | ✔                     | ✔          | ✔
-|===
+include::modules/coo-features.adoc[leveloffset=+1]
 
 include::snippets/unified-perspective-web-console.adoc[]
+
+include::modules/coo-rel-notes-150.adoc[leveloffset=+1]
 
 include::modules/coo-rel-notes-140.adoc[leveloffset=+1]
 
@@ -63,5 +53,3 @@ include::modules/coo-rel-notes-012.adoc[leveloffset=+2]
 include::modules/coo-rel-notes-011.adoc[leveloffset=+2]
 
 include::modules/coo-rel-notes-010.adoc[leveloffset=+2]
-
-


### PR DESCRIPTION
Change type: Doc update; COO 1.5.0 GA Release Notes

Doc JIRA: https://redhat.atlassian.net/browse/OBSDOCS-3314

Also merge to: standalone-coo-docs-1-latest

Doc Preview: https://112877--ocpdocs-pr.netlify.app/openshift-coo/latest/release-notes/cluster-observability-operator-release-notes.html

SME/QE Review: @jgbernalp @PeterYurkovich 
Peer review: @shivanisathe25 