### PR TITLE
TELCODOCS-2922: Fix typo vcio_pci -> vfio_pci in Telco RAN Node Tuning Operator docs

### DIFF
--- a/modules/telco-ran-node-tuning-operator.adoc
+++ b/modules/telco-ran-node-tuning-operator.adoc
@@ -64,7 +64,7 @@ To ensure that pods with guaranteed whole CPU QoS have full use of allocated CPU
 * To enable workload partitioning, set `cpuPartitioningMode` to `AllNodes` during deployment, and then use the `PerformanceProfile` CR to allocate enough CPUs to support the operating system, interrupts, and {product-title} pods.
 * Tailor `systemReserved` memory for each cluster based on its size and application workload. The minimum recommended value is 11Gi.
 * Under x86_64, the `PerformanceProfile` may be customized with the following optional arguments in the `additionalKernelargs` list:
-** The `vcio_pci` arguments support devices such as the FEC accelerator. You can omit them if they are not required for your workload.
+** The `vfio_pci` arguments support devices such as the FEC accelerator. You can omit them if they are not required for your workload.
 ** To enable the `acpi_idle` CPUIdle driver, for example, for Intel FlexRAN, add `intel_idle.max_cstate=0`
 * Under aarch64, the `PerformanceProfile` must be adjusted depending on the needs of the platform:
 ** For Grace Hopper systems, the following kernel commandline arguments are required:


### PR DESCRIPTION
## Summary

- Fixes a typo in `modules/telco-ran-node-tuning-operator.adoc` where `vcio_pci` was incorrectly used instead of `vfio_pci`.
- The `vfio_pci` kernel module is used for VFIO PCI passthrough to support devices such as the FEC accelerator.
- This typo was introduced between 4.20 and 4.21 when the text was rewritten.

Jira: https://redhat.atlassian.net/browse/TELCODOCS-2922


Made with [Cursor](https://cursor.com)