### PR TITLE
OSDOCS-17079-2: CQA 2.0 for SUPP-1: Remote Health Monitoring (Insight

### DIFF
--- a/modules/insights-operator-configuring-sca.adoc
+++ b/modules/insights-operator-configuring-sca.adoc
@@ -8,10 +8,9 @@
 = Configuring simple content access import interval
 
 [role="_abstract"]
-You can configure how often the {insights-operator} imports the simple content access (sca) entitlements by using the *insights-config* `ConfigMap` object in the `openshift-insights` namespace. The entitlement import normally occurs every eight hours, but you can shorten this sca interval if you update your simple content access configuration in the *insights-config* `ConfigMap` object.
+You can configure how often the {insights-operator} imports the simple content access (sca) entitlements by using the `insights-config` `ConfigMap` object in the `openshift-insights` namespace. The entitlement import normally occurs every eight hours, but you can shorten this sca interval if you update your simple content access configuration in the `insights-config` `ConfigMap` object.
 
 This procedure describes how to update the import interval to two hours (2h). You can specify hours (h) or hours and minutes, for example: 2h30m.
-
 
 .Prerequisites
 
@@ -24,13 +23,16 @@ ifdef::openshift-rosa,openshift-dedicated[]
 endif::openshift-rosa,openshift-dedicated[]
 * The *insights-config* `ConfigMap` object exists in the `openshift-insights` namespace.
 
-
 .Procedure
 
 . Go to *Workloads* -> *ConfigMaps* and select *Project: openshift-insights*.
+
 . Click on the *insights-config* `ConfigMap` object to open it.
+
 . Click *Actions* and select *Edit ConfigMap*.
+
 . Click the *YAML view* radio button.
+
 . Set the `sca` attribute in the file to `interval: 2h` to import content every two hours.
 +
 [source,yaml]
@@ -46,4 +48,5 @@ data:
 ----
 
 . Click *Save*. The *insights-config* config-map details page opens.
+
 . Verify that the value of the `config.yaml` `sca` attribute is set to `interval: 2h`.

--- a/modules/insights-operator-disabling-sca.adoc
+++ b/modules/insights-operator-disabling-sca.adoc
@@ -2,26 +2,29 @@
 //
 // * support/remote_health_monitoring/insights-operator-simple-access.adoc
 
-
 :_mod-docs-content-type: PROCEDURE
 [id="insights-operator-disabling-sca_{context}"]
 = Disabling simple content access import
 
 [role="_abstract"]
-You can disable the importing of simple content access entitlements by using the *insights-config* `ConfigMap` object in the `openshift-insights` namespace.
+You can disable the importing of simple content access entitlements by using the `insights-config` `ConfigMap` object in the `openshift-insights` namespace.
 
 .Prerequisites
 
 * Remote health reporting is enabled, which is the default.
 * You are logged in to the {product-title} web console as `cluster-admin`.
-* The *insights-config* `ConfigMap` object exists in the `openshift-insights` namespace.
+* The `insights-config` `ConfigMap` object exists in the `openshift-insights` namespace.
 
 .Procedure
 
 . Go to *Workloads* -> *ConfigMaps* and select *Project: openshift-insights*.
+
 . Click the *insights-config* `ConfigMap` object to open it.
+
 . Click *Actions* and select *Edit ConfigMap*.
+
 . Click *YAML view*.
+
 . In the file, set the `sca` attribute to `disabled: true`.
 +
 [source,yaml]
@@ -37,4 +40,5 @@ data:
 ----
 
 . Click *Save*. The *insights-config* config-map details page opens.
+
 . Verify that the value of the `config.yaml` `sca` attribute is set to `disabled: true`.

--- a/modules/insights-operator-enable-obfuscation.adoc
+++ b/modules/insights-operator-enable-obfuscation.adoc
@@ -2,8 +2,6 @@
 //
 // * support/remote_health_monitoring/remote-health-reporting-from-restricted-network.adoc
 
-
-
 :_mod-docs-content-type: PROCEDURE
 [id="insights-operator-enable-obfuscation_{context}"]
 = Enabling {insights-operator} data obfuscation
@@ -29,22 +27,33 @@ The following procedure enables obfuscation using the `support` secret in the `o
 .Procedure
 
 . Navigate to *Workloads* -> *Secrets*.
+
 . Select the *openshift-config* project.
+
 . Search for the *support* secret using the *Search by name* field. If it does not exist, click *Create* -> *Key/value secret* to create it.
+
 . Click the Options menu {kebab}, and then click *Edit Secret*.
+
 . Click *Add Key/Value*.
+
 . Create a key named `enableGlobalObfuscation` with a value of `true`, and click *Save*.
+
 . Navigate to *Workloads* -> *Pods*
+
 . Select the `openshift-insights` project.
+
 . Find the `insights-operator` pod.
+
 . To restart the `insights-operator` pod, click the Options menu {kebab}, and then click *Delete Pod*.
 
 .Verification
 
 . Navigate to *Workloads* -> *Secrets*.
+
 . Select the *openshift-insights* project.
+
 . Search for the *obfuscation-translation-table* secret using the *Search by name* field.
-
++
 If the `obfuscation-translation-table` secret exists, then obfuscation is enabled and working.
-
++
 Alternatively, you can inspect `/insights-operator/gathers.json` in your {insights-operator} archive for the value `"is_global_obfuscation_enabled": true`.

--- a/modules/insights-operator-enabling-sca.adoc
+++ b/modules/insights-operator-enabling-sca.adoc
@@ -19,14 +19,18 @@ endif::openshift-rosa,openshift-dedicated[]
 ifdef::openshift-rosa,openshift-dedicated[]
 * You have logged in to the {product-title} web console as a user with the `dedicated-admin` role.
 endif::openshift-rosa,openshift-dedicated[]
-* The *insights-config* `ConfigMap` object exists in the `openshift-insights` namespace.
+* The `insights-config` `ConfigMap` object exists in the `openshift-insights` namespace.
 
 .Procedure
 
 . Go to *Workloads* -> *ConfigMaps* and select *Project: openshift-insights*.
+
 . Click on the *insights-config* `ConfigMap` object to open it.
+
 . Click *Actions* and select *Edit ConfigMap*.
+
 . Click the *YAML view* radio button.
+
 . In the file, set the `sca` attribute to `disabled: false`.
 +
 [source,yaml]
@@ -42,4 +46,5 @@ data:
 ----
 
 . Click *Save*. The *insights-config* config-map details page opens.
+
 . Verify that the value of the `config.yaml` `sca` attribute is set to `disabled: false`.

--- a/modules/insights-operator-manual-upload.adoc
+++ b/modules/insights-operator-manual-upload.adoc
@@ -23,6 +23,7 @@ You can manually upload an {insights-operator} archive to link:https://console.r
 ----
 $ oc extract secret/pull-secret -n openshift-config --to=.
 ----
+
 . Copy your `"cloud.openshift.com"` `"auth"` token from the `dockerconfig.json` file:
 +
 [source,json,subs="+quotes"]
@@ -42,7 +43,12 @@ $ oc extract secret/pull-secret -n openshift-config --to=.
 ----
 $ curl -v -H "User-Agent: insights-operator/one10time200gather184a34f6a168926d93c330 cluster/_<cluster_id>_" -H "Authorization: Bearer _<your_token>_" -F "upload=@_<path_to_archive>_; type=application/vnd.redhat.openshift.periodic+tar" https://console.redhat.com/api/ingress/v1/upload
 ----
-where `_<cluster_id>_` is your cluster ID, `_<your_token>_` is the token from your pull secret, and `_<path_to_archive>_` is the path to the {insights-operator} archive.
++
+where:
++
+`<cluster_id>`:: Specifies the cluster ID.
+`<your_token>`:: Specifies the token from your pull secret. 
+`<path_to_archive>`:: Specifies the path to the {insights-operator} archive.
 +
 If the operation is successful, the command returns a `"request_id"` and `"account_number"`:
 +
@@ -54,6 +60,7 @@ If the operation is successful, the command returns a `"request_id"` and `"accou
 ----
 
 .Verification
+
 . Log in to link:https://console.redhat.com/openshift[].
 
 . Click the *Cluster List* menu in the left pane.

--- a/modules/insights-operator-one-time-gather.adoc
+++ b/modules/insights-operator-one-time-gather.adoc
@@ -2,8 +2,6 @@
 //
 // * support/remote_health_monitoring/remote-health-reporting-from-restricted-network.adoc
 
-
-
 :_mod-docs-content-type: PROCEDURE
 [id="insights-operator-one-time-gather_{context}"]
 = Running an {insights-operator} gather operation
@@ -23,6 +21,7 @@ You must run a gather operation to create an {insights-operator} archive.
 ----
 include::https://raw.githubusercontent.com/openshift/insights-operator/release-4.22/docs/gather-job.yaml[]
 ----
+
 . Copy your `insights-operator` image version:
 +
 [source,terminal]
@@ -72,8 +71,7 @@ spec:
       volumeMounts:
 ----
 +
-where::
-`spec.template.initContainers.image`:: Replace any existing value with your `insights-operator` image version.
+Replace the value of `spec.template.initContainers.image` with your `insights-operator` image version.
 
 . Create the gather job:
 +
@@ -81,6 +79,7 @@ where::
 ----
 $ oc apply -n openshift-insights -f gather-job.yaml
 ----
+
 . Find the name of the job pod:
 +
 [source,terminal]
@@ -100,7 +99,7 @@ Events:
   Normal  SuccessfulCreate  7m18s  job-controller  Created pod: insights-operator-job-<your_job>
 ----
 +
-where:: `insights-operator-job-<your_job>` is the name of the pod.
+Replace `insights-operator-job-<your_job>` with the name of the pod.
 
 . Verify that the operation has finished:
 +
@@ -114,12 +113,14 @@ $ oc logs -n openshift-insights insights-operator-job-<your_job> insights-operat
 ----
 I0407 11:55:38.192084       1 diskrecorder.go:34] Wrote 108 records to disk in 33ms
 ----
