### PR TITLE
Created missing L2 topics for Configure category JTBD

### DIFF
--- a/configuring/customize-build-strategy-runtime-options.adoc
+++ b/configuring/customize-build-strategy-runtime-options.adoc
@@ -1,0 +1,62 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="customize-build-strategy-runtime-options"]
+= Customize Your Build Strategy and Runtime Options
+
+include::_attributes/common-attributes.adoc[]
+:context: customize-build-strategy-runtime-options
+
+toc::[]
+
+[role="_abstract"]
+Platform engineers can customize build execution by configuring source inputs, strategy selection, build specifications, pod settings, volumes, environment variables, and runtime parameters. These configuration options enable fine-grained control over how builds run on the cluster.
+
+include::modules/ob-define-build-inputs-source-code.adoc[leveloffset=+1]
+
+include::modules/ob-defining-the-source.adoc[leveloffset=+2]
+
+include::modules/ob-defining-the-strategy.adoc[leveloffset=+2]
+
+include::modules/ob-defining-the-container-file.adoc[leveloffset=+2]
+
+include::modules/ob-defining-the-build-specification.adoc[leveloffset=+2]
+
+include::modules/ob-configuring-pods-in-build.adoc[leveloffset=+2]
+
+include::modules/ob-defining-the-service-account.adoc[leveloffset=+2]
+
+include::modules/ob-specifying-environment-variables.adoc[leveloffset=+2]
+
+include::modules/ob-defining-volumes.adoc[leveloffset=+2]
+
+include::modules/ob-resource-management-in-tekton-pipelines.adoc[leveloffset=+2]
+
+include::modules/ob-configure-build-inputs-outputs.adoc[leveloffset=+1]
+
+include::modules/ob-defining-the-output.adoc[leveloffset=+2]
+
+include::modules/ob-defining-param-values.adoc[leveloffset=+2]
+
+include::modules/ob-defining-the-build-reference.adoc[leveloffset=+2]
+
+include::modules/ob-run-customize-build-execution.adoc[leveloffset=+1]
+
+include::modules/ob-configuring-pods-in-build-run.adoc[leveloffset=+2]
+
+include::modules/ob-defining-volumes-in-build-run.adoc[leveloffset=+2]
+
+include::modules/ob-defining-param-values-in-build-run.adoc[leveloffset=+2]
+
+include::modules/ob-defining-retention-parameters-in-build-run.adoc[leveloffset=+2]
+
+include::modules/ob-track-build-progress-manage-running-builds.adoc[leveloffset=+1]
+
+include::modules/ob-understanding-the-status-of-a-build-run.adoc[leveloffset=+2]
+
+include::modules/ob-canceling-a-build-run.adoc[leveloffset=+2]
+
+include::modules/ob-defining-system-results.adoc[leveloffset=+2]
+
+include::modules/ob-build-snapshot.adoc[leveloffset=+1]
+
+// [role="_additional-resources"]
+// == Additional resources

--- a/modules/ob-configure-build-inputs-outputs.adoc
+++ b/modules/ob-configure-build-inputs-outputs.adoc
@@ -1,0 +1,11 @@
+// This module is included in the following assembly:
+//
+// * configuring/customize-build-strategy-runtime-options.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="ob-configure-build-inputs-outputs_{context}"]
+= Configure build inputs and outputs
+
+[role="_abstract"]
+Build inputs and outputs define how {builds-shortname} sources content for the build process and where it delivers the resulting container image. The input configuration specifies the source code location, authentication credentials, and any parameters that customize the build behavior. The output configuration determines the registry destination, push credentials, and optional metadata for the built image.
+

--- a/modules/ob-define-build-inputs-source-code.adoc
+++ b/modules/ob-define-build-inputs-source-code.adoc
@@ -1,0 +1,10 @@
+// This module is included in the following assembly:
+//
+// * configuring/customize-build-strategy-runtime-options.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="ob-define-build-inputs-source-code_{context}"]
+= Define build inputs and source code
+
+[role="_abstract"]
+Build inputs and source code configuration determine how {builds-shortname} locates, retrieves, and processes your application source code during the build process. These configuration options specify the source repository, build strategy, containerization instructions, and runtime environment needed to transform source code into a container image.

--- a/modules/ob-run-customize-build-execution.adoc
+++ b/modules/ob-run-customize-build-execution.adoc
@@ -1,0 +1,10 @@
+// This module is included in the following assembly:
+//
+// * configuring/customize-build-strategy-runtime-options.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="ob-run-customize-build-execution_{context}"]
+= Run and customize a build execution
+
+[role="_abstract"]
+Running and customizing a build execution involves configuring the runtime environment and resource behavior for a BuildRun custom resource. These settings control how {builds-shortname} executes a build, including pod configuration, volume mounts, parameter values, and retention policies for completed build runs.

--- a/modules/ob-track-build-progress-manage-running-builds.adoc
+++ b/modules/ob-track-build-progress-manage-running-builds.adoc
@@ -1,0 +1,10 @@
+// This module is included in the following assembly:
+//
+// * configuring/customize-build-strategy-runtime-options.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="ob-track-build-progress-manage-running-builds_{context}"]
+= Track build progress and manage running builds
+
+[role="_abstract"]
+Tracking build progress and managing running builds enables you to monitor the current state of build executions and control their lifecycle. You can observe build status through the BuildRun custom resource, which provides real-time information about build progression, completion, and any errors that occur. When necessary, you can cancel running builds before they complete.


### PR DESCRIPTION
Version(s): build-docs-main

Issue: JTBD-based topic organization for Configure category

Link to docs preview:

QE review:
- [ ] QE has approved this change.

Additional information:
Created missing L2 topics for JTBD-based Configure category:
- customize-build-strategy-runtime-options.adoc (assembly)
- ob-configure-build-inputs-outputs.adoc (module)
- ob-define-build-inputs-source-code.adoc (module)
- ob-run-customize-build-execution.adoc (module)
- ob-track-build-progress-manage-running-builds.adoc (module)

These topics complete the Configure category structure based on JTBD analysis.