### PR TITLE
OSDOCS-20310 updated API documentation

### DIFF
--- a/modules/eso-cert-manager-config.adoc
+++ b/modules/eso-cert-manager-config.adoc
@@ -20,10 +20,8 @@ You can integrate the {external-secrets-operator} with cert-manager to secure in
 | `mode`
 | _string_
 | `mode` specifies whether to use cert-manager for certificate management instead of the built-in `cert-controller` which can be indicated by setting either `Enabled` or `Disabled`. If set to `Enabled`, uses `cert-manager` for obtaining the certificates for the webhook server and other components. If set to `Disabled`, uses the `cert-controller` for obtaining the certificates for the webhook server. `Disabled` is the default behavior.
-| false
-| enum: [true false]
-
-Required
+| 
+| enum: [Enabled Disabled]
 
 | `injectAnnotations`
 | _string_
@@ -31,23 +29,21 @@ Required
 | false
 | enum: [true false]
 
-Optional
-
 | `issuerRef`
 | _ObjectReference_
 | `issuerRef` contains details of the referenced object used for obtaining certificates. The object must exist in the `external-secrets` namespace unless a cluster-scoped `cert-manager` Operator issuer is used.
 |
-| Required
+| 
 
 | `certificateDuration`
 | link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#duration-v1-meta[_Duration_]
 | `certificateDuration` sets the validity period of the webhook certificate.
 | 8760h
-| Optional
+| 
 
 | `certificateRenewBefore`
 | link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#duration-v1-meta[_Duration_]
 | `certificateRenewBefore` sets the ahead time to renew the webhook certificate before expiry.
 | 30m
-| Optional
+| 
 |===

--- a/modules/eso-cert-providers-config.adoc
+++ b/modules/eso-cert-providers-config.adoc
@@ -21,5 +21,5 @@ The `certProvidersConfig` defines the configuration for the certificate provider
 | _object_
 | `certManager` defines the configuration for `cert-manager` provider specifics.
 |
-| Optional
+| 
 |===

--- a/modules/eso-common-configs.adoc
+++ b/modules/eso-common-configs.adoc
@@ -1,0 +1,62 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-operator-api.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="eso-common-config_{context}"]
+= commonConfigs
+
+[role="_abstract"]
+The `commonConfigs` specifies the common configurations available for all operands managed by the Operator.
+
+[cols="1,1,1,1,1",options="header"]
+|===
+| Field
+| Type
+| Description
+| Default
+| Validation
+
+| `logLevel`
+| _integer_
+| `logLevel` supports the value range as defined in the link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#time-v1-meta[_Time_].
+| 1
+a| The maximum number of log levels is 5.
+
+The minimum number of log levels is 1.
+
+| `resources`
+| link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#resourcerequirements-v1-core[_ResourceRequirements_].
+| `resources` defines the resource requirements. This cannot be updated. See link:https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/[Resource Management for Pods and Containers].
+|
+| 
+
+| `affinity`
+| link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#affinity-v1-core[_affinity_].
+| `affinity` is used for setting scheduling affinity rules. See See link:https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/[Assigning Pods to Nodes].
+|
+| 
+
+| `tolerations`
+| link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#toleration-v1-core[_toleration array_]
+| `tolerations` sets the pod tolerations.
+|
+a| The maximum number of items is 50.
+
+The minimum number of items is 0.
+
+| `nodeSelector`
+| _object (keys:string, values:string)_
+| `nodeSelector` defines the scheduling criteria using node labels.
+|
+a| The maximum number of properties is 50.
+
+The minimum number of properties is 0.
+
+| `proxy`
+| _proxyConfig_
+| `proxy` sets the proxy configurations which are made avaiable in operand containers managed by the Operator as environment variables.
+|
+| 
+
+|===

--- a/modules/eso-component-config.adoc
+++ b/modules/eso-component-config.adoc
@@ -29,7 +29,7 @@ Required
 | _object_
 | `deploymentConfigs` specifies overrides for the Kubernetes Deployment resource of this component.
 |
-|Optional
+|
 
 | `overrideEnv`
 a| *EnvVar*
