### PR TITLE
OSDOCS-17038: Final Agent CQA PR

### DIFF
--- a/installing/installing_with_agent_based_installer/installation-config-parameters-agent.adoc
+++ b/installing/installing_with_agent_based_installer/installation-config-parameters-agent.adoc
@@ -6,7 +6,9 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 Before you deploy an {product-title} cluster using the Agent-based Installer, you provide parameters to customize your cluster and the platform that hosts it.
+
 When you create the `install-config.yaml` and `agent-config.yaml` files, you must provide values for the required parameters, and you can use the optional parameters to customize your cluster further.
 
 include::modules/installation-configuration-parameters.adoc[leveloffset=+1]
@@ -22,4 +24,5 @@ include::modules/agent-configuration-parameters.adoc[leveloffset=+1]
 [role="_additional-resources"]
 .Additional resources
 * xref:../../installing/installing_with_agent_based_installer/prepare-pxe-assets-agent.adoc#prepare-pxe-assets-agent[Preparing PXE assets for {product-title}]
+* link:https://nmstate.io/[Declarative Network API (nmstate documentation)]
 * xref:../../installing/installing_bare_metal/ipi/ipi-install-installation-workflow.adoc#root-device-hints_ipi-install-installation-workflow[Root device hints]

--- a/installing/installing_with_agent_based_installer/prepare-pxe-assets-agent.adoc
+++ b/installing/installing_with_agent_based_installer/prepare-pxe-assets-agent.adoc
@@ -11,7 +11,7 @@ You can create the assets needed to PXE boot an {product-title} cluster by using
 
 The assets you create in these procedures will deploy a single-node {product-title} installation. You can use these procedures as a basis and modify configurations according to your requirements.
 
-See xref:../../installing/installing_with_agent_based_installer/installing-with-agent-based-installer.adoc#installing-with-agent-based-installer[Installing an {product-title} cluster with the Agent-based Installer] to learn about more configurations available with the Agent-based Installer.
+See "Installing an {product-title} cluster with the Agent-based Installer" to learn about more configurations available with the Agent-based Installer.
 
 include::modules/installing-ocp-agent-prereqs.adoc[leveloffset=+1]
 
@@ -68,3 +68,8 @@ include::modules/adding-ibm-z-lpar-agent.adoc[leveloffset=+2]
 
 * xref:../../installing/installing_ibm_z/upi/installing-ibm-z-lpar.adoc#installing-ibm-z-lpar[Installing a cluster in an LPAR on {ibm-z-title} and {ibm-linuxone-title}]
 
+[role="_additional-resources"]
+[id="additional-resources_{context}"]
+== Additional resources
+
+* xref:../../installing/installing_with_agent_based_installer/installing-with-agent-based-installer.adoc#installing-with-agent-based-installer[Installing an {product-title} cluster with the Agent-based Installer]

--- a/installing/installing_with_agent_based_installer/preparing-an-agent-based-installed-cluster-for-mce.adoc
+++ b/installing/installing_with_agent_based_installer/preparing-an-agent-based-installed-cluster-for-mce.adoc
@@ -1,25 +1,26 @@
 :_mod-docs-content-type: ASSEMBLY
-[id="preparing-an-agent-based-installed-cluster-for-mce"]
 include::_attributes/common-attributes.adoc[]
+[id="preparing-an-agent-based-installed-cluster-for-mce"]
 = Preparing an Agent-based installed cluster for the {mce}
 :context: preparing-an-agent-based-installed-cluster-for-mce
 
 toc::[]
 
-You can install the {mce-short} and deploy a hub cluster with the Agent-based {product-title} Installer.
+[role="_abstract"]
+You can install the {mce-short} and deploy a hub cluster with the Agent-based Installer.
+
 The following procedure is partially automated and requires manual steps after the initial cluster is deployed.
 
