### PR TITLE
OCPBUGS-86705: [enterprise-4.19] Hybrid cluster network cited instead of cluster network for metallb+vrf symmetric NNCP config

### DIFF
--- a/modules/nw-metallb-configure-return-traffic-proc.adoc
+++ b/modules/nw-metallb-configure-return-traffic-proc.adoc
@@ -6,13 +6,14 @@
 [id="nw-metallb-configure-return-traffic-proc_{context}"]
 = Configuring symmetric routing by using VRFs with MetalLB
 
+[role="_abstract"]
 You can configure symmetric network routing for applications behind a MetalLB service that require the same ingress and egress network paths.
 
 This example associates a VRF routing table with MetalLB and an egress service to enable symmetric routing for ingress and egress traffic for pods behind a `LoadBalancer` service.
 
 [IMPORTANT]
 ====
-* If you use the `sourceIPBy: "LoadBalancerIP"` setting in the `EgressService` CR, you must specify the load-balancer node in the `BGPAdvertisement` custom resource (CR).
+* If you use the `sourceIPBy: "LoadBalancerIP"` setting in the `EgressService` CR, you must specify the `LoadBalancer` node in the `BGPAdvertisement` custom resource (CR).
 
 * You can use the `sourceIPBy: "Network"` setting on clusters that use OVN-Kubernetes configured with the `gatewayConfig.routingViaHost` specification set to `true` only. Additionally, if you use the `sourceIPBy: "Network"` setting, you must schedule the application workload on nodes configured with the network VRF instance.
 ====
@@ -23,33 +24,43 @@ This example associates a VRF routing table with MetalLB and an egress service t
 * Log in as a user with `cluster-admin` privileges.
 * Install the Kubernetes NMState Operator.
 * Install the MetalLB Operator.
+* Create a namespace for your application workload. The examples in this procedure use a namespace called `test`.
 
 .Procedure
 
+. Label the nodes that you want to participate in the VRF configuration by running the following command:
++
+[source,terminal]
+----
+$ oc label node <node_name> vrf=true
+----
++
+The examples in this procedure use the label `vrf: "true"`.
+
 . Create a `NodeNetworkConfigurationPolicy` CR to define the VRF instance:
 
-.. Create a file, such as `node-network-vrf.yaml`, with content like the following example:
+.. Create a file, such as `node-network-vrf.yaml`, with content such as the following example:
 +
 [source,yaml]
 ----
 apiVersion: nmstate.io/v1
 kind: NodeNetworkConfigurationPolicy
 metadata:
-  name: vrfpolicy <1>
+  name: vrfpolicy
 spec:
   nodeSelector:
-    vrf: "true" <2>
+    vrf: "true"
   maxUnavailable: 3
   desiredState:
     interfaces:
-    - name: ens4vrf <3>
-      type: vrf <4>
+    - name: ens4vrf
+      type: vrf
       state: up
       vrf:
         port:
-        - ens4 <5>
-        route-table-id: 2 <6>
-    - name: ens4 <7>
+        - ens4
+        route-table-id: 2
+    - name: ens4
       type: ethernet
       state: up
       ipv4:
@@ -58,35 +69,39 @@ spec:
           prefix-length: 24
         dhcp: false
         enabled: true
-    routes: <8>
+    routes:
       config:
       - destination: 0.0.0.0/0
         metric: 150
         next-hop-address: 192.168.130.1
         next-hop-interface: ens4
         table-id: 2
-    route-rules: <9>
+    route-rules:
       config:
       - ip-to: 172.30.0.0/16
         priority: 998
-        route-table: 254 <10>
-      - ip-to: 10.132.0.0/14
+        route-table: 254
+      - ip-to: 10.128.0.0/14
         priority: 998
         route-table: 254
       - ip-to: 169.254.0.0/17
         priority: 998
         route-table: 254
+# ...
 ----
