### PR TITLE
OSDOCS-20561:Update the z-stream RNs for 4.15.66

### DIFF
--- a/modules/zstream-4-15-66.adoc
+++ b/modules/zstream-4-15-66.adoc
@@ -1,0 +1,31 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-15-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-15-66_{context}"]
+= RHSA-2026:28964 - {product-title} {product-version}.66 fixed issues
+
+Issued: 01 July 2026
+
+[role="_abstract"]
+{product-title} release {product-version}.66 is now available. The list of fixed issues that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2026:28964[RHSA-2026:28964] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2026:28961[RHSA-2026:28961] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.15.66 --pullspecs
+----
+
+[id="zstream-4-15-66-fixed-issues_{context}"]
+== Fixed issues
+
+There are no notable fixed issues for this release.
+
+[id="zstream-4-15-66-updating_{context}"]
+== Updating
+
+To update an {product-title} 4.15 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].

--- a/release_notes/ocp-4-15-release-notes.adoc
+++ b/release_notes/ocp-4-15-release-notes.adoc
@@ -2814,6 +2814,9 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+//  4.15.66
+include::modules/zstream-4-15-66.adoc[leveloffset=+2]
+
 //  4.15.65
 include::modules/zstream-4-15-65.adoc[leveloffset=+2]
 


### PR DESCRIPTION
Version(s):
4.15

Issue:
https://redhat.atlassian.net/browse/OSDOCS-20561

Link to docs preview:
https://114634--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-15-release-notes.html#zstream-4-15-66_release-notes

Additional information:
4.15.66 MR: https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/600
ART Dashboard: https://art-dash.engineering.redhat.com/dashboard/release/openshift-4.15?page=1
