### PR TITLE
OSDOCS-20487:Update the z-stream RNs for 4.22.4

### DIFF
--- a/modules/zstream-4-22-4.adoc
+++ b/modules/zstream-4-22-4.adoc
@@ -1,0 +1,53 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-22-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-22-4_{context}"]
+= RHSA-2026:34794 - {product-title} {product-version}.4 bug fix and security update
+
+Issued: 07 July 2026
+
+[role="_abstract"]
+{product-title} release {product-version}.4 is now available. The list of fixed issues that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2026:34794[RHSA-2026:34794] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2026:34789[RHSA-2026:34789] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.22.4 --pullspecs
+----
+
+[id="zstream-4-22-4-fixed-issues_{context}"]
+== Fixed issues
+
+* Before this update, Role Based Access Control (RBAC) permissions were insufficient for the Secrets Store CSI driver in the Control Plane Operator on the management cluster. As a consequence, users could not create hosted clusters with the Secrets Store CSI driver and the Control Plane Operator on versions later than 4.19.19. With this release, the Control Plane Operator now checks the accessibility of resource types before creation, granting access to the Secrets Store CSI driver and enabling successful hosted cluster creation. (link:https://redhat.atlassian.net/browse/OCPBUGS-65687[OCPBUGS-65687])
+
+* Before this update, a transient failure to attach or detach a persistent volume to a node sometimes occurred. As a consequence, the Machine API Operator incorrectly marked the Machine as permanently failed. With this release, the Machine API provider for {azure-first} does not misinterpret the failure of any asynchronous operation on an {azure-short} VM as a failure to provision the VM. As a result, the failure of a volume attach or a volume detach does not affect the status of the Machine object. (link:https://issues.redhat.com/browse/OCPBUGS-86996[OCPBUGS-86996])
+
+* Before this update, changes to the `tlsAdherence` feature, such as  `""` -> `StrictAllComponents`, would not trigger a Cluster Baremetal Operator (CBO) restart. As a consequence, the Operator would run with a stale TLS (Transport Layer Security) configuration. With this release, the `controller-runtime-common` resource is updated to watch both the `tlsAdherence` field and the TLS security profile on the API Server custom resource (CR) in the Security Profile Watcher. As a result, changes to the `tlsAdherence` feature triggers a CBO restart as expected. (link:https://issues.redhat.com/browse/OCPBUGS-87212[OCPBUGS-87212])
+
+* Before this update, the Hosted Cluster Config Operator would crash loop on an uncustomized Kubernetes cluster because the Operator was unconditionally attempting to watch the {product-title} Route resource. With this release, the Operator attempts to watch the resource only when it exists on the management cluster. As a result, the Operator is no longer crash looping on an uncustomized Kubernetes cluster. (link:https://issues.redhat.com/browse/OCPBUGS-87364[OCPBUGS-87364])
+
+* Before this update, the `kube-apiserver-to-kubelet` client signer certificate was being refreshed every 30 days despite having a 365-day validity period. With this release, the refresh interval is corrected to 292 days, 80% of validity, which is consistent with other signers. As a result, certificate rotations are prevented and the signer behavior is aligned with the intended configuration. (link:https://issues.redhat.com/browse/OCPBUGS-87844[OCPBUGS-87844])
+
+* Before this update, deleting a BareMetalHost (BMH) that referenced a pre-provisioning network data Secret through the `spec.preprovisioningNetworkDataName` parameter could report a `RegistrationError` if the Secret was removed before the BMH finished deleting. As a consequence, the BMH deletion would take minutes to complete before an eventual force-delete by the controller. With this enhancement, the Bare Metal Operator (BMO) manages the lifecycle of that Secret in the same way as the BMC credential Secrets. The BMO now protects the Secret using a finalizer while the host is active, which prevents the Secret deletion until the finalizer is removed by the controller. As a result, the BMH is removed successfully before the Secret is allowed to be deleted.  (link:https://issues.redhat.com/browse/OCPBUGS-87963[OCPBUGS-87963])
+
+* Before this update, in vSphere installer-provisioned infrastructure clusters using static IPs, the control plane machine set (CPMS) Operator was not copying the name server into the CPMS when the CPMS was deleted. As a consequence, the CPMS Operator would identify current masters as not valid and would identify the masters as needing to be recreated. With this release, the CPMS Operator logic is updated to copy the name server definition into the CPMS when the clusters used static IPs. As a result, the name server information is configured in the CPMS when recreating the CPMS cluster instance. (link:https://issues.redhat.com/browse/OCPBUGS-87968[OCPBUGS-87968])
+
+* Before this update, when generateRelease used the digest-only `ImageDigestMirrorSet` (IDMS) mode, images that were referenced as tag and digest, for example, nvcr.io/.../container-toolkit:v1.19.1@sha256:..., were treated as tag-only and excluded from IDMS generation. As a consequence, those images appeared only in the `ImageTagMirrorSet` (ITMS) mode. For disconnected installs that rely on IDMS for digest-based resolution, the mirroring install could fail for Operator-related images that were referenced as ITMS. With this release, updated `generateImageMirrors` objects are updated so that the tag and digest references are included in IDMS and ITMS. As a result, tag and digest images are written to both IDMS and ITMS. (link:https://issues.redhat.com/browse/OCPBUGS-88484[OCPBUGS-88484])
+
+* Before this update, the *Column Management* modal did not display the help text that informed you that the namespace column is shown only when you select *All projects*. With this release, the help text displays correctly. (link:https://issues.redhat.com/browse/OCPBUGS-90110[OCPBUGS-90110])
+
+* Before this update, the Ingress Node Firewall Operator used the `reflect.DeepEqual` parameter for node label comparison which required an exact label match instead of Kubernetes label selector semantics. As a consequence, the `IngressNodeFirewallNodeState` objects that were not created for nodes were added after the Ingress Node Firewall  Operator startup. With this release, the `reflect.DeepEqual` parameter is replaced with the `labels.SelectorFromSet().Matches()` parameter for correct Kubernetes label selector matching. As a result, the Ingress Node Firewall Operator correctly creates the `IngressNodeFirewallNodeState` parameter for dynamically added nodes and label changes. (link:https://issues.redhat.com/browse/OCPBUGS-90550[OCPBUGS-90550])
+
+* Before this update, the metrics-proxy scraper created a new HTTP client with a new `http.Transport` on an every 30-60-second scrape cycle without ever closing idle connections. The `http.Transport` for Go retained idle connections and their TLS buffers until `CloseIdleConnections` was explicitly called. As a consequence, idle connections and the TLS (Transport Layer Security) session state accumulated indefinitely across scrape cycles, which caused unbounded memory growth in metrics-proxy pods on request-serving nodes. Up to 2774Mi usage was observed against a 40Mi request, which triggered `RequestServingNodesNeedUpscale` alerts. With this release, the `DisableKeepAlives` parameter is set on the ephemeral transport to prevent connection pooling on single-use clients, and `CloseIdleConnections` is deferred as a safety net after each `ScrapeAll` call. As a result, the `metrics-proxy` memory usage remains stable over time within reasonable bounds. (link:https://issues.redhat.com/browse/OCPBUGS-90563[OCPBUGS-90563])
+
+* Before this update, the GatewayClass controller set up watches on the Operator Lifecycle Management (OLM) `Subscription` and `InstallPlan` resources without checking whether the `OperatorLifecycleManager` capability was enabled on the cluster. As a consequence, on clusters that did not have the OLM capability, the GatewayClass controller blocked indefinitely during startup because the OLM CRDs did not exist. This blocking prevented the controller reconcile workers from starting, making Gateway API non-functional on those clusters. With this release, the Subscription and InstallPlan watches in the GatewayClass controller are guarded with an `OperatorLifecycleManagerEnabled` check so that the watches are only registered when OLM is present. The status controller `subscriptionCache` creation is also guarded with the same check. As a result, the GatewayClass controller starts successfully on clusters without OLM, and Gateway API functions correctly on non-OLM clusters. (link:https://issues.redhat.com/browse/OCPBUGS-91967[OCPBUGS-91967])
+
+[id="zstream-4-22-4-updating_{context}"]
+== Updating
+
+To update an {product-title} 4.22 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].

--- a/release_notes/ocp-4-22-release-notes.adoc
+++ b/release_notes/ocp-4-22-release-notes.adoc
@@ -44,6 +44,9 @@ include::modules/rn-ocp-release-notes-known-issues.adoc[leveloffset=+1]
 // Asynchronous errata updates
 include::modules/rn-ocp-release-notes-async-errata-updates.adoc[leveloffset=+1]
 
+// 4.22.4 RNs and updating
+include::modules/zstream-4-22-4.adoc[leveloffset=+2]
+
 // 4.22.2 RNs and updating
 include::modules/zstream-4-22-2.adoc[leveloffset=+2]
 


### PR DESCRIPTION
Version(s):
4.22

Issue:
https://redhat.atlassian.net/browse/OSDOCS-20487

Link to docs preview:
https://114695--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-22-release-notes.html#zstream-4-22-4_release-notes

Additional information:
4.22.4 MR: https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/628
ART Dashboard: https://art-dash.engineering.redhat.com/dashboard/release/openshift-4.22?page=1