### PR TITLE
PR for SRVOCF-637: Added "Configuring HTTPS for functions with cert-manager" chapter in the Serverless section 

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -73,6 +73,8 @@ Topics:
   File: serverless-functions-eventing
 - Name: Subscribing functions to CloudEvents
   File: serverless-functions-subscribing
+- Name: Configuring HTTPS for functions with cert-manager
+  File: serverless-functions-configuring-https-cert-manager
 - Name: Functions development reference guide
   Dir: reference
   Topics:

--- a/functions/serverless-functions-configuring-https-cert-manager.adoc
+++ b/functions/serverless-functions-configuring-https-cert-manager.adoc
@@ -1,0 +1,27 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="serverless-functions-configuring-https-cert-manager"]
+= Configuring HTTPS for functions with cert-manager
+:context: serverless-functions-configuring-https-cert-manager
+include::_attributes/common-attributes.adoc[]
+
+toc::[]
+
+[role="_abstract"]
+You can configure automatic TLS certificate provisioning for {FunctionsProductName} by using cert-manager. This enables your functions to be served over HTTPS with custom domains, with certificates automatically requested and renewed from a configured certificate authority such as Let's Encrypt.
+
+include::modules/about-tls-certificates-serverless-functions.adoc[leveloffset=+1]
+
+include::modules/prerequisites-configuring-https-serverless-functions.adoc[leveloffset=+1]
+
+include::modules/deploying-function-custom-domain-https.adoc[leveloffset=+1]
+
+include::modules/enabling-cluster-domain-allocation.adoc[leveloffset=+1]
+
+include::modules/troubleshooting-https-serverless-functions.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+== Additional resources
+
+* link:https://cert-manager.io/docs/[cert-manager documentation]
+* link:https://knative.dev/docs/serving/encryption/encryption-overview/[Knative Serving encryption overview]
+* link:https://knative.dev/docs/serving/using-a-custom-domain/[Configuring custom domains for Knative services]

