### PR TITLE
RHDEVDOCS-7551: CQA assessment and fixes for the  Securing webhooks with event listener chapter.

### DIFF
--- a/modules/op-providing-secure-connection.adoc
+++ b/modules/op-providing-secure-connection.adoc
@@ -1,13 +1,11 @@
 :_mod-docs-content-type: PROCEDURE
 // This module is included in the following assemblies:
 // * secure/securing-webhooks-with-event-listeners.adoc
-
-:_mod-docs-content-type: PROCEDURE
 [id='op-providing-secure-connection_{context}']
-= Providing secure connection with OpenShift routes
+= Provide secure connection with OpenShift routes
 
 [role="_abstract"]
-You can give a secure connection with OpenShift routes by using re-encrypted TLS termination.
+Provide secure connections with OpenShift routes using re-encrypted TLS termination to protect data in transit between external services and your cluster.
 
 .Procedure
 
@@ -64,4 +62,19 @@ Re-encryption requires this field. The `destinationCACertificate` field specifie
 $ oc create route reencrypt --help
 ----
 
+.Verification
 
+* Verify that the route is created:
++
+[source,terminal]
+----
+$ oc get route <route_name>
+----
+
+* The output shows the route with TLS termination type `reencrypt`.
+
+[role="_additional-resources"]
+.Additional resources
+
+* link:https://docs.openshift.com/container-platform/latest/networking/routes/route-configuration.html[Configuring routes]
+* link:https://docs.openshift.com/container-platform/latest/networking/routes/secured-routes.html[Secured routes]

--- a/modules/op-sample-eventlistener-resource.adoc
+++ b/modules/op-sample-eventlistener-resource.adoc
@@ -3,10 +3,10 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id='op-sample-eventlistener-resource_{context}']
-= Creating a sample EventListener resource using a secure HTTPS connection
+= Create a sample EventListener resource using secure HTTPS connection
 
 [role="_abstract"]
-The following procedure uses the link:https://github.com/openshift/pipelines-tutorial[pipelines-tutorial] example to create a sample `EventListener` resource by using a secure HTTPS connection.
+Create a sample `EventListener` resource with secure HTTPS connectivity by using the pipelines-tutorial examples for hands-on learning and testing webhook security configurations.
 
 .Procedure
 
@@ -32,7 +32,7 @@ $ oc create -f https://raw.githubusercontent.com/openshift/pipelines-tutorial/ma
 ----
 
 . Create an `EventListener` resource using a secure HTTPS connection:
-.. Add a label to enable the secure HTTPS connection to the `Eventlistener` resource:
+.. Add a label to enable the secure HTTPS connection to the `EventListener` resource:
 +
 [source,terminal,subs="attributes+"]
 ----
@@ -52,3 +52,45 @@ $ oc create -f https://raw.githubusercontent.com/openshift/pipelines-tutorial/ma
 ----
 $ oc create route reencrypt --service=<svc_name> --cert=tls.crt --key=tls.key --ca-cert=ca.crt --hostname=<hostname>
 ----
+
+.Verification
+
+* Verify that the `EventListener` resource is created and is available:
++
+[source,terminal]
+----
+$ oc get eventlistener
+----
++
+The output shows the `EventListener` resource with `AVAILABLE` and `READY` columns indicating `True`.
+
+* Verify that the `EventListener` service is created:
++
+[source,terminal]
+----
+$ oc get svc -l eventlistener=<eventlistener_name>
+----
++
+The output shows a service prefixed with `el-` and the port `8080/TCP` or `8443/TCP` for HTTPS.
+
+* Verify that the other trigger resources are created:
++
+[source,terminal]
+----
+$ oc get trigger,triggertemplate,triggerbinding
+----
+
+* Verify that the secure route is accessible:
++
+[source,terminal]
+----
+$ curl -k https://<hostname>/
+----
++
+The event listener responds with a success message. The `-k` flag bypasses certificate verification for testing purposes.
+
+[role="_additional-resources"]
+.Additional resources
+
+* link:https://github.com/openshift/pipelines-tutorial[OpenShift Pipelines Tutorial]
+* link:https://tekton.dev/docs/triggers/[Tekton Triggers Documentation]

--- a/modules/op-setting-eventlistener-scc.adoc
+++ b/modules/op-setting-eventlistener-scc.adoc
@@ -3,10 +3,10 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="op-setting-eventlistener-scc_{context}"]
-= Configuring security context for event listeners
+= Configure security context for event listeners
 
 [role="_abstract"]
