### PR TITLE
[enterprise-4.21] Cherry picks 4013fc267a8f0d1a8263e1a0536f1654c3025fb9 for 4.21

### DIFF
--- a/modules/cco-ccoctl-configuring.adoc
+++ b/modules/cco-ccoctl-configuring.adoc
@@ -124,6 +124,7 @@ endif::[]
 ifndef::update[= Configuring the Cloud Credential Operator utility]
 ifdef::update[= Configuring the Cloud Credential Operator utility for a cluster update]
 
+[role="_abstract"]
 //Nutanix-only intro because it needs context in its install procedure.
 ifdef::nutanix[]
 The Cloud Credential Operator (CCO) manages cloud provider credentials as Kubernetes custom resource definitions (CRDs). To install a cluster on Nutanix, you must set the CCO to `manual` mode as part of the installation process.
@@ -200,10 +201,11 @@ Ensure that the architecture of the `$RELEASE_IMAGE` matches the architecture of
 [source,terminal]
 ----
 $ oc image extract $CCO_IMAGE \
-  --file="/usr/bin/ccoctl.<rhel_version>" \// <1>
+  --file="/usr/bin/ccoctl.<rhel_version>" \
   -a ~/.pull-secret
 ----
-<1> For `<rhel_version>`, specify the value that corresponds to the version of {op-system-base-full} that the host uses.
++
+For `<rhel_version>`, specify the value that corresponds to the version of {op-system-base-full} that the host uses.
 If no value is specified, `ccoctl.rhel8` is used by default.
 The following values are valid:
 +

