### PR TITLE
WMCO 10.22 RN Add Errata Link

### DIFF
--- a/modules/windows-containers-release-notes-10-22-0.adoc
+++ b/modules/windows-containers-release-notes-10-22-0.adoc
@@ -6,12 +6,12 @@
 [id="windows-containers-release-notes-10-22-0_{context}"]
 = Release notes for Red Hat Windows Machine Config Operator 10.22.0
 
-Issued: DD Mm 2026
+Issued: 20 May 2026
 
 [role="_abstract"]
 You can review the following release notes to learn about the new features and bug fixes in the Windows Machine Config Operator (WMCO) version 10.22.0.
 
-The components of the WMCO version 10.22.0 were released in TBD.
+The components of the WMCO version 10.22.0 were released in link:https://access.redhat.com/errata/RHBA-2026:19710[RHBA-2026:19710].
 
 [id="wmco-10-22-0-new-features_{context}"]
 == New features and improvements


### PR DESCRIPTION
Added the link to the errata.

Preview: [Release notes for Red Hat Windows Machine Config Operator 10.22.0](https://113042--ocpdocs-pr.netlify.app/openshift-enterprise/latest/windows_containers/wmco_rn/windows-containers-release-notes.html#windows-containers-release-notes-10-22-0_windows-containers-release-notes) 