### PR TITLE
OSDOCS-16851-5-CQA: Fifth CQA for OVNK2 Egress Traffic and Gateway co

### DIFF
--- a/modules/nw-egress-router-cr.adoc
+++ b/modules/nw-egress-router-cr.adoc
@@ -12,6 +12,7 @@ endif::[]
 [id="nw-egress-router-ovn-cr_{context}"]
 = Egress router custom resource
 
+[role="_abstract"]
 Define the configuration for an egress router pod in an egress router custom resource. The following YAML describes the fields for the configuration of an egress router in {router-type} mode:
 
 // cluster-network-operator/manifests/0000_70_cluster-network-operator_01_egr_crd.yaml
@@ -21,37 +22,39 @@ apiVersion: network.operator.openshift.io/v1
 kind: EgressRouter
 metadata:
   name: <egress_router_name>
-  namespace: <namespace>  <1>
+  namespace: <namespace>
 spec:
-  addresses: [  <2>
+  addresses: [
     {
-      ip: "<egress_router>",  <3>
-      gateway: "<egress_gateway>"  <4>
+      ip: "<egress_router>",
+      gateway: "<egress_gateway>"
     }
   ]
   mode: Redirect
   redirect: {
-    redirectRules: [  <5>
+    redirectRules: [
       {
         destinationIP: "<egress_destination>",
         port: <egress_router_port>,
-        targetPort: <target_port>,  <6>
-        protocol: <network_protocol>  <7>
+        targetPort: <target_port>,
+        protocol: <network_protocol>
       },
       ...
     ],
-    fallbackIP: "<egress_destination>" <8>
+    fallbackIP: "<egress_destination>"
   }
 ----
-// openshift/api:networkoperator/v1/001-egressrouter.crd.yaml
-<1> Optional: The `namespace` field specifies the namespace to create the egress router in. If you do not specify a value in the file or on the command line, the `default` namespace is used.
-<2> The `addresses` field specifies the IP addresses to configure on the secondary network interface.
-<3> The `ip` field specifies the reserved source IP address and netmask from the physical network that the node is on to use with egress router pod. Use CIDR notation to specify the IP address and netmask.
-<4> The `gateway` field specifies the IP address of the network gateway.
-<5> Optional: The `redirectRules` field specifies a combination of egress destination IP address, egress router port, and protocol. Incoming connections to the egress router on the specified port and protocol are routed to the destination IP address.
-<6> Optional: The `targetPort` field specifies the network port on the destination IP address. If this field is not specified, traffic is routed to the same network port that it arrived on.
-<7> The `protocol` field supports TCP, UDP, or SCTP.
-<8> Optional: The `fallbackIP` field specifies a destination IP address. If you do not specify any redirect rules, the egress router sends all traffic to this fallback IP address. If you specify redirect rules, any connections to network ports that are not defined in the rules are sent by the egress router to this fallback IP address. If you do not specify this field, the egress router rejects connections to network ports that are not defined in the rules.
+
+where:
+
+`metadata.namespace`:: Optional parameter. Specifies the `namespace` for creating the egress router. If you do not specify a value in the file or on the command line, the `default` namespace is used.
+`spec.addresses`:: Specifies the IP addresses to configure on the secondary network interface.
+`spec.addresses.ip`:: Specifies the reserve source IP address and netmask from the physical network that the node is on to use with egress router pod. Use CIDR notation to specify the IP address and netmask.
+`spec.addresses.gateway`:: Specifies the IP address of the network gateway.
+`spec.redirect.redirectRules`:: Optional parameter. Specifies the combinination of egress destination IP address, egress router port, and protocol. Incoming connections to the egress router on the specified port and protocol are routed to the destination IP address.
+`spec.redirect.redirectRules.targetPort`:: Optional parameter. Specifies the network port on the destination IP address. If this field is not specified, traffic is routed to the same network port that it arrived on.
+`spec.redirect.redirectRules.protocol`:: Specifies the protocols to support, such as TCP, UDP, or SCTP.
+`spec.redirect.fallbackIP`:: Optional parameter. Specifies a destination IP address. If you do not specify any redirect rules, the egress router sends all traffic to this fallback IP address. If you specify redirect rules, any connections to network ports that are not defined in the rules are sent by the egress router to this fallback IP address. If you do not specify this field, the egress router rejects connections to network ports that are not defined in the rules.
 
 .Example egress router specification
 [source,yaml,subs="attributes+"]

--- a/modules/nw-egress-router-redirect-mode-ovn.adoc
+++ b/modules/nw-egress-router-redirect-mode-ovn.adoc
@@ -6,13 +6,14 @@
 [id="nw-egress-router-redirect-mode-ovn_{context}"]
 = Deploying an egress router in redirect mode
 
+[role="_abstract"]
 You can deploy an egress router to redirect traffic from its own reserved source IP address to one or more destination IP addresses.
 
 After you add an egress router, the client pods that need to use the reserved source IP address must be modified to connect to the egress router rather than connecting directly to the destination IP.
 
 .Prerequisites
 
-* Install the OpenShift CLI (`oc`).
+* Install the {oc-first}.
 * Log in as a user with `cluster-admin` privileges.
 
 .Procedure
@@ -34,9 +35,9 @@ spec:
     port: 8080
   type: ClusterIP
   selector:
-    app: egress-router-cni <1>
+    app: egress-router-cni
 ----
-<1> Specify the label for the egress router. The value shown is added by the Cluster Network Operator and is not configurable.
+** `spec.selector`: Specifies the label for the egress router. The value shown is added by the Cluster Network Operator and is not configurable.
 +
 After you create the service, your pods can connect to the service. The egress router pod redirects traffic to the corresponding port on the destination IP address. The connections originate from the reserved source IP address.
 
@@ -54,7 +55,6 @@ $ oc get network-attachment-definition egress-router-cni-nad
 The name of the network attachment definition is not configurable.
 +
 .Example output
-+
 [source,terminal]
 ----
 NAME                    AGE
@@ -71,7 +71,6 @@ $ oc get deployment egress-router-cni-deployment
 The name of the deployment is not configurable.
 +
 .Example output
-+
 [source,terminal]
 ----
 NAME                           READY   UP-TO-DATE   AVAILABLE   AGE
@@ -86,7 +85,6 @@ $ oc get pods -l app=egress-router-cni
 ----
 +
 .Example output
-+
 [source,terminal]
 ----
 NAME                                            READY   STATUS    RESTARTS   AGE

--- a/networking/ovn_kubernetes_network_provider/deploying-egress-router-ovn-redirection.adoc
+++ b/networking/ovn_kubernetes_network_provider/deploying-egress-router-ovn-redirection.adoc
@@ -6,6 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 As a cluster administrator, you can deploy an egress router pod to redirect traffic to specified destination IP addresses from a reserved source IP address.
 
 The egress router implementation uses the egress router Container Network Interface (CNI) plugin.


### PR DESCRIPTION
Version(s):
4.20+

Issue:
[OSDOCS-16851](https://redhat.atlassian.net/browse/OSDOCS-16851)

Link to docs preview:

https://113062--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/deploying-egress-router-ovn-redirection.html
