### PR TITLE
Use oc delete consistently in OSSM Istio CRD uninstall command

### DIFF
--- a/modules/ossm-uninstalling-delete-istio-crds.adoc
+++ b/modules/ossm-uninstalling-delete-istio-crds.adoc
@@ -16,5 +16,5 @@ Deleting {istio} custom resource definitions (CRDs) are optional.
 +
 [source,terminal]
 ----
-$ oc get crds -oname | grep -e istio.io -e sailoperator.io | xargs kubectl delete
+$ oc get crds -oname | grep -e istio.io -e sailoperator.io | xargs oc delete
 ----


### PR DESCRIPTION
## Summary
- Replace `kubectl delete` with `oc delete` in the optional Istio CRD uninstall command
- Aligns the example with OpenShift documentation conventions and the other CLI steps on the same uninstall page

## Test plan
- [ ] Verify the updated command renders correctly in the docs preview
- [ ] Confirm `oc delete` works for CRD resources listed by the preceding `oc get crds` command

Version(s): OSSM 3.x standalone docs (service-mesh-docs-main and downstream release branches)

Issue: Documentation consistency fix (https://redhat.atlassian.net/browse/OSSM-14932)