### PR TITLE
CNV-92277: Disks per VM maximum tested value should be added to supported limits documentation

### DIFF
--- a/modules/virt-tested-maximums.adoc
+++ b/modules/virt-tested-maximums.adoc
@@ -22,6 +22,8 @@ Maximums apply to virtual machines (VMs) running on {VirtProductName} and are su
 |Memory |6 TB |16 TB
 |Single disk size |100 TB |100 TB
 |Hot-pluggable disks |255 disks |N/A
+|Attached disks (virtio) |160 disks |170 disks
+|Attached disks (SCSI) |200 disks |N/A
 |===
 
 [NOTE]


### PR DESCRIPTION
Resolves: https://redhat.atlassian.net/browse/CNV-92277

CNV 4.22+
OCP 4.22+

Preview: https://114876--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/about_virt/virt-supported-limits.html#vm-maximums_virt-supported-limits