### PR TITLE
OCPBUGS#91652 Added plan to Azure osImage param

### DIFF
--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -1850,6 +1850,15 @@ The following values are associated with the boot diagnostics type:
   platform:
     azure:
       osImage:
+        plan:
+|Optional. Whether or not the image uses a purchase plan.
+
+*Value:* String. Valid values are `WithPurchasePlan` and `NoPurchasePlan`. The default value is `WithPurchasePlan`.
+
+|compute:
+  platform:
+    azure:
+      osImage:
         publisher:
 |Optional. By default, the installation program downloads and installs the {op-system-first} image that is used to boot compute machines. You can override the default behavior by using a custom {op-system} image that is available from the Azure Marketplace. The installation program uses this image for compute machines only.
 


### PR DESCRIPTION
Version(s):
4.20+

Issue:
https://redhat.atlassian.net/browse/OCPBUGS-91652

Link to docs preview:
https://114152--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_azure/installation-config-parameters-azure#installation-configuration-parameters-additional-azure_installation-config-parameters-azure

QE review:
- [ ] QE has approved this change.
