### PR TITLE
OBSDOCS-3510: Add channel guidance

### DIFF
--- a/modules/installing-the-clo-cli.adoc
+++ b/modules/installing-the-clo-cli.adoc
@@ -55,7 +55,21 @@ spec:
   sourceNamespace: openshift-marketplace
 ----
 +
-`spec.channel`:: Specify `stable-{logging-major-version}` as the channel. This must match the channel used for the {loki-op}.
+`spec.channel`:: Specify `stable-{logging-major-version}` as the channel. This must match the channel used for the {loki-op}. The channel version corresponds to the {product-title} minor version.
++
+[NOTE]
+====
+To verify the channels available for your cluster, run the following command:
+
+[source,terminal]
+----
+$ oc get packagemanifest cluster-logging -n openshift-marketplace \
+  -o jsonpath='{.status.channels[*].name}'
+----
+
+If the channel is not found, use one of the available channels from the command output.
+====
++
 `spec.source`:: Specify `redhat-operators` as the value. If your {ocp-product-title} cluster is installed on a restricted network, specify the name of the `CatalogSource` object you created when you configured {olm}.
 
 . Apply the `Subscription` object by running the following command:

--- a/modules/installing-the-loki-operator-cli.adoc
+++ b/modules/installing-the-loki-operator-cli.adoc
@@ -76,7 +76,20 @@ spec:
   sourceNamespace: openshift-marketplace
 ----
 +
-`spec.channel`:: Specify `stable-{logging-major-version}` as the channel.
+`spec.channel`:: Specify `stable-{logging-major-version}` as the channel. The channel version corresponds to the {product-title} minor version.
++
+[NOTE]
+====
+To verify the channels available for your cluster, run the following command:
+
+[source,terminal]
+----
+$ oc get packagemanifest loki-operator -n openshift-marketplace \
+  -o jsonpath='{.status.channels[*].name}'
+----
+
+If the channel is not found, use one of the available channels from the command output.
+====
 `spec.installPlanApproval`:: If the approval strategy in the subscription is set to `Automatic`, the update process initiates as soon as a new Operator version is available in the selected channel. If the approval strategy is set to `Manual`, you must manually approve pending updates.
 `spec.source`:: Specify `redhat-operators` as the value. If your {ocp-product-title} cluster is installed on a restricted network, also known as a disconnected cluster, specify the name of the `CatalogSource` object that you created when you configured {olm-first}.
 +


### PR DESCRIPTION
Adds troubleshooting guidance for OLM channel version mismatch that blocks operator installation with cryptic 'constraints not satisfiable' error.

During real-world installation testing, discovered that users encounter immediate installation failure when the channel attribute doesn't match available channels on their cluster. The error message is cryptic and doesn't indicate how to discover available channels.

Changes:
- Explain that channel version corresponds to OCP minor version
- Add NOTE with discovery command to list available channels
- Provide troubleshooting guidance when channel mismatch occurs

This prevents the #1 installation blocker identified during testing.

Modules updated:
- modules/installing-the-loki-operator-cli.adoc
- modules/installing-the-clo-cli.adoc

Severity: Important 
Cherry-pick required: To all supported branches after merge

Related: [OBSDOCS-3462](https://redhat.atlassian.net/browse/OBSDOCS-3462) (testing that discovered this issue)
Testing: Validated on SNO cluster during [OBSDOCS-3462](https://redhat.atlassian.net/browse/OBSDOCS-3462) work

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 6.6-6.1
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://redhat.atlassian.net/browse/OBSDOCS-3510
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://113405--ocpdocs-pr.netlify.app/openshift-logging/latest/installing/installing-the-loki-operator.html
https://113405--ocpdocs-pr.netlify.app/openshift-logging/latest/installing/installing-the-red-hat-openshift-logging-operator.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
