### PR TITLE
OSDOCS-17042 Moving VPA and CRO operators

### DIFF
--- a/modules/nodes-pods-vertical-autoscaler-moving-vpa.adoc
+++ b/modules/nodes-pods-vertical-autoscaler-moving-vpa.adoc
@@ -173,7 +173,7 @@ spec:
         resources: {}
       nodeSelector:
         node-role.kubernetes.io/infra: ""
-      tolerations: <1>
+      tolerations:
       - key: "my-example-node-taint-key"
         operator: "Exists"
         effect: "NoSchedule"
@@ -182,7 +182,7 @@ spec:
         resources: {}
       nodeSelector:
         node-role.kubernetes.io/infra: ""
-      tolerations: <2>
+      tolerations:
       - key: "my-example-node-taint-key"
         operator: "Exists"
         effect: "NoSchedule"
@@ -191,7 +191,7 @@ spec:
         resources: {}
       nodeSelector:
         node-role.kubernetes.io/infra: ""
-      tolerations: <3>
+      tolerations:
       - key: "my-example-node-taint-key"
         operator: "Exists"
         effect: "NoSchedule"
@@ -228,7 +228,7 @@ metadata:
 spec:
   config:
     nodeSelector:
-      node-role.kubernetes.io/<node_role>: "" <1>
+      node-role.kubernetes.io/<node_role>: ""
 ----
 where:
 +
@@ -255,7 +255,7 @@ spec:
   config:
     nodeSelector:
       node-role.kubernetes.io/infra: ""
-    tolerations: <1>
+    tolerations:
     - key: "node-role.kubernetes.io/infra"
       operator: "Exists"
       effect: "NoSchedule"
@@ -290,17 +290,17 @@ spec:
       container:
         resources: {}
       nodeSelector:
-        node-role.kubernetes.io/<node_role>: "" <1>
+        node-role.kubernetes.io/<node_role>: ""
     recommender:
       container:
         resources: {}
       nodeSelector:
-        node-role.kubernetes.io/<node_role>: "" <2>
+        node-role.kubernetes.io/<node_role>: ""
     updater:
       container:
         resources: {}
       nodeSelector:
-        node-role.kubernetes.io/<node_role>: "" <3>
+        node-role.kubernetes.io/<node_role>: ""
 ----
 where:
 +


### PR DESCRIPTION
Version(s):
4.20+

Issue:
https://redhat.atlassian.net/browse/OSDOCS-17042

Link to docs preview:
https://113446--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/creating-infrastructure-machinesets.html#infrastructure-moving-vpa_creating-infrastructure-machinesets

QE review:
NA

Michael Burke already added description lists to the VPA file, so I just needed to remove a few callouts that were left over.