### PR TITLE
OSDOCS#20304: Update the MicroShift RNs for 4.20.26

### DIFF
--- a/microshift_release_notes/microshift-4-20-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-20-release-notes.adoc
@@ -24,6 +24,8 @@ include::modules/microshift-4-20-additional-release-notes.adoc[leveloffset=+1]
 
 include::modules/microshift-4-20-asynchronous-updates.adoc[leveloffset=+1]
 
+include::modules/microshift-4-20-26-dp.adoc[leveloffset=+2]
+
 include::modules/microshift-4-20-23-dp.adoc[leveloffset=+2]
 
 include::modules/microshift-4-20-20-dp.adoc[leveloffset=+2]
@@ -31,5 +33,3 @@ include::modules/microshift-4-20-20-dp.adoc[leveloffset=+2]
 include::modules/microshift-4-20-13-dp.adoc[leveloffset=+2]
 
 include::modules/microshift-4-20-0-dp.adoc[leveloffset=+2]
-
-

--- a/modules/microshift-4-20-26-dp.adoc
+++ b/modules/microshift-4-20-26-dp.adoc
@@ -1,0 +1,23 @@
+
+// Module included in the following assemblies:
+//
+//microshift_release_notes/microshift-4-20-release-notes.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="microshift-4-20-26-dp_{context}"]
+= RHBA-2026:27184 - {microshift-short} 4.20.26 fixed issue update
+
+[role="_abstract"]
+Issued: 23 June 2026
+
+{product-title} release 4.20.26 is now available, see the link:https://access.redhat.com/errata/RHBA-2026:27184[RHBA-2026:27184] advisory. Release notes for bug fixes are provided in this documentation. The images that are included in the update are provided by the {OCP} link:https://access.redhat.com/errata/RHSA-2026:27063[RHSA-2026:27063] advisory.
+
+See the latest images included with {microshift-short} by using the following instructions:
+
+* xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[Listing the contents of the {microshift-short} RPM release package]
+* xref:../microshift_install_bootc/microshift-install-bootc-image.adoc#microshift-install-bootc-get-published-image_microshift-install-bootc-image[Getting the published bootc image for {microshift-short}]
+
+[id="microshift-4-20-26-dp-fixed-issues_{context}"]
+== Fixed issues
+
+* Before this update, `Gateway-api` manifests had an `imagePullPolicy` of `Always`, and caused issues in disconnected environments. With this release, the `imagePullPolicy` for `Gateway-api` manifests is changed from `Always` to `IfNotPresent`. As a result, `Gateway-api` manifests do not use `imagePullPolicy:Always`, improving functionality in disconnected environments. (https://issues.redhat.com/browse/OCPBUGS-90515[OCPBUGS-90515])


### PR DESCRIPTION
Version(s):
4.20

Issue:
[OSDOCS-20304](https://redhat.atlassian.net/browse/OSDOCS-20304)

Link to docs preview:
[4.20.26](https://113872--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-20-release-notes.html#microshift-4-20-26-dp_release-notes)

QE review:
- [ ] QE has approved this change.
N/A

Additional information:
Shipment [MR](https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/594)
ART [Dashboard](https://art-dash.engineering.redhat.com/dashboard/release/openshift-4.20?page=1)
