### PR TITLE
OSDOCS-16415: CQA fixes for ROSA and OSD storage module

### DIFF
--- a/modules/sd-persistent-storage-csi-efs-sts.adoc
+++ b/modules/sd-persistent-storage-csi-efs-sts.adoc
@@ -4,10 +4,10 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="efs-sts_{context}"]
-= Obtaining a role Amazon Resource Name for Security Token Service
+= Obtain a role Amazon Resource Name for Security Token Service
 
 [role="_abstract"]
-This procedure explains how to obtain a role Amazon Resource Name (ARN) to configure the AWS EFS CSI Driver Operator with {product-title} on AWS Security Token Service (STS).
+Before you install the AWS EFS CSI Driver Operator, create an AWS Identity and Access Management (IAM) role and policy and obtain a role Amazon Resource Name (ARN). The role ARN grants the Operator permissions to manage Amazon Elastic File System (EFS) resources through AWS Security Token Service (STS).
 
 [IMPORTANT]
 ====
@@ -16,8 +16,8 @@ Perform this procedure before you install the AWS EFS CSI Driver Operator (see _
 
 .Prerequisites
 
-* Access to the cluster as a user with the cluster-admin role.
-* AWS account credentials
+* You have access to the cluster as a user with the cluster-admin role.
+* You have AWS account credentials.
 
 .Procedure
 
@@ -94,7 +94,7 @@ Perform this procedure before you install the AWS EFS CSI Driver Operator (see _
 --
 where:
 
-`Statement.Principal.Federated`:: Specifies your AWS account ID and the OpenShift OIDC provider endpoint. 
+`Statement.Principal.Federated`:: Specifies your AWS account ID and the {OCP-short} OpenID Connect (OIDC) provider endpoint.
 +
 Obtain your AWS account ID by running the following command:
 +
@@ -104,7 +104,7 @@ $ aws sts get-caller-identity --query Account --output text
 ----
 ifdef::openshift-rosa[]
 +
-Obtain the OpenShift OIDC endpoint by running the following command:
+Obtain the {OCP-short} OIDC endpoint by running the following command:
 +
 [source,terminal]
 ----
@@ -115,7 +115,7 @@ $ rosa describe cluster \
 endif::openshift-rosa[]
 ifdef::openshift-dedicated[]
 +
-Obtain the OpenShift OIDC endpoint by running the following command:
+Obtain the {OCP-short} OIDC endpoint by running the following command:
 +
 [source,terminal]
 ----
@@ -125,7 +125,7 @@ $ openshift_oidc_provider=`oc get authentication.config.openshift.io cluster \
 ----
 endif::openshift-dedicated[]
 
-`Statement.Condition.StringEquals[0]`:: Specify the OpenShift OIDC endpoint again.
+`Statement.Condition.StringEquals[0]`:: Specify the {OCP-short} OIDC endpoint again.
 --
 
 . Create the IAM role:

--- a/storage/container_storage_interface/persistent-storage-csi-aws-efs.adoc
+++ b/storage/container_storage_interface/persistent-storage-csi-aws-efs.adoc
@@ -2,6 +2,7 @@
 [id="persistent-storage-csi-aws-efs"]
 = AWS Elastic File Service CSI Driver Operator
 include::_attributes/common-attributes.adoc[]
+include::_attributes/attributes-openshift-dedicated.adoc[]
 :context: persistent-storage-csi-aws-efs
 
 toc::[]

--- a/storage/container_storage_interface/persistent-storage-csi.adoc
+++ b/storage/container_storage_interface/persistent-storage-csi.adoc
@@ -30,10 +30,7 @@ include::modules/persistent-storage-csi-drivers-supported.adoc[leveloffset=+1]
 * link:https://access.redhat.com/articles/third-party-software-support[Third-party support policy]
 
 ifdef::openshift-rosa,openshift-rosa-hcp[]
-[role="_additional-resources"]
-.Additional resources
 * xref:../../storage/container_storage_interface/persistent-storage-csi-aws-efs.adoc#persistent-storage-csi-aws-efs[AWS Elastic File Service CSI Driver Operator]
-
 * xref:../../rosa_architecture/rosa_policy_service_definition/rosa-policy-responsibility-matrix.adoc#rosa-policy-shared-responsibility[Shared responsibilities for {product-title}]
 endif::openshift-rosa,openshift-rosa-hcp[]
 


### PR DESCRIPTION
Version(s):
4.22+
5.0+

Issue:
https://redhat.atlassian.net/browse/OSDOCS-16415 

Link to docs preview:
**ROSA HCP**
- ROSA/OSD-only module: [Obtain a role Amazon Resource Name for Security Token Service](https://114326--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/storage/container_storage_interface/persistent-storage-csi-aws-efs.html#efs-sts_persistent-storage-csi-aws-efs)
- Removed double Additional resources at the end of [CSI drivers supported by Red Hat OpenShift Service on AWS](https://114326--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/storage/container_storage_interface/persistent-storage-csi.html#persistent-storage-csi-drivers-supported_persistent-storage-csi)

**Classic**
- ROSA/OSD-only module: [Obtain a role Amazon Resource Name for Security Token Service](https://114326--ocpdocs-pr.netlify.app/openshift-rosa/latest/storage/container_storage_interface/persistent-storage-csi-aws-efs.html#efs-sts_persistent-storage-csi-aws-efs)
- Removed double Additional resources at the end of [CSI drivers supported by Red Hat OpenShift Service on AWS (classic architecture)](https://114326--ocpdocs-pr.netlify.app/openshift-rosa/latest/storage/container_storage_interface/persistent-storage-csi.html#persistent-storage-csi-drivers-supported_persistent-storage-csi)
 
**OSD**
- ROSA/OSD-only module: [Obtain a role Amazon Resource Name for Security Token Service](https://114326--ocpdocs-pr.netlify.app/openshift-dedicated/latest/storage/container_storage_interface/persistent-storage-csi-aws-efs.html#efs-sts_persistent-storage-csi-aws-efs)
- OSD didn't have double Additional resources and continues to not have them, see end of [CSI drivers supported by OpenShift Dedicated](https://114326--ocpdocs-pr.netlify.app/openshift-dedicated/latest/storage/container_storage_interface/persistent-storage-csi#persistent-storage-csi-drivers-supported_persistent-storage-csi)

**OCP**
- ROSA/OSD module remains hidden. A link to the [OCP counterpart module](https://114326--ocpdocs-pr.netlify.app/openshift-enterprise/latest/storage/container_storage_interface/persistent-storage-csi-aws-efs.html#efs-sts_persistent-storage-csi-aws-efs)
- OCP didn't have double Additional resources and continues to not have them, see end of [CSI drivers supported by OpenShift Container Platform](https://114326--ocpdocs-pr.netlify.app/openshift-enterprise/latest/storage/container_storage_interface/persistent-storage-csi.html#persistent-storage-csi-drivers-supported_persistent-storage-csi) Rendering before the Additional resources is broken and it affects the published [OCP Storage doc](https://docs.redhat.com/en/documentation/openshift_container_platform/4.22/html-single/storage/index#persistent-storage-csi-drivers-supported_persistent-storage-csi) too.

QE review:
N/A

Additional information:
