### PR TITLE
OSDOCS-17049: Fix DITA Vale ShortDescription partial

### DIFF
--- a/modules/images-cluster-sample-imagestream-import.adoc
+++ b/modules/images-cluster-sample-imagestream-import.adoc
@@ -5,6 +5,7 @@
 [id="images-cluster-sample-imagestream-import_{context}"]
 = Configuring periodic importing of Cluster Sample Operator image stream tags
 
+[role="_abstract"]
 You can ensure that you always have access to the latest versions of the Cluster Sample Operator images by periodically importing the image stream tags when new versions become available.
 
 .Procedure

--- a/modules/installation-preparing-restricted-cluster-to-gather-support-data.adoc
+++ b/modules/installation-preparing-restricted-cluster-to-gather-support-data.adoc
@@ -6,6 +6,7 @@
 [id="installation-preparing-restricted-cluster-to-gather-support-data_{context}"]
 = Preparing your cluster to gather support data
 
+[role="_abstract"]
 Clusters using a restricted network must import the default must-gather image to gather debugging data for Red Hat support. The must-gather image is not imported by default, and clusters on a restricted network do not have access to the internet to pull the latest image from a remote repository.
 
 .Procedure

--- a/modules/machine-health-checks-about.adoc
+++ b/modules/machine-health-checks-about.adoc
@@ -12,6 +12,7 @@
 You can only apply a machine health check to machines that are managed by compute machine sets or control plane machine sets.
 ====
 
+[role="_abstract"]
 To monitor machine health, create a resource to define the configuration for a controller. Set a condition to check, such as staying in the `NotReady` status for five minutes or displaying a permanent condition in the node-problem-detector, and a label for the set of machines to monitor.
 
 The controller that observes a `MachineHealthCheck` resource checks for the defined condition. If a machine fails the health check, the machine is automatically deleted and one is created to take its place. When a machine is deleted, you see a `machine deleted` event.

--- a/modules/machine-health-checks-creating.adoc
+++ b/modules/machine-health-checks-creating.adoc
@@ -7,6 +7,7 @@
 [id="machine-health-checks-creating_{context}"]
 = Creating a machine health check resource
 
+[role="_abstract"]
 You can create a `MachineHealthCheck` resource for machine sets in your cluster.
 
 [NOTE]

--- a/modules/machine-health-checks-resource.adoc
+++ b/modules/machine-health-checks-resource.adoc
@@ -7,6 +7,7 @@
 [id="machine-health-checks-resource_{context}"]
 = Sample MachineHealthCheck resource
 
+[role="_abstract"]
 The `MachineHealthCheck` resource for all cloud-based installation types, and other than bare metal, resembles the following YAML file:
 
 [source,yaml]

--- a/modules/machine-node-custom-partition.adoc
+++ b/modules/machine-node-custom-partition.adoc
@@ -8,6 +8,7 @@
 [id="machine-node-custom-partition_{context}"]
 = Adding a new {op-system} worker node with a custom `/var` partition in AWS
 
+[role="_abstract"]
 {product-title} supports partitioning devices during installation by using machine configs that are processed during the bootstrap. However, if you use `/var` partitioning, the device name must be determined at installation and cannot be changed. You cannot add different instance types as nodes if they have a different device naming schema. For example, if you configured the `/var` partition with the default AWS device name for `m4.large` instances, `dev/xvdb`, you cannot directly add an AWS `m5.large` instance, as `m5.large` instances use a `/dev/nvme1n1` device by default. The device might fail to partition due to the different naming schema.
 
 The procedure in this section shows how to add a new {op-system-first} compute node with an instance that uses a different device name from what was configured at installation. You create a custom user data secret and configure a new compute machine set. These steps are specific to an AWS cluster. The principles apply to other cloud deployments also. However, the device naming schema is different for other deployments and should be determined on a per-case basis.

--- a/modules/modify-unavailable-workers.adoc
+++ b/modules/modify-unavailable-workers.adoc
@@ -6,6 +6,7 @@
 [id="modify-unavailable-workers_{context}"]
 = Modifying the number of unavailable worker nodes
 
+[role="_abstract"]
 By default, only one machine is allowed to be unavailable when applying the kubelet-related configuration to the available worker nodes. For a large cluster, it can take a long time for the configuration change to be reflected. At any time, you can adjust the number of machines that are updating to speed up the process.
 
 .Procedure

--- a/modules/nodes-pods-plugins-about.adoc
+++ b/modules/nodes-pods-plugins-about.adoc
@@ -7,6 +7,7 @@
 [id="nodes-pods-plugins-about_{context}"]
 = Understanding device plugins
 
+[role="_abstract"]
 The device plugin provides a consistent and portable solution to consume hardware
 devices across clusters. The device plugin provides support for these devices
 through an extension mechanism, which makes these devices available to

