### PR TITLE
OSDOCS-16402: CQA fixes for ROSA HCP Tutorials (part 1)

### DIFF
--- a/cloud_experts_tutorials/cloud-experts-aws-load-balancer-operator.adoc
+++ b/cloud_experts_tutorials/cloud-experts-aws-load-balancer-operator.adoc
@@ -11,11 +11,11 @@ include::snippets/snip-mobb-support-statement.adoc[leveloffset=+1]
 
 [TIP]
 ====
-Load Balancers created by the AWS Load Balancer Operator cannot be used for xref:../networking/ingress_load_balancing/routes/nw-configuring-routes.adoc#route-configuration[OpenShift Routes], and should only be used for individual services or ingress resources that do not need the full layer 7 capabilities of an OpenShift Route.
+Load Balancers created by the AWS Load Balancer Operator cannot be used for {OCP-short} Routes, and should only be used for individual services or ingress resources that do not need the full layer 7 capabilities of an {OCP-short} Route. For more information about {OCP-short} Routes, see _Additional resources_.
 ====
 
 [role="_abstract"]
-The link:https://kubernetes-sigs.github.io/aws-load-balancer-controller/[AWS Load Balancer Controller] manages AWS Elastic Load Balancers for a {product-title} cluster. The controller provisions link:https://docs.aws.amazon.com/elasticloadbalancing/latest/application/introduction.html[AWS Application Load Balancers (ALB)] when you create Kubernetes Ingress resources and link:https://docs.aws.amazon.com/elasticloadbalancing/latest/network/introduction.html[AWS Network Load Balancers (NLB)] when implementing Kubernetes Service resources with a type of LoadBalancer.
+The AWS Load Balancer Controller manages AWS Elastic Load Balancers for a {product-title} cluster. The controller provisions AWS Application Load Balancers (ALB) when you create Kubernetes Ingress resources and AWS Network Load Balancers (NLB) when implementing Kubernetes Service resources with a type of LoadBalancer. For more information, see _Additional resources_.
 
 Compared with the default AWS in-tree load balancer provider, this controller is developed with advanced annotations for both ALBs and NLBs. Some advanced use cases are:
 
@@ -30,28 +30,23 @@ WAFv1, WAF classic, is no longer supported. Use WAFv2.
 * Specify custom NLB source IP ranges
 * Specify custom NLB internal IP addresses
 
-The link:https://github.com/openshift/aws-load-balancer-operator[AWS Load Balancer Operator] is used to used to install, manage and configure an instance of `aws-load-balancer-controller` in a {product-title} cluster.
+The AWS Load Balancer Operator is used to used to install, manage and configure an instance of `aws-load-balancer-controller` in a {product-title} cluster. For more information, see _Additional resources_.
 
-[id="prerequisites_{context}"]
-== Prerequisites
+include::modules/cloud-experts-aws-load-balancer-operator-environment.adoc[leveloffset=+1]
 
-[NOTE]
-====
-AWS ALBs require a multi-AZ cluster, as well as three public subnets split across three AZs in the same VPC as the cluster. This makes ALBs unsuitable for many PrivateLink clusters. AWS NLBs do not have this restriction.
-====
-
-ifndef::openshift-rosa-hcp[]
-* xref:../rosa_install_access_delete_clusters/rosa-sts-creating-a-cluster-quickly.adoc#rosa-sts-creating-a-cluster-quickly[A multi-AZ {product-title} cluster]
-endif::openshift-rosa-hcp[]
-ifdef::openshift-rosa-hcp[]
-* xref:../rosa_hcp/rosa-hcp-sts-creating-a-cluster-quickly.adoc#rosa-hcp-sts-creating-a-cluster-quickly[A multi-AZ {product-title} cluster]
-endif::openshift-rosa-hcp[]
-* BYO VPC cluster
-* AWS CLI
-* OC CLI
-
-include::modules/cloud-experts-aws-load-balancer-operator-environment.adoc[leveloffset=+2]
 include::modules/cloud-experts-aws-load-balancer-operator-aws-vpc-subnets.adoc[leveloffset=+2]
+
 include::modules/cloud-experts-aws-load-balancer-operator-install.adoc[leveloffset=+1]
+
 include::modules/cloud-experts-aws-load-balancer-operator-validating.adoc[leveloffset=+1]
+
 include::modules/cloud-experts-aws-load-balancer-operator-cleanup.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+[id="additional-resources_{context}"]
+== Additional resources
+* xref:../networking/ingress_load_balancing/routes/nw-configuring-routes.adoc#nw-configuring-routes[{OCP-short} Routes]
+* link:https://kubernetes-sigs.github.io/aws-load-balancer-controller/[AWS Load Balancer Controller]
+* link:https://docs.aws.amazon.com/elasticloadbalancing/latest/application/introduction.html[AWS Application Load Balancers]
+* link:https://docs.aws.amazon.com/elasticloadbalancing/latest/network/introduction.html[AWS Network Load Balancers]
+* link:https://github.com/openshift/aws-load-balancer-operator[AWS Load Balancer Operator]

--- a/cloud_experts_tutorials/cloud-experts-aws-secret-manager.adoc
+++ b/cloud_experts_tutorials/cloud-experts-aws-secret-manager.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="cloud-experts-aws-secret-manager"]
-= Tutorial: Using AWS Secrets Manager CSI on {product-title} with STS
+= Tutorial: Use AWS Secrets Manager CSI on {product-title} with STS
 
 include::_attributes/attributes-openshift-dedicated.adoc[]
 :context: cloud-experts-aws-secret-manager
@@ -10,19 +10,12 @@ toc::[]
 [role="_abstract"]
 The AWS Secrets and Configuration Provider (ASCP) provides a way to expose AWS Secrets as Kubernetes storage volumes. With the ASCP, you can store and manage your secrets in Secrets Manager and then retrieve them through your workloads running on {product-title}.
 
-[id="cloud-experts-aws-secret-manager-prerequisites"]
-== Prerequisites
+include::modules/cloud-experts-aws-secret-manager-preparing-environment.adoc[leveloffset=+1]
 
-Ensure that you have the following resources and tools before starting this process:
-
-* A {product-title} cluster deployed with STS
-* Helm 3
-* `aws` CLI
-* `oc` CLI
-* `jq` CLI
-
-include::modules/cloud-experts-aws-secret-manager-preparing-environment.adoc[leveloffset=+2]
 include::modules/cloud-experts-aws-secret-manager-deply-aws-secrets.adoc[leveloffset=+1]
+
 include::modules/cloud-experts-aws-secret-manager-create-iam-polices.adoc[leveloffset=+1]
+
 include::modules/cloud-experts-aws-secret-manager-creating-application.adoc[leveloffset=+1]
+
 include::modules/cloud-experts-aws-secret-manager-cleanup.adoc[leveloffset=+1]

--- a/cloud_experts_tutorials/cloud-experts-consistent-egress-ip.adoc
+++ b/cloud_experts_tutorials/cloud-experts-consistent-egress-ip.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="cloud-experts-consistent-egress-ip"]
-= Tutorial: Assigning a consistent egress IP for external traffic
+= Tutorial: Assign a consistent egress IP for external traffic
 
 include::_attributes/attributes-openshift-dedicated.adoc[]
 include::_attributes/common-attributes.adoc[]
@@ -13,29 +13,38 @@ This tutorial teaches you how to configure a set of predictable IP addresses for
 
 By default, {product-title} uses the OVN-Kubernetes container network interface (CNI) to assign random IP addresses from a pool. This can make configuring security lockdowns unpredictable or open.
 
-ifndef::openshift-rosa-hcp[]
-See xref:../networking/ovn_kubernetes_network_provider/configuring-egress-ips-ovn.adoc#configuring-egress-ips-ovn[Configuring an egress IP address] for more information.
-endif::openshift-rosa-hcp[]
-ifdef::openshift-rosa-hcp[]
-See link:https://docs.openshift.com/rosa/networking/ovn_kubernetes_network_provider/configuring-egress-ips-ovn.html[Configuring an egress IP address] for more information.
-endif::openshift-rosa-hcp[]
-
-== Prerequisites
-
-* A {product-title} cluster deployed with OVN-Kubernetes
-* The xref:../cli_reference/openshift_cli/getting-started-cli.adoc#cli-getting-started[OpenShift CLI] (`oc`)
-* The xref:../cli_reference/rosa_cli/rosa-get-started-cli.adoc#rosa-get-started-cli[ROSA CLI] (`rosa`)
-* link:https://stedolan.github.io/jq/[`jq`]
+ifdef::openshift-rosa[]
+For more information on configuring an egress IP address, see _Additional resources_.
+endif::openshift-rosa[]
 
 include::modules/egress-ip-env-variables.adoc[leveloffset=+1]
+
 include::modules/egress-ip-capacity.adoc[leveloffset=+1]
+
 include::modules/egress-ip-creating-ip-rules.adoc[leveloffset=+1]
+
 include::modules/egress-ip-assign-ip-namespace.adoc[leveloffset=+1]
+
 include::modules/egress-ip-assigning-to-pod.adoc[leveloffset=+1]
+
 include::modules/egress-ip-node-labels.adoc[leveloffset=+2]
+
 include::modules/egress-ip-egress-ip-review.adoc[leveloffset=+2]
+
 include::modules/egress-ip-deploy-sample-app.adoc[leveloffset=+2]
+
 include::modules/egress-ip-namespace-egress.adoc[leveloffset=+2]
+
 include::modules/egress-ip-pod-egress-test.adoc[leveloffset=+2]
+
 include::modules/egress-ip-blocked-egress.adoc[leveloffset=+2]
+
 include::modules/egress-ip-cluster-cleanup.adoc[leveloffset=+1]
+
+ifdef::openshift-rosa[]
+[role="_additional-resources"]
+[id="additional-resources_{context}"]
+== Additional resources
+* xref:../networking/ovn_kubernetes_network_provider/configuring-egress-ips-ovn.adoc#configuring-egress-ips-ovn[Configuring an egress IP address]
+endif::openshift-rosa[]
+//Additional resources are Classic-only because the assembly configuring-egress-ips-ovn is commented out of the ROSA HCP topic map (as of June 2026).

