### PR TITLE
OSDOCS CQA MCO-1: MCO Core Configuration and Customization

### DIFF
--- a/machine_configuration/machine-config-pin-preload-images-about.adoc
+++ b/machine_configuration/machine-config-pin-preload-images-about.adoc
@@ -6,11 +6,12 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-A slow, unreliable connection to an image registry can interfere with operations that require pulling images, such as updating a cluster or deploying an application. This can include clusters that have low bandwidth, clusters with unreliable internet connectivity, or clusters in a disconnected environment. For example, a cluster update might require pulling more than one hundred images. Failure to pull those images could cause retries that can interfere with the update process and might cause the update to fail. 
+[role="_abstract"]
+You can prevent a slow, unreliable connection to an image registry from interfering with operations that require pulled images by pulling those images in advance and _pinning_ those images to a specific machine config pool (MCP) before they are actually needed. 
 
-One way to prevent this is to pull the required images in advance, before they are actually needed, and _pinning_ those images to a specific machine config pool (MCP). This ensures that the images are available to your nodes when needed. Pinned images can provide a more consistent update, which is important when scheduling updates into maintenance windows.
+This problem can affect clusters that have low bandwidth, clusters with unreliable internet connectivity, or clusters in a disconnected environment. For example, a cluster update might require pulling more than one hundred images. Failure to pull those images could cause retries that can interfere with the update process and might cause the update to fail. 
 
-Pinned images also ensures that the images are available when deploying applications, so that you can deploy in a more reliable manner. 
+By pinning images, you can ensure that the images are available to your nodes when needed for operations such as updating a cluster or deploying an application. You can provide a more consistent update, which is important when scheduling updates into maintenance windows. When deploying applications, you can pin images to ensure that the images are available, so that you can deploy in a more reliable manner. 
 
 You can pin images to specific nodes by using a `PinnedImageSet` custom resource (CR), as described in _Pinning images_. Pinned images are stored on the nodes in the `/etc/crio/crio.conf.d/50-pinned-images` file on those nodes. The contents of the file appear similar to the following example:
 

--- a/machine_configuration/machine-configs-custom.adoc
+++ b/machine_configuration/machine-configs-custom.adoc
@@ -6,8 +6,10 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
+In addition to `MachineConfig` objects, you can use `KubeletConfig` or `ContainerRuntimeConfig` custom resources to change node-level settings that impact how the kubelet and CRI-O container runtime services behave.
 
-Besides managing `MachineConfig` objects, the MCO manages two custom resources (CRs): `KubeletConfig` and `ContainerRuntimeConfig`. Those CRs let you change node-level settings impacting how the kubelet and CRI-O container runtime services behave.
+The kubelet configuration is currently serialized as an Ignition configuration, so it can be directly edited. However, there is also a new `kubelet-config-controller` added to the Machine Config Controller (MCC). This lets you use a `KubeletConfig` custom resource (CR) to edit the kubelet parameters.
 
 include::modules/create-a-kubeletconfig-crd-to-edit-kubelet-parameters.adoc[leveloffset=+1]
 

--- a/modules/create-a-containerruntimeconfig-crd.adoc
+++ b/modules/create-a-containerruntimeconfig-crd.adoc
@@ -6,7 +6,10 @@
 [id="create-a-containerruntimeconfig_{context}"]
 = Creating a ContainerRuntimeConfig CR to edit CRI-O parameters
 
-You can change some of the settings associated with the {product-title} CRI-O runtime for the nodes associated with a specific machine config pool (MCP). Using a `ContainerRuntimeConfig` custom resource (CR), you set the configuration values and add a label to match the MCP. The MCO then rebuilds the `crio.conf` and `storage.conf` configuration files on the associated nodes with the updated values.
+[role="_abstract"]
+You can change some of the settings associated with the {product-title} CRI-O runtime for the nodes associated with a specific machine config pool (MCP) by using a `ContainerRuntimeConfig` custom resource (CR).
+
+With a `ContainerRuntimeConfig` CR, you set the configuration values and add a label to match the MCP. The MCO then rebuilds the `crio.conf` and `storage.conf` configuration files on the associated nodes with the updated values.
 
 [NOTE]
 ====
@@ -32,13 +35,13 @@ If you want to delete the machine configs, you should delete them in reverse ord
 If you have a machine config with a `containerruntime-9` suffix, and you create another `ContainerRuntimeConfig` CR, a new machine config is not created, even if there are fewer than 10 `containerruntime` machine configs.
 ====
 
