### PR TITLE
OCPBUGS-93800: Added HCP note to egress IP docs

### DIFF
--- a/modules/nw-egress-ips-platform-support.adoc
+++ b/modules/nw-egress-ips-platform-support.adoc
@@ -9,6 +9,14 @@
 [role="_abstract"]
 The Egress IP address feature that runs on a primary host network is supported on specific platforms.
 
+[IMPORTANT]
+====
+For {hcp-capital} environments, egress IP address functionality is not supported on the following networks:
+
+* Primary host networks that have been configured with multiple network interface controllers (NICs).
+* Any secondary host networks.
+====
+
 The following table shows supported platforms for egress IP on primary host networks:
 
 [cols="1,1",options="header"]

--- a/modules/nw-egress-ips-platform-support.adoc
+++ b/modules/nw-egress-ips-platform-support.adoc
@@ -9,6 +9,11 @@
 [role="_abstract"]
 The Egress IP address feature that runs on a primary host network is supported on specific platforms.
 
+[IMPORTANT]
+====
+EgressIP is only supported on a primary network that is configured to run {hcp} nodes.
+====
+
 The following table shows supported platforms for egress IP on primary host networks:
 
 [cols="1,1",options="header"]


### PR DESCRIPTION
Version(s):
4.16+

Issue:
[OCPBUGS-93800](https://redhat.atlassian.net/browse/OCPBUGS-93800)

Link to docs preview:

* https://114286--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/configuring-egress-ips-ovn.html
* https://114286--ocpdocs-pr.netlify.app/openshift-rosa/latest/networking/ovn_kubernetes_network_provider/configuring-egress-ips-ovn.html

- [ ] SME has approved this change.
- [ ] QE has approved this change.

https://redhat-internal.slack.com/archives/CDCP2LA9L/p1781090406894909
