### PR TITLE
OSDOCS CQA AUTH-4 Service Accounts and Cloud Credential Operator I

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -787,29 +787,6 @@ Topics:
       File: update-completing-the-y-stream-update
     - Name: Completing the z-stream update
       File: update-completing-the-z-stream-update
-  - Name: Upgrading OpenShift Container Platform clusters with RHACM and TALM
-    Dir: updating
-    Topics:
-    - Name: About cluster updates with RHACM and TALM
-      File: update-rhacm-talm-overview
-    - Name: Prepare RHACM policies and TALM for cluster updates
-      File: update-rhacm-talm-preparing-policies
-    - Name: Prepare worker node pools before a cluster update with TALM
-      File: update-rhacm-talm-worker-batching
-    - Name: Perform health checks before a cluster update with TALM
-      File: update-rhacm-talm-health-checks
-    - Name: Manage worker nodes during a cluster update with TALM
-      File: update-rhacm-talm-worker-management
-    - Name: Coordinate OLM-managed Operator updates with TALM
-      File: update-rhacm-talm-operator-coordination
-    - Name: Complete a z-stream cluster update with TALM
-      File: update-rhacm-talm-z-stream
-    - Name: Complete a y-stream cluster update with TALM
-      File: update-rhacm-talm-y-stream
-    - Name: Complete an EUS-to-EUS cluster update with TALM
-      File: update-rhacm-talm-eus
-    - Name: Troubleshoot cluster updates with TALM
-      File: update-rhacm-talm-troubleshooting
   - Name: Troubleshooting and maintaining OpenShift Container Platform clusters
     Dir: troubleshooting
     Topics:
@@ -1306,22 +1283,6 @@ Topics:
     File: nbde-tang-server-operator-identifying-url
 - Name: Understanding secrets management
   File: understanding-secrets-management
-- Name: External Secrets Management Console Plug-in
-  Dir: external_secrets_management_console_plugin
-  Distros: openshift-enterprise
-  Topics:
-  - Name: External Secrets Management Console Plug-in overview
-    File: index
-  - Name: External Secrets Management Console Plug-in release notes
-    File: external-secrets-console-plugin-release-notes
-  - Name: Installing the External Secrets Management Console Plug-in
-    File: external-secrets-console-plugin-install
-  - Name: Monitoring the External Secrets Management Console Plug-in
-    File: external-secrets-console-plugin-monitor
-  - Name: Uninstalling the External Secrets Management Console Plug-in
-    File: external-secrets-console-plugin-uninstall
-  - Name: Deleting certificates and secrets with External Secrets Management Console Plug-in
-    File: external-secrets-console-plugin-delete
 - Name: cert-manager Operator for Red Hat OpenShift
   Dir: cert_manager_operator
   Distros: openshift-enterprise
@@ -1522,13 +1483,13 @@ Topics:
   Topics:
   - Name: About the Cloud Credential Operator
     File: about-cloud-credential-operator
-  - Name: Mint mode
+  - Name: About mint mode
     File: cco-mode-mint
-  - Name: Passthrough mode
+  - Name: About passthrough mode
     File: cco-mode-passthrough
-  - Name: Manual mode with long-term credentials for components
+  - Name: About manual mode with long-term credentials for components
     File: cco-mode-manual
-  - Name: Manual mode with short-term credentials for components
+  - Name: About manual mode with short-term credentials for components
     File: cco-short-term-creds
 ---
 Name: Networking
@@ -1866,8 +1827,6 @@ Topics:
       File: assigning-network-addresses-gateways
     - Name: Routing HTTP requests to services
       File: routing-http-requests-to-services
-    - Name: Securing HTTPRoutes
-      File: securing-httproutes
     - Name: Routing gRPC requests to services
       File: routing-grpc-requests-to-services
     - Name: Verifying Gateway infrastructure status
@@ -2836,7 +2795,7 @@ Topics:
   File: hcp-authentication-authorization
 - Name: Handling machine configuration for hosted control planes
   File: hcp-machine-config
