### PR TITLE
OSDOCS-20263 created RNs for ESO 1-2

### DIFF
--- a/modules/external-secrets-operator-rn-1-2.adoc
+++ b/modules/external-secrets-operator-rn-1-2.adoc
@@ -1,0 +1,78 @@
+:_mod-docs-content-type: REFERENCE
+[id="external-secrets-operator-rn-1-2_{context}"]
+= Release notes for {external-secrets-operator} 1.2.0
+
+[role="_abstract"]
+{external-secrets-operator} version 1.2.0 is based on the upstream external-secrets project, version v2.5.0. For more information, see the link:https://github.com/external-secrets/external-secrets/releases/tag/v2.5.0[external-secrets project release notes for v2.5.0].
+
+Issued: 2026-07-09
+
+The following advisories are available for the {external-secrets-operator} 1.2.0:
+
+* link:https://access.redhat.com/errata/RHBA-2026:36640[RHBA-2026:36640]
+* link:https://access.redhat.com/errata/RHBA-2026:36647[RHBA-2026:36647]
+* link:https://access.redhat.com/errata/RHBA-2026:36650[RHBA-2026:36650]
+* link:https://access.redhat.com/errata/RHBA-2026:36676[RHBA-2026:36676]
+
+[id="external-secrets-operator-1-2-0-features-enhancements_{context}"]
+== New features and enhancements
+
+*Support for user-provided trusted CA bundles on the {external-secrets-operator-short} core controller*
+
+With this release, you can configure the {external-secrets-operator} to trust custom Certificate Authority (CA) certificates when the `external-secrets` core controller makes outbound TLS connections to external secret management systems, such as HashiCorp Vault or {aws-first} Secrets Manager.
+
+To use this feature, create a `ConfigMap` object in the operand namespace containing one or more PEM-encoded CA certificates, and reference it in the `ExternalSecretsConfig` custom resource under the `spec.controllerConfig.trustedCABundle` field. The Operator validates the bundle on every reconcile and mounts it as a volume only on the core controller deployment. The webhook and cert-controller deployments are not affected.
+
+If the referenced `ConfigMap` object is missing or contains invalid data, the Operator sets the `ExternalSecretsConfig` custom resource (CR) status to `Degraded` and emits a warning event describing the problem. The Operator recovers automatically when the `ConfigMap` object is created or corrected, without requiring a spec change.
+
+If the proxy is configured and the `ConfigMap` carries the Cluster Network Operator (CNO) `inject-trusted-cabundle` label, the user bundle mount is skipped because the proxy TLS connections already use the {product-title} trusted CA bundle injected by the CNO.
+
+For more information, see link:https://docs.redhat.com/en/documentation/openshift_container_platform/latest/html-single/security_and_compliance/index#external-secrets-operator-config-trusted-ca[Configuring a trusted CA bundle for the External Secrets Operator for Red Hat OpenShift].
+
+
+*Optional feature configuration is available for {external-secrets-operator-short} deployments*
+
+With this release, the `ExternalSecretsManager` CR supports a `spec.features` field for toggling optional capabilities across operator-managed deployments. Each entry is identified by name and can be individually set to `Enabled` or `Disabled`.
+
+The first supported feature is `UnsafeAllowGenericTargets`. When enabled, the Operator passes the `--unsafe-allow-generic-targets` flag to the `external-secrets` core controller, allowing `ExternalSecret` resources to sync secrets into Kubernetes resources other than `Secret` objects.
+
+[IMPORTANT]
+====
+`UnsafeAllowGenericTargets` is a pre-release feature in the upstream `external-secrets` project. The `UnsafeAllowGenericTargets` feature has the following limitations:
+
+* Only namespaced resources can be targeted, and only by an `ExternalSecret` CR in the same namespace as the target resource.
+* Performance is approximately 20% slower than standard `Secret` synchronization.
+* Custom resources are not encrypted at rest by Kubernetes. Use this feature only when the target resource does not contain sensitive credentials, or when encryption is provided by other means.
+====
+
+Enabling this feature also requires that the `external-secret` service account has the appropriate role-based access control (RBAC) permissions to create and update the target resource types. Without these permissions, secret synchronization for affected `ExternalSecret` CR resources fails.
+
+*Improved status reporting for invalid user configuration*
+
+With this release, the {external-secrets-operator} distinguishes between Operator-level failures and user configuration errors during reconciliation. When an invalid or incomplete user configuration is detected, such as a missing cert-manager issuer reference or an incomplete Bitwarden TLS setup, the Operator immediately sets the `ExternalSecretsConfig` CR status to `Degraded=True` and `Ready=False` without entering an exponential backoff retry loop.
+
+The Operator recovers automatically when the configuration is corrected. If a referenced object does not yet exist, the Operator requeues periodically until the object is created.
+
+*Automatic proxy egress NetworkPolicy management*
+
+With this release, the {external-secrets-operator} automatically creates, updates, and deletes a proxy egress `NetworkPolicy` named `eso-sys-allow-proxy-egress`, for all `external-secrets` pods when a cluster proxy is configured. The policy allows outbound traffic from operand pods to the configured proxy server port. You can control whether the Operator manages this policy by setting the `networkPolicyProvisioning` field on the proxy configuration to `Managed` or `Unmanaged`. When set to `Unmanaged`, no proxy egress policy is created or deleted by the Operator.
+
+*Standardized NetworkPolicy naming*
+
+With this release, Operator-managed `NetworkPolicies` now use an `eso-sys-` prefix such as `eso-sys-deny-all-traffic`, `eso-sys-allow-to-dns`, and so on. User-configured `NetworkPolicies` defined in the `spec.controllerConfig.networkPolicies` field now use an `eso-user-` prefix when the Kubernetes object is created. This makes it easier to distinguish Operator-managed policies from user-defined ones.
+
+As a result of the `eso-user-` prefix, the maximum length for the name field in `spec.controllerConfig.networkPolicies` entries is reduced from 253 to 243 characters.
+
+
+*Automatic migration of legacy NetworkPolicy names*
+
+With this release, when upgrading from a version that used unprefixed `NetworkPolicy` names, the Operator automatically detects and deletes the legacy unprefixed `NetworkPolicies` during the first reconciliation after upgrade. This migration runs once per cluster and is gated by the `externalsecretsconfig.operator.openshift.io/skip-np-cleanup-check` annotation so that subsequent reconciliations do not repeat the cleanup scan.
+
+
+[id="external-secrets-operator-1-2-0-bug-fixes_{context}"]
+== Fixed issues
+
+* Before this release, if the `app=external-secrets` managed label was externally removed from a resource that the {external-secrets-operator} owns, the resource fell out of the label-filtered informer cache. Subsequent reconciliation attempts to create the resource received an `AlreadyExists` error, causing the controller to enter a permanent error loop. With this release, the controller detects this cache-miss condition and restores the managed labels and annotations directly on the API server by using an uncached client, without interrupting the operand. (link:https://issues.redhat.com/browse/ESO-237[ESO-237])
+
+
+

--- a/security/external_secrets_operator/external-secrets-operator-release-notes.adoc
+++ b/security/external_secrets_operator/external-secrets-operator-release-notes.adoc
@@ -13,6 +13,9 @@ These release notes track the development of {external-secrets-operator-short}.
 
 For more information, see xref:../../security/external_secrets_operator/index.adoc#external-secrets-operator-about[{external-secrets-operator-short} overview].
 
+// ESO RN 1.2
+include::modules/external-secrets-operator-rn-1-2.adoc[leveloffset=+1]
+
 // ESO RN 1.1
 include::modules/external-secrets-operator-rn-1-1.adoc[leveloffset=+1]
 


### PR DESCRIPTION
Version(s):
4.19+

Issue:
https://redhat.atlassian.net/browse/OSDOCS-20263

Link to docs preview:
https://113679--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/external_secrets_operator/external-secrets-operator-release-notes.html


QE review:
- [ ] QE has approved this change.


Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
