### PR TITLE
OSDOCS-19029 Doc work for cert-manager 1.20.0

### DIFF
--- a/modules/cert-manager-configure-tls-adherence.adoc
+++ b/modules/cert-manager-configure-tls-adherence.adoc
@@ -1,0 +1,55 @@
+// Module included in the following assemblies:
+//
+// * security/cert_manager_operator/cert-manager-customizing-api-fields.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="cert-manager-configure-tls-adherence_{context}"]
+= Configuring cluster TLS security profile adherence for cert-manager components
+
+[role="_abstract"]
+You can configure the {cert-manager-operator} to apply the cluster-wide TLS security profile by setting the TLS adherence policy on the cluster `APIServer` resource. When the adherence policy is set to `StrictAllComponents`, cert-manager components automatically apply the cluster TLS security profile settings.
+
+:FeatureName: TLS adherence for cert-manager operands
+include::snippets/technology-preview.adoc[]
+
+.Prerequisites
+
+* You have access to the cluster with `cluster-admin` privileges.
+* You installed the {cert-manager-operator}.
+* You enabled the `TechPreviewNoUpgrade` feature set. For more information, see "Enabling features using feature gates".
+
+.Procedure
+
+. Edit the cluster `APIServer` custom resource (CR) by running the following command:
++
+[source,terminal]
+----
+$ oc edit apiserver cluster
+----
+
+. Add or modify the `tlsAdherence` field in the `spec` section and set it to `StrictAllComponents` by using the following example:
++
+[source,yaml]
+----
+apiVersion: config.openshift.io/v1
+kind: APIServer
+metadata:
+  name: cluster
+spec:
+  tlsSecurityProfile:
+    type: Intermediate
+    intermediate: {}
+  tlsAdherence: StrictAllComponents
+----
++
+where:
+
+`tlsSecurityProfile.type`:: Optional: Specifies the TLS security profile type. Valid values are `Old`, `Intermediate`, `Modern`, or `Custom`. If not specified, the default is `Intermediate`. When specifying a profile type, you must also include the corresponding profile-specific field, for example, `intermediate: {}` for the `Intermediate` profile.
+
+`tlsAdherence: StrictAllComponents`:: Specifies that cluster-wide TLS settings are enforced on all components, including cert-manager.
+
+. Save the changes and exit the editor.
+
+.Verification
+
+. The {cert-manager-operator} automatically applies the cluster TLS security profile to the cert-manager controller, webhook, and CA injector deployments. Check that the TLS configuration is applied to the cert-manager components. For more information, see "Verifying TLS security profile adherence for cert-manager components".

--- a/modules/cert-manager-explanation-of-certmanager-cr-fields.adoc
+++ b/modules/cert-manager-explanation-of-certmanager-cr-fields.adoc
@@ -63,7 +63,7 @@ You can configure the overridable arguments for the cert-manager components in t
 
 The following table describes the overridable arguments for the cert-manager components:
 
-.Overridable arguments the cert-manager components
+.Overridable arguments for the cert-manager components
 [cols=".^5a,.^2,.^4a",options="header"]
 |====
 
@@ -117,6 +117,22 @@ DNS over HTTPS (DoH) is supported starting only from {cert-manager-operator} ver
 |`--certificate-request-minimum-backoff-duration`
 |Controller
 |Specify the minimum backoff duration for certificate requests. The default value is `1h0m0s`.
+
+|`--concurrent-workers`
+|Controller
+|The number of concurrent workers for each controller. The default value is `5`.
+
+|`--kube-api-qps`
+|Controller
+|The maximum number of queries per second sent to the Kubernetes API server. The default value is `20`.
+
+|`--kube-api-burst`
+|Controller
+|The maximum burst of queries per second sent to the Kubernetes API server. Must be greater than or equal to `--kube-api-qps`. The default value is `50`.
+
+|`--max-concurrent-challenges`
+|Controller
+|The maximum number of ACME challenges that can run concurrently. The default value is `60`.
 
 |`--v=<verbosity_level>`
 |Controller, Webhook, CA injector
@@ -178,7 +194,7 @@ The following table describes the overridable resource parameters for the cert-m
 [id="cert-manager-overridable-scheduling-parameters_{context}"]
 == Overridable scheduling parameters for the cert-manager components
 
-You can configure the pod scheduling constrainsts for the cert-manager components in the `spec.controllerConfig`, `spec.webhookConfig` field, and `spec.cainjectorConfig` sections in the `CertManager` CR.
+You can configure the pod scheduling constraints for the cert-manager components in the `spec.controllerConfig`, `spec.webhookConfig` field, and `spec.cainjectorConfig` sections in the `CertManager` CR.
 
 The following table describes the pod scheduling parameters for the cert-manager components:
 

--- a/modules/cert-manager-override-arguments.adoc
+++ b/modules/cert-manager-override-arguments.adoc
@@ -46,6 +46,10 @@ spec:
       - '--acme-http01-solver-resource-request-cpu=<quantity>'
       - '--acme-http01-solver-resource-request-memory=<quantity>'
       - '--certificate-request-minimum-backoff-duration=<duration>'
