### PR TITLE
OSDOCS-20131: adds QE bug fixes RHCL deployment

### DIFF
--- a/modules/con-about-connectivity-link.adoc
+++ b/modules/con-about-connectivity-link.adoc
@@ -14,7 +14,7 @@ You can use {prodname} to connect, secure, observe, and protect all of your serv
 * {prodname} Operator: Provides policy attachment and Gateway API integration. Includes runtime images for wasm-shim and console-plugin.
 * Authorino Operator: Provides authentication and authorization engine. Includes the `authorino` runtime image.
 * Limitador Operator: Provides rate limiting engine. Includes the `limitador` runtime image.
-* DNS Operator: Provides multi-cluster DNS management.
+* DNS Operator: Provides multicluster DNS management.
 
 The {prodname} Operator declares the other three Operators as dependencies through Operator Lifecycle Manager (OLM).
 

--- a/modules/proc-configure-token-based-rate-limiting.adoc
+++ b/modules/proc-configure-token-based-rate-limiting.adoc
@@ -58,21 +58,23 @@ spec:
 ----
 +
 * Choose a filename for the policy that makes sense in your environment.
-* `spec.limits.free-users.rates.limit`: 10,000 tokens per day for free tier.
-* `spec.limits.free-users.when.predicate`: Set to inference traffic only.
-* `pro-users.rates.limit`: 100,000 per day for the pro user.
-* `spec.limits.pro-users.when.predicate`: Set to inference traffic only.
+* The `spec.limits.free-users.rates.limit` parameter is set for 10,000 tokens per day for free tier.
+* The `spec.limits.free-users.when.predicate` parameter is set to inference traffic only.
+* The `spec.limits.pro-users.rates.limit` parameter is set for 100,000 per day for the pro user.
+* The  `spec.limits.pro-users.when.predicate` parameter is set to inference traffic only.
+* The predicates must match each other in each section.
 
 . Apply the `TokenRateLimitPolicy` policy by running the following command:
 +
 [source,terminal,subs="+quotes"]
 ----
-$ oc apply -f _<tokenratelimitpolicy.yaml>_ -n <gateway_namespace>
+$ oc apply -f _<tokenratelimitpolicy.yaml>_ -n _<gateway_namespace>_
 ----
 +
-Replace `_<tokenratelimitpolicy.yaml>_` with the filename you used. Replace `_<gateway-namespace>_` with your gateway namespace.
+* Replace `_<tokenratelimitpolicy.yaml>_` with the filename you used.
+* Replace `_<gateway-namespace>_` with your gateway namespace.
 
-. Check the status of the policy to ensure it was accepted and enforced on the target `HTTPRoute`. Look for conditions with `type: Accepted` and `type: Enforced` with `status: "True"`.
+. Check the status of the policy to ensure it was accepted and enforced on the target `Gateway` object. Look for conditions with `type: Accepted` and `type: Enforced` with `status: "True"`.
 +
 [source,terminal,subs="+quotes"]
 ----
@@ -89,6 +91,7 @@ $ curl -H "Authorization: _<auth_policy>_" \
      -d '{"model": "gpt-4", "messages": [{"role": "user", "content": "Hello"}]}' \
      _<api_endpoint>_
 ----
++
 Replace `_<auth_policy>_` and `_<api_endpoint>_` with your values.
 
 .Verification

--- a/modules/proc-set-up-environment.adoc
+++ b/modules/proc-set-up-environment.adoc
@@ -43,7 +43,7 @@ $ export KUADRANT_GATEWAY_NS=api-gateway \
 * `KUADRANT_AWS_ACCESS_KEY_ID`: DNS provider access key ID. In this example, AWS is used. You can replace this value with your DNS provider information.
 * `KUADRANT_AWS_SECRET_ACCESS_KEY`: DNS provider secret access key with permissions to manage your DNS zone. In this example, AWS is used. You can replace this value with your DNS provider information.
 * `KUADRANT_ZONE_ROOT_DOMAIN`: The root domain associated with your DNS zone ID. In this example, the {ocp} secret containing the credentials for the DNS provider is AWS Route53. You can replace this value with your DNS provider information.
