### PR TITLE
OBSDOCS-3517: Fix incorrect apiVersion in LokiStack CR example

### DIFF
--- a/modules/configuring-tls-ca-bundle-for-object-storage.adoc
+++ b/modules/configuring-tls-ca-bundle-for-object-storage.adoc
@@ -54,7 +54,7 @@ $ oc create configmap loki-s3-ca-bundle \
 +
 [source,yaml]
 ----
-apiVersion: loki.storage.openshift.io/v1
+apiVersion: loki.grafana.com/v1
 kind: LokiStack
 metadata:
   name: logging-loki


### PR DESCRIPTION
## Summary

Fixes the incorrect `apiVersion` in the LokiStack CR YAML example in the "Configuring a TLS CA bundle for object storage" section.

**Bug:** The example specifies `apiVersion: loki.storage.openshift.io/v1`, which is a non-existent API group.
**Fix:** Changed to `apiVersion: loki.grafana.com/v1`, which is the correct API group defined by the Loki Operator CRD.

## Evidence

- All other LokiStack examples in the documentation (15+ files) correctly use `loki.grafana.com/v1`
- The Loki Operator CRD defines the resource under `loki.grafana.com/v1`
- The API group `loki.storage.openshift.io` is not registered by any operator

## Jira

- [OBSDOCS-3517](https://redhat.atlassian.net/browse/OBSDOCS-3517)

## Cherry-pick branches

- standalone-logging-docs-6.6
- standalone-logging-docs-6.5
- standalone-logging-docs-6.4


Made with [Cursor](https://cursor.com)