### PR TITLE
[OSDOCS-20481]: CQA: Managing HCP on OpenStack (3 of 3)

### DIFF
--- a/modules/hcp-manage-openstack-az.adoc
+++ b/modules/hcp-manage-openstack-az.adoc
@@ -6,15 +6,19 @@
 [id="hcp-manage-openstack-az_{context}"]
 = Configuring node pools for availability zones
 
-You can distribute node pools across multiple {rh-openstack-first} Nova availability zones to improve the high availability of your hosted cluster.
+[role="_abstract"]
+To improve the high availability of your hosted cluster, you can distribute node pools across multiple {rh-openstack-first} Nova availability zones.
 
-NOTE: Availability zones do not necessarily correspond to fault domains and do not inherently provide high availability benefits.
+[NOTE]
+====
+Availability zones do not necessarily correspond to fault domains and do not inherently provide high availability benefits.
+====
 
 .Prerequisites
 
 * You created a hosted cluster.
 * You have access to the management cluster.
-* The `hcp` and `oc` CLIs are installed.
+* The `hcp` and `oc` command-line interfaces (CLIs) are installed.
 
 .Procedure
 

--- a/modules/hcp-openstack-accessing.adoc
+++ b/modules/hcp-openstack-accessing.adoc
@@ -6,16 +6,17 @@
 [id="hcp-openstack-accessing_{context}"]
 = Accessing the hosted cluster
 
+[role="_abstract"]
 You can access hosted clusters on {rh-openstack-first} by extracting the kubeconfig secret directly from resources by using the `oc` CLI.
 
-The _hosted cluster (hosting)_ namespace contains hosted cluster resources and the access secrets. The _hosted control plane_ namespace is where the hosted control plane runs.
+The _hosted cluster (hosting)_ namespace has hosted cluster resources and the access secrets. The _hosted control plane_ namespace is where the hosted control plane runs.
 
 The secret name formats are as follows:
 
 ** `kubeconfig` secret: `<hosted_cluster_namespace>-<name>-admin-kubeconfig`. For example, `clusters-hypershift-demo-admin-kubeconfig`.
 ** `kubeadmin` password secret: `<hosted_cluster_namespace>-<name>-kubeadmin-password`. For example, `clusters-hypershift-demo-kubeadmin-password`.
 
-The `kubeconfig` secret contains a Base64-encoded `kubeconfig` field. The `kubeadmin` password secret is also Base64-encoded; you can extract it and then use the password to log in to the API server or console of the hosted cluster.
+The `kubeconfig` secret has a Base64-encoded `kubeconfig` field. The `kubeadmin` password secret is also Base64-encoded; you can extract it and then use the password to log in to the API server or console of the hosted cluster.
 
 .Prerequisites
 

--- a/modules/hcp-openstack-autoscale.adoc
+++ b/modules/hcp-openstack-autoscale.adoc
@@ -6,6 +6,7 @@
 [id="hcp-openstack-autoscale_{context}"]
 = Enabling node auto-scaling for the hosted cluster
 
+[role="_abstract"]
 When you need more capacity in your hosted cluster on {rh-openstack-first} and spare agents are available, you can enable auto-scaling to install new worker nodes.
 
 .Procedure
@@ -21,7 +22,7 @@ $ oc -n <hosted_cluster_namespace> patch nodepool <hosted_cluster_name> \
 
 . Create a workload that requires a new node.
 
-.. Create a YAML file that contains the workload configuration, by using the following example:
+.. Create a YAML file that has the workload configuration, by using the following example:
 +
 [source,yaml]
 ----


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.20+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://redhat.atlassian.net/browse/OSDOCS-20481
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
- Accessing the hosted cluster: https://114678--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-manage/hcp-manage-openstack.html#hcp-openstack-accessing_hcp-manage-openstack
- Enabling node autoscaling: https://114678--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-manage/hcp-manage-openstack.html#hcp-openstack-autoscale_hcp-manage-openstack
- Configuring node pools for availability zones: https://114678--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-manage/hcp-manage-openstack.html#hcp-manage-openstack-az_hcp-manage-openstack
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
N/A no technical changes
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: Do not merge until https://github.com/openshift/openshift-docs/pull/114577 and https://github.com/openshift/openshift-docs/pull/114579 are merged
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
