### PR TITLE
CNV-3575: Self-Referential / Introductory Language in abstracts

### DIFF
--- a/modules/virt-dr-solutions-rh-managed-clusters.adoc
+++ b/modules/virt-dr-solutions-rh-managed-clusters.adoc
@@ -39,9 +39,3 @@ For more information about using the Metro-DR solution for {rh-storage} with {Vi
 * Using the import method when selecting a population source for your VM disk is recommended. However, you can protect VMs that use cloned PVCs if you select a `VolumeReplicationClass` that enables image flattening. For more information, see the {rh-storage} documentation.
 
 For more information about using the Regional-DR solution for {rh-storage} with {VirtProductName}, see {ibm-title}'s {rh-storage} Regional-DR documentation.
-
-[role="_additional-resources"]
-.Additional resources
-
-* link:https://access.redhat.com/documentation/en-us/red_hat_openshift_data_foundation/latest/html-single/configuring_openshift_data_foundation_disaster_recovery_for_openshift_workloads/index#metro-dr-solution[Metro-DR solution for {rh-storage}]
-* link:https://docs.redhat.com/en/documentation/red_hat_openshift_data_foundation/latest/html-single/configuring_openshift_data_foundation_disaster_recovery_for_openshift_workloads/index#rdr-solution[Regional-DR solution for {rh-storage}]

--- a/modules/virt-dv-annotations.adoc
+++ b/modules/virt-dv-annotations.adoc
@@ -7,7 +7,7 @@
 = Example: Data volume annotations
 
 [role="_abstract"]
-This example shows how you can configure data volume (DV) annotations to control which network the importer pod uses. The `v1.multus-cni.io/default-network: bridge-network` annotation causes the pod to use the Multus network named `bridge-network` as its default network.
+You can configure data volume (DV) annotations to control which network the importer pod uses. The `v1.multus-cni.io/default-network: bridge-network` annotation causes the pod to use the Multus network named `bridge-network` as its default network.
 
 If you want the importer pod to use both the default network from the cluster and the secondary Multus network, use the `k8s.v1.cni.cncf.io/networks: <network_name>` annotation.
 

--- a/modules/virt-live-migration-metrics.adoc
+++ b/modules/virt-live-migration-metrics.adoc
@@ -7,7 +7,7 @@
 = Live migration metrics
 
 [role="_abstract"]
-The following metrics can be queried to show live migration status.
+You can query metrics to show live migration status.
 
 `kubevirt_vmi_migration_data_processed_bytes`:: The amount of guest operating system data that has migrated to the new virtual machine (VM). Type: Gauge.
 

--- a/modules/virt-networking-wizard-fields-web.adoc
+++ b/modules/virt-networking-wizard-fields-web.adoc
@@ -9,7 +9,7 @@
 = Networking fields
 
 [role="_abstract"]
-The following table describes the networking fields in the virtual machine wizard.
+Information about networking fields in the virtual machine wizard.
 
 |===
 |Name | Description

--- a/modules/virt-nw-overview-comparing-localnet-linuxbridge.adoc
+++ b/modules/virt-nw-overview-comparing-localnet-linuxbridge.adoc
@@ -3,14 +3,11 @@
 // * virt/vm_networking/virt-networking-overview.adoc
 
 :_mod-docs-content-type: REFERENCE
-[id="virt-nw-overview-comparing-localnet-linuxbridge_{context}"]                                
+[id="virt-nw-overview-comparing-localnet-linuxbridge_{context}"]
 = Comparing Linux bridge CNI and OVN-Kubernetes localnet topology
 
-// Hiding from ROSA/OSD as Linux Bridge is not supported
-ifndef::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
-
 [role="_abstract"]
-The following table provides a comparison of features available when using the Linux bridge CNI compared to the localnet topology for an OVN-Kubernetes plugin.
+A comparison of features available when using the Linux bridge CNI compared to the localnet topology for an OVN-Kubernetes plugin.
 
 .Linux bridge CNI compared to an OVN-Kubernetes localnet topology
 [cols="1,1,1",options="header"]
@@ -40,4 +37,3 @@ The following table provides a comparison of features available when using the L
 |Yes (Always on)
 
 |===
-endif::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]

--- a/modules/virt-querying-metrics.adoc
+++ b/modules/virt-querying-metrics.adoc
@@ -7,8 +7,7 @@
 = Virtualization metrics
 
 [role="_abstract"]
-The following metric descriptions include example Prometheus Query Language (PromQL) queries. These metrics are not an API and might change between versions.
-For a complete list of virtualization metrics, see link:https://github.com/kubevirt/monitoring/blob/main/docs/metrics.md[KubeVirt components metrics].
+Metric descriptions including example Prometheus Query Language (PromQL) queries. These metrics are not an API and might change between versions.
 
 [NOTE]
 ====
@@ -37,7 +36,7 @@ Returns the cumulative time, in seconds, that a vCPU was enqueued by the host sc
 This delay appears to the virtual machine as _steal time_, which is CPU time lost when the host runs other workloads. Steal time can impact performance and often indicates CPU overcommitment or contention on the host.
 Type: Counter.
 
-*Example vCPU delay query*
+Example vCPU delay query:
 
 The following query returns the average per-second delay over a 5-minute period. A high value may indicate CPU overcommitment or contention on the node:
 
@@ -46,8 +45,7 @@ The following query returns the average per-second delay over a 5-minute period.
 irate(kubevirt_vmi_vcpu_delay_seconds_total[5m]) > 0.05
 ----
 
-
-*Example vCPU wait time query*
+Example vCPU wait time query:
 
 The following query returns the top 3 VMs waiting for I/O at every given moment over a six-minute time period:
 
@@ -68,7 +66,7 @@ Returns the total amount of traffic received (in bytes) on the virtual machine's
 `kubevirt_vmi_network_transmit_bytes_total`::
 Returns the total amount of traffic transmitted (in bytes) on the virtual machine's network. Type: Counter.
 
-*Example network traffic query*
+Example network traffic query:
 
 The following query returns the top 3 VMs transmitting the most network traffic at every given moment over a six-minute time period:
 
@@ -91,7 +89,7 @@ Returns the total amount (in bytes) of the virtual machine's storage-related tra
 Returns the total amount of storage writes (in bytes) of the virtual machine's storage-related traffic. Type: Counter.
 --
 
-*Example storage-related traffic queries*
+Example storage-related traffic queries:
 
 * The following query returns the top 3 VMs performing the most storage traffic at every given moment over a six-minute time period:
 +
@@ -115,7 +113,7 @@ Returns the total number of virtual machine disks restored from the source virtu
 `vm:kubevirt_vmsnapshot_restored_bytes:sum`::
 Returns the amount of space in bytes restored from the source virtual machine. Type: Gauge.
 
-*Examples of storage snapshot data queries*
+Examples of storage snapshot data queries:
 
 * The following query returns the total number of virtual machine disks restored from the source virtual machine:
 +
@@ -131,8 +129,6 @@ vm:kubevirt_vmsnapshot_disks_restored:sum{vm_name="simple-vm", vm_namespace="def
 vm:kubevirt_vmsnapshot_restored_bytes:sum{vm_name="simple-vm", vm_namespace="default"}
 ----
 
-
-
 The following queries can determine the I/O performance of storage devices:
 
 `kubevirt_vmi_storage_iops_read_total`::
@@ -141,7 +137,7 @@ Returns the amount of write I/O operations the virtual machine is performing per
 `kubevirt_vmi_storage_iops_write_total`::
 Returns the amount of read I/O operations the virtual machine is performing per second. Type: Counter.
 
-*Example I/O performance query*
+Example I/O performance query:
 
 The following query returns the top 3 VMs performing the most I/O operations per second at every given moment over a six-minute time period:
 
@@ -161,7 +157,7 @@ Returns the total amount (in bytes) of memory the virtual guest is swapping in. 
 `kubevirt_vmi_memory_swap_out_traffic_bytes`::
 Returns the total amount (in bytes) of memory the virtual guest is swapping out. Type: Gauge.
 
-*Example memory swapping query*
+Example memory swapping query:
 
 The following query returns the top 3 VMs where the guest is performing the most memory swapping at every given moment over a six-minute time period:
 

--- a/virt/backup_restore/virt-disaster-recovery.adoc
+++ b/virt/backup_restore/virt-disaster-recovery.adoc
@@ -22,5 +22,7 @@ include::modules/virt-dr-solutions-rh-managed-clusters.adoc[leveloffset=+1]
 == Additional resources
 * link:https://access.redhat.com/articles/7041594[Red{nbsp}Hat {VirtProductName} disaster recovery guide]
 * link:https://docs.redhat.com/en/documentation/red_hat_openshift_data_foundation/latest/html/configuring_openshift_data_foundation_disaster_recovery_for_openshift_workloads/index[Configuring {rh-storage} Disaster Recovery for OpenShift Workloads]
+* link:https://access.redhat.com/documentation/en-us/red_hat_openshift_data_foundation/latest/html-single/configuring_openshift_data_foundation_disaster_recovery_for_openshift_workloads/index#metro-dr-solution[Metro-DR solution for {rh-storage}]
+* link:https://docs.redhat.com/en/documentation/red_hat_openshift_data_foundation/latest/html-single/configuring_openshift_data_foundation_disaster_recovery_for_openshift_workloads/index#rdr-solution[Regional-DR solution for {rh-storage}]
 * link:https://access.redhat.com/articles/7053115[Use {rh-storage} Disaster Recovery to Protect Virtual Machines (in the Red{nbsp}Hat Knowledgebase)]
 * link:https://docs.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.10[Red{nbsp}Hat Advanced Cluster Management for Kubernetes 2.10]

--- a/virt/monitoring/virt-prometheus-queries.adoc
+++ b/virt/monitoring/virt-prometheus-queries.adoc
@@ -30,9 +30,10 @@ include::modules/virt-live-migration-metrics.adoc[leveloffset=+2]
 
 include::modules/virt-node-memory-overcommit-dashboard.adoc[leveloffset=+1]
 
-[id="additional-resources_virt-prometheus-queries"]
 [role="_additional-resources"]
+[id="additional-resources_{context}"]
 == Additional resources
+* link:https://github.com/kubevirt/monitoring/blob/main/docs/metrics.md[KubeVirt components metrics]
 // Hiding in ROSA/OSD as user cannot edit MCO
 ifndef::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
 * xref:../../machine_configuration/machine-configs-configure.adoc#nodes-nodes-kernel-arguments_machine-configs-configure[Adding kernel arguments to nodes]


### PR DESCRIPTION
Version(s):
4.20+

Issue:
[CCSINTL-3575](https://redhat.atlassian.net/browse/CCSINTL-3575)

Link to docs preview:
- https://114296--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/backup_restore/virt-disaster-recovery#additional-resources_virt-disaster-recovery
- https://114296--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/storage/virt-managing-data-volume-annotations#virt-dv-annotations_virt-managing-data-volume-annotations
- https://114296--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/monitoring/virt-prometheus-queries#virt-live-migration-metrics_virt-prometheus-queries
- https://114296--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/vm_networking/virt-connecting-vm-to-linux-bridge#virt-networking-wizard-fields-web_virt-connecting-vm-to-linux-bridge
- https://114296--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/vm_networking/virt-networking-overview#virt-nw-overview-comparing-localnet-linuxbridge_virt-networking-overview
- https://114296--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/monitoring/virt-prometheus-queries#virt-querying-metrics_virt-prometheus-queries
- https://114296--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/monitoring/virt-prometheus-queries#additional-resources_virt-prometheus-queries

QE review:
n/a, CQA work