-* `KUADRANT_CLUSTER_ISSUER_NAME`: Name of the certificate authority or issuer TLS certificates.
+* `KUADRANT_CLUSTER_ISSUER_NAME`: Name of the certificate authority or the issuer for TLS certificates.
 
 . Create the namespace for the application by running the following command:
 +

--- a/modules/proc-use-coredns-multicluster.adoc
+++ b/modules/proc-use-coredns-multicluster.adoc
@@ -7,7 +7,7 @@
 = Using CoreDNS with primary and secondary clusters
 
 [role="_abstract"]
-You can use CoreDNS as a DNS provider for {prodname} in an existing multi-cluster, on-premise environment. This integration allows {prodname} to manage DNS entries within your internal network infrastructure.
+You can use CoreDNS as a DNS provider for {prodname} in an existing multicluster, on-premise environment. This integration allows {prodname} to manage DNS entries within your internal network infrastructure.
 
 .Prerequisites
 
@@ -28,22 +28,24 @@ You can use CoreDNS as a DNS provider for {prodname} in an existing multi-cluste
 $ export CTX_PRIMARY=_<primary_cluster_context_name>_ \
   export KUBECONFIG=~/.kube/config \
   export PRIMARY_CLUSTER_NAME=_<primary_cluster_name>_ \
-  export ONPREM_DOMAIN=_<onprem-domain>_ \
+  export ONPREM_DOMAIN=_<onprem_domain>_ \
   export KUADRANT_SUBDOMAIN=_<kuadrant>_
 ----
 +
 * `CTX_PRIMARY`: Replace `_<primary_cluster_context_name>_` with the namespace of the cluster that you are specifying as primary.
 * `KUBECONFIG`: Adjust the path to your config directy as needed.
 * `PRIMARY_CLUSTER_NAME`: Replace `_<primary_cluster_name>_` with the name of the cluster that you are specifying as primary.
-* `ONPREM_DOMAIN`: Replace `_<onprem-domain>_` with your actual root domain.
-*` KUADRANT_SUBDOMAIN`: List the subdomain to delegate.
+* `ONPREM_DOMAIN`: Replace `_<onprem_domain>_` with your actual root domain.
+* `KUADRANT_SUBDOMAIN`: List the subdomain to delegate.
 
 . Extract the CoreDNS manifests from the `dns-operator` bundle by running the following commands:
 +
-[source,terminal]
+[source,terminal,subs="+quotes"]
 ----
-$ podman create --name bundle registry.redhat.io/rhcl-1/dns-operator-bundle:rhcl-1.3.0
+$ podman create --name bundle registry.redhat.io/rhcl-1/dns-operator-bundle:rhcl-_<1.3.0>_
 ----
++
+Replace `_<1.3.0>_` with your {prodname} version.
 +
 [source,terminal]
 ----
@@ -70,11 +72,10 @@ $ export COREDNS_IP_PRIMARY=$(oc --context $CTX_PRIMARY -n kuadrant-system get s
 echo "CoreDNS Primary IP: ${COREDNS_IP_PRIMARY}"
 ----
 
-. Create a `ConfigMap` to define the authoritative zone for CoreDNS on the primary cluster. This minimal configuration enables the `kuadrant` plugin and GeoIP features.
+. Create a `ConfigMap` object to define the authoritative zone for CoreDNS on the primary cluster. The following minimal example configuration enables the `kuadrant` plugin and GeoIP features:
 +
-[source,terminal]
+[source,yaml]
 ----
-$ cat | oc --context $CTX_PRIMARY apply -f -
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -102,6 +103,13 @@ data:
 ====
 For production or exact GeoIP routing, mount your licensed MaxMind GeoIP database into the CoreDNS pod and update the filename in the `data.Corefile.geoip` parameter.
 ====
+
+. Apply the `ConfigMap` object by running the following command:
++
+[source,terminal]
+----
+$ oc apply -f --context $CTX_PRIMARY coredns-kuadrant-config.yaml
+----
 
 . Update the CoreDNS deployment to use the new configuration by running the following command:
 +
@@ -171,10 +179,10 @@ After configuring delegation, you can test that the DNS resolution for the deleg
 +
 [source,terminal,subs="+quotes"]
 ----
-$ oc debug node/_<node-name>_
+$ oc debug node/_<node_name>_
 ----
 +
-Replace `_<node-name>_` with the node you are testing on.
+Replace `_<node_name>_` with the node you are testing on.
 
 . Add `transfer` to your Corefile by running the following command:
 +

--- a/modules/proc-use-coredns-single-cluster.adoc
+++ b/modules/proc-use-coredns-single-cluster.adoc
@@ -28,34 +28,47 @@ In a single-cluster setup, ensure that the `endpoints` IP address value you use 
 
 . Set up your cluster. Set the following environment variables for your cluster context:
 +
-[source,terminal]
+[source,terminal,subs="+quotes"]
 ----
 $ export CTX_PRIMARY=$(oc config current-context) \
   export KUBECONFIG=~/.kube/config \
   export PRIMARY_CLUSTER_NAME=local-cluster \
-  export ONPREM_DOMAIN=<onprem-domain> \
+  export ONPREM_DOMAIN=_<onprem_domain>_ \
   export KUADRANT_SUBDOMAIN=""
 ----
 +
 For the `ONPREM_DOMAIN` variable value, use your actual root domain.
 For the `KUADRANT_SUBDOMAIN` variable value, valid values are empty or `kuadrant`.
 
-. Extract the CoreDNS manifests from `dns-operator` bundle by running the following commands:
+. Extract the CoreDNS manifests from the `dns-operator` bundle by running the following commands:
+
+.. Create a writable container layer from your DNS Operator bundle image by running the following command:
 +
-[source,terminal]
+[source,terminal,subs="+quotes"]
 ----
-$ podman create --name bundle registry.redhat.io/rhcl-1/dns-operator-bundle:rhcl-1.3.0
-----
-+
-[source,terminal]
-----
-$ podman cp bundle:/coredns/manifests.yaml ./coredns-manifests.yaml
+$ podman create --name _<bundle>_ registry.redhat.io/rhcl-1/dns-operator-bundle:rhcl-_<1.3.0>_
 ----
 +
-[source,terminal]
+* Optional. Replace `_<bundle>_` with the name you want to use.
+* Replace `_<1.3.0>_` with your {prodname} version.
+
+.. Copy the CoreDNS manifest file out of the stopped container and onto your local host machine by running the following command:
++
+[source,terminal,subs="+quotes"]
 ----
-$ podman rm bundle
+$ podman cp _<bundle>_:/coredns/manifests.yaml ./coredns-manifests.yaml
 ----
++
+* Optional. Replace `_<bundle>_` with the name you want to use.
+
+.. Delete the stopped container named `_<bundle>_` that you created in the first step since you no longer need it by running the following command:
++
+[source,terminal,subs="+quotes"]
+----
+$ podman rm _<bundle>_
+----
++
+* Optional. Replace `_<bundle>_` with the name you want to use.
 
 . Apply the manifests to the cluster by running the following command:
 +
@@ -64,11 +77,10 @@ $ podman rm bundle
 $ oc apply -f ./coredns-manifests.yaml
 ----
 
-. Create a `ConfigMap` to define the authoritative zone for CoreDNS. This minimal configuration enables the `kuadrant` plugin and GeoIP features.
+. Create a `ConfigMap` object to define the authoritative zone for CoreDNS by using the following example. This minimal configuration enables the `kuadrant` plugin and GeoIP features.
 +
-[source,terminal]
+[source,yaml]
 ----
-$ cat | oc --context $CTX_PRIMARY apply -f -
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -97,6 +109,13 @@ data:
 For production or exact GeoIP routing, mount your licensed MaxMind GeoIP database into the CoreDNS pod and update the filename in the `data.Corefile.geoip` parameter.
 ====
 
+. Apply the `ConfigMap` object by running the following command:
++
+[source,terminal]
+----
+$ oc apply -f --context $CTX_PRIMARY coredns-kuadrant-config.yaml
+----
+
 . Update the CoreDNS deployment to use the new configuration by running the following command:
 +
 [source,terminal]
@@ -104,7 +123,7 @@ For production or exact GeoIP routing, mount your licensed MaxMind GeoIP databas
 $ oc --context $CTX_PRIMARY -n kuadrant-system patch deployment kuadrant-coredns --patch '{"spec":{"template":{"spec":{"volumes":[{"name":"config-volume","configMap":{"name":"coredns-kuadrant-config","items":[{"key":"Corefile","path":"Corefile"}]}}]}}}}'
 ----
 
-. Set a watch-and-wait command for the deployment rollout to complete:
+. Set a watch-and-wait command for the deployment rollout to complete by running the following command:
 +
 [source,terminal]
 ----
@@ -117,30 +136,32 @@ $ oc --context $CTX_PRIMARY -n kuadrant-system rollout status deployment/kuadran
 kuadrant-coredns successfully rolled out
 ----
 
-. Create the Kubernetes `Secret` that {prodname} uses to interact with CoreDNS. This secret specifies the zones this provider instance is authoritative for.
+. Create the Kubernetes `Secret` that {prodname} uses to interact with CoreDNS. This secret specifies the zones this provider instance is authoritative for. To create the secret, run the following command:
 +
-[source,terminal]
+[source,terminal,subs="+quotes"]
 ----
 $ oc create secret generic coredns-credentials \
-  --namespace=kuadrant-system \
+  --namespace=_<kuadrant_system>_ \
   --type=kuadrant.io/coredns \
   --from-literal=ZONES="${KUADRANT_SUBDOMAIN}.${ONPREM_DOMAIN}" \
   --context ${CTX_PRIMARY}
 ----
++
+Replace `_<kuadrant_system>_` with the namespace of your {prodname} deployment.
 
 .Verification
 
 * Check the status of the `DNSRecord` CR by running the following commands:
 +
-[source,terminal]
+[source,terminal,subs="+quotes"]
 ----
-$ oc get dnsrecord <name> -n <namespace> -o jsonpath='{.status.conditions[?(@.type=="Ready")]}'
+$ oc get dnsrecord _<name>_ -n _<namespace>_ -o jsonpath='{.status.conditions[?(@.type=="Ready")]}'
 ----
 +
-[source,terminal]
+[source,terminal,subs="+quotes"]
 ----
 $ NS1=$(oc get svc kuadrant-coredns -n kuadrant-coredns -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
-  ROOT_HOST=$(oc get dnsrecord <name> -n <namespace> -o jsonpath='{.spec.rootHost}')
+  ROOT_HOST=$(oc get dnsrecord _<name>_ -n _<namespace>_ -o jsonpath='{.spec.rootHost}')
   dig @${NS1} ${ROOT_HOST}
 ----
 +
@@ -178,10 +199,10 @@ $ oc get pods -n dns-operator-system
 $ oc logs -n dns-operator-system deployment/dns-operator-controller-manager
 ----
 
-* A couple of common issues can be missing RBAC and GeoIP database.
+* A couple of common issues can be missing RBAC and GeoIP database, as shown in the following output examples:
 
-** RBAC permissions missing. Check your `ClusterRole` and `ClusterRoleBinding` configurations.
-** GeoIP database file not found. Ensure that your database is accessible.
+** `RBAC permissions missing.`: Check your `ClusterRole` and `ClusterRoleBinding` configurations.
+** `GeoIP database file not found.`: Ensure that your database is accessible.
 
 .Next steps
 


### PR DESCRIPTION
Version(s):
rhcl-docs-1.4
rhcl-docs-1.5

Issue:
[OSDOCS-20131](https://redhat.atlassian.net/browse/OSDOCS-20131)

Link to docs preview:
https://113373--ocpdocs-pr.netlify.app/rhcl/latest/introduction/introduction.html#about-connectivity-link_rhcl-introduction
https://113373--ocpdocs-pr.netlify.app/rhcl/latest/deployment/coredns.html#proc-use-coredns-single-cluster_rhcl-using-on-prem-dns-coredns
https://113373--ocpdocs-pr.netlify.app/rhcl/latest/deployment/coredns.html#proc-use-coredns-multicluster_rhcl-using-on-prem-dns-coredns
https://113373--ocpdocs-pr.netlify.app/rhcl/latest/deployment/deployment.html#set-up-environment_rhcl-config-deploy-gateway-policies
https://113373--ocpdocs-pr.netlify.app/rhcl/latest/deployment/deployment.html#proc-configure-token-based-rate-limiting_rhcl-config-deploy-gateway-policies

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->


<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