--- a/cloud_experts_tutorials/cloud-experts-custom-dns-resolver.adoc
+++ b/cloud_experts_tutorials/cloud-experts-custom-dns-resolver.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="cloud-experts-custom-dns-resolver"]
-= Tutorial: Deploying {product-title} with a Custom DNS Resolver
+= Tutorial: Deploy {product-title} with a custom DNS resolver
 
 include::_attributes/attributes-openshift-dedicated.adoc[]
 :context: cloud-experts-custom-dns-resolver
@@ -8,29 +8,19 @@ include::_attributes/attributes-openshift-dedicated.adoc[]
 toc::[]
 
 [role="_abstract"]
-A link:https://docs.aws.amazon.com/vpc/latest/userguide/DHCPOptionSet.html[custom DHCP option set] enables you to customize your VPC with your own DNS server, domain name, and more. {product-title} clusters support using custom DHCP option sets. By default, {product-title} clusters require setting the "domain name servers" option to `AmazonProvidedDNS` to ensure successful cluster creation and operation. Customers who want to use custom DNS servers for DNS resolution must do additional configuration to ensure successful {product-title} cluster creation and operation. 
+Use a custom Dynamic Host Configuration Protocol (DHCP) option set to customize your Virtual Private Cloud (VPC) with your own Domain Name System (DNS) server, domain name, and more. {product-title} clusters support using custom DHCP option sets. By default, {product-title} clusters require setting the "domain name servers" option to `AmazonProvidedDNS` to ensure successful cluster creation and operation. Customers who want to use custom DNS servers for DNS resolution must do additional configuration to ensure successful {product-title} cluster creation and operation.
 
-In this tutorial, we will configure our DNS server to forward DNS lookups for specific DNS zones (further detailed below) to an link:https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/resolver.html[Amazon Route 53 Inbound Resolver]. 
+In this tutorial, we will configure our DNS server to forward DNS lookups for specific DNS zones (further detailed below) to an Amazon Route 53 Inbound Resolver. For more information, see _Additional resources_.
 
 [NOTE]
 ====
 This tutorial uses the open-source BIND DNS server (`named`) to demonstrate the configuration necessary to forward DNS lookups to an Amazon Route 53 Inbound Resolver located in the VPC you plan to deploy a {product-title} cluster into. Refer to the documentation of your preferred DNS server for how to configure zone forwarding.
 ====
 
-== Prerequisites
-
-* ROSA CLI (`rosa`)
-* AWS CLI (`aws`)
-ifdef::openshift-rosa[]
-* A manually created AWS VPC
-endif::openshift-rosa[]
-ifdef::openshift-rosa-hcp[]
-* A xref:../rosa_hcp/rosa-hcp-sts-creating-a-cluster-quickly.adoc#rosa-hcp-creating-vpc_rosa-hcp-sts-creating-a-cluster-quickly[manually created AWS VPC]
-endif::openshift-rosa-hcp[]
-* A DHCP option set configured to point to a custom DNS server and set as the default for your VPC
-
 include::modules/cloud-experts-custom-dns-resolver-environment-setup.adoc[leveloffset=+1]
+
 include::modules/cloud-experts-custom-dns-resolver-create-inbound-resolver.adoc[leveloffset=+1]
+
 ifdef::openshift-rosa-hcp[]
 include::modules/cloud-experts-custom-dns-resolver-configure-dns-server-hcp.adoc[leveloffset=+1]
 endif::openshift-rosa-hcp[]
@@ -39,7 +29,10 @@ include::modules/cloud-experts-custom-dns-resolver-configure-dns-server-classic.
 endif::openshift-rosa[]
 
 [role="_additional-resources"]
+[id="additional-resources_{context}"]
 == Additional resources
+* link:https://docs.aws.amazon.com/vpc/latest/userguide/DHCPOptionSet.html[Custom DHCP option set]
+* link:https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/resolver.html[Amazon Route 53 Inbound Resolver]
 ifdef::openshift-rosa[]
 * xref:../rosa_install_access_delete_clusters/rosa-sts-creating-a-cluster-quickly.adoc#rosa-sts-creating-account-wide-sts-roles-and-policies_rosa-sts-creating-a-cluster-quickly[Create your cluster]
 endif::openshift-rosa[]

--- a/cloud_experts_tutorials/cloud-experts-deploy-api-data-protection.adoc
+++ b/cloud_experts_tutorials/cloud-experts-deploy-api-data-protection.adoc
@@ -1,7 +1,8 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="cloud-experts-deploy-api-data-protection"]
-= Tutorial: Deploying OpenShift API for Data Protection on a {product-title} cluster
+= Tutorial: Deploy OpenShift API for Data Protection on a {product-title} cluster
 
+include::_attributes/common-attributes.adoc[]
 include::_attributes/attributes-openshift-dedicated.adoc[]
 :context: cloud-experts-deploy-api-data-protection
 
@@ -10,25 +11,20 @@ toc::[]
 include::snippets/snip-mobb-support-statement.adoc[leveloffset=+1]
 
 [role="_abstract"]
-The following tutorial shows you how to deploy the OpenShift API for data protection on your {product-title} cluster.
-
-[id="cloud-experts-deploy-api-data-protection-prerequisites_{context}"]
-== Prerequisites
-
-ifndef::openshift-rosa-hcp[]
-* A xref:../rosa_install_access_delete_clusters/rosa-sts-creating-a-cluster-quickly.adoc#rosa-sts-creating-a-cluster-quickly[{product-title} cluster]
-endif::openshift-rosa-hcp[]
-ifdef::openshift-rosa-hcp[]
-* A xref:../rosa_hcp/rosa-hcp-sts-creating-a-cluster-quickly.adoc#rosa-hcp-sts-creating-a-cluster-quickly[{product-title} cluster]
-endif::openshift-rosa-hcp[]
+The following tutorial shows you how to deploy the {oadp-full} on your {product-title} cluster.
 
 include::modules/cloud-experts-deploy-api-data-protection-environment-variables.adoc[leveloffset=+1]
+
 include::modules/cloud-experts-deploy-api-data-protection-prepare-aws-account.adoc[leveloffset=+1]
+
 include::modules/cloud-experts-deploy-api-data-protection-deploy-oadp-on-cluster.adoc[leveloffset=+1]
+
 include::modules/cloud-experts-deploy-api-data-protection-perform-backup.adoc[leveloffset=+1]
+
 include::modules/cloud-experts-deploy-api-data-protection-cleanup.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
+[id="additional-resources_{context}"]
 == Additional resources
 * link:https://github.com/openshift/oadp-operator/blob/master/docs/TROUBLESHOOTING.md[OADP team's troubleshooting documentation]
 * link:https://github.com/openshift/oadp-operator/tree/master/tests/e2e/sample-applications[Sample applications directory]

--- a/cloud_experts_tutorials/cloud-experts-entra-id-idp.adoc
+++ b/cloud_experts_tutorials/cloud-experts-entra-id-idp.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="cloud-experts-entra-id-idp"]
-= Tutorial: Configuring Microsoft Entra ID (formerly Azure Active Directory) as an identity provider
+= Tutorial: Configure Microsoft Entra ID (formerly Azure Active Directory) as an identity provider
 
 include::_attributes/attributes-openshift-dedicated.adoc[]
 :context: cloud-experts-entra-id-idp
@@ -17,20 +17,23 @@ This tutorial guides you to complete the following tasks:
 . Configure the {product-title} cluster to use Entra ID as the identity provider.
 . Grant additional permissions to individual groups.
 
-== Prerequisites
-
-* You created a set of security groups and assigned users by following link:https://learn.microsoft.com/en-us/azure/active-directory/fundamentals/how-to-manage-groups[the Microsoft documentation].
-
 include::modules/cloud-experts-entra-id-idp-register-app.adoc[leveloffset=+1]
+
 include::modules/cloud-experts-entra-id-idp-configure-app.adoc[leveloffset=+1]
+
 include::modules/cloud-experts-entra-id-idp-configure-optional-claims.adoc[leveloffset=+2]
+
 include::modules/cloud-experts-entra-id-idp-configure-group-claims.adoc[leveloffset=+2]
+
 include::modules/cloud-experts-entra-id-idp-configure-entra-idp.adoc[leveloffset=+1]
+
 include::modules/cloud-experts-entra-id-idp-additional-user-groups.adoc[leveloffset=+1]
+
 include::modules/cloud-experts-entra-id-idp-additional-individual-user.adoc[leveloffset=+1]
+
 include::modules/cloud-experts-entra-id-idp-additional-individual-groups.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
+[id="additional-resources_{context}"]
 == Additional resources
-
 * link:https://docs.redhat.com/en/documentation/openshift_container_platform/latest/html/authentication_and_authorization/using-rbac[Using RBAC to define and apply permissions]

--- a/cloud_experts_tutorials/cloud-experts-rosa-hcp-activation-and-account-linking-tutorial.adoc
+++ b/cloud_experts_tutorials/cloud-experts-rosa-hcp-activation-and-account-linking-tutorial.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="cloud-experts-activation-account-linking"]
-= Tutorial: {product-title} activation and account linking
+= Tutorial: Activate {product-title} and link your account
 
 include::_attributes/attributes-openshift-dedicated.adoc[]
 :context: cloud-experts-activation-account-linking
@@ -14,14 +14,10 @@ This tutorial describes the process for activating {product-title} and linking t
 If you have received a private offer for the product, make sure to proceed according to the instructions provided with the private offer before following this tutorial. The private offer is designed either for a case when the product is already activated, which replaces an active subscription, or for first time activations.
 ====
 
-== Prerequisites
-
-* Log in to the Red{nbsp}Hat account that you want to associate with the AWS account that will activate the {product-title} product subscription.
-* The AWS account used for service billing can only be associated with a single Red{nbsp}Hat account. Typically an AWS payer account is the one that is used to subscribe to {product-title} and used for account linking and billing.
-* All team members belonging to the same Red{nbsp}Hat organization can use the linked AWS account for service billing while creating {product-title} clusters.
-
 include::modules/subscription-enablement.adoc[leveloffset=+1]
+
 include::modules/aws-rh-linking.adoc[leveloffset=+1]
+
 include::modules/selecting-billing-account-cli.adoc[leveloffset=+1]
 
 ifdef::openshift-rosa[]
@@ -34,8 +30,8 @@ endif::openshift-rosa[]
 include::modules/selecting-billing-account-ui.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
