### PR TITLE
OSDOCS-20588: Add 4.20.28 z-stream release notes

### DIFF
--- a/modules/zstream-4-20-28.adoc
+++ b/modules/zstream-4-20-28.adoc
@@ -1,0 +1,31 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-20-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-20-28_{context}"]
+= RHSA-2026:34791 - {product-title} {product-version}.28 bug fix and security update
+
+Issued: 7 July 2026
+
+[role="_abstract"]
+{product-title} release {product-version}.28 is now available. The list of fixed issues that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2026:34791[RHSA-2026:34791] advisory. There are no RPM packages for this release.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.20.28 --pullspecs
+----
+
+[id="zstream-4-20-28-fixed-issues_{context}"]
+== Fixed issues
+
+There are no notable fixed issues in this release.
+
+[id="zstream-4-20-28-updating_{context}"]
+== Updating
+
+To update an {product-title} 4.20 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].

--- a/release_notes/ocp-4-20-release-notes.adoc
+++ b/release_notes/ocp-4-20-release-notes.adoc
@@ -3021,6 +3021,9 @@ In both cases, the installation program generates a user-assigned identity. (lin
 
 include::modules/rn-async-errata.adoc[leveloffset=+1]
 
+// 4.20.28 release notes
+include::modules/zstream-4-20-28.adoc[leveloffset=+2]
+
 // 4.20.27 release notes
 include::modules/zstream-4-20-27.adoc[leveloffset=+2]
 


### PR DESCRIPTION
## Summary
- Adds z-stream release notes for OpenShift 4.20.28 (advisory-only)
- Jira: https://redhat.atlassian.net/browse/OSDOCS-20588
- Shipment MR: https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/627 (open)
- ART Dashboard: https://art-dash.engineering.redhat.com/dashboard/release/openshift-4.20
- Errata: RHSA-2026:34791 / RHBA-2026:34787 (RPM)

## Documented
- _(none — advisory-only release)_

## Skipped (not documented)
| Key | Reason |
|-----|--------|
| OCPBUGS-74908 | Release Note Not Required |
| OCPBUGS-82295 | Internal |
| OCPBUGS-82854 | CVE-only |
| OCPBUGS-86020 | Incomplete Bug Fix RN |
| OCPBUGS-86455 | CVE-only |
| OCPBUGS-86552 | Internal |
| OCPBUGS-86567 | Release Note Not Required |
| OCPBUGS-86846 | Release Note Not Required |
| OCPBUGS-88360 | Incomplete Bug Fix RN |
| OCPBUGS-90559 | Incomplete Bug Fix RN |
| OCPBUGS-90598 | Incomplete Bug Fix RN |
| OCPBUGS-90969 | Release Note Not Required |
| OCPBUGS-91635 | Incomplete Bug Fix RN |
| OCPBUGS-92043 | Release Note Not Required |
| OCPBUGS-92044 | Internal |
| OCPBUGS-92045 | Internal |
| OCPBUGS-93748 | Internal |
| OCPBUGS-95086 | Internal |

## Scope notes
- Shipment YAML keys: 18
- Documented bug fixes: 0

## Test plan
- [x] Title and issued date match errata (RHSA-2026:34791, issued 7 July 2026)
- [x] Primary + RPM advisory links correct
- [x] Vale clean on module (0 errors)

Made with [Cursor](https://cursor.com)