-.Example showing multiple `ContainerRuntimeConfig` CRs
+The following example command and output show multiple `ContainerRuntimeConfig` CRs:
+
 [source,terminal]
 ----
 $ oc get ctrcfg
 ----
 
-.Example output
 [source,terminal]
 ----
 NAME         AGE
@@ -46,13 +49,13 @@ ctr-overlay  15m
 ctr-level    5m45s
 ----
 
-.Example showing multiple `containerruntime` machine configs
+The following example command and output show multiple `containerruntime` machine configs:
+
 [source,terminal]
 ----
 $ oc get mc | grep container
 ----
 
-.Example output
 [source,terminal]
 ----
 ...
@@ -68,7 +71,6 @@ $ oc get mc | grep container
 
 The following example sets the `log_level` field to `debug`, sets the overlay size to 8 GB, and configures runC as the container runtime:
 
-.Example `ContainerRuntimeConfig` CR
 [source,yaml]
 ----
 apiVersion: machineconfiguration.openshift.io/v1
@@ -78,20 +80,22 @@ metadata:
 spec:
  machineConfigPoolSelector:
    matchLabels:
-     pools.operator.machineconfiguration.openshift.io/worker: '' <1>
+     pools.operator.machineconfiguration.openshift.io/worker: ''
  containerRuntimeConfig:
-   logLevel: debug <2>
-   overlaySize: 8G <3>
-   defaultRuntime: "runc" <4>
+   logLevel: debug
+   overlaySize: 8G
+   defaultRuntime: "runc"
 ----
-<1> Specifies the machine config pool label. For a container runtime config, the role must match the name of the associated machine config pool.
-<2> Optional: Specifies the level of verbosity for log messages.
-<3> Optional: Specifies the maximum size of a container image.
-<4> Optional: Specifies the container runtime to deploy to new containers, either `crun` or `runc`. The default value is `crun`.
+where:
+
+`spec.machineConfigPoolSelector.matchLabels`:: Specifies the machine config pool label. For a container runtime config, the role must match the name of the associated machine config pool.
+`spec.containerRuntimeConfig.logLevel`:: Specifies the level of verbosity for log messages. This parameter is optional.
+`spec.containerRuntimeConfig.overlaySize`:: Specifies the maximum size of a container image. This parameter is optional.
+`spec.containerRuntimeConfig.defaultRuntime`:: Specifies the container runtime to deploy to new containers, either `crun` or `runc`. The default value is `crun`. This parameter is optional.
+
+The following procedure shows how to change CRI-O settings by using a `ContainerRuntimeConfig` CR.
 
 .Procedure
-
-To change CRI-O settings using the `ContainerRuntimeConfig` CR:
 
 . Create a YAML file for the `ContainerRuntimeConfig` CR:
 +
@@ -104,14 +108,17 @@ metadata:
 spec:
  machineConfigPoolSelector:
    matchLabels:
-     pools.operator.machineconfiguration.openshift.io/worker: '' <1>
- containerRuntimeConfig: <2>
+     pools.operator.machineconfiguration.openshift.io/worker: ''
+ containerRuntimeConfig:
    logLevel: debug
    overlaySize: 8G
    defaultRuntime: "runc"
 ----
-<1> Specify a label for the machine config pool that you want you want to modify.
-<2> Set the parameters as needed.
++
+where:
+
+`spec.machineConfigPoolSelector.matchLabels`:: Set a label for the machine config pool that you want you want to modify.
+`spec.containerRuntimeConfig`:: Set the parameters as needed.
 
 . Create the `ContainerRuntimeConfig` CR:
 +
@@ -155,7 +162,6 @@ $ oc get mcp worker
 ----
 +
 .Example output
-+
 [source,terminal]
 ----
 NAME    CONFIG               UPDATED  UPDATING  DEGRADED  MACHINECOUNT  READYMACHINECOUNT  UPDATEDMACHINECOUNT  DEGRADEDMACHINECOUNT  AGE
@@ -184,7 +190,6 @@ sh-4.4# crio config | grep 'log_level'
 ----
 +
 .Example output
-+
 [source,terminal]
 ----
 log_level = "debug"

--- a/modules/create-a-kubeletconfig-crd-to-edit-kubelet-parameters.adoc
+++ b/modules/create-a-kubeletconfig-crd-to-edit-kubelet-parameters.adoc
@@ -7,7 +7,8 @@
 [id="create-a-kubeletconfig-crd-to-edit-kubelet-parameters_{context}"]
 = Creating a KubeletConfig CR to edit kubelet parameters
 