-- Name: Feature gates in a hosted cluster
+- Name: Using feature gates in a hosted cluster
   File: hcp-using-feature-gates
 - Name: Observability for hosted control planes
   File: hcp-observability
@@ -3175,8 +3134,6 @@ Topics:
   File: removing-windows-nodes
 - Name: Disabling Windows container workloads
   File: disabling-windows-container-workloads
-- Name: Troubleshooting Windows container workloads
-  File: windows-containers-troubleshooting
 ---
 Name: OpenShift sandboxed containers
 Dir: sandboxed_containers

--- a/_topic_maps/_topic_map_osd.yml
+++ b/_topic_maps/_topic_map_osd.yml
@@ -450,13 +450,13 @@ Topics:
 #   Topics:
 #   - Name: About the Cloud Credential Operator
 #     File: about-cloud-credential-operator
-#   - Name: Mint mode
+#   - Name: About mint mode
 #     File: cco-mode-mint
-#   - Name: Passthrough mode
+#   - Name: About assthrough mode
 #     File: cco-mode-passthrough
-#   - Name: Manual mode with long-term credentials for components
+#   - Name: About manual mode with long-term credentials for components
 #     File: cco-mode-manual
-#   - Name: Manual mode with short-term credentials for components
+#   - Name: About manual mode with short-term credentials for components
 #     File: cco-short-term-creds
 ---
 Name: Upgrading

--- a/_topic_maps/_topic_map_rosa.yml
+++ b/_topic_maps/_topic_map_rosa.yml
@@ -656,13 +656,13 @@ Topics:
 #   Topics:
 #   - Name: About the Cloud Credential Operator
 #     File: about-cloud-credential-operator
-#   - Name: Mint mode
+#   - Name: About mint mode
 #     File: cco-mode-mint
-#   - Name: Passthrough mode
+#   - Name: About passthrough mode
 #     File: cco-mode-passthrough
-#   - Name: Manual mode with long-term credentials for components
+#   - Name: About manual mode with long-term credentials for components
 #     File: cco-mode-manual
-#   - Name: Manual mode with short-term credentials for components
+#   - Name: About manual mode with short-term credentials for components
 #     File: cco-short-term-creds
 ---
 Name: Upgrading

--- a/_topic_maps/_topic_map_rosa_hcp.yml
+++ b/_topic_maps/_topic_map_rosa_hcp.yml
@@ -559,13 +559,13 @@ Topics:
 #   Topics:
 #   - Name: About the Cloud Credential Operator
 #     File: about-cloud-credential-operator
-#   - Name: Mint mode
+#   - Name: About mint mode
 #     File: cco-mode-mint
-#   - Name: Passthrough mode
+#   - Name: About passthrough mode
 #     File: cco-mode-passthrough
-#   - Name: Manual mode with long-term credentials for components
+#   - Name: About manual mode with long-term credentials for components
 #     File: cco-mode-manual
-#   - Name: Manual mode with short-term credentials for components
+#   - Name: About manual mode with short-term credentials for components
 #     File: cco-short-term-creds
 ---
 Name: Upgrading

--- a/authentication/managing_cloud_provider_credentials/cco-mode-manual.adoc
+++ b/authentication/managing_cloud_provider_credentials/cco-mode-manual.adoc
@@ -1,17 +1,17 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="cco-mode-manual"]
-= Manual mode with long-term credentials for components
+= About the Cloud Credential Operator in manual mode with long-term credentials for components
 include::_attributes/common-attributes.adoc[]
 :context: cco-mode-manual
 
 toc::[]
 
-Manual mode is supported for Amazon Web Services (AWS), global Microsoft Azure, Microsoft Azure Stack Hub, {gcp-first}, {ibm-cloud-name}, and Nutanix.
+[role="_abstract"]
+You can manage your cloud credentials instead of the Cloud Credential Operator (CCO) by setting the Operator to manual mode.
 
