### PR TITLE
[RHDEVDOCS-7256] Fix bad indentation in PipelineRun timeout override code snippet

### DIFF
--- a/modules/op-release-notes-1-21-0.adoc
+++ b/modules/op-release-notes-1-21-0.adoc
@@ -23,24 +23,24 @@ With this update, all {pipelines-shortname} containers, including controllers an
 
 //https://issues.redhat.com/browse/SRVKP-8341
 Override individual `TaskRun` timeouts in a `PipelineRun`::
-With this update, you can override the timeout for individual `TaksRun` objects within a `PipelineRun` by using the `spec.taskRunSpecs[].timeout` field.
+With this update, you can override the timeout for individual `TaskRun` objects within a `PipelineRun` by using the `spec.taskRunSpecs[].timeout` field.
 +
 [source, yaml]
 ----
 apiVersion: tekton.dev/v1
-  kind: PipelineRun
-  metadata:
-    name: example-with-timeout-override
-  spec:
-    pipelineRef:
-      name: my-pipeline
-    timeouts:
-      pipeline: "2h"
-    taskRunSpecs:
-      - pipelineTaskName: build-task
-        timeout: "30m"
-      - pipelineTaskName: test-task
-        timeout: "1h"
+kind: PipelineRun
+metadata:
+  name: example-with-timeout-override
+spec:
+  pipelineRef:
+    name: my-pipeline
+  timeouts:
+    pipeline: "2h"
+  taskRunSpecs:
+    - pipelineTaskName: build-task
+      timeout: "30m"
+    - pipelineTaskName: test-task
+      timeout: "1h"
 ----
 +
 This allows finer-grained control over task execution duration without affecting the overall `PipelineRun` timeout.


### PR DESCRIPTION
Version(s):
OpenShift Pipelines 1.21

Issue:
https://issues.redhat.com/browse/RHDEVDOCS-7256

Link to docs preview:
https://114442--ocpdocs-pr.netlify.app/openshift-pipelines/latest/release_notes/op-release-notes-1-21.html 

QE/ SME review:
@bobade@redhat.com 


Peer review:
@Dhruv-Soni11 


Additional information:
This PR corrects an unexpected 2-space left margin indentation mismatch inside the YAML snippet located under the "Override individual TaskRun timeouts in a PipelineRun" sub-section. Aligning these fields to the left boundary ensures the resource blocks compile straight and load with correct vertical margins in downstream portal builds.