### PR TITLE
CNV#33335: Move service account volume fix to Fixed issues

### DIFF
--- a/virt/release_notes/virt-4-22-release-notes.adoc
+++ b/virt/release_notes/virt-4-22-release-notes.adoc
@@ -67,7 +67,7 @@ You can set a connection method to secure the communication between Windows host
 link:https://redhat.atlassian.net/browse/CNV-73306[CNV-73306]
 
 Configuring PCI passthrough for the {ibm-name} Spyre Accelerator for VMs on {ibm-z-name} and {ibm-linuxone-name} is generally available::
-You can attach the {ibm-name} Spyre Accelerator to VMs using PCI passthrough on {ibm-name} z17 and {ibm-linuxone-name} Emperor 5 or later. The {ibm-name} Spyre Accelerator enhances AI inferencing capabilities on {ibm-z-name} and {ibm-linuxone-name} systems. 
+You can attach the {ibm-name} Spyre Accelerator to VMs using PCI passthrough on {ibm-name} z17 and {ibm-linuxone-name} Emperor 5 or later. The {ibm-name} Spyre Accelerator enhances AI inferencing capabilities on {ibm-z-name} and {ibm-linuxone-name} systems.
 +
 For more information, see xref:../managing_vms/advanced_vm_management/virt-configuring-pci-passthrough.adoc#virt-configuring-pci-passthrough[Configuring PCI passthrough].
 +
@@ -244,8 +244,16 @@ You can provision {VirtProductName} clusters that run Red Hat Enterprise Linux C
 +
 link:https://redhat.atlassian.net/browse/CNV-49964[CNV-49964]
 
-//[id="virt-4-22-bug-fixes_{context}"]
-//== Fixed issues
+[id="virt-4-22-bug-fixes_{context}"]
+== Fixed issues
+
+[role="_abstract"]
+The following issues are fixed for this release.
+
+Service account volumes preserved during VM migration::
+Before this update, migrating a virtual machine (VM) invalidated any service account volumes attached to that VM. As a consequence, workloads that relied on service account tokens failed after migration. With this release, service account volumes are preserved during VM migration. As a result, workloads that use service account tokens continue to function correctly after live migration.
++
+link:https://issues.redhat.com/browse/CNV-33835[CNV-33835]
 
 [id="virt-4-22-known-issues_{context}"]
 == Known issues
@@ -300,14 +308,6 @@ Live migration fails if a virtual machine name exceeds 47 characters. As a conse
 To work around this problem, use VM names that are 47 characters or fewer when you create VMs that you plan to live migrate.
 +
 link:https://issues.redhat.com/browse/CNV-61066[CNV-61066]
-
-//CNV-33835: According to Kedar, this remains an issue in 4.21 (see also CNV-27131)
-Service account volume becomes invalid after VM migration::
-{VirtProductName} links a service account token in use by a pod to that specific pod by creating a disk image that contains the token. If you migrate a VM, the service account volume becomes invalid for the migrated VM. As a consequence, workloads that rely on that service account token can fail after migration.
-+
-To work around this problem, use user accounts instead of service accounts, because user account tokens are not bound to a specific pod.
-+
-link:https://issues.redhat.com/browse/CNV-33835[CNV-33835]
 
 Upgrading to {VirtProductName} 4.22 when using wasp-agent::
 +


### PR DESCRIPTION
Version(s):
4.22

Issue:
https://redhat.atlassian.net/browse/CNV-33835

Link to docs preview:
https://113400--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/release_notes/virt-4-22-release-notes.html#virt-4-22-bug-fixes_virt-4-22-release-notes

QE review:
- [x] QE has approved this change.

Additional information:
This PR moves the service account volume migration issue from the Known Issues section to the Fixed Issues section. The bug was fixed in [CNV-33835](https://redhat.atlassian.net/browse/CNV-33835). The release note follows the SSG CCFR format with a descriptive heading.

---

🤖 Generated with Claude Code