### PR TITLE
OBSDOCS-3087 OpenShift monitoring 4.22 release notes Errata Link Update

### DIFF
--- a/modules/monitoring-4-22-release-notes.adoc
+++ b/modules/monitoring-4-22-release-notes.adoc
@@ -9,10 +9,9 @@
 [role="_abstract"]
 Review changes for {ocp} {product-version} monitoring stack, including new features and enhancements, Technology Previews, deprecated and removed features, known issues, and fixed issues.
 
-//The changes are included in the following errata advisory:
+The changes are included in the following errata advisory:
 
-//* link:<link>[RHSA-year:00000]
-//Add errata advisory link
+* link:https://access.redhat.com/errata/RHEA-2026:5487[RHEA-2026:5487]
 
 [id="monitoring-4-22-updates-to-monitoring-components-and-dependencies_{context}"]
 == Updates to monitoring stack components and dependencies


### PR DESCRIPTION
Change type: Doc update; OpenShift monitoring 4.22 release notes

Doc JIRA: https://redhat.atlassian.net/browse/OBSDOCS-3087

Merge to: monitoring-docs-4.22

Doc Preview: https://113144--ocpdocs-pr.netlify.app/openshift-monitoring/latest/release-notes/monitoring-release-notes.html

Peer review: @shreyasiddhartha