### PR TITLE
RHDEVDOCS-7669: Updated docs as per CQA rules

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: SNIPPET
+:_mod-docs-content-type: ATTRIBUTES
 // The {product-title} attribute provides the context-sensitive name of the relevant OpenShift distribution, for example, "OpenShift Container Platform" or "OKD". The {product-version} attribute provides the product version relative to the distribution, for example "4.9".
 // {product-title} and {product-version} are parsed when AsciiBinder queries the _distro_map.yml file in relation to the base branch of a pull request.
 // See https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#product-name-and-version for more information on this topic.

--- a/modules/ob-about-buildrun.adoc
+++ b/modules/ob-about-buildrun.adoc
@@ -7,7 +7,7 @@
 = BuildRun resource
 
 [role="_abstract"]
-A `BuildRun` resource invokes a build on the cluster similar to a Tekton task run. It represents a workload that instantiates a build for execution with specific parameters. Each BuildRun defines a unique name for monitoring, references a Build instance, and specifies a service account within a namespace.
+A `BuildRun` resource invokes a build on the cluster similar to a Tekton task run. It represents a workload that instantiates a build for execution with specific parameters. Each `BuildRun` defines a unique name for monitoring, references a Build instance, and specifies a service account within a namespace.
 
 A `BuildRun` resource helps you to define the following elements:
 

--- a/modules/ob-basic-authentication.adoc
+++ b/modules/ob-basic-authentication.adoc
@@ -7,7 +7,7 @@
 = Basic authentication
 
 [role="_abstract"]
-Configure basic authentication credentials for a Git repository by creating a Kubernetes secret with a username and password. The following example shows a Git basic-auth secret referenced by a build:
+Configure Basic authentication credentials for a Git repository by creating a Kubernetes secret with a username and password. The following example shows a Git basic-auth secret referenced by a build:
 
 [source,yaml]
 ----
@@ -24,5 +24,5 @@ stringData:
 ----
 where:
 
-`type`:: Specifies the Kubernetes secret type. `kubernetes.io/basic-auth` indicates that the secret contains credentials for basic authentication.
-`stringData`:: Specifies the username and password used for basic authentication to the Git repository referenced by the build.
+`type`:: Specifies the Kubernetes secret type. `kubernetes.io/basic-auth` indicates that the secret contains credentials for Basic authentication.
+`stringData`:: Specifies the username and password used for Basic authentication to the Git repository referenced by the build.

--- a/modules/ob-build-run-status.adoc
+++ b/modules/ob-build-run-status.adoc
@@ -10,7 +10,7 @@
 Monitor the progress and completion of your image builds by checking the status of the `BuildRun` custom resource (CR).
 A `BuildRun` CR stores status information in the status.conditions field. This field includes the status, the reason for that status, and a descriptive message. For example, a `Succeeded` condition type means the build finished successfully.
 
-The following examples show how to view the status of a specific BuildRun CR.
+The following examples show how to view the status of a specific `BuildRun` CR.
 
 Unknown status::
 An `Unknown` status indicates the build is still starting or in progress. The following example shows a `BuildRun` with `Unknown` status:

--- a/modules/ob-configuring-pods-in-build-run.adoc
+++ b/modules/ob-configuring-pods-in-build-run.adoc
@@ -11,7 +11,7 @@ Configure pod scheduling and placement for {builds-shortname} by using optional 
 
 Use the following fields to configure {builds-shortname} pods:
 
-* `spec.tolerations`: Specifies pod tolerations. Note: Only the NoSchedule taint effect is supported.
+* `spec.tolerations`: Specifies pod tolerations. Note: Only the `NoSchedule` taint effect is supported.
 
 * `spec.nodeSelector`: Specifies the nodes where the pod must run.
 

--- a/modules/ob-configuring-pods-in-build.adoc
+++ b/modules/ob-configuring-pods-in-build.adoc
@@ -20,6 +20,6 @@ Use the following optional `Build` CR fields to configure {builds-shortname} pod
 
 [NOTE]
 ====
-If you define these fields in the Build and BuildRun CRs, the BuildRun values take priority.
+If you define these fields in the Build and `BuildRun` CRs, the `BuildRun` values take priority.
 ====
 

--- a/modules/ob-creating-a-buildah-build-network-restricted.adoc
+++ b/modules/ob-creating-a-buildah-build-network-restricted.adoc
@@ -1,21 +1,35 @@
 // Module included in the following assemblies:
 //
-// * work-with-builds/creating-container-images.adoc
+// * work_with_builds/creating-container-images-in-a-network-restricted-environment.adoc
 
 :_mod-docs-content-type: PROCEDURE
