### PR TITLE
OSDOCS-20585: Add 4.19.37 z-stream release notes

### DIFF
--- a/modules/zstream-4-19-37.adoc
+++ b/modules/zstream-4-19-37.adoc
@@ -1,0 +1,32 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-19-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-19-37_{context}"]
+= RHSA-2026:34766 - {product-title} {product-version}.37 bug fix and security update
+
+Issued: 8 July 2026
+
+[role="_abstract"]
+{product-title} release {product-version}.37 is now available. The list of fixed issues that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2026:34766[RHSA-2026:34766] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2026:34755[RHSA-2026:34755] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.19.37 --pullspecs
+----
+
+[id="zstream-4-19-37-fixed-issues_{context}"]
+== Fixed issues
+
+There are no notable fixed issues in this release.
+
+[id="zstream-4-19-37-updating_{context}"]
+== Updating
+
+To update an {product-title} 4.19 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+

--- a/release_notes/ocp-4-19-release-notes.adoc
+++ b/release_notes/ocp-4-19-release-notes.adoc
@@ -2977,6 +2977,9 @@ To save the `vmcore` file, use the `crashkernel` setting to reserve 1024 MB of m
 // 4.19.z about errata updates
 include::modules/ocp-release-asynch-errata-updates.adoc[leveloffset=+1]
 
+// 4.19.37 z-stream RNs full document
+include::modules/zstream-4-19-37.adoc[leveloffset=+2]
+
 // 4.19.35 z-stream RNs full document
 include::modules/zstream-4-19-35.adoc[leveloffset=+2]
 


### PR DESCRIPTION
## Summary
- Adds z-stream release notes for OpenShift 4.19.37 (advisory-only; no documentable bug bullets)
- Jira: https://redhat.atlassian.net/browse/OSDOCS-20585
- Shipment MR: https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/625
- ART Dashboard: https://art-dash.engineering.redhat.com/dashboard/release/openshift-4.19
- Errata: RHSA-2026:34766 / RHSA-2026:34755

## Documented
- None (advisory-only)

## Skipped (not documented)
| Key | Reason |
|-----|--------|
| OCPBUGS-82806 | CVE-only / Internal / Release Note Not Required |
| OCPBUGS-82814 | CVE-only / Internal / Release Note Not Required |
| OCPBUGS-87084 | CVE-only / Internal / Release Note Not Required |
| OCPBUGS-87808 | Release Note Not Required |
| OCPBUGS-88424 | CVE-only / Internal / Release Note Not Required |
| OCPBUGS-88435 | CVE-only / Internal / Release Note Not Required |
| OCPBUGS-88436 | CVE-only / Internal / Release Note Not Required |
| OCPBUGS-90623 | Incomplete Bug Fix RN (missing before/after CCFR clauses) |
| OCPBUGS-94046 | Internal / Invalid RN type / Release Note Not Required |

## Scope notes
- Shipment YAML keys: 9
- Errata Fixes keys: 9 (same OCPBUGS keys plus Bugzilla IDs)
- Errata not yet live on access.redhat.com at draft time; issued date set from shipment ship date (8 July 2026)

## Test plan
- [ ] Title and issued date match access.redhat.com when errata publishes
- [ ] Primary + RPM advisory links correct
- [ ] Vale clean on touched files


Made with [Cursor](https://cursor.com)