### PR TITLE
[RHDEVDOCS-7365]: Add gathering diagnostic information procedure for …

### DIFF
--- a/modules/op-proc-gathering-diagnostic-information.adoc
+++ b/modules/op-proc-gathering-diagnostic-information.adoc
@@ -1,0 +1,98 @@
+// This module is included in the following assemblies:
+// * about/understanding-openshift-pipelines.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="gathering-diagnostic-information-pipelines_{context}"]
+= Gathering diagnostic information for support
+
+When you open a support case, you must provide debugging information about your cluster to the Red Hat Support team. You can use the `must-gather` tool to collect diagnostic information for project-level resources, cluster-level resources, and {pipelines-title} components.
+
+[NOTE]
+====
+For prompt support, provide diagnostic information for both OpenShift Container Platform and {pipelines-title}.
+====
+
+== About the must-gather tool
+The `oc adm must-gather` CLI command collects the information from your cluster that is most likely needed for debugging issues, including:
+
+* Resource definitions
+* Service logs
+
+By default, the `oc adm must-gather` command uses the default plugin image and writes into `./must-gather.local`.
+
+Alternatively, you can collect specific information by running the command with the appropriate arguments as described in the following sections:
+
+* To collect data related to one or more specific features, use the `--image` argument with an image, as listed in a following section.
+* To collect the audit logs, use the `-- /usr/bin/gather_audit_logs` argument, as described in a following section.
+
+.Example command for default data collection
+[source,terminal]
+----
+$ oc adm must-gather --image=quay.io/openshift-pipeline/must-gather
+----
+
+.Example command for collecting audit logs
+[source,terminal]
+----
+$ oc adm must-gather -- /usr/bin/gather_audit_logs
+----
+
+[NOTE]
+====
+Audit logs are not collected as part of the default set of information to reduce the size of the files.
+====
+
+When you run `oc adm must-gather`, a new pod with a random name is created in a new project on the cluster. The data is collected on that pod and saved in a new directory that starts with `must-gather.local`. This directory is created in the current working directory.
+
+.Example pod layout
+[source,terminal]
+----
+NAMESPACE                      NAME                 READY   STATUS      RESTARTS      AGE
+...
+openshift-must-gather-5drcj    must-gather-bklx4    2/2     Running     0             72s
+openshift-must-gather-5drcj    must-gather-s8sdh    2/2     Running     0             72s
+...
+----
+
+Optionally, you can run the `oc adm must-gather` command in a specific namespace by using the `--run-namespace` option.
+
+.Example command for a specific namespace
+[source,terminal]
+----
+$ oc adm must-gather --image=quay.io/openshift-pipeline/must-gather --run-namespace=<namespace>
+----
+
+== Collecting debugging data for {pipelines-title}
+Use the `oc adm must-gather` CLI command to collect the following details about the cluster that is associated with {pipelines-title}:
+
+- The subscription and namespace of the {pipelines-title} Operator.
+- The namespaces where Tekton objects are available and the objects in those namespaces, such as `Pipeline`, `PipelineRun`, `Task`, `TaskRun`, `TektonConfig`, and configmaps.
+- Logs of the pods in the `openshift-operators` and `openshift-pipelines` namespaces.
+
+.Prerequisites
+- You have logged in to the OpenShift Container Platform cluster as an administrator.
+- You have installed the OpenShift Container Platform CLI (`oc`).
+- You have installed the {pipelines-title} Operator.
+
+.Procedure
+. Navigate to the directory where you want to store the debugging information.
+. Run the `oc adm must-gather` command with the {pipelines-shortname} `must-gather` image:
++
+[source,terminal]
+----
+$ oc adm must-gather --image=quay.io/openshift-pipeline/must-gather <1>
+----
+The must-gather image for OpenShift Pipelines.
++
+The `must-gather` tool creates a new directory that starts with `./must-gather.local` in the current directory.
+. Create a compressed file from the directory that was just created. For example, on a computer that uses a Linux or macOS operating system, run the following command:
++
+[source,terminal]
+----
+$ tar -cvaf must-gather.tar.gz must-gather.local.<random-hash> <1>
+----
+Replace `must-gather.local.<random-hash>` with the actual directory name.
+. Attach the compressed file to your support case on the Red Hat Customer Portal.
+
+.Verification
+* Verify that the `must-gather.tar.gz` file exists in your current working directory.


### PR DESCRIPTION
This pull request adds the new procedure module for gathering diagnostic information for OpenShift Pipelines, fully formatted according to the OpenShift contributor guidelines.

Version(s):
Latest (main)

Issue:
https://issues.redhat.com/browse/RHDEVDOCS-7365

Link to docs preview:
*Pending automated ocpdocs-previewbot build comment*

QE review:
- [x] QE has approved this change.

Additional information:
- Verified that the PR contains exactly one squashed commit.
- Document structure uses correct modular tags (`:_mod-docs-content-type: PROCEDURE`).
- Validated all step continuity blocks (`+` symbols) and itemization formatting.