### PR TITLE
[NETOBSERV] 1.12 release integration branch

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -3347,6 +3347,8 @@ Topics:
     File: observing-network-traffic
   - Name: Network observability health rules
     File: network-observability-health-rules
+  - Name: Monitoring TLS traffic
+    File: network-observability-monitoring-tls-traffic
   - Name: Using metrics with dashboards and alerts
     File: metrics-alerts-dashboards
   - Name: Monitoring the Network Observability Operator

--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -3331,6 +3331,8 @@ Topics:
     File: network-observability-overview
   - Name: Installing the Network Observability Operator
     File: installing-operators
+  - Name: Scaling network flow collection with Kafka
+    File: network-observability-kafka-operator-scaling-network-flow-collection
   - Name: Understanding Network Observability Operator
     File: understanding-network-observability-operator
   - Name: Configuring the Network Observability Operator

--- a/modules/network-observability-analyze-tls-traffic.adoc
+++ b/modules/network-observability-analyze-tls-traffic.adoc
@@ -1,0 +1,69 @@
+// Module included in the following assemblies:
+//
+// * observability/network_observability/network-observability-monitoring-tls-traffic.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="network-observability-analyze-tls-traffic_{context}"]
+= Analyze Transport Layer Security traffic data
+
+[role="_abstract"]
+View and filter Transport Layer Security (TLS) metadata to identify deprecated configurations and verify encryption compliance in the cluster.
+
+.Prerequisites
+
+* The Network Observability Operator is installed.
+* TLS tracking is enabled in the `FlowCollector` custom resource (CR).
+* Access to the {product-title} web console.
+
+.Procedure
+
+. Navigate to *Observe* -> *Network Traffic* in the {product-title} web console and click the *Traffic flows* tab.
++
+[NOTE]
+====
+The *TLS Version* column is enabled by default. If the default TLS version column is not visible after enabling TLS tracking, click *Restore default columns* in *Manage columns* to refresh the table.
+====
+
+. Add TLS-specific columns to the traffic table:
+.. Click *Manage columns*.
+.. Select the *TLS Cipher Suite*, *TLS Group*, and *TLS Types* checkboxes.
+.. Click *Save*.
+
+. Filter traffic by message type to view complete TLS metadata:
+.. In the filter bar, select *TLS Types* and choose *ServerHello* from the dropdown menu.
++
+`ServerHello` messages contain negotiated TLS metadata such as cipher suite and cryptographic group information.
+
+. Filter traffic by TLS version to identify deprecated configurations:
+.. In the filter bar, select *TLS Version*.
+.. Select the versions you want to review:
+* *1.0*: Deprecated
+* *1.1*: Deprecated
+* *1.2*: Legacy
+* *1.3*: Current standard
++
+To identify all deprecated connections, filter for TLS versions 1.0 and 1.1.
+
+. Analyze TLS metrics in the overview panel:
+.. Click the *Overview* tab.
+.. Review the default TLS panels, which include *TLS usage (network flows per second)* and *TLS per version (network flows per second)*.
+.. Optional: To view additional TLS metrics, click *Manage panels* to select and display additional panels, such as *TLS per group (network flows per second)* or *TLS per cipher suite (network flows per second)*.
+
+. Identify secure connections in the *Topology* view:
+.. Click the *Topology* tab.
++
+Connections secured with TLS are marked with a lock icon. The color of the lock icon indicates the security level:
++
+* *Red*: Deprecated TLS versions (1.0 or 1.1)
+* *Yellow*: Legacy configurations (TLS 1.2)
+* *Green*: Secure connections (TLS 1.3)
+* *Blue*: Post-Quantum Cryptography (PQC) compliant
++
+Select a connection node to view its specific TLS version and cipher suite details.
+
+. View TLS metrics in the Network Observability dashboard:
+.. Navigate to *Observe* -> *Dashboards*.
+.. Search for *NetObserv* and review the available metrics:
+* *TLS Traffic*: Displays overall TLS traffic metrics.
+* *Flows rate per TLS version*: Displays traffic trends by TLS version over time.
+* *Flows rate per TLS group*: Displays traffic by TLS group over time.

--- a/modules/network-observability-configuring-kafka-compression.adoc
+++ b/modules/network-observability-configuring-kafka-compression.adoc
@@ -1,0 +1,65 @@
+// Module included in the following assemblies:
+//
+// * observability/network_observability/network-observability-kafka-operator-scaling-network-flow-collection.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="network-observability-configuring-kafka-compression_{context}"]
+= Configure Kafka compression
+
+[role="_abstract"]
+Configure the compression algorithm for network flow records exported to Kafka to optimize bandwidth and storage. This helps manage the data footprint of high-volume network telemetry.
+
+.Prerequisites
+
+* The Network Observability Operator is installed.
+* The `FlowCollector` custom resource (CR) is configured to export data to a Kafka topic.
+* You have `cluster-admin` permissions to edit the `FlowCollector` CR.
+
+.Procedure
+
+. Open the `FlowCollector` custom resource for editing by running the following command:
++
+[source,terminal]
+----
+$ oc edit flowcollector cluster
+----
+
+. Navigate to the `spec.kafka` section and add the `compression` parameter:
++
+[source,yaml]
+----
+apiVersion: flows.netobserv.io/v1beta2
+kind: FlowCollector
+metadata:
+  name: cluster
+spec:
+  deploymentModel: Kafka
+  kafka:
+    address: "kafka-cluster-kafka-bootstrap.netobserv:9093"
+    topic: "network-flows"
+    compression: "lz4"
+----
++
+where:
++
+`spec.kafka.compression`:: Specifies the compression algorithm. Accepted values: `gzip`, `snappy`, `lz4`, `zstd`, `none`. Default is `none`.
+
+. Save and apply the changes.
+
+.Verification
+
+. Confirm that the eBPF agent pods are running in the cluster by running the following command:
++
+[source,terminal]
+----
+$ oc get pods -A -l app=netobserv-ebpf-agent
+----
+
+. Verify that Kafka compression is active by running the following command:
++
+[source,terminal]
+----
+$ oc logs -n <namespace> <pod_name> | grep "KafkaCompression"
+----
++
+The output shows the compression configuration attribute in the eBPF agent pod logs.

--- a/modules/network-observability-custom-health-rule-configuration.adoc
+++ b/modules/network-observability-custom-health-rule-configuration.adoc
@@ -3,22 +3,27 @@
 // * network_observability/network-observability-alerts.adoc
 
 :_mod-docs-content-type: PROCEDURE
-[id="network-observability-custom-health-rule-configuration_{context}"]
-= Custom health rule configuration
+[id="network-observability-configuring-custom-health-rules_{context}"]
+= Configuring custom health rules
 
 [role="_abstract"]
-Use the Prometheus Query Language (`PromQL`) to define a custom `AlertingRule` resource to trigger alerts based on specific network metrics (e.g., traffic surges).
+Create custom health rules by using Prometheus Query Language (PromQL) to define an `AlertingRule` resource. These rules trigger alerts based on specific network metrics, such as traffic surges.
 
 .Prerequisites
 
-* Familiarity with `PromQL`.
-* You have installed {product-title} 4.16 or later.
-* You have access to the cluster as a user with the `cluster-admin` role.
-* You have installed the Network Observability Operator.
+* Access to the cluster with `cluster-admin` privileges.
+* The Network Observability Operator is installed.
+* {product-title} 4.16 or later is installed.
+* Familiarity with PromQL.
+
+[IMPORTANT]
+====
+Custom `PrometheusRule` resources are not owned by the `FlowCollector` resource. Custom rules created in the `netobserv` namespace might be deleted if the Network Observability Operator is uninstalled. To prevent data loss, create custom rules in a different namespace, such as `openshift-monitoring`, and maintain a backup in version control.
+====
 
 .Procedure
 
-. Create a YAML file named `custom-alert.yaml` that contains your `AlertingRule` resource.
+. Define an `AlertingRule` resource in a YAML file, for example, `custom-alert.yaml`.
 . Apply the custom alert rule by running the following command:
 +
 [source,terminal]
@@ -28,13 +33,13 @@ $ oc apply -f custom-alert.yaml
 
 .Verification
 
-. Verify that the `PrometheusRule` resource was created in the `netobserv` namespace by running the following command:
+. Confirm the `PrometheusRule` resource was created in the target namespace by running the following command:
 +
 [source,terminal]
 ----
-$ oc get prometheusrules -n netobserv -oyaml
+$ oc get prometheusrules -n <namespace> -o yaml
 ----
-+
-The output should include the `netobserv-alerts` rule you just created, confirming that the resource was generated correctly.
 
-. Confirm the rule is active by checking the *Network Health* dashboard in the {product-title} web console → *Observe*.
+. Confirm the rule is active in the {product-title} web console:
+.. Navigate to *Observe* → *Alerting* to see the firing status.
+.. Navigate to *Observe* → *Network Health* to view the dashboard integration.

--- a/modules/network-observability-disable-predefined-rules.adoc
+++ b/modules/network-observability-disable-predefined-rules.adoc
@@ -4,9 +4,11 @@
 
 :_mod-docs-content-type: REFERENCE
 [id="network-observability-disable-predefined-rules_{context}"]
-= Disable predefined rules
+= Disabling default rules
 
 [role="_abstract"]
 Rule templates can be disabled in the `spec.processor.metrics.disableAlerts` field of the `FlowCollector` custom resource (CR). This setting accepts a list of rule template names. For a list of alert template names, see "List of default rules".
 
-If a template is disabled and overridden in the `spec.processor.metrics.healthRules` field, the disable setting takes precedence and the alert rule is not created.
+If a rule template is included in the `disableAlerts` list, it is not created, even if a custom override exists in the `spec.processor.metrics.healthRules` field. The `disableAlerts` configuration takes precedence over all other health rule settings.
+
+For a list of alert template names, see "List of default rules".

