### PR TITLE
OSDOCS-16421: CQA fixes for ROSA OSD Nodes

### DIFF
--- a/modules/rosa-creating-node-tuning.adoc
+++ b/modules/rosa-creating-node-tuning.adoc
@@ -4,10 +4,10 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="rosa-creating-node-tuning_{context}"]
-= Creating node tuning configurations
+= Create node tuning configurations
 
 [role="_abstract"]
-You can create tuning configurations by using the {product-title} (ROSA) CLI, `rosa`.
+Create node tuning configurations to optimize node-level performance for your workloads by using the {rosa-cli-first}.
 
 .Prerequisites
 
@@ -17,14 +17,14 @@ You can create tuning configurations by using the {product-title} (ROSA) CLI, `r
 
 .Procedure
 
-. Run the following command to create your tuning configuration:
+* Run the following command to create your tuning configuration:
 +
 [source,terminal]
 ----
 $ rosa create tuning-config -c <cluster_id> --name <name_of_tuning> --spec-path <path_to_spec_file>
 ----
 +
-You must supply the path to the `spec.json` file or the command returns an error.
+You must supply the path to the `spec.json` file, or the command returns an error.
 +
 [source,terminal]
 ----
@@ -38,7 +38,7 @@ $ I: To view all tuning configs, run 'rosa list tuning-configs -c cluster-exampl
 
 .Verification
 
-* You can verify the existing tuning configurations that are applied by your account with the following command:
+* You can verify the existing tuning configurations by running the following command:
 +
 [source,terminal]
 ----
@@ -49,7 +49,8 @@ You can specify the type of output you want for the configuration list.
 
 ** Without specifying the output type, you see the ID and name of the tuning configuration:
 +
-.Example output without specifying output type
+*Example output without specifying output type*
++
 [source,terminal]
 ----
 ID                                    NAME
@@ -63,7 +64,8 @@ ID                                    NAME
 The following JSON output has hard line-returns for the sake of reading clarity. This JSON output is invalid unless you remove the newlines in the JSON strings.
 ====
 +
-.Example output specifying JSON output
+*Example output specifying JSON output*
++
 [source,terminal]
 ----
 [

--- a/modules/rosa-deleting-node-tuning.adoc
+++ b/modules/rosa-deleting-node-tuning.adoc
@@ -4,25 +4,25 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="rosa-deleting-node-tuning_{context}"]
-= Deleting node tuning configurations
+= Delete node tuning configurations
 
 [role="_abstract"]
-You can delete tuning configurations if you no longer need them by using the {product-title} (ROSA) CLI, `rosa`.
+Remove unused node tuning configurations from your cluster to simplify management by using the {rosa-cli-first}.
 
 [NOTE]
 ====
-You cannot delete a tuning configuration referenced in a machine pool. You must first remove the tuning configuration from all machine pools before you can delete  it.
+You cannot delete a tuning configuration referenced in a machine pool. You must remove the tuning configuration from all machine pools before you can delete it.
 ====
 
 .Prerequisites
 
-* You have downloaded the latest version of the ROSA CLI.
-* You have a cluster on the latest version .
-* Your cluster has a node tuning configuration that you want delete.
+* You have downloaded the latest version of the {rosa-cli}.
+* You have a cluster on the latest version.
+* Your cluster has a node tuning configuration that you want to delete.
 
 .Procedure
 
-* To delete the tuning configurations, run the following command:
+* To delete a tuning configuration, run the following command:
 +
 [source,terminal]
 ----
@@ -31,7 +31,8 @@ $ rosa delete tuning-config -c <cluster_id> <name_of_tuning>
 +
 The tuning configuration on the cluster is deleted
 +
-.Example output
+*Example output*
++
 [source,terminal]
 ----
 ? Are you sure you want to delete tuning config sample-tuning on cluster sample-cluster? Yes

--- a/modules/rosa-modifying-node-tuning.adoc
+++ b/modules/rosa-modifying-node-tuning.adoc
@@ -4,10 +4,11 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="rosa-modifying-node-tuning_{context}"]
-= Modifying your node tuning configurations
+= Modify node tuning configurations
 
 [role="_abstract"]
-You can view and update the node tuning configurations by using the {product-title} (ROSA) CLI, `rosa`.
+
+View and update node tuning configurations to adjust performance settings for your cluster by using the {rosa-cli-first}.
 
 .Prerequisites
 
@@ -17,7 +18,7 @@ You can view and update the node tuning configurations by using the {product-tit
 
 .Procedure
 
-. You view the tuning configurations with the `rosa describe` command:
+. View the tuning configurations with the `rosa describe` command:
 +
 [source,terminal]
 ----
@@ -33,7 +34,8 @@ where:
 `-o json`:: Specifies the output type. This parameter is optional. If you do not specify any outputs, you see only the ID and name of the tuning configuration.
 --
 +
-.Example output without specifying output type
+*Example output without specifying output type*
++
 [source,terminal]
 ----
 Name:    sample-tuning
@@ -55,7 +57,8 @@ Spec:    {
 
 ----
 +
-.Example output specifying JSON output
+*Example output specifying JSON output*
++
 [source,terminal]
 ----
 {
@@ -80,8 +83,9 @@ Spec:    {
 }
 ----
 
-. After verifying the tuning configuration, you edit the existing configurations with the `rosa edit` command:
+. After verifying the tuning configuration, edit the existing configuration with the `rosa edit` command:
 +
+[source,terminal]
 ----
 $ rosa edit tuning-config -c <cluster_id> --name <name_of_tuning> --spec-path <path_to_spec_file>
 ----
@@ -90,14 +94,15 @@ In this command, you use the `spec.json` file to edit your configurations.
 
 .Verification
 
-* Run the `rosa describe` command again, to see that the changes you made to the `spec.json` file are updated in the tuning configurations:
+* Run the `rosa describe` command again to see that the changes you made to the `spec.json` file are updated in the tuning configurations:
 +
 [source,terminal]
 ----
 $ rosa describe tuning-config -c <cluster_id> --name <name_of_tuning>
 ----
 +
-.Example output
+*Example output*
++
 [source,terminal]
 ----
 Name:  sample-tuning

--- a/modules/sd-nodes-cma-autoscaling-custom-install.adoc
+++ b/modules/sd-nodes-cma-autoscaling-custom-install.adoc
@@ -4,42 +4,44 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="sd-nodes-cma-autoscaling-custom-install_{context}"]
-= Installing the custom metrics autoscaler
+= Install the custom metrics autoscaler
 
-You can use the following procedure to install the Custom Metrics Autoscaler Operator.
+[role="_abstract"]
+Install the Custom Metrics Autoscaler Operator to enable autoscaling of your workloads based on custom metrics from external sources such as Kafka or Prometheus.
 
 .Prerequisites
 
 * You have access to the cluster as a user with the `cluster-admin` role.
 ifdef::openshift-dedicated[]
 +
-If your {product-title} cluster is in a cloud account that is owned by Red Hat (non-CCS), you must request `cluster-admin` privileges.
+If your {product-title} cluster is in a cloud account that is owned by Red{nbsp}Hat (non-CCS), you must request `cluster-admin` privileges.
 endif::openshift-dedicated[]
 
-* Remove any previously-installed Technology Preview versions of the Cluster Metrics Autoscaler Operator.
+* Any previously installed Technology Preview versions of the Cluster Metrics Autoscaler Operator are removed.
 
-* Remove any versions of the community-based KEDA.
-+
-Also, remove the KEDA 1.x custom resource definitions by running the following commands:
-+
-[source,terminal]
-----
-$ oc delete crd scaledobjects.keda.k8s.io
-----
-+
-[source,terminal]
-----
-$ oc delete crd triggerauthentications.keda.k8s.io
-----
+* Any versions of the community-based KEDA are removed, including the KEDA 1.x custom resource definitions (CRDs). To learn how to delete CRDs, see step 5 in
+ifdef::openshift-rosa-hcp[]
+link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html-single/nodes/index#nodes-cma-autoscaling-custom-uninstalling_nodes-cma-autoscaling-custom-removing[Uninstalling the Custom Metrics Autoscaler Operator].
+endif::[]
+ifdef::openshift-rosa[]
+link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws_classic_architecture/4/html-single/nodes/index#nodes-cma-autoscaling-custom-uninstalling_nodes-cma-autoscaling-custom-removing[Uninstalling the Custom Metrics Autoscaler Operator].
+endif::[]
+ifdef::openshift-dedicated[]
+link:https://docs.redhat.com/en/documentation/openshift_dedicated/4/html-single/nodes/index#nodes-cma-autoscaling-custom-uninstalling_nodes-cma-autoscaling-custom-removing[Uninstalling the Custom Metrics Autoscaler Operator].
+endif::[]
 
-* Ensure that the `keda` namespace exists. If not, you must manaully create the `keda` namespace.
+* The `keda` namespace exists. If the namespace does not exist, you must create it manually.
 
-* Optional: If you need the Custom Metrics Autoscaler Operator to connect to off-cluster services, such as an external Kafka cluster or an external Prometheus service, put any required service CA certificates into a config map. The config map must exist in the same namespace where the Operator is installed. For example:
-+
-[source,terminal]
-----
-$ oc create configmap -n openshift-keda thanos-cert  --from-file=ca-cert.pem
-----
+* Optional: If you need the Custom Metrics Autoscaler Operator to connect to off-cluster services, such as an external Kafka cluster or an external Prometheus service, put any required service CA certificates into a config map. The config map must exist in the same namespace where the Operator is installed. For more information, see
+ifdef::openshift-rosa-hcp[]
+link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html-single/nodes/index#nodes-pods-configmap-creating-from-files_configmaps[Creating a config map from a file].
+endif::[]
+ifdef::openshift-rosa[]
+link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws_classic_architecture/4/html-single/nodes/index#nodes-pods-configmap-creating-from-files_configmaps[Creating a config map from a file].
+endif::[]
+ifdef::openshift-dedicated[]
+link:https://docs.redhat.com/en/documentation/openshift_dedicated/4/html-single/nodes/index#nodes-pods-configmap-creating-from-files_configmaps[Creating a config map from a file].
+endif::[]
 
 .Procedure
 
@@ -47,8 +49,7 @@ $ oc create configmap -n openshift-keda thanos-cert  --from-file=ca-cert.pem
 
 . Choose *Custom Metrics Autoscaler* from the list of available Operators, and click *Install*.
 
-. On the *Install Operator* page, ensure that the *A specific namespace on the cluster* option
-is selected for *Installation Mode*.
+. On the *Install Operator* page, ensure that the *A specific namespace on the cluster* option is selected for *Installation Mode*.
 
 . For *Installed Namespace*, click *Select a namespace*.
 
@@ -80,9 +81,8 @@ is selected for *Installation Mode*.
 $ oc get all -n keda
 ----
 +
-The output appears similar to the following:
+*Example output*
 +
-.Example output
 [source,text]
 ----
 NAME                                                      READY   STATUS    RESTARTS   AGE
@@ -94,4 +94,3 @@ deployment.apps/custom-metrics-autoscaler-operator   1/1     1            1     
 NAME                                                            DESIRED   CURRENT   READY   AGE
 replicaset.apps/custom-metrics-autoscaler-operator-5fd8d9ffd8   1         1         1       18m
 ----
-

--- a/nodes/nodes/nodes-nodes-viewing.adoc
+++ b/nodes/nodes/nodes-nodes-viewing.adoc
@@ -2,6 +2,7 @@
 [id="nodes-nodes-viewing"]
 = Viewing and listing the nodes in your {product-title} cluster
 include::_attributes/common-attributes.adoc[]
+include::_attributes/attributes-openshift-dedicated.adoc[]
 :context: nodes-nodes-viewing
 
 toc::[]
@@ -28,9 +29,11 @@ include::modules/nodes-nodes-viewing-listing-pods.adoc[leveloffset=+1]
 
 include::modules/nodes-nodes-viewing-memory.adoc[leveloffset=+1]
 
+ifndef::openshift-dedicated[]
 [role="_additional-resources"]
 [id="additional-resources_{context}"]
 == Additional resources
+endif::openshift-dedicated[]
 ifndef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 * xref:../../nodes/nodes/nodes-nodes-working.adoc#nodes-nodes-working-updating_nodes-nodes-working[Understanding how to update labels on nodes]
 endif::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]

--- a/snippets/rosa-node-lifecycle.adoc
+++ b/snippets/rosa-node-lifecycle.adoc
@@ -1,10 +1,10 @@
 // Module included in the following assemblies:
 //
-// * nodes/index.adoc
+// * nodes/nodes-nodes-viewing.adoc
 
 :_mod-docs-content-type: SNIPPET
 
 [IMPORTANT]
 ====
-Worker nodes are not guaranteed longevity, and may be replaced at any time as part of the normal operation and management of OpenShift. For more details about the node lifecycle, refer to _additional resources_.
+Worker node longevity is not guaranteed, and nodes may be replaced at any time as part of the normal operation and management of {OCP-short}. For more details about the node lifecycle, refer to _Additional resources_.
 ====


### PR DESCRIPTION
(cherry picked from commit 7d258718cd1ad41e5d404f42579035327ad88860)

**Version(s):**
4.20

**Issue:**
https://redhat.atlassian.net/browse/OSDOCS-16421

**Link to docs preview:**
Since ROSA and OSD docs won't be touched by changes to the 4.20 branch, Netlify only built the OCP previews.

- The `sd-nodes-cma-autoscaling-custom-install` module (**Installing the custom metrics autoscaler**) remains unseen in the OCP [nodes-cma-autoscaling-custom-install](https://114010--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/cma/nodes-cma-autoscaling-custom-install.html#nodes-cma-autoscaling-custom-install_nodes-cma-autoscaling-custom-install) assembly. It includes an OCP-specific module without `sd-` in the beginning.

- The `rosa-node-lifecycle.adoc` snippet remains unseen in the [nodes-nodes-viewing](https://114010--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/nodes/nodes-nodes-viewing.html) assembly.

- The 3 `rosa-` node tuning modules remain unseen in the [nodes-node-tuning-operator](https://114010--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/nodes/nodes-node-tuning-operator.html) assembly.

**QE review:**
N/A

**Additional information:**
Solved merge conflicts in 4 files:

- 	modules/rosa-creating-node-tuning.adoc
- 	modules/rosa-deleting-node-tuning.adoc
- 	modules/rosa-modifying-node-tuning.adoc
- 	modules/sd-nodes-cma-autoscaling-custom-install.adoc