### PR TITLE
[enterprise-4.20] OSDOCS-16850: CQA updates for OVN-Kubernetes architecture content

### DIFF
--- a/modules/configuring-a-proxy-after-installation-cli.adoc
+++ b/modules/configuring-a-proxy-after-installation-cli.adoc
@@ -49,7 +49,7 @@ Preface a domain with `.` to match subdomains only. For example, `.y.com` matche
 +
 If you scale up workers that are not included in the network defined by the `networking.machineNetwork[].cidr` field from the installation configuration, you must add them to this list to prevent connection issues.
 +
-This field is ignored if neither the `httpProxy` or `httpsProxy` fields are set.
+This field is ignored if neither the `httpProxy` nor `httpsProxy` fields are set.
 --
 
 .Verification

--- a/modules/configuring-a-proxy-during-installation-cli.adoc
+++ b/modules/configuring-a-proxy-during-installation-cli.adoc
@@ -41,5 +41,5 @@ $ rosa create cluster \
 Preface a domain with `.` to match subdomains only. For example, `.y.com` matches `x.y.com`, but not `y.com`. Use `*` to bypass proxy for all destinations.
 If you scale up workers that are not included in the network defined by the `networking.machineNetwork[].cidr` field from the installation configuration, you must add them to this list to prevent connection issues.
 +
-This field is ignored if neither the `httpProxy` or `httpsProxy` fields are set.
+This field is ignored if neither the `httpProxy` nor `httpsProxy` fields are set.
 --

--- a/modules/nw-ovn-kubernetes-installing-network-tools.adoc
+++ b/modules/nw-ovn-kubernetes-installing-network-tools.adoc
@@ -6,7 +6,8 @@
 [id="nw-ovn-kubernetes-installing-network-tools_{context}"]
 = Installing network-tools on local host
 
-Install `network-tools` on your local host to make a collection of tools available for debugging {product-title} cluster network issues.
+[role="_abstract"]
+Install `network-tools` on your local host for debugging {product-title} cluster network issues.
 
 .Procedure
 

--- a/modules/nw-ovn-kubernetes-limitations.adoc
+++ b/modules/nw-ovn-kubernetes-limitations.adoc
@@ -3,14 +3,14 @@
 // * networking/ovn_kubernetes_network_provider/about-ovn-kubernetes.adoc
 // * microshift_networking/microshift-nw-ipv6-config.adoc
 
-:_mod-docs-content-type: REFERENCE
+:_mod-docs-content-type: CONCEPT
 [id="nw-ovn-kubernetes-limitations_{context}"]
 = OVN-Kubernetes IPv6 and dual-stack limitations
 
-[role="abstract"]
-IPv6 and dual-stack networking for the OVN-Kubernetes network plugin have limitations that affect gateway configuration, routing, and cluster stability.
+[role="_abstract"]
+The OVN-Kubernetes network plugin has specific IPv6 and dual-stack networking configuration limitations. These limitations affect gateway configuration, routing layouts, and infrastructure environment stability.
 
-// The foll limitation is also recorded in the installation section.
+// The following limitation is also recorded in the installation section.
 ifndef::microshift[]
 * For clusters configured for dual-stack networking, both IPv4 and IPv6 traffic must use the same network interface as the default gateway.
 endif::microshift[]

--- a/modules/nw-ovn-kubernetes-list-database-contents.adoc
+++ b/modules/nw-ovn-kubernetes-list-database-contents.adoc
@@ -6,21 +6,17 @@
 [id="nw-ovn-kubernetes-list-database-contents_{context}"]
 = Listing the OVN-Kubernetes northbound database contents
 
-Each node is controlled by the `ovnkube-controller` container running in the `ovnkube-node` pod on that node. To understand the OVN logical networking entities you need to examine the northbound database that is running as a container inside the `ovnkube-node` pod on that node to see what objects are in the node you wish to see.
+[role="_abstract"]
+To understand OVN-Kubernetes (OVN-K) logical networking entities, you must examine the northbound database running as a container inside the ovnkube-node pod. Each node is controlled by the ovnkube-controller container running within that local pod structure.
 
 .Prerequisites
 
 * Access to the cluster as a user with the `cluster-admin` role.
-* The OpenShift CLI (`oc`) installed.
+* The {oc-first} is installed.
 
 .Procedure
 
