### PR TITLE
QE review fixes for OSDOCS-19890: multi-cluster OSSM+SPIRE federation

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -1335,7 +1335,7 @@ Topics:
     File: zero-trust-manager-proxy
   - Name: Configuring Zero Trust Workload Identity Manager OIDC Federation
     File: zero-trust-manager-oidc-federation
-  - Name: Configuring Zero Trust Worload Identity Manager SPIRE Federation
+  - Name: Configuring Zero Trust Workload Identity Manager SPIRE Federation
     File: zero-trust-manager-spire-federation
   - Name: Using the SPIFFE Helper container image
     File: zero-trust-manager-spiffe-helper

--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -1335,10 +1335,12 @@ Topics:
     File: zero-trust-manager-proxy
   - Name: Configuring Zero Trust Workload Identity Manager OIDC Federation
     File: zero-trust-manager-oidc-federation
-  - Name: Configuring Zero Trust Workload Identity Manager SPIRE Federation
+  - Name: Configuring Zero Trust Worload Identity Manager SPIRE Federation
     File: zero-trust-manager-spire-federation
   - Name: Using the SPIFFE Helper container image
     File: zero-trust-manager-spiffe-helper
+  - Name: Integrating SPIRE federation with multi-cluster Red Hat OpenShift Service Mesh
+    File: zero-trust-manager-mesh-integration-multi-cluster
   - Name: Enabling create-only mode for the Zero Trust Workload Identity Manager
     File: zero-trust-manager-reconciliation
   - Name: SPIRE UpstreamAuthority plugins for Zero Trust Workload Identity Manager

--- a/modules/zero-trust-manager-configure-spire-mesh-multi-cluster.adoc
+++ b/modules/zero-trust-manager-configure-spire-mesh-multi-cluster.adoc
@@ -1,0 +1,137 @@
+// Module included in the following assemblies:
+//
+// * security/zero_trust_workload_identity_manager/zero-trust-manager-mesh-integration-multi-cluster.adoc.
+
+:_mod-docs-content-type: PROCEDURE
+[id="zero-trust-manager-configure-spire-mesh-multi-cluster_{context}"]
+= Configuring {SMProductName} for multi-cluster {spire-full} integration
+
+[role="_abstract"]
+Configure {SMProductName} on each cluster with federation settings, East-West Gateways, and Remote Secrets to enable cross-cluster service communication by using SPIRE-issued certificates.
+
+.Prerequisites
+
+* You have completed the "Deploying {spire-full} with federation for multi-cluster integration" steps.
+
+.Procedure
+
+. Enable federation on `SpireServer`:
+
+.. Patch the `SpireServer` CR on both clusters to enable the federation endpoint:
++
+[source,terminal]
+----
+//Cluster A
+$ oc patch spireserver cluster --kubeconfig="${CLUSTER_A_KUBECONFIG}" --type=merge -p '{
+  "spec": {
+    "federation": {
+      "bundleEndpoint": {
+        "profile": "https_spiffe",
+        "refreshHint": 300,
+        "httpsWeb": ""
+      },
+      "federatesWith": "",
+      "managedRoute": "true"
+    }
+  }
+}'
+//Cluster B
+$ oc patch spireserver cluster --kubeconfig="${CLUSTER_B_KUBECONFIG}" --type=merge -p '{
+  "spec": {
+    "federation": {
+      "bundleEndpoint": {
+        "profile": "https_spiffe",
+        "refreshHint": 300,
+        "httpsWeb": ""
+      },
+      "federatesWith": "",
+      "managedRoute": "true"
+    }
+  }
+}'
+----
+
+.. Verify that the federation routes were created by running the following command:
++
+[source,terminal]
+----
+$ for KUBECONFIG in "${CLUSTER_A_KUBECONFIG}" "${CLUSTER_B_KUBECONFIG}"; do
+  echo "--- Federation route ---"
+  oc get route -n ${ZTWIM_NS} --kubeconfig="${KUBECONFIG}" | grep federation
+done
+----
+
+. Create the `ClusterFederatedTrustDomain` CRs:
+
+.. On Cluster A, create a `ClusterFederatedTrustDomain` pointing to Cluster B by running the following command:
++
+[source,terminal]
+----
+$ oc apply --kubeconfig="${CLUSTER_A_KUBECONFIG}" -f - <<EOF
+apiVersion: spire.spiffe.io/v1alpha1
+kind: ClusterFederatedTrustDomain
+metadata:
+  name: federation-to-cluster-b
+spec:
+  trustDomain: ${CLUSTER_B_TRUST_DOMAIN}
+  bundleEndpointURL: ${FEDERATION_ENDPOINT_B}
+  bundleEndpointProfile:
+    type: https_spiffe
+    endpointSPIFFEID: spiffe://${CLUSTER_B_TRUST_DOMAIN}/spire/server
+EOF
+----
+
+.. On Cluster B, create a CFTD pointing to Cluster A by running the following command:
++
+[source,terminal]
+----
+$ oc apply --kubeconfig="${CLUSTER_B_KUBECONFIG}" -f - <<EOF
+apiVersion: spire.spiffe.io/v1alpha1
+kind: ClusterFederatedTrustDomain
+metadata:
+  name: federation-to-cluster-a
+spec:
+  trustDomain: ${CLUSTER_A_TRUST_DOMAIN}
+  bundleEndpointURL: ${FEDERATION_ENDPOINT_A}
+  bundleEndpointProfile:
+    type: https_spiffe
+    endpointSPIFFEID: spiffe://${CLUSTER_A_TRUST_DOMAIN}/spire/server
+EOF
+----
+
+.Verification
+
+. Check that each SPIRE Server has the remote cluster's trust bundle by running the following command:
++
+[source,terminal]
+----
+// Cluster A should have Cluster B's bundle
+$ oc exec --kubeconfig="${CLUSTER_A_KUBECONFIG}" -n ${ZTWIM_NS} spire-server-0 -c spire-server -- \
+  spire-server bundle list -socketPath /tmp/spire-server/private/api.sock -format spiffe 2>&1 | head -5
+----
++
+The output should show `apps.cluster-b.example.com` with its public keys.
++
+[source,terminal]
+----
+// Cluster B should have Cluster A's bundle
+$ oc exec --kubeconfig="${CLUSTER_B_KUBECONFIG}" -n ${ZTWIM_NS} spire-server-0 -c spire-server -- \
+  spire-server bundle list -socketPath /tmp/spire-server/private/api.sock -format spiffe 2>&1 | head -5
+----
++
+The output should show `apps.cluster-a.example.com` with its public keys.
+
+. Verify that the federation endpoints exist by running the following commands:
++
+[source,terminal]
+----
+$ curl -sk "${FEDERATION_ENDPOINT_A}" | python3 -c "import sys,json; print(f'Keys: {len(json.load(sys.stdin).get(\"keys\",[]))}')"
+----
++
+[source,terminal]
+----
+$ curl -sk "${FEDERATION_ENDPOINT_B}" | python3 -c "import sys,json; print(f'Keys: {len(json.load(sys.stdin).get(\"keys\",[]))}')"
+----
++
+Both should return at least two keys, one x509-svid and one jwt-svid.
+

