### PR TITLE
OSDOCS-20372:Update the z-stream RNs for 4.20.27

### DIFF
--- a/modules/zstream-4-20-27.adoc
+++ b/modules/zstream-4-20-27.adoc
@@ -1,0 +1,45 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-20-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-20-27_{context}"]
+= RHSA-2026:29800 - {product-title} {product-version}.27 fixed issues and security update
+
+Issued: 30 June 2026
+
+[role="_abstract"]
+{product-title} release {product-version}.27 is now available. The list of fixed issues that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2026:29800[RHSA-2026:29800] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2026:29798[RHBA-2026:29798] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.20.27 --pullspecs
+----
+
+[id="zstream-4-20-27-enhancements_{context}"]
+== Enhancements
+
+* With this release, the `chrony-wait` service is updated to not block during the node bootstrapping process. As a result, the time to the `NodeReady` event is reduced to between 10-24 seconds dependent on the platform. (link:https://redhat.atlassian.net/browse/OCPBUGS-88689[OCPBUGS-88689])
+
+[id="zstream-4-20-27-known-issues_{context}"]
+== Known issues
+
+* Currently, when you apply the `openshift-node-performance` PerformanceProfile with the non-RT kernel, timer migration (`kernel.timer_migration`) is not enabled. As a consequence, kernel timers such as TCP timeout and keep-alive timers can remain stuck on CPUs assigned to latency-sensitive workloads, causing unwanted interruptions to those workloads. As a workaround, enable timer migration by using a TuneD custom resource to set the `kernel.timer_migration=1` `sysctl` parameter. For more information about configuring TuneD, see link:https://access.redhat.com/solutions/5532341[Performance addons Operator advanced configuration]. (link:https://issues.redhat.com/browse/OCPBUGS-88468[OCPBUGS-88468])
+
+[id="zstream-4-20-27-fixed-issues_{context}"]
+== Fixed issues
+
+* Before this update, a race condition in the `globalps` controller skipped labeling new nodes, causing a delay in `global-pull-secret-syncer` pod scheduling. As a consequence, users experienced image pull failures from private registries on new nodes. With this release, the scheduling delay is resolved, which fixes the race condition in the Hosted Cluster Config Operator. As a result, the `global-pull-secret-syncer` pod now schedules immediately on new nodes, which ensures timely access to private images. (link:https://redhat.atlassian.net/browse/OCPBUGS-77967[OCPBUGS-77967])
+
+* Before this update, binary data such as `JAR` or `JCEKS` keystores, was incorrectly decoded as UTF-8 text when `Secret` objects were edited through the {product-title} web console. This corrupted the binary values with replacement characters and rendered the files unusable. With this release, the web console now preserves base64-encoded binary data and passes it directly to the file input component without text conversion. Binary secret data remains intact when editing other fields in the same secret. (link:https://issues.redhat.com/browse/OCPBUGS-87835[OCPBUGS-87835])
+
+* Before this update, you were prompted to complete the *Restore as new PVC* action for VolumeSnapshots to work when the parent persistent volume claim (PVC) was deleted, which aligned the console behavior with the CLI which already supported this operation. With this release, the restore `VolumeSnapshot` modal now falls back to snapshot annotations for storage class, access modes, and size instead of requiring the original PVC to be present. (link:https://issues.redhat.com/browse/OCPBUGS-89235[OCPBUGS-89235])
+
+[id="zstream-4-20-27-updating_{context}"]
+== Updating
+
+To update an {product-title} 4.20 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].

--- a/release_notes/ocp-4-20-release-notes.adoc
+++ b/release_notes/ocp-4-20-release-notes.adoc
@@ -3021,6 +3021,9 @@ In both cases, the installation program generates a user-assigned identity. (lin
 
 include::modules/rn-async-errata.adoc[leveloffset=+1]
 
+// 4.20.27 release notes
+include::modules/zstream-4-20-27.adoc[leveloffset=+2]
+
 // 4.20.26 release notes
 include::modules/zstream-4-20-26.adoc[leveloffset=+2]
 


### PR DESCRIPTION
Version(s):
4.20

Issue:
https://redhat.atlassian.net/browse/OSDOCS-20372

Link to docs preview:
https://114122--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-20-release-notes.html#zstream-4-20-27_release-notes

Additional information:
4.20.27 MR: https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/609
ART Dashboard: https://art-dash.engineering.redhat.com/dashboard/release/openshift-4.20?page=1
