### PR TITLE
OSDOCS-20100 [NETOBSERV] Comment out Technology Preview Automatic Install

### DIFF
--- a/observability/network_observability/network-observability-operator-release-notes.adoc
+++ b/observability/network_observability/network-observability-operator-release-notes.adoc
@@ -18,7 +18,8 @@ include::modules/network-observability-operator-release-notes-1-12-advisory.adoc
 
 include::modules/network-observability-operator-release-notes-1-12-new-features-enhancements.adoc[leveloffset=+1]
 
-include::modules/network-observability-operator-release-notes-1-12-technology-preview.adoc[leveloffset=+1]
+//include::modules/network-observability-operator-release-notes-1-12-technology-preview.adoc[leveloffset=+1]
+//06/10/2026: commenting out as engineering PR did not get merged, so feature is not available.
 
 include::modules/network-observability-operator-release-notes-1-12-fixed-issues.adoc[leveloffset=+1]
 


### PR DESCRIPTION
[OSDOCS-20100](https://redhat.atlassian.net/browse/OSDOCS-20100) Comment out Technology Preview Automatic Install

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.17, 4.19+

Issue:
https://redhat.atlassian.net/browse/OSDOCS-20100

Link to docs preview:
NetObserv 1.12 release notes without Technology Preview section: https://113031--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/network-observability-operator-release-notes.html

QE review:
QE is not required for this PR.

Additional information:
* Engineering PR https://github.com/openshift/cluster-network-operator/pull/2925 must be merged first
* Rel notes will be updated with https://github.com/openshift/openshift-docs/pull/111382 when engineering PR is merged.
* Per Kathryn Alexander, change management is not required.
* ~~4.12, 4.14, 4.16, 4.18 integration cherry-picks are still in merge review queue so will update those PRs to comment out.~~

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
