### PR TITLE
new feature for machine pools and root disks

### DIFF
--- a/modules/osd-configure-machine-pool-root-disk.adoc
+++ b/modules/osd-configure-machine-pool-root-disk.adoc
@@ -1,0 +1,76 @@
+// Module included in the following assemblies:
+//
+// * creating-a-gcp-cluster.adoc
+
+:_mod-docs-content-type: PROCEDURE
+
+[id="osd-configure-machine-pool-root-disk_{context}"]
+= Configure machine pool root disk sizes for clusters
+
+[role="_abstract"]
+You can configure a custom root disk size for worker nodes in an {product-title} cluster on {GCP}. By customizing the root disk volume size, you can safely host storage intensive workloads or scale space within your infrastructure.
+
+First, you create a new cluster and specify a custom disk size for it. Then, you create a new machine pool with distinct disk allocations to handle changing infrastructure requirements for the cluster that you created.
+
+[NOTE]
+====
+You cannot resize existing cluster and machine pool node volumes. To change root disk sizing for active workloads, you must create a new machine pool with your preferred storage allocation, then migrate your running application and delete the outdated pool.
+====
+
+.Prerequisites
+
+* {cluster-manager-first} command-line interface (CLI) is installed.
+* Ensure that you have appropriate project quotas and identity permissions configured on your targeted {GCP} account.
+* You are logged in to the {cluster-manager-first} CLI.
+
+.Procedure
+
+. In your `ocm` CLI, create a cluster by running the interactive cluster creation wizard and including the `--root-disk-size` flag with the target value in gigabytes (GB):
++
+[source,bash]
+----
+$ ocm create cluster --root-disk-size=250 --interactive
+----
++
+. Complete the prompts that your CLI gives you and specify the {GCP} platform as your cloud provider and specify your required node sizes. For example:
+.. *Cluster name:* rc-test
+.. *Subscription type:* standard cloud provider account owned by Red{nbsp}Hat.
+.. *Authentication type:* Workload Identity Federation (WIF)
+.. *Compute machine type:* e2-standard-4
+.. *Compute nodes:* 2
+. When your CLI gives your cluster a `validating` or `creating` state, confirm the cluster configuration in the output summary.
+. Create a machine pool by running the `create machine-pool` command:
++
+[source,bash,subs="+quotes"]
+----
+$ ocm create machine-pool --root-disk-size 320 --cluster __<cluster_id>__ --instance-type e2-standard-4 --replicas 1 __<machine_pool_name>__
+----
++
+. Define the following components:
+.. Target cluster ID
+.. Disk capacity
+.. Machine compute type
+.. Replica scale
+.. Unique name
++
+For example, run the following `create machine-pool` command with all the defined components:
++
+[source,bash]
+----
+$ ocm create machine-pool --root-disk-size 320 --cluster 2plhcmdsi3kijhr72h04mlrvvsltj9rn --instance-type e2-standard-4 --replicas 1 mp2
+----
++
+. Confirm that your CLI gives you a confirmation message, stating that the tracking instance attached successfully. For example:
+`Machine pool 'mp2' created on cluster '2plhcmdsi3kijhr72h04mlrvvsltj9rn'`.
+
+.Verification
+
+. Go to the cluster that you provisioned.
+. Verify that the root disk value you customized is used by your machine pool by running the following command:
++
+[source,bash,subs="+quotes"]
+----
+$ oc get machineset __<MACHINESET_NAME>__ -n openshift-machine-api -o jsonpath='{.spec.template.spec.providerSpec.value.disks[*].sizeGb}'
+----
++
+. Make sure that the output for your value matches the root disk size that you set for your machine pool.

--- a/modules/osd-create-cluster-red-hat-account.adoc
+++ b/modules/osd-create-cluster-red-hat-account.adoc
@@ -10,6 +10,11 @@
 [role="_abstract"]
 Through {cluster-manager-url}, you can create an {product-title} cluster on {GCP} using a standard cloud provider account owned by Red Hat.
 
+[NOTE]
+====
+If you want to create an {product-title} cluster on {GCP} with the {cluster-manager-first} command-line interface (`ocm`), see the instructions for configuring machine pool root disk sizes for clusters
+====
+
 .Procedure
 
 . Log in to {cluster-manager-url} and click *Create cluster*.

--- a/osd_gcp_clusters/creating-a-gcp-cluster-redhat-account.adoc
+++ b/osd_gcp_clusters/creating-a-gcp-cluster-redhat-account.adoc
@@ -16,6 +16,7 @@ Through {cluster-manager-url}, you can create an {product-title} cluster on {GCP
 * You reviewed the xref:../osd_getting_started/osd-understanding-your-cloud-deployment-options.adoc#osd-understanding-your-cloud-deployment-options[{product-title} cloud deployment options].
 
 include::modules/osd-create-cluster-red-hat-account.adoc[leveloffset=+1]
+include::modules/osd-configure-machine-pool-root-disk.adoc[leveloffset=+1]
 
 [id="next-steps-rh-account_{context}"]
 == Next steps


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.21+

Issue:
https://redhat.atlassian.net/browse/OSDOCS-19082

Link to docs preview:

- Preview for new feature, configure machine pool root disk sizes: https://113383--ocpdocs-pr.netlify.app/openshift-dedicated/latest/osd_gcp_clusters/creating-a-gcp-cluster-redhat-account.html#osd-configure-machine-pool-root-disk_osd-creating-a-gcp-cluster-rh-account 
- Preview for added "Note" for creating cluster on google cloud: https://113383--ocpdocs-pr.netlify.app/openshift-dedicated/latest/osd_gcp_clusters/creating-a-gcp-cluster-redhat-account.html#osd-create-gcp-cluster-ccs_osd-creating-a-gcp-cluster-rh-account 

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
