### PR TITLE
OSDOCS-20129:Update the z-stream RNs for 4.18.44

### DIFF
--- a/modules/zstream-4-18-44.adoc
+++ b/modules/zstream-4-18-44.adoc
@@ -1,0 +1,31 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-18-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-18-44_{context}"]
+= RHSA-2026:25182 - {product-title} {product-version}.44 fixed issues and security update
+
+Issued: 17 June 2026
+
+[role="_abstract"]
+{product-title} release {product-version}.44 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2026:25182[RHSA-2026:25182] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2026:25180[RHSA-2026:25180] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.18.44 --pullspecs
+----
+
+[id="zstream-4-18-44-fixed-issues_{context}"]
+== Fixed issues
+
+* Before this update, creating snapshots of large {azure-first} `UltraSSD_LRS` or `PremiumV2_LRS` persistent volumes could fail due to a hard-coded 10-minute timeout in the Container Storage Interface (CSI) driver, which was insufficient for the {azure-short} background copy process on large disks. With this release, the {azure-short] Disk CSI driver supports instant access snapshots which can be configured by the `instantAccessDurationMinutes` parameter in the VolumeSnapshotClass. As a result, snapshot operations on large volumes are successfully completed. (link:https://redhat.atlassian.net/browse/OCPBUGS-78037[OCPBUGS-78037])
+
+[id="zstream-4-18-44-updating_{context}"]
+== Updating
+
+To update an {product-title} 4.18 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].

--- a/release_notes/ocp-4-18-release-notes.adoc
+++ b/release_notes/ocp-4-18-release-notes.adoc
@@ -3064,6 +3064,9 @@ As a workaround, you must manually reboot the failed host from the disk. (link:h
 // 4.18 about async
 include::modules/rn-async-errata.adoc[leveloffset=+1]
 
+// 4.18.44 RNs and updating
+include::modules/zstream-4-18-44.adoc[leveloffset=+2]
+
 // 4.18.43 RNs and updating
 include::modules/zstream-4-18-43.adoc[leveloffset=+2]
 


### PR DESCRIPTION
Version(s):
4.18

Issue:
https://redhat.atlassian.net/browse/OSDOCS-20129

Link to docs preview:
https://113196--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-18-release-notes.html#zstream-4-18-44_release-notes

Additional information:
4.18.44 MR: https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/575
ART Dashboard: https://art-dash.engineering.redhat.com/dashboard/release/openshift-4.18?page=1