### PR TITLE
CNV-68646: Golden images in heterogenous multi-arch clusters is now GA

### DIFF
--- a/modules/virt-about-architecture-defaults-heterogeneous-clusters.adoc
+++ b/modules/virt-about-architecture-defaults-heterogeneous-clusters.adoc
@@ -1,0 +1,41 @@
+// Module included in the following assemblies:
+//
+// * virt/storage/virt-boot-source-image-heterogeneous-clusters.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="virt-about-architecture-defaults-heterogeneous-clusters_{context}"]
+= Default architecture behavior in heterogeneous clusters
+
+[role="_abstract"]
+In a heterogeneous cluster, worker nodes run different CPU architectures, such as amd64 and arm64. A boot source image built for one architecture cannot start on a node with a different architecture.
+
+To prevent architecture mismatches, {VirtProductName} creates a separate boot source for each supported architecture, each represented by a `DataSource` object.
+
+[IMPORTANT]
+====
+If you have a heterogeneous cluster and do not enable the `enableMultiArchBootImageImport` feature gate, VMs might fail to start on nodes with a different architecture than the boot source image.
+====
+
+[id="data-sources-boot-source-images-heterogeneous-clusters_{context}"]
+== How data sources for boot source images work in heterogeneous clusters
+
+After you enable the `enableMultiArchBootImageImport` feature gate, the Scheduling, Scale, and Performance (SSP) Operator creates a new separate boot source for each supported architecture, represented by a `DataSource` object. For example, the `rhel9` boot source image gets the following data sources:
+
+* `rhel9-amd64`
+* `rhel9-arm64`
+
+The original name, such as `rhel9`, defaults to the boot source that matches the control-plane architecture. For example, if the control-plane nodes use `amd64`, then `rhel9` resolves to `rhel9-amd64`.
+
+Existing VM manifests and templates that use the original name, without an architecture suffix, continue to work without changes.
+
+For common boot sources that are provided by {VirtProductName}, the SSP Operator determines the supported architectures automatically. For custom boot sources that you add through the `HyperConverged` CR, you must specify the supported architectures by using the `ssp.kubevirt.io/dict.architectures` annotation.
+
+[id="default-architecture-standalone-vms_{context}"]
+== Default architecture for standalone VMs
+
+A VM that is not based on a boot source image, for example a VM from a container disk, HTTP source, upload, or clone, defaults to the control-plane architecture. The `spec.template.spec.architecture` field in the `VirtualMachine` manifest controls which architecture the VM uses.
+
+[id="default-architecture-standalone-data-volumes_{context}"]
+== Default architecture for standalone data volumes
+
+A `DataVolume` created directly from a registry source does not have a default architecture. Without an explicit architecture, CDI pulls whichever image variant the registry returns. The `spec.source.registry.platform.architecture` field in the `DataVolume` manifest controls which architecture to pull.

--- a/modules/virt-add-custom-boot-source-image-heterogeneous-cluster.adoc
+++ b/modules/virt-add-custom-boot-source-image-heterogeneous-cluster.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * virt/creating_vms_advanced/virt-boot-source-image-heterogeneous-clusters.adoc
+// * virt/storage/virt-boot-source-image-heterogeneous-clusters.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="virt-add-custom-boot-source-image-heterogeneous-cluster_{context}"]
@@ -9,12 +9,11 @@
 [role="_abstract"]
 Add a custom boot source image in a heterogeneous cluster by editing the `HyperConverged` custom resource (CR).
 
-:FeatureName: Boot source image support for heterogeneous clusters
-include::snippets/technology-preview.adoc[]
-
 .Prerequisites
 
+* You have access to the cluster as a user with `cluster-admin` permissions.
 * You have installed the {oc-first}.
+* You have enabled the `enableMultiArchBootImageImport` feature gate in the `HyperConverged` CR.
 
 .Procedure
 
@@ -25,7 +24,7 @@ include::snippets/technology-preview.adoc[]
 $ oc edit {HCOCliKind} kubevirt-hyperconverged -n {CNVNamespace}
 ----
 
