### PR TITLE
OSDOCS-20064:Update the z-stream RNs for 4.15.65

### DIFF
--- a/modules/zstream-4-15-64.adoc
+++ b/modules/zstream-4-15-64.adoc
@@ -28,4 +28,4 @@ $ oc adm release info 4.15.64 --pullspecs
 [id="zstream-4-15-64-updating_{context}"]
 == Updating
 
-To update an {product-title} 4.20 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+To update an {product-title} 4.15 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].

--- a/modules/zstream-4-15-65.adoc
+++ b/modules/zstream-4-15-65.adoc
@@ -1,0 +1,31 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-15-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-15-65_{context}"]
+= RHSA-2026:23234 - {product-title} {product-version}.65 fixed issues
+
+Issued: 11 June 2026
+
+[role="_abstract"]
+{product-title} release {product-version}.65 is now available. The list of fixed issues that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2026:23234[RHSA-2026:23234] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2026:23232[RHBA-2026:23232] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.15.65 --pullspecs
+----
+
+[id="zstream-4-15-65-fixed-issues_{context}"]
+== Fixed issues
+
+There are no notable fixed issues for this release.
+
+[id="zstream-4-15-65-updating_{context}"]
+== Updating
+
+To update an {product-title} 4.15 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].

--- a/release_notes/ocp-4-15-release-notes.adoc
+++ b/release_notes/ocp-4-15-release-notes.adoc
@@ -2814,6 +2814,9 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+//  4.15.65
+include::modules/zstream-4-15-65.adoc[leveloffset=+2]
+
 //  4.15.64
 include::modules/zstream-4-15-64.adoc[leveloffset=+2]
 


### PR DESCRIPTION
Version(s):
4.15

Issue:
https://redhat.atlassian.net/browse/OSDOCS-20064

Link to docs preview:
https://113177--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-15-release-notes.html#zstream-4-15-65_release-notes

Additional information:
4.15.65 MR: https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/563
ART Dashboard: https://art-dash.engineering.redhat.com/dashboard/release/openshift-4.15?page=1