-[id="manual-mode-classic_{context}"]
-== User-managed credentials
+You can use manual mode with your {aws-first}, global {azure-first}, {azure-first} Stack Hub, {gcp-first}, {ibm-cloud-name}, or Nutanix cluster.
 
-In manual mode, a user manages cloud credentials instead of the Cloud Credential Operator (CCO). To use this mode, you must examine the `CredentialsRequest` CRs in the release image for the version of {product-title} that you are running or installing, create corresponding credentials in the underlying cloud provider, and create Kubernetes Secrets in the correct namespaces to satisfy all `CredentialsRequest` CRs for the cluster's cloud provider. Some platforms use the CCO utility (`ccoctl`) to facilitate this process during installation and updates.
+To use manual mode, you must examine the `CredentialsRequest` CRs in the release image for the version of {product-title} that you are running or installing, create corresponding credentials in the underlying cloud provider, and create Kubernetes Secrets in the correct namespaces to satisfy all `CredentialsRequest` CRs for the cluster's cloud provider. Some platforms use the CCO utility (`ccoctl`) to facilitate this process during installation and updates.
 
 Using manual mode with long-term credentials allows each cluster component to have only the permissions it requires, without storing an administrator-level credential in the cluster. This mode also does not require connectivity to services such as the AWS public IAM endpoint. However, you must manually reconcile permissions with new release images for every upgrade.
 
@@ -19,7 +19,7 @@ For information about configuring your cloud provider to use manual mode, see th
 
 [NOTE]
 ====
-An AWS, global Azure, or {gcp-short} cluster that uses manual mode might be configured to use short-term credentials for different components. For more information, see xref:../../authentication/managing_cloud_provider_credentials/cco-short-term-creds.adoc#cco-short-term-creds[Manual mode with short-term credentials for components].
+An {aws-short}, global {azure-short}, or {gcp-short} cluster that uses manual mode can be configured to use short-term credentials for different components. For more information, see "Manual mode with short-term credentials for components".
 ====
 
 [role="_additional-resources"]
@@ -31,5 +31,5 @@ An AWS, global Azure, or {gcp-short} cluster that uses manual mode might be conf
 * xref:../../installing/installing_gcp/installing-gcp-customizations.adoc#manually-create-iam_installing-gcp-customizations[Manually creating long-term credentials for {gcp-short}]
 * xref:../../installing/installing_ibm_cloud/configuring-iam-ibm-cloud.adoc#configuring-iam-ibm-cloud[Configuring IAM for {ibm-cloud-name}]
 * xref:../../installing/installing_nutanix/installing-nutanix-installer-provisioned.adoc#manually-create-iam-nutanix_installing-nutanix-installer-provisioned[Configuring IAM for Nutanix]
-* xref:../../authentication/managing_cloud_provider_credentials/cco-short-term-creds.adoc#cco-short-term-creds[Manual mode with short-term credentials for components]
+* xref:../../authentication/managing_cloud_provider_credentials/cco-short-term-creds.adoc#cco-short-term-creds[About the Cloud Credential Operator in manual mode with short-term credentials for components]
 * xref:../../updating/preparing_for_updates/preparing-manual-creds-update.adoc#preparing-manual-creds-update[Preparing to update a cluster with manually maintained credentials]

--- a/authentication/managing_cloud_provider_credentials/cco-mode-mint.adoc
+++ b/authentication/managing_cloud_provider_credentials/cco-mode-mint.adoc
@@ -1,73 +1,21 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="cco-mode-mint"]
-= The Cloud Credential Operator in mint mode
+= About the Cloud Credential Operator in mint mode
 include::_attributes/common-attributes.adoc[]
 :context: cco-mode-mint
 
 toc::[]
 
