### PR TITLE
[Enterprise-4.20] OSDOCS-17011: Remove backported content from CQA 

### DIFF
--- a/installing/installing_bare_metal/bare-metal-postinstallation-configuration.adoc
+++ b/installing/installing_bare_metal/bare-metal-postinstallation-configuration.adoc
@@ -20,11 +20,6 @@ include::modules/bare-metal-about-the-cluster-api.adoc[leveloffset=+1]
 // Configuring NTP for disconnected clusters
 include::modules/ipi-install-configuring-ntp-for-disconnected-clusters.adoc[leveloffset=+1]
 
-[role="_additional-resources"]
-.Additional resources
-
-* xref:../../installing/installing_bare_metal/bare-metal-postinstallation-configuration.adoc#bmo-editing-a-baremetalhost-resource_bare-metal-postinstallation-configuration[Editing a `BareMetalHost` resource]
-
 // Enabling a provisioning network after installation
 include::modules/nw-enabling-a-provisioning-network-after-installation.adoc[leveloffset=+1]
 

--- a/modules/bmo-about-the-baremetalhost-resource.adoc
+++ b/modules/bmo-about-the-baremetalhost-resource.adoc
@@ -14,17 +14,6 @@ The `BareMetalHost` resource contains two sections:
 . The `BareMetalHost` spec
 . The `BareMetalHost` status
 
-Hardware data is available in the `status.hardware` section of the `BareMetalHost` object and in the `HardwareData` object. You can access the `HardwareData` object by running the following command:
-
-[source,terminal]
-----
-$ oc get hardwaredata <machine_name> -n openshift-machine-api
-----
-
-where:
-
-`<machine_name>`:: Specifies the name of a bare-metal host.
-
 == The `BareMetalHost` spec
 
 The `spec` section of the `BareMetalHost` resource defines the desired state of the host.


### PR DESCRIPTION
## Description
This PR removes content that was incorrectly backported to 4.20 during CQA 2 work (PR #113285).

## Branch: 4.20

## Changes
**File 1:** `modules/bmo-about-the-baremetalhost-resource.adoc`
- Removed "Hardware data is available..." paragraph
- Removed command example for accessing HardwareData object

**File 2:** `installing/installing_bare_metal/bare-metal-postinstallation-configuration.adoc`
- Removed Additional resources section after NTP configuration
- Removed xref to "Editing a BareMetalHost resource"

## Related
- Original CQA 2 PR: #113285
- JIRA: https://redhat.atlassian.net/browse/OSDOCS-17011