### PR TITLE
OSDOCS-20127 created z-stream RNs for 4-19-34

### DIFF
--- a/modules/zstream-4-19-34.adoc
+++ b/modules/zstream-4-19-34.adoc
@@ -1,0 +1,34 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-19-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-19-34_{context}"]
+= RHSA-2026:25201 - {product-title} {product-version}.34 fixed issues and security update
+
+Issued: 17 June 2026
+
+[role="_abstract"]
+{product-title} release {product-version}.34 is now available. The list of fixed issues that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2026:25201[RHSA-2026:25201] advisory. There are no RPM packages for this release.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.19.34 --pullspecs
+----
+
+[id="zstream-4-19-34-fixed-issues_{context}"]
+== Fixed issues
+
+*Before this update, misconfigured clients that did not properly close connections to the API could cause HAProxy to accumulate idle connections, eventually exhausting available ports and preventing API access on {product-title} installer-provisioned infrastructure clusters. With this release, additional HAProxy `-fin` timeouts are configured to quickly clean up such connections. (link:https://issues.redhat.com/browse/OCPBUGS-66284[OCPBUGS-66284])
+
+[id="zstream-4-19-34-updating_{context}"]
+== Updating
+
+To update an {product-title} 4.19 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
+
+

--- a/release_notes/ocp-4-19-release-notes.adoc
+++ b/release_notes/ocp-4-19-release-notes.adoc
@@ -2978,6 +2978,9 @@ To save the `vmcore` file, use the `crashkernel` setting to reserve 1024 MB of m
 include::modules/ocp-release-asynch-errata-updates.adoc[leveloffset=+1]
 
 // 4.19.33 z-stream RNs full document
+include::modules/zstream-4-19-34.adoc[leveloffset=+2]
+
+// 4.19.33 z-stream RNs full document
 include::modules/zstream-4-19-33.adoc[leveloffset=+2]
 
 // 4.19.32 z-stream RNs full document


### PR DESCRIPTION
Version(s):
4.19

Issue:
https://redhat.atlassian.net/browse/OSDOCS-20127

Link to docs preview:
https://113288--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-19-release-notes.html#zstream-4-19-34_release-notes


QE review:
- [ ] QE has approved this change.


Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
