### PR TITLE
Service_Mesh _v2.6.17

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -209,7 +209,7 @@ endif::[]
 :product-rosa: Red{nbsp}Hat OpenShift Service on AWS
 :SMProductName: Red{nbsp}Hat OpenShift Service Mesh
 :SMProductShortName: Service Mesh
-:SMProductVersion: 2.6.16
+:SMProductVersion: 2.6.17
 :MaistraVersion: 2.6
 :KialiProduct: Kiali Operator provided by Red Hat
 :SMPlugin: OpenShift Service Mesh Console (OSSMC) plugin

--- a/modules/ossm-release-2-6-16.adoc
+++ b/modules/ossm-release-2-6-16.adoc
@@ -11,8 +11,6 @@ This release of {SMProductName} updates the {SMProductName} Operator version to 
 
 This release addresses Common Vulnerabilities and Exposures (CVEs) and is supported on {product-title} 4.14, 4.16, 4.18, and 4.19.
 
-include::snippets/ossm-current-version-support-snippet.adoc[]
-
 You can use the most current version of the {KialiProduct} with all supported versions of {SMProductName}. The version of {SMProductShortName} automatically ensures a compatible version of Kiali.
 
 [id="ossm-release-2-6-16-components_{context}"]

--- a/modules/ossm-release-2-6-17.adoc
+++ b/modules/ossm-release-2-6-17.adoc
@@ -1,0 +1,32 @@
+// Module included in the following assemblies:
+//
+// * service_mesh/v2x/servicemesh-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="ossm-release-2-6-17_{context}"]
+= {SMProductName} version 2.6.17
+
+[role="_abstract"]
+This release of {SMProductName} updates the {SMProductName} Operator to version 2.6.17 and includes the `ServiceMeshControlPlane` resource version updates for 2.6.17.
+
+This release addresses Common Vulnerabilities and Exposures (CVEs) and is supported on {product-title} versions 4.14, 4.16, 4.18, and 4.19.
+
+include::snippets/ossm-current-version-support-snippet.adoc[]
+
+You can use the most current version of the {KialiProduct} with all supported versions of {SMProductName}. The version of {SMProductShortName} automatically ensures a compatible version of Kiali.
+
+[id="ossm-release-2-6-17-components_{context}"]
+== Component updates
+
+|===
+|Component |Version
+
+|Istio
+|1.20.8
+
+|Envoy Proxy
+|1.28.8
+
+|Kiali Server
+|1.73.32
+|===

--- a/service_mesh/v2x/servicemesh-release-notes.adoc
+++ b/service_mesh/v2x/servicemesh-release-notes.adoc
@@ -8,6 +8,8 @@ toc::[]
 
 // The following include statements pull in the module files that comprise 2.x release notes.
 
+include::modules/ossm-release-2-6-17.adoc[leveloffset=+1]
+
 include::modules/ossm-release-2-6-16.adoc[leveloffset=+1]
 
 include::modules/ossm-release-2-6-15.adoc[leveloffset=+1]


### PR DESCRIPTION
OSSM 14106: OSSM 2.6.17 At ReleaseCandidate Documentation Tasks

Version(s):
enterprise-4.019

Issue:
https://redhat.atlassian.net/browse/OSSM-14106

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
