### PR TITLE
OSDOCS#20444: Update the MicroShift RNs for 4.22.3

### DIFF
--- a/microshift_release_notes/microshift-4-22-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-22-release-notes.adoc
@@ -23,6 +23,8 @@ include::modules/microshift-4-22-additional-release-notes.adoc[leveloffset=+1]
 
 include::modules/microshift-4-22-asynch-updates.adoc[leveloffset=+1]
 
+include::modules/microshift-4-22-3-async.adoc[leveloffset=+2]
+
 include::modules/microshift-4-22-0-async.adoc[leveloffset=+2]
 
 //add module for each z-stream

--- a/modules/microshift-4-22-3-async.adoc
+++ b/modules/microshift-4-22-3-async.adoc
@@ -1,0 +1,22 @@
+// Module included in the following assemblies:
+//
+//microshift_release_notes/microshift-4-22-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="microshift-4-22-3-async_{context}"]
+= RHBA-2026:29956 - {microshift-short} 4.22.3 fixed issue update
+
+Issued: 30 June 2026
+
+[role="_abstract"]
+{product-title} release 4.22.3 is now available. Fixed issues are listed in the link:https://access.redhat.com/errata/RHBA-2026:29956[RHBA-2026:29956] advisory. Release notes for fixed issues are provided in this documentation. The images that are included in the update are provided by the {OCP} link:https://access.redhat.com/errata/RHBA-2026:29797[RHBA-2026:29797] advisory.
+
+See the latest images included with {microshift-short} by using the following instructions:
+
+* xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[Listing the contents of the {microshift-short} RPM release package]
+* xref:../microshift_install_bootc/microshift-install-bootc-image.adoc#microshift-install-bootc-get-published-image_microshift-install-publish-bootc-image[Getting the published bootc image for {microshift-short}]
+
+[id="microshift-4-22-3-fixed-issues_{context}"]
+== Fixed issues
+
+There are no notable fixed issues in this release.


### PR DESCRIPTION
Version(s):
4.22

Issue:
[OSDOCS-20444](https://redhat.atlassian.net/browse/OSDOCS-20444)

Link to docs preview:
[4.22.3](https://114422--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-22-release-notes.html#microshift-4-22-3-async_release-notes)

QE review:
- [ ] QE has approved this change.
N/A for RNs.

Additional information:
Shipment [MR](https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/614)
ART [Dashboard](https://art-dash.engineering.redhat.com/dashboard/release/openshift-4.22?page=1)

