### PR TITLE
OSDOCS CQA NODES-9 plus sign follow up

### DIFF
--- a/modules/nodes-pods-adjust-resources-in-place-configuring.adoc
+++ b/modules/nodes-pods-adjust-resources-in-place-configuring.adoc
@@ -34,6 +34,7 @@ spec:
       restartPolicy: RestartContainer
 # ...
 ----
++
 where:
 
 `spec.containers.resizePolicy`:: Specifies a resize policy. For CPU and/or memory resources specify one of the following values:

--- a/modules/nodes-pods-autoscaling-creating-cpu-percent.adoc
+++ b/modules/nodes-pods-autoscaling-creating-cpu-percent.adoc
@@ -31,6 +31,7 @@ $ oc autoscale <object_type>/<name> \
   --max <number> \
   --cpu-percent=<percent>
 ----
++
 where:
 +
 --

--- a/modules/nodes-pods-autoscaling-creating-cpu-specific.adoc
+++ b/modules/nodes-pods-autoscaling-creating-cpu-specific.adoc
@@ -44,6 +44,7 @@ spec:
         type: AverageValue
         averageValue: 500m
 ----
++
 where:
 +
 --

--- a/modules/nodes-pods-autoscaling-creating-memory-percent.adoc
+++ b/modules/nodes-pods-autoscaling-creating-memory-percent.adoc
@@ -58,6 +58,7 @@ spec:
         periodSeconds: 120
       selectPolicy: Max
 ----
++
 where:
 +
 --

--- a/modules/nodes-pods-autoscaling-creating-memory-specific.adoc
+++ b/modules/nodes-pods-autoscaling-creating-memory-specific.adoc
@@ -58,6 +58,7 @@ spec:
         periodSeconds: 60
       selectPolicy: Max
 ----
++
 where:
 +
 --

--- a/modules/nodes-pods-vertical-autoscaler-configuring.adoc
+++ b/modules/nodes-pods-vertical-autoscaler-configuring.adoc
@@ -45,6 +45,7 @@ spec:
   recommenders:
     - name: my-recommender
 ----
++
 where:
 
 `spec.targetRef.kind`:: Specifies the type of workload object you want this VPA to manage: `Deployment`, `StatefulSet`, `Job`, `DaemonSet`, `ReplicaSet`, or `ReplicationController`.
@@ -116,6 +117,7 @@ status:
 
 ...
 ----
++
 where:
 
 `status.recommendation.containerRecommendations`:: Specifies the minimum and maximum recommended resource levels for the container:

--- a/modules/nodes-pods-vertical-autoscaler-custom.adoc
+++ b/modules/nodes-pods-vertical-autoscaler-custom.adoc
@@ -125,6 +125,7 @@ spec:
       securityContext:
         runAsNonRoot: true
 ----
++
 where:
 +
 --
@@ -168,6 +169,7 @@ spec:
     kind:       Deployment
     name:       frontend
 ----
++
 where:
 
 `spec.recommenders.name`:: Specifies the name of the alternative recommender deployment.

--- a/modules/nodes-pods-vertical-autoscaler-moving-vpa.adoc
+++ b/modules/nodes-pods-vertical-autoscaler-moving-vpa.adoc
@@ -72,6 +72,7 @@ spec:
     nodeSelector:
       node-role.kubernetes.io/infra: ""
 ----
++
 where:
 +
 --
@@ -144,6 +145,7 @@ spec:
       nodeSelector:
         node-role.kubernetes.io/infra: ""
 ----
++
 where:
 +
 --
@@ -230,6 +232,7 @@ spec:
     nodeSelector:
       node-role.kubernetes.io/<node_role>: ""
 ----
++
 where:
 +
 --
@@ -260,10 +263,10 @@ spec:
       operator: "Exists"
       effect: "NoSchedule"
 ----
-====
 where:
 
 `spec.config.tolerations`:: Specifies a toleration for a taint on the node where you want to move the VPA Operator pod.
+====
 
 . Move each VPA component by adding node selectors to the `VerticalPodAutoscaler` custom resource (CR):
 