-[NOTE]
-====
-To run ovn `nbctl` or `sbctl` commands in a cluster you must open a remote shell into the `nbdb` or `sbdb` containers on the relevant node
-====
-
-. List pods by running the following command:
+. List the pods in the network namespace by entering the following command:
 +
 [source,terminal]
 ----
@@ -41,7 +37,7 @@ ovnkube-node-mlr8k                       8/8     Running   0             26m
 ovnkube-node-wqn2m                       8/8     Running   0             16m
 ----
 
-. Optional: To list the pods with node information, run the following command:
+. Optional: To list the pods with node information, enter the following command:
 +
 [source,terminal]
 ----
@@ -62,14 +58,9 @@ ovnkube-node-mlr8k                       8/8     Running   0             27m   1
 ovnkube-node-wqn2m                       8/8     Running   0             17m   10.0.128.4   ci-ln-t487nnb-72292-mdcnq-worker-c-przlm   <none>           <none>
 ----
 
-. Navigate into a pod to look at the northbound database by running the following command:
-+
-[source,terminal]
-----
-$ oc rsh -c nbdb -n openshift-ovn-kubernetes ovnkube-node-55xs2
-----
+. Open a remote shell into the `nbdb` or `sbdb` containers on the relevant node.
 
-. Run the following command to show all the objects in the northbound database:
+. Show all the objects in the northbound database by entering the following command:
 +
 [source,terminal]
 ----
@@ -80,7 +71,7 @@ The output is too long to list here. The list includes the NAT rules, logical sw
 +
 You can narrow down and focus on specific components by using some of the following optional commands:
 
-.. Run the following command to show the list of logical routers:
+.. View the list of active logical routers by entering the following command:
 +
 [source,terminal]
 ----
@@ -100,7 +91,7 @@ $ oc exec -n openshift-ovn-kubernetes -it ovnkube-node-55xs2 \
 From this output you can see there is router on each node plus an `ovn_cluster_router`.
 ====
 
-.. Run the following command to show the list of logical switches:
+.. View the list of logical switches by entering the following command:
 +
 [source,terminal]
 ----
@@ -122,7 +113,7 @@ b349292d-ee03-4914-935f-1940b6cb91e5 (ext_ci-ln-t487nnb-72292-mdcnq-master-2)
 From this output you can see there is an ext switch for each node plus switches with the node name itself and a join switch.
 ====
 
-.. Run the following command to show the list of load balancers:
+.. View the list of load balancers by entering the following command:
 +
 [source,terminal]
 ----
@@ -176,7 +167,7 @@ b1fb34d3-0944-4770-9ee3-2683e7a630e2    Service_openshif    tcp        172.30.15
 From this truncated output you can see there are many OVN-Kubernetes load balancers. Load balancers in OVN-Kubernetes are representations of services.
 ====
 
-. Run the following command to display the options available with the command `ovn-nbctl`:
+. Display the options available with the `ovn-nbctl` command by entering the following command:
 +
 [source,terminal]
 ----

--- a/modules/nw-ovn-kubernetes-list-resources.adoc
+++ b/modules/nw-ovn-kubernetes-list-resources.adoc
@@ -6,16 +6,12 @@
 [id="nw-ovn-kubernetes-list-resources_{context}"]
 = Listing all resources in the OVN-Kubernetes project
 
-Finding the resources and containers that run in the OVN-Kubernetes project is important to help you understand the OVN-Kubernetes networking implementation.
-
-.Prerequisites
-
-* Access to the cluster as a user with the `cluster-admin` role.
-* The OpenShift CLI (`oc`) installed.
+[role="_abstract"]
+List the resources and containers running within the OVN-Kubernetes project to identify network workload states and verify component placement across the infrastructure.
 
 .Procedure
 
-. Run the following command to get all resources, endpoints, and `ConfigMaps` in the OVN-Kubernetes project:
+. List all pods and endpoints by entering the following command:
 +
 [source,terminal]
 ----
@@ -65,33 +61,41 @@ configmap/signer-ca                  1      114m
 +
 There is one `ovnkube-node` pod for each node in the cluster.
 The `ovnkube-config` config map has the {product-title} OVN-Kubernetes configurations.
-+
 
-. List all of the containers in the `ovnkube-node` pods by running the following command:
+. Display the container layout within the node pod by entering the following command:
 +
 [source,terminal]
 ----
 $ oc get pods ovnkube-node-bcvts -o jsonpath='{.spec.containers[*].name}' -n openshift-ovn-kubernetes
 ----
