### PR TITLE
OLS-3214: Missing documentation on mcp server default config

### DIFF
--- a/modules/ols-enabling-custom-mcp-server.adoc
+++ b/modules/ols-enabling-custom-mcp-server.adoc
@@ -8,6 +8,8 @@
 [role="_abstract"]
 Add an additional Model Context Protocol (MCP) server that interfaces with a tool in your environment so that the large language model (LLM) uses the tool to generate answers to your questions.
 
+By default, the cluster introspection feature blocks access to secrets and role-based access control (RBAC) objects. This configuration prevents the leakage of sensitive infrastructure data. Security teams can use this default restriction to validate production deployment safety.
+
 :FeatureName: The MCP server feature
 include::snippets/technology-preview.adoc[]
 :FeatureName!:

--- a/modules/ols-olsconfig-api-specifications.adoc
+++ b/modules/ols-olsconfig-api-specifications.adoc
@@ -479,7 +479,11 @@ Type::
 ====
 The `introspectionEnabled` field in the `OLSConfig` custom resource (CR) is `true` by default. You do not need to specify this field to use the built-in {k8s} MCP server. To disable the built-in {k8s} MCP server, you must set `introspectionEnabled` to `false`.
 ====
-
++
+[IMPORTANT]
+====
+Modifying the MCP server configuration managed by the operator is unsupported. Customizing this configuration requires changing the operator to an unmanaged state. Users who want to customize the MCP server configuration must deploy a standalone MCP server instance independently.
+====
 
 
 == .spec.mcpServers[]


### PR DESCRIPTION


<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
lightspeed-docs-main, lightspeed-docs-1.0, lightspeed-docs-1.1

Issue:
[OLS-3214](https://redhat.atlassian.net/browse/OLS-3214)

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
