### PR TITLE
CNV-89504: Add 1 CNV release note for 4.22

### DIFF
--- a/virt/release_notes/virt-4-22-release-notes.adoc
+++ b/virt/release_notes/virt-4-22-release-notes.adoc
@@ -297,13 +297,15 @@ To work around this problem, use user accounts instead of service accounts, beca
 +
 link:https://issues.redhat.com/browse/CNV-33835[CNV-33835]
 
-Upgrading to {VirtProductName} 4.21 when using wasp-agent:: If you are upgrading {VirtProductName} from version 4.20 to 4.21 and using `wasp-agent` to increase VM workload density, you must perform the following steps after you begin the upgrade:
-
-. Wait for the Machine Configuration Pool (MCP) to complete the updating of the infra nodes.
-
+Upgrading to {VirtProductName} 4.22 when using wasp-agent::
++
+If you are upgrading {VirtProductName} from version 4.20 to 4.22 and using `wasp-agent` to increase VM workload density, you must perform the following steps after you begin the upgrade:
++
+. Wait for the Machine Configuration Pool (MCP) to complete updating the control-plane nodes.
++
 . Edit the `KubeletConfig` file to remove the `failSwapOn: false` key-value pair.
-
++
 . Wait for the MCP to finish updating the worker nodes.
 
 +
-link:https://issues.redhat.com/browse/CNV-75837[CNV-75837]
+link:https://redhat.atlassian.net/browse/CNV-89504[CNV-89504]


### PR DESCRIPTION
Version(s):
4.22

Issue:
https://redhat.atlassian.net/browse/CNV-89504

Link to docs preview:
https://112986--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/release_notes/virt-4-22-release-notes.html#virt-4-22-known-issues_virt-4-22-release-notes

QE review:
- [x] QE has approved this change.

Additional information:
Adds 1 CNV known issue for OpenShift Virtualization 4.22 regarding wasp-agent upgrade process from version 4.20.

---

🤖 Generated with Claude Code