### PR TITLE
OSDOCS-20313: Add 18.45 z-stream release notes

### DIFF
--- a/modules/zstream-4-18-45.adoc
+++ b/modules/zstream-4-18-45.adoc
@@ -1,0 +1,31 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-18-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-18-45_{context}"]
+= RHSA-2026:26997 - {product-title} {product-version}.45 fixed issues and security update
+
+Issued: 24 June 2026
+
+[role="_abstract"]
+{product-title} release {product-version}.45 is now available. The list of fixed issues that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2026:26997[RHSA-2026:26997] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2026:26997[RHSA-2026:26997] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.18.45 --pullspecs
+----
+
+[id="zstream-4-18-45-fixed-issues_{context}"]
+== Fixed issues
+
+There are no notable fixed issues in this release.
+
+[id="zstream-4-18-45-updating_{context}"]
+== Updating
+
+To update an {product-title} 4.18 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].

--- a/release_notes/ocp-4-18-release-notes.adoc
+++ b/release_notes/ocp-4-18-release-notes.adoc
@@ -3064,6 +3064,9 @@ As a workaround, you must manually reboot the failed host from the disk. (link:h
 // 4.18 about async
 include::modules/rn-async-errata.adoc[leveloffset=+1]
 
+// 4.18.45 RNs and updating
+include::modules/zstream-4-18-45.adoc[leveloffset=+2]
+
 // 4.18.44 RNs and updating
 include::modules/zstream-4-18-44.adoc[leveloffset=+2]
 


### PR DESCRIPTION
## Summary
- Adds z-stream release notes for OpenShift 18.45 (advisory-only)
- Jira: https://redhat.atlassian.net/browse/OSDOCS-20313
- Shipment MR: https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/589 (open, not merged)
- ART Dashboard: https://art-dash.engineering.redhat.com/dashboard/release/openshift-4.18
- Errata: RHSA-2026:26997 (not yet published on access.redhat.com at draft time)
- Issued: 24 June 2026

## Documented
- _(none — advisory-only release)_

## Skipped (not documented)
| Key | Reason |
|-----|--------|
| OCPBUGS-80210 | CVE-only / internal / RN-NR |
| OCPBUGS-80211 | CVE-only / internal / RN-NR |
| OCPBUGS-80213 | CVE-only / internal / RN-NR |
| OCPBUGS-80293 | CVE-only / internal / RN-NR |
| OCPBUGS-81803 | CVE-only / internal / RN-NR |
| OCPBUGS-86995 | RN-NR |
| OCPBUGS-87830 | RN-NR |

## Scope notes
- Shipment YAML keys: see skipped table
- All keys CVE/internal/RN-NR per workflow filters

## Vale
- 0 errors on touched modules

## Test plan
- [ ] Title and issued date match access.redhat.com after errata publishes
- [ ] Primary + RPM advisory links correct
- [ ] Vale clean on touched files


Made with [Cursor](https://cursor.com)