@@ -37,7 +37,6 @@ a| *EnvVar*
 _array_
 | `overrideEnv` specifies custom environment variables for this component's container. These are merged with operator-managed environment variables, with user-defined values taking precedence. Environment variable names starting with `HOSTNAME`, `KUBERNETES_` or `EXTERNAL_SECRETS_` are reserved and are not allowed.
 |
-a| The maximum number of items is 50.
+| The maximum number of items is 50.
 
-Optional
 |===

--- a/modules/eso-component-name.adoc
+++ b/modules/eso-component-name.adoc
@@ -1,0 +1,34 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-operator-api.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="eso-comoponent-name_{context}"]
+= componentName
+
+[role="_abstract"]
+The `componentName` field represents the different external-secrets components that can have network policies applied.
+
+[cols="1,1,1",options="header"]
+|===
+| Field
+| Type
+| Description
+
+| `ExternalSecretsCoreController`
+| _object_
+| `ExternalSecretsCoreController` represents the `external-secret` component.
+
+| `BitwardenSDKServer`
+| _object_
+| `BitwardenSDKServer` represents the `bitwarden-sdk-server` component.
+
+| `Webhook`
+| _object_
+| `Webhook` represents the `external-secrets` webhook component.
+
+| `CertController`
+| _object_
+| `CertController` represents the `cert-controller` component.
+
+|===

--- a/modules/eso-condition.adoc
+++ b/modules/eso-condition.adoc
@@ -9,29 +9,22 @@
 [role="_abstract"]
 The `condition` object reports the current health and operational state of the {external-secrets-operator} deployment. It provides a standardized status check by detailing the specific type of condition, its current status, and a message to verify deployment success or troubleshooting errors.
 
-[cols="1,1,1,1,1",options="header"]
+[cols="1,1,1",options="header"]
 |===
 | Field
 | Type
 | Description
-| Default
-| Validation
 
 | `type`
 | _string_
 | `type` contains the condition of the deployment.
-|
-| Required
 
 | `status`
 | link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#conditionstatus-v1-meta[_ConditionStatus_]
 | `status` contains the status of the condition of the deployment
-|
-|
 
 | `message`
 | _string_
 | `message` provides details on the state of the deployment
-|
-|
+
 |===

--- a/modules/eso-conditional-status.adoc
+++ b/modules/eso-conditional-status.adoc
@@ -9,17 +9,13 @@
 [role="_abstract"]
 The `conditionalStatus` field holds information about the current state of the `external-secrets` deployment.
 
-[cols="1,1,1,1,1",options="header"]
+[cols="1,1,1",options="header"]
 |===
 | Field
 | Type
 | Description
-| Default
-| Validation
 
 | `conditions`
 | _array_
 | `conditions` contains information on the current state of the deployment.
-|
-|
 |===

--- a/modules/eso-configmap-key-reference.adoc
+++ b/modules/eso-configmap-key-reference.adoc
@@ -1,0 +1,38 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-operator-api.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="eso-configmap-key-reference_{context}"]
+= configMapKeyReference
+
+[role="_abstract"]
+The `configMapKeyReference` specifies a specific key in a ConfigMap.
+
+[cols="1,1,1,1,1",options="header"]
+|===
+| Field
+| Type
+| Description
+| Default
+| Validation
+
+| `name`
+|  _string_
+| `name` specifies the name of the ConfigMap resource being referred to.
+|
+a| The maximum length of the name is 253 characters.
+
+The minimum length of the name is 1 character.
+
+| `key`
+| _string_
+| `key` specifies the specific key to be used in the ConfigMap. When ommitted, defaults to `ca-bundle.crt`.
+| `ca-bundle.crt`
+a| The maximum length of the key is 253 characters.
+
+The minimum length of the key is 1 character.
+
+The pattern is: `^[-._a-zA-Z0-9]+$`
+
+|===

--- a/modules/eso-controller-config.adoc
+++ b/modules/eso-controller-config.adoc
@@ -21,7 +21,7 @@ The `controllerConfig` specifies the configurations used by the controller when 
 | _string_
 | `certProvider` defines the configuration for the certificate providers used to manage TLS certificates for webhook and plugins.
 |