--- a/modules/cco-ccoctl-creating-at-once.adoc
+++ b/modules/cco-ccoctl-creating-at-once.adoc
@@ -149,13 +149,16 @@ $ RELEASE_IMAGE=$(./openshift-install version | awk '/release image/ {print $3}'
 $ oc adm release extract \
   --from=$RELEASE_IMAGE \
   --credentials-requests \
-  --included \// <1>
-  --install-config=<path_to_directory_with_installation_configuration>/install-config.yaml \// <2>
-  --to=<path_to_directory_for_credentials_requests> <3>
+  --included \
+  --install-config=<path_to_directory_with_installation_configuration>/install-config.yaml \
+  --to=<path_to_directory_for_credentials_requests>
 ----
-<1> The `--included` parameter includes only the manifests that your specific cluster configuration requires.
-<2> Specify the location of the `install-config.yaml` file.
-<3> Specify the path to the directory where you want to store the `CredentialsRequest` objects. If the specified directory does not exist, this command creates it.
++
+where:
++
+`--included`:: Specifies to include only the manifests that your specific cluster configuration requires.
+`<path_to_directory_with_installation_configuration>`:: Specifies the location of the `install-config.yaml` file.
+`<path_to_directory_for_credentials_requests>`:: Specifies the path to the directory where you want to store the `CredentialsRequest` objects. If the specified directory does not exist, this command creates it.
 +
 [NOTE]
 ====
@@ -179,19 +182,22 @@ ifdef::aws-sts[]
 [source,terminal]
 ----
 $ ccoctl aws create-all \
-  --name=<name> \// <1>
-  --region=<aws_region> \// <2>
-  --credentials-requests-dir=<path_to_credentials_requests_directory> \// <3>
-  --output-dir=<path_to_ccoctl_output_dir> \// <4>
-  --create-private-s3-bucket \// <5>
-  --permissions-boundary-arn=<policy_arn> <6>
+  --name=<name> \
+  --region=<aws_region> \
+  --credentials-requests-dir=<path_to_credentials_requests_directory> \
+  --output-dir=<path_to_ccoctl_output_dir> \
+  --create-private-s3-bucket \
+  --permissions-boundary-arn=<policy_arn>
 ----
-<1> Specify the name used to tag any cloud resources that are created for tracking.
-<2> Specify the AWS region in which cloud resources will be created.
-<3> Specify the directory containing the files for the component `CredentialsRequest` objects.
-<4> Optional: Specify the directory in which you want the `ccoctl` utility to create objects. By default, the utility creates objects in the directory in which the commands are run.
-<5> Optional: By default, the `ccoctl` utility stores the OpenID Connect (OIDC) configuration files in a public S3 bucket and uses the S3 URL as the public OIDC endpoint. To store the OIDC configuration in a private S3 bucket that is accessed by the IAM identity provider through a public CloudFront distribution URL instead, use the `--create-private-s3-bucket` parameter.
-<6> Optional: Specify the Amazon Resource Name (ARN) of the {aws-short} IAM policy to use as the permissions boundary for the IAM roles created by the `ccoctl` utility.
++
+where:
++
+`<name>`:: Specifies the name used to tag any cloud resources that are created for tracking.
+`<aws_region>`:: Specifies the AWS region in which cloud resources will be created.
+`<path_to_credentials_requests_directory>`:: Specifies the directory containing the files for the component `CredentialsRequest` objects.
+`<path_to_ccoctl_output_dir>`:: Specifies the directory in which you want the `ccoctl` utility to create objects. By default, the utility creates objects in the directory in which the commands are run. This parameter is optional.
+`--create-private-s3-bucket`:: Specifies that the OpenID Connect (OIDC) configuration files should be stored in a private S3 bucket that is accessed by the IAM identity provider through a public CloudFront distribution URL. Note that by default, the `ccoctl` utility stores the OIDC configuration files in a public S3 bucket and uses the S3 URL as the public OIDC endpoint. This parameter is optional.
+`<policy_arn>`:: Specifies the Amazon Resource Name (ARN) of the {aws-short} IAM policy to use as the permissions boundary for the IAM roles created by the `ccoctl` utility. This parameter is optional.
 +
 [NOTE]
 ====
@@ -202,15 +208,19 @@ ifdef::google-cloud-platform[]
 [source,terminal]
 ----
 $ ccoctl gcp create-all \
-  --name=<name> \// <1>
-  --region=<gcp_region> \// <2>
-  --project=<gcp_project_id> \// <3>
-  --credentials-requests-dir=<path_to_credentials_requests_directory> <4>
+  --name=<name> \
+  --region=<gcp_region> \
+  --project=<gcp_project_id> \
+  --credentials-requests-dir=<path_to_credentials_requests_directory> \
+  --key-storage-method=<key_storage_method>
 ----
-<1> Specify the user-defined name for all created {gcp-short} resources used for tracking. If you plan to install the {gcp-short} Filestore Container Storage Interface (CSI) Driver Operator, retain this value.
-<2> Specify the {gcp-short} region in which cloud resources will be created.
-<3> Specify the {gcp-short} project ID in which cloud resources will be created.
-<4> Specify the directory containing the files of `CredentialsRequest` manifests to create {gcp-short} service accounts.
++
+where:
++
+`<name>`:: Specifies the user-defined name for all created {gcp-short} resources used for tracking. If you plan to install the {gcp-short} Filestore Container Storage Interface (CSI) Driver Operator, retain this value.
+`<gcp_region>`:: Specifies the {gcp-short} region in which cloud resources will be created.
+`<gcp_project_id>`:: Specifies the {gcp-short} project ID in which cloud resources will be created.
+`<path_to_credentials_requests_directory>`:: Specifies the directory containing the files of `CredentialsRequest` manifests to create {gcp-short} service accounts.
 +
 [NOTE]
 ====
@@ -221,25 +231,28 @@ ifdef::azure-workload-id[]
 [source,terminal]
 ----
 $ ccoctl azure create-all \
-  --name=<azure_infra_name> \// <1>
-  --output-dir=<ccoctl_output_dir> \// <2>
-  --region=<azure_region> \// <3>
-  --subscription-id=<azure_subscription_id> \// <4>
-  --credentials-requests-dir=<path_to_credentials_requests_directory> \// <5>
-  --dnszone-resource-group-name=<azure_dns_zone_resource_group_name> \// <6>
-  --tenant-id=<azure_tenant_id> \// <7>
-  --network-resource-group-name <azure_resource_group> \// <8>
-  --preserve-existing-roles <9>
+  --name=<azure_infra_name> \
+  --output-dir=<ccoctl_output_dir> \
+  --region=<azure_region> \
+  --subscription-id=<azure_subscription_id> \
+  --credentials-requests-dir=<path_to_credentials_requests_directory> \
+  --dnszone-resource-group-name=<azure_dns_zone_resource_group_name> \
+  --tenant-id=<azure_tenant_id> \
+  --network-resource-group-name <azure_resource_group> \
+  --preserve-existing-roles
 ----
-<1> Specify the user-defined name for all created Azure resources used for tracking.
-<2> Optional: Specify the directory in which you want the `ccoctl` utility to create objects. By default, the utility creates objects in the directory in which the commands are run.
-<3> Specify the Azure region in which cloud resources will be created.
-<4> Specify the Azure subscription ID to use.
-<5> Specify the directory containing the files for the component `CredentialsRequest` objects.
-<6> Specify the name of the resource group containing the cluster's base domain Azure DNS zone.
-<7> Specify the Azure tenant ID to use.
-<8> Optional: Specify the virtual network resource group if it is different from the cluster resource group.
-<9> Optional: Specify this flag to ensure that any custom role assignments you define on managed identities are not removed during {product-title} updates.
++
+where:
++
+`<azure_infra_name>`:: Specifies the user-defined name for all created Azure resources used for tracking.
+`<ccoctl_output_dir>`:: Specifies the directory in which you want the `ccoctl` utility to create objects. By default, the utility creates objects in the directory in which the commands are run. This parameter is optional.
+`<azure_region>`:: Specifies the Azure region in which cloud resources will be created.
+`<azure_subscription_id>`:: Specifies the Azure subscription ID to use.
+`<path_to_credentials_requests_directory>`:: Specifies the directory containing the files for the component `CredentialsRequest` objects.
+`<azure_dns_zone_resource_group_name>`:: Specifies the name of the resource group containing the cluster's base domain Azure DNS zone.
+`<azure_tenant_id>`:: Specifies the Azure tenant ID to use.
+`<azure_resource_group>`:: Specifies the virtual network resource group if it is different from the cluster resource group. This parameter is optional.
+`--preserve-existing-roles`:: Specifies that any custom role assignments you define on managed identities are not removed during {product-title} updates. This parameter is optional.
 +
 [NOTE]
 ====


### PR DESCRIPTION
Cherry picks 4013fc267a8f0d1a8263e1a0536f1654c3025fb9
xref: https://github.com/openshift/openshift-docs/pull/112756

Slight discrepancy because later versions include the <key_storage_method> parameter in the modules/cco-ccoctl-creating-at-once.adoc file. Later versions do not this field. Also I made a slight alteration to BGP EVPN docs that is not included here. 