--- a/modules/network-observability-enable-tls-tracking.adoc
+++ b/modules/network-observability-enable-tls-tracking.adoc
@@ -1,0 +1,84 @@
+// Module included in the following assemblies:
+//
+// * observability/network_observability/network-observability-monitoring-tls-traffic.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="network-observability-enable-tls-tracking_{context}"]
+= Enable Transport Layer Security tracking
+
+[role="_abstract"]
+Enable Transport Layer Security (TLS) tracking to monitor encryption protocols and identify security risks in the cluster.
+
+[NOTE]
+====
+TLS fields only appear in flows for connections that perform a TLS handshake after the feature is enabled.
+====
+
+.Prerequisites
+
+* The Network Observability Operator is installed.
+* The `FlowCollector` custom resource (CR) is configured with `spec.agent.type: eBPF`.
+* Access to the cluster with `cluster-admin` privileges.
+
+.Procedure
+
+. Edit the `FlowCollector` CR by running the following command:
++
+[source,terminal]
+----
+$ oc edit flowcollector cluster
+----
+
+. Add `TLSTracking` to the `spec.agent.ebpf.features` list:
++
+[source,yaml]
+----
+apiVersion: flows.netobserv.io/v1beta2
+kind: FlowCollector
+metadata:
+  name: cluster
+spec:
+  agent:
+    type: eBPF
+    ebpf:
+      features:
+      - TLSTracking
+# ...
+----
++
+where:
++
+`spec.agent.ebpf.features`:: Specifies the list of eBPF agent features to enable. Add `TLSTracking` to this array to enable TLS metadata capture from handshake messages.
+
+. Save and exit your editor.
+
+.Verification
+
+. Confirm that the eBPF agent pods have restarted by running the following command:
++
+[source,terminal]
+----
+$ oc get pods -n netobserv-privileged
+----
++
+.Example output
+[source,terminal]
+----
+NAME                                    READY   STATUS    RESTARTS   AGE
+netobserv-ebpf-agent-abc12              1/1     Running   0          2m
+----
+
+. Verify the TLS tracking feature is active by running the following command:
++
+[source,terminal]
+----
+$ oc logs -n netobserv-privileged ds/netobserv-ebpf-agent | grep "EnableTLSTracking"
+----
++
+.Example output
+[source,terminal]
+----
+EnableTLSTracking:true
+----
++
+The output confirms that the TLS tracking feature has been initialized in the eBPF agent.

