### PR TITLE
TELCODOCS-2761: DITA compatibility fixes for ztp-manual-install assembly (4.20 backport)

### DIFF
--- a/edge_computing/ztp-manual-install.adoc
+++ b/edge_computing/ztp-manual-install.adoc
@@ -8,6 +8,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 You can deploy a managed {sno} cluster by using {rh-rhacm-first} and the assisted service.
 
 [NOTE]

--- a/modules/ztp-checking-the-managed-cluster-status.adoc
+++ b/modules/ztp-checking-the-managed-cluster-status.adoc
@@ -6,6 +6,7 @@
 [id="ztp-checking-the-managed-cluster-status_{context}"]
 = Monitoring the managed cluster installation status
 
+[role="_abstract"]
 Ensure that cluster provisioning was successful by checking the cluster status.
 
 .Prerequisites

--- a/modules/ztp-configuring-kernel-arguments-for-discovery-iso-in-manual-installations.adoc
+++ b/modules/ztp-configuring-kernel-arguments-for-discovery-iso-in-manual-installations.adoc
@@ -6,12 +6,8 @@
 [id="setting-managed-bare-metal-host-kernel-arguments_{context}"]
 = Configuring Discovery ISO kernel arguments for manual installations using {ztp}
 
-The {ztp-first} workflow uses the Discovery ISO as part of the {product-title} installation process on managed bare-metal hosts. You can edit the `InfraEnv` resource to specify kernel arguments for the Discovery ISO. This is useful for cluster installations with specific environmental requirements. For example, configure the `rd.net.timeout.carrier` kernel argument for the Discovery ISO to facilitate static networking for the cluster or to receive a DHCP address before downloading the root file system during installation.
-
-[NOTE]
-====
-In {product-title} {product-version}, you can only add kernel arguments. You can not replace or delete kernel arguments.
-====
+[role="_abstract"]
+The {ztp-first} workflow uses the Discovery ISO as part of the {product-title} installation process on managed bare-metal hosts. You can edit the `InfraEnv` resource to specify kernel arguments for the Discovery ISO. This is useful for cluster installations with specific environmental requirements. For example, configure the `rd.net.timeout.carrier` kernel argument for the Discovery ISO to facilitate static networking for the cluster or to receive a DHCP address before downloading the root file system during installation. In {product-title} {product-version}, you can only add kernel arguments. You can not replace or delete kernel arguments.
 
 .Prerequisites
 
@@ -22,7 +18,7 @@ In {product-title} {product-version}, you can only add kernel arguments. You can
 .Procedure
 
 . Edit the `spec.kernelArguments` specification in the `InfraEnv` CR to configure kernel arguments:
-
++
 [source,yaml,options="nowrap",role="white-space-pre"]
 ----
 apiVersion: agent-install.openshift.io/v1beta1
@@ -32,8 +28,8 @@ metadata:
   namespace: <cluster_name>
 spec:
   kernelArguments:
-    - operation: append <1>
-      value: audit=0 <2>
+    - operation: append
+      value: audit=0
     - operation: append
       value: trace=1
   clusterRef:
@@ -42,8 +38,14 @@ spec:
   pullSecretRef:
     name: pull-secret
 ----
-<1> Specify the append operation to add a kernel argument.
-<2> Specify the kernel argument you want to configure. This example configures the audit kernel argument and the trace kernel argument.
++
+where:
++
+--
+`operation`:: Specify the `append` operation to add a kernel argument.
+`value`:: Specify the kernel argument you want to configure. This example configures the `audit` kernel argument and the `trace` kernel argument.
+--
++
 
 [NOTE]
 ====

--- a/modules/ztp-creating-the-site-secrets.adoc
+++ b/modules/ztp-creating-the-site-secrets.adoc
@@ -7,6 +7,7 @@
 [id="ztp-creating-the-site-secrets_{context}"]
 = Creating the managed bare-metal host secrets
 
+[role="_abstract"]
 Add the required `Secret` custom resources (CRs) for the managed bare-metal host to the hub cluster. You need a secret for the {ztp-first} pipeline to access the Baseboard Management Controller (BMC) and a secret for the assisted installer service to pull cluster installation images from the registry.
 
 [NOTE]
@@ -27,8 +28,8 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: example-sno-bmc-secret
-  namespace: example-sno <1>
-data: <2>
+  namespace: example-sno
+data:
   password: <base64_password>
   username: <base64_username>
 type: Opaque
@@ -37,14 +38,18 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: pull-secret
-  namespace: example-sno  <3>
+  namespace: example-sno
 data:
-  .dockerconfigjson: <pull_secret> <4>
+  .dockerconfigjson: <pull_secret>
 type: kubernetes.io/dockerconfigjson
 ----
