### PR TITLE
OSDOCS-18105 [ROSA]: New Feature Log Forwarding in UI 

### DIFF
--- a/modules/rosa-create-cluster-log-forwarding-ui.adoc
+++ b/modules/rosa-create-cluster-log-forwarding-ui.adoc
@@ -1,0 +1,54 @@
+// Module included in the following assemblies:
+//
+// * observability/logging/rosa-forwarding-control-plane-logs.adoc
+:_mod-docs-content-type: PROCEDURE
+[id="rosa-create-cluster-log-forwarding-ui_{context}"]
+= Create a {product-title} cluster with log forwarding
+
+[role="_abstract"]
+You can set up control plane log forwarding when you create your {product-title} cluster in the {hybrid-console}. As you create your {product-title} cluster, you have the option to forward your control plane logs to an Amazon `S3` bucket, `CloudWatch` log group, or both. 
+
+.Procedure
+
+. In the {hybrid-console}, go to *Clusters* -> *Cluster List*, then click the *Create cluster* button.
+. On the *Managed services* offerings page, go to the offering, *Red Hat OpenShift Service on AWS (ROSA)*, and click the *Create cluster* button, then select *With web interface*.
+. For *Create a ROSA Cluster* -> *Control plane*, select your *ROSA hosted architecture*.
+. For *Accounts and roles*, select your *Associated AWS infrastructure account* and *AWS billing account*.
+. For the *Cluster settings* -> *Cluster details*, complete the following text boxes:
++
+* *Region*
+* *Cluster name*
+* *Version*
+* *Channel*
+
++ 
+In about 20 minutes after you complete this information, your cluster is ready to install and you can continue to configure it.
+. For *Machine pool* -> *Networking* -> *Configuration* -> *CIDR ranges* -> *Cluster roles and policies*, complete all of the required text boxes with the specifications that you want for your cluster.
+. On the *Review and create* -> *Review your ROSA cluster* page, verify that the cluster details are correct.
+. Optional: If you want to forward your control plane logs to an Amazon `S3` bucket or `CloudWatch` log group, complete the following instructions:
+.. On the *Control plane log forwarding (optional)* page, click *Enable Amazon S3*, or *Enable CloudWatch*, or both.
+.. If you enable Amazon `S3`, complete the following fields:
++
+* *Bucket name*: Give it a unique identifier across all of {AWS}.
+* *Bucket prefix*: Give it an optional path to organize your data.
+* *Select groups and applications* (optional): When you select a group, the log forwarder collects all of the applications and related services from that group.
+.. If you enable `CloudWatch`, complete the following fields:
++
+* *Prerequisite*: Verify that you have created an `IAM` role and policy, then click the box stating that you have.
+* *Log group name*: Give it a unique identifier.
+* *Role ARN*: Give the `IAM` role ARN. For example, `arn:aws:iam::<12-digit-account-id>:role/<role-name>`.
+* *Select groups and applications*: When you select a group, the log forwarder collects all the applications and related services from that group.
+.. On the *Review and create* -> *Review your ROSA cluster* page, verify that the cluster details are correct.
+.. Click the *Create cluster* button.
+. If you want to finish completing your cluster with no designated log forwarding destination, click the *Create cluster* button.
+
+.Verification 
+
+. In the {hybrid-console}, go to *Clusters* -> *Cluster List*.  You can see the name and status of your cluster.
+. Verify that the status of your cluster is “Ready” and click the name of your cluster.
+. In the *Overview* tab, verify that the details of your cluster are what you specified.
+. Go to the *Control plane log forwarding* section.
+.. If you enabled `Amazon S3`, verify that you see *Amazon S3: Enabled*. If you did not set it up, it shows, *Amazon S3: Disabled*.
+.. If you enabled `CloudWatch`, verify that you see *CloudWatch: Enabled*. If you did not set it up, it shows, *CloudWatch: Disabled*.
+. Click *View details*, which takes you to the *Settings* tab. Confirm all the specific details for your control plane log forwarding are correct.
+