-You can configure a custom security context directly in your `EventListener` custom resource (CR) to meet your security requirements. A custom security context can help ensure that containers run with restricted privileges and comply with {OCP} security context constraints (SCCs).
+You can configure a custom security context directly in your `EventListener` custom resource (CR) to meet your security requirements. A custom security context helps ensure that containers run with restricted privileges and comply with {OCP} security context constraints (SCCs).
 
 .Procedure
 
@@ -43,3 +43,20 @@ spec:
 +
 `runAsNonRoot`:: Specify the pod-level security context settings. The example setting sets the pod-level security context to prevent the containers from running as the root user.
 `readOnlyRootFilesystem`:: Specify the container-level security context settings. The example setting restricts the container root filesystem to read-only to limit potential file system modifications at runtime.
+
+.Verification
+
+* Verify that the `EventListener` pod uses the security context:
++
+[source,terminal]
+----
+$ oc describe pod -l eventlistener=<eventlistener_name>
+----
+
+* The output shows `runAsNonRoot: true` and `readOnlyRootFilesystem: true` in the security context.
+
+[role="_additional-resources"]
+.Additional resources
+
+* link:https://docs.openshift.com/container-platform/latest/authentication/managing-security-context-constraints.html[Managing security context constraints]
+* link:https://kubernetes.io/docs/tasks/configure-pod-container/security-context/[Configure a Security Context for a Pod or Container]

--- a/secure/securing-webhooks-with-event-listeners.adoc
+++ b/secure/securing-webhooks-with-event-listeners.adoc
@@ -1,24 +1,15 @@
 :_mod-docs-content-type: ASSEMBLY
 include::_attributes/common-attributes.adoc[]
 [id="securing-webhooks-with-event-listeners"]
-= Securing webhooks with event listeners
+= Secure webhooks with event listeners
 :context: securing-webhooks-with-event-listeners
 
 toc::[]
 
 [role="_abstract"]
-As an administrator, you can secure webhooks with event listeners. After creating a namespace, you enable HTTPS for the `Eventlistener` resource by adding the `operator.tekton.dev/enable-annotation=enabled` label to the namespace. Then, you create a `Trigger` resource and a secured route using the re-encrypted TLS termination.
+Secure webhook connections to protect sensitive pipeline triggers and prevent unauthorized access to your {pipelines-shortname} infrastructure. {pipelines-title} supports both insecure HTTP and secure HTTPS connections to the `EventListener` resource, with HTTPS providing security within and outside the cluster.
 
-Triggers in {pipelines-title} support insecure HTTP and secure HTTPS connections to the `Eventlistener` resource. HTTPS secures connections within and outside the cluster.
-
-{pipelines-title} runs a `tekton-operator-proxy-webhook` pod that watches for the labels in the namespace. When you add the label to the namespace, the webhook sets the `service.beta.openshift.io/serving-cert-secret-name=<secret_name>` annotation on the `EventListener` object. This, in turn, creates secrets and the required certificates.
-
-[source,terminal,subs="attributes+"]
-----
-service.beta.openshift.io/serving-cert-secret-name=<secret_name>
-----
-
-In addition, you can mount the created secret into the `Eventlistener` pod to secure the request.
+{pipelines-title} runs a `tekton-operator-proxy-webhook` pod that monitors namespace labels. When you add the required label, the webhook sets the `service.beta.openshift.io/serving-cert-secret-name=<secret_name>` annotation on the `EventListener` object, creating the necessary secrets and certificates. You can then mount the created secret into the `EventListener` pod to secure requests.
 
 include::modules/op-providing-secure-connection.adoc[leveloffset=+1]
 


### PR DESCRIPTION
[RHDEVDOCS-7551](https://redhat.atlassian.net/browse/RHDEVDOCS-7551): CQA assessment and fixes for the  Securing webhooks with event listener chapter.

The changes primarily include:
- Added Verification and Additional Resources section to procedures
- Updated to Titles (from gerund form to imperative or noun form as the case may be)

Version(s): 1.22, 1.21, 1.20

Issue: [RHDEVDOCS-7551](https://redhat.atlassian.net/browse/RHDEVDOCS-7551)

Link to docs preview: https://113107--ocpdocs-pr.netlify.app/openshift-pipelines/latest/secure/securing-webhooks-with-event-listeners.html

SME/QE review:
- [x] SME/QE has approved this change.

Additional information: N/Q