### PR TITLE
CNV-63301: Add installation methods overview with links to Agent-based and Assisted Installer

### DIFF
--- a/modules/virt-about-installation-methods.adoc
+++ b/modules/virt-about-installation-methods.adoc
@@ -1,0 +1,35 @@
+// Module included in the following assemblies:
+//
+// * virt/install/installing-virt.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="virt-about-installation-methods_{context}"]
+= About installation methods for {VirtProductName}
+
+[role="_abstract"]
+You can install {VirtProductName} on your {product-title} cluster by using one of the following methods:
+
+Standard installation by using {olm-first}:: Install the {VirtProductName} Operator from the {product-title} web console or CLI. This method is suitable for most deployment scenarios and provides the most flexibility for cluster configuration.
++
+For disconnected environments, you must configure {olm} for restricted networks before installing {VirtProductName}.
+
+Agent-based installation:: Use the Agent-based Installer to deploy a cluster with {VirtProductName} and related operators pre-configured. This installation method is designed for users who want a streamlined, UI-driven installation experience, particularly in disconnected environments.
++
+--
+:FeatureName: Agent-based installation
+include::snippets/technology-preview.adoc[]
+--
+
+Assisted Installer with virtualization bundle:: Use the Assisted Installer to deploy {VirtProductName} or {ove-first} by using the virtualization operator bundle, which includes {VirtProductName} and essential supporting operators. This installation method simplifies the deployment process by pre-configuring operators and minimizing external dependencies. This is the preferred installation method for {ove}.
+
+== Choosing an installation method
+
+Consider the following factors when choosing an installation method:
+
+* Network connectivity: For disconnected or air-gapped environments, the Agent-based Installer or Assisted Installer with the virtualization bundle can simplify deployment by reducing registry dependencies.
+
+* Installation experience: If you prefer a UI-driven installation workflow over writing YAML files, consider using the Agent-based Installer or Assisted Installer.
+
+* Operator requirements: If you need additional operators such as the Node Health Check Operator, Fence Agents Remediation Operator, or NMState Operator, the Assisted Installer virtualization bundle includes these operators by default.
+
+* Customization needs: For maximum flexibility in cluster configuration, use the standard {olm} installation method.

--- a/virt/install/installing-virt.adoc
+++ b/virt/install/installing-virt.adoc
@@ -16,6 +16,8 @@ If you install {VirtProductName} in a restricted environment with no internet co
 
 If you have limited internet connectivity, you can configure proxy support in {olm} to access the software catalog.
 ====
+
+include::modules/virt-about-installation-methods.adoc[leveloffset=+1]
 endif::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
 
 include::modules/virt-installing-virt-operator.adoc[leveloffset=+1]
@@ -26,6 +28,8 @@ include::modules/virt-deploying-operator-cli.adoc[leveloffset=+1]
 [id="additional-resources_{context}"]
 == Additional resources
 ifdef::openshift-enterprise[]
+* xref:../../installing/installing_with_agent_based_installer/installing-ove.adoc#installing-ove[Installing a cluster for {VirtProductName} using the Agent-based Installer]
+* link:https://docs.redhat.com/en/documentation/assisted_installer_for_openshift_container_platform/2026/html/installing_openshift_container_platform_with_the_assisted_installer/customizing-with-bundles-and-operators#openshift-virtualization-operator_customizing-with-bundles-and-operators[Installing with the virtualization operator bundle (Assisted Installer)]
 * xref:../../disconnected/using-olm.adoc#olm-restricted-networks[Using Operator Lifecycle Manager in disconnected environments]
 * xref:../../operators/admin/olm-configuring-proxy-support.adoc#olm-configuring-proxy-support[Configuring proxy support in Operator Lifecycle Manager]
 * xref:../../virt/post_installation_configuration/virt-self-validation-checkups.adoc#virt-self-validation-checkups[Self validation checkup]

--- a/virt/install/preparing-cluster-for-virt.adoc
+++ b/virt/install/preparing-cluster-for-virt.adoc
@@ -35,6 +35,7 @@ endif::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
 == Additional resources
 
 ifndef::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
+* xref:../../virt/install/installing-virt.adoc#virt-about-installation-methods_installing-virt[About installation methods for {VirtProductName}]
 * xref:../../virt/install/virt-requirements.adoc#virt-requirements[Hardware, software, and operational requirements]
 * xref:../../installing/installing_bare_metal/preparing-to-install-on-bare-metal.adoc#virt-planning-bare-metal-cluster-for-ocp-virt_preparing-to-install-on-bare-metal[Planning a bare-metal cluster for {VirtProductName}]
 * xref:../../installing/installing_ibm_z/preparing-to-install-on-ibm-z.adoc#preparing-to-install-on-ibm-z_preparing-to-install-on-ibm-z[Preparing to install on {ibm-z-title} and {ibm-linuxone-title}]


### PR DESCRIPTION
Version(s): 4.20+

Issue: https://redhat.atlassian.net/browse/CNV-63301

Link to docs preview:
* https://114299--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/install/installing-virt.html#virt-about-installation-methods_installing-virt
* https://114299--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/install/installing-virt#additional-resources_installing-virt
* https://114299--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/install/preparing-cluster-for-virt.html#additional-resources_preparing-cluster-for-virt

QE review:
- [x] QE has approved this change.

Additional information:

This PR adds conceptual content about installation methods for OpenShift Virtualization, providing the "connective tissue" to help users discover simplified installation options.

Changes include:
- New module `virt-about-installation-methods.adoc` with overview of three installation methods (standard OLM, Agent-based Installer, and Assisted Installer with virtualization bundle)
- Decision guidance section to help users choose the right installation method based on network connectivity, installation experience preferences, operator requirements, and customization needs
- Links to Agent-based Installer documentation (Sebastian Kopacz's content at `installing/installing_with_agent_based_installer/installing-ove.adoc`)
- Links to Assisted Installer virtualization bundle documentation (external docs.redhat.com)