### PR TITLE
OSDOCS-20430 created RNs for zero-trust 1.1.0

### DIFF
--- a/modules/zero-trust-manager-release-notes-1-1-0.adoc
+++ b/modules/zero-trust-manager-release-notes-1-1-0.adoc
@@ -1,0 +1,142 @@
+// Module included in the following assemblies:
+//
+// * security/zero_trust_workload_identity_manager/zero-trust-manager-release-notes.adoc
+:_mod-docs-content-type: REFERENCE
+[id="zero-trust-manager-release-notes-1-1-0_{context}"]
+= {zero-trust-full} 1.1.0
+
+Issued: 30 Jun 2026
+
+[role="_abstract"]
+This release adds integration and operational capabilities for workloads that use external certificate authorities, service mesh deployments, or file-based Transport Layer Security (TLS) credentials. The release includes a supported SPIFFE Helper container image, SPIRE UpstreamAuthority plugins for cert-manager and HashiCorp Vault, and {SMProductName} integration with SPIRE for single-cluster and federated multi-cluster mutual Transport Layer Security (mTLS).
+
+The following advisories are available for {zero-trust-full}:
+
+* https://access.redhat.com/errata/RHBA-2026:28869[RHBA-2026:28869]
+* https://access.redhat.com/errata/RHBA-2026:28784[RHBA-2026:28784]
+* https://access.redhat.com/errata/RHBA-2026:28399[RHBA-2026:28399]
+* https://access.redhat.com/errata/RHBA-2026:28392[RHBA-2026:28392]
+* https://access.redhat.com/errata/RHBA-2026:28391[RHBA-2026:28391]
+* https://access.redhat.com/errata/RHBA-2026:28260[RHBA-2026:28260]
+* https://access.redhat.com/errata/RHBA-2026:28200[RHBA-2026:28200]
+* https://access.redhat.com/errata/RHBA-2026:28140[RHBA-2026:28140]
+
+{zero-trust-full} supports the following components and versions:
+
+[cols="1,1",options="header"]
+|===
+| Component
+| Version
+
+| {zero-trust-full}
+| 1.1.0
+
+| SPIRE Server
+| 1.14.7
+
+| SPIRE Agent
+| 1.14.7
+
+| SPIRE Controller Manager
+| 0.6.4
+
+| SPIRE OIDC Discovery Provider
+| 1.14.7
+
+| SPIFFE CSI Driver
+| 0.2.8
+|===
+
+[id="zero-trust-manager-1-1-0-features-enhancements_{context}"]
+== New features and enhancements
+
+Supported SPIFFE Helper container image::
+
+{zero-trust-full} now provides a supported SPIFFE Helper container image for workloads that cannot use the SPIFFE Workload API directly but can read Transport Layer Security (TLS) credentials from a shared volume. The image is based on upstream SPIFFE Helper. The configuration file format, command-line flags, and Workload API behavior remain compatible.
+
+SPIRE UpstreamAuthority plugins for external certificate authorities::
+
+{zero-trust-full} now supports SPIRE Server UpstreamAuthority plugins that obtain intermediate signing certificates from external certificate management systems while preserving {spiffe-full} identity standards.
+
+* Supported plugins:
+
+** cert-manager UpstreamAuthority plugin: integrates SPIRE Server with {cert-manager-operator}.
+** Vault UpstreamAuthority plugin: integrates SPIRE Server with the HashiCorp Vault Public Key Infrastructure (PKI) secrets engine.
+
+cert-manager UpstreamAuthority plugin::
+
+The cert-manager UpstreamAuthority plugin connects SPIRE Server to {cert-manager-operator} for automated intermediate certificate provisioning. SPIRE Server creates a `CertificateRequest` custom resource, then the configured `Issuer` or `ClusterIssuer` signs the request, and then the SPIRE Server uses the signed intermediate certificate to issue workload identities.
+
+Vault UpstreamAuthority plugin::
+
+The Vault UpstreamAuthority plugin connects SPIRE Server to the HashiCorp Vault PKI secrets engine for automated intermediate certificate authority (CA) certificate signing. Use this plugin when PKI is centralized in Vault and SPIRE must obtain intermediate signing certificates through Vault policies and authentication.
+
+Single-cluster Service Mesh integration with SPIRE::
+
+{zero-trust-full} now supports single-cluster integration with {SMProductName}. SPIRE replaces Istio's built-in certificate authority (CA) with SPIFFE-compliant identities and short-lived certificates that rotate automatically for workload mutual Transport Layer Security (mTLS).
+
+Multi-cluster Service Mesh integration with SPIRE federation::
+
+{zero-trust-full} now supports multi-cluster integration with {SMProductName} through SPIRE federation, enabling cross-cluster mutual Transport Layer Security (mTLS) authentication and zero trust workload identity across separate {product-title} clusters.
+
+* Cross-cluster trust requires federation at two layers:
+
+** SPIRE federation: SPIRE Servers exchange trust bundles through the `https_spiffe` profile.
+** Istio federation: Istio discovers remote endpoints through remote secrets and routes traffic through East-West Gateways.
+
+[id="zero-trust-manager-1-1-0-deprecated-features_{context}"]
+== Deprecated features
+
+Custom SCC `spire-spiffe-csi-driver`::
+
+Starting in {zero-trust-full} 1.1.0, the SPIFFE CSI Driver no longer uses the custom `SecurityContextConstraints` (SCC) `spire-spiffe-csi-driver`.
++
+{zero-trust-full} now grants the CSI `ServiceAccount` access to the platform `privileged` SCC through a `RoleBinding` namespace.
++
+{zero-trust-full} uses only the existing OpenShift `privileged` SCC. {zero-trust-full} does not create, modify, update, or delete the `privileged` SCC.
+
+Action required after upgrade::
+
+{zero-trust-full} does not remove the legacy custom SCC `spire-spiffe-csi-driver`. After you upgrade {zero-trust-full} to 1.1.0 from the **OpenShift OperatorHub** catalog, remove it manually once CSI is healthy on the platform SCC.
+
+
+[id="zero-trust-manager-1-1-0-bug-fixes_{context}"]
+== Fixed issues
+
+Managed route TLS secrets no longer require manual RBAC configuration::
++
+* Before this update, when you configured a managed route with an `externalSecretRef` TLS certificate on the `SpireOIDCDiscoveryProvider` or `SpireServer` custom resource (CR), {zero-trust-full} did not create the `RoleBinding` that grants the OpenShift Ingress router service account permission to read the referenced Secret. As a consequence, route reconciliation failed with a `ManagedRouteUpdateFailed` condition, and you had to manually create `secret-reader`, `Role`, and `RoleBinding` CRs. With this release, {zero-trust-full} automatically reconciles the required `Role` and `RoleBinding` CRs so that the router service account can access the Secrets referenced by the `externalSecretRef` TLS certificate. Managed routes that use externally provided TLS certificates now reconcile without additional manual RBAC steps.
++
+(link:https://issues.redhat.com/browse/SPIRE-164[SPIRE-164])
+
+Pre-existing operand resources are no longer overwritten at installation::
++
+* Before this update, when you installed {zero-trust-full} on a cluster that already contained Kubernetes resources with the same names as operand objects, {zero-trust-full} reconciled and overwrote those resources during the initial installation without reporting a conflict. As a consequence, manually created or third-party resources could be modified unexpectedly before you had a chance to resolve naming collisions. With this release, {zero-trust-full} checks the `app.kubernetes.io/managed-by` label before updating any existing resource during installation. If a matching resource is not managed by {zero-trust-full}, {zero-trust-full} sets a `ResourceConflict` status condition and stops reconciliation instead of overwriting the resource.
++
+(link:https://issues.redhat.com/browse/SPIRE-340[SPIRE-340])
+
+Unmanaged cluster resources are protected during reconciliation::
++
+* Before this update, after {zero-trust-full} was already running, operand controllers could still update Kubernetes resources with matching names even when those resources were not owned by {zero-trust-full}. This could occur when a name collision appeared later or when the `app.kubernetes.io/managed-by: zero-trust-workload-identity-manager` label was removed from a resource that {zero-trust-full} had previously managed. With this release, each operand controller verifies the `managed-by` label on every reconcile cycle before applying updates. When the label is absent, {zero-trust-full} sets a `ResourceConflict` status condition on the custom resource and skips the update to the conflicting object. Operand updates proceed only for resources that {zero-trust-full} currently manages.
++
+(link:https://issues.redhat.com/browse/SPIRE-344[SPIRE-344])
+
+Duplicate health check port names resolved in SPIRE Server StatefulSet::
++
+* Before this update, the `spire-server` and `spire-controller-manager` containers in the SPIRE Server `StatefulSet` field both declared a port named `healthz` on different container ports. Kubernetes treated this as a duplicate port name within the pod, issued a warning, and the services or probes that selected the ports by name could target the wrong container. With this release, {zero-trust-full} assigns unique port names, such as `server-healthz` and `ctrlmgr-healthz`, and updates the liveness and readiness probes to reference those names. Health checks and monitoring configurations now resolve to the intended container.
++
+(link:https://issues.redhat.com/browse/SPIRE-353[SPIRE-353])
+
+Create-only mode disabled status now updates on the main custom resource::
++
+* Before this update, after you disabled create-only mode by setting `CREATE_ONLY_MODE` to `false` in the Operator subscription, the `CreateOnlyMode` condition on the main `ZeroTrustWorkloadIdentityManager` CR could remain `True` with the reason `CreateOnlyModeEnabled`. Because {zero-trust-full} set that condition from operand status instead of from the `CREATE_ONLY_MODE` environment variable in the subscription, the main CR status did not reflect that create-only mode was disabled even though the operand reconciliation had resumed. With this release, {zero-trust-full} sets the `CreateOnlyMode` condition on the main CR directly from the `CREATE_ONLY_MODE` environment variable and updates it to `False` with reason `CreateOnlyModeDisabled` when create-only mode is turned off.
++
+(link:https://issues.redhat.com/browse/SPIRE-365[SPIRE-365])
+
+
+Create-only mode status updates reconcile reliably::
++
+* Before this update, {zero-trust-full} controllers wrote the custom resource (CR) status twice during each reconciliation cycle. The CR status was written at the start through the `SetInitialReconciliationStatus` cycle and again at the end through the status manager. Because the informer cache could return a stale `ResourceVersion` after the first write, the deferred status update was rejected with `HTTP 409 Conflict`. Status conditions, including `CreateOnlyMode`, could fail to transition to the expected state even after you changed configuration in the Operator subscription. With this release, controllers apply the status in a single update at the end of reconciliation, and status update retry logic now complies with the `RetryOnConflict` contract. CR status updates, including create-only mode transitions, are now completed.
++
+(link:https://issues.redhat.com/browse/SPIRE-506[SPIRE-506])
+

--- a/security/zero_trust_workload_identity_manager/zero-trust-manager-release-notes.adoc
+++ b/security/zero_trust_workload_identity_manager/zero-trust-manager-release-notes.adoc
@@ -11,6 +11,9 @@ The {zero-trust-full} leverages Secure Production Identity Framework for Everyon
 
 These release notes track the development of {zero-trust-full}.
 
+// RNs 1.1.0
+include::modules/zero-trust-manager-release-notes-1-1-0.adoc[leveloffset=+1]
+
 // RNs 1.0.1
 include::modules/zero-trust-manager-release-notes-1-0-1.adoc[leveloffset=+1]
 


### PR DESCRIPTION
Version(s):
4.21+

Issue:
https://redhat.atlassian.net/browse/OSDOCS-20430

Link to docs preview:
https://114294--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/zero_trust_workload_identity_manager/zero-trust-manager-release-notes.html


QE review:
- [x] QE has approved this change.


Additional information:

