### PR TITLE
CNV-64193: Virtual CPUs maximum tested value should be updated

### DIFF
--- a/modules/virt-tested-maximums.adoc
+++ b/modules/virt-tested-maximums.adoc
@@ -18,7 +18,7 @@ Maximums apply to virtual machines (VMs) running on {VirtProductName} and are su
 |===
 |Objective (per VM) |Tested limit |Theoretical limit
 
-|Virtual CPUs |216 vCPUs |255 vCPUs
+|Virtual CPUs |255 vCPUs |255 vCPUs
 |Memory |6 TB |16 TB
 |Single disk size |100 TB |100 TB
 |Hot-pluggable disks |255 disks |N/A


### PR DESCRIPTION
Resolves: https://redhat.atlassian.net/browse/CNV-64193

CNV 4.22, 5.0
OCP 4.22, 5.0

Preview: https://114358--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/about_virt/virt-supported-limits.html#virt-tested-maximums_virt-supported-limits