### PR TITLE
CNV-83485: Broken verification script in vGPU documentation

### DIFF
--- a/modules/virt-creating-and-exposing-mediated-devices.adoc
+++ b/modules/virt-creating-and-exposing-mediated-devices.adoc
@@ -130,8 +130,5 @@ where:
 +
 [source,terminal]
 ----
-$ oc get node <node_name> -o json \
-  | jq '.status.allocatable \
-  | with_entries(select(.key | startswith("nvidia.com/"))) \
-  | with_entries(select(.value != "0"))'
+$ oc get node <node_name> -o json | jq '.status.allocatable | with_entries(select(.key | startswith("nvidia.com/"))) | with_entries(select(.value != "0"))'
 ----


### PR DESCRIPTION
Resolves: https://redhat.atlassian.net/browse/CNV-83485

CNV 4.21+
OCP 4.21+

Preview: https://114075--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/managing_vms/advanced_vm_management/virt-configuring-virtual-gpus.html#virt-creating-exposing-mediated-devices_virt-configuring-virtual-gpus