### PR TITLE
OSDOCS-17171:CQA 2.0-Security-Certificates-Attachment1

### DIFF
--- a/modules/ca-bundle-replacing.adoc
+++ b/modules/ca-bundle-replacing.adoc
@@ -6,6 +6,9 @@
 [id="ca-bundle-replacing_{context}"]
 = Replacing the CA Bundle certificate
 
+[role="_abstract"]
+To trust a custom certificate authority for egress connections in {product-title}, you can replace the CA bundle by creating a config map with your root CA certificate and updating the cluster proxy configuration.
+
 .Procedure
 
 . Create a config map that includes the root CA certificate used to sign the wildcard certificate:
@@ -13,10 +16,10 @@
 [source,terminal]
 ----
 $ oc create configmap custom-ca \
-     --from-file=ca-bundle.crt=</path/to/example-ca.crt> \//<1>
+     --from-file=ca-bundle.crt=</path/to/example-ca.crt> \
      -n openshift-config
 ----
-<1> `</path/to/example-ca.crt>` is the path to the CA certificate bundle on your local file system.
+`</path/to/example-ca.crt>` is the path to the CA certificate bundle on your local file system.
 
 . Update the cluster-wide proxy configuration with the newly created config map:
 +

--- a/security/certificates/updating-ca-bundle.adoc
+++ b/security/certificates/updating-ca-bundle.adoc
@@ -6,6 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
+To trust custom certificate authorities for egress connections in {product-title}, you can update the CA bundle by specifying custom CA certificates in the cluster-wide proxy configuration.
 
 include::modules/ca-bundle-understanding.adoc[leveloffset=+1]
 


### PR DESCRIPTION
Version(s):
4.20+

Issue:
https://redhat.atlassian.net/browse/OSDOCS-17171

Link to docs preview:
https://113561--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/certificates/updating-ca-bundle.html

