### PR TITLE
CNV-78320: CLI module is in the wrong place

### DIFF
--- a/modules/virt-uploading-image-virtctl.adoc
+++ b/modules/virt-uploading-image-virtctl.adoc
@@ -4,7 +4,7 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="virt-uploading-image-virtctl_{context}"]
-= Creating a VM from an uploaded image by using the CLI
+= Uploading a virtual machine image by using the CLI
 
 [role="_abstract"]
 You can upload an operating system image by using the `virtctl` command-line tool. You can use an existing data volume or create a new data volume for the image.

--- a/virt/creating_vms_advanced/virt-creating-vms-from-cli.adoc
+++ b/virt/creating_vms_advanced/virt-creating-vms-from-cli.adoc
@@ -15,7 +15,7 @@ You can also create VMs from instance types by using the {product-title} web con
 ====
 
 include::modules/virt-creating-vm-cli.adoc[leveloffset=+1]
-
+include::modules/virt-uploading-image-virtctl.adoc[leveloffset=+1]
 include::modules/virt-supported-custom-video-devices.adoc[leveloffset=+2]
 
 [role="_additional-resources"]


### PR DESCRIPTION
Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
https://redhat.atlassian.net/browse/CNV-78320

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Re-opening the fix for [CNV-78320](https://redhat.atlassian.net/browse/CNV-78320) (previously closed in PR #108353) to correctly restructure the virtual machine CLI documentation according to reviewer feedback.