### PR TITLE
OSDOCS-20346: Add 4.12.92 z-stream release notes

### DIFF
--- a/modules/zstream-4-12-92-about.adoc
+++ b/modules/zstream-4-12-92-about.adoc
@@ -1,0 +1,21 @@
+// Module included in the following assembly:
+//
+// * release_notes/ocp-4-12-release-notes.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="zstream-4-12-92-about_{context}"]
+= RHSA-2026:26527 - {product-title} {product-version}.92 bug fix and security update
+
+[role="_abstract"]
+Issued: 25 June 2026
+
+{product-title} release {product-version}.92, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2026:26527[RHSA-2026:26527] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2026:26527[RHSA-2026:26527] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.12.92 --pullspecs
+----

--- a/modules/zstream-4-12-92-fixed-issues.adoc
+++ b/modules/zstream-4-12-92-fixed-issues.adoc
@@ -1,0 +1,10 @@
+// Module included in the following assembly:
+//
+// * release_notes/ocp-4-12-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-12-92-fixed-issues_{context}"]
+= Fixed issues
+
+[role="_abstract"]
+There are no notable fixed issues in this release.

--- a/modules/zstream-4-12-92-updating.adoc
+++ b/modules/zstream-4-12-92-updating.adoc
@@ -1,0 +1,10 @@
+// Module included in the following assembly:
+//
+// * release_notes/ocp-4-12-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-12-92-updating_{context}"]
+= Updating
+
+[role="_abstract"]
+To update an existing {product-title} 4.12 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].

--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -5414,6 +5414,15 @@ include::modules/zstream-4-12-90-fixed-issues.adoc[leveloffset=+3]
 // 4.12.90 updating
 include::modules/zstream-4-12-90-updating.adoc[leveloffset=+3]
 
+// 4.12.92 about
+include::modules/zstream-4-12-92-about.adoc[leveloffset=+2]
+
+// 4.12.92 fixes
+include::modules/zstream-4-12-92-fixed-issues.adoc[leveloffset=+3]
+
+// 4.12.92 updating
+include::modules/zstream-4-12-92-updating.adoc[leveloffset=+3]
+
 // 4.12.91 about
 include::modules/zstream-4-12-91-about.adoc[leveloffset=+2]
 


### PR DESCRIPTION
## Summary
- Adds z-stream release notes for OpenShift 4.12.92
- Jira: https://redhat.atlassian.net/browse/OSDOCS-20346
- Shipment MR: https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/587 (open, not merged — scope from cached shipment YAML)
- ART Dashboard: https://art-dash.engineering.redhat.com/dashboard/release/openshift-4.12
- Errata: RHSA-2026:26527 (not yet published)
- Issued: 25 June 2026

## Documented
_(none — advisory-only)_

## Skipped (not documented)
| Key | Reason |
|-----|--------|
| OCPBUGS-86254 | CVE-only / internal / RN-NR |
| OCPBUGS-86891 | RN-NR |

## Vale
- 0 errors on touched modules

## Test plan
- [ ] Title and issued date match access.redhat.com after errata publishes
- [ ] Primary + RPM advisory links correct
- [ ] Vale clean on touched files

Made with [Cursor](https://cursor.com)