--- a/modules/network-observability-flowcollector-api-specifications.adoc
+++ b/modules/network-observability-flowcollector-api-specifications.adoc
@@ -104,6 +104,10 @@ Kafka can provide better scalability, resiliency, and high availability (for mor
 
 `Direct` is not recommended on large clusters as it is less memory efficient.
 
+| `execution`
+| `object`
+| `execution` defines configuration related to the execution of the flow collection process.
+
 | `exporters`
 | `array`
 | `exporters` defines additional optional exporters for custom consumption or storage.
@@ -231,6 +235,8 @@ This feature requires mounting the kernel debug filesystem, so the eBPF agent po
 It requires using the OVN-Kubernetes network plugin with the Observability feature.  +
 
 - `IPSec`, to track flows between nodes with IPsec encryption.  +
+
+- `TLSTracking`, to track TLS usage.  +
 
 
 | `flowFilter`
@@ -1082,6 +1088,31 @@ otherwise to an implementation-defined value. Requests cannot exceed Limits.
 More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
 
 |===
+== .spec.execution
+Description::
++
+--
+`execution` defines configuration related to the execution of the flow collection process.
+--
+
+Type::
+  `object`
+
+
+
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `mode`
+| `string`
+| `mode` is the flow collection process execution desired mode: `Running` or `OnHold`.
+When `OnHold`, the operator deletes all managed services and workloads, with the exception
+of the static console plugin, and the operator itself.
+It allows to use minimal cluster resources without losing configuration.
+
+|===
 == .spec.exporters
 Description::
 +
@@ -1195,13 +1226,19 @@ Required::
 | `string`
 | Address of the Kafka server
 
+| `compression`
+| `string`
+| Compression codec to use when producing messages to Kafka.
+Accepted values are: `none` (default), `gzip`, `snappy`, `lz4`, `zstd`.
+
 | `sasl`
 | `object`
 | SASL authentication configuration. [Unsupported (*)].
 
 | `tls`
 | `object`
-| TLS client configuration. When using TLS, verify that the address matches the Kafka port used for TLS, generally 9093.
+| TLS and mTLS client configuration. When using TLS, verify that the address matches the Kafka port used for TLS, generally 9093.
+We recommend the use of mTLS for higher security standards.
 
 | `topic`
 | `string`
@@ -1312,7 +1349,8 @@ If the namespace is different, the config map or the secret is copied so that it
 Description::
 +
 --
-TLS client configuration. When using TLS, verify that the address matches the Kafka port used for TLS, generally 9093.
+TLS and mTLS client configuration. When using TLS, verify that the address matches the Kafka port used for TLS, generally 9093.
+We recommend the use of mTLS for higher security standards.
 --
 
 Type::
@@ -1706,13 +1744,19 @@ Required::
 | `string`
 | Address of the Kafka server
 
+| `compression`
+| `string`
+| Compression codec to use when producing messages to Kafka.
+Accepted values are: `none` (default), `gzip`, `snappy`, `lz4`, `zstd`.
+
 | `sasl`
 | `object`
 | SASL authentication configuration. [Unsupported (*)].
 
 | `tls`
 | `object`
-| TLS client configuration. When using TLS, verify that the address matches the Kafka port used for TLS, generally 9093.
+| TLS and mTLS client configuration. When using TLS, verify that the address matches the Kafka port used for TLS, generally 9093.
+We recommend the use of mTLS for higher security standards.
 
 | `topic`
 | `string`
@@ -1823,7 +1867,8 @@ If the namespace is different, the config map or the secret is copied so that it
 Description::
 +
 --
-TLS client configuration. When using TLS, verify that the address matches the Kafka port used for TLS, generally 9093.
+TLS and mTLS client configuration. When using TLS, verify that the address matches the Kafka port used for TLS, generally 9093.
+We recommend the use of mTLS for higher security standards.
 --
 
 Type::
@@ -2705,8 +2750,10 @@ configuration, you can disable it and install your own instead.
 | `boolean`
 | Deploys network policies on the namespaces used by Network Observability (main and privileged).
 These network policies better isolate the Network Observability components to prevent undesired connections from and to them.
-This option is enabled by default when using with OVNKubernetes, and disabled otherwise (it has not been tested with other CNIs).
-When disabled, you can manually create the network policies for the Network Observability components.
+Because it cannot be tested with all CNIs, this option is only enabled by default when Network Observability runs in a known
+supported environment, and it is disabled by default otherwise.
+When disabled, it is highly recommended to create network policies manually, to prevent undesired accesses.
+More information: https://github.com/netobserv/netobserv-operator/blob/main/docs/NetworkPolicy.md.
 
 |===
 == .spec.processor
@@ -2811,6 +2858,10 @@ Deprecation notice: use `spec.processor.consumerReplicas` instead.
 | `resources` are the compute resources required by this container.
 For more information, see https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
 
+| `service`
+| `object`
+| Service configuration, only used when `spec.deploymentModel` is `Service`.
+
 | `slicesConfig`
 | `object`
 | Global configuration managing FlowCollectorSlices custom resources.
@@ -2895,6 +2946,7 @@ By convention, some values are forbidden. It must be greater than 1024 and diffe
 | Defines secondary networks to be checked for resources identification.
 To guarantee a correct identification, indexed values must form an unique identifier across the cluster.
 If the same index is used by several resources, those resources might be incorrectly labeled.
+If not provided and `spec.agent.ebpf.privileged` is `true`, secondary networks are detected automatically.
 
 |===
 == .spec.processor.advanced.scheduling
@@ -2988,7 +3040,6 @@ Type::
 
 Required::
   - `index`
-  - `name`
 
 
 
@@ -3004,7 +3055,7 @@ Fields absent from the 'k8s.v1.cni.cncf.io/network-status' annotation must not b
 
 | `name`
 | `string`
-| `name` should match the network name as visible in the pods annotation 'k8s.v1.cni.cncf.io/network-status'.
+| Deprecated: `name` is unused.
 
 |===
 == .spec.processor.deduper
@@ -3116,6 +3167,16 @@ Type::
 [cols="1,1,1",options="header"]
 |===
 | Property | Type | Description
+
+| `additionalIncludeList`
+| `array (string)`
+| `additionalIncludeList` is a list of metric names to include in addition to the default metrics.
+Unlike `includeList`, this appends to the default list rather than replacing it.
+This field is mutually exclusive with `includeList`. If `includeList` is set, `additionalIncludeList` is ignored.
+The names correspond to the names in Prometheus without the prefix. For example,
+`namespace_egress_packets_total` shows up as `netobserv_namespace_egress_packets_total` in Prometheus.
+Note that the more metrics you add, the bigger is the impact on Prometheus workload resources.
+More information, with full list of available metrics: https://github.com/netobserv/network-observability-operator/blob/main/docs/Metrics.md
 
 | `disableAlerts`
 | `array (string)`
@@ -3471,6 +3532,187 @@ otherwise to an implementation-defined value. Requests cannot exceed Limits.
 More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
 
 |===
+== .spec.processor.service
+Description::
++
+--
+Service configuration, only used when `spec.deploymentModel` is `Service`.
+--
+
+Type::
+  `object`
+
+Required::
+  - `tlsType`
+
+
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `providedCertificates`
+| `object`
+| TLS or mTLS configuration when `type` is set to `Provided`.
+
+| `tlsType`
+| `string`
+| Select the type of TLS configuration: +
+
+- `Disabled` to not configure TLS for the endpoint. Disabling TLS results in a less secure deployment model. +
+
+- `Provided` to manually provide the key and certificate references. +
+
+- `Auto` (default) to enable automatically based on the running environment. +
+
+- `Auto-mTLS` to preconfigure mTLS. [Unsupported (*)]. +
+
+See also: https://github.com/netobserv/netobserv-operator/blob/main/docs/TLS.md.
+
+|===
+== .spec.processor.service.providedCertificates
+Description::
++
+--
+TLS or mTLS configuration when `type` is set to `Provided`.
+--
+
+Type::
+  `object`
+
+
+
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `caFile`
+| `object`
+| Reference to the CA file.
+
+| `clientCert`
+| `object`
+| TLS client certificate reference, used for mTLS. Leave unset for simple TLS.
+
+| `serverCert`
+| `object`
+| TLS server certificate reference.
+
+|===
+== .spec.processor.service.providedCertificates.caFile
+Description::
++
+--
+Reference to the CA file.
+--
+
+Type::
+  `object`
+
+
+
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `file`
+| `string`
+| File name within the config map or secret.
+
+| `name`
+| `string`
+| Name of the config map or secret containing the file.
+
+| `namespace`
+| `string`
+| Namespace of the config map or secret containing the file. If omitted, the default is to use the same namespace as where Network Observability is deployed.
+If the namespace is different, the config map or the secret is copied so that it can be mounted as required.
+
+| `type`
+| `string`
+| Type for the file reference: `configmap` or `secret`.
+
+|===
+== .spec.processor.service.providedCertificates.clientCert
+Description::
++
+--
+TLS client certificate reference, used for mTLS. Leave unset for simple TLS.
+--
+
+Type::
+  `object`
+
+
+
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `certFile`
+| `string`
+| `certFile` defines the path to the certificate file name within the config map or secret.
+
+| `certKey`
+| `string`
+| `certKey` defines the path to the certificate private key file name within the config map or secret. Omit when the key is not necessary.
+
+| `name`
+| `string`
+| Name of the config map or secret containing certificates.
+
+| `namespace`
+| `string`
+| Namespace of the config map or secret containing certificates. If omitted, the default is to use the same namespace as where Network Observability is deployed.
+If the namespace is different, the config map or the secret is copied so that it can be mounted as required.
+
+| `type`
+| `string`
+| Type for the certificate reference: `configmap` or `secret`.
+
+|===
+== .spec.processor.service.providedCertificates.serverCert
+Description::
++
+--
+TLS server certificate reference.
+--
+
+Type::
+  `object`
+
+
+
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `certFile`
+| `string`
+| `certFile` defines the path to the certificate file name within the config map or secret.
+
+| `certKey`
+| `string`
+| `certKey` defines the path to the certificate private key file name within the config map or secret. Omit when the key is not necessary.
+
+| `name`
+| `string`
+| Name of the config map or secret containing certificates.
+
+| `namespace`
+| `string`
+| Namespace of the config map or secret containing certificates. If omitted, the default is to use the same namespace as where Network Observability is deployed.
+If the namespace is different, the config map or the secret is copied so that it can be mounted as required.
+
+| `type`
+| `string`
+| Type for the certificate reference: `configmap` or `secret`.
+
+|===
 == .spec.processor.slicesConfig
 Description::
 +
@@ -3639,7 +3881,7 @@ Required::
 | `enable`
 | `boolean`
 | When `enable` is `true`, the Console plugin queries flow metrics from Prometheus instead of Loki whenever possible.
-It is enbaled by default: set it to `false` to disable this feature.
+It is enabled by default: set it to `false` to disable this feature.
 The Console plugin can use either Loki or Prometheus as a data source for metrics (see also `spec.loki`), or both.
 Not all queries are transposable from Loki to Prometheus. Hence, if Loki is disabled, some features of the plugin are disabled as well,
 such as getting per-pod information or viewing raw flows.

--- a/modules/network-observability-flows-format.adoc
+++ b/modules/network-observability-flows-format.adoc
@@ -63,7 +63,7 @@ The "Cardinality" column gives information about the implied metric cardinality 
 | `dns_name`
 | no
 | careful
-| n/a
+| dns.name
 | `Dscp`
 | number
 | Differentiated Services Code Point (DSCP) value
@@ -112,7 +112,7 @@ The "Cardinality" column gives information about the implied metric cardinality 
 | `dst_network`
 | no
 | fine
-| n/a
+| destination.network.name
 | `DstK8S_OwnerName`
 | string
 | Name of the destination owner, such as Deployment name, StatefulSet name, etc.
@@ -188,7 +188,7 @@ The "Cardinality" column gives information about the implied metric cardinality 
 | `ipsec_status`
 | no
 | fine
-| n/a
+| ipsec.status
 | `IcmpCode`
 | number
 | ICMP code
@@ -343,7 +343,7 @@ The "Cardinality" column gives information about the implied metric cardinality 
 | `src_network`
 | no
 | fine
-| n/a
+| source.network.name
 | `SrcK8S_OwnerName`
 | string
 | Name of the source owner, such as Deployment name, StatefulSet name, etc.
@@ -393,6 +393,34 @@ The "Cardinality" column gives information about the implied metric cardinality 
 | no
 | fine
 | source.subnet.label
+| `TLSCipherSuite`
+| string
+| TLS cipher suite
+| `tls_cipher_suite`
+| no
+| fine
+| tls.ciphersuite
+| `TLSGroup`
+| string
+| TLS group name
+| `tls_group`
+| no
+| fine
+| tls.group
+| `TLSTypes`
+| string[]
+| TLS message types (bitfield)
+| `tls_types`
+| no
+| careful
+| tls.types
+| `TLSVersion`
+| string
+| TLS version
+| `tls_version`
+| no
+| fine
+| tls.version
 | `TimeFlowEndMs`
 | number
 | End timestamp of this flow, in milliseconds

--- a/modules/network-observability-health-rule-structure-customization.adoc
+++ b/modules/network-observability-health-rule-structure-customization.adoc
@@ -3,15 +3,15 @@
 // network_observability/network-observability-alerts.adoc
 
 :_mod-docs-content-type: CONCEPT
-[id="network-observability-health-rule-structure-customization_{context}"]
-= Network observability health rule structure and customization
+[id="network-observability-health-rule-customization_{context}"]
+= Health rule threshold and grouping customization
 
 [role="_abstract"]
-Health rules in the Network Observability Operator are defined using rule templates and variants in the `spec.processor.metrics.healthRules` object of the `FlowCollector` custom resource (CR). You can customize the default templates and variants for flexible, fine-grained alerting.
+Health rules in the Network Observability Operator are defined by using rule templates and variants in the `spec.processor.metrics.healthRules` field of the `FlowCollector` custom resource (CR). Customizing these templates allows for flexible, fine-grained alerting tailored to specific environment needs.
 
-For each template, you can define a list of variants, each with their own thresholds and grouping configurations. For more information, see "List of default alert templates".
+For each template, a list of variants can be defined, each with distinct thresholds and grouping configurations.
 
-The following example shows an alert:
+The following example shows a `FlowCollector` configuration with custom health rules:
 
 [source,yaml]
 ----
@@ -26,10 +26,10 @@ spec:
       - template: PacketDropsByKernel
         mode: Alert # or Recording
         variants:
-        # triggered when the whole cluster traffic (no grouping) reaches 10% of drops
+        # Triggered when aggregate cluster traffic reaches 10% drops
         - thresholds:
             critical: "10"
-        # triggered when per-node traffic reaches 5% of drops, with gradual severity
+        # Triggered per-node with increasing severity levels
         - thresholds:
             critical: "15"
             warning: "10"
@@ -37,15 +37,12 @@ spec:
           groupBy: Node
 ----
 
-where:
-
 `spec.processor.metrics.healthRules.template`:: Specifies the name of the predefined rule template.
-`spec.processor.metrics.healthRules.mode`:: Specifies whether the rule functions as an `Alert` or a `Recording` rule. This setting can either be defined per variant, or for the whole template.
-`spec.processor.metrics.healthRules.variants.thresholds`:: Specifies the numerical values that trigger the rule. You can define multiple severity levels, such as `critical`, `warning`, or `info`, within a single variant.
-`cluster-wide variant`:: Specifies a variant defined without a `groupBy` setting. In the provided example, this variant triggers when the total cluster traffic reaches 10% drops.
-`spec.processor.metrics.healthRules.variants.groupBy`:: Specifies the dimension used to aggregate the metric. In the provided example, the alert is evaluated independently for each *Node8.
+`spec.processor.metrics.healthRules.mode`:: Specifies whether the rule functions as an `Alert` or a `Recording` rule.
+`spec.processor.metrics.healthRules.variants.thresholds`:: Specifies the numerical values that trigger the rule. Multiple severity levels, such as `critical`, `warning`, or `info`, can be defined within a single variant.
+`spec.processor.metrics.healthRules.variants.groupBy`:: Specifies the dimension used to aggregate the metric, such as `Node` or `Namespace`.
 
 [NOTE]
 ====
-Customizing a rule replaces the default configuration for that template. If you want to keep the default configurations, you must manually replicate them.
+Customizing a rule replaces the default configuration for that template. To retain default configurations, the default settings must be manually included in the custom resource.
 ====

--- a/modules/network-observability-health-rules-and-performance.adoc
+++ b/modules/network-observability-health-rules-and-performance.adoc
@@ -4,17 +4,53 @@
 
 :_mod-docs-content-type: CONCEPT
 [id="network-observability-health-rules-and-performance_{context}"]
-= Network observability rules for health and performance
+= Identifying network issues with automated health rules
 
 [role="_abstract"]
-Network observability includes a system for managing Prometheus-based rules. Use these rules to monitor the health and performance of {product-title} applications and infrastructure.
+Network observability identifies network issues by using automated health rules to monitor metrics. These rules trigger alerts when anomalies occur, which assists in maintaining connectivity and responding to network degradation.
 
-The Network Observability Operator converts these rules into a `PrometheusRule` resource. The Network Observability Operator supports the following rule types:
+The Network Observability Operator manages a system of Prometheus-based rules that detect network problems, and converts these rules into `PrometheusRule` resources. It supports the following rule types:
 
-* Alerting rules: Specifies rules managed by the Prometheus `AlertManager` to provide notification of network anomalies or infrastructure failures.
-* Recording rules: Specifies pre-compute complex Prometheus Query Language (PromQL) expressions into new time series to improve dashboard performance and visualization.
+Alerting rules:: Trigger notifications through the Prometheus `Alertmanager` when network anomalies or infrastructure failures are detected.
 
-View the `PrometheusRule` resource in the `netobserv` namespace by running the following command:
+Recording rules:: Pre-compute complex Prometheus Query Language (PromQL) expressions into new time series to improve dashboard performance.
+
+[id="importance-of-network-health-monitoring_{context}"]
+== Importance of network health monitoring
+
+Maintaining reliable and secure network connectivity is critical for cluster administrators and security teams. Unresolved network issues can result in the following consequences:
+
+* Application downtime caused by packet drops or DNS failures.
+* Security risks from undetected network policy violations.
+* Performance degradation caused by latency spikes or bandwidth saturation.
+* Compliance issues from unmonitored network traffic.
+
+Early detection of these issues allows for resolution before service level objectives (SLOs) are affected.
+
+[id="detection-of-network-issues_{context}"]
+== Automated health monitoring
+
+The Network Observability Operator provides automated health monitoring through the following features:
+
+* Pre-configured health rules: Detect common network problems by using default thresholds.
+* Automated alerting: Integrates with the {product-title} monitoring stack.
+* Health dashboards: Displays health status for clusters, nodes, namespaces, and workloads.
+* Custom rules: Supports the creation of organization-specific monitoring rules.
+
+Health rules monitor network flow metrics and trigger alerts when defined thresholds are exceeded. For example, the `PacketDropsByKernel` rule reports an alert when kernel packet drop rates exceed defined levels.
+
+[id="network-health-monitoring-workflow_{context}"]
+== Network health monitoring workflow
+
+Monitoring network health involves the following phases:
+
+* Configuring the Network Observability Operator to collect required network health data for monitoring, such as packet drops or DNS tracking.
+* Reviewing and customizing default health rules and thresholds in the `FlowCollector` custom resource.
+* Monitoring alerts in the {product-title} web console in the *Observe* → *Alerting* and *Observe* → *Network Health* views.
+* Creating custom health rules for specific requirements.
+* Configuring recording rules to optimize performance for large-scale deployments.
+
+The `PrometheusRule` resource in the `netobserv` namespace can be viewed by running the following command:
 
 [source,terminal]
 ----

--- a/modules/network-observability-health-rules-monitoring-and-alerting.adoc
+++ b/modules/network-observability-health-rules-monitoring-and-alerting.adoc
@@ -4,21 +4,21 @@
 
 :_mod-docs-content-type: REFERENCE
 [id="network-observability-health-rules-monitoring-and-alerting_{context}"]
-= Network health monitoring and alerting rules
+= Detecting network issues with automated health rules
 
 [role="_abstract"]
-The Network Observability Operator includes a rule-based system to detect network anomalies and infrastructure failures. By converting configurations into alerting rules, the Operator enables automated monitoring and troubleshooting through the {product-title} web console.
+The Network Observability Operator includes a rule-based system to detect network anomalies and infrastructure failures. By converting configurations into alerting rules, the Operator provides automated monitoring and troubleshooting through the {product-title} web console.
 
 [id="network-observability-health-outcomes_{context}"]
 == Monitoring outcomes
-The Network Observability Operator surfaces network status in the following areas:
+The Network Observability Operator displays network status in the following views:
 
-*Alerting* UI:: Specific alerts appear in *Observe* → *Alerting*, where notifications are managed through the Prometheus `AlertManager`.
-*Network Health* dashboard:: A specialized dashboard in *Observe* → *Network Health* provides a high-level summary of cluster network status.
+*Alerting* UI:: Specific alerts appear in *Observe* → *Alerting*. Notifications are managed through the Prometheus `Alertmanager`.
+*Network Health* dashboard:: A specialized dashboard in *Observe* → *Network Health* provides a summary of cluster network status.
 
 The *Network Health* dashboard categorizes violations into tabs to isolate the scope of an issue:
 
-* *Global*: Aggregate health of the entire cluster.
+* *Global*: Aggregate health of the cluster.
 * *Nodes*: Violations specific to infrastructure nodes.
 * *Namespaces*: Violations specific to individual namespaces.
 * *Workloads*: Violations specific to resources, such as `Deployments` or `DaemonSets`.
@@ -29,22 +29,22 @@ The Network Observability Operator provides default rules for common networking 
 
 The following list contains a subset of available default rules:
 
-`PacketDropsByDevice`:: Triggers on a high percentage of packet drops from network devices. It is based on standard node-exporter metrics and does not require the `PacketDrop` agent feature.
-`PacketDropsByKernel`:: Triggers on a high percentage of packet drops by the kernel. Requires the `PacketDrop` agent feature.
-`IPsecErrors`:: Triggers when IPsec encryption errors are detected. Requires the `IPSec` agent feature.
-`NetpolDenied`:: Triggers when traffic denied by network policies is detected. Requires the `NetworkEvents` agent feature.
-`LatencyHighTrend`:: Triggers when a significant increase in TCP latency is detected. Requires the `FlowRTT` agent feature.
-`DNSErrors`:: Triggers when DNS errors are detected. Requires the `DNSTracking` agent feature.
+`PacketDropsByDevice`:: Reports a high percentage of packet drops from network devices. This rule is based on node-exporter metrics and does not require the `PacketDrop` agent feature.
+`PacketDropsByKernel`:: Reports a high percentage of packet drops by the kernel. This rule requires the `PacketDrop` agent feature.
+`IPsecErrors`:: Reports IPsec encryption errors. This rule requires the `IPSec` agent feature.
+`NetpolDenied`:: Reports traffic denied by network policies. This rule requires the `NetworkEvents` agent feature.
+`LatencyHighTrend`:: Reports a significant increase in TCP latency. This rule requires the `FlowRTT` agent feature.
+`DNSErrors`:: Reports DNS errors. This rule requires the `DNSTracking` agent feature.
 
-Operational alerts for the Network Observability Operator:
+The following operational alerts apply to the Network Observability Operator:
 
-`NetObservNoFlows`:: Triggers when the pipeline is active but no flows are observed.
-`NetObservLokiError`:: Triggers when flows are dropped because of Loki errors.
+`NetObservNoFlows`:: Reports when the pipeline is active but no flows are observed.
+`NetObservLokiError`:: Reports when flows are dropped because of Loki errors.
 
 For a complete list of rules and runbooks, see the link:https://github.com/openshift/runbooks/tree/master/alerts/network-observability-operator[Network Observability Operator runbooks].
 
-[id="network-observability-rule-dependencies_{context}"]
-== Rule dependencies and feature requirements
-The Network Observability Operator creates rules based on the features enabled in the `FlowCollector` custom resource (CR).
+[id="network-observability-enabling-features-for-health-monitoring_{context}"]
+== Enabling features for health monitoring
+The Network Observability Operator creates rules based on the features enabled in the `FlowCollector` CR.
 
-For example, packet drop-related rules are created only if the `PacketDrop` agent feature is enabled. Rules are built on metrics; if the required metrics are missing, configuration warnings might appear. Configure metrics in the `spec.processor.metrics.includeList` object of the `FlowCollector` resource.
+For example, packet drop rules are created only if the `PacketDrop` agent feature is enabled. Rules depend on metrics; if the required metrics are unavailable, configuration warnings might appear. Configure metrics in the `spec.processor.metrics.includeList` field of the `FlowCollector` resource.

--- a/modules/network-observability-health-rules-promql-expressions-metadata.adoc
+++ b/modules/network-observability-health-rules-promql-expressions-metadata.adoc
@@ -4,69 +4,63 @@
 
 :_mod-docs-content-type: REFERENCE
 [id="network-observability-health-rules-promql-expressions-metadata_{context}"]
-= PromQL expressions and metadata for health rules
+= Health rule query and metadata reference
 
 [role="_abstract"]
-Learn about the base query for Prometheus Query Language (`PromQL`), and how to customize it so you can configure network observability alerts for your specific needs.
+The `FlowCollector` health rule API maps to the Prometheus Operator to generate `PrometheusRule` objects. Use these base Prometheus Query Language (PromQL) patterns and metadata configurations to create custom health rules for network observability.
 
-The health rule API in the network observability `FlowCollector` custom resource (`CR`) is mapped to the Prometheus Operator API, generating a `PrometheusRule`. You can see the `PrometheusRule` in the default `netobserv` namespace by running the following command:
+The `PrometheusRule` resource in the `netobserv` namespace can be viewed by running the following command:
 
 [source,terminal]
 ----
-$ oc get prometheusrules -n netobserv -oyaml
+$ oc get prometheusrules -n netobserv -o yaml
 ----
 
-[id="example-example-query-alert-for-surge-in-incoming-traffic_{context}"]
-== An example query for an alert in a surge of incoming traffic
+[id="example-query-surge-incoming-traffic_{context}"]
+== Customizing alert logic with PromQL: Incoming traffic surge
 
-This example provides the base `PromQL` query pattern for an alert about a surge in incoming traffic:
+The following PromQL query calculates the byte rate from the `openshift-ingress` namespace to any workload namespace over a 30-minute interval:
 
 [source,promql]
 ----
 sum(rate(netobserv_workload_ingress_bytes_total{SrcK8S_Namespace="openshift-ingress"}[30m])) by (DstK8S_Namespace)
 ----
 
-This query calculates the byte rate coming from the `openshift-ingress` namespace to any of your workloads' namespaces over the past 30 minutes.
+Queries can be customized to filter low-bandwidth data, compare time periods, and establish thresholds.
 
-You can customize the query, including retaining only some rates, running the query for specific time periods, and setting a final threshold.
-
-Filtering noise:: Appending `> 1000` to this query retains only the rates observed that are greater than `1 KB/s`, which eliminates noise from low-bandwidth consumers.
+Data filtering:: Appending `> 1000` to the query removes rates lower than `1 KB/s` to filter low-bandwidth traffic.
 +
 `(sum(rate(netobserv_workload_ingress_bytes_total{SrcK8S_Namespace="openshift-ingress"}[30m])) by (DstK8S_Namespace) > 1000)`
 +
-The byte rate is relative to the sampling interval defined in the `FlowCollector` custom resource (`CR`) configuration. If the sampling interval is `1:100`, the actual traffic might be approximately 100 times higher than the reported metrics.
+[NOTE]
+====
+The byte rate is relative to the sampling interval in the `FlowCollector` CR. Normalizing byte rates with the `netobserv_agent_sampling_rate` metric decouples the PromQL expression from the sampling configuration.
+====
 
-Time comparison:: You can run the same query for a particular period of time using the `offset` modifier. For example, a query for one day earlier can be run using `offset 1d`, and a query for five hours ago can be run using `offset 5h`.
+Time comparison:: The `offset` modifier compares data across different time periods. For example, `offset 1d` retrieves data from the previous day.
 +
 `sum(rate(netobserv_workload_ingress_bytes_total{SrcK8S_Namespace="openshift-ingress"}[30m] offset 1d)) by (DstK8S_Namespace))`
-+
-You can use the formula `100 * (<query now> - <query from the previous day>) / <query from the previous day>` to calculate the percentage of increase compared to the previous day. This value can be negative if the byte rate today is lower than the previous day.
 
-Final threshold:: You can apply a final threshold to filter increases that are lower than the desired percentage. For example, `> 100` eliminates increases that are lower than 100%.
+Threshold application:: A final threshold filters increases below a specific percentage. For example, `> 100` removes increases lower than 100%.
 
-Together, the complete expression for the `PrometheusRule` looks like the following:
+The following example shows a complete PromQL expression for a `PrometheusRule`:
 
 [source,promql]
 ----
-...
-      expr: |-
-        (100 *
-          (
-            (sum(rate(netobserv_workload_ingress_bytes_total{SrcK8S_Namespace="openshift-ingress"}[30m])) by (DstK8S_Namespace) > 1000)
-            - sum(rate(netobserv_workload_ingress_bytes_total{SrcK8S_Namespace="openshift-ingress"}[30m] offset 1d)) by (DstK8S_Namespace)
-          )
-          / sum(rate(netobserv_workload_ingress_bytes_total{SrcK8S_Namespace="openshift-ingress"}[30m] offset 1d)) by (DstK8S_Namespace))
-        > 100
+expr: |-
+  (100 *
+    (
+      (sum(rate(netobserv_workload_ingress_bytes_total{SrcK8S_Namespace="openshift-ingress"}[30m])) by (DstK8S_Namespace) > 1000)
+      - sum(rate(netobserv_workload_ingress_bytes_total{SrcK8S_Namespace="openshift-ingress"}[30m] offset 1d)) by (DstK8S_Namespace)
+    )
+    / sum(rate(netobserv_workload_ingress_bytes_total{SrcK8S_Namespace="openshift-ingress"}[30m] offset 1d)) by (DstK8S_Namespace))
+  > 100
 ----
 
 [id="alert-metadata-fields_{context}"]
 == Alert metadata fields
 
-The Network Observability Operator uses components from other {product-title} features, such as the monitoring stack, to enhance visibility into network traffic. For more information, see: "Monitoring stack architecture".
-
-Some metadata must be configured for the rule definitions. This metadata is used by Prometheus and the `Alertmanager` service from the monitoring stack, or by the *Network Health* dashboard.
-
-The following example shows an `AlertingRule` resource with the configured metadata:
+Rule definitions require specific metadata for the Prometheus `Alertmanager` service and the *Network Health* dashboard. The following example shows an `AlertingRule` resource with configured metadata:
 
 [source,yaml]
 ----
@@ -83,16 +77,10 @@ spec:
       annotations:
         netobserv_io_network_health: '{"namespaceLabels":["DstK8S_Namespace"],"threshold":"100","unit":"%","upperBound":"500"}'
         message: |-
-          NetObserv is detecting a surge of incoming traffic: current traffic to {{ $labels.DstK8S_Namespace }} has increased by more than 100% since yesterday.
+          Surge of incoming traffic detected: current traffic to {{ $labels.DstK8S_Namespace }} increased by more than 100% since yesterday.
         summary: "Surge in incoming traffic"
       expr: |-
-        (100 *
-          (
-            (sum(rate(netobserv_workload_ingress_bytes_total{SrcK8S_Namespace="openshift-ingress"}[30m])) by (DstK8S_Namespace) > 1000)
-            - sum(rate(netobserv_workload_ingress_bytes_total{SrcK8S_Namespace="openshift-ingress"}[30m] offset 1d)) by (DstK8S_Namespace)
-          )
-          / sum(rate(netobserv_workload_ingress_bytes_total{SrcK8S_Namespace="openshift-ingress"}[30m] offset 1d)) by (DstK8S_Namespace))
-        > 100
+        # ... (PromQL expression)
       for: 1m
       labels:
         app: netobserv
@@ -100,20 +88,17 @@ spec:
         severity: warning
 ----
 
-where:
-
 `spec.groups.rules.alert.labels.netobserv`::
-Specifies the alert for the *Network Health* dashboard to detect when set to `true`.
+Specifies that the *Network Health* dashboard must detect the alert when set to `true`.
 `spec.groups.rules.alert.labels.severity`::
-Specifies the severity of the alert. The following values are valid: `critical`, `warning`, or `info`.
+Specifies the alert severity. Valid values are `critical`, `warning`, or `info`.
 
-You can leverage the output labels from the defined `PromQL` expression in the `message` annotation. In the example, since results are grouped per `DstK8S_Namespace`, the expression `{{ $labels.DstK8S_Namespace }}` is used in the message text.
+[id="netobserv-io-network-health-annotation_{context}"]
+== netobserv_io_network_health annotation fields
 
-The `netobserv_io_network_health` annotation is optional, and controls how the alert is rendered on the *Network Health* page.
+The optional `netobserv_io_network_health` annotation is a JSON string that controls how the alert renders on the *Network Health* page.
 
-The `netobserv_io_network_health` annotation is a JSON string consisting of the following fields:
-
-.Fields for the netobserv_io_network_health annotation
+.Fields for the `netobserv_io_network_health` annotation
 [cols="2,2,6",options="header"]
 |===
 | Field
@@ -122,55 +107,30 @@ The `netobserv_io_network_health` annotation is a JSON string consisting of the 
 
 | `namespaceLabels`
 | List of strings
-| One or more labels that hold namespaces. When provided, the alert appears under the *Namespaces* tab.
+| One or more labels containing namespaces. Alerts appear under the *Namespaces* tab.
 
 | `nodeLabels`
 | List of strings
-| One or more labels that hold node names. When provided, the alert appears under the *Nodes* tab.
+| One or more labels containing node names. Alerts appear under the *Nodes* tab.
 
-|`workloadLabels`
+| `workloadLabels`
 | List of strings
-| One or more labels that hold owner/workload names. When provided alongside with `kindLabels`, the alert will show up under the "Owners" tab.
-
-|`kindLabels`
-| List of strings
-| One or more labels that hold owner/workload kinds. When provided alongside with `workloadLabels`, the alert will show up under the "Owners" tab.
+| One or more labels containing owner or workload names. Alerts appear under the *Owners* tab when `kindLabels` is also provided.
 
 | `threshold`
 | String
-| The alert threshold, expected to match the threshold defined in the `PromQL` expression.
+| The alert threshold. This value should match the threshold in the PromQL expression.
 
 | `unit`
 | String
-| The data unit, used only for display purposes.
+| The data unit for display purposes.
 
 | `upperBound`
 | String
-| An upper bound value used to compute the score on a closed scale. Metric values exceeding this bound are clamped.
-
-| `links`
-| List of objects
-| A list of links to display contextually with the alert. Each link requires a `name` (display name) and `url`.
-
-| `trafficLink`
-| String
-| Information related to the link to the *Network Traffic* page, for URL building. Some filters will be set automatically, such as the `node` or `namespace` filter.
+| An upper bound value used to calculate scores on a closed scale. Metric values exceeding this bound are clamped.
 |===
 
-The `namespaceLabels` and `nodeLabels` are mutually exclusive. If neither is provided, the alert appears under the *Global* tab.
-
-.`trafficLink` fields
-[cols="1,3",options="header"]
-|===
-| Field
-| Description
-
-| `extraFilter`
-| Additional filter to inject (for example, a DNS response code for DNS-related alerts).
-
-| `backAndForth`
-| Whether the filter should include return traffic (`true` or `false`).
-
-| `filterDestination`
-| Whether the filter should target the destination of the traffic instead of the source (`true` or `false`).
-|===
+[NOTE]
+====
+The `namespaceLabels` and `nodeLabels` fields are mutually exclusive. If neither is provided, the alert appears under the *Global* tab.
+====

--- a/modules/network-observability-health-rules-recording-rules-performance-optimization.adoc
+++ b/modules/network-observability-health-rules-recording-rules-performance-optimization.adoc
@@ -3,11 +3,11 @@
 // * network_observability/network-observability-health-rules.adoc
 
 :_mod-docs-content-type: CONCEPT
-[id="network-observability-health-rules-recording-rules-performance-optimization_{context}"]
+[id="network-observability-recording-rules-performance-optimization_{context}"]
 = Performance optimization with recording rules
 
 [role="_abstract"]
-For large-scale clusters, recording rules optimize how Prometheus handles network data. Recording rules improve dashboard responsiveness and reduce the computational overhead of complex queries.
+In large-scale clusters, recording rules optimize how Prometheus handles network data. Recording rules improve dashboard responsiveness and reduce the computational overhead of complex queries.
 
 [id="network-observability-recording-rules-benefits_{context}"]
 == Optimization benefits
@@ -19,29 +19,46 @@ Improved performance:: Pre-computing Prometheus queries allows dashboards to loa
 Resource efficiency:: Calculating data at fixed intervals reduces CPU load on the Prometheus server compared to recalculating data on every dashboard refresh.
 Simplified queries:: Using short metric names, such as `cluster:network_traffic:rate_5m`, simplifies complex aggregate calculations in custom dashboards.
 
+
+
 [id="network-observability-alert-vs-recording-comparison_{context}"]
 == Comparison of rule modes
 The following table compares rule modes based on the expected outcome:
 
 [cols="1,2,2",options="header"]
 |===
-| Description
+| Feature
 | Alerting rules
 | Recording rules
 
-| Goal
+| Primary goal
 | Issue notification.
-| Save history of high level metrics.
+| Persistent metric history.
 
-| Data result
-| Generates an alerting state.
-| Creates a persistent metric.
+| Data output
+| Alerting state.
+| New time series metric.
 
-| Visibility
-| *Alerting* UI and *Network Health* view.
-| *Metrics Explorer* and *Network Health* view.
+| UI visibility
+| *Alerting* and *Network Health* views.
+| *Metrics Explorer* and *Network Health* views.
 
 | Notifications
-| Triggers `AlertManager` notifications.
+| Triggers `Alertmanager` notifications.
 | Does not trigger notifications.
 |===
+
+[id="network-observability-integrating-recording-rules-with-health-dashboard_{context}"]
+== Integrating recording rules with the health dashboard
+
+Custom recording rules that contribute to the *Network Health* dashboard must meet specific metadata requirements.
+
+Label requirements::
+Include the `netobserv: "true"` label in the `labels` field of the rule and the `PrometheusRule` metadata. The Network Observability Operator identifies `PrometheusRule` resources cluster-wide by using this label.
+
+Annotation requirements::
+Include the `netobserv.io/network-health` annotation in the `PrometheusRule` metadata. This annotation is required for recording rules to appear in the *Network Health* dashboard. The value is a JSON object where keys are the metric names (the `record` field of each rule). Each value consists of the following fields:
++
+* `summary`: An optional short title. This field supports Prometheus template syntax, such as `{{ $labels.namespace }}`.
+* `description`: An optional description. This field supports Prometheus template syntax.
+* `netobserv_io_network_health`: A required JSON string. For recording rules, use the `recordingThresholds` field instead of `threshold`. This field determines the health score and UI coloring, such as `{"info":"10","warning":"25","critical":"50"}`.

--- a/modules/network-observability-kafka-compression-benefits.adoc
+++ b/modules/network-observability-kafka-compression-benefits.adoc
@@ -1,0 +1,28 @@
+// Module included in the following assemblies:
+//
+// * observability/network_observability/network-observability-kafka-operator-scaling-network-flow-collection.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="network-observability-kafka-compression-benefits_{context}"]
+= Reducing network bandwidth for flow telemetry
+
+[role="_abstract"]
+Enable Kafka compression for flow records to optimize network traffic. This configuration reduces network bandwidth consumption while increasing the CPU load on the eBPF agent.
+
+By default, the Network Observability Operator sends network flow records to Kafka without compression. This minimizes CPU overhead but can consume significant network bandwidth in clusters with high traffic volumes.
+
+Enabling compression reduces the amount of data transmitted over the network, which is beneficial when the following cases are true:
+
+* Network bandwidth is constrained or expensive
+* Flow volumes are high and impacting network performance
+* Kafka brokers are located on different nodes or in remote data centers
+
+The trade-off is increased CPU usage on the eBPF agent pods, which run as a `DaemonSet` on every node. Each of the different compression algorithms provide the following balances between compression ratio and CPU cost:
+
+* `lz4`: Very low CPU cost with 2 to 3 times compression. Best for most deployments.
+* `zstd`: Moderate CPU cost with 3 to 5 times compression. Good for bandwidth-constrained environments.
+* `snappy`: Similar to lz4 with slightly lower compression ratio.
+* `gzip`: High CPU cost with 3 to 5 times compression. Maximum compression at highest CPU expense.
+* `none`: No compression. Use when CPU is the bottleneck.
+
+Flow records contain many repeated fields (IP addresses, namespaces, node names) and compress efficiently, often reaching the higher end of these compression ratios.

--- a/modules/network-observability-kafka-compression-codec-reference.adoc
+++ b/modules/network-observability-kafka-compression-codec-reference.adoc
@@ -1,0 +1,53 @@
+// Module included in the following assemblies:
+//
+// * observability/network_observability/network-observability-kafka-operator-scaling-network-flow-collection.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="network-observability-kafka-compression-codec-reference_{context}"]
+= Kafka compression codec reference
+
+[role="_abstract"]
+Compare Kafka compression codecs to choose the optimal algorithm for your environment.
+
+This reference applies to compression configured in both `spec.kafka.compression` for flow collection and `spec.exporters` for flow export.
+
+.Kafka compression codec comparison
+[cols="1,1,1,1,3",options="header"]
+|===
+|Codec |Compression ratio |CPU cost (producer) |Decompression cost |Notes
+
+|`none`
+|1x
+|N/A
+|N/A
+|No overhead. Use when CPU is the bottleneck.
+
+|`lz4`
+|2:1 to 3:1
+|Very low
+|Very low
+|*Recommended default.* Best latency-to-compression ratio trade-off.
+
+|`snappy`
+|2:1 to 3:1
+|Very low
+|Very low
+|Similar to `lz4`, with a slightly lower compression ratio.
+
+|`zstd`
+|3:1 to 5:1
+|Moderate
+|Low
+|Higher compression ratio. Good for high-throughput clusters.
+
+|`gzip`
+|3:1 to 5:1
+|High
+|Moderate
+|Maximum compression ratio but incurs a significant CPU cost.
+|===
+
+[NOTE]
+====
+The compression ratios and CPU cost estimates are approximate values derived from upstream benchmarks, not from Network Observability-specific measurements. Actual results vary depending on flow record characteristics and batch sizes.
+====

--- a/modules/network-observability-kafka-for-large-scale-environments.adoc
+++ b/modules/network-observability-kafka-for-large-scale-environments.adoc
@@ -1,0 +1,29 @@
+// Module included in the following assemblies:
+
+// * observability/network_observability/network-observability-installing-kafka-operator.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="network-observability-kafka-for-large-scale-environments_{context}"]
+= Kafka deployment scenarios for network flows
+
+[role="_abstract"]
+The Kafka Operator manages high-throughput and low-latency data feeds for network flow forwarding. This architecture provides a resilient and scalable solution for handling telemetry data in large-scale cluster environments.
+
+[id="when-to-use-kafka-for-network-flow-collection_{context}"]
+== When to use Kafka for network flow collection
+
+Consider using Kafka to manage your network flow data when you experience the following circumstances:
+
+* High flow volumes that overwhelm the default flowlogs-pipeline buffer
+* Need for data persistence and replay capabilities
+* Multiple consumers requiring access to the same flow data
+* Requirements for horizontal scaling across multiple processing nodes
+
+For smaller deployments with moderate flow volumes, the default configuration without Kafka is typically sufficient.
+
+You can install the Kafka Operator as Red Hat AMQ Streams from the Operator Hub. See "Red{nbsp}Hat AMQ Streams".
+
+[NOTE]
+====
+To uninstall Kafka, refer to the uninstallation process that corresponds with the method you used to install.
+====

--- a/modules/network-observability-operator-release-notes-1-12-advisory.adoc
+++ b/modules/network-observability-operator-release-notes-1-12-advisory.adoc
@@ -1,0 +1,11 @@
+// Module included in the following assemblies:
+// * network_observability/network-observability-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="network-observability-operator-release-notes_{context}"]
+= Network Observability Operator 1.12 advisory
+
+[role="_abstract"]
+You can review the advisory for Network Observability Operator 1.12 release.
+
+* link:https://access.redhat.com/errata/RHSA-2026:24473[RHSA-2026:24473 Network Observability Operator 1.12]

--- a/modules/network-observability-operator-release-notes-1-12-fixed-issues.adoc
+++ b/modules/network-observability-operator-release-notes-1-12-fixed-issues.adoc
@@ -1,0 +1,86 @@
+// Module included in the following assemblies:
+// * network_observability/network-observability-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="network-observability-operator-release-notes-1-12-fixed-issues_{context}"]
+= Network Observability Operator 1.12 fixed issues
+
+[role="_abstract"]
+The Network Observability Operator 1.12 release contains several fixed issues that improve performance, system status reporting, and user experience.
+
+Consistent FlowCollector pipeline status::
+Before this update, changes to the sampling field caused an inconsistency in the `FlowCollector` resource status. As a consequence, you could see conflicting statuses across pipeline components.
++
+With this release, status reporting is made consistent across all components. As a result, the reliability of the pipeline status indicator is improved.
++
+link:https://issues.redhat.com/browse/NETOBSERV-2375[NETOBSERV-2375]
+
+Fixed `--help` flag processing in netobserv-cli::
+Before this update, the `--help` flag was ignored when placed after other command flags in the Network Observability CLI. As a consequence, running commands such as `oc netobserv flows --interfaces=br-ex --max-time=10s --help` executed the flow collection instead of displaying the help page.
++
+With this release, the `--help` flag is recognized regardless of its position in the command. As a result, you can now display help information by placing the `--help` flag anywhere in your command arguments.
++
+link:https://issues.redhat.com/browse/NETOBSERV-2617[NETOBSERV-2617]
+
+Improved visibility of DNS names warning messages::
+Before this update, the **DNS names** graph repeatedly displayed a warning message on every refresh when running in a Prometheus-only configuration. As a consequence, the persistent warning message covered other dashboard elements.
++
+With this release, the warning message is only displayed during the initial data load and does not overlay other content. As a result, interface clarity is improved when navigating the dashboard.
++
+link:https://issues.redhat.com/browse/NETOBSERV-2618[NETOBSERV-2618]
+
+Prometheus enabled by default in FlowCollector configurations::
+Before this update, the default setting for Prometheus metrics was unassigned during `FlowCollector` custom resource creation. As a consequence, you had to manually ensure that metrics collection was active to query accurate flow data.
++
+With this release, the default value for Prometheus metrics collection in the `FlowCollector` configuration is set to `true`. As a result, the deployment process is simplified and flow metrics are collected automatically.
++
+link:https://issues.redhat.com/browse/NETOBSERV-2620[NETOBSERV-2620]
+
+Usage examples added to CLI subcommand help text::
+Before this update, the `help` subcommands for the Network Observability CLI lacked syntax examples. As a consequence, understanding how to construct complex filtering and capture commands required additional research.
++
+With this release, clear examples are included in the subcommand help outputs. As a result, the usability and discoverability of the CLI features are enhanced.
++
+link:https://issues.redhat.com/browse/NETOBSERV-2646[NETOBSERV-2646]
+
+Corrected latency formatting for values above one second::
+Before this update, flow durations and network latencies greater than one second were improperly formatted as milliseconds. As a consequence, donut graphs and latency metrics displayed confusing or inaccurate time designations.
++
+With this release, the duration formatting function handles values greater than one millisecond accurately using decimal seconds. As a result, you can view precise network latency values in console charts.
++
+link:https://issues.redhat.com/browse/NETOBSERV-2669[NETOBSERV-2669]
+
+Improved FlowCollector status reporting when eBPF pods are absent::
+Before this update, the `FlowCollector` resource reported a status of `Ready` even when a restrictive `nodeSelector` prevented any eBPF agent pods from deploying. As a consequence, the system status misrepresented the health of the agent layer.
++
+With this release, the Operator checks for a zero-pod deployment count. As a result, the `FlowCollector` CR now correctly identifies when zero eBPF pods are active, improving cluster error diagnostics.
++
+link:https://issues.redhat.com/browse/NETOBSERV-2674[NETOBSERV-2674]
+
+Optimized field exports for OpenTelemetry exporters::
+Before this update, the OpenTelemetry exporter processed missing or null keys as non-null data. As a consequence, unpopulated `metadata` fields were exported to log streams, which increased storage usage and cluttered telemetry files.
++
+With this release, the OpenTelemetry exporter filters out null or unrelated fields, exporting only keys that belong to explicitly enabled features. As a result, exported log sizes are reduced and data efficiency is improved.
++
+link:https://issues.redhat.com/browse/NETOBSERV-2705[NETOBSERV-2705]
+
+Added sampling probability fields to IPFIX exports::
+Before this update, Internet Protocol Flow Information Export (IPFIX) record exports omitted per-flow sampling information. As a consequence, data exports failed to comply with the standard IPFIX specifications for `samplingProbability` usage.
++
+With this release, the exporter includes sampling probability details within the IPFIX packet metadata. As a result, exported OpenTelemetry data matches industry compliance standards.
++
+link:https://issues.redhat.com/browse/NETOBSERV-2706[NETOBSERV-2706]
+
+Fixed TLS volume name conflicts on OpenTelemetry exporters::
+Before this update, configuring TLS certificates on OpenTelemetry exporters generated an invalid volume name format. As a consequence, the `apiserver` rejected the underlying Flow-logs Pipeline deployment specification, causing the pipeline pod to fail during initialization.
++
+With this release, the Operator ensures valid volume names are generated when handling TLS attributes. As a result, enabling TLS on your OpenTelemetry exporters no longer interferes with pipeline pod lifecycles.
++
+link:https://issues.redhat.com/browse/NETOBSERV-2707[NETOBSERV-2707]
+
+Improved pod-to-pod flow filter rule matching for asymmetric CIDR rules::
+Before this update, the default flow filter action was not enforced when a network flow failed to match both a CIDR rule and its corresponding `peerCIDR` rule identically. As a consequence, unexpected acknowledgment-only, `ACK`, flows bypass filtering restrictions inside the pod network.
++
+With this release, when a network flow matches a designated CIDR rule but fails the `peerCIDR` pairing, the default filtering action is correctly applied. As a result, traffic blocking and network rule isolation are handled more securely.
++
+link:https://issues.redhat.com/browse/NETOBSERV-2755[NETOBSERV-2755]

--- a/modules/network-observability-operator-release-notes-1-12-known-issues.adoc
+++ b/modules/network-observability-operator-release-notes-1-12-known-issues.adoc
@@ -1,0 +1,16 @@
+// Module included in the following assemblies:
+// * network_observability/network-observability-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="network-observability-operator-release-notes-1-12-known-issues_{context}"]
+= Network Observability Operator 1.12 known issues
+
+[role="_abstract"]
+The following known issues affect the Network Observability Operator 1.12 release.
+
+Operator fails to start when custom web console logos are configured::
+When you configure custom product logos in the `Console.operator.openshift.io` resource using the `spec.customization.logos` field, the Network Observability Operator pod fails to start during installation. The Operator incorrectly reports a validation error indicating that both `logos` and the deprecated `customLogoFile` fields are set, even though only `logos` is configured.
++
+To work around this problem, manually enable the Network Observability Operator {product-title} web console plugin by adding `netobserv-plugin-static` to the `spec.plugins` list in the `Console` cluster resource, or by enabling the plugin through the web console under *Administration* -> *Cluster Settings* -> *Configuration* -> *Console* -> *Console plugins*.
++
+link:https://issues.redhat.com/browse/NETOBSERV-2767[NETOBSERV-2767]

--- a/modules/network-observability-operator-release-notes-1-12-new-features-enhancements.adoc
+++ b/modules/network-observability-operator-release-notes-1-12-new-features-enhancements.adoc
@@ -1,0 +1,40 @@
+// Module included in the following assemblies:
+// * network_observability/network-observability-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="network-observability-operator-release-notes-1-12-new-features-enhancements_{context}"]
+= Network Observability Operator 1.12 new features and enhancements
+
+[role="_abstract"]
+The Network Observability Operator 1.12 release introduces non-decrypting TLS metadata tracking, Kafka message compression options, automated secondary network indexing, and expanded web console compatibility for {product-title} clusters.
+
+Transport Layer Security traffic metadata tracking::
+The Network Observability Operator can now capture and analyze Transport Layer Security (TLS) metadata from network flows without decrypting traffic. By extracting handshake details from `ClientHello` and `ServerHello` messages, the Operator provides visibility into encryption protocols while maintaining data privacy.
++
+The following key benefits include:
++
+* Security risk detection: Identify workloads using deprecated TLS versions (1.0, 1.1) or weak cipher suites.
+* Compliance auditing: Audit TLS configurations to meet regulatory requirements through metric aggregation and dashboard visualization.
+* Security posture assessment: Visualize encrypted network traffic with lock icons in the *Topology* view and identify unencrypted communications across your cluster.
+* Configure Prometheus alerts to automatically report insecure or non-compliant TLS configurations.
++
+To use this feature, enable `TLSTracking` in the `spec.agent.ebpf.features` list of the `FlowCollector` custom resource (CR).
+
+Support for Kafka compression::
+Message compression configuration is now available when using Kafka to scale network flow collection. Enabling compression reduces the network bandwidth required to transport flows and decreases the storage footprint on Kafka brokers.
++
+The following key benefits include:
++
+* Reduced network load: Compressing flow data minimizes the traffic volume between the eBPF agent or flowlogs-pipeline and your Kafka cluster.
+* Storage efficiency: Smaller message sizes lead to improved disk space utilization on Kafka brokers.
+* Tunable performance: Choose from several compression algorithms, such as `gzip`, `snappy`, `lz4`, or `zstd`, to balance CPU usage with compression ratios.
++
+To enable this feature, configure the `spec.kafka.compression` and `spec.exporters.kafka.compression` fields in the `FlowCollector` custom resource.
+
+Simplified secondary network indexing::
+The configuration process for secondary network indexing is now simplified.
++
+The `name` field in the `spec.processor.advanced.secondaryNetworks` list is deprecated and ignored. The Network Observability Operator automatically evaluates all secondary networks regardless of their assigned names, removing the requirement for manual name-matching entries in the `FlowCollector` CR.
+
+{product-title} web console compatibility::
+The Network Observability web console plugin is updated to support {product-title} 4.22 and later. Backward compatibility is maintained for {product-title} versions 4.14 through 4.21.

--- a/modules/network-observability-operator-release-notes-1-12-technology-preview.adoc
+++ b/modules/network-observability-operator-release-notes-1-12-technology-preview.adoc
@@ -1,0 +1,11 @@
+// Module included in the following assemblies:
+// * network_observability/network-observability-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="network-observability-operator-release-notes-1-12-technology-preview_{context}"]
+= Network Observability Operator 1.12 Technology Preview features
+
+[role="_abstract"]
+The Network Observability Operator is included by default as a Technology Preview feature in 1.12 and {product-title} 4.22. You can explore network traffic visualization and monitoring capabilities without performing a separate installation.
+
+To use this Technology Preview feature, you must enable the `NetworkObservabilityInstall` feature gate through a manifest file during cluster installation.

--- a/modules/network-observability-recording-rule-custom-configuration.adoc
+++ b/modules/network-observability-recording-rule-custom-configuration.adoc
@@ -1,0 +1,73 @@
+// Module included in the following assemblies:
+//
+// * network_observability/network-observability-health-rules.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="network-observability-configuring-custom-recording-rules_{context}"]
+= Optimizing dashboard metrics with recording rules
+
+[role="_abstract"]
+Create custom recording rules to pre-compute metrics for the *Network Health* dashboard. Recording rules require specific annotations and labels to integrate with the Network Observability Operator.
+
+.Prerequisites
+
+* Access to the cluster with `cluster-admin` privileges.
+* The Network Observability Operator is installed.
+* {product-title} 4.16 or later is installed.
+* Familiarity with PromQL.
+
+[IMPORTANT]
+====
+Custom `PrometheusRule` resources are not owned by the `FlowCollector` resource. Custom rules created in the `netobserv` namespace might be deleted if the Network Observability Operator is uninstalled. To prevent data loss, create custom rules in a different namespace, such as `openshift-monitoring`, and maintain a backup in version control.
+====
+
+.Procedure
+
+. Define a `PrometheusRule` resource in a YAML file, such as `custom-recording-rule.yaml`, ensuring the `netobserv: "true"` label and `netobserv.io/network-health` annotation are included:
++
+[source,yaml]
+----
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: my-recording-rules
+  namespace: openshift-monitoring
+  labels:
+    netobserv: "true"
+  annotations:
+    netobserv.io/network-health: |
+      {
+        "my_metric_per_namespace": {
+          "summary": "Custom metric is {{ $value }} in the namespace {{ $labels.namespace }}",
+          "description": "Custom metric is {{ $value }} in the namespace {{ $labels.namespace }}",
+          "netobserv_io_network_health": "{\"unit\":\"%\",\"upperBound\":\"100\",\"namespaceLabels\":[\"namespace\"],\"recordingThresholds\":{\"info\":\"10\",\"warning\":\"25\",\"critical\":\"50\"}}"
+        }
+      }
+spec:
+  groups:
+    - name: MyRecordingRules
+      interval: 30s
+      rules:
+        - record: my_metric_per_namespace
+          expr: (count by (namespace) (kube_pod_info) * 0 + 20)
+          labels:
+            netobserv: "true"
+----
+
+. Apply the custom recording rule by running the following command:
++
+[source,terminal]
+----
+$ oc apply -f custom-recording-rule.yaml
+----
+
+.Verification
+
+. Confirm the `PrometheusRule` resource exists by running the following command:
++
+[source,terminal]
+----
+$ oc get prometheusrules my-recording-rules -n openshift-monitoring -o yaml
+----
+
+. Confirm the recording rule appears in the {product-title} web console by navigating to *Observe* → *Network Health*.

--- a/modules/network-observability-tls-monitoring-overview.adoc
+++ b/modules/network-observability-tls-monitoring-overview.adoc
@@ -1,0 +1,34 @@
+// Module included in the following assemblies:
+//
+// * observability/network_observability/network-observability-monitoring-tls-traffic.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="network-observability-tls-monitoring-overview_{context}"]
+= Transport Layer Security traffic monitoring
+
+[role="_abstract"]
+Transport Layer Security (TLS) traffic monitoring identifies security risks and maintains compliance by analyzing encrypted traffic metadata without decryption.
+
+As a network administrator or security practitioner, you must verify that encrypted traffic uses secure protocols and cipher suites. Monitoring TLS usage identifies security risks, such as workloads that use deprecated TLS versions, and helps maintain compliance with cluster security policies.
+
+[id="tls-monitoring-security-benefits_{context}"]
+== Security improvements through metadata analysis
+
+The Network Observability Operator captures TLS metadata from handshake messages without decrypting traffic, providing visibility into encryption protocols while maintaining data privacy. This approach enables the following improvements:
+
+Security risk detection:: Identifies workloads using deprecated TLS versions (1.0, 1.1) or weak cipher suites by capturing TLS version, cipher suite, and group information. You can configure Prometheus alerts to automatically report deprecated TLS configurations.
+
+Compliance auditing:: Audits TLS configurations to meet regulatory requirements through metric aggregation in dashboard charts and overview panels. You can filter flows by TLS fields to isolate specific protocol versions or cipher suites for compliance reporting.
+
+Security posture assessment:: Visualizes encrypted network traffic with lock icons in the topology view and identifies unencrypted communications across your cluster. You can analyze TLS usage patterns to evaluate your overall security posture.
+
+Remediation prioritization:: Targets workloads using deprecated protocols for updates by filtering and analyzing TLS fields to isolate problematic connections requiring immediate attention.
+
+[id="monitoring-tls-traffic-workflow_{context}"]
+== TLS traffic monitoring workflow phases
+
+To monitor TLS traffic effectively, complete the following phases:
+
+* Enable the TLS tracking feature in the eBPF agent configuration.
+* Analyze TLS traffic details in the *Network Traffic* view.
+* Visualize secure connections in the *Topology* view.

--- a/modules/network-observability-tls-tracking-fields.adoc
+++ b/modules/network-observability-tls-tracking-fields.adoc
@@ -1,0 +1,52 @@
+// Module included in the following assemblies:
+//
+// * observability/network_observability/network-observability-monitoring-tls-traffic.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="tls-tracking-fields_{context}"]
+= Transport Layer Security tracking fields reference
+
+[role="_abstract"]
+Transport Layer Security (TLS) metadata fields track and define encryption protocols, protocol versions, and cipher suite data to help you analyze secure network flows.
+
+.TLS tracking fields
+[cols="1,2,2,2",options="header"]
+|===
+|Field |Description |Possible values |Availability
+
+|*TLS Version*
+|Negotiated TLS protocol version.
+a|* `1.0`: Deprecated
+* `1.1`: Deprecated
+* `1.2`: Secure
+* `1.3`: Current standard
+a|`ClientHello`, `ServerHello`
+
+`ClientHello` displays the version requested by the client. `ServerHello` displays the negotiated version selected by the server.
+
+|*TLS Cipher Suite*
+|Cryptographic algorithm suite negotiated between the client and server.
+a|Examples:
+
+* `TLS_AES_256_GCM_SHA384`
+* `TLS_CHACHA20_POLY1305_SHA256`
+a|`ServerHello` only
+
+Displays as `n/a` in `ClientHello` messages.
+
+|*TLS Group*
+|Elliptic curve used for key exchange.
+a|Examples:
+
+* `X25519`: Recommended for TLS 1.3
+* `secp256r1` (P-256)
+a|`ServerHello` (TLS 1.3 only)
+
+Displays as `n/a` in `ClientHello` messages and TLS 1.2 connections.
+
+|*TLS Types*
+|Type of TLS handshake message captured.
+a|* `ClientHello`: Initial client request
+* `ServerHello`: Server response
+|All TLS flows
+|===

--- a/observability/network_observability/installing-operators.adoc
+++ b/observability/network_observability/installing-operators.adoc
@@ -75,7 +75,6 @@ include::modules/network-observability-multitenancy.adoc[leveloffset=+1]
 .Additional resources
 * xref:../../operators/operator-reference.adoc#cluster-kube-storage-version-migrator-operator_operator-reference[Kubernetes Storage Version Migrator Operator]
 
-include::modules/network-observability-kafka-option.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources

--- a/observability/network_observability/network-observability-health-rules.adoc
+++ b/observability/network_observability/network-observability-health-rules.adoc
@@ -1,6 +1,6 @@
 
 :_mod-docs-content-type: ASSEMBLY
-[id="network-observability-health-rules_{context}"]
+[id="network-observability-health-rules"]
 = Network observability health rules
 :context: network-observability-health-rules
 :toc:
@@ -20,13 +20,15 @@ include::modules/network-observability-health-rules-and-performance.adoc[levelof
 
 include::modules/network-observability-health-rules-monitoring-and-alerting.adoc[leveloffset=+2]
 
-include::modules/network-observability-health-rules-recording-rules-performance-optimization.adoc[leveloffset=+1]
-
 include::modules/network-observability-health-rule-structure-customization.adoc[leveloffset=+1]
 
 include::modules/network-observability-health-rules-promql-expressions-metadata.adoc[leveloffset=+2]
 
 include::modules/network-observability-custom-health-rule-configuration.adoc[leveloffset=+2]
+
+include::modules/network-observability-health-rules-recording-rules-performance-optimization.adoc[leveloffset=+1]
+
+include::modules/network-observability-recording-rule-custom-configuration.adoc[leveloffset=+2]
 
 include::modules/network-observability-disable-predefined-rules.adoc[leveloffset=+1]
 

--- a/observability/network_observability/network-observability-kafka-operator-scaling-network-flow-collection.adoc
+++ b/observability/network_observability/network-observability-kafka-operator-scaling-network-flow-collection.adoc
@@ -1,0 +1,25 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="network-observability-kafka-operator-scaling-network-flow-collection"]
+= Scaling network flow collection with Kafka
+include::_attributes/common-attributes.adoc[]
+:context: network-observability-kafka-operator-scaling-network-flow-collection
+
+toc::[]
+
+[role="_abstract"]
+Scale your network flow collection by using the Kafka Operator to manage high-volume telemetry. Configure compression to reduce network bandwidth while balancing CPU overhead in large-scale cluster environments.
+
+include::modules/network-observability-kafka-for-large-scale-environments.adoc[leveloffset=+1]
+
+include::modules/network-observability-kafka-compression-benefits.adoc[leveloffset=+1]
+
+include::modules/network-observability-configuring-kafka-compression.adoc[leveloffset=+1]
+
+include::modules/network-observability-kafka-compression-codec-reference.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+[id="additional-resources_{context}"]
+== Additional resources
+
+* link:https://access.redhat.com/documentation/en-us/red_hat_amq_streams[Red Hat AMQ Streams documentation]
+* xref:../../observability/network_observability/configuring-operator.adoc#network-observability-flowcollector-kafka-config_network_observability[Configuring the FlowCollector resource with Kafka]

--- a/observability/network_observability/network-observability-monitoring-tls-traffic.adoc
+++ b/observability/network_observability/network-observability-monitoring-tls-traffic.adoc
@@ -1,0 +1,19 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="network-observability-monitoring-tls-traffic"]
+= Monitoring Transport Layer Security traffic
+include::_attributes/common-attributes.adoc[]
+:context: network-observability-monitoring-tls-traffic
+
+toc::[]
+
+[role="_abstract"]
+[role="_abstract"]
+Monitor TLS traffic to identify insecure protocols, detect security risks, and maintain compliance without decrypting traffic.
+
+include::modules/network-observability-tls-monitoring-overview.adoc[leveloffset=+1]
+
+include::modules/network-observability-enable-tls-tracking.adoc[leveloffset=+1]
+
+include::modules/network-observability-analyze-tls-traffic.adoc[leveloffset=+1]
+
+include::modules/network-observability-tls-tracking-fields.adoc[leveloffset=+1]

