### PR TITLE
OBSDOCS-3386: Logging 6.6.0 release notes

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -334,6 +334,8 @@ endif::openshift-origin[]
 :sts-first: Security Token Service (STS)
 :sts-full: Security Token Service
 :sts-short: STS
+//Microsoft Entra ID (FKA Azure Active Directory)
+:entra-id: Microsoft Entra ID
 //Microsoft Entra Workload ID (FKA Azure Active Directory Workload Identities)
 :entra-first: Microsoft Entra Workload ID
 :entra-short: Workload ID

--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -16,7 +16,7 @@ Name: Release notes
 Dir: release_notes
 Distros: openshift-logging
 Topics:
-- Name: Logging 6.3 release notes
+- Name: Logging 6.6 release notes
   File: logging-release-notes
 ---
 Name: Installing logging

--- a/modules/logging-release-notes-6-6-0-deprecations.adoc
+++ b/modules/logging-release-notes-6-6-0-deprecations.adoc
@@ -1,0 +1,13 @@
+// Module included in the following assemblies:
+//
+// * release_notes/logging-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="logging-release-notes-6-6-0-deprecations_{context}"]
+= Deprecations and removals
+
+[role="_abstract"]
+The following section lists features and functionality that are deprecated or removed in this release of {LoggingProductName}.
+
+Azure Monitor Data Collector API deprecated::
+The `azureMonitor` output type is deprecated in this release. This output type uses the Azure HTTP Data Collector API. Microsoft will disable the Data Collector API on September 14, 2026. If you currently use the `azureMonitor` output type, you must migrate to the new `azureLogsIngestion` output type before this date to avoid service disruption. The `azureLogsIngestion` output type uses the Azure Monitor Logs Ingestion API with Data Collection Rules (DCR). This new API provides enhanced security, schema flexibility, and improved reliability compared to the deprecated API. Both output types can coexist in the same `ClusterLogForwarder` custom resource during the migration period. This allows you to validate the new configuration before you remove the deprecated output. (link:https://redhat.atlassian.net/browse/OBSDA-804[OBSDA-804])

--- a/modules/logging-release-notes-6-6-0-enhancement.adoc
+++ b/modules/logging-release-notes-6-6-0-enhancement.adoc
@@ -1,0 +1,44 @@
+// Module included in the following assemblies:
+//
+// * release_notes/logging-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="logging-release-notes-6-6-0-enhancement_{context}"]
+= New features and enhancements
+
+[role="_abstract"]
+This release of {LoggingProductName} includes the following new features and enhancements.
+
+Azure Monitor Logs Ingestion API support::
+With this release, you can forward logs to Azure Monitor by using the new Logs Ingestion API with Data Collection Rules (DCR). This replaces the deprecated Data Collector API, which Microsoft will disable on September 14, 2026. The new `azureLogsIngestion` output type offers enhanced security through support for {entra-id} Workload Identity. This enables pod-based authentication without managing shared secrets. Service principal authentication with client secrets remains available for environments that require it. Data Collection Rules provide schema flexibility. You can define custom log schemas that match your organization's requirements. You can specify which field receives the timestamp. This supports standard schemas such as `TimeGenerated` or specialized schemas such as ASIM that use `EventStartTime`. Both the new `azureLogsIngestion` output and the deprecated `azureMonitor` output can coexist in the same `ClusterLogForwarder` custom resource during the migration period. (link:https://redhat.atlassian.net/browse/LOG-7259[LOG-7259])
+
+Google Cloud Platform Workload Identity Federation authentication::
+With this release, you can forward logs to Google Cloud Logging by using Workload Identity Federation (WIF) for authentication. WIF provides short-lived credentials instead of long-lived service account keys. This improves security by eliminating the need to manage and rotate service account key files. This feature is only supported on {product-title} clusters installed on GCP in manual credentials mode with WIF enabled. To configure WIF authentication, use the Cloud Credential Operator utility (`ccoctl`). This utility creates GCP service accounts, IAM policy bindings, and workload identity bindings between {product-title} service accounts and GCP service accounts. The collector uses pod-injected service account tokens as subject tokens for WIF token exchange with GCP. Service account key authentication remains available for environments that do not use WIF. (link:https://redhat.atlassian.net/browse/LOG-3577[LOG-3577])
+
+Metrics collection profiles to reduce collector cardinality::
+With this release, you can configure the cluster monitoring operator to use metrics collection profiles. These profiles control how many metrics Prometheus collects from the log collector. The `minimal` profile reduces metrics cardinality by collecting only the metrics needed for platform alerts, dashboards, telemetry, and Horizontal and Vertical Pod Autoscaling. This profile excludes high-cardinality histogram metrics, such as `vector_component_received_events_count_bucket` and `vector_buffer_send_duration_seconds_bucket`. These metrics create thousands of time series in multitenant environments but are not required for platform functionality. Testing shows the minimal profile reduces Prometheus CPU consumption by approximately 21% and memory consumption by approximately 33% while maintaining all functionality needed for cluster operations. To configure the profile, set the `collectionProfile` field to `minimal` in the `cluster-monitoring-config` ConfigMap in the `openshift-monitoring` namespace. The available profiles are `full` (default, collects all metrics), `minimal` (collects only metrics needed for platform functionality), and `telemetry` (collects only metrics required for Red Hat telemetry). (link:https://redhat.atlassian.net/browse/LOG-9355[LOG-9355])
+
+Improved high availability for LokiStack ingestion::
+With this release, the `1x.extra-small` and `1x.small` LokiStack deployment sizes now deploy 3 ingester replicas instead of 2. This provides high availability for log ingestion. Previously, these sizes deployed only 2 ingesters with a replication factor of 2. Log ingestion could be interrupted during pod restarts or node failures because at least replication factor plus one (RF+1) ingester replicas are needed to maintain availability. The operator previously generated a warning condition for these sizes indicating non-HA configuration. With this release, ingester resources are redistributed within the existing resource envelope to support 3 ingester replicas. This ensures that log ingestion continues uninterrupted during routine maintenance operations. This change aligns `1x.extra-small` and `1x.small` with the HA configuration already used by `1x.pico` and `1x.medium` sizes. (link:https://issues.redhat.com/browse/LOG-9352[LOG-9352])
+
+== Additional enhancements
+
+The following enhancements were also introduced in this release:
+
+* The log collector now exposes a metric that tracks when logs are discarded at the source because they exceed the `MaxRecordSize` tuning parameter. This enables you to create alerts when logs are being dropped. You can then investigate which log stream is affected and take corrective action. (link:https://redhat.atlassian.net/browse/LOG-6384[LOG-6384])
+
+* A runbook for the `CollectorNodeDown` critical alert is now available in the OpenShift runbooks repository. The runbook provides troubleshooting steps and remediation guidance when this alert fires. (link:https://redhat.atlassian.net/browse/LOG-7256[LOG-7256])
+
+* The LokiStack configuration now uses the new object storage backend based on `thanos-io/objstore`, which was introduced in Loki 3.4.0. The new backend uses named stores to avoid duplication of object storage configuration across components. (link:https://redhat.atlassian.net/browse/LOG-7392[LOG-7392])
+
+* The {clo} now reacts to changes in the cluster TLS profile and updates its own TLS configuration to match. The operator's metrics endpoint uses the cluster TLS profile for cipher suites and minimum TLS version. When you modify the cluster TLS profile, the {clo} pod restarts to apply the new configuration. The collector also respects the cluster TLS profile unless you specify an output-specific TLS security profile in the `ClusterLogForwarder` custom resource. An output-specific profile takes precedence over the cluster-level profile. (link:https://redhat.atlassian.net/browse/LOG-8972[LOG-8972])
+
+* The {clo} metrics endpoint now uses authentication and TLS encryption. Prometheus must provide a valid bearer token to scrape metrics from the operator. This ensures that only authorized clients can retrieve operator metrics and that the configuration respects the cluster TLS profile. (link:https://redhat.atlassian.net/browse/LOG-8977[LOG-8977])
+
+* The log file metrics exporter metrics endpoint now uses authentication and TLS encryption. Prometheus must provide a valid bearer token to scrape metrics from the exporter. This ensures that only authorized clients can retrieve exporter metrics and that the configuration respects the cluster TLS profile. (link:https://redhat.atlassian.net/browse/LOG-8978[LOG-8978])
+
+* The Vector collector metrics endpoint now uses authentication and TLS encryption. Prometheus must provide a valid bearer token to scrape metrics from the collector. This ensures that only authorized clients can retrieve collector metrics and that the configuration respects the cluster TLS profile. (link:https://redhat.atlassian.net/browse/LOG-9358[LOG-9358])
+
+* LokiStack ingesters now persist ring tokens to disk by using the `ingester.tokens-file-path` configuration option. When an ingester pod restarts, it reuses its previous tokens instead of generating new ones. This avoids unnecessary resharding of data across the ring. (link:https://redhat.atlassian.net/browse/LOG-9401[LOG-9401])
+
+* LokiStack PodDisruptionBudgets now set `maxUnavailable: 1` instead of `minAvailable`. This ensures that during voluntary disruptions such as node drains or upgrades, at most one pod is unavailable at a time. This preserves availability guarantees. (link:https://redhat.atlassian.net/browse/LOG-9402[LOG-9402])

--- a/modules/logging-release-notes-6-6-0-fixed-issues.adoc
+++ b/modules/logging-release-notes-6-6-0-fixed-issues.adoc
@@ -1,0 +1,28 @@
+// Module included in the following assemblies:
+//
+// * release_notes/logging-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="logging-release-notes-6-6-0-fixed-issues_{context}"]
+= Bug fixes
+
+[role="_abstract"]
+The following issues were resolved in this release of {LoggingProductName}.
+
+* Previously, the description of the `LokiIngesterFlushFailureRateCritical` alert did not match its actual definition. This caused confusion when investigating alert conditions. With this release, the alert description accurately reflects its definition. (link:https://issues.redhat.com/browse/LOG-8509[LOG-8509])
+
+* Previously, when the CA certificate in the `spec.outputs.tls.ca.configMapName` field was updated, the collector pods did not restart to use the new certificate. With this release, the {clo} watches the CA `ConfigMap` and restarts collector pods when the certificate changes. (link:https://issues.redhat.com/browse/LOG-8631[LOG-8631])
+
+* Previously, the `RulerConfig` custom resource definition validation incorrectly listed `header` as a valid value for `RemoteWriteAuthType` instead of the correct value `bearer`. With this release, the validation accepts `bearer` as the valid authentication type. (link:https://issues.redhat.com/browse/LOG-9002[LOG-9002])
+
+* Previously, the `LokiRequestLatency` alert threshold was set to 1 second. This was lower than the actual distributor timeout of 5 seconds. This caused the alert to fire even when no timeouts occurred. With this release, the alert threshold matches the distributor timeout. (link:https://issues.redhat.com/browse/LOG-9196[LOG-9196])
+
+* Previously, the default `ignore_older_secs` value of 3600 seconds for the `input_audit_host` input type was too short. This caused audit logs older than one hour to be ignored. With this release, the default value is increased to allow collection of older audit logs. (link:https://issues.redhat.com/browse/LOG-9359[LOG-9359])
+
+* Previously, when `noProxy: example.com` was set and logs were forwarded to `x.example.com`, the `noProxy` setting was not honored and the proxy was used incorrectly. With this release, subdomain matching for `noProxy` settings works correctly. (link:https://issues.redhat.com/browse/LOG-9383[LOG-9383])
+
+* Previously, the API description for `spec.outputs.lokiStack.tuning.deliveryMode` did not list the possible options. This made it difficult to configure this field correctly. With this release, the API description lists all valid options for the `deliveryMode` field. (link:https://issues.redhat.com/browse/LOG-9400[LOG-9400])
+
+* Previously, the `kubernetes` field was null for all non-container logs such as node logs and audit logs. With this release, the `kubernetes` field contains appropriate values for non-container logs or is properly omitted where not applicable. (link:https://issues.redhat.com/browse/LOG-9423[LOG-9423])
+
+* Previously, the `DiskBufferUsage` alert had a broken template variable in the summary annotation and used inconsistent severity casing. With this release, the alert summary displays the actual node hostname and uses lowercase severity labels consistent with other alerts. (link:https://issues.redhat.com/browse/LOG-9461[LOG-9461])

--- a/modules/logging-release-notes-6-6-0.adoc
+++ b/modules/logging-release-notes-6-6-0.adoc
@@ -1,0 +1,12 @@
+// Module included in the following assemblies:
+//
+// * release_notes/logging-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="logging-release-notes-6-6-0_{context}"]
+= Logging 6.6.0
+
+[role="_abstract"]
+This release of {LoggingProductName} is supported on {ocp-product-title} 4.20 and later. This release includes new features, enhancements, and bug fixes.
+
+This release includes link:https://access.redhat.com/errata/RHBA-2026:39344[RHBA-2026:39344].

--- a/release_notes/logging-release-notes.adoc
+++ b/release_notes/logging-release-notes.adoc
@@ -1,10 +1,19 @@
 :_mod-docs-content-type: ASSEMBLY
 include::_attributes/common-attributes.adoc[]
 [id="logging-release-notes"]
-= Logging 6.3 release notes
+= Logging 6.6 release notes
 
 :context: logging-release-notes
 
 toc::[]
 
-include::modules/logging-release-notes-6-3-0.adoc[leveloffset=+1]
+[role="_abstract"]
+This release of {LoggingProductName} is supported on {ocp-product-title} 4.19 and later.
+
+include::modules/logging-release-notes-6-6-0.adoc[leveloffset=+1]
+
+include::modules/logging-release-notes-6-6-0-enhancement.adoc[leveloffset=+2]
+
+include::modules/logging-release-notes-6-6-0-fixed-issues.adoc[leveloffset=+2]
+
+include::modules/logging-release-notes-6-6-0-deprecations.adoc[leveloffset=+2]


### PR DESCRIPTION
## Summary

Draft release notes for OpenShift Logging 6.6.0 release. This PR contains the new features/enhancements and deprecations sections. Bug fixes section will be added after JIRA query for fixed issues.

**Status: Draft for review**
**Preview:** https://114835--ocpdocs-pr.netlify.app/openshift-logging/latest/release_notes/logging-release-notes.html


## Changes

**New modules (3):**
- `modules/logging-release-notes-6-6-0.adoc` - Main release module with abstract and errata placeholder
- `modules/logging-release-notes-6-6-0-enhancement.adoc` - New features and enhancements section
- `modules/logging-release-notes-6-6-0-deprecations.adoc` - Deprecations and removals section

**Updated files:**
- `release_notes/logging-release-notes.adoc` - Updated from 6.3 to 6.6, added includes
- `_topic_maps/_topic_map.yml` - Updated release notes title to 6.6
- `_attributes/common-attributes.adoc` - Added `:entra-id:` attribute

## Features documented (3)

### 1. Azure Monitor Logs Ingestion API support ([OBSDA-804](https://redhat.atlassian.net/browse/OBSDA-804))
- New `azureLogsIngestion` output type with Data Collection Rules
- Replaces deprecated Data Collector API (Microsoft disabling Sept 14, 2026)
- Enhanced security with Microsoft Entra ID Workload Identity
- Schema flexibility for custom log schemas (TimeGenerated, ASIM)
- Migration path with coexistence support

### 2. GCP Workload Identity Federation authentication ([OBSDA-746](https://redhat.atlassian.net/browse/OBSDA-746))
- Short-lived credentials instead of service account keys
- Uses `ccoctl` for GCP service account and IAM setup
- Pod-injected tokens for WIF token exchange
- Only supported on OCP on GCP with WIF enabled

### 3. Metrics collection profiles to reduce collector cardinality ([OBSDA-1341](https://redhat.atlassian.net/browse/OBSDA-1341))
- `minimal` profile for cluster monitoring operator
- Reduces Prometheus CPU by ~21%, memory by ~33%
- Excludes high-cardinality histogram metrics
- Maintains all platform functionality (alerts, dashboards, telemetry, HPA/VPA)
- Configured via `cluster-monitoring-config` ConfigMap

## Deprecations (1)

### Azure Monitor Data Collector API deprecated
- `azureMonitor` output type deprecated
- Microsoft disabling API on September 14, 2026
- Must migrate to `azureLogsIngestion` before deadline
- Coexistence during migration period supported

## Related PRs

The features documented here have corresponding docs PRs already merged or in review:
- [OBSDA-804](https://redhat.atlassian.net/browse/OBSDA-804) (Azure): https://github.com/openshift/openshift-docs/pull/112606
- [OBSDA-746](https://redhat.atlassian.net/browse/OBSDA-746) (GCP WIF): https://github.com/openshift/openshift-docs/pull/112914
- [OBSDA-1341](https://redhat.atlassian.net/browse/OBSDA-1341) (Metrics): https://github.com/openshift/openshift-docs/pull/113290

## JIRA

- https://redhat.atlassian.net/browse/OBSDOCS-3386

---

Signed-off-by: John Wilkins <jowilkin@redhat.com>