### PR TITLE
OSDOCS-20001: Fix invalid componentName and empty egress in ExternalS…

### DIFF
--- a/modules/external-secrets-operator-create-externalsecretsconfig.adoc
+++ b/modules/external-secrets-operator-create-externalsecretsconfig.adoc
@@ -36,7 +36,9 @@ spec:
     networkPolicies:
       - componentName: ExternalSecretsCoreController
         egress:
-          - {}
+          - ports:
+              - port: 443
+                protocol: TCP
         name: allow-external-secrets-egress
   plugins: {}
 ----

--- a/modules/external-secrets-operator-egress-allow-all-traffic.adoc
+++ b/modules/external-secrets-operator-egress-allow-all-traffic.adoc
@@ -36,8 +36,9 @@ spec:
   controllerConfig:
     networkPolicies:
       - name: allow-external-secrets-egress
-        componentName: CoreController
-        egress: # Allow all egress traffic
+        componentName: ExternalSecretsCoreController
+        egress:
+          - {} # Allow all egress traffic
 ----
 
 


### PR DESCRIPTION
…ecretsConfig documentation

- Replace invalid componentName: CoreController with the correct CRD enum value ExternalSecretsCoreController in the allow-all-traffic egress module.
- Replace the null egress: (deny-all) with egress: - {} (allow all) in the allow-all-traffic module.
- Replace egress: - {} (empty object) with an explicit port 443/TCP egress rule in the create-externalsecretsconfig module.

Resolves: [OSDOCS-20001](https://redhat.atlassian.net/browse/OSDOCS-20001)

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
