### PR TITLE
Add fencing parameter tuning guide for TNF clusters

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -447,6 +447,8 @@ Topics:
       File: operating-a-degraded-tnf
     - Name: Post-installation troubleshooting and recovery
       File: install-post-tnf
+    - Name: Tuning fencing parameters for a TNF cluster
+      File: tuning-tnf-fencing-parameters
 - Name: Installing on bare metal
   Dir: installing_bare_metal
   Distros: openshift-origin,openshift-enterprise

--- a/installing/installing_two_node_cluster/installing_tnf/tuning-tnf-fencing-parameters.adoc
+++ b/installing/installing_two_node_cluster/installing_tnf/tuning-tnf-fencing-parameters.adoc
@@ -1,0 +1,31 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="tuning-tnf-fencing-parameters"]
+= Tuning fencing parameters for a TNF cluster
+include::_attributes/common-attributes.adoc[]
+:context: tuning-tnf-fencing-parameters
+
+toc::[]
+
+[role="_abstract"]
+Two-node {product-title} clusters with fencing (TNF) use Pacemaker, Corosync, and STONITH fence agents for high availability. The default parameter values work for most hardware, but some environments experience unwanted fencing events caused by brief latency spikes under load.
+
+Tune these parameters only if you observe one of the following symptoms:
+
+* **Spurious fencing during load spikes** -- Nodes are fenced even though they are healthy, typically during `MachineConfig` rollouts or heavy I/O. Use the `tolerant-detection` preset or increase the Corosync `token` value.
+* **Slow or unreliable BMC** -- Fence operations time out or fail intermittently. Use the `slow-bmc` preset or increase the fence agent timeouts.
+* **Kubelet stuck after reboot** -- Kubelet start times out waiting for NetworkManager, leaving the resource blocked. Increase `KUBELET_OP_START_TIMEOUT`.
+* **Etcd stop failures under load** -- Etcd takes too long to shut down, triggering fencing. Increase `ETCD_OP_STOP_TIMEOUT`.
+
+Do not change parameters preemptively. Tune only the parameter that addresses your observed symptom.
+
+include::modules/tnf-fencing-tuning-overview.adoc[leveloffset=+1]
+
+include::modules/tnf-applying-fencing-tuning-preset.adoc[leveloffset=+1]
+
+include::modules/tnf-applying-custom-fencing-tuning.adoc[leveloffset=+1]
+
+include::modules/tnf-reverting-fencing-tuning.adoc[leveloffset=+1]
+
+include::modules/tnf-fencing-tuning-parameter-reference.adoc[leveloffset=+1]
+
+include::modules/tnf-fencing-tuning-ceo-overwrite-matrix.adoc[leveloffset=+1]

--- a/installing/installing_two_node_cluster/installing_tnf/tuning-tnf-fencing-parameters.adoc
+++ b/installing/installing_two_node_cluster/installing_tnf/tuning-tnf-fencing-parameters.adoc
@@ -11,7 +11,7 @@ Two-node {product-title} clusters with fencing (TNF) use Pacemaker, Corosync, an
 
 Tune these parameters only if you observe one of the following symptoms:
 
-* **Spurious fencing during load spikes** -- Nodes are fenced even though they are healthy, typically during `MachineConfig` rollouts or heavy I/O. Use the `tolerant-detection` preset or increase the Corosync `token` value.
+* **Spurious fencing during load spikes** -- Nodes are fenced even though they are healthy, typically during `MachineConfig` rollouts, cluster upgrades (which always trigger `MachineConfig` rollouts), or heavy I/O. Use the `tolerant-detection` preset or increase the Corosync `token` value.
 * **Slow or unreliable BMC** -- Fence operations time out or fail intermittently. Use the `slow-bmc` preset or increase the fence agent timeouts.
 * **Kubelet stuck after reboot** -- Kubelet start times out waiting for NetworkManager, leaving the resource blocked. Increase `KUBELET_OP_START_TIMEOUT`.
 * **Etcd stop failures under load** -- Etcd takes too long to shut down, triggering fencing. Increase `ETCD_OP_STOP_TIMEOUT`.

--- a/modules/tnf-applying-custom-fencing-tuning.adoc
+++ b/modules/tnf-applying-custom-fencing-tuning.adoc
@@ -1,0 +1,72 @@
+// Module included in the following assemblies:
+// * installing_tnf/tuning-tnf-fencing-parameters.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="tnf-applying-custom-fencing-tuning_{context}"]
+= Applying custom fencing tuning values
+
+[role="_abstract"]
+If your scenario does not match a preset, you can edit individual parameter values in the script. Change only the parameters that address your observed symptom.
+
+.Prerequisites
+
+* You have access to the cluster as a user with the `cluster-admin` role.
+* You have the `oc` CLI tool installed.
+* Both control plane nodes are `Ready` and all Pacemaker resources are started.
+
+.Procedure
+
+. Save the `apply-fencing-tuning.sh` script to a local file.
+
+. Open the script in a text editor and modify the values in the `DEFAULT VALUES` section at the top of the script. For example, to increase the Corosync token to 6000 ms and the etcd stop timeout to 120 seconds:
++
+[source,bash]
+----
+COROSYNC_TOKEN=6000
+
+ETCD_OP_STOP_TIMEOUT=120s
+----
++
+See the parameter reference for valid ranges and fencing risk for each parameter.
+
+. Run the script:
++
+[source,terminal]
+----
+$ ./apply-fencing-tuning.sh
+----
+
+. Wait for the MCO to roll out the change to both control plane nodes:
++
+[source,terminal]
+----
+$ oc get mcp master -w
+----
++
+Wait until `UPDATED` is `True` and `UPDATING` is `False`.
+
+.Verification
+
+. Verify the Corosync token value:
++
+[source,terminal]
+----
+$ oc debug node/<master-node> -- chroot /host pcs cluster config show | grep token
+----
+
+. Verify the resource agent timeouts:
++
+[source,terminal]
+----
+$ oc debug node/<master-node> -- chroot /host pcs resource config kubelet
+$ oc debug node/<master-node> -- chroot /host pcs resource config etcd
+----
+
+. Verify the fence agent timeouts:
++
+[source,terminal]
+----
+$ oc debug node/<master-node> -- chroot /host pcs stonith config
+----
+
+. To change values after the initial application, edit the script with new values and run it again. The MCO detects the change and rolls out a new update.

