### PR TITLE
OSDOCS-20245:Update the z-stream RNs for 4.22.2

### DIFF
--- a/hosted_control_planes/hcp-deploy/hcp-deploy-ibm-power.adoc
+++ b/hosted_control_planes/hcp-deploy/hcp-deploy-ibm-power.adoc
@@ -48,7 +48,7 @@ include::modules/hcp-bm-hc.adoc[leveloffset=+1]
 [role="_additional-resources"]
 .Additional resources
 
-* xref:../../hosted_control_planes/hcp-prepare/hcp-requirements.adoc[Requirements for hosted control planes]
+* xref:../../hosted_control_planes/hcp-prepare/hcp-requirements.adoc#hcp-requirements[Requirements for hosted control planes]
 * xref:../../hosted_control_planes/hcp-deploy/hcp-deploy-bm.adoc#hcp-bm-dns_hcp-deploy-bm[DNS configurations on bare metal]
 * xref:../../hosted_control_planes/hcp-import.adoc[Manually importing a hosted cluster]
 * xref:../../hosted_control_planes/hcp-disconnected/hcp-deploy-dc-bm.adoc#hcp-dc-extract_hcp-deploy-dc-bm[Extracting the release image digest]

--- a/hosted_control_planes/hcp-prepare/hcp-requirements.adoc
+++ b/hosted_control_planes/hcp-prepare/hcp-requirements.adoc
@@ -1,18 +1,19 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="hcp-requirements"]
-include::_attributes/common-attributes.adoc[]
 = Requirements for {hcp}
+include::_attributes/common-attributes.adoc[]
 :context: hcp-requirements
 
 toc::[]
 
-In the context of {hcp}, a _management cluster_ is an {product-title} cluster where the HyperShift Operator is deployed and where the control planes for hosted clusters are hosted.
-
-The control plane is associated with a hosted cluster and runs as pods in a single namespace. When the cluster service consumer creates a hosted cluster, it creates a worker node that is independent of the control plane.
+[role=_abstract]
+Ensure you are familiar with the general requirements to deploy {hcp}.
 
 The following requirements apply to {hcp}:
 
-* In order to run the HyperShift Operator, your management cluster needs at least three worker nodes.
+* In order to run the HyperShift Operator, your management cluster needs at least three worker nodes. In the context of {hcp}, a _management cluster_ is an {product-title} cluster where the HyperShift Operator is deployed and where the control planes for hosted clusters are hosted.
++
+The control plane is associated with a hosted cluster and runs as pods in a single namespace. When the cluster service consumer creates a hosted cluster, it creates a worker node that is independent of the control plane.
 
 * You must open the firewall port `53` on Transmission Control Protocol (TCP) and User Datagram Protocol (UDP) to allow the Domain Name Service (DNS) protocol to work as expected.
 

--- a/modules/hcp-fips.adoc
+++ b/modules/hcp-fips.adoc
@@ -7,6 +7,7 @@
 [id="hcp-fips_{context}"]
 = FIPS-enabled hosted clusters
 
+[role="_abstract"]
 The binaries for {hcp} are FIPs-compliant, with the exception of the {hcp} command-line interface, `hcp`.
 
 If you want to deploy a FIPS-enabled hosted cluster, you must use a FIPS-enabled management cluster. To enable FIPS mode for your management cluster, you must run the installation program from a {op-system-base-full} computer configured to operate in FIPS mode. For more information about configuring FIPS mode on {op-system-base}, see link:https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9/html/security_hardening/switching-rhel-to-fips-mode_security-hardening[Switching {op-system-base} to FIPS mode].