--- a/modules/nodes-pods-plugins-device-mgr.adoc
+++ b/modules/nodes-pods-plugins-device-mgr.adoc
@@ -7,6 +7,7 @@
 [id="nodes-pods-plugins-device-mgr_{context}"]
 = Understanding the Device Manager
 
+[role="_abstract"]
 Device Manager provides a mechanism for advertising specialized node hardware resources
 with the help of plugins known as device plugins.
 

--- a/modules/nodes-pods-plugins-install.adoc
+++ b/modules/nodes-pods-plugins-install.adoc
@@ -7,6 +7,7 @@
 [id="nodes-pods-plugins-install_{context}"]
 = Enabling Device Manager
 
+[role="_abstract"]
 Enable Device Manager to implement a device plugin to advertise specialized
 hardware without any upstream code changes.
 

--- a/modules/nodes-vsphere-machine-set-concept-static-ip.adoc
+++ b/modules/nodes-vsphere-machine-set-concept-static-ip.adoc
@@ -6,6 +6,7 @@
 [id="nodes-vsphere-machine-set-concept-static-ip_{context}"]
 = Machine set scaling of machines with configured static IP addresses
 
+[role="_abstract"]
 You can use a machine set to scale machines with configured static IP addresses.
 
 After you configure a machine set to request a static IP address for a machine, the machine controller creates an `IPAddressClaim` resource in the `openshift-machine-api` namespace. The external controller then creates an `IPAddress` resource and binds any static IP addresses to the `IPAddressClaim` resource.

--- a/modules/nodes-vsphere-machine-set-scaling-static-ip.adoc
+++ b/modules/nodes-vsphere-machine-set-scaling-static-ip.adoc
@@ -6,6 +6,7 @@
 [id="nodes-vsphere-machine-set-scaling-static-ip_{context}"]
 = Using a machine set to scale machines with configured static IP addresses
 
+[role="_abstract"]
 You can use a machine set to scale machines with configured static IP addresses.
 
 The example in the procedure demonstrates the use of controllers for scaling machines in a machine set.

--- a/modules/nodes-vsphere-scaling-machines-static-ip.adoc
+++ b/modules/nodes-vsphere-scaling-machines-static-ip.adoc
@@ -6,6 +6,7 @@
 [id="nodes-vsphere-scaling-machines-static-ip_{context}"]
 = Scaling machines to use static IP addresses
 
+[role="_abstract"]
 You can scale additional machine sets to use pre-defined static IP addresses on your cluster. For this configuration, you need to create a machine resource YAML file and then define static IP addresses in this file.
 
 .Prerequisites

--- a/modules/recommended-node-host-practices.adoc
+++ b/modules/recommended-node-host-practices.adoc
@@ -6,6 +6,7 @@
 [id="recommended-node-host-practices_{context}"]
 = Recommended node host practices
 
+[role="_abstract"]
 The {product-title} node configuration file contains important options. For
 example, two parameters control the maximum number of pods that can be scheduled
 to a node: `podsPerCore` and `maxPods`.

--- a/post_installation_configuration/node-tasks.adoc
+++ b/post_installation_configuration/node-tasks.adoc
@@ -6,6 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 After installing {product-title}, you can further expand and customize your
 cluster to your requirements through certain node tasks.
 

--- a/post_installation_configuration/post-install-image-config.adoc
+++ b/post_installation_configuration/post-install-image-config.adoc
@@ -7,6 +7,7 @@ include::_attributes/attributes-openshift-dedicated.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 You can update the global pull secret for your cluster by either replacing the current pull secret or appending a new pull secret. The procedure is required when users use a separate registry to store images than the registry used during installation. For more information, see xref:../openshift_images/managing_images/using-image-pull-secrets.adoc#using-image-pull-secrets[Using image pull secrets].
 
 For information about images and configuring image streams or image registries, see the following documentation:

--- a/post_installation_configuration/post-install-network-configuration.adoc
+++ b/post_installation_configuration/post-install-network-configuration.adoc
@@ -6,6 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 After installing {product-title}, you can further expand and customize your network to your requirements.
 
 [id="post-install-network-configuration-cno"]

--- a/post_installation_configuration/post-install-storage-configuration.adoc
+++ b/post_installation_configuration/post-install-storage-configuration.adoc
@@ -20,6 +20,7 @@ endif::[]
 
 toc::[]
 
+[role="_abstract"]
 After installing {product-title}, you can further expand and customize your cluster to your requirements, including storage configuration.
 
 By default, containers operate by using the ephemeral storage or transient local storage. The ephemeral storage has a lifetime limitation. To store the data for a long time, you must configure persistent storage. You can configure storage by using one of the following methods:


### PR DESCRIPTION
… configuration

Address ConceptLink and ShortDescription Vale checks for node tasks, device plugins, vSphere static IP, and post-install image, network, and storage assemblies.

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.20+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
