### PR TITLE
OSDOCS-20280:Update the z-stream RNs for 4.19.35

### DIFF
--- a/modules/zstream-4-19-35.adoc
+++ b/modules/zstream-4-19-35.adoc
@@ -1,0 +1,34 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-19-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-19-35_{context}"]
+= RHSA-2026:27004 - {product-title} {product-version}.35 fixed issues and security update
+
+Issued: 24 June 2026
+
+[role="_abstract"]
+{product-title} release {product-version}.35 is now available. The list of fixed issues that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2026:27004[RHSA-2026:27004] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2026:26999[RHSA-2026:26999] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.19.35 --pullspecs
+----
+
+[id="zstream-4-19-35-fixed-issues_{context}"]
+== Fixed issues
+
+There are no notable fixed issues in this release.
+
+[id="zstream-4-19-35-updating_{context}"]
+== Updating
+
+To update an {product-title} 4.19 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
+
+

--- a/release_notes/ocp-4-19-release-notes.adoc
+++ b/release_notes/ocp-4-19-release-notes.adoc
@@ -2977,7 +2977,10 @@ To save the `vmcore` file, use the `crashkernel` setting to reserve 1024 MB of m
 // 4.19.z about errata updates
 include::modules/ocp-release-asynch-errata-updates.adoc[leveloffset=+1]
 
-// 4.19.33 z-stream RNs full document
+// 4.19.35 z-stream RNs full document
+include::modules/zstream-4-19-35.adoc[leveloffset=+2]
+
+// 4.19.34 z-stream RNs full document
 include::modules/zstream-4-19-34.adoc[leveloffset=+2]
 
 // 4.19.33 z-stream RNs full document


### PR DESCRIPTION
Version(s):
4.19

Issue:
https://redhat.atlassian.net/browse/OSDOCS-20280

Link to docs preview:
https://114072--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-19-release-notes.html#zstream-4-19-35_release-notes

Additional information:
4.19.35 MR: https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/590
ART Dashboard: https://art-dash.engineering.redhat.com/dashboard/release/openshift-4.19?page=1
