### PR TITLE
OSDOCS CQA NODES-3 plus sign follow up

### DIFF
--- a/modules/ai-adding-worker-nodes-to-cluster.adoc
+++ b/modules/ai-adding-worker-nodes-to-cluster.adoc
@@ -51,6 +51,7 @@ $ export CLUSTER_REQUEST=$(jq --null-input --arg openshift_cluster_id "$OPENSHIF
   "name": "<openshift_cluster_name>"
 }')
 ----
++
 where:
 
 `<api_vip>`:: Specifies the hostname for the cluster's API server. This can be the DNS domain for the API server or the IP address of the single node which the worker node can reach. For example, `api.compute-1.example.com`.
@@ -83,6 +84,7 @@ export INFRA_ENV_REQUEST=$(jq --null-input \
   "image_type": "<iso_image_type>"
 }')
 ----
++
 where:
 
 `<path_to_pull_secret_file>`:: Specifies the path to the local file containing the downloaded {cluster-manager-url-pull}.

--- a/modules/custom-tuning-specification.adoc
+++ b/modules/custom-tuning-specification.adoc
@@ -114,18 +114,17 @@ ifndef::rosa-hcp-tuning[]
     tunedConfig:
       reapply_sysctl: <bool>
 ----
-
 where:
 
-* `machineConfigLabels`: Optional.
-* `<mcLabels>`: A dictionary of key/value `MachineConfig` labels. The keys must be unique.
-* `match`: If omitted, profile match is assumed unless a profile with a higher priority matches first or `machineConfigLabels` is set.
-* `<match>`: An optional list.
-* `<priority>`: Profile ordering priority. Lower numbers mean higher priority (`0` is the highest priority).
-* `<tuned_profile_name>`: A TuneD profile to apply on a match. For example `tuned_profile_1`.
-* `operand`: Optional operand configuration.
-* `debug`: Turn debugging on or off for the TuneD daemon. Options are `true` for on or `false` for off. The default is `false`.
-* `reapply_sysctl`: Turn `reapply_sysctl` functionality on or off for the TuneD daemon. Options are `true` for on and `false` for off.
+`machineConfigLabels`:: Optional.
+`<mcLabels>`:: A dictionary of key/value `MachineConfig` labels. The keys must be unique.
+`match`:: If omitted, profile match is assumed unless a profile with a higher priority matches first or `machineConfigLabels` is set.
+`<match>`:: An optional list.
+`<priority>`:: Profile ordering priority. Lower numbers mean higher priority (`0` is the highest priority).
+`<tuned_profile_name>`:: A TuneD profile to apply on a match. For example `tuned_profile_1`.
+`operand`:: Optional operand configuration.
+`debug`:: Turn debugging on or off for the TuneD daemon. Options are `true` for on or `false` for off. The default is `false`.
+`reapply_sysctl`:: Turn `reapply_sysctl` functionality on or off for the TuneD daemon. Options are `true` for on and `false` for off.
 
 endif::rosa-hcp-tuning[]
 ifdef::rosa-hcp-tuning[]
@@ -151,17 +150,16 @@ ifdef::rosa-hcp-tuning[]
   ]
 }
 ----
-
 where:
 
-* `<tuned_profile_name>`: A TuneD profile to apply on a match. For example `tuned_profile_1`.
-* `<priority>`: Profile ordering priority. Lower numbers mean higher priority (`0` is the highest priority).
-* `match`: If omitted, profile match is assumed unless a profile with a higher priority matches first.
-* `<label_information>`: The label for the profile matched items.
+`<tuned_profile_name>`:: A TuneD profile to apply on a match. For example `tuned_profile_1`.
+`<priority>`:: Profile ordering priority. Lower numbers mean higher priority (`0` is the highest priority).
+`match`:: If omitted, profile match is assumed unless a profile with a higher priority matches first.
+`<label_information>`:: The label for the profile matched items.
 
 endif::[]
 
-`<match>` is an optional list recursively defined as follows:
+The `<match>` parameter is an optional list recursively defined as follows:
 
 ifndef::rosa-hcp-tuning[]
 [source,yaml]
@@ -171,13 +169,12 @@ ifndef::rosa-hcp-tuning[]
   type: <label_type>
     <match>
 ----
-
 where:
 
