### PR TITLE
CNV-70515: VM specification should use default as network instead of the UDN name given for primary UDN

### DIFF
--- a/modules/virt-attaching-vm-to-primary-udn.adoc
+++ b/modules/virt-attaching-vm-to-primary-udn.adoc
@@ -35,12 +35,12 @@ spec:
       domain:
         devices:
           interfaces:
-            - name: udn-l2-net
+            - name: default
               binding:
                 name: l2bridge
 # ...
       networks:
-      - name: udn-l2-net
+      - name: default
         pod: {}
 # ...
 ----


### PR DESCRIPTION
Resolves: https://redhat.atlassian.net/browse/CNV-70515

CNV 4.22+
OCP 4.22+

Preview: https://114359--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/vm_networking/virt-connecting-vm-to-primary-udn.html#virt-attaching-vm-to-primary-udn_virt-connecting-vm-to-primary-udn