### PR TITLE
[OSDOCS-20358]: CQA: Automated DR with OADP for HCP (part 1 of 4)

### DIFF
--- a/hosted_control_planes/hcp_high_availability/hcp-disaster-recovery-oadp-auto.adoc
+++ b/hosted_control_planes/hcp_high_availability/hcp-disaster-recovery-oadp-auto.adoc
@@ -1,11 +1,12 @@
 :_mod-docs-content-type: ASSEMBLY
+include::_attributes/common-attributes.adoc[]
 [id="hcp-disaster-recovery-oadp-auto"]
 = Automated disaster recovery for a hosted cluster by using {oadp-short}
-include::_attributes/common-attributes.adoc[]
 :context: hcp-disaster-recovery-oadp-auto
 
 toc::[]
 
+[role="_abstract"]
 In hosted clusters on bare-metal or {aws-first} platforms, you can automate some backup and restore steps by using the {oadp-first} Operator.
 
 The process involves the following steps:
@@ -16,34 +17,27 @@ The process involves the following steps:
 . Backing up the control plane workload
 . Restoring a hosted cluster by using {oadp-short}
 
-[id="hcp-auto-dr-prereqs_{context}"]
-== Prerequisites
+include::modules/hcp-dr-oadp-auto-prereqs.adoc[leveloffset=+1]
 
-You must meet the following prerequisites on the management cluster:
+[role="_additional-resources"]
+.Additional resources
 
-* You xref:../../backup_and_restore/application_backup_and_restore/installing/about-installing-oadp.adoc#about-installing-oadp[installed the {oadp-short} Operator].
-* You created a storage class.
-* You have access to the cluster with `cluster-admin` privileges.
-* You have access to the {oadp-short} subscription through a catalog source.
-* You have access to a cloud storage provider that is compatible with {oadp-short}, such as S3, {azure-full}, {gcp-full}, or MinIO.
-* In a disconnected environment, you have access to a self-hosted storage provider that is compatible with {oadp-short}, for example link:https://docs.redhat.com/en/documentation/red_hat_openshift_data_foundation/[{odf-full}] or link:https://min.io/[MinIO].
-* Your {hcp} pods are up and running.
-* You are using a supported version of {oadp-short} for your management cluster. For example, if your management cluster is on {product-title} 4.20, you must use {oadp-short} version 1.5. For more information, see xref:../../backup_and_restore/application_backup_and_restore/oadp-intro.adoc#oadp-operator-supported_oadp-api[Support for {oadp-first}].
+* xref:../../backup_and_restore/application_backup_and_restore/installing/about-installing-oadp.adoc#about-installing-oadp[About installing {oadp-short}]
+* link:https://docs.redhat.com/en/documentation/red_hat_openshift_data_foundation/[{odf-full}]
+* link:https://min.io/[MinIO]
+* xref:../../backup_and_restore/application_backup_and_restore/oadp-intro.adoc#oadp-operator-supported_oadp-api[Support for {oadp-first}]
 
 include::modules/hcp-dr-prep-oadp-auto.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources
 
-* xref:../../backup_and_restore/application_backup_and_restore/installing/installing-oadp-aws.adoc#installing-oadp-aws[Configuring the {oadp-full} with Multicloud Object Gateway]
 * xref:../../backup_and_restore/application_backup_and_restore/installing/installing-oadp-mcg.adoc#installing-oadp-mcg[Configuring the {oadp-full} with AWS S3 compatible storage]
+* xref:../../backup_and_restore/application_backup_and_restore/installing/installing-oadp-aws.adoc#installing-oadp-aws[Configuring the {oadp-full} with Multicloud Object Gateway]
 
 include::modules/hcp-dr-oadp-dpa.adoc[leveloffset=+1]
 
-[id="backing-up-data-plane-oadp-auto_{context}"]
-== Backing up the data plane workload
-
-To back up the data plane workload by using the {oadp-short} Operator, see "Backing up applications". If the data plane workload is not important, you can skip this procedure.
+include::modules/hcp-dp-backup-oadp-auto.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources

--- a/modules/hcp-dp-backup-oadp-auto.adoc
+++ b/modules/hcp-dp-backup-oadp-auto.adoc
@@ -1,0 +1,16 @@
+// Module included in the following assemblies:
+//
+// * hosted_control_planes/hcp-disaster-recovery-oadp-auto.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="hcp-dp-backup-oadp-auto_{context}"]
+= Backing up the data plane workload by using the {oadp-short} Operator
+
+[role="_abstract"]
+You can back up the data plane workload by using the {oadp-short} Operator. 
+
+However, if the data plane workload is not important, you can skip this procedure.
+
+.Procedure
+
+* To back up the data plane workload, follow the steps in "Backing up applications".

--- a/modules/hcp-dr-oadp-auto-prereqs.adoc
+++ b/modules/hcp-dr-oadp-auto-prereqs.adoc
@@ -1,0 +1,21 @@
+// Module included in the following assemblies:
+//
+// * hosted_control_planes/hcp-disaster-recovery-oadp-auto.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="hcp-dr-oadp-auto-prereqs_{context}"]
+= Prerequisites to automate disaster recovery by using {oadp-short}
+
+[role="_abstract"]
+Ensure that you meet the prerequisites to automate disaster recovery for {hcp} by using {oadp-short}.
+
+The following prerequisites apply to the management cluster:
+
+* You installed the {oadp-short} Operator. For more information, see "About installing {oadp-short}".
+* You created a storage class.
+* You have access to the cluster with `cluster-admin` privileges.
+* You have access to the {oadp-short} subscription through a catalog source.
+* You have access to a cloud storage provider that is compatible with {oadp-short}, such as S3, {azure-full}, {gcp-full}, or MinIO.
+* In a disconnected environment, you have access to a self-hosted storage provider that is compatible with {oadp-short}, for example {odf-full} or MinIO.
+* Your {hcp} pods are up and running.
+* You are using a supported version of {oadp-short} for your management cluster. For example, if your management cluster is on {product-title} 4.20, you must use {oadp-short} version 1.5. For more information, see "Support for {oadp-first}".

--- a/modules/hcp-dr-prep-oadp-auto.adoc
+++ b/modules/hcp-dr-prep-oadp-auto.adoc
@@ -4,8 +4,13 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="hcp-dr-prep-oadp-auto_{context}"]
-= Configuring {oadp-short}
+= Configuring {oadp-short} to automate disaster recovery for {hcp}
 
-If your hosted cluster is on {aws-short}, follow the steps in "Configuring the {oadp-full} with Multicloud Object Gateway" to configure {oadp-short}.
+[role="_abstract"]
+Before you can automate disaster recovery by using {oadp-first}, you need to configure it for your {hcp} platform.
 
-If your hosted cluster is on a bare-metal platform, follow the steps in "Configuring the {oadp-full} with AWS S3 compatible storage" to configure {oadp-short}.
+.Procedure
+
+* If your hosted cluster is on {aws-short}, follow the steps in "Configuring the {oadp-full} with AWS S3 compatible storage" to configure {oadp-short}.
+
+* If your hosted cluster is on a bare metal, follow the steps in "Configuring the {oadp-full} with Multicloud Object Gateway" to configure {oadp-short}.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.20+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://redhat.atlassian.net/browse/OSDOCS-20358
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
- Automated disaster recovery for a hosted cluster by using OADP: https://114142--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp_high_availability/hcp-disaster-recovery-oadp-auto
- Prerequisites to automate disaster recovery by using OADP: https://114142--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp_high_availability/hcp-disaster-recovery-oadp-auto#hcp-dr-oadp-auto-prereqs_hcp-disaster-recovery-oadp-auto
- Configuring OADP to automate disaster recovery for hosted control planes: https://114142--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp_high_availability/hcp-disaster-recovery-oadp-auto#hcp-dr-prep-oadp-auto_hcp-disaster-recovery-oadp-auto
- Backing up the data plane workload by using the OADP Operator: https://114142--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp_high_availability/hcp-disaster-recovery-oadp-auto#hcp-dp-backup-oadp-auto_hcp-disaster-recovery-oadp-auto
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
N/A no technical changes
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
