### PR TITLE
CNV-89006: Add release note about recording metrics

### DIFF
--- a/virt/release_notes/virt-4-22-release-notes.adoc
+++ b/virt/release_notes/virt-4-22-release-notes.adoc
@@ -153,11 +153,12 @@ Cluster administrators can create a custom certificate authority (CA) or a self-
 +
 link:https://redhat.atlassian.net/browse/CNV-79324[CNV-79324]
 
-
-
 // Monitoring
 
-
+Recording rule names updated to conform to Prometheus best practices::
+Recording rule names have been updated to follow the naming convention `<level>:<metric>:<operations>`. This aligns with the Prometheus best practices on naming rules, and helps users to distinguish between recording rules and metrics. For information about which rule names have changed, see the Knowledgebase article link:https://access.redhat.com/articles/7144047[Updates to {VirtProductName} {VirtVersion} recording rules naming].
++
+link:https://redhat.atlassian.net/browse/CNV-89006[CNV-89006]
 
 // Documentation improvements
 


### PR DESCRIPTION
Version(s):
4.22

Issue:
https://redhat.atlassian.net/browse/CNV-89006

Link to docs preview:
https://113473--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/release_notes/virt-4-22-release-notes.html#virt-4-22-new_virt-4-22-release-notes

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
