### PR TITLE
OSDOCS CQA Nodes/MCO/WMCO misc plus sign follow up

### DIFF
--- a/modules/coreos-layering-install-time.adoc
+++ b/modules/coreos-layering-install-time.adoc
@@ -65,6 +65,7 @@ type: kubernetes.io/dockerconfigjson
 ----
 $ cp <file-name>.yaml manifests/
 ----
++
 where:
 +
 `file-name`:: Specifies the YAML file for the `MachineOSConfig` object.
@@ -75,6 +76,7 @@ where:
 ----
 $ cp <file-name>.yaml manifests/
 ----
++
 where:
 +
 `file-name`:: Specifies the YAML file for the push secret.
@@ -110,6 +112,7 @@ items:
       type: Seeded
     currentImagePullSpec: image-registry.openshift-image-registry.svc:5000/openshift-machine-config-operator/layered-rhcos@sha256:3c8fc667adcb432ce0c83581f16086afec08a961dd28fed69bb6bad6db0a0754 
 ----
++
 where:
 +
 --

--- a/modules/creating-runtimeclass.adoc
+++ b/modules/creating-runtimeclass.adoc
@@ -40,6 +40,7 @@ scheduling:
     operator: Equal
     value: "Windows"
 ----
++
 where:
 
 `metadata.name`:: Specifies the `RuntimeClass` object name, which is defined in the pods you want to be managed by this runtime class.
@@ -75,6 +76,7 @@ spec:
   runtimeClassName: windows2025
 # ...
 ----
++
 where:
 
 `spec.runtimeClassName`:: Specifies the runtime class to manage the scheduling of your pod.

--- a/modules/deleting-cluster-autoscaler.adoc
+++ b/modules/deleting-cluster-autoscaler.adoc
@@ -37,6 +37,7 @@ default   42m
 $ oc get ClusterAutoscaler/default \
   -o yaml> <cluster_autoscaler_backup_name>.yaml
 ----
++
 where:
 
 <cluster_autoscaler_backup_name>:: Specifies the file name in which to store the backup.

--- a/modules/deleting-machine-autoscaler.adoc
+++ b/modules/deleting-machine-autoscaler.adoc
@@ -39,6 +39,7 @@ $ oc get MachineAutoscaler/<machine_autoscaler_name> \
   -n openshift-machine-api \
   -o yaml> <machine_autoscaler_name_backup>.yaml
 ----
++
 where:
 
 <machine_autoscaler_name_backup>:: Specifies the file name in which to store the backup.

--- a/modules/nodes-nodes-additional-crio-storage-configuring.adoc
+++ b/modules/nodes-nodes-additional-crio-storage-configuring.adoc
@@ -61,6 +61,7 @@ spec:
     additionalLayerStores:
       - path: /var/lib/stargz-store
 ----
++
 where:
 +
 --

--- a/modules/nodes-nodes-audit-policy-custom.adoc
+++ b/modules/nodes-nodes-audit-policy-custom.adoc
@@ -46,6 +46,7 @@ spec:
       profile: AllRequestBodies
     profile: Default
 ----
++
 where:
 +
 `customRules`:: Add one or more groups and specify the profile to use for that group. These custom rules take precedence over the top-level profile field. The custom rules are evaluated from top to bottom, and the first that matches is applied.

--- a/modules/nodes-nodes-audit-policy.adoc
+++ b/modules/nodes-nodes-audit-policy.adoc
@@ -34,6 +34,7 @@ spec:
   audit:
     profile: WriteRequestBodies
 ----
++
 where:
 +
 `profile`:: Set to `Default`, `WriteRequestBodies`, `AllRequestBodies`, or `None`. The default profile is `Default`.

--- a/modules/nodes-nodes-psi-enable.adoc
+++ b/modules/nodes-nodes-psi-enable.adoc
@@ -34,6 +34,7 @@ spec:
   kernelArguments:
     - psi=1
 ----
++
 where:
 +
 `metadata.labels.machineconfiguration.openshift.io/role:<label>`:: Specifies the role of the nodes where you want to enable PSI.
@@ -78,6 +79,7 @@ sh-5.1# cat /proc/cmdline | grep psi=1
 ----
 BOOT_IMAGE=(hd0,gpt3)/boot/ostree/rhcos-462f0c234e81f17224d7dbd4dc22d3f7046f70179e259c41a0a807e8b2f99428/vmlinuz-5.14.0-570.80.1.el9_6.x86_64 rw ostree=/ostree/boot.0/rhcos/462f0c234e81f17224d7dbd4dc22d3f7046f70179e259c41a0a807e8b2f99428/0 ignition.platform.id=gcp console=tty0 console=ttyS0,115200n8 root=UUID=d8254ef4-668e-49c5-b430-a45eefb834d7 rw rootflags=prjquota boot=UUID=22972ae8-ed08-43ff-931d-49e6d737c542 systemd.unified_cgroup_hierarchy=1 cgroup_no_v1=all psi=1
 ----
++
 where:
 
 `psi=1`:: Specifies that PSI is enabled on the node.
@@ -94,6 +96,7 @@ sh-5.1# ls /proc/pressure/
 ----
 cpu  io  irq  memory
 ----
++
 where:
 
  `cpu`, `io`, `irq`, and `memory`:: Specifies the pressure files, indicating the PSI is enabled.
@@ -110,6 +113,7 @@ where:
 ----
 some avg10=0.91 avg60=1.05 avg300=1.28 total=61523749                                                                                                                                                                                                      full avg10=0.00 avg60=0.00 avg300=0.00 total=0
 ----
++
 where:
 +
 --


### PR DESCRIPTION
I neglected to add the + character before the where: when doing call-out replacements. This PR fixes that oversight for a manual review of Nodes/MCO/WMCO files.

https://redhat.atlassian.net/browse/OSDOCS-16929

Previews:

[Applying a custom layered image during OpenShift Container Platform installation](https://114881--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_configuration/mco-coreos-layering.html#coreos-layering-install-time_mco-coreos-layering)
[Disabling a machine autoscaler](https://114881--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/applying-autoscaling.html#deleting-machine-autoscaler_applying-autoscaling)
[Disabling the cluster autoscaler](https://114881--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/applying-autoscaling.html#deleting-cluster-autoscaler_applying-autoscaling)
[Configuring additional storage locations for CRI-O](https://114881--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/nodes/nodes-nodes-additional-crio-storage.html#nodes-nodes-additional-crio-storage-configuring_nodes-nodes-additional-crio-storage)
[Enabling Pressure Stall Information (PSI) monitoring](https://114881--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/nodes/nodes-nodes-managing.html#nodes-nodes-psi-enable_nodes-nodes-managing)
[Configuring the audit log policy](https://114881--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/audit-log-policy-config.html#configuring-audit-policy_audit-log-policy-config)
[Configuring the audit log policy with custom rules](https://114881--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/audit-log-policy-config.html#configuring-audit-policy-custom_audit-log-policy-config)
[Creating a RuntimeClass object to encapsulate scheduling mechanisms](https://114881--ocpdocs-pr.netlify.app/openshift-enterprise/latest/windows_containers/scheduling-windows-workloads.html#creating-runtimeclass_scheduling-windows-workloads)