-. Edit the `HyperConverged` CR, to add the custom boot source image. You must add the appropriate values for the `ssp.kubevirt.io/dict.architectures` annotation in the `dataImportCronTemplates` section. For example:
+. Edit the `HyperConverged` CR to add the custom boot source image. You must add the appropriate values for the `ssp.kubevirt.io/dict.architectures` annotation in the `dataImportCronTemplates` section. For example:
 +
 [source,yaml]
 ----
@@ -56,8 +55,22 @@ where:
 +
 `<architecture_list>`:: Specifies a comma-separated list of supported architectures for this image. For example, if the image supports `amd64` and `arm64` architectures, the value would be `"amd64,arm64"`.
 +
-[NOTE]
+[IMPORTANT]
 ====
-An image may support more architectures than you want to use in your cluster. You do not have to list all of the architectures an image supports, only those for which you want to create a boot source image.
+Only include architectures that are present on your worker nodes and supported by your registry image. You do not need to list every architecture an image supports. {VirtProductName} does not validate the declared architectures.
+
+The annotation is optional but strongly recommended. Without it, only one boot source is created, and missing annotations trigger `HCOGoldenImageWithNoArchitectureAnnotation`.
 ====
+
 . Save and exit the editor to update the `HyperConverged` CR.
+
+.Verification
+
+* Verify that architecture-suffixed data sources are created for the custom image by running the following command:
++
+[source,terminal,subs="attributes+"]
+----
+$ oc get datasources -n openshift-virtualization-os-images
+----
++
+Architecture-suffixed data sources for the custom image should appear in the output.

--- a/modules/virt-architecture-field-standalone-vms.adoc
+++ b/modules/virt-architecture-field-standalone-vms.adoc
@@ -1,0 +1,41 @@
+// Module included in the following assemblies:
+//
+// * virt/storage/virt-boot-source-image-heterogeneous-clusters.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="virt-architecture-field-standalone-vms_{context}"]
+= Architecture field for standalone virtual machines
+
+[role="_abstract"]
+To run a standalone VM on a specific architecture in a heterogeneous cluster, set the `spec.template.spec.architecture` field in the `VirtualMachine` manifest. If you do not set this field, the VM defaults to the control-plane architecture.
+
+This field applies to VMs created from container disks, HTTP sources, uploads, or clones. For VMs based on boot source images, the `DataSource` object resolves the architecture automatically.
+
+.Example `VirtualMachine` manifest with the `architecture` field
+
+[source,yaml]
+----
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: my-vm
+spec:
+  template:
+    spec:
+      architecture: <architecture>
+      domain:
+        devices: {}
+        memory:
+          guest: 512Mi
+        resources: {}
+      volumes:
+      - name: my-volume
+        containerDisk:
+          image: <container_disk_image>
+# ...
+----
+
+where:
+
+`<architecture>`:: Specifies the target architecture for the VM, for example `arm64`. If not specified, defaults to the control-plane architecture.
+`<container_disk_image>`:: Specifies the container disk image to use for the VM.

