### PR TITLE
OSDOCS#19822: Docs for OSSO 1.6.0

### DIFF
--- a/modules/nodes-secondary-scheduler-about.adoc
+++ b/modules/nodes-secondary-scheduler-about.adoc
@@ -17,3 +17,7 @@ You can use the {secondary-scheduler-operator} to deploy a custom secondary sche
 ====
 
 The {secondary-scheduler-operator} creates the default roles and role bindings required by the secondary scheduler. You can specify which scheduling plugins to enable or disable by configuring the `KubeSchedulerConfiguration` resource for the secondary scheduler.
+
+You can optionally configure high availability for the secondary scheduler to ensure continuous pod scheduling during scheduler pod failures or maintenance. When high availability is enabled, the Operator deploys multiple secondary scheduler replicas distributed across nodes, eliminating the scheduler as a single point of failure in production environments.
+
+The {secondary-scheduler-operator} publishes secondary scheduler metrics to Prometheus by default, enabling monitoring and observability of scheduler performance.

--- a/modules/nodes-secondary-scheduler-configuring-console.adoc
+++ b/modules/nodes-secondary-scheduler-configuring-console.adoc
@@ -65,12 +65,26 @@ where:
 .. Select *{secondary-scheduler-operator-full}*.
 .. Select the *Secondary Scheduler* tab and click *Create SecondaryScheduler*.
 .. The *Name* field defaults to `cluster`; do not change this name.
-.. The *Scheduler Config* field defaults to `secondary-scheduler-config`. Ensure that this value matches the name of the config map created earlier in this procedure.
-.. In the *Scheduler Image* field, enter the image name for your custom scheduler.
+.. The *schedulerConfig* field defaults to `secondary-scheduler-config`. Ensure that this value matches the name of the config map created earlier in this procedure.
+.. In the *schedulerImage* field, enter the image name for your custom scheduler.
 +
 [IMPORTANT]
 ====
 Red Hat does not directly support the functionality of your custom secondary scheduler.
+====
+
+.. Optional: To enable high availability for the secondary scheduler, configure the following settings:
++
+--
+... Expand the *topology* section.
+... In the *mode* field, select *HighlyAvailable*.
+... In the *maxReplicas* field, enter the maximum number of secondary scheduler replicas to deploy. If unset, the maximum number of replicas is `3`.
+... In the *tolerations* field, enter tolerations to allow scheduler replicas on tainted nodes. If unset, no taints are tolerated.
+--
++
+[NOTE]
+====
+To configure node selectors, use the *YAML view* option. Add the `spec.topology.highlyAvailableTopology.nodeSelector` field and enter the necessary node labels to target a specific group of nodes for scheduler replica placement. If unset, all nodes are considered.
 ====
 
 .. Click *Create*.

