### PR TITLE
OSDOCS CQA WINC-3: Windows Containers Release Notes and Support

### DIFF
--- a/windows_containers/index.adoc
+++ b/windows_containers/index.adoc
@@ -7,7 +7,10 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 
-{productwinc} is a feature providing the ability to run Windows compute nodes in an {product-title} cluster. This is possible by using the Red Hat Windows Machine Config Operator (WMCO) to install and manage Windows nodes. With a Red Hat subscription, you can get support for running Windows workloads in {product-title}. Windows instances deployed by the WMCO are configured with the containerd container runtime. For more information, see the xref:../windows_containers/wmco_rn/windows-containers-release-notes.adoc#windows-containers-release-notes[release notes].
+[role="_abstract"]
+You can use {productwinc} run Windows compute nodes in an {product-title} cluster by using the Red Hat Windows Machine Config Operator (WMCO) to install and manage Windows nodes. 
+
+With a Red Hat subscription, you can get support for running Windows workloads in {product-title}. Windows instances deployed by the WMCO are configured with the containerd container runtime. For more information, see the xref:../windows_containers/wmco_rn/windows-containers-release-notes.adoc#windows-containers-release-notes[release notes].
 
 You can add Windows nodes either by creating a xref:../windows_containers/creating_windows_machinesets/creating-windows-machineset-aws.adoc#creating-windows-machineset-aws[compute machine set] or by specifying existing Bring-Your-Own-Host (BYOH) Window instances through a xref:../windows_containers/byoh-windows-instance.adoc#byoh-windows-instance[configuration map].
 

--- a/windows_containers/windows-containers-release-notes-6-x.adoc
+++ b/windows_containers/windows-containers-release-notes-6-x.adoc
@@ -9,21 +9,23 @@ toc::[]
 [id="about-windows-containers"]
 == About {productwinc}
 
-Windows Container Support for Red Hat OpenShift enables running Windows compute nodes in an {product-title} cluster. Running Windows workloads is possible by using the Red Hat Windows Machine Config Operator (WMCO) to install and manage Windows nodes. With Windows nodes available, you can run Windows container workloads in {product-title}.
+[role="_abstract"]
+You can use {productwinc} to run Windows compute nodes in an {product-title} cluster. With Windows nodes available, you can run Windows container workloads in {product-title}.
+
+Running Windows workloads is possible by using the Red Hat Windows Machine Config Operator (WMCO) to install and manage Windows nodes.
 
 The release notes for Red Hat OpenShift for Windows Containers tracks the development of the WMCO, which provides all Windows container workload capabilities in {product-title}.
 
 ifndef::openshift-origin[]
-[id="getting-support"]
-== Getting support
-
+Getting support::
++
 // wording taken and modified from https://access.redhat.com/support/policy/updates/openshift#windows
-
-Windows Container Support for Red Hat OpenShift is provided and available as an optional, installable component. Windows Container Support for Red Hat OpenShift is not part of the {product-title} subscription. It requires an additional Red Hat subscription and is supported according to the link:https://access.redhat.com/support/offerings/production/soc/[Scope of coverage] and link:https://access.redhat.com/support/offerings/production/sla[Service level agreements].
-
-You must have this separate subscription to receive support for Windows Container Support for Red Hat OpenShift. Without this additional Red Hat subscription, deploying Windows container workloads in production clusters is not supported. You can request support through the link:http://access.redhat.com/[Red Hat Customer Portal].
-
-For more information, see the Red Hat OpenShift Container Platform Life Cycle Policy document for link:https://access.redhat.com/support/policy/updates/openshift#windows[{productwinc}].
++
+{productwinc} is provided and available as an optional, installable component. {productwinc} is not part of the {product-title} subscription. It requires an additional Red Hat subscription and is supported according to the "Scope of coverage" and "Service level agreements". See the links in the _Additional resources_ section.
++
+You must have this separate subscription to receive support for {productwinc}. Without this additional Red Hat subscription, deploying Windows container workloads in production clusters is not supported. You can request support through the Red Hat Customer Portal. See the link in the _Additional resources_ section.
++
+For more information, see the "Red Hat {product-title} Life Cycle Policy" document for {productwinc}.
 
 If you do not have this additional Red Hat subscription, you can use the Community Windows Machine Config Operator, a distribution that lacks official support.
 endif::openshift-origin[]
@@ -33,23 +35,29 @@ endif::openshift-origin[]
 
 This release of the WMCO provides bug fixes for running Windows compute nodes in an {product-title} cluster. The components of the WMCO 6.0.0 were released in
 
-=== New features and improvements
-[id="wmco-6.0.0-node-certificates"]
-==== Windows node certificates are updated
+[id="wmco-6-0-0-new-features"]
+== New features and improvements
 
+Windows node certificates are updated::
 With this release, the WMCO updates the Windows node certificates when the kubelet client certificate authority (CA) certificate is rotated.
 
 [id="wmco-6-0-0-new-features"]
-=== New features
+== New features
 
-[id="wmco-6-0-0-containerd"]
-==== Containerd is the default container runtime
-
+Containerd is the default container runtime::
 Because the Docker runtime is deprecated in Kubernetes 1.24, containerD is now the default runtime for WMCO-supported Windows nodes. Upon the installation of or an upgrade to WMCO 6.0.0, containerd is installed as a Windows service. The kubelet now uses containerd for image pulls instead of the Docker runtime. Users no longer need to enable the Docker-formatted container runtime or install the Docker container runtime on Bring-Your-Own-Host (BYOH) instances. You can continue to use nodes based on VM images that use Docker. containerd can run along with the Docker service.
-
++
 The WMCO supports a Windows golden image with or without Docker for vSphere and Bring-Your-Own-Host (BYOH) Windows instances.
 
 include::modules/wmco-prerequisites.adoc[leveloffset=+1]
 
 include::modules/windows-containers-release-notes-limitations.adoc[leveloffset=+1]
 
+[role="_additional-resources"]
+[id="additional-resources_{context}"]
+== Additional resources
+
+* link:https://access.redhat.com/support/offerings/production/soc/[Scope of coverage]
+* link:https://access.redhat.com/support/offerings/production/sla[Service level agreements]
+* link:http://access.redhat.com/[Red Hat Customer Portal]
+* link:https://access.redhat.com/support/policy/updates/openshift#windows[{productwinc}]

--- a/windows_containers/windows-containers-support.adoc
+++ b/windows_containers/windows-containers-support.adoc
@@ -9,10 +9,13 @@ toc::[]
 
 // wording taken and modified from https://access.redhat.com/support/policy/updates/openshift#windows
 
-Windows Container Support for Red{nbsp}Hat OpenShift is provided and available as an optional, installable component. Windows Container Support for Red{nbsp}Hat OpenShift is not part of the {product-title} subscription. It requires an additional Red{nbsp}Hat subscription and is supported according to the link:https://access.redhat.com/support/offerings/production/soc/[Scope of coverage] and link:https://access.redhat.com/support/offerings/production/sla[Service level agreements].
+[role="_abstract"]
+You must have an additional Red{nbsp}Hat subscription in order to receive support for {productwinc}.
 
-You must have this separate subscription to receive support for Windows Container Support for Red{nbsp}Hat OpenShift. Without this additional Red{nbsp}Hat subscription, deploying Windows container workloads in production clusters is not supported. You can request support through the link:http://access.redhat.com/[Red{nbsp}Hat Customer Portal].
+{productwinc} is provided and available as an optional, installable component. {productwinc} is not part of the {product-title} subscription. It requires an additional Red{nbsp}Hat subscription and is supported according to the "Scope of coverage" and "Service level agreements". See the links in the _Additional resources_ section.
 
-For more information, see the Red{nbsp}Hat {product-title} Life Cycle Policy document for link:https://access.redhat.com/support/policy/updates/openshift#windows[{productwinc}].
+You must have this separate subscription to receive support for {productwinc}. Without this additional Red{nbsp}Hat subscription, deploying Windows container workloads in production clusters is not supported. You can request support through the Red{nbsp}Hat Customer Portal. See the link in the _Additional resources_ section.
+
+For more information, see the Red{nbsp}Hat {product-title} Life Cycle Policy document for {productwinc}. See the link in the _Additional resources_ section.
 
 If you do not have this additional Red{nbsp}Hat subscription, you can use the Community Windows Machine Config Operator, a distribution that lacks official support.

--- a/windows_containers/wmco_rn/windows-containers-release-notes-limitations.adoc
+++ b/windows_containers/wmco_rn/windows-containers-release-notes-limitations.adoc
@@ -4,7 +4,10 @@
 = Windows Machine Config Operator known limitations
 include::_attributes/common-attributes.adoc[]
 
-Note the following limitations when working with Windows nodes managed by the WMCO (Windows nodes):
+[role="_abstract"]
+You should familiarize yourself with the set of known limitations when working with Windows nodes managed by the Windows Machine Config Operator (WMCO).
+
+Note the following limitations when working with Windows nodes:
 
 * The following {product-title} features are not supported on Windows nodes:
 // ** Red Hat OpenShift Developer CLI (odo)
@@ -18,8 +21,8 @@ Note the following limitations when working with Windows nodes managed by the WM
 ** Hosted Control Planes
 
 * The following Red Hat features are not supported on Windows nodes:
-** link:https://docs.redhat.com/en/documentation/cost_management_service/1-latest[{red-hat-lightspeed} cost management]
-** link:https://developers.redhat.com/products/openshift-local/overview[Red Hat OpenShift Local]
+** {red-hat-lightspeed} cost management
+** {openshift-local-productname}
 
 * Dual NIC is not supported on WMCO-managed Windows instances.
 
@@ -31,9 +34,17 @@ Note the following limitations when working with Windows nodes managed by the WM
 
 * Due to a limitation within the Windows operating system, `clusterNetwork` CIDR addresses of class E, such as `240.0.0.0`, are not compatible with Windows nodes.
 
-* Kubernetes has identified the following link:https://kubernetes.io/docs/concepts/windows/intro/#limitations[node feature limitations] :
+* Kubernetes has identified the following node feature limitations. For more information, see "Compatibility and limitations (Kubernetes documenation)" in the _Additional resources_ section.
 ** Huge pages are not supported for Windows containers.
 ** Privileged containers are not supported for Windows containers.
 ** Pod termination grace periods require the containerd container runtime to be installed on the Windows node.
 
-* Kubernetes has identified link:https://kubernetes.io/docs/concepts/windows/intro/#api[several API compatibility issues].
+* Kubernetes has identified several API compatibility issues. For more information, see "API compatibility (Kubernetes documenation)" in the _Additional resources_ section.
+
+[role="_additional-resources"]
+[id="additional-resources_{context}"]
+== Additional resources
+* link:https://docs.redhat.com/en/documentation/cost_management_service/1-latest[{red-hat-lightspeed} cost management]
+* link:https://developers.redhat.com/products/openshift-local/overview[{openshift-local-productname}]
+* link:https://kubernetes.io/docs/concepts/windows/intro/#limitations[Compatibility and limitations (Kubernetes documenation)]
+* link:https://kubernetes.io/docs/concepts/windows/intro/#api[API compatibility (Kubernetes documenation)]

--- a/windows_containers/wmco_rn/windows-containers-release-notes-past.adoc
+++ b/windows_containers/wmco_rn/windows-containers-release-notes-past.adoc
@@ -7,9 +7,10 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 // Release notes for past versions; cut and paste current version to top of this file for next release
-The following release notes are for previous versions of the Windows Machine Config Operator (WMCO).
+[role="_abstract"]
+You can review the following release notes to learn about changes in previous versions of the Windows Machine Config Operator.
 
-For the current version, see xref:../../windows_containers/wmco_rn/windows-containers-release-notes.adoc#windows-containers-release-notes[{productwinc} release notes].
+For the current {productwinc} release notes, use the link in the _Additional resources_ section.
 
 [id="wmco-10-x-x-past-release-notes"]
 == Release notes for Red Hat Windows Machine Config Operator 10.x.0
@@ -17,9 +18,13 @@ For the current version, see xref:../../windows_containers/wmco_rn/windows-conta
 This release of the WMCO provides bug fixes for running Windows compute nodes in an {product-title} cluster. The components of the WMCO 10.x.0 were released in
 
 [id="wmco-10-x-x-past-new-features"]