--- a/modules/virt-creating-dv-registry-heterogeneous-cluster.adoc
+++ b/modules/virt-creating-dv-registry-heterogeneous-cluster.adoc
@@ -1,0 +1,66 @@
+// Module included in the following assemblies:
+//
+// * virt/storage/virt-boot-source-image-heterogeneous-clusters.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="virt-creating-dv-registry-heterogeneous-cluster_{context}"]
+= Creating a data volume from a registry source in a heterogeneous cluster
+
+[role="_abstract"]
+To pull the correct architecture-specific image in a heterogeneous cluster, specify the architecture in the `DataVolume` manifest. This step is only required for data volumes that you create outside the boot source image pipeline.
+
+[NOTE]
+====
+Boot source images managed through the `HyperConverged` custom resource (CR) select the correct architecture automatically. You do not need to specify the architecture for those images.
+====
+
+.Prerequisites
+
+* You have installed the {oc-first}.
+
+.Procedure
+
+. Create a `DataVolume` manifest and save it as a YAML file:
++
+[source,yaml]
+----
+apiVersion: cdi.kubevirt.io/v1beta1
+kind: DataVolume
+metadata:
+  name: <datavolume_name>
+spec:
+  source:
+    registry:
+      url: <image_url>
+      platform:
+        architecture: <architecture>
+  storage:
+    resources:
+      requests:
+        storage: <storage_size>
+----
++
+where:
++
+`<datavolume_name>`:: Specifies the name of the data volume.
+`<image_url>`:: Specifies the URL of the container image, for example `docker://quay.io/containerdisks/centos-stream:9`.
+`<architecture>`:: Specifies the architecture of the image to pull, for example `amd64`, `arm64`, or `s390x`.
+`<storage_size>`:: Specifies the size of the storage requested, for example `10Gi`.
+
+. Create the data volume:
++
+[source,terminal]
+----
+$ oc create -f <datavolume_manifest>.yaml
+----
+
+.Verification
+
+* Verify that the data volume was created and is importing by running the following command:
++
+[source,terminal]
+----
+$ oc get dv <datavolume_name>
+----
++
+The `PHASE` column should show `ImportScheduled`, `ImportInProgress`, or `Succeeded`.

--- a/modules/virt-enabling-heterogeneous-clusters.adoc
+++ b/modules/virt-enabling-heterogeneous-clusters.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * virt/virtual_machines/advanced_vm_management/virt-creating-vms-from-rh-images-overview.adoc
+// * virt/storage/virt-boot-source-image-heterogeneous-clusters.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="virt-enabling-heterogeneous-clusters_{context}"]
@@ -8,9 +8,6 @@
 
 [role="_abstract"]
 You can enable boot source image support for heterogeneous clusters by setting the `enableMultiArchBootImageImport` feature gate to `true` in the `HyperConverged` custom resource (CR).
-
-:FeatureName: Boot source image support for heterogeneous clusters
-include::snippets/technology-preview.adoc[]
 
 .Prerequisites
 
@@ -27,3 +24,15 @@ $ oc patch {HCOCliKind} kubevirt-hyperconverged -n {CNVNamespace} \
   --type json -p '[{"op": "add", "path": "/spec/featureGates/-", \
   "value": {"name": "enableMultiArchBootImageImport"}}]'
 ----
+
+.Verification
+
+* Verify that the feature gate is enabled by running the following command:
++
+[source,terminal,subs="attributes+"]
+----
+$ oc get {HCOCliKind} kubevirt-hyperconverged -n {CNVNamespace} \
+  -o jsonpath='{.spec.featureGates[*].name}'
+----
++
+The output must include `enableMultiArchBootImageImport`.

--- a/modules/virt-mod-boot-source-image-heterogeneous-clusters.adoc
+++ b/modules/virt-mod-boot-source-image-heterogeneous-clusters.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * virt/creating_vms_advanced/virt-boot-source-image-heterogeneous-clusters.adoc
+// * virt/storage/virt-boot-source-image-heterogeneous-clusters.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="virt-mod-boot-source-image-heterogeneous-clusters_{context}"]
@@ -9,12 +9,11 @@
 [role="_abstract"]
 You can modify the source of a common boot source image in a heterogeneous cluster by specifying the supported architectures in the `ssp.kubevirt.io/dict.architectures` annotation in the `HyperConverged` custom resource (CR).
 
-:FeatureName: Boot source image support for heterogeneous clusters
-include::snippets/technology-preview.adoc[]
-
 .Prerequisites
 
+* You have access to the cluster as a user with `cluster-admin` permissions.
 * You have installed the {oc-first}.
+* You have enabled the `enableMultiArchBootImageImport` feature gate in the `HyperConverged` CR.
 
 .Procedure
 
@@ -25,7 +24,7 @@ include::snippets/technology-preview.adoc[]
 $ oc edit {HCOCliKind} kubevirt-hyperconverged -n {CNVNamespace}
 ----
 
