### PR TITLE
TELCODOCS-2609: RN fix for tech preview

### DIFF
--- a/virt/release_notes/virt-4-22-release-notes.adoc
+++ b/virt/release_notes/virt-4-22-release-notes.adoc
@@ -256,6 +256,12 @@ You can provision {VirtProductName} clusters that run Red Hat Enterprise Linux C
 +
 link:https://redhat.atlassian.net/browse/CNV-49964[CNV-49964]
 
+KubeVirt Redfish for VM management through the Redfish API (Technology Preview)::
++
+KubeVirt Redfish exposes {VirtProductName} virtual machines through the standard Redfish API. Using KubeVirt Redfish, administrators can manage VM power states, boot configuration, and virtual media attachments. This feature is available as a Technology Preview.
++
+For more information, see xref:../post_installation_configuration/virt-kubevirt-redfish.adoc#proc_virt-installing-kubevirt-redfish_virt-kubevirt-redfish[Install KubeVirt Redfish].
+
 [id="virt-4-22-bug-fixes_{context}"]
 == Fixed issues
 


### PR DESCRIPTION
Version(s):
4.22

Issue:
https://redhat.atlassian.net/browse/TELCODOCS-2609

Link to docs preview:
https://113384--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/release_notes/virt-4-22-release-notes.html#virt-4-22-technology-preview_virt-4-22-release-notes

QE review:
NA

Additional information:
This was added in #111890 but needs to be moved from the features section to the tech preview section
