### PR TITLE
OCPBUGS-83508 Reordering steps to bare metal control plane node repla…

### DIFF
--- a/modules/nodes-enable-etcd-quorum-guard.adoc
+++ b/modules/nodes-enable-etcd-quorum-guard.adoc
@@ -1,0 +1,123 @@
+// Module included in the following assemblies:
+//
+// * nodes/nodes/nodes-nodes-replace-control-plane.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="enabling-etcd-quorum-guard_{context}"]
+= Re-enabling the etcd quorum guard
+
+[role="_abstract"]
+Re-enable the etcd quorum guard after completing the control plane node replacement to restore normal cluster operation and verify that the cluster has returned to a healthy three-member etcd configuration.
+
+.Procedure
+
+. Turn the quorum guard back on by running the following command:
++
+[source,terminal]
+----
+$ oc patch etcd/cluster --type=merge -p '{"spec": {"unsupportedConfigOverrides": null}}'
+----
+
+. Verify that the `unsupportedConfigOverrides` section is removed by running the following command:
++
+[source,terminal]
+----
+$ oc get etcd/cluster -oyaml
+----
+
+. If using {sno}, restart the node. Otherwise, you might encounter the following error in the etcd cluster Operator:
++
+.Example output
+[source,terminal]
+----
+EtcdCertSignerControllerDegraded: [Operation cannot be fulfilled on secrets "etcd-peer-sno-0": the object has been modified; please apply your changes to the latest version and try again, Operation cannot be fulfilled on secrets "etcd-serving-sno-0": the object has been modified; please apply your changes to the latest version and try again, Operation cannot be fulfilled on secrets "etcd-serving-metrics-sno-0": the object has been modified; please apply your changes to the latest version and try again]
+----
+
+.Verification
+
+. Verify that all etcd pods are running by running the following command:
++
+[source,terminal]
+----
+$ oc -n openshift-etcd get pods -l k8s-app=etcd
+----
++
+.Example output
+[source,terminal]
+----
+etcd-openshift-control-plane-0      5/5     Running     0     105m
+etcd-openshift-control-plane-1      5/5     Running     0     107m
+etcd-openshift-control-plane-3      5/5     Running     0     12m
+----
++
+If the output from the previous command only lists two pods, you can manually force an etcd redeployment. In a terminal that has access to the cluster as a `cluster-admin` user, run the following command:
++
+[source,terminal]
+----
+$ oc patch etcd cluster -p='{"spec": {"forceRedeploymentReason": "recovery-'"$( date --rfc-3339=ns )"'"}}' --type=merge
+----
++
+The `forceRedeploymentReason` value must be unique, which is why a timestamp is appended.
+
+. Connect to a running etcd container by running the following command:
++
+[source,terminal]
+----
+$ oc rsh -n openshift-etcd etcd-openshift-control-plane-0
+----
+
+. View the member list by running the following command:
++
+[source,terminal]
+----
+sh-4.2# etcdctl member list -w table
+----
++
+.Example output
+[source,terminal]
+----
++------------------+---------+--------------------+---------------------------+---------------------------+-----------------+
+|        ID        | STATUS  |        NAME        |        PEER ADDRS         |       CLIENT ADDRS        |    IS LEARNER    |
++------------------+---------+--------------------+---------------------------+---------------------------+-----------------+
+| 8d5abe9669a39192 | started | openshift-control-plane-1 | https://192.168.10.10:2380 | https://192.168.10.10:2379 |   false |
+| cc3830a72fc357f9 | started | openshift-control-plane-0 | https://192.168.10.9:2380 | https://192.168.10.9:2379 |     false |
+| d4f6a4e8b2c91a3f | started | openshift-control-plane-3 | https://192.168.10.12:2380 | https://192.168.10.12:2379 |   false |
++------------------+---------+--------------------+---------------------------+---------------------------+-----------------+
+----
++
+Verify that exactly three etcd members are listed.
+
+. Verify that all etcd members are healthy by running the following command:
++
+[source,terminal]
+----
+sh-4.2# etcdctl endpoint health --cluster
+----
++
+.Example output
+[source,terminal]
+----
+https://192.168.10.10:2379 is healthy: successfully committed proposal: took = 8.973065ms
+https://192.168.10.9:2379 is healthy: successfully committed proposal: took = 11.559829ms
+https://192.168.10.12:2379 is healthy: successfully committed proposal: took = 11.665203ms
+----
+
+. Exit the rsh session by running the following command:
++
+[source,terminal]
+----
+sh-4.2# exit
+----
+
+. Verify that all nodes are at the latest revision by running the following command:
++
+[source,terminal]
+----
+$ oc get etcd -o=jsonpath='{range.items[0].status.conditions[?(@.type=="NodeInstallerProgressing")]}{.reason}{"\n"}{.message}{"\n"}'
+----
++
+.Example output
+[source,terminal]
+----
+AllNodesAtLatestRevision
+----

--- a/modules/nodes-remove-unhealthy-etcd-member.adoc
+++ b/modules/nodes-remove-unhealthy-etcd-member.adoc
@@ -6,9 +6,18 @@
 [id="removing-etcd-member_{context}"]
 = Removing the unhealthy etcd member
 
-Begin removing the failed control plane node by first removing the unhealthy etcd member.
+Begin removing the failed control plane node by first disabling the quorum guard, then removing the unhealthy etcd member and its secrets.
 
 .Procedure
+
+. Turn off the etcd quorum guard by running the following command:
++
+[source,terminal]
+----
+$ oc patch etcd/cluster --type=merge -p '{"spec": {"unsupportedConfigOverrides": {"useUnsupportedUnsafeNonHANonProductionUnstableEtcd": true}}}'
+----
++
+This command ensures that the cluster can temporarily operate with fewer etcd members and allows you to successfully re-create secrets and roll out the static pods.
 
 . List etcd pods by running the following command and make note of a pod that is not on the affected node:
 +
@@ -114,15 +123,6 @@ After you remove the member, the cluster might be unreachable for a short time w
 ----
 sh-4.2# exit
 ----
-
-. Turn off the etcd quorum guard by running the following command:
-+
-[source,terminal]
-----
-$ oc patch etcd/cluster --type=merge -p '{"spec": {"unsupportedConfigOverrides": {"useUnsupportedUnsafeNonHANonProductionUnstableEtcd": true}}}'
-----
-+
-This command ensures that you can successfully re-create secrets and roll out the static pods.
 
 . List the secrets for the removed, unhealthy etcd member by running the following command:
 +

--- a/nodes/nodes/nodes-nodes-replace-control-plane.adoc
+++ b/nodes/nodes/nodes-nodes-replace-control-plane.adoc
@@ -11,14 +11,8 @@ If a control plane node on your bare-metal cluster has failed and cannot be reco
 // Prerequisites
 include::modules/nodes-replace-control-plane-prereqs.adoc[leveloffset=+1]
 
-// Removing the unhealthy etcd member
+// Removing the unhealthy etcd member (includes disabling quorum guard and deleting secrets)
 include::modules/nodes-remove-unhealthy-etcd-member.adoc[leveloffset=+1]
-
-// Deleting the machine of the unhealthy etcd member
-include::modules/nodes-delete-machine-unhealthy-etcd.adoc[leveloffset=+1]
-
-// Verifying that the failed node was deleted
-include::modules/nodes-verify-failed-node-deleted.adoc[leveloffset=+1]
 
 // Creating the new control plane node
 include::modules/nodes-create-new-control-plane-node.adoc[leveloffset=+1]
@@ -29,6 +23,15 @@ include::modules/nodes-link-node-machine-bmh.adoc[leveloffset=+1]
 // Adding the new etcd member
 include::modules/nodes-add-new-etcd-member.adoc[leveloffset=+1]
 
+// Re-enabling the etcd quorum guard
+include::modules/nodes-enable-etcd-quorum-guard.adoc[leveloffset=+1]
+
+// Deleting the machine of the unhealthy etcd member
+include::modules/nodes-delete-machine-unhealthy-etcd.adoc[leveloffset=+1]
+
+// Verifying that the failed node was deleted
+include::modules/nodes-verify-failed-node-deleted.adoc[leveloffset=+1]
+
 [role="_additional-resources"]
 [id="additional-resources_{context}"]
 == Additional resources
@@ -36,4 +39,4 @@ include::modules/nodes-add-new-etcd-member.adoc[leveloffset=+1]
 * xref:../../backup_and_restore/control_plane_backup_and_restore/replacing-unhealthy-etcd-member.adoc#restore-replace-stopped-baremetal-etcd-member_replacing-unhealthy-etcd-member[Replacing an unhealthy bare metal etcd member whose machine is not running or whose node is not ready]
 * xref:../../backup_and_restore/control_plane_backup_and_restore/replacing-unhealthy-etcd-member.adoc#restore-replace-crashlooping-etcd-member_replacing-unhealthy-etcd-member[Replacing an unhealthy etcd member whose etcd pod is crashlooping]
 * link:https://access.redhat.com/solutions/6471021[BareMetalHost reference is missing after adding a host to OpenShift Assisted Installer cluster (Red{nbsp}Hat KCS article)]
-* link:https://access.redhat.com/solutions/5504291[How to retrieve Master or Worker Ignition Configuration from {product-title} 4? (Red{nbsp}Hat KCS article)]
+* link:https://access.redhat.com/solutions/5504291[How to retrieve control plane or worker Ignition Configuration from {product-title} 4? (Red{nbsp}Hat KCS article)]


### PR DESCRIPTION
Version(s): 4.17+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [OCPBUGS-83508](https://redhat.atlassian.net/browse/OCPBUGS-83508)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://114156--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/control_plane_backup_and_restore/replacing-unhealthy-etcd-member.html
https://114156--ocpdocs-pr.netlify.app/openshift-enterprise/latest/etcd/etcd-backup-restore/replace-unhealthy-etcd-member.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [X] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
