### PR TITLE
OSDOCS-16419: Fixing product names in ROSA Backup and restore

### DIFF
--- a/backup_and_restore/application_backup_and_restore/oadp-rosa/oadp-rosa-backing-up-applications.adoc
+++ b/backup_and_restore/application_backup_and_restore/oadp-rosa/oadp-rosa-backing-up-applications.adoc
@@ -61,7 +61,7 @@ endif::openshift-rosa,openshift-rosa-hcp[]
 
 * xref:../../../backup_and_restore/application_backup_and_restore/backing_up_and_restoring/backing-up-applications.adoc#backing-up-applications[Backing up applications]
 
-* link:https://www.redhat.com/en/products/interactive-walkthrough/install-rosa[Installing Red Hat OpenShift Service on AWS (ROSA) interactive walkthrough]
+* link:https://www.redhat.com/en/products/interactive-walkthrough/install-rosa[Installing Red Hat OpenShift Service on AWS interactive walkthrough]
 
 * link:https://docs.openshift.com/dedicated/ocm/ocm-overview.html[{cluster-manager-first}]
 

--- a/backup_and_restore/application_backup_and_restore/oadp-use-cases/oadp-rosa-backup-restore.adoc
+++ b/backup_and_restore/application_backup_and_restore/oadp-use-cases/oadp-rosa-backup-restore.adoc
@@ -7,7 +7,14 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 [role="_abstract"]
-To back up and restore workloads on ROSA, you can use {oadp-short}. You can create a backup of a workload, restore it from the backup, and verify the restoration. You can also clean up the {oadp-short} Operator, backup storage, and {aws-short} resources when they are no longer needed.
+To back up and restore workloads on
+ifndef::openshift-rosa,openshift-rosa-hcp[]
+ROSA,
+endif::openshift-rosa,openshift-rosa-hcp[]
+ifdef::openshift-rosa,openshift-rosa-hcp[]
+{product-title},
+endif::openshift-rosa,openshift-rosa-hcp[]
+you can use {oadp-short}. You can create a backup of a workload, restore it from the backup, and verify the restoration. You can also clean up the {oadp-short} Operator, backup storage, and {aws-short} resources when they are no longer needed.
 
 include::modules/performing-a-backup-oadp-rosa-sts.adoc[leveloffset=+1]
 

--- a/modules/cleanup-a-backup-oadp-rosa-sts.adoc
+++ b/modules/cleanup-a-backup-oadp-rosa-sts.adoc
@@ -4,7 +4,14 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="cleanup-a-backup-oadp-rosa-sts_{context}"]
+ifndef::openshift-rosa,openshift-rosa-hcp[]
 = Cleaning up a cluster after a backup with OADP and ROSA STS
+
+endif::openshift-rosa,openshift-rosa-hcp[]
+ifdef::openshift-rosa,openshift-rosa-hcp[]
+= Cleaning up a cluster after a backup with OADP
+
+endif::openshift-rosa,openshift-rosa-hcp[]
 
 [role="_abstract"]
 Uninstall the {oadp-first} Operator together with the backups and the S3 bucket from the hello-world example.

--- a/modules/installing-oadp-rosa-sts.adoc
+++ b/modules/installing-oadp-rosa-sts.adoc
@@ -22,30 +22,36 @@ Example file systems include the following:
 * `emptyDir` volumes
 * Local volumes
 
+ifndef::openshift-rosa,openshift-rosa-hcp[]
 For backing up volumes, OADP on ROSA with {aws-short} {sts-short} recommends native snapshots and Container Storage Interface (CSI) snapshots. Data Mover backups are supported, but can be slower than native snapshots.
 
 In an Amazon ROSA cluster that uses STS authentication, restoring backed-up data in a different {aws-short} region is not supported.
-====
+endif::openshift-rosa,openshift-rosa-hcp[]
+ifdef::openshift-rosa,openshift-rosa-hcp[]
+For backing up volumes on clusters with {aws-short} {sts-short}, OADP recommends native snapshots and Container Storage Interface (CSI) snapshots. Data Mover backups are supported, but can be slower than native snapshots.
 
+In a {product-title} cluster that uses STS authentication, restoring backed-up data in a different {aws-short} region is not supported.
+endif::openshift-rosa,openshift-rosa-hcp[]
+====
 
 .Prerequisites
 
 ifndef::openshift-rosa,openshift-rosa-hcp[]
-* An {product-title} 
+* An {product-title}
 endif::openshift-rosa,openshift-rosa-hcp[]
 ifdef::openshift-rosa,openshift-rosa-hcp[]
-* A {product-title} 
+* A {product-title}
 endif::openshift-rosa,openshift-rosa-hcp[]
 cluster with the required access and tokens. For instructions, see the previous procedure _Preparing AWS credentials for OADP_. If you plan to use two different clusters for backing up and restoring, you must prepare {aws-short} credentials, including `ROLE_ARN`, for each cluster.
 
 .Procedure
 
-. Create 
+. Create
 ifndef::openshift-rosa,openshift-rosa-hcp[]
