### PR TITLE
OSDOCS CQA NODES-1 plus sign follow up

### DIFF
--- a/modules/deploying-resource.adoc
+++ b/modules/deploying-resource.adoc
@@ -27,7 +27,7 @@ $ oc create -f <filename>.yaml
 ----
 where:
 
-<filename>:: Specifies the name of the YAML file you created.
+`<filename>`:: Specifies the name of the YAML file you created.
 
 // Undefine attributes, so that any mistakes are easily spotted
 :!FeatureName:

--- a/modules/nodes-cluster-enabling-features-cli.adoc
+++ b/modules/nodes-cluster-enabling-features-cli.adoc
@@ -38,6 +38,7 @@ metadata:
 spec:
   featureSet: TechPreviewNoUpgrade
 ----
++
 where:
 +
 --

--- a/modules/nodes-cluster-enabling-features-console.adoc
+++ b/modules/nodes-cluster-enabling-features-console.adoc
@@ -38,6 +38,7 @@ metadata:
 spec:
   featureSet: TechPreviewNoUpgrade <2>
 ----
++
 where:
 +
 --

--- a/modules/nodes-cluster-limit-ranges-creating.adoc
+++ b/modules/nodes-cluster-limit-ranges-creating.adoc
@@ -56,6 +56,7 @@ spec:
       max:
         storage: "50Gi"
 ----
++
 where:
 +
 --
@@ -76,6 +77,7 @@ where:
 ----
 $ oc create -f <limit_range_file> -n <project>
 ----
++
 where:
 +
 --

--- a/modules/nodes-cluster-limit-ranges-limits.adoc
+++ b/modules/nodes-cluster-limit-ranges-limits.adoc
@@ -57,6 +57,7 @@ spec:
       maxLimitRequestRatio:
         cpu: "10"
 ----
++
 where:
 +
 --
@@ -107,6 +108,7 @@ spec:
       maxLimitRequestRatio:
         cpu: "10"
 ----
++
 where:
 +
 --
@@ -140,6 +142,7 @@ spec:
       max:
         storage: 1Gi
 ----
++
 where:
 +
 --
@@ -191,6 +194,7 @@ spec:
         openshift.io/image-tags: 20
         openshift.io/images: 30
 ----
++
 where
 +
 --
@@ -229,6 +233,7 @@ spec:
       max:
         storage: "50Gi"
 ----
++
 where:
 +
 --

--- a/modules/nodes-cluster-overcommit-node-enforcing.adoc
+++ b/modules/nodes-cluster-overcommit-node-enforcing.adoc
@@ -41,6 +41,7 @@ spec:
   kubeletConfig:
     cpuCfsQuota: false
 ----
++
 where:
 +
 --

--- a/modules/nodes-cluster-overcommit-project-disable.adoc
+++ b/modules/nodes-cluster-overcommit-project-disable.adoc
@@ -64,6 +64,7 @@ metadata:
     quota.openshift.io/cluster-resource-override-enabled: "false"
 # ...
 ----
++
 where:
 +
 --

--- a/modules/nodes-cluster-resource-configure-request-limit.adoc
+++ b/modules/nodes-cluster-resource-configure-request-limit.adoc
@@ -53,6 +53,7 @@ spec:
       capabilities:
         drop: [ALL]
 ----
++
 where:
 +
 --

--- a/modules/nodes-cluster-resource-configure.adoc
+++ b/modules/nodes-cluster-resource-configure.adoc
@@ -38,6 +38,7 @@ spec:
       limitCPUToMemoryPercent: 200
 # ...
 ----
++
 where:
 +
 --
@@ -61,6 +62,7 @@ metadata:
 
 # ...
 ----
++
 where:
 +
 --

--- a/modules/nodes-cluster-resource-levels-job.adoc
+++ b/modules/nodes-cluster-resource-levels-job.adoc
@@ -70,7 +70,7 @@ $ oc adm policy add-cluster-role-to-user cluster-capacity-role \
 +
 where:
 
-<namespace>:: Specifies the namespace where the pod is located.
+`<namespace>`:: Specifies the namespace where the pod is located.
 
 . Define and create the pod spec:
 
@@ -170,6 +170,7 @@ spec:
           configMap:
             name: cluster-capacity-configmap
 ----
++
 where:
 
 `spec.template.spec.containers.env`:: Specifies a required environment variable that indicates the Cluster Capacity Tool is running inside a cluster as a pod.

--- a/modules/nodes-cluster-resource-override-deploy-cli.adoc
+++ b/modules/nodes-cluster-resource-override-deploy-cli.adoc
@@ -132,6 +132,7 @@ spec:
       cpuRequestToLimitPercent: 25
       limitCPUToMemoryPercent: 200
 ----
++
 where
 +
 --
@@ -198,6 +199,7 @@ status:
 
 # ...
 ----
++
 where:
 +
 --
@@ -222,6 +224,7 @@ metadata:
     clusterresourceoverrides.admission.autoscaling.openshift.io: enabled
 # ...
 ----
++
 where:	
 +
 --

--- a/modules/nodes-cluster-resource-override-deploy-console.adoc
+++ b/modules/nodes-cluster-resource-override-deploy-console.adoc
@@ -58,6 +58,7 @@ spec:
       cpuRequestToLimitPercent: 25
       limitCPUToMemoryPercent: 200
 ----
++
 where:
 +
 --
@@ -109,6 +110,7 @@ status:
 # ...
 
 ----
++
 where:
 +
 --
@@ -135,6 +137,7 @@ metadata:
     clusterresourceoverrides.admission.autoscaling.openshift.io: enabled
 # ...
 ----
++
 where:
 +
 --

--- a/modules/nodes-cluster-worker-latency-profiles-using.adoc
+++ b/modules/nodes-cluster-worker-latency-profiles-using.adoc
@@ -54,6 +54,7 @@ spec:
   workerLatencyProfile: MediumUpdateAverageReaction
 # ...
 ----
++
 where:
 +
 --
@@ -98,6 +99,7 @@ spec:
   workerLatencyProfile: LowUpdateSlowReaction
 # ...
 ----
++
 where:
 +
 --
@@ -136,6 +138,7 @@ $ oc get KubeControllerManager -o yaml | grep -i workerlatency -A 5 -B 5
       status: "False"
 # ...
 ----
++
 where:
 +
 --

--- a/modules/nodes-containers-events-viewing.adoc
+++ b/modules/nodes-containers-events-viewing.adoc
@@ -17,6 +17,7 @@ You can get a list of events in a given project by using the CLI.
 ----
 $ oc get events [-n <project>]
 ----
++
 where:
 +
 --


### PR DESCRIPTION
I neglected to add the `+` character before the `where:` when doing call-out replacements. This PR fixes that oversight.

https://redhat.atlassian.net/browse/OSDOCS-16929

Previews: 
List generated by Prow.  I just did a search on `where:` to make sure nothing looked wonky.

https://114585--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/clusters/nodes-cluster-enabling-features.html
https://114585--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/clusters/nodes-cluster-limit-ranges.html
https://114585--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/clusters/nodes-cluster-overcommit.html
https://114585--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/clusters/nodes-cluster-resource-configure.html
https://114585--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/clusters/nodes-cluster-resource-levels.html
https://114585--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/clusters/nodes-cluster-worker-latency-profiles.html
https://114585--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/clusters/nodes-containers-events.html
https://114585--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/cluster-tasks.html
https://114585--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/node-tasks.html
https://114585--ocpdocs-pr.netlify.app/openshift-enterprise/latest/scalability_and_performance/scaling-worker-latency-profiles.html