### PR TITLE
OSDOCS-19889: gets RHCL 1.5.0 release note template ready

### DIFF
--- a/_attributes/attributes.adoc
+++ b/_attributes/attributes.adoc
@@ -11,15 +11,15 @@
 :prodnamefull: {rh} {prodname}
 :productpkg: red_hat_connectivity_link
 :mcpg: MCP gateway
-:mcpg-version: 0.7.0
+:mcpg-version: 1.0
 
-:version: 1.4
-:version-2: 1.2
-:version-1: 1.3.x
-:operator-version: 1.4.0
+:version: 1.5
+:version-2: 1.3
+:version-1: 1.4.x
+:operator-version: 1.5.0
 :ocp: OpenShift Container Platform
-:ocp-latest-version: 4.22
-:ocp-min-version: 4.18
+:ocp-latest-version: 5.0
+:ocp-min-version: 4.19
 :oc-first: pass:quotes[OpenShift CLI (`oc`)]
 
 :OTELName: Red{nbsp}Hat build of OpenTelemetry

--- a/modules/ref-relnotes-about.adoc
+++ b/modules/ref-relnotes-about.adoc
@@ -7,10 +7,6 @@
 = About this release
 
 [role="_abstract"]
-{rh} {prodname} {version}, link:https://access.redhat.com/errata/RHBA-2026:25234[RHBA-2026:25234], is now available. This release includes the {mcpg} {mcpg-version} as a Technology Preview feature. New features, changes, and known issues that pertain to {prodname} {version} are included in this topic.
+{rh} {prodname} {version}, link:https://access.redhat.com/errata/RHBA-2026:XXXXX[RHBA-2026:XXXXX], is now available. This release includes the {mcpg} {mcpg-version} as a Generally Available feature. New features, changes, and known issues that pertain to {prodname} {version} are included in this topic.
 
-Starting with {prodname} {version}, full support ends with the release of the next minor version. Maintenance support ends with the minor version after that. See the link:https://access.redhat.com/RedHatConnectivityLink[Red Hat Connectivity Link Life Cycle Policy] for details about version support and {ocp} compatibility.
-
-Important lifecycle update for {prodname} 1.3::
-
-With this release, the maintenance support lifecycle for {prodname} 1.3 is updated. Maintenance Support for version 1.3 ends with the release of {prodname} 1.5. The maintenance lifecycle of 1.3 was announced before as ending with {prodname} 1.6.
+Full support ends with the release of the next minor version. Maintenance support ends with the minor version after that. See the link:https://access.redhat.com/RedHatConnectivityLink[Red Hat Connectivity Link Life Cycle Policy] for details about version support and {ocp} compatibility.

--- a/modules/ref-relnotes-intro.adoc
+++ b/modules/ref-relnotes-intro.adoc
@@ -7,6 +7,6 @@
 = {product-title} {version} release notes
 
 [role="_abstract"]
-{prodname} is a modular and flexible solution for application connectivity, policy management, and API management in multicloud and hybrid cloud environments. You can use {prodname} to secure, protect, connect, and observe your APIs, applications, and infrastructure.
+{rh} {prodname} is a modular and flexible solution for application connectivity, policy management, and API management in multicloud and hybrid cloud environments. You can use {prodname} to secure, protect, connect, and observe your APIs, applications, and infrastructure.
 
 {prodname} is based on the link:https://kuadrant.io/[Kuadrant] community project, providing a control plane for you to configure and deploy ingress gateways and policies based on the link:https://gateway-api.sigs.k8s.io/[Kubernetes Gateway API] standard. {prodname} supports link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_mesh/{service-mesh-version}/html-single/about/index[{service-mesh} {service-mesh-version}] as the Gateway API provider, which is based on the link:https://istio.io/[Istio] community project.

--- a/modules/ref-relnotes-known-issues.adoc
+++ b/modules/ref-relnotes-known-issues.adoc
@@ -7,6 +7,6 @@
 = Known issues
 
 [role="_abstract"]
-{prodname} {version} has a known issue.
+{prodname} {version} has the following known issues.
 
