### PR TITLE
OCPBUGS-85374 Edit optional note

### DIFF
--- a/modules/nw-metallb-configure-secondary-interface.adoc
+++ b/modules/nw-metallb-configure-secondary-interface.adoc
@@ -64,3 +64,8 @@ $ oc apply -f enable-ip-forward.yaml
 ----
 $ oc patch network.operator cluster -p '{"spec":{"defaultNetwork":{"ovnKubernetesConfig":{"gatewayConfig":{"ipForwarding": "Global"}}}}}' --type=merge
 ----
++
+[NOTE]
+====
+Setting `ipForwarding` to `Global` sets `net.ipv4.conf.default.forwarding = 1`. All interfaces on the node inherit this, resulting in settings like `net.ipv4.conf.tun0.forwarding = 1`. This configuration also skips installing the default drop firewall rules, allowing the node to act as a router that forwards traffic between interfaces.
+====


### PR DESCRIPTION
Version(s): 4.15

Issue: https://redhat.atlassian.net/browse/OCPBUGS-85374

Backport of https://github.com/openshift/openshift-docs/pull/111710 to 4.15.

Adds a NOTE explaining `ipForwarding: Global` behavior after the `oc patch` command.

QE review:
- [x] QE has approved this change.