### PR TITLE
OCPBUGS-88471: Backport MetalLB fixes to enterprise-4.18

### DIFF
--- a/modules/nw-metallb-configure-l2-advertisement.adoc
+++ b/modules/nw-metallb-configure-l2-advertisement.adoc
@@ -6,18 +6,19 @@
 [id="nw-metallb-configure-with-L2-advertisement_{context}"]
 = Configuring MetalLB with an L2 advertisement
 
-Configure MetalLB as follows so that the `IPAddressPool` is advertised with the L2 protocol.
+[role="_abstract"]
+You can configure MetalLB so that the `IPAddressPool` is advertised with the L2 protocol.
 
 .Prerequisites
 
-* Install the OpenShift CLI (`oc`).
-
+* Install the {oc-first}.
 * Log in as a user with `cluster-admin` privileges.
+* Install the MetalLB Operator and start MetalLB.
 
 .Procedure
 
 . Create an IP address pool.
-
++
 .. Create a file, such as `ipaddresspool.yaml`, with content like the following example:
 +
 [source,yaml]
@@ -29,10 +30,14 @@ metadata:
   name: doc-example-l2
 spec:
   addresses:
-    - 4.4.4.0/24
+    - <ip_address_range>
   autoAssign: false
 ----
-
++
+--
+* `<ip_address_range>` specifies a range of IP addresses that are routable on your network, for example `4.4.4.0/24`.
+--
++
 .. Apply the configuration for the IP address pool:
 +
 [source,terminal]
@@ -40,8 +45,8 @@ spec:
 $ oc apply -f ipaddresspool.yaml
 ----
 
-. Create a L2 advertisement.
-
+. Create an L2 advertisement.
++
 .. Create a file, such as `l2advertisement.yaml`, with content like the following example:
 +
 [source,yaml]
@@ -55,10 +60,42 @@ spec:
   ipAddressPools:
    - doc-example-l2
 ----
-
++
 .. Apply the configuration:
 +
 [source,terminal]
 ----
 $ oc apply -f l2advertisement.yaml
+----
+
+.Verification
+
+. Verify that the IP address pool is created:
++
+[source,terminal]
+----
+$ oc get ipaddresspool -n metallb-system
+----
++
+The following is example output:
++
+[source,terminal]
+----
+NAME             AUTO ASSIGN   AVOID BUGGY IPS   ADDRESSES
+doc-example-l2   false         false             ["4.4.4.0/24"]
+----
+
+. Verify that the L2 advertisement is created:
++
+[source,terminal]
+----
+$ oc get l2advertisement -n metallb-system
+----
++
+The following is example output:
++
+[source,terminal]
+----
+NAME              IPADDRESSPOOLS     IPADDRESSPOOL SELECTORS   INTERFACES
+l2advertisement   ["doc-example-l2"]
 ----

--- a/modules/nw-metallb-configure-svc.adoc
+++ b/modules/nw-metallb-configure-svc.adoc
@@ -6,35 +6,82 @@
 [id="nw-metallb-configure-svc_{context}"]
 = Configuring a service with MetalLB
 
-You can configure a load-balancing service to use an external IP address from an address pool.
+[role="_abstract"]
+To expose an application to external network traffic, configure a load-balancing service. MetalLB assigns an external IP address from a configured address pool, ensuring that your application is reachable from outside the cluster.
 
 .Prerequisites
 
-* Install the OpenShift CLI (`oc`).
-
+* Install the {oc-first}.
 * Install the MetalLB Operator and start MetalLB.
-
 * Configure at least one address pool.
-
 * Configure your network to route traffic from the clients to the host network for the cluster.
 
 .Procedure
 
-. Create a `<service_name>.yaml` file. In the file, ensure that the `spec.type` field is set to `LoadBalancer`.
+. Create a deployment and service for your application. Save the following YAML to a file named `example-metallb-app.yaml`:
 +