-[id="ob-creating-a-buildah-build_{context}"]
-= Creating a buildah build
+[id='ob-creating-a-buildah-build-in-a-network-restricted-environment_{context}']
+= Creating a buildah build in a network-restricted environment
 
 [role="_abstract"]
-Use a `buildah` build strategy to build and push a container image using a Dockerfile.
+Create a `buildah` build in a network-restricted environment by mirroring the images that `buildah` build strategy requires. Mirroring the images eliminates the need for public registry access. This ensures clusters use only images that comply with external content controls.
 
 .Prerequisites
 
 * You have installed the {builds-operator} on the {ocp-product-title} cluster.
 * You have installed the `oc` CLI.
 * Optional: You have installed the link:https://console.redhat.com/openshift/downloads[`shp` CLI].
+* Your cluster can connect and interact with the Git source that you can use to create the buildah build.
+* You have the builder-image required to create the `buildah` build in your local registry. If the builder-image is not present in the local registry, mirror the source image.
 
 .Procedure
+
+. Run the following command to mirror the images that `buildah` build strategy requires:
++
+[source,terminal]
+----
+$ oc image mirror --insecure -a <registry_authentication> registry.redhat.io/ubi8/buildah@sha256:1c89cc3cab0ac0fc7387c1fe5e63443468219aab6fd531c8dad6d22fd999819e <mirror_registry>/<repo>/ubi8_buildah
+----
++
+where:
+
+`<registry_authentication>`:: Specifies the authentication credentials used to access a container registry. This is required when pushing to or pulling from a private registry.
+`<mirror_registry>`:: Specifies the registry where the image you want to mirror is stored.
 
 . Create a `Build` resource and apply it to the {ocp-product-title} cluster. You can
 do so by using the `oc` command or the `shp` command:
@@ -57,7 +71,7 @@ where:
 [source,terminal]
 ----
 $ shp build create buildah-golang-build \
---source-url="https://github.com/redhat-openshift-builds/samples"
+--source-url="https://github.com/redhat-openshift-builds/samples" \
 --source-context-dir="buildah-build" \
 --strategy-name="buildah" \
 --dockerfile="Dockerfile" \
@@ -125,7 +139,7 @@ $ oc get buildrun buildah-golang-buildrun
 $ shp buildrun list
 ----
 +
-The `BuildRun` resource creates a `TaskRun` resource, which then creates the pods to execute build strategy steps.
+The `BuildRun` resource creates a `TaskRun` resource, which then creates the pods to run build strategy steps.
 
 .Verification
 
@@ -189,10 +203,10 @@ The pod might switch to a `NotReady` state because one of the containers has com
 +
 [source,terminal]
 ----
-$ podman manifest inspect image-registry.openshift-image-registry.svc:5000/buildah-example/taxi-app
+$ podman manifest inspect image-registry.openshift-image-registry.svc:5000/buildah-example/go-app
 ----
 +
-In the previous example, the project name is `buildah-example`, and the image name is `taxi-app`.
+In the previous example, the project name is `buildah-example`, and the image name is `go-app`.
 +
 Example output:
 +

--- a/modules/ob-creating-a-buildpacks-build.adoc
+++ b/modules/ob-creating-a-buildpacks-build.adoc
@@ -23,8 +23,7 @@ Use a `buildpacks` build to create and push container images to the target regis
 
 [IMPORTANT]
 ====
-Using `shp` CLI with buildpacks requires additional permissions setup that
-you must complete before you start creating a buildpacks build.
+Using `shp` CLI with buildpacks requires additional permissions setup that you must complete before you start creating a buildpacks build.
 ====
 
 .Procedure
@@ -127,7 +126,7 @@ $ oc get builds.shipwright.io buildpack-nodejs-build
 $ shp build list
 ----
 
-. Create a `BuildRun` resource and apply it to the {ocp-product-title} cluster.  You can do so by using the `oc` command or the `shp` command:
+. Create a `BuildRun` resource and apply it to the {ocp-product-title} cluster. You can do so by using the `oc` command or the `shp` command:
 +
 [source,terminal]
 ----
@@ -198,7 +197,7 @@ $ shp buildrun list
 +
 [NOTE]
 ====
-The `BuildRun` resource creates a `TaskRun` resource, which then creates the pods to execute build strategy steps.
+The `BuildRun` resource creates a `TaskRun` resource, which then creates the pods to run build strategy steps.
 ====
 
 .Verification

--- a/modules/ob-creating-a-s2i-build-network-restricted.adoc
+++ b/modules/ob-creating-a-s2i-build-network-restricted.adoc
@@ -1,21 +1,35 @@
 // Module included in the following assemblies:
 //
