### PR TITLE
OSDOCS CQA WMCO misc plus sign follow up

### DIFF
--- a/modules/wmco-configure-debug-logging.adoc
+++ b/modules/wmco-configure-debug-logging.adoc
@@ -37,6 +37,7 @@ spec:
     - name: ARGS
       value: --debugLogging
 ----
++
 where:
 +
 --


### PR DESCRIPTION
I neglected to add the + character before the where: when doing call-out replacements. This PR fixes that oversight.

https://redhat.atlassian.net/browse/OSDOCS-16929

Previews:
List generated by Prow. I just did a search on where: to make sure nothing looked wonky.

https://114653--ocpdocs-pr.netlify.app/openshift-enterprise/latest/windows_containers/creating_windows_machinesets/creating-windows-machineset-aws.html
https://114653--ocpdocs-pr.netlify.app/openshift-enterprise/latest/windows_containers/creating_windows_machinesets/creating-windows-machineset-azure.html
https://114653--ocpdocs-pr.netlify.app/openshift-enterprise/latest/windows_containers/creating_windows_machinesets/creating-windows-machineset-gcp.html
https://114653--ocpdocs-pr.netlify.app/openshift-enterprise/latest/windows_containers/creating_windows_machinesets/creating-windows-machineset-nutanix.html
https://114653--ocpdocs-pr.netlify.app/openshift-enterprise/latest/windows_containers/creating_windows_machinesets/creating-windows-machineset-vsphere.html
https://114653--ocpdocs-pr.netlify.app/openshift-enterprise/latest/windows_containers/enabling-windows-container-workloads.html