### PR TITLE
OBSDOCS-2747: Fix syslog receiver verification to use logger instead of curl

### DIFF
--- a/modules/configuring-the-collector-to-listen-for-connections-as-a-syslog-server.adoc
+++ b/modules/configuring-the-collector-to-listen-for-connections-as-a-syslog-server.adoc
@@ -10,6 +10,7 @@
 [id="configuring-the-collector-to-listen-for-connections-as-a-syslog-server_{context}"]
 = Configuring the collector to listen for connections as a syslog server
 
+[role="_abstract"]
 You can configure your log collector to collect journal format infrastructure logs by specifying `syslog` as a receiver input in the `ClusterLogForwarder` custom resource (CR).
 
 :feature-name: Syslog receiver input
@@ -39,18 +40,18 @@ $ oc adm policy add-cluster-role-to-user collect-infrastructure-logs -z logcolle
 apiVersion: observability.openshift.io/v1
 kind: ClusterLogForwarder
 metadata:
-  name: <clusterlogforwarder_name> #<1>
+  name: <clusterlogforwarder_name>
   namespace: <namespace>
 # ...
 spec:
   serviceAccount:
-    name: <service_account_name> # <1>
+    name: <service_account_name>
   inputs:
-    - name: syslog-receiver # <2>
+    - name: syslog-receiver
       type: receiver
       receiver:
-        type: syslog # <3>
-        port: 10514 # <4>
+        type: syslog
+        port: 10514
   outputs:
   - name: <output_name>
     lokiStack:
@@ -60,13 +61,13 @@ spec:
       target:
         name: logging-loki
         namespace: openshift-logging
-    tls: # <5>
+    tls:
       ca:
         key: service-ca.crt
         configMapName: openshift-service-ca.crt
     type: lokiStack
-# ...      
-  pipelines: # <6>
+# ...
+  pipelines:
     - name: syslog-pipeline
       inputRefs:
         - syslog-receiver
@@ -74,12 +75,15 @@ spec:
         - <output_name>
 # ...
 ----
-<1> Use the service account that you granted the `collect-infrastructure-logs` permission in the previous step.
-<2> Specify a name for your input receiver.
-<3> Specify the input receiver type as `syslog`.
-<4> Optional: Specify the port that the input receiver listens on. This must be a value between `1024` and `65535`.
-<5> If TLS configuration is not set, the default certificates will be used. For more information, run the command `oc explain clusterlogforwarders.spec.inputs.receiver.tls`.
-<6> Configure a pipeline for your input receiver.
++
+`metadata.name`:: Specify the name of your `ClusterLogForwarder` resource.
+`metadata.namespace`:: Specify the namespace for your `ClusterLogForwarder` resource.
+`serviceAccount.name`:: Use the service account that you granted the `collect-infrastructure-logs` permission in an earlier step.
+`inputs.name`:: Specify a name for your input receiver.
+`inputs.receiver.type`:: Specify the input receiver type as `syslog`.
+`inputs.receiver.port`:: Optional. Specify the port on which the input receiver listens. This must be a value between `1024` and `65535`.
+`outputs.tls`:: If TLS configuration is not set, the default certificates are used. For more information, run the command `oc explain clusterlogforwarders.spec.inputs.receiver.tls`.
+`pipelines`:: Configure a pipeline for your input receiver.
 
 . Apply the changes to the `ClusterLogForwarder` CR by running the following command:
 +
@@ -95,8 +99,6 @@ $ oc apply -f <filename>.yaml
 $ oc get svc
 ----
 +
-.Example output
-+
 [source,terminal,options="nowrap"]
 ----
 NAME                        TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)            AGE
@@ -108,32 +110,11 @@ In this example output, the service name is `collector-syslog-receiver`.
 
 .Verification
 
-. Extract the certificate authority (CA) certificate file by running the following command:
+. As an example, send test logs by running the following command:
 +
 [source,terminal]
 ----
-$ oc extract cm/openshift-service-ca.crt -n <namespace>
+$ logger --tcp --server collector-syslog-receiver.<namespace>.svc --port 10514 “test message”
 ----
 +
-[NOTE]
-====
-If the CA in the cluster where the collectors are running changes, you must extract the CA certificate file again.
-====
-
-. As an example, use the `curl` command to send logs by running the following command:
-+
-[source,terminal]
-----
-$ curl --cacert <openshift_service_ca.crt> collector-syslog-receiver.<namespace>.svc:10514  “test message”
-----
-+
-Replace <openshift_service_ca.crt> with the extracted CA certificate file.
-
-////
-. As an example, send logs by running the following command:
-+
-[source,terminal]
-----
-$ logger --tcp --server  collector-syslog-receiver.<ns>.svc:10514  “test message”
-----
-////
+Replace `<namespace>` with the namespace where the collector service is running.


### PR DESCRIPTION
## Summary

Fix incorrect verification command for syslog receiver configuration. The documentation was using `curl` to test a syslog receiver, which is incorrect because curl sends HTTP requests, not syslog messages.

**Changes:**
- Removed curl-based verification steps including CA certificate extraction
- Replaced with proper `logger` command that uses the syslog protocol
- Simplified the verification to a single step with the correct tool

**Versions:** 6.6, 6.5, 6.4, 6.3 (cherry-pick needed)

**JIRA:** https://redhat.atlassian.net/browse/OBSDOCS-2747

Signed-off-by: John Wilkins <jowilkin@redhat.com>