### PR TITLE
OBSDOCS-3445: Added release notes for OpenShift Logging 6.0.15.

### DIFF
--- a/modules/logging-release-notes-6-0-15.adoc
+++ b/modules/logging-release-notes-6-0-15.adoc
@@ -1,0 +1,27 @@
+// Module included in the following assemblies:
+//
+// * release_notes/logging-release-notes-6.0.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="logging-release-notes-6-0-15_{context}"]
+= Logging 6.0.15
+
+[role="_abstract"]
+This release includes link:https://access.redhat.com/errata/RHSA-2026:26585[RHBA-2026:26585].
+
+[id="logging-release-notes-6-0-15-cves_{context}"]
+== CVEs
+
+* link:https://access.redhat.com/security/cve/CVE-2026-25679[CVE-2026-25679]
+
+* link:https://access.redhat.com/security/cve/CVE-2026-27137[CVE-2026-27137]
+
+* link:https://access.redhat.com/security/cve/CVE-2026-32280[CVE-2026-32280]
+
+* link:https://access.redhat.com/security/cve/CVE-2026-32281[CVE-2026-32281]
+
+* link:https://access.redhat.com/security/cve/CVE-2026-32282[CVE-2026-32282]
+
+* link:https://access.redhat.com/security/cve/CVE-2026-33810[CVE-2026-33810]
+
+* link:https://access.redhat.com/security/cve/CVE-2026-34986[CVE-2026-34986]

--- a/release_notes/logging-release-notes-6-0.adoc
+++ b/release_notes/logging-release-notes-6-0.adoc
@@ -9,6 +9,8 @@ toc::[]
 [role="_abstract"]
 These release notes describe the updates in {LoggingProductName} 6.0. They include new features and enhancements, bug fixes, security updates (CVEs), known issues, and Technology Preview features.
 
+include::modules/logging-release-notes-6-0-15.adoc[leveloffset=+1]
+
 include::modules/logging-release-notes-6-0-14.adoc[leveloffset=+1]
 
 include::modules/logging-release-notes-6-0-13.adoc[leveloffset=+1]


### PR DESCRIPTION
Added z-stream release notes for OpenShift Logging docs version 6.0.15. 

Version(s): 6.0

Issue: https://redhat.atlassian.net/browse/OBSDOCS-3445
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://113581--ocpdocs-pr.netlify.app/openshift-logging/latest/release_notes/logging-release-notes-6-0.html#logging-release-notes-6-0-15_logging-release-notes-6-0
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
