### PR TITLE
OSSM_3.4_Ambient-multicluster-TP-banners

### DIFF
--- a/modules/ossm-about-istio-ambient-mode.adoc
+++ b/modules/ossm-about-istio-ambient-mode.adoc
@@ -31,13 +31,6 @@ The L7 features require deploying `waypoint` proxies, which introduces minimal a
 
 * *Enhanced security* that provides a secure, zero-trust network foundation with mTLS by default for all meshed workloads.
 
-[NOTE]
-====
-Ambient mode is a newer architecture and might involve different operational considerations than traditional sidecar models.
-====
-
-While well-defined discovery selectors allow a service mesh deployed in ambient mode alongside a mesh in sidecar mode, this scenario has not been thoroughly validated. To avoid potential conflicts, install {istio} ambient mode only on clusters that do not have an existing {SMProductName} installation. Ambient mode remains a Technology Preview feature.
-
 [IMPORTANT]
 ====
 {istio} ambient mode is not compatible with clusters that use {SMProductName} 2.6 or earlier. You must not install or use them together.

--- a/modules/ossm-installing-multi-primary-multi-network-mesh-ambient.adoc
+++ b/modules/ossm-installing-multi-primary-multi-network-mesh-ambient.adoc
@@ -7,18 +7,13 @@
 = Installing a multi-primary multi-network mesh in ambient mode
 
 [role="_abstract"]
-Install {istio} and configure it for ambient mode in the multi-primary multi-network topology on two {ocp-product-title} clusters.
+Install {istio} and configure it for ambient mode in the multi-primary multi-network topology on two {ocp-product-title} clusters. For a mesh spanning more than two clusters, you can adapt these instructions.
 
-[NOTE]
-====
-In this procedure, `CLUSTER1` is the East cluster and `CLUSTER2` is the West cluster.
-====
-
-You can adapt these instructions for a mesh spanning more than two clusters.
+include::snippets/technology-preview-ambient-multicluster.adoc[]
 
 .Prerequisites
 
-* You have {istio} version 1.29.2 or later.
+* You have {istio} version 1.30 or later.
 
 * You have installed the {SMProduct} 3 Operator on all of the clusters that include the mesh.
 
@@ -55,10 +50,10 @@ In addition to bare metal, the MetalLB Operator can offer load balancing for ins
 +
 [source,terminal]
 ----
-$ export ISTIO_VERSION=1.29.2
+$ export ISTIO_VERSION=1.30
 ----
 
-. Install {istio} on the East cluster:
+. Install {istio} on the East cluster (`CLUSTER1`):
 
 .. Create an `{istio}` resource on the East cluster by running the following command:
 +
@@ -157,7 +152,7 @@ EOF
 $ oc --context="${CTX_CLUSTER1}" wait gateway/istio-eastwestgateway -n istio-system --for=condition=Programmed=True --timeout=3m
 ----
 
-. Install {istio} on the West cluster:
+. Install {istio} on the West cluster (`CLUSTER2`):
 
 .. Create an `Istio` resource on the West cluster by running the following command:
 +

--- a/modules/ossm-verifying-multi-cluster-topology-ambient.adoc
+++ b/modules/ossm-verifying-multi-cluster-topology-ambient.adoc
@@ -7,17 +7,13 @@
 = Verifying a multi-primary multi-network mesh in ambient mode
 
 [role="_abstract"]
-
 Deploy sample applications and verify traffic across two {ocp-product-title} clusters with {SMProductShortName} in ambient mode.
 
-[NOTE]
-====
-In this procedure, `CLUSTER1` is the East cluster and `CLUSTER2` is the West cluster.
-====
+include::snippets/technology-preview-ambient-multicluster.adoc[]
 
 .Prerequisites
 
-* You have {istio} version 1.27.3 or later.
+* You have {istio} version 1.30 or later.
 
 * You have installed the {SMProduct} Operator on all of the clusters that include the mesh.
 
@@ -33,7 +29,7 @@ In this procedure, `CLUSTER1` is the East cluster and `CLUSTER2` is the West clu
 
 .Procedure
 
-. Deploy sample applications on the East cluster:
+. Deploy sample applications on the East cluster (`CLUSTER1`):
 
 .. Create a sample application namespace on the East cluster by running the following command:
 +
@@ -98,7 +94,7 @@ $ oc --context="${CTX_CLUSTER1}" wait --for condition=available -n sample deploy
 $ oc --context="${CTX_CLUSTER1}" wait --for condition=available -n sample deployment/sleep
 ----
 
-. Deploy the sample applications on the West cluster:
+. Deploy the sample applications on the West cluster (`CLUSTER2`):
 
 .. Create a sample application namespace on the West cluster by running the following command:
 +

--- a/snippets/technology-preview-ambient-multicluster.adoc
+++ b/snippets/technology-preview-ambient-multicluster.adoc
@@ -1,0 +1,12 @@
+// snippet included in the following modules:
+//
+// * service-mesh-docs-main/modules/ossm-installing-multi-primary-multi-network-mesh-ambient.adoc
+// * service-mesh-docs-main/modules/ossm-verifying-multi-cluster-topology-ambient.adoc
+:_mod-docs-content-type: SNIPPET
+
+[IMPORTANT]
+====
+Ambient mode in a multi-primary multi-network topology is a Technology Preview feature only. Technology Preview features are not supported with Red Hat production service level agreements (SLAs) and might not be functionally complete. Red Hat does not recommend using them in production. These features provide early access to upcoming product features, enabling customers to test functionality and provide feedback during the development process.
+
+For more information about the support scope of Red Hat Technology Preview features, see link:https://access.redhat.com/support/offerings/techpreview/[Technology Preview Features Support Scope].
+====


### PR DESCRIPTION
OSSM 12578: [TP2] Ambient multi-cluster (multi-primary) support

Version(s):
service-mesh-docs-3.4

Issue:
https://redhat.atlassian.net/browse/OSSM-12578

Link to docs preview:
https://113966--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/install/ossm-multi-cluster-topologies#ossm-installing-multi-primary-multi-network-mesh-ambient_ossm-multi-cluster-topologies

https://113966--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/install/ossm-multi-cluster-topologies#ossm-verifying-multi-cluster-topology-ambient_ossm-multi-cluster-topologies

QE review is not necessary.