### PR TITLE
OSDOCS-17075_e#Cluster updates CQAs

### DIFF
--- a/modules/update-etcd-backup.adoc
+++ b/modules/update-etcd-backup.adoc
@@ -6,10 +6,13 @@
 [id="update-etcd-backup_{context}"]
 = etcd backups before cluster updates
 
-etcd backups record the state of your cluster and all of its resource objects.
-You can use backups to attempt restoring the state of a cluster in disaster scenarios where you cannot recover a cluster in its currently dysfunctional state.
+[role="_abstract"]
+Create etcd backups before you update clusters to preserve your cluster state and to enable disaster recovery.
+
+etcd backups record the state of your cluster and all of its resource objects. You can use backups to try to restore the state of a cluster when the cluster has become unrecoverable.
 
 In the context of updates, you can attempt an etcd restoration of the cluster if an update introduced catastrophic conditions that cannot be fixed without reverting to the previous cluster version.
+
 etcd restorations might be destructive and destabilizing to a running cluster, use them only as a last resort.
 
 [WARNING]

--- a/modules/update-preparing-conditional.adoc
+++ b/modules/update-preparing-conditional.adoc
@@ -2,18 +2,18 @@
 //
 // * updating/preparing_for_updates/updating-cluster-prepare.adoc
 
-:_mod-docs-content-type: PROCEDURE
+:_mod-docs-content-type: CONCEPT
 [id="update-preparing-conditional_{context}"]
-= Assessing the risk of conditional updates
+= The risk of conditional updates
 
-A _conditional update_ is an update target that is available but not recommended due to a known risk that applies to your cluster.
-The Cluster Version Operator (CVO) periodically queries the OpenShift Update Service (OSUS) for the most recent data about update recommendations, and some potential update targets might have risks associated with them.
+[role="_abstract"]
+Conditional updates are update targets flagged by the OpenShift Update Service (OSUS) as available but not recommended due to known risks that apply to your cluster.
 
-The CVO evaluates the conditional risks, and if the risks are not applicable to the cluster, then the target version is available as a recommended update path for the cluster.
-If the risk is determined to be applicable, or if for some reason CVO cannot evaluate the risk, then the update target is available to the cluster as a conditional update.
+The Cluster Version Operator (CVO) periodically queries the OSUS for the most recent data about update recommendations, and some potential update targets might have risks associated with them.
 
-When you encounter a conditional update while you are trying to update to a target version, you must assess the risk of updating your cluster to that version.
-Generally, if you do not have a specific need to update to that target version, it is best to wait for a recommended update path from Red Hat.
+The CVO evaluates the conditional risks, and if the risks are not applicable to the cluster, then the target version is available as a recommended update path for the cluster. If the risk is determined to be applicable, or if for some reason CVO cannot evaluate the risk, then the update target is available to the cluster as a conditional update.
+
+When you encounter a conditional update while you are trying to update to a target version, you must assess the risk of updating your cluster to that version. Generally, if you do not have a specific need to update to that target version, it is best to wait for a recommended update path from Red Hat.
 
 However, if you have a strong reason to update to that version, for example, if you need to fix an important CVE, then the benefit of fixing the CVE might outweigh the risk of the update being problematic for your cluster.
 You can complete the following tasks to determine whether you agree with the Red Hat assessment of the update risk:


### PR DESCRIPTION
Versions:
4.20+

Issue:
https://issues.redhat.com/browse/OSDOCS-17075

Link to docs preview:

- [etcd backups before cluster updates](https://115163--ocpdocs-pr.netlify.app/openshift-enterprise/latest/updating/preparing_for_updates/updating-cluster-prepare.html#update-etcd-backup_updating-cluster-prepare)
- [The risk of conditional updates](https://115163--ocpdocs-pr.netlify.app/openshift-enterprise/latest/updating/preparing_for_updates/updating-cluster-prepare.html#update-preparing-conditional_updating-cluster-prepare)




QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