@@ -302,6 +305,7 @@ spec:
       nodeSelector:
         node-role.kubernetes.io/<node_role>: ""
 ----
++
 where:
 +
 --
@@ -354,12 +358,12 @@ spec:
         operator: "Exists"
         effect: "NoSchedule"
 ----
-====
 where:
 
 `spec.deploymentOverrides.admission.tolerations`:: Specifies a toleration for the admission controller pod for a taint on the node where you want to install the pod.
 `spec.deploymentOverrides.recommender.tolerations`:: Specifies a toleration for the recommender pod for a taint on the node where you want to install the pod.
 `spec.deploymentOverrides.updater.tolerations`:: Specifies a toleration for the updater pod for a taint on the node where you want to install the pod.
+====
 endif::vpa[]
 
 .Verification

--- a/modules/nodes-sigstore-configure-cluster-policy.adoc
+++ b/modules/nodes-sigstore-configure-cluster-policy.adoc
@@ -57,6 +57,7 @@ spec:
     signedIdentity:
       matchPolicy: MatchRepoDigestOrExact
 ----
++
 where:
 +
 --
@@ -97,6 +98,7 @@ spec:
     signedIdentity:
       matchPolicy: MatchRepository
 ----
++
 where:
 +
 --
@@ -138,6 +140,7 @@ spec:
         prefix: example.com
         signedPrefix: mirror-example.com
 ----
++
 where:
 +
 --
@@ -278,6 +281,7 @@ docker:
   quay.io/openshift-release-dev/ocp-release:
     use-sigstore-attachments: true
 ----
++
 where:
 
 `docker.example.com.use-sigstore-attachments`:: When `true`, specifies that sigstore signatures are going to be read along with the image.

--- a/modules/nodes-sigstore-configure-image-policy.adoc
+++ b/modules/nodes-sigstore-configure-image-policy.adoc
@@ -49,6 +49,8 @@ spec:
     signedIdentity:
       matchPolicy: MatchRepository
 ----
+where:
+
 `kind`:: Specifies that the configuration is for a `ImagePolicy` object.
 `metadata.namespace`:: Specifies the namespace where the image policy is applied.
 `spec.scopes`:: Specifies a list of repositories or images assigned to this policy.
@@ -79,7 +81,7 @@ spec:
   policy:
     rootOfTrust:
       policyType: PKI
-      pki: <7>
+      pki:
         caRootsData: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk....RVJUSUZJQ0FURS0tLS0t
         caIntermediatesData: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURkVENDQ....0QT09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0=
         pkiCertificateSubject:
@@ -88,6 +90,8 @@ spec:
     signedIdentity:
       matchPolicy: MatchRepository
 ----
+where:
+
 `kind`:: Specifies that the configuration is for a `ImagePolicy` object.
 `metadata.namespace`:: Specifies the namespace where the image policy is applied.
 `spec.scopes`:: Specifies a list of repositories or images assigned to this policy.
@@ -127,6 +131,8 @@ spec:
       exactRepository:
         repository: quay.io/crio/signed
 ----
+where:
+
 `kind`:: Specifies that the configuration is for a `ImagePolicy` object.
 `metadata.namespace`:: Specifies the namespace where the image policy is applied.
 `spec.scopes`:: Specifies a list of repositories or images assigned to this policy.
@@ -262,6 +268,7 @@ docker:
   quay.io/openshift-release-dev/ocp-release:
     use-sigstore-attachments: true
 ----
++
 where:
 
 `docker.example.com.use-sigstore-attachments`:: When `true`, specifies that sigstore signatures are going to be read along with the image.


### PR DESCRIPTION
I neglected to add the + character before the where: when doing call-out replacements. This PR fixes that oversight.

https://redhat.atlassian.net/browse/OSDOCS-16929

Previews:
List generated by Prow. I just did a search on where: to make sure nothing looked wonky.

https://114646--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/creating-infrastructure-machinesets.html
https://114646--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/nodes-sigstore-using.html
https://114646--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/pods/nodes-pods-adjust-resources-in-place.html
https://114646--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/pods/nodes-pods-autoscaling.html
https://114646--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/pods/nodes-pods-vertical-autoscaler.html