### PR TITLE
OCPBUGS-83851-fix: Updated RHOSP note in nw-egress-ips-about.adoc

### DIFF
--- a/modules/nw-egress-ips-public-cloud-platform-considerations.adoc
+++ b/modules/nw-egress-ips-public-cloud-platform-considerations.adoc
@@ -18,6 +18,11 @@ IP capacity = public cloud default capacity - sum(current IP assignments)
 
 While the Egress IP addresses capability manages the IP address capacity per node, ensure you plan for this constraint in your deployments. For example, if a public cloud provider limits IP address capacity to 10 IP addresses per node, and you have 8 nodes, the total number of assignable IP addresses is only 80. To achieve a higher IP address capacity, you would need to allocate additional nodes. For example, if you needed 150 assignable IP addresses, you would need to allocate 7 additional nodes.
 
+[NOTE]
+====
+The {rh-openstack} egress IP address feature creates a Neutron reservation port called `egressip-<IP_address>`. Using the same {rh-openstack} user as the one used for the {product-title} cluster installation, you can assign a floating IP address to this reservation port to have a predictable SNAT address for egress traffic.
+====
+
 To confirm the IP capacity and subnets for any node in your public cloud environment, you can enter the `oc get node <node_name> -o yaml` command. The `cloud.network.openshift.io/egress-ipconfig` annotation includes capacity and subnet information for the node.
 
 The annotation value is an array with a single object with fields that provide the following information for the primary network interface:
@@ -30,7 +35,7 @@ Automatic attachment and detachment of egress IP addresses for traffic between n
 
 [NOTE]
 ====
-When an {rh-openstack} cluster administrator assigns a floating IP to the reservation port, {product-title} cannot delete the reservation port. The `CloudPrivateIPConfig` object cannot perform delete and move operations until an {rh-openstack} cluster administrator unassigns the floating IP from the reservation port.
+When an {rh-openstack} cluster administrator assigns a floating IP to the reservation port, {product-title} cannot delete the reservation port. The `CloudPrivateIPConfig` object cannot perform delete and move operations until an {rh-openstack} cluster administrator unassigns the floating IP from the reservation port. The floating IP should be assigned with the same user as the one used for the {product-title} cluster installation to allow the delete and move operation.
 ====
 
 The following examples illustrate the annotation from nodes on several public cloud providers. The annotations are indented for readability.


### PR DESCRIPTION
Version(s):
4.16+

Issue:
[OCPBUGS-83851](https://redhat.atlassian.net/browse/OCPBUGS-83851)

Preview links:

* https://114931--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/configuring-egress-ips-ovn.html
* https://114931--ocpdocs-pr.netlify.app/openshift-rosa/latest/networking/ovn_kubernetes_network_provider/configuring-egress-ips-ovn.html

* [] SME approval (OpenStack)
* [] QE approval ()
* [x] Reporter approval on https://github.com/openshift/openshift-docs/pull/110825 (Had to close as no changes were detected)

Posted in the openstack-ovn channel on AUgust 6th
