### PR TITLE
OCPBUGS-98160: Document dynamic memory for CNF latency test pods

### DIFF
--- a/modules/cnf-measuring-latency.adoc
+++ b/modules/cnf-measuring-latency.adoc
@@ -29,7 +29,10 @@ The tests introduce the following environment variables:
 |Specifies the amount of time in seconds after which the test starts running. You can use the variable to allow the CPU manager reconcile loop to update the default CPU pool. The default value is 0.
 
 |`LATENCY_TEST_CPUS`
-|Specifies the number of CPUs that the pod running the latency tests uses. If you do not set the variable, the default configuration includes all isolated CPUs.
+|Specifies the number of CPUs that the pod running the latency tests uses. If you do not set the variable, the default configuration includes all isolated CPUs. When `LATENCY_TEST_MEMORY` is unset, this value is also used to calculate the default memory request and limit for the latency test pod.
+
+|`LATENCY_TEST_MEMORY`
+|Specifies the memory request and limit for the pod that runs the latency tests. If you do not set the variable, the test allocates 32Mi of memory per `LATENCY_TEST_CPUS`, with a minimum of 1Gi. To override the calculated value, set `LATENCY_TEST_MEMORY` to a valid Kubernetes quantity greater than `0`, for example `2Gi`.
 
 |`LATENCY_TEST_RUNTIME`
 |Specifies the amount of time in seconds that the latency test must run. The default value is 300 seconds.

--- a/modules/cnf-performing-end-to-end-tests-running-cyclictest.adoc
+++ b/modules/cnf-performing-end-to-end-tests-running-cyclictest.adoc
@@ -32,6 +32,8 @@ registry.redhat.io/openshift4/cnf-tests-rhel9:v{product-version} \
 +
 The command runs the `cyclictest` tool for 10 minutes (600 seconds). The test runs successfully when the maximum observed latency is lower than `MAXIMUM_LATENCY` (in this example, 20 μs). Latency spikes of 20 μs and above are generally not acceptable for telco RAN workloads.
 +
+If you do not set `LATENCY_TEST_MEMORY`, the test allocates 32Mi of memory per `LATENCY_TEST_CPUS`, with a minimum of `1Gi`. To override that value, set `LATENCY_TEST_MEMORY` to a valid Kubernetes quantity, for example `2Gi`.
++
 If the results exceed the latency threshold, the test fails.
 +
 [IMPORTANT]

--- a/modules/cnf-performing-end-to-end-tests-running-hwlatdetect.adoc
+++ b/modules/cnf-performing-end-to-end-tests-running-hwlatdetect.adoc
@@ -32,6 +32,8 @@ registry.redhat.io/openshift4/cnf-tests-rhel9:v{product-version} \
 +
 The `hwlatdetect` test runs for 10 minutes (600 seconds). The test runs successfully when the maximum observed latency is lower than `MAXIMUM_LATENCY` (20 μs).
 +
+If you do not set `LATENCY_TEST_MEMORY`, the test allocates 32Mi of memory per `LATENCY_TEST_CPUS`, with a minimum of `1Gi`. To override that value, set `LATENCY_TEST_MEMORY` to a valid Kubernetes quantity, for example `2Gi`.
++
 If the results exceed the latency threshold, the test fails.
 +
 [IMPORTANT]

--- a/modules/cnf-performing-end-to-end-tests-running-oslat.adoc
+++ b/modules/cnf-performing-end-to-end-tests-running-oslat.adoc
@@ -32,6 +32,8 @@ registry.redhat.io/openshift4/cnf-tests-rhel9:v{product-version} \
 +
 `LATENCY_TEST_CPUS` specifies the number of CPUs to test with the `oslat` command.
 +
+If you do not set `LATENCY_TEST_MEMORY`, the test allocates 32Mi of memory per `LATENCY_TEST_CPUS`, with a minimum of `1Gi`. To override that value, set `LATENCY_TEST_MEMORY` to a valid Kubernetes quantity, for example `2Gi`.
++
 The command runs the `oslat` tool for 10 minutes (600 seconds). The test runs successfully when the maximum observed latency is lower than `MAXIMUM_LATENCY` (20 μs).
 +
 If the results exceed the latency threshold, the test fails.
@@ -41,7 +43,7 @@ If the results exceed the latency threshold, the test fails.
 During testing shorter time periods, as shown, can be used to run the tests. However, for final verification and valid results, the test should run for at least 12 hours (43200 seconds).
 ====
 +
