### PR TITLE
OSDOCS-20579: Add 4.22.4 z-stream release notes

### DIFF
--- a/modules/zstream-4-22-4.adoc
+++ b/modules/zstream-4-22-4.adoc
@@ -1,0 +1,47 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-22-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-22-4_{context}"]
+= RHSA-2026:34794 - {product-title} {product-version}.4 bug fix and security update
+
+Issued: 7 July 2026
+
+[role="_abstract"]
+{product-title} release {product-version}.4 is now available. The list of fixed issues that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2026:34794[RHSA-2026:34794] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2026:34789[RHSA-2026:34789] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.22.4 --pullspecs
+----
+
+[id="zstream-4-22-4-fixed-issues_{context}"]
+== Fixed issues
+
+* Before this update, role-based access control (RBAC) permissions were insufficient for the Secrets Store CSI driver in the Control Plane Operator on the management cluster. As a consequence, users could not create hosted clusters with the Secrets Store CSI driver and the Control Plane Operator on versions later than 4.19.19. With this release, the Control Plane Operator now checks the accessibility of resource types before creation, granting access to the Secrets Store CSI driver and enabling successful hosted cluster creation. (link:https://issues.redhat.com/browse/OCPBUGS-65687[OCPBUGS-65687])
+
+* Before this update, changes to the `tlsAdherence` parameter, such as `""` -> `StrictAllComponents`, would not trigger a Cluster Baremetal Operator (CBO) restart. As a consequence, the Operator would run with a stale TLS (Transport Layer Security) configuration. With this release, the `controller-runtime-common` resource is updated to watch both the `tlsAdherence` field and the TLS security profile on the API Server custom resource (CR) in the Security Profile Watcher. As a result, changes to the `tlsAdherence` parameter triggers a CBO restart as expected. (link:https://issues.redhat.com/browse/OCPBUGS-87212[OCPBUGS-87212])
+
+* Before this update, the Hosted Cluster Config Operator would crash loop on an uncustomized Kubernetes cluster because the Operator was unconditionally attempting to watch the {product-title} Route resource. With this release, the Operator attempts to watch the resource only when it exists on the management cluster. As a result, the Operator is no longer crash looping on an uncustomized Kubernetes cluster. (link:https://issues.redhat.com/browse/OCPBUGS-87364[OCPBUGS-87364])
+
+* Before this update, in vSphere installer-provisioned infrastructure clusters using static IPs, the control plane machine set (CPMS) Operator was not copying the name server into the CPMS when the CPMS was deleted. As a consequence, the CPMS Operator would identify current masters as not valid and would identify the masters as needing to be recreated. With this release, the CPMS Operator logic is updated to copy the name server definition into the CPMS when the clusters used static IPs. As a result, the name server information is configured in the CPMS when recreating the CPMS cluster instance. (link:https://issues.redhat.com/browse/OCPBUGS-87968[OCPBUGS-87968])
+
+* Before this update, when the `generateRelease` parameter used the digest-only `ImageDigestMirrorSet` (IDMS) mode, images that were referenced as tag+digest, for example, nvcr.io/.../container-toolkit:v1.19.1@sha256:..., were treated as tag-only and excluded from IDMS generation. As a consequence, those images appeared only in the `ImageTagMirrorSet` (ITMS) mode. For disconnected installs that rely on IDMS for digest-based resolution, the mirroring install could fail for Operator-related images that were referenced as ITMS. With this release, updated generateImageMirrors objects are updated so that the tag+digest references are included in IDMS and ITMS. As a result, tag+digest images are written to both IDMS and ITMS. (link:https://issues.redhat.com/browse/OCPBUGS-88484[OCPBUGS-88484])
+
+* Before this update, the Column Management modal did not display the help text that informed you that the namespace column is shown only when you select All projects. With this release, the help text displays correctly. (link:https://issues.redhat.com/browse/OCPBUGS-90110[OCPBUGS-90110])
+
+* Before this update, the Operator used the `reflect.DeepEqual` parameter for node label comparison which required an exact label match instead of Kubernetes label selector semantics. As a consequence, the `IngressNodeFirewallNodeState` objects that were not created for nodes were added after the Operator startup. With this release, the `reflect.DeepEqual` parameter is replaced with the `labels.SelectorFromSet().Matches()` parameter for correct Kubernetes label selector matching. As a result, the Operator correctly creates the `IngressNodeFirewallNodeState` parameter for dynamically added nodes and label changes. (link:https://issues.redhat.com/browse/OCPBUGS-90550[OCPBUGS-90550])
+
+* Before this update, the metrics-proxy scraper created a new HTTP client with a new `http.Transport` on every 30-60-second scrape cycle without ever closing idle connections. The `http.Transport` for Go retained idle connections and their TLS buffers until `CloseIdleConnections` was explicitly called. As a consequence, idle connections and the TLS session state accumulated indefinitely across scrape cycles, which caused unbounded memory growth in metrics-proxy pods on request-serving nodes. Up to 2774Mi usage was observed against a 40Mi request, which triggered `RequestServingNodesNeedUpscale` alerts. With this release, the `DisableKeepAlives` parameter is set on the ephemeral Transport to prevent connection pooling on single-use clients, and `CloseIdleConnections` is deferred as a safety net after each `ScrapeAll` call. As a result, the `metrics-proxy` memory usage remains stable over time within reasonable bounds. (link:https://issues.redhat.com/browse/OCPBUGS-90563[OCPBUGS-90563])
+
+* Before this update, the GatewayClass controller set up watches on Operator Lifecycle Management (OLM) resources (Subscription and InstallPlan) without checking whether the `OperatorLifecycleManager` capability was enabled on the cluster. As a consequence, on clusters that did not have the OLM capability, the GatewayClass controller blocked indefinitely during startup because the OLM CRDs did not exist. This blocking prevented the controller reconcile workers from starting, making Gateway API non-functional on those clusters. With this release, the Subscription and InstallPlan watches in the GatewayClass controller are guarded with an `OperatorLifecycleManagerEnabled` check so that the watches are only registered when OLM is present. The status controller `subscriptionCache` creation is also guarded with the same check. As a result, the GatewayClass controller now starts successfully on clusters without OLM, and Gateway API functions correctly on non-OLM clusters. (link:https://issues.redhat.com/browse/OCPBUGS-91967[OCPBUGS-91967])
+
+[id="zstream-4-22-4-updating_{context}"]
+== Updating
+
+To update an {product-title} 4.22 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].

--- a/release_notes/ocp-4-22-release-notes.adoc
+++ b/release_notes/ocp-4-22-release-notes.adoc
@@ -44,6 +44,9 @@ include::modules/rn-ocp-release-notes-known-issues.adoc[leveloffset=+1]
 // Asynchronous errata updates
 include::modules/rn-ocp-release-notes-async-errata-updates.adoc[leveloffset=+1]
 
+// 4.22.4 RNs and updating
+include::modules/zstream-4-22-4.adoc[leveloffset=+2]
+
 // 4.22.2 RNs and updating
 include::modules/zstream-4-22-2.adoc[leveloffset=+2]
 


### PR DESCRIPTION
## Summary
- Adds z-stream release notes for OpenShift 4.22.4
- Jira: https://redhat.atlassian.net/browse/OSDOCS-20579
- Shipment MR: https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/628
- ART Dashboard: https://art-dash.engineering.redhat.com/dashboard/release/openshift-4.22
- Errata: RHSA-2026:34794 / RHSA-2026:34789 (RPM)

## Documented
- OCPBUGS-65687
- OCPBUGS-87212
- OCPBUGS-87364
- OCPBUGS-87968
- OCPBUGS-88484
- OCPBUGS-90110
- OCPBUGS-90550
- OCPBUGS-90563
- OCPBUGS-91967

## Skipped (not documented)
| Key | Reason |
|-----|--------|
| OCPBUGS-73886 | Release Note Not Required |
| OCPBUGS-78617 | Release Note Not Required |
| OCPBUGS-83633 | CVE-only |
| OCPBUGS-83942 | CVE-only |
| OCPBUGS-84392 | CVE-only |
| OCPBUGS-84436 | CVE-only |
| OCPBUGS-84679 | Release Note Not Required |
| OCPBUGS-86574 | Release Note Not Required |
| OCPBUGS-86807 | Release Note Not Required |
| OCPBUGS-86996 | Internal |
| OCPBUGS-87164 | Internal |
| OCPBUGS-87844 | Internal |
| OCPBUGS-87963 | Internal |
| OCPBUGS-88025 | Release Note Not Required |
| OCPBUGS-88026 | Release Note Not Required |
| OCPBUGS-88184 | Internal |
| OCPBUGS-88307 | Release Note Not Required |
| OCPBUGS-88314 | Release Note Not Required |
| OCPBUGS-88321 | Release Note Not Required |
| OCPBUGS-88356 | Release Note Not Required |
| OCPBUGS-88413 | CVE-only |
| OCPBUGS-88472 | Internal |
| OCPBUGS-88718 | Release Note Not Required |
| OCPBUGS-88723 | Release Note Not Required |
| OCPBUGS-88748 | CVE-only |
| OCPBUGS-89244 | Release Note Not Required |
| OCPBUGS-89320 | Release Note Not Required |
| OCPBUGS-89329 | Internal |
| OCPBUGS-89337 | Internal |
| OCPBUGS-90542 | Release Note Not Required |
| OCPBUGS-90638 | Internal |
| OCPBUGS-90721 | Release Note Not Required |
| OCPBUGS-91958 | Release Note Not Required |
| OCPBUGS-91982 | Release Note Not Required |
| OCPBUGS-92047 | Release Note Not Required |
| OCPBUGS-92056 | Release Note Not Required |
| OCPBUGS-92656 | Release Note Not Required |
| OCPBUGS-93565 | Internal |
| OCPBUGS-93787 | Internal |
| OCPBUGS-95171 | Internal |

## Scope notes
- Shipment YAML keys: 49
- Documented bug fixes: 9

## Test plan
- [x] Title and issued date match access.redhat.com (RHSA-2026:34794, issued 7 July 2026)
- [x] Primary + RPM advisory links correct
- [x] Vale clean on module (0 errors)


Made with [Cursor](https://cursor.com)