### PR TITLE
[RHDEVDOCS-7365]: Add gathering diagnostic information procedure for OpenShift Pipelines

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -37,6 +37,8 @@ Topics:
   File: about-pipelines
 - Name: Understanding OpenShift Pipelines
   File: understanding-openshift-pipelines
+- Name: Gathering diagnostic information
+  File: op-proc-gathering-diagnostic-information
 ---
 Name: Installing and configuring
 Dir: install_config

--- a/about/op-proc-gathering-diagnostic-information.adoc
+++ b/about/op-proc-gathering-diagnostic-information.adoc
@@ -1,0 +1,27 @@
+:_mod-docs-content-type: ASSEMBLY
+:doctype: book
+include::_attributes/common-attributes.adoc[]
+[id="op-proc-gathering-diagnostic-information"]
+= Gathering diagnostic information for support
+:context: op-proc-gathering-diagnostic-information
+
+toc::[]
+
+[role="_abstract"]
+When you open a support case, you must provide debugging information about your cluster to the Red Hat Support team. You can use the `must-gather` tool to collect diagnostic information for project-level resources, cluster-level resources, and {pipelines-title} components.
+
+[NOTE]
+====
+For prompt support, provide diagnostic information for both {OCP} and {pipelines-title}.
+====
+
+// About the must-gather tool
+include::modules/op-about-must-gather.adoc[leveloffset=+1]
+
+// Collecting debugging data for OpenShift Pipelines
+include::modules/op-collecting-pipelines-debugging-data.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+[id="additional-resources_{context}"]
+== Additional resources
+* link:https://docs.redhat.com/en/documentation/openshift_container_platform/latest/html/support/gathering-cluster-data#about-must-gather_gathering-cluster-data[Gathering cluster data]

--- a/modules/op-about-must-gather.adoc
+++ b/modules/op-about-must-gather.adoc
@@ -1,0 +1,14 @@
+:_mod-docs-content-type: CONCEPT
+[id="op-about-must-gather_{context}"]
+= About the must-gather tool
+
+The `oc adm must-gather` tool collects diagnostic information about your cluster, such as resource definitions, configurations, and logs for project-level and cluster-level resources. 
+
+When you run the command, the tool performs the following actions:
+
+* Creates a new namespace on the cluster specifically for the collection process.
+* Spawns one or more `must-gather` pods within that namespace.
+* Executes scripts inside the pods to gather logs, custom resource definitions (CRDs), and system states from the relevant nodes and control plane components.
+* Streams the collected data back to your local machine and saves it into a newly created directory starting with `./must-gather.local`.
+
+By default, the tool collects data across core cluster components. When troubleshooting issues specific to {pipelines-title}, you specify the {pipelines-shortname} `must-gather` image to capture components like the operator subscription, Tekton configurations, task runs, pipeline runs, and pod logs in the operator namespaces.

--- a/modules/op-collecting-pipelines-debugging-data.adoc
+++ b/modules/op-collecting-pipelines-debugging-data.adoc
@@ -1,0 +1,46 @@
+:_mod-docs-content-type: PROCEDURE
+[id="op-collecting-pipelines-debugging-data_{context}"]
+= Collecting OpenShift Pipelines debugging data
+
+You can use the `oc adm must-gather` CLI command to collect detailed diagnostic data and logs for OpenShift Pipelines components on your cluster.
+
+.Prerequisites
+
+* You have access to the cluster as a user with the `cluster-admin` cluster role.
+* You have installed the OpenShift CLI (`oc`).
+
+.Procedure
+. Navigate to the directory where you want to store the debugging information.
+
+. Run the `oc adm must-gather` command with the {pipelines-shortname} `must-gather` image:
++
+[source,terminal]
+----
+$ oc adm must-gather --image=quay.io/openshift-pipeline/must-gather
+----
++
+The `must-gather` tool creates a new directory starting with `./must-gather.local` in your current directory, for example, `./must-gather.local.4157245944708210399`.
+
+. Create a compressed file from the directory created by the `must-gather` tool. For example, on a computer running a Linux operating system, run the following command:
++
+[source,terminal]
+----
+$ tar -cvaf must-gather.tar.gz must-gather.local.<random-hash>
+----
++
+Replace `must-gather.local.<random-hash>` with the actual name of the generated directory.
+
+.Verification
+. Verify that the compressed file exists in your current directory:
++
+[source,terminal]
+----
+$ ls -lh must-gather.tar.gz
+----
++
+*Example output*
++
+[source,terminal]
+----
+-rw-r--r--. 1 user user 2.5M Jun 26 14:30 must-gather.tar.gz
+----


### PR DESCRIPTION
Version(s):
pipelines-docs-1.23 (OpenShift Pipelines 1.23)

Issue:
https://redhat.atlassian.net/browse/RHDEVDOCS-7365

Peer review:
@Dhruv-Soni11 
@ochromy 

SME/QA review:
@smahadik-27 


Link to docs preview:
https://113892--ocpdocs-pr.netlify.app/openshift-pipelines/latest/about/op-proc-gathering-diagnostic-information 

Additional Information:
Fully addressed all structural and modular review comments:
- Refactored monolithic code into a proper Assembly block.
- Extracted standalone content into a Concept module (op-about-must-gather.adoc) and Procedure module (op-collecting-pipelines-debugging-data.adoc).
- Corrected the _topic_map.yml structure and chapter separators.
- Cleared out the local workspace guidelines file (CLAUDE.md).
- Consolidated all fixes into exactly 1 clean commit.


