### PR TITLE
OSDOCS-20584: Add 4.18.47 z-stream release notes

### DIFF
--- a/modules/zstream-4-18-47.adoc
+++ b/modules/zstream-4-18-47.adoc
@@ -1,0 +1,31 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-18-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-18-47_{context}"]
+= RHBA-2026:34816 - {product-title} {product-version}.47 bug fix update
+
+Issued: 8 July 2026
+
+[role="_abstract"]
+{product-title} release {product-version}.47 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2026:34816[RHBA-2026:34816] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2026:34814[RHBA-2026:34814] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.18.47 --pullspecs
+----
+
+[id="zstream-4-18-47-fixed-issues_{context}"]
+== Fixed issues
+
+There are no notable fixed issues in this release.
+
+[id="zstream-4-18-47-updating_{context}"]
+== Updating
+
+To update an {product-title} 4.18 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].

--- a/release_notes/ocp-4-18-release-notes.adoc
+++ b/release_notes/ocp-4-18-release-notes.adoc
@@ -3064,6 +3064,9 @@ As a workaround, you must manually reboot the failed host from the disk. (link:h
 // 4.18 about async
 include::modules/rn-async-errata.adoc[leveloffset=+1]
 
+// 4.18.47 RNs and updating
+include::modules/zstream-4-18-47.adoc[leveloffset=+2]
+
 // 4.18.46 RNs and updating
 include::modules/zstream-4-18-46.adoc[leveloffset=+2]
 


### PR DESCRIPTION
## Summary
- Adds z-stream release notes for OpenShift 4.18.47
- Jira: https://redhat.atlassian.net/browse/OSDOCS-20584
- Shipment MR: https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/629
- ART Dashboard: https://art-dash.engineering.redhat.com/dashboard/release/openshift-4.18
- Errata: RHBA-2026:34816 / RHBA-2026:34814 (not yet published on access.redhat.com; draft PR)

## Documented
- Advisory-only release (no documentable bug bullets)

## Skipped (not documented)
| Key | Reason |
|-----|--------|
| OCPBUGS-94075 | Release Note Not Required |
| OCPBUGS-95084 | Release Note Not Required |

## Scope notes
- Shipment YAML keys: 2
- Errata Fixes keys: N/A (errata not yet published)
- All shipment YAML keys skipped (RN-NR)

## Test plan
- [ ] Title and issued date match access.redhat.com when errata publishes
- [ ] Primary + RPM advisory links correct
- [ ] Vale clean on touched files


Made with [Cursor](https://cursor.com)