--- a/modules/tnf-applying-fencing-tuning-preset.adoc
+++ b/modules/tnf-applying-fencing-tuning-preset.adoc
@@ -1,0 +1,253 @@
+// Module included in the following assemblies:
+// * installing_tnf/tuning-tnf-fencing-parameters.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="tnf-applying-fencing-tuning-preset_{context}"]
+= Applying a fencing tuning preset
+
+[role="_abstract"]
+Use a preset configuration when your symptom matches one of the following categories. Presets override only the parameters relevant to the scenario and leave all other values at their defaults.
+
+`tolerant-detection`::
+Raises the Corosync token from 3000 ms to 5000 ms. Use this preset when nodes are fenced during `MachineConfig` rollouts, heavy I/O, or network reconfiguration such as the OVS bridge race on IPv6 reboots.
+
+`slow-bmc`::
+Increases fence agent timeouts for BMC hardware where the default values are insufficient, for example HPE ProLiant with iLO. Sets `power_timeout=120`, `shell_timeout=15`, `login_timeout=15`, and `retry_on=3`.
+
+.Prerequisites
+
+* You have access to the cluster as a user with the `cluster-admin` role.
+* You have the `oc` CLI tool installed.
+* Both control plane nodes are `Ready` and all Pacemaker resources are started.
+
+.Procedure
+
+. Create a file named `apply-fencing-tuning.sh` with the following content:
++
+[source,bash,subs="none"]
+----
+#!/bin/bash
+set -euo pipefail
+
+# === DEFAULT VALUES (used when no preset is selected) ===
+COROSYNC_TOKEN=3000
+KUBELET_OP_START_TIMEOUT=180s
+KUBELET_OP_STOP_TIMEOUT=100s
+KUBELET_OP_MONITOR_TIMEOUT=100s
+KUBELET_OP_MONITOR_INTERVAL=60s
+ETCD_OP_STOP_TIMEOUT=90s
+ETCD_OP_START_TIMEOUT=600s
+FENCE_POWER_TIMEOUT=25
+FENCE_SHELL_TIMEOUT=3
+FENCE_LOGIN_TIMEOUT=5
+FENCE_POWER_WAIT=0
+FENCE_RETRY_ON=1
+FENCE_DELAY=0
+
+# === PRESETS ===
+apply_preset_tolerant_detection() { COROSYNC_TOKEN=5000; }
+apply_preset_slow_bmc() {
+  FENCE_POWER_TIMEOUT=120; FENCE_SHELL_TIMEOUT=15
+  FENCE_LOGIN_TIMEOUT=15; FENCE_RETRY_ON=3
+}
+print_presets() {
+  cat <<'EOF'
+Available presets:
+  tolerant-detection  Corosync token 3000ms -> 5000ms (load spike tolerance)
+  slow-bmc            Fence agent timeouts for slow BMC hardware (e.g. HPE iLO)
+EOF
+}
+
+# === ARGUMENT HANDLING ===
+if [ "${1:-}" = "--preset" ]; then
+  PRESET="${2:-}"
+  if [ -z "$PRESET" ] || [ "$PRESET" = "list" ]; then
+    print_presets; [ "$PRESET" = "list" ] && exit 0
+    echo "ERROR: --preset requires a name." >&2; exit 1
+  fi
+  case "$PRESET" in
+    tolerant-detection) apply_preset_tolerant_detection ;;
+    slow-bmc) apply_preset_slow_bmc ;;
+    *) echo "ERROR: unknown preset '$PRESET'." >&2; print_presets; exit 1 ;;
+  esac
+  echo "Using preset: $PRESET"
+elif [ "${1:-}" = "--revert" ]; then
+  echo "Reverting to default values..."
+  COROSYNC_TOKEN=3000; KUBELET_OP_START_TIMEOUT=180s
+  KUBELET_OP_STOP_TIMEOUT=100s; KUBELET_OP_MONITOR_TIMEOUT=100s
+  KUBELET_OP_MONITOR_INTERVAL=60s; ETCD_OP_STOP_TIMEOUT=90s
+  ETCD_OP_START_TIMEOUT=600s; FENCE_POWER_TIMEOUT=25
+  FENCE_SHELL_TIMEOUT=3; FENCE_LOGIN_TIMEOUT=5
+  FENCE_POWER_WAIT=0; FENCE_RETRY_ON=1; FENCE_DELAY=0
+fi
+
+if [ "$COROSYNC_TOKEN" -lt 3000 ] || [ "$COROSYNC_TOKEN" -gt 10000 ]; then
+  echo "ERROR: COROSYNC_TOKEN=$COROSYNC_TOKEN outside safe range (3000-10000ms)." >&2
+  exit 1
+fi
+command -v oc >/dev/null 2>&1 || { echo "ERROR: oc not found in PATH." >&2; exit 1; }
+oc whoami >/dev/null 2>&1 || { echo "ERROR: not logged in. Run 'oc login' first." >&2; exit 1; }
+
+VALUES_CONF="COROSYNC_TOKEN=${COROSYNC_TOKEN}
+KUBELET_OP_START_TIMEOUT=${KUBELET_OP_START_TIMEOUT}
+KUBELET_OP_STOP_TIMEOUT=${KUBELET_OP_STOP_TIMEOUT}
+KUBELET_OP_MONITOR_TIMEOUT=${KUBELET_OP_MONITOR_TIMEOUT}
+KUBELET_OP_MONITOR_INTERVAL=${KUBELET_OP_MONITOR_INTERVAL}
+ETCD_OP_STOP_TIMEOUT=${ETCD_OP_STOP_TIMEOUT}
+ETCD_OP_START_TIMEOUT=${ETCD_OP_START_TIMEOUT}
+FENCE_POWER_TIMEOUT=${FENCE_POWER_TIMEOUT}
+FENCE_SHELL_TIMEOUT=${FENCE_SHELL_TIMEOUT}
+FENCE_LOGIN_TIMEOUT=${FENCE_LOGIN_TIMEOUT}
+FENCE_POWER_WAIT=${FENCE_POWER_WAIT}
+FENCE_RETRY_ON=${FENCE_RETRY_ON}
+FENCE_DELAY=${FENCE_DELAY}"
+
+TUNING_SCRIPT='#!/bin/bash
+set -euo pipefail
+source /etc/fencing-parameter-tuning/values.conf
+MY_HOST=$(hostname)
+PEER_HOST=$(pcs status nodes 2>/dev/null | grep " Online:" | tr '"'"' '"'"' '"'"'\n'"'"' | \
+  grep -v "Online:\|^$" | grep -v "^${MY_HOST}$" | sort | head -1)
+if [ -n "$PEER_HOST" ] && [ "$MY_HOST" \> "$PEER_HOST" ]; then
+  echo "Not the primary node, skipping."; exit 0
+fi
+pcs_retry() {
+  for i in 1 2 3; do
+    if "$@"; then return 0; fi; echo "Retry $i/3..."; sleep 5
+  done; return 1
+}
+if [ "$COROSYNC_TOKEN" -lt 3000 ] || [ "$COROSYNC_TOKEN" -gt 10000 ]; then
+  echo "ERROR: token out of range"; exit 1
+fi
+FENCE_TYPE=$(pcs stonith config | grep "class=stonith type=" | \
+  awk -F"type=" "{print \$2}" | tr -d ")" | head -1)
+pcs_retry pcs cluster config update totem token="${COROSYNC_TOKEN}"
+pcs_retry pcs resource update kubelet op start \
+  timeout="${KUBELET_OP_START_TIMEOUT}" start-delay=15s
+pcs_retry pcs resource update kubelet op stop \
+  timeout="${KUBELET_OP_STOP_TIMEOUT}"
+pcs_retry pcs resource update kubelet op monitor \
+  timeout="${KUBELET_OP_MONITOR_TIMEOUT}" interval="${KUBELET_OP_MONITOR_INTERVAL}"
+pcs_retry pcs resource update etcd op stop timeout="${ETCD_OP_STOP_TIMEOUT}"
+pcs_retry pcs resource update etcd op start timeout="${ETCD_OP_START_TIMEOUT}"
+for SID in $(pcs stonith config | grep "^Resource:" | awk "{print \$2}"); do
+  if pcs stonith describe "$FENCE_TYPE" | grep -q "^  power_timeout"; then
+    pcs_retry pcs stonith update "$SID" power_timeout="${FENCE_POWER_TIMEOUT}" \
+      shell_timeout="${FENCE_SHELL_TIMEOUT}" login_timeout="${FENCE_LOGIN_TIMEOUT}" \
+      power_wait="${FENCE_POWER_WAIT}" retry_on="${FENCE_RETRY_ON}" delay="${FENCE_DELAY}"
+  fi
+done
+echo "Fencing parameter tuning applied successfully."'
+
+VALUES_B64=$(echo "$VALUES_CONF" | base64 | tr -d '\n')
+SCRIPT_B64=$(echo "$TUNING_SCRIPT" | base64 | tr -d '\n')
+
+cat <<MCEOF | oc apply -f -
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  name: 99-fencing-parameter-tuning
+  labels:
+    machineconfiguration.openshift.io/role: master
+spec:
+  config:
+    ignition:
+      version: 3.5.0
+    systemd:
+      units:
+        - name: fencing-parameter-tuning.service
+          enabled: true
+          contents: |
+            [Unit]
+            Description=Apply fencing parameter tuning for TNF clusters
+            After=pacemaker.service
+            Requires=pacemaker.service
+            StartLimitIntervalSec=300
+            StartLimitBurst=5
+            [Service]
+            Type=oneshot
+            ExecStart=/usr/local/bin/fencing-parameter-tuning.sh
+            RemainAfterExit=yes
+            TimeoutStartSec=120
+            Restart=on-failure
+            RestartSec=30
+            [Install]
+            WantedBy=multi-user.target
+    storage:
+      files:
+        - path: /etc/fencing-parameter-tuning/values.conf
+          mode: 0644
+          overwrite: true
+          contents:
+            source: "data:text/plain;charset=utf-8;base64,${VALUES_B64}"
+        - path: /usr/local/bin/fencing-parameter-tuning.sh
+          mode: 0755
+          overwrite: true
+          contents:
+            source: "data:text/plain;charset=utf-8;base64,${SCRIPT_B64}"
+MCEOF
+
+echo "MachineConfig applied. MCO will roll out to both master nodes (~10-15 min)."
+echo "Monitor: oc get mcp master -w"
+if [ "${1:-}" = "--revert" ]; then
+  echo "After rollout, remove: oc delete mc 99-fencing-parameter-tuning"
+fi
+----
+
+. Make the script executable:
++
+[source,terminal]
+----
+$ chmod +x apply-fencing-tuning.sh
+----
+
+. List the available presets:
++
+[source,terminal]
+----
+$ ./apply-fencing-tuning.sh --preset list
+----
+
+. Apply the preset that matches your scenario:
++
+[source,terminal]
+----
+$ ./apply-fencing-tuning.sh --preset <preset_name> <1>
+----
+<1> Replace `<preset_name>` with `tolerant-detection` or `slow-bmc`.
+
+. Wait for the Machine Config Operator (MCO) to roll out the change to both control plane nodes. This process takes approximately 10-15 minutes and reboots each node sequentially.
++
+[source,terminal]
+----
+$ oc get mcp master -w
+----
++
+Wait until `UPDATED` is `True` and `UPDATING` is `False`.
+
+.Verification
+
+. Verify that both nodes are `Ready`:
++
+[source,terminal]
+----
+$ oc get nodes
+----
+
+. For the `tolerant-detection` preset, verify the Corosync token value:
++
+[source,terminal]
+----
+$ oc debug node/<master-node> -- chroot /host pcs cluster config show | grep token
+----
++
+The output shows `token: 5000`.
+
+. For the `slow-bmc` preset, verify the fence agent timeouts:
++
+[source,terminal]
+----
+$ oc debug node/<master-node> -- chroot /host pcs stonith config | grep -E "power_timeout|shell_timeout|login_timeout|retry_on"
+----
++
+The output shows `power_timeout=120`, `shell_timeout=15`, `login_timeout=15`, and `retry_on=3`.

