### PR TITLE
CNV-91800: Fix swapped read/write metric descriptions

### DIFF
--- a/modules/virt-querying-metrics.adoc
+++ b/modules/virt-querying-metrics.adoc
@@ -136,10 +136,10 @@ vm:kubevirt_vmsnapshot_restored_bytes:sum{vm_name="simple-vm", vm_namespace="def
 The following queries can determine the I/O performance of storage devices:
 
 `kubevirt_vmi_storage_iops_read_total`::
-Returns the amount of write I/O operations the virtual machine is performing per second. Type: Counter.
+Returns the amount of read I/O operations the virtual machine is performing per second. Type: Counter.
 
 `kubevirt_vmi_storage_iops_write_total`::
-Returns the amount of read I/O operations the virtual machine is performing per second. Type: Counter.
+Returns the amount of write I/O operations the virtual machine is performing per second. Type: Counter.
 
 *Example I/O performance query*
 


### PR DESCRIPTION
Version(s):
4.16+

Issue:
https://issues.redhat.com/browse/CNV-91800

Link to docs preview:
https://114487--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/monitoring/virt-prometheus-queries.html#virt-promql-storage-metrics_virt-prometheus-queries

QE review:
NA

Additional information:
Fixed swapped read/write metric descriptions for kubevirt_vmi_storage_iops_read_total and kubevirt_vmi_storage_iops_write_total.