### PR TITLE
[OSDOCS#RHDEVDOCS-7687]: Red Hat OpenShift Pipelines 1.21.3 release notes

### DIFF
--- a/modules/op-release-notes-1-21-3.adoc
+++ b/modules/op-release-notes-1-21-3.adoc
@@ -1,0 +1,50 @@
+// This module is included in the following assemblies:
+// * release_notes/op-release-notes-1-21.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="op-release-notes-1-21-3_{context}"]
+= Release notes for {pipelines-title} 1.21.3
+
+[role="_abstract"]
+With this update, {pipelines-title} General Availability (GA) 1.21.3 is available on {OCP} 4.14 and later supported versions.
+
+[id="new-features-1-21-3_{context}"]
+== New features and enhancements
+
+.{pac}
+Pipelines-as-Code informer caches consume less memory::
+With this update, {pac} strips large unused fields from cached objects in informer caches. This change reduces per-object memory consumption by up to 94%, significantly lowering the memory footprint of the controller watcher pods in clusters with many cached objects. This change is internal and does not affect the functional behavior of user workloads; all required data continues to be fetched directly from the API when needed.
++
+link:https://issues.redhat.com/browse/SRVKP-11061[SRVKP-11061]
+
+[id="pipelines-fixed-issues-1-21-3_{context}"]
+== Fixed issues
+
+.{pac}
+Webhook validation prevents credential exfiltration to unauthorized servers::
+Before this update, when {pac} received a webhook from GitHub Enterprise, it read an unverified header in the request to determine which GitHub Enterprise server address to contact for an authentication token. As a consequence, an attacker could forge the server address in the header, causing the controller to send a valid GitHub App installation token to an attacker-controlled server. With this update, the controller validates the enterprise host header request. As a result, the GitHub App credentials cannot be exfiltrated to an unauthorized server.
++
+link:https://issues.redhat.com/browse/SRVKP-12216[SRVKP-12216]
+
+GitHub App installation tokens are strictly scoped to the triggering repository::
+Before this update, if the `secret-github-app-scope-extra-repos` parameter was not set in the configuration, GitHub App installation tokens issued during webhook processing were not scoped to the triggering repository by default. As a consequence, a user with push access to one repository could create a `PipelineRun` object with a remote task annotation pointing to a private repository in the same installation, exposing the contents of its Tekton definitions. With this update, installation tokens are scoped to only the triggering repository by default. As a result, remote task resolution for unauthorized private repositories fails with a 404 error.
++
+[IMPORTANT]
+====
+If your `PipelineRun` objects fetch remote tasks or pipelines from other private repositories in the same installation, you must add those repositories to the `secret-github-app-scope-extra-repos` parameter in the `pipelines-as-code` config map in a comma-separated `owner/repository` format.
+====
++
+Additionally, this update fixes a bug where cached remote Pipeline and Task objects were mutated during inlining, causing subsequent `PipelineRun` objects referencing the same remote resource to receive corrupted definitions. Cached objects are now deep-copied before use.
++
+link:https://issues.redhat.com/browse/SRVKP-12241[SRVKP-12241]
+
+Admission controller correctly rejects duplicate repository configurations::
+Before this update, the {pac} admission webhook did not normalize repository URLs before checking for duplicates. As a consequence, multiple `Repository` custom resources could be created for the same repository if the URLs differed only by a trailing slash, causing configuration conflicts and unpredictable pipeline runs. With this update, the admission controller treats URLs with and without trailing slashes as identical. As a result, duplicate repository configurations are correctly rejected, preventing the creation of multiple resources for the same repository URL.
++
+link:https://issues.redhat.com/browse/SRVKP-11295[SRVKP-11295]
+
+.User interface
+Approvals list view displays the Current status column correctly without text overlaps::
+Before this update, text components in the Current status column of the Approvals tab interface in the {OCP} web console occasionally failed to render correctly. As a consequence, multiple status components rendered on top of one another, making the text superimposed and unreadable under certain screen sizes or user login sessions. With this update, the alignment logic for the status column is corrected. As a result, the status values render distinctly and are easy to read.
++
+link:https://issues.redhat.com/browse/SRVKP-9448[SRVKP-9448]

--- a/release_notes/op-release-notes-1-21.adoc
+++ b/release_notes/op-release-notes-1-21.adoc
@@ -1,9 +1,10 @@
 :_mod-docs-content-type: ASSEMBLY
-//OpenShift Pipelines Release Notes
 include::_attributes/common-attributes.adoc[]
+//OpenShift Pipelines Release Notes
 [id="op-release-notes-1-21"]
 = {pipelines-title} release notes
 :context: op-release-notes-1-21
+
 
 toc::[]
 
@@ -28,6 +29,9 @@ For an overview of {pipelines-title}, see xref:../about/understanding-openshift-
 
 // Compatibility and support matrix 1.21
 include::modules/op-tkn-pipelines-compatibility-support-matrix.adoc[leveloffset=+1]
+
+// Release notes for Red Hat OpenShift Pipelines 1.21.3
+include::modules/op-release-notes-1-21-3.adoc[leveloffset=+1]
 
 // Release notes for Red Hat OpenShift Pipelines 1.21.2
 include::modules/op-release-notes-1-21-2.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s):
pipelines-docs-1.21

none for cherry-picking 

Issue:
https://issues.redhat.com/browse/RHDEVDOCS-7687

Link to docs preview:
https://114849--ocpdocs-pr.netlify.app/openshift-pipelines/latest/release_notes/op-release-notes-1-21.html 

Peer review:
@ochromy 

QE review:
@srivickynesh 
@zakisk 
@theakshaypant 

Additional information:
Z-stream release notes