### PR TITLE
OSDOCS-20375 created z-stream RNs for 4-18-46

### DIFF
--- a/modules/zstream-4-18-46.adoc
+++ b/modules/zstream-4-18-46.adoc
@@ -1,0 +1,36 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-18-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-18-46_{context}"]
+= RHSA-2026:29857 - {product-title} {product-version}.46 fixed issues and security update
+
+Issued: 1 Jul 2026
+
+[role="_abstract"]
+{product-title} release {product-version}.46 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2026:29857[RHSA-2026:29857] advisory. There are no RPM packages for this release.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.18.46 --pullspecs
+----
+
+[id="zstream-4-18-46-known-issues_{context}"]
+== Known issues
+
+* Currently, when you apply the `openshift-node-performance` `PerformanceProfile` with the {op-system-base} non-Real Time kernel, timer migration is not enabled for the `kernel.timer_migration` setting. As a consequence, kernel timers such as TCP timeout and keep-alive timers can remain stuck on CPUs assigned to latency-sensitive workloads, causing unwanted interruptions to those workloads. As a workaround, enable the timer migration by using a TuneD profile to set the `kernel.timer_migration=1` `sysctl` parameter. For more information about configuring TuneD, see link:https://access.redhat.com/solutions/5532341[Performance addons operator advanced configuration]. (link:https://issues.redhat.com/browse/OCPBUGS-88470[OCPBUGS-88470])
+
+[id="zstream-4-18-46-fixed-issues_{context}"]
+== Fixed issues
+
+There are no notable fixed issues in this release.
+
+[id="zstream-4-18-46-updating_{context}"]
+== Updating
+
+To update an {product-title} 4.18 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].

--- a/release_notes/ocp-4-18-release-notes.adoc
+++ b/release_notes/ocp-4-18-release-notes.adoc
@@ -3064,6 +3064,9 @@ As a workaround, you must manually reboot the failed host from the disk. (link:h
 // 4.18 about async
 include::modules/rn-async-errata.adoc[leveloffset=+1]
 
+// 4.18.46 RNs and updating
+include::modules/zstream-4-18-46.adoc[leveloffset=+2]
+
 // 4.18.45 RNs and updating
 include::modules/zstream-4-18-45.adoc[leveloffset=+2]
 


### PR DESCRIPTION
Version(s):
4.18

Issue:
https://redhat.atlassian.net/browse/OSDOCS-20375

Link to docs preview:
https://114412--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-18-release-notes.html#zstream-4-18-46_release-notes


QE review:
- [ ] QE has approved this change.


Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
