### PR TITLE
OSDOCS-19542 [NETOBSERV] Tags

### DIFF
--- a/modules/network-observability-loki-secret.adoc
+++ b/modules/network-observability-loki-secret.adoc
@@ -14,7 +14,7 @@ The {loki-op} supports a few log storage options, such as AWS S3, {gcp-full} Sto
 .Procedure
 
 . Using the web console, navigate to the *Project* -> *All Projects* dropdown and select *Create Project*.
-. Name the project `netobserv` and click *Create*.
+. Name the project `netobserv-loki` and click *Create*.
 . Navigate to the Import icon, *+*, in the top right corner. Paste your YAML file into the editor.
 +
 The following shows an example secret YAML file for S3 storage:

--- a/modules/network-observability-role-based-access-control-for-loki-logs.adoc
+++ b/modules/network-observability-role-based-access-control-for-loki-logs.adoc
@@ -1,0 +1,45 @@
+// Module included in the following assemblies:
+//
+// * observability/network_observability/installing-operators.adoc
+// Original file in main: * logging//log_storage/cluster-logging-loki.adoc content in this file specific to tag=!NetObservMode in modules/logging-loki-log-access.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="network-observability-role-based-access-control-for-loki-logs_{context}"]
+= Role-based access control for Loki logs
+
+[role="_abstract"]
+Configure role-based access control to grant users permission to view application, infrastructure, or audit logs in Loki.
+
+By default, {logging} 5.8 and later does not grant users access to logs. You must configure role-based access control to grant users permission to view specific log types.
+
+
+For more information on access control for Loki logs, see: "Fine grained access for Loki logs" in the {clo} documentation.
+
+[id="grant-non-admin-users-cluster-wide-log-access_{context}"]
+== Grant non-admin users cluster-wide log access
+
+Add users to a custom admin group to grant cluster-wide log access without making them cluster administrators. This is useful for senior engineers who need full log visibility but should not have cluster modification privileges.
+
+Users who are members of any group specified in the `adminGroups` field of the `LokiStack` custom resource (CR) have the same read access to logs as administrators.
+
+.Example LokiStack CR
+[source,yaml]
+----
+apiVersion: loki.grafana.com/v1
+kind: LokiStack
+metadata:
+  name: loki
+  namespace: netobserv-loki
+spec:
+  tenants:
+    mode: openshift-network
+    openshift:
+      adminGroups:
+      - cluster-admin
+      - custom-admin-group
+----
+
+where:
+
+`spec.tenants.mode`:: Specifies the tenant mode. Must be `openshift-network` for network observability.
+`spec.tenants.openshift.adminGroups`:: Specifies the list of groups whose members have cluster-wide log access. Defaults to `system:cluster-admins`, `cluster-admin`, and `dedicated-admin`. Set to `[]` to disable.

--- a/observability/network_observability/installing-operators.adoc
+++ b/observability/network_observability/installing-operators.adoc
@@ -28,26 +28,24 @@ include::modules/network-observability-loki-install.adoc[leveloffset=+1]
 
 include::modules/network-observability-loki-secret.adoc[leveloffset=+2]
 
-[role="_additional-resources"]
-.Additional resources
-* xref:../../observability/network_observability/installing-operators.adoc#network-observability-lokistack-create_network_observability[Creating a LokiStack custom resource]
-* xref:../../observability/network_observability/flowcollector-api.adoc#network-observability-flowcollector-api-specifications_network_observability[Flow Collector API Reference]
-* xref:../../observability/network_observability/configuring-operator.adoc#network-observability-flowcollector-view_network_observability[Flow Collector sample resource]
-//* xref :../../observability/logging/log_storage/installing-log-storage.adoc#logging-loki-storage_installing-log-storage[Loki object storage]
-
 include::modules/network-observability-lokistack-create.adoc[leveloffset=+2]
 
-include::modules/logging-creating-new-group-cluster-admin-user-role.adoc[leveloffset=+2]
+include::modules/network-observability-role-based-access-control-for-loki-logs.adoc[leveloffset=+2]
 
-include::modules/logging-loki-log-access.adoc[leveloffset=+1,tags=CustomAdmin;NetObservMode;!LokiMode]
-
-include::modules/loki-deployment-sizing.adoc[leveloffset=+2]
+[role="_additional-resources"]
+.Additional resources
+* https://docs.redhat.com/en/documentation/red_hat_openshift_logging/6.5/html/configuring_logging/configuring-lokistack-storage#logging-loki-log-access_configuring-the-log-store[Fine grained access for Loki logs]
 
 include::modules/network-observability-lokistack-ingestion-query.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
 .Additional resources
+* xref:../../observability/network_observability/installing-operators.adoc#network-observability-lokistack-create_network_observability[Creating a LokiStack custom resource]
+* link:https://docs.redhat.com/en/documentation/red_hat_openshift_logging/latest/html/configuring_logging/configuring-lokistack-storage#logging-loki-storage_configuring-the-log-store[Loki object storage]
+* link:https://docs.redhat.com/en/documentation/red_hat_openshift_logging/latest/html/configuring_logging/configuring-lokistack-storage.html#loki-sizing_configuring-the-log-store[Loki deployment sizing]
 * link:https://loki-operator.dev/docs/api.md/#loki-grafana-com-v1-IngestionLimitSpec[LokiStack API reference]
+* xref:../../observability/network_observability/flowcollector-api.adoc#network-observability-flowcollector-api-specifications_network_observability[Flow Collector API Reference]
+* xref:../../observability/network_observability/configuring-operator.adoc#network-observability-flowcollector-view_network_observability[Flow Collector sample resource]
 
 include::modules/network-observability-operator-install.adoc[leveloffset=+1]
 
@@ -67,18 +65,12 @@ include::modules/network-observability-important-flowcollector-considerations.ad
 * xref:../../observability/network_observability/troubleshooting-network-observability.adoc#controller-manager-pod-runs-out-of-memory_network-observability-troubleshooting[Troubleshooting network observability controller manager pod runs out of memory]
 * xref:../../observability/network_observability/understanding-network-observability-operator.adoc#network-observability-architecture_nw-network-observability-operator[Network observability architecture]
 
-include::modules/network-observability-updating-migrating.adoc[leveloffset=+2]
+include::modules/network-observability-updating-migrating.adoc[leveloffset=+1]
 
 include::modules/network-observability-multitenancy.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources
 * xref:../../operators/operator-reference.adoc#cluster-kube-storage-version-migrator-operator_operator-reference[Kubernetes Storage Version Migrator Operator]
-
-
-[role="_additional-resources"]
-.Additional resources
-* link:https://docs.redhat.com/en/documentation/red_hat_streams_for_apache_kafka/2.2[Red Hat AMQ Streams]
-* xref:../../observability/network_observability/configuring-operator.adoc#network-observability-flowcollector-kafka-config_network_observability[Configuring the FlowCollector resource with Kafka]
 
 include::modules/network-observability-operator-uninstall.adoc[leveloffset=+1]

--- a/observability/network_observability/network-observability-overview.adoc
+++ b/observability/network_observability/network-observability-overview.adoc
@@ -19,6 +19,7 @@ include::modules/network-observability-dependency-network-observability-operator
 [id="additional-resources-operator_{context}"]
 .Additional resources
 * xref:../network_observability/installing-operators.adoc#network-observability-without-loki_network_observability[Network observability without Loki]
+* link:https://docs.redhat.com/en/documentation/red_hat_streams_for_apache_kafka/2.2[Red Hat AMQ Streams]
 
 include::modules/network-observability-openshift-console-integration.adoc[leveloffset=+1]
 


### PR DESCRIPTION
[OSDOCS-19542](https://redhat.atlassian.net/browse/OSDOCS-19542) [NETOBSERV] Tags

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.16+ since migration related

Issue:
https://redhat.atlassian.net/browse/OSDOCS-19542

Link to docs preview:
* Install operators: https://113088--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/installing-operators.html
* Role-based access control for Loki logs: https://113088--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/installing-operators.html#network-observability-logging-loki-log-access_network_observability

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
* `include::modules/network-observability-logging-loki-log-access.adoc[leveloffset=+1]` replaces `includes::modules/logging-loki-log-access.adoc`. The Logging file on `main` has not been maintained since Logging docs moved to the stand alone format, and tags are not supported with the move to DITA. However, some content in the Logging file is applicable only to Network Observability Operator, and that content is what has become the `include::modules/network-observability-role-based-access-control-for-loki-logs.adoc[leveloffset=+1]` file. 
* This is already noted in https://redhat.atlassian.net/browse/OSDOCS-20182 to address post-migration.
* Also addresses DOCBUG https://redhat.atlassian.net/browse/OSDOCS-19779 as restructuring of content and removal of tags addressed issues raised in the reported doc bug.
* Also addresses https://redhat.atlassian.net/browse/OSDOCS-19782 as removing tags has required restructuring the assembly file.
* Cherry-pick failures are possible. Manual cherry-picks will be created accordingly.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
