### PR TITLE
CQA checks for Using Tekton Chains for OpenShift Pipelines supply chain security

### DIFF
--- a/modules/op-authenticating-to-an-oci-registry.adoc
+++ b/modules/op-authenticating-to-an-oci-registry.adoc
@@ -3,10 +3,10 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="authenticating-to-an-oci-registry_{context}"]
-= Authenticating to an OCI registry
+= Authenticate to an OCI registry
 
 [role="_abstract"]
-Set up a service account with the necessary credentials so that {tekton-chains} can push signatures to an OCI registry.
+Configure a service account with the necessary credentials to enable {tekton-chains} to push signatures to an OCI registry.
 
 The {tekton-chains} controller uses the same service account that starts task runs. To configure authentication with an OCI registry, create the required credentials and associate them with this service account.
 
@@ -69,3 +69,20 @@ spec:
 ----
 +
 `serviceAccountName`:: Substitute with the name of the newly created service account.
+
+.Verification
+
+* Verify that the service account has the registry secret:
++
+[source,bash]
+----
+$ oc describe serviceaccount $SERVICE_ACCOUNT_NAME -n $NAMESPACE
+----
++
+The output shows the registry secret in the `Secrets` or `Image pull secrets` list.
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:signing-secrets-in-tekton-chains_{context}[Secrets for signing data in {tekton-chains}]
+* xref:configuring-tekton-chains_{context}[Configuring {tekton-chains}]

--- a/modules/op-chains-generating-cosign-secret.adoc
+++ b/modules/op-chains-generating-cosign-secret.adoc
@@ -3,7 +3,7 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="chains-generating-cosign-secret_{context}"]
-= Generating the cosign key pair by using the TektonConfig CR
+= Generate the cosign key pair by using the TektonConfig CR
 
 [role="_abstract"]
 To use the `cosign` signing scheme for {tekton-chains} secrets, you can generate a `cosign` key pair that uses Elliptic Curve Digital Signature Algorithm (ECDSA) encryption by setting the `generateSigningSecret` field in the `TektonConfig` custom resource (CR) to `true`.
@@ -68,3 +68,26 @@ The {pipelines-title} Operator does not offer the following security functions:
 * Key rotation
 * Auditing key usage
 * Proper access control to the key
+
+.Verification
+
+* Verify that the signing secret is created:
++
+[source,bash]
+----
+$ oc get secret signing-secrets -n openshift-pipelines
+----
++
+.Example output
+[source,terminal]
+----
+NAME              TYPE     DATA   AGE
+signing-secrets   Opaque   3      5s
+----
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:signing-secrets-in-tekton-chains_{context}[Secrets for signing data in {tekton-chains}]
+* xref:chains-signing-secrets-cosign_{context}[Manually generating signing secrets with the cosign tool]
+* link:https://docs.sigstore.dev/cosign/key_management/overview/[Cosign key management documentation]

--- a/modules/op-chains-resolving-existing-secret.adoc
+++ b/modules/op-chains-resolving-existing-secret.adoc
@@ -4,18 +4,10 @@
 :_mod-docs-content-type: PROCEDURE
 
 [id="chains-resolving-existing-secret_{context}"]
-= Resolving the "secret already exists" error
+= Resolve the "secret already exists" error
 
 [role="_abstract"]
-If the `signing-secret` secret is already populated, the command to create this secret might output the following error message:
-
-.Example output
-[source,terminal]
-----
-Error from server (AlreadyExists): secrets "signing-secrets" already exists
-----
-
-You can resolve this error by deleting the secret.
+If the `signing-secret` secret is already populated, the command to create this secret returns an "AlreadyExists" error. You can resolve this error by deleting the existing secret.
 
 .Procedure
 
@@ -27,3 +19,25 @@ $ oc delete secret signing-secrets -n openshift-pipelines
 ----
 
 . Re-create the key pairs and store them in the secret using your preferred signing scheme.
+
+.Verification
+
+* Verify that the secret is deleted:
++
+[source,bash]
+----
+$ oc get secret signing-secrets -n openshift-pipelines
+----
++
+.Example output
+[source,terminal]
+----
+Error from server (NotFound): secrets "signing-secrets" not found
+----
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:signing-secrets-in-tekton-chains_{context}[Secrets for signing data in {tekton-chains}]
+* xref:chains-generating-cosign-secret_{context}[Generating the cosign key pair by using the `TektonConfig` CR]
+* xref:chains-signing-secrets-cosign_{context}[Manually generating signing secrets with the cosign tool]

