### PR TITLE
ROX-35505: Patch releases for 4.9.9

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ bin
 commercial_package
 .vscode
 .vale
+.agent_workspace
+.claude

--- a/modules/common-attributes.adoc
+++ b/modules/common-attributes.adoc
@@ -62,7 +62,7 @@ endif::[]
 :product-registry: OpenShift image registry
 :olm-first: Operator Lifecycle Manager (OLM)
 :olm: OLM
-:rhacs-version: 4.9.8
+:rhacs-version: 4.9.9
 :ga-date-490: 30 October 2025
 :ga-date-491: 24 November 2025
 :ga-date-492: 16 December 2025
@@ -72,6 +72,7 @@ endif::[]
 :ga-date-496: 6 May 2026
 :ga-date-497: 2 June 2026
 :ga-date-498: 18 June 2026
+:ga-date-499: 7 July 2026
 :ocp-supported-version: 4.12
 :ocp-latest-version: 4.21
 :pipelines-shortname: OpenShift Pipelines

--- a/release_notes/49-release-notes.adoc
+++ b/release_notes/49-release-notes.adoc
@@ -24,6 +24,7 @@ toc::[]
 |`4.9.6` | {ga-date-496}
 |`4.9.7` | {ga-date-497}
 |`4.9.8` | {ga-date-498}
+|`4.9.9` | {ga-date-499}
 
 |====
 
@@ -743,5 +744,52 @@ This release addresses the following security vulnerabilities:
 * Go crypto/x509: Denial of service via inefficient certificate chain validation (link:https://access.redhat.com/security/cve/CVE-2026-32281[CVE-2026-32281])
 
 include::modules/bug-fixes-in-version-498.adoc[leveloffset=+1]
+
+[id="about-this-release-499_{context}"]
+== About release 4.9.9
+
+*Release date*: {ga-date-499}
+
+This release provides the following bug fixes:
+
+//ROX-35177
+* Images built with erroneous quotes in metadata can now be properly scanned by Scanner V4.
+
+//ROX-35227
+* Before this update, the Artifactory "test" function always returned `true`, even when authentication failed. The test endpoint did not require authentication, causing confusion about integration status. With this release, the test function now performs an authenticated operation to properly validate credentials before reporting success.
+
+This release addresses the following security vulnerabilities:
+
+* Go and golang.org:
+//ROX-35153, ROX-35157
+** golang.org/x/crypto/ssh: Unauthorized command execution via discarded SSH permissions (link:https://access.redhat.com/security/cve/CVE-2026-39828[CVE-2026-39828])
+//ROX-35174, ROX-35176
+** golang.org/x/crypto/ssh: Denial of service via crafted public key with excessive parameters (link:https://access.redhat.com/security/cve/CVE-2026-39829[CVE-2026-39829])
+//ROX-35201, ROX-35207
+** golang.org/x/crypto/ssh: Denial of service via resource leak from unsolicited SSH responses (link:https://access.redhat.com/security/cve/CVE-2026-39830[CVE-2026-39830])
+** golang.org/x/crypto/ssh: `Verify()` method for FIDO/U2F security key types does not properly check for user presence (link:https://access.redhat.com/security/cve/CVE-2026-39831[CVE-2026-39831])
+** golang.org/x/crypto/ssh: Security restrictions not properly processed when keys are added to remote agents (link:https://access.redhat.com/security/cve/CVE-2026-39832[CVE-2026-39832])
+** golang.org/x/crypto/ssh: Denial of service via crafted SSH certificate (link:https://access.redhat.com/security/cve/CVE-2026-39835[CVE-2026-39835])
+** golang.org/x/crypto/ssh: Authorization bypass due to skipped source-address validation (link:https://access.redhat.com/security/cve/CVE-2026-46597[CVE-2026-46597])
+//ROX-35243, ROX-35244
+** golang.org/x/net/html: Arbitrary code execution via Cross-Site Scripting (link:https://access.redhat.com/security/cve/CVE-2026-25681[CVE-2026-25681])
+** golang.org/x/net/html: Problem with library function `net/url.Parse` (link:https://access.redhat.com/security/cve/CVE-2026-25679[CVE-2026-25679])
+//ROX-35270, ROX-35272
+** Go crypto/x509: Denial of service via inefficient certificate chain validation (link:https://access.redhat.com/security/cve/CVE-2026-32280[CVE-2026-32280]) and (link:https://access.redhat.com/security/cve/CVE-2026-32281[CVE-2026-32281])
+//ROX-35288
+** Go net package: Denial of service via long CNAME response in LookupCNAME (link:https://access.redhat.com/security/cve/CVE-2026-33811[CVE-2026-33811])
+//ROX-35322
+** Go net/mail: Denial of service via crafted email inputs (link:https://access.redhat.com/security/cve/CVE-2026-39820[CVE-2026-39820])
+//ROX-35236
+** Go net/mail: Denial of service via pathological email address parsing (link:https://access.redhat.com/security/cve/CVE-2026-42499[CVE-2026-42499])
+//ROX-35164
+** go-git: Commit signature validation bypass via malformed Git objects (link:https://access.redhat.com/security/cve/CVE-2026-45022[CVE-2026-45022])
+** go-billy: Path traversal vulnerabilities (link:https://access.redhat.com/security/cve/CVE-2026-44973[CVE-2026-44973])
+** OpenTelemetry-Go: PATH hijacking vulnerability on BSD and Solaris (link:https://access.redhat.com/security/cve/CVE-2026-39883[CVE-2026-39883])
+* form-data: Form field override via CRLF injection (link:https://access.redhat.com/security/cve/CVE-2026-12143[CVE-2026-12143])
+//ROX-35328
+* containerd: Privilege escalation via User directive parsing (link:https://access.redhat.com/security/cve/CVE-2026-46680[CVE-2026-46680])
+* github.com/containerd/containerd: Command execution vulnerability (link:https://access.redhat.com/security/cve/CVE-2026-53488[CVE-2026-53488])
+* Flaw in {product-title-short} potentially could allow excessive resource consumption leading to denial of service (link:https://access.redhat.com/security/cve/CVE-2026-9165[CVE-2026-9165])
 
 include::modules/image-versions.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s): 4.9
 
Issue: https://redhat.atlassian.net/browse/ROX-35505

Link to docs preview: 

https://114481--ocpdocs-pr.netlify.app/openshift-acs/latest/release_notes/49-release-notes#about-this-release-499_release-notes-49

QE review: **ACS has no QE, approved by SMEs**
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
