### PR TITLE
OCPBUGS-87862: Updated hcp-get-upgrade-versions.adoc for a more direc…

### DIFF
--- a/modules/hcp-get-upgrade-versions.adoc
+++ b/modules/hcp-get-upgrade-versions.adoc
@@ -19,20 +19,9 @@ To keep your hosted cluster fully operational during an update process, the cont
 
 The {mce} requires a specific {product-title} version for the management cluster to remain in a supported state. You can install the {mce-short} from the software catalog in the {product-title} web console.
 
-See the following support matrices for the {mce-short} versions:
+See the following support matrix for the {product-title} versions that {mce-short} supports:
 
-* link:https://access.redhat.com/articles/7120837[{mce-short} 2.9]
-* link:https://access.redhat.com/articles/7099674[{mce-short} 2.8]
-* link:https://access.redhat.com/articles/7086906[{mce-short} 2.7]
-* link:https://access.redhat.com/articles/7073030[{mce-short} 2.6]
-* link:https://access.redhat.com/articles/7056007[{mce-short} 2.5]
-* link:https://access.redhat.com/articles/7027079[{mce-short} 2.4]
-
-The {mce-short} supports the following {product-title} versions:
-
-* The latest unreleased version
-* The latest released version
-* Two versions before the latest released version
+* link:https://access.redhat.com/articles/7143552[{mce} Support Matrix - Index]
 
 You can also get the {mce-short} version as a part of {rh-rhacm-first}.
 


### PR DESCRIPTION
Version(s):
4.16+

Issue:
[OCPBUGS-87862](https://redhat.atlassian.net/browse/OCPBUGS-87862)

Link to docs preview:

* https://112919--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-updating.html#hcp-mce-hub-cluster_hcp-updating

- [x] SME has approved this change (Vincent Lours - Approval on Jira).
- [x] QE has approved this change (Martin Gencur).

https://docs.redhat.com/en/documentation/openshift_container_platform/4.21/html/hosted_control_planes/preparing-to-deploy-hosted-control-planes#hcp-matrix-updates_hcp-requirements