-// * work_with_builds/creating-container-images.adoc
+// * work_with_builds/creating-container-images-in-a-network-restricted-environment.adoc
 
 :_mod-docs-content-type: PROCEDURE
-[id="ob-creating-a-s2i-build_{context}"]
-= Creating a source-to-image build
+[id='ob-creating-a-source-to-image-build-in-a-network-restricted-environment_{context}']
+= Creating a source-to-image build in a network-restricted environment
 
 [role="_abstract"]
-Use a `source-to-image` (S2I) build strategy to turn application source code into a container image using a base image.
+Use the `source-to-image` build strategy in disconnected environments by first mirroring required builder images to a local registry. This approach allows your cluster to operate without public registry access while maintaining compliance with organizational content policies.
 
 .Prerequisites
 
 * You have installed the {builds-operator} on the {ocp-product-title} cluster.
 * You have installed the `oc` CLI.
 * Optional: You have installed the link:https://console.redhat.com/openshift/downloads[`shp` CLI].
+* Your cluster can connect and interact with the Git source that you can use to create the source-to-image build.
+* You have the builder-image required to create the `source-to-image` build in your local registry. If the builder-image is not present in the local registry, mirror the source image.
 
 .Procedure
+
+. Run the following command to mirror the images that `source-to-image` build strategy requires:
++
+[source,terminal]
+----
+$ oc image mirror --insecure -a <registry_authentication> registry.redhat.io/source-to-image/source-to-image-rhel8@sha256:d041c1bbe503d152d0759598f79802e257816d674b342670ef61c6f9e6d401c5 <mirror_registry>/<repo>/source-to-image-source-to-image-rhel8
+----
++
+where:
+
+`<registry_authentication>`:: Specifies the authentication credentials used to access a container registry. This is required when pushing to or pulling from a private registry.
+`<mirror_registry>`:: Specifies the registry where the image you want to mirror is stored.
 
 . Create a `Build` resource and apply it to the {ocp-product-title} cluster. You can do so by using the `oc` command or the `shp` command:
 +
@@ -58,7 +72,8 @@ where:
 [source,terminal]
 ----
 $ shp build create s2i-nodejs-build \
---source-url="https://github.com/redhat-openshift-builds/samples" --source-context-dir="s2i-build/nodejs" \
+--source-url="https://github.com/redhat-openshift-builds/samples" \
+--source-context-dir="s2i-build/nodejs" \
 --strategy-name="source-to-image" \
 --builder-image="quay.io/centos7/nodejs-12-centos7" \
 --output-image="quay.io/<repo>/s2i-nodejs-example" \
@@ -128,7 +143,7 @@ $ oc get buildrun s2i-nodejs-buildrun
 $ shp buildrun list
 ----
 +
-The `BuildRun` resource creates a `TaskRun` resource, which then creates the pods to execute build strategy steps.
+The `BuildRun` resource creates a `TaskRun` resource, which then creates the pods to run build strategy steps.
 
 .Verification
 
@@ -192,9 +207,9 @@ The pod might switch to a `NotReady` state because one of the containers has com
 +
 [source,terminal]
 ----
-$ podman manifest inspect image-registry.openshift-image-registry.svc:5000/s2i-example/taxi-app
+$ podman manifest inspect quay.io/<repo>/s2i-nodejs-example
 ----
-In the previous example, the project name is `s2i-example`, and the image name is `taxi-app`.
+In the previous example, the image name is `s2i-nodejs-example`.
 +
 Example output:
 +

--- a/modules/ob-defining-param-values-in-build-run.adoc
+++ b/modules/ob-defining-param-values-in-build-run.adoc
@@ -7,7 +7,7 @@
 = Parameter values definition for a build run
 
 [role="_abstract"]
-You can define values for build strategy parameters in your BuildRun custom resource (CR). Values set in the BuildRun resource override any values with the same name in the Build resource.
+You can define values for build strategy parameters in your `BuildRun` custom resource (CR). Values set in the `BuildRun` resource override any values with the same name in the Build resource.
 
 In the following example, the `cache` value in the `BuildRun` overrides the `cache` value in the `Build` resource:
 

--- a/modules/ob-example-configuration-for-defining-parameter-values.adoc
+++ b/modules/ob-example-configuration-for-defining-parameter-values.adoc
@@ -9,7 +9,7 @@
 [role="_abstract"]
 The following examples show how to set parameters in a build strategy. You can use a `Build` custom resource (CR) to give these parameters specific values. You can also assign values to array parameters.
 
