### PR TITLE
[OSDOCS#20240]: Added new files for z-stream release notes 4.16.64

### DIFF
--- a/modules/zstream-4-16-64.adoc
+++ b/modules/zstream-4-16-64.adoc
@@ -1,0 +1,33 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-16-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-16-64_{context}"]
+= RHSA-2026:25045 - {product-title} {product-version}.64 fixed issues and security updates
+
+Issued: 17 June 2026
+
+[role="_abstract"]
+{product-title} release {product-version}.64 is now available. The list of fixed issues that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2026:25045[RHSA-2026:25045] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2026:25043[RHSA-2026:25043] advisory.
+
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.16.64 --pullspecs
+----
+
+[id="zstream-4-16-64-enhancements_{context}"]
+== Enhancements
+
+* With this enhancement, the must-gather report collects the total size of every kind of resources in etcd, which helps with many control plane troubleshooting scenarios.
+
+
+[id="zstream-4-16-64-updating_{context}"]
+== Updating
+
+To update an {product-title} 4.16 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].

--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -3390,6 +3390,9 @@ Testing has shown that wake up latencies are under 20μs for over 99.99999% of t
 // 4.16 about async
 include::modules/rn-async-errata.adoc[leveloffset=+1]
 
+// 4.16.64 Rns and updating
+include::modules/zstream-4-16-64.adoc[leveloffset=+2]
+
 // 4.16.63 Rns and updating
 include::modules/zstream-4-16-63.adoc[leveloffset=+2]
 


### PR DESCRIPTION
Version(s):
4.16

Issue:
https://redhat.atlassian.net/browse/OSDOCS-20240

Link to docs preview:
https://113511--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html#zstream-4-16-64_release-notes

QE review:
N/A

