### PR TITLE
OSDOCS-17043_a_420: AWS and Azure CQA updates

### DIFF
--- a/machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-supported-features-aws.adoc
+++ b/machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-supported-features-aws.adoc
@@ -35,6 +35,10 @@ include::modules/machineset-imds-options.adoc[leveloffset=+1]
 //Creating machines that use the Amazon EC2 Instance Metadata Service
 include::modules/machineset-creating-imds-options.adoc[leveloffset=+2]
 
+[role="_additional-resources"]
+.Additional resources
+* link:https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html[Use the Instance Metadata Service to access instance metadata ({aws-short} documentation)]
+
 //Machine sets that deploy machines as Dedicated Instances
 include::modules/machineset-dedicated-instances.adoc[leveloffset=+1]
 

--- a/machine_management/creating_machinesets/creating-machineset-aws.adoc
+++ b/machine_management/creating_machinesets/creating-machineset-aws.adoc
@@ -36,6 +36,7 @@ include::modules/machineset-imds-options.adoc[leveloffset=+1]
 * link:https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html[Use the Instance Metadata Service to access instance metadata ({aws-short} documentation)]
 * xref:../../machine_configuration/mco-update-boot-images.adoc#mco-update-boot-images[Boot image management]
 
+
 //Creating machines that use the Amazon EC2 Instance Metadata Service
 include::modules/machineset-creating-imds-options.adoc[leveloffset=+2]
 

--- a/modules/machineset-aws-existing-placement-group.adoc
+++ b/modules/machineset-aws-existing-placement-group.adoc
@@ -12,9 +12,10 @@ endif::[]
 = Assigning machines to placement groups for Elastic Fabric Adapter instances by using machine sets
 
 [role="_abstract"]
-You can configure a machine set to deploy machines on Elastic Fabric Adapter (EFA) instances within an existing {aws-first} placement group. Using EFA instances to run control plane machines can improve network performance.
 
-https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/efa.html[EFA] instances do not require placement groups, and you can use placement groups for purposes other than configuring an EFA. This example uses both to demonstrate a configuration that can improve network performance for machines within the specified placement group.
+You can configure a machine set to deploy machines on Elastic Fabric Adapter (EFA) instances within an existing {aws-first} placement group.
+
+link:https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/efa.html[EFA] instances do not require placement groups, and you can use placement groups for purposes other than configuring an EFA. This example uses both to demonstrate a configuration that can improve network performance for machines within the specified placement group.
 
 .Prerequisites
 
@@ -62,14 +63,13 @@ spec:
 
 where:
 
---
 `spec.template.spec.providerSpec.value.instanceType`:: Specifies an instance type that link:https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/efa.html#efa-instance-types[supports EFAs].
 `spec.template.spec.providerSpec.value.networkInterfaceType`:: Specifies the `EFA` network interface type.
 `spec.template.spec.providerSpec.value.placement.availabilityZone`:: Specifies the zone, for example, `us-east-1a`.
 `spec.template.spec.providerSpec.value.placement.region`:: Specifies the region, for example, `us-east-1`.
 `spec.template.spec.providerSpec.value.placementGroupName`:: Specifies the name of the existing {aws-short} placement group to deploy machines in.
-`spec.template.spec.providerSpec.value.placementGroupPartition`:: Optional: Specifies the partition number of the existing AWS placement group to deploy machines in.
---
+`spec.template.spec.providerSpec.value.placementGroupPartition`:: Specifies the partition number of the existing AWS placement group to deploy machines in. This value is optional.
+
 
 .Verification
 

--- a/modules/machineset-capacity-reservation.adoc
+++ b/modules/machineset-capacity-reservation.adoc
@@ -40,7 +40,7 @@ ifdef::aws[Capacity Reservation]
 can accommodate the capacity request, the deployment succeeds.
 
 For more information, including limitations and suggested use cases for this
