### PR TITLE
[enterprise-5.0] OSDOCS#16913: CQA for CLI tools usage of oc/kubectl

### DIFF
--- a/cli_reference/openshift_cli/usage-oc-kubectl.adoc
+++ b/cli_reference/openshift_cli/usage-oc-kubectl.adoc
@@ -4,79 +4,26 @@
 include::_attributes/common-attributes.adoc[]
 :context: usage-oc-kubectl
 
-The Kubernetes command-line interface (CLI), `kubectl`, can be used to run commands against a Kubernetes cluster. Because {product-title} is a certified Kubernetes distribution, you can use the supported `kubectl` binaries that ship with
-{product-title}, or you can gain extended functionality by using the `oc` binary.
+toc::[]
 
-== The oc binary
+[role="_abstract"]
+Because {product-title} is a certified Kubernetes distribution, you can use the Kubernetes CLI (`kubectl`) that ships with {product-title} to interact with your cluster. You can also gain extended functionality specific to {product-title} by using the {oc-first} binary.
 
-The `oc` binary offers the same capabilities as the `kubectl` binary, but it extends to natively support additional
-{product-title} features, including:
+// The oc binary
+include::modules/oc-usage-oc.adoc[leveloffset=+1]
 
-* **Full support for {product-title} resources**
-+
-Resources such as `DeploymentConfig`, `BuildConfig`, `Route`, `ImageStream`, and `ImageStreamTag` objects are specific to
-{product-title}
-distributions, and build upon standard Kubernetes primitives.
-+
-* **Authentication**
-+
-ifndef::microshift,openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
-The `oc` binary offers a built-in `login` command for authentication and lets you work with projects, which map Kubernetes namespaces to authenticated users.
-Read xref:../../authentication/understanding-authentication.adoc#understanding-authentication[Understanding authentication] for more information.
-endif::microshift,openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
-+
-ifdef::microshift[]
-The `oc` binary offers a built-in `login` command for authentication to {product-title}.
-endif::[]
-+
-* **Additional commands**
-+
-The additional command `oc new-app`, for example, makes it easier to get new applications started using existing source code or pre-built images. Similarly, the additional command `oc new-project` makes it easier to start a project that you can switch to as your default.
+ifndef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
+[role="_additional-resources"]
+.Additional resources
 
-[IMPORTANT]
-====
-If you installed an earlier version of the `oc` binary, you cannot use it to complete all of the commands in
-ifndef::openshift-rosa,openshift-rosa-hcp[]
-{product-title} {product-version}
-endif::openshift-rosa,openshift-rosa-hcp[]
-ifdef::openshift-rosa,openshift-rosa-hcp[]
-{product-title}
-endif::openshift-rosa,openshift-rosa-hcp[]
-. If you want the latest features, you must download and install the latest version of the `oc` binary corresponding to your {product-title} server version.
-====
+* xref:../../authentication/understanding-authentication.adoc#understanding-authentication[Understanding authentication]
+endif::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 
-Non-security API changes will involve, at minimum, two minor releases (4.1 to 4.2 to 4.3, for example) to allow older `oc` binaries to update. Using new capabilities might require newer `oc` binaries. A 4.3 server might have additional capabilities that a 4.2 `oc` binary cannot use and a 4.3 `oc` binary might have additional capabilities that are unsupported by a 4.2 server.
+// The kubectl binary
+include::modules/oc-usage-kubectl.adoc[leveloffset=+1]
 
-.Compatibility Matrix
+[role="_additional-resources"]
+.Additional resources
 
-[cols="1,1,1"]
-|===
-
-|
-|*X.Y* (`oc` Client)
-|*X.Y+N* footnote:versionpolicyn[Where *N* is a number greater than or equal to 1.] (`oc` Client)
-
-|*X.Y* (Server)
-|image:redcircle-1.png[]
-|image:redcircle-3.png[]
-
-|*X.Y+N* footnote:versionpolicyn[] (Server)
-|image:redcircle-2.png[]
-|image:redcircle-1.png[]
-
-|===
-image:redcircle-1.png[] Fully compatible.
-
-image:redcircle-2.png[] `oc` client might not be able to access server features.
-
-image:redcircle-3.png[] `oc` client might provide options and features that might not be compatible with the accessed server.
-
-
-== The kubectl binary
-
-The `kubectl` binary is provided as a means to support existing workflows and scripts for new
-{product-title} users coming from a standard Kubernetes environment, or for those who prefer to use the `kubectl` CLI. Existing users of `kubectl` can continue to use the binary to interact with Kubernetes primitives, with no changes required to the {product-title} cluster.
-
-You can install the supported `kubectl` binary by following the steps to xref:../../cli_reference/openshift_cli/getting-started-cli.adoc#cli-installing-cli-linux_cli-developer-commands[Install the OpenShift CLI]. The `kubectl` binary is included in the archive if you download the binary, or is installed when you install the CLI by using an RPM.
-
-For more information, see the link:https://kubernetes.io/docs/reference/kubectl/overview/[kubectl documentation].
+* link:https://kubernetes.io/docs/reference/kubectl/overview/[kubectl (Kubernetes documentation)]
+* xref:../../cli_reference/openshift_cli/getting-started-cli.adoc#cli-getting-started[Getting started with the OpenShift CLI]

--- a/modules/oc-usage-kubectl.adoc
+++ b/modules/oc-usage-kubectl.adoc
@@ -1,0 +1,12 @@
+// Module included in the following assemblies:
+//
+// * cli_reference/openshift_cli/usage-oc-kubectl.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="oc-usage-kubectl_{context}"]
+= The kubectl binary
+
+[role="_abstract"]
+The Kubernetes CLI (`kubectl`) binary is provided as a means to support existing workflows and scripts for new {product-title} users coming from a standard Kubernetes environment, or for those who prefer to use the `kubectl` CLI. Existing users of `kubectl` can continue to use the binary to interact with Kubernetes primitives, with no changes required to the {product-title} cluster.
+
+You can install the supported `kubectl` binary by following the steps to install the OpenShift CLI. The `kubectl` binary is included in the archive if you download the binary, or is installed when you install the CLI by using an RPM.

--- a/modules/oc-usage-oc.adoc
+++ b/modules/oc-usage-oc.adoc
@@ -1,0 +1,62 @@
+// Module included in the following assemblies:
+//
+// * cli_reference/openshift_cli/usage-oc-kubectl.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="oc-usage-oc_{context}"]
+= The oc binary
+
+[role="_abstract"]
+The {oc-first} binary offers the same capabilities as the `kubectl` binary, but it extends to natively support additional {product-title} features.
+
+Full support for {product-title} resources::
++
+Resources such as `DeploymentConfig`, `BuildConfig`, `Route`, `ImageStream`, and `ImageStreamTag` objects are specific to {product-title} distributions, and build upon standard Kubernetes primitives.
+
+ifndef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
+Authentication::
++
+The `oc` binary offers a built-in `login` command for authentication and lets you work with projects, which map Kubernetes namespaces to authenticated users.
+Read "Understanding authentication" for more information.
+endif::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
+
+Additional commands::
++
+The additional command `oc new-app`, for example, makes it easier to get new applications started using existing source code or pre-built images. Similarly, the additional command `oc new-project` makes it easier to start a project that you can switch to as your default.
+
+[IMPORTANT]
+====
+If you installed an earlier version of the `oc` binary, you cannot use it to complete all of the commands in
+ifndef::openshift-rosa,openshift-rosa-hcp[]
+{product-title} {product-version}
+endif::openshift-rosa,openshift-rosa-hcp[]
+ifdef::openshift-rosa,openshift-rosa-hcp[]
+{product-title}
+endif::openshift-rosa,openshift-rosa-hcp[]
+. If you want the latest features, you must download and install the latest version of the `oc` binary corresponding to your {product-title} server version.
+====
+
+Non-security API changes will involve, at minimum, two minor releases (4.1 to 4.2 to 4.3, for example) to allow older `oc` binaries to update. Using new capabilities might require newer `oc` binaries. A 4.3 server might have additional capabilities that a 4.2 `oc` binary cannot use and a 4.3 `oc` binary might have additional capabilities that are unsupported by a 4.2 server.
+
+.Compatibility matrix
+[cols="1,1,1"]
+|===
+
+|
+|*X.Y* (`oc` Client)
+|*X.Y+N* footnote:versionpolicyn[Where *N* is a number greater than or equal to 1.] (`oc` Client)
+
+|*X.Y* (Server)
+|image:redcircle-1.png[Red circle 1]
+|image:redcircle-3.png[Red circle 3]
+
+|*X.Y+N* footnote:versionpolicyn[] (Server)
+|image:redcircle-2.png[Red circle 2]
+|image:redcircle-1.png[Red circle 1]
+
+|===
+image:redcircle-1.png[Red circle 1] Fully compatible.
+
+image:redcircle-2.png[Red circle 2] `oc` client might not be able to access server features.
+
+image:redcircle-3.png[Red circle 3] `oc` client might provide options and features that might not be compatible with the accessed server.


### PR DESCRIPTION
Manual CP of #113945.

Verified that the only reason it's causing a conflict on the latest branch is due to someone else's conflict resolution that added an extra blank line. Nothing to be concerned about.