-[id="prerequisites_{context}"]
-== Prerequisites
-* You have read the following documentation:
-** link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.9/html/clusters/cluster_mce_overview[Cluster lifecycle with multicluster engine operator overview].
-** xref:../../storage/persistent_storage_local/persistent-storage-local.adoc#persistent-storage-using-local-volume[Persistent storage using local volumes].
-** xref:../../edge_computing/ztp-deploying-far-edge-clusters-at-scale.adoc#about-ztp_ztp-deploying-far-edge-clusters-at-scale[Using {ztp} to provision clusters at the network far edge].
-** xref:../../installing/installing_with_agent_based_installer/preparing-to-install-with-agent-based-installer.adoc#preparing-to-install-with-agent-based-installer[Preparing to install with the Agent-based Installer].
-** xref:../../disconnected/index.adoc#installing-mirroring-disconnected-about[About disconnected installation mirroring].
-* You have access to the internet to obtain the necessary container images.
-* You have installed the OpenShift CLI (`oc`).
-* If you are installing in a disconnected environment, you must have a configured local mirror registry for disconnected installation mirroring.
+include::modules/preparing-mce-prereqs.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.9/html/clusters/cluster_mce_overview[Cluster lifecycle with multicluster engine operator overview]
+* xref:../../storage/persistent_storage_local/persistent-storage-local.adoc#persistent-storage-using-local-volume[Persistent storage using local volumes]
+* xref:../../edge_computing/ztp-deploying-far-edge-clusters-at-scale.adoc#about-ztp_ztp-deploying-far-edge-clusters-at-scale[Using {ztp} to provision clusters at the network far edge]
+* xref:../../installing/installing_with_agent_based_installer/preparing-to-install-with-agent-based-installer.adoc#preparing-to-install-with-agent-based-installer[Preparing to install with the Agent-based Installer]
+* xref:../../disconnected/index.adoc#installing-mirroring-disconnected-about[About disconnected installation mirroring]
 
 // Preparing an Agent-based cluster deployment for the multicluster engine for Kubernetes operator while disconnected
 include::modules/preparing-an-initial-cluster-deployment-for-mce-disconnected.adoc[leveloffset=+1]

--- a/installing/installing_with_agent_based_installer/understanding-disconnected-installation-mirroring.adoc
+++ b/installing/installing_with_agent_based_installer/understanding-disconnected-installation-mirroring.adoc
@@ -6,16 +6,15 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 // Reusing applicable content from Disconnected installation mirroring assembly
+[role="_abstract"]
+You can use a mirror registry for disconnected installations and to ensure that your clusters only use container images that satisfy your organization's controls on external content.
 
-You can use a mirror registry for disconnected installations and to ensure that your clusters only use container images that satisfy your organization's controls on external content. Before you install a cluster on infrastructure that you provision in a disconnected environment, you must mirror the required container images into that environment. To mirror container images, you must have a registry for mirroring.
-
-[id="agent-install-mirroring-images-disconnected_{context}"]
-== Mirroring images for a disconnected installation through the Agent-based Installer
+Before you install a cluster on infrastructure that you provision in a disconnected environment, you must mirror the required container images into that environment. To mirror container images, you must have a registry for mirroring.
 
 You can use one of the following procedures to mirror your {product-title} image repository to your mirror registry:
 
-* xref:../../disconnected/installing-mirroring-installation-images.adoc#installing-mirroring-installation-images[Mirroring images for a disconnected installation]
-* xref:../../disconnected/about-installing-oc-mirror-v2.adoc#about-installing-oc-mirror-v2[Mirroring images for a disconnected installation by using the oc-mirror plugin v2]
+* "Mirroring images for a disconnected installation by using the oc-mirror plugin v2"
+* "Mirroring images for a disconnected installation"
 
 include::modules/agent-install-about-mirroring-for-disconnected-registry.adoc[leveloffset=+1]
 
