### PR TITLE
OSDOCS-17045-4:  CQA 1 for MACH-4 Cluster API for Compute Machines

### DIFF
--- a/machine_management/cluster_api_machine_management/cluster_api_provider_configurations/cluster-api-config-options-bare-metal.adoc
+++ b/machine_management/cluster_api_machine_management/cluster_api_provider_configurations/cluster-api-config-options-bare-metal.adoc
@@ -6,6 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 You can change the configuration of your bare metal Cluster API machines by updating values in the Cluster API custom resource manifests.
 
 :FeatureName: Managing machines with the Cluster API

--- a/machine_management/cluster_api_machine_management/cluster_api_provider_configurations/cluster-api-config-options-gcp.adoc
+++ b/machine_management/cluster_api_machine_management/cluster_api_provider_configurations/cluster-api-config-options-gcp.adoc
@@ -6,6 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 You can change the configuration of your {gcp-first} Cluster API machines by updating values in the Cluster API custom resource manifests.
 
 :FeatureName: Managing machines with the Cluster API

--- a/modules/capi-yaml-machine-set-bare-metal.adoc
+++ b/modules/capi-yaml-machine-set-bare-metal.adoc
@@ -6,6 +6,7 @@
 [id="capi-yaml-machine-set-bare-metal_{context}"]
 = Sample YAML for a Cluster API compute machine set resource on bare metal
 
+[role="_abstract"]
 The compute machine set resource defines additional properties of the machines that it creates.
 The compute machine set also references the cluster resource and machine template when creating machines.
 
@@ -14,10 +15,10 @@ The compute machine set also references the cluster resource and machine templat
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineSet
 metadata:
-  name: <machine_set_name> # <1>
+  name: <machine_set_name>
   namespace: openshift-cluster-api
   labels:
-    cluster.x-k8s.io/cluster-name: <cluster_name> # <2>
+    cluster.x-k8s.io/cluster-name: <cluster_name>
 spec:
   clusterName: <cluster_name>
   replicas: 1
@@ -39,12 +40,15 @@ spec:
       clusterName: <cluster_name>
       infrastructureRef:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-        kind: Metal3MachineTemplate # <3>
-        name: <template_name> # <4>
+        kind: Metal3MachineTemplate
+        name: <template_name>
 ----
-<1> Specify a name for the compute machine set.
+
+where:
+
+`metadata.name`:: Specifies a name for the compute machine set. 
 The cluster ID, machine role, and region form a typical pattern for this value in the following format: `<cluster_name>-<role>-<region>`.
-<2> Specify the cluster ID as the name of the cluster.
-<3> Specify the machine template kind.
+`metadata.labels.cluster.x-k8s.io/cluster-name`:: Specifies the cluster ID as the name of the cluster.
+`spec.template.spec.infrastructureRef.kind`:: Specifies the machine template kind. 
 This value must match the value for your platform.
-<4> Specify the machine template name.
+`spec.template.spec.infrastructureRef.name`:: Specifies the machine template name.

--- a/modules/capi-yaml-machine-set-gcp.adoc
+++ b/modules/capi-yaml-machine-set-gcp.adoc
@@ -6,6 +6,7 @@
 [id="capi-yaml-machine-set-gcp_{context}"]
 = Sample YAML for a Cluster API compute machine set resource on {gcp-full}
 
+[role="_abstract"]
 The compute machine set resource defines additional properties of the machines that it creates.
 The compute machine set also references the cluster resource and machine template when creating machines.
 
@@ -14,12 +15,12 @@ The compute machine set also references the cluster resource and machine templat
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineSet
 metadata:
-  name: <machine_set_name> # <1>
+  name: <machine_set_name>
   namespace: openshift-cluster-api
   labels:
-    cluster.x-k8s.io/cluster-name: <cluster_name> # <2>
+    cluster.x-k8s.io/cluster-name: <cluster_name>
 spec:
-  clusterName: <cluster_name> # <2>
+  clusterName: <cluster_name>
   replicas: 1
   selector:
     matchLabels:
@@ -39,14 +40,18 @@ spec:
       clusterName: <cluster_name>
       infrastructureRef:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-        kind: GCPMachineTemplate # <3>
-        name: <template_name> # <4>
-      failureDomain: <failure_domain> # <5>
+        kind: GCPMachineTemplate
+        name: <template_name>
+      failureDomain: <failure_domain>
 ----
