### PR TITLE
OSDOCS-17049: Add DITA short descriptions

### DIFF
--- a/modules/about-etcd-encryption.adoc
+++ b/modules/about-etcd-encryption.adoc
@@ -8,6 +8,8 @@
 = etcd encryption
 
 [role="_abstract"]
+You can encrypt sensitive resource data in etcd to provide an additional layer of protection if an etcd backup or storage data is exposed.
+
 By default, etcd data is not encrypted in {product-title}. You can enable etcd encryption for your cluster to provide an additional layer of data security. For example, it can help protect the loss of sensitive data if an etcd backup is exposed to the incorrect parties.
 
 When you enable etcd encryption, the following OpenShift API server and Kubernetes API server resources are encrypted:

--- a/modules/differences-between-machinesets-and-machineconfigpool.adoc
+++ b/modules/differences-between-machinesets-and-machineconfigpool.adoc
@@ -8,6 +8,9 @@
 [id="differences-between-machinesets-and-machineconfigpool_{context}"]
 = Understanding the difference between compute machine sets and the machine config pool
 
+[role="_abstract"]
+Compute machine sets and machine config pools control different aspects of node lifecycle in {product-title}. Understanding how each object relates to scaling and upgrades helps you configure nodes correctly.
+
 `MachineSet` objects describe {product-title} nodes with respect to the cloud or machine provider.
 
 The `MachineConfigPool` object allows `MachineConfigController` components to define and provide the status of machines in the context of upgrades.

--- a/modules/dr-scenario-cluster-state-issues.adoc
+++ b/modules/dr-scenario-cluster-state-issues.adoc
@@ -8,6 +8,9 @@
 [id="dr-scenario-cluster-state-issues_{context}"]
 = Issues and workarounds for restoring a persistent storage state
 
+[role="_abstract"]
+After restoring a cluster from an etcd snapshot, persistent storage resources might no longer match the current storage provider state. Identify and resolve outdated volume, credential, attachment, or device references to restore workloads safely.
+
 If your {product-title} cluster uses persistent storage of any form, a state of the cluster is typically stored outside etcd. When you restore from an etcd backup, the status of the workloads in {product-title} is also restored. However, if the etcd snapshot is old, the status might be invalid or outdated.
 
 [IMPORTANT]

--- a/modules/manually-removing-cloud-creds.adoc
+++ b/modules/manually-removing-cloud-creds.adoc
@@ -6,6 +6,9 @@
 [id="manually-removing-cloud-creds_{context}"]
 = Removing cloud provider credentials
 
+[role="_abstract"]
+You can remove administrator-level cloud provider credentials from a cluster that uses the Cloud Credential Operator in mint mode to reduce the risk of credential exposure after installation.
+
 For clusters that use the Cloud Credential Operator (CCO) in mint mode, the administrator-level credential is stored in the `kube-system` namespace. 
 The CCO uses the `admin` credential to process the `CredentialsRequest` objects in the cluster and create users for components with limited permissions.
 

--- a/modules/monitoring-sending-notifications-to-external-systems.adoc
+++ b/modules/monitoring-sending-notifications-to-external-systems.adoc
@@ -7,6 +7,9 @@
 [id="sending-notifications-to-external-systems_{context}"]
 = Sending notifications to external systems
 
+[role="_abstract"]
+You can configure alert receivers to notify the appropriate teams or external systems when alerts fire. You can also use the watchdog alert to detect communication failures between Alertmanager and a notification provider.
+
 In {product-title} 
 ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 {product-version}

--- a/modules/refreshing-service-ids-ibm-cloud.adoc
+++ b/modules/refreshing-service-ids-ibm-cloud.adoc
@@ -6,6 +6,9 @@
 [id="refreshing-service-ids-ibm-cloud_{context}"]
 = Rotating {ibm-cloud-title} credentials
 
+[role="_abstract"]
+You can rotate API keys for existing {ibm-cloud-title} service IDs and update the corresponding cluster secrets to maintain valid cloud provider credentials.
+
 You can rotate API keys for your existing service IDs and update the corresponding secrets.
 
 .Prerequisites

