### PR TITLE
OSDOCS-19029 cert-manager 1.20.0 release notes, Releasing Today

### DIFF
--- a/security/cert_manager_operator/cert-manager-operator-release-notes.adoc
+++ b/security/cert_manager_operator/cert-manager-operator-release-notes.adoc
@@ -13,10 +13,91 @@ These release notes track the development of {cert-manager-operator}.
 
 For more information, see xref:../../security/cert_manager_operator/index.adoc#cert-manager-operator-about[About the {cert-manager-operator}].
 
+[id="cert-manager-operator-release-notes-1-20-0_{context}"]
+== {cert-manager-operator} 1.20.0
+
+Issued: 2 July 2026
+
+The following advisories are available for the {cert-manager-operator} 1.20.0:
+
+* link:https://access.redhat.com/errata/RHBA-2026:34294[RHBA-2026:34294]
+* link:https://access.redhat.com/errata/RHBA-2026:34309[RHBA-2026:34309]
+* link:https://access.redhat.com/errata/RHBA-2026:34336[RHBA-2026:34336]
+* link:https://access.redhat.com/errata/RHBA-2026:34714[RHBA-2026:34714]
+
+Version `v1.20.0` of the {cert-manager-operator} is based on the upstream cert-manager version `v1.20.2`. For more information, see the link:https://cert-manager.io/docs/releases/release-notes/release-notes-1.20#v1202[cert-manager project release notes for v1.20.2].
+
+[id="cert-manager-operator-1-20-0-features-enhancements_{context}"]
+=== New features and enhancements
+
+:FeatureName: TLS adherence for cert-manager operands
+include::snippets/technology-preview.adoc[]
+
+TrustManager Technology Preview no longer requires a cluster preview FeatureSet::
+With this release, the {cert-manager-operator} no longer requires the `featuregates.config.openshift.io/cluster` object to use a preview `FeatureSet`, such as `TechPreviewNoUpgrade`, in order to enable the TrustManager Technology Preview operand.
++
+Previously, enabling TrustManager required both of the following conditions to be met:
++
+* The cluster `FeatureSet` must be set to a preview value, such as `TechPreviewNoUpgrade`, `DevPreviewNoUpgrade`, or `CustomNoUpgrade`.
+* The Operator subscription must opt in to TrustManager by setting `UNSUPPORTED_ADDON_FEATURES=TrustManager=true`.
++
+Customers running clusters with the `Default` `FeatureSet` were unable to evaluate TrustManager without first switching the cluster to a preview `FeatureSet`, which is a disruptive, cluster-wide change that prevents upgrades.
++
+With this update, the cluster `FeatureSet` requirement is removed. Enabling TrustManager now requires only that the Operator subscription includes `UNSUPPORTED_ADDON_FEATURES=TrustManager=true`. TrustManager remains a Technology Preview feature and is disabled by default.
++
+For more information, see xref:../../security/cert_manager_operator/cert-manager-trust-manager.adoc#cert-manager-trust-manager-install_cert-manager-trust-manager[Enabling the TrustManager Operand].
+
+New performance-tuning override arguments for the cert-manager controller::
+With this release, the {cert-manager-operator} supports configuring performance-tuning parameters for the cert-manager controller by using the `overrideArgs` field of the `CertManager` custom resource (CR). Previously, users had to rely on `spec.unsupportedConfigOverrides` to tune these settings.
++
+You can now set the following arguments under `spec.controllerConfig.overrideArgs`:
++
+* `--concurrent-workers`: The number of concurrent workers for each controller. The default value is `5`.
+* `--kube-api-qps`: The maximum number of queries per second sent to the Kubernetes API server. The default value is `20`.
+* `--kube-api-burst`: The maximum burst of queries per second sent to the Kubernetes API server. Must be greater than or equal to `--kube-api-qps`. The default value is `50`.
+* `--max-concurrent-challenges`: The maximum number of ACME challenges that can be scheduled as processing at the same time. The default value is `60`.
++
+The Operator validates that `--kube-api-burst` is greater than or equal to `--kube-api-qps` when both values are set. If this constraint is not met, the Operator sets the `Degraded` condition on the `CertManager` CR and does not apply the invalid configuration to the controller deployment.
++
+For more information, see xref:../../security/cert_manager_operator/cert-manager-customizing-api-fields.adoc#cert-manager-overridable-arguments_cert-manager-customizing-api-fields[Overridable arguments for the cert-manager components].
+
+Cluster TLS security profile applied to cert-manager operands::
++
+With this release, the {cert-manager-operator} can read the cluster TLS security profile from the `apiserver.config.openshift.io/cluster` object and automatically apply the corresponding TLS configuration to the cert-manager controller, webhook, and CA injector deployments.
++
+Previously, the TLS configuration for cert-manager operands was not tied to the cluster-wide TLS security profile. Cluster administrators who configured a stricter TLS profile at the cluster level had no automated mechanism to propagate those settings to cert-manager operands, creating a gap in cluster-wide TLS posture enforcement.
++
+With this update, when the `spec.tlsAdherence` field of the `CertManager` custom resource (CR) is set to `StrictAllComponents`, the Operator reads the `spec.tlsSecurityProfile` value from `apiserver.config.openshift.io/cluster` and applies the corresponding TLS arguments to the cert-manager operand deployments. The Operator reconciles the deployments whenever the cluster TLS profile changes.
++
+TLS arguments are applied per operand component as follows:
++
+* `cert-manager-webhook`: serving TLS flags and metrics endpoint TLS flags.
+* `cert-manager` (controller): metrics endpoint TLS flags only.
+* `cert-manager-cainjector`: metrics endpoint TLS flags only.
++
+TLS profile enforcement is not yet supported for the IstioCSR and TrustManager operand.
++
+To support this feature, the Operator now requires `get`, `list`, and `watch` permissions on the `apiservers` resource in the `config.openshift.io` API group.
++
+This feature is gated by the `TLSAdherence` feature gate. To use this feature, you must enable the `TechPreviewNoUpgrade` feature set. For more information, see xref:../../nodes/clusters/nodes-cluster-enabling-features.adoc#nodes-cluster-enabling-features-about_nodes-cluster-enabling[Understanding feature gates].
++
+[NOTE]
+====
+Elliptic curve preferences are not configurable because cert-manager does not yet support specifying curve preferences upstream.
+====
++
+:FeatureName: TLS adherence for cert-manager operands
+include::snippets/technology-preview.adoc[]
+
+[id="cert-manager-operator-1-20-0-known-issues_{context}"]
+=== Fixed issues
+
+* Before this update, the {cert-manager-operator} installation failed on clusters with the Console capability disabled because the `ConsoleYAMLSample` resources were missing the required capability annotation. With this release, the Operator installs successfully on Console-less clusters. (link:https://redhat.atlassian.net/browse/OCPBUGS-85579[OCPBUGS-85579])
+
 [id="cert-manager-operator-release-notes-1-19-0_{context}"]
 == {cert-manager-operator} 1.19.0
 
-Issued: 2026-04-20
+Issued: 20 April 2026
 
 The following advisories are available for the {cert-manager-operator} 1.19.0:
 
@@ -36,7 +117,6 @@ In this release, the {cert-manager-operator} adds support for the trust-manager 
 
 Support for configuring the certificate request backoff duration::
 In this release, the {cert-manager-operator} adds support for the `--certificate-request-minimum-backoff-duration` flag. With this flag, you can configure the minimum backoff period for certificate requests by override the default configuration. For more information, see xref:../../security/cert_manager_operator/cert-manager-customizing-api-fields.adoc#cert-manager-overridable-arguments_cert-manager-customizing-api-fields[Overridable arguments for the cert-manager components].
-
 
 [id="cert-manager-operator-1-19-0-known-issues_{context}"]
 === Fixed issues


### PR DESCRIPTION

Version(s): 4.19+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [OSDOCS-19029](https://redhat.atlassian.net/browse/OSDOCS-19029)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:  https://113983--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/cert_manager_operator/cert-manager-operator-release-notes.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [X] QE has approved this change. (No dedicated QE, 2 SMEs checked.)
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: The team is postponing the release to July 2, 2026 to incorporate critical fixes from the upcoming Go 1.26.4 release, which addresses several CVEs. 

Also, I am changing the release date of 1.19.0 to the proper style guide format. 

Release notes will be modularized in a future CQA. Release notes exception for the bot comments. 
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
