### PR TITLE
OCPBUGS-91957: Change ASN in nw-routeadvertisements-example.adoc

### DIFF
--- a/modules/nw-routeadvertisements-example.adoc
+++ b/modules/nw-routeadvertisements-example.adoc
@@ -293,7 +293,7 @@ spec:
     - asn: 64512
       neighbors:
       - address: 182.18.0.5
-        asn: 64512
+        asn: 65100
         toReceive:
           allowed:
             mode: filtered
@@ -307,7 +307,7 @@ spec:
     - asn: 64512
       neighbors:
       - address: 192.18.0.5
-        asn: 64512
+        asn: 65200
         toReceive:
           allowed:
             mode: filtered
@@ -323,4 +323,4 @@ spec:
         kubernetes.io/hostname: ovn-worker
 ----
 
-In this scenario, any filtering or selection of routes to receive must be done in the `FRRConfiguration` CR that defines peering relationships.
+In this scenario, any filtering or selection of routes to receive must be done in the `FRRConfiguration` CR that defines peering relationships. Note the different values assigned to the `spec.bgp.routers.asn` and `neighbors.asn` fields. The different values are required for External BGP (eBGP) peering sessions, where the local cluster nodes and the remote upstream switches belong to different autonomous systems.


### PR DESCRIPTION
Version(s):
4.19+

Issue:
[OCPBUGS-91957](https://redhat.atlassian.net/browse/OCPBUGS-91957)

Link to docs preview:

https://115174--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/advanced_networking/route_advertisements/about-route-advertisements.html#advertising-pod-ips-from-a-user-defined-network-over-bgp-with-vpn_about-route-advertisements

- [ ] SME has approved this change (Jaime C.).
- [ ] QE has approved this change ().

https://github.com/openshift/openshift-docs/pull/98727