+
 . Save the created archive:
 +
 [source,terminal,subs="+quotes"]
 ----
 $ oc cp openshift-insights/insights-operator-job-_<your_job>_:/var/lib/insights-operator ./insights-data
 ----
+
 . Clean up the job:
 +
 [source,terminal]

--- a/support/remote_health_monitoring/insights-operator-simple-access.adoc
+++ b/support/remote_health_monitoring/insights-operator-simple-access.adoc
@@ -9,7 +9,9 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 [role="_abstract"]
-{insights-operator} automates the import of Simple Content Access (SCA) entitlement certificates every 8 hours. These Red{nbsp}Hat Subscription Management (RHSM) certificates allow the cluster to authenticate with the Red{nbsp}Hat Content Delivery Network (CDN) to access subscription-governed content. SCA supports multi-architecture clusters by generating architecture-specific secrets, such as `amd64` or `arm64`, in the `openshift-config-managed` namespace to ensure compatibility across all worker node types.
+{insights-operator} automates the import of Simple Content Access (SCA) entitlement certificates every 8 hours. These Red{nbsp}Hat Subscription Management (RHSM) certificates allow the cluster to authenticate with the Red{nbsp}Hat Content Delivery Network (CDN) to access subscription-governed content. 
+
+SCA supports multi-architecture clusters by generating architecture-specific secrets, such as `amd64` or `arm64`, in the `openshift-config-managed` namespace to ensure compatibility across all worker node types.
 
 [role="_additional-resources"]
 .Additional resources

