### PR TITLE
HCCDOC-4893: Insights Operator: Update the API documentation to v1

### DIFF
--- a/modules/disabling-insights-operator-gather.adoc
+++ b/modules/disabling-insights-operator-gather.adoc
@@ -44,7 +44,7 @@ endif::openshift-rosa,openshift-dedicated[]
 [source,yaml]
 ----
 
-apiVersion: insights.openshift.io/v1alpha2
+apiVersion: insights.openshift.io/v1
 kind: InsightsDataGather
 metadata:
   name: cluster
@@ -57,7 +57,7 @@ spec:
 +
 [source,yaml]
 ----
-apiVersion: insights.openshift.io/v1alpha2
+apiVersion: insights.openshift.io/v1
 kind: InsightsDataGather
 metadata:
   name: cluster

--- a/modules/enabling-insights-operator-gather.adoc
+++ b/modules/enabling-insights-operator-gather.adoc
@@ -35,7 +35,7 @@ endif::openshift-rosa,openshift-dedicated[]
 [source,yaml]
 ----
 
-apiVersion: insights.openshift.io/v1alpha2
+apiVersion: insights.openshift.io/v1
 kind: InsightsDataGather
 metadata:
   name: cluster
@@ -49,7 +49,7 @@ spec:
 +
 [source,yaml]
 ----
-apiVersion: insights.openshift.io/v1alpha2
+apiVersion: insights.openshift.io/v1
 kind: InsightsDataGather
 metadata:
   name: cluster

--- a/modules/running-insights-operator-gather-cli.adoc
+++ b/modules/running-insights-operator-gather-cli.adoc
@@ -24,7 +24,7 @@ Use the following procedure to create a `DataGather` custom resource definition 
 [source,yaml]
 ----
 
-apiVersion: insights.openshift.io/v1alpha2
+apiVersion: insights.openshift.io/v1
 kind: DataGather
 metadata:
   name: <your_data_gather>
@@ -46,7 +46,7 @@ spec:
 +
 [source,yaml]
 ----
-apiVersion: insights.openshift.io/v1alpha2
+apiVersion: insights.openshift.io/v1
 kind: DataGather
 metadata:
   name: <your_data_gather>
@@ -68,7 +68,7 @@ spec:
 +
 [source,yaml]
 ----
-apiVersion: insights.openshift.io/v1alpha2
+apiVersion: insights.openshift.io/v1
 kind: DataGather
 metadata:
   name: <your_data_gather>
@@ -90,7 +90,7 @@ Ensure that the volume name specified matches the existing `PersistentVolumeClai
 +
 [source,yaml]
 ----
-apiVersion: insights.openshift.io/v1alpha2
+apiVersion: insights.openshift.io/v1
 kind: DataGather
 metadata:
   name: <your_data_gather>

--- a/modules/running-insights-operator-gather-web-console.adoc
+++ b/modules/running-insights-operator-gather-web-console.adoc
@@ -28,7 +28,7 @@ Use the following procedure to create a `DataGather` custom resource definition 
 [source,yaml]
 ----
 
-apiVersion: insights.openshift.io/v1alpha2
+apiVersion: insights.openshift.io/v1
 kind: DataGather
 metadata:
   name: <your_data_gather>
@@ -50,7 +50,7 @@ spec:
 +
 [source,yaml]
 ----
-apiVersion: insights.openshift.io/v1alpha2
+apiVersion: insights.openshift.io/v1
 kind: DataGather
 metadata:
   name: <your_data_gather>
@@ -72,7 +72,7 @@ spec:
 +
 [source,yaml]
 ----
-apiVersion: insights.openshift.io/v1alpha2
+apiVersion: insights.openshift.io/v1
 kind: DataGather
 metadata:
   name: <your_data_gather>
@@ -93,7 +93,7 @@ Ensure that the volume name specified matches the existing `PersistentVolumeClai
 +
 [source,yaml]
 ----
-apiVersion: insights.openshift.io/v1alpha2
+apiVersion: insights.openshift.io/v1
 kind: DataGather
 metadata:
   name: <your_data_gather>


### PR DESCRIPTION


Version(s):
4.22

Issue:
https://redhat.atlassian.net/browse/HCCDOC-4893

Link to docs preview:

- [Disabling the Insights Operator periodic gather operations](https://114545--ocpdocs-pr.netlify.app/openshift-enterprise/latest/support/remote_health_monitoring/using-insights-operator.html#disabling-insights-operator-gather_using-insights-operator)
- [Re-enabling the Insights Operator periodic gather operations](https://114545--ocpdocs-pr.netlify.app/openshift-enterprise/latest/support/remote_health_monitoring/using-insights-operator.html#enabling-insights-operator-gather_using-insights-operator)
- [Gathering data on demand with the Insights Operator from the web console](https://114545--ocpdocs-pr.netlify.app/openshift-enterprise/latest/support/remote_health_monitoring/using-insights-operator.html#running-insights-operator-gather-web-console_using-insights-operator)
- [Gathering data on demand with the Insights Operator from the OpenShift CLI](https://114545--ocpdocs-pr.netlify.app/openshift-enterprise/latest/support/remote_health_monitoring/using-insights-operator.html#enabling-insights-operator-gather_using-insights-operator)


QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

