### PR TITLE
Fix `EntityRef` error in the converted output

### DIFF
--- a/modules/ref_virt-kubevirt-redfish-api-endpoints.adoc
+++ b/modules/ref_virt-kubevirt-redfish-api-endpoints.adoc
@@ -10,7 +10,7 @@
 KubeVirt Redfish implements a subset of the Redfish standard for managing virtual machines.
 The following table lists the supported API endpoints.
 
-Access these endpoints using the full URL format `https://<route_hostname>/<endpoint_path>`, where `<route_hostname>` is the KubeVirt Redfish Route hostname.
+Access these endpoints using the full URL format `\https://<route_hostname>/<endpoint_path>`, where `<route_hostname>` is the KubeVirt Redfish Route hostname.
 
 [NOTE]
 ====


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.22, 5.0
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: N/A
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
- https://113194--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/post_installation_configuration/virt-kubevirt-redfish.html#ref_virt-kubevirt-redfish-api-endpoints_virt-kubevirt-redfish
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Because marking text as [monospace](https://docs.asciidoctor.org/asciidoc/latest/text/monospace/) does not prevent Asciidoctor from [resolving common URL schemes as links](https://docs.asciidoctor.org/asciidoc/latest/macros/autolinks/), using angle brackets inside of such a link can cause it to produce invalid XHTML/XML output. Notice the semicolon incorrectly placed after the closing `</a>` tag:

```console
$ asciidoctor -so - modules/ref_virt-kubevirt-redfish-api-endpoints.adoc | grep -oP '<code>.*?endpoint_path.*?</code>'
<code><a href="https://&lt;route_hostname&gt;/&lt;endpoint_path&gt" class="bare">https://&lt;route_hostname&gt;/&lt;endpoint_path&gt</a>;</code>
```

This is also visible in the [preview of the module on GitHub](https://github.com/openshift/openshift-docs/blob/1f0231ba1e2b520d5aaaeb8671164533a49c84d5/modules/ref_virt-kubevirt-redfish-api-endpoints.adoc) and would be visible in the published content. When attempting to process such output with any XML-aware tool, the unterminated `&gt;` entity reference triggers the following error:

```console
$ asciidoctor -so - modules/ref_virt-kubevirt-redfish-api-endpoints.adoc | xmllint - --html >/dev/null 
-:6: HTML parser error : htmlParseEntityRef: expecting ';'
ll URL format <code><a href="https://&lt;route_hostname&gt;/&lt;endpoint_path&gt
                                                                               ^
-:6: HTML parser error : htmlParseEntityRef: expecting ';'
dpoint_path&gt" class="bare">https://&lt;route_hostname&gt;/&lt;endpoint_path&gt
                                                                               ^
```

This problem manifests when converting such a module to DITA. Because this is intended as an example and not a clickable link, this pull request escapes the link, which resolves this problem.

<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
