### PR TITLE
Document OSSMC plugin features, new pages, and enhanced detail tabs

### DIFF
--- a/modules/ossm-about-console-plugin.adoc
+++ b/modules/ossm-about-console-plugin.adoc
@@ -8,37 +8,69 @@
 
 [role="_abstract"]
 
-The {SMPlugin} is an extension to {ocp-product-title} web console that provides visibility into your {SMProductShortName}.
+The {SMPlugin} is an {ocp-product-title} dynamic plugin that integrates Kiali functionality into the {ocp-product-title} web console, providing full visibility into your {SMProductShortName}. It offers the same features as the standalone Kiali console but organized to fit the {ocp-product-title} web console experience.
 
 [WARNING]
 ====
 The {SMPluginShort} supports only one Kiali instance, regardless of its project access scope.
 ====
 
-The {SMPluginShort} provides a new category, *{SMProductShortName}*, in the main {ocp-product-title} web console navigation with the following menu options:
+The {SMPluginShort} integrates into the {ocp-product-title} web console through the Main Navigation Menu and enhanced detail pages for workloads, services, applications, {istio} configuration, and projects.
 
-Overview:: Provides a summary of your mesh, displayed as cards that represent the namespaces in the mesh.
+=== Main Navigation Menu
+
+The {SMPluginShort} adds a *{SMProductShortName}* category to the main {ocp-product-title} web console navigation with the following menu options:
+
+Overview:: Provides a summary of your mesh, including cluster and control plane status, data plane information, {istio} configuration validation, application health, and service insights with error rates, latency and throughput metrics.
 
 Traffic Graph:: Provides a full topology view of your mesh, represented by nodes and edges. Each node represents a component of the mesh and each edge represents traffic flowing through the mesh between components.
 
-{istio} config:: Provides a list of all {istio} configuration files in your mesh, with a column that provides a quick way to know if the configuration for each resource is valid.
+Mesh:: Provides detailed information about the service mesh infrastructure status. It shows an infrastructure topology view with core and add-on components, their health, and how they are connected to each other.
 
-Mesh:: Provides detailed information about the {istio} infrastructure status. It shows an infrastructure topology view with core and add-on components, their health, and how they connect to each other.
+Namespaces:: Provides a list of namespaces participating in the mesh with information about type, data plane mode, cluster, health, mTLS status, {istio} configuration status, and labels.
 
-In the web console *Workloads* details page, the {SMPluginShort} adds a *{SMProductShortName}* tab that has the following subtabs:
+Applications:: Provides a list of applications detected in the mesh with information about health status and associated workloads.
 
-Overview:: Shows a summary of the selected workload, including a localized topology graph showing the workload with all inbound and outbound edges and nodes.
+Services:: Provides a list of services in the mesh with information about health, {istio} configuration status, and labels.
 
-Traffic:: Shows information about all inbound and outbound traffic to the workload.
+Workloads:: Provides a list of workloads in the mesh with information about health status, type (Deployment, ReplicaSet, DaemonSet, StatefulSet, etc.), and associated {istio} configuration.
 
-Logs:: Shows the logs for the workload's containers. You can see container logs individually ordered by log time and how the Envoy sidecar proxy logs relate to your workload's application logs. You can enable tracing span integration to see logs that correspond to specific trace spans.
+{istio} Config:: Provides a list of all service mesh configuration resources, with a column that provides a quick way to know if the configuration for each resource is valid. The list page supports full filtering capabilities, including type, name, and validation status filters. You can also create new configuration resources from this page.
 
-Metrics:: Shows inbound and outbound metric graphs in the corresponding subtabs. All the workload metrics are here, providing a detailed view of the performance of your workload. You can enable the tracing span integration to see spans that occurred at the same time as the metrics. With the span marker in the graph, you can see the specific spans associated with that time frame.
+=== Application, Workload, and Service Details
 
