### PR TITLE
[OSDOCS-20363]: CQA: Disaster recovery for HCP by using OADP (2 of 2)

### DIFF
--- a/modules/hcp-dr-oadp-backup-cp-workload-aws.adoc
+++ b/modules/hcp-dr-oadp-backup-cp-workload-aws.adoc
@@ -2,13 +2,14 @@
 //
 // * hosted_control_planes/hcp-disaster-recovery-oadp.adoc
 
-:_mod-docs-content-type: REFERENCE
+:_mod-docs-content-type: PROCEDURE
 [id="hcp-dr-oadp-backup-cp-workload-aws_{context}"]
 = Backing up the control plane workload on {aws-short}
 
+[role="_abstract"]
 You can back up the control plane workload by creating the `Backup` custom resource (CR).
 
-To monitor and observe the backup process, see "Observing the backup and restore process".
+For information about monitoring the backup process, see "Observing the backup and restore process".
 
 .Procedure
 
@@ -79,22 +80,20 @@ $ oc --kubeconfig <management_cluster_kubeconfig_file> \
 . Create a YAML file that defines the `Backup` CR:
 +
 .Example `backup-control-plane.yaml` file
-[%collapsible]
-====
 [source,yaml]
 ----
 apiVersion: velero.io/v1
 kind: Backup
 metadata:
-  name: <backup_resource_name> <1>
+  name: <backup_resource_name>
   namespace: openshift-adp
   labels:
     velero.io/storage-location: default
 spec:
   hooks: {}
-  includedNamespaces: <2>
-  - <hosted_cluster_namespace> <3>
-  - <hosted_control_plane_namespace> <4>
+  includedNamespaces:
+  - <hosted_cluster_namespace>
+  - <hosted_control_plane_namespace>
   includedResources:
   - sa
   - role
@@ -104,7 +103,7 @@ spec:
   - pv
   - bmh
   - configmap
-  - infraenv <5>
+  - infraenv
   - priorityclasses
   - pdb
   - agents
@@ -124,18 +123,16 @@ spec:
   excludedResources: []
   storageLocation: default
   ttl: 2h0m0s
-  snapshotMoveData: true <6>
-  datamover: "velero" <6>
-  defaultVolumesToFsBackup: true <7>
+  snapshotMoveData: true
+  datamover: "velero"
+  defaultVolumesToFsBackup: true
 ----
-====
-<1> Replace `backup_resource_name` with the name of your `Backup` resource.
-<2> Selects specific namespaces to back up objects from them. You must include your hosted cluster namespace and the hosted control plane namespace.
-<3> Replace `<hosted_cluster_namespace>` with the name of the hosted cluster namespace, for example, `clusters`.
-<4> Replace `<hosted_control_plane_namespace>` with the name of the hosted control plane namespace, for example, `clusters-hosted`.
-<5> You must create the `infraenv` resource in a separate namespace. Do not delete the `infraenv` resource during the backup process.
-<6> Enables the CSI volume snapshots and uploads the control plane workload automatically to the cloud storage.
-<7> Sets the `fs-backup` backing up method for persistent volumes (PVs) as default. This setting is useful when you use a combination of Container Storage Interface (CSI) volume snapshots and the `fs-backup` method.
++
+* `metadata.name` specifies the name of your `Backup` resource.
+* `spec.includedNamespaces` includes specific namespaces to back up objects from them. You must replace `<hosted_cluster_namespace>` with the name of the hosted cluster namespace and replace `<hosted_control_plane_namespace>` with the name of the hosted control plane namespace.
+* `spec.includedResources` includes the `infraenv` resource. You must create the `infraenv` resource in a separate namespace. Do not delete the `infraenv` resource during the backup process.
+* `spec.snapshotMoveData` and `spec.datamover` enable the CSI volume snapshots and upload the control plane workload automatically to the cloud storage.
+* `spec.defaultVolumesToFsBackup` sets the `fs-backup` backing up method for persistent volumes (PVs) as default. This setting is useful when you use a combination of Container Storage Interface (CSI) volume snapshots and the `fs-backup` method.
 +
 [NOTE]
 ====

--- a/modules/hcp-dr-oadp-backup-cp-workload-bm.adoc
+++ b/modules/hcp-dr-oadp-backup-cp-workload-bm.adoc
@@ -4,11 +4,12 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="hcp-dr-oadp-backup-cp-workload-bm_{context}"]
-= Backing up the control plane workload on a bare-metal platform
+= Backing up the control plane workload on a bare metal
 
+[role="_abstract"]
 You can back up the control plane workload by creating the `Backup` custom resource (CR).
 
-To monitor and observe the backup process, see "Observing the backup and restore process".
+For more information about monitoring the backup process, see "Observing the backup and restore process".
 
 .Procedure
 
@@ -80,23 +81,21 @@ $ oc --kubeconfig <management_cluster_kubeconfig_file> \
 . Create a YAML file that defines the `Backup` CR:
 +
 .Example `backup-control-plane.yaml` file
-[%collapsible]
-====
 [source,yaml]
 ----
 apiVersion: velero.io/v1
 kind: Backup
 metadata:
-  name: <backup_resource_name> # <1>
+  name: <backup_resource_name>
   namespace: openshift-adp
   labels:
     velero.io/storage-location: default
 spec:
   hooks: {}
-  includedNamespaces: # <2>
-  - <hosted_cluster_namespace> # <3>
-  - <hosted_control_plane_namespace> # <4>
-  - <agent_namespace> # <5>
+  includedNamespaces:
+  - <hosted_cluster_namespace>
+  - <hosted_control_plane_namespace>
+  - <agent_namespace>
   includedResources:
   - sa
   - role
@@ -126,18 +125,15 @@ spec:
   excludedResources: []
   storageLocation: default
   ttl: 2h0m0s
-  snapshotMoveData: true # <6>
-  datamover: "velero" # <6>
-  defaultVolumesToFsBackup: true # <7>
+  snapshotMoveData: true
+  datamover: "velero"
+  defaultVolumesToFsBackup: true
 ----
-====
-<1> Replace `backup_resource_name` with the name of your `Backup` resource.
-<2> Selects specific namespaces to back up objects from them. You must include your hosted cluster namespace and the hosted control plane namespace.
-<3> Replace `<hosted_cluster_namespace>` with the name of the hosted cluster namespace, for example, `clusters`.
-<4> Replace `<hosted_control_plane_namespace>` with the name of the hosted control plane namespace, for example, `clusters-hosted`.
-<5> Replace `<agent_namespace>` with the namespace where your `Agent`, `BMH`, and `InfraEnv` CRs are located, for example, `agents`.
-<6> Enables the CSI volume snapshots and uploads the control plane workload automatically to the cloud storage.
-<7> Sets the `fs-backup` backing up method for persistent volumes (PVs) as default. This setting is useful when you use a combination of Container Storage Interface (CSI) volume snapshots and the `fs-backup` method.
++
+* `metadata.name` specifies the name of your `Backup` resource.
+* `spec.includedNamespaces` specifies namespaces to back up objects from them. Replace `<hosted_cluster_namespace>` with the name of the hosted cluster namespace, replace `<hosted_control_plane_namespace>` with the name of the hosted control plane namespace, and replace `<agent_namespace>` with the namespace where your `Agent`, `BMH`, and `InfraEnv` CRs are located.
+* `spec.snapshotMoveData` enable the CSI volume snapshots and upload the control plane workload automatically to the cloud storage.
+* `spec.defaultVolumesToFsBackup` sets the `fs-backup` backing up method for persistent volumes (PVs) as default. This setting is useful when you use a combination of Container Storage Interface (CSI) volume snapshots and the `fs-backup` method.
 +
 [NOTE]
 ====

--- a/modules/hcp-dr-oadp-restore-new-mgmt.adoc
+++ b/modules/hcp-dr-oadp-restore-new-mgmt.adoc
@@ -6,6 +6,7 @@
 [id="hcp-dr-oadp-restore-new-mgmt_{context}"]
 = Restoring a hosted cluster into a new management cluster by using {oadp-short}
 
+[role="_abstract"]
 You can restore the hosted cluster into a new management cluster by creating the `Restore` custom resource (CR).
 
 * If you are using an in-place update, the `InfraEnv` resource does not need spare nodes. Instead, you need to re-provision the worker nodes from the new management cluster.
@@ -36,21 +37,21 @@ Complete the following steps on the new management cluster that you are restorin
 apiVersion: velero.io/v1
 kind: Restore
 metadata:
-  name: <restore_resource_name> # <1>
+  name: <restore_resource_name>
   namespace: openshift-adp
 spec:
-  includedNamespaces: # <2>
-  - <hosted_cluster_namespace> # <3>
-  - <hosted_control_plane_namespace> # <4>
-  - <agent_namespace> # <5>
-  backupName: <backup_resource_name> # <6>
+  includedNamespaces:
+  - <hosted_cluster_namespace>
+  - <hosted_control_plane_namespace>
+  - <agent_namespace>
+  backupName: <backup_resource_name>
   cleanupBeforeRestore: CleanupRestored
-  veleroManagedClustersBackupName: <managed_cluster_name> # <7>
+  veleroManagedClustersBackupName: <managed_cluster_name>
   veleroCredentialsBackupName: <credentials_backup_name>
   veleroResourcesBackupName: <resources_backup_name>
-  restorePVs: true # <8>
+  restorePVs: true
   preserveNodePorts: true
-  existingResourcePolicy: update # <9>
+  existingResourcePolicy: update
   excludedResources:
   - pod
   - nodes
@@ -62,15 +63,13 @@ spec:
   - pv
   - pvc
 ----
