### PR TITLE
TRACING-6089: Add MCOA OpenTelemetry trace collection docs

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -3315,6 +3315,8 @@ Topics:
   Topics:
   - Name: About the Red Hat build of OpenTelemetry
     File: otel-architecture
+  - Name: Collecting traces from multiple clusters with the multicluster observability addon
+    File: otel-config-multicluster-addon
 - Name: Network Observability
   Dir: network_observability
   Distros: openshift-enterprise,openshift-origin

--- a/modules/otel-mcoa-about.adoc
+++ b/modules/otel-mcoa-about.adoc
@@ -1,0 +1,25 @@
+// Module included in the following assemblies:
+//
+//  observability/otel/otel-config-multicluster-addon.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="otel-mcoa-about_{context}"]
+= About the multicluster observability addon for traces
+
+[role="_abstract"]
+The multicluster observability addon (MCOA) is a pluggable addon for {rh-rhacm-first} that automates the collection and forwarding of observability signals from managed clusters to central stores. MCOA is built on the link:https://github.com/open-cluster-management-io/addon-framework[Open Cluster Management addon framework]. For traces, MCOA installs the {OTELOperator} on each managed (spoke) cluster and configures an `OpenTelemetryCollector` instance that forwards traces to a central store.
+
+You manage the trace collection configuration from the hub cluster. MCOA uses resources that you create on the hub cluster as templates, and then renders and deploys the corresponding resources to the managed clusters automatically.
+
+MCOA manages the following trace-related signals:
+
+Collector:: MCOA deploys an `OpenTelemetryCollector` custom resource (CR) on each managed cluster. The collector receives traces from workloads and forwards them to the configured central store.
+
+Auto-instrumentation:: Optionally, MCOA deploys an `Instrumentation` CR on each managed cluster. The `Instrumentation` CR enables automatic instrumentation of application workloads so that they emit traces to the local collector.
+
+The addon manager on the hub cluster builds the manifests that are deployed to the managed clusters. The addon installs automatically on a managed cluster when the resources referenced in the `ClusterManagementAddOn` resource are created and the cluster matches the configured placement.
+
+[NOTE]
+====
+MCOA also supports metrics and logs collection in addition to traces. This documentation describes the trace collection workflow that uses the {OTELName}.
+====

--- a/modules/otel-mcoa-architecture.adoc
+++ b/modules/otel-mcoa-architecture.adoc
@@ -1,0 +1,37 @@
+// Module included in the following assemblies:
+//
+//  observability/otel/otel-config-multicluster-addon.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="otel-mcoa-architecture_{context}"]
+= Trace collection architecture
+
+[role="_abstract"]
+When you enable trace collection, the multicluster observability addon (MCOA) renders trace resources from the hub cluster to each managed cluster. Understanding the resources and namespaces that MCOA creates on the managed clusters helps you configure and troubleshoot trace forwarding.
+
+On each managed cluster, MCOA creates the following resources:
+
+* A `Subscription` and `OperatorGroup` that install the {OTELOperator} in the `openshift-opentelemetry-operator` namespace from the `redhat-operators` catalog source.
+* An `OpenTelemetryCollector` CR named `mcoa-instance` in the `mcoa-opentelemetry` namespace.
+* An optional `Instrumentation` CR named `mcoa-instance` in the `mcoa-opentelemetry` namespace, when auto-instrumentation is enabled.
+* Any `Secret` resources that the collector exporters reference for authentication, copied from the hub cluster.
+
+The following table lists the namespaces that MCOA uses on each managed cluster.
+
+.Namespaces created by MCOA for traces
+[options="header"]
+|===
+|Namespace |Purpose
+
+|`openshift-opentelemetry-operator`
+|Contains the {OTELOperator} subscription and operator group.
+
+|`mcoa-opentelemetry`
+|Contains the `OpenTelemetryCollector` and `Instrumentation` instances and any referenced secrets.
+|===
+
+The trace data flows through the following path:
+
+. Application workloads on the managed cluster emit traces. If auto-instrumentation is enabled, the `Instrumentation` CR injects the configuration that points workloads to the local collector.
+. The `OpenTelemetryCollector` instance on the managed cluster receives traces through its configured receivers, such as the OTLP and Jaeger receivers.
+. The collector forwards traces to the central store through its configured exporter. The default template uses an OTLP exporter that is secured with mutual TLS (mTLS) authentication.

--- a/modules/otel-mcoa-collector.adoc
+++ b/modules/otel-mcoa-collector.adoc
@@ -1,0 +1,81 @@
+// Module included in the following assemblies:
+//
+//  observability/otel/otel-config-multicluster-addon.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="otel-mcoa-collector_{context}"]
+= Configuring the trace collector template
+
+[role="_abstract"]
+The multicluster observability addon (MCOA) uses an `OpenTelemetryCollector` custom resource (CR) on the hub cluster as a template for the collector that it deploys to managed clusters. You create this template in the `open-cluster-management-observability` namespace and reference it from the `ClusterManagementAddOn` resource. Edit the template to define how the collector receives traces and where it forwards them.
+
+.Prerequisites
+
+* You have enabled trace collection with MCOA.
+* You have access to the hub cluster as a user with the `cluster-admin` role.
+
+.Procedure
+
+. Create an `OpenTelemetryCollector` CR named `instance` in the `open-cluster-management-observability` namespace on the hub cluster:
++
+[source,yaml]
+----
+apiVersion: opentelemetry.io/v1beta1
+kind: OpenTelemetryCollector
+metadata:
+  name: instance
+  namespace: open-cluster-management-observability
+spec:
+  managementState: unmanaged
+  mode: deployment
+  config:
+    receivers: # <1>
+      otlp:
+        protocols:
+          grpc: {}
+          http: {}
+      jaeger:
+        protocols:
+          grpc: {}
+    processors: {}
+    exporters: # <2>
+      otlp:
+        endpoint: <central_store_endpoint> # <3>
+        headers:
+          x-scope-orgid: <tenant> # <4>
+        tls:
+          insecure: false
+          ca_file: /tracing-otlp-auth/ca-bundle.crt
+          cert_file: /tracing-otlp-auth/tls.crt
+          key_file: /tracing-otlp-auth/tls.key
+      debug: {}
+    service:
+      pipelines:
+        traces:
+          receivers:
+            - otlp
+            - jaeger
+          processors: []
+          exporters:
+            - otlp
+            - debug
+  volumeMounts: # <5>
+    - name: tracing-otlp-auth
+      mountPath: /tracing-otlp-auth
+  volumes:
+    - name: tracing-otlp-auth
+      secret:
+        secretName: tracing-otlp-auth
+----
+<1> Receivers define how the collector ingests traces. The example enables the OTLP and Jaeger receivers.
+<2> Exporters define where the collector sends traces. The example uses an OTLP exporter secured with mutual TLS (mTLS).
+<3> Replace `<central_store_endpoint>` with the endpoint of your central trace store.
+<4> Optional: Set a tenant header, such as the cluster name, for multitenant stores.
+<5> The collector mounts the authentication secret as a volume. MCOA detects which secrets the exporters reference through their `tls` file paths and copies those secrets to the managed clusters.
+
+. Add a reference to the collector template in the `ClusterManagementAddOn` resource. For more information, see the configuration reference.
+
+[NOTE]
+====
+MCOA inspects each exporter that defines a `tls` section and matches the `ca_file`, `cert_file`, or `key_file` paths against the collector volume mounts. When a match is found, MCOA copies the referenced secret from the hub cluster to the `mcoa-opentelemetry` namespace on each managed cluster. Ensure that the secret referenced by the volume exists on the hub cluster.
+====

--- a/modules/otel-mcoa-config-reference.adoc
+++ b/modules/otel-mcoa-config-reference.adoc
@@ -1,0 +1,82 @@
+// Module included in the following assemblies:
+//
+//  observability/otel/otel-config-multicluster-addon.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="otel-mcoa-config-reference_{context}"]
+= Trace configuration reference
+
+[role="_abstract"]
+The multicluster observability addon (MCOA) uses the `ClusterManagementAddOn` resource to determine which configuration resources to render to managed clusters. The `installStrategy` field associates a placement with a list of configuration references. Each reference identifies a resource on the hub cluster that MCOA uses as a template.
+
+The following example shows the trace-related configuration references in a `ClusterManagementAddOn` resource:
+
+[source,yaml]
+----
+apiVersion: addon.open-cluster-management.io/v1alpha1
+kind: ClusterManagementAddOn
+spec:
+  installStrategy:
+    type: Placements
+    placements:
+      - name: <placement_name> # <1>
+        namespace: open-cluster-management-global-set
+        configs:
+          - group: opentelemetry.io # <2>
+            resource: opentelemetrycollectors
+            name: instance
+            namespace: open-cluster-management-observability
+          - group: opentelemetry.io # <3>
+            resource: instrumentations
+            name: instance
+            namespace: open-cluster-management-observability
+----
+<1> The name of the placement that selects the managed clusters. Use `global` to select all clusters.
+<2> The reference to the `OpenTelemetryCollector` template that MCOA renders to managed clusters.
+<3> The reference to the `Instrumentation` template that MCOA renders to managed clusters when auto-instrumentation is enabled.
+
+The following table describes the trace configuration references.
+
+.Trace configuration references
+[options="header"]
+|===
+|Resource |API group |Default name |Description
+
+|`opentelemetrycollectors`
+|`opentelemetry.io`
+|`instance`
+|The `OpenTelemetryCollector` template that defines the collector deployed to managed clusters.
+
+|`instrumentations`
+|`opentelemetry.io`
+|`instance`
+|The `Instrumentation` template that defines auto-instrumentation deployed to managed clusters.
+|===
+
+The following table describes the resources that MCOA creates on each managed cluster for traces.
+
+.Resources created on managed clusters for traces
+[options="header"]
+|===
+|Resource |Namespace |Name |Description
+
+|`Subscription`
+|`openshift-opentelemetry-operator`
+|`opentelemetry-product`
+|Installs the {OTELOperator} from the `redhat-operators` catalog source on the `stable` channel.
+
+|`OperatorGroup`
+|`openshift-opentelemetry-operator`
+|`openshift-opentelemetry-operator`
+|Defines the operator group for the {OTELOperator}.
+
+|`OpenTelemetryCollector`
+|`mcoa-opentelemetry`
+|`mcoa-instance`
+|The rendered trace collector instance.
+
+|`Instrumentation`
+|`mcoa-opentelemetry`
+|`mcoa-instance`
+|The rendered auto-instrumentation instance, when enabled.
+|===

--- a/modules/otel-mcoa-enabling.adoc
+++ b/modules/otel-mcoa-enabling.adoc
@@ -1,0 +1,69 @@
+// Module included in the following assemblies:
+//
+//  observability/otel/otel-config-multicluster-addon.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="otel-mcoa-enabling_{context}"]
+= Enabling trace collection with the multicluster observability addon
+
+[role="_abstract"]
+You enable trace collection by configuring the `capabilities` field of the `MultiClusterObservability` custom resource (CR). When you enable the trace capability, the multicluster-observability-operator installs the multicluster observability addon (MCOA), which then deploys the {OTELOperator} and a trace collector to your managed clusters.
+
+.Prerequisites
+
+* You have installed {rh-rhacm-first}.
+* You have installed the multicluster-observability-operator and created a `MultiClusterObservability` resource.
+* You have access to the hub cluster as a user with the `cluster-admin` role.
+
+.Procedure
+
+. Edit the `MultiClusterObservability` CR to enable trace collection under the `userWorkloads` capability:
++
+[source,yaml]
+----
+apiVersion: observability.open-cluster-management.io/v1beta2
+kind: MultiClusterObservability
+metadata:
+  name: observability
+spec:
+  capabilities:
+    userWorkloads:
+      traces:
+        collection:
+          instrumentation:
+            enabled: true # <1>
+          openTelemetryCollector:
+            enabled: true # <2>
+  observabilityAddonSpec: {}
+  storageConfig:
+    metricObjectStorage:
+      name: thanos-object-storage
+      key: thanos.yaml
+----
+<1> Set to `true` to deploy an `Instrumentation` CR for automatic instrumentation of application workloads. Set to `false` if you do not need auto-instrumentation.
+<2> Set to `true` to deploy an `OpenTelemetryCollector` instance to managed clusters.
+
+. Apply the changes to the CR.
+
+.Verification
+
+* Verify that the `ClusterManagementAddOn` resource for MCOA exists on the hub cluster:
++
+[source,terminal]
+----
+$ oc get ClusterManagementAddOn multicluster-observability-addon
+----
+
+* After the addon installs on a managed cluster, verify that the {OTELOperator} subscription is created on that cluster:
++
+[source,terminal]
+----
+$ oc get subscription -n openshift-opentelemetry-operator
+----
+
+* Verify that the collector instance is created on the managed cluster:
++
+[source,terminal]
+----
+$ oc get opentelemetrycollector -n mcoa-opentelemetry
+----

