### PR TITLE
TELCODOCS-2777: Update SiteConfig deprecation message for 4.21

### DIFF
--- a/edge_computing/ztp-migrate-clusterinstance.adoc
+++ b/edge_computing/ztp-migrate-clusterinstance.adoc
@@ -10,7 +10,7 @@ You can incrementally migrate {sno} clusters from `SiteConfig` custom resources 
 
 [IMPORTANT]
 ====
-* The `SiteConfig` CR is deprecated from {product-title} version 4.18 and will be removed in a future version.
+* The `SiteConfig` CR is deprecated from {product-title} version 4.18 and removed from {product-title} 4.21.
 
 * The `ClusterInstance` CR is available from {rh-rhacm-first} version 2.12 or later.
 ====


### PR DESCRIPTION
Version(s):
4.21+

Issue:
https://redhat.atlassian.net/browse/TELCODOCS-2777

Link to docs preview:
<!-- Add direct link(s) to the exact page(s) with updated content from the preview build. -->

QE review:
- [ ] QE has approved this change.

Additional information:
The `SiteConfig` CR was removed in OpenShift Container Platform 4.21. This PR updates the deprecation notice in `edge_computing/ztp-migrate-clusterinstance.adoc` from "will be removed in a future version" to explicitly state the removal version (4.21).

Made with [Cursor](https://cursor.com)