### PR TITLE
CNV-64731: Fix incorrect ksmConfiguration path in HyperConverged CR

### DIFF
--- a/modules/virt-about-ksm.adoc
+++ b/modules/virt-about-ksm.adoc
@@ -18,7 +18,7 @@ You can enable or disable the KSM activation feature for all nodes by using the 
 [id="virt-ksm-cr-configuration"]
 CR configuration::
 +
-You can configure the KSM activation feature by editing the `spec.configuration.ksmConfiguration` stanza of the `HyperConverged` CR.
+You can configure the KSM activation feature by editing the `spec.ksmConfiguration` stanza of the `HyperConverged` CR.
 +
 --
 * You enable the feature and configure settings by editing the `ksmConfiguration` stanza.

--- a/modules/virt-configure-ksm-cli.adoc
+++ b/modules/virt-configure-ksm-cli.adoc
@@ -34,9 +34,8 @@ metadata:
   name: kubevirt-hyperconverged
   namespace: {CNVNamespace}
 spec:
-  configuration:
-    ksmConfiguration:
-      nodeLabelSelector: {}
+  ksmConfiguration:
+    nodeLabelSelector: {}
 # ...
 ----
 
@@ -50,12 +49,11 @@ metadata:
   name: kubevirt-hyperconverged
   namespace: {CNVNamespace}
 spec:
-  configuration:
-    ksmConfiguration:
-      nodeLabelSelector:
-        matchLabels:
-          <first_example_key>: "true"
-          <second_example_key>: "true"
+  ksmConfiguration:
+    nodeLabelSelector:
+      matchLabels:
+        <first_example_key>: "true"
+        <second_example_key>: "true"
 # ...
 ----
 
@@ -69,7 +67,6 @@ metadata:
   name: kubevirt-hyperconverged
   namespace: {CNVNamespace}
 spec:
-  configuration:
 # ...
 ----
 


### PR DESCRIPTION
Version(s):
4.16-4.22

Issue:
https://redhat.atlassian.net/browse/CNV-64731

Link to docs preview:
* https://114482--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/nodes/virt-activating-ksm.html#virt-about-ksm_virt-activating-ksm
* https://114482--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/nodes/virt-activating-ksm.html#virt-configure-ksm-cli_virt-activating-ksm

QE review:
- [x] QE has approved this change.

Additional information:
Fixed ksmConfiguration field path from `spec.configuration.ksmConfiguration` to `spec.ksmConfiguration` for v1beta1 API.