### PR TITLE
CNV#78225: VMFR for virt (claude-based)

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -3843,8 +3843,6 @@ Topics:
       File: oadp-vmfr
     - Name: Using OADP VMFR
       File: oadp-using-vmfr
-    - Name: OADP VMFR end-to-end workflow
-      File: oadp-vmfr-end-to-end
   - Name: OADP VMDP
     Dir: oadp-vmdp
     Topics:
@@ -5110,6 +5108,10 @@ Topics:
     File: virt-backup-restore-snapshots
   - Name: Backing up and restoring virtual machines
     File: virt-backup-restore-overview
+  - Name: Recover individual files from virtual machine backups
+    File: virt-recovering-individual-files-from-vm-backups
+  - Name: Use virtual machine file restore
+    File: virt-using-vm-file-restore
   - Name: Disaster recovery
     File: virt-disaster-recovery
 #  - Name: Collecting OKD Virtualization data for community report

--- a/modules/oadp-vmfr-access-methods.adoc
+++ b/modules/oadp-vmfr-access-methods.adoc
@@ -1,6 +1,7 @@
 // Module included in the following assemblies:
 //
 // backup_and_restore/application_backup_and_restore/oadp-vmfr/oadp-vmfr.adoc
+// virt/backup_restore/virt-recovering-individual-files-from-vm-backups.adoc
 
 :_mod-docs-content-type: CONCEPT
 [id="oadp-vmfr-access-methods_{context}"]
@@ -33,5 +34,5 @@ SSH access uses the following defaults:
 
 * Default username: `oadp`
 * Default port: `2222`
-* Remote path format: `/restores/_<date>_/_<backup_name>_/_<vm_name>_/_<path_to_fi
+* Remote path format: `/restores/<date>/<backup_name>/<vm_name>/<path_to_file>`
 * SSH access uses key-based authentication only. Password-based logins are not supported.

--- a/modules/oadp-vmfr-accessing-files-ssh.adoc
+++ b/modules/oadp-vmfr-accessing-files-ssh.adoc
@@ -1,10 +1,11 @@
 // Module included in the following assemblies:
 //
 // backup_and_restore/application_backup_and_restore/oadp-vmfr/oadp-using-vmfr.adoc
+// virt/backup_restore/virt-using-vm-file-restore.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="oadp-vmfr-accessing-files-ssh_{context}"]
-= Accessing restored files through SSH
+= Access restored files through SSH
 
 [role="_abstract"]
 Access restored virtual machine (VM) files through SSH by using `rsync`, `scp`, or `sftp` with the `VirtualMachineFileRestore` (VMFR) custom resource (CR). You can transfer files from VM backups efficiently.

--- a/modules/oadp-vmfr-accessing-files-web.adoc
+++ b/modules/oadp-vmfr-accessing-files-web.adoc
@@ -1,10 +1,11 @@
 // Module included in the following assemblies:
 //
 // backup_and_restore/application_backup_and_restore/oadp-vmfr/oadp-using-vmfr.adoc
+// virt/backup_restore/virt-using-vm-file-restore.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="oadp-vmfr-accessing-files-web_{context}"]
-= Accessing restored files through a web browser
+= Access restored files through a web browser
 
 [role="_abstract"]
 Access restored virtual machine (VM) files through a web browser by using the file browser interface provided by the `VirtualMachineFileRestore` (VMFR) custom resource (CR). You can browse, preview, and download files from VM backups.

--- a/modules/oadp-vmfr-creating-vmbd.adoc
+++ b/modules/oadp-vmfr-creating-vmbd.adoc
@@ -1,10 +1,11 @@
 // Module included in the following assemblies:
 //
 // backup_and_restore/application_backup_and_restore/oadp-vmfr/oadp-using-vmfr.adoc
+// virt/backup_restore/virt-using-vm-file-restore.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="oadp-vmfr-creating-vmbd_{context}"]
-= Creating a VirtualMachineBackupsDiscovery CR
+= Create a VirtualMachineBackupsDiscovery CR
 
 [role="_abstract"]
 Create a `VirtualMachineBackupsDiscovery` (VMBD) custom resource (CR) to identify which Velero backups contain a specified virtual machine (VM). You can locate available backups before performing a file-level restore.
@@ -25,7 +26,7 @@ Create all VMFR custom resources in the protected namespace, which is `openshift
 * You are logged in to the cluster with the `cluster-admin` role.
 * You have installed the {oadp-short} Operator.
 * You have configured the `DataProtectionApplication` (DPA) CR with the VMFR feature enabled.
-* You have existing Velero backups that contain `kubevirt` virtual machine data.
+* You have existing Velero backups that contain virtual machine data.
 
 .Procedure
 