-<1> Specify a name for the compute machine set.
+
+where:
+
+`metadata.name`:: Specifies a name for the compute machine set. 
 The cluster ID, machine role, and region form a typical pattern for this value in the following format: `<cluster_name>-<role>-<region>`.
-<2> Specify the cluster ID as the name of the cluster.
-<3> Specify the machine template kind.
+`metadata.labels.cluster.x-k8s.io/cluster-name`:: Specifies the cluster ID as the name of the cluster.
+`spec.clusterName`:: Specifies the cluster ID as the name of the cluster.
+`spec.template.spec.infrastructureRef.kind`:: Specifies the machine template kind. 
 This value must match the value for your platform.
-<4> Specify the machine template name.
-<5> Specify the failure domain within the {gcp-short} region.
+`spec.template.spec.infrastructureRef.name`:: Specifies the machine template name.
+`spec.template.spec.failureDomain`:: Specifies the failure domain within the {gcp-short} region.

--- a/modules/capi-yaml-machine-template-bare-metal.adoc
+++ b/modules/capi-yaml-machine-template-bare-metal.adoc
@@ -6,29 +6,35 @@
 [id="capi-yaml-machine-template-bare-metal_{context}"]
 = Sample YAML for a Cluster API machine template resource on bare metal
 
+[role="_abstract"]
 The machine template resource is provider-specific and defines the basic properties of the machines that a compute machine set creates.
 The compute machine set references this template when creating machines.
 
 [source,yaml]
 ----
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-kind: Metal3MachineTemplate # <1>
+kind: Metal3MachineTemplate
 metadata:
-  name: <template_name>  # <2>
+  name: <template_name>
   namespace: openshift-cluster-api
 spec:
   template:
-    spec: # <3>
+    spec:
       customDeploy: install_coreos
       userData: 
-        name: worker-user-data-managed # <4>
+        name: worker-user-data-managed
 ----
-<1> Specify the machine template kind.
+
+where:
+
+`kind`:: Specifies the machine template kind.
 This value must match the value for your platform.
-<2> Specify a name for the machine template.
-<3> Specify the details for your environment. The values here are examples.
-<4> The `userData` parameter refers to the Ignition configuration, which the Machine API Operator generates during installation. You must apply the `openshift-cluster-api` namespace to ensure the cluster can access the secret by running the following command:
-+
+`metadata.name`:: Specifies a name for the machine template.
+`spec.template.spec`:: Specifies the details for your environment. 
+The values here are examples.
+`spec.template.spec.userData.name`:: Specifies the Ignition configuration, which the Machine API Operator generates during installation. 
+You must apply the `openshift-cluster-api` namespace to ensure the cluster can access the secret by running the following command:
+
 [source,terminal]
 ----
 $ oc get secret worker-user-data-managed \

--- a/modules/capi-yaml-machine-template-gcp.adoc
+++ b/modules/capi-yaml-machine-template-gcp.adoc
@@ -6,19 +6,20 @@
 [id="capi-yaml-machine-template-gcp_{context}"]
 = Sample YAML for a Cluster API machine template resource on {gcp-full}
 
+[role="_abstract"]
 The machine template resource is provider-specific and defines the basic properties of the machines that a compute machine set creates.
 The compute machine set references this template when creating machines.
 
 [source,yaml]
 ----
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-kind: GCPMachineTemplate # <1>
+kind: GCPMachineTemplate
 metadata:
-  name: <template_name> # <2>
+  name: <template_name>
   namespace: openshift-cluster-api
 spec:
   template:
-    spec: # <3>
+    spec:
       rootDeviceType: pd-ssd
       rootDeviceSize: 128
       instanceType: n1-standard-4
@@ -34,8 +35,11 @@ spec:
         - <cluster_name>-worker
       ipForwarding: Disabled
 ----
-<1> Specify the machine template kind.
+
+where:
+
+`kind`:: Specifies the machine template kind.
 This value must match the value for your platform.
-<2> Specify a name for the machine template.
-<3> Specify the details for your environment.
+`metadata.name`:: Specifies a name for the machine template.
+`spec.template.spec`:: Specifies the details for your environment. 
 The values here are examples.


### PR DESCRIPTION
Version(s):
4.20+

Issue:
[OSDOCS-17045](https://redhat.atlassian.net/browse/OSDOCS-17045)

Link to docs preview:

* https://114293--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/cluster_api_machine_management/cluster_api_provider_configurations/cluster-api-config-options-bare-metal.html
* https://114293--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/cluster_api_machine_management/cluster_api_provider_configurations/cluster-api-config-options-gcp.html