### PR TITLE
OSDOCS-20083: update MCP audit trail docs with QE test

### DIFF
--- a/modules/proc-mcp-gateway-add-custom-audit-log-provider.adoc
+++ b/modules/proc-mcp-gateway-add-custom-audit-log-provider.adoc
@@ -38,25 +38,26 @@ metadata:
 spec:
   meshConfig:
     extensionProviders:
-      - name: mcp-json-access-log
-        file:
+      - envoyFileAccessLog:
+          logFormat:
+            labels:
+              bytes_received: '%BYTES_RECEIVED%'
+              bytes_sent: '%BYTES_SENT%'
+              duration_ms: '%DURATION%'
+              mcp_method: '%REQ(X-MCP-METHOD)%'
+              mcp_server_name: '%REQ(X-MCP-SERVERNAME)%'
+              mcp_session_id: '%REQ(MCP-SESSION-ID)%'
+              mcp_tool_name: '%REQ(X-MCP-TOOLNAME)%'
+              mcp_user_id: '%REQ(X-AUTH-IDENTITY)%'
+              method: '%REQ(:METHOD)%'
+              path: '%REQ(:PATH)%'
+              request_id: '%REQ(X-REQUEST-ID)%'
+              response_code: '%RESPONSE_CODE%'
+              timestamp: '%START_TIME%'
+              traceparent: '%REQ(TRACEPARENT)%'
+              upstream_host: '%UPSTREAM_HOST%'
           path: /dev/stdout
-          jsonFormat:
-            timestamp: "%START_TIME%"
-            method: "%REQ(:METHOD)%"
-            path: "%REQ(:PATH)%"
-            response_code: "%RESPONSE_CODE%"
-            request_id: "%REQ(X-REQUEST-ID)%"
-            traceparent: "%REQ(TRACEPARENT)%"
-            mcp_method: "%REQ(X-MCP-METHOD)%"
-            mcp_tool_name: "%REQ(X-MCP-TOOLNAME)%"
-            mcp_server_name: "%REQ(X-MCP-SERVERNAME)%"
-            mcp_session_id: "%REQ(MCP-SESSION-ID)%"
-            mcp_user_id: "%REQ(X-AUTH-IDENTITY)%"
-            duration_ms: "%DURATION%"
-            upstream_host: "%UPSTREAM_HOST%"
-            bytes_sent: "%BYTES_SENT%"
-            bytes_received: "%BYTES_RECEIVED%"
+        name: mcp-json-access-log
 #...
 ----
 +


### PR DESCRIPTION
Version(s):
rhcl-docs-1.4

Issue:
[OSDOCS-20083](https://redhat.atlassian.net/browse/OSDOCS-20083)

Link to docs preview:
https://112960--ocpdocs-pr.netlify.app/rhcl/latest/observe/mcp-gateway-observe.html#proc-mcp-gateway-add-custom-audit-log-provider_mcp-gateway-observe

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Updates https://github.com/openshift/openshift-docs/pull/112003/changes#diff-dc13a8cfaf8301a737388d1bbfd932a163f6f4aee2101443e051693cd02e547eR28

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
