### PR TITLE
[OSDOCS-19997]: CQA: Overriding resource utilization for HCP

### DIFF
--- a/hosted_control_planes/hcp-prepare/hcp-override-resource-util.adoc
+++ b/hosted_control_planes/hcp-prepare/hcp-override-resource-util.adoc
@@ -6,7 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-The set of baseline measurements for resource utilization can vary in each hosted cluster.
+[role="_abstract"]
+The set of baseline measurements for resource utilization can vary in each hosted cluster. Ensure that you understand the resource utilization needed for your deployment.
 
 include::modules/hcp-override.adoc[leveloffset=+1]
 

--- a/modules/hcp-disable-metrics.adoc
+++ b/modules/hcp-disable-metrics.adoc
@@ -6,11 +6,10 @@
 [id="hcp-disable-metrics_{context}"]
 = Disabling the metric service monitoring
 
-After you enable the `hypershift-addon` managed cluster add-on, metric service monitoring is configured by default so that {product-title} monitoring can gather metrics from `hypershift-addon`. 
+[role="_abstract"]
+After you enable the `hypershift-addon` managed cluster add-on, metric service monitoring is configured by default so that {product-title} monitoring can gather metrics from `hypershift-addon`. If needed, you can disable metric service monitoring.
 
 .Procedure
-
-You can disable metric service monitoring by completing the following steps:
 
 . Log in to your hub cluster by running the following command:
 +
@@ -42,11 +41,11 @@ spec:
     value: "80"
   - name: hcThresholdNumber
     value: "60"
-  - name: disableMetrics <1>
+  - name: disableMetrics
     value: "true"
 ----
 +
-<1> The `disableMetrics=true` customized variable disables metric service monitoring for both new and existing `hypershift-addon` managed cluster add-ons.
+The `disableMetrics=true` customized variable disables metric service monitoring for both new and existing `hypershift-addon` managed cluster add-ons.
 
 . Apply the changes to the configuration specification by running the following command:
 +

--- a/modules/hcp-override.adoc
+++ b/modules/hcp-override.adoc
@@ -6,6 +6,7 @@
 [id="hcp-override_{context}"]
 = Overriding resource utilization measurements for a hosted cluster
 
+[role="_abstract"]
 You can override resource utilization measurements based on the type and pace of your cluster workload.
 
 .Procedure


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.20+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://redhat.atlassian.net/browse/OSDOCS-19997
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://113692--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-prepare/hcp-override-resource-util.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
N/A no technical changes
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
