### PR TITLE
DOCPLAN-404: Rewrite short desc to meet DITA standards

### DIFF
--- a/virt/managing_vms/ssh/virt-accessing-vm-ssh.adoc
+++ b/virt/managing_vms/ssh/virt-accessing-vm-ssh.adoc
@@ -7,12 +7,7 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 [role="_abstract"]
-You can use SSH to securely access your virtual machines (VMs) from the command line. To set up your SSH configuration, use one of the following methods:
-
-* `virtctl ssh` command
-* `virtctl port-forward` command
-* Service
-* Secondary network
+You can use SSH to securely access your virtual machines (VMs) from the command line. You can set up your SSH configuration using the `virtctl ssh` command, `virtctl port-forward` command, a service, or a secondary network.
 
 include::modules/virt-access-configuration-considerations.adoc[leveloffset=+1]
 

--- a/virt/post_installation_configuration/virt-configuring-higher-vm-workload-density.adoc
+++ b/virt/post_installation_configuration/virt-configuring-higher-vm-workload-density.adoc
@@ -7,10 +7,7 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 [role="_abstract"]
-You can increase the number of virtual machines (VMs) on nodes by overcommitting memory (RAM). Increasing VM workload density can be useful in the following situations:
-
-* You have many similar workloads.
-* You have underused workloads.
+You can increase the number of virtual machines (VMs) on nodes by overcommitting memory (RAM). Increasing VM workload density can be useful if you have many similar workloads or underused workloads.
 
 [NOTE]
 ====

--- a/virt/support/virt-collecting-virt-data.adoc
+++ b/virt/support/virt-collecting-virt-data.adoc
@@ -7,7 +7,9 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 [role="_abstract"]
-When you submit a support case to Red{nbsp}Hat Support, it is helpful to provide debugging information for {product-title} and {VirtProductName} by using the following tools:
+When you submit a support case to Red{nbsp}Hat Support, it is helpful to provide debugging information for {product-title} and {VirtProductName}.
+
+You can use the following tools to collect debugging information:
 
 // must-gather not supported for ROSA/OSD, per Dustin Row
 ifndef::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]


### PR DESCRIPTION
Version(s):
4.20+

Issue:
https://redhat.atlassian.net/browse/DOCPLAN-404

Link to docs preview:
- https://114776--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/virt/managing_vms/ssh/virt-accessing-vm-ssh.html
- https://114776--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/support/virt-collecting-virt-data.html
- https://114776--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/post_installation_configuration/virt-configuring-higher-vm-workload-density

QE review:
n/a, editing only, no new content

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
