### PR TITLE
TELCODOCS-2764: Backport DITA compatibility fixes for vDU reference cluster configuration

### DIFF
--- a/edge_computing/ztp-reference-cluster-configuration-for-vdu.adoc
+++ b/edge_computing/ztp-reference-cluster-configuration-for-vdu.adoc
@@ -11,9 +11,9 @@ Use the following reference information to understand the {sno} configurations r
 [role="_additional-resources"]
 .Additional resources
 
-* To deploy a single cluster by hand, see xref:../edge_computing/ztp-manual-install.adoc#ztp-manual-install[Manually installing a {sno} cluster with {ztp}].
+* xref:../edge_computing/ztp-manual-install.adoc#ztp-manual-install[Manually installing a {sno} cluster with {ztp}]
 
-* To deploy a fleet of clusters using {ztp-first}, see xref:../edge_computing/ztp-deploying-far-edge-sites.adoc#ztp-deploying-far-edge-sites[Deploying far edge sites with {ztp}].
+* xref:../edge_computing/ztp-deploying-far-edge-sites.adoc#ztp-deploying-far-edge-sites[Deploying far edge sites with {ztp}]
 
 include::modules/ztp-low-latency.adoc[leveloffset=+1]
 
@@ -37,12 +37,13 @@ include::modules/ztp-sno-du-disk-encryption.adoc[leveloffset=+1]
 
 * xref:../security/network_bound_disk_encryption/nbde-about-disk-encryption-technology.adoc#nbde-tpm-encryption_nbde-implementation[TPM encryption]
 
-* For information about enabling disk encryption, see xref:../edge_computing/ztp-reference-cluster-configuration-for-vdu.adoc#ztp-sno-du-configuring-disk-encryption-with-pcr-protection_sno-configure-for-vdu[Enabling disk encryption with TPM and PCR protection].
+* xref:../edge_computing/ztp-reference-cluster-configuration-for-vdu.adoc#ztp-sno-du-configuring-disk-encryption-with-pcr-protection_sno-configure-for-vdu[Enabling disk encryption with TPM and PCR protection]
 
 [id="ztp-sno-install-time-cluster-config"]
 == Recommended cluster install manifests
 
-The ZTP pipeline applies the following custom resources (CRs) during cluster installation. These configuration CRs ensure that the cluster meets the feature and performance requirements necessary for running a vDU application.
+[role="_additional-resources"]
+.Additional resources
 
 [NOTE]
 ====
@@ -75,7 +76,8 @@ include::modules/ztp-sno-du-configuring-disk-encryption-with-pcr-protection.adoc
 [id="ztp-sno-post-install-time-cluster-config"]
 == Recommended postinstallation cluster configurations
 
-When the cluster installation is complete, the ZTP pipeline applies the following custom resources (CRs) that are required to run DU workloads.
+[role="_additional-resources"]
+.Additional resources
 
 [NOTE]
 ====

--- a/modules/ztp-du-host-firmware-requirements.adoc
+++ b/modules/ztp-du-host-firmware-requirements.adoc
@@ -6,6 +6,7 @@
 [id="ztp-du-configuring-host-firmware-requirements_{context}"]
 = Configuring host firmware for low latency and high performance
 
+[role="_abstract"]
 Bare-metal hosts require the firmware to be configured before the host can be provisioned. The firmware configuration is dependent on the specific hardware and the particular requirements of your installation.
 
 .Procedure
@@ -61,7 +62,7 @@ The exact firmware configuration depends on your specific hardware and network r
 |Processor C6
 |Disabled
 |====
-
++
 [NOTE]
 ====
 Enable global SR-IOV and VT-d settings in the firmware for the host. These settings are relevant to bare-metal environments.

--- a/modules/ztp-enabling-workload-partitioning-sno.adoc
+++ b/modules/ztp-enabling-workload-partitioning-sno.adoc
@@ -6,6 +6,7 @@
 [id="ztp-workload-partitioning-sno_{context}"]
 = Workload partitioning in {sno} with {ztp}
 
