### PR TITLE
OBSDOCS-3578: Add Logging 6.4.6 z-stream release notes

### DIFF
--- a/modules/logging-release-notes-6-4-6.adoc
+++ b/modules/logging-release-notes-6-4-6.adoc
@@ -1,0 +1,34 @@
+// Module included in the following assemblies:
+//
+// * release_notes/logging-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="logging-release-notes-6-4-6_{context}"]
+= Logging 6.4.6 release notes
+
+[role="_abstract"]
+
+This release includes link:https://access.redhat.com/errata/RHSA-2026:34364[RHSA-2026:34364].
+
+[id="logging-release-notes-6-4-6-cves_{context}"]
+== CVEs
+
+* link:https://access.redhat.com/security/cve/CVE-2026-25681[CVE-2026-25681]
+
+* link:https://access.redhat.com/security/cve/CVE-2026-32285[CVE-2026-32285]
+
+* link:https://access.redhat.com/security/cve/CVE-2026-33186[CVE-2026-33186]
+
+* link:https://access.redhat.com/security/cve/CVE-2026-33811[CVE-2026-33811]
+
+* link:https://access.redhat.com/security/cve/CVE-2026-33813[CVE-2026-33813]
+
+* link:https://access.redhat.com/security/cve/CVE-2026-34986[CVE-2026-34986]
+
+* link:https://access.redhat.com/security/cve/CVE-2026-39820[CVE-2026-39820]
+
+* link:https://access.redhat.com/security/cve/CVE-2026-39821[CVE-2026-39821]
+
+* link:https://access.redhat.com/security/cve/CVE-2026-42154[CVE-2026-42154]
+
+* link:https://access.redhat.com/security/cve/CVE-2026-42499[CVE-2026-42499]

--- a/release_notes/logging-release-notes.adoc
+++ b/release_notes/logging-release-notes.adoc
@@ -10,6 +10,8 @@ toc::[]
 [role="_abstract"]
 The following release notes describe the updates in {LoggingProductName} 6.4. They include new features and enhancements, bug fixes, security updates (CVEs), known issues, and Technology Preview features.
 
+include::modules/logging-release-notes-6-4-6.adoc[leveloffset=+1]
+
 include::modules/logging-release-notes-6-4-5.adoc[leveloffset=+1]
 
 include::modules/logging-release-notes-6-4-4.adoc[leveloffset=+1]


### PR DESCRIPTION
## Summary
- Adds release notes for OpenShift Logging 6.4.6 z-stream release
- Includes 10 CVEs sorted numerically
- Includes errata number RHSA-2026:34364

## Changes
- Created `modules/logging-release-notes-6-4-6.adoc` with CVE-only release notes
- Updated `release_notes/logging-release-notes.adoc` to include new module

## CVEs Included
- CVE-2026-25681
- CVE-2026-32285
- CVE-2026-33186
- CVE-2026-33811
- CVE-2026-33813
- CVE-2026-34986
- CVE-2026-39820
- CVE-2026-39821
- CVE-2026-42154
- CVE-2026-42499

Release: 6.4
Preview: https://114488--ocpdocs-pr.netlify.app/openshift-logging/latest/release_notes/logging-release-notes.html
Issue: https://redhat.atlassian.net/browse/OBSDOCS-3578

Signed-off-by: John Wilkins <jowilkin@redhat.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)