### PR TITLE
OSDOCS#18753: [CQA 2.0] OPP+ Architecture section

### DIFF
--- a/architecture/opp-architecture.adoc
+++ b/architecture/opp-architecture.adoc
@@ -7,9 +7,9 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 [role="_abstract"]
-{product-title} provides a hybrid-cloud platform to build, deploy, and manage applications consistently across multiple infrastructures. By integrating {op-system-base-full}, Kubernetes, and {ocp}, the platform enables you to streamline application lifecycles while maintaining security and scalability.
+With {product-title}, you can build, deploy, and manage applications consistently across hybrid-cloud infrastructures. The platform integrates {op-system-base-full}, Kubernetes, and {ocp} to streamline application lifecycles while maintaining security and scalability.
 
-The platform includes the following products:
+{product-title} integrates these core products:
 
 * {rh-rhacm} for Kubernetes - Controls clusters and applications from a single console.
 * {acs} for Kubernetes - Provides information about cluster security, visibility management, and security compliance.
@@ -20,11 +20,16 @@ The platform includes the following products:
 include::modules/opp-architecture-architecture.adoc[leveloffset=+1]
 
 include::modules/opp-architecture-installation.adoc[leveloffset=+1]
+[role="_additional-resources"]
+.Additional resources
+* link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.21/html-single/installation_overview/index#supported-installation-methods-for-different-platforms[Supported installation methods for different platforms]
+* link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.15/html/install/installing[Installing {rh-rhacm}]
 
 include::modules/opp-architecture-installing-policyset.adoc[leveloffset=+2]
 [role="_additional-resources"]
 .Additional resources
-* link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.8/html/governance/governance#deploying-policies-using-gitops[Deploying policies using gitops]
+* link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.15/html/governance/policy-deployment#policy-deploy-ext-tools[Deploying policies using gitops]
+// * link:https://github.com/stolostron/rhacm-docs/blob/2.17_prod/governance/policy_generator.adoc[Policy Generator]
 
 include::modules/opp-architecture-relnotes.adoc[leveloffset=+1]
 

--- a/modules/opp-architecture-installation.adoc
+++ b/modules/opp-architecture-installation.adoc
@@ -13,5 +13,5 @@ See the Red{nbsp}Hat {product-title} policy set for detailed information about i
 
 * link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.8/html/governance/governance#opp-policy-set[Red{nbsp}Hat {product-title} policy set]
 * link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.21/html-single/installation_overview/index#supported-installation-methods-for-different-platforms[Supported installation methods for different platforms]
-* link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.10/html/install/installing[Installing {rh-rhacm}]
+* link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.15/html/install/installing[Installing {rh-rhacm}]
 * link:https://access.redhat.com/support/policy/updates/openshift_operators[OpenShift Operator Life Cycles]

--- a/modules/opp-architecture-installing-policyset.adoc
+++ b/modules/opp-architecture-installing-policyset.adoc
@@ -17,12 +17,8 @@ To install the policy sets using gitops, follow the steps in "Deploying policies
 
 .Procedure
 . Install the `PolicyGenerator` plugin by following the instructions in _Installing and using the PolicyGenerator Kustomize plug-in_.
-. Clone the `policy-collection` repository:
-+
-[source,terminal]
-----
-$ git clone https://github.com/stolostron/policy-collection
-----
+. Clone the `policy-collection` repository.
+
 . Navigate to the policy set directory:
 +
 [source,terminal]

--- a/modules/opp-architecture-relnotes.adoc
+++ b/modules/opp-architecture-relnotes.adoc
@@ -9,8 +9,8 @@
 [role="_abstract"]
 Learn about new features, known issues, and fixed bugs in the latest {product-title} release. This information helps you plan your upgrade and understand how changes to the platform affect your existing environment.
 
-* link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.21/html/release_notes/ocp-4-21-release-notes[{ocp}]
-* link:https://https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.15/html/release_notes/acm-release-notes[Release notes for {rh-rhacm}]
-* link:https://https://docs.redhat.com/en/documentation/red_hat_quay/3.16/html/red_hat_quay_release_notes/release-notes-316[{quay} Release Notes]
-* link:https://https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_security_for_kubernetes/4.9/html/release_notes/release-notes-49[{acs} for Kubernetes 4.9]
-* link:https://https://docs.redhat.com/en/documentation/red_hat_openshift_data_foundation/4.20/html/4.20_release_notes/index[{rh-storage-data-foundation}]
+* link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.20/html/release_notes/ocp-4-20-release-notes[{ocp}]
+* link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.15/html/release_notes/acm-release-notes[Release notes for {rh-rhacm}]
+* link:https://docs.redhat.com/en/documentation/red_hat_quay/3.16/html/red_hat_quay_release_notes/release-notes-316[{quay} Release Notes]
+* link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_security_for_kubernetes/4.9/html/release_notes/release-notes-49[{acs} for Kubernetes 4.9]
+* link:https://docs.redhat.com/en/documentation/red_hat_openshift_data_foundation/4.20/html/4.20_release_notes/index[{rh-storage-data-foundation}]


### PR DESCRIPTION
Version(s):
This PR is based on the ‘opp-docs-main’ repo and when merged, it should be in that branch only. The OPP doc is not versioned. Add the ‘Continuous Release’ milestone to this PR.

Issue:
[OSDOCS-18753](https://redhat.atlassian.net/browse/OSDOCS-18753)

Link to docs preview:
[Architecture](https://114165--ocpdocs-pr.netlify.app/openshift-opp/latest/architecture/opp-architecture.html)

QE review:
- [ ] QE has approved this change.
N/A for CQA.

Additional information:
The CQA spreadsheet is attached to the Jira.