-.Additional resources
-
+[id="additional-resources_{context}"]
+== Additional resources
 ifdef::openshift-rosa-hcp[]
 * xref:../rosa_hcp/rosa-hcp-sts-creating-a-cluster-quickly.adoc#rosa-hcp-sts-creating-a-cluster-quickly[Creating {product-title} clusters using the default options]
 endif::openshift-rosa-hcp[]

--- a/cloud_experts_tutorials/cloud-experts-rosa-with-hcp-private-offer-acceptance-and-sharing.adoc
+++ b/cloud_experts_tutorials/cloud-experts-rosa-with-hcp-private-offer-acceptance-and-sharing.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="cloud-experts-rosa-with-hcp-private-offer-acceptance-and-sharing"]
-= Tutorial: {product-title} private offer acceptance and sharing
+= Tutorial: Accept and share a private offer for {product-title}
 
 include::_attributes/attributes-openshift-dedicated.adoc[]
 :context: cloud-experts-rosa-with-hcp-private-offer-acceptance-and-sharing
@@ -12,15 +12,24 @@ This guide describes how to accept a private offer for {product-title} and how t
 
 {product-title} costs are composed of the AWS infrastructure costs and the {product-title} service costs. AWS infrastructure costs, such as the EC2 instances that are running the needed workloads, are charged to the AWS account where the infrastructure is deployed. {product-title} service costs are charged to the AWS account specified as the "AWS billing account" when deploying a cluster.
 
-The cost components can be billed to different AWS accounts. Detailed description of how the {product-title} service cost and AWS infrastructure costs are calculated can be found on the link:https://aws.amazon.com/rosa/pricing/[{product-title} Pricing page].
+The cost components can be billed to different AWS accounts. Detailed description of how the {product-title} service cost and AWS infrastructure costs are calculated can be found on the "Pricing" page linked in the _Additional resources_.
 
 
 include::modules/accepting-private-offer.adoc[leveloffset=+1]
+
 include::modules/sharing-private-offer.adoc[leveloffset=+1]
+
 include::modules/aws-account-billing-selection.adoc[leveloffset=+1]
+
 include::modules/offer-troubleshooting.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+[id="additional-resources_{context}"]
+== Additional resources
+* link:https://aws.amazon.com/rosa/pricing/[{product-title} Pricing page]
+
 ////
-//Commenting out for now, but we can examine how to incorporate the example scenario 
+//Commenting out for now, but we can examine how to incorporate the example scenario
 
 == Example scenario
 

--- a/cloud_experts_tutorials/cloud-experts-using-alb-and-waf.adoc
+++ b/cloud_experts_tutorials/cloud-experts-using-alb-and-waf.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="cloud-experts-using-alb-and-waf"]
-= Tutorial: Using AWS WAF and AWS ALBs to protect {product-title} workloads
+= Tutorial: Use AWS WAF and AWS ALBs to protect {product-title} workloads
 
 include::_attributes/attributes-openshift-dedicated.adoc[]
 :context: cloud-experts-using-alb-and-waf
@@ -8,36 +8,28 @@ include::_attributes/attributes-openshift-dedicated.adoc[]
 toc::[]
 
 [role="_abstract"]
-AWS WAF is a web application firewall that lets you monitor the HTTP and HTTPS requests that are forwarded to your protected web application resources.
+You can use AWS Web Application Firewall (WAF) to monitor HTTP and HTTPS requests that are forwarded to your protected web application resources.
 
 You can use an AWS Application Load Balancer (ALB) to add a Web Application Firewall (WAF) to your {product-title} workloads. Using an external solution protects {product-title} resources from experiencing denial of service due to handling the WAF.
 
 [IMPORTANT]
 ====
-It is recommended that you use the more flexible xref:../cloud_experts_tutorials/cloud-experts-using-cloudfront-and-waf.adoc#cloud-experts-using-cloudfront-and-waf[CloudFront method] unless you absolutely must use an ALB based solution.
+It is recommended that you use the more flexible CloudFront method unless you absolutely must use an ALB-based solution. For more information, see _Additional resources_.
 ====
 
-[id="prerequisites_{context}"]
-== Prerequisites
+include::modules/cloud-experts-using-alb-and-waf-environment-setup.adoc[leveloffset=+1]
 
-* Multiple availability zone (AZ) {product-title} cluster.
-+
-[NOTE]
-====
-AWS ALBs require at least two _public_ subnets across AZs, link:https://docs.aws.amazon.com/elasticloadbalancing/latest/application/application-load-balancers.html#availability-zones[per the AWS documentation]. For this reason, only multiple AZ {product-title} clusters can be used with ALBs.
-====
-+
-* You have access to the OpenShift CLI (`oc`).
-* You have access to the AWS CLI (`aws`).
-
-include::modules/cloud-experts-using-alb-and-waf-environment-setup.adoc[leveloffset=+2]
 include::modules/cloud-experts-using-alb-and-waf-aws-vpc-and-subnets.adoc[leveloffset=+2]
+
 include::modules/cloud-experts-using-alb-and-waf-deploy-aws-load-balancer-operator.adoc[leveloffset=+1]
+
 include::modules/cloud-experts-using-alb-and-waf-deploy-sample-application.adoc[leveloffset=+1]
+
 include::modules/cloud-experts-using-alb-and-waf-configure-aws-waf.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 [id="additional-resources_{context}"]
 == Additional resources
-
+* xref:../cloud_experts_tutorials/cloud-experts-using-cloudfront-and-waf.adoc#cloud-experts-using-cloudfront-and-waf[CloudFront method]
 * link:https://youtu.be/-HorEsl2ho4[Adding Extra Security with AWS WAF, CloudFront and ROSA | Amazon Web Services on YouTube]
+// Keeping ROSA in the name since this is how a linked YouTube video is called.

--- a/cloud_experts_tutorials/cloud-experts-using-aws-ack.adoc
+++ b/cloud_experts_tutorials/cloud-experts-using-aws-ack.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="cloud-experts-using-aws-ack"]
-= Tutorial: Using AWS Controllers for Kubernetes on {product-title}
+= Tutorial: Use AWS Controllers for Kubernetes on {product-title}
 
 include::_attributes/attributes-openshift-dedicated.adoc[]
 :context: cloud-experts-using-aws-ack
@@ -8,22 +8,23 @@ include::_attributes/attributes-openshift-dedicated.adoc[]
 toc::[]
 
 [role="_abstract"]
-link:https://aws-controllers-k8s.github.io/community/[AWS Controllers for Kubernetes] (ACK) lets you define and use AWS service resources directly from {product-title}. With ACK, you can take advantage of AWS-managed services for your applications without needing to define resources outside of the cluster or run services that provide supporting capabilities such as databases or message queues within the cluster.
+You can use AWS Controllers for Kubernetes (ACK) to define and use AWS service resources directly from {product-title}. With ACK, you can take advantage of AWS-managed services for your applications without needing to define resources outside of the cluster or run services that provide supporting capabilities such as databases or message queues within the cluster. For more information, see _Additional resources_.
 
 You can install various ACK Operators directly from the software catalog. This makes it easy to get started and use the Operators with your applications. This controller is a component of the AWS Controller for Kubernetes project, which is currently in developer preview.
 
 Use this tutorial to deploy the ACK S3 Operator. You can also adapt it for any other ACK Operator in the software catalog of your cluster.
 
-[id="cloud-experts-using-aws-ack-prerequisites"]
-== Prerequisites
-
-* A {product-title} cluster
-* A user account with `cluster-admin` privileges
-* The OpenShift CLI (`oc`)
-* The Amazon Web Services (AWS) CLI (`aws`)
-
 include::modules/cloud-experts-using-aws-ack-environment-setup.adoc[leveloffset=+1]
+
 include::modules/cloud-experts-using-aws-ack-prep-aws.adoc[leveloffset=+1]
+
 include::modules/cloud-experts-using-aws-ack-install-ack.adoc[leveloffset=+1]
+
 include::modules/cloud-experts-using-aws-ack-valid-deploy.adoc[leveloffset=+1]
+
 include::modules/cloud-experts-using-aws-ack-clean-up.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+[id="additional-resources_{context}"]
+== Additional resources
+* link:https://aws-controllers-k8s.github.io/community/[AWS Controllers for Kubernetes]

--- a/cloud_experts_tutorials/cloud-experts-using-cloudfront-and-waf.adoc
+++ b/cloud_experts_tutorials/cloud-experts-using-cloudfront-and-waf.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="cloud-experts-using-cloudfront-and-waf"]
-= Tutorial: Using AWS WAF and Amazon CloudFront to protect {product-title} workloads
+= Tutorial: Use AWS WAF and Amazon CloudFront to protect {product-title} workloads
 
 include::_attributes/attributes-openshift-dedicated.adoc[]
 :context: cloud-experts-using-cloudfront-and-waf
@@ -8,30 +8,29 @@ include::_attributes/attributes-openshift-dedicated.adoc[]
 toc::[]
 
 [role="_abstract"]
-AWS WAF is a web application firewall that lets you monitor the HTTP and HTTPS requests that are forwarded to your protected web application resources.
+You can use AWS Web Application Firewall (WAF) to monitor HTTP and HTTPS requests that are forwarded to your protected web application resources.
 
-You can use an Amazon CloudFront to add a Web Application Firewall (WAF) to your {product-title} workloads. Using an external solution protects {product-title} resources from experiencing denial of service due to handling the WAF.
+You can use an Amazon CloudFront to add a WAF to your {product-title} workloads. Using an external solution protects {product-title} resources from experiencing denial of service due to handling the WAF.
 
 [NOTE]
 ====
 WAFv1, WAF classic, is no longer supported. Use WAFv2.
 ====
 
-== Prerequisites
-
-* A {product-title} cluster.
-* You have access to the OpenShift CLI (`oc`).
-* You have access to the AWS CLI (`aws`).
-
 include::modules/cloud-experts-using-cloudfront-and-waf-setup-environ.adoc[leveloffset=+1]
+
 include::modules/cloud-experts-using-cloudfront-and-waf-secondary_ingress_controller_setup.adoc[leveloffset=+1]
+
 include::modules/cloud-experts-using-cloudfront-and-waf-configure-aws-waf.adoc[leveloffset=+2]
+
 include::modules/cloud-experts-using-cloudfront-and-waf-configure_amazon_cloudfront.adoc[leveloffset=+1]
