### PR TITLE
OSDOCS-20327: Revert format bug introduced in ROSA split work

### DIFF
--- a/networking/ovn_kubernetes_network_provider/about-ovn-kubernetes.adoc
+++ b/networking/ovn_kubernetes_network_provider/about-ovn-kubernetes.adoc
@@ -22,7 +22,7 @@ OVN-Kubernetes is a series of daemons for OVS that transform virtual network con
 
 OVN-Kubernetes provides more of the advanced functionality not available with `OpenFlow`. OVN supports distributed virtual routing, distributed logical switches, access control, Dynamic Host Configuration Protocol (DHCP), and DNS. OVN implements distributed virtual routing within logic flows that equate to open flows. For example, if you have a pod that sends out a DHCP request to the DHCP server on the network, a logic flow rule in the request enables the OVN-Kubernetes plugin to process the packet. This means that the server can respond with gateway, DNS server, IP address, and other information.
 
-OVN-Kubernetes runs a daemon on each node. There are daemon sets for the databases and for the OVN controller that run on every node. The OVN controller programs the Open vSwitch daemon on the nodes to support the following network provider features: 
+OVN-Kubernetes runs a daemon on each node. There are daemon sets for the databases and for the OVN controller that run on every node. The OVN controller programs the Open vSwitch daemon on the nodes to support the following network provider features:
 
 * Egress IPs
 * Firewalls
@@ -53,5 +53,5 @@ ifndef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 * xref:../../networking/network_security/logging-network-security.adoc#logging-network-security[Logging network policy events]
 * xref:../../networking/ovn_kubernetes_network_provider/enabling-multicast.adoc#nw-ovn-kubernetes-enabling-multicast[Enabling multicast for a project]
 * xref:../../networking/network_security/configuring-ipsec-ovn.adoc#configuring-ipsec-ovn[Configuring IPsec encryption]
-* xref:../../rest_api/operator_apis/network-operator-openshift-io-v1.adoc#network-operator-openshift-io-v1[Network [operator.openshift.io/v1\]
+* xref:../../rest_api/operator_apis/network-operator-openshift-io-v1.adoc#network-operator-openshift-io-v1[Network [operator.openshift.io/v1\]]
 endif::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]


### PR DESCRIPTION
Version(s):
4.19+ (to match #99155 where the bug is introduced)

Issue:
[OSDOCS-20327](https://redhat.atlassian.net/browse/OSDOCS-20327)

Link to docs preview:
[Additional resources](https://113955--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/about-ovn-kubernetes#nw-ovn-kubernetes-session-affinity-stickyness-timeout_about-ovn-kubernetes)

QE review:
N/A

Additional information:
Minor issue reported by @prb112, thanks!