### PR TITLE
OSDOCS-17171-4:CQA 2.0-Security-Certificates-Attachment5

### DIFF
--- a/modules/customize-certificates-replace-default-router.adoc
+++ b/modules/customize-certificates-replace-default-router.adoc
@@ -6,7 +6,8 @@
 [id="replacing-default-ingress_{context}"]
 = Replacing the default ingress certificate
 
-You can replace the default ingress certificate for all applications under the `.apps` subdomain. After you replace the certificate, all applications, including the web console and CLI, have encryption provided by the specified certificate.
+[role="_abstract"]
+To secure the web console, CLI, and all applications under the `.apps` subdomain in {product-title}, you can replace the default ingress certificate by creating a TLS secret with your wildcard certificate and updating the Ingress Controller and cluster proxy configuration.
 
 [NOTE]
 ====

--- a/modules/customize-certificates-understanding-default-router.adoc
+++ b/modules/customize-certificates-understanding-default-router.adoc
@@ -6,15 +6,7 @@
 [id="understanding-default-ingress_{context}"]
 = Understanding the default ingress certificate
 
-By default, {product-title} uses the Ingress Operator to
-create an internal CA and issue a wildcard certificate that is valid for
-applications under the `.apps` sub-domain. Both the web console and CLI
-use this certificate as well.
+[role="_abstract"]
+You can replace the default ingress certificate with a certificate from a public CA so that external clients connect securely to your applications.
 
-The internal infrastructure CA certificates are self-signed.
-While this process might be perceived as bad practice by some security or
-PKI teams, any risk here is minimal. The only clients that implicitly
-trust these certificates are other components within the cluster.
-Replacing the default wildcard certificate with one that is issued by a
-public CA already included in the CA bundle as provided by the container userspace
-allows external clients to connect securely to applications running under the `.apps` sub-domain.
+The default ingress certificate in {product-title} is a wildcard certificate that the Ingress Operator issues from an internal CA for the web console, CLI, and applications under the `.apps` subdomain.

--- a/security/certificates/replacing-default-ingress-certificate.adoc
+++ b/security/certificates/replacing-default-ingress-certificate.adoc
@@ -4,6 +4,9 @@
 include::_attributes/common-attributes.adoc[]
 :context: replacing-default-ingress
 
+[role="_abstract"]
+To allow external clients to connect securely to applications under the .apps subdomain in {product-title}, you can replace the default wildcard ingress certificate with one issued by a trusted public CA.
+
 toc::[]
 
 include::modules/customize-certificates-understanding-default-router.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s):
4.20+

Issue:
https://redhat.atlassian.net/browse/OSDOCS-17171

Link to docs preview:
https://115151--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/certificates/replacing-default-ingress-certificate.html
