### PR TITLE
OSDOCS-20474:Update the z-stream RNs for 4.21.23

### DIFF
--- a/modules/zstream-4-21-23.adoc
+++ b/modules/zstream-4-21-23.adoc
@@ -1,0 +1,43 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-21-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-21-23_{context}"]
+= RHSA-2026:34769 - {product-title} {product-version}.23 fixed issues advisory
+
+Issued: 07 July 2026
+
+[role="_abstract"]
+{product-title} release {product-version}.23 is now available. The list of fixed issues that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2026:34769[RHSA-2026:34769] advisory. There are no RPM packages for this release.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.21.23 --pullspecs
+----
+
+[id="zstream-4-21-23-fixed-issues_{context}"]
+== Fixed issues
+
+* Before this update, the Cluster Ingress Operator (CIO) hard-coded the Operator Lifecycle Manager (OLM) `redhat-operators` catalog source name when managing the {product-title} Service Mesh (OSSM) subscription for Gateway API. In disconnected environments, the catalog source had a different name, and the CIO unconditionally overwrote it. As a consequence, Gateway API installation failed in disconnected and air-gapped environments because the OSSM subscription pointed to a catalog source that did not exist. With this release, the dependency on OLM catalog sources is removed entirely because the OLM-based OSSM installation is replaced with the Sail Library, which installs Istio directly through embedded Helm charts. As a result, Gateway API works in disconnected environments without workarounds, provided that the required container images are mirrored to an accessible registry. (link:https://issues.redhat.com/browse/OCPBUGS-78330[OCPBUGS-78330])
+
+* Before this update, enabling Gateway API on a cluster with an existing {product-title} Service Mesh (OSSM) installation caused the Cluster Ingress Operator to take over or duplicate the OSSM subscription, which resulted in unexpected behavior. With this release, the OLM-based OSSM installation is replaced with the Sail Library, which installs Istio directly without OLM subscriptions. As a result, existing OSSM installations are not affected when Gateway API is enabled.(link:https://issues.redhat.com/browse/OCPBUGS-82146[OCPBUGS-82146])
+
+* Before this update, the Cluster Ingress Operator (CIO) depended on the Marketplace capability to install {product-title} Service Mesh (OSSM) through Operator Lifecycle Manager (OLM) for Gateway API. On clusters where the Marketplace capability was disabled, such as disconnected clusters that cannot reach external catalog sources, the CIO could not create or manage the OLM subscription and the Istio control plane never started. As a consequence, Gateway API did not function on these clusters. When the GatewayClass was created, the `istiod-openshift-gateway` pod did not start. With this release, the OLM-based OSSM installation is replaced with the Sail Library, which installs Istio directly through embedded Helm charts. As a result, the dependency on the Marketplace capability is removed and Gateway API works on disconnected clusters and other environments without the Marketplace capability, provided that the required container images are mirrored to an accessible registry. (link:https://issues.redhat.com/browse/OCPBUGS-85550[OCPBUGS-85550])
+
+* Before this update, deleting a BareMetalHost (BMH) that referenced a pre-provisioning network data Secret (through the `spec.preprovisioningNetworkDataName` parameter) could report a `RegistrationError` if the Secret was removed before the BMH finished deleting. As a consequence, the BMH deletion would take minutes to complete before an eventual force-delete by the controller. With this release, the Bare Metal Operator (BMO) manages the lifecycle of that Secret in the same way as the BMC credential Secrets. The BMO now protects the Secret using a finalizer while the host is active, which prevents the Secret deletion until the finalizer is removed by the controller. As a result, the BMH is removed successfully before the Secret is allowed to be deleted.  (link:https://issues.redhat.com/browse/OCPBUGS-87964[OCPBUGS-87964])
+
+* Before this update, the Cluster Ingress Operator (CIO) installed the {product-title} Service Mesh (OSSM) Operator through OLM to provide Gateway API support. and pinned OSSM to a specific version using the `startingCSV` parameter and manual install plan approval. As a consequence, after the OSSM was already installed, the OLM ignored the `startingCSV` parameter and resolved upgrades to the channel head, which generated install plans that the CIO never approved because the version did not match. The OSSM z-stream upgrades were then blocked, which prevented CVE fixes from being delivered to clusters using the Gateway API. With this release, the OLM-based OSSM installation is replaced with the Sail Library, which installs Istio directly through embedded Helm charts. The dependency on OLM for the Gateway API is removed and clusters that are upgraded from the OLM-based path are automatically migrated to the Sail Library during the z-stream upgrade. As a result, OSSM and Istio version management is not blocked by OLM and the CVE fixes can be shipped. (link:https://issues.redhat.com/browse/OCPBUGS-88295[OCPBUGS-88295])
+
+* Before this update, when you clicked a status count, such as counts from error pods or not-ready nodes, from the *Overview* dashboard view, the resource list page opened without applying the expected filter. As a consequence, all resources were displayed instead of only the resources that matched the selected status. With this update, clicking a status count opens a filtered list page that shows only the matching resources. (link:https://issues.redhat.com/browse/OCPBUGS-90553[OCPBUGS-90553])
+
+* Before this update, during parallel single node {product-title} deployments, specifically with hypervisor-based single node deployments, some systems would hang in the middle of the deployment due to a race condition involving the BareMetalHost (BMH) custom resource. The single node deployment was never powered on by metal3 after virtual media was attached. As a consequence, parallel deployments at scale (10+ nodes) had approximately 80% success rate, with the remaining nodes requiring manual intervention to patch the `online` field to `true` for the impacted BMH custom resources. With this release, the race condition in the BMH power-on process has been resolved. As a result, parallel single node deployments successfully power on all nodes without manual intervention, even at scale. (link:https://issues.redhat.com/browse/OCPBUGS-90554[OCPBUGS-90554])
+
+[id="zstream-4-21-23-updating_{context}"]
+== Updating
+
+To update an {product-title} 4.21 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].

--- a/release_notes/ocp-4-21-release-notes.adoc
+++ b/release_notes/ocp-4-21-release-notes.adoc
@@ -44,6 +44,9 @@ include::modules/rn-ocp-release-notes-known-issues.adoc[leveloffset=+1]
 // Asynchronous errata updates
 include::modules/rn-async-errata.adoc[leveloffset=+1]
 
+// 4.21.23 RNs and updating
+include::modules/zstream-4-21-23.adoc[leveloffset=+2]
+
 // 4.21.22 RNs and updating
 include::modules/zstream-4-21-22.adoc[leveloffset=+2]
 


### PR DESCRIPTION
Version(s):
4.21

Issue:
https://redhat.atlassian.net/browse/OSDOCS-20474

Link to docs preview:
https://114547--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-21-release-notes.html#zstream-4-21-23_release-notes

Additional information:
4.21.23 MR: https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/626
ART Dashboard: https://art-dash.engineering.redhat.com/dashboard/release/openshift-4.21?page=1