--- a/modules/tnf-fencing-tuning-ceo-overwrite-matrix.adoc
+++ b/modules/tnf-fencing-tuning-ceo-overwrite-matrix.adoc
@@ -1,0 +1,39 @@
+// Module included in the following assemblies:
+// * installing_tnf/tuning-tnf-fencing-parameters.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="tnf-fencing-tuning-ceo-overwrite-matrix_{context}"]
+= Cluster etcd Operator overwrite matrix
+
+[role="_abstract"]
+The cluster etcd Operator manages initial Pacemaker configuration by using TNF jobs. The following table shows which tuned parameters survive Operator reconciliation, for example when the fencing job re-runs after a credential change or Operator restart.
+
+[cols="1,2,1,2",options="header"]
+|===
+|Category |Parameters |Safe from Operator? |Details
+
+|Corosync
+|`token`
+|Yes
+|The Operator never sets Corosync totem values. Tuning survives job re-runs and node replacement.
+
+|Kubelet resource operations
+|`start`, `stop`, `monitor` timeouts
+|Yes
+|The Operator creates the kubelet resource once. Operation timeouts set by using `pcs resource update` are not overwritten by subsequent Operator runs.
+
+|Etcd resource operations
+|`start`, `stop` timeouts
+|Yes
+|Same behavior as kubelet. Created once and guarded by a presence check.
+
+|STONITH fence agent
+|`power_timeout`, `shell_timeout`, `login_timeout`, `power_wait`, `retry_on`, `delay`
+|Yes
+|The `pcs stonith update` command only modifies specified attributes. The Operator does not set these values.
+
+|STONITH `pcmk_delay_base`
+|--
+|**No**
+|The Operator sets different values per node, for example 10s and 1s, to control the fencing race. A fencing credential change triggers the Operator to re-run and reset these values. Do not modify this parameter.
+|===