--- a/modules/zero-trust-manager-deploy-east-west.adoc
+++ b/modules/zero-trust-manager-deploy-east-west.adoc
@@ -11,6 +11,14 @@ Deploy SPIRE-enabled East-West gateways on both clusters using Helm. {SMProductN
 
 .Procedure
 
+. Add the Istio Helm repository by running the following commands:
++
+[source,terminal]
+----
+$ helm repo add istio https://istio-release.storage.googleapis.com/charts
+$ helm repo update
+----
+
 . Grant security context constraints (SCC) permissions by running the following commands:
 +
 [source,terminal]

--- a/modules/zero-trust-manager-deploy-east-west.adoc
+++ b/modules/zero-trust-manager-deploy-east-west.adoc
@@ -1,0 +1,57 @@
+// Module included in the following assemblies:
+//
+// * security/zero_trust_workload_identity_manager/zero-trust-manager-mesh-integration-multi-cluster.adoc.
+
+:_mod-docs-content-type: PROCEDURE
+[id="zero-trust-manager-deploy-east-west_{context}"]
+= Deploy the East-West gateways
+
+[role="_abstract"]
+Deploy SPIRE-enabled East-West gateways on both clusters using Helm. {SMProductName} uses East-West gateways to connect cluster networks and enable secure cross-cluster communication in a multi-cluster mesh.
+
+.Procedure
+
+. Grant security context constraints (SCC) permissions by running the following commands:
++
+[source,terminal]
+----
+$ for KUBECONFIG in "${CLUSTER_A_KUBECONFIG}" "${CLUSTER_B_KUBECONFIG}"; do
+  oc adm policy add-scc-to-user anyuid \
+    -z istio-eastwestgateway -n istio-system --kubeconfig="${KUBECONFIG}"
+done
+----
+
+. Install the Istio gateway on cluster A by running the following command:
++
+[source,terminal]
+----
+$ helm upgrade --install istio-eastwestgateway istio/gateway \
+  -n istio-system \
+  --set-json 'podAnnotations={"inject.istio.io/templates":"gateway,spireGw"}' \
+  --set name=istio-eastwestgateway \
+  --set networkGateway="${NETWORK_A}" \
+  --kubeconfig="${CLUSTER_A_KUBECONFIG}"
+----
+
+. Install the Istio gateway on Cluster B by running the following command:
++
+[source,terminal]
+----
+$ helm upgrade --install istio-eastwestgateway istio/gateway \
+  -n istio-system \
+  --set-json 'podAnnotations={"inject.istio.io/templates":"gateway,spireGw"}' \
+  --set name=istio-eastwestgateway \
+  --set networkGateway="${NETWORK_B}" \
+  --kubeconfig="${CLUSTER_B_KUBECONFIG}"
+----
+
+. Wait for the gateways to complete by running the following command:
++
+[source,terminal]
+----
+$ for KUBECONFIG in "${CLUSTER_A_KUBECONFIG}" "${CLUSTER_B_KUBECONFIG}"; do
+  oc wait --for=condition=Available deployment/istio-eastwestgateway \
+    --kubeconfig="${KUBECONFIG}" -n istio-system --timeout=300s
+done
+----
+

--- a/modules/zero-trust-manager-deploy-istio-cr.adoc
+++ b/modules/zero-trust-manager-deploy-istio-cr.adoc
@@ -59,7 +59,7 @@ $ export BUNDLE_URL_B="${FEDERATION_ENDPOINT_B}"
 ----
 $ oc new-project "${OSSM_NS}" --kubeconfig="${CLUSTER_A_KUBECONFIG}" 2>/dev/null || true
 
-cat <<EOF | oc apply --kubeconfig="${CLUSTER_A_KUBECONFIG}" -f -
+$ cat <<EOF | oc apply --kubeconfig="${CLUSTER_A_KUBECONFIG}" -f -
 apiVersion: sailoperator.io/v1
 kind: Istio
 metadata:
@@ -128,7 +128,7 @@ EOF
 ----
 $ oc new-project "${OSSM_NS}" --kubeconfig="${CLUSTER_B_KUBECONFIG}" 2>/dev/null || true
 
-cat <<EOF | oc apply --kubeconfig="${CLUSTER_B_KUBECONFIG}" -f -
+$ cat <<EOF | oc apply --kubeconfig="${CLUSTER_B_KUBECONFIG}" -f -
 apiVersion: sailoperator.io/v1
 kind: Istio
 metadata:

--- a/modules/zero-trust-manager-deploy-istio-cr.adoc
+++ b/modules/zero-trust-manager-deploy-istio-cr.adoc
@@ -1,0 +1,206 @@
+// Module included in the following assemblies:
+//
+// * security/zero_trust_workload_identity_manager/zero-trust-manager-mesh-integration-multi-cluster.adoc.
+
+:_mod-docs-content-type: PROCEDURE
+[id="zero-trust-manager-deploy-istio-cr_{context}"]
+= Deploy the Istio custom resource with the federation configuration
+
+[role="_abstract"]
+Deploy the Istio custom resource on Cluster A and Cluster B with SPIRE federation and multi-cluster mesh settings.
+
+The Istio CR must include:
+
+* `meshConfig.trustDomain` matching the SPIRE trust domain
+* `meshConfig.caCertificates` with bundle URLs for both clusters. This handles cross-trust-domain validation.
+* `WORKLOAD_IDENTITY_SOCKET_FILE` for SPIRE SDS integration
+* `jwksResolverExtraRootCA` for OIDC validation
+* Multi-cluster settings which include `meshID`, `clusterName`, and `network`.
+* SPIRE injection templates
+
+[NOTE]
+====
+Do not use `meshConfig.trustDomainAliases`. Use `meshConfig.caCertificates` with `spiffeBundleUrl` instead.
+====
+
+.Procedure
+
+. Extract the OpenID Connect (OIDC) certificates by running the following commands:
++
+[source,terminal]
+----
+$ export EXTRA_ROOT_CA_A="$(oc get secret oidc-serving-cert \
+  --kubeconfig="${CLUSTER_A_KUBECONFIG}" -n ${ZTWIM_NS} -o json | \
+  jq -r '.data."tls.crt"' | base64 -d | sed 's/^/        /')"
+----
++
+[source,terminal]
+----
+$ export EXTRA_ROOT_CA_B="$(oc get secret oidc-serving-cert \
+  --kubeconfig="${CLUSTER_B_KUBECONFIG}" -n ${ZTWIM_NS} -o json | \
+  jq -r '.data."tls.crt"' | base64 -d | sed 's/^/        /')"
+----
+
+. Get the bundle endpoint URLs by running the following command:
++
+[source,terminal]
+----
+$ export BUNDLE_URL_A="${FEDERATION_ENDPOINT_A}"
+----
++
+[source,terminal]
+----
+$ export BUNDLE_URL_B="${FEDERATION_ENDPOINT_B}"
+----
+
+. Create the Istio CR on Cluster A by running the following command:
++
+[source,terminal]
+----
+$ oc new-project "${OSSM_NS}" --kubeconfig="${CLUSTER_A_KUBECONFIG}" 2>/dev/null || true
+
+cat <<EOF | oc apply --kubeconfig="${CLUSTER_A_KUBECONFIG}" -f -
+apiVersion: sailoperator.io/v1
+kind: Istio
+metadata:
+  name: default
+spec:
+  namespace: istio-system
+  updateStrategy:
+    type: InPlace
+  values:
+    meshConfig:
+      trustDomain: ${CLUSTER_A_TRUST_DOMAIN}
+      defaultConfig:
+        proxyMetadata:
+          WORKLOAD_IDENTITY_SOCKET_FILE: "spire-agent.sock"
+      caCertificates:
+        - spiffeBundleUrl: ${BUNDLE_URL_A}
+          trustDomains:
+            - ${CLUSTER_A_TRUST_DOMAIN}
+        - spiffeBundleUrl: ${BUNDLE_URL_B}
+          trustDomains:
+            - ${CLUSTER_B_TRUST_DOMAIN}
+    global:
+      meshID: mesh1
+      multiCluster:
+        clusterName: ${CLUSTER_A}
+      network: ${NETWORK_A}
+    pilot:
+      jwksResolverExtraRootCA: |
+${EXTRA_ROOT_CA_A}
+      env:
+        ENABLE_CA_SERVER: "true"
+    sidecarInjectorWebhook:
+      templates:
+        spire: |
+          spec:
+            initContainers:
+            - name: istio-proxy
+              volumeMounts:
+              - name: workload-socket
+                mountPath: /run/secrets/workload-spiffe-uds
+                readOnly: true
+            volumes:
+              - name: workload-socket
+                csi:
+                  driver: "csi.spiffe.io"
+                  readOnly: true
+        spireGw: |
+          spec:
+            containers:
+            - name: istio-proxy
+              volumeMounts:
+              - name: workload-socket
+                mountPath: /run/secrets/workload-spiffe-uds
+                readOnly: true
+            volumes:
+              - name: workload-socket
+                csi:
+                  driver: "csi.spiffe.io"
+                  readOnly: true
+EOF
+----
+
+. Create the Istio CR on Cluster B by running the following command:
++
+[source,terminal]
+----
+$ oc new-project "${OSSM_NS}" --kubeconfig="${CLUSTER_B_KUBECONFIG}" 2>/dev/null || true
+
+cat <<EOF | oc apply --kubeconfig="${CLUSTER_B_KUBECONFIG}" -f -
+apiVersion: sailoperator.io/v1
+kind: Istio
+metadata:
+  name: default
+spec:
+  namespace: istio-system
+  updateStrategy:
+    type: InPlace
+  values:
+    meshConfig:
+      trustDomain: ${CLUSTER_B_TRUST_DOMAIN}
+      defaultConfig:
+        proxyMetadata:
+          WORKLOAD_IDENTITY_SOCKET_FILE: "spire-agent.sock"
+      caCertificates:
+        - spiffeBundleUrl: ${BUNDLE_URL_B}
+          trustDomains:
+            - ${CLUSTER_B_TRUST_DOMAIN}
+        - spiffeBundleUrl: ${BUNDLE_URL_A}
+          trustDomains:
+            - ${CLUSTER_A_TRUST_DOMAIN}
+    global:
+      meshID: mesh1
+      multiCluster:
+        clusterName: ${CLUSTER_B}
+      network: ${NETWORK_B}
+    pilot:
+      jwksResolverExtraRootCA: |
+${EXTRA_ROOT_CA_B}
+      env:
+        ENABLE_CA_SERVER: "true"
+    sidecarInjectorWebhook:
+      templates:
+        spire: |
+          spec:
+            initContainers:
+            - name: istio-proxy
+              volumeMounts:
+              - name: workload-socket
+                mountPath: /run/secrets/workload-spiffe-uds
+                readOnly: true
+            volumes:
+              - name: workload-socket
+                csi:
+                  driver: "csi.spiffe.io"
+                  readOnly: true
+        spireGw: |
+          spec:
+            containers:
+            - name: istio-proxy
+              volumeMounts:
+              - name: workload-socket
+                mountPath: /run/secrets/workload-spiffe-uds
+                readOnly: true
+            volumes:
+              - name: workload-socket
+                csi:
+                  driver: "csi.spiffe.io"
+                  readOnly: true
+EOF
+----
+
+. Wait for the Istiod to become ready on both clusters by running the following command:
++
+[source,terminal]
+----
+$ for KUBECONFIG in "${CLUSTER_A_KUBECONFIG}" "${CLUSTER_B_KUBECONFIG}"; do
+  until oc get deployment istiod --kubeconfig="${KUBECONFIG}" -n "${OSSM_NS}" &> /dev/null; do
+    sleep 3
+  done
+  oc wait --for=condition=Available deployment/istiod \
+    --kubeconfig="${KUBECONFIG}" -n "${OSSM_NS}" --timeout=300s
+done
+----
+

--- a/modules/zero-trust-manager-deploy-istiocni.adoc
+++ b/modules/zero-trust-manager-deploy-istiocni.adoc
@@ -4,68 +4,103 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="zero-trust-manager-deploy-istiocni_{context}"]
-= Deploy IstioCNI on both clusters
+= Deploy IstioCNI and configure federated ClusterSPIFFEIDs on both clusters
 
 [role="_abstract"]
-Deploy the IstioCNI custom resource on Cluster A and Cluster B. IstioCNI configures pod networking for {SMProductName} so sidecars can intercept traffic without privileged init containers. Deploy it on both clusters before you install the Istio control plane.
+Deploy the `IstioCNI` custom resource and create federated `ClusterSPIFFEID` resources on Cluster A and Cluster B. IstioCNI configures pod networking for {SMProductName} so sidecars can intercept traffic without privileged init containers. Federated `ClusterSPIFFEID` resources ensure workloads and gateways receive trust bundles from both clusters.
 
 .Procedure
 
-. Define the following environment variables:
+. Deploy IstioCNI on both clusters by running the following commands:
 +
 [source,terminal]
 ----
-$ export CLUSTER_A_KUBECONFIG="path/to/cluster-a/kubeconfig"
-$ export CLUSTER_B_KUBECONFIG="path/to/cluster-b/kubeconfig"
-$ export ZTWIM_NS="zero-trust-workload-identity-manager"
-$ export CLUSTER_A="cluster-a"
-$ export NETWORK_A="network-a"
-$ export CLUSTER_B="cluster-b"
-$ export NETWORK_B="network-b"
-----
+$ for KUBECONFIG in "${CLUSTER_A_KUBECONFIG}" "${CLUSTER_B_KUBECONFIG}"; do
+  oc new-project "${OSSM_CNI}" --kubeconfig="${KUBECONFIG}" 2>/dev/null || true
 
-. Patch the `spire-agent` ConfigMap to add SDS configuration by running the following commands:
-+
-[source,terminal]
-----
-$ for kubeconfig in "${CLUSTER_A_KUBECONFIG}" "${CLUSTER_B_KUBECONFIG}"; do
-  # Get current agent.conf
-  AGENT_CONF=$(oc get configmap spire-agent --kubeconfig "${kubeconfig}" -n "${ZTWIM_NS}" -o jsonpath='{.data.agent\.conf}')
-  # Check if SDS configuration already exists
-  if echo "${AGENT_CONF}" | grep -q '"sds"'; then
-    echo "SDS configuration already exists in spire-agent configmap, skipping patch"
-    continue
-  fi
- 
-$ PATCHED_CONF=$(echo "${AGENT_CONF}" | jq '.agent.sds = {
-    "default_svid_name": "default",
-    "default_bundle_name": "null",
-    "default_all_bundles_name": "ROOTCA"
-  }')
+  oc apply --kubeconfig="${KUBECONFIG}" -f - <<EOF
+apiVersion: sailoperator.io/v1
+kind: IstioCNI
+metadata:
+  name: default
+spec:
+  namespace: ${OSSM_CNI}
+EOF
 
-$ oc patch configmap spire-agent --kubeconfig "${kubeconfig}" -n "${ZTWIM_NS}" --type merge -p "{\"data\":{\"agent.conf\":$(echo "${PATCHED_CONF}" | jq -Rs .)}}"
-
-$ oc rollout restart daemonset/spire-agent --kubeconfig "${kubeconfig}" -n "${ZTWIM_NS}"
-$ oc rollout status daemonset/spire-agent --kubeconfig "${kubeconfig}" -n "${ZTWIM_NS}" --timeout=300s
+  until oc get daemonset/istio-cni-node --kubeconfig="${KUBECONFIG}" -n "${OSSM_CNI}" &> /dev/null; do
+    sleep 3
+  done
+  oc rollout status daemonset/istio-cni-node --kubeconfig="${KUBECONFIG}" -n "${OSSM_CNI}" --timeout=300s
 done
 ----
 
-. Patch the `ClusterSPIFFEID` on Cluster A to federate with Cluster B by running the following command:
+. Create federated `ClusterSPIFFEID` resources on Cluster A:
++
+[NOTE]
+====
+Do not patch the default `ClusterSPIFFEID` (`zero-trust-workload-identity-manager-spire-default`). The {zero-trust-full} operator reconciles and reverts manual changes to it. Create custom `ClusterSPIFFEID` resources for specific namespaces instead.
+====
 +
 [source,terminal]
 ----
-$ kubectl patch clusterspiffeid zero-trust-workload-identity-manager-spire-default \
-  --kubeconfig="${CLUSTER_A_KUBECONFIG}" \
-  --type=merge \
-  -p "{\"spec\":{\"federatesWith\":[\"${CLUSTER_B}\"],\"autoPopulateDNSNames\":true}}"
+$ oc apply --kubeconfig="${CLUSTER_A_KUBECONFIG}" -f - <<EOF
+apiVersion: spire.spiffe.io/v1alpha1
+kind: ClusterSPIFFEID
+metadata:
+  name: sample-federation
+spec:
+  className: zero-trust-workload-identity-manager-spire
+  spiffeIDTemplate: "spiffe://{{ .TrustDomain }}/ns/{{ .PodMeta.Namespace }}/sa/{{ .PodSpec.ServiceAccountName }}"
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: sample
+  federatesWith:
+    - "${CLUSTER_B_TRUST_DOMAIN}"
+---
+apiVersion: spire.spiffe.io/v1alpha1
+kind: ClusterSPIFFEID
+metadata:
+  name: istio-system-federation
+spec:
+  className: zero-trust-workload-identity-manager-spire
+  spiffeIDTemplate: "spiffe://{{ .TrustDomain }}/ns/{{ .PodMeta.Namespace }}/sa/{{ .PodSpec.ServiceAccountName }}"
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: istio-system
+  federatesWith:
+    - "${CLUSTER_B_TRUST_DOMAIN}"
+EOF
 ----
 
-. Patch the `ClusterSPIFFEID` on Cluster B to federate with Cluster A by running the following command:
+. Create federated `ClusterSPIFFEID` resources on Cluster B:
 +
 [source,terminal]
 ----
-$ kubectl patch clusterspiffeid zero-trust-workload-identity-manager-spire-default \
-  --kubeconfig="${CLUSTER_B_KUBECONFIG}" \
-  --type=merge \
-  -p "{\"spec\":{\"federatesWith\":[\"${CLUSTER_A}\"],\"autoPopulateDNSNames\":true}}"
+$ oc apply --kubeconfig="${CLUSTER_B_KUBECONFIG}" -f - <<EOF
+apiVersion: spire.spiffe.io/v1alpha1
+kind: ClusterSPIFFEID
+metadata:
+  name: sample-federation
+spec:
+  className: zero-trust-workload-identity-manager-spire
+  spiffeIDTemplate: "spiffe://{{ .TrustDomain }}/ns/{{ .PodMeta.Namespace }}/sa/{{ .PodSpec.ServiceAccountName }}"
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: sample
+  federatesWith:
+    - "${CLUSTER_A_TRUST_DOMAIN}"
+---
+apiVersion: spire.spiffe.io/v1alpha1
+kind: ClusterSPIFFEID
+metadata:
+  name: istio-system-federation
+spec:
+  className: zero-trust-workload-identity-manager-spire
+  spiffeIDTemplate: "spiffe://{{ .TrustDomain }}/ns/{{ .PodMeta.Namespace }}/sa/{{ .PodSpec.ServiceAccountName }}"
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: istio-system
+  federatesWith:
+    - "${CLUSTER_A_TRUST_DOMAIN}"
+EOF
 ----

--- a/modules/zero-trust-manager-deploy-istiocni.adoc
+++ b/modules/zero-trust-manager-deploy-istiocni.adoc
@@ -1,0 +1,71 @@
+// Module included in the following assemblies:
+//
+// * security/zero_trust_workload_identity_manager/zero-trust-manager-mesh-integration-multi-cluster.adoc.
+
+:_mod-docs-content-type: PROCEDURE
+[id="zero-trust-manager-deploy-istiocni_{context}"]
+= Deploy IstioCNI on both clusters
+
+[role="_abstract"]
+Deploy the IstioCNI custom resource on Cluster A and Cluster B. IstioCNI configures pod networking for {SMProductName} so sidecars can intercept traffic without privileged init containers. Deploy it on both clusters before you install the Istio control plane.
+
+.Procedure
+
+. Define the following environment variables:
++
+[source,terminal]
+----
+$ export CLUSTER_A_KUBECONFIG="path/to/cluster-a/kubeconfig"
+$ export CLUSTER_B_KUBECONFIG="path/to/cluster-b/kubeconfig"
+$ export ZTWIM_NS="zero-trust-workload-identity-manager"
+$ export CLUSTER_A="cluster-a"
+$ export NETWORK_A="network-a"
+$ export CLUSTER_B="cluster-b"
+$ export NETWORK_B="network-b"
+----
+
+. Patch the `spire-agent` ConfigMap to add SDS configuration by running the following commands:
++
+[source,terminal]
+----
+$ for kubeconfig in "${CLUSTER_A_KUBECONFIG}" "${CLUSTER_B_KUBECONFIG}"; do
+  # Get current agent.conf
+  AGENT_CONF=$(oc get configmap spire-agent --kubeconfig "${kubeconfig}" -n "${ZTWIM_NS}" -o jsonpath='{.data.agent\.conf}')
+  # Check if SDS configuration already exists
+  if echo "${AGENT_CONF}" | grep -q '"sds"'; then
+    echo "SDS configuration already exists in spire-agent configmap, skipping patch"
+    continue
+  fi
+ 
+$ PATCHED_CONF=$(echo "${AGENT_CONF}" | jq '.agent.sds = {
+    "default_svid_name": "default",
+    "default_bundle_name": "null",
+    "default_all_bundles_name": "ROOTCA"
+  }')
+
+$ oc patch configmap spire-agent --kubeconfig "${kubeconfig}" -n "${ZTWIM_NS}" --type merge -p "{\"data\":{\"agent.conf\":$(echo "${PATCHED_CONF}" | jq -Rs .)}}"
+
+$ oc rollout restart daemonset/spire-agent --kubeconfig "${kubeconfig}" -n "${ZTWIM_NS}"
+$ oc rollout status daemonset/spire-agent --kubeconfig "${kubeconfig}" -n "${ZTWIM_NS}" --timeout=300s
+done
+----
+
+. Patch the `ClusterSPIFFEID` on Cluster A to federate with Cluster B by running the following command:
++
+[source,terminal]
+----
+$ kubectl patch clusterspiffeid zero-trust-workload-identity-manager-spire-default \
+  --kubeconfig="${CLUSTER_A_KUBECONFIG}" \
+  --type=merge \
+  -p "{\"spec\":{\"federatesWith\":[\"${CLUSTER_B}\"],\"autoPopulateDNSNames\":true}}"
+----
+
+. Patch the `ClusterSPIFFEID` on Cluster B to federate with Cluster A by running the following command:
++
+[source,terminal]
+----
+$ kubectl patch clusterspiffeid zero-trust-workload-identity-manager-spire-default \
+  --kubeconfig="${CLUSTER_B_KUBECONFIG}" \
+  --type=merge \
+  -p "{\"spec\":{\"federatesWith\":[\"${CLUSTER_A}\"],\"autoPopulateDNSNames\":true}}"
+----

--- a/modules/zero-trust-manager-deploy-spire-multi-cluster.adoc
+++ b/modules/zero-trust-manager-deploy-spire-multi-cluster.adoc
@@ -1,0 +1,235 @@
+// Module included in the following assemblies:
+//
+// * security/zero_trust_workload_identity_manager/zero-trust-manager-mesh-integration-multi-cluster.adoc.
+
+:_mod-docs-content-type: PROCEDURE
+[id="zero-trust-manager-deploy-spire-multi-cluster_{context}"]
+= Deploying {spire-full} with federation for multi-cluster integration
+
+[role="_abstract"]
+Deploy {spire-full} with federation capabilities on each cluster to enable cross-cluster trust bundle exchange and workload identity validation across multiple {product-title} clusters.
+
+.Prerequisites
+
+* You have two {product-title} clusters (4.x) with network connectivity between them.
+* You have installed {zero-trust-full} on both clusters.
+* You have installed SPIRE federation on both clusters.
+* The `oc` CLI is configured with access to both clusters.
+* You have installed `istioctl`.
+* You have `create-only` mode enabled.
+* You have `helm` installed. This is used for gateway deployment.
+* You have Istio version >= 1.29.2
+
+.Procedure
+
+. Define the following environment variables:
++
+[source,terminal]
+----
+$ export ZTWIM_NS=zero-trust-workload-identity-manager
+$ export OSSM_NS=istio-system
+$ export OSSM_CNI=istio-cni
+
+$ export CLUSTER_A_KUBECONFIG="/path/to/cluster-a/kubeconfig"
+$ export CLUSTER_B_KUBECONFIG="/path/to/cluster-b/kubeconfig"
+
+$ export CLUSTER_A_BASE_DOMAIN=$(oc get ingresses.config/cluster \
+  -o jsonpath='{.spec.domain}' --kubeconfig "${CLUSTER_A_KUBECONFIG}")
+$ export CLUSTER_B_BASE_DOMAIN=$(oc get ingresses.config/cluster \
+  -o jsonpath='{.spec.domain}' --kubeconfig "${CLUSTER_B_KUBECONFIG}")
+
+$ export CLUSTER_A_TRUST_DOMAIN="apps.${CLUSTER_A_BASE_DOMAIN##apps.}"
+$ export CLUSTER_B_TRUST_DOMAIN="apps.${CLUSTER_B_BASE_DOMAIN##apps.}"
+
+$ export CLUSTER_A_TRUST_DOMAIN="${CLUSTER_A_BASE_DOMAIN}"
+$ export CLUSTER_B_TRUST_DOMAIN="${CLUSTER_B_BASE_DOMAIN}"
+
+$ export CLUSTER_A=cluster-a
+$ export CLUSTER_B=cluster-b
+$ export NETWORK_A=network-a
+$ export NETWORK_B=network-b
+
+$ export FEDERATION_ENDPOINT_A="https://federation.${CLUSTER_A_BASE_DOMAIN}"
+$ export FEDERATION_ENDPOINT_B="https://federation.${CLUSTER_B_BASE_DOMAIN}"
+$ export VALIDATOR_DOMAIN_CLUSTER_A="validator.$CLUSTER_A_BASE_DOMAIN"
+----
+
+. Deploy SPIRE with federation enabled:
+
+.. Create the `ZeroTrustWorkloadIdentityManager` CR on Cluster A:
++
+[source,terminal]
+----
+$ export KUBECONFIG="${CLUSTER_A_KUBECONFIG}"
+export JWT_ISSUER_A="https://oidc-discovery.${CLUSTER_A_BASE_DOMAIN}"
+
+$ oc apply -f - <<EOF
+apiVersion: operator.openshift.io/v1alpha1
+kind: ZeroTrustWorkloadIdentityManager
+metadata:
+  name: cluster
+spec:
+  trustDomain: ${CLUSTER_A_TRUST_DOMAIN}
+  clusterName: ${CLUSTER_A}
+EOF
+----
+
+.. Create the `SpireServer` CR:
++
+[source,yaml]
+----
+cat <<EOF | oc apply -f -
+apiVersion: operator.openshift.io/v1alpha1
+kind: SpireServer
+metadata:
+  name: cluster
+spec:
+  logLevel: "info"
+  logFormat: "text"
+  jwtIssuer: $JWT_ISSUER
+  caValidity: "24h"
+  defaultX509Validity: "1h"
+  defaultJWTValidity: "5m"
+  caKeytype: “rsa-2048”
+  jwtKeyType: "rsa-2048"
+  keyManager: “”
+  caSubject:
+    country: "US"
+    organization: "RH"
+    commonName: "SPIRE Server CA"
+  persistence:
+    size: "5Gi"
+    accessMode: "ReadWriteOnce"
+  datastore:
+    databaseType: "sqlite3"
+    connectionString: "/run/spire/data/datastore.sqlite3"
+    tlsSecretName: ""
+    maxOpenConns: 100
+    maxIdleConns: 10
+    connMaxLifetime: 0
+    disableMigration: "false"
+  federation:
+    enabled: true
+    bundleEndpoint:
+      address: "0.0.0.0"
+      port: 8443
+  UpstreamAuthorityConfig:
+    certManager:
+      namespace: "Issuer"
+      issuerName: "Issuer"
+      issuerKind: "Issuer"
+      issuerGroup: "cert-manager.io"
+    vault:
+      vaultAddr: "https://vault.example.org"
+      pkiMountPoint: "pki"
+      caCertSecretRef:
+       name: ""
+       key: ""
+      insecureSkipVerify: "false"
+      vaultNamespace: ""
+      k8sAuth: 
+       k8sAuthMointPoint: "kubernetes"
+       k8sAuthRoleName: ""
+       audience: "vault"
+----
+
+.. Create the `SpireAgent` CR:
++
+[source,yaml]
+----
+cat <<EOF | oc apply -f -
+apiVersion: operator.openshift.io/v1alpha1
+kind: SpireAgent
+metadata:
+  name: cluster
+spec:
+  socketPath: "/run/spire/agent-sockets"
+  logLevel: "info"
+  logFormat: "text"
+  nodeAttestor:
+    k8sPSATEnabled: "true"
+  workloadAttestors:
+    k8sEnabled: "true"
+    workloadAttestorsVerification:
+      type: "auto"
+      hostCertBasePath: "/etc/kubernetes"
+      hostCertFileName: "auto"
+    disableContainerSelectors: "true"
+    useNewContainerLocator: "true"
+EOF
+----
+
+.. Create the `SpiffeCSIDriver` CR:
++
+[source,yaml]
+----
+$ cat <<EOF | oc apply -f -
+apiVersion: operator.openshift.io/v1alpha1
+kind: SpiffeCSIDriver
+metadata:
+  name: cluster
+spec:
+  agentSocketPath: "/run/spire/agent-sockets"
+  pluginName: csi-spiffe.io
+status:
+  ConditionalStatus: ""
+EOF
+----
+
+.. Create the `SpireOIDCDiscoveryProvider` CR:
++
+[source,yaml]
+----
+$ cat <<EOF | oc apply -f -
+apiVersion: operator.openshift.io/v1alpha1
+kind: SpireOIDCDiscoveryProvider
+metadata:
+  name: cluster
+spec:
+  logLevel: "info"
+  logFormat: "text"
+  csiDriverName: "csi-spiffe.io"
+  jwtIssuer: $JWT_ISSUER
+  replicaCount: 1
+  managedRoute: "true"
+  externalSecretRef: ""
+EOF
+----
++
+Repeat for Cluster B substituting the `CLUSTER_B_*` variables.
+
+. Wait for SPIRE to be ready on both clusters by running the following command:
++
+[source,terminal]
+----
+$ for KUBECONFIG in "${CLUSTER_A_KUBECONFIG}" "${CLUSTER_B_KUBECONFIG}"; do
+  echo "--- Waiting for SPIRE on $(oc whoami --show-server --kubeconfig=${KUBECONFIG}) ---"
+  oc rollout status statefulset/spire-server --kubeconfig="${KUBECONFIG}" -n ${ZTWIM_NS} --timeout=300s
+  oc rollout status daemonset/spire-agent --kubeconfig="${KUBECONFIG}" -n ${ZTWIM_NS} --timeout=300s
+  oc rollout status daemonset/spire-spiffe-csi-driver --kubeconfig="${KUBECONFIG}" -n ${ZTWIM_NS} --timeout=300s
+  oc wait --for=condition=Available deployment/spire-spiffe-oidc-discovery-provider \
+    --kubeconfig="${KUBECONFIG}" -n ${ZTWIM_NS} --timeout=300s
+done
+----
+
+.Verification
+
+. Verify that the SDS configuration is available by running the following command:
++
+[source,terminal]
+----
+$ for KUBECONFIG in "${CLUSTER_A_KUBECONFIG}" "${CLUSTER_B_KUBECONFIG}"; do
+  echo "--- SDS config ---"
+  oc get cm spire-agent --kubeconfig "${KUBECONFIG}" -n "${ZTWIM_NS}" \
+    -o jsonpath='{.data.agent\.conf}' | grep -A5 '"sds"'
+done
+----
++
+.Example output
+[source,terminal]
+----
+"sds": {
+  "default_all_bundles_name": "ROOTCA",
+  "default_bundle_name": "null"
+},
+----

--- a/modules/zero-trust-manager-deploy-spire-multi-cluster.adoc
+++ b/modules/zero-trust-manager-deploy-spire-multi-cluster.adoc
@@ -16,7 +16,6 @@ Deploy {spire-full} with federation capabilities on each cluster to enable cross
 * You have installed SPIRE federation on both clusters.
 * The `oc` CLI is configured with access to both clusters.
 * You have installed `istioctl`.
-* You have `create-only` mode enabled.
 * You have `helm` installed. This is used for gateway deployment.
 * You have Istio version >= 1.29.2
 
@@ -38,9 +37,6 @@ $ export CLUSTER_A_BASE_DOMAIN=$(oc get ingresses.config/cluster \
 $ export CLUSTER_B_BASE_DOMAIN=$(oc get ingresses.config/cluster \
   -o jsonpath='{.spec.domain}' --kubeconfig "${CLUSTER_B_KUBECONFIG}")
 
-$ export CLUSTER_A_TRUST_DOMAIN="apps.${CLUSTER_A_BASE_DOMAIN##apps.}"
-$ export CLUSTER_B_TRUST_DOMAIN="apps.${CLUSTER_B_BASE_DOMAIN##apps.}"
-
 $ export CLUSTER_A_TRUST_DOMAIN="${CLUSTER_A_BASE_DOMAIN}"
 $ export CLUSTER_B_TRUST_DOMAIN="${CLUSTER_B_BASE_DOMAIN}"
 
@@ -51,7 +47,6 @@ $ export NETWORK_B=network-b
 
 $ export FEDERATION_ENDPOINT_A="https://federation.${CLUSTER_A_BASE_DOMAIN}"
 $ export FEDERATION_ENDPOINT_B="https://federation.${CLUSTER_B_BASE_DOMAIN}"
-$ export VALIDATOR_DOMAIN_CLUSTER_A="validator.$CLUSTER_A_BASE_DOMAIN"
 ----
 
 . Deploy SPIRE with federation enabled:
@@ -61,7 +56,7 @@ $ export VALIDATOR_DOMAIN_CLUSTER_A="validator.$CLUSTER_A_BASE_DOMAIN"
 [source,terminal]
 ----
 $ export KUBECONFIG="${CLUSTER_A_KUBECONFIG}"
-export JWT_ISSUER_A="https://oidc-discovery.${CLUSTER_A_BASE_DOMAIN}"
+$ export JWT_ISSUER_A="https://oidc-discovery.${CLUSTER_A_BASE_DOMAIN}"
 
 $ oc apply -f - <<EOF
 apiVersion: operator.openshift.io/v1alpha1
@@ -78,7 +73,7 @@ EOF
 +
 [source,yaml]
 ----
-cat <<EOF | oc apply -f -
+$ cat <<EOF | oc apply -f -
 apiVersion: operator.openshift.io/v1alpha1
 kind: SpireServer
 metadata:
@@ -86,7 +81,7 @@ metadata:
 spec:
   logLevel: "info"
   logFormat: "text"
-  jwtIssuer: $JWT_ISSUER
+  jwtIssuer: $JWT_ISSUER_A
   caValidity: "24h"
   defaultX509Validity: "1h"
   defaultJWTValidity: "5m"
@@ -113,31 +108,14 @@ spec:
     bundleEndpoint:
       address: "0.0.0.0"
       port: 8443
-  UpstreamAuthorityConfig:
-    certManager:
-      namespace: "Issuer"
-      issuerName: "Issuer"
-      issuerKind: "Issuer"
-      issuerGroup: "cert-manager.io"
-    vault:
-      vaultAddr: "https://vault.example.org"
-      pkiMountPoint: "pki"
-      caCertSecretRef:
-       name: ""
-       key: ""
-      insecureSkipVerify: "false"
-      vaultNamespace: ""
-      k8sAuth: 
-       k8sAuthMointPoint: "kubernetes"
-       k8sAuthRoleName: ""
-       audience: "vault"
+EOF
 ----
 
 .. Create the `SpireAgent` CR:
 +
 [source,yaml]
 ----
-cat <<EOF | oc apply -f -
+$ cat <<EOF | oc apply -f -
 apiVersion: operator.openshift.io/v1alpha1
 kind: SpireAgent
 metadata:
@@ -170,9 +148,7 @@ metadata:
   name: cluster
 spec:
   agentSocketPath: "/run/spire/agent-sockets"
-  pluginName: csi-spiffe.io
-status:
-  ConditionalStatus: ""
+  pluginName: "csi.spiffe.io"
 EOF
 ----
 
@@ -188,11 +164,10 @@ metadata:
 spec:
   logLevel: "info"
   logFormat: "text"
-  csiDriverName: "csi-spiffe.io"
-  jwtIssuer: $JWT_ISSUER
+  csiDriverName: "csi.spiffe.io"
+  jwtIssuer: $JWT_ISSUER_A
   replicaCount: 1
   managedRoute: "true"
-  externalSecretRef: ""
 EOF
 ----
 +

--- a/modules/zero-trust-manager-exchange-remote-secrets.adoc
+++ b/modules/zero-trust-manager-exchange-remote-secrets.adoc
@@ -1,0 +1,47 @@
+// Module included in the following assemblies:
+//
+// * security/zero_trust_workload_identity_manager/zero-trust-manager-mesh-integration-multi-cluster.adoc.
+
+:_mod-docs-content-type: PROCEDURE
+[id="zero-trust-manager-exchange-remote-secrets_{context}"]
+= Exchanging remote secrets
+
+[role="_abstract"]
+Create remote secrets on both clusters so Istiod can discover services in the peer cluster and route cross-cluster traffic through the East-West gateways.
+
+.Procedure
+
+. Create Istio remote secrets on Cluster A and Cluster B by running the following commands:
++
+[source,terminal]
+----
+$ istioctl create-remote-secret \
+  --kubeconfig="${CLUSTER_A_KUBECONFIG}" \
+  --name="${CLUSTER_A}" \
+  --istioNamespace=istio-system | \
+  kubectl apply --kubeconfig="${CLUSTER_B_KUBECONFIG}" -f -
+----
++
+[source,terminal]
+----
+$ istioctl create-remote-secret \
+  --kubeconfig="${CLUSTER_B_KUBECONFIG}" \
+  --name="${CLUSTER_B}" \
+  --istioNamespace=istio-system | \
+  kubectl apply --kubeconfig="${CLUSTER_A_KUBECONFIG}" -f -
+----
+
+. Verify that remote clusters are synced by running the following commands:
++
+[source,terminal]
+----
+$ istioctl remote-clusters --kubeconfig="${CLUSTER_A_KUBECONFIG}"
+----
++
+[source,terminal]
+----
+$ istioctl remote-clusters --kubeconfig="${CLUSTER_B_KUBECONFIG}"
+----
++
+Both commands should show the remote cluster with status `synced`.
+

--- a/modules/zero-trust-manager-multi-cluster-config-ref.adoc
+++ b/modules/zero-trust-manager-multi-cluster-config-ref.adoc
@@ -1,0 +1,149 @@
+// Module included in the following assemblies:
+//
+// * security/zero_trust_workload_identity_manager/zero-trust-manager-mesh-integration-multi-cluster.adoc.
+
+:_mod-docs-content-type: REFERENCE
+[id="zero-trust-manager-multi-cluster-config-ref_{context}"]
+= Configuration reference
+
+[role="_abstract"]
+Reference checklist of SPIRE federation and multi-cluster {SMProductName} configuration settings for both clusters, and a summary of responsibilities split between SPIRE and OSSM.
+
+[id="multi-cluster-configuration-checklist_{context}"]
+== Complete configuration checklist
+
+[cols="1,3,2,3,3",options="header"]
+|===
+| #
+| Configuration
+| Where
+| Cluster A Value
+| Cluster B Value
+
+| 1
+| +`SpireServer.federation.enabled`+
+| SpireServer CR
+| +`true`+
+| +`true`+
+
+| 2
+| +`ClusterFederatedTrustDomain`+
+| {zero-trust-full} CR
+| Points to B
+| Points to A
+
+| 3
+| Custom +`ClusterSPIFFEID`+ with +`federatesWith`+
+| {zero-trust-full} CR
+| Lists B's trust domain
+| Lists A's trust domain
+
+| 4
+| +`meshConfig.trustDomain`+
+| Istio CR
+| A's SPIRE trust domain
+| B's SPIRE trust domain
+
+| 5
+| +`meshConfig.caCertificates`+
+| Istio CR
+| Bundle URLs for A + B
+| Bundle URLs for B + A
+
+| 6
+| +`WORKLOAD_IDENTITY_SOCKET_FILE`+
+| Istio CR
+| +`spire-agent.sock`+
+| +`spire-agent.sock`+
+
+| 7
+| +`jwksResolverExtraRootCA`+
+| Istio CR
+| A's OIDC cert
+| B's OIDC cert
+
+| 8
+| +`global.meshID`+
+| Istio CR
+| +`mesh1`+
+| +`mesh1`+
+
+| 9
+| +`global.multiCluster.clusterName`+
+| Istio CR
+| +`cluster-a`+
+| +`cluster-b`+
+
+| 10
+| +`global.network`+
+| Istio CR
+| +`network-a`+
+| +`network-b`+
+
+| 11
+| Injection templates (+`spire`+, +`spireGw`+)
+| Istio CR
+| Defined
+| Defined
+
+| 12
+| East-West Gateway
+| Helm
+| +`networkGateway=network-a`+
+| +`networkGateway=network-b`+
+
+| 13
+| Remote Secret
+| Kubernetes Secret
+| A's secret on B
+| B's secret on A
+
+| 14
+| Cross-network Gateway
+| Istio Gateway CR
+| +`AUTO_PASSTHROUGH`+ on 15443
+| +`AUTO_PASSTHROUGH`+ on 15443
+|===
+
+[id="spire-ossm-responsibilities_{context}"]
+== SPIRE side vs. OSSM side
+
+[cols="2,3,3",options="header"]
+|===
+| Responsibility
+| SPIRE
+| OSSM
+
+| Issue workload certificates
+| SpireServer + SpireAgent
+| —
+
+| Exchange trust bundles
+| ClusterFederatedTrustDomain
+| +`caCertificates.spiffeBundleUrl`+
+
+| Control which workloads get federated CAs
+| +`ClusterSPIFFEID.federatesWith`+
+| —
+
+| SDS config (ROOTCA)
+| SPIRE Agent ConfigMap (auto PR #120)
+| —
+
+| Match trust domains for SAN
+| —
+| +`meshConfig.trustDomain`+
+
+| Accept remote trust domains
+| —
+| +`meshConfig.caCertificates`+ (not [.line-through]#trustDomainAliases#)
+
+| Route cross-cluster traffic
+| —
+| East-West Gateway + Remote Secrets
+
+| Service discovery
+| —
+| Remote Secrets + Istiod
+|===
+

--- a/modules/zero-trust-manager-multi-cluster-spire-mesh-about.adoc
+++ b/modules/zero-trust-manager-multi-cluster-spire-mesh-about.adoc
@@ -1,0 +1,34 @@
+// Module included in the following assemblies:
+//
+// * security/zero_trust_workload_identity_manager/zero-trust-manager-mesh-integration-multi-cluster.adoc.
+
+:_mod-docs-content-type: CONCEPT
+[id="zero-trust-manager-multi-cluster-spire-mesh-about_{context}"]
+= Multi-cluster {spire-full} integration with {SMProductName}
+
+[role="_abstract"]
+You can use {spire-full} federation to enable cross-cluster mutual TLS authentication between {SMProductName} workloads running on separate clusters, providing a unified zero trust identity framework across a multi-cluster deployment.
+
+Multi-cluster {spire-full} integration extends single-cluster {spire-full} capabilities to enable workloads in different clusters to authenticate each other using {spiffe-full} identities. This eliminates the need for separate certificate authorities per cluster and enables true cross-cluster zero trust architecture.
+
+== What gets federated
+
+Federation happens at two layers and both are required:
+
+
+[cols="1,1,1",options="header"]
+|===
+| Layer
+| What
+| How
+
+| SPIRE Federation
+| Trust bundles 
+| SPIRE Servers exchange bundles via `https_spiffe` profile
+
+| Istio Federation
+| Service discovery and routing 
+| Istiod discovers remote endpoints via remote secrets, routes traffic through East-West Gateways
+
+|===
+

--- a/security/zero_trust_workload_identity_manager/zero-trust-manager-mesh-integration-multi-cluster.adoc
+++ b/security/zero_trust_workload_identity_manager/zero-trust-manager-mesh-integration-multi-cluster.adoc
@@ -18,7 +18,6 @@ include::modules/zero-trust-manager-deploy-spire-multi-cluster.adoc[leveloffset=
 
 * link:https://docs.redhat.com/en/documentation/openshift_container_platform/latest/html-single/security_and_compliance/index#zero-trust-manager-install[Installing the Zero Trust Workload Identity Manager]
 * link:https://docs.redhat.com/en/documentation/openshift_container_platform/latest/html/security_and_compliance/zero-trust-workload-identity-manager#zero-trust-manager-spire-federation_zero-trust-manager-oidc-federation[Zero Trust Workload Identity Manager SPIRE federation]
-* link:https://docs.redhat.com/en/documentation/openshift_container_platform/latest/html-single/security_and_compliance/index#zero-trust-manager-reconciliation[Enabling create-only mode for the Zero Trust Workload Identity Manager]
 
 include::modules/zero-trust-manager-configure-spire-mesh-multi-cluster.adoc[leveloffset=+1]
 

--- a/security/zero_trust_workload_identity_manager/zero-trust-manager-mesh-integration-multi-cluster.adoc
+++ b/security/zero_trust_workload_identity_manager/zero-trust-manager-mesh-integration-multi-cluster.adoc
@@ -1,0 +1,36 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="zero-trust-manager-mesh-integration-multi-cluster"]
+= Integrating SPIRE federation with multi-cluster Red Hat OpenShift Service Mesh
+include::_attributes/common-attributes.adoc[]
+:context: zero-trust-manager-mesh-integration-multi-cluster
+
+toc::[]
+
+[role="_abstract"]
+Configure {spire-full} federation across multiple {product-title} clusters to enable cross-cluster mutual TLS (mTLS) authentication and zero trust workload identity in a multi-cluster service mesh deployment.
+
+include::modules/zero-trust-manager-multi-cluster-spire-mesh-about.adoc[leveloffset=+1]
+
+include::modules/zero-trust-manager-deploy-spire-multi-cluster.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* link:https://docs.redhat.com/en/documentation/openshift_container_platform/latest/html-single/security_and_compliance/index#zero-trust-manager-install[Installing the Zero Trust Workload Identity Manager]
+* link:https://docs.redhat.com/en/documentation/openshift_container_platform/latest/html/security_and_compliance/zero-trust-workload-identity-manager#zero-trust-manager-spire-federation_zero-trust-manager-oidc-federation[Zero Trust Workload Identity Manager SPIRE federation]
+* link:https://docs.redhat.com/en/documentation/openshift_container_platform/latest/html-single/security_and_compliance/index#zero-trust-manager-reconciliation[Enabling create-only mode for the Zero Trust Workload Identity Manager]
+
+include::modules/zero-trust-manager-configure-spire-mesh-multi-cluster.adoc[leveloffset=+1]
+
+include::modules/zero-trust-manager-deploy-istiocni.adoc[leveloffset=+1]
+
+include::modules/zero-trust-manager-deploy-istio-cr.adoc[leveloffset=+1]
+
+include::modules/zero-trust-manager-deploy-east-west.adoc[leveloffset=+1]
+
+include::modules/zero-trust-manager-exchange-remote-secrets.adoc[leveloffset=+1]
+
+[id="additional-resources-spire-multicluster_{context}"]
+== Additional resources
+
+* link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_mesh/3.3/html-single/installing/index#ossm-multi-cluster-configuration-overview_ossm-multi-cluster-topologies[Multi-cluster configuration overview]


### PR DESCRIPTION
## Summary

QE review corrections for PR #112274 (`OSDOCS-19890`), based on hands-on multi-cluster federation testing with **ZTWIM v4.0.1 (PR #120)** on **OpenShift 4.20** with **Sail Operator v1.30.0**.

Depends on: #112274

### Critical fixes

- **Fix CSI driver name typo** — `csi-spiffe.io` (wrong, hyphen) → `csi.spiffe.io` (correct, dot) in `SpiffeCSIDriver` and `SpireOIDCDiscoveryProvider` CRs. The wrong name prevents pods from mounting the SPIRE Agent socket.
- **Fix undefined `$JWT_ISSUER` variable** — The doc exported `JWT_ISSUER_A` but referenced `$JWT_ISSUER` in SpireServer and OIDC provider CRs, resulting in empty values.
- **Add missing `EOF` heredoc terminator** — SpireServer CR block started with `cat <<EOF` but never closed, causing the shell to hang.
- **Remove UpstreamAuthorityConfig block** — Copy-paste from the upstream-authority plugins doc with placeholder values (`"Issuer"`, `"https://vault.example.org"`). Not needed for basic federation and will cause validation errors.
- **Remove `status` field from SpiffeCSIDriver CR** — `status` is controller-managed and invalid in user-applied resources.

### High-severity fixes

- **Add actual IstioCNI CR deployment** — The "Deploy IstioCNI" section title promised IstioCNI deployment but only contained SDS patching and ClusterSPIFFEID patches. Added the actual `IstioCNI` CR creation with wait loop.
- **Remove manual SDS ConfigMap patching** — Eliminated by [PR #120](https://github.com/openshift/zero-trust-workload-identity-manager/pull/120), which auto-generates SDS config.
- **Remove `create-only` mode prerequisite** — Not needed with PR #120.
- **Replace default ClusterSPIFFEID patching with custom ClusterSPIFFEIDs** — The ZTWIM operator reconciles the default `ClusterSPIFFEID` and reverts manual patches. Created custom `ClusterSPIFFEID` resources with `namespaceSelector` and `federatesWith` for `sample` and `istio-system` namespaces.
- **Add `istio-system` federated ClusterSPIFFEID** — East-West Gateways run in `istio-system` and need federated CA bundles for cross-cluster TLS.

### Other fixes

- Add missing `$` prefix on 4 `cat <<EOF` commands
- Add `helm repo add` step before East-West Gateway install
- Remove duplicate TRUST_DOMAIN variable assignments
- Remove unused `VALIDATOR_DOMAIN_CLUSTER_A` variable
- Remove `externalSecretRef` from OIDC provider CR
- Fix topic map typo: "Worload" → "Workload"
- Remove create-only mode link from assembly additional resources

## Test plan

All fixes were validated against QE execution results documented in cross-cluster federation testing (Phase 1–12 of the tested multi-cluster guide).

- [ ] Verify AsciiDoc renders correctly in preview
- [ ] Verify all YAML blocks are valid and copy-pasteable
- [ ] Verify all shell commands include `$` prefix and `EOF` terminators
- [ ] Verify CSI driver name is consistently `csi.spiffe.io`
- [ ] QE has approved this change

Made with [Cursor](https://cursor.com)