### PR TITLE
TELCODOCS-2811: Reworking assembly for CQA errors

### DIFF
--- a/modules/troubleshooting-cc-false-positives.adoc
+++ b/modules/troubleshooting-cc-false-positives.adoc
@@ -1,0 +1,19 @@
+// Module included in the following assembly:
+//
+// * scalability_and_performance/cluster-compare/troubleshooting-cluster-comparisons.adoc
+
+:_mod-docs-content-type: PROCEDURE
+
+[id="troubleshooting-cc-false-positives_{context}"]
+= Troubleshooting false positives for missing resources
+
+[role="_abstract"]
+The plugin might report a missing resource even though the cluster custom resource (CR) is present in the cluster.
+
+.Procedure
+
+. Ensure you are using the latest version of the `cluster-compare` plugin. For more information, see "Installing the cluster-compare plugin".
+
+. Ensure you are using the most up-to-date version of the reference configuration.
+
+. Ensure that template has the same `apiVersion`, `kind`, `name`, and `namespace` fields as the cluster CR.

--- a/modules/troubleshooting-cc-multiple-matches.adoc
+++ b/modules/troubleshooting-cc-multiple-matches.adoc
@@ -1,0 +1,19 @@
+// Module included in the following assembly:
+//
+// * scalability_and_performance/cluster-compare/troubleshooting-cluster-comparisons.adoc
+
+:_mod-docs-content-type: PROCEDURE
+
+[id="troubleshooting-cc-multiple-matches_{context}"]
+= Troubleshooting multiple template matches for the same CR
+
+[role="_abstract"]
+In some cases, more than one cluster CR can match a template because they feature the same `apiVersion`, `namespace`, and `kind`. The plugin's default matching compares the CR that features the least differences.
+
+You can optionally configure your reference configuration to avoid this situation.
+
+.Procedure
+
+. Ensure the templates feature distinct `apiVersion`, `namespace`, and `kind` values to ensure no duplicate template matching.
+
+. Use a user configuration file to manually match a template to a CR. For more information, see "Configuring manual matching between CRs and templates".

--- a/scalability_and_performance/cluster-compare/troubleshooting-cluster-comparisons.adoc
+++ b/scalability_and_performance/cluster-compare/troubleshooting-cluster-comparisons.adoc
@@ -1,38 +1,18 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="troubleshooting-cluster-comparisons"]
 = Troubleshooting cluster comparisons
+
 include::_attributes/common-attributes.adoc[]
 :context: troubleshooting-cluster-comparisons
 
 toc::[]
 
-When using the `cluster-compare` plugin, you might see unexpected results, such as false positives or conflicts when multiple cluster custom resources (CRs) exist. 
+[role="_abstract"]
+When using the `cluster-compare` plugin, you might see unexpected results, such as false positives or conflicts when multiple cluster custom resources (CRs) exist.
 
-[id="troubleshooting-cc-false-positives_{context}"]
-== Troubleshooting false positives for missing resources
+include::modules/troubleshooting-cc-false-positives.adoc[leveloffset=+1]
 
-The plugin might report a missing resource even though the cluster custom resource (CR) is present in the cluster.
-
-.Procedure
-
-. Ensure you are using the latest version of the `cluster-compare` plugin. For more information, see "Installing the cluster-compare plugin".
-
-. Ensure you are using the most up-to-date version of the reference configuration.
-
-. Ensure that template has the same `apiVersion`, `kind`, `name`, and `namespace` fields as the cluster CR.
-
-[id="troubleshooting-cc-multiple-matches_{context}"]
-== Troubleshooting multiple template matches for the same CR
-
-In some cases, more than one cluster CR can match a template because they feature the same `apiVersion`, `namespace`, and `kind`. The plugin's default matching compares the CR that features the least differences.
-
-You can optionally configure your reference configuration to avoid this situation.
-
-.Procedure
-
-. Ensure the templates feature distinct `apiVersion`, `namespace`, and `kind` values to ensure no duplicate template matching.
-
-. Use a user configuration file to manually match a template to a CR. For more information, see "Configuring manual matching between CRs and templates".
+include::modules/troubleshooting-cc-multiple-matches.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 == Additional resources


### PR DESCRIPTION
[TELCODOCS-2811](https://redhat.atlassian.net/browse/TELCODOCS-2811): Reworking assembly for CQA errors

Version(s):
4.20+

Issue:
https://redhat.atlassian.net/browse/TELCODOCS-2811

Link to docs preview:
https://113819--ocpdocs-pr.netlify.app/openshift-enterprise/latest/scalability_and_performance/cluster-compare/troubleshooting-cluster-comparisons.html