-Mint mode is the default Cloud Credential Operator (CCO) credentials mode for {product-title} on platforms that support it. Mint mode supports Amazon Web Services (AWS) and {gcp-first} clusters.
+[role="_abstract"]
+You can use the Cloud Credential Operator (CCO) in mint mode to create and reconcile credentials for components in the cluster. 
 
-[id="mint-mode-about"]
-== Mint mode credentials management
+Mint mode is the default CCO credentials mode for {product-title} on platforms that support it. Mint mode supports {aws-first} and {gcp-first} clusters.
 
-For clusters that use the CCO in mint mode, the administrator-level credential is stored in the `kube-system` namespace. 
-The CCO uses the `admin` credential to process the `CredentialsRequest` objects in the cluster and create users for components with limited permissions.
+//Mint mode credentials management
+include::modules/mint-mode-credentials-management.adoc[leveloffset=+1]
 
-With mint mode, each cluster component has only the specific permissions it requires.
-Cloud credential reconciliation is automatic and continuous so that components can perform actions that require additional credentials or permissions.
-
-For example, a minor version cluster update (such as updating from {product-title} {ocp-nminus1} to {product-version}) might include an updated `CredentialsRequest` resource for a cluster component.
-The CCO, operating in mint mode, uses the `admin` credential to process the `CredentialsRequest` resource and create users with limited permissions to satisfy the updated authentication requirements.
-
-[NOTE]
-====
-By default, mint mode requires storing the `admin` credential in the cluster `kube-system` namespace. If this approach does not meet the security requirements of your organization, you can xref:../../post_installation_configuration/changing-cloud-credentials-configuration.adoc#manually-removing-cloud-creds_changing-cloud-credentials-configuration[remove the credential after installing the cluster].
-====
-
-[id="mint-mode-permissions"]
-=== Mint mode permissions requirements
-When using the CCO in mint mode, ensure that the credential you provide meets the requirements of the cloud on which you are running or installing {product-title}. If the provided credentials are not sufficient for mint mode, the CCO cannot create an IAM user.
-
-The credential you provide for mint mode in Amazon Web Services (AWS) must have the following permissions:
-
-.Required AWS permissions
-[%collapsible]
-====
-* `iam:CreateAccessKey`
-* `iam:CreateUser`
-* `iam:DeleteAccessKey`
-* `iam:DeleteUser`
-* `iam:DeleteUserPolicy`
-* `iam:GetUser`
-* `iam:GetUserPolicy`
-* `iam:ListAccessKeys`
-* `iam:PutUserPolicy`
-* `iam:TagUser`
-* `iam:SimulatePrincipalPolicy`
-====
-
-The credential you provide for mint mode in {gcp-first} must have the following permissions:
-
-.Required {gcp-short} permissions
-[%collapsible]
-====
-* `resourcemanager.projects.get`
-* `serviceusage.services.list`
-* `iam.serviceAccountKeys.create`
-* `iam.serviceAccountKeys.delete`
-* `iam.serviceAccountKeys.list`
-* `iam.serviceAccounts.create`
-* `iam.serviceAccounts.delete`
-* `iam.serviceAccounts.get`
-* `iam.roles.create`
-* `iam.roles.get`
-* `iam.roles.list`
-* `iam.roles.undelete`
-* `iam.roles.update`
-* `resourcemanager.projects.getIamPolicy`
-* `resourcemanager.projects.setIamPolicy`
-====
+//Mint mode permissions requirements
+include::modules/mint-mode-permission-requirements.adoc[leveloffset=+2]
 
 //Admin credentials root secret format
 include::modules/admin-credentials-root-secret-formats.adoc[leveloffset=+2]
@@ -76,5 +24,7 @@ include::modules/admin-credentials-root-secret-formats.adoc[leveloffset=+2]
 include::modules/manually-rotating-cloud-creds.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
+[id="additional-resources_{context}"]
 == Additional resources
+
 * xref:../../post_installation_configuration/changing-cloud-credentials-configuration.adoc#manually-removing-cloud-creds_changing-cloud-credentials-configuration[Removing cloud provider credentials]

