### PR TITLE
OSDOCS CQA NODES-5 plus sign follow up

### DIFF
--- a/modules/nodes-application-secrets-using.adoc
+++ b/modules/nodes-application-secrets-using.adoc
@@ -30,6 +30,7 @@ metadata:
     kubernetes.io/service-account.name: "sa-name"
 type: kubernetes.io/service-account-token
 ----
++
 where:
 
 `metadata.name`:: Specifies a name for your service token secret.

--- a/modules/nodes-containers-volumes-subpath.adoc
+++ b/modules/nodes-containers-volumes-subpath.adoc
@@ -72,6 +72,7 @@ spec:
       persistentVolumeClaim:
         claimName: my-site-data
 ----
++
 where:
 
 `spec.containers.volumeMounts.subPath.mysql`:: Specifies that databases are stored in the `mysql` folder.

--- a/modules/nodes-pods-configmaps-use-case-consuming-in-env-vars.adoc
+++ b/modules/nodes-pods-configmaps-use-case-consuming-in-env-vars.adoc
@@ -86,6 +86,7 @@ spec:
           drop: [ALL]
   restartPolicy: Never
 ----
++
 where:
 +
 --

--- a/modules/nodes-pods-configmaps-use-case-consuming-in-volumes.adoc
+++ b/modules/nodes-pods-configmaps-use-case-consuming-in-volumes.adoc
@@ -56,6 +56,7 @@ spec:
         name: special-config
   restartPolicy: Never
 ----
++
 where:
 
 `spec.volumes.configMap.name`:: Specifies a file containing key.
@@ -99,6 +100,7 @@ spec:
           path: path/to/special-key
   restartPolicy: Never
 ----
++
 where:
 +
 --

--- a/modules/nodes-pods-configmaps-use-case-setting-command-line-arguments.adoc
+++ b/modules/nodes-pods-configmaps-use-case-setting-command-line-arguments.adoc
@@ -61,6 +61,7 @@ spec:
           drop: [ALL]
   restartPolicy: Never
 ----
++
 where:
 +
 --

--- a/modules/nodes-pods-pod-disruption-configuring.adoc
+++ b/modules/nodes-pods-pod-disruption-configuring.adoc
@@ -29,6 +29,7 @@ spec:
     matchLabels:
       name: my-pod
 ----
++
 where:
 +
 --
@@ -53,6 +54,7 @@ spec:
     matchLabels:
       name: my-pod
 ----
++
 where:
 +
 --

--- a/modules/nodes-pods-secrets-creating-basic.adoc
+++ b/modules/nodes-pods-secrets-creating-basic.adoc
@@ -36,6 +36,7 @@ stringData:
   username: admin
   password: <password>
 ----
++
 where:
 
 `type`:: Specifies a basic authentication secret.

--- a/modules/nodes-pods-secrets-creating-docker.adoc
+++ b/modules/nodes-pods-secrets-creating-docker.adoc
@@ -29,6 +29,7 @@ type: kubernetes.io/dockerconfig
 data:
   .dockerconfig:bm5ubm5ubm5ubm5ubm5ubm5ubm5ubmdnZ2dnZ2dnZ2dnZ2dnZ2dnZ2cgYXV0aCBrZXlzCg==
 ----
++
 where:
 +
 --
@@ -48,6 +49,7 @@ type: kubernetes.io/dockerconfig
 data:
   .dockerconfigjson:bm5ubm5ubm5ubm5ubm5ubm5ubm5ubmdnZ2dnZ2dnZ2dnZ2dnZ2dnZ2cgYXV0aCBrZXlzCg==
 ----
++
 where:
 +
 --

--- a/modules/nodes-pods-secrets-creating-opaque.adoc
+++ b/modules/nodes-pods-secrets-creating-opaque.adoc
@@ -26,6 +26,7 @@ data:
   username: <username>
   password: <password>
 ----
++
 where:
 
 `type`:: Specifies an opaque secret.

--- a/modules/nodes-pods-secrets-creating-sa.adoc
+++ b/modules/nodes-pods-secrets-creating-sa.adoc
@@ -39,6 +39,7 @@ metadata:
     kubernetes.io/service-account.name: "sa-name"
 type: kubernetes.io/service-account-token
 ----
++
 where:
 
 `metadata.annotations`:: Specifies an existing service account name. If you are creating both the `ServiceAccount` and the `Secret` objects, create the `ServiceAccount` object first.

--- a/modules/nodes-pods-secrets-creating-ssh.adoc
+++ b/modules/nodes-pods-secrets-creating-ssh.adoc
@@ -27,6 +27,7 @@ data:
   ssh-privatekey: | <2>
           MIIEpQIBAAKCAQEAulqb/Y ...
 ----
++
 where:
 
 `type`:: Specifies an SSH authentication secret.

