### PR TITLE
OSDOCS#20216: Update the z-stream RNs for 4.14.67

### DIFF
--- a/modules/zstream-4-14-67.adoc
+++ b/modules/zstream-4-14-67.adoc
@@ -1,0 +1,31 @@
+// Module included in the following assembly:
+//
+// * release_notes/ocp-4-14-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-14-67-bug-fixes_{context}"]
+= RHSA-2026:25008 - {product-title} {product-version}.67 image release, fixed issues, and security update
+
+Issued: 17 June 2026
+
+[role="_abstract"]
+{product-title} release {product-version}.67 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2026:25008[RHSA-2026:25008] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2026:25006[RHBA-2026:25006] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.14.67 --pullspecs
+----
+
+[id="zstream-4-14-67-fixed_issues_{context}"]
+== Fixed issues
+
+There are no notable fixed issues in this release.
+
+[id="zstream-4-14-67-updating_{context}"]
+== Updating
+
+To update an {product-title} 4.14 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].

--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -3413,6 +3413,9 @@ The impact is on East/West traffic in local gateway mode with `routingViaHost` s
 // 4.14 about async
 include::modules/rn-async-errata.adoc[leveloffset=+1]
 
+// 4.14.67 Rns and updating
+include::modules/zstream-4-14-67.adoc[leveloffset=+2]
+
 // 4.14.66 Rns and updating
 include::modules/zstream-4-14-66.adoc[leveloffset=+2]
 


### PR DESCRIPTION
Version(s):
4.14

Issue:
[OSDOCS-20216](https://redhat.atlassian.net/browse/OSDOCS-20216)

Link to docs preview:
[4.14.67](https://113401--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes.html#zstream-4-14-67-bug-fixes_release-notes)

QE review:
- [ ] QE has approved this change.
N/A for RNs.

Additional information:
Shipment [MR](https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/573/diffs)
ART [Dashboard](https://art-dash.engineering.redhat.com/dashboard/release/openshift-4.14?page=1)