--- a/authentication/managing_cloud_provider_credentials/cco-mode-passthrough.adoc
+++ b/authentication/managing_cloud_provider_credentials/cco-mode-passthrough.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="cco-mode-passthrough"]
-= The Cloud Credential Operator in passthrough mode
+= About the Cloud Credential Operator in passthrough mode
 include::_attributes/common-attributes.adoc[]
 :context: cco-mode-passthrough
 

--- a/authentication/managing_cloud_provider_credentials/cco-short-term-creds.adoc
+++ b/authentication/managing_cloud_provider_credentials/cco-short-term-creds.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="cco-short-term-creds"]
-= Manual mode with short-term credentials for components
+= About the Cloud Credential Operator in manual mode with short-term credentials for components
 include::_attributes/common-attributes.adoc[]
 :context: cco-short-term-creds
 

--- a/authentication/using-service-accounts-as-oauth-client.adoc
+++ b/authentication/using-service-accounts-as-oauth-client.adoc
@@ -6,4 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
+To authenticate users when restricting access to a specific namespace, you can configure a service account as a constrained OAuth client by using static or dynamic redirect URI annotations.
+
 include::modules/service-accounts-as-oauth-clients.adoc[leveloffset=+1]

--- a/modules/admin-credentials-root-secret-formats.adoc
+++ b/modules/admin-credentials-root-secret-formats.adoc
@@ -14,10 +14,12 @@ endif::[]
 [id="admin-credentials-root-secret-formats_{context}"]
 = Admin credentials root secret format
 
+[role="_abstract"]
+The Cloud Credential Operator (CCO) creates a credentials root secret by minting new credentials with _mint mode_ or by copying the credentials root secret with _passthrough mode_.
+
 Each cloud provider uses a credentials root secret in the `kube-system`
 namespace by convention, which is then used to satisfy all credentials requests
 and create their respective secrets.
-This is done either by minting new credentials with _mint mode_, or by copying the credentials root secret with _passthrough mode_.
 
 The format for the secret varies by cloud, and is also used for each
 `CredentialsRequest` secret.

--- a/modules/manually-rotating-cloud-creds.adoc
+++ b/modules/manually-rotating-cloud-creds.adoc
@@ -16,9 +16,14 @@ endif::[]
 
 :_mod-docs-content-type: PROCEDURE
 [id="manually-rotating-cloud-creds_{context}"]
-ifdef::post-install[= Rotating cloud provider credentials manually]
-ifndef::post-install[= Maintaining cloud provider credentials]
+ifdef::post-install[]
+= Rotating cloud provider credentials manually
+endif::post-install[]
+ifndef::post-install[]
+= Maintaining cloud provider credentials
+endif::post-install[]
 
+[role="_abstract"]
 If your cloud provider credentials are changed for any reason, you must manually update the secret that the Cloud Credential Operator (CCO) uses to manage cloud provider credentials.
 
 The process for rotating cloud credentials depends on the mode that the CCO is configured to use. After you rotate credentials for a cluster that is using mint mode, you must manually remove the component credentials that were created by the removed credential.
@@ -134,7 +139,7 @@ where `<provider_spec>` is the corresponding value for your cloud provider:
 * {gcp-short}: `GCPProviderSpec`
 --
 +
-.Partial example output for AWS
+The following example is partial output for the command on an {aws-short} cluster:
 +
 [source,json]
 ----
@@ -156,10 +161,14 @@ $ oc delete secret <secret_name> \//<1>
   -n <secret_namespace> <2>
 ----
 +
-<1> Specify the name of a secret.
-<2> Specify the namespace that contains the secret.
+where:
 +
-.Example deletion of an AWS secret
+--
+`<secret_name>`:: Specifies the name of a secret.
+`<secret_namespace>`:: Specifies the namespace that contains the secret.
+--
++
+The following example is a command to delete an AWS secret:
 +
 [source,terminal]
 ----