+[role="_abstract"]
 Workload partitioning configures {product-title} services, cluster management workloads, and infrastructure pods to run on a reserved number of host CPUs.
 
 To configure workload partitioning with {ztp-first}, you configure a `cpuPartitioningMode` field in the `SiteConfig` custom resource (CR) that you use to install the cluster and you apply a `PerformanceProfile` CR that configures the `isolated` and `reserved` CPUs on the host.

--- a/modules/ztp-low-latency.adoc
+++ b/modules/ztp-low-latency.adoc
@@ -6,6 +6,7 @@
 [id="ztp-low-latency_{context}"]
 = Running low latency applications on {product-title}
 
+[role="_abstract"]
 {product-title} enables low latency processing for applications running on commercial off-the-shelf (COTS) hardware by using several technologies and specialized hardware devices:
 
 Real-time kernel for RHCOS:: Ensures workloads are handled with a high degree of process determinism.

--- a/modules/ztp-managed-cluster-network-prereqs.adoc
+++ b/modules/ztp-managed-cluster-network-prereqs.adoc
@@ -6,6 +6,7 @@
 [id="ztp-managed-cluster-network-prereqs_{context}"]
 = Connectivity prerequisites for managed cluster networks
 
+[role="_abstract"]
 Before you can install and provision a managed cluster with the {ztp-first} pipeline, the managed cluster host must meet the following networking prerequisites:
 
 * There must be bi-directional connectivity between the {ztp} container in the hub cluster and the Baseboard Management Controller (BMC) of the target bare-metal host.

--- a/modules/ztp-sno-du-configuring-crun-container-runtime.adoc
+++ b/modules/ztp-sno-du-configuring-crun-container-runtime.adoc
@@ -6,6 +6,7 @@
 [id="ztp-sno-du-configuring-crun-container-runtime_{context}"]
 = Configuring crun as the default container runtime
 
+[role="_abstract"]
 The following `ContainerRuntimeConfig` custom resources (CRs) configure crun as the default OCI container runtime for control plane and worker nodes.
 The crun container runtime is fast and lightweight and has a low memory footprint.
 

--- a/modules/ztp-sno-du-configuring-logging-locally-and-forwarding.adoc
+++ b/modules/ztp-sno-du-configuring-logging-locally-and-forwarding.adoc
@@ -6,6 +6,7 @@
 [id="ztp-sno-du-configuring-logging-locally-and-forwarding_{context}"]
 = Cluster logging and log forwarding
 
+[role="_abstract"]
 {sno-caps} clusters that run DU workloads require logging and log forwarding for debugging.
 The following custom resources (CRs) are required.
 

--- a/modules/ztp-sno-du-configuring-lvms.adoc
+++ b/modules/ztp-sno-du-configuring-lvms.adoc
@@ -6,6 +6,7 @@
 [id="lvms-configuring-lvms-on-sno_{context}"]
 = {lvms}
 
+[role="_abstract"]
 You can dynamically provision local storage on {sno} clusters with {lvms-first}.
 
 [NOTE]

--- a/modules/ztp-sno-du-configuring-performance-addons.adoc
+++ b/modules/ztp-sno-du-configuring-performance-addons.adoc
@@ -6,6 +6,7 @@
 [id="ztp-sno-du-configuring-performance-addons_{context}"]
 = Performance profile
 
+[role="_abstract"]
 {sno-caps} clusters that run DU workloads require a Node Tuning Operator performance profile to use real-time host capabilities and services.
 
 [NOTE]

--- a/modules/ztp-sno-du-configuring-sriov.adoc
+++ b/modules/ztp-sno-du-configuring-sriov.adoc
@@ -6,6 +6,7 @@
 [id="ztp-sno-du-configuring-sriov_{context}"]
 = SR-IOV
 
+[role="_abstract"]
 Single root I/O virtualization (SR-IOV) is commonly used to enable fronthaul and midhaul networks. The following YAML example configures SR-IOV for a {sno} cluster.
 
 [NOTE]

--- a/modules/ztp-sno-du-configuring-the-container-mountspace.adoc
+++ b/modules/ztp-sno-du-configuring-the-container-mountspace.adoc
@@ -6,6 +6,7 @@
 [id="ztp-sno-du-configuring-the-container-mountspace_{context}"]
 = Reduced platform management footprint
 
