### PR TITLE
CNV-83807: Introduce new VolumeRestorePolicy to have target VM name in restored PVCs names (for enterprise-4.22)

### DIFF
--- a/modules/virt-restoring-vm-from-snapshot-cli.adoc
+++ b/modules/virt-restoring-vm-from-snapshot-cli.adoc
@@ -20,6 +20,10 @@ You can restore an existing virtual machine (VM) to a previous configuration by 
 ** `StopTarget` - If the VM is not ready, it gets stopped, and the restore process starts.
 ** `WaitGracePeriod 5` - The restore process waits for a set amount of time, in minutes, for the VM to be ready. This is the default setting, with the default value set to 5 minutes.
 ** `WaitEventually` - The restore process waits indefinitely for the VM to be ready.
+* Optional: To control the naming of restored persistent volume claims (PVCs), you can set the `volumeRestorePolicy` parameter to one of the following values:
+** `PrefixTargetName` - The restored PVC names use the target VM name as a prefix: `<vm_name>-<volume_name>`.
+** `RandomizeNames` - The system generates the restored PVC names randomly: `restore-<uid>-<volume_name>`.
+** `InPlace` - The restored PVCs overwrite the original PVCs. The system deletes the original PVCs if they exist and creates new PVCs with the same names. This is the default setting.
 
 .Procedure
 


### PR DESCRIPTION
Resolves: https://redhat.atlassian.net/browse/CNV-83807

CNV 4.22, 5.0
OCP 4.22, 5.0

Preview: https://113853--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/backup_restore/virt-backup-restore-snapshots.html#virt-restoring-vm-from-snapshot-cli_virt-backup-restore-snapshots