### PR TITLE
[OSDOCS#20563] Fix broken 'where:' definition lists in node IP hint module

### DIFF
--- a/modules/overriding-default-node-ip-selection-logic.adoc
+++ b/modules/overriding-default-node-ip-selection-logic.adoc
@@ -67,10 +67,6 @@ spec:
         path: /etc/default/nodeip-configuration
 ----
 +
-where::
-`spec.config.storage.files.contents.source.<encoded_content>`:: Replace this placeholder with the base64-encoded content of the `/etc/default/nodeip-configuration` file, for example, `Tk9ERUlQX0hJTlQ9MTkyLjAuMCxxxx==`. Note that a space is not acceptable after the comma and before the encoded content.
-
-+
 .99-nodeip-hint-worker.yaml
 [source,yaml]
 ----
@@ -92,7 +88,9 @@ spec:
        overwrite: true
        path: /etc/default/nodeip-configuration
 ----
-where::
++
+where:
++
 `spec.config.storage.files.contents.source.<encoded_content>`:: Replace this placeholder with the base64-encoded content of the `/etc/default/nodeip-configuration` file, for example, `Tk9ERUlQX0hJTlQ9MTkyLjAuMCxxxx==`. Note that a space is not acceptable after the comma and before the encoded content.
 
 . Save the manifest to the directory where you store your cluster configuration, for example, `~/clusterconfigs`.


### PR DESCRIPTION
Fix a bug and consolidate an explanation to get around what I think is an adoc processing quirk.

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.20+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [OSDOCS-20563](https://redhat.atlassian.net/browse/OSDOCS-20563)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://114638--ocpdocs-pr.netlify.app/openshift-enterprise/latest/support/troubleshooting/troubleshooting-network-issues.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] ~~QE has approved this change.~~
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: [Live bug viewing URL](https://docs.redhat.com/en/documentation/openshift_container_platform/4.21/html/support/troubleshooting#overriding-default-node-ip-selection-logic_troubleshooting-network-issues)
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
