### PR TITLE
[OSDOCS-20477]: CQA: Managing HCP on AWS (1 of 6)

### DIFF
--- a/hosted_control_planes/hcp-manage/hcp-manage-aws.adoc
+++ b/hosted_control_planes/hcp-manage/hcp-manage-aws.adoc
@@ -1,12 +1,13 @@
 :_mod-docs-content-type: ASSEMBLY
-[id="hcp-manage-aws"]
 include::_attributes/common-attributes.adoc[]
+[id="hcp-manage-aws"]
 = Managing {hcp} on {aws-short}
 :context: hcp-managing-aws
 
 toc::[]
 
-When you use {hcp} for {product-title} on {aws-first}, the infrastructure requirements vary based on your setup.
+[role="_abstract"]
+After you deploy a hosted cluster on {aws-first}, you can manage the cluster.
 
 include::modules/hcp-manage-aws-prereq.adoc[leveloffset=+1]
 

--- a/modules/hcp-k8s-managed-aws-infra-hc.adoc
+++ b/modules/hcp-k8s-managed-aws-infra-hc.adoc
@@ -6,7 +6,10 @@
 [id="hcp-k8s-managed-aws-infra-hc_{context}"]
 = Kubernetes-managed infrastructure in a hosted cluster {aws-short} account
 
-When Kubernetes manages your infrastructure in a hosted cluster {aws-first} account, the infrastructure requirements are as follows:
+[role="_abstract"]
+When Kubernetes manages your infrastructure in a hosted cluster {aws-first} account, ensure that you meet the infrastructure requirements.
+
+The infrastructure requirements are as follows:
 
 * A network load balancer for default Ingress
 * An S3 bucket for registry

--- a/modules/hcp-manage-aws-infra-ho-req.adoc
+++ b/modules/hcp-manage-aws-infra-ho-req.adoc
@@ -6,6 +6,7 @@
 [id="hcp-manage-aws-infra-ho-req_{context}"]
 = Unmanaged infrastructure for the HyperShift Operator in an {aws-short} account
 
+[role="_abstract"]
 An arbitrary {aws-first} account depends on the provider of the {hcp} service.
 
 In self-managed {hcp}, the cluster service provider controls the {aws-short} account. The cluster service provider is the administrator who hosts cluster control planes and is responsible for uptime. In managed {hcp}, the {aws-short} account belongs to Red Hat.

--- a/modules/hcp-manage-aws-infra-req.adoc
+++ b/modules/hcp-manage-aws-infra-req.adoc
@@ -6,7 +6,10 @@
 [id="hcp-manage-aws-infra-req_{context}"]
 = Infrastructure requirements for {aws-short}
 
-When you use {hcp} on {aws-first}, the infrastructure requirements fit in the following categories:
+[role="_abstract"]
+When you use {hcp} on {aws-first}, the infrastructure requirements vary based on your setup.
+
+The infrastructure requirements fit in the following categories:
 
 * Prerequired and unmanaged infrastructure for the HyperShift Operator in an arbitrary {aws-short} account
 * Prerequired and unmanaged infrastructure in a hosted cluster {aws-short} account
@@ -14,4 +17,4 @@ When you use {hcp} on {aws-first}, the infrastructure requirements fit in the fo
 * {hcp-capital}-managed infrastructure in a hosted cluster {aws-short} account
 * Kubernetes-managed infrastructure in a hosted cluster {aws-short} account
 
-Prerequired means that {hcp} requires {aws-short} infrastructure to properly work. Unmanaged means that no Operator or controller creates the infrastructure for you.
+_Prerequired_ means that {hcp} requires {aws-short} infrastructure to properly work. _Unmanaged_ means that no Operator or controller creates the infrastructure for you.

--- a/modules/hcp-manage-aws-prereq.adoc
+++ b/modules/hcp-manage-aws-prereq.adoc
@@ -6,7 +6,8 @@
 [id="hcp-manage-aws-prereq_{context}"]
 = Prerequisites to manage {aws-short} infrastructure and IAM permissions
 
