### PR TITLE
CNV-68916: Remove CD-ROM hotplug release note for 4.22

### DIFF
--- a/virt/release_notes/virt-4-22-release-notes.adoc
+++ b/virt/release_notes/virt-4-22-release-notes.adoc
@@ -109,14 +109,6 @@ With this update, the `volumeRestorePolicy` default setting has been changed to 
 +
 link:https://redhat.atlassian.net/browse/CNV-77397[CNV-77397]
 
-Insert and eject CD-ROMs in a live VM::
-+
-{VirtProductName} support for declarative hot plug of CD-ROM storage devices in live virtual machines (VMs) is generally available. You can insert and eject CD-ROM storage in running VMs by enabling the `DeclarativeHotplugVolumes` feature gate in the `HyperConverged` custom resource (CR) without restarting the VM.
-+
-link:https://redhat.atlassian.net/browse/CNV-68916[CNV-68916]
-
-
-
 // Web console
 
 Configure AAQ to track resource utilization for VMs and mixed workloads::


### PR DESCRIPTION
Version(s):
4.22

Issue:
https://redhat.atlassian.net/browse/CNV-68916

Link to docs preview:
https://113279--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/release_notes/virt-4-22-release-notes.html

QE review:
- [x] QE has approved this change.

Additional information:
Removes the CD-ROM hotplug release note for [CNV-68916](https://redhat.atlassian.net/browse/CNV-68916) from the 4.22 release notes. This entry was previously added in PR #112502 but needs to be removed. See [this comment](https://redhat.atlassian.net/browse/CNV-68916?focusedCommentId=17267398).