--- a/support/remote_health_monitoring/remote-health-reporting-from-restricted-network.adoc
+++ b/support/remote_health_monitoring/remote-health-reporting-from-restricted-network.adoc
@@ -15,7 +15,12 @@ To use the {insights-operator} in a restricted network, you must:
 * Create a copy of your {insights-operator} archive.
 * Upload the {insights-operator} archive to link:https://console.redhat.com[console.redhat.com].
 
-Additionally, you can select to xref:../../support/remote_health_monitoring/remote-health-reporting-from-restricted-network.adoc#insights-operator-enable-obfuscation_remote-health-reporting-from-restricted-network[obfuscate] the {insights-operator} data before upload.
+Additionally, you can select to obfuscate the {insights-operator} data before data upload.
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../support/remote_health_monitoring/remote-health-reporting-from-restricted-network.adoc#insights-operator-enable-obfuscation_remote-health-reporting-from-restricted-network[Enabling {insights-operator} data obfuscation]
 
 include::modules/insights-operator-one-time-gather.adoc[leveloffset=+1]
 


### PR DESCRIPTION
Version(s):
4.20+

Issue:
[OSDOCS-17079](https://redhat.atlassian.net/browse/OSDOCS-17079)

Link to docs preview:

* https://114850--ocpdocs-pr.netlify.app/openshift-enterprise/latest/support/remote_health_monitoring/insights-operator-simple-access.html
* https://114850--ocpdocs-pr.netlify.app/openshift-enterprise/latest/support/remote_health_monitoring/remote-health-reporting-from-restricted-network.html


support/remote_health_monitoring/about-remote-health-monitoring.adoc