-| Optional
+| 
 
 | `labels`
 | _object (keys:string, values:string)_
@@ -31,25 +31,39 @@ a| The maximum number of properties is 20.
 
 The minimum number of properties is 0.
 
-Optional
-
 | `annotations`
 | _object (keys:string, values:string)_
 | `annotations` add custom annotations to all the resources created for the `external-secrets` deployment. The annotations are merged with any default annotations set by the Operator. User-specified annotations take precedence over defaults in case of conflicts. Annotation keys containing the reserved domains `kubernetes.io/`, `openshift.io/`, `k8s.io/`, or `cert-manager.io/` (including subdomains like `*.kubernetes.io/`) are not allowed.
 |
-a| The maximum number of properties is 20.
+a| The maximum number of annotations is 20.
 
-The minimum number of properties is 0.
+The minimum number of annotations is 0.
 
-Optional
-
-| `componentConfigs`
-| _ComponentConfig array_
-| `componentConfigs` allows specifying deployment-level configuration overrides for individual `external-secrets` components. Each component can have only one configuration entry.
-a| The maximum number of items is 4.
+| `networkPolicies`
+| _networkPolicy array_
+| `networkPolicies` specifies the list of network policy configurations to be applied to the `external-secrets` pods. Each entry allows specifying a name for the generated `NetworkPolicy` object, along with its full Kubernetes `NetworkPolicy` definition. The Operator prepends `eso-user-` to the provided name when creating the Kubernetes object. If this field is not provided, `external-secrets` components are isolated with `deny-all` network policies, which prevents proper operation.
+|
+a| The maximum number of items is 50.
 
 The minimum number of items is 0.
 
-Optional
+| `componentConfigs`
+| _ComponentConfig array_
+| `componentConfigs` allows specifying deployment-level configuration overrides for individual `external-secrets` components. This field enables fine-grained control over deployment settings for each component independently.
+Each component can have only one configuration entry.
+|
+| The maximum number of items is 4.
+
+The minimum number of items is 0.
+
+| `trustedCABundle`
+
+*ConfigMapKeyReference*
+| _object_
+a| `trustedCABundle` references a ConfigMap containing PEM-encoded CA certificates for the `external-secrets` core controller to trust when making outbound TLS connections. If specified, this bundle is used for all outbound TLS traffic, including connections to external secret management systems and configured proxies.
+
+The ConfigMap must exist in the `external-secrets` Operand namespace and must not carry the CNO inject-trusted-cabundle label when proxy is configured. When omitted, external providers use standard system certificates. When proxy is configured, proxy TLS connections use the operator-managed {product-title} trusted CA bundle injected by the Cluster Network Operator.
+| 
+|
 
 |===

--- a/modules/eso-controller-status.adoc
+++ b/modules/eso-controller-status.adoc
@@ -21,7 +21,7 @@ The `controllerStatus` field tracks the health and synchronization state of the 
 | _string_
 | `name` specifies the name of the controller for which the observed condition is recorded.
 |
-| Required
+| 
 
 | `conditions`
 | _array_

--- a/modules/eso-deployment-config.adoc
+++ b/modules/eso-deployment-config.adoc
@@ -21,9 +21,8 @@ The `deploymentConfig` field defines configuration overrides for a Kubernetes De
 | _integer_
 | `revisionHistoryLimit` specifies the number of old `ReplicaSets` to retain for rollback purposes. This allows rolling back to previous deployment versions using the command `oc rollout undo`. Must be at least 1 to ensure rollback capability.
 | 10
-a| The minimum value is 1.
+a| The maximum value is 50.
 
-The maximum value is 50.
+The minimum value is 1.
 
-Optional
 |===

--- a/modules/eso-external-secrets-list.adoc
+++ b/modules/eso-external-secrets-list.adoc
@@ -9,35 +9,26 @@
 [role="_abstract"]
 The `externalSecretsConfigList` object fetches the list of `externalSecretsConfig` objects.
 