+[role="_abstract"]
 To reduce the overall management footprint of the platform, a `MachineConfig` custom resource (CR) is required that places all Kubernetes-specific mount points in a new namespace separate from the host operating system.
 The following base64-encoded example `MachineConfig` CR illustrates this configuration.
 

--- a/modules/ztp-sno-du-configuring-the-operators.adoc
+++ b/modules/ztp-sno-du-configuring-the-operators.adoc
@@ -6,6 +6,7 @@
 [id="ztp-sno-du-configuring-the-operators_{context}"]
 = Operators
 
+[role="_abstract"]
 {sno-caps} clusters that run DU workloads require the following Operators to be installed:
 
 * Local Storage Operator

--- a/modules/ztp-sno-du-configuring-time-sync.adoc
+++ b/modules/ztp-sno-du-configuring-time-sync.adoc
@@ -6,6 +6,7 @@
 [id="ztp-sno-du-configuring-time-sync_{context}"]
 = Configuring cluster time synchronization
 
+[role="_abstract"]
 Run a one-time system time synchronization job for control plane or worker nodes.
 
 .Recommended one time time-sync for control plane nodes (`99-sync-time-once-master.yaml`)

--- a/modules/ztp-sno-du-disabling-crio-wipe.adoc
+++ b/modules/ztp-sno-du-disabling-crio-wipe.adoc
@@ -6,6 +6,7 @@
 [id="ztp-sno-du-disabling-crio-wipe_{context}"]
 = Disable automatic CRI-O cache wipe
 
+[role="_abstract"]
 After an uncontrolled host shutdown or cluster reboot, CRI-O automatically deletes the entire CRI-O cache, causing all images to be pulled from the registry when the node reboots.
 This can result in unacceptably slow recovery times or recovery failures.
 To prevent this from happening in {sno} clusters that you install with {ztp}, disable the CRI-O delete cache feature during cluster installation.

--- a/modules/ztp-sno-du-disabling-network-diagnostics.adoc
+++ b/modules/ztp-sno-du-disabling-network-diagnostics.adoc
@@ -6,6 +6,7 @@
 [id="ztp-sno-du-disabling-network-diagnostics_{context}"]
 = Network diagnostics
 
+[role="_abstract"]
 {sno-caps} clusters that run DU workloads require less inter-pod network connectivity checks to reduce the additional load created by these pods. The following custom resource (CR) disables these checks.
 
 .Recommended network diagnostics configuration (`DisableSnoNetworkDiag.yaml`)

--- a/modules/ztp-sno-du-enabling-kdump.adoc
+++ b/modules/ztp-sno-du-enabling-kdump.adoc
@@ -6,6 +6,7 @@
 [id="ztp-sno-du-enabling-kdump_{context}"]
 = Automatic kernel crash dumps with kdump
 
+[role="_abstract"]
 `kdump` is a Linux kernel feature that creates a kernel crash dump when the kernel crashes. `kdump` is enabled with the following `MachineConfig` CRs.
 
 .Recommended control plane node kdump configuration (`06-kdump-master.yaml`)

--- a/modules/ztp-sno-du-enabling-sctp.adoc
+++ b/modules/ztp-sno-du-enabling-sctp.adoc
@@ -6,6 +6,7 @@
 [id="ztp-sno-du-enabling-sctp_{context}"]
 = SCTP
 
+[role="_abstract"]
 Stream Control Transmission Protocol (SCTP) is a key protocol used in RAN applications. This `MachineConfig` object adds the SCTP kernel module to the node to enable this protocol.
 
 .Recommended control plane node SCTP configuration (`03-sctp-machine-config-master.yaml`)

--- a/modules/ztp-sno-du-reducing-resource-usage-with-cluster-monitoring.adoc
+++ b/modules/ztp-sno-du-reducing-resource-usage-with-cluster-monitoring.adoc
@@ -6,6 +6,7 @@
 [id="ztp-sno-du-reducing-resource-usage-with-cluster-monitoring_{context}"]
 = Alertmanager
 
