### PR TITLE
OSDOCS#20444: Update the MicroShift RNs for 4.22.3

### DIFF
--- a/microshift_release_notes/microshift-4-22-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-22-release-notes.adoc
@@ -23,6 +23,8 @@ include::modules/microshift-4-22-additional-release-notes.adoc[leveloffset=+1]
 
 include::modules/microshift-4-22-asynch-updates.adoc[leveloffset=+1]
 
+include::modules/microshift-4-22-3-async.adoc[leveloffset=+2]
+
 include::modules/microshift-4-22-0-async.adoc[leveloffset=+2]
 
 //add module for each z-stream

--- a/modules/microshift-4-22-3-async.adoc
+++ b/modules/microshift-4-22-3-async.adoc
@@ -1,0 +1,22 @@
+// Module included in the following assemblies:
+//
+//microshift_release_notes/microshift-4-22-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="microshift-4-22-3-async_{context}"]
+= RHBA-2026:29956 - {microshift-short} 4.22.3 fixed issue update
+
+Issued: 30 June 2026
+
+[role="_abstract"]
+{product-title} release 4.22.3 is now available. Fixed issues are listed in the link:https://access.redhat.com/errata/RHBA-2026:29956[RHBA-2026:29956] advisory. The images that are included in the update are provided by the {OCP} link:https://access.redhat.com/errata/RHBA-2026:29797[RHBA-2026:29797] advisory.
+
+See the latest images included with {microshift-short} by using the following instructions:
+
+* xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[Listing the contents of the {microshift-short} RPM release package]
+* xref:../microshift_install_bootc/microshift-install-bootc-image.adoc#microshift-install-bootc-get-published-image_microshift-install-publish-bootc-image[Getting the published bootc image for {microshift-short}]
+
+[id="microshift-4-22-3-fixed_issues_{context}"]
+== Fixed issues
+
+There are no notable fixed issues in this release.

--- a/modules/microshift-4-22-new-features-enhancements.adoc
+++ b/modules/microshift-4-22-new-features-enhancements.adoc
@@ -14,6 +14,10 @@ This release adds improvements related to the following components and concepts.
 
 With this release, {microshift-short} is supported on {op-system-base-full} {op-system-version}.
 
+[id="microshift-4-22-ingress-tls-doc_{context}"]
+== Ingress TLS Configuration Documentation 
+With this release, {microshift-short} documentation adds procedures and prerequisites for the default ingress router certificate (`ingress.certificateSecret`) and for TLS on Kubernetes `Ingress` objects.
+
 //TODO add new features and enhancements as neededGeneric Device Plugin feature
 //[id="microshift-4-22-placeholder-feature2_{context}"]
 //== placeholder feature 2


### PR DESCRIPTION
Version(s):
4.22

Issue:
[OSDOCS-20444](https://redhat.atlassian.net/browse/OSDOCS-20444)

Link to docs preview:
4.22.3

QE review:
- [ ] QE has approved this change.
N/A for RNs.

Additional information:
Shipment [MR](https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/614)
ART [Dashboard](https://art-dash.engineering.redhat.com/dashboard/release/openshift-4.22?page=1)
