### PR TITLE
OSDOCS-17049: Fix DITA Vale errors in OLM software catalog CLI module

### DIFF
--- a/modules/olm-installing-from-software-catalog-using-cli.adoc
+++ b/modules/olm-installing-from-software-catalog-using-cli.adoc
@@ -56,8 +56,6 @@ $ oc get packagemanifests -n openshift-marketplace
 ----
 +
 .Example output
-[%collapsible]
-====
 [source,terminal]
 ----
 NAME                               CATALOG               AGE
@@ -74,7 +72,6 @@ jaeger                             Community Operators   91m
 kubefed                            Community Operators   91m
 # ...
 ----
-====
 +
 Note the catalog for your desired Operator.
 
@@ -86,14 +83,12 @@ $ oc describe packagemanifests <operator_name> -n openshift-marketplace
 ----
 +
 .Example output
-[%collapsible]
-====
 [source,terminal]
 ----
 # ...
 Kind:         PackageManifest
 # ...
-      Install Modes: <1>
+      Install Modes:
         Supported:  true
         Type:       OwnNamespace
         Supported:  true 
@@ -108,20 +103,18 @@ Kind:         PackageManifest
       Version:    3.7.11
       Name:       example-operator.v3.7.10
       Version:    3.7.10
-    Name:         stable-3.7 <2>
+    Name:         stable-3.7
 # ...
    Entries:
       Name:         example-operator.v3.8.5
       Version:      3.8.5
       Name:         example-operator.v3.8.4
       Version:      3.8.4
-    Name:           stable-3.8 <2>
-  Default Channel:  stable-3.8 <3>
+    Name:           stable-3.8
+  Default Channel:  stable-3.8
 ----
-<1> Indicates which install modes are supported.
-<2> Example channel names.
-<3> The channel selected by default if one is not specified.
-====
++
+In the example output, `Install Modes` indicates which install modes are supported; `Name` shows example channel names; and `Default Channel` is the channel selected by default if one is not specified.
 +
 [TIP]
 ====
@@ -169,12 +162,13 @@ apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:
   name: <operatorgroup_name>
-  namespace: <namespace> <1>
+  namespace: <namespace>
 spec:
   targetNamespaces:
-  - <namespace> <1>
+  - <namespace>
 ----
-<1> For `SingleNamespace` install mode, use the same `<namespace>` value for both the `metadata.namespace` and `spec.targetNamespaces` fields.
++
+For `SingleNamespace` install mode, use the same `<namespace>` value for both the `metadata.namespace` and `spec.targetNamespaces` fields.
 +
 .. Create the `OperatorGroup` object:
 +