+
 include::modules/cloud-experts-using-cloudfront-and-waf-deploy-sample-application.adoc[leveloffset=+1]
+
 include::modules/cloud-experts-using-cloudfront-and-waf-test-waf.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 [id="additional-resources_{context}"]
 == Additional resources
-
 * link:https://youtu.be/-HorEsl2ho4[Adding Extra Security with AWS WAF, CloudFront and ROSA | Amazon Web Services on YouTube]
+// Keeping ROSA in the name since this is how a linked YouTube video is called.

--- a/modules/accepting-private-offer.adoc
+++ b/modules/accepting-private-offer.adoc
@@ -4,7 +4,7 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="accepting-private-offer_{context}"]
-= Accepting a private offer
+= Accept a private offer
 
 [role="_abstract"]
 You can accept private offers from other team members within your Red{nbsp}Hat organization account.
@@ -27,7 +27,7 @@ image::rosa-regular-private-offer.png[]
 [caption="Private offer selection selection screen"]
 image::rosa-private-offer-selection-selection-screen.png[]
 
-.. The drop down menu allows selecting between multiple offers, if available. The previously activated public offer is shown together with the newly provided agreement based offer that is labeled as "Upgrade" in Figure 3.
+.. In the drop-down menu, select from multiple offers, if available. The previously activated public offer is shown together with the newly provided agreement based offer that is labeled as "Upgrade" in Figure 3.
 +
 [caption="Private offer selection dropdown"]
 +
@@ -48,15 +48,15 @@ image::rosa-private-offer-details.png[]
 +
 [NOTE]
 ====
-Private offers have several available configurations. 
+Private offers have several available configurations.
 
-* It is possible that the private offer you are accepting is set up with a fixed future start date. 
-* If you do not have another active {product-title} subscription at the time of accepting the private offer, a public offer or an older private offer entitlement, accept the private offer itself and continue with the account linking and cluster deployment steps after the specified service start date. 
+* It is possible that the private offer you are accepting is set up with a fixed future start date.
+* If you do not have another active {product-title} subscription at the time of accepting the private offer, a public offer or an older private offer entitlement, accept the private offer itself and continue with the account linking and cluster deployment steps after the specified service start date.
 
 You must have an active {product-title} entitlement to complete these steps. Service start dates are always reported in the UTC time zone
 ====
 
-. Create or upgrade your contract. 
+. Create or upgrade your contract.
 +
 .. For private offers accepted by an AWS account that does not have {product-title} activated yet and is creating the first contract for this service, click the *Create contract button*.
 +
@@ -78,7 +78,7 @@ image::rosa-private-offer-acceptance-confirmation-window.png[]
 [caption="Subscription confirmation"]
 image::rosa-subscription-contfirmation.png[]
 
-. If the accepted private offer has a future start date specified, return to the private offer page after the service start date, and click the *Setup your account* button to proceed with the Red{nbsp}Hat and AWS account linking. 
+. If the accepted private offer has a future start date specified, return to the private offer page after the service start date, and click the *Setup your account* button to proceed with the Red{nbsp}Hat and AWS account linking.
 +
 [NOTE]
 ====

--- a/modules/aws-account-billing-selection.adoc
+++ b/modules/aws-account-billing-selection.adoc
@@ -4,15 +4,15 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="aws-account-billing-selection_{context}"]
-= AWS billing account selection
+= Select the AWS billing account
 
 [role="_abstract"]
-When deploying {product-title} clusters, verify that end users select the AWS billing account that accepted the private offer. 
+When deploying {product-title} clusters, verify that end users select the AWS billing account that accepted the private offer.
 
 .Procedure
 
-* When using the web interface for deploying {product-title}, the Associated AWS infrastructure account" is typically set to the AWS account ID used by the administrator of the cluster that is being created. 
-** This can be the same AWS account as the billing AWS account. 
+* When using the web interface for deploying {product-title}, the associated AWS infrastructure account is typically set to the AWS account ID used by the administrator of the cluster that is being created.
+** This can be the same AWS account as the billing AWS account.
 ** AWS resources are deployed into this account and all the billing associated with those resources are processed accordingly.
 +
 [caption="Infrastructure and billing AWS account selection during {product-title} cluster deployment"]

--- a/modules/aws-rh-linking.adoc
+++ b/modules/aws-rh-linking.adoc
@@ -4,7 +4,7 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="aws-rh-linking_{context}"]
-= AWS and Red{nbsp}Hat account and subscription linking
+= Link AWS and Red{nbsp}Hat accounts and subscriptions
 
 [role="_abstract"]
 You must link your AWS and Red{nbsp}Hat accounts and subscriptions.
@@ -18,7 +18,7 @@ image::rosa-continue-rh-6.png[]
 +
 [NOTE]
 ====
-Your AWS account must be linked to a single Red{nbsp}Hat organization. 
+Your AWS account must be linked to a single Red{nbsp}Hat organization.
 ====
 +
 . Log in to your Red{nbsp}Hat account:
@@ -66,7 +66,7 @@ Submit your agreement once you have reviewed any additional terms when prompted 
 [caption="Complete {product-title} prerequisites"]
 image::rosa-cluster-create-10.png[]
 +
-The last section of this page shows cluster deployment options, either using the `rosa` CLI or through the web console:
+The last section of this page shows cluster deployment options, either using the {rosa-cli-first} or through the web console:
 +
 [caption="Deploy the cluster and set up access"]
 image::rosa-cli-ui-12.png[]

--- a/modules/cloud-experts-aws-load-balancer-operator-aws-vpc-subnets.adoc
+++ b/modules/cloud-experts-aws-load-balancer-operator-aws-vpc-subnets.adoc
@@ -7,7 +7,7 @@
 = AWS VPC and subnets
 
 [role="_abstract"]
-Before installing the AWS Load Balancer Operator, you must tag your VPC and its subnets.
+Before installing the AWS Load Balancer Operator, you must tag your Virtual Private Cloud (VPC) and its subnets.
 
 [NOTE]
 ====

--- a/modules/cloud-experts-aws-load-balancer-operator-cleanup.adoc
+++ b/modules/cloud-experts-aws-load-balancer-operator-cleanup.adoc
@@ -4,7 +4,7 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="cloud-experts-aws-load-balancer-operator-cleanup_{context}"]
-= Cleaning up
+= Clean up
 
 [role="_abstract"]
 Clean up your AWS resources after completing this lab tutorial.

--- a/modules/cloud-experts-aws-load-balancer-operator-environment.adoc
+++ b/modules/cloud-experts-aws-load-balancer-operator-environment.adoc
@@ -4,10 +4,28 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="cloud-experts-aws-load-balancer-operator-environment_{context}"]
-= Setting up your environment
+= Set up your environment
 
 [role="_abstract"]
 You can use environment variables to ensure consistency across the commands within this lab.
+
+.Prerequisites
+
+ifndef::openshift-rosa-hcp[]
+* You have created a link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws_classic_architecture/4/html-single/install_rosa_classic_clusters/index#rosa-sts-creating-a-cluster-quickly[multi-availability zone (AZ) {product-title} cluster].
+endif::openshift-rosa-hcp[]
+ifdef::openshift-rosa-hcp[]
+* You have created a link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html-single/install_clusters/index#rosa-hcp-sts-creating-a-cluster-quickly[multi-availability zone (AZ) {product-title} cluster].
+endif::openshift-rosa-hcp[]
++
+[NOTE]
+====
+AWS ALBs require a multi-AZ cluster, as well as three public subnets split across three AZs in the same (Virtual Private Cloud) VPC as the cluster. This makes ALBs unsuitable for many PrivateLink clusters. AWS NLBs do not have this restriction.
+====
++
+* You have created a Bring Your Own (BYO) VPC cluster.
+* You have access to the AWS CLI (`aws`).
+* You have access to the {oc-first}.
 
 .Procedure
 * Prepare the environment variables:

--- a/modules/cloud-experts-aws-load-balancer-operator-install.adoc
+++ b/modules/cloud-experts-aws-load-balancer-operator-install.adoc
@@ -4,7 +4,7 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="cloud-experts-aws-load-balancer-operator-install_{context}"]
-= Installation
+= Install the AWS Load Balancer Operator
 
 [role="_abstract"]
 You can use the {oc-first} tool to install the AWS Load Balancer Operator.

--- a/modules/cloud-experts-aws-load-balancer-operator-validating.adoc
+++ b/modules/cloud-experts-aws-load-balancer-operator-validating.adoc
@@ -4,7 +4,7 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="cloud-experts-aws-load-balancer-operator-validating_{context}"]
-= Validating the deployment
+= Validate the deployment
 
 [role="_abstract"]
 You can validate your load balancer Operators using the {oc-first} tool.
@@ -24,7 +24,7 @@ $ oc new-project hello-world
 $ oc new-app -n hello-world --image=docker.io/openshift/hello-openshift
 ----
 +
-. Configure a NodePort service for the AWS ALB to connect to:
+. Configure a NodePort service for the AWS Application Load Balancer (ALB) to connect to:
 +
 [source,terminal]
 ----
@@ -93,7 +93,7 @@ $ curl "http://${INGRESS}"
 Hello OpenShift!
 ----
 
-. Deploy an AWS NLB for your hello world application:
+. Deploy an AWS Network Load Balancer (NLB) for your hello world application:
 +
 [source,terminal]
 ----

--- a/modules/cloud-experts-aws-secret-manager-create-iam-polices.adoc
+++ b/modules/cloud-experts-aws-secret-manager-create-iam-polices.adoc
@@ -4,7 +4,7 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="cloud-experts-aws-secret-manager-create-iam-polices_{context}"]
-= Creating a Secret and IAM Access Policies
+= Create a Secret and IAM Access Policies
 
 [role="_abstract"]
 Use the AWS CLI to create your AWS secret and IAM access policies.

--- a/modules/cloud-experts-aws-secret-manager-creating-application.adoc
+++ b/modules/cloud-experts-aws-secret-manager-creating-application.adoc
@@ -10,7 +10,7 @@
 You can create your application using the secret that you created.
 
 .Procedure
-. Create an OpenShift project by running the following command:
+. Create an {OCP-short} project by running the following command:
 +
 [source,terminal]
 ----

