### PR TITLE
OBSDOCS-3462: Add documentation for understanding existing logging deployments (6.6)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,11 @@ LOGGING_DOCS_RESTRUCTURE_PLAN.md
 LOGGING_DOCS_SUMMARY.md
 JIRA_HOTSPOTS.md
 OBSDOCS-*_PLAN.md
+# Analysis and working documents (markdown files in root)
+*.md
+!README.md
+!CONTRIBUTING.md
+!CODE_OF_CONDUCT.md
 jira-token
 pull-jira-backlog.sh
 .jira-backlog/

--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -5,6 +5,8 @@ Distros: openshift-logging
 Topics:
 - Name: Logging overview
   File: about-logging
+- Name: Understanding an existing logging deployment
+  File: understanding-existing-deployment
 - Name: Cluster logging support
   File: cluster-logging-support
 - Name: Visualization for logging

--- a/about/understanding-existing-deployment.adoc
+++ b/about/understanding-existing-deployment.adoc
@@ -1,0 +1,29 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="understanding-existing-deployment"]
+= Understanding an existing logging deployment
+include::_attributes/common-attributes.adoc[]
+:context: understanding-existing-deployment
+
+toc::[]
+
+[role="_abstract"]
+If you inherit a cluster with logging already configured, understand the current deployment before making changes. You can discover what logging components are installed, understand how logs are collected and forwarded, verify that the deployment is healthy, and audit storage and access control settings.
+
+include::modules/discovering-logging-deployment.adoc[leveloffset=+1]
+
+include::modules/listing-logging-components.adoc[leveloffset=+1]
+
+include::modules/understanding-log-forwarding-configuration.adoc[leveloffset=+1]
+
+include::modules/checking-logging-deployment-health.adoc[leveloffset=+1]
+
+include::modules/auditing-log-storage-and-retention.adoc[leveloffset=+1]
+
+include::modules/understanding-log-access-control.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+== Additional resources
+
+* xref:../about/about-logging.adoc#about-logging[{product-title} overview]
+* xref:../configuring/configuring-log-forwarding.adoc#configuring-log-forwarding[Configuring log forwarding]
+* xref:../configuring/configuring-the-log-store.adoc#configuring-the-log-store[Configuring the log store]

