### PR TITLE
OBSDOCS-3530: Add per-component LokiStack resource tables for capacity planning

### DIFF
--- a/installing/loki-deployment-sizing.adoc
+++ b/installing/loki-deployment-sizing.adoc
@@ -13,6 +13,18 @@ include::modules/understanding-loki-sizing.adoc[leveloffset=+1]
 
 include::modules/loki-sizing.adoc[leveloffset=+1]
 
+include::modules/loki-sizing-1x-demo.adoc[leveloffset=+2]
+
+include::modules/loki-sizing-1x-pico.adoc[leveloffset=+2]
+
+include::modules/loki-sizing-1x-extra-small.adoc[leveloffset=+2]
+
+include::modules/loki-sizing-1x-small.adoc[leveloffset=+2]
+
+include::modules/loki-sizing-1x-medium.adoc[leveloffset=+2]
+
+include::modules/loki-sizing-interpretation-guide.adoc[leveloffset=+2]
+
 [role="_additional-resources"]
 [id="additional-resources_loki-deployment-sizing"]
 == Additional resources

--- a/modules/loki-sizing-1x-demo.adoc
+++ b/modules/loki-sizing-1x-demo.adoc
@@ -1,0 +1,27 @@
+// Module is included in the following assemblies:
+//
+// * installing/loki-deployment-sizing.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="loki-sizing-1x-demo_{context}"]
+= 1x.demo size component resources
+
+[role="_abstract"]
+The 1x.demo size demonstrates logging functionality only and does not offer high availability.
+
+.Component resource requirements for 1x.demo
+[cols="2,1,1,1,2,2,2",options="header"]
+|===
+|Component |CPU Request |Memory Request |Replicas |Total CPU |Total Memory |Disk per Pod
+
+|Compactor |None |None |1 |None |None |10Gi
+|Distributor |None |None |1 |None |None |None
+|Gateway |None |None |2 |None |None |None
+|Index Gateway |None |None |1 |None |None |10Gi
+|Ingester |None |None |1 |None |None |10Gi
+|Querier |None |None |1 |None |None |None
+|Query front end |None |None |1 |None |None |None
+4+|*Subtotal (without ruler)* |*None* |*None* |*40Gi*
+|Ruler |None |None |1 |None |None |10Gi
+4+|*Subtotal (with ruler)* |*None* |*None* |*60Gi*
+|===

--- a/modules/loki-sizing-1x-extra-small.adoc
+++ b/modules/loki-sizing-1x-extra-small.adoc
@@ -1,0 +1,32 @@
+// Module is included in the following assemblies:
+//
+// * installing/loki-deployment-sizing.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="loki-sizing-1x-extra-small_{context}"]
+= 1x.extra-small size component resources
+
+[role="_abstract"]
+The 1x.extra-small size supports 100 GB per day log ingestion with high availability (replication factor 2).
+
+.Component resource requirements for 1x.extra-small
+[cols="2,1,1,1,2,2,2",options="header"]
+|===
+|Component |CPU Request |Memory Request |Replicas |Total CPU |Total Memory |Disk per Pod
+
+|Compactor |1 |2Gi |1 |1 |2Gi |10Gi
+|Distributor |1 |1Gi |2 |2 |2Gi |None
+|Gateway |500m |500Mi |2 |1 |1Gi |None
+|Index Gateway |500m |1Gi |2 |1 |2Gi |50Gi
+|Ingester |1 |5.25Gi |3 |3 |15.75Gi |10Gi
+|Querier |1.5 |3Gi |2 |3 |6Gi |None
+|Query front end |1 |1Gi |2 |2 |2Gi |None
+4+|*Subtotal (without ruler)* |*13 vCPUs* |*30.75Gi* |*180Gi*
+|Ruler |1 |2Gi |2 |2 |4Gi |10Gi
+4+|*Subtotal (with ruler)* |*15 vCPUs* |*34.75Gi* |*200Gi*
+|===
+
+[NOTE]
+====
+Write-Ahead Log (WAL) storage requires an additional 150Gi persistent volume shared across ingester pods.
+====

--- a/modules/loki-sizing-1x-medium.adoc
+++ b/modules/loki-sizing-1x-medium.adoc
@@ -1,0 +1,32 @@
+// Module is included in the following assemblies:
+//
+// * installing/loki-deployment-sizing.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="loki-sizing-1x-medium_{context}"]
+= 1x.medium size component resources
+
+[role="_abstract"]
+The 1x.medium size supports 2 TB per day log ingestion with high availability (replication factor 2).
+
+.Component resource requirements for 1x.medium
+[cols="2,1,1,1,2,2,2",options="header"]
+|===
+|Component |CPU Request |Memory Request |Replicas |Total CPU |Total Memory |Disk per Pod
+
+|Compactor |2 |4Gi |1 |2 |4Gi |10Gi
+|Distributor |2 |2Gi |2 |4 |4Gi |None
+|Gateway |1 |1Gi |2 |2 |2Gi |None
+|Index Gateway |1 |2Gi |2 |2 |4Gi |50Gi
+|Ingester |6 |30Gi |3 |18 |90Gi |10Gi
+|Querier |6 |10Gi |3 |18 |30Gi |None
+|Query front end |4 |2.5Gi |2 |8 |5Gi |None
+4+|*Subtotal (without ruler)* |*54 vCPUs* |*139Gi* |*180Gi*
+|Ruler |8 |16Gi |2 |16 |32Gi |10Gi
+4+|*Subtotal (with ruler)* |*70 vCPUs* |*171Gi* |*200Gi*
+|===
+
+[NOTE]
+====
+Write-Ahead Log (WAL) storage requires an additional 150Gi persistent volume shared across ingester pods.
+====

--- a/modules/loki-sizing-1x-pico.adoc
+++ b/modules/loki-sizing-1x-pico.adoc
@@ -1,0 +1,32 @@
+// Module is included in the following assemblies:
+//
+// * installing/loki-deployment-sizing.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="loki-sizing-1x-pico_{context}"]
+= 1x.pico size component resources
+
+[role="_abstract"]
+The 1x.pico size supports 50 GB per day log ingestion with high availability (replication factor 2).
+
+.Component resource requirements for 1x.pico
+[cols="2,1,1,1,2,2,2",options="header"]
+|===
+|Component |CPU Request |Memory Request |Replicas |Total CPU |Total Memory |Disk per Pod
+
+|Compactor |500m |500Mi |1 |500m |500Mi |10Gi
+|Distributor |500m |500Mi |2 |1 |1Gi |None
+|Gateway |500m |500Mi |2 |1 |1Gi |None
+|Index Gateway |150m |250Mi |2 |300m |500Mi |50Gi
+|Ingester |500m |3Gi |3 |1.5 |9Gi |10Gi
+|Querier |750m |1.5Gi |2 |1.5 |3Gi |None
+|Query front end |500m |500Mi |2 |1 |1Gi |None
+4+|*Subtotal (without ruler)* |*6.8 vCPUs* |*16.5Gi* |*180Gi*
+|Ruler |500m |1Gi |2 |1 |2Gi |10Gi
+4+|*Subtotal (with ruler)* |*7.8 vCPUs* |*18.5Gi* |*200Gi*
+|===
+
+[NOTE]
+====
+Write-Ahead Log (WAL) storage requires an additional 150Gi persistent volume shared across ingester pods.
+====

--- a/modules/loki-sizing-1x-small.adoc
+++ b/modules/loki-sizing-1x-small.adoc
@@ -1,0 +1,32 @@
+// Module is included in the following assemblies:
+//
+// * installing/loki-deployment-sizing.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="loki-sizing-1x-small_{context}"]
+= 1x.small size component resources
+
+[role="_abstract"]
+The 1x.small size supports 500 GB per day log ingestion with high availability (replication factor 2).
+
+.Component resource requirements for 1x.small
+[cols="2,1,1,1,2,2,2",options="header"]
+|===
+|Component |CPU Request |Memory Request |Replicas |Total CPU |Total Memory |Disk per Pod
+
+|Compactor |2 |4Gi |1 |2 |4Gi |10Gi
+|Distributor |2 |2Gi |2 |4 |4Gi |None
+|Gateway |1 |1Gi |2 |2 |2Gi |None
+|Index Gateway |1 |2Gi |2 |2 |4Gi |50Gi
+|Ingester |2.5 |13.25Gi |3 |7.5 |39.75Gi |10Gi
+|Querier |4 |4Gi |2 |8 |8Gi |None
+|Query front end |4 |2.5Gi |2 |8 |5Gi |None
+4+|*Subtotal (without ruler)* |*33.5 vCPUs* |*66.75Gi* |*180Gi*
+|Ruler |4 |8Gi |2 |8 |16Gi |10Gi
+4+|*Subtotal (with ruler)* |*41.5 vCPUs* |*82.75Gi* |*200Gi*
+|===
+
+[NOTE]
+====
+Write-Ahead Log (WAL) storage requires an additional 150Gi persistent volume shared across ingester pods.
+====

--- a/modules/loki-sizing-interpretation-guide.adoc
+++ b/modules/loki-sizing-interpretation-guide.adoc
@@ -1,0 +1,36 @@
+// Module is included in the following assemblies:
+//
+// * installing/loki-deployment-sizing.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="loki-sizing-interpretation-guide_{context}"]
+= Interpreting component resource tables
+
+[role="_abstract"]
+The following field definitions help you understand the per-component resource tables for each LokiStack deployment size.
+
+CPU Request::
+CPU cores requested per pod. Values with m suffix indicate millicores (for example, 500m = 0.5 cores). Whole numbers indicate full cores.
+
+Memory Request::
+Memory requested per pod. Values use Mi (mebibytes) or Gi (gibibytes) suffixes.
+
+Replicas::
+Number of pod instances deployed for this component. Higher replica counts offer fault tolerance and distribute load.
+
+Total CPU::
+CPU Request multiplied by Replicas. This is the total CPU reservation for all pods of this component.
+
+Total Memory::
+Memory Request multiplied by Replicas. This is the total memory reservation for all pods of this component.
+
+Disk per Pod::
+Persistent volume size requested per pod. Not all components require persistent storage. Ingester, Index Gateway, Compactor, and Ruler components use persistent volumes.
+
+[IMPORTANT]
+====
+* The subtotals match the total sizing table values within rounding tolerances.
+* Write-Ahead Log (WAL) storage shares space across ingester pods and requires a separate 150Gi persistent volume for all sizes except 1x.demo, which requires 10Gi.
+* The ruler component is optional. If you enable alerting or recording rules, include the ruler resources in your capacity planning.
+* Resource requests are guaranteed minimums. Actual usage might be higher during peak load or complex queries.
+====

--- a/modules/loki-sizing.adoc
+++ b/modules/loki-sizing.adoc
@@ -7,9 +7,10 @@
 [id="loki-sizing_{context}"]
 = Loki deployment sizing
 
-Sizing for Loki follows the format of `1x.<size>` where the value `1x` is number of instances and `<size>` specifies performance capabilities.
+[role="_abstract"]
+Sizing for Loki follows the format of 1x._<size>_ where the value 1x is number of instances and _<size>_ specifies performance capabilities.
 
-The `1x.pico` configuration defines a single Loki deployment with minimal resource and limit requirements, offering high availability (HA) support for all Loki components. This configuration is suited for deployments that do not require a single replication factor or auto-compaction.
+The 1x.pico configuration defines a single Loki deployment with minimal resource and limit requirements, offering high availability (HA) support for all Loki components. This configuration is suited for deployments that do not require a single replication factor or auto-compaction.
 
 Disk requests are similar across size configurations, allowing customers to test different sizes to determine the best fit for their deployment needs.
 
@@ -53,30 +54,30 @@ It is not possible to change the number `1x` for the deployment size.
 |Total CPU requests
 |None
 |7 vCPUs
