### PR TITLE
OSDOCS-20079-1: adds advisory to RHCL release notes

### DIFF
--- a/modules/ref-relnotes-about.adoc
+++ b/modules/ref-relnotes-about.adoc
@@ -7,10 +7,10 @@
 = About this release
 
 [role="_abstract"]
-{prodname} {version} (RHEA-2026:XXXXX) is now available. This release includes the {mcpg} {mcpg-version} as a Technology Preview feature. New features, changes, and known issues that pertain to {prodname} {version} are included in this topic.
+{rh} {prodname} {version} link:https://access.redhat.com/errata/RHBA-2026:25234[RHBA-2026:25234] is now available. This release includes the {mcpg} {mcpg-version} as a Technology Preview feature. New features, changes, and known issues that pertain to {prodname} {version} are included in this topic.
 
 Starting with {prodname} {version}, full support ends with the release of the next minor version. Maintenance support ends with the minor version after that. See the link:https://access.redhat.com/RedHatConnectivityLink[Red Hat Connectivity Link Life Cycle Policy] for details about version support and {ocp} compatibility.
 
 Important lifecycle update for {prodname} 1.3::
 
-With this release, the maintenance support lifecycle for {prodname} 1.3 is updated. Maintenance Support for version 1.3 ends with the release of {prodname} 1.5. The maintenance lifecycle of 1.3 was announced before as ending with version {prodname} 1.6.
+With this release, the maintenance support lifecycle for {prodname} 1.3 is updated. Maintenance Support for version 1.3 ends with the release of {prodname} 1.5. The maintenance lifecycle of 1.3 was announced before as ending with {prodname} 1.6.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
rhcl-docs-1.4

Issue:
[OSDOCS-20079](https://redhat.atlassian.net/browse/OSDOCS-20079)

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change. See https://github.com/openshift/openshift-docs/pull/112944


<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