--- a/observability/network_observability/network-observability-operator-release-notes.adoc
+++ b/observability/network_observability/network-observability-operator-release-notes.adoc
@@ -8,22 +8,18 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 [role="_abstract"]
-Find information about new features, security advisories, fixed issues, and known issues for the Network Observability Operator, and stay informed about changes and performance enhancements in the latest version of the operator for {product-title}.
+Review new features, enhancements, fixed issues, and known issues for the Network Observability Operator. These release notes provide information to help you understand changes and security advisories in the latest Operator release.
 
 The Network Observability Operator enables administrators to observe and analyze network traffic flows for {product-title} clusters.
 
 These release notes track the development of the Network Observability Operator in the {product-title}.
 
-include::modules/network-observability-operator-release-notes-1-11-2-advisory.adoc[leveloffset=+1]
+include::modules/network-observability-operator-release-notes-1-12-advisory.adoc[leveloffset=+1]
 
-include::modules/network-observability-operator-release-notes-1-11-1-advisory.adoc[leveloffset=+1]
+include::modules/network-observability-operator-release-notes-1-12-new-features-enhancements.adoc[leveloffset=+1]
 
-include::modules/network-observability-operator-release-notes-1-11-1-fixed-issues.adoc[leveloffset=+1]
+include::modules/network-observability-operator-release-notes-1-12-technology-preview.adoc[leveloffset=+1]
 
