### PR TITLE
OSDOCS WMCO add 'How to collect WICD logs' to docs

### DIFF
--- a/modules/collecting-wicd-logs-windows.adoc
+++ b/modules/collecting-wicd-logs-windows.adoc
@@ -1,0 +1,32 @@
+// Module included in the following assemblies:
+//
+// * support/troubleshooting/troubleshooting-windows-container-workload-issues.adoc
+// * windows_containers/windows-containers-troubleshooting.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="collecting-wicd-logs-windows_{context}"]
+= Collecting WICD logs for Windows containers
+
+[role="_abstract"]
+The Windows Instance Config Daemon (WICD) service writes and rotates its own log files directly in the `C:\var\log\wicd\` directory. You can view the WICD event logs to investigate issues you think might be caused by the WICD service.
+
+.Prerequisites
+
+* You installed the Windows Machine Config Operator (WMCO) using Operator Lifecycle Manager (OLM).
+* You have created a Windows compute machine set.
+
+.Procedure
+
+. SSH into the Windows node and enter PowerShell by running the following command:
++
+[source,terminal]
+----
+C:\> powershell
+----
+
+. View the WICD logs by using the following command:
++
+[source,terminal]
+----
+C:\> Get-Content "C:\var\log\wicd\windows-instance-config-daemon.exe.INFO" -Tail 50 -Wait
+----

--- a/modules/collecting-wicd-logs-windows.adoc
+++ b/modules/collecting-wicd-logs-windows.adoc
@@ -8,7 +8,11 @@
 = Collecting WICD logs for Windows containers
 
 [role="_abstract"]
-The Windows Instance Config Daemon (WICD) service writes and rotates its own log files directly in the `C:\var\log\wicd\` directory. You can view the WICD event logs to investigate issues you think might be caused by the WICD service.
+You can view the Windows Instance Config Daemon (WICD) and Windows Exporter (windows-exporter) event logs to investigate issues you think might be caused by the WICD service.
+
+WRITER'S NOTE: The windows-exporter service applies to 5.0+ only. 
+
+The WICD and Windows Exporter services write and rotate log files directly to the `C:\var\log\wicd\` and `C:\var\log\windows-exporter\` directories respectively. You can view the WICD event logs to investigate issues you think might be caused by the WICD service.
 
 .Prerequisites
 


### PR DESCRIPTION
https://redhat.atlassian.net/browse/OSDOCS-20500

The WMCO team decided to not document log rotation until all services are addressed.

NOTE: Added windows-exporter service per https://redhat.atlassian.net/browse/WINC-2046 and [Windows internal docs](https://github.com/openshift/windows-machine-config-operator/pull/4530/changes#diff-96160ca341eafe20466fcf7f74d2d720f3f05a614452c5ab41f32d8756a3fec0R102-R103) and [here](https://github.com/openshift/windows-machine-config-operator/pull/4530/changes#diff-96160ca341eafe20466fcf7f74d2d720f3f05a614452c5ab41f32d8756a3fec0R123). This applies to 4.23 and 5.0 only. Remove if CP'ing to previous branches.  

Previews:

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
