### PR TITLE
OSDOCS-17049: Fix AsciiDocDITA BlockTitle Vale warnings in post-install modules

### DIFF
--- a/modules/configuring-private-storage-endpoint-azure-user-provided-vnet-subnet.adoc
+++ b/modules/configuring-private-storage-endpoint-azure-user-provided-vnet-subnet.adoc
@@ -61,7 +61,7 @@ When redirect is enabled, pulling images from outside of the cluster will not wo
 $ oc get imagestream -n openshift
 ----
 +
-.Example output
+The output is similar to the following:
 +
 [source,terminal]
 ----
@@ -91,7 +91,7 @@ $ chroot /host
 $ podman login --tls-verify=false -u unused -p $(oc whoami -t) image-registry.openshift-image-registry.svc:5000
 ----
 +
-.Example output
+The output is similar to the following:
 +
 [source,terminal]
 ----
@@ -105,7 +105,7 @@ Login Succeeded!
 $ podman pull --tls-verify=false image-registry.openshift-image-registry.svc:5000/openshift/tools
 ----
 +
-.Example output
+The output is similar to the following:
 +
 [source,terminal]
 ----

--- a/modules/configuring-private-storage-endpoint-azure-vnet-subnet-iro-discovery.adoc
+++ b/modules/configuring-private-storage-endpoint-azure-vnet-subnet-iro-discovery.adoc
@@ -65,7 +65,7 @@ When redirect is enabled,  pulling images from outside of the cluster will not w
 $ oc get imagestream -n openshift
 ----
 +
-.Example output
+The output is similar to the following:
 +
 [source,terminal]
 ----
@@ -95,7 +95,7 @@ $ chroot /host
 $ podman login --tls-verify=false -u unused -p $(oc whoami -t) image-registry.openshift-image-registry.svc:5000
 ----
 +
-.Example output
+The output is similar to the following:
 +
 [source,terminal]
 ----
@@ -109,7 +109,7 @@ Login Succeeded!
 $ podman pull --tls-verify=false image-registry.openshift-image-registry.svc:5000/openshift/tools
 ----
 +
-.Example output
+The output is similar to the following:
 +
 [source,terminal]
 ----

--- a/modules/disabling-redirect-private-storage-endpoint-azure.adoc
+++ b/modules/disabling-redirect-private-storage-endpoint-azure.adoc
@@ -36,7 +36,7 @@ $ oc patch configs.imageregistry cluster --type=merge -p '{"spec":{"disableRedir
 $ oc get imagestream -n openshift
 ----
 +
-.Example output
+The output is similar to the following:
 +
 [source,terminal]
 ----
@@ -52,7 +52,7 @@ cli    default-route-openshift-image-registry.<cluster_dns>/cli   latest   8 hou
 $ podman login --tls-verify=false -u unused -p $(oc whoami -t) default-route-openshift-image-registry.<cluster_dns>
 ----
 +
-.Example output
+The output is similar to the following:
 +
 [source,terminal]
 ----
@@ -67,7 +67,7 @@ $ podman pull --tls-verify=false default-route-openshift-image-registry.<cluster
 /openshift/tools
 ----
 +
-.Example output
+The output is similar to the following:
 +
 [source,terminal]
 ----

--- a/modules/enabling-entra-workload-id-existing-cluster.adoc
+++ b/modules/enabling-entra-workload-id-existing-cluster.adoc
@@ -74,7 +74,7 @@ To use an existing Azure resource group instead of creating a new one, specify t
 $ ll ./output_dir/manifests
 ----
 +
-.Example output
+The output is similar to the following:
 +
 [source,text]
 ----

--- a/modules/machine-node-custom-partition.adoc
+++ b/modules/machine-node-custom-partition.adoc
@@ -213,7 +213,7 @@ The machines might take a few moments to become available.
 $ oc get machineset
 ----
 +
-.Example output
+The output is similar to the following:
 +
 [source,terminal]
 ----
@@ -231,7 +231,7 @@ worker-us-east-2-nvme1n1                           1         1         1       1
 $ oc get nodes
 ----
 +
-.Example output
+The output is similar to the following:
 +
 [source,terminal]
 ----
@@ -260,7 +260,7 @@ For example:
 $ oc debug node/ip-10-0-217-135.ec2.internal -- chroot /host lsblk
 ----
 +
-.Example output
+The output is similar to the following:
 +
 [source,terminal]
 ----

--- a/modules/manually-rotating-cloud-creds.adoc
+++ b/modules/manually-rotating-cloud-creds.adoc
@@ -134,7 +134,7 @@ where `<provider_spec>` is the corresponding value for your cloud provider:
 * {gcp-short}: `GCPProviderSpec`
 --
 +
