### PR TITLE
OBSDOCS-3529: Document quoting special characters in prune filter field paths

### DIFF
--- a/modules/adding-a-prune-filter.adoc
+++ b/modules/adding-a-prune-filter.adoc
@@ -27,6 +27,23 @@ spec:
 +
 `prune.notIn`:: Fields to keep. The collector removes all other fields.
 +
+[NOTE]
+====
+Field paths use dot-delimited notation. Path segments can contain alphanumeric characters and underscores (`a-z`, `A-Z`, `0-9`, `_`). If a segment contains any other characters (such as hyphens, periods, or slashes), enclose that segment in double quotes.
+
+For example, to keep a label with the key `foo-bar/baz`:
+
+[source,yaml]
+----
+spec:
+  filters:
+  - name: keep-instance-label
+    type: prune
+    prune:
+      notIn: [.kubernetes.labels."foo-bar/baz"]
+----
+====
++
 [IMPORTANT]
 ====
 You cannot prune the following required fields: `.log_type`, `.log_source`, `.message`, `.kubernetes.namespace_name`, `.kubernetes.pod_name`, `.kubernetes.container_name`, and `.level`. If you try to prune these required fields, the Operator accepts the CR but sets the validation condition to `False`.

--- a/modules/clf-filters-reference.adoc
+++ b/modules/clf-filters-reference.adoc
@@ -43,6 +43,11 @@ The prune filter supports two modes:
 +
 **Use case**: Security officers must prune personally identifiable information (PII) from logs before forwarding them to third-party SaaS providers to ensure data sovereignty and compliance with privacy regulations.
 +
+[NOTE]
+====
+Field paths use dot-delimited notation. Path segments can contain alphanumeric characters and underscores (`a-z`, `A-Z`, `0-9`, `_`). If a segment contains any other characters (such as hyphens, periods, or slashes), enclose that segment in double quotes. For example, to keep a label with the key `foo-bar/baz`, use `.kubernetes.labels."foo-bar/baz"`.
+====
++
 [IMPORTANT]
 ====
 You cannot prune the following required fields: `.log_type`, `.log_source`, `.message`, `.kubernetes.namespace_name`, `.kubernetes.pod_name`, `.kubernetes.container_name`, and `.level`. If you try to prune these required fields, the Operator accepts the CR but sets the validation condition to `False`.


### PR DESCRIPTION
## Summary

Adds documentation for how to handle label keys and field paths that contain special characters (hyphens, periods, slashes) in prune filter configurations.

## Changes

Without this documentation, users attempting to use  with labels like `foo-bar.com/instanceId` will have the field incorrectly pruned because the collector cannot parse the unquoted field path.

Updated two modules:
1. **adding-a-prune-filter.adoc**: Added NOTE block with detailed example showing quoted segments
2. **clf-filters-reference.adoc**: Added NOTE explaining the quoting requirement

## Example

The documentation now shows that label keys with special characters must be quoted:

```yaml
spec:
  filters:
  - name: keep-instance-label
    type: prune
    prune:
      notIn: [.kubernetes.labels."foo-bar.com/instanceId"]
```

- Jira: https://redhat.atlassian.net/browse/OBSDOCS-3529
- Versions: 6.6, 6.5, 6.4

Signed-off-by: John Wilkins <jowilkin@redhat.com>