### PR TITLE
policies field for configuring Fine Grained Retention policy in Tekton Results expects a string [RHDEVDOCS-7254]

### DIFF
--- a/modules/op-release-notes-1-21-0.adoc
+++ b/modules/op-release-notes-1-21-0.adoc
@@ -364,7 +364,7 @@ result:
         tekton-results-config-results-retention-policy:
           data:
             defaultRetention: "30d"
-            policies:
+            policies: | 
               - name: "retain-critical-failures-long-term"
                 selector:
                   matchNamespaces:


### PR DESCRIPTION
[RHDEVDOCS-7254](https://redhat.atlassian.net/browse/RHDEVDOCS-7254): policies field for configuring Fine Grained Retention policy in Tekton Results expects a string

The `policies` field expects a string when configuring fine-grained-policies for Tekton Results.

Version(s): pipelines-docs-1.21


Issue: https://redhat.atlassian.net/browse/RHDEVDOCS-7254


