### PR TITLE
Restore missing troubleshooting-cert-maintenance.adoc

### DIFF
--- a/post_installation_configuration/day_2_core_cnf_clusters/troubleshooting/troubleshooting-cert-maintenance.adoc
+++ b/post_installation_configuration/day_2_core_cnf_clusters/troubleshooting/troubleshooting-cert-maintenance.adoc
@@ -20,7 +20,7 @@ include::modules/troubleshooting-certs-manual-proxy.adoc[leveloffset=+2]
 [role="_additional-resources"]
 .Additional resources
 
-* xref:../../../security/certificate_types_descriptions/proxy-certificates.adoc#cert-types-proxy-certificates[Proxy certificates]
+* xref:../../../security/certificate_types_descriptions/proxy-certificates.adoc#proxy-certificates[Proxy certificates]
 
 include::modules/troubleshooting-certs-manual-user-provisioned.adoc[leveloffset=+2]
 


### PR DESCRIPTION
## Summary

This PR restores the accidentally deleted `troubleshooting-cert-maintenance.adoc` file that is causing portal build validation to fail for all PRs.

## Details

- The file was accidentally deleted in commit 418e3c4752
- The file is still referenced in `_topic_maps/_topic_map.yml`
- This is causing `build_for_portal.py` to fail with `FileNotFoundError` for all PRs
- Restored from commit 418e3c4752^ (the state before deletion)
- Also includes updated xref anchor to match current proxy-certificates assembly

## Impact

Without this fix, all PRs are failing portal build validation with:
```
FileNotFoundError: [Errno 2] No such file or directory: '.../troubleshooting-cert-maintenance.adoc'
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)