### PR TITLE
ROX-35505: Patch release notes for 4.10.5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,7 @@ include/
 # Environment variables / Credentials (IMPORTANT!)
 .env
 .secrets
+
+# Claude Code workspace and tool files
+.agent_workspace/
+.claude/

--- a/modules/bug-fixes-in-version-4105.adoc
+++ b/modules/bug-fixes-in-version-4105.adoc
@@ -1,0 +1,52 @@
+// Module included in the following assemblies:
+//
+// * release_notes/410-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="bug-fixes_4105_{context}"]
+= Bug fixes in version 4.10.5
+
+[role="_abstract"]
+This release provides the following bug fixes:
+
+//ROX-34779
+* Fixed an issue where under certain circumstances, clusters might not appear in the *OpenShift Coverage* section under the *Compliance* tab. Red{nbsp}Hat has improved compliance scan watcher behavior to prevent this issue.
+
+//ROX-35177
+* Images built with erroneous quotes in metadata can now be properly scanned by Scanner V4.
+
+//ROX-35227
+* Before this update, the Artifactory "test" function always returned `true`, even when authentication failed. The test endpoint did not require authentication, causing confusion about integration status. With this release, the test function now performs an authenticated operation to properly validate credentials before reporting success.
+
+This release also addresses the following security vulnerabilities:
+
+* Go and golang.org:
+//ROX-35149, ROX-35152
+** golang.org/x/crypto/ssh: Unauthorized command execution via discarded SSH permissions (link:https://access.redhat.com/security/cve/CVE-2026-39828[CVE-2026-39828])
+//ROX-35165, ROX-35167
+** golang.org/x/crypto/ssh: Denial of service via crafted public key with excessive parameters (link:https://access.redhat.com/security/cve/CVE-2026-39829[CVE-2026-39829])
+//ROX-35199, ROX-35202
+** golang.org/x/crypto/ssh: Denial of service via resource leak from unsolicited SSH responses (link:https://access.redhat.com/security/cve/CVE-2026-39830[CVE-2026-39830])
+** golang.org/x/crypto/ssh: Security key bypass due to missing user presence check (link:https://access.redhat.com/security/cve/CVE-2026-39831[CVE-2026-39831])
+** golang.org/x/crypto/ssh/agent: Security bypass due to improper handling of key restrictions (link:https://access.redhat.com/security/cve/CVE-2026-39832[CVE-2026-39832])
+** golang.org/x/crypto/ssh: Denial of service via crafted SSH certificate (link:https://access.redhat.com/security/cve/CVE-2026-39835[CVE-2026-39835])
+** golang.org/x/crypto/ssh: Denial of service via crafted AES-GCM packet decoder inputs (link:https://access.redhat.com/security/cve/CVE-2026-46597[CVE-2026-46597])
+//ROX-35249, ROX-35250
+** golang.org/x/net/html: Arbitrary HTML parsing and rendering can permit cross-site scripting attacks (link:https://access.redhat.com/security/cve/CVE-2026-25681[CVE-2026-25681])
+//ROX-35286
+** Go net package: Denial of service via long CNAME response in LookupCNAME (link:https://access.redhat.com/security/cve/CVE-2026-33811[CVE-2026-33811])
+//ROX-35235
+** Go net/mail: Denial of service via pathological email address parsing (link:https://access.redhat.com/security/cve/CVE-2026-42499[CVE-2026-42499])
+//ROX-35321
+** Go net/mail: Denial of service via crafted email inputs (link:https://access.redhat.com/security/cve/CVE-2026-39820[CVE-2026-39820])
+//ROX-35328
+** go-git: Commit signature validation bypass via malformed Git objects (link:https://access.redhat.com/security/cve/CVE-2026-45022[CVE-2026-45022])
+//ROX-35163
+** go-billy: Path traversal vulnerabilities (link:https://access.redhat.com/security/cve/CVE-2026-44973[CVE-2026-44973])
+** OpenTelemetry-Go: PATH hijacking vulnerability on BSD and Solaris (link:https://access.redhat.com/security/cve/CVE-2026-39883[CVE-2026-39883])
+* form-data: Form field override via CRLF injection (link:https://access.redhat.com/security/cve/CVE-2026-12143[CVE-2026-12143])
+//ROX-35184
+* JavaScript Cookie: Cookie attribute manipulation via prototype pollution (link:https://access.redhat.com/security/cve/CVE-2026-46625[CVE-2026-46625])
+* containerd: Privilege escalation via User directive parsing (link:https://access.redhat.com/security/cve/CVE-2026-46680[CVE-2026-46680])
+* github.com/containerd/containerd: Command execution vulnerability (link:https://access.redhat.com/security/cve/CVE-2026-53488[CVE-2026-53488])
+* Flaw in {product-title-short} potentially could allow excessive resource consumption leading to denial of service (link:https://access.redhat.com/security/cve/CVE-2026-9165[CVE-2026-9165])

--- a/modules/common-attributes.adoc
+++ b/modules/common-attributes.adoc
@@ -64,12 +64,13 @@ endif::[]
 :product-registry: OpenShift image registry
 :olm-first: Operator Lifecycle Manager (OLM)
 :olm: OLM
-:rhacs-version: 4.10.4
+:rhacs-version: 4.10.5
 :ga-date-410: 3 March 2026
 :ga-date-4101: 8 April 2026
 :ga-date-4102: 4 May 2026
 :ga-date-4103: 2 June 2026
 :ga-date-4104: 18 June 2026
+:ga-date-4105: 7 July 2026
 :ocp-supported-version: 4.12
 :ocp-latest-version: 4.21
 :pipelines-shortname: OpenShift Pipelines

--- a/modules/release-dates-410.adoc
+++ b/modules/release-dates-410.adoc
@@ -20,5 +20,6 @@ Review the official release dates and update schedule for {product-title-short} 
 |`4.10.2` | {ga-date-4102}
 |`4.10.3` | {ga-date-4103}
 |`4.10.4` | {ga-date-4104}
+|`4.10.5` | {ga-date-4105}
 
 |====

--- a/release_notes/410-release-notes.adoc
+++ b/release_notes/410-release-notes.adoc
@@ -87,6 +87,8 @@ include::modules/bug-fixes-in-version-4103.adoc[leveloffset=+1]
 
 include::modules/bug-fixes-in-version-4104.adoc[leveloffset=+1]
 
+include::modules/bug-fixes-in-version-4105.adoc[leveloffset=+1]
+
 include::modules/known-issues-in-version-4101.adoc[leveloffset=+1]
 
 include::modules/image-versions.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s): 4.10.5

Issue: https://redhat.atlassian.net/browse/ROX-35505

Link to docs preview: https://114489--ocpdocs-pr.netlify.app/openshift-acs/latest/release_notes/410-release-notes#bug-fixes_4105_release-notes-410

QE review: **ACS has no QE, approved by SME**
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