-include::modules/network-observability-operator-release-notes-1-11-advisory.adoc[leveloffset=+1]
+include::modules/network-observability-operator-release-notes-1-12-fixed-issues.adoc[leveloffset=+1]
 
-include::modules/network-observability-operator-release-notes-1-11-new-features-enhancements.adoc[leveloffset=+1]
-
-include::modules/network-observability-operator-release-notes-1-11-known-issues.adoc[leveloffset=+1]
-
-include::modules/network-observability-operator-release-notes-1-11-fixed-issues.adoc[leveloffset=+1]
+include::modules/network-observability-operator-release-notes-1-12-known-issues.adoc[leveloffset=+1]

--- a/observability/network_observability/release_notes_archive/network-observability-operator-release-notes-archive.adoc
+++ b/observability/network_observability/release_notes_archive/network-observability-operator-release-notes-archive.adoc
@@ -13,6 +13,21 @@ These release notes track past developments of the Network Observability Operato
 
 The Network Observability Operator enables administrators to observe and analyze network traffic flows for {product-title} clusters.
 
+
+include::modules/network-observability-operator-release-notes-1-11-2-advisory.adoc[leveloffset=+1]
+
+include::modules/network-observability-operator-release-notes-1-11-1-advisory.adoc[leveloffset=+1]
+
+include::modules/network-observability-operator-release-notes-1-11-1-fixed-issues.adoc[leveloffset=+1]
+
+include::modules/network-observability-operator-release-notes-1-11-advisory.adoc[leveloffset=+1]
+
+include::modules/network-observability-operator-release-notes-1-11-new-features-enhancements.adoc[leveloffset=+1]
+
+include::modules/network-observability-operator-release-notes-1-11-known-issues.adoc[leveloffset=+1]
+
+include::modules/network-observability-operator-release-notes-1-11-fixed-issues.adoc[leveloffset=+1]
+
 include::modules/network-observability-operator-release-notes-1-10-1.adoc[leveloffset=+1]
 
 include::modules/network-observability-operator-release-notes-1-10-1-cves.adoc[leveloffset=+1]


