### PR TITLE
OADP-8089: Add OADP 1.4.10 RNs

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -46,9 +46,9 @@ endif::[]
 :oadp-first: OpenShift API for Data Protection (OADP)
 :oadp-full: OpenShift API for Data Protection
 :oadp-short: OADP
-:oadp-version: 1.4.9
+:oadp-version: 1.4.10
 :oadp-version-1-3: 1.3.8
-:oadp-version-1-4: 1.4.9
+:oadp-version-1-4: 1.4.10
 :oadp-bsl-api: backupstoragelocations.velero.io
 :velero-overview: link:https://{velero-domain}/docs/v{velero-version}/locations/[Overview of backup and snapshot locations in the Velero documentation]
 :velero-link: link:https://{velero-domain}/docs/v{velero-version}/[Velero {velero-version}]

--- a/backup_and_restore/application_backup_and_restore/release-notes/oadp-1-4-release-notes.adoc
+++ b/backup_and_restore/application_backup_and_restore/release-notes/oadp-1-4-release-notes.adoc
@@ -15,6 +15,8 @@ The release notes for {oadp-first} 1.4 describe new features and enhancements, d
 For additional information about {oadp-short}, see _{oadp-first} FAQ_.
 ====
 
+include::modules/oadp-1-4-10-release-notes.adoc[leveloffset=+1]
+
 include::modules/oadp-1-4-9-release-notes.adoc[leveloffset=+1]
 
 include::modules/oadp-1-4-8-release-notes.adoc[leveloffset=+1]

--- a/modules/oadp-1-4-10-release-notes.adoc
+++ b/modules/oadp-1-4-10-release-notes.adoc
@@ -1,0 +1,46 @@
+// Module included in the following assemblies:
+//
+// * backup_and_restore/application_backup_and_restore/release-notes/oadp-1-4-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+
+[id="oadp-1-4-10-release-notes_{context}"]
+= {oadp-short} 1.4.10 release notes
+
+[role="_abstract"]
+The {oadp-first} 1.4.10 release notes list resolved and known issues.
+
+
+[id="resolved-issues-1-4-10_{context}"]
+== Resolved issues
+
+CSI snapshot early frequent polling can be configured in the DPA CR::
+Before this update, a Velero change introduced 1-second Container Storage Interface (CSI) snapshot readiness polling for the first 10 seconds of every backup, designed specifically for Microsoft Volume Shadow Copy Service (VSS) workloads on Windows. {oadp-short} did not expose this behavior as a configurable option in the `DataProtectionApplication` (DPA) custom resource (CR). As a consequence, all CSI-enabled backups used the earlier polling behavior regardless of whether VSS compatibility was needed, and you had no way to disable or control this behavior through {oadp-short}. This release adds a new `enableCSISnapshotEarlyFrequentPolling` field under `configuration.velero` in the DPA CR. By default, this feature is disabled. If your workloads require this frequent polling behavior, you must enable it.
++
+link:https://redhat.atlassian.net/browse/OADP-7884[OADP-7884]
+
+
+{oadp-short} 1.4.10 fixes the following CVEs::
+
+* link:https://access.redhat.com/security/cve/cve-2025-68121[CVE-2025-68121]
+* link:https://access.redhat.com/security/cve/cve-2026-25679[CVE-2026-25679]
+* link:https://access.redhat.com/security/cve/cve-2026-27137[CVE-2026-27137]
+* link:https://access.redhat.com/security/cve/cve-2026-32280[CVE-2026-32280]
+* link:https://access.redhat.com/security/cve/cve-2026-32281[CVE-2026-32281]
+* link:https://access.redhat.com/security/cve/cve-2026-32282[CVE-2026-32282]
+* link:https://access.redhat.com/security/cve/cve-2026-33186[CVE-2026-33186]
+* link:https://access.redhat.com/security/cve/cve-2026-33747[CVE-2026-33747]
+* link:https://access.redhat.com/security/cve/cve-2026-33748[CVE-2026-33748]
+* link:https://access.redhat.com/security/cve/cve-2026-33810[CVE-2026-33810]
+* link:https://access.redhat.com/security/cve/cve-2026-34986[CVE-2026-34986]
+
+
+[id="known-issues-1-4-10_{context}"]
+== Known issues
+
+CSI volume snapshot sequential creation exceeds Microsoft Windows VSS freeze timeout for multi-disk VMs::
+{oadp-short} creates Container Storage Interface (CSI) volume snapshots sequentially for each disk attached to a Microsoft Windows virtual machine, waiting for CSI reconciliation before initiating the next snapshot. As a consequence, the total freeze duration exceeds the Windows Volume Shadow Copy Service (VSS) 10-second timeout for shadow copy creation, causing VSS to stop the freeze and resume write operations before all snapshots complete.
++
+No known workaround exists.
++
+link:https://redhat.atlassian.net/browse/OADP-7542[OADP-7542]


### PR DESCRIPTION
Summary of changes:
Add Release Notes for OADP 1.4.10 and update attributes accordingly.

Version(s):
OCP 4.14-4.18

Issue:
[OADP-8089](https://redhat.atlassian.net/browse/OADP-8089)

Link to docs preview:
[OADP 1.4.10 release notes](https://113714--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/release-notes/oadp-1-4-release-notes.html#oadp-1-4-10-release-notes_oadp-1-4-release-notes)

QE review:
- [x] QE has approved this change.