### PR TITLE
OSDOCS-20108-1:Update the z-stream RNs for 4.21.20

### DIFF
--- a/modules/zstream-4-21-20.adoc
+++ b/modules/zstream-4-21-20.adoc
@@ -1,0 +1,45 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-21-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-21-20_{context}"]
+= RHSA-2026:25187 - {product-title} {product-version}.20 fixed issues advisory
+
+Issued: 16 June 2026
+
+[role="_abstract"]
+{product-title} release {product-version}.20 is now available. The list of fixed issues that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2026:25187[RHSA-2026:25187] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2026:25185[RHBA-2026:25185] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.21.20 --pullspecs
+----
+
+[id="zstream-4-21-20-fixed-issues_{context}"]
+== Fixed issues
+
+* Before this update, virtual media provisioning could fail on servers such as the Cisco C845A M8. As a consequence, the Baseboard Management Controller (BMC) on this hardware reported a missing `TransferProtocolType` parameter in a non-standard way that the Redfish client library did not recognize, which prevented an automatic retry. Some virtual media slots on this hardware also did not support remote image mounting, and the provisioning service treated errors from those slots as unrecoverable rather than falling back to the next slot. With this release, the Redfish client library recognizes the non-standard error format, and the provisioning service skips unusable virtual media slots. As a result, virtual media-based deployments work reliably on this class of hardware. (link:https://redhat.atlassian.net/browse/OCPBUGS-82294[OCPBUGS-82294])
+
+* Before this update, when every service step could run entirely out-of-band (that is, there was no agent ramdisk), the conductor had already skipped the initial ramdisk boot. However, an internal flag still indicated that a ramdisk boot was allowed. As a consequence, steps that rebooted the node to finish their work could still trigger an agent ramdisk boot before that reboot, even though none of the steps required it. This issue caused Operators to identify an extra, unnecessary agent ramdisk boot during out-of-band service work that was disruptive and slower, such as when applying BIOS settings over the management interface. With this release, whenever all service steps are out-of-band-only, the conductor now sets that internal flag so the `no ramdisk needed` decision also applies consistently through the reboot-to-finish paths. As a result, the service-step flows do not pull in a spare agent boot. Instead, the node stays on the intended out-of-band path without the extra cycle. (link:https://redhat.atlassian.net/browse/OCPBUGS-84370[OCPBUGS-84370])
+
+* Before this update, binary data such as `JAR` or `JCEKS` keystores, was incorrectly decoded as UTF-8 text when `Secret` objects were edited through the {ocp} web console. This corrupted the binary values with replacement characters and rendered the files unusable. With this release, the web console now preserves base64-encoded binary data and passes it directly to the file input component without text conversion. Binary secret data remains intact when editing other fields in the same secret. (link:https://issues.redhat.com/browse/OCPBUGS-85674[OCPBUGS-85674])
+
+* Before this update, a race condition occurred between network namespace management and the optional container mount namespace separation in the rare instance when software on the host that was not within the {product-title} cluster created network namespaces. As a consequence, pods became stuck and could not restart. With this release, the race condition is solved by initializing the network namespace infrastructure before the container mount namespace. (link:https://issues.redhat.com/browse/OCPBUGS-86003[OCPBUGS-86003])
+
+* Before this update, the `MachineSet` object scale sub-resource lacked a valid selector, which prevented autoscalers such as HPA and KEDA from scaling the `MachineSet` object. As a consequence, autoscalers requiring a selector failed. With this release, the `MachineSet` object exposes an active label selector on the scale sub-resource, which enables scaling using autoscalers such as HPA and KEDA that require the label selector to be populated. (link:https://issues.redhat.com/browse/OCPBUGS-86493[OCPBUGS-86493])
+
+* Before this update, when a user applied a `MachineConfig` parameter to install extensions, the Machine Config Operator (MCO) did not validate that all packages were installed. As a consequence, extension installation appeared to be successful, but packages were missing. If one or more packages were not present, the node, and subsequently the associated machine config pool, degraded. With this release, the MCO validates after the node reboot that all packages associated with your desired extension were successfully installed before reporting a successful update. (link:https://issues.redhat.com/browse/OCPBUGS-86576[OCPBUGS-86576])
+
+* Before this update, the macOS Option key was treated as a Meta key instead of a compose key in the pod terminal. As a consequence, characters that rely on Option key combinations, such as `@`, `{`, `}`, `|`, `\`, and `~`, could not be entered. With this release, the terminal correctly identifies macOS, so the Option key functions as a compose key as expected. (link:https://issues.redhat.com/browse/OCPBUGS-86581[OCPBUGS-86581])
+
+* Before this update, the router liveness probe used an HTTP backend check to monitor HAProxy health. As a consequence, when HAProxy reached its `maxconn` connection limit due to client traffic, the HTTP health check failed and the router pods unnecessarily restarted. With this release, the router liveness probe uses an HAProxy `admin` socket check instead of an HTTP  backend check. As a result, router pods remain stable when HAProxy reaches  its `maxconn` connection limit due to legitimate client traffic, preventing  unnecessary restarts. (link:https://issues.redhat.com/browse/OCPBUGS-87002[OCPBUGS-87002])
+
+[id="zstream-4-21-20-updating_{context}"]
+== Updating
+
+To update an {product-title} 4.21 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].

--- a/release_notes/ocp-4-21-release-notes.adoc
+++ b/release_notes/ocp-4-21-release-notes.adoc
@@ -44,6 +44,9 @@ include::modules/rn-ocp-release-notes-known-issues.adoc[leveloffset=+1]
 // Asynchronous errata updates
 include::modules/rn-async-errata.adoc[leveloffset=+1]
 
+// 4.21.20 RNs and updating
+include::modules/zstream-4-21-20.adoc[leveloffset=+2]
+
 // 4.21.19 RNs and updating
 include::modules/zstream-4-21-19.adoc[leveloffset=+2]
 


### PR DESCRIPTION
Version(s):
4.21

Issue:
https://redhat.atlassian.net/browse/OSDOCS-20108

Link to docs preview:
https://113667--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-21-release-notes.html#zstream-4-21-20_release-notes

Additional information:
4.21.20 MR: https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/576
ART Dashboard: https://art-dash.engineering.redhat.com/dashboard/release/openshift-4.21?page=1

NOTE: This PR was created to replace https://github.com/openshift/openshift-docs/pull/113191 to address repo glitches. It incorporates the review comments from Shauna Diaz for that PR.