### PR TITLE
TELCODOCS-2901 Document declarative late binding for BMH selection from a single InfraEnv in ZTP workflow

### DIFF
--- a/edge_computing/ztp-manual-install.adoc
+++ b/edge_computing/ztp-manual-install.adoc
@@ -46,6 +46,30 @@ include::modules/ztp-manually-install-a-single-managed-cluster.adoc[leveloffset=
 
 * xref:../edge_computing/policygenerator_for_ztp/ztp-configuring-managed-clusters-policygenerator.adoc#ztp-configuring-managed-clusters-policygenerator[Configuring managed cluster policies by using PolicyGenerator resources]
 
+include::modules/ztp-late-binding-bare-metal-host-pools.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../edge_computing/ztp-manual-install.adoc#ztp-binding-bmh-to-cluster-using-annotation_ztp-manual-install[Bind bare-metal hosts to clusters using the cluster-reference annotation in {ztp} deployments]
+
+* xref:../edge_computing/ztp-manual-install.adoc#ztp-bmh-cluster-reference-annotation-ref_ztp-manual-install[`BareMetalHost` cluster-reference annotation reference]
+
+* link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.17/html/clusters/cluster_mce_overview#bind-unbind-hosts[Binding and unbinding hosts in the {rh-rhacm} documentation]
+
+include::modules/ztp-binding-bmh-to-cluster-using-annotation.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../edge_computing/ztp-manual-install.adoc#ztp-late-binding-bare-metal-host-pools_ztp-manual-install[Late binding for bare-metal host pools in {ztp} deployments]
+
+* xref:../edge_computing/ztp-manual-install.adoc#ztp-bmh-cluster-reference-annotation-ref_ztp-manual-install[`BareMetalHost` cluster-reference annotation reference]
+
+* link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.16/html/clusters/cluster_mce_overview#binding-and-unbinding-hosts[Binding and unbinding hosts in the {rh-rhacm} documentation]
+
+include::modules/ztp-bmh-cluster-reference-annotation-ref.adoc[leveloffset=+1]
+
 include::modules/ztp-checking-the-managed-cluster-status.adoc[leveloffset=+1]
 
 include::modules/ztp-troubleshooting-the-managed-cluster.adoc[leveloffset=+1]

--- a/modules/sample-ztp-custom-resources.adoc
+++ b/modules/sample-ztp-custom-resources.adoc
@@ -57,13 +57,12 @@ spec:
   controlPlaneConfig:
     servingCertificates: {}
   platform:
-    agentBareMetal:
-      agentSelector:
-        matchLabels:
-          bla: aaa
+    agentBareMetal: {}
   pullSecretRef:
     name: pull-secret
 ----
+
+To declaratively bind specific bare-metal hosts to a cluster, use the `bmac.agent-install.openshift.io/cluster-reference` annotation on `BareMetalHost` resources.
 
 .Example `cluster-image-set.yaml` file
 
@@ -98,6 +97,10 @@ spec:
     matchLabels:
       cluster0-nmstate-label-name: cluster0-nmstate-label-value
 ----
+
+The `clusterRef` field and its child fields (`name` and `namespace`) are optional.
+To enable the late-binding workflow, remove the `clusterRef` field and its child fields from the `InfraEnv` CR.
+Hosts are then bound to clusters individually by using the `bmac.agent-install.openshift.io/cluster-reference` annotation on `BareMetalHost` resources.
 
 .Example `nmstateconfig.yaml` file
 

--- a/modules/ztp-binding-bmh-to-cluster-using-annotation.adoc
+++ b/modules/ztp-binding-bmh-to-cluster-using-annotation.adoc
@@ -1,0 +1,147 @@
+// Module included in the following assemblies:
+//
+// * edge_computing/ztp-manual-install.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="ztp-binding-bmh-to-cluster-using-annotation_{context}"]
+= Bind bare-metal hosts to clusters using the cluster-reference annotation in {ztp} deployments
+
+[role="_abstract"]
+In {ztp} deployments, you can declaratively bind individual `BareMetalHost` resources from a shared `InfraEnv` pool to specific `ClusterDeployment` CRs by using the `bmac.agent-install.openshift.io/cluster-reference` annotation.
+This approach is compatible with GitOps workflows because the binding is managed through annotations on the `BareMetalHost` resource rather than by patching `Agent` CRs directly.
+
+.Prerequisites
+
+* You have installed the OpenShift CLI (`oc`).
+
+* You have logged in to the hub cluster as a user with `cluster-admin` privileges.
+
+* You have created an `InfraEnv` CR without a `clusterRef` field. If you use the SiteConfig Operator, verify that the generated `InfraEnv` does not include a `clusterRef` field.
+
+* You have `BareMetalHost` resources that reference the shared `InfraEnv`. These resources are either generated automatically by the SiteConfig Operator from a `ClusterInstance` CR, or created manually with the `infraenvs.agent-install.openshift.io` label set to the name of the `InfraEnv` CR.
+
+* You have booted the hosts from the discovery ISO and `Agent` CRs have been created automatically for the discovered hosts.
+
+* You have created the target `ClusterDeployment` and `AgentClusterInstall` CRs for the cluster that you want to bind hosts to.
+
+.Procedure
+
+. Verify that the `InfraEnv` CR does not have a `clusterRef` field set:
++
+[source,terminal]
+----
+$ oc get infraenv <infraenv_name> -n <namespace> -o jsonpath='{.spec.clusterRef}'
+----
++
+If the command returns an empty result, the `InfraEnv` is configured for late binding.
+If a `clusterRef` value is returned, the `BareMetalHost` cluster-reference annotation is ignored and you must use the standard binding flow.
+
+. Verify that the `Agent` CRs exist and are not bound to a cluster:
++
+[source,terminal]
+----
+$ oc get agents -n <namespace>
+----
++
+.Example output
+[source,terminal]
+----
+NAME                                   CLUSTER   APPROVED   ROLE          STAGE
+aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb             false      auto-assign
+cccccccc-4444-5555-6666-dddddddddddd             false      auto-assign
+----
++
+Agents that are not bound to a cluster have an empty `CLUSTER` column.
+
+. Add the `bmac.agent-install.openshift.io/cluster-reference` annotation to the `BareMetalHost` resource to bind it to the target `ClusterDeployment` CR:
++
+[source,terminal]
+----
+$ oc annotate bmh <bmh_name> -n <namespace> \
+    bmac.agent-install.openshift.io/cluster-reference=<cluster_namespace>/<cluster_name>
+----
++
+Replace `<cluster_namespace>/<cluster_name>` with the namespace and name of the target `ClusterDeployment` CR.
++
+Alternatively, you can set the annotation declaratively in the `BareMetalHost` YAML manifest:
++
+[source,yaml]
+----
+apiVersion: metal3.io/v1alpha1
+kind: BareMetalHost
+metadata:
+  name: worker-01
+  namespace: my-infraenv-ns
+  annotations:
+    bmac.agent-install.openshift.io/cluster-reference: my-cluster-ns/my-cluster
+  labels:
+    infraenvs.agent-install.openshift.io: my-infraenv
+spec:
+  online: true
+  bootMACAddress: 00:00:5E:00:53:01
+  bmc:
+    address: redfish-virtualmedia://192.0.2.10/redfish/v1/Systems/1
+    credentialsName: worker-01-bmc-secret
+----
++
+The `bmac.agent-install.openshift.io/cluster-reference` annotation value uses the format `<namespace>/<name>`, referencing the target `ClusterDeployment`.
+
+. Verify that the `Agent` CR is bound to the correct `ClusterDeployment` CR by running the following command:
++
+[source,terminal]
+----
+$ oc get agents -n <namespace>
+----
++
+.Example output
+[source,terminal]
+----
+NAME                                   CLUSTER      APPROVED   ROLE          STAGE
+aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb   my-cluster   false      auto-assign
+----
++
+The `CLUSTER` column shows the name of the target `ClusterDeployment`.
+
+. Verify the `Bound` condition on the `Agent` CR:
++
+[source,terminal]
+----
+$ oc get agent <agent_name> -n <namespace> \
+    -o jsonpath='{.status.conditions[?(@.type=="Bound")]}'
+----
++
+A successfully bound agent shows `status: "True"` and `reason: "Bound"` in the output.
++
+[NOTE]
+====
+Agents discovered by using a `BareMetalHost` resource are automatically approved for installation when the `bootMACAddress` in the `BareMetalHost` matches a NIC in the inventory of the discovered host.
+You do not need to manually approve these agents.
+====
+
+. Optional: To unbind a host from a cluster before installation starts, set the annotation value to an empty string:
++
+[source,terminal]
+----
+$ oc annotate bmh <bmh_name> -n <namespace> \
+    bmac.agent-install.openshift.io/cluster-reference="" --overwrite
+----
++
+The bare metal agent controller (BMAC) clears the `spec.clusterDeploymentName` field on the corresponding `Agent` CR, and the host returns to the unbound pool.
++
+[IMPORTANT]
+====
+You cannot unbind a host after cluster installation has started.
+If you try to unbind a host that is already installed or in an `error` or `canceled` state, the `Agent` CR `Bound` condition is set to `False` with the reason `UnbindingPendingUserAction`.
+For hosts discovered by using a `BareMetalHost` resource, the assisted controllers automatically use the `BareMetalHost` to boot the host back into the discovery ISO to complete the unbinding process.
+For hosts discovered without a `BareMetalHost` resource, you must manually reboot the host with the discovery ISO.
+====
+
+.Verification
+
+* Verify that all agents are approved and bound to the correct cluster:
++
+[source,terminal]
+----
+$ oc get agents -n <namespace> -o custom-columns=NAME:.metadata.name,CLUSTER:.spec.clusterDeploymentName.name,APPROVED:.spec.approved
+----
+

--- a/modules/ztp-bmh-cluster-reference-annotation-ref.adoc
+++ b/modules/ztp-bmh-cluster-reference-annotation-ref.adoc
@@ -1,0 +1,75 @@
+// Module included in the following assemblies:
+//
+// * edge_computing/ztp-manual-install.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="ztp-bmh-cluster-reference-annotation-ref_{context}"]
+= BareMetalHost cluster-reference annotation
+
+[role="_abstract"]
+The `bmac.agent-install.openshift.io/cluster-reference` annotation on `BareMetalHost` resources controls the declarative binding of discovered hosts to `ClusterDeployment` CRs.
+You can use this annotation to bind, unbind, or leave hosts unchanged in a late binding workflow.
+
+.Cluster-reference annotation states
+[cols="1,1,2", options="header"]
+|===
+|Annotation state
+|Value
+|Effect on Agent CR
+
+|Set with cluster reference
+|`<namespace>/<name>`
+|Sets `spec.clusterDeploymentName` to the referenced `ClusterDeployment` CR. The `Agent` is bound to the specified cluster.
+
+|Set with empty string
+|`""`
+|Clears `spec.clusterDeploymentName`. The `Agent` is unbound from its current cluster and returns to the unbound pool.
+
+|Not set
+|N/A
+|No change to the `Agent` CR cluster reference. The host remains in its current state.
+|===
+
+.Constraints and precedence rules
+[cols="1,3", options="header"]
+|===
+|Constraint
+|Description
+
+|`InfraEnv` `clusterRef` takes precedence
+|If the `InfraEnv` CR has a `clusterRef` field set, the `BareMetalHost` cluster-reference annotation is ignored.
+The `InfraEnv` CR must not have a `clusterRef` for late binding to work.
+
+|Unbinding is blocked after installation starts
+|You can only unbind a host before cluster installation begins.
+After the installation starts, setting the annotation to an empty string results in an `UnbindingPendingUserAction` state on the `Agent` CR.
+
+|`ClusterDeployment` CR must exist
+|The `ClusterDeployment` CR referenced by the annotation must exist in the specified namespace.
+If the `ClusterDeployment` CR does not exist, the binding fails.
+
+|One `InfraEnv` CR per host
+|Each `BareMetalHost` CR is associated with a single `InfraEnv` CR through the `infraenvs.agent-install.openshift.io` label.
+|===
+
+.Related BareMetalHost bare metal agent controller (BMAC) annotations
+[cols="2,3", options="header"]
+|===
+|Annotation
+|Description
+
+|`bmac.agent-install.openshift.io/cluster-reference`
+|Binds the host to a specific `ClusterDeployment` CR. Value format: `<namespace>/<name>`.
+
+|`bmac.agent-install.openshift.io/hostname`
+|Sets the hostname for the agent during deployment.
+
+|`bmac.agent-install.openshift.io/role`
+|Sets the role of the host, such as `master` or `worker`.
+
+|`bmac.agent-install.openshift.io/installer-args`
+|Passes additional arguments to the {product-title} installer.
+
+|`bmac.agent-install.openshift.io/ignition-config-overrides`
+|Provides ignition configuration overrides for the host.
+|===

--- a/modules/ztp-installation-crs.adoc
+++ b/modules/ztp-installation-crs.adoc
@@ -4,10 +4,10 @@
 
 :_mod-docs-content-type: REFERENCE
 [id="ztp-installation-crs_{context}"]
-= {rh-rhacm} generated cluster installation CRs reference
+= {rh-rhacm} generated cluster installation CRs
 
 [role="_abstract"]
-{rh-rhacm-first} supports deploying {product-title} on single-node clusters, three-node clusters, and standard clusters with a specific set of installation custom resources (CRs) that you generate using `ClusterInstance` CRs for each cluster.
+{rh-rhacm-first} supports deploying {product-title} on single-node clusters, three-node clusters, and standard clusters with a specific set of installation custom resources (CRs) that you generate by using `ClusterInstance` CRs for each cluster.
 
 [NOTE]
 ====
@@ -23,11 +23,13 @@ The following table lists the installation CRs that are automatically applied by
 
 |`BareMetalHost`
 |Contains the connection information for the Baseboard Management Controller (BMC) of the target bare-metal host.
+In late binding scenarios where the `InfraEnv` CR is not bound to a `ClusterDeployment` CR, the optional `bmac.agent-install.openshift.io/cluster-reference` annotation on the `BareMetalHost` CR declaratively binds the host to a specific `ClusterDeployment` CR.
 |Provides access to the BMC to load and start the discovery image on the target server by using the Redfish protocol.
 
 |`InfraEnv`
 |Contains information for installing {product-title} on the target bare-metal host.
 |Used with `ClusterDeployment` to generate the discovery ISO for the managed cluster.
+Can also be created without a `ClusterDeployment` reference to enable late binding, where hosts are bound to clusters individually by using the `BareMetalHost` cluster-reference annotation.
 
 |`AgentClusterInstall`
 |Specifies details of the managed cluster configuration such as networking and the number of control plane nodes. Displays the cluster `kubeconfig` and credentials when the installation is complete.
@@ -39,7 +41,7 @@ The following table lists the installation CRs that are automatically applied by
 
 |`NMStateConfig`
 |Provides network configuration information such as `MAC` address to `IP` mapping, DNS server, default route, and other network settings.
-|Sets up a static IP address for the managed cluster’s Kube API server.
+|Sets up a static IP address for the managed cluster's Kube API server.
 
 |`Agent`
 |Contains hardware information about the target bare-metal host.
@@ -51,7 +53,7 @@ The following table lists the installation CRs that are automatically applied by
 
 |`KlusterletAddonConfig`
 |Contains the list of services provided by the hub to be deployed to the `ManagedCluster` resource.
-|Tells the hub which addon services to deploy to the `ManagedCluster` resource.
+|Tells the hub which add-on services to deploy to the `ManagedCluster` resource.
 
 |`Namespace`
 |Logical space for `ManagedCluster` resources existing on the hub. Unique per site.

--- a/modules/ztp-late-binding-bare-metal-host-pools.adoc
+++ b/modules/ztp-late-binding-bare-metal-host-pools.adoc
@@ -1,0 +1,27 @@
+// Module included in the following assemblies:
+//
+// * edge_computing/ztp-manual-install.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="ztp-late-binding-bare-metal-host-pools_{context}"]
+= Late binding for bare-metal host pools in {ztp} deployments
+
+[role="_abstract"]
+In the standard {ztp} flow, the `InfraEnv` custom resource (CR) references a specific `ClusterDeployment` CR, and all discovered hosts are automatically associated with that cluster.
+Late binding separates host discovery from cluster assignment, so you can manage a pool of bare-metal hosts independently from cluster lifecycle.
+
+With late binding, you create an `InfraEnv` CR without a `ClusterDeployment` reference, so that all hosts booted from the discovery ISO remain unbound and available for assignment to any cluster.
+You then use the `bmac.agent-install.openshift.io/cluster-reference` annotation on `BareMetalHost` resources to declaratively bind individual hosts to specific `ClusterDeployment` CRs.
+This annotation-based binding is compatible with GitOps workflows such as ArgoCD.
+
+Late binding in the {ztp} workflow is designed for environments where hardware provisioning and cluster creation happen independently.
+Common scenarios include:
+
+* An infrastructure team boots a set of bare-metal servers from a single discovery ISO, and a platform team later assigns subsets of those hosts to different clusters as demand arises.
+
+* Hardware provisioning and cluster creation are handled by different teams at different times.
+
+* Spare bare metal capacity must be allocated to clusters as workload requirements change.
+
+If you are deploying a single cluster where all discovered hosts belong to that cluster, use the standard {ztp} flow with a `ClusterDeployment` reference in the `InfraEnv` CR.
+


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][TELCODOCS-2901]: Document declarative late binding for BMH selection from a single InfraEnv in ZTP workflow

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 5.0, 4.22 and main
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:https://redhat.atlassian.net/browse/TELCODOCS-2901
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
https://113181--ocpdocs-pr.netlify.app/openshift-enterprise/latest/edge_computing/ztp-manual-install.html
https://113181--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_with_agent_based_installer/installing-with-agent-based-installer.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
