### PR TITLE
OSDOCS-20293 updated configure proxy module

### DIFF
--- a/modules/external-secrets-operator-configure-proxy.adoc
+++ b/modules/external-secrets-operator-configure-proxy.adoc
@@ -9,6 +9,8 @@
 [role="_abstract"]
 The egress proxy can be configured in the `ExternalSecretsConfig` or the `ExternalSecretsManager` custom resource (CR). The Operator and the operand make use of the {product-title} supported certificate authority (CA) bundle for the proxy validations.
 
+The Operator can automatically create and manage a `NetworkPolicy` such as `eso-sys-allow-proxy-egress`, that allows all `external-secrets` pods to reach the proxy server. You control this behavior by using the `networkPolicyProvisioning` field. The field can be set in either the `ExternalSecretsConfig` CR or the `ExternalSecretsManager` CR, and can be configured independently of proxy URL fields. For example, when the proxy is provided by Operator Lifecycle Manager (OLM) environment variables at the cluster level, you can set only `networkPolicyProvisioning` in either CR without specifying any proxy URLs.
+
 .Prerequisites
 
 * You have access to the cluster as a user with the `cluster-admin` role.
@@ -39,17 +41,21 @@ spec:
       httpProxy: <http_proxy>
       httpsProxy: <https_proxy>
       noProxy: <no_proxy>
+      networkPolicyProvisioning: Managed
+
 ----
 +
 where:
 
-<http_proxy>:: Specifies the proxy URL for the http requests.
+`spec.appConfig.proxy.httpProxy`:: Specifies the proxy URL for the HTTP requests.
 
-<https_proxy>:: Specifies the proxy URL for the https requests.
+`spec.appConfig.proxy.httpsProxy`:: Specifies the proxy URL for the HTTPS requests.
 
-<no_proxy>:: Specifies a comma-separated list of hostnames, CIDRs, IPs or a combination of these, for which the proxy should not be used.
+`spec.appConfig.proxy.noProxy`:: Specifies a comma-separated list of hostnames, CIDRs, IPs or a combination of these, for which the proxy should not be used.
 
-. To set the proxy in the `ExternalSecretsManager` CR, perform the following steps.
+`spec.appConfig.proxy.networkPolicyProvisioning`:: Specifies whether the Operator automatically creates and manages the `eso-sys-allow-proxy-egress` `NetworkPolicy`. Accepted values are `Managed`, which is the default, and `Unmanaged`. When set to `Managed`, the Operator creates the policy based on the proxy URL port and deletes it when the proxy is removed. When set to `Unmanaged`, the Operator does not create or delete the policy and you are responsible for managing proxy egress traffic.
+
+. To set the proxy in the `ExternalSecretsManager` CR, perform the following steps:
 
 .. Edit the `ExternalSecretsManager` CR by running the following command:
 +
@@ -71,13 +77,52 @@ spec:
       httpProxy: <http_proxy>
       httpsProxy: <https_proxy>
       noProxy: <no_proxy>
+      networkPolicyProvisioning: Managed
 ----
 +
 where:
 
-<http_proxy>:: Specifies the proxy URL for the http requests.
+`spec.appConfig.proxy.httpProxy`:: Specifies the proxy URL for the HTTP requests.
 
-<https_proxy>:: Proxy URL for the https requests.
+`spec.appConfig.proxy.httpsProxy`:: Specifies the proxy URL for the HTTPS requests.
 
-<no_proxy>:: Comma-separated list of hostnames, CIDRs, IPs or a combination of these for which the proxy should not be used.
+`spec.appConfig.proxy.noProxy`:: Specifies a comma-separated list of hostnames, CIDRs, IPs or a combination of these, for which the proxy should not be used.
+
+`spec.appConfig.proxy.networkPolicyProvisioning`:: Specifies whether the Operator automatically creates and manages the `eso-sys-allow-proxy-egress` `NetworkPolicy`. The values are`Managed`, which is the default, and `Unmanaged`.
++
+[NOTE]
+====
+When `networkPolicyProvisioning` is set in both the `ExternalSecretsConfig` CR and the `ExternalSecretsManager` CR, the value in the `ExternalSecretsConfig` CR takes precedence.
+====
+
+. If the proxy is configured at the cluster level through OLM environment variables and you only want to control `NetworkPolicy` provisioning without specifying proxy URLs in a CR, set only the `networkPolicyProvisioning` field in either CR as follows:
++
+[source,yaml]
+----
+apiVersion: operator.openshift.io/v1alpha1
+kind: ExternalSecretsConfig
+...
+spec:
+  applicationConfig:
+    proxy:
+      networkPolicyProvisioning: Unmanaged
+----
+
+.Verification
+
+. Verify that the proxy egress `NetworkPolicy` was created by running the following command:
++
+[source,terminal]
+----
+$ oc get networkpolicy eso-sys-allow-proxy-egress -n external-secrets -o yaml
+----
++
+The policy should show an egress rule allowing transmission control protocol (TCP) traffic on the port derived from the configured proxy URL.
+
+. Verify that the proxy configuration is applied to the `external-secrets` deployment by running the following command:
++
+[source,terminal]
+----
+$ oc set env deployment/external-secrets -n external-secrets --list | grep -i proxy
+----
 

--- a/security/external_secrets_operator/external-secrets-operator-proxy.adoc
+++ b/security/external_secrets_operator/external-secrets-operator-proxy.adoc
@@ -7,7 +7,7 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 [role="_abstract"]
-If a cluster-wide egress proxy is configured in {product-title}, Operator Lifecycle Manager (OLM) automatically configures Operators that it manages with the cluster-wide proxy. OLM automatically updates all of the Operator’s deployments with the `HTTP_PROXY`, `HTTPS_PROXY`, `NO_PROXY` environment variables.
+If a cluster-wide egress proxy is configured in {product-title}, the Operator Lifecycle Manager (OLM) automatically configures Operators that it manages with the cluster-wide proxy. OLM automatically updates all of the Operator deployments with the `HTTP_PROXY`, `HTTPS_PROXY`, and `NO_PROXY` environment variables.
 
 // Configure egress proxy
 include::modules/external-secrets-operator-configure-proxy.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s):
4.19+

Issue:
https://redhat.atlassian.net/browse/OSDOCS-20293

Link to docs preview:
https://113866--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/external_secrets_operator/external-secrets-operator-proxy.html


QE review:
- [ ] QE has approved this change.


Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
