### PR TITLE
TELCODOCS-2927: auth for kubevirt redfish

### DIFF
--- a/modules/proc_virt-installing-kubevirt-redfish.adoc
+++ b/modules/proc_virt-installing-kubevirt-redfish.adoc
@@ -135,7 +135,25 @@ subjects:
 $ oc apply -f clusterrolebinding.yaml
 ----
 
-. Create the `Secret` CR containing the configuration by creating a YAML file with content such as the following example.
+. Create a `Secret` CR to enable the Redfish API to manage specific VMs:
+
+.. Generate a `bcrypt` hashed password for the Redfish API by running the following command in a Linux terminal:
++
+[source,terminal]
+----
+$ htpasswd -nbB "" '<password>' | cut -d: -f2
+----
++
+* `<password>` is the password you want to use for the Redfish API.
++
+The output is a `bcrypt` hashed password beginning with `$2a$`, `$2b$`, or `$2y$`.
++
+[NOTE]
+====
+In earlier Technology Preview releases, plain text passwords were used. Use `bcrypt` hashed passwords for improved security.
+====
+
+.. Create the `Secret` CR containing the configuration with content such as the following example.
 Edit the `config.yaml` section to match your environment:
 +
 [source,yaml]
@@ -167,7 +185,8 @@ stringData:
     authentication:
       users:
         - username: "admin"
-          password: "<password>"
+          password:
+            hash: "<bcrypt_password>"
           chassis: ["<chassis_name>"]
     datavolume:
       storage_class: "<storage_class>"
@@ -175,11 +194,11 @@ stringData:
 ----
 +
 where:
-
-* `system_id_convention` specifies the format for Redfish system IDs. The recommended setting is `enhanced` to use `<namespace>.<vm-name>` format. The `legacy` setting uses `<vm-name>` only.
-* `chassis` specifies the namespaces where VMs are deployed. Replace `<chassis_name>` with a name for this chassis configuration and `<vm_namespace>` with the namespace containing your VMs. The `vm_selector` labels identify which VMs in the namespace are exposed through Redfish. Only VMs with matching labels are visible. You can configure multiple chassis entries to expose different subsets of VMs in the same namespace, each with different authentication users.
-* `authentication` specifies the username and password required to access the Redfish API. These credentials enable full management control over exposed VMs, independently of any {product-title} privileges. Replace `<password>` with a secure password.
-* `datavolume` specifies storage for VirtualMedia operations. Replace `<storage_class>` with a storage class available on your cluster, such as `lvms-vg1` or `ocs-storagecluster-ceph-rbd-virtualization`. For more information about storage options, see _Storage requirements_ in "Prerequisites for virtualized control planes".
++
+`system_id_convention`:: Specifies the format for Redfish system IDs. The recommended setting is `enhanced` to use `<namespace>.<vm-name>` format. The `legacy` setting uses `<vm-name>` only.
+`chassis`:: Specifies the namespaces where VMs are deployed. Replace `<chassis_name>` with a name for this chassis configuration and `<vm_namespace>` with the namespace containing your VMs. The `vm_selector` labels identify which VMs in the namespace are exposed through Redfish. Only VMs with matching labels are visible. You can configure multiple chassis entries to expose different subsets of VMs in the same namespace, each with different authentication users.
+`authentication`:: Specifies the username and password required to validate requests to the Redfish API. Replace `<bcrypt_password>` with the `bcrypt` hashed password that you generated.
+`datavolume`:: Specifies storage for VirtualMedia operations. Replace `<storage_class>` with a storage class available on your cluster, such as `lvms-vg1` or `ocs-storagecluster-ceph-rbd-virtualization`. For more information about storage options, see _Storage requirements_ in "Prerequisites for virtualized control planes".
 
 . Apply the resource by running the following command:
 +


### PR DESCRIPTION
[TELCODOCS-2927](https://redhat.atlassian.net/browse/TELCODOCS-2927): auth for kubevirt redfish

Version(s):
4.22+

Issue:
https://redhat.atlassian.net/browse/TELCODOCS-2927

Link to docs preview:
- https://115086--ocpdocs-pr.netlify.app/openshift-enterprise/latest/vcp/vcp-preparing-environment.html#proc_virt-installing-kubevirt-redfish_vcp-preparing-environment
- (same procedure just re-used in vanilla Virt section) https://115086--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/post_installation_configuration/virt-kubevirt-redfish.html#proc_virt-installing-kubevirt-redfish_virt-kubevirt-redfish


QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->