--- a/modules/otel-mcoa-instrumentation.adoc
+++ b/modules/otel-mcoa-instrumentation.adoc
@@ -1,0 +1,59 @@
+// Module included in the following assemblies:
+//
+//  observability/otel/otel-config-multicluster-addon.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="otel-mcoa-instrumentation_{context}"]
+= Configuring auto-instrumentation
+
+[role="_abstract"]
+When you enable the instrumentation capability, the multicluster observability addon (MCOA) deploys an `Instrumentation` custom resource (CR) to managed clusters. The `Instrumentation` CR configures automatic instrumentation so that application workloads emit traces to the local trace collector without code changes. You define the instrumentation behavior in a template `Instrumentation` CR on the hub cluster.
+
+.Prerequisites
+
+* You have enabled trace collection and the instrumentation capability with MCOA.
+* You have configured the trace collector template.
+* You have access to the hub cluster as a user with the `cluster-admin` role.
+
+.Procedure
+
+. Create an `Instrumentation` CR named `instance` in the `open-cluster-management-observability` namespace on the hub cluster:
++
+[source,yaml]
+----
+apiVersion: opentelemetry.io/v1alpha1
+kind: Instrumentation
+metadata:
+  name: instance
+  namespace: open-cluster-management-observability
+spec:
+  exporter:
+    endpoint: http://mcoa-instance-collector.mcoa-opentelemetry.svc.cluster.local:4318 # <1>
+  sampler:
+    type: parentbased_traceidratio # <2>
+    argument: "0.25"
+  propagators: # <3>
+    - jaeger
+    - b3
+  python: # <4>
+    env:
+      - name: OTEL_LOG_LEVEL
+        value: "debug"
+      - name: OTEL_TRACES_EXPORTER
+        value: otlp
+      - name: OTEL_METRICS_EXPORTER
+        value: none
+----
+<1> The exporter endpoint points to the collector service that MCOA deploys on the managed cluster. The default collector instance is named `mcoa-instance` in the `mcoa-opentelemetry` namespace.
+<2> The sampler controls the proportion of traces that are sampled. The example samples 25% of traces by using the `parentbased_traceidratio` sampler.
+<3> Propagators define the trace context formats that instrumented workloads use.
+<4> Language-specific sections configure auto-instrumentation per runtime. The example sets environment variables for Python workloads. Add other language sections, such as `java`, `nodejs`, `dotnet`, or `go`, as needed.
+
+. Add a reference to the `Instrumentation` template in the `ClusterManagementAddOn` resource. For more information, see the configuration reference.
+
+. To instrument a workload, add the appropriate auto-instrumentation annotation to the workload pod template on the managed cluster. For example, to instrument a Python workload, add the following annotation:
++
+[source,yaml]
+----
+instrumentation.opentelemetry.io/inject-python: "true"
+----

--- a/observability/otel/otel-config-multicluster-addon.adoc
+++ b/observability/otel/otel-config-multicluster-addon.adoc
@@ -1,0 +1,27 @@
+:_mod-docs-content-type: ASSEMBLY
+include::_attributes/common-attributes.adoc[]
+[id="otel-config-multicluster-addon"]
+= Collecting traces from multiple clusters with the multicluster observability addon
+:context: otel-config-multicluster-addon
+
+toc::[]
+
+You can collect and forward traces from multiple managed clusters to a central store by using the multicluster observability addon (MCOA) in {rh-rhacm-first}. MCOA deploys the {OTELName} to your managed clusters and configures trace collection from a single hub cluster.
+
+include::modules/otel-mcoa-about.adoc[leveloffset=+1]
+
+include::modules/otel-mcoa-architecture.adoc[leveloffset=+1]
+
+include::modules/otel-mcoa-enabling.adoc[leveloffset=+1]
+
+include::modules/otel-mcoa-collector.adoc[leveloffset=+1]
+
+include::modules/otel-mcoa-instrumentation.adoc[leveloffset=+1]
+
+include::modules/otel-mcoa-config-reference.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+== Additional resources
+
+* link:https://github.com/stolostron/multicluster-observability-addon[multicluster-observability-addon repository]
+* link:https://docs.redhat.com/en/documentation/red_hat_build_of_opentelemetry/latest[{OTELName} documentation]


### PR DESCRIPTION
https://redhat.atlassian.net/browse/TRACING-6089

## Summary

Adds modular documentation for collecting traces from multiple clusters using the **multicluster observability addon (MCOA)**, which deploys the Red Hat build of OpenTelemetry to managed clusters and configures trace collection from the hub cluster.

Content is sourced from the [`stolostron/multicluster-observability-addon`](https://github.com/stolostron/multicluster-observability-addon) repository (README, `tracing` Helm chart, and tracing handler/manifests code).

## What's included

New assembly: `observability/otel/otel-config-multicluster-addon.adoc`

New modules:
| Module | Type |
|--------|------|
| `otel-mcoa-about` | Concept |
| `otel-mcoa-architecture` | Concept |
| `otel-mcoa-enabling` | Procedure |
| `otel-mcoa-collector` | Procedure |
| `otel-mcoa-instrumentation` | Procedure |
| `otel-mcoa-config-reference` | Reference |

Registered the assembly in `_topic_maps/_topic_map.yml` under **Observability → Red Hat build of OpenTelemetry**.

## Notes for reviewers

- MCOA is an RHACM feature; this currently lands in the OCP (`openshift-enterprise`) Observability book alongside the existing OTel content. If it should live in the RHACM observability book instead, let me know and I'll relocate it.
- `asciidoctor`/`vale` were not available locally; structure, include paths, and topic-map YAML were verified manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)