-Traces:: Provides a chart showing the trace spans collected over the given time frame. The trace spans show the lowest-level detail within your workload application. The trace details further show heatmaps that offer a comparison of one span in relation to other requests and spans in the same time frame.
+The *Applications*, *Workloads* (Deployments, ReplicaSets, Pods, StatefulSets, DaemonSets), and *Services* detail pages provide the following subtabs:
 
-Envoy:: Shows information about the Envoy sidecar configuration.
+[options="header"]
+|===
+| Subtab | Description
 
-In the web console *Networking* details page, the {SMPluginShort} adds a *{SMProductShortName}* tab similar to the *Workloads* details page.
+| *Overview*
+| Shows a summary of the selected application, workload, or service, including a localized topology graph with all inbound and outbound edges and nodes.
 
-In the web console *Projects* details page, the {SMPluginShort} adds a *{SMProductShortName}* tab that provides traffic graph information about that project. It is the same information shown in the *Traffic Graph* page but specific to that project.
+| *Traffic*
+| Shows information about all inbound and outbound traffic.
+
+| *Logs*
+| Shows the logs for the workload's containers. You can see container logs individually ordered by log time and how the Envoy sidecar proxy logs relate to your workload's application logs. You can enable the tracing span integration, which allows you to see which logs correspond to trace spans. Only available for workloads.
+
+| *Inbound Metrics*
+| Shows inbound metric graphs, providing a detailed view of performance. You can enable the tracing span integration, which allows you to see which spans occurred at the same time as the metrics. With the span marker in the graph, you can see the specific spans associated with that timeframe.
+
+| *Outbound Metrics*
+| Shows outbound metric graphs. Not available for services.
+
+| *Traces*
+| Provides a chart showing the trace spans collected over the given timeframe. The trace spans show the most low-level detail within your application. The trace details further show heatmaps that provide a comparison of one span in relation to other requests and spans in the same timeframe.
+
+| *Envoy*
+| Shows information about the Envoy sidecar configuration. Only available for workloads.
+|===
+
+=== Istio Configuration Details
+
+In the web console detail pages for *{istio} configuration resources* (such as VirtualService, DestinationRule, Gateway, AuthorizationPolicy, and others), the {SMPluginShort} adds a *{SMProductShortName}* tab that shows an overview and validation status for the resource.
+
+=== Project Details
+
+In the web console *Projects* details page, the {SMPluginShort} adds a *{SMProductShortName}* tab that shows the namespace detail page with a split-panel layout: the left panel contains stacked cards showing namespace attributes, resource links, and health information, while the right panel displays a namespace-scoped traffic minigraph.

--- a/modules/ossm-install-console-plugin-ocp-cli.adoc
+++ b/modules/ossm-install-console-plugin-ocp-cli.adoc
@@ -12,13 +12,13 @@ You can install the {SMPlugin} by using the {ocp-short-name} CLI.
 
 .Prerequisites
 
-* You have access to the {oc-first} on the cluster as an administrator.
+* You have logged in to the {ocp-product-title} cluster either through the web console as a user with the `cluster-admin` role, or with the `oc login` command, depending on the installation method.
 
-* You have installed the {SMProduct} (OSSM).
+* You have installed the {SMProduct} Operator in the {ocp-product-title} cluster.
 
-* You have installed the `{istio}` control plane from OSSM 3.0.
+* You have installed the `{istio}` resource from OSSM.
 
-* You have installed the {KialiServer} 2.4.
+* You have installed the {KialiServer}.
 
 .Procedure
 
@@ -39,7 +39,7 @@ EOM
 +
 [NOTE]
 ====
-The {ossmc-full} (OSSMC) version must match with the {KialiServer} version. If `spec.version` field value is the string `default` or is not specified, the Kiali Operator installs OSSMC with the same version as the operator. The `spec.version` field requires the `v` prefix in the version number. The version number must only include the major and minor version numbers (not the patch number); for example: `v1.73`.
+The {ossmc-full} (OSSMC) version must match with the {KialiServer} version. If `spec.version` field value is the string `default` or is not specified, the Kiali Operator installs OSSMC with the same version as the operator. The `spec.version` field requires the `v` prefix in the version number. The version number must only include the major and minor version numbers (not the patch number); for example: `v2.4`.
 ====
 +
 The plugin resources deploy in the same namespace as the `OSSMConsole` CR.

