### PR TITLE
OSDOCS-20079: updates RHCL 1.4.0 release notes

### DIFF
--- a/_attributes/attributes.adoc
+++ b/_attributes/attributes.adoc
@@ -14,6 +14,7 @@
 :mcpg-version: 0.7.0
 
 :version: 1.4
+:version-2: 1.2
 :version-1: 1.3.x
 :operator-version: 1.4.0
 :ocp: OpenShift Container Platform

--- a/modules/ref-relnotes-about.adoc
+++ b/modules/ref-relnotes-about.adoc
@@ -9,4 +9,8 @@
 [role="_abstract"]
 {prodname} {version} (RHEA-2026:XXXXX) is now available. This release includes the {mcpg} {mcpg-version} as a Technology Preview feature. New features, changes, and known issues that pertain to {prodname} {version} are included in this topic.
 
-Starting from {prodname} {version}, full support begins at the GA/release of the minor version and ends with the release of the superseding minor release (typically 4 months after the GA date). See the link:https://access.redhat.com/RedHatConnectivityLink[Red Hat Connectivity Link Life Cycle Policy] for details about version support and {ocp} compatibility.
+Starting with {prodname} {version}, full support ends with the release of the next minor version. Maintenance support ends with the minor version after that. See the link:https://access.redhat.com/RedHatConnectivityLink[Red Hat Connectivity Link Life Cycle Policy] for details about version support and {ocp} compatibility.
+
+Important lifecycle update for {prodname} 1.3::
+
+With this release, the maintenance support lifecycle for {prodname} 1.3 is updated. Maintenance Support for version 1.3 ends with the release of {prodname} 1.5. The maintenance lifecycle of 1.3 was announced before as ending with version {prodname} 1.6.

--- a/modules/ref-relnotes-tech-preview.adoc
+++ b/modules/ref-relnotes-tech-preview.adoc
@@ -18,7 +18,7 @@ Technology Preview features give you early access to upcoming product features, 
 
 Support for `GRPCRoute` policy attachment::
 
-Beginning with {prodname} 1.4.0, `GRPCRoute` policy attachment support is available as a Technology Preview feature. You can attach `AuthPolicy` and `RateLimitPolicy` custom resources (CRs) to `GRPCRoute` CRs, enabling authentication and rate-limiting controls for gRPC services with native `service` and `method` matching.
+With this {prodname} release, `GRPCRoute` policy attachment support is available as a Technology Preview feature. You can attach `AuthPolicy` and `RateLimitPolicy` custom resources (CRs) to `GRPCRoute` CRs, enabling authentication and rate-limiting controls for gRPC services with native `service` and `method` matching.
 
 For more information, see xref:../deployment/deployment.adoc#con-about-grpc-support_rhcl-config-deploy-gateway-policies[About GRPCRoute policy attachment support].
 
@@ -32,4 +32,4 @@ For more information, see xref:../install-rhcl/rhcl-install-disconnected.adoc#rh
 
 With this {prodname} release, you can use the {ocp} web console to manage your APIs and access to them with the OpenShift web console. You can manage an API catalog and role-based access. You can also see the relationships between your API products and attached resources, such as policies and routes, in a dynamic graph view.
 
-//For more information, see xref:../develop/rhcl-api-management.adoc#rhcl-api-management[Create, share, and consume APIs across teams]
+For more information, see xref:../develop/rhcl-api-management.adoc#rhcl-api-management[Create, share, and consume APIs across teams].


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
rhcl-docs-1.4

Issue:
[OSDOCS-20079](https://redhat.atlassian.net/browse/OSDOCS-20079)

Link to docs preview:
https://112944--ocpdocs-pr.netlify.app/rhcl/latest/release_notes/rhcl-release-notes.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Notes:
For release 11 June; awaiting final advisory number and QE. Please review but do not merge.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
