### PR TITLE
LOG-9632: Add known issue for Loki S3 upload failure with certain backends

### DIFF
--- a/modules/logging-release-notes-6-4-6.adoc
+++ b/modules/logging-release-notes-6-4-6.adoc
@@ -32,3 +32,32 @@ This release includes link:https://access.redhat.com/errata/RHSA-2026:34364[RHSA
 * link:https://access.redhat.com/security/cve/CVE-2026-42154[CVE-2026-42154]
 
 * link:https://access.redhat.com/security/cve/CVE-2026-42499[CVE-2026-42499]
+
+[id="logging-release-notes-6-4-6-known-issues_{context}"]
+== Known Issues
+
+* The Loki version in Logging 6.4.6 has a known issue that prevents data upload to certain S3-compatible object storage backends. This issue affects storage systems that do not support the `STREAMING-AWS4-HMAC-SHA256-PAYLOAD-TRAILER` value in the `x-amz-content-sha256` header.
++
+When this issue occurs, Loki ingesters fail to flush logs to object storage. The following error appears:
++
+[source,terminal]
+----
+failed to upload delete requests file err="operation error S3: PutObject, https response error StatusCode: 400, RequestID: , HostID: , api error InvalidArgument: x-amz-content-sha256 must be UNSIGNED-PAYLOAD, STREAMING-AWS4-HMAC-SHA256-PAYLOAD or a valid sha256 value.
+----
++
+*Affected configurations:*
++
+This issue affects S3-compatible storage backends that do not support the `STREAMING-AWS4-HMAC-SHA256-PAYLOAD-TRAILER` value in the `x-amz-content-sha256` header.
++
+NetApp ONTAP versions before 9.11.1 do not support this value. Contact NetApp to determine which version supports this value, or upgrade to NetApp ONTAP 9.11.1 or later for full AWS Signature Version 4 streaming support.
++
+*Workaround:*
++
+Do not upgrade to Logging 6.4.6 if you use affected S3-compatible storage backends. Remain on Logging 6.4.5 until this issue is resolved. For rollback instructions, see link:https://access.redhat.com/solutions/7145126[KCS 7145126].
++
+[NOTE]
+====
+This issue does not affect Amazon S3 or other storage backends that fully support AWS Signature Version 4 streaming.
+====
++
+(link:https://issues.redhat.com/browse/LOG-9632[LOG-9632])


### PR DESCRIPTION
## Summary

Add known issue to Logging 6.4.6 release notes documenting Loki's failure to upload data to certain S3-compatible storage backends.

## Issue Details

**Bug:** https://issues.redhat.com/browse/LOG-9632  
**KCS:** https://access.redhat.com/solutions/7145126
**Preview:** https://114659--ocpdocs-pr.netlify.app/openshift-logging/latest/release_notes/logging-release-notes.html#logging-release-notes-6-4-6-known-issues_logging-release-notes
**Severity:** Critical (multiple customer cases filed)

The Loki version in 6.4.6 fails to upload data to S3-compatible storage backends that do not support the `STREAMING-AWS4-HMAC-SHA256-PAYLOAD-TRAILER` value in the `x-amz-content-sha256` header.

## Affected Configurations

- NetApp ONTAP versions before 9.11.1
- Other S3-compatible storage backends without full AWS Signature Version 4 streaming support

## Changes

- Added comprehensive Known Issues section with:
  - Clear explanation of the issue
  - Actual error message users will see
  - Specific NetApp ONTAP version affected (< 9.11.1)
  - Guidance for users of other S3-compatible backends
  - Recommendation to remain on 6.4.5
  - Links to bug tracker and KCS article
  - Note that AWS S3 is not affected

## Vale Results

✔ 0 errors, 0 warnings, 14 suggestions (all acceptable for release notes)

Signed-off-by: John Wilkins <jowilkin@redhat.com>