### PR TITLE
OSDOCS-20258 created zstream RNs for 4-20-26

### DIFF
--- a/modules/zstream-4-20-26.adoc
+++ b/modules/zstream-4-20-26.adoc
@@ -1,0 +1,39 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-20-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-20-26_{context}"]
+= RHSA-2026:27063 - {product-title} {product-version}.26 fixed issues and security update
+
+Issued: 23 June 2026
+
+[role="_abstract"]
+{product-title} release {product-version}.26 is now available. The list of fixed issues that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2026:27063[RHSA-2026:27063] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2026:27059[RHBA-2026:27059] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.20.26 --pullspecs
+----
+
+[id="zstream-4-20-26-enhancements_{context}"]
+== Enhancements
+
+* You can now set `unhealthyPodEvictionPolicy` to `AlwaysAllow` on all Pod Disruption Budgets (PDBs) for control plane pods. This means pods not yet healthy are considered disrupted and can be evicted regardless of whether the criteria in a PDB are met. (link:https://issues.redhat.com/browse/OCPBUGS-85825[OCPBUGS-85825])
+
+[id="zstream-4-20-26-fixed-issues_{context}"]
+== Fixed issues
+
+* Before this update, when a user applied a `MachineConfig` object to install extensions, the Machine Config Operator (MCO) did not validate that all packages were installed. This would lead to situations where users believed their extension installation was successful, but packages were actually missing. With this release, the MCO validates after the node reboots that all packages associated with the desired extension were successfully installed before reporting a successful update. If one or more packages are not present, the node degrades, and subsequently the associated `MachineConfigPool` also degrades. (link:https://issues.redhat.com/browse/OCPBUGS-86864[OCPBUGS-86864])
+
+* Before this update, the router liveness probe used an HTTP backend check to monitor HAProxy health. As a consequence, when HAProxy reached its `maxconn` connection limit due to client traffic, the HTTP health check failed and Kubernetes unnecessarily restarted the router pods. With this update, the router liveness probe uses an HAProxy admin socket check instead of an HTTP backend check. As a result, router pods remain stable when HAProxy reaches its maxconn connection limit due to client traffic, preventing unnecessary restarts. (link:https://issues.redhat.com/browse/OCPBUGS-67161[OCPBUGS-67161])
+
+
+[id="zstream-4-20-26-updating_{context}"]
+== Updating
+
+To update an {product-title} 4.20 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].

--- a/release_notes/ocp-4-20-release-notes.adoc
+++ b/release_notes/ocp-4-20-release-notes.adoc
@@ -3021,6 +3021,9 @@ In both cases, the installation program generates a user-assigned identity. (lin
 
 include::modules/rn-async-errata.adoc[leveloffset=+1]
 
+// 4.20.26 release notes
+include::modules/zstream-4-20-26.adoc[leveloffset=+2]
+
 // 4.20.25 release notes
 include::modules/zstream-4-20-25.adoc[leveloffset=+2]
 


### PR DESCRIPTION
Version(s):
4.20

Issue:
https://redhat.atlassian.net/browse/OSDOCS-20258

Link to docs preview:
https://113864--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-20-release-notes.html#zstream-4-20-26_release-notes


QE review:
- [ ] QE has approved this change.


Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