--- a/modules/ossm-install-console-plugin-ocp-web-console.adoc
+++ b/modules/ossm-install-console-plugin-ocp-web-console.adoc
@@ -12,13 +12,13 @@ You can install the {SMPlugin} by using the {ocp-product-title} web console.
 
 .Prerequisites
 
-* You have the administrator access to the {ocp-product-title} web console.
+* You have logged in to the {ocp-product-title} cluster either through the web console as a user with the `cluster-admin` role, or with the `oc login` command, depending on the installation method.
 
-* You have installed the {SMProduct} (OSSM).
+* You have installed the {SMProduct} Operator in the {ocp-product-title} cluster.
 
-* You have installed the `{istio}` control plane from OSSM 3.0.
+* You have installed the `{istio}` resource from OSSM.
 
-* You have installed the {KialiServer} 2.4.
+* You have installed the {KialiServer}.
 
 .Procedure
 
@@ -32,7 +32,7 @@ You can install the {SMPlugin} by using the {ocp-product-title} web console.
 +
 [NOTE]
 ====
-The *Version* field must match with the `spec.version` field in your Kiali custom resource (CR). If *Version* value is the string `default`, the Kiali Operator installs {ossmc-full} (OSSMC) with the same version as the operator. The `spec.version` field requires the `v` prefix in the version number. The version number must only include the major and minor version numbers (not the patch number); for example: `v1.73`.
+The *Version* field must match with the `spec.version` field in your Kiali custom resource (CR). If *Version* value is the string `default`, the Kiali Operator installs {ossmc-full} (OSSMC) with the same version as the operator. The `spec.version` field requires the `v` prefix in the version number. The version number must only include the major and minor version numbers (not the patch number); for example: `v2.4`.
 ====
 
 . Click *Create*.

--- a/observability/kiali/ossm-console-plugin.adoc
+++ b/observability/kiali/ossm-console-plugin.adoc
@@ -8,7 +8,7 @@ toc::[]
 
 [role="_abstract"]
 
-The {SMPlugin} extends the {ocp-product-title} web console with a {SMProductShortName} menu and enhanced tabs for workloads and services.
+The {SMPlugin} extends the {ocp-product-title} web console, allowing you to monitor and manage your service mesh directly without switching to a separate application.
 
 include::modules/ossm-about-console-plugin.adoc[leveloffset=+1]
 


### PR DESCRIPTION
## Summary
- Restructure the "About" section into clear subsections: Main Navigation Menu, Application/Workload/Service Details, Istio Configuration Details, and Project Details
- Add new standalone navigation pages: Namespaces, Applications, Services, Workloads
- Document Istio Config creation and filtering capabilities
- Replace separate Workloads/Networking detail sections with a unified table covering all subtabs (Overview, Traffic, Logs, Inbound/Outbound Metrics, Traces, Envoy) with per-subtab availability notes
- Add Istio configuration resource detail tab and Project namespace detail documentation
- Update prerequisites to OSSM-standard documentation language (remove hardcoded versions)
- Update version examples from `v1.73` to `v2.4`

Aligns with [openshift-service-mesh/sail-operator#232](https://github.com/openshift-service-mesh/sail-operator/pull/232).

## Files changed
- `observability/kiali/ossm-console-plugin.adoc` -- update assembly title and abstract
- `modules/ossm-about-console-plugin.adoc` -- restructured with new subsections and content
- `modules/ossm-install-console-plugin-ocp-web-console.adoc` -- updated prerequisites and version example
- `modules/ossm-install-console-plugin-ocp-cli.adoc` -- updated prerequisites and version example


Made with [Cursor](https://cursor.com)