### PR TITLE
ROX-35425: Fix unresolved {rhacs-version} in welcome page title (4.11)

### DIFF
--- a/welcome/index.adoc
+++ b/welcome/index.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="welcome-index"]
-= Red Hat Advanced Cluster Security for Kubernetes {rhacs-version} documentation
+= Red Hat Advanced Cluster Security for Kubernetes {product-version} Documentation
 include::modules/common-attributes.adoc[]
 :context: welcome-index
 


### PR DESCRIPTION
## Summary

- The welcome page title on docs.redhat.com for RHACS 4.11 displays the literal `{rhacs-version}` placeholder instead of the actual version number
- **Root cause**: `{rhacs-version}` is defined in `modules/common-attributes.adoc` which is included *after* the title line — the Pantheon/AsciiBinder build pipeline resolves the title before processing includes, so the attribute is not available
- **Fix**: Replace `{rhacs-version}` with `{product-version}` in the document title, which is injected by AsciiBinder from `_distro_map.yml` before parsing (consistent with all working versions 4.8 and earlier)

## Bug

https://redhat.atlassian.net/browse/ROX-35425

## Affected URL

https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_security_for_kubernetes/4.11/html/about/welcome-index

## Test plan

- [ ] Verify local asciidoctor renders title as "Red Hat Advanced Cluster Security for Kubernetes 4.11 Documentation"
- [ ] Verify published page no longer shows literal `{rhacs-version}` after merge and rebuild


Made with [Cursor](https://cursor.com)