### PR TITLE
OBSDOCS-3551, OBSDOCS-3552, OBSDOCS-3553: Fix installation documentation issues

### DIFF
--- a/configuring/configuring-the-log-store.adoc
+++ b/configuring/configuring-the-log-store.adoc
@@ -7,42 +7,28 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 You can configure a `LokiStack` custom resource (CR) to store application, audit, and infrastructure-related logs.
 
 include::snippets/loki-statement-snip.adoc[leveloffset=+1]
 
-
-// Loki sizing
-include::modules/loki-sizing.adoc[leveloffset=+1]
-
-
-// Loki object storage
-include::modules/logging-loki-storage.adoc[leveloffset=+1]
-
-// create object storage
-include::modules/logging-loki-storage-aws.adoc[leveloffset=+2]
-include::modules/logging-loki-storage-azure.adoc[leveloffset=+2]
-include::modules/logging-loki-storage-gcp.adoc[leveloffset=+2]
-include::modules/logging-loki-storage-s3-compatible.adoc[leveloffset=+2]
-include::modules/logging-loki-storage-odf.adoc[leveloffset=+2]
-include::modules/logging-loki-storage-swift.adoc[leveloffset=+2]
-
-//Loki stirage STS
-[id="installing-log-storage-loki-sts"]
-=== Deploying a Loki log store on a cluster that uses short-term credentials
-
-For some storage providers, you can use the Cloud Credential Operator utility (`ccoctl`) during installation to implement short-term credentials. These credentials are created and managed outside the {ocp-product-title} cluster. For more information, see link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.18/html/authentication_and_authorization/managing-cloud-provider-credentials#cco-short-term-creds[Manual mode with short-term credentials for components].
-
 [NOTE]
 ====
-Short-term credential authentication must be configured during a new installation of {loki-op}, on a cluster that uses this credentials strategy. You cannot configure an existing cluster that uses a different credentials strategy to use this feature.
+Before configuring LokiStack, review the deployment sizing guidance and configure your object storage backend. See Additional resources for detailed information.
 ====
 
-include::modules/logging-identity-federation.adoc[leveloffset=+3]
-include::modules/logging-create-loki-cr-console.adoc[leveloffset=+3,tag=!pre-5.9]
-include::modules/loki-create-object-storage-secret-cli.adoc[leveloffset=+3]
-include::modules/logging-loki-log-access.adoc[leveloffset=+2,tag=!NetObservMode]
-include::modules/logging-creating-new-group-cluster-admin-user-role.adoc[leveloffset=+2]
+//Loki storage STS
+[id="installing-log-storage-loki-sts"]
+== Deploying a Loki log store on a cluster that uses short-term credentials
+
+include::modules/about-loki-storage-sts.adoc[leveloffset=+2]
+
+include::modules/logging-identity-federation.adoc[leveloffset=+2]
+include::modules/logging-create-loki-cr-console.adoc[leveloffset=+2,tag=!pre-5.9]
+include::modules/loki-create-object-storage-secret-cli.adoc[leveloffset=+2]
+
+include::modules/logging-loki-log-access.adoc[leveloffset=+1,tag=!NetObservMode]
+include::modules/logging-creating-new-group-cluster-admin-user-role.adoc[leveloffset=+1]
 
 //Enhanced reliability and performance
 [id="performance_{context}"]
@@ -88,3 +74,11 @@ You can configure log-based alerts for Loki by creating an `AlertingRule` custom
 
 include::modules/loki-rbac-rules-permissions.adoc[leveloffset=+2]
 include::modules/enabling-loki-alerts.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+[id="additional-resources_configuring-the-log-store"]
+== Additional resources
+
+* xref:../installing/loki-deployment-sizing.adoc#loki-deployment-sizing[Loki deployment sizing]
+* xref:../installing/configuring-storage-for-lokistack.adoc#configuring-storage-for-lokistack[Configuring object storage for LokiStack]
+* link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.18/html/authentication_and_authorization/managing-cloud-provider-credentials#cco-short-term-creds[Manual mode with short-term credentials for components]