--- a/modules/oadp-vmfr-creating-vmfr.adoc
+++ b/modules/oadp-vmfr-creating-vmfr.adoc
@@ -1,10 +1,11 @@
 // Module included in the following assemblies:
 //
 // backup_and_restore/application_backup_and_restore/oadp-vmfr/oadp-using-vmfr.adoc
+// virt/backup_restore/virt-using-vm-file-restore.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="oadp-vmfr-creating-vmfr_{context}"]
-= Creating a VirtualMachineFileRestore CR
+= Create a VirtualMachineFileRestore CR
 
 [role="_abstract"]
 Create a `VirtualMachineFileRestore` (VMFR) custom resource (CR) to make files from discovered virtual machine (VM) backups accessible for browsing and downloading. You can recover individual files without restoring the entire VM.

--- a/modules/oadp-vmfr-custom-resources.adoc
+++ b/modules/oadp-vmfr-custom-resources.adoc
@@ -1,13 +1,14 @@
 // Module included in the following assemblies:
 //
 // backup_and_restore/application_backup_and_restore/oadp-vmfr/oadp-vmfr.adoc
+// virt/backup_restore/virt-recovering-individual-files-from-vm-backups.adoc
 
 :_mod-docs-content-type: REFERENCE
 [id="oadp-vmfr-custom-resources_{context}"]
 = {oadp-short} VMFR custom resources
 
 [role="_abstract"]
-Use {oadp-short} virtual machine file restore (VMFR) custom resources to discover VM backups and restore individual files from those backups. You can perform file-level recovery for `kubevirt` VMs.
+Use {oadp-short} virtual machine file restore (VMFR) custom resources to discover VM backups and restore individual files from those backups.
 
 The {oadp-short} VMFR feature uses the following custom resources (CRs) to perform file-level restore operations:
 

--- a/modules/oadp-vmfr-deleting-vmfr.adoc
+++ b/modules/oadp-vmfr-deleting-vmfr.adoc
@@ -1,10 +1,11 @@
 // Module included in the following assemblies:
 //
 // backup_and_restore/application_backup_and_restore/oadp-vmfr/oadp-using-vmfr.adoc
+// virt/backup_restore/virt-using-vm-file-restore.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="oadp-vmfr-deleting-vmfr_{context}"]
-= Deleting a VirtualMachineFileRestore CR
+= Delete a VirtualMachineFileRestore CR
 
 [role="_abstract"]
 Delete a `VirtualMachineFileRestore` (VMFR) custom resource (CR) to clean up file-serving resources after you have recovered the files you need. This helps you free cluster resources used by the file-serving pod and temporary namespace.

--- a/modules/oadp-vmfr-enabling.adoc
+++ b/modules/oadp-vmfr-enabling.adoc
@@ -1,10 +1,11 @@
 // Module included in the following assemblies:
 //
 // backup_and_restore/application_backup_and_restore/oadp-vmfr/oadp-using-vmfr.adoc
+// virt/backup_restore/virt-using-vm-file-restore.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="oadp-vmfr-enabling_{context}"]
-= Enabling {oadp-short} VMFR
+= Enable {oadp-short} VMFR
 
 [role="_abstract"]
 Enable {oadp-short} virtual machine file restore (VMFR) by configuring the `DataProtectionApplication` (DPA) custom resource (CR) with the `vmFileRestore` section. You can allow file-level restore operations for VM backups.

--- a/modules/oadp-vmfr-end-to-end-workflow.adoc
+++ b/modules/oadp-vmfr-end-to-end-workflow.adoc
@@ -1,12 +1,14 @@
-:_mod-docs-content-type: PROCEDURE
-include::_attributes/common-attributes.adoc[]
+// Module included in the following assemblies:
+//
+// backup_and_restore/application_backup_and_restore/oadp-vmfr/oadp-using-vmfr.adoc
+// virt/backup_restore/virt-using-vm-file-restore.adoc
 
-[id="oadp-vmfr-end-to-end"]
-= Recovering files from a virtual machine backup
-:context: oadp-vmfr-end-to-end
+:_mod-docs-content-type: PROCEDURE
+[id="oadp-vmfr-end-to-end-workflow_{context}"]
+= Test the VM file restore workflow
 
 [role="_abstract"]
-Recover files from a virtual machine (VM) backup by creating a backup, discovering which backups contain the target VM, and restoring individual files through SSH. Complete this end-to-end {oadp-short} VM file restore (VMFR) workflow to quickly regain access to your data.
+Complete an end-to-end workflow that creates a VM, backs it up, and restores individual files through SSH to test the VM file restore feature or verify your configuration.
 
 .Prerequisites
 

--- a/modules/oadp-vmfr-how-it-works.adoc
+++ b/modules/oadp-vmfr-how-it-works.adoc
@@ -1,6 +1,7 @@
 // Module included in the following assemblies:
 //
 // backup_and_restore/application_backup_and_restore/oadp-vmfr/oadp-vmfr.adoc
+// virt/backup_restore/virt-recovering-individual-files-from-vm-backups.adoc
 
 :_mod-docs-content-type: CONCEPT
 [id="oadp-vmfr-how-it-works_{context}"]

--- a/modules/oadp-vmfr-limitations.adoc
+++ b/modules/oadp-vmfr-limitations.adoc
@@ -1,6 +1,7 @@
 // Module included in the following assemblies:
 //
 // backup_and_restore/application_backup_and_restore/oadp-vmfr/oadp-vmfr.adoc
+// virt/backup_restore/virt-recovering-individual-files-from-vm-backups.adoc
 
 :_mod-docs-content-type: CONCEPT
 [id="oadp-vmfr-limitations_{context}"]
@@ -11,7 +12,7 @@ Review the limitations of {oadp-short} virtual machine file restore (VMFR) to un
 
 The following limitations apply to {oadp-short} VMFR:
 
-* VMFR supports only `kubevirt` VM backups created by {oadp-short} with the `kubevirt` Velero plugin. Backups created without this plugin are not supported.
+* VMFR supports only VM backups created by {oadp-short} with the `kubevirt` Velero plugin. Backups created without this plugin are not supported.
 
 * Restored files are mounted as read-only. You cannot modify files directly in the backup.
 

--- a/modules/oadp-vmfr-overview.adoc
+++ b/modules/oadp-vmfr-overview.adoc
@@ -1,13 +1,14 @@
 // Module included in the following assemblies:
 //
 // backup_and_restore/application_backup_and_restore/oadp-vmfr/oadp-vmfr.adoc
+// virt/backup_restore/virt-recovering-individual-files-from-vm-backups.adoc
 
 :_mod-docs-content-type: CONCEPT
 [id="oadp-vmfr-overview_{context}"]
 = What problem is {oadp-short} VMFR solving
 
 [role="_abstract"]
-Recover individual files from `kubevirt` virtual machine (VM) backups without restoring the entire VM. You can browse multiple backups simultaneously and retrieve only the files you need through standard tools such as a web browser or `rsync`.
+Recover individual files from virtual machine (VM) backups without restoring the entire VM. Browse multiple backups simultaneously and retrieve only the files you need through standard tools such as a web browser or `rsync`.
 
 Current VM backup recovery workflows require you to restore an entire virtual machine to access a single file. This uses substantial cluster resources and time. The virtual machine file restore (VMFR) feature addresses this problem by providing a Kubernetes-native mechanism for file-level recovery from VM backups created by {oadp-short}.
 

--- a/modules/oadp-vmfr-phases.adoc
+++ b/modules/oadp-vmfr-phases.adoc
@@ -1,6 +1,7 @@
 // Module included in the following assemblies:
 //
 // backup_and_restore/application_backup_and_restore/oadp-vmfr/oadp-vmfr.adoc
+// virt/backup_restore/virt-recovering-individual-files-from-vm-backups.adoc
 
 :_mod-docs-content-type: REFERENCE
 [id="oadp-vmfr-phases_{context}"]

--- a/modules/oadp-vmfr-prerequisites.adoc
+++ b/modules/oadp-vmfr-prerequisites.adoc
@@ -1,6 +1,7 @@
 // Module included in the following assemblies:
 //
 // backup_and_restore/application_backup_and_restore/oadp-vmfr/oadp-vmfr.adoc
+// virt/backup_restore/virt-recovering-individual-files-from-vm-backups.adoc
 
 :_mod-docs-content-type: CONCEPT
 [id="oadp-vmfr-prerequisites_{context}"]
@@ -11,7 +12,7 @@ Configure your cluster environment to enable {oadp-short} virtual machine file r
 
 * You have installed the {oadp-short} Operator.
 * You have configured the `DataProtectionApplication` (DPA) CR with the `vmFileRestore.enable` field set to `true`.
-* The DPA CR includes the `kubevirt` plugin in the `defaultPlugins` list.
+* The DPA CR includes the `kubevirt` Velero plugin in the `defaultPlugins` list.
 * {VirtProductName} is installed and running on the cluster.
 * You have a default storage class configured on the cluster.
-* You have existing Velero backups that contain `kubevirt` virtual machine data.
+* You have existing Velero backups that contain virtual machine data.

--- a/modules/oadp-vmfr-security.adoc
+++ b/modules/oadp-vmfr-security.adoc
@@ -1,6 +1,7 @@
 // Module included in the following assemblies:
 //
 // backup_and_restore/application_backup_and_restore/oadp-vmfr/oadp-vmfr.adoc
+// virt/backup_restore/virt-recovering-individual-files-from-vm-backups.adoc
 
 :_mod-docs-content-type: CONCEPT
 [id="oadp-vmfr-security_{context}"]

--- a/modules/oadp-vmfr-use-scenarios.adoc
+++ b/modules/oadp-vmfr-use-scenarios.adoc
@@ -1,6 +1,7 @@
 // Module included in the following assemblies:
 //
 // backup_and_restore/application_backup_and_restore/oadp-vmfr/oadp-vmfr.adoc
+// virt/backup_restore/virt-recovering-individual-files-from-vm-backups.adoc
 
 :_mod-docs-content-type: CONCEPT
 [id="oadp-vmfr-use-scenarios_{context}"]

--- a/virt/backup_restore/virt-recovering-individual-files-from-vm-backups.adoc
+++ b/virt/backup_restore/virt-recovering-individual-files-from-vm-backups.adoc
@@ -1,9 +1,9 @@
 :_mod-docs-content-type: ASSEMBLY
 include::_attributes/common-attributes.adoc[]
 
-[id="oadp-vmfr"]
-= {oadp-short} virtual machine file restore
-:context: oadp-vmfr
+[id="virt-recovering-individual-files-from-vm-backups"]
+= Recover individual files from virtual machine backups
+:context: virt-recovering-individual-files-from-vm-backups
 
 toc::[]
 
@@ -27,3 +27,11 @@ include::modules/oadp-vmfr-limitations.adoc[leveloffset=+1]
 include::modules/oadp-vmfr-security.adoc[leveloffset=+1]
 
 include::modules/oadp-vmfr-phases.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+[id="additional-resources_{context}"]
+== Additional resources
+* xref:../../virt/backup_restore/virt-using-vm-file-restore.adoc#virt-using-vm-file-restore[Use virtual machine file restore]
+* xref:../../virt/backup_restore/virt-backup-restore-overview.adoc#virt-backup-restore-overview[Backing up and restoring virtual machines]
+* xref:../../virt/backup_restore/virt-backup-restore-snapshots.adoc#virt-backup-restore-snapshots[Backup and restore by using VM snapshots]
+* xref:../../backup_and_restore/application_backup_and_restore/oadp-intro.adoc#oadp-introduction[Introduction to {oadp-full}]

--- a/virt/backup_restore/virt-using-vm-file-restore.adoc
+++ b/virt/backup_restore/virt-using-vm-file-restore.adoc
@@ -1,15 +1,14 @@
 :_mod-docs-content-type: ASSEMBLY
 include::_attributes/common-attributes.adoc[]
 
-[id="oadp-configuring-using-vmfr"]
-= Configure and use {oadp-short} VMFR
-:context: oadp-using-vmfr
+[id="virt-using-vm-file-restore"]
+= Use virtual machine file restore
+:context: virt-using-vm-file-restore
 
 toc::[]
 
 [role="_abstract"]
 Discover VM backups, restore files, and access restored files through a web browser or SSH-based tools.
-
 
 include::modules/oadp-vmfr-enabling.adoc[leveloffset=+1]
 
@@ -24,3 +23,10 @@ include::modules/oadp-vmfr-accessing-files-ssh.adoc[leveloffset=+1]
 include::modules/oadp-vmfr-deleting-vmfr.adoc[leveloffset=+1]
 
 include::modules/oadp-vmfr-end-to-end-workflow.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+[id="additional-resources_{context}"]
+== Additional resources
+* xref:../../virt/backup_restore/virt-recovering-individual-files-from-vm-backups.adoc#virt-recovering-individual-files-from-vm-backups[Recover individual files from virtual machine backups]
+* xref:../../virt/backup_restore/virt-backup-restore-overview.adoc#virt-backup-restore-overview[Backing up and restoring virtual machines]
+* xref:../../backup_and_restore/application_backup_and_restore/oadp-intro.adoc#oadp-introduction[Introduction to {oadp-full}]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.22+, 5.0
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [cnv-78225](https://redhat.atlassian.net/browse/cnv-78225)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
- https://114691--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/oadp-vmfr/oadp-using-vmfr.html (OADP)
- https://114691--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/oadp-vmfr/oadp-vmfr.html (OADP)
- https://114691--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/backup_restore/virt-recovering-individual-files-from-vm-backups.html (CNV)
- https://114691--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/backup_restore/virt-using-vm-file-restore.html (CNV)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: This is a WIP; the first pass was entirely done by Claude Code with my instructions (_not_ docs-orchestrator -- I am trying to keep the changes in scope and not add content)

Edit: At this point I've done several passes with Claude and manually identified a couple of issues, namely that a procedure was included in the topic map directly (the end-to-end workflow). I had claude move it into the separate assemblies. 

Deferred/out of scope: consolidating the end-to-end workflow steps; differentiating the content from the OADP content. There's a lot of good stuff here that is useful.
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
