### PR TITLE
[OSDOCS-20103]: Further clarifying network isolation docs for HCP

### DIFF
--- a/modules/hcp-isolation-overview.adoc
+++ b/modules/hcp-isolation-overview.adoc
@@ -14,8 +14,10 @@ For hosted clusters, network isolation levels include container-based isolation,
 Container-based isolation:: With container-based isolation, you use shared compute nodes, and isolation is enforced by policy, namespaces, and control group or SELinux boundaries. Control-plane components run as pods on the management cluster, isolated mainly by Kubernetes or Linux mechanisms, not by giving each hosted cluster its own VM or server. Each control plane runs in a dedicated namespace, with default-deny networking and a network policy that allows only defined traffic. Pods use the restricted security context constraint, with unique identifiers (UIDs) scoped for each namespace.
 
 VM-based isolation:: With VM-based isolation, you run hosted control plane pods inside VMs; for example, on {VirtProductName}. This type of isolation is useful if you require VM-based isolation over container-based isolation for a multitenant management cluster. You add a hypervisor boundary between hosted clusters that share a management cluster. Control plane pods are pinned to dedicated VMs.
++
+To achieve VM-based isolation, you follow a "shared-nothing" approach, where each control plane has its own dedicated node. The management cluster must be an {product-title} cluster on a VM so that the VM compute nodes can be used with the "shared-nothing" annotations to dedicate them to specific hosted control planes. Those hosted control planes will not share kernel space with control planes from other hosted clusters that are on the same management cluster.
 
-Physical isolation:: With physical isolation, you follow a "shared-nothing" approach, where each control plane has its own dedicated node. Nodes for a specific hosted cluster are tainted and labeled with a specific `hypershift.openshift.io/hosted-cluster` value. Security involves the use of a network policy and physical network access control lists (ACLs) across hosted clusters.  
+Physical isolation:: With physical isolation, you also follow a "shared-nothing" approach. Nodes for a specific hosted cluster are tainted and labeled with a specific `hypershift.openshift.io/hosted-cluster` value. Security involves the use of a network policy and physical network access control lists (ACLs) across hosted clusters.  
 
 For more information, see "Control plane isolation" and "Distributing hosted cluster workloads".
 

--- a/modules/hcp-isolation.adoc
+++ b/modules/hcp-isolation.adoc
@@ -42,3 +42,5 @@ The following SELinux labels are used for key processes and sockets:
 `crio`:: `system_u:system_r:container_runtime_t:s0`
 `crio.sock`:: `system_u:object_r:container_var_run_t:s0` 
 `<example user container processes>`:: `system_u:system_r:container_t:s0:c14,c24`
+
+To achieve physical or virtual machine (VM) isolation, you need to use a "shared-nothing" approach, where each control plane has its own dedicated node. Nodes for a specific hosted cluster are tainted and labeled with a specific `hypershift.openshift.io/hosted-cluster` value. Security involves the use of a network policy and physical network access control lists (ACLs) across hosted clusters. 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.18+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://redhat.atlassian.net/browse/OSDOCS-20103
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
- Network isolation: https://113391--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-networking.html#hcp-isolation-overview_hcp-networking
- Control plane pod isolation: https://113391--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-prepare/hcp-distribute-workloads.html#hcp-isolation_hcp-distribute-workloads
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