--- a/modules/nodes-pods-secrets-creating-web-console-secrets.adoc
+++ b/modules/nodes-pods-secrets-creating-web-console-secrets.adoc
@@ -30,6 +30,7 @@ data:
 stringData:
   hostname: myapp.mydomain.com
 ----
++
 where:
 
 `type`:: Specifies an opaque secret. However, you may see other secret types such as service account token secret, basic authentication secret, SSH authentication secret, or a secret that uses Docker configuration.

--- a/modules/nodes-pods-secrets-creating.adoc
+++ b/modules/nodes-pods-secrets-creating.adoc
@@ -54,6 +54,7 @@ stringData:
     property1=valueA
     property2=valueB
 ----
++
 where:
 +
 --
@@ -109,6 +110,7 @@ spec:
         secretName: test-secret
   restartPolicy: Never
 ----
++
 where:
 +
 --
@@ -146,6 +148,7 @@ spec:
           drop: [ALL]
   restartPolicy: Never
 ----
++
 where:
 +
 --
@@ -173,6 +176,7 @@ spec:
         namespace: openshift
         name: 'cli:latest'
 ----
++
 where:
 +
 --

--- a/modules/pod-disruption-eviction-policy.adoc
+++ b/modules/pod-disruption-eviction-policy.adoc
@@ -40,6 +40,7 @@ spec:
       name: my-pod
   unhealthyPodEvictionPolicy: AlwaysAllow
 ----
++
 where:
 
 `spec.unhealthyPodEvictionPolicy`:: Specifies the unhealthy pod eviction policy, either `IfHealthyBudget` or `AlwaysAllow`. The default is `IfHealthyBudget` when the `unhealthyPodEvictionPolicy` field is empty.

--- a/modules/secrets-store-aws.adoc
+++ b/modules/secrets-store-aws.adoc
@@ -261,6 +261,7 @@ ifdef::aws-systems-manager-parameter-store[]
         objectType: "ssmparameter"
 endif::aws-systems-manager-parameter-store[]
 ----
++
 where:
 
 `metadata.name`:: Specifies the name for the secret provider class.
@@ -316,6 +317,7 @@ spec:
             volumeAttributes:
               secretProviderClass: "my-aws-provider"
 ----
++
 where:
 
 `metadata.name`:: Specifies the name for the deployment.

--- a/modules/secrets-store-azure.adoc
+++ b/modules/secrets-store-azure.adoc
@@ -214,6 +214,7 @@ spec:
           objectType: secret
     tenantId: "tid"
 ----
++
 where:
 
 `metadata.name`:: Specifies the name for the secret provider class.
@@ -270,6 +271,7 @@ spec:
             nodePublishSecretRef:
               name: secrets-store-creds
 ----
++
 where:
 
 `metadata.name`:: Specifies the name for the deployment.

--- a/modules/secrets-store-google.adoc
+++ b/modules/secrets-store-google.adoc
@@ -211,6 +211,7 @@ spec:
       - resourceName: "projects/my-project/secrets/testsecret1/versions/1"
         path: "testsecret1.txt"
 ----
++
 where:
 
 `metadata.name`:: Specifies the name for the secret provider class.
@@ -268,6 +269,7 @@ spec:
             nodePublishSecretRef:
               name: secrets-store-creds
 ----
++
 where:
 
 `metadata.name`:: Specifies the name for the deployment.

--- a/modules/secrets-store-sync-secrets.adoc
+++ b/modules/secrets-store-sync-secrets.adoc
@@ -72,6 +72,7 @@ spec:
           objectType: secret
     tenantId: "tid"
 ----
++
 where:
 
 `spec.secretObjects`:: Specifies the configuration for synchronized Kubernetes secrets.

--- a/modules/secrets-store-vault.adoc
+++ b/modules/secrets-store-vault.adoc
@@ -296,6 +296,7 @@ spec:
         objectName: "testSecret1"
         secretKey: "testSecret1"
 ----
++
 where:
 
 `metadata.name`:: Specifies the name for the secret provider class.
@@ -354,6 +355,7 @@ spec:
             volumeAttributes:
               secretProviderClass: "my-vault-provider"
 ----
++
 where:
 
 `metadata.name`:: Specifies the name for the deployment.


### PR DESCRIPTION
I neglected to add the + character before the where: when doing call-out replacements. This PR fixes that oversight.

https://redhat.atlassian.net/browse/OSDOCS-16929

Previews:
List generated by Prow. I just did a search on where: to make sure nothing looked wonky.

https://114633--ocpdocs-pr.netlify.app/openshift-enterprise/latest/applications/config-maps.html
https://114633--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/containers/nodes-containers-volumes.html
https://114633--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/pods/nodes-pods-configmaps.html
https://114633--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/pods/nodes-pods-configuring.html
https://114633--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/pods/nodes-pods-secrets.html
https://114633--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/pods/nodes-pods-secrets-store.html
https://114633--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/cluster-tasks.html