--- a/modules/tnf-fencing-tuning-overview.adoc
+++ b/modules/tnf-fencing-tuning-overview.adoc
@@ -1,0 +1,24 @@
+// Module included in the following assemblies:
+// * installing_tnf/tuning-tnf-fencing-parameters.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="tnf-fencing-tuning-overview_{context}"]
+= How fencing parameter tuning works
+
+[role="_abstract"]
+The fencing parameter tuning script generates and applies a `MachineConfig` resource that deploys a systemd oneshot service on both control plane nodes. This service runs `pcs` commands to apply your chosen parameter values to the Pacemaker and Corosync cluster configuration.
+
+The `MachineConfig` deploys three components:
+
+* **`/etc/fencing-parameter-tuning/values.conf`** -- your parameter values.
+* **`/usr/local/bin/fencing-parameter-tuning.sh`** -- applies the values by using `pcs` commands.
+* **`fencing-parameter-tuning.service`** -- a systemd oneshot unit that runs the script once after Pacemaker starts on each boot.
+
+The tuning script runs on only one node, which is the alphabetically-first hostname, because Pacemaker synchronizes configuration changes between nodes internally.
+
+The script includes preset configurations for common scenarios. Use a preset when your symptom matches a known category. Alternatively, edit individual parameter values for fine-grained control.
+
+[NOTE]
+====
+The tuning values persist in the Pacemaker cluster configuration independently of the `MachineConfig`. Deleting the `MachineConfig` removes the files and service but does not revert the tuned values. Always run the revert procedure before deleting the `MachineConfig`.
+====

