### PR TITLE
[OSDOCS-19997]: CQA: Distributing workloads for HCP

### DIFF
--- a/modules/hcp-labels-taints.adoc
+++ b/modules/hcp-labels-taints.adoc
@@ -6,6 +6,7 @@
 [id="hcp-labels-taints_{context}"]
 = Labeling management cluster nodes
 
+[role="_abstract"]
 Proper node labeling is a prerequisite to deploying {hcp}.
 
 As a management cluster administrator, you use the following labels and taints in management cluster nodes to schedule a control plane workload:
@@ -34,13 +35,13 @@ For the `ControllerAvailabilityPolicy` option, use `HighlyAvailable`, which is t
 
 .Procedure
 
-To enable a hosted cluster to require its pods to be scheduled into infrastructure nodes, set `HostedCluster.spec.nodeSelector`, as shown in the following example:
-
+* To enable a hosted cluster to require its pods to be scheduled into infrastructure nodes, set the `HostedCluster.spec.nodeSelector` specification, as shown in the following example:
++
 [source,yaml]
 ----
   spec:
     nodeSelector:
       node-role.kubernetes.io/infra: ""
 ----
-
++
 This way, {hcp} for each hosted cluster are eligible infrastructure node workloads, and you do not need to entitle the underlying {product-title} nodes.

--- a/modules/hcp-priority-classes.adoc
+++ b/modules/hcp-priority-classes.adoc
@@ -6,7 +6,10 @@
 [id="hcp-priority-classes_{context}"]
 = Priority classes
 
-Four built-in priority classes influence the priority and preemption of the hosted cluster pods. You can create the pods in the management cluster in the following order from highest to lowest:
+[role="_abstract"]
+Four built-in priority classes influence the priority and preemption of the hosted cluster pods. 
+
+You can create the pods in the management cluster in the following order from highest to lowest:
 
 * `hypershift-operator`: HyperShift Operator pods.
 * `hypershift-etcd`: Pods for etcd.

--- a/modules/hcp-virt-taints-tolerations.adoc
+++ b/modules/hcp-virt-taints-tolerations.adoc
@@ -6,7 +6,8 @@
 [id="hcp-virt-taints-tolerations_{context}"]
 = Custom taints and tolerations
 
-By default, pods for a hosted cluster tolerate the `control-plane` and `cluster` taints. However, you can also use custom taints on nodes so that hosted clusters can tolerate those taints on a per-hosted-cluster basis by setting `HostedCluster.spec.tolerations`.
+[role="_abstract"]
+By default, pods for a hosted cluster tolerate the `control-plane` and `cluster` taints. However, you can also use custom taints on nodes so that hosted clusters can tolerate those taints on a per-hosted-cluster basis by setting the `HostedCluster.spec.tolerations` specification.
 
 :FeatureName: Passing tolerations for a hosted cluster
 include::snippets/technology-preview.adoc[]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.20+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://redhat.atlassian.net/browse/OSDOCS-19997
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://113672--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-prepare/hcp-distribute-workloads.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
N/A no technical changes
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
