### PR TITLE
OSDOCS-20311: Add 4.20.26 z-stream release notes

### DIFF
--- a/modules/zstream-4-20-26.adoc
+++ b/modules/zstream-4-20-26.adoc
@@ -1,0 +1,33 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-20-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-20-26_{context}"]
+= RHSA-2026:27063 - {product-title} {product-version}.26 fixed issues and security update
+
+Issued: 23 June 2026
+
+[role="_abstract"]
+{product-title} release {product-version}.26 is now available. The list of fixed issues that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2026:27063[RHSA-2026:27063] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2026:27059[RHBA-2026:27059] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.20.26 --pullspecs
+----
+
+[id="zstream-4-20-26-fixed-issues_{context}"]
+== Fixed issues
+
+* Before this update, when a user applied a `MachineConfig` to install extensions, the Machine Config Operator (MCO) did not validate that all packages were installed. This would lead to situations where users believed their extension installation was successful, but packages were actually missing. With this release, the MCO validates post node reboot that all packages associated with the user's desired extension were successfully installed before reporting a successful update. If one or more packages are not present, the node, and subsequently the associated `MachineConfigPool`, will degrade. (link:https://issues.redhat.com/browse/OCPBUGS-86864[OCPBUGS-86864])
+
+* Before this update, the router liveness probe used an HTTP backend check to monitor HAProxy health. As a consequence, when HAProxy reached its `maxconn` connection limit due to client traffic, the HTTP health check failed and Kubernetes unnecessarily restarted the router pods. With this release, the router liveness probe uses an HAProxy admin socket check instead of an HTTP backend check. As a result, router pods remain stable when HAProxy reaches its `maxconn` connection limit due to legitimate client traffic, preventing unnecessary restarts. (link:https://issues.redhat.com/browse/OCPBUGS-87220[OCPBUGS-87220])
+
+[id="zstream-4-20-26-updating_{context}"]
+== Updating
+
+To update an {product-title} 4.20 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].

--- a/release_notes/ocp-4-20-release-notes.adoc
+++ b/release_notes/ocp-4-20-release-notes.adoc
@@ -3021,6 +3021,9 @@ In both cases, the installation program generates a user-assigned identity. (lin
 
 include::modules/rn-async-errata.adoc[leveloffset=+1]
 
+// 4.20.26 RNs and updating
+include::modules/zstream-4-20-26.adoc[leveloffset=+2]
+
 // 4.20.25 release notes
 include::modules/zstream-4-20-25.adoc[leveloffset=+2]
 


### PR DESCRIPTION
## Summary
- Adds z-stream release notes for OpenShift 4.20.26
- Jira: https://redhat.atlassian.net/browse/OSDOCS-20311
- Shipment MR: https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/593
- ART Dashboard: https://art-dash.engineering.redhat.com/dashboard/release/openshift-4.20
- Errata: RHSA-2026:27063 / RHBA-2026:27059 (Issued 23 June 2026)

## Documented
- OCPBUGS-86864
- OCPBUGS-87220

## Skipped (not documented)
| Key | Reason |
|-----|--------|
| OCPBUGS-79455 | CVE-only / internal / RN-NR |
| OCPBUGS-80538 | CVE-only / internal / RN-NR |
| OCPBUGS-80566 | CVE-only / internal / RN-NR |
| OCPBUGS-80567 | CVE-only / internal / RN-NR |
| OCPBUGS-81813 | CVE-only / internal / RN-NR |
| OCPBUGS-81937 | CVE-only / internal / RN-NR |
| OCPBUGS-82867 | CVE-only / internal / RN-NR |
| OCPBUGS-84289 | CVE-only / internal / RN-NR |
| OCPBUGS-85366 | RN-NR |
| OCPBUGS-85825 | internal (Enhancement) |
| OCPBUGS-86717 | CVE-only / internal / RN status Proposed |
| OCPBUGS-87207 | RN-NR |
| OCPBUGS-87870 | RN-NR |
| OCPBUGS-87902 | incomplete Bug Fix RN text |
| OCPBUGS-88372 | CVE-only / internal / RN-NR |
| OCPBUGS-88383 | CVE-only / internal / RN-NR |
| OCPBUGS-88392 | CVE-only / internal / RN-NR |
| OCPBUGS-88428 | CVE-only / internal / RN-NR |
| OCPBUGS-88430 | CVE-only / internal / RN-NR |
| OCPBUGS-88446 | CVE-only / internal / RN-NR |

## Scope notes
- Shipment YAML keys: 22
- Errata Fixes OCPBUGS keys: 6 (OCPBUGS-85366, OCPBUGS-86864, OCPBUGS-87207, OCPBUGS-87220, OCPBUGS-87870, OCPBUGS-87902)
- In YAML but not errata Fixes: OCPBUGS-79455, OCPBUGS-80538, OCPBUGS-80566, OCPBUGS-80567, OCPBUGS-81813, OCPBUGS-81937, OCPBUGS-82867, OCPBUGS-84289, OCPBUGS-85825, OCPBUGS-86717, OCPBUGS-88372, OCPBUGS-88383, OCPBUGS-88392, OCPBUGS-88428, OCPBUGS-88430, OCPBUGS-88446

## Test plan
- [ ] Title and issued date match access.redhat.com
- [ ] Primary + RPM advisory links correct
- [ ] Vale clean on touched files


Made with [Cursor](https://cursor.com)