-Define parameters in a ClusterBuildStrategy CR::
+Define parameters in a `ClusterBuildStrategy` CR::
 The following example shows a `ClusterBuildStrategy` CR with several parameters:
 +
 [source,yaml]

--- a/modules/ob-specifying-environment-variables.adoc
+++ b/modules/ob-specifying-environment-variables.adoc
@@ -7,7 +7,7 @@
 = Environment variables definition
 
 [role="_abstract"]
-You can set environment variables in your BuildRun custom resource (CR). These variables pass information to the build container. You can use literal values or the Kubernetes downward API.
+You can set environment variables in your `BuildRun` custom resource (CR). These variables pass information to the build container. You can use literal values or the Kubernetes downward API.
  
 The following example shows how to define environment variables:
 [source,yaml]

--- a/modules/ob-step-results-in-build-run-status.adoc
+++ b/modules/ob-step-results-in-build-run-status.adoc
@@ -7,7 +7,7 @@
 = Step results in build run status
 
 [role="_abstract"]
-After a `BuildRun` custom resource (CR) finishes execution, `.status.taskResults` shows step results like the image digest or commit SHA. `.status.sources` holds results from source steps, and `.status.output` holds results from output steps, reflecting the source and built image.
+After a `BuildRun` custom resource (CR) finishes execution, `.status.taskResults` shows step results such as the image digest or commit SHA. `.status.sources` holds results from source steps, and `.status.output` holds results from output steps, reflecting the source and built image.
 
 The following example shows a `BuildRun` CR with step results for a Git source:
 

--- a/modules/ob-strategies-with-different-resources.adoc
+++ b/modules/ob-strategies-with-different-resources.adoc
@@ -9,7 +9,7 @@
 [role="_abstract"]
 Define multiple variants of the same strategy to apply different resource limits for different build requirements.
 
-The following examples use the same `buildah` strategy with small and medium limits defined for the resources.These examples provide a strategy administrator more control over the step resources definition.
+The following examples use the same `buildah` strategy with small and medium limits defined for the resources. These examples provide a strategy administrator more control over the step resources definition.
 
 You can define the `spec.steps[].resources` field with a small resource limit for the `buildah` strategy, as shown in the following example:
 

--- a/modules/ob-usage-of-git-secret.adoc
+++ b/modules/ob-usage-of-git-secret.adoc
@@ -8,7 +8,7 @@
 = Usage of Git secret
 
 [role="_abstract"]
-After creating a secret in the relevant namespace, you can reference it in your `Build` custom resource (CR). You can configure the Git secret to use either basic authentication or Secure Shell (SSH) authentication.
+After creating a secret in the relevant namespace, you can reference it in your `Build` custom resource (CR). You can configure the Git secret to use either Basic authentication or Secure Shell (SSH) authentication.
 
 The following example shows the usage of a Git secret with SSH authentication type:
 
@@ -25,7 +25,7 @@ spec:
       cloneSecret: secret-git-ssh-auth
 ----
 
-The following example shows the usage of a Git secret with basic authentication type:
+The following example shows the usage of a Git secret with Basic authentication type:
 
 [source,yaml]
 ----

--- a/work_with_builds/creating-container-images-in-a-network-restricted-environment.adoc
+++ b/work_with_builds/creating-container-images-in-a-network-restricted-environment.adoc
@@ -4,16 +4,15 @@
 
 include::_attributes/common-attributes.adoc[]
 :context: managing-builds-in-network-restricted-environment
-:network-restricted: true
 
 toc::[]
 
 [role="_abstract"]
 As an application developer, configure {ocp-product-title} with an HTTP or HTTPS proxy to enforce security and prevent direct internet access for your build processes. This setup enforces security by routing build pulls of dependencies, images, and code through a monitored outgoing proxy gateway.
 
-include::modules/ob-creating-a-buildah-build.adoc[leveloffset=+1]
+include::modules/ob-creating-a-buildah-build-network-restricted.adoc[leveloffset=+1]
 
-include::modules/ob-creating-a-s2i-build.adoc[leveloffset=+1]
+include::modules/ob-creating-a-s2i-build-network-restricted.adoc[leveloffset=+1]
 
 include::modules/ob-verifying-proxy-details.adoc[leveloffset=+1]
 
@@ -21,9 +20,9 @@ include::modules/ob-verifying-proxy-details.adoc[leveloffset=+1]
 [id="additional-resources_{context}"]
 == Additional resources
 