@@ -25,4 +24,6 @@ include::modules/agent-install-configuring-for-disconnected-registry.adoc[levelo
 [id="additional-resources_{context}"]
 == Additional resources
 
+* xref:../../disconnected/about-installing-oc-mirror-v2.adoc#about-installing-oc-mirror-v2[Mirroring images for a disconnected installation by using the oc-mirror plugin v2]
+* xref:../../disconnected/installing-mirroring-installation-images.adoc#installing-mirroring-installation-images[Mirroring images for a disconnected installation]
 * xref:../../installing/installing_with_agent_based_installer/installing-with-agent-based-installer.adoc#installing-with-agent-based-installer[Installing an {product-title} cluster with the Agent-based Installer]

--- a/modules/agent-configuration-parameters.adoc
+++ b/modules/agent-configuration-parameters.adoc
@@ -6,9 +6,10 @@
 [id="agent-configuration-parameters_{context}"]
 = Available Agent configuration parameters
 
-The following tables specify the required and optional Agent configuration parameters that you can set as part of the Agent-based installation process.
+[role="_abstract"]
+To customize your cluster installation, configuration parameters are available to use in the `agent-config.yaml` file.
 
-These values are specified in the `agent-config.yaml` file.
+The following tables specify the required and optional Agent configuration parameters that you can set as part of the Agent-based installation process.
 
 [NOTE]
 ====
@@ -145,7 +146,7 @@ For more information, see "Root device hints" in the "Setting up the environment
 |hosts:
   networkConfig:
 |The host network definition.
-The configuration must match the Host Network Management API defined in the link:https://nmstate.io/[nmstate documentation].
+The configuration must match the Host Network Management API defined in the "Declarative Network API (nmstate documentation)".
 
 *Value:* A dictionary of host network configuration objects.
 

--- a/modules/agent-install-about-mirroring-for-disconnected-registry.adoc
+++ b/modules/agent-install-about-mirroring-for-disconnected-registry.adoc
@@ -8,6 +8,7 @@
 [id="agent-install-about-mirroring-for-disconnected-registry_{context}"]
 = About mirroring the {product-title} image repository for a disconnected registry
 
+[role="_abstract"]
 To use mirror images for a disconnected installation with the Agent-based Installer, you must modify the `install-config.yaml` file.
 
 You can mirror the release image by using the output of either the `oc adm release mirror` or `oc mirror` command.

--- a/modules/agent-install-configuring-for-disconnected-registry.adoc
+++ b/modules/agent-install-configuring-for-disconnected-registry.adoc
@@ -6,6 +6,7 @@
 [id="agent-install-configuring-for-disconnected-registry_{context}"]
 = Configuring the Agent-based Installer to use mirrored images
 
+[role="_abstract"]
 You must use the output of either the `oc adm release mirror` command or the oc-mirror plugin to configure the Agent-based Installer to use mirrored images.
 
 .Procedure

--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -69,6 +69,8 @@ ifndef::agent,generic[]
 = Available installation configuration parameters for {platform}
 
 [role="_abstract"]
+To customize your cluster installation, configuration parameters are available to use in the `install-config.yaml` file.
+
 The following tables specify the required, optional, and {platform}-specific installation configuration parameters that you can set as part of the installation process.
 
 [IMPORTANT]
@@ -80,12 +82,18 @@ endif::agent,generic[]
 ifdef::generic[]
 = Available installation configuration parameters
 
+[role="_abstract"]
+To customize your cluster installation, configuration parameters are available to use in the `install-config.yaml` file.
+
 The following tables specify the required, network, and optional installation configuration parameters that you can set as part of the installation process.
 
 endif::generic[]
 
 ifdef::agent[]
 = Available installation configuration parameters
+
+[role="_abstract"]
+To customize your cluster installation, configuration parameters are available to use in the `install-config.yaml` file.
 
 The following tables specify the required and optional installation configuration parameters that you can set as part of the Agent-based installation process.
 

--- a/modules/preparing-an-initial-cluster-deployment-for-mce-connected.adoc
+++ b/modules/preparing-an-initial-cluster-deployment-for-mce-connected.adoc
@@ -4,9 +4,9 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="preparing-an-initial-cluster-deployment-for-mce-connected_{context}"]
-
 = Preparing an Agent-based cluster deployment for the {mce} while connected
 
+[role="_abstract"]
 Create the required manifests for the {mce-short}, the Local Storage Operator (LSO), and to deploy an agent-based {product-title} cluster as a hub cluster.
 
 .Procedure
@@ -22,7 +22,6 @@ The installer does not validate extra manifests.
 . For the multicluster engine, create the following manifests and save them in the `<assets_directory>/openshift` folder:
 +
 .Example `mce_namespace.yaml`
-+
 [source,yaml]
 ----
   apiVersion: v1
@@ -34,7 +33,6 @@ The installer does not validate extra manifests.
 ----
 +
 .Example `mce_operatorgroup.yaml`
