### PR TITLE
OSDOCS-17171-1:CQA 2.0-Security-Certificates-Attachment2

### DIFF
--- a/modules/tls-profiles-ingress-configuring.adoc
+++ b/modules/tls-profiles-ingress-configuring.adoc
@@ -6,9 +6,11 @@
 [id="tls-profiles-ingress-configuring_{context}"]
 = Configuring the TLS security profile for the Ingress Controller
 
-To configure a TLS security profile for an Ingress Controller, edit the `IngressController` custom resource (CR) to specify a predefined or custom TLS security profile. If a TLS security profile is not configured, the default value is based on the TLS security profile set for the API server.
+[role="_abstract"]
+To configure a TLS security profile for an Ingress Controller, edit the `IngressController` custom resource (CR) to specify a predefined or custom TLS security profile.
 
-.Sample `IngressController` CR that configures the `Old` TLS security profile
+If a TLS security profile is not configured, the default value is based on the TLS security profile set for the API server, as shown in the following example:
+
 [source,yaml]
 ----
 apiVersion: operator.openshift.io/v1
@@ -18,7 +20,7 @@ spec:
   tlsSecurityProfile:
     old: {}
     type: Old
- ...
+
 ----
 
 The TLS security profile defines the minimum TLS version and the TLS ciphers for TLS connections for Ingress Controllers.
@@ -29,7 +31,7 @@ You can see the ciphers and the minimum TLS version of the configured TLS securi
 ====
 The HAProxy Ingress Controller image supports TLS `1.3` and the `Modern` profile.
 
-The Ingress Operator also converts the TLS `1.0` of an `Old` or `Custom` profile to `1.1`.
+The Ingress Operator also converts the TLS `1.0` of an `Old` or `Custom` profile to `1.1`. 
 ====
 
 .Prerequisites
@@ -42,9 +44,9 @@ The Ingress Operator also converts the TLS `1.0` of an `Old` or `Custom` profile
 +
 [source,terminal]
 ----
-$ oc edit IngressController default -n openshift-ingress-operator
+$ oc edit IngressController default -n openshift-ingress-operator.
 ----
-
++
 . Add the `spec.tlsSecurityProfile` field:
 +
 .Sample `IngressController` CR for a `Custom` profile
@@ -55,9 +57,9 @@ kind: IngressController
  ...
 spec:
   tlsSecurityProfile:
-    type: Custom <1>
-    custom: <2>
-      ciphers: <3>
+    type: Custom
+    custom:
+      ciphers:
       - ECDHE-ECDSA-CHACHA20-POLY1305
       - ECDHE-RSA-CHACHA20-POLY1305
       - ECDHE-RSA-AES128-GCM-SHA256
@@ -65,13 +67,10 @@ spec:
       minTLSVersion: VersionTLS11
  ...
 ----
-<1> Specify the TLS security profile type (`Old`, `Intermediate`, or `Custom`). The default is `Intermediate`.
-<2> Specify the appropriate field for the selected type:
-* `old: {}`
-* `intermediate: {}`
-* `modern: {}`
-* `custom:`
-<3> For the `custom` type, specify a list of TLS ciphers and minimum accepted TLS version.
++
+* Specify the value for the `spec.tlsSecurityProfile` parameter. The TLS security profile types are `Old`, `Intermediate`, or `Custom`. The default type is `Intermediate`.
+* Specify the appropriate field for the selected `spec.tlsSecurityProfile.type`. The fields are `old: {}`, `intermediate: {}`, `modern: {}`, or `custom:`.
+* For the `custom` type, specify a list of TLS ciphers and the minimum accepted TLS version.
 
 . Save the file to apply the changes.
 

--- a/modules/tls-profiles-kubelet-configuring.adoc
+++ b/modules/tls-profiles-kubelet-configuring.adoc
@@ -12,12 +12,10 @@ endif::[]
 = Configuring the TLS security profile for the kubelet
 
 [role="_abstract"]
-You can configure a TLS security profile for the kubelet when it is acting as an HTTP server by creating a `KubeletConfig` custom resource (CR) to specify a predefined or custom TLS security profile for specific nodes. 
-
-If a TLS security profile is not configured, the default TLS security profile, `Intermediate`, is used.
+To configure TLS ciphers and minimum versions for the kubelet HTTP server in {product-title}, apply a predefined or custom TLS security profile through a `KubeletConfig` custom resource (CR). Without a custom profile, the kubelet defaults to the `Intermediate` profile.
 
 ifdef::tls[]