--- a/modules/op-chains-signing-secrets-cosign.adoc
+++ b/modules/op-chains-signing-secrets-cosign.adoc
@@ -4,10 +4,10 @@
 :_mod-docs-content-type: PROCEDURE
 
 [id="chains-signing-secrets-cosign_{context}"]
-= Manually generating signing secrets with the cosign tool
+= Manually generate signing secrets with the cosign tool
 
 [role="_abstract"]
-You can use the `cosign` signing scheme with {tekton-chains} using the `cosign` tool.
+Manually generate cosign signing keys by using the `cosign` tool when you need custom encryption parameters or when you want to manage key generation outside the `TektonConfig` CR automated workflow.
 
 .Prerequisites
 
@@ -25,3 +25,26 @@ $ cosign generate-key-pair k8s://openshift-pipelines/signing-secrets
 Cosign prompts you for a password and then creates a Kubernetes secret.
 
 . Store the encrypted `cosign.key` private key and the `cosign.password` decryption password in the `signing-secrets` Kubernetes secret. Ensure that you store the private key as an encrypted Privacy Enhanced Mail (PEM) file of the `ENCRYPTED COSIGN PRIVATE KEY` type.
+
+.Verification
+
+* Verify that the signing secret is created:
++
+[source,bash]
+----
+$ oc get secret signing-secrets -n openshift-pipelines
+----
++
+.Example output
+[source,terminal]
+----
+NAME              TYPE     DATA   AGE
+signing-secrets   Opaque   3      10s
+----
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:signing-secrets-in-tekton-chains_{context}[Secrets for signing data in {tekton-chains}]
+* xref:chains-generating-cosign-secret_{context}[Generating the cosign key pair by using the `TektonConfig` CR]
+* link:https://docs.sigstore.dev/cosign/system_config/installation/[Cosign installation documentation]

--- a/modules/op-chains-signing-secrets-skopeo.adoc
+++ b/modules/op-chains-signing-secrets-skopeo.adoc
@@ -4,10 +4,10 @@
 :_mod-docs-content-type: PROCEDURE
 
 [id="chains-signing-secrets-skopeo_{context}"]
-= Manually generating signing secrets with the skopeo tool
+= Manually generate signing secrets with the Skopeo tool
 
 [role="_abstract"]
-You can generate keys by using the `skopeo` tool and use them in the `cosign` signing scheme with {tekton-chains}.
+Generate signing keys by using the `skopeo` tool when you already have Skopeo in your workflow or when you need GPG-based key generation for use with the cosign signing scheme in {tekton-chains}.
 
 .Prerequisites
 
@@ -83,3 +83,26 @@ type: Opaque
 `<Encoded <mykey>.private>`:: Replace with the content of the `b64.private` file.
 `<Encoded passphrase>`:: Replace with the content of the `b64.passphrase` file.
 `<Encoded <mykey>.pub>`:: Replace with the content of the `b64.pub` file.
+
+.Verification
+
+* Verify that the signing secret is created and has the required keys:
++
+[source,bash]
+----
+$ oc get secret signing-secrets -n openshift-pipelines -o jsonpath='{.data}' | grep -o 'cosign\.[a-z]*' | sort
+----
++
+.Example output
+[source,terminal]
+----
+cosign.key
+cosign.password
+cosign.pub
+----
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:signing-secrets-in-tekton-chains_{context}[Secrets for signing data in {tekton-chains}]
+* xref:chains-signing-secrets-cosign_{context}[Manually generating signing secrets with the cosign tool]

--- a/modules/op-configuring-tekton-chains.adoc
+++ b/modules/op-configuring-tekton-chains.adoc
@@ -3,7 +3,7 @@
 
 :_mod-docs-content-type: CONCEPT
 [id="configuring-tekton-chains_{context}"]
-= Configuring {tekton-chains}
+= {tekton-chains} configuration
 
 [role="_abstract"]
 The {pipelines-title} Operator installs {tekton-chains} by default. You can configure {tekton-chains} by modifying the `TektonConfig` custom resource; the Operator automatically applies the changes that you make in this custom resource.

--- a/modules/op-creating-and-verifying-task-run-signatures-without-any-additional-authentication.adoc
+++ b/modules/op-creating-and-verifying-task-run-signatures-without-any-additional-authentication.adoc
@@ -3,23 +3,16 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="creating-and-verifying-task-run-signatures-without-any-additional-authentication_{context}"]
-= Creating and verifying task run signatures without any additional authentication
+= Create and verify task run signatures without any additional authentication
 
 [role="_abstract"]
