### PR TITLE
OSDOCS-20353: Kueue 1.4 fixed issues

### DIFF
--- a/modules/kueue-release-notes-1.4.adoc
+++ b/modules/kueue-release-notes-1.4.adoc
@@ -1,4 +1,4 @@
-/ Module included in the following assemblies:
+// Module included in the following assemblies:
 //
 // * ai_workloads/kueue/release-notes.adoc
 
@@ -14,9 +14,32 @@
 
 Admission fair sharing::
 This release introduces admission fair sharing, which balances workload admission across multiple local Queues feeding into a shared `ClusterQueue`. Admission fair sharing:
-  
++  
   - Prioritizes workloads based on historical resource consumption
   - Tracks usage over time with a configurable decay function
   - Applies immediate admission penalties to prevent resource monopolization
 
 For more information, see xref:../../ai_workloads/kueue/admission-fair-sharing.adoc#admission-fair-sharing[Admission fair sharing].
+
+
+[id="release-notes-1.4-fixed-issues_{context}"]
+== Fixed issues
+
+Use  the `resourceNames` object to limit webhooks to only {kueue-name} resources::
+You can restrict the `kueue-manager-role` `ClusterRole` webhook configurations and CRD rules to specific `resourceNames`, preventing the controller from modifying other Operators' webhook configurations or CRDs. Webhook rules are scoped to `kueue-mutating-webhook-configuration` and `kueue-validating-webhook-configuration`, as shown in this example:
++
+[source,yaml]
+----
+resourceNames: 
+  - kueue-mutating-webhook-configuration
+  - kueue-validating-webhook-configuration
+----
++
+(link:https://issues.redhat.com/browse/OCPBUGS-88495[OCPBUGS-88495])
+
+Removed secrets from the core API resources list::
+The upstream version of Kueue moved the `secrets` RBAC to a namespace-scoped role (`kueue-manager-secrets-role`), but the `ClusterRole` was not updated to remove the cluster-wide secrets permission.
++
+This version of {kueue-name} removes the `secrets` resource type from the cluster-wide openshift-kueue-operator `ClusterRole`. The namespace-scoped `kueue-manager-secrets-role` role already exists and provides the necessary access.
++
+(link:https://issues.redhat.com/browse/OCPBUGS-88040[OCPBUGS-88040])


### PR DESCRIPTION
Kueue 1.4 Release Notes - Fixed issues

Version: 4.18+
Needs manual CP for 4.18, 4.19, 4.20, 4.21

Jira: https://redhat.atlassian.net/browse/OSDOCS-20353

Preview: https://114608--ocpdocs-pr.netlify.app/openshift-enterprise/latest/ai_workloads/kueue/release-notes.html#release-notes-1.4-fixed-issues_release-notes

SME: @sohankunkerkar 
QE: @PannagaRao 