### PR TITLE
OSDOCS-20493-1 updated release notes for 1-1-0

### DIFF
--- a/modules/zero-trust-manager-release-notes-1-1-0.adoc
+++ b/modules/zero-trust-manager-release-notes-1-1-0.adoc
@@ -98,7 +98,8 @@ Starting in {zero-trust-full} 1.1.0, the SPIFFE CSI Driver no longer uses the cu
 Action required after upgrade::
 
 {zero-trust-full} does not remove the legacy custom SCC `spire-spiffe-csi-driver`. After you upgrade {zero-trust-full} to 1.1.0 from the **OpenShift OperatorHub** catalog, remove it manually once CSI is healthy on the platform SCC.
-
++
+For more information, see xref:../../security/zero_trust_workload_identity_manager/zero-trust-manager-configuration.adoc#zero-trust-manager-manually-delete-scc_zero-trust-manager-configuration[Manually delete the custom security context constraints].
 
 [id="zero-trust-manager-1-1-0-bug-fixes_{context}"]
 == Fixed issues


### PR DESCRIPTION
Version(s):
4.21+

Issue:
https://redhat.atlassian.net/browse/OSDOCS-20493

Link to docs preview:
https://114533--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/zero_trust_workload_identity_manager/zero-trust-manager-release-notes.html


QE review:
- [ ] QE has approved this change.


Additional information:
Reviewer: All that was done is the xref was added. All of the other text has been verified by QE/SME. Also allowed xrefs in release notes. Thanks.