-To verify signatures of task runs by using {tekton-chains} with any additional authentication, perform the following tasks:
-
-* Generate an encrypted `x509` or `cosign` key pair and store it as a Kubernetes secret.
-* Configure the {tekton-chains} backend storage.
-* Create a task run, sign it, and store the signature and the payload as annotations on the task run itself.
-* Retrieve the signature and payload from the signed task run.
-* Verify the signature of the task run.
+Create and verify task run signatures using {tekton-chains} without additional authentication by generating encryption keys, configuring the backend storage, and validating the signed artifacts.
 
 .Prerequisites
-Ensure that you install the following components on the cluster:
 
-* {pipelines-title} Operator
-* {tekton-chains}
-* link:https://docs.sigstore.dev/cosign/system_config/installation/[Cosign]
+* {pipelines-title} Operator is installed on the cluster.
+* {tekton-chains} is installed and running.
+* link:https://docs.sigstore.dev/cosign/system_config/installation/[Cosign] is installed.
 
 .Procedure
 
@@ -110,3 +103,18 @@ $ cosign verify-blob-attestation --insecure-ignore-tlog --key path/to/cosign.pub
 ----
 Verified OK
 ----
+
+.Verification
+
+* Verify that the task run signature is successfully verified:
++
+The output displays `Verified OK` when the signature matches the public key and the attestation is valid.
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:signing-secrets-in-tekton-chains_{context}[Secrets for signing data in {tekton-chains}]
+* xref:configuring-tekton-chains_{context}[Configuring {tekton-chains}]
+* xref:supported-parameters-tekton-chains-configuration_{context}[Supported parameters for {tekton-chains} configuration]
+* link:https://docs.sigstore.dev/cosign/signing/overview/[Cosign documentation]
+* link:https://docs.sigstore.dev/logging/overview/[Rekor documentation]

--- a/modules/op-creating-mounting-kms-authentication-token-secret.adoc
+++ b/modules/op-creating-mounting-kms-authentication-token-secret.adoc
@@ -3,7 +3,7 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="creating-mounting-kms-authentication-token-secret_{context}"]
-= Creating and mounting the Key Management Service (KMS) authentication token secret
+= Create and mount the Key Management Service (KMS) authentication token secret
 
 [role="_abstract"]
 You can give the authentication token for the Key Management Service (KMS) server by using a secret. For example, if the KMS provider is Hashicorp Vault, the secret must contain the value of `VAULT_TOKEN`.
@@ -13,7 +13,7 @@ You must create this secret, mount it on the {tekton-chains} controller, and set
 .Prerequisites
 
 * You installed the {oc-first} utility.
-* Log in to your {OCP} cluster with administrative rights for the `openshift-pipelines` namespace.
+* You are logged in to your {OCP} cluster with administrative rights for the `openshift-pipelines` namespace.
 
 .Procedure
 
@@ -27,7 +27,7 @@ $ oc create secret generic kms-secrets -n tekton-chains \
 +
 `<path_and_name>`:: The full path and name of the file that has the authentication token for the KMS server, for example, `/home/user/KMS_AUTH_TOKEN`. You can use another file name instead of `KMS_AUTH_TOKEN`.
 
-. In the `TektonConfig` custom resource (CR), in the `chain` section, configure mounting the secret on the {tekton-chains} controller and set the `signers.kms.auth.token-path` parameter to the full path name of the authentication token file, as shown in the following example:
+. In the `TektonConfig` custom resource (CR), mount the secret on the {tekton-chains} controller within the `chain` section. Set the `signers.kms.auth.token-path` parameter to the full path name of the authentication token file, as shown in the following example:
 +
 .Example configuration for mounting the `kms-secrets` secret
 [source,yaml]
@@ -58,3 +58,20 @@ spec:
                     secretName: kms-secrets
 # ...
 ----
+
+.Verification
+
+* Verify that the secret is mounted on the controller:
++
+[source,bash]
+----
+$ oc get deployment tekton-chains-controller -n openshift-pipelines -o jsonpath='{.spec.template.spec.volumes[?(@.name=="kms-secrets")].secret.secretName}'
+----
++
+The output displays `kms-secrets` if the secret is correctly mounted.
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:configuring-tekton-chains_{context}[Configuring {tekton-chains}]
+* xref:supported-parameters-tekton-chains-configuration_{context}[Supported parameters for {tekton-chains} configuration]

--- a/modules/op-creating-mounting-mongo-server-url-secret.adoc
+++ b/modules/op-creating-mounting-mongo-server-url-secret.adoc
@@ -3,7 +3,7 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="creating-mounting-mongo-server-url-secret_{context}"]
-= Creating and mounting the Mongo server URL secret
+= Create and mount the Mongo server URL secret
 
 [role="_abstract"]
 You can give the value of the Mongo server URL to use for `docdb` storage (`MONGO_SERVER_URL`) using a secret. You must create this secret, mount it on the {tekton-chains} controller, and set the `storage.docdb.mongo-server-url-dir` parameter to the directory where you mount the secret.
