### PR TITLE
HCCDOC-5255: Insights Operator: Option to Disable Runtime Extractor

### DIFF
--- a/modules/insights-operator-configuring-configmap.adoc
+++ b/modules/insights-operator-configuring-configmap.adoc
@@ -24,6 +24,7 @@ data:
       storagePath: /var/lib/insights-operator
       downloadEndpoint: https://console.redhat.com/api/insights-results-aggregator/v2/cluster/%s/reports
       conditionalGathererEndpoint: https://console.redhat.com/api/gathering/gathering_rules
+      disableRuntimeExtractor: true
     sca:
         disabled: false
         endpoint: https://api.openshift.com/api/accounts_mgmt/v1/entitlement_certificates
@@ -96,6 +97,11 @@ The `insights-config` `ConfigMap` object follows standard YAML formatting, where
 |URL
 |https://console.redhat.com/api/gathering/gathering_rules
 
+|dataReporting:
+    disableRuntimeExtractor: true
+|When set to true, it disables the deployment and management of all insights-runtime-extractor resources.
+|Boolean
+|`false`
 
 |dataReporting:
     obfuscation:

--- a/modules/insights-operator-configuring.adoc
+++ b/modules/insights-operator-configuring.adoc
@@ -18,4 +18,3 @@ The `ConfigMap` object does not exist by default, so an {product-title} cluster 
 //====
 //{red-hat-lightspeed} encourages cluster administrators to use the config-map configuration method. Support secrets will continue to be supported in the near future but will eventually be deprecated.
 //====
-


### PR DESCRIPTION
Version(s):
4.19+

Issue:
https://redhat.atlassian.net/browse/HCCDOC-5255

Link to docs preview:
https://114887--ocpdocs-pr.netlify.app/openshift-enterprise/latest/support/remote_health_monitoring/using-insights-operator.html

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