--- a/modules/tnf-fencing-tuning-parameter-reference.adoc
+++ b/modules/tnf-fencing-tuning-parameter-reference.adoc
@@ -1,0 +1,119 @@
+// Module included in the following assemblies:
+// * installing_tnf/tuning-tnf-fencing-parameters.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="tnf-fencing-tuning-parameter-reference_{context}"]
+= Fencing tuning parameter reference
+
+[role="_abstract"]
+The following tables list all tunable parameters, their default values, and their fencing risk. Tune parameters that can cause fencing first, then address parameters that cause stuck resources.
+
+== Corosync parameters
+
+[cols="1,1,1,3",options="header"]
+|===
+|Parameter |Default |Safe range |Effect
+
+|`COROSYNC_TOKEN`
+|3000
+|3000-10000 ms
+|How long before a silent node is declared dead and fenced. Lower values provide faster detection but a higher risk of false positives. Higher values are more tolerant of load spikes but slower to detect actual failures.
+|===
+
+The token value and resource agent timeouts are independent. Changing the token does not require changing etcd or kubelet timeouts.
+
+== Kubelet resource agent parameters
+
+[cols="1,1,2",options="header"]
+|===
+|Parameter |Default |Fencing risk
+
+|`KUBELET_OP_START_TIMEOUT`
+|180s
+|None. Start failure blocks the resource and requires `pcs resource cleanup`.
+
+|`KUBELET_OP_STOP_TIMEOUT`
+|100s
+|**Direct.** Stop failure always triggers fencing.
+
+|`KUBELET_OP_MONITOR_TIMEOUT`
+|100s
+|Indirect. Monitor failure triggers recovery, which runs stop then start.
+
+|`KUBELET_OP_MONITOR_INTERVAL`
+|60s
+|None. Controls health check frequency.
+|===
+
+== Etcd resource agent parameters
+
+[cols="1,1,2",options="header"]
+|===
+|Parameter |Default |Fencing risk
+
+|`ETCD_OP_STOP_TIMEOUT`
+|90s
+|**Direct.** Stop failure always triggers fencing.
+
+|`ETCD_OP_START_TIMEOUT`
+|600s
+|None. Start failure blocks the resource and requires `pcs resource cleanup`.
+|===
+
+== Fence agent parameters
+
+These values depend on your BMC hardware. Test your fence agent response times before setting these values by running the following command:
+
+[source,terminal]
+----
+$ fence_<type> -a <bmc_ip> -l <user> -p <pass> -o status
+----
+
+[cols="1,1,2",options="header"]
+|===
+|Parameter |Default |Description
+
+|`FENCE_POWER_TIMEOUT`
+|25
+|Wait for BMC to confirm power state change after ON/OFF.
+
+|`FENCE_SHELL_TIMEOUT`
+|3
+|Wait for BMC to respond to a command.
+
+|`FENCE_LOGIN_TIMEOUT`
+|5
+|Wait for BMC login prompt after connecting.
+
+|`FENCE_POWER_WAIT`
+|0
+|Wait after toggling power before checking new state.
+
+|`FENCE_RETRY_ON`
+|1
+|Number of power-on retry attempts.
+
+|`FENCE_DELAY`
+|0
+|Fixed wait before executing the fence action.
+|===
+
+[IMPORTANT]
+====
+Do not modify `pcmk_delay_base`. This parameter is managed by the cluster etcd Operator with different values per node to control the fencing race. Changing it can cause both nodes to fence simultaneously.
+====
+
+== Fencing risk priority
+
+Parameters that can cause fencing should be tuned first:
+
+. `COROSYNC_TOKEN` -- Corosync heartbeat expiry triggers fencing.
+. `KUBELET_OP_STOP_TIMEOUT` -- Stop failure always triggers fencing.
+. `ETCD_OP_STOP_TIMEOUT` -- Stop failure triggers fencing with cascade risk on clone-wide operations.
+. Fence agent timeouts -- Slow or failed fencing blocks cluster recovery.
+
+Parameters that cannot cause fencing should be tuned only for stuck resources:
+
+. `KUBELET_OP_START_TIMEOUT` -- Start failure blocks resource and requires `pcs resource cleanup`.
+. `ETCD_OP_START_TIMEOUT` -- Start failure blocks resource and requires `pcs resource cleanup`.
+. `KUBELET_OP_MONITOR_TIMEOUT` -- Monitor failure triggers recovery, which runs stop then start.