--- a/modules/rn-ocp-release-notes-known-issues.adoc
+++ b/modules/rn-ocp-release-notes-known-issues.adoc
@@ -41,3 +41,5 @@ This section includes several known issues for {product-title} {product-version}
 * Deleting and recreating test workloads with a BlueField-3 NIC causes clock jumps due to inconsistent PTP synchronization. This disrupts time synchronization in test workloads. The time synchronization stabilizes when the workloads are stable. (link:https://issues.redhat.com/browse/RHEL-93579[RHEL-93579])
 
 * Currently, Extended Update Support (EUS) to EUS image-based upgrades are not supported on clusters that have cert-manager installed. (link:https://issues.redhat.com/browse/OCPBUGS-86967[OCPBUGS-86967])
+
+* The Cluster Ingress Operator does not grant role-based access control (RBAC) permissions for the `ReferenceGrant` and `BackendTLSPolicy` custom resources (CRs) that are installed in the Gateway API. As a consequence, manual RBAC configuration is required to manage these CRs. (link:https://issues.redhat.com/browse/OCPBUGS-20239[OCPBUGS-20239])

--- a/modules/rn-ocp-release-notes-new-features.adoc
+++ b/modules/rn-ocp-release-notes-new-features.adoc
@@ -111,6 +111,19 @@ Item description::
 Detailed information.
 ////
 
+[id="ocp-Helm-CLI_{context}"]
+== Helm CLI for Red{nbsp}Hat {product-title}
+
+The Helm CLI for Red{nbsp}Hat {product-title} v4 is now available as a standalone download::
++
+The Helm CLI for Red{nbsp}Hat {product-title} v4.1.4 is the first supported downstream build of Helm v4, available as a standalone binary from the {product-title}  mirror repository. This release gives you access to Helm v4 capabilities. As a result, you can start evaluating and using Helm v4 workflows on {product-title} today.
++
+Note that all integrated {product-title} console flows and software catalogs still run on Helm v3 only. If you use new Helm chart features or Helm v4-exclusive features through the command line interface (CLI), they will not map to or render in the current {ocp} web console.
++
+Red{nbsp}Hat does not plan to ship a traditional RPM for Helm.
++
+For more information, see (link:https://access.redhat.com/solutions/7144038[Helm CLI for Red{nbsp}Hat {product-title}]).
+
 [id="ocp-release-notes-ibm-power_{context}"]
 == IBM Power
 

--- a/modules/zstream-4-22-2.adoc
+++ b/modules/zstream-4-22-2.adoc
@@ -1,0 +1,52 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-22-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-22-2_{context}"]
+= RHSA-2026:27009 - {product-title} {product-version}.2 fixed issues and security update
+
+Issued: 23 June 2026
+
+[role="_abstract"]
+{product-title} release {product-version}.2 is now available. The list of fixed issues that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2026:27009[RHSA-2026:27009] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2026:27007[RHBA-2026:27007] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.22.2 --pullspecs
+----
+
+[id="zstream-4-22-2-enhancements_{context}"]
+== Enhancements
+
+* With this release, the `chrony-wait` service is updated to not block during the Node Bootstrap process. As a result, the time to `NodeReady` is reduced to between 10-24 seconds depending on the platform. (link:https://redhat.atlassian.net/browse/OCPBUGS-88114[OCPBUGS-88114])
+
+[id="zstream-4-22-2-fixed-issues_{context}"]
+== Fixed issues
+
+* Before this update, when you created a namespace-scoped `ProjectHelmChartRepository` object in the {product-title} web console, the Certificate Authority (CA) certificate and Transport Layer Security (TLS) client config drop-down menus listed only the resources from the `openshift-config` namespace. With this release, the form lists CA and TLS resources from the selected project namespace for `ProjectHelmChartRepository` objects, while cluster-scoped `HelmChartRepository` objects continue to use the `openshift-config` namespace. (link:https://redhat.atlassian.net/browse/OCPBUGS-76328[OCPBUGS-76328])
+
+* Before this update, when a boundary clock (T-BC) entered holdover, the `event.sync.sync-status.synchronization-state-change` (/sync/sync-status/sync-state) event would sometimes incorrectly report `FREERUN` instead of `HOLDOVER`. These reports might have occurred because of an issue with the calculation of the overall node sync state. With this release, the `ptp4l` state is ignored. As a result, the `event.sync.sync-status.synchronization-state-change` (/sync/sync-status/sync-state) event correctly reports `HOLDOVER`. (link:https://redhat.atlassian.net/browse/OCPBUGS-86530[OCPBUGS-86530])
+
+* Before this update, arbiter configs previously used runc as the default container runtime. With this release, the arbiter configs have been updated to be in sync with the master nodes and use crun as the default container runtime. (link:https://redhat.atlassian.net/browse/OCPBUGS-87019[OCPBUGS-87019])
+
+* Before this update, the `openshift-apiserver` might have failed when multiple requests accessed project authorization data at the same time. This issue occurred more often on clusters with many namespaces and role-based access control (RBAC) rules. As a consequence, `openshift-apiserver` pods restarted unexpectedly with exit code `2`, which temporarily disrupted the API availability for project and namespace operations. With this release, the project authorization cache safely handles concurrent access. As a result, the `openshift-apiserver` namespace does not fail during concurrent project authorization lookups, and project listing operations remain responsive regardless of cluster size. (link:https://redhat.atlassian.net/browse/OCPBUGS-87022[OCPBUGS-87022])
+
+* Before this update, when you navigated to the *Cluster Dashboard Overview* page and clicked the *Insights* window on the *Status* card, an underlying UI component rendered the text incorrectly. As a consequence, the icons for the four severity levels (*Critical*, *Important*, *Moderate*, and *Low*) appeared, but the actual issue counts and the links to the *Insights* advisor were missing. With this release, the link component inside the *Insights* severity message is updated to ensure that the text and links render properly. As a result, each severity level in the *Insights* window now successfully displays its icon, the correct issue count, and a clickable link to the *Insights* advisor. (link:https://redhat.atlassian.net/browse/OCPBUGS-87096[OCPBUGS-87096])
+
+* Before this update, after a `cloud-event-proxy` (CEP) sidecar restart, the linuxptp-daemon sent replay data and live ptp4l output concurrently over the same event socket. A stale replayed port-role event containing `FAULTY` forced the clock state to `HOLDOVER`, and because port roles update only on discrete state-change events, subsequent live offsets could not restore `LOCKED`. Additionally, the replayed `RECEIVER`-to-`FAULTY` transition also overwrote the live `RECEIVER` role already established on the socket, persisting indefinitely until a real port state change occurs. This affects T-BC and dual-follower configurations and, with lower probability, {oc-first} configurations. As a consequence, the clock state metric and the `SyncStateChange` cloud event remained stuck at `FREERUN` or `HOLDOVER`. The port role also remained stuck at `FAULTY`. The clock recovered, even though ptp4l was fully locked. With this release, a live gate is introduced that blocks process connections from writing to the event socket until the replay completes, which ensures that all historical state is processed before any live data arrives. As a result, stale replay data cannot race with live output and the clock state and port role metrics correctly reflect the current synchronization status after a CEP restart. (link:https://redhat.atlassian.net/browse/OCPBUGS-87839[OCPBUGS-87839])
+
+* Before this update, {product-title} disabled timer migration to ensure that the high resolution kernel timers and cyclictest (a timer-based bench-marking tool) was not affected by extra latency. However, timer migration was required to allow kernel to migrate previously started timers such as the transmission control protocol (TCP) timeout and keep-alive away from CPUs assigned to a newly CPU-pinned guaranteed workload container. As a consequence, when the timer migration was disabled, the remaining timers kept interrupting the latency sensitive workloads. With this release, the timer migration is reinstated to enable configuration because the `PerformanceProfile` parameter is mostly used with latency sensitive workloads. As a result, newly created pods are not interrupted by timers that are stuck on the CPUs assigned to those workloads. If you do not want the latency-sensitive polling application running on the cluster, you can set set the `kernel.timer_migration=0` sysctl by using the advanced configuration instructions that are provided in the Knowledge Base at link:https://access.redhat.com/solutions/5532341[5532341]. (link:https://redhat.atlassian.net/browse/OCPBUGS-87891[OCPBUGS-87891])
+
+* Before this update, when you bootstrapped a new node, the extensions image was pulled regardless of whether it was required by the cluster configuration. As a consequence, the time for bootstrapping was increased. With this release, the extensions image is only pulled when the configuration requires it. (link:https://redhat.atlassian.net/browse/OCPBUGS-88120[OCPBUGS-88120])
+
+* Before this update, you were prompted to complete the *Restore as new PVC* action for the `VolumeSnapshot` modals to work when the parent persistent volume claim (PVC) was deleted, which aligned the console behavior with the command-line interface (CLI) which already supported this operation. With this release, the restore `VolumeSnapshot` modal now falls back to snapshot annotations for storage class, access modes, and size instead of requiring the original PVC to be present. (link:https://redhat.atlassian.net/browse/OCPBUGS-88304[OCPBUGS-88304])
+
+[id="zstream-4-22-2-updating_{context}"]
+== Updating
+
+To update an {product-title} 4.22 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].

--- a/release_notes/ocp-4-22-release-notes.adoc
+++ b/release_notes/ocp-4-22-release-notes.adoc
@@ -44,6 +44,9 @@ include::modules/rn-ocp-release-notes-known-issues.adoc[leveloffset=+1]
 // Asynchronous errata updates
 include::modules/rn-ocp-release-notes-async-errata-updates.adoc[leveloffset=+1]
 
+// zstream 4.22.2 RNs full document
+include::modules/zstream-4-22-2.adoc[leveloffset=+2]
+
 // zstream 4.22.1 RNs full document
 include::modules/zstream-4-22-1.adoc[leveloffset=+2]
 


### PR DESCRIPTION
Version(s):
4.22

Issue:
https://redhat.atlassian.net/browse/OSDOCS-20245

Link to docs preview:

- Update to new features: https://113651--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-22-release-notes.html#ocp-Helm-CLI_release-notes
- Update to known issues: https://113651--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-22-release-notes.html#rn-ocp-release-notes-known-issues_release-notes
- Updates to async RNs: https://113651--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-22-release-notes.html#zstream-4-22-2_release-notes

Additional information:
4.22.2 MR: https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/591
ART Dashboard: https://art-dash.engineering.redhat.com/dashboard/release/openshift-4.22?page=1

NOTE: Closing this PR because the merged content for the 4.22.2 Release Note is in https://github.com/openshift/openshift-docs/pull/114031.