-<1> Replace `<restore_resource_name>` with the name of your `Restore` resource.
-<2> Selects specific namespaces to back up objects from them. You must include your hosted cluster namespace and the hosted control plane namespace.
-<3> Replace `<hosted_cluster_namespace>` with the name of the hosted cluster namespace, for example, `clusters`.
-<4> Replace `<hosted_control_plane_namespace>` with the name of the hosted control plane namespace, for example, `clusters-hosted`.
-<5> Replace `<agent_namespace>` with the namespace where your `Agent`, `BMH`, and `InfraEnv` CRs are located, for example, `agents`.
-<6> Replace `<backup_resource_name>` with the name of your `Backup` resource.
-<7> You can omit this field if you are not using {rh-rhacm-title}.
-<8> Initiates the recovery of persistent volumes (PVs) and its pods.
-<9> Ensures that the existing objects are overwritten with the backed up content.
++
+* `metadata.name` specifies the name of your `Restore` resource.
+* `spec.includedNamespaces` specifies namespaces to back up objects from them. Replace `<hosted_cluster_namespace>` with the name of the hosted cluster namespace, replace `<hosted_control_plane_namespace>` with the name of the hosted control plane namespace, and replace `<agent_namespace>` with the namespace where your `Agent`, `BMH`, and `InfraEnv` CRs are located.
+* `spec.backupName` specifies the name of your `Backup` resource.
+* `spec.veleroManagedClustersBackupName` can be omitted if you are not using {rh-rhacm-title}.
+* `spec.restorePVs: true` starts the recovery of persistent volumes (PVs) and its pods.
+* `spec.existingResourcePolicy: update` ensures that the existing objects are overwritten with the backed up content.
 
 . Apply the `Restore` CR by running the following command:
 +

--- a/modules/hcp-dr-oadp-restore.adoc
+++ b/modules/hcp-dr-oadp-restore.adoc
@@ -6,14 +6,15 @@
 [id="hcp-dr-oadp-restore_{context}"]
 = Restoring a hosted cluster into the same management cluster by using {oadp-short}
 
+[role="_abstract"]
 You can restore the hosted cluster by creating the `Restore` custom resource (CR).
 
-* If you are using an _in-place_ update, InfraEnv does not need spare nodes. You need to re-provision the worker nodes from the new management cluster.
-* If you are using a _replace_ update, you need some spare nodes for InfraEnv to deploy the worker nodes.
+* If you are using an _in-place_ update, the `InfraEnv` resource does not need spare nodes. You need to re-provision the worker nodes from the new management cluster.
+* If you are using a _replace_ update, you need some spare nodes for the `InfraEnv` resource to deploy the worker nodes.
 
 [IMPORTANT]
 ====
-After you back up your hosted cluster, you must destroy it to initiate the restoring process. To initiate node provisioning, you must back up workloads in the data plane before deleting the hosted cluster.
+After you back up your hosted cluster, you must delete it to start the restoring process. To start node provisioning, you must back up workloads in the data plane before deleting the hosted cluster.
 ====
 
 .Prerequisites
@@ -46,12 +47,12 @@ No resources found
 apiVersion: velero.io/v1
 kind: Restore
 metadata:
-  name: <restore_resource_name> <1>
+  name: <restore_resource_name>
   namespace: openshift-adp
 spec:
-  backupName: <backup_resource_name> <2>
-  restorePVs: true <3>
-  existingResourcePolicy: update <4>
+  backupName: <backup_resource_name>
+  restorePVs: true
+  existingResourcePolicy: update
   excludedResources:
   - nodes
   - events
@@ -60,10 +61,11 @@ spec:
   - restores.velero.io
   - resticrepositories.velero.io
 ----
-<1> Replace `<restore_resource_name>` with the name of your `Restore` resource.
-<2> Replace `<backup_resource_name>` with the name of your `Backup` resource.
-<3> Initiates the recovery of persistent volumes (PVs) and its pods.
-<4> Ensures that the existing objects are overwritten with the backed up content.
++
+* `metadata.name` specifies the name of your `Restore` resource.
+* `spec.backupName` specifies the name of your `Backup` resource.
+* `spec.restorePVs: true` starts the recovery of persistent volumes (PVs) and its pods.
+* `spec.existingResourcePolicy: update` ensures that the existing objects are overwritten with the backed up content.
 +
 [IMPORTANT]
 ====


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.20+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://redhat.atlassian.net/browse/OSDOCS-20363
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
- Backing up the control plane workload on AWS: https://114493--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp_high_availability/hcp-disaster-recovery-oadp.html#hcp-dr-oadp-backup-cp-workload-aws_hcp-disaster-recovery-oadp
- Backing up the control plane workload on bare metal: https://114493--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp_high_availability/hcp-disaster-recovery-oadp.html#hcp-dr-oadp-backup-cp-workload-bm_hcp-disaster-recovery-oadp
- Restoring a hosted cluster into a new management cluster by using OADP: https://114493--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp_high_availability/hcp-disaster-recovery-oadp.html#hcp-dr-oadp-restore-new-mgmt_hcp-disaster-recovery-oadp
- Restoring a hosted cluster into the same management cluster by using OADP: https://114493--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp_high_availability/hcp-disaster-recovery-oadp.html#hcp-dr-oadp-restore_hcp-disaster-recovery-oadp
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
n/a no technical changes
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: Related PR: https://github.com/openshift/openshift-docs/pull/114077
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
