### PR TITLE
OCPBUGS-61688: Fix env-overrides doc for OVN-Kubernetes log levels

### DIFF
--- a/modules/nw-ovn-kubernetes-change-log-levels.adoc
+++ b/modules/nw-ovn-kubernetes-change-log-levels.adoc
@@ -11,6 +11,11 @@ To debug OVN-Kubernetes in {product-title}, you can raise log levels by applying
 
 The default log level for OVN-Kubernetes is 4. To debug OVN-Kubernetes, set the log level to 5. Follow this procedure to increase the log level of the OVN-Kubernetes to help you debug an issue.
 
+[NOTE]
+====
+The `env-overrides` config map applies only to `ovnkube-node` pods. Each key in the config map must be an exact node name from the `oc get nodes` output. The `ovnkube-control-plane` pods are not affected by this config map.
+====
+
 .Prerequisites
 
 * You have access to the cluster with `cluster-admin` privileges.
@@ -39,6 +44,13 @@ ovnkube-node-nsct4                       8/8     Running   0              146m  
 ovnkube-node-zrj9f                       8/8     Running   0              134m   10.0.128.3   ci-ln-3njdr9b-72292-5nwkp-worker-b-v78h7   <none>           <none>
 ----
 
+. Identify the node names by running the following command:
++
+[source,terminal]
+----
+$ oc get nodes -o custom-columns=NAME:.metadata.name
+----
+
 . Create a `ConfigMap` file similar to the following example and use a filename such as `env-overrides.yaml`:
 +
 [source,yaml]
@@ -50,26 +62,17 @@ metadata:
   name: env-overrides
   namespace: openshift-ovn-kubernetes
 data:
-  ci-ln-3njdr9b-72292-5nwkp-master-0: |
-    # This sets the log level for the ovn-kubernetes node process:
+  <node_name_1>: |
     OVN_KUBE_LOG_LEVEL=5
-    # You might also/instead want to enable debug logging for ovn-controller:
     OVN_LOG_LEVEL=dbg
-  ci-ln-3njdr9b-72292-5nwkp-master-2: |
-    # This sets the log level for the ovn-kubernetes node process:
+  <node_name_2>: |
     OVN_KUBE_LOG_LEVEL=5
-    # You might also/instead want to enable debug logging for ovn-controller:
-    OVN_LOG_LEVEL=dbg
-  _master: |
-    # This sets the log level for the ovn-kubernetes master process as well as the ovn-dbchecker:
-    OVN_KUBE_LOG_LEVEL=5
-    # You might also/instead want to enable debug logging for northd, nbdb and sbdb on all masters:
     OVN_LOG_LEVEL=dbg
 ----
 +
-where::
-`ci-ln-3njdr9b-72292-5nwkp-master-0:`:: Specifies the name of the node you want to set the debug log level on.
-`_master:`:: Specifies `_master` to set the log levels of `ovnkube-master` components.
+`<node_name_1>`, `<node_name_2>`:: Replace with the exact node names from the `oc get nodes` output. You can specify one or more nodes.
+`OVN_KUBE_LOG_LEVEL`:: Sets the log level for the `ovnkube-controller` process. The default value is `4`. Set to `5` for debug logging.
+`OVN_LOG_LEVEL`:: Sets the log level for `ovn-controller`, `northd`, `nbdb`, and `sbdb` processes. Set to `dbg` for debug logging.
 
 . Apply the `ConfigMap` file by using the following command:
 +
@@ -81,73 +84,59 @@ $ oc apply -n openshift-ovn-kubernetes -f env-overrides.yaml
 .Example output
 [source,terminal]
 ----
-configmap/env-overrides.yaml created
+configmap/env-overrides created
 ----
 
-. Restart the `ovnkube` pods to apply the new log level by using the following commands:
+. Restart the `ovnkube-node` pods on the affected nodes to apply the new log level by running the following command:
 +
 [source,terminal]
 ----
 $ oc delete pod -n openshift-ovn-kubernetes \
---field-selector spec.nodeName=ci-ln-3njdr9b-72292-5nwkp-master-0 -l app=ovnkube-node
+  --field-selector spec.nodeName=<node_name> -l app=ovnkube-node
 ----
 +
-[source,terminal]
-----
-$ oc delete pod -n openshift-ovn-kubernetes \
---field-selector spec.nodeName=ci-ln-3njdr9b-72292-5nwkp-master-2 -l app=ovnkube-node
-----
+Repeat this command for each node specified in the config map. Alternatively, to restart all `ovnkube-node` pods at once, run the following command:
 +
 [source,terminal]
 ----
 $ oc delete pod -n openshift-ovn-kubernetes -l app=ovnkube-node
 ----
 
