### PR TITLE
OSDOCS-20079-2: removes fixed issue from KIs RHCL 1.4

### DIFF
--- a/modules/ref-relnotes-about.adoc
+++ b/modules/ref-relnotes-about.adoc
@@ -7,7 +7,7 @@
 = About this release
 
 [role="_abstract"]
-{rh} {prodname} {version} link:https://access.redhat.com/errata/RHBA-2026:25234[RHBA-2026:25234] is now available. This release includes the {mcpg} {mcpg-version} as a Technology Preview feature. New features, changes, and known issues that pertain to {prodname} {version} are included in this topic.
+{rh} {prodname} {version}, link:https://access.redhat.com/errata/RHBA-2026:25234[RHBA-2026:25234], is now available. This release includes the {mcpg} {mcpg-version} as a Technology Preview feature. New features, changes, and known issues that pertain to {prodname} {version} are included in this topic.
 
 Starting with {prodname} {version}, full support ends with the release of the next minor version. Maintenance support ends with the minor version after that. See the link:https://access.redhat.com/RedHatConnectivityLink[Red Hat Connectivity Link Life Cycle Policy] for details about version support and {ocp} compatibility.
 

--- a/modules/ref-relnotes-known-issues.adoc
+++ b/modules/ref-relnotes-known-issues.adoc
@@ -7,8 +7,6 @@
 = Known issues
 
 [role="_abstract"]
-{prodname} {version} has two known issues.
-
-* When the disk storage option is enabled in the `Limitador` custom resource (CR), both the initial `limitador` deployment and Operator update get stuck on a `Multi-Attach` error because of the persistent volume claim (PVC) volume. As a workaround, you can change the `limitador` deployment strategy to `"Recreate"` and the reconcilation process works as expected. (link:https://issues.redhat.com/browse/CONNLINK-855[CONNLINK-855])
+{prodname} {version} has a known issue.
 
 * When either the `Redis` or `RedisCached` storage option is set in a `Limitador` CR and the `limitador` pod gets restarted for any reason, the first request to the gateway is never rate-limited. All `http` requests after this are rate-limited. (link:https://issues.redhat.com/browse/CONNLINK-856[CONNLINK-856])


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
rhcl-docs-1.4

Issue:
[OSDOCS-20079](https://redhat.atlassian.net/browse/OSDOCS-20079)

Link to docs preview:
https://113180--ocpdocs-pr.netlify.app/rhcl/latest/release_notes/rhcl-release-notes.html

QE review:
- [x] QE has approved this change.
See https://github.com/openshift/openshift-docs/pull/112989

Additional information:
This was a pre-release fix that I forgot to remove from our release notes.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
