### PR TITLE
CNV-89893: Outdated URL in 9.3.3. Installing VirtIO drivers from a container disk added as a SATA CD drive

### DIFF
--- a/modules/virt-adding-container-disk-as-cd.adoc
+++ b/modules/virt-adding-container-disk-as-cd.adoc
@@ -13,7 +13,7 @@ You can install VirtIO drivers from a container disk that you add to a Windows v
 
 [TIP]
 ====
-Downloading the `container-native-virtualization/virtio-win` container disk from the link:https://catalog.redhat.com/software/containers/search?q=virtio-win&p=1[Red Hat Ecosystem Catalog] is not mandatory, because the container disk is downloaded from the Red Hat registry if it not already present in the cluster. However, downloading reduces the installation time.
+You do not need to download the `container-native-virtualization/virtio-win-rhel9` container disk. If the container disk is not present, the cluster downloads it from the Red Hat registry. However, to reduce the installation time, you can download the container disk in advance from the link:https://catalog.redhat.com/en/software/containers/container-native-virtualization/virtio-win-rhel9/633ffae83be061d37b2770f6[Red Hat Ecosystem Catalog].
 ====
 
 .Prerequisites
@@ -39,7 +39,7 @@ spec:
             bus: sata
 volumes:
   - containerDisk:
-      image: container-native-virtualization/virtio-win
+      image: registry.redhat.io/container-native-virtualization/virtio-win-rhel9:v4.22
     name: virtiocontainerdisk
 ----
 +


### PR DESCRIPTION
Resolves: https://redhat.atlassian.net/browse/CNV-89893

CNV 4.16+
OCP 4.16+

Preview: https://114137--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/managing_vms/virt-install-virtio-drivers-on-windows-vms.html#virt-adding-container-disk-as-cd_virt-install-virtio-drivers-on-windows-vms