### PR TITLE
[OSDOCS#16704]:Modularize the ROSA and STS explained assembly and CQA fixes

### DIFF
--- a/modules/rosa-hcp-sts-components.adoc
+++ b/modules/rosa-hcp-sts-components.adoc
@@ -1,0 +1,56 @@
+// Module included in the following assemblies:
+//
+// * rosa_architecture/cloud-experts-rosa-hcp-sts-explained.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="rosa-hcp-sts-components_{context}"]
+= Components of {product-title}
+
+[role="_abstract"]
+{product-title} consists of the following components:
+
+* *AWS infrastructure* - The infrastructure required for the cluster including the Amazon EC2 instances, Amazon Elastic Block Store (EBS) storage, and networking components.
+* *AWS STS* - A method for granting short-term, dynamic tokens to provide users the necessary permissions to temporarily interact with your AWS account resources.
+* *OpenID Connect (OIDC)* - A mechanism for cluster Operators to authenticate with AWS, assume the cluster roles through a trust policy, and obtain temporary credentials from AWS IAM STS to make the required API calls.
+* *Roles and policies* - The roles and policies used by {product-title} can be divided into account-wide roles and policies and Operator roles and policies.
++
+The policies determine the allowed actions for each of the roles.
++
+--
+** The following account-wide roles are required:
+
+*** `<prefix>-HCP-ROSA-Worker-Role`
+*** `<prefix>-HCP-ROSA-Support-Role`
+*** `<prefix>-HCP-ROSA-Installer-Role`
+
+** The following account-wide AWS-managed policies are required:
+
+*** `ROSAInstallerPolicy`
+*** `ROSAWorkerInstancePolicy`
+*** `ROSASRESupportPolicy`
+*** `ROSAIngressOperatorPolicy`
+*** `ROSAAmazonEBSCSIDriverOperatorPolicy`
+*** `ROSACloudNetworkConfigOperatorPolicy`
+*** `ROSAControlPlaneOperatorPolicy`
+*** `ROSAImageRegistryOperatorPolicy`
+*** `ROSAKMSProviderPolicy`
+*** `ROSAKubeControllerPolicy`
+*** `ROSAManageSubscription`
+*** `ROSANodePoolManagementPolicy`
+--
++
+[NOTE]
+====
+Certain policies are used by the cluster Operator roles, listed below. The Operator roles are created in a second step because they are dependent on an existing cluster name and cannot be created at the same time as the account-wide roles.
+====
++
+** The Operator roles are:
+
+*** <operator_role_prefix>-openshift-cluster-csi-drivers-ebs-cloud-credentials
+*** <operator_role_prefix>-openshift-cloud-network-config-controller-cloud-credentials
+*** <operator_role_prefix>-openshift-machine-api-aws-cloud-credentials
+*** <operator_role_prefix>-openshift-cloud-credential-operator-cloud-credentials
+*** <operator_role_prefix>-openshift-image-registry-installer-cloud-credentials
+*** <operator_role_prefix>-openshift-ingress-operator-cloud-credentials
++
+** Trust policies are created for each account-wide role and each Operator role.

--- a/modules/rosa-hcp-sts-credential-method.adoc
+++ b/modules/rosa-hcp-sts-credential-method.adoc
@@ -1,0 +1,15 @@
+// Module included in the following assemblies:
+//
+// * rosa_architecture/cloud-experts-rosa-hcp-sts-explained.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="rosa-hcp-sts-credential-method_{context}"]
+= AWS STS credential method
+
+[role="_abstract"]
+As part of {product-title}, Red{nbsp}Hat requires the necessary permissions to manage infrastructure resources in your AWS account.
+{product-title} IAM STS policies grant the cluster's automation software limited, short-term access to resources in your AWS account.
+
+The STS method uses predefined roles and policies to grant temporary, least-privilege permissions to IAM roles. The credentials typically expire an hour after being requested. Once expired, they are no longer recognized by AWS and no longer have account access to make API requests with them.
+
+AWS IAM STS roles must be created for each {product-title} cluster. Use the {rosa-cli-first} to manage the STS roles and attach the required AWS-managed policies to each role. The CLI provides the commands and files to create the roles, attach the AWS-managed policies, and an option to allow the CLI to automatically create the roles and attach the policies. Alternatively, the {rosa-cli} can also provide you with the content to prepare the roles and attach the AWS-managed policies required for {product-title}.

--- a/modules/rosa-hcp-sts-deploying-cluster.adoc
+++ b/modules/rosa-hcp-sts-deploying-cluster.adoc
@@ -1,0 +1,20 @@
+// Module included in the following assemblies:
+//
+// * rosa_architecture/cloud-experts-rosa-hcp-sts-explained.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="rosa-hcp-sts-deploying-cluster_{context}"]
+= Deploy a {product-title} cluster
+
+[role="_abstract"]
+During the cluster creation process, the {rosa-cli-first} creates the required JSON files for you and outputs the commands you need, and if necessary, it can also run the commands for you. The {rosa-cli} can automatically create the roles, or you can manually create them by using the `--mode manual` or `--mode auto` flags.
+
+Deploying a {product-title} cluster consists of the following general steps.
+
+.Procedure
+
+. Create the account-wide roles.
+. Create the Operator roles.
+** Red{nbsp}Hat uses AWS IAM STS to send the required permissions to AWS that allow AWS to create and attach the corresponding AWS-managed Operator policies.
+. Create the OIDC provider.
+. Create the cluster.

--- a/modules/rosa-hcp-sts-security.adoc
+++ b/modules/rosa-hcp-sts-security.adoc
@@ -1,0 +1,19 @@
+// Module included in the following assemblies:
+//
+// * rosa_architecture/cloud-experts-rosa-hcp-sts-explained.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="rosa-hcp-sts-security_{context}"]
+= AWS STS security
+
+[role="_abstract"]
+Security features for AWS STS include:
+
+* An explicit and limited set of policies that the user creates ahead of time.
+** The user can review every requested permission needed by the platform.
+* The service cannot do anything outside of those permissions.
+* There is no need to rotate or revoke credentials. Whenever the service needs to perform an action, it obtains credentials that expire in one hour or less.
+* Credential expiration reduces the risks of credentials leaking and being reused.
+* The AWS-managed policies for {product-title} are tightly scoped to only allow actions on the associated AWS resources in your account, within the limits of the AWS API.
+
+{product-title} policies grant cluster software components with least-privilege permissions with short-term security credentials to specific and segregated IAM roles. The credentials are associated with IAM roles specific to each component and cluster that makes AWS API calls. This method aligns with principles of least-privilege and secure practices in cloud service resource management.

--- a/modules/rosa-hcp-sts-workflow.adoc
+++ b/modules/rosa-hcp-sts-workflow.adoc
@@ -1,0 +1,34 @@
+// Module included in the following assemblies:
+//
+// * rosa_architecture/cloud-experts-rosa-hcp-sts-explained.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="rosa-hcp-sts-workflow_{context}"]
+= {product-title} workflow
+
+[role="_abstract"]
+The user creates the required account-wide roles. During role creation, a trust policy, known as a cross-account trust policy, is created which allows a Red{nbsp}Hat-owned role to assume the roles. Trust policies are also created for the EC2 service, which allows workloads on EC2 instances to assume roles and obtain credentials. AWS assigns a corresponding permissions policy to each role.
+
+After both the account-wide operator roles and policies are created, the user can create a cluster. These operator roles are assigned to the corresponding permission policies that were created earlier and a trust policy with an OIDC provider. The operator roles differ from the account-wide roles in that they ultimately represent the in-cluster pods that need access to AWS resources. Because a user cannot attach IAM roles to pods, they must create a trust policy with an OIDC provider so that the Operator, and therefore the pods, can access the roles they need.
+
+image::cloud-experts-sts-explained_creation_flow_hcp.png[{product-title} cluster creation flow diagram]
+
+When a new role is needed, the workload currently using the Red{nbsp}Hat role will assume the role in the AWS account, obtain temporary credentials from AWS STS, and begin performing the actions by using API calls within the user's AWS account as permitted by the assumed role's permissions policy. The credentials are temporary and have a maximum duration of one hour.
+
+image::cloud-experts-sts-explained_highlevel.png[High-level AWS STS workflow for {product-title}]
+
+//The entire workflow is depicted in the following graphic:
+
+//image::cloud-experts-sts-explained_entire_flow_hcp.png[AWS STS entire workflow]
+
+Operators use the following process to obtain the requisite credentials to perform their tasks. 
+
+* Each Operator is assigned an Operator role, a permissions policy, and a trust policy with an OIDC provider. 
+* The Operator will assume the role by passing a JSON web token that contains the role and a token file (`web_identity_token_file`) to the OIDC provider, which then authenticates the signed key with a public key. 
+* The public key is created during cluster creation and stored in an S3 bucket. 
+* The Operator then confirms that the subject in the signed token file matches the role in the role trust policy, which ensures that the OIDC provider can only obtain the allowed role. 
+* The OIDC provider then returns the temporary credentials to the Operator so that the Operator can make AWS API calls. 
+
+For a visual representation, see the following diagram:
+
+image::cloud-experts-sts-explained_oidc_op_roles_hcp.png[OIDC provider and operator roles workflow diagram]

--- a/rosa_architecture/cloud-experts-rosa-hcp-sts-explained.adoc
+++ b/rosa_architecture/cloud-experts-rosa-hcp-sts-explained.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="cloud-experts-rosa-hcp-sts-explained"]
-= AWS STS and ROSA with HCP explained
+= AWS STS and {product-title} explained
 
 include::_attributes/common-attributes.adoc[]
 include::_attributes/attributes-openshift-dedicated.adoc[]
@@ -13,117 +13,37 @@ toc::[]
 //Modified for HCP 2024-4-16
 
 [role="_abstract"]
-{hcp-title-first} uses an AWS (Amazon Web Services) Security Token Service (STS) for AWS Identity Access Management (IAM) to obtain the necessary credentials to interact with resources in your AWS account.
+{product-title} uses the Amazon Web Services (AWS) Security Token Service (STS) for AWS Identity and Access Management (IAM) to obtain the necessary credentials to interact with resources in your AWS account.
 
-[id="credential-methods-rosa-hcp"]
-== AWS STS credential method
-As part of {hcp-title}, Red{nbsp}Hat must be granted the necessary permissions to manage infrastructure resources in your AWS account.
-{hcp-title} IAM STS policies grants the cluster's automation software limited, short-term access to resources in your AWS account.
-
-The STS method uses predefined roles and policies to grant temporary, least-privilege permissions to IAM roles. The credentials typically expire an hour after being requested. Once expired, they are no longer recognized by AWS and no longer have account access to make API requests with them. For more information, see the link:https://docs.aws.amazon.com/STS/latest/APIReference/welcome.html[AWS documentation].
-
-AWS IAM STS roles must be created for each ROSA cluster. The ROSA command-line interface (CLI) (`rosa`) manages the STS roles and helps you attach the ROSA-specific, AWS managed policies to each role. The CLI provides the commands and files to create the roles, attach the AWS-managed policies, and an option to allow the CLI to automatically create the roles and attach the policies. Alternatively, the ROSA CLI can also provide you with the content to prepare the roles and attach the ROSA-specific AWS managed policies.
+include::modules/rosa-hcp-sts-credential-method.adoc[leveloffset=+1]
 
 //See [insert new xref when we have one for HCP] for more information about the different `--mode` options.
 