--- a/modules/cloud-experts-aws-secret-manager-deply-aws-secrets.adoc
+++ b/modules/cloud-experts-aws-secret-manager-deply-aws-secrets.adoc
@@ -4,7 +4,7 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="cloud-experts-aws-secret-manager-deply-aws-secrets_{context}"]
-= Deploying the AWS Secrets and Configuration Provider
+= Deploy the AWS Secrets and Configuration Provider
 
 [role="_abstract"]
 

--- a/modules/cloud-experts-aws-secret-manager-preparing-environment.adoc
+++ b/modules/cloud-experts-aws-secret-manager-preparing-environment.adoc
@@ -9,6 +9,13 @@
 [role="_abstract"]
 Before creating your application, you need to gain access to your {product-title} cluster.
 
+.Prerequisites
+* You have created a {product-title} cluster deployed with STS.
+* You have installed Helm 3.
+* You have access to the AWS CLI (`aws`).
+* You have access to the {oc-first}.
+* You have access to the `jq` CLI.
+
 .Procedure
 . Log in to your {product-title} cluster by running the following command:
 +

--- a/modules/cloud-experts-custom-dns-resolver-configure-dns-server-classic.adoc
+++ b/modules/cloud-experts-custom-dns-resolver-configure-dns-server-classic.adoc
@@ -7,11 +7,11 @@
 = Configure your DNS server
 
 [role="_abstract"]
-{product-title} clusters require you to configure DNS server to forward the necessary private hosted zones to your Amazon Route 53 Inbound Resolver:
+{product-title} clusters require you to configure your DNS server to forward the necessary private hosted zones to your Amazon Route 53 Inbound Resolver:
 
 * `<domain-prefix>.<unique-ID>.p1.openshiftapps.com`
 
-This Amazon Route 53 private hosted zones is created during cluster creation. The `domain-prefix` is a customer-specified value, but the `unique-ID` is randomly generated during cluster creation and cannot be preselected. As such, you must wait for the cluster creation process to begin before configuring forwarding for the `p1.openshiftapps.com` private hosted zone. 
+This Amazon Route 53 private hosted zone is created during cluster creation. The `domain-prefix` is a customer-specified value, but the `unique-ID` is randomly generated during cluster creation and cannot be preselected. As such, you must wait for the cluster creation process to begin before configuring forwarding for the `p1.openshiftapps.com` private hosted zone. 
 
 .Procedure
 . Create your cluster.

--- a/modules/cloud-experts-custom-dns-resolver-configure-dns-server-hcp.adoc
+++ b/modules/cloud-experts-custom-dns-resolver-configure-dns-server-hcp.adoc
@@ -7,7 +7,7 @@
 = Configure your DNS server
 
 [role="_abstract"]
-{product-title} clusters require you to configure DNS server to forward the necessary private hosted zones to your Amazon Route 53 Inbound Resolver:
+{product-title} clusters require you to configure your DNS server to forward the necessary private hosted zones to your Amazon Route 53 Inbound Resolver:
 
 * `<cluster-name>.hypershift.local`
 * `rosa.<domain-prefix>.<unique-ID>.p3.openshiftapps.com`

--- a/modules/cloud-experts-custom-dns-resolver-environment-setup.adoc
+++ b/modules/cloud-experts-custom-dns-resolver-environment-setup.adoc
@@ -4,10 +4,21 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="cloud-experts-custom-dns-resolver-environment-setup_{context}"]
-= Setting up your environment
+= Set up your environment
 
 [role="_abstract"]
 You can use environment variables to ensure consistency across the commands within this lab.
+
+.Prerequisites
+* You have access to the {rosa-cli-first}.
+* You have access to the AWS CLI (`aws`).
+ifdef::openshift-rosa[]
+* You have manually created an AWS Virtual Private Cloud (VPC).
+endif::openshift-rosa[]
+ifdef::openshift-rosa-hcp[]
+* You have manually created link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html-single/install_clusters/index#rosa-hcp-creating-vpc_rosa-hcp-sts-creating-a-cluster-quickly[an AWS Virtual Private Cloud (VPC)].
+endif::openshift-rosa-hcp[]
+* You have configured a DHCP option set to point to a custom DNS server and set as the default for your VPC.
 
 .Procedure
 . In your terminal, configure the following environment variables:

--- a/modules/cloud-experts-deploy-api-data-protection-cleanup.adoc
+++ b/modules/cloud-experts-deploy-api-data-protection-cleanup.adoc
@@ -4,7 +4,7 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="cloud-experts-deploy-api-data-protection-cleanup_{context}"]
-=  Cleaning up
+= Clean up
 
 [role="_abstract"]
 Clean up your AWS resources after completing this lab tutorial.

--- a/modules/cloud-experts-deploy-api-data-protection-deploy-oadp-on-cluster.adoc
+++ b/modules/cloud-experts-deploy-api-data-protection-deploy-oadp-on-cluster.adoc
@@ -7,7 +7,7 @@
 = Deploy OADP on the cluster
 
 [role="_abstract"]
-You need to use the {oc-first} tool to deploy OADP to your cluster.
+You need to use the {oc-first} tool to deploy {oadp-first} to your cluster.
 
 .Procedure
 . Create a namespace for OADP:
@@ -136,7 +136,7 @@ gp3                 ebs.csi.aws.com         Delete          WaitForFirstConsumer
 gp3-csi (default)   ebs.csi.aws.com         Delete          WaitForFirstConsumer   true                   4d21h
 ----
 +
-Using either gp3-csi, gp2-csi, gp3 or gp2 will work. If the application(s) that are being backed up are all using PV's with CSI, include the CSI plugin in the OADP DPA configuration.
+Using either gp3-csi, gp2-csi, gp3 or gp2 will work. If the application(s) that are being backed up are all using Persistent Volumes (PVs) with the Container Storage Interface (CSI), include the CSI plugin in the OADP Data Protection Application (DPA) configuration.
 
 . CSI only: Deploy a Data Protection Application:
 +

--- a/modules/cloud-experts-deploy-api-data-protection-environment-variables.adoc
+++ b/modules/cloud-experts-deploy-api-data-protection-environment-variables.adoc
@@ -4,10 +4,18 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="cloud-experts-deploy-api-data-protection-environment-variables_{context}"]
-= Setting up your environment
+= Set up your environment
 
 [role="_abstract"]
 You can use environment variables to ensure consistency across the commands within this lab.
+
+.Prerequisites
+ifndef::openshift-rosa-hcp[]
+* You have created a link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws_classic_architecture/4/html-single/install_rosa_classic_clusters/index#rosa-sts-creating-a-cluster-quickly[{product-title} cluster].
+endif::openshift-rosa-hcp[]
+ifdef::openshift-rosa-hcp[]
+* You have created a link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html-single/install_clusters/index#rosa-hcp-sts-creating-a-cluster-quickly[{product-title} cluster].
+endif::openshift-rosa-hcp[]
 
 .Procedure
 * Prepare the environment variables:
@@ -15,7 +23,7 @@ You can use environment variables to ensure consistency across the commands with
 [NOTE]
 ====
 Change the cluster name to match your {product-title} cluster and ensure you are logged into the cluster as an Administrator.
-Ensure all fields are outputted correctly before moving on.
+Ensure all fields are output correctly before moving on.
 ====
 +
 [source,terminal]

--- a/modules/cloud-experts-deploy-api-data-protection-perform-backup.adoc
+++ b/modules/cloud-experts-deploy-api-data-protection-perform-backup.adoc
@@ -7,11 +7,11 @@
 = Perform a backup
 
 [role="_abstract"]
-You can perform a back up by using the {oc-first} tool.
+You can perform a backup by using the {oc-first} tool.
 
 [NOTE]
 ====
-The following sample hello-world application has no attached persistent volumes. Either DPA configuration will work.
+The following sample hello-world application has no attached persistent volumes. Either Data Protection Application (DPA) configuration will work.
 ====
 
 .Procedure

--- a/modules/cloud-experts-deploy-api-data-protection-prepare-aws-account.adoc
+++ b/modules/cloud-experts-deploy-api-data-protection-prepare-aws-account.adoc
@@ -4,10 +4,10 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="cloud-experts-deploy-api-data-protection-prepare-aws-account_{context}"]
-= Prepare AWS Account
+= Prepare your AWS account
 
 [role="_abstract"]
-Before deploying OpenShift API for data protection, you must set up your AWS account.
+Before deploying {oadp-full}, you must set up your AWS account.
 
 .Procedure
 . Create an IAM Policy to allow for S3 Access:

--- a/modules/cloud-experts-entra-id-idp-additional-individual-groups.adoc
+++ b/modules/cloud-experts-entra-id-idp-additional-individual-groups.adoc
@@ -4,7 +4,7 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="cloud-experts-entra-id-idp--additional-individual-groups_{context}"]
-= Granting additional permissions to individual groups
+= Grant additional permissions to individual groups
 
 [role="_abstract"]
 If you opted to enable group claims, the cluster OAuth provider automatically creates or updates the user's group memberships by using the group ID. The cluster OAuth provider does not automatically create `RoleBindings` and `ClusterRoleBindings` for the groups that are created; you are responsible for creating those bindings by using your own processes.

--- a/modules/cloud-experts-entra-id-idp-additional-individual-user.adoc
+++ b/modules/cloud-experts-entra-id-idp-additional-individual-user.adoc
@@ -4,7 +4,7 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="cloud-experts-entra-id-idp-additional-individual-user_{context}"]
-= Granting additional permissions to individual users
+= Grant additional permissions to individual users
 
 [role="_abstract"]
 {product-title} includes a significant number of preconfigured roles, including the `cluster-admin` role that grants full access and control over the cluster.

--- a/modules/cloud-experts-entra-id-idp-additional-user-groups.adoc
+++ b/modules/cloud-experts-entra-id-idp-additional-user-groups.adoc
@@ -2,11 +2,11 @@
 //
 // * cloud_experts_tutorials/cloud-experts-entra-id-idp.adoc
 
-:_mod-docs-content-type: REFERENCE
+:_mod-docs-content-type: CONCEPT
 [id="cloud-experts-entra-id-idp-additional-user-groups_{context}"]
-= Granting additional permissions to individual users and groups
+= Grant additional permissions to individual users and groups
 
 [role="_abstract"]