-=== New features and improvements
+== New features and improvements
 
 [id="wmco-10-x-x-past-bug-fixes"]
-=== Bug fixes
+== Bug fixes
 
+[role="_additional-resources"]
+[id="additional-resources_{context}"]
+== Additional resources
 
+* xref:../../windows_containers/wmco_rn/windows-containers-release-notes.adoc#windows-containers-release-notes[{productwinc} release notes]

--- a/windows_containers/wmco_rn/windows-containers-release-notes-prereqs.adoc
+++ b/windows_containers/wmco_rn/windows-containers-release-notes-prereqs.adoc
@@ -4,12 +4,13 @@
 = Windows Machine Config Operator prerequisites
 include::_attributes/common-attributes.adoc[]
 
+[role="_abstract"]
 The following information details the supported platform versions, Windows Server versions, and networking configurations for the Windows Machine Config Operator (WMCO). See the vSphere documentation for any information that is relevant to only that platform.
 
 [id="wmco-prerequisites-supported_{context}"]
 == WMCO supported platforms and Windows Server versions
 
-The following table lists the link:https://docs.microsoft.com/en-us/windows/release-health/windows-server-release-info[Windows Server versions] that are supported by WMCO, based on the applicable platform. Windows Server versions not listed are not supported and attempting to use them will cause errors. To prevent these errors, use only an appropriate version for your platform.
+The following table lists the Windows Server versions that are supported by WMCO, based on the applicable platform. Windows Server versions not listed are not supported and attempting to use them will cause errors. To prevent these errors, use only an appropriate version for your platform.
 
 [cols="3,7",options="header"]
 |===
@@ -17,28 +18,28 @@ The following table lists the link:https://docs.microsoft.com/en-us/windows/rele
 |Supported Windows Server version
 
 |Amazon Web Services (AWS)
-a|* Windows Server 2022, OS Build link:https://support.microsoft.com/en-us/topic/april-25-2022-kb5012637-os-build-20348-681-preview-2233d69c-d4a5-4be9-8c24-04a450861a8d[20348.681] or later ^[1]^
+a|* Windows Server 2022, OS Build 20348.681 or later ^[1]^
 * Windows Server 2019, version 1809
 
 |Microsoft Azure
-a|* Windows Server 2022, OS Build link:https://support.microsoft.com/en-us/topic/april-25-2022-kb5012637-os-build-20348-681-preview-2233d69c-d4a5-4be9-8c24-04a450861a8d[20348.681] or later
+a|* Windows Server 2022, OS Build 20348.681 or later
 * Windows Server 2019, version 1809
 
 |VMware vSphere
-|Windows Server 2022, OS Build link:https://support.microsoft.com/en-us/topic/april-25-2022-kb5012637-os-build-20348-681-preview-2233d69c-d4a5-4be9-8c24-04a450861a8d[20348.681] or later
+|Windows Server 2022, OS Build 20348.681 or later
 
 |{gcp-first}
-|Windows Server 2022, OS Build link:https://support.microsoft.com/en-us/topic/april-25-2022-kb5012637-os-build-20348-681-preview-2233d69c-d4a5-4be9-8c24-04a450861a8d[20348.681] or later
+|Windows Server 2022, OS Build 20348.681 or later
 
 |Nutanix
-|Windows Server 2022, OS Build link:https://support.microsoft.com/en-us/topic/april-25-2022-kb5012637-os-build-20348-681-preview-2233d69c-d4a5-4be9-8c24-04a450861a8d[20348.681] or later
+|Windows Server 2022, OS Build 20348.681 or later
 
 |Bare metal or provider agnostic
-a|* Windows Server 2022, OS Build link:https://support.microsoft.com/en-us/topic/april-25-2022-kb5012637-os-build-20348-681-preview-2233d69c-d4a5-4be9-8c24-04a450861a8d[20348.681] or later
+a|* Windows Server 2022, OS Build 20348.681 or later
 * Windows Server 2019, version 1809
 |===
 [.small]