-[id="hcp-sts-security"]
-== AWS STS security
-Security features for AWS STS include:
+include::modules/rosa-hcp-sts-security.adoc[leveloffset=+1]
 
-* An explicit and limited set of policies that the user creates ahead of time.
-** The user can review every requested permission needed by the platform.
-* The service cannot do anything outside of those permissions.
-* There is no need to rotate or revoke credentials. Whenever the service needs to perform an action, it obtains credentials that expire in one hour or less.
-* Credential expiration reduces the risks of credentials leaking and being reused.
-* The ROSA-specific AWS managed policies are tightly scoped to only allow actions on ROSA-specific AWS resources in your account, within the limits of the AWS API.
+include::modules/rosa-hcp-sts-components.adoc[leveloffset=+1]
 
-ROSA policies grant cluster software components with least-privilege permissions with short-term security credentials to specific and segregated IAM roles. The credentials are associated with IAM roles specific to each component and cluster that makes AWS API calls. This method aligns with principles of least-privilege and secure practices in cloud service resource management.
+include::modules/rosa-hcp-sts-deploying-cluster.adoc[leveloffset=+1]
 
-[id="components-specific-to-rosa-hcp-with-sts"]
-== Components of {hcp-title}
-* *AWS infrastructure* - The infrastructure required for the cluster including the Amazon EC2 instances, Amazon EBS storage, and networking components. See xref:../rosa_architecture/rosa_policy_service_definition/rosa-hcp-service-definition.adoc#rosa-sdpolicy-instance-types_rosa-hcp-service-definition[AWS compute types] to see the supported instance types for compute nodes and xref:../rosa_planning/rosa-sts-aws-prereqs.adoc#rosa-ec2-instances_rosa-sts-aws-prereqs[provisioned AWS infrastructure] for more information on cloud resource configuration.
-* *AWS STS* - A method for granting short-term, dynamic tokens to provide users the necessary permissions to temporarily interact with your AWS account resources.
-* *OpenID Connect (OIDC)* - A mechanism for cluster Operators to authenticate with AWS, assume the cluster roles through a trust policy, and obtain temporary credentials from AWS IAM STS to make the required API calls.
-* *Roles and policies* - The roles and policies used by {hcp-title} can be divided into account-wide roles and policies and Operator roles and policies.
-+
-The policies determine the allowed actions for each of the roles.
-ifdef::openshift-rosa[]
-See xref:../rosa_architecture/rosa-sts-about-iam-resources.adoc#rosa-sts-about-iam-resources[About IAM resources] for more details about the individual roles and policies. See xref:../rosa_planning/rosa-sts-ocm-role.adoc#rosa-sts-ocm-role[ROSA IAM role resource] for more details about trust policies.
-endif::openshift-rosa[]
-ifdef::openshift-rosa-hcp[]
-See xref:../rosa_architecture/rosa-sts-about-iam-resources.adoc#rosa-hcp-about-iam-resources[About IAM resources] for more details about the individual roles and policies. See xref:../rosa_planning/rosa-hcp-prepare-iam-roles-resources.adoc#rosa-hcp-prepare-iam-roles-resources[Required IAM roles and resources] for more details on preparing these resources in your cluster.
-endif::openshift-rosa-hcp[]
-+
---
-** The following account-wide roles are required:
+include::modules/rosa-hcp-sts-workflow.adoc[leveloffset=+1]
 