-When your first log in, you might notice that you have very limited permissions. By default, {product-title} only grants you the ability to create new projects, or namespaces, in the cluster. Other projects are restricted from view.
+When you first log in, you might notice that you have very limited permissions. By default, {product-title} only grants you the ability to create new projects, or namespaces, in the cluster. Other projects are restricted from view.
 
 You must grant these additional abilities to individual users and groups.

--- a/modules/cloud-experts-entra-id-idp-configure-app.adoc
+++ b/modules/cloud-experts-entra-id-idp-configure-app.adoc
@@ -4,7 +4,7 @@
 
 :_mod-docs-content-type: CONCEPT
 [id="cloud-experts-entra-id-idp-configure-app_{context}"]
-= Configuring the application registration in Entra ID to include optional and group claims
+= Configure the application registration in Entra ID to include optional and group claims
 
 [role="_abstract"]
 To ensure that {product-title} has enough information to create the user's account, you must configure Entra ID to give two optional claims: `email` and `preferred_username`. For more information about optional claims in Entra ID, see link:https://learn.microsoft.com/en-us/azure/active-directory/develop/optional-claims[the Microsoft documentation].

--- a/modules/cloud-experts-entra-id-idp-configure-entra-idp.adoc
+++ b/modules/cloud-experts-entra-id-idp-configure-entra-idp.adoc
@@ -4,10 +4,10 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="cloud-experts-entra-id-idp-configure-entra-idp_{context}"]
-= Configuring the {product-title} cluster to use Entra ID as the identity provider
+= Configure the {product-title} cluster to use Entra ID as the identity provider
 
 [role="_abstract"]
-You must configure {product-title} to use Entra ID as its identity provider. Although {product-title} offers the ability to configure identity providers by using {cluster-manager}, use the ROSA CLI to configure the cluster's OAuth provider to use Entra ID as its identity provider. Before configuring the identity provider, set the necessary variables for the identity provider configuration.
+You must configure {product-title} to use Entra ID as its identity provider. Although {product-title} offers the ability to configure identity providers by using {cluster-manager}, use the {rosa-cli-first} to configure the cluster's OAuth provider to use Entra ID as its identity provider. Before configuring the identity provider, set the necessary variables for the identity provider configuration.
 
 .Procedure
 . Create the variables by running the following command:
@@ -22,7 +22,7 @@ $ TENANT_ID=zzzzzzzz-zzzz-zzzz-zzzz-zzzzzzzzzzzz
 ----
 +
 --
-where: 
+where:
 
 `example-cluster`:: Replace this with the name of your cluster.
 `AAD`:: Replace this value with the name you used in the OAuth callback URL that you generated earlier in this process.

--- a/modules/cloud-experts-entra-id-idp-configure-group-claims.adoc
+++ b/modules/cloud-experts-entra-id-idp-configure-group-claims.adoc
@@ -4,7 +4,7 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="cloud-experts-entra-id-idp-configure-group-claims_{context}"]
-= Configuring group claims (optional)
+= Configure group claims (optional)
 
 [role="_abstract"]
 Configure Entra ID to offer a groups claim.

--- a/modules/cloud-experts-entra-id-idp-configure-optional-claims.adoc
+++ b/modules/cloud-experts-entra-id-idp-configure-optional-claims.adoc
@@ -4,7 +4,7 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="cloud-experts-entra-id-idp-configure-optional-claims_{context}"]
-= Configuring optional claims
+= Configure optional claims
 
 [role="_abstract"]
 You can configure the optional claims in Entra ID.

--- a/modules/cloud-experts-entra-id-idp-register-app.adoc
+++ b/modules/cloud-experts-entra-id-idp-register-app.adoc
@@ -4,10 +4,13 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="cloud-experts-entra-id-idp-register-app_{context}"]
-= Registering a new application in Entra ID for authentication
+= Register a new application in Entra ID for authentication
 
 [role="_abstract"]
 To register your application in Entra ID, first create the OAuth callback URL, then register your application.
+
+.Prerequisites
+* You have created a set of security groups and assigned users by following link:https://learn.microsoft.com/en-us/azure/active-directory/fundamentals/how-to-manage-groups[the Microsoft documentation].
 
 .Procedure
 . Create the cluster's OAuth callback URL by changing the specified variables and running the following command:

--- a/modules/cloud-experts-using-alb-and-waf-configure-aws-waf.adoc
+++ b/modules/cloud-experts-using-alb-and-waf-configure-aws-waf.adoc
@@ -7,10 +7,10 @@
 = Configure the AWS WAF
 
 [role="_abstract"]
-The link:https://aws.amazon.com/waf/[AWS WAF] service is a web application firewall that lets you monitor, protect, and control the HTTP and HTTPS requests that are forwarded to your protected web application resources, like {product-title}.
+You can use the link:https://aws.amazon.com/waf/[AWS Web Application Firewall (WAF)] service to monitor, protect, and control the HTTP and HTTPS requests that are forwarded to your protected web application resources, like {product-title}.
 
 .Procedure
-. Create a AWS WAF rules file to apply to our web ACL:
+. Create an AWS WAF rules file to apply to our web access control list (ACL):
 +
 [source,terminal]
 ----
@@ -73,7 +73,7 @@ $ WAF_ARN=$(aws wafv2 create-web-acl \
   --output text)
 ----
 +
-. Annotate the Ingress resource with the AWS WAF Web ACL ARN:
+. Annotate the Ingress resource with the AWS WAF Web ACL (Amazon Resource Name) ARN:
 +
 [source,terminal]
 ----

--- a/modules/cloud-experts-using-alb-and-waf-deploy-aws-load-balancer-operator.adoc
+++ b/modules/cloud-experts-using-alb-and-waf-deploy-aws-load-balancer-operator.adoc
@@ -7,7 +7,7 @@
 = Deploy the AWS Load Balancer Operator
 
 [role="_abstract"]
-The link:https://github.com/openshift/aws-load-balancer-operator[AWS Load Balancer Operator] is used to used to install, manage and configure an instance of `aws-load-balancer-controller` in a {product-title} cluster. To deploy ALBs in {product-title}, we need to first deploy the AWS Load Balancer Operator.
+The link:https://github.com/openshift/aws-load-balancer-operator[AWS Load Balancer Operator] is used to install, manage, and configure an instance of `aws-load-balancer-controller` in a {product-title} cluster. To deploy ALBs in {product-title}, we need to first deploy the AWS Load Balancer Operator.
 
 .Procedure
 . Create a new project to deploy the AWS Load Balancer Operator into by running the following command:

--- a/modules/cloud-experts-using-alb-and-waf-environment-setup.adoc
+++ b/modules/cloud-experts-using-alb-and-waf-environment-setup.adoc
@@ -4,10 +4,22 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="cloud-experts-using-alb-and-waf-environment-setup_{context}"]
-= Setting up your environment
+= Set up your environment
 
 [role="_abstract"]
 You can use environment variables to ensure consistency across the commands within this lab.
+
+.Prerequisites
+
+* You have created a multiple availability zone (AZ) {product-title} cluster.
++
+[NOTE]
+====
+AWS ALBs require at least two _public_ subnets across AZs, link:https://docs.aws.amazon.com/elasticloadbalancing/latest/application/application-load-balancers.html#availability-zones[per the AWS documentation]. For this reason, only multiple AZ {product-title} clusters can be used with ALBs.
+====
++
+* You have access to the {oc-first}.
+* You have access to the AWS CLI (`aws`).
 
 .Procedure
 

--- a/modules/cloud-experts-using-aws-ack-clean-up.adoc
+++ b/modules/cloud-experts-using-aws-ack-clean-up.adoc
@@ -4,7 +4,7 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="cloud-experts-using-aws-ack-clean-up_{context}"]
-= Cleaning up
+= Clean up
 
 [role="_abstract"]
 Clean up your AWS resources after completing this lab tutorial.

--- a/modules/cloud-experts-using-aws-ack-environment-setup.adoc
+++ b/modules/cloud-experts-using-aws-ack-environment-setup.adoc
@@ -4,10 +4,16 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="cloud-experts-using-aws-ack-environment-setup_{context}"]
-= Setting up your environment
+= Set up your environment
 
 [role="_abstract"]
 You can use environment variables to ensure consistency across the commands within this lab.
+
+.Prerequisites
+* You have created a {product-title} cluster.
+* You have access to a user account with `cluster-admin` privileges.
+* You have access to the {oc-first}.
+* You have access to the AWS CLI (`aws`).
 
 .Procedure
 . Configure the following environment variables, changing the cluster name to suit your cluster:

--- a/modules/cloud-experts-using-aws-ack-install-ack.adoc
+++ b/modules/cloud-experts-using-aws-ack-install-ack.adoc
@@ -4,7 +4,7 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="cloud-experts-using-aws-ack-install-ack_{context}"]
-= Installing the ACK S3 Controller
+= Install the ACK S3 Controller
 
 [role="_abstract"]
 Use the {oc-first} to create a project for your ACK S3 Controller. 

--- a/modules/cloud-experts-using-aws-ack-prep-aws.adoc
+++ b/modules/cloud-experts-using-aws-ack-prep-aws.adoc
@@ -4,13 +4,13 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="cloud-experts-using-aws-ack-prep-aws_{context}"]
-= Preparing your AWS Account
+= Prepare your AWS Account
 
 [role="_abstract"]
 Before using your AWS controllers, you must prepare your AWS account.
 
 .Procedure
-. Create an AWS Identity Access Management (IAM) trust policy for the ACK Operator:
+. Create an AWS Identity and Access Management (IAM) trust policy for the ACK Operator:
 +
 [source,terminal]
 ----

--- a/modules/cloud-experts-using-aws-ack-valid-deploy.adoc
+++ b/modules/cloud-experts-using-aws-ack-valid-deploy.adoc
@@ -4,7 +4,7 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="cloud-experts-using-aws-ack-valid-deploy_{context}"]
-= Validating the deployment
+= Validate the deployment
 
 [role="_abstract"]
 After installing your controller, you can verify the installation by using the {oc-first} tool.

--- a/modules/cloud-experts-using-cloudfront-and-waf-configure-aws-waf.adoc
+++ b/modules/cloud-experts-using-cloudfront-and-waf-configure-aws-waf.adoc
@@ -10,7 +10,7 @@
 The link:https://aws.amazon.com/waf/[AWS WAF] service is a web application firewall that lets you monitor, protect, and control the HTTP and HTTPS requests that are forwarded to your protected web application resources, like {product-title}.
 
 .Procedure