-.Expected output
 +
+.Example output
 [source,terminal]
 ----
 ovn-controller ovn-acl-logging kube-rbac-proxy-node kube-rbac-proxy-ovn-metrics northd nbdb sbdb ovnkube-controller
 ----
-The `ovnkube-node` pod is made up of several containers. It is responsible for hosting the northbound database (`nbdb` container), the southbound database (`sbdb` container), the north daemon (`northd` container), `ovn-controller` and the `ovnkube-controller` container. The `ovnkube-controller` container watches for API objects like pods, egress IPs, namespaces, services, endpoints, egress firewall, and network policies. It is also responsible for allocating pod IP from the available subnet pool for that node.
++
+The `ovnkube-node` pod hosts the following networking containers:
++
+* The northbound database, `nbdb`.
+* The southbound database, `sbdb`.
+* The north daemon, `northd`.
+* The `ovn-controller`.
+* The `ovnkube-controller`.
++
+The `ovnkube-controller` container watches for API objects such as pods, egress IPs, namespaces, services, endpoints, egress firewall, and network policies. The controller is also responsible for allocating pod IP addresses from the available subnet pool for that node.
 
-. List all the containers in the `ovnkube-control-plane` pods by running the following command:
+. List all the containers in the `ovnkube-control-plane` pods by entering the following command:
 +
 [source,terminal]
 ----
 $ oc get pods ovnkube-control-plane-65c6f55656-6d55h -o jsonpath='{.spec.containers[*].name}' -n openshift-ovn-kubernetes
 ----
-.Expected output
 +
+.Example output
 [source,terminal]
 ----
 kube-rbac-proxy ovnkube-cluster-manager
 ----
 +
-The `ovnkube-control-plane` pod has a container (`ovnkube-cluster-manager`) that resides on each {product-title} node. The `ovnkube-cluster-manager` container allocates pod subnet, transit switch subnet IP and join switch subnet IP to each node in the cluster. The `kube-rbac-proxy` container monitors metrics for the `ovnkube-cluster-manager` container.
+The `ovnkube-control-plane` pod has a container that runs on each {product-title} node, the `ovnkube-cluster-manager`. The `ovnkube-cluster-manager` container allocates pod subnet, transit-switch subnet IP addresses, and join-switch subnet IP addresses to each node in the cluster. The `kube-rbac-proxy` container monitors metrics for the `ovnkube-cluster-manager` container.

--- a/modules/nw-ovn-kubernetes-list-southbound-database-contents.adoc
+++ b/modules/nw-ovn-kubernetes-list-southbound-database-contents.adoc
@@ -6,21 +6,17 @@
 [id="nw-ovn-kubernetes-list-southbound-database-contents_{context}"]
 = Listing the OVN-Kubernetes southbound database contents
 
-Each node is controlled by the `ovnkube-controller` container running in the `ovnkube-node` pod on that node. To understand the OVN logical networking entities you need to examine the northbound database that is running as a container inside the `ovnkube-node` pod on that node to see what objects are in the node you wish to see.
+[role="_abstract"]
+To understand OVN-Kubernetes (OVN-K) logical networking entities, examine the southbound database running as a container inside the `ovnkube-node` pod. Each node is controlled by the `ovnkube-controller` container running in that pod on the node.
 
 .Prerequisites
 
 * Access to the cluster as a user with the `cluster-admin` role.
-* The OpenShift CLI (`oc`) installed.
+* The {oc-first} is installed.
 
 .Procedure
 
-[NOTE]
-====
-To run ovn `nbctl` or `sbctl` commands in a cluster you must open a remote shell into the `nbdb` or `sbdb` containers on the relevant node
-====
-
-. List the pods by running the following command:
+. List the pods in the network namespace by entering the following command:
 +
 [source,terminal]
 ----
@@ -41,7 +37,7 @@ ovnkube-node-mlr8k                       8/8     Running   0             26m
 ovnkube-node-wqn2m                       8/8     Running   0             16m
 ----
 
-. Optional: To list the pods with node information, run the following command:
+. Optional: To list the pods with node information, enter the following command:
 +
 [source,terminal]
 ----
