### PR TITLE
OBSDOCS-3110: Document HTTP output format parameter

### DIFF
--- a/modules/logging-http-forward.adoc
+++ b/modules/logging-http-forward.adoc
@@ -23,6 +23,8 @@ spec:
   - name: <output_name>
     type: http
     http:
+      url: <url>
+      format: json
       headers:
           h1: v1
           h2: v2
@@ -35,7 +37,6 @@ spec:
           secretName: <http_auth_secret>
       timeout: 300
       proxyURL: <proxy_url>
-      url: <url>
     tls:
       insecureSkipVerify:
       ca:
@@ -50,13 +51,14 @@ spec:
   serviceAccount:
     name: <service_account_name>
 ----
-`headers`:: Optional: Additional headers to send with each log record.
-`authentication.username`:: Optional: Username for HTTP Basic authentication. Specify the secret name and key containing the username.
-`authentication.password`:: Optional: Password for HTTP Basic authentication. Specify the secret name and key containing the password.
-`timeout`:: Optional: Timeout in seconds for HTTP requests. Default is 300 seconds (5 minutes).
-`proxyURL`:: Optional: URL of the HTTP/HTTPS proxy to forward logs over http or https from this output. This setting overrides any default proxy settings for the cluster or the node.
 `url`:: Destination address for logs.
-`tls.insecureSkipVerify`:: Optional: When set to `true`, the collector skips verification of the server's certificate. When set to `false` (the default), the collector verifies the server's certificate against the CA specified in `tls.ca`. If `insecureSkipVerify` is set to `true`, the `tls.ca` field is not required.
+`format`:: Optional. Data format for sending logs. Valid values are `json` (default) and `ndjson` (newline-delimited JSON). Use `ndjson` for systems that expect newline-delimited JSON format, such as VictoriaLogs.
+`headers`:: Optional. Additional headers to send with each log record.
+`authentication.username`:: Optional. Username for HTTP Basic authentication. Specify the secret name and key containing the username.
+`authentication.password`:: Optional. Password for HTTP Basic authentication. Specify the secret name and key containing the password.
+`timeout`:: Optional. Timeout in seconds for HTTP requests. Default is 300 seconds (5 minutes).
+`proxyURL`:: Optional. URL of the HTTP/HTTPS proxy to forward logs over http or https from this output. This setting overrides any default proxy settings for the cluster or the node.
+`tls.insecureSkipVerify`:: Optional. When set to `true`, the collector skips verification of the server's certificate. When set to `false` (the default), the collector verifies the server's certificate against the CA specified in `tls.ca`. If `insecureSkipVerify` is set to `true`, the `tls.ca` field is not required.
 +
 [WARNING]
 ====


### PR DESCRIPTION
## Summary
Documents the new `format` parameter for HTTP outputs in ClusterLogForwarder, which allows users to specify the data format for logs sent to HTTP endpoints.

## Changes

**Modified Module:**
- **logging-http-forward.adoc**: Added `format` field documentation and example

## Format Options

- **`json`** (default) - Standard JSON format
- **`ndjson`** - Newline-delimited JSON for systems that process logs line by line

## Use Case

The `ndjson` format is required for systems like VictoriaLogs and other log aggregation platforms that expect newline-delimited JSON format instead of standard JSON arrays.

## Example

```yaml
outputs:
  - name: http-receiver
    type: http
    http:
      url: 'https://victorialogs.example.com/insert/jsonline'
      format: ndjson
```

## Testing

- ✅ Vale check passed (0 errors, 0 warnings, 3 suggestions)
- ✅ Field description clear and concise
- ✅ Use case explained

## Related

- Engineering ticket: [LOG-7892](https://redhat.atlassian.net/browse/LOG-7892)
- Upstream commit: cluster-logging-operator 0ad01ba6f
- JIRA: https://redhat.atlassian.net/browse/OBSDOCS-3110
- Versions: 6.6, 6.5

Signed-off-by: John Wilkins <jowilkin@redhat.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)