### PR TITLE
OSDOCS-20373:Update the z-stream RNs for 4.16.65

### DIFF
--- a/modules/zstream-4-16-65.adoc
+++ b/modules/zstream-4-16-65.adoc
@@ -1,0 +1,34 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-16-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-16-65_{context}"]
+= RHSA-2026:29082 - {product-title} {product-version}.65 fixed issues and security updates
+
+Issued: 01 July 2026
+
+[role="_abstract"]
+{product-title} release {product-version}.65 is now available. The list of fixed issues that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2026:29082[RHSA-2026:29082] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2026:29079[RHSA-2026:29079] advisory.
+
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.16.65 --pullspecs
+----
+
+[id="zstream-4-16-65-fixed-issues_{context}"]
+== Fixed issues
+
+* Before this update, if NetworkManager was restarted or crashed on a node with a `br-ex` interface managed by NMState, the node lost network connectivity. With this release, a fallback check in the dispatcher script is added to detect NMState-managed `br-ex` interfaces by checking for the `br-ex-br` bridge ID when the standard `br-ex` bridge ID is not found. As a result, nodes with this interface type do not lose network connectivity when NetworkManager restarts or crashes. (link:https://redhat.atlassian.net/browse/OCPBUGS-62171[OCPBUGS-62171])
+
+* Before this update, the Operator Lifecycle Management (OLM) CSV annotation contained unexpected JSON, which was successfully parsed, but then threw a runtime error when attempting to use the resulting value. With this release, JSON values from OLM annotations are validated before use, and errors are logged, but the console does not fail when unexpected JSON is received in an annotation. (link:https://redhat.atlassian.net/browse/OCPBUGS-88027[OCPBUGS-88027])
+
+[id="zstream-4-16-65-updating_{context}"]
+== Updating
+
+To update an {product-title} 4.16 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].

--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -3390,6 +3390,9 @@ Testing has shown that wake up latencies are under 20μs for over 99.99999% of t
 // 4.16 about async
 include::modules/rn-async-errata.adoc[leveloffset=+1]
 
+// 4.16.65 Rns and updating
+include::modules/zstream-4-16-65.adoc[leveloffset=+2]
+
 // 4.16.64 Rns and updating
 include::modules/zstream-4-16-64.adoc[leveloffset=+2]
 


### PR DESCRIPTION
Version(s):
4.16

Issue:
https://redhat.atlassian.net/browse/OSDOCS-20373

Link to docs preview:
https://114132--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html#zstream-4-16-65_release-notes

Additional information:
4.16.65 MR: https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/601
ART Dashboard: https://art-dash.engineering.redhat.com/dashboard/release/openshift-4.16?page=1