+      - '--concurrent-workers=<quantity>'
+      - '--kube-api-qps=<quantity>'
+      - '--kube-api-burst=<quantity>'
+      - '--max-concurrent-challenges=<quantity>'
   webhookConfig:
     overrideArgs:
       - '--v=<verbosity_level>'
@@ -78,14 +82,16 @@ $ oc get pods -n cert-manager -o yaml
   spec:
     containers:
     - args:
-      - --acme-http01-solver-nameservers=1.1.1.1:53
-      - --cluster-resource-namespace=$(POD_NAMESPACE)
-      - --dns01-recursive-nameservers=1.1.1.1:53
-      - --dns01-recursive-nameservers-only
-      - --leader-election-namespace=kube-system
-      - --max-concurrent-challenges=60
-      - --metrics-listen-address=0.0.0.0:9042
-      - --v=6
+      # ...
+        - --acme-http01-solver-nameservers=1.1.1.1:53
+        - --concurrent-workers=5
+        - --dns01-recursive-nameservers=1.1.1.1:53
+        - --dns01-recursive-nameservers-only
+        - --kube-api-burst=50
+        - --kube-api-qps=20
+        - --max-concurrent-challenges=60
+        - --metrics-listen-address=0.0.0.0:9042
+        - --v=6
 ...
   metadata:
     name: cert-manager-cainjector-866c4fd758-ltxxj
@@ -94,8 +100,8 @@ $ oc get pods -n cert-manager -o yaml
   spec:
     containers:
     - args:
-      - --leader-election-namespace=kube-system
-      - --v=2
+      # ...
+        - --v=2
 ...
   metadata:
     name: cert-manager-webhook-6d48f88495-c88gd
@@ -104,6 +110,6 @@ $ oc get pods -n cert-manager -o yaml
   spec:
     containers:
     - args:
-      ...
-      - --v=4
+      # ...
+        - --v=2
 ----

--- a/modules/cert-manager-trust-manager-install.adoc
+++ b/modules/cert-manager-trust-manager-install.adoc
@@ -14,8 +14,6 @@ include::snippets/technology-preview.adoc[leveloffset=+1]
 
 .Prerequisites
 
-* You have enabled one of the following feature sets on your cluster: `TechPreviewNoUpgrade`, `DevPreviewNoUpgrade`, `CustomNoUpgrade`, or `OKD`. For more information on enabling the feature set, see "Enabling features using feature gates".
-
 * You have access to the cluster with `cluster-admin` privileges.
 
 * You have installed {cert-manager-operator}.

--- a/modules/cert-manager-verify-tls-adherence.adoc
+++ b/modules/cert-manager-verify-tls-adherence.adoc
@@ -1,0 +1,90 @@
+// Module included in the following assemblies:
+//
+// * security/cert_manager_operator/cert-manager-customizing-api-fields.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="cert-manager-verify-tls-adherence_{context}"]
+= Verifying TLS security profile adherence for cert-manager components
+
+[role="_abstract"]
+After configuring the cluster TLS security profile adherence, you can verify that the TLS configuration is applied to the cert-manager controller, webhook, and CA injector deployments.
+
+.Prerequisites
+
+* You have access to the cluster with `cluster-admin` privileges.
+* You installed the {cert-manager-operator}.
+* You enabled the `TechPreviewNoUpgrade` feature set. For more information, see "Enabling features using feature gates".
+* You configured the cluster TLS security profile adherence for cert-manager components. For more information, see "Configuring cluster TLS security profile adherence for cert-manager components".
+
+.Procedure
+
+. Verify that the cert-manager controller deployment has the TLS configuration applied by running the following command:
++
+[source,terminal]
+----
+$ oc get deployment -n cert-manager cert-manager -o yaml | grep -A 15 "args:"
+----
++
+.Example output
+[source,terminal]
+----
+args:
+- --v=2
+- --cluster-resource-namespace=$(POD_NAMESPACE)
+- --leader-election-namespace=kube-system
+- --acme-http01-solver-image=registry.redhat.io/cert-manager/cert-manager-acmesolver-rhel9@sha256:...
+- --max-concurrent-challenges=60
+- --metrics-tls-min-version=VersionTLS12
+- --metrics-tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+----
++
+The `--metrics-tls-min-version` flag shows the minimum TLS version configured based on the cluster TLS security profile. The `--metrics-tls-cipher-suites` flag shows TLS cipher suites configured based on the cluster TLS security profile.
+
+. Verify that the webhook deployment has the TLS configuration applied by running the following command:
++
+[source,terminal]
+----
+$ oc get deployment -n cert-manager cert-manager-webhook -o yaml | grep -A 20 "args:"
+----
++
+.Example output
+[source,terminal]
+----
+args:
+- --v=2
+- --dynamic-serving-ca-secret-namespace=$(POD_NAMESPACE)
+- --dynamic-serving-ca-secret-name=cert-manager-webhook-ca
+- --dynamic-serving-dns-names=cert-manager-webhook
+- --tls-min-version=VersionTLS12
+- --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+- --metrics-tls-min-version=VersionTLS12
+- --metrics-tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+----
++
+The webhook deployment includes serving TLS flags (`--tls-min-version` and `--tls-cipher-suites`) for the webhook HTTPS endpoint, and TLS flags for the metrics endpoint.
+
+. Verify that the CA injector deployment has the TLS configuration applied by running the following command:
++
+[source,terminal]
+----
+$ oc get deployment -n cert-manager cert-manager-cainjector -o yaml | grep -A 10 "args:"
+----
++
+.Example output
+[source,terminal]
+----
+args:
+- --v=2
+- --leader-election-namespace=kube-system
+- --metrics-tls-min-version=VersionTLS12
+- --metrics-tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+----
++
+The CA injector deployment includes metrics endpoint TLS flags.
++
+[NOTE]
+====
+TLS profile enforcement is not available for the IstioCSR and TrustManager operands.
+
+When the cluster TLS security profile is set to `Modern` (TLS 1.3), the cipher suite flags are automatically omitted.
+====