@@ -62,14 +58,9 @@ ovnkube-node-mlr8k                       8/8     Running   0             27m   1
 ovnkube-node-wqn2m                       8/8     Running   0             17m   10.0.128.4   ci-ln-t487nnb-72292-mdcnq-worker-c-przlm   <none>           <none>
 ----
 
-. Navigate into a pod to look at the southbound database:
-+
-[source,terminal]
-----
-$ oc rsh -c sbdb -n openshift-ovn-kubernetes ovnkube-node-55xs2
-----
+. Open a remote shell into the `nbdb` or `sbdb` containers on the relevant node to examine the southbound database.
 
-. Run the following command to show all the objects in the southbound database:
+. Show all the objects in the southbound database by entering the following command:
 +
 [source,terminal]
 ----
@@ -78,7 +69,6 @@ $ ovn-sbctl show
 
 +
 .Example output
-+
 [source,terminal]
 ----
 Chassis "5db31703-35e9-413b-8cdf-69e7eecb41f7"
@@ -134,15 +124,11 @@ Chassis "1d371cb8-5e21-44fd-9025-c4b162cc4247"
     Port_Binding tstor-ci-ln-9gp362t-72292-v2p94-master-1
 ----
 +
-This detailed output shows the chassis and the ports that are attached to the chassis which in this case are all of the router ports and anything that runs like host networking.
-Any pods communicate out to the wider network using source network address translation (SNAT).
-Their IP address is translated into the IP address of the node that the pod is running on and then sent out into the network.
-+
-In addition to the chassis information the southbound database has all the logic flows and those logic flows are then sent to the `ovn-controller` running on each of the nodes.
-The `ovn-controller` translates the logic flows into open flow rules and ultimately programs `OpenvSwitch` so that your pods can then follow open flow rules and make it out of the network.
-+
+* This detailed output shows the chassis and the ports that are attached to the chassis which in this case are all of the router ports and anything that uses host networking.
+* Any pods communicate out to the wider network by using source network address translation (SNAT). Their IP address is translated into the IP address of the node that the pod is running on and then sent out into the network.
+* In addition to the chassis information the southbound database has all the logic flows and those logic flows are then sent to the `ovn-controller` running on each of the nodes. The `ovn-controller` translates the logic flows into open flow rules and ultimately programs `OpenvSwitch` so that your pods can then follow open flow rules and make it out of the network.
 
-. Run the following command to display the options available with the command `ovn-sbctl`:
+. Display the options available with the `ovn-sbctl` command by entering the following command:
 +
 [source,terminal]
 ----

--- a/modules/nw-ovn-kubernetes-running-network-tools.adoc
+++ b/modules/nw-ovn-kubernetes-running-network-tools.adoc
@@ -6,17 +6,18 @@
 [id="nw-ovn-kubernetes-running-network-tools_{context}"]
 = Running network-tools
 
-Get information about the logical switches and routers by running `network-tools`.
+[role="_abstract"]
+Run `network-tools` to retrieve configuration status from logical switches and routers when diagnosing internal routing loops and cluster network issues.
 
 .Prerequisites
 
-* You installed the OpenShift CLI (`oc`).
+* You installed the {oc-first}.
 * You are logged in to the cluster as a user with `cluster-admin` privileges.
 * You have installed `network-tools` on local host.
 
 .Procedure
 
-. List the routers by running the following command:
+. Display the logical router map by entering the following command:
 +
 [source,terminal]
 ----
@@ -24,23 +25,20 @@ $ ./debug-scripts/network-tools ovn-db-run-command ovn-nbctl lr-list
 ----
 +
 .Example output
-+
 [source,terminal]
 ----
 944a7b53-7948-4ad2-a494-82b55eeccf87 (GR_ci-ln-54932yb-72292-kd676-worker-c-rzj99)
 84bd4a4c-4b0b-4a47-b0cf-a2c32709fc53 (ovn_cluster_router)
 ----
 
-. List the localnet ports by running the following command:
+. Locate active port bindings with local network attributes by entering the following command:
 +
 [source,terminal]
 ----
-$ ./debug-scripts/network-tools ovn-db-run-command \
-ovn-sbctl find Port_Binding type=localnet
+$ ./debug-scripts/network-tools ovn-db-run-command "ovn-sbctl find Port_Binding type=localnet"
 ----
 +
 .Example output
-+
 [source,terminal]
 ----
 _uuid               : d05298f5-805b-4838-9224-1211afc2f199