-* xref:../about/build-strategies.adoc[Build strategies]
-* xref:../installing/installing-openshift-builds.adoc[Installing builds]
+* xref:../about/build-strategies.adoc#build-strategies[Build strategies]
+* xref:../installing/installing-openshift-builds.adoc#installing-openshift-builds[Installing builds]
 * xref:../authenticating/understanding-authentication-at-runtime.adoc#ob-authentication-to-container-registries_understanding-authentication-at-runtime[Authentication to container registries]
-* link:https://docs.openshift.com/pipelines/1.16/install_config/installing-pipelines.html#op-pipelines-operator-in-restricted-environment_installing-pipelines[Red Hat OpenShift Pipelines Operator in a restricted environment]
+* link:https://docs.openshift.com/pipelines/1.16/install_config/installing-pipelines.html#op-pipelines-operator-in-restricted-environment_installing-pipelines[{pipelines-title} Operator in a restricted environment]
 * link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html/configuring_network_settings/enable-cluster-wide-proxy[Configuring cluster-wide proxy]
 * link:https://docs.redhat.com/en/documentation/openshift_container_platform/latest/html/disconnected_environments/installing-mirroring-installation-images[Mirroring images for a disconnected installation by using the oc adm command]

--- a/work_with_builds/creating-container-images.adoc
+++ b/work_with_builds/creating-container-images.adoc
@@ -8,7 +8,7 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 [role="_abstract"]
-As an application developer, create container images using `buildah`, `source-to-image`, or the `buildpacks` strategy, depending on your source code, framework, and automation requirements. You can also use Open Container Initiative (OCI) artifacts to build container images.
+As an application developer, create container images by using `buildah`, `source-to-image`, or the `buildpacks` strategy, depending on your source code, framework, and automation requirements. You can also use Open Container Initiative (OCI) artifacts to build container images.
 
 include::modules/ob-creating-a-buildah-build.adoc[leveloffset=+1]
 
@@ -23,5 +23,5 @@ include::modules/ob-creating-a-build-with-oci-artifacts.adoc[leveloffset=+1]
 == Additional resources
 
 * xref:../authenticating/understanding-authentication-at-runtime.adoc#ob-authentication-to-container-registries_understanding-authentication-at-runtime[Authentication to container registries]
-* xref:../about/build-strategies.adoc[Build strategies]
-* xref:../installing/installing-openshift-builds.adoc[Installing builds]
+* xref:../about/build-strategies.adoc#about-build-strategies[Build strategies]
+* xref:../installing/installing-openshift-builds.adoc#installing-openshift-builds[Installing builds]

--- a/work_with_builds/managing-builds.adoc
+++ b/work_with_builds/managing-builds.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="managing-builds"]
-= Managing Builds
+= Managing builds
 
 include::_attributes/common-attributes.adoc[]
 :context: managing-builds
@@ -22,5 +22,5 @@ include::modules/ob-deleting-a-buildstrategy-resource.adoc[leveloffset=+1]
 [id="additional-resources_{context}"]
 == Additional resources
 
-* xref:../about/build-strategies.adoc[Build strategies]
-* xref:../installing/installing-openshift-builds.adoc[Installing builds]
+* xref:../about/build-strategies.adoc#build-strategies[Build strategies]
+* xref:../installing/installing-openshift-builds.adoc#installing-openshift-builds[Installing builds]

--- a/work_with_shared_resources/using-shared-resource-csi-driver.adoc
+++ b/work_with_shared_resources/using-shared-resource-csi-driver.adoc
@@ -8,7 +8,7 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 [role="_abstract"]
-To securely share `Secret` and `ConfigMap` objects across namespaces, use the Shared Resource Container Storage Interface (CSI) driver with the `csi` volume type. This driver provisions inline ephemeral volumes, enabling pods and {builds-shortname} to utilize these shared configuration resources.
+To securely share `Secret` and `ConfigMap` objects across namespaces, use the Shared Resource Container Storage Interface (CSI) driver with the `csi` volume type. This driver provisions inline ephemeral volumes, enabling pods and {builds-shortname} to use these shared configuration resources.
 
 include::modules/ephemeral-storage-sharing-secrets-across-namespaces.adoc[leveloffset=+1]
 


### PR DESCRIPTION
Cherry-pick of #113232 for build-docs-1.7

Version(s): build-docs-1.7

Issue: https://redhat.atlassian.net/browse/RHDEVDOCS-7669

**Note**: This is a manual cherry-pick. The following files were excluded as they don't exist in build-docs-1.7:
- modules/ob-isolate-all-project-builds-using-a-specific-runtimeclass.adoc
- modules/ob-runtimeclass-prerequisites-and-precedence.adoc
- work_with_builds/optimize-build-performance.adoc

QE review: Builds does not have a QE
- [ ] QE has approved this change.