### PR TITLE
OSDOCS-17075_b:CQA updates

### DIFF
--- a/modules/changing-cvo-log-level.adoc
+++ b/modules/changing-cvo-log-level.adoc
@@ -9,7 +9,10 @@
 :FeatureName: Changing the CVO log level
 include::snippets/technology-preview.adoc[]
 
-The Cluster Version Operator (CVO) log level verbosity can be changed by the cluster administrator. There are four log levels.
+[role="_abstract"]
+Adjust the verbosity of the Cluster Version Operator (CVO) log to troubleshoot update issues or diagnose errors by using four available log levels.
+
+The following list outlines the four log levels:
 
 * `Normal` - The default log level. Contains working log information. Used when everything is fine. Provides helpful notices for auditing or common operations.
 * `Debug` - Used when something goes wrong. Expect a higher quantity of notices.
@@ -28,13 +31,15 @@ If `TraceAll` is turned on in a production cluster it may cause widespread perfo
 
 .Procedure
 
-. Enter the following command into the CLI to change the log level.
+. Enter the following command into the CLI to change the log level:
 
++
 [source,terminal]
 ----
 $ oc patch clusterversionoperator/cluster --type=merge --patch '{"spec":{"operatorLogLevel":"<log_level>"}}'
 ----
 
++
 .Example output
 [source,terminal]
 ----

--- a/modules/gathering-clusterversion-history-cli.adoc
+++ b/modules/gathering-clusterversion-history-cli.adoc
@@ -6,7 +6,8 @@
 [id="gathering-clusterversion-history-cli_{context}"]
 = Gathering ClusterVersion history using the {oc-first}
 
-You can view the ClusterVersion history using the {oc-first}.
+[role="_abstract"]
+Use the {oc-first} to view ClusterVersion history. You can use the history to troubleshoot update issues or to verify completed updates.
 
 .Prerequisites
 * You have access to the cluster as a user with the `cluster-admin` role.

--- a/modules/gathering-clusterversion-history-console.adoc
+++ b/modules/gathering-clusterversion-history-console.adoc
@@ -6,7 +6,8 @@
 [id="gathering-clusterversion-history-console_{context}"]
 = Gathering ClusterVersion history in the {product-title} web console
 
-You can view the ClusterVersion history in the {product-title} web console.
+[role="_abstract"]
+You can view the ClusterVersion history and status information in the {product-title} web console. Use the history to verify successful updates and to troubleshoot failures.
 
 .Prerequisites
 * You have access to the cluster as a user with the `cluster-admin` role.

--- a/modules/gathering-clusterversion-history.adoc
+++ b/modules/gathering-clusterversion-history.adoc
@@ -1,11 +1,8 @@
-// Module included in the following assemblies:
-//
-// * updating/troubleshooting_updates/gathering-data-cluster-update.adoc
-
-:_mod-docs-content-type: PROCEDURE
+:_mod-docs-content-type: CONCEPT
 [id="gathering-clusterversion-history_{context}"]
-= Gathering ClusterVersion history 
+= Gathering ClusterVersion history
 
+[role="_abstract"]
 The Cluster Version Operator (CVO) records updates made to a cluster, known as the ClusterVersion history. The entries can reveal correlation between changes in cluster behavior with potential triggers, although correlation does not imply causation.
 
 [NOTE]

--- a/modules/gathering-log-data.adoc
+++ b/modules/gathering-log-data.adoc
@@ -1,9 +1,6 @@
-// Module included in the following assemblies:
-//
-// * updating/troubleshooting_updates/gathering-data-cluster-update.adoc
-
-:_mod-docs-content-type: PROCEDURE
+:_mod-docs-content-type: CONCEPT
 [id="gathering-log-data_{context}"]
 = Gathering log data for a support case
 
-To gather data from your cluster, including log data, use the `oc adm must-gather` command. See _Gathering data about your cluster_.
+[role="_abstract"]
+Use the `oc adm must-gather` command to collect cluster data and logs. Red Hat Support can then use the data and logs to diagnose and resolve support cases.

--- a/modules/kmm-example-cr.adoc
+++ b/modules/kmm-example-cr.adoc
@@ -6,7 +6,8 @@
 [id="kmm-example-cr_{context}"]
 = Example PreflightValidationOCP resource
 
-The following example shows a `PreflightValidationOCP` resource in the YAML format.
+[role="_abstract"]
+The example `PreflightValidationOCP` resource validates kernel modules and pushes built images to repositories.
 
 The example verifies all of the currently present modules against the upcoming `5.14.0-570.19.1.el9_6.x86_64` kernel. Because `.spec.pushBuiltImage` is set to `true`, KMM pushes the resulting images of Build/Sign into the defined repositories.
 
@@ -18,6 +19,6 @@ metadata:
   name: preflight
 spec:
   kernelVersion: 5.14.0-570.19.1.el9_6.x86_64
-  dtkImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:fe0322730440f1cbe6fffaaa8cac131b56574bec8abe3ec5b462e17557fecb32 
+  dtkImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:fe0322730440f1cbe6fffaaa8cac131b56574bec8abe3ec5b462e17557fecb32
   pushBuiltImage: true
 ----

--- a/modules/kmm-image-validation-stage.adoc
+++ b/modules/kmm-image-validation-stage.adoc
@@ -6,6 +6,9 @@
 [id="kmm-image-validation-stage_{context}"]
 = Image validation stage
 
+[role="_abstract"]
+Image validation checks whether kernel module images exist and are accessible before attempting to build or sign new images.
+
 Image validation is always the first stage of the preflight validation to be executed. If image validation is successful, no other validations are run on that specific module. The Operator uses the container runtime to check the image existence and accessibility for the updaded kernel in the module.
 
 If the image validation fails and there is a `build/sign` section in the module that is relevant to the upgraded kernel, the controller tries to build or sign the image. If the `PushBuiltImage` flag is defined in the `PreflightValidationOCP` resource, the controller will also try to push the resulting image into its repository. The resulting image name is taken from the definition of the `containerImage` field of the `Module` CR.

--- a/modules/kmm-validation-kickoff.adoc
+++ b/modules/kmm-validation-kickoff.adoc
@@ -6,6 +6,9 @@
 [id="kmm-validation-kickoff_{context}"]
 = Validation kickoff
 
+[role="_abstract"]
+Create a `PreflightValidationOCP` resource to trigger preflight validation and specify the kernel version and DTK image for validation.
+
 Preflight validation is triggered by creating a `PreflightValidationOCP` resource in the cluster. This resource contains the following fields:
 
 `dtkImage`:: The DTK container image released for the specific {product-title} version of the cluster. If this value is not set, the `DTK_AUTO` feature cannot be used.

--- a/modules/kmm-validation-lifecycle.adoc
+++ b/modules/kmm-validation-lifecycle.adoc
@@ -6,6 +6,9 @@
 [id="kmm-validation-lifecycle_{context}"]
 = Validation lifecycle
 
-Preflight validation attempts to validate every module loaded in the cluster. Preflight stops running validation on a `Module` resource after the validation is successful. If module validation fails, you can change the module definitions and Preflight tries to validate the module again in the next loop.
+[role="_abstract"]
+Preflight validation continuously validates all cluster modules, retrying failures after changes until all modules succeed or the validation resource is deleted.
+
+Each module stops being validated after it succeeds individually. Failed modules are retried in subsequent validation loops.
 
 If you want to run Preflight validation for an additional kernel, then you should create another `PreflightValidationOCP` resource for that kernel. After all the modules have been validated, it is recommended to delete the `PreflightValidationOCP` resource.

--- a/modules/kmm-validation-status.adoc
+++ b/modules/kmm-validation-status.adoc
@@ -6,7 +6,10 @@
 [id="kmm-validation-status_{context}"]
 = Validation status
 
-A `PreflightValidationOCP` resource reports the status and progress of each module in the cluster that it attempts or has attempted to validate in its `.status.modules` list. Elements of that list contain the following fields:
+[role="_abstract"]
+The `PreflightValidationOCP` resource reports validation status and progress for each cluster module in its `.status.modules` list.
+
+The following outlines the fields included in the `.status.modules` list:
 
 `name`:: The name of the `Module` resource.
 

--- a/updating/troubleshooting_updates/gathering-data-cluster-update.adoc
+++ b/updating/troubleshooting_updates/gathering-data-cluster-update.adoc
@@ -6,11 +6,12 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 ifndef::openshift-origin[]
-When reaching out to Red Hat support for issues with an update, it is important to provide data for the support team to use for troubleshooting your failed cluster update.
+Collect cluster data, logs, and update history to help Red Hat Support diagnose and troubleshoot failed cluster updates.
 endif::openshift-origin[]
 ifdef::openshift-origin[]
-If your cluster update fails, you can examine cluster data to troubleshoot the failure.
+Collect cluster data, logs, and update history to diagnose and troubleshoot failed cluster updates.
 endif::openshift-origin[]
 
 include::modules/gathering-log-data.adoc[leveloffset=+1]
@@ -27,4 +28,4 @@ include::modules/gathering-clusterversion-history-cli.adoc[leveloffset=+2]
 [id="additional-resources_gathering-cluster-data"]
 .Additional resources
 
-* xref:../../support/gathering-cluster-data.adoc#support_gathering_data_gathering-cluster-data[Gathering data about your cluster]
+* xref:../../support/gathering-cluster-data.adoc#support_gathering_data_gathering-cluster-data[Gathering data about your cluster for Red Hat Support]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Versions:
4.20+

Issue:
https://redhat.atlassian.net/browse/OSDOCS-17075

Link to docs preview:

[Changing CVO log level](https://114838--ocpdocs-pr.netlify.app/openshift-enterprise/latest/updating/troubleshooting_updates/gathering-data-cluster-update.html#changing-log-data_troubleshooting_updates)

[Gathering ClusterVersion history using the OpenShift CLI (oc)](https://114838--ocpdocs-pr.netlify.app/openshift-enterprise/latest/updating/troubleshooting_updates/gathering-data-cluster-update.html#gathering-clusterversion-history-cli_troubleshooting_updates)

[Gathering ClusterVersion history in the OpenShift Container Platform web console](https://114838--ocpdocs-pr.netlify.app/openshift-enterprise/latest/updating/troubleshooting_updates/gathering-data-cluster-update.html#gathering-clusterversion-history-console_troubleshooting_updates)

[About cluster update history](https://114838--ocpdocs-pr.netlify.app/openshift-enterprise/latest/updating/troubleshooting_updates/gathering-data-cluster-update.html#gathering-clusterversion-history_troubleshooting_updates)

[About gathering cluster data for support cases](https://114838--ocpdocs-pr.netlify.app/openshift-enterprise/latest/updating/troubleshooting_updates/gathering-data-cluster-update.html#gathering-log-data_troubleshooting_updates)

[Example PreflightValidationOCP resource](https://114838--ocpdocs-pr.netlify.app/openshift-enterprise/latest/updating/preparing_for_updates/kmm-preflight-validation.html#kmm-example-cr_kmm-preflight-validation)

[Image validation stage](https://114838--ocpdocs-pr.netlify.app/openshift-enterprise/latest/updating/preparing_for_updates/kmm-preflight-validation.html#kmm-image-validation-stage_kmm-preflight-validation)

[Validation status](https://114838--ocpdocs-pr.netlify.app/openshift-enterprise/latest/updating/preparing_for_updates/kmm-preflight-validation.html#kmm-validation-status_kmm-preflight-validation)

[Validation kickoff](https://114838--ocpdocs-pr.netlify.app/openshift-enterprise/latest/updating/preparing_for_updates/kmm-preflight-validation.html#kmm-validation-kickoff_kmm-preflight-validation)

[Validation lifecycle](https://114838--ocpdocs-pr.netlify.app/openshift-enterprise/latest/updating/preparing_for_updates/kmm-preflight-validation.html#kmm-validation-lifecycle_kmm-preflight-validation)

[Validation status](https://114838--ocpdocs-pr.netlify.app/openshift-enterprise/latest/updating/preparing_for_updates/kmm-preflight-validation.html#kmm-validation-status_kmm-preflight-validation)

[Gathering data about your cluster update](https://114838--ocpdocs-pr.netlify.app/openshift-enterprise/latest/updating/troubleshooting_updates/gathering-data-cluster-update)

QE review:
- [ ] QE has approved this change.
QE approval not required. 

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
