### PR TITLE
OSDOCS-18180-dep-tables updated missing values in deprecation table

### DIFF
--- a/modules/rn-ocp-release-notes-deprecated-removed-tables.adoc
+++ b/modules/rn-ocp-release-notes-deprecated-removed-tables.adoc
@@ -13,7 +13,7 @@
 |Cluster Samples Operator
 |Deprecated
 |Deprecated
-|
+|Deprecated
 |====
 
 
@@ -101,7 +101,7 @@
 |iptables
 |Deprecated
 |Deprecated
-|
+|Deprecated
 |====
 
 
@@ -151,13 +151,13 @@
 |oc-mirror plugin v1
 |Deprecated
 |Deprecated
-|
+|Deprecated
 
 
 |Docker v2 registries
 |Deprecated
 |Deprecated
-|
+|Deprecated
 
 |`oc adm release mirror` command
 |General Availability
@@ -241,7 +241,7 @@
 |`useModal` hook for dynamic plugin SDK
 |Deprecated
 |Deprecated
-|
+|Deprecated
 |====
 
 


### PR DESCRIPTION
Version(s):
4.22

Issue:
https://redhat.atlassian.net/browse/OSDOCS-18180

Link to docs preview:
https://113087--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-22-release-notes.html#rn-ocp-release-notes-deprecated-removed-tables_release-notes


QE review:
- [ ] QE has approved this change.


Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
