### PR TITLE
OCPBUGS-92831: Add missing IAM permissions to HCP AWS STS role policy

### DIFF
--- a/modules/hcp-aws-create-role-sts-creds.adoc
+++ b/modules/hcp-aws-create-role-sts-creds.adoc
@@ -156,6 +156,7 @@ arn:aws:iam::820196288204:role/myrole
             "Action": [
                 "iam:CreateInstanceProfile",
                 "iam:DeleteInstanceProfile",
+                "iam:TagInstanceProfile",
                 "iam:GetRole",
                 "iam:UpdateAssumeRolePolicy",
                 "iam:GetInstanceProfile",
@@ -166,11 +167,15 @@ arn:aws:iam::820196288204:role/myrole
                 "iam:PutRolePolicy",
                 "iam:AddRoleToInstanceProfile",
                 "iam:CreateOpenIDConnectProvider",
+                "iam:TagOpenIDConnectProvider",
                 "iam:ListOpenIDConnectProviders",
                 "iam:DeleteRolePolicy",
                 "iam:UpdateRole",
                 "iam:DeleteOpenIDConnectProvider",
-                "iam:GetRolePolicy"
+                "iam:GetRolePolicy",
+                "iam:ListAttachedRolePolicies",
+                "iam:ListRolePolicies",
+                "iam:DetachRolePolicy"
             ],
             "Resource": "*"
         },


### PR DESCRIPTION
## Summary

- Add 5 missing IAM permissions to the documented HCP AWS STS CLI role policy in `hcp-aws-create-role-sts-creds.adoc`
- Aligns the documented policy with the hypershift source of truth (`cmd/infra/aws/create_cli_role.go`)

## Why this change

The documented IAM policy for creating an AWS STS role for HCP is missing permissions that the `hcp` CLI expects. A customer following the documented procedure was able to create a cluster, but `hcp destroy cluster aws` failed with AccessDenied errors during IAM cleanup:

```
failed to list attached policies for role: iam:ListAttachedRolePolicies ... AccessDenied
failed to list inline policies for role: iam:ListRolePolicies ... AccessDenied
```

Comparing the documented policy against the hypershift source (`cmd/infra/aws/create_cli_role.go`), the following 5 permissions are in the source but missing from the docs:

| Permission | Purpose |
|---|---|
| `iam:ListAttachedRolePolicies` | Destroy: list managed policies before role deletion |
| `iam:ListRolePolicies` | Destroy: list inline policies before role deletion |
| `iam:DetachRolePolicy` | Destroy: detach managed policies before role deletion |
| `iam:TagInstanceProfile` | Create: tag instance profiles |
| `iam:TagOpenIDConnectProvider` | Create: tag OIDC providers |

The new permissions are inserted in the same position as they appear in the hypershift source to keep the policy consistent.

OCPBUGS-92831: https://redhat.atlassian.net/browse/OCPBUGS-92831