### PR TITLE
CMA RN add 2.18.2 RN back

### DIFF
--- a/modules/nodes-pods-autoscaling-custom-rn-218.adoc
+++ b/modules/nodes-pods-autoscaling-custom-rn-218.adoc
@@ -9,11 +9,23 @@
 [role="_abstract"]
 You can review the following release notes to learn about changes in the 2.18.z releases.
 
-:_mod-docs-content-type: REFERENCE
-[id="nodes-pods-autoscaling-custom-rn-2181_{context}"]
-= Custom Metrics Autoscaler Operator 2.18.1-1 release notes
+[id="nodes-pods-autoscaling-custom-rn-2181-2_{context}"]
+== Custom Metrics Autoscaler Operator 2.18.1-2 release notes
 
-[role="_abstract"]
+Issued: 09 February 2026
+
+You can review the following release notes to learn about the bug fixes provided in this release of the Custom Metrics Autoscaler Operator.
+
+This release of the Custom Metrics Autoscaler Operator 2.18.1-2 addresses Common Vulnerabilities and Exposures (CVEs). The following advisory is available for the Custom Metrics Autoscaler Operator: link:https://access.redhat.com/errata/RHSA-2026:2368[RHSA-2026:2368]
+
+[IMPORTANT]
+====
+Before installing this version of the Custom Metrics Autoscaler Operator, remove any previously installed Technology Preview versions or the community-supported version of Kubernetes-based Event Driven Autoscaler (KEDA).
+====
+
+[id="nodes-pods-autoscaling-custom-rn-2181_{context}"]
+== Custom Metrics Autoscaler Operator 2.18.1-1 release notes
+
 This release of the Custom Metrics Autoscaler Operator 2.18.1-1, which provides new features and enhancements, deprecated features, and bug fixes for running the Operator in an {product-title} cluster, was issued on 15 January 2026. Review the following information to understand important changes in this release. 
 
 The following advisory is available for the Custom Metrics Autoscaler Operator: link:https://access.redhat.com/errata/RHBA-2026:0730[RHBA-2026:0730]


### PR DESCRIPTION
When compiling the CMA release notes for 2.19.0, I [removed the current release notes for 2.18.2 from the current release notes page](https://github.com/openshift/openshift-docs/pull/110102/changes), but neglected to add to past release notes. This PR corrects that. 

[Custom Metrics Autoscaler Operator 2.18.1-2 release notes](https://114898--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/cma/nodes-cma-rn/nodes-cma-autoscaling-custom-rn-past.html#nodes-pods-autoscaling-custom-rn-2181-2_nodes-cma-autoscaling-custom-rn-past)