### PR TITLE
OCPBUGS-87810: Updated the note in Configuring the cluster-wide proxy

### DIFF
--- a/networking/configuring_network_settings/enable-cluster-wide-proxy.adoc
+++ b/networking/configuring_network_settings/enable-cluster-wide-proxy.adoc
@@ -57,7 +57,7 @@ where:
 
 [IMPORTANT]
 ====
-If your installation type does not include setting the `networking.machineNetwork[].cidr` field, you must include the machine IP addresses manually in the `.status.noProxy` field to make sure that the traffic between nodes can bypass the proxy.
+If node IP addresses fall outside the specified `networking.machineNetwork[].cidr` range, you must add the IP addresses to the `noProxy` field. This configuration ensures that traffic between nodes can bypass the proxy.
 ====
 
 [id="prerequisites_cluster-wide-proxy"]


### PR DESCRIPTION
Version(s):
4.16+

Issue:
[OCPBUGS-87810](https://redhat.atlassian.net/browse/OCPBUGS-87810)

Link to docs preview:

* https://112900--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/configuring_network_settings/enable-cluster-wide-proxy

- [x] SME has approved this change (Simone Massimo Zucchi).
- [x] QE has approved this change (Melvin Joseph).

https://github.com/openshift/openshift-docs/pull/87909