--- a/modules/auditing-log-storage-and-retention.adoc
+++ b/modules/auditing-log-storage-and-retention.adoc
@@ -1,0 +1,139 @@
+// Module included in the following assemblies:
+//
+// * about/understanding-existing-deployment.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="auditing-log-storage-and-retention_{context}"]
+= Auditing log storage and retention
+
+[role="_abstract"]
+Understanding storage configuration helps you assess costs, plan capacity, and ensure that retention policies meet compliance requirements.
+
+.Procedure
+
+. Check if `LokiStack` stores logs in-cluster:
++
+[source,terminal]
+----
+$ oc get lokistack -A
+----
++
+If a `LokiStack` exists, it is configured to store logs in-cluster. If not, the collector forwards all logs to external destinations.
+
+. View the `LokiStack` size tier:
++
+[source,terminal]
+----
+$ oc get lokistack logging-loki -n openshift-logging \
+  -o jsonpath='{.spec.size}'
+----
++
+[NOTE]
+====
+This example uses `logging-loki` as the `LokiStack` name. If you used a different name, replace `logging-loki` with your actual `LokiStack` name.
+====
++
+.Example output
+[source,terminal]
+----
+1x.small
+----
++
+The size tier determines the resource allocation and ingestion rate capacity.
+
+. Check the object storage configuration:
++
+[source,terminal]
+----
+$ oc get lokistack logging-loki -n openshift-logging \
+  -o jsonpath='{.spec.storage}' | python3 -m json.tool
+----
++
+.Example output
+[source,json]
+----
+{
+    "schemas": [
+        {
+            "effectiveDate": "2023-12-16",
+            "version": "v13"
+        }
+    ],
+    "secret": {
+        "name": "logging-loki-s3",
+        "type": "s3"
+    }
+}
+----
++
+This shows the secret that contains the S3-compatible object storage configuration. The `LokiStack` requires both PVC storage (for indexes) and object storage (for log data).
+
+. View retention policies:
++
+[source,terminal]
+----
+$ oc get lokistack logging-loki -n openshift-logging \
+  -o jsonpath='{.spec.limits.global.retention}' | python3 -m json.tool
+----
++
+.Example output
+[source,json]
+----
+{
+    "days": 7,
+    "streams": [
+        {
+            "days": 30,
+            "priority": 1,
+            "selector": "{log_type=\"audit\"}"
+        }
+    ]
+}
+----
++
+This output shows:
++
+* Global retention: 7 days for all logs
+* Audit logs: 30 days retention (overrides global)
+
+. Check PVC storage consumption:
++
+[source,terminal]
+----
+$ oc get pvc -n openshift-logging -l app.kubernetes.io/name=lokistack
+----
++
+.Example output
+[source,terminal]
+----
+NAME                                     STATUS   VOLUME                CAPACITY   ACCESS MODES
+storage-logging-compactor-0              Bound    pvc-abc123            10Gi       RWO
+storage-logging-index-gateway-0          Bound    pvc-def456            10Gi       RWO
+storage-logging-ingester-0               Bound    pvc-ghi789            10Gi       RWO
+storage-logging-querier-0                Bound    pvc-jkl012            10Gi       RWO
+----
++
+This shows the persistent volume claims for `LokiStack` components. The `CAPACITY` column shows allocated storage.
+
+. View PVC usage percentage using a PromQL query in the web console (*Observe* > *Metrics*):
++
+[source,terminal]
+----
+(
+  kubelet_volume_stats_used_bytes{namespace="openshift-logging", persistentvolumeclaim=~"storage-logging.*"}
+  /
+  kubelet_volume_stats_capacity_bytes{namespace="openshift-logging", persistentvolumeclaim=~"storage-logging.*"}
+) * 100
+----
++
+This shows the percentage of used storage for each `LokiStack` PVC.
+
+. If the collector forwards logs to external destinations, list the output configurations:
++
+[source,terminal]
+----
+$ oc get clusterlogforwarder instance -n openshift-logging \
+  -o jsonpath='{range .spec.outputs[*]}{.name}{"\t"}{.type}{"\t"}{.url}{"\n"}{end}'
+----
++
+This shows where the collector sends logs externally. Those systems manage retention for external destinations, not OpenShift Logging.

