### PR TITLE
add time out for request.get()

### DIFF
--- a/build_for_portal.py
+++ b/build_for_portal.py
@@ -662,7 +662,7 @@ def scrub_file(info, book_src_dir, src_file, image_files, tag=None, cwd=None):
             base_src_file = base_src_file[https_pos:]
 
         try:
-            response = requests.get(base_src_file)
+            response = requests.get(base_src_file, timeout=30)
             if response:
                 return response.text
             else:


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): at least 4.22+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://redhat.atlassian.net/browse/OSDOCS-20123
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Additional information: this PR adds a 30s timeout to `requests.get()` to prevent indefinite hangs when fetching remote GH includes when dealing with slow or broken IPv6 connectivity. without this, the script hangs unless interrupted. this is affecting ROSA classic docs builds that, since releasing 4.22, require fetching multiple remote files sequentially in the same `.adoc` file
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
