### PR TITLE
OCPBUGS 90610 Replace OCPBUGS-74176 changes

### DIFF
--- a/modules/nw-dns-cache-tuning.adoc
+++ b/modules/nw-dns-cache-tuning.adoc
@@ -6,7 +6,11 @@
 = Tuning the CoreDNS cache
 
 [role="_abstract"]
-For CoreDNS, you can configure the maximum duration of both successful or unsuccessful caching, also known respectively as positive or negative caching. Tuning the cache duration of DNS query responses can reduce the load for any upstream DNS resolvers.
+To reduce the load on upstream DNS resolvers, you can tune the CoreDNS cache by adjusting the duration of positive and negative caching. This process involves modifying the time-to-live (TTL) values within the DNS Operator object to control how long query responses are stored.
+
+For CoreDNS, you can configure the maximum duration of both successful or unsuccessful caching, also known respectively as positive or negative caching. Tuning the cache duration of DNS query responses can reduce the load for any upstream DNS resolvers. 
+
+You can shorten the TTL of the DNS record by setting a lower positive cache. You cannot increase the TTL on the DNS record by setting a higher positive cache. The maximum cache is the lower of the TTL of the DNS record or the positive cache.
 
 [WARNING]
 ====


### PR DESCRIPTION
https://redhat.atlassian.net/browse/OCPBUGS-90610

The changes introduced by https://github.com/openshift/openshift-docs/pull/106150 were overwritten by https://github.com/GroceryBoyJr/openshift-docs/commit/e1e37e8eba1#diff-7bd74e91e692780ff22a0d7df57a088fda57df64fa2db8f2f90b2fa6cca7cc9b. This PR replaces that change, most importantly,  [line 13](https://github.com/openshift/openshift-docs/pull/106150/changes#diff-7bd74e91e692780ff22a0d7df57a088fda57df64fa2db8f2f90b2fa6cca7cc9bR13).

4.22+

No QE; this PR fixes a docs error.