-|14 vCPUs
-|34 vCPUs
+|13 vCPUs
+|33.5 vCPUs
 |54 vCPUs
 
 |Total CPU requests if using the ruler
 |None
 |8 vCPUs
-|16 vCPUs
-|42 vCPUs
+|15 vCPUs
+|41.5 vCPUs
 |70 vCPUs
 
 |Total memory requests
 |None
 |17Gi
-|31Gi
-|67Gi
+|30.75Gi
+|66.75Gi
 |139Gi
 
 
 |Total memory requests if using the ruler
 |None
 |18Gi
-|35Gi
-|83Gi
+|34.75Gi
+|82.75Gi
 |171Gi
 
 |Total disk requests

--- a/modules/understanding-loki-sizing.adoc
+++ b/modules/understanding-loki-sizing.adoc
@@ -6,28 +6,29 @@
 [id="understanding-loki-sizing_{context}"]
 = Understanding Loki deployment sizing
 
+[role="_abstract"]
 Understanding how to size your Loki deployment helps you avoid performance issues and ensure logs are reliably collected and queryable.
 
 [id="what-is-qps_{context}"]
-== What is QPS (Queries Per Second)?
+== What is QPS
 
-QPS (Queries Per Second) measures the rate of log queries against your LokiStack. Common sources of queries include:
+Queries Per Second (QPS) measures the rate of log queries against your LokiStack. Common sources of queries include:
 
 * User queries from the OpenShift web console
 * Dashboard auto-refresh intervals (for example, Grafana dashboards refreshing every 30 seconds)
 * Alert rule evaluations running continuously
 * API queries from monitoring and observability tools
 
-A single user running multiple dashboards can generate 10-20 QPS. The sizing table shows average QPS at 200ms query latency.
+A single user running multiple dashboards can generate 10 to 20 QPS. The sizing table shows average QPS at 200ms query latency.
 
 [id="log-volume-affects-sizing_{context}"]
 == How log volume affects sizing
 
 Log volume directly impacts the resources required for Loki components:
 
-Ingestion rate (GB/day):: Drives ingester CPU and memory requirements. Higher log volume requires more ingesters to handle the write load.
+Ingestion rate (GB per day):: Drives ingester CPU and memory requirements. Higher log volume requires more ingesters to handle the write load.
 
-Retention period:: Drives object storage capacity. Retention multiplied by daily log volume determines total storage needed (for example, 100 GB/day × 30 days = 3 TB storage).
+Retention period:: Drives object storage capacity. Retention multiplied by daily log volume determines total storage needed (for example, 100 GB per day × 30 days = 3 TB storage).
 
 Query time range:: Affects querier resource requirements. Queries across longer time ranges require more memory and CPU to process results.
 
@@ -40,9 +41,9 @@ The ruler component evaluates alerting rules and retention policies continuously
 * Evaluates retention policies for log deletion
 * Scales based on: number of tenants × number of rules × log data volume
 
-For example, the `1x.medium` size requires:
-* *Without ruler:* 34 vCPUs
-* *With ruler:* 42 vCPUs (+8 vCPUs for ruler evaluation)
+For example, the 1x.medium size requires:
+* Without ruler: 34 vCPUs
+* With ruler: 42 vCPUs (+8 vCPUs for ruler evaluation)
 
 [id="determining-initial-deployment-size_{context}"]
 == Determining initial deployment size
@@ -50,19 +51,24 @@ For example, the `1x.medium` size requires:
 Because log volume cannot be predicted before installation, use these baseline recommendations:
 
 Small clusters (≤10 nodes)::
-Start with `1x.extra-small` size
+Start with 1x.extra-small size
 
 Medium to large clusters (>10 nodes)::
-Start with `1x.medium` size
+Start with 1x.medium size
 
-Single-node OpenShift (SNO) or edge::
-Start with `1x.pico` size (minimum viable deployment)
+{sno-caps} or edge deployments::
+Start with 1x.pico size for production edge deployments with high availability requirements; for development, testing, or resource-constrained single-node environments, use 1x.demo size.
+
+[NOTE]
+====
+If you experience pod failures or resource exhaustion on {sno} with 1x.pico or 1x.extra-small, scale down to 1x.demo. Single-node environments have limited CPU and memory compared to multi-node clusters, and larger LokiStack sizes might exceed available resources.
+====
 
 [IMPORTANT]
 ====
