### PR TITLE
OSDOCS-17042 CQA Manual scaling compute machine set

### DIFF
--- a/machine_management/manually-scaling-machineset.adoc
+++ b/machine_management/manually-scaling-machineset.adoc
@@ -6,16 +6,17 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-You can add or remove an instance of a machine in a compute machine set.
+[role="_abstract"]
+You can manually add or remove an instance of a machine in a compute machine set. Manually scaling a compute machine set gives you control over the resource utilization of that machine set.
 
 [NOTE]
 ====
-If you need to modify aspects of a compute machine set outside of scaling, see xref:../machine_management/modifying-machineset.adoc#modifying-machineset[Modifying a compute machine set].
+If you need to modify aspects of a compute machine set outside of scaling, see "Modifying a compute machine set".
 ====
 
 == Prerequisites
 
-* If you enabled the cluster-wide proxy and scale up compute machines not included in `networking.machineNetwork[].cidr` from the installation configuration, you must xref:../networking/configuring_network_settings/enable-cluster-wide-proxy.adoc#nw-proxy-configure-object_config-cluster-wide-proxy[add the compute machines to the Proxy object's `noProxy` field] to prevent connection issues.
+* If you enabled the cluster-wide proxy and scale up compute machines not included in `networking.machineNetwork[].cidr` from the installation configuration, you must add the compute machines to the Proxy object's `noProxy` field to prevent connection issues. See "Add the compute machines to the Proxy object's `noProxy` field" for more information.
 
 include::snippets/machine-user-provisioned-limitations.adoc[leveloffset=+1]
 
@@ -26,4 +27,6 @@ include::modules/machineset-delete-policy.adoc[leveloffset=+1]
 [role="_additional-resources"]
 [id="additional-resources_manually-scaling-machineset"]
 == Additional resources
+* xref:../machine_management/modifying-machineset.adoc#modifying-machineset[Modifying a compute machine set]
+* xref:../networking/configuring_network_settings/enable-cluster-wide-proxy.adoc#nw-proxy-configure-object_config-cluster-wide-proxy[Add the compute machines to the Proxy object's `noProxy` field]
 * xref:../machine_management/deleting-machine.adoc#machine-lifecycle-hook-deletion_deleting-machine[Lifecycle hooks for the machine deletion phase]

--- a/modules/cluster-autoscaler-config-priority-expander.adoc
+++ b/modules/cluster-autoscaler-config-priority-expander.adoc
@@ -45,7 +45,6 @@ For example, use the regular expression pattern `\*fast*` to match any compute m
 . Create a `cluster-autoscaler-priority-expander.yml` YAML file that defines a config map similar to the following:
 +
 --
-.Example priority expander config map
 [source,yaml]
 ----
 apiVersion: v1

--- a/modules/machineset-delete-policy.adoc
+++ b/modules/machineset-delete-policy.adoc
@@ -7,7 +7,10 @@
 [id="machineset-delete-policy_{context}"]
 = The compute machine set deletion policy
 
-`Random`, `Newest`, and `Oldest` are the three supported deletion options. The default is `Random`, meaning that random machines are chosen and deleted when scaling compute machine sets down. The deletion policy can be set according to the use case by modifying the particular compute machine set:
+[role="_abstract"]
+Compute machine sets can be configured to use the `Random`, `Newest`, and `Oldest` deletion options. The default is `Random`, meaning that random machines are chosen and deleted when scaling compute machine sets down.
+
+The deletion policy can be set according to the use case by modifying the particular compute machine set as in the following example:
 
 [source,yaml]
 ----

--- a/modules/nodes-cluster-resource-override-move-infra.adoc
+++ b/modules/nodes-cluster-resource-override-move-infra.adoc
@@ -18,9 +18,8 @@ ifdef::cro[]
 You can create and use infrastructure nodes to host only infrastructure components, such as the default router, the integrated container image registry, and the components for cluster metrics and monitoring. These infrastructure nodes are not counted toward the total number of subscriptions that are required to run the environment. For more information about infrastructure nodes, see "Creating infrastructure machine sets".
 endif::cro[]
 
-The following examples shows the Cluster Resource Override pods are deployed to control plane nodes and the Cluster Resource Override Operator pod is deployed to a worker node.
+The following example shows that the Cluster Resource Override pods are deployed to control plane nodes.
 
-.Example Cluster Resource Override pods
 [source,terminal]
 ----
 NAME                                                READY   STATUS    RESTARTS   AGE   IP            NODE                                        NOMINATED NODE   READINESS GATES
@@ -29,7 +28,8 @@ clusterresourceoverride-786b8c898c-vn2lf            1/1     Running   0         
 clusterresourceoverride-operator-6b8b8b656b-lvr62   1/1     Running   0          56m   10.131.0.33   ip-10-0-2-39.us-west-2.compute.internal     <none>           <none>
 ----
 
-.Example node list
+The following example shows that the Cluster Resource Override Operator pod is deployed to a worker node.
+
 [source,terminal]
 ----
 NAME                                        STATUS   ROLES                  AGE   VERSION


### PR DESCRIPTION
Version(s):
4.20+

Issue:
https://redhat.atlassian.net/browse/OSDOCS-17042

Link to docs preview:
[Manually scaling a compute machine set](https://113924--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/manually-scaling-machineset.html)
[Moving Cluster Resource Override Operator](https://113924--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/creating-infrastructure-machinesets.html#nodes-cluster-resource-override-move-infra_creating-infrastructure-machinesets)
[Compute machine set deletion policy](https://113924--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/manually-scaling-machineset.html#machineset-delete-policy_manually-scaling-machineset)

QE review:
NA