-[cols="1,1,1,1,1",options="header"]
+[cols="1,1,1",options="header"]
 |===
 | Field
 | Type
 | Description
-| Default
-| Validation
 
 | `apiVersion`
 | _string_
 | The `apiVersion` specifies the version of the schema in use, which is `operator.openshift.io/v1alpha1`
-|
-|
 
 | `kind`
 | _string_
 | `kind` specifies the type of the object, which is `externalSecretsList` for this API.
-|
-|
 
 | `metadata`
 | link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#listmeta-v1-meta[_ListMeta_]
 | Refer to Kubernetes API documentation for details about the `metadata` fields.
-|
-|
 
 | `items`
 | _array_
 | `Items` contains a list of `externalSecrets` objects.
-|
-|
+
 |===

--- a/modules/eso-external-secrets-manager.adoc
+++ b/modules/eso-external-secrets-manager.adoc
@@ -9,41 +9,30 @@
 [role="_abstract"]
 The `externalSecretsManager` object defines the configuration and information of deployments managed by the {external-secrets-operator-short}. Set the name to `cluster` as this allows only one instance of `externalSecretsManager` per cluster. You can configure global options by using `externalSecretsManager`. This serves as a centralized configuration for managing multiple controllers of the Operator. The Operator automatically creates the `externalSecretsManager` object during installation.
 
-[cols="1,1,1,1,1",options="header"]
+[cols="1,1,1",options="header"]
 |===
 | Field
 | Type
 | Description
-| Default
-| Validation
 
 | `apiVersion`
 | _string_
 | The `apiVersion` specifies the version of the schema in use, which is `operator.openshift.io/v1alpha1`.
-|
-|
 
 | `kind`
 | _string_
 | `kind` specifies the type of the object, which is `externalSecretsManager` for this Object.
-|
-|
 
 | `metadata`
 | link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#objectmeta-v1-meta[_ObjectMeta_]
 | Refer to Kubernetes API documentation for details about the `metadata` fields.
-|
-|
 
 | `spec`
 | _object_
 | `spec` contains specifications of the desired behavior.
-|
-|
 
 | `status`
 | _object_
 | `status` displays the most recently observed state of the controllers in the {external-secrets-operator-short}.
-|
-|
+
 |===

--- a/modules/eso-external-secrets-spec.adoc
+++ b/modules/eso-external-secrets-spec.adoc
@@ -9,29 +9,24 @@
 [role="_abstract"]
 The `externalSecretsConfigSpec` field defines the desired behavior of the `externalSecrets` object.
 
-[cols="1,1,1,1,1",options="header"]
+[cols="1,1,1",options="header"]
 |===
 | Field
 | Type
 | Description
-| Default
-| Validation
 
 | `appConfig`
 | _object_
 | `appConfig` configures the behavior of the `external-secrets` operand.
-|
-| Optional
+
 
 | `plugins`
 | _object_
 | `plugins` configures the optional provider plugins.
-|
-| Optional
+
 
 | `controllerConfig`
 | _object_
 | `controllerConfig` configures the controller to set up defaults that enable `external-secrets` operand.
-|
-| Optional
+
 |===

--- a/modules/eso-external-secrets-status.adoc
+++ b/modules/eso-external-secrets-status.adoc
@@ -9,29 +9,22 @@
 [role="_abstract"]
 The `externalSecretsConfigStatus` field shows the most recently observed status of the `externalSecretsConfig` Object.
 
-[cols="1,1,1,1,1",options="header"]
+[cols="1,1,1",options="header"]
 |===
 | Field
 | Type
 | Description
-| Default
-| Validation
 
 | `conditions`
 | link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#condition-v1-meta[_Condition_] _array_
 | `conditions` contains information about the current state of deployment.
-|
-|
 
 | `externalSecretsImage`
 | _string_
 | `externalSecretsImage` specifies the image name and tag used for deploy `external-secrets` operand.
-|
-|
 
 | `bitwardenSDKServerImage`
 | _string_
 | `bitwardenSDKServerImage` specifies the name of the image and tag used for deploying the `bitwarden-sdk-server`.