--- a/modules/checking-logging-deployment-health.adoc
+++ b/modules/checking-logging-deployment-health.adoc
@@ -1,0 +1,120 @@
+// Module included in the following assemblies:
+//
+// * about/understanding-existing-deployment.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="checking-logging-deployment-health_{context}"]
+= Checking logging deployment health
+
+[role="_abstract"]
+After understanding the logging configuration, verify that all components are running and logs are flowing correctly.
+
+.Procedure
+
+. Check the `ClusterLogForwarder` status conditions:
++
+[source,terminal]
+----
+$ oc get clusterlogforwarder instance -n openshift-logging \
+  -o jsonpath='{.status.conditions}' | python3 -m json.tool
+----
++
+.Example healthy output
+[source,json]
+----
+[
+    {
+        "lastTransitionTime": "2026-06-01T14:52:07Z",
+        "message": "permitted to collect log types: [application audit infrastructure]",
+        "reason": "ClusterRolesExist",
+        "status": "True",
+        "type": "observability.openshift.io/Authorized"
+    },
+    {
+        "lastTransitionTime": "2026-06-01T14:52:07Z",
+        "message": "",
+        "reason": "ValidationSuccess",
+        "status": "True",
+        "type": "observability.openshift.io/Valid"
+    },
+    {
+        "lastTransitionTime": "2026-06-01T14:52:07Z",
+        "message": "",
+        "reason": "ReconciliationComplete",
+        "status": "True",
+        "type": "Ready"
+    }
+]
+----
++
+All three conditions should show `"status": "True"`:
++
+* `Authorized` confirms the collector service account has required permissions
+* `Valid` confirms the `ClusterLogForwarder` configuration is correct
+* `Ready` confirms the Operator successfully reconciled the configuration
++
+If any condition shows `"status": "False"`, check the `message` field for details.
+
+. Verify that collector pods are running:
++
+[source,terminal]
+----
+$ oc get pods -n openshift-logging -l app.kubernetes.io/component=collector
+----
++
+.Example output
+[source,terminal]
+----
+NAME               READY   STATUS    RESTARTS   AGE
+instance-abc123    1/1     Running   0          45d
+instance-def456    1/1     Running   0          45d
+instance-ghi789    1/1     Running   0          45d
+----
++
+You should see one collector pod per cluster node. All pods should show `Running` status and `1/1` ready.
+
+. If a `LokiStack` exists, check its status:
++
+[source,terminal]
+----
+$ oc get lokistack logging-loki -n openshift-logging \
+  -o jsonpath='{.status.conditions}' | python3 -m json.tool
+----
++
+[NOTE]
+====
+This example uses `logging-loki` as the `LokiStack` name, which is the default name shown in the installation documentation. If you used a different name when creating your `LokiStack`, replace `logging-loki` with your actual `LokiStack` name. You can list all `LokiStack` instances by running:
+
+[source,terminal]
+----
+$ oc get lokistack -n openshift-logging
+----
+====
++
+Look for the `Ready` condition with `"status": "True"`.
+
+. Verify that logs are flowing by checking recent log entries in the web console:
+.. In the {ocp-product-title} web console, go to *Observe* > *Logs*.
+.. Select a log type such as *infrastructure*.
+.. Verify that recent log entries appear with timestamps from the last few minutes.
++
+If no logs appear, check the collector pod logs for errors:
++
+[source,terminal]
+----
+$ oc logs -n openshift-logging -l app.kubernetes.io/component=collector --tail=50
+----
+
+. Check for common error messages in collector logs:
++
+[source,terminal]
+----
+$ oc logs -n openshift-logging -l app.kubernetes.io/component=collector --tail=200 \
+  | grep -i "error\|failed\|certificate\|connection"
+----
++
+Common issues:
++
+* Certificate errors indicate missing or incorrect TLS configuration
+* Connection errors indicate network issues reaching output destinations
+* Authorization errors indicate missing `ClusterRoleBindings`

--- a/modules/discovering-logging-deployment.adoc
+++ b/modules/discovering-logging-deployment.adoc
@@ -1,0 +1,33 @@
+// Module included in the following assemblies:
+//
+// * about/understanding-existing-deployment.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="discovering-logging-deployment_{context}"]
+= Discovering your logging deployment
+
+[role="_abstract"]
+When you inherit a cluster with logging already configured, start by identifying which logging components exist and their configuration. OpenShift Logging consists of up to three operators, each managing a different aspect of the logging stack.
+
+The logging stack components are:
+
+{clo}::
+Manages log collection and forwarding. When installed, it creates a `ClusterLogForwarder` custom resource that defines what logs to collect and where to send them.
+
+{loki-op}::
+Manages the log store when using in-cluster storage. When installed, it creates a `LokiStack` custom resource that defines storage configuration, sizing, and retention policies.
+
+{coo-first}::
+Manages visualization in the {ocp-product-title} web console. When installed, it adds the *Logs* tab under *Observe* > *Logs*.
+
+Understanding which operators exist tells you:
+
+* Whether the collector gathers logs (requires {clo})
+* Whether `LokiStack` stores logs in-cluster or the collector forwards them externally
+* Whether you can view logs in the web console (requires {coo-short})
+
+After identifying installed operators, examine the custom resources they manage to understand the specific configuration:
+
+* `ClusterLogForwarder` - Defines log collection sources (inputs), destinations (outputs), and routing (pipelines)
+* `LokiStack` - Defines in-cluster log storage configuration, sizing, and retention
+* `UIPlugin` - Enables log visualization in the web console

--- a/modules/listing-logging-components.adoc
+++ b/modules/listing-logging-components.adoc
@@ -1,0 +1,100 @@
+// Module included in the following assemblies:
+//
+// * about/understanding-existing-deployment.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="listing-logging-components_{context}"]
+= Listing logging components
+
+[role="_abstract"]
+You can identify which logging operators exist and which custom resources they created by querying the cluster.
+
+.Procedure
+
+. Check which logging operators exist:
++
+[source,terminal]
+----
+$ oc get deployment -n openshift-logging cluster-logging-operator \
+  -o jsonpath='{.metadata.name}{"\n"}' 2>/dev/null || echo "Cluster Logging Operator not found"
+----
++
+[source,terminal]
+----
+$ oc get deployment -n openshift-operators-redhat loki-operator-controller-manager \
+  -o jsonpath='{.metadata.name}{"\n"}' 2>/dev/null || echo "Loki Operator not found"
+----
++
+[source,terminal]
+----
+$ oc get deployment -n openshift-cluster-observability-operator \
+  cluster-observability-operator \
+  -o jsonpath='{.metadata.name}{"\n"}' 2>/dev/null || echo "Cluster Observability Operator not found"
+----
+
+. List the `ClusterLogForwarder` resources:
++
+[source,terminal]
+----
+$ oc get clusterlogforwarder -A
+----
++
+.Example output
+[source,terminal]
+----
+NAMESPACE          NAME       AGE
+openshift-logging  instance   45d
+----
++
+The `ClusterLogForwarder` named `instance` in the `openshift-logging` namespace is the default log forwarder.
+
+. List the `LokiStack` resources:
++
+[source,terminal]
+----
+$ oc get lokistack -A
+----
++
+.Example output
+[source,terminal]
+----
+NAMESPACE          NAME      AGE
+openshift-logging  logging   45d
+----
++
+If no `LokiStack` exists, the collector forwards logs to external destinations only.
+
+. List the `UIPlugin` resources:
++
+[source,terminal]
+----
+$ oc get uiplugin logging
+----
++
+.Example output
+[source,terminal]
+----
+logging   45d
+----
++
+If no logging `UIPlugin` exists, the *Logs* tab is not available in the web console.
+
+. Get the versions of the installed operators:
++
+[source,terminal]
+----
+$ oc get csv -n openshift-logging -l operators.coreos.com/cluster-logging.openshift-logging \
+  -o jsonpath='{.items[0].spec.version}{"\n"}'
+----
++
+[source,terminal]
+----
+$ oc get csv -n openshift-operators-redhat -l operators.coreos.com/loki-operator.openshift-operators-redhat \
+  -o jsonpath='{.items[0].spec.version}{"\n"}'
+----
++
+[source,terminal]
+----
+$ oc get csv -n openshift-cluster-observability-operator -l operators.coreos.com/cluster-observability-operator.openshift-cluster-observability-operator \
+  -o jsonpath='{.items[0].spec.version}{"\n"}'
+----

