### PR TITLE
OCPBUGS-75886: Updated the spec.nodeSelector in file-integrity-import…

### DIFF
--- a/modules/file-integrity-important-attributes.adoc
+++ b/modules/file-integrity-important-attributes.adoc
@@ -14,11 +14,7 @@
 |Description
 
 |`spec.nodeSelector`
-|A map of key-values pairs that must match with node's labels in order for the
-AIDE pods to be schedulable on that node. The typical use is to set only a
-single key-value pair where `node-role.kubernetes.io/worker: ""` schedules AIDE on
-all worker nodes, `node.openshift.io/os_id: "rhcos"` schedules on all
-{op-system-first} nodes.
+|Specifies a map of key-value pairs that labels for a node must match for a cluster to schedule Advanced Intrusion Detection Environment (AIDE) pods on that node. Typically, you can configure only a single key-value pair. For example, `node-role.kubernetes.io/worker: ""` schedules AIDE on all compute nodes, while `node.openshift.io/os_id: "rhel"` schedules AIDE on all {op-system-base} nodes.
 
 |`spec.debug`
 |A boolean attribute. If set to `true`, the daemon running in the AIDE deamon set's


### PR DESCRIPTION
Version(s):
4.19+

Issue:
[OCPBUGS-75886](https://redhat.atlassian.net/browse/OCPBUGS-75886)

Link to docs preview:

* https://113812--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/file_integrity_operator/file-integrity-operator-configuring.html#important-file-integrity-object-attributes_file-integrity-operator

QE review:
- [x] SME has approved this change (Watson Yuuma Sato).
- [x] QE has approved this change (Anna Koudelkova).