-The kubelet uses its HTTP/GRPC server to communicate with the Kubernetes API server, which sends commands to pods, gathers logs, and run exec commands on pods through the kubelet.
+* The kubelet uses its HTTP/GRPC server to communicate with the Kubernetes API server, which sends commands to pods, gathers logs, and run exec commands on pods through the kubelet.
 endif::[]
 
 .Sample `KubeletConfig` CR that configures the `Old` TLS security profile on worker nodes

--- a/modules/tls-profiles-kubernetes-configuring.adoc
+++ b/modules/tls-profiles-kubernetes-configuring.adoc
@@ -6,7 +6,10 @@
 [id="tls-profiles-kubernetes-configuring_{context}"]
 = Configuring the TLS security profile for the control plane
 
-To configure a TLS security profile for the control plane, edit the `APIServer` custom resource (CR) to specify a predefined or custom TLS security profile. Setting the TLS security profile in the `APIServer` CR propagates the setting to the following control plane components:
+[role="_abstract"]
+To configure a TLS security profile for the control plane, edit the `APIServer` custom resource (CR) to specify a predefined or custom TLS security profile.
+
+Setting the TLS security profile in the `APIServer` CR propagates the setting to the following control plane components:
 
 * Kubernetes API server
 * Kubernetes controller manager
@@ -18,14 +21,15 @@ To configure a TLS security profile for the control plane, edit the `APIServer` 
 * Machine Config Operator
 * Machine Config Server
 
-If a TLS security profile is not configured, the default TLS security profile is `Intermediate`.
-
 [NOTE]
 ====
 The default TLS security profile for the Ingress Controller is based on the TLS security profile set for the API server.
 ====
 
-.Sample `APIServer` CR that configures the `Old` TLS security profile
+If a TLS security profile is not configured, the default TLS security profile is `Intermediate`.
+
+The following YAML is a sample `APIServer` CR that configures the `Old` TLS security profile.
+
 [source,yaml]
 ----
 apiVersion: config.openshift.io/v1
@@ -66,28 +70,24 @@ metadata:
   name: cluster
 spec:
   tlsSecurityProfile:
-    type: Custom <1>
-    custom: <2>
-      ciphers: <3>
+    type: Custom
+    custom:
+      ciphers:
       - ECDHE-ECDSA-CHACHA20-POLY1305
       - ECDHE-RSA-CHACHA20-POLY1305
       - ECDHE-RSA-AES128-GCM-SHA256
       - ECDHE-ECDSA-AES128-GCM-SHA256
       minTLSVersion: VersionTLS11
 ----
-<1> Specify the TLS security profile type (`Old`, `Intermediate`, or `Custom`). The default is `Intermediate`.
-<2> Specify the appropriate field for the selected type:
-* `old: {}`
-* `intermediate: {}`
-* `modern: {}`
-* `custom:`
-<3> For the `custom` type, specify a list of TLS ciphers and minimum accepted TLS version.
+* Specify the value for the `spec.tlsSecurityProfile.type` parameter. The TLS security profile types are `Old`, `Intermediate`, or `Custom`. The default type is `Intermediate`.
+* Specify the appropriate field for the selected `spec.tlsSecurityProfile`. The fields are `old: {}`, `intermediate: {}`, `modern: {}`, or `custom:`.
+* For the `custom` type, specify a list of TLS ciphers and the minimum accepted TLS version.
 
 . Save the file to apply the changes.
 
 .Verification
 
-* Verify that the TLS security profile is set in the `APIServer` CR:
+. Verify that the TLS security profile is set in the `APIServer` CR:
 +
 [source,terminal]
 ----
@@ -117,9 +117,8 @@ Spec:
     Type:               Custom
  ...
 ----
-.Verification
 
-* Verify that the TLS security profile is set in the `etcd` CR:
+. Verify that the TLS security profile is set in the `etcd` CR:
 +
 [source,terminal]
 ----
@@ -151,7 +150,7 @@ Spec:
  ...
 ----
 
-* Verify that the TLS security profile is set in the Machine Config Server pod:
+. Verify that the TLS security profile is set in the Machine Config Server pod:
 +
 [source,terminal]
 ----

--- a/modules/tls-profiles-view-details.adoc
+++ b/modules/tls-profiles-view-details.adoc
@@ -6,7 +6,8 @@
 [id="tls-profiles-view-details_{context}"]
 = Viewing TLS security profile details
 
-You can view the minimum TLS version and ciphers for the predefined TLS security profiles for each of the following components: Ingress Controller, control plane, and kubelet.
+[role="_abstract"]
+To check the minimum TLS version and ciphers that a security profile applies in {product-title}, you can inspect the profile configuration for the Ingress Controller, control plane, or kubelet. Use the `oc explain` command to display settings for a predefined or custom profile.
 
 [IMPORTANT]
 ====
@@ -19,9 +20,10 @@ The effective configuration of minimum TLS version and list of ciphers for a pro
 +
 [source,terminal]
 ----
-$ oc explain <component>.spec.tlsSecurityProfile.<profile> <1>
+$ oc explain <component>.spec.tlsSecurityProfile.<profile>
 ----
-<1> For `<component>`, specify `ingresscontroller`, `apiserver`, or `kubeletconfig`. For `<profile>`, specify `old`, `intermediate`, or `custom`.
++
+* For `<component>`, specify `ingresscontroller`, `apiserver`, or `kubeletconfig`. For `<profile>`, specify `old`, `intermediate`, or `custom`.
 +
 For example, to check the ciphers included for the `intermediate` profile for the control plane:
 +
@@ -52,9 +54,10 @@ DESCRIPTION:
 +
 [source,terminal]
 ----
-$ oc explain <component>.spec.tlsSecurityProfile <1>
+$ oc explain <component>.spec.tlsSecurityProfile
 ----
-<1> For `<component>`, specify `ingresscontroller`, `apiserver`, or `kubeletconfig`.
++
+* For `<component>`, specify `ingresscontroller`, `apiserver`, or `kubeletconfig`.
 +
 For example, to check all details for the `tlsSecurityProfile` field for the Ingress Controller:
 +
@@ -87,24 +90,21 @@ FIELDS:
      intermediate is a TLS security profile based on:
      https://wiki.mozilla.org/Security/Server_Side_TLS#Intermediate_compatibility_.28recommended.29
      and looks like this (yaml):
-     ... <1>
+     (A list of ciphers and the minimum version for the intermediate profile opens here.)
 
    modern	<>
      modern is a TLS security profile based on:
      https://wiki.mozilla.org/Security/Server_Side_TLS#Modern_compatibility and
      looks like this (yaml):
-     ... <2>
+     (A list of ciphers and the minimum version for the modern profile opens here.)
      NOTE: Currently unsupported.
 
    old	<>
      old is a TLS security profile based on:
      https://wiki.mozilla.org/Security/Server_Side_TLS#Old_backward_compatibility
      and looks like this (yaml):
-     ... <3>
+     (A list of ciphers and the minimum version for the old profile opens here.)
 
    type	<string>
      ...
 ----
-<1> Lists ciphers and minimum version for the `intermediate` profile here.
-<2> Lists ciphers and minimum version for the `modern` profile here.
-<3> Lists ciphers and minimum version for the `old` profile here.

--- a/security/tls-security-profiles.adoc
+++ b/security/tls-security-profiles.adoc
@@ -6,18 +6,23 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-TLS security profiles provide a way for servers to regulate which ciphers a client can use when connecting to the server. This ensures that {product-title} components use cryptographic libraries that do not allow known insecure protocols, ciphers, or algorithms.
+[role="_abstract"]
 
-Cluster administrators can choose which TLS security profile to use for each of the following components:
+To enforce secure cryptographic libraries for the {product-title} components, cluster administrators can configure TLS security profiles to control cipher usage when the client connects to the Ingress Controller, the control plane, or the kubelet.
 
-* the Ingress Controller
-* the control plane
-+
-This includes the Kubernetes API server, Kubernetes controller manager, Kubernetes scheduler, OpenShift API server, OpenShift OAuth API server, OpenShift OAuth server, etcd, the Machine Config Operator, and the Machine Config Server.
-+
+The control plane includes the following components:
+
+* Kubernetes API server
+* Kubernetes controller manager
+* Kubernetes scheduler
+* OpenShift API server
+* OpenShift OAuth API server
+* OpenShift OAuth server
+* etcd
+* Machine Config Operator
+* Machine Config Server.
+
 // NOTE: OpenShift controller manager are not included
-
-* the kubelet, when it acts as an HTTP server for the Kubernetes API server
 
 // Understanding TLS security profiles
 include::modules/tls-profiles-understanding.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s):
4.20+

Issue:
https://redhat.atlassian.net/browse/OSDOCS-17171

Link to docs preview:
https://114283--ocpdocs-pr.netlify.app/openshift-dedicated/latest/networking/networking_operators/ingress-operator.html
https://114283--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/networking_operators/ingress-operator.html
https://114283--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/nodes/nodes-nodes-tls.html
https://114283--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/tls-security-profiles.html
https://114283--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/networking/networking_operators/ingress-operator.html
https://114283--ocpdocs-pr.netlify.app/openshift-rosa/latest/networking/networking_operators/ingress-operator.html