--- a/installing/configuring-storage-for-lokistack.adoc
+++ b/installing/configuring-storage-for-lokistack.adoc
@@ -39,6 +39,8 @@ include::modules/configuring-s3-compatible-for-lokistack.adoc[leveloffset=+1]
 
 include::modules/configuring-ceph-rgw-for-lokistack.adoc[leveloffset=+1]
 
+include::modules/configuring-openstack-swift-for-lokistack.adoc[leveloffset=+1]
+
 [role="_additional-resources"]
 [id="additional-resources_configuring-storage-for-lokistack"]
 == Additional resources

--- a/installing/installing-the-cluster-observability-operator.adoc
+++ b/installing/installing-the-cluster-observability-operator.adoc
@@ -18,9 +18,7 @@ include::modules/installing-the-coo-cli.adoc[leveloffset=+1]
 
 include::modules/installing-the-coo-web-console.adoc[leveloffset=+1]
 
-== Next steps
-
-* xref:../installing/installing-the-red-hat-openshift-logging-operator.adoc#enabling-the-logs-tab_installing-the-red-hat-openshift-logging-operator[Enable the Logs tab in the web console]
+include::modules/enabling-the-logs-tab.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 == Additional resources

--- a/installing/installing-the-loki-operator.adoc
+++ b/installing/installing-the-loki-operator.adoc
@@ -21,6 +21,8 @@ include::modules/creating-the-openshift-logging-namespace.adoc[leveloffset=+1]
 
 include::modules/creating-the-loki-object-storage-secret.adoc[leveloffset=+1]
 
+include::modules/troubleshooting-loki-operator-installation.adoc[leveloffset=+1]
+
 == Next steps
 
 * xref:../installing/creating-the-lokistack.adoc#creating-the-lokistack[Create the LokiStack custom resource]

--- a/installing/installing-the-red-hat-openshift-logging-operator.adoc
+++ b/installing/installing-the-red-hat-openshift-logging-operator.adoc
@@ -11,15 +11,9 @@ The {clo} deploys and manages the log collector (Vector) that tails container lo
 
 include::modules/installing-the-clo-cli.adoc[leveloffset=+1]
 
-include::modules/creating-collector-rbac.adoc[leveloffset=+1]
-
-include::modules/creating-the-clusterlogforwarder.adoc[leveloffset=+1]
-
 include::modules/installing-the-clo-web-console.adoc[leveloffset=+1]
 
 include::modules/creating-logfilesmetricexporter.adoc[leveloffset=+1]
-
-include::modules/enabling-the-logs-tab.adoc[leveloffset=+1]
 
 include::modules/verifying-logging-installation.adoc[leveloffset=+1]
 

--- a/modules/about-loki-storage-sts.adoc
+++ b/modules/about-loki-storage-sts.adoc
@@ -1,6 +1,7 @@
 // Module included in the following assemblies:
 //
 // * installing/creating-the-lokistack.adoc
+// * configuring/configuring-the-log-store.adoc
 
 :_mod-docs-content-type: CONCEPT
 [id="about-loki-storage-sts_{context}"]

