### PR TITLE
[OSDOCS-20364]: CQA: Recovering etcd cluster on HCP

### DIFF
--- a/hosted_control_planes/hcp_high_availability/hcp-recovering-etcd-cluster.adoc
+++ b/hosted_control_planes/hcp_high_availability/hcp-recovering-etcd-cluster.adoc
@@ -1,11 +1,12 @@
 :_mod-docs-content-type: ASSEMBLY
+include::_attributes/common-attributes.adoc[]
 [id="hcp-recovering-etcd-cluster"]
 = Recovering an unhealthy etcd cluster for {hcp}
-include::_attributes/common-attributes.adoc[]
 :context: hcp-recovering-etcd-cluster
 
 toc::[]
 
+[role="_abstract"]
 In a highly available control plane, three etcd pods run as a part of a stateful set in an etcd cluster. To recover an etcd cluster, identify unhealthy etcd pods by checking the etcd cluster health.
 
 include::modules/hosted-cluster-etcd-status.adoc[leveloffset=+1]

--- a/modules/hcp-recover-failing-etcd-pods.adoc
+++ b/modules/hcp-recover-failing-etcd-pods.adoc
@@ -6,6 +6,7 @@
 [id="hcp-recover-failing-etcd-pods_{context}"]
 = Recovering a failing etcd pod
 
+[role="_abstract"]
 Each etcd pod of a 3-node cluster has its own persistent volume claim (PVC) to store its data. An etcd pod might fail because of corrupted or missing data. You can recover a failing etcd pod and its PVC.
 
 .Procedure
@@ -17,7 +18,7 @@ Each etcd pod of a 3-node cluster has its own persistent volume claim (PVC) to s
 $ oc get pods -l app=etcd -n clusters-<hosted_cluster_name>
 ----
 +
-`<hosted_cluster_name>`:: Specifies the hosted cluster of the etcd instance.
+Replace `<hosted_cluster_name>` with the name of the hosted cluster of the etcd instance.
 +
 .Example output
 [source,terminal]
@@ -37,7 +38,7 @@ The failing etcd pod might have the `CrashLoopBackOff` or `Error` status.
 $ oc delete pods <etcd_pod_name> -n clusters-<hosted_cluster_name>
 ----
 +
-`<etcd_pod_name>`:: Specifies the failing pod.
+Replace `<etcd_pod_name>` with the name of the failing pod.
 
 .Verification
 

--- a/modules/hosted-cluster-etcd-status.adoc
+++ b/modules/hosted-cluster-etcd-status.adoc
@@ -6,6 +6,7 @@
 [id="hosted-cluster-etcd-status_{context}"]
 = Checking the status of an etcd cluster
 
+[role="_abstract"]
 You can check the status of the etcd cluster health by logging into any etcd pod.
 
 .Procedure


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.20+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://redhat.atlassian.net/browse/OSDOCS-20364
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://114052--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp_high_availability/hcp-recovering-etcd-cluster.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
N/A no technical changes
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