-. For disconnected clusters, the Windows AMI must have the EC2LaunchV2 agent version 2.0.2107 or later installed. For more information, see the link:https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2launch-v2-install.html[Install the latest version of EC2Launch v2] in the AWS documentation.
+. For disconnected clusters, the Windows AMI must have the EC2LaunchV2 agent version 2.0.2107 or later installed. For more information, see "Install the latest version of EC2Launch v2 (AWS documentation)" in the _Additional resources_ section.
 
 == Supported networking
 
@@ -76,10 +77,18 @@ Hybrid networking with OVN-Kubernetes is the only supported networking configura
 |Supported Windows Server version
 
 |Default VXLAN port
-a|* Windows Server 2022, OS Build link:https://support.microsoft.com/en-us/topic/april-25-2022-kb5012637-os-build-20348-681-preview-2233d69c-d4a5-4be9-8c24-04a450861a8d[20348.681] or later
+a|* Windows Server 2022, OS Build 20348.681 or later
 * Windows Server 2019, version 1809
 
 |Custom VXLAN port
-|Windows Server 2022, OS Build link:https://support.microsoft.com/en-us/topic/april-25-2022-kb5012637-os-build-20348-681-preview-2233d69c-d4a5-4be9-8c24-04a450861a8d[20348.681] or later
+|Windows Server 2022, OS Build 20348.681 or later
 
 |===
+
+[role="_additional-resources"]
+[id="additional-resources_{context}"]
+== Additional resources
+
+* link:https://docs.microsoft.com/en-us/windows/release-health/windows-server-release-info[Windows Server release information (Microsoft documentation)]
+* link:https://support.microsoft.com/en-us/topic/april-25-2022-kb5012637-os-build-20348-681-preview-2233d69c-d4a5-4be9-8c24-04a450861a8d[Windows Server 2022, OS Build 20348.681]
+* link:https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2launch-v2-install.html[Install the latest version of EC2Launch v2 (AWS documentation)]

--- a/windows_containers/wmco_rn/windows-containers-release-notes.adoc
+++ b/windows_containers/wmco_rn/windows-containers-release-notes.adoc
@@ -11,13 +11,11 @@ toc::[]
 // Update the version numbers
 == Release notes for Red Hat Windows Machine Config Operator 10.x.0
 
+[role="_abstract"]
+You can review the release notes to learn about the changes introduced through each release of the {productwinc} and the Windows Machine Config Operator (WMCO).
+
 This release of the WMCO provides bug fixes for running Windows compute nodes in an {product-title} cluster. The components of the WMCO 10.x.0 were released in
 
-// Use as needed
-[id="wmco-new-features"]
-=== New features and improvements
+New features and improvements::
 
-// Use as needed
-[id="wmco-bug-fixes"]
-=== Bug fixes
-
+Bug fixes::


### PR DESCRIPTION
https://redhat.atlassian.net/browse/OSDOCS-16910

**REVIEWERS: These files are placeholder files. The "live" WMCO release note file are in each OCP feature branches. The changes here are to pass the Vale checks only.  Do not cherrypick.**

[Windows Machine Config Operator known limitations](https://113586--ocpdocs-pr.netlify.app/openshift-enterprise/latest/windows_containers/wmco_rn/windows-containers-release-notes-limitations)
[Release notes for past releases of the Windows Machine Config Operator](https://113586--ocpdocs-pr.netlify.app/openshift-enterprise/latest/windows_containers/wmco_rn/windows-containers-release-notes-past)
[Windows Machine Config Operator prerequisites](https://113586--ocpdocs-pr.netlify.app/openshift-enterprise/latest/windows_containers/wmco_rn/windows-containers-release-notes-prereqs)
[Red Hat OpenShift support for Windows Containers release notes](https://113586--ocpdocs-pr.netlify.app/openshift-enterprise/latest/windows_containers/wmco_rn/windows-containers-release-notes)
[Red Hat OpenShift support for Windows Containers overview](https://113586--ocpdocs-pr.netlify.app/openshift-enterprise/latest/windows_containers/index.html)
[Getting support](https://113586--ocpdocs-pr.netlify.app/openshift-enterprise/latest/windows_containers/windows-containers-support)
