### PR TITLE
[Enterprise-4.21] OSDOCS-17011: Remove backported Hardware data paragraph from CQA 

### DIFF
--- a/modules/bmo-about-the-baremetalhost-resource.adoc
+++ b/modules/bmo-about-the-baremetalhost-resource.adoc
@@ -14,17 +14,6 @@ The `BareMetalHost` resource contains two sections:
 . The `BareMetalHost` spec
 . The `BareMetalHost` status
 
-Hardware data is available in the `status.hardware` section of the `BareMetalHost` object and in the `HardwareData` object. You can access the `HardwareData` object by running the following command:
-
-[source,terminal]
-----
-$ oc get hardwaredata <machine_name> -n openshift-machine-api
-----
-
-where:
-
-`<machine_name>`:: Specifies the name of a bare-metal host.
-
 == The `BareMetalHost` spec
 
 The `spec` section of the `BareMetalHost` resource defines the desired state of the host.


### PR DESCRIPTION
## Description
This PR removes content that was incorrectly backported to 4.21 during CQA 2 work (PR #113283).

## Changes
Removed the following content from `modules/bmo-about-the-baremetalhost-resource.adoc`:
- "Hardware data is available..." paragraph
- Command example for accessing HardwareData object

## Related
- Original CQA 2 PR: #113283
- JIRA: https://redhat.atlassian.net/browse/OSDOCS-17011