-.Partial example output for AWS
+Partial output for AWS is similar to the following:
 +
 [source,json]
 ----
@@ -159,7 +159,7 @@ $ oc delete secret <secret_name> \//<1>
 <1> Specify the name of a secret.
 <2> Specify the namespace that contains the secret.
 +
-.Example deletion of an AWS secret
+The following is an example deletion of an AWS secret:
 +
 [source,terminal]
 ----
@@ -190,7 +190,7 @@ $ oc -n openshift-cloud-credential-operator get CredentialsRequest -o json | jq 
 +
 Where `<provider_spec>` is the corresponding value for your cloud provider: `AWSProviderSpec` for AWS, `AzureProviderSpec` for Azure, or `GCPProviderSpec` for {gcp-short}.
 +
-.Example output for AWS
+The output for AWS is similar to the following:
 +
 [source,terminal]
 ----
@@ -210,7 +210,7 @@ $ oc get credentialsrequest <cr_name> -n openshift-cloud-credential-operator -o 
 +
 Where `<cr_name>` is the name of a `CredentialsRequest` CR.
 +
-.Example output for AWS
+The output for AWS is similar to the following:
 +
 [source,json]
 ----

--- a/modules/monitoring-sending-notifications-to-external-systems.adoc
+++ b/modules/monitoring-sending-notifications-to-external-systems.adoc
@@ -21,6 +21,6 @@ endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 
 Routing alerts to receivers enables you to send timely notifications to the appropriate teams when failures occur. For example, critical alerts require immediate attention and are typically paged to an individual or a critical response team. Alerts that provide non-critical warning notifications might instead be routed to a ticketing system for non-immediate review.
 
-.Checking that alerting is operational by using the watchdog alert
+== Checking that alerting is operational by using the watchdog alert
 
 {product-title} monitoring includes a watchdog alert that fires continuously. Alertmanager repeatedly sends watchdog alert notifications to configured notification providers. The provider is usually configured to notify an administrator when it stops receiving the watchdog alert. This mechanism helps you quickly identify any communication issues between Alertmanager and the notification provider.

--- a/modules/monitoring-sending-notifications-to-external-systems.adoc
+++ b/modules/monitoring-sending-notifications-to-external-systems.adoc
@@ -21,6 +21,7 @@ endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 
 Routing alerts to receivers enables you to send timely notifications to the appropriate teams when failures occur. For example, critical alerts require immediate attention and are typically paged to an individual or a critical response team. Alerts that provide non-critical warning notifications might instead be routed to a ticketing system for non-immediate review.
 
+[id="checking-that-alerting-is-operational-by-using-the-watchdog-alert_{context}"]
 == Checking that alerting is operational by using the watchdog alert
 
 {product-title} monitoring includes a watchdog alert that fires continuously. Alertmanager repeatedly sends watchdog alert notifications to configured notification providers. The provider is usually configured to notify an administrator when it stops receiving the watchdog alert. This mechanism helps you quickly identify any communication issues between Alertmanager and the notification provider.

--- a/modules/nodes-vsphere-scaling-machines-static-ip.adoc
+++ b/modules/nodes-vsphere-scaling-machines-static-ip.adoc
@@ -16,7 +16,7 @@ You can scale additional machine sets to use pre-defined static IP addresses on 
 
 . Create a machine resource YAML file and define static IP address network information in the `network` parameter.
 +
-.Example of a machine resource YAML file with static IP address information defined in the `network` parameter.
+The following is an example of a machine resource YAML file with static IP address information defined in the `network` parameter:
 +
 [source,yaml]
 ----


### PR DESCRIPTION
Wrap example output in DITA example blocks and convert an unsupported concept block title to a section heading so Vale passes BlockTitle checks.

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.20+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

- [The Cloud Credential Operator in mint mode](https://114391--ocpdocs-pr.netlify.app/openshift-enterprise/latest/authentication/managing_cloud_provider_credentials/cco-mode-mint.html)
- [The Cloud Credential Operator in passthrough mode](https://114391--ocpdocs-pr.netlify.app/openshift-enterprise/latest/authentication/managing_cloud_provider_credentials/cco-mode-passthrough.html)
- [Changing the cloud provider credentials configuration](https://114391--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/changing-cloud-credentials-configuration.html)
- [Configuring alert notifications](https://114391--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/configuring-alert-notifications.html)
- [Configuring a private cluster](https://114391--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/configuring-private-cluster.html)
- [Postinstallation node tasks](https://114391--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/node-tasks.html)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