-In this example failure output, the measured latency is outside the maximum allowed value.
+The following shows a sample output:
 +
 [source,terminal,subs="attributes+"]
 ----
@@ -76,3 +78,5 @@ FAIL! -- 0 Passed | 1 Failed | 0 Pending | 2 Skipped
 --- FAIL: TestTest (161.42s)
 FAIL
 ----
++
+In this example, the measured latency is outside the maximum allowed value as indicated by the line "The current latency 304 is bigger than the expected one".

--- a/modules/cnf-performing-end-to-end-tests-running-the-tests.adoc
+++ b/modules/cnf-performing-end-to-end-tests-running-the-tests.adoc
@@ -32,15 +32,28 @@ In the following command, your local `kubeconfig` is mounted to kubeconfig/kubec
 [source,terminal,subs="attributes+"]
 ----
 $ podman run -v $(pwd)/:/kubeconfig:Z -e KUBECONFIG=/kubeconfig/kubeconfig \
--e LATENCY_TEST_RUNTIME=600\
+-e LATENCY_TEST_RUNTIME=600 \
 -e MAXIMUM_LATENCY=20 \
 registry.redhat.io/openshift4/cnf-tests-rhel9:v{product-version} /usr/bin/test-run.sh \
 --ginkgo.v --ginkgo.timeout="24h"
 ----
 +
-The LATENCY_TEST_RUNTIME is shown in seconds, in this case 600 seconds (10 minutes). The test runs successfully when the maximum observed latency is lower than MAXIMUM_LATENCY (20 μs).
+The `LATENCY_TEST_RUNTIME` is shown in seconds, in this case 600 seconds (10 minutes). The test runs successfully when the maximum observed latency is lower than `MAXIMUM_LATENCY` (20 μs).
 +
 If the results exceed the latency threshold, the test fails.
++
+. Optional: To override the default memory request and limit for the latency test pod, set the `LATENCY_TEST_MEMORY` variable. Use this option when the default value, which is the greater of `32Mi` multiplied by `LATENCY_TEST_CPUS` or `1Gi`, is not enough for your test. For example:
++
+[source,terminal,subs="attributes+"]
+----
+$ podman run -v $(pwd)/:/kubeconfig:Z -e KUBECONFIG=/kubeconfig/kubeconfig \
+-e LATENCY_TEST_RUNTIME=600 \
+-e LATENCY_TEST_CPUS=40 \
+-e LATENCY_TEST_MEMORY=2Gi \
+-e MAXIMUM_LATENCY=20 \
+registry.redhat.io/openshift4/cnf-tests-rhel9:v{product-version} /usr/bin/test-run.sh \
+--ginkgo.v --ginkgo.timeout="24h"
+----
 +
 . Optional: Append `--ginkgo.dry-run` flag to run the latency tests in dry-run mode. This is useful for checking what commands the tests run.
 

--- a/modules/cnf-performing-end-to-end-tests-troubleshooting.adoc
+++ b/modules/cnf-performing-end-to-end-tests-troubleshooting.adoc
@@ -26,3 +26,5 @@ oc get nodes
 ----
 +
 If this command does not work, an error related to spanning across DNS, MTU size, or firewall access might be occurring.
+
+* If the latency test pod is terminated with an `OOMKilled` status when you use a high `LATENCY_TEST_CPUS` value, set the `LATENCY_TEST_MEMORY` environment variable to a larger memory quantity, for example `2Gi`, and run the test again.


### PR DESCRIPTION
[OCPBUGS-90094]: Document dynamic memory for CNF latency test pods

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.20, 4.21, 4.22, 5.0 and main
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:https://redhat.atlassian.net/browse/OCPBUGS-98160
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
https://114935--ocpdocs-pr.netlify.app/openshift-enterprise/latest/scalability_and_performance/cnf-performing-platform-verification-latency-tests.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->


## Summary
- Documents the new `LATENCY_TEST_MEMORY` environment variable and default memory scaling (`max(32Mi × LATENCY_TEST_CPUS, 1Gi)`) for CNF latency test pods.
- Adds an optional `podman` override example in the main latency test procedure.
- Adds brief memory guidance in the oslat, cyclictest, and hwlatdetect procedures, plus OOMKilled troubleshooting.

## Test plan
- [ ] Review env-var table in Measuring latency for accuracy against OCPBUGS-90598 / NTO PR #1553
- [ ] Confirm override example renders correctly in Running the latency tests
- [ ] Spot-check per-tool procedures and troubleshooting note for consistency


Made with [Cursor](https://cursor.com)