-. Edit the `HyperConverged` CR, adding the appropriate values for `ssp.kubevirt.io/dict.architectures` annotation in the `dataImportCronTemplates` section. For example:
+. Edit the `HyperConverged` CR to add the appropriate values for the `ssp.kubevirt.io/dict.architectures` annotation in the `dataImportCronTemplates` section. For example:
 +
 [source,yaml]
 ----
@@ -53,3 +52,14 @@ where:
 `ssp.kubevirt.io/dict.architectures`:: Specifies a comma-separated list of supported architectures for this image. For example, if the image supports `amd64` and `arm64` architectures, the value would be `"amd64,arm64"`.
 
 . Save and exit the editor to update the `HyperConverged` CR.
+
+.Verification
+
+* Verify that architecture-suffixed data sources are created by running the following command:
++
+[source,terminal,subs="attributes+"]
+----
+$ oc get datasources -n openshift-virtualization-os-images
+----
++
+Architecture-suffixed data sources, such as `centos-stream8-amd64` and `centos-stream8-arm64`, should appear in the output.

--- a/modules/virt-modify-workload-node-heterogeneous-cluster.adoc
+++ b/modules/virt-modify-workload-node-heterogeneous-cluster.adoc
@@ -1,20 +1,17 @@
 // Module included in the following assemblies:
 //
-// * virt/virtual_machines/advanced_vm_management/virt-creating-vms-from-rh-images-overview.adoc
+// * virt/storage/virt-boot-source-image-heterogeneous-clusters.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="virt-modify-workload-node-heterogeneous-cluster_{context}"]
-
 = Modifying workloads node placement in a heterogeneous cluster
-
-:FeatureName: Boot source image support for heterogeneous clusters
-include::snippets/technology-preview.adoc[]
 
 [role="_abstract"]
 If you have a heterogeneous cluster but do not want to enable multiple architecture support, you can modify the workloads node placement in the `HyperConverged` custom resource (CR) to include only nodes with a specific architecture.
 
 .Prerequisites
 
+* You have access to the cluster as a user with `cluster-admin` permissions.
 * You have installed the {oc-first}.
 
 .Procedure
@@ -56,3 +53,15 @@ where:
 `<node_architecture>`:: Specifies the target architecture. For example, to limit placement to AMD nodes, use `amd64`.
 
 . Save and exit the editor to update the `HyperConverged` CR.
+
+.Verification
+
+* Verify that the node affinity is applied by running the following command:
++
+[source,terminal,subs="attributes+"]
+----
+$ oc get {HCOCliKind} kubevirt-hyperconverged -n {CNVNamespace} \
+  -o jsonpath='{.spec.deployment.nodePlacements.workload}'
+----
++
+The output should show the node affinity configuration with the architecture you specified.

--- a/virt/storage/virt-boot-source-image-heterogeneous-clusters.adoc
+++ b/virt/storage/virt-boot-source-image-heterogeneous-clusters.adoc
@@ -9,28 +9,31 @@ toc::[]
 [role="_abstract"]
 A heterogeneous cluster is a cluster where nodes have differing architectures. Heterogeneous clusters promote optimal compute resource usage by mixing different types of hardware in one cluster.
 
-:FeatureName: Boot source image support for heterogeneous clusters
-include::snippets/technology-preview.adoc[]
-
-With heterogeneous clusters, you can match workloads to hardware intended for the workload task instead of general purpose compute platforms. For example, GPU and general purpose compute resources could be combined and workloads assigned to the appropriate hardware.
-
-[IMPORTANT]
-====
-If boot source image support is disabled in a heterogeneous cluster, you can encounter inconsistencies between node and image architectures. This happens when images are used for virtual machine creation that do not match the node architecture. This can lead to the failure of virtual machine boot up or virtual machines that do not run as expected. The warning level alert `HCOMultiArchGoldenImagesDisabled` is produced when this feature is not enabled in a heterogeneous cluster.
-====
+With heterogeneous clusters, you can match workloads to hardware intended for the workload task instead of general purpose compute platforms. For example, you can combine GPU and general purpose compute resources and assign workloads to the appropriate hardware.
 
 If you have a heterogeneous cluster but do not want to enable multiple architecture support, you can modify the workloads node placement in the `HyperConverged` custom resource (CR) to include only nodes with a specific architecture.
 