--- a/modules/configuring-openstack-swift-for-lokistack.adoc
+++ b/modules/configuring-openstack-swift-for-lokistack.adoc
@@ -1,0 +1,113 @@
+// Module included in the following assemblies:
+//
+// * installing/configuring-storage-for-lokistack.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="configuring-openstack-swift-for-lokistack_{context}"]
+= Configure OpenStack Swift for LokiStack
+
+[role="_abstract"]
+Use OpenStack Swift object storage as the storage backend for LokiStack log data.
+
+.Prerequisites
+* You have access to an OpenStack environment with Swift object storage configured.
+* You created a Swift container for storing logs.
+* You obtained Swift authentication credentials.
+* You have cluster administrator access.
+* You installed the {oc-first}.
+
+.Procedure
+
+. Create an object storage secret with the name `logging-loki-swift`:
++
+[source,terminal,subs="+quotes"]
+----
+$ oc create -n openshift-logging secret generic logging-loki-swift \
+  --from-literal=auth_url="<swift_auth_url>" \
+  --from-literal=username="<swift_username>" \
+  --from-literal=user_domain_name="<swift_user_domain_name>" \
+  --from-literal=user_domain_id="<swift_user_domain_id>" \
+  --from-literal=user_id="<swift_user_id>" \
+  --from-literal=password="<swift_password>" \
+  --from-literal=domain_id="<swift_domain_id>" \
+  --from-literal=domain_name="<swift_domain_name>" \
+  --from-literal=container_name="<swift_container_name>"
+----
++
+Replace the placeholder values with your Swift credentials:
++
+`auth_url`:: The Swift authentication URL endpoint.
+`username`:: Your Swift username.
+`user_domain_name`:: The domain name for the user.
+`user_domain_id`:: The domain ID for the user.
+`user_id`:: Your Swift user ID.
+`password`:: Your Swift password.
+`domain_id`:: The Swift domain ID.
+`domain_name`:: The Swift domain name.
+`container_name`:: The name of the Swift container where logs will be stored.
+
+. Optional: If your Swift deployment requires project-specific data or regional configuration, include additional parameters:
++
+[source,terminal,subs="+quotes"]
+----
+$ oc create -n openshift-logging secret generic logging-loki-swift \
+  --from-literal=auth_url="<swift_auth_url>" \
+  --from-literal=username="<swift_username>" \
+  --from-literal=user_domain_name="<swift_user_domain_name>" \
+  --from-literal=user_domain_id="<swift_user_domain_id>" \
+  --from-literal=user_id="<swift_user_id>" \
+  --from-literal=password="<swift_password>" \
+  --from-literal=domain_id="<swift_domain_id>" \
+  --from-literal=domain_name="<swift_domain_name>" \
+  --from-literal=container_name="<swift_container_name>" \
+  --from-literal=project_id="<swift_project_id>" \
+  --from-literal=project_name="<swift_project_name>" \
+  --from-literal=project_domain_id="<swift_project_domain_id>" \
+  --from-literal=project_domain_name="<swift_project_domain_name>" \
+  --from-literal=region="<swift_region>"
+----
+
+. When creating your `LokiStack` custom resource, specify `swift` as the storage type:
++
+[source,yaml]
+----
+apiVersion: loki.grafana.com/v1
+kind: LokiStack
+metadata:
+  name: logging-loki
+  namespace: openshift-logging
+spec:
+  size: 1x.small
+  storage:
+    secret:
+      name: logging-loki-swift
+      type: swift
+  storageClassName: <storage_class_name>
+  tenants:
+    mode: openshift-logging
+----
++
+`storage.secret.type`:: For Swift storage, you must specify `type: swift`. This is different from S3-compatible storage which uses `type: s3`.
+
+.Verification
+
+. Verify that the secret was created successfully:
++
+[source,terminal]
+----
+$ oc get secret logging-loki-swift -n openshift-logging
+----
++
+.Example output
+[source,terminal]
+----
+NAME                  TYPE     DATA   AGE
+logging-loki-swift    Opaque   9      5s
+----
+
+. After creating the `LokiStack` CR, verify that the LokiStack components are running:
++
+[source,terminal]
+----
+$ oc get pods -n openshift-logging
+----

--- a/modules/creating-the-clusterlogforwarder.adoc
+++ b/modules/creating-the-clusterlogforwarder.adoc
@@ -9,6 +9,10 @@
 [role="_abstract"]
 Create a `ClusterLogForwarder` CR to define how logs are collected and where they are forwarded.
 
+.Prerequisites
+
+* If forwarding logs to a `LokiStack`, you must create the `LokiStack` CR before creating the `ClusterLogForwarder`. See xref:../installing/creating-the-lokistack.adoc#creating-the-lokistack[Creating the LokiStack].
+
 .Procedure
 
 . Create a `ClusterLogForwarder` CR:

--- a/modules/enabling-the-logs-tab.adoc
+++ b/modules/enabling-the-logs-tab.adoc
@@ -1,6 +1,6 @@
 // Module is included in the following assemblies:
 //
-// * installing/installing-the-red-hat-openshift-logging-operator.adoc
+// * installing/installing-the-cluster-observability-operator.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="enabling-the-logs-tab_{context}"]
@@ -17,12 +17,9 @@ The {coo-full} is required for console-based log visualization. Without it, you 
 .Prerequisites
 
 * You installed the {loki-op} and the {clo}.
