### PR TITLE
OSDOCS-17049: Fix DITA Vale ShortDescription continuation

### DIFF
--- a/modules/olm-creating-catalog-from-index.adoc
+++ b/modules/olm-creating-catalog-from-index.adoc
@@ -25,6 +25,7 @@ endif::[]
 [id="olm-creating-catalog-from-index_{context}"]
 = Adding a catalog source to a cluster
 
+[role="_abstract"]
 Adding a catalog source to an {product-title} cluster enables the discovery and installation of Operators for users.
 ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 Cluster administrators

--- a/modules/olm-installing-from-software-catalog-using-cli.adoc
+++ b/modules/olm-installing-from-software-catalog-using-cli.adoc
@@ -16,6 +16,7 @@ endif::[]
 [id="olm-installing-operator-from-software-catalog-using-cli_{context}"]
 = Installing from the software catalog by using the CLI
 
+[role="_abstract"]
 Instead of using the {product-title} web console, you can install an Operator from the software catalog by using the CLI. Use the `oc` command to create or update a `Subscription` object.
 
 For `SingleNamespace` install mode, you must also ensure an appropriate Operator group exists in the related namespace. An Operator group, defined by an `OperatorGroup` object, selects target namespaces in which to generate required RBAC access for all Operators in the same namespace as the Operator group.

--- a/modules/olm-installing-from-software-catalog-using-web-console.adoc
+++ b/modules/olm-installing-from-software-catalog-using-web-console.adoc
@@ -33,6 +33,7 @@ endif::[]
 [id="olm-installing-from-software-catalog-using-web-console_{context}"]
 = Installing from the software catalog by using the web console
 
+[role="_abstract"]
 You can install and subscribe to an Operator from software catalog by using the {product-title} web console.
 
 .Prerequisites

--- a/modules/olm-installing-operators-from-software-catalog-configure.adoc
+++ b/modules/olm-installing-operators-from-software-catalog-configure.adoc
@@ -10,6 +10,7 @@
 [id="olm-installing-operators-from-software-catalog-configure_{context}"]
 = About Operator Catalogs in {product-title}
 
+[role="_abstract"]
 Out of the box {product-title} provides a catalog source for community operators.
 These operators are built and distributed by the community.
 There are ongoing efforts to make more operators available through a community operator catalog.

--- a/modules/olm-installing-operators-from-software-catalog.adoc
+++ b/modules/olm-installing-operators-from-software-catalog.adoc
@@ -16,6 +16,7 @@ endif::[]
 [id="olm-installing-operators-from-software-catalog_{context}"]
 = About Operator installation from the software catalog
 
+[role="_abstract"]
 The software catalog is a user interface for discovering Operators; it works in conjunction with Operator Lifecycle Manager (OLM), which installs and manages Operators on a cluster.
 
 ifndef::olm-user,openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]

--- a/modules/olm-mirroring-catalog-icsp.adoc
+++ b/modules/olm-mirroring-catalog-icsp.adoc
@@ -6,6 +6,7 @@
 [id="olm-mirror-catalog-icsp_{context}"]
 = Creating the ImageContentSourcePolicy object
 
+[role="_abstract"]
 After mirroring Operator catalog content to your mirror registry, create the required `ImageContentSourcePolicy` (ICSP) object. The ICSP object configures nodes to translate between the image references stored in Operator manifests and the mirrored registry.
 
 .Procedure

--- a/modules/rbac-adding-roles.adoc
+++ b/modules/rbac-adding-roles.adoc
@@ -7,6 +7,7 @@
 [id="adding-roles_{context}"]
 = Adding roles to users
 
+[role="_abstract"]
 You can use  the `oc adm` administrator CLI to manage the roles and bindings.
 
 Binding, or adding, a role to users or groups gives the user or group the access

--- a/modules/rbac-cluster-role-binding-commands.adoc
+++ b/modules/rbac-cluster-role-binding-commands.adoc
@@ -8,6 +8,7 @@ ifdef::openshift-enterprise,openshift-webscale,openshift-origin,openshift-dedica
 [id="cluster-role-binding-commands_{context}"]
 = Cluster role binding commands
 
+[role="_abstract"]
 You can also manage cluster role bindings using the following
 operations. The `-n` flag is not used for these operations because
 cluster role bindings use non-namespaced resources.

--- a/modules/rbac-creating-cluster-admin.adoc
+++ b/modules/rbac-creating-cluster-admin.adoc
@@ -7,6 +7,7 @@
 [id="creating-cluster-admin_{context}"]
 = Creating a cluster admin
 