@@ -25,7 +25,7 @@ $ oc create secret generic mongo-url -n tekton-chains \
 +
 `<path>`:: The full path and name of the `MONGO_SERVER_URL` file that has the Mongo server URL value.
 
-. In the `TektonConfig` custom resource (CR), in the `chain` section, configure mounting the secret on the {tekton-chains} controller and set the `storage.docdb.mongo-server-url-dir` parameter to the directory where you mount the secret, as shown in the following example:
+. In the `TektonConfig` custom resource (CR), mount the secret on the {tekton-chains} controller within the `chain` section. Set the `storage.docdb.mongo-server-url-dir` parameter to the directory where you mount the secret, as shown in the following example:
 +
 .Example configuration for mounting the `mongo-url` secret
 [source,yaml]
@@ -56,3 +56,21 @@ spec:
                     secretName: mongo-url
 # ...
 ----
+
+.Verification
+
+* Verify that the secret is mounted on the controller:
++
+[source,bash]
+----
+$ oc get deployment tekton-chains-controller -n openshift-pipelines -o jsonpath='{.spec.template.spec.volumes[?(@.name=="mongo-url")].secret.secretName}'
+----
++
+The output displays `mongo-url` if the secret is correctly mounted.
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:configuring-tekton-chains_{context}[Configuring {tekton-chains}]
+* xref:supported-parameters-tekton-chains-configuration_{context}[Supported parameters for {tekton-chains} configuration]
+* link:https://gocloud.dev/howto/docstore/[Go Cloud docstore documentation]

--- a/modules/op-enabling-tekton-chains-to-operate-only-in-selected-namespaces.adoc
+++ b/modules/op-enabling-tekton-chains-to-operate-only-in-selected-namespaces.adoc
@@ -3,7 +3,7 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="enabling-tekton-chains-to-operate-only-in-selected-namespaces_{context}"]
-= Enabling {tekton-chains} to operate only in selected namespaces
+= Enable {tekton-chains} to operate only in selected namespaces
 
 [role="_abstract"]
 By default, the {tekton-chains} controller monitors resources in all namespaces. You can customize {tekton-chains} to run only in specific namespaces, which provides granular control over its operation.
@@ -39,3 +39,20 @@ spec:
 ----
 +
 `--namespace`:: If you do not give the `--namespace` argument or leave it empty, the controller watches all namespaces by default.
+
+.Verification
+
+* Verify that the controller is configured to watch only the specified namespaces:
++
+[source,bash]
+----
+$ oc get deployment tekton-chains-controller -n openshift-pipelines -o jsonpath='{.spec.template.spec.containers[?(@.name=="tekton-chains-controller")].args}'
+----
++
+The output displays the `--namespace=` argument with the configured namespaces.
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:configuring-tekton-chains_{context}[Configuring {tekton-chains}]
+* xref:supported-parameters-tekton-chains-configuration_{context}[Supported parameters for {tekton-chains} configuration]

--- a/modules/op-using-tekton-chains-to-sign-and-verify-image-and-provenance.adoc
+++ b/modules/op-using-tekton-chains-to-sign-and-verify-image-and-provenance.adoc
@@ -3,25 +3,18 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="using-tekton-chains-to-sign-and-verify-image-and-provenance_{context}"]
-= Using {tekton-chains} to sign and verify image and provenance
+= Use {tekton-chains} to sign and verify image and provenance
 
 [role="_abstract"]
-Cluster administrators can use {tekton-chains} to sign and verify images and provenances, by performing the following tasks:
-
-* Generate an encrypted `x509` or `cosign` key pair and store it as a Kubernetes secret.
-* Set up authentication for the Open Container Initiative (OCI) registry to store images, image signatures, and signed image attestations.
-* Configure {tekton-chains} to generate and sign provenance.
-* Create an image with Kaniko in a task run.
-* Verify the signed image and the signed provenance.
+Sign and verify container images and their provenance by using {tekton-chains} to establish supply chain integrity and ensure artifacts originate from trusted pipeline runs.
 
 .Prerequisites
-Ensure that you install the following tools on the cluster:
 
