### PR TITLE
RHACS 4.11: Document image name change in upgrade docs

### DIFF
--- a/upgrading/upgrade-helm.adoc
+++ b/upgrading/upgrade-helm.adoc
@@ -9,6 +9,13 @@ toc::[]
 [role="_abstract"]
 You must follow a specific upgrade path for {product-title-short} depending on the release of {product-title-short} that you are running. You must also back up your Central database before updating the Helm chart and performing the upgrade.
 
+[IMPORTANT]
+====
+In {product-title-short} 4.11, all container image names changed from the `-rhel8` suffix to `-rhel9` as part of the migration to UBI 9 Minimal base images. For example, `rhacs-main-rhel8` is now `rhacs-main-rhel9`.
+
+If you use image mirrors, allowlists, or firewall rules that reference specific {product-title-short} image names, you must update them to use the new `-rhel9` names before upgrading. For the complete list of current image names, see xref:../configuration/enable-offline-mode.adoc#image-versions_enable-offline-mode[Image versions].
+====
+
 include::modules/helm-upgrade-overview.adoc[leveloffset=+1]
 
 include::modules/back-up-central-database.adoc[leveloffset=+1]

--- a/upgrading/upgrade-operator.adoc
+++ b/upgrading/upgrade-operator.adoc
@@ -11,8 +11,9 @@ Upgrades through the {rh-rhacs-first} Operator are performed automatically by th
 
 [IMPORTANT]
 ====
-To upgrade to {product-title-short} 4.8, which includes an upgrade to PostgreSQL 15, you must free up disk space.
-Before beginning the upgrade, ensure you have free disk space that is at least double the size of your existing database.
+In {product-title-short} 4.11, all container image names changed from the `-rhel8` suffix to `-rhel9` as part of the migration to UBI 9 Minimal base images. For example, `rhacs-main-rhel8` is now `rhacs-main-rhel9`.
+
+If you use image mirrors, allowlists, or firewall rules that reference specific {product-title-short} image names, you must update them to use the new `-rhel9` names before upgrading. For the complete list of current image names, see xref:../configuration/enable-offline-mode.adoc#image-versions_enable-offline-mode[Image versions].
 ====
 
 include::modules/prepare-operator-upgrades.adoc[leveloffset=+1]

--- a/upgrading/upgrade-roxctl.adoc
+++ b/upgrading/upgrade-roxctl.adoc
@@ -11,10 +11,9 @@ You can upgrade to the latest version of {rh-rhacs-first} from a supported older
 
 [IMPORTANT]
 ====
-* You need to perform the manual upgrade procedure only if you used the `roxctl` CLI to install {product-title-short}.
-* You must follow manual steps for each version upgrade, for example, from version 3.74 to version 4.0, and from version 4.0 to version 4.1. Therefore, Red{nbsp}Hat recommends upgrading first from 3.74 to 4.0, then from 4.0 to 4.1, then 4.1 to 4.2, until you install the selected version. For full functionality, Red{nbsp}Hat recommends upgrading to the most recent version.
-* Upgrading to {product-title-short} 4.8 includes an upgrade to PostgreSQL 15 and it requires additional free space on your disk.
-Before starting the upgrade, ensure you have enough free disk space, ideally almost double the size of your existing database.
+In {product-title-short} 4.11, all container image names changed from the `-rhel8` suffix to `-rhel9` as part of the migration to UBI 9 Minimal base images. For example, `rhacs-main-rhel8` is now `rhacs-main-rhel9`.
+
+If you use image mirrors, allowlists, or firewall rules that reference specific {product-title-short} image names, you must update them to use the new `-rhel9` names before upgrading. For the complete list of current image names, see xref:../configuration/enable-offline-mode.adoc#image-versions_enable-offline-mode[Image versions].
 ====
 
 To upgrade {product-title-short} to the latest version, perform the following steps:


### PR DESCRIPTION
Release: 4.11

Jira: none

Previews:

https://113995--ocpdocs-pr.netlify.app/openshift-acs/latest/upgrading/upgrade-helm.html
https://113995--ocpdocs-pr.netlify.app/openshift-acs/latest/upgrading/upgrade-operator.html
https://113995--ocpdocs-pr.netlify.app/openshift-acs/latest/upgrading/upgrade-roxctl.html

Additional information:

## Summary

Adds an IMPORTANT admonition to all three upgrade guides (Operator, Helm, roxctl) noting that RHACS 4.11 container image names changed from `-rhel8` to `-rhel9` as part of the UBI 9 migration.

Users with image mirrors, allowlists, or firewall rules referencing specific image names need to update them before upgrading. This follows the same pattern as the existing PostgreSQL 15 disk space note in the upgrade docs.

### Files changed

- `upgrading/upgrade-operator.adoc` — added `[IMPORTANT]` block
- `upgrading/upgrade-helm.adoc` — added `[IMPORTANT]` block
- `upgrading/upgrade-roxctl.adoc` — added `[IMPORTANT]` block