### PR TITLE
TELCODOCS-2829 Update ZTP reference config YAML examples for 4.22

### DIFF
--- a/modules/ztp-sno-du-configuring-sriov.adoc
+++ b/modules/ztp-sno-du-configuring-sriov.adoc
@@ -45,6 +45,9 @@ containers:
 |`spec.enableOperatorWebhook`
 |Disable `OperatorWebhook` pods to reduce the number of management pods. Start with the `OperatorWebhook` pods enabled, and only disable them after verifying the user manifests.
 
+|`spec.featureGates.mellanoxFirmwareReset`
+|Enable the Mellanox firmware reset feature gate to allow firmware reset for Mellanox NICs during SR-IOV configuration changes.
+
 |====
 
 .Recommended `SriovNetwork` configuration (`SriovNetwork.yaml`)

--- a/snippets/ztp_ClusterLogForwarder.yaml
+++ b/snippets/ztp_ClusterLogForwarder.yaml
@@ -1,15 +1,30 @@
-apiVersion: "observability.openshift.io/v1"
+apiVersion: observability.openshift.io/v1
 kind: ClusterLogForwarder
 metadata:
   name: instance
   namespace: openshift-logging
   annotations: {}
 spec:
-  # outputs: $outputs
-  # pipelines: $pipelines
+  filters:
+  - name: ran-du-labels
+    type: openshiftLabels
+  outputs:
+  - kafka:
+      url: tcp://$kafka-server:9092/endpoint
+    name: kafka-output
+    type: kafka
+  pipelines:
+  - name: all-to-default
+    inputRefs:
+    - audit
+    - infrastructure
+    outputRefs:
+    - kafka-output
+    filterRefs:
+    - ran-du-labels
   serviceAccount:
-    name: logcollector
-#apiVersion: "observability.openshift.io/v1"
+    name: collector
+#apiVersion: observability.openshift.io/v1
 #kind: ClusterLogForwarder
 #metadata:
 #  name: instance
@@ -20,7 +35,7 @@ spec:
 #     name: kafka-open
 #     # below url is an example
 #     kafka:
-#       url: tcp://10.46.55.190:9092/test
+#       url: tcp://10.11.12.13:9092/test
 #   filters:
 #   - name: test-labels
 #     type: openshiftLabels
@@ -39,4 +54,4 @@ spec:
 #     outputRefs:
 #     - kafka-open
 #   serviceAccount:
-#     name: logcollector
+#     name: collector

--- a/snippets/ztp_ClusterLogNS.yaml
+++ b/snippets/ztp_ClusterLogNS.yaml
@@ -5,3 +5,5 @@ metadata:
   name: openshift-logging
   annotations:
     workload.openshift.io/allowed: management
+  labels:
+    openshift.io/cluster-monitoring: "true"

--- a/snippets/ztp_ClusterLogServiceAccount.yaml
+++ b/snippets/ztp_ClusterLogServiceAccount.yaml
@@ -2,6 +2,6 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: logcollector
+  name: collector
   namespace: openshift-logging
   annotations: {}

--- a/snippets/ztp_ClusterLogServiceAccountAuditBinding.yaml
+++ b/snippets/ztp_ClusterLogServiceAccountAuditBinding.yaml
@@ -9,6 +9,6 @@ roleRef:
   kind: ClusterRole
   name: collect-audit-logs
 subjects:
-  - kind: ServiceAccount
-    name: logcollector
-    namespace: openshift-logging
+- kind: ServiceAccount
+  name: collector
+  namespace: openshift-logging

--- a/snippets/ztp_ClusterLogServiceAccountInfrastructureBinding.yaml
+++ b/snippets/ztp_ClusterLogServiceAccountInfrastructureBinding.yaml
@@ -9,6 +9,6 @@ roleRef:
   kind: ClusterRole
   name: collect-infrastructure-logs
 subjects:
-  - kind: ServiceAccount
-    name: logcollector
-    namespace: openshift-logging
+- kind: ServiceAccount
+  name: collector
+  namespace: openshift-logging

--- a/snippets/ztp_ClusterLogSubscription.yaml
+++ b/snippets/ztp_ClusterLogSubscription.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: openshift-logging
   annotations: {}
 spec:
-  channel: "stable-6.0"
+  channel: "stable-6.5"
   name: cluster-logging
   source: redhat-operators-disconnected
   sourceNamespace: openshift-marketplace

--- a/snippets/ztp_PerformanceProfile.yaml
+++ b/snippets/ztp_PerformanceProfile.yaml
@@ -3,18 +3,20 @@ kind: PerformanceProfile
 metadata:
   # if you change this name make sure the 'include' line in TunedPerformancePatch.yaml
   # matches this name: include=openshift-node-performance-${PerformanceProfile.metadata.name}
-  # Also in file 'validatorCRs/informDuValidator.yaml': 
+  # Also in file 'validatorCRs/informDuValidator.yaml':
   # name: 50-performance-${PerformanceProfile.metadata.name}
   name: openshift-node-performance-profile
   annotations:
     ran.openshift.io/reference-configuration: "ran-du.redhat.com"
+    # systemReserved: when used, it should be tailored for each environment.
+    kubeletconfig.experimental: |
+      {
+       "systemReserved":{"memory":"11Gi"}
+      }
 spec:
   additionalKernelArgs:
-    - "rcupdate.rcu_normal_after_boot=0"
-    - "efi=runtime"
-    - "vfio_pci.enable_sriov=1"
-    - "vfio_pci.disable_idle_d3=1"
-    - "module_blacklist=irdma"
+    - vfio_pci.enable_sriov=1
+    - vfio_pci.disable_idle_d3=1
   cpu:
     isolated: $isolated
     reserved: $reserved
