### PR TITLE
CNV-88591: Removed important note from configuring LUN disks

### DIFF
--- a/modules/virt-configuring-disk-sharing-lun.adoc
+++ b/modules/virt-configuring-disk-sharing-lun.adoc
@@ -22,11 +22,6 @@ You can set an error policy for each LUN disk. The error policy controls how the
 
 For a LUN disk with an SCSi connection and a persistent reservation, as required for Windows Failover Clustering for shared volumes, you set the error policy to `report`.
 
-[IMPORTANT]
-====
-{VirtProductName} does not currently support SCSI-3 Persistent Reservations (SCSI-3 PR) over multipath storage. As a workaround, disable multipath or ensure the Windows Server Failover Clustering (WSFC) shared disk is setup from a single device and not part of multipath.
-====
-
 .Prerequisites
 
 * You must have cluster administrator privileges to configure the feature gate option.


### PR DESCRIPTION
Version(s):
Main, 4.18, 4.19, 4.21, 4.22. 5.0

Issues:

- [CNV-88591](https://redhat.atlassian.net/browse/CNV-88591)
- [CNV-88595](https://redhat.atlassian.net/browse/CNV-88595)

[Link to docs preview](https://113012--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/managing_vms/virtual_disks/virt-configuring-shared-volumes-for-vms.html)

QE review:
- [x] QE has approved this change.