+[role="_abstract"]
 {sno-caps} clusters that run DU workloads require reduced CPU resources consumed by the {product-title} monitoring components. The following `ConfigMap` custom resource (CR) disables Alertmanager.
 
 .Recommended cluster monitoring configuration (`ReduceMonitoringFootprint.yaml`)

--- a/modules/ztp-sno-du-reducing-resource-usage-with-olm-pprof.adoc
+++ b/modules/ztp-sno-du-reducing-resource-usage-with-olm-pprof.adoc
@@ -6,6 +6,7 @@
 [id="ztp-sno-du-reducing-resource-usage-with-olm-pprof_{context}"]
 = Operator Lifecycle Manager
 
+[role="_abstract"]
 {sno-caps} clusters that run distributed unit workloads require consistent access to CPU resources. Operator Lifecycle Manager (OLM) collects performance data from Operators at regular intervals, resulting in an increase in CPU utilisation. The following `ConfigMap` custom resource (CR) disables the collection of Operator performance data by OLM.
 
 .Recommended cluster OLM configuration (`ReduceOLMFootprint.yaml`)

--- a/modules/ztp-sno-du-removing-the-console-operator.adoc
+++ b/modules/ztp-sno-du-removing-the-console-operator.adoc
@@ -6,6 +6,7 @@
 [id="ztp-sno-du-removing-the-console-operator_{context}"]
 = Console Operator
 
+[role="_abstract"]
 Use the cluster capabilities feature to prevent the Console Operator from being installed.
 When the node is centrally managed it is not needed.
 Removing the Operator provides additional space and capacity for application workloads.

--- a/modules/ztp-sno-du-setting-rcu-normal.adoc
+++ b/modules/ztp-sno-du-setting-rcu-normal.adoc
@@ -6,6 +6,7 @@
 [id="ztp-setting-rcu-normal_{context}"]
 = Setting rcu_normal
 
+[role="_abstract"]
 The following `MachineConfig` CR configures the system to set `rcu_normal` to 1 after the system has finished startup. This improves kernel latency for vDU applications.
 
 .Recommended configuration for disabling `rcu_expedited` after the node has finished startup (`08-set-rcu-normal-master.yaml`)

--- a/modules/ztp-sno-du-subscribing-to-the-operators-needed-for-platform-configuration.adoc
+++ b/modules/ztp-sno-du-subscribing-to-the-operators-needed-for-platform-configuration.adoc
@@ -6,6 +6,7 @@
 [id="ztp-sno-du-subscribing-to-the-operators-needed-for-platform-configuration_{context}"]
 = Operator subscriptions
 
+[role="_abstract"]
 {sno-caps} clusters that run DU workloads require the following `Subscription` CRs. The subscription provides the location to download the following Operators:
 
 * Local Storage Operator

--- a/modules/ztp-sno-du-tuning-the-performance-patch.adoc
+++ b/modules/ztp-sno-du-tuning-the-performance-patch.adoc
@@ -6,6 +6,7 @@
 [id="ztp-sno-du-tuning-the-performance-patch_{context}"]
 = Extended Tuned profile
 
+[role="_abstract"]
 {sno-caps} clusters that run DU workloads require additional performance tuning configurations necessary for high-performance workloads. The following example `Tuned` CR extends the `Tuned` profile:
 
 .Recommended extended `Tuned` profile configuration (`TunedPerformancePatch.yaml`)


### PR DESCRIPTION
Backport of #106778 to enterprise-4.20.

Fix AsciiDocDITA Vale errors and warnings across the assembly and its included modules: add [role="_abstract"] short descriptions, add missing content-type attributes, fix trailing NOTE attachment to last procedure step.

**Excluded from this backport (2 files — new modules not applicable to 4.20):**
- `modules/ztp-sno-du-recommended-cluster-install-manifests.adoc`
- `modules/ztp-sno-du-recommended-postinstallation-cluster-configurations.adoc`

**Conflict resolutions:**
- Kept 4.20 inline section headings and content (SiteConfig references) instead of the new module includes (ClusterInstance references)
- Applied editorial xref-only related-links fixes where applicable

Version(s): 4.20

Issue: [TELCODOCS-2764](https://redhat.atlassian.net/browse/TELCODOCS-2764)

QE review:
- [ ] QE has approved this change.