-+
 [source,yaml]
 ----
   apiVersion: operators.coreos.com/v1
@@ -48,7 +46,6 @@ The installer does not validate extra manifests.
 ----
 +
 .Example `mce_subscription.yaml`
-+
 [source,yaml]
 ----
   apiVersion: operators.coreos.com/v1alpha1
@@ -72,7 +69,6 @@ The AI service requires persistent volumes (PVs), which are manually created.
 . For the AI service, create the following manifests and save them in the `<assets_directory>/openshift` folder:
 +
 .Example `lso_namespace.yaml`
-+
 [source,yaml]
 ----
   apiVersion: v1
@@ -84,7 +80,6 @@ The AI service requires persistent volumes (PVs), which are manually created.
 ----
 +
 .Example `lso_operatorgroup.yaml`
-+
 [source,yaml]
 ----
   apiVersion: operators.coreos.com/v1
@@ -98,7 +93,6 @@ The AI service requires persistent volumes (PVs), which are manually created.
 ----
 +
 .Example `lso_subscription.yaml`
-+
 [source,yaml]
 ----
   apiVersion: operators.coreos.com/v1alpha1
@@ -118,7 +112,6 @@ The AI service requires persistent volumes (PVs), which are manually created.
 After creating all the manifests, your filesystem must display as follows:
 
 .Example Filesystem
-
 [source,terminal]
 ----
 <assets_directory>
@@ -191,7 +184,6 @@ $ oc wait localvolume -n openshift-local-storage assisted-service --for conditio
 . Create a manifest for a multicluster engine instance.
 +
 .Example `MultiClusterEngine.yaml`
-+
 [source,yaml]
 ----
   apiVersion: multicluster.openshift.io/v1
@@ -204,7 +196,6 @@ $ oc wait localvolume -n openshift-local-storage assisted-service --for conditio
 . Create a manifest to enable the AI service.
 +
 .Example `agentserviceconfig.yaml`
-+
 [source,yaml]
 ----
   apiVersion: agent-install.openshift.io/v1beta1
@@ -232,7 +223,6 @@ $ oc wait localvolume -n openshift-local-storage assisted-service --for conditio
 . Create a manifest to deploy subsequently spoke clusters.
 +
 .Example `clusterimageset.yaml`
-+
 [source,yaml,subs="attributes+"]
 ----
   apiVersion: hive.openshift.io/v1
@@ -246,7 +236,6 @@ $ oc wait localvolume -n openshift-local-storage assisted-service --for conditio
 . Create a manifest to import the agent installed cluster (that hosts the multicluster engine and the Assisted Service) as the hub cluster.
 +
 .Example `autoimport.yaml`
-+
 [source,yaml]
 ----
   apiVersion: cluster.open-cluster-management.io/v1
@@ -269,6 +258,7 @@ $ oc wait -n multicluster-engine managedclusters local-cluster --for condition=M
 ----
 
 .Verification
+
 * To confirm that the managed cluster installation is successful, run the following command:
 +
 [source,terminal]

--- a/modules/preparing-an-initial-cluster-deployment-for-mce-disconnected.adoc
+++ b/modules/preparing-an-initial-cluster-deployment-for-mce-disconnected.adoc
@@ -7,6 +7,7 @@
 
 = Preparing an Agent-based cluster deployment for the {mce} while disconnected
 
+[role="_abstract"]
 You can mirror the required {product-title} container images, the {mce-short}, and the Local Storage Operator (LSO) into your local mirror registry in a disconnected environment.
 Ensure that you note the local DNS hostname and port of your mirror registry.
 
@@ -27,34 +28,35 @@ To mirror your {product-title} image repository to your mirror registry, you can
 ----
   kind: ImageSetConfiguration
   apiVersion: mirror.openshift.io/v1alpha2
-  archiveSize: 4 <1>
-  storageConfig: <2>
-    imageURL: <your-local-registry-dns-name>:<your-local-registry-port>/mirror/oc-mirror-metadata <3>
+  archiveSize: 4
+  storageConfig:
+    imageURL: <your-local-registry-dns-name>:<your-local-registry-port>/mirror/oc-mirror-metadata
     skipTLS: true
   mirror:
     platform:
       architectures:
         - "amd64"
       channels:
-        - name: stable-{product-version} <4>
+        - name: stable-{product-version}
           type: ocp
     additionalImages:
       - name: registry.redhat.io/ubi9/ubi:latest
     operators:
-      - catalog: registry.redhat.io/redhat/redhat-operator-index:v{product-version} <5>
-        packages: <6>
-          - name: multicluster-engine <7>
-          - name: local-storage-operator <8>
+      - catalog: registry.redhat.io/redhat/redhat-operator-index:v{product-version}
+        packages:
+          - name: multicluster-engine
+          - name: local-storage-operator
 ----
 +
-<1> Specify the maximum size, in GiB, of each file within the image set.
-<2> Set the back-end location to receive the image set metadata. This location can be a registry or local directory. It is required to specify `storageConfig` values.
-<3> Set the registry URL for the storage backend.
-<4> Set the channel that contains the {product-title} images for the version you are installing.
-<5> Set the Operator catalog that contains the {product-title} images that you are installing.
-<6> Specify only certain Operator packages and channels to include in the image set. Remove this field to retrieve all packages in the catalog.
-<7> The multicluster engine packages and channels.
-<8> The LSO packages and channels.
+where:
+
+`archiveSize`:: Specifies the maximum size, in GiB, of each file within the image set.
+`storageConfig`:: Specifies the back-end location to receive the image set metadata. This location can be a registry or local directory. It is required to specify `storageConfig` values.
+`storageConfig.imageURL`:: Specifies the registry URL for the storage backend.
+`channels.name`:: Specifies the channel that contains the {product-title} images for the version you are installing.
+`operators.catalog`:: Specifies the Operator catalog that contains the {product-title} images that you are installing.
+`packages`:: Specifies only certain Operator packages and channels to include in the image set. Remove this field to retrieve all packages in the catalog.
+In this example, a `package.name` value of `multicluster-engine` includes the multicluster engine packages and channels, and `local-storage-operator` includes the LSO packages and channels.
 +
 [NOTE]
 ====

--- a/modules/preparing-mce-prereqs.adoc
+++ b/modules/preparing-mce-prereqs.adoc
@@ -1,0 +1,22 @@
+// Module included in the following assemblies:
+//
+// * installing_with_agent_based_installer/preparing-an-agent-based-installed-cluster-for-mce.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="prerequisites_{context}"]
+= Prerequisites
+
+[role="_abstract"]
+Before installing the {mce-short} and deploying a hub cluster with the Agent-based Installer, you must complete several prerequisites.
+
+The following prerequisites must be completed:
+
+* You have read the following documentation:
+** "Cluster lifecycle with multicluster engine operator overview"
+** "Persistent storage using local volumes"
+** "Using {ztp} to provision clusters at the network far edge"
+** "Preparing to install with the Agent-based Installer"
+** "About disconnected installation mirroring"
+* You have access to the internet to obtain the necessary container images.
+* You have installed the OpenShift CLI (`oc`).
+* If you are installing in a disconnected environment, you must have a configured local mirror registry for disconnected installation mirroring.


### PR DESCRIPTION
[OSDOCS-17038](https://redhat.atlassian.net/browse/OSDOCS-17038)

Version(s): 4.20+

This PR performs the final CQA dita fixes for the Agent docs. Two small assemblies and a few scattered fixes elsewhere.

QE review: QE not required for these changes but let me know if anything makes you disagree.

Previews:

- [Installation configuration parameters for the Agent-based Installer](https://113860--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_with_agent_based_installer/installation-config-parameters-agent) (agent installer)
- [Installation configuration parameters](https://113860--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/installation-config-parameters-aws) (platform example)
- [Installation configuration parameters](https://113860--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/install_config/installation-config-parameters-generic) (I think the generic conditional)
- [Preparing PXE assets for OCP](https://113860--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_with_agent_based_installer/prepare-pxe-assets-agent)
- [Preparing an Agent-based installed cluster for the multicluster engine for Kubernetes](https://113860--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_with_agent_based_installer/preparing-an-agent-based-installed-cluster-for-mce)
- [Understanding disconnected installation mirroring](https://113860--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_with_agent_based_installer/understanding-disconnected-installation-mirroring)