### PR TITLE
Move Excluding resources section to Migration controller options

### DIFF
--- a/migrating_from_ocp_3_to_4/advanced-migration-options-3-4.adoc
+++ b/migrating_from_ocp_3_to_4/advanced-migration-options-3-4.adoc
@@ -47,7 +47,6 @@ include::modules/migration-writing-ansible-playbook-hook.adoc[leveloffset=+2]
 
 You can exclude, edit, and map components in the `MigPlan` custom resource (CR).
 
-include::modules/migration-excluding-resources.adoc[leveloffset=+2]
 include::modules/migration-mapping-destination-namespaces-in-the-migplan-cr.adoc[leveloffset=+2]
 include::modules/migration-excluding-pvcs.adoc[leveloffset=+2]
 include::modules/migration-mapping-pvcs.adoc[leveloffset=+2]
@@ -67,8 +66,9 @@ include::modules/migration-kubernetes-objects.adoc[leveloffset=+2]
 [id="migration-controller-options_{context}"]
 == Migration controller options
 
-You can edit migration plan limits, enable persistent volume resizing, or enable cached Kubernetes clients in the `MigrationController` custom resource (CR) for large migrations and improved performance.
+You can exclude resources, edit migration plan limits, enable persistent volume resizing, or enable cached Kubernetes clients in the `MigrationController` custom resource (CR) for large migrations and improved performance.
 
+include::modules/migration-excluding-resources.adoc[leveloffset=+2]
 include::modules/migration-changing-migration-plan-limits.adoc[leveloffset=+2]
 include::modules/migration-enabling-pv-resizing-dvm.adoc[leveloffset=+2]
 include::modules/migration-enabling-cached-kubernetes-clients.adoc[leveloffset=+2]

--- a/migration_toolkit_for_containers/advanced-migration-options-mtc.adoc
+++ b/migration_toolkit_for_containers/advanced-migration-options-mtc.adoc
@@ -38,7 +38,6 @@ include::modules/migration-writing-ansible-playbook-hook.adoc[leveloffset=+2]
 
 You can exclude, edit, and map components in the `MigPlan` custom resource (CR).
 
-include::modules/migration-excluding-resources.adoc[leveloffset=+2]
 include::modules/migration-mapping-destination-namespaces-in-the-migplan-cr.adoc[leveloffset=+2]
 include::modules/migration-excluding-pvcs.adoc[leveloffset=+2]
 include::modules/migration-mapping-pvcs.adoc[leveloffset=+2]
@@ -58,8 +57,9 @@ include::modules/migration-kubernetes-objects.adoc[leveloffset=+2]
 [id="migration-controller-options_{context}"]
 == Migration controller options
 
-You can edit migration plan limits, enable persistent volume resizing, or enable cached Kubernetes clients in the `MigrationController` custom resource (CR) for large migrations and improved performance.
+You can exclude resources, edit migration plan limits, enable persistent volume resizing, or enable cached Kubernetes clients in the `MigrationController` custom resource (CR) for large migrations and improved performance.
 
+include::modules/migration-excluding-resources.adoc[leveloffset=+2]
 include::modules/migration-changing-migration-plan-limits.adoc[leveloffset=+2]
 include::modules/migration-enabling-pv-resizing-dvm.adoc[leveloffset=+2]
 include::modules/migration-enabling-cached-kubernetes-clients.adoc[leveloffset=+2]


### PR DESCRIPTION
## Summary

- Move the "Excluding resources" module (`migration-excluding-resources.adoc`) from the "Migration plan options" section to the "Migration controller options" section in both MTC assembly files
- Update the "Migration controller options" intro text to mention resource exclusion

## Problem

The "Excluding resources" section is currently placed under **"Migration plan options"**, which opens with:

> "You can exclude, edit, and map components in the `MigPlan` custom resource (CR)."

However, this section exclusively documents **MigrationController** CR parameters (`additional_excluded_resources`, `disable_image_migration`, `disable_pv_migration`). The YAML example shows `kind: MigrationController`, and the procedure instructs users to `oc edit migrationcontroller`.

This placement misleads users into believing these are MigPlan fields. When users run `oc explain migplan.spec`, the fields are not found because they belong to the MigrationController CR.

## Fix

Moved the `include::modules/migration-excluding-resources.adoc` from the "Migration plan options" section to the "Migration controller options" section in both assembly files:

- `migration_toolkit_for_containers/advanced-migration-options-mtc.adoc`
- `migrating_from_ocp_3_to_4/advanced-migration-options-3-4.adoc`

Updated the "Migration controller options" intro text to include "exclude resources" alongside the other capabilities.

### Before (section structure)
| Migration plan options (MigPlan CR) | Migration controller options (MigrationController CR) |
|---|---|
| Excluding resources (**wrong - documents MigrationController CR**) | Increasing limits |
| Mapping namespaces | PV resizing |
| Excluding PVCs | Cached clients |

### After (section structure)
| Migration plan options (MigPlan CR) | Migration controller options (MigrationController CR) |
|---|---|
| Mapping namespaces | **Excluding resources (moved here)** |
| Excluding PVCs | Increasing limits |
| ... | PV resizing |
| | Cached clients |

## Verification

- Cross-references to `#migration-excluding-resources_{context}` remain valid since the module is still included in the same assembly files
- Confirmed on MTC 1.8.15 / OCP 4.20: `oc explain migplan.spec` does not contain `additional_excluded_resources` — it is a MigrationController CR field
- The module content (`migration-excluding-resources.adoc`) is unchanged — only its placement in the assembly files is corrected

## Test plan

- [ ] Verify rendered docs show "Excluding resources" under "Migration controller options" instead of "Migration plan options"
- [ ] Verify cross-reference from `premigration-checklists-3-4.adoc` still resolves correctly
- [ ] Verify no broken links in either assembly