### PR TITLE
OSDOCS-18201-re: Re-added deleted note

### DIFF
--- a/modules/nw-networkpolicy-about.adoc
+++ b/modules/nw-networkpolicy-about.adoc
@@ -11,6 +11,18 @@ To control traffic between workloads and improve network isolation, configure `N
 
 By default, all pods in a project are accessible from other pods and network endpoints. To isolate one or more pods in a project, you can create `NetworkPolicy` objects in that project to indicate the allowed incoming connections. Project administrators can create and delete `NetworkPolicy` objects within their own project.
 
+[IMPORTANT]
+====
+From {product-title} 4.22, {product-title} now includes `NetworkPolicy` objects in some of its own namespaces by default. This inclusion improves overall security and better protects control plane components. Do not modify the `NetworkPolicy` objects that {product-title} includes in its own namespaces by default. To check the namespaces that include the objects by default, you can run the following command:
+
+[source,terminal]
+----
+$ oc get networkpolicies --all-namespaces
+----
+
+The {product-title} 4.22 release does not include these objects in all {product-title} namespaces; later {product-title} releases might include the objects in additional namespaces. 
+====
+
 By default, all pods in a project are accessible from any network endpoint.
 
 If a pod is matched by selectors in one or more `NetworkPolicy` objects, then the pod accepts only connections that are allowed by at least one of those `NetworkPolicy` objects. A pod that is not selected by any `NetworkPolicy` objects remains fully accessible.


### PR DESCRIPTION

My original change was merged but then deleted via https://github.com/openshift/openshift-docs/commit/054a327412303cc32e25a60f084e8d6ad4f85292#diff-823a0e84ac6a01ebd98c7a2b9115bbe2708ab5275824d765b24f7ec48ca067a1. This deletion was incorrect.

Version(s):
4.22+

Issue:

https://redhat.atlassian.net/browse/OSDOCS-18200

Link to docs preview:

* https://110722--ocpdocs-pr.netlify.app/openshift-dedicated/latest/networking/network_security/network_policy/about-network-policy.html
* https://110722--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/network_security/network_policy/about-network-policy.html
* https://110722--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/networking/network_security/network_policy/about-network-policy.html
* https://110722--ocpdocs-pr.netlify.app/openshift-rosa/latest/networking/network_security/network_policy/about-network-policy.html

- [x] SME has approved this change (Dan W.).
- [x] QE has approved this change (Rahul G.).
