### PR TITLE
OBSDOCS-1049: Tuning log payloads and delivery section (6.5)

### DIFF
--- a/.vale/styles/config/vocabularies/OpenShiftDocs/accept.txt
+++ b/.vale/styles/config/vocabularies/OpenShiftDocs/accept.txt
@@ -33,3 +33,9 @@ pmc
 ubxtool
 vDUs?
 VFs?
+kibibyte
+kibibytes
+mebibyte
+mebibytes
+gibibyte
+gibibytes

--- a/modules/logging-delivery-tuning.adoc
+++ b/modules/logging-delivery-tuning.adoc
@@ -70,18 +70,18 @@ spec:
     lokiStack:
       tuning:
         deliveryMode: AtLeastOnce
-        compression: none
-        maxWrite: <integer>
-        minRetryDuration: 1s
-        maxRetryDuration: 1s
+        compression: gzip
+        maxWrite: 3Mi
+        minRetryDuration: 2
+        maxRetryDuration: 300
 ----
 `deliveryMode`:: Specify the delivery mode for log forwarding. When left unset, the system defaults to using an in-memory buffer, which offers the highest performance due to low latency but does not provide durability. Buffered data is lost on process termination or failure.
 ** `AtLeastOnce` delivery means that if the log forwarder crashes or restarts, the collector re-sends any logs it read before the crash but did not send to their destination. The collector might duplicate some logs after a crash.
 ** `AtMostOnce` delivery means that the log forwarder makes no effort to recover logs lost during a crash. This mode gives better throughput, but might result in greater log loss.
-`compression`:: Specifying a `compression` configuration causes the collector to compress data before sending it over the network. Note that not all output types support compression, and if the specified compression type is not supported by the output, this results in an error. For more information, see "Supported compression types for tuning outputs".
-`maxWrite`:: Specifies a limit for the maximum payload of a single send operation to the output.
-`minRetryDuration`:: Specifies a minimum duration to wait between attempts before retrying delivery after a failure. This value is a string, and you can specify it as milliseconds (`ms`), seconds (`s`), or minutes (`m`).
-`maxRetryDuration`:: Specifies a maximum duration to wait between attempts before retrying delivery after a failure. This value is a string, and you can specify it as milliseconds (`ms`), seconds (`s`), or minutes (`m`).
+`compression`:: Specifying a `compression` configuration causes the collector to compress data before sending it over the network. Note that not all output types support compression, and if the specified compression type is not supported by the output, this results in an error. For more information, see "Supported compression types for tuning outputs". When left unset, the collector does not apply compression.
+`maxWrite`:: Specifies a limit for the maximum payload in bytes of a single send operation to the output. You can specify this value as an integer or as a string with units such as `Ki` (kibibyte), `Mi` (mebibyte), or `Gi` (gibibyte). For example: `1048576`, `"1Mi"`, or `"3Mi"`. For `LokiStack` outputs, the default value is `3Mi` when not specified.
+`minRetryDuration`:: Specifies a minimum duration in seconds to wait between attempts before retrying delivery after a failure. This value is an integer representing seconds. For example, `2` means 2 seconds.
+`maxRetryDuration`:: Specifies a maximum duration in seconds to wait between attempts before retrying delivery after a failure. This value is an integer representing seconds. For example, `300` means 300 seconds (5 minutes).
 
 [id="supported-compression-types_{context}"]
 .Supported compression types for tuning outputs


### PR DESCRIPTION
Cherry-pick of #112365 to standalone-logging-docs-6.5

## Summary

This PR cherry-picks the [OBSDOCS-1049](https://redhat.atlassian.net/browse/OBSDOCS-1049) fix to the 6.5 branch.

**Original PR:** #112365  
**Jira:** https://redhat.atlassian.net/browse/OBSDOCS-1049

## Changes

Fixed tuning spec data types and added default values in `modules/logging-delivery-tuning.adoc`:
- Corrected `maxRecordSize` type from string to resource.Quantity
- Added binary unit suffixes (Ki, Mi, Gi) documentation
- Added default values for all tuning parameters

## Conflict Resolution

Resolved merge conflict in `.vale/styles/config/vocabularies/OpenShiftDocs/accept.txt` by merging both sets of vocabulary terms (kibibyte, mebibyte, gibibyte from the commit and pmc, ubxtool, vDUs, VFs from 6.5).

Signed-off-by John Wilkins <jowilkin@redhat.com>