### PR TITLE
[SRVCOM-3851] OCPSTRAT-819 changes to network policies

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -43,6 +43,8 @@ Topics:
   File: install-serverless-logic-operator
 - Name: Installing the OpenShift Serverless Logic Knative Workflow plugin
   File: serverless-logic-install-kn-workflow-plugin-cli
+- Name: Network policies for OpenShift Serverless
+  File: serverless-network-policies
 - Name: OpenShift Serverless upgrades
   File: serverless-upgrades
 ---

--- a/install/serverless-network-policies.adoc
+++ b/install/serverless-network-policies.adoc
@@ -1,0 +1,28 @@
+:_mod-docs-content-type: ASSEMBLY
+include::_attributes/common-attributes.adoc[]
+[id="serverless-network-policies"]
+= Network policies for OpenShift Serverless
+:context: serverless-network-policies
+
+toc::[]
+
+[role="_abstract"]
+The {ServerlessOperatorName} deploys pre-defined Kubernetes `NetworkPolicy` resources to provide network isolation for {ServerlessProductShortName} components. These policies implement a default-deny approach that helps protect against lateral movement attacks and unintended data leakage.
+
+[NOTE]
+====
+This documentation covers network policies specific to {ServerlessProductName} operator-managed namespaces. For general information about network policies in {product-title}, including how to create custom network policies for your applications, see
+link:https://docs.redhat.com/en/documentation/openshift_container_platform/latest/html/network_security/network-policy[About network policy].
+====
+
+include::modules/serverless-network-policies-security.adoc[leveloffset=+1]
+
+include::modules/serverless-default-network-policies.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+[id="additional-resources_{context}"]
+== Additional resources
+
+* xref:../knative-serving/config-applications/restrictive-network-policies.adoc#restrictive-network-policies[Restrictive network policies]
+* link:https://docs.redhat.com/en/documentation/openshift_container_platform/latest/html/network_security/network-policy[About network policy]
+* link:https://docs.redhat.com/en/documentation/openshift_container_platform/latest/html/network_security/network-policy#creating-network-policy[Creating a network policy]

--- a/modules/serverless-default-network-policies.adoc
+++ b/modules/serverless-default-network-policies.adoc
@@ -1,0 +1,97 @@
+// Module included in the following assemblies:
+//
+// * serverless/install/serverless-network-policies.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="serverless-default-network-policies_{context}"]
+= Default ingress and egress rules for OpenShift Serverless
+
+[role="_abstract"]
+The {ServerlessOperatorName} deploys network policies that allow specific ingress and egress traffic required for Knative components to function properly. All other traffic is denied by default.
+
+== Default ingress and egress rules
+
+The following tables summarize the default network traffic rules for OpenShift Serverless components.
+
+//components + port values
+.Knative Serving component network rules
+[cols="1,1,1,1",options="header"]
+|===
+| Component
+| Allowed ingress
+| Allowed egress
+| Description
+
+|
+|
+|
+|
+
+|
+|
+|
+|
+
+|
+|
+|
+|
+
+|
+|
+|
+|
+|===
+
+.Knative Eventing component network rules
+[cols="1,1,1,1",options="header"]
+|===
+| Component
+| Allowed ingress
+| Allowed egress
+| Description
+
+|
+|
+|
+|
+
+|
+|
+|
+|
+
+|
+|
+|
+|
+
+|
+|
+|
+|
+|===
+
+.Network infrastructure
+[cols="1,1,1,1",options="header"]
+|===
+| Component
+| Allowed ingress
+| Allowed egress
+| Description
+
+| DNS resolution
+|
+|
+|
+
+| Metrics collection
+|
+|
+|
+|===
+
+[NOTE]
+====
+All components require egress access to the Kubernetes API server (port 6443) for cluster operations. DNS egress (port 5353) is permitted cluster-wide for service discovery.
+====

--- a/modules/serverless-network-policies-security.adoc
+++ b/modules/serverless-network-policies-security.adoc
@@ -1,0 +1,39 @@
+// Module included in the following assemblies:
+//
+// * serverless/install/serverless-network-policies.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="serverless-network-policies-security_{context}"]
+= About OpenShift Serverless network policies
+
+[role="_abstract"]
+Starting with {product-title} 4.20, the {ServerlessOperatorName} automatically deploys `NetworkPolicy` resources to operator-managed namespaces. These policies implement a default-deny security model that helps protect OpenShift Serverless components from unauthorized network access.
+
+The network policies deployed by OpenShift Serverless:
+
+* Block all ingress and egress traffic by default in operator-managed namespaces
+* Allow only the specific network communication required for Knative functionality
+* Help protect against lateral movement by compromised pods
+* Help prevent unintended data leakage to unauthorized destinations
+
+[IMPORTANT]
+====
+Do not delete or modify the network policies deployed by the {ServerlessOperatorName}. Removing or modifying these policies might result in cluster instability, component failures, or security vulnerabilities.
+====
+
+== Operator-managed namespaces
+
+The {ServerlessOperatorName} deploys network policies to the following namespaces:
+
+* `knative-serving`
+* `knative-serving-ingress`
+* `knative-eventing`
+* `knative-kafka` (if Knative Kafka is installed)
+
+These policies apply only to OpenShift Serverless system components and do not restrict network traffic in your application namespaces.
+
+== User application network policies
+
+To apply network policies to your Knative Services, create `NetworkPolicy` objects in your application namespaces. Ensure that your policies allow traffic from Knative system namespaces, which are labeled with `knative.openshift.io/system-namespace=true`.
+
+For more information, see "Enabling communication with Knative applications on a cluster with restrictive network policies" in the "Additional resources" section.


### PR DESCRIPTION
Version(s):
- `serverless-docs-1.38`

Issue:
- https://redhat.atlassian.net/browse/SRVCOM-3851

Link to docs preview:
FIXME

QE review:
- [ ] QE has approved this change.

Additional information:
_This PR is still WIP, as the exact implementation is not yet known._