-|
-|
+
 |===

--- a/modules/eso-external-secrets.adoc
+++ b/modules/eso-external-secrets.adoc
@@ -11,42 +11,30 @@ The `externalSecretsConfig` object defines the configuration and information for
 
 Creating an `externalSecretsConfig` object triggers the deployment of the `external-secrets` operand and maintains the desired state.
 
-[cols="1,1,1,1,1",options="header"]
+[cols="1,1,1",options="header"]
 |===
 | Field
 | Type
 | Description
-| Default
-| Validation
 
 | `apiVersion`
 | _string_
 | The `apiVersion` specifies the version of the schema in use, which is `operator.openshift.io/v1alpha1`.
-|
-|
 
 | `kind`
 | _string_
 | `kind` specifies the type of the object, which is `externalSecrets` for this object.
-|
-|
 
 | `metadata`
 | link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#objectmeta-v1-meta[_ObjectMeta_]
 | Refer to Kubernetes API documentation for details about the `metadata` fields.
-|
-|
 
 | `spec`
 | _object_
 | `spec` contains the specifications of the desired behavior of the `externalSecrets` object.
-|
-|
 
 | `status`
 | _object_
 | `status` displays the most recently observed status of the `externalSecrets` object.
-|
-|
 
 |===

--- a/modules/eso-feature-name.adoc
+++ b/modules/eso-feature-name.adoc
@@ -1,0 +1,22 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-operator-api.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="eso-feature-name_{context}"]
+= featureName
+
+[role="_abstract"]
+The `featureName` field identifies an optional feature that can be configured on the `ExternalSecretsManager` and applied by the `external-secrets-operator`.
+
+[cols="1,1,1",options="header"]
+|===
+| Field
+| Type
+| Description
+
+| `UnsafeAllowGenericTargets`
+|_object_
+| `UnsafeAllowGenericTargets` configures the `external-secrets` core controller to run with the `--unsafe-allow-generic-targets` startup flag, which allows `ExternalSecret` resources to sync data into Kubernetes resources other than `Secrets`.
+
+|===

--- a/modules/eso-feature.adoc
+++ b/modules/eso-feature.adoc
@@ -1,0 +1,41 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-operator-api.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="eso-feature_{context}"]
+= Feature
+
+[role="_abstract"]
+The `Feature` field configures an optional capability that is applied by the `external-secrets-operator` across its managed deployments.
+
+[cols="1,1,1,1,1",options="header"]
+|===
+| Field
+| Type
+| Description
+| Default
+| Validation
+
+| `name`
+a|*FeatureName*
+
+_string_
+| `name` identifies the optional feature to configure. Currently, the only supported value is `UnsafeAllowGenericTargets`.
+|
+| Enum: [`UnsafeAllowGenericTargets`]
+
+| `mode`
+a| *mode*
+
+_string_
+a| `mode` mode controls whether the feature is active. When set to `Enabled`, the Operator applies the configuration associated with the named feature to the relevant managed deployments. For `UnsafeAllowGenericTargets`, this passes the `--unsafe-allow-generic-targets` flag to the `external-secrets` core controller, allowing `ExternalSecret` resources to target Kubernetes resources other than `Secrets`. For example, ConfigMaps or custom resources.
+
+[WARNING]
+====
+Generic targets require additional RBAC permissions on the affected operand; enabling this feature without the appropriate permissions will cause reconciliation failures.
+====
+| Disabled
+| Enum:[`Enabled` `Disabled`]
+
+|===

--- a/modules/eso-global-config.adoc
+++ b/modules/eso-global-config.adoc
@@ -17,16 +17,6 @@ The `globalConfig` field defines the baseline behavior and deployment parameters
 | Default
 | Validation
 
-| `labels`
-| _integer_
-| `labels` applies to all resources created by the Operator. This field can have a maximum of 20 entries
-| 1
-| The maximum number of properties is 20
-
-The minimum number of properties is 0
-
-Optional
-
 | `logLevel`
 | _integer_
 | `logLevel` supports a range of values as defined in the link:https://github.com/kubernetes/community/blob/master/contributors/devel/sig-instrumentation/logging.md#what-method-to-use[kubernetes logging guidelines].
