### PR TITLE
OBSDOCS-3537: Fix incorrect field reference in COO CLI Subscription example

### DIFF
--- a/modules/installing-the-coo-cli.adoc
+++ b/modules/installing-the-coo-cli.adoc
@@ -34,7 +34,7 @@ spec:
 ----
 +
 `spec.channel`:: Specify `development` as the channel.
-`spec.namespace`:: The {coo-short} installs into the `openshift-operators` namespace, which already has a pre-existing `OperatorGroup`. No additional namespace or `OperatorGroup` configuration is required.
+`metadata.namespace`:: The {coo-short} installs into the `openshift-operators` namespace, which already has a pre-existing `OperatorGroup`. No additional namespace or `OperatorGroup` configuration is required.
 `spec.source`:: Specify `redhat-operators` as the value. If your {ocp-product-title} cluster is installed on a restricted network, specify the name of the `CatalogSource` object you created when you configured {olm}.
 
 . Apply the `Subscription` object by running the following command:


### PR DESCRIPTION
## Summary

Fixes the incorrect field reference in the "Installing the COO by using the CLI" section.

**Bug:** The parameter description references `spec.namespace`, but a Subscription object does not have that field.
**Fix:** Changed the field description to `metadata.namespace`, matching the YAML example above it.

## Jira

- [OBSDOCS-3537](https://redhat.atlassian.net/browse/OBSDOCS-3537)

Version(s): 6.6 (main), cherry-pick to 6.5 and 6.4 as needed

Issue: https://redhat.atlassian.net/browse/OBSDOCS-3537

Link to docs preview:
<!-- Add preview link after Netlify build completes -->

QE review:
- [ ] QE has approved this change.

Additional information:

The YAML example already correctly uses `metadata.namespace: openshift-operators`. Only the field description below the example was wrong.

**Source file:** `modules/installing-the-coo-cli.adoc`