@@ -70,16 +68,14 @@ virtual_parent      : []
 [...]
 ----
 
-. List the `l3gateway` ports by running the following command:
+. List the `l3gateway` ports by entering the following command:
 +
 [source,terminal]
 ----
-$ ./debug-scripts/network-tools ovn-db-run-command \
-ovn-sbctl find Port_Binding type=l3gateway
+$ ./debug-scripts/network-tools ovn-db-run-command "ovn-sbctl find Port_Binding type=l3gateway"
 ----
 +
 .Example output
-+
 [source,terminal]
 ----
 _uuid               : 5207a1f3-1cf3-42f1-83e9-387bbb06b03c
@@ -133,16 +129,14 @@ virtual_parent      : []
 [...]
 ----
 
-. List the patch ports by running the following command:
+. List the patch ports by entering the following command:
 +
 [source,terminal]
 ----
-$ ./debug-scripts/network-tools ovn-db-run-command \
-ovn-sbctl find Port_Binding type=patch
+$ ./debug-scripts/network-tools ovn-db-run-command "ovn-sbctl find Port_Binding type=patch"
 ----
 +
 .Example output
-+
 [source,terminal]
 ----
 _uuid               : 785fb8b6-ee5a-4792-a415-5b1cb855dac2

--- a/modules/nw-ovn-kubernetes-session-affinity.adoc
+++ b/modules/nw-ovn-kubernetes-session-affinity.adoc
@@ -6,10 +6,21 @@
 [id="nw-ovn-kubernetes-session-affinity_{context}"]
 = Session affinity
 
-Session affinity is a feature that applies to Kubernetes `Service` objects. You can use _session affinity_ if you want to ensure that each time you connect to a <service_VIP>:<Port>, the traffic is always load balanced to the same back end. For more information, including how to set session affinity based on a client's IP address, see link:https://kubernetes.io/docs/reference/networking/virtual-ips/#session-affinity[Session affinity].
+[role="_abstract"]
+You can use _session affinity_ if you want to ensure that each time you connect to a <service_VIP>:<Port>, the traffic is always load balanced to the same back end. For more information, including how to set session affinity based on a client's IP address, see the Additional resources.
 
 
 [id="nw-ovn-kubernetes-session-affinity-stickyness-timeout_{context}"]
 == Stickiness timeout for session affinity
 
-The OVN-Kubernetes network plugin for {product-title} calculates the stickiness timeout for a session from a client based on the last packet. For example, if you run a `curl` command 10 times, the sticky session timer starts from the tenth packet not the first. As a result, if the client is continuously contacting the service, then the session never times out. The timeout starts when the service has not received a packet for the amount of time set by the link:https://kubernetes.io/docs/reference/networking/virtual-ips/#session-stickiness-timeout[`timeoutSeconds`] parameter.
+The OVN-Kubernetes network plugin for {product-title} calculates the stickiness timeout for a session from a client based on the last packet.
+
+For example, if you run a `curl` command 10 times, the sticky session timer starts from the tenth packet not the first.
+
+As a result, if the client is continuously contacting the service, then the session never times out. The timeout starts when the service has not received a packet for the amount of time set by the `timeoutSeconds` parameter. For more information about `timeoutSeconds`, see the Additional resources.
+
+[role="_additional-resources"]
+.Additional resources
+
+* link:https://kubernetes.io/docs/reference/networking/virtual-ips/#session-affinity[Session affinity in Kubernetes]
+* link:https://kubernetes.io/docs/reference/networking/virtual-ips/#session-stickiness-timeout[Session stickiness timeout in Kubernetes]

--- a/modules/ovn-kubernetes-architecture-con.adoc
+++ b/modules/ovn-kubernetes-architecture-con.adoc
@@ -2,26 +2,27 @@
 [id="ovn-kubernetes-architecture-con"]
 = Introduction to OVN-Kubernetes architecture
 
-The following diagram shows the OVN-Kubernetes architecture.
+[role="_abstract"]
+The OVN-Kubernetes architecture comprises specialized databases and daemons that process network state requests. Use this mapping to evaluate data paths and troubleshoot multi-node communication routing.
 
-.OVK-Kubernetes architecture
+.OVN-Kubernetes architecture
 image::299_OpenShift_OVN_Kubernetes_arch_1_0725.png[OVN-Kubernetes architecture]
 
 The key components are:
 
