### PR TITLE
Updating contrib guidelines for not changing IDs and file names, and …

### DIFF
--- a/contributing_to_docs/doc_guidelines.adoc
+++ b/contributing_to_docs/doc_guidelines.adoc
@@ -201,9 +201,15 @@ endif::[]
 When backporting content that contains IBM-related attributes to `enterprise-4.13` and earlier branches, you might need to create manual cherry picks because IBM-related attributes names are not consistent with later release branches.
 ====
 
+[id="assembly-module-file-names"]
 == Assembly/module file names
 
 Try to shorten the file name as much as possible _without_ abbreviating important terms that may cause confusion. For example, the `managing-authorization-policies.adoc` file name would be appropriate for an assembly titled "Managing Authorization Policies".
+
+[IMPORTANT]
+====
+Do not unnecessarily rename assembly or module files or change anchor IDs in existing content. Bookmarks, external links, and cross-references on the Customer Portal depend on stable file paths and anchor IDs, and changing them can break those links. The ToolX team will not provide redirects for renamed files or changed IDs.
+====
 
 == Directory names
 
@@ -268,6 +274,11 @@ Try to be as descriptive as possible with the title or section headings without 
 * Managing
 * Using
 
+[NOTE]
+====
+Although CCS is switching to using imperatives instead of gerunds for headings, do not start using imperatives yet. We will make this switch when we start implementing jobs-to-be-done (JTBD) changes, so that our users experience as smooth of a transition as possible.
+====
+
 Do not use "Overview" as a heading.
 
 Do not use backticks or other markup in assembly or module headings.
@@ -280,6 +291,11 @@ Level 0 headings map to an H1 or `<h1>` in HTML.
 Do not use Level 2 (H3) headings (`===`) or lower in any files.
 
 === Anchoring titles and section headings
+
+[IMPORTANT]
+====
+Do not unnecessarily rename anchor IDs in existing content. Bookmarks, external links, and cross-references on the Customer Portal depend on stable anchor IDs, and changing them can break those links. The ToolX team will not provide redirects for renamed files or changed IDs. Also see xref:assembly-module-file-names[Assembly/module file names] for guidance on avoiding unnecessary file renames.
+====
 
 All titles and section headings must have an anchor ID. The anchor ID must be similar to the title or section heading. Do not include line spaces between the anchor ID and the section title.
 
@@ -431,7 +447,7 @@ link:https://redhat-documentation.github.io/modular-docs/#creating-concept-modul
 == Writing procedures
 A _procedure_ contains the steps that users follow to complete a single process or task. Procedures contain ordered steps and explicit commands. In most cases, create your procedures as individual modules and include them in appropriate assemblies.
 
-Use a gerund in the procedure title, such as "Creating".
+Use a gerund in the procedure title, such as "Creating". Do not use imperatives for headings yet; we will switch to using imperatives for headings when we start implementing jobs-to-be-done (JTBD) changes
 
 [IMPORTANT]
 ====


### PR DESCRIPTION
…not using imperatives in headings yet

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
main only

Issue:
N/A

Link to docs preview:
Sections updated:
- https://github.com/bergerhoffer/openshift-docs/blob/cfe3dafaefdd8aa1215cde00e1e47a97ab196d3e/contributing_to_docs/doc_guidelines.adoc#assembly-module-file-names
- https://github.com/bergerhoffer/openshift-docs/blob/cfe3dafaefdd8aa1215cde00e1e47a97ab196d3e/contributing_to_docs/doc_guidelines.adoc#assemblymodule-titles-and-section-headings
- https://github.com/bergerhoffer/openshift-docs/blob/cfe3dafaefdd8aa1215cde00e1e47a97ab196d3e/contributing_to_docs/doc_guidelines.adoc#anchoring-titles-and-section-headings
- https://github.com/bergerhoffer/openshift-docs/blob/cfe3dafaefdd8aa1215cde00e1e47a97ab196d3e/contributing_to_docs/doc_guidelines.adoc#writing-procedures

QE review:
N/A

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
