### PR TITLE
docs: add missing steps for spring-petclinic deployment

### DIFF
--- a/modules/gitops-creating-an-application-by-using-the-argo-cd-dashboard.adoc
+++ b/modules/gitops-creating-an-application-by-using-the-argo-cd-dashboard.adoc
@@ -49,6 +49,12 @@ Revision:: `HEAD`
 Path:: `app`
 Destination:: `https://kubernetes.default.svc`
 Namespace:: `spring-petclinic`
+Directory Recurse:: `checked`
++
+[IMPORTANT]
+====
+In the *Sync Options* section, ensure that the *Auto-Create Namespace* checkbox is selected. This allows Argo CD to automatically create the `spring-petclinic` namespace when syncing the application for the first time.
+====
 endif::app[]
 
 . Click *CREATE* to create your application.

--- a/modules/gitops-creating-an-application-by-using-the-oc-tool.adoc
+++ b/modules/gitops-creating-an-application-by-using-the-oc-tool.adoc
@@ -25,8 +25,25 @@ You can create Argo CD applications in your terminal by using the `oc` tool.
 $ git clone git@github.com:redhat-developer/openshift-gitops-getting-started.git
 ----
 
-. Create the application:
 ifdef::app[]
+. Create and configure the destination namespace before deploying the application:
++
+[source,terminal]
+----
+$ oc create namespace spring-petclinic
+----
++
+[source,terminal]
+----
+$ oc label namespace spring-petclinic argocd.argoproj.io/managed-by=openshift-gitops
+----
++
+[NOTE]
+====
+The `argocd.argoproj.io/managed-by=openshift-gitops` label allows the Argo CD instance in the `openshift-gitops` namespace to manage the `spring-petclinic` namespace.
+====
+
+. Create the application:
 +
 [source,terminal]
 ----
@@ -35,10 +52,18 @@ $ oc create -f openshift-gitops-getting-started/argo/app.yaml
 endif::app[]
 
 ifdef::cluster[]
+. Create the application:
 +
 [source,terminal]
 ----
 $ oc create -f openshift-gitops-getting-started/argo/app.yaml
+----
+
+. Add a label to the namespace your application is deployed in so that the Argo CD instance in the `openshift-gitops` namespace can manage it:
++
+[source,terminal]
+----
+$ oc label namespace spring-petclinic argocd.argoproj.io/managed-by=openshift-gitops
 ----
 endif::cluster[]
 
@@ -49,19 +74,16 @@ endif::cluster[]
 $ oc get application -n openshift-gitops
 ----
 
-. Add a label to the namespace your application is deployed in so that the Argo CD instance in the `openshift-gitops` namespace can manage it:
-
 ifdef::app[]
+. Optional: After you have finished exploring the sample application, you can delete the application and namespace:
 +
 [source,terminal]
 ----
-$ oc label namespace spring-petclinic argocd.argoproj.io/managed-by=openshift-gitops
+$ oc delete -n openshift-gitops -f openshift-gitops-getting-started/argo/app.yaml
+----
++
+[source,terminal]
+----
+$ oc delete namespace spring-petclinic
 ----
 endif::app[]
-ifdef::cluster[]
-+
-[source,terminal]
-----
-$ oc label namespace spring-petclinic argocd.argoproj.io/managed-by=openshift-gitops
-----
-endif::cluster[]


### PR DESCRIPTION
This commit addresses [RHDEVDOCS-6408](https://redhat.atlassian.net/browse/RHDEVDOCS-6408) by adding missing documentation steps for deploying the spring-petclinic sample application.

Changes:
- For Argo CD UI: Added note about selecting "Auto-Create Namespace" in Sync Options to automatically create the destination namespace
- For CLI: Added steps to create and label the destination namespace before creating the application
- Added optional cleanup steps to delete the app and namespace

Fixes: [RHDEVDOCS-6408](https://redhat.atlassian.net/browse/RHDEVDOCS-6408)

