### PR TITLE
Use fully qualified OLM API when deleting OpenShift Virtualization subscription

### DIFF
--- a/modules/virt-deleting-virt-cli.adoc
+++ b/modules/virt-deleting-virt-cli.adoc
@@ -28,7 +28,7 @@ $ oc delete HyperConverged kubevirt-hyperconverged -n {CNVNamespace}
 +
 [source,terminal,subs="attributes+"]
 ----
-$ oc delete subscription hco-operatorhub -n {CNVNamespace}
+$ oc delete subscriptions.operators.coreos.com hco-operatorhub -n {CNVNamespace}
 ----
 
 . Delete the {VirtProductName} `ClusterServiceVersion` resource:


### PR DESCRIPTION
## Summary

Updates the OpenShift Virtualization CLI uninstall procedure to delete the OLM subscription using the fully qualified resource type `subscriptions.operators.coreos.com`.

Fixes: https://docs.redhat.com/en/documentation/openshift_container_platform/4.22/html/virtualization/installing#virt-deleting-virt-cli_uninstalling-virt

## Problem

The uninstall procedure currently uses:

```shell
$ oc delete subscription hco-operatorhub -n openshift-cnv
```

On clusters where multiple operators expose a resource named `subscription`, the short form `oc delete subscription` is ambiguous. For example, when Red Hat Advanced Cluster Management (ACM) is installed:

```
$ oc api-resources | grep -i subscriptions
subscriptions   apps.open-cluster-management.io/v1
subscriptions   operators.coreos.com/v1alpha1
```

In that case, `oc delete subscription` may target the ACM `Subscription` API group instead of the OLM subscription required to uninstall OpenShift Virtualization.

## Solution

Use the fully qualified OLM resource type in the uninstall command:

```shell
$ oc delete subscriptions.operators.coreos.com hco-operatorhub -n openshift-cnv
```

This ensures the command always targets the Operator Lifecycle Manager (OLM) subscription in the `openshift-cnv` namespace, regardless of other installed operators.

## Files changed

- `modules/virt-deleting-virt-cli.adoc`

## Test plan

- [ ] Verify OCP 4.22 docs preview renders the updated command at [virt-deleting-virt-cli](https://docs.redhat.com/en/documentation/openshift_container_platform/4.22/html/virtualization/installing#virt-deleting-virt-cli_uninstalling-virt)
- [ ] Confirm rendered output shows `subscriptions.operators.coreos.com` instead of `subscription`
- [ ] Confirm no other modules are changed in this PR

## Versions

4.22+ (cherry-pick to affected enterprise branches as needed)