--- a/modules/rosa-create-cluster-ui-log-groups.adoc
+++ b/modules/rosa-create-cluster-ui-log-groups.adoc
@@ -1,0 +1,13 @@
+// Module included in the following assemblies:
+//
+// * observability/logging/rosa-configuring-the-log-forwarder.adoc
+:_mod-docs-content-type: CONCEPT
+[id="rosa-create-cluster-ui-log-groups_{context}"]
+= Creating a {product-title} cluster in the {hybrid-console}
+
+[role="_abstract"]
+You can forward logs from your {product-title} cluster to `CloudWatch`, `S3`, or both. When you forward your control plane logs, you can store them in the infrastructure that you designated, helping you meet compliance and audit requirements and workflows. 
+
+In the {hybrid-console}, you set up your {product-title} cluster to forward control plane logs when you create the cluster. Then, you can continue to use the web user interface (UI) to forward your control plane logs.
+
+Enable control plane log forwarding when you create the cluster to ensure a complete audit trail. If enabled later, the feature cannot capture logs generated before the activation, leaving gaps in your data.

--- a/modules/rosa-edit-cluster-log-forwarding-ui.adoc
+++ b/modules/rosa-edit-cluster-log-forwarding-ui.adoc
@@ -1,0 +1,30 @@
+// Module included in the following assemblies:
+//
+// * observability/logging/rosa-forwarding-control-plane-logs.adoc
+:_mod-docs-content-type: PROCEDURE
+[id="rosa-edit-cluster-log-forwarding-ui_{context}"]
+= Edit a {product-title} cluster with log forwarding
+
+[role="_abstract"]
+You can verify the status of log forwarding for a cluster and edit the log forwarding configurations.
+
+.Procedure
+
+. In the {hybrid-console}, go to *Clusters* -> *Cluster List*, then click the name of your cluster.
+. Go to the *Settings* tab then the *Control plane log forwarding* section.
+. To add to your log forwarding, click the *Add configuration* dropdown button.
+.. You can add a `CloudWatch` or `Amazon S3` configuration.
+. To make changes to your existing log forwarding, click the three dots within your `CloudWatch` or `Amazon S3` log forwarding configuration, then select *Edit configuration* or *Delete configuration*.
+. When you click *Edit configuration* for `Amazon S3` log forwarding, you see your configuration and can make changes to the following:
+* *Bucket Name*
+* *Bucket Prefix*
+* *Select groups and applications*
+. When you click *Edit configuration* for `CloudWatch` log forwarding, you see your configuration and can make changes to the following:
+* *Log group name*
+* *Role ARN*
+* *Select groups and applications*
+. Make the changes to your configuration, then click *Save*.
+
+.Verification
+
+. In the *Settings* tab -> *Control plane log forwarding* section, verify that you see the changes you made to your configuration. The changes you made instantly go through and appear in this section.

--- a/observability/logging/rosa-forwarding-control-plane-logs.adoc
+++ b/observability/logging/rosa-forwarding-control-plane-logs.adoc
@@ -22,3 +22,9 @@ include::modules/rosa-set-up-cloudwatch-log-group.adoc[leveloffset=+1]
 include::modules/rosa-set-up-s3-bucket.adoc[leveloffset=+1]
 
 include::modules/rosa-manage-control-plane-log-forwarding.adoc[leveloffset=+1]
+
+include::modules/rosa-create-cluster-ui-log-groups.adoc[leveloffset=+1]
+
+include::modules/rosa-create-cluster-log-forwarding-ui.adoc[leveloffset=+1]
+
+include::modules/rosa-edit-cluster-log-forwarding-ui.adoc[leveloffset=+1]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.21+ 

Issue:
Jira: https://redhat.atlassian.net/browse/OSDOCS-18105 

Relevant PR: This PR was originally for the work before we had to pause due to more feature updates: https://github.com/openshift/openshift-docs/pull/112116 

Link to docs preview:
https://113857--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/observability/logging/rosa-forwarding-control-plane-logs.html#rosa-create-cluster-ui-log-groups_rosa-configuring-the-log-forwarder

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
