### PR TITLE
OCPBUGS-90094 vtysh moved to openshift-frrk8s pods in OCP 4.20+

### DIFF
--- a/modules/nw-metallb-configure-vrf-bgppeer.adoc
+++ b/modules/nw-metallb-configure-vrf-bgppeer.adoc
@@ -147,10 +147,10 @@ spec:
     spec:
       containers:
       - name: server
-        image: nginx
+        image: registry.access.redhat.com/ubi9/httpd-24
         ports:
         - name: http
-          containerPort: 80
+          containerPort: 8080
 ---
 apiVersion: v1
 kind: Service
@@ -162,7 +162,7 @@ spec:
   - name: http
     port: 80
     protocol: TCP
-    targetPort: 80
+    targetPort: 8080
   selector:
     app: server
   type: LoadBalancer
@@ -178,32 +178,32 @@ $ oc apply -f deploy-service.yaml
 
 .Verification
 
-. Identify a MetalLB speaker pod by running the following command:
+. Identify a `frr-k8s` pod by running the following command:
 +
 [source,terminal]
 ----
-$ oc get -n metallb-system pods -l component=speaker
+$ oc get -n openshift-frr-k8s pods -l app=frr-k8s
 ----
 +
 .Example output
 [source,terminal]
 ----
 NAME            READY   STATUS    RESTARTS   AGE
-speaker-c6c5f   6/6     Running   0          69m
+frr-k8s-abcde   7/7     Running   0          69m
 ----
 
-. Verify that the state of the BGP session is `Established` in the speaker pod by running the following command, replacing the variables to match your configuration:
+. Verify that the state of the BGP session is `Established` in the `frr-k8s` pod by running the following command, replacing the variables to match your configuration:
 +
 [source,terminal]
 ----
-$ oc exec -n metallb-system <speaker_pod> -c frr -- vtysh -c "show bgp vrf <vrf_name> neigh"
+$ oc exec -n openshift-frr-k8s <frr_k8s_pod> -c frr -- vtysh -c "show bgp vrf <vrf_name> neigh"
 ----
 +
 .Example output
 [source,terminal]
 ----
-BGP neighbor is 192.168.30.1, remote AS 200, local AS 100, external link
-  BGP version 4, remote router ID 192.168.30.1, local router ID 192.168.30.71
+BGP neighbor is 192.168.130.1, remote AS 200, local AS 100, external link
+  BGP version 4, remote router ID 192.168.130.1, local router ID 192.168.130.71
   BGP state = Established, up for 04:20:09
 
 ...
@@ -213,5 +213,5 @@ BGP neighbor is 192.168.30.1, remote AS 200, local AS 100, external link
 +
 [source,terminal]
 ----
-$ oc exec -n metallb-system <speaker_pod> -c frr -- vtysh -c "show bgp vrf <vrf_name> ipv4"
+$ oc exec -n openshift-frr-k8s <frr_k8s_pod> -c frr -- vtysh -c "show bgp vrf <vrf_name> ipv4"
 ----


### PR DESCRIPTION
[OCPBUGS-90094]: MetalLB FRR architecture shift: vtysh moved to openshift-frrk8s pods in OCP 4.20+

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.20, 4.21, 4.22, 5.0 and main
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:https://redhat.atlassian.net/browse/OCPBUGS-90094
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:https://114119--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ingress_load_balancing/metallb/metallb-configure-bgp-peers.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