-an {product-title} 
+an {product-title}
 endif::openshift-rosa,openshift-rosa-hcp[]
 ifdef::openshift-rosa,openshift-rosa-hcp[]
-a {product-title} 
+a {product-title}
 endif::openshift-rosa,openshift-rosa-hcp[]
 secret from your {aws-short} token file by entering the following commands:
 
@@ -276,12 +282,12 @@ You are now ready to back up and restore {product-title} applications, as descri
 --
 [IMPORTANT]
 ====
-The `enable` parameter of `restic` is set to `false` in this configuration, because OADP does not support Restic in 
+The `enable` parameter of `restic` is set to `false` in this configuration, because OADP does not support Restic in
 ifndef::openshift-rosa,openshift-rosa-hcp[]
-ROSA 
+ROSA
 endif::openshift-rosa,openshift-rosa-hcp[]
 ifdef::openshift-rosa,openshift-rosa-hcp[]
-{product-title} 
+{product-title}
 endif::openshift-rosa,openshift-rosa-hcp[]
 environments.
 ====

--- a/modules/updating-role-arn-oadp-rosa-sts.adoc
+++ b/modules/updating-role-arn-oadp-rosa-sts.adoc
@@ -7,14 +7,14 @@
 = Updating the IAM role ARN in the {oadp-short} Operator subscription
 
 [role="_abstract"]
-Update the {oadp-short} Operator subscription to fix an installation error due to incorrect IAM role Amazon Resource Name (ARN). 
+Update the {oadp-short} Operator subscription to fix an installation error due to incorrect IAM role Amazon Resource Name (ARN).
 
 While installing the {oadp-short} Operator on a
 ifndef::openshift-rosa,openshift-rosa-hcp[]
-ROSA Security Token Service (STS) 
+ROSA Security Token Service (STS)
 endif::openshift-rosa,openshift-rosa-hcp[]
 ifdef::openshift-rosa,openshift-rosa-hcp[]
-{product-title} 
+{product-title}
 endif::openshift-rosa,openshift-rosa-hcp[]
 cluster, if you provide an incorrect IAM role Amazon Resource Name (ARN), the `openshift-adp-controller` pod gives an error. The credential requests that are generated contain the wrong IAM role ARN. To update the credential requests object with the correct IAM role ARN, you can edit the {oadp-short} Operator subscription and patch the IAM role ARN with the correct value. By editing the {oadp-short} Operator subscription, you do not have to uninstall and reinstall {oadp-short} to update the IAM role ARN.
 
@@ -22,11 +22,12 @@ cluster, if you provide an incorrect IAM role Amazon Resource Name (ARN), the `o
 
 ifdef::openshift-enterprise[]
 * You have a {product-rosa} STS cluster with the required access and tokens.
+* You have installed {oadp-short} on the ROSA STS cluster.
 endif::openshift-enterprise[]
 ifdef::openshift-rosa,openshift-rosa-hcp[]
 * You have a {product-title} cluster with the required access and tokens.
+* You have installed {oadp-short} on the {product-title} cluster.
 endif::openshift-rosa,openshift-rosa-hcp[]
-* You have installed {oadp-short} on the ROSA STS cluster.
 
 .Procedure
 
@@ -37,7 +38,7 @@ endif::openshift-rosa,openshift-rosa-hcp[]
 $ oc get sub -o yaml redhat-oadp-operator
 ----
 +
-.Example subscription 
+.Example subscription
 [source,yaml]
 ----
 apiVersion: operators.coreos.com/v1alpha1


### PR DESCRIPTION
Version(s):
4.22+
5.0+

**Issue:**
https://redhat.atlassian.net/browse/OSDOCS-16419

**Link to docs preview:**
**ROSA HCP**
https://114603--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/backup_and_restore/application_backup_and_restore/oadp-rosa/oadp-rosa-backing-up-applications.html
https://114603--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/backup_and_restore/application_backup_and_restore/oadp-use-cases/oadp-rosa-backup-restore.html

**ROSA Classic**
https://114603--ocpdocs-pr.netlify.app/openshift-rosa/latest/backup_and_restore/application_backup_and_restore/oadp-rosa/oadp-rosa-backing-up-applications.html
https://114603--ocpdocs-pr.netlify.app/openshift-rosa/latest/backup_and_restore/application_backup_and_restore/oadp-use-cases/oadp-rosa-backup-restore.html

**OCP docs** shouldn't show changes, except for 1 removed (ROSA) from a link displayed text
https://114603--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/oadp-rosa/oadp-rosa-backing-up-applications.html
https://114603--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/oadp-use-cases/oadp-rosa-backup-restore.html

**QE review:**
N/A

**Additional information:**
Changes to look for (per assembly):

**oadp-rosa-backing-up-applications.adoc**

- First admonition in chapter Installing the OADP Operator...
- Prereqs in chapter Updating the IAM role ARN...
- Link text

**oadp-rosa-backup-restore.adoc**

- Intro to assembly
- Module title = Cleaning up a cluster after a backup with OADP

