### PR TITLE
OSDOCS-19400: Missing scope selectors in scalability_and_performance doc

### DIFF
--- a/modules/quota-scopes.adoc
+++ b/modules/quota-scopes.adoc
@@ -25,6 +25,15 @@ To restrict the set of resources that a quota applies to, add associated scopes.
 
 |`NotBestEffort`
 |Match pods that do not have best effort quality of service for `cpu` and `memory`.
+
+|`CrossNamespacePodAffinity`
+|Match all pod objects that have cross-namespace pod (anti)affinity mentioned.
+
+|`PriorityClass`
+|Match all pod objects that have priority class mentioned.
+
+|`VolumeAttributesClass`
+|Match all persistent volume claims (PVCs) that have volume attributes class mentioned.
 |===
 
 A `BestEffort` scope restricts a quota to limiting the following resources:
@@ -48,3 +57,34 @@ A `Terminating`, `NotTerminating`, and `NotBestEffort` scope restricts a quota t
 ====
 Ephemeral storage requests and limits apply only if you enabled the ephemeral storage technology preview. This feature is disabled by default.
 ====
+
+You can also limit a quota with the optional `scopeSelector` field. In `scopeSelector.matchExpressions`, set a `scopeName`, an `operator`, and, when required, a `values` array. Scopes such as `PriorityClass` and `VolumeAttributesClass` match resources when the selector selects them.
+
+The `operator` field supports the following values:
+
+* `In`
+* `NotIn`
+* `Exists`
+* `DoesNotExist`
+
+If the `operator` is `In` or `NotIn`, the `values` field must include at least one value. If the `operator` is `Exists` or `DoesNotExist`, do not set `values`.
+
+.Example ResourceQuota scoped to a PriorityClass
+[source,yaml]
+----
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: pods-high-priority
+spec:
+  hard:
+    pods: "10"
+    requests.cpu: "1"
+    requests.memory: 1Gi
+  scopeSelector:
+    matchExpressions:
+    - scopeName: PriorityClass
+      operator: In
+      values:
+      - high-priority
+----


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.20+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:  https://redhat.atlassian.net/browse/OSDOCS-19400
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:  https://113090--ocpdocs-pr.netlify.app/openshift-enterprise/latest/scalability_and_performance/compute-resource-quotas.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [X] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