--- a/post_installation_configuration/changing-cloud-credentials-configuration.adoc
+++ b/post_installation_configuration/changing-cloud-credentials-configuration.adoc
@@ -6,6 +6,9 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
+You can change your cluster's cloud provider credentials configuration to meet security and authentication requirements. You can rotate or remove credentials, or enable supported short-term credential methods.
+
 For supported configurations, you can change how {product-title} authenticates with your cloud provider.
 
 To determine which cloud credentials strategy your cluster uses, see xref:../authentication/managing_cloud_provider_credentials/about-cloud-credential-operator.adoc#cco-determine-mode_about-cloud-credential-operator[Determining the Cloud Credential Operator mode].

--- a/post_installation_configuration/cluster-tasks.adoc
+++ b/post_installation_configuration/cluster-tasks.adoc
@@ -6,6 +6,9 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
+After installing {product-title}, you can configure, scale, and maintain your cluster to meet operational requirements, including managing nodes and infrastructure workloads, enabling features, applying autoscaling, and maintaining etcd.
+
 After installing {product-title}, you can further expand and customize your cluster to your requirements.
 
 [id="available_cluster_customizations"]

--- a/post_installation_configuration/configuring-alert-notifications.adoc
+++ b/post_installation_configuration/configuring-alert-notifications.adoc
@@ -6,6 +6,9 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
+You can configure alert notifications to send firing alerts from your cluster to external systems, helping ensure that administrators are notified of conditions that require attention.
+
 In {product-title}, an alert is fired when the conditions defined in an alerting rule are true. An alert provides a notification that a set of circumstances are apparent within a cluster. Firing alerts can be viewed in the Alerting UI in the {product-title} web console by default. After an installation, you can configure {product-title} to send alert notifications to external systems.
 
 include::modules/monitoring-sending-notifications-to-external-systems.adoc[leveloffset=+1]


### PR DESCRIPTION
…batch

Write user-focused [role="_abstract"] paragraphs for post-install cloud credential, cluster task, etcd, and alert notification topics to satisfy ShortDescription checks.

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.20+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:

https://redhat.atlassian.net/browse/OSDOCS-17049
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

- [OSD: key-concepts](https://115150--ocpdocs-pr.netlify.app/openshift-dedicated/latest/observability/monitoring/about-ocp-monitoring/key-concepts.html)
- [OCP: cco-mode-mint](https://115150--ocpdocs-pr.netlify.app/openshift-enterprise/latest/authentication/managing_cloud_provider_credentials/cco-mode-mint.html)
- [OCP: cco-mode-passthrough](https://115150--ocpdocs-pr.netlify.app/openshift-enterprise/latest/authentication/managing_cloud_provider_credentials/cco-mode-passthrough.html)
- [OCP: scenario-2-restoring-cluster-state](https://115150--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/control_plane_backup_and_restore/disaster_recovery/scenario-2-restoring-cluster-state.html)
- [OCP: etcd-disaster-recovery](https://115150--ocpdocs-pr.netlify.app/openshift-enterprise/latest/etcd/etcd-backup-restore/etcd-disaster-recovery.html)
- [OCP: etcd-encrypt](https://115150--ocpdocs-pr.netlify.app/openshift-enterprise/latest/etcd/etcd-encrypt.html)
- [OCP: changing-cloud-credentials-configuration](https://115150--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/changing-cloud-credentials-configuration.html)
- [OCP: cluster-tasks](https://115150--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/cluster-tasks.html)
- [OCP: configuring-alert-notifications](https://115150--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/configuring-alert-notifications.html)
- [OCP: node-tasks](https://115150--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/node-tasks.html)
- [ROSA HCP: key-concepts](https://115150--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/observability/monitoring/about-ocp-monitoring/key-concepts.html)
- [ROSA: key-concepts](https://115150--ocpdocs-pr.netlify.app/openshift-rosa/latest/observability/monitoring/about-ocp-monitoring/key-concepts.html)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
