### PR TITLE
OSDOCS-20473 added new module

### DIFF
--- a/modules/zero-trust-manager-manually-delete-scc.adoc
+++ b/modules/zero-trust-manager-manually-delete-scc.adoc
@@ -1,0 +1,61 @@
+// Module included in the following assemblies:
+//
+// * security/zero_trust_workload_identity_manager/zero-trust-manager-configuration.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="zero-trust-manager-manually-delete-scc_{context}"]
+= Manually delete the custom security context constraints
+
+[role="_abstract"]
+You can delete the `spire-spiffe-csi-driver` custom SCC when the SPIFFE CSI driver is ready and its pods are using the `privileged` security context constraint (SCC). 
+
+.Prerequisites
+
+* You have upgraded {zero-trust-full} to 1.1.0 from the **OperatorHub** catalog.
+
+.Procedure
+
+. Confirm the SPIFFE CSI driver is ready by running the following command:
++
+[source,terminal]
+----
+$ oc get spiffecsidriver cluster -o jsonpath='{range .status.conditions[*]}{.type}={.status}{"\n"}{end}'
+----
++
+The expected output includes `DaemonSetAvailable=True` and `Ready=True`.
+
+. Confirm that the CSI `DaemonSet` is available by running the following command:
++
+[source,terminal]
+----
+$ oc get ds spire-spiffe-csi-driver -n zero-trust-workload-identity-manager
+----
+
+. Confirm the CSI pods are running and are using the `privileged` SCC by running the following commands:
++
+[source,terminal]
+----
+$ oc get pods -n zero-trust-workload-identity-manager -l app.kubernetes.io/name=spiffe-csi-driver
+----
++
+[source,terminal]
+----
+$ oc get pod -n zero-trust-workload-identity-manager -l app.kubernetes.io/name=spiffe-csi-driver \
+    -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.metadata.annotations.openshift\.io/scc}{"\n"}{end}'
+----
++
+Every pod should show `privileged`.
+
+. After all checks have passed, delete the legacy custom SCC by running the following commands:
++
+[source,terminal]
+----
+$ oc get scc spire-spiffe-csi-driver
+----
++
+[source,terminal]
+----
+$ oc delete scc spire-spiffe-csi-driver
+----
++
+If the SCC is already absent, no action is needed.

--- a/security/zero_trust_workload_identity_manager/zero-trust-manager-configuration.adoc
+++ b/security/zero_trust_workload_identity_manager/zero-trust-manager-configuration.adoc
@@ -42,4 +42,7 @@ include::modules/zero-trust-manager-oidc-config.adoc[leveloffset=+1]
 // Deploying and configuring OIDC Discovery Provider
 include::modules/zero-trust-manager-verify-operands.adoc[leveloffset=+1]
 
+// Deleting the custom SecurityContextConstraints
+include::modules/zero-trust-manager-manually-delete-scc.adoc[leveloffset=+1]
+
 


### PR DESCRIPTION
Version(s):
4.21+

Issue:
https://redhat.atlassian.net/browse/OSDOCS-20473

Link to docs preview:
https://114491--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/zero_trust_workload_identity_manager/zero-trust-manager-configuration.html


QE review:
- [ ] QE has approved this change.


Additional information:
This module was originally in the release notes and I pulled it out. It's already been acked by QE/SME. Just need a quick look through for any mistakes and then can be merged.
