### PR TITLE
RHDEVDOCS-7625: Content creation for configuring webhook secrets for Git providers

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -66,6 +66,8 @@ Topics:
   File: setting-up-argocd-instance
 - Name: Argo CD custom resource and component properties
   File: argo-cd-cr-component-properties
+- Name: Configure webhook secrets for Git providers
+  File: configure-webhook-secrets-git-providers
 ---
 Name: Access control and user management
 Dir: accesscontrol_usermanagement

--- a/argocd_instance/configure-webhook-secrets-git-providers.adoc
+++ b/argocd_instance/configure-webhook-secrets-git-providers.adoc
@@ -1,0 +1,27 @@
+:_mod-docs-content-type: ASSEMBLY
+include::_attributes/common-attributes.adoc[]
+[id="configure-webhook-secrets-git-providers"]
+= Configure webhook secrets for Git providers
+:context: configure-webhook-secrets-git-providers
+
+toc::[]
+
+[role="_abstract"]
+You can configure webhook secrets for Git providers declaratively by using the `Argo CD` custom resource (CR). This allows you to manage webhook credentials alongside your GitOps configuration instead of manually updating the `argocd-secret` secret.
+
+// Declarative webhook secrets for Git providers
+include::modules/gitops-declarative-webhook-secrets-git-providers.adoc[leveloffset=+1]
+
+// Create webhook secrets using the Argo CD CR
+include::modules/gitops-create-webhook-secrets-argocd-cr.adoc[leveloffset=+1]
+
+// Verify declarative webhook secret configuration
+include::modules/gitops-verify-webhook-secret-configuration.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+[id="additional-resources_{context}"]
+== Additional resources
+
+* xref:../argocd_instance/setting-up-argocd-instance.adoc#setting-up-argocd-instance[Setting up a new Argo CD instance]
+* xref:../argocd_instance/argo-cd-cr-component-properties.adoc#argo-cd-cr-component-properties[Argo CD custom resource and component properties]
+* link:https://argocd-operator.readthedocs.io/en/latest/usage/webhook-secrets/[Argo CD Webhook Secrets]

--- a/modules/gitops-create-webhook-secrets-argocd-cr.adoc
+++ b/modules/gitops-create-webhook-secrets-argocd-cr.adoc
@@ -1,0 +1,55 @@
+// Module included in the following assemblies:
+//
+// * argocd_instance/configure-webhook-secrets-git-providers.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="gitops-create-webhook-secrets-argocd-cr_{context}"]
+= Create webhook secrets using the Argo CD CR
+
+You can configure webhook secrets for Git providers by creating a Kubernetes `Secret` resource and referencing it in the `Argo CD` custom resource (CR).
+
+.Prerequisites
+
+* You have installed the {gitops-title} Operator.
+* You have created an `ArgoCD` instance.
+* You have configured a webhook in your Git provider.
+
+.Procedure
+
+. Create a `Secret` resource in the same namespace as the `ArgoCD` CR and configure the `spec.webhookSecrets` field in the `ArgoCD` CR.
++
+The following example configures a webhook secret for GitHub:
++
+[source,yaml]
+----
+apiVersion: v1
+kind: Secret
+metadata:
+  name: github-webhook-credentials
+  namespace: argocd
+  labels:
+    app.kubernetes.io/part-of: argocd
+    app.kubernetes.io/component: webhook
+type: Opaque
+stringData:
+  token: "your-github-webhook-secret"
+---
+apiVersion: argoproj.io/v1beta1
+kind: ArgoCD
+metadata:
+  name: example-argocd
+  namespace: argocd
+spec:
+  webhookSecrets:
+    github:
+      webhookSecretRef:
+        name: github-webhook-credentials
+        key: token
+----
+
+. Apply the configuration:
++
+[source,terminal]
+----
+$ oc apply -f webhook-secret.yaml
+----

