### PR TITLE
CNV-78574: Removed obsolete warning from mtc-migrating-vms

### DIFF
--- a/migration_toolkit_for_containers/mtc-migrating-vms.adoc
+++ b/migration_toolkit_for_containers/mtc-migrating-vms.adoc
@@ -46,24 +46,6 @@ Before migrating virtual machine storage, you must install xref:../virt/install/
 
 To support storage live migration, you need to deploy {VirtProductName} version 4.17 or later. Earlier versions of {VirtProductName} do not support live storage migration.
 
-You also need to configure `KubeVirt` to enable storage live migration according to the xref:../virt/live_migration/virt-configuring-live-migration.adoc#virt-configuring-live-migration-limits_virt-configuring-live-migration[Configuring live migration].
-
-In {VirtProductName} 4.17.0, not all the required feature gates are enabled. However, to use the storage live migration feature, you must enable the feature gate.
-
-Enable the feature gate by running the following command:
-
-[source,terminal]
-----
-$ oc annotate --overwrite -n openshift-cnv hco kubevirt-hyperconverged kubevirt.kubevirt.io/jsonpatch='[ {"op": "add", "path": "/spec/configuration/developerConfiguration/featureGates/-", "value": "VolumesUpdateStrategy"}, {"op": "add", "path": "/spec/configuration/developerConfiguration/featureGates/-", "value": "VolumeMigration"} ]'
-----
-
-[WARNING]
-====
-Red{nbsp}Hat does not support clusters with the annotation enabling this feature gate.
-
-Do not add this annotation in a production cluster, if you add that annotation you receive a cluster wide alert indicating that your cluster is no longer supported.
-====
-
 For more information about the deployments and custom resource definitions (CRDs) that the migration controller uses to manipulate the VMs, see xref:../migrating_from_ocp_3_to_4/advanced-migration-options-3-4.adoc#migration-controller-options_advanced-migration-options-3-4[Migration controller options].
 
 [NOTE]
@@ -73,9 +55,9 @@ If the `mig-controller` pod starts before you install {VirtProductName}, the mig
 Restart the `mig-controller` pod in the `openshift-migration` namespace after installing {VirtProductName}.
 ====
 
-The following table explains that to use storage live migrations, you need to have {VirtProductName} installed. Moreover, you must use {mtc-short} CRDs and at least two storage classes. 
+The following table explains that to use storage live migrations, you need to have {VirtProductName} installed. Moreover, you must use {mtc-short} CRDs and at least two storage classes.
 
-.Storage live migration requirements 
+.Storage live migration requirements
 [width="100%",cols="50%,50%",options="header",]
 |===
 |Resource |Purpose


### PR DESCRIPTION
Version(s):
4.18, 4.19, 4.20

Issue: [CNV-78574](https://redhat.atlassian.net/browse/CNV-78574)

Link to docs preview: N/A

QE review:
- [x] QE has approved this change.