--- a/modules/nodes-secondary-scheduler-rn-1.6.0.adoc
+++ b/modules/nodes-secondary-scheduler-rn-1.6.0.adoc
@@ -1,0 +1,41 @@
+// Module included in the following assemblies:
+//
+// * nodes/scheduling/secondary_scheduler/nodes-secondary-scheduler-release-notes.adoc
+
+// This release notes module is allowed to contain xrefs. It must only ever be included from one assembly.
+
+:_mod-docs-content-type: REFERENCE
+[id="secondary-scheduler-operator-release-notes-1.6.0_{context}"]
+= Release notes for {secondary-scheduler-operator-full} 1.6.0
+
+[role="_abstract"]
+Review the release notes for {secondary-scheduler-operator} 1.6.0 to learn what is new and updated with this release.
+
+Issued: 24 June 2026
+
+The following advisory is available for the {secondary-scheduler-operator-full} 1.6.0:
+
+* link:https://access.redhat.com/errata/RHBA-2026:28915[RHBA-2026:28915]
+
+[id="secondary-scheduler-1.6.0-new-features_{context}"]
+== New features and enhancements
+
+* You can now configure high availability for the {secondary-scheduler-operator}, ensuring continuous pod scheduling for specialized workloads during scheduler pod failures or maintenance. High availability eliminates the secondary scheduler as a single point of failure in production environments.
++
+To enable high availability, set the topology mode to `HighlyAvailable` in the `SecondaryScheduler` custom resource (CR). In this mode, the Operator deploys multiple secondary scheduler replicas distributed across nodes, up to a configurable maximum. You can optionally set a node selector to target specific nodes or set tolerations for tainted nodes.
++
+For more information, see xref:../../../nodes/scheduling/secondary_scheduler/nodes-secondary-scheduler-configuring.adoc#nodes-secondary-scheduler-configuring-console_secondary-scheduler-configuring[Deploying a secondary scheduler].
+
+* The {secondary-scheduler-operator} now publishes secondary scheduler metrics to Prometheus by default.
+
+* This release of the {secondary-scheduler-operator} updates the Kubernetes version to 1.35.
+
+[id="secondary-scheduler-1.6.0-bug-fixes_{context}"]
+== Bug fixes
+
+* This release of the {secondary-scheduler-operator} addresses Common Vulnerabilities and Exposures (CVEs).
+
+[id="secondary-scheduler-operator-1.6.0-known-issues_{context}"]
+== Known issues
+
+* Currently, you cannot deploy additional resources, such as config maps, CRDs, or RBAC policies through the {secondary-scheduler-operator}. Any resources other than roles and role bindings that are required by your custom secondary scheduler must be applied externally. (link:https://issues.redhat.com/browse/WRKLDS-645[WRKLDS-645])

--- a/nodes/scheduling/secondary_scheduler/index.adoc
+++ b/nodes/scheduling/secondary_scheduler/index.adoc
@@ -9,8 +9,5 @@ toc::[]
 [role="_abstract"]
 You can install the {secondary-scheduler-operator} to run a custom secondary scheduler alongside the default scheduler to schedule pods.
 
-:operator-name: The {secondary-scheduler-operator}
-include::snippets/operator-not-available.adoc[]
-
 // About the {secondary-scheduler-operator}
 include::modules/nodes-secondary-scheduler-about.adoc[leveloffset=+1]

--- a/nodes/scheduling/secondary_scheduler/nodes-secondary-scheduler-configuring.adoc
+++ b/nodes/scheduling/secondary_scheduler/nodes-secondary-scheduler-configuring.adoc
@@ -9,9 +9,6 @@ toc::[]
 [role="_abstract"]
 You can run a custom secondary scheduler in {product-title} by installing the {secondary-scheduler-operator}, deploying the secondary scheduler, and setting the secondary scheduler in the pod definition.
 
-:operator-name: The {secondary-scheduler-operator}
-include::snippets/operator-not-available.adoc[]
-
 // Installing the {secondary-scheduler-operator}
 include::modules/nodes-secondary-scheduler-install-console.adoc[leveloffset=+1]
 

--- a/nodes/scheduling/secondary_scheduler/nodes-secondary-scheduler-release-notes.adoc
+++ b/nodes/scheduling/secondary_scheduler/nodes-secondary-scheduler-release-notes.adoc
@@ -11,10 +11,7 @@ Review the {secondary-scheduler-operator-full} release notes to track its develo
 
 The {secondary-scheduler-operator} allows you to deploy a custom secondary scheduler in your {product-title} cluster.
 
-:operator-name: The {secondary-scheduler-operator}
-include::snippets/operator-not-available.adoc[]
-
 For more information, see xref:../../../nodes/scheduling/secondary_scheduler/index.adoc#nodes-secondary-scheduler-about_nodes-secondary-scheduler-about[About the {secondary-scheduler-operator}].
 
-// Release notes for Secondary Scheduler Operator for Red Hat OpenShift x.y.z
-// include::modules/nodes-secondary-scheduler-rn-x.y.z.adoc[leveloffset=+1]
+// Release notes for Secondary Scheduler Operator for Red Hat OpenShift 1.6.0
+include::modules/nodes-secondary-scheduler-rn-1.6.0.adoc[leveloffset=+1]

--- a/nodes/scheduling/secondary_scheduler/nodes-secondary-scheduler-uninstalling.adoc
+++ b/nodes/scheduling/secondary_scheduler/nodes-secondary-scheduler-uninstalling.adoc
@@ -9,9 +9,6 @@ toc::[]
 [role="_abstract"]
 If you no longer need the {secondary-scheduler-operator-full} in your cluster, you can uninstall the Operator and remove its related resources.
 
-:operator-name: The {secondary-scheduler-operator}
-include::snippets/operator-not-available.adoc[]
-
 // Uninstalling the {secondary-scheduler-operator}
 include::modules/nodes-secondary-scheduler-uninstall-console.adoc[leveloffset=+1]
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.22+

Issue:
https://redhat.atlassian.net/browse/OSDOCS-19822

Link to docs preview:

- https://113227--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/scheduling/secondary_scheduler/index.html
- https://113227--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/scheduling/secondary_scheduler/nodes-secondary-scheduler-configuring.html
- https://113227--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/scheduling/secondary_scheduler/nodes-secondary-scheduler-release-notes.html
- https://113227--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/scheduling/secondary_scheduler/nodes-secondary-scheduler-uninstalling.html


QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->

**The advisory link won't work until it's updated on release day**