### PR TITLE
Document virtctl image-upload --archive-path option

### DIFF
--- a/modules/virt-image-upload-commands.adoc
+++ b/modules/virt-image-upload-commands.adoc
@@ -6,19 +6,32 @@
 = Image upload commands
 
 [role="_abstract"]
-You can use the following `virtctl image-upload` commands to upload a VM image to a data volume.
+You can use the following `virtctl image-upload` commands to upload a VM disk image or tar archive to a data volume.
 
 .Image upload commands
 [width="100%",cols="1a,2a",options="header"]
 |===
 |Command |Description
 |`virtctl image-upload dv <datavolume_name> --image-path=</path/to/image> --no-create`
-|Upload a VM image to a data volume that already exists.
+|Upload a VM disk image to a data volume that already exists.
 
 |`virtctl image-upload dv <datavolume_name> --size=<datavolume_size> --image-path=</path/to/image>`
-|Upload a VM image to a new data volume of a specified requested size.
+|Upload a VM disk image to a new data volume of a specified requested size.
 
 |`virtctl image-upload dv <datavolume_name> --datasource --size=<datavolume_size> --image-path=</path/to/image>`
-|Upload a VM image to a new data volume and create an associated `DataSource` object for it.
+|Upload a VM disk image to a new data volume and create an associated `DataSource` object for it.
+
+|`virtctl image-upload dv <datavolume_name> --archive-path=</path/to/archive> --no-create`
+|Upload a tar archive to a data volume that already exists.
+
+|`virtctl image-upload dv <datavolume_name> --size=<datavolume_size> --archive-path=</path/to/archive>`
+|Upload a tar archive to a new data volume of a specified requested size.
 |===
 
+[NOTE]
+====
+* Use `--image-path` to upload VM disk images. Supported formats include `ISO`, `IMG`, `QCOW2`, and gzip-compressed images, such as `.img.gz`. Containerized Data Importer (CDI) automatically decompresses gzip-compressed images during upload.
+* Use `--archive-path` to upload a tar archive that contains one or more files, such as a disk image created with `tar -cvf disk.tar disk.img`. CDI extracts the contents of the archive during upload.
+* Specify either `--image-path` or `--archive-path`. You cannot specify both flags in the same command.
+* Do not use `--archive-path` with gzip-compressed disk images. A gzip-compressed image, such as `disk.img.gz`, is not a tar archive. Upload these images by using `--image-path` instead.
+====

--- a/modules/virt-uploading-image-virtctl.adoc
+++ b/modules/virt-uploading-image-virtctl.adoc
@@ -36,6 +36,8 @@ $ virtctl image-upload dv <datavolume_name> \
 [NOTE]
 ====
 * If you do not want to create a new data volume, omit the `--size` parameter and include the `--no-create` flag.
+* Use `--image-path` to upload VM disk images, including gzip-compressed images such as `.img.gz`. CDI automatically decompresses gzip-compressed images during upload.
+* Use `--archive-path` only to upload tar archives, such as `disk.tar`. Do not use this flag with gzip-compressed disk images.
 * When uploading a disk image to a PVC, the PVC size must be larger than the size of the uncompressed virtual disk.
 * To allow insecure server connections when using HTTPS, use the `--insecure` parameter. When you use the `--insecure` flag, the authenticity of the upload endpoint is *not* verified.
 ====


### PR DESCRIPTION
Title:
OSDOCS: Document virtctl image-upload --archive-path option for VM disk uploads
Note: If you have a Jira OSDOCS ticket, replace the title with:
[OSDOCS#<jira-issue-id>]: Document virtctl image-upload --archive-path option for VM disk uploads

PR Body:
Clarify when to use `--image-path` versus `--archive-path` for VM disk uploads, including guidance for gzip-compressed images exported from `virtctl vmexport`.

Version(s):
4.22

Issue:
N/A

Link to docs preview:
Add the Netlify preview link from the PR bot comment after the PR is created.

Expected preview pages to verify:
- Virtualization > Getting started > Using the CLI tools > Image upload commands
  Anchor: `#image-upload-commands_virt-using-the-cli-tools`
- Virtualization > Creating VMs > Advanced > Uploading a virtual machine image by using the CLI
  Anchor: `#virt-uploading-image-virtctl_virt-creating-vms-uploading-images`
Published reference pages (for comparison after merge):
- https://docs.redhat.com/en/documentation/openshift_container_platform/4.22/html/virtualization/getting-started#image-upload-commands_virt-using-the-cli-tools
- https://docs.redhat.com/en/documentation/openshift_container_platform/4.22/html/virtualization/creating-vms-advanced#virt-uploading-image-virtctl_virt-creating-vms-uploading-images


QE review:
- [ ] QE has approved this change.


Additional information:
## Summary
This PR documents the `virtctl image-upload --archive-path` option, which is available in `virtctl image-upload --help` but was not previously described in the OpenShift Virtualization documentation.
The update also clarifies when to use `--image-path` versus `--archive-path`, including guidance for gzip-compressed disk images such as `.img.gz` exported with `virtctl vmexport`.


## Motivation
Customers uploading VM disk images with `virtctl image-upload` can choose between two source flags:
- `--image-path`: for VM disk images
- `--archive-path`: for tar archives
Using `--archive-path` with a gzip-compressed disk image (for example, `disk.img.gz`) fails with an HTTP 500 error and CDI log messages such as:
```
begin untar to /data...
unable to untar files from endpoint
exit status 2
```
This happens because CDI treats archive uploads as tar extraction (`tar -xvC /data`), not gzip decompression. A `.img.gz` file produced by `virtctl vmexport download --output=disk.img.gz` is a gzip-compressed disk image, not a tar archive, and must be uploaded with `--image-path`.
Example:
Wrong:
```terminal
$ virtctl image-upload dv my-dv --size=200Gi --archive-path=disk.img.gz --insecure
```
Correct:
```terminal
$ virtctl image-upload dv my-dv --size=200Gi --image-path=disk.img.gz --insecure
```
Use `--archive-path` only for tar archives, for example:
```terminal
$ tar -cvf disk.tar disk.img
$ virtctl image-upload dv my-dv --size=200Gi --archive-path=disk.tar
```
## Changes

### `modules/virt-image-upload-commands.adoc`
- Updated the module abstract to mention tar archive uploads.
- Added two `--archive-path` command examples to the Image upload commands table.
- Added a NOTE that explains:
  - `--image-path` is for VM disk images, including `.img`, `.qcow2`, `.iso`, and `.img.gz`
  - `--archive-path` is for tar archives only
  - only one of the two flags can be used
  - gzip-compressed disk images must not be uploaded with `--archive-path`

### `modules/virt-uploading-image-virtctl.adoc`
- Added NOTE bullets in the upload procedure explaining when to use `--image-path` and `--archive-path`.
- Clarified that gzip-compressed images such as `.img.gz` must use `--image-path`.

## Files changed
- `modules/virt-image-upload-commands.adoc`
- `modules/virt-uploading-image-virtctl.adoc`

## Test plan
- [x] Open the Netlify docs preview from the PR bot comment.
- [x] Verify the Image upload commands table includes the new `--archive-path` rows.
- [x] Verify the NOTE under Image upload commands renders correctly.
- [x] Verify the NOTE in Uploading a virtual machine image by using the CLI includes the new guidance.
- [x] Confirm the content is accurate against `virtctl image-upload --help`.

## Review request
@openshift/team-documentation please review.