### PR TITLE
[OSDOCS#19987]: Remove outdated fips-mode-setup command

### DIFF
--- a/modules/creating-cluster-with-fips-encryption-cli.adoc
+++ b/modules/creating-cluster-with-fips-encryption-cli.adoc
@@ -7,7 +7,7 @@
 = Creating a {product-title} cluster using FIPS encryption in the CLI
 
 [role="_abstract"]
-You can create a {product-title} cluster with Federal Information Processing Standards (FIPS) encryption and a customer-provided KMS key using {rosa-cli-first}.
+You can create a {product-title} cluster with Federal Information Processing Standards (FIPS) encryption and a customer-provided Key Management Service (KMS) key by using {rosa-cli-first}.
 
 .Procedure
 
@@ -77,7 +77,6 @@ $ NODE=$(oc get nodes --no-headers | awk '$2=="Ready"{print $1; exit}')
 [source,terminal]
 ----
 $ oc debug node/${NODE} --to-namespace=default -- chroot /host bash -c 'set -x; \
-fips-mode-setup --check; \
 update-crypto-policies --show; \
 cat /etc/system-fips; \
 cat /proc/sys/crypto/fips_enabled; \
@@ -89,8 +88,6 @@ sysctl crypto.fips_enabled'
 ----
 Starting pod/ip-10-0-1-162us-east-2computeinternal-debug-86cnb ...
 To use host binaries, run `chroot /host`
-+ fips-mode-setup --check
-FIPS mode is enabled.
 + update-crypto-policies --show
 FIPS
 + cat /etc/system-fips


### PR DESCRIPTION
Version(s):
4.21+

Issue:
https://redhat.atlassian.net/browse/OSDOCS-19987
https://redhat.atlassian.net/browse/OCPBUGS-81557

Link to docs preview:
[Creating a Red Hat OpenShift Service on AWS cluster using FIPS encryption in the CLI](https://112885--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/rosa_hcp/rosa-hcp-creating-cluster-with-fips-encryption.html#creating-cluster-with-fips-encryption-cli_rosa-hcp-creating-cluster-with-fips-encryption)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