-* `<label_name>`: Node or pod label name.
-* `<label_value>`: Optional node or pod label value. If omitted, the presence of `<label_name>` is enough to match.
-* `<label_type>`: Optional object type (`node` or `pod`). If omitted, `node` is assumed.
-* `<match>`: An optional `<match>` list.
+`<label_name>`:: Node or pod label name.
+`<label_value>`:: Optional node or pod label value. If omitted, the presence of `<label_name>` is enough to match.
+`<label_type>`:: Optional object type (`node` or `pod`). If omitted, `node` is assumed.
+`<match>`:: An optional `<match>` list.
 
 endif::rosa-hcp-tuning[]
 ifdef::rosa-hcp-tuning[]
@@ -189,10 +186,9 @@ ifdef::rosa-hcp-tuning[]
         },
 ]
 ----
-
 where:
 
-* `<label_name>`: Node or pod label name.
+`<label_name>`:: Node or pod label name.
 
 endif::[]
 

--- a/modules/nodes-edge-remote-workers-strategies.adoc
+++ b/modules/nodes-edge-remote-workers-strategies.adoc
@@ -112,6 +112,7 @@ spec:
     node-status-report-frequency:
       - "1m"
 ----
++
 where:
 +
 --

--- a/modules/nodes-nodes-managing-max-pods-proc.adoc
+++ b/modules/nodes-nodes-managing-max-pods-proc.adoc
@@ -36,6 +36,7 @@ spec:
     maxPods: 250
 #...
 ----
++
 where:
 +
 --

--- a/modules/nodes-nodes-resources-cpus-reserve.adoc
+++ b/modules/nodes-nodes-resources-cpus-reserve.adoc
@@ -35,6 +35,7 @@ spec:
       pools.operator.machineconfiguration.openshift.io/worker: ""
 #...
 ----
++
 where:
 
 `metadata.name`:: Specifies a name for the CR.

--- a/modules/rosa-modifying-node-tuning.adoc
+++ b/modules/rosa-modifying-node-tuning.adoc
@@ -25,6 +25,7 @@ $ rosa describe tuning-config -c <cluster_id> \
        --name <name_of_tuning> \
        [-o json]
 ----
++
 where:
 +
 --

--- a/modules/sno-adding-worker-nodes-to-sno-clusters-manually.adoc
+++ b/modules/sno-adding-worker-nodes-to-sno-clusters-manually.adoc
@@ -99,8 +99,8 @@ ipv4.addresses <static_ip> ipv4.gateway <network_gateway> ipv4.dns <dns_server> 
 where:
 +
 --
-<static_ip>:: Specifies the host static IP address and CIDR, for example, `10.1.101.50/24`.
-<network_gateway>:: Specifies the network gateway, for example, `10.1.101.1`.
+`<static_ip>`:: Specifies the host static IP address and CIDR, for example, `10.1.101.50/24`.
+`<network_gateway>`:: Specifies the network gateway, for example, `10.1.101.1`.
 --
 
 ... Activate the modified network interface:
@@ -140,6 +140,7 @@ $ nmcli con up <network_interface>
   }
 }
 ----
++
 where:
 +
 `<hosted_worker_ign_file>`:: Specifies the locally accessible URL for the original `worker.ign` file. For example, `http://webserver.example.com/worker.ign`.
@@ -158,8 +159,8 @@ $ sudo coreos-installer install --copy-network /
 where:
 +
 --
-<new_worker_ign_file>:: Specifies the locally accessible URL for the hosted `new-worker.ign` file, for example, `http://webserver.example.com/new-worker.ign`.
-<hard_disk>:: Specifies the hard disk where you install {op-system}, for example, `/dev/sda`.
+`<new_worker_ign_file>`:: Specifies the locally accessible URL for the hosted `new-worker.ign` file, for example, `http://webserver.example.com/new-worker.ign`.
+`<hard_disk>`:: Specifies the hard disk where you install {op-system}, for example, `/dev/sda`.
 --
 
 .. For networks that have DHCP enabled, you do not need to set a static IP. Run the following `coreos-installer` command from the target host console to install the system:


### PR DESCRIPTION
I neglected to add the + character before the where: when doing call-out replacements. This PR fixes that oversight.

https://redhat.atlassian.net/browse/OSDOCS-16931

Previews:
List generated by Prow. I just did a search on where: to make sure nothing looked wonky.
https://114602--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/edge/nodes-edge-remote-workers.html
https://114602--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/nodes/nodes-nodes-managing-max-pods.html
https://114602--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/nodes/nodes-nodes-resources-cpus.html
https://114602--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/nodes/nodes-node-tuning-operator.html
https://114602--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/nodes/nodes-sno-worker-nodes.html
https://114602--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/node-tasks.html
https://114602--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/nodes/nodes/nodes-node-tuning-operator.html
https://114602--ocpdocs-pr.netlify.app/openshift-rosa/latest/nodes/nodes/nodes-node-tuning-operator.html