-Refer to the examples for information about how to request the external IP address that MetalLB assigns to the service.
+[source,yaml]
+----
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: example-metallb
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: example-app
+  namespace: example-metallb
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: example-app
+  template:
+    metadata:
+      labels:
+        app: example-app
+    spec:
+      containers:
+      - name: example-app
+        image: registry.access.redhat.com/ubi9/httpd-24:latest
+        ports:
+        - containerPort: 8080
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: example-metallb-svc
+  namespace: example-metallb
+  annotations:
+    metallb.io/address-pool: <ipaddresspool_name>
+spec:
+  type: LoadBalancer
+  selector:
+    app: example-app
+  ports:
+  - port: 80
+    targetPort: 8080
+----
++
+--
+* `<ipaddresspool_name>` specifies the name of the `IPAddressPool` resource, for example `doc-example-l2`. If you do not set this annotation, MetalLB automatically assigns an IP address from any pool that has `autoAssign` set to `true`.
+--
 
-. Create the service:
+. Create the deployment and service:
 +
 [source,terminal]
 ----
-$ oc apply -f <service_name>.yaml
+$ oc apply -f example-metallb-app.yaml
 ----
 +
-.Example output
+The following is example output:
++
 [source,terminal]
 ----
-service/<service_name> created
+namespace/example-metallb created
+deployment.apps/example-app created
+service/example-metallb-svc created
 ----
 
 .Verification
@@ -43,35 +90,40 @@ service/<service_name> created
 +
 [source,terminal]
 ----
-$ oc describe service <service_name>
+$ oc describe service example-metallb-svc -n example-metallb
 ----
 +
-.Example output
+The following is example output:
++
 ----
-Name:                     <service_name>
-Namespace:                default
+Name:                     example-metallb-svc
+Namespace:                example-metallb
 Labels:                   <none>
-Annotations:              metallb.io/address-pool: doc-example  <1>
-Selector:                 app=service_name
-Type:                     LoadBalancer  <2>
+Annotations:              metallb.io/address-pool: doc-example-l2
+                          metallb.io/ip-allocated-from-pool: doc-example-l2
+Selector:                 app=example-app
+Type:                     LoadBalancer
 IP Family Policy:         SingleStack
 IP Families:              IPv4
 IP:                       10.105.237.254
 IPs:                      10.105.237.254
-LoadBalancer Ingress:     192.168.100.5  <3>
+LoadBalancer Ingress:     192.168.100.5
 Port:                     <unset>  80/TCP
 TargetPort:               8080/TCP
 NodePort:                 <unset>  30550/TCP
 Endpoints:                10.244.0.50:8080
 Session Affinity:         None
 External Traffic Policy:  Cluster
-Events:  <4>
-  Type    Reason        Age                From             Message
-  ----    ------        ----               ----             -------
-  Normal  nodeAssigned  32m (x2 over 32m)  metallb-speaker  announcing from node "<node_name>"
+Events:
+  Type    Reason        Age                From                Message
+  ----    ------        ----               ----                -------
+  Normal  IPAllocated   12s                metallb-controller  Assigned IP ["192.168.100.5"]
+  Normal  nodeAssigned  12s (x2 over 12s)  metallb-speaker     announcing from node "<node_name>"
 ----
-<1> The annotation is present if you request an IP address from a specific pool.
-<2> The service type must indicate `LoadBalancer`.
-<3> The load-balancer ingress field indicates the external IP address if the service is assigned correctly.
-<4> The events field indicates the node name that is assigned to announce the external IP address.
-If you experience an error, the events field indicates the reason for the error.
++
+where:
++
+`Annotations`:: Specifies the annotation that is present if you request an IP address from a specific pool.
+`Type`:: Specifies the service type that must indicate `LoadBalancer`.
+`LoadBalancer Ingress`:: Specifies the external IP address that is assigned to the service.
+`Events`:: Specifies the events parameter that indicates the node name that is assigned to announce the external IP address. If you experience an error, the events parameter indicates the reason for the error.

--- a/modules/nw-metallb-installing-operator-cli.adoc
+++ b/modules/nw-metallb-installing-operator-cli.adoc
@@ -51,7 +51,8 @@ EOF
 $ oc get operatorgroup -n metallb-system
 ----
 +
-.Example output
+The following is example output:
++
 [source,terminal]
 ----
 NAME               AGE
@@ -81,7 +82,7 @@ spec:
 +
 [source,terminal]
 ----
-$ oc create -f metallb-sub.yaml
+$ oc apply -f metallb-sub.yaml
 ----
 
 . Optional: To ensure BGP and BFD metrics appear in Prometheus, you can label the namespace as in the following command:
@@ -95,18 +96,20 @@ $ oc label ns metallb-system "openshift.io/cluster-monitoring=true"
 
 The verification steps assume the MetalLB Operator is installed in the `metallb-system` namespace.
 
-. Confirm the install plan is in the namespace:
+. Verify that the Operator installed successfully by running the following command. Wait until the `PHASE` displays `Succeeded`:
 +
 [source,terminal]
 ----
-$ oc get installplan -n metallb-system
+$ oc get clusterserviceversion -n metallb-system \
+  -o custom-columns=Name:.metadata.name,Phase:.status.phase
 ----
 +
-.Example output
-[source,terminal,subs="attributes+"]
+The following is example output:
++
+[source,terminal]
 ----
-NAME            CSV                                   APPROVAL    APPROVED
-install-wzg94   metallb-operator.{product-version}.0-nnnnnnnnnnnn   Automatic   true
+Name                                                Phase
+metallb-operator.{product-version}.0-nnnnnnnnnnnn   Succeeded
 ----
 +
 [NOTE]
@@ -114,10 +117,17 @@ install-wzg94   metallb-operator.{product-version}.0-nnnnnnnnnnnn   Automatic   
 Installation of the Operator might take a few seconds.
 ====
 
-. To verify that the Operator is installed, enter the following command and then check that output shows `Succeeded` for the Operator:
+. Confirm that the install plan is in the namespace:
 +
 [source,terminal]
 ----
-$ oc get clusterserviceversion -n metallb-system \
-  -o custom-columns=Name:.metadata.name,Phase:.status.phase
+$ oc get installplan -n metallb-system
+----
++
+The following is example output:
++
+[source,terminal,subs="attributes+"]
+----
+NAME            CSV                                                 APPROVAL    APPROVED
+install-wzg94   metallb-operator.{product-version}.0-nnnnnnnnnnnn   Automatic   true
 ----

--- a/modules/nw-metallb-operator-initial-config.adoc
+++ b/modules/nw-metallb-operator-initial-config.adoc
@@ -32,11 +32,16 @@ metadata:
 EOF
 ----
 +
-** For the `metdata.namespace` parameter, substitute `metallb-system` with `openshift-operators` if you installed the MetalLB Operator using the web console.
+** For the `metadata.namespace` parameter, substitute `metallb-system` with `openshift-operators` if you installed the MetalLB Operator using the web console.
 
 .Verification
 
 Confirm that the deployment for the MetalLB controller and the daemon set for the MetalLB speaker are running.
+
+[NOTE]
+====
+It might take a few seconds for the controller deployment and speaker daemon set to become available after you create the `MetalLB` custom resource.
+====
 
 . Verify that the deployment for the controller is running:
 +
@@ -45,7 +50,8 @@ Confirm that the deployment for the MetalLB controller and the daemon set for th
 $ oc get deployment -n metallb-system controller
 ----
 +
-.Example output
+The following is example output:
++
 [source,terminal]
 ----
 NAME         READY   UP-TO-DATE   AVAILABLE   AGE
@@ -59,12 +65,13 @@ controller   1/1     1            1           11m
 $ oc get daemonset -n metallb-system speaker
 ----
 +
-.Example output
+The following is example output:
++
 [source,terminal]
 ----
 NAME      DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE   NODE SELECTOR            AGE
 speaker   6         6         6       6            6           kubernetes.io/os=linux   18m
 ----
 +
-The example output indicates 6 speaker pods. The number of speaker pods in your cluster might differ from the example output. Make sure the output indicates one pod for each node in your cluster.
+The example output indicates six speaker pods. The number of speaker pods in your cluster might differ from the example output. Verify that the number of speaker pods equals the number of nodes in your cluster. For example, a single-node cluster has one speaker pod.
 


### PR DESCRIPTION
## Summary

Backport of https://github.com/openshift/openshift-docs/pull/111492 to enterprise-4.18.

Fix MetalLB procedure gaps found by live cluster verification.

## Files

4 files included, 0 files excluded.

- `modules/nw-metallb-configure-l2-advertisement.adoc`
- `modules/nw-metallb-configure-svc.adoc`
- `modules/nw-metallb-installing-operator-cli.adoc`
- `modules/nw-metallb-operator-initial-config.adoc`

## Verification

- [ ] Preview renders correctly
- [ ] No broken includes or cross-references
- [ ] Content is appropriate for this release version