@@ -31,6 +33,7 @@ spec:
   numa:
     topologyPolicy: "restricted"
   # To use the standard (non-realtime) kernel, set enabled to false
+  # For aarch64, only the non-realtime kernel is supported with 64k pagesize.
   realTimeKernel:
     enabled: true
   workloadHints:

--- a/snippets/ztp_PtpConfigSlave.yaml
+++ b/snippets/ztp_PtpConfigSlave.yaml
@@ -1,12 +1,12 @@
 apiVersion: ptp.openshift.io/v1
 kind: PtpConfig
 metadata:
-  name: ordinary
+  name: du-ptp-slave
   namespace: openshift-ptp
   annotations: {}
 spec:
   profile:
-    - name: "ordinary"
+    - name: "slave"
       # The interface name is hardware-specific
       interface: $interface
       ptp4lOpts: "-2 -s"
@@ -118,7 +118,7 @@ spec:
         userDescription ;
         timeSource 0xA0
   recommend:
-    - profile: "ordinary"
+    - profile: "slave"
       priority: 4
       match:
         - nodeLabel: "node-role.kubernetes.io/$mcp"

--- a/snippets/ztp_SriovOperatorConfig.yaml
+++ b/snippets/ztp_SriovOperatorConfig.yaml
@@ -22,4 +22,6 @@ spec:
   #          openshift.io/<resource_name>:  "1"
   enableInjector: false
   enableOperatorWebhook: false
+  featureGates:
+    mellanoxFirmwareReset: true
   logLevel: 0

--- a/snippets/ztp_TunedPerformancePatch.yaml
+++ b/snippets/ztp_TunedPerformancePatch.yaml
@@ -1,30 +1,48 @@
 apiVersion: tuned.openshift.io/v1
 kind: Tuned
 metadata:
-  name: performance-patch
+  name: ran-du-performance
   namespace: openshift-cluster-node-tuning-operator
   annotations: {}
 spec:
   profile:
-    - name: performance-patch
+    - name: ran-du-performance
       # Please note:
       # - The 'include' line must match the associated PerformanceProfile name, following below pattern
       #   include=openshift-node-performance-${PerformanceProfile.metadata.name}
-      # - When using the standard (non-realtime) kernel, remove the kernel.timer_migration override from
-      #   the [sysctl] section and remove the entire section if it is empty.
       data: |
         [main]
-        summary=Configuration changes profile inherited from performance created tuned
-        include=openshift-node-performance-openshift-node-performance-profile
+        summary=Top-level ran-du performance tuning overrides
+        include=openshift-node-performance-openshift-node-performance-profile,ran-du-performance-architecture-common
+    - name: ran-du-performance-architecture-common
+      data: |
+        [main]
+        summary=Common cross-architecture performance tuning which also includes architecture-specific profiles
+        include=ran-du-common-${f:lscpu_check:Architecture\:\s*x86_64:x86:Architecture\:\s*aarch64:aarch64}
+        [service]
+        service.chronyd=stop,disable
+        service.stalld=start,enable
+        [bootloader]
+        cmdline_ran_rcu=rcupdate.rcu_normal_after_boot=0
+        cmdline_ran_efi=efi=runtime
+    - name: ran-du-common-aarch64
+      data: |
+        [main]
+        summary=Configuration specific to aarch64 performance
+    - name: ran-du-common-x86
+      data: |
+        [main]
+        summary=Configuration specific to x86_64 performance
         [scheduler]
         group.ice-ptp=0:f:10:*:ice-ptp.*
         group.ice-gnss=0:f:10:*:ice-gnss.*
         group.ice-dplls=0:f:10:*:ice-dplls.*
-        [service]
-        service.stalld=start,enable
-        service.chronyd=stop,disable
+        [bootloader]
+        cmdline_x86_blacklist=module_blacklist=irdma,mgag200
+        [sysctl]
+        kernel.panic_on_unrecovered_nmi=1
   recommend:
     - machineConfigLabels:
-        machineconfiguration.openshift.io/role: "$mcp"
-      priority: 19
-      profile: performance-patch
+        machineconfiguration.openshift.io/role: $mcp
+      priority: 18
+      profile: ran-du-performance


### PR DESCRIPTION
Version(s):
4.22

Issue:
https://redhat.atlassian.net/browse/TELCODOCS-2829

Link to docs preview:


QE review:
- [ ] QE has approved this change.

Additional information:

Validated and updated ZTP vDU reference configuration YAML code examples against the upstream source CRs in [openshift-kni/telco-reference](https://github.com/openshift-kni/telco-reference) (release-4.22 submodule commit `4a3a969`).

Changes:
- **ClusterLogForwarder**: Updated to full example with filters, outputs, pipelines; corrected serviceAccount name to `collector`
- **ClusterLogSubscription**: Channel `stable-6.0` → `stable-6.5`
- **ClusterLogNS**: Added `openshift.io/cluster-monitoring: "true"` label
- **ClusterLogServiceAccount + bindings**: Populated stubs with correct content
- **PerformanceProfile**: Removed kernel args moved to Tuned (`rcupdate.rcu_normal_after_boot=0`, `efi=runtime`, `module_blacklist=irdma`); added `kubeletconfig.experimental` annotation
- **TunedPerformancePatch**: Restructured to multi-profile architecture (x86/aarch64 specific tuning)
- **PtpConfigSlave**: Updated name to `du-ptp-slave` / profile `slave`
- **SriovOperatorConfig**: Added `featureGates.mellanoxFirmwareReset: true` + documented in module


Made with [Cursor](https://cursor.com)