--- a/functions/serverless-functions-getting-started.adoc
+++ b/functions/serverless-functions-getting-started.adoc
@@ -28,7 +28,7 @@ include::modules/serverless-functions-creating-deploying-invoking.adoc[leveloffs
 
 * link:https://docs.openshift.com/container-platform/latest/registry/securing-exposing-registry.html#securing-exposing-registry[Exposing a default registry manually]
 
-* link:https://plugins.jetbrains.com/plugin/16476-knative\--serverless-functions-by-red-hat[Marketplace page for the Intellij Knative plugin]
+* link:https://plugins.jetbrains.com/plugin/16476-knative\--serverless-functions-by-red-hat[Marketplace page for the IntelliJ Knative plugin]
 
 * link:https://marketplace.visualstudio.com/items?itemName=redhat.vscode-knative&utm_source=VSCode.pro&utm_campaign=AhmadAwais[Marketplace page for the Visual Studio Code Knative plugin]
 

--- a/modules/about-tls-certificates-serverless-functions.adoc
+++ b/modules/about-tls-certificates-serverless-functions.adoc
@@ -1,0 +1,17 @@
+// Module included in the following assemblies:
+//
+// * serverless/functions/serverless-functions-configuring-https-cert-manager.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="about-tls-certificates-serverless-functions_{context}"]
+= TLS certificates for Serverless Functions
+
+[role="_abstract"]
+Knative Serving integrates with cert-manager to automatically provision and manage TLS certificates for your services. When a custom domain is mapped to a Knative service, cert-manager detects the new domain, requests a certificate from the configured certificate authority, and attaches the certificate to the route. HTTPS is enforced automatically, with HTTP requests redirected to HTTPS.
+
+{FunctionsProductName} exposes this integration through the `--domain` flag on the `func deploy` command. When you deploy a function with `--domain`, the CLI sets a `func.domain` label on the Knative Service. Knative Serving uses this label to match the service to a configured domain in the `config-domain` ConfigMap, which determines the external domain under which the function is reachable.
+
+[IMPORTANT]
+====
+This feature is a Technology Preview. The `--domain` flag sets the domain label on the function, but you must manually create a `DomainMapping` resource to complete the routing. Automatic creation of domain mappings is planned for a future release.
+====

--- a/modules/deploying-function-custom-domain-https.adoc
+++ b/modules/deploying-function-custom-domain-https.adoc
@@ -1,0 +1,105 @@
+// Module included in the following assemblies:
+//
+// * serverless/functions/serverless-functions-configuring-https-cert-manager.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="deploying-function-custom-domain-https_{context}"]
+= Deploying a function with a custom domain and HTTPS
+
+[role="_abstract"]
+You can deploy a Serverless function with a custom domain and automatic TLS by using the `--domain` flag and creating a `DomainMapping` resource.
+
+.Prerequisites
+
+* You have satisfied the prerequisites for configuring HTTPS for Serverless Functions.
+
+.Procedure
+
+. Create a new function:
++
+[source,terminal]
+----
+$ func create -l <language> <function_name>
+----
+
+. Change to the function directory:
++
+[source,terminal]
+----
+$ cd <function_name>
+----
+
+. Deploy the function with the `--domain` flag:
++
+[source,terminal]
+----
+$ func deploy --domain <domain_name>
+----
++
+where:
++
+--
+* `<domain_name>` specifies the domain configured in the `config-domain` ConfigMap. For example, `example.com`. The function is reachable at `<function_name>.<domain_name>`.
+--
+
+. Create a `DomainMapping` resource to map your custom domain to the function:
++
+[source,terminal]
+----
+$ oc apply -f - <<EOF
+apiVersion: serving.knative.dev/v1beta1
+kind: DomainMapping
+metadata:
+  name: <function_name>.<domain_name>
+  namespace: <namespace>
+spec:
+  ref:
+    name: <function_name>
+    kind: Service
+    apiVersion: serving.knative.dev/v1
+EOF
+----
++
+where:
++
+--
+* `<function_name>` specifies the name of your function.
+* `<domain_name>` specifies your custom domain.
+* `<namespace>` specifies the namespace where your function is deployed.
+--
++
+After you create the `DomainMapping`, cert-manager automatically requests a TLS certificate for the domain and attaches it to the route.
+
+.Verification
+
+. Verify that the `DomainMapping` resource is ready:
++
+[source,terminal]
+----
+$ oc get domainmapping <function_name>.<domain_name>
+----
++
+.Example output
+[source,terminal]
+----
+NAME                    URL                             READY   REASON
+myfunc.example.com      https://myfunc.example.com      True
+----
++
+The `READY` column shows `True` and the `URL` column shows the `https` scheme when the certificate has been provisioned successfully.
+
+. Verify that the TLS certificate has been issued:
++
+[source,terminal]
+----
+$ oc get certificates -n <namespace>
+----
++
+The certificate status shows `True` in the `READY` column when provisioning is complete.
+
+. Send a request to verify HTTPS access:
++
+[source,terminal]
+----
+$ curl https://<function_name>.<domain_name>
+----

--- a/modules/enabling-cluster-domain-allocation.adoc
+++ b/modules/enabling-cluster-domain-allocation.adoc
@@ -1,0 +1,50 @@
+// Module included in the following assemblies:
+//
+// * serverless/functions/serverless-functions-configuring-https-cert-manager.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="enabling-cluster-domain-allocation_{context}"]
+= Enabling cluster domain allocation
+
+[role="_abstract"]
+When you create a `DomainMapping` resource, Knative requires a corresponding `ClusterDomainClaim` to authorize use of that domain. You can either enable automatic creation of these claims, or create them manually for each domain.
+
+.Automatic allocation
+
+If your cluster policy allows it, you can enable automatic creation of `ClusterDomainClaim` resources by setting the following in the `config-network` ConfigMap in the `knative-serving` namespace:
+
+[source,yaml]
+----
+autocreate-cluster-domain-claims: "true"
+----
+
+With this setting enabled, Knative automatically creates a `ClusterDomainClaim` whenever a `DomainMapping` is created. This is the simplest configuration but grants any namespace the ability to claim any domain.
+
+.Manual allocation
+
+If automatic allocation is not enabled, you must create a `ClusterDomainClaim` for each domain before creating a `DomainMapping`.
+
+.Procedure
+
+. Create a `ClusterDomainClaim` resource:
++
+[source,terminal]
+----
+$ oc apply -f - <<EOF
+apiVersion: networking.internal.knative.dev/v1alpha1
+kind: ClusterDomainClaim
+metadata:
+  name: <function_name>.<domain_name>
+spec:
+  namespace: <namespace>
+EOF
+----
++
+where:
++
+--
+* `<function_name>.<domain_name>` specifies the fully qualified domain name to claim. For example, `myfunc.example.com`.
+* `<namespace>` specifies the namespace that is authorized to use this domain.
+--
++
+Manual allocation gives cluster administrators explicit control over which namespaces can use which domains.

--- a/modules/prerequisites-configuring-https-serverless-functions.adoc
+++ b/modules/prerequisites-configuring-https-serverless-functions.adoc
@@ -1,0 +1,50 @@
+// Module included in the following assemblies:
+//
+// * serverless/functions/serverless-functions-configuring-https-cert-manager.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="prerequisites-configuring-https-serverless-functions_{context}"]
+= Prerequisites for configuring HTTPS for Serverless Functions
+
+[role="_abstract"]
+Before you can deploy a Serverless function with a custom domain and automatic TLS, you must configure cert-manager, Knative Serving, and your custom domain on the cluster.
+
+.Prerequisites
+
+* The {ServerlessOperatorName} and Knative Serving are installed on your cluster.
+
+* cert-manager is installed and configured with a `ClusterIssuer` that can issue certificates for your domain. For example, you can use Let's Encrypt with a DNS-01 challenge solver.
+
+* The `config-certmanager` ConfigMap in the `knative-serving` namespace references your `ClusterIssuer`:
++
+[source,yaml]
+----
+issuerRef: |
+  kind: ClusterIssuer
+  name: letsencrypt-issuer
+----
+
+* The `config-network` ConfigMap in the `knative-serving` namespace has TLS enabled:
++
+[source,yaml]
+----
+external-domain-tls: Enabled
+http-protocol: Redirected
+----
+
+* Your custom domain is configured in the `config-domain` ConfigMap in the `knative-serving` namespace with a `func.domain` label selector:
++
+[source,yaml]
+----
+example.com: |
+  selector:
+    func.domain: "example.com"
+----
+
+* Either automatic `ClusterDomainClaim` creation is enabled on the cluster, or a `ClusterDomainClaim` has been created for your domain. See "Enabling cluster domain allocation" for more information.
+
+* DNS is configured so that `*.<your_domain>` resolves to your cluster's ingress IP address.
+
+* You have installed the `func` CLI.
+
+* You have installed the `oc` CLI.

--- a/modules/troubleshooting-https-serverless-functions.adoc
+++ b/modules/troubleshooting-https-serverless-functions.adoc
@@ -1,0 +1,35 @@
+// Module included in the following assemblies:
+//
+// * serverless/functions/serverless-functions-configuring-https-cert-manager.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="troubleshooting-https-serverless-functions_{context}"]
+= Troubleshooting HTTPS for Serverless Functions
+
+[role="_abstract"]
+When configuring HTTPS for Serverless Functions, you might encounter issues with certificate provisioning or TLS configuration. This section describes common issues and their solutions.
+
+.The DomainMapping shows HTTPDowngrade in its status
+
+The TLS certificate is not yet ready. Knative Serving falls back to HTTP-only access until the certificate is provisioned. Check the certificate status:
+
+[source,terminal]
+----
+$ oc describe certificate <function_name>.<domain_name> -n <namespace>
+----
+
+If the certificate shows a rate-limit error, Let's Encrypt limits certificate issuance to 5 certificates per domain per week. Wait for the rate limit to reset and cert-manager retries automatically.
+
+.The certificate shows IncorrectIssuer
+
+The existing TLS secret was issued by a different `ClusterIssuer` than the one currently configured in the `config-certmanager` ConfigMap. Delete the existing secret to allow cert-manager to re-issue the certificate with the correct issuer:
+
+[source,terminal]
+----
+$ oc delete secret <secret_name> -n <namespace>
+----
+
+[NOTE]
+====
+Deleting and re-issuing certificates counts toward Let's Encrypt rate limits.
+====


### PR DESCRIPTION
**You can cherry-pick for the following branches:** 

- `serverless-docs-1.38`
- `serverless-docs-1.37`

**Tracking JIRA:** https://redhat.atlassian.net/browse/SRVOCF-637

**Changes:** 
Added a "[Configuring HTTPS for functions with cert-manager](https://113014--ocpdocs-pr.netlify.app/openshift-serverless/latest/functions/serverless-functions-configuring-https-cert-manager)" section under the Functions directory. 

**Reviews:**
- [ ] SME has approved this change
- [ ] QE has approved this change
- [ ] Peer has approved this change