### PR TITLE
[OSDOCS#20215]: Z-Stream release notes 4.20.25

### DIFF
--- a/modules/zstream-4-20-25.adoc
+++ b/modules/zstream-4-20-25.adoc
@@ -1,0 +1,48 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-20-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-20-25_{context}"]
+= RHSA-2026:25194 - {product-title} {product-version}.25 fixed issues and security update
+
+Issued: 16 June 2026
+
+[role="_abstract"]
+{product-title} release {product-version}.25 is now available. The list of fixed issues that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2026:25194[RHSA-2026:25194] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2026:25192[RHBA-2026:25192] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.20.25 --pullspecs
+----
+
+[id="zstream-4-20-25-fixed-issues_{context}"]
+== Fixed issues
+
+* Before this update, init containers in Tekton Pipelines finished too quickly for CRI-O to capture exit codes. As a consequence, these intermittent,  non-deterministic pipeline failures occurred in high-performance environments. With this release, the exit code handling of CRI-O for fast-completing init containers is improved. As a result, high-performance Tekton Pipelines no longer intermittently fail due to non-deterministic exit code issues in init containers. (link:https://redhat.atlassian.net/browse/OCPBUGS-82143[OCPBUGS-82143])
+
+* Before this update, `service-CA` certificate rotation was not automatically detected by the `cluster-monitoring-operator` object, causing pods to continue using expired certificates. As a consequence, users experienced monitoring Operator failures due to expired `service-CA` certificates. With this release, the console Operator now watches for secret changes of `service-CA` certificates, triggering deployment updates to restart pods. As a result, the monitoring Operator now automatically restarts pods with new certificates after service-CA rotation. (link:https://issues.redhat.com/browse/OCPBUGS-84254[OCPBUGS-84254])
+
+* Before this update, an ungraceful shutdown of a {sno} cluster caused API server pod failures and rendered the cluster inoperable. This issue occurred because the `atomicdir` component of `library-go` did not use the `fsync` system call to securely save certificate files to the disk. With this release, the component is updated to use the `fsync` system call when writing these certificates. As a result, API server certificates persist during ungraceful shutdowns, which prevents cluster failures on {sno} clusters. (link:https://redhat.atlassian.net/browse/OCPBUGS-85271[OCPBUGS-85271])
+
+* Before this update, a timing conflict occurred between network management and container isolation in rare cases when software outside the {product-title} cluster created network namespaces. As a result, pods were stuck and could not restart. With this release, the conflict is fixed by setting up the network infrastructure before the container mounts. (link:https://redhat.atlassian.net/browse/OCPBUGS-86004[OCPBUGS-86004])
+
+* Before this update, the Bare Metal Operator (BMO) emitted the `IRONIC_ENDPOINT` variable with a trailing dot, causing proxy routing issues. As a consequence, requests from the BMO to Ironic were routed through a corporate proxy, causing provisioning failures in {product-title} 4.20 clusters with a configured Proxy cluster custom resource. With this release, BMO no longer sets the `IRONIC_ENDPOINT` variable with a trailing dot. As a result, BareMetalHost provisioning in {product-title} 4.20 clusters no longer fails due to an incorrect `IRONIC_ENDPOINT` format. (link:https://redhat.atlassian.net/browse/OCPBUGS-86555[OCPBUGS-86555])
+
+* Before this update, the macOS Option key was treated as a Meta key instead of a compose key in the pod terminal. As a consequence, characters that rely on Option key combinations, such as `@`, `{`, `}`, `|`, `\`, and `~`, could not be entered. With this release, the terminal correctly identifies macOS, so the Option key functions as a compose key as expected. (link:https://redhat.atlassian.net/browse/OCPBUGS-86582[OCPBUGS-86582])
+
+* Before this update, a failure to update the `PerformanceProfile` status due to a temporarily unavailable API server during an upgrade or under network load could leave the profile in a `Degraded` condition. As a consequence, the degraded condition might get stuck and never resolve, even after the cluster returned to a healthy state, because the Operator did not retry until the next reconcile event. With this release, the Operator schedules a retry of the status update until it succeeds, retrying approximately every 30 seconds. As a result, the stuck degraded status is temporary and resolves automatically during the next retry. (link:https://redhat.atlassian.net/browse/OCPBUGS-86815[OCPBUGS-86815])
+
+* Before this update, when you navigated to the resource detail pages for Shipwright components (`Build`, `BuildRun`, `BuildStrategy`, or `ClusterBuildStrategy`) with the builds for the {product-title} Operator installed, the console crashed with React error `#310`. With this release, the component rendering logic is corrected. As a result, Shipwright detail pages load successfully without crashing. (link:https://redhat.atlassian.net/browse/OCPBUGS-86872[OCPBUGS-86872])
+
+* Before {product-title} 4.20.23 upgrade, a trailing quote error in a Prometheus query caused the control plane status indicator to flash. As a consequence, the cluster upgrade resulted in a persistent gray control plane status indicator, affecting user visibility of cluster health. With this release, the trailing quote in the Prometheus query has been fixed, resolving the control plane status issue. As a result, the control plane status of {product-title} 4.20.23 clusters now correctly shows green when healthy, improving the overall user experience. (link:https://redhat.atlassian.net/browse/OCPBUGS-87001[OCPBUGS-87001])
+
+
+[id="zstream-4-20-25-updating_{context}"]
+== Updating
+
+To update an {product-title} 4.20 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].

--- a/release_notes/ocp-4-20-release-notes.adoc
+++ b/release_notes/ocp-4-20-release-notes.adoc
@@ -3021,6 +3021,9 @@ In both cases, the installation program generates a user-assigned identity. (lin
 
 include::modules/rn-async-errata.adoc[leveloffset=+1]
 
+// 4.20.25 release notes
+include::modules/zstream-4-20-25.adoc[leveloffset=+2]
+
 // 4.20.24 release notes
 include::modules/zstream-4-20-24.adoc[leveloffset=+2]
 


### PR DESCRIPTION

Version(s):
4.20

Issue:
https://redhat.atlassian.net/browse/OSDOCS-20215

Link to docs preview:
https://113393--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-20-release-notes.html#zstream-4-20-25_release-notes

QE review:
N/A