-* When either the `Redis` or `RedisCached` storage option is set in a `Limitador` CR and the `limitador` pod gets restarted for any reason, the first request to the gateway is never rate-limited. All `http` requests after this are rate-limited. (link:https://issues.redhat.com/browse/CONNLINK-856[CONNLINK-856])
+//* use text and link format, the same as bugs

--- a/modules/ref-relnotes-new-features.adoc
+++ b/modules/ref-relnotes-new-features.adoc
@@ -9,38 +9,15 @@
 [role="_abstract"]
 You can use the new features and enhancements that are available with {product-title} {version}.
 
-X.509 cryptographic identity verification now available::
+//placeholder feature::
 
-With this {prodname} release, you can use X.509 client certificate authentication with for strong cryptographic identity verification. The X.509 format creates a two-layer authentication process that requires both cryptographic proof and context-aware validation before a request authenticates.
+//placeholder text
 
-For more information, see xref:../deployment/rhcl-using-x509-crypt-id-verify.adoc#rhcl-using-x509-crypt-id-verify[Using X.509 cryptographic identity verification].
+//For more information, see xref:../.
 
-MCP gateway: MCP prompt federation is now available::
 
-{mcpg} adds support for federating MCP prompts through the `Gateway` object as a Generally Available feature. MCP prompt federation makes it much easier to supply your large language models (LLMs) with the exact context and steering instructions they need, no matter which server originally hosted the template.
-+
-With this update, you can now access and run prompt templates from your upstream MCP servers through a single, central `Gateway` connection. Instead of managing separate connections to multiple backend servers, you can query the `Gateway` object to see a unified, prefixed list of every available prompt across your network. When you find the prompt template that you need, you can plug in your custom variables. The `Gateway` object automatically routes the request to the right place.
+//Notable technical changes::
 
-For more information, see xref:../mcp_gateway_config/mcp-gateway-register-on-prem-mcp-servers.adoc#mcp-gateway-register-on-prem-mcp-servers[Registering on-prem MCP servers].
-
-MCP gateway: Vault documentation now included::
-
-Now you can learn how to use HashiCorp Vault (Vault) to retrieve and inject authentication credentials into your MCP server request flow with the MCP gateway.
-
-For more information see xref:../mcp_gateway_config/mcp-gateway-vault.adoc#mcp-gateway-vault[Using credentials to access external APIs with Vault].
-
-MCP gateway audit trail documentation is now available::
-
-The {mcpg} documentation now includes configuration instructions for creating an audit trail for compliance and accountability that captures caller identity, tool names, and MCP session context through the MCP gateway.
-
-For more information, see xref:../observe/mcp-gateway-observe.adoc#con-mcp-gateway-audit-trail_mcp-gateway-observe[Understanding an MCP gateway audit trail].
-
-Notable technical changes::
-
-*{prodname}*: The gateway integration has been migrated from an Istio `WasmPlugin` to `EnvoyFilter` custom resources (CRs). WASM injection now uses `EnvoyFilter` patches. This enables native support for image pull secrets and allows for embedded plugin configurations directly within the patches. This is an internal Operator change. No user action is required during an update. Existing CRs might remain in your cluster as orphans.
-+
-*{prodname}*: To improve performance and scalability, the Kuadrant CR lookup is cached within the reconciliation state. This internal optimization reduces redundant `get` requests to the Kubernetes API server during reconciliation loops. This change reduces control plane utilization and consumption, reduces Operator resource usage, and makes policy reconciliation times faster.
-+
-*MCP gateway*: The `toolPrefix` field on the `MCPServerRegistration` CR is renamed `prefix`. This field has always been a server-level namespace, not tool-specific, and the rename aligns the API with its actual semantics now that it applies to both tools and prompts.
-+
-Migration: You must replace `toolPrefix` with `prefix` in your `MCPServerRegistration` CRs. Existing CRs must be deleted and recreated, not patched in-place. For bulk updates, you can use a `sed` one-liner or `yq edit` on these manifest files before you run the `oc apply` command.
+//*{prodname}*: placeholder
+//+
+//*{mcpg}: placeholder

--- a/modules/ref-relnotes-tech-preview.adoc
+++ b/modules/ref-relnotes-tech-preview.adoc
@@ -16,20 +16,8 @@ Technology Preview features are not supported with Red Hat production service le
 Technology Preview features give you early access to upcoming product features, enabling you to test functionality and provide feedback during the development process. For more information, see https://access.redhat.com/support/offerings/techpreview[{rh} Technology Preview Features - Scope of Support].
 ====
 
-Support for `GRPCRoute` policy attachment::
+//placeholder feature::
 
-With this {prodname} release, `GRPCRoute` policy attachment support is available as a Technology Preview feature. You can attach `AuthPolicy` and `RateLimitPolicy` custom resources (CRs) to `GRPCRoute` CRs, enabling authentication and rate-limiting controls for gRPC services with native `service` and `method` matching.
+//placeholder text
 
-For more information, see xref:../deployment/deployment.adoc#con-about-grpc-support_rhcl-config-deploy-gateway-policies[About GRPCRoute policy attachment support].
-
-Disconnected installation documentation added::
-
-The {prodname} documentation now includes procedures for installing in a disconnected environment. You can apply cloud-like traffic management within your private, secure network.
-
-For more information, see xref:../install-rhcl/rhcl-install-disconnected.adoc#rhcl-install-disconnected[Installing Connectivity Link in a disconnected environment].
-
-{prodname} {ocp} web console plugin adds API management::
-
-With this {prodname} release, you can use the {ocp} web console to manage your APIs and access to them with the OpenShift web console. You can manage an API catalog and role-based access. You can also see the relationships between your API products and attached resources, such as policies and routes, in a dynamic graph view.
-
-For more information, see xref:../develop/rhcl-api-management.adoc#rhcl-api-management[Create, share, and consume APIs across teams].
+//For more information, see xref:../.

--- a/modules/rhcl-relnotes-z-stream.adoc
+++ b/modules/rhcl-relnotes-z-stream.adoc
@@ -9,6 +9,6 @@
 [role="_abstract"]
 Security, bug fix, and enhancement updates for {product-title} {version} are released asynchronously through the Red{nbsp}Hat Network. All {product-title} {version} updates are available on the Red{nbsp}Hat Customer Portal. For more information about asynchronous updates, read the link:https://access.redhat.com/RedHatConnectivityLink[Red Hat Connectivity Link Life Cycle Policy].
 
-Red{nbsp}Hat Customer Portal users can enable update notifications in the account settings for Red{nbsp}Hat Subscription Management (RHSM). When notifications are enabled, you are notified through email whenever new updates relevant to your registered systems are released.
+Red{nbsp}Hat Customer Portal users can enable update notifications in the account settings for Red{nbsp}Hat Subscription Management (RHSM). When you enable notifications, you are notified through email whenever new updates relevant to your registered systems are released.
 
-This section is updated over time to provide notes on enhancements and bug fixes for future asynchronous releases of {product-title} {version}. Versioned asynchronous releases, for example with the {product-title} 1.4.z, are detailed in the following subsections.
+This section is updated over time to provide notes on enhancements and bug fixes for future asynchronous releases of {product-title} {version}. Versioned asynchronous releases, titled in the form {product-title} 1.5.z, are detailed in the following subsections.

--- a/release_notes/rhcl-release-notes.adoc
+++ b/release_notes/rhcl-release-notes.adoc
@@ -1,11 +1,11 @@
 :_mod-docs-content-type: ASSEMBLY
 include::_attributes/attributes.adoc[]
 [id="rhcl-release-notes"]
-= {product-title} {version} release notes
+= {rh} {prodname} {version} release notes
 :context: rhcl-release-notes
 
 [role="_abstract"]
-Welcome to the {product-title} release notes, where you can learn about what is new and what is fixed.
+Welcome to the {rh} {prodname} release notes, where you can learn about what is new and what is fixed.
 
 include::modules/ref-relnotes-intro.adoc[leveloffset=+1]
 
@@ -15,8 +15,8 @@ include::modules/ref-relnotes-new-features.adoc[leveloffset=+2]
 
 include::modules/ref-relnotes-tech-preview.adoc[leveloffset=+2]
 
-//include::modules/ref-relnotes-bug-fixes.adoc[leveloffset=+2]
+include::modules/ref-relnotes-bug-fixes.adoc[leveloffset=+2]
 
 include::modules/ref-relnotes-known-issues.adoc[leveloffset=+2]
 
-//include::modules/rhcl-relnotes-z-stream.adoc[leveloffset=+2]
+include::modules/rhcl-relnotes-z-stream.adoc[leveloffset=+2]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
rhcl-docs-1.5

Issue:
[OSDOCS-19889](https://redhat.atlassian.net/browse/OSDOCS-19889)

Link to docs preview:
https://113629--ocpdocs-pr.netlify.app/rhcl/latest/release_notes/rhcl-release-notes.html

QE review:
N/A preliminary file setup only (RHCL relnotes are made in `main` and CP'd up; will finalize versions and advisory numbers close to release)

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
