### PR TITLE
Removes accidental addition field in ccoutil docs from a previous che…

### DIFF
--- a/modules/cco-ccoctl-creating-at-once.adoc
+++ b/modules/cco-ccoctl-creating-at-once.adoc
@@ -211,8 +211,7 @@ $ ccoctl gcp create-all \
   --name=<name> \
   --region=<gcp_region> \
   --project=<gcp_project_id> \
-  --credentials-requests-dir=<path_to_credentials_requests_directory> \
-  --key-storage-method=<key_storage_method>
+  --credentials-requests-dir=<path_to_credentials_requests_directory>
 ----
 +
 where:


### PR DESCRIPTION
Cherry pick remediation of https://github.com/openshift/openshift-docs/pull/113440/changes. I accidentally added the   --key-storage-method=<key_storage_method> field in the command when it should not exist in 4.21. 