@@ -35,19 +25,17 @@ Optional
 
 The minimum range value is 1
 
-Optional
-
 | `resources`
 | link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#resourcerequirements-v1-core[_ResourceRequirements_]
 | `resources` defines the resource requirements. You cannot change the value of this field after setting it initially. For more information, see link:https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/[]
 |
-| Optional
+| 
 
 | `affinity`
 | link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#affinity-v1-core[_Affinity_]
 | `affinity` sets the scheduling affinity rules. For more information, see link:https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/[]
 |
-| Optional
+| 
 
 | `tolerations`
 | link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#toleration-v1-core[_Toleration_] _array_
@@ -57,8 +45,6 @@ Optional
 
 The minimum number of items is 0
 
-Optional
-
 | `nodeSelector`
 | _object (keys:string, values:string)_
 | `nodeSelector` defines the scheduling criteria by using the node labels. For more information, see link:https://kubernetes.io/docs/concepts/configuration/assign-pod-node/[]
@@ -67,11 +53,18 @@ Optional
 
 The minimum number of properties is 0
 
-Optional
-
 | `proxy`
 | _object_
 | `proxy` sets the proxy configurations available in the operand containers managed by the Operator as environment variables.
 |
-| Optional
+| 
+
+| `labels`
+| _object (keys:string, values:string)_
+| `labels` applies to all resources created by the Operator. This field can have a maximum of 20 entries
+| 
+| The maximum number of properties is 20
+
+The minimum number of properties is 0
+
 |===

--- a/modules/eso-management-state.adoc
+++ b/modules/eso-management-state.adoc
@@ -1,0 +1,26 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-operator-api.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="eso-management-state_{context}"]
+= managementState
+
+[role="_abstract"]
+The `managementState` field controls whether the Operator manages the resource lifecycle.
+
+[cols="1,1,1",options="header"]
+|===
+| Field
+| Type
+| Description
+
+| `Managed`
+|_string_
+| `ManagementStateManaged` indicates the Operator is responsible for the resource lifecycle.
+
+| `Unmanaged`
+|_string_
+| `ManagementStateUnmanaged` indicates the user is responsible for the resource lifecycle.
+
+|===

--- a/modules/eso-mode.adoc
+++ b/modules/eso-mode.adoc
@@ -9,23 +9,17 @@
 [role="_abstract"]
 The `mode` field indicates the operational state of the optional features.
 
-[cols="1,1,1,1,1",options="header"]
+[cols="1,1,1",options="header"]
 |===
 | Field
 | Type
 | Description
-| Default
-| Validation
 
 | `Enabled`
-|
+| _string_
 | `Enabled` indicates the optional configuration is enabled.
-|
-|
 
 | `Disabled`
-|
+| _string_
 | `Disabled` indicates the optional configuration is disabled.
-|
-|
 |===

--- a/modules/eso-network-policy.adoc
+++ b/modules/eso-network-policy.adoc
@@ -1,0 +1,41 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-operator-api.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="eso-network-policy_{context}"]
+= networkPolicy
+
+[role="_abstract"]
+The `networkPolicy` field represents a custom network policy configuration for operator-managed components. The field includes a name for identification and the network policy rules to be enforced.
+
+[cols="1,1,1,1,1",options="header"]
+|===
+| Field
+| Type
+| Description
+| Default
+| Validation
+
+| `name`
+| _string_
+| `name` is the logical identifier for this network policy entry. The Operator prepends `eso-user-` to this value when creating the Kubernetes `NetworkPolicy` object, for example `allow-egress` becomes `eso-user-allow-egress`. The maximum length is 243 to accommodate the prefix within the 253-character Kubernetes name limit.
+|
+a| The maximum length is 243 characters.
+
+The minimum length is 1. character.
+
+| `componentName`
+| _string_
+| `componentName` specifies which external-secrets component this network policy applies to.
+|
+| Enum:[`ExternalSecretsCoreController` `BitwardenSDIServer`]
+
+| `egress`
+  *NetworkPolicyegressRule*
+|_array_
+| `egress` is a list of egress rules to be applied to the selected pods. Outgoing traffic is allowed if there are no `NetworkPolicies` selecting the pod, and cluster policy otherwise allows the traffic, or if the traffic matches at least one egress rule across all the `NetworkPolicy` objects whose `podSelector` matches the pod. If this field is empty, then this `NetworkPolicy` limits all outgoing traffic and serves solely to ensure that the pods it selects are isolated by default. The Operator automatically handles ingress rules based on the current running ports.
+|
+| 
+
+|===

