### PR TITLE
OBSDOCS-3566 [DOC] COO 1.5.1 patch release notes

### DIFF
--- a/modules/coo-rel-notes-151.adoc
+++ b/modules/coo-rel-notes-151.adoc
@@ -1,0 +1,111 @@
+//Module included in the following assemblies:
+//
+// * release-notes/cluster-observability-operator-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+
+[id="cluster-observability-operator-release-notes-1-5-1_{context}"]
+= {coo-full} 1.5.1
+
+[role="_abstract"]
+Review the release notes for {coo-full} version 1.5.1, including fixed issues and security advisories for each minor release.
+
+The following advisory is available for {coo-full} 1.5.1:
+
+* link:https://access.redhat.com/errata/RHSA-2026:34342[RHSA-2026:34342] {coo-full} 1.5.1
+
+[id="cluster-observability-operator-1-5-1-fixed-issues_{context}"]
+== Fixed issues
+
+{log-plug} UI correctly displays all logs when loading more data::
+
+Before this update, the option to load more data in the {log-plug} UI disappeared. This issue caused the Loki logs UI to omit log lines when you attempted to load more data or export logs to a CSV file.
++
+With this release, the option to load more data is available, and the UI displays and exports all log lines successfully.
++
+link:https://issues.redhat.com/browse/OU-737[OU-737]
+
+[id="cluster-observability-operator-1-5-1-CVEs_{context}"]
+== CVEs
+
+* link:https://access.redhat.com/security/cve/cve-2026-48779[CVE-2026-48779]
+
+* link:https://access.redhat.com/security/cve/cve-2026-42506[CVE-2026-42506]
+
+* link:https://access.redhat.com/security/cve/cve-2026-39821[CVE-2026-39821]
+
+* link:https://access.redhat.com/security/cve/cve-2026-33941[CVE-2026-33941]
+
+* link:https://access.redhat.com/security/cve/cve-2026-33940[CVE-2026-33940]
+
+* link:https://access.redhat.com/security/cve/cve-2026-33939[CVE-2026-33939]
+
+* link:https://access.redhat.com/security/cve/cve-2026-33938[CVE-2026-33938]
+
+* link:https://access.redhat.com/security/cve/cve-2026-33937[CVE-2026-33937]
+
+* link:https://access.redhat.com/security/cve/cve-2026-33896[CVE-2026-33896]
+
+* link:https://access.redhat.com/security/cve/cve-2026-33895[CVE-2026-33895]
+
+* link:https://access.redhat.com/security/cve/cve-2026-33894[CVE-2026-33894]
+
+* link:https://access.redhat.com/security/cve/cve-2026-33891[CVE-2026-33891]
+
+* link:https://access.redhat.com/security/cve/cve-2026-33814[CVE-2026-33814]
+
+* link:https://access.redhat.com/security/cve/cve-2026-33671[CVE-2026-33671]
+
+* link:https://access.redhat.com/security/cve/cve-2026-33228[CVE-2026-33228]
+
+* link:https://access.redhat.com/security/cve/cve-2026-32141[CVE-2026-32141]
+
+* link:https://access.redhat.com/security/cve/cve-2026-29063[CVE-2026-29063]
+
+* link:https://access.redhat.com/security/cve/cve-2026-25681[CVE-2026-25681]
+
+* link:https://access.redhat.com/security/cve/cve-2026-25680[CVE-2026-25680]
+
+* link:https://access.redhat.com/security/cve/cve-2026-12151[CVE-2026-12151]
+
+* link:https://access.redhat.com/security/cve/cve-2026-12143[CVE-2026-12143]
+
+* link:https://access.redhat.com/security/cve/cve-2026-9697[CVE-2026-9697]
+
+* link:https://access.redhat.com/security/cve/cve-2026-9277[CVE-2026-9277]
+
+* link:https://access.redhat.com/security/cve/cve-2026-6734[CVE-2026-6734]
+
+* link:https://access.redhat.com/security/cve/cve-2026-6322[CVE-2026-6322]
+
+* link:https://access.redhat.com/security/cve/cve-2026-6321[CVE-2026-6321]
+
+* link:https://access.redhat.com/security/cve/cve-2026-4867[CVE-2026-4867]
+
+* link:https://access.redhat.com/security/cve/cve-2026-4800[CVE-2026-4800]
+
+* link:https://access.redhat.com/security/cve/cve-2026-2229[CVE-2026-2229]
+
+* link:https://access.redhat.com/security/cve/cve-2026-1528[CVE-2026-1528]
+
+* link:https://access.redhat.com/security/cve/cve-2026-1526[CVE-2026-1526]
+
+* link:https://access.redhat.com/security/cve/cve-2025-58190[CVE-2025-58190]
+
+* link:https://access.redhat.com/security/cve/cve-2025-47911[CVE-2025-47911]
+
+* link:https://access.redhat.com/security/cve/cve-2025-22872[CVE-2025-22872]
+
+* link:https://access.redhat.com/security/cve/cve-2025-22870[CVE-2025-22870]
+
+* link:https://access.redhat.com/security/cve/cve-2025-22868[CVE-2025-22868]
+
+* link:https://access.redhat.com/security/cve/cve-2024-52011[CVE-2024-52011]
+
+* link:https://access.redhat.com/security/cve/cve-2024-45338[CVE-2024-45338]
+
+* link:https://access.redhat.com/security/cve/cve-2024-4068[CVE-2024-4068]
+
+* link:https://access.redhat.com/security/cve/cve-2021-33623[CVE-2021-33623]
+
+* link:https://access.redhat.com/security/cve/cve-2020-7753[CVE-2020-7753]

--- a/release-notes/cluster-observability-operator-release-notes.adoc
+++ b/release-notes/cluster-observability-operator-release-notes.adoc
@@ -14,6 +14,8 @@ include::modules/coo-features.adoc[leveloffset=+1]
 
 include::snippets/unified-perspective-web-console.adoc[]
 
+include::modules/coo-rel-notes-151.adoc[leveloffset=+1]
+
 include::modules/coo-rel-notes-150.adoc[leveloffset=+1]
 
 include::modules/coo-rel-notes-140.adoc[leveloffset=+1]


### PR DESCRIPTION
Change type: Doc update; COO 1.5.1 patch release notes

Doc JIRA: https://redhat.atlassian.net/browse/OBSDOCS-3566

Also merge to: standalone-coo-docs-1-latest

Doc Preview: https://114367--ocpdocs-pr.netlify.app/openshift-coo/latest/release-notes/cluster-observability-operator-release-notes.html#cluster-observability-operator-release-notes-1-5-1_cluster-observability-operator-release-notes

SME/QE Review: @PeterYurkovich @danielmellado 
Peer review: @kaldesai 