### PR TITLE
[OSDOCS-19826]: Updating links to RHACM from HCP docs

### DIFF
--- a/architecture/mce-overview-ocp.adoc
+++ b/architecture/mce-overview-ocp.adoc
@@ -22,7 +22,7 @@ When you enable multicluster engine on {product-title}, you gain the following c
 * Infrastructure Operator, which manages the deployment of the Assisted Service to orchestrate on-premise bare metal and vSphere installations of {product-title}, such as {sno} on bare metal. The Infrastructure Operator includes xref:../edge_computing/ztp-deploying-far-edge-clusters-at-scale.adoc#ztp-challenges-of-far-edge-deployments_ztp-deploying-far-edge-clusters-at-scale[{ztp-first}], which fully automates cluster creation on bare metal and vSphere provisioning with GitOps workflows to manage deployments and configuration changes.
 * Open cluster management, which provides resources to manage Kubernetes clusters.
 
-The multicluster engine is included with your {product-title} support subscription and is delivered separately from the core payload. To start to use multicluster engine, you deploy the {product-title} cluster and then install the operator. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.16/html/clusters/cluster_mce_overview#mce-install-intro[Installing and upgrading multicluster engine operator].
+The multicluster engine is included with your {product-title} support subscription and is delivered separately from the core payload. To start to use multicluster engine, you deploy the {product-title} cluster and then install the operator. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/latest/html/clusters/cluster_mce_overview#mce-install-intro[Installing and upgrading multicluster engine operator].
 
 [id="mce-on-rhacm"]
 == Cluster management with Red Hat Advanced Cluster Management
@@ -32,4 +32,4 @@ If you need cluster management capabilities beyond what {product-title} with mul
 [id="mce-additional-resources-ocp"]
 == Additional resources
 
-For the complete documentation for multicluster engine, see link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.16/html/clusters/cluster_mce_overview[Cluster lifecycle with multicluster engine documentation], which is part of the product documentation for Red Hat Advanced Cluster Management.
+For the complete documentation for multicluster engine, see link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/latest/html/clusters/cluster_mce_overview[Cluster lifecycle with multicluster engine documentation], which is part of the product documentation for Red Hat Advanced Cluster Management.

--- a/hosted_control_planes/hcp-deploy/hcp-deploy-aws.adoc
+++ b/hosted_control_planes/hcp-deploy/hcp-deploy-aws.adoc
@@ -21,11 +21,11 @@ include::modules/hcp-aws-prereqs.adoc[leveloffset=+2]
 [role="_additional-resources"]
 .Additional resources
 
-* link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.16/html/clusters/cluster_mce_overview#ansible-config-hosted-cluster[Configuring Ansible Automation Platform jobs to run on hosted clusters]
+* link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/latest/html/clusters/cluster_mce_overview#ansible-config-hosted-cluster[Configuring Ansible Automation Platform jobs to run on hosted clusters]
 
-* link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.16/html/clusters/cluster_mce_overview#advanced-config-engine[Advanced configuration]
+* link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/latest/html/clusters/cluster_mce_overview#advanced-config-engine[Advanced configuration]
 
-* link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.16/html/clusters/cluster_mce_overview#enable-cim[Enabling the central infrastructure management service]
+* link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/latest/html/clusters/cluster_mce_overview#enable-cim[Enabling the central infrastructure management service]
 
 * xref:../../hosted_control_planes/hcp-prepare/hcp-enable-disable.adoc#hcp-enable-manual_hcp-enable-disable[Manually enabling the {hcp} feature]
 
@@ -79,6 +79,7 @@ include::modules/hcp-create-hc-arm64-aws.adoc[leveloffset=+2]
 [role="_additional-resources"]
 .Additional resources
 
+* xref:../../hosted_control_planes/hcp-disconnected/hcp-deploy-dc-bm.adoc#hcp-dc-extract_hcp-deploy-dc-bm[Extracting the release image digest]
 * link:https://console.redhat.com/openshift/install/aws/arm[Create an {product-title} Cluster: {aws-short} (ARM)]
 * xref:../../hosted_control_planes/hcp-deploy/hcp-deploy-aws.adoc#hcp-aws-create-role-sts-creds_hcp-deploy-aws[Creating an {aws-short} IAM role and STS credentials]
 
@@ -88,7 +89,6 @@ include::modules/hcp-create-np-arm64-aws.adoc[leveloffset=+2]
 .Additional resources
 
 * link:https://multi.ocp.releases.ci.openshift.org/[Multi-architecture nightly images]
-* link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.16/html/clusters/cluster_mce_overview#configure-hosted-disconnected-digest-image[Extracting the {product-title} release image digest]
 
 include::modules/hcp-create-private-hc-aws.adoc[leveloffset=+1]
 

--- a/hosted_control_planes/hcp-deploy/hcp-deploy-bm.adoc
+++ b/hosted_control_planes/hcp-deploy/hcp-deploy-bm.adoc
@@ -67,14 +67,13 @@ include::modules/hcp-bm-hc.adoc[leveloffset=+2]
 * xref:../../hosted_control_planes/hcp-import.adoc[Manually importing a hosted cluster]
 * xref:../../hosted_control_planes/hcp-disconnected/hcp-deploy-dc-bm.adoc#hcp-dc-extract_hcp-deploy-dc-bm[Extracting the release image digest]
 * xref:../../hosted_control_planes/hcp-certificates.adoc#hcp-custom-cert_hcp-certificates[Configuring a custom API server certificate in a hosted cluster]
-* link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/latest/html/clusters/cluster_mce_overview#add-host-host-inventory[Adding hosts to the host inventory by using the Discovery Image]
 
 include::modules/hcp-bm-hc-console.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
 .Additional resources
 
-* link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/latest/html/clusters/cluster_mce_overview#creating-a-credential-for-an-on-premises-environment[Creating a credential for an on-premises environment]
+* link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.15/html/clusters/cluster_mce_overview#creating-a-credential-for-an-on-premises-environment[Creating a credential for an on-premises environment]
 * xref:../../web_console/web-console.adoc#web-console-overview[Accessing the web console]
 * xref:../../hosted_control_planes/hcp-certificates.adoc#hcp-custom-cert_hcp-certificates[Configuring a custom API server certificate in a hosted cluster]
 
@@ -83,6 +82,7 @@ include::modules/hcp-bm-hc-mirror.adoc[leveloffset=+2]
 [role="_additional-resources"]
 .Additional resources
 
+* xref:../../hosted_control_planes/hcp-disconnected/hcp-deploy-dc-bm.adoc#hcp-dc-extract_hcp-deploy-dc-bm[Extracting the release image digest]
 * xref:../../hosted_control_planes/hcp-manage/hcp-manage-bm.adoc#hcp-bm-access_hcp-manage-bm[Accessing the hosted cluster]
 * xref:../../hosted_control_planes/hcp-certificates.adoc#hcp-custom-cert_hcp-certificates[Configuring a custom API server certificate in a hosted cluster]
 

--- a/hosted_control_planes/hcp-deploy/hcp-deploy-ibm-power.adoc
+++ b/hosted_control_planes/hcp-deploy/hcp-deploy-ibm-power.adoc
@@ -28,8 +28,8 @@ include::modules/hcp-ibm-power-prereqs.adoc[leveloffset=+1]
 [role="_additional-resources"]
 .Additional resources
 
-* link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.16/html/clusters/cluster_mce_overview#advanced-config-engine[Advanced configuration]
-* link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.16/html/clusters/cluster_mce_overview#enable-cim[Enabling the central infrastructure management service]
+* link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/latest/html/clusters/cluster_mce_overview#advanced-config-engine[Advanced configuration]
+* link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/latest/html/clusters/cluster_mce_overview#enable-cim[Enabling the central infrastructure management service]
 * xref:../../hosted_control_planes/hcp-prepare/hcp-cli.adoc#hcp-cli-terminal_hcp-cli[Installing the hosted control plane command-line interface]
 * xref:../../hosted_control_planes/hcp-prepare/hcp-enable-disable.adoc#hcp-enable-manual_hcp-enable-disable[Manually enabling the {hcp} feature]
 * xref:../../hosted_control_planes/hcp-prepare/hcp-enable-disable.adoc#hcp-disable-feature_hcp-enable-disable[Disabling the {hcp} feature]

--- a/hosted_control_planes/hcp-deploy/hcp-deploy-ibmz.adoc
+++ b/hosted_control_planes/hcp-deploy/hcp-deploy-ibmz.adoc
@@ -29,8 +29,8 @@ include::modules/hcp-ibm-z-prereqs.adoc[leveloffset=+1]
 [role="_additional-resources"]
 .Additional resources
 
-* link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.16/html/clusters/cluster_mce_overview#advanced-config-engine[Advanced configuration]
-* link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.16/html/clusters/cluster_mce_overview#enable-cim[Enabling the central infrastructure management service]
+* link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/latest/html/clusters/cluster_mce_overview#advanced-config-engine[Advanced configuration]
+* link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/latest/html/clusters/cluster_mce_overview#enable-cim[Enabling the central infrastructure management service]
 * xref:../../hosted_control_planes/hcp-prepare/hcp-cli.adoc#hcp-cli-terminal_hcp-cli[Installing the {hcp} command-line interface]
 
 include::modules/hcp-ibm-z-infra-reqs.adoc[leveloffset=+1]

--- a/hosted_control_planes/hcp-deploy/hcp-deploy-non-bm.adoc
+++ b/hosted_control_planes/hcp-deploy/hcp-deploy-non-bm.adoc
@@ -46,9 +46,9 @@ include::modules/hcp-non-bm-prereqs.adoc[leveloffset=+2]
 [role="_additional-resources"]
 .Additional resources
 
-* link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.16/html/clusters/cluster_mce_overview#advanced-config-engine[Advanced configuration ({rh-rhacm-title} documentation)]
+* link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/latest/html/clusters/cluster_mce_overview#advanced-config-engine[Advanced configuration ({rh-rhacm-title} documentation)]
 
-* link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.16/html/clusters/cluster_mce_overview#enable-cim[Enabling the central infrastructure management service ({rh-rhacm-title} documentation)]
+* link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/latest/html/clusters/cluster_mce_overview#enable-cim[Enabling the central infrastructure management service ({rh-rhacm-title} documentation)]
 
 include::modules/hcp-non-bm-firewall-port-svc-reqs.adoc[leveloffset=+2]
 
@@ -80,8 +80,6 @@ include::modules/hcp-non-bm-hc.adoc[leveloffset=+1]
 
 * xref:../../hosted_control_planes/hcp-certificates.adoc#hcp-custom-cert_hcp-certificates[Configuring a custom API server certificate in a hosted cluster]
 
-* link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.16/html/clusters/cluster_mce_overview#add-host-host-inventory[Adding hosts to the host inventory by using the Discovery Image ({rh-rhacm-title} documentation)]
-
 * xref:../../hosted_control_planes/hcp-disconnected/hcp-deploy-dc-bm.adoc#hcp-dc-extract_hcp-deploy-dc-bm[Extracting the release image digest]
 
 include::modules/hcp-non-bm-hc-console.adoc[leveloffset=+1]
@@ -89,7 +87,7 @@ include::modules/hcp-non-bm-hc-console.adoc[leveloffset=+1]
 [role="_additional-resources"]
 .Additional resources
 
-* link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.16/html/clusters/cluster_mce_overview#creating-a-credential-for-an-on-premises-environment[Creating a credential for an on-premises environment ({rh-rhacm-title} documentation)]
+* link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.15/html/clusters/cluster_mce_overview#creating-a-credential-for-an-on-premises-environment[Creating a credential for an on-premises environment ({rh-rhacm-title} documentation)]
 
 * xref:../../web_console/web-console.adoc#web-console-overview[Accessing the web console]
 

--- a/hosted_control_planes/hcp-deploy/hcp-deploy-virt.adoc
+++ b/hosted_control_planes/hcp-deploy/hcp-deploy-virt.adoc
@@ -25,7 +25,7 @@ You can use the hosted control plane command-line interface, `hcp`, to create an
 
 * xref:../../hosted_control_planes/hcp-import.adoc#hcp-import-disable_hcp-import[Disabling the automatic import of hosted clusters into {mce-short}]
 * xref:../../hosted_control_planes/hcp-prepare/hcp-enable-disable.adoc#hcp-enable-disable[Enabling or disabling the {hcp} feature]
-* link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.16/html/clusters/cluster_mce_overview#ansible-config-hosted-cluster[Configuring Ansible Automation Platform jobs to run on hosted clusters]
+* link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/latest/html/clusters/cluster_mce_overview#ansible-config-hosted-cluster[Configuring Ansible Automation Platform jobs to run on hosted clusters ({rh-rhacm-title} documentation)]
 
 include::modules/hcp-virt-reqs.adoc[leveloffset=+1]
 
@@ -44,7 +44,7 @@ include::modules/hcp-virt-prereqs.adoc[leveloffset=+2]
 * xref:../../post_installation_configuration/post-install-storage-configuration.adoc#post-install-storage-configuration[Postinstallation storage configuration]
 * link:https://console.redhat.com/openshift/install/platform-agnostic/user-provisioned[Install OpenShift on any x86_64 platform with user-provisioned infrastructure]
 * xref:../../hosted_control_planes/hcp-deploy/hcp-deploy-virt.adoc#hcp-metallb_hcp-deploy-virt[Configuring MetalLB]
-* link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.16/html/clusters/cluster_mce_overview#advanced-config-engine[Advanced configuration]
+* link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/latest/html/clusters/cluster_mce_overview#advanced-config-engine[Advanced configuration ({rh-rhacm-title} documentation)]
 
 include::modules/hcp-virt-firewall-port.adoc[leveloffset=+2]
 
@@ -86,7 +86,7 @@ include::modules/hcp-virt-create-hc-console.adoc[leveloffset=+2]
 
 * xref:../../hosted_control_planes/hcp-certificates.adoc#hcp-custom-cert_hcp-certificates[Configuring a custom API server certificate in a hosted cluster]
 
-* link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.16/html/clusters/cluster_mce_overview#creating-a-credential-for-an-on-premises-environment[Creating a credential for an on-premises environment]
+* link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.15/html/clusters/cluster_mce_overview#creating-a-credential-for-an-on-premises-environment[Creating a credential for an on-premises environment ({rh-rhacm-title} documentation)]
 
 * xref:../../hosted_control_planes/hcp-manage/hcp-manage-virt.adoc#hcp-virt-access_hcp-manage-virt[Accessing the hosted cluster]
 

--- a/hosted_control_planes/hcp-disconnected/hcp-deploy-dc-bm.adoc
+++ b/hosted_control_planes/hcp-disconnected/hcp-deploy-dc-bm.adoc
@@ -32,8 +32,10 @@ include::modules/hcp-dc-mgmt-cluster.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources
-* link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.16/html/clusters/cluster_mce_overview#mce-install-intro[Installing and upgrading multicluster engine operator]
-* xref:../../hosted_control_planes/hcp-prepare/hcp-enable-disable.adoc#hcp-enable-manual-addon_hcp-enable-disable[Manually enabling the hypershift-addon managed cluster add-on for local-cluster]
+
+* link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/latest/html/clusters/cluster_mce_overview#mce-install-intro[Installing and upgrading multicluster engine operator]
+* xref:../../hosted_control_planes/hcp-prepare/hcp-enable-disable.html#hcp-enable-manual-addon_hcp-enable-disable[Manually enabling the hypershift-addon managed cluster add-on for local-cluster]
+* link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/latest/html/clusters/cluster_mce_overview#mce-intro[Cluster lifecycle with multicluster engine operator overview]
 
 include::modules/hcp-dc-web-server.adoc[leveloffset=+1]
 
@@ -43,7 +45,7 @@ include::modules/hcp-dc-image-mirror.adoc[leveloffset=+1]
 .Additional resources
 * xref:../../disconnected/about-installing-oc-mirror-v2.adoc#oc-mirror-workflows-partially-disconnected-v2_about-installing-oc-mirror-v2[Mirroring an image set in a partially disconnected environment]
 * xref:../../disconnected/about-installing-oc-mirror-v2.adoc#oc-mirror-workflows-fully-disconnected-v2_about-installing-oc-mirror-v2[Mirroring an image set in a fully disconnected environment]
-* link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.16/html/clusters/cluster_mce_overview#install-on-disconnected-networks[Install on disconnected networks]
+* link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/latest/html/clusters/cluster_mce_overview#install-on-disconnected-networks[Install on disconnected networks]
 
 include::modules/hcp-dc-apply-objects.adoc[leveloffset=+1]
 
@@ -77,4 +79,4 @@ include::modules/hcp-dc-scale-np.adoc[leveloffset=+2]
 [role="_additional-resources"]
 == Additional resources
 
-* link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.16/html/clusters/cluster_mce_overview#enable-cim[Enabling the central infrastructure management service]
+* link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/latest/html/clusters/cluster_mce_overview#enable-cim[Enabling the central infrastructure management service]

--- a/hosted_control_planes/hcp-disconnected/hcp-deploy-dc-virt.adoc
+++ b/hosted_control_planes/hcp-disconnected/hcp-deploy-dc-virt.adoc
@@ -42,8 +42,8 @@ include::modules/hcp-dc-mce-virt.adoc[leveloffset=+1]
 [role="_additional-resources"]
 .Additional resources
 
-* link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.16/html/clusters/cluster_mce_overview#mce-intro[About cluster lifecycle with multicluster engine operator]
-* link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.16/html/clusters/cluster_mce_overview#mce-install-intro[Installing and upgrading multicluster engine operator]
+* link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/latest/html/clusters/cluster_mce_overview#mce-intro[About cluster lifecycle with multicluster engine operator]
+* link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/latest/html/clusters/cluster_mce_overview#mce-install-intro[Installing and upgrading multicluster engine operator]
 
 include::modules/hcp-dc-tls-virt.adoc[leveloffset=+1]
 

--- a/hosted_control_planes/hcp-import.adoc
+++ b/hosted_control_planes/hcp-import.adoc
@@ -15,7 +15,7 @@ include::modules/hcp-import-limitations.adoc[leveloffset=+1]
 
 * xref:../hosted_control_planes/hcp-updating.adoc#hcp-update-node-pools_hcp-updating[Updating node pools in a hosted cluster]
 * xref:../hosted_control_planes/hcp-updating.adoc#hcp-update-ocp-hc_hcp-updating[Updating a control plane in a hosted cluster]
-* link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.11/html/clusters/cluster_mce_overview#discover-hosted-acm[Discovering {mce} hosted clusters in {rh-rhacm-title}]
+* link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/latest/html/multicluster_engine_operator_with_red_hat_advanced_cluster_management/hosted-acm#discover-hosted-acm[Discovering {mce} hosted clusters in {rh-rhacm-title}]
 
 include::modules/hcp-import-manual.adoc[leveloffset=+1]
 

--- a/hosted_control_planes/hcp-machine-config.adoc
+++ b/hosted_control_planes/hcp-machine-config.adoc
@@ -35,7 +35,7 @@ include::modules/hcp-configure-ntp.adoc[leveloffset=+1]
 .Additional resources
 
 * xref:../installing/install_config/installing-customizing.adoc#installation-special-config-butane_installing-customizing[Creating machine configs with Butane]
-* link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.14/html-single/clusters/index#create-host-inventory-cli-steps[Creating a host inventory]
+* link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/latest/html-single/clusters/index#create-host-inventory-cli[Creating a host inventory by using the command line interface]
 
 
 include::modules/scale-up-down-autoscaler-hcp.adoc[leveloffset=+1]

--- a/hosted_control_planes/hcp-prepare/hcp-requirements.adoc
+++ b/hosted_control_planes/hcp-prepare/hcp-requirements.adoc
@@ -27,12 +27,12 @@ The control plane is associated with a hosted cluster and runs as pods in a sing
 include::modules/hcp-support-matrix.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
-.Additional resources
+== Additional resources
 
 * link:https://access.redhat.com/support/policy/updates/openshift_operators[OpenShift Operator Life Cycles]
 * xref:../../hosted_control_planes/hcp-prepare/hcp-sizing-guidance.adoc#hcp-shared-infra_hcp-sizing-guidance[Shared infrastructure between hosted and standalone control planes]
 * xref:../../hosted_control_planes/hcp-release-notes.adoc#hcp-release-notes-technology-preview-tables_hcp-release-notes[Technology Preview features status]
-* link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.16/html/clusters/cluster_mce_overview#remove-managed-cluster[Removing a cluster from management]
+* link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/latest/html/clusters/cluster_mce_overview#remove-managed-cluster[Removing a cluster from management]
 * link:https://access.redhat.com/articles/7142379[The multicluster engine for Kubernetes operator 2.17 Support Matrix]
 
 //FIPS-enabled hosted clusters

--- a/hosted_control_planes/hcp-troubleshooting.adoc
+++ b/hosted_control_planes/hcp-troubleshooting.adoc
@@ -25,7 +25,7 @@ include::modules/hcp-must-gather-dc.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources
-* link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.16/html/clusters/cluster_mce_overview#install-on-disconnected-networks[Install on disconnected networks]
+* link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/latest/html/clusters/cluster_mce_overview#install-on-disconnected-networks[Install on disconnected networks]
 
 include::modules/hcp-ts-ocp-virt.adoc[leveloffset=+1]
 
@@ -35,7 +35,7 @@ include::modules/hcp-ts-no-nodes-reg.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
 .Additional resources
-* link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.16/html/clusters/cluster_mce_overview#identifying-vm-console-logs[Identifying the problem: Access the VM console logs]
+* link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.11/html/clusters/cluster_mce_overview#identifying-vm-console-logs[Identifying the problem: Access the VM console logs]
 
 include::modules/hcp-ts-nodes-stuck.adoc[leveloffset=+2]
 
@@ -53,7 +53,7 @@ include::modules/hcp-ts-non-bm.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
 .Additional resources
-* link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.16/html/clusters/cluster_mce_overview#remove-managed-cluster[Removing a cluster from management]
+* link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/latest/html/clusters/cluster_mce_overview#remove-managed-cluster[Removing a cluster from management]
 
 include::modules/hcp-ts-bm.adoc[leveloffset=+1]
 

--- a/hosted_control_planes/hcp_high_availability/hcp-disaster-recovery-oadp.adoc
+++ b/hosted_control_planes/hcp_high_availability/hcp-disaster-recovery-oadp.adoc
@@ -95,8 +95,8 @@ include::modules/hcp-dr-oadp-restore-new-mgmt.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
 .Additional resources
-* link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.13/html/clusters/cluster_mce_overview#remove-a-cluster-by-using-the-console[Removing a cluster by using the console]
-* link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.13/html/clusters/cluster_mce_overview#removing-a-cluster-from-management-in-special-cases[Removing remaining resources after removing a cluster]
+* link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/latest/html/clusters/cluster_mce_overview#remove-a-cluster-by-using-the-console[Removing a cluster by using the console]
+* link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/latest/html/clusters/cluster_mce_overview#removing-a-cluster-from-management-in-special-cases[Removing remaining resources after removing a cluster]
 
 include::modules/hcp-dr-oadp-observe.adoc[leveloffset=+1]
 