-* **Cloud Management System (CMS)** - A platform specific client for OVN that provides a CMS specific plugin for OVN integration. The plugin translates the cloud management system's concept of the logical network configuration, stored in the CMS configuration database in a  CMS-specific  format, into an intermediate representation understood by OVN.
+* **Cloud Management System (CMS)** - A platform specific client for OVN that provides a CMS specific plugin for OVN integration. The plugin translates the cloud management system's concept of the logical network configuration, stored in the CMS configuration database in a CMS-specific format, into an intermediate representation understood by OVN.
 * **OVN Northbound database (`nbdb`) container** - Stores the logical network configuration passed by the CMS plugin.
 * **OVN Southbound database (`sbdb`) container** - Stores the physical and logical network configuration state for Open vSwitch (OVS) system on each node, including tables that bind them.
-* **OVN north daemon (`ovn-northd`)** - This is the intermediary client between `nbdb` container and `sbdb` container. It translates  the logical network configuration in terms of conventional network concepts, taken from the `nbdb` container, into  logical data path flows in the `sbdb` container. The container name for `ovn-northd` daemon is `northd` and it runs in the `ovnkube-node` pods.
-* **ovn-controller** - This is the OVN agent that interacts with OVS and hypervisors, for any information or update that is needed for `sbdb` container. The `ovn-controller` reads logical flows from the `sbdb` container, translates them into `OpenFlow` flows and sends them to the node’s OVS daemon. The container name is `ovn-controller` and it runs in the `ovnkube-node` pods.
+* **OVN north daemon (`ovn-northd`)** - This is the intermediary client between `nbdb` container and `sbdb` container. It translates the logical network configuration in terms of conventional network concepts, taken from the `nbdb` container, into logical data path flows in the `sbdb` container. The container name for `ovn-northd` daemon is `northd` and it runs in the `ovnkube-node` pods.
+* **ovn-controller** - This is the OVN agent that interacts with OVS and hypervisors, for any information or update that is required for `sbdb` container. The `ovn-controller` reads logical flows from the `sbdb` container, translates them into `OpenFlow` flows and sends them to the node's OVS daemon. The container name is `ovn-controller` and it runs in the `ovnkube-node` pods.
 
 The OVN northd, northbound database, and southbound database run on each node in the cluster and mostly contain and process information that is local to that node.
 
 The OVN northbound database has the logical network configuration passed down to it by the cloud management system (CMS).
-The OVN northbound database contains the current desired state of the network, presented as a collection of logical ports, logical switches, logical routers, and more.
+The OVN northbound database contains the current intended state of the network, presented as a collection of logical ports, logical switches, logical routers, and more.
 The `ovn-northd` (`northd` container) connects to the OVN northbound database and the OVN southbound database.
 It translates the logical network configuration in terms of conventional network concepts, taken from the OVN northbound database, into logical data path flows in the OVN southbound database.
 
-The OVN southbound database has physical and logical representations of the network and binding tables that link them together. It contains the chassis information of the node and other constructs like remote transit switch ports that are required to connect to the other nodes in the cluster. The OVN southbound database also contains all the logic flows. The logic flows are shared with the `ovn-controller` process that runs on each node and the `ovn-controller` turns those into `OpenFlow` rules to program `Open vSwitch`(OVS).
+The OVN southbound database has physical and logical representations of the network and binding tables that link them together. It contains the chassis information of the node and other constructs such as remote transit switch ports that are required to connect to the other nodes in the cluster. The OVN southbound database also contains all the logic flows. The logic flows are shared with the `ovn-controller` process that runs on each node and the `ovn-controller` turns those into `OpenFlow` rules to program `Open vSwitch`(OVS).
 
 The Kubernetes control plane nodes contain two `ovnkube-control-plane` pods on separate nodes, which perform the central IP address management (IPAM) allocation for each node in the cluster. At any given time, a single `ovnkube-control-plane` pod is the leader.

--- a/modules/ovn-kubernetes-logical-architecture-con.adoc
+++ b/modules/ovn-kubernetes-logical-architecture-con.adoc
@@ -2,7 +2,8 @@
 [id="ovn-kubernetes-logical-architecture-con_{context}"]
 = OVN-Kubernetes logical architecture
 