@@ -170,8 +179,6 @@ You do not need to manually delete the credentials from your provider console. D
 endif::passthrough[]
 
 .Verification
-
-To verify that the credentials have changed:
 
 . In the *Administrator* perspective of the web console, navigate to *Workloads* -> *Secrets*.
 

--- a/modules/mint-mode-credentials-management.adoc
+++ b/modules/mint-mode-credentials-management.adoc
@@ -1,0 +1,24 @@
+// Module included in the following assemblies:
+//
+// * authentication/managing_cloud_provider_credentials/cco-mode-mint.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="mint-mode-credentials-management_{context}"]
+= About mint mode credentials management
+
+[role="_abstract"]
+When using the Cloud Credential Operator (CCO) in mint mode, you should be familiar with how the CCO uses provider credentials.
+
+For clusters that use the CCO in mint mode, the administrator-level credential is stored in the `kube-system` namespace. 
+The CCO uses the `admin` credential to process the `CredentialsRequest` objects in the cluster and create users for components with limited permissions.
+
+With mint mode, each cluster component has only the specific permissions it requires.
+Cloud credential reconciliation is automatic and continuous so that components can perform actions that require additional credentials or permissions.
+
+For example, a minor version cluster update (such as updating from {product-title} {ocp-nminus1} to {product-version}) might include an updated `CredentialsRequest` resource for a cluster component.
+The CCO, operating in mint mode, uses the `admin` credential to process the `CredentialsRequest` resource and create users with limited permissions to satisfy the updated authentication requirements.
+
+[NOTE]
+====
+By default, mint mode requires storing the `admin` credential in the cluster `kube-system` namespace. If this approach does not meet the security requirements of your organization, you can remove the credential after installing the cluster. For more information, see "Removing cloud provider credentials".
+====

--- a/modules/mint-mode-permission-requirements.adoc
+++ b/modules/mint-mode-permission-requirements.adoc
@@ -1,0 +1,49 @@
+// Module included in the following assemblies:
+//
+// * authentication/managing_cloud_provider_credentials/cco-mode-mint.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="mint-mode-permission-requirements_{context}"]
+= About mint mode permissions requirements
+
+[role="_abstract"]
+When using the Cloud Credential Operator (CCO) in mint mode, ensure that the credential you provide meets the requirements of the cloud on which you are running or installing {product-title}. If the provided credentials are not sufficient for mint mode, the CCO cannot create an IAM user.
+
+[id="mint-mode-permission-requirements_aws_{context}"]
+== Required {aws-short} permissions
+
+The credential you provide for mint mode in {aws-first} must have the following permissions:
+
+* `iam:CreateAccessKey`
+* `iam:CreateUser`
+* `iam:DeleteAccessKey`
+* `iam:DeleteUser`
+* `iam:DeleteUserPolicy`
+* `iam:GetUser`
+* `iam:GetUserPolicy`
+* `iam:ListAccessKeys`
+* `iam:PutUserPolicy`
+* `iam:TagUser`
+* `iam:SimulatePrincipalPolicy`
+
+[id="mint-mode-permission-requirements_gcp_{context}"]
+== Required {gcp-short} permissions
+
+The credential you provide for mint mode in {gcp-first} must have the following permissions:
+
+* `resourcemanager.projects.get`
+* `serviceusage.services.list`
+* `iam.serviceAccountKeys.create`
+* `iam.serviceAccountKeys.delete`
+* `iam.serviceAccountKeys.list`
+* `iam.serviceAccounts.create`
+* `iam.serviceAccounts.delete`
+* `iam.serviceAccounts.get`
+* `iam.roles.create`
+* `iam.roles.get`
+* `iam.roles.list`
+* `iam.roles.undelete`
+* `iam.roles.update`
+* `resourcemanager.projects.getIamPolicy`
+* `resourcemanager.projects.setIamPolicy`
+

