### PR TITLE
OSDOCS#OSDOCS-20306: Update the RNs for 4.12.92

### DIFF
--- a/modules/zstream-4-12-92-about.adoc
+++ b/modules/zstream-4-12-92-about.adoc
@@ -1,0 +1,24 @@
+// Module included in the following assembly:
+//
+// * release_notes/ocp-4-12-release-notes.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="zstream-4-12-92-about_{context}"]
+= RHSA-2026:26529 - {product-title} {product-version}.92 fixed issue and security update
+
+[role="_abstract"]
+Issued: 25 June 2026
+
+{product-title} release {product-version}.92, which includes security updates, is now available. The list of fixed issues that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2026:26529[RHSA-2026:26529] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2026:26527[RHSA-2026:26527] advisory.
+
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+
+You can view the container images in this release by running the following command:
+
+
+[source,terminal]
+----
+$ oc adm release info 4.12.92 --pullspecs
+----

--- a/modules/zstream-4-12-92-fixed-issues.adoc
+++ b/modules/zstream-4-12-92-fixed-issues.adoc
@@ -1,0 +1,10 @@
+// Module included in the following assembly:
+//
+// * release_notes/ocp-4-12-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-12-92-fixed-issues_{context}"]
+= Fixed issues
+
+[role="_abstract"]
+There are no notable fixed issues in this release.

--- a/modules/zstream-4-12-92-updating.adoc
+++ b/modules/zstream-4-12-92-updating.adoc
@@ -1,0 +1,10 @@
+// Module included in the following assembly:
+//
+// * release_notes/ocp-4-12-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-12-92-updating_{context}"]
+= Updating
+
+[role="_abstract"]
+To update an existing {product-title} 4.12 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].

--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -5422,3 +5422,12 @@ include::modules/zstream-4-12-91-fixed-issues.adoc[leveloffset=+3]
 
 // 4.12.91 updating
 include::modules/zstream-4-12-91-updating.adoc[leveloffset=+3]
+
+// 4.12.92 about
+include::modules/zstream-4-12-92-about.adoc[leveloffset=+2]
+
+// 4.12.92 fixes
+include::modules/zstream-4-12-92-fixed-issues.adoc[leveloffset=+3]
+
+// 4.12.92 updating
+include::modules/zstream-4-12-92-updating.adoc[leveloffset=+3]


### PR DESCRIPTION
Version(s):
4.12

Issue:
[OSDOCS-20306](https://redhat.atlassian.net/browse/OSDOCS-20306)

Link to docs preview:
[4.12.92](https://113886--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-12-release-notes.html#zstream-4-12-92-about_release-notes)

QE review:
- [ ] QE has approved this change.
N/A for RNs.

Additional information:
Shipment [MR](https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/587/diffs)
ART [Dashboard](https://art-dash.engineering.redhat.com/dashboard/release/openshift-4.12?page=1)