### PR TITLE
[OSDOCS-19525]: Autoscaling docs for self-managed hosted clusters on Azure

### DIFF
--- a/hosted_control_planes/hcp-deploy/hcp-deploy-azure.adoc
+++ b/hosted_control_planes/hcp-deploy/hcp-deploy-azure.adoc
@@ -99,11 +99,7 @@ include::modules/hcp-azure-private-access.adoc[leveloffset=+2]
 
 include::modules/hcp-azure-private-ts.adoc[leveloffset=+2]
 
-// include::modules/hcp-azure-autoscaling.adoc[leveloffset=+1]
-
-// include::modules/hcp-azure-hc-config-params.adoc[leveloffset=+1]
-
-// include::modules/hcp-azure-nodepool-config-params.adoc[leveloffset=+2]
+include::modules/hcp-azure-autoscaling.adoc[leveloffset=+1]
 
 include::modules/hcp-azure-delete.adoc[leveloffset=+1]
 

--- a/modules/hcp-azure-autoscaling.adoc
+++ b/modules/hcp-azure-autoscaling.adoc
@@ -1,0 +1,72 @@
+//Module included in the following assemblies:
+// hosted_control_planes/hcp-deploy/hcp-deploy-azure.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="hcp-azure-autoscaling_{context}"]
+= Example: Autoscaling a hosted cluster on {azure-short}
+
+[role="_abstract"]
+To balance node pools on your {azure-short} hosted cluster, you can configure autoscaling for the cluster.
+
+When you scale up `NodePool` objects, the Cluster API Provider for {azure-short} provisions individual {azure-short} virtual machines.
+
+To configure autoscaling for a hosted cluster on {azure-short}, you edit the `spec.autoscaling` parameters in the `HostedCluster` resource. The following example shows a `HostedCluster` resource with 2 {azure-short} node pools.
+
+[NOTE]
+====
+This example shows only the autoscaling-related fields.
+====
+
+[source,yaml]
+----
+apiVersion: hypershift.openshift.io/v1beta1
+kind: HostedCluster
+metadata:
+  name: my-cluster
+  namespace: my-cluster-namespace
+spec:
+  autoscaling:
+    scaling: ScaleUpAndScaleDown
+    maxNodesTotal: 12
+    expanders:
+      - Random
+    scaleDown:
+      delayAfterAddSeconds: 300
+      unneededDurationSeconds: 600
+      utilizationThresholdPercent: 40
+    balancingIgnoredLabels:
+      - "custom.label/environment"
+    maxFreeDifferenceRatioPercent: 70
+---
+apiVersion: hypershift.openshift.io/v1beta1
+kind: NodePool
+metadata:
+  name: my-cluster-nodepool-1
+  namespace: my-cluster-namespace
+spec:
+  clusterName: my-cluster
+  autoScaling:
+    min: 1
+    max: 6
+  platform:
+    azure:
+      vmSize: Standard_D4s_v3
+      # ... 
+---
+apiVersion: hypershift.openshift.io/v1beta1
+kind: NodePool
+metadata:
+  name: my-cluster-nodepool-2
+  namespace: my-cluster-namespace
+spec:
+  clusterName: my-cluster
+  autoScaling:
+    min: 1
+    max: 6
+  platform:
+    azure:
+      vmSize: Standard_D4s_v3
+      # ... 
+----
+
+* `spec.autoScaling.min` must be greater than or equal to `1`. Scaling from zero (`autoScaling.min: 0`) is not supported on {azure-short}.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.22+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://redhat.atlassian.net/browse/OSDOCS-19525
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://113175--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-deploy/hcp-deploy-azure.html#hcp-azure-autoscaling_hcp-deploy-azure
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review: In lieu of QE review, the self-managed HCP on Azure docs will have 2 SME reviews.
- [x] SME 1 (Bryan)
- [x] SME 2 (Alessandro)
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