+[role="_abstract"]
 The `cluster-admin` role is required to perform administrator
 level tasks on the {product-title} cluster, such as modifying
 cluster resources.

--- a/modules/rbac-creating-cluster-role.adoc
+++ b/modules/rbac-creating-cluster-role.adoc
@@ -8,6 +8,7 @@ ifdef::openshift-enterprise,openshift-webscale,openshift-origin[]
 [id="creating-cluster-role_{context}"]
 = Creating a cluster role
 
+[role="_abstract"]
 You can create a cluster role.
 
 .Procedure

--- a/modules/rbac-creating-local-role.adoc
+++ b/modules/rbac-creating-local-role.adoc
@@ -8,6 +8,7 @@ ifdef::openshift-enterprise,openshift-webscale,openshift-origin,openshift-dedica
 [id="creating-local-role_{context}"]
 = Creating a local role
 
+[role="_abstract"]
 You can create a local role for a project and then bind it to a user.
 
 .Procedure

--- a/modules/rbac-default-projects.adoc
+++ b/modules/rbac-default-projects.adoc
@@ -7,6 +7,7 @@
 [id="rbac-default-projects_{context}"]
 = Default projects
 
+[role="_abstract"]
 {product-title} comes with a number of default projects, and projects
 starting with `openshift-` are the most essential to users.
 These projects host master components that run as pods and other infrastructure

--- a/modules/rbac-local-role-binding-commands.adoc
+++ b/modules/rbac-local-role-binding-commands.adoc
@@ -7,6 +7,7 @@
 [id="local-role-binding-commands_{context}"]
 = Local role binding commands
 
+[role="_abstract"]
 When you manage a user or group's associated roles for local role bindings using the
 following operations, a project may be specified with the `-n` flag. If it is
 not specified, then the current project is used.

--- a/modules/rbac-overview.adoc
+++ b/modules/rbac-overview.adoc
@@ -7,6 +7,7 @@
 [id="authorization-overview_{context}"]
 = RBAC overview
 
+[role="_abstract"]
 Role-based access control (RBAC) objects determine whether a user is allowed to
 perform a given action within a project.
 

--- a/modules/rbac-projects-namespaces.adoc
+++ b/modules/rbac-projects-namespaces.adoc
@@ -7,6 +7,7 @@
 [id="rbac-projects-namespaces_{context}"]
 = Projects and namespaces
 
+[role="_abstract"]
 A Kubernetes _namespace_ provides a mechanism to scope resources in a cluster.
 The
 https://kubernetes.io/docs/tasks/administer-cluster/namespaces/[Kubernetes documentation]

--- a/modules/rbac-viewing-cluster-roles.adoc
+++ b/modules/rbac-viewing-cluster-roles.adoc
@@ -7,6 +7,7 @@
 [id="viewing-cluster-roles_{context}"]
 = Viewing cluster roles and bindings
 
+[role="_abstract"]
 You can use the `oc` CLI to view cluster roles and bindings by using the
 `oc describe` command.
 

--- a/modules/rbac-viewing-local-roles.adoc
+++ b/modules/rbac-viewing-local-roles.adoc
@@ -7,6 +7,7 @@
 [id="viewing-local-roles_{context}"]
 = Viewing local roles and bindings
 
+[role="_abstract"]
 You can use the `oc` CLI to view local roles and bindings by using the
 `oc describe` command.
 

--- a/modules/unauthenticated-users-cluster-role-binding-con.adoc
+++ b/modules/unauthenticated-users-cluster-role-binding-con.adoc
@@ -12,6 +12,7 @@
 Before {product-title} 4.17, unauthenticated groups were allowed access to some cluster roles. Clusters updated from versions before {product-title} 4.17 retain this access for unauthenticated groups.
 ====
 
+[role="_abstract"]
 For security reasons {product-title} {product-version} does not allow unauthenticated groups to have default access to cluster roles.
 
 There are use cases where it might be necessary to add `system:unauthenticated` to a cluster role.

--- a/post_installation_configuration/preparing-for-users.adoc
+++ b/post_installation_configuration/preparing-for-users.adoc
@@ -6,6 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 After installing {product-title}, you can further expand and customize your
 cluster to your requirements, including taking steps to prepare for users.
 


### PR DESCRIPTION
Address ConceptLink and ShortDescription Vale checks for preparing-for-users, authentication, identity providers, OLM software catalog, and RBAC modules.

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.20+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
