### PR TITLE
OSDOCS-20580: Add 4.21.23 z-stream release notes

### DIFF
--- a/modules/zstream-4-21-23.adoc
+++ b/modules/zstream-4-21-23.adoc
@@ -1,0 +1,39 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-21-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-21-23_{context}"]
+= RHSA-2026:34769 - {product-title} {product-version}.23 bug fix and security update
+
+Issued: 7 July 2026
+
+[role="_abstract"]
+{product-title} release {product-version}.23 is now available. The list of fixed issues that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2026:34769[RHSA-2026:34769] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2026:34759[RHBA-2026:34759] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.21.23 --pullspecs
+----
+
+[id="zstream-4-21-23-fixed-issues_{context}"]
+== Fixed issues
+
+* Before this update, enabling the Gateway API on a cluster would replace an existing OSSM subscription, which caused unexpected behavior on existing OSSM installations. With this release, when the Gateway API is enabled on a cluster, the cluster is used for installing components and the existing OSSM subscriptions are not replaced. (link:https://issues.redhat.com/browse/OCPBUGS-82146[OCPBUGS-82146])
+
+* Before this update, the Cluster Ingress Operator (CIO) depended on the Marketplace capability to install OSSM through OLM for the Gateway API. On clusters where the Marketplace capability was disabled, such as disconnected clusters that cannot reach external catalog sources, the CIO could not create or manage the OLM subscription and the Istio control plane never started. As a consequence, the Gateway API did not function on these clusters. When the GatewayClass was created, the `istiod-openshift-gateway` pod did not start. With this release, the OLM-based OSSM installation is replaced with the Sail Library, which installs Istio directly through embedded Helm charts. As a result, the dependency on the Marketplace capability is removed and the Gateway API works on disconnected clusters and other environments without the Marketplace capability, provided that the required container images are mirrored to an accessible registry. (link:https://issues.redhat.com/browse/OCPBUGS-85550[OCPBUGS-85550])
+
+* Before this update, the Cluster Ingress Operator (CIO) installed the OpenShift Service Mesh (OSSM) Operator through OLM to provide Gateway API support and pinned OSSM to a specific version using the `startingCSV` parameter and manual install plan approval. As a consequence, after the OSSM was already installed, the OLM ignored the `startingCSV` parameter and resolved upgrades to the channel head, which generated install plans that the CIO never approved because the version did not match. The OSSM z-stream upgrades were then blocked, which prevented CVE fixes from being delivered to clusters using the Gateway API. With this release, the OLM-based OSSM installation is replaced with the Sail Library, which installs Istio directly through embedded Helm charts. The dependency on OLM for the Gateway API is removed and clusters that are upgraded from the OLM-based path are automatically migrated to the Sail Library during the z-stream upgrade. As a result, OSSM and Istio version management is not blocked by OLM and the CVE fixes can be shipped. (link:https://issues.redhat.com/browse/OCPBUGS-88295[OCPBUGS-88295])
+
+* Before this update, when you clicked a status count, such as counts from error pods or not-ready nodes, from the Overview dashboard view, the resource list page opened without applying the expected filter. As a consequence, all resources were displayed instead of only the resources that matched the selected status. With this update, clicking a status count opens a filtered list page that shows only the matching resources. (link:https://issues.redhat.com/browse/OCPBUGS-90553[OCPBUGS-90553])
+
+* Before this update, during parallel deployments of Single Node {sno}, specifically with hypervisor-based {sno} clusters, some systems would hang in the middle of the deployment due to a race condition involving the BareMetalHost (BMH) custom resource. The {sno} cluster was never powered on by metal3 after virtual media was attached. As a consequence, parallel deployments at scale (10+ nodes) had approximately 80% success rate, with the remaining nodes requiring manual intervention to patch the `online` field to `true` for the impacted BMH custom resources. With this release, the race condition in the BMH power-on process has been resolved. As a result, parallel {sno} deployments successfully power on all nodes without manual intervention, even at scale. (link:https://issues.redhat.com/browse/OCPBUGS-90554[OCPBUGS-90554])
+
+[id="zstream-4-21-23-updating_{context}"]
+== Updating
+
+To update an {product-title} 4.21 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].

--- a/release_notes/ocp-4-21-release-notes.adoc
+++ b/release_notes/ocp-4-21-release-notes.adoc
@@ -44,6 +44,9 @@ include::modules/rn-ocp-release-notes-known-issues.adoc[leveloffset=+1]
 // Asynchronous errata updates
 include::modules/rn-async-errata.adoc[leveloffset=+1]
 
+// 4.21.23 RNs and updating
+include::modules/zstream-4-21-23.adoc[leveloffset=+2]
+
 // 4.21.22 RNs and updating
 include::modules/zstream-4-21-22.adoc[leveloffset=+2]
 


### PR DESCRIPTION
## Summary
- Adds z-stream release notes for OpenShift 4.21.23
- Jira: https://redhat.atlassian.net/browse/OSDOCS-20580
- Shipment MR: https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/626
- ART Dashboard: https://art-dash.engineering.redhat.com/dashboard/release/openshift-4.21
- Errata: RHSA-2026:34769 / RHBA-2026:34759 (RPM)

## Documented
- OCPBUGS-82146
- OCPBUGS-85550
- OCPBUGS-88295
- OCPBUGS-90553
- OCPBUGS-90554

## Skipped (not documented)
| Key | Reason |
|-----|--------|
| OCPBUGS-78330 | Internal |
| OCPBUGS-80813 | CVE-only |
| OCPBUGS-80831 | CVE-only |
| OCPBUGS-82900 | CVE-only |
| OCPBUGS-86806 | Release Note Not Required |
| OCPBUGS-87964 | Internal |
| OCPBUGS-88297 | Release Note Not Required |
| OCPBUGS-89328 | Release Note Not Required |
| OCPBUGS-91734 | Internal |
| OCPBUGS-92012 | Internal |
| OCPBUGS-93937 | Release Note Not Required |
| OCPBUGS-95170 | Internal |

## Scope notes
- Shipment YAML keys: 17
- Documented bug fixes: 5

## Test plan
- [x] Title and issued date match access.redhat.com (RHSA-2026:34769, issued 7 July 2026)
- [x] Primary + RPM advisory links correct
- [x] Vale clean on module (0 errors)


Made with [Cursor](https://cursor.com)