### PR TITLE
OSDOCS-17051-4: CQA POST-3: Multi-Architecture Compute Node Creation

### DIFF
--- a/modules/machine-user-infra-machines-ibm-z.adoc
+++ b/modules/machine-user-infra-machines-ibm-z.adoc
@@ -13,11 +13,13 @@ endif::[]
 ifdef::ibm-z[]
 = Creating {op-system} machines on {ibm-z-title} with z/VM
 
+[role="_abstract"]
 You can create more {op-system-first} compute machines running on {ibm-z-name} with z/VM and attach them to your existing cluster.
 endif::ibm-z[]
 ifdef::ibm-z-lpar[]
 = Creating {op-system} machines on {ibm-z-title} in an LPAR
 
+[role="_abstract"]
 You can create more {op-system-first} compute machines running on {ibm-z-name} in a logical partition (LPAR) and attach them to your existing cluster.
 endif::ibm-z-lpar[]
 
@@ -67,20 +69,33 @@ $ curl -LO $(oc -n openshift-machine-config-operator get configmap/coreos-bootim
 . Move the downloaded {op-system-base} live `kernel`, `initramfs`, and `rootfs` files to an HTTP or HTTPS server that is accessible from the {op-system} guest you want to add.
 
 . Create a parameter file for the guest. The following parameters are specific for the virtual machine:
++
 ** Optional: To specify a static IP address, add an `ip=` parameter with the following entries, with each separated by a colon:
++
 ... The IP address for the machine.
++
 ... An empty string.
++
 ... The gateway.
++
 ... The netmask.
++
 ... The machine host and domain name in the form `hostname.domainname`. If you omit this value, {op-system} obtains the hostname through a reverse DNS lookup.
++
 ... The network interface name. If you omit this value, {op-system} applies the IP configuration to all available interfaces.
++
 ... The value `none`.
++
 ** For `coreos.inst.ignition_url=`, specify the URL to the `worker.ign` file. Only HTTP and HTTPS protocols are supported.
++
 ** For `coreos.live.rootfs_url=`, specify the matching rootfs artifact for the `kernel` and `initramfs` you are booting. Only HTTP and HTTPS protocols are supported.
-
++
 ** For installations on DASD-type disks, complete the following tasks:
++
 ... For `coreos.inst.install_dev=`, specify `/dev/dasda`.
++
 ... Use `rd.dasd=` to specify the DASD where {op-system} is to be installed.
++
 ... You can adjust further parameters if required.
 +
 The following is an example parameter file, `additional-worker-dasd.parm`:
@@ -99,20 +114,23 @@ zfcp.allow_lun_scan=0
 ----
 +
 Write all options in the parameter file as a single line and make sure that you have no newline characters.
-
++
 ** For installations on FCP-type disks, complete the following tasks:
++
 ... Use `rd.zfcp=<adapter>,<wwpn>,<lun>` to specify the FCP disk where {op-system} is to be installed. For multipathing, repeat this step for each additional path.
 +
 [NOTE]
 ====
-When you install with multiple paths, you must enable multipathing directly after the installation, not at a later point in time, as this can cause problems.
+When you install with multiple paths, you must enable multipathing directly after the installation. Enabling multipathing much later can cause problems for your cluster.
 ====
++
 ... Set the install device as: `coreos.inst.install_dev=/dev/sda`.
 +
 [NOTE]
 ====
 If additional LUNs are configured with NPIV, FCP requires `zfcp.allow_lun_scan=0`. If you must enable `zfcp.allow_lun_scan=1` because you use a CSI driver, for example, you must configure your NPIV so that each node cannot access the boot partition of another node.
 ====
++
 ... You can adjust further parameters if required.
 +
 [IMPORTANT]
@@ -140,18 +158,21 @@ rd.zfcp=0.0.19C7,0x50050763071bc5e3,0x4008400B00000000
 ----
 +
 Write all options in the parameter file as a single line and make sure that you have no newline characters.
+
 ifdef::ibm-z[]
 . Transfer the `initramfs`, `kernel`, parameter files, and {op-system} images to z/VM, for example, by using FTP. For details about how to transfer the files with FTP and boot from the virtual reader, see link:https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9/html-single/interactively_installing_rhel_over_the_network/index#installing-under-z-vm_booting-the-installation-media[Booting the installation on {ibm-z-name} to install {op-system-base} in z/VM].
+
 . Punch the files to the virtual reader of the z/VM guest virtual machine.
 +
 See link:https://www.ibm.com/docs/en/zvm/latest?topic=commands-punch[PUNCH] in {ibm-name} Documentation.
 +
 [TIP]
 ====
-You can use the CP PUNCH command or, if you use Linux, the **vmur** command to transfer files between two z/VM guest virtual machines.
+You can use the CP PUNCH command or, if you use Linux, the `vmur` command to transfer files between two z/VM guest virtual machines.
 ====
-+
+
 . Log in to CMS on the bootstrap machine.
+
 . IPL the bootstrap machine from the reader by running the following command:
 +
 ----
@@ -160,10 +181,11 @@ $ ipl c
 +
 See link:https://www.ibm.com/docs/en/zvm/latest?topic=commands-ipl[IPL] in {ibm-name} Documentation.
 endif::ibm-z[]
+
 ifdef::ibm-z-lpar[]
 . Transfer the initramfs, kernel, parameter files, and {op-system} images to the LPAR, for example with FTP. For details about how to transfer the files with FTP and boot, see link:https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9/html-single/interactively_installing_rhel_over_the_network/index#installing-in-an-lpar_booting-the-installation-media[Booting the installation on {ibm-z-name} to install {op-system-base} in an LPAR].
 
-. Boot the machine
+. Boot the machine.
 endif::ibm-z-lpar[]
 
 ifeval::["{context}" == "creating-multi-arch-compute-nodes-ibm-z"]

--- a/modules/multi-arch-tuning-operator-release-notes-1-0-0.adoc
+++ b/modules/multi-arch-tuning-operator-release-notes-1-0-0.adoc
@@ -2,6 +2,9 @@
 [id="multi-arch-tuning-operator-release-notes-1-0-0_{context}"]
 = Release notes for the Multiarch Tuning Operator 1.0.0
 
+[role="_abstract"]
+The release notes for the Multiarch Tuning Operator 1.0.0 summarize all new features and enhancements, notable technical changes, major corrections from the previous version, and any known bugs upon general availability.
+
 Issued: 31 October 2024
 
 [id="multi-arch-tuning-operator-1-0-0-new-features-and-enhancements_{context}"]

--- a/modules/multi-arch-tuning-operator-release-notes-1-1-0.adoc
+++ b/modules/multi-arch-tuning-operator-release-notes-1-1-0.adoc
@@ -2,6 +2,9 @@
 [id="multi-arch-tuning-operator-release-notes-1-1-0_{context}"]
 = Release notes for the Multiarch Tuning Operator 1.1.0
 
+[role="_abstract"]
+The release notes for the Multiarch Tuning Operator 1.1.0 summarize all new features and enhancements, notable technical changes, major corrections from the previous version, and any known bugs upon general availability.
+
 Issued: 18 March 2024
 
 [id="multi-arch-tuning-operator-1-1-0-new-features-and-enhancements_{context}"]
@@ -9,9 +12,9 @@ Issued: 18 March 2024
 
 * The Multiarch Tuning Operator is now supported on managed offerings, including ROSA with Hosted Control Planes (HCP) and other HCP environments.
 
-* With this release, you can configure architecture-aware workload scheduling by using the new `plugins` field in the `ClusterPodPlacementConfig` object. You can use the `plugins.nodeAffinityScoring` field to set architecture preferences for pod placement. If you enable the `nodeAffinityScoring` plugin, the scheduler first filters out nodes that do not meet the pod requirements. Then, the scheduler prioritizes the remaining nodes based on the architecture scores defined in the `nodeAffinityScoring.platforms` field.
+* With this release, you can configure architecture-aware workload scheduling by using the new `plugins` field in the `ClusterPodPlacementConfig` object. You can use the `plugins.nodeAffinityScoring` field to set architecture preferences for pod placement. If you enable the `nodeAffinityScoring` plugin, the scheduler first filters out nodes that do not meet the pod requirements. The scheduler then prioritizes the remaining nodes based on the architecture scores defined in the `nodeAffinityScoring.platforms` field.
 
 [id="multi-arch-tuning-operator-1-1-0-bug-fixes_{context}"]
 == Bug fixes
 
-* With this release, the Multiarch Tuning Operator does not update the `nodeAffinity` field for pods that are managed by a daemon set. (link:https://issues.redhat.com/browse/OCPBUGS-45885[*OCPBUGS-45885*])
+* With this release, the Multiarch Tuning Operator does not update the `nodeAffinity` field for pods that are managed by a daemon set. (link:https://issues.redhat.com/browse/OCPBUGS-45885[OCPBUGS-45885])

--- a/modules/multi-arch-tuning-operator-release-notes-1-1-1.adoc
+++ b/modules/multi-arch-tuning-operator-release-notes-1-1-1.adoc
@@ -2,6 +2,9 @@
 [id="multi-arch-tuning-operator-release-notes-1-1-1_{context}"]
 = Release notes for the Multiarch Tuning Operator 1.1.1
 
+[role="_abstract"]
+The release notes for the Multiarch Tuning Operator 1.1.1 summarize all new features and enhancements, notable technical changes, major corrections from the previous version, and any known bugs upon general availability.
+
 Issued: 27 May 2025
 
 [id="multi-arch-tuning-operator-1-1-z-bug-fixes_{context}"]
@@ -13,4 +16,4 @@ With this release, the pod placement operand supports pull secrets that include 
 
 * Previously, when image inspection failed after all retries and the `nodeAffinityScoring` plugin was enabled, the pod placement operand applied incorrect `nodeAffinityScoring` labels.
 +
-With this release, the operand sets `nodeAffinityScoring` labels correctly, even when image inspection fails. It now applies these labels independently of the required affinity process to ensure accurate and consistent scheduling.
+With this release, the operand sets `nodeAffinityScoring` labels correctly, even when image inspection fails. The operand now applies these labels independently of the required affinity process to ensure accurate and consistent scheduling.

--- a/modules/multi-arch-tuning-operator-release-notes-1-2-0.adoc
+++ b/modules/multi-arch-tuning-operator-release-notes-1-2-0.adoc
@@ -2,22 +2,25 @@
 [id="multi-arch-tuning-operator-release-notes-1-2-0_{context}"]
 = Release notes for the Multiarch Tuning Operator 1.2.0
 
+[role="_abstract"]
+The release notes for the Multiarch Tuning Operator 1.2.0 summarize all new features and enhancements, notable technical changes, major corrections from the previous version, and any known bugs upon general availability.
+
 Issued: 22 October 2025
 
 [id="multi-arch-tuning-operator-1-2-0-new-features-and-enhancements_{context}"]
 == New features and enhancements
 
-* With this release, you can enable the *exec format error monitor* plugin for the Multiarch Tuning Operator. This plugin detects `ENOEXEC` errors, which occur when a pod attempts to execute a binary incompatible with the node's architecture. You enable this plugin by setting the `plugins.execFormatErrorMonitor.enabled` parameter to `true` in the `ClusterPodPlacementConfig` object. For more information, see xref:../../post_installation_configuration/configuring-multi-arch-compute-machines/multiarch-tuning-operator.adoc#multi-architecture-creating-podplacement-config_multiarch-tuning-operator[Creating the ClusterPodPlacementConfig object].
+* With this release, you can enable the `exec format error monitor` plugin for the Multiarch Tuning Operator. This plugin detects `ENOEXEC` errors, which occur when a pod attempts to execute a binary incompatible with the node's architecture. You enable this plugin by setting the `plugins.execFormatErrorMonitor.enabled` parameter to `true` in the `ClusterPodPlacementConfig` object. For more information, see xref:../../post_installation_configuration/configuring-multi-arch-compute-machines/multiarch-tuning-operator.adoc#multi-architecture-creating-podplacement-config_multiarch-tuning-operator[Creating the ClusterPodPlacementConfig object].
 
 [id="multi-arch-tuning-operator-1-2-0-bug-fixes_{context}"]
 == Bug fixes
 
-* Previously, the Multiarch Tuning Operator incorrectly handled the Operator bundle image inspector, restricting it to a single architecture, which could cause OLM to fail when installing Operators. With this update, MTO now sets the bundle image to support all architectures, allowing Operators to be successfully installed on single-architecture clusters when the Multiarch Tuning Operator is deployed. (link:https://issues.redhat.com/browse/MULTIARCH-5546[*MULTIARCH-5546*])
+* Previously, the Multiarch Tuning Operator incorrectly handled the Operator bundle image inspector, restricting inspector to a single architecture, which could cause OLM to fail when installing Operators. With this update, MTO now sets the bundle image to support all architectures, allowing Operators to be successfully installed on single-architecture clusters when the Multiarch Tuning Operator is deployed. (link:https://issues.redhat.com/browse/MULTIARCH-5546[MULTIARCH-5546])
 
-* Previously, when a cluster global pull secret was changed, stale authentication information could remain in the Multiarch Tuning Operator cache. With this update, the cache is cleared whenever a cluster global pull secret is changed. (link:https://issues.redhat.com/browse/MULTIARCH-5538[*MULTIARCH-5538*])
+* Previously, when a cluster global pull secret was changed, stale authentication information could remain in the Multiarch Tuning Operator cache. With this update, the cache is cleared whenever a cluster global pull secret is changed. (link:https://issues.redhat.com/browse/MULTIARCH-5538[MULTIARCH-5538])
 
-* Previously, the Multiarch Tuning Operator failed to process pods if an image reference contained both a tag and a digest. With this update, the image inspector prioritizes the digest if both are present. (link:https://issues.redhat.com/browse/MULTIARCH-5584[*MULTIARCH-5584*])
+* Previously, the Multiarch Tuning Operator failed to process pods if an image reference contained both a tag and a digest. With this update, the image inspector prioritizes the digest if both are present. (link:https://issues.redhat.com/browse/MULTIARCH-5584[MULTIARCH-5584])
 
-* Previously, the Multiarch Tuning Operator did not respect the `.spec.registrySources.containerRuntimeSearchRegistries` field in the `config.openshift.io/Image` custom resource when a workload image did not specify a registry URL. With this update, the Operator can now handle this case, allowing workload images without an explicit registry URL to be pulled successfully. (link:https://issues.redhat.com/browse/MULTIARCH-5611[*MULTIARCH-5611*])
+* Previously, the Multiarch Tuning Operator did not respect the `.spec.registrySources.containerRuntimeSearchRegistries` field in the `config.openshift.io/Image` custom resource when a workload image did not specify a registry URL. With this update, the Operator can now handle this case, allowing workload images without an explicit registry URL to be pulled successfully. (link:https://issues.redhat.com/browse/MULTIARCH-5611[MULTIARCH-5611])
 
-* Previously, if the `ClusterPodPlacementConfig` object was deleted less than 1 second after its creation, some finalizers were not removed in time, causing certain resources to remain. With this update, all finalizers are properly deleted when the `ClusterPodPlacementConfig` object is deleted. (link:https://issues.redhat.com/browse/MULTIARCH-5372[*MULTIARCH-5372*])
+* Previously, if the `ClusterPodPlacementConfig` object was deleted less than 1 second after its creation, some finalizers were not removed in time, causing certain resources to remain. With this update, all finalizers are properly deleted when the `ClusterPodPlacementConfig` object is deleted. (link:https://issues.redhat.com/browse/MULTIARCH-5372[MULTIARCH-5372])

--- a/modules/multi-arch-tuning-operator-release-notes-1-2-1.adoc
+++ b/modules/multi-arch-tuning-operator-release-notes-1-2-1.adoc
@@ -2,9 +2,12 @@
 [id="multi-arch-tuning-operator-release-notes-1-2-1_{context}"]
 = Release notes for the Multiarch Tuning Operator 1.2.1
 
+[role="_abstract"]
+The release notes for the Multiarch Tuning Operator 1.2.1 summarize all new features and enhancements, notable technical changes, major corrections from the previous version, and any known bugs upon general availability.
+
 Issued: 15 December 2025
 
 [id="multi-arch-tuning-operator-1-2-1-bug-fixes_{context}"]
 == Bug fixes
 
-* Previously, the Multiarch Tuning Operator image inspector incorrectly processed images whose registry address included a digest, tag, and port number. The port portion of the registry was incorrectly interpreted as an image tag and was trimmed, causing the inspector to construct an invalid image reference. With this update, image references that contain a digest, tag, and registry port are now correctly parsed and handled. (link:https://issues.redhat.com/browse/MULTIARCH-5767[*MULTIARCH-5767*])
+* Previously, the Multiarch Tuning Operator image inspector incorrectly processed images whose registry address included a digest, tag, and port number. The port portion of the registry was incorrectly interpreted as an image tag and was trimmed, causing the inspector to construct an invalid image reference. With this update, image references that contain a digest, tag, and registry port are now correctly parsed and handled. (link:https://issues.redhat.com/browse/MULTIARCH-5767[MULTIARCH-5767])

--- a/modules/multi-arch-tuning-operator-release-notes-1-2-2.adoc
+++ b/modules/multi-arch-tuning-operator-release-notes-1-2-2.adoc
@@ -2,6 +2,9 @@
 [id="multi-arch-tuning-operator-release-notes-1-2-2_{context}"]
 = Release notes for the Multiarch Tuning Operator 1.2.2
 
+[role="_abstract"]
+The release notes for the Multiarch Tuning Operator 1.2.2 summarize all new features and enhancements, notable technical changes, major corrections from the previous version, and any known bugs upon general availability.
+
 Issued: 6 February 2026
 
 [id="multi-arch-tuning-operator-1-2-2-enhancements_{context}"]

--- a/modules/multi-arch-tuning-operator-release-notes-1-3-0.adoc
+++ b/modules/multi-arch-tuning-operator-release-notes-1-3-0.adoc
@@ -2,6 +2,9 @@
 [id="multi-arch-tuning-operator-release-notes-1-3-0_{context}"]
 = Release notes for the Multiarch Tuning Operator 1.3.0
 
+[role="_abstract"]
+The release notes for the Multiarch Tuning Operator 1.3.0 summarize all new features and enhancements, notable technical changes, major corrections from the previous version, and any known bugs upon general availability.
+
 Issued: 6 April 2026
 
 [id="multi-arch-tuning-operator-1-3-0-new-features-and-enhancements_{context}"]
@@ -14,9 +17,9 @@ Issued: 6 April 2026
 [id="multi-arch-tuning-operator-1-3-0-bug-fixes_{context}"]
 == Bug fixes
 
-* Previously, an error could occur that led to an `ENoExecEvent` custom resource (CR) to fail to be deleted. This leftover CR resulted in the failure to uninstall the `execFormatErrorMonitor` plugin. With this update, the `execFormatErrorMonitor` plugin can be uninstalled if there are leftover `ENoExecEvent` CRs. Deleting the `ClusterPodPlacementConfig` object removes all remaining CRs regardless of their state. (link:https://redhat.atlassian.net/browse/MULTIARCH-5642[*MULTIARCH-5642*])
+* Previously, an error could occur that led to an `ENoExecEvent` custom resource (CR) to fail to be deleted. This leftover CR resulted in the failure to uninstall the `execFormatErrorMonitor` plugin. With this update, the `execFormatErrorMonitor` plugin can be uninstalled if there are leftover `ENoExecEvent` CRs. Deleting the `ClusterPodPlacementConfig` object removes all remaining CRs regardless of their state. (link:https://redhat.atlassian.net/browse/MULTIARCH-5642[MULTIARCH-5642])
 
-* Previously, the Multiarch Tuning Operator (MTO) processed images that contained attestation manifests, leading to the incorrect creation of an "unknown" architecture. Pods could fail to be scheduled when they tried to target the "unknown" architecture. With this update, the MTO does not process attestation manifests, and the "unknown" architecture is not created. (link:https://redhat.atlassian.net/browse/MULTIARCH-5800[*MULTIARCH-5800*])
+* Previously, the Multiarch Tuning Operator (MTO) processed images that contained attestation manifests, leading to the incorrect creation of an "unknown" architecture. Pods could fail to be scheduled when they tried to target the "unknown" architecture. With this update, the MTO does not process attestation manifests, and the "unknown" architecture is not created. (link:https://redhat.atlassian.net/browse/MULTIARCH-5800[MULTIARCH-5800])
 
 [id="multi-arch-tuning-operator-1-3-0-enhancements_{context}"]
 == Enhancements

--- a/modules/multi-arch-tuning-operator-release-notes-1-3-1.adoc
+++ b/modules/multi-arch-tuning-operator-release-notes-1-3-1.adoc
@@ -2,6 +2,9 @@
 [id="multi-arch-tuning-operator-release-notes-1-3-1_{context}"]
 = Release notes for the Multiarch Tuning Operator 1.3.1
 
+[role="_abstract"]
+The release notes for the Multiarch Tuning Operator 1.3.1 summarize all new features and enhancements, notable technical changes, major corrections from the previous version, and any known bugs upon general availability.
+
 Issued: 1 July 2026
 
 [id="multi-arch-tuning-operator-1-3-1-enhancements_{context}"]

--- a/modules/multi-arch-tuning-operator-release-notes-1-3-2.adoc
+++ b/modules/multi-arch-tuning-operator-release-notes-1-3-2.adoc
@@ -2,6 +2,9 @@
 [id="multi-arch-tuning-operator-release-notes-1-3-2_{context}"]
 = Release notes for the Multiarch Tuning Operator 1.3.2
 
+[role="_abstract"]
+The release notes for the Multiarch Tuning Operator 1.3.2 summarize all new features and enhancements, notable technical changes, major corrections from the previous version, and any known bugs upon general availability.
+
 Issued: 13 July 2026
 
 [id="multi-arch-tuning-operator-1-3-2-bug-fixes_{context}"]

--- a/post_installation_configuration/configuring-multi-arch-compute-machines/creating-multi-arch-compute-nodes-ibm-z-lpar.adoc
+++ b/post_installation_configuration/configuring-multi-arch-compute-machines/creating-multi-arch-compute-nodes-ibm-z-lpar.adoc
@@ -6,17 +6,27 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-To create a cluster with multi-architecture compute machines on {ibm-z-name} and {ibm-linuxone-name} (`s390x`) in an LPAR, you must have an existing single-architecture `x86_64` cluster. You can then add `s390x` compute machines to your {product-title} cluster.
+[role="_abstract"]
+To create a cluster with multi-architecture compute machines on {ibm-z-name} and {ibm-linuxone-name} (`s390x`) in a logical partition (LPAR), you must have an existing single-architecture `x86_64` cluster. You can then add `s390x` compute machines to your {product-title} cluster.
 
-Before you can add `s390x` nodes to your cluster, you must upgrade your cluster to one that uses the multi-architecture payload. For more information on migrating to the multi-architecture payload, see xref:../../updating/updating_a_cluster/migrating-to-multi-payload.adoc#migrating-to-multi-payload[Migrating to a cluster with multi-architecture compute machines].
+Before you can add `s390x` nodes to your cluster, you must upgrade your cluster to one that uses the multi-architecture payload. For more information on migrating to the multi-architecture payload, see "Migrating to a cluster with multi-architecture compute machines".
 
-The following procedures explain how to create a {op-system} compute machine using an LPAR instance. This will allow you to add `s390x` nodes to your cluster and deploy a cluster with multi-architecture compute machines.
+The following procedures explain how to create a {op-system} compute machine by using an LPAR instance. By using an LPAR instance, you can add `s390x` nodes to your cluster and deploy a cluster with multi-architecture compute machines.
 
 [NOTE]
 ====
-To create an {ibm-z-name} or {ibm-linuxone-name} (`s390x`) cluster with multi-architecture compute machines on `x86_64`, follow the instructions for
-xref:../../installing/installing_ibm_z/preparing-to-install-on-ibm-z.adoc#preparing-to-install-on-ibm-z[Installing a cluster on {ibm-z-name} and {ibm-linuxone-name}]. You can then add `x86_64` compute machines as described in xref:./creating-multi-arch-compute-nodes-bare-metal.adoc#creating-multi-arch-compute-nodes-bare-metal[Creating a cluster with multi-architecture compute machines on bare metal, {ibm-power-title}, or {ibm-z-title}].
+To create an {ibm-z-name} or {ibm-linuxone-name} (`s390x`) cluster with multi-architecture compute machines on `x86_64`, follow the instructions for "Installing a cluster on {ibm-z-name} and {ibm-linuxone-name}". You can then add `x86_64` compute machines as described in "Creating a cluster with multi-architecture compute machines on bare metal, {ibm-power-title}, or {ibm-z-title}".
 ====
+
+[role="_additional-resources"]
+[id="additional-resources_{context}"]
+== Additional resources
+
+* xref:../../updating/updating_a_cluster/migrating-to-multi-payload.adoc#migrating-to-multi-payload[Migrating to a cluster with multi-architecture compute machines]
+
+* xref:../../installing/installing_ibm_z/preparing-to-install-on-ibm-z.adoc#preparing-to-install-on-ibm-z[Installing a cluster on {ibm-z-name} and {ibm-linuxone-name}] 
+
+* xref:./creating-multi-arch-compute-nodes-bare-metal.adoc#creating-multi-arch-compute-nodes-bare-metal[Creating a cluster with multi-architecture compute machines on bare metal, {ibm-power-title}, or {ibm-z-title}]
 
 include::modules/machine-user-infra-machines-ibm-z.adoc[leveloffset=+1]
 

--- a/post_installation_configuration/configuring-multi-arch-compute-machines/creating-multi-arch-compute-nodes-ibm-z.adoc
+++ b/post_installation_configuration/configuring-multi-arch-compute-machines/creating-multi-arch-compute-nodes-ibm-z.adoc
@@ -6,19 +6,31 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 To create a cluster with multi-architecture compute machines on {ibm-z-name} and {ibm-linuxone-name} (`s390x`) with z/VM, you must have an existing single-architecture `x86_64` cluster. You can then add `s390x` compute machines to your {product-title} cluster.
 
-Before you can add `s390x` nodes to your cluster, you must upgrade your cluster to one that uses the multi-architecture payload. For more information on migrating to the multi-architecture payload, see xref:../../updating/updating_a_cluster/migrating-to-multi-payload.adoc#migrating-to-multi-payload[Migrating to a cluster with multi-architecture compute machines].
+Before you can add `s390x` nodes to your cluster, you must upgrade your cluster to one that uses the multi-architecture payload. For more information on migrating to the multi-architecture payload, see "Migrating to a cluster with multi-architecture compute machines".
 
 The following procedures explain how to create a {op-system} compute machine using a z/VM instance. This will allow you to add `s390x` nodes to your cluster and deploy a cluster with multi-architecture compute machines.
 
-To create an {ibm-z-name} or {ibm-linuxone-name} (`s390x`) cluster with multi-architecture compute machines on `x86_64`, follow the instructions for
-xref:../../installing/installing_ibm_z/preparing-to-install-on-ibm-z.adoc#preparing-to-install-on-ibm-z[Installing a cluster on {ibm-z-name} and {ibm-linuxone-name}]. You can then add `x86_64` compute machines as described in xref:./creating-multi-arch-compute-nodes-bare-metal.adoc#creating-multi-arch-compute-nodes-bare-metal[Creating a cluster with multi-architecture compute machines on bare metal, {ibm-power-title}, or {ibm-z-title}].
+To create an {ibm-z-name} or {ibm-linuxone-name} (`s390x`) cluster with multi-architecture compute machines on `x86_64`, follow the instructions for "Installing a cluster on {ibm-z-name} and {ibm-linuxone-name}". You can then add `x86_64` compute machines as described in "Creating a cluster with multi-architecture compute machines on bare metal, {ibm-power-title}, or {ibm-z-title}".
 
 [NOTE]
 ====
-Before adding a secondary architecture node to your cluster, it is recommended to install the Multiarch Tuning Operator, and deploy a `ClusterPodPlacementConfig` object. For more information, see xref:../../post_installation_configuration/configuring-multi-arch-compute-machines/multiarch-tuning-operator.adoc#multiarch-tuning-operator[Managing workloads on multi-architecture clusters by using the Multiarch Tuning Operator].
+Before adding a secondary architecture node to your cluster, installing the Multiarch Tuning Operator and deploying a `ClusterPodPlacementConfig` object are best practices. For more information, see "Managing workloads on multi-architecture clusters by using the Multiarch Tuning Operator".
 ====
+
+[role="_additional-resources"]
+[id="additional-resources_{context}"]
+== Additional resources
+
+* xref:../../updating/updating_a_cluster/migrating-to-multi-payload.adoc#migrating-to-multi-payload[Migrating to a cluster with multi-architecture compute machines]
+
+* xref:../../installing/installing_ibm_z/preparing-to-install-on-ibm-z.adoc#preparing-to-install-on-ibm-z[Installing a cluster on {ibm-z-name} and {ibm-linuxone-name}]
+
+* xref:./creating-multi-arch-compute-nodes-bare-metal.adoc#creating-multi-arch-compute-nodes-bare-metal[Creating a cluster with multi-architecture compute machines on bare metal, {ibm-power-title}, or {ibm-z-title}]
+
+* xref:../../post_installation_configuration/configuring-multi-arch-compute-machines/multiarch-tuning-operator.adoc#multiarch-tuning-operator[Managing workloads on multi-architecture clusters by using the Multiarch Tuning Operator]
 
 include::modules/machine-user-infra-machines-ibm-z.adoc[leveloffset=+1]
 

--- a/post_installation_configuration/configuring-multi-arch-compute-machines/multi-arch-tuning-operator-release-notes.adoc
+++ b/post_installation_configuration/configuring-multi-arch-compute-machines/multi-arch-tuning-operator-release-notes.adoc
@@ -9,7 +9,11 @@ toc::[]
 [role="_abstract"]
 The Multiarch Tuning Operator (MTO) optimizes workload management within multi-architecture clusters and in single-architecture clusters transitioning to multi-architecture environments. Use the release notes to track the development of the Multiarch Tuning Operator.
 
-For more information, see xref:../../post_installation_configuration/configuring-multi-arch-compute-machines/multiarch-tuning-operator.adoc#multiarch-tuning-operator[Managing workloads on multi-architecture clusters by using the Multiarch Tuning Operator].
+[role="_additional-resources"]
+[id="additional-resources_{context}"]
+== Additional resources
+
+* xref:../../post_installation_configuration/configuring-multi-arch-compute-machines/multiarch-tuning-operator.adoc#multiarch-tuning-operator[Managing workloads on multi-architecture clusters by using the Multiarch Tuning Operator]
 
 include::modules/multi-arch-tuning-operator-release-notes-1-3-2.adoc[leveloffset=+1]
 


### PR DESCRIPTION
Version(s):
4.20+

Issue:
[OSDOCS-17051](https://redhat.atlassian.net/browse/OSDOCS-17051)

Link to docs preview:

* https://115168--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/configuring-multi-arch-compute-machines/creating-multi-arch-compute-nodes-ibm-power.html
* https://115168--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/configuring-multi-arch-compute-machines/creating-multi-arch-compute-nodes-ibm-z.html
* https://115168--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/configuring-multi-arch-compute-machines/creating-multi-arch-compute-nodes-ibm-z-kvm.html
* https://115168--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/configuring-multi-arch-compute-machines/creating-multi-arch-compute-nodes-ibm-z-lpar.html
* https://115168--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/configuring-multi-arch-compute-machines/multi-arch-tuning-operator-release-notes.html
* https://115168--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/node-tasks.html
* https://115168--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/configuring-multi-arch-compute-machines/multi-arch-tuning-operator-release-notes.html

Next PR: post_installation_configuration/configuring-multi-arch-compute-machines/creating-multi-arch-compute-nodes-ibm-z.adoc