-ifdef::azure[{azure-short} offering, see link:https://learn.microsoft.com/en-us/azure/virtual-machines/capacity-reservation-overview[On-demand Capacity Reservation] in the {azure-full} documentation.]
+ifdef::azure[{azure-full} offering, see link:https://learn.microsoft.com/en-us/azure/virtual-machines/capacity-reservation-overview[On-demand Capacity Reservation] in the {azure-short} documentation.]
 ifdef::aws[{aws-full} offering, see link:https://docs.aws.amazon.com/en_us/AWSEC2/latest/UserGuide/capacity-reservation-overview.html[On-Demand Capacity Reservations and Capacity Blocks for ML] in the {aws-short} documentation.]
 
 ifdef::azure[]

--- a/modules/machineset-creating-imds-options.adoc
+++ b/modules/machineset-creating-imds-options.adoc
@@ -23,7 +23,7 @@ providerSpec:
     metadataServiceOptions:
       authentication: Required
 ----
-
++
 where:
 
-`providerSpec.value.metadataServiceOptions.authentication`:: Specifies whether to require IMDSv2. Set this parameter to `Required` to require IMDSv2. Set this parameter to `Optional` to allow the use of both IMDSv1 and IMDSv2. If you do not specify a value, both IMDSv1 and IMDSv2 are allowed.
+`providerSpec.value.metadataServiceOptions.authentication`:: Specifies whether to require IMDSv2. To require IMDSv2, set the parameter value to `Required`. To allow the use of both IMDSv1 and IMDSv2, set the parameter value to `Optional`. If you do not specify a value, both IMDSv1 and IMDSv2 are allowed.

--- a/modules/machineset-imds-options.adoc
+++ b/modules/machineset-imds-options.adoc
@@ -12,7 +12,7 @@ endif::[]
 = Machine set options for the Amazon EC2 Instance Metadata Service
 
 [role="_abstract"]
-You can use machine sets to create machines that use a specific version of the Amazon EC2 Instance Metadata Service (IMDS). Configuring Amazon EC2 IMDS behavior for control plane machines improves security.
+You can use machine sets to create machines that use a specific version of the Amazon EC2 Instance Metadata Service (IMDS).
 
 Machine sets can create machines that allow the use of both IMDSv1 and IMDSv2 or machines that require the use of IMDSv2.
 

--- a/modules/machineset-yaml-aws.adoc
+++ b/modules/machineset-yaml-aws.adoc
@@ -193,17 +193,6 @@ ifdef::edge[]
 `<infrastructure_id>-edge-<zone>`:: Specifies the infrastructure ID, `edge` role node label, and zone name.
 `<edge>`:: Specifies the `edge` role node label.
 endif::edge[]
-[NOTE]
-====
-The `spec.template.spec.providerSpec.value.ami.id` stanza specifies a valid {op-system-first} Amazon Machine Image (AMI) for your AWS zone for your {product-title} nodes. If you want to use an {aws-short} Marketplace image, you must complete the {product-title} subscription from the link:https://aws.amazon.com/marketplace/fulfillment?productId=59ead7de-2540-4653-a8b0-fa7926d5c845[{aws-short} Marketplace] to obtain an AMI ID for your region.
-
-[source,terminal]
-----
-$ oc -n openshift-machine-api \
-    -o jsonpath='{.spec.template.spec.providerSpec.value.ami.id}{"\n"}' \
-    get machineset/<infrastructure_id>-<role>-<zone>
-----
-====
 ifndef::edge[]
 `<zone>`:: Specifies the zone name, for example, `us-east-1a`.
 endif::edge[]
@@ -224,7 +213,20 @@ endif::edge[]
 Custom tags can also be specified during installation in the `install-config.yaml` file. If the `install-config.yaml` file and the machine set include a tag with the same `name` data, the value for the tag from the machine set takes priority over the value for the tag in the `install-config.yaml` file.
 ====
 
+[NOTE]
+====
+The `spec.template.spec.providerSpec.value.ami.id` stanza specifies a valid {op-system-first} Amazon Machine Image (AMI) for your {aws-short} zone for your {product-title} nodes. If you want to use an {aws-short} Marketplace image, you must complete the {product-title} subscription from the link:https://aws.amazon.com/marketplace/fulfillment?productId=59ead7de-2540-4653-a8b0-fa7926d5c845[{aws-short} Marketplace] to obtain an AMI ID for your region.
+
+[source,terminal]
+----
+$ oc -n openshift-machine-api \
+    -o jsonpath='{.spec.template.spec.providerSpec.value.ami.id}{"\n"}' \
+    get machineset/<infrastructure_id>-<role>-<zone>
+----
+====
+
 ifdef::infra[]
+
 Machine sets running on {aws-short} support non-guaranteed Spot Instances. You can save on costs by using Spot Instances at a lower price compared to On-Demand Instances on {aws-short}. For more information, see "Machine sets that deploy machines as Spot Instances".
 endif::[]
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version:
4.20

Issue:
https://redhat.atlassian.net/browse/OSDOCS-17043

Link to docs preview:
[Creating a compute machine set on Azure](https://114643--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/creating_machinesets/creating-machineset-azure.html)

[Creating a compute machine set on AWS](https://114643--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/creating_machinesets/creating-machineset-aws)

[Configuring Amazon Web Services features for control plane machines](https://114643--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-supported-features-aws)

[Assigning machines to placement groups for Elastic Fabric Adapter instances by using machine sets](https://114643--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/creating_machinesets/creating-machineset-aws#machineset-aws-existing-placement-group_creating-machineset-aws)

[Configuring IMDS by using machine sets](https://114643--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/creating_machinesets/creating-machineset-aws#machineset-creating-imds-options_creating-machineset-aws)

[Sample YAML for a compute machine set custom resource on AWS](https://114643--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/aws-compute-edge-zone-tasks.html#machineset-yaml-aws_aws-compute-edge-zone-tasks)

[Machine set options for the Amazon EC2 Instance Metadata Service](https://114643--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-supported-features-aws.html#machineset-imds-options_cpmso-supported-features-aws)

[Adding a GPU node to an existing OpenShift Container Platform cluster](https://114643--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/creating_machinesets/creating-machineset-azure.html#nvidia-gpu-aws-adding-a-gpu-node_creating-machineset-azure)

[Configuring Capacity Reservations by using machine sets (AWS)](https://114643--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-supported-features-aws#machineset-capacity-reservation_cpmso-supported-features-aws)

[Configuring Capacity Reservation by using machine sets (Azure)](https://114643--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-supported-features-azure#machineset-capacity-reservation_cpmso-supported-features-azure)

QE review:
- [ ] QE has approved this change.
Not required.

Additional information:
These CQA updates are required for 4.20 only. They are already applied to 4.21+.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
