### PR TITLE
OCPBUGS-71292: Clarify custom image replacement in ownership IMPORTANT block

### DIFF
--- a/modules/coreos-layering-configuring.adoc
+++ b/modules/coreos-layering-configuring.adoc
@@ -14,7 +14,7 @@ To apply a custom layered image to your cluster, you must have the custom layere
 
 [IMPORTANT]
 ====
-As soon as you apply an out-of-cluster custom image to your cluster, you effectively _take ownership_ of your custom layered images and those nodes. {product-title} no longer automatically updates any node that uses the custom layered image. You become responsible for maintaining and updating your nodes as appropriate. If you roll back the custom layer, {product-title} resumes automatically updating the node. See the "Updating with a RHCOS custom layered image" for important information about updating nodes that use a custom layered image.
+As soon as you apply an out-of-cluster custom image to your cluster, you effectively _take ownership_ of your custom layered images and those nodes. {product-title} no longer automatically updates any node that uses the custom layered image. You become responsible for maintaining and updating your nodes as appropriate. When you apply a new custom layered image, the node uses only that new image. It does not retain customizations from your previous custom layered image. To keep earlier changes, you must include them again when building the new image. If you roll back the custom layer, {product-title} resumes automatically updating the node. See the "Updating with a RHCOS custom layered image" for important information about updating nodes that use a custom layered image.
 ====
 
 .Prerequisites


### PR DESCRIPTION
## Summary

- Updates the ownership IMPORTANT block in the out-of-cluster Image Mode procedure to clarify that applying a new custom layered image replaces the previous one on the node, that prior customizations are not retained, and that earlier changes must be included again when building the new image.

## Jira

https://redhat.atlassian.net/browse/OCPBUGS-71292

## Justification

The published docs warn that admins take ownership of nodes after applying a custom layered image, but they do not explain replacement semantics when a second custom image is applied. Without this clarification, admins may lose prior customizations unexpectedly. The updated IMPORTANT block now reads:

> As soon as you apply an out-of-cluster custom image to your cluster, you effectively take ownership of your custom layered images and those nodes. OpenShift Container Platform no longer automatically updates any node that uses the custom layered image. You become responsible for maintaining and updating your nodes as appropriate. When you apply a new custom layered image, the node uses only that new image. It does not retain customizations from your previous custom layered image. To keep earlier changes, you must include them again when building the new image. If you roll back the custom layer, OpenShift Container Platform resumes automatically updating the node. See the "Updating with a RHCOS custom layered image" for important information about updating nodes that use a custom layered image.

## Affected section

`modules/coreos-layering-configuring.adoc` — "Using Out-of-cluster image mode to apply a custom layered image"  
Anchor: `#coreos-layering-configuring_mco-coreos-layering`

## Branches

- [x] `main`

## Test plan

- [ ] Build or preview docs locally if tooling is available
- [ ] Verify the updated IMPORTANT block renders with the new replacement sentence
- [ ] Confirm anchor `#coreos-layering-configuring_mco-coreos-layering` is unchanged
- [ ] Spot-check rendered pages:
  - [OCP 4.19](https://docs.redhat.com/en/documentation/openshift_container_platform/4.19/html/machine_configuration/mco-coreos-layering#coreos-layering-configuring_mco-coreos-layering)
  - [OCP 4.20](https://docs.redhat.com/en/documentation/openshift_container_platform/4.20/html/machine_configuration/mco-coreos-layering#coreos-layering-configuring_mco-coreos-layering)