### PR TITLE
[enterprise-4.18] OSDOCS-19521 [NETSOBERV] Restructure order of includes for  assembly

### DIFF
--- a/observability/network_observability/observing-network-traffic.adoc
+++ b/observability/network_observability/observing-network-traffic.adoc
@@ -16,51 +16,66 @@ include::modules/network-observability-working-with-overview.adoc[leveloffset=+2
 
 include::modules/network-observability-configuring-options-overview.adoc[leveloffset=+2]
 
+// JOB (prep): packet drops
 include::modules/network-observability-pktdrop-overview.adoc[leveloffset=+2]
 
-[role="_additional-resources-packet-drops"]
+include::modules/network-observability-packet-drops.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
 .Additional resources
-* xref:../../observability/network_observability/observing-network-traffic.adoc#network-observability-packet-drops_nw-observe-network-traffic[Working with packet drops]
 * xref:../../observability/network_observability/metrics-alerts-dashboards.adoc#network-observability-metrics_metrics-dashboards-alerts[Network Observability metrics]
 
+// JOB (prep): DNS
 include::modules/network-observability-dns-overview.adoc[leveloffset=+2]
 
 //02-12-2026: adding comment here for JTBD for DNS. May make sense to revisit dns-overview for DNS resolution analysis. Might all be a JTBD. modules/network-observability-dns-tracking.adoc part of DNS resolution analysis now. Addressing this is outside scope of no-1.11 release but came up so making a note. This comment will be removed with JTBD.
 
+include::modules/network-observability-dns-tracking.adoc[leveloffset=+2]
+//02-12-2026 adding comment as dns-tracking must be addressed as part of JTBD post no-1.11 release. Commenting out include breaks a number of xrefs, and addressing the IA to fix that is outside the scope of no-1.11.
+
 [role="_additional-resources"]
 .Additional resources
-* xref:../../observability/network_observability/observing-network-traffic.adoc#network-observability-dns-tracking_nw-observe-network-traffic[Working with DNS tracking]
 * xref:../../observability/network_observability/metrics-alerts-dashboards.adoc#network-observability-metrics_metrics-dashboards-alerts[Network Observability metrics]
 
+// JOB (prep): RTT
 include::modules/network-observability-RTT-overview.adoc[leveloffset=+2]
 
-[role="_additional-resources-rtt-overview"]
-.Additional resources
-* xref:../../observability/network_observability/observing-network-traffic.adoc#network-observability-RTT_nw-observe-network-traffic[Working with RTT tracing]
+include::modules/network-observability-RTT.adoc[leveloffset=+2]
 
+// JOB (prep): eBPF flow filtering
 include::modules/network-observability-ebpf-rule-flow-filter.adoc[leveloffset=+2]
 
 include::modules/network-observability-flow-filter-parameters.adoc[leveloffset=+3]
 
-[role="_additional-resources-flow-filter-parameters"]
+include::modules/network-observability-filtering-ebpf-rule.adoc[leveloffset=+2]
+
+include::modules/network-observability-ebpf-flow-data-filtering-examples.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
 .Additional resources
-* xref:../../observability/network_observability/observing-network-traffic.adoc#network-observability-filtering-ebpf-rule_nw-observe-network-traffic[Filtering eBPF flow data with rules]
 * xref:../../observability/network_observability/metrics-alerts-dashboards.adoc#network-observability-metrics_metrics-dashboards-alerts[Network Observability metrics]
 * xref:../../observability/network_observability/network-observability-operator-monitoring.adoc#network-observability-health-dashboard-overview_network_observability[Health dashboards]
 
+// JOB (prep): UDN
 include::modules/network-observability-user-defined-networks.adoc[leveloffset=+2]
+
+include::modules/network-observability-working-with-udn.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
 .Additional resources
 * xref:../../networking/multiple_networks/primary_networks/about-user-defined-networks.adoc#about-user-defined-networks[About user-defined networks]
 * xref:../../networking/multiple_networks/primary_networks/about-user-defined-networks.adoc#nw-udn-cr_about-user-defined-networks[Creating a UserDefinedNetwork by using the CLI]
 * xref:../../networking/multiple_networks/primary_networks/about-user-defined-networks.adoc#nw-udn-cr-ui_about-user-defined-networks[Creating a UserDefinedNetwork by using the web console]
-* xref:../../observability/network_observability/observing-network-traffic.adoc#network-observability-working-with-udn_nw-observe-network-traffic[Working with user-defined networks]
 
+// JOB (prep): network events
 include::modules/network-observability-networking-events-overview.adoc[leveloffset=+2]
-[role="_additional-resources-networking-events-overview"]
+
+include::modules/network-observability-viewing-network-events.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
 .Additional resources
-* xref:../../observability/network_observability/observing-network-traffic.adoc#network-observability-viewing-network-events_nw-observe-network-traffic[Viewing network events]
+* xref:../../nodes/clusters/nodes-cluster-enabling-features.adoc#nodes-cluster-enabling-features-cli_nodes-cluster-enabling-features[Enabling feature sets using the CLI]
+* xref:../../networking/ovn_kubernetes_network_provider/ovn-kubernetes-troubleshooting-sources.adoc#nw-ovn-kubernetes-observability_ovn-kubernetes-sources-of-troubleshooting-information[Checking OVN-Kubernetes network traffic with OVS sampling using the CLI]
 
 //Traffic flows
 include::modules/network-observability-trafficflow.adoc[leveloffset=+1]
@@ -77,15 +92,7 @@ include::modules/network-observability-configuring-ipsec-with-flow-collector-res
 .Additional resources
 * xref:../../networking/network_security/configuring-ipsec-ovn.adoc#configuring-ipsec-ovn[Configuring IPsec encryption]
 
-//Traffic flows continued
 include::modules/network-observability-working-with-conversations.adoc[leveloffset=+2]
-
-include::modules/network-observability-packet-drops.adoc[leveloffset=+2]
-
-include::modules/network-observability-dns-tracking.adoc[leveloffset=+2]
-//02-12-2026 adding comment as dns-tracking must be addressed as part of JTBD post no-1.11 release. Commenting out include breaks a number of xrefs, and addressing the IA to fix that is outside the scope of no-1.11.
-
-include::modules/network-observability-RTT.adoc[leveloffset=+2]
 
 include::modules/network-observability-ebpf-manager-operator.adoc[leveloffset=+2]
 
@@ -94,36 +101,17 @@ include::modules/network-observability-ebpf-manager-operator.adoc[leveloffset=+2
 .Additional resources
 * xref:../../networking/networking_operators/ebpf_manager/ebpf-manager-operator-install.adoc[Installing the eBPF Manager Operator]
 
-//Traffic flows continued
 include::modules/network-observability-histogram-trafficflow.adoc[leveloffset=+2]
 
 include::modules/network-observability-working-with-zones.adoc[leveloffset=+2]
-
-include::modules/network-observability-filtering-ebpf-rule.adoc[leveloffset=+2]
-
-include::modules/network-observability-ebpf-flow-data-filtering-examples.adoc[leveloffset=+2]
-
-include::modules/network-observability-packet-translation-overview.adoc[leveloffset=+2]
-
-include::modules/network-observability-packet-translation.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
 .Additional resources
 * link:https://lwn.net/Articles/370152/#:~:text=A%20zone%20is%20simply%20a,to%20seperate%20conntrack%20defragmentation%20queues.[Conntrack Zone ID]
 
-include::modules/network-observability-working-with-udn.adoc[leveloffset=+2]
+include::modules/network-observability-packet-translation-overview.adoc[leveloffset=+2]
 
-[role="_additional-resources-working-with-udn"]
-.Additional resources
-* xref:../../networking/multiple_networks/primary_networks/about-user-defined-networks.adoc#nw-udn-cr_about-user-defined-networks[Creating a UserDefinedNetwork by using the CLI]
-* xref:../../networking/multiple_networks/primary_networks/about-user-defined-networks.adoc#nw-udn-cr-ui_about-user-defined-networks[Creating a UserDefinedNetwork by using the web console]
-
-include::modules/network-observability-viewing-network-events.adoc[leveloffset=+2]
-
-[role="_additional-resources-viewing-network-events"]
-.Additional resources
-* xref:../../nodes/clusters/nodes-cluster-enabling-features.adoc#nodes-cluster-enabling-features-cli_nodes-cluster-enabling[Enabling feature sets using the CLI]
-* xref:../../networking/ovn_kubernetes_network_provider/ovn-kubernetes-troubleshooting-sources.adoc#nw-ovn-kubernetes-observability_ovn-kubernetes-sources-of-troubleshooting-information[Checking OVN-Kubernetes network traffic with OVS sampling using the CLI]
+include::modules/network-observability-packet-translation.adoc[leveloffset=+2]
 
 //Topology
 include::modules/network-observability-topology.adoc[leveloffset=+1]


### PR DESCRIPTION
Manual cherry-pick

Original PR: https://github.com/openshift/openshift-docs/pull/112909
Original commit: https://github.com/openshift/openshift-docs/commit/9a88ae3e32a5532a8baa8cf1bb33943ba4e6153b

Version(s):
4.16

QE review:
QE is not required for this PR.

Additional information: