### PR TITLE
OSDOCS-17045-5: CQA for MACH-4 Cluster API for Compute Machines

### DIFF
--- a/machine_management/cluster_api_machine_management/cluster-api-disabling.adoc
+++ b/machine_management/cluster_api_machine_management/cluster-api-disabling.adoc
@@ -6,6 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 To stop using the Cluster API to automate the management of infrastructure resources on your {product-title} cluster, convert any Cluster API resources on your cluster to equivalent Machine API resources.
 
 :FeatureName: Managing machines with the Cluster API

--- a/machine_management/cluster_api_machine_management/cluster_api_provider_configurations/cluster-api-config-options-rhosp.adoc
+++ b/machine_management/cluster_api_machine_management/cluster_api_provider_configurations/cluster-api-config-options-rhosp.adoc
@@ -6,6 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 You can change the configuration of your {rh-openstack-first} Cluster API machines by updating values in the Cluster API custom resource manifests.
 
 :FeatureName: Managing machines with the Cluster API
@@ -18,6 +19,11 @@ The following example YAML files show configurations for a {rh-openstack} cluste
 
 //Sample YAML for CAPI RHOSP machine template resource
 include::modules/capi-yaml-machine-template-rhosp.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources
+
+* link:https://docs.redhat.com/en/documentation/red_hat_openstack_platform/17.1/html/configuring_the_compute_service_for_instance_creation/assembly_creating-flavors-for-launching-instances_instance-flavors[Creating flavors for launching instances]
 
 //Sample YAML for a CAPI RHOSP compute machine set resource
 include::modules/capi-yaml-machine-set-rhosp.adoc[leveloffset=+2]

--- a/modules/capi-to-mapi-migration-overview.adoc
+++ b/modules/capi-to-mapi-migration-overview.adoc
@@ -4,9 +4,10 @@
 
 :_mod-docs-content-type: CONCEPT
 [id="capi-to-mapi-migration-overview_{context}"]
-= Migrating Cluster API resources to Machine API resources
+= Cluster API resources migration to Machine API resources
 
-On clusters that support migrating between Machine API and Cluster API resources, the two-way synchronization controller supports converting a Cluster API resource to a Machine API resource.
+[role="_abstract"]
+On clusters that support migrating between the Cluster API and Machine API resources, the two-way synchronization controller supports converting a Cluster API resource to a Machine API resource.
 
 [NOTE]
 ====

--- a/modules/capi-yaml-machine-set-rhosp.adoc
+++ b/modules/capi-yaml-machine-set-rhosp.adoc
@@ -6,7 +6,8 @@
 [id="capi-yaml-machine-set-rhosp_{context}"]
 = Sample YAML for a Cluster API compute machine set resource on {rh-openstack}
 
-The compute machine set resource defines additional properties of the machines that it creates.
+[role="_abstract"]
+The compute machine set resource defines additional properties of the machines that the resource creates.
 The compute machine set also references the infrastructure resource and machine template when creating machines.
 
 [source,yaml]
@@ -14,10 +15,10 @@ The compute machine set also references the infrastructure resource and machine 
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineSet
 metadata:
-  name: <machine_set_name> # <1>
+  name: <machine_set_name>
   namespace: openshift-cluster-api
 spec:
-  clusterName: <cluster_name> # <2>
+  clusterName: <cluster_name>
   replicas: 1
   selector:
     matchLabels:
@@ -33,19 +34,23 @@ spec:
         node-role.kubernetes.io/<role>: ""
     spec:
       bootstrap:
-         dataSecretName: worker-user-data # <3>
+         dataSecretName: worker-user-data
       clusterName: <cluster_name>
       infrastructureRef:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-        kind: OpenStackMachineTemplate # <4>
-        name: <template_name> # <5>
-      failureDomain: <nova_availability_zone> # <6>
+        kind: OpenStackMachineTemplate
+        name: <template_name>
+      failureDomain: <nova_availability_zone>
 ----
-<1> Specify a name for the compute machine set.
-<2> Specify the cluster ID as the name of the cluster.
-<3> For the Cluster API Technology Preview, the Operator can use the worker user data secret from the `openshift-machine-api` namespace.
-<4> Specify the machine template kind.
+
+where:
+
+`metadata.name`:: Specifies a name for the compute machine set.
+`spec.clusterName`:: Specifies the cluster ID as the name of the cluster.
+`spec.template.spec.bootstrap.dataSecretName`:: For the Cluster API Technology Preview, the Operator can use the worker user data secret from the `openshift-machine-api` namespace.
+`spec.template.spec.infrastructureRef.kind`:: Specifies the machine template kind.
 This value must match the value for your platform.
-<5> Specify the machine template name.
-<6> Optional: Specify the name of the Nova availability zone for the machine set to create machines in.
+`spec.template.spec.infrastructureRef.name`:: Specifies the machine template name.
+`spec.template.spec.failureDomain`:: Optional parameter. 
+Specifies the name of the Nova availability zone for the machine set to create machines in.
 If you do not specify a value, machines are not restricted to a specific availability zone.

--- a/modules/capi-yaml-machine-template-rhosp.adoc
+++ b/modules/capi-yaml-machine-template-rhosp.adoc
@@ -6,29 +6,32 @@
 [id="capi-yaml-machine-template-rhosp_{context}"]
 = Sample YAML for a Cluster API machine template resource on {rh-openstack}
 
+[role="_abstract"]
 The machine template resource is provider-specific and defines the basic properties of the machines that a compute machine set creates.
 The compute machine set references this template when creating machines.
 
 [source,yaml]
 ----
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-kind: OpenStackMachineTemplate # <1>
+kind: OpenStackMachineTemplate
 metadata:
-  name: <template_name> # <2>
+  name: <template_name>
   namespace: openshift-cluster-api
 spec:
   template:
-    spec: # <3>
-      flavor: <openstack_node_machine_flavor> # <4>
+    spec:
+      flavor: <openstack_node_machine_flavor>
       image:
         filter:
-          name: <openstack_image> # <5>
+          name: <openstack_image>
 ----
-<1> Specify the machine template kind.
+where:
+
+`kind`:: Specifies the machine template kind.
 This value must match the value for your platform.
-<2> Specify a name for the machine template.
-<3> Specify the details for your environment.
+`metadata.name`:: Specifies a name for the machine template.
+`spec.template.spec`:: Specifies the details for your environment.
 The values here are examples.
-<4> Specify the {rh-openstack} flavor to use.
-For more information, see link:https://docs.redhat.com/en/documentation/red_hat_openstack_platform/17.1/html/configuring_the_compute_service_for_instance_creation/assembly_creating-flavors-for-launching-instances_instance-flavors[Creating flavors for launching instances].
-<5> Specify the image to use.
+`spec.template.spec.flavor`:: Specifies the {rh-openstack} flavor to use.
+For more information, see "Creating flavors for launching instances".
+`spec.template.spec.image.filter.name`:: Specifies the image to use.


### PR DESCRIPTION
Version(s):
4.20+

Issue:
[OSDOCS-17045](https://redhat.atlassian.net/browse/OSDOCS-17045)

Link to docs preview:

* https://114350--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/cluster_api_machine_management/cluster-api-disabling.html
* https://114350--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/cluster_api_machine_management/cluster-api-getting-started.html
* https://114350--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/cluster_api_machine_management/cluster_api_provider_configurations/cluster-api-config-options-rhosp.html
* https://114350--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/cluster_api_machine_management/cluster-api-troubleshooting.html

Continue from machine_management/cluster_api_machine_management/cluster_api_provider_configurations/cluster-api-config-options-vsphere.adoc'