### PR TITLE
OSDOCS-17172-mco-certificates-cqa

### DIFF
--- a/modules/machine-config-operator-certificates-overview.adoc
+++ b/modules/machine-config-operator-certificates-overview.adoc
@@ -1,0 +1,34 @@
+// Module included in the following assemblies:
+//
+// * machine-config-operator-certificates.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="machine-config-operator-certificates-overview_{context}"]
+= Machine Config Operator certificates overview
+
+[role="_abstract"]
+Learn how Machine Config Operator (MCO) certificates secure node connections to the Machine Config Server (MCS) during cluster provisioning, so you can plan for certificate maintenance and for troubleshooting node provisioning issues.
+
+This certificate authority (CA) is used to secure connections from nodes to the MCS during initial provisioning.
+
+There are two certificates:
+
+* A self-signed CA, the `machine-config-server-ca` config map (MCS CA).
+* A derived certificate, the `machine-config-server-tls` secret (MCS certificate).
+
+[id="cert-types-machine-config-operator-certificates-details_{context}"]
+== Provisioning details
+
+{product-title} installations that use {op-system-first} are installed by using Ignition. This process is split into two parts:
+
+* An Ignition config is created that references a URL for the full configuration served by the MCS.
+* For user-provisioned infrastructure installation methods, the Ignition config manifests as a `worker.ign` file created by the `openshift-install` command. For installer-provisioned infrastructure installation methods that use the Machine API Operator, this configuration appears as the `worker-user-data` secret.
+
+include::snippets/mcs-endpoint-limitation.adoc[]
+
+[id="cert-types-machine-config-operator-certificates-trust_{context}"]
+== Provisioning chain of trust
+
+The MCS CA is injected into the Ignition configuration under the `security.tls.certificateAuthorities` configuration field. The MCS then provides the complete configuration using the MCS certificate presented by the web server.
+
+The client validates that the MCS certificate presented by the server has a chain of trust to an authority it recognizes. In this case, the MCS CA is that authority, and it signs the MCS certificate. This ensures that the client is accessing the correct server. The client in this case is Ignition running on a machine in the initial RAM filesystem (initramfs).

--- a/modules/machine-config-operator-certificates-reference.adoc
+++ b/modules/machine-config-operator-certificates-reference.adoc
@@ -1,0 +1,46 @@
+// Module included in the following assemblies:
+//
+// * machine-config-operator-certificates.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="machine-config-operator-certificates-reference_{context}"]
+= Machine Config Operator certificates reference
+
+[role="_abstract"]
+Use this reference to locate Machine Config Operator (MCO) certificate key material, rotation requirements, and support boundaries, so you can plan for certificate maintenance and for scheduling rotation before certificates expire.
+
+[id="cert-types-machine-config-operator-certificates-materials_{context}"]
+== Key material inside a cluster
+
+The following objects are stored in the `openshift-machine-config-operator` namespace:
+
+* The Machine Config Server (MCS) certificate authority (CA) bundle is stored as the `machine-config-server-ca` config map. The MCS CA bundle stores all valid CAs for the `MachineConfigServer` TLS certificate.
+* The MCS CA signing key is stored as the `machine-config-server-ca` secret. The MCS CA signing key is used to sign the `MachineConfigServer` TLS certificate.
+* The MCS certificate is stored as the `machine-config-server-tls` secret, which contains the `MachineConfigServer` TLS certificate and key.
+
+The `machine-config-server-ca` config map is used in the following ways:
+
+* The certificate controller updates the `*-user-data` secrets in the `openshift-machine-api` namespace any time the `machine-config-server-ca` configmap is updated.
+* The Machine Config Operator renders the `master-user-data-managed` and `worker-user-data-managed` secrets from the `machine-config-server-ca` configmap.
+
+[id="cert-types-machine-config-operator-certificates-mgmt_{context}"]
+== Management
+
+At this time, directly modifying either of these certificates is not supported.
+
+[id="cert-types-machine-config-operator-certificates-exp_{context}"]
+== Expiration
+
+The MCS CA and MCS certificate are valid for 10 years and are automatically rotated by the MCO at 8 years.
+
+The issued serving certificates are valid for 10 years.
+
+[NOTE]
+====
+This automatic certificate rotation applies only to clusters that use machine sets. For clusters that do not use machine sets, such as vSphere user-provisioned infrastructure clusters, you are required to manually rotate these certificates. For more information on manual certificate rotation, see the Red{nbsp}Hat Knowledgebase article _Regenerating CA certificates for the Machine Config Server_.
+====
+
+[id="cert-types-machine-config-operator-certificates-custom_{context}"]
+== Customization
+
+You cannot customize the MCO certificates.

--- a/security/certificate_types_descriptions/machine-config-operator-certificates.adoc
+++ b/security/certificate_types_descriptions/machine-config-operator-certificates.adoc
@@ -6,70 +6,18 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-== Purpose
+[role="_abstract"]
+Understand Machine Config Operator (MCO) certificates used to secure node connections to the Machine Config Server (MCS) during cluster provisioning, including their lifecycle, rotation, and support boundaries.
 
-This certificate authority is used to secure connections from nodes to Machine Config Server (MCS) during initial provisioning.
+// MCO overview
+include::modules/machine-config-operator-certificates-overview.adoc[leveloffset=+1]
 
-There are two certificates:
-
-. A self-signed CA, the `machine-config-server-ca` config map (MCS CA)
-. A derived certificate, the `machine-config-server-tls` secret (MCS cert)
-
-[id="cert-types-machine-config-operator-certificates-details"]
-=== Provisioning details
-
-{product-title} installations that use {op-system-first} are installed by using Ignition. This process is split into two parts:
-
-. An Ignition config is created that references a URL for the full configuration served by the MCS.
-. For user-provisioned infrastucture installation methods, the Ignition config manifests as a `worker.ign` file created by the `openshift-install` command. For installer-provisioned infrastructure installation methods that use the Machine API Operator, this configuration appears as the `worker-user-data` secret.
-
-include::snippets/mcs-endpoint-limitation.adoc[]
+// MCO reference
+include::modules/machine-config-operator-certificates-reference.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources
 
-* xref:../../machine_configuration/index.adoc#machine-config-operator_machine-config-overview[Machine Config Operator]
-
+* xref:../../machine_configuration/index.adoc#about-machine-config-operator_machine-config-overview[About the Machine Config Operator]
 * xref:../../networking/ovn_kubernetes_network_provider/about-ovn-kubernetes.adoc#about-ovn-kubernetes[About the OVN-Kubernetes network plugin]
-
-[id="cert-types-machine-config-operator-certificates-trust"]
-=== Provisioning chain of trust
-
-The MCS CA is injected into the Ignition configuration under the `security.tls.certificateAuthorities` configuration field. The MCS then provides the complete configuration using the MCS cert presented by the web server.
-
-The client validates that the MCS cert presented by the server has a chain of trust to an authority it recognizes. In this case, the MCS CA is that authority, and it signs the MCS cert. This ensures that the client is accessing the correct server. The client in this case is Ignition running on a machine in the initramfs.
-
-[id="cert-types-machine-config-operator-certificates-materials"]
-=== Key material inside a cluster
-
-The following objects are stored in the `openshift-machine-config-operator` namespace:
-
-* The MCS CA bundle is stored as the `machine-config-server-ca` config map. The MCS CA bundle stores all valid CAs for the `MachineConfigServer` TLS certificate.
-* The MCS CA signing key is stored as the `machine-config-server-ca` secret. The MCS CA signing key is used to sign the `MachineConfigServer` TLS certificate.
-* The MCS cert is stored as the `machine-config-server-tls` secret, which contains the `MachineConfigServer` TLS certificate and key.
-
-The `machine-config-server-ca` config map is used in the following ways:
-
-* The certificate controller updates the `*-user-data` secrets in the `openshift-machine-api` namespace any time the `machine-config-server-ca` configmap is updated.
-* The Machine Config Operator renders the `master-user-data-managed` and `worker-user-data-managed` secrets from the `machine-config-server-ca` configmap.
-
-[id="cert-types-machine-config-operator-certificates-mgmt"]
-== Management
-
-At this time, directly modifying either of these certificates is not supported.
-
-[id="cert-types-machine-config-operator-certificates-exp"]
-== Expiration
-The MCS CA and MCS cert are valid for 10 years and are automatically rotated by the MCO at 8 years.
-
-The issued serving certificates are valid for 10 years.
-
-[NOTE]
-====
-This automatic certificate rotation applies only to clusters that use machine sets. For clusters that do not use machine sets, such as vSphere user-provisioned infrastructure clusters, you are required to manually rotate these certificates. For more information on manual certificate rotation, see the Red{nbsp}Hat Knowledgebase article link:https://access.redhat.com/articles/regenerating_cluster_certificates#regenerating-ca-certificates-for-the-machine-config-server-5[Regenerating CA certificates for the Machine Config Server]. 
-====
-
-[id="cert-types-machine-config-operator-certificates-custom"]
-== Customization
-
-You cannot customize the Machine Config Operator certificates.
+* link:https://access.redhat.com/articles/regenerating_cluster_certificates#regenerating-ca-certificates-for-the-machine-config-server-5[Regenerating CA certificates for the Machine Config Server]

--- a/snippets/mcs-endpoint-limitation.adoc
+++ b/snippets/mcs-endpoint-limitation.adoc
@@ -1,8 +1,8 @@
 // Text snippet included in the following modules:
 //
-// * modules/installation-about-custom-azure-vnet.adoc
+// * modules/installation-about-custom-azure-vnet-requirements.adoc
 // * modules/machine-config-operator.adoc
-// * security/certificate_types_descriptions/machine-config-operator-certificates.adoc
+// * modules/machine-config-operator-certificates-overview.adoc
 
 :_mod-docs-content-type: SNIPPET
 


### PR DESCRIPTION
Version(s):
4.20+

Issue:
https://redhat.atlassian.net/browse/OSDOCS-17172

Link to docs preview:
https://114800--ocpdocs-pr.netlify.app/
https://114800--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/certificate_types_descriptions/machine-config-operator-certificates.html


QE review:
- [ ] QE has approved this change.


Additional information:

