### PR TITLE
OCPBUGS-92066: Merged commands in scale-up-autoscaler-hcp.adoc

### DIFF
--- a/modules/scale-up-autoscaler-hcp.adoc
+++ b/modules/scale-up-autoscaler-hcp.adoc
@@ -22,19 +22,16 @@ To scale up the workloads in your hosted cluster, you can use the `ScaleUpOnly` 
 $ oc patch -n <hosted_cluster_namespace> hostedcluster <hosted_cluster_name> --type=merge --patch='{"spec": {"autoscaling": {"scaling": "ScaleUpOnly", "maxPodGracePeriod": 60}}}'
 ----
 
-. Remove the `spec.replicas` field from the `NodePool` resource to allow the cluster autoscaler to manage the node count. Run the following command:
+. Remove the `spec.replicas` field from the `NodePool` resource to allow the cluster autoscaler to manage the node count. Additionally, enable cluster autoscaling to configure the minimum and maximum node counts for your node pools. Enter the following command:
 +
 [source,terminal]
 ----
-$ oc patch -n clusters nodepool <node_pool_name> --type=json  --patch='[{"op": "remove", "path": "/spec/replicas"}]'
-----
-
-. Enable cluster autoscaling to configure the minimum and maximum node counts for your node pools. Run the following command:
-+
-[source,terminal]
-----
-$ oc patch -n <hosted_cluster_namespace> nodepool <nodepool_name> \
-  --type=merge --patch='{"spec": {"autoScaling": {"max": 3, "min": 1}}}'
+$ oc -n clusters patch nodepool yhe-hosted-ap-northeast-1a \
+  --type=json \
+  -p='[
+    {"op":"remove","path":"/spec/replicas"},
+    {"op":"add","path":"/spec/autoScaling","value":{"min":2,"max":4}}
+  ]'
 ----
 
 .Verification


### PR DESCRIPTION
Version(s):
4.20+

Issue:
[OCPBUGS-92066](https://redhat.atlassian.net/browse/OCPBUGS-92066)

Link to docs preview:

* https://114117--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-machine-config.html#scale-up-autoscaler-hcp_hcp-machine-config

- [x] SME has approved this change (Yiyong Ye).
- [x] QE has approved this change (Jie Zhao).

Reference for approvals: https://github.com/openshift/openshift-docs/pull/102493
