### PR TITLE
OSDOCS-20617-1 deleted topic from SPIFFE Helper doc

### DIFF
--- a/security/zero_trust_workload_identity_manager/zero-trust-manager-spiffe-helper.adoc
+++ b/security/zero_trust_workload_identity_manager/zero-trust-manager-spiffe-helper.adoc
@@ -18,9 +18,6 @@ include::modules/zero-trust-manager-spiffe-helper-modes.adoc[leveloffset=+1]
 // spiffe helper credential types
 include::modules/zero-trust-manager-spiffe-helper-credential-types.adoc[leveloffset=+1]
 
-// spiffe helper architecture
-include::modules/zero-trust-manager-spiffe-helper-architecture.adoc[leveloffset=+1]
-
 // deploy spiffe helper
 include::modules/zero-trust-manager-deploy-spiffe-helper.adoc[leveloffset=+1]
 


### PR DESCRIPTION
Version(s):
4.21+

Issue:
https://redhat.atlassian.net/browse/OSDOCS-20617

Link to docs preview:
https://114906--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/zero_trust_workload_identity_manager/zero-trust-manager-spiffe-helper.html

QE review:
- [x] QE has approved this change.


Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