@@ -193,63 +187,61 @@ If you want to subscribe to a specific version of an Operator, set the `starting
 ====
 +
 .Example `Subscription` object
-[%collapsible]
-====
 [source,yaml]
 ----
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
   name: <subscription_name>
-  namespace: <namespace_per_install_mode> <1>
+  namespace: <namespace_per_install_mode>
 spec:
-  channel: <channel_name> <2>
-  name: <operator_name> <3>
-  source: <catalog_name> <4>
-  sourceNamespace: <catalog_source_namespace> <5>
+  channel: <channel_name>
+  name: <operator_name>
+  source: <catalog_name>
+  sourceNamespace: <catalog_source_namespace>
   config:
-    env: <6>
+    env:
     - name: ARGS
       value: "-v=10"
-    envFrom: <7>
+    envFrom:
     - secretRef:
         name: license-secret
-    volumes: <8>
+    volumes:
     - name: <volume_name>
       configMap:
         name: <configmap_name>
-    volumeMounts: <9>
+    volumeMounts:
     - mountPath: <directory_name>
       name: <volume_name>
-    tolerations: <10>
+    tolerations:
     - operator: "Exists"
-    resources: <11>
+    resources:
       requests:
         memory: "64Mi"
         cpu: "250m"
       limits:
         memory: "128Mi"
         cpu: "500m"
-    nodeSelector: <12>
+    nodeSelector:
       foo: bar
 ----
-<1> For default `AllNamespaces` install mode usage, specify the `openshift-operators` namespace. Alternatively, you can specify a custom global namespace, if you have created one. For `SingleNamespace` install mode usage, specify the relevant single namespace.
-<2> Name of the channel to subscribe to.
-<3> Name of the Operator to subscribe to.
-<4> Name of the catalog source that provides the Operator.
-<5> Namespace of the catalog source. Use `openshift-marketplace` for the default software catalog sources.
-<6> The `env` parameter defines a list of environment variables that must exist in all containers in the pod created by OLM.
-<7> The `envFrom` parameter defines a list of sources to populate environment variables in the container.
-<8> The `volumes` parameter defines a list of volumes that must exist on the pod created by OLM.
-<9> The `volumeMounts` parameter defines a list of volume mounts that must exist in all containers in the pod created by OLM. If a `volumeMount` references a `volume` that does not exist, OLM fails to deploy the Operator.
-<10> The `tolerations` parameter defines a list of tolerations for the pod created by OLM.
-<11> The `resources` parameter defines resource constraints for all the containers in the pod created by OLM.
-<12> The `nodeSelector` parameter defines a `NodeSelector` for the pod created by OLM.
-====
++
+where:
++
+`<namespace_per_install_mode>`:: Specifies the namespace for your chosen install mode. For default `AllNamespaces` install mode usage, specify the `openshift-operators` namespace. Alternatively, you can specify a custom global namespace, if you have created one. For `SingleNamespace` install mode usage, specify the relevant single namespace.
+`<channel_name>`:: Specifies the name of the channel to subscribe to.
+`<operator_name>`:: Specifies the name of the Operator to subscribe to.
+`<catalog_name>`:: Specifies the name of the catalog source that provides the Operator.
+`<catalog_source_namespace>`:: Specifies the namespace of the catalog source. Use `openshift-marketplace` for the default software catalog sources.
+`config.env`:: Specifies a list of environment variables that must exist in all containers in the pod created by OLM.
+`config.envFrom`:: Specifies a list of sources to populate environment variables in the container.
+`config.volumes`:: Specifies a list of volumes that must exist on the pod created by OLM.
+`config.volumeMounts`:: Specifies a list of volume mounts that must exist in all containers in the pod created by OLM. If a `volumeMount` references a `volume` that does not exist, OLM fails to deploy the Operator.
+`config.tolerations`:: Specifies a list of tolerations for the pod created by OLM.
+`config.resources`:: Specifies resource constraints for all the containers in the pod created by OLM.
+`config.nodeSelector`:: Specifies a `NodeSelector` for the pod created by OLM.
 +
 .Example `Subscription` object with a specific starting Operator version
-[%collapsible]
-====
 [source,yaml]
 ----
 apiVersion: operators.coreos.com/v1alpha1
@@ -259,40 +251,38 @@ metadata:
   namespace: example-operator
 spec:
   channel: stable-3.7
-  installPlanApproval: Manual <1>
+  installPlanApproval: Manual
   name: example-operator
   source: custom-operators
   sourceNamespace: openshift-marketplace
-  startingCSV: example-operator.v3.7.10 <2>
+  startingCSV: example-operator.v3.7.10
 ----
-<1> Set the approval strategy to `Manual` in case your specified version is superseded by a later version in the catalog. This plan prevents an automatic upgrade to a later version and requires manual approval before the starting CSV can complete the installation.
-<2> Set a specific version of an Operator CSV.
-====
++
+where:
++
+`installPlanApproval`:: Specifies the approval strategy. Set to `Manual` in case your specified version is superseded by a later version in the catalog. This plan prevents an automatic upgrade to a later version and requires manual approval before the starting CSV can complete the installation.
+`startingCSV`:: Specifies a specific version of an Operator CSV.
 +
 .. For clusters on cloud providers with token authentication enabled, such as {aws-first} {sts-first}, {entra-first}, or {gcp-wid-first}, configure your `Subscription` object by following these steps:
 +
 ... Ensure the `Subscription` object is set to manual update approvals:
 +
 .Example `Subscription` object with manual update approvals
-[%collapsible]
-====
 [source,yaml]
 ----
 kind: Subscription
 # ...
 spec:
-  installPlanApproval: Manual <1>
+  installPlanApproval: Manual
 ----
-<1> Subscriptions with automatic approvals for updates are not recommended because there might be permission changes to make before updating. Subscriptions with manual approvals for updates ensure that administrators have the opportunity to verify the permissions of the later version, take any necessary steps, and then update.
-====
++
+Subscriptions with automatic approvals for updates are not recommended because there might be permission changes to make before updating. Subscriptions with manual approvals for updates ensure that administrators have the opportunity to verify the permissions of the later version, take any necessary steps, and then update.
 +
 ... Include the relevant cloud provider-specific fields in the `Subscription` object's `config` section:
 +
 If the cluster is in AWS STS mode, include the following fields:
 +
 .Example `Subscription` object with {aws-short} {sts-short} variables
-[%collapsible]
-====
 [source,yaml]
 ----
 kind: Subscription
@@ -301,16 +291,14 @@ spec:
   config:
     env:
     - name: ROLEARN
-      value: "<role_arn>" <1>
+      value: "<role_arn>"
 ----
-<1> Include the role ARN details.
-====
++
+** `ROLEARN` is the Amazon Resource Name (ARN) of the role that the Operator assumes.
 +
 If the cluster is in {entra-short} mode, include the following fields:
 +
 .Example `Subscription` object with {entra-short} variables
-[%collapsible]
-====
 [source,yaml]
 ----
 kind: Subscription
@@ -319,22 +307,22 @@ spec:
  config:
    env:
    - name: CLIENTID
-     value: "<client_id>" <1>
+     value: "<client_id>"
    - name: TENANTID
-     value: "<tenant_id>" <2>
+     value: "<tenant_id>"
    - name: SUBSCRIPTIONID
-     value: "<subscription_id>" <3>
+     value: "<subscription_id>"
 ----
-<1> Include the client ID.
-<2> Include the tenant ID.
-<3> Include the subscription ID.
-====
++
+where:
++
+`<client_id>`:: Specifies the client ID.
+`<tenant_id>`:: Specifies the tenant ID.
+`<subscription_id>`:: Specifies the subscription ID.
 +
 If the cluster is in {gcp-wid-short} mode, include the following fields:
 +
 .Example `Subscription` object with {gcp-wid-short} variables
-[%collapsible]
-====
 [source,yaml]
 ----
 kind: Subscription
@@ -343,15 +331,14 @@ spec:
  config:
    env:
    - name: AUDIENCE
-     value: "<audience_url>" <1>
+     value: "<audience_url>"
    - name: SERVICE_ACCOUNT_EMAIL
-     value: "<service_account_email>" <2>
+     value: "<service_account_email>"
 ----
-====
 +
 where:
 +
-`<audience>`:: Created in {gcp-short} by the administrator when they set up {gcp-wid-short}, the `AUDIENCE` value must be a preformatted URL in the following format:
+`<audience_url>`:: Created in {gcp-short} by the administrator when they set up {gcp-wid-short}, the `AUDIENCE` value must be a preformatted URL in the following format:
 +
 [source,text]
 ----
@@ -370,7 +357,7 @@ where:
 ----
 $ oc apply -f subscription.yaml
 ----
-+
+
 . If you set the `installPlanApproval` field to `Manual`, manually approve the pending install plan to complete the Operator installation. For more information, see "Manually approving a pending Operator update".
 +
 At this point, OLM is now aware of the selected Operator. A cluster service version (CSV) for the Operator should appear in the target namespace, and APIs provided by the Operator should be available for creation.


### PR DESCRIPTION
Restructure examples and callouts for DITA task compliance so ShortDescription, ExampleBlock, TaskExample, and CalloutList checks pass.

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.20+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

https://redhat.atlassian.net/browse/OSDOCS-17049

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

* [OSD — Adding Operators to a cluster](https://114645--ocpdocs-pr.netlify.app/openshift-dedicated/latest/operators/admin/olm-adding-operators-to-cluster.html)
* [OCP — Adding Operators to a cluster](https://114645--ocpdocs-pr.netlify.app/openshift-enterprise/latest/operators/admin/olm-adding-operators-to-cluster.html)
* [OCP — Installing Operators from the software catalog in a namespace](https://114645--ocpdocs-pr.netlify.app/openshift-enterprise/latest/operators/user/olm-installing-operators-in-namespace.html)
* [OCP — Preparing for users](https://114645--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/preparing-for-users.html)
* [ROSA HCP — Adding Operators to a cluster](https://114645--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/operators/admin/olm-adding-operators-to-cluster.html)
* [ROSA — Adding Operators to a cluster](https://114645--ocpdocs-pr.netlify.app/openshift-rosa/latest/operators/admin/olm-adding-operators-to-cluster.html)

QE review:
- [ ] QE has approved this change. N/A
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
