### PR TITLE
OSDOCS-17171-2:CQA 2.0-Security-Certificates-Attachment3

### DIFF
--- a/security/certificates/api-server.adoc
+++ b/security/certificates/api-server.adoc
@@ -6,10 +6,10 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-The default API server certificate is issued by an internal {product-title}
-cluster CA. Clients outside of the cluster will not be able to verify the
-API server's certificate by default. This certificate can be replaced
-by one that is issued by a CA that clients trust.
+[role="_abstract"]
+To allow clients outside of the cluster to verify the API server's certificate, you can replace the default API server certificate with one that is issued by a CA that clients trust.
+
+By default, the API server certificate is issued by an internal {product-title} cluster CA. As a result, clients outside of the cluster cannot verify the API server's certificate.
 
 [NOTE]
 ====


### PR DESCRIPTION
Version(s):
4.20+

Issue:
https://redhat.atlassian.net/browse/OSDOCS-17171

Link to docs preview:
https://114797--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/certificates/api-server.html