-. Create a AWS WAF rules file to apply to our web ACL:
+. Create an AWS WAF rules file to apply to our web access control list (ACL):
 +
 [source,terminal]
 ----

--- a/modules/cloud-experts-using-cloudfront-and-waf-secondary_ingress_controller_setup.adoc
+++ b/modules/cloud-experts-using-cloudfront-and-waf-secondary_ingress_controller_setup.adoc
@@ -4,7 +4,7 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="cloud-experts-using-cloudfront-and-waf-secondary_ingress_controller_setup_{context}"]
-= Setting up the secondary ingress controller
+= Set up the secondary ingress controller
 
 [role="_abstract"]
 It is necessary to configure a secondary ingress controller to segment your external WAF-protected traffic from your standard (and default) cluster ingress controller. 

--- a/modules/cloud-experts-using-cloudfront-and-waf-setup-environ.adoc
+++ b/modules/cloud-experts-using-cloudfront-and-waf-setup-environ.adoc
@@ -4,10 +4,15 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="cloud-experts-using-cloudfront-and-waf-setup-environ_{context}"]
-= Setting up your environment
+= Set up your environment
 
 [role="_abstract"]
 You can use environment variables to ensure consistency across the commands within this lab.
+
+.Prerequisites
+* You have created a {product-title} cluster.
+* You have access to the {oc-first}.
+* You have access to the AWS CLI (`aws`).
 
 .Procedure
 . In your terminal, configure the following environment variables:

--- a/modules/egress-ip-assign-ip-namespace.adoc
+++ b/modules/egress-ip-assign-ip-namespace.adoc
@@ -4,7 +4,7 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="cloud-experts-consistent-egress-ip-assign-ip-namespace_{context}"]
-= Assigning an egress IP to a namespace
+= Assign an egress IP to a namespace
 
 [role="_abstract"]
 You can assign an egress IP to a namespace on your cluster by using the {oc-first} tool.

--- a/modules/egress-ip-assigning-to-pod.adoc
+++ b/modules/egress-ip-assigning-to-pod.adoc
@@ -6,7 +6,7 @@
 // * cloud_experts_tutorials/cloud-experts-consistent-egress-ip.adoc
 :_mod-docs-content-type: PROCEDURE
 [id="cloud-experts-consistent-egress-ip-assigning-to-pod_{context}"]
-= Assigning an egress IP to a pod
+= Assign an egress IP to a pod
 
 [role="_abstract"]
 Create an egress rule to assign an egress IP to a specified pod.

--- a/modules/egress-ip-blocked-egress.adoc
+++ b/modules/egress-ip-blocked-egress.adoc
@@ -4,10 +4,10 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="cloud-experts-consistent-egress-ip-blocked-egress_{context}"]
-= Optional: Testing blocked egress
+= Test blocked egress
 
 [role="_abstract"]
-You can test if the egress is blocked by using {oc-first} tool.
+You can test if the egress is blocked by using the {oc-first} tool. This procedure is optional.
 
 .Procedure
 . Test that the traffic is successfully blocked when the egress rules do not apply by running the following command:

--- a/modules/egress-ip-capacity.adoc
+++ b/modules/egress-ip-capacity.adoc
@@ -4,7 +4,7 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="cloud-experts-consistent-egress-ip-capacity_{context}"]
-= Ensuring capacity
+= Ensure capacity
 
 [role="_abstract"]
 The number of IP addresses assigned to each node is limited for each public cloud provider. 

--- a/modules/egress-ip-cluster-cleanup.adoc
+++ b/modules/egress-ip-cluster-cleanup.adoc
@@ -4,7 +4,7 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="cloud-experts-consistent-egress-ip-cluster-cleanup_{context}"]
-= Cleaning up your cluster
+= Clean up your cluster
 
 [role="_abstract"]
 Before moving to a different tutorial, you can clean up your cluster environment with a few commands.

--- a/modules/egress-ip-creating-ip-rules.adoc
+++ b/modules/egress-ip-creating-ip-rules.adoc
@@ -4,7 +4,7 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="cloud-experts-consistent-egress-ip-creating-ip-rules_{context}"]
-= Creating the egress IP rules
+= Create the egress IP rules
 
 [role="_abstract"]
 Before creating the egress IP rules, identify which egress IPs you will use.

--- a/modules/egress-ip-deploy-sample-app.adoc
+++ b/modules/egress-ip-deploy-sample-app.adoc
@@ -4,7 +4,7 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="cloud-experts-consistent-egress-ip-deploy-sample-app_{context}"]
-= Deploying a sample application
+= Deploy a sample application
 
 [role="_abstract"]
 To test the egress IP rule, create a service that is restricted to the egress IP addresses which we have specified. This simulates an external service that is expecting a small subset of IP addresses.

--- a/modules/egress-ip-egress-ip-review.adoc
+++ b/modules/egress-ip-egress-ip-review.adoc
@@ -4,10 +4,10 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="cloud-experts-consistent-egress-ip-egress-ip-review_{context}"]
-= Reviewing the egress IPs
+= Review the egress IPs
 
 [role="_abstract"]
-You can list all of the egress IPs by using {oc-first} tool.
+You can list all of the egress IPs by using the {oc-first} tool.
 
 .Procedure
 * Review the egress IP assignments by running the following command:

--- a/modules/egress-ip-env-variables.adoc
+++ b/modules/egress-ip-env-variables.adoc
@@ -4,10 +4,16 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="cloud-experts-consistent-egress-ip-env-variables_{context}"]
-= Setting your environment variables
+= Set your environment variables
 
 [role="_abstract"]
 You may set environment variables to make it easier to reuse values.
+
+.Prerequisites
+* You have created a {product-title} cluster deployed with OVN-Kubernetes.
+* You have access to the {oc-first}.
+* You have access to the {rosa-cli-first}.
+* You have access to the link:https://jqlang.org/[`jq` JSON processor].
 
 .Procedure
 * Set your environment variables by running the following command:

--- a/modules/egress-ip-namespace-egress.adoc
+++ b/modules/egress-ip-namespace-egress.adoc
@@ -4,7 +4,7 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="cloud-experts-consistent-egress-ip-namespace-egress_{context}"]
-= Testing the namespace egress
+= Test the namespace egress
 
 [role="_abstract"]
 You can test the namespace egress by using the {oc-first} tool.
@@ -34,7 +34,7 @@ $ curl -s http://$LOAD_BALANCER_HOSTNAME
 +
 [NOTE]
 ====
-The `client_address` is the internal IP address of the load balancer not your egress IP. You can verify that you have  configured the client address correctly by connecting with your service limited to `.spec.loadBalancerSourceRanges`.
+The `client_address` is the internal IP address of the load balancer, not your egress IP. You can verify that you have  configured the client address correctly by connecting with your service limited to `.spec.loadBalancerSourceRanges`.
 ====
 +
 *For example*:

--- a/modules/egress-ip-node-labels.adoc
+++ b/modules/egress-ip-node-labels.adoc
@@ -4,7 +4,7 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="cloud-experts-consistent-egress-ip-node-labels_{context}"]
-= Labeling the nodes
+= Label the nodes
 
 [role="_abstract"]
 You can label your nodes by using the {oc-first} tool.

--- a/modules/egress-ip-pod-egress-test.adoc
+++ b/modules/egress-ip-pod-egress-test.adoc
@@ -4,7 +4,7 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="cloud-experts-consistent-egress-ip-pod-egress-test_{context}"]
-= Testing the pod egress
+= Test the pod egress
 
 [role="_abstract"]
 You can test your pod's egress by using the {oc-first} tool.
@@ -30,11 +30,11 @@ $ oc run \
 $ curl -s http://$LOAD_BALANCER_HOSTNAME
 ----
 +
-. Check the output for a successful connection: 
+. Check the output for a successful connection:
 +
 [NOTE]
 ====
-The `client_address` is the internal IP address of the load balancer not your egress IP. You can verify that you have  configured the client address correctly by connecting with your service limited to `.spec.loadBalancerSourceRanges`.
+The `client_address` is the internal IP address of the load balancer, not your egress IP. You can verify that you have configured the client address correctly by connecting with your service limited to `.spec.loadBalancerSourceRanges`.
 ====
 +
 *For example*:

--- a/modules/offer-troubleshooting.adoc
+++ b/modules/offer-troubleshooting.adoc
@@ -11,7 +11,7 @@ The most frequent issues associated with private offer acceptance and Red{nbsp}H
 
 == Accessing a private offer using a different AWS account
 
-* If you try accessing the private offer when logged in under AWS account ID that is not defined in the offer, and see the message shown in Figure 11, then verify that you are logged in as the desired AWS billing account. 
+* If you try accessing the private offer when logged in under an AWS account ID that is not defined in the offer, and see the message shown in Figure 11, then verify that you are logged in as the desired AWS billing account. 
 +
 [caption="HTTP 404 error when using the private offer URL"]
 +
@@ -21,7 +21,7 @@ image::rosa-http-404-error-when-using-the-private-offer-url.png[]
 
 == The private offer cannot be accepted because of active subscription
 
-* If you try accessing a private offer that was created for the first time {product-title} activation, while you already have {product-title} activated using another public or private offer, and see the following notice, then contact the seller who provided you with the offer. 
+* If you try accessing a private offer that was created for the first-time {product-title} activation, while you already have {product-title} activated using another public or private offer, and see the following notice, then contact the seller who provided you with the offer. 
 +
 The seller can provide you with a new offer that will seamlessly replace your current agreement, without a need to cancel your previous subscription.
 +

--- a/modules/selecting-billing-account-cli.adoc
+++ b/modules/selecting-billing-account-cli.adoc
@@ -4,18 +4,18 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="selecting-billing-account-cli_{context}"]
-= Selecting the AWS billing account for {product-title} during cluster deployment using the CLI
+= Select the AWS billing account for {product-title} during cluster deployment using the CLI
 
 [role="_abstract"]
-When deploying your cluster using {rosa-cli}, you must select the correct AWS billing account.
+When deploying your cluster using {rosa-cli-first}, you must select the correct AWS billing account.
 
 [IMPORTANT]
 ====
