### PR TITLE
OSSM_v3.0.13

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -17,10 +17,10 @@
 :SMProductName: Red{nbsp}Hat OpenShift Service Mesh
 :SMProduct: OpenShift Service Mesh
 :SMProductShortName: Service Mesh
-:SMProductVersion: 3.0.12
+:SMProductVersion: 3.0.13
 //service mesh v2
 //Update when there is a new 2.6.z release
-:SMv2Version: 2.6.15
+:SMv2Version: 2.6.17
 //SMv2Version must be updated with each 2.x release because users can only migrate from the latest 2.x.z version. Update 02/24/2025 for service-mesh-docs-3.0
 //Istio
 :istio: Istio

--- a/modules/ossm-release-notes-3-0-13.adoc
+++ b/modules/ossm-release-notes-3-0-13.adoc
@@ -1,0 +1,12 @@
+// Module included in the following assemblies:
+//
+// * service-mesh-docs-main/ossm-release-notes/ossm-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="ossm-release-3-0-13_{context}"]
+= {SMProductName} version 3.0.13
+
+[role="_abstract"]
+This release of {SMProductName} is included with the {SMProductName} Operator 3.0.13 and is supported on {ocp-product-title} 4.14-4.19. This release addresses Common Vulnerabilities and Exposures (CVEs). 
+
+For supported component versions for 3.0.13, see "Service Mesh version support tables".

--- a/modules/ossm-release-notes-supported-versions.adoc
+++ b/modules/ossm-release-notes-supported-versions.adoc
@@ -7,6 +7,37 @@
 = {SMProduct} supported versions
 
 [role="_abstract"]
+See the following table for information about {SMProduct} 3.0.13 supported versions.
+
+== {SMProduct} 3.0.13 supported versions
+
+[cols="1,1"]
+|===
+| Feature | Supported versions
+
+| {SMProduct} 3 Operator
+| 3.0.13
+
+| {SMProduct} `Istio` control plane resource
+| 1.24.6
+
+| {ocp-product-title}
+| 4.14-4.19
+
+| Envoy proxy
+| 1.32.13
+
+| `IstioCNI` resource
+| 1.24.6
+
+| Kiali Operator
+| 2.22.6
+
+| Kiali server
+| 2.4.19
+
+|===
+
 See the following table for information about {SMProduct} 3.0.12 supported versions.
 
 == {SMProduct} 3.0.12 supported versions

--- a/ossm-release-notes/ossm-release-notes.adoc
+++ b/ossm-release-notes/ossm-release-notes.adoc
@@ -16,6 +16,8 @@ The {SMProductName} release notes provide details about new features and enhance
 For additional information about the {SMProductName} life cycle and supported platforms, refer to the "{ocp-short-name} Operator Life Cycles".
 ====
 
+include::modules/ossm-release-notes-3-0-13.adoc[leveloffset=+1]
+
 include::modules/ossm-release-notes-3-0-12.adoc[leveloffset=+1]
 
 include::modules/ossm-release-notes-3-0-11.adoc[leveloffset=+1]


### PR DESCRIPTION
OSSM 14442: OSSM 3.3.5 & 3.2.7 & 3.1.10 & 3.0.13 At ReleaseCandidate Documentation Tasks

Version(s):
service-mesh-docs-3.0 (no cherry picks necessary)

Issue:
https://redhat.atlassian.net/browse/OSSM-14442

Link to docs preview:
https://114428--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/ossm-release-notes/ossm-release-notes.html
https://114428--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/ossm-release-notes/ossm-release-notes-version-support-tables.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->