### PR TITLE
OSDOCS-16988-5-CQA-TP: Updated the table for the Adding kernel module…

### DIFF
--- a/modules/rn-ocp-release-notes-deprecated-removed-tables.adoc
+++ b/modules/rn-ocp-release-notes-deprecated-removed-tables.adoc
@@ -61,8 +61,8 @@
 |Deprecated
 
 |Adding kernel modules to nodes with kvc
-|General Availability
-|General Availability
+|Technology Preview
+|Technology Preview
 |Deprecated
 
 |Installing a cluster using Fujitsu iRMC drivers on bare-metal machines


### PR DESCRIPTION
Feature is TP for 4.21 and 4.20. During CQA work, the item was flagged.

Version(s):
4.22

Issue:
[OSDOCS-16988](https://redhat.atlassian.net/browse/OSDOCS-16988)

Link to docs preview:

https://114526--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-22-release-notes.html#ocp-release-note-install-dep-rem_release-notes

Additional info:

https://github.com/openshift/openshift-docs/pull/111705/changes