### PR TITLE
OSDOCS#18812: [CQA 2.0] - RHDE

### DIFF
--- a/modules/about-rhde.adoc
+++ b/modules/about-rhde.adoc
@@ -6,6 +6,7 @@
 [id="about-rhde_{context}"]
 = About {product-title}
 
+[role="_abstract"]
 {product-title} is for organizations that need small-form-factor edge devices and support for bare metal, virtualized, or containerized applications. {product-title} is a solution for large-scale computing at the device edge that combines {microshift-short} and an edge-optimized {op-system-first} operating system. {microshift-short} is a Kubernetes orchestration in a smaller, lighter-weight footprint. Together, these components of {product-title} provide all of the benefits of containers deployed to the edge. You can manage {product-title} by using {ansible}.
 
 .{product-title} components

--- a/overview/rhde-overview.adoc
+++ b/overview/rhde-overview.adoc
@@ -3,6 +3,7 @@
 include::_attributes/common-attributes.adoc[]
 :context: device-edge-overview
 
+[role="_abstract"]
 {product-title} delivers an enterprise-ready distribution of the Red Hat-led open source community project {microshift-first} with {op-system-first} and {ansible}.
 
 include::modules/about-rhde.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s):
4

Issue:
[OSDOCS-18812](https://redhat.atlassian.net/browse/OSDOCS-18812)

Link to docs preview:
[Red Hat Device Edge overview](https://114926--ocpdocs-pr.netlify.app/openshift-rhde/latest/overview/rhde-overview.html)

QE review:
- [ ] QE has approved this change.
N/A for CQAs

Additional information:
There is no version of RHDE. `4` was assigned to align with OCP and MicroShift.