--- a/modules/eso-proxy-config.adoc
+++ b/modules/eso-proxy-config.adoc
@@ -25,8 +25,6 @@ The `proxyConfig` object defines the network proxy settings that the Operator in
 
 The minimum length is 0 characters.
 
-Optional
-
 | `httpsProxy`
 | _string_
 | The `httpsProxy` field contains the URL of the proxy for HTTPS requests. This field can have a maximum of 2048 characters.
@@ -34,8 +32,6 @@ Optional
 | The maximum length is 2048 characters.
 
 The minimum length is 0 characters.
-
-Optional
 
 | `noProxy`
 | _string_
@@ -45,5 +41,12 @@ Optional
 
 The minimum length is 0 characters.
 
-Optional
+| `networkPolicyProvisioning`
+
+*ManagementState*
+| _string_
+| The `networkPolicyProvisioning` field defines the management strategy for the proxy egress rule. When set to `Managed`, the Operator automatically provisions and maintains a `NetworkPolicy` allowing traffic to the configured proxy. If no proxy is configured, a `NetworkPolicy` is not created regardless of this setting.
+| Managed
+| Enum:[`Managed` `Unmanaged`]
+
 |===

--- a/modules/eso-secret-reference.adoc
+++ b/modules/eso-secret-reference.adoc
@@ -25,5 +25,4 @@ The `secretReference` field refers to a secret with the given name in the same n
 
 The minimum length is 1.
 
-Required
 |===

--- a/security/external_secrets_operator/external-secrets-operator-api.adoc
+++ b/security/external_secrets_operator/external-secrets-operator-api.adoc
@@ -32,47 +32,11 @@ The following list contains the {external-secrets-operator} APIs:
 * ExternalSecretsConfig
 * ExternalSecretsManager
 
-//ExternalSecretsManagerList
-include::modules/eso-external-secrets-manager-list.adoc[leveloffset=+1]
-
-//ExternalSecretsManager
-include::modules/eso-external-secrets-manager.adoc[leveloffset=+1]
-
-//ExternalSecretsConfigList
-include::modules/eso-external-secrets-list.adoc[leveloffset=+1]
-
-//ExternalSecretsConfig
-include::modules/eso-external-secrets.adoc[leveloffset=+1]
-
-//ExternalSecretsManagerSpec
-include::modules/eso-external-secrets-manager-spec.adoc[leveloffset=+1]
-
-//externalSecretsManagerStatus
-include::modules/eso-external-secrets-manager-status.adoc[leveloffset=+1]
-
-//ExternalSecretsConfigSpec
-include::modules/eso-external-secrets-spec.adoc[leveloffset=+1]
-
-//externalSecretsConfigStatus
-include::modules/eso-external-secrets-status.adoc[leveloffset=+1]
-
-//GlobalConfig
-include::modules/eso-global-config.adoc[leveloffset=+1]
-
-//ControllerConfig
-include::modules/eso-controller-config.adoc[leveloffset=+1]
-
-//controllerStatus
-include::modules/eso-controller-status.adoc[leveloffset=+1]
-
 //ApplicationConfig
 include::modules/eso-external-secrets-config.adoc[leveloffset=+1]
 
 //bitwardenSecretManagerProvider
 include::modules/eso-bitwarden-secret.adoc[leveloffset=+1]
-
-//WebhookConfig
-include::modules/eso-web-hook-config.adoc[leveloffset=+1]
 
 //CertManagerConfig
 include::modules/eso-cert-manager-config.adoc[leveloffset=+1]
@@ -80,11 +44,14 @@ include::modules/eso-cert-manager-config.adoc[leveloffset=+1]
 //CertProvidersConfig
 include::modules/eso-cert-providers-config.adoc[leveloffset=+1]
 
-//ObjectReference
-include::modules/eso-object-reference.adoc[leveloffset=+1]
+//CommonConfigs
+include::modules/eso-common-configs.adoc[leveloffset=+1]
 
-//secretReference
-include::modules/eso-secret-reference.adoc[leveloffset=+1]
+//componentConfig
+include::modules/eso-component-config.adoc[leveloffset=+1]
+
+//componentName
+include::modules/eso-component-name.adoc[leveloffset=+1]
 
 //condition
 include::modules/eso-condition.adoc[leveloffset=+1]
@@ -92,8 +59,62 @@ include::modules/eso-condition.adoc[leveloffset=+1]
 //conditionalStatus
 include::modules/eso-conditional-status.adoc[leveloffset=+1]
 
+//configMapKeyReference
+include::modules/eso-configmap-key-reference.adoc[leveloffset=+1]
+
+//ControllerConfig
+include::modules/eso-controller-config.adoc[leveloffset=+1]
+
+//controllerStatus
+include::modules/eso-controller-status.adoc[leveloffset=+1]
+
+//deploymentConfig
+include::modules/eso-deployment-config.adoc[leveloffset=+1]
+
+//ExternalSecretsConfig
+include::modules/eso-external-secrets.adoc[leveloffset=+1]
+
+//ExternalSecretsConfigList
+include::modules/eso-external-secrets-list.adoc[leveloffset=+1]
+
+//ExternalSecretsConfigSpec
+include::modules/eso-external-secrets-spec.adoc[leveloffset=+1]
+
+//externalSecretsConfigStatus
+include::modules/eso-external-secrets-status.adoc[leveloffset=+1]
+
+//ExternalSecretsManager
+include::modules/eso-external-secrets-manager.adoc[leveloffset=+1]
+
+//ExternalSecretsManagerList
+include::modules/eso-external-secrets-manager-list.adoc[leveloffset=+1]
+
+//ExternalSecretsManagerSpec
+include::modules/eso-external-secrets-manager-spec.adoc[leveloffset=+1]
+
+//externalSecretsManagerStatus
+include::modules/eso-external-secrets-manager-status.adoc[leveloffset=+1]
+
+//feature
+include::modules/eso-feature.adoc[leveloffset=+1]
+
+//featureName
+include::modules/eso-feature-name.adoc[leveloffset=+1]
+
+//GlobalConfig
+include::modules/eso-global-config.adoc[leveloffset=+1]
+
+//managedState
+include::modules/eso-management-state.adoc[leveloffset=+1]
+
 //mode
 include::modules/eso-mode.adoc[leveloffset=+1]
+
+//networkPolicy
+include::modules/eso-network-policy.adoc[leveloffset=+1]
+
+//ObjectReference
+include::modules/eso-object-reference.adoc[leveloffset=+1]
 
 //pluginsConfig
 include::modules/eso-plugins-config.adoc[leveloffset=+1]
@@ -101,9 +122,19 @@ include::modules/eso-plugins-config.adoc[leveloffset=+1]
 //ProxyConfig
 include::modules/eso-proxy-config.adoc[leveloffset=+1]
 
-//componentConfig
-include::modules/eso-component-config.adoc[leveloffset=+1]
+//secretReference
+include::modules/eso-secret-reference.adoc[leveloffset=+1]
 
-//deploymentConfig
-include::modules/eso-deployment-config.adoc[leveloffset=+1]
+//WebhookConfig
+include::modules/eso-web-hook-config.adoc[leveloffset=+1]
+
+
+
+
+
+
+
+
+
+
 


### PR DESCRIPTION
Version(s):
4.19+

Issue:
https://redhat.atlassian.net/browse/OSDOCS-20310

Link to docs preview:
https://113909--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/external_secrets_operator/external-secrets-operator-api.html


QE review:
- [ ] QE has approved this change.


Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