-*** `<prefix>-HCP-ROSA-Worker-Role`
-*** `<prefix>-HCP-ROSA-Support-Role`
-*** `<prefix>-HCP-ROSA-Installer-Role`
-
-** The following account-wide AWS-managed policies are required:
-
-*** link:https://docs.aws.amazon.com/aws-managed-policy/latest/reference/ROSAInstallerPolicy.html[ROSAInstallerPolicy]
-*** link:https://docs.aws.amazon.com/aws-managed-policy/latest/reference/ROSAWorkerInstancePolicy.html[ROSAWorkerInstancePolicy]
-*** link:https://docs.aws.amazon.com/aws-managed-policy/latest/reference/ROSASRESupportPolicy.html[ROSASRESupportPolicy]
-*** link:https://docs.aws.amazon.com/aws-managed-policy/latest/reference/ROSAIngressOperatorPolicy.html[ROSAIngressOperatorPolicy]
-*** link:https://docs.aws.amazon.com/aws-managed-policy/latest/reference/ROSAAmazonEBSCSIDriverOperatorPolicy.html[ROSAAmazonEBSCSIDriverOperatorPolicy]
-*** link:https://docs.aws.amazon.com/aws-managed-policy/latest/reference/ROSACloudNetworkConfigOperatorPolicy.html[ROSACloudNetworkConfigOperatorPolicy]
-*** link:https://docs.aws.amazon.com/aws-managed-policy/latest/reference/ROSAControlPlaneOperatorPolicy.html[ROSAControlPlaneOperatorPolicy]
-*** link:https://docs.aws.amazon.com/aws-managed-policy/latest/reference/ROSAImageRegistryOperatorPolicy.html[ROSAImageRegistryOperatorPolicy]
-*** link:https://docs.aws.amazon.com/aws-managed-policy/latest/reference/ROSAKMSProviderPolicy.html[ROSAKMSProviderPolicy]
-*** link:https://docs.aws.amazon.com/aws-managed-policy/latest/reference/ROSAKubeControllerPolicy.html[ROSAKubeControllerPolicy]
-*** link:https://docs.aws.amazon.com/aws-managed-policy/latest/reference/ROSAManageSubscription.html[ROSAManageSubscription]
-*** link:https://docs.aws.amazon.com/aws-managed-policy/latest/reference/ROSANodePoolManagementPolicy.html[ROSANodePoolManagementPolicy]
---
-+
-[NOTE]
-====
-Certain policies are used by the cluster Operator roles, listed below. The Operator roles are created in a second step because they are dependent on an existing cluster name and cannot be created at the same time as the account-wide roles.
-====
-+
-** The Operator roles are:
-
-*** <operator_role_prefix>-openshift-cluster-csi-drivers-ebs-cloud-credentials
-*** <operator_role_prefix>-openshift-cloud-network-config-controller-cloud-credentials
-*** <operator_role_prefix>-openshift-machine-api-aws-cloud-credentials
-*** <operator_role_prefix>-openshift-cloud-credential-operator-cloud-credentials
-*** <operator_role_prefix>-openshift-image-registry-installer-cloud-credentials
-*** <operator_role_prefix>-openshift-ingress-operator-cloud-credentials
-+
-** Trust policies are created for each account-wide role and each Operator role.
-
-[id="deploying-rosa-hcp-with-sts-cluster"]
-== Deploying a {hcp-title} cluster
-
-Deploying a {hcp-title} cluster follows the following general steps:
-
-. You create the account-wide roles.
-. You create the Operator roles.
-. Red{nbsp}Hat uses AWS IAM STS to send the required permissions to AWS that allow AWS to create and attach the corresponding AWS-managed Operator policies.
-. You create the OIDC provider.
-. You create the cluster.
-
-During the cluster creation process, the ROSA CLI creates the required JSON files for you and outputs the commands you need. If desired, the ROSA CLI can also run the commands for you.
-
-The ROSA CLI can automatically create the roles for you, or you can manually create them by using the `--mode manual` or `--mode auto` flags. For further details about deployment, see xref:../rosa_hcp/rosa-hcp-sts-creating-a-cluster-quickly.adoc#rosa-sts-creating-cluster-using-customizations_rosa-sts-creating-a-cluster-with-customizations[Creating a cluster with customizations].
-
-[id="hcp-sts-process"]
-== {hcp-title} workflow
-The user creates the required account-wide roles. During role creation, a trust policy, known as a cross-account trust policy, is created which allows a Red{nbsp}Hat-owned role to assume the roles. Trust policies are also created for the EC2 service, which allows workloads on EC2 instances to assume roles and obtain credentials. AWS assigns a corresponding permissions policy to each role.
-
-After both the account-wide operator roles and policies are created, the user can create a cluster. These operator roles are assigned to the corresponding permission policies that were created earlier and a trust policy with an OIDC provider. The operator roles differ from the account-wide roles in that they ultimately represent the in-cluster pods that need access to AWS resources. Because a user cannot attach IAM roles to pods, they must create a trust policy with an OIDC provider so that the Operator, and therefore the pods, can access the roles they need.
-
-image::cloud-experts-sts-explained_creation_flow_hcp.png[]
-
-When a new role is needed, the workload currently using the Red{nbsp}Hat role will assume the role in the AWS account, obtain temporary credentials from AWS STS, and begin performing the actions using API calls within the user's AWS account as permitted by the assumed role's permissions policy. The credentials are temporary and have a maximum duration of one hour.
-
-image::cloud-experts-sts-explained_highlevel.png[]
-
-//The entire workflow is depicted in the following graphic:
-
-//image::cloud-experts-sts-explained_entire_flow_hcp.png[]
-
-Operators use the following process to obtain the requisite credentials to perform their tasks. Each Operator is assigned an Operator role, a permissions policy, and a trust policy with an OIDC provider. The Operator will assume the role by passing a JSON web token that contains the role and a token file (`web_identity_token_file`) to the OIDC provider, which then authenticates the signed key with a public key. The public key is created during cluster creation and stored in an S3 bucket. The Operator then confirms that the subject in the signed token file matches the role in the role trust policy which ensures that the OIDC provider can only obtain the allowed role. The OIDC provider then returns the temporary credentials to the Operator so that the Operator can make AWS API calls. For a visual representation, see the following diagram:
-
-image::cloud-experts-sts-explained_oidc_op_roles_hcp.png[]
+[role="_additional-resources"]
+== Additional resources
+* link:https://docs.aws.amazon.com/STS/latest/APIReference/welcome.html[AWS STS documentation]
+* xref:../rosa_architecture/rosa_policy_service_definition/rosa-hcp-service-definition.adoc#rosa-sdpolicy-instance-types_rosa-hcp-service-definition[AWS compute types]
+* xref:../rosa_planning/rosa-sts-aws-prereqs.adoc#rosa-ec2-instances_rosa-sts-aws-prereqs[Provisioned AWS infrastructure]
+* link:https://docs.aws.amazon.com/aws-managed-policy/latest/reference/ROSAInstallerPolicy.html[`ROSAInstallerPolicy`]
+* link:https://docs.aws.amazon.com/aws-managed-policy/latest/reference/ROSAWorkerInstancePolicy.html[`ROSAWorkerInstancePolicy`]
+* link:https://docs.aws.amazon.com/aws-managed-policy/latest/reference/ROSASRESupportPolicy.html[`ROSASRESupportPolicy`]
+* link:https://docs.aws.amazon.com/aws-managed-policy/latest/reference/ROSAIngressOperatorPolicy.html[`ROSAIngressOperatorPolicy`]
+* link:https://docs.aws.amazon.com/aws-managed-policy/latest/reference/ROSAAmazonEBSCSIDriverOperatorPolicy.html[`ROSAAmazonEBSCSIDriverOperatorPolicy`]
+* link:https://docs.aws.amazon.com/aws-managed-policy/latest/reference/ROSACloudNetworkConfigOperatorPolicy.html[`ROSACloudNetworkConfigOperatorPolicy`]
+* link:https://docs.aws.amazon.com/aws-managed-policy/latest/reference/ROSAControlPlaneOperatorPolicy.html[`ROSAControlPlaneOperatorPolicy`]
+* link:https://docs.aws.amazon.com/aws-managed-policy/latest/reference/ROSAImageRegistryOperatorPolicy.html[`ROSAImageRegistryOperatorPolicy`]
+* link:https://docs.aws.amazon.com/aws-managed-policy/latest/reference/ROSAKMSProviderPolicy.html[`ROSAKMSProviderPolicy`]
+* link:https://docs.aws.amazon.com/aws-managed-policy/latest/reference/ROSAKubeControllerPolicy.html[`ROSAKubeControllerPolicy`]
+* link:https://docs.aws.amazon.com/aws-managed-policy/latest/reference/ROSAManageSubscription.html[`ROSAManageSubscription`]
+* link:https://docs.aws.amazon.com/aws-managed-policy/latest/reference/ROSANodePoolManagementPolicy.html[`ROSANodePoolManagementPolicy`]
+* xref:../rosa_hcp/rosa-hcp-sts-creating-a-cluster-quickly.adoc#rosa-sts-creating-cluster-using-customizations_rosa-sts-creating-a-cluster-with-customizations[Creating a cluster with customizations]
+* xref:../rosa_architecture/rosa-sts-about-iam-resources.adoc#rosa-hcp-about-iam-resources[About IAM resources]
+* xref:../rosa_planning/rosa-hcp-prepare-iam-roles-resources.adoc#rosa-hcp-prepare-iam-roles-resources[Required IAM roles and resources]


### PR DESCRIPTION
Version(s):
4.22+

Issue:
https://redhat.atlassian.net/browse/OSDOCS-16704

Link to docs preview:
[AWS STS and Red Hat OpenShift Service on AWS explained](https://114035--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/rosa_architecture/cloud-experts-rosa-hcp-sts-explained.html)

Peer review:
- [x] Peer reviewer has approved this change.

QE review:
- QE approval not required as no procedural updates for this PR.

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
