### PR TITLE
[WIP]OCPBUGS-97967: RN:  Privilege Escalation via Device Plugin DaemonSet

### DIFF
--- a/hardware_enablement/kmm-release-notes.adoc
+++ b/hardware_enablement/kmm-release-notes.adoc
@@ -411,6 +411,20 @@ Kernel Module Management (KMM) 2.5 is now supported on {ibm-z-title} architectur
 
 ** *Result*: ROSA controller pods start successfully. 
 
+[id="kmm-2-5-2-RN"]
+== Release notes for Kernel Module Management Operator 2.5.2
+=== Notable technical changes
+// OCPBUGS-97967
+* Privilege escalation issue in the Device Plugin DaemonSet
+
+** *Cause*: A privilege escalation vulnerability exists in the Device Plugin DaemonSet when creating namespace-scoped Module CRs that could allow tenants to run arbitrary code as root on nodes. 
+
+** *Consequence*: Because the Module CR is namespace-scoped, any user who can create a Module CR can run arbitrary code as root on every matched node with full host filesystem access.
+
+** *Fix*: Device plugin volume mounts are now limited to the following paths: `/dev`, `/sys`, `/var`, `/run`, and `/opt`. Webhook validation rejects disallowed paths such as `/`, `/etc`, and `/root` to reduce security risks.
+
+** *Result*: The webhook now rejects disallowed `hostPath` paths and accepts only explicitly allowed paths to ensure safer volume mounting.
+
 [id="kmm-2-6-RN"]
 == Release notes for Kernel Module Management Operator 2.6
 === New features and enhancements
@@ -483,3 +497,16 @@ For more information, see https://redhat.atlassian.net/browse/MGMT-19647[MGMT-19
 * Issues have been encountered when loading out-of-tree (OOT) drivers for QDU x100 DU PCIe cards from v4.14. For more information, see link:https://access.redhat.com/support/cases/#/case/04245147[Case 04245147].
 
 
+[id="kmm-2-6-1-RN"]
+== Release notes for Kernel Module Management Operator 2.6.1
+=== Notable technical changes
+// OCPBUGS-97967
+* Privilege escalation issue in the Device Plugin DaemonSet
+
+** *Cause*: A privilege escalation vulnerability exists in the Device Plugin DaemonSet when creating namespace-scoped Module CRs that could allow tenants to run arbitrary code as root on nodes. 
+
+** *Consequence*: Because the Module CR is namespace-scoped, any user who can create a Module CR can run arbitrary code as root on every matched node with full host filesystem access.
+
+** *Fix*: Device plugin volume mounts are now limited to the following paths: `/dev`, `/sys`, `/var`, `/run`, and `/opt`. Webhook validation rejects disallowed paths such as `/`, `/etc`, and `/root` to reduce security risks.
+
+** *Result*: The webhook now rejects disallowed `hostPath` paths and accepts only explicitly allowed paths to ensure safer volume mounting.


### PR DESCRIPTION
[MGMT-24507] CVE - Privilege Escalation via Device Plugin DaemonSet

Version: 4.18+

KMM version: 2.5.2 and 2.6.1

Jira: https://redhat.atlassian.net/browse/OCPBUGS-97967

Preview: https://114871--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hardware_enablement/kmm-release-notes.html#kmm-2-5-2-RN

Dev: @ybettan 
QE: @ybrodsky-rh 