### PR TITLE
OSDOCS-20592: Add 4.12.93 z-stream release notes

### DIFF
--- a/modules/zstream-4-12-93-about.adoc
+++ b/modules/zstream-4-12-93-about.adoc
@@ -1,0 +1,21 @@
+// Module included in the following assembly:
+//
+// * release_notes/ocp-4-12-release-notes.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="zstream-4-12-93-about_{context}"]
+= RHSA-2026:34049 - {product-title} {product-version}.93 bug fix and security update
+
+[role="_abstract"]
+Issued: 9 July 2026
+
+{product-title} release {product-version}.93, which includes security updates, is now available. The list of fixed issues that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2026:34049[RHSA-2026:34049] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2026:34046[RHBA-2026:34046] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.12.93 --pullspecs
+----

--- a/modules/zstream-4-12-93-fixed-issues.adoc
+++ b/modules/zstream-4-12-93-fixed-issues.adoc
@@ -1,0 +1,10 @@
+// Module included in the following assembly:
+//
+// * release_notes/ocp-4-12-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-12-93-fixed-issues_{context}"]
+= Fixed issues
+
+[role="_abstract"]
+There are no notable fixed issues in this release.

--- a/modules/zstream-4-12-93-updating.adoc
+++ b/modules/zstream-4-12-93-updating.adoc
@@ -1,0 +1,10 @@
+// Module included in the following assembly:
+//
+// * release_notes/ocp-4-12-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-12-93-updating_{context}"]
+= Updating
+
+[role="_abstract"]
+To update an existing {product-title} 4.12 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].

--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -5431,3 +5431,12 @@ include::modules/zstream-4-12-92-fixed-issues.adoc[leveloffset=+3]
 
 // 4.12.92 updating
 include::modules/zstream-4-12-92-updating.adoc[leveloffset=+3]
+
+// 4.12.93 about
+include::modules/zstream-4-12-93-about.adoc[leveloffset=+2]
+
+// 4.12.93 fixes
+include::modules/zstream-4-12-93-fixed-issues.adoc[leveloffset=+3]
+
+// 4.12.93 updating
+include::modules/zstream-4-12-93-updating.adoc[leveloffset=+3]


### PR DESCRIPTION
## Summary
- Adds z-stream release notes for OpenShift 4.12.93 (advisory-only)
- Jira: https://redhat.atlassian.net/browse/OSDOCS-20592
- Shipment MR: https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/623 (open)
- ART Dashboard: https://art-dash.engineering.redhat.com/dashboard/release/openshift-4.12
- Errata: RHSA-2026:34049 / RHBA-2026:34046 (RPM; not yet on access.redhat.com)

## Documented
- _(none — advisory-only release)_

## Skipped (not documented)
| Key | Reason |
|-----|--------|
| OCPBUGS-79430 | CVE-only |
| OCPBUGS-79763 | CVE-only |
| OCPBUGS-87882 | Release Note Not Required |

## Scope notes
- Shipment YAML keys: 3
- Documented bug fixes: 0
- Note: RHSA-2026:34049 not yet published on access.redhat.com; issued date from shipment ship date (9 July 2026)

## Test plan
- [x] Advisory links from shipment YAML
- [x] Vale clean on modules (0 errors)

Made with [Cursor](https://cursor.com)