### PR TITLE
HCIDOCS-731-NEW: Include create-resource-attribution-tags step

### DIFF
--- a/modules/creating-oci-resources-services.adoc
+++ b/modules/creating-oci-resources-services.adoc
@@ -24,18 +24,26 @@ Before installing {product-title} using Assisted Installer, create the necessary
 .. Create a new object storage bucket into which you will upload the discovery ISO image.
 For the full procedure, see link:https://docs.oracle.com/en-us/iaas/Content/Object/Tasks/managingbuckets_topic-To_create_a_bucket.htm#top[Creating an Object Storage Bucket (Oracle documentation)].
 
-. Download the latest version of the `create-cluster-vX.X.X.zip` configuration file from the link:https://github.com/oracle-quickstart/oci-openshift[`oracle-quickstart/oci-openshift`] repository. This file
-provides the infrastructure for the cluster and contains configurations for the following:
+. Download the latest versions of the following configuration files from the link:https://github.com/oracle-quickstart/oci-openshift/releases[`oracle-quickstart/oci-openshift`] releases page:
+
+** `create-resource-attribution-tags-vX.X.X.zip`: The Terraform stack for creating the required resource attribution tags in your {oci} tenancy.
++
+[IMPORTANT]
+====
+Resource attribution tags are mandatory for {product-title} on {oci-distributed-no-rt}. If you have not previously applied the `create-resource-attribution-tags` stack in your tenancy, you must download and apply it before proceeding. After the tags exist, later cluster deployments can reuse them. For more details, see link:https://github.com/oracle-quickstart/oci-openshift?tab=readme-ov-file#prerequisites[OpenShift on OCI (OSO) Prerequisites].
+====
+
+** `create-cluster-vX.X.X.zip`: The Terraform stack and custom manifests for provisioning {oci} resources and installing {product-title} clusters on {oci-distributed-no-rt}.
++
+The `create-cluster` configuration file contains the following:
 +
 --
-** *Terraform Stacks*: The Terraform stack code for provisioning {oci} resources to create and manage {product-title} clusters on {oci-distributed-no-rt}.
+*** *Terraform Stacks*: The Terraform stack code for provisioning {oci} resources to create and manage {product-title} clusters on {oci-distributed-no-rt}.
 
-** *Custom Manifests*: The manifest files needed for the installation of {product-title} clusters on {oci-distributed-no-rt}.
+*** *Custom Manifests*: The manifest files needed for the installation of {product-title} clusters on {oci-distributed-no-rt}.
 --
 +
 [NOTE]
 ====
-To make any changes to the manifests, you can clone the entire Oracle GitHub repository and access the `custom_manifests` and `terraform-stacks` directories directly.
+To make any changes to the manifests, you can clone the entire Oracle GitHub repository and access the `custom_manifests` and `terraform-stacks` directories directly. For details, see link:https://docs.oracle.com/iaas/Content/openshift-on-oci/install-prereq.htm#install-configuration-files[Configuration Files (Oracle documentation)].
 ====
-+
-For details, see link:https://docs.oracle.com/iaas/Content/openshift-on-oci/install-prereq.htm#install-configuration-files[Configuration Files (Oracle documentation)].

--- a/modules/provision-oci-infrastructure-ocp-cluster.adoc
+++ b/modules/provision-oci-infrastructure-ocp-cluster.adoc
@@ -29,7 +29,22 @@ When using the {ai-full} to create details for your {product-title} cluster, you
 +
 For the full procedure, see link:https://docs.oracle.com/en-us/iaas/Content/Object/Tasks/usingpreauthenticatedrequests_topic-To_create_a_preauthenticated_request_for_all_objects_in_a_bucket.htm[Creating a Pre-Authenticated Requests in Object Storage (Oracle documentation)].
 
-. Create and apply the Terraform stack:
+. If you have not already done so, apply the `create-resource-attribution-tags` Terraform stack to create the required resource attribution tags:
++
+[IMPORTANT]
+====
+Resource attribution tags are mandatory for {product-title} on {oci-distributed-no-rt}. If the tags do not already exist in your tenancy, you must apply the `create-resource-attribution-tags` stack before creating the cluster. You typically apply this stack once for the first cluster deployment in a tenancy. After the tags exist, later cluster deployments can reuse them.
+====
++
+--
+.. In the {oci-distributed-no-rt} console, navigate to *Resource Manager* -> *Stacks* and click *Create Stack*.
+.. Upload the `create-resource-attribution-tags-vX.X.X.zip` file and click *Next*.
+.. Click *Apply* to create the resource attribution tags.
+--
++
+For details, see link:https://github.com/oracle-quickstart/oci-openshift/tree/main/terraform-stacks/create-resource-attribution-tags[create-resource-attribution-tags (Oracle GitHub)].
+
+. Create and apply the `create-cluster` Terraform stack:
 +
 [IMPORTANT]
 ====


### PR DESCRIPTION
Summary of changes:
-  Preparing the Oracle Distributed Cloud environment (creating-oci-resources-services.adoc) - Added a bullet for downloading the 'create-resource-attribution-tags' stack to step 3.
- Provisioning OCI infrastructure for your cluster (provision-oci-infrastructure-ocp-cluster.adoc) - Added step 4 for applying the 'create-resource-attribution-tags' stack.

Version(s):
main, 4.23, 4.22, 4.21

Issue:
https://redhat.atlassian.net/browse/HCIDOCS-731

Link to docs preview:
https://113620--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_oci/installing-oci-assisted-installer.html

Contacts:
- Reporter/SME: Ayush Garg
- QE: Benny Kopilov

QE review:
- [X ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