--- a/modules/hcp-bm-hc-mirror.adoc
+++ b/modules/hcp-bm-hc-mirror.adoc
@@ -54,4 +54,4 @@ where:
 `<icsp.yaml>`:: Specifies the `icsp.yaml` file that defines ICSP and your mirror registries.
 `<path_to_ssh_key>`:: Specifies the path to your SSH public key. The default file path is `~/.ssh/id_rsa.pub`.
 `<hosted_cluster_namespace>`:: Specifies your hosted cluster namespace.
-`<ocp_release_image>`:: Specifies the supported {product-title} version that you want to use, for example, `4.22.0-multi`. If you are using a disconnected environment, replace `<ocp_release_image>` with the digest image. To extract the {product-title} release image digest, see "Extracting the {product-title} release image digest".
+`<ocp_release_image>`:: Specifies the supported {product-title} version that you want to use, for example, `4.22.0-multi`. If you are using a disconnected environment, replace `<ocp_release_image>` with the digest image. To extract the {product-title} release image digest, see "Extracting the release image digest".

--- a/modules/hcp-bm-hc.adoc
+++ b/modules/hcp-bm-hc.adoc
@@ -88,7 +88,7 @@ where:
 `<path_to_ssh_key>`:: Specifies the path to your SSH public key. The default file path is `~/.ssh/id_rsa.pub`.
 `<hosted_cluster_namespace>`:: Specifies your hosted cluster namespace.
 `control-plane-availability-policy`:: Specifies the availability policy for the hosted control plane components. Supported options are `SingleReplica` and `HighlyAvailable`. The default value is `HighlyAvailable`.
-`<ocp_release_image>`:: Specifies the supported {product-title} version that you want to use, such as `4.22.0-multi`. If you are using a disconnected environment, replace `<ocp_release_image>` with the digest image. To extract the {product-title} release image digest, see "Extracting the {product-title} release image digest".
+`<ocp_release_image>`:: Specifies the supported {product-title} version that you want to use, such as `4.22.0-multi`. If you are using a disconnected environment, replace `<ocp_release_image>` with the digest image. To extract the {product-title} release image digest, see "Extracting the release image digest".
 `<node_pool_replica_count>`:: Specifies the node pool replica count, such as `3`. You must specify the replica count as `0` or greater to create the same number of replicas. Otherwise, you do not create node pools.
 `<home_directory>/<path_to_ssh_key>/<ssh_key>`:: Specifies the path to the SSH key, such as `user/.ssh/id_rsa`.
 

--- a/modules/hcp-create-hc-arm64-aws.adoc
+++ b/modules/hcp-create-hc-arm64-aws.adoc
@@ -41,5 +41,5 @@ where:
 `<path_to_pull_secret>`:: Specifies the path to your pull secret, for example, `/user/name/pullsecret`.
 `<path_to_sts_credential_file>`:: Specifies the path to your {aws-short} STS credentials file, for example, `/home/user/sts-creds/sts-creds.json`.
 `<region>`:: Specifies the {aws-short} region name, for example, `us-east-1`.
-`<ocp_release_image>`:: Specifies the supported {product-title} version that you want to use, for example, `4.22.0-multi`. If you are using a disconnected environment, replace `<ocp_release_image>` with the digest image. To extract the {product-title} release image digest, see "Extracting the {product-title} release image digest".
+`<ocp_release_image>`:: Specifies the supported {product-title} version that you want to use, for example, `4.22.0-multi`. If you are using a disconnected environment, replace `<ocp_release_image>` with the digest image. To extract the {product-title} release image digest, see "Extracting the release image digest".
 `<role_name>`:: Specifies the Amazon Resource Name (ARN), for example, `arn:aws:iam::820196288204:role/myrole`.

--- a/modules/hcp-ibmz-create-hc.adoc
+++ b/modules/hcp-ibmz-create-hc.adoc
@@ -64,7 +64,7 @@ where:
 `<path_to_ssh_key>`:: Specifies the path to your SSH public key. The default file path is `~/.ssh/id_rsa.pub`.
 `<hosted_cluster_namespace>`:: Specifies your hosted cluster namespace.
 `control-plane-availability-policy`:: Specifies the availability policy for the hosted control plane components. Supported options are `SingleReplica` and `HighlyAvailable`. The default value is `HighlyAvailable`.
-`<ocp_release_image>`:: Specifies the supported {product-title} version that you want to use, such as `4.19.0-multi`. If you are using a disconnected environment, replace `<ocp_release_image>` with the digest image. To extract the {product-title} release image digest, see "Extracting the {product-title} release image digest".
+`<ocp_release_image>`:: Specifies the supported {product-title} version that you want to use, such as `4.19.0-multi`. If you are using a disconnected environment, replace `<ocp_release_image>` with the digest image. To extract the {product-title} release image digest, see "Extracting the release image digest".
 `<node_pool_replica_count>`:: Specifies the node pool replica count, such as `3`. You must specify the replica count as `0` or greater to create the same number of replicas. Otherwise, you do not create node pools.
 `<home_directory>/<path_to_ssh_key>/<ssh_key>`:: Specifies the path to the SSH key, such as `user/.ssh/id_rsa`.
 

--- a/modules/hcp-non-bm-hc-mirror.adoc
+++ b/modules/hcp-non-bm-hc-mirror.adoc
@@ -52,4 +52,4 @@ $ hcp create cluster agent \
 * `--image-content-sources` specifies the `icsp.yaml` file that defines ICSP and your mirror registries.
 * `--ssh-key` specifies the path to your SSH public key. The default file path is `~/.ssh/id_rsa.pub`.
 * `--namespace` specifies your hosted cluster namespace.
-* `--release-image` specifies the supported {product-title} version that you want to use. If you are using a disconnected environment, replace the version with the digest image. To extract the {product-title} release image digest, see "Extracting the {product-title} release image digest".
+* `--release-image` specifies the supported {product-title} version that you want to use. If you are using a disconnected environment, replace the version with the digest image. To extract the {product-title} release image digest, see "Extracting the release image digest".


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.22
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://redhat.atlassian.net/browse/OSDOCS-19826
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
- MCE overview: https://113280--ocpdocs-pr.netlify.app/openshift-enterprise/latest/architecture/mce-overview-ocp.html
- Deploying HCP on AWS: https://113280--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-deploy/hcp-deploy-aws#hcp-aws-prereqs_hcp-deploy-aws
- Deploying HCP on IBM Power: https://113280--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-deploy/hcp-deploy-ibm-power#hcp-ibm-power-prereqs_hcp-deploy-ibm-power
- Deploying HCP on IBM Z: https://113280--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-deploy/hcp-deploy-ibmz#hcp-ibm-z-prereqs_hcp-deploy-ibmz
- Deploying HCP on non-bare-metal agent machines: https://113280--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-deploy/hcp-deploy-non-bm#hcp-non-bm-prepare_hcp-deploy-non-bm
- Deploying HCP on OpenShift Virtualization: https://113280--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-deploy/hcp-deploy-virt
- Deploying HCP on bare metal disconnected: https://113280--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-disconnected/hcp-deploy-dc-bm
- Deploying HCP on OpenShift Virtualization disconnected: https://113280--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-disconnected/hcp-deploy-dc-virt
- Requirements to deploy HCP: https://113280--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-prepare/hcp-requirements#additional-resources
- Disaster recovery for a hosted cluster by using OADP: https://113280--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp_high_availability/hcp-disaster-recovery-oadp#hcp-dr-oadp-restore-new-mgmt_hcp-disaster-recovery-oadp
- Manually importing a hosted cluster: https://113280--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-import
- Handling machine configuration: https://113280--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-machine-config#hcp-configure-ntp_hcp-machine-config
- Troubleshooting: https://113280--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-troubleshooting#hcp-must-gather-dc_hcp-troubleshooting
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
N/A - this PR updates links to RHACM to point to the latest version
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
