### PR TITLE
OSDOCS-20257 created zstream RNs for 4-13-68

### DIFF
--- a/modules/zstream-4-13-68-about.adoc
+++ b/modules/zstream-4-13-68-about.adoc
@@ -1,0 +1,15 @@
+:_mod-docs-content-type: CONCEPT
+[id="zstream-4-13-68-about_{context}"]
+= RHSA-2026:26543 - {product-title} 4.13.68 fixed issues and security update
+
+Issued: 25 June 2026
+
+[role="_abstract"]
+{product-title} release 4.13.68, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2026:26543[RHSA-2026:26543] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2026:26541[RHSA-2026:26541] advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.13.68 --pullspecs
+----

--- a/modules/zstream-4-13-68-bug-fixes.adoc
+++ b/modules/zstream-4-13-68-bug-fixes.adoc
@@ -1,0 +1,7 @@
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-13-68-bug-fixes_{context}"]
+= Fixed issues
+
+[role="_abstract"]
+
+There are no notable fixed issues in this release.

--- a/modules/zstream-4-13-68-updating.adoc
+++ b/modules/zstream-4-13-68-updating.adoc
@@ -1,0 +1,6 @@
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-13-68-updating_{context}"]
+= Updating
+
+[role="_abstract"]
+To update an existing {product-title} 4.13 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].

--- a/release_notes/ocp-4-13-release-notes.adoc
+++ b/release_notes/ocp-4-13-release-notes.adoc
@@ -4686,3 +4686,10 @@ include::modules/zstream-4-13-67-about.adoc[leveloffset=+2]
 include::modules/zstream-4-13-67-bug-fixes.adoc[leveloffset=+2]
 
 include::modules/zstream-4-13-67-updating.adoc[leveloffset=+2]
+
+//4.13.68
+include::modules/zstream-4-13-68-about.adoc[leveloffset=+2]
+
+include::modules/zstream-4-13-68-bug-fixes.adoc[leveloffset=+2]
+
+include::modules/zstream-4-13-68-updating.adoc[leveloffset=+2]


### PR DESCRIPTION
Version(s):
4.13

Issue:
https://redhat.atlassian.net/browse/OSDOCS-20257

Link to docs preview:
https://113859--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-13-release-notes.html#zstream-4-13-68-about_release-notes

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
