### PR TITLE
OSDOCS-20312: Add 4.19.35 z-stream release notes

### DIFF
--- a/modules/zstream-4-19-35.adoc
+++ b/modules/zstream-4-19-35.adoc
@@ -1,0 +1,31 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-19-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-19-35_{context}"]
+= RHSA-2026:26999 - {product-title} {product-version}.35 fixed issues and security update
+
+Issued: 24 June 2026
+
+[role="_abstract"]
+{product-title} release {product-version}.35 is now available. The list of fixed issues that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2026:26999[RHSA-2026:26999] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2026:26999[RHSA-2026:26999] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.19.35 --pullspecs
+----
+
+[id="zstream-4-19-35-fixed-issues_{context}"]
+== Fixed issues
+
+There are no notable fixed issues in this release.
+
+[id="zstream-4-19-35-updating_{context}"]
+== Updating
+
+To update an {product-title} 4.19 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].

--- a/release_notes/ocp-4-19-release-notes.adoc
+++ b/release_notes/ocp-4-19-release-notes.adoc
@@ -2975,6 +2975,9 @@ To save the `vmcore` file, use the `crashkernel` setting to reserve 1024 MB of m
 // 4.19.z about errata updates
 include::modules/ocp-release-asynch-errata-updates.adoc[leveloffset=+1]
 
+// 4.19.35 RNs and updating
+include::modules/zstream-4-19-35.adoc[leveloffset=+2]
+
 // 4.19.27 z-stream RNs full document
 include::modules/zstream-4-19-27.adoc[leveloffset=+2]
 


### PR DESCRIPTION
## Summary
- Adds z-stream release notes for OpenShift 4.19.35 (advisory-only; no documentable bug bullets)
- Jira: https://redhat.atlassian.net/browse/OSDOCS-20312
- Shipment MR: https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/590 (**open, not merged**)
- ART Dashboard: https://art-dash.engineering.redhat.com/dashboard/release/openshift-4.19
- Errata: RHSA-2026:26999 (from shipment YAML; **not yet published** on access.redhat.com at draft time)

## Documented
- _(none — advisory-only release)_

## Skipped (not documented)
| Key | Reason |
|-----|--------|
| OCPBUGS-80390 | CVE-only / internal / RN-NR |
| OCPBUGS-80391 | CVE-only / internal / RN-NR |
| OCPBUGS-81808 | CVE-only / internal / RN-NR |
| OCPBUGS-82820 | CVE-only / internal / RN-NR |
| OCPBUGS-84288 | CVE-only / internal / RN-NR |

## Scope notes
- Shipment YAML keys: 5 (all CVE/internal/RN-NR)
- Errata Fixes OCPBUGS keys: 5 (same set)
- Shipment MR !590 is open; verify advisory IDs and issued date when errata publishes

## Test plan
- [ ] Title and issued date match access.redhat.com after errata publishes
- [ ] Primary + RPM advisory links correct (YAML lists RHSA-2026:26999 for both image and RPM)
- [ ] Vale clean on touched files


Made with [Cursor](https://cursor.com)