### PR TITLE
CNV-77504: Storage permissions

### DIFF
--- a/modules/virt-migrating-storage-permissions.adoc
+++ b/modules/virt-migrating-storage-permissions.adoc
@@ -1,0 +1,46 @@
+// Module included in the following assemblies:
+//
+// * virt/managing_vms/virtual_disks/virt-migrating-storage-class.adoc
+
+:_mod-docs-content-type: PROCEDURE
+
+[id="virt-migrating-storage-permissions_{context}"]
+= Assign storage migration permissions
+
+[role="_abstract"]
+Cluster administrators must grant users permission to perform storage migrations. Permissions to perform storage migrations are not part of the administrative or editing roles in the cluster by default.
+
+.Prerequisites
+
+* You have cluster administrator privileges.
+
+.Procedure
+
+. (Optional) To assign the user single namespace storage migration permissions, run the following command:
++
+[source,terminal]
+----
+$ kubectl create rolebinding <role_binding_name> \
+    --clusterrole=migrations.kubevirt.io:storagemigrate \
+    --user=<user_name> -n <namespace>
+----
++
+where:
++
+<role_binding_name>::  The name to assign to this role binding instance.
+<user_name>::  The user to assign the storage migration permission.
+<namespace>::  The applicable namespace for this role binding instance.
+
+. (Optional) To assign the user multiple namespace storage migration permissions, run the following command:
++
+[source,terminal]
+----
+$ kubectl create clusterrolebinding <role_binding_name> \
+    --clusterrole=migrations.kubevirt.io:storagemigrate-multins \
+    --user=<user_name>
+----
++
+where:
++
+<role_binding_name>::  The name to assign to this role binding instance.
+<user_name>::  The user to assign the storage migration permission.

--- a/virt/managing_vms/virtual_disks/virt-migrating-storage-class.adoc
+++ b/virt/managing_vms/virtual_disks/virt-migrating-storage-class.adoc
@@ -11,4 +11,5 @@ toc::[]
 [role="_abstract"]
 You can migrate one or more virtual disks to a different storage class to optimize storage performance or reduce costs without stopping your virtual machine (VM) or virtual machine instance (VMI).
 
+include::modules/virt-migrating-storage-permissions.adoc[leveloffset=+1]
 include::modules/virt-migrating-storage-class-ui.adoc[leveloffset=+1]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->
Received a request to integrate the storage permission documentation now and defer the rest to 5.0. This PR integrates the permissions topic.

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.22+

Issue:
[CNV-77504](https://redhat.atlassian.net/browse/CNV-77504)

Link to docs preview:

- [Assigning storage migration permissions](https://114676--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/managing_vms/virtual_disks/virt-migrating-storage-class.html#virt-migrating-storage-permissions_virt-migrating-storage-class)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
