### PR TITLE
OSDOCS-20341: adds RHCL 1.3.5 async release note

### DIFF
--- a/modules/ref-relnotes-1.3.5-z-stream.adoc
+++ b/modules/ref-relnotes-1.3.5-z-stream.adoc
@@ -1,0 +1,17 @@
+// Module used in the following assemblies
+//
+// *release_notes/rhcl-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="rhcl-relnotes-1.3.5-z-stream_{context}"]
+= {product-title} 1.3.5 bug fix and security update
+
+Issued: 1 July 2026
+
+[role="_abstract"]
+{product-title} release 1.3.5 is now available. A description is available in the link:https://access.redhat.com/errata/RHBA-2026:34242[RHBA-2026:34242] advisory. {product-title} uses the `stable` update channel to track and receive updates for the {product-title} Operator. You can manage how your updates are applied through your Operator Lifecycle Manager (OLM) subscription resource. For more information, see xref:../updating/updating-rhcl.adoc#proc-update-rhcl-with-web-console_updating-rhcl[Updating Red Hat Connectivity Link].
+
+[id="rhcl-relnotes-1.3.5-z-stream-bug-fixes_{context}"]
+== Bug fixes
+
+* During upgrades, the Operator Lifecycle Manager (OLM) automatically validates your existing `AuthConfig` custom resources (CRs) against all active versions of the Custom Resource Definition (CRD) served on the cluster. However, the `v1beta2` version of the CRD lacks a schema validation patch for Common Expression Language (CEL) predicate fields. Before this release, the Kubernetes API server evaluated the newer `v1beta3` resources containing CEL predicates against the stricter `v1beta2` schema. Because of this, if you had `AuthConfig` resources configured with CEL predicate conditions, OLM blocked your upgrades. The upgrade process failed because the API server rejected the CEL predicate field as an invalid option under the `v1beta2` rules. With this release, the `v1beta3` version of the `AuthConfig` API is the standard for the served CRD versions and the `v1beta2` version of the CRD is deprecated and removed. Existing `AuthConfig` resources that have CEL predicate conditions do not trigger schema validation failures. You can now upgrade without OLM blocking the process. (https://redhat.atlassian.net/browse/CONNLINK-1131[CONNLINK-1131])

--- a/release_notes/rhcl-release-notes.adoc
+++ b/release_notes/rhcl-release-notes.adoc
@@ -17,6 +17,8 @@ include::modules/ref-relnotes-known-issues.adoc[leveloffset=+2]
 
 include::modules/ref-relnotes-z-streams.adoc[leveloffset=+1]
 
+include::modules/ref-relnotes-1.3.5-z-stream.adoc[leveloffset=+2]
+
 include::modules/ref-relnotes-1.3.4-z-stream.adoc[leveloffset=+2]
 
 include::modules/ref-relnotes-1.3.3-z-stream.adoc[leveloffset=+2]


### PR DESCRIPTION
Version(s):
rhcl-docs-1.3

Issue:
https://redhat.atlassian.net/browse/OSDOCS-20341

Link to docs preview:
https://114024--ocpdocs-pr.netlify.app/rhcl/latest/release_notes/rhcl-release-notes.html#rhcl-relnotes-1.3.5-z-stream_rhcl-release-notes

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
