### PR TITLE
OSDOCS-20367: adds RHCL 1.4.1 async release note

### DIFF
--- a/_attributes/attributes.adoc
+++ b/_attributes/attributes.adoc
@@ -16,7 +16,7 @@
 :version: 1.4
 :version-2: 1.2
 :version-1: 1.3.x
-:operator-version: 1.4.0
+:operator-version: 1.4.1
 :ocp: OpenShift Container Platform
 :ocp-latest-version: 4.22
 :ocp-min-version: 4.18

--- a/modules/proc-update-rhcl-with-web-console.adoc
+++ b/modules/proc-update-rhcl-with-web-console.adoc
@@ -16,8 +16,13 @@ Update your {product-title} with the {ocp} web console.
 .Procedure
 
 . Click *Ecosystem > Installed Operators* > *{rh} {prodname}*.
+
 . Ensure that the *Update channel* is set to `stable`.
-. If *Update approval* is set to *Automatic*, the update is installed immediately when the *Update channel* is set to `stable`.
+
+. If *Update approval* is set to *Automatic*, the update is installed immediately.
+
 . If *Update approval* is set to *Manual*, click *Install*.
+
 . Wait until the {prodname} Operator is deployed.
+
 . Verify that {prodname} {version} is installed and that your deployment is up and running.

--- a/modules/rhcl-relnotes-1.4.1-z-stream.adoc
+++ b/modules/rhcl-relnotes-1.4.1-z-stream.adoc
@@ -1,0 +1,17 @@
+// Module used in the following assemblies
+//
+// *release_notes/rhcl-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="rhcl-relnotes-1.4.1-z-stream_{context}"]
+= {product-title} 1.4.1 bug fix and security update
+
+Issued: 1 July 2026
+
+[role="_abstract"]
+{product-title} release 1.4.1 is now available. A description is available in the link:https://access.redhat.com/errata/RHBA-2026:34242[RHBA-2026:34242] advisory. {product-title} uses the `stable` update channel to track and receive updates for the {product-title} Operator. You can manage how your updates are applied through your Operator Lifecycle Manager (OLM) subscription resource. For more information, see xref:../updating/updating-rhcl.adoc#proc-update-rhcl-with-web-console_updating-rhcl[Updating Red Hat Connectivity Link].
+
+[id="rhcl-relnotes-1.4.1-z-stream-bug-fixes_{context}"]
+== Bug fixes
+
+* During upgrades, the Operator Lifecycle Manager (OLM) automatically validates your existing `AuthConfig` custom resources (CRs) against all active versions of the Custom Resource Definition (CRD) served on the cluster. However, the `v1beta2` version of the CRD lacks a schema validation patch for Common Expression Language (CEL) predicate fields. Before this release, the Kubernetes API server evaluated the newer `v1beta3` resources containing CEL predicates against the stricter `v1beta2` schema. Because of this, if you had `AuthConfig` resources configured with CEL predicate conditions, OLM blocked your upgrades. The upgrade process failed because the API server rejected the CEL predicate field as an invalid option under the `v1beta2` rules. With this release, the `v1beta3` version of the `AuthConfig` API is the standard for the served CRD versions and the `v1beta2` version of the CRD is deprecated and removed. Existing `AuthConfig` resources that have CEL predicate conditions do not trigger schema validation failures. You can now upgrade without OLM blocking the process. (https://redhat.atlassian.net/browse/CONNLINK-1131[CONNLINK-1131])

--- a/release_notes/rhcl-release-notes.adoc
+++ b/release_notes/rhcl-release-notes.adoc
@@ -4,6 +4,8 @@ include::_attributes/attributes.adoc[]
 = {product-title} {version} release notes
 :context: rhcl-release-notes
 
+toc::[]
+
 [role="_abstract"]
 Welcome to the {product-title} release notes, where you can learn about what is new and what is fixed.
 
@@ -21,4 +23,6 @@ include::modules/ref-relnotes-tech-preview.adoc[leveloffset=+2]
 
 include::modules/ref-relnotes-known-issues.adoc[leveloffset=+2]
 
-//include::modules/rhcl-relnotes-z-stream.adoc[leveloffset=+2]
+include::modules/rhcl-relnotes-z-stream.adoc[leveloffset=+1]
+
+include::modules/rhcl-relnotes-1.4.1-z-stream.adoc[leveloffset=+2]

--- a/snippets/rhcl-1-4-0-do-not-install.adoc
+++ b/snippets/rhcl-1-4-0-do-not-install.adoc
@@ -4,11 +4,5 @@
 ====
 {rh} {prodname} 1.4.0 is deprecated. {ocp} clusters running {prodname} 1.4.0 might experience authentication failures, API key management errors, gateway instability, or gateway pod memory pressure because of integration changes that are not fully compatible on all supported {ocp} and {service-mesh} combinations.
 
-Until a patch is released, take one of the two actions, depending on your scenario:
-
-* If you are a new customer, do not install {rh} {prodname} 1.4.0.
-
-* If you are an upgrade customer, pin {prodname} and its dependent Operators to the latest {rh} {prodname} 1.3.z release. Prevent upgrades to {prodname} 1.4.0.
-
-// See link:https://access.redhat.com/solutions/7144055 for instructions.
+Install or upgrade to {rh} {prodname} 1.4.1.
 ====

--- a/updating/updating-rhcl.adoc
+++ b/updating/updating-rhcl.adoc
@@ -11,16 +11,16 @@ You can update your {product-title} from one version to the next if your support
 
 include::snippets/rhcl-1-4-0-do-not-install.adoc[leveloffset=+1]
 
-//include::modules/con-connectivity-link-supported-configs.adoc[leveloffset=+1]
+include::modules/con-connectivity-link-supported-configs.adoc[leveloffset=+1]
 
-//include::modules/con-update-rhcl-with-web-console.adoc[leveloffset=+1]
+include::modules/con-update-rhcl-with-web-console.adoc[leveloffset=+1]
 
-//include::modules/proc-update-rhcl-with-web-console.adoc[leveloffset=+1]
+include::modules/proc-update-rhcl-with-web-console.adoc[leveloffset=+1]
 
-//include::modules/using-your-subscription.adoc[leveloffset=+1]
+include::modules/using-your-subscription.adoc[leveloffset=+1]
 
-//[id="addtional-resources_rhcl-updating"]
-//[role="_additional-resources"]
-//== Additional resources
+[id="addtional-resources_rhcl-updating"]
+[role="_additional-resources"]
+== Additional resources
 
-//* link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.21/html/operators/administrator-tasks#olm-upgrading-operators[Updating installed Operators]
+* link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.22/html/operators/administrator-tasks#olm-upgrading-operators[Updating installed Operators]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
rhcl-docs-1.4

Issue:
[OSDOCS-20367](https://redhat.atlassian.net/browse/OSDOCS-20367)

Link to docs preview:
https://114281--ocpdocs-pr.netlify.app/rhcl/latest/release_notes/rhcl-release-notes.html#rhcl-relnotes-1.4.1-z-stream_rhcl-release-notes

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Releasing with https://github.com/openshift/openshift-docs/pull/114024 (same bug text)

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
