### PR TITLE
OCPBUGS-89264: Fixed the Image registry repository mirroring configur…

### DIFF
--- a/modules/images_configuring_registry_mirror_config_params.adoc
+++ b/modules/images_configuring_registry_mirror_config_params.adoc
@@ -26,7 +26,7 @@ You can use the following table for information about parameters when configurin
 |The kind of object according to the pull type. The `ImageDigestMirrorSet` type pulls a digest reference image The `ImageTagMirrorSet` type pulls a tag reference image.
 
 |`spec: imageDigestMirrors:`
-|The type of image pull method. Use `imageDigestMirrors`for an `ImageDigestMirrorSet` CR. Use `imageTagMirrors` for an `ImageTagMirrorSet` CR.
+|The type of image pull method. Use `imageDigestMirrors` for an `ImageDigestMirrorSet` CR. Use `imageTagMirrors` for an `ImageTagMirrorSet` CR.
 
 |`- mirrors: - example.io/example/ubi-minimal`
 |The name of the mirrored image registry and repository.
@@ -40,7 +40,8 @@ You can use the following table for information about parameters when configurin
 |`mirrorSourcePolicy: AllowContactingSource`
 |Optional parameter that indicates the fallback policy if the image pull fails. The `AllowContactingSource` value allows continued attempts to pull the image from the source repository. Default value. `NeverContactSource` prevents continued attempts to pull the image from the source repository.
 ifndef::winc[]
-|`source: registry.example.com/redhat`: An optional parameter that indicates a namespace inside a registry. Setting a namespace inside a registry allows use of any image in that namespace. If you use a registry domain as a source, the object applies to all of the repositories from the registry.
+|`source: registry.example.com/redhat`
+| An optional parameter that indicates a namespace inside a registry. Setting a namespace inside a registry allows use of any image in that namespace. If you use a registry domain as a source, the object applies to all of the repositories from the registry.
 
 |`source: registry.example.com`
 |Optional parameter that indicates a registry. Allows us of any image in that registry. If you specify a registry name, the object applies to all repositories from a source registry to a mirror registry.


### PR DESCRIPTION
Version(s):
4.16+

Issue:
[OCPBUGS-89264](https://redhat.atlassian.net/browse/OCPBUGS-89264)

Link to docs preview:

* https://113500--ocpdocs-pr.netlify.app/openshift-dedicated/latest/openshift_images/image-configuration.html
* https://113500--ocpdocs-pr.netlify.app/openshift-enterprise/latest/openshift_images/image-configuration.html
* https://113500--ocpdocs-pr.netlify.app/openshift-rosa/latest/openshift_images/image-configuration.html