-The kubelet configuration is currently serialized as an Ignition configuration, so it can be directly edited. However, there is also a new `kubelet-config-controller` added to the Machine Config Controller (MCC). This lets you use a `KubeletConfig` custom resource (CR) to edit the kubelet parameters.
+[role="_abstract"]
+You can use a `KubeletConfig` custom resource (CR) to edit a kubelet parameters without modifing the kubelet configuration directly.
 
 [NOTE]
 ====
@@ -49,7 +50,8 @@ If you want to delete the machine configs, delete them in reverse order to avoid
 If you have a machine config with a `kubelet-9` suffix, and you create another `KubeletConfig` CR, a new machine config is not created, even if there are fewer than 10 `kubelet` machine configs.
 ====
 
-.Example `KubeletConfig` CR
+The following example command and output show a `KubeletConfig` CR:
+
 [source,terminal]
 ----
 $ oc get kubeletconfig
@@ -61,7 +63,8 @@ NAME                      AGE
 set-kubelet-config        15m
 ----
 
-.Example showing a `KubeletConfig` machine config
+The following example command and output show a `KubeletConfig` machine config:
+
 [source,terminal]
 ----
 $ oc get mc | grep kubelet
@@ -104,9 +107,10 @@ metadata:
   creationTimestamp: 2019-02-08T14:52:39Z
   generation: 1
   labels:
-    custom-kubelet: set-kubelet-config <1>
+    custom-kubelet: set-kubelet-config
 ----
-<1> If a label has been added it appears under `labels`.
++
+The `metadata.labels` parameter specifies labels you can use with a `KubeletConfig` CR.
 
 .. If the label is not present, add a key/value pair:
 +
@@ -172,14 +176,17 @@ metadata:
 spec:
   machineConfigPoolSelector:
     matchLabels:
-      custom-kubelet: set-kubelet-config <1>
-  kubeletConfig: <2>
+      custom-kubelet: set-kubelet-config
+  kubeletConfig:
       podPidsLimit: 8192
       containerLogMaxSize: 50Mi
       maxPods: 500
 ----
-<1> Enter the label from the machine config pool.
-<2> Add the kubelet configuration. For example: 
++
+where:
+
+`spec.machineConfigPoolSelector.matchLabels`:: Specifies the label from the machine config pool.
+`spec.kubeletConfig`:: Specifies the kubelet configuration. For example: 
 +
 --
 * Use `podPidsLimit` to set the maximum number of PIDs in any pod.
@@ -262,10 +269,11 @@ Allocatable:
   hugepages-1Gi:              0
   hugepages-2Mi:              0
   memory:                     14225400Ki
-  pods:                       500 <1>
+  pods:                       500
  ...
 ----
-<1> In this example, the `pods` parameter should report the value you set in the `KubeletConfig` object.
++
+In this example, the `pods` parameter should report the value you set in the `KubeletConfig` object.
 
 . Verify the change in the `KubeletConfig` object:
 +

--- a/modules/create-crio-default-capabilities.adoc
+++ b/modules/create-crio-default-capabilities.adoc
@@ -6,7 +6,10 @@
 [id="create-crio-default-capabilities_{context}"]
 = Creating a drop-in file for the default CRI-O capabilities
 
-You can change some of the settings associated with the {product-title} CRI-O runtime for the nodes associated with a specific machine config pool (MCP). By using a controller custom resource (CR), you set the configuration values and add a label to match the MCP. The Machine Config Operator (MCO) then rebuilds the `crio.conf` and `default.conf` configuration files on the associated nodes with the updated values.
+[role="_abstract"]
+You can change some of the settings associated with the {product-title} CRI-O runtime for the nodes associated with a specific machine config pool (MCP) by using a controller custom resource (CR). 
+
+You set the configuration values and add a label to match the MCP in a `ContainerRuntimeConfig` CR. The Machine Config Operator (MCO) then rebuilds the `crio.conf` and `default.conf` configuration files on the associated nodes with the updated values.
 
 Earlier versions of {product-title} included specific machine configs by default. If you updated to a later version of {product-title}, those machine configs were retained to ensure that clusters running on the same {product-title} version have the same machine configs.
 
@@ -41,6 +44,7 @@ $ cat /proc/1/status | grep Cap
 
 [source,terminal]
 ----
-$ capsh --decode=<decode_CapBnd_value> <1>
+$ capsh --decode=<decode_CapBnd_value>
 ----
-<1> Replace `<decode_CapBnd_value>` with the specific value you want to decode.
+
+Replace `<decode_CapBnd_value>` with the specific value you want to decode.