### PR DESCRIPTION
Integration Branch for release branch `no-1.12`

This PR integrates all commits to the `no-1.12` release branch with `main` and `enterprise-4.12`, `enterprise-4.14`, `enterprise-4.16+`

All files in this PR have been SME/QE, Peer and merge reviewed. This PR is for merging only.

Version(s):
4.12, 4.14, 4.16+

Issue:
https://redhat.atlassian.net/browse/OSDOCS-20077

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change. All content in this integration release branch has been peer review/merge review/QE/SME ack'd before it was merged into the `no-1.12` branch. This PR simply integrates all that merged content into `main` , `enterprise-4.12`, `enterprise-4.14`, `enterprise-4.16+`. NetObserv GA: 06/08/26.

Additional information:
* Cherry pick failures are expected as not all content applies to all OCP versions. Manual cherry-picks will be created.
* Commits are kept for reference and verification purposes. See OCP Docs Manual > GA preparation (integrating your release branch with main) > Step 6 https://docs.google.com/document/d/1fLMpK4bqthtFlCwA36yeo2cI-pExFpX76VMnSi_In6Q/edit?tab=t.0 : You can optionally not squash commits if its easier to show any stakeholders the individual commits.
* Per OCP Core, no migration updates were made to the automatically generated API docs. Automatically generated API docs are still "Pending further discussion."
* Previous integration branch PRs for reference:
    * https://github.com/openshift/openshift-docs/pull/95552
    * https://github.com/openshift/openshift-docs/pull/101238
    * https://github.com/openshift/openshift-docs/pull/106887

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