-To configure {hcp} for {product-title} on {aws-first}, you must meet the following the infrastructure requirements:
+[role="_abstract"]
+To configure {hcp} for {product-title} on {aws-first}, you must meet the infrastructure requirements.
 
-* You configured {hcp} before you can create hosted clusters.
-* You created an {aws-short} Identity and Access Management (IAM) role and {aws-short} Security Token Service (STS) credentials.
+* You must configure {hcp} before you can create hosted clusters.
+* You must create an {aws-short} Identity and Access Management (IAM) role and {aws-short} Security Token Service (STS) credentials.

--- a/modules/hcp-managed-aws-infra-hc.adoc
+++ b/modules/hcp-managed-aws-infra-hc.adoc
@@ -6,6 +6,7 @@
 [id="hcp-managed-aws-infra-hc_{context}"]
 = Infrastructure requirements for an {aws-short} account in a hosted cluster
 
+[role="_abstract"]
 When your infrastructure is managed by {hcp} in a hosted cluster {aws-first} account, the infrastructure requirements differ depending on whether your clusters are public, private, or a combination.
 
 For accounts with public clusters, the infrastructure requirements are as follows:

--- a/modules/hcp-managed-aws-infra-mgmt.adoc
+++ b/modules/hcp-managed-aws-infra-mgmt.adoc
@@ -6,6 +6,7 @@
 [id="hcp-managed-aws-infra-mgmt_{context}"]
 = Infrastructure requirements for a management {aws-short} account
 
+[role="_abstract"]
 When your infrastructure is managed by {hcp} in a management AWS account, the infrastructure requirements differ depending on whether your clusters are public, private, or a combination.
 
 For accounts with public clusters, the infrastructure requirements are as follows:

--- a/modules/hcp-unmanaged-aws-hc-prereq.adoc
+++ b/modules/hcp-unmanaged-aws-hc-prereq.adoc
@@ -6,7 +6,8 @@
 [id="hcp-unmanaged-aws-hc-prereq_{context}"]
 = Unmanaged infrastructure requirements for a management {aws-short} account
 
-When your infrastructure is prerequired and unmanaged in a hosted cluster {aws-first} account, the infrastructure requirements for all access modes are as follows:
+[role="_abstract"]
+When your infrastructure is prerequired and unmanaged in a hosted cluster {aws-first} account, ensure that you are familiar with the infrastructure requirements for all access modes.
 
 * One VPC
 * One DHCP Option


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.20+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://redhat.atlassian.net/browse/OSDOCS-20477
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
- Managing HCP on AWS: http://115021--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-manage/hcp-manage-aws.html
- Prerequisites to manage AWS infrastructure and IAM permissions: https://115021--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-manage/hcp-manage-aws.html#hcp-manage-aws-prereq_hcp-managing-aws
- Infrastructure requirements: https://115021--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-manage/hcp-manage-aws.html#hcp-manage-aws-infra-req_hcp-managing-aws
- Unmanaged infrastructure for the HO in an AWS account: https://115021--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-manage/hcp-manage-aws.html#hcp-manage-aws-infra-ho-req_hcp-managing-aws
- Unmanaged infrastructure requirements for a management AWS account: https://115021--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-manage/hcp-manage-aws.html#hcp-unmanaged-aws-hc-prereq_hcp-managing-aws
- Infrastructure requirements for a management AWS account: https://115021--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-manage/hcp-manage-aws.html#hcp-managed-aws-infra-mgmt_hcp-managing-aws
- Infrastructure requirements for an AWS account in a hosted cluster: https://115021--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-manage/hcp-manage-aws.html#hcp-managed-aws-infra-hc_hcp-managing-aws
- Kubernetes-managed infrastructure in a hosted cluster AWS account: https://115021--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-manage/hcp-manage-aws.html#hcp-k8s-managed-aws-infra-hc_hcp-managing-aws
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
N/A no technical changes
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
