### PR TITLE
OSSM_v3.2.7

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -17,10 +17,10 @@
 :SMProductName: Red{nbsp}Hat OpenShift Service Mesh
 :SMProduct: OpenShift Service Mesh
 :SMProductShortName: Service Mesh
-:SMProductVersion: 3.2.6
+:SMProductVersion: 3.2.7
 //service mesh v2
 //Update when there is a new 2.6.z release
-:SMv2Version: 2.6.15
+:SMv2Version: 2.6.17
 //SMv2Version must be updated with each 2.x release because users can only migrate from the latest 2.x.z version. Update 02/24/2025 for service-mesh-docs-3.0
 //Istio
 :istio: Istio

--- a/modules/ossm-release-notes-3-2-7.adoc
+++ b/modules/ossm-release-notes-3-2-7.adoc
@@ -1,0 +1,12 @@
+// Module included in the following assemblies:
+//
+// * service-mesh-docs-main/ossm-release-notes/ossm-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="ossm-release-3-2-7_{context}"]
+= {SMProductName} version 3.2.7
+
+[role="_abstract"]
+This release of {SMProductName} is included with the {SMProductName} Operator 3.2.7 and is supported on {ocp-product-title} 4.18-4.22. This release addresses Common Vulnerabilities and Exposures (CVEs).
+
+For supported component versions for 3.2.7, see "Service Mesh version support tables".

--- a/modules/ossm-release-notes-supported-versions.adoc
+++ b/modules/ossm-release-notes-supported-versions.adoc
@@ -7,6 +7,40 @@
 = {SMProduct} supported versions
 
 [role="_abstract"]
+See the following table for information about {SMProduct} 3.2.7 supported versions.
+
+== {SMProduct} 3.2.7 supported versions
+
+[cols="1,1"]
+|===
+| Feature | Supported versions
+
+| {SMProduct} 3 Operator
+| 3.2.7
+
+| {SMProduct} `Istio` control plane resource
+| 1.27.9
+
+| {ocp-product-title}
+| 4.18-4.22
+
+| Envoy proxy
+| 1.35.12
+
+| `IstioCNI` resource
+| 1.27.9
+
+| `Ztunnel` resource
+| 1.27.9
+
+| Kiali Operator
+| 2.22.6
+
+| Kiali server
+| 2.17.10
+
+|===
+
 See the following table for information about {SMProduct} 3.2.6 supported versions.
 
 == {SMProduct} 3.2.6 supported versions

--- a/ossm-release-notes/ossm-release-notes.adoc
+++ b/ossm-release-notes/ossm-release-notes.adoc
@@ -16,6 +16,8 @@ toc::[]
 For additional information about the {SMProductName} life cycle and supported platforms, refer to the "{ocp-short-name} Operator Life Cycles".
 ====
 
+include::modules/ossm-release-notes-3-2-7.adoc[leveloffset=+1]
+
 include::modules/ossm-release-notes-3-2-6.adoc[leveloffset=+1]
 
 include::modules/ossm-release-notes-3-2-5.adoc[leveloffset=+1]


### PR DESCRIPTION
OSSM 14442: OSSM 3.3.5 & 3.2.7 & 3.1.10 & 3.0.13 At ReleaseCandidate Documentation Tasks

Version(s):
service-mesh-docs-3.2 (no cherry picks necessary)

Issue:
https://redhat.atlassian.net/browse/OSSM-14442

Link to docs preview:
https://114418--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/ossm-release-notes/ossm-release-notes.html
https://114418--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/ossm-release-notes/ossm-release-notes-version-support-tables.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