-<1> Must match the namespace configured in the related `SiteConfig` CR
-<2> Base64-encoded values for `password` and `username`
-<3> Must match the namespace configured in the related `SiteConfig` CR
-<4> Base64-encoded pull secret
++
+where:
++
+--
+`namespace`:: Must match the namespace configured in the related `SiteConfig` CR.
+`password`, `username`:: Base64-encoded values for `password` and `username`.
+`.dockerconfigjson`:: Base64-encoded pull secret.
+--
 
 . Add the relative path to `example-sno-secret.yaml` to the `kustomization.yaml` file that you use to install the cluster.

--- a/modules/ztp-generating-install-and-config-crs-manually.adoc
+++ b/modules/ztp-generating-install-and-config-crs-manually.adoc
@@ -6,6 +6,7 @@
 [id="ztp-generating-install-and-config-crs-manually_{context}"]
 = Generating {ztp} installation and configuration CRs manually
 
+[role="_abstract"]
 Use the `generator` entrypoint for the `ztp-site-generate` container to generate the site installation and configuration custom resource (CRs) for a cluster based on `SiteConfig` and `{policy-gen-cr}` CRs.
 
 include::snippets/siteconfig-deprecation-notice.adoc[]

--- a/modules/ztp-installation-crs.adoc
+++ b/modules/ztp-installation-crs.adoc
@@ -6,6 +6,7 @@
 [id="ztp-installation-crs_{context}"]
 = {rh-rhacm} generated cluster installation CRs reference
 
+[role="_abstract"]
 {rh-rhacm-first} supports deploying {product-title} on single-node clusters, three-node clusters, and standard clusters with a specific set of installation custom resources (CRs) that you generate using `SiteConfig` CRs for each site.
 
 [NOTE]

--- a/modules/ztp-manually-install-a-single-managed-cluster.adoc
+++ b/modules/ztp-manually-install-a-single-managed-cluster.adoc
@@ -6,6 +6,7 @@
 [id="ztp-manually-install-a-single-managed-cluster_{context}"]
 = Installing a single managed cluster
 
+[role="_abstract"]
 You can manually deploy a single managed cluster using the assisted service and {rh-rhacm-first}.
 
 .Prerequisites
@@ -27,12 +28,17 @@ You can manually deploy a single managed cluster using the assisted service and 
 apiVersion: hive.openshift.io/v1
 kind: ClusterImageSet
 metadata:
-  name: openshift-{product-version}.0 <1>
+  name: openshift-{product-version}.0
 spec:
-   releaseImage: quay.io/openshift-release-dev/ocp-release:{product-version}.0-x86_64 <2>
+   releaseImage: quay.io/openshift-release-dev/ocp-release:{product-version}.0-x86_64
 ----
-<1> The descriptive version that you want to deploy.
-<2> Specifies the `releaseImage` to deploy and determines the operating system image version. The discovery ISO is based on the image version as set by `releaseImage`, or the latest version if the exact version is unavailable.
++
+where:
++
+--
+`name`:: The descriptive version that you want to deploy.
+`releaseImage`:: Specifies the `releaseImage` to deploy and determines the operating system image version. The discovery ISO is based on the image version as set by `releaseImage`, or the latest version if the exact version is unavailable.
+--
 
 . Apply the `clusterImageSet` CR:
 +
@@ -48,11 +54,16 @@ $ oc apply -f clusterImageSet-{product-version}.yaml
 apiVersion: v1
 kind: Namespace
 metadata:
-     name: <cluster_name> <1>
+     name: <cluster_name>
      labels:
-        name: <cluster_name> <1>
+        name: <cluster_name>
 ----
-<1>  The name of the managed cluster to provision.
++
+where:
++
+--
+`name`:: The name of the managed cluster to provision.
+--
 
 . Apply the `Namespace` CR by running the following command:
 +

--- a/modules/ztp-troubleshooting-the-managed-cluster.adoc
+++ b/modules/ztp-troubleshooting-the-managed-cluster.adoc
@@ -6,6 +6,7 @@
 [id="ztp-troubleshooting-the-managed-cluster_{context}"]
 = Troubleshooting the managed cluster
 
+[role="_abstract"]
 Use this procedure to diagnose any installation issues that might occur with the managed cluster.
 
 .Procedure


### PR DESCRIPTION
# CP of PR https://github.com/openshift/openshift-docs/pull/106774 to enterprise-4.20

# Changes
Add [role="_abstract"] to assembly and all 7 included modules
Replace callout lists with description lists in 3 modules
Fix standalone content not attached to procedure steps
Integrate NOTE admonition into abstract to resolve TaskStep violation
Version(s):

Issue:https://issues.redhat.com/browse/TELCODOCS-2761

Link to docs preview:

QE review:

 QE has approved this change.
Additional information: