### PR TITLE
OSDOCS-19993 - Fixing a table error in osd_planning

### DIFF
--- a/modules/aws-limits.adoc
+++ b/modules/aws-limits.adoc
@@ -81,7 +81,4 @@ Additional ENIs are created for additional machines and load balancers that are 
 |250
 |2,500 per account
 |Each cluster creates 10 distinct security groups.
-                                                                                                                                        | Fail, optionally surfacing response body to the user
 |===
-
-// TODO: what is this random text/cell on line 82^?


### PR DESCRIPTION
Version(s):
4.22+

Issue:
https://redhat.atlassian.net/browse/OSDOCS-19993

Link to docs preview:
[AWS account limits](https://113310--ocpdocs-pr.netlify.app/openshift-dedicated/latest/osd_planning/aws-ccs.html) - the final table raw used to have a 5th cell that's not rendered, the table looks good.

QE review:
N/A

**Additional information:**
The PR removes a 5th cell from a 4-column table.

The [published OSD doc "AWS account limits"](https://docs.redhat.com/en/documentation/openshift_dedicated/4/html-single/planning_your_environment/index#aws-limits_aws-ccs) looks correct, but for DITA migration, we'd want to play it safe and remove all suspicious unexpected elements.

An error that this PR fixes:
`asciidoctor: ERROR: includes/aws-limits.adoc: line 83: dropping cells from incomplete row detected end of table`
This error shows during manual GitHub-GitLab syncs that are still running the makeBuild.py script. That script throws such errors.