### PR TITLE
OSDOCS-20211: Mark CIS 1.4, 1.5 and DISA STIG V1R1 as deprecated

### DIFF
--- a/modules/compliance-profiles.adoc
+++ b/modules/compliance-profiles.adoc
@@ -19,13 +19,11 @@ $ oc get profile.compliance -n openshift-compliance
 [source,terminal]
 ----
 NAME                       AGE     VERSION
-ocp4-cis                   3h49m   1.5.0
-ocp4-cis-1-4               3h49m   1.4.0
-ocp4-cis-1-5               3h49m   1.5.0
-ocp4-cis-node              3h49m   1.5.0
-ocp4-cis-node-1-4          3h49m   1.4.0
-ocp4-cis-node-1-5          3h49m   1.5.0
-ocp4-e8                    3h49m   
+ocp4-cis                   3h49m   1.9.0
+ocp4-cis-1-9               3h49m   1.9.0
+ocp4-cis-node              3h49m   1.9.0
+ocp4-cis-node-1-9          3h49m   1.9.0
+ocp4-e8                    3h49m
 ocp4-high                  3h49m   Revision 4
 ocp4-high-node             3h49m   Revision 4
 ocp4-high-node-rev-4       3h49m   Revision 4
@@ -34,29 +32,26 @@ ocp4-moderate              3h49m   Revision 4
 ocp4-moderate-node         3h49m   Revision 4
 ocp4-moderate-node-rev-4   3h49m   Revision 4
 ocp4-moderate-rev-4        3h49m   Revision 4
-ocp4-nerc-cip              3h49m   
-ocp4-nerc-cip-node         3h49m   
-ocp4-pci-dss               3h49m   3.2.1
+ocp4-nerc-cip              3h49m
+ocp4-nerc-cip-node         3h49m
+ocp4-pci-dss               3h49m   4.0.0
 ocp4-pci-dss-3-2           3h49m   3.2.1
 ocp4-pci-dss-4-0           3h49m   4.0.0
-ocp4-pci-dss-node          3h49m   3.2.1
+ocp4-pci-dss-node          3h49m   4.0.0
 ocp4-pci-dss-node-3-2      3h49m   3.2.1
 ocp4-pci-dss-node-4-0      3h49m   4.0.0
-ocp4-stig                  3h49m   V2R1
-ocp4-stig-node             3h49m   V2R1
-ocp4-stig-node-v1r1        3h49m   V1R1
-ocp4-stig-node-v2r1        3h49m   V2R1
-ocp4-stig-v1r1             3h49m   V1R1
-ocp4-stig-v2r1             3h49m   V2R1
-rhcos4-e8                  3h49m   
+ocp4-stig                  3h49m   V2R3
+ocp4-stig-node             3h49m   V2R3
+ocp4-stig-node-v2r3        3h49m   V2R3
+ocp4-stig-v2r3             3h49m   V2R3
+rhcos4-e8                  3h49m
 rhcos4-high                3h49m   Revision 4
 rhcos4-high-rev-4          3h49m   Revision 4
 rhcos4-moderate            3h49m   Revision 4
 rhcos4-moderate-rev-4      3h49m   Revision 4
-rhcos4-nerc-cip            3h49m   
-rhcos4-stig                3h49m   V2R1
-rhcos4-stig-v1r1           3h49m   V1R1
-rhcos4-stig-v2r1           3h49m   V2R1
+rhcos4-nerc-cip            3h49m
+rhcos4-stig                3h49m   V2R3
+rhcos4-stig-v2r3           3h49m   V2R3
 ----
 +
 These profiles represent different compliance benchmarks. Each profile has the product name that it applies to added as a prefix to the profile’s name. `ocp4-e8` applies the Essential 8 benchmark to the {product-title} product, while `rhcos4-e8` applies the Essential 8 benchmark to the {op-system-first} product.

--- a/modules/oc-compliance-using-scan-setting-bindings.adoc
+++ b/modules/oc-compliance-using-scan-setting-bindings.adoc
@@ -35,13 +35,11 @@ $ oc get profile.compliance -n openshift-compliance
 [source,terminal]
 ----
 NAME                       AGE     VERSION
-ocp4-cis                   3h49m   1.5.0
-ocp4-cis-1-4               3h49m   1.4.0
-ocp4-cis-1-5               3h49m   1.5.0
-ocp4-cis-node              3h49m   1.5.0
-ocp4-cis-node-1-4          3h49m   1.4.0
-ocp4-cis-node-1-5          3h49m   1.5.0
-ocp4-e8                    3h49m   
+ocp4-cis                   3h49m   1.9.0
+ocp4-cis-1-9               3h49m   1.9.0
+ocp4-cis-node              3h49m   1.9.0
+ocp4-cis-node-1-9          3h49m   1.9.0
+ocp4-e8                    3h49m
 ocp4-high                  3h49m   Revision 4
 ocp4-high-node             3h49m   Revision 4
 ocp4-high-node-rev-4       3h49m   Revision 4
@@ -50,29 +48,26 @@ ocp4-moderate              3h49m   Revision 4
 ocp4-moderate-node         3h49m   Revision 4
 ocp4-moderate-node-rev-4   3h49m   Revision 4
 ocp4-moderate-rev-4        3h49m   Revision 4
-ocp4-nerc-cip              3h49m   
-ocp4-nerc-cip-node         3h49m   
-ocp4-pci-dss               3h49m   3.2.1
+ocp4-nerc-cip              3h49m
+ocp4-nerc-cip-node         3h49m
+ocp4-pci-dss               3h49m   4.0.0
 ocp4-pci-dss-3-2           3h49m   3.2.1
 ocp4-pci-dss-4-0           3h49m   4.0.0
-ocp4-pci-dss-node          3h49m   3.2.1
+ocp4-pci-dss-node          3h49m   4.0.0
 ocp4-pci-dss-node-3-2      3h49m   3.2.1
 ocp4-pci-dss-node-4-0      3h49m   4.0.0
-ocp4-stig                  3h49m   V2R1
-ocp4-stig-node             3h49m   V2R1
-ocp4-stig-node-v1r1        3h49m   V1R1
-ocp4-stig-node-v2r1        3h49m   V2R1
-ocp4-stig-v1r1             3h49m   V1R1
-ocp4-stig-v2r1             3h49m   V2R1
-rhcos4-e8                  3h49m   
+ocp4-stig                  3h49m   V2R3
+ocp4-stig-node             3h49m   V2R3
+ocp4-stig-node-v2r3        3h49m   V2R3
+ocp4-stig-v2r3             3h49m   V2R3
+rhcos4-e8                  3h49m
 rhcos4-high                3h49m   Revision 4
 rhcos4-high-rev-4          3h49m   Revision 4
 rhcos4-moderate            3h49m   Revision 4
 rhcos4-moderate-rev-4      3h49m   Revision 4
-rhcos4-nerc-cip            3h49m   
-rhcos4-stig                3h49m   V2R1
-rhcos4-stig-v1r1           3h49m   V1R1
-rhcos4-stig-v2r1           3h49m   V2R1
+rhcos4-nerc-cip            3h49m
+rhcos4-stig                3h49m   V2R3
+rhcos4-stig-v2r3           3h49m   V2R3
 
 ----
 +


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.20+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://redhat.atlassian.net/browse/OSDOCS-20211
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://113106--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/compliance_operator/co-concepts/compliance-operator-understanding.html
https://113106--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/compliance_operator/co-scans/oc-compliance-plug-in-using.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [X] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
