### PR TITLE
[OSDOCS#20427]: Added files for 4.19.36 zstream release notes

### DIFF
--- a/modules/zstream-4-19-36.adoc
+++ b/modules/zstream-4-19-36.adoc
@@ -1,0 +1,41 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-19-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-19-36_{context}"]
+= RHSA-2026:29864 - {product-title} {product-version}.36 fixed issues and security update
+
+Issued: 01 July 2026
+
+[role="_abstract"]
+{product-title} release {product-version}.36 is now available. The list of fixed issues that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2026:29864[RHSA-2026:29864] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2026:29862[RHBA-2026:29862] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.19.36 --pullspecs
+----
+
+[id="zstream-4-19-36-known-issues_{context}"]
+== Known issues
+
+* Currently, when you apply the `openshift-node-performance` PerformanceProfile resource with the non-RT kernel, timer migration (`kernel.timer_migration`) is not enabled. As a consequence, kernel timers such as TCP timeout and keep-alive timers can remain stuck on CPUs assigned to latency-sensitive workloads, causing unwanted interruptions to those workloads. As a workaround, enable timer migration by using a TuneD custom resource to set the `kernel.timer_migration=1` `sysctl` parameter. For more information about configuring TuneD, see link:https://access.redhat.com/solutions/5532341[Performance addons Operator advanced configuration]. (link:https://issues.redhat.com/browse/OCPBUGS-88469[OCPBUGS-88469])
+
+[id="zstream-4-19-36-fixed-issues_{context}"]
+== Fixed issues
+
+* Before this update, the tuned daemon lost its connection to the API server during control plane node restarts. As a consequence, during resiliency testing when control plane nodes were rebooted one by one, the PerformanceProfile resource could enter a degraded state with an error message: `rpc error: code = Unavailable desc = keepalive ping failed to receive ACK within timeout`. With this release, the Operator now properly handles connection timeouts and automatically recovers. As a result, the PerformanceProfile resource no longer enters a degraded state during control plane node restarts. (link:https://issues.redhat.com/browse/OCPBUGS-87932[*OCPBUGS-87932*])
+
+* Before this update, when a machine config attempted to install an extension package, the installation could silently fail. As a consequence, the Machine Config Pool (MCP) would incorrectly report `Update=True` even though the packages were not actually installed on the nodes. With this release, the Machine Config Operator now verifies that the expected packages are successfully installed on the nodes. As a result, the Operator degrades the MCP appropriately if the installation is not successful, preventing a false successful update status. (link:https://issues.redhat.com/browse/OCPBUGS-88566[*OCPBUGS-88566*])
+
+* Before this update, modifying any field in a `Secret` object containing binary data (such as JAR or JCEKS files) via the web console corrupted the binary content. As a consequence, the binary data was decoded as text, resulting in UTF-8 replacement characters that rendered the file invalid and increased its size. With this release, the web console properly preserves binary data when editing other fields in the `Secret` object. As a result, binary files remain intact and usable. (link:https://issues.redhat.com/browse/OCPBUGS-89712[*OCPBUGS-89712*])
+
+
+[id="zstream-4-19-36-updating_{context}"]
+== Updating
+
+To update an {product-title} 4.19 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].

--- a/release_notes/ocp-4-19-release-notes.adoc
+++ b/release_notes/ocp-4-19-release-notes.adoc
@@ -2977,6 +2977,9 @@ To save the `vmcore` file, use the `crashkernel` setting to reserve 1024 MB of m
 // 4.19.z about errata updates
 include::modules/ocp-release-asynch-errata-updates.adoc[leveloffset=+1]
 
+// 4.19.36 z-stream RNs full document
+include::modules/zstream-4-19-36.adoc[leveloffset=+2]
+
 // 4.19.35 z-stream RNs full document
 include::modules/zstream-4-19-35.adoc[leveloffset=+2]
 


### PR DESCRIPTION

Version(s):
4.19

Issue:
https://redhat.atlassian.net/browse/OSDOCS-20427

Link to docs preview:
https://114454--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-19-release-notes.html#zstream-4-19-36_release-notes

QE review:
N/A
