### PR TITLE
Remove unnecessary list interruption

### DIFF
--- a/modules/nw-sriov-additional-network.adoc
+++ b/modules/nw-sriov-additional-network.adoc
@@ -90,7 +90,6 @@ You can specify `"{ "ips": true }"` to enable IP address support or `"{ "mac": t
 ** `spec.capabilities` defines a configuration object for the IPAM CNI plugin as a YAML block scalar. The plugin manages IP address assignment for the attachment definition.
 endif::ocp-sriov-net[]
 
-[start=2]
 . To create the object, enter the following command. Replace `<name>` with a name for this additional network.
 +
 [source,terminal]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.20+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: N/A
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
- https://113198--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/vm_networking/virt-connecting-vm-to-sriov.html#nw-sriov-additional-network_virt-connecting-vm-to-sriov
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
When using the `start` attribute to [define at which number to start the numerals](https://docs.asciidoctor.org/asciidoc/latest/lists/ordered/), although the list looks uninterrupted visually, to achieve this arbitrary number, Asciidoctor starts a new list:

```console
$ asciidoctor -so - modules/nw-sriov-additional-network.adoc | xmllint - --html --xpath 'count(//ol)'
2
```

This is a problem for conversion to DITA because only a single list can be successfully mapped to `<steps>`:

```
WARNING: Extra list elements found in steps, skipping...
```

This pull request corrects the markup to ensure the procedure steps form a single ordered list:

```console
$ asciidoctor -so - modules/nw-sriov-additional-network.adoc | xmllint - --html --xpath 'count(//ol)'
1
```

<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
