### PR TITLE
CNV-80383: Add 3 CNV release notes for 4.22

### DIFF
--- a/virt/release_notes/virt-4-22-release-notes.adoc
+++ b/virt/release_notes/virt-4-22-release-notes.adoc
@@ -37,6 +37,13 @@ To view the supported guest operating systems for {VirtProductName}, see link:ht
 
 // Installation and update
 
+Extended Upgrade Support enables 36-month lifecycle for {VirtProductName} clusters::
++
+{VirtProductName} now supports a 36-month cluster lifecycle policy with optional Extended Upgrade Support (EUS) add-ons. With EUS, you can remain on the same release for up to 36 months, enabling stable production environments for mission-critical applications.
++
+For more information about EUS add-on subscriptions, see link:https://access.redhat.com/support/policy/updates/openshift[{product-title} Life Cycle Policy].
++
+link:https://redhat.atlassian.net/browse/CNV-73922[CNV-73922]
 
 // Infrastructure
 
@@ -84,6 +91,12 @@ link:https://redhat.atlassian.net/browse/CNV-72621[CNV-72621]
 
 
 // Storage
+
+Bulk storage class migration for offline VMs::
++
+Administrators can bulk migrate storage classes of stopped virtual machines (VMs) in the {product-title} web console. This functionality supports storage class migration for VMs in any state. You can select both running and stopped VMs in a single plan for the migration.
++
+link:https://redhat.atlassian.net/browse/CNV-73500[CNV-73500]
 
 Option to automatically clean up source PVCs after storage migration::
 +
@@ -231,6 +244,13 @@ Create virtual machines from in-cluster native templates (Technology Preview)::
 Virtual machine (VM) owners can create VMs from the {VirtProductName} cluster native template custom resource. The VM template tracks a golden image that is updated periodically, reducing errors and ensuring uniformity in the virtualized environment. You can host the template in all namespaces that you can control.
 +
 link:https://redhat.atlassian.net/browse/CNV-73392[CNV-73392]
+
+//CNV-49964
+Dual stream support for {VirtProductName} clusters (Technology Preview)::
++
+You can provision {VirtProductName} clusters that run Red Hat Enterprise Linux CoreOS (RHCOS) version 9.8 and version 10.2 in {product-title} 4.22. RHCOS 9.8 is the default operating system. VM live migration between RHCOS 9.x and RHCOS 10.x worker nodes is supported in {product-title} 4.22.
++
+link:https://redhat.atlassian.net/browse/CNV-49964[CNV-49964]
 
 //[id="virt-4-22-bug-fixes_{context}"]
 //== Fixed issues


### PR DESCRIPTION
Version(s):
4.22

Issue:
https://redhat.atlassian.net/browse/CNV-73922
https://redhat.atlassian.net/browse/CNV-73500
https://redhat.atlassian.net/browse/CNV-49964

Link to docs preview:
https://113178--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/release_notes/virt-4-22-release-notes.html

QE review:
- [x] QE has approved this change.

Additional information:
Adds 3 CNV release notes for OpenShift Virtualization 4.22 covering EUS lifecycle policy, storage migration enhancements, and dual stream RHCOS support.

---

🤖 Generated with Claude Code