### PR TITLE
OSDOCS-20408: Oracle Alloy GA RN

### DIFF
--- a/modules/rn-ocp-release-notes-new-features.adoc
+++ b/modules/rn-ocp-release-notes-new-features.adoc
@@ -60,7 +60,7 @@ Network reconfiguration for {sno} clusters::
 +
 You can change the network configuration of a {sno} cluster without performing a full cluster redeployment by using the {lcao}. This feature supports critical edge computing scenarios such as disaster recovery and network rehoming with a stage-driven workflow that includes the ability to rollback changes on failure.
 +
-You can change network properties such as node IP addresses, machine network CIDRs, default gateways, VLAN settings, and DNS servers. 
+You can change network properties such as node IP addresses, machine network CIDRs, default gateways, VLAN settings, and DNS servers.
 +
 For more information, see xref:../edge_computing/sno_ip_configuration/cnf-understanding-sno-ip-configuration.adoc#cnf-understanding-sno-ip-configuration[Understand {sno} network reconfiguration].
 
@@ -94,7 +94,7 @@ The `deploymentConfig` API in the `ClusterExtension` resource enables declarativ
 +
 For more information, see xref:../extensions/ce/olmv1-configuring-extensions.adoc#olmv1-deployment-config-api_olmv1-configuring-extensions[Configuring cluster extensions].
 
-`ClusterObjectSet` API for safe phased rollouts (Technology Preview):: 
+`ClusterObjectSet` API for safe phased rollouts (Technology Preview)::
 +
 {olmv1-first} introduces the `ClusterObjectSet` API, which enables safe, phased rollouts of Kubernetes resources during ClusterExtension deployments and upgrades. A `ClusterObjectSet` object applies resources sequentially in ordered phases with built-in readiness checks, ensuring resources are created after any resources they are dependent on.
 +
@@ -163,7 +163,7 @@ Detailed information.
 
 The Insights Operator collects custom resources to improve data retrieval efficiency and system performance::
 +
-With this release, the Insights Operator now collects the `opentelemetrycollectors.opentelemetry.io` custom resource to improve data retrieval efficiency and system performance. 
+With this release, the Insights Operator now collects the `opentelemetrycollectors.opentelemetry.io` custom resource to improve data retrieval efficiency and system performance.
 +
 To maintain security and prevent the collection of sensitive information, the Insights Operator applies the following constraints:
 +
@@ -188,7 +188,7 @@ Detailed information.
 
 Enhancements for {ibm-power-server-title}::
 +
-The {ibm-power-server-title} {cluster-capi-operator} is enhanced to `v0.12.2` in {product-title} version 4.22. Users are required to manually select the appropriate partner group in the `Contributing Group` field due to multiple partner confidential group memberships. This feature ensures compatibility, improves system performance, and maintains security by proper selection of partner groups. The result is an {product-title} deployment with improved overall performance and reliability. 
+The {ibm-power-server-title} {cluster-capi-operator} is enhanced to `v0.12.2` in {product-title} version 4.22. Users are required to manually select the appropriate partner group in the `Contributing Group` field due to multiple partner confidential group memberships. This feature ensures compatibility, improves system performance, and maintains security by proper selection of partner groups. The result is an {product-title} deployment with improved overall performance and reliability.
 
 Installing a cluster on {azure-full} with a user-provisioned DNS is generally available::
 +
@@ -245,6 +245,12 @@ Bucketless workload identity for {gcp-short} clusters::
 When installing or upgrading an {product-title} cluster on {gcp-first} with short-term credentials, you can now use the `--key-storage-method=pool-jwk-file` option with the `ccoctl gcp create-all` command to attach OIDC signing keys directly to the workload identity pool provider. This method eliminates the need to create a publicly accessible Google Cloud Storage (GCS) bucket for OIDC configuration, which reduces the public attack surface and can help meet security and network policies in restricted environments.
 +
 For more information, see xref:../installing/installing_gcp/installing-gcp-customizations.adoc#cco-ccoctl-creating-at-once_installing-gcp-customizations[Creating GCP resources with the Cloud Credential Operator utility].
+
+Oracle Alloy General Availability::
++
+With this update, installing a cluster on Oracle Alloy is now Generally Available.
++
+For more information, see xref:../installing/installing_oci/installing-oci-assisted-installer.adoc#installing-oci-assisted-installer[Installing a cluster on {oci-distributed-no-rt} by using the {ai-full}] or xref:../installing/installing_oci/installing-oci-agent-based-installer.adoc#installing-oci-agent-based-installer[Installing a cluster on {oci-distributed-no-rt} by using the Agent-based Installer].
 
 [id="ocp-release-notes-machine-config-operator_{context}"]
 == Machine Config Operator


### PR DESCRIPTION
[OSDOCS-20408](https://redhat.atlassian.net/browse/OSDOCS-20408)

Version(s): 4.22

 This PR adds a release note declaring Oracle Alloy installations as GA.

QE review:
- [x] QE has approved this change.

Preview: [Release Note](https://114153--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-22-release-notes.html#ocp-release-notes-machine-config-operator_release-notes:~:text=Oracle%20Alloy%20General%20Availability)

Change management acks:

- [x] Product Management - Marcos Entenza Garcia
- [x] Documentation Program Management - Kathryn Alexander
- [x] Content Strategy - Avani Bhatt