### PR TITLE
RHDEVDOCS-7556: Content creation for deprecating the Dynamic scaling feature

### DIFF
--- a/modules/gitops-argo-cd-dynamic-scaling-by-using-cli.adoc
+++ b/modules/gitops-argo-cd-dynamic-scaling-by-using-cli.adoc
@@ -12,6 +12,11 @@
 [role="_abstract"]
 You can enable dynamic scaling of shards by using the {oc-first}.
 
+[IMPORTANT]
+====
+Dynamic scaling of shards for the Argo CD Application Controller, including the `dynamicScalingEnabled` field, is deprecated and might be removed in a future {gitops-shortname} release.
+====
+
 .Prerequisites
 * You have installed the {gitops-title} Operator on your {OCP} cluster.
 * You have access to the cluster with `cluster-admin` privileges.

--- a/modules/gitops-argo-cd-dynamic-scaling-in-web-console.adoc
+++ b/modules/gitops-argo-cd-dynamic-scaling-in-web-console.adoc
@@ -10,6 +10,11 @@
 [role="_abstract"]
 You can enable dynamic scaling of shards by using the {OCP} web console.
 
+[IMPORTANT]
+====
+Dynamic scaling of shards for the Argo CD Application Controller, including the `dynamicScalingEnabled` field, is deprecated and might be removed in a future {gitops-shortname} release.
+====
+
 .Prerequisites
 * You have access to the cluster with `cluster-admin` privileges.
 * You have access to the {OCP} web console.

--- a/modules/gitops-argo-cd-dynamic-scaling.adoc
+++ b/modules/gitops-argo-cd-dynamic-scaling.adoc
@@ -10,6 +10,11 @@
 :FeatureName: Dynamic scaling of shards
 include::snippets/technology-preview.adoc[]
 
+[IMPORTANT]
+====
+Dynamic scaling of shards for the Argo CD Application Controller, including the `dynamicScalingEnabled` field, is deprecated and might be removed in a future {gitops-shortname} release.
+====
+
 By default, the Argo CD Application Controller assigns clusters to shards indefinitely. If you are using the `round-robin` sharding algorithm, this static assignment can result in uneven distribution of shards, particularly when replicas are added or removed. You can enable dynamic scaling of shards to automatically adjust the number of shards based on the number of clusters managed by the Argo CD Application Controller at a given time. This ensures that shards are well-balanced and optimizes the use of compute resources.
 
 [NOTE]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

gitops-docs-1.21

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

https://redhat.atlassian.net/browse/RHDEVDOCS-7556

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

Important Deprecation notice added for Dynamic enabling in the following sections:

- [Dynamic scaling of shards for the Argo CD Application Controller](https://113237--ocpdocs-pr.netlify.app/openshift-gitops/latest/declarative_clusterconfig/sharding-clusters-across-argo-cd-application-controller-replicas.html#gitops-argo-cd-dynamic-scaling_sharding-clusters-across-argo-cd-application-controller-replicas)

- [Enabling dynamic scaling of shards in the web console](https://113237--ocpdocs-pr.netlify.app/openshift-gitops/latest/declarative_clusterconfig/sharding-clusters-across-argo-cd-application-controller-replicas.html#gitops-argo-cd-dynamic-scaling-in-web-console_sharding-clusters-across-argo-cd-application-controller-replicas)

- [Enabling dynamic scaling of shards by using the CLI](https://113237--ocpdocs-pr.netlify.app/openshift-gitops/latest/declarative_clusterconfig/sharding-clusters-across-argo-cd-application-controller-replicas.html#gitops-argo-cd-dynamic-scaling-by-using-cli_sharding-clusters-across-argo-cd-application-controller-replicas)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

SME review: @svghadi 
QE review: @varshab1210 
Peer review: @shivanisathe25 

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