-OVN is a network virtualization solution. It creates logical switches and routers. These switches and routers are interconnected to create any network topologies. When you run `ovnkube-trace` with the log level set to 2 or 5 the OVN-Kubernetes logical components are exposed. The following diagram shows how the routers and switches are connected in {product-title}.
+[role="_abstract"]
+OVN-Kubernetes is a network virtualization solution that creates logical switches and routers across cluster nodes. These virtual infrastructure components interconnect to construct distinct network topologies.
 
 .OVN-Kubernetes router and switch components
 image::299_OpenShift_OVN-Kubernetes_arch_1023_2.png[OVN-Kubernetes logical architecture]
@@ -15,11 +16,17 @@ Distributed logical routers:: Distributed logical routers and the logical switch
 
 Join local switch:: Join local switches are used to connect the distributed router and gateway routers. It reduces the number of IP addresses needed on the distributed router.
 
-Logical switches with patch ports:: Logical switches with patch ports are used to virtualize the network stack. They connect remote logical ports through tunnels.
+Logical switches with patch ports:: Logical switches with patch ports virtualize the network stack. These components connect remote logical ports through network encapsulation tunnels.
 
-Logical switches with localnet ports:: Logical switches with localnet ports are used to connect OVN to the physical network. They connect remote logical ports by bridging the packets to directly connected physical L2 segments using localnet ports.
+Logical switches with localnet ports:: Logical switches with localnet ports connect the OVN layout to the physical network. These elements connect remote logical ports by bridging packets to directly attached physical Layer 2 segments.
 
-Patch ports:: Patch ports represent connectivity between logical switches and logical routers and between peer logical routers. A single connection has a pair of patch ports at each such point of connectivity, one on each side.
+Patch ports:: Patch ports provide connectivity between logical switches and logical routers, or between peer logical routers. A single connection uses a pair of patch ports at each connectivity intersection, one on each side.
 
-l3gateway ports:: l3gateway ports are the port binding entries in the `ovn-sbdb` for logical patch ports used in the gateway routers. They are called l3gateway ports rather than patch ports just to portray the fact that these ports are bound to a chassis just like the gateway router itself.
+`l3gateway` ports:: Port binding entries in the `ovn-sbdb` for logical patch ports used in gateway routers. They are called `l3gateway` ports rather than patch ports because these ports are bound to a chassis similar to the gateway router itself.
+
 localnet ports:: localnet ports are present on the bridged logical switches that allows a connection to a locally accessible network from each `ovn-controller` instance. This helps model the direct connectivity to the physical network from the logical switches. A logical switch can only have a single localnet port attached to it.
+
+[NOTE]
+====
+Executing `ovnkube-trace` with the log level configuration set to `2` or `5` exposes these internal OVN-Kubernetes logical routing components for analysis.
+====

--- a/networking/ovn_kubernetes_network_provider/about-ovn-kubernetes.adoc
+++ b/networking/ovn_kubernetes_network_provider/about-ovn-kubernetes.adoc
@@ -6,7 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-The {product-title} cluster uses a virtualized network for pod and service networks.
+[role="_abstract"]
+The {product-title} cluster uses a virtualized network for pod and service networks. The OVN-Kubernetes network plugin is the default provider that implements this virtualized overlay network by transforming configurations into OpenFlow rules to enable advanced routing and security features.
 
 Part of {openshift-networking}, the OVN-Kubernetes network plugin is the default network provider for {product-title}. OVN-Kubernetes is based on Open Virtual Network (OVN) and provides an overlay-based networking implementation. A cluster that uses the OVN-Kubernetes plugin also runs Open vSwitch (OVS) on each node. OVN configures OVS on each node to implement the declared network configuration.
 
@@ -15,11 +16,11 @@ Part of {openshift-networking}, the OVN-Kubernetes network plugin is the default
 OVN-Kubernetes is the default networking solution for {product-title} and {sno} deployments.
 ====
 
-OVN-Kubernetes, which arose from the OVS project, uses many of the same constructs, such as open flow rules, to decide how packets travel through the network. For more information, see the link:https://www.ovn.org/en/[Open Virtual Network website].
+OVN-Kubernetes, which arose from the OVS project, uses many of the same constructs. For example, the plugin applies OpenFlow rules to direct packet routing through the network infrastructure. For more information, see Additional resources.
 
-OVN-Kubernetes is a series of daemons for OVS that transform virtual network configurations into `OpenFlow` rules. `OpenFlow` is a protocol for communicating with network switches and routers, providing a means for remotely controlling the flow of network traffic on a network device. This means that network administrators can configure, manage, and watch the flow of network traffic.
+OVN-Kubernetes is a series of daemons for OVS that transform virtual network configurations into `OpenFlow` rules. `OpenFlow` is a protocol for communicating with network switches and routers, providing a means for remotely controlling the flow of network traffic on a network device. This means that network administrators can configure, manage, and monitor the flow of network traffic.
 
-OVN-Kubernetes provides more of the advanced functionality not available with `OpenFlow`. OVN supports distributed virtual routing, distributed logical switches, access control, Dynamic Host Configuration Protocol (DHCP), and DNS. OVN implements distributed virtual routing within logic flows that equate to open flows. For example, if you have a pod that sends out a DHCP request to the DHCP server on the network, a logic flow rule in the request helps the OVN-Kubernetes handle the packet. This means that the server can respond with gateway, DNS server, IP address, and other information.
+OVN-Kubernetes provides more of the advanced functionality not available with `OpenFlow`. OVN supports distributed virtual routing, distributed logical switches, access control, Dynamic Host Configuration Protocol (DHCP), and DNS. OVN implements distributed virtual routing within logic flows that equate to open flows. For example, if you have a pod that sends out a DHCP request to the DHCP server on the network, a logic flow rule in the request enables the OVN-Kubernetes plugin to process the packet. This means that the server can respond with gateway, DNS server, IP address, and other information.
 
 OVN-Kubernetes runs a daemon on each node. There are daemon sets for the databases and for the OVN controller that run on every node. The OVN controller programs the Open vSwitch daemon on the nodes to support the following network provider features: 
 
@@ -46,6 +47,7 @@ ifndef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 [role="_additional-resources"]
 .Additional resources
 
+* link:https://www.ovn.org/en/[Open Virtual Network website]
 * xref:../../networking/network_security/egress_firewall/configuring-egress-firewall-ovn.adoc#configuring-egress-firewall-ovn[Configuring an egress firewall for a project]
 * xref:../../networking/network_security/network_policy/about-network-policy.adoc#about-network-policy[About network policy]
 * xref:../../networking/network_security/logging-network-security.adoc#logging-network-security[Logging network policy events]

--- a/networking/ovn_kubernetes_network_provider/ovn-kubernetes-architecture-assembly.adoc
+++ b/networking/ovn_kubernetes_network_provider/ovn-kubernetes-architecture-assembly.adoc
@@ -6,6 +6,9 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
+The following sections describe the OVN-Kubernetes architecture, how OVN components map to cluster resources and databases, and how to install and run `network-tools` for debugging.
+
 include::modules/ovn-kubernetes-architecture-con.adoc[leveloffset=+1]
 
 include::modules/nw-ovn-kubernetes-list-resources.adoc[leveloffset=+1]
@@ -30,7 +33,7 @@ include::modules/nw-ovn-kubernetes-running-network-tools.adoc[leveloffset=+2]
 
 * xref:../../networking/ovn_kubernetes_network_provider/ovn-kubernetes-tracing-using-ovntrace.adoc#ovn-kubernetes-tracing-using-ovntrace[Tracing Openflow with ovnkube-trace]
 * link:https://www.ovn.org/support/dist-docs/ovn-architecture.7.html[OVN architecture]
-* link:https://man7.org/linux/man-pages/man8/ovn-nbctl.8.html[ovn-nbctl linux manual page]
-* link:https://man7.org/linux/man-pages/man8/ovn-sbctl.8.html[ovn-sbctl linux manual page]
+* link:https://man7.org/linux/man-pages/man8/ovn-nbctl.8.html[ovn-nbctl Linux manual page]
+* link:https://man7.org/linux/man-pages/man8/ovn-sbctl.8.html[ovn-sbctl Linux manual page]
 
 


### PR DESCRIPTION
Apply CQA 2.0 editorial updates across OVN-Kubernetes architecture modules and proxy CLI modules per merge-review feedback.

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

Version(s): 4.20

Issue: https://redhat.atlassian.net/browse/OSDOCS-16850

Link to docs preview:
https://111189--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/ovn-kubernetes-architecture-assembly.html

QE review: N/A - CQA change only

Additional information:
Manual cherry-pick for https://github.com/openshift/openshift-docs/pull/111189
<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