--- a/modules/service-accounts-as-oauth-clients.adoc
+++ b/modules/service-accounts-as-oauth-clients.adoc
@@ -6,9 +6,11 @@
 [id="service-accounts-as-oauth-clients_{context}"]
 = Service accounts as OAuth clients
 
-You can use a service account as a constrained form of OAuth client.
+[role="_abstract"]
+To authenticate users when restricting access to a specific namespace, you can use a service account as a constrained form of OAuth client.
+
 Service accounts can request only a subset of scopes that
-allow access to some basic user information
+allow access to the following basic user information
 and role-based power inside of the service account's own namespace:
 
 * `user:info`
@@ -32,10 +34,7 @@ account to `true`.
 
 * `redirect_uri` must match an annotation on the service account.
 
-[id="redirect-uris-for-service-accounts_{context}"]
-== Redirect URIs for service accounts as OAuth clients
-
-Annotation keys must have the prefix
+Annotation keys in service accounts must have the prefix
 `serviceaccounts.openshift.io/oauth-redirecturi.` or
 `serviceaccounts.openshift.io/oauth-redirectreference.` such as:
 
@@ -93,17 +92,18 @@ valid.  The full specification for an `OAuthRedirectReference` is:
   "kind": "OAuthRedirectReference",
   "apiVersion": "v1",
   "reference": {
-    "kind": ..., <1>
-    "name": ..., <2>
-    "group": ... <3>
+    "kind": ...,
+    "name": ...,
+    "group": ...
   }
 }
 
 ----
+where:
 
-<1> `kind` refers to the type of the object being referenced. Currently, only `route` is supported.
-<2> `name` refers to the name of the object. The object must be in the same namespace as the service account.
-<3> `group` refers to the group of the object. Leave this blank, as the group for a route is the empty string.
+`reference.kind`:: Specifies the type of the object being referenced. Currently, only `route` is supported.
+`reference.name`:: Specifies the name of the object. The object must be in the same namespace as the service account.
+`reference.group`:: Specifies the group of the object. Leave this blank, as the group for a route is the empty string.
 
 Both annotation prefixes can be combined to override the data provided by the
 reference object. For example:
@@ -122,7 +122,7 @@ data is as follows:
 [cols="4a,8a",options="header"]
 |===
 |Type | Syntax
-|Scheme| "https://"
+|Scheme| "\https://"
 |Hostname| "//website.com"
 |Port| "//:8000"
 |Path| "examplepath"


### PR DESCRIPTION
https://redhat.atlassian.net/browse/OSDOCS-16962

Previews
[About the Cloud Credential Operator in mint mode](https://115126--ocpdocs-pr.netlify.app/openshift-enterprise/latest/authentication/managing_cloud_provider_credentials/cco-mode-mint)
[About manual mode with long-term credentials for components](https://115126--ocpdocs-pr.netlify.app/openshift-enterprise/latest/authentication/managing_cloud_provider_credentials/cco-mode-manual)
[Using bound service account tokens](https://115126--ocpdocs-pr.netlify.app/openshift-enterprise/latest/authentication/bound-service-account-tokens)
[About the Cloud Credential Operator in passthrough mode](https://115126--ocpdocs-pr.netlify.app/openshift-enterprise/latest/authentication/managing_cloud_provider_credentials/cco-mode-passthrough) -- Changed title for consistency.
[Manual mode with short-term credentials for components](https://115126--ocpdocs-pr.netlify.app/openshift-enterprise/latest/authentication/managing_cloud_provider_credentials/cco-short-term-creds) -- Changed title for consistency.
Post install -> [Rotating cloud provider service keys with the Cloud Credential Operator utility](https://115126--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/changing-cloud-credentials-configuration.html#ccoctl-rotate-cloud-creds_changing-cloud-credentials-configuration) -- Same module as "Maintaining cloud provider credentials" with a different name in the post-install book. 



Assemblies:
cco-mode-manual.adoc
cco-mode-mint.adoc
using-service-accounts-as-oauth-client.adoc