### PR TITLE
Remove erroneous description list markup

### DIFF
--- a/modules/virt-vm-manifest-creation-commands.adoc
+++ b/modules/virt-vm-manifest-creation-commands.adoc
@@ -13,7 +13,7 @@ You can use the following `virtctl create` commands to create manifests for virt
 |===
 |Command |Description
 
-|`virtctl create vm`::
+|`virtctl create vm`
 |Create a `VirtualMachine` (VM) manifest.
 
 |`virtctl create vm --name <vm_name>`


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.20+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: N/A
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
- https://113195--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/getting_started/virt-using-the-cli-tools.html#vm-manifest-creation-commands_virt-using-the-cli-tools
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
The `virtctl create vm` cell contains markup that causes Asciidoctor to interpret it as a [description list term](https://docs.asciidoctor.org/asciidoc/latest/lists/description/). Because this description list is not intentional and is not constructed correctly, the explanation of the term is not present. Because in DITA the `<dl>` element requires complete `<dt>` (description term) and `<dd>` (description definition) pairs, this causes the following error during conversion:

```
ERROR: Incomplete definition list
```

This pull request removes this erroneous markup.

<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