--- a/modules/understanding-log-access-control.adoc
+++ b/modules/understanding-log-access-control.adoc
@@ -1,0 +1,116 @@
+// Module included in the following assemblies:
+//
+// * about/understanding-existing-deployment.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="understanding-log-access-control_{context}"]
+= Understanding log access control
+
+[role="_abstract"]
+Log access control determines who can view logs in the web console and through the `LokiStack` API. Understanding the current access control configuration helps you assess security posture and plan changes.
+
+.Procedure
+
+. Check if tenant mode is enabled:
++
+[source,terminal]
+----
+$ oc get lokistack logging-loki -n openshift-logging \
+  -o jsonpath='{.spec.tenants.mode}'
+----
++
+[NOTE]
+====
+This example uses `logging-loki` as the `LokiStack` name. If you used a different name, replace `logging-loki` with your actual `LokiStack` name.
+====
++
+.Example output
+[source,terminal]
+----
+openshift-logging
+----
++
+* `openshift-logging` (or `dynamic`): Fine-grained access control is enabled. Users can query logs based on their namespace access.
+* If the command returns empty or the `LokiStack` does not exist, external systems manage access control.
+
+. View the collector service account:
++
+[source,terminal]
+----
+$ oc get clusterlogforwarder instance -n openshift-logging \
+  -o jsonpath='{.spec.serviceAccount.name}'
+----
++
+This service account must have `ClusterRoleBindings` for the log types it collects.
+
+. Check which log types the collector is authorized to collect:
++
+[source,terminal]
+----
+$ oc get clusterlogforwarder instance -n openshift-logging \
+  -o jsonpath='{.status.conditions[?(@.type=="observability.openshift.io/Authorized")].message}'
+----
++
+.Example output
+[source,terminal]
+----
+permitted to collect log types: [application audit infrastructure]
+----
+
+. List the `ClusterRoleBindings` for the collector service account:
++
+First, get the service account name from the `ClusterLogForwarder`:
++
+[source,terminal]
+----
+$ SA_NAME=$(oc get clusterlogforwarder instance -n openshift-logging \
+  -o jsonpath='{.spec.serviceAccount.name}')
+----
++
+Then list the `ClusterRoleBindings` for that service account:
++
+[source,terminal]
+----
+$ oc get clusterrolebinding -o json | \
+  jq -r ".items[] | select(.subjects[]?.name==\"$SA_NAME\") | .metadata.name"
+----
++
+.Example output
+[source,terminal]
+----
+logcollector-application
+logcollector-audit
+logcollector-infrastructure
+----
++
+Each `ClusterRoleBinding` grants permission to collect a specific log type.
+
+. Check namespace-level access to logs (when tenant mode is enabled):
++
+[source,terminal]
+----
+$ oc get rolebinding -n _<namespace>_ -o json | \
+  jq -r '.items[] | select(.roleRef.name=="cluster-logging-application-view") | {name: .metadata.name, subjects: .subjects}'
+----
++
+Replace `_<namespace>_` with a specific namespace to check. This shows which users or service accounts can view application logs from that namespace.
+
+. List users with cluster-wide log access:
++
+[source,terminal]
+----
+$ oc get clusterrolebinding -o json | \
+  jq -r '.items[] | select(.roleRef.name=="cluster-logging-application-view") | {name: .metadata.name, subjects: .subjects}'
+----
++
+This shows cluster-level bindings that grant log access across all namespaces.
+
+. If using an external log destination, check the output authentication configuration:
++
+[source,terminal]
+----
+$ oc get clusterlogforwarder instance -n openshift-logging \
+  -o jsonpath='{range .spec.outputs[*]}{.name}{"\t"}{.type}{"\t"}{.authentication}{"\n"}{end}'
+----
++
+This shows how the collector authenticates to external destinations. Secrets store sensitive credentials.