-You cannot accurately estimate log volume before installation. Factors that make pre-installation sizing impossible:
+You cannot accurately estimate log volume before installation. Factors that make preinstallation sizing impossible:
 
-* A single pod can produce 100 GB/day of logs
+* A single pod can produce 100 GB per day of logs
 * Log volume varies dramatically based on application verbosity, not pod count
 * Infrastructure logs (journald) and audit logs are not produced by containers
 * Cluster activity (pod creation/deletion) affects log volume independently of workload size
@@ -73,9 +79,7 @@ Start with a baseline size and adjust after monitoring actual log production.
 [id="calculating-sizing-after-installation_{context}"]
 == Calculating sizing after installation
 
-After the logging stack is running, calculate the correct size based on observed metrics:
-
-.Procedure
+After the logging stack is running, calculate the correct size based on observed metrics.
 
 . Wait at least 24 hours after installation to capture representative log volume patterns.
 
@@ -86,16 +90,16 @@ After the logging stack is running, calculate the correct size based on observed
 sum by (component_name) (rate(vector_component_sent_bytes_total{component_type="loki", component_kind="sink"}[5m]))
 ----
 
-. Convert the rate to GB/day and compare against the sizing table:
+. Convert the rate to GB per day and compare against the sizing table:
 +
 [source,terminal]
 ----
 # Example: If query returns 5242880 bytes/second
-# = 5242880 * 86400 / 1073741824 = ~421 GB/day
-# → Requires 1x.small (500 GB/day capacity)
+# = 5242880 * 86400 / 1073741824 = ~421 GB per day
+# → Requires 1x.small (500 GB per day capacity)
 ----
 
-. Update the `LokiStack` CR with the new size if needed:
+. Update the LokiStack CR with the new size if needed:
 +
 [source,yaml]
 ----
@@ -107,5 +111,5 @@ spec:
 
 [NOTE]
 ====
-Resizing a `LokiStack` triggers a rolling restart of components. Plan resizing during maintenance windows.
+Resizing a LokiStack triggers a rolling restart of components. Plan resizing during maintenance windows.
 ====


### PR DESCRIPTION
## Summary

Extends the Loki deployment sizing documentation with per-component resource requirement tables for each supported t-shirt size. Administrators can now plan OpenShift node capacity for LokiStack deployments by seeing the exact resource requests and replica counts for each component.

Release version: 6.6, 6.5, 6.4

## Problem

The current documentation at `Loki deployment sizing` provides only aggregate resource guidance per profile. Cluster administrators need per-component CPU and memory requests and pod replica counts to:
- Size worker nodes and dedicated infrastructure nodes
- Estimate total cluster resource consumption  
- Compare profiles before deployment

## Solution

Added a new module `loki-component-sizing-tables.adoc` with detailed tables for each size:
- **1x.demo** - demonstration use
- **1x.pico** - 50GB/day
- **1x.extra-small** - 100GB/day
- **1x.small** - 500GB/day
- **1x.medium** - 2TB/day

Each table shows per-component:
- CPU request per pod
- Memory request per pod
- Replica count
- Total CPU (request × replicas)
- Total memory (request × replicas)
- Disk per pod (where applicable)

Subtotal rows confirm that per-component totals match the existing aggregate sizing tables.

## Data Source

Resource specifications extracted from:
```
loki-operator/internal/manifests/internal/sizes.go
```

## Related

- Jira: [OBSDOCS-3530](https://redhat.atlassian.net/browse/OBSDOCS-3530)
- Closes: [OBSDOCS-1233](https://redhat.atlassian.net/browse/OBSDOCS-1233) (customer request for per-component breakdown)
- Similar to upstream Grafana docs: https://github.com/grafana/loki/blob/main/docs/sources/setup/size/_index.md

Signed-off-by: John Wilkins <jowilkin@redhat.com>