--- a/modules/machine-config-pin-preload-images.adoc
+++ b/modules/machine-config-pin-preload-images.adoc
@@ -6,7 +6,10 @@
 [id="machine-config-pin-preload-images_{context}"]
 = Pinning images
 
-You can pin images to your nodes by using a `PinnedImageSet` custom resource (CR). The pinned image set defines the list of images to pre-load and the machine config pool to which the images should be pinned.
+[role="_abstract"]
+You can pin images to your nodes by using a `PinnedImageSet` custom resource (CR) making the images available to your nodes when needed for operations such as updating a cluster or deploying an application.
+
+The pinned image set defines the list of images to pre-load and the machine config pool to which the images should be pinned.
 
 The images are stored in the `/etc/crio/crio.conf.d/50-pinned-images` file on the nodes. 
 
@@ -24,11 +27,11 @@ Only images that you can successfully inspect with the `podman manifest inspect 
 apiVersion: machineconfiguration.openshift.io/v1
 kind: PinnedImageSet
 metadata:
-  labels: <1>
+  labels:
     machineconfiguration.openshift.io/role: worker
   name: worker-pinned-images
 spec:
-  pinnedImages: <2>
+  pinnedImages:
    - name: quay.io/openshift-release-dev/ocp-release@sha256:513cf1028aa1a021fa73d0601427a0fbcf6d212b88aaf9d76d4e4841a061e44e
    - name: quay.io/openshift-release-dev/ocp-release@sha256:61eae2d261e54d1b8a0e05f6b5326228b00468364563745eed88460af04f909b
 ----
@@ -36,8 +39,8 @@ spec:
 where:
 +
 --
-`labels`:: Specifies an optional node selector to specify the machine config pool to pin the images to. If not specified, the images are pinned to all nodes in the cluster.
-`pinnedImages`:: Specifies a list of one or more images to pre-load.
+`metadata.labels`:: Specifies an optional node selector to specify the machine config pool to pin the images to. If not specified, the images are pinned to all nodes in the cluster.
+`spec.pinnedImages`:: Specifies a list of one or more images to pre-load.
 --
 
 . Create the `PinnedImageSet` object by running the following command:
@@ -63,7 +66,6 @@ $ oc describe machineconfignode ci-ln-25hlkvt-72292-jrs48-worker-a-2bdj
 ----
 +
 .Example output for a successful image pull and pin
-+
 [source,terminal]
 ----
 apiVersion: machineconfiguration.openshift.io/v1
@@ -77,14 +79,18 @@ status
   pinnedImageSets:
   - currentGeneration: 1
     desiredGeneration: 1
-    name: worker-pinned-images <1>
+    name: worker-pinned-images
 ----
-<1> The `PinnedImageset` object is associated with the machine config node.
++
+where:
++
+--
+`status.pinnedImageSets`:: Specifies that the `PinnedImageSet` object you created is associated with the machine config node.
+--
 +
 Any failures or error messages would appear in the `MachineConfigNode` object status fields, as shown in the following example:
 +
 .Example output for a failed image pull and pin
-+
 [source,terminal]
 ----
 apiVersion: machineconfiguration.openshift.io/v1
@@ -136,7 +142,6 @@ $ cat /etc/crio/crio.conf.d/50-pinned-images
 ----
 +
 .Example output
-+
 [source,terminal]
 ----
 [crio]

--- a/modules/set-the-default-max-container-root-partition-size-for-overlay-with-crio.adoc
+++ b/modules/set-the-default-max-container-root-partition-size-for-overlay-with-crio.adoc
@@ -6,7 +6,10 @@
 [id="set-the-default-max-container-root-partition-size-for-overlay-with-crio_{context}"]
 = Setting the default maximum container root partition size for Overlay with CRI-O
 
-The root partition of each container shows all of the available disk space of the underlying host. Follow this guidance to set a maximum partition size for the root disk of all containers.
+[role="_abstract"]
+You can use a `ContainerRuntimeConfig` custom resource (CR) to set a maximum partition size for the root disk of all containers.
+
+The root partition of each container shows all of the available disk space of the underlying host.
 
 To configure the maximum Overlay size, as well as other CRI-O options like the log level, you can create the following `ContainerRuntimeConfig` custom resource definition (CRD):
 


### PR DESCRIPTION
https://redhat.atlassian.net/browse/OSDOCS-16921

Previews
Machine configuration -> [Pinning images to nodes](https://113845--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_configuration/machine-config-pin-preload-images-about.html)
Machine configuration -> [Configuring MCO-related custom resources](https://113845--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_configuration/machine-configs-custom)


Assemblies:
machine-config-pin-preload-images.adoc
machine-configs-custom.adoc