-Make sure that you have the most recent ROSA command-line interface (CLI) and AWS CLI installed and have completed the {product-title} prerequisites covered in the previous section. See link:https://github.com/openshift/openshift-docs/pull/104179[Help with ROSA CLI setup] and link:https://aws.amazon.com/cli/[Instructions to install the AWS CLI] for more information.
+Make sure that you have the most recent {rosa-cli} and AWS CLI installed and have completed the {product-title} prerequisites covered in the previous section. See link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html-single/cli_tools/index#rosa-get-started-cli[Getting started with the {rosa-cli}] and link:https://aws.amazon.com/cli/[Instructions to install the AWS CLI] for more information.
 ====
 
 .Procedure
-. Initiate the cluster deployment using the `rosa create cluster` command. You can click the *copy* button on the link:https://console.redhat.com/openshift/create/rosa/getstarted[Set up Red{nbsp}Hat OpenShift Service on AWS (ROSA) console page] and paste the command in your terminal. This launches the cluster creation process in interactive mode:
+. Initiate the cluster deployment using the `rosa create cluster` command. You can click the *copy* button on the link:https://console.redhat.com/openshift/create/rosa/getstarted[Set up {product-title} console page] and paste the command in your terminal. This launches the cluster creation process in interactive mode:
 +
 [caption="Deploy the cluster and set up access"]
 image::rosa-cli-15.png[]

--- a/modules/selecting-billing-account-ui.adoc
+++ b/modules/selecting-billing-account-ui.adoc
@@ -4,38 +4,38 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="selecting-billing-account-ui_{context}"]
-= Selecting the AWS billing account for {product-title} during cluster deployment using the web console
+= Select the AWS billing account for {product-title} during cluster deployment using the web console
 
 [role="_abstract"]
 When deploying your cluster using {cluster-manager}, you must select the correct AWS billing account.
 
 .Procedure
-. A cluster can be created using the web console by selecting the second option in the bottom section of the introductory *Set up {product-title}* page:
+. To start creating a cluster, select the second option in the bottom section of the introductory *Set up {product-title}* page:
 +
 [caption="Deploy with web interface"]
 image::rosa-deploy-ui-19.png[]
 +
 [NOTE]
 ====
-Complete the prerequisites before starting the web console deployment process. 
+Complete the prerequisites before starting the web console deployment process.
 
-The `rosa` CLI is required for certain tasks, such as creating the account roles. If you are deploying {product-title} for the first time, follow this the CLI steps until running the `rosa whoami` command, before starting the web console deployment steps.
+The {rosa-cli-first} is required for certain tasks, such as creating the account roles. If you are deploying {product-title} for the first time, follow the CLI steps until running the `rosa whoami` command, before starting the web console deployment steps.
 ====
 
-. The first step when creating a {product-title} cluster using the web console is the control plane selection. Make sure the *Hosted* option is selected before clicking the *Next* button:
+. Select the *Hosted* control plane option, then click *Next*:
 +
 [caption="Select hosted option"]
 +
 image::rosa-deploy-ui-hcp-20.png[]
 
-. The next step *Accounts and roles* allows you specifying the infrastructure AWS account, into which the {product-title} cluster is deployed and where the resources are consumed and managed:
+. In the next step *Accounts and roles*, specify the infrastructure AWS account, into which the {product-title} cluster is deployed and where the resources are consumed and managed:
 +
 [caption="AWS infrastructure account"]
 image::rosa-ui-account-21.png[]
 +
-* Click the *How to associate a new AWS account*, if you don not see the account into which you want to deploy the {product-title} cluster for detailed information on how to create or link account roles for this association.
-* The `rosa` CLI is used for this.
-* If you are using multiple AWS accounts and have their profiles configured for the AWS CLI, you can use the `--profile` selector to specify the AWS profile when working with the `rosa` CLI commands.
+* Click the *How to associate a new AWS account*, if you don't see the account into which you want to deploy the {product-title} cluster for detailed information on how to create or link account roles for this association.
+* The {rosa-cli} is used for this.
+* If you are using multiple AWS accounts and have their profiles configured for the AWS CLI, you can use the `--profile` selector to specify the AWS profile when working with the {rosa-cli} commands.
 
 . The billing AWS account is selected in the immediately following section:
 +

--- a/modules/sharing-private-offer.adoc
+++ b/modules/sharing-private-offer.adoc
@@ -4,7 +4,7 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="sharing-private-offer_{context}"]
-= Sharing a private offer
+= Share a private offer
 
 [role="_abstract"]
 You can share a private offer with other team members that are within your Red{nbsp}Hat organization account.

--- a/modules/subscription-enablement.adoc
+++ b/modules/subscription-enablement.adoc
@@ -9,6 +9,14 @@
 [role="_abstract"]
 You can activate the {product-title} product at the link:https://console.aws.amazon.com/rosa/home[AWS console page] by clicking the *Get started* button:
 
+.Prerequisites
+
+* You're logged in to the Red{nbsp}Hat account that you want to associate with the AWS account that will activate the {product-title} product subscription.
++
+The AWS account used for service billing can only be associated with a single Red{nbsp}Hat account. Typically an AWS payer account is the one that is used to subscribe to {product-title} and used for account linking and billing.
++
+All team members belonging to the same Red{nbsp}Hat organization can use the linked AWS account for service billing while creating {product-title} clusters.
+
 .Procedure
 . Click the *Get started* button on link:https://console.aws.amazon.com/rosa/home[AWS console page]:
 +
@@ -35,7 +43,7 @@ image::rosa-prereq-enable-3.png[]
 +
 image::rosa-service-quota-4.png[]
 +
-** Click the *Increase service quotas* button or use the *Learn more* link to get more information about the about how to manage service quotas. In the case of insufficient quotas, note that quotas are region-specific. You can use the region switcher in the upper right corner of the web console to re-run the quota check for any region you are interested in and then submit service quota increase requests as needed.
+** Click the *Increase service quotas* button or use the *Learn more* link to get more information about how to manage service quotas. In the case of insufficient quotas, note that quotas are region-specific. You can use the region switcher in the upper right corner of the web console to re-run the quota check for any region you are interested in and then submit service quota increase requests as needed.
 
 . If all the prerequisites are met, the page will look like this:
 +


### PR DESCRIPTION
**Version(s):**
4.22+
5.0+

**Issues:**
Main ROSA HCP Tutorials CQA ticket: https://redhat.atlassian.net/browse/OSDOCS-16402 
Bug tickets:

- Editorial fixes (grammar): https://redhat.atlassian.net/browse/OSDOCS-20285
- Broken links: https://redhat.atlassian.net/browse/OSDOCS-20305
- Product names and attributes: https://redhat.atlassian.net/browse/OSDOCS-20284
- Expanding abbreviations on first use: https://redhat.atlassian.net/browse/OSDOCS-20282
- Rewriting prereqs for consistency: https://redhat.atlassian.net/browse/OSDOCS-20371

**Link to docs preview:**
ROSA HCP and Classic tutorials include the same 9 assemblies. 2 assemblies are HCP-only.

**ROSA HCP tutorials:**
https://113885--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/cloud_experts_tutorials/cloud-experts-aws-load-balancer-operator.html
https://113885--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/cloud_experts_tutorials/cloud-experts-aws-secret-manager.html
https://113885--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/cloud_experts_tutorials/cloud-experts-consistent-egress-ip.html
https://113885--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/cloud_experts_tutorials/cloud-experts-custom-dns-resolver.html
https://113885--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/cloud_experts_tutorials/cloud-experts-deploy-api-data-protection.html
https://113885--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/cloud_experts_tutorials/cloud-experts-entra-id-idp.html
https://113885--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/cloud_experts_tutorials/cloud-experts-using-alb-and-waf.html
https://113885--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/cloud_experts_tutorials/cloud-experts-using-aws-ack.html
https://113885--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/cloud_experts_tutorials/cloud-experts-using-cloudfront-and-waf.html
https://113885--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/cloud_experts_tutorials/cloud-experts-rosa-hcp-activation-and-account-linking-tutorial.html (no Classic counterpart)
https://113885--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/cloud_experts_tutorials/cloud-experts-rosa-with-hcp-private-offer-acceptance-and-sharing.html (no Classic counterpart)

**ROSA Classic tutorials:**
https://113885--ocpdocs-pr.netlify.app/openshift-rosa/latest/cloud_experts_tutorials/cloud-experts-aws-load-balancer-operator.html
https://113885--ocpdocs-pr.netlify.app/openshift-rosa/latest/cloud_experts_tutorials/cloud-experts-aws-secret-manager.html
https://113885--ocpdocs-pr.netlify.app/openshift-rosa/latest/cloud_experts_tutorials/cloud-experts-consistent-egress-ip.html
https://113885--ocpdocs-pr.netlify.app/openshift-rosa/latest/cloud_experts_tutorials/cloud-experts-custom-dns-resolver.html
https://113885--ocpdocs-pr.netlify.app/openshift-rosa/latest/cloud_experts_tutorials/cloud-experts-deploy-api-data-protection.html
https://113885--ocpdocs-pr.netlify.app/openshift-rosa/latest/cloud_experts_tutorials/cloud-experts-entra-id-idp.html
https://113885--ocpdocs-pr.netlify.app/openshift-rosa/latest/cloud_experts_tutorials/cloud-experts-using-alb-and-waf.html
https://113885--ocpdocs-pr.netlify.app/openshift-rosa/latest/cloud_experts_tutorials/cloud-experts-using-aws-ack.html
https://113885--ocpdocs-pr.netlify.app/openshift-rosa/latest/cloud_experts_tutorials/cloud-experts-using-cloudfront-and-waf.html

**QE review:**
N/A

**Additional information:**

CQA fixes for ROSA HCP Tutorials will be split into 2 PRs.

This PR 1 checks and fixes:

- CQA section **Procedures** (prereqs only)
- CQA section **Editorial** (grammar and content types)
- CQA section **URLs and links** (4 broken links)
- CQA section **Legal and Branding** (updated ROSA, ROSA CLI, OC CLI, and OADP attributes and spelling)
- Gerunds in titles
- Abbreviations not expanded on first use: OADP, DPA, BYO VPC, ACL, WAF, ARN, CFI, and PVs
- Moves == Prereqs out of assemblies to first modules in assemblies
- Moves links to assemblies' Additional resources