--- a/modules/gitops-declarative-webhook-secrets-git-providers.adoc
+++ b/modules/gitops-declarative-webhook-secrets-git-providers.adoc
@@ -1,0 +1,64 @@
+// Module included in the following assemblies:
+//
+// * argocd_instance/configure-webhook-secrets-git-providers.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="gitops-declarative-webhook-secrets-git-providers_{context}"]
+= Declarative webhook secrets for Git providers
+
+Argo CD uses webhook secrets to validate incoming webhook requests from Git providers. You can configure webhook secrets declaratively by using the `spec.webhookSecrets` field in the `Argo CD` custom resource (CR).
+
+Using declarative webhook secrets provides the following benefits:
+
+* Manage webhook secrets together with Argo CD configuration
+* Integrate with Kubernetes secret management tools, such as Sealed Secrets or External Secrets Operator
+* Simplify operations by allowing the {gitops-title} Operator to synchronize referenced secret values to the `argocd-secret` secret
+* Configure webhook secrets for multiple Git providers in a single `ArgoCD` CR
+
+When you configure `spec.webhookSecrets`, the {gitops-title} Operator automatically populates the required keys in the `argocd-secret` secret that Argo CD uses internally.
+
+[IMPORTANT]
+====
+The referenced `Secret` resource must exist in the same namespace as the `Argo CD` CR. Cross-namespace secret references are not supported.
+====
+
+The following Git providers are supported for declarative webhook secret configuration:
+
+[cols="1,1,2",options="header"]
+|===
+|Provider |Field in `spec.webhookSecrets` |Required secret reference
+
+|GitHub
+|`github`
+|`webhookSecretRef`
+
+|GitLab
+|`gitlab`
+|`webhookSecretRef`
+
+|Bitbucket Cloud
+|`bitbucket`
+|`webhookUUIDSecretRef`
+
+|Bitbucket Server
+|`bitbucketServer`
+|`webhookSecretRef`
+
+|Gogs
+|`gogs`
+|`webhookSecretRef`
+
+|Azure DevOps
+|`azureDevOps`
+|`usernameSecretRef` and `passwordSecretRef`
+|===
+
+[NOTE]
+====
+When `spec.webhookSecrets` is configured, the {gitops-title} Operator synchronizes webhook secret values only for the declared providers. Webhook keys for providers that are not declared in `spec.webhookSecrets` might be removed from the `argocd-secret` secret.
+====
+
+[IMPORTANT]
+====
+Do not store plain-text secrets in Git repositories. Use secret management solutions, such as sealed secrets or external secrets Operator, to manage sensitive data securely.
+====

--- a/modules/gitops-verify-webhook-secret-configuration.adoc
+++ b/modules/gitops-verify-webhook-secret-configuration.adoc
@@ -1,0 +1,43 @@
+// Module included in the following assemblies:
+//
+// * argocd_instance/configure-webhook-secrets-git-providers.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="gitops-verify-webhook-secret-configuration_{context}"]
+= Verify declarative webhook secret configuration
+
+After configuring declarative webhook secrets, verify that the {gitops-title} Operator synchronized the webhook secret values to the `argocd-secret` secret.
+
+.Procedure
+
+. Run the following command to verify the configured GitHub webhook secret:
++
+[source,terminal,subs="+quotes"]
+----
+$ oc get secret argocd-secret -n _<namespace>_ -o jsonpath='{.data.webhook\.github\.secret}' | base64 -d
+----
++
+where:
++
+`<namespace>`:: Specifies the namespace where your Argo CD instance is installed, such as `openshift-gitops` for the default instance.
+
+. Verify that the command output matches the value stored in the Secret referenced by `spec.webhookSecrets.github.webhookSecretRef`.
+
+[NOTE]
+====
+After updating webhook secrets, the Argo CD server might need to restart to pick up the updated values.
+
+Run the following command to restart the Argo CD server deployment:
+
+[source,terminal,subs="+quotes"]
+----
+$ oc rollout restart deployment/_<argocd_cr_name>_-server -n _<namespace>_
+----
+
+--
+where:
+
+`<argocd_cr_name>`:: Specifies the name of your Argo CD custom resource.
+`<namespace>`:: Specifies the namespace where your Argo CD instance is installed.
+--
+====


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

gitops-docs-1.21

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

https://redhat.atlassian.net/browse/RHDEVDOCS-7625

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

[Configure webhook secrets for Git providers](https://113172--ocpdocs-pr.netlify.app/openshift-gitops/latest/argocd_instance/configure-webhook-secrets-git-providers.html)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

SME review: @aali309 
QE review: @Naveena-058 
Peer review: @shivanisathe25 

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