--- a/security/cert_manager_operator/cert-manager-customizing-api-fields.adoc
+++ b/security/cert_manager_operator/cert-manager-customizing-api-fields.adoc
@@ -7,12 +7,13 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 [role="_abstract"]
-After installing the {cert-manager-operator}, you can perform the following actions by configuring the `CertManager` custom resource (CR):
+You can customize the {cert-manager-operator} after installation to suit your cluster requirements.
 
-* Configure the arguments to modify the behavior of the cert-manager components, such as the cert-manager controller, CA injector, and Webhook.
+* Configure the `CertManager` custom resource (CR) to modify the behavior of cert-manager components, such as the cert-manager controller, CA injector, and webhook.
 * Set environment variables for the controller pod.
 * Define resource requests and limits to manage CPU and memory usage.
 * Configure scheduling rules to control where pods run in your cluster.
+* Configure the cluster `APIServer` custom resource (CR) to apply the cluster-wide TLS security profile to cert-manager components.
 
 .Example CertManager CR YAML file
 [source,yaml]
@@ -108,3 +109,13 @@ include::modules/cert-manager-override-scheduling.adoc[leveloffset=+1]
 .Additional resources
 
 * xref:../../security/cert_manager_operator/cert-manager-customizing-api-fields.adoc#cert-manager-explanation-of-certmanager-cr-fields_cert-manager-customizing-api-fields[Explanation of fields in the CertManager custom resource]
+
+include::modules/cert-manager-configure-tls-adherence.adoc[leveloffset=+1]
+
+include::modules/cert-manager-verify-tls-adherence.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../nodes/clusters/nodes-cluster-enabling-features.adoc#nodes-cluster-enabling-features-about_nodes-cluster-enabling[Understanding feature gates]
+* xref:../../security/tls-security-profiles.adoc#tls-profiles-understanding_tls-security-profiles[Understanding TLS security profiles]

--- a/security/cert_manager_operator/cert-manager-operator-release-notes.adoc
+++ b/security/cert_manager_operator/cert-manager-operator-release-notes.adoc
@@ -25,7 +25,7 @@ The following advisories are available for the {cert-manager-operator} 1.20.0:
 * link:https://access.redhat.com/errata/RHBA-2026:34336[RHBA-2026:34336]
 * link:https://access.redhat.com/errata/RHBA-2026:34714[RHBA-2026:34714]
 
-Version `v1.20.0` of the {cert-manager-operator} is based on the upstream cert-manager version `v1.20.2`. For more information, see the link:https://cert-manager.io/docs/releases/release-notes/release-notes-1.20#v1202[cert-manager project release notes for v1.20.2].
+Version `v1.20.0` of the {cert-manager-operator} is based on the upstream cert-manager version `v1.20.3`. For more information, see the link:https://cert-manager.io/docs/releases/release-notes/release-notes-1.20/#v1203[cert-manager project release notes for v1.20.3].
 
 [id="cert-manager-operator-1-20-0-features-enhancements_{context}"]
 === New features and enhancements

--- a/security/cert_manager_operator/cert-manager-trust-manager.adoc
+++ b/security/cert_manager_operator/cert-manager-trust-manager.adoc
@@ -24,10 +24,6 @@ The trust-manager operand provides the following benefits:
 
 include::modules/cert-manager-trust-manager-install.adoc[leveloffset=+1]
 
-[role="_additional-resources"]
-.Additional resources
-* xref:../../nodes/clusters/nodes-cluster-enabling-features.adoc#nodes-cluster-enabling-features[Enabling features using feature gates]
-
 include::modules/cert-manager-configure-trust-bundle.adoc[leveloffset=+1]
 
 include::modules/cert-manager-trust-manager-uninstall.adoc[leveloffset=+1]


### PR DESCRIPTION

Version(s): 4.19+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [OSDOCS-19029](https://redhat.atlassian.net/browse/OSDOCS-19029)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://114542--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/cert_manager_operator/cert-manager-customizing-api-fields.html
https://114542--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/cert_manager_operator/cert-manager-trust-manager.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [X] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
