### PR TITLE
OSDOCS-20591: Add 4.17.55 z-stream release notes

### DIFF
--- a/modules/zstream-4-17-55.adoc
+++ b/modules/zstream-4-17-55.adoc
@@ -1,0 +1,31 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-17-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-17-55-about_{context}"]
+= RHSA-2026:34099 - {product-title} {product-version}.55 bug fix and security update
+
+Issued: 9 July 2026
+
+[role="_abstract"]
+{product-title} release {product-version}.55 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2026:34099[RHSA-2026:34099] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2026:34097[RHSA-2026:34097] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.17.55 --pullspecs
+----
+
+[id="zstream-4-17-55-fixed-issues_{context}"]
+== Fixed issues
+
+There are no notable fixed issues for this release.
+
+[id="zstream-4-17-55-updating_{context}"]
+== Updating
+
+To update an {product-title} 4.17 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].

--- a/release_notes/ocp-4-17-release-notes.adoc
+++ b/release_notes/ocp-4-17-release-notes.adoc
@@ -2948,6 +2948,9 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+// 4.17.55
+include::modules/zstream-4-17-55.adoc[leveloffset=+2]
+
 // 4.17.54
 include::modules/zstream-4-17-54.adoc[leveloffset=+2]
 


### PR DESCRIPTION
## Summary
- Adds z-stream release notes for OpenShift 4.17.55 (advisory-only)
- Jira: https://redhat.atlassian.net/browse/OSDOCS-20591
- Shipment MR: https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/624 (open)
- ART Dashboard: https://art-dash.engineering.redhat.com/dashboard/release/openshift-4.17
- Errata: RHSA-2026:34099 / RHSA-2026:34097 (RPM; not yet on access.redhat.com)

## Documented
- _(none — advisory-only release)_

## Skipped (not documented)
| Key | Reason |
|-----|--------|
| OCPBUGS-62170 | Invalid RN type: '' |
| OCPBUGS-79443 | CVE-only |
| OCPBUGS-79444 | CVE-only |
| OCPBUGS-80009 | CVE-only |
| OCPBUGS-80022 | CVE-only |
| OCPBUGS-80031 | CVE-only |
| OCPBUGS-80035 | CVE-only |
| OCPBUGS-80036 | CVE-only |
| OCPBUGS-80037 | CVE-only |
| OCPBUGS-80038 | CVE-only |
| OCPBUGS-80041 | CVE-only |
| OCPBUGS-80045 | CVE-only |
| OCPBUGS-80049 | CVE-only |
| OCPBUGS-80056 | CVE-only |
| OCPBUGS-80063 | CVE-only |
| OCPBUGS-80080 | CVE-only |
| OCPBUGS-80082 | CVE-only |
| OCPBUGS-80085 | CVE-only |
| OCPBUGS-80088 | CVE-only |
| OCPBUGS-80089 | CVE-only |
| OCPBUGS-80095 | CVE-only |
| OCPBUGS-80098 | CVE-only |
| OCPBUGS-80099 | CVE-only |
| OCPBUGS-80100 | CVE-only |
| OCPBUGS-80103 | CVE-only |
| OCPBUGS-80105 | CVE-only |
| OCPBUGS-80108 | CVE-only |
| OCPBUGS-80118 | CVE-only |
| OCPBUGS-80129 | CVE-only |
| OCPBUGS-80133 | CVE-only |
| OCPBUGS-80134 | CVE-only |
| OCPBUGS-80136 | CVE-only |
| OCPBUGS-80137 | CVE-only |
| OCPBUGS-80138 | CVE-only |
| OCPBUGS-80145 | CVE-only |
| OCPBUGS-80146 | CVE-only |
| OCPBUGS-80165 | CVE-only |
| OCPBUGS-80168 | CVE-only |
| OCPBUGS-81795 | CVE-only |
| OCPBUGS-82172 | CVE-only |
| OCPBUGS-82183 | CVE-only |
| OCPBUGS-82208 | CVE-only |
| OCPBUGS-82706 | CVE-only |
| OCPBUGS-82720 | CVE-only |
| OCPBUGS-83379 | CVE-only |
| OCPBUGS-84085 | Release Note Not Required |
| OCPBUGS-85250 | Release Note Not Required |
| OCPBUGS-85671 | Release Note Not Required |
| OCPBUGS-86069 | Internal |
| OCPBUGS-86234 | Release Note Not Required |
| OCPBUGS-87591 | Release Note Not Required |
| OCPBUGS-87877 | Release Note Not Required |
| OCPBUGS-87998 | Release Note Not Required |

## Scope notes
- Shipment YAML keys: 53
- Documented bug fixes: 0
- Note: RHSA-2026:34099 not yet published on access.redhat.com; issued date from shipment ship date (9 July 2026)

## Test plan
- [x] Advisory links from shipment YAML
- [x] Vale clean on module (0 errors)

Made with [Cursor](https://cursor.com)