### PR TITLE
CNV-64731: Fix incorrect ksmConfiguration path in HyperConverged CR

### DIFF
--- a/modules/virt-about-ksm.adoc
+++ b/modules/virt-about-ksm.adoc
@@ -18,7 +18,7 @@ You can enable or disable the KSM activation feature for all nodes by using the 
 [id="virt-ksm-cr-configuration"]
 CR configuration::
 +
-You can configure the KSM activation feature by editing the `spec.virtualization.ksmConfiguration` stanza of the `HyperConverged` CR.
+You can configure the KSM activation feature by editing the `spec.ksmConfiguration` stanza of the `HyperConverged` CR.
 +
 --
 * You enable the feature and configure settings by editing the `ksmConfiguration` stanza.

--- a/modules/virt-configure-ksm-cli.adoc
+++ b/modules/virt-configure-ksm-cli.adoc
@@ -28,15 +28,14 @@ $ oc edit {HCOCliKind} kubevirt-hyperconverged -n {CNVNamespace}
 +
 [source,yaml,subs="attributes+"]
 ----
-apiVersion: hco.kubevirt.io/v1
+apiVersion: hco.kubevirt.io/v1beta1
 kind: HyperConverged
 metadata:
   name: kubevirt-hyperconverged
   namespace: {CNVNamespace}
 spec:
-  virtualization:
-    ksmConfiguration:
-      nodeLabelSelector: {}
+  ksmConfiguration:
+    nodeLabelSelector: {}
 # ...
 ----
 
@@ -44,18 +43,17 @@ spec:
 +
 [source,yaml,subs="attributes+"]
 ----
-apiVersion: hco.kubevirt.io/v1
+apiVersion: hco.kubevirt.io/v1beta1
 kind: HyperConverged
 metadata:
   name: kubevirt-hyperconverged
   namespace: {CNVNamespace}
 spec:
-  virtualization:
-    ksmConfiguration:
-      nodeLabelSelector:
-        matchLabels:
-          <first_example_key>: "true"
-          <second_example_key>: "true"
+  ksmConfiguration:
+    nodeLabelSelector:
+      matchLabels:
+        <first_example_key>: "true"
+        <second_example_key>: "true"
 # ...
 ----
 
@@ -63,13 +61,12 @@ spec:
 +
 [source,yaml,subs="attributes+"]
 ----
-apiVersion: hco.kubevirt.io/v1
+apiVersion: hco.kubevirt.io/v1beta1
 kind: HyperConverged
 metadata:
   name: kubevirt-hyperconverged
   namespace: {CNVNamespace}
-spec:
-  virtualization: {}
+spec: {}
 # ...
 ----
 


### PR DESCRIPTION
Version(s):
4.16+

Issue:
https://redhat.atlassian.net/browse/CNV-64731

Link to docs preview:
* https://114381--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/nodes/virt-activating-ksm.html#virt-about-ksm_virt-activating-ksm
* https://114381--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/nodes/virt-activating-ksm.html#virt-configure-ksm-cli_virt-activating-ksm

QE review:
- [ ] QE has approved this change.

Additional information:
Fixed incorrect ksmConfiguration field path in HyperConverged CR documentation. The field is located at `spec.ksmConfiguration`, not `spec.virtualization.ksmConfiguration` as previously documented. This fix corrects all YAML examples in the procedure module and the field path reference in the concept module. Also updated the apiVersion to v1beta1, which is the current stable version.

This resolves a documentation bug that would cause the configuration examples to be silently ignored when applied to a cluster.