-Boot source image support in heterogeneous clusters enables VM creators to deploy persistent VMs with specific architectures, and to define custom boot images that support heterogeneous clusters.
+With boot source image support, you can deploy persistent VMs with specific architectures and define custom boot images that support heterogeneous clusters.
+
+[IMPORTANT]
+====
+If you do not enable boot source image support in a heterogeneous cluster, images might not match the node architecture. As a result, virtual machines might fail to start or might not run as expected. {VirtProductName} raises the `HCOMultiArchGoldenImagesDisabled` alert when this feature is not enabled.
+====
 
 The same image can be used with nodes of different architectures if the boot image supports the required architectures. For example, a boot image that supports both ARM and AMD architectures can be used with both types of nodes.
 
 Boot source image support for heterogeneous clusters is not enabled by default. You can enable heterogeneous cluster support by setting the feature gate in the `HyperConverged` CR.
+
+include::modules/virt-about-architecture-defaults-heterogeneous-clusters.adoc[leveloffset=+1]
 
 include::modules/virt-enabling-heterogeneous-clusters.adoc[leveloffset=+1]
 
 include::modules/virt-mod-boot-source-image-heterogeneous-clusters.adoc[leveloffset=+1]
 
 include::modules/virt-add-custom-boot-source-image-heterogeneous-cluster.adoc[leveloffset=+1]
+
+include::modules/virt-creating-dv-registry-heterogeneous-cluster.adoc[leveloffset=+1]
+
+include::modules/virt-architecture-field-standalone-vms.adoc[leveloffset=+1]
 
 include::modules/virt-modify-workload-node-heterogeneous-cluster.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s):
Main, 4.22, 5.0

Issue:
[CNV-68646](https://redhat.atlassian.net/browse/CNV-68646)

[Link to docs preview](https://113596--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/storage/virt-boot-source-image-heterogeneous-clusters.html)

QE review:
- [x] QE has approved this change.

PR summary:

  Writing and content development

  - New module creation: I used AI to draft three new modules based on SME-provided technical details about how architecture defaults, standalone VMs, and standalone data volumes behave in heterogeneous clusters.
  - Assembly rewrite: I had AI rewrite the assembly intro for active voice and clearer information flow, and reorganize the include order.
  - I removed all TP snippets from the content.
  - Prerequisites and verification steps: I used AI to add missing cluster-admin prerequisites and .Verification sections to all procedure modules.

  User judgment applied

  - Reviewed all AI-drafted content for technical accuracy against the engineering spec and SME feedback.
  - Decided which architectural behaviors warranted standalone concept/reference modules vs. inline coverage.
  - Followed up with SME to find out whether there was missing content, or this should just be a TP admonition removal. There was actually quite a lot of content that needed to be added.
  - Reviewed AI-generated YAML examples as well as CLI commands. Made sure variables resolved to the correct attributes depending on the version.
  - Removed redundant HyperConverged CR references from the standalone data volumes concept to keep it in descriptive voice.

  Peer review with AI

  - DITA compliance: Verified content type classification (CONCEPT, PROCEDURE, REFERENCE) for all new and modified modules; confirmed anchor IDs match filenames with {context} variable; confirmed assembly-level
  metadata is correct.
  - Style review: Checked against CQA 2.1, Red Hat SSG, and IBM Style Guide for active voice, abstract length, conscious language, and code block formatting.
  - Technical/security review: Validated CLI commands, YAML manifests, and API field paths against the KubeVirt and CDI schemas; confirmed no unsafe examples or missing failure paths.