-* {pipelines-title} Operator
-* {tekton-chains}
-* link:https://docs.sigstore.dev/cosign/system_config/installation/[Cosign]
-* link:https://docs.sigstore.dev/logging/installation/[Rekor]
-* link:https://stedolan.github.io/jq/[jq]
+* {pipelines-title} Operator is installed on the cluster.
+* {tekton-chains} is installed and running.
+* link:https://docs.sigstore.dev/cosign/system_config/installation/[Cosign] is installed.
+* link:https://docs.sigstore.dev/logging/installation/[Rekor] transparency log server is accessible.
+* link:https://stedolan.github.io/jq/[jq] command-line JSON processor is installed.
 
 .Procedure
 
@@ -29,7 +22,7 @@ Ensure that you install the following tools on the cluster:
 
 . Configure authentication for the image registry.
 
-.. To configure the {tekton-chains} controller for pushing signature to an OCI registry, use the credentials associated with the service account of the task run. For detailed information, see the "Authenticating to an OCI registry" section.
+.. To configure the {tekton-chains} controller for pushing signatures to an OCI registry, use the credentials associated with the service account of the task run. For detailed information, see "Authenticating to an OCI registry".
 
 .. To configure authentication for a Kaniko task that builds and pushes image to the registry, create a Kubernetes secret of the docker `config.json` file containing the required credentials.
 +
@@ -142,3 +135,18 @@ The search result displays universally unique identifiers (UUIDs) of the matchin
 ----
 $ rekor-cli get --uuid <uuid> --format json | jq -r .Attestation | base64 --decode | jq
 ----
+
+.Verification
+
+* Verify that the image signature and provenance are valid:
++
+The `cosign verify` command returns `Verified OK` when the signature is valid. The Rekor search returns one or more UUIDs that contain the provenance attestation for the signed image.
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:signing-secrets-in-tekton-chains_{context}[Secrets for signing data in {tekton-chains}]
+* xref:configuring-tekton-chains_{context}[Configuring {tekton-chains}]
+* xref:authenticating-to-an-oci-registry_{context}[Authenticating to an OCI registry]
+* link:https://docs.sigstore.dev/cosign/signing/overview/[Cosign documentation]
+* link:https://docs.sigstore.dev/logging/overview/[Rekor transparency log documentation]

--- a/secure/using-tekton-chains-for-openshift-pipelines-supply-chain-security.adoc
+++ b/secure/using-tekton-chains-for-openshift-pipelines-supply-chain-security.adoc
@@ -49,17 +49,10 @@ include::modules/op-authenticating-to-an-oci-registry.adoc[leveloffset=+1]
 
 include::modules/op-creating-and-verifying-task-run-signatures-without-any-additional-authentication.adoc[leveloffset=+1]
 
-[role="_additional-resources"]
-.Additional resources
-* xref:../secure/using-tekton-chains-for-openshift-pipelines-supply-chain-security.adoc#signing-secrets-in-tekton-chains_using-tekton-chains-for-openshift-pipelines-supply-chain-security[Secrets for signing data in {tekton-chains}]
-
-* xref:../secure/using-tekton-chains-for-openshift-pipelines-supply-chain-security.adoc#configuring-tekton-chains_using-tekton-chains-for-openshift-pipelines-supply-chain-security[Configuring {tekton-chains}]
-
 include::modules/op-using-tekton-chains-to-sign-and-verify-image-and-provenance.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources
-
 * xref:../secure/using-tekton-chains-for-openshift-pipelines-supply-chain-security.adoc#signing-secrets-in-tekton-chains_using-tekton-chains-for-openshift-pipelines-supply-chain-security[Secrets for signing data in {tekton-chains}]
-
+* xref:../secure/using-tekton-chains-for-openshift-pipelines-supply-chain-security.adoc#configuring-tekton-chains_using-tekton-chains-for-openshift-pipelines-supply-chain-security[Configuring {tekton-chains}]
 * xref:../install_config/installing-pipelines.adoc#installing-pipelines[Installing {pipelines-shortname}]


### PR DESCRIPTION
[RHDEVDOCS-7646](https://redhat.atlassian.net/browse/RHDEVDOCS-7646): CQA updates for the Using Tekton Chains for OpenShift Pipelines supply chain security chapter

The changes primarily include:
- Added Verification and Additional Resources section to procedures
- Updated to Titles (from gerund form to imperative or noun form as the case may be)

Version(s): 1.22, 1.21, 1.20

Issue: [RHDEVDOCS-7646](https://redhat.atlassian.net/browse/RHDEVDOCS-7646)

Link to docs preview: https://112887--ocpdocs-pr.netlify.app/openshift-pipelines/latest/secure/using-tekton-chains-for-openshift-pipelines-supply-chain-security.html

SME review:
- [x] SME has approved this change.

Additional information: N/A