### PR TITLE
OSDOCS CQA NODES-7 plus sign follow up

### DIFF
--- a/modules/nodes-scheduler-node-affinity-configuring-preferred.adoc
+++ b/modules/nodes-scheduler-node-affinity-configuring-preferred.adoc
@@ -52,6 +52,7 @@ spec:
             operator: In
 #...
 ----
++
 where:
 
 `spec.affinity.nodeAffinity`:: Specifies the stanza to configure node affinity.

--- a/modules/nodes-scheduler-node-affinity-configuring-required.adoc
+++ b/modules/nodes-scheduler-node-affinity-configuring-required.adoc
@@ -67,6 +67,7 @@ spec:
             operator: In
 #...
 ----
++
 where:
 
 `spec.affinity.nodeAffinity`:: Specifies the stanza to configure node affinity.

--- a/modules/nodes-scheduler-node-selectors-about.adoc
+++ b/modules/nodes-scheduler-node-selectors-about.adoc
@@ -115,6 +115,7 @@ spec:
     type: user-node
 #...
 ----
++
 where:
 +
 --

--- a/modules/nodes-scheduler-node-selectors-cluster.adoc
+++ b/modules/nodes-scheduler-node-selectors-cluster.adoc
@@ -42,6 +42,7 @@ spec:
   defaultNodeSelector: type=user-node,region=east
   mastersSchedulable: false
 ----
++
 where:
 +
 --

--- a/modules/nodes-scheduler-node-selectors-pod.adoc
+++ b/modules/nodes-scheduler-node-selectors-pod.adoc
@@ -212,6 +212,7 @@ spec:
         type: user-node
 # ...
 ----
++
 where:
 
 `spec.template.spec.nodeSelector`:: Specifies the node selectors .
@@ -266,6 +267,7 @@ spec:
         type: user-node
 # ...
 ----
++
 where:
 
 `spec.template.spec.nodeSelector`:: Specifies the node selectors.

--- a/modules/nodes-scheduler-pod-affinity-configuring.adoc
+++ b/modules/nodes-scheduler-pod-affinity-configuring.adoc
@@ -73,6 +73,7 @@ spec:
         topologyKey: topology.kubernetes.io/zone
 # ...
 ----
++
 where:
 
 `spec.affinity.podAffinity`:: Specifies a stanza to configure pod affinity.

--- a/modules/nodes-scheduler-pod-anti-affinity-configuring.adoc
+++ b/modules/nodes-scheduler-pod-anti-affinity-configuring.adoc
@@ -78,6 +78,7 @@ spec:
           topologyKey: kubernetes.io/hostname
 # ...
 ----
++
 where:
 
 `spec.affinity.podAffinity`:: Specifies a stanza to configure pod affinity.

--- a/modules/nodes-scheduler-taints-tolerations-adding-machineset.adoc
+++ b/modules/nodes-scheduler-taints-tolerations-adding-machineset.adoc
@@ -33,6 +33,7 @@ spec:
     tolerationSeconds: 3600
 #...
 ----
++
 where:
 +
 --

--- a/modules/nodes-scheduler-taints-tolerations-adding.adoc
+++ b/modules/nodes-scheduler-taints-tolerations-adding.adoc
@@ -33,6 +33,7 @@ spec:
     tolerationSeconds: 3600
 #...
 ----
++
 where:
 +
 --

--- a/modules/nodes-scheduler-taints-tolerations-projects.adoc
+++ b/modules/nodes-scheduler-taints-tolerations-projects.adoc
@@ -33,6 +33,7 @@ metadata:
       "<key_name>"}
       ]
 ----
++
 where:
 
 `metadata.name`:: Specifies the project name.

--- a/modules/olm-overriding-operator-pod-affinity.adoc
+++ b/modules/olm-overriding-operator-pod-affinity.adoc
@@ -220,6 +220,7 @@ spec:
               - ip-10-0-185-229.ec2.internal
 #...
 ----
++
 where:
 
 `spec.config.affinity`:: Specifies a `nodeAffinity`, `podAffinity`, or `podAntiAffinity`. See the Additional resources section that follows for information about creating the affinity.
@@ -250,6 +251,7 @@ spec:
               - ip-10-0-185-229.ec2.internal
 #...
 ----
++
 where:
 
 `spec.config.affinity`:: Specifies a `nodeAffinity`.
@@ -283,6 +285,7 @@ spec:
             topologyKey: topology.kubernetes.io/zone
 #...
 ----
++
 where:
 
 `spec.config.affinity`:: Specifies a `podAffinity` or `podAntiAffinity`.


### PR DESCRIPTION
I neglected to add the + character before the where: when doing call-out replacements. This PR fixes that oversight.

https://redhat.atlassian.net/browse/OSDOCS-16929

Previews:
List generated by Prow. I just did a search on where: to make sure nothing looked wonky.

https://114640--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/pods/nodes-pods-node-selectors.html
https://114640--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/scheduling/nodes-scheduler-node-affinity.html
https://114640--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/scheduling/nodes-scheduler-node-selectors.html
https://114640--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/scheduling/nodes-scheduler-pod-affinity.html
https://114640--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/scheduling/nodes-scheduler-taints-tolerations.html
https://114640--ocpdocs-pr.netlify.app/openshift-enterprise/latest/operators/admin/olm-adding-operators-to-cluster.html
https://114640--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/cluster-tasks.html
https://114640--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/node-tasks.html