### PR TITLE
OSDOCS-16988-5-CQA2-TP: Follow up for TP

### DIFF
--- a/modules/installation-special-config-kmod.adoc
+++ b/modules/installation-special-config-kmod.adoc
@@ -22,8 +22,6 @@ For information on the software needed for this procedure, see "kmods-via-contai
 
 The following list details some important items before you start the procedure:
 
-* The procedure is Technology Preview.
-
 * Software tools and examples are not yet available in official RPM form and can only be obtained for now from unofficial `github.com` sites noted in the procedure.
 
 * Third-party kernel modules you might add through these procedures are not supported by Red Hat.


### PR DESCRIPTION
Feature is deprecated in 4.22 and should not be marked as TP. See https://docs.redhat.com/en/documentation/openshift_container_platform/4.22/html-single/release_notes/index#ocp-release-note-install-dep-rem_release-notes

Version(s):
4.22+

Issue:
[OSDOCS-16988](https://redhat.atlassian.net/browse/OSDOCS-16988)

Link to docs preview:

* https://114178--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/install_config/installing-customizing.html#installation-special-config-kmod_installing-customizing

https://github.com/openshift/openshift-docs/pull/111705/changes