--- a/modules/tnf-reverting-fencing-tuning.adoc
+++ b/modules/tnf-reverting-fencing-tuning.adoc
@@ -1,0 +1,69 @@
+// Module included in the following assemblies:
+// * installing_tnf/tuning-tnf-fencing-parameters.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="tnf-reverting-fencing-tuning_{context}"]
+= Reverting fencing tuning to defaults
+
+[role="_abstract"]
+The `--revert` flag applies a `MachineConfig` that restores all parameters to their default values. You must run this procedure before deleting the `MachineConfig`.
+
+[IMPORTANT]
+====
+Do not run `oc delete mc 99-fencing-parameter-tuning` without reverting first. Deleting the `MachineConfig` removes the tuning service but does not undo the Pacemaker changes. The tuned values remain active in the cluster configuration.
+====
+
+.Prerequisites
+
+* You have access to the cluster as a user with the `cluster-admin` role.
+* The fencing parameter tuning `MachineConfig` is currently applied.
+
+.Procedure
+
+. Run the script with the `--revert` flag:
++
+[source,terminal]
+----
+$ ./apply-fencing-tuning.sh --revert
+----
+
+. Wait for the MCO to roll out the default values to both control plane nodes:
++
+[source,terminal]
+----
+$ oc get mcp master -w
+----
++
+Wait until `UPDATED` is `True` and `UPDATING` is `False`.
+
+. After the rollout completes, delete the `MachineConfig`:
++
+[source,terminal]
+----
+$ oc delete mc 99-fencing-parameter-tuning
+----
+
+. Wait for the MCO to roll out the deletion:
++
+[source,terminal]
+----
+$ oc get mcp master -w
+----
+
+.Verification
+
+. Verify that the Corosync token is back to the default value:
++
+[source,terminal]
+----
+$ oc debug node/<master-node> -- chroot /host pcs cluster config show | grep token
+----
++
+The output shows `token: 3000`.
+
+. Verify that both nodes are `Ready`:
++
+[source,terminal]
+----
+$ oc get nodes
+----


### PR DESCRIPTION
## Summary

- Adds a new page under "Two-node with Fencing" (TNF) for tuning Pacemaker, Corosync, and STONITH fence agent parameters
- Includes two evidence-backed presets: `tolerant-detection` (Corosync token 3000→5000ms for load spike tolerance) and `slow-bmc` (fence agent timeouts for slow BMC hardware like HPE iLO)
- Provides the full tuning script as an inline code block with preset, custom, and revert workflows
- Documents parameter reference tables with fencing risk priority and cluster etcd Operator overwrite matrix

## Files

| File | Type | Description |
|------|------|-------------|
| `tuning-tnf-fencing-parameters.adoc` | Assembly | Top-level page with symptom-based guidance |
| `tnf-fencing-tuning-overview.adoc` | CONCEPT | How the tuning script works (systemd oneshot + MachineConfig) |
| `tnf-applying-fencing-tuning-preset.adoc` | PROCEDURE | Apply a preset configuration (includes full script) |
| `tnf-applying-custom-fencing-tuning.adoc` | PROCEDURE | Edit default values for custom tuning |
| `tnf-reverting-fencing-tuning.adoc` | PROCEDURE | Revert to defaults and remove the MachineConfig |
| `tnf-fencing-tuning-parameter-reference.adoc` | REFERENCE | Parameter tables with defaults, ranges, fencing risk |
| `tnf-fencing-tuning-ceo-overwrite-matrix.adoc` | REFERENCE | Which parameters survive CEO reconciliation |
| `_topic_map.yml` | Config | Register new page under TNF section |

## JIRA

[OCPEDGE-2368](https://redhat.atlassian.net/browse/OCPEDGE-2368)

## Test plan

- [ ] Verify AsciiDoc renders correctly (tables, admonitions, code blocks)
- [ ] Verify all `include::` directives resolve correctly
- [ ] Verify topic map entry appears in the correct section
- [ ] Script in the procedure module is functionally identical to the tested version

🤖 Generated with [Claude Code](https://claude.com/claude-code)