--- a/modules/understanding-log-forwarding-configuration.adoc
+++ b/modules/understanding-log-forwarding-configuration.adoc
@@ -1,0 +1,130 @@
+// Module included in the following assemblies:
+//
+// * about/understanding-existing-deployment.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="understanding-log-forwarding-configuration_{context}"]
+= Understanding log forwarding configuration
+
+[role="_abstract"]
+The `ClusterLogForwarder` custom resource defines which logs to collect, where to send them, and how to process them. You can examine the configuration to understand the current log flow.
+
+.Procedure
+
+. View the complete `ClusterLogForwarder` configuration:
++
+[source,terminal]
+----
+$ oc get clusterlogforwarder instance -n openshift-logging -o yaml
+----
+
+. Identify which logs the collector gathers by examining the `spec.pipelines` section:
++
+[source,terminal]
+----
+$ oc get clusterlogforwarder instance -n openshift-logging \
+  -o jsonpath='{range .spec.pipelines[*]}{.inputRefs[*]}{"\n"}{end}' | sort -u
+----
++
+.Example output
+[source,terminal]
+----
+application
+audit
+infrastructure
+----
++
+The default log input types are:
++
+* `application` - Logs from application containers
+* `infrastructure` - Logs from OpenShift and Kubernetes infrastructure components
+* `audit` - Audit logs from the Kubernetes API server, node audit, and OpenShift OAuth
++
+These inputs exist by default and do not need to be defined in `spec.inputs`. Custom inputs in `spec.inputs` are used to filter logs or define receivers for non-cluster sources.
+
+. Identify where the collector sends logs by examining the `spec.outputs` section:
++
+[source,terminal]
+----
+$ oc get clusterlogforwarder instance -n openshift-logging \
+  -o jsonpath='{range .spec.outputs[*]}{.name}{"\t"}{.type}{"\n"}{end}'
+----
++
+.Example output
+[source,terminal]
+----
+default-lokistack	lokiStack
+splunk-prod	        splunk
+----
++
+This output shows logs are sent to both a `LokiStack` and an external Splunk instance.
+
+. Understand how the pipelines route logs by examining the `spec.pipelines` section:
++
+[source,terminal]
+----
+$ oc get clusterlogforwarder instance -n openshift-logging \
+  -o jsonpath='{range .spec.pipelines[*]}{.name}{"\n  inputs: "}{.inputRefs}{"\n  outputs: "}{.outputRefs}{"\n"}{end}'
+----
++
+.Example output
+[source,terminal]
+----
+application-logs
+  inputs: [application]
+  outputs: [default-lokistack]
+infrastructure-logs
+  inputs: [infrastructure]
+  outputs: [default-lokistack]
+audit-logs
+  inputs: [audit]
+  outputs: [default-lokistack splunk-prod]
+----
++
+This output shows that:
++
+* Application logs go to the `LokiStack`
+* Infrastructure logs go to the `LokiStack`
+* Audit logs go to both the `LokiStack` and Splunk
+
+. Check if any filters are applied:
++
+[source,terminal]
+----
+$ oc get clusterlogforwarder instance -n openshift-logging \
+  -o jsonpath='{.spec.filters}'
+----
++
+If the output is empty or `null`, no filters are configured. Filters can drop or modify log records before forwarding.
+
+. Check if any receivers are configured to accept logs from non-cluster sources:
++
+[source,terminal]
+----
+$ oc get clusterlogforwarder instance -n openshift-logging \
+  -o jsonpath='{.spec.inputs[?(@.receiver)].name}'
+----
++
+If output appears, the `ClusterLogForwarder` includes receivers that accept logs from external sources via HTTP or other protocols. View the receiver configuration with:
++
+[source,terminal]
+----
+$ oc get clusterlogforwarder instance -n openshift-logging \
+  -o jsonpath='{.spec.inputs[?(@.receiver)]}' | python3 -m json.tool
+----
+
+. Identify which service account has collector permissions:
++
+[source,terminal]
+----
+$ oc get clusterlogforwarder instance -n openshift-logging \
+  -o jsonpath='{.spec.serviceAccount.name}'
+----
++
+.Example output
+[source,terminal]
+----
+logcollector
+----
++
+This service account must have the appropriate `ClusterRoleBindings` for the log types being collected.


### PR DESCRIPTION
Cherry-pick of #112369 to standalone-logging-docs-6.6

Adds documentation for understanding existing logging deployments, including:
- Discovering logging components
- Checking deployment health
- Understanding log forwarding configuration
- Auditing log storage and retention
- Understanding log access control

Original PR: https://github.com/openshift/openshift-docs/pull/112369