### PR TITLE
OSDOCS CQA MCO misc plus sign follow up

### DIFF
--- a/modules/machine-config-custom-mcp-automatic.adoc
+++ b/modules/machine-config-custom-mcp-automatic.adoc
@@ -33,6 +33,7 @@ spec:
     matchLabels:
       node-role.kubernetes.io/custom: ""
 ----
++
 where: 
 +
 --

--- a/modules/machine-config-install-time-configs.adoc
+++ b/modules/machine-config-install-time-configs.adoc
@@ -58,6 +58,7 @@ spec:
     - FileSystems
 # ...
 ----
++
 where:
 +
 --
@@ -110,6 +111,7 @@ spec:
         format: ext4
         label: DATA
 ----
++
 where:
 
 `spec.config.storage.disks`:: Specifies changes to the installed storage disk configuration in Ignition format. This field is optional.

--- a/modules/mco-update-boot-images-aws.adoc
+++ b/modules/mco-update-boot-images-aws.adoc
@@ -231,6 +231,7 @@ Replace `<machineset_name>` with the name of your machine set.
 ----
 $ oc scale --replicas=<count> machineset <machineset_name> -n openshift-machine-api
 ----
++
 where:
 
 `<count>`:: Specifies the total number of replicas, including any existing replicas, that you want for this machine set.
@@ -270,6 +271,7 @@ Replace `<new_node>` with the name of your new node.
     "version": "9.6.20251212-1"
 }
 ----
++
 where:
 
 `version`:: Specifies the boot image version.

--- a/modules/mco-update-boot-images-azure.adoc
+++ b/modules/mco-update-boot-images-azure.adoc
@@ -275,6 +275,7 @@ $ oc patch machineset <machineset-name> -n openshift-machine-api --type merge \
 ----
 $ oc scale --replicas=<count> machineset <machineset_name> -n openshift-machine-api
 ----
++
 where:
 
 `<count>`:: Specifies the total number of replicas, including any existing replicas, that you want for this machine set.
@@ -314,6 +315,7 @@ Replace `<new_node>` with the name of your new node.
     "version": "9.6.20251015"
 }
 ----
++
 where:
 
 `version`:: Specifies the boot image version.

--- a/modules/mco-update-boot-images-configuring.adoc
+++ b/modules/mco-update-boot-images-configuring.adoc
@@ -196,6 +196,7 @@ sh-5.1# cat /sysroot/.coreos-aleph-version.json
     "version": "9.6.20251015-1"
 }
 ----
++
 where:
 
 `<version>`:: Specifies the boot image version.

--- a/modules/mco-update-boot-images-gcp.adoc
+++ b/modules/mco-update-boot-images-gcp.adoc
@@ -337,6 +337,7 @@ Replace `<machineset_name>` with the name of your machine set.
 ----
 $ oc scale --replicas=<count> machineset <machineset_name> -n openshift-machine-api
 ----
++
 where:
 
 `<count>`:: Specifies the total number of replicas, including any existing replicas, that you want for this machine set.
@@ -376,6 +377,7 @@ Replace `<new_node>` with the name of your new node.
     "version": "9.6.20251212-1"
 }
 ----
++
 where:
 
 `version`:: Specifies the boot image version.

--- a/modules/mco-update-boot-images-ibm-bare-metal.adoc
+++ b/modules/mco-update-boot-images-ibm-bare-metal.adoc
@@ -78,6 +78,7 @@ This process migrates the cluster to the `machine-os-images` provisioning method
 ----
 $ oc scale --replicas=<count> machineset <machineset_name> -n openshift-machine-api
 ----
++
 where:
 
 `<count>`:: Specifies the total number of replicas, including any existing replicas, that you want for this machine set.
@@ -117,6 +118,7 @@ Replace `<new_node>` with the name of your new node.
     "version": "9.6.20251212-1"
 }
 ----
++
 where:
 
 `version`:: Specifies the boot image version.

--- a/modules/mco-update-boot-images-ibm-cloud.adoc
+++ b/modules/mco-update-boot-images-ibm-cloud.adoc
@@ -260,6 +260,7 @@ Replace `<machineset_name>` with the name of your machine set.
 ----
 $ oc scale --replicas=<count> machineset <machineset_name> -n openshift-machine-api
 ----
++
 where:
 
 `<count>`:: Specifies the total number of replicas, including any existing replicas, that you want for this machine set.
@@ -299,6 +300,7 @@ Replace `<new_node>` with the name of your new node.
     "version": "9.6.20251212-1"
 }
 ----
++
 where:
 
 `<version>`:: Specifies the boot image version.

--- a/modules/mco-update-boot-images-nutanix.adoc
+++ b/modules/mco-update-boot-images-nutanix.adoc
@@ -95,6 +95,7 @@ $ oc get configmap cloud-provider-config -n openshift-config -o jsonpath='{.data
         }
     },
 ----
++
 where:
 
 `prismCentral.address`:: Specifies the Prism Central IP address.
@@ -213,6 +214,7 @@ Replace `<machineset_name>` with the name of your machine set.
 ----
 $ oc scale --replicas=<count> machineset <machineset_name> -n openshift-machine-api
 ----
++
 where:
 
 `<count>`:: Specifies the total number of replicas, including any existing replicas, that you want for this machine set.
@@ -252,6 +254,7 @@ Replace `<new_node>` with the name of your new node.
     "version": "9.6.20251212-1"
 }
 ----
++
 where:
 
 `version`:: Specifies the boot image version.

--- a/modules/mco-update-boot-images-openstack.adoc
+++ b/modules/mco-update-boot-images-openstack.adoc
@@ -252,6 +252,7 @@ Replace `<machineset_name>` with the name of your machine set.
 ----
 $ oc scale --replicas=<count> machineset <machineset_name> -n openshift-machine-api
 ----
++
 where:
 
 `<count>`:: Specifies the total number of replicas, including any existing replicas, that you want for this machine set.
@@ -291,6 +292,7 @@ Replace `<new_node>` with the name of your new node.
     "version": "9.6.20251212-1"
 }
 ----
++
 where:
 +
 --

--- a/modules/mco-update-boot-images-vsphere.adoc
+++ b/modules/mco-update-boot-images-vsphere.adoc
@@ -115,6 +115,7 @@ Replace `<machineset_name>` with the name of your machine set.
 ----
 $ oc scale --replicas=<count> machineset <machineset_name> -n openshift-machine-api
 ----
++
 where:
 
 `<count>`:: Specifies the total number of replicas, including any existing replicas, that you want for this machine set.
@@ -154,6 +155,7 @@ Replace `<new_node>` with the name of your new node.
     "version": "9.6.20251212-1"
 }
 ----
++
 where:
 
 `version`:: Specifies the boot image version.

--- a/modules/mco-update-boot-skew-mgmt-configuring.adoc
+++ b/modules/mco-update-boot-skew-mgmt-configuring.adoc
@@ -51,6 +51,7 @@ spec:
       rhcosVersion: 9.6.20251023-0
 # ...
 ----
++
 where:
 
 `spec.bootImageSkewEnforcement.mode`:: Specifies the boot image enforcement mode, one of the following values:


### PR DESCRIPTION
I neglected to add the + character before the where: when doing call-out replacements. This PR fixes that oversight.

https://redhat.atlassian.net/browse/OSDOCS-16929

Previews:
List generated by Prow. I just did a search on where: to make sure nothing looked wonky.

https://114648--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_configuration/machine-config-custom-mcp.html
https://114648--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_configuration/machine-configs-configure.html
https://114648--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_configuration/machine-configs-garbage-collection.html
https://114648--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_configuration/mco-update-boot-images.html
https://114648--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_configuration/mco-update-boot-images-manual.html
https://114648--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_configuration/mco-update-boot-skew-mgmt.html
https://114648--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/nodes/nodes-update-boot-images.html