### PR TITLE
docs: fix custom serving certificate SAN conflict prerequisite

### DIFF
--- a/modules/hcp-custom-cert.adoc
+++ b/modules/hcp-custom-cert.adoc
@@ -17,7 +17,11 @@ You can configure a custom certificate during either day-1 or day-2 operations. 
  ** `tls.crt`: The certificate
  ** `tls.key`: The private key
 
-* If your `HostedCluster` configuration includes a service publishing strategy that uses a load balancer, ensure that the Subject Alternative Names (SANs) of the certificate do not conflict with the internal API endpoint (`api-int`). The internal API endpoint is automatically created and managed by your platform. If you use the same hostname in both the custom certificate and the internal API endpoint, routing conflicts can occur. The only exception to this rule is when you use {aws-short} as the provider with either `Private` or `PublicAndPrivate` configurations. In those cases, the SAN conflict is managed by the platform.
+* If your `HostedCluster` configuration includes custom serving certificates via the `spec.configuration.apiServer.servingCerts.namedCertificates` specification, ensure that the Subject Alternative Names (SANs) of the certificate do not conflict with the external API server address. For example, depending on the hostname pattern used in your environment, the address might be in the following format: `api.<cluster-name>.<domain>`.  
++
+The `HostedCluster` resource automatically includes the external API address in the default Kubernetes API server certificate SANs. If the same hostname is in both the custom certificate and the auto-generated Kubernetes API server certificate, the configuration is rejected to prevent TLS serving ambiguity. 
++
+This validation applies to all service publishing strategies, including `LoadBalancer` and `NodePort`. The only exception is when you use {aws-first} as the provider with `Private` or `PublicAndPrivate` endpoint access configurations, where the platform manages the SAN conflict.
 
 * The certificate must be valid for the external API endpoint.
 


### PR DESCRIPTION
The existing documentation incorrectly states that the SAN conflict validation applies only to HostedClusters using a load balancer publishing strategy and references the internal API endpoint (api-int) as the source of conflict.

The validation in the codebase applies to all service publishing strategies (LoadBalancer and NodePort) and the actual conflict is with the external API server address (api.<cluster-name>.<domain>), not the internal API endpoint.

The only exception remains AWS with Private or PublicAndPrivate endpoint access configurations, where the platform manages the SAN conflict internally.

This change corrects the prerequisite to reflect the accurate validation behavior.

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.20+

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:

https://113323--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-certificates.html


QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:

Identified while investigating a customer issue where a HostedCluster using NodePort publishing strategy was rejected due to SAN conflict, despite the docs stating the validation only applies to LoadBalancer.


<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