-<1> The name of the policy.
-<2> This example applies the policy to all nodes with the label `vrf:true`.
-<3> The name of the interface.
-<4> The type of interface. This example creates a VRF instance.
-<5> The node interface that the VRF attaches to.
-<6> The name of the route table ID for the VRF.
-<7> The IPv4 address of the interface associated with the VRF. 
-<8> Defines the configuration for network routes. The `next-hop-address` field defines the IP address of the next hop for the route. The `next-hop-interface` field defines the outgoing interface for the route. In this example, the VRF routing table is `2`, which references the ID that you define in the `EgressService` CR.
-<9> Defines additional route rules. The `ip-to` fields must match the `Cluster Network` CIDR, `Service Network` CIDR, and `Internal Masquerade` subnet CIDR. You can view the values for these CIDR address specifications by running the following command: `oc describe network.operator/cluster`.
-<10> The main routing table that the Linux kernel uses when calculating routes has the ID `254`.
++
+where:
++
+`metadata.name`:: Specifies the name of the policy.
+`nodeSelector.vrf`:: Specifies the policy for all nodes with the label `vrf:true`.
+`interfaces.name.ens4vrf`:: Specifies the name of the interface.
+`interfaces.type`:: Specifies the type of interface. This example creates a VRF instance.
+`vrf.port`:: Specifies the node interface that the VRF attaches to.
+`vrf.route-table-id`:: Specifies the name of the route table ID for the VRF.
+`interfaces.name.ens4`:: Specifies the IPv4 address of the interface associated with the VRF.
+`routes`:: Specifies the configuration for network routes. The `next-hop-address` field defines the IP address of the next hop for the route. The `next-hop-interface` field defines the outgoing interface for the route. In this example, the VRF routing table is `2`, which references the ID that you define in the `EgressService` CR.
+`route-rules`:: Specifies additional route rules. The `ip-to` fields must match the `Cluster Network` CIDR, `Service Network` CIDR, and `Internal Masquerade` subnet CIDR. You can view the values for these CIDR address specifications by running the following command: `oc describe network.operator/cluster`.
+`route-rules.route-table`:: Specifies the main routing table that the Linux kernel uses when calculating routes has the ID `254`.
 
 .. Apply the policy by running the following command:
 +
@@ -94,10 +109,19 @@ spec:
 ----
 $ oc apply -f node-network-vrf.yaml
 ----
++
+.. Verify that the policy is applied by running the following command:
++
+[source,terminal]
+----
+$ oc get nncp vrfpolicy
+----
++
+The output must show `Available` in the `STATUS` column before you continue to the next step.
 
 . Create a `BGPPeer` custom resource (CR):
 
-.. Create a file, such as `frr-via-vrf.yaml`, with content like the following example:
+.. Create a file, such as `frr-via-vrf.yaml`, with content such as the following example:
 +
 [source,yaml]
 ----
@@ -110,9 +134,13 @@ spec:
   myASN: 100
   peerASN: 200
   peerAddress: 192.168.130.1
-  vrf: ens4vrf <1>
+  vrf: ens4vrf
+# ...
 ----
-<1> Specifies the VRF instance to associate with the BGP peer. MetalLB can advertise services and make routing decisions based on the routing information in the VRF.
++
+where:
++
+`spec.vrf`:: Specifies the VRF instance to associate with the BGP peer. MetalLB can advertise services and make routing decisions based on the routing information in the VRF.
 
 .. Apply the configuration for the BGP peer by running the following command:
 +
@@ -123,7 +151,7 @@ $ oc apply -f frr-via-vrf.yaml
 
 . Create an `IPAddressPool` CR:
 
-.. Create a file, such as `first-pool.yaml`, with content like the following example:
+.. Create a file, such as `first-pool.yaml`, with content such as the following example:
 +
 [source,yaml]
 ----
@@ -135,6 +163,7 @@ metadata:
 spec:
   addresses:
   - 192.169.10.0/32
+# ...
 ----
 
 .. Apply the configuration for the IP address pool by running the following command:
@@ -146,7 +175,7 @@ $ oc apply -f first-pool.yaml
 
 . Create a `BGPAdvertisement` CR:
 
-.. Create a file, such as `first-adv.yaml`, with content like the following example:
+.. Create a file, such as `first-adv.yaml`, with content such as the following example:
 +
 [source,yaml]
 ----
@@ -159,13 +188,17 @@ spec:
   ipAddressPools:
     - first-pool
   peers:
-    - frrviavrf <1>
+    - frrviavrf
   nodeSelectors:
     - matchLabels:
-        egress-service.k8s.ovn.org/test-server1: "" <2>
+        egress-service.k8s.ovn.org/test-server1: ""
+# ...
 ----
-<1> In this example, MetalLB advertises a range of IP addresses from the `first-pool` IP address pool to the `frrviavrf` BGP peer.
-<2> In this example, the `EgressService` CR configures the source IP address for egress traffic to use the load-balancer service IP address. Therefore, you must specify the load-balancer node for return traffic to use the same return path for the traffic originating from the pod.
++
+where:
++
+`peers`:: In this example, MetalLB advertises a range of IP addresses from the `first-pool` IP address pool to the `frrviavrf` BGP peer.
+`nodeSelectors`:: In this example, the `EgressService` CR configures the source IP address for egress traffic to use the `LoadBalancer` service IP address. Therefore, you must specify the `LoadBalancer` node for return traffic to use the same return path for the traffic originating from the pod.
 
 .. Apply the configuration for the BGP advertisement by running the following command:
 +
@@ -176,27 +209,31 @@ $ oc apply -f first-adv.yaml
 
 . Create an `EgressService` CR:
 
-.. Create a file, such as `egress-service.yaml`, with content like the following example:
+.. Create a file, such as `egress-service.yaml`, with content such as the following example:
 +
 [source,yaml,options="nowrap",role="white-space-pre"]
 ----
 apiVersion: k8s.ovn.org/v1
 kind: EgressService
 metadata:
-  name: server1 <1>
-  namespace: test <2>
+  name: server1
+  namespace: test
 spec:
-  sourceIPBy: "LoadBalancerIP" <3>
+  sourceIPBy: "LoadBalancerIP"
   nodeSelector:
     matchLabels:
-      vrf: "true" <4>
-  network: "2" <5>
+      vrf: "true"
+  network: "2"
+# ...
 ----
-<1> Specify the name for the egress service. The name of the `EgressService` resource must match the name of the load-balancer service that you want to modify.
-<2> Specify the namespace for the egress service. The namespace for the `EgressService` must match the namespace of the load-balancer service that you want to modify. The egress service is namespace-scoped.
-<3> This example assigns the `LoadBalancer` service ingress IP address as the source IP address for egress traffic.
-<4> If you specify `LoadBalancer` for the `sourceIPBy` specification, a single node handles the `LoadBalancer` service traffic. In this example, only a node with the label `vrf: "true"` can handle the service traffic. If you do not specify a node, OVN-Kubernetes selects a worker node to handle the service traffic. When a node is selected, OVN-Kubernetes labels the node in the following format: `egress-service.k8s.ovn.org/<svc_namespace>-<svc_name>: ""`.
-<5> Specify the routing table ID for egress traffic. Ensure that the value matches the `route-table-id` ID defined in the `NodeNetworkConfigurationPolicy` resource, for example, `route-table-id: 2`. 
++
+where:
++
+`metadata.name`:: Specifies the name for the egress service. The name of the `EgressService` resource must match the name of the `LoadBalancer` service that you want to modify.
+`metadata.namespace`:: Specifies the namespace for the egress service. The namespace for the `EgressService` must match the namespace of the `LoadBalancer` service that you want to modify. The egress service is namespace-scoped.
+`spec.sourceIPBy`:: Specifies the `LoadBalancer` service ingress IP address as the source IP address for egress traffic.
+`matchLabels.vrf`:: If you specify `LoadBalancer` for the `sourceIPBy` specification, a single node handles the `LoadBalancer` service traffic. In this example, only a node with the label `vrf: "true"` can handle the service traffic. If you do not specify a node, OVN-Kubernetes selects a worker node to handle the service traffic. When a node is selected, OVN-Kubernetes labels the node in the following format: `egress-service.k8s.ovn.org/<svc_namespace>-<svc_name>: ""`.
+`network`:: Specifies the routing table ID for egress traffic. Ensure that the value matches the `route-table-id` ID defined in the `NodeNetworkConfigurationPolicy` resource, for example, `route-table-id: 2`.
 
 .. Apply the configuration for the egress service by running the following command:
 +
@@ -207,12 +244,22 @@ $ oc apply -f egress-service.yaml
 
 .Verification
 
+. Get the external IP address for the `LoadBalancer` service by running the following command:
++
+[source,terminal]
+----
+$ oc get svc <service_name> -n <namespace>
+----
++
+where `<service_name>` is the name of your `LoadBalancer` service and `<namespace>` is the namespace where the service is deployed. Note the `EXTERNAL-IP` value from the output.
+
 . Verify that you can access the application endpoint of the pods running behind the MetalLB service by running the following command:
 +
 [source,terminal]
 ----
-$ curl <external_ip_address>:<port_number> <1>
+$ curl <external_ip_address>:<port_number>
 ----
-<1> Update the external IP address and port number to suit your application endpoint.
++
+where `<external_ip_address>` is the `EXTERNAL-IP` value from the preceding step, and `<port_number>` is the port number of your application endpoint.
 
 . Optional: If you assigned the `LoadBalancer` service ingress IP address as the source IP address for egress traffic, verify this configuration by using tools such as `tcpdump` to analyze packets received at the external client.


### PR DESCRIPTION
Cherry-pick of #112391 to enterprise-4.19.

OCPBUGS-86705: Hybrid cluster network cited instead of cluster network for metallb+vrf symmetric NNCP config

Version(s): 4.19

Issue: https://redhat.atlassian.net/browse/OCPBUGS-86705

QE review:
- [x] QE has approved this change.

## Summary
- Add namespace creation (`test`) as a prerequisite — the procedure references it but never creates it
- Move node labeling (`vrf=true`) from prerequisites into the procedure body as an actionable step
- Add NMState policy readiness check (`oc get nncp`) after applying the `NodeNetworkConfigurationPolicy` — the policy reconciles asynchronously
- Fix cluster network CIDR from `10.132.0.0/14` to `10.128.0.0/14`
- Add a step to retrieve the external IP (`oc get svc`) before the curl verification step
- Clarify curl placeholder values with a reference to the preceding step
- Fix `load-balancer` → `LoadBalancer` terminology throughout