### PR TITLE
[RHDEVDOCS-7682] Release notes for Pipelines 1.22.4

### DIFF
--- a/modules/op-release-notes-1-22-4.adoc
+++ b/modules/op-release-notes-1-22-4.adoc
@@ -1,0 +1,17 @@
+// This module is included in the following assemblies:
+// * release_notes/op-release-notes-1-22.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="op-release-notes-1-22-4_{context}"]
+= Release notes for {pipelines-title} 1.22.4
+
+[role="_abstract"]
+With this update, {pipelines-title} General Availability (GA) 1.22.4 is available on {OCP} 4.14, 4.16, and later versions.
+
+[id="fixed-issues-1-22-4_{context}"]
+== Fixed issues
+
+Multicluster proxy permissions consolidated into scheduler role::
+Before this update, the {pipelines-shortname} Operator created the `tekton-multicluster-proxy-aae-rolebinding` role binding even when multicluster was disabled. This role binding referenced a nonexistent ServiceAccount and namespace, creating a potential security concern where a user could create the referenced resources and inherit the associated permissions. With this update, the `tekton-multicluster-proxy-aae-role` role and `tekton-multicluster-proxy-aae-rolebinding` role binding are removed, and the required permissions are moved to the `tekton-scheduler-role` role. As a result, no orphaned roles or role bindings are present.
++
+link:https://issues.redhat.com/browse/SRVKP-12211[SRVKP-12211]

--- a/release_notes/op-release-notes-1-22.adoc
+++ b/release_notes/op-release-notes-1-22.adoc
@@ -28,6 +28,9 @@ For an overview of {pipelines-title}, see xref:../about/understanding-openshift-
 // Compatibility and support matrix 1.22
 include::modules/op-tkn-pipelines-compatibility-support-matrix.adoc[leveloffset=+1]
 
+// Release notes for Red Hat OpenShift Pipelines 1.22.4
+include::modules/op-release-notes-1-22-4.adoc[leveloffset=+1]
+
 // Release notes for Red Hat OpenShift Pipelines 1.22.3
 include::modules/op-release-notes-1-22-3.adoc[leveloffset=+1]
 


### PR DESCRIPTION
Version(s):
- _none for cherry-picking_

Issue:
- https://redhat.atlassian.net/browse/RHDEVDOCS-7682

Link to docs preview:
- [OSP 1.22.4 RNs](https://114110--ocpdocs-pr.netlify.app/openshift-pipelines/latest/release_notes/op-release-notes-1-22.html#op-release-notes-1-22-4_op-release-notes-1-22)

Review:
- [x] Engineering has approved this change.

