### PR TITLE
Revert "[enterprise-5.0] [OSDOCS#20563] Fix broken 'where:' definition lists in node IP hint module"

### DIFF
--- a/modules/overriding-default-node-ip-selection-logic.adoc
+++ b/modules/overriding-default-node-ip-selection-logic.adoc
@@ -67,6 +67,10 @@ spec:
         path: /etc/default/nodeip-configuration
 ----
 +
+where::
+`spec.config.storage.files.contents.source.<encoded_content>`:: Replace this placeholder with the base64-encoded content of the `/etc/default/nodeip-configuration` file, for example, `Tk9ERUlQX0hJTlQ9MTkyLjAuMCxxxx==`. Note that a space is not acceptable after the comma and before the encoded content.
+
++
 .99-nodeip-hint-worker.yaml
 [source,yaml]
 ----
@@ -88,9 +92,7 @@ spec:
        overwrite: true
        path: /etc/default/nodeip-configuration
 ----
-+
-where:
-+
+where::
 `spec.config.storage.files.contents.source.<encoded_content>`:: Replace this placeholder with the base64-encoded content of the `/etc/default/nodeip-configuration` file, for example, `Tk9ERUlQX0hJTlQ9MTkyLjAuMCxxxx==`. Note that a space is not acceptable after the comma and before the encoded content.
 
 . Save the manifest to the directory where you store your cluster configuration, for example, `~/clusterconfigs`.


### PR DESCRIPTION
Reverts openshift/openshift-docs#114660

Testing branch protection 