### PR TITLE
OSDOCS-20345: Add 4.13.68 z-stream release notes

### DIFF
--- a/modules/zstream-4-13-68-about.adoc
+++ b/modules/zstream-4-13-68-about.adoc
@@ -1,0 +1,15 @@
+:_mod-docs-content-type: CONCEPT
+[id="zstream-4-13-68-about_{context}"]
+= RHSA-2026:26541 - {product-title} 4.13.68 fixed issues and security update
+
+Issued: 25 June 2026
+
+[role="_abstract"]
+{product-title} release 4.13.68, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2026:26541[RHSA-2026:26541] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2026:26541[RHSA-2026:26541] advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.13.68 --pullspecs
+----

--- a/modules/zstream-4-13-68-bug-fixes.adoc
+++ b/modules/zstream-4-13-68-bug-fixes.adoc
@@ -1,0 +1,7 @@
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-13-68-bug-fixes_{context}"]
+= Fixed issues
+
+[role="_abstract"]
+
+There are no notable fixed issues in this release.

--- a/modules/zstream-4-13-68-updating.adoc
+++ b/modules/zstream-4-13-68-updating.adoc
@@ -1,0 +1,6 @@
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-13-68-updating_{context}"]
+= Updating
+
+[role="_abstract"]
+To update an existing {product-title} 4.13 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].

--- a/release_notes/ocp-4-13-release-notes.adoc
+++ b/release_notes/ocp-4-13-release-notes.adoc
@@ -4680,6 +4680,13 @@ include::modules/zstream-4-13-66-bug-fixes.adoc[leveloffset=+2]
 
 include::modules/zstream-4-13-66-updating.adoc[leveloffset=+2]
 
+//4.13.68
+include::modules/zstream-4-13-68-about.adoc[leveloffset=+2]
+
+include::modules/zstream-4-13-68-bug-fixes.adoc[leveloffset=+2]
+
+include::modules/zstream-4-13-68-updating.adoc[leveloffset=+2]
+
 //4.13.67
 include::modules/zstream-4-13-67-about.adoc[leveloffset=+2]
 


### PR DESCRIPTION
## Summary
- Adds z-stream release notes for OpenShift 4.13.68
- Jira: https://redhat.atlassian.net/browse/OSDOCS-20345
- Shipment MR: https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/588 (open, not merged — scope from cached shipment YAML)
- ART Dashboard: https://art-dash.engineering.redhat.com/dashboard/release/openshift-4.13
- Errata: RHSA-2026:26541 (not yet published)
- Issued: 25 June 2026

## Documented
_(none — advisory-only)_

## Skipped (not documented)
| Key | Reason |
|-----|--------|
| OCPBUGS-74945 | CVE-only / internal / RN-NR |
| OCPBUGS-82051 | CVE-only / RN-NR |

## Vale
- 0 errors on touched modules

## Test plan
- [ ] Title and issued date match access.redhat.com after errata publishes
- [ ] Primary + RPM advisory links correct
- [ ] Vale clean on touched files

Made with [Cursor](https://cursor.com)