-. To verify that the `ConfigMap`file has been applied to all nodes for a specific pod, run the following command:
+. To verify that the log level has been applied for a specific node, run the following command:
 +
 [source,terminal]
 ----
-$ oc logs -n openshift-ovn-kubernetes --all-containers --prefix ovnkube-node-<xxxx> | grep -E -m 10 '(Logging config:|vconsole|DBG)'
+$ oc logs -n openshift-ovn-kubernetes --all-containers --prefix \
+  $(oc get pods -n openshift-ovn-kubernetes -l app=ovnkube-node \
+  --field-selector spec.nodeName=<node_name> \
+  -o jsonpath='{.items[0].metadata.name}') \
+  | grep -E -m 10 '(Logging config:|vconsole|DBG)'
 ----
 +
-where:
-`<XXXX>`:: Specifies the random sequence of letters for a pod from the previous step.
-+
-.Example output
-[source,terminal]
-----
-[pod/ovnkube-node-2cpjc/sbdb] + exec /usr/share/ovn/scripts/ovn-ctl --no-monitor '--ovn-sb-log=-vconsole:info -vfile:off -vPATTERN:console:%D{%Y-%m-%dT%H:%M:%S.###Z}|%05N|%c%T|%p|%m' run_sb_ovsdb
-[pod/ovnkube-node-2cpjc/ovnkube-controller] I1012 14:39:59.984506   35767 config.go:2247] Logging config: {File: CNIFile:/var/log/ovn-kubernetes/ovn-k8s-cni-overlay.log LibovsdbFile:/var/log/ovnkube/libovsdb.log Level:5 LogFileMaxSize:100 LogFileMaxBackups:5 LogFileMaxAge:0 ACLLoggingRateLimit:20}
-[pod/ovnkube-node-2cpjc/northd] + exec ovn-northd --no-chdir -vconsole:info -vfile:off '-vPATTERN:console:%D{%Y-%m-%dT%H:%M:%S.###Z}|%05N|%c%T|%p|%m' --pidfile /var/run/ovn/ovn-northd.pid --n-threads=1
-[pod/ovnkube-node-2cpjc/nbdb] + exec /usr/share/ovn/scripts/ovn-ctl --no-monitor '--ovn-nb-log=-vconsole:info -vfile:off -vPATTERN:console:%D{%Y-%m-%dT%H:%M:%S.###Z}|%05N|%c%T|%p|%m' run_nb_ovsdb
-[pod/ovnkube-node-2cpjc/ovn-controller] 2023-10-12T14:39:54.552Z|00002|hmap|DBG|lib/shash.c:114: 1 bucket with 6+ nodes, including 1 bucket with 6 nodes (32 nodes total across 32 buckets)
-[pod/ovnkube-node-2cpjc/ovn-controller] 2023-10-12T14:39:54.553Z|00003|hmap|DBG|lib/shash.c:114: 1 bucket with 6+ nodes, including 1 bucket with 6 nodes (64 nodes total across 64 buckets)
-[pod/ovnkube-node-2cpjc/ovn-controller] 2023-10-12T14:39:54.553Z|00004|hmap|DBG|lib/shash.c:114: 1 bucket with 6+ nodes, including 1 bucket with 7 nodes (32 nodes total across 32 buckets)
-[pod/ovnkube-node-2cpjc/ovn-controller] 2023-10-12T14:39:54.553Z|00005|reconnect|DBG|unix:/var/run/openvswitch/db.sock: entering BACKOFF
-[pod/ovnkube-node-2cpjc/ovn-controller] 2023-10-12T14:39:54.553Z|00007|reconnect|DBG|unix:/var/run/openvswitch/db.sock: entering CONNECTING
-[pod/ovnkube-node-2cpjc/ovn-controller] 2023-10-12T14:39:54.553Z|00008|ovsdb_cs|DBG|unix:/var/run/openvswitch/db.sock: SERVER_SCHEMA_REQUESTED -> SERVER_SCHEMA_REQUESTED at lib/ovsdb-cs.c:423
-----
+Replace `<node_name>` with the name of a node where you applied the override.
 
-. Optional: Check the `ConfigMap` file has been applied by running the following command:
+. Optional: Verify the log level across all `ovnkube-node` pods by running the following command:
 +
 [source,terminal]
 ----
-for f in $(oc -n openshift-ovn-kubernetes get po -l 'app=ovnkube-node' --no-headers -o custom-columns=N:.metadata.name) ; do echo "---- $f ----" ; oc -n openshift-ovn-kubernetes exec -c ovnkube-controller $f --  pgrep -a -f  init-ovnkube-controller | grep -P -o '^.*loglevel\s+\d' ; done
+$ for f in $(oc -n openshift-ovn-kubernetes get po -l 'app=ovnkube-node' \
+  --no-headers -o custom-columns=N:.metadata.name); do \
+  echo "---- $f ----" ; \
+  oc -n openshift-ovn-kubernetes exec -c ovnkube-controller $f -- \
+  pgrep -a -f init-ovnkube-controller \
+  | grep -P -o '^.*loglevel\s+\d' ; done
 ----
 +
-.Example output
+Nodes with the override applied show `--loglevel 5`. Nodes without the override show the default `--loglevel 4`.
+
+. To remove the debug log level, delete the config map and restart the pods:
++
 [source,terminal]
 ----
----- ovnkube-node-2dt57 ----
-60981 /usr/bin/ovnkube --init-ovnkube-controller xpst8-worker-c-vmh5n.c.openshift-qe.internal --init-node xpst8-worker-c-vmh5n.c.openshift-qe.internal --config-file=/run/ovnkube-config/ovnkube.conf --ovn-empty-lb-events --loglevel 4
----- ovnkube-node-4zznh ----
-178034 /usr/bin/ovnkube --init-ovnkube-controller xpst8-master-2.c.openshift-qe.internal --init-node xpst8-master-2.c.openshift-qe.internal --config-file=/run/ovnkube-config/ovnkube.conf --ovn-empty-lb-events --loglevel 4
----- ovnkube-node-548sx ----
-77499 /usr/bin/ovnkube --init-ovnkube-controller xpst8-worker-a-fjtnb.c.openshift-qe.internal --init-node xpst8-worker-a-fjtnb.c.openshift-qe.internal --config-file=/run/ovnkube-config/ovnkube.conf --ovn-empty-lb-events --loglevel 4
----- ovnkube-node-6btrf ----
-73781 /usr/bin/ovnkube --init-ovnkube-controller xpst8-worker-b-p8rww.c.openshift-qe.internal --init-node xpst8-worker-b-p8rww.c.openshift-qe.internal --config-file=/run/ovnkube-config/ovnkube.conf --ovn-empty-lb-events --loglevel 4
----- ovnkube-node-fkc9r ----
-130707 /usr/bin/ovnkube --init-ovnkube-controller xpst8-master-0.c.openshift-qe.internal --init-node xpst8-master-0.c.openshift-qe.internal --config-file=/run/ovnkube-config/ovnkube.conf --ovn-empty-lb-events --loglevel 5
----- ovnkube-node-tk9l4 ----
-181328 /usr/bin/ovnkube --init-ovnkube-controller xpst8-master-1.c.openshift-qe.internal --init-node xpst8-master-1.c.openshift-qe.internal --config-file=/run/ovnkube-config/ovnkube.conf --ovn-empty-lb-events --loglevel 4
+$ oc delete configmap env-overrides -n openshift-ovn-kubernetes
+----
++
+[source,terminal]
+----
+$ oc delete pod -n openshift-ovn-kubernetes -l app=ovnkube-node
 ----


### PR DESCRIPTION
## Summary

- Remove the `_master` key from the `env-overrides` ConfigMap example. The `_master` key has no effect since the `ovnkube-master` deployment was replaced by `ovnkube-control-plane` in OCP 4.14+. No code in `ovnkube-lib.sh` or any container startup script checks for a `_master` key.
- Clarify that `env-overrides` applies only to `ovnkube-node` pods. Each key must be an exact node name from `oc get nodes`.
- Note that `ovnkube-control-plane` pods are not affected by this ConfigMap.
- Fix the example output (`configmap/env-overrides.yaml created` changed to `configmap/env-overrides created`).
- Improve verification commands to target specific nodes.
- Add a cleanup step to remove the override and restore default log levels.

## Root cause

The `ovnkube-lib.sh` script sources `/env/${K8S_NODE}` where `K8S_NODE` is set to `spec.nodeName` via the downward API. Only files matching exact node names are read. The `_master` key was likely intended for the old `ovnkube-master` deployment which no longer exists. The `ovnkube-control-plane` deployment does not source `ovnkube-lib.sh` at all, so the `/env` volume mount in that deployment is unused.

## Test plan

- [ ] Verify the procedure works with exact node names on OVN-Kubernetes clusters
- [ ] Confirm `ovnkube-node` pods pick up the override after restart
- [ ] Confirm `ovnkube-control-plane` pods are unaffected (expected)