### PR TITLE
hc_prefix instead of cp_prefix for configmap

### DIFF
--- a/modules/hosted-control-planes-monitoring-dashboard.adoc
+++ b/modules/hosted-control-planes-monitoring-dashboard.adoc
@@ -36,7 +36,7 @@ data:
 ----
 
 +
-When monitoring dashboards are enabled, for each hosted cluster that the HyperShift Operator manages, the Operator creates a config map named `cp-<hosted_cluster_namespace>-<hosted_cluster_name>` in the `openshift-config-managed` namespace, where `<hosted_cluster_namespace>` is the namespace of the hosted cluster and `<hosted_cluster_name>` is the name of the hosted cluster. As a result, a new dashboard is added in the administrative console of the management cluster.
+When monitoring dashboards are enabled, for each hosted cluster that the HyperShift Operator manages, the Operator creates a config map named `hc-<hosted_cluster_namespace>-<hosted_cluster_name>` in the `openshift-config-managed` namespace, where `<hosted_cluster_namespace>` is the namespace of the hosted cluster and `<hosted_cluster_name>` is the name of the hosted cluster. As a result, a new dashboard is added in the administrative console of the management cluster.
 
 . To view the dashboard, log in to the management cluster's console and go to the dashboard for the hosted cluster by clicking *Observe -> Dashboards*.
 


### PR DESCRIPTION
The ConfigMap created by the HyperShift Operator when enabling the monitoring dashboard for HCP uses the prefix 'hc', whereas the documented steps indicate that the prefix should be 'cp'

Version(s): 4.22

Issue:
https://redhat.atlassian.net/browse/OCPBUGS-97986

Link to docs preview:
https://docs.redhat.com/en/documentation/openshift_container_platform/4.22/html/hosted_control_planes/hcp-observability#hosted-control-planes-monitoring-dashboard_hcp-observability

QE review:
- [x] QE has approved this change.