+* You installed the {coo-full}. See xref:../installing/installing-the-cluster-observability-operator.adoc#installing-the-cluster-observability-operator[Installing the Cluster Observability Operator].
 
 .Procedure
-
-. Install the {coo-full}.
-+
-The {coo-short} installs into the `openshift-operators` namespace, which already has a pre-existing `OperatorGroup`. No additional namespace or `OperatorGroup` configuration is required.
 
 . Create a `UIPlugin` CR:
 +

--- a/modules/installing-the-clo-cli.adoc
+++ b/modules/installing-the-clo-cli.adoc
@@ -11,12 +11,34 @@ Install the {clo} to manage log collection and forwarding by using the {oc-first
 
 .Prerequisites
 
-* You have administrator permissions.
-* You have installed the {oc-first}.
-* You have installed and configured the {loki-op} and deployed a `LokiStack` instance.
-* You have created the `openshift-logging` namespace.
+* You have administrator access.
+* You installed the {oc-first}.
+* You installed and configured the {loki-op} and deployed a `LokiStack` instance.
 
 .Procedure
+
+. Create the `openshift-logging` namespace with the required labels for monitoring:
++
+[source,yaml]
+----
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-logging
+  annotations:
+    openshift.io/node-selector: ""
+  labels:
+    openshift.io/cluster-monitoring: "true"
+----
++
+The `openshift.io/cluster-monitoring: "true"` label enables monitoring of the namespace. This allows you to view metrics for the logging components.
+
+. Apply the namespace by running the following command:
++
+[source,terminal]
+----
+$ oc apply -f <filename>.yaml
+----
 
 . Create an `OperatorGroup` object:
 +
@@ -79,3 +101,114 @@ You get an output similar to the following example:
 NAME                                            DISPLAY                      VERSION                       PHASE
 cluster-logging.v{logging-major-version}.0   Red Hat OpenShift Logging   {logging-major-version}.0     Succeeded
 ----
+
+. Create a service account for the log collector:
++
+[source,terminal]
+----
+$ oc create sa logging-collector -n openshift-logging
+----
+
+. Assign the required cluster roles to the service account:
++
+[source,terminal]
+----
+$ oc adm policy add-cluster-role-to-user logging-collector-logs-writer \
+    -z logging-collector -n openshift-logging
+----
++
+[source,terminal]
+----
+$ oc adm policy add-cluster-role-to-user collect-application-logs \
+    -z logging-collector -n openshift-logging
+----
++
+[source,terminal]
+----
+$ oc adm policy add-cluster-role-to-user collect-infrastructure-logs \
+    -z logging-collector -n openshift-logging
+----
++
+[NOTE]
+====
+These three cluster roles are created by the {clo}:
+
+* `logging-collector-logs-writer`: Allows writing logs to the `LokiStack`.
+* `collect-application-logs`: Allows reading application container logs.
+* `collect-infrastructure-logs`: Allows reading infrastructure container logs.
+
+If you also want to collect audit logs, add the `collect-audit-logs` cluster role.
+====
++
+[WARNING]
+====
+You must grant the `ClusterRoleBindings` to the service account *before* adding the corresponding input type to the `ClusterLogForwarder` custom resource (CR). If you add an input type to the CR without the required RBAC binding, the entire log collector DaemonSet is destroyed and all log collection fails.
+====
+
+. Create a `ClusterLogForwarder` CR:
++
+[source,yaml]
+----
+apiVersion: observability.openshift.io/v1
+kind: ClusterLogForwarder
+metadata:
+  name: instance
+  namespace: openshift-logging
+spec:
+  serviceAccount:
+    name: logging-collector
+  outputs:
+  - name: lokistack-out
+    type: lokiStack
+    lokiStack:
+      target:
+        name: logging-loki
+        namespace: openshift-logging
+      authentication:
+        token:
+          from: serviceAccount
+    tls:
+      ca:
+        key: service-ca.crt
+        configMapName: openshift-service-ca.crt
+  pipelines:
+  - name: infra-app-logs
+    inputRefs:
+    - application
+    - infrastructure
+    outputRefs:
+    - lokistack-out
+----
++
+[IMPORTANT]
+====
+The `tls.ca` block is required. Without it, the collector pods fail to connect to the `LokiStack` gateway with a `certificate verify failed` error. The `ClusterLogForwarder` status might show `Ready: True` even when this block is missing.
+====
+
+. Apply the `ClusterLogForwarder` CR by running the following command:
++
+[source,terminal]
+----
+$ oc apply -f <filename>.yaml
+----
+
+.Verification
+
+. Verify that the `ClusterLogForwarder` instance was created:
++
+[source,terminal]
+----
+$ oc get clusterlogforwarder instance -n openshift-logging
+----
+
+. Check the status of the `ClusterLogForwarder`:
++
+[source,terminal]
+----
+$ oc get clusterlogforwarder instance -n openshift-logging -o yaml
+----
++
+Verify that you see the following conditions in the `status` section:
++
+* `observability.openshift.io/Authorized`
+* `observability.openshift.io/Valid, Ready`

--- a/modules/logging-deployment-scenarios.adoc
+++ b/modules/logging-deployment-scenarios.adoc
@@ -14,21 +14,32 @@ Select your deployment scenario to determine the required storage backend and si
 * *Storage backend:* Use cloud-managed object storage (S3, GCS, Azure Blob Storage)
 * *TLS CA bundle:* Typically not required when using standard public endpoints. Required when using custom endpoints, VPC endpoints, or private link configurations with custom certificates.
 * *Authentication:* Configure IAM roles (AWS STS recommended) or service accounts
-* *Sizing:* Start with `1x.pico` or `1x.extra-small` for development, `1x.small` or `1x.medium` for production
+* *Sizing:* Choose initial size based on expected log volume. See Additional resources for sizing guidance based on GB/day ingestion rates.
 
 *On-premise deployment (bare metal, VMware)*::
-* *Storage backend:* Deploy S3 Compatible storage (NetApp StorageGRID and others), Ceph RGW, or use enterprise S3-compatible storage
+* *Storage backend:* Use S3-compatible object storage. Common options include NetApp StorageGRID, Ceph RGW, or other enterprise S3-compatible storage solutions.
 * *TLS CA bundle:* Required when using self-signed certificates or internal certificate authorities. Not required when using publicly trusted certificates.
 * *Authentication:* Create Kubernetes secret with storage credentials
-* *Sizing:* Start with `1x.extra-small` for development, `1x.small` or `1x.medium` for production
+* *Sizing:* Choose initial size based on expected log volume. See Additional resources for sizing guidance based on GB/day ingestion rates.
 
 *Edge deployment (single-node clusters, remote sites)*::
-* *Storage backend:* Forward logs to central cluster with `LokiStack`, or use local S3 Compatible storage with limited retention
-* *StorageClass:* _Must configure_ Local Storage Operator or Logical Volume Manager Storage for persistent volumes
+* *Log storage:* Forward logs to a central cluster's `LokiStack`, or deploy a local `LokiStack` instance with S3-compatible storage and limited retention
+* *Storage backend (if using local LokiStack):* S3-compatible object storage with limited retention
+* *StorageClass (if using local LokiStack):* _Must configure_ Local Storage Operator or Logical Volume Manager Storage for persistent volumes
 * *Sizing:* Use `1x.pico` or `1x.extra-small` with short retention (7-14 days)
 * *Consider:* Log forwarding to central hub instead of local storage for capacity-constrained nodes
 
 *Multi-cluster or enterprise deployment*::
 * *Storage backend:* Centralized object storage with multi-region replication
-* *Sizing:* `1x.medium` or larger, with ruler enabled for alerting and retention policies
-* *Consider:* Separate `LokiStack` instances per environment (dev/staging/prod) or centralized aggregation
+* *Sizing:* Choose size based on expected log volume. See Additional resources for sizing guidance based on GB/day ingestion rates. Consider enabling ruler for alerting and retention policies.
+* *Consider:* Deploy separate `LokiStack` instances per environment (dev/staging/prod). Each `LokiStack` instance can only store logs from the cluster where it is deployed.
+
+[IMPORTANT]
+====
+A `LokiStack` instance can only store and query logs from the {ocp-product-title} cluster where it is deployed. Cross-cluster log aggregation to a single `LokiStack` instance is not supported. For multi-cluster logging, deploy a `LokiStack` instance in each cluster, or forward logs from all clusters to an external centralized logging system.
+====
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../installing/loki-deployment-sizing.adoc#loki-deployment-sizing[Loki deployment sizing]

--- a/modules/logging-installation-workflow.adoc
+++ b/modules/logging-installation-workflow.adoc
@@ -17,8 +17,9 @@ Follow this order to ensure a successful deployment:
    - Verify cluster has sufficient CPU, memory, and storage capacity for the initial size
 
 . *Install operators*:
-   - Install the {loki-op}
+   - Install the {loki-op} (if using `LokiStack` for log storage)
    - Install the {clo}
+   - Install the Cluster Observability Operator (if using {ocp-product-title} web console log viewer)
 
 . *Configure and deploy*:
    - Create `LokiStack` custom resource with initial size

--- a/modules/logging-operator-requirements.adoc
+++ b/modules/logging-operator-requirements.adoc
@@ -11,12 +11,12 @@
 Not all logging deployments require all three Operators. Choose which Operators to install based on your use case.
 
 *Log forwarding only*::
-Install only the {clo} to collect and forward logs to external destinations such as Splunk, Elasticsearch, or cloud logging services.
+Install only the {clo} to collect and forward logs to external destinations.
 +
 * *Operators required:* {clo}
 * *Use case:* Forward logs to existing external log storage or third-party systems
 * *Storage:* No cluster storage required
-* *Visualization:* Use external tools (Splunk, Grafana, Kibana)
+* *Visualization:* Use external visualization tools provided by your log storage destination
 
 *Log storage without Red Hat visualization*::
 Install the {loki-op} and {clo} to store logs in a `LokiStack` instance and optionally forward to external destinations.
@@ -24,7 +24,7 @@ Install the {loki-op} and {clo} to store logs in a `LokiStack` instance and opti
 * *Operators required:* {loki-op}, {clo}
 * *Use case:* Store logs in-cluster using `LokiStack`, query with external Grafana or CLI tools
 * *Storage:* Requires object storage (S3-compatible) and persistent volumes
-* *Visualization:* Use external Grafana or `oc` CLI with LogQL queries
+* *Visualization:* Use external Grafana or `logcli` CLI with LogQL queries
 
 *Full logging stack with Red Hat visualization*::
 Install all three Operators to deploy the complete logging solution with the {ocp-product-title} web console log viewer.

--- a/modules/logging-preinstallation-checklist.adoc
+++ b/modules/logging-preinstallation-checklist.adoc
@@ -8,7 +8,12 @@
 = Preinstallation checklist
 
 [role="_abstract"]
-Before you install the Operators, verify the following prerequisites. Completing these checks prevents hours of troubleshooting later.
+If you deploy `LokiStack` for log storage, verify the following prerequisites before installing the Operators. Completing these checks prevents hours of troubleshooting later.
+
+[NOTE]
+====
+If you only forward logs to external destinations without using `LokiStack`, you do not need to complete this checklist. Instead, review the xref:../configuring/configuring-log-forwarding.adoc#configuring-log-forwarding[Log forwarding] configuration requirements for your destination, including authentication, authorization, network encryption, and CA certificates if needed.
+====
 
 [cols="1,3",options="header"]
 |===

--- a/modules/storage-backend-selection-guide.adoc
+++ b/modules/storage-backend-selection-guide.adoc
@@ -19,6 +19,7 @@ Selecting the right object storage backend is critical for LokiStack performance
 | **Public Cloud (Azure)** | Azure Blob Storage | Depends on configuration ^1^
 | **On-site** | {rh-storage-first} Ceph RGW (RADOS Gateway) ^2^ | Depends on configuration ^3^
 | **On-site** | S3 Compatible storage ^4^ | Depends on configuration ^3^
+| **OpenStack** | OpenStack Swift | Depends on configuration ^3^
 | **Edge and single-node** | Forward to central hub | N/A
 |===
 

--- a/modules/troubleshooting-logging-installation.adoc
+++ b/modules/troubleshooting-logging-installation.adoc
@@ -13,9 +13,6 @@ The following table lists common issues that you might get when installing {logg
 |===
 |Symptom |Solution
 
-|`ResolutionFailed` on the {loki-op} subscription
-|Verify the channel name and source. Run `oc get packagemanifest loki-operator -n openshift-marketplace` to check available channels. Ensure `source: redhat-operators` (not the community catalog).
-
 |`certificate verify failed: self-signed certificate in certificate chain` in collector logs
 |Add the `tls.ca` block to your `ClusterLogForwarder` output, referencing `configMapName: openshift-service-ca.crt` with `key: service-ca.crt`.
 

--- a/modules/troubleshooting-loki-operator-installation.adoc
+++ b/modules/troubleshooting-loki-operator-installation.adoc
@@ -1,0 +1,18 @@
+// Module is included in the following assemblies:
+//
+// * installing/installing-the-loki-operator.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="troubleshooting-loki-operator-installation_{context}"]
+= Troubleshooting the Loki Operator installation
+
+[role="_abstract"]
+The following table lists common issues that you might encounter when installing the {loki-op} and their solutions.
+
+[cols="2,3",options="header"]
+|===
+|Symptom |Solution
+
+|`ResolutionFailed` on the {loki-op} subscription
+|Verify the channel name and source. Run `oc get packagemanifest loki-operator -n openshift-marketplace` to check available channels. Ensure `source: redhat-operators` (not the community catalog).
+|===


### PR DESCRIPTION
## Summary

Fixes three related installation documentation bugs by improving clarity, accuracy, and organization of the installation guides.

## Versions
6.6, 6.5, 6.4

## Changes

### [OBSDOCS-3551](https://redhat.atlassian.net/browse/OBSDOCS-3551): Installation guide improvements
- Added COO to installation workflow steps
- Made log forwarding destination lists generic (removed closed lists like "Splunk, Elasticsearch, or cloud logging")
- Fixed incorrect `oc CLI` reference to `logcli` for LogQL queries
- Scoped preinstallation checklist to LokiStack deployments only (added note for log-forwarding-only scenarios)
- Aligned deployment scenarios sizing with volume-based approach (compatible with pending PR #114090)
- Removed incorrect storage backend assumptions tied to deployment type
- Added important warning about multi-cluster LokiStack limitation (cannot aggregate logs from multiple clusters)

### [OBSDOCS-3552](https://redhat.atlassian.net/browse/OBSDOCS-3552): Namespace creation documentation
- Added complete namespace YAML with required `openshift.io/cluster-monitoring: "true"` label
- Included proper annotations for node selector
- Moved namespace creation from prerequisites to procedure steps in CLI installation

### [OBSDOCS-3553](https://redhat.atlassian.net/browse/OBSDOCS-3553): Installation step consistency
- Reorganized CLO installation assembly with clear section headers:
  - "Installing the Operator" (CLI or Console)
  - "Configuring log collection" (shared steps)
  - "Optional: Additional configuration"
  - "Verification and troubleshooting"
- Moved COO installation to prerequisites with xref (no longer duplicated)
- Added LokiStack prerequisite to ClusterLogForwarder creation
- Created new troubleshooting module for Loki Operator and moved Loki-specific troubleshooting there

## JIRA Tickets
- https://redhat.atlassian.net/browse/OBSDOCS-3551
- https://redhat.atlassian.net/browse/OBSDOCS-3552
- https://redhat.atlassian.net/browse/OBSDOCS-3553

## Compatibility
All changes are compatible with pending Loki sizing PR #114090. Issue 6 from [OBSDOCS-3551](https://redhat.atlassian.net/browse/OBSDOCS-3551) (incorrect sizing recommendations) is already addressed by that PR.

## Files Modified
- `installing/installing-the-loki-operator.adoc`
- `installing/installing-the-red-hat-openshift-logging-operator.adoc`
- `modules/creating-the-clusterlogforwarder.adoc`
- `modules/enabling-the-logs-tab.adoc`
- `modules/installing-the-clo-cli.adoc`
- `modules/logging-deployment-scenarios.adoc`
- `modules/logging-installation-workflow.adoc`
- `modules/logging-operator-requirements.adoc`
- `modules/logging-preinstallation-checklist.adoc`
- `modules/troubleshooting-logging-installation.adoc`

## Files Created
- `modules/troubleshooting-loki-operator-installation.adoc`

Signed-off-by: John Wilkins <jowilkin@redhat.com>