### PR TITLE
RHDEVDOCS-7643: Fix duplicate word in GitOps 1.13 Glossary Application Controller entry

### DIFF
--- a/modules/gitops-openshift-go-common-terms.adoc
+++ b/modules/gitops-openshift-go-common-terms.adoc
@@ -9,7 +9,7 @@
 This glossary defines common OpenShift {gitops-shortname} terms.
 
 Application Controller (Argo CD Application Controller)::
-A controller that that performs the following actions:
+A controller that performs the following actions:
 
 * Continuously watches the Git repository for changes
 * Monitors running applications


### PR DESCRIPTION
## Summary

Fixes a persistent duplicate word typo in the OpenShift GitOps Glossary (section 2.2) for version 1.13.

**Location:** Glossary of common terms → Application Controller (Argo CD Application Controller)

**Change:**
- Before: `A controller that that performs the following actions...`
- After: `A controller that performs the following actions...`

**Jira:** https://redhat.atlassian.net/browse/RHDEVDOCS-7643

This same typo is present in versions 1.13–1.18 and is being fixed in separate PRs for each version. It is already corrected in 1.19